### PR TITLE
Add action to block merging if PR labeled `needs-internal-pr`

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,16 @@
+# Based on https://www.neilmacy.co.uk/blog/github-action-to-block-merging
+name: "Internal PR Required"
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  InternalPRRequired:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for label
+        if: ${{ contains(github.event.*.labels.*.name, 'needs-internal-pr') }}
+        run: |
+          echo "Pull request is labeled as 'needs-internal-pr'"
+          echo "This workflow fails so the pull request cannot be merged"
+          exit 1


### PR DESCRIPTION
Adds a new github action that will block merging of a PR if it has the label `needs-internal-pr`. This is not a perfect solution, of course, but allows us to easily flag PRs that should not be landed without a corresponding Workers PR ready to go (which requires manual confirmation)

![image](https://user-images.githubusercontent.com/439929/205458170-288350c7-06f3-46b6-a444-993177c14ea5.png)
![image](https://user-images.githubusercontent.com/439929/205458249-d78e98b4-84dd-40f6-91b8-55dc127827c0.png)

