### PR TITLE
Change ActorCache backpressure to be based on dirty bytes rather than…

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1523,10 +1523,10 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
     ActorCacheSharedLruOptions getActorCacheLruOptions() override {
       // TODO(someday): Make this configurable?
       return {
-        .softLimit = 16ull << 20,
-        .hardLimit = 128ull << 20,
+        .softLimit = 16 * (1ull << 20), // 16 MiB
+        .hardLimit = 128 * (1ull << 20), // 128 MiB
         .staleTimeout = 30 * kj::SECONDS,
-        .dirtyKeySoftLimit = 64,
+        .dirtyListByteLimit = 8 * (1ull << 20), // 8 MiB
         .maxKeysPerRpc = 128,
 
         // For now, we use `neverFlush` to implement in-memory-only actors.

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -136,10 +136,10 @@ struct MockIsolateLimitEnforcer final: public IsolateLimitEnforcer {
     void customizeIsolate(v8::Isolate* isolate) override {}
     ActorCacheSharedLruOptions getActorCacheLruOptions() override {
       return {
-        .softLimit = 16ull << 20,
-        .hardLimit = 128ull << 20,
+        .softLimit = 16 * (1ull << 20), // 16 MiB
+        .hardLimit = 128 * (1ull << 20), // 128 MiB
         .staleTimeout = 30 * kj::SECONDS,
-        .dirtyKeySoftLimit = 64,
+        .dirtyListByteLimit = 8 * (1ull << 20), // 8 MiB
         .maxKeysPerRpc = 128,
         .neverFlush = true
       };


### PR DESCRIPTION
… dirty keys

---

I'm not sure what to use for the default limit, I started with 2MB but that's probably too low?