### PR TITLE
Revert "Update R2/KJ to avoid mod-after-put when using ArrayBuffer"

### DIFF
--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -281,8 +281,7 @@ jsg::Promise<void> KvNamespace::put(
     kj::String name,
     KvNamespace::PutBody body,
     jsg::Optional<PutOptions> options,
-    const jsg::TypeHandler<KvNamespace::PutSupportedTypes>& putTypeHandler,
-    CompatibilityFlags::Reader featureFlags) {
+    const jsg::TypeHandler<KvNamespace::PutSupportedTypes>& putTypeHandler) {
   return js.evalNow([&] {
     validateKeyName("PUT", name);
 
@@ -314,7 +313,6 @@ jsg::Promise<void> KvNamespace::put(
     }
 
     PutSupportedTypes supportedBody;
-    kj::Maybe<jsg::BackingStore> maybeBackingStore;
 
     KJ_SWITCH_ONEOF(body) {
       KJ_CASE_ONEOF(text, kj::String) {
@@ -338,16 +336,8 @@ jsg::Promise<void> KvNamespace::put(
         headers.set(kj::HttpHeaderId::CONTENT_TYPE, "text/plain;charset=UTF-8");
         expectedBodySize = uint64_t(text.size());
       }
-      KJ_CASE_ONEOF(data, jsg::BufferSource) {
+      KJ_CASE_ONEOF(data, kj::Array<byte>) {
         expectedBodySize = uint64_t(data.size());
-        // We want to either detach or copy the given ArrayBuffer/TypedArray
-        // in order to prevent the possibility of post-call modification.
-        if (featureFlags.getDetachArrayBufferOnPut()) {
-          maybeBackingStore = data.detach(js);
-        } else {
-          // In this case, we'll copy the buffer source given.
-          maybeBackingStore = data.cloneBackingStore(js);
-        }
       }
       KJ_CASE_ONEOF(stream, jsg::Ref<ReadableStream>) {
         expectedBodySize = stream->tryGetLength(StreamEncoding::IDENTITY);
@@ -361,8 +351,7 @@ jsg::Promise<void> KvNamespace::put(
     auto promise = context.waitForOutputLocks()
         .then([&context, client = kj::mv(client), urlStr = kj::mv(urlStr),
                headers = kj::mv(headers), expectedBodySize,
-               supportedBody = kj::mv(supportedBody),
-               maybeBackingStore = kj::mv(maybeBackingStore)]() mutable {
+               supportedBody = kj::mv(supportedBody)]() mutable {
       auto innerReq = client->request(
           kj::HttpMethod::PUT, urlStr,
           headers, expectedBodySize);
@@ -379,14 +368,8 @@ jsg::Promise<void> KvNamespace::put(
         KJ_CASE_ONEOF(text, kj::String) {
           writePromise = req.body->write(text.begin(), text.size()).attach(kj::mv(text));
         }
-        KJ_CASE_ONEOF(data, jsg::BufferSource) {
-          // maybeBackingStore was set outside of this lambda above,
-          // before entering the promise continuation. data here might
-          // have been copied or detached.
-          auto& backing = KJ_ASSERT_NONNULL(maybeBackingStore);
-          writePromise = req.body->write(
-              backing.asArrayPtr().begin(),
-              backing.size()).attach(kj::mv(maybeBackingStore));
+        KJ_CASE_ONEOF(data, kj::Array<byte>) {
+          writePromise = req.body->write(data.begin(), data.size()).attach(kj::mv(data));
         }
         KJ_CASE_ONEOF(stream, jsg::Ref<ReadableStream>) {
           writePromise = context.run([

--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -88,15 +88,14 @@ public:
   // OneOf to differentiate between primitives and objects, and check the object for the types that
   // we specifically support later.
 
-  using PutSupportedTypes = kj::OneOf<kj::String, jsg::BufferSource, jsg::Ref<ReadableStream>>;
+  using PutSupportedTypes = kj::OneOf<kj::String, kj::Array<byte>, jsg::Ref<ReadableStream>>;
 
   jsg::Promise<void> put(
       jsg::Lock& js,
       kj::String name,
       PutBody body,
       jsg::Optional<PutOptions> options,
-      const jsg::TypeHandler<PutSupportedTypes>& putTypeHandler,
-      CompatibilityFlags::Reader featureFlags);
+      const jsg::TypeHandler<PutSupportedTypes>& putTypeHandler);
 
   jsg::Promise<void> delete_(jsg::Lock& js, kj::String name);
 

--- a/src/workerd/api/r2-admin.c++
+++ b/src/workerd/api/r2-admin.c++
@@ -18,8 +18,7 @@ jsg::Ref<R2Bucket> R2Admin::get(jsg::Lock& js, kj::String bucketName) {
 }
 
 jsg::Promise<jsg::Ref<R2Bucket>> R2Admin::create(jsg::Lock& js, kj::String name,
-    const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
-    CompatibilityFlags::Reader compatFlags) {
+    const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
   auto& context = IoContext::current();
   auto client = context.getHttpClient(subrequestChannel, true, nullptr, "r2_delete"_kj);
 
@@ -36,7 +35,7 @@ jsg::Promise<jsg::Ref<R2Bucket>> R2Admin::create(jsg::Lock& js, kj::String name,
   auto requestJson = json.encode(requestBuilder);
 
   auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr,
-                                    kj::mv(requestJson), nullptr, compatFlags);
+                                    kj::mv(requestJson), nullptr);
 
   return context.awaitIo(kj::mv(promise),
       [this, subrequestChannel = subrequestChannel, name = kj::mv(name), &errorType]
@@ -112,8 +111,7 @@ jsg::Promise<R2Admin::ListResult> R2Admin::list(jsg::Lock& js,
 }
 
 jsg::Promise<void> R2Admin::delete_(jsg::Lock& js, kj::String name,
-    const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
-    CompatibilityFlags::Reader compatFlags) {
+    const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
   auto& context = IoContext::current();
   auto client = context.getHttpClient(subrequestChannel, true, nullptr, "r2_delete"_kj);
 
@@ -130,7 +128,7 @@ jsg::Promise<void> R2Admin::delete_(jsg::Lock& js, kj::String name,
   auto requestJson = json.encode(requestBuilder);
 
   auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr,
-                                    kj::mv(requestJson), nullptr, compatFlags);
+                                    kj::mv(requestJson), nullptr);
 
   return context.awaitIo(kj::mv(promise), [&errorType](R2Result r2Result) mutable {
     r2Result.throwIfError("deleteBucket", errorType);

--- a/src/workerd/api/r2-admin.h
+++ b/src/workerd/api/r2-admin.h
@@ -62,12 +62,10 @@ public:
   };
 
   jsg::Promise<jsg::Ref<R2Bucket>> create(jsg::Lock& js, kj::String name,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
-      CompatibilityFlags::Reader compatFlags);
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType);
   jsg::Ref<R2Bucket> get(jsg::Lock& js, kj::String name);
   jsg::Promise<void> delete_(jsg::Lock& js, kj::String bucketName,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
-      CompatibilityFlags::Reader compatFlags);
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType);
   jsg::Promise<ListResult> list(jsg::Lock& js, jsg::Optional<ListOptions> options,
       const jsg::TypeHandler<jsg::Ref<RetrievedBucket>>& retrievedBucketType,
       const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType);

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -304,13 +304,11 @@ public:
   );
   jsg::Promise<kj::Maybe<jsg::Ref<HeadResult>>> put(jsg::Lock& js,
       kj::String key, kj::Maybe<R2PutValue> value, jsg::Optional<PutOptions> options,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
-      CompatibilityFlags::Reader featureFlags
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType
   );
   jsg::Promise<jsg::Ref<R2MultipartUpload>> createMultipartUpload(
       jsg::Lock& js, kj::String key, jsg::Optional<MultipartOptions> options,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
-      CompatibilityFlags::Reader featureFlags
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType
   );
   jsg::Ref<R2MultipartUpload> resumeMultipartUpload(
       jsg::Lock& js, kj::String key, kj::String uploadId,
@@ -318,8 +316,7 @@ public:
   );
   jsg::Promise<void> delete_(
       jsg::Lock& js, kj::OneOf<kj::String, kj::Array<kj::String>> keys,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
-      CompatibilityFlags::Reader featureFlags
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType
   );
   jsg::Promise<ListResult> list(
       jsg::Lock& js, jsg::Optional<ListOptions> options,

--- a/src/workerd/api/r2-multipart.h
+++ b/src/workerd/api/r2-multipart.h
@@ -28,17 +28,12 @@ class R2MultipartUpload: public jsg::Object {
 
     jsg::Promise<UploadedPart> uploadPart(
         jsg::Lock& js, int partNumber, R2PutValue value,
-        const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
-        CompatibilityFlags::Reader featureFlags
+        const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType
     );
-    jsg::Promise<void> abort(
-        jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
-        CompatibilityFlags::Reader featureFlags
-    );
+    jsg::Promise<void> abort(jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType);
     jsg::Promise<jsg::Ref<R2Bucket::HeadResult>> complete(
         jsg::Lock& js, kj::Array<UploadedPart> uploadedParts,
-        const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType,
-        CompatibilityFlags::Reader featureFlags
+        const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType
     );
 
     JSG_RESOURCE_TYPE(R2MultipartUpload) {

--- a/src/workerd/api/r2-rpc.c++
+++ b/src/workerd/api/r2-rpc.c++
@@ -130,7 +130,7 @@ kj::Promise<R2Result> doR2HTTPGetRequest(kj::Own<kj::HttpClient> client,
 
 kj::Promise<R2Result> doR2HTTPPutRequest(jsg::Lock& js, kj::Own<kj::HttpClient> client,
     kj::Maybe<R2PutValue> supportedBody, kj::Maybe<uint64_t> streamSize, kj::String metadataPayload,
-    kj::Maybe<kj::String> path, CompatibilityFlags::Reader featureFlags) {
+    kj::Maybe<kj::String> path) {
   // NOTE: A lot of code here is duplicated with kv.c++. Maybe it can be refactored to be more
   // reusable?
   auto& context = IoContext::current();
@@ -143,7 +143,6 @@ kj::Promise<R2Result> doR2HTTPPutRequest(jsg::Lock& js, kj::Own<kj::HttpClient> 
   }
 
   kj::Maybe<uint64_t> expectedBodySize;
-  kj::Maybe<jsg::BackingStore> maybeBackingStore;
 
   KJ_IF_MAYBE(b, supportedBody) {
     KJ_SWITCH_ONEOF(*b) {
@@ -163,17 +162,9 @@ kj::Promise<R2Result> doR2HTTPPutRequest(jsg::Lock& js, kj::Own<kj::HttpClient> 
         expectedBodySize = text.value.size();
         KJ_REQUIRE(streamSize == nullptr);
       }
-      KJ_CASE_ONEOF(data, jsg::BufferSource) {
+      KJ_CASE_ONEOF(data, kj::Array<kj::byte>) {
         expectedBodySize = data.size();
         KJ_REQUIRE(streamSize == nullptr);
-        // We want to either detach or copy the given ArrayBuffer/TypedArray
-        // in order to prevent the possibility of post-call modification.
-        if (featureFlags.getDetachArrayBufferOnPut()) {
-          maybeBackingStore = data.detach(js);
-        } else {
-          // In this case, we'll copy the buffer source given.
-          maybeBackingStore = data.cloneBackingStore(js);
-        }
       }
       KJ_CASE_ONEOF(data, jsg::Ref<Blob>) {
         expectedBodySize = data->getSize();
@@ -192,8 +183,7 @@ kj::Promise<R2Result> doR2HTTPPutRequest(jsg::Lock& js, kj::Own<kj::HttpClient> 
   return context.waitForOutputLocks()
       .then([&context, client = kj::mv(client), urlStr = kj::mv(urlStr),
       metadataPayload = kj::mv(metadataPayload), headers = kj::mv(headers),
-      expectedBodySize, supportedBody = kj::mv(supportedBody),
-      maybeBackingStore = kj::mv(maybeBackingStore)]
+      expectedBodySize, supportedBody = kj::mv(supportedBody)]
       () mutable {
     uint64_t combinedSize = metadataPayload.size() + KJ_ASSERT_NONNULL(expectedBodySize);
     auto innerReq = client->request(kj::HttpMethod::PUT, urlStr, headers, combinedSize);
@@ -209,23 +199,16 @@ kj::Promise<R2Result> doR2HTTPPutRequest(jsg::Lock& js, kj::Own<kj::HttpClient> 
     return req.body->write(metadataPayload.begin(), metadataPayload.size())
         .attach(kj::mv(metadataPayload))
         .then([&context, supportedBody = kj::mv(supportedBody),
-               reqBody = kj::mv(req.body),
-               maybeBackingStore = kj::mv(maybeBackingStore)]() mutable -> kj::Promise<void> {
+               reqBody = kj::mv(req.body)]() mutable -> kj::Promise<void> {
       KJ_IF_MAYBE(b, supportedBody) {
         KJ_SWITCH_ONEOF(*b) {
           KJ_CASE_ONEOF(text, jsg::NonCoercible<kj::String>) {
             return reqBody->write(text.value.begin(), text.value.size())
                 .attach(kj::mv(text.value), kj::mv(reqBody));
           }
-          KJ_CASE_ONEOF(data, jsg::BufferSource) {
-            // maybeBackingStore was set outside of this lambda above,
-            // before entering the promise continuation. data here might
-            // have been copied or detached.
-            auto& backing = KJ_ASSERT_NONNULL(maybeBackingStore);
-            return reqBody->write(
-                backing.asArrayPtr().begin(),
-                backing.size())
-                .attach(kj::mv(backing), kj::mv(reqBody));
+          KJ_CASE_ONEOF(data, kj::Array<byte>) {
+            return reqBody->write(data.begin(), data.size())
+                .attach(kj::mv(data), kj::mv(reqBody));
           }
           KJ_CASE_ONEOF(blob, jsg::Ref<Blob>) {
             auto data = blob->getData();

--- a/src/workerd/api/r2-rpc.h
+++ b/src/workerd/api/r2-rpc.h
@@ -48,7 +48,7 @@ private:
   friend struct R2Result;
 };
 
-using R2PutValue = kj::OneOf<jsg::Ref<ReadableStream>, jsg::BufferSource,
+using R2PutValue = kj::OneOf<jsg::Ref<ReadableStream>, kj::Array<kj::byte>,
                              jsg::NonCoercible<kj::String>, jsg::Ref<Blob>>;
 
 struct R2Result {
@@ -82,7 +82,6 @@ kj::Promise<R2Result> doR2HTTPPutRequest(
     kj::Maybe<uint64_t> streamSize,
     // Deprecated. For internal beta API only.
     kj::String metadataPayload,
-    kj::Maybe<kj::String> path,
-    CompatibilityFlags::Reader featureFlags);
+    kj::Maybe<kj::String> path);
 
 } // namespace workerd::api

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -254,13 +254,4 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # WHATWG URL Standard, leading to a number of issues reported by users. Unfortunately,
   # the specCompliantUrl flag did not contemplate the redirect usage. This flag is
   # specifically about the usage in a redirect().
-
-  detachArrayBufferOnPut @24 :Bool
-      $compatEnableDate("2023-03-01")
-      $compatEnableFlag("detach_arraybuffer_on_kv_r2_put")
-      $compatDisableFlag("copy_arraybuffer_on_kv_r2_put");
-  # The original implementations of K2 and R2 put allow TypedArray/ArrayBuffer
-  # passed in as the value to be modified after the call. That original behavior
-  # is modified with this flag. When disabled, the ArrayBuffer is copied on put.
-  # When enabled, the ArrayBuffer is detached.
 }

--- a/src/workerd/jsg/buffersource-test.c++
+++ b/src/workerd/jsg/buffersource-test.c++
@@ -12,14 +12,6 @@ namespace {
 V8System v8System;
 
 struct BufferSourceContext: public Object {
-
-  BufferSource cloneBackingStore(Lock& js, BufferSource buf) {
-    auto backing = buf.cloneBackingStore(js);
-    KJ_ASSERT(backing.size() == buf.size());
-    KJ_ASSERT(backing.getElementSize() == buf.getElementSize());
-    return BufferSource(js, kj::mv(backing));
-  }
-
   BufferSource takeBufferSource(BufferSource buf) {
     auto ptr = buf.asArrayPtr();
     KJ_ASSERT(!buf.isDetached());
@@ -68,7 +60,6 @@ struct BufferSourceContext: public Object {
     JSG_METHOD(takeUint8Array);
     JSG_METHOD(makeBufferSource);
     JSG_METHOD(makeArrayBuffer);
-    JSG_METHOD(cloneBackingStore);
   }
 };
 JSG_DECLARE_ISOLATE_TYPE(BufferSourceIsolate, BufferSourceContext);
@@ -134,19 +125,6 @@ KJ_TEST("BufferSource works") {
       "const u2 = takeUint8Array(u8);"
       "u8.byteLength === 0 && u2.byteLength === 1 && u2 instanceof Uint8Array && "
       "u2.buffer.byteLength === 4 && u2.byteOffset === 1 && u8 !== u2",
-      "boolean",
-      "true");
-
-  e.expectEval(
-      "const u8 = new Uint8Array(4); "
-      "u8.fill(1); "
-      "const other = cloneBackingStore(u8); "
-      "if (!(other instanceof Uint8Array)) throw new Error('wrong type'); "
-      "if (other.byteLength !== u8.byteLength) throw new Error('wrong length'); "
-      "for (let n = 0; n < u8.byteLength; n++) { "
-      "  if (u8[n] !== other[n]) throw new Error('wrong value'); "
-      "} "
-      "true;",
       "boolean",
       "true");
 }

--- a/src/workerd/jsg/buffersource.c++
+++ b/src/workerd/jsg/buffersource.c++
@@ -82,17 +82,6 @@ bool BackingStore::operator==(const BackingStore& other) {
          byteOffset == other.byteOffset;
 }
 
-BackingStore BackingStore::clone(Lock& js) {
-  auto newBacking = BackingStore::alloc(js, byteLength);
-  auto src = asArrayPtr();
-  newBacking.elementSize = elementSize;
-  newBacking.ctor = ctor;
-  newBacking.integerType = integerType;
-  auto dest = newBacking.asArrayPtr();
-  std::copy(src.begin(), src.end(), dest.begin());
-  return newBacking;
-}
-
 BufferSource::BufferSource(Lock& js, v8::Local<v8::Value> handle)
     : handle(js.v8Ref(handle)),
       maybeBackingStore(BackingStore(
@@ -126,14 +115,6 @@ BackingStore BufferSource::detach(Lock& js) {
   buffer->Detach();
 
   return kj::mv(backingStore);
-}
-
-BackingStore BufferSource::cloneBackingStore(Lock& js) {
-  auto& backingStore =
-      JSG_REQUIRE_NONNULL(maybeBackingStore,
-                          TypeError,
-                          "This BufferSource has been detached.");
-  return backingStore.clone(js);
 }
 
 bool BufferSource::canDetach(Lock& js) {

--- a/src/workerd/jsg/buffersource.h
+++ b/src/workerd/jsg/buffersource.h
@@ -190,9 +190,6 @@ public:
     byteLength -= bytes;
   }
 
-  BackingStore clone(Lock& js);
-  // Copy this backing store.
-
 private:
   std::shared_ptr<v8::BackingStore> backingStore;
   size_t byteLength;
@@ -288,14 +285,9 @@ public:
   BackingStore detach(Lock& js);
   // Removes the BackingStore from the BufferSource and severs its connection to
   // the ArrayBuffer/ArrayBufferView handle.
-  // It's worth mentioning that detach can throw application-visible exceptions
+  // It's worth mentioning that detach wcan throw application-visible exceptions
   // in the case the ArrayBuffer cannot be detached. Any detaching should be
-  // performed as early as possible in an API method implementation.
-
-  BackingStore cloneBackingStore(Lock& js);
-  // Copies the underlying backing store into a new instance.
-  // An application-visible exception can be thrown if the BufferSource was
-  // already detached.
+  // performance as early as possible in an API method implementation.
 
   v8::Local<v8::Value> getHandle(Lock& js);
 


### PR DESCRIPTION
Reverts cloudflare/workerd#309

This change was merged prematurely, the team hasn't reached consensus on this approach. Some possible concerns:

* What is the performance impact of copying? Is it worth the cost to force copying on existing users?
* Is detaching ArrayBuffers a good API? Will it possibly confuse people who are trying to pass the same ArrayBuffer to multiple calls?

It's possible we'll re-land this exactly the same once we've talked this through.