### PR TITLE
Remove ArrayPtr<byte> from list of supported jsg wrapping types

### DIFF
--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -223,7 +223,6 @@ private:
 // - C++ kj::OneOf<T, U, ...> <-> JS T or U or ...
 // - C++ kj::Array<T> <-> JS Array of T
 // - C++ kj::Array<byte> <-> JS ArrayBuffer
-// - C++ kj::ArrayPtr<byte> <- JS ArrayBuffer, ArrayBufferView
 // - C++ jsg::Dict<T> <-> JS Object used as a map of strings to values of type T
 // - C++ jsg::Function<T(U, V, ...)> <-> JS Function
 // - C++ jsg::Promise<T> <-> JS Promise


### PR DESCRIPTION
It does not work when I try to add an ArrayPtr<byte> member field to a JSG_STRUCT, so we should remove the documentation of it. The functionality appears to have been removed in
ca17240f28279292f5fa8ae281965ee982a9cac7 without updating the comments.