### PR TITLE
Add an ability to inject an arbitrary set of headers to KV requests

### DIFF
--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -13,9 +13,16 @@ class KvNamespace: public jsg::Object {
   // A capability to a KV namespace.
 
 public:
-  explicit KvNamespace(uint subrequestChannel): subrequestChannel(subrequestChannel) {}
+  struct AdditionalHeader {
+    kj::String name;
+    kj::String value;
+  };
+
+  explicit KvNamespace(kj::Array<AdditionalHeader> additionalHeaders, uint subrequestChannel)
+      : additionalHeaders(kj::mv(additionalHeaders)), subrequestChannel(subrequestChannel) {}
   // `subrequestChannel` is what to pass to IoContext::getHttpClient() to get an HttpClient
   // representing this namespace.
+  // `additionalHeaders` is what gets appended to every outbound request.
 
   struct GetOptions {
     jsg::Optional<kj::String> type;
@@ -90,6 +97,7 @@ public:
   }
 
 private:
+  kj::Array<AdditionalHeader> additionalHeaders;
   uint subrequestChannel;
 };
 

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -450,7 +450,8 @@ void WorkerdApiIsolate::compileGlobals(
       }
 
       KJ_CASE_ONEOF(ns, Global::KvNamespace) {
-        value = lock.wrap(context, jsg::alloc<api::KvNamespace>(ns.subrequestChannel));
+        value = lock.wrap(context, jsg::alloc<api::KvNamespace>(
+            kj::Array<api::KvNamespace::AdditionalHeader>{}, ns.subrequestChannel));
       }
 
       KJ_CASE_ONEOF(r2, Global::R2Bucket) {


### PR DESCRIPTION
Relands #135 which was reverted in #145. This time I'll land EW first before merging this PR since there's a strong dependency.