### PR TITLE
Update R2/KJ to avoid mod-after-put when using ArrayBuffer

### DIFF
--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -281,7 +281,8 @@ jsg::Promise<void> KvNamespace::put(
     kj::String name,
     KvNamespace::PutBody body,
     jsg::Optional<PutOptions> options,
-    const jsg::TypeHandler<KvNamespace::PutSupportedTypes>& putTypeHandler) {
+    const jsg::TypeHandler<KvNamespace::PutSupportedTypes>& putTypeHandler,
+    CompatibilityFlags::Reader featureFlags) {
   return js.evalNow([&] {
     validateKeyName("PUT", name);
 
@@ -313,6 +314,7 @@ jsg::Promise<void> KvNamespace::put(
     }
 
     PutSupportedTypes supportedBody;
+    kj::Maybe<jsg::BackingStore> maybeBackingStore;
 
     KJ_SWITCH_ONEOF(body) {
       KJ_CASE_ONEOF(text, kj::String) {
@@ -336,8 +338,16 @@ jsg::Promise<void> KvNamespace::put(
         headers.set(kj::HttpHeaderId::CONTENT_TYPE, "text/plain;charset=UTF-8");
         expectedBodySize = uint64_t(text.size());
       }
-      KJ_CASE_ONEOF(data, kj::Array<byte>) {
+      KJ_CASE_ONEOF(data, jsg::BufferSource) {
         expectedBodySize = uint64_t(data.size());
+        // We want to either detach or copy the given ArrayBuffer/TypedArray
+        // in order to prevent the possibility of post-call modification.
+        if (featureFlags.getDetachArrayBufferOnPut()) {
+          maybeBackingStore = data.detach(js);
+        } else {
+          // In this case, we'll copy the buffer source given.
+          maybeBackingStore = data.cloneBackingStore(js);
+        }
       }
       KJ_CASE_ONEOF(stream, jsg::Ref<ReadableStream>) {
         expectedBodySize = stream->tryGetLength(StreamEncoding::IDENTITY);
@@ -351,7 +361,8 @@ jsg::Promise<void> KvNamespace::put(
     auto promise = context.waitForOutputLocks()
         .then([&context, client = kj::mv(client), urlStr = kj::mv(urlStr),
                headers = kj::mv(headers), expectedBodySize,
-               supportedBody = kj::mv(supportedBody)]() mutable {
+               supportedBody = kj::mv(supportedBody),
+               maybeBackingStore = kj::mv(maybeBackingStore)]() mutable {
       auto innerReq = client->request(
           kj::HttpMethod::PUT, urlStr,
           headers, expectedBodySize);
@@ -368,8 +379,14 @@ jsg::Promise<void> KvNamespace::put(
         KJ_CASE_ONEOF(text, kj::String) {
           writePromise = req.body->write(text.begin(), text.size()).attach(kj::mv(text));
         }
-        KJ_CASE_ONEOF(data, kj::Array<byte>) {
-          writePromise = req.body->write(data.begin(), data.size()).attach(kj::mv(data));
+        KJ_CASE_ONEOF(data, jsg::BufferSource) {
+          // maybeBackingStore was set outside of this lambda above,
+          // before entering the promise continuation. data here might
+          // have been copied or detached.
+          auto& backing = KJ_ASSERT_NONNULL(maybeBackingStore);
+          writePromise = req.body->write(
+              backing.asArrayPtr().begin(),
+              backing.size()).attach(kj::mv(maybeBackingStore));
         }
         KJ_CASE_ONEOF(stream, jsg::Ref<ReadableStream>) {
           writePromise = context.run([

--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -88,14 +88,15 @@ public:
   // OneOf to differentiate between primitives and objects, and check the object for the types that
   // we specifically support later.
 
-  using PutSupportedTypes = kj::OneOf<kj::String, kj::Array<byte>, jsg::Ref<ReadableStream>>;
+  using PutSupportedTypes = kj::OneOf<kj::String, jsg::BufferSource, jsg::Ref<ReadableStream>>;
 
   jsg::Promise<void> put(
       jsg::Lock& js,
       kj::String name,
       PutBody body,
       jsg::Optional<PutOptions> options,
-      const jsg::TypeHandler<PutSupportedTypes>& putTypeHandler);
+      const jsg::TypeHandler<PutSupportedTypes>& putTypeHandler,
+      CompatibilityFlags::Reader featureFlags);
 
   jsg::Promise<void> delete_(jsg::Lock& js, kj::String name);
 

--- a/src/workerd/api/r2-admin.c++
+++ b/src/workerd/api/r2-admin.c++
@@ -18,7 +18,8 @@ jsg::Ref<R2Bucket> R2Admin::get(jsg::Lock& js, kj::String bucketName) {
 }
 
 jsg::Promise<jsg::Ref<R2Bucket>> R2Admin::create(jsg::Lock& js, kj::String name,
-    const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
+    const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+    CompatibilityFlags::Reader compatFlags) {
   auto& context = IoContext::current();
   auto client = context.getHttpClient(subrequestChannel, true, nullptr, "r2_delete"_kj);
 
@@ -35,7 +36,7 @@ jsg::Promise<jsg::Ref<R2Bucket>> R2Admin::create(jsg::Lock& js, kj::String name,
   auto requestJson = json.encode(requestBuilder);
 
   auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr,
-                                    kj::mv(requestJson), nullptr);
+                                    kj::mv(requestJson), nullptr, compatFlags);
 
   return context.awaitIo(kj::mv(promise),
       [this, subrequestChannel = subrequestChannel, name = kj::mv(name), &errorType]
@@ -111,7 +112,8 @@ jsg::Promise<R2Admin::ListResult> R2Admin::list(jsg::Lock& js,
 }
 
 jsg::Promise<void> R2Admin::delete_(jsg::Lock& js, kj::String name,
-    const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
+    const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+    CompatibilityFlags::Reader compatFlags) {
   auto& context = IoContext::current();
   auto client = context.getHttpClient(subrequestChannel, true, nullptr, "r2_delete"_kj);
 
@@ -128,7 +130,7 @@ jsg::Promise<void> R2Admin::delete_(jsg::Lock& js, kj::String name,
   auto requestJson = json.encode(requestBuilder);
 
   auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr,
-                                    kj::mv(requestJson), nullptr);
+                                    kj::mv(requestJson), nullptr, compatFlags);
 
   return context.awaitIo(kj::mv(promise), [&errorType](R2Result r2Result) mutable {
     r2Result.throwIfError("deleteBucket", errorType);

--- a/src/workerd/api/r2-admin.h
+++ b/src/workerd/api/r2-admin.h
@@ -62,10 +62,12 @@ public:
   };
 
   jsg::Promise<jsg::Ref<R2Bucket>> create(jsg::Lock& js, kj::String name,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType);
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+      CompatibilityFlags::Reader compatFlags);
   jsg::Ref<R2Bucket> get(jsg::Lock& js, kj::String name);
   jsg::Promise<void> delete_(jsg::Lock& js, kj::String bucketName,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType);
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+      CompatibilityFlags::Reader compatFlags);
   jsg::Promise<ListResult> list(jsg::Lock& js, jsg::Optional<ListOptions> options,
       const jsg::TypeHandler<jsg::Ref<RetrievedBucket>>& retrievedBucketType,
       const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType);

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -359,7 +359,8 @@ R2Bucket::get(jsg::Lock& js, kj::String name, jsg::Optional<GetOptions> options,
 
 jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>>
 R2Bucket::put(jsg::Lock& js, kj::String name, kj::Maybe<R2PutValue> value,
-    jsg::Optional<PutOptions> options, const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
+    jsg::Optional<PutOptions> options, const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+    CompatibilityFlags::Reader featureFlags) {
   return js.evalNow([&] {
     auto cancelReader = kj::defer([&] {
       KJ_IF_MAYBE(v, value) {
@@ -525,7 +526,7 @@ R2Bucket::put(jsg::Lock& js, kj::String name, kj::Maybe<R2PutValue> value,
 
     cancelReader.cancel();
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), kj::mv(value), nullptr,
-                                      kj::mv(requestJson), kj::mv(bucket));
+                                      kj::mv(requestJson), kj::mv(bucket), featureFlags);
 
     return context.awaitIo(js, kj::mv(promise),
         [sentHttpMetadata = kj::mv(sentHttpMetadata),
@@ -546,8 +547,10 @@ R2Bucket::put(jsg::Lock& js, kj::String name, kj::Maybe<R2PutValue> value,
   });
 }
 
-jsg::Promise<jsg::Ref<R2MultipartUpload>> R2Bucket::createMultipartUpload(jsg::Lock& js, kj::String key,
-    jsg::Optional<MultipartOptions> options, const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
+jsg::Promise<jsg::Ref<R2MultipartUpload>> R2Bucket::createMultipartUpload(
+    jsg::Lock& js, kj::String key,
+    jsg::Optional<MultipartOptions> options, const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+    CompatibilityFlags::Reader featureFlags) {
   return js.evalNow([&] {
     auto& context = IoContext::current();
     auto client = context.getHttpClient(
@@ -611,7 +614,7 @@ jsg::Promise<jsg::Ref<R2MultipartUpload>> R2Bucket::createMultipartUpload(jsg::L
     auto bucket = adminBucket.map([](auto&& s) { return kj::str(s); });
 
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr, kj::mv(requestJson),
-        kj::mv(bucket));
+        kj::mv(bucket), featureFlags);
 
     return context.awaitIo(js, kj::mv(promise),
         [&errorType, key=kj::mv(key), this] (jsg::Lock& js, R2Result r2Result) mutable {
@@ -634,8 +637,10 @@ jsg::Ref<R2MultipartUpload> R2Bucket::resumeMultipartUpload(jsg::Lock& js,
     return jsg::alloc<R2MultipartUpload>(kj::mv(key), kj::mv(uploadId), JSG_THIS);
 }
 
-jsg::Promise<void> R2Bucket::delete_(jsg::Lock& js, kj::OneOf<kj::String, kj::Array<kj::String>> keys,
-    const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
+jsg::Promise<void> R2Bucket::delete_(jsg::Lock& js,
+    kj::OneOf<kj::String, kj::Array<kj::String>> keys,
+    const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+    CompatibilityFlags::Reader featureFlags) {
   return js.evalNow([&] {
     auto& context = IoContext::current();
     auto client = context.getHttpClient(clientIndex, true, nullptr, "r2_delete"_kj);
@@ -665,7 +670,7 @@ jsg::Promise<void> R2Bucket::delete_(jsg::Lock& js, kj::OneOf<kj::String, kj::Ar
     auto bucket = adminBucket.map([](auto&& s) { return kj::str(s); });
 
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr, kj::mv(requestJson),
-        kj::mv(bucket));
+        kj::mv(bucket), featureFlags);
 
     return context.awaitIo(js, kj::mv(promise), [&errorType](jsg::Lock& js, R2Result r) {
       if (r.objectNotFound()) {

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -304,11 +304,13 @@ public:
   );
   jsg::Promise<kj::Maybe<jsg::Ref<HeadResult>>> put(jsg::Lock& js,
       kj::String key, kj::Maybe<R2PutValue> value, jsg::Optional<PutOptions> options,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+      CompatibilityFlags::Reader featureFlags
   );
   jsg::Promise<jsg::Ref<R2MultipartUpload>> createMultipartUpload(
       jsg::Lock& js, kj::String key, jsg::Optional<MultipartOptions> options,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+      CompatibilityFlags::Reader featureFlags
   );
   jsg::Ref<R2MultipartUpload> resumeMultipartUpload(
       jsg::Lock& js, kj::String key, kj::String uploadId,
@@ -316,7 +318,8 @@ public:
   );
   jsg::Promise<void> delete_(
       jsg::Lock& js, kj::OneOf<kj::String, kj::Array<kj::String>> keys,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+      CompatibilityFlags::Reader featureFlags
   );
   jsg::Promise<ListResult> list(
       jsg::Lock& js, jsg::Optional<ListOptions> options,

--- a/src/workerd/api/r2-multipart.c++
+++ b/src/workerd/api/r2-multipart.c++
@@ -20,7 +20,8 @@ jsg::Promise<R2MultipartUpload::UploadedPart> R2MultipartUpload::uploadPart(
   jsg::Lock& js,
   int partNumber,
   R2PutValue value,
-  const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
+  const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+  CompatibilityFlags::Reader featureFlags) {
   return js.evalNow([&] {
     JSG_REQUIRE(partNumber >= 1 && partNumber <= 10000, TypeError,
       "Part number must be between 1 and 10000 (inclusive). Actual value was: ", partNumber);
@@ -46,7 +47,7 @@ jsg::Promise<R2MultipartUpload::UploadedPart> R2MultipartUpload::uploadPart(
     auto bucket = this->bucket->adminBucket.map([](auto&& s) { return kj::str(s); });
 
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), kj::mv(value), nullptr,
-                                      kj::mv(requestJson), kj::mv(bucket));
+                                      kj::mv(requestJson), kj::mv(bucket), featureFlags);
 
     return context.awaitIo(js, kj::mv(promise),
         [&errorType, partNumber]
@@ -69,7 +70,8 @@ jsg::Promise<R2MultipartUpload::UploadedPart> R2MultipartUpload::uploadPart(
 jsg::Promise<jsg::Ref<R2Bucket::HeadResult>> R2MultipartUpload::complete(
   jsg::Lock& js,
   kj::Array<UploadedPart> uploadedParts,
-  const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
+  const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+  CompatibilityFlags::Reader featureFlags) {
   return js.evalNow([&] {
     auto& context = IoContext::current();
     auto client = context.getHttpClient(this->bucket->clientIndex, true, nullptr, "r2_completeMultipartUpload"_kj);
@@ -101,7 +103,7 @@ jsg::Promise<jsg::Ref<R2Bucket::HeadResult>> R2MultipartUpload::complete(
     auto bucket = this->bucket->adminBucket.map([](auto&& s) { return kj::str(s); });
 
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr, kj::mv(requestJson),
-        kj::mv(bucket));
+        kj::mv(bucket), featureFlags);
 
     return context.awaitIo(js, kj::mv(promise),
         [&errorType]
@@ -116,7 +118,9 @@ jsg::Promise<jsg::Ref<R2Bucket::HeadResult>> R2MultipartUpload::complete(
   });
 }
 
-jsg::Promise<void> R2MultipartUpload::abort(jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
+jsg::Promise<void> R2MultipartUpload::abort(jsg::Lock& js,
+    const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+    CompatibilityFlags::Reader featureFlags) {
   return js.evalNow([&] {
     auto& context = IoContext::current();
     auto client = context.getHttpClient(this->bucket->clientIndex, true, nullptr, "r2_abortMultipartUpload"_kj);
@@ -137,7 +141,7 @@ jsg::Promise<void> R2MultipartUpload::abort(jsg::Lock& js, const jsg::TypeHandle
     auto bucket = this->bucket->adminBucket.map([](auto&& s) { return kj::str(s); });
 
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr, kj::mv(requestJson),
-        kj::mv(bucket));
+        kj::mv(bucket), featureFlags);
 
     return context.awaitIo(js, kj::mv(promise), [&errorType](jsg::Lock& js, R2Result r) {
       if (r.objectNotFound()) {

--- a/src/workerd/api/r2-multipart.h
+++ b/src/workerd/api/r2-multipart.h
@@ -28,12 +28,17 @@ class R2MultipartUpload: public jsg::Object {
 
     jsg::Promise<UploadedPart> uploadPart(
         jsg::Lock& js, int partNumber, R2PutValue value,
-        const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType
+        const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+        CompatibilityFlags::Reader featureFlags
     );
-    jsg::Promise<void> abort(jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType);
+    jsg::Promise<void> abort(
+        jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+        CompatibilityFlags::Reader featureFlags
+    );
     jsg::Promise<jsg::Ref<R2Bucket::HeadResult>> complete(
         jsg::Lock& js, kj::Array<UploadedPart> uploadedParts,
-        const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType
+        const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
+        CompatibilityFlags::Reader featureFlags
     );
 
     JSG_RESOURCE_TYPE(R2MultipartUpload) {

--- a/src/workerd/api/r2-rpc.h
+++ b/src/workerd/api/r2-rpc.h
@@ -48,7 +48,7 @@ private:
   friend struct R2Result;
 };
 
-using R2PutValue = kj::OneOf<jsg::Ref<ReadableStream>, kj::Array<kj::byte>,
+using R2PutValue = kj::OneOf<jsg::Ref<ReadableStream>, jsg::BufferSource,
                              jsg::NonCoercible<kj::String>, jsg::Ref<Blob>>;
 
 struct R2Result {
@@ -82,6 +82,7 @@ kj::Promise<R2Result> doR2HTTPPutRequest(
     kj::Maybe<uint64_t> streamSize,
     // Deprecated. For internal beta API only.
     kj::String metadataPayload,
-    kj::Maybe<kj::String> path);
+    kj::Maybe<kj::String> path,
+    CompatibilityFlags::Reader featureFlags);
 
 } // namespace workerd::api

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -254,4 +254,13 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # WHATWG URL Standard, leading to a number of issues reported by users. Unfortunately,
   # the specCompliantUrl flag did not contemplate the redirect usage. This flag is
   # specifically about the usage in a redirect().
+
+  detachArrayBufferOnPut @24 :Bool
+      $compatEnableDate("2023-03-01")
+      $compatEnableFlag("detach_arraybuffer_on_kv_r2_put")
+      $compatDisableFlag("copy_arraybuffer_on_kv_r2_put");
+  # The original implementations of K2 and R2 put allow TypedArray/ArrayBuffer
+  # passed in as the value to be modified after the call. That original behavior
+  # is modified with this flag. When disabled, the ArrayBuffer is copied on put.
+  # When enabled, the ArrayBuffer is detached.
 }

--- a/src/workerd/jsg/README.md
+++ b/src/workerd/jsg/README.md
@@ -383,6 +383,69 @@ is separate the `v8::BackingStore` from the original `TypedArray`/`BufferSource`
 original can no longer be used to read or mutate the data. This is important is cases where ownership
 of the data storage must transfer and cannot be shared.
 
+#### Considerations Synchronous vs. Asynchronous APIs
+
+Because the `kj::Array<kj::byte>` type mapping shares the underlying memory with a JavaScript
+`ArrayBuffer`, care must be taken when using the type mapping with asynchronous APIs. For example,
+consider the following case:
+
+```cpp
+class Foo : public jsg::Object {
+public:
+  static jsg::Ref<Foo> constructor() { return jsg::alloc<Foo>(); }
+  jsg::Promise<void> doSomething(jsg::Lock& js, kj::Array<kj::byte> data) {
+    return awaitSomePromise().then(js, [data = kj::mv(data)](jsg::Lock& js) {
+      // do something with the data...
+    });
+  }
+};
+```
+
+In this case, a script could call the `doSomething(...)` method passing in an `ArrayBuffer` or
+`TypedArray` *then* modify it. If those modifications occur before the promise continuation is
+trigged, the contination would get the modified version of the data rather than the version that
+was passed at the time `doSomething(...)` was called.
+
+```js
+const foo = new Foo();
+const u8 = new Uint8Array(10);
+u8.fill(1);
+const p = foo.doSomething(u8);
+// The continuation inside p might see all 2's instead of all 1's!!
+u8.fill(2);
+await p;
+```
+
+As a general rule, only use the `kj::Array<kj::byte>` mapping in *synchronous* APIs where the
+bytes are going to be consumed immediately. And for *asynchronous* APIs, where consuming the bytes
+may happen at some point in the future, it is best to use `jsg::BufferSource` and either copy or
+detach the underlying `jsg::BackingStore`:
+
+```cpp
+class Foo : public jsg::Object {
+public:
+  static jsg::Ref<Foo> constructor() { return jsg::alloc<Foo>(); }
+  jsg::Promise<void> doSomething(jsg::Lock& js, jsg::BufferSource data) {
+    auto backing = data.detach(js);
+    // or copy:
+    // as a BackingStore:
+    // auto backing = data.cloneBackingStore(js);
+    //
+    // as a kj::Array<kj::byte>:
+    // auto backing = data.cloneBackingStore(js);
+    // auto array = backing.asArrayPtr().attach(kj::mv(backing));
+
+    return awaitSomePromise().then(js, [backing = kj::mv(backing)](jsg::Lock& js) {
+      // do something with the backing...
+    });
+  }
+};
+```
+
+Detaching the `jsg::BackingStore` has the benefit of being more performant but has the
+observable side-effect of transitioning the passed in `ArrayBuffer` or `TypedArray` into
+a zero-length, "detached" state.
+
 ### Functions (`jsg::Function<Ret(Args...)>`)
 
 The `jsg::Function<Ret(Args...)>` type provides a wrapper around JavaScript functions, making it

--- a/src/workerd/jsg/buffersource-test.c++
+++ b/src/workerd/jsg/buffersource-test.c++
@@ -12,6 +12,14 @@ namespace {
 V8System v8System;
 
 struct BufferSourceContext: public Object {
+
+  BufferSource cloneBackingStore(Lock& js, BufferSource buf) {
+    auto backing = buf.cloneBackingStore(js);
+    KJ_ASSERT(backing.size() == buf.size());
+    KJ_ASSERT(backing.getElementSize() == buf.getElementSize());
+    return BufferSource(js, kj::mv(backing));
+  }
+
   BufferSource takeBufferSource(BufferSource buf) {
     auto ptr = buf.asArrayPtr();
     KJ_ASSERT(!buf.isDetached());
@@ -60,6 +68,7 @@ struct BufferSourceContext: public Object {
     JSG_METHOD(takeUint8Array);
     JSG_METHOD(makeBufferSource);
     JSG_METHOD(makeArrayBuffer);
+    JSG_METHOD(cloneBackingStore);
   }
 };
 JSG_DECLARE_ISOLATE_TYPE(BufferSourceIsolate, BufferSourceContext);
@@ -125,6 +134,19 @@ KJ_TEST("BufferSource works") {
       "const u2 = takeUint8Array(u8);"
       "u8.byteLength === 0 && u2.byteLength === 1 && u2 instanceof Uint8Array && "
       "u2.buffer.byteLength === 4 && u2.byteOffset === 1 && u8 !== u2",
+      "boolean",
+      "true");
+
+  e.expectEval(
+      "const u8 = new Uint8Array(4); "
+      "u8.fill(1); "
+      "const other = cloneBackingStore(u8); "
+      "if (!(other instanceof Uint8Array)) throw new Error('wrong type'); "
+      "if (other.byteLength !== u8.byteLength) throw new Error('wrong length'); "
+      "for (let n = 0; n < u8.byteLength; n++) { "
+      "  if (u8[n] !== other[n]) throw new Error('wrong value'); "
+      "} "
+      "true;",
       "boolean",
       "true");
 }

--- a/src/workerd/jsg/buffersource.c++
+++ b/src/workerd/jsg/buffersource.c++
@@ -82,6 +82,17 @@ bool BackingStore::operator==(const BackingStore& other) {
          byteOffset == other.byteOffset;
 }
 
+BackingStore BackingStore::clone(Lock& js) {
+  auto newBacking = BackingStore::alloc(js, byteLength);
+  auto src = asArrayPtr();
+  newBacking.elementSize = elementSize;
+  newBacking.ctor = ctor;
+  newBacking.integerType = integerType;
+  auto dest = newBacking.asArrayPtr();
+  std::copy(src.begin(), src.end(), dest.begin());
+  return newBacking;
+}
+
 BufferSource::BufferSource(Lock& js, v8::Local<v8::Value> handle)
     : handle(js.v8Ref(handle)),
       maybeBackingStore(BackingStore(
@@ -115,6 +126,14 @@ BackingStore BufferSource::detach(Lock& js) {
   buffer->Detach();
 
   return kj::mv(backingStore);
+}
+
+BackingStore BufferSource::cloneBackingStore(Lock& js) {
+  auto& backingStore =
+      JSG_REQUIRE_NONNULL(maybeBackingStore,
+                          TypeError,
+                          "This BufferSource has been detached.");
+  return backingStore.clone(js);
 }
 
 bool BufferSource::canDetach(Lock& js) {

--- a/src/workerd/jsg/buffersource.h
+++ b/src/workerd/jsg/buffersource.h
@@ -190,6 +190,9 @@ public:
     byteLength -= bytes;
   }
 
+  BackingStore clone(Lock& js);
+  // Copy this backing store.
+
 private:
   std::shared_ptr<v8::BackingStore> backingStore;
   size_t byteLength;
@@ -285,9 +288,14 @@ public:
   BackingStore detach(Lock& js);
   // Removes the BackingStore from the BufferSource and severs its connection to
   // the ArrayBuffer/ArrayBufferView handle.
-  // It's worth mentioning that detach wcan throw application-visible exceptions
+  // It's worth mentioning that detach can throw application-visible exceptions
   // in the case the ArrayBuffer cannot be detached. Any detaching should be
-  // performance as early as possible in an API method implementation.
+  // performed as early as possible in an API method implementation.
+
+  BackingStore cloneBackingStore(Lock& js);
+  // Copies the underlying backing store into a new instance.
+  // An application-visible exception can be thrown if the BufferSource was
+  // already detached.
 
   v8::Local<v8::Value> getHandle(Lock& js);
 


### PR DESCRIPTION
Prior to this change, R2/KV would allow post-call modification of the ArrayBuffer. This updates it to copy by default and detach with enablement of a compat flag.