### PR TITLE
Fix `Request` and `ReadableStream` overrides

### DIFF
--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -651,9 +651,10 @@ public:
       JSG_READONLY_PROTOTYPE_PROPERTY(integrity, getIntegrity);
       JSG_READONLY_PROTOTYPE_PROPERTY(cache, getCache);
 
-      JSG_TS_OVERRIDE({
+      JSG_TS_OVERRIDE(<CfHostMetadata = unknown> {
         constructor(input: RequestInfo, init?: RequestInit);
-        get cf(): IncomingRequestCfProperties | undefined;
+        clone(): Request<CfHostMetadata>;
+        get cf(): IncomingRequestCfProperties<CfHostMetadata> | undefined;
       });
       // Use `RequestInfo` and `RequestInit` type aliases in constructor instead of inlining.
       // `IncomingRequestCfProperties` is defined in `/types/defines/cf.d.ts`.
@@ -672,9 +673,10 @@ public:
       JSG_READONLY_INSTANCE_PROPERTY(integrity, getIntegrity);
       JSG_READONLY_INSTANCE_PROPERTY(cache, getCache);
 
-      JSG_TS_OVERRIDE({
+      JSG_TS_OVERRIDE(<CfHostMetadata = unknown> {
         constructor(input: RequestInfo, init?: RequestInit);
-        readonly cf?: IncomingRequestCfProperties;
+        clone(): Request<CfHostMetadata>;
+        readonly cf?: IncomingRequestCfProperties<CfHostMetadata>;
       });
       // Use `RequestInfo` and `RequestInit` type aliases in constructor instead of inlining.
       // `IncomingRequestCfProperties` is defined in `/types/defines/cf.d.ts`.

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -297,20 +297,41 @@ public:
 
     JSG_ASYNC_ITERABLE(values);
 
-    JSG_TS_DEFINE(interface ReadableStream<R = any> {
-      cancel(reason?: any): Promise<void>;
+    if (flags.getJsgPropertyOnPrototypeTemplate()) {
+      JSG_TS_DEFINE(interface ReadableStream<R = any> {
+        get locked(): boolean;
 
-      getReader(): ReadableStreamDefaultReader<R>;
-      getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
+        cancel(reason?: any): Promise<void>;
 
-      pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
-      pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
+        getReader(): ReadableStreamDefaultReader<R>;
+        getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
 
-      tee(): [ReadableStream<R>, ReadableStream<R>];
+        pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
+        pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
 
-      values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
-      [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
-    });
+        tee(): [ReadableStream<R>, ReadableStream<R>];
+
+        values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+        [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+      });
+    } else {
+      JSG_TS_DEFINE(interface ReadableStream<R = any> {
+        readonly locked: boolean;
+
+        cancel(reason?: any): Promise<void>;
+
+        getReader(): ReadableStreamDefaultReader<R>;
+        getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
+
+        pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
+        pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
+
+        tee(): [ReadableStream<R>, ReadableStream<R>];
+
+        values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+        [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+      });
+    }
     JSG_TS_OVERRIDE(const ReadableStream: {
       prototype: ReadableStream;
       new (underlyingSource: UnderlyingByteSource, strategy?: QueuingStrategy<Uint8Array>): ReadableStream<Uint8Array>;


### PR DESCRIPTION
- Add missing `locked` property to `ReadableStream` define
- Allow the `HostMetadata` type parameter on `IncomingRequestCfProperties` to be specified with `Request`