### PR TITLE
new event info type email

### DIFF
--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -41,6 +41,9 @@ kj::Maybe<TraceItem::EventInfo> TraceItem::getEvent() {
       KJ_CASE_ONEOF(queue, Trace::QueueEventInfo) {
         return kj::Maybe(jsg::alloc<QueueEventInfo>(kj::addRef(*trace), queue));
       }
+      KJ_CASE_ONEOF(email, Trace::EmailEventInfo) {
+        return kj::Maybe(jsg::alloc<EmailEventInfo>(kj::addRef(*trace), email));
+      }
       KJ_CASE_ONEOF(custom, Trace::CustomEventInfo) {
         return kj::Maybe(jsg::alloc<CustomEventInfo>(kj::addRef(*trace), custom));
       }
@@ -186,6 +189,21 @@ kj::StringPtr TraceItem::QueueEventInfo::getQueueName() {
 
 uint32_t TraceItem::QueueEventInfo::getBatchSize() {
   return eventInfo.batchSize;
+}
+
+TraceItem::EmailEventInfo::EmailEventInfo(kj::Own<Trace> trace,
+    const Trace::EmailEventInfo& eventInfo) : trace(kj::mv(trace)), eventInfo(eventInfo) {}
+
+kj::StringPtr TraceItem::EmailEventInfo::getMailFrom() {
+  return eventInfo.mailFrom;
+}
+
+kj::StringPtr TraceItem::EmailEventInfo::getRcptTo() {
+  return eventInfo.rcptTo;
+}
+
+uint32_t TraceItem::EmailEventInfo::getRawSize() {
+  return eventInfo.rawSize;
 }
 
 TraceItem::CustomEventInfo::CustomEventInfo(kj::Own<Trace> trace,

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -51,12 +51,14 @@ public:
   class ScheduledEventInfo;
   class AlarmEventInfo;
   class QueueEventInfo;
+  class EmailEventInfo;
   class CustomEventInfo;
 
   explicit TraceItem(kj::Own<Trace> trace);
 
   typedef kj::OneOf<jsg::Ref<FetchEventInfo>, jsg::Ref<ScheduledEventInfo>,
-      jsg::Ref<AlarmEventInfo>, jsg::Ref<QueueEventInfo>, jsg::Ref<CustomEventInfo>> EventInfo;
+      jsg::Ref<AlarmEventInfo>, jsg::Ref<QueueEventInfo>,
+      jsg::Ref<EmailEventInfo>, jsg::Ref<CustomEventInfo>> EventInfo;
   kj::Maybe<EventInfo> getEvent();
   // TODO(someday): support more event types (trace, email) via kj::OneOf.
   kj::Maybe<double> getEventTimestamp();
@@ -209,6 +211,25 @@ private:
   const Trace::QueueEventInfo& eventInfo;
 };
 
+class TraceItem::EmailEventInfo final: public jsg::Object {
+public:
+  explicit EmailEventInfo(kj::Own<Trace> trace, const Trace::EmailEventInfo& eventInfo);
+
+  kj::StringPtr getMailFrom();
+  kj::StringPtr getRcptTo();
+  uint32_t getRawSize();
+
+  JSG_RESOURCE_TYPE(EmailEventInfo) {
+    JSG_READONLY_PROTOTYPE_PROPERTY(mailFrom, getMailFrom);
+    JSG_READONLY_PROTOTYPE_PROPERTY(rcptTo, getRcptTo);
+    JSG_READONLY_PROTOTYPE_PROPERTY(rawSize, getRawSize);
+  }
+
+private:
+  kj::Own<Trace> trace;
+  const Trace::EmailEventInfo& eventInfo;
+};
+
 class TraceItem::CustomEventInfo final: public jsg::Object {
 public:
   explicit CustomEventInfo(kj::Own<Trace> trace, const Trace::CustomEventInfo& eventInfo);
@@ -320,6 +341,7 @@ private:
   api::TraceItem::CustomEventInfo,            \
   api::TraceItem::ScheduledEventInfo,         \
   api::TraceItem::QueueEventInfo,             \
+  api::TraceItem::EmailEventInfo,             \
   api::TraceItem::FetchEventInfo,             \
   api::TraceItem::FetchEventInfo::Request,    \
   api::TraceItem::FetchEventInfo::Response,   \

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -112,6 +112,18 @@ public:
     void copyTo(rpc::Trace::QueueEventInfo::Builder builder);
   };
 
+  class EmailEventInfo {
+  public:
+    explicit EmailEventInfo(kj::String mailFrom, kj::String rcptTo, uint32_t rawSize);
+    EmailEventInfo(rpc::Trace::EmailEventInfo::Reader reader);
+
+    kj::String mailFrom;
+    kj::String rcptTo;
+    uint32_t rawSize;
+
+    void copyTo(rpc::Trace::EmailEventInfo::Builder builder);
+  };
+
   class CustomEventInfo {
   public:
     explicit CustomEventInfo() {};
@@ -172,7 +184,7 @@ public:
   // We treat the origin value as "unset".
 
   typedef kj::OneOf<FetchEventInfo, ScheduledEventInfo, AlarmEventInfo, QueueEventInfo,
-          CustomEventInfo> EventInfo;
+          EmailEventInfo, CustomEventInfo> EventInfo;
   kj::Maybe<EventInfo> eventInfo;
   // TODO(someday): Support more event types.
   // TODO(someday): Work out what sort of information we may want to convey about the parent

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -49,6 +49,7 @@ struct Trace @0x8e8d911203762d34 {
     alarm @9 :AlarmEventInfo;
     queue @15 :QueueEventInfo;
     custom @13 :CustomEventInfo;
+    email @16 :EmailEventInfo;
   }
   struct FetchEventInfo {
     method @0 :HttpMethod;
@@ -74,6 +75,12 @@ struct Trace @0x8e8d911203762d34 {
   struct QueueEventInfo {
     queueName @0 :Text;
     batchSize @1 :UInt32;
+  }
+
+  struct EmailEventInfo {
+    mailFrom @0 :Text;
+    rcptTo @1 :Text;
+    rawSize @2 :UInt32;
   }
 
   struct CustomEventInfo {}


### PR DESCRIPTION
Added new event info type for email events. This will contain the from, to and raw size of the email.