### PR TITLE
Change TCP Socket's `connect` to take a SocketAddress struct.

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -600,7 +600,7 @@ jsg::Promise<jsg::Ref<Response>> ServiceWorkerGlobalScope::fetch(
 }
 
 jsg::Ref<Socket> ServiceWorkerGlobalScope::connect(
-    jsg::Lock& js, kj::String address, jsg::Optional<SocketOptions> options,
+    jsg::Lock& js, AnySocketAddress address, jsg::Optional<SocketOptions> options,
     CompatibilityFlags::Reader featureFlags) {
   return connectImpl(js, nullptr, kj::mv(address), featureFlags);
 }

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -264,7 +264,7 @@ public:
       CompatibilityFlags::Reader featureFlags);
 
   jsg::Ref<Socket> connect(
-      jsg::Lock& js, kj::String address, jsg::Optional<SocketOptions> options,
+      jsg::Lock& js, AnySocketAddress address, jsg::Optional<SocketOptions> options,
       CompatibilityFlags::Reader featureFlags);
 
   jsg::Ref<ServiceWorkerGlobalScope> getSelf() {

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1878,7 +1878,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImpl(
 }
 
 jsg::Ref<Socket> Fetcher::connect(
-    jsg::Lock& js, kj::String address, jsg::Optional<SocketOptions> options,
+    jsg::Lock& js, AnySocketAddress address, jsg::Optional<SocketOptions> options,
     CompatibilityFlags::Reader featureFlags) {
   return connectImpl(js, JSG_THIS, kj::mv(address), featureFlags);
 }

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -353,6 +353,8 @@ struct RequestInitializerDict;
 
 class Socket;
 struct SocketOptions;
+struct SocketAddress;
+typedef kj::OneOf<SocketAddress, kj::String> AnySocketAddress;
 
 class Fetcher: public jsg::Object {
   // A capability to send HTTP requests to some destination other than the public internet.
@@ -429,7 +431,7 @@ public:
   // specified on URLs, Fetcher-specific URL decoding options, and error handling.
 
   jsg::Ref<Socket> connect(
-      jsg::Lock& js, kj::String address, jsg::Optional<SocketOptions> options,
+      jsg::Lock& js, AnySocketAddress address, jsg::Optional<SocketOptions> options,
       CompatibilityFlags::Reader featureFlags);
 
   jsg::Promise<jsg::Ref<Response>> fetch(

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -10,6 +10,12 @@
 
 namespace workerd::api {
 
+struct SocketAddress {
+  kj::String hostname;
+  uint16_t port;
+  JSG_STRUCT(hostname, port);
+};
+
 struct SocketOptions {
   jsg::Unimplemented tls; // TODO(later): TCP socket options need to be implemented.
   JSG_STRUCT(tls);
@@ -74,15 +80,16 @@ private:
 };
 
 jsg::Ref<Socket> connectImplNoOutputLock(
-    jsg::Lock& js, jsg::Ref<Fetcher> fetcher, kj::String address);
+    jsg::Lock& js, jsg::Ref<Fetcher> fetcher, AnySocketAddress address);
 
 jsg::Ref<Socket> connectImpl(
-    jsg::Lock& js, kj::Maybe<jsg::Ref<Fetcher>> fetcher, kj::String address,
+    jsg::Lock& js, kj::Maybe<jsg::Ref<Fetcher>> fetcher, AnySocketAddress address,
     CompatibilityFlags::Reader featureFlags);
 
-#define EW_SOCKETS_ISOLATE_TYPES         \
+#define EW_SOCKETS_ISOLATE_TYPES     \
   api::Socket,                       \
-  api::SocketOptions
+  api::SocketOptions,                \
+  api::SocketAddress
 
 // The list of sockets.h types that are added to worker.c++'s JSG_DECLARE_ISOLATE_TYPE
 }  // namespace workerd::api


### PR DESCRIPTION
This is a breaking change to the API, but one that should make it more consistent with other implementations.

Tested upstream.