### PR TITLE
Improve representation of trace spans.

### DIFF
--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -15,7 +15,7 @@ class CacheClient {
   // contain it.
 public:
   virtual kj::Own<kj::HttpClient> getDefault(
-      kj::Maybe<kj::String> cfBlobJson, kj::Maybe<Tracer::Span&> parentSpan) = 0;
+      kj::Maybe<kj::String> cfBlobJson, SpanParent parentSpan) = 0;
   // Get the default namespace, i.e. the one that fetch() will use for caching.
   //
   // The returned client is intended to be used for one request. `cfBlobJson` and `parentSpan` have
@@ -23,7 +23,7 @@ public:
 
   virtual kj::Own<kj::HttpClient> getNamespace(
       kj::StringPtr name, kj::Maybe<kj::String> cfBlobJson,
-      kj::Maybe<Tracer::Span&> parentSpan) = 0;
+      SpanParent parentSpan) = 0;
   // Get an HttpClient for the given cache namespace.
   //
   // The returned client is intended to be used for one request. `parentSpan` has the same meaning
@@ -125,15 +125,8 @@ public:
     kj::Maybe<kj::String> cfBlobJson;
     // The `request.cf` blob, JSON-encoded.
 
-    kj::Maybe<Tracer::Span&> parentSpan;
-    // If specified, and tracing is active, specifies the parent span for the subrequest.
-    //
-    // Note the referenced `Span` object is only guaranteed to exist until the factory callback
-    // returns. (In practice, it probably lives for the lifetime of the subrequest, but this
-    // shouldn't be assumed.)
-    //
-    // Design note: We use a `Tracer::Span` rather than a `Jaeger::SpanContext` here in order to
-    // try to keep tracing implementation details out of the IoContext / APIs layer.
+    SpanParent parentSpan = nullptr;
+    // Specifies the parent span for the subrequest for tracing purposes.
 
     kj::Maybe<kj::StringPtr> featureFlagsForFl;
     // Serialized JSON value to pass in ew_compat field of control header to FL. If this subrequest
@@ -192,7 +185,7 @@ public:
   // `ActorIdFactory` -- if it's from some other factory, the method will throw an appropriate
   // exception.
 
-  virtual kj::Own<ActorChannel> getColoLocalActor(uint channel, kj::String id) = 0;
+  virtual kj::Own<ActorChannel> getColoLocalActor(uint channel, kj::StringPtr id) = 0;
   // Get an actor stub from the given namespace for the actor with the given name.
 };
 

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -735,15 +735,15 @@ public:
     // When true, the client is wrapped by metrics.wrapSubrequestClient() ensuring appropriate
     // metrics collection.
     kj::Maybe<kj::StringPtr> operationName;
-    // The name to use for the request's Jaeger span if Jaeger tracing is turned on.
+    // The name to use for the request's span if tracing is turned on.
   };
 
   kj::Own<WorkerInterface> getSubrequestNoChecks(
-      kj::FunctionParam<kj::Own<WorkerInterface>(kj::Maybe<Tracer::Span&>, IoChannelFactory&)> func,
+      kj::FunctionParam<kj::Own<WorkerInterface>(SpanBuilder&, IoChannelFactory&)> func,
       SubrequestOptions options);
 
   kj::Own<WorkerInterface> getSubrequest(
-      kj::FunctionParam<kj::Own<WorkerInterface>(kj::Maybe<Tracer::Span&>, IoChannelFactory&)> func,
+      kj::FunctionParam<kj::Own<WorkerInterface>(SpanBuilder&, IoChannelFactory&)> func,
       SubrequestOptions options);
   // If creating a new subrequest is permitted, calls the given factory function to create one.
 
@@ -766,8 +766,7 @@ public:
   //   request.
   // - In preview, in-house requests do not show up in the network tab.
   //
-  // `operationName` is the name to use for the request's Jaeger span, if Jaeger tracing is
-  // turned on.
+  // `operationName` is the name to use for the request's span, if tracing is turned on.
 
   kj::Own<WorkerInterface> getSubrequestChannelNoChecks(
       uint channel, bool isInHouse, kj::Maybe<kj::String> cfBlobJson,
@@ -793,14 +792,14 @@ public:
         uint channel, const ActorIdFactory::ActorId& id, kj::Maybe<kj::String> locationHint) {
     return getIoChannelFactory().getGlobalActor(channel, id, kj::mv(locationHint));
   }
