### PR TITLE
Relax overly strict IoContext checking for ReadableStreams

### DIFF
--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -599,4 +599,11 @@ jsg::Promise<T> rejectedMaybeHandledPromise(
   return kj::mv(prp.promise);
 }
 
+inline kj::Maybe<IoContext&> tryGetIoContext() {
+  if (IoContext::hasCurrent()) {
+    return IoContext::current();
+  }
+  return nullptr;
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -48,7 +48,7 @@ private:
   // ReadableStream remains in the "reader locked" state, per the spec.
   struct Released {};
 
-  IoContext& ioContext;
+  kj::Maybe<IoContext&> ioContext;
   ReadableStreamController::Reader& reader;
 
   kj::OneOf<Initial, Attached, StreamStates::Closed, Released> state = Initial();
@@ -176,7 +176,7 @@ class ReadableStream: public jsg::Object {
 private:
 
   struct AsyncIteratorState {
-    IoContext& ioContext;
+    kj::Maybe<IoContext&> ioContext;
     jsg::Ref<ReadableStreamDefaultReader> reader;
     bool preventCancel;
   };
@@ -361,7 +361,7 @@ public:
   // state of the readable.
 
 private:
-  IoContext& ioContext;
+  kj::Maybe<IoContext&> ioContext;
   Controller controller;
   kj::Maybe<jsg::Promise<void>> maybePipeThrough;
 

--- a/src/workerd/api/streams/writable.h
+++ b/src/workerd/api/streams/writable.h
@@ -87,7 +87,7 @@ private:
   // WritableStream remains in the "writer locked" state, per the spec.
   struct Released {};
 
-  IoContext& ioContext;
+  kj::Maybe<IoContext&> ioContext;
   kj::OneOf<Initial, Attached, Released, StreamStates::Closed> state = Initial();
 
   kj::Maybe<jsg::MemoizedIdentity<jsg::Promise<void>>> closedPromise;
@@ -152,7 +152,7 @@ public:
   }
 
 private:
-  IoContext& ioContext;
+  kj::Maybe<IoContext&> ioContext;
   Controller controller;
 
   void visitForGc(jsg::GcVisitor& visitor) {


### PR DESCRIPTION
Previous fix broke ability to create a ReadableStream outside of an IoContext.