### PR TITLE
Add support for TypeScript-only definitions

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -149,12 +149,14 @@ struct ExportedHandler {
     type ExportedHandlerFetchHandler<Env = unknown> = (request: Request, env: Env, ctx: ExecutionContext) => Response | Promise<Response>;
     type ExportedHandlerTraceHandler<Env = unknown> = (traces: TraceItem[], env: Env, ctx: ExecutionContext) => void | Promise<void>;
     type ExportedHandlerScheduledHandler<Env = unknown> = (controller: ScheduledController, env: Env, ctx: ExecutionContext) => void | Promise<void>;
+    type ExportedHandlerQueueHandler<Env = unknown, Message = unknown> = (batch: MessageBatch<Message>, env: Env, ctx: ExecutionContext) => void | Promise<void>;
   );
-  JSG_STRUCT_TS_OVERRIDE(<Env = unknown> {
+  JSG_STRUCT_TS_OVERRIDE(<Env = unknown, QueueMessage = unknown> {
     fetch?: ExportedHandlerFetchHandler<Env>;
     trace?: ExportedHandlerTraceHandler<Env>;
     scheduled?: ExportedHandlerScheduledHandler<Env>;
     alarm: never;
+    queue?: ExportedHandlerQueueHandler<Env, QueueMessage>;
   });
   // Make `env` parameter generic
 

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -524,6 +524,7 @@ struct RequestInitializerDict {
   JSG_STRUCT_TS_OVERRIDE(RequestInit {
     headers?: HeadersInit;
     body?: BodyInit | null;
+    cf?: IncomingRequestCfProperties | RequestInitCfProperties;
   });
 };
 
@@ -624,6 +625,10 @@ public:
 
     JSG_METHOD(clone);
 
+    JSG_TS_DEFINE(type RequestInfo = Request | string | URL);
+    // All type aliases get inlined when exporting RTTI, but this type alias is included by
+    // the official TypeScript types, so users might be depending on it.
+
     if (flags.getJsgPropertyOnPrototypeTemplate()) {
       JSG_READONLY_PROTOTYPE_PROPERTY(method, getMethod);
       JSG_READONLY_PROTOTYPE_PROPERTY(url, getUrl);
@@ -638,6 +643,13 @@ public:
       JSG_READONLY_PROTOTYPE_PROPERTY(credentials, getCredentials);
       JSG_READONLY_PROTOTYPE_PROPERTY(integrity, getIntegrity);
       JSG_READONLY_PROTOTYPE_PROPERTY(cache, getCache);
+
+      JSG_TS_OVERRIDE({
+        constructor(input: RequestInfo, init?: RequestInit);
+        get cf(): IncomingRequestCfProperties | undefined;
+      });
+      // Use `RequestInfo` and `RequestInit` type aliases in constructor instead of inlining.
+      // `IncomingRequestCfProperties` is defined in `/types/defines/cf.d.ts`.
     } else {
       JSG_READONLY_INSTANCE_PROPERTY(method, getMethod);
       JSG_READONLY_INSTANCE_PROPERTY(url, getUrl);
@@ -652,13 +664,14 @@ public:
       JSG_READONLY_INSTANCE_PROPERTY(credentials, getCredentials);
       JSG_READONLY_INSTANCE_PROPERTY(integrity, getIntegrity);
       JSG_READONLY_INSTANCE_PROPERTY(cache, getCache);
-    }
 
-    JSG_TS_DEFINE(type RequestInfo = Request | string | URL);
-    // All type aliases get inlined when exporting RTTI, but this type alias is included by
-    // the official TypeScript types, so users might be depending on it.
-    JSG_TS_OVERRIDE({ constructor(input: RequestInfo, init?: RequestInit); });
-    // Use `RequestInfo` and `RequestInit` type aliases in constructor instead of inlining
+      JSG_TS_OVERRIDE({
+        constructor(input: RequestInfo, init?: RequestInit);
+        readonly cf?: IncomingRequestCfProperties;
+      });
+      // Use `RequestInfo` and `RequestInit` type aliases in constructor instead of inlining.
+      // `IncomingRequestCfProperties` is defined in `/types/defines/cf.d.ts`.
+    }
   }
 
 private:

