### PR TITLE
Add `default` exports for `node:{buffer,events}` and remove `assert` export on `node:assert`

### DIFF
--- a/src/node/buffer.ts
+++ b/src/node/buffer.ts
@@ -3,3 +3,4 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 export * from 'node-internal:internal_buffer';
+export { default } from 'node-internal:internal_buffer';

--- a/src/node/events.ts
+++ b/src/node/events.ts
@@ -4,4 +4,4 @@
 //
 
 export * from 'node-internal:events';
-
+export { default } from 'node-internal:events';

--- a/src/node/internal/internal_assert.ts
+++ b/src/node/internal/internal_assert.ts
@@ -71,7 +71,7 @@ function createAssertionError(
   return error;
 }
 
-export function assert(actual: unknown, message?: string | Error): asserts actual {
+function assert(actual: unknown, message?: string | Error): asserts actual {
   if (arguments.length === 0) {
     throw new AssertionError({
       message: "No value argument passed to `assert.ok()`",


### PR DESCRIPTION
Hey! 👋 This PR adds some missing default exports and removes an extraneous `assert` export, to match the behaviour of Node.js:

```js
import assert from "node:assert";
import * as all_assert from "node:assert";
import buffer from "node:buffer";
import events from "node:events";

console.log(typeof assert); // function
console.log(assert.assert); // undefined
console.log(all_assert.assert); // undefined
console.log(typeof assert.AssertionError); // function
console.log(typeof all_assert.AssertionError); // function
console.log(typeof buffer); // object
console.log(typeof events); // function
```

Given `nodejs_compat` hasn't been released publicly yet, I guess the removing `assert` change doesn't need to be behind a compatibility flag?