### PR TITLE
Add sendBatch definition to @cloudflare/workers-types

### DIFF
--- a/types/defines/queues.d.ts
+++ b/types/defines/queues.d.ts
@@ -35,6 +35,16 @@ interface MessageBatch<Body = unknown> {
 }
 
 /**
+ * A wrapper class used to structure message batches.
+ */
+type MessageSendRequest<Body = unknown> = {
+  /**
+   * The body of the message.
+   */
+  body: Body
+}
+
+/**
  * A binding that allows a producer to send messages to a Queue.
  */
 interface Queue<Body = any> {
@@ -44,4 +54,11 @@ interface Queue<Body = any> {
    * @returns A promise that resolves when the message is confirmed to be written to disk.
    */
   send(message: Body): Promise<void>;
+
+  /**
+   * Sends a batch of messages to the Queue.
+   * @param messages Each item in the array must be supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types). A batch can contain up to 100 messages, though items are limited to 128 KB each, and the total size of the array cannot exceed 256 KB.
+   * @returns A promise that resolves when the messages are confirmed to be written to disk.
+   */
+  sendBatch(messages: Iterable<MessageSendRequest<Body>>): Promise<void>;
 }

--- a/types/defines/queues.d.ts
+++ b/types/defines/queues.d.ts
@@ -57,7 +57,7 @@ interface Queue<Body = any> {
 
   /**
    * Sends a batch of messages to the Queue.
-   * @param messages Each item in the array must be supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types). A batch can contain up to 100 messages, though items are limited to 128 KB each, and the total size of the array cannot exceed 256 KB.
+   * @param messages Each item in the input must be supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types). A batch can contain up to 100 messages, though items are limited to 128 KB each, and the total size of the array cannot exceed 256 KB.
    * @returns A promise that resolves when the messages are confirmed to be written to disk.
    */
   sendBatch(messages: Iterable<MessageSendRequest<Body>>): Promise<void>;


### PR DESCRIPTION
This commit adds relevant docstring to sendBatch method in Queues API, which was previously not supported.