### PR TITLE
Remove `id` parameter from IsolateObserver::created()

### DIFF
--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -74,7 +74,7 @@ public:
 
 class IsolateObserver: public kj::AtomicRefcounted {
 public:
-  virtual void created(kj::StringPtr id) {};
+  virtual void created() {};
   // Called when Worker::Isolate is created.
 
   virtual void evicted() {}

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -977,7 +977,7 @@ Worker::Isolate::Isolate(kj::Own<ApiIsolate> apiIsolateParam,
       metrics(kj::mv(metricsParam)),
       impl(kj::heap<Impl>(*apiIsolate, *metrics, *limitEnforcer, allowInspector)),
       weakIsolateRef(kj::atomicRefcounted<WeakIsolateRef>(this)) {
-  metrics->created(id);
+  metrics->created();
   // We just created our isolate, so we don't need to use Isolate::Impl::Lock (nor an async lock).
   auto lock = apiIsolate->lock();
   auto features = apiIsolate->getFeatureFlags();


### PR DESCRIPTION
This turned out to be unnecessary, since implementations of IsolateObserver can already receive arbitrary identifiers by other means.