### PR TITLE
Implements TLS support for TCP sockets (with default TLS settings).

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,10 +35,10 @@ rules_foreign_cc_dependencies()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "79d1ae721c79bd5679ff3036961045c410eccf6dd8199fef4767ca9c343eb438",
-    strip_prefix = "capnproto-capnproto-f557d9d/c++",
+    sha256 = "72dfd487fcdec4223bd6475a4f481b07f7a8884e09185e0c68b67730f1711f0b",
+    strip_prefix = "capnproto-capnproto-9b1acb2/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/f557d9d728a773d954cf0586fe6e78adf828c5f4"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/9b1acb2f642fef318576c10a215bf6590c77538b"],
 )
 
 http_archive(

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -65,7 +65,11 @@ jsg::Ref<Socket> connectImplNoOutputLock(
   // Set up the connection.
   auto headers = kj::heap<kj::HttpHeaders>(ioContext.getHeaderTable());
   auto httpClient = kj::newHttpClient(*client);
-  auto request = httpClient->connect(addressStr, *headers);
+  kj::HttpConnectSettings httpConnectSettings = { .useTls = false };
+  KJ_IF_MAYBE(opts, options) {
+    httpConnectSettings.useTls = opts->useSecureTransport;
+  }
+  auto request = httpClient->connect(addressStr, *headers, httpConnectSettings);
   auto connDisconnPromise = request.connection->whenWriteDisconnected();
 
   // Initialise the readable/writable streams with the readable/writable sides of an AsyncIoStream.

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -17,9 +17,9 @@ struct SocketAddress {
 };
 
 struct SocketOptions {
-  jsg::Unimplemented tls; // TODO(later): TCP socket options need to be implemented.
+  bool useSecureTransport = false;
   bool allowHalfOpen = false;
-  JSG_STRUCT(tls, allowHalfOpen);
+  JSG_STRUCT(useSecureTransport, allowHalfOpen);
 };
 
 class Socket: public jsg::Object {

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -311,7 +311,8 @@ kj::Promise<void> WorkerEntrypoint::request(
 }
 
 kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host, const kj::HttpHeaders& headers,
-    kj::AsyncIoStream& connection, ConnectResponse& response) {
+    kj::AsyncIoStream& connection, ConnectResponse& response,
+    kj::HttpConnectSettings settings) {
   KJ_UNIMPLEMENTED("Incoming CONNECT on a worker not supported");
 }
 

--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -50,7 +50,8 @@ public:
       kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
       kj::AsyncInputStream& requestBody, Response& response) override;
   kj::Promise<void> connect(kj::StringPtr host, const kj::HttpHeaders& headers,
-      kj::AsyncIoStream& connection, ConnectResponse& response) override;
+      kj::AsyncIoStream& connection, ConnectResponse& response,
+      kj::HttpConnectSettings settings) override;
   void prewarm(kj::StringPtr url) override;
   kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override;
   kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override;

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -41,7 +41,8 @@ public:
   virtual kj::Promise<void> connect(kj::StringPtr host,
                                     const kj::HttpHeaders& headers,
                                     kj::AsyncIoStream& connection,
-                                    ConnectResponse& response) = 0;
+                                    ConnectResponse& response,
+                                    kj::HttpConnectSettings settings) = 0;
   // This is the same as the inherited HttpService::connect(), but we override it to be
   // pure-virtual to force all subclasses of WorkerInterface to implement it explicitly rather
   // than get the default implementation which throws an unimplemented exception.
@@ -153,7 +154,8 @@ public:
       kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
       kj::AsyncInputStream& requestBody, Response& response) override;
   kj::Promise<void> connect(kj::StringPtr host, const kj::HttpHeaders& headers,
-      kj::AsyncIoStream& connection, ConnectResponse& response) override;
+      kj::AsyncIoStream& connection, ConnectResponse& response,
+      kj::HttpConnectSettings settings) override;
   void prewarm(kj::StringPtr url) override;
   kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override;
   kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override;
@@ -184,7 +186,7 @@ public:
 
   kj::Promise<void> connect(
     kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& connection,
-    ConnectResponse& tunnel) override;
+    ConnectResponse& tunnel, kj::HttpConnectSettings settings) override;
 
   void prewarm(kj::StringPtr url) override;
   kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override;

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3458,9 +3458,9 @@ kj::Promise<void> Worker::Isolate::SubrequestClient::request(
 
 kj::Promise<void> Worker::Isolate::SubrequestClient::connect(
     kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& connection,
-    kj::HttpService::ConnectResponse& tunnel) {
+    kj::HttpService::ConnectResponse& tunnel, kj::HttpConnectSettings settings) {
   // TODO(someday): EW-7116 Figure out how to represent TCP connections in the devtools network tab.
-  return inner->connect(host, headers, connection, tunnel);
+  return inner->connect(host, headers, connection, tunnel, kj::mv(settings));
 }
 
 // TODO(someday): Log other kinds of subrequests?

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -424,7 +424,8 @@ private:
         kj::AsyncInputStream& requestBody, kj::HttpService::Response& response) override;
     kj::Promise<void> connect(
         kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& connection,
-        kj::HttpService::ConnectResponse& tunnel) override;
+        kj::HttpService::ConnectResponse& tunnel,
+        kj::HttpConnectSettings settings) override;
     void prewarm(kj::StringPtr url) override;
     kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override;
     kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override;

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -553,8 +553,8 @@ private:
 
     kj::Promise<void> connect(
         kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& connection,
-        ConnectResponse& tunnel) override {
-      return parent.serviceAdapter->connect(host, headers, connection, tunnel);
+        ConnectResponse& tunnel, kj::HttpConnectSettings settings) override {
+      return parent.serviceAdapter->connect(host, headers, connection, tunnel, kj::mv(settings));
     }
 
     void prewarm(kj::StringPtr url) override {}
@@ -686,12 +686,12 @@ private:
 
   kj::Promise<void> connect(
       kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& connection,
-      ConnectResponse& tunnel) override {
+      ConnectResponse& tunnel, kj::HttpConnectSettings settings) override {
     // This code is hit when the global `connect` function is called in a JS worker script.
     // It represents a proxy-less TCP connection, which means we can simply defer the handling of
     // the connection to the service adapter (likely NetworkHttpClient). Its behaviour will be to
     // connect directly to the host over TCP.
-    return serviceAdapter->connect(host, headers, connection, tunnel);
+    return serviceAdapter->connect(host, headers, connection, tunnel, kj::mv(settings));
   }
 
   void prewarm(kj::StringPtr url) override {}
@@ -895,7 +895,8 @@ private:
   }
 
   kj::Promise<void> connect(kj::StringPtr host, const kj::HttpHeaders& headers,
-      kj::AsyncIoStream& connection, kj::HttpService::ConnectResponse& response) override {
+      kj::AsyncIoStream& connection, kj::HttpService::ConnectResponse& response,
+      kj::HttpConnectSettings settings) override {
     throwUnsupported();
   }
   void prewarm(kj::StringPtr url) override {}


### PR DESCRIPTION
Depends on https://github.com/capnproto/capnproto/pull/1633

### Test Plan

Tested with changes to gopher.js script (https://gist.github.com/dom96/1fda0c3fc62b68f403f98583763e1ea6)

```
$ bazel run @workerd//src/workerd/server:workerd -- serve $PWD/deps/workerd/samples/tcp/config.capnp --watch --verbose --experimental
$ curl -v localhost:8080
```
