### PR TITLE
Generate an exportable and ambient version of the TypeScript types

### DIFF
--- a/types/BUILD.bazel
+++ b/types/BUILD.bazel
@@ -28,7 +28,7 @@ js_run_binary(
     srcs = [
         "//src/workerd/tools:api_encoder",
     ],
-    outs = ["api.d.ts"],  # TODO(soon) switch to out_dirs when generating multiple files
+    outs = ["api.d.ts", "api.ts"],  # TODO(soon) switch to out_dirs when generating multiple files
     args = [
         "src/workerd/tools/api.capnp.bin",
         "--output",

--- a/types/src/program.ts
+++ b/types/src/program.ts
@@ -1,3 +1,4 @@
+import { assert } from "console";
 import path from "path";
 import ts from "typescript";
 
@@ -6,11 +7,32 @@ interface MemorySourceFile {
   sourceFile: ts.SourceFile;
 }
 
+// Update compiler host to return in-memory source file
+function patchHostMethod<K extends "fileExists" | "readFile" | "getSourceFile">(
+  host: ts.CompilerHost,
+  sourceFiles: Map<string, MemorySourceFile>,
+  key: K,
+  placeholderResult: (f: MemorySourceFile) => ReturnType<ts.CompilerHost[K]>
+) {
+  const originalMethod: (...args: any[]) => any = host[key];
+  host[key] = (fileName: string, ...args: any[]) => {
+    const sourceFile = sourceFiles.get(path.resolve(fileName));
+    if (sourceFile !== undefined) {
+      return placeholderResult(sourceFile);
+    }
+    return originalMethod.call(host, fileName, ...args);
+  };
+}
+
 // Creates a TypeScript program from in-memory source files. Accepts a Map of
 // fully-resolved "virtual" paths to source code.
-export function createMemoryProgram(sources: Map<string, string>): ts.Program {
-  const options = ts.getDefaultCompilerOptions();
-  const host = ts.createCompilerHost(options, true);
+export function createMemoryProgram(
+  sources: Map<string, string>,
+  host?: ts.CompilerHost,
+  options?: ts.CompilerOptions
+): ts.Program {
+  options ??= ts.getDefaultCompilerOptions();
+  host ??= ts.createCompilerHost(options, true);
 
   const sourceFiles = new Map<string, MemorySourceFile>();
   for (const [sourcePath, source] of sources) {
@@ -24,25 +46,14 @@ export function createMemoryProgram(sources: Map<string, string>): ts.Program {
     sourceFiles.set(sourcePath, { source, sourceFile });
   }
 
-  // Update compiler host to return in-memory source file
-  function patchHostMethod<
-    K extends "fileExists" | "readFile" | "getSourceFile"
-  >(
-    key: K,
-    placeholderResult: (f: MemorySourceFile) => ReturnType<ts.CompilerHost[K]>
-  ) {
-    const originalMethod: (...args: any[]) => any = host[key];
-    host[key] = (fileName: string, ...args: any[]) => {
-      const sourceFile = sourceFiles.get(path.resolve(fileName));
-      if (sourceFile !== undefined) {
-        return placeholderResult(sourceFile);
-      }
-      return originalMethod.call(host, fileName, ...args);
-    };
-  }
-  patchHostMethod("fileExists", () => true);
-  patchHostMethod("readFile", ({ source }) => source);
-  patchHostMethod("getSourceFile", ({ sourceFile }) => sourceFile);
+  patchHostMethod(host, sourceFiles, "fileExists", () => true);
+  patchHostMethod(host, sourceFiles, "readFile", ({ source }) => source);
+  patchHostMethod(
+    host,
+    sourceFiles,
+    "getSourceFile",
+    ({ sourceFile }) => sourceFile
+  );
 
   const rootNames = [...sourceFiles.keys()];
   return ts.createProgram(rootNames, options, host);

--- a/types/src/standards.ts
+++ b/types/src/standards.ts
@@ -1,0 +1,68 @@
+import { assert } from "console";
+import { readFile } from "fs/promises";
+import * as ts from "typescript";
+import { createMemoryProgram } from "./program";
+export interface ParsedTypeDefinition {
+  program: ts.Program;
+  source: ts.SourceFile;
+  checker: ts.TypeChecker;
+  parsed: {
+    functions: Map<string, ts.FunctionDeclaration>;
+    interfaces: Map<string, ts.InterfaceDeclaration>;
+    vars: Map<string, ts.VariableDeclaration>;
+    types: Map<string, ts.TypeAliasDeclaration>;
+    classes: Map<string, ts.ClassDeclaration>;
+  };
+}
+
+// Collate standards (to support lib.(dom|webworker).iterable.d.ts being defined separately)
+export async function collateStandards(
+  ...standardTypes: string[]
+): Promise<ParsedTypeDefinition> {
+  const STANDARDS_PATH = "/source.ts";
+  const text: string = (
+    await Promise.all(
+      standardTypes.map(
+        async (s) =>
+          // Remove the Microsoft copyright notices from the file, to prevent them being copied in as TS comments
+          (await readFile(s, "utf-8")).split(`/////////////////////////////`)[2]
+      )
+    )
+  ).join("\n");
+  const program = createMemoryProgram(new Map([[STANDARDS_PATH, text]]));
+  const source = program.getSourceFile(STANDARDS_PATH)!;
+  const checker = program.getTypeChecker();
+  const parsed = {
+    functions: new Map<string, ts.FunctionDeclaration>(),
+    interfaces: new Map<string, ts.InterfaceDeclaration>(),
+    vars: new Map<string, ts.VariableDeclaration>(),
+    types: new Map<string, ts.TypeAliasDeclaration>(),
+    classes: new Map<string, ts.ClassDeclaration>(),
+  };
+  ts.forEachChild(source, (node) => {
+    let name = "";
+    if (node && ts.isFunctionDeclaration(node)) {
+      name = node.name?.text ?? "";
+      parsed.functions.set(name, node);
+    } else if (ts.isVariableStatement(node)) {
+      assert(node.declarationList.declarations.length === 1);
+      name = node.declarationList.declarations[0].name.getText(source);
+      parsed.vars.set(name, node.declarationList.declarations[0]);
+    } else if (ts.isInterfaceDeclaration(node)) {
+      name = node.name.text;
+      parsed.interfaces.set(name, node);
+    } else if (ts.isTypeAliasDeclaration(node)) {
+      name = node.name.text;
+      parsed.types.set(name, node);
+    } else if (ts.isClassDeclaration(node)) {
+      name = node.name?.text ?? "";
+      parsed.classes.set(name, node);
+    }
+  });
+  return {
+    program,
+    source,
+    checker,
+    parsed,
+  };
+}

--- a/types/src/transforms/ambient.ts
+++ b/types/src/transforms/ambient.ts
@@ -1,0 +1,18 @@
+import ts from "typescript";
+import { ensureStatementModifiers } from "./helpers";
+
+// This ensures that all nodes have the `declare` keyword
+export function createAmbientTransformer(): ts.TransformerFactory<ts.SourceFile> {
+  return (ctx) => {
+    return (node) => {
+      const visitor = createVisitor(ctx);
+      return ts.visitEachChild(node, visitor, ctx);
+    };
+  };
+}
+
+function createVisitor(ctx: ts.TransformationContext) {
+  return (node: ts.Node) => {
+    return ensureStatementModifiers(ctx, node, false);
+  };
+}

--- a/types/src/transforms/comments.ts
+++ b/types/src/transforms/comments.ts
@@ -1,0 +1,123 @@
+import assert from "assert";
+import ts from "typescript";
+import { ParsedTypeDefinition } from "../standards";
+import { hasModifier } from "./helpers";
+
+function attachComments(
+  from: ts.Node,
+  to: ts.Node,
+  sourceFile: ts.SourceFile
+): void {
+  const text = sourceFile.getFullText();
+  const extractCommentText = (comment: ts.CommentRange) =>
+    comment.kind === ts.SyntaxKind.MultiLineCommentTrivia
+      ? text.slice(comment.pos + 2, comment.end - 2)
+      : text.slice(comment.pos + 2, comment.end);
+  const leadingComments: string[] =
+    ts
+      .getLeadingCommentRanges(text, from.getFullStart())
+      ?.map(extractCommentText) ?? [];
+
+  leadingComments.map((c) =>
+    ts.addSyntheticLeadingComment(
+      to,
+      ts.SyntaxKind.MultiLineCommentTrivia,
+      c,
+      true
+    )
+  );
+}
+
+// Copy comments from a parsed standards TS program. It relies on the shape of lib.dom or lib.webworker
+// Specifically, classes must be defined as a global var with the static properties, and an interface with the instance properties
+export function createCommentsTransformer(
+  standards: ParsedTypeDefinition
+): ts.TransformerFactory<ts.SourceFile> {
+  return (ctx) => {
+    return (node) => {
+      const visitor = createVisitor(standards);
+      return ts.visitEachChild(node, visitor, ctx);
+    };
+  };
+}
+
+function createVisitor(standards: ParsedTypeDefinition) {
+  return (node: ts.Node) => {
+    if (ts.isClassDeclaration(node)) {
+      const name = node.name?.getText();
+      assert(name !== undefined);
+      const standardsVersion = standards.parsed.vars.get(name);
+      if (standardsVersion) {
+        const type = standardsVersion.type;
+        assert(
+          type !== undefined && ts.isTypeLiteralNode(type),
+          `Non type literal found for "${name}"`
+        );
+        attachComments(standardsVersion, node, standards.source);
+        const standardsInterface = standards.parsed.interfaces.get(name);
+        assert(standardsInterface !== undefined);
+        node.members.forEach((member) => {
+          const n = member.name?.getText();
+          if (!n && ts.isConstructorDeclaration(member)) return;
+
+          assert(n !== undefined, `No name for child of ${name}`);
+          if (member.modifiers === undefined) return;
+
+          const isStatic = hasModifier(
+            member.modifiers,
+            ts.SyntaxKind.StaticKeyword
+          );
+          const target = isStatic ? type : standardsInterface;
+          const standardsEquivalent = target.members.find(
+            (member) => member.name?.getText() === n
+          );
+
+          if (standardsEquivalent)
+            attachComments(standardsEquivalent, member, standards.source);
+        });
+      }
+    } else if (ts.isFunctionDeclaration(node)) {
+      assert(node.name !== undefined);
+      const name = node.name.text;
+      const standardsVersion = standards.parsed.functions.get(name);
+      if (standardsVersion) {
+        attachComments(standardsVersion, node, standards.source);
+      }
+    } else if (ts.isInterfaceDeclaration(node)) {
+      assert(node.name !== undefined);
+      const name = node.name.text;
+      const standardsVersion = standards.parsed.interfaces.get(name);
+      if (standardsVersion) {
+        attachComments(standardsVersion, node, standards.source);
+        node.members.forEach((member) => {
+          const n = member.name?.getText();
+          assert(n !== undefined);
+          const standardsEquivalent = standardsVersion.members.find(
+            (m) => m.name?.getText() === n
+          );
+          if (standardsEquivalent)
+            attachComments(standardsEquivalent, member, standards.source);
+        });
+      }
+    } else if (ts.isTypeAliasDeclaration(node)) {
+      assert(node.name !== undefined);
+      const name = node.name.text;
+      const standardsVersion = standards.parsed.types.get(name);
+      if (standardsVersion) {
+        attachComments(standardsVersion, node, standards.source);
+      }
+    } else if (ts.isVariableStatement(node)) {
+      // These contain comments that are misleading in the context of a Worker
+      const ignoreForComments = new Set(["self", "navigator", "caches"]);
+      assert(node.declarationList.declarations.length === 1);
+      assert(node.declarationList.declarations[0].name !== undefined);
+      const name = node.declarationList.declarations[0].name.getText();
+      const standardsVersion = standards.parsed.vars.get(name);
+      if (standardsVersion && !ignoreForComments.has(name)) {
+        attachComments(standardsVersion, node, standards.source);
+      }
+    }
+
+    return node;
+  };
+}

--- a/types/src/transforms/helpers.ts
+++ b/types/src/transforms/helpers.ts
@@ -1,0 +1,164 @@
+import assert from "assert";
+import * as ts from "typescript";
+import { printNode } from "../print";
+// Checks whether the modifiers array contains a modifier of the specified kind
+export function hasModifier(
+  modifiers: ts.ModifiersArray,
+  kind: ts.Modifier["kind"]
+) {
+  let hasModifier = false;
+  modifiers?.forEach((modifier) => {
+    hasModifier ||= modifier.kind === kind;
+  });
+  return hasModifier;
+}
+
+// Ensure a modifiers array has the specified modifier, inserting it at the
+// start if it doesn't.
+export function ensureModifier(
+  ctx: ts.TransformationContext,
+  modifiers: ts.ModifiersArray | undefined,
+  ensure: ts.SyntaxKind.ExportKeyword | ts.SyntaxKind.DeclareKeyword
+): ts.ModifiersArray {
+  // If modifiers already contains the required modifier, return it as is...
+  if (modifiers !== undefined && hasModifier(modifiers, ensure)) {
+    return modifiers;
+  }
+  // ...otherwise, add the modifier to the start of the array
+  return ctx.factory.createNodeArray(
+    [ctx.factory.createToken(ensure), ...(modifiers ?? [])],
+    modifiers?.hasTrailingComma
+  );
+}
+
+// Ensure a modifiers array doesn't have the specified modifier
+export function ensureNoModifier(
+  ctx: ts.TransformationContext,
+  modifiers: ts.ModifiersArray | undefined,
+  ensure: ts.SyntaxKind.ExportKeyword | ts.SyntaxKind.DeclareKeyword
+): ts.ModifiersArray {
+  // If modifiers already doesn't contain the required modifier, return it as is...
+  if (modifiers !== undefined && !hasModifier(modifiers, ensure)) {
+    return modifiers;
+  }
+  // ...otherwise, remove the modifier
+  return ctx.factory.createNodeArray(
+    modifiers?.filter((m) => m.kind !== ensure),
+    modifiers?.hasTrailingComma
+  );
+}
+
+// Ensure a modifiers array includes the `export` modifier
+export function ensureExportModifier(
+  ctx: ts.TransformationContext,
+  modifiers: ts.ModifiersArray | undefined,
+  exported = true
+): ts.ModifiersArray {
+  return exported
+    ? ensureModifier(ctx, modifiers, ts.SyntaxKind.ExportKeyword)
+    : ensureNoModifier(ctx, modifiers, ts.SyntaxKind.ExportKeyword);
+}
+
+// Ensures a modifiers array includes the `export declare` modifiers
+export function ensureExportDeclareModifiers(
+  ctx: ts.TransformationContext,
+  modifiers: ts.ModifiersArray | undefined,
+  exported = true
+): ts.ModifiersArray {
+  // Call in reverse, so we end up with `export declare` not `declare export`
+  modifiers = ensureModifier(ctx, modifiers, ts.SyntaxKind.DeclareKeyword);
+  return ensureExportModifier(ctx, modifiers, exported);
+}
+
+// Make sure replacement node is `export`ed, with the `declare` modifier if it's
+// a class, variable or function declaration.
+// If the `noExport` option is set, only ensure `declare` modifiers
+export function ensureStatementModifiers(
+  ctx: ts.TransformationContext,
+  node: ts.Node,
+  exported = true
+): ts.Node {
+  if (ts.isClassDeclaration(node)) {
+    return ctx.factory.updateClassDeclaration(
+      node,
+      node.decorators,
+      ensureExportDeclareModifiers(ctx, node.modifiers, exported),
+      node.name,
+      node.typeParameters,
+      node.heritageClauses,
+      node.members
+    );
+  }
+  if (ts.isInterfaceDeclaration(node)) {
+    return ctx.factory.updateInterfaceDeclaration(
+      node,
+      node.decorators,
+      ensureExportModifier(
+        ctx,
+        exported
+          ? ensureNoModifier(ctx, node.modifiers, ts.SyntaxKind.DeclareKeyword)
+          : ensureModifier(ctx, node.modifiers, ts.SyntaxKind.DeclareKeyword),
+        exported
+      ),
+      node.name,
+      node.typeParameters,
+      node.heritageClauses,
+      node.members
+    );
+  }
+  if (ts.isEnumDeclaration(node)) {
+    return ctx.factory.updateEnumDeclaration(
+      node,
+      node.decorators,
+      ensureExportDeclareModifiers(ctx, node.modifiers, exported),
+      node.name,
+      node.members
+    );
+  }
+  if (ts.isTypeAliasDeclaration(node)) {
+    return ctx.factory.updateTypeAliasDeclaration(
+      node,
+      node.decorators,
+      ensureExportModifier(
+        ctx,
+        exported
+          ? ensureNoModifier(ctx, node.modifiers, ts.SyntaxKind.DeclareKeyword)
+          : ensureModifier(ctx, node.modifiers, ts.SyntaxKind.DeclareKeyword),
+        exported
+      ),
+      node.name,
+      node.typeParameters,
+      node.type
+    );
+  }
+  if (ts.isVariableStatement(node)) {
+    return ctx.factory.updateVariableStatement(
+      node,
+      ensureExportDeclareModifiers(ctx, node.modifiers, exported),
+      node.declarationList
+    );
+  }
+  if (ts.isFunctionDeclaration(node)) {
+    return ctx.factory.updateFunctionDeclaration(
+      node,
+      node.decorators,
+      ensureExportDeclareModifiers(ctx, node.modifiers, exported),
+      node.asteriskToken,
+      node.name,
+      node.typeParameters,
+      node.parameters,
+      node.type,
+      node.body
+    );
+  }
+  if (ts.isModuleDeclaration(node)) {
+    return ctx.factory.updateModuleDeclaration(
+      node,
+      node.decorators,
+      ensureExportDeclareModifiers(ctx, node.modifiers, exported),
+      node.name,
+      node.body
+    );
+  }
+  assert.fail(`Expected statement, got "${printNode(node)}"`);
+}

--- a/types/src/transforms/importable.ts
+++ b/types/src/transforms/importable.ts
@@ -1,0 +1,18 @@
+import ts from "typescript";
+import { ensureStatementModifiers } from "./helpers";
+
+// This ensures that all nodes have the `export` keyword (and, where relevant, `export declare`)
+export function createImportableTransformer(): ts.TransformerFactory<ts.SourceFile> {
+  return (ctx) => {
+    return (node) => {
+      const visitor = createVisitor(ctx);
+      return ts.visitEachChild(node, visitor, ctx);
+    };
+  };
+}
+
+function createVisitor(ctx: ts.TransformationContext) {
+  return (node: ts.Node) => {
+    return ensureStatementModifiers(ctx, node);
+  };
+}

--- a/types/src/transforms/index.ts
+++ b/types/src/transforms/index.ts
@@ -1,3 +1,4 @@
 export * from "./globals";
 export * from "./iterators";
 export * from "./overrides";
+export * from "./comments";

--- a/types/test/index.spec.ts
+++ b/types/test/index.spec.ts
@@ -119,23 +119,24 @@ test("main: generates types", async () => {
     output,
     `/* eslint-disable */
 // noinspection JSUnusedGlobalSymbols
-export declare class EventTarget<EventMap extends Record<string, Event> = Record<string, Event>> {
+declare class EventTarget<EventMap extends Record<string, Event> = Record<string, Event>> {
     constructor();
     addEventListener<Type extends keyof EventMap>(type: Type, handler: (event: EventMap[Type]) => void): void;
 }
-export type WorkerGlobalScopeEventMap = {
+declare type WorkerGlobalScopeEventMap = {
     fetch: Event;
     scheduled: Event;
 };
-export declare abstract class WorkerGlobalScope extends EventTarget<WorkerGlobalScopeEventMap> {
+declare abstract class WorkerGlobalScope extends EventTarget<WorkerGlobalScopeEventMap> {
 }
-export interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
+/** This ServiceWorker API interface represents the global execution context of a service worker. */
+declare interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
     things(param0: boolean): IterableIterator<string>;
     get prop(): Promise<number>;
 }
-export declare function addEventListener<Type extends keyof WorkerGlobalScopeEventMap>(type: Type, handler: (event: WorkerGlobalScopeEventMap[Type]) => void): void;
-export declare function things(param0: boolean): IterableIterator<string>;
-export declare const prop: Promise<number>;
+declare function addEventListener<Type extends keyof WorkerGlobalScopeEventMap>(type: Type, handler: (event: WorkerGlobalScopeEventMap[Type]) => void): void;
+declare function things(param0: boolean): IterableIterator<string>;
+declare const prop: Promise<number>;
 `
   );
 
@@ -146,7 +147,7 @@ export declare const prop: Promise<number>;
     output,
     `/* eslint-disable */
 // noinspection JSUnusedGlobalSymbols
-export declare class EventTarget<
+declare class EventTarget<
   EventMap extends Record<string, Event> = Record<string, Event>
 > {
   constructor();
@@ -155,20 +156,22 @@ export declare class EventTarget<
     handler: (event: EventMap[Type]) => void
   ): void;
 }
-export type WorkerGlobalScopeEventMap = {
+declare type WorkerGlobalScopeEventMap = {
   fetch: Event;
   scheduled: Event;
 };
-export declare abstract class WorkerGlobalScope extends EventTarget<WorkerGlobalScopeEventMap> {}
-export interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
+declare abstract class WorkerGlobalScope extends EventTarget<WorkerGlobalScopeEventMap> {}
+/** This ServiceWorker API interface represents the global execution context of a service worker. */
+declare interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
   things(param0: boolean): IterableIterator<string>;
   get prop(): Promise<number>;
 }
-export declare function addEventListener<
-  Type extends keyof WorkerGlobalScopeEventMap
->(type: Type, handler: (event: WorkerGlobalScopeEventMap[Type]) => void): void;
-export declare function things(param0: boolean): IterableIterator<string>;
-export declare const prop: Promise<number>;
+declare function addEventListener<Type extends keyof WorkerGlobalScopeEventMap>(
+  type: Type,
+  handler: (event: WorkerGlobalScopeEventMap[Type]) => void
+): void;
+declare function things(param0: boolean): IterableIterator<string>;
+declare const prop: Promise<number>;
 `
   );
 });


### PR DESCRIPTION
> This is blocked on merging #133 

This follows on from @mrbbot's work, by parsing the outputted type definitions along with `lib.webworker` and `lib.webworker.d.ts`. It does two major things:
- Attach doc comments from `lib.webworker` to the generated workers types, which gives much better documentation for standard types.
- Generate two versions of the types:
  - [`api.ts`](https://gist.github.com/penalosa/204f40ba0719fb815db75ba28239f4fd#file-api-ts) which contains importable versions of the types. Importantly, they're only importable as types, not as values.
     The intention here is that it will be possible to type a worker in combination with an ambient `lib.dom` or `lib.webworker` declaration, as the ambient declaration will provide global (value) versions of `Response` and `fetch` etc... These will be slightly different to what's available in the workers runtime, of course, but not significantly so (see [Workers/Standards diff](https://gist.github.com/penalosa/23efb9df31dabbc18ca0aac07c43bcc2) for a look at how far off the workers runtime is from standards compliance).
  - [`api.d.ts`](https://gist.github.com/penalosa/204f40ba0719fb815db75ba28239f4fd#file-api-d-ts) which is the same as the current version of the types—purely ambient declarations.
  