### PR TITLE
Switch from EmbedderHeapTracer to cppgc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -221,7 +221,7 @@ npm_repositories()
 git_repository(
     name = "v8",
     remote = "https://chromium.googlesource.com/v8/v8.git",
-    commit = "35952837d5c420b727642b88e28651cb80c3f538",
+    commit = "18865d6af0404f2d2aeb1c99dd73503364ce0967",
     shallow_since = "1662649276 +0000",
     patch_args = [ "-p1" ],
     patches = [
@@ -229,13 +229,14 @@ git_repository(
         "//:patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch",
         "//:patches/v8/0003-Make-icudata-target-public.patch",
         "//:patches/v8/0004-Add-ArrayBuffer-MaybeNew.patch",
+        "//:patches/v8/0005-Revert-bazel-Add-hide-symbols-from-release-fast-buil.patch",
     ],
 )
 
 new_git_repository(
     name = "com_googlesource_chromium_icu",
     remote = "https://chromium.googlesource.com/chromium/deps/icu.git",
-    commit = "b3070c52557323463e6b9827e2343e60e1b91f85",
+    commit = "20f8ac695af59b6c830def7d4e95bfeb13dd7be5",
     shallow_since = "1660168635 +0000",
     build_file = "@v8//:bazel/BUILD.icu",
     patch_cmds = [ "find source -name BUILD.bazel | xargs rm" ]
@@ -244,7 +245,7 @@ new_git_repository(
 new_git_repository(
     name = "com_googlesource_chromium_base_trace_event_common",
     remote = "https://chromium.googlesource.com/chromium/src/base/trace_event/common.git",
-    commit = "2ba7a48ca6167ee8ef311a7f3bc60b5e5cf5ee79",
+    commit = "521ac34ebd795939c7e16b37d9d3ddb40e8ed556",
     shallow_since = "1659619139 -0700",
     build_file = "@v8//:bazel/BUILD.trace_event_common",
 )

--- a/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
+++ b/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
@@ -1,7 +1,7 @@
-From 6c3439ffcdfea7acc0135ca39147f959805723a8 Mon Sep 17 00:00:00 2001
+From 9552b08768d3325b8c755cc082500ba2990a1282 Mon Sep 17 00:00:00 2001
 From: Alex Robinson <arobinson@cloudflare.com>
 Date: Wed, 2 Mar 2022 15:58:04 -0600
-Subject: [PATCH 1/4] Allow manually setting ValueDeserializer format version
+Subject: [PATCH 1/5] Allow manually setting ValueDeserializer format version
 
 For many years, V8's serialization version didn't change. In the meantime,
 we accidentally stored data that was missing a version header. This patch
@@ -22,13 +22,13 @@ like:
  3 files changed, 18 insertions(+)
 
 diff --git a/include/v8-value-serializer.h b/include/v8-value-serializer.h
-index 078f367c64..da5c327955 100644
+index 729730c608..4398684017 100644
 --- a/include/v8-value-serializer.h
 +++ b/include/v8-value-serializer.h
-@@ -256,6 +256,13 @@ class V8_EXPORT ValueDeserializer {
+@@ -279,6 +279,13 @@ class V8_EXPORT ValueDeserializer {
     */
    uint32_t GetWireFormatVersion() const;
-
+ 
 +  /**
 +   * Sets the underlying wire format version. Should only be used if there's no
 +   * header specifying the wire format version but you're confident you know
@@ -40,13 +40,13 @@ index 078f367c64..da5c327955 100644
     * Reads raw data in various common formats to the buffer.
     * Note that integer types are read in base-128 varint format, not with a
 diff --git a/src/api/api.cc b/src/api/api.cc
-index bbab4c72ac..512099336f 100644
+index 14b7c541b3..4a71629579 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -3579,6 +3579,10 @@ uint32_t ValueDeserializer::GetWireFormatVersion() const {
+@@ -3578,6 +3578,10 @@ uint32_t ValueDeserializer::GetWireFormatVersion() const {
    return private_->deserializer.GetWireFormatVersion();
  }
-
+ 
 +void ValueDeserializer::SetWireFormatVersion(uint32_t version) {
 +  private_->deserializer.SetWireFormatVersion(version);
 +}
@@ -55,13 +55,13 @@ index bbab4c72ac..512099336f 100644
    PREPARE_FOR_EXECUTION(context, ValueDeserializer, ReadValue, Value);
    i::MaybeHandle<i::Object> result;
 diff --git a/src/objects/value-serializer.h b/src/objects/value-serializer.h
-index 445d75b7a4..b69157e026 100644
+index 1c7e7bb76f..95950427c3 100644
 --- a/src/objects/value-serializer.h
 +++ b/src/objects/value-serializer.h
-@@ -213,6 +213,13 @@ class ValueDeserializer {
+@@ -216,6 +216,13 @@ class ValueDeserializer {
     */
    uint32_t GetWireFormatVersion() const { return version_; }
-
+ 
 +  /*
 +   * Sets the underlying wire format version. Should only be used if there's no
 +   * header specifying the wire format version but you're confident you know
@@ -72,6 +72,6 @@ index 445d75b7a4..b69157e026 100644
    /*
     * Deserializes a V8 object from the buffer.
     */
---
+-- 
 2.30.2
 

--- a/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
+++ b/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
@@ -1,8 +1,9 @@
-From a36011bb5e1e6247b225d8e1499931aa91c1c60a Mon Sep 17 00:00:00 2001
+From 089c7f4788d2ccac74a36f3925874e3dcc031a4c Mon Sep 17 00:00:00 2001
 From: James M Snell <jasnell@gmail.com>
 Date: Wed, 16 Mar 2022 08:59:21 -0700
-Subject: [PATCH 2/4] Allow manually setting ValueSerializer format version
+Subject: [PATCH 2/5] Allow manually setting ValueSerializer format version
 
+Refs: https://bitbucket.cfdata.org/projects/MIRRORS/repos/v8/pull-requests/2/overview
 ---
  include/v8-value-serializer.h   |  5 +++++
  src/api/api.cc                  |  4 ++++
@@ -11,10 +12,10 @@ Subject: [PATCH 2/4] Allow manually setting ValueSerializer format version
  4 files changed, 29 insertions(+), 3 deletions(-)
 
 diff --git a/include/v8-value-serializer.h b/include/v8-value-serializer.h
-index da5c327955..ea64c33ea3 100644
+index 4398684017..7f8693eab1 100644
 --- a/include/v8-value-serializer.h
 +++ b/include/v8-value-serializer.h
-@@ -110,6 +110,11 @@ class V8_EXPORT ValueSerializer {
+@@ -140,6 +140,11 @@ class V8_EXPORT ValueSerializer {
    ValueSerializer(Isolate* isolate, Delegate* delegate);
    ~ValueSerializer();
  
@@ -27,10 +28,10 @@ index da5c327955..ea64c33ea3 100644
     * Writes out a header, which includes the format version.
     */
 diff --git a/src/api/api.cc b/src/api/api.cc
-index 512099336f..5a0dd6f22d 100644
+index 4a71629579..22c660e708 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -3444,6 +3444,10 @@ ValueSerializer::ValueSerializer(Isolate* v8_isolate, Delegate* delegate)
+@@ -3445,6 +3445,10 @@ ValueSerializer::ValueSerializer(Isolate* v8_isolate, Delegate* delegate)
  
  ValueSerializer::~ValueSerializer() { delete private_; }
  
@@ -42,12 +43,12 @@ index 512099336f..5a0dd6f22d 100644
  
  void ValueSerializer::SetTreatArrayBufferViewsAsHostObjects(bool mode) {
 diff --git a/src/objects/value-serializer.cc b/src/objects/value-serializer.cc
-index e7788029a3..a426cdee86 100644
+index 61a7cae8e8..6287bb0d66 100644
 --- a/src/objects/value-serializer.cc
 +++ b/src/objects/value-serializer.cc
 @@ -263,6 +263,7 @@ ValueSerializer::ValueSerializer(Isolate* isolate,
+     : isolate_(isolate),
        delegate_(delegate),
-       supports_shared_values_(delegate && delegate->SupportsSharedValues()),
        zone_(isolate->allocator(), ZONE_NAME),
 +      version_(kLatestVersion),
        id_map_(isolate->heap(), ZoneAllocationPolicy(&zone_)),
@@ -72,7 +73,7 @@ index e7788029a3..a426cdee86 100644
  }
  
  void ValueSerializer::SetTreatArrayBufferViewsAsHostObjects(bool mode) {
-@@ -975,10 +984,12 @@ Maybe<bool> ValueSerializer::WriteJSArrayBufferView(JSArrayBufferView view) {
+@@ -972,10 +981,12 @@ Maybe<bool> ValueSerializer::WriteJSArrayBufferView(JSArrayBufferView view) {
    WriteVarint(static_cast<uint8_t>(tag));
    WriteVarint(static_cast<uint32_t>(view.byte_offset()));
    WriteVarint(static_cast<uint32_t>(view.byte_length()));
@@ -88,10 +89,10 @@ index e7788029a3..a426cdee86 100644
  }
  
 diff --git a/src/objects/value-serializer.h b/src/objects/value-serializer.h
-index b69157e026..e05efe8738 100644
+index 95950427c3..f3c9054af9 100644
 --- a/src/objects/value-serializer.h
 +++ b/src/objects/value-serializer.h
-@@ -53,6 +53,11 @@ class ValueSerializer {
+@@ -54,6 +54,11 @@ class ValueSerializer {
    ValueSerializer(const ValueSerializer&) = delete;
    ValueSerializer& operator=(const ValueSerializer&) = delete;
  

--- a/patches/v8/0003-Make-icudata-target-public.patch
+++ b/patches/v8/0003-Make-icudata-target-public.patch
@@ -1,7 +1,7 @@
-From c1c2ff778334ace97d889cb486a48ae28c989fd0 Mon Sep 17 00:00:00 2001
+From 8881367c1e77b81901a950c7fc18c22a79b1a941 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Sat, 17 Sep 2022 11:11:15 -0500
-Subject: [PATCH 3/4] Make `:icudata` target public.
+Subject: [PATCH 3/5] Make `:icudata` target public.
 
 Dependencies are required to load this file, so it ought to be exposed for them to use.
 ---

--- a/patches/v8/0004-Add-ArrayBuffer-MaybeNew.patch
+++ b/patches/v8/0004-Add-ArrayBuffer-MaybeNew.patch
@@ -1,7 +1,7 @@
-From ef1d0dc9dcd206fe658d63472556d197369f1149 Mon Sep 17 00:00:00 2001
+From fe5b8a5a21e1ce15625b2b8389ecf861883b7788 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Fri, 16 Sep 2022 21:41:45 -0500
-Subject: [PATCH 4/4] Add `ArrayBuffer::MaybeNew()`.
+Subject: [PATCH 4/5] Add `ArrayBuffer::MaybeNew()`.
 
 In Cloudflare's edge runtime, this is part of a larger patch that allows graceful handling of allocations that exceed memory limits. `workerd` currently doesn't enforce any limits, so to reduce complexity we just forward to `New()`.
 

--- a/patches/v8/0005-Revert-bazel-Add-hide-symbols-from-release-fast-buil.patch
+++ b/patches/v8/0005-Revert-bazel-Add-hide-symbols-from-release-fast-buil.patch
@@ -1,0 +1,45 @@
+From d0f3e57286f40413f0a54488a098e92e5d86326a Mon Sep 17 00:00:00 2001
+From: Victor Gomes <victorgomes@chromium.org>
+Date: Fri, 21 Oct 2022 12:18:34 +0000
+Subject: [PATCH 5/5] Revert "[bazel] Add hide symbols from release / fast
+ builds"
+
+This reverts commit 6e4dea75e8e66d47bbfb0b0832400e32e6e57620.
+
+[Commit description from Kenton for workerd; patch content from upstream.]
+
+This revert appears upstream shortly after V8 10.8 was cut:
+
+https://chromium-review.googlesource.com/c/v8/v8/+/3971120
+
+The upstream revert message is not very informative, but the change broke
+dynamic linking of unit tests in fastbuild mode. A subsequent reland of
+the change uses the flags only in opt mode, which should work better.
+
+This patch can be removed when updating to V8 10.9.
+---
+ bazel/defs.bzl | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/bazel/defs.bzl b/bazel/defs.bzl
+index d8db3fe8ba..a472b828e0 100644
+--- a/bazel/defs.bzl
++++ b/bazel/defs.bzl
+@@ -151,14 +151,6 @@ def _default_args():
+                 "-fno-integrated-as",
+             ],
+             "//conditions:default": [],
+-        }) + select({
+-            "@v8//bazel/config:is_debug":[
+-                "-fvisibility=default",
+-            ],
+-            "//conditions:default": [
+-                "-fvisibility=hidden",
+-                "-fvisibility-inlines-hidden",
+-            ],
+         }),
+         includes = ["include"],
+         linkopts = select({
+--
+2.30.2
+

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -362,6 +362,12 @@ private:
 // Use inside a JSG_RESOURCE_TYPE block to declare a property on this object that should be
 // accessible to JavaScript. `name` is the JavaScript member name, while `getter` and `setter` are
 // the names of C++ methods that get and set this property.
+//
+// WARNING: This is usually not what you want. Usually you want JSG_PROTOTYPE_PROPERTY instead.
+// Note that V8 implements instance properties by modifying the instance immediately after
+// construction, which is inefficient and can break some optimizations. For example, any object
+// with an instance proprety will not be possible to collect during minor GCs, only major GCs.
+// Prototype properties are on the prototype, so have no runtime overhead until they are used.
 
 #define JSG_PROTOTYPE_PROPERTY(name, getter, setter) \
   do { \

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1523,12 +1523,15 @@ public:
 
 private:
   Wrappable& parent;
+  kj::Maybe<cppgc::Visitor&> cppgcVisitor;
 
-  explicit GcVisitor(Wrappable& parent): parent(parent) {}
+  explicit GcVisitor(Wrappable& parent, kj::Maybe<cppgc::Visitor&> cppgcVisitor)
+      : parent(parent), cppgcVisitor(cppgcVisitor) {}
   KJ_DISALLOW_COPY(GcVisitor);
 
   friend class Wrappable;
   friend class Object;
+  friend class HeapTracer;
 };
 
 constexpr bool isGcVisitable_(...) { return false; }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -703,7 +703,20 @@ public:
     destroy();
   }
   Data(Data&& other): isolate(other.isolate), handle(kj::mv(other.handle)) {
-    if (other.tracedHandle != nullptr) handle.ClearWeak();
+    KJ_IF_MAYBE(t, other.tracedHandle) {
+      // `other` is a traced `Data`, but once moved, we don't assume the new location is traced.
+      // So, we need to make the handle strong.
+      handle.ClearWeak();
+
+      // Presumably, `other` is about to be destroyed. The destructor of `TracedReference`, though,
+      // does nothing, because it doesn't know if the reference is even still valid, since it
+      // could be called during GC sweep time. But here, we know that `other` is definitely still
+      // valid, because we wouldn't be moving from an unreachable object. So we should Reset() the
+      // `TracedReference` so that V8 knows it's gone, which might make minor GCs more effective.
+      t->Reset();
+
+      other.tracedHandle = nullptr;
+    }
     other.isolate = nullptr;
     assertInvariant();
     other.assertInvariant();
@@ -714,7 +727,11 @@ public:
       isolate = other.isolate;
       handle = kj::mv(other.handle);
       other.isolate = nullptr;
-      if (other.tracedHandle != nullptr) handle.ClearWeak();
+      KJ_IF_MAYBE(t, other.tracedHandle) {
+        handle.ClearWeak();
+        t->Reset();
+        other.tracedHandle = nullptr;
+      }
     }
     assertInvariant();
     other.assertInvariant();

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -350,7 +350,7 @@ IsolateBase::IsolateBase(const V8System& system, v8::Isolate::CreateParams&& cre
   {
     v8::HandleScope scope(ptr);
     auto opaqueTemplate = v8::FunctionTemplate::New(ptr, &throwIllegalConstructor);
-    opaqueTemplate->InstanceTemplate()->SetInternalFieldCount(2);
+    opaqueTemplate->InstanceTemplate()->SetInternalFieldCount(Wrappable::INTERNAL_FIELD_COUNT);
     this->opaqueTemplate.Reset(ptr, opaqueTemplate);
   }
 }

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -204,6 +204,8 @@ void HeapTracer::ResetRoot(const v8::TracedReference<v8::Value>& handle) {
   // We don't want to call `detachWrapper()` now because it may create new handles (specifically,
   // if the wrapable has strong references, which means that its outgoing references need to be
   // upgraded to strong).
+  // TODO(now): Find out if it's actually safe to `detachWrapper()` inline. In my experiments it
+  //   didn't appear to cause any problems.
   detachLater.add(&wrappable);
 }
 

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -221,8 +221,6 @@ void HeapTracer::ResetRoot(const v8::TracedReference<v8::Value>& handle) {
   // We don't want to call `detachWrapper()` now because it may create new handles (specifically,
   // if the wrapable has strong references, which means that its outgoing references need to be
   // upgraded to strong).
-  // TODO(now): Find out if it's actually safe to `detachWrapper()` inline. In my experiments it
-  //   didn't appear to cause any problems.
   detachLater.add(&wrappable);
 }
 

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -160,6 +160,10 @@ void HeapTracer::destroy() {
   wrappersToTrace.clear();
 }
 
+HeapTracer& HeapTracer::getTracer(v8::Isolate* isolate) {
+  return IsolateBase::from(isolate).heapTracer;
+}
+
 void HeapTracer::mark(TraceableHandle& handle) {
   if (handle.lastMarked == traceId) {
     return;

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -208,6 +208,7 @@ private:
 
   friend class Data;
   friend class Wrappable;
+  friend class HeapTracer;
 
   friend bool getCaptureThrowsAsRejections(v8::Isolate* isolate);
   friend bool getCommonJsExportDefault(v8::Isolate* isolate);

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -54,6 +54,7 @@ public:
 
 private:
   kj::Own<v8::Platform> platform;
+  friend class IsolateBase;
 
   explicit V8System(kj::Own<v8::Platform>, kj::ArrayPtr<const kj::StringPtr>);
 };
@@ -205,6 +206,7 @@ private:
   friend kj::Maybe<kj::StringPtr> getJsStackTrace(void* ucontext, kj::ArrayPtr<char> scratch);
 
   HeapTracer heapTracer;
+  std::unique_ptr<v8::CppHeap> cppgcHeap;
 
   friend class Data;
   friend class Wrappable;

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -196,8 +196,8 @@ private:
       v8::Local<v8::Context> context, v8::Local<v8::Value> source, bool isCodeLike);
   static bool allowWasmCallback(v8::Local<v8::Context> context, v8::Local<v8::String> source);
 
-  static void scavengePrologue(v8::Isolate* isolate, v8::GCType type, v8::GCCallbackFlags flags);
-  static void scavengeEpilogue(v8::Isolate* isolate, v8::GCType type, v8::GCCallbackFlags flags);
+  static void gcPrologue(v8::Isolate* isolate, v8::GCType type, v8::GCCallbackFlags flags);
+  static void gcEpilogue(v8::Isolate* isolate, v8::GCType type, v8::GCCallbackFlags flags);
 
   static void jitCodeEvent(const v8::JitCodeEvent* event) noexcept;
 

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -197,9 +197,6 @@ private:
       v8::Local<v8::Context> context, v8::Local<v8::Value> source, bool isCodeLike);
   static bool allowWasmCallback(v8::Local<v8::Context> context, v8::Local<v8::String> source);
 
-  static void gcPrologue(v8::Isolate* isolate, v8::GCType type, v8::GCCallbackFlags flags);
-  static void gcEpilogue(v8::Isolate* isolate, v8::GCType type, v8::GCCallbackFlags flags);
-
   static void jitCodeEvent(const v8::JitCodeEvent* event) noexcept;
 
   friend class IsolateBase;

--- a/src/workerd/jsg/tracing-test.c++
+++ b/src/workerd/jsg/tracing-test.c++
@@ -27,7 +27,48 @@ public:
   Ref<NumberBox> getInner() { return inner.addRef(); }
 
   JSG_RESOURCE_TYPE(NumberBoxHolder) {
-    JSG_READONLY_INSTANCE_PROPERTY(inner, getInner);
+    JSG_READONLY_PROTOTYPE_PROPERTY(inner, getInner);
+  }
+
+private:
+  void visitForGc(GcVisitor& visitor) {
+    visitor.visit(inner);
+  }
+};
+
+class GcDetector: public jsg::Object {
+  // Object which comes in pairs where one member of the pair can detect if the other has been
+  // collected.
+
+public:
+  ~GcDetector() noexcept(false) {
+    KJ_IF_MAYBE(s, sibling) s->sibling = nullptr;
+  }
+
+  kj::Maybe<GcDetector&> sibling;
+
+  bool getSiblingCollected() { return sibling == nullptr; }
+
+  bool touch() { return true; }
+
+  JSG_RESOURCE_TYPE(GcDetector) {
+    // NOTE: Using an instance property instead of a prototype property causes V8 to refuse to
+    //   collect the wrapper during minor GCs, as it always thinks the wrapper is "modified".
+    JSG_READONLY_PROTOTYPE_PROPERTY(siblingCollected, getSiblingCollected);
+    JSG_METHOD(touch);
+  }
+};
+
+class GcDetectorBox: public jsg::Object {
+  // Contains a GcDetector. Useful for testing tracing scenarios.
+
+public:
+  jsg::Ref<GcDetector> inner = jsg::alloc<GcDetector>();
+
+  jsg::Ref<GcDetector> getInner() { return inner.addRef(); }
+
+  JSG_RESOURCE_TYPE(GcDetectorBox) {
+    JSG_READONLY_PROTOTYPE_PROPERTY(inner, getInner);
   }
 
 private:
@@ -48,15 +89,112 @@ struct TraceTestContext: public Object {
     strongRef = kj::mv(ref);
   }
 
+  kj::Array<jsg::Ref<GcDetector>> makeGcDetectorPair() {
+    auto obj1 = jsg::alloc<GcDetector>();
+    auto obj2 = jsg::alloc<GcDetector>();
+    obj1->sibling = *obj2;
+    obj2->sibling = *obj1;
+    return kj::arr(kj::mv(obj1), kj::mv(obj2));
+  }
+
+  kj::Array<jsg::Ref<GcDetectorBox>> makeGcDetectorBoxPair() {
+    auto obj1 = jsg::alloc<GcDetectorBox>();
+    auto obj2 = jsg::alloc<GcDetectorBox>();
+    obj1->inner->sibling = *obj2->inner;
+    obj2->inner->sibling = *obj1->inner;
+    return kj::arr(kj::mv(obj1), kj::mv(obj2));
+  }
+
+  void assert_(bool condition, jsg::Optional<kj::String> message) {
+    JSG_ASSERT(condition, Error, message.orDefault(nullptr));
+  }
+
   JSG_RESOURCE_TYPE(TraceTestContext) {
     JSG_NESTED_TYPE(NumberBox);
     JSG_NESTED_TYPE(NumberBoxHolder);
-    JSG_INSTANCE_PROPERTY(strongRef, getStrongRef, setStrongRef);
+    JSG_NESTED_TYPE(GcDetector);
+    JSG_METHOD(makeGcDetectorPair);
+    JSG_METHOD(makeGcDetectorBoxPair);
+    JSG_METHOD_NAMED(assert, assert_);
+    JSG_PROTOTYPE_PROPERTY(strongRef, getStrongRef, setStrongRef);
   }
 };
 
 JSG_DECLARE_ISOLATE_TYPE(TraceTestIsolate, TraceTestContext, NumberBox,
-                          NumberBoxHolder);
+                         NumberBoxHolder, GcDetector, GcDetectorBox);
+
+KJ_TEST("GC collects objects when expected") {
+  Evaluator<TraceTestContext, TraceTestIsolate> e(v8System);
+
+  // Test that a full GC can collect native objects.
+  e.expectEval(R"(
+    let pair = makeGcDetectorPair();
+    let a = pair[0];
+    let b = pair[1];
+    pair = null;
+    a = null;
+    gc();
+    assert(b.siblingCollected, "full GC did not collect native objects");
+  )", "undefined", "undefined");
+
+  // Test that a full GC can collect native cyclic objects.
+  e.expectEval(R"(
+    let pair = makeGcDetectorBoxPair();
+    let a = pair[0];
+    let b = pair[1].inner;
+    pair = null;
+    a.inner.cycle = a;  // create cycle involving a jsg::Ref and a V8 native reference
+    gc();
+    assert(!b.siblingCollected);
+    a = null;
+    gc();
+    assert(b.siblingCollected, "full GC did not collect cycles");
+  )", "undefined", "undefined");
+
+  // Test that minor GC can collect native objects.
+  e.expectEval(R"(
+    let pair = makeGcDetectorPair();
+    let a = pair[0];
+    let b = pair[1];
+    pair = null;
+    a = null;
+    gc({type: "minor"});
+    assert(b.siblingCollected, "minor GC did not collect native objects");
+  )", "undefined", "undefined");
+
+  // Test that minor GC does not collect native objects whose wrappers have been "modified".
+  //
+  // This verifies our assumptions about how V8's EmbedderRootHandler works.
+  e.expectEval(R"(
+    let pair = makeGcDetectorPair();
+    let a = pair[0];
+    let b = pair[1];
+    pair = null;
+    a.foo = 123;  // modify the wrapper
+    a = null;
+    gc({type: "minor"});
+    assert(!b.siblingCollected, "minor GC collected modified native object");
+  )", "undefined", "undefined");
+
+  // Test that minor GC collects a native object contained in another native object.
+  e.expectEval(R"(
+    let pair = makeGcDetectorBoxPair();
+    let a = pair[0];
+    let b = pair[1].inner;
+    pair = null;
+    let inner = a.inner;
+    // If I don't wrap `inner.touch()` in an IIFE then `inner` doesn't get collected (even with a
+    // full GC). I guess when invoking a method on a native object, V8 ends up putting a handle on
+    // the stack which doesn't get released until the end of the function? Weird but whatever.
+    (() => {
+      assert(inner.touch());  // make sure inner wrapper is initialized
+    })();
+    inner = null;
+    a = null;
+    gc({type: "minor"});
+    assert(b.siblingCollected, "minor GC did not collect transitive native objects");
+  )", "undefined", "undefined");
+}
 
 KJ_TEST("TracedReference usage does not lead to crashes") {
   Evaluator<TraceTestContext, TraceTestIsolate> e(v8System);

--- a/src/workerd/jsg/tracing-test.c++
+++ b/src/workerd/jsg/tracing-test.c++
@@ -237,7 +237,8 @@ KJ_TEST("GC collects objects when expected") {
     // We need two minor GC passes to fully collect the object. This is because the first GC pass
     // collects the `ValueBox`, thus destroying its `jsg::Value inner` member, but V8's GC doesn't
     // actually notice that this makes the inner object unreachable until a second pass.
-    // TODO(now): Is there any trick we could use to make V8 notice?
+    // TODO(perf): When V8 implements "unified young-generation", circle back and see if we can
+    //   improved this.
     gc({type: "minor"});
     gc({type: "minor"});
 

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -14,34 +14,41 @@ namespace workerd::jsg {
 
 class Wrappable::CppgcShim final: public cppgc::GarbageCollected<CppgcShim> {
 public:
-  CppgcShim(Wrappable& wrappable): wrappable(kj::addRef(wrappable)) {}
-
-  void Trace(cppgc::Visitor* visitor) const {
-    const_cast<Wrappable*>(wrappable.get())->traceFromV8(*visitor);
+  CppgcShim(Wrappable& wrappable): wrappable(kj::addRef(wrappable)) {
+    KJ_DASSERT(wrappable.cppgcShim == nullptr);
+    wrappable.cppgcShim = *this;
   }
 
-  kj::Own<Wrappable> wrappable;
+  ~CppgcShim() {
+    KJ_IF_MAYBE(w, wrappable) {
+      KJ_DASSERT(&KJ_ASSERT_NONNULL(w->get()->cppgcShim) == this);
+      KJ_DASSERT(w->get()->strongWrapper.IsEmpty());
+      w->get()->detachWrapper();
+    }
+  }
+
+  void Trace(cppgc::Visitor* visitor) const {
+    KJ_IF_MAYBE(w, wrappable) {
+      w->get()->traceFromV8(*visitor);
+    }
+  }
+
+  mutable kj::Maybe<kj::Own<Wrappable>> wrappable;
+  // This can become null if the wrappable is force-collected without waiting for GC.
 };
 
 kj::Own<Wrappable> Wrappable::detachWrapper() {
-  resetWrapperHandle();
-  return detachWrapperRef();
-}
-
-void Wrappable::resetWrapperHandle() {
-  if (!wrapper.IsEmpty()) {
-    auto& tracer = HeapTracer::getTracer(isolate);
-    detachedTraceId = tracer.currentTraceId();
-    detached = tracer.isScavenging() ? WHILE_SCAVENGING
-             : tracer.isTracing() ? WHILE_TRACING
-             : OTHER;
-    tracer.removeWrapper({}, *this);
+  KJ_IF_MAYBE(s, cppgcShim) {
+    auto result = kj::mv(KJ_ASSERT_NONNULL(s->wrappable));
+    s->wrappable = nullptr;
+    wrapper = nullptr;
+    cppgcShim = nullptr;
+    strongWrapper.Reset();
+    HeapTracer::getTracer(isolate).removeWrapper({}, *this);
+    return result;
+  } else {
+    return {};
   }
-  wrapper.Reset();
-}
-
-kj::Own<Wrappable> Wrappable::detachWrapperRef() {
-  return kj::mv(wrapperRef);
 }
 
 v8::Local<v8::Object> Wrappable::getHandle(v8::Isolate* isolate) {
@@ -52,20 +59,15 @@ void Wrappable::addStrongRef() {
   KJ_DREQUIRE(v8::Isolate::TryGetCurrent() != nullptr, "referencing wrapper without isolate lock");
   if (strongRefcount++ == 0) {
     // This object previously had no strong references, but now it has one.
-    if (wrapper.IsEmpty()) {
+    KJ_IF_MAYBE(w, wrapper) {
+      // Copy the traced reference into the strong reference.
+      v8::HandleScope scope(isolate);
+      strongWrapper.Reset(isolate, w->Get(isolate));
+    } else {
       // Since we have no JS wrapper, we're forced to recursively mark all references reachable
       // through this wrapper as strong.
       GcVisitor visitor(*this, nullptr);
       jsgVisitForGc(visitor);
-    } else {
-      // Mark the handle strong. V8 will find it and trace it.
-      //
-      // If a trace is already in-progress, V8 won't have registered this handle as a root at the
-      // start of the trace, because it wasn't strong then. That's OK: as long as the handle still
-      // exists and is strong when the trace cycle later enters its final pause, it'll be
-      // discovered and traced then. OTOH if the handle becomes weak again before that (and
-      // short-lived strong handles are common), then we can get away without tracing it.
-      wrapper.ClearWeak<Wrappable>();
     }
   }
 }
@@ -74,7 +76,7 @@ void Wrappable::removeStrongRef() {
               "destroying wrapper without isolate lock");
   if (--strongRefcount == 0) {
     // This was the last strong reference.
-    if (wrapper.IsEmpty()) {
+    if (wrapper == nullptr) {
       // We have no wrapper. We need to mark all references held by this object as weak.
       if (isolate != nullptr) {
         // But only if the current isolate isn't null. If strong ref count is zero,
@@ -85,9 +87,8 @@ void Wrappable::removeStrongRef() {
         jsgVisitForGc(visitor);
       }
     } else {
-      // Mark the handle weak, so that it only stays alive if reached via tracing or if JavaScript
-      // objects reference it.
-      setWeak();
+      // Just clear the strong ref.
+      strongWrapper.Reset();
     }
   }
 }
@@ -120,6 +121,7 @@ void Wrappable::traceFromV8(cppgc::Visitor& cppgcVisitor) {
     // get duplicate traces.
   } else {
     lastTraceId = traceId;
+    cppgcVisitor.Trace(KJ_ASSERT_NONNULL(wrapper));
     GcVisitor visitor(*this, cppgcVisitor);
     jsgVisitForGc(visitor);
   }
@@ -129,89 +131,35 @@ void Wrappable::attachWrapper(v8::Isolate* isolate,
                               v8::Local<v8::Object> object, bool needsGcTracing) {
   auto& tracer = HeapTracer::getTracer(isolate);
 
-  if (detached != NOT_DETACHED) {
-    // It appears that this Wrappable once had a wrapper attached, and then that wrapper was GC'd,
-    // but later on a wrapper was added again. This suggests a serious problem with our GC, in that
-    // it is collecting objects that are still reachable from JavaScript. However, we can usually
-    // continue operating even in the presence of such a bug: it'll only cause a real problem if
-    // a script has attached additional properites to the object in JavaScript and expects them
-    // to still be there later. This is relatively uncommon for scripts to do, though it does
-    // happen.
-#ifdef KJ_DEBUG
-    KJ_FAIL_ASSERT("Wrappable had wrapper collected and then re-added later");
-#else
-    // Don't crash in production. Also avoid spamming logs.
-    static bool alreadyWarned = false;
-    if (!alreadyWarned) {
-      kj::StringPtr collected;
-      switch (detached) {
-        case NOT_DETACHED:     collected = "NOT_DETACHED";     break;
-        case WHILE_SCAVENGING: collected = "WHILE_SCAVENGING"; break;
-        case WHILE_TRACING:    collected = "WHILE_TRACING";    break;
-        case OTHER:            collected = "OTHER";            break;
-      }
-      KJ_LOG(ERROR, "Wrappable had wrapper collected and then re-added later", collected,
-                    kj::getStackTrace(), lastTraceId, wrapper.getLastMarked(),
-                    detachedTraceId, tracer.currentTraceId());
-      alreadyWarned = true;
-    }
-#endif
-  }
+  KJ_REQUIRE(wrapper == nullptr);
+  KJ_REQUIRE(strongWrapper.IsEmpty());
 
-  KJ_REQUIRE(wrapper.IsEmpty());
-  wrapperRef = kj::addRef(*this);
-  wrapper.Reset(isolate, object);
+  wrapper = v8::TracedReference<v8::Object>(isolate, object);
   this->isolate = isolate;
 
+  // Add to list of objects to force-clean at isolate shutdown.
   tracer.addWrapper({}, *this);
 
   // Set up internal fields for a newly-allocated object.
   KJ_REQUIRE(object->InternalFieldCount() == Wrappable::INTERNAL_FIELD_COUNT);
   object->SetAlignedPointerInInternalField(WRAPPED_OBJECT_FIELD_INDEX, this);
 
+  // Allocate the cppgc shim.
   auto& cppgcAllocHandle = isolate->GetCppHeap()->GetAllocationHandle();
-
   auto cppgcShim = cppgc::MakeGarbageCollected<CppgcShim>(cppgcAllocHandle, *this);
+  this->cppgcShim = *cppgcShim;
 
   object->SetAlignedPointerInInternalField(CPPGC_SHIM_FIELD_INDEX, cppgcShim);
   object->SetAlignedPointerInInternalField(WRAPPABLE_TAG_FIELD_INDEX,
       const_cast<uint16_t*>(&WRAPPABLE_TAG));
 
-  if (lastTraceId == tracer.currentTraceId() || strongRefcount == 0) {
-    // Either:
-    // a) This object was reached during the most-recent trace cycle, but the wrapper wasn't
-    //    allocated yet.
-    // b) This object is currently only reachable from other JavaScript objects that themselves
-    //    have wrappers reachable only from JavaScript. (Note: As of this writing, this never
-    //    happens in practice since attachWrapper() is always called in cases where there is a
-    //    strong ref, typically on the stack.)
-    //
-    // In either case, it's important that we inform V8 that the wrapper cannot be scavenged, since
-    // it may be reachable via tracing. So, we must call tracer.mark(), which has the effect of
-    // initializing the TracedReference.
-    tracer.mark(wrapper, nullptr);
-  } else {
-    // This object is not currently reachable via GC tracing from other C++ objects (it was not
-    // reached during the most-recent cycle), therefore it does not need a v8::TracedReference
-    // reference. It's best that we do not create such a reference unless it is needed, because the
-    // presence of a TracedReference reference will make the object ineligible to be collected
-    // during scavenges, because embedder heap tracing does not occur during those. Most wrappers
-    // are only ever referenced from the JS heap, *not* from other C++ objects, therefore would
-    // never be reached by tracing anyway -- we would like for those objects to remain eligible for
-    // collection during scavenges.
-    //
-    // So, we will avoid initializing `tracedWrapper` until an object is first discovered to be
-    // reachable via tracing from another C++ object.
-  }
+  if (strongRefcount > 0) {
+    strongWrapper.Reset(isolate, object);
 
-  if (strongRefcount == 0) {
-    // This object has no untraced references, so we should make it weak. Note that any refs it
-    // transitively holds are already weak, so we don't need to visit.
-    setWeak();
-  } else {
     // This object has untraced references, but didn't have a wrapper. That means that any refs
     // transitively reachable through the reference are strong. Now that a wrapper exists, the
-    // refs will be traced when the wrapper is traced, so they need to be marked weak.
+    // refs will be traced when the wrapper is traced, so they should be converted to traced
+    // references. Performing a visitation pass will update them.
     GcVisitor visitor(*this, nullptr);
     jsgVisitForGc(visitor);
   }
@@ -244,26 +192,6 @@ void Wrappable::jsgVisitForGc(GcVisitor& visitor) {
   // Nothing; subclasses that need tracing will override.
 }
 
-void Wrappable::deleterPass1(const v8::WeakCallbackInfo<Wrappable>& data) {
-  // We are required to clear the handle immediately.
-  data.GetParameter()->resetWrapperHandle();
-
-  // But we cannot do anything else right now. In particular, deleting the object could lead to
-  // other V8 APIs being invoked, which is illegal right now. We must register a second-pass
-  // callback to do that.
-  data.SetSecondPassCallback(&deleterPass2);
-}
-
-void Wrappable::deleterPass2(const v8::WeakCallbackInfo<Wrappable>& data) {
-  // Detach the wrapper ref and let it be deleted. This possibly deletes the Wrappable, if it has
-  // no jsg::Refs left pointing at it from C++ objects.
-  data.GetParameter()->detachWrapperRef();
-}
-
-void Wrappable::setWeak() {
-  wrapper.SetWeak(this, &deleterPass1, v8::WeakCallbackType::kParameter);
-}
-
 void Wrappable::visitRef(GcVisitor& visitor, kj::Maybe<Wrappable&>& refParent, bool& refStrong) {
   KJ_IF_MAYBE(p, refParent) {
     KJ_ASSERT(p == &visitor.parent);
@@ -276,7 +204,6 @@ void Wrappable::visitRef(GcVisitor& visitor, kj::Maybe<Wrappable&>& refParent, b
   }
 
   // Make ref strength match the parent.
-  bool becameWeak = false;
   if (visitor.parent.strongRefcount > 0) {
     // This reference should be strong, because the parent has strong refs.
     //
@@ -296,33 +223,23 @@ void Wrappable::visitRef(GcVisitor& visitor, kj::Maybe<Wrappable&>& refParent, b
       // Ref transitions from strong to weak.
       refStrong = false;
       removeStrongRef();
-      becameWeak = true;
     }
   }
 
-  if (wrapper.IsEmpty()) {
-    if (lastTraceId != visitor.parent.lastTraceId) {
-      // Our wrapper hasn't been allocated yet, i.e. this object has never been directly visible to
-      // JavaScript. However, we might transitively hold reference to objects that do have wrappers,
-      // so we need to transitively trace to our children.
-      lastTraceId = visitor.parent.lastTraceId;
-      GcVisitor subVisitor(*this, visitor.cppgcVisitor);
-      jsgVisitForGc(subVisitor);
-    }
-  } else {
-    // Wrapper is non-empty, so `isolate` can't be null.
-    auto& tracer = HeapTracer::getTracer(isolate);
-
-    if (becameWeak || visitor.parent.lastTraceId == tracer.currentTraceId()) {
-      // Either:
-      // a) This reference newly became a weak reference. However, it is clearly reachable from
-      //    another object. Therefore, we must ensure that the TracedReference is initialized so
-      //    that V8 knows that this object cannot be collected during scavenging and must instead
-      //    wait for tracing. Marking will do this for us.
-      // b) The parent has already been traced during this cycle. Probably, this call to visitRef()
-      //    is actually a result of the parent being traced. So this is the usual case where we
-      //    need to mark.
-      tracer.mark(wrapper, visitor);
+  KJ_IF_MAYBE(cgv, visitor.cppgcVisitor) {
+    // We're visiting for the purpose of a GC trace.
+    KJ_IF_MAYBE(w, wrapper) {
+      cgv->Trace(*w);
+    } else {
+      // This object doesn't currently have a wrapper, so traces must transitively trace through
+      // it. However, as an optimization, we can skip the trace if we've already been traced in
+      // this trace pass.
+      auto& tracer = HeapTracer::getTracer(isolate);
+      if (lastTraceId != tracer.currentTraceId()) {
+        lastTraceId = tracer.currentTraceId();
+        GcVisitor subVisitor(*this, visitor.cppgcVisitor);
+        jsgVisitForGc(subVisitor);
+      }
     }
   }
 }

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -194,19 +194,8 @@ public:
   void removeWrapper(kj::Badge<Wrappable>, Wrappable& wrappable) { wrappers.remove(wrappable); }
   void clearWrappers();
 
-  void startScavenge() { scavenging = true; }
-  void endScavenge() { scavenging = false; }
-
-  void startTrace() { tracing = true; }
-  void endTrace() { tracing = false; }
-
-  bool isTracing() { return tracing; }
-  bool isScavenging() { return scavenging; }
-
 private:
   v8::Isolate* isolate;
-  bool scavenging = false;
-  bool tracing = false;
   kj::Vector<Wrappable*> wrappersToTrace;
 
   kj::List<Wrappable, &Wrappable::link> wrappers;

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -90,6 +90,26 @@ class Wrappable: public kj::Refcounted {
   // Wrappable and are not visible to GC tracing.
 
 public:
+  static constexpr uint INTERNAL_FIELD_COUNT = 2;
+  // Number of internal fields in a wrapper object.
+  //
+  // V8's EmbedderHeapTracer API imposes the following seemingly-arbitrary requirements on objects'
+  // internal fields:
+  // - The object has at least two internal fields (otherwise, it is ignored).
+  // - The first internal field is not null (otherwise, the object is ignored).
+  // - The object has an even number of internal fields (otherwise, DCHECK-failure).
+  // - Only the first two internal field values are reported to the tracing API.
+  //
+  // Right then, we'll allocate two fields. The first will point to the GC tracing callback
+  // (null if no tracing needed), the second will point to the object itself.
+
+  static constexpr uint WRAPPED_OBJECT_FIELD_INDEX = 1;
+  // Index of the internal field that points back to the `Wrappable`.
+
+  static constexpr uint NEEDS_TRACING_FIELD_INDEX = 0;
+  // Index of the internal field that must be non-null to convince EmbedderHeapTracer that the
+  // object needs tracing. The actual value is not relevant aside from nullness.
+
   void addStrongRef();
   void removeStrongRef();
 

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -222,13 +222,11 @@ private:
   friend class HeapTracer;
 };
 
-class HeapTracer final: public v8::EmbedderHeapTracer {
+class HeapTracer {
   // For historical reasons, this is actually implemented in setup.c++.
 
 public:
-  explicit HeapTracer(v8::Isolate* isolate): isolate(isolate) {
-    isolate->SetEmbedderHeapTracer(this);
-  }
+  explicit HeapTracer(v8::Isolate* isolate): isolate(isolate) {}
 
   ~HeapTracer() noexcept {
     // Destructor has to be noexcept because it inherits from a V8 type that has a noexcept
@@ -254,24 +252,14 @@ public:
   void startScavenge() { scavenging = true; }
   void endScavenge() { scavenging = false; }
 
-  void RegisterV8References(const std::vector<std::pair<void*, void*>>& internalFields) override;
-  void TracePrologue(TraceFlags flags) override;
-  bool AdvanceTracing(double deadlineMs) override;
-  bool IsTracingDone() override;
-  void TraceEpilogue(TraceSummary* trace_summary) override;
-  void EnterFinalPause(EmbedderStackState stackState) override;
-
-  bool isTracing() { return inTrace; }
+  bool isTracing() { return false; }
   bool isScavenging() { return scavenging; }
 
 private:
   v8::Isolate* isolate;
   uint traceId = 1;
-  bool inTrace = false;
-  bool inAdvanceTracing = false;
   bool scavenging = false;
   kj::Vector<Wrappable*> wrappersToTrace;
-  kj::Vector<v8::TracedReference<v8::Data>> referencesToMarkLater;
 
   kj::List<Wrappable, &Wrappable::link> wrappers;
   // List of all Wrappables for which a JavaScript wrapper exists.

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -157,12 +157,7 @@ private:
   // `wrapper`, to force it to stay alive. Otherwise, `strongWrapper` is empty.
 
   v8::Isolate* isolate = nullptr;
-  // Will be non-null if `wrapper` has ever been non-null or `lastTraceId` is non-zero.
-
-  uint lastTraceId = 0;
-  // Last GC trace in which this object was reached. 0 = never reached.
-  //
-  // Whenever this changes, a GC visitation must be executed to update outgoing refs.
+  // Will be non-null if `wrapper` has ever been non-null.
 
   uint strongRefcount = 0;
   // How many strong Ref<T>s point at this object, forcing the wrapper to stay alive even if GC
@@ -195,8 +190,6 @@ public:
 
   static HeapTracer& getTracer(v8::Isolate* isolate);
 
-  uint currentTraceId() { return traceId; }
-
   void addWrapper(kj::Badge<Wrappable>, Wrappable& wrappable) { wrappers.add(wrappable); }
   void removeWrapper(kj::Badge<Wrappable>, Wrappable& wrappable) { wrappers.remove(wrappable); }
   void clearWrappers();
@@ -204,11 +197,7 @@ public:
   void startScavenge() { scavenging = true; }
   void endScavenge() { scavenging = false; }
 
-  void startTrace() {
-    tracing = true;
-    ++traceId;
-    if (traceId == 0) traceId = 1;  // allow wrap-around but skip ID zero
-  }
+  void startTrace() { tracing = true; }
   void endTrace() { tracing = false; }
 
   bool isTracing() { return tracing; }
@@ -216,7 +205,6 @@ public:
 
 private:
   v8::Isolate* isolate;
-  uint traceId = 1;
   bool scavenging = false;
   bool tracing = false;
   kj::Vector<Wrappable*> wrappersToTrace;

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -190,6 +190,10 @@ public:
 
   static HeapTracer& getTracer(v8::Isolate* isolate);
 
+  static bool isInCppgcDestructor();
+  // Returns true if the current thread is currently executing the destructor of a CppgcShim
+  // object, which implies that we are collecting unreachable objects.
+
   void addWrapper(kj::Badge<Wrappable>, Wrappable& wrappable) { wrappers.add(wrappable); }
   void removeWrapper(kj::Badge<Wrappable>, Wrappable& wrappable) { wrappers.remove(wrappable); }
   void clearWrappers();

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -49,16 +49,6 @@ class Wrappable: public kj::Refcounted {
 public:
   static constexpr uint INTERNAL_FIELD_COUNT = 3;
   // Number of internal fields in a wrapper object.
-  //
-  // V8's EmbedderHeapTracer API imposes the following seemingly-arbitrary requirements on objects'
-  // internal fields:
-  // - The object has at least two internal fields (otherwise, it is ignored).
-  // - The first internal field is not null (otherwise, the object is ignored).
-  // - The object has an even number of internal fields (otherwise, DCHECK-failure).
-  // - Only the first two internal field values are reported to the tracing API.
-  //
-  // Right then, we'll allocate two fields. The first will point to the GC tracing callback
-  // (null if no tracing needed), the second will point to the object itself.
 
   static constexpr uint WRAPPED_OBJECT_FIELD_INDEX = 2;
   // Index of the internal field that points back to the `Wrappable`.

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -252,13 +252,21 @@ public:
   void startScavenge() { scavenging = true; }
   void endScavenge() { scavenging = false; }
 
-  bool isTracing() { return false; }
+  void startTrace() {
+    tracing = true;
+    ++traceId;
+    if (traceId == 0) traceId = 1;  // allow wrap-around but skip ID zero
+  }
+  void endTrace() { tracing = false; }
+
+  bool isTracing() { return tracing; }
   bool isScavenging() { return scavenging; }
 
 private:
   v8::Isolate* isolate;
   uint traceId = 1;
   bool scavenging = false;
+  bool tracing = false;
   kj::Vector<Wrappable*> wrappersToTrace;
 
   kj::List<Wrappable, &Wrappable::link> wrappers;

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -239,9 +239,7 @@ public:
   void destroy();
   // Call under isolate lock when shutting down isolate.
 
-  static HeapTracer& getTracer(v8::Isolate* isolate) {
-    return *reinterpret_cast<HeapTracer*>(isolate->GetEmbedderHeapTracer());
-  }
+  static HeapTracer& getTracer(v8::Isolate* isolate);
 
   uint currentTraceId() { return traceId; }
 


### PR DESCRIPTION
V8's `EmbedderHeapTracer` API is going away, and integration with cppgc is the replacement.

Compared to #171, this PR is much more conservative, only making the minimal changes necessary to move off the deprecated APIs before the deadline. #171, in contrast, proposes much deeper design changes to JSG's reference hierarchy. These design changes may have advantages, but I think we need to evaluate those advantages independently of the urgent need to switch APIs. Once this more conservative PR is landed, then we can consider broader design changes.

Additionally, I went ahead and implemented an optimization: I integrated with `EmbedderRootsHandler` to allow wrappers to be collected during minor GCs (aka "scavenges"). V8 has a trick here where it'll propose collecting any _unmodified_ API wrapper object that is no longer reachable from JavaScript. The object might still be reachable from the C++ side, but from that side we always have the ability to recreate the wrapper on-demand. If the application has actually modified the wrapper in some way, V8 detects that and will not consider the object a candidate for collection. This turns out to be a great fit for our lazy-wrapper design.

As of this writing, there are a few open questions marked with `TODO(now)` which I need to clarify with the V8 team.