-  kj::Own<IoChannelFactory::ActorChannel> getColoLocalActorChannel(uint channel, kj::String id) {
-    return getIoChannelFactory().getColoLocalActor(channel, kj::mv(id));
+  kj::Own<IoChannelFactory::ActorChannel> getColoLocalActorChannel(uint channel, kj::StringPtr id) {
+    return getIoChannelFactory().getColoLocalActor(channel, id);
   }
 
   kj::Own<CacheClient> getCacheClient();
   // Get an HttpClient to use for Cache API subrequests.
 
-  kj::Maybe<Tracer::Span> makeTraceSpan(kj::StringPtr operationName);
+  SpanBuilder makeTraceSpan(kj::StringPtr operationName);
   // Make a new trace span, if tracing is active. Returns null if tracing is not active.
 
   jsg::Promise<kj::Maybe<IoOwn<kj::AsyncInputStream>>> makeCachePutStream(
@@ -970,7 +969,7 @@ private:
 
   kj::Own<WorkerInterface> getSubrequestChannelImpl(
       uint channel, bool isInHouse, kj::Maybe<kj::String> cfBlobJson,
-      kj::Maybe<Tracer::Span&> span, IoChannelFactory& channelFactory);
+      SpanBuilder& span, IoChannelFactory& channelFactory);
 
   friend class IoContext_IncomingRequest;
   template <typename T> friend class IoOwn;

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -62,7 +62,7 @@ public:
     return kj::mv(client);
   }
 
-  virtual kj::Maybe<Tracer::Span&> getSpan() { return nullptr; }
+  virtual SpanParent getSpan() { return nullptr; }
 
   virtual void addedContextTask() {}
   virtual void finishedContextTask() {}
@@ -132,7 +132,7 @@ public:
   };
 
   virtual kj::Maybe<kj::Own<LockTiming>> tryCreateLockTiming(
-      kj::OneOf<MaybeTracer, kj::Maybe<RequestObserver&>> tracerOrRequest) const { return nullptr; }
+      kj::OneOf<SpanParent, kj::Maybe<RequestObserver&>> parentOrRequest) const { return nullptr; }
   // Construct a LockTiming if config.reportScriptLockTiming is true, or if the
   // request (if any) is being traced.
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -78,7 +78,7 @@ public:
                       jsg::Lock& lock, const ApiIsolate& apiIsolate,
                       v8::Local<v8::Object> target)> compileBindings,
                   IsolateObserver::StartType startType,
-                  MaybeTracer systemTracer, LockType lockType,
+                  SpanParent parentSpan, LockType lockType,
                   kj::Maybe<ValidationErrorReporter&> errorReporter = nullptr);
   // `compileBindings()` is a callback that constructs all of the bindings and adds them as
   // properties to `target`.
@@ -94,7 +94,7 @@ public:
   class Lock;
 
   class AsyncLock;
-  kj::Promise<AsyncLock> takeAsyncLockWithoutRequest(MaybeTracer systemTracer) const;
+  kj::Promise<AsyncLock> takeAsyncLockWithoutRequest(SpanParent parentSpan) const;
   kj::Promise<AsyncLock> takeAsyncLock(RequestObserver& request) const;
   // Places this thread into the queue of threads which are interested in locking this isolate,
   // and returns when it is this thread's turn. The thread must still obtain a `Worker::Lock`, but
@@ -102,7 +102,7 @@ public:
   // with many other threads, and all interested threads get their fair turn.
   //
   // The version accepting a `request` metrics object accumulates lock timing data and reports the
-  // data via `request`'s Jaeger span.
+  // data via `request`'s trace span.
 
   class Actor;
 
@@ -299,7 +299,7 @@ public:
   void completedRequest() const;
   // Called after each completed request. Does not require a lock.
 
-  kj::Promise<AsyncLock> takeAsyncLockWithoutRequest(MaybeTracer systemTracer) const;
+  kj::Promise<AsyncLock> takeAsyncLockWithoutRequest(SpanParent parentSpan) const;
   kj::Promise<AsyncLock> takeAsyncLock(RequestObserver&) const;
   // See Worker::takeAsyncLock().
 


### PR DESCRIPTION
This is a sketch of a better interface for trace spans that does not involve a `Tracer` object. Instead, anything which needs to produce traces receives a `SpanParent`, which is a reference to a parent span, and can create children from that.

An additional goal of this refactoring is to eliminate the dependency on Jaeger which also allows us to eliminate the dependency on Protobuf. Jaeger is one system that these traces could feed into, but by abstracting the API we can potentially support many different trace collectors.

The classes are designed such that if no tracing is active, no extra memory allocations are needed.

This is very incomplete. I'm uploading it for discussion purposes.

The interface proposal is in `trace.h`. The rest is showing how some things would change to use this.