### PR TITLE
Add scripts tags to Trace Workers

### DIFF
--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -185,6 +185,14 @@ jsg::Optional<kj::StringPtr> TraceItem::getDispatchNamespace() {
   return trace->dispatchNamespace;
 }
 
+jsg::Optional<kj::Array<kj::StringPtr>> TraceItem::getScriptTags() {
+  if (trace->scriptTags.size() > 0) {
+    return KJ_MAP(t, trace->scriptTags) -> kj::StringPtr { return t; };
+  } else {
+    return nullptr;
+  }
+}
+
 kj::StringPtr TraceItem::getOutcome() {
   // TODO(cleanup): Add to enumToStr() to capnp?
   auto enums = capnp::Schema::from<EventOutcome>().getEnumerants();

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -64,6 +64,7 @@ public:
   kj::Array<jsg::Ref<TraceException>> getExceptions();
   kj::Maybe<kj::StringPtr> getScriptName();
   jsg::Optional<kj::StringPtr> getDispatchNamespace();
+  jsg::Optional<kj::Array<kj::StringPtr>> getScriptTags();
   kj::StringPtr getOutcome();
 
   uint getCpuTime();
@@ -76,6 +77,7 @@ public:
     JSG_READONLY_INSTANCE_PROPERTY(exceptions, getExceptions);
     JSG_READONLY_INSTANCE_PROPERTY(scriptName, getScriptName);
     JSG_READONLY_INSTANCE_PROPERTY(dispatchNamespace, getDispatchNamespace);
+    JSG_READONLY_INSTANCE_PROPERTY(scriptTags, getScriptTags);
     JSG_READONLY_INSTANCE_PROPERTY(outcome, getOutcome);
   }
 

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -101,10 +101,11 @@ Trace::Exception::Exception(kj::Date timestamp, kj::String name, kj::String mess
     : timestamp(timestamp), name(kj::mv(name)), message(kj::mv(message)) {}
 
 Trace::Trace(kj::Maybe<kj::String> stableId, kj::Maybe<kj::String> scriptName,
-  kj::Maybe<kj::String> dispatchNamespace)
+  kj::Maybe<kj::String> dispatchNamespace, kj::Array<kj::String> scriptTags)
     : stableId(kj::mv(stableId)),
     scriptName(kj::mv(scriptName)),
-    dispatchNamespace(kj::mv(dispatchNamespace)) {}
+    dispatchNamespace(kj::mv(dispatchNamespace)),
+    scriptTags(kj::mv(scriptTags)) {}
 Trace::Trace(rpc::Trace::Reader reader) {
   mergeFrom(reader, PipelineLogLevel::FULL);
 }
@@ -134,6 +135,13 @@ void Trace::copyTo(rpc::Trace::Builder builder) {
   }
   KJ_IF_MAYBE(s, dispatchNamespace) {
     builder.setDispatchNamespace(*s);
+  }
+
+  {
+    auto list = builder.initScriptTags(scriptTags.size());
+    for (auto i: kj::indices(scriptTags)) {
+      list.set(i, scriptTags[i]);
+    }
   }
   builder.setEventTimestampNs((eventTimestamp - kj::UNIX_EPOCH) / kj::NANOSECONDS);
 
@@ -200,6 +208,10 @@ void Trace::mergeFrom(rpc::Trace::Reader reader, PipelineLogLevel pipelineLogLev
 
   if (reader.hasDispatchNamespace()) {
     dispatchNamespace = kj::str(reader.getDispatchNamespace());
+  }
+
+  if (auto tags = reader.getScriptTags(); tags.size() > 0) {
+    scriptTags = KJ_MAP(tag, tags) { return kj::str(tag); };
   }
 
   eventTimestamp = kj::UNIX_EPOCH + reader.getEventTimestampNs() * kj::NANOSECONDS;
@@ -344,8 +356,8 @@ kj::Promise<kj::Array<kj::Own<Trace>>> PipelineTracer::onComplete() {
 
 kj::Own<WorkerTracer> PipelineTracer::makeWorkerTracer(
     PipelineLogLevel pipelineLogLevel, kj::Maybe<kj::String> stableId,
-    kj::Maybe<kj::String> scriptName,  kj::Maybe<kj::String> dispatchNamespace) {
-  auto trace = kj::refcounted<Trace>(kj::mv(stableId), kj::mv(scriptName), kj::mv(dispatchNamespace));
+    kj::Maybe<kj::String> scriptName,  kj::Maybe<kj::String> dispatchNamespace, kj::Array<kj::String> scriptTags) {
+  auto trace = kj::refcounted<Trace>(kj::mv(stableId), kj::mv(scriptName), kj::mv(dispatchNamespace), kj::mv(scriptTags));
   traces.add(kj::addRef(*trace));
   return kj::refcounted<WorkerTracer>(kj::addRef(*this), kj::mv(trace), pipelineLogLevel);
 }
@@ -356,7 +368,7 @@ WorkerTracer::WorkerTracer(kj::Own<PipelineTracer> parentPipeline,
       parentPipeline(kj::mv(parentPipeline)) {}
 WorkerTracer::WorkerTracer(PipelineLogLevel pipelineLogLevel)
     : pipelineLogLevel(pipelineLogLevel),
-      trace(kj::refcounted<Trace>(nullptr, nullptr, nullptr)) {}
+      trace(kj::refcounted<Trace>(nullptr, nullptr, nullptr, nullptr)) {}
 
 void WorkerTracer::log(kj::Date timestamp, LogLevel logLevel, kj::String message) {
   if (trace->exceededLogLimit) {

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -44,7 +44,7 @@ enum class PipelineLogLevel {
 class Trace final : public kj::Refcounted {
   // Collects trace information about the handling of a worker/pipline fetch event.
 public:
-  explicit Trace(kj::Maybe<kj::String> stableId, kj::Maybe<kj::String> scriptName, kj::Maybe<kj::String> dispatchNamespace);
+  explicit Trace(kj::Maybe<kj::String> stableId, kj::Maybe<kj::String> scriptName, kj::Maybe<kj::String> dispatchNamespace, kj::Array<kj::String> scriptTags);
   Trace(rpc::Trace::Reader reader);
   ~Trace() noexcept(false);
   KJ_DISALLOW_COPY(Trace);
@@ -165,6 +165,7 @@ public:
 
   kj::Maybe<kj::String> scriptName;
   kj::Maybe<kj::String> dispatchNamespace;
+  kj::Array<kj::String> scriptTags;
 
   kj::Vector<Log> logs;
   kj::Vector<Exception> exceptions;
@@ -426,7 +427,8 @@ public:
   kj::Own<WorkerTracer> makeWorkerTracer(PipelineLogLevel pipelineLogLevel,
                                          kj::Maybe<kj::String> stableId,
                                          kj::Maybe<kj::String> scriptName,
-                                         kj::Maybe<kj::String> dispatchNamespace);
+                                         kj::Maybe<kj::String> dispatchNamespace,
+                                         kj::Array<kj::String> scriptTags);
   // Makes a tracer for a worker stage.
 
 private:

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -79,6 +79,7 @@ struct Trace @0x8e8d911203762d34 {
   wallTime @11 :UInt64;
 
   dispatchNamespace @12 :Text;
+  scriptTags @14 :List(Text);
 }
 
 struct ScheduledRun @0xd98fc1ae5c8095d0 {


### PR DESCRIPTION
Adds support for script tags in trace events by introducing an optional string array property on `TraceItem` called `scriptTags`. Because most Workers will never have script tags on them this property is optional and undefined if no tags are defined.