### PR TITLE
Adopt proposed new Node.js AsyncLocalStorage apis to replace AsyncResource use cases

### DIFF
--- a/src/workerd/api/node/async-hooks.c++
+++ b/src/workerd/api/node/async-hooks.c++
@@ -57,6 +57,18 @@ v8::Local<v8::Value> AsyncLocalStorage::getStore(jsg::Lock& js) {
   return v8::Undefined(js.v8Isolate);
 }
 
+v8::Local<v8::Function> AsyncLocalStorage::bind(jsg::Lock& js, v8::Local<v8::Function> fn) {
+  KJ_IF_MAYBE(frame, jsg::AsyncContextFrame::current(js)) {
+    return frame->wrap(js, fn);
+  } else {
+    return jsg::AsyncContextFrame::wrapRoot(js, fn);
+  }
+}
+
+v8::Local<v8::Function> AsyncLocalStorage::snapshot(jsg::Lock& js) {
+  return jsg::AsyncContextFrame::wrapSnapshot(js);
+}
+
 namespace {
 kj::Maybe<jsg::Ref<jsg::AsyncContextFrame>> tryGetFrameRef(jsg::Lock& js) {
   return jsg::AsyncContextFrame::current(js).map(

--- a/src/workerd/jsg/async-context.h
+++ b/src/workerd/jsg/async-context.h
@@ -125,6 +125,11 @@ public:
   // Wraps the given JavaScript function such that whenever the wrapper function is called,
   // the root AsyncContextFrame will be entered.
 
+  static v8::Local<v8::Function> wrapSnapshot(Lock& js);
+  // Returns a function that captures the current frame and calls the function passed
+  // in as an argument within that captured context. Equivalent to wrapping a function
+  // with the signature (cb, ...args) => cb(...args).
+
   v8::Local<v8::Function> wrap(
       Lock& js, V8Ref<v8::Function>& fn,
       kj::Maybe<v8::Local<v8::Value>> thisArg = nullptr);


### PR DESCRIPTION
Additions to AsyncLocalStorage in Node.js that serve a dual purpose:

1. They align the API closer to the expected AsyncContext.wrap api (AsyncLocalStorage.bind == AsyncContext.wrap). It uses the existing naming from AsyncResource for consistency with the existing API.
2. They eliminate the need to use AsyncResource. We will keep AsyncResource for backwards compatibility as part of the larger Node.js compat story, but these cover all of the key use cases of AsyncResource for context tracking.

The TC-39 `AsyncContext` proposal is expected to include `AsyncContext.wrap(...)` (which is the same as `AsyncLocalStorage.bind(...)` and some version of a `AsyncContext.snapshot()` (naming still to be determined).

Refs: https://github.com/nodejs/node/pull/46387

```js
// The AsyncResource use case...
class Foo extends AsyncResource {
  constructor() { super('foo'); }
  bar() { this.runInAsyncScope(() => {});
}

// is replaced by

class Foo {
  #runInAsyncScope = AsyncLocalStorage.snapshot();
  bar() { this.#runInAsyncScope(() => {});
}

// The AsyncResource use case...
const foo = AsyncResource.bind(() => {});

// is replaced by
const foo = AsyncLocalStorage.bind(() => {})
```
