### PR TITLE
Refactor JSG exception decoding, add relevant test cases

### DIFF
--- a/src/workerd/jsg/util-test.c++
+++ b/src/workerd/jsg/util-test.c++
@@ -220,6 +220,26 @@ struct TunneledContext: public Object {
     JSG_REQUIRE(s.startsWith(";"), DOMOperationError,
         "thrown from ", kj::str("throwTunneledMacroOperationErrorWithExpectation"));
   }
+  // Test that the error types mapped to WasmCompileError are handled correctly
+  void throwTunneledCompileError() {
+    KJ_FAIL_REQUIRE("jsg.CompileError: thrown from throwTunneledCompileError");
+  }
+  void throwTunneledLinkError() {
+    KJ_FAIL_REQUIRE("jsg.LinkError: thrown from throwTunneledLinkError");
+  }
+  void throwTunneledRuntimeError() {
+    KJ_FAIL_REQUIRE("jsg.RuntimeError: thrown from throwTunneledRuntimeError");
+  }
+  // Test that only valid DOM exceptions are processed
+  void throwTunneledDOMException() {
+    KJ_FAIL_REQUIRE("jsg.DOMException(Some error): thrown from throwTunneledDOMException");
+  }
+  void throwTunneledInvalidDOMException() {
+    KJ_FAIL_REQUIRE("jsg.DOMException: thrown from throwTunneledInvalidDOMException");
+  }
+  void throwTunneledGarbledDOMException() {
+    KJ_FAIL_REQUIRE("jsg.DOMException(: thrown from throwTunneledGarbledDOMException");
+  }
 
   JSG_RESOURCE_TYPE(TunneledContext) {
     JSG_NESTED_TYPE(DOMException);
@@ -240,6 +260,12 @@ struct TunneledContext: public Object {
     JSG_METHOD(throwTunneledMacroTypeErrorWithExpectation);
     JSG_METHOD(throwTunneledMacroOperationError);
     JSG_METHOD(throwTunneledMacroOperationErrorWithExpectation);
+    JSG_METHOD(throwTunneledCompileError);
+    JSG_METHOD(throwTunneledLinkError);
+    JSG_METHOD(throwTunneledRuntimeError);
+    JSG_METHOD(throwTunneledDOMException);
+    JSG_METHOD(throwTunneledInvalidDOMException);
+    JSG_METHOD(throwTunneledGarbledDOMException);
   }
 };
 JSG_DECLARE_ISOLATE_TYPE(TunneledIsolate, TunneledContext);
@@ -311,6 +337,36 @@ KJ_TEST("throw tunneled exception") {
       "throwTunneledMacroOperationErrorWithExpectation()",
       "throws", "OperationError: thrown from throwTunneledMacroOperationErrorWithExpectation"
   );
