### PR TITLE
add missing header

### DIFF
--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -6,6 +6,7 @@
 #include <workerd/io/worker-entrypoint.h>
 #include <workerd/jsg/modules.h>
 #include <workerd/server/workerd-api.h>
+#include <algorithm>
 
 namespace workerd {
 


### PR DESCRIPTION
looks like it is already included in most environments somehow, but others need it.