### PR TITLE
Neuter the EncodedAsyncOutputStream on end/abort

### DIFF
--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -2229,6 +2229,9 @@ private:
             js.resolvedPromise();
       }
       KJ_CASE_ONEOF(errored, StreamStates::Errored) {
+        if (end) {
+          sink->abort(js.exceptionToKj(errored.addRef(js)));
+        }
         return js.rejectedPromise<void>(errored.addRef(js));
       }
       KJ_CASE_ONEOF(readable, Readable) {


### PR DESCRIPTION
Original commit description by @jasnell:

Because kj::AsyncOutputStream does not have an explicit end, some impls use their destructor to perform final writes, some of those using held bare refs to other objects. If the EncodedAsyncOutputStream happens to be held by an IoOwn (or some other mechanism that extends its lifetime past that of those deeply nested bare refs) then we can have a problem.

Here, we modify EncodedAsyncOutputStream to free inner when either end or abort are called, effectively neutering it and allowing the inner to perform any additional cleanup it needs on end.