### PR TITLE
Add explicit flush to Durable Object storage interface

### DIFF
--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -187,6 +187,8 @@ public:
 
   jsg::Promise<void> deleteAll(jsg::Optional<PutOptions> options, v8::Isolate* isolate);
 
+  jsg::Promise<void> sync(jsg::Lock& js);
+
   JSG_RESOURCE_TYPE(DurableObjectStorage, CompatibilityFlags::Reader flags) {
     JSG_METHOD(get);
     JSG_METHOD(list);
@@ -197,6 +199,7 @@ public:
     JSG_METHOD(getAlarm);
     JSG_METHOD(setAlarm);
     JSG_METHOD(deleteAlarm);
+    JSG_METHOD(sync);
   }
 
 protected:

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -197,6 +197,7 @@ public:
   kj::OneOf<bool, kj::Promise<bool>> delete_(Key key, WriteOptions options) override;
   kj::OneOf<uint, kj::Promise<uint>> delete_(kj::Array<Key> keys, WriteOptions options) override;
   kj::Maybe<kj::Promise<void>> setAlarm(kj::Maybe<kj::Date> newAlarmTime, WriteOptions options) override;
+  kj::Maybe<kj::Promise<void>> onNoPendingFlush();
   // See ActorCacheInterface.
 
   struct DeleteAllResults {
@@ -494,6 +495,9 @@ private:
   // When flushScheduled is true, indicates whether the output gate is already waiting on said
   // flush. The first write that does *not* set `allowUnconfirmed` causes the output gate to be
   // applied.
+
+  size_t flushesEnqueued = 0;
+  // The count of the number of flushes that have been queued without yet resolving.
 
   struct DeleteAllState {
     kj::Vector<kj::Own<Entry>> deletedDirty;


### PR DESCRIPTION
This PR provides a way for a worker to wait for its writes (including those performed with allowUnconfirmed) to be flushed to storage. Note that if there is no flush currently pending, the JSG method will provide a resolved promise and the current task will continue through its microtask queue instead of yielding to other tasks.