### PR TITLE
Build: replace angled-include with quotes-include to fix build.

### DIFF
--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -13,7 +13,7 @@
 #include <ucontext.h>
 
 #ifdef WORKERD_ICU_DATA_EMBED
-#include <icudata-embed.capnp.h>
+#include "icudata-embed.capnp.h"
 #include <unicode/udata.h>
 #endif
 


### PR DESCRIPTION
The compiler complains while building:

> src/workerd/jsg/setup.c++:16:10: error: 'icudata-embed.capnp.h' file not found with <angled> include; use "quotes" instead
> #include <icudata-embed.capnp.h>
>          ^~~~~~~~~~~~~~~~~~~~~~~
>          "icudata-embed.capnp.h"
> 1 error generated.

Signed-off-by: Jianyong Chen <baluschch@gmail.com>