### PR TITLE
Add support for deflate-raw and check for trailing or incomplete data in Compression Streams

### DIFF
--- a/src/workerd/api/streams/compression.h
+++ b/src/workerd/api/streams/compression.h
@@ -19,7 +19,7 @@ public:
     JSG_INHERIT(TransformStream);
 
     JSG_TS_OVERRIDE(extends TransformStream<ArrayBuffer | ArrayBufferView, Uint8Array> {
-      constructor(format: "gzip" | "deflate");
+      constructor(format: "gzip" | "deflate" | "deflate-raw");
     });
   }
 };
@@ -34,7 +34,7 @@ public:
     JSG_INHERIT(TransformStream);
 
     JSG_TS_OVERRIDE(extends TransformStream<ArrayBuffer | ArrayBufferView, Uint8Array> {
-      constructor(format: "gzip" | "deflate");
+      constructor(format: "gzip" | "deflate" | "deflate-raw");
     });
   }
 };

--- a/src/workerd/jsg/README.md
+++ b/src/workerd/jsg/README.md
@@ -1442,7 +1442,7 @@ Here are some example overrides demonstrating these rules:
 
 - ```ts
   extends TransformStream<ArrayBuffer | ArrayBufferView, Uint8Array> {
-    constructor(format: "gzip" | "deflate");
+    constructor(format: "gzip" | "deflate" | "deflate-raw");
   }
   ```
   Adds `ArrayBuffer | ArrayBufferView` and `Uint8Array` as type arguments to the generated type's

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -38,6 +38,16 @@
   KJ_FAIL_REQUIRE(kj::str(JSG_EXCEPTION(jsErrorType) ": ", ##__VA_ARGS__))
 // JSG_REQUIRE + KJ_FAIL_REQUIRE
 
+// Conditionally log a warning, at most once. Useful for determining if code changes would break
+// any existing scripts.
+#define JSG_WARN_ONCE_IF(cond, msg) \
+  if (cond) { \
+    static bool logOnce KJ_UNUSED = ([] { \
+      KJ_LOG(WARNING, msg); \
+      return true; \
+    })(); \
+  }
+
 // These are passthrough functions to KJ. We expect the error string to be
 // surfaced to the application.
 

--- a/types/src/transforms/overrides/compiler.ts
+++ b/types/src/transforms/overrides/compiler.ts
@@ -29,7 +29,7 @@ function compileOverride(
     // Use existing name and type classification, may merge members
     // Examples:
     // - `extends EventTarget<WorkerGlobalScopeEventMap>`
-    // - `extends TransformStream<ArrayBuffer | ArrayBufferView, Uint8Array> { constructor(format: "gzip" | "deflate"); }`
+    // - `extends TransformStream<ArrayBuffer | ArrayBufferView, Uint8Array> { constructor(format: "gzip" | "deflate" | "deflate-raw"); }`
     // - `{ json<T>(): Promise<T>; }`
     override = `class ${name} ${override}`;
   } else if (override.startsWith("<")) {


### PR DESCRIPTION
With deflate-raw, we have all required data formats for the current Compression Streams API version. Also see the eponymous internal branch.