### PR TITLE
macOS x86 Support

### DIFF
--- a/rust-deps/BUILD.bazel
+++ b/rust-deps/BUILD.bazel
@@ -97,8 +97,9 @@ crates_vendor(
         ),
     },
     supported_platform_triples = [
-        "x86_64-unknown-linux-gnu",
         "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
+        "x86_64-unknown-linux-gnu",
 
         # this is not used but its required to work around a bug in rules_rust where
         # invalid select statements can get generated in vendored BUILD files
@@ -118,8 +119,9 @@ crates_vendor(
     },
     # host toolchain only
     supported_platform_triples = [
-        "x86_64-unknown-linux-gnu",
         "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
+        "x86_64-unknown-linux-gnu",
     ],
     vendor_path = "cxxbridge_crates",
 )

--- a/rust-deps/crates/BUILD.ahash-0.7.6.bazel
+++ b/rust-deps/crates/BUILD.ahash-0.7.6.bazel
@@ -91,6 +91,7 @@ rust_library(
         # cfg(any(target_os = "linux", target_os = "android", target_os = "windows", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "solaris", target_os = "illumos", target_os = "fuchsia", target_os = "redox", target_os = "cloudabi", target_os = "haiku", target_os = "vxworks", target_os = "emscripten", target_os = "wasi"))
         (
             "@rules_rust//rust/platform:aarch64-apple-darwin",
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             # Target Deps
@@ -103,6 +104,7 @@ rust_library(
         (
             "@rules_rust//rust/platform:aarch64-apple-darwin",
             "@rules_rust//rust/platform:wasm32-unknown-unknown",
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             # Target Deps

--- a/rust-deps/crates/BUILD.getrandom-0.1.16.bazel
+++ b/rust-deps/crates/BUILD.getrandom-0.1.16.bazel
@@ -97,6 +97,7 @@ rust_library(
         # cfg(unix)
         (
             "@rules_rust//rust/platform:aarch64-apple-darwin",
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             # Target Deps

--- a/rust-deps/crates/BUILD.getrandom-0.2.7.bazel
+++ b/rust-deps/crates/BUILD.getrandom-0.2.7.bazel
@@ -92,6 +92,7 @@ rust_library(
         # cfg(unix)
         (
             "@rules_rust//rust/platform:aarch64-apple-darwin",
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             # Target Deps

--- a/rust-deps/crates/BUILD.rand-0.7.3.bazel
+++ b/rust-deps/crates/BUILD.rand-0.7.3.bazel
@@ -97,6 +97,7 @@ rust_library(
         (
             "@rules_rust//rust/platform:aarch64-apple-darwin",
             "@rules_rust//rust/platform:wasm32-unknown-unknown",
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             # Target Deps
@@ -115,6 +116,7 @@ rust_library(
         # cfg(unix)
         (
             "@rules_rust//rust/platform:aarch64-apple-darwin",
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             # Target Deps

--- a/rust-deps/crates/defs.bzl
+++ b/rust-deps/crates/defs.bzl
@@ -363,12 +363,12 @@ _BUILD_PROC_MACRO_ALIASES = {
 
 _CONDITIONS = {
     "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))": ["wasm32-unknown-unknown"],
-    "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
-    "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": ["aarch64-apple-darwin", "wasm32-unknown-unknown", "x86_64-unknown-linux-gnu"],
-    "cfg(not(target_os = \"emscripten\"))": ["aarch64-apple-darwin", "wasm32-unknown-unknown", "x86_64-unknown-linux-gnu"],
+    "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))": ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"],
+    "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": ["aarch64-apple-darwin", "wasm32-unknown-unknown", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"],
+    "cfg(not(target_os = \"emscripten\"))": ["aarch64-apple-darwin", "wasm32-unknown-unknown", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"],
     "cfg(target_os = \"emscripten\")": [],
     "cfg(target_os = \"wasi\")": [],
-    "cfg(unix)": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
+    "cfg(unix)": ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"],
 }
 
 ###############################################################################


### PR DESCRIPTION
This PR adds the missing Rust platform triple required for Intel-based x86 macOS builds. @GregBrimble has built this on his x86 Mac and it seems to be working.  🎉 