### PR TITLE
Allow setAlarm to be invoked in Durable Object constructors

### DIFF
--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -703,7 +703,7 @@ public:
 
   const Worker& getWorker() { return *worker; }
 
-  bool hasAlarmHandler();
+  void assertCanSetAlarm();
   kj::Promise<void> makeAlarmTaskForPreview(kj::Date scheduledTime);
 
   kj::Promise<WorkerInterface::AlarmResult> dedupAlarm(


### PR DESCRIPTION
For implementation reasons, we cannot confirm the presence of an alarm handler during the invocation of a durable object's constructor. That said, we also cannot confirm the absence of that handler either. Let's just lean on the alarm runner to do the right thing when the time comes.