### PR TITLE
symbolizer improvements

### DIFF
--- a/build/kj_test.bzl
+++ b/build/kj_test.bzl
@@ -11,4 +11,7 @@ def kj_test(
             "@capnp-cpp//src/kj:kj-test",
             "@workerd//src/workerd/util:symbolizer",
         ] + deps,
+        env = {
+            "LLVM_SYMBOLIZER": "llvm-symbolizer",
+        },
     )

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -11,17 +11,21 @@ config_setting(
 wd_cc_binary(
     name = "workerd",
     srcs = ["workerd.c++"],
-    tags = ["no-arm64"],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":server",
-        ":workerd_capnp",
-        ":workerd-meta_capnp",
-    ],
+    env = {
+        "LLVM_SYMBOLIZER": "llvm-symbolizer",
+    },
     malloc = select({
         ":is_linux": "@com_google_tcmalloc//tcmalloc",
         "//conditions:default": "@bazel_tools//tools/cpp:malloc",
     }),
+    tags = ["no-arm64"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":server",
+        ":workerd-meta_capnp",
+        ":workerd_capnp",
+        "//src/workerd/util:symbolizer",
+    ],
 )
 
 wd_cc_library(
@@ -37,9 +41,9 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":workerd_capnp",
-        "@capnp-cpp//src/capnp:capnpc",
         "//src/workerd/io",
         "//src/workerd/jsg",
+        "@capnp-cpp//src/capnp:capnpc",
     ],
 )
 


### PR DESCRIPTION
- linked symbolizer to workerd
- set LLVM_SYMBOLIZER to llvm-symbolizer by default