### PR TITLE
Changed `Own<Worker::Actor>` to `LocalActorReference`

### DIFF
--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -24,7 +24,7 @@ public:
                    ThreadContext& threadContext,
                    kj::Own<const Worker> worker,
                    kj::Maybe<kj::StringPtr> entrypointName,
-                   kj::Maybe<kj::Own<Worker::Actor>> actor,
+                   kj::Maybe<Worker::Actor::LocalActorReference&> actor,
                    kj::Own<LimitEnforcer> limitEnforcer,
                    kj::Own<void> ioContextDependency,
                    kj::Own<IoChannelFactory> ioChannelFactory,
@@ -74,7 +74,7 @@ private:
 
   void init(
       kj::Own<const Worker> worker,
-      kj::Maybe<kj::Own<Worker::Actor>> actor,
+      kj::Maybe<Worker::Actor::LocalActorReference&> actor,
       kj::Own<LimitEnforcer> limitEnforcer,
       kj::Own<void> ioContextDependency,
       kj::Own<IoChannelFactory> ioChannelFactory,

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1137,12 +1137,12 @@ public:
 
   kj::Own<WorkerInterface> startRequest(
       IoChannelFactory::SubrequestMetadata metadata, kj::Maybe<kj::StringPtr> entrypointName,
-      kj::Maybe<kj::Own<Worker::Actor>> actor = nullptr) {
+      kj::Maybe<Worker::Actor::LocalActorReference> actor = nullptr) {
     return WorkerEntrypoint::construct(
         threadContext,
         kj::atomicAddRef(*worker),
         entrypointName,
-        kj::mv(actor),
+        actor,
         kj::Own<LimitEnforcer>(this, kj::NullDisposer::instance),
         {},                        // ioContextDependency
         kj::Own<IoChannelFactory>(this, kj::NullDisposer::instance),
@@ -1247,7 +1247,8 @@ private:
 
     kj::Own<WorkerInterface> startRequest(
         IoChannelFactory::SubrequestMetadata metadata) override {
-      return service.startRequest(kj::mv(metadata), className, kj::addRef(*actor));
+      return service.startRequest(kj::mv(metadata), className,
+          Worker::Actor::LocalActorReference(kj::addRef(*actor)));
     }
 
   private:


### PR DESCRIPTION
We need to make this change to track the number of active requests holding actor references. We aren't relying on the `Worker::Actor` refcount, rather, we will manually keep track of the refcount in another class.

This PR likely replaces https://github.com/cloudflare/workerd/pull/125, though I'd like to keep that one around until we know this we're going with this.