### PR TITLE
Redirect spec flag

### DIFF
--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -13,6 +13,7 @@
 #include "form-data.h"
 #include "web-socket.h"
 #include "url.h"
+#include "url-standard.h"
 #include "blob.h"
 #include <workerd/io/compatibility-date.capnp.h>
 
@@ -784,7 +785,7 @@ public:
   //     an Optional, so we need an inner Maybe to inhibit string coercion to Body::Initializer.
 
   static jsg::Ref<Response> redirect(
-      jsg::Lock& js, kj::String url, jsg::Optional<int> status, CompatibilityFlags::Reader flags);
+      jsg::Lock& js, jsg::UsvString url, jsg::Optional<int> status, CompatibilityFlags::Reader flags);
   // Constructs a redirection response. `status` must be a redirect status if given, otherwise it
   // defaults to 302 (technically a non-conformity, but both Chrome and Firefox use this default).
   //

--- a/src/workerd/api/url-standard-test.c++
+++ b/src/workerd/api/url-standard-test.c++
@@ -447,6 +447,16 @@ KJ_TEST("Minimal URL Parse - Not special (data URL)") {
   KJ_ASSERT(!record.special);
 }
 
+KJ_TEST("Minimal URL Parse - unknown scheme") {
+  auto record = KJ_ASSERT_NONNULL(URL::parse(jsg::usv("com.tapbots.Ivory.219:/request_token?code=8")));
+
+  KJ_ASSERT(record.scheme == jsg::usv("com.tapbots.ivory.219"));
+  auto& path = KJ_ASSERT_NONNULL(record.path.tryGet<kj::Array<jsg::UsvString>>());
+  KJ_ASSERT(path.size() == 1);
+  KJ_ASSERT(path[0] == jsg::usv("request_token"));
+  KJ_ASSERT(!record.special);
+}
+
 KJ_TEST("Special scheme URLS") {
   jsg::UsvString tests[] = {
     jsg::usv("http://example.org"),

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -245,4 +245,13 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Enables TCP sockets in workerd.
   # These are still under development and therefore subject to change.
   # WARNING: DO NOT depend on this feature as its API is still subject to change.
+
+  specCompliantResponseRedirect @23 :Bool
+      $compatEnableDate("2023-03-14")
+      $compatEnableFlag("response_redirect_url_standard")
+      $compatDisableFlag("response_redirect_url_original");
+  # The original URL implementation based on kj::Url is not compliant with the
+  # WHATWG URL Standard, leading to a number of issues reported by users. Unfortunately,
+  # the specCompliantUrl flag did not contemplate the redirect usage. This flag is
+  # specifically about the usage in a redirect().
 }


### PR DESCRIPTION
Added a new flag to enable the use of spec compliant URL parsing when doing a redirect. There was a previous flag to enable the use of this new class but it was not used when calling the redirect() method, hence the need for a new flag.