### PR TITLE
Multiple miscellaneous cleanups

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -387,10 +387,7 @@ void AbortSignal::throwIfAborted(jsg::Lock& js) {
 jsg::Ref<AbortSignal> AbortSignal::timeout(jsg::Lock& js, double delay) {
   auto signal = jsg::alloc<AbortSignal>();
 
-  auto context = js.v8Isolate->GetCurrentContext();
-
-  auto& global = jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(
-      context, context->Global());
+  auto& global = ServiceWorkerGlobalScope::from(js);
 
   // It's worth noting that the setTimeout holds a strong pointer to the AbortSignal,
   // keeping it from being garbage collected before the timer fires or until the request
@@ -477,10 +474,8 @@ kj::Promise<void> Scheduler::wait(
   //   the abort signal to support wrapping jsg promises.
   auto paf = kj::newPromiseAndFulfiller<void>();
 
-  auto context = js.v8Isolate->GetCurrentContext();
+  auto& global = ServiceWorkerGlobalScope::from(js);
 
-  auto& global = jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(
-      context, context->Global());
   global.setTimeoutInternal(
       [fulfiller = IoContext::current().addObject(kj::mv(paf.fulfiller))]
       (jsg::Lock& lock) mutable {

--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -505,7 +505,7 @@ void ExtendableEvent::waitUntil(kj::Promise<void> promise) {
   IoContext::current().addWaitUntil(kj::mv(promise));
 }
 
-jsg::Optional<jsg::Ref<ActorState>> ExtendableEvent::getActorState(v8::Isolate* isolate) {
+jsg::Optional<jsg::Ref<ActorState>> ExtendableEvent::getActorState() {
   IoContext& context = IoContext::current();
   return context.getActor().map([&](Worker::Actor& actor) {
     auto& lock = context.getCurrentLock();

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -173,7 +173,7 @@ public:
 
   void waitUntil(kj::Promise<void> promise);
 
-  jsg::Optional<jsg::Ref<ActorState>> getActorState(v8::Isolate* isolate);
+  jsg::Optional<jsg::Ref<ActorState>> getActorState();
 
   JSG_RESOURCE_TYPE(ExtendableEvent) {
     JSG_INHERIT(Event);

--- a/src/workerd/api/blob.c++
+++ b/src/workerd/api/blob.c++
@@ -115,12 +115,12 @@ jsg::Ref<Blob> Blob::slice(jsg::Optional<int> maybeStart, jsg::Optional<int> may
       normalizeType(kj::mv(type).orDefault(nullptr)));
 }
 
-jsg::Promise<kj::Array<kj::byte>> Blob::arrayBuffer(v8::Isolate* isolate) {
+jsg::Promise<kj::Array<kj::byte>> Blob::arrayBuffer(jsg::Lock& js) {
   // TODO(perf): Find a way to avoid the copy.
-  return jsg::resolvedPromise(isolate, kj::heapArray<byte>(data));
+  return js.resolvedPromise(kj::heapArray<byte>(data));
 }
-jsg::Promise<kj::String> Blob::text(v8::Isolate* isolate) {
-  return jsg::resolvedPromise(isolate, kj::str(data.asChars()));
+jsg::Promise<kj::String> Blob::text(jsg::Lock& js) {
+  return js.resolvedPromise(kj::str(data.asChars()));
 }
 
 class Blob::BlobInputStream final: public ReadableStreamSource {
@@ -166,7 +166,7 @@ private:
   jsg::Ref<Blob> blob;
 };
 
-jsg::Ref<ReadableStream> Blob::stream(v8::Isolate* isolate) {
+jsg::Ref<ReadableStream> Blob::stream() {
   return jsg::alloc<ReadableStream>(
       IoContext::current(),
       kj::heap<BlobInputStream>(JSG_THIS));

--- a/src/workerd/api/blob.h
+++ b/src/workerd/api/blob.h
@@ -39,9 +39,9 @@ public:
   jsg::Ref<Blob> slice(jsg::Optional<int> start, jsg::Optional<int> end,
                         jsg::Optional<kj::String> type);
 
-  jsg::Promise<kj::Array<kj::byte>> arrayBuffer(v8::Isolate* isolate);
-  jsg::Promise<kj::String> text(v8::Isolate* isolate);
-  jsg::Ref<ReadableStream> stream(v8::Isolate* isolate);
+  jsg::Promise<kj::Array<kj::byte>> arrayBuffer(jsg::Lock& js);
+  jsg::Promise<kj::String> text(jsg::Lock& js);
+  jsg::Ref<ReadableStream> stream();
 
   JSG_RESOURCE_TYPE(Blob, CompatibilityFlags::Reader flags) {
     if (flags.getJsgPropertyOnPrototypeTemplate()) {

--- a/src/workerd/api/crypto.c++
+++ b/src/workerd/api/crypto.c++
@@ -476,6 +476,9 @@ jsg::Promise<kj::Array<kj::byte>> SubtleCrypto::wrapKey(jsg::Lock& js,
         return wrappingKey.impl->wrapKey(kj::mv(algorithm), bytes.asPtr().asConst());
       }
       KJ_CASE_ONEOF(jwk, JsonWebKey) {
+        // TODO(conform): The WebCrypto spec would seem to indicate we need to pad AES-KW here.
+        // However, I can't find any conformance test that fails if we don't pad. I can't find
+        // anywhere within Chromium that has padding either.
         auto str = js.serializeJson(jwkHandler.wrap(js, kj::mv(jwk))).asBytes().asConst();
         return wrappingKey.impl->wrapKey(kj::mv(algorithm), str);
       }

--- a/src/workerd/api/encoding.c++
+++ b/src/workerd/api/encoding.c++
@@ -299,7 +299,7 @@ kj::Maybe<IcuDecoder> IcuDecoder::create(Encoding encoding, bool fatal, bool ign
 }
 
 kj::Maybe<v8::Local<v8::String>> IcuDecoder::decode(
-    v8::Isolate* isolate,
+    jsg::Lock& js,
     kj::ArrayPtr<const kj::byte> buffer,
     bool flush) {
   UErrorCode status = U_ZERO_ERROR;
@@ -336,7 +336,7 @@ kj::Maybe<v8::Local<v8::String>> IcuDecoder::decode(
       // Note also that in this case we'll interpret as Latin1 since UTF-8 bytes
       // within this range are identical to Latin1 and v8 allocates these more
       // efficiently.
-      return jsg::v8StrFromLatin1(isolate, buffer);
+      return jsg::v8StrFromLatin1(js.v8Isolate, buffer);
     }
 
     if (encoding == Encoding::Utf16le && buffer.size() % sizeof(char16_t) == 0) {
@@ -356,7 +356,7 @@ kj::Maybe<v8::Local<v8::String>> IcuDecoder::decode(
           omitInitialBom = data[0] == 0xfeff;
           bomSeen = true;
         }
-        return jsg::v8Str(isolate, data.slice(omitInitialBom ? 1 : 0, data.size()));
+        return jsg::v8Str(js.v8Isolate, data.slice(omitInitialBom ? 1 : 0, data.size()));
       }
     }
   }
@@ -391,14 +391,14 @@ kj::Maybe<v8::Local<v8::String>> IcuDecoder::decode(
     bomSeen = true;
   }
 
-  return jsg::v8Str(isolate, result.slice(omitInitialBom ? 1 : 0, length));
+  return jsg::v8Str(js.v8Isolate, result.slice(omitInitialBom ? 1 : 0, length));
 }
 
 kj::Maybe<v8::Local<v8::String>> AsciiDecoder::decode(
-    v8::Isolate* isolate,
+    jsg::Lock& js,
     kj::ArrayPtr<const kj::byte> buffer,
     bool flush) {
-  return jsg::v8StrFromLatin1(isolate, buffer);
+  return jsg::v8StrFromLatin1(js.v8Isolate, buffer);
 }
 
 void IcuDecoder::reset() {
@@ -450,27 +450,27 @@ kj::StringPtr TextDecoder::getEncoding() {
 }
 
 v8::Local<v8::String> TextDecoder::decode(
+    jsg::Lock& js,
     jsg::Optional<kj::Array<const kj::byte>> maybeInput,
-    jsg::Optional<DecodeOptions> maybeOptions,
-    v8::Isolate* isolate) {
+    jsg::Optional<DecodeOptions> maybeOptions) {
   auto options = maybeOptions.orDefault(DEFAULT_OPTIONS);
   auto& input = maybeInput.orDefault(EMPTY);
   return JSG_REQUIRE_NONNULL(
-      getImpl().decode(isolate, input, !options.stream),
+      getImpl().decode(js, input, !options.stream),
       TypeError,
       "Failed to decode input.");
 }
 
 kj::Maybe<v8::Local<v8::String>> TextDecoder::decodePtr(
-    v8::Isolate* isolate,
+    jsg::Lock& js,
     kj::ArrayPtr<const kj::byte> buffer,
     bool flush) {
   KJ_SWITCH_ONEOF(decoder) {
     KJ_CASE_ONEOF(dec, AsciiDecoder) {
-      return dec.decode(isolate, buffer, flush);
+      return dec.decode(js, buffer, flush);
     }
     KJ_CASE_ONEOF(dec, IcuDecoder) {
-      return dec.decode(isolate, buffer, flush);
+      return dec.decode(js, buffer, flush);
     }
   }
   KJ_UNREACHABLE;
@@ -483,24 +483,26 @@ jsg::Ref<TextEncoder> TextEncoder::constructor() {
   return jsg::alloc<TextEncoder>();
 }
 
-v8::Local<v8::Uint8Array> TextEncoder::encode(jsg::Optional<v8::Local<v8::String>> input,
-    v8::Isolate* isolate) {
-  auto str = input.orDefault(v8::String::Empty(isolate));
-  auto maybeBuffer = v8::ArrayBuffer::MaybeNew(isolate, str->Utf8Length(isolate));
+v8::Local<v8::Uint8Array> TextEncoder::encode(
+    jsg::Lock& js,
+    jsg::Optional<v8::Local<v8::String>> input) {
+  auto str = input.orDefault(v8::String::Empty(js.v8Isolate));
+  auto maybeBuffer = v8::ArrayBuffer::MaybeNew(js.v8Isolate, str->Utf8Length(js.v8Isolate));
   JSG_ASSERT(!maybeBuffer.IsEmpty(), RangeError, "Cannot allocate space for TextEncoder.encode");
   auto buffer = maybeBuffer.ToLocalChecked();
   auto view = v8::Uint8Array::New(buffer, 0, buffer->ByteLength());
-  [[maybe_unused]] auto result = encodeInto(str, view, isolate);
+  [[maybe_unused]] auto result = encodeInto(js, str, view);
   KJ_DASSERT(result.written == buffer->ByteLength());
   KJ_DASSERT(result.read == str->Length());
   return view;
 }
 
 TextEncoder::EncodeIntoResult TextEncoder::encodeInto(
-    v8::Local<v8::String> input, v8::Local<v8::Uint8Array> buffer, v8::Isolate* isolate) {
+    jsg::Lock& js,
+    v8::Local<v8::String> input, v8::Local<v8::Uint8Array> buffer) {
   EncodeIntoResult result{0,0};
   auto bytes = jsg::asBytes(buffer.As<v8::ArrayBufferView>()).releaseAsChars();
-  result.written = input->WriteUtf8(isolate, bytes.begin(), bytes.size(), &result.read,
+  result.written = input->WriteUtf8(js.v8Isolate, bytes.begin(), bytes.size(), &result.read,
       v8::String::NO_NULL_TERMINATION | v8::String::REPLACE_INVALID_UTF8);
   return result;
 }

--- a/src/workerd/api/encoding.h
+++ b/src/workerd/api/encoding.h
@@ -68,7 +68,7 @@ public:
   virtual ~Decoder() noexcept(true) {}
   virtual Encoding getEncoding() = 0;
   virtual kj::Maybe<v8::Local<v8::String>> decode(
-      v8::Isolate* isolate,
+      jsg::Lock& js,
       kj::ArrayPtr<const kj::byte> buffer,
       bool flush = false) = 0;
 
@@ -86,7 +86,7 @@ public:
   Encoding getEncoding() override { return Encoding::Windows_1252; }
 
   kj::Maybe<v8::Local<v8::String>> decode(
-      v8::Isolate* isolate,
+      jsg::Lock& js,
       kj::ArrayPtr<const kj::byte> buffer,
       bool flush = false) override;
 };
@@ -106,7 +106,7 @@ public:
   Encoding getEncoding() override { return encoding; }
 
   kj::Maybe<v8::Local<v8::String>> decode(
-      v8::Isolate* isolate,
+      jsg::Lock& js,
       kj::ArrayPtr<const kj::byte> buffer,
       bool flush = false) override;
 
@@ -147,9 +147,9 @@ public:
       jsg::Optional<kj::String> label,
       jsg::Optional<ConstructorOptions> options);
 
-  v8::Local<v8::String> decode(jsg::Optional<kj::Array<const kj::byte>> input,
-                               jsg::Optional<DecodeOptions> options,
-                               v8::Isolate* isolate);
+  v8::Local<v8::String> decode(jsg::Lock& js,
+                               jsg::Optional<kj::Array<const kj::byte>> input,
+                               jsg::Optional<DecodeOptions> options);
 
   kj::StringPtr getEncoding();
 
@@ -175,7 +175,7 @@ public:
       : decoder(kj::mv(decoder)), ctorOptions(options) {}
 
   kj::Maybe<v8::Local<v8::String>> decodePtr(
-      v8::Isolate* isolate,
+      jsg::Lock& js,
       kj::ArrayPtr<const kj::byte> buffer,
       bool flush);
 
@@ -206,10 +206,12 @@ public:
   static jsg::Ref<TextEncoder> constructor();
 
   v8::Local<v8::Uint8Array> encode(
-      jsg::Optional<v8::Local<v8::String>> input, v8::Isolate* isolate);
+      jsg::Lock& js,
+      jsg::Optional<v8::Local<v8::String>> input);
 
   EncodeIntoResult encodeInto(
-      v8::Local<v8::String> input, v8::Local<v8::Uint8Array> buffer, v8::Isolate* isolate);
+      jsg::Lock& js,
+      v8::Local<v8::String> input, v8::Local<v8::Uint8Array> buffer);
 
   kj::StringPtr getEncoding() { return "utf-8"; }
   // UTF-8 is the only encoding type supported by the WHATWG spec.

--- a/src/workerd/api/form-data.c++
+++ b/src/workerd/api/form-data.c++
@@ -412,19 +412,15 @@ void FormData::forEach(
   // from JavaScript, which means a Headers JS wrapper object must already exist.
   auto localParams = KJ_ASSERT_NONNULL(JSG_THIS.tryGetHandle(isolate));
 
-  auto context = isolate->GetCurrentContext();  // Needed later for Call().
   for (int i = 0; i < this->data.size(); i++) {
     auto& [key, value] = this->data[i];
-    static constexpr auto ARG_COUNT = 3;
-
-    v8::Local<v8::Value> args[ARG_COUNT] = {
-      handler.wrap(js, clone(value)),
-      jsg::v8Str(isolate, key),
-      localParams,
-    };
     // Call jsg::check() to propagate exceptions, but we don't expect any
     // particular return value.
-    jsg::check(localCallback->Call(context, localThisArg, ARG_COUNT, args));
+    js.call(localCallback,
+            localThisArg,
+            handler.wrap(js, clone(value)),
+            jsg::v8Str(isolate, key),
+            localParams);
   }
 }
 

--- a/src/workerd/api/form-data.c++
+++ b/src/workerd/api/form-data.c++
@@ -284,7 +284,7 @@ kj::Array<kj::byte> FormData::serialize(kj::ArrayPtr<const char> boundary) {
   return builder.releaseAsArray().releaseAsBytes();
 }
 
-FormData::EntryType FormData::clone(v8::Isolate* isolate, FormData::EntryType& value) {
+FormData::EntryType FormData::clone(FormData::EntryType& value) {
   KJ_SWITCH_ONEOF(value) {
     KJ_CASE_ONEOF(file, jsg::Ref<File>) {
       return file.addRef();
@@ -344,22 +344,20 @@ void FormData::delete_(kj::String name) {
   data.truncate(pivot - data.begin());
 }
 
-kj::Maybe<kj::OneOf<jsg::Ref<File>, kj::String>> FormData::get(
-    kj::String name, v8::Isolate* isolate) {
+kj::Maybe<kj::OneOf<jsg::Ref<File>, kj::String>> FormData::get(kj::String name) {
   for (auto& [k, v]: data) {
     if (k == name) {
-      return clone(isolate, v);
+      return clone(v);
     }
   }
   return nullptr;
 }
 
-kj::Array<kj::OneOf<jsg::Ref<File>, kj::String>> FormData::getAll(
-    kj::String name, v8::Isolate* isolate) {
+kj::Array<kj::OneOf<jsg::Ref<File>, kj::String>> FormData::getAll(kj::String name) {
   kj::Vector<kj::OneOf<jsg::Ref<File>, kj::String>> result;
   for (auto& [k, v]: data) {
     if (k == name) {
-      result.add(clone(isolate, v));
+      result.add(clone(v));
     }
   }
   return result.releaseAsArray();
@@ -407,9 +405,9 @@ void FormData::forEach(
     jsg::Optional<jsg::Value> thisArg,
     const jsg::TypeHandler<EntryType>& handler) {
   auto isolate = js.v8Isolate;
-  auto localCallback = callback.getHandle(isolate);
-  auto localThisArg = thisArg.map([&](jsg::Value& v) { return v.getHandle(isolate); })
-      .orDefault(v8::Undefined(isolate));
+  auto localCallback = callback.getHandle(js);
+  auto localThisArg = thisArg.map([&](jsg::Value& v) { return v.getHandle(js); })
+      .orDefault(js.v8Undefined());
   // JSG_THIS.tryGetHandle() is guaranteed safe because `forEach()` is only called
   // from JavaScript, which means a Headers JS wrapper object must already exist.
   auto localParams = KJ_ASSERT_NONNULL(JSG_THIS.tryGetHandle(isolate));
@@ -420,7 +418,7 @@ void FormData::forEach(
     static constexpr auto ARG_COUNT = 3;
 
     v8::Local<v8::Value> args[ARG_COUNT] = {
-      handler.wrap(js, clone(isolate, value)),
+      handler.wrap(js, clone(value)),
       jsg::v8Str(isolate, key),
       localParams,
     };

--- a/src/workerd/api/form-data.h
+++ b/src/workerd/api/form-data.h
@@ -67,9 +67,9 @@ public:
 
   void delete_(kj::String name);
 
-  kj::Maybe<kj::OneOf<jsg::Ref<File>, kj::String>> get(kj::String name, v8::Isolate* isolate);
+  kj::Maybe<kj::OneOf<jsg::Ref<File>, kj::String>> get(kj::String name);
 
-  kj::Array<kj::OneOf<jsg::Ref<File>, kj::String>> getAll(kj::String name, v8::Isolate* isolate);
+  kj::Array<kj::OneOf<jsg::Ref<File>, kj::String>> getAll(kj::String name);
 
   bool has(kj::String name);
 
@@ -145,7 +145,7 @@ public:
 private:
   kj::Vector<Entry> data;
 
-  static EntryType clone(v8::Isolate* isolate, EntryType& value);
+  static EntryType clone(EntryType& value);
 
   template <typename Type>
   static kj::Maybe<Type> iteratorNext(jsg::Lock& js, IteratorState& state) {
@@ -154,11 +154,11 @@ private:
     }
     auto& [key, value] = state.parent->data[state.index++];
     if constexpr (kj::isSameType<Type, EntryIteratorType>()) {
-      return kj::arr<EntryType>(kj::str(key), clone(js.v8Isolate, value));
+      return kj::arr<EntryType>(kj::str(key), clone(value));
     } else if constexpr (kj::isSameType<Type, KeyIteratorType>()) {
       return kj::str(key);
     } else if constexpr (kj::isSameType<Type, ValueIteratorType>()) {
-      return clone(js.v8Isolate, value);
+      return clone(value);
     } else {
       KJ_UNREACHABLE;
     }

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -471,7 +471,7 @@ void ServiceWorkerGlobalScope::emitPromiseRejection(
 }
 
 kj::String ServiceWorkerGlobalScope::btoa(jsg::Lock& js, v8::Local<v8::Value> data) {
-  auto str = jsg::check(data->ToString(js.v8Isolate->GetCurrentContext()));
+  auto str = jsg::check(data->ToString(js.v8Context()));
 
   // We could implement btoa() by accepting a kj::String, but then we'd have to check that it
   // doesn't have any multibyte code points. Easier to perform that test using v8::String's

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -97,6 +97,12 @@ void ExecutionContext::passThroughOnException() {
   IoContext::current().setFailOpen();
 }
 
+ServiceWorkerGlobalScope& ServiceWorkerGlobalScope::from(jsg::Lock& js) {
+  auto context = js.v8Isolate->GetCurrentContext();
+  return jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(
+      context, context->Global());
+}
+
 ServiceWorkerGlobalScope::ServiceWorkerGlobalScope(v8::Isolate* isolate)
     : unhandledRejections(
         [this](jsg::Lock& js,

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -148,7 +148,7 @@ kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::request(
 
     auto handle = jsg::check(v8::JSON::Parse(isolate->GetCurrentContext(), jsonString));
     // For the inbound request, we make the `cf` blob immutable.
-    jsg::recursivelyFreeze(isolate->GetCurrentContext(), handle);
+    jsg::recursivelyFreeze(isolate, handle);
     KJ_ASSERT(handle->IsObject());
     cf = jsg::V8Ref(isolate, handle.As<v8::Object>());
   }

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -98,9 +98,8 @@ void ExecutionContext::passThroughOnException() {
 }
 
 ServiceWorkerGlobalScope& ServiceWorkerGlobalScope::from(jsg::Lock& js) {
-  auto context = js.v8Isolate->GetCurrentContext();
   return jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(
-      context, context->Global());
+      js.v8Context(), js.v8Global());
 }
 
 ServiceWorkerGlobalScope::ServiceWorkerGlobalScope(v8::Isolate* isolate)
@@ -555,15 +554,12 @@ TimeoutId::NumberType ServiceWorkerGlobalScope::setTimeout(
       [function = function.addRef(js),
        argv = kj::mv(argv)]
        (jsg::Lock& js) mutable {
-    auto context = js.v8Isolate->GetCurrentContext();
-    auto localFunction = function.getHandle(js);
     auto localArgs = KJ_MAP(arg, argv) {
       return arg.getHandle(js);
     };
-    auto argc = localArgs.size();
 
     // Cast to void to discard the result value.
-    (void)jsg::check(localFunction->Call(context, context->Global(), argc, &localArgs.front()));
+    (void)js.call(function.getHandle(js), localArgs);
   }, msDelay.orDefault(0));
   return timeoutId.toNumber();
 }
@@ -595,15 +591,12 @@ TimeoutId::NumberType ServiceWorkerGlobalScope::setInterval(
       [function = function.addRef(js),
        argv = kj::mv(argv)]
        (jsg::Lock& js) mutable {
-    auto context = js.v8Isolate->GetCurrentContext();
-    auto localFunction = function.getHandle(js);
     auto localArgs = KJ_MAP(arg, argv) {
       return arg.getHandle(js);
     };
-    auto argc = localArgs.size();
 
     // Cast to void to discard the result value.
-    (void)jsg::check(localFunction->Call(context, context->Global(), argc, &localArgs.front()));
+    (void)js.call(function.getHandle(js), localArgs);
   }, msDelay.orDefault(0));
   return timeoutId.toNumber();
 }

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -465,8 +465,8 @@ void ServiceWorkerGlobalScope::emitPromiseRejection(
   }
 }
 
-kj::String ServiceWorkerGlobalScope::btoa(v8::Local<v8::Value> data, v8::Isolate* isolate) {
-  auto str = jsg::check(data->ToString(isolate->GetCurrentContext()));
+kj::String ServiceWorkerGlobalScope::btoa(jsg::Lock& js, v8::Local<v8::Value> data) {
+  auto str = jsg::check(data->ToString(js.v8Isolate->GetCurrentContext()));
 
   // We could implement btoa() by accepting a kj::String, but then we'd have to check that it
   // doesn't have any multibyte code points. Easier to perform that test using v8::String's
@@ -479,11 +479,11 @@ kj::String ServiceWorkerGlobalScope::btoa(v8::Local<v8::Value> data, v8::Isolate
   //   negatives. Conceivably we could take advantage of this fact to completely avoid the later
   //   WriteOneByte() call in some cases!
   auto buf = kj::heapArray<kj::byte>(str->Length());
-  str->WriteOneByte(isolate, buf.begin(), 0, buf.size());
+  str->WriteOneByte(js.v8Isolate, buf.begin(), 0, buf.size());
 
   return kj::encodeBase64(buf);
 }
-v8::Local<v8::String> ServiceWorkerGlobalScope::atob(kj::String data, v8::Isolate* isolate) {
+v8::Local<v8::String> ServiceWorkerGlobalScope::atob(jsg::Lock& js, kj::String data) {
   auto decoded = kj::decodeBase64(data.asArray());
 
   JSG_REQUIRE(!decoded.hadErrors, DOMInvalidCharacterError,
@@ -494,7 +494,7 @@ v8::Local<v8::String> ServiceWorkerGlobalScope::atob(kj::String data, v8::Isolat
   // Similar to btoa() taking a v8::Value, we return a v8::String directly, as this allows us to
   // construct a string from the non-nul-terminated array returned from decodeBase64(). This avoids
   // making a copy purely to append a nul byte.
-  return jsg::v8StrFromLatin1(isolate, decoded.asBytes());
+  return jsg::v8StrFromLatin1(js.v8Isolate, decoded.asBytes());
 }
 
 void ServiceWorkerGlobalScope::queueMicrotask(
@@ -504,9 +504,9 @@ void ServiceWorkerGlobalScope::queueMicrotask(
 }
 
 v8::Local<v8::Value> ServiceWorkerGlobalScope::structuredClone(
+    jsg::Lock& js,
     v8::Local<v8::Value> value,
-    jsg::Optional<StructuredCloneOptions> maybeOptions,
-    v8::Isolate* isolate) {
+    jsg::Optional<StructuredCloneOptions> maybeOptions) {
   kj::Maybe<kj::ArrayPtr<jsg::Value>> transfers;
   KJ_IF_MAYBE(options, maybeOptions) {
     transfers = options->transfer.map([&](kj::Array<jsg::Value>& transfer) {
@@ -514,7 +514,7 @@ v8::Local<v8::Value> ServiceWorkerGlobalScope::structuredClone(
     });
   }
 
-  return jsg::structuredClone(value, isolate, transfers);
+  return jsg::structuredClone(value, js.v8Isolate, transfers);
 }
 
 TimeoutId::NumberType ServiceWorkerGlobalScope::setTimeoutInternal(

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -48,8 +48,8 @@ public:
 
   static jsg::Ref<PromiseRejectionEvent> constructor(kj::String type) = delete;
 
-  jsg::V8Ref<v8::Promise> getPromise(v8::Isolate* isolate) { return promise.addRef(isolate); }
-  jsg::Value getReason(v8::Isolate* isolate) { return reason.addRef(isolate); }
+  jsg::V8Ref<v8::Promise> getPromise(jsg::Lock& js) { return promise.addRef(js); }
+  jsg::Value getReason(jsg::Lock& js) { return reason.addRef(js); }
 
   JSG_RESOURCE_TYPE(PromiseRejectionEvent) {
     JSG_INHERIT(Event);
@@ -226,8 +226,8 @@ public:
   // ---------------------------------------------------------------------------
   // JS API
 
-  kj::String btoa(v8::Local<v8::Value> data, v8::Isolate* isolate);
-  v8::Local<v8::String> atob(kj::String data, v8::Isolate* isolate);
+  kj::String btoa(jsg::Lock& js, v8::Local<v8::Value> data);
+  v8::Local<v8::String> atob(jsg::Lock& js, kj::String data);
 
   void queueMicrotask(jsg::Lock& js, v8::Local<v8::Function> task);
 
@@ -238,9 +238,9 @@ public:
   };
 
   v8::Local<v8::Value> structuredClone(
+      jsg::Lock& js,
       v8::Local<v8::Value> value,
-      jsg::Optional<StructuredCloneOptions> options,
-      v8::Isolate* isolate);
+      jsg::Optional<StructuredCloneOptions> options);
 
   TimeoutId::NumberType setTimeout(jsg::Lock& js,
                                    jsg::V8Ref<v8::Function> function,

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -179,6 +179,8 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
   // Global object API exposed to JavaScript.
 
 public:
+  static ServiceWorkerGlobalScope& from(jsg::Lock& js);
+
   ServiceWorkerGlobalScope(v8::Isolate* isolate);
 
   void clear();

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -334,17 +334,11 @@ void Headers::forEach(
   // from JavaScript, which means a Headers JS wrapper object must already exist.
   auto localHeaders = KJ_ASSERT_NONNULL(JSG_THIS.tryGetHandle(isolate));
 
-  auto context = isolate->GetCurrentContext();  // Needed later for Call().
   for (auto& entry: getDisplayedHeaders()) {
-    static constexpr auto ARG_COUNT = 3;
-    v8::Local<v8::Value> args[ARG_COUNT] = {
+    (void)js.call(localCallback, localThisArg,
       jsg::v8Str(isolate, entry.value),
       jsg::v8Str(isolate, entry.key),
-      localHeaders,
-    };
-    // Call jsg::check() to propagate exceptions, but we don't expect any
-    // particular return value.
-    jsg::check(localCallback->Call(context, localThisArg, ARG_COUNT, args));
+      localHeaders);
   }
 }
 

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -39,13 +39,13 @@ static void parseListMetadata(jsg::Lock& js, v8::Local<v8::Value> listResponse) 
   v8::HandleScope handleScope(isolate);
   KJ_ASSERT(listResponse->IsObject());
   v8::Local<v8::Object> obj = listResponse.As<v8::Object>();
-  auto context = isolate->GetCurrentContext();
-  auto keyName = jsg::v8Str(isolate, "keys"_kj);
+  auto context = js.v8Context();
+  auto keyName = jsg::v8StrIntern(isolate, "keys"_kj);
   auto keys = jsg::check(obj->Get(context, keyName));
   if (keys->IsArray()) {
     auto keysArr = keys.As<v8::Array>();
     auto length = keysArr->Length();
-    auto metaName = jsg::v8Str(isolate, "metadata"_kj);
+    auto metaName = jsg::v8StrIntern(isolate, "metadata"_kj);
     v8::Local<v8::Object> key;
     for (int i = 0; i < length; i++) {
       v8::HandleScope handleScope(isolate);

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -53,9 +53,7 @@ static void parseListMetadata(jsg::Lock& js, v8::Local<v8::Value> listResponse) 
       if (jsg::check(key->HasOwnProperty(context, metaName))) {
         auto metadata = jsg::check(key->Get(context, metaName));
         KJ_ASSERT(metadata->IsString());
-        auto metadataStr = metadata.As<v8::String>();
-        auto json = jsg::check(v8::JSON::Parse(context, metadataStr));
-        jsg::check(key->Set(context, metaName, json));
+        jsg::check(key->Set(context, metaName, js.v8ParseJson(js.toString(metadata))));
       }
     }
   }

--- a/src/workerd/api/node/async-hooks.c++
+++ b/src/workerd/api/node/async-hooks.c++
@@ -20,15 +20,9 @@ v8::Local<v8::Value> AsyncLocalStorage::run(
     argv.add(arg.getHandle(js));
   }
 
-  auto context = js.v8Isolate->GetCurrentContext();
-
   jsg::AsyncContextFrame::StorageScope scope(js, *key, js.v8Ref(store));
 
-  return jsg::check(callback->Call(
-      context,
-      context->Global(),
-      argv.size(),
-      argv.begin()));
+  return js.call(callback, argv.asPtr());
 }
 
 v8::Local<v8::Value> AsyncLocalStorage::exit(
@@ -106,15 +100,9 @@ v8::Local<v8::Value> AsyncResource::runInAsyncScope(
     argv.add(arg.getHandle(js));
   }
 
-  auto context = js.v8Isolate->GetCurrentContext();
-
   jsg::AsyncContextFrame::Scope scope(js, *frame);
 
-  return jsg::check(fn->Call(
-      context,
-      thisArg.orDefault(context->Global()),
-      argv.size(),
-      argv.begin()));
+  return js.call(fn, thisArg.orDefault(js.v8Global()), argv.asPtr());
 }
 
 }  // namespace workerd::api::node

--- a/src/workerd/api/node/async-hooks.c++
+++ b/src/workerd/api/node/async-hooks.c++
@@ -84,7 +84,7 @@ v8::Local<v8::Function> AsyncResource::bind(
   // Per Node.js documentation (https://nodejs.org/dist/latest-v19.x/docs/api/async_context.html#asyncresourcebindfn-thisarg), the returned function "will have an
   // asyncResource property referencing the AsyncResource to which the function
   // is bound".
-  jsg::check(bound->Set(js.v8Isolate->GetCurrentContext(),
+  jsg::check(bound->Set(js.v8Context(),
              jsg::v8StrIntern(js.v8Isolate, "asyncResource"_kj),
              handler.wrap(js, JSG_THIS)));
   return bound;

--- a/src/workerd/api/r2-admin.c++
+++ b/src/workerd/api/r2-admin.c++
@@ -80,7 +80,7 @@ jsg::Promise<R2Admin::ListResult> R2Admin::list(jsg::Lock& js,
     r2Result.throwIfError("listBucket", errorType);
 
     auto isolate = js.v8Isolate;
-    auto context = isolate->GetCurrentContext();
+    auto context = js.v8Context();
 
     capnp::MallocMessageBuilder responseMessage;
     capnp::JsonCodec json;

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -48,10 +48,10 @@ static jsg::ByteString toUTCString(jsg::Lock& js, kj::Date date) {
       context, (date - kj::UNIX_EPOCH) / kj::MILLISECONDS));
   KJ_REQUIRE(converted->IsDate());
   const auto stringify = jsg::check(converted.template As<v8::Date>()->Get(
-      context, jsg::v8Str(isolate, "toUTCString")));
+      context, jsg::v8StrIntern(isolate, "toUTCString")));
   JSG_REQUIRE(stringify->IsFunction(), TypeError, "toUTCString on a Date is not a function");
-  const auto stringified = jsg::check(stringify.template As<v8::Function>()->Call(
-      context, stringify, 0, nullptr));
+
+  const auto stringified = js.call(stringify.template As<v8::Function>());
   JSG_REQUIRE(stringified->IsString(), TypeError, "toUTCString on a Date did not return a string");
 
   const auto str = stringified.template As<v8::String>();

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -25,11 +25,11 @@ static bool isWholeNumber(double x) {
 // concerns about the user overriding the methods we're invoking.
 static kj::Date parseDate(jsg::Lock& js, kj::StringPtr value) {
   auto isolate = js.v8Isolate;
-  const auto context = isolate->GetCurrentContext();
+  const auto context = js.v8Context();
   const auto tmp = jsg::check(v8::Date::New(context, 0));
   KJ_REQUIRE(tmp->IsDate());
   const auto constructor = jsg::check(tmp.template As<v8::Date>()->Get(
-      context, jsg::v8Str(isolate, "constructor")));
+      context, jsg::v8StrIntern(isolate, "constructor"_kj)));
   JSG_REQUIRE(constructor->IsFunction(), TypeError, "Date.constructor is not a function");
   v8::Local<v8::Value> argv = jsg::v8Str(isolate, value);
   const auto converted = jsg::check(
@@ -43,12 +43,12 @@ static jsg::ByteString toUTCString(jsg::Lock& js, kj::Date date) {
   // NOTE: If you need toISOString just unify it into this function as the only difference will be
   // the function name called.
   auto isolate = js.v8Isolate;
-  const auto context = isolate->GetCurrentContext();
+  const auto context = js.v8Context();
   const auto converted = jsg::check(v8::Date::New(
       context, (date - kj::UNIX_EPOCH) / kj::MILLISECONDS));
   KJ_REQUIRE(converted->IsDate());
   const auto stringify = jsg::check(converted.template As<v8::Date>()->Get(
-      context, jsg::v8StrIntern(isolate, "toUTCString")));
+      context, jsg::v8StrIntern(isolate, "toUTCString"_kj)));
   JSG_REQUIRE(stringify->IsFunction(), TypeError, "toUTCString on a Date is not a function");
 
   const auto stringified = js.call(stringify.template As<v8::Function>());

--- a/src/workerd/api/r2-rpc.c++
+++ b/src/workerd/api/r2-rpc.c++
@@ -26,7 +26,7 @@ static kj::Own<R2Error> toError(uint statusCode, kj::StringPtr responseBody) {
 v8::Local<v8::Value> R2Error::getStack(jsg::Lock& js) {
   auto stackString = jsg::v8StrIntern(js.v8Isolate, "stack"_kj);
   return jsg::check(KJ_ASSERT_NONNULL(errorForStack).Get(js.v8Isolate)->Get(
-      js.v8Isolate->GetCurrentContext(), stackString));
+      js.v8Context(), stackString));
 }
 
 kj::Maybe<uint> R2Result::v4ErrorCode() {
@@ -47,7 +47,7 @@ void R2Result::throwIfError(kj::StringPtr action,
     auto isolate = IoContext::current().getCurrentLock().getIsolate();
     (*e)->action = kj::str(action);
     (*e)->errorForStack = v8::Global<v8::Object>(
-        isolate, v8::Exception::Error(jsg::v8Str(isolate, "")).As<v8::Object>());
+        isolate, v8::Exception::Error(v8::String::Empty(isolate)).As<v8::Object>());
     isolate->ThrowException(errorType.wrapRef(kj::mv(*e)));
     throw jsg::JsExceptionThrown();
 #else

--- a/src/workerd/api/r2-rpc.c++
+++ b/src/workerd/api/r2-rpc.c++
@@ -23,10 +23,10 @@ static kj::Own<R2Error> toError(uint statusCode, kj::StringPtr responseBody) {
   return kj::refcounted<R2Error>(errorMessage.getV4code(), kj::str(errorMessage.getMessage()));
 }
 
-v8::Local<v8::Value> R2Error::getStack(v8::Isolate* isolate) {
-  auto stackString = jsg::v8Str(isolate, "stack", v8::NewStringType::kInternalized);
-  return jsg::check(KJ_ASSERT_NONNULL(errorForStack).Get(isolate)->Get(
-      isolate->GetCurrentContext(), stackString));
+v8::Local<v8::Value> R2Error::getStack(jsg::Lock& js) {
+  auto stackString = jsg::v8StrIntern(js.v8Isolate, "stack"_kj);
+  return jsg::check(KJ_ASSERT_NONNULL(errorForStack).Get(js.v8Isolate)->Get(
+      js.v8Isolate->GetCurrentContext(), stackString));
 }
 
 kj::Maybe<uint> R2Result::v4ErrorCode() {

--- a/src/workerd/api/r2-rpc.h
+++ b/src/workerd/api/r2-rpc.h
@@ -20,7 +20,7 @@ public:
   uint getV4Code() const { return v4Code; }
   kj::StringPtr getMessage() const { return message; }
   kj::StringPtr getAction() const { return KJ_ASSERT_NONNULL(action); }
-  v8::Local<v8::Value> getStack(v8::Isolate* isolate);
+  v8::Local<v8::Value> getStack(jsg::Lock& js);
 
   JSG_RESOURCE_TYPE(R2Error) {
     JSG_INHERIT_INTRINSIC(v8::kErrorPrototype);

--- a/src/workerd/api/streams/encoding.c++
+++ b/src/workerd/api/streams/encoding.c++
@@ -24,7 +24,7 @@ jsg::Ref<TextEncoderStream> TextEncoderStream::constructor(
     Transformer {
       .transform = jsg::Function<Transformer::TransformAlgorithm>(
           [](jsg::Lock& js, auto chunk, auto controller) {
-      auto str = jsg::check(chunk->ToString(js.v8Isolate->GetCurrentContext()));
+      auto str = jsg::check(chunk->ToString(js.v8Context()));
       auto maybeBuffer = v8::ArrayBuffer::MaybeNew(js.v8Isolate, str->Utf8Length(js.v8Isolate));
       JSG_ASSERT(!maybeBuffer.IsEmpty(), RangeError,
                   "Cannot allocate space for TextEncoder.encode");

--- a/src/workerd/api/streams/encoding.c++
+++ b/src/workerd/api/streams/encoding.c++
@@ -73,7 +73,7 @@ jsg::Ref<TextDecoderStream> TextDecoderStream::constructor(
                                 (jsg::Lock& js, auto chunk, auto controller) {
         jsg::BufferSource source(js, chunk);
         controller->enqueue(js, JSG_REQUIRE_NONNULL(
-            decoder->decodePtr(js.v8Isolate, source.asArrayPtr(), false),
+            decoder->decodePtr(js, source.asArrayPtr(), false),
             TypeError,
             "Failed to decode input."));
         return js.resolvedPromise();
@@ -83,7 +83,7 @@ jsg::Ref<TextDecoderStream> TextDecoderStream::constructor(
                                 (decoder),
                                 (jsg::Lock& js, auto controller) {
         controller->enqueue(js, JSG_REQUIRE_NONNULL(
-            decoder->decodePtr(js.v8Isolate, kj::ArrayPtr<kj::byte>(), true),
+            decoder->decodePtr(js, kj::ArrayPtr<kj::byte>(), true),
             TypeError,
             "Failed to decode input."));
         return js.resolvedPromise();

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -107,8 +107,8 @@ jsg::Optional<v8::Local<v8::Object>> TraceItem::FetchEventInfo::Request::getCf(
     jsg::Lock& js) {
   const auto& cfJson = eventInfo.cfJson;
   if (cfJson.size() > 0) {
-    auto jsonString = jsg::v8Str(js.v8Isolate, cfJson);
-    auto handle = jsg::check(v8::JSON::Parse(js.v8Isolate->GetCurrentContext(), jsonString));
+    auto handle = js.v8ParseJson(cfJson);
+    KJ_ASSERT(handle->IsObject());
     return handle.As<v8::Object>();
   }
   return nullptr;
@@ -255,8 +255,8 @@ kj::StringPtr TraceLog::getLevel() {
 }
 
 v8::Local<v8::Object> TraceLog::getMessage(jsg::Lock& js) {
-  auto jsonString = jsg::v8Str(js.v8Isolate, log.message);
-  auto handle = jsg::check(v8::JSON::Parse(js.v8Isolate->GetCurrentContext(), jsonString));
+  auto handle = js.v8ParseJson(log.message);
+  KJ_ASSERT(handle->IsObject());
   return handle.As<v8::Object>();
 }
 

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -104,11 +104,11 @@ TraceItem::FetchEventInfo::Request::Request(kj::Own<Trace> trace, const Trace::F
     : trace(kj::mv(trace)), eventInfo(eventInfo) {}
 
 jsg::Optional<v8::Local<v8::Object>> TraceItem::FetchEventInfo::Request::getCf(
-    v8::Isolate* isolate) {
+    jsg::Lock& js) {
   const auto& cfJson = eventInfo.cfJson;
   if (cfJson.size() > 0) {
-    auto jsonString = jsg::v8Str(isolate, cfJson);
-    auto handle = jsg::check(v8::JSON::Parse(isolate->GetCurrentContext(), jsonString));
+    auto jsonString = jsg::v8Str(js.v8Isolate, cfJson);
+    auto handle = jsg::check(v8::JSON::Parse(js.v8Isolate->GetCurrentContext(), jsonString));
     return handle.As<v8::Object>();
   }
   return nullptr;
@@ -254,9 +254,9 @@ kj::StringPtr TraceLog::getLevel() {
   KJ_UNREACHABLE;
 }
 
-v8::Local<v8::Object> TraceLog::getMessage(v8::Isolate* isolate) {
-  auto jsonString = jsg::v8Str(isolate, log.message);
-  auto handle = jsg::check(v8::JSON::Parse(isolate->GetCurrentContext(), jsonString));
+v8::Local<v8::Object> TraceLog::getMessage(jsg::Lock& js) {
+  auto jsonString = jsg::v8Str(js.v8Isolate, log.message);
+  auto handle = jsg::check(v8::JSON::Parse(js.v8Isolate->GetCurrentContext(), jsonString));
   return handle.As<v8::Object>();
 }
 

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -124,7 +124,7 @@ class TraceItem::FetchEventInfo::Request final: public jsg::Object {
 public:
   explicit Request(kj::Own<Trace> trace, const Trace::FetchEventInfo& eventInfo);
 
-  jsg::Optional<v8::Local<v8::Object>> getCf(v8::Isolate* isolate);
+  jsg::Optional<v8::Local<v8::Object>> getCf(jsg::Lock& js);
   jsg::Dict<jsg::ByteString, jsg::ByteString> getHeaders();
   kj::StringPtr getMethod();
   kj::String getUrl();
@@ -247,7 +247,7 @@ public:
 
   double getTimestamp();
   kj::StringPtr getLevel();
-  v8::Local<v8::Object> getMessage(v8::Isolate* isolate);
+  v8::Local<v8::Object> getMessage(jsg::Lock& js);
 
   JSG_RESOURCE_TYPE(TraceLog) {
     JSG_READONLY_INSTANCE_PROPERTY(timestamp, getTimestamp);

--- a/src/workerd/api/url-standard.c++
+++ b/src/workerd/api/url-standard.c++
@@ -2033,12 +2033,10 @@ void URLSearchParams::forEach(
   // are added to the search params unconditionally on each iteration.
   for (int i = 0; i < list.size(); i++) {
     auto& entry = list[i];
-    v8::Local<v8::Value> args[3] = {
+    (void)js.call(cb, this_,
       jsg::v8Str(js.v8Isolate, entry.value),
       jsg::v8Str(js.v8Isolate, entry.name),
-      query,
-    };
-    jsg::check(cb->Call(js.v8Isolate->GetCurrentContext(), this_, 3, args));
+      query);
   }
 }
 

--- a/src/workerd/api/url-standard.h
+++ b/src/workerd/api/url-standard.h
@@ -120,9 +120,9 @@ public:
                 iteratorNext<ValueIteratorType>)
 
   void forEach(
+      jsg::Lock& js,
       jsg::V8Ref<v8::Function> callback,
-      jsg::Optional<jsg::Value> thisArg,
-      v8::Isolate* isolate);
+      jsg::Optional<jsg::Value> thisArg);
 
   jsg::UsvString toString();
 
@@ -279,7 +279,7 @@ public:
   jsg::UsvString getHash();
   void setHash(jsg::UsvString value);
 
-  inline jsg::Ref<URLSearchParams> getSearchParams(v8::Isolate* isolate) {
+  inline jsg::Ref<URLSearchParams> getSearchParams() {
     KJ_IF_MAYBE(searchParams, maybeSearchParams) {
       return searchParams->addRef();
     }

--- a/src/workerd/api/url.c++
+++ b/src/workerd/api/url.c++
@@ -586,23 +586,23 @@ void URLSearchParams::sort() {
 }
 
 void URLSearchParams::forEach(
+    jsg::Lock& js,
     jsg::V8Ref<v8::Function> callback,
-    jsg::Optional<jsg::Value> thisArg,
-    v8::Isolate* isolate) {
-  auto localCallback = callback.getHandle(isolate);
-  auto localThisArg = thisArg.map([&](jsg::Value& v) { return v.getHandle(isolate); })
-      .orDefault(v8::Undefined(isolate));
+    jsg::Optional<jsg::Value> thisArg) {
+  auto localCallback = callback.getHandle(js);
+  auto localThisArg = thisArg.map([&](jsg::Value& v) { return v.getHandle(js); })
+      .orDefault(js.v8Undefined());
   // JSG_THIS.getHandle() is guaranteed safe because `forEach()` is only called
   // from JavaScript, which means a Headers JS wrapper object must already exist.
-  auto localParams = KJ_ASSERT_NONNULL(JSG_THIS.tryGetHandle(isolate));
+  auto localParams = KJ_ASSERT_NONNULL(JSG_THIS.tryGetHandle(js.v8Isolate));
 
-  auto context = isolate->GetCurrentContext();  // Needed later for Call().
+  auto context = js.v8Isolate->GetCurrentContext();  // Needed later for Call().
   for (int i = 0; i < this->url->query.size(); i++) {
     auto& [key, value] = this->url->query[i];
     static constexpr auto ARG_COUNT = 3;
     v8::Local<v8::Value> args[ARG_COUNT] = {
-      jsg::v8Str(isolate, value),
-      jsg::v8Str(isolate, key),
+      jsg::v8Str(js.v8Isolate, value),
+      jsg::v8Str(js.v8Isolate, key),
       localParams,
     };
     // Call jsg::check() to propagate exceptions, but we don't expect any

--- a/src/workerd/api/url.c++
+++ b/src/workerd/api/url.c++
@@ -596,18 +596,12 @@ void URLSearchParams::forEach(
   // from JavaScript, which means a Headers JS wrapper object must already exist.
   auto localParams = KJ_ASSERT_NONNULL(JSG_THIS.tryGetHandle(js.v8Isolate));
 
-  auto context = js.v8Isolate->GetCurrentContext();  // Needed later for Call().
   for (int i = 0; i < this->url->query.size(); i++) {
     auto& [key, value] = this->url->query[i];
-    static constexpr auto ARG_COUNT = 3;
-    v8::Local<v8::Value> args[ARG_COUNT] = {
+    (void)js.call(localCallback, localThisArg,
       jsg::v8Str(js.v8Isolate, value),
       jsg::v8Str(js.v8Isolate, key),
-      localParams,
-    };
-    // Call jsg::check() to propagate exceptions, but we don't expect any
-    // particular return value.
-    jsg::check(localCallback->Call(context, localThisArg, ARG_COUNT, args));
+      localParams);
   }
 }
 

--- a/src/workerd/api/url.h
+++ b/src/workerd/api/url.h
@@ -168,9 +168,9 @@ public:
                 iteratorNext<ValueIteratorType>)
 
   void forEach(
+      jsg::Lock& js,
       jsg::V8Ref<v8::Function> callback,
-      jsg::Optional<jsg::Value> thisArg,
-      v8::Isolate* isolate);
+      jsg::Optional<jsg::Value> thisArg);
 
   kj::String toString();
 

--- a/src/workerd/jsg/async-context.c++
+++ b/src/workerd/jsg/async-context.c++
@@ -101,17 +101,13 @@ v8::Local<v8::Function> AsyncContextFrame::wrap(
       ),
       (frame, thisArg, fn),
       (Lock& js, const v8::FunctionCallbackInfo<v8::Value>& args) {
-    auto function = fn.getHandle(js);
-    auto context = js.v8Isolate->GetCurrentContext();
-
     kj::Vector<v8::Local<v8::Value>> argv(args.Length());
     for (int n = 0; n < args.Length(); n++) {
       argv.add(args[n]);
     }
 
     AsyncContextFrame::Scope scope(js, *frame);
-    v8::Local<v8::Value> result;
-    return check(function->Call(context, thisArg.getHandle(js), args.Length(), argv.begin()));
+    return js.call(fn.getHandle(js), thisArg.getHandle(js), argv.asPtr());
   }));
 }
 

--- a/src/workerd/jsg/function.h
+++ b/src/workerd/jsg/function.h
@@ -383,7 +383,8 @@ public:
         typeWrapper.wrap(context, nullptr, kj::fwd<Args>(args))...
       };
 
-      auto result = check(func->Call(context, receiver, sizeof...(Args), argv));
+      auto result = js.call(func, receiver,
+          kj::ArrayPtr<v8::Local<v8::Value>>(argv, sizeof...(Args)));
       if constexpr(!isVoid<Ret>()) {
         return typeWrapper.template unwrap<Ret>(
             context, result, TypeErrorContext::callbackReturn());

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -116,10 +116,15 @@ Lock::~Lock() noexcept(false) {
   v8Isolate->SetData(2, previousData);
 }
 
+v8::Local<v8::Value> Lock::v8ParseJson(kj::StringPtr text) {
+  v8::EscapableHandleScope scope(v8Isolate);
+  return scope.Escape(jsg::check(
+      v8::JSON::Parse(v8Isolate->GetCurrentContext(), v8Str(v8Isolate, text))));
+}
+
 Value Lock::parseJson(kj::StringPtr text) {
   v8::HandleScope scope(v8Isolate);
-  return jsg::Value(v8Isolate,
-      jsg::check(v8::JSON::Parse(v8Isolate->GetCurrentContext(), v8Str(v8Isolate, text))));
+  return jsg::Value(v8Isolate, v8ParseJson(text));
 }
 
 kj::String Lock::serializeJson(v8::Local<v8::Value> value) {

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -116,6 +116,17 @@ Lock::~Lock() noexcept(false) {
   v8Isolate->SetData(2, previousData);
 }
 
+v8::Local<v8::Value> Lock::call(v8::Local<v8::Function> fn,
+                                v8::Local<v8::Value> thisArg,
+                                kj::ArrayPtr<v8::Local<v8::Value>> args) {
+  return check(fn->Call(v8Context(), thisArg, args.size(), args.begin()));
+}
+
+v8::Local<v8::Value> Lock::call(v8::Local<v8::Function> fn,
+                                kj::ArrayPtr<v8::Local<v8::Value>> args) {
+  return call(fn, v8Isolate->GetCurrentContext()->Global(), args);
+}
+
 v8::Local<v8::Value> Lock::v8ParseJson(kj::StringPtr text) {
   v8::EscapableHandleScope scope(v8Isolate);
   return scope.Escape(jsg::check(

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -128,8 +128,8 @@ kj::String Lock::serializeJson(v8::Local<v8::Value> value) {
       v8::JSON::Stringify(v8Isolate->GetCurrentContext(), value)));
 }
 
-v8::Local<v8::String> Lock::wrapString(kj::StringPtr text) {
-  return v8Str(v8Isolate, text);
+Value Lock::wrapString(kj::StringPtr text) {
+  return Value(v8Isolate, v8Str(v8Isolate, text));
 }
 
 bool Lock::toBool(v8::Local<v8::Value> value) {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1977,8 +1977,8 @@ public:
 
   kj::String serializeJson(v8::Local<v8::Value> value);
 
-  v8::Local<v8::String> wrapString(kj::StringPtr text);
-  virtual v8::Local<v8::ArrayBuffer> wrapBytes(kj::Array<byte> data) = 0;
+  Value wrapString(kj::StringPtr text);
+  virtual Value wrapBytes(kj::Array<byte> data) = 0;
   virtual v8::Local<v8::Function> wrapSimpleFunction(v8::Local<v8::Context> context,
       jsg::Function<void(const v8::FunctionCallbackInfo<v8::Value>& info)> simpleFunction) = 0;
   virtual v8::Local<v8::Function> wrapReturningFunction(v8::Local<v8::Context> context,

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2023,11 +2023,6 @@ public:
   }
 
   template <typename... Args>
-  v8::Local<v8::Value> call(v8::Local<v8::Function> fn, v8::Local<Args>... args) {
-    return call(fn, v8Isolate->GetCurrentContext()->Global(), kj::fwd<Args...>(args...));
-  }
-
-  template <typename... Args>
   v8::Local<v8::Value> call(v8::Local<v8::Function> fn,
                             v8::Local<v8::Value> thisArg,
                             v8::Local<Args>... args) {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1832,6 +1832,8 @@ public:
   }
 
   Value parseJson(kj::StringPtr text);
+  v8::Local<v8::Value> v8ParseJson(kj::StringPtr text);
+
   template <typename T>
   kj::String serializeJson(V8Ref<T>& value) { return serializeJson(value.getHandle(*this)); }
   template <typename T>

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -372,8 +372,8 @@ public:
           context, handle, jsg::TypeErrorContext::other());
     }
 
-    v8::Local<v8::ArrayBuffer> wrapBytes(kj::Array<byte> data) override {
-      return jsgIsolate.wrapper->wrap(v8Isolate, nullptr, kj::mv(data));
+    Value wrapBytes(kj::Array<byte> data) override {
+      return Value(v8Isolate, jsgIsolate.wrapper->wrap(v8Isolate, nullptr, kj::mv(data)));
     }
     v8::Local<v8::Function> wrapSimpleFunction(v8::Local<v8::Context> context,
         jsg::Function<void(const v8::FunctionCallbackInfo<v8::Value>& info)>

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -364,6 +364,10 @@ public:
       return jsgIsolate.wrapper->wrap(v8Isolate, nullptr, kj::fwd<T>(value));
     }
 
+    v8::Local<v8::Value> parseJson(v8::Local<v8::String> str) {
+      return jsg::check(v8::JSON::Parse(v8Isolate->GetCurrentContext(), str));
+    }
+
     template <typename T>
     auto unwrap(v8::Local<v8::Context> context, v8::Local<v8::Value> handle) {
       // Convert a JavaScript value to a C++ value, or throw a JS exception if the type doesn't

--- a/src/workerd/jsg/util-test.c++
+++ b/src/workerd/jsg/util-test.c++
@@ -13,8 +13,8 @@ namespace {
 V8System v8System;
 
 struct FreezeContext: public Object {
-  void recursivelyFreeze(v8::Local<v8::Value> value, v8::Isolate* isolate) {
-    jsg::recursivelyFreeze(isolate->GetCurrentContext(), value);
+  void recursivelyFreeze(jsg::Lock& js, v8::Local<v8::Value> value) {
+    jsg::recursivelyFreeze(js.v8Isolate, value);
   }
   JSG_RESOURCE_TYPE(FreezeContext) {
     JSG_METHOD(recursivelyFreeze);

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -173,7 +173,7 @@ kj::Array<kj::byte> asBytes(v8::Local<v8::ArrayBuffer> arrayBuffer);
 kj::Array<kj::byte> asBytes(v8::Local<v8::ArrayBufferView> arrayBufferView);
 // View the contents of the given v8::ArrayBuffer/ArrayBufferView as an ArrayPtr<byte>.
 
-void recursivelyFreeze(v8::Local<v8::Context> context, v8::Local<v8::Value> value);
+void recursivelyFreeze(v8::Isolate* isolate, v8::Local<v8::Value> value);
 // Freeze the given object and all its members, making it recursively immutable.
 //
 // WARNING: This function is unsafe to call on user-provided content since if the value is cyclic


### PR DESCRIPTION
Several misc cleanups including:

* Replacing v8::Isolate* args with jsg::Lock in api calls
* Adds a new js::Lock::call(...) utility to reduce some boilerplate
* Replace direct calls to `GetCurrentContext()`
* Use of v8StrIntern where appropriate
* Other minor tweaks

I wouldn't consider any of these to be critical, just miscellaneous cleanups batched together.