### PR TITLE
Enforce WorkerInterface::connect to be implemented in all subclasses.

### DIFF
--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -315,6 +315,11 @@ kj::Promise<void> WorkerEntrypoint::request(
   });
 }
 
+kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host, const kj::HttpHeaders& headers,
+    kj::AsyncIoStream& connection, ConnectResponse& response) {
+  KJ_UNIMPLEMENTED("Incoming CONNECT on a worker not supported");
+}
+
 void WorkerEntrypoint::prewarm(kj::StringPtr url) {
   // Nothing to do, the worker is already loaded.
 

--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -49,6 +49,8 @@ public:
   kj::Promise<void> request(
       kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
       kj::AsyncInputStream& requestBody, Response& response) override;
+  kj::Promise<void> connect(kj::StringPtr host, const kj::HttpHeaders& headers,
+      kj::AsyncIoStream& connection, ConnectResponse& response) override;
   void prewarm(kj::StringPtr url) override;
   kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override;
   kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override;

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -38,6 +38,14 @@ public:
   //   more resources to be dropped when merely proxying a request. However, it means we would no
   //   longer be immplementing kj::HttpService. But maybe that doesn't matter too much in practice.
 
+  virtual kj::Promise<void> connect(kj::StringPtr host,
+                                    const kj::HttpHeaders& headers,
+                                    kj::AsyncIoStream& connection,
+                                    ConnectResponse& response) = 0;
+  // This is the same as the inherited HttpService::connect(), but we override it to be
+  // pure-virtual to force all subclasses of WorkerInterface to implement it explicitly rather
+  // than get the default implementation which throws an unimplemented exception.
+
   virtual void prewarm(kj::StringPtr url) = 0;
   // Hints that this worker will likely be invoked in the near future, so should be warmed up now.
   // This method should also call `prewarm()` on any subsequent pipeline stages that are expected
@@ -136,6 +144,8 @@ public:
   kj::Promise<void> request(
       kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
       kj::AsyncInputStream& requestBody, Response& response) override;
+  kj::Promise<void> connect(kj::StringPtr host, const kj::HttpHeaders& headers,
+      kj::AsyncIoStream& connection, ConnectResponse& response) override;
   void prewarm(kj::StringPtr url) override;
   kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override;
   kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override;

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -872,6 +872,10 @@ private:
     }
   }
 
+  kj::Promise<void> connect(kj::StringPtr host, const kj::HttpHeaders& headers,
+      kj::AsyncIoStream& connection, kj::HttpService::ConnectResponse& response) override {
+    throwUnsupported();
+  }
   void prewarm(kj::StringPtr url) override {}
   kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override {
     throwUnsupported();


### PR DESCRIPTION
Not 100% sure whether I understood the purpose of each of these classes. In particular, is there anything special I need to do in the RevokableWorkerInterface implementation?

### Test Plan

Just checking that build succeeds:

```
$ bazel build //src/ew/tests:sockets/sockets-tcp-test.ew-test-bin
```