### PR TITLE
call setEventInfo() for custom events

### DIFF
--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -38,6 +38,9 @@ kj::Maybe<TraceItem::EventInfo> TraceItem::getEvent() {
       KJ_CASE_ONEOF(alarm, Trace::AlarmEventInfo) {
         return kj::Maybe(jsg::alloc<AlarmEventInfo>(kj::addRef(*trace), alarm));
       }
+      KJ_CASE_ONEOF(custom, Trace::CustomEventInfo) {
+        return kj::Maybe(jsg::alloc<CustomEventInfo>(kj::addRef(*trace), custom));
+      }
     }
   }
   return nullptr;
@@ -170,6 +173,9 @@ TraceItem::AlarmEventInfo::AlarmEventInfo(kj::Own<Trace> trace,
 kj::Date TraceItem::AlarmEventInfo::getScheduledTime() {
   return eventInfo.scheduledTime;
 }
+
+TraceItem::CustomEventInfo::CustomEventInfo(kj::Own<Trace> trace,
+    const Trace::CustomEventInfo& eventInfo) : trace(kj::mv(trace)), eventInfo(eventInfo) {}
 
 kj::Maybe<kj::StringPtr> TraceItem::getScriptName() {
   return trace->scriptName;

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -50,10 +50,12 @@ public:
   class FetchEventInfo;
   class ScheduledEventInfo;
   class AlarmEventInfo;
+  class CustomEventInfo;
 
   explicit TraceItem(kj::Own<Trace> trace);
 
-  typedef kj::OneOf<jsg::Ref<FetchEventInfo>, jsg::Ref<ScheduledEventInfo>, jsg::Ref<AlarmEventInfo>> EventInfo;
+  typedef kj::OneOf<jsg::Ref<FetchEventInfo>, jsg::Ref<ScheduledEventInfo>,
+      jsg::Ref<AlarmEventInfo>, jsg::Ref<CustomEventInfo>> EventInfo;
   kj::Maybe<EventInfo> getEvent();
   // TODO(someday): support more event types (trace, queue) via kj::OneOf.
   kj::Maybe<double> getEventTimestamp();
@@ -186,6 +188,17 @@ private:
   const Trace::AlarmEventInfo& eventInfo;
 };
 
+class TraceItem::CustomEventInfo final: public jsg::Object {
+public:
+  explicit CustomEventInfo(kj::Own<Trace> trace, const Trace::CustomEventInfo& eventInfo);
+
+  JSG_RESOURCE_TYPE(CustomEventInfo) {}
+
+private:
+  kj::Own<Trace> trace;
+  const Trace::CustomEventInfo& eventInfo;
+};
+
 class TraceLog final: public jsg::Object {
 public:
   TraceLog(kj::Own<Trace> trace, const Trace::Log& log);
@@ -283,6 +296,7 @@ private:
   api::TraceEvent,                            \
   api::TraceItem,                             \
   api::TraceItem::AlarmEventInfo,             \
+  api::TraceItem::CustomEventInfo,            \
   api::TraceItem::ScheduledEventInfo,         \
   api::TraceItem::FetchEventInfo,             \
   api::TraceItem::FetchEventInfo::Request,    \

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -152,6 +152,9 @@ void Trace::copyTo(rpc::Trace::Builder builder) {
         auto alarmBuilder = eventInfoBuilder.initAlarm();
         alarm.copyTo(alarmBuilder);
       }
+      KJ_CASE_ONEOF(custom, CustomEventInfo) {
+        eventInfoBuilder.initCustom();
+      }
     }
   } else {
     eventInfoBuilder.setNone();
@@ -214,6 +217,9 @@ void Trace::mergeFrom(rpc::Trace::Reader reader, PipelineLogLevel pipelineLogLev
         break;
       case rpc::Trace::EventInfo::Which::ALARM:
         eventInfo = AlarmEventInfo(e.getAlarm());
+        break;
+      case rpc::Trace::EventInfo::Which::CUSTOM:
+        eventInfo = CustomEventInfo(e.getCustom());
         break;
       case rpc::Trace::EventInfo::Which::NONE:
         eventInfo = nullptr;
@@ -426,6 +432,7 @@ void WorkerTracer::setEventInfo(kj::Date timestamp, Trace::EventInfo&& info) {
     }
     KJ_CASE_ONEOF(_, Trace::ScheduledEventInfo) {}
     KJ_CASE_ONEOF(_, Trace::AlarmEventInfo) {}
+    KJ_CASE_ONEOF(_, Trace::CustomEventInfo) {}
   }
   trace->bytesUsed = newSize;
   trace->eventInfo = kj::mv(info);

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -98,6 +98,14 @@ public:
     void copyTo(rpc::Trace::AlarmEventInfo::Builder builder);
   };
 
+  class CustomEventInfo {
+  public:
+    explicit CustomEventInfo() {};
+    CustomEventInfo(rpc::Trace::CustomEventInfo::Reader reader) {};
+
+//    void copyTo(rpc::Trace::CustomEventInfo::Builder builder);
+  };
+
   class FetchResponseInfo {
   public:
     explicit FetchResponseInfo(uint16_t statusCode);
@@ -150,7 +158,7 @@ public:
   kj::Date eventTimestamp = kj::UNIX_EPOCH;
   // We treat the origin value as "unset".
 
-  typedef kj::OneOf<FetchEventInfo, ScheduledEventInfo, AlarmEventInfo> EventInfo;
+  typedef kj::OneOf<FetchEventInfo, ScheduledEventInfo, AlarmEventInfo, CustomEventInfo> EventInfo;
   kj::Maybe<EventInfo> eventInfo;
   // TODO(someday): Support more event types.
   // TODO(someday): Work out what sort of information we may want to convey about the parent

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -103,7 +103,6 @@ public:
     explicit CustomEventInfo() {};
     CustomEventInfo(rpc::Trace::CustomEventInfo::Reader reader) {};
 
-//    void copyTo(rpc::Trace::CustomEventInfo::Builder builder);
   };
 
   class FetchResponseInfo {

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -402,6 +402,12 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
   auto incomingRequest = kj::mv(KJ_REQUIRE_NONNULL(this->incomingRequest,
                                 "customEvent() can only be called once"));
   this->incomingRequest = nullptr;
+
+  auto& context = incomingRequest->getContext();
+  KJ_IF_MAYBE(t, incomingRequest->getWorkerTracer()) {
+      t->setEventInfo(context.now(), Trace::CustomEventInfo());
+  }
+
   return event->run(kj::mv(incomingRequest), entrypointName).attach(kj::mv(event));
 }
 

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -45,6 +45,7 @@ struct Trace @0x8e8d911203762d34 {
     fetch @6 :FetchEventInfo;
     scheduled @7 :ScheduledEventInfo;
     alarm @9 :AlarmEventInfo;
+    custom @13 :CustomEventInfo;
   }
   struct FetchEventInfo {
     method @0 :HttpMethod;
@@ -66,6 +67,8 @@ struct Trace @0x8e8d911203762d34 {
   struct AlarmEventInfo {
     scheduledTimeMs @0 :Int64;
   }
+
+  struct CustomEventInfo {}
 
   response @8 :FetchResponseInfo;
   struct FetchResponseInfo {


### PR DESCRIPTION
Custom events do not currently get a timestamp assigned, instead being logged with an unix epoch value. Create a custom event info, empty for now, so that we can correctly set the timestamp.