### PR TITLE
readme: add python3 to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Windows users should run `workerd` under WSL (1 or 2).
 To build `workerd`, you need:
 
 * [Bazel](https://bazel.build/)
+* Python 3 and distutils (e.g. packages `python3` and `python3-distutils` on Debian Bullseye)
 * On Linux:
   * Clang 11+ (e.g. package `clang` on Debian Bullseye)
   * libc++ 11+ (e.g. packages `libc++-dev` and `libc++abi-dev` on Debian Bullseye)


### PR DESCRIPTION
distutils isn't included in all base python3 installations (e.g. my WSL install didn't have it) and the V8 python deps step complains when it isn't there.