### PR TITLE
Cleanup: Do not log tunneled exceptions that cause alarm retries

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2852,9 +2852,7 @@ kj::Promise<void> Worker::Actor::makeAlarmTaskForPreview(kj::Date scheduledTime)
             auto& persistent = KJ_ASSERT_NONNULL(impl->actorCache);
             persistent.cancelDeferredAlarmDeletion();
 
-            if (!jsg::isDoNotLogException(e.getDescription())) {
-              KJ_LOG(ERROR, e);
-            }
+            LOG_EXCEPTION_IF_INTERNAL("alarmRetry", e);
 
             return WorkerInterface::AlarmResult {
               .retry = true,


### PR DESCRIPTION
Failures that lead to alarm retries may in fact be JSG errors.