### PR TITLE
fix content-type param extraction

### DIFF
--- a/src/workerd/api/util-test.c++
+++ b/src/workerd/api/util-test.c++
@@ -15,6 +15,16 @@ void expectUnredacted(kj::StringPtr input) {
   KJ_EXPECT(redactUrl(input) == input, redactUrl(input), input);
 }
 
+void expectCTypeParameter(kj::StringPtr input, kj::StringPtr param, kj::StringPtr expected) {
+  auto res = readContentTypeParameter(input, param);
+  KJ_ASSERT_NONNULL(res);
+
+  KJ_IF_MAYBE(valueArr, res) {
+    auto value = kj::str(*valueArr);
+    KJ_EXPECT(value == expected, value, expected);
+  }
+}
+
 KJ_TEST("redactUrl can detect hex ids") {
   // no id:
   expectUnredacted(""_kj);
@@ -51,6 +61,45 @@ KJ_TEST("redactUrl can detect base64 ids") {
 
   // not enough digits:
   expectUnredacted("https://domain/IThinkIShallNeverSee0/x"_kj);
+}
+
+KJ_TEST("readContentTypeParameter can fetch boundary parameter") {
+
+  // normal
+  expectCTypeParameter(
+    "multipart/form-data; boundary=\"__boundary__\""_kj,
+    "boundary"_kj,
+    "__boundary__"_kj
+  );
+
+  // multiple params
+  expectCTypeParameter(
+    "multipart/form-data; charset=utf-8; boundary=\"__boundary__\""_kj,
+    "boundary"_kj,
+    "__boundary__"_kj
+  );
+
+ // param name inside value of other param
+  expectCTypeParameter(
+    "multipart/form-data; charset=\"boundary=;\"; boundary=\"__boundary__\""_kj,
+    "boundary"_kj,
+    "__boundary__"_kj
+  );
+
+  // ensure param is not found
+  auto res = readContentTypeParameter(
+    "multipart/form-data; charset=\"boundary=;\"; boundary=\"__boundary__\""_kj,
+    "boundary1"_kj
+  );
+  KJ_ASSERT(res == nullptr);
+
+  // no quotes
+  expectCTypeParameter(
+    "multipart/form-data; charset=\"boundary=;\"; boundary=__boundary__"_kj,
+    "boundary"_kj,
+    "__boundary__"_kj
+  );
+
 }
 
 }  // namespace

--- a/src/workerd/api/util.c++
+++ b/src/workerd/api/util.c++
@@ -66,34 +66,69 @@ void parseQueryString(kj::Vector<kj::Url::QueryParam>& query, kj::ArrayPtr<const
   }
 }
 
-kj::Maybe<kj::ArrayPtr<const char>> readContentTypeParameter(kj::StringPtr contentType,
+kj::Maybe<kj::Array<char>> readContentTypeParameter(kj::StringPtr contentType,
                                                              kj::StringPtr param) {
   KJ_IF_MAYBE(semiColon, contentType.findFirst(';')) {
+    // Get to the parameters
     contentType = contentType.slice(*semiColon + 1);
-    while (contentType.startsWith(" ")) {
-      contentType = contentType.slice(1);
-    }
 
     // The attribute name of a MIME type parameter is always case-insensitive. See definition of
     // the attribute production rule in https://tools.ietf.org/html/rfc2045#page-29
     auto lowerContentType = toLower(kj::str(contentType));
+    kj::StringPtr leftover = lowerContentType.cStr();
     auto lowerParam = toLower(kj::str(param));
-    if (!lowerContentType.startsWith(lowerParam)) return nullptr;
 
-    contentType = contentType.slice(param.size());
-    if (!contentType.startsWith("=")) return nullptr;
-    contentType = contentType.slice(1);
-
-    if (contentType.size() == 0) return nullptr;
-    bool quoted = contentType[0] == '"';
-
-    if (quoted) {
-      contentType = contentType.slice(1);
-      KJ_IF_MAYBE(endQuote, contentType.findFirst('"')) {
-        return contentType.slice(0, *endQuote);
+    while(true) {
+      while (leftover.startsWith(" ")) {
+        leftover = leftover.slice(1);
       }
-    } else {
-      return contentType.slice(0, contentType.size());
+
+      KJ_IF_MAYBE(equal, leftover.findFirst('=')) {
+        // Handle parameter
+        auto name = leftover.slice(0, *equal);
+        auto valueStart = *equal + 1;
+        kj::ArrayPtr<const char> value = nullptr;
+
+        if (leftover[valueStart] == '"') {
+          // parameter value surrounded by quotes
+          KJ_IF_MAYBE(valueEnd, leftover.slice(valueStart + 1).findFirst('"')) {
+            value = leftover.slice(valueStart + 1, valueStart + 1 + *valueEnd);
+            // skip name, =, value and quotes
+            leftover = leftover.slice(name.size() + 1 + value.size() + 2);
+            if (leftover.startsWith(";")) {
+              leftover = leftover.slice(1);
+            }
+          } else {
+            // invalid value, no closing "
+            break;
+          }
+
+        } else {
+          // parameter value with no quotes, just glob until the next ;
+          KJ_IF_MAYBE(valueEnd, leftover.findFirst(';')) {
+            value = leftover.slice(valueStart, *valueEnd);
+            leftover = leftover.slice(*valueEnd + 1);
+          } else {
+            // there's nothing else
+            value = leftover.slice(valueStart);
+            leftover = leftover.slice(leftover.size());
+          }
+        }
+
+        // have we got it?
+        if (name == lowerParam) {
+          auto hValue = kj::heapArray(value);
+          return kj::mv(hValue);
+        }
+      } else {
+        // skip to next parameter
+        KJ_IF_MAYBE(nextParam, leftover.findFirst(';')) {
+          leftover = leftover.slice(*nextParam + 1);
+        } else {
+          // we are done and we didn't find the parameter
+          break;
+        }
+      }
     }
   }
 

--- a/src/workerd/api/util.h
+++ b/src/workerd/api/util.h
@@ -46,7 +46,7 @@ void parseQueryString(kj::Vector<kj::Url::QueryParam>& query, kj::ArrayPtr<const
 //
 // TODO(cleanup): Would be really nice to move this to kj-url.
 
-kj::Maybe<kj::ArrayPtr<const char>> readContentTypeParameter(kj::StringPtr contentType,
+kj::Maybe<kj::Array<char>> readContentTypeParameter(kj::StringPtr contentType,
                                                              kj::StringPtr param);
 // Given the value of a Content-Type header, returns the value of a single expected parameter.
 // For example:


### PR DESCRIPTION
Handle scenario where the content-type header has
multiple params.