### PR TITLE
Add Node.js Compat utils implementation

### DIFF
--- a/samples/nodejs-compat/worker.js
+++ b/samples/nodejs-compat/worker.js
@@ -1,7 +1,15 @@
 import { EventEmitter } from 'node:events';
 import { Buffer } from 'node:buffer';
-import { ok, deepStrictEqual, throws } from 'node:assert';
-import { callbackify, promisify } from 'node:util';
+import {
+  ok,
+  deepStrictEqual,
+  throws,
+} from 'node:assert';
+import {
+  callbackify,
+  promisify,
+  format,
+} from 'node:util';
 
 // Callback function
 function doSomething(a, cb) {
@@ -51,9 +59,9 @@ export default {
         }
       });
       throws(() => {
-        throw new Error('boom');
+        // util.format
+        throw new Error(format('%s', 'boom'));
       }, new Error('boom'));
-
       // The buffer module...
       const buffer = Buffer.concat([Buffer.from('Hello '), Buffer.from('There')], 12);
       buffer.fill(Buffer.from('!!'), 11);

--- a/samples/nodejs-compat/worker.js
+++ b/samples/nodejs-compat/worker.js
@@ -1,19 +1,41 @@
 import { EventEmitter } from 'node:events';
 import { Buffer } from 'node:buffer';
