### PR TITLE
Fix KVNamespace get() types when passing KVNamespaceGetOptions

### DIFF
--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -129,8 +129,8 @@ public:
       get(key: Key, type: "stream"): Promise<ReadableStream | null>;
       get(key: Key, options?: KVNamespaceGetOptions<"text">): Promise<string | null>;
       get<ExpectedValue = unknown>(key: Key, options?: KVNamespaceGetOptions<"json">): Promise<ExpectedValue | null>;
-      get(key: Key, options?: KVNamespaceGetOptions<"arrayBuffer">): Promise<string | null>;
-      get(key: Key, options?: KVNamespaceGetOptions<"stream">): Promise<string | null>;
+      get(key: Key, options?: KVNamespaceGetOptions<"arrayBuffer">): Promise<ArrayBuffer | null>;
+      get(key: Key, options?: KVNamespaceGetOptions<"stream">): Promise<ReadableStream | null>;
 
       list<Metadata = unknown>(options?: KVNamespaceListOptions): Promise<KVNamespaceListResult<Metadata, Key>>;
 


### PR DESCRIPTION
Currently the types are correct if you do:
```js
const myArrayBuffer = env.KV.get("myKey", "arrayBuffer")
```
But incorrect if you do:
```js
const myArrayBuffer = env.KV.get("myKey", { type: "arrayBuffer", cacheTtl: 60 })
```