### PR TITLE
fix context.now() when handling a trace

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -808,8 +808,8 @@ size_t IoContext::getTimeoutCount() {
   return timeoutManager->getTimeoutCount();
 }
 
-kj::Date IoContext::now() {
-  kj::Date adjustedTime = getIoChannelFactory().getTimer().now();
+kj::Date IoContext::now(IncomingRequest& incomingRequest) {
+  kj::Date adjustedTime = incomingRequest.ioChannelFactory->getTimer().now();
 
   KJ_IF_MAYBE (maybeNextTimeout, timeoutManager->getNextTimeout()) {
     // Don't return a time beyond when the next setTimeout() callback is intended to run. This
@@ -820,6 +820,10 @@ kj::Date IoContext::now() {
   } else {
     return adjustedTime;
   }
+}
+
+kj::Date IoContext::now() {
+  return now(getCurrentIncomingRequest());
 }
 
 kj::Own<WorkerInterface> IoContext::getSubrequestNoChecks(

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -685,6 +685,7 @@ public:
 
   size_t getTimeoutCount();
 
+  kj::Date now(IncomingRequest& incomingRequest);
   kj::Date now();
   // Access the event loop's current time point. This will remain constant between ticks.
 

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -405,7 +405,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
 
   auto& context = incomingRequest->getContext();
   KJ_IF_MAYBE(t, incomingRequest->getWorkerTracer()) {
-      t->setEventInfo(context.now(), Trace::CustomEventInfo());
+      t->setEventInfo(context.now(*incomingRequest), Trace::CustomEventInfo());
   }
 
   return event->run(kj::mv(incomingRequest), entrypointName).attach(kj::mv(event));


### PR DESCRIPTION
The TraceCustomEventImpl is a custom event and when handling it the incomingRequests list is empty, causing getCurrentIncomingRequest() to fail.

A new version of IoContext::now() is introduced for when we already have an incoming request available.