### PR TITLE
Enable CLA Assistant on this repo

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,26 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.2.0
+        env:
+          # CLA Action uses this in-built GitHub token to make the API calls for interacting with GitHub.
+          # It is built into Github Actions and does not need to be manually specified in your secrets store.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The below token should have repo scope and must be manually added by you in the repository's secret
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://www.cloudflare.com/cla/'
+          # branch should not be protected
+          branch: 'main'
+          allowlist: dependabot


### PR DESCRIPTION
With the CLA Assistant able, when a PR is opened it will check if the person has signed the CLA before, and if not, add a comment like this:
<img width="817" alt="image" src="https://user-images.githubusercontent.com/24921/193067329-ca726f8f-d1ec-49e3-ba38-2ce6174a3817.png">

The link there goes to https://www.cloudflare.com/cla/ 

* Signatures will be stored in a file in this repo: `signatures/version1/cla.json` (this is configurable, and could even be in a separate repo)
* For users or bots who should not be required to sign the CLA, there's an `allowlist:` option in this file.
* There's currently no way to make an exception for "trivial changes" (fixing typos, etc) 