### PR TITLE
Implements Socket allowHalfOpen option.

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -616,7 +616,7 @@ jsg::Promise<jsg::Ref<Response>> ServiceWorkerGlobalScope::fetch(
 jsg::Ref<Socket> ServiceWorkerGlobalScope::connect(
     jsg::Lock& js, AnySocketAddress address, jsg::Optional<SocketOptions> options,
     CompatibilityFlags::Reader featureFlags) {
-  return connectImpl(js, nullptr, kj::mv(address), featureFlags);
+  return connectImpl(js, nullptr, kj::mv(address), kj::mv(options), featureFlags);
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1880,7 +1880,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImpl(
 jsg::Ref<Socket> Fetcher::connect(
     jsg::Lock& js, AnySocketAddress address, jsg::Optional<SocketOptions> options,
     CompatibilityFlags::Reader featureFlags) {
-  return connectImpl(js, JSG_THIS, kj::mv(address), featureFlags);
+  return connectImpl(js, JSG_THIS, kj::mv(address), kj::mv(options), featureFlags);
 }
 
 jsg::Promise<jsg::Ref<Response>> Fetcher::fetch(

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -40,7 +40,8 @@ bool isValidHost(kj::StringPtr host) {
 }
 
 jsg::Ref<Socket> connectImplNoOutputLock(
-    jsg::Lock& js, jsg::Ref<Fetcher> fetcher, AnySocketAddress address) {
+    jsg::Lock& js, jsg::Ref<Fetcher> fetcher, AnySocketAddress address,
+    jsg::Optional<SocketOptions> options) {
 
   auto addressStr = kj::str("");
   KJ_SWITCH_ONEOF(address) {
@@ -65,10 +66,12 @@ jsg::Ref<Socket> connectImplNoOutputLock(
   auto headers = kj::heap<kj::HttpHeaders>(ioContext.getHeaderTable());
   auto httpClient = kj::newHttpClient(*client);
   auto request = httpClient->connect(addressStr, *headers);
+  auto connDisconnPromise = request.connection->whenWriteDisconnected();
 
   // Initialise the readable/writable streams with the readable/writable sides of an AsyncIoStream.
   auto sysStreams = newSystemMultiStream(kj::mv(request.connection), ioContext);
   auto readable = jsg::alloc<ReadableStream>(ioContext, kj::mv(sysStreams.readable));
+  readable->initEofResolverPair(js);
   auto writable = jsg::alloc<WritableStream>(ioContext, kj::mv(sysStreams.writable));
 
   auto closeFulfiller = kj::heap<jsg::PromiseResolverPair<void>>(
@@ -76,15 +79,18 @@ jsg::Ref<Socket> connectImplNoOutputLock(
   closeFulfiller->promise.markAsHandled();
 
   auto result = jsg::alloc<Socket>(
-      js, kj::mv(readable), kj::mv(writable), kj::mv(closeFulfiller));
+      js, kj::mv(readable), kj::mv(writable), kj::mv(closeFulfiller), kj::mv(connDisconnPromise),
+      kj::mv(options));
   // `handleProxyStatus` needs an initialised refcount to use `JSG_THIS`, hence it cannot be
   // called in Socket's constructor.
   result->handleProxyStatus(js, kj::mv(request.status));
+  result->handleReadableEof(js);
   return result;
 }
 
 jsg::Ref<Socket> connectImpl(
     jsg::Lock& js, kj::Maybe<jsg::Ref<Fetcher>> fetcher, AnySocketAddress address,
+    jsg::Optional<SocketOptions> options,
     CompatibilityFlags::Reader featureFlags) {
   // `connect()` should be hidden when the feature flag is off, so we shouldn't even get here.
   KJ_ASSERT(featureFlags.getTcpSocketsSupport());
@@ -96,7 +102,7 @@ jsg::Ref<Socket> connectImpl(
     actualFetcher = jsg::alloc<Fetcher>(
         IoContext::NULL_CLIENT_CHANNEL, Fetcher::RequiresHostAndProtocol::YES);
   }
-  return connectImplNoOutputLock(js, kj::mv(actualFetcher), kj::mv(address));
+  return connectImplNoOutputLock(js, kj::mv(actualFetcher), kj::mv(address), kj::mv(options));
 }
 
 jsg::Promise<void> Socket::close(jsg::Lock& js) {
@@ -126,6 +132,40 @@ void Socket::handleProxyStatus(
     }
   });
   result.markAsHandled();
+}
+
+void Socket::handleReadableEof(jsg::Lock& js) {
+  // Listen for EOF on the ReadableStream.
+  KJ_ASSERT_NONNULL(readable->eofResolverPair).promise.then(js,
+      JSG_VISITABLE_LAMBDA((ref=JSG_THIS), (ref), (jsg::Lock& js) {
+    return ref->maybeCloseWriteSide(js);
+  })).markAsHandled();
+}
+
+jsg::Promise<void> Socket::maybeCloseWriteSide(jsg::Lock& js) {
+  // When `allowHalfOpen` is set to true then we do not automatically close the write side on EOF.
+  // The default value for `allowHalfOpen` is also false.
+  KJ_IF_MAYBE(opts, options) {
+    if (opts->allowHalfOpen) {
+      return js.resolvedPromise();
+    }
+  }
+
+  // We want to close the socket, but only after its WritableStream has been flushed. We do this
+  // below by calling `close` on the WritableStream which ensures that any data pending on it
+  // is flushed. Then once the `close` either completes or fails we can be sure that any data has
+  // been flushed.
+  return writable->getController().close(js).catch_(js,
+      [](jsg::Lock& js, workerd::jsg::V8Ref<v8::Value> exc) {
+    // A failure to close the WritableStream can indicate one of these things:
+    //   * The WritableStream hasn't been attached.
+    //   * The WritableStream has already been released or closed.
+    //
+    // We only want to ensure that the writable stream is flushed before closing the socket.
+    // With the above we are certain that it was flushed, so we are safe to close.
+  }).then(js, JSG_VISITABLE_LAMBDA((ref=JSG_THIS), (ref), (jsg::Lock& js) {
+    ref->closeFulfiller->resolver.resolve();
+  }));
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -18,16 +18,24 @@ struct SocketAddress {
 
 struct SocketOptions {
   jsg::Unimplemented tls; // TODO(later): TCP socket options need to be implemented.
-  JSG_STRUCT(tls);
+  bool allowHalfOpen = false;
+  JSG_STRUCT(tls, allowHalfOpen);
 };
 
 class Socket: public jsg::Object {
 public:
-  Socket(jsg::Lock& js, jsg::Ref<ReadableStream> readable, jsg::Ref<WritableStream> writable,
-      kj::Own<jsg::PromiseResolverPair<void>> close)
-      : readable(kj::mv(readable)), writable(kj::mv(writable)),
+  Socket(jsg::Lock& js, jsg::Ref<ReadableStream> readableParam, jsg::Ref<WritableStream> writable,
+      kj::Own<jsg::PromiseResolverPair<void>> close, kj::Promise<void> connDisconnPromise,
+      jsg::Optional<SocketOptions> options)
+      : readable(kj::mv(readableParam)), writable(kj::mv(writable)),
         closeFulfiller(kj::mv(close)),
-        closedPromise(kj::mv(closeFulfiller->promise)) { };
+        closedPromise(kj::mv(closeFulfiller->promise)),
+        // Listen for abrupt disconnects and resolve the `closed` promise when they occur.
+        writeDisconnectedPromise(IoContext::current().awaitIo(kj::mv(connDisconnPromise))
+            .then(js, [this](jsg::Lock& js) {
+              closeFulfiller->resolver.resolve();
+            })),
+        options(kj::mv(options)) { };
 
   jsg::Ref<ReadableStream> getReadable() { return readable.addRef(); }
   jsg::Ref<WritableStream> getWritable() { return writable.addRef(); }
@@ -42,6 +50,9 @@ public:
       jsg::Lock& js, kj::Promise<kj::HttpClient::ConnectRequest::Status> status);
   // Sets up relevant callbacks to handle the case when the proxy rejects our connection.
 
+  void handleReadableEof(jsg::Lock& js);
+  // Sets up relevant callbacks to handle the case when the readable stream reaches EOF.
+
   JSG_RESOURCE_TYPE(Socket, CompatibilityFlags::Reader flags) {
     JSG_READONLY_PROTOTYPE_PROPERTY(readable, getReadable);
     JSG_READONLY_PROTOTYPE_PROPERTY(writable, getWritable);
@@ -55,10 +66,11 @@ private:
   kj::Own<jsg::PromiseResolverPair<void>> closeFulfiller;
   // This fulfiller is used to resolve the `closedPromise` below.
   jsg::MemoizedIdentity<jsg::Promise<void>> closedPromise;
+  jsg::Promise<void> writeDisconnectedPromise;
+  jsg::Optional<SocketOptions> options;
 
   kj::Promise<kj::Own<kj::AsyncIoStream>> processConnection();
-
-
+  jsg::Promise<void> maybeCloseWriteSide(jsg::Lock& js);
 
   void resolveFulfiller(jsg::Lock& js, kj::Maybe<kj::Exception> maybeErr) {
     KJ_IF_MAYBE(err, maybeErr) {
@@ -80,10 +92,12 @@ private:
 };
 
 jsg::Ref<Socket> connectImplNoOutputLock(
-    jsg::Lock& js, jsg::Ref<Fetcher> fetcher, AnySocketAddress address);
+    jsg::Lock& js, jsg::Ref<Fetcher> fetcher, AnySocketAddress address,
+    jsg::Optional<SocketOptions> options);
 
 jsg::Ref<Socket> connectImpl(
     jsg::Lock& js, kj::Maybe<jsg::Ref<Fetcher>> fetcher, AnySocketAddress address,
+    jsg::Optional<SocketOptions> options,
     CompatibilityFlags::Reader featureFlags);
 
 #define EW_SOCKETS_ISOLATE_TYPES     \

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -456,6 +456,11 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
           if (!state.is<StreamStates::Errored>()) {
             doClose();
           }
+          KJ_IF_MAYBE(o, owner) {
+            KJ_IF_MAYBE(pair, o->eofResolverPair) {
+              pair->resolver.resolve();
+            }
+          }
           return js.resolvedPromise(ReadResult { .done = true });
         }
         // Return a slice so the script can see how many bytes were read.

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -301,6 +301,10 @@ ReadableStream::ReadableStream(Controller controller)
   getController().setOwnerRef(*this);
 }
 
+void ReadableStream::initEofResolverPair(jsg::Lock& js) {
+  eofResolverPair = js.newPromiseAndResolver<void>();
+}
+
 ReadableStreamController& ReadableStream::getController() {
   KJ_SWITCH_ONEOF(controller) {
     KJ_CASE_ONEOF(c, kj::Own<ReadableStreamInternalController>) {

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -360,6 +360,11 @@ public:
   // disturbed and the DeferredProxy returned will take over ownership of the internal
   // state of the readable.
 
+  kj::Maybe<jsg::PromiseResolverPair<void>> eofResolverPair;
+  // Used to signal when this ReadableStream reads EOF. This signal is required for TCP sockets.
+  void initEofResolverPair(jsg::Lock& js);
+  // By default the eofResolverPair is not initialised, calling this method will initialise it so
+  // that the signalling is active.
 private:
   kj::Maybe<IoContext&> ioContext;
   Controller controller;
@@ -367,6 +372,10 @@ private:
 
   void visitForGc(jsg::GcVisitor& visitor) {
     visitor.visit(getController(), maybePipeThrough);
+    KJ_IF_MAYBE(pair, eofResolverPair) {
+      visitor.visit(pair->resolver);
+      visitor.visit(pair->promise);
+    }
   }
 };
 


### PR DESCRIPTION
Followed the advice in https://github.com/cloudflare/workerd/pull/205#pullrequestreview-1225144756.

There are actually two changes here:

- Closing the socket on `whenWriteDisconnected` (which I'm unsure about as I wasn't able to repro when it triggers)
- Closing the socket when `allowHalfOpen=false` (the default) and ReadableStream reads an EOF.

### Test Plan

Tested upstream.