### PR TITLE
Improve Webcrypto error handling, resolve several internal errors and add clarifying comments

### DIFF
--- a/src/workerd/api/crypto-impl-asymmetric.c++
+++ b/src/workerd/api/crypto-impl-asymmetric.c++
@@ -624,6 +624,7 @@ public:
     auto signature = kj::heapArray<kj::byte>(size);
     size_t signatureSize = 0;
 
+    // Use raw RSA, no padding
     OSSLCALL(RSA_decrypt(rsa, &signatureSize, signature.begin(), size, data.begin(), data.size(),
         RSA_NO_PADDING));
 
@@ -992,6 +993,8 @@ kj::Own<CryptoKey::Impl> CryptoKey::Impl::importRsaRaw(
     SubtleCrypto::ImportKeyData keyData,
     SubtleCrypto::ImportKeyAlgorithm&& algorithm, bool extractable,
     kj::ArrayPtr<const kj::String> keyUsages) {
+  // Note that in this context raw refers to the RSA-RAW algorithm, not to keys represented by raw
+  // data. Importing raw keys is currently not supported for this algorithm.
   CryptoKeyUsageSet allowedUsages = CryptoKeyUsageSet::sign() | CryptoKeyUsageSet::verify();
   auto [evpPkey, keyType, usages] = importAsymmetric(
       kj::mv(format), kj::mv(keyData), normalizedName, extractable, keyUsages,
@@ -1534,6 +1537,7 @@ kj::Own<EVP_PKEY> ellipticJwkReader(int curveId, SubtleCrypto::JsonWebKey keyDat
 ImportAsymmetricResult importEllipticRaw(SubtleCrypto::ImportKeyData keyData, int curveId,
     kj::StringPtr normalizedName, kj::ArrayPtr<const kj::String> keyUsages,
     CryptoKeyUsageSet allowedUsages) {
+  // Import an elliptic key represented by raw data, only public keys are supported.
   JSG_REQUIRE(keyData.is<kj::Array<kj::byte>>(), DOMDataError,
       "Expected raw EC key but instead got a Json Web Key.");
 


### PR DESCRIPTION
Commit messages and comments should explain the changes reasonably well, please let me know if you find anything unclear.
One issue that merits discussion is whether to validate imported RSA keys. Calling validateRsaParams() should only reject keys that are unreasonably large or possibly insecure based on the modulus size or exponent, but may break existing scripts that import such keys. Fortunately, the other changes add some key size checks during signing and should be sufficient to prevent internal errors even if unreasonably small keys are imported.
For signing with RSASSA-PKCS1-v1_5, in very few cases errors will be reported where there previously was no error (e.g. when importing a key of exactly 62 or 63 bytes, using SHA256 as the hash digest and trying to use it for signing). I think the change – requiring the key to be at least 32 bytes larger than the hash digest when 26 or 30 would be sufficient depending on which hash is used – is sensible since there is no good reason to use keys of these specific sizes, boringssl doesn't generate keys of that size already and it is unlikely anyone is using this exact configuration.