### PR TITLE
Fix overridden Jaeger span duration

### DIFF
--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -513,7 +513,8 @@ Tracer::Span Tracer::makeSpan(kj::StringPtr operationName,
   }
   kj::TimePoint durationStartTime = kj::origin<kj::TimePoint>();
   if (parentSpanContext != nullptr || overrideParent != nullptr) {
-    durationStartTime = kj::systemPreciseMonotonicClock().now();
+    auto delta = kj::systemPreciseCalendarClock().now() - overrideStartTime;
+    durationStartTime = kj::systemPreciseMonotonicClock().now() - delta;
   }
   return makeSpanImpl(operationName, overrideStartTime, durationStartTime, overrideParentContext);
 }
@@ -523,7 +524,8 @@ Tracer::Span Tracer::makeSpan(kj::StringPtr operationName,
                               kj::Maybe<Jaeger::SpanContext&> overrideParent) {
   kj::TimePoint durationStartTime = kj::origin<kj::TimePoint>();
   if (parentSpanContext != nullptr || overrideParent != nullptr) {
-    durationStartTime = kj::systemPreciseMonotonicClock().now();
+    auto delta = kj::systemPreciseCalendarClock().now() - overrideStartTime;
+    durationStartTime = kj::systemPreciseMonotonicClock().now() - delta;
   }
   return makeSpanImpl(operationName, overrideStartTime, durationStartTime, overrideParent);
 }

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -511,14 +511,20 @@ Tracer::Span Tracer::makeSpan(kj::StringPtr operationName,
   KJ_IF_MAYBE(p, overrideParent) {
     overrideParentContext = p->spanData.map([](auto& d) -> auto& { return d.context; });
   }
-  kj::TimePoint durationStartTime = kj::systemPreciseMonotonicClock().now();
+  kj::TimePoint durationStartTime = kj::origin<kj::TimePoint>();
+  if (parentSpanContext != nullptr || overrideParent != nullptr) {
+    durationStartTime = kj::systemPreciseMonotonicClock().now();
+  }
   return makeSpanImpl(operationName, overrideStartTime, durationStartTime, overrideParentContext);
 }
 
 Tracer::Span Tracer::makeSpan(kj::StringPtr operationName,
                               kj::Date overrideStartTime,
                               kj::Maybe<Jaeger::SpanContext&> overrideParent) {
-  kj::TimePoint durationStartTime = kj::systemPreciseMonotonicClock().now();
+  kj::TimePoint durationStartTime = kj::origin<kj::TimePoint>();
+  if (parentSpanContext != nullptr || overrideParent != nullptr) {
+    durationStartTime = kj::systemPreciseMonotonicClock().now();
+  }
   return makeSpanImpl(operationName, overrideStartTime, durationStartTime, overrideParent);
 }
 
@@ -529,22 +535,24 @@ Tracer::Span Tracer::makeSpan(kj::StringPtr operationName,
     overrideParentContext = p->spanData.map([](auto& d) -> auto& { return d.context; });
   }
   kj::Date startTime = kj::origin<kj::Date>();
+  kj::TimePoint durationStartTime = kj::origin<kj::TimePoint>();
   if (parentSpanContext != nullptr || overrideParent != nullptr) {
     auto& clock = isPredictableModeForTest() ? kj::nullClock() : kj::systemPreciseCalendarClock();
     startTime = clock.now();
+    durationStartTime = kj::systemPreciseMonotonicClock().now();
   }
-  kj::TimePoint durationStartTime = kj::systemPreciseMonotonicClock().now();
   return makeSpanImpl(operationName, startTime, durationStartTime, overrideParentContext);
 }
 
 Tracer::Span Tracer::makeSpan(kj::StringPtr operationName,
                               kj::Maybe<Jaeger::SpanContext&> overrideParent) {
   kj::Date startTime = kj::origin<kj::Date>();
+  kj::TimePoint durationStartTime = kj::origin<kj::TimePoint>();
   if (parentSpanContext != nullptr || overrideParent != nullptr) {
     auto& clock = isPredictableModeForTest() ? kj::nullClock() : kj::systemPreciseCalendarClock();
     startTime = clock.now();
+    durationStartTime = kj::systemPreciseMonotonicClock().now();
   }
-  kj::TimePoint durationStartTime = kj::systemPreciseMonotonicClock().now();
   return makeSpanImpl(operationName, startTime, durationStartTime, overrideParent);
 }
 

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -290,6 +290,9 @@ private:
   kj::Maybe<JaegerSpanSubmitter&> jaegerSpanSubmitter;
   kj::Own<void> ownJaegerSpanSubmitter;
   uint64_t predictableJaegerSpanId = 1;
+
+  Span makeSpanImpl(kj::StringPtr operationName, kj::Date startTime,
+      kj::Maybe<Jaeger::SpanContext&> overrideParent);
 };
 
 kj::Maybe<Tracer::Span> mapMakeSpan(

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -213,7 +213,8 @@ class Tracer final : public kj::Refcounted {
 public:
   class Span final {
   public:
-    explicit Span(kj::Own<Tracer> tracer, kj::Maybe<Jaeger::SpanData> spanData);
+    explicit Span(kj::Own<Tracer> tracer, kj::Maybe<Jaeger::SpanData> spanData,
+        kj::TimePoint durationStartTime);
     ~Span() noexcept(false);
     Span(Span&&) = default;
     Span& operator=(Span&&) = default;
@@ -278,6 +279,10 @@ public:
   // Makes a Jaeger tracing span, automatically tracking the beginning and end of the span via
   // lifetime.  Jaeger spans are for internal profiling, so we record more precise timing than we
   // expose to customers.
+  //
+  // TODO(someday): Expose a way to override both the span's starting timestamp and the duration
+  // start time.  These are measured from the calendar clock and the monotonic clock,
+  // respectively; the current API only allows overriding the starting timestamp.
 
 private:
   Jaeger::SpanId makeSpanId();
@@ -292,7 +297,7 @@ private:
   uint64_t predictableJaegerSpanId = 1;
 
   Span makeSpanImpl(kj::StringPtr operationName, kj::Date startTime,
-      kj::Maybe<Jaeger::SpanContext&> overrideParent);
+      kj::TimePoint durationStartTime, kj::Maybe<Jaeger::SpanContext&> overrideParent);
 };
 
 kj::Maybe<Tracer::Span> mapMakeSpan(


### PR DESCRIPTION
When starting to record a Jaeger span, we do two different clock reads -- we read the calendar clock for the timestamp, and we read from the monotonic clock for the start of the span duration.  We also allow callers to override the timestamp, to record a span that started earlier.  But this override was only affecting the timestamp, not the start of the span duration, so durations for overridden spans were incorrect.

Ideally, we'd want callers to provide both the monotonic and calendar clock measurements for their span overrides, but as a stopgap we can compute the elapsed calendar time at the time of the override and subtract it from the current monotonic clock time, to estimate the intended duration start time.

(The official Jaeger C++ library has a more complex system, allowing users to specify both clock overrides, or just one or the other -- in which case the missing value is estimated using a similar calculation:

https://github.com/jaegertracing/jaeger-client-cpp/blob/e56b1bdb/src/jaegertracing/Tracer.cpp#L41
https://github.com/opentracing/opentracing-cpp/blob/06b57f48/include/opentracing/util.h#L40-L63

It appears the rust opentelemetry library doesn't have this problem, since it just uses monotonic clocks for everything... which presumably has a different set of problems.)