### PR TITLE
Allow Durable Objects to be stored persistently on local disk using SQLite

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -59,6 +59,15 @@ http_archive(
     build_file = "//:build/BUILD.lol-html",
 )
 
+http_archive(
+    name = "sqlite3",
+    url = "https://sqlite.org/2022/sqlite-amalgamation-3400100.zip",
+    strip_prefix = "sqlite-amalgamation-3400100",
+    type = "zip",
+    sha256 = "49112cc7328392aa4e3e5dae0b2f6736d0153430143d21f69327788ff4efe734",
+    build_file = "//:build/BUILD.sqlite3",
+)
+
 # ========================================================================================
 # tcmalloc
 

--- a/build/BUILD.sqlite3
+++ b/build/BUILD.sqlite3
@@ -4,4 +4,5 @@ cc_library(
     srcs = ["sqlite3.c"],
     visibility = ["//visibility:public"],
     include_prefix = ".",
+    copts = ["-w"],  # Ignore all warnings. This is not our code, we can't fix the warnings.
 )

--- a/build/BUILD.sqlite3
+++ b/build/BUILD.sqlite3
@@ -1,0 +1,7 @@
+cc_library(
+    name = "sqlite3",
+    hdrs = ["sqlite3.h", "sqlite3ext.h"],
+    srcs = ["sqlite3.c"],
+    visibility = ["//visibility:public"],
+    include_prefix = "",
+)

--- a/build/BUILD.sqlite3
+++ b/build/BUILD.sqlite3
@@ -3,5 +3,5 @@ cc_library(
     hdrs = ["sqlite3.h", "sqlite3ext.h"],
     srcs = ["sqlite3.c"],
     visibility = ["//visibility:public"],
-    include_prefix = "",
+    include_prefix = ".",
 )

