### PR TITLE
[WIP] Implements TLS support for TCP sockets.

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -616,7 +616,7 @@ jsg::Promise<jsg::Ref<Response>> ServiceWorkerGlobalScope::fetch(
 jsg::Ref<Socket> ServiceWorkerGlobalScope::connect(
     jsg::Lock& js, AnySocketAddress address, jsg::Optional<SocketOptions> options,
     CompatibilityFlags::Reader featureFlags) {
-  return connectImpl(js, nullptr, kj::mv(address), featureFlags);
+  return connectImpl(js, nullptr, kj::mv(address), kj::mv(options), featureFlags);
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1880,7 +1880,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImpl(
 jsg::Ref<Socket> Fetcher::connect(
     jsg::Lock& js, AnySocketAddress address, jsg::Optional<SocketOptions> options,
     CompatibilityFlags::Reader featureFlags) {
-  return connectImpl(js, JSG_THIS, kj::mv(address), featureFlags);
+  return connectImpl(js, JSG_THIS, kj::mv(address), kj::mv(options), featureFlags);
 }
 
 jsg::Promise<jsg::Ref<Response>> Fetcher::fetch(

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -6,6 +6,7 @@
 
 #include <workerd/jsg/jsg.h>
 #include "http.h"
+#include <kj/compat/tls.h>
 
 
 namespace workerd::api {
@@ -17,17 +18,19 @@ struct SocketAddress {
 };
 
 struct SocketOptions {
-  jsg::Unimplemented tls; // TODO(later): TCP socket options need to be implemented.
+  bool tls;
   JSG_STRUCT(tls);
 };
 
 class Socket: public jsg::Object {
 public:
   Socket(jsg::Lock& js, jsg::Ref<ReadableStream> readable, jsg::Ref<WritableStream> writable,
-      kj::Own<jsg::PromiseResolverPair<void>> close)
+      kj::Own<jsg::PromiseResolverPair<void>> close,
+      kj::Maybe<kj::Array<kj::TlsCertificate>> systemCerts)
       : readable(kj::mv(readable)), writable(kj::mv(writable)),
         closeFulfiller(kj::mv(close)),
-        closedPromise(kj::mv(closeFulfiller->promise)) { };
+        closedPromise(kj::mv(closeFulfiller->promise)),
+        systemCerts(kj::mv(systemCerts)) { };
 
   jsg::Ref<ReadableStream> getReadable() { return readable.addRef(); }
   jsg::Ref<WritableStream> getWritable() { return writable.addRef(); }
@@ -55,6 +58,7 @@ private:
   kj::Own<jsg::PromiseResolverPair<void>> closeFulfiller;
   // This fulfiller is used to resolve the `closedPromise` below.
   jsg::MemoizedIdentity<jsg::Promise<void>> closedPromise;
+  kj::Maybe<kj::Array<kj::TlsCertificate>> systemCerts;
 
   kj::Promise<kj::Own<kj::AsyncIoStream>> processConnection();
 
@@ -80,10 +84,12 @@ private:
 };
 
 jsg::Ref<Socket> connectImplNoOutputLock(
-    jsg::Lock& js, jsg::Ref<Fetcher> fetcher, AnySocketAddress address);
+    jsg::Lock& js, jsg::Ref<Fetcher> fetcher, AnySocketAddress address,
+    jsg::Optional<SocketOptions> options);
 
 jsg::Ref<Socket> connectImpl(
     jsg::Lock& js, kj::Maybe<jsg::Ref<Fetcher>> fetcher, AnySocketAddress address,
+    jsg::Optional<SocketOptions> options,
     CompatibilityFlags::Reader featureFlags);
 
 #define EW_SOCKETS_ISOLATE_TYPES     \

--- a/src/workerd/util/thread-scopes.c++
+++ b/src/workerd/util/thread-scopes.c++
@@ -14,6 +14,8 @@ namespace {
 
 thread_local uint allowV8BackgroundThreadScopeCount = 0;
 thread_local uint isolateShutdownThreadScopeCount = 0;
+// XXX: Do we have other global vars? Is there a better place for this?
+kj::Maybe<kj::String> globalTlsSystemCerts;
 
 bool multiTenantProcess = false;
 bool predictableMode = false;
@@ -63,6 +65,14 @@ bool isPredictableModeForTest() {
 
 void setPredictableModeForTest() {
   predictableMode = true;
+}
+
+void initGlobalTlsSystemCerts() {
+  globalTlsSystemCerts = KJ_ASSERT_NONNULL(kj::readTlsSystemCerts());
+}
+
+kj::Maybe<kj::StringPtr> getGlobalTlsSystemCerts() {
+  return globalTlsSystemCerts;
 }
 
 ThreadProgressCounter::ThreadProgressCounter(uint64_t& counter)

--- a/src/workerd/util/thread-scopes.h
+++ b/src/workerd/util/thread-scopes.h
@@ -14,6 +14,7 @@
 
 #include <kj/common.h>
 #include <inttypes.h>
+#include <kj/compat/tls.h>
 
 namespace workerd {
 
@@ -63,6 +64,9 @@ void setPredictableModeForTest();
 // Tracks whether the process should run in "predictable mode" for testing purposes. This causes
 // random number generators to return static results instead, changes some timers to return zero,
 // etc. This should only be used in tests.
+
+void initGlobalTlsSystemCerts();
+kj::Maybe<kj::StringPtr> getGlobalTlsSystemCerts();
 
 class ThreadProgressCounter {
   // RAII class which allows the thread's active watchdog to observe forward progress through


### PR DESCRIPTION
Adds TLS support to TCP sockets with default TLS system store certificates.

### Test Plan

Tested with changes to gopher.js script (https://gist.github.com/dom96/1fda0c3fc62b68f403f98583763e1ea6)

```
$ bazel run @workerd//src/workerd/server:workerd -- serve $PWD/deps/workerd/samples/tcp/config.capnp --watch --verbose --experimental
$ curl -v localhost:8080
```

And with proxy:

```
$ tinyproxy -d -c tinyproxy.conf
$ curl -v localhost:8080/?use_proxy=true
```
