### PR TITLE
jsg rtti: adding explicit Configuration parameter everywhere

### DIFF
--- a/src/workerd/api/api-rtti-test.c++
+++ b/src/workerd/api/api-rtti-test.c++
@@ -8,19 +8,17 @@
 
 // Test building rtti for various APIs.
 
-JSG_RTTI_DECLARE_CONFIGURATION_TYPE(workerd::CompatibilityFlags::Reader);
-
 namespace workerd::api {
 namespace {
 
 KJ_TEST("WorkerGlobalScope") {
   CompatibilityFlags::Reader flags;
-  jsg::rtti::Builder().structure<WorkerGlobalScope>(flags);
+  jsg::rtti::Builder(flags).structure<WorkerGlobalScope>();
 }
 
 KJ_TEST("ServiceWorkerGlobalScope") {
   CompatibilityFlags::Reader flags;
-  jsg::rtti::Builder().structure<ServiceWorkerGlobalScope>(flags);
+  jsg::rtti::Builder(flags).structure<ServiceWorkerGlobalScope>();
 }
 
 } // namespace

--- a/src/workerd/jsg/rtti-test.c++
+++ b/src/workerd/jsg/rtti-test.c++
@@ -7,7 +7,6 @@
 #include <workerd/jsg/rtti.h>
 
 struct MockConfig {};
-JSG_RTTI_DECLARE_CONFIGURATION_TYPE(MockConfig);
 
 namespace workerd::jsg::rtti {
 namespace {
@@ -15,7 +14,7 @@ namespace {
 template<typename T>
 kj::String tType() {
   // returns textual encoding of rtti.
-  Builder builder;
+  Builder<MockConfig> builder((MockConfig()));
   auto type = builder.type<T>();
   capnp::TextCodec codec;
   return codec.encode(type);
@@ -24,8 +23,8 @@ kj::String tType() {
 template<typename T>
 kj::String tStructure() {
   // returns textual encoding of structure.
-  Builder builder;
-  auto type = builder.structure<T>(MockConfig());
+  Builder<MockConfig> builder((MockConfig()));
+  auto type = builder.structure<T>();
   capnp::TextCodec codec;
   return codec.encode(type);
 }
@@ -111,7 +110,7 @@ KJ_TEST("builtins") {
   KJ_EXPECT(tType<v8::Isolate*>() == "(builtin = (type = v8Isolate))");
   KJ_EXPECT(tType<v8::Function>() == "(builtin = (type = v8Function))");
   KJ_EXPECT(tType<kj::Date>() == "(builtin = (type = kjDate))");
-  KJ_EXPECT(tType<MockConfig>() == "(builtin = (type = flags))");
+  KJ_EXPECT(tType<MockConfig>() == "(builtin = (type = configuration))");
   KJ_EXPECT(tType<jsg::TypeHandler<kj::Date>>() == "(builtin = (type = jsgTypeHandler))");
 }
 

--- a/src/workerd/jsg/rtti.capnp
+++ b/src/workerd/jsg/rtti.capnp
@@ -135,8 +135,8 @@ struct BuiltinType {
     v8Function @7;
     # v8::Function
 
-    flags @8;
-    # CompatibilityFlags::Reader
+    configuration @8;
+    # api meta configuration object
 
     jsgLock @9;
     # jsg::Lock


### PR DESCRIPTION
Rather mechanical change. It is needed to resolve structures in a symbol table while invoking type().

Rather than passing Configuration object, pass rtti builder that will eventually contain the mentioned table.

Lets us retire JSG_RTTI_DECLARE_CONFIGURATION_TYPE too.