### PR TITLE
Optimize single-batch delete flushes in ActorCache

### DIFF
--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -617,6 +617,7 @@ private:
   };
   using CountedDeleteFlushes = kj::Array<CountedDeleteFlush>;
   kj::Promise<void> flushImplUsingSinglePut(PutFlush putFlush);
+  kj::Promise<void> flushImplUsingSingleDelete(MutedDeleteFlush mutedFlush);
   kj::Promise<void> flushImplAlarmOnly(DirtyAlarm dirty);
   kj::Promise<void> flushImplUsingTxn(
       PutFlush putFlush, MutedDeleteFlush mutedDeleteFlush,

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -617,7 +617,8 @@ private:
   };
   using CountedDeleteFlushes = kj::Array<CountedDeleteFlush>;
   kj::Promise<void> flushImplUsingSinglePut(PutFlush putFlush);
-  kj::Promise<void> flushImplUsingSingleDelete(MutedDeleteFlush mutedFlush);
+  kj::Promise<void> flushImplUsingSingleMutedDelete(MutedDeleteFlush mutedFlush);
+  kj::Promise<void> flushImplUsingSingleCountedDelete(CountedDeleteFlush countedFlush);
   kj::Promise<void> flushImplAlarmOnly(DirtyAlarm dirty);
   kj::Promise<void> flushImplUsingTxn(
       PutFlush putFlush, MutedDeleteFlush mutedDeleteFlush,


### PR DESCRIPTION
This is just doing the same thing for deletes (both muted and batch) that we already do for puts and alarm writes. Sorry for letting this sit for so long without finishing it up (especially since deletes should benefit the most from not needing transactions due to a quirk within cockroach transaction pipelining).