### PR TITLE
Implement IsolatePtr

### DIFF
--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -44,6 +44,47 @@ const char* JsExceptionThrown::what() const noexcept {
 Data::Data(v8::Isolate* isolate, v8::Local<v8::Data> handle)
     : isolate(IsolateBase::from(isolate).getIsolatePtr()), handle(isolate, handle) {}
 
+Data::Data(Data&& other): isolate(other.isolate), handle(kj::mv(other.handle)) {
+  KJ_IF_MAYBE(t, other.tracedHandle) {
+    // `other` is a traced `Data`, but once moved, we don't assume the new location is traced.
+    // So, we need to make the handle strong.
+    handle.ClearWeak();
+
+    // Presumably, `other` is about to be destroyed. The destructor of `TracedReference`, though,
+    // does nothing, because it doesn't know if the reference is even still valid, since it
+    // could be called during GC sweep time. But here, we know that `other` is definitely still
+    // valid, because we wouldn't be moving from an unreachable object. So we should Reset() the
+    // `TracedReference` so that V8 knows it's gone, which might make minor GCs more effective.
+    t->Reset();
+
+    other.tracedHandle = nullptr;
+  }
+  other.isolate.clear();
+  assertInvariant();
+  other.assertInvariant();
+}
+
+Data::~Data() noexcept(false) {
+  destroy();
+}
+
+Data& Data::operator=(Data&& other) {
+  if (this != &other) {
+    destroy();
+    isolate = other.isolate;
+    handle = kj::mv(other.handle);
+    other.isolate.clear();
+    KJ_IF_MAYBE(t, other.tracedHandle) {
+      handle.ClearWeak();
+      t->Reset();
+      other.tracedHandle = nullptr;
+    }
+  }
+  assertInvariant();
+  other.assertInvariant();
+  return *this;
+}
+
 void Data::destroy() {
   assertInvariant();
   auto i = isolate.get();

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -717,7 +717,7 @@ public:
 
       other.tracedHandle = nullptr;
     }
-    other.isolate = nullptr;
+    other.isolate.clear();
     assertInvariant();
     other.assertInvariant();
   }
@@ -726,7 +726,7 @@ public:
       destroy();
       isolate = other.isolate;
       handle = kj::mv(other.handle);
-      other.isolate = nullptr;
+      other.isolate.clear();
       KJ_IF_MAYBE(t, other.tracedHandle) {
         handle.ClearWeak();
         t->Reset();
@@ -739,8 +739,7 @@ public:
   }
   KJ_DISALLOW_COPY(Data);
 
-  Data(v8::Isolate* isolate, v8::Local<v8::Data> handle)
-      : isolate(isolate), handle(isolate, handle) {}
+  Data(v8::Isolate* isolate, v8::Local<v8::Data> handle);
   v8::Local<v8::Data> getHandle(v8::Isolate* isolate) { return handle.Get(isolate); }
   v8::Local<v8::Data> getHandle(Lock& js);
   // Interact with raw V8 types.
@@ -753,7 +752,7 @@ public:
   }
 
 private:
-  v8::Isolate* isolate = nullptr;
+  IsolatePtr isolate;
   // The isolate with which the handles below are associated.
 
   v8::Global<v8::Data> handle;

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -248,7 +248,7 @@ namespace {
 IsolateBase::IsolateBase(const V8System& system, v8::Isolate::CreateParams&& createParams)
     : system(system),
       ptr(newIsolate(kj::mv(createParams))),
-      heapTracer(ptr) {
+      heapTracer(ptr.get()) {
   v8::CppHeapCreateParams params {
     .wrapper_descriptor = v8::WrapperDescriptor(
         Wrappable::WRAPPABLE_TAG_FIELD_INDEX,
@@ -325,7 +325,7 @@ IsolateBase::~IsolateBase() noexcept(false) {
   // To be safe we call `Terminate()`.
   cppgcHeap->Terminate();
 
-  ptr->Dispose();
+  ptr.Dispose();
 }
 
 v8::Local<v8::FunctionTemplate> IsolateBase::getOpaqueTemplate(v8::Isolate* isolate) {

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -106,6 +106,8 @@ public:
 
   v8::Local<v8::Private> getPrivateSymbolFor(Lock::PrivateSymbols symbol);
 
+  inline IsolatePtr getIsolatePtr() { return ptr; }
+
 private:
   template <typename TypeWrapper>
   friend class Isolate;
@@ -135,7 +137,7 @@ private:
   using Item = kj::OneOf<v8::Global<v8::Data>, RefToDelete>;
 
   const V8System& system;
-  v8::Isolate* ptr;
+  IsolatePtr ptr;
   bool evalAllowed = false;
   bool captureThrowsAsRejections = false;
   // The Web Platform API specifications require that any API that returns a JavaScript Promise


### PR DESCRIPTION
A crash can occur if a Ref or V8Ref is accessed or destroyed after the associated IsolateBase is destroyed and the v8::Isolate* has been disposed. The existing raw pointers to v8::Isolate* that are held by Ref and V8Ref aren't safe to access once that happens. The case is rare but not impossible to hit -- particularly when a Ref/V8Ref is held persistently.

This implements a safer IsolatePtr that will return nullptr for the v8::Isolate if it has been cleared, moved, or disposed.

Also moves a couple jsg::Data class impl methods into jsg.c++. Since it's not a template class, there's no reason for the implementations to be in the header.