### PR TITLE
Add an ability to inject an arbitrary set of headers to KV requests

### DIFF
--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -102,6 +102,9 @@ jsg::Promise<KvNamespace::GetWithMetadataResult> KvNamespace::getWithMetadata(
   auto urlStr = url.toString(kj::Url::Context::HTTP_PROXY_REQUEST);
   auto headers = kj::HttpHeaders(context.getHeaderTable());
   headers.add(FLPROD_405_HEADER, kj::str(urlStr));
+  for (const auto& header: additionalHeaders) {
+    headers.add(header.name.asPtr(), header.value.asPtr());
+  }
 
   return context.awaitIo(js,
       client->request(kj::HttpMethod::GET, urlStr, headers).response,
@@ -211,6 +214,9 @@ jsg::Promise<jsg::Value> KvNamespace::list(
   auto urlStr = url.toString(kj::Url::Context::HTTP_PROXY_REQUEST);
   auto headers = kj::HttpHeaders(context.getHeaderTable());
   headers.add(FLPROD_405_HEADER, kj::str(urlStr));
+  for (const auto& header: additionalHeaders) {
+    headers.add(header.name.asPtr(), header.value.asPtr());
+  }
 
   return context.awaitIo(js,
       client->request(kj::HttpMethod::GET, urlStr, headers).response,
@@ -311,6 +317,9 @@ jsg::Promise<void> KvNamespace::put(
 
   auto urlStr = url.toString(kj::Url::Context::HTTP_PROXY_REQUEST);
   headers.add(FLPROD_405_HEADER, kj::str(urlStr));
+  for (const auto& header: additionalHeaders) {
+    headers.add(header.name.asPtr(), header.value.asPtr());
+  }
 
   auto promise = context.waitForOutputLocks()
       .then([&context, client = kj::mv(client), urlStr = kj::mv(urlStr), headers = kj::mv(headers),
@@ -367,9 +376,13 @@ jsg::Promise<void> KvNamespace::delete_(jsg::Lock& js, kj::String name) {
   auto client = context.getHttpClient(subrequestChannel, true, nullptr, "kv_delete"_kj);
   auto urlStr = kj::str("https://fake-host/", kj::encodeUriComponent(name), "?urlencoded=true");
   auto promise = context.waitForOutputLocks()
-      .then([&context, client = kj::mv(client), urlStr = kj::mv(urlStr)]() mutable {
+      .then([this, &context, client = kj::mv(client), urlStr = kj::mv(urlStr)]() mutable {
     auto headers = kj::HttpHeaders(context.getHeaderTable());
     headers.add(FLPROD_405_HEADER, kj::str(urlStr));
+    for (const auto& header: additionalHeaders) {
+      headers.add(header.name.asPtr(), header.value.asPtr());
+    }
+
     return client->request(kj::HttpMethod::DELETE, urlStr, headers,
                           uint64_t(0))
         .response.then([](kj::HttpClient::Response&& response) mutable {

--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -13,9 +13,16 @@ class KvNamespace: public jsg::Object {
   // A capability to a KV namespace.
 
 public:
-  explicit KvNamespace(uint subrequestChannel): subrequestChannel(subrequestChannel) {}
+  struct AdditionalHeader {
+    kj::String name;
+    kj::String value;
+  };
+
+  explicit KvNamespace(kj::Array<AdditionalHeader> additionalHeaders, uint subrequestChannel)
+      : additionalHeaders(kj::mv(additionalHeaders)), subrequestChannel(subrequestChannel) {}
   // `subrequestChannel` is what to pass to IoContext::getHttpClient() to get an HttpClient
   // representing this namespace.
+  // `additionalHeaders` is what gets appended to every outbound request.
 
   struct GetOptions {
     jsg::Optional<kj::String> type;
@@ -90,6 +97,7 @@ public:
   }
 
 private:
+  kj::Array<AdditionalHeader> additionalHeaders;
   uint subrequestChannel;
 };
 

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -450,7 +450,8 @@ void WorkerdApiIsolate::compileGlobals(
       }
 
       KJ_CASE_ONEOF(ns, Global::KvNamespace) {
-        value = lock.wrap(context, jsg::alloc<api::KvNamespace>(ns.subrequestChannel));
+        value = lock.wrap(context, jsg::alloc<api::KvNamespace>(
+            kj::Array<api::KvNamespace::AdditionalHeader>{}, ns.subrequestChannel));
       }
 
       KJ_CASE_ONEOF(r2, Global::R2Bucket) {


### PR DESCRIPTION
We want to start injecting some headers in the multi-tenant runtime.