### PR TITLE
Fix `waitUntil` types to accept any `Promise` as opposed to just `Promise<void>`

### DIFF
--- a/types/src/generator/structure.ts
+++ b/types/src/generator/structure.ts
@@ -26,7 +26,10 @@ function createMethodPartial(
     modifiers.push(f.createToken(ts.SyntaxKind.StaticKeyword));
   }
   const name = method.getName();
-  const params = createParamDeclarationNodes(method.getArgs().toArray());
+  const params = createParamDeclarationNodes(
+    method.getArgs().toArray(),
+    /* forMethod */ true
+  );
   const result = createTypeNode(method.getReturnType());
   return [modifiers, name, params, result];
 }
@@ -265,7 +268,10 @@ function createClassMemberNode(
       );
     case Member_Which.CONSTRUCTOR:
       const constructor = member.getConstructor();
-      params = createParamDeclarationNodes(constructor.getArgs().toArray());
+      params = createParamDeclarationNodes(
+        constructor.getArgs().toArray(),
+        /* forMethod */ true
+      );
       return f.createConstructorDeclaration(
         /* decorators */ undefined,
         /* modifiers */ undefined,

--- a/types/test/generator/structure.spec.ts
+++ b/types/test/generator/structure.spec.ts
@@ -15,9 +15,10 @@ test("createStructureNode: method members", () => {
   let method = members.get(0).initMethod();
   method.setName("one");
   {
-    const args = method.initArgs(2);
+    const args = method.initArgs(3);
     args.get(0).setBoolt();
-    const maybe = args.get(1).initMaybe();
+    args.get(1).initPromise().initValue().setVoidt();
+    const maybe = args.get(2).initMaybe();
     maybe.setName("jsg::Optional");
     maybe.initValue().initNumber().setName("int");
   }
@@ -42,7 +43,7 @@ test("createStructureNode: method members", () => {
   assert.strictEqual(
     printNode(createStructureNode(structure, false)),
     `export interface Methods {
-    one(param0: boolean, param1?: number): void;
+    one(param0: boolean, param1: Promise<any>, param2?: number): void;
     three(...param0: any[]): boolean;
 }`
   );
@@ -51,7 +52,7 @@ test("createStructureNode: method members", () => {
   assert.strictEqual(
     printNode(createStructureNode(structure, true)),
     `export declare abstract class Methods {
-    one(param0: boolean, param1?: number): void;
+    one(param0: boolean, param1: Promise<any>, param2?: number): void;
     static three(...param0: any[]): boolean;
 }`
   );
@@ -252,12 +253,13 @@ test("createStructureNode: constructors", () => {
 
   const constructor = members.get(0).initConstructor();
   {
-    const args = constructor.initArgs(3);
+    const args = constructor.initArgs(4);
     let maybe = args.get(0).initMaybe();
     maybe.setName("jsg::Optional");
     maybe.initValue().setBoolt();
     args.get(1).initString().setName("kj::String");
-    maybe = args.get(2).initMaybe();
+    args.get(2).initPromise().initValue().setVoidt();
+    maybe = args.get(3).initMaybe();
     maybe.setName("jsg::Optional");
     maybe.initValue().initNumber().setName("int");
   }
@@ -265,7 +267,7 @@ test("createStructureNode: constructors", () => {
   assert.strictEqual(
     printNode(createStructureNode(structure, true)),
     `export declare class Constructor {
-    constructor(param0: boolean | undefined, param1: string, param2?: number);
+    constructor(param0: boolean | undefined, param1: string, param2: Promise<any>, param3?: number);
 }`
   );
 });

--- a/types/test/generator/type.spec.ts
+++ b/types/test/generator/type.spec.ts
@@ -81,6 +81,10 @@ test("createTypeNode: generic types", () => {
     printNode(createTypeNode(type, true)),
     "void | Promise<void>"
   );
+  assert.strictEqual(
+    printNode(createTypeNode(type, true, true)),
+    "Promise<any>"
+  );
 
   const maybe = type.initMaybe();
   maybe.initValue().setBoolt();


### PR DESCRIPTION
This PR fixes the TypeScript types of `waitUntil`s to accept `Promise<any>` rather than `Promise<void>`.

See 
https://www.typescriptlang.org/play?target=99#code/MYewdgzgLgBMCGwAWBTGBeG8Du8CWsCyKEAdCAA4pgAUAREanQJQDcAUOwCYrAA28AE5oAZgFcwwKHnAwQfLgHV8UAKphpfGhUEgAtnggoAXDAAKug0YA8ANxB4uAPman7jjvKUr1mmoxRSHj4UKBR6JCgoCmMAeli+EAQ+JBBoWJY2GHiYQF4NwCI99i9lAl88LQCglBCwiKiY+MTk1PSWUihUWhpmDCcYAG8AX2YsnMA+DcAiXc4efiFRCSkZMBgwFGwStQ1y7UtDE3Ndm3gwAE8XNwcuDlX1ny2KxFQqmvC6SOi4hKT4FLSoDJGrGysTygAA9zgoAAeFBAglgQyAA.