### PR TITLE
Update sockets to use new pipelining support in capnproto.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,10 +35,10 @@ rules_foreign_cc_dependencies()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "f2545a2de980f4de51b28ed305098964e4f4367faa8f70b0178cbc0851c407c4",
-    strip_prefix = "capnproto-capnproto-3e54cc2/c++",
+    sha256 = "523f41d27e7ae7aed2b176a63fc759a5dac095d93bf508d2d52ad4f75083d31b",
+    strip_prefix = "capnproto-capnproto-5dffa41/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/3e54cc22972658393cd430c5d5eac17d1c0a9fb7"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/5dffa41c2c63c7ce79a00059d5f93de5ca1eb4f0"],
 )
 
 http_archive(

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -9,52 +9,6 @@
 namespace workerd::api {
 
 
-class TCPConnectResponseImpl final: public kj::HttpService::ConnectResponse, public kj::Refcounted {
-public:
-  TCPConnectResponseImpl(kj::Own<kj::PromiseFulfiller<kj::HttpClient::ConnectResponse>> fulfiller)
-      : fulfiller(kj::mv(fulfiller)) {}
-
-  void setPromise(kj::Promise<void> promise) {
-    task = promise.eagerlyEvaluate([this](kj::Exception&& exception) {
-      if (fulfiller->isWaiting()) {
-        fulfiller->reject(kj::mv(exception));
-      } else {
-        kj::throwRecoverableException(kj::mv(exception));
-      }
-    });
-  }
-
-  kj::Own<kj::AsyncIoStream> accept(
-      uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers) override {
-    KJ_REQUIRE(statusCode >= 200 && statusCode < 300, "the statusCode must be 2xx for accept");
-
-    auto headersCopy = kj::heap(headers.clone());
-
-    auto pipe = kj::newTwoWayPipe();
-
-    fulfiller->fulfill(kj::HttpClient::ConnectResponse {
-      statusCode,
-      statusText,
-      headersCopy.get(),
-      pipe.ends[0].attach(kj::addRef(*this)),
-    });
-    return kj::mv(pipe.ends[1]);
-  }
-
-  kj::Own<kj::AsyncOutputStream> reject(
-      uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers,
-      kj::Maybe<uint64_t> expectedBodySize) override {
-    KJ_REQUIRE(statusCode < 200 || statusCode >= 300, "the statusCode must not be 2xx for reject.");
-    kj::throwRecoverableException(KJ_EXCEPTION(FAILED,
-        kj::str("jsg.Error: Connection rejected by proxy with HTTP code ", statusCode)));
-    KJ_UNREACHABLE;
-  }
-
-private:
-  kj::Own<kj::PromiseFulfiller<kj::HttpClient::ConnectResponse>> fulfiller;
-  kj::Promise<void> task = nullptr;
-};
-
 jsg::Ref<Socket> connectImplNoOutputLock(
     jsg::Lock& js, jsg::Ref<Fetcher> fetcher, kj::String address) {
   auto& ioContext = IoContext::current();
@@ -66,15 +20,15 @@ jsg::Ref<Socket> connectImplNoOutputLock(
   // TODO: Validate `address` is well formed. Do I need to use `parseAddress` here or is there
   // a better way?
 
-  // Set up the connection. This is similar to HttpClientAdapter::connect.
+  // Set up the connection.
   auto headers = kj::heap<kj::HttpHeaders>(ioContext.getHeaderTable());
-  auto paf = kj::newPromiseAndFulfiller<kj::HttpClient::ConnectResponse>();
-  auto tunnel = kj::refcounted<TCPConnectResponseImpl>(kj::mv(paf.fulfiller));
-  auto promise = client->connect(address, *headers, *tunnel)
-      .attach(kj::str(address), kj::mv(headers));
-  tunnel->setPromise(kj::mv(promise));
-  kj::Promise<kj::HttpClient::ConnectResponse> connResponse = paf.promise.attach(kj::mv(tunnel));
-  return jsg::alloc<Socket>(kj::mv(connResponse));
+  auto httpClient = kj::newHttpClient(*client);
+  auto request = httpClient->connect(address, *headers);
+  // TODO(soon): If `request.status` resolves to have a statusCode < 200 || >= 300, arrange for the
+  //   the Socket to throw an appropriate error. Right now in this circumstance,
+  //   `request.connection`'s operations will throw KJ exceptions which will be exposed to the
+  //   script as internal errors.
+  return jsg::alloc<Socket>(request.connection.attach(kj::mv(request.status)));
 }
 
 jsg::Ref<Socket> connectImpl(
@@ -93,31 +47,12 @@ jsg::Ref<Socket> connectImpl(
   return connectImplNoOutputLock(js, kj::mv(actualFetcher), kj::mv(address));
 }
 
-kj::Promise<kj::Own<kj::AsyncIoStream>> processConnection(
-    kj::Promise<kj::HttpClient::ConnectResponse> connectionPromise) {
-  return connectionPromise.then([](kj::HttpClient::ConnectResponse&& response)
-      -> kj::Own<kj::AsyncIoStream> {
-    KJ_REQUIRE(response.statusCode >= 200 && response.statusCode < 300,
-        "the statusCode must be 2xx for connect");
-    KJ_SWITCH_ONEOF(response.connectionOrBody) {
-      KJ_CASE_ONEOF(connection, kj::Own<kj::AsyncIoStream>) {
-        return kj::mv(connection);
-      }
-      KJ_CASE_ONEOF(body, kj::Own<kj::AsyncInputStream>) {
-        kj::throwRecoverableException(
-            KJ_EXCEPTION(FAILED, "jsg.Error: Could not establish proxy connection"));
-      }
-    }
-    KJ_UNREACHABLE;
-  });
-}
-
-InitData initialiseSocket(kj::Promise<kj::HttpClient::ConnectResponse> connectionPromise) {
+InitData initialiseSocket(kj::Promise<kj::Own<kj::AsyncIoStream>> connectionPromise) {
   auto& context = IoContext::current();
 
   // Initialise the readable/writable streams with a custom AsyncIoStream that waits for the
   // completion of `connectionPromise` before performing reads/writes.
-  auto stream = kj::refcounted<PipelinedAsyncIoStream>(processConnection(kj::mv(connectionPromise)));
+  auto stream = kj::refcounted<PipelinedAsyncIoStream>(kj::mv(connectionPromise));
   auto sysStreams = newSystemMultiStream(kj::addRef(*stream), StreamEncoding::IDENTITY, context);
 
   return {
@@ -128,7 +63,7 @@ InitData initialiseSocket(kj::Promise<kj::HttpClient::ConnectResponse> connectio
   };
 }
 
-Socket::Socket(kj::Promise<kj::HttpClient::ConnectResponse> connectionPromise) :
+Socket::Socket(kj::Promise<kj::Own<kj::AsyncIoStream>> connectionPromise) :
     Socket(initialiseSocket(kj::mv(connectionPromise))) {};
 
 jsg::Promise<void> Socket::close(jsg::Lock& js) {

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -77,7 +77,7 @@ public:
   Socket(InitData data)
       : readable(kj::mv(data.readable)), writable(kj::mv(data.writable)),
         closeFulfiller(kj::mv(data.closeFulfiller)) {};
-  Socket(kj::Promise<kj::HttpClient::ConnectResponse> connectionPromise);
+  Socket(kj::Promise<kj::Own<kj::AsyncIoStream>> connectionPromise);
 
   jsg::Ref<ReadableStream> getReadable() { return readable.addRef(); }
   jsg::Ref<WritableStream> getWritable() { return writable.addRef(); }

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -540,8 +540,9 @@ private:
     }
 
     kj::Promise<void> connect(
-        kj::StringPtr host, const kj::HttpHeaders& headers, ConnectResponse& tunnel) override {
-      return parent.serviceAdapter->connect(host, headers, tunnel);
+        kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& connection,
+        ConnectResponse& tunnel) override {
+      return parent.serviceAdapter->connect(host, headers, connection, tunnel);
     }
 
     void prewarm(kj::StringPtr url) override {}
@@ -656,12 +657,13 @@ public:
   }
 
   kj::Promise<void> connect(
-      kj::StringPtr host, const kj::HttpHeaders& headers, ConnectResponse& tunnel) override {
+      kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& connection,
+      ConnectResponse& tunnel) override {
     // This code is hit when the global `connect` function is called in a JS worker script.
     // It represents a proxy-less TCP connection, which means we can simply defer the handling of
     // the connection to the service adapter (likely NetworkHttpClient). Its behaviour will be to
     // connect directly to the host over TCP.
-    return serviceAdapter->connect(host, headers, tunnel);
+    return serviceAdapter->connect(host, headers, connection, tunnel);
   }
 
 private:


### PR DESCRIPTION
This is a simplified version of https://github.com/cloudflare/workerd/pull/200, containing just the diff required to be able to merge https://github.com/capnproto/capnproto/pull/1579.