### PR TITLE
Add dispatchNamespace to TraceItem

### DIFF
--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -175,6 +175,10 @@ kj::Maybe<kj::StringPtr> TraceItem::getScriptName() {
   return trace->scriptName;
 }
 
+jsg::Optional<kj::StringPtr> TraceItem::getDispatchNamespace() {
+  return trace->dispatchNamespace;
+}
+
 kj::StringPtr TraceItem::getOutcome() {
   // TODO(cleanup): Add to enumToStr() to capnp?
   auto enums = capnp::Schema::from<EventOutcome>().getEnumerants();

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -61,6 +61,7 @@ public:
   kj::Array<jsg::Ref<TraceLog>> getLogs();
   kj::Array<jsg::Ref<TraceException>> getExceptions();
   kj::Maybe<kj::StringPtr> getScriptName();
+  jsg::Optional<kj::StringPtr> getDispatchNamespace();
   kj::StringPtr getOutcome();
 
   uint getCpuTime();
@@ -72,6 +73,7 @@ public:
     JSG_READONLY_INSTANCE_PROPERTY(logs, getLogs);
     JSG_READONLY_INSTANCE_PROPERTY(exceptions, getExceptions);
     JSG_READONLY_INSTANCE_PROPERTY(scriptName, getScriptName);
+    JSG_READONLY_INSTANCE_PROPERTY(dispatchNamespace, getDispatchNamespace);
     JSG_READONLY_INSTANCE_PROPERTY(outcome, getOutcome);
   }
 

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -44,7 +44,7 @@ enum class PipelineLogLevel {
 class Trace final : public kj::Refcounted {
   // Collects trace information about the handling of a worker/pipline fetch event.
 public:
-  explicit Trace(kj::Maybe<kj::String> stableId, kj::Maybe<kj::String> scriptName);
+  explicit Trace(kj::Maybe<kj::String> stableId, kj::Maybe<kj::String> scriptName, kj::Maybe<kj::String> dispatchNamespace);
   Trace(rpc::Trace::Reader reader);
   ~Trace() noexcept(false);
   KJ_DISALLOW_COPY(Trace);
@@ -157,6 +157,7 @@ public:
   // trace, if any.
 
   kj::Maybe<kj::String> scriptName;
+  kj::Maybe<kj::String> dispatchNamespace;
 
   kj::Vector<Log> logs;
   kj::Vector<Exception> exceptions;
@@ -403,7 +404,8 @@ public:
 
   kj::Own<WorkerTracer> makeWorkerTracer(PipelineLogLevel pipelineLogLevel,
                                          kj::Maybe<kj::String> stableId,
-                                         kj::Maybe<kj::String> scriptName);
+                                         kj::Maybe<kj::String> scriptName,
+                                         kj::Maybe<kj::String> dispatchNamespace);
   // Makes a tracer for a worker stage.
 
 private:

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -74,6 +74,8 @@ struct Trace @0x8e8d911203762d34 {
 
   cpuTime @10 :UInt64;
   wallTime @11 :UInt64;
+
+  dispatchNamespace @12 :Text;
 }
 
 struct ScheduledRun @0xd98fc1ae5c8095d0 {


### PR DESCRIPTION
Adds a property called `dispatchNamespace` on `TraceItem` so that Workers for Platforms customers can tell which namespace a script emitted trace events from.