### PR TITLE
Cleanup: Take out jsg error throwing functions

### DIFF
--- a/src/workerd/api/r2-rpc.c++
+++ b/src/workerd/api/r2-rpc.c++
@@ -39,20 +39,20 @@ kj::Maybe<uint> R2Result::v4ErrorCode() {
 void R2Result::throwIfError(kj::StringPtr action,
     const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
   KJ_IF_MAYBE(e, toThrow) {
-    auto isolate = IoContext::current().getCurrentLock().getIsolate();
     // TODO(soon): Once jsg::JsPromise exists, switch to using that to tunnel out the exception. As
     // it stands today, unfortunately, all we can send back to the user is a message. R2Error isn't
     // a registered type in the runtime. When reenabling, make sure to update overrides/r2.d.ts to
     // reenable the type
 #if 0
+    auto isolate = IoContext::current().getCurrentLock().getIsolate();
     (*e)->action = kj::str(action);
     (*e)->errorForStack = v8::Global<v8::Object>(
         isolate, v8::Exception::Error(jsg::v8Str(isolate, "")).As<v8::Object>());
     isolate->ThrowException(errorType.wrapRef(kj::mv(*e)));
     throw jsg::JsExceptionThrown();
 #else
-    jsg::throwError(isolate, kj::str(action, ": ", (e)->get()->getMessage(), " (", (*e)->v4Code,
-        ')'));
+    JSG_FAIL_REQUIRE(Error, kj::str(
+        action, ": ", (e)->get()->getMessage(), " (", (*e)->v4Code, ')'));
 #endif
   }
 }

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <kj/async.h>
-#include <workerd/io/actor-storage.capnp.h>
+#include <workerd/io/actor-storage.h>
 #include <workerd/io/io-context.h>
 #include <kj/one-of.h>
 #include <kj/map.h>

--- a/src/workerd/io/actor-storage.c++
+++ b/src/workerd/io/actor-storage.c++
@@ -1,0 +1,28 @@
+#include "actor-storage.h"
+
+#include <workerd/jsg/jsg.h>
+
+namespace workerd {
+void ActorStorageLimits::checkMaxKeySize(kj::StringPtr key) {
+  // It's tempting to put the key in this message, but that key could be surprisingly large so let's
+  // return a simple message.
+  JSG_REQUIRE(key.size() <= MAX_KEY_SIZE, RangeError, kj::str(
+      "Keys cannot be larger than ", MAX_KEY_SIZE, " bytes. ",
+      "A key of size ", key.size(), " was provided."));
+}
+
+void ActorStorageLimits::checkMaxValueSize(kj::StringPtr, kj::ArrayPtr<kj::byte> value) {
+  // It's tempting to put the key in this message, but that key could be surprisingly large so let's
+  // return a simple message.
+  JSG_REQUIRE(value.size() <= ENFORCED_MAX_VALUE_SIZE, RangeError, kj::str(
+      "Values cannot be larger than ", ADVERTISED_MAX_VALUE_SIZE, " bytes. ",
+      "A value of size ", value.size(), " was provided."));
+}
+
+void ActorStorageLimits::checkMaxPairsCount(size_t count) {
+  JSG_REQUIRE(count <= rpc::ActorStorage::MAX_KEYS, RangeError, kj::str(
+      "Maximum number of key value pairs is ", rpc::ActorStorage::MAX_KEYS, ". ",
+      count, " pairs were provided."));
+}
+
+} // namespace workerd

--- a/src/workerd/io/actor-storage.capnp
+++ b/src/workerd/io/actor-storage.capnp
@@ -62,11 +62,9 @@ interface ActorStorage @0xd7759d7fc87c08e4 {
   }
 
   const maxKeys :UInt32 = 128;
-  # The maximum number of keys that clients should be allowed to modify in a single transaction.
-  # This should be enforced both for explicit transactions and the implicit transactions created
-  # by calls to put or delete that provide multiple keys.
-  #
-  # TODO(someday): Do we still need this limit?
+  # The maximum number of keys that clients should be allowed to modify in a single storage
+  # operation. This should be enforced for operations that access or modify multiple keys. This
+  # limit will not be enforced upon the total count of keys involved in explicit transactions.
 
   const renameLimit :UInt32 = 1000;
   # The maximum number of keys in a rename() operation.

--- a/src/workerd/io/actor-storage.h
+++ b/src/workerd/io/actor-storage.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <kj/common.h>
+#include <kj/string.h>
+
+#include <workerd/io/actor-storage.capnp.h>
+
+namespace workerd {
+class ActorStorageLimits {
+// This class wraps common values and functions for interacting durable object (actor) storage.
+public:
+  static constexpr size_t ADVERTISED_MAX_VALUE_SIZE = 128 * 1024;
+  static constexpr size_t ENFORCED_MAX_VALUE_SIZE = ADVERTISED_MAX_VALUE_SIZE + 34;
+  // We grant some extra cushion on top of the advertised max size in order
+  // to avoid penalizing people for pushing right up against the advertised size.
+  // The v8 serialization method we use can add a few extra bytes for its type tag
+  // and other metadata, such as the length of a string or number of items in an
+  // array. The most important cases (where users are most likely to try to
+  // intentionally run right up against the limit) are Strings and ArrayBuffers,
+  // which each get 4 bytes of metadata attached when encoded. We throw a little
+  // extra on just for future proofing and an abundance of caution.
+  //
+  // If you're curious why we add 34 bytes of cushion -- we used to add 32, but
+  // then started writing v8 serialization headers, which are 2 bytes, and didn't
+  // want to stop accepting values that we accepted before writing headers.
+
+  static constexpr size_t MAX_KEY_SIZE = 2048;
+
+  static void checkMaxKeySize(kj::StringPtr key);
+  static void checkMaxValueSize(kj::StringPtr key, kj::ArrayPtr<kj::byte> value);
+  static void checkMaxPairsCount(size_t count);
+};
+
+} // namespace workerd

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -41,15 +41,6 @@ const char* JsExceptionThrown::what() const noexcept {
   return whatBuffer.cStr();
 }
 
-void throwRangeError(v8::Isolate* isolate, kj::StringPtr message) {
-  isolate->ThrowException(v8::Exception::RangeError(v8Str(isolate, message)));
-  throw JsExceptionThrown();
-}
-
-void throwError(v8::Isolate* isolate, kj::StringPtr message) {
-  isolate->ThrowException(v8::Exception::Error(v8Str(isolate, message)));
-  throw JsExceptionThrown();
-}
 void Data::destroy() {
   assertInvariant();
   if (isolate != nullptr) {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -133,12 +133,6 @@ private:
 // case an exception is thrown. Writing code that deals with maybes is cumbersome and error-prone
 // compared to C++ exceptions.
 
-[[noreturn]] void throwRangeError(v8::Isolate* isolate, kj::StringPtr message);
-// Convenience method to throw a RangeError.
-
-[[noreturn]] void throwError(v8::Isolate* isolate, kj::StringPtr message);
-// Convenience method to throw a generic Error.
-
 // =======================================================================================
 // Macros for declaring type glue.
 

--- a/src/workerd/jsg/promise-test.c++
+++ b/src/workerd/jsg/promise-test.c++
@@ -37,7 +37,7 @@ struct PromiseContext: public Object {
 
   void catchIt(Lock& js, Promise<int> promise) {
     promise.catch_(js, [](Lock& js, Value value) -> int {
-      throwError(js.v8Isolate, kj::str(value.getHandle(js.v8Isolate)));
+      JSG_FAIL_REQUIRE(Error, kj::str(value.getHandle(js.v8Isolate)));
     }).then(js, [](Lock& js, int i) {
       KJ_FAIL_REQUIRE("shouldn't get here");
       return kj::str("nope");


### PR DESCRIPTION
These functions are no longer preferred in favor of `JSG_[FAIL_]REQUIRE()`. Luckily, they were only in limited use in the durable object and r2 code.