### PR TITLE
Request compression when calling `new WebSocket()` by default

### DIFF
--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -187,6 +187,9 @@ jsg::Ref<WebSocket> WebSocket::constructor(
   auto connUrl = urlRecord.toString();
   auto ws = jsg::alloc<WebSocket>(kj::mv(url), Locality::REMOTE);
 
+  headers.set(kj::HttpHeaderId::SEC_WEBSOCKET_EXTENSIONS, kj::str("permessage-deflate"));
+  // By default, browsers set the compression extension header for `new WebSocket()`.
+
   if (!flags.getWebSocketCompression()) {
     // If we haven't enabled the websocket compression feature flag, strip the header from the
     // subrequest.


### PR DESCRIPTION
Browsers set the compression extension by default when `new WebSocket()` is called, since the API doesn't give the caller control over that header. See step 9 of whatwg's [opening handshake process](https://websockets.spec.whatwg.org/#websocket-opening-handshake) for websockets.

---
I think we can leave the `fetch()` implementation as is, since you could easily just set the extension header yourself:

```
  let resp = await fetch(request, {
    headers: {
      "Upgrade": "websocket",
      "Sec-WebSocket-Extensions": "permessage-deflate"
    }
  });
```