### PR TITLE
Change internal error to user facing error on writer double close

### DIFF
--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -721,8 +721,8 @@ void WritableImpl<Self>::advanceQueueIfNeeded(jsg::Lock& js, jsg::Ref<Self> self
 template <typename Self>
 jsg::Promise<void> WritableImpl<Self>::close(jsg::Lock& js, jsg::Ref<Self> self) {
   KJ_ASSERT(state.template is<Writable>() || state.template is<StreamStates::Erroring>());
-  KJ_ASSERT(!isCloseQueuedOrInFlight());
-
+  JSG_REQUIRE(!isCloseQueuedOrInFlight(), TypeError,
+      "Cannot close a writer that is already being closed");
   auto prp = js.newPromiseAndResolver<void>();
   closeRequest = kj::mv(prp.resolver);
 


### PR DESCRIPTION
```
const ws = new WritableStream();
const writer = ws.getWriter();
writer.close();
writer.close();
```

... would cause an internal error when it needed to be a user-facing error.