### PR TITLE
Add experimental `getExisting` method to DurableObjectNamespace

### DIFF
--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -143,14 +143,24 @@ public:
       CompatibilityFlags::Reader featureFlags);
   // Gets a durable object by ID or creates it if it doesn't already exist.
 
+  jsg::Ref<DurableObject> getExisting(
+      jsg::Ref<DurableObjectId> id,
+      jsg::Optional<GetDurableObjectOptions> options,
+      CompatibilityFlags::Reader featureFlags);
+  // Experimental. Gets a durable object by ID if it already exists. Currently, gated for use
+  // by cloudflare only.
+
   jsg::Ref<DurableObjectNamespace> jurisdiction(kj::String jurisdiction);
   // Creates a subnamespace with the jurisdiction hardcoded.
 
-  JSG_RESOURCE_TYPE(DurableObjectNamespace) {
+  JSG_RESOURCE_TYPE(DurableObjectNamespace, CompatibilityFlags::Reader flags) {
     JSG_METHOD(newUniqueId);
     JSG_METHOD(idFromName);
     JSG_METHOD(idFromString);
     JSG_METHOD(get);
+    if (flags.getDurableObjectGetExisting()) {
+      JSG_METHOD(getExisting);
+    }
     JSG_METHOD(jurisdiction);
     JSG_TS_ROOT();
   }
@@ -158,6 +168,12 @@ public:
 private:
   uint channel;
   kj::Own<ActorIdFactory> idFactory;
+
+  jsg::Ref<DurableObject> getImpl(
+      ActorGetMode mode,
+      jsg::Ref<DurableObjectId> id,
+      jsg::Optional<GetDurableObjectOptions> options,
+      CompatibilityFlags::Reader featureFlags);
 };
 
 #define EW_ACTOR_ISOLATE_TYPES                      \

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -268,4 +268,10 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # development. Don't use this for backwards-incompatible changes; give them their own flag.
   # WARNING: Any feature blocked by this flag is subject to change at any time, including
   # removal. Do not ignore this warning.
+
+  durableObjectGetExisting @25 :Bool
+      $compatEnableFlag("durable_object_get_existing")
+      $experimental;
+  # Experimental, allows getting a durable object stub that ensures the object already exists.
+  # This is currently a work in progress mechanism that is not yet available for use in workerd.
 }

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -50,6 +50,16 @@ public:
   // not implement any spectre mitigations.
 };
 
+enum class ActorGetMode {
+  // Behavior mode for getting an actor
+
+  GET_OR_CREATE,
+  // Creates the actor if it does not already exist, otherwise gets the existing actor.
+
+  GET_EXISTING
+  // Get an already-created actor, throwing an error if it does not exist.
+};
+
 class ActorIdFactory {
   // An abstract class that implements generation of global actor IDs in a particular namespace.
   //
@@ -177,7 +187,7 @@ public:
   };
 
   virtual kj::Own<ActorChannel> getGlobalActor(uint channel, const ActorIdFactory::ActorId& id,
-      kj::Maybe<kj::String> locationHint) = 0;
+      kj::Maybe<kj::String> locationHint, ActorGetMode mode) = 0;
   // Get an actor stub from the given namespace for the actor with the given ID.
   //
   // `id` must have been constructed using one of the `ActorIdFactory` instances corresponding to

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -794,8 +794,9 @@ public:
   }
 
   kj::Own<IoChannelFactory::ActorChannel> getGlobalActorChannel(
-        uint channel, const ActorIdFactory::ActorId& id, kj::Maybe<kj::String> locationHint) {
-    return getIoChannelFactory().getGlobalActor(channel, id, kj::mv(locationHint));
+        uint channel, const ActorIdFactory::ActorId& id, kj::Maybe<kj::String> locationHint,
+        ActorGetMode mode) {
+    return getIoChannelFactory().getGlobalActor(channel, id, kj::mv(locationHint), mode);
   }
   kj::Own<IoChannelFactory::ActorChannel> getColoLocalActorChannel(uint channel, kj::StringPtr id) {
     return getIoChannelFactory().getColoLocalActor(channel, id);

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1414,7 +1414,9 @@ private:
   }
 
   kj::Own<ActorChannel> getGlobalActor(uint channel, const ActorIdFactory::ActorId& id,
-      kj::Maybe<kj::String> locationHint) override {
+      kj::Maybe<kj::String> locationHint, ActorGetMode mode) override {
+    JSG_REQUIRE(mode == ActorGetMode::GET_OR_CREATE, Error,
+        "workerd only supports GET_OR_CREATE mode for getting actor stubs");
     auto& channels = KJ_REQUIRE_NONNULL(ioChannels.tryGet<LinkedIoChannels>(),
         "link() has not been called");
 

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -75,7 +75,7 @@ struct DummyIoChannelFactory final: public IoChannelFactory {
   }
 
   kj::Own<ActorChannel> getGlobalActor(uint channel, const ActorIdFactory::ActorId& id,
-      kj::Maybe<kj::String> locationHint) override {
+      kj::Maybe<kj::String> locationHint, ActorGetMode mode) override {
     KJ_FAIL_REQUIRE("no actor channels");
   }
 


### PR DESCRIPTION
Right now this isn't implemented in workerd's ActorChannel, as this is an internal-only experimental method.

Still need to add a commit to hide `getExisting` from being generated by workers-types

@MellowYarker as primary reviewer