### PR TITLE
Simplify async context tracking by eliminating the promise hook

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -496,6 +496,9 @@ v8::Local<v8::String> ServiceWorkerGlobalScope::atob(kj::String data, v8::Isolat
 void ServiceWorkerGlobalScope::queueMicrotask(
     jsg::Lock& js,
     v8::Local<v8::Function> task) {
+  // TODO(later): It currently does not appear as if v8 attaches the continuation embedder data
+  // to microtasks scheduled using EnqueueMicrotask, so we have to wrap in order to propagate
+  // the context to those.
   KJ_IF_MAYBE(context, jsg::AsyncContextFrame::current(js)) {
     task = context->wrap(js, task);
   }

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -105,8 +105,6 @@ ServiceWorkerGlobalScope::ServiceWorkerGlobalScope(v8::Isolate* isolate)
                 jsg::Value value) {
           // If async context tracking is enabled, then we need to ensure that we enter the frame
           // associated with the promise before we invoke the unhandled rejection callback handling.
-          jsg::AsyncContextFrame::Scope scope(js,
-              jsg::AsyncContextFrame::tryGetContext(js, promise));
           auto ev = jsg::alloc<PromiseRejectionEvent>(event, kj::mv(promise), kj::mv(value));
           dispatchEventImpl(js, kj::mv(ev));
         }) {}

--- a/src/workerd/api/node/async-hooks.h
+++ b/src/workerd/api/node/async-hooks.h
@@ -194,8 +194,16 @@ public:
     }
   }
 
+  kj::Maybe<jsg::AsyncContextFrame&> getFrame();
+  // Returns the jsg::AsyncContextFrame captured when the AsyncResource was created,
+  // if any.
+
 private:
