### PR TITLE
Enable built-in modules to import internal modules

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1341,7 +1341,7 @@ Worker::Worker(kj::Own<const Script> scriptParam,
           KJ_IF_MAYBE(entry, registry.resolve(lock, mainModule)) {
             JSG_REQUIRE(entry->maybeSynthetic == nullptr, TypeError,
                         "Main module must be an ES module.");
-            auto module = entry->module.Get(lock.v8Isolate);
+            auto module = entry->module.getHandle(lock);
 
             {
               auto limitScope = script->isolate->getLimitEnforcer()

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -159,6 +159,15 @@ v8::MaybeLocal<v8::Value> evaluateSyntheticModuleCallback(
           // leave 'result' empty to propagate the JS exception
         }
       }
+      KJ_CASE_ONEOF(info, ModuleRegistry::ObjectModuleInfo) {
+        if (module->SetSyntheticModuleExport(isolate,
+                                             v8StrIntern(isolate, "default"_kj),
+                                             info.value.getHandle(isolate)).IsJust()) {
+          result = makeResolvedPromise();
+        } else {
+          // leave 'result' empty to propagate the JS exception
+        }
+      }
     }
   })) {
     // V8 doc comments say in the case of an error, throw the error and return an empty Maybe.

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -27,15 +27,20 @@ v8::MaybeLocal<v8::Module> resolveCallback(v8::Local<v8::Context> context,
     auto registry = getModulesForResolveCallback(isolate);
     KJ_REQUIRE(registry != nullptr, "didn't expect resolveCallback() now");
 
-    auto& referrerPath = KJ_ASSERT_NONNULL(registry->resolvePath(referrer),
+    auto ref = KJ_ASSERT_NONNULL(registry->resolve(js, referrer),
         "referrer passed to resolveCallback isn't in modules table");
 
-    kj::Path targetPath = referrerPath.parent().eval(kj::str(specifier));
+    kj::Path targetPath = ref.specifier.parent().eval(kj::str(specifier));
 
-    result = JSG_REQUIRE_NONNULL(registry->resolve(js, targetPath), Error,
+    // If the referrer module is a built-in, it is only permitted to resolve
+    // internal modules. If the worker bundle provided an override for a builtin,
+    // then internalOnly will be false.
+    bool internalOnly = ref.type == ModuleRegistry::Type::BUILTIN;
+
+    result = JSG_REQUIRE_NONNULL(registry->resolve(js, targetPath, internalOnly), Error,
         "No such module \"", targetPath.toString(),
-        "\".\n  imported from \"", referrerPath.toString(), "\"")
-        .module.Get(isolate);
+        "\".\n  imported from \"", ref.specifier.toString(), "\"")
+        .module.getHandle(js);
 
   })) {
     isolate->ThrowException(makeInternalError(isolate, kj::mv(*exception)));
@@ -57,7 +62,7 @@ v8::MaybeLocal<v8::Value> evaluateSyntheticModuleCallback(
 
   KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
     auto registry = getModulesForResolveCallback(isolate);
-    auto& entry = KJ_ASSERT_NONNULL(registry->resolve(js, module),
+    auto ref = KJ_ASSERT_NONNULL(registry->resolve(js, module),
         "module passed to evaluateSyntheticModuleCallback isn't in modules table");
 
     // V8 doc comments say this callback must always return an already-resolved promise... I don't
@@ -75,7 +80,7 @@ v8::MaybeLocal<v8::Value> evaluateSyntheticModuleCallback(
       return resolver->GetPromise();
     };
 
-    auto& synthetic = KJ_REQUIRE_NONNULL(entry.maybeSynthetic, "Not a synthetic module.");
+    auto& synthetic = KJ_REQUIRE_NONNULL(ref.module.maybeSynthetic, "Not a synthetic module.");
 
     KJ_SWITCH_ONEOF(synthetic) {
       KJ_CASE_ONEOF(info, ModuleRegistry::CapnpModuleInfo) {
@@ -173,6 +178,10 @@ v8::Local<v8::Value> CommonJsModuleContext::require(kj::String specifier, v8::Is
 
   kj::Path targetPath = path.parent().eval(specifier);
   auto& js = Lock::from(isolate);
+
+  // require() is only exposed to worker bundle modules so the resolve here is only
+  // permitted to require worker bundle or built-in modules. Internal modules are
+  // excluded.
   auto& info = JSG_REQUIRE_NONNULL(modulesForResolveCallback->resolve(js, targetPath),
       Error, "No such module \"", targetPath.toString(), "\".");
   // Adding imported from suffix here not necessary like it is for resolveCallback, since we have a
@@ -181,7 +190,7 @@ v8::Local<v8::Value> CommonJsModuleContext::require(kj::String specifier, v8::Is
   JSG_REQUIRE_NONNULL(info.maybeSynthetic, TypeError,
       "Cannot use require() to import an ES Module.");
 
-  auto module = info.module.Get(isolate);
+  auto module = info.module.getHandle(js);
   auto context = isolate->GetCurrentContext();
 
   check(module->InstantiateModule(context, &resolveCallback));
@@ -298,7 +307,6 @@ ModuleRegistry::ModuleInfo::ModuleInfo(
     v8::Local<v8::Module> module,
     kj::Maybe<SyntheticModuleInfo> maybeSynthetic)
     : module(js.v8Isolate, module),
-      hash(module->GetIdentityHash()),
       maybeSynthetic(kj::mv(maybeSynthetic)) {}
 
 ModuleRegistry::ModuleInfo::ModuleInfo(

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -82,6 +82,19 @@ class ModuleRegistry {
   // The ModuleRegistry maintains the collection of modules known to a script that can be
   // required or imported.
 public:
+  enum class Type {
+    // BUNDLE is for modules provided by the worker bundle.
+    // BUILTIN is for modules that are provided by the runtime and can be
+    // imported by the worker bundle. These can be overridden by modules
+    // in the worker bundle.
+    // INTERNAL is for BUILTIN modules that can only be imported by other
+    // BUILTIN modules. These cannot be overriden by modules in the worker
+    // bundle.
+
+    BUNDLE,
+    BUILTIN,
+    INTERNAL,
+  };
 
   static inline ModuleRegistry* from(jsg::Lock& js) {
     return static_cast<ModuleRegistry*>(
@@ -146,8 +159,7 @@ public:
   using JsonModuleInfo = ValueModuleInfo<v8::Value>;
 
   struct ModuleInfo {
-    v8::Global<v8::Module> module;
-    int hash;
+    HashableV8Ref<v8::Module> module;
 
     using SyntheticModuleInfo = kj::OneOf<CapnpModuleInfo,
                                           CommonJsModuleInfo,
@@ -157,7 +169,7 @@ public:
                                           JsonModuleInfo>;
     kj::Maybe<SyntheticModuleInfo> maybeSynthetic;
 
-  ModuleInfo(jsg::Lock& js,
+    ModuleInfo(jsg::Lock& js,
                v8::Local<v8::Module> module,
                kj::Maybe<SyntheticModuleInfo> maybeSynthetic = nullptr);
 
@@ -169,15 +181,25 @@ public:
 
     ModuleInfo(ModuleInfo&&) = default;
     ModuleInfo& operator=(ModuleInfo&&) = default;
+
+    uint hashCode() const { return module.hashCode(); }
   };
 
-  virtual kj::Maybe<ModuleInfo&> resolve(jsg::Lock& js, const kj::Path& specifier) = 0;
+  struct ModuleRef {
+    const kj::Path& specifier;
+    Type type;
+    ModuleInfo& module;
+  };
 
-  virtual kj::Maybe<ModuleInfo&> resolve(jsg::Lock& js, v8::Local<v8::Module> module) = 0;
+  virtual kj::Maybe<ModuleInfo&> resolve(jsg::Lock& js,
+                                         const kj::Path& specifier,
+                                         bool internalOnly = false) = 0;
 
-  virtual kj::Maybe<const kj::Path&> resolvePath(v8::Local<v8::Module> referrer)= 0;
+  virtual kj::Maybe<ModuleRef> resolve(jsg::Lock& js, v8::Local<v8::Module> module) = 0;
 
-  virtual Promise<Value> resolveDynamicImport(jsg::Lock& js, kj::Path specifier) = 0;
+  virtual Promise<Value> resolveDynamicImport(jsg::Lock& js,
+                                              const kj::Path& specifier,
+                                              const kj::Path& referrer) = 0;
 
   using DynamicImportCallback = Promise<Value>(jsg::Lock& js, kj::Function<Value()> handler);
   // The dynamic import callback is provided by the embedder to set up any context necessary
@@ -195,53 +217,89 @@ public:
   }
 
   void add(kj::Path& specifier, ModuleInfo&& info) {
-    entries.insert(Entry(specifier, kj::fwd<ModuleInfo>(info)));
+    entries.insert(Entry(specifier, Type::BUNDLE, kj::fwd<ModuleInfo>(info)));
   }
 
-  void addBuiltinModule(const kj::Path& specifier, kj::ArrayPtr<const char> sourceCode) {
+  void addBuiltinModule(const kj::Path& specifier,
+                        kj::ArrayPtr<const char> sourceCode,
+                        Type type = Type::BUILTIN) {
     // Register new module accessible by a given importPath. The module is instantiated
     // after first resolve attempt within application has failed, i.e. it is possible for
     // application to override the module.
     // sourceCode has to exist while this ModuleRegistry exists.
     // The expectation is for this method to be called during the assembly of worker global context
     // after registering all user modules.
+    KJ_ASSERT(type != Type::BUNDLE);
+    using Key = typename Entry::Key;
 
-    if (entries.find(specifier) != nullptr) {
+    // We need to make sure there is not an existing worker bundle module with the same
+    // name if type == Type::BUILTIN
+    if (type == Type::BUILTIN && entries.find(Key(specifier, Type::BUNDLE)) != nullptr) {
       return;
     }
 
-    entries.insert(Entry(specifier, sourceCode));
+    entries.insert(Entry(specifier, type, sourceCode));
   }
 
-  kj::Maybe<ModuleInfo&> resolve(jsg::Lock& js, const kj::Path& specifier) override {
-    // TODO(soon): Soon we will support prefixed imports of Workers built in types.
-    KJ_IF_MAYBE(entry, entries.find(specifier)) {
-      return entry->module(js);
+  kj::Maybe<ModuleInfo&> resolve(jsg::Lock& js,
+                                 const kj::Path& specifier,
+                                 bool internalOnly = false) override {
+    using Key = typename Entry::Key;
+    if (internalOnly) {
+      KJ_IF_MAYBE(entry, entries.find(Key(specifier, Type::INTERNAL))) {
+        return entry->module(js);
+      }
+    } else {
+      // First, we try to resolve a worker bundle version of the module.
+      KJ_IF_MAYBE(entry, entries.find(Key(specifier, Type::BUNDLE))) {
+        return entry->module(js);
+      }
+      // Then we look for a built-in version of the module.
+      KJ_IF_MAYBE(entry, entries.find(Key(specifier, Type::BUILTIN))) {
+        return entry->module(js);
+      }
     }
     return nullptr;
   }
 
-  kj::Maybe<ModuleInfo&> resolve(jsg::Lock& js, v8::Local<v8::Module> module) override {
-    KJ_IF_MAYBE(entry, entries.template find<1>(module)) {
-      return entry->module(js);
-    }
-    return nullptr;
-  }
-
-  kj::Maybe<const kj::Path&> resolvePath(v8::Local<v8::Module> module) override {
-    KJ_IF_MAYBE(entry, entries.template find<1>(module)) {
-      return entry->specifier;
+  kj::Maybe<ModuleRef> resolve(jsg::Lock& js, v8::Local<v8::Module> module) override {
+    for (const Entry& entry : entries) {
+      // Unfortunately we cannot use entries.find(...) in here because the module info can
+      // be initialized lazily at any point after the entry is indexed, making the lookup
+      // by module a bit problematic. Iterating through the entries is slower but it works.
+      KJ_IF_MAYBE(info, entry.info.template tryGet<ModuleInfo>()) {
+        if (info->hashCode() == module->GetIdentityHash()) {
+          return ModuleRef {
+            .specifier = entry.specifier,
+            .type = entry.type,
+            .module = const_cast<ModuleInfo&>(*info),
+          };
+        }
+      }
     }
     return nullptr;
   }
 
   size_t size() const { return entries.size(); }
 
-  Promise<Value> resolveDynamicImport(jsg::Lock& js, kj::Path specifier) override {
-    KJ_IF_MAYBE(info, resolve(js, specifier)) {
+  Promise<Value> resolveDynamicImport(jsg::Lock& js,
+                                      const kj::Path& specifier,
+                                      const kj::Path& referrer) override {
+    // Here, we first need to determine if the referrer is a built-in module
+    // or not. If it is a built-in, then we are only permitted to resolve
+    // internal modules. If the worker bundle provided an override for the
+    // built-in module, then the built-in was never registered and won't
+    // be found.
+    using Key = typename Entry::Key;
+    bool internalOnly = false;
+    KJ_IF_MAYBE(entry, entries.find(Key(referrer, Type::BUILTIN))) {
+      internalOnly = true;
+    }
+
+    KJ_IF_MAYBE(info, resolve(js, specifier, internalOnly)) {
       KJ_IF_MAYBE(func, dynamicImportHandler) {
         auto handler = [&info = *info, isolate = js.v8Isolate]() -> Value {
-          auto module = info.module.Get(isolate);
+          auto module = info.module.getHandle(isolate);
           auto& js = Lock::from(isolate);
           instantiateModule(js, module);
           return Value(isolate, module->GetModuleNamespace());
@@ -267,15 +325,33 @@ private:
   // we need to be able to search it by path (filename) as well as search for a specific module
   // object by identity. We use a kj::Table!
   struct Entry {
+    using Info = kj::OneOf<ModuleInfo, kj::ArrayPtr<const char>>;
+
+    struct Key {
+      const kj::Path& specifier;
+      Type type = Type::BUNDLE;
+
+      Key(const kj::Path& specifier, Type type) : specifier(specifier), type(type) {}
+
+      uint hashCode() const {
+        return kj::hashCode(specifier, type);
+      }
+    };
+
     kj::Path specifier;
-    kj::OneOf<ModuleInfo, kj::ArrayPtr<const char>> info;
+    Type type;
+    Info info;
     // Either instantiated module or module source code.
 
-    Entry(const kj::Path& specifier, ModuleInfo info)
-        : specifier(specifier.clone()), info(kj::mv(info)) {}
+    Entry(const kj::Path& specifier, Type type, ModuleInfo info)
+        : specifier(specifier.clone()),
+          type(type),
+          info(kj::mv(info)) {}
 
-    Entry(const kj::Path& specifier, kj::ArrayPtr<const char> src)
-        : specifier(specifier.clone()), info(src) {}
+    Entry(const kj::Path& specifier, Type type, kj::ArrayPtr<const char> src)
+        : specifier(specifier.clone()),
+          type(type),
+          info(src) {}
 
     Entry(Entry&&) = default;
     Entry& operator=(Entry&&) = default;
@@ -297,48 +373,20 @@ private:
   };
 
   struct SpecifierHashCallbacks {
-    const kj::Path& keyForRow(const Entry& row) const { return row.specifier; }
+    using Key = typename Entry::Key;
 
-    bool matches(const Entry& row, const kj::Path& specifier) const {
-      return row.specifier == specifier;
+    const Key keyForRow(const Entry& row) const { return Key(row.specifier, row.type); }
+
+    bool matches(const Entry& row, Key key) const {
+      return row.specifier == key.specifier && row.type == key.type;
     }
 
-    uint hashCode(const kj::Path& specifier) const {
-      return specifier.hashCode();
-    }
-  };
-
-  struct InfoHashCallbacks {
-    const Entry& keyForRow(const Entry& row) const { return row; }
-
-    bool matches(const Entry& entry, const Entry& other) const {
-      return hashCode(entry) == hashCode(other);
-    }
-
-    bool matches(const Entry& entry, v8::Local<v8::Module>& module) const {
-      return entry.info.template is<ModuleInfo>() &&
-          entry.info.template get<ModuleInfo>().hash == module->GetIdentityHash();
-    }
-
-    uint hashCode(v8::Local<v8::Module>& module) const {
-      return kj::hashCode(module->GetIdentityHash());
-    }
-
-    uint hashCode(const Entry& entry) const {
-      KJ_SWITCH_ONEOF(entry.info) {
-        KJ_CASE_ONEOF(moduleInfo, ModuleInfo) {
-          return moduleInfo.hash;
-        }
-        KJ_CASE_ONEOF(src, kj::ArrayPtr<const char>) {
-          return kj::hashCode(src);
-        }
-      }
-      KJ_UNREACHABLE;
+    uint hashCode(Key key) const {
+      return key.hashCode();
     }
   };
 
-  kj::Table<Entry, kj::HashIndex<SpecifierHashCallbacks>,
-                   kj::HashIndex<InfoHashCallbacks>> entries;
+  kj::Table<Entry, kj::HashIndex<SpecifierHashCallbacks>> entries;
 };
 
 template <typename TypeWrapper>
@@ -370,12 +418,14 @@ v8::MaybeLocal<v8::Promise> dynamicImportCallback(v8::Local<v8::Context> context
   // explicitly as rejected Promises.
   v8::TryCatch tryCatch(isolate);
   try {
-    auto& lock = jsg::Lock::from(isolate);
-    auto what = kj::Path::parse(kj::str(resource_name)).parent().eval(kj::str(specifier));
+    auto& js = jsg::Lock::from(isolate);
+    auto referrerPath = kj::Path::parse(kj::str(resource_name));
+    auto specifierPath = referrerPath.parent().eval(kj::str(specifier));
     // TODO(soon): If kj::Path::parse fails it is most likely the application's fault and yet
     // we end up throwing an "internal error" here. We could handle this more gracefully
     // (and correctly) if kj::Path had a tryEval() variant.
-    return wrapper.wrap(context, nullptr, registry->resolveDynamicImport(lock, kj::mv(what)));
+    return wrapper.wrap(context, nullptr,
+        registry->resolveDynamicImport(js, specifierPath, referrerPath));
   } catch (JsExceptionThrown&) {
     if (!tryCatch.CanContinue()) {
       // There's nothing else we can reasonably do.


### PR DESCRIPTION
Built-in TypeScript modules were previously unable to import other built-in TypeScript modules due to a bug in the table indexing.

Adds a new internal-only scope for built-in modules.

Also adds the ability for built-ins to be sourced from jsg::Object's not just typescript.