### PR TITLE
Disable CLA Assistant locking PR's

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,5 +22,6 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://www.cloudflare.com/cla/'
           # branch should not be protected
-          branch: 'main'
+          branch: 'cla-signatures'
           allowlist: dependabot
+          lock-pullrequest-aftermerge: false


### PR DESCRIPTION
CLA Assistant has a feature to lock a PR after merge.  We want this disabled.
Also moving signature to a separate branch for now. 