-  kj::Own<jsg::AsyncContextFrame> frame;
+  kj::Maybe<jsg::Ref<jsg::AsyncContextFrame>> frame;
+
+  inline void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(frame);
+  }
 };
 
 class AsyncHooksModule final: public jsg::Object {

--- a/src/workerd/jsg/README.md
+++ b/src/workerd/jsg/README.md
@@ -1515,11 +1515,10 @@ Context Frame.
 
 ```cpp
 jsg::Lock& js = ...;
-kj::Own<jsg::AsyncContextFrame> frame = kj::addRef(jsg::AsyncResource::current(js));
 
 // enter the async resource scope:
 {
-  jsg::AsyncContextFrame::Scope asyncScope(js, *frame);
+  jsg::AsyncContextFrame::Scope asyncScope(js, jsg::AsyncResource::current(js));
   // run some code synchronously...
 }
 // The async scope will exit automatically...

--- a/src/workerd/jsg/async-context.c++
+++ b/src/workerd/jsg/async-context.c++
@@ -8,51 +8,24 @@
 
 namespace workerd::jsg {
 
-namespace {
-kj::Maybe<AsyncContextFrame&> tryGetContextFrame(
-    v8::Isolate* isolate,
-    v8::Local<v8::Value> handle) {
-  // Gets the held AsyncContextFrame from the opaque wrappable but does not consume it.
-  KJ_IF_MAYBE(wrappable, Wrappable::tryUnwrapOpaque(isolate, handle)) {
-    AsyncContextFrame* frame = dynamic_cast<AsyncContextFrame*>(wrappable);
-    KJ_ASSERT(frame != nullptr);
-    return *frame;
-  }
-  return nullptr;
-}
-
-}  // namespace
-
-AsyncContextFrame::AsyncContextFrame(IsolateBase& isolate)
-    : isolate(isolate) {}
-
-AsyncContextFrame::AsyncContextFrame(
-    Lock& js,
-    kj::Maybe<AsyncContextFrame&> maybeParent,
-    kj::Maybe<StorageEntry> maybeStorageEntry)
-    : AsyncContextFrame(IsolateBase::from(js.v8Isolate)) {
+AsyncContextFrame::AsyncContextFrame(Lock& js, StorageEntry storageEntry)
+    : isolate(IsolateBase::from(js.v8Isolate)) {
   // Lazily enables the hooks for async context tracking.
   isolate.setAsyncContextTrackingEnabled();
 
-  // Propagate the storage context of the parent frame to this newly created frame.
-  const auto propagate = [&](AsyncContextFrame& parent) {
-    parent.storage.eraseAll([](const auto& entry) { return entry.key->isDead(); });
-    for (auto& entry : parent.storage) {
+  KJ_IF_MAYBE(frame, current(js)) {
+    // Propagate the storage context of the current frame (if any).
+    // If current(js) returns nullptr, we assume we're in the root
+    // frame and there is no storage to propagate.
+    frame->storage.eraseAll([](const auto& entry) { return entry.key->isDead(); });
+    for (auto& entry : frame->storage) {
       storage.insert(entry.clone(js));
     }
-
-    KJ_IF_MAYBE(entry, maybeStorageEntry) {
-      storage.upsert(kj::mv(*entry), [](StorageEntry& existing, StorageEntry&& row) mutable {
-        existing.value = kj::mv(row.value);
-      });
-    }
-  };
-
-  KJ_IF_MAYBE(parent, maybeParent) {
-    propagate(*parent);
-  } else {
-    propagate(current(js));
   }
+
+  storage.upsert(kj::mv(storageEntry), [](StorageEntry& existing, StorageEntry&& row) mutable {
+    existing.value = kj::mv(row.value);
+  });
 }
 
 kj::Maybe<AsyncContextFrame&> AsyncContextFrame::tryGetContext(
@@ -61,8 +34,13 @@ kj::Maybe<AsyncContextFrame&> AsyncContextFrame::tryGetContext(
   auto handle = js.getPrivateSymbolFor(Lock::PrivateSymbols::ASYNC_CONTEXT);
   // We do not use the normal unwrapOpaque here since that would consume the wrapped
   // value, and we need to be able to unwrap multiple times.
-  return tryGetContextFrame(js.v8Isolate,
-      check(promise->GetPrivate(js.v8Isolate->GetCurrentContext(), handle)));
+  auto ref = check(promise->GetPrivate(js.v8Isolate->GetCurrentContext(), handle));
+  KJ_IF_MAYBE(wrappable, Wrappable::tryUnwrapOpaque(js.v8Isolate, ref)) {
+    AsyncContextFrame* frame = dynamic_cast<AsyncContextFrame*>(wrappable);
+    KJ_ASSERT(frame != nullptr);
+    return *frame;
+  }
+  return nullptr;
 }
 
 kj::Maybe<AsyncContextFrame&> AsyncContextFrame::tryGetContext(
@@ -71,31 +49,45 @@ kj::Maybe<AsyncContextFrame&> AsyncContextFrame::tryGetContext(
   return tryGetContext(js, promise.getHandle(js));
 }
 
-AsyncContextFrame& AsyncContextFrame::current(Lock& js) {
+kj::Maybe<AsyncContextFrame&> AsyncContextFrame::current(Lock& js) {
   auto& isolateBase = IsolateBase::from(js.v8Isolate);
   if (isolateBase.asyncFrameStack.size() == 0) {
-    return *isolateBase.getRootAsyncContext();
+    return nullptr;
   }
-  return *isolateBase.asyncFrameStack.back();
+  KJ_SWITCH_ONEOF(isolateBase.asyncFrameStack.back()) {
+    KJ_CASE_ONEOF(frame, AsyncContextFrame*) {
+      return *frame;
+    }
+    KJ_CASE_ONEOF(root, IsolateBase::RootAsyncContextFrame) {
+      // In this case, the logical root frame has been pushed onto the
+      // top of the stack. This effectively means that no storage context
+      // is active, so we just return nullptr.
+      return nullptr;
+    }
+  }
+  KJ_UNREACHABLE;
 }
 
-Ref<AsyncContextFrame> AsyncContextFrame::create(
-    Lock& js,
-    kj::Maybe<AsyncContextFrame&> maybeParent,
-    kj::Maybe<StorageEntry> maybeStorageEntry) {
-  return alloc<AsyncContextFrame>(js, maybeParent, kj::mv(maybeStorageEntry));
+Ref<AsyncContextFrame> AsyncContextFrame::create(Lock& js, StorageEntry storageEntry) {
+  return alloc<AsyncContextFrame>(js, kj::mv(storageEntry));
+}
+
+v8::Local<v8::Function> AsyncContextFrame::wrap(
+    Lock& js, V8Ref<v8::Function>& fn,
+    kj::Maybe<v8::Local<v8::Value>> thisArg) {
+  return wrap(js, fn.getHandle(js), thisArg);
 }
 
 v8::Local<v8::Function> AsyncContextFrame::wrap(
     Lock& js,
     v8::Local<v8::Function> fn,
-    kj::Maybe<AsyncContextFrame&> maybeFrame,
     kj::Maybe<v8::Local<v8::Value>> thisArg) {
   auto isolate = js.v8Isolate;
   auto context = isolate->GetCurrentContext();
+
   return js.wrapReturningFunction(context, JSG_VISITABLE_LAMBDA(
       (
-        frame = Ref(kj::addRef(AsyncContextFrame::current(js))),
+        frame = JSG_THIS,
         thisArg = js.v8Ref(thisArg.orDefault(context->Global())),
         fn = js.v8Ref(fn)
       ),
@@ -109,25 +101,45 @@ v8::Local<v8::Function> AsyncContextFrame::wrap(
       argv.add(args[n]);
     }
 
-    AsyncContextFrame::Scope scope(js, *frame);
+    AsyncContextFrame::Scope scope(js, *frame.get());
     v8::Local<v8::Value> result;
     return check(function->Call(context, thisArg.getHandle(js), args.Length(), argv.begin()));
   }));
 }
 
-void AsyncContextFrame::attachContext(
+v8::Local<v8::Function> AsyncContextFrame::wrapRoot(
     Lock& js,
-    v8::Local<v8::Promise> promise,
-    kj::Maybe<AsyncContextFrame&> maybeFrame) {
+    v8::Local<v8::Function> fn,
+    kj::Maybe<v8::Local<v8::Value>> thisArg) {
+  auto isolate = js.v8Isolate;
+  auto context = isolate->GetCurrentContext();
+
+  return js.wrapReturningFunction(context, JSG_VISITABLE_LAMBDA(
+      (
+        thisArg = js.v8Ref(thisArg.orDefault(context->Global())),
+        fn = js.v8Ref(fn)
+      ),
+      (thisArg, fn),
+      (Lock& js, const v8::FunctionCallbackInfo<v8::Value>& args) {
+    auto function = fn.getHandle(js);
+    auto context = js.v8Isolate->GetCurrentContext();
+
+    kj::Vector<v8::Local<v8::Value>> argv(args.Length());
+    for (int n = 0; n < args.Length(); n++) {
+      argv.add(args[n]);
+    }
+
+    AsyncContextFrame::Scope scope(js, nullptr);
+    v8::Local<v8::Value> result;
+    return check(function->Call(context, thisArg.getHandle(js), args.Length(), argv.begin()));
+  }));
+}
+
+void AsyncContextFrame::attachContext(Lock& js, v8::Local<v8::Promise> promise) {
   auto handle = js.getPrivateSymbolFor(Lock::PrivateSymbols::ASYNC_CONTEXT);
   auto context = js.v8Isolate->GetCurrentContext();
-
   KJ_DASSERT(!check(promise->HasPrivate(context, handle)));
-
-  // Otherwise, we have to create an opaque wrapper holding a ref to the current frame
-  // because we do not have the option of using an internal field with promises.
-  auto frame = kj::addRef(AsyncContextFrame::current(js));
-  KJ_ASSERT(check(promise->SetPrivate(context, handle, frame->getJSWrapper(js))));
+  KJ_ASSERT(check(promise->SetPrivate(context, handle, getJSWrapper(js))));
 }
 
 kj::Maybe<Value&> AsyncContextFrame::get(StorageKey& key) {
@@ -144,7 +156,7 @@ AsyncContextFrame::Scope::Scope(v8::Isolate* isolate, kj::Maybe<AsyncContextFram
   KJ_IF_MAYBE(f, frame) {
     this->isolate.pushAsyncFrame(*f);
   } else {
-    this->isolate.pushAsyncFrame(*this->isolate.getRootAsyncContext());
+    this->isolate.pushRootAsyncFrame();
   }
 }
 
@@ -156,15 +168,11 @@ AsyncContextFrame::StorageScope::StorageScope(
     Lock& js,
     StorageKey& key,
     Value store)
-    : frame(AsyncContextFrame::create(js, nullptr, StorageEntry {
+    : frame(AsyncContextFrame::create(js, StorageEntry {
         .key = kj::addRef(key),
         .value = kj::mv(store)
       })),
       scope(js, *frame) {}
-
-bool AsyncContextFrame::isRoot(Lock& js) const {
-  return IsolateBase::from(js.v8Isolate).getRootAsyncContext() == this;
-}
 
 v8::Local<v8::Object> AsyncContextFrame::getJSWrapper(Lock& js) {
   KJ_IF_MAYBE(handle, tryGetHandle(js.v8Isolate)) {
@@ -183,6 +191,10 @@ void IsolateBase::pushAsyncFrame(AsyncContextFrame& next) {
   asyncFrameStack.add(&next);
 }
 
+void IsolateBase::pushRootAsyncFrame() {
+  asyncFrameStack.add(RootAsyncContextFrame{});
+}
+
 void IsolateBase::popAsyncFrame() {
   KJ_DASSERT(asyncFrameStack.size() > 0, "the async context frame stack was corrupted");
   asyncFrameStack.removeLast();
@@ -196,19 +208,6 @@ void IsolateBase::setAsyncContextTrackingEnabled() {
   if (asyncContextTrackingEnabled) return;
   asyncContextTrackingEnabled = true;
   ptr->SetPromiseHook(&promiseHook);
-}
-
-AsyncContextFrame* IsolateBase::getRootAsyncContext() {
-  KJ_IF_MAYBE(frame, rootAsyncFrame) {
-    return frame->get();
-  }
-  // We initialize this lazily instead of in the IsolateBase constructor
-  // because AsyncContextFrame is a Wrappable and rootAsyncFrame is a Ref.
-  // Calling alloc during IsolateBase construction is not allowed because
-  // Ref's constructor requires the Isolate lock to be held already.
-  KJ_ASSERT(asyncFrameStack.size() == 0);
-  rootAsyncFrame = alloc<AsyncContextFrame>(*this);
-  return KJ_ASSERT_NONNULL(rootAsyncFrame).get();
 }
 
 void IsolateBase::promiseHook(v8::PromiseHookType type,
@@ -229,7 +228,6 @@ void IsolateBase::promiseHook(v8::PromiseHookType type,
 
   auto& js = Lock::from(isolate);
   auto& isolateBase = IsolateBase::from(isolate);
-  auto& currentFrame = AsyncContextFrame::current(js);
 
   const auto isRejected = [&] { return promise->State() == v8::Promise::PromiseState::kRejected; };
 
@@ -244,11 +242,8 @@ void IsolateBase::promiseHook(v8::PromiseHookType type,
         // includes all calls to `new Promise(...)`, `then()`, `catch()`, `finally()`,
         // uses of `await ...`, `Promise.all()`, etc.
         // Whenever a Promise is created, we associate it with the current AsyncContextFrame.
-        // As a performance optimization, we only attach the context if the current is not
-        // the root.
-        if (!currentFrame.isRoot(js)) {
-          KJ_DASSERT(AsyncContextFrame::tryGetContext(js, promise) == nullptr);
-          AsyncContextFrame::attachContext(js, promise);
+        KJ_IF_MAYBE(frame, AsyncContextFrame::current(js)) {
+          frame->attachContext(js, promise);
         }
         break;
       }
@@ -259,25 +254,13 @@ void IsolateBase::promiseHook(v8::PromiseHookType type,
         KJ_IF_MAYBE(frame, AsyncContextFrame::tryGetContext(js, promise)) {
           isolateBase.pushAsyncFrame(*frame);
         } else {
-          // If the promise does not have a frame attached, we assume the root
-          // frame is used. Just to keep bookkeeping easier, we still go ahead
-          // and push the frame onto the stack again so we can just unconditionally
-          // pop it off in the kAfter without performing additional checks.
-          isolateBase.pushAsyncFrame(*isolateBase.getRootAsyncContext());
+          isolateBase.pushRootAsyncFrame();
         }
         // We do not use AsyncContextFrame::Scope here because we do not exit the frame
         // until the kAfter event fires.
         break;
       }
       case v8::PromiseHookType::kAfter: {
-  #ifdef KJ_DEBUG
-        KJ_IF_MAYBE(frame, AsyncContextFrame::tryGetContext(js, promise)) {
-          // The frame associated with the promise must be the current frame.
-          KJ_ASSERT(frame == &currentFrame);
-        } else {
-          KJ_ASSERT(currentFrame.isRoot(js));
-        }
-  #endif
         isolateBase.popAsyncFrame();
 
         // If the promise has been rejected here, we have to maintain the association of the
@@ -298,9 +281,10 @@ void IsolateBase::promiseHook(v8::PromiseHookType type,
         // Promise.resolve, and Promise.reject) and instead will emit the kResolve event first.
         // When this event occurs, and the promise is rejected, we need to check to see if the
         // promise is already wrapped, and if it is not, do so.
-        if (!currentFrame.isRoot(js) && isRejected() &&
-            AsyncContextFrame::tryGetContext(js, promise) == nullptr) {
-          AsyncContextFrame::attachContext(js, promise);
+        KJ_IF_MAYBE(current, AsyncContextFrame::current(js)) {
+          if (isRejected() && AsyncContextFrame::tryGetContext(js, promise) == nullptr) {
+            current->attachContext(js, promise);
+          }
         }
         break;
       }

--- a/src/workerd/jsg/async-context.h
+++ b/src/workerd/jsg/async-context.h
@@ -131,6 +131,7 @@ public:
     // AsyncContextFrame::Scope makes the given AsyncContextFrame the current in the
     // stack until the scope is destroyed.
     IsolateBase& isolate;
+    kj::Maybe<AsyncContextFrame&> prior;
     Scope(Lock& js, kj::Maybe<AsyncContextFrame&> frame = nullptr);
     Scope(v8::Isolate* isolate, kj::Maybe<AsyncContextFrame&> frame = nullptr);
     // If frame is nullptr, the root frame is assumed.
@@ -141,6 +142,7 @@ public:
   kj::Maybe<Value&> get(StorageKey& key);
   // Retrieves the value that is associated with the given key.
 
+  v8::Local<v8::Object> getJSWrapper(v8::Isolate* isolate);
   v8::Local<v8::Object> getJSWrapper(Lock& js);
   // Gets an opaque JavaScript Object wrapper object for this frame. If a wrapper
   // does not currently exist, one is created. This wrapper is only used to set a

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -774,6 +774,7 @@ private:
     v8::Global<v8::Promise> promise;
     v8::Global<v8::Value> value;
     v8::Global<v8::Message> message;
+    kj::Maybe<Ref<AsyncContextFrame>> asyncContextFrame;
 
     inline bool isAlive() { return !promise.IsEmpty() && !value.IsEmpty(); }
 

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -100,8 +100,6 @@ public:
     KJ_IF_MAYBE(logger, maybeLogger) { (*logger)(js, message); }
   }
 
-  void setAsyncContextTrackingEnabled();
-
   v8::Local<v8::Private> getPrivateSymbolFor(Lock::PrivateSymbols symbol);
 
 private:
@@ -233,10 +231,6 @@ private:
   // use `->InstanceTemplate()->NewInstance()` to construct an object, and you can pass this to
   // `FindInstanceInPrototypeChain()` on an existing object to check whether it was created using
   // this template.
-
-  static void promiseHook(v8::PromiseHookType type,
-                          v8::Local<v8::Promise> promise,
-                          v8::Local<v8::Value> parent);
 
   void setCurrentAsyncContextFrame(kj::Maybe<AsyncContextFrame&> maybeFrame);
   kj::Maybe<AsyncContextFrame&> maybeCurrentAsyncContextFrame;

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -102,7 +102,6 @@ public:
   }
 
   void setAsyncContextTrackingEnabled();
-  AsyncContextFrame* getRootAsyncContext();
 
   v8::Local<v8::Private> getPrivateSymbolFor(Lock::PrivateSymbols symbol);
 
@@ -243,15 +242,15 @@ private:
   // Pushes the frame onto the stack making it current. Importantly, the stack
   // does not maintain a refcounted reference to the frame so it is important
   // for the caller to ensure that the frame is kept alive.
+  void pushRootAsyncFrame();
   void popAsyncFrame();
 
-  kj::Vector<AsyncContextFrame*> asyncFrameStack;
-  kj::Maybe<Ref<AsyncContextFrame>> rootAsyncFrame;
-  // The rootAsyncFrame is a maybe because it is lazily initialized.
-  // We cannot create Ref's within the IsolateBase constructor and
-  // we don't want this to be a bare kj::Own because it might have
-  // a JS wrapper associated with it. Calling getRootAsyncContext
-  // for the first time will lazily create the root frame.
+  struct RootAsyncContextFrame {
+    // A sentinel for the RootAsyncContextFrame. Used only for bookkeeping
+    // in the async frame stack below.
+  };
+
+  kj::Vector<kj::OneOf<AsyncContextFrame*, RootAsyncContextFrame>> asyncFrameStack;
 
   friend class AsyncContextFrame;
 };

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -11,7 +11,6 @@
 #include <workerd/util/batch-queue.h>
 #include <kj/map.h>
 #include <kj/mutex.h>
-#include <deque>
 
 namespace workerd::jsg {
 
@@ -238,19 +237,9 @@ private:
   static void promiseHook(v8::PromiseHookType type,
                           v8::Local<v8::Promise> promise,
                           v8::Local<v8::Value> parent);
-  void pushAsyncFrame(AsyncContextFrame& next);
-  // Pushes the frame onto the stack making it current. Importantly, the stack
-  // does not maintain a refcounted reference to the frame so it is important
-  // for the caller to ensure that the frame is kept alive.
-  void pushRootAsyncFrame();
-  void popAsyncFrame();
 
-  struct RootAsyncContextFrame {
-    // A sentinel for the RootAsyncContextFrame. Used only for bookkeeping
-    // in the async frame stack below.
-  };
-
-  kj::Vector<kj::OneOf<AsyncContextFrame*, RootAsyncContextFrame>> asyncFrameStack;
+  void setCurrentAsyncContextFrame(kj::Maybe<AsyncContextFrame&> maybeFrame);
+  kj::Maybe<AsyncContextFrame&> maybeCurrentAsyncContextFrame;
 
   friend class AsyncContextFrame;
 };


### PR DESCRIPTION
Further simplify async context tracking (and improve performance) by eliminating the promise hook.

Unfortunately, this does introduce a change in behavior that is incompatible with Node.js around the behavior of unhandled rejections. See https://github.com/nodejs/node/issues/46262 for details.

That difference is likely acceptable, however, Node.js' unhandled rejection handler does not follow the standard anyway. And this implementation is much simpler and more performant than the promise hook