### PR TITLE
Implement headers.getSetCookie()

### DIFF
--- a/src/workerd/api/form-data.c++
+++ b/src/workerd/api/form-data.c++
@@ -389,15 +389,21 @@ void FormData::set(kj::String name,
   }
 }
 
-jsg::Ref<FormData::EntryIterator> FormData::entries(jsg::Lock&) {
+jsg::Ref<FormData::EntryIterator> FormData::entries(
+    jsg::Lock&,
+    CompatibilityFlags::Reader featureFlags) {
   return jsg::alloc<EntryIterator>(IteratorState { JSG_THIS });
 }
 
-jsg::Ref<FormData::KeyIterator> FormData::keys(jsg::Lock&) {
+jsg::Ref<FormData::KeyIterator> FormData::keys(
+    jsg::Lock&,
+    CompatibilityFlags::Reader featureFlags) {
   return jsg::alloc<KeyIterator>(IteratorState { JSG_THIS });
 }
 
-jsg::Ref<FormData::ValueIterator> FormData::values(jsg::Lock&) {
+jsg::Ref<FormData::ValueIterator> FormData::values(
+    jsg::Lock&,
+    CompatibilityFlags::Reader featureFlags) {
   return jsg::alloc<ValueIterator>(IteratorState { JSG_THIS });
 }
 

--- a/src/workerd/api/form-data.h
+++ b/src/workerd/api/form-data.h
@@ -8,6 +8,7 @@
 #include <kj/compat/url.h>
 #include <workerd/jsg/jsg.h>
 #include "blob.h"
+#include <workerd/io/compatibility-date.capnp.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/url-standard.c++
+++ b/src/workerd/api/url-standard.c++
@@ -2006,15 +2006,21 @@ void URLSearchParams::sort() {
   update();
 }
 
-jsg::Ref<URLSearchParams::EntryIterator> URLSearchParams::entries(jsg::Lock&) {
+jsg::Ref<URLSearchParams::EntryIterator> URLSearchParams::entries(
+    jsg::Lock&,
+    CompatibilityFlags::Reader featureFlags) {
   return jsg::alloc<URLSearchParams::EntryIterator>(IteratorState { JSG_THIS });
 }
 
-jsg::Ref<URLSearchParams::KeyIterator> URLSearchParams::keys(jsg::Lock&) {
+jsg::Ref<URLSearchParams::KeyIterator> URLSearchParams::keys(
+    jsg::Lock&,
+    CompatibilityFlags::Reader featureFlags) {
   return jsg::alloc<URLSearchParams::KeyIterator>(IteratorState { JSG_THIS });
 }
 
-jsg::Ref<URLSearchParams::ValueIterator> URLSearchParams::values(jsg::Lock&) {
+jsg::Ref<URLSearchParams::ValueIterator> URLSearchParams::values(
+    jsg::Lock&,
+    CompatibilityFlags::Reader featureFlags) {
   return jsg::alloc<URLSearchParams::ValueIterator>(IteratorState { JSG_THIS });
 }
 

--- a/src/workerd/api/url-standard.h
+++ b/src/workerd/api/url-standard.h
@@ -8,6 +8,7 @@
 #include "form-data.h"
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/string.h>
+#include <workerd/io/compatibility-date.capnp.h>
 
 namespace workerd::api {
   // The original URL implementation based on kj::Url is not compliant with the

--- a/src/workerd/api/url.c++
+++ b/src/workerd/api/url.c++
@@ -611,15 +611,21 @@ void URLSearchParams::forEach(
   }
 }
 
-jsg::Ref<URLSearchParams::EntryIterator> URLSearchParams::entries(jsg::Lock&) {
+jsg::Ref<URLSearchParams::EntryIterator> URLSearchParams::entries(
+    jsg::Lock&,
+    CompatibilityFlags::Reader featureFlags) {
   return jsg::alloc<EntryIterator>(IteratorState { JSG_THIS });
 }
 
-jsg::Ref<URLSearchParams::KeyIterator> URLSearchParams::keys(jsg::Lock&) {
+jsg::Ref<URLSearchParams::KeyIterator> URLSearchParams::keys(
+    jsg::Lock&,
+    CompatibilityFlags::Reader featureFlags) {
   return jsg::alloc<KeyIterator>(IteratorState { JSG_THIS });
 }
 
-jsg::Ref<URLSearchParams::ValueIterator> URLSearchParams::values(jsg::Lock&) {
+jsg::Ref<URLSearchParams::ValueIterator> URLSearchParams::values(
+    jsg::Lock&,
+    CompatibilityFlags::Reader featureFlags) {
   return jsg::alloc<ValueIterator>(IteratorState { JSG_THIS });
 }
 

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -274,4 +274,11 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $experimental;
   # Experimental, allows getting a durable object stub that ensures the object already exists.
   # This is currently a work in progress mechanism that is not yet available for use in workerd.
+
+  httpHeadersGetSetCookie @26 :Bool
+      $compatEnableFlag("http_headers_getsetcookie")
+      $compatDisableFlag("no_http_headers_getsetcookie")
+      $compatEnableDate("2023-03-01");
+  # Enables the new headers.getSetCookie() API and the corresponding changes in behavior for
+  # the Header objects keys() and entries() iterators.
 }

--- a/src/workerd/jsg/iterator.h
+++ b/src/workerd/jsg/iterator.h
@@ -921,7 +921,7 @@ private:
       JSG_ITERABLE(self);                                                                      \
     }                                                                                           \
   };                                                                                            \
-  jsg::Ref<Name> Label(jsg::Lock&);
+  jsg::Ref<Name> Label(jsg::Lock&, CompatibilityFlags::Reader featureFlags);
 // The JSG_ITERATOR macro provides a mechanism for easily implementing JavaScript-style iterators
 // for JSG_RESOURCE_TYPES.
 //


### PR DESCRIPTION
Implementation of the proposed `headers.getSetCookie()` API

~~The API is still not 100% finished so we likely don't want to land just yet. Deno folks have asked (through wintercg) if we could coordinate on the release of this so that it hits multiple runtimes at the same time, allowing us to get a bit more of a bang-for-the-buck announcing the common API.~~ The spec change has landed, this should be just about ready to go.

~~Note: this is *potentially* a breaking change due to the change in the way the iterator is handled. Previously, our iterator would inappropriate munge `set-cookie` headers together. This change separates them properly for both `entries()` and `values()`. Do we need a compatibility flag tor this behavior change?~~ Added a compatibility flag

Refs: https://github.com/whatwg/fetch/pull/1346