### PR TITLE
Cleanup: Don't pass `Tracer` to `WorkerEntrypoint::construct()`.

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -220,12 +220,10 @@ IoContext::IncomingRequest::IoContext_IncomingRequest(
     kj::Own<IoContext> contextParam,
     kj::Own<IoChannelFactory> ioChannelFactoryParam,
     kj::Own<RequestObserver> metricsParam,
-    kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
-    kj::Maybe<kj::Own<Tracer>> tracer)
+    kj::Maybe<kj::Own<WorkerTracer>> workerTracer)
     : context(kj::mv(contextParam)),
       metrics(kj::mv(metricsParam)),
       workerTracer(kj::mv(workerTracer)),
-      tracer(kj::mv(tracer)),
       ioChannelFactory(kj::mv(ioChannelFactoryParam)) {}
 
 void IoContext::IncomingRequest::delivered() {
@@ -917,7 +915,7 @@ kj::Own<CacheClient> IoContext::getCacheClient() {
 }
 
 kj::Maybe<Tracer::Span> IoContext::makeTraceSpan(kj::StringPtr operationName) {
-  return mapMakeSpan(getTracer(), operationName, getMetrics().getSpan());
+  return mapMakeSpan(getMetrics().getSpan(), operationName);
 }
 
 void IoContext::taskFailed(kj::Exception&& exception) {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -193,8 +193,7 @@ public:
   IoContext_IncomingRequest(kj::Own<IoContext> context,
                             kj::Own<IoChannelFactory> ioChannelFactory,
                             kj::Own<RequestObserver> metrics,
-                            kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
-                            kj::Maybe<kj::Own<Tracer>> tracer);
+                            kj::Maybe<kj::Own<WorkerTracer>> workerTracer);
   KJ_DISALLOW_COPY(IoContext_IncomingRequest);
   ~IoContext_IncomingRequest() noexcept(false);
 
@@ -236,13 +235,10 @@ public:
 
   kj::Maybe<WorkerTracer&> getWorkerTracer() { return workerTracer; }
 
-  kj::Maybe<Tracer&> getTracer() { return tracer; }
-
 private:
   kj::Own<IoContext> context;
   kj::Own<RequestObserver> metrics;
   kj::Maybe<kj::Own<WorkerTracer>> workerTracer;
-  kj::Maybe<kj::Own<Tracer>> tracer;
   kj::Own<IoChannelFactory> ioChannelFactory;
 
   bool wasDelivered = false;
@@ -315,11 +311,6 @@ public:
   const kj::Maybe<WorkerTracer&> getWorkerTracer() {
     if (incomingRequests.empty()) return nullptr;
     return getCurrentIncomingRequest().getWorkerTracer();
-  }
-
-  const kj::Maybe<Tracer&> getTracer() {
-    if (incomingRequests.empty()) return nullptr;
-    return getCurrentIncomingRequest().tracer.map([](kj::Own<Tracer>& t) -> Tracer& { return *t; });
   }
 
   LimitEnforcer& getLimitEnforcer() { return *limitEnforcer; }

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -564,6 +564,19 @@ kj::Maybe<Tracer::Span> mapMakeSpan(
   return nullptr;
 }
 
+kj::Maybe<Tracer::Span> mapMakeSpan(
+    kj::Maybe<Tracer::Span&> parent,
+    kj::StringPtr operationName) {
+  KJ_IF_MAYBE(p, parent) {
+    // Only return a Jaeger span if this Tracer has a parent span -- i.e., we're actually being
+    // Jaeger traced.
+    if (p->getTracer().getParentSpanContext() != nullptr) {
+      return p->getTracer().makeSpan(operationName, parent);
+    }
+  }
+  return nullptr;
+}
+
 kj::Maybe<Jaeger::SpanContext> mapGetParentSpanContext(kj::Maybe<kj::Own<Tracer>>& tracer) {
   KJ_IF_MAYBE(t, tracer) {
     return t->get()->getParentSpanContext();

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -306,7 +306,12 @@ public:
   };
 
   bool operator==(std::nullptr_t) { return span == nullptr; }
+
   explicit operator bool() { return span != nullptr; }
+  // TODO(cleanup): Remove this, per KJ style people should always use `== nullptr`.
+
+  operator kj::Maybe<Tracer::Span&>() & { return span; }
+  // TODO(cleanup): Remove this. It's a temporary helper while refactoring.
 
   kj::Maybe<Jaeger::SpanContext> getSpanContext() {
     KJ_IF_MAYBE(s, span) {

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -283,6 +283,10 @@ kj::Maybe<Tracer::Span> mapMakeSpan(
 //
 // TODO(cleanup): Tracing suffers from Maybe-overload. There's probably a better interface design.
 
+kj::Maybe<Tracer::Span> mapMakeSpan(
+    kj::Maybe<Tracer::Span&> parent, kj::StringPtr operationName);
+// Like above but gets the `tracer` from `parent.getTracer()` (if parent is non-null).
+
 kj::Maybe<Jaeger::SpanContext> mapGetParentSpanContext(kj::Maybe<kj::Own<Tracer>>& tracer);
 kj::Maybe<Jaeger::SpanContext> mapGetParentSpanContext(kj::Maybe<Tracer&> tracer);
 // If tracer is non-null, return tracer->getParentSpanContext().

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -50,13 +50,12 @@ kj::Own<WorkerInterface> WorkerEntrypoint::construct(
                                    kj::TaskSet& waitUntilTasks,
                                    bool tunnelExceptions,
                                    kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
-                                   kj::Maybe<kj::Own<Tracer>> tracer,
                                    kj::Maybe<kj::String> cfBlobJson) {
   auto obj = kj::heap<WorkerEntrypoint>(kj::Badge<WorkerEntrypoint>(), threadContext,
       waitUntilTasks, tunnelExceptions, entrypointName, kj::mv(cfBlobJson));
   obj->init(kj::mv(worker), kj::mv(actor), kj::mv(limitEnforcer),
       kj::mv(ioContextDependency), kj::mv(ioChannelFactory), kj::addRef(*metrics),
-      kj::mv(workerTracer), kj::mv(tracer));
+      kj::mv(workerTracer));
   auto& wrapper = metrics->wrapWorkerInterface(*obj);
   return kj::attachRef(wrapper, kj::mv(obj), kj::mv(metrics));
 }
@@ -80,8 +79,7 @@ void WorkerEntrypoint::init(
     kj::Own<void> ioContextDependency,
     kj::Own<IoChannelFactory> ioChannelFactory,
     kj::Own<RequestObserver> metrics,
-    kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
-    kj::Maybe<kj::Own<Tracer>> tracer) {
+    kj::Maybe<kj::Own<WorkerTracer>> workerTracer) {
   // We need to construct the IoContext -- unless this is an actor and it already has a
   // IoContext, in which case we reuse it.
 
@@ -109,7 +107,7 @@ void WorkerEntrypoint::init(
 
   incomingRequest = kj::heap<IoContext::IncomingRequest>(
       kj::mv(context), kj::mv(ioChannelFactory), kj::mv(metrics),
-      kj::mv(workerTracer), kj::mv(tracer))
+      kj::mv(workerTracer))
       .attach(kj::mv(actor));
 }
 

--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -32,7 +32,6 @@ public:
                    kj::TaskSet& waitUntilTasks,
                    bool tunnelExceptions,
                    kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
-                   kj::Maybe<kj::Own<Tracer>> tracer,
                    kj::Maybe<kj::String> cfBlobJson);
   // Call this instead of the constructor. It actually adds a wrapper object around the
   // `WorkerEntrypoint`, but the wrapper still implements `WorkerInterface`.
@@ -79,8 +78,7 @@ private:
       kj::Own<void> ioContextDependency,
       kj::Own<IoChannelFactory> ioChannelFactory,
       kj::Own<RequestObserver> metrics,
-      kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
-      kj::Maybe<kj::Own<Tracer>> tracer);
+      kj::Maybe<kj::Own<WorkerTracer>> workerTracer);
 
 public:  // For kj::heap() only; pretend this is private.
   WorkerEntrypoint(kj::Badge<WorkerEntrypoint> badge,

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1150,7 +1150,6 @@ public:
         waitUntilTasks,
         true,                      // tunnelExceptions
         nullptr,                   // workerTracer
-        nullptr,                   // tracer
         kj::mv(metadata.cfBlobJson));
   }
 


### PR DESCRIPTION
It turns out this is always redundant because if Jaeger tracing is enabled, `RequestObserver::getSpan()` returns non-null, and we can get the `Tracer` object from that.

Historically, `Tracer` was used for more than just Jaeger tracing, but the other usage was split off into the `WorkerTracer` class a few months ago. So, there's just no need to pass `Tracer` separately anymore.

Note that we should probably take this a few steps further and remove the `Tracer` class altogether, while moving the concept of spans over to `observer.h`, where it more naturally belongs at this point. I may work on that a bit later, but this simple cleanup seems worth merging as-is.