### PR TITLE
Allow workerd inspector client to be fully trusted

### DIFF
--- a/src/workerd/io/cdp.capnp
+++ b/src/workerd/io/cdp.capnp
@@ -337,14 +337,6 @@ struct Profiler {
 
 struct HeapProfiler {
   struct Command {
-    struct Enable {
-      struct Params {}
-      struct Result {}
-    }
-    struct Disable {
-      struct Params {}
-      struct Result {}
-    }
     struct TakeHeapSnapshot {
       struct Params {
         reportProgress @0 : Bool;
@@ -391,9 +383,7 @@ struct Command $Json.discriminator(name = "method") {
     profilerEnable @6 :Method(Profiler.Command.Enable.Params, Profiler.Command.Enable.Result) $Json.name("Profiler.enable") $Json.flatten();
     profilerStart @7 :Method(Profiler.Command.Start.Params, Profiler.Command.Start.Result) $Json.name("Profiler.start") $Json.flatten();
     profilerStop @8 :Method(Profiler.Command.Stop.Params, Profiler.Command.Stop.Result) $Json.name("Profiler.stop") $Json.flatten();
-    heapProfilerEnable @9 : Method(HeapProfiler.Command.Enable.Params, HeapProfiler.Command.Enable.Result) $Json.name("HeapProfiler.enable") $Json.flatten();
-    heapProfilerDisable @10 : Method(HeapProfiler.Command.Enable.Params, HeapProfiler.Command.Disable.Result) $Json.name("HeapProfiler.disable") $Json.flatten();
-    takeHeapSnapshot @11 : Method(HeapProfiler.Command.TakeHeapSnapshot.Params, HeapProfiler.Command.TakeHeapSnapshot.Result) $Json.name("HeapProfiler.takeHeapSnapshot") $Json.flatten();
+    takeHeapSnapshot @9 : Method(HeapProfiler.Command.TakeHeapSnapshot.Params, HeapProfiler.Command.TakeHeapSnapshot.Result) $Json.name("HeapProfiler.takeHeapSnapshot") $Json.flatten();
   }
 }
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -236,11 +236,18 @@ class Worker::Isolate: public kj::AtomicRefcounted {
   // destructed soon.
 
 public:
+  enum class InspectorPolicy {
+    // Determines whether a devtools inspector client can be attached.
+    DISALLOW,
+    ALLOW_UNTRUSTED,
+    ALLOW_FULLY_TRUSTED,
+  };
+
   explicit Isolate(kj::Own<ApiIsolate> apiIsolate,
                    kj::Own<IsolateObserver>&& metrics,
                    kj::StringPtr id,
                    kj::Own<IsolateLimitEnforcer> limitEnforcer,
-                   bool allowInspector);
+                   InspectorPolicy inspectorPolicy);
   // Creates an isolate with the given ID. The ID only matters for metrics-reporting purposes.
   // Usually it matches the script ID. An exception is preview isolates: there, each preview
   // session has one isolate which may load many iterations of the script (this allows the

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1563,7 +1563,10 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
       kj::atomicRefcounted<IsolateObserver>(),
       name,
       kj::mv(limitEnforcer),
-      maybeInspectorService != nullptr);
+      // For workerd, if the inspector is enabled, it is always fully trusted.
+      maybeInspectorService != nullptr ?
+          Worker::Isolate::InspectorPolicy::ALLOW_FULLY_TRUSTED :
+          Worker::Isolate::InspectorPolicy::DISALLOW);
 
   // If we are using the inspector, we need to register the Worker::Isolate
   // with the inspector service.

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -264,7 +264,7 @@ TestFixture::TestFixture(SetupParams params)
       kj::atomicRefcounted<IsolateObserver>(),
       scriptId,
       kj::mv(isolateLimitEnforcer),
-      false)),
+      Worker::Isolate::InspectorPolicy::DISALLOW)),
     workerScript(kj::atomicRefcounted<Worker::Script>(
       kj::atomicAddRef(*workerIsolate),
       scriptId,


### PR DESCRIPTION
Allows a workerd inspector client to be fully trusted, enabling a greater range of devtools capabilities (including memory profiling and timeline)