### PR TITLE
Bump compatibility date to `2023-01-15` to trigger release

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -8,7 +8,7 @@ using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("workerd");
 $Cxx.allowCancellation;
 
-const supportedCompatibilityDate :Text = "2022-11-08";
+const supportedCompatibilityDate :Text = "2023-01-15";
 # Newest compatibility date that can safely be set using code compiled from this repo. Trying to
 # run a Worker with a newer compatibility date than this will fail.
 #


### PR DESCRIPTION
As per https://github.com/cloudflare/workerd/blob/main/RELEASE.md, this PR bumps the supported compatibility date to trigger a GitHub/npm `workerd` release.