### PR TITLE
Generate multiple types, one for each compatibility date that changes type signatures

### DIFF
--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -25,7 +25,7 @@ compat_dates = [
     # https://developers.cloudflare.com/workers/platform/compatibility-dates/#global-navigator
     ("2022-08-04", "2022-08-04"),
     # Latest compatibility date
-    ("2024-01-01", "experimental"),
+    ("2030-01-01", "experimental"),
 ]
 
 filegroup(

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -13,13 +13,42 @@ wd_cc_binary(
     ],
 )
 
-run_binary(
+compat_dates = [
+    # Oldest compatibility date, with no flags enabled
+    ("2021-01-01", "oldest"),
+    # https://developers.cloudflare.com/workers/platform/compatibility-dates/#formdata-parsing-supports-file
+    ("2021-11-03", "2021-11-03"),
+    # https://developers.cloudflare.com/workers/platform/compatibility-dates/#settersgetters-on-api-object-prototypes
+    ("2022-01-31", "2022-01-31"),
+    # https://developers.cloudflare.com/workers/platform/compatibility-dates/#global-navigator
+    ("2022-03-21", "2022-03-21"),
+    # https://developers.cloudflare.com/workers/platform/compatibility-dates/#global-navigator
+    ("2022-08-04", "2022-08-04"),
+    # Latest compatibility date
+    ("2024-01-01", "experimental"),
+]
+
+filegroup(
     name = "api_encoder",
-    outs = ["api.capnp.bin"],
-    args = [
-        "--output",
-        "$(location api.capnp.bin)",
+    srcs = [
+        "//src/workerd/tools:api_encoder_" + label
+        for (date, label) in compat_dates
     ],
-    tool = "api_encoder_bin",
     visibility = ["//visibility:public"],
 )
+
+[
+    run_binary(
+        name = "api_encoder_" + label,
+        outs = [label + ".api.capnp.bin"],
+        args = [
+            "--output",
+            "$(location " + label + ".api.capnp.bin)",
+            "--compatibility-date",
+            date,
+        ],
+        tool = "api_encoder_bin",
+        visibility = ["//visibility:public"],
+    )
+    for (date, label) in compat_dates
+]

--- a/types/BUILD.bazel
+++ b/types/BUILD.bazel
@@ -28,13 +28,13 @@ js_run_binary(
     srcs = [
         "//src/workerd/tools:api_encoder",
     ],
-    outs = ["api.d.ts", "api.ts"],  # TODO(soon) switch to out_dirs when generating multiple files
     args = [
-        "src/workerd/tools/api.capnp.bin",
+        "src/workerd/tools",
         "--output",
-        "types/api.d.ts",
+        "types/definitions",
         "--format",
     ],
+    out_dirs = ["definitions"],
     silent_on_success = False,  # Always enable logging for debugging
     tool = ":types_bin",
 )

--- a/types/src/program.ts
+++ b/types/src/program.ts
@@ -1,4 +1,3 @@
-import { assert } from "console";
 import path from "path";
 import ts from "typescript";
 

--- a/types/test/index.spec.ts
+++ b/types/test/index.spec.ts
@@ -108,12 +108,16 @@ test("main: generates types", async () => {
   // https://bazel.build/reference/test-encyclopedia#initial-conditions
   const tmpPath = process.env.TEST_TMPDIR;
   assert(tmpPath !== undefined);
-  const inputPath = path.join(tmpPath, "types.capnp.bin");
-  const outputPath = path.join(tmpPath, "types.d.ts");
+  const definitionsDir = path.join(tmpPath, "definitions");
+  await fs.mkdir(definitionsDir);
+  const inputDir = path.join(tmpPath, "capnp");
+  await fs.mkdir(inputDir);
+  const inputPath = path.join(inputDir, "types.api.capnp.bin");
+  const outputPath = path.join(definitionsDir, "types", "api.d.ts");
 
   await fs.writeFile(inputPath, new Uint8Array(message.toArrayBuffer()));
 
-  await main([inputPath, "--output", outputPath]);
+  await main([inputDir, "--output", definitionsDir]);
   let output = await fs.readFile(outputPath, "utf8");
   assert.strictEqual(
     output,
@@ -141,7 +145,7 @@ declare const prop: Promise<number>;
   );
 
   // Test formatted output
-  await main([inputPath, "-o", outputPath, "--format"]);
+  await main([inputDir, "-o", definitionsDir, "--format"]);
   output = await fs.readFile(outputPath, "utf8");
   assert.strictEqual(
     output,


### PR DESCRIPTION
> Blocked on #136 

This generates a `bazel-bin/types/definitions/*/api.d.ts` and `bazel-bin/types/definitions/*/api.ts` file for the following compatibility dates:

> The expandable diff shows how the (ambient) types have changed from the directly preceding older date


<details>
    <summary><code>latest</code>, the current up to date version of the runtime</summary>
    <div>
<br/>

```sh
diff bazel-bin/types/definitions/2022-08-04/api.d.ts bazel-bin/types/definitions/latest/api.d.ts
```

```diff
515a516,539
> declare abstract class ReadableStreamBYOBRequest {
>   readonly view: Uint8Array | null;
>   respond(param0: number): void;
>   respondWithNewView(param0: ArrayBuffer | ArrayBufferView): void;
>   readonly atLeast: number | null;
> }
> declare abstract class ReadableStreamDefaultController<R = any> {
>   readonly desiredSize: number | null;
>   close(): void;
>   enqueue(chunk?: R): void;
>   error(param0: any): void;
> }
> declare abstract class ReadableByteStreamController {
>   readonly byobRequest: ReadableStreamBYOBRequest | null;
>   readonly desiredSize: number | null;
>   close(): void;
>   enqueue(param0: ArrayBuffer | ArrayBufferView): void;
>   error(param0: any): void;
> }
> /** This Streams API interface represents a controller allowing control of a WritableStream's state. When constructing a WritableStream, the underlying sink is given a corresponding WritableStreamDefaultController instance to manipulate. */
> declare abstract class WritableStreamDefaultController {
>   readonly signal: AbortSignal;
>   error(param0?: any): void;
> }
593a618
>   get origin(): string;
596d620
<   get origin(): string;
613d636
<   get searchParams(): URLSearchParams;
616c639
<   toString(): string;
---
>   get searchParams(): URLSearchParams;
617a641
>   toString(): string;
621,625c645
<     init?:
<       | URLSearchParams
<       | string
<       | Record<string, string>
<       | [key: string, value: string][]
---
>     param0?: Iterable<Iterable<string>> | Record<string, string> | string
872a893,896
>   ReadableStreamBYOBRequest: typeof ReadableStreamBYOBRequest;
>   ReadableStreamDefaultController: typeof ReadableStreamDefaultController;
>   ReadableByteStreamController: typeof ReadableByteStreamController;
>   WritableStreamDefaultController: typeof WritableStreamDefaultController;
1573,1596d1596
< declare interface ReadableStreamBYOBRequest {
<   readonly view: Uint8Array | null;
<   respond(param0: number): void;
<   respondWithNewView(param0: ArrayBuffer | ArrayBufferView): void;
<   readonly atLeast: number | null;
< }
< declare interface ReadableStreamDefaultController<R = any> {
<   readonly desiredSize: number | null;
<   close(): void;
<   enqueue(chunk?: R): void;
<   error(param0: any): void;
< }
< declare interface ReadableByteStreamController {
<   readonly byobRequest: ReadableStreamBYOBRequest | null;
<   readonly desiredSize: number | null;
<   close(): void;
<   enqueue(param0: ArrayBuffer | ArrayBufferView): void;
<   error(param0: any): void;
< }
< /** This Streams API interface represents a controller allowing control of a WritableStream's state. When constructing a WritableStream, the underlying sink is given a corresponding WritableStreamDefaultController instance to manipulate. */
< declare interface WritableStreamDefaultController {
<   readonly signal: AbortSignal;
<   error(param0?: any): void;
< }
```

  </div>
  </details>

<details>
    <summary>
<code>2022-08-04</code>, <a href="https://developers.cloudflare.com/workers/platform/compatibility-dates/#r2-bucket-list-respects-the-include-option">#r2-bucket-list-respects-the-include-option</a>

</summary>
    <div>
<br/>

```sh
diff bazel-bin/types/definitions/2022-03-21/api.d.ts bazel-bin/types/definitions/2022-08-04/api.d.ts
```

</div></details>


<details>
    <summary>
<code>2022-03-21</code>, <a href="https://developers.cloudflare.com/workers/platform/compatibility-dates/#global-navigator">#global-navigator</a>

</summary>
    <div>
<br/>

```sh
diff bazel-bin/types/definitions/2022-01-31/api.d.ts bazel-bin/types/definitions/2022-03-21/api.d.ts
```

```diff
43a44,46
> declare abstract class Navigator {
>   readonly userAgent: string;
> }
883a887,888
>   navigator: Navigator;
>   Navigator: typeof Navigator;
1720a1726
> declare var navigator: Navigator;

```

</div></details>

<details>
    <summary>
<code>2022-01-31</code>, <a href="https://developers.cloudflare.com/workers/platform/compatibility-dates/#settersgetters-on-api-object-prototypes">#settersgetters-on-api-object-prototypes</a>

</summary>
    <div>
<br/>

```sh
diff bazel-bin/types/definitions/2021-11-03/api.d.ts bazel-bin/types/definitions/2022-01-31/api.d.ts
```

```diff
48c48
<   readonly type: string;
---
>   get type(): string;
50c50
<   readonly eventPhase: number;
---
>   get eventPhase(): number;
52c52
<   readonly composed: boolean;
---
>   get composed(): boolean;
54c54
<   readonly bubbles: boolean;
---
>   get bubbles(): boolean;
56c56
<   readonly cancelable: boolean;
---
>   get cancelable(): boolean;
58c58
<   readonly defaultPrevented: boolean;
---
>   get defaultPrevented(): boolean;
60c60
<   readonly returnValue: boolean;
---
>   get returnValue(): boolean;
62c62
<   readonly currentTarget?: EventTarget;
---
>   get currentTarget(): EventTarget | undefined;
64c64
<   readonly srcElement?: EventTarget;
---
>   get srcElement(): EventTarget | undefined;
66c66
<   readonly timeStamp: number;
---
>   get timeStamp(): number;
68,69c68,70
<   readonly isTrusted: boolean;
<   cancelBubble: boolean;
---
>   get isTrusted(): boolean;
>   get cancelBubble(): boolean;
>   set cancelBubble(value: boolean);
121c122
<   readonly signal: AbortSignal;
---
>   get signal(): AbortSignal;
129,130c130,131
<   readonly aborted: boolean;
<   readonly reason: any;
---
>   get aborted(): boolean;
>   get reason(): any;
143,144c144,145
<   readonly size: number;
<   readonly type: string;
---
>   get size(): number;
>   get type(): string;
157,158c158,159
<   readonly name: string;
<   readonly lastModified: number;
---
>   get name(): string;
>   get lastModified(): number;
186c187
<   readonly subtle: SubtleCrypto;
---
>   get subtle(): SubtleCrypto;
300c301
<   readonly digest: Promise<ArrayBuffer>;
---
>   get digest(): Promise<ArrayBuffer>;
322,324c323,325
<   readonly encoding: string;
<   readonly fatal: boolean;
<   readonly ignoreBOM: boolean;
---
>   get encoding(): string;
>   get fatal(): boolean;
>   get ignoreBOM(): boolean;
333c334
<   readonly encoding: string;
---
>   get encoding(): string;
393,394c394,395
<   readonly body: ReadableStream | null;
<   readonly bodyUsed: boolean;
---
>   get body(): ReadableStream | null;
>   get bodyUsed(): boolean;
419,426c420,427
<   readonly status: number;
<   readonly statusText: string;
<   readonly headers: Headers;
<   readonly ok: boolean;
<   readonly redirected: boolean;
<   readonly url: string;
<   readonly webSocket: WebSocket | null;
<   readonly cf?: any;
---
>   get status(): number;
>   get statusText(): string;
>   get headers(): Headers;
>   get ok(): boolean;
>   get redirected(): boolean;
>   get url(): string;
>   get webSocket(): WebSocket | null;
>   get cf(): any | undefined;
433c434
<   readonly method: string;
---
>   get method(): string;
435c436
<   readonly url: string;
---
>   get url(): string;
437c438
<   readonly headers: Headers;
---
>   get headers(): Headers;
439,440c440,441
<   readonly redirect: string;
<   readonly fetcher: Fetcher | null;
---
>   get redirect(): string;
>   get fetcher(): Fetcher | null;
442,443c443,444
<   readonly signal: AbortSignal;
<   readonly cf?: any;
---
>   get signal(): AbortSignal;
>   get cf(): any | undefined;
494c495
<   readonly closed: Promise<void>;
---
>   get closed(): Promise<void>;
501c502
<   readonly closed: Promise<void>;
---
>   get closed(): Promise<void>;
515c516
<   readonly locked: boolean;
---
>   get locked(): boolean;
523,525c524,526
<   readonly closed: Promise<void>;
<   readonly ready: Promise<void>;
<   readonly desiredSize: number | null;
---
>   get closed(): Promise<void>;
>   get ready(): Promise<void>;
>   get desiredSize(): number | null;
537,538c538,539
<   readonly readable: ReadableStream<O>;
<   readonly writable: WritableStream<I>;
---
>   get readable(): ReadableStream<O>;
>   get writable(): WritableStream<I>;
590,601c591,612
<   href: string;
<   readonly origin: string;
<   protocol: string;
<   username: string;
<   password: string;
<   host: string;
<   hostname: string;
<   port: string;
<   pathname: string;
<   search: string;
<   readonly searchParams: URLSearchParams;
<   hash: string;
---
>   get href(): string;
>   set href(value: string);
>   get origin(): string;
>   get protocol(): string;
>   set protocol(value: string);
>   get username(): string;
>   set username(value: string);
>   get password(): string;
>   set password(value: string);
>   get host(): string;
>   set host(value: string);
>   get hostname(): string;
>   set hostname(value: string);
>   get port(): string;
>   set port(value: string);
>   get pathname(): string;
>   set pathname(value: string);
>   get search(): string;
>   set search(value: string);
>   get searchParams(): URLSearchParams;
>   get hash(): string;
>   set hash(value: string);
687c698
<   readonly readyState: number;
---
>   get readyState(): number;
689c700
<   readonly url: string | null;
---
>   get url(): string | null;
691c702
<   readonly protocol: string | null;
---
>   get protocol(): string | null;
693c704
<   readonly extensions: string | null;
---
>   get extensions(): string | null;

```

</div></details>

<details>
    <summary>
<code>2021-11-03</code>, <a href="https://developers.cloudflare.com/workers/platform/compatibility-dates/#formdata-parsing-supports-file">#formdata-parsing-supports-file</a>

</summary>
    <div>
<br/>

```sh
diff bazel-bin/types/definitions/2021-01-01/api.d.ts bazel-bin/types/definitions/2021-11-03/api.d.ts
```

</div></details>

<details>
    <summary>
<code>2021-01-01</code>, before any compatibility date based changes
</summary>
    <div>

</div></details>

Two of these dates don't change the types, but I think they _should_, based on their description (cc @mrbbot):
- 2022-08-04

  > With the r2_list_honor_include flag set, the include argument to R2 list options is honored. With an older compatability date and without this flag, the include argument behaves implicitly as `include: ["httpMetadata", "customMetadata"]`.

- 2021-11-03

  > Originally, the Workers runtime’s implementation of the FormData API incorrectly converted uploaded files to strings. Therefore, `formData.get("filename")` would return a string containing the file contents instead of a `File` object. This change fixes the problem, causing files to be represented using `File` as specified in the standard.