### PR TITLE
Report js exceptions from alarm handlers in traces

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -156,6 +156,7 @@ kj::StringPtr KJ_STRINGIFY(UncaughtExceptionSource value) {
     case UncaughtExceptionSource::ASYNC_TASK:       return "Uncaught (async)"_kj;
     case UncaughtExceptionSource::REQUEST_HANDLER:  return "Uncaught (in response)"_kj;
     case UncaughtExceptionSource::TRACE_HANDLER:    return "Uncaught (in trace)"_kj;
+    case UncaughtExceptionSource::ALARM_HANDLER:    return "Uncaught (in alarm)"_kj;
   };
   KJ_UNREACHABLE;
 }

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -504,7 +504,8 @@ enum class UncaughtExceptionSource {
 
   ASYNC_TASK,
   REQUEST_HANDLER,
-  TRACE_HANDLER
+  TRACE_HANDLER,
+  ALARM_HANDLER,
 };
 kj::StringPtr KJ_STRINGIFY(UncaughtExceptionSource value);
 


### PR DESCRIPTION
While we were correctly observing that exceptions had happened in the event outcome, we were not logging these exceptions in the trace, which makes debugging difficult for worker developers.