### PR TITLE
Require a close following a short byob atLeast read

### DIFF
--- a/samples/streams/atLeast/README.md
+++ b/samples/streams/atLeast/README.md
@@ -1,0 +1,28 @@
+# Hello World Example
+
+To run the example on http://localhost:8080
+
+```sh
+$ ./workerd serve config.capnp
+```
+
+To run using bazel
+
+```sh
+$ bazel run //src/workerd/server:workerd -- serve ~/cloudflare/workerd/samples/streams/atLeast/config.capnp
+```
+
+To create a standalone binary that can be run:
+
+```sh
+$ ./workerd compile config.capnp > streams
+
+$ ./streams
+```
+
+To test:
+
+```sh
+% curl http://localhost:8080
+OK
+```

--- a/samples/streams/atLeast/config.capnp
+++ b/samples/streams/atLeast/config.capnp
@@ -1,0 +1,33 @@
+# Imports the base schema for workerd configuration files.
+
+# Refer to the comments in /src/workerd/server/workerd.capnp for more details.
+
+using Workerd = import "/workerd/workerd.capnp";
+
+# A constant of type Workerd.Config defines the top-level configuration for an
+# instance of the workerd runtime. A single config file can contain multiple
+# Workerd.Config definitions and must have at least one.
+const streamsExample :Workerd.Config = (
+
+  # Every workerd instance consists of a set of named services. A worker, for instance,
+  # is a type of service. Other types of services can include external servers, the
+  # ability to talk to a network, or accessing a disk directory. Here we create a single
+  # worker service. The configuration details for the worker are defined below.
+  services = [ (name = "main", worker = .example) ],
+
+  # Every configuration defines the one or more sockets on which the server will listene.
+  # Here, we create a single socket that will listen on localhost port 8080, and will
+  # dispatch to the "main" service that we defined above.
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ]
+);
+
+# The definition of the actual helloWorld worker exposed using the "main" service.
+# In this example the worker is implemented as a single simple script (see worker.js).
+# The compatibilityDate is required. For more details on compatibility dates see:
+#   https://developers.cloudflare.com/workers/platform/compatibility-dates/
+
+const example :Workerd.Worker = (
+  serviceWorkerScript = embed "worker.js",
+  compatibilityDate = "2022-09-16",
+  compatibilityFlags = ["streams_enable_constructors"],
+);

--- a/samples/streams/atLeast/worker.js
+++ b/samples/streams/atLeast/worker.js
@@ -1,0 +1,51 @@
+addEventListener('fetch', event => {
+  event.respondWith(handle(event.request));
+});
+
+async function handle(request) {
+
+  const chunks = [
+    "never gonna give you up",
+    "never gonna let you go",
+    "boom",
+  ];
+
+  const enc = new TextEncoder();
+  const dec = new TextDecoder();
+
+  const rs = new ReadableStream({
+    type: 'bytes',
+
+    pull(c) {
+      const byobRequest = c.byobRequest;
+      if (chunks.length === 0) {
+        // In this case, the previous read should have been short,
+        // and the controller is expecting us to close things down.
+        c.close();
+        byobRequest.respond(0);
+      } else {
+        const { written } = enc.encodeInto(chunks.shift(), byobRequest.view);
+        byobRequest.respond(written);
+      }
+    },
+  });
+
+  const min = 23;
+  const ab = new ArrayBuffer(min);
+
+  const reader = rs.getReader({ mode: 'byob' });
+
+  let res = await reader.readAtLeast(min, new Uint8Array(ab));
+
+  console.log(dec.decode(res.value));
+
+  res = await reader.readAtLeast(min, new Uint8Array(res.value.buffer));
+
+  console.log(dec.decode(res.value));
+
+  res = await reader.readAtLeast(min, new Uint8Array(res.value.buffer));
+
+  console.log(res.done);
+
+  return new Response("OK");
+}

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -796,6 +796,8 @@ public:
 
   void pull(jsg::Lock& js);
 
+  bool isExpectingClose() { return closeExpected; }
+
   kj::Own<ByteQueue::Consumer> getConsumer(
       kj::Maybe<ByteQueue::ConsumerImpl::StateListener&> stateListener);
 
@@ -810,8 +812,11 @@ public:
 private:
   ReadableImpl impl;
   kj::Maybe<jsg::Ref<ReadableStreamBYOBRequest>> maybeByobRequest;
+  bool closeExpected = false;
 
   void visitForGc(jsg::GcVisitor& visitor);
+
+  void expectCloseOnNextPull();
 
   friend class ReadableStreamBYOBRequest;
   friend class ReadableStreamJsController;


### PR DESCRIPTION
Currently, in a JS-backed byte-oriented ReadableStream, when using BYOB and the readAtLeast extension, it is possible for the controller to completely ignore the atLeast contract. In such cases, readAtLeast() can return fewer than atLeast bytes.

With this change, we set an internal flag when `c.byobRequest.respond()` or `c.byobRequest.respondWithNewView()` are called with fewer than `atLeast` bytes that indicates that the next call to pull() must close or error the stream, enforcing the rule that the only short read allowed when using readAtLeast is the final chunk of data in the stream.

Technically this is a breaking change, so *probably* needs a compatibility flag? @kentonv @harrishancock ... opinions?

/cc @vlovich 