### PR TITLE
Refactor out ReadableStreamJsSource

### DIFF
--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -906,15 +906,8 @@ jsg::Promise<kj::Array<kj::byte>> R2Bucket::GetResult::arrayBuffer(jsg::Lock& js
     JSG_REQUIRE(!body->isDisturbed(), TypeError, "Body has already been used. "
       "It can only be used once. Use tee() first if you need to read it twice.");
 
-    auto source = body->removeSource(js);
-
-    // TODO(cleanup): We use awaitIoLegacy() because ReadableStreamSource is responsible for
-    //   registering its own pending events. Someday ReadableStreamSource should return
-    //   jsg::Promise instead of kj::Promise.
     auto& context = IoContext::current();
-    return context.awaitIoLegacy(
-        source->readAllBytes(context.getLimitEnforcer().getBufferingLimit())
-            .attach(kj::mv(source)));
+    return body->getController().readAllBytes(js, context.getLimitEnforcer().getBufferingLimit());
   });
 }
 
@@ -945,14 +938,7 @@ jsg::Promise<kj::String> R2Bucket::GetResult::text(jsg::Lock& js) {
       }
     }
 
-    auto source = body->removeSource(js);
-
-    // TODO(cleanup): We use awaitIoLegacy() because ReadableStreamSource is responsible for
-    //   registering its own pending events. Someday ReadableStreamSource should return
-    //   jsg::Promise instead of kj::Promise.
-    return context.awaitIoLegacy(
-        source->readAllText(context.getLimitEnforcer().getBufferingLimit())
-            .attach(kj::mv(source)));
+    return body->getController().readAllText(js, context.getLimitEnforcer().getBufferingLimit());
   });
 }
 

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -45,8 +45,8 @@ public:
 
   virtual kj::Maybe<uint64_t> tryGetLength(StreamEncoding encoding);
 
-  kj::Promise<kj::Array<byte>> readAllBytes(uint64_t limit = kj::maxValue);
-  kj::Promise<kj::String> readAllText(uint64_t limit = kj::maxValue);
+  kj::Promise<kj::Array<byte>> readAllBytes(uint64_t limit);
+  kj::Promise<kj::String> readAllText(uint64_t limit);
 
   virtual void cancel(kj::Exception reason);
   // Hook to inform this ReadableStreamSource that the ReadableStream has been canceled. This only
@@ -147,7 +147,7 @@ public:
 
   Tee tee(jsg::Lock& js) override;
 
-  kj::Maybe<kj::Own<ReadableStreamSource>> removeSource(jsg::Lock& js) override;
+  kj::Maybe<kj::Own<ReadableStreamSource>> removeSource(jsg::Lock& js);
 
   bool isClosedOrErrored() const override {
     return state.is<StreamStates::Closed>() || state.is<StreamStates::Errored>();
@@ -165,6 +165,11 @@ public:
   kj::Maybe<PipeController&> tryPipeLock(jsg::Ref<WritableStream> destination) override;
 
   void visitForGc(jsg::GcVisitor& visitor) override;
+
+  jsg::Promise<kj::Array<byte>> readAllBytes(jsg::Lock& js, uint64_t limit) override;
+  jsg::Promise<kj::String> readAllText(jsg::Lock& js, uint64_t limit) override;
+
+  kj::Maybe<uint64_t> tryGetLength(StreamEncoding encoding) override;
 
 private:
   void doCancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason);
@@ -208,6 +213,7 @@ private:
   bool disturbed = false;
   bool readPending = false;
 
+  friend class ReadableStream;
   friend class WritableStreamInternalController;
   friend class PipeLocked;
 };


### PR DESCRIPTION
The `ReadableStreamJsSource` class was a bit overly complicated. This PR allows us to eliminate it entirely through a number of key refactors.

* We eliminate all uses of `removeSource` and direct uses of `ReadableStreamSource` outside of internal streams. This means moving methods like `tryGetLength(...)` and `pumpTo` directly onto `ReadableStream`.
* We refactor `readAllText()` and `readAllBytes()` to use pure JS read loops when reading from JS-backed streams. This eliminates the expensive pass through `ReadableStreamJsSource` that we were performing (and thus bouncing in an out of the event loop / isolate lock on every read.
* We refactor the pumpTo implementation for JS-backed streams to be more efficient, using default reads for both default and byob JS-backed streams.
* We clarify the ownership of the destination of the `WritableStreamSink` destination for pipeTo by passing ownership into the `pumpTo` operation.
