### PR TITLE
Capture request trace info in async contexts

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -389,8 +389,10 @@ kj::Promise<WorkerInterface::AlarmResult> ServiceWorkerGlobalScope::runAlarm(
     auto& alarm = KJ_ASSERT_NONNULL(handler.alarm);
 
     auto alarmResultPromise = context
-        .run([exportedHandler, &alarm](Worker::Lock& lock)
-        -> kj::Promise<WorkerInterface::AlarmResult> {
+        .run([exportedHandler, &alarm,
+              maybeAsyncContext = jsg::AsyncContextFrame::currentRef(lock)]
+             (Worker::Lock& lock) mutable -> kj::Promise<WorkerInterface::AlarmResult> {
+      jsg::AsyncContextFrame::Scope asyncScope(lock, maybeAsyncContext);
       return alarm(lock).then([]() -> kj::Promise<WorkerInterface::AlarmResult> {
         return WorkerInterface::AlarmResult {
           .retry = false,

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -303,6 +303,8 @@ kj::Promise<void> sendTracesToExportedHandler(
     co_await context.run(
         [&context, traces=mapAddRef(traces), entrypointName=kj::mv(entrypointName)]
         (Worker::Lock& lock) mutable {
+      jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+
       auto handler = lock.getExportedHandler(entrypointName, context.getActor());
       lock.getGlobalScope().sendTraces(traces, lock, handler);
     });

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -161,6 +161,8 @@ kj::Promise<void> WorkerEntrypoint::request(
        &metrics = incomingRequest->getMetrics(),
        &wrappedResponse = *wrappedResponse, entrypointName = entrypointName]
       (Worker::Lock& lock) mutable {
+    jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+
     return lock.getGlobalScope().request(
         method, url, headers, requestBody, wrappedResponse,
         cfBlobJson, lock, lock.getExportedHandler(entrypointName, context.getActor()));
@@ -354,6 +356,8 @@ kj::Promise<WorkerInterface::ScheduledResult> WorkerEntrypoint::runScheduled(
       [scheduledTime, cron, entrypointName=entrypointName, &context,
        &metrics = incomingRequest->getMetrics()]
       (Worker::Lock& lock) mutable {
+    jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+
     lock.getGlobalScope().startScheduled(scheduledTime, cron, lock,
         lock.getExportedHandler(entrypointName, context.getActor()));
   }));
@@ -400,6 +404,8 @@ kj::Promise<WorkerInterface::AlarmResult> WorkerEntrypoint::runAlarm(
           [scheduledTime, entrypointName=entrypointName, &context,
            &metrics = incomingRequest->getMetrics()]
           (Worker::Lock& lock){
+        jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+
         return lock.getGlobalScope().runAlarm(scheduledTime, lock,
             lock.getExportedHandler(entrypointName, context.getActor()));
       }).attach(kj::defer([this, incomingRequest = kj::mv(incomingRequest)]() mutable {
@@ -425,6 +431,8 @@ kj::Promise<bool> WorkerEntrypoint::test() {
   context.addWaitUntil(context.run(
       [entrypointName=entrypointName, &context, &metrics = incomingRequest->getMetrics()]
       (Worker::Lock& lock) mutable -> kj::Promise<void> {
+    jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+
     return context.awaitJs(lock.getGlobalScope()
         .test(lock, lock.getExportedHandler(entrypointName, context.getActor())));
   }));


### PR DESCRIPTION
This should allow tracing spans recorded during async JS to be attributed to the incoming request that set them up, rather than the heuristic of using most recently received active request.  This should make DO traces more intuitive.