### PR TITLE
Rename nodejs compat flag to remove version

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -231,11 +231,11 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Sec-WebSocket-Extensions header, or setting the header to the empty string to explicitly
   # request that no compression be used.
 
-  nodeJs18CompatExperimental @21 :Bool
-      $compatEnableFlag("nodejs_18_compat_experimental")
+  nodeJsCompat @21 :Bool
+      $compatEnableFlag("nodejs_compat")
       $experimental;
   # Experimental, do not use.
-  # Enables nodejs 18 compat imports in the application.
+  # Enables nodejs compat imports in the application.
   # This is currently a work in progress mechanism that is not yet available for use in workerd.
   # WARNING: IT WILL BREAK in the future. Do not ignore this warning.
 


### PR DESCRIPTION
We don't want to bake the version or "Experimental" flag in the name.