+  e.expectEval(
+      "throwTunneledCompileError()",
+      "throws", "CompileError: thrown from throwTunneledCompileError"
+  );
+  e.expectEval(
+      "throwTunneledLinkError()",
+      "throws", "CompileError: thrown from throwTunneledLinkError"
+  );
+  e.expectEval(
+      "throwTunneledRuntimeError()",
+      "throws", "CompileError: thrown from throwTunneledRuntimeError"
+  );
+  e.expectEval(
+      "throwTunneledDOMException()",
+      "throws", "Some error: thrown from throwTunneledDOMException"
+  );
+  {
+    KJ_EXPECT_LOG(ERROR, " thrown from throwTunneledInvalidDOMException");
+    e.expectEval(
+        "throwTunneledInvalidDOMException()",
+        "throws", "Error: internal error"
+    );
+  }
+  {
+    KJ_EXPECT_LOG(ERROR, " thrown from throwTunneledGarbledDOMException");
+    e.expectEval(
+        "throwTunneledGarbledDOMException()",
+        "throws", "Error: internal error"
+    );
+  }
 }
 
 KJ_TEST("runTunnelingExceptions") {

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -51,7 +51,7 @@ kj::String typeName(const std::type_info& type) {
 
 v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::StringPtr internalMessage) {
   KJ_LOG(ERROR, internalMessage);
-  return v8::Exception::Error(v8Str(isolate, "internal error"));
+  return v8::Exception::Error(v8StrIntern(isolate, "internal error"));
 }
 
 namespace {
@@ -84,7 +84,7 @@ kj::Maybe<v8::Local<v8::Value>> tryMakeDomException(v8::Isolate* isolate,
     return check(value->ToObject(context));
   };
   const auto getInterned = [isolate, context](v8::Local<v8::Object> object, const char* s) {
-    auto name = v8Str(isolate, s, v8::NewStringType::kInternalized);
+    auto name = v8StrIntern(isolate, s);
     return check(object->Get(context, name));
   };
 
@@ -119,7 +119,7 @@ bool setRemoteError(v8::Isolate* isolate, v8::Local<v8::Value>& exception) {
   return jsg::check(
     obj->Set(
       isolate->GetCurrentContext(),
-      jsg::v8Str(isolate, "remote"_kj, v8::NewStringType::kInternalized),
+      jsg::v8StrIntern(isolate, "remote"_kj),
       v8::True(isolate)));
 }
 
@@ -129,7 +129,7 @@ bool setDurableObjectResetError(v8::Isolate* isolate, v8::Local<v8::Value>& exce
   return jsg::check(
     obj->Set(
       isolate->GetCurrentContext(),
-      jsg::v8Str(isolate, "durableObjectReset"_kj, v8::NewStringType::kInternalized),
+      jsg::v8StrIntern(isolate, "durableObjectReset"_kj),
       v8::True(isolate)));
 }
 
@@ -344,7 +344,7 @@ DecodedException decodeTunneledException(v8::Isolate* isolate,
       }
     }
     // unrecognized exception type
-    result.handle = v8::Exception::Error(v8Str(isolate, "internal error"));
+    result.handle = v8::Exception::Error(v8StrIntern(isolate, "internal error"));
     result.isInternal = true;
   } while (false);
 #undef HANDLE_V8_ERROR

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -315,54 +315,39 @@ DecodedException decodeTunneledException(v8::Isolate* isolate,
   result.isFromRemote = tunneledInfo.isFromRemote;
   result.isDurableObjectReset = tunneledInfo.isDurableObjectReset;
 
-  // TODO(cleanup): This code has gotten pretty ugly, could probably use some refactoring.
-  if (errorType.startsWith("Error")) {
-    auto message = appMessage(errorType.slice(strlen("Error")));
-    result.handle = v8::Exception::Error(v8Str(isolate, message));
-  } else if (errorType.startsWith("RangeError")) {
-    auto message = appMessage(errorType.slice(strlen("RangeError")));
-    result.handle = v8::Exception::RangeError(v8Str(isolate, message));
-  } else if (errorType.startsWith("TypeError")) {
-    auto message = appMessage(errorType.slice(strlen("TypeError")));
-    result.handle = v8::Exception::TypeError(v8Str(isolate, message));
-  } else if (errorType.startsWith("SyntaxError")) {
-    auto message = appMessage(errorType.slice(strlen("SyntaxError")));
-    result.handle = v8::Exception::SyntaxError(v8Str(isolate, message));
-  } else if (errorType.startsWith("ReferenceError")) {
-    auto message = appMessage(errorType.slice(strlen("ReferenceError")));
-    result.handle = v8::Exception::ReferenceError(v8Str(isolate, message));
-  } else if (errorType.startsWith("CompileError")) {
-    auto message = appMessage(errorType.slice(strlen("CompileError")));
-    result.handle = v8::Exception::WasmCompileError(v8Str(isolate, message));
-  } else if (errorType.startsWith("LinkError")) {
-    auto message = appMessage(errorType.slice(strlen("LinkError")));
-    result.handle = v8::Exception::WasmCompileError(v8Str(isolate, message));
-  } else if (errorType.startsWith("RuntimeError")) {
-    auto message = appMessage(errorType.slice(strlen("RuntimeError")));
-    result.handle = v8::Exception::WasmCompileError(v8Str(isolate, message));
-  } else if (errorType.startsWith("DOMException")) {
-    errorType = errorType.slice(strlen("DOMException"));
+#define HANDLE_V8_ERROR(error_name, error_type) \
+  if (errorType.startsWith(error_name)) { \
+    auto message = appMessage(errorType.slice(strlen(error_name))); \
+    result.handle = v8::Exception::error_type(v8Str(isolate, message)); \
+    break; \
+  }
+
+  do {
+    HANDLE_V8_ERROR("Error", Error);
+    HANDLE_V8_ERROR("RangeError", RangeError);
+    HANDLE_V8_ERROR("TypeError", TypeError);
+    HANDLE_V8_ERROR("SyntaxError", SyntaxError);
+    HANDLE_V8_ERROR("ReferenceError", ReferenceError);
+    HANDLE_V8_ERROR("CompileError", WasmCompileError);
+    HANDLE_V8_ERROR("LinkError", WasmCompileError);
+    HANDLE_V8_ERROR("RuntimeError", WasmCompileError);
+
     // DOMExceptions require a parenthesized error name argument, like DOMException(SyntaxError).
-    if (errorType.startsWith("(")) {
+    if (errorType.startsWith("DOMException(")) {
+      errorType = errorType.slice(strlen("DOMException("));
+      // Check for closing brace
       KJ_IF_MAYBE(closeParen, errorType.findFirst(')')) {
-        auto errorName = kj::str(errorType.slice(1, *closeParen));
-        auto message = appMessage(errorType.slice(2 + errorName.size()));
+        auto errorName = kj::str(errorType.slice(0, *closeParen));
+        auto message = appMessage(errorType.slice(1 + *closeParen));
         result.handle = tryMakeDomExceptionOrDefaultError(isolate, message, errorName);
-      } else {
-        // no closing parenthesis
-        result.handle = v8::Exception::Error(v8Str(isolate, "internal error"));
-        result.isInternal = true;
+        break;
       }
-    } else {
-      // no opening parenthesis
-      result.handle = v8::Exception::Error(v8Str(isolate, "internal error"));
-      result.isInternal = true;
     }
-  } else {
     // unrecognized exception type
     result.handle = v8::Exception::Error(v8Str(isolate, "internal error"));
     result.isInternal = true;
-  }
+  } while (false);
+#undef HANDLE_V8_ERROR
 
   if (result.isFromRemote) {
     setRemoteError(isolate, result.handle);


### PR DESCRIPTION
This commit resolves a TODO about refactoring code for different error types in `decodeTunneledException`. This should make the code more maintainable if there are future additions. I also added some test cases for handling compile errors and DOM exceptions since tunneling them was not tested before and adding them made it easier to spot potential bugs while refactoring the function.