### PR TITLE
Implement ReadableStream.from(...)

### DIFF
--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -487,6 +487,11 @@ jsg::Ref<ReadableStream> ReadableStream::from(
     jsg::Lock& js,
     kj::OneOf<jsg::AsyncGenerator<jsg::Value>, jsg::Generator<jsg::Value>> generator,
     CompatibilityFlags::Reader flags) {
+
+  JSG_REQUIRE(flags.getReadableStreamFrom(), Error,
+              "ReadableStream.from() is not available. Use the enable_readablestream_from "
+              "compatibility flag to enable it.");
+
   KJ_SWITCH_ONEOF(generator) {
     KJ_CASE_ONEOF(gen, jsg::AsyncGenerator<jsg::Value>) {
       auto wrapper = kj::refcounted<AsyncGeneratorWrapper>(kj::mv(gen));

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -487,11 +487,6 @@ jsg::Ref<ReadableStream> ReadableStream::from(
     jsg::Lock& js,
     kj::OneOf<jsg::AsyncGenerator<jsg::Value>, jsg::Generator<jsg::Value>> generator,
     CompatibilityFlags::Reader flags) {
-
-  JSG_REQUIRE(flags.getReadableStreamFrom(), Error,
-              "ReadableStream.from() is not available. Use the enable_readablestream_from "
-              "compatibility flag to enable it.");
-
   KJ_SWITCH_ONEOF(generator) {
     KJ_CASE_ONEOF(gen, jsg::AsyncGenerator<jsg::Value>) {
       auto wrapper = kj::refcounted<AsyncGeneratorWrapper>(kj::mv(gen));

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -221,6 +221,11 @@ public:
   // We use v8::Local<v8::Object>'s here instead of jsg structs because we need
   // to preserve the object references within the implementation.
 
+  static jsg::Ref<ReadableStream> from(
+      jsg::Lock& js,
+      kj::OneOf<jsg::AsyncGenerator<jsg::Value>, jsg::Generator<jsg::Value>> generator,
+      CompatibilityFlags::Reader flags);
+
   bool isLocked() { return getController().isLockedToReader(); }
 
   jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason);
@@ -296,6 +301,7 @@ public:
     JSG_METHOD(values);
 
     JSG_ASYNC_ITERABLE(values);
+    JSG_STATIC_METHOD(from);
 
     if (flags.getJsgPropertyOnPrototypeTemplate()) {
       JSG_TS_DEFINE(interface ReadableStream<R = any> {
@@ -313,6 +319,8 @@ public:
 
         values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
         [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+
+        static from<T>(iterable: AsyncIterable<T> | Iterable<T>): ReadableStream<T>;
       });
     } else {
       JSG_TS_DEFINE(interface ReadableStream<R = any> {
@@ -330,6 +338,8 @@ public:
 
         values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
         [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+
+        static from<T>(iterable: AsyncIterable<T> | Iterable<T>): ReadableStream<T>;
       });
     }
     JSG_TS_OVERRIDE(const ReadableStream: {

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -301,46 +301,87 @@ public:
     JSG_METHOD(values);
 
     JSG_ASYNC_ITERABLE(values);
-    JSG_STATIC_METHOD(from);
+
+    if (flags.getReadableStreamFrom()) {
+      JSG_STATIC_METHOD(from);
+    }
 
     if (flags.getJsgPropertyOnPrototypeTemplate()) {
-      JSG_TS_DEFINE(interface ReadableStream<R = any> {
-        get locked(): boolean;
+      if (flags.getReadableStreamFrom()) {
+        JSG_TS_DEFINE(interface ReadableStream<R = any> {
+          get locked(): boolean;
 
-        cancel(reason?: any): Promise<void>;
+          cancel(reason?: any): Promise<void>;
 
-        getReader(): ReadableStreamDefaultReader<R>;
-        getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
+          getReader(): ReadableStreamDefaultReader<R>;
+          getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
 
-        pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
-        pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
+          pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
+          pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
 
-        tee(): [ReadableStream<R>, ReadableStream<R>];
+          tee(): [ReadableStream<R>, ReadableStream<R>];
 
-        values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
-        [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+          values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+          [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
 
-        static from<T>(iterable: AsyncIterable<T> | Iterable<T>): ReadableStream<T>;
-      });
+          static from<T>(iterable: AsyncIterable<T> | Iterable<T>): ReadableStream<T>;
+        });
+      } else {
+        JSG_TS_DEFINE(interface ReadableStream<R = any> {
+          get locked(): boolean;
+
+          cancel(reason?: any): Promise<void>;
+
+          getReader(): ReadableStreamDefaultReader<R>;
+          getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
+
+          pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
+          pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
+
+          tee(): [ReadableStream<R>, ReadableStream<R>];
+
+          values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+          [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+        });
+      }
     } else {
-      JSG_TS_DEFINE(interface ReadableStream<R = any> {
-        readonly locked: boolean;
+      if (flags.getReadableStreamFrom()) {
+        JSG_TS_DEFINE(interface ReadableStream<R = any> {
+          readonly locked: boolean;
 
-        cancel(reason?: any): Promise<void>;
+          cancel(reason?: any): Promise<void>;
 
-        getReader(): ReadableStreamDefaultReader<R>;
-        getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
+          getReader(): ReadableStreamDefaultReader<R>;
+          getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
 
-        pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
-        pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
+          pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
+          pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
 
-        tee(): [ReadableStream<R>, ReadableStream<R>];
+          tee(): [ReadableStream<R>, ReadableStream<R>];
 
-        values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
-        [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+          values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+          [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
 
-        static from<T>(iterable: AsyncIterable<T> | Iterable<T>): ReadableStream<T>;
-      });
+          static from<T>(iterable: AsyncIterable<T> | Iterable<T>): ReadableStream<T>;
+        });
+      } else {
+        JSG_TS_DEFINE(interface ReadableStream<R = any> {
+          readonly locked: boolean;
+
+          cancel(reason?: any): Promise<void>;
+
+          getReader(): ReadableStreamDefaultReader<R>;
+          getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
+
+          pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
+          pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
+
+          tee(): [ReadableStream<R>, ReadableStream<R>];
+
+          values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+          [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+        });
+      }
     }
     JSG_TS_OVERRIDE(const ReadableStream: {
       prototype: ReadableStream;

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -240,4 +240,11 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Enables TCP sockets in workerd.
   # These are still under development and therefore subject to change.
   # WARNING: DO NOT depend on this feature as its API is still subject to change.
+
+  readableStreamFrom @23 :Bool
+      $compatEnableFlag("enable_readablestream_from")
+      $compatDisableFlag("disable_readablestream_from");
+  # Enables ReadableStream.from() in workerd.
+  # ReadableStream.from() is a new API proposed for the stream specification.
+  # It will remain disabled by default until the change officially lands in the spec.
 }

--- a/src/workerd/jsg/iterator.h
+++ b/src/workerd/jsg/iterator.h
@@ -362,7 +362,8 @@ private:
 
             // If result.done is true, we set the impl.returnValue, set impl to finished,
             // and return a resolved promise.
-            if (impl.processResultMaybeDone(js, func, result)) {
+            if (result.done) {
+              impl.setFinished(kj::mv(result.value));
               return js.resolvedPromise();
             }
 

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -264,6 +264,20 @@ struct BuildRtti<Configuration, jsg::NonCoercible<T>> {
   }
 };
 
+template <typename Configuration, typename T>
+struct BuildRtti<Configuration, jsg::AsyncGenerator<T>> {
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) {
+    builder.initIntrinsic().setName("v8::kAsyncIteratorPrototype"_kj);
+  }
+};
+
+template <typename Configuration, typename T>
+struct BuildRtti<Configuration, jsg::Generator<T>> {
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) {
+    builder.initIntrinsic().setName("v8::IteratorPrototype"_kj);
+  }
+};
+
 // Maybe Types
 
 #define DECLARE_MAYBE_TYPE(T) \


### PR DESCRIPTION
`ReadableStream.from()` is a [proposed new API standard](https://github.com/whatwg/streams/pull/1083)  that allows creating a new `ReadableStream` from a sync or async generator.

```js
async function* gen() {
  await scheduler.wait(10);
  yield 'a';
  await scheduler.wait(10);
  yield 'b';
}

const rs = ReadableStream.from(gen());
```

Will be disabled by default, enabled using a compatibility flag since the API is still considered experimental.