### PR TITLE
Make it work on FreeBSD

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -177,6 +177,7 @@ git_repository(
         "//:patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch",
         "//:patches/v8/0003-Make-icudata-target-public.patch",
         "//:patches/v8/0004-Add-ArrayBuffer-MaybeNew.patch",
+        "//:patches/v8/0005-Extend-Bazel-files-for-FreeBSD.patch",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,10 +35,10 @@ rules_foreign_cc_dependencies()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "0cb62c35736ab4202a3e2f245ef4ac34549b209cb79e070711e42293fc4daf1c",
-    strip_prefix = "capnproto-capnproto-253c18f/c++",
+    sha256 = "ad3e0ab6fca9860ba97bf4f7d0a540d07ab188cbe05e736a960364050cb2e241",
+    strip_prefix = "capnproto-capnproto-e10182b/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/253c18fc6d8e21bb1114c720ab778fc397115c41"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/e10182bb6d5a1491193511feee105129e9080a67"],
 )
 
 http_archive(

--- a/patches/v8/0005-Extend-Bazel-files-for-FreeBSD.patch
+++ b/patches/v8/0005-Extend-Bazel-files-for-FreeBSD.patch
@@ -1,0 +1,114 @@
+From e2d52f615073d4ce6af78f5c9bfd760f9e81fe9b Mon Sep 17 00:00:00 2001
+From: Kenton Varda <kenton@cloudflare.com>
+Date: Thu, 6 Oct 2022 17:26:48 -0500
+Subject: [PATCH] Extend Bazel files for FreeBSD.
+
+V8's codebase has FreeBSD support, but the Bazel files did not. This fixes
+that.
+
+The static function `StringToLong` in `platform-freebsd.c++` was unused,
+leading to a compiler warning which was promoted to an error, so I also
+removed it.
+
+---
+ BUILD.bazel                           | 7 +++++++
+ bazel/config/BUILD.bazel              | 8 ++++++++
+ bazel/defs.bzl                        | 1 +
+ src/base/platform/platform-freebsd.cc | 4 ----
+ 4 files changed, 16 insertions(+), 4 deletions(-)
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 416fb05fdc..00a5499ed8 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -368,6 +368,9 @@ v8_config(
+             "V8_HAVE_TARGET_OS",
+             "V8_TARGET_OS_LINUX",
+         ],
++        "@v8//bazel/config:is_freebsd": [
++            # There is no TARGET_OS, live with unknown target.
++        ],
+         "@v8//bazel/config:is_macos": [
+             "V8_HAVE_TARGET_OS",
+             "V8_TARGET_OS_MACOS",
+@@ -697,6 +700,10 @@ filegroup(
+             "src/base/platform/platform-linux.cc",
+             "src/base/platform/platform-linux.h",
+         ],
++        "@v8//bazel/config:is_freebsd": [
++            "src/base/debug/stack_trace_posix.cc",
++            "src/base/platform/platform-freebsd.cc",
++        ],
+         "@v8//bazel/config:is_android": [
+             "src/base/debug/stack_trace_android.cc",
+             "src/base/platform/platform-linux.cc",
+diff --git a/bazel/config/BUILD.bazel b/bazel/config/BUILD.bazel
+index 448260de88..fbbaf5d6ee 100644
+--- a/bazel/config/BUILD.bazel
++++ b/bazel/config/BUILD.bazel
+@@ -133,6 +133,11 @@ config_setting(
+     constraint_values = ["@platforms//os:linux"],
+ )
+
++config_setting(
++    name = "is_freebsd",
++    constraint_values = ["@platforms//os:freebsd"],
++)
++
+ config_setting(
+     name = "is_android",
+     constraint_values = ["@platforms//os:android"],
+@@ -172,6 +177,7 @@ selects.config_setting_group(
+     name = "is_posix",
+     match_any = [
+         ":is_linux",
++        ":is_freebsd",
+         ":is_android",
+         ":is_macos",
+     ],
+@@ -182,6 +188,7 @@ selects.config_setting_group(
+     match_any = [
+         ":is_windows",
+         ":is_linux",
++        ":is_freebsd",
+         ":is_macos",
+     ]
+ )
+@@ -190,6 +197,7 @@ selects.config_setting_group(
+     name = "is_non_android_posix",
+     match_any = [
+         ":is_linux",
++        ":is_freebsd",
+         ":is_macos",
+     ],
+ )
+diff --git a/bazel/defs.bzl b/bazel/defs.bzl
+index e957c0fad3..9931eb1a1a 100644
+--- a/bazel/defs.bzl
++++ b/bazel/defs.bzl
+@@ -383,6 +383,7 @@ def _v8_target_cpu_transition_impl(settings, attr):
+         "k8": "x64",
+         "x86_64": "x64",
+         "darwin": "x64",
++        "freebsd": "x64",
+         "darwin_x86_64": "x64",
+         "x64_windows": "x64",
+         "x86": "ia32",
+diff --git a/src/base/platform/platform-freebsd.cc b/src/base/platform/platform-freebsd.cc
+index 55d600283f..b7023dc8da 100644
+--- a/src/base/platform/platform-freebsd.cc
++++ b/src/base/platform/platform-freebsd.cc
+@@ -43,10 +43,6 @@ TimezoneCache* OS::CreateTimezoneCache() {
+   return new PosixDefaultTimezoneCache();
+ }
+
+-static unsigned StringToLong(char* buffer) {
+-  return static_cast<unsigned>(strtol(buffer, nullptr, 16));
+-}
+-
+ std::vector<OS::SharedLibraryAddress> OS::GetSharedLibraryAddresses() {
+   std::vector<SharedLibraryAddress> result;
+   int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_VMMAP, getpid()};
+--
+2.30.2
+

--- a/rust-deps/BUILD.bazel
+++ b/rust-deps/BUILD.bazel
@@ -11,6 +11,13 @@ selects.config_setting_group(
     ],
 )
 selects.config_setting_group(
+    name = "freebsd_x64",
+    match_all = [
+        "@platforms//os:freebsd",
+        "@platforms//cpu:x86_64",
+    ],
+)
+selects.config_setting_group(
     name = "linux_arm64",
     match_all = [
         "@platforms//os:linux",
@@ -109,6 +116,7 @@ crates_vendor(
         "x86_64-apple-darwin",
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-freebsd",
 
         # this is not used but its required to work around a bug in rules_rust where
         # invalid select statements can get generated in vendored BUILD files
@@ -132,6 +140,7 @@ crates_vendor(
         "x86_64-apple-darwin",
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-freebsd",
     ],
     vendor_path = "cxxbridge_crates",
 )

--- a/rust-deps/crates/BUILD.ahash-0.7.6.bazel
+++ b/rust-deps/crates/BUILD.ahash-0.7.6.bazel
@@ -94,6 +94,7 @@ rust_library(
             "@rules_rust//rust/platform:aarch64-unknown-linux-gnu",
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:x86_64-unknown-freebsd",
         ): [
             # Target Deps
             "@crates_vendor__getrandom-0.2.7//:getrandom",
@@ -108,6 +109,7 @@ rust_library(
             "@rules_rust//rust/platform:wasm32-unknown-unknown",
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:x86_64-unknown-freebsd",
         ): [
             # Target Deps
             "@crates_vendor__once_cell-1.15.0//:once_cell",

--- a/rust-deps/crates/BUILD.getrandom-0.1.16.bazel
+++ b/rust-deps/crates/BUILD.getrandom-0.1.16.bazel
@@ -100,6 +100,7 @@ rust_library(
             "@rules_rust//rust/platform:aarch64-unknown-linux-gnu",
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:x86_64-unknown-freebsd",
         ): [
             # Target Deps
             "@crates_vendor__libc-0.2.133//:libc",

--- a/rust-deps/crates/BUILD.getrandom-0.2.7.bazel
+++ b/rust-deps/crates/BUILD.getrandom-0.2.7.bazel
@@ -95,6 +95,7 @@ rust_library(
             "@rules_rust//rust/platform:aarch64-unknown-linux-gnu",
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:x86_64-unknown-freebsd",
         ): [
             # Target Deps
             "@crates_vendor__libc-0.2.133//:libc",

--- a/rust-deps/crates/BUILD.rand-0.7.3.bazel
+++ b/rust-deps/crates/BUILD.rand-0.7.3.bazel
@@ -100,6 +100,7 @@ rust_library(
             "@rules_rust//rust/platform:wasm32-unknown-unknown",
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:x86_64-unknown-freebsd",
         ): [
             # Target Deps
             "@crates_vendor__rand_chacha-0.2.2//:rand_chacha",
@@ -120,6 +121,7 @@ rust_library(
             "@rules_rust//rust/platform:aarch64-unknown-linux-gnu",
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:x86_64-unknown-freebsd",
         ): [
             # Target Deps
             "@crates_vendor__libc-0.2.133//:libc",

--- a/rust-deps/crates/defs.bzl
+++ b/rust-deps/crates/defs.bzl
@@ -363,12 +363,12 @@ _BUILD_PROC_MACRO_ALIASES = {
 
 _CONDITIONS = {
     "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))": ["wasm32-unknown-unknown"],
-    "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))": ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"],
-    "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "wasm32-unknown-unknown", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"],
-    "cfg(not(target_os = \"emscripten\"))": ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "wasm32-unknown-unknown", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"],
+    "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))": ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-freebsd"],
+    "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "wasm32-unknown-unknown", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-freebsd"],
+    "cfg(not(target_os = \"emscripten\"))": ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "wasm32-unknown-unknown", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-freebsd"],
     "cfg(target_os = \"emscripten\")": [],
     "cfg(target_os = \"wasi\")": [],
-    "cfg(unix)": ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"],
+    "cfg(unix)": ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-freebsd"],
 }
 
 ###############################################################################

--- a/src/workerd/api/url-standard.c++
+++ b/src/workerd/api/url-standard.c++
@@ -16,6 +16,9 @@
 #include <arpa/inet.h>
 #include <algorithm>
 #include <numeric>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 
 namespace workerd::api::url {
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -29,6 +29,10 @@
 #include <sys/syscall.h>
 #include <numeric>
 
+#if __FreeBSD__
+#include <pthread_np.h>
+#endif
+
 namespace v8_inspector {
   kj::String KJ_STRINGIFY(const v8_inspector::StringView& view) {
     if (view.is8Bit()) {
@@ -418,6 +422,8 @@ void reportStartupError(
 uint64_t getCurrentThreadId() {
 #if __linux__
   return syscall(SYS_gettid);
+#elif __FreeBSD__
+  return pthread_getthreadid_np();
 #else
   // Assume MacOS or BSD
   uint64_t tid;

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -563,6 +563,10 @@ kj::Maybe<kj::StringPtr> getJsStackTrace(void* ucontext, kj::ArrayPtr<char> scra
   state.pc = reinterpret_cast<void*>(mcontext.gregs[REG_RIP]);
   state.sp = reinterpret_cast<void*>(mcontext.gregs[REG_RSP]);
   state.fp = reinterpret_cast<void*>(mcontext.gregs[REG_RBP]);
+#elif defined(__FreeBSD__) && defined(__x86_64__)
+  state.pc = reinterpret_cast<void*>(mcontext.mc_rip);
+  state.sp = reinterpret_cast<void*>(mcontext.mc_rsp);
+  state.fp = reinterpret_cast<void*>(mcontext.mc_rbp);
 #elif defined(__linux__) && defined(__aarch64__)
   state.pc = reinterpret_cast<void*>(mcontext.pc);
   state.sp = reinterpret_cast<void*>(mcontext.sp);

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -43,6 +43,10 @@
 #define environ (*_NSGetEnviron())
 #endif
 
+#if __FreeBSD__
+extern char **environ;
+#endif
+
 namespace workerd::server {
 
 static kj::StringPtr getVersionString() {
@@ -245,8 +249,6 @@ private:
   kj::AutoCloseFd kqueueFd;
   kj::UnixEventPort::FdObserver observer;
   kj::Vector<kj::AutoCloseFd> filesWatched;
-
-  bool sawChange = false;
 
   static kj::AutoCloseFd makeKqueue() {
     int fd_;


### PR DESCRIPTION
**THIS IS NOT AN OFFICIALLY-SUPPORTED PLATFORM.** Since we don't plan to have it in CI, it'll probably bitrot, but I'll be happy to accept patches to fix.

Since I had a FreeBSD VM set up to test https://github.com/capnproto/capnproto/pull/1555 (which also benefits Mac, but testing on FreeBSD was easier), I thought it'd be fun to try to build the whole of workerd on FreeBSD. I managed to do so! With all tests passing!

However, this PR will NOT work out-of-the-box. You need some extra hacks:

* Add `--linkopt='-lm' --linkopt='-lexecinfo' --host_linkopt='-lm' --host_linkopt='-lexecinfo'` to your `bazel build` or `bazel test` command line.
* Symlink `libstdc++.so` to `libc++.so`, i.e. `ln -s libc++.so /usr/lib/libstdc++.so`, to work around a Bazel bug which will be [fixed in 6.0](https://github.com/bazelbuild/bazel/commit/a987b98ea0d6da2656c4115568ef9cbe8a164550) (but that's not released yet).
* Move `/usr/bin/clang` to `/usr/bin/clang.real` and instead replace `/usr/bin/clang` with this script:

```
#! /usr/local/bin/bash

set -euo pipefail

FLAGS=("$@")
for I in "${!FLAGS[@]}"; do
  if [ "${FLAGS[$I]}" = '--target=x86_64-unknown-freebsd' ]; then
    unset -v 'FLAGS[$I]'
  fi
done

exec /usr/bin/clang.real "${FLAGS[@]}"
```

Obviously, the last hack is unreasonable, but without this I had persistent problems building `//rust-deps`. Specifically, when building the `cxx` crate, it would try to build the C++ source file `scr/cxx.cc`, but would not be able to find the libc++ library headers when doing so. It looks like this code is supposed to remove the `-target` flag, but is not designed to also recognize `--target`:

https://github.com/bazelbuild/rules_rust/blob/da3d522d59becbec5697dac0b2aa39890656ed4b/cargo/cargo_build_script.bzl#L16-L39

But I have no idea why this is needed or generally what is going on in this code. Moreover, I could not figure out how to tell it to use a different compiler binary (setting `CC`, `CXX`, etc. seemed to have no effect; it always used `/usr/bin/clang` no matter what I did). Otherwise, I could have placed by wrapper script somewhere else and pointed this code at that. Instead, I had to replace `clang` in its install location, which is awful.

It'd be great if some Bazel and/or FreeBSD expert could figure out what is needed here.