### PR TITLE
Improved support for readAtLeast byob reads

### DIFF
--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -1656,7 +1656,6 @@ kj::Promise<size_t> IdentityTransformStreamImpl::tryRead(
 
     total += amount;
     buffer = reinterpret_cast<char*>(buffer) + amount;
-    minBytes -= kj::min(minBytes, amount);
     maxBytes -= amount;
   }
 

--- a/src/workerd/api/streams/queue.h
+++ b/src/workerd/api/streams/queue.h
@@ -771,15 +771,17 @@ public:
 
     ReadRequest& getRequest() { return KJ_ASSERT_NONNULL(request); }
 
-    void respond(jsg::Lock& js, size_t amount);
+    bool respond(jsg::Lock& js, size_t amount);
 
-    void respondWithNewView(jsg::Lock& js, jsg::BufferSource view);
+    bool respondWithNewView(jsg::Lock& js, jsg::BufferSource view);
 
     void invalidate();
     // Disconnects this ByobRequest instance from the associated ByteQueue::ReadRequest.
     // The term "invalidate" is adopted from the streams spec for handling BYOB requests.
 
     inline bool isInvalidated() const { return request == nullptr; }
+
+    bool isPartiallyFulfilled();
 
     size_t getAtLeast() const;
 

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -108,12 +108,8 @@ jsg::Promise<ReadResult> ReaderImpl::read(
                   ") exceeds size of buffer (", options->byteLength, ").")));
         }
 
-        // TODO(conform): This should really be defined as the number of elements of the provided
-        // buffer view rather than a byte length for consistency with read().
-        // TODO(soon): This check is not valid for JS controllers, which support this no problem.
-        if (!options->bufferView.getHandle(js)->IsUint8Array()) {
-          KJ_LOG(WARNING, "Reading into non-Uint8Array isn't currently supported.");
-        }
+        jsg::BufferSource source(js, options->bufferView.getHandle(js));
+        options->atLeast = atLeast * source.getElementSize();
       }
 
       return KJ_ASSERT_NONNULL(stream->getController().read(js, kj::mv(byobOptions)));

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -748,6 +748,8 @@ public:
     // readAtLeast API.
   }
 
+  bool isPartiallyFulfilled();
+
 private:
   struct Impl {
     kj::Own<ByteQueue::ByobRequest> readRequest;
@@ -760,6 +762,8 @@ private:
          : readRequest(kj::mv(readRequest)),
            controller(kj::mv(controller)),
            view(js.v8Ref(this->readRequest->getView(js))) {}
+
+    void updateView(jsg::Lock& js);
   };
 
   kj::Maybe<Impl> maybeImpl;


### PR DESCRIPTION
* Allows multiple respond/respondWithNewView to partially resolve readAtLeast byob reads.
* Fix IdentityTransformStream minBytes calculation
* Properly calculate atLeast with multi-byte views

/cc @harrishancock 