--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -485,17 +485,27 @@ jsg::Promise<void> DurableObjectStorageOperations::deleteAlarm(
 }
 
 jsg::Promise<void> DurableObjectStorage::deleteAll(
-    jsg::Optional<PutOptions> maybeOptions, v8::Isolate* isolate) {
+    jsg::Lock& js, jsg::Optional<PutOptions> maybeOptions) {
   auto options = configureOptions(kj::mv(maybeOptions).orDefault(PutOptions{}));
-  auto deleteAll = cache->deleteAll(options);
 
-  auto& context = IoContext::current();
-  context.addTask(deleteAll.count.then([&metrics = currentActorMetrics()](uint deleted) {
-    if (deleted == 0) deleted = 1;
-    metrics.addStorageDeletes(deleted);
-  }));
+  KJ_SWITCH_ONEOF(cache) {
+    KJ_CASE_ONEOF(actorCache, IoPtr<ActorCache>) {
+      auto deleteAll = actorCache->deleteAll(options);
 
-  return transformMaybeBackpressure(isolate, options, kj::mv(deleteAll.backpressure));
+      auto& context = IoContext::current();
+      context.addTask(deleteAll.count.then([&metrics = currentActorMetrics()](uint deleted) {
+        if (deleted == 0) deleted = 1;
+        metrics.addStorageDeletes(deleted);
+      }));
+
+      return transformMaybeBackpressure(js.v8Isolate, options, kj::mv(deleteAll.backpressure));
+    }
+    KJ_CASE_ONEOF(sqliteKv, IoPtr<ActorSqlite>) {
+      sqliteKv->deleteAll();
+      return js.resolvedPromise();
+    }
+  }
+  KJ_UNREACHABLE;
 }
 
 void DurableObjectTransaction::deleteAll() {
@@ -572,67 +582,97 @@ jsg::Promise<int> DurableObjectStorageOperations::deleteMultiple(
 }
 
 ActorCacheInterface& DurableObjectStorage::getCache(OpName op) {
-  return *cache;
+  KJ_SWITCH_ONEOF(cache) {
+    KJ_CASE_ONEOF(actorCache, IoPtr<ActorCache>) {
+      return *actorCache;
+    }
+    KJ_CASE_ONEOF(sqliteKv, IoPtr<ActorSqlite>) {
+      return *sqliteKv;
+    }
+  }
+  KJ_UNREACHABLE;
 }
 
 jsg::Promise<jsg::Value> DurableObjectStorage::transaction(jsg::Lock& js,
     jsg::Function<jsg::Promise<jsg::Value>(jsg::Ref<DurableObjectTransaction>)> callback,
     jsg::Optional<TransactionOptions> options) {
-  auto& context = IoContext::current();
-  auto txn = jsg::alloc<DurableObjectTransaction>(context.addObject(
-        kj::heap<ActorCache::Transaction>(*cache)));
-
-  struct TxnResult {
-    jsg::Value value;
-    bool isError;
-  };
-
-  return context.blockConcurrencyWhile(js,
-      [callback = kj::mv(callback), txn = kj::mv(txn)]
-      (jsg::Lock& js) mutable -> jsg::Promise<TxnResult> {
-    return js.resolvedPromise(txn.addRef())
-        .then(js, kj::mv(callback))
-        .then(js, [txn = txn.addRef()](jsg::Lock& js, jsg::Value value) mutable {
-      // In correct usage, `context` should not have changed here, particularly because we're in
-      // a critical section so it should have been impossible for any other context to receive
-      // control. However, depending on all that is a bit precarious. jsg::Promise::then() itself
-      // does NOT guarantee it runs in the same context (the application could have returned a
-      // custom Promise and then resolved in from some other context). So let's be safe and grab
-      // IoContext::current() again here, rather than capture it in the lambda.
+  KJ_SWITCH_ONEOF(cache) {
+    KJ_CASE_ONEOF(actorCache, IoPtr<ActorCache>) {
       auto& context = IoContext::current();
-      return context.awaitIoWithInputLock(txn->maybeCommit(), [value = kj::mv(value)]() mutable {
-        return TxnResult { kj::mv(value), false };
+      auto txn = jsg::alloc<DurableObjectTransaction>(context.addObject(
+            kj::heap<ActorCache::Transaction>(*actorCache)));
+
+      struct TxnResult {
+        jsg::Value value;
+        bool isError;
+      };
+
+      return context.blockConcurrencyWhile(js,
+          [callback = kj::mv(callback), txn = kj::mv(txn)]
+          (jsg::Lock& js) mutable -> jsg::Promise<TxnResult> {
+        return js.resolvedPromise(txn.addRef())
+            .then(js, kj::mv(callback))
+            .then(js, [txn = txn.addRef()](jsg::Lock& js, jsg::Value value) mutable {
+          // In correct usage, `context` should not have changed here, particularly because we're in
+          // a critical section so it should have been impossible for any other context to receive
+          // control. However, depending on all that is a bit precarious. jsg::Promise::then() itself
+          // does NOT guarantee it runs in the same context (the application could have returned a
+          // custom Promise and then resolved in from some other context). So let's be safe and grab
+          // IoContext::current() again here, rather than capture it in the lambda.
+          auto& context = IoContext::current();
+          return context.awaitIoWithInputLock(txn->maybeCommit(), [value = kj::mv(value)]() mutable {
+            return TxnResult { kj::mv(value), false };
+          });
+        }, [txn = txn.addRef()](jsg::Lock& js, jsg::Value exception) mutable {
+          // The transaction callback threw an exception. We don't actually want to reset the object,
+          // we only want to roll back the transaction and propagate the exception. So, we carefully
+          // pack the exception away into a value.
+          txn->maybeRollback();
+          return js.resolvedPromise(TxnResult { kj::mv(exception), true });
+        });
+      }).then(js, [](jsg::Lock& js, TxnResult result) -> jsg::Value {
+        if (result.isError) {
+          js.throwException(kj::mv(result.value));
+        } else {
+          return kj::mv(result.value);
+        }
       });
-    }, [txn = txn.addRef()](jsg::Lock& js, jsg::Value exception) mutable {
-      // The transaction callback threw an exception. We don't actually want to reset the object,
-      // we only want to roll back the transaction and propagate the exception. So, we carefully
-      // pack the exception away into a value.
-      txn->maybeRollback();
-      return js.resolvedPromise(TxnResult { kj::mv(exception), true });
-    });
-  }).then(js, [](jsg::Lock& js, TxnResult result) -> jsg::Value {
-    if (result.isError) {
-      js.throwException(kj::mv(result.value));
-    } else {
-      return kj::mv(result.value);
     }
-  });
+    KJ_CASE_ONEOF(sqliteKv, IoPtr<ActorSqlite>) {
+      // TODO(sqlite): Implement transactions.
+      JSG_FAIL_REQUIRE(Error, "transaction() not yet implemented for SQLite-backed storage");
+    }
+  }
+  KJ_UNREACHABLE;
 }
 
 jsg::Promise<void> DurableObjectStorage::sync(jsg::Lock& js) {
-  KJ_IF_MAYBE(p, cache->onNoPendingFlush()) {
-    // Note that we're not actually flushing since that will happen anyway once we go async. We're
-    // merely checking if we have any pending or in-flight operations, and providing a promise that
-    // resolves when they succeed. This promise only covers operations that were scheduled before
-    // this method was invoked. If the cache has to flush again later from future operations, this
-    // promise will resolve before they complete. If this promise were to reject, then the actor's
-    // output gate will be broken first and the isolate will not resume synchronous execution.
+  KJ_SWITCH_ONEOF(cache) {
+    KJ_CASE_ONEOF(actorCache, IoPtr<ActorCache>) {
+      KJ_IF_MAYBE(p, actorCache->onNoPendingFlush()) {
+        // Note that we're not actually flushing since that will happen anyway once we go async. We're
+        // merely checking if we have any pending or in-flight operations, and providing a promise that
+        // resolves when they succeed. This promise only covers operations that were scheduled before
+        // this method was invoked. If the cache has to flush again later from future operations, this
+        // promise will resolve before they complete. If this promise were to reject, then the actor's
+        // output gate will be broken first and the isolate will not resume synchronous execution.
 
-    auto& context = IoContext::current();
-    return context.awaitIo(kj::mv(*p));
-  } else {
-    return js.resolvedPromise();
+        auto& context = IoContext::current();
+        return context.awaitIo(kj::mv(*p));
+      } else {
+        return js.resolvedPromise();
+      }
+    }
+    KJ_CASE_ONEOF(sqliteKv, IoPtr<ActorSqlite>) {
+      KJ_IF_MAYBE(p, sqliteKv->sync()) {
+        auto& context = IoContext::current();
+        return context.awaitIo(kj::mv(*p));
+      } else {
+        return js.resolvedPromise();
+      }
+    }
   }
+  KJ_UNREACHABLE;
 }
 
 ActorCacheInterface& DurableObjectTransaction::getCache(OpName op) {

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -21,6 +21,7 @@ wd_cc_library(
         "//src/workerd/api:analytics-engine_capnp",
         "//src/workerd/api:r2-api_capnp",
         "//src/workerd/jsg",
+        "//src/workerd/util:sqlite",
         "//src/node:bundle",
     ],
 )

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -1,0 +1,94 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "actor-sqlite.h"
+#include <algorithm>
+
+namespace workerd {
+
+kj::OneOf<kj::Maybe<ActorCacheInterface::Value>,
+          kj::Promise<kj::Maybe<ActorCacheInterface::Value>>>
+    ActorSqlite::get(Key key, ReadOptions options) {
+  kj::Maybe<ActorCacheInterface::Value> result;
+  kv.get(key, [&](ValuePtr value) {
+    result = kj::heapArray(value);
+  });
+  return result;
+}
+
+kj::OneOf<ActorCacheInterface::GetResultList, kj::Promise<ActorCacheInterface::GetResultList>>
+    ActorSqlite::get(kj::Array<Key> keys, ReadOptions options) {
+  kj::Vector<KeyValuePair> results;
+  for (auto& key: keys) {
+    kv.get(key, [&](ValuePtr value) {
+      results.add(KeyValuePair { kj::mv(key), kj::heapArray(value) });
+    });
+  }
+  std::sort(results.begin(), results.end(),
+      [](auto& a, auto& b) { return a.key < b.key; });
+  return GetResultList(kj::mv(results));
+}
+
+kj::OneOf<kj::Maybe<kj::Date>, kj::Promise<kj::Maybe<kj::Date>>> ActorSqlite::getAlarm(
+    ReadOptions options) {
+  // TODO(sqlite): Implement alarms for sqlite storage.
+  JSG_FAIL_REQUIRE(Error, "getAlarm() is not yet implemented for SQLite-backed Durable Objects");
+}
+
+kj::OneOf<ActorCacheInterface::GetResultList, kj::Promise<ActorCacheInterface::GetResultList>>
+    ActorSqlite::list(Key begin, kj::Maybe<Key> end, kj::Maybe<uint> limit, ReadOptions options) {
+  kj::Vector<KeyValuePair> results;
+  kv.list(begin, end, limit, SqliteKv::FORWARD, [&](KeyPtr key, ValuePtr value) {
+    results.add(KeyValuePair { kj::str(key), kj::heapArray(value) });
+  });
+
+  // Already guaranteed sorted.
+  return GetResultList(kj::mv(results));
+}
+
+kj::OneOf<ActorCacheInterface::GetResultList, kj::Promise<ActorCacheInterface::GetResultList>>
+    ActorSqlite::listReverse(Key begin, kj::Maybe<Key> end, kj::Maybe<uint> limit,
+                               ReadOptions options) {
+  kj::Vector<KeyValuePair> results;
+  kv.list(begin, end, limit, SqliteKv::REVERSE, [&](KeyPtr key, ValuePtr value) {
+    results.add(KeyValuePair { kj::str(key), kj::heapArray(value) });
+  });
+
+  // Already guaranteed sorted (reversed).
+  return GetResultList(kj::mv(results));
+}
+
+kj::Maybe<kj::Promise<void>> ActorSqlite::put(Key key, Value value, WriteOptions options) {
+  kv.put(key, value);
+  return nullptr;
+}
+
+kj::Maybe<kj::Promise<void>> ActorSqlite::put(
+    kj::Array<KeyValuePair> pairs, WriteOptions options) {
+  for (auto& pair: pairs) {
+    kv.put(pair.key, pair.value);
+  }
+  return nullptr;
+}
+
+kj::OneOf<bool, kj::Promise<bool>> ActorSqlite::delete_(Key key, WriteOptions options) {
+  return kv.delete_(key);
+}
+
+kj::OneOf<uint, kj::Promise<uint>> ActorSqlite::delete_(
+    kj::Array<Key> keys, WriteOptions options) {
+  uint count = 0;
+  for (auto& key: keys) {
+    count += kv.delete_(key);
+  }
+  return count;
+}
+
+kj::Maybe<kj::Promise<void>> ActorSqlite::setAlarm(
+    kj::Maybe<kj::Date> newAlarmTime, WriteOptions options) {
+  // TODO(sqlite): Implement alarms for sqlite storage.
+  JSG_FAIL_REQUIRE(Error, "getAlarm() is not yet implemented for SQLite-backed Durable Objects");
+}
+
+}  // namespace workerd

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include "actor-cache.h"
+#include <workerd/util/sqlite-kv.h>
+
+namespace workerd {
+
+class ActorSqlite final: public ActorCacheInterface {
+  // An implementation of ActorCacheInterface that is backed by SqliteKv.
+  //
+  // TODO(perf): This interface is not designed ideally for wrapping SqliteKv. In particular, we
+  //   end up allocating extra copies of all the results. It would be nicer if we could actually
+  //   parse the V8-serialized values directly from the blob pointers that SQLite spits out.
+  //   However, that probably requires rewriting `DurableObjectStorageOperations`. For now, hooking
+  //   here is easier and not too costly.
+
+public:
+  ActorSqlite(Sqlite::Vfs& vfs, kj::PathPtr path)
+      : db(vfs, path, kj::WriteMode::CREATE | kj::WriteMode::MODIFY | kj::WriteMode::CREATE_PARENT),
+        kv(db) {}
+
+  kj::OneOf<kj::Maybe<Value>, kj::Promise<kj::Maybe<Value>>> get(
+      Key key, ReadOptions options) override;
+  kj::OneOf<GetResultList, kj::Promise<GetResultList>> get(
+      kj::Array<Key> keys, ReadOptions options) override;
+  kj::OneOf<kj::Maybe<kj::Date>, kj::Promise<kj::Maybe<kj::Date>>> getAlarm(
+      ReadOptions options) override;
+  kj::OneOf<GetResultList, kj::Promise<GetResultList>> list(
+      Key begin, kj::Maybe<Key> end, kj::Maybe<uint> limit, ReadOptions options) override;
+  kj::OneOf<GetResultList, kj::Promise<GetResultList>> listReverse(
+      Key begin, kj::Maybe<Key> end, kj::Maybe<uint> limit, ReadOptions options) override;
+  kj::Maybe<kj::Promise<void>> put(Key key, Value value, WriteOptions options) override;
+  kj::Maybe<kj::Promise<void>> put(kj::Array<KeyValuePair> pairs, WriteOptions options) override;
+  kj::OneOf<bool, kj::Promise<bool>> delete_(Key key, WriteOptions options) override;
+  kj::OneOf<uint, kj::Promise<uint>> delete_(kj::Array<Key> keys, WriteOptions options) override;
+  kj::Maybe<kj::Promise<void>> setAlarm(kj::Maybe<kj::Date> newAlarmTime, WriteOptions options) override;
+
+  void deleteAll() { kv.deleteAll(); }
+  // TODO(sqlite): deleteAll() should delete the database from disk if there are no other tables.
+  //   For that matter, the database should not be created on disk until it is first written.
+
+  kj::Maybe<kj::Promise<void>> sync() { return nullptr; }
+  // TODO(sqlite): synk() should wait for replication if applicable.
+
+private:
+  Sqlite db;
+  SqliteKv kv;
+};
+
+}  // namespace workerd

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -19,7 +19,7 @@ class ActorSqlite final: public ActorCacheInterface {
   //   here is easier and not too costly.
 
 public:
-  ActorSqlite(Sqlite::Vfs& vfs, kj::PathPtr path)
+  ActorSqlite(SqliteDatabase::Vfs& vfs, kj::PathPtr path)
       : db(vfs, path, kj::WriteMode::CREATE | kj::WriteMode::MODIFY | kj::WriteMode::CREATE_PARENT),
         kv(db) {}
 
@@ -47,7 +47,7 @@ public:
   // TODO(sqlite): synk() should wait for replication if applicable.
 
 private:
-  Sqlite db;
+  SqliteDatabase db;
   SqliteKv kv;
 };
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -20,6 +20,7 @@
 #include <openssl/bio.h>
 #include <openssl/pem.h>
 #include <workerd/io/actor-cache.h>
+#include <workerd/io/actor-sqlite.h>
 #include <workerd/api/actor-state.h>
 #include "workerd-api.h"
 
@@ -745,6 +746,8 @@ public:
     return { this, kj::NullDisposer::instance };
   }
 
+  kj::Maybe<const kj::Directory&> getWritable() { return writable; }
+
   bool hasHandler(kj::StringPtr handlerName) override {
     return handlerName == "fetch"_kj;
   }
@@ -1147,6 +1150,7 @@ public:
     kj::Array<Service*> subrequest;
     kj::Array<kj::Maybe<ActorNamespace&>> actor;  // null = configuration error
     kj::Maybe<Service&> cache;
+    kj::Maybe<kj::Own<Sqlite::Vfs>> actorStorage;
   };
   using LinkCallback = kj::Function<LinkedIoChannels(WorkerService&)>;
 
@@ -1155,9 +1159,10 @@ public:
                 kj::HashMap<kj::String, kj::HashSet<kj::String>> namedEntrypointsParam,
                 const kj::HashMap<kj::String, ActorConfig>& actorClasses,
                 LinkCallback linkCallback)
-      : threadContext(threadContext), worker(kj::mv(worker)),
-        defaultEntrypointHandlers(kj::mv(defaultEntrypointHandlers)),
+      : threadContext(threadContext),
         ioChannels(kj::mv(linkCallback)),
+        worker(kj::mv(worker)),
+        defaultEntrypointHandlers(kj::mv(defaultEntrypointHandlers)),
         waitUntilTasks(*this) {
     namedEntrypoints.reserve(namedEntrypointsParam.size());
     for (auto& ep: namedEntrypointsParam) {
@@ -1248,16 +1253,34 @@ public:
         }
 
         auto actor = kj::addRef(*actors.findOrCreate(idStr, [&]() {
+          auto& channels = KJ_ASSERT_NONNULL(service.ioChannels.tryGet<LinkedIoChannels>());
+          kj::Maybe<ActorSqlite&> actorSqlite;
+
           auto persistent = config.tryGet<Durable>().map([&](const Durable& d) {
-            // TODO(someday): Implement some sort of actual durable storage. For now we force
-            //   `ActorCache` into `neverFlush` mode so that all state is kept in-memory.
-            return rpc::ActorStorage::Stage::Client(kj::heap<EmptyReadOnlyActorStorageImpl>());
+            kj::Own<ActorSqlite> ownSqlite;
+            KJ_IF_MAYBE(as, channels.actorStorage) {
+              ownSqlite = kj::heap<ActorSqlite>(**as,
+                  kj::Path({d.uniqueKey, kj::str(idStr, ".sqlite")}));
+              actorSqlite = *ownSqlite;
+            }
+
+            // TODO(sqlite)(cleanup): This isn't actually used when using local disk storage. Can
+            //   we make it go away? For now we use it as a convenient place to attach the
+            //   ActorSqlite object so that it sticks around for the appropriate lifetime.
+            return rpc::ActorStorage::Stage::Client(
+                kj::heap<EmptyReadOnlyActorStorageImpl>().attach(kj::mv(ownSqlite)));
           });
 
-          auto makeStorage = [](jsg::Lock& js, const Worker::ApiIsolate& apiIsolate,
-                                ActorCache& actorCache)
+          auto makeStorage = [actorSqlite](jsg::Lock& js, const Worker::ApiIsolate& apiIsolate,
+                                           ActorCache& actorCache)
                             -> jsg::Ref<api::DurableObjectStorage> {
-            return jsg::alloc<api::DurableObjectStorage>(IoContext::current().addObject(actorCache));
+            KJ_IF_MAYBE(a, actorSqlite) {
+              return jsg::alloc<api::DurableObjectStorage>(
+                  IoContext::current().addObject(*a));
+            } else {
+              return jsg::alloc<api::DurableObjectStorage>(
+                  IoContext::current().addObject(actorCache));
+            }
           };
 
           TimerChannel& timerChannel = service;
@@ -1268,6 +1291,8 @@ public:
               className, kj::mv(makeStorage), lock,
               timerChannel, kj::refcounted<ActorObserver>());
 
+          // TODO(sqlite): Now that actors are backed by real disk, we should shut them down after
+          //   a minute of inactivity...
           return kj::HashMap<kj::String, kj::Own<Worker::Actor>>::Entry {
             kj::mv(idStr), kj::mv(newActor)
           };
@@ -1309,11 +1334,14 @@ private:
   };
 
   ThreadContext& threadContext;
+
+  kj::OneOf<LinkCallback, LinkedIoChannels> ioChannels;
+  // LinkedIoChannels owns the Sqlite::Vfs, so make sure it is destroyed last.
+
   kj::Own<const Worker> worker;
   kj::Maybe<kj::HashSet<kj::String>> defaultEntrypointHandlers;
   kj::HashMap<kj::String, EntrypointService> namedEntrypoints;
   kj::HashMap<kj::StringPtr, ActorNamespace> actorNamespaces;
-  kj::OneOf<LinkCallback, LinkedIoChannels> ioChannels;
   kj::TaskSet waitUntilTasks;
 
   class ActorChannelImpl final: public IoChannelFactory::ActorChannel {
@@ -1902,6 +1930,8 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
   auto linkCallback =
       [this, name, conf, subrequestChannels = kj::mv(subrequestChannels),
        actorChannels = kj::mv(actorChannels)](WorkerService& workerService) mutable {
+    WorkerService::LinkedIoChannels result;
+
     auto services = kj::heapArrayBuilder<Service*>(subrequestChannels.size() +
               IoContext::SPECIAL_SUBREQUEST_CHANNEL_COUNT);
 
@@ -1918,7 +1948,9 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
       services.add(&lookupService(channel.designator, kj::mv(channel.errorContext)));
     }
 
-    auto actors = KJ_MAP(channel, actorChannels) -> kj::Maybe<WorkerService::ActorNamespace&> {
+    result.subrequest = services.finish();
+
+    result.actor = KJ_MAP(channel, actorChannels) -> kj::Maybe<WorkerService::ActorNamespace&> {
       WorkerService* targetService = &workerService;
       if (channel.designator.hasServiceName()) {
         auto& svc = KJ_UNWRAP_OR(this->services.find(channel.designator.getServiceName()), {
@@ -1937,21 +1969,31 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
     };
 
     if (conf.hasCacheApiOutbound()) {
-      Service& cacheApi = lookupService(conf.getCacheApiOutbound(),
-                                        kj::str("Worker \"", name, "\"'s cacheApiOutbound"));
-
-      return WorkerService::LinkedIoChannels{
-          .subrequest = services.finish(),
-          .actor = kj::mv(actors),
-          .cache = &cacheApi
-      };
-    } else {
-      return WorkerService::LinkedIoChannels{
-          .subrequest = services.finish(),
-          .actor = kj::mv(actors)
-      };
+      result.cache = lookupService(conf.getCacheApiOutbound(),
+                                   kj::str("Worker \"", name, "\"'s cacheApiOutbound"));
     }
 
+    auto actorStorageConf = conf.getDurableObjectStorage();
+    if (actorStorageConf.isLocalDisk()) {
+      kj::StringPtr diskName = actorStorageConf.getLocalDisk();
+      KJ_IF_MAYBE(svc, this->services.find(actorStorageConf.getLocalDisk())) {
+        auto diskSvc = dynamic_cast<DiskDirectoryService*>(svc->get());
+        if (diskSvc == nullptr) {
+          reportConfigError(kj::str("service ", name, ": durableObjectStorage config refers "
+              "to the service \"", diskName, "\", but that service is not a local disk service."));
+        } else KJ_IF_MAYBE(dir, diskSvc->getWritable()) {
+          result.actorStorage = kj::heap<Sqlite::Vfs>(*dir);
+        } else {
+          reportConfigError(kj::str("service ", name, ": durableObjectStorage config refers "
+              "to the disk service \"", diskName, "\", but that service is defined read-only."));
+        }
+      } else {
+        reportConfigError(kj::str("service ", name, ": durableObjectStorage config refers "
+            "to a service \"", diskName, "\", but no such service is defined."));
+      }
+    }
+
+    return result;
   };
 
   return kj::heap<WorkerService>(globalContext->threadContext, kj::mv(worker),
@@ -2301,6 +2343,7 @@ void Server::startServices(jsg::V8System& v8System, config::Config::Reader confi
           }
           goto validDurableObjectStorage;
         case config::Worker::DurableObjectStorage::IN_MEMORY:
+        case config::Worker::DurableObjectStorage::LOCAL_DISK:
           goto validDurableObjectStorage;
       }
       reportConfigError(kj::str(

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1150,7 +1150,7 @@ public:
     kj::Array<Service*> subrequest;
     kj::Array<kj::Maybe<ActorNamespace&>> actor;  // null = configuration error
     kj::Maybe<Service&> cache;
-    kj::Maybe<kj::Own<Sqlite::Vfs>> actorStorage;
+    kj::Maybe<kj::Own<SqliteDatabase::Vfs>> actorStorage;
   };
   using LinkCallback = kj::Function<LinkedIoChannels(WorkerService&)>;
 
@@ -1336,7 +1336,7 @@ private:
   ThreadContext& threadContext;
 
   kj::OneOf<LinkCallback, LinkedIoChannels> ioChannels;
-  // LinkedIoChannels owns the Sqlite::Vfs, so make sure it is destroyed last.
+  // LinkedIoChannels owns the SqliteDatabase::Vfs, so make sure it is destroyed last.
 
   kj::Own<const Worker> worker;
   kj::Maybe<kj::HashSet<kj::String>> defaultEntrypointHandlers;
@@ -1982,7 +1982,7 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
           reportConfigError(kj::str("service ", name, ": durableObjectStorage config refers "
               "to the service \"", diskName, "\", but that service is not a local disk service."));
         } else KJ_IF_MAYBE(dir, diskSvc->getWritable()) {
-          result.actorStorage = kj::heap<Sqlite::Vfs>(*dir);
+          result.actorStorage = kj::heap<SqliteDatabase::Vfs>(*dir);
         } else {
           reportConfigError(kj::str("service ", name, ": durableObjectStorage config refers "
               "to the disk service \"", diskName, "\", but that service is defined read-only."));

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -495,8 +495,16 @@ struct Worker {
     #
     # This mode is intended for local testing purposes.
 
-    # TODO(someday): Support storage to a local directory.
-    # TODO(someday): Support storage to a database.
+    localDisk @12 :Text;
+    # ** EXPERIMENTAL; SUBJECT TO BACKWARDS-INCOMPATIBLE CHANGE **
+    #
+    # Durable Object data will be stored in a directory on local disk. This field is the name of
+    # a service, which must be a DiskDirectory service. For each Durable Object class, a
+    # subdirectory will be created using `uniqueKey` as the name. Within the directory, one or
+    # more files are created for each object, with names `<id>.<ext>`, where `.<ext>` may be any of
+    # a number of different extensions depending on the storage mode. (Currently, the main storage
+    # is a file with the extension `.sqlite`, and in certain situations extra files with the
+    # extensions `.sqlite-wal`, and `.sqlite-shm` may also be present.)
   }
 
   # TODO(someday): Support distributing objects across a cluster. At present, objects are always

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -9,11 +9,15 @@ wd_cc_library(
             "*-test.c++",
             "capnp-mock.c++",
             "symbolizer.c++",
+            "sqlite*.c++",
         ],
     ),
     hdrs = glob(
         ["*.h"],
-        exclude = ["capnp-mock.h"],
+        exclude = [
+            "capnp-mock.h",
+            "sqlite*.h"
+        ],
     ),
     visibility = ["//visibility:public"],
     deps = [
@@ -23,6 +27,17 @@ wd_cc_library(
         "@capnp-cpp//src/kj/compat:kj-http",
         "@capnp-cpp//src/kj/compat:kj-tls",
     ],
+)
+
+wd_cc_library(
+    name = "sqlite",
+    srcs = [ "sqlite.c++" ],
+    hdrs = [ "sqlite.h" ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@sqlite3//:sqlite3",
+        "@capnp-cpp//src/kj:kj-async",
+    ]
 )
 
 wd_cc_library(
@@ -51,4 +66,11 @@ wd_cc_library(
     deps = [
         ":util",
     ],
-) for f in glob(["*-test.c++"])]
+) for f in glob(["*-test.c++"], exclude = ["sqlite-*.c++"])]
+
+kj_test(
+    src = "sqlite-test.c++",
+    deps = [
+        ":sqlite",
+    ],
+)

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -31,8 +31,8 @@ wd_cc_library(
 
 wd_cc_library(
     name = "sqlite",
-    srcs = [ "sqlite.c++" ],
-    hdrs = [ "sqlite.h" ],
+    srcs = [ "sqlite.c++", "sqlite-kv.c++" ],
+    hdrs = [ "sqlite.h", "sqlite-kv.h" ],
     visibility = ["//visibility:public"],
     deps = [
         "@sqlite3//:sqlite3",
@@ -70,6 +70,13 @@ wd_cc_library(
 
 kj_test(
     src = "sqlite-test.c++",
+    deps = [
+        ":sqlite",
+    ],
+)
+
+kj_test(
+    src = "sqlite-kv-test.c++",
     deps = [
         ":sqlite",
     ],

--- a/src/workerd/util/sqlite-kv-test.c++
+++ b/src/workerd/util/sqlite-kv-test.c++
@@ -10,8 +10,8 @@ namespace {
 
 KJ_TEST("SQLite-KV") {
   auto dir = kj::newInMemoryDirectory(kj::nullClock());
-  Sqlite::Vfs vfs(*dir);
-  Sqlite db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
+  SqliteDatabase::Vfs vfs(*dir);
+  SqliteDatabase db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
   SqliteKv kv(db);
 
   kv.put("foo", "abc"_kj.asBytes());

--- a/src/workerd/util/sqlite-kv-test.c++
+++ b/src/workerd/util/sqlite-kv-test.c++
@@ -1,0 +1,95 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "sqlite-kv.h"
+#include <kj/test.h>
+
+namespace workerd {
+namespace {
+
+KJ_TEST("SQLite-KV") {
+  auto dir = kj::newInMemoryDirectory(kj::nullClock());
+  Sqlite::Vfs vfs(*dir);
+  Sqlite db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
+  SqliteKv kv(db);
+
+  kv.put("foo", "abc"_kj.asBytes());
+  kv.put("bar", "def"_kj.asBytes());
+  kv.put("baz", "123"_kj.asBytes());
+  kv.put("qux", "321"_kj.asBytes());
+
+  {
+    bool called = false;
+    KJ_EXPECT(kv.get("foo", [&](kj::ArrayPtr<const byte> value) {
+      KJ_EXPECT(kj::str(value.asChars()) == "abc");
+      called = true;
+    }));
+    KJ_EXPECT(called);
+  }
+
+  {
+    bool called = false;
+    KJ_EXPECT(kv.get("bar", [&](kj::ArrayPtr<const byte> value) {
+      KJ_EXPECT(kj::str(value.asChars()) == "def");
+      called = true;
+    }));
+    KJ_EXPECT(called);
+  }
+
+  KJ_EXPECT(!kv.get("corge", [&](kj::ArrayPtr<const byte> value) {
+    KJ_FAIL_EXPECT("should not call callback when no match", value.asChars());
+  }));
+
+  auto list = [&](auto&&... params) {
+    kj::Vector<kj::String> results;
+    auto callback = [&](kj::StringPtr key, kj::ArrayPtr<const byte> value) {
+      results.add(kj::str(key, "=", value.asChars()));
+    };
+
+    auto n = kv.list(params..., callback);
+    KJ_EXPECT(results.size() == n);
+    return kj::strArray(results, ", ");
+  };
+
+  constexpr auto F = SqliteKv::FORWARD;
+  constexpr auto R = SqliteKv::REVERSE;
+
+  KJ_EXPECT(list(nullptr, nullptr, nullptr, F) == "bar=def, baz=123, foo=abc, qux=321");
+  KJ_EXPECT(list("cat"_kj, nullptr, nullptr, F) == "foo=abc, qux=321");
+  KJ_EXPECT(list("foo"_kj, nullptr, nullptr, F) == "foo=abc, qux=321");
+  KJ_EXPECT(list("fop"_kj, nullptr, nullptr, F) == "qux=321");
+  KJ_EXPECT(list("foo "_kj, nullptr, nullptr, F) == "qux=321");
+
+  KJ_EXPECT(list(nullptr, "cat"_kj, nullptr, F) == "bar=def, baz=123");
+  KJ_EXPECT(list(nullptr, "foo"_kj, nullptr, F) == "bar=def, baz=123");
+  KJ_EXPECT(list(nullptr, "fop"_kj, nullptr, F) == "bar=def, baz=123, foo=abc");
+
+  KJ_EXPECT(list(nullptr, nullptr, 2, F) == "bar=def, baz=123");
+  KJ_EXPECT(list(nullptr, nullptr, 3, F) == "bar=def, baz=123, foo=abc");
+  KJ_EXPECT(list("baz"_kj, nullptr, 2, F) == "baz=123, foo=abc");
+  KJ_EXPECT(list(nullptr, "foo"_kj, 1, F) == "bar=def");
+  KJ_EXPECT(list(nullptr, "foo"_kj, 2, F) == "bar=def, baz=123");
+  KJ_EXPECT(list(nullptr, "foo"_kj, 3, F) == "bar=def, baz=123");
+
+  KJ_EXPECT(list(nullptr, nullptr, nullptr, R) == "qux=321, foo=abc, baz=123, bar=def");
+  KJ_EXPECT(list("foo"_kj, nullptr, nullptr, R) == "qux=321, foo=abc");
+  KJ_EXPECT(list(nullptr, "foo"_kj, nullptr, R) == "baz=123, bar=def");
+  KJ_EXPECT(list(nullptr, nullptr, 2, R) == "qux=321, foo=abc");
+  KJ_EXPECT(list(nullptr, "foo"_kj, 1, R) == "baz=123");
+
+  KJ_EXPECT(kv.delete_("baz"));
+  KJ_EXPECT(!kv.delete_("corge"));
+
+  KJ_EXPECT(list(nullptr, nullptr, nullptr, F) == "bar=def, foo=abc, qux=321");
+
+  // Put can overwrite.
+  kv.put("foo", "hello"_kj.asBytes());
+  KJ_EXPECT(list(nullptr, nullptr, nullptr, F) == "bar=def, foo=hello, qux=321");
+
+  kv.deleteAll();
+  KJ_EXPECT(list(nullptr, nullptr, nullptr, F) == "");
+}
+
+}  // namespace
+}  // namespace workerd

--- a/src/workerd/util/sqlite-kv.c++
+++ b/src/workerd/util/sqlite-kv.c++
@@ -6,9 +6,9 @@
 
 namespace workerd {
 
-SqliteKv::SqliteKv(Sqlite& db, bool): db(db) {}
+SqliteKv::SqliteKv(SqliteDatabase& db, bool): db(db) {}
 
-Sqlite& SqliteKv::ensureInitialized(Sqlite& db) {
+SqliteDatabase& SqliteKv::ensureInitialized(SqliteDatabase& db) {
   // TODO(sqlite): Do this automatically at a lower layer?
   db.run("PRAGMA journal_mode=WAL;");
 
@@ -35,7 +35,7 @@ bool SqliteKv::get(KeyPtr key, kj::FunctionParam<void(ValuePtr)> callback) {
 
 uint SqliteKv::list(KeyPtr begin, kj::Maybe<KeyPtr> end, kj::Maybe<uint> limit, Order order,
                     kj::FunctionParam<void(KeyPtr, ValuePtr)> callback) {
-  auto iterate = [&](Sqlite::Query&& query) {
+  auto iterate = [&](SqliteDatabase::Query&& query) {
     size_t count = 0;
     while (!query.isDone()) {
       callback(query.getText(0), query.getBlob(1));

--- a/src/workerd/util/sqlite-kv.c++
+++ b/src/workerd/util/sqlite-kv.c++
@@ -1,0 +1,92 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "sqlite-kv.h"
+
+namespace workerd {
+
+SqliteKv::SqliteKv(Sqlite& db, bool): db(db) {}
+
+Sqlite& SqliteKv::ensureInitialized(Sqlite& db) {
+  // TODO(sqlite): Do this automatically at a lower layer?
+  db.run("PRAGMA journal_mode=WAL;");
+
+  db.run(R"(
+    CREATE TABLE IF NOT EXISTS _cf_KV (
+      key TEXT PRIMARY KEY,
+      value BLOB
+    ) WITHOUT ROWID;
+  )");
+
+  return db;
+}
+
+bool SqliteKv::get(KeyPtr key, kj::FunctionParam<void(ValuePtr)> callback) {
+  auto query = stmtGet.run(key);
+
+  if (query.isDone()) {
+    return false;
+  } else {
+    callback(query.getBlob(0));
+    return true;
+  }
+}
+
+uint SqliteKv::list(KeyPtr begin, kj::Maybe<KeyPtr> end, kj::Maybe<uint> limit, Order order,
+                    kj::FunctionParam<void(KeyPtr, ValuePtr)> callback) {
+  auto iterate = [&](Sqlite::Query&& query) {
+    size_t count = 0;
+    while (!query.isDone()) {
+      callback(query.getText(0), query.getBlob(1));
+      query.nextRow();
+      ++count;
+    }
+    return count;
+  };
+
+  if (order == Order::FORWARD) {
+    KJ_IF_MAYBE(e, end) {
+      KJ_IF_MAYBE(l, limit) {
+        return iterate(stmtListEndLimit.run(begin, *e, (int64_t)*l));
+      } else {
+        return iterate(stmtListEnd.run(begin, *e));
+      }
+    } else {
+      KJ_IF_MAYBE(l, limit) {
+        return iterate(stmtListLimit.run(begin, (int64_t)*l));
+      } else {
+        return iterate(stmtList.run(begin));
+      }
+    }
+  } else {
+    KJ_IF_MAYBE(e, end) {
+      KJ_IF_MAYBE(l, limit) {
+        return iterate(stmtListEndLimitReverse.run(begin, *e, (int64_t)*l));
+      } else {
+        return iterate(stmtListEndReverse.run(begin, *e));
+      }
+    } else {
+      KJ_IF_MAYBE(l, limit) {
+        return iterate(stmtListLimitReverse.run(begin, (int64_t)*l));
+      } else {
+        return iterate(stmtListReverse.run(begin));
+      }
+    }
+  }
+}
+
+void SqliteKv::put(KeyPtr key, ValuePtr value) {
+  stmtPut.run(key, value);
+}
+
+bool SqliteKv::delete_(KeyPtr key) {
+  auto query = stmtDelete.run(key);
+  return query.changeCount() > 0;
+}
+
+void SqliteKv::deleteAll() {
+  stmtDeleteAll.run();
+}
+
+}  // namespace workerd

--- a/src/workerd/util/sqlite-kv.c++
+++ b/src/workerd/util/sqlite-kv.c++
@@ -22,60 +22,6 @@ SqliteDatabase& SqliteKv::ensureInitialized(SqliteDatabase& db) {
   return db;
 }
 
-bool SqliteKv::get(KeyPtr key, kj::FunctionParam<void(ValuePtr)> callback) {
-  auto query = stmtGet.run(key);
-
-  if (query.isDone()) {
-    return false;
-  } else {
-    callback(query.getBlob(0));
-    return true;
-  }
-}
-
-uint SqliteKv::list(KeyPtr begin, kj::Maybe<KeyPtr> end, kj::Maybe<uint> limit, Order order,
-                    kj::FunctionParam<void(KeyPtr, ValuePtr)> callback) {
-  auto iterate = [&](SqliteDatabase::Query&& query) {
-    size_t count = 0;
-    while (!query.isDone()) {
-      callback(query.getText(0), query.getBlob(1));
-      query.nextRow();
-      ++count;
-    }
-    return count;
-  };
-
-  if (order == Order::FORWARD) {
-    KJ_IF_MAYBE(e, end) {
-      KJ_IF_MAYBE(l, limit) {
-        return iterate(stmtListEndLimit.run(begin, *e, (int64_t)*l));
-      } else {
-        return iterate(stmtListEnd.run(begin, *e));
-      }
-    } else {
-      KJ_IF_MAYBE(l, limit) {
-        return iterate(stmtListLimit.run(begin, (int64_t)*l));
-      } else {
-        return iterate(stmtList.run(begin));
-      }
-    }
-  } else {
-    KJ_IF_MAYBE(e, end) {
-      KJ_IF_MAYBE(l, limit) {
-        return iterate(stmtListEndLimitReverse.run(begin, *e, (int64_t)*l));
-      } else {
-        return iterate(stmtListEndReverse.run(begin, *e));
-      }
-    } else {
-      KJ_IF_MAYBE(l, limit) {
-        return iterate(stmtListLimitReverse.run(begin, (int64_t)*l));
-      } else {
-        return iterate(stmtListReverse.run(begin));
-      }
-    }
-  }
-}
-
 void SqliteKv::put(KeyPtr key, ValuePtr value) {
   stmtPut.run(key, value);
 }

--- a/src/workerd/util/sqlite-kv.h
+++ b/src/workerd/util/sqlite-kv.h
@@ -18,7 +18,7 @@ class SqliteKv {
   // obnoxious about of string allocation.)
 
 public:
-  explicit SqliteKv(Sqlite& db): SqliteKv(ensureInitialized(db), true) {}
+  explicit SqliteKv(SqliteDatabase& db): SqliteKv(ensureInitialized(db), true) {}
 
   typedef kj::StringPtr KeyPtr;
   typedef kj::ArrayPtr<const kj::byte> ValuePtr;
@@ -52,70 +52,70 @@ public:
   //   byte blobs or strings containing NUL bytes.
 
 private:
-  Sqlite& db;
+  SqliteDatabase& db;
 
-  Sqlite::Statement stmtGet = db.prepare(R"(
+  SqliteDatabase::Statement stmtGet = db.prepare(R"(
     SELECT value FROM _cf_KV WHERE key = ?
   )");
-  Sqlite::Statement stmtPut = db.prepare(R"(
+  SqliteDatabase::Statement stmtPut = db.prepare(R"(
     INSERT INTO _cf_KV VALUES(?, ?)
       ON CONFLICT DO UPDATE SET value = excluded.value;
   )");
-  Sqlite::Statement stmtDelete = db.prepare(R"(
+  SqliteDatabase::Statement stmtDelete = db.prepare(R"(
     DELETE FROM _cf_KV WHERE key = ?
   )");
-  Sqlite::Statement stmtList = db.prepare(R"(
+  SqliteDatabase::Statement stmtList = db.prepare(R"(
     SELECT * FROM _cf_KV
     WHERE key >= ?
     ORDER BY key
   )");
-  Sqlite::Statement stmtListEnd = db.prepare(R"(
+  SqliteDatabase::Statement stmtListEnd = db.prepare(R"(
     SELECT * FROM _cf_KV
     WHERE key >= ? AND key < ?
     ORDER BY key
   )");
-  Sqlite::Statement stmtListLimit = db.prepare(R"(
+  SqliteDatabase::Statement stmtListLimit = db.prepare(R"(
     SELECT * FROM _cf_KV
     WHERE key >= ?
     ORDER BY key
     LIMIT ?
   )");
-  Sqlite::Statement stmtListEndLimit = db.prepare(R"(
+  SqliteDatabase::Statement stmtListEndLimit = db.prepare(R"(
     SELECT * FROM _cf_KV
     WHERE key >= ? AND key < ?
     ORDER BY key
     LIMIT ?
   )");
-  Sqlite::Statement stmtListReverse = db.prepare(R"(
+  SqliteDatabase::Statement stmtListReverse = db.prepare(R"(
     SELECT * FROM _cf_KV
     WHERE key >= ?
     ORDER BY key DESC
   )");
-  Sqlite::Statement stmtListEndReverse = db.prepare(R"(
+  SqliteDatabase::Statement stmtListEndReverse = db.prepare(R"(
     SELECT * FROM _cf_KV
     WHERE key >= ? AND key < ?
     ORDER BY key DESC
   )");
-  Sqlite::Statement stmtListLimitReverse = db.prepare(R"(
+  SqliteDatabase::Statement stmtListLimitReverse = db.prepare(R"(
     SELECT * FROM _cf_KV
     WHERE key >= ?
     ORDER BY key DESC
     LIMIT ?
   )");
-  Sqlite::Statement stmtListEndLimitReverse = db.prepare(R"(
+  SqliteDatabase::Statement stmtListEndLimitReverse = db.prepare(R"(
     SELECT * FROM _cf_KV
     WHERE key >= ? AND key < ?
     ORDER BY key DESC
     LIMIT ?
   )");
-  Sqlite::Statement stmtDeleteAll = db.prepare(R"(
+  SqliteDatabase::Statement stmtDeleteAll = db.prepare(R"(
     DELETE FROM _cf_KV
   )");
 
-  Sqlite& ensureInitialized(Sqlite& db);
+  SqliteDatabase& ensureInitialized(SqliteDatabase& db);
   // Make sure the KV table is created, then return the same object.
 
-  SqliteKv(Sqlite& db, bool);
+  SqliteKv(SqliteDatabase& db, bool);
 };
 
 }  // namespace workerd

--- a/src/workerd/util/sqlite-kv.h
+++ b/src/workerd/util/sqlite-kv.h
@@ -1,0 +1,121 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include "sqlite.h"
+
+namespace workerd {
+
+class SqliteKv {
+  // Class which implements KV storage on top of SQLite. This is intended to be used for Durable
+  // Object storage.
+  //
+  // The table is named `_cf_KV`. The naming is designed so that if the application is allowed to
+  // perform direct SQL queries, we can block it from accessing any table prefixed with `_cf_`.
+  // (Ideally this class would allow configuring the table name, but this would require a somewhat
+  // obnoxious about of string allocation.)
+
+public:
+  explicit SqliteKv(Sqlite& db): SqliteKv(ensureInitialized(db), true) {}
+
+  typedef kj::StringPtr KeyPtr;
+  typedef kj::ArrayPtr<const kj::byte> ValuePtr;
+
+  bool get(KeyPtr key, kj::FunctionParam<void(ValuePtr)> callback);
+  // Search for a match for the given key. Calls the callback function with the result, if found.
+  // This is intended to avoid the need to copy the bytes, if the caller would just parse them and
+  // drop them immediately anyway. Returns true if there was a match, false if not.
+
+  enum Order {
+    FORWARD,
+    REVERSE
+  };
+
+  uint list(KeyPtr begin, kj::Maybe<KeyPtr> end, kj::Maybe<uint> limit, Order order,
+            kj::FunctionParam<void(KeyPtr, ValuePtr)> callback);
+  // Search for all knows keys and values in a range, calling the callback for each one seen.
+  // `end` and `limit` can be null to request no constraint be enforced.
+
+  void put(KeyPtr key, ValuePtr value);
+  // Store a value into the table.
+
+  bool delete_(KeyPtr key);
+  // Delete the key and return whether it was matched.
+
+  void deleteAll();
+
+  // TODO(perf): Should we provide multi-get, multi-put, and multi-delete? It's a bit tricky to
+  //   implement them as single SQL queries, while still using prepared statements. The c-array
+  //   extension might help here, though it can only support arrays of NUL-terminated strings, not
+  //   byte blobs or strings containing NUL bytes.
+
+private:
+  Sqlite& db;
+
+  Sqlite::Statement stmtGet = db.prepare(R"(
+    SELECT value FROM _cf_KV WHERE key = ?
+  )");
+  Sqlite::Statement stmtPut = db.prepare(R"(
+    INSERT INTO _cf_KV VALUES(?, ?)
+      ON CONFLICT DO UPDATE SET value = excluded.value;
+  )");
+  Sqlite::Statement stmtDelete = db.prepare(R"(
+    DELETE FROM _cf_KV WHERE key = ?
+  )");
+  Sqlite::Statement stmtList = db.prepare(R"(
+    SELECT * FROM _cf_KV
+    WHERE key >= ?
+    ORDER BY key
+  )");
+  Sqlite::Statement stmtListEnd = db.prepare(R"(
+    SELECT * FROM _cf_KV
+    WHERE key >= ? AND key < ?
+    ORDER BY key
+  )");
+  Sqlite::Statement stmtListLimit = db.prepare(R"(
+    SELECT * FROM _cf_KV
+    WHERE key >= ?
+    ORDER BY key
+    LIMIT ?
+  )");
+  Sqlite::Statement stmtListEndLimit = db.prepare(R"(
+    SELECT * FROM _cf_KV
+    WHERE key >= ? AND key < ?
+    ORDER BY key
+    LIMIT ?
+  )");
+  Sqlite::Statement stmtListReverse = db.prepare(R"(
+    SELECT * FROM _cf_KV
+    WHERE key >= ?
+    ORDER BY key DESC
+  )");
+  Sqlite::Statement stmtListEndReverse = db.prepare(R"(
+    SELECT * FROM _cf_KV
+    WHERE key >= ? AND key < ?
+    ORDER BY key DESC
+  )");
+  Sqlite::Statement stmtListLimitReverse = db.prepare(R"(
+    SELECT * FROM _cf_KV
+    WHERE key >= ?
+    ORDER BY key DESC
+    LIMIT ?
+  )");
+  Sqlite::Statement stmtListEndLimitReverse = db.prepare(R"(
+    SELECT * FROM _cf_KV
+    WHERE key >= ? AND key < ?
+    ORDER BY key DESC
+    LIMIT ?
+  )");
+  Sqlite::Statement stmtDeleteAll = db.prepare(R"(
+    DELETE FROM _cf_KV
+  )");
+
+  Sqlite& ensureInitialized(Sqlite& db);
+  // Make sure the KV table is created, then return the same object.
+
+  SqliteKv(Sqlite& db, bool);
+};
+
+}  // namespace workerd

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -13,10 +13,10 @@ namespace {
 
 KJ_TEST("SQLite backed by in-memory directory") {
   auto dir = kj::newInMemoryDirectory(kj::nullClock());
-  Sqlite::Vfs vfs(*dir);
+  SqliteDatabase::Vfs vfs(*dir);
 
   {
-    Sqlite db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
+    SqliteDatabase db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
 
     // TODO(sqlite): Do this automatically and don't permit it via run().
     db.run("PRAGMA journal_mode=WAL;");
@@ -99,7 +99,7 @@ KJ_TEST("SQLite backed by in-memory directory") {
 
   // Open it again and make sure tha data is still there!
   {
-    Sqlite db(vfs, kj::Path({"foo"}), kj::WriteMode::MODIFY);
+    SqliteDatabase db(vfs, kj::Path({"foo"}), kj::WriteMode::MODIFY);
 
     {
       auto query = db.run("SELECT * FROM people WHERE people.name = ?", "Alice"_kj);
@@ -153,10 +153,10 @@ KJ_TEST("SQLite backed by real disk") {
   // in a unit test, using real disk.
 
   TempDirOnDisk dir;
-  Sqlite::Vfs vfs(*dir);
+  SqliteDatabase::Vfs vfs(*dir);
 
   {
-    Sqlite db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
+    SqliteDatabase db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
 
     // TODO(sqlite): Do this automatically and don't permit it via run().
     db.run("PRAGMA journal_mode=WAL;");
@@ -211,7 +211,7 @@ KJ_TEST("SQLite backed by real disk") {
 
   // Open it again and make sure tha data is still there!
   {
-    Sqlite db(vfs, kj::Path({"foo"}), kj::WriteMode::MODIFY);
+    SqliteDatabase db(vfs, kj::Path({"foo"}), kj::WriteMode::MODIFY);
 
     {
       auto query = db.run("SELECT * FROM people WHERE people.name = ?", "Alice"_kj);

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -21,20 +21,19 @@ KJ_TEST("SQLite backed by in-memory directory") {
     // TODO(sqlite): Do this automatically and don't permit it via run().
     db.run("PRAGMA journal_mode=WAL;");
 
-    db.run(R"(
-      CREATE TABLE people (
-        id INTEGER PRIMARY KEY,
-        name TEXT NOT NULL,
-        email TEXT NOT NULL UNIQUE
-      );
-    )");
-
     {
       auto query = db.run(R"(
+        CREATE TABLE people (
+          id INTEGER PRIMARY KEY,
+          name TEXT NOT NULL,
+          email TEXT NOT NULL UNIQUE
+        );
+
         INSERT INTO people (id, name, email)
-        VALUES (123, "Bob", "bob@example.com"),
-              (321, "Alice", "alice@example.com");
-      )");
+        VALUES (?, ?, ?),
+              (?, ?, ?);
+      )", 123, "Bob"_kj, "bob@example.com"_kj,
+          321, "Alice"_kj, "alice@example.com"_kj);
 
       KJ_EXPECT(query.changeCount() == 2);
     }

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -1,0 +1,233 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "sqlite.h"
+#include <kj/test.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+namespace workerd {
+namespace {
+
+KJ_TEST("SQLite backed by in-memory directory") {
+  auto dir = kj::newInMemoryDirectory(kj::nullClock());
+  Sqlite::Vfs vfs(*dir);
+
+  {
+    Sqlite db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
+
+    // TODO(sqlite): Do this automatically and don't permit it via run().
+    db.run("PRAGMA journal_mode=WAL;");
+
+    db.run(R"(
+      CREATE TABLE people (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL,
+        email TEXT NOT NULL UNIQUE
+      );
+    )");
+
+    {
+      auto query = db.run(R"(
+        INSERT INTO people (id, name, email)
+        VALUES (123, "Bob", "bob@example.com"),
+              (321, "Alice", "alice@example.com");
+      )");
+
+      KJ_EXPECT(query.changeCount() == 2);
+    }
+
+    {
+      auto query = db.run("SELECT * FROM people ORDER BY name");
+
+      KJ_ASSERT(!query.isDone());
+      KJ_ASSERT(query.columnCount() == 3);
+      KJ_EXPECT(query.getInt(0) == 321);
+      KJ_EXPECT(query.getText(1) == "Alice");
+      KJ_EXPECT(query.getText(2) == "alice@example.com");
+
+      query.nextRow();
+      KJ_ASSERT(!query.isDone());
+      KJ_EXPECT(query.getInt(0) == 123);
+      KJ_EXPECT(query.getText(1) == "Bob");
+      KJ_EXPECT(query.getText(2) == "bob@example.com");
+
+      query.nextRow();
+      KJ_EXPECT(query.isDone());
+    }
+
+    {
+      auto query = db.run("SELECT * FROM people WHERE people.id = ?", 123l);
+
+      KJ_ASSERT(!query.isDone());
+      KJ_ASSERT(query.columnCount() == 3);
+      KJ_EXPECT(query.getInt(0) == 123);
+      KJ_EXPECT(query.getText(1) == "Bob");
+      KJ_EXPECT(query.getText(2) == "bob@example.com");
+
+      query.nextRow();
+      KJ_EXPECT(query.isDone());
+    }
+
+    {
+      auto query = db.run("SELECT * FROM people WHERE people.name = ?", "Alice"_kj);
+
+      KJ_ASSERT(!query.isDone());
+      KJ_ASSERT(query.columnCount() == 3);
+      KJ_EXPECT(query.getInt(0) == 321);
+      KJ_EXPECT(query.getText(1) == "Alice");
+      KJ_EXPECT(query.getText(2) == "alice@example.com");
+
+      query.nextRow();
+      KJ_EXPECT(query.isDone());
+    }
+
+    {
+      auto files = dir->listNames();
+      KJ_ASSERT(files.size() == 2);
+      KJ_EXPECT(files[0] == "foo");
+      KJ_EXPECT(files[1] == "foo-wal");
+    }
+  }
+
+  {
+    auto files = dir->listNames();
+    KJ_ASSERT(files.size() == 1);
+    KJ_EXPECT(files[0] == "foo");
+  }
+
+  // Open it again and make sure tha data is still there!
+  {
+    Sqlite db(vfs, kj::Path({"foo"}), kj::WriteMode::MODIFY);
+
+    {
+      auto query = db.run("SELECT * FROM people WHERE people.name = ?", "Alice"_kj);
+
+      KJ_ASSERT(!query.isDone());
+      KJ_ASSERT(query.columnCount() == 3);
+      KJ_EXPECT(query.getInt(0) == 321);
+      KJ_EXPECT(query.getText(1) == "Alice");
+      KJ_EXPECT(query.getText(2) == "alice@example.com");
+
+      query.nextRow();
+      KJ_EXPECT(query.isDone());
+    }
+  }
+}
+
+class TempDirOnDisk {
+public:
+  TempDirOnDisk() {}
+  ~TempDirOnDisk() noexcept(false) {
+    dir = nullptr;
+    disk->getRoot().remove(path);
+  }
+
+  const kj::Directory* operator->() {
+    return dir;
+  }
+  const kj::Directory& operator*() {
+    return *dir;
+  }
+
+private:
+  kj::Own<kj::Filesystem> disk = kj::newDiskFilesystem();
+  kj::Path path = makeTmpPath();
+  kj::Own<const kj::Directory> dir = disk->getRoot().openSubdir(path, kj::WriteMode::MODIFY);
+
+  kj::Path makeTmpPath() {
+    const char* tmpDir = getenv("TEST_TMPDIR");
+    kj::String pathStr = kj::str(
+        tmpDir != nullptr ? tmpDir : "/var/tmp", "/workerd-sqlite-test.XXXXXX");
+    if (mkdtemp(pathStr.begin()) == nullptr) {
+      KJ_FAIL_SYSCALL("mkdtemp", errno, pathStr);
+    }
+    return disk->getCurrentPath().evalNative(pathStr);
+  }
+};
+
+KJ_TEST("SQLite backed by real disk") {
+  // Well, I made it possible to use an in-memory directory so that unit tests wouldn't have to
+  // use real disk. But now I have to test that it does actually work on real disk. So here we are,
+  // in a unit test, using real disk.
+
+  TempDirOnDisk dir;
+  Sqlite::Vfs vfs(*dir);
+
+  {
+    Sqlite db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
+
+    // TODO(sqlite): Do this automatically and don't permit it via run().
+    db.run("PRAGMA journal_mode=WAL;");
+
+    db.run(R"(
+      CREATE TABLE people (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL,
+        email TEXT NOT NULL UNIQUE
+      );
+    )");
+
+    db.run(R"(
+      INSERT INTO people (id, name, email)
+      VALUES (123, "Bob", "bob@example.com"),
+             (321, "Alice", "alice@example.com");
+    )");
+
+    {
+      auto query = db.run("SELECT * FROM people ORDER BY name");
+
+      KJ_ASSERT(!query.isDone());
+      KJ_ASSERT(query.columnCount() == 3);
+      KJ_EXPECT(query.getInt(0) == 321);
+      KJ_EXPECT(query.getText(1) == "Alice");
+      KJ_EXPECT(query.getText(2) == "alice@example.com");
+
+      query.nextRow();
+      KJ_ASSERT(!query.isDone());
+      KJ_EXPECT(query.getInt(0) == 123);
+      KJ_EXPECT(query.getText(1) == "Bob");
+      KJ_EXPECT(query.getText(2) == "bob@example.com");
+
+      query.nextRow();
+      KJ_EXPECT(query.isDone());
+    }
+
+    {
+      auto files = dir->listNames();
+      KJ_ASSERT(files.size() == 3);
+      KJ_EXPECT(files[0] == "foo");
+      KJ_EXPECT(files[1] == "foo-shm");
+      KJ_EXPECT(files[2] == "foo-wal");
+    }
+  }
+
+  {
+    auto files = dir->listNames();
+    KJ_ASSERT(files.size() == 1);
+    KJ_EXPECT(files[0] == "foo");
+  }
+
+  // Open it again and make sure tha data is still there!
+  {
+    Sqlite db(vfs, kj::Path({"foo"}), kj::WriteMode::MODIFY);
+
+    {
+      auto query = db.run("SELECT * FROM people WHERE people.name = ?", "Alice"_kj);
+
+      KJ_ASSERT(!query.isDone());
+      KJ_ASSERT(query.columnCount() == 3);
+      KJ_EXPECT(query.getInt(0) == 321);
+      KJ_EXPECT(query.getText(1) == "Alice");
+      KJ_EXPECT(query.getText(2) == "alice@example.com");
+
+      query.nextRow();
+      KJ_EXPECT(query.isDone());
+    }
+  }
+}
+
+}  // namespace
+}  // namespace workerd

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -195,7 +195,7 @@ void SqliteDatabase::Query::bind(uint i, ValuePtr value) {
       SQLITE_CALL(sqlite3_bind_text(statement, i+1, text.begin(), text.size(), SQLITE_STATIC));
     }
     KJ_CASE_ONEOF(n, int64_t) {
-      SQLITE_CALL(sqlite3_bind_int64(statement, i+1, n));
+      SQLITE_CALL(sqlite3_bind_int64(statement, i+1, static_cast<long long>(n)));
     }
     KJ_CASE_ONEOF(x, double) {
       SQLITE_CALL(sqlite3_bind_double(statement, i+1, x));
@@ -214,7 +214,7 @@ void SqliteDatabase::Query::bind(uint i, kj::StringPtr value) {
   SQLITE_CALL(sqlite3_bind_text(statement, i+1, value.begin(), value.size(), SQLITE_STATIC));
 }
 
-void SqliteDatabase::Query::bind(uint i, int64_t value) {
+void SqliteDatabase::Query::bind(uint i, long long value) {
   SQLITE_CALL(sqlite3_bind_int64(statement, i+1, value));
 }
 

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -1,0 +1,835 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "sqlite.h"
+#include <kj/debug.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sqlite3.h>
+#include <kj/vector.h>
+
+namespace workerd {
+
+#define SQLITE_CALL_NODB(code, ...) do { \
+    int _ec = code; \
+    KJ_ASSERT(_ec == SQLITE_OK, "SQLite failed: " #code, sqlite3_errstr(_ec), ##__VA_ARGS__); \
+  } while (false)
+// Make a SQLite call and check the returned error code. Use this version when the call is not
+// associated with an open DB connection.
+
+#define SQLITE_CALL(code, ...) do { \
+    int _ec = code; \
+    /* SQLITE_MISUSE doesn't put error info on the database object, so check it separately */ \
+    KJ_ASSERT(_ec != SQLITE_MISUSE, "SQLite misused: " #code, ##__VA_ARGS__); \
+    KJ_ASSERT(_ec == SQLITE_OK, "SQLite failed: " #code, sqlite3_errmsg(db), ##__VA_ARGS__); \
+  } while (false)
+// This version requires the scope to contain a variable named `db` which is of type sqlite3*, or
+// can convert to it.
+
+#define SQLITE_CALL_FAILED(code, error, ...) do { \
+    KJ_ASSERT(error != SQLITE_MISUSE, "SQLite misused: " code, ##__VA_ARGS__); \
+    KJ_ASSERT(error == SQLITE_OK, "SQLite failed: " code, sqlite3_errmsg(db), ##__VA_ARGS__); \
+  } while (false);
+// Version of `SQLITE_CALL` that can be called after inspecting the error code, in case some codes
+// aren't really errors.
+
+namespace {
+
+void disposeSqlite(sqlite3_stmt* stmt) {
+  sqlite3_finalize(stmt);
+
+  // Note that any returned error code is actually the last error to occur while executing the
+  // statement. This does not really mean that finalization failed, and the error in question
+  // should have been checked and reported earlier. So, we ignore it here.
+}
+
+template <typename T>
+class SqliteDisposer: public kj::Disposer {
+public:
+  void disposeImpl(void* pointer) const override {
+    disposeSqlite(reinterpret_cast<T*>(pointer));
+  }
+};
+
+template <typename T>
+kj::Own<T> ownSqlite(T* obj) {
+  static const SqliteDisposer<T> disposer;
+  return kj::Own<T>(obj, disposer);
+}
+
+}  // namespace
+
+// =======================================================================================
+
+Sqlite::Sqlite(Vfs& vfs, kj::PathPtr path) {
+  SQLITE_CALL_NODB(sqlite3_open_v2(path.toString().cStr(), &db,
+                                   SQLITE_OPEN_READONLY, vfs.getName().cStr()));
+}
+
+Sqlite::Sqlite(Vfs& vfs, kj::PathPtr path, kj::WriteMode mode) {
+  int flags = SQLITE_OPEN_READWRITE;
+  if (kj::has(mode, kj::WriteMode::CREATE)) {
+    flags |= SQLITE_OPEN_CREATE;
+
+    if (kj::has(mode, kj::WriteMode::CREATE_PARENT) && path.size() > 1) {
+      // SQLite isn't going to try to create the parent directory so let's try to create it now.
+      vfs.directory.openSubdir(path.parent(),
+          kj::WriteMode::CREATE | kj::WriteMode::MODIFY | kj::WriteMode::CREATE_PARENT);
+    }
+  }
+  KJ_REQUIRE(kj::has(mode, kj::WriteMode::MODIFY), "SQLite doesn't support create-exclusive mode");
+
+  SQLITE_CALL_NODB(sqlite3_open_v2(path.toString().cStr(), &db,
+                                   flags, vfs.getName().cStr()));
+}
+
+Sqlite::~Sqlite() noexcept(false) {
+  auto err = sqlite3_close(db);
+  if (err == SQLITE_BUSY) {
+    KJ_LOG(ERROR, "sqlite database destroyed while dependent objects still exist");
+    // SQLite actually provides a lazy-close API which we might as well use here instead of leaking
+    // memory.
+    err = sqlite3_close_v2(db);
+  }
+
+  KJ_REQUIRE(err == SQLITE_OK, sqlite3_errstr(err)) { break; }
+}
+
+static kj::Own<sqlite3_stmt> prepareSql(sqlite3* db, kj::StringPtr sqlCode, uint prepFlags) {
+  sqlite3_stmt* result;
+  const char* tail;
+
+  SQLITE_CALL(sqlite3_prepare_v3(db, sqlCode.begin(), sqlCode.size(), prepFlags, &result, &tail));
+  KJ_REQUIRE(result != nullptr, "SQL code did not contain a statement", sqlCode);
+  auto ownResult = ownSqlite(result);
+
+  while (*tail == ' ' || *tail == '\n') ++tail;
+  KJ_REQUIRE(tail == sqlCode.end(), "sqlite statement had leftover code", tail);
+
+  return ownResult;
+}
+
+Sqlite::Statement Sqlite::prepare(kj::StringPtr sqlCode) {
+  return Statement(*this, prepareSql(db, sqlCode, SQLITE_PREPARE_PERSISTENT));
+}
+
+Sqlite::Query::Query(Sqlite& db, Statement& statement, kj::ArrayPtr<const ValuePtr> bindings)
+    : db(db), statement(statement) {
+  init(bindings);
+}
+
+Sqlite::Query::Query(Sqlite& db, kj::StringPtr sqlCode, kj::ArrayPtr<const ValuePtr> bindings)
+    : db(db), ownStatement(prepareSql(db, sqlCode, 0)), statement(ownStatement) {
+  init(bindings);
+}
+
+Sqlite::Query::~Query() noexcept(false) {
+  if (statement == nullptr) {
+    // Object was moved away.
+  } else {
+    // The error code returned by sqlite3_reset() actually represents the last error encountered
+    // when stepping the statement. This doesn't mean that the reset failed.
+    sqlite3_reset(statement);
+
+    // sqlite3_clear_bindings() returns int, but there is no documentation on how the return code
+    // should be interpreted, so we ignore it.
+    sqlite3_clear_bindings(statement);
+  }
+}
+
+void Sqlite::Query::init(kj::ArrayPtr<const ValuePtr> bindings) {
+  KJ_REQUIRE(!sqlite3_stmt_busy(statement), "only one Query can run at a time");
+
+  KJ_REQUIRE(bindings.size() == sqlite3_bind_parameter_count(statement),
+      "wrong number of bindings for SQLite query");
+
+  for (auto i: kj::indices(bindings)) {
+    KJ_SWITCH_ONEOF(bindings[i]) {
+      KJ_CASE_ONEOF(blob, kj::ArrayPtr<const byte>) {
+        SQLITE_CALL(sqlite3_bind_blob(statement, i+1, blob.begin(), blob.size(), SQLITE_STATIC));
+      }
+      KJ_CASE_ONEOF(text, kj::StringPtr) {
+        SQLITE_CALL(sqlite3_bind_text(statement, i+1, text.begin(), text.size(), SQLITE_STATIC));
+      }
+      KJ_CASE_ONEOF(n, int64_t) {
+        SQLITE_CALL(sqlite3_bind_int64(statement, i+1, n));
+      }
+      KJ_CASE_ONEOF(x, double) {
+        SQLITE_CALL(sqlite3_bind_double(statement, i+1, x));
+      }
+      KJ_CASE_ONEOF(_, decltype(nullptr)) {
+        SQLITE_CALL(sqlite3_bind_null(statement, i+1));
+      }
+    }
+  }
+
+  nextRow();
+}
+
+void Sqlite::Query::nextRow() {
+  int err = sqlite3_step(statement);
+  if (err == SQLITE_DONE) {
+    done = true;
+  } else if (err != SQLITE_ROW) {
+    SQLITE_CALL_FAILED("sqlite3_step()", err);
+  }
+}
+
+uint Sqlite::Query::changeCount() {
+  KJ_REQUIRE(done);
+  KJ_DREQUIRE(columnCount() == 0,
+      "changeCount() can only be called on INSERT/UPDATE/DELETE queries");
+  return sqlite3_changes(db);
+}
+
+uint Sqlite::Query::columnCount() {
+  return sqlite3_column_count(statement);
+}
+
+Sqlite::Query::ValuePtr Sqlite::Query::getValue(uint column) {
+  switch (sqlite3_column_type(statement, column)) {
+    case SQLITE_INTEGER: return getInt64(column);
+    case SQLITE_FLOAT:   return getDouble(column);
+    case SQLITE_TEXT:    return getText(column);
+    case SQLITE_BLOB:    return getBlob(column);
+    case SQLITE_NULL:    return nullptr;
+  }
+  KJ_UNREACHABLE;
+}
+
+kj::ArrayPtr<const byte> Sqlite::Query::getBlob(uint column) {
+  const byte* ptr = reinterpret_cast<const byte*>(sqlite3_column_blob(statement, column));
+  return kj::arrayPtr(ptr, sqlite3_column_bytes(statement, column));
+}
+
+kj::StringPtr Sqlite::Query::getText(uint column) {
+  const char* ptr = reinterpret_cast<const char*>(sqlite3_column_text(statement, column));
+  return kj::StringPtr(ptr, sqlite3_column_bytes(statement, column));
+}
+
+int Sqlite::Query::getInt(uint column) {
+  return sqlite3_column_int(statement, column);
+}
+
+int64_t Sqlite::Query::getInt64(uint column) {
+  return sqlite3_column_int64(statement, column);
+}
+
+double Sqlite::Query::getDouble(uint column) {
+  return sqlite3_column_double(statement, column);
+}
+
+bool Sqlite::Query::isNull(uint column) {
+  return sqlite3_column_type(statement, column) == SQLITE_NULL;
+}
+
+// =======================================================================================
+// VFS
+
+// -----------------------------------------------------------------------------
+// Code to wrap SQLite's native VFS so that it can be rooted in some `kj::Directory`, where that
+// directory points at a real disk directory.
+//
+// A native disk `kj::Directory` -- at least on Unix -- wraps an open file descriptor, pointing at
+// a directory. It does NOT keep track of the directory's path on disk. In fact, the directory can
+// be moved or renamed, and `kj::Directory` will continue to point at it.
+//
+// There is no portable way to query the current path of a directory. In order to open files within
+// a directory given only the directory descriptor, you must use syscalls like `openat()`, which
+// take a directory file descriptor to use as the root.
+//
+// SQLite's native VFS, however, is not openat()-aware. Luckily, it _does_ provide the ability to
+// redirect its syscalls to custom implementations. So we can intercept `open()` and make it use
+// `openat()` instead! With a little thread-local hackery, we can make sure to use the desired root
+// directory descriptor from the `kj::Directory`.
+//
+// Of course, SQLite also lets us virtualize the whole filesystem at a higher level. Why go to all
+// the bother to hack it at a low level rather than just implement an entire VFS based on the
+// `kj::Directory` interface? The problem is, SQLite's native VFS contains a ton of code to handle
+// all sorts of corner cases and do things just right. When our files are actually on real disk,
+// we want to leverage all that code. If we can just make it interpret paths differently, then we
+// can reuse the rest of the implementation.
+
+namespace {
+
+static thread_local int currentVfsRoot = AT_FDCWD;
+// We will tell SQLite to use alternate implementations of path-oriented syscalls which use the
+// `*at()` versions of the calls with `currentVfsRoot` as the directory descriptor. When the
+// descriptor is `AT_FDCWD`, this will naturally reproduce the behavior of the non-`at()` versions.
+// We temporarily swap this for a real desriptor when our custom VFS wrapper is being invoked.
+
+static int replaced_open(const char* path, int flags, int mode) {
+  return openat(currentVfsRoot, path, flags, mode);
+}
+static int replaced_access(const char* path, int type) {
+  return faccessat(currentVfsRoot, path, type, 0);
+}
+static char* replaced_getcwd(char* buf, size_t size) noexcept {
+  KJ_REQUIRE(currentVfsRoot == AT_FDCWD,
+      "SQLite custom VFS shouldn't call getcwd() because we overrode xFullPathname");
+  return getcwd(buf, size);
+}
+static int replaced_stat(const char* path, struct stat* stats) {
+  return fstatat(currentVfsRoot, path, stats, 0);
+}
+static int replaced_unlink(const char* path) {
+  return unlinkat(currentVfsRoot, path, 0);
+}
+static int replaced_mkdir(const char* path, mode_t mode) {
+  return mkdirat(currentVfsRoot, path, mode);
+}
+static int replaced_rmdir(const char* path) {
+  return unlinkat(currentVfsRoot, path, AT_REMOVEDIR);
+}
+static ssize_t replaced_readlink(const char* path, char* buf, size_t len) {
+  return readlinkat(currentVfsRoot, path, buf, len);
+}
+static int replaced_lstat(const char* path, struct stat* stats) {
+  return fstatat(currentVfsRoot, path, stats, AT_SYMLINK_NOFOLLOW);
+}
+
+};
+
+struct Sqlite::Vfs::WrappedNativeFileImpl: public sqlite3_file {
+  // The sqlite3_file implementation we use when wrapping the native filesystem.
+
+  int rootFd;
+
+  // It's expected that the wrapped sqlite_file begins in memory immediately after this object.
+  sqlite3_file* getWrapped() { return reinterpret_cast<sqlite3_file*>(this + 1); }
+
+  static const sqlite3_io_methods METHOD_TABLE;
+};
+
+template <typename Result, typename... Params,
+          Result (*sqlite3_vfs::*slot)(sqlite3_vfs* vfs, Params...)>
+struct Sqlite::Vfs::MethodWrapperHack<Result (*sqlite3_vfs::*)(sqlite3_vfs* vfs, Params...), slot> {
+  // This completely nutso template generates wrapper functions for each of the function pointer
+  // members of sqlite3_vfs. The wrapper function temporarily sets `currentVfsRoot` to the FD
+  // of the directory from the Sqlite::Vfs instance in use, then invokes the same function on
+  // the underlying native VFS.
+
+  static Result wrapper(sqlite3_vfs* vfs, Params... params) noexcept {
+    auto& self = *reinterpret_cast<Sqlite::Vfs*>(vfs->pAppData);
+    KJ_ASSERT(currentVfsRoot == AT_FDCWD);
+    currentVfsRoot = self.rootFd;
+    KJ_DEFER(currentVfsRoot = AT_FDCWD);
+    return (self.native.*slot)(&self.native, params...);
+  }
+};
+
+template <typename Result, typename... Params,
+          Result (*sqlite3_io_methods::*slot)(sqlite3_file* file, Params...)>
+struct Sqlite::Vfs::MethodWrapperHack<
+    Result (*sqlite3_io_methods::*)(sqlite3_file* file, Params...), slot> {
+  // Specialization of MethodWrapperHack for wrapping methods of sqlite_file, aka
+  // sqlite3_io_methods. Unfortunately, some file methods go back and perform filesystem ops. In
+  // particular, accessing shared memory associated with a file actually opens another adjacent
+  //file.
+
+  static Result wrapper(sqlite3_file* file, Params... params) noexcept {
+    auto wrapper = static_cast<WrappedNativeFileImpl*>(file);
+    file = wrapper->getWrapped();
+    KJ_ASSERT(currentVfsRoot == AT_FDCWD);
+    currentVfsRoot = wrapper->rootFd;
+    KJ_DEFER(currentVfsRoot = AT_FDCWD);
+    return (file->pMethods->*slot)(file, params...);
+  }
+};
+
+const sqlite3_io_methods Sqlite::Vfs::WrappedNativeFileImpl::METHOD_TABLE = {
+  .iVersion = 3,
+
+#define WRAP(name) \
+  .name = &MethodWrapperHack<decltype(&sqlite3_io_methods::name), \
+                             &sqlite3_io_methods::name>::wrapper
+
+  WRAP(xClose),
+  WRAP(xRead),
+  WRAP(xWrite),
+  WRAP(xTruncate),
+  WRAP(xSync),
+  WRAP(xFileSize),
+  WRAP(xLock),
+  WRAP(xUnlock),
+  WRAP(xCheckReservedLock),
+  WRAP(xFileControl),
+  WRAP(xSectorSize),
+  WRAP(xDeviceCharacteristics),
+
+  WRAP(xShmMap),
+  WRAP(xShmLock),
+  WRAP(xShmBarrier),
+  WRAP(xShmUnmap),
+
+  WRAP(xFetch),
+  WRAP(xUnfetch),
+#undef WRAP
+};
+
+sqlite3_vfs Sqlite::Vfs::makeWrappedNativeVfs() {
+  // The native VFS gives us the ability to override its syscalls. We need to do so, in
+  // particular to force them to use the *at() versions of the calls that accept a directory FD
+  // to use as the root.
+  //
+  // Unfortunately, these overrides are global for the process, with no ability to pass down any
+  // context to them. So, we stash the current root FD in `currentVfsRoot` whenever we call into
+  // the native VFS. We also don't want to interfere with anything else in the process that is
+  // using SQLite directly, so we make sure that when we're not specifically trying to invoke
+  // our wrapper, then `currentVfsRoot` is `AT_FDCWD`, which causes the *at() syscalls to match
+  // their non-at() versions.
+  static bool registerOnce KJ_UNUSED = ([&]() {
+#define REPLACE_SYSCALL(name) \
+    native.xSetSystemCall(&native, #name, (sqlite3_syscall_ptr)replaced_##name);
+
+    REPLACE_SYSCALL(open);
+    REPLACE_SYSCALL(access);
+    REPLACE_SYSCALL(getcwd);
+    REPLACE_SYSCALL(stat);
+    REPLACE_SYSCALL(unlink);
+    REPLACE_SYSCALL(mkdir);
+    REPLACE_SYSCALL(rmdir);
+    REPLACE_SYSCALL(readlink);
+    REPLACE_SYSCALL(lstat);
+#undef REPLACE_SYSCALL
+
+    return true;
+  })();
+
+  // We construct a sqlite3_vfs that is basically a copy of the native VFS, except each method is
+  // wrapped so that it sets `currentVfsRoot` while running.
+  return {
+    .iVersion = kj::min(3, native.iVersion),
+    .szOsFile = native.szOsFile + (int)sizeof(WrappedNativeFileImpl),
+    .mxPathname = native.mxPathname,
+    .pNext = nullptr,
+    .zName = name.cStr(),
+    .pAppData = this,
+
+    .xOpen = [](sqlite3_vfs* vfs, sqlite3_filename zName, sqlite3_file* file,
+                int flags, int *pOutFlags) -> int {
+      // We have to wrap xOpen explicitly because we need to furthder wrap each created file.
+      //
+      // My trick here is to prefix the native file with a second vtable. So the layout of the
+      // `sqlite3_file` that we construct is actually a simple `struct sqlite_file` (which just
+      // contains a single pointer to sqlite3_io_methods, i.e. the vtable pointer) _followed by_
+      // the regular native file structure.
+
+      auto wrapper = static_cast<WrappedNativeFileImpl*>(file);
+      file = wrapper->getWrapped();
+      file->pMethods = nullptr;
+
+      // Set up currentVfsRoot.
+      auto& self = *reinterpret_cast<Sqlite::Vfs*>(vfs->pAppData);
+      KJ_ASSERT(currentVfsRoot == AT_FDCWD);
+      currentVfsRoot = self.rootFd;
+      KJ_DEFER(currentVfsRoot = AT_FDCWD);
+
+      int result = self.native.xOpen(&self.native, zName, file, flags, pOutFlags);
+
+      // `xOpen` setting `pMethods` to non-null indicates that `xClose` is needed, i.e. the file
+      // has been constructed. We need our wrapper to match.
+      if (file->pMethods == nullptr) {
+        wrapper->pMethods = nullptr;
+      } else {
+        wrapper->pMethods = &WrappedNativeFileImpl::METHOD_TABLE;
+        wrapper->rootFd = self.rootFd;
+      }
+
+      return result;
+    },
+
+#define WRAP(name) \
+    .name = &MethodWrapperHack<decltype(&sqlite3_vfs::name), &sqlite3_vfs::name>::wrapper
+
+    WRAP(xDelete),
+    WRAP(xAccess),
+    .xFullPathname = [](sqlite3_vfs*, const char *zName, int nOut, char *zOut) -> int {
+      // Override xFullPathname so that it doesn't rewrite the path at all.
+      size_t len = kj::min(strlen(zName), nOut - 1);
+      memcpy(zOut, zName, len);
+      zOut[len] = 0;
+      return SQLITE_OK;
+    },
+
+    .xDlOpen = nullptr,
+    .xDlError = nullptr,
+    .xDlSym = nullptr,
+    .xDlClose = nullptr,
+    // There is no dlopenat(), but we don't need to support these anyway.
+
+    WRAP(xRandomness),
+    WRAP(xSleep),
+    WRAP(xCurrentTime),
+    WRAP(xGetLastError),
+    WRAP(xCurrentTimeInt64),
+
+    .xSetSystemCall = nullptr,
+    .xGetSystemCall = nullptr,
+    .xNextSystemCall = nullptr,
+    // We don't support further overriding syscalls.
+#undef WRAP
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Code to implement a true SQLite VFS based on `kj::Directory`.
+//
+// This VFS implementation actually delegates to the KJ filesystem interface for everything.
+// This is used only when given a `kj::Directory` that does NOT represent a native file, i.e.
+// one where `getFd()` returns null. This is mainly used for unit tests which want to use in-memory
+// directories.
+//
+// WARNING: Since KJ filesystem does not implement locking, this implementation ignores all locks.
+
+struct Sqlite::Vfs::FileImpl: public sqlite3_file {
+  // Implementation of sqlite3_file.
+  //
+  // Weirdly, for sqlite3_file, SQLite uses a C++-like inheritance approach, with a separate
+  // virtual table that can be shared among all files of the same type. This is different from the
+  // way sqlite3_vfs works, where the function pointers are inlined into the sqlite3_vfs struct.
+  // In any case, as a result, `FileImpl`, unlike `VfsImpl`, is NOT just a namespace struct, but
+  // an actual instance.
+
+  kj::Maybe<const kj::File&> writableFile;
+  kj::Own<const kj::ReadableFile> file;
+
+  kj::Vector<kj::Array<byte>> shmRegions;
+  // Rather complicatedly, SQLite doesn't consider the -shm file to be a separate file that it
+  // opens via the VFS, but rather a facet of the database file itself. This implementation, since
+  // it doesn't support locking anyway, allocates shm regions entirely in memory.
+
+  FileImpl(kj::Own<const kj::File> file)
+      : sqlite3_file { .pMethods = &FILE_METHOD_TABLE },
+        writableFile(*file),
+        file(kj::mv(file)) {}
+  FileImpl(kj::Own<const kj::ReadableFile> file)
+      : sqlite3_file { .pMethods = &FILE_METHOD_TABLE },
+        file(kj::mv(file)) {}
+
+  static const sqlite3_io_methods FILE_METHOD_TABLE;
+};
+
+const sqlite3_io_methods Sqlite::Vfs::FileImpl::FILE_METHOD_TABLE = {
+  .iVersion = 3,
+#define WRAP_METHOD(errorCode, block) \
+  auto& self KJ_UNUSED = *static_cast<FileImpl*>(file); \
+  try block catch (kj::Exception& e) { \
+    KJ_LOG(ERROR, "SQLite VFS I/O error", e); \
+    return errorCode; \
+  }
+
+  .xClose = [](sqlite3_file* file) noexcept -> int {
+    WRAP_METHOD(SQLITE_OK, {
+      auto& self = *static_cast<FileImpl*>(file);
+
+      // Caller will free the object's memory, but knows nothing of destructors.
+      kj::dtor(self);
+
+      return SQLITE_OK;  // return value is ignored by SQLite
+    });
+  },
+
+  .xRead = [](sqlite3_file* file, void* buffer, int iAmt, sqlite3_int64 iOfst) noexcept -> int {
+    WRAP_METHOD(SQLITE_IOERR_READ, {
+      auto bytes = kj::arrayPtr(reinterpret_cast<byte*>(buffer), iAmt);
+      size_t actual = self.file->read(iOfst, bytes);
+
+      if (actual < iAmt) {
+        memset(bytes.begin() + actual, 0, iAmt - actual);
+        return SQLITE_IOERR_SHORT_READ;
+      } else {
+        return SQLITE_OK;
+      }
+    });
+  },
+
+  .xWrite = [](sqlite3_file* file, const void* buffer, int iAmt,
+               sqlite3_int64 iOfst) noexcept -> int {
+    WRAP_METHOD(SQLITE_IOERR_WRITE, {
+      auto bytes = kj::arrayPtr(reinterpret_cast<const byte*>(buffer), iAmt);
+      KJ_REQUIRE_NONNULL(self.writableFile).write(iOfst, bytes);
+      return SQLITE_OK;
+    });
+  },
+
+  .xTruncate = [](sqlite3_file* file, sqlite3_int64 size) noexcept -> int {
+    WRAP_METHOD(SQLITE_IOERR_TRUNCATE, {
+      KJ_REQUIRE_NONNULL(self.writableFile).truncate(size);
+      return SQLITE_OK;
+    });
+  },
+
+  .xSync = [](sqlite3_file* file, int flags) noexcept -> int {
+    WRAP_METHOD(SQLITE_IOERR_FSYNC, {
+      if (flags&SQLITE_SYNC_DATAONLY) {
+        self.file->datasync();
+      } else {
+        self.file->sync();
+      }
+      return SQLITE_OK;
+    });
+  },
+
+  .xFileSize = [](sqlite3_file* file, sqlite3_int64 *pSize) noexcept -> int {
+    WRAP_METHOD(SQLITE_IOERR_FSTAT, {
+      *pSize = self.file->stat().size;
+      return SQLITE_OK;
+    });
+  },
+
+  .xLock = [](sqlite3_file* file, int level) noexcept -> int {
+    // Locks not implemented.
+    return SQLITE_OK;
+  },
+
+  .xUnlock = [](sqlite3_file* file, int level) noexcept -> int {
+    // Locks not implemented.
+    return SQLITE_OK;
+  },
+
+  .xCheckReservedLock = [](sqlite3_file* file, int *pResOut) noexcept -> int {
+    // Locks not implemented.
+    //
+    // We always report that there is no reserved lock. Hopefully this doesn't confuse SQLite when
+    // it thinks it has taken a reserved lock itself.
+    *pResOut = false;
+    return SQLITE_OK;
+  },
+
+  .xFileControl = [](sqlite3_file* file, int op, void *pArg) noexcept -> int {
+    // Apparently we can return SQLITE_NOTFOUND for controls we don't implement.
+    return SQLITE_NOTFOUND;
+  },
+  .xSectorSize = [](sqlite3_file* file) noexcept -> int {
+    // This function doesn't return a status code, it returns the size. It's largely a performance
+    // hint, I think. For in-memory file systems, it has no real meaning. 4096 is the value of
+    // SQLITE_DEFAULT_SECTOR_SIZE in the SQLite codebase, though the comments also say the result
+    // is "almost always 512".
+    return 4096;
+  },
+  .xDeviceCharacteristics = [](sqlite3_file* file) noexcept -> int {
+    // This returns a bitfield of SQLITE_IOCAP_* flags that make promises to SQLite, presumably
+    // allowing it to perform better. These promises depend on the underlying filesystem details.
+    // We can't really make any promises since we don't know anything here. Weirdly enough, the
+    // standard unix implementation doesn't seem to set any bits at all, unless you're using f2fs
+    // on Linux, or you're using QNX. I guess a lot of this stuff is various guarantees that
+    // embedded device vendors implemented in hardware which allow sqlite to run faster on their
+    // device.
+    return 0;
+  },
+
+  .xShmMap = [](sqlite3_file* file, int iRegion, int szRegion, int bExtend,
+                void volatile** pp) noexcept -> int {
+    WRAP_METHOD(SQLITE_IOERR_SHMMAP, {
+      if (iRegion >= self.shmRegions.size()) {
+        if (bExtend) {
+          self.shmRegions.resize(iRegion + 1);
+        } else {
+          *pp = nullptr;
+          return SQLITE_OK;
+        }
+      }
+      if (self.shmRegions[iRegion].size() == 0) {
+        self.shmRegions[iRegion] = kj::heapArray<byte>(szRegion);
+      } else {
+        // Presumably regions cannot change size.
+        KJ_ASSERT(self.shmRegions[iRegion].size() == szRegion);
+      }
+      *pp = self.shmRegions[iRegion].begin();
+      return SQLITE_OK;
+    });
+  },
+  .xShmLock = [](sqlite3_file* file, int offset, int n, int flags) noexcept -> int {
+    // Locking not implemented.
+    return SQLITE_OK;
+  },
+  .xShmBarrier = [](sqlite3_file*) noexcept -> void {
+    // Locking not implemented.
+  },
+  .xShmUnmap = [](sqlite3_file* file, int deleteFlag) noexcept -> int {
+    WRAP_METHOD(SQLITE_OK, {
+      if (deleteFlag) {
+        self.shmRegions.clear();
+      }
+      return SQLITE_OK;  // return value is ignored by sqlite
+    });
+  },
+
+  .xFetch = [](sqlite3_file* file, sqlite3_int64 iOfst, int iAmt, void **pp) noexcept -> int {
+    // This is essentially requesting an mmap(). kj::File supports mmap(). Great, right?
+    //
+    // Well, there's a problem. We mostly use this VFS implementation to wrap an in-memory
+    // `kj::File`. Such files support mmap by returning a pointer into the backing store. But
+    // while such a mapping exists, the backing store cannot be resized. So write()s that extend
+    // the file may fail. This does not work for SQLite's use case.
+    //
+    // So, alas, we must act like we don't support this. Luckily, SQLite has fallbacks for this.
+    *pp = nullptr;
+    return SQLITE_OK;
+  },
+  .xUnfetch = [](sqlite3_file* file, sqlite3_int64 iOfst, void *p) noexcept -> int {
+    // Shouldn't ever be called since xFetch() always produces null? But the native implementation
+    // return SQLITE_OK even when mmap is disabled so we will too.
+    return SQLITE_OK;
+  },
+#undef WRAP_METHOD
+};
+
+sqlite3_vfs Sqlite::Vfs::makeKjVfs() {
+  // SQLite VFS implementation based on abstract `kj::Directory`. This is used only when the
+  // directory is NOT a true disk directory.
+  //
+  // This is a namespace-struct defining static methods to fill in the function pointers of
+  // sqlite3_vfs.
+
+  return {
+    .iVersion = kj::min(3, native.iVersion),
+    .szOsFile = sizeof(FileImpl),
+
+    .mxPathname = 512,
+    // We have no real limit on paths but SQLite likes to allocate buffers of this size whenever
+    // doing path stuff so making it huge would be bad. The default unix implementation uses
+    // 512 as a limit so that "should be enough for anyone".
+
+    .pNext = nullptr,
+    .zName = name.cStr(),
+    .pAppData = this,
+
+#define WRAP_METHOD(errorCode, block) \
+      auto& self KJ_UNUSED = *static_cast<Sqlite::Vfs*>(vfs->pAppData); \
+      try block catch (kj::Exception& e) { \
+        KJ_LOG(ERROR, "SQLite VFS I/O error", e); \
+        return errorCode; \
+      }
+
+    .xOpen = [](sqlite3_vfs* vfs, sqlite3_filename zName, sqlite3_file* file,
+                int flags, int *pOutFlags) -> int {
+      WRAP_METHOD(SQLITE_CANTOPEN, {
+        auto& target = *static_cast<FileImpl*>(file);
+
+        if (flags & SQLITE_OPEN_READONLY) {
+          KJ_REQUIRE(zName != nullptr, "readonly unnamed temporary file? what?");
+          KJ_REQUIRE(!(flags & SQLITE_OPEN_CREATE), "create readonly file? what?");
+
+          auto path = kj::Path::parse(zName);
+          auto kjFile = self.directory.openFile(path);
+
+          kj::ctor(target, kj::mv(kjFile));
+        } else {
+          kj::Own<const kj::File> kjFile;
+
+          if (zName == nullptr) {
+            // Open a temp file.
+            KJ_ASSERT(flags & SQLITE_OPEN_DELETEONCLOSE);
+            kjFile = self.directory.createTemporary();
+          } else {
+            kj::WriteMode mode;
+            if (flags & SQLITE_OPEN_CREATE) {
+              if (flags & SQLITE_OPEN_EXCLUSIVE) {
+                mode = kj::WriteMode::CREATE;
+              } else {
+                mode = kj::WriteMode::CREATE | kj::WriteMode::MODIFY;
+              }
+            } else {
+                mode = kj::WriteMode::MODIFY;
+            }
+
+            auto path = kj::Path::parse(zName);
+            kjFile = self.directory.openFile(path, mode);
+
+            if (flags & SQLITE_OPEN_DELETEONCLOSE) {
+              self.directory.remove(path);
+            }
+          }
+
+          kj::ctor(target, kj::mv(kjFile));
+        }
+
+        // In theory if read-write was requested, but failed, we should retry read-only, and then
+        // alter the pOutFlags to reflect this... I'm not going to bother.
+        if (pOutFlags != nullptr) {
+          *pOutFlags = flags;
+        }
+
+        return SQLITE_OK;
+      });
+    },
+    .xDelete = [](sqlite3_vfs* vfs, const char *zName, int syncDir) -> int {
+      WRAP_METHOD(SQLITE_IOERR_DELETE, {
+        if (self.directory.tryRemove(kj::Path::parse(zName))) {
+          return SQLITE_OK;
+        } else {
+          return SQLITE_IOERR_DELETE_NOENT;
+        }
+      });
+    },
+    .xAccess = [](sqlite3_vfs* vfs, const char *zName, int flags, int *pResOut) -> int {
+      WRAP_METHOD(SQLITE_IOERR_ACCESS, {
+        // Technically, depending on the flags, this may be checking whether the file is readable
+        // or writable, rather than just whether it exists. However, the KJ filesystem API
+        // assumes that all descendents of a writable directory are readable and writable, hence
+        // this is equivalent to checking for existence.
+        //
+        // If we were to extend the VFS so it can wrap `kj::ReadableDirectory` then in that case
+        // we would want to return false when querying writability.
+        *pResOut = self.directory.exists(kj::Path::parse(zName));
+        return SQLITE_OK;
+      });
+    },
+    .xFullPathname = [](sqlite3_vfs*, const char *zName, int nOut, char *zOut) -> int {
+      // Don't rewrite the path at all. All paths are canonical. Our path parsing will reject
+      // the existence of `.` or `..` as path components as well as leading `/`.
+      size_t len = kj::min(strlen(zName), nOut - 1);
+      memcpy(zOut, zName, len);
+      zOut[len] = 0;
+      return SQLITE_OK;
+    },
+
+    .xDlOpen = nullptr,
+    .xDlError = nullptr,
+    .xDlSym = nullptr,
+    .xDlClose = nullptr,
+    // We don't support loading shared libraries from virtual files.
+
+    .xRandomness = native.xRandomness,
+    .xSleep = native.xSleep,
+    .xCurrentTime = native.xCurrentTime,
+    .xGetLastError = nullptr,
+    .xCurrentTimeInt64 = native.xCurrentTimeInt64,
+    // Use native implementations of these OS functions. I'm not sure why these are even part
+    // of the VFS. (Exception: xGetLastError is actually sensibly a VFS thing, but we are allowed
+    // to just not implement it.)
+
+    .xSetSystemCall = nullptr,
+    .xGetSystemCall = nullptr,
+    .xNextSystemCall = nullptr,
+    // We don't support overriding any syscalls.
+
+#undef WRAP_METHOD
+  };
+};
+
+// -----------------------------------------------------------------------------
+
+Sqlite::Vfs::Vfs(const kj::Directory& directory)
+    : directory(directory), name(kj::str("kj-", &directory)),
+      native(*sqlite3_vfs_find(nullptr)) {
+  KJ_IF_MAYBE(fd, directory.getFd()) {
+    rootFd = *fd;
+    vfs = kj::heap(makeWrappedNativeVfs());
+  } else {
+    vfs = kj::heap(makeKjVfs());
+  }
+  sqlite3_vfs_register(vfs, false);
+}
+
+Sqlite::Vfs::~Vfs() noexcept(false) {
+  sqlite3_vfs_unregister(vfs);
+}
+
+// =======================================================================================
+
+}  // namespace workerd

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -126,17 +126,13 @@ Sqlite::Query::Query(Sqlite& db, kj::StringPtr sqlCode, kj::ArrayPtr<const Value
 }
 
 Sqlite::Query::~Query() noexcept(false) {
-  if (statement == nullptr) {
-    // Object was moved away.
-  } else {
-    // The error code returned by sqlite3_reset() actually represents the last error encountered
-    // when stepping the statement. This doesn't mean that the reset failed.
-    sqlite3_reset(statement);
+  // The error code returned by sqlite3_reset() actually represents the last error encountered
+  // when stepping the statement. This doesn't mean that the reset failed.
+  sqlite3_reset(statement);
 
-    // sqlite3_clear_bindings() returns int, but there is no documentation on how the return code
-    // should be interpreted, so we ignore it.
-    sqlite3_clear_bindings(statement);
-  }
+  // sqlite3_clear_bindings() returns int, but there is no documentation on how the return code
+  // should be interpreted, so we ignore it.
+  sqlite3_clear_bindings(statement);
 }
 
 void Sqlite::Query::init(kj::ArrayPtr<const ValuePtr> bindings) {

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -186,12 +186,13 @@ private:
   void bind(uint column, ValuePtr value);
   void bind(uint column, kj::ArrayPtr<const byte> value);
   void bind(uint column, kj::StringPtr value);
-  void bind(uint column, int64_t value);
+  void bind(uint column, long long value);
   void bind(uint column, double value);
   void bind(uint column, decltype(nullptr));
 
-  inline void bind(uint column, int value) { bind(column, static_cast<int64_t>(value)); }
-  inline void bind(uint column, uint value) { bind(column, static_cast<int64_t>(value)); }
+  inline void bind(uint column, int value) { bind(column, static_cast<long long>(value)); }
+  inline void bind(uint column, uint value) { bind(column, static_cast<long long>(value)); }
+  inline void bind(uint column, long value) { bind(column, static_cast<long long>(value)); }
   inline void bind(uint column, float value) { bind(column, static_cast<double>(value)); }
   // Some reasonable automatic conversions.
 

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -1,0 +1,235 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <kj/filesystem.h>
+#include <kj/async.h>
+#include <kj/one-of.h>
+
+struct sqlite3;
+struct sqlite3_vfs;
+struct sqlite3_stmt;
+
+KJ_DECLARE_NON_POLYMORPHIC(sqlite3_stmt);
+
+namespace workerd {
+
+using kj::byte;
+using kj::uint;
+
+class Sqlite {
+  // C++/KJ API for SQLite.
+  //
+  // In addition to providing a more modern C++ interface vs. the classic C API, this API layers
+  // SQLite on top of KJ's filesystem API. This means that you can use KJ's in-memory filesystem
+  // implementation in unit tests. Meanwhile, though, if you do actually give it a `kj::Directory`
+  // representing a true disk directory, the real SQLite disk implementation will be used with
+  // all of its features.
+
+public:
+  class Vfs;
+  class Query;
+  class Statement;
+
+  Sqlite(Vfs& vfs, kj::PathPtr path);
+  Sqlite(Vfs& vfs, kj::PathPtr path, kj::WriteMode mode);
+  ~Sqlite() noexcept(false);
+
+  Sqlite(Sqlite&& other): db(other.db) { other.db = nullptr; }
+  Sqlite& operator=(Sqlite&& other) { db = other.db; other.db = nullptr; return *this; }
+  KJ_DISALLOW_COPY(Sqlite);
+
+  operator sqlite3*() { return db; }
+  // Allows a Sqlite object to be passed directly into SQLite API functions where `sqlite*` is
+  // expected.
+
+  Statement prepare(kj::StringPtr sqlCode);
+  // Prepares the given SQL code as a persistent statement that can be used across several queries.
+  // Don't use this for one-off queries; pass the code to the Query constructor.
+
+  template <typename... Params>
+  Query run(kj::StringPtr sqlCode, Params&&... bindings);
+  // Convenience method to start a query. This is equivalent to:
+  //
+  //     Sqlite::Query(db, sqlCode, bindings...);
+
+private:
+  sqlite3* db;
+
+  void close();
+};
+
+class Sqlite::Statement {
+public:
+  template <typename... Params>
+  Query run(Params&&... bindings);
+  // Convenience method to start a query. This is equivalent to:
+  //
+  //     Sqlite::Query(db, statement, bindings...);
+
+  operator sqlite3_stmt*() { return stmt; }
+
+private:
+  Sqlite& db;
+  kj::Own<sqlite3_stmt> stmt;
+
+  Statement(Sqlite& db, kj::Own<sqlite3_stmt> stmt): db(db), stmt(kj::mv(stmt)) {}
+
+  friend class Sqlite;
+};
+
+class Sqlite::Query {
+  // Represents one SQLite query.
+  //
+  // Only one Query can exist at a time, for a given database. It should probably be allocated on
+  // the stack.
+
+public:
+  typedef kj::OneOf<kj::ArrayPtr<const byte>, kj::StringPtr, int64_t, double,
+                    decltype(nullptr)> ValuePtr;
+
+  Query(Sqlite& db, Statement& statement, kj::ArrayPtr<const ValuePtr> bindings);
+  // Begin a query executing a prepared statement.
+  //
+  // `bindings` are the value to fill into `?`s in the statement. The `bindings` array itself
+  // need only live until the constructor returns, but any strings or blobs it points to must
+  // remain valid until the Query is destroyed.
+
+  Query(Sqlite& db, kj::StringPtr sqlCode, kj::ArrayPtr<const ValuePtr> bindings);
+  // Begin a one-off query executing some code directly.
+
+  template <typename... Params>
+  Query(Sqlite& db, Statement& statement, Params&&... bindings)
+      : Query(db, statement, {ValuePtr(bindings)...}) {}
+  template <typename... Params>
+  Query(Sqlite& db, kj::StringPtr sqlCode, Params&&... bindings)
+      : Query(db, sqlCode, {ValuePtr(bindings)...}) {}
+  // These versions of the constructor accept the binding values as positional parameters. This
+  // may be convenient when the number of bindings is statically known.
+
+  Query(Query&& other)
+      : db(other.db), ownStatement(kj::mv(other.ownStatement)),
+        statement(other.statement), done(other.done) { other.statement = nullptr; }
+  // Move construction is supported mainly so that Sqlite::query() can return a Query.
+
+  ~Query() noexcept(false);
+
+  KJ_DISALLOW_COPY(Query);
+
+  bool isDone() { return done; }
+  // If true, there are no more rows. (When true, the methods below must not be called.)
+
+  uint changeCount();
+  // For INSERT, UPDATE, or DELETE queries, returns the number of rows changed. For other query
+  // types the result is undefined.
+
+  void nextRow();
+  // Advance to the next row.
+
+  uint columnCount();
+  // How many columns does each row of the result have?
+
+  ValuePtr getValue(uint column);
+  // Get the value at the given column, as whatever type was actually returned.
+  //
+  // Returned pointers (strings and blobs) remain valid only until either (a) nextRow() is called,
+  // or (b) a different get method is called on the same column but with a different type.
+
+  kj::ArrayPtr<const byte> getBlob(uint column);
+  kj::StringPtr getText(uint column);
+  int getInt(uint column);
+  int64_t getInt64(uint column);
+  double getDouble(uint column);
+  bool isNull(uint column);
+  // Get the value at the given column, coercing it to the desired type according to SQLite rules.
+
+  kj::Maybe<kj::ArrayPtr<const byte>> getMaybeBlob(uint column) {
+    if (isNull(column)) { return nullptr; } else { return getBlob(column); }
+  }
+  kj::Maybe<kj::StringPtr> getMaybeText(uint column) {
+    if (isNull(column)) { return nullptr; } else { return getText(column); }
+  }
+  kj::Maybe<int> getMaybeInt(uint column) {
+    if (isNull(column)) { return nullptr; } else { return getInt(column); }
+  }
+  kj::Maybe<int64_t> getMaybeInt64(uint column) {
+    if (isNull(column)) { return nullptr; } else { return getInt64(column); }
+  }
+  kj::Maybe<double> getMaybeDouble(uint column) {
+    if (isNull(column)) { return nullptr; } else { return getDouble(column); }
+  }
+
+private:
+  sqlite3* db;
+  kj::Own<sqlite3_stmt> ownStatement;   // for one-off queries
+  sqlite3_stmt* statement;
+  bool done = false;
+
+  void init(kj::ArrayPtr<const ValuePtr> bindings);
+};
+
+class Sqlite::Vfs {
+  // Implements a SQLite VFS based on a KJ directory.
+  //
+  // If the directory is detected to be a disk directory (i.e. getFd() or getWin32Handle() returns
+  // non-null), this VFS implementation will actually delegate to the built-in one. This ensures
+  // feature-parity for production use.
+  //
+  // If the directory is not a disk directory, then the VFS will actually use the KJ APIs, but
+  // some features will be missing. Most importantly, as of this writing, KJ filesystem APIs do
+  // not support locks, so all locking will be ignored.
+
+public:
+  explicit Vfs(const kj::Directory& directory);
+  ~Vfs() noexcept(false);
+
+  kj::StringPtr getName() { return name; }
+  // Unfortunately, all SQLite VFSes must be registered in a global list with unique names, and
+  // then the _name_ must be passed to sqlite3_open_v2() to use it when opening a database. This is
+  // dumb, you should instead be able to simply pass the sqlite3_vfs* when opening the database,
+  // but this is the way it is. To work around this, each VFS is assigned an auto-generated unique
+  // name.
+  //
+  // TODO(cleanup): Patch SQLite to allow passing the pointer in?
+
+  KJ_DISALLOW_COPY_AND_MOVE(Vfs);
+
+private:
+  const kj::Directory& directory;
+  kj::String name;
+
+  sqlite3_vfs& native;  // the system's default VFS implementation
+  kj::Own<sqlite3_vfs> vfs;  // our VFS
+
+  int rootFd = -1;
+  // Result of `directory.getFd()`, if it returns non-null. Cached here for convenience.
+
+  template <typename T, T slot>
+  struct MethodWrapperHack;
+
+  struct WrappedNativeFileImpl;
+  sqlite3_vfs makeWrappedNativeVfs();
+  // Create a VFS definition that wraps the native VFS implementation except that it treats our
+  // `directory` as the root. Requires that the directory is a real disk directory (and `rootFd`
+  // is filled in).
+
+  struct FileImpl;
+  sqlite3_vfs makeKjVfs();
+  // Create a VFS definition that actually delegates to the KJ filesystem.
+
+  friend class Sqlite;
+};
+
+template <typename... Params>
+Sqlite::Query Sqlite::run(kj::StringPtr sqlCode, Params&&... params) {
+  return Query(*this, sqlCode, kj::fwd<Params>(params)...);
+}
+
+template <typename... Params>
+Sqlite::Query Sqlite::Statement::run(Params&&... params) {
+  return Query(db, *this, kj::fwd<Params>(params)...);
+}
+
+}  // namespace workerd


### PR DESCRIPTION
Each DO gets its own separate SQLite database.

There is no change to the storage API (for now). We simply use SQLite to store keys and values behind the traditional DO storage API.

This was a weird project where the first 10% of the project (creating the SQLite/KJ bindings) took 90% of the time, and the remaining 90% (implementing Durable Objects in terms of it) took 10% of the time.

I think the plan is for @TrevorSundberg to review this.

/cc @xortive @bcaimano @a-robinson @bretthoerner who are probably interested.