### PR TITLE
types: add botManagement.detectionIds to cf.d.ts

### DIFF
--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -371,7 +371,6 @@ interface IncomingRequestCfPropertiesBotManagementBase {
   staticResource: boolean;
   /**
    * List of IDs that correlate to the Bot Management heuristic detections made on a request (you can have multiple heuristic detections on the same request).
-   * Use this field to explicitly match a specific heuristic or to exclude a heuristic in a rule.
    */
   detectionIds: number[];
 }

--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -369,6 +369,11 @@ interface IncomingRequestCfPropertiesBotManagementBase {
    * A boolean value that's true if the request matches [file extensions](https://developers.cloudflare.com/bots/reference/static-resources/) for many types of static resources.
    */
   staticResource: boolean;
+  /**
+   * List of IDs that correlate to the Bot Management heuristic detections made on a request (you can have multiple heuristic detections on the same request).
+   * Use this field to explicitly match a specific heuristic or to exclude a heuristic in a rule.
+   */
+  detectionIds: number[];
 }
 
 interface IncomingRequestCfPropertiesBotManagement {


### PR DESCRIPTION
Example: `➜  ~ curl https://kian.org.uk/cf.json | jq '.botManagement'`

```json
{
  "corporateProxy": false,
  "verifiedBot": false,
  "staticResource": false,
  "detectionIds": [
    33554817
  ],
  "score": 1
}
```