### PR TITLE
Minor span tracing improvements

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,10 +35,10 @@ rules_foreign_cc_dependencies()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "dfca9b050b0e3b381c39f44a998cbb6885b36ab650bc041b6ade55b11473e0d4",
-    strip_prefix = "capnproto-capnproto-6e26d26/c++",
+    sha256 = "81204dee1c5d3a2b7ebcfd266f5f15d9dbf586eeae6127411c64e196d6b37633",
+    strip_prefix = "capnproto-capnproto-4558245/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/6e26d260d1d91e0465ca12bbb5230a1dfa28f00d"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/455824528cd01268d4f9491a0df961c9a3678852"],
 )
 
 http_archive(

--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -32,7 +32,7 @@ public:
     return context.getMetrics().wrapActorSubrequestClient(context.getSubrequest(
         [&](SpanBuilder& span, IoChannelFactory& ioChannelFactory) {
       if (span.isObserved()) {
-        span.setTag("actor_id"_kj, kj::str(actorId));
+        span.setTag("actor_id"_kjc, kj::str(actorId));
       }
 
       return KJ_REQUIRE_NONNULL(actorChannel)->startRequest({
@@ -42,7 +42,7 @@ public:
     }, {
       .inHouse = true,
       .wrapMetrics = true,
-      .operationName = "actor_subrequest"_kj
+      .operationName = kj::ConstString("actor_subrequest"_kjc)
     }));
   }
 
@@ -77,7 +77,7 @@ public:
     return context.getMetrics().wrapActorSubrequestClient(context.getSubrequest(
         [&](SpanBuilder& span, IoChannelFactory& ioChannelFactory) {
       if (span.isObserved()) {
-        span.setTag("actor_id"_kj, id->toString());
+        span.setTag("actor_id"_kjc, id->toString());
       }
 
       return KJ_REQUIRE_NONNULL(actorChannel)->startRequest({
@@ -87,7 +87,7 @@ public:
     }, {
       .inHouse = true,
       .wrapMetrics = true,
-      .operationName = "actor_subrequest"_kj
+      .operationName = kj::ConstString("actor_subrequest"_kjc)
     }));
   }
 

--- a/src/workerd/api/cache.c++
+++ b/src/workerd/api/cache.c++
@@ -86,7 +86,7 @@ jsg::Promise<jsg::Optional<jsg::Ref<Response>>> Cache::match(
     }
 
     auto httpClient = getHttpClient(context, jsRequest->serializeCfBlobJson(js),
-                                    "cache_match"_kj);
+                                    "cache_match"_kjc);
     auto requestHeaders = kj::HttpHeaders(context.getHeaderTable());
     jsRequest->shallowCopyHeadersTo(requestHeaders);
     requestHeaders.set(context.getHeaderIds().cacheControl, "only-if-cached");
@@ -316,7 +316,7 @@ jsg::Promise<void> Cache::put(jsg::Lock& js, Request::Info requestOrUrl,
 
       // Make the PUT request to cache.
       auto httpClient = getHttpClient(context, jsRequest->serializeCfBlobJson(js),
-                                      "cache_put"_kj);
+                                      "cache_put"_kjc);
       auto requestHeaders = kj::HttpHeaders(context.getHeaderTable());
       jsRequest->shallowCopyHeadersTo(requestHeaders);
       auto nativeRequest = httpClient->request(
@@ -467,7 +467,7 @@ jsg::Promise<bool> Cache::delete_(
     // Make the PURGE request to cache.
 
     auto httpClient = getHttpClient(context, jsRequest->serializeCfBlobJson(js),
-                                    "cache_delete"_kj);
+                                    "cache_delete"_kjc);
     auto requestHeaders = kj::HttpHeaders(context.getHeaderTable());
     jsRequest->shallowCopyHeadersTo(requestHeaders);
     // HACK: The cache doesn't permit PURGE requests from the outside world. It does this by
@@ -500,8 +500,8 @@ jsg::Promise<bool> Cache::delete_(
 
 kj::Own<kj::HttpClient> Cache::getHttpClient(IoContext& context,
                                              kj::Maybe<kj::String> cfBlobJson,
-                                             kj::StringPtr operationName) {
-  auto span = context.makeTraceSpan(operationName);
+                                             kj::ConstString operationName) {
+  auto span = context.makeTraceSpan(kj::mv(operationName));
 
   auto cacheClient = context.getCacheClient();
   auto httpClient = cacheName.map([&](kj::String& n) {

--- a/src/workerd/api/cache.h
+++ b/src/workerd/api/cache.h
@@ -78,7 +78,7 @@ private:
   kj::Maybe<kj::String> cacheName;
 
   kj::Own<kj::HttpClient> getHttpClient(IoContext& context,
-      kj::Maybe<kj::String> cfBlobJson, kj::StringPtr operationName);
+      kj::Maybe<kj::String> cfBlobJson, kj::ConstString operationName);
 };
 
 // =======================================================================================

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -278,7 +278,7 @@ kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::request(
       auto client = ioContext.getHttpClient(
           IoContext::NEXT_CLIENT_CHANNEL, false,
           cfBlobJson.map([](kj::StringPtr s) { return kj::str(s); }),
-          "fetch_default"_kj);
+          "fetch_default"_kjc);
       auto adapter = kj::newHttpService(*client);
       auto promise = adapter->request(method, url, headers, requestBody, response);
       // Default handling doesn't rely on the IoContext at all so we can return it as a

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1545,7 +1545,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(
   // TODO(cleanup): Don't convert to HttpClient. Use the HttpService interface instead. This
   //   requires a significant rewrite of the code below. It'll probably get simpler, though?
   kj::Own<kj::HttpClient> client = asHttpClient(fetcher->getClient(
-      ioContext, jsRequest->serializeCfBlobJson(js), "fetch"_kj));
+      ioContext, jsRequest->serializeCfBlobJson(js), "fetch"_kjc));
 
   kj::HttpHeaders headers(ioContext.getHeaderTable());
   jsRequest->shallowCopyHeadersTo(headers);
@@ -2017,7 +2017,7 @@ jsg::Promise<void> Fetcher::delete_(jsg::Lock& js, kj::String url) {
 jsg::Promise<QueueResponse> Fetcher::queue(
       jsg::Lock& js, kj::String queueName, kj::Array<ServiceBindingQueueMessage> messages) {
   auto& ioContext = IoContext::current();
-  auto worker = getClient(ioContext, nullptr, "queue"_kj);
+  auto worker = getClient(ioContext, nullptr, "queue"_kjc);
 
   auto encodedMessages = kj::heapArrayBuilder<IncomingQueueMessage>(messages.size());
   for (auto& msg : messages) {
@@ -2052,10 +2052,10 @@ jsg::Promise<QueueResponse> Fetcher::queue(
 }
 
 kj::Own<WorkerInterface> Fetcher::getClient(
-    IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::StringPtr operationName) {
+    IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName) {
   KJ_SWITCH_ONEOF(channelOrClientFactory) {
     KJ_CASE_ONEOF(channel, uint) {
-      return ioContext.getSubrequestChannel(channel, isInHouse, kj::mv(cfStr), operationName);
+      return ioContext.getSubrequestChannel(channel, isInHouse, kj::mv(cfStr), kj::mv(operationName));
     }
     KJ_CASE_ONEOF(outgoingFactory, IoOwn<OutgoingFactory>) {
       return outgoingFactory->newSingleUseClient(kj::mv(cfStr));

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -422,7 +422,7 @@ public:
   kj::Own<WorkerInterface> getClient(
       IoContext& ioContext,
       kj::Maybe<kj::String> cfStr,
-      kj::StringPtr operationName);
+      kj::ConstString operationName);
   // Returns an `WorkerInterface` that is only valid for the lifetime of the current
   // `IoContext`.
 

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -67,11 +67,11 @@ constexpr auto FLPROD_405_HEADER = "CF-KV-FLPROD-405"_kj;
 kj::Own<kj::HttpClient> KvNamespace::getHttpClient(
     IoContext& context,
     kj::HttpHeaders& headers,
-    kj::OneOf<LimitEnforcer::KvOpType, kj::StringPtr> opTypeOrUnknown,
+    kj::OneOf<LimitEnforcer::KvOpType, kj::LiteralStringConst> opTypeOrUnknown,
     kj::StringPtr urlStr) {
   const auto operationName = [&] {
     KJ_SWITCH_ONEOF(opTypeOrUnknown) {
-      KJ_CASE_ONEOF(name, kj::StringPtr) {
+      KJ_CASE_ONEOF(name, kj::LiteralStringConst) {
         return name;
       }
       KJ_CASE_ONEOF(opType, LimitEnforcer::KvOpType) {
@@ -80,13 +80,13 @@ kj::Own<kj::HttpClient> KvNamespace::getHttpClient(
 
         switch (opType) {
           case LimitEnforcer::KvOpType::GET:
-            return "kv_get"_kj;
+            return "kv_get"_kjc;
           case LimitEnforcer::KvOpType::PUT:
-            return "kv_put"_kj;
+            return "kv_put"_kjc;
           case LimitEnforcer::KvOpType::LIST:
-            return "kv_list"_kj;
+            return "kv_list"_kjc;
           case LimitEnforcer::KvOpType::DELETE:
-            return "kv_delete"_kj;
+            return "kv_delete"_kjc;
         }
       }
     }

--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -156,7 +156,7 @@ protected:
   kj::Own<kj::HttpClient> getHttpClient(
       IoContext& context,
       kj::HttpHeaders& headers,
-      kj::OneOf<LimitEnforcer::KvOpType, kj::StringPtr> opTypeOrName,
+      kj::OneOf<LimitEnforcer::KvOpType, kj::LiteralStringConst> opTypeOrName,
       kj::StringPtr urlStr
   );
   // Do the boilerplate work of constructing an HTTP client to KV. Setting a KvOptType causes

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -104,7 +104,7 @@ kj::Promise<void> WorkerQueue::send(
   // we have to do is provide the end of the path (which is "/message") to send a single message.
   kj::StringPtr url = "https://fake-host/message"_kj;
 
-  auto client = context.getHttpClient(subrequestChannel, true, nullptr, "queue_send"_kj);
+  auto client = context.getHttpClient(subrequestChannel, true, nullptr, "queue_send"_kjc);
   auto req = client->request(kj::HttpMethod::POST, url, headers, serialized.size());
   return req.body->write(serialized.begin(), serialized.size())
       .attach(kj::mv(serialized), kj::mv(req.body), context.registerPendingEvent())
@@ -187,7 +187,7 @@ kj::Promise<void> WorkerQueue::sendBatch(
   KJ_DASSERT(jsg::check(
         v8::JSON::Parse(js.v8Isolate->GetCurrentContext(), jsg::v8Str(js.v8Isolate, body)))->IsObject());
 
-  auto client = context.getHttpClient(subrequestChannel, true, nullptr, "queue_send"_kj);
+  auto client = context.getHttpClient(subrequestChannel, true, nullptr, "queue_send"_kjc);
 
   // The stage that we're sending a subrequest to provides a base URL that includes a scheme, the
   // queue broker's domain, and the start of the URL path including the account ID and queue ID. All

--- a/src/workerd/api/r2-admin.c++
+++ b/src/workerd/api/r2-admin.c++
@@ -21,7 +21,7 @@ jsg::Ref<R2Bucket> R2Admin::get(jsg::Lock& js, kj::String bucketName) {
 jsg::Promise<jsg::Ref<R2Bucket>> R2Admin::create(jsg::Lock& js, kj::String name,
     const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
   auto& context = IoContext::current();
-  auto client = context.getHttpClient(subrequestChannel, true, nullptr, "r2_delete"_kj);
+  auto client = context.getHttpClient(subrequestChannel, true, nullptr, "r2_delete"_kjc);
 
   capnp::JsonCodec json;
   json.handleByAnnotation<R2BindingRequest>();
@@ -51,7 +51,7 @@ jsg::Promise<R2Admin::ListResult> R2Admin::list(jsg::Lock& js,
     const jsg::TypeHandler<jsg::Ref<RetrievedBucket>>& retrievedBucketType,
     const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType, CompatibilityFlags::Reader flags) {
   auto& context = IoContext::current();
-  auto client = context.getHttpClient(subrequestChannel, true, nullptr, "r2_delete"_kj);
+  auto client = context.getHttpClient(subrequestChannel, true, nullptr, "r2_delete"_kjc);
 
   capnp::JsonCodec json;
   json.handleByAnnotation<R2BindingRequest>();
@@ -112,7 +112,7 @@ jsg::Promise<R2Admin::ListResult> R2Admin::list(jsg::Lock& js,
 jsg::Promise<void> R2Admin::delete_(jsg::Lock& js, kj::String name,
     const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
   auto& context = IoContext::current();
-  auto client = context.getHttpClient(subrequestChannel, true, nullptr, "r2_delete"_kj);
+  auto client = context.getHttpClient(subrequestChannel, true, nullptr, "r2_delete"_kjc);
 
   capnp::JsonCodec json;
   json.handleByAnnotation<R2BindingRequest>();

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -315,7 +315,7 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::head(
   return js.evalNow([&] {
     auto& context = IoContext::current();
 
-    auto client = context.getHttpClient(clientIndex, true, nullptr, "r2_get"_kj);
+    auto client = context.getHttpClient(clientIndex, true, nullptr, "r2_get"_kjc);
 
     capnp::JsonCodec json;
     json.handleByAnnotation<R2BindingRequest>();
@@ -349,7 +349,7 @@ R2Bucket::get(jsg::Lock& js, kj::String name, jsg::Optional<GetOptions> options,
   return js.evalNow([&] {
     auto& context = IoContext::current();
 
-    auto client = context.getHttpClient(clientIndex, true, nullptr, "r2_get"_kj);
+    auto client = context.getHttpClient(clientIndex, true, nullptr, "r2_get"_kjc);
 
     capnp::JsonCodec json;
     json.handleByAnnotation<R2BindingRequest>();
@@ -407,7 +407,7 @@ R2Bucket::put(jsg::Lock& js, kj::String name, kj::Maybe<R2PutValue> value,
     });
 
     auto& context = IoContext::current();
-    auto client = context.getHttpClient(clientIndex, true, nullptr, "r2_put"_kj);
+    auto client = context.getHttpClient(clientIndex, true, nullptr, "r2_put"_kjc);
 
     capnp::JsonCodec json;
     json.handleByAnnotation<R2BindingRequest>();
@@ -586,7 +586,7 @@ jsg::Promise<jsg::Ref<R2MultipartUpload>> R2Bucket::createMultipartUpload(jsg::L
   return js.evalNow([&] {
     auto& context = IoContext::current();
     auto client = context.getHttpClient(
-      clientIndex, true, nullptr, "r2_createMultipartUpload"_kj);
+      clientIndex, true, nullptr, "r2_createMultipartUpload"_kjc);
 
     capnp::JsonCodec json;
     json.handleByAnnotation<R2BindingRequest>();
@@ -673,7 +673,7 @@ jsg::Promise<void> R2Bucket::delete_(jsg::Lock& js, kj::OneOf<kj::String, kj::Ar
     const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
   return js.evalNow([&] {
     auto& context = IoContext::current();
-    auto client = context.getHttpClient(clientIndex, true, nullptr, "r2_delete"_kj);
+    auto client = context.getHttpClient(clientIndex, true, nullptr, "r2_delete"_kjc);
 
     capnp::JsonCodec json;
     json.handleByAnnotation<R2BindingRequest>();
@@ -717,7 +717,7 @@ jsg::Promise<R2Bucket::ListResult> R2Bucket::list(
     const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType, CompatibilityFlags::Reader flags) {
   return js.evalNow([&] {
     auto& context = IoContext::current();
-    auto client = context.getHttpClient(clientIndex, true, nullptr, "r2_list"_kj);
+    auto client = context.getHttpClient(clientIndex, true, nullptr, "r2_list"_kjc);
 
     capnp::JsonCodec json;
     json.handleByAnnotation<R2BindingRequest>();

--- a/src/workerd/api/r2-multipart.c++
+++ b/src/workerd/api/r2-multipart.c++
@@ -24,7 +24,7 @@ jsg::Promise<R2MultipartUpload::UploadedPart> R2MultipartUpload::uploadPart(
       "Part number must be between 1 and 10000 (inclusive). Actual value was: ", partNumber);
 
     auto& context = IoContext::current();
-    auto client = context.getHttpClient(this->bucket->clientIndex, true, nullptr, "r2_uploadPart"_kj);
+    auto client = context.getHttpClient(this->bucket->clientIndex, true, nullptr, "r2_uploadPart"_kjc);
 
     capnp::JsonCodec json;
     json.handleByAnnotation<R2BindingRequest>();
@@ -72,7 +72,7 @@ jsg::Promise<jsg::Ref<R2Bucket::HeadResult>> R2MultipartUpload::complete(
   const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
   return js.evalNow([&] {
     auto& context = IoContext::current();
-    auto client = context.getHttpClient(this->bucket->clientIndex, true, nullptr, "r2_completeMultipartUpload"_kj);
+    auto client = context.getHttpClient(this->bucket->clientIndex, true, nullptr, "r2_completeMultipartUpload"_kjc);
 
     capnp::JsonCodec json;
     json.handleByAnnotation<R2BindingRequest>();
@@ -119,7 +119,7 @@ jsg::Promise<jsg::Ref<R2Bucket::HeadResult>> R2MultipartUpload::complete(
 jsg::Promise<void> R2MultipartUpload::abort(jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
   return js.evalNow([&] {
     auto& context = IoContext::current();
-    auto client = context.getHttpClient(this->bucket->clientIndex, true, nullptr, "r2_abortMultipartUpload"_kj);
+    auto client = context.getHttpClient(this->bucket->clientIndex, true, nullptr, "r2_abortMultipartUpload"_kjc);
 
     capnp::JsonCodec json;
     json.handleByAnnotation<R2BindingRequest>();

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -151,7 +151,7 @@ jsg::Ref<Socket> connectImplNoOutputLock(
 
   auto jsRequest = Request::constructor(js, kj::str(addressStr), nullptr);
   kj::Own<WorkerInterface> client = fetcher->getClient(
-      ioContext, jsRequest->serializeCfBlobJson(js), "connect"_kj);
+      ioContext, jsRequest->serializeCfBlobJson(js), "connect"_kjc);
 
   // Set up the connection.
   auto headers = kj::heap<kj::HttpHeaders>(ioContext.getHeaderTable());

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -195,7 +195,7 @@ jsg::Ref<WebSocket> WebSocket::constructor(
       "The url fragment must be empty.");
 
   kj::HttpHeaders headers(context.getHeaderTable());
-  auto client = context.getHttpClient(0, false, nullptr, "WebSocket::constructor");
+  auto client = context.getHttpClient(0, false, nullptr, "WebSocket::constructor"_kjc);
 
   // Set protocols header if necessary.
   KJ_IF_MAYBE(variant, protocols) {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -747,7 +747,7 @@ public:
     bool wrapMetrics;
     // When true, the client is wrapped by metrics.wrapSubrequestClient() ensuring appropriate
     // metrics collection.
-    kj::Maybe<kj::StringPtr> operationName;
+    kj::Maybe<kj::ConstString> operationName;
     // The name to use for the request's span if tracing is turned on.
   };
 
@@ -761,7 +761,7 @@ public:
   // If creating a new subrequest is permitted, calls the given factory function to create one.
 
   kj::Own<WorkerInterface> getSubrequestChannel(
-      uint channel, bool isInHouse, kj::Maybe<kj::String> cfBlobJson, kj::StringPtr operationName);
+      uint channel, bool isInHouse, kj::Maybe<kj::String> cfBlobJson, kj::ConstString operationName);
   // Get WorkerInterface objects to use for subrequests.
   //
   // `channel` specifies which outgoing channel to use. The special channel 0 refers to the "null"
@@ -783,14 +783,14 @@ public:
 
   kj::Own<WorkerInterface> getSubrequestChannelNoChecks(
       uint channel, bool isInHouse, kj::Maybe<kj::String> cfBlobJson,
-      kj::Maybe<kj::StringPtr> operationName = nullptr);
+      kj::Maybe<kj::ConstString> operationName = nullptr);
   // Like getSubrequestChannel() but doesn't enforce limits. Use for trusted paths only.
 
   kj::Own<kj::HttpClient> getHttpClient(
-      uint channel, bool isInHouse, kj::Maybe<kj::String> cfBlobJson, kj::StringPtr operationName);
+      uint channel, bool isInHouse, kj::Maybe<kj::String> cfBlobJson, kj::ConstString operationName);
   kj::Own<kj::HttpClient> getHttpClientNoChecks(
       uint channel, bool isInHouse, kj::Maybe<kj::String> cfBlobJson,
-      kj::Maybe<kj::StringPtr> operationName = nullptr);
+      kj::Maybe<kj::ConstString> operationName = nullptr);
   // Convenience methods that call getSubrequest*() and adapt the returned WorkerInterface objects
   // to HttpClient.
   //
@@ -822,7 +822,7 @@ public:
   // Returns the current span being recorded.  If called while the JS lock is held, uses the trace
   // information from the current async context, if available.
 
-  SpanBuilder makeTraceSpan(kj::StringPtr operationName);
+  SpanBuilder makeTraceSpan(kj::ConstString operationName);
   // Returns a builder for recording tracing spans (or a no-op builder if tracing is inactive).
   // If called while the JS lock is held, uses the trace information from the current async
   // context, if available.

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -312,19 +312,20 @@ void SpanBuilder::end() {
   }
 }
 
-void SpanBuilder::setOperationName(kj::StringPtr operationName) {
+void SpanBuilder::setOperationName(kj::ConstString operationName) {
   KJ_IF_MAYBE(s, span) {
-    s->operationName = operationName;
+    s->operationName = kj::mv(operationName);
   }
 }
 
-void SpanBuilder::setTag(kj::StringPtr key, TagValue value) {
+void SpanBuilder::setTag(kj::ConstString key, TagValue value) {
   KJ_IF_MAYBE(s, span) {
-    s->tags.upsert(key, kj::mv(value), [key](TagValue& existingValue, TagValue&& newValue) {
+    auto keyPtr = key.asPtr();
+    s->tags.upsert(kj::mv(key), kj::mv(value), [keyPtr](TagValue& existingValue, TagValue&& newValue) {
       // This is a programming error, but not a serious one. We could alternatively just emit
       // duplicate tags and leave the Jaeger UI in charge of warning about them.
-      [[maybe_unused]] static auto logged = [key]() {
-        KJ_LOG(WARNING, "overwriting previous tag", key);
+      [[maybe_unused]] static auto logged = [keyPtr]() {
+        KJ_LOG(WARNING, "overwriting previous tag", keyPtr);
         return true;
       }();
       existingValue = kj::mv(newValue);
@@ -332,7 +333,7 @@ void SpanBuilder::setTag(kj::StringPtr key, TagValue value) {
   }
 }
 
-void SpanBuilder::addLog(kj::Date timestamp, kj::StringPtr key, TagValue value) {
+void SpanBuilder::addLog(kj::Date timestamp, kj::ConstString key, TagValue value) {
   KJ_IF_MAYBE(s, span) {
     if (s->logs.size() >= Span::MAX_LOGS) {
       ++s->droppedLogs;
@@ -340,7 +341,7 @@ void SpanBuilder::addLog(kj::Date timestamp, kj::StringPtr key, TagValue value) 
       s->logs.add(Span::Log {
         .timestamp = timestamp,
         .tag = {
-          .key = key,
+          .key = kj::mv(key),
           .value = kj::mv(value),
         }
       });

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -347,7 +347,7 @@ struct Span {
 public:
   using TagValue = kj::OneOf<bool, int64_t, double, kj::String>;
   // TODO(someday): Support binary bytes, too.
-  using TagMap = kj::HashMap<kj::StringPtr, TagValue>;
+  using TagMap = kj::HashMap<kj::ConstString, TagValue>;
   using Tag = TagMap::Entry;
 
   struct Log {
@@ -355,7 +355,7 @@ public:
     Tag tag;
   };
 
-  kj::StringPtr operationName;
+  kj::ConstString operationName;
   kj::Date startTime;
   kj::Date endTime;
   TagMap tags;
@@ -370,8 +370,8 @@ public:
   // we'll typically have space for one last element available for the "dropped_logs" log without
   // needing to grow the vector.
 
-  explicit Span(kj::StringPtr operationName, kj::Date startTime)
-      : operationName(operationName), startTime(startTime), endTime(startTime) {}
+  explicit Span(kj::ConstString operationName, kj::Date startTime)
+      : operationName(kj::mv(operationName)), startTime(startTime), endTime(startTime) {}
 };
 
 class SpanParent {
@@ -394,7 +394,7 @@ public:
 
   SpanParent addRef();
 
-  SpanBuilder newChild(kj::StringPtr operationName,
+  SpanBuilder newChild(kj::ConstString operationName,
       kj::Date startTime = kj::systemPreciseCalendarClock().now());
   // Create a new child span.
   //
@@ -427,11 +427,11 @@ class SpanBuilder {
   // observer (if there is one) receives the content.
 
 public:
-  explicit SpanBuilder(kj::Maybe<kj::Own<SpanObserver>> observer, kj::StringPtr operationName,
+  explicit SpanBuilder(kj::Maybe<kj::Own<SpanObserver>> observer, kj::ConstString operationName,
                        kj::Date startTime = kj::systemPreciseCalendarClock().now()) {
     if (observer != nullptr) {
       this->observer = kj::mv(observer);
-      span.emplace(operationName, startTime);
+      span.emplace(kj::mv(operationName), startTime);
     }
   }
   // Create a new top-level span that will report to the given observer. If the observer is null,
@@ -464,23 +464,23 @@ public:
   // trace IDs in a way that is specific to the trace back-end being used. The caller must downcast
   // the `SpanObserver` to the expected observer type in order to extract the trace ID.
 
-  SpanBuilder newChild(kj::StringPtr operationName,
+  SpanBuilder newChild(kj::ConstString operationName,
       kj::Date startTime = kj::systemPreciseCalendarClock().now());
   // Create a new child span.
   //
   // `operationName` should be a string literal with infinite lifetime.
 
-  void setOperationName(kj::StringPtr operationName);
+  void setOperationName(kj::ConstString operationName);
   // Change the operation name from what was specified at span creation.
   //
   // `operationName` should be a string literal with infinite lifetime.
 
   using TagValue = Span::TagValue;
-  void setTag(kj::StringPtr key, TagValue value);
+  void setTag(kj::ConstString key, TagValue value);
   // `key` must point to memory that will remain valid all the way until this span's data is
   // serialized.
 
-  void addLog(kj::Date timestamp, kj::StringPtr key, TagValue value);
+  void addLog(kj::Date timestamp, kj::ConstString key, TagValue value);
   // `key` must point to memory that will remain valid all the way until this span's data is
   // serialized.
   //
@@ -522,14 +522,14 @@ inline SpanParent SpanParent::addRef() {
   return SpanParent(mapAddRef(observer));
 }
 
-inline SpanBuilder SpanParent::newChild(kj::StringPtr operationName, kj::Date startTime) {
+inline SpanBuilder SpanParent::newChild(kj::ConstString operationName, kj::Date startTime) {
   return SpanBuilder(observer.map([](kj::Own<SpanObserver>& obs) { return obs->newChild(); }),
-                     operationName, startTime);
+                     kj::mv(operationName), startTime);
 }
 
-inline SpanBuilder SpanBuilder::newChild(kj::StringPtr operationName, kj::Date startTime) {
+inline SpanBuilder SpanBuilder::newChild(kj::ConstString operationName, kj::Date startTime) {
   return SpanBuilder(observer.map([](kj::Own<SpanObserver>& obs) { return obs->newChild(); }),
-                     operationName, startTime);
+                     kj::mv(operationName), startTime);
 }
 
 } // namespace workerd

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -457,6 +457,13 @@ public:
   bool isObserved() { return observer != nullptr; }
   // Useful to skip unnecessary code when not observed.
 
+  kj::Maybe<SpanObserver&> getObserver() { return observer; }
+  // Get the underlying SpanObserver representing the span.
+  //
+  // This is needed in particular when making outbound network requests that must be annotated with
+  // trace IDs in a way that is specific to the trace back-end being used. The caller must downcast
+  // the `SpanObserver` to the expected observer type in order to extract the trace ID.
+
   SpanBuilder newChild(kj::StringPtr operationName,
       kj::Date startTime = kj::systemPreciseCalendarClock().now());
   // Create a new child span.


### PR DESCRIPTION
* [Don't set observer null when ending span](https://github.com/cloudflare/workerd/commit/6e971e5439ec67e4a3f8e2788d3bdb9ff71b80ed)

  Encapsulating the entire span in a state containing the observer and span and setting it null on `end()` prevents the creation of subspans after the span has ended.

* [Add getObserver to SpanBuilder](https://github.com/cloudflare/workerd/commit/e3ec9a9541908a00ddcd793435ca63c0986c2785)

* [Switch span tracing APIs to use kj::ConstString](https://github.com/cloudflare/workerd/commit/66b2b51ca93693f4f6ee5edaec483f5456fe553a)