--- a/types/BUILD.bazel
+++ b/types/BUILD.bazel
@@ -27,9 +27,11 @@ js_run_binary(
     name = "types",
     srcs = [
         "//src/workerd/tools:api_encoder",
-    ],
+    ] + glob(["defines/**/*.ts"]),
     args = [
         "src/workerd/tools",
+        "--defines",
+        "types/defines",
         "--output",
         "types/definitions",
         "--format",

--- a/types/README.md
+++ b/types/README.md
@@ -32,4 +32,5 @@ $ bazel test //types:all
 - `src/transforms`: post-processing TypeScript AST transforms
 - `src/index.ts`: main entrypoint
 - `src/{print,program}.ts`: helpers for printing nodes and creating programs
-- `workerd`: symlink required to resolve JSG RTTI Cap’n Proto files during development
+- `defines`: additional TypeScript-only definitions that don't correspond to
+  `workerd` runtime APIs, appended to the end of outputs

--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -1,0 +1,943 @@
+interface BasicImageTransformations {
+  /**
+   * Maximum width in image pixels. The value must be an integer.
+   */
+  width?: number;
+  /**
+   * Maximum height in image pixels. The value must be an integer.
+   */
+  height?: number;
+  /**
+   * Resizing mode as a string. It affects interpretation of width and height
+   * options:
+   *  - scale-down: Similar to contain, but the image is never enlarged. If
+   *    the image is larger than given width or height, it will be resized.
+   *    Otherwise its original size will be kept.
+   *  - contain: Resizes to maximum size that fits within the given width and
+   *    height. If only a single dimension is given (e.g. only width), the
+   *    image will be shrunk or enlarged to exactly match that dimension.
+   *    Aspect ratio is always preserved.
+   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
+   *    and height. If the image has an aspect ratio different from the ratio
+   *    of width and height, it will be cropped to fit.
+   *  - crop: The image will be shrunk and cropped to fit within the area
+   *    specified by width and height. The image will not be enlarged. For images
+   *    smaller than the given dimensions it's the same as scale-down. For
+   *    images larger than the given dimensions, it's the same as cover.
+   *    See also trim.
+   *  - pad: Resizes to the maximum size that fits within the given width and
+   *    height, and then fills the remaining area with a background color
+   *    (white by default). Use of this mode is not recommended, as the same
+   *    effect can be more efficiently achieved with the contain mode and the
+   *    CSS object-fit: contain property.
+   */
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  /**
+   * When cropping with fit: "cover", this defines the side or point that should
+   * be left uncropped. The value is either a string
+   * "left", "right", "top", "bottom", "auto", or "center" (the default),
+   * or an object {x, y} containing focal point coordinates in the original
+   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
+   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
+   * crop bottom or left and right sides as necessary, but won’t crop anything
+   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
+   * preserve as much as possible around a point at 20% of the height of the
+   * source image.
+   */
+  gravity?:
+    | "left"
+    | "right"
+    | "top"
+    | "bottom"
+    | "center"
+    | "auto"
+    | BasicImageTransformationsGravityCoordinates;
+  /**
+   * Background color to add underneath the image. Applies only to images with
+   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
+   * hsl(…), etc.)
+   */
+  background?: string;
+  /**
+   * Number of degrees (90, 180, 270) to rotate the image by. width and height
+   * options refer to axes after rotation.
+   */
+  rotate?: 0 | 90 | 180 | 270 | 360;
+}
+
+interface BasicImageTransformationsGravityCoordinates {
+  x: number;
+  y: number;
+}
+
+/**
+ * In addition to the properties you can set in the RequestInit dict
+ * that you pass as an argument to the Request constructor, you can
+ * set certain properties of a `cf` object to control how Cloudflare
+ * features are applied to that new Request.
+ *
+ * Note: Currently, these properties cannot be tested in the
+ * playground.
+ */
+interface RequestInitCfProperties {
+  cacheEverything?: boolean;
+  /**
+   * A request's cache key is what determines if two requests are
+   * "the same" for caching purposes. If a request has the same cache key
+   * as some previous request, then we can serve the same cached response for
+   * both. (e.g. 'some-key')
+   *
+   * Only available for Enterprise customers.
+   */
+  cacheKey?: string;
+  /**
+   * This allows you to append additional Cache-Tag response headers
+   * to the origin response without modifications to the origin server.
+   * This will allow for greater control over the Purge by Cache Tag feature
+   * utilizing changes only in the Workers process.
+   *
+   * Only available for Enterprise customers.
+   */
+  cacheTags?: string[];
+  /**
+   * Force response to be cached for a given number of seconds. (e.g. 300)
+   */
+  cacheTtl?: number;
+  /**
+   * Force response to be cached for a given number of seconds based on the Origin status code.
+   * (e.g. { '200-299': 86400, '404': 1, '500-599': 0 })
+   */
+  cacheTtlByStatus?: Record<string, number>;
+  scrapeShield?: boolean;
+  apps?: boolean;
+  image?: RequestInitCfPropertiesImage;
+  minify?: RequestInitCfPropertiesImageMinify;
+  mirage?: boolean;
+  polish?: "lossy" | "lossless" | "off";
+  /**
+   * Redirects the request to an alternate origin server. You can use this,
+   * for example, to implement load balancing across several origins.
+   * (e.g.us-east.example.com)
+   *
+   * Note - For security reasons, the hostname set in resolveOverride must
+   * be proxied on the same Cloudflare zone of the incoming request.
+   * Otherwise, the setting is ignored. CNAME hosts are allowed, so to
+   * resolve to a host under a different domain or a DNS only domain first
+   * declare a CNAME record within your own zone’s DNS mapping to the
+   * external hostname, set proxy on Cloudflare, then set resolveOverride
+   * to point to that CNAME record.
+   */
+  resolveOverride?: string;
+}
+
+interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
+  /**
+   * Absolute URL of the image file to use for the drawing. It can be any of
+   * the supported file formats. For drawing of watermarks or non-rectangular
+   * overlays we recommend using PNG or WebP images.
+   */
+  url: string;
+  /**
+   * Floating-point number between 0 (transparent) and 1 (opaque).
+   * For example, opacity: 0.5 makes overlay semitransparent.
+   */
+  opacity?: number;
+  /**
+   * - If set to true, the overlay image will be tiled to cover the entire
+   *   area. This is useful for stock-photo-like watermarks.
+   * - If set to "x", the overlay image will be tiled horizontally only
+   *   (form a line).
+   * - If set to "y", the overlay image will be tiled vertically only
+   *   (form a line).
+   */
+  repeat?: true | "x" | "y";
+  /**
+   * Position of the overlay image relative to a given edge. Each property is
+   * an offset in pixels. 0 aligns exactly to the edge. For example, left: 10
+   * positions left side of the overlay 10 pixels from the left edge of the
+   * image it's drawn over. bottom: 0 aligns bottom of the overlay with bottom
+   * of the background image.
+   *
+   * Setting both left & right, or both top & bottom is an error.
+   *
+   * If no position is specified, the image will be centered.
+   */
+  top?: number;
+  left?: number;
+  bottom?: number;
+  right?: number;
+}
+
+interface RequestInitCfPropertiesImage extends BasicImageTransformations {
+  /**
+   * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
+   * easier to specify higher-DPI sizes in <img srcset>.
+   */
+  dpr?: number;
+  /**
+   * An object with four properties {left, top, right, bottom} that specify
+   * a number of pixels to cut off on each side. Allows removal of borders
+   * or cutting out a specific fragment of an image. Trimming is performed
+   * before resizing or rotation. Takes dpr into account.
+   */
+  trim?: {
+    left?: number;
+    top?: number;
+    right?: number;
+    bottom?: number;
+  };
+  /**
+   * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
+   * make images look worse, but load faster. The default is 85. It applies only
+   * to JPEG and WebP images. It doesn’t have any effect on PNG.
+   */
+  quality?: number;
+  /**
+   * Output format to generate. It can be:
+   *  - avif: generate images in AVIF format.
+   *  - webp: generate images in Google WebP format. Set quality to 100 to get
+   *    the WebP-lossless format.
+   *  - json: instead of generating an image, outputs information about the
+   *    image, in JSON format. The JSON object will contain image size
+   *    (before and after resizing), source image’s MIME type, file size, etc.
+   * - jpeg: generate images in JPEG format.
+   * - png: generate images in PNG format.
+   */
+  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  /**
+   * Whether to preserve animation frames from input files. Default is true.
+   * Setting it to false reduces animations to still images. This setting is
+   * recommended when enlarging images or processing arbitrary user content,
+   * because large GIF animations can weigh tens or even hundreds of megabytes.
+   * It is also useful to set anim:false when using format:"json" to get the
+   * response quicker without the number of frames.
+   */
+  anim?: boolean;
+  /**
+   * What EXIF data should be preserved in the output image. Note that EXIF
+   * rotation and embedded color profiles are always applied ("baked in" into
+   * the image), and aren't affected by this option. Note that if the Polish
+   * feature is enabled, all metadata may have been removed already and this
+   * option may have no effect.
+   *  - keep: Preserve most of EXIF metadata, including GPS location if there's
+   *    any.
+   *  - copyright: Only keep the copyright tag, and discard everything else.
+   *    This is the default behavior for JPEG files.
+   *  - none: Discard all invisible EXIF metadata. Currently WebP and PNG
+   *    output formats always discard metadata.
+   */
+  metadata?: "keep" | "copyright" | "none";
+  /**
+   * Strength of sharpening filter to apply to the image. Floating-point
+   * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
+   * recommended value for downscaled images.
+   */
+  sharpen?: number;
+  /**
+   * Radius of a blur filter (approximate gaussian). Maximum supported radius
+   * is 250.
+   */
+  blur?: number;
+  /**
+   * Overlays are drawn in the order they appear in the array (last array
+   * entry is the topmost layer).
+   */
+  draw?: RequestInitCfPropertiesImageDraw[];
+  /**
+   * Fetching image from authenticated origin. Setting this property will
+   * pass authentication headers (Authorization, Cookie, etc.) through to
+   * the origin.
+   */
+  "origin-auth"?: "share-publicly";
+}
+
+interface RequestInitCfPropertiesImageMinify {
+  javascript?: boolean;
+  css?: boolean;
+  html?: boolean;
+}
+
+/**
+ * Request metadata provided by Cloudflare's edge.
+ */
+type IncomingRequestCfProperties<HostMetadata = unknown> =
+  IncomingRequestCfPropertiesBase &
+    IncomingRequestCfPropertiesBotManagementEnterprise &
+    IncomingRequestCfPropertiesCloudflareForSaaSEnterprise<HostMetadata> &
+    IncomingRequestCfPropertiesGeographicInformation &
+    IncomingRequestCfPropertiesCloudflareAccessOrApiShield;
+
+interface IncomingRequestCfPropertiesBase {
+  /**
+   * [ASN](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) of the incoming request.
+   *
+   * @example 395747
+   */
+  asn: number;
+  /**
+   * The organization which owns the ASN of the incoming request.
+   *
+   * @example "Google Cloud"
+   */
+  asOrganization: string;
+  /**
+   * The original value of the `Accept-Encoding` header if Cloudflare modified it.
+   *
+   * @example "gzip, deflate, br"
+   */
+  clientAcceptEncoding?: string;
+  /**
+   * The number of milliseconds it took for the request to reach your worker.
+   *
+   * @example 22
+   */
+  clientTcpRtt?: number;
+  /**
+   * The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)
+   * airport code of the data center that the request hit.
+   *
+   * @example "DFW"
+   */
+  colo: string;
+  /**
+   * Represents the upstream's response to a
+   * [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)
+   * from cloudflare.
+   *
+   * For workers with no upstream, this will always be `1`.
+   *
+   * @example 3
+   */
+  edgeRequestKeepAliveStatus: IncomingRequestCfPropertiesEdgeRequestKeepAliveStatus;
+  /**
+   * The HTTP Protocol the request used.
+   *
+   * @example "HTTP/2"
+   */
+  httpProtocol: string;
+  /**
+   * The browser-requested prioritization information in the request object.
+   *
+   * If no information was set, defaults to the empty string `""`
+   *
+   * @example "weight=192;exclusive=0;group=3;group-weight=127"
+   * @default ""
+   */
+  requestPriority: string;
+  /**
+   * The TLS version of the connection to Cloudflare.
+   * In requests served over plaintext (without TLS), this property is the empty string `""`.
+   *
+   * @example "TLSv1.3"
+   */
+  tlsVersion: string;
+  /**
+   * The cipher for the connection to Cloudflare.
+   * In requests served over plaintext (without TLS), this property is the empty string `""`.
+   *
+   * @example "AEAD-AES128-GCM-SHA256"
+   */
+  tlsCipher: string;
+  /**
+   * Metadata containing the [`HELLO`](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2) and [`FINISHED`](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.9) messages from this request's TLS handshake.
+   *
+   * If the incoming request was served over plaintext (without TLS) this field is undefined.
+   */
+  tlsExportedAuthenticator?: IncomingRequestCfPropertiesExportedAuthenticatorMetadata;
+}
+
+interface IncomingRequestCfPropertiesBotManagementBase {
+  /**
+   * Cloudflare’s [level of certainty](https://developers.cloudflare.com/bots/concepts/bot-score/) that a request comes from a bot,
+   * represented as an integer percentage between `1` (almost certainly human)
+   * and `99` (almost certainly a bot).
+   *
+   * @example 54
+   */
+  score: number;
+  /**
+   * A boolean value that is true if the request comes from a good bot, like Google or Bing.
+   * Most customers choose to allow this traffic. For more details, see [Traffic from known bots](https://developers.cloudflare.com/firewall/known-issues-and-faq/#how-does-firewall-rules-handle-traffic-from-known-bots).
+   */
+  verifiedBot: boolean;
+  /**
+   * A boolean value that is true if the request originates from a
+   * Cloudflare-verified proxy service.
+   */
+  corporateProxy: boolean;
+  /**
+   * A boolean value that's true if the request matches [file extensions](https://developers.cloudflare.com/bots/reference/static-resources/) for many types of static resources.
+   */
+  staticResource: boolean;
+}
+
+interface IncomingRequestCfPropertiesBotManagement {
+  /**
+   * Results of Cloudflare's Bot Management analysis
+   */
+  botManagement: IncomingRequestCfPropertiesBotManagementBase;
+  /**
+   * Duplicate of `botManagement.score`.
+   *
+   * @deprecated
+   */
+  clientTrustScore: number;
+}
+
+interface IncomingRequestCfPropertiesBotManagementEnterprise
+  extends IncomingRequestCfPropertiesBotManagement {
+  /**
+   * Results of Cloudflare's Bot Management analysis
+   */
+  botManagement: IncomingRequestCfPropertiesBotManagementBase & {
+    /**
+     * A [JA3 Fingerprint](https://developers.cloudflare.com/bots/concepts/ja3-fingerprint/) to help profile specific SSL/TLS clients
+     * across different destination IPs, Ports, and X509 certificates.
+     */
+    ja3Hash: string;
+  };
+}
+
+interface IncomingRequestCfPropertiesCloudflareForSaaSEnterprise<HostMetadata> {
+  /**
+   * Custom metadata set per-host in [Cloudflare for SaaS](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/).
+   *
+   * This field is only present if you have Cloudflare for SaaS enabled on your account
+   * and you have followed the [required steps to enable it]((https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/domain-support/custom-metadata/)).
+   */
+  hostMetadata: HostMetadata;
+}
+
+interface IncomingRequestCfPropertiesCloudflareAccessOrApiShield {
+  /**
+   * Information about the client certificate presented to Cloudflare.
+   *
+   * This is populated when the incoming request is served over TLS using
+   * either Cloudflare Access or API Shield (mTLS)
+   * and the presented SSL certificate has a valid
+   * [Certificate Serial Number](https://ldapwiki.com/wiki/Certificate%20Serial%20Number)
+   * (i.e., not `null` or `""`).
+   *
+   * Otherwise, a set of placeholder values are used.
+   *
+   * The property `certPresented` will be set to `"1"` when
+   * the object is populated (i.e. the above conditions were met).
+   */
+  tlsClientAuth:
+    | IncomingRequestCfPropertiesTLSClientAuth
+    | IncomingRequestCfPropertiesTLSClientAuthPlaceholder;
+}
+
+/**
+ * Metadata about the request's TLS handshake
+ */
+interface IncomingRequestCfPropertiesExportedAuthenticatorMetadata {
+  /**
+   * The client's [`HELLO` message](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2), encoded in hexadecimal
+   *
+   * @example "44372ba35fa1270921d318f34c12f155dc87b682cf36a790cfaa3ba8737a1b5d"
+   */
+  clientHandshake: string;
+  /**
+   * The server's [`HELLO` message](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2), encoded in hexadecimal
+   *
+   * @example "44372ba35fa1270921d318f34c12f155dc87b682cf36a790cfaa3ba8737a1b5d"
+   */
+  serverHandshake: string;
+  /**
+   * The client's [`FINISHED` message](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.9), encoded in hexadecimal
+   *
+   * @example "084ee802fe1348f688220e2a6040a05b2199a761f33cf753abb1b006792d3f8b"
+   */
+  clientFinished: string;
+  /**
+   * The server's [`FINISHED` message](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.9), encoded in hexadecimal
+   *
+   * @example "084ee802fe1348f688220e2a6040a05b2199a761f33cf753abb1b006792d3f8b"
+   */
+  serverFinished: string;
+}
+
+/**
+ * Geographic data about the request's origin.
+ */
+type IncomingRequestCfPropertiesGeographicInformation =
+  | {
+      /* No geographic data was found for the incoming request. */
+    }
+  | {
+      /** The country code `"T1"` is used for requests originating on TOR  */
+      country: "T1";
+    }
+  | {
+      /**
+       * The [ISO 3166-1 Alpha 2](https://www.iso.org/iso-3166-country-codes.html) country code the request originated from.
+       *
+       * If your worker is [configured to accept TOR connections](https://support.cloudflare.com/hc/en-us/articles/203306930-Understanding-Cloudflare-Tor-support-and-Onion-Routing), this may also be `"T1"`, indicating a request that originated over TOR.
+       *
+       * If Cloudflare is unable to determine where the request originated this property is omitted.
+       *
+       * @example "GB"
+       */
+      country: Iso3166Alpha2Code;
+      /**
+       * If present, this property indicates that the request originated in the EU
+       *
+       * @example "1"
+       */
+      isEUCountry?: "1";
+      /**
+       * A two-letter code indicating the continent the request originated from.
+       *
+       * @example "AN"
+       */
+      continent: ContinentCode;
+      /**
+       * The city the request originated from
+       *
+       * @example "Austin"
+       */
+      city?: string;
+      /**
+       * Postal code of the incoming request
+       *
+       * @example "78701"
+       */
+      postalCode?: string;
+      /**
+       * Latitude of the incoming request
+       *
+       * @example "30.27130"
+       */
+      latitude?: string;
+      /**
+       * Longitude of the incoming request
+       *
+       * @example "-97.74260"
+       */
+      longitude?: string;
+      /**
+       * Timezone of the incoming request
+       *
+       * @example "America/Chicago"
+       */
+      timezone?: string;
+      /**
+       * If known, the ISO 3166-2 name for the first level region associated with
+       * the IP address of the incoming request
+       *
+       * @example "Texas"
+       */
+      region?: string;
+      /**
+       * If known, the ISO 3166-2 code for the first-level region associated with
+       * the IP address of the incoming request
+       *
+       * @example "TX"
+       */
+      regionCode?: string;
+      /**
+       * Metro code (DMA) of the incoming request
+       *
+       * @example "635"
+       */
+      metroCode?: string;
+    };
+
+/** Data about the incoming request's TLS certificate */
+interface IncomingRequestCfPropertiesTLSClientAuth {
+  /** Always `"1"`, indicating that the certificate was presented */
+  certPresented: "1";
+  /**
+   * Result of certificate verification.
+   *
+   * @example "FAILED:self signed certificate"
+   */
+  certVerified: Exclude<CertVerificationStatus, "NONE">;
+  /** The presented certificate's revokation status.
+   *
+   * - A value of `"1"` indicates the certificate has been revoked
+   * - A value of `"0"` indicates the certificate has not been revoked
+   */
+  certRevoked: "1" | "0";
+  /**
+   * The certificate issuer's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html)
+   *
+   * @example "CN=cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare"
+   */
+  certIssuerDN: string;
+  /**
+   * The certificate subject's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html)
+   *
+   * @example "CN=*.cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare"
+   */
+  certSubjectDN: string;
+  /**
+   * The certificate issuer's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)
+   *
+   * @example "CN=cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare"
+   */
+  certIssuerDNRFC2253: string;
+  /**
+   * The certificate subject's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)
+   *
+   * @example "CN=*.cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare"
+   */
+  certSubjectDNRFC2253: string;
+  /** The certificate issuer's distinguished name (legacy policies) */
+  certIssuerDNLegacy: string;
+  /** The certificate subject's distinguished name (legacy policies) */
+  certSubjectDNLegacy: string;
+  /**
+   * The certificate's serial number
+   *
+   * @example "00936EACBE07F201DF"
+   */
+  certSerial: string;
+  /**
+   * The certificate issuer's serial number
+   *
+   * @example "2489002934BDFEA34"
+   */
+  certIssuerSerial: string;
+  /**
+   * The certificate's Subject Key Identifier
+   *
+   * @example "BB:AF:7E:02:3D:FA:A6:F1:3C:84:8E:AD:EE:38:98:EC:D9:32:32:D4"
+   */
+  certSKI: string;
+  /**
+   * The certificate issuer's Subject Key Identifier
+   *
+   * @example "BB:AF:7E:02:3D:FA:A6:F1:3C:84:8E:AD:EE:38:98:EC:D9:32:32:D4"
+   */
+  certIssuerSKI: string;
+  /**
+   * The certificate's SHA-1 fingerprint
+   *
+   * @example "6b9109f323999e52259cda7373ff0b4d26bd232e"
+   */
+  certFingerprintSHA1: string;
+  /**
+   * The certificate's SHA-256 fingerprint
+   *
+   * @example "acf77cf37b4156a2708e34c4eb755f9b5dbbe5ebb55adfec8f11493438d19e6ad3f157f81fa3b98278453d5652b0c1fd1d71e5695ae4d709803a4d3f39de9dea"
+   */
+  certFingerprintSHA256: string;
+  /**
+   * The effective starting date of the certificate
+   *
+   * @example "Dec 22 19:39:00 2018 GMT"
+   */
+  certNotBefore: string;
+  /**
+   * The effective expiration date of the certificate
+   *
+   * @example "Dec 22 19:39:00 2018 GMT"
+   */
+  certNotAfter: string;
+}
+
+/** Placeholder values for TLS Client Authorization */
+interface IncomingRequestCfPropertiesTLSClientAuthPlaceholder {
+  certPresented: "0";
+  certVerified: "NONE";
+  certRevoked: "0";
+  certIssuerDN: "";
+  certSubjectDN: "";
+  certIssuerDNRFC2253: "";
+  certSubjectDNRFC2253: "";
+  certIssuerDNLegacy: "";
+  certSubjectDNLegacy: "";
+  certSerial: "";
+  certIssuerSerial: "";
+  certSKI: "";
+  certIssuerSKI: "";
+  certFingerprintSHA1: "";
+  certFingerprintSHA256: "";
+  certNotBefore: "";
+  certNotAfter: "";
+}
+
+/** Possible outcomes of TLS verification */
+declare type CertVerificationStatus =
+  /** Authentication succeeded */
+  | "SUCCESS"
+  /** No certificate was presented */
+  | "NONE"
+  /** Failed because the certificate was self-signed */
+  | "FAILED:self signed certificate"
+  /** Failed because the certificate failed a trust chain check */
+  | "FAILED:unable to verify the first certificate"
+  /** Failed because the certificate not yet valid */
+  | "FAILED:certificate is not yet valid"
+  /** Failed because the certificate is expired */
+  | "FAILED:certificate has expired"
+  /** Failed for another unspecified reason */
+  | "FAILED";
+
+/**
+ * An upstream endpoint's response to a TCP `keepalive` message from Cloudflare.
+ */
+declare type IncomingRequestCfPropertiesEdgeRequestKeepAliveStatus =
+  | 0 /** Unknown */
+  | 1 /** no keepalives (not found) */
+  | 2 /** no connection re-use, opening keepalive connection failed */
+  | 3 /** no connection re-use, keepalive accepted and saved */
+  | 4 /** connection re-use, refused by the origin server (`TCP FIN`) */
+  | 5; /** connection re-use, accepted by the origin server */
+
+/** ISO 3166-1 Alpha-2 codes */
+declare type Iso3166Alpha2Code =
+  | "AD"
+  | "AE"
+  | "AF"
+  | "AG"
+  | "AI"
+  | "AL"
+  | "AM"
+  | "AO"
+  | "AQ"
+  | "AR"
+  | "AS"
+  | "AT"
+  | "AU"
+  | "AW"
+  | "AX"
+  | "AZ"
+  | "BA"
+  | "BB"
+  | "BD"
+  | "BE"
+  | "BF"
+  | "BG"
+  | "BH"
+  | "BI"
+  | "BJ"
+  | "BL"
+  | "BM"
+  | "BN"
+  | "BO"
+  | "BQ"
+  | "BR"
+  | "BS"
+  | "BT"
+  | "BV"
+  | "BW"
+  | "BY"
+  | "BZ"
+  | "CA"
+  | "CC"
+  | "CD"
+  | "CF"
+  | "CG"
+  | "CH"
+  | "CI"
+  | "CK"
+  | "CL"
+  | "CM"
+  | "CN"
+  | "CO"
+  | "CR"
+  | "CU"
+  | "CV"
+  | "CW"
+  | "CX"
+  | "CY"
+  | "CZ"
+  | "DE"
+  | "DJ"
+  | "DK"
+  | "DM"
+  | "DO"
+  | "DZ"
+  | "EC"
+  | "EE"
+  | "EG"
+  | "EH"
+  | "ER"
+  | "ES"
+  | "ET"
+  | "FI"
+  | "FJ"
+  | "FK"
+  | "FM"
+  | "FO"
+  | "FR"
+  | "GA"
+  | "GB"
+  | "GD"
+  | "GE"
+  | "GF"
+  | "GG"
+  | "GH"
+  | "GI"
+  | "GL"
+  | "GM"
+  | "GN"
+  | "GP"
+  | "GQ"
+  | "GR"
+  | "GS"
+  | "GT"
+  | "GU"
+  | "GW"
+  | "GY"
+  | "HK"
+  | "HM"
+  | "HN"
+  | "HR"
+  | "HT"
+  | "HU"
+  | "ID"
+  | "IE"
+  | "IL"
+  | "IM"
+  | "IN"
+  | "IO"
+  | "IQ"
+  | "IR"
+  | "IS"
+  | "IT"
+  | "JE"
+  | "JM"
+  | "JO"
+  | "JP"
+  | "KE"
+  | "KG"
+  | "KH"
+  | "KI"
+  | "KM"
+  | "KN"
+  | "KP"
+  | "KR"
+  | "KW"
+  | "KY"
+  | "KZ"
+  | "LA"
+  | "LB"
+  | "LC"
+  | "LI"
+  | "LK"
+  | "LR"
+  | "LS"
+  | "LT"
+  | "LU"
+  | "LV"
+  | "LY"
+  | "MA"
+  | "MC"
+  | "MD"
+  | "ME"
+  | "MF"
+  | "MG"
+  | "MH"
+  | "MK"
+  | "ML"
+  | "MM"
+  | "MN"
+  | "MO"
+  | "MP"
+  | "MQ"
+  | "MR"
+  | "MS"
+  | "MT"
+  | "MU"
+  | "MV"
+  | "MW"
+  | "MX"
+  | "MY"
+  | "MZ"
+  | "NA"
+  | "NC"
+  | "NE"
+  | "NF"
+  | "NG"
+  | "NI"
+  | "NL"
+  | "NO"
+  | "NP"
+  | "NR"
+  | "NU"
+  | "NZ"
+  | "OM"
+  | "PA"
+  | "PE"
+  | "PF"
+  | "PG"
+  | "PH"
+  | "PK"
+  | "PL"
+  | "PM"
+  | "PN"
+  | "PR"
+  | "PS"
+  | "PT"
+  | "PW"
+  | "PY"
+  | "QA"
+  | "RE"
+  | "RO"
+  | "RS"
+  | "RU"
+  | "RW"
+  | "SA"
+  | "SB"
+  | "SC"
+  | "SD"
+  | "SE"
+  | "SG"
+  | "SH"
+  | "SI"
+  | "SJ"
+  | "SK"
+  | "SL"
+  | "SM"
+  | "SN"
+  | "SO"
+  | "SR"
+  | "SS"
+  | "ST"
+  | "SV"
+  | "SX"
+  | "SY"
+  | "SZ"
+  | "TC"
+  | "TD"
+  | "TF"
+  | "TG"
+  | "TH"
+  | "TJ"
+  | "TK"
+  | "TL"
+  | "TM"
+  | "TN"
+  | "TO"
+  | "TR"
+  | "TT"
+  | "TV"
+  | "TW"
+  | "TZ"
+  | "UA"
+  | "UG"
+  | "UM"
+  | "US"
+  | "UY"
+  | "UZ"
+  | "VA"
+  | "VC"
+  | "VE"
+  | "VG"
+  | "VI"
+  | "VN"
+  | "VU"
+  | "WF"
+  | "WS"
+  | "YE"
+  | "YT"
+  | "ZA"
+  | "ZM"
+  | "ZW";
+
+/** The 2-letter continent codes Cloudflare uses */
+declare type ContinentCode = "AF" | "AN" | "AS" | "EU" | "NA" | "OC" | "SA";

