### PR TITLE
Add overrides for Analytics Engine

### DIFF
--- a/src/workerd/api/analytics-engine.h
+++ b/src/workerd/api/analytics-engine.h
@@ -49,6 +49,7 @@ public:
     // have a maximum of 20 elements.
 
     JSG_STRUCT(indexes, doubles, blobs);
+    JSG_STRUCT_TS_OVERRIDE(AnalyticsEngineDataPoint)
   };
 
   void writeDataPoint(jsg::Lock& js,
@@ -59,6 +60,7 @@ public:
   JSG_RESOURCE_TYPE(AnalyticsEngine) {
     JSG_METHOD(writeDataPoint);
     JSG_TS_ROOT();
+    JSG_TS_OVERRIDE(AnalyticsEngineDataset);
   }
 
 private:

--- a/src/workerd/api/analytics-engine.h
+++ b/src/workerd/api/analytics-engine.h
@@ -49,7 +49,7 @@ public:
     // have a maximum of 20 elements.
 
     JSG_STRUCT(indexes, doubles, blobs);
-    JSG_STRUCT_TS_OVERRIDE(AnalyticsEngineDataPoint)
+    JSG_STRUCT_TS_OVERRIDE(AnalyticsEngineDataPoint);
   };
 
   void writeDataPoint(jsg::Lock& js,


### PR DESCRIPTION
We want the Analytics Engine binding to be of type `AnalyticsEngineDataset` and the events to be of type `AnalyticsEngineDataPoint`.