### PR TITLE
Fix `tsl` typo and comment about address validation

### DIFF
--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -62,8 +62,8 @@ private:
 };
 
 struct SocketOptions {
-  bool tsl; // TODO(later): TCP socket options need to be implemented.
-  JSG_STRUCT(tsl);
+  jsg::Unimplemented tls; // TODO(later): TCP socket options need to be implemented.
+  JSG_STRUCT(tls);
 };
 
 struct InitData {


### PR DESCRIPTION
This addresses my unresolved comments from #162.