### PR TITLE
Add workerd:compatibility-flags internal built-in module

### DIFF
--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -1,21 +1,44 @@
 #pragma once
 
 #include "async-hooks.h"
+#include <workerd/jsg/jsg.h>
 #include <workerd/jsg/modules.h>
+#include <capnp/dynamic.h>
 #include <node/bundle.capnp.h>
 
 namespace workerd::api::node {
 
+class CompatibilityFlags : public jsg::Object {
+  // To be exposed only as an internal module for use by other built-ins.
+  // TODO(later): Consider moving out of node.h when needed for other
+  // built-ins
+public:
+  JSG_RESOURCE_TYPE(CompatibilityFlags, workerd::CompatibilityFlags::Reader flags) {
+    // Not your typical JSG_RESOURCE_TYPE definition.. here we are iterating
+    // through all of the compatibility flags and registering each as read-only
+    // literal values on the instance...
+    auto dynamic = capnp::toDynamic(flags);
+    auto schema = dynamic.getSchema();
+    for (auto field : schema.getFields()) {
+      registry.template registerReadonlyInstanceProperty<bool>(
+          field.getProto().getName(),
+          dynamic.get(field).as<bool>());
+    }
+  }
+};
+
 template <typename TypeWrapper>
 void registerNodeJsCompatModules(
     workerd::jsg::ModuleRegistryImpl<TypeWrapper>& registry, auto featureFlags) {
+  registry.template addBuiltinModule<CompatibilityFlags>("workerd:compatibility-flags",
+      workerd::jsg::ModuleRegistry::Type::INTERNAL);
   registry.template addBuiltinModule<AsyncHooksModule>("node-internal:async_hooks",
       workerd::jsg::ModuleRegistry::Type::INTERNAL);
-
   registry.addBuiltinBundle(NODE_BUNDLE);
 }
 
-#define EW_NODE_ISOLATE_TYPES \
+#define EW_NODE_ISOLATE_TYPES      \
+  api::node::CompatibilityFlags,   \
   EW_NODE_ASYNCHOOKS_ISOLATE_TYPES
 
 }  // namespace workerd::api::node

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -759,6 +759,13 @@ struct ResourceTypeBuilder {
                             v8::PropertyAttribute::ReadOnly | v8::PropertyAttribute::DontEnum));
   }
 
+  template<typename T>
+  inline void registerReadonlyInstanceProperty(kj::StringPtr name, T value) {
+    auto v8Name = v8StrIntern(isolate, name);
+    auto v8Value = typeWrapper.wrap(isolate, nullptr, kj::mv(value));
+    instance->Set(v8Name, v8Value, v8::PropertyAttribute::ReadOnly);
+  }
+
   template<const char* name, typename Getter, Getter getter>
   inline void registerReadonlyPrototypeProperty() {
     using Gcb = GetterCallback<TypeWrapper, name, Getter, getter, isContext>;
@@ -795,7 +802,7 @@ struct ResourceTypeBuilder {
     // The main difference between this and a read-only property is that a static constant has no
     // getter but is simply a primitive value set at constructor creation time.
 
-    auto v8Name = v8Str(isolate, name, v8::NewStringType::kInternalized);
+    auto v8Name = v8StrIntern(isolate, name);
     auto v8Value = typeWrapper.wrap(isolate, nullptr, kj::mv(value));
 
     constructor->Set(v8Name, v8Value, v8::PropertyAttribute::ReadOnly);

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -505,6 +505,9 @@ struct MemberCounter {
   template<const char* name, typename Getter, Getter getter>
   inline void registerReadonlyInstanceProperty() { ++count; }
 
+  template<typename T>
+  inline void registerReadonlyInstanceProperty(kj::StringPtr, T value) { ++count; }
+
   template<const char* name, typename Getter, Getter getter, typename Setter, Setter setter>
   inline void registerInstanceProperty() { ++count; }
 
@@ -572,6 +575,14 @@ struct MembersBuilder {
     prop.setReadonly(true);
     using GetterTraits = FunctionTraits<Getter>;
     BuildRtti<Configuration, typename GetterTraits::ReturnType>::build(prop.initType(), rtti);
+  }
+
+  template<typename T>
+  inline void registerReadonlyInstanceProperty(kj::StringPtr name, T value) {
+    auto prop = members[index++].initProperty();
+    prop.setName(name);
+    prop.setReadonly(true);
+    BuildRtti<Configuration, T>::build(prop.initType(), rtti);
   }
 
   template<const char* name, typename Getter, Getter getter, bool readOnly>


### PR DESCRIPTION
For use only by built-in TypeScript modules, this provides an import that gives information on the currently set compatibility flags.

e.g.

```
import { default as flags } from 'worker:compatibility-flags';
console.log(flags.nodeJsCompat); // true|false
```

The flags are set as readonly booleans on the export.

Note that this does introduce an issue if we rename any of the compatibility flags. Right now renaming will cause a compile error in the native code because the `getWhatever` method names will change. However, we won't get errors during compile for the typescript side unless we also someone automatically generate a ts.d for this built-in from the capnp definitions.