### PR TITLE
Fix refresh_compile_commands target.

### DIFF
--- a/rust-deps/BUILD.bazel
+++ b/rust-deps/BUILD.bazel
@@ -25,9 +25,9 @@ selects.config_setting_group(
     ],
 )
 CARGO_BAZEL = select({
-    "//:linux_x64": "@cargo_bazel_linux_x64//file:downloaded",
-    "//:macos_x64": "@cargo_bazel_macos_x64//file:downloaded",
-    "//:macos_arm64": "@cargo_bazel_macos_arm64//file:downloaded",
+    ":linux_x64": "@cargo_bazel_linux_x64//file:downloaded",
+    ":macos_x64": "@cargo_bazel_macos_x64//file:downloaded",
+    ":macos_arm64": "@cargo_bazel_macos_arm64//file:downloaded",
 })
 
 # TODO (before prod):


### PR DESCRIPTION
It appears to me that this select statement in rust-deps/BUILD.bazel is incorrectly using absolute paths to targets that aren't located at the root, but rather located within the same module. Fixing them to be local targets seems to make refresh_compile_commands now work. However, I'm confused why this didn't cause a broader breakage so I'm unsure if I totally understand what's going on here.

Fixes #16 