### PR TITLE
[WIP] Add hibernatable websocket sub-state to `api::WebSocket`

### DIFF
--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -557,6 +557,10 @@ kj::Maybe<kj::StringPtr> WebSocket::getExtensions() {
   return extensions.map([](kj::StringPtr value){ return value; });
 }
 
+kj::Maybe<v8::Local<v8::Value>> WebSocket::getAttachment() {
+  return attachment.map([](v8::Local<v8::Value>& value){ return value; });
+}
+
 void WebSocket::dispatchOpen(jsg::Lock& js) {
   dispatchEventImpl(js, jsg::alloc<Event>("open"));
 }

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -212,10 +212,16 @@ public:
   // We need to access the underlying KJ WebSocket so we can determine the compression configuration
   // it uses (if any).
 
+  kj::Maybe<v8::Local<v8::Value>> attachment;
+  // All WebSockets have this property. It starts out null but can
+  // be assigned to any serializable value. The property will
+  // survive hibernation.
+
 
   kj::Maybe<kj::StringPtr> getUrl();
   kj::Maybe<kj::StringPtr> getProtocol();
   kj::Maybe<kj::StringPtr> getExtensions();
+  kj::Maybe<v8::Local<v8::Value>> getAttachment();
 
   JSG_RESOURCE_TYPE(WebSocket, CompatibilityFlags::Reader flags) {
     JSG_INHERIT(EventTarget);
@@ -237,11 +243,13 @@ public:
       JSG_READONLY_PROTOTYPE_PROPERTY(url, getUrl);
       JSG_READONLY_PROTOTYPE_PROPERTY(protocol, getProtocol);
       JSG_READONLY_PROTOTYPE_PROPERTY(extensions, getExtensions);
+      JSG_READONLY_PROTOTYPE_PROPERTY(attachment, getAttachment);
     } else {
       JSG_READONLY_INSTANCE_PROPERTY(readyState, getReadyState);
       JSG_READONLY_INSTANCE_PROPERTY(url, getUrl);
       JSG_READONLY_INSTANCE_PROPERTY(protocol, getProtocol);
       JSG_READONLY_INSTANCE_PROPERTY(extensions, getExtensions);
+      JSG_READONLY_INSTANCE_PROPERTY(attachment, getAttachment);
     }
 
     JSG_TS_DEFINE(type WebSocketEventMap = {

--- a/src/workerd/io/hibernation-manager.c++
+++ b/src/workerd/io/hibernation-manager.c++
@@ -1,0 +1,165 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "io-context.h"
+#include <workerd/io/hibernation-manager.h>
+
+namespace workerd {
+
+HibernationManagerImpl::~HibernationManagerImpl() {
+  // Note that the HibernatableWebSocket destructor handles removing any references to itself in
+  // `tagToWs`, and even removes the hashmap entry if there are no more entries in the bucket.
+  allWs.clear();
+  KJ_ASSERT(tagToWs.size() == 0, "tagToWs hashmap wasn't cleared.");
+  KJ_ASSERT(allWs.size() == 0 && allWs.empty(), "allWs collection wasn't cleared.");
+}
+
+void HibernationManagerImpl::acceptWebSocket(jsg::Ref<api::WebSocket> ws,
+    kj::ArrayPtr<kj::String> tags) {
+  // First, we create the HibernatableWebSocket and add it to the collection where it'll stay
+  // until it's destroyed.
+  auto hib = kj::heap<HibernatableWebSocket>(kj::mv(ws), tags, countOfAcceptedWebSockets++, *this);
+  HibernatableWebSocket& refToHibernatable = *hib.get();
+  auto node = kj::heap<kj::Node<HibernatableWebSocket>>(kj::mv(hib));
+  refToHibernatable.node = *node.get();
+  allWs.addFront(kj::mv(node));
+
+  // Next, we add the HibernatableWebSocket to each bucket in `tagToWs` corresponding to its tags.
+  // The process looks like:
+  //  1. Create the entry if it doesn't exist
+  //  2. Fill the TagListItem in the HibernatableWebSocket's tagItems array
+  //  3. Initiate the readLoop.
+  size_t position = 0;
+  for (auto tag = tags.begin(); tag < tags.end(); tag++, position++) {
+    auto& tagCollection = tagToWs.findOrCreate(*tag, [&tag]() {
+      auto item = kj::heap<TagCollection>(
+          kj::mv(*tag), kj::heap<kj::List<TagListItem, &TagListItem::link>>());
+      return decltype(tagToWs)::Entry {
+          item->tag,
+          kj::mv(item)
+      };
+    });
+    // This TagListItem sits in the HibernatableWebSocket's tagItems array.
+    auto& tagListItem = refToHibernatable.tagItems[position];
+    tagListItem.hibWS = refToHibernatable;
+    tagListItem.tag = tagCollection->tag.asPtr();
+
+    auto& list = tagCollection->list;
+    list->add(tagListItem);
+    // We also give the TagListItem a reference to the list it was added to so the
+    // HibernatableWebSocket can quickly remove itself from the list without doing a lookup
+    // in `tagToWs`.
+    tagListItem.list = *list.get();
+  }
+
+  // Now that we've populated `tagToWs`, start the readloop for this HibernatableWebSocket.
+  kj::Promise<kj::Maybe<kj::Exception>> readLoopPromise = kj::evalNow([&] {
+    return readLoop(refToHibernatable);
+  }).then([]() -> kj::Maybe<kj::Exception> { return nullptr; },
+          [](kj::Exception&& e) -> kj::Maybe<kj::Exception> { return kj::mv(e); });
+
+  // Give the task to the HibernationManager so it lives long.
+  readLoopTasks.add(readLoopPromise.then(
+      [&refToHibernatable, this](kj::Maybe<kj::Exception>&& e) {
+    // We've disconnected cleanly, let's remove from our collections.
+    //
+    // TODO(now): We need to take the code in the api::WebSocket readLoop (that sets it to released)
+    //            and do the same stuff here. Technically, if the object is loaded in JS it
+    //            can still be used even after we drop our ref in the HibernationManager,
+    //            so we need to set it to Released, and do whatever else.
+    //
+    //    Since we don't have access to the relevant properties of api::WebSocket, we should
+    //    instead turn it into a public method.
+    return dropHibernatableWebSocket(refToHibernatable);
+  }, [](kj::Exception&& e) {
+    // TODO(now): We've disconnected in an unclean way?
+    return kj::mv(e);
+  }));
+}
+
+kj::Vector<jsg::Ref<api::WebSocket>> HibernationManagerImpl::getWebSockets(
+    jsg::Lock& js,
+    kj::StringPtr tag) {
+  kj::Vector<jsg::Ref<api::WebSocket>> matches;
+  KJ_IF_MAYBE(item, tagToWs.find(tag)) {
+    auto& list = *((*item)->list);
+    for (auto& entry: list) {
+      auto& hibWS = KJ_REQUIRE_NONNULL(entry.hibWS);
+      // If the websocket is hibernating, we have to create an api::WebSocket
+      // and add it to the HibernatableWebSocket.
+      if (hibWS.activeWebSocket == nullptr) {
+        // Note that we read the `attachment`, and in the process of doing so we will
+        // deserialize the value so it can be accessed and modified in JS code.
+        hibWS.activeWebSocket.emplace(
+            api::WebSocket::unhibernate(js, *hibWS.ws, hibWS.attachment, hibWS.url,
+                                        hibWS.protocol, hibWS.extensions));
+      }
+      // Now that we know the websocket is "awake", we simply add it to the vector.
+      KJ_IF_MAYBE(awake, hibWS.activeWebSocket) {
+        matches.add(awake->addRef());
+      }
+    }
+  };
+  return kj::mv(matches);
+}
+
+kj::Array<kj::byte> HibernationManagerImpl::serializeV8Value(
+    v8::Local<v8::Value> value,
+    v8::Isolate* isolate) {
+  jsg::Serializer serializer(isolate, jsg::Serializer::Options {
+    .version = 15,
+    .omitHeader = false,
+  });
+  serializer.write(value);
+  auto released = serializer.release();
+  return kj::mv(released.data);
+}
+
+void HibernationManagerImpl::hibernateWebSockets(
+    jsg::Lock& js,
+    v8::Isolate* isolate,
+    IoContext& context) {
+
+  for (auto& ws : allWs) {
+    KJ_IF_MAYBE(active, ws.activeWebSocket) {
+      // We need to serialize the attachment before hibernating.
+      KJ_IF_MAYBE(attachment, active->get()->getAttachment()) {
+        ws.attachment = serializeV8Value(*attachment, isolate);
+      }
+    }
+    ws.activeWebSocket = nullptr;
+  }
+}
+
+void HibernationManagerImpl::dropHibernatableWebSocket(HibernatableWebSocket& hib) {
+  removeFromAllWs(hib);
+}
+
+inline void HibernationManagerImpl::removeFromAllWs(HibernatableWebSocket& hib) {
+  auto& node = KJ_REQUIRE_NONNULL(hib.node);
+  allWs.remove(node);
+}
+
+kj::Promise<void> HibernationManagerImpl::readLoop(HibernatableWebSocket& hib) {
+  // Like the api::WebSocket readLoop(), but we dispatch different types of events.
+  auto& ws = *hib.ws;
+  return ws.receive()
+      .then([this, &hib] (kj::WebSocket::Message&& message) mutable -> kj::Promise<void> {
+    // TODO(now): Within CustomEvent impl run, when we pass a reference to this hibernation manager,
+    // we'll want to assign the hib manager ref to the Worker::Actorso that JS can access it elsewhere.
+    if (hib.activeWebSocket == nullptr) {
+      // If we are currently hibernating, we need to wake up.
+      // TODO(soon): Ping/Pongs that don't wake us from hibernation.
+      // TODO(now): We need to get access to an Isolate so we can deserialize `attachment` and
+      //            pass a jsg::Lock& to unhibernate.
+      // TODO(now): We can't create the api::WebSocket at this point since we aren't guaranteed to
+      // have an Isolate. We should create and assign the `activeWebSocket` when running inside the
+      // CustomEvent instead.
+    }
+
+    return readLoop(hib);
+  });
+}
+
+}; // namespace workerd

--- a/src/workerd/io/hibernation-manager.h
+++ b/src/workerd/io/hibernation-manager.h
@@ -1,0 +1,184 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <kj/debug.h>
+#include <workerd/api/web-socket.h>
+#include <workerd/io/worker.h>
+#include "v8-isolate.h"
+#include <workerd/jsg/ser.h>
+#include <kj/linked-list.h>
+
+namespace workerd {
+
+class HibernationManagerImpl final : public Worker::Actor::HibernationManager {
+  // Implements the HibernationManager class.
+public:
+  HibernationManagerImpl(kj::Maybe<WorkerInterface&> worker)
+      : workerInterface(kj::mv(worker)), onDisconnect(DisconnectHandler{}), readLoopTasks(onDisconnect) {}
+  ~HibernationManagerImpl();
+
+  void acceptWebSocket(jsg::Ref<api::WebSocket> ws, kj::ArrayPtr<kj::String> tags) override;
+  // Tells the HibernationManager to create a new HibernatableWebSocket with the associated tags
+  // and to initiate the `readLoop()` for this websocket.
+
+  kj::Vector<jsg::Ref<api::WebSocket>> getWebSockets(jsg::Lock& js, kj::StringPtr tag) override;
+  // Gets a collection of websockets associated with the given tag. Any hibernating websockets will
+  // be woken up.
+
+  kj::Array<kj::byte> serializeV8Value(v8::Local<v8::Value> value, v8::Isolate* isolate);
+  // We need to serialize the `attachment` for each websocket when they hibernate.
+
+  // TODO(now): Should we include a deseriailizeV8Value() in this class, or elsewhere?
+
+  void hibernateWebSockets(jsg::Lock& js, v8::Isolate* isolate, IoContext& context) override;
+  // Hibernates all the websockets held by the HibernationManager.
+  // This involves:
+  //    - Seriailizing the `attachment`
+  //    - Dropping the api::WebSocket reference (`activeWebSocket`)
+
+private:
+  class HibernatableWebSocket;
+  struct TagListItem {
+    // Each HibernatableWebSocket can have multiple tags, so we want to store a reference
+    // in our kj::List.
+    kj::Maybe<HibernatableWebSocket&> hibWS;
+    kj::ListLink<TagListItem> link;
+    kj::StringPtr tag;
+    kj::Maybe<kj::List<TagListItem, &TagListItem::link>&> list;
+    // The List that refers to this TagListItem.
+    // If `list` is null, we've already removed this item from the list.
+  };
+
+  class HibernatableWebSocket {
+    // api::WebSockets cannot survive hibernation, but kj::WebSockets do. This class helps us
+    // manage the transition of an api::WebSocket from its active state to a hibernated state
+    // and vice versa.
+    //
+    // Some properties of the JS websocket object need to be retained throughout hibernation,
+    // such as `attachment`, `url`, `extensions`, etc. These properties are only read/modified
+    // when initiating, or waking from hibernation.
+  public:
+    HibernatableWebSocket(jsg::Ref<api::WebSocket> websocket,
+                          kj::ArrayPtr<kj::String> tags,
+                          size_t id, HibernationManagerImpl& manager)
+        : tagItems(kj::heapArray<TagListItem>(tags.size())),
+          activeWebSocket(kj::mv(websocket)),
+          // Extract's the kj::Own<kj::WebSocket> from api::WebSocket so the HibernatableWebSocket
+          // can own it. The api::WebSocket retains a reference to our ws.
+          ws(KJ_REQUIRE_NONNULL(activeWebSocket)->acceptAsHibernatable()),
+          id(id),
+          manager(manager),
+          url(KJ_REQUIRE_NONNULL(activeWebSocket)->getUrl()
+              .map([](kj::StringPtr s) { return kj::str(s);})),
+          protocol(KJ_REQUIRE_NONNULL(activeWebSocket)->getProtocol()
+              .map([](kj::StringPtr s) { return kj::str(s);})),
+          extensions(KJ_REQUIRE_NONNULL(activeWebSocket)->getExtensions()
+              .map([](kj::StringPtr s) { return kj::str(s);})) {}
+
+    ~HibernatableWebSocket() {
+      // We expect this dtor to be called when we're removing a HibernatableWebSocket
+      // from our `allWs` collection in the HibernationManager.
+
+      // This removal is fast because we have direct access to each kj::List, as well as direct
+      // access to each TagListItem we want to remove.
+      for (auto& item: tagItems) {
+        KJ_IF_MAYBE(list, item.list) {
+          // The list reference is non-null, so we still have a valid reference to this
+          // TagListItem in the list, which we will now remove.
+          list->remove(item);
+          if (list->empty()) {
+            // Remove the bucket in tagToWs if the tag has no more websockets.
+            manager.tagToWs.erase(kj::mv(item.tag));
+          }
+        }
+        item.hibWS = nullptr;
+        item.list = nullptr;
+      }
+    }
+
+    kj::ListLink<HibernatableWebSocket> link;
+
+    kj::Array<TagListItem> tagItems;
+    // An array of all the items/nodes that refer to this HibernatableWebSocket.
+    // Keeping track of these items allows us to quickly remove every reference from `tagToWs`
+    // once the websocket disconnects -- rather than iterating through each relevant tag in the
+    // hashmap and removing it from each kj::List.
+
+    kj::Maybe<jsg::Ref<api::WebSocket>> activeWebSocket;
+    // Null if we're hibernating, otherwise, a reference to the active api::WebSocket.
+    kj::Own<kj::WebSocket> ws;
+    size_t id;
+    // Used for equality check.
+    HibernationManagerImpl& manager;
+    // TODO(now): We (currently) only use the HibernationManagerImpl reference to refer to `tagToWs`
+    // when running the dtor for `HibernatableWebSocket`. This feels a bit excessive, I would rather
+    // have the HibernationManager deal with its collections than have the HibernatableWebSocket
+    // do so. Maybe come back to this at some point?
+    kj::Maybe<kj::Node<HibernatableWebSocket>&> node;
+    // Reference to the Node in `allWs` that allows us to do fast deletion on disconnect.
+
+    // The following properties must be retained through hibernation.
+
+    kj::Array<kj::byte> attachment;
+    // Serialized attachment property of the api::WebSocket.
+    // The `attachment` is read upon waking from hibernation, and written to upon hibernating.
+    const kj::Maybe<kj::String> url;
+    const kj::Maybe<kj::String> protocol;
+    const kj::Maybe<kj::String> extensions;
+    friend HibernationManagerImpl;
+
+    bool operator==(HibernatableWebSocket& other) {
+      return other.id == this->id;
+    }
+  };
+
+  size_t countOfAcceptedWebSockets = 0;
+
+private:
+  void dropHibernatableWebSocket(HibernatableWebSocket& hib);
+  // Removes a HibernatableWebSocket from the HibernationManager's various collections.
+
+  inline void removeFromAllWs(HibernatableWebSocket& hib);
+  // Removes the HibernatableWebSocket from `allWs`.
+
+  kj::Promise<void> readLoop(HibernatableWebSocket& hib);
+  // Like the api::WebSocket readLoop(), but we dispatch different types of events.
+
+  struct TagCollection {
+    // This struct is held by the `tagToWs` hashmap. The key is a StringPtr to tag, and the value
+    // is this struct itself.
+    kj::String tag;
+    kj::Own<kj::List<TagListItem, &TagListItem::link>> list;
+
+    TagCollection(kj::String tag, decltype(list) list): tag(kj::mv(tag)), list(kj::mv(list)) {}
+    TagCollection(TagCollection&& other) = default;
+  };
+
+  kj::HashMap<kj::StringPtr, kj::Own<TagCollection>> tagToWs;
+  // A hashmap of tags to HibernatableWebSockets associated with the tag.
+  // We use a kj::List so we can quickly remove websockets that have disconnected.
+  // Also note that we box the keys and values such that in the event of a hashmap resizing we don't
+  // move the underlying data (thereby keeping any references intact).
+
+  kj::LinkedList<HibernatableWebSocket> allWs;
+  // We store all of our HibernatableWebSockets in a doubly linked-list.
+  // Note that we actually heap allocate `HibernatableWebSocket` since the `data` of a Node
+  // in the LinkedList must be boxed.
+
+  kj::Maybe<WorkerInterface&> workerInterface;
+  // TODO(now): Change this to `HibernationEventDispatcher`, WorkerInterface was an old idea.
+
+  class DisconnectHandler: public kj::TaskSet::ErrorHandler {
+  // TODO(now): rename because it's not necessarily on disconnect.
+  public:
+    void taskFailed(kj::Exception&& exception) override {
+      // Called when a readLoop promise throws an exception.
+    }
+  };
+  DisconnectHandler onDisconnect;
+  kj::TaskSet readLoopTasks;
+};
+}; // namespace workerd

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -9,6 +9,7 @@
 #include <workerd/api/global-scope.h>
 #include <workerd/util/own-util.h>
 #include <workerd/util/thread-scopes.h>
+#include <workerd/io/hibernation-manager.h>
 
 namespace workerd {
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3071,6 +3071,17 @@ void Worker::Actor::setIoContext(kj::Own<IoContext> context) {
   });
 }
 
+kj::Maybe<Worker::Actor::HibernationManager&> Worker::Actor::getHibernationManager() {
+  return hibernationManager.map([](kj::Own<HibernationManager>& hib) -> HibernationManager& {
+    return *hib;
+  });
+}
+
+void Worker::Actor::setHibernationManager(kj::Own<HibernationManager> hib) {
+  KJ_REQUIRE(hibernationManager == nullptr);
+  hibernationManager = kj::mv(hib);
+}
+
 // =======================================================================================
 
 uint Worker::Isolate::getCurrentLoad() const {


### PR DESCRIPTION
### This is a WIP
We're still working things out, mainly of interest to @xortive.

---

When we hibernate, `kj::WebSocket`s stick around but `api::WebSocket`s go away. Currently, `api::WebSocket` owns its `kj::WebSocket`, so we need to extract the `kj::WebSocket` without breaking things. We also want to make some of the existing `api::WebSocket` api inaccessible since hibernatable WebSockets receive events through a separate mechanism.