### PR TITLE
Hide `connect()` function entirely when the flag is not enabled.

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -418,7 +418,9 @@ public:
     JSG_NESTED_TYPE(FixedLengthStream);
     JSG_NESTED_TYPE(IdentityTransformStream);
     JSG_NESTED_TYPE(HTMLRewriter);
-    JSG_METHOD(connect);
+    if (flags.getTcpSocketsSupport()) {
+      JSG_METHOD(connect);
+    }
 
     JSG_TS_ROOT();
     JSG_TS_DEFINE(

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -454,9 +454,11 @@ public:
   jsg::Promise<void> delete_(jsg::Lock& js, kj::String url,
       CompatibilityFlags::Reader featureFlags);
 
-  JSG_RESOURCE_TYPE(Fetcher) {
+  JSG_RESOURCE_TYPE(Fetcher, CompatibilityFlags::Reader flags) {
     JSG_METHOD(fetch);
-    JSG_METHOD(connect);
+    if (flags.getTcpSocketsSupport()) {
+      JSG_METHOD(connect);
+    }
 
     JSG_METHOD(get);
     JSG_METHOD(put);

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -34,9 +34,9 @@ jsg::Ref<Socket> connectImplNoOutputLock(
 jsg::Ref<Socket> connectImpl(
     jsg::Lock& js, kj::Maybe<jsg::Ref<Fetcher>> fetcher, kj::String address,
     CompatibilityFlags::Reader featureFlags) {
-  if (!featureFlags.getTcpSocketsSupport()) {
-    JSG_FAIL_REQUIRE(TypeError, "TCP Sockets API not enabled.");
-  }
+  // `connect()` should be hidden when the feature flag is off, so we shouldn't even get here.
+  KJ_ASSERT(featureFlags.getTcpSocketsSupport());
+
   jsg::Ref<Fetcher> actualFetcher = nullptr;
   KJ_IF_MAYBE(f, fetcher) {
     actualFetcher = kj::mv(*f);


### PR DESCRIPTION
This resolves my comment from #180.