### PR TITLE
Bump compatibility date for release

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -6,7 +6,7 @@
 
 $import "/capnp/c++.capnp".namespace("workerd");
 
-const supportedCompatibilityDate :Text = "2022-09-26";
+const supportedCompatibilityDate :Text = "2022-11-08";
 # Newest compatibility date that can safely be set using code compiled from this repo. Trying to
 # run a Worker with a newer compatibility date than this will fail.
 #


### PR DESCRIPTION
We'd like to do a release of `workerd` to npm pretty soon—this bumps the compatibility date so the package version will work.