### PR TITLE
Emit different error if a non-actor is looking for a class entrypoint

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1580,8 +1580,15 @@ kj::Maybe<api::ExportedHandler&> Worker::Lock::getExportedHandler(
   }
 
   KJ_IF_MAYBE(n, name) {
-    return KJ_ASSERT_NONNULL(worker.impl->namedHandlers.find(*n),
-        "worker has no such named entrypoint", *n);
+    KJ_IF_MAYBE(h, worker.impl->namedHandlers.find(*n)){
+      return *h;
+    } else {
+      if (worker.impl->actorClasses.find(*n) != nullptr) {
+        KJ_FAIL_ASSERT("worker is not an actor but class name was requested", *n);
+      } else {
+        KJ_FAIL_ASSERT("worker has no such named entrypoint", *n);
+      }
+    }
   } else {
     return worker.impl->defaultHandler;
   }


### PR DESCRIPTION
Sometimes we specify a class name as the entrypoint for a worker but fail to define the worker as an actor. The entrypoint is in the script but we cannot use it in this case, so let's emit a different error to help debug these issues.