### PR TITLE
Refine r2/kv detach buffer flag to avoid copy

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -258,9 +258,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   detachArrayBufferOnPut @24 :Bool
       $compatEnableDate("2023-03-01")
       $compatEnableFlag("detach_arraybuffer_on_kv_r2_put")
-      $compatDisableFlag("copy_arraybuffer_on_kv_r2_put");
+      $compatDisableFlag("no_detach_arraybuffer_on_kv_r2_put")
+      $experimental;
   # The original implementations of K2 and R2 put allow TypedArray/ArrayBuffer
   # passed in as the value to be modified after the call. That original behavior
-  # is modified with this flag. When disabled, the ArrayBuffer is copied on put.
-  # When enabled, the ArrayBuffer is detached.
+  # is modified with this flag. When enabled, the ArrayBuffer is detached.
 }


### PR DESCRIPTION
Concerns over the possible performance hit of copying were raised. This adjusts the flag to preserve the post-call modification behavior when the detach flag is not set. Also sets the flag as explicitly experimental so we can experiment with it before releasing.