### PR TITLE
Clear root context frame under lock

### DIFF
--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -337,6 +337,9 @@ void IsolateBase::dropWrappers(kj::Own<void> typeWrapperInstance) {
   v8::Locker lock(ptr);
   v8::Isolate::Scope scope(ptr);
 
+  // Clear the rootAsyncFrame reference under lock.
+  rootAsyncFrame = nullptr;
+
   // Make sure everything in the deferred destruction queue is dropped.
   clearDestructionQueue();
 


### PR DESCRIPTION
https://github.com/cloudflare/workerd/pull/282 is a better more complete change but this addresses an immediate bug.