### PR TITLE
Simplify and refine async context tracking

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -496,7 +496,8 @@ void ServiceWorkerGlobalScope::queueMicrotask(
     v8::Local<v8::Function> task) {
   // TODO(later): It currently does not appear as if v8 attaches the continuation embedder data
   // to microtasks scheduled using EnqueueMicrotask, so we have to wrap in order to propagate
-  // the context to those.
+  // the context to those. Once V8 is fixed to correctly associate continuation data with
+  // microtasks automatically, we can remove this workaround.
   KJ_IF_MAYBE(context, jsg::AsyncContextFrame::current(js)) {
     task = context->wrap(js, task);
   }

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -105,8 +105,6 @@ ServiceWorkerGlobalScope::ServiceWorkerGlobalScope(v8::Isolate* isolate)
                 jsg::Value value) {
           // If async context tracking is enabled, then we need to ensure that we enter the frame
           // associated with the promise before we invoke the unhandled rejection callback handling.
-          jsg::AsyncContextFrame::Scope scope(js,
-              jsg::AsyncContextFrame::tryGetContext(js, promise));
           auto ev = jsg::alloc<PromiseRejectionEvent>(event, kj::mv(promise), kj::mv(value));
           dispatchEventImpl(js, kj::mv(ev));
         }) {}
@@ -496,6 +494,9 @@ v8::Local<v8::String> ServiceWorkerGlobalScope::atob(kj::String data, v8::Isolat
 void ServiceWorkerGlobalScope::queueMicrotask(
     jsg::Lock& js,
     v8::Local<v8::Function> task) {
+  // TODO(later): It currently does not appear as if v8 attaches the continuation embedder data
+  // to microtasks scheduled using EnqueueMicrotask, so we have to wrap in order to propagate
+  // the context to those.
   KJ_IF_MAYBE(context, jsg::AsyncContextFrame::current(js)) {
     task = context->wrap(js, task);
   }

--- a/src/workerd/api/node/async-hooks.h
+++ b/src/workerd/api/node/async-hooks.h
@@ -194,8 +194,16 @@ public:
     }
   }
 
+  kj::Maybe<jsg::AsyncContextFrame&> getFrame();
+  // Returns the jsg::AsyncContextFrame captured when the AsyncResource was created,
+  // if any.
+
 private:
