### PR TITLE
Use `kj::uint` to fix macOS builds

### DIFF
--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -23,6 +23,7 @@ namespace kj {
 namespace workerd {
 
 using kj::byte;
+using kj::uint;
 
 typedef rpc::Trace::Log::Level LogLevel;
 


### PR DESCRIPTION
#141 introduced some new uses of `uint` without a corresponding `using kj::uint;`. [`Build & Release` CI](https://github.com/cloudflare/workerd/actions/workflows/release.yml) has been failing since.