### PR TITLE
Cache API

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -135,7 +135,7 @@ ThreadContext::HeaderIdBundle::HeaderIdBundle(kj::HttpHeaderTable::Builder& buil
       contentEncoding(builder.add("Content-Encoding")),
       cfCacheStatus(builder.add("CF-Cache-Status")),
       cacheControl(builder.add("Cache-Control")),
-      cfCacheMetadata(builder.add("CF-Cache-Metadata")),
+      cfCacheNamespace(builder.add("CF-Cache-Namespace")),
       cfKvMetadata(builder.add("CF-KV-Metadata")),
       cfR2ErrorHeader(builder.add("CF-R2-Error")),
       cfBlobMetadataSize(builder.add("CF-R2-Metadata-Size")),

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -135,6 +135,7 @@ ThreadContext::HeaderIdBundle::HeaderIdBundle(kj::HttpHeaderTable::Builder& buil
       contentEncoding(builder.add("Content-Encoding")),
       cfCacheStatus(builder.add("CF-Cache-Status")),
       cacheControl(builder.add("Cache-Control")),
+      cfCacheMetadata(builder.add("CF-Cache-Metadata")),
       cfKvMetadata(builder.add("CF-KV-Metadata")),
       cfR2ErrorHeader(builder.add("CF-R2-Error")),
       cfBlobMetadataSize(builder.add("CF-R2-Metadata-Size")),

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -55,7 +55,7 @@ public:
     const kj::HttpHeaderId contentEncoding;
     const kj::HttpHeaderId cfCacheStatus;         // used by cache API implementation
     const kj::HttpHeaderId cacheControl;
-    const kj::HttpHeaderId cfCacheMetadata;       // used by Cache binding implementation
+    const kj::HttpHeaderId cfCacheNamespace;       // used by Cache binding implementation
     const kj::HttpHeaderId cfKvMetadata;          // used by KV binding implementation
     const kj::HttpHeaderId cfR2ErrorHeader;       // used by R2 binding implementation
     const kj::HttpHeaderId cfBlobMetadataSize;    // used by R2 binding implementation

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -55,6 +55,7 @@ public:
     const kj::HttpHeaderId contentEncoding;
     const kj::HttpHeaderId cfCacheStatus;         // used by cache API implementation
     const kj::HttpHeaderId cacheControl;
+    const kj::HttpHeaderId cfCacheMetadata;       // used by Cache binding implementation
     const kj::HttpHeaderId cfKvMetadata;          // used by KV binding implementation
     const kj::HttpHeaderId cfR2ErrorHeader;       // used by R2 binding implementation
     const kj::HttpHeaderId cfBlobMetadataSize;    // used by R2 binding implementation

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -2103,6 +2103,98 @@ KJ_TEST("Server: disk service allow dotfiles") {
   KJ_EXPECT(test.root->openFile(kj::Path({"secret"}))->readAllText() == "this is super-secret");
 }
 
+
+KJ_TEST("Cache: If no cache service is defined, access to the cache API should error") {
+  TestServer test(singleWorker(R"((
+    compatibilityDate = "2022-08-17",
+    modules = [
+      ( name = "test.js",
+        esModule =
+          `export default {
+          `  async fetch(request) {
+          `    try {
+          `      return new Response(await caches.default.match(request))
+          `    } catch (e) {return new Response(e.message)}
+          `
+          `  }
+          `}
+      )
+    ]
+  ))"_kj));
+
+
+  test.start();
+  auto conn = test.connect("test-addr");
+  conn.httpGet200("/",
+      "No Cache was configured");
+
+}
+
+
+KJ_TEST("Cache: cached response") {
+  TestServer test(R"((
+    services = [
+      ( name = "hello",
+        worker = (
+          cacheApiOutbound = "cache-outbound",
+          compatibilityDate = "2022-08-17",
+          modules = [
+            ( name = "main.js",
+              esModule =
+                `export default {
+                `  async fetch(request, env, ctx) {
+                `    const cache = caches.default;
+                `    let response = await cache.match(request);
+                `    return response ?? new Response('not cached');
+                `  }
+                `}
+            )
+          ]
+        )
+      ),
+      ( name = "cache-outbound", external = "cache-host" ),
+    ],
+    sockets = [
+      ( name = "main",
+        address = "test-addr",
+        service = "hello"
+      )
+    ]
+  ))"_kj);
+
+  test.start();
+  auto conn = test.connect("test-addr");
+  conn.sendHttpGet("/");
+
+  {
+    auto subreq = test.receiveSubrequest("cache-host");
+    subreq.recv(R"(
+      GET / HTTP/1.1
+      Host: foo
+      Cache-Control: only-if-cached
+
+    )"_blockquote);
+    subreq.send(R"(
+      HTTP/1.1 200 OK
+      CF-Cache-Status: HIT
+      Content-Size: 6
+
+      cached)"_blockquote);
+  }
+
+  conn.recv(R"(
+    HTTP/1.1 200 OK
+    Transfer-Encoding: chunked
+    CF-Cache-Status: HIT
+    Content-Size: 6
+
+    6
+    cached
+    0
+
+  )"_blockquote);
+
+}
 // =======================================================================================
 
 // TODO(beta): Test TLS (send and receive)

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -424,7 +424,7 @@ struct Worker {
   # Where should the global "fetch" go to? The default is the service called "internet", which
   # should usually be configured to talk to the public internet.
 
-  cacheOutbound @11 :ServiceDesignator = "cache";
+  cacheApiOutbound @11 :ServiceDesignator;
   # Where should cache API (i.e. caches.default and caches.open(...)) requests go?
 
   durableObjectNamespaces @7 :List(DurableObjectNamespace);

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -424,6 +424,9 @@ struct Worker {
   # Where should the global "fetch" go to? The default is the service called "internet", which
   # should usually be configured to talk to the public internet.
 
+  cacheOutbound @11 :ServiceDesignator = "cache";
+  # Where should cache API (i.e. caches.default and caches.open(...)) requests go?
+
   durableObjectNamespaces @7 :List(DurableObjectNamespace);
   # List of durable object namespaces in this Worker.
 


### PR DESCRIPTION
Initial implementation wiring together the Cache API and the `cacheApiOutbound` binding. I've tested this with a WIP Miniflare plugin, and it seems to send the cache API requests out as expected. The approach I've taken may well not be the correct one (I've used a special `subrequestChannel` to open an HTTP client—perhaps there's a different way to separate out cache requests?).