-  kj::Own<jsg::AsyncContextFrame> frame;
+  kj::Maybe<jsg::Ref<jsg::AsyncContextFrame>> frame;
+
+  inline void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(frame);
+  }
 };
 
 class AsyncHooksModule final: public jsg::Object {

--- a/src/workerd/jsg/README.md
+++ b/src/workerd/jsg/README.md
@@ -1515,11 +1515,10 @@ Context Frame.
 
 ```cpp
 jsg::Lock& js = ...;
-kj::Own<jsg::AsyncContextFrame> frame = kj::addRef(jsg::AsyncResource::current(js));
 
 // enter the async resource scope:
 {
-  jsg::AsyncContextFrame::Scope asyncScope(js, *frame);
+  jsg::AsyncContextFrame::Scope asyncScope(js, jsg::AsyncResource::current(js));
   // run some code synchronously...
 }
 // The async scope will exit automatically...

--- a/src/workerd/jsg/README.md
+++ b/src/workerd/jsg/README.md
@@ -1484,7 +1484,7 @@ JSG provides a mechanism for rudimentary async context tracking to support the i
 of async local storage. This is provided by the `workerd::jsg::AsyncContextFrame` class defined in
 `src/workerd/jsg/async-context.h`.
 
-`AsyncContextFrame`s form a stack. For every `v8::Isolate` there is always a root frame.
+`AsyncContextFrame`s form a logical stack. For every `v8::Isolate` there is always a root frame.
 "Entering" a frame means pushing it to the top of the stack, making it "current". Exiting
 a frame means popping it back off the top of the stack.
 
@@ -1510,39 +1510,43 @@ als.run(123, () => scheduler.wait(10)).then(() => {
 console.log(als.getStore());  // undefined
 ```
 
-Any type can act as an async resource by acquiring a reference to the current Async
-Context Frame.
+Within C++, any type can act as an async resource by acquiring a reference to the current `jsg::AsyncContextFrame`.
 
 ```cpp
 jsg::Lock& js = ...;
 
-// enter the async resource scope:
+auto maybeAsyncContext = jsg::AsyncContextFrame::current(js);
+                   // or jsg::AsyncContextFrame::currentRef(js) to get a jsg::Ref
+
+// enter the async resource scope whenever necessary...
 {
-  jsg::AsyncContextFrame::Scope asyncScope(js, jsg::AsyncResource::current(js));
-  // run some code synchronously...
+  jsg::AsyncContextFrame::Scope asyncScope(js, maybeAsyncContext);
+  // run some code synchronously that requires the async context
 }
 // The async scope will exit automatically...
 ```
 
-The `jsg::AsyncResource::StorageScope` can be used to temporarily set the stored value
-associated with a given storage key in the current AsyncResource's storage context:
+Within C++, The `jsg::AsyncContextFrame::StorageScope` can be used to temporarily set the stored
+value associated with a given storage key in a new storage context independently of the Node.js API:
 
-```js
-class MyStorageKey: public jsg::StorageKey {
-  // ...
-}
-
+```cpp
 jsg::Lock& js = ...
 jsg::Value value = ...
 
-// The storage key must be kj::Refcounted. References to the key will be retained
-// by any AsyncResources that are created within the storage scope.
-kj::Own<MyStorageKey> key = kj::refcounted<MyStorageKey>();
+// The storage key must be kj::Refcounted.
+kj::Own<AsyncContextFrame::StorageKey> key =
+    kj::refcounted<AsyncContextFrame::StorageKey>();
+// When you're done with the storage key and know it will not be reused,
+// reset it to clear the storage cell.
+KJ_DEFER(key->reset());
 
 {
-  jsg::AsyncResource::StorageScope(js, *key, value);
-  // run some code synchronously
+  jsg::AsyncContextFrame::StorageScope(js, *key, value);
+  // run some code synchronously. The relevant parts of the code
+  // will capture the current async context as necessary.
 }
-// The storage cell will be automatically reset to the previous value
+
+// The storage cell will be automatically reset to the previous context
 // with the scope exits.
 ```
+

--- a/src/workerd/jsg/async-context.c++
+++ b/src/workerd/jsg/async-context.c++
@@ -8,51 +8,24 @@
 
 namespace workerd::jsg {
 
-namespace {
-kj::Maybe<AsyncContextFrame&> tryGetContextFrame(
-    v8::Isolate* isolate,
-    v8::Local<v8::Value> handle) {
-  // Gets the held AsyncContextFrame from the opaque wrappable but does not consume it.
-  KJ_IF_MAYBE(wrappable, Wrappable::tryUnwrapOpaque(isolate, handle)) {
-    AsyncContextFrame* frame = dynamic_cast<AsyncContextFrame*>(wrappable);
-    KJ_ASSERT(frame != nullptr);
-    return *frame;
-  }
-  return nullptr;
-}
-
-}  // namespace
-
-AsyncContextFrame::AsyncContextFrame(IsolateBase& isolate)
-    : isolate(isolate) {}
-
-AsyncContextFrame::AsyncContextFrame(
-    Lock& js,
-    kj::Maybe<AsyncContextFrame&> maybeParent,
-    kj::Maybe<StorageEntry> maybeStorageEntry)
-    : AsyncContextFrame(IsolateBase::from(js.v8Isolate)) {
+AsyncContextFrame::AsyncContextFrame(Lock& js, StorageEntry storageEntry)
+    : isolate(IsolateBase::from(js.v8Isolate)) {
   // Lazily enables the hooks for async context tracking.
   isolate.setAsyncContextTrackingEnabled();
 
-  // Propagate the storage context of the parent frame to this newly created frame.
-  const auto propagate = [&](AsyncContextFrame& parent) {
-    parent.storage.eraseAll([](const auto& entry) { return entry.key->isDead(); });
-    for (auto& entry : parent.storage) {
+  KJ_IF_MAYBE(frame, current(js)) {
+    // Propagate the storage context of the current frame (if any).
+    // If current(js) returns nullptr, we assume we're in the root
+    // frame and there is no storage to propagate.
+    frame->storage.eraseAll([](const auto& entry) { return entry.key->isDead(); });
+    for (auto& entry : frame->storage) {
       storage.insert(entry.clone(js));
     }
-
-    KJ_IF_MAYBE(entry, maybeStorageEntry) {
-      storage.upsert(kj::mv(*entry), [](StorageEntry& existing, StorageEntry&& row) mutable {
-        existing.value = kj::mv(row.value);
-      });
-    }
-  };
-
-  KJ_IF_MAYBE(parent, maybeParent) {
-    propagate(*parent);
-  } else {
-    propagate(current(js));
   }
+
+  storage.upsert(kj::mv(storageEntry), [](StorageEntry& existing, StorageEntry&& row) mutable {
+    existing.value = kj::mv(row.value);
+  });
 }
 
 kj::Maybe<AsyncContextFrame&> AsyncContextFrame::tryGetContext(
@@ -61,8 +34,13 @@ kj::Maybe<AsyncContextFrame&> AsyncContextFrame::tryGetContext(
   auto handle = js.getPrivateSymbolFor(Lock::PrivateSymbols::ASYNC_CONTEXT);
   // We do not use the normal unwrapOpaque here since that would consume the wrapped
   // value, and we need to be able to unwrap multiple times.
-  return tryGetContextFrame(js.v8Isolate,
-      check(promise->GetPrivate(js.v8Isolate->GetCurrentContext(), handle)));
+  auto ref = check(promise->GetPrivate(js.v8Isolate->GetCurrentContext(), handle));
+  KJ_IF_MAYBE(wrappable, Wrappable::tryUnwrapOpaque(js.v8Isolate, ref)) {
+    AsyncContextFrame* frame = dynamic_cast<AsyncContextFrame*>(wrappable);
+    KJ_ASSERT(frame != nullptr);
+    return *frame;
+  }
+  return nullptr;
 }
 
 kj::Maybe<AsyncContextFrame&> AsyncContextFrame::tryGetContext(
@@ -71,31 +49,45 @@ kj::Maybe<AsyncContextFrame&> AsyncContextFrame::tryGetContext(
   return tryGetContext(js, promise.getHandle(js));
 }
 
-AsyncContextFrame& AsyncContextFrame::current(Lock& js) {
+kj::Maybe<AsyncContextFrame&> AsyncContextFrame::current(Lock& js) {
   auto& isolateBase = IsolateBase::from(js.v8Isolate);
   if (isolateBase.asyncFrameStack.size() == 0) {
-    return *isolateBase.getRootAsyncContext();
+    return nullptr;
   }
-  return *isolateBase.asyncFrameStack.back();
+  KJ_SWITCH_ONEOF(isolateBase.asyncFrameStack.back()) {
+    KJ_CASE_ONEOF(frame, AsyncContextFrame*) {
+      return *frame;
+    }
+    KJ_CASE_ONEOF(root, IsolateBase::RootAsyncContextFrame) {
+      // In this case, the logical root frame has been pushed onto the
+      // top of the stack. This effectively means that no storage context
+      // is active, so we just return nullptr.
+      return nullptr;
+    }
+  }
+  KJ_UNREACHABLE;
 }
 
-Ref<AsyncContextFrame> AsyncContextFrame::create(
-    Lock& js,
-    kj::Maybe<AsyncContextFrame&> maybeParent,
-    kj::Maybe<StorageEntry> maybeStorageEntry) {
-  return alloc<AsyncContextFrame>(js, maybeParent, kj::mv(maybeStorageEntry));
+Ref<AsyncContextFrame> AsyncContextFrame::create(Lock& js, StorageEntry storageEntry) {
+  return alloc<AsyncContextFrame>(js, kj::mv(storageEntry));
+}
+
+v8::Local<v8::Function> AsyncContextFrame::wrap(
+    Lock& js, V8Ref<v8::Function>& fn,
+    kj::Maybe<v8::Local<v8::Value>> thisArg) {
+  return wrap(js, fn.getHandle(js), thisArg);
 }
 
 v8::Local<v8::Function> AsyncContextFrame::wrap(
     Lock& js,
     v8::Local<v8::Function> fn,
-    kj::Maybe<AsyncContextFrame&> maybeFrame,
     kj::Maybe<v8::Local<v8::Value>> thisArg) {
   auto isolate = js.v8Isolate;
   auto context = isolate->GetCurrentContext();
+
   return js.wrapReturningFunction(context, JSG_VISITABLE_LAMBDA(
       (
-        frame = Ref(kj::addRef(AsyncContextFrame::current(js))),
+        frame = JSG_THIS,
         thisArg = js.v8Ref(thisArg.orDefault(context->Global())),
         fn = js.v8Ref(fn)
       ),
@@ -109,25 +101,45 @@ v8::Local<v8::Function> AsyncContextFrame::wrap(
       argv.add(args[n]);
     }
 
-    AsyncContextFrame::Scope scope(js, *frame);
+    AsyncContextFrame::Scope scope(js, *frame.get());
     v8::Local<v8::Value> result;
     return check(function->Call(context, thisArg.getHandle(js), args.Length(), argv.begin()));
   }));
 }
 
-void AsyncContextFrame::attachContext(
+v8::Local<v8::Function> AsyncContextFrame::wrapRoot(
     Lock& js,
-    v8::Local<v8::Promise> promise,
-    kj::Maybe<AsyncContextFrame&> maybeFrame) {
+    v8::Local<v8::Function> fn,
+    kj::Maybe<v8::Local<v8::Value>> thisArg) {
+  auto isolate = js.v8Isolate;
+  auto context = isolate->GetCurrentContext();
+
+  return js.wrapReturningFunction(context, JSG_VISITABLE_LAMBDA(
+      (
+        thisArg = js.v8Ref(thisArg.orDefault(context->Global())),
+        fn = js.v8Ref(fn)
+      ),
+      (thisArg, fn),
+      (Lock& js, const v8::FunctionCallbackInfo<v8::Value>& args) {
+    auto function = fn.getHandle(js);
+    auto context = js.v8Isolate->GetCurrentContext();
+
+    kj::Vector<v8::Local<v8::Value>> argv(args.Length());
+    for (int n = 0; n < args.Length(); n++) {
+      argv.add(args[n]);
+    }
+
+    AsyncContextFrame::Scope scope(js, nullptr);
+    v8::Local<v8::Value> result;
+    return check(function->Call(context, thisArg.getHandle(js), args.Length(), argv.begin()));
+  }));
+}
+
+void AsyncContextFrame::attachContext(Lock& js, v8::Local<v8::Promise> promise) {
   auto handle = js.getPrivateSymbolFor(Lock::PrivateSymbols::ASYNC_CONTEXT);
   auto context = js.v8Isolate->GetCurrentContext();
-
   KJ_DASSERT(!check(promise->HasPrivate(context, handle)));
-
-  // Otherwise, we have to create an opaque wrapper holding a ref to the current frame
-  // because we do not have the option of using an internal field with promises.
-  auto frame = kj::addRef(AsyncContextFrame::current(js));
-  KJ_ASSERT(check(promise->SetPrivate(context, handle, frame->getJSWrapper(js))));
+  KJ_ASSERT(check(promise->SetPrivate(context, handle, getJSWrapper(js))));
 }
 
 kj::Maybe<Value&> AsyncContextFrame::get(StorageKey& key) {
@@ -144,7 +156,7 @@ AsyncContextFrame::Scope::Scope(v8::Isolate* isolate, kj::Maybe<AsyncContextFram
   KJ_IF_MAYBE(f, frame) {
     this->isolate.pushAsyncFrame(*f);
   } else {
-    this->isolate.pushAsyncFrame(*this->isolate.getRootAsyncContext());
+    this->isolate.pushRootAsyncFrame();
   }
 }
 
@@ -156,15 +168,11 @@ AsyncContextFrame::StorageScope::StorageScope(
     Lock& js,
     StorageKey& key,
     Value store)
-    : frame(AsyncContextFrame::create(js, nullptr, StorageEntry {
+    : frame(AsyncContextFrame::create(js, StorageEntry {
         .key = kj::addRef(key),
         .value = kj::mv(store)
       })),
       scope(js, *frame) {}
-
-bool AsyncContextFrame::isRoot(Lock& js) const {
-  return IsolateBase::from(js.v8Isolate).getRootAsyncContext() == this;
-}
 
 v8::Local<v8::Object> AsyncContextFrame::getJSWrapper(Lock& js) {
   KJ_IF_MAYBE(handle, tryGetHandle(js.v8Isolate)) {
@@ -183,6 +191,10 @@ void IsolateBase::pushAsyncFrame(AsyncContextFrame& next) {
   asyncFrameStack.add(&next);
 }
 
+void IsolateBase::pushRootAsyncFrame() {
+  asyncFrameStack.add(RootAsyncContextFrame{});
+}
+
 void IsolateBase::popAsyncFrame() {
   KJ_DASSERT(asyncFrameStack.size() > 0, "the async context frame stack was corrupted");
   asyncFrameStack.removeLast();
@@ -196,19 +208,6 @@ void IsolateBase::setAsyncContextTrackingEnabled() {
   if (asyncContextTrackingEnabled) return;
   asyncContextTrackingEnabled = true;
   ptr->SetPromiseHook(&promiseHook);
-}
-
-AsyncContextFrame* IsolateBase::getRootAsyncContext() {
-  KJ_IF_MAYBE(frame, rootAsyncFrame) {
-    return frame->get();
-  }
-  // We initialize this lazily instead of in the IsolateBase constructor
-  // because AsyncContextFrame is a Wrappable and rootAsyncFrame is a Ref.
-  // Calling alloc during IsolateBase construction is not allowed because
-  // Ref's constructor requires the Isolate lock to be held already.
-  KJ_ASSERT(asyncFrameStack.size() == 0);
-  rootAsyncFrame = alloc<AsyncContextFrame>(*this);
-  return KJ_ASSERT_NONNULL(rootAsyncFrame).get();
 }
 
 void IsolateBase::promiseHook(v8::PromiseHookType type,
@@ -229,7 +228,6 @@ void IsolateBase::promiseHook(v8::PromiseHookType type,
 
   auto& js = Lock::from(isolate);
   auto& isolateBase = IsolateBase::from(isolate);
-  auto& currentFrame = AsyncContextFrame::current(js);
 
   const auto isRejected = [&] { return promise->State() == v8::Promise::PromiseState::kRejected; };
 
@@ -244,11 +242,8 @@ void IsolateBase::promiseHook(v8::PromiseHookType type,
         // includes all calls to `new Promise(...)`, `then()`, `catch()`, `finally()`,
         // uses of `await ...`, `Promise.all()`, etc.
         // Whenever a Promise is created, we associate it with the current AsyncContextFrame.
-        // As a performance optimization, we only attach the context if the current is not
-        // the root.
-        if (!currentFrame.isRoot(js)) {
-          KJ_DASSERT(AsyncContextFrame::tryGetContext(js, promise) == nullptr);
-          AsyncContextFrame::attachContext(js, promise);
+        KJ_IF_MAYBE(frame, AsyncContextFrame::current(js)) {
+          frame->attachContext(js, promise);
         }
         break;
       }
@@ -259,25 +254,13 @@ void IsolateBase::promiseHook(v8::PromiseHookType type,
         KJ_IF_MAYBE(frame, AsyncContextFrame::tryGetContext(js, promise)) {
           isolateBase.pushAsyncFrame(*frame);
         } else {
-          // If the promise does not have a frame attached, we assume the root
-          // frame is used. Just to keep bookkeeping easier, we still go ahead
-          // and push the frame onto the stack again so we can just unconditionally
-          // pop it off in the kAfter without performing additional checks.
-          isolateBase.pushAsyncFrame(*isolateBase.getRootAsyncContext());
+          isolateBase.pushRootAsyncFrame();
         }
         // We do not use AsyncContextFrame::Scope here because we do not exit the frame
         // until the kAfter event fires.
         break;
       }
       case v8::PromiseHookType::kAfter: {
-  #ifdef KJ_DEBUG
-        KJ_IF_MAYBE(frame, AsyncContextFrame::tryGetContext(js, promise)) {
-          // The frame associated with the promise must be the current frame.
-          KJ_ASSERT(frame == &currentFrame);
-        } else {
-          KJ_ASSERT(currentFrame.isRoot(js));
-        }
-  #endif
         isolateBase.popAsyncFrame();
 
         // If the promise has been rejected here, we have to maintain the association of the
@@ -298,9 +281,10 @@ void IsolateBase::promiseHook(v8::PromiseHookType type,
         // Promise.resolve, and Promise.reject) and instead will emit the kResolve event first.
         // When this event occurs, and the promise is rejected, we need to check to see if the
         // promise is already wrapped, and if it is not, do so.
-        if (!currentFrame.isRoot(js) && isRejected() &&
-            AsyncContextFrame::tryGetContext(js, promise) == nullptr) {
-          AsyncContextFrame::attachContext(js, promise);
+        KJ_IF_MAYBE(current, AsyncContextFrame::current(js)) {
+          if (isRejected() && AsyncContextFrame::tryGetContext(js, promise) == nullptr) {
+            current->attachContext(js, promise);
+          }
         }
         break;
       }

--- a/src/workerd/jsg/async-context.c++
+++ b/src/workerd/jsg/async-context.c++
@@ -8,11 +8,22 @@
 
 namespace workerd::jsg {
 
+namespace {
+inline void maybeSetV8ContinuationContext(
+    v8::Isolate* isolate,
+    kj::Maybe<AsyncContextFrame&> maybeFrame) {
+  v8::Local<v8::Value> value;
+  KJ_IF_MAYBE(frame, maybeFrame) {
+    value = frame->getJSWrapper(isolate);
+  } else {
+    value = v8::Undefined(isolate);
+  }
+  isolate->GetCurrentContext()->SetContinuationPreservedEmbedderData(value);
+}
+}  // namespace
+
 AsyncContextFrame::AsyncContextFrame(Lock& js, StorageEntry storageEntry)
     : isolate(IsolateBase::from(js.v8Isolate)) {
-  // Lazily enables the hooks for async context tracking.
-  isolate.setAsyncContextTrackingEnabled();
-
   KJ_IF_MAYBE(frame, current(js)) {
     // Propagate the storage context of the current frame (if any).
     // If current(js) returns nullptr, we assume we're in the root
@@ -50,22 +61,17 @@ kj::Maybe<AsyncContextFrame&> AsyncContextFrame::tryGetContext(
 }
 
 kj::Maybe<AsyncContextFrame&> AsyncContextFrame::current(Lock& js) {
-  auto& isolateBase = IsolateBase::from(js.v8Isolate);
-  if (isolateBase.asyncFrameStack.size() == 0) {
-    return nullptr;
+  return current(js.v8Isolate);
+}
+
+kj::Maybe<AsyncContextFrame&> AsyncContextFrame::current(v8::Isolate* isolate) {
+  auto value = isolate->GetCurrentContext()->GetContinuationPreservedEmbedderData();
+  KJ_IF_MAYBE(wrappable, Wrappable::tryUnwrapOpaque(isolate, value)) {
+    AsyncContextFrame* frame = dynamic_cast<AsyncContextFrame*>(wrappable);
+    KJ_ASSERT(frame != nullptr);
+    return *frame;
   }
-  KJ_SWITCH_ONEOF(isolateBase.asyncFrameStack.back()) {
-    KJ_CASE_ONEOF(frame, AsyncContextFrame*) {
-      return *frame;
-    }
-    KJ_CASE_ONEOF(root, IsolateBase::RootAsyncContextFrame) {
-      // In this case, the logical root frame has been pushed onto the
-      // top of the stack. This effectively means that no storage context
-      // is active, so we just return nullptr.
-      return nullptr;
-    }
-  }
-  KJ_UNREACHABLE;
+  return nullptr;
 }
 
 Ref<AsyncContextFrame> AsyncContextFrame::create(Lock& js, StorageEntry storageEntry) {
@@ -151,17 +157,14 @@ kj::Maybe<Value&> AsyncContextFrame::get(StorageKey& key) {
 AsyncContextFrame::Scope::Scope(Lock& js, kj::Maybe<AsyncContextFrame&> resource)
     : Scope(js.v8Isolate, resource) {}
 
-AsyncContextFrame::Scope::Scope(v8::Isolate* isolate, kj::Maybe<AsyncContextFrame&> frame)
-    : isolate(IsolateBase::from(isolate)) {
-  KJ_IF_MAYBE(f, frame) {
-    this->isolate.pushAsyncFrame(*f);
-  } else {
-    this->isolate.pushRootAsyncFrame();
-  }
+AsyncContextFrame::Scope::Scope(v8::Isolate* ptr, kj::Maybe<AsyncContextFrame&> maybeFrame)
+    : isolate(ptr),
+      prior(AsyncContextFrame::current(ptr)) {
+  maybeSetV8ContinuationContext(isolate, maybeFrame);
 }
 
 AsyncContextFrame::Scope::~Scope() noexcept(false) {
-  isolate.popAsyncFrame();
+  maybeSetV8ContinuationContext(isolate, prior);
 }
 
 AsyncContextFrame::StorageScope::StorageScope(
@@ -174,11 +177,15 @@ AsyncContextFrame::StorageScope::StorageScope(
       })),
       scope(js, *frame) {}
 
-v8::Local<v8::Object> AsyncContextFrame::getJSWrapper(Lock& js) {
-  KJ_IF_MAYBE(handle, tryGetHandle(js.v8Isolate)) {
+v8::Local<v8::Object> AsyncContextFrame::getJSWrapper(v8::Isolate* isolate) {
+  KJ_IF_MAYBE(handle, tryGetHandle(isolate)) {
     return *handle;
   }
-  return attachOpaqueWrapper(js.v8Isolate->GetCurrentContext(), true);
+  return attachOpaqueWrapper(isolate->GetCurrentContext(), true);
+}
+
+v8::Local<v8::Object> AsyncContextFrame::getJSWrapper(Lock& js) {
+  return getJSWrapper(js.v8Isolate);
 }
 
 void AsyncContextFrame::jsgVisitForGc(GcVisitor& visitor) {
@@ -186,123 +193,4 @@ void AsyncContextFrame::jsgVisitForGc(GcVisitor& visitor) {
     visitor.visit(entry.value);
   }
 }
-
-void IsolateBase::pushAsyncFrame(AsyncContextFrame& next) {
-  asyncFrameStack.add(&next);
-}
-
-void IsolateBase::pushRootAsyncFrame() {
-  asyncFrameStack.add(RootAsyncContextFrame{});
-}
-
-void IsolateBase::popAsyncFrame() {
-  KJ_DASSERT(asyncFrameStack.size() > 0, "the async context frame stack was corrupted");
-  asyncFrameStack.removeLast();
-}
-
-void IsolateBase::setAsyncContextTrackingEnabled() {
-  // Enabling async context tracking installs a relatively expensive callback on the v8 isolate
-  // that attaches additional metadata to every promise created. The additional metadata is used
-  // to implement support for the Node.js AsyncLocalStorage API. Since that is the only current
-  // use for it, we only install the promise hook when that api is used.
-  if (asyncContextTrackingEnabled) return;
-  asyncContextTrackingEnabled = true;
-  ptr->SetPromiseHook(&promiseHook);
-}
-
-void IsolateBase::promiseHook(v8::PromiseHookType type,
-                              v8::Local<v8::Promise> promise,
-                              v8::Local<v8::Value> parent) {
-  auto isolate = promise->GetIsolate();
-
-  // V8 will call the promise hook even while execution is terminating. In that
-  // case we don't want to do anything here.
-  if (isolate->IsExecutionTerminating() || isolate->IsDead()) {
-    return;
-  }
-
-  // This is a fairly expensive method. It is invoked at least once, and a most
-  // four times for every JavaScript promise that is created within an isolate.
-  // Accordingly, the hook is only installed when the AsyncLocalStorage API is
-  // used.
-
-  auto& js = Lock::from(isolate);
-  auto& isolateBase = IsolateBase::from(isolate);
-
-  const auto isRejected = [&] { return promise->State() == v8::Promise::PromiseState::kRejected; };
-
-  // TODO(later): The try/catch block here echoes the semantics of LiftKj.
-  // We don't use LiftKj here because that currently requires a FunctionCallbackInfo,
-  // which we don't have (or want here). If we end up needing this pattern elsewhere,
-  // we can implement a variant of LiftKj that does so and switch this over to use it.
-  try {
-    switch (type) {
-      case v8::PromiseHookType::kInit: {
-        // The kInit event is triggered by v8 when a deferred Promise is created. This
-        // includes all calls to `new Promise(...)`, `then()`, `catch()`, `finally()`,
-        // uses of `await ...`, `Promise.all()`, etc.
-        // Whenever a Promise is created, we associate it with the current AsyncContextFrame.
-        KJ_IF_MAYBE(frame, AsyncContextFrame::current(js)) {
-          frame->attachContext(js, promise);
-        }
-        break;
-      }
-      case v8::PromiseHookType::kBefore: {
-        // The kBefore event is triggered immediately before a Promise continuation.
-        // We use it here to enter the AsyncContextFrame that was associated with the
-        // promise when it was created.
-        KJ_IF_MAYBE(frame, AsyncContextFrame::tryGetContext(js, promise)) {
-          isolateBase.pushAsyncFrame(*frame);
-        } else {
-          isolateBase.pushRootAsyncFrame();
-        }
-        // We do not use AsyncContextFrame::Scope here because we do not exit the frame
-        // until the kAfter event fires.
-        break;
-      }
-      case v8::PromiseHookType::kAfter: {
-        isolateBase.popAsyncFrame();
-
-        // If the promise has been rejected here, we have to maintain the association of the
-        // async context to the promise so that the context can be propagated to the unhandled
-        // rejection handler. However, if the promise has been fulfilled, we do not expect
-        // the context to be used any longer so we can break the context association here and
-        // allow the opaque wrapper to be garbage collected.
-        if (!isRejected()) {
-          auto handle = js.getPrivateSymbolFor(Lock::PrivateSymbols::ASYNC_CONTEXT);
-          check(promise->DeletePrivate(js.v8Isolate->GetCurrentContext(), handle));
-        }
-
-        break;
-      }
-      case v8::PromiseHookType::kResolve: {
-        // This case is a bit different. As an optimization, it appears that v8 will skip
-        // the kInit, kBefore, and kAfter events for Promises that are immediately resolved (e.g.
-        // Promise.resolve, and Promise.reject) and instead will emit the kResolve event first.
-        // When this event occurs, and the promise is rejected, we need to check to see if the
-        // promise is already wrapped, and if it is not, do so.
-        KJ_IF_MAYBE(current, AsyncContextFrame::current(js)) {
-          if (isRejected() && AsyncContextFrame::tryGetContext(js, promise) == nullptr) {
-            current->attachContext(js, promise);
-          }
-        }
-        break;
-      }
-    }
-  } catch (JsExceptionThrown&) {
-    // Catching JsExceptionThrown implies that an exception is already scheduled on the isolate
-    // so we don't need to throw it again, just allow it to bubble up and out.
-  } catch (std::exception& ex) {
-    // This case is purely defensive and is included really just to align with the
-    // semantics in LiftKj. We'd be using LiftKj here already if that didn't require
-    // use of a FunctionCallbackInfo.
-    throwInternalError(isolate, ex.what());
-  } catch (kj::Exception& ex) {
-    throwInternalError(isolate, kj::mv(ex));
-  } catch (...) {
-    throwInternalError(isolate, kj::str("caught unknown exception of type: ",
-                                        kj::getCaughtExceptionType()));
-  }
-}
-
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/async-context.c++
+++ b/src/workerd/jsg/async-context.c++
@@ -121,7 +121,6 @@ v8::Local<v8::Function> AsyncContextFrame::wrapRoot(
     }
 
     AsyncContextFrame::Scope scope(js, nullptr);
-    v8::Local<v8::Value> result;
     return check(function->Call(context, thisArg.getHandle(js), args.Length(), argv.begin()));
   }));
 }

--- a/src/workerd/jsg/async-context.h
+++ b/src/workerd/jsg/async-context.h
@@ -96,6 +96,7 @@ public:
   inline Ref<AsyncContextFrame> addRef() { return JSG_THIS; }
 
   static kj::Maybe<AsyncContextFrame&> current(Lock& js);
+  static kj::Maybe<AsyncContextFrame&> current(v8::Isolate* isolate);
   // Returns the reference to the AsyncContextFrame currently at the top of the stack, if any.
 
   static Ref<AsyncContextFrame> create(Lock& js, StorageEntry storageEntry);
@@ -130,7 +131,8 @@ public:
   struct Scope {
     // AsyncContextFrame::Scope makes the given AsyncContextFrame the current in the
     // stack until the scope is destroyed.
-    IsolateBase& isolate;
+    v8::Isolate* isolate;
+    kj::Maybe<AsyncContextFrame&> prior;
     Scope(Lock& js, kj::Maybe<AsyncContextFrame&> frame = nullptr);
     Scope(v8::Isolate* isolate, kj::Maybe<AsyncContextFrame&> frame = nullptr);
     // If frame is nullptr, the root frame is assumed.
@@ -141,6 +143,7 @@ public:
   kj::Maybe<Value&> get(StorageKey& key);
   // Retrieves the value that is associated with the given key.
 
+  v8::Local<v8::Object> getJSWrapper(v8::Isolate* isolate);
   v8::Local<v8::Object> getJSWrapper(Lock& js);
   // Gets an opaque JavaScript Object wrapper object for this frame. If a wrapper
   // does not currently exist, one is created. This wrapper is only used to set a

--- a/src/workerd/jsg/async-context.h
+++ b/src/workerd/jsg/async-context.h
@@ -111,6 +111,10 @@ public:
   static kj::Maybe<AsyncContextFrame&> current(v8::Isolate* isolate);
   // Returns the reference to the AsyncContextFrame currently at the top of the stack, if any.
 
+  static kj::Maybe<Ref<AsyncContextFrame>> currentRef(Lock& js);
+  // Convenience variation on current() that returns the result wrapped in a Ref for when we
+  // need to make sure the frame stays alive.
+
   static Ref<AsyncContextFrame> create(Lock& js, StorageEntry storageEntry);
   // Create a new AsyncContextFrame. The new frame inherits the storage context of the current
   // frame (if any) and the given StorageEntry is added.
@@ -138,6 +142,7 @@ public:
     kj::Maybe<AsyncContextFrame&> prior;
     Scope(Lock& js, kj::Maybe<AsyncContextFrame&> frame = nullptr);
     Scope(v8::Isolate* isolate, kj::Maybe<AsyncContextFrame&> frame = nullptr);
+    Scope(Lock& js, kj::Maybe<Ref<AsyncContextFrame>>& frame);
     // If frame is nullptr, the root frame is assumed.
     ~Scope() noexcept(false);
     KJ_DISALLOW_COPY(Scope);

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -177,10 +177,6 @@ kj::StringPtr Lock::getUuid() const {
   return IsolateBase::from(v8Isolate).getUuid();
 }
 
-v8::Local<v8::Private> Lock::getPrivateSymbolFor(Lock::PrivateSymbols symbol) {
-  return IsolateBase::from(v8Isolate).getPrivateSymbolFor(symbol);
-}
-
 Name Lock::newSymbol(kj::StringPtr symbol) {
   return Name(*this, v8::Symbol::New(v8Isolate, v8StrIntern(v8Isolate, symbol)));
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1789,10 +1789,6 @@ class Isolate;
 
 class AsyncContextFrame;
 
-#define JSG_PRIVATE_SYMBOLS(V)       \
-  V(ASYNC_CONTEXT, "asyncContext")
-// Defines the enum values for Lock::PrivateSymbols.
-
 class Lock {
   // Represents an isolate lock, which allows the current thread to execute JavaScript code within
   // an isolate. A thread must lock an isolate -- obtaining an instance of `Lock` -- before it can
@@ -2020,18 +2016,6 @@ public:
   kj::StringPtr getUuid() const;
   // Returns a random UUID for this isolate instance. This is largely intended for logging and
   // diagnostic purposes.
-
-#define V(name, _) name,
-  enum PrivateSymbols {
-    JSG_PRIVATE_SYMBOLS(V)
-    SYMBOL_COUNT,
-    // The SYMBOL_COUNT is a special token used to size the array for storing the
-    // symbol instances. It must always be the last item in the enum. To add private
-    // symbols, add values to the JSG_PRIVATE_SYMBOLS define.
-  };
-#undef V
-
-  v8::Local<v8::Private> getPrivateSymbolFor(PrivateSymbols symbol);
 
 private:
   friend class IsolateBase;

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -774,6 +774,7 @@ private:
     v8::Global<v8::Promise> promise;
     v8::Global<v8::Value> value;
     v8::Global<v8::Message> message;
+    kj::Maybe<Ref<AsyncContextFrame>> asyncContextFrame;
 
     inline bool isAlive() { return !promise.IsEmpty() && !value.IsEmpty(); }
 

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -338,9 +338,6 @@ void IsolateBase::dropWrappers(kj::Own<void> typeWrapperInstance) {
   v8::Locker lock(ptr);
   v8::Isolate::Scope scope(ptr);
 
-  // Clear the rootAsyncFrame reference under lock.
-  rootAsyncFrame = nullptr;
-
   // Make sure everything in the deferred destruction queue is dropped.
   clearDestructionQueue();
 
@@ -357,11 +354,6 @@ void IsolateBase::dropWrappers(kj::Own<void> typeWrapperInstance) {
 
   // Destroy all wrappers.
   heapTracer.clearWrappers();
-
-  // Clear any cached private symbols here while we are in the isolate lock.
-  for (auto& maybeSymbol : privateSymbols) {
-    maybeSymbol = nullptr;
-  }
 }
 
 void IsolateBase::fatalError(const char* location, const char* message) {
@@ -510,30 +502,6 @@ void IsolateBase::jitCodeEvent(const v8::JitCodeEvent* event) noexcept {
       break;
     }
   }
-}
-
-v8::Local<v8::Private> IsolateBase::getPrivateSymbolFor(Lock::PrivateSymbols symbol) {
-  KJ_ASSERT(symbol != Lock::PrivateSymbols::SYMBOL_COUNT);
-  int pos = static_cast<int>(symbol);
-  // If the private symbol has already been retrieved before, it will be memoized in
-  // the privateSymbols array. Just grab the reference and return it.
-  KJ_IF_MAYBE(i, privateSymbols[pos]) {
-    return i->getHandle(ptr);
-  }
-  // Otherwise, we have to ask v8 for the symbol. The list of symbols available is
-  // defined by the JSG_PRIVATE_SYMBOLS define in jsg.h.
-  v8::Local<v8::Private> handle;
-  switch (symbol) {
-#define V(name, val) \
-  case Lock::PrivateSymbols::name: \
-    handle = v8::Private::ForApi(ptr, v8StrIntern(ptr, #val)); break;
-    JSG_PRIVATE_SYMBOLS(V)
-#undef V
-    default:
-      KJ_UNREACHABLE;
-  }
-  privateSymbols[pos] = V8Ref(ptr, handle);
-  return handle;
 }
 
 kj::Maybe<kj::StringPtr> getJsStackTrace(void* ucontext, kj::ArrayPtr<char> scratch) {

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -102,7 +102,6 @@ public:
   }
 
   void setAsyncContextTrackingEnabled();
-  AsyncContextFrame* getRootAsyncContext();
 
   v8::Local<v8::Private> getPrivateSymbolFor(Lock::PrivateSymbols symbol);
 
@@ -247,15 +246,15 @@ private:
   // Pushes the frame onto the stack making it current. Importantly, the stack
   // does not maintain a refcounted reference to the frame so it is important
   // for the caller to ensure that the frame is kept alive.
+  void pushRootAsyncFrame();
   void popAsyncFrame();
 
-  kj::Vector<AsyncContextFrame*> asyncFrameStack;
-  kj::Maybe<Ref<AsyncContextFrame>> rootAsyncFrame;
-  // The rootAsyncFrame is a maybe because it is lazily initialized.
-  // We cannot create Ref's within the IsolateBase constructor and
-  // we don't want this to be a bare kj::Own because it might have
-  // a JS wrapper associated with it. Calling getRootAsyncContext
-  // for the first time will lazily create the root frame.
+  struct RootAsyncContextFrame {
+    // A sentinel for the RootAsyncContextFrame. Used only for bookkeeping
+    // in the async frame stack below.
+  };
+
+  kj::Vector<kj::OneOf<AsyncContextFrame*, RootAsyncContextFrame>> asyncFrameStack;
 
   friend class AsyncContextFrame;
 };

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -100,8 +100,6 @@ public:
     KJ_IF_MAYBE(logger, maybeLogger) { (*logger)(js, message); }
   }
 
-  v8::Local<v8::Private> getPrivateSymbolFor(Lock::PrivateSymbols symbol);
-
   kj::StringPtr getUuid();
   // Returns a random UUID for this isolate instance.
 
@@ -151,9 +149,6 @@ private:
   v8::Global<v8::FunctionTemplate> opaqueTemplate;
   // FunctionTemplate used by Wrappable::attachOpaqueWrapper(). Just a constructor for an empty
   // object with 2 internal fields.
-
-  // Keep the size here in sync w
-  kj::Maybe<V8Ref<v8::Private>> privateSymbols[Lock::PrivateSymbols::SYMBOL_COUNT];
 
   static constexpr auto DESTRUCTION_QUEUE_INITIAL_SIZE = 8;
   // We expect queues to remain relatively small -- 8 is the largest size I have observed from local

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -11,7 +11,6 @@
 #include <workerd/util/batch-queue.h>
 #include <kj/map.h>
 #include <kj/mutex.h>
-#include <deque>
 
 namespace workerd::jsg {
 
@@ -100,8 +99,6 @@ public:
     // being used).
     KJ_IF_MAYBE(logger, maybeLogger) { (*logger)(js, message); }
   }
-
-  void setAsyncContextTrackingEnabled();
 
   v8::Local<v8::Private> getPrivateSymbolFor(Lock::PrivateSymbols symbol);
 
@@ -238,25 +235,6 @@ private:
   // use `->InstanceTemplate()->NewInstance()` to construct an object, and you can pass this to
   // `FindInstanceInPrototypeChain()` on an existing object to check whether it was created using
   // this template.
-
-  static void promiseHook(v8::PromiseHookType type,
-                          v8::Local<v8::Promise> promise,
-                          v8::Local<v8::Value> parent);
-  void pushAsyncFrame(AsyncContextFrame& next);
-  // Pushes the frame onto the stack making it current. Importantly, the stack
-  // does not maintain a refcounted reference to the frame so it is important
-  // for the caller to ensure that the frame is kept alive.
-  void pushRootAsyncFrame();
-  void popAsyncFrame();
-
-  struct RootAsyncContextFrame {
-    // A sentinel for the RootAsyncContextFrame. Used only for bookkeeping
-    // in the async frame stack below.
-  };
-
-  kj::Vector<kj::OneOf<AsyncContextFrame*, RootAsyncContextFrame>> asyncFrameStack;
-
-  friend class AsyncContextFrame;
 };
 
 kj::Maybe<kj::StringPtr> getJsStackTrace(void* ucontext, kj::ArrayPtr<char> scratch);


### PR DESCRIPTION
There are two key changes here:

* Elimate the root context frame: It occurred to me that we really do not need a root AsyncContextFrame instance at all since there's nothing actually being stored there ever. Just have AsyncContextFrame::current() return an empty kj::Maybe in that case and treat the nullptr as equivalent to the root frame.
* Makes use of an obscure v8 API that allows setting continuation context for promises and tasks. Allows a number of simplifications.

Also fixes a couple of minor bugs.