### PR TITLE
Properly handle JS exceptions in promise rejection callback.

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1036,7 +1036,12 @@ Worker::Isolate::Isolate(kj::Own<ApiIsolate> apiIsolateParam,
     // do something like unwrap(isolate->GetCurrentContext()).emitPromiseRejection(). However, JSG
     // doesn't currently provide an easy way to do this.
     if (IoContext::hasCurrent()) {
-      IoContext::current().reportPromiseRejectEvent(message);
+      try {
+        IoContext::current().reportPromiseRejectEvent(message);
+      } catch (jsg::JsExceptionThrown&) {
+        // V8 expects us to just return.
+        return;
+      }
     }
   });
 }


### PR DESCRIPTION
We already catch exceptions generated by the app itself, but under certain circumstances, our calls to the V8 API in this callback can throw.

I am actually not even sure how to trigger such an exception but there was one odd crash report in production.