### PR TITLE
Allow an isolate to have a simple random uuid

### DIFF
--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -359,4 +359,21 @@ KJ_TEST("Test JSG_CALLABLE") {
 }
 
 }  // namespace
+
+// ========================================================================================
+
+struct IsolateUuidContext: public Object {
+  JSG_RESOURCE_TYPE(IsolateUuidContext) {}
+};
+JSG_DECLARE_ISOLATE_TYPE(IsolateUuidIsolate, IsolateUuidContext);
+
+KJ_TEST("jsg::Lock getUuid") {
+  IsolateUuidIsolate isolate(v8System);
+  IsolateUuidIsolate::Lock lock(isolate);
+  // Returns the same value
+  KJ_ASSERT(lock.getUuid() == lock.getUuid());
+  KJ_ASSERT(isolate.getUuid() == lock.getUuid());
+  KJ_ASSERT(lock.getUuid().size() == 36);
+}
+
 }  // namespace workerd::jsg::test

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -173,6 +173,10 @@ void Lock::requestGcForTesting() const {
     v8::Isolate::GarbageCollectionType::kFullGarbageCollection);
 }
 
+kj::StringPtr Lock::getUuid() const {
+  return IsolateBase::from(v8Isolate).getUuid();
+}
+
 v8::Local<v8::Private> Lock::getPrivateSymbolFor(Lock::PrivateSymbols symbol) {
   return IsolateBase::from(v8Isolate).getPrivateSymbolFor(symbol);
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2017,6 +2017,10 @@ public:
   // it will throw. If a need for a minor GC is needed look at the call in jsg.c++ and the
   // implementation in setup.c++. Use responsibly.
 
+  kj::StringPtr getUuid() const;
+  // Returns a random UUID for this isolate instance. This is largely intended for logging and
+  // diagnostic purposes.
+
 #define V(name, _) name,
   enum PrivateSymbols {
     JSG_PRIVATE_SYMBOLS(V)

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -9,6 +9,7 @@
 
 #include "setup.h"
 #include "async-context.h"
+#include <workerd/util/uuid.h>
 #include <cxxabi.h>
 #include "libplatform/libplatform.h"
 #include <ucontext.h>
@@ -639,6 +640,12 @@ kj::Maybe<kj::StringPtr> getJsStackTrace(void* ucontext, kj::ArrayPtr<char> scra
 
   *pos = '\0';
   return kj::StringPtr(scratch.begin(), pos - scratch.begin());
+}
+
+kj::StringPtr IsolateBase::getUuid() {
+  // Lazily create a random UUID for this isolate.
+  KJ_IF_MAYBE(u, uuid) { return *u; }
+  return uuid.emplace(randomUUID(nullptr));
 }
 
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -106,6 +106,9 @@ public:
 
   v8::Local<v8::Private> getPrivateSymbolFor(Lock::PrivateSymbols symbol);
 
+  kj::StringPtr getUuid();
+  // Returns a random UUID for this isolate instance.
+
 private:
   template <typename TypeWrapper>
   friend class Isolate;
@@ -136,6 +139,7 @@ private:
 
   const V8System& system;
   v8::Isolate* ptr;
+  kj::Maybe<kj::String> uuid;
   bool evalAllowed = false;
   bool captureThrowsAsRejections = false;
   // The Web Platform API specifications require that any API that returns a JavaScript Promise


### PR DESCRIPTION
The `jsg::Lock::getUuid()` will lazily create a random uuid for the
isolate instance. It is expected that this will primarily be used for
logging/diagnostics in DO cases. The uuid is generated lazily so there
is zero cost if the uuid is never used.

( Prompted by a chat with @bcaimano )

Another option would be to just log the memory address of the isolate itself but the requirement here is that the uniqueness be relatively guaranteed for the lifetime of the process, which we can't guarantee with the pointer address. We could also use a simple counter but that would likely require a lock. lazily creating the uuid here seems Good Enough (tm).