### PR TITLE
Use service name as service worker script name

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1137,7 +1137,7 @@ Worker::Script::Script(kj::Own<const Isolate> isolateParam, kj::StringPtr id,
             // limit just to be safe. Don't add it to the rollover bank, though.
             auto limitScope = isolate->getLimitEnforcer().enterStartupJs(lock, maybeLimitError);
             impl->unboundScriptOrMainModule =
-                jsg::NonModuleScript::compile(script.mainScript, lock);
+                jsg::NonModuleScript::compile(script.mainScript, lock, script.mainScriptName);
           }
 
           break;

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -186,6 +186,10 @@ public:
     // Content of the script (JavaScript). Pointer is valid only until the Script constructor
     // returns.
 
+    kj::StringPtr mainScriptName;
+    // Name of the script, used as the script origin for stack traces. Pointer is valid only until
+    // the Script constructor returns.
+
     kj::Function<kj::Array<CompiledGlobal>(jsg::Lock& lock, const ApiIsolate& apiIsolate)>
         compileGlobals;
     // Callback which will compile the script-level globals, returning a list of them.

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -264,10 +264,10 @@ void NonModuleScript::run(v8::Local<v8::Context> context) const {
   check(boundScript->Run(context));
 }
 
-NonModuleScript NonModuleScript::compile(kj::StringPtr code, jsg::Lock& js) {
+NonModuleScript NonModuleScript::compile(kj::StringPtr code, jsg::Lock& js, kj::StringPtr name) {
   // Create a dummy script origin for it to appear in Sources panel.
   auto isolate = js.v8Isolate;
-  v8::ScriptOrigin origin(isolate, v8StrIntern(isolate, "worker.js"));
+  v8::ScriptOrigin origin(isolate, v8StrIntern(isolate, name));
   v8::ScriptCompiler::Source source(v8Str(isolate, code), origin);
   return NonModuleScript(js,
       check(v8::ScriptCompiler::CompileUnboundScript(isolate, &source)));

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -64,7 +64,7 @@ public:
   // Running the script will create a v8::Script instance bound to the given
   // context then will run it to completion.
 
-  static jsg::NonModuleScript compile(kj::StringPtr code, jsg::Lock& js);
+  static jsg::NonModuleScript compile(kj::StringPtr code, jsg::Lock& js, kj::StringPtr name = "worker.js");
 
 private:
   v8::Global<v8::UnboundScript> unboundScript;

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -485,6 +485,22 @@ KJ_TEST("Server: serve basic Service Worker") {
     Bad Request)"_blockquote);
 }
 
+KJ_TEST("Server: use service name as Service Worker origin") {
+  TestServer test(singleWorker(R"((
+    compatibilityDate = "2022-08-17",
+    serviceWorkerScript =
+        `addEventListener("fetch", event => {
+        `  event.respondWith(new Response(new Error("Doh!").stack));
+        `})
+  ))"_kj));
+
+  test.start();
+  auto conn = test.connect("test-addr");
+  conn.httpGet200("/", R"(
+    Error: Doh!
+        at hello:2:34)"_blockquote);
+}
+
 KJ_TEST("Server: serve basic modular Worker") {
   TestServer test(singleWorker(R"((
     compatibilityDate = "2022-08-17",

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1569,9 +1569,9 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
     (*inspector)->registerIsolate(name, isolate.get());
   }
 
-  auto script = isolate->newScript(name, WorkerdApiIsolate::extractSource(conf, errorReporter),
-                                   IsolateObserver::StartType::COLD,
-                                   false, errorReporter);
+  auto script = isolate->newScript(name,
+                                   WorkerdApiIsolate::extractSource(name, conf, errorReporter),
+                                   IsolateObserver::StartType::COLD, false, errorReporter);
 
   struct FutureSubrequestChannel {
     config::ServiceDesignator::Reader designator;

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -157,7 +157,8 @@ const jsg::TypeHandler<Worker::ApiIsolate::ErrorInterface>&
   return kj::downcast<JsgWorkerdIsolate::Lock>(lock).getTypeHandler<ErrorInterface>();
 }
 
-Worker::Script::Source WorkerdApiIsolate::extractSource(config::Worker::Reader conf,
+Worker::Script::Source WorkerdApiIsolate::extractSource(kj::StringPtr name,
+    config::Worker::Reader conf,
     Worker::ValidationErrorReporter& errorReporter) {
   switch (conf.which()) {
     case config::Worker::MODULES: {
@@ -178,6 +179,7 @@ Worker::Script::Source WorkerdApiIsolate::extractSource(config::Worker::Reader c
     case config::Worker::SERVICE_WORKER_SCRIPT:
       return Worker::Script::ScriptSource {
         conf.getServiceWorkerScript(),
+        name,
         [conf,&errorReporter](jsg::Lock& lock, const Worker::ApiIsolate& apiIsolate) {
           return kj::downcast<const WorkerdApiIsolate>(apiIsolate)
               .compileScriptGlobals(lock, conf, errorReporter);
@@ -193,6 +195,7 @@ Worker::Script::Source WorkerdApiIsolate::extractSource(config::Worker::Reader c
 invalid:
   return Worker::Script::ScriptSource {
     ""_kj,
+    name,
     [](jsg::Lock& lock, const Worker::ApiIsolate& apiIsolate)
         -> kj::Array<Worker::Script::CompiledGlobal> {
       return nullptr;

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -26,7 +26,8 @@ public:
   const jsg::TypeHandler<ErrorInterface>&
       getErrorInterfaceTypeHandler(jsg::Lock& lock) const override;
 
-  static Worker::Script::Source extractSource(config::Worker::Reader conf,
+  static Worker::Script::Source extractSource(kj::StringPtr name,
+      config::Worker::Reader conf,
       Worker::ValidationErrorReporter& errorReporter);
 
   struct Global {


### PR DESCRIPTION
Hey! 👋 Currently, when multiple nanoservices are configured with service worker scripts, they'll all use `worker.js` as their script origin. This means if an error is thrown, it's difficult to identify which script threw from inspecting the stack trace. We hit this issue in Miniflare, when attempting to locate source maps for service workers: https://github.com/cloudflare/miniflare/blob/5ecaae2b482feb583d8eeca2310785ea4d68165c/packages/tre/src/plugins/core/prettyerror.ts#L37-L41.

This PR adds a new `name` option for configuring the script origin of service worker scripts. Rather than making `serviceWorkerScript` a `:group` with `name`, I've added a new `serviceWorker` union member to maintain text-format compatibility.