### PR TITLE
GitHub Actions workflow for automatic releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,132 @@
+name: Build & Release
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  version: 
+    outputs:
+      version: ${{ steps.echo.outputs.version }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: bazelbuild/setup-bazelisk@v2
+      - name: Cache
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: ~/bazel-disk-cache
+          key: capnp-cache
+      - name: build capnp
+        run: |
+          bazel build --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev @capnp-cpp//src/capnp:capnp_tool
+      - id: echo
+        run: |
+          echo "::set-output name=version::1.$(bazel-bin/external/capnp-cpp/src/capnp/capnp_tool eval src/workerd/io/compatibility-date.capnp supportedCompatibilityDate | tr -d '-' | tr -d '"').0"
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: bazelbuild/setup-bazelisk@v2
+      - name: Cache
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: ~/bazel-disk-cache
+          key: ${{ runner.os }}-${{ runner.arch }}-bazel-disk-cache
+          
+      - name: install dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+            export DEBIAN_FRONTEND=noninteractive
+            sudo apt-get install -y build-essential git clang libc++-dev
+
+      - name: build
+        run: |
+            bazel build --disk_cache=~/bazel-disk-cache  --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev -c opt //src/workerd/server:workerd
+      - name: Upload binary
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: ${{ runner.os }}-${{ runner.arch }}-binary
+          path: bazel-bin/src/workerd/server/workerd
+  check-tag:
+    name: Check tag is new
+    outputs:
+      exists: ${{ steps.check_tag.outputs.exists }}
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: mukunku/tag-exists-action@v1.1.0
+        id: check_tag
+        with: 
+          tag: v${{ needs.version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+  tag-and-release:
+    name: Tag & Release
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    needs: [check-tag, version, build]
+    runs-on: ubuntu-latest
+    if: needs.check-tag.outputs.exists != 'true'
+    steps:
+      - run: echo ${{ needs.check-tag.outputs.exists }}
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git tag v${{ needs.version.outputs.version }} && git push origin v${{ needs.version.outputs.version }}
+      - uses: ncipollo/release-action@v1
+        id: create_release
+        with:
+          generateReleaseNotes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: v${{ needs.version.outputs.version }}
+          
+  upload-artifacts:
+    name: Upload Artifacts
+    needs: [tag-and-release]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [linux-64, darwin-64]
+        include:
+          - arch: linux-64
+            name: Linux-X64
+          - arch: darwin-64
+            name: macOS-X64
+    steps:
+      - name: Download ${{ matrix.name }}
+        uses: actions/download-artifact@v3.0.0
+        with:
+          name: ${{ matrix.name }}-binary
+          path: /tmp
+      - run: mv /tmp/workerd /tmp/workerd-${{ matrix.arch }}
+      - run: chmod +x /tmp/workerd-${{ matrix.arch }}
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.tag-and-release.outputs.upload_url }} 
+          asset_path: /tmp/workerd-${{ matrix.arch }}
+          asset_name: workerd-${{ matrix.arch }}
+          asset_content_type: application/octet-stream
+  
+          
+          
+      
+          
+          
+          


### PR DESCRIPTION
This PR creates a GitHub Actions workflow to automatically create a release of `workerd` when the maximum supported compatibility date changes. A follow up PR will use the binaries uploaded to the release in order to publish a new version of `workerd` on npm