### PR TITLE
Implement missing Worker::Isolate::SubrequestClient::connect.

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3418,6 +3418,13 @@ kj::Promise<void> Worker::Isolate::SubrequestClient::request(
   });
 }
 
+kj::Promise<void> Worker::Isolate::SubrequestClient::connect(
+    kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& connection,
+    kj::HttpService::ConnectResponse& tunnel) {
+  // TODO(someday): EW-7116 Figure out how to represent TCP connections in the devtools network tab.
+  return inner->connect(host, headers, connection, tunnel);
+}
+
 // TODO(someday): Log other kinds of subrequests?
 void Worker::Isolate::SubrequestClient::prewarm(kj::StringPtr url) {
   inner->prewarm(url);

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -408,10 +408,12 @@ private:
           contentEncodingHeaderId(contentEncodingHeaderId),
           requestMetrics(kj::addRef(requestMetrics)) {}
     KJ_DISALLOW_COPY(SubrequestClient);
-
     kj::Promise<void> request(
         kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
         kj::AsyncInputStream& requestBody, kj::HttpService::Response& response) override;
+    kj::Promise<void> connect(
+        kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& connection,
+        kj::HttpService::ConnectResponse& tunnel) override;
     void prewarm(kj::StringPtr url) override;
     kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override;
     kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override;


### PR DESCRIPTION
When testing via fiddle this code path was hit. 

@kentonv should `connect` be implemented in all classes which extend WorkerInterface/HttpService? if not are there any other `connect` codepaths which are likely to be hit in production and so should be implemented?