--- a/types/defines/d1.d.ts
+++ b/types/defines/d1.d.ts
@@ -1,0 +1,21 @@
+interface D1Result<T = unknown> {
+  results?: T[];
+  success: boolean;
+  error?: string;
+  meta: any;
+}
+
+declare abstract class D1Database {
+  prepare(query: string): D1PreparedStatement;
+  dump(): Promise<ArrayBuffer>;
+  batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]>;
+  exec<T = unknown>(query: string): Promise<D1Result<T>>;
+}
+
+declare abstract class D1PreparedStatement {
+  bind(...values: any[]): D1PreparedStatement;
+  first<T = unknown>(colName?: string): Promise<T>;
+  run<T = unknown>(): Promise<D1Result<T>>;
+  all<T = unknown>(): Promise<D1Result<T>>;
+  raw<T = unknown>(): Promise<T[]>;
+}

--- a/types/defines/pages.d.ts
+++ b/types/defines/pages.d.ts
@@ -1,0 +1,43 @@
+type Params<P extends string = any> = Record<P, string | string[]>;
+
+type EventContext<Env, P extends string, Data> = {
+  request: Request;
+  functionPath: string;
+  waitUntil: (promise: Promise<any>) => void;
+  passThroughOnException: () => void;
+  next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
+  env: Env & { ASSETS: { fetch: typeof fetch } };
+  params: Params<P>;
+  data: Data;
+};
+
+type PagesFunction<
+  Env = unknown,
+  Params extends string = any,
+  Data extends Record<string, unknown> = Record<string, unknown>
+> = (context: EventContext<Env, Params, Data>) => Response | Promise<Response>;
+
+type EventPluginContext<Env, P extends string, Data, PluginArgs> = {
+  request: Request;
+  functionPath: string;
+  waitUntil: (promise: Promise<any>) => void;
+  passThroughOnException: () => void;
+  next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
+  env: Env & { ASSETS: { fetch: typeof fetch } };
+  params: Params<P>;
+  data: Data;
+  pluginArgs: PluginArgs;
+};
+
+type PagesPluginFunction<
+  Env = unknown,
+  Params extends string = any,
+  Data extends Record<string, unknown> = Record<string, unknown>,
+  PluginArgs = unknown
+> = (
+  context: EventPluginContext<Env, Params, Data, PluginArgs>
+) => Response | Promise<Response>;
+
+declare module "assets:*" {
+  export const onRequest: PagesFunction;
+}

--- a/types/defines/queues.d.ts
+++ b/types/defines/queues.d.ts
@@ -1,0 +1,47 @@
+/**
+ * A message that is sent to a consumer Worker.
+ */
+interface Message<Body = unknown> {
+  /**
+   * A unique, system-generated ID for the message.
+   */
+  readonly id: string;
+  /**
+   * A timestamp when the message was sent.
+   */
+  readonly timestamp: Date;
+  /**
+   * The body of the message.
+   */
+  readonly body: Body;
+}
+
+/**
+ * A batch of messages that are sent to a consumer Worker.
+ */
+interface MessageBatch<Body = unknown> {
+  /**
+   * The name of the Queue that belongs to this batch.
+   */
+  readonly queue: string;
+  /**
+   * An array of messages in the batch. Ordering of messages is not guaranteed.
+   */
+  readonly messages: readonly Message<Body>[];
+  /**
+   * Marks every message to be retried in the next batch.
+   */
+  retryAll(): void;
+}
+
+/**
+ * A binding that allows a producer to send messages to a Queue.
+ */
+interface Queue<Body = any> {
+  /**
+   * Sends a message to the Queue.
+   * @param message The message can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types), as long as its size is less than 128 KB.
+   * @returns A promise that resolves when the message is confirmed to be written to disk.
+   */
+  send(message: Body): Promise<void>;
+}

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -52,6 +52,7 @@ function checkDiagnostics(sources: Map<string, string>) {
     path.dirname(require.resolve("typescript"));
   const program = createMemoryProgram(sources, host, {
     lib: ["lib.esnext.d.ts"],
+    types: [], // Make sure not to include @types/node from dependencies
   });
   const emitResult = program.emit();
 
@@ -69,7 +70,9 @@ function checkDiagnostics(sources: Map<string, string>) {
         diagnostic.messageText,
         "\n"
       );
-      console.log(`(${line + 1},${character + 1}): ${message}`);
+      console.log(
+        `${diagnostic.file.fileName}:${line + 1}:${character + 1} : ${message}`
+      );
     } else {
       console.log(
         ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")

--- a/types/src/transforms/importable.ts
+++ b/types/src/transforms/importable.ts
@@ -13,6 +13,16 @@ export function createImportableTransformer(): ts.TransformerFactory<ts.SourceFi
 
 function createVisitor(ctx: ts.TransformationContext) {
   return (node: ts.Node) => {
+    // Remove `module` declarations (e.g. `declare module "assets:*" {...}`) as
+    // these can't be `export`ed, and don't really make sense in non-ambient
+    // declarations
+    if (
+      ts.isModuleDeclaration(node) &&
+      (node.flags & ts.NodeFlags.Namespace) === 0
+    ) {
+      return;
+    }
+
     return ensureStatementModifiers(ctx, node);
   };
 }

--- a/types/test/index.spec.ts
+++ b/types/test/index.spec.ts
@@ -29,6 +29,7 @@ test("main: generates types", async () => {
     }
     method.initReturnType().setVoidt();
   }
+  eventTarget.setTsDefine("interface Event {}");
   eventTarget.setTsOverride(`<EventMap extends Record<string, Event> = Record<string, Event>> {
     addEventListener<Type extends keyof EventMap>(type: Type, handler: (event: EventMap[Type]) => void): void;
   }`);
@@ -123,6 +124,9 @@ test("main: generates types", async () => {
     output,
     `/* eslint-disable */
 // noinspection JSUnusedGlobalSymbols
+/** An event which takes place in the DOM. */
+declare interface Event {
+}
 declare class EventTarget<EventMap extends Record<string, Event> = Record<string, Event>> {
     constructor();
     addEventListener<Type extends keyof EventMap>(type: Type, handler: (event: EventMap[Type]) => void): void;
@@ -151,6 +155,8 @@ declare const prop: Promise<number>;
     output,
     `/* eslint-disable */
 // noinspection JSUnusedGlobalSymbols
+/** An event which takes place in the DOM. */
+declare interface Event {}
 declare class EventTarget<
   EventMap extends Record<string, Event> = Record<string, Event>
 > {


### PR DESCRIPTION
A directory of TypeScript files can now be passed to the type generation scripts containing extra definitions appended to the
output. These don't correspond to `workerd` runtime APIs as their implementations are defined elsewhere (e.g. FL, Pages), so it doesn't make sense to include them in the C++ source code.

We kind of do this already with `JSG_TS_DEFINE` in `global-scope.h`...

https://github.com/cloudflare/workerd/blob/ad5665449bcdd117349ff563df7ab2e9163fd369/src/workerd/api/global-scope.h#L416-L515

...but this directory makes it easier to add definitions that don't have a logical C++ location. We can also use this for APIs that are only implemented internally and not ready to be open-sourced yet.