### PR TITLE
Take Worker::Lock by reference when constructing a Worker::Actor

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2666,11 +2666,10 @@ kj::Promise<Worker::AsyncLock> Worker::takeAsyncLockWhenActorCacheReady(
 
 Worker::Actor::Actor(const Worker& worker, Actor::Id actorId,
     bool hasTransient, kj::Maybe<rpc::ActorStorage::Stage::Client> persistent,
-    kj::Maybe<kj::StringPtr> className, MakeStorageFunc makeStorage, LockType lockType,
+    kj::Maybe<kj::StringPtr> className, MakeStorageFunc makeStorage, Worker::Lock& lock,
     TimerChannel& timerChannel,
     kj::Own<ActorObserver> metrics)
     : worker(kj::atomicAddRef(worker)) {
-  Worker::Lock lock(worker, lockType);
   impl = kj::heap<Impl>(*this, lock, kj::mv(actorId), hasTransient, kj::mv(persistent),
                         kj::mv(makeStorage), timerChannel, kj::mv(metrics));
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -630,7 +630,7 @@ public:
 
   Actor(const Worker& worker, Id actorId,
         bool hasTransient, kj::Maybe<rpc::ActorStorage::Stage::Client> persistent,
-        kj::Maybe<kj::StringPtr> className, MakeStorageFunc makeStorage, LockType lockType,
+        kj::Maybe<kj::StringPtr> className, MakeStorageFunc makeStorage, Worker::Lock& lock,
         TimerChannel& timerChannel, kj::Own<ActorObserver> metrics);
   // Create a new Actor hosted by this Worker. Note that this Actor object may only be manipulated
   // from the thread that created it.

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1200,8 +1200,8 @@ public:
       // lock and take a lock on the target isolate before constructing the actor. Even if these
       // are the same isolate (as is commonly the case), we really don't want to do this stuff
       // synchronously, so this has the effect of pushing off to a later turn of the event loop.
-      auto promise = service.worker->takeAsyncLockWithoutRequest(nullptr)
-          .then([this, id = kj::mv(id)](Worker::AsyncLock lock) mutable -> kj::Own<ActorChannel> {
+      auto promise = service.worker->takeAsyncLockWithoutRequest(nullptr).then(
+          [this, id = kj::mv(id)](Worker::AsyncLock asyncLock) mutable -> kj::Own<ActorChannel> {
         kj::String idStr;
         KJ_SWITCH_ONEOF(id) {
           KJ_CASE_ONEOF(obj, kj::Own<ActorIdFactory::ActorId>) {
@@ -1228,6 +1228,8 @@ public:
           };
 
           TimerChannel& timerChannel = service;
+
+          Worker::Lock lock(*service.worker, asyncLock);
           auto newActor = kj::refcounted<Worker::Actor>(
               *service.worker, kj::mv(id), true, kj::mv(persistent),
               className, kj::mv(makeStorage), lock,


### PR DESCRIPTION
Since we may want to make the components (notably ActorObserver) separately, it turns out that we want to take the lock slightly before constructing the Worker::Actor.