### PR TITLE
Log accesses to the request.cf.botManagement property

### DIFF
--- a/src/workerd/api/util.h
+++ b/src/workerd/api/util.h
@@ -140,4 +140,8 @@ inline kj::Promise<DeferredProxy<void>> addNoopDeferredProxy(kj::Promise<void> p
   return promise.then([]() { return DeferredProxy<void> { kj::READY_NOW }; });
 }
 
+kj::Maybe<jsg::V8Ref<v8::Object>> cloneRequestCf(
+    jsg::Lock& js, kj::Maybe<jsg::V8Ref<v8::Object>> maybeCf);
+void maybeWrapBotManagement(v8::Isolate* isolate, v8::Local<v8::Object> handle);
+
 }  // namespace workerd::api

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -70,6 +70,9 @@ public:
   virtual void finishedWaitUntilTask() {}
 
   virtual void setFailedOpen(bool value) {}
+
+  virtual void logBotManagementUse() {}
+  // Logging accesses to the request.cf.botManagement object.
 };
 
 class IsolateObserver: public kj::AtomicRefcounted {

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1492,6 +1492,9 @@ void Worker::handleLog(jsg::Lock& js, LogLevel level, const v8::FunctionCallback
       }
 
       KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+        // On the off chance the the arg is the request.cf object, let's make
+        // sure we do not log proxied fields here.
+        NoRequestCfProxyLoggingScope noLoggingScope;
         if (shouldSerialiseToJson) {
           auto s = js.serializeJson(arg);
           // serializeJson returns the string "undefined" for some values (undefined,

--- a/src/workerd/util/thread-scopes.c++
+++ b/src/workerd/util/thread-scopes.c++
@@ -14,6 +14,7 @@ namespace {
 
 thread_local uint allowV8BackgroundThreadScopeCount = 0;
 thread_local uint isolateShutdownThreadScopeCount = 0;
+thread_local uint noProxyLoggingScope = 0;
 
 bool multiTenantProcess = false;
 bool predictableMode = false;
@@ -111,6 +112,18 @@ void ThreadProgressCounter::acknowledgeProgress() {
   KJ_IF_MAYBE(progressCounter, activeProgressCounter) {
     progressCounter->savedValue = __atomic_load_n(&progressCounter->counter, __ATOMIC_RELAXED);
   }
+}
+
+NoRequestCfProxyLoggingScope::NoRequestCfProxyLoggingScope() {
+  ++noProxyLoggingScope;
+}
+
+NoRequestCfProxyLoggingScope::~NoRequestCfProxyLoggingScope() noexcept(false) {
+  --noProxyLoggingScope;
+}
+
+bool NoRequestCfProxyLoggingScope::isActive() {
+  return noProxyLoggingScope > 0;
 }
 
 }  // namespace workerd

--- a/src/workerd/util/thread-scopes.h
+++ b/src/workerd/util/thread-scopes.h
@@ -99,4 +99,17 @@ private:
   friend class Watchdog;
 };
 
+class NoRequestCfProxyLoggingScope {
+  // We current implement logging when the request.cf.botManagement properties are accessed.
+  // This scope is used specifically to suppress logging when we need to iterate or clone
+  // that structure.
+public:
+  NoRequestCfProxyLoggingScope();
+  ~NoRequestCfProxyLoggingScope() noexcept(false);
+
+  static bool isActive();
+
+  KJ_DISALLOW_COPY_AND_MOVE(NoRequestCfProxyLoggingScope);
+};
+
 }  // namespace workerd


### PR DESCRIPTION
This adds logging when a worker accesses the `request.cf.botManagement` metadata property. ~~We attempt to be smart about it, only logging once per worker instance per process, and we disable the logging when internally cloning or JSON serializing the value. However, this could still yield false positives. For instance, if the user just simply destructures the object, or iterates over the values without actually intending to access the `botManagement` property, this will get triggered.~~

An alternative approach would be to proxy the individual fields of the `botManagement` object itself. That approach would likely yield more accurate logging with fewer false positives but is slightly more invasive, requiring us to either wrap the entire `botManagement` value in a Proxy or define a catch-all named property interceptor. Either approach should work.

~~Marking this draft until we settle on what approach we want to go with.~~

Updated: Went with the proxy wrapper approach.