### PR TITLE
jsg: adding long long types to rtti

### DIFF
--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -164,6 +164,8 @@ struct BuildRtti<Configuration, T> { \
   F(unsigned int) \
   F(long) \
   F(unsigned long) \
+  F(long long) \
+  F(unsigned long long) \
   F(double)
 
 FOR_EACH_NUMBER_TYPE(DECLARE_NUMBER_TYPE)


### PR DESCRIPTION
Some unsigned long linux types are unsigned long long on mac.