-import * as assert from 'node:assert';
+import { ok, deepStrictEqual, throws } from 'node:assert';
+import { callbackify, promisify } from 'node:util';
+
+// Callback function
+function doSomething(a, cb) {
+  setTimeout(() => cb(null, a), 1);
+}
+
+// Async function
+async function promiseSomething(a) {
+  await scheduler.wait(1);
+  return a;
+}
+
+const promisified = promisify(doSomething);
+const callbackified = callbackify(promiseSomething);
 
 export default {
   async fetch(request) {
     let res;
     const promise = new Promise((a) => res = a);
 
+    // Util promisify/callbackify
+    console.log(await promisified(321));
+
+    callbackified(123, (err, val) => {
+      console.log(err, val);
+    });
+
     // The events module...
     const ee = new EventEmitter();
     ee.on('foo', () => {
 
       // The assertion module...
-      assert.ok(true);
-      assert.deepStrictEqual({
+      ok(true);
+      deepStrictEqual({
         a: {
           b: new Set([1,2,3]),
           c: [
@@ -28,7 +50,7 @@ export default {
           ]
         }
       });
-      assert.throws(() => {
+      throws(() => {
         throw new Error('boom');
       }, new Error('boom'));
 

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -417,9 +417,18 @@ export class ERR_MISSING_ARGS extends NodeTypeError {
   }
 }
 
+export class ERR_FALSY_VALUE_REJECTION extends NodeError {
+  reason: string;
+  constructor(reason: string) {
+    super("ERR_FALSY_VALUE_REJECTION", "Promise was rejected with falsy value");
+    this.reason = reason;
+  }
+}
+
 export default {
   ERR_AMBIGUOUS_ARGUMENT,
   ERR_BUFFER_OUT_OF_BOUNDS,
+  ERR_FALSY_VALUE_REJECTION,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_BUFFER_SIZE,

--- a/src/node/internal/internal_format.ts
+++ b/src/node/internal/internal_format.ts
@@ -23,6 +23,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
 export function format(...args: [string, unknown[]?]) {
   return formatInternal(...args);
 }

--- a/src/node/internal/internal_format.ts
+++ b/src/node/internal/internal_format.ts
@@ -1,0 +1,222 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+export function format(...args: [string, unknown[]?]) {
+  return formatInternal(...args);
+}
+
+function formatBigInt(bigint: BigInt, numericSeparator?: boolean) {
+  const string = String(bigint);
+  if (!numericSeparator) {
+    return `${string}n`;
+  }
+  return `${addNumericSeparator(string)}n`;
+}
+
+function addNumericSeparator(integerString: string) {
+  let result = '';
+  let i = integerString.length;
+  const start = integerString.startsWith('-') ? 1 : 0;
+  for (; i >= start + 4; i -= 3) {
+    result = `_${integerString.slice(i - 3, i)}${result}`;
+  }
+  return i === integerString.length ?
+    integerString :
+    `${integerString.slice(0, i)}${result}`;
+}
+
+function addNumericSeparatorEnd(integerString: string) {
+  let result = '';
+  let i = 0;
+  for (; i < integerString.length - 3; i += 3) {
+    result += `${integerString.slice(i, i + 3)}_`;
+  }
+  return i === 0 ?
+    integerString :
+    `${result}${integerString.slice(i)}`;
+}
+
+function formatNumber(number: number, numericSeparator?: boolean) {
+  if (!numericSeparator) {
+    // Format -0 as '-0'. Checking `number === -0` won't distinguish 0 from -0.
+    if (Object.is(number, -0)) {
+      return '-0';
+    }
+    return `${number}`;
+  }
+  const integer = Math.trunc(number);
+  const string = String(integer);
+  if (integer === number) {
+    if (!Number.isFinite(number) || string.includes('e')) {
+      return string;
+    }
+    return `${addNumericSeparator(string)}`;
+  }
+  if (Number.isNaN(number)) {
+    return string;
+  }
+  return `${addNumericSeparator(string)}.${addNumericSeparatorEnd(String(number).slice(string.length + 1))}`;
+}
+
+function formatStringOrSymbol(val: unknown) {
+  if (typeof val === 'symbol') {
+    return (val as symbol).description;
+  }
+  return `${val}`;
+}
+
+const firstErrorLine = (error: any) => error?.message?.split('\n', 1)[0];
+let CIRCULAR_ERROR_MESSAGE: string;
+function tryStringify(arg: unknown) {
+  try {
+    return JSON.stringify(arg);
+  } catch (err) {
+    // Populate the circular error message lazily
+    if (!CIRCULAR_ERROR_MESSAGE) {
+      try {
+        const a = {};
+        (a as any).a = a;
+        JSON.stringify(a);
+      } catch (circularError) {
+        CIRCULAR_ERROR_MESSAGE = firstErrorLine(circularError);
+      }
+    }
+    if ((err as Error)?.name === 'TypeError' &&
+        firstErrorLine(err) === CIRCULAR_ERROR_MESSAGE) {
+      return '[Circular]';
+    }
+    throw err;
+  }
+}
+
+function formatInternal(...args: [string, unknown[]?]) {
+  const first = args[0];
+  let a = 0;
+  let str = '';
+  let join = '';
+
+  if (typeof first === 'string') {
+    if (args.length === 1) {
+      return first;
+    }
+    let tempStr;
+    let lastPos = 0;
+
+    for (let i = 0; i < first.length - 1; i++) {
+      if (first.charCodeAt(i) == 37) { // %
+        const nextChar = first.charCodeAt(++i);
+        if (a + 1 !== args.length) {
+          switch (nextChar) {
+            case 115: { // 's'
+              const tempArg = args[++a];
+              if (typeof tempArg === 'number') {
+                tempStr = formatNumber(tempArg);
+              } else if (typeof tempArg === 'bigint') {
+                tempStr = formatBigInt(tempArg);
+              } else {
+                tempStr = formatStringOrSymbol(tempArg);
+              }
+              break;
+            }
+            case 106: // 'j'
+              tempStr = tryStringify(args[++a]);
+              break;
+            case 100: { // 'd'
+              const tempNum = args[++a];
+              if (typeof tempNum === 'bigint') {
+                tempStr = formatBigInt(tempNum);
+              } else if (typeof tempNum === 'symbol') {
+                tempStr = 'NaN';
+              } else {
+                tempStr = formatNumber(Number(tempNum));
+              }
+              break;
+            }
+            case 79: // 'O'
+              tempStr = `${args[++a]}`;
+              break;
+            case 111: // 'o'
+              tempStr = formatStringOrSymbol(args[++a]);
+              break;
+            case 105: { // 'i'
+              const tempInteger = args[++a];
+              if (typeof tempInteger === 'bigint') {
+                tempStr = formatBigInt(tempInteger);
+              } else if (typeof tempInteger === 'symbol') {
+                tempStr = 'NaN';
+              } else {
+                tempStr = formatNumber(Number.parseInt(`${tempInteger}`));
+              }
+              break;
+            }
+            case 102: { // 'f'
+              const tempFloat = args[++a];
+              if (typeof tempFloat === 'symbol') {
+                tempStr = 'NaN';
+              } else {
+                tempStr = formatNumber(Number.parseFloat(`${tempFloat}`));
+              }
+              break;
+            }
+            case 99: // 'c'
+              a += 1;
+              tempStr = '';
+              break;
+            case 37: // '%'
+              str += first.slice(lastPos, i);
+              lastPos = i + 1;
+              continue;
+            default: // Any other character is not a correct placeholder
+              continue;
+          }
+          if (lastPos !== i - 1) {
+            str += first.slice(lastPos, i - 1);
+          }
+          str += tempStr;
+          lastPos = i + 1;
+        } else if (nextChar === 37) {
+          str += first.slice(lastPos, i);
+          lastPos = i + 1;
+        }
+      }
+    }
+    if (lastPos !== 0) {
+      a++;
+      join = ' ';
+      if (lastPos < first.length) {
+        str += first.slice(lastPos);
+      }
+    }
+  }
+
+  while (a < args.length) {
+    const value = args[a];
+    str += `${join}${formatStringOrSymbol(value)}`
+    join = ' ';
+    a++;
+  }
+  return str;
+}
+

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -4,8 +4,120 @@
 
 import { default as internalTypes } from 'node-internal:internal_types';
 
+import {
+  validateFunction
+} from 'node-internal:validators';
+
+import {
+  ERR_FALSY_VALUE_REJECTION
+} from 'node-internal:internal_errors';
+
 export const types = internalTypes;
+
+const callbackifyOnRejected = (reason: unknown, cb : Function) => {
+  if (!reason) {
+    reason = new ERR_FALSY_VALUE_REJECTION(`${reason}`);
+  }
+  return cb(reason);
+};
+
+export function callbackify
+    <T extends (...args: any[]) => Promise<any>>(original: T):
+    T extends (...args: infer TArgs) => Promise<infer TReturn> ? (...params: [...TArgs, (err: Error, ret: TReturn) => any]) => void : never {
+  validateFunction(original, 'original');
+
+  function callbackified(this: unknown,
+                         ...args: [...unknown[],
+                         (err: unknown, ret: unknown) => void]) : any {
+    const maybeCb = args.pop();
+    validateFunction(maybeCb, 'last argument');
+    const cb = (maybeCb as Function).bind(this);
+    Reflect.apply(original, this, args)
+      .then((ret: any) => queueMicrotask(() => cb(null, ret)),
+            (rej: any) => queueMicrotask(() => callbackifyOnRejected(rej, cb)));
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(original);
+  if (typeof descriptors['length']!.value === 'number') {
+    descriptors['length']!.value++;
+  }
+  if (typeof descriptors['name']!.value === 'string') {
+    descriptors['name']!.value += 'Callbackified';
+  }
+  const propertiesValues = Object.values(descriptors);
+  for (let i = 0; i < propertiesValues.length; i++) {
+    Object.setPrototypeOf(propertiesValues[i], null);
+  }
+  Object.defineProperties(callbackified, descriptors);
+  return callbackified as any;
+}
+
+const kCustomPromisifiedSymbol = Symbol.for('nodejs.util.promisify.custom');
+const kCustomPromisifyArgsSymbol = Symbol('customPromisifyArgs');
+
+// TODO(later): Proper type signature for promisify.
+export function promisify(original: Function): Function {
+  validateFunction(original, 'original');
+
+  if ((original as any)[kCustomPromisifiedSymbol]) {
+    const fn = (original as any)[kCustomPromisifiedSymbol];
+
+    validateFunction(fn, 'util.promisify.custom');
+
+    return Object.defineProperty(fn, kCustomPromisifiedSymbol, {
+      value: fn,
+      enumerable: false,
+      writable: false,
+      configurable: true
+    });
+  }
+
+  // Names to create an object from in case the callback receives multiple
+  // arguments, e.g. ['bytesRead', 'buffer'] for fs.read.
+  const argumentNames = (original as any)[kCustomPromisifyArgsSymbol];
+
+  function fn(this: any, ...args: any[]) {
+    return new Promise((resolve, reject) => {
+      args.push((err: unknown, ...values: unknown[]) => {
+        if (err) {
+          return reject(err);
+        }
+        if (argumentNames !== undefined && values.length > 1) {
+          const obj = {};
+          for (let i = 0; i < argumentNames.length; i++)
+            (obj as any)[argumentNames[i]] = values[i];
+          resolve(obj);
+        } else {
+          resolve(values[0]);
+        }
+      });
+      Reflect.apply(original, this, args);
+    });
+  }
+
+  Object.setPrototypeOf(fn, Object.getPrototypeOf(original));
+
+  Object.defineProperty(fn, kCustomPromisifiedSymbol, {
+    value: fn,
+    enumerable: false,
+    writable: false,
+    configurable: true
+  });
+
+  const descriptors = Object.getOwnPropertyDescriptors(original);
+  const propertiesValues = Object.values(descriptors);
+  for (let i = 0; i < propertiesValues.length; i++) {
+    // We want to use null-prototype objects to not rely on globally mutable
+    // %Object.prototype%.
+    Object.setPrototypeOf(propertiesValues[i], null);
+  }
+  return Object.defineProperties(fn, descriptors);
+}
+
+promisify.custom = kCustomPromisifiedSymbol;
 
 export default {
   types,
+  callbackify,
+  promisify,
 };

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -12,8 +12,14 @@ import {
   ERR_FALSY_VALUE_REJECTION
 } from 'node-internal:internal_errors';
 
-export const types = internalTypes;
+export {
+  format
+} from 'node-internal:internal_format';
 
+import { format } from 'node-internal:internal_format';
+
+export const types = internalTypes;
+;
 const callbackifyOnRejected = (reason: unknown, cb : Function) => {
   if (!reason) {
     reason = new ERR_FALSY_VALUE_REJECTION(`${reason}`);
@@ -120,4 +126,5 @@ export default {
   types,
   callbackify,
   promisify,
+  format,
 };


### PR DESCRIPTION
Supported:
* [x] types
* [x] promisify/callbackify
* [x] format/formatWithOptions
* [x] inherits

Questionable (might not implement these, but if we do it will be later)
* inspect
* deprecate
* debug/debuglog
* toUSVString
* MIMEType (experimental added in 19.x)
* parseArgs() (experimental added in 19.x, backported, not relevant?)
* stripVTControlCharacters (not relevant?)
* isDeepStrictEqual

Won't implement:
* transferableAbortController/transferableAbortSignal
* deprecated util.is* methods