### PR TITLE
remove lto clang override

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,11 +24,7 @@ build --cxxopt='-Wno-ignored-qualifiers' --host_cxxopt='-Wno-ignored-qualifiers'
 build --cxxopt='-Wno-ambiguous-reversed-operator' --host_cxxopt='-Wno-ambiguous-reversed-operator'
 
 
-# optimized LTO build
-# You'll need the following packages installed: clang-15 libc++-15-dev libc++abi-15-dev
-build:thin-lto --action_env=BAZEL_COMPILER=clang-15
-build:thin-lto --action_env=CC=clang-15
-build:thin-lto --action_env=CXX=clang++-15
+# optimized LTO build. you'll need a fairly recent clang for this to work
 build:thin-lto -c opt
 build:thin-lto --cxxopt='-flto=thin'
 build:thin-lto --linkopt='-flto=thin'

--- a/README.md
+++ b/README.md
@@ -93,9 +93,7 @@ bazel clean --expunge
 
 The cache will now be cleaned and you can try building again.
 
-#### Thin LTO build
-
-If you have clang-15 and libc++-15 packages installed you can build a higher performant release
+If you have a fairly recent clang packages installed you can build a more performant release
 version of workerd:
 
 ```


### PR DESCRIPTION
tcmalloc doesn't build with clang-15 because it matches compiler against "clang" string and decides it is being built by gcc. (you can argue it is bazel's problem)

There's no better way but to symlink /usr/bin/clang and clang++ to recent clang version.