### PR TITLE
set event info in custom event

### DIFF
--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -403,11 +403,6 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
                                 "customEvent() can only be called once"));
   this->incomingRequest = nullptr;
 
-  auto& context = incomingRequest->getContext();
-  KJ_IF_MAYBE(t, incomingRequest->getWorkerTracer()) {
-      t->setEventInfo(context.now(*incomingRequest), Trace::CustomEventInfo());
-  }
-
   return event->run(kj::mv(incomingRequest), entrypointName).attach(kj::mv(event));
 }
 


### PR DESCRIPTION
Instead of setting event info in the general
custom event handler, let these custom events
set it themselves.