### PR TITLE
Refactors Sockets closed promise handling.

### DIFF
--- a/src/workerd/api/system-streams.h
+++ b/src/workerd/api/system-streams.h
@@ -38,11 +38,8 @@ struct SystemMultiStream {
 };
 
 SystemMultiStream newSystemMultiStream(
-    kj::Own<PipelinedAsyncIoStream> rc, StreamEncoding encoding,
-    IoContext& context = IoContext::current());
-// A combo ReadableStreamSource and WritableStreamSink which automatically decodes/encodes its
-// underlying stream. This function takes `PipelinedAsyncIoStream` because it needs a refcounted
-// stream.
+    kj::Own<kj::AsyncIoStream> stream, IoContext& context = IoContext::current());
+// A combo ReadableStreamSource and WritableStreamSink.
 
 StreamEncoding getContentEncoding(IoContext& context, const kj::HttpHeaders& headers,
                                   Response::BodyEncoding bodyEncoding = Response::BodyEncoding::AUTO);


### PR DESCRIPTION
This is a more basic version of https://github.com/cloudflare/workerd/pull/205. The main change in semantics here is that the `closed` promise will now have any errors propagated to it (from the readable/writable stream close calls). The rest is a major refactor to reuse the existing `newPromisedStream`.

### Test Plan

```
$ bazel test //src/ew/tests:sockets/sockets-tcp-test.ew-test-bin --config=asan --test_timeout 5
```