### PR TITLE
Use externalized strings for built-in js/ts modules

### DIFF
--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -394,4 +394,23 @@ inline bool isFinite(double value) {
   return !(kj::isNaN(value) || value == kj::inf() || value == -kj::inf());
 }
 
+// ======================================================================================
+
+class Lock;
+
+v8::MaybeLocal<v8::String> newExternalOneByteString(Lock& js, kj::ArrayPtr<const char> buf);
+v8::MaybeLocal<v8::String> newExternalTwoByteString(Lock& js, kj::ArrayPtr<const uint16_t> buf);
+// Creates v8 Strings from buffers not on the v8 heap. These do not copy and do not
+// take ownership of the buf. The buf *must* point to a static constant with infinite
+// lifetime.
+//
+// It is important to understand that the OneByteString variant will interpret buf as
+// latin-1 rather than UTF-8, which is how KJ normally represents text. There is no
+// variation of external strings that support UTF-8 encoded bytes. To represent any
+// text outside of the Latin1 range, the two-byte (uint16_t) variant must be used.
+//
+// Note that these intentionally do not use the v8Str naming convention like the other
+// string methods because it needs to be absolutely clear that these use external buffers
+// that are not owned by the v8 heap.
+
 }  // namespace workerd::jsg


### PR DESCRIPTION
Uses externalized strings for built-in modules to avoid copying built-ins into every isolate's heap. Results in a significant reduction in memory use per isolate for built-ins.