### PR TITLE
Give actors the ability to go away when we're handling a deferred proxy task

### DIFF
--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -11,6 +11,7 @@
 #include <workerd/jsg/jsg.h>
 #include <workerd/io/io-gate.h>
 #include <workerd/util/sentry.h>
+#include <workerd/io/io-context.h>
 
 namespace workerd {
 

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -6,7 +6,6 @@
 
 #include <kj/async.h>
 #include <workerd/io/actor-storage.capnp.h>
-#include <workerd/io/io-context.h>
 #include <kj/one-of.h>
 #include <kj/map.h>
 #include <kj/list.h>

--- a/src/workerd/io/actor.h
+++ b/src/workerd/io/actor.h
@@ -1,0 +1,116 @@
+#include "worker.h"
+#include "actor-cache.h"
+#include "worker-interface.h"
+#include "io-gate.h"
+#include <workerd/api/global-scope.h>
+
+namespace workerd {
+
+struct Worker::Actor::Impl final: public kj::TaskSet::ErrorHandler {
+  Actor::Id actorId;
+  using MakeStorageFunc = kj::Function<jsg::Ref<api::DurableObjectStorage>(
+      jsg::Lock& js, const ApiIsolate& apiIsolate, ActorCache& actorCache)>;
+  MakeStorageFunc makeStorage;
+
+  kj::Own<ActorObserver> metrics;
+
+  kj::Maybe<jsg::Value> transient;
+  kj::Maybe<ActorCache> actorCache;
+
+  struct NoClass {};
+  struct Initializing {};
+
+  kj::OneOf<
+    NoClass,                         // not class-based
+    DurableObjectConstructor*,       // constructor not run yet
+    Initializing,                    // constructor currently running
+    api::ExportedHandler,            // fully constructed
+    kj::Exception                    // constructor threw
+  > classInstance;
+  // If the actor is backed by a class, this field tracks the instance through its stages. The
+  // instance is constructed as part of the first request to be delivered.
+
+  class HooksImpl: public InputGate::Hooks, public OutputGate::Hooks {
+  public:
+    HooksImpl(TimerChannel& timerChannel, ActorObserver& metrics)
+        : timerChannel(timerChannel), metrics(metrics) {}
+
+    void inputGateLocked() override { metrics.inputGateLocked(); }
+    void inputGateReleased() override { metrics.inputGateReleased(); }
+    void inputGateWaiterAdded() override { metrics.inputGateWaiterAdded(); }
+    void inputGateWaiterRemoved() override { metrics.inputGateWaiterRemoved(); }
+    // Implements InputGate::Hooks.
+
+    kj::Promise<void> makeTimeoutPromise() override {
+      return timerChannel.afterLimitTimeout(10 * kj::SECONDS)
+          .then([]() -> kj::Promise<void> {
+        return KJ_EXCEPTION(FAILED,
+            "broken.outputGateBroken; jsg.Error: Durable Object storage operation exceeded "
+            "timeout which caused object to be reset.");
+      });
+    }
+
+    void outputGateLocked() override { metrics.outputGateLocked(); }
+    void outputGateReleased() override { metrics.outputGateReleased(); }
+    void outputGateWaiterAdded() override { metrics.outputGateWaiterAdded(); }
+    void outputGateWaiterRemoved() override { metrics.outputGateWaiterRemoved(); }
+    // Implements OutputGate::Hooks.
+
+  private:
+    TimerChannel& timerChannel;    // only for afterLimitTimeout()
+    ActorObserver& metrics;
+  };
+
+  HooksImpl hooks;
+
+  InputGate inputGate;
+  // Handles both input locks and request locks.
+
+  OutputGate outputGate;
+  // Handles output locks.
+
+  kj::Maybe<kj::Own<IoContext>> ioContext;
+  // `ioContext` is initialized upon delivery of the first request.
+  // TODO(cleanup): Rename IoContext to IoContext.
+
+  kj::Maybe<kj::Own<kj::PromiseFulfiller<kj::Promise<void>>>> abortFulfiller;
+  // If onBroken() is called while `ioContext` is still null, this is initialized. When
+  // `ioContext` is constructed, this will be fulfilled with `ioContext.onAbort()`.
+
+  kj::Maybe<kj::Promise<void>> metricsFlushLoopTask;
+  // Task which periodically flushes metrics. Initialized after `ioContext` is initialized.
+
+  TimerChannel& timerChannel;
+
+  kj::ForkedPromise<void> shutdownPromise;
+  kj::Own<kj::PromiseFulfiller<void>> shutdownFulfiller;
+
+  kj::PromiseFulfillerPair<void> constructorFailedPaf = kj::newPromiseAndFulfiller<void>();
+
+  struct Alarm {
+    kj::Promise<void> alarmTask;
+    kj::ForkedPromise<WorkerInterface::AlarmResult> alarm;
+    kj::Own<kj::PromiseFulfiller<WorkerInterface::AlarmResult>> fulfiller;
+    kj::Date scheduledTime;
+  };
+
+  struct RunningAlarm : public Alarm {
+    kj::Maybe<Alarm> queuedAlarm;
+  };
+
+  kj::TaskSet deletedAlarmTasks;
+  kj::Maybe<RunningAlarm> runningAlarm;
+  // Used to handle deduplication of alarm requests
+
+  Impl(Worker::Actor& self, Worker::Lock& lock, Actor::Id actorId,
+       bool hasTransient, kj::Maybe<rpc::ActorStorage::Stage::Client> persistent,
+       MakeStorageFunc makeStorage, TimerChannel& timerChannel,
+       kj::Own<ActorObserver> metricsParam,
+       kj::PromiseFulfillerPair<void> paf = kj::newPromiseAndFulfiller<void>());
+
+  void taskFailed(kj::Exception&& e) override {
+    LOG_EXCEPTION("deletedAlarmTaskFailed", e);
+  }
+};
+
+}; // namespace workerd

--- a/src/workerd/io/actor.h
+++ b/src/workerd/io/actor.h
@@ -6,7 +6,10 @@
 
 namespace workerd {
 
-struct Worker::Actor::Impl final: public kj::TaskSet::ErrorHandler {
+// TODO(now): Rename to Worker::Actor
+struct Worker::ActorImpl final: public kj::TaskSet::ErrorHandler {
+  // Represents actor state within a Worker instance. This object tracks the JavaScript heap
+  // objects backing `event.actorState`. Multiple `Actor`s can be created within a single `Worker`.
   kj::Own<const Worker> worker;
   Actor::Id actorId;
   using MakeStorageFunc = kj::Function<jsg::Ref<api::DurableObjectStorage>(
@@ -33,7 +36,7 @@ struct Worker::Actor::Impl final: public kj::TaskSet::ErrorHandler {
 
   static kj::OneOf<NoClass, DurableObjectConstructor*>
       buildClassInstance(Worker& worker, kj::Maybe<kj::StringPtr> className);
-    // Used by the Worker::Actor::Impl constructor to initialize the classInstance.
+    // Used by the Worker::ActorImpl constructor to initialize the classInstance.
 
   class HooksImpl: public InputGate::Hooks, public OutputGate::Hooks {
   public:
@@ -109,7 +112,7 @@ struct Worker::Actor::Impl final: public kj::TaskSet::ErrorHandler {
 
   bool hasCalledOnBroken = false;
 
-  Impl(Worker::Lock& lock, Actor::Id actorId,
+  ActorImpl(Worker::Lock& lock, Actor::Id actorId,
        bool hasTransient, kj::Maybe<rpc::ActorStorage::Stage::Client> persistent,
        kj::Maybe<kj::StringPtr> className,
        MakeStorageFunc makeStorage, TimerChannel& timerChannel,

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -105,6 +105,9 @@ public:
   // data via `request`'s Jaeger span.
 
   class Actor;
+  // TODO(now): rename to `Worker::TimedActorRef`
+  struct ActorImpl;
+  // TODO(now): rename to `Worker::Actor`
 
   kj::Promise<AsyncLock> takeAsyncLockWhenActorCacheReady(kj::Date now, Actor& actor,
       RequestObserver& request) const;
@@ -621,14 +624,9 @@ class Worker::Actor final: public kj::Refcounted {
   // after some time.
 
 public:
-  // TODO(now): Rename to Worker::Actor (not as subtype, move to toplevel).
-  struct Impl;
-  // Represents actor state within a Worker instance. This object tracks the JavaScript heap
-  // objects backing `event.actorState`. Multiple `Actor`s can be created within a single `Worker`.
-
   using Id = kj::OneOf<kj::Own<ActorIdFactory::ActorId>, kj::String>;
 
-  Actor(Impl& impl, kj::Own<void> attachments) : impl(impl), attachments(kj::mv(attachments)) {}
+  Actor(ActorImpl& impl, kj::Own<void> attachments) : impl(impl), attachments(kj::mv(attachments)) {}
   // Create a new Actor hosted by this Worker. Note that this Actor object may only be manipulated
   // from the thread that created it.
 
@@ -699,7 +697,7 @@ public:
   // isn't a duplicate alarm, func will be called to run the alarm.
 
 private:
-  Impl& impl;
+  ActorImpl& impl;
 
   kj::Own<void> attachments;
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1157,7 +1157,7 @@ public:
   class ActorNamespace {
   public:
     struct LocalActor {
-      kj::Own<Worker::Actor::Impl> actor;
+      kj::Own<Worker::ActorImpl> actor;
 
       kj::Maybe<Worker::Actor*> hibernationTaskOrActor;
     };
@@ -1214,7 +1214,7 @@ public:
 
           TimerChannel& timerChannel = service;
           auto workerLock = Worker::Lock(*service.worker, lock);
-          auto newActorImpl = kj::heap<Worker::Actor::Impl>(
+          auto newActorImpl = kj::heap<Worker::ActorImpl>(
               workerLock, kj::mv(id), true, kj::mv(persistent),
               className, kj::mv(makeStorage),
               timerChannel, kj::refcounted<ActorObserver>());


### PR DESCRIPTION
### WIP
This lays the groundwork for removing the actor from the actor map.

Was hoping to move `Worker::Actor::Impl` up a level to `Worker::ActorImpl` as the first commit to try and get each step to compile successfully, but I've been dealing with a bunch of (I suspect unrelated) compilation issues.
