### PR TITLE
Implements RpcWorkerInterface::connect.

### DIFF
--- a/src/workerd/io/worker-interface.c++
+++ b/src/workerd/io/worker-interface.c++
@@ -285,6 +285,15 @@ kj::Promise<void> RpcWorkerInterface::request(
   return promise.attach(kj::mv(inner));
 }
 
+kj::Promise<void> RpcWorkerInterface::connect(
+    kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& connection,
+    ConnectResponse& tunnel) {
+  auto inner = httpOverCapnpFactory.capnpToKj(dispatcher.getHttpServiceRequest().send().getHttp());
+  auto promise = inner->connect(host, headers, connection, tunnel);
+  return promise.attach(kj::mv(inner));
+}
+
+
 void RpcWorkerInterface::prewarm(kj::StringPtr url) {
   auto req = dispatcher.prewarmRequest(
       capnp::MessageSize { url.size() / sizeof(capnp::word) + 4, 0 });

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -164,6 +164,10 @@ public:
       kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
       kj::AsyncInputStream& requestBody, Response& response) override;
 
+  kj::Promise<void> connect(
+    kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& connection,
+    ConnectResponse& tunnel) override;
+
   void prewarm(kj::StringPtr url) override;
   kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override;
   kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override;


### PR DESCRIPTION
Depends on https://github.com/capnproto/capnproto/pull/1586/.

### Test Plan

In internal repo:

```
$ bazel test //src/edgeworker/tests:sockets/sockets-tcp-test.ew-test-bin@force-process-sandboxing
```