### PR TITLE
macOS: added README note about Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ To build `workerd`, you need:
   * libc++ 11+ (e.g. packages `libc++-dev` and `libc++abi-dev` on Debian Bullseye)
 * On macOS:
   * full XCode 13+ installation
+  * Python 3.10 (3.9 does not work)
+    * A build failure can occur when using Conda or another virtual environment with Python 3.9. To solve this, you can create a virtual environment with Python 3.10 and activate it before building workerd.
 
 You may then build using:
 


### PR DESCRIPTION
Hey! 👋 

Tested out building `workerd` today and ran into a small issue. The build fails on Python 3.9.7, and since `miniforge` has that as the default version (when no environments are activated) this seems like a common issue.

The solution is to use Python 3.10. Because I'm using `miniforge` I simply created a new Conda environment with Python 3.10 and activated it before build and that solved the issue.

This PR adds a note to the docs (under the macOS section) about this restriction/limitation.