### PR TITLE
Allow specifying usages when importing public ECDH key, deriveBits/deriveKey refactor

### DIFF
--- a/src/workerd/api/crypto-impl-hkdf.c++
+++ b/src/workerd/api/crypto-impl-hkdf.c++
@@ -67,7 +67,7 @@ kj::Own<CryptoKey::Impl> CryptoKey::Impl::importHkdf(
     kj::ArrayPtr<const kj::String> keyUsages) {
   auto usages =
       CryptoKeyUsageSet::validate(normalizedName, CryptoKeyUsageSet::Context::importSecret,
-          keyUsages, CryptoKeyUsageSet::deriveBits() | CryptoKeyUsageSet::deriveKey());
+          keyUsages, CryptoKeyUsageSet::derivationKeyMask());
 
   JSG_REQUIRE(!extractable, DOMSyntaxError, "HKDF key cannot be extractable.");
   JSG_REQUIRE(format == "raw", DOMNotSupportedError, "HKDF key must be imported "

--- a/src/workerd/api/crypto-impl-pbkdf2.c++
+++ b/src/workerd/api/crypto-impl-pbkdf2.c++
@@ -80,7 +80,7 @@ kj::Own<CryptoKey::Impl> CryptoKey::Impl::importPbkdf2(
     kj::ArrayPtr<const kj::String> keyUsages) {
   auto usages =
       CryptoKeyUsageSet::validate(normalizedName, CryptoKeyUsageSet::Context::importSecret,
-          keyUsages, CryptoKeyUsageSet::deriveKey() | CryptoKeyUsageSet::deriveBits());
+          keyUsages, CryptoKeyUsageSet::derivationKeyMask());
 
   JSG_REQUIRE(!extractable, DOMSyntaxError, "PBKDF2 key cannot be extractable.");
   JSG_REQUIRE(format == "raw", DOMNotSupportedError,

--- a/src/workerd/api/crypto.h
+++ b/src/workerd/api/crypto.h
@@ -41,6 +41,10 @@ public:
     return decrypt() | sign() | unwrapKey() | deriveKey() | deriveBits();
   }
 
+  static constexpr CryptoKeyUsageSet derivationKeyMask() {
+    return deriveKey() | deriveBits();
+  }
+
   CryptoKeyUsageSet() : set(0) {}
 
   CryptoKeyUsageSet operator&(CryptoKeyUsageSet other) const { return set & other.set; }


### PR DESCRIPTION
- Allow specifying deriveBits and deriveKey usages when importing public ECDH keys. This behavior is already supported when importing raw ECDH keys and is more intuitive even though the usages are not required for public keys, see comments.
- Create CryptoKeyUsageSet::derivationKeyMask() to include both derive operations
- Deletes two superfluous assertions in importEllipticRaw – the validation right afterwards is more thorough and provides better error handling.

Please let me know if you find anything unclear