### PR TITLE
Extend and harden crypto api error handling

### DIFF
--- a/src/workerd/api/crypto-impl-asymmetric.c++
+++ b/src/workerd/api/crypto-impl-asymmetric.c++
@@ -1025,10 +1025,10 @@ public:
 
     // Adapted from https://wiki.openssl.org/index.php/Elliptic_Curve_Diffie_Hellman:
     auto& privateEcKey = JSG_REQUIRE_NONNULL(EVP_PKEY_get0_EC_KEY(getEvpPkey()),
-        InternalDOMOperationError, "Not elliptic curve data backing key",
+        InternalDOMOperationError, "No elliptic curve data backing key",
         tryDescribeOpensslErrors());
     auto& publicEcKey = JSG_REQUIRE_NONNULL(EVP_PKEY_get0_EC_KEY(publicKeyImpl.getEvpPkey()),
-        InternalDOMOperationError, "Not elliptic curve data backing key",
+        InternalDOMOperationError, "No elliptic curve data backing key",
         tryDescribeOpensslErrors());
     auto& publicEcPoint = JSG_REQUIRE_NONNULL(EC_KEY_get0_public_key(&publicEcKey),
         DOMOperationError, "No public elliptic curve key data in this key",
@@ -1212,7 +1212,7 @@ private:
 
   SubtleCrypto::JsonWebKey exportJwk() const override final {
     const EC_KEY& ec = JSG_REQUIRE_NONNULL(EVP_PKEY_get0_EC_KEY(getEvpPkey()), DOMOperationError,
-        "Not elliptic curve data backing key", tryDescribeOpensslErrors());
+        "No elliptic curve data backing key", tryDescribeOpensslErrors());
 
     const auto& group = JSG_REQUIRE_NONNULL(EC_KEY_get0_group(&ec), DOMOperationError,
         "No elliptic curve group in this key", tryDescribeOpensslErrors());
@@ -1250,7 +1250,7 @@ private:
         "Raw export of elliptic curve keys is only allowed for public keys.");
 
     const EC_KEY& ec = JSG_REQUIRE_NONNULL(EVP_PKEY_get0_EC_KEY(getEvpPkey()),
-        InternalDOMOperationError, "Not elliptic curve data backing key",
+        InternalDOMOperationError, "No elliptic curve data backing key",
         tryDescribeOpensslErrors());
     const auto& group = JSG_REQUIRE_NONNULL(EC_KEY_get0_group(&ec), InternalDOMOperationError,
         "No elliptic curve group in this key", tryDescribeOpensslErrors());

--- a/src/workerd/api/crypto-impl-test.c++
+++ b/src/workerd/api/crypto-impl-test.c++
@@ -1,0 +1,36 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include <kj/test.h>
+
+#include "crypto-impl.h"
+
+#include <openssl/rsa.h>
+#include <openssl/ec.h>
+
+namespace workerd::api {
+namespace {
+
+KJ_TEST("Crypto error conversion") {
+  ERR_clear_error();
+  // Intentionally provide an error type not handled in throwOpensslError()
+  // (RSA_R_CANNOT_RECOVER_MULTI_PRIME_KEY) that overlaps with an EC error that we do handle
+  // (EC_R_INVALID_ENCODING). This test will fail if we do not check the library code of the error.
+  // This test needs to be updated (e.g. with a different error code) if
+  // RSA_R_CANNOT_RECOVER_MULTI_PRIME_KEY is added to the error types provided to users in
+  // throwOpensslError().
+
+  OPENSSL_PUT_ERROR(RSA, RSA_R_CANNOT_RECOVER_MULTI_PRIME_KEY);
+  // Throw an exception based on boringssl error queue, expecting to get an internal error instead
+  // of a DOMException
+  KJ_EXPECT_THROW_MESSAGE("OpenSSL call failed", OSSLCALL(0));
+
+  // EC_R_INVALID_ENCODING is one of the errors converted to user errors, test that it is converted
+  // to a DOMException.
+  OPENSSL_PUT_ERROR(EC, EC_R_INVALID_ENCODING);
+  KJ_EXPECT_THROW_MESSAGE("jsg.DOMException(OperationError): Invalid point encoding.", OSSLCALL(0));
+}
+
+}  // namespace
+}  // namespace workerd::api


### PR DESCRIPTION
This commit improves error handling in the Web Crypto API:
- Do error checking for a few functions that can produce openssl errors and did not have error checking previously. This should result in more meaningful errors being reported.
- Examine errors more thoroughly in `throwOpensslError`, this is necessary as some error codes in different libraries have the same value, this could result in the wrong error being recorded unless the library code is checked too.
- Add a new test case to ensure that the function is now working correctly.