### PR TITLE
macos: Allow compiling on catalina to ventura

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -253,6 +253,7 @@ git_repository(
         "//:patches/v8/0003-Make-icudata-target-public.patch",
         "//:patches/v8/0004-Add-ArrayBuffer-MaybeNew.patch",
         "//:patches/v8/0005-Revert-bazel-Add-hide-symbols-from-release-fast-buil.patch",
+        "//:patches/v8/0006-bazel-Allow-compiling-on-macOS-catalina-and-ventura.patch",
     ],
 )
 

--- a/patches/v8/0006-bazel-Allow-compiling-on-macOS-catalina-and-ventura.patch
+++ b/patches/v8/0006-bazel-Allow-compiling-on-macOS-catalina-and-ventura.patch
@@ -1,0 +1,35 @@
+From 79e1d8e03c54f2b1fa1795ad5383fb0c7a94e742 Mon Sep 17 00:00:00 2001
+From: Dhi Aurrahman <dio@rockybars.com>
+Date: Thu, 27 Oct 2022 12:45:05 +0700
+Subject: [PATCH] [bazel] Allow compiling on macOS catalina and ventura
+
+Signed-off-by: Dhi Aurrahman <dio@rockybars.com>
+---
+ bazel/defs.bzl | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/bazel/defs.bzl b/bazel/defs.bzl
+index e957c0fad3..b557471eba 100644
+--- a/bazel/defs.bzl
++++ b/bazel/defs.bzl
+@@ -151,6 +151,18 @@ def _default_args():
+                 "-fno-integrated-as",
+             ],
+             "//conditions:default": [],
++        }) + select({
++            "@v8//bazel/config:is_macos": [
++                # The clang available on macOS Catalina has a warning that isn't clean on v8 code.
++                # The warning doesn't show up with more recent clangs, so disable it for now.
++                "-Wno-range-loop-analysis",
++
++                # To supress warning on deprecated declaration on v8 code:
++                # src/base/platform/platform-darwin.cc:56:22:
++                # 'getsectdatafromheader_64' is deprecated: first deprecated in macOS 13.0.
++                "-Wno-deprecated-declarations",
++            ],
++            "//conditions:default": [],
+         }),
+         includes = ["include"],
+         linkopts = select({
+--
+2.39.0


### PR DESCRIPTION
This patch adds a patch to allow building workerd on macOS Catalina to Ventura.

Fix https://github.com/cloudflare/workerd/issues/45

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>