### PR TITLE
Add initial port of Node.js Compat Streams

### DIFF
--- a/samples/nodejs-compat-streams/README.md
+++ b/samples/nodejs-compat-streams/README.md
@@ -1,0 +1,28 @@
+# Node.js Compat Example
+
+To run the example on http://localhost:8080
+
+```sh
+$ ./workerd serve config.capnp
+```
+
+To run using bazel
+
+```sh
+$ bazel run //src/workerd/server:workerd -- serve ~/cloudflare/workerd/samples/nodejs-compat/config.capnp
+```
+
+To create a standalone binary that can be run:
+
+```sh
+$ ./workerd compile config.capnp > nodejs-compat
+
+$ ./nodejs-compat
+```
+
+To test:
+
+```sh
+% curl http://localhost:8080
+Hello World
+```

--- a/samples/nodejs-compat-streams/config.capnp
+++ b/samples/nodejs-compat-streams/config.capnp
@@ -1,0 +1,35 @@
+# Imports the base schema for workerd configuration files.
+
+# Refer to the comments in /src/workerd/server/workerd.capnp for more details.
+
+using Workerd = import "/workerd/workerd.capnp";
+
+# A constant of type Workerd.Config defines the top-level configuration for an
+# instance of the workerd runtime. A single config file can contain multiple
+# Workerd.Config definitions and must have at least one.
+const helloWorldExample :Workerd.Config = (
+
+  # Every workerd instance consists of a set of named services. A worker, for instance,
+  # is a type of service. Other types of services can include external servers, the
+  # ability to talk to a network, or accessing a disk directory. Here we create a single
+  # worker service. The configuration details for the worker are defined below.
+  services = [ (name = "main", worker = .helloWorld) ],
+
+  # Every configuration defines the one or more sockets on which the server will listene.
+  # Here, we create a single socket that will listen on localhost port 8080, and will
+  # dispatch to the "main" service that we defined above.
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ]
+);
+
+# The definition of the actual helloWorld worker exposed using the "main" service.
+# In this example the worker is implemented as a single simple script (see worker.js).
+# The compatibilityDate is required. For more details on compatibility dates see:
+#   https://developers.cloudflare.com/workers/platform/compatibility-dates/
+
+const helloWorld :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js")
+  ],
+  compatibilityDate = "2022-11-08",
+  compatibilityFlags = ["nodejs_compat", "experimental"]
+);

--- a/samples/nodejs-compat-streams/worker.js
+++ b/samples/nodejs-compat-streams/worker.js
@@ -1,0 +1,56 @@
+import {
+  Readable,
+  Transform,
+  promises,
+} from 'node:stream';
+
+const { pipeline } = promises;
+
+class MyTransform extends Transform {
+  constructor() {
+    super({ encoding: 'utf8' });
+  }
+  _transform(chunk, _, cb) {
+    this.push(chunk.toString().toUpperCase());
+    cb();
+  }
+  _flush(cb) {
+    this.push('\n');
+    cb();
+  }
+}
+
+export default {
+  async fetch() {
+    const chunks = [
+      "hello ",
+      "from ",
+      "the ",
+      "wonderful ",
+      "world ",
+      "of ",
+      "node.js ",
+      "streams!"
+    ];
+
+    function nextChunk(readable) {
+      readable.push(chunks.shift());
+      if (chunks.length === 0) readable.push(null);
+      else queueMicrotask(() => nextChunk(readable));
+    }
+
+    const readable = new Readable({
+      encoding: 'utf8',
+      read() { nextChunk(readable); }
+    });
+
+    const transform = new MyTransform();
+
+    let ret = '';
+    transform.on('data', (chunk) => ret += chunk);
+
+    await pipeline(readable, transform);
+
+    return new Response(ret);
+  }
+};

--- a/src/node/_stream_duplex.js
+++ b/src/node/_stream_duplex.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+/* eslint-disable */
+
+// TODO(soon): Remove this once assert is out of experimental
+import { default as CompatibilityFlags } from 'workerd:compatibility-flags';
+if (!CompatibilityFlags.workerdExperimental) {
+  throw new Error('node:stream is experimental.');
+}
+
+import { Duplex } from 'node-internal:streams_duplex';
+export { Duplex };
+export default Duplex;

--- a/src/node/_stream_passthrough.js
+++ b/src/node/_stream_passthrough.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+/* eslint-disable */
+
+// TODO(soon): Remove this once assert is out of experimental
+import { default as CompatibilityFlags } from 'workerd:compatibility-flags';
+if (!CompatibilityFlags.workerdExperimental) {
+  throw new Error('node:stream is experimental.');
+}
+
+import { PassThrough } from 'node-internal:streams_transform';
+export { PassThrough };
+export default PassThrough;

--- a/src/node/_stream_readable.js
+++ b/src/node/_stream_readable.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+/* eslint-disable */
+
+// TODO(soon): Remove this once assert is out of experimental
+import { default as CompatibilityFlags } from 'workerd:compatibility-flags';
+if (!CompatibilityFlags.workerdExperimental) {
+  throw new Error('node:stream is experimental.');
+}
+
+import { Readable } from 'node-internal:streams_readable';
+export { Readable };
+export default Readable;

--- a/src/node/_stream_transform.js
+++ b/src/node/_stream_transform.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+/* eslint-disable */
+
+// TODO(soon): Remove this once assert is out of experimental
+import { default as CompatibilityFlags } from 'workerd:compatibility-flags';
+if (!CompatibilityFlags.workerdExperimental) {
+  throw new Error('node:stream is experimental.');
+}
+
+import { Transform } from 'node-internal:streams_transform';
+export { Transform };
+export default Transform;

--- a/src/node/_stream_writable.js
+++ b/src/node/_stream_writable.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+/* eslint-disable */
+
+// TODO(soon): Remove this once assert is out of experimental
+import { default as CompatibilityFlags } from 'workerd:compatibility-flags';
+if (!CompatibilityFlags.workerdExperimental) {
+  throw new Error('node:stream is experimental.');
+}
+
+import { Writable } from 'node-internal:streams_writable';
+export { Writable };
+export default Writable;

--- a/src/node/internal/events.ts
+++ b/src/node/internal/events.ts
@@ -60,7 +60,27 @@ export interface EventEmitterOptions {
   captureRejections? : boolean;
 };
 
-type EventEmitter = typeof EventEmitter;
+export type EventName = string|symbol;
+export type EventCallback = (...args: any[]) => unknown;
+export interface EventEmitter {
+  addListener(eventName: EventName, listener: EventCallback): EventEmitter;
+  emit(eventName: EventName, ...args: unknown[]): void;
+  eventNames() : EventName[];
+  getMaxListeners(): number;
+  listenerCount(eventName: EventName): number;
+  listeners(eventName: EventName): EventCallback[];
+  off(eventName: EventName, listener: EventCallback): EventEmitter;
+  on(eventName: EventName, listener: EventCallback): EventEmitter;
+  once(eventName: EventName, listener: EventCallback): EventEmitter;
+  prependListener(eventName: EventName, listener: EventCallback): EventEmitter;
+  prependOnceListener(eventName: EventName, listener: EventCallback): EventEmitter;
+  removeAllListeners(eventName?: EventName): EventEmitter;
+  removeListener(eventName: EventName, listener: EventCallback): EventEmitter;
+  setMaxListeners(n: number): EventEmitter;
+  rawListeners(eventName: EventName): EventCallback[];
+  [kRejection](err: unknown, eventName: EventName, ...args: unknown[]) : void;
+};
+
 type AsyncResource = typeof AsyncResource;
 
 declare var EventTarget : Function;

--- a/src/node/internal/internal_buffer.ts
+++ b/src/node/internal/internal_buffer.ts
@@ -73,14 +73,104 @@ function createBuffer(length: number) : Buffer {
   }
   const buf = new Uint8Array(length);
   Object.setPrototypeOf(buf, Buffer.prototype);
-  return buf;
+  return buf as Buffer;
 }
 
 type WithImplicitCoercion<T> = | T | { valueOf(): T; };
 type StringLike = WithImplicitCoercion<string> | { [Symbol.toPrimitive](hint: "string"): string; };
 type ArrayBufferLike = WithImplicitCoercion<ArrayBuffer| SharedArrayBuffer>;
 type BufferSource = StringLike|ArrayBufferLike|Uint8Array|ReadonlyArray<number>;
-type Buffer = typeof Buffer.prototype;
+
+export interface Buffer extends Uint8Array {
+  readonly buffer: ArrayBuffer;
+  readonly parent: ArrayBuffer;
+  readonly byteOffset: number;
+  readonly length: number;
+  compare(target: Uint8Array,
+          targetStart?: number,
+          targetEnd?: number,
+          sourceStart?: number,
+          sourceEnd?: number): number;
+  copy(target: Uint8Array,
+       targetStart?: number,
+       sourceStart?: number,
+       sourceEnd?: number): number;
+  equals(other: Uint8Array): boolean;
+  fill(value: number, offset?: number, end?: number): this;
+  fill(value: string, encoding?: string): this;
+  fill(value: string, offset?: number, end?: number, encoding?: string): this;
+  fill(value: Uint8Array, offset?: number, end?: number): this;
+  includes(value: number, byteOffset?: number): boolean;
+  includes(value: string, encoding?: string): boolean;
+  includes(value: string, byteOffset?: number, encoding?: string): boolean;
+  includes(value: Uint8Array, byteOffset?: number): boolean;
+  indexOf(value: number, byteOffset?: number): number;
+  indexOf(value: string, encoding?: string): number;
+  indexOf(value: string, byteOffset?: number, encoding?: string): number;
+  indexOf(value: Uint8Array, byteOffset?: number): number;
+  lastIndexOf(value: number, byteOffset?: number): number;
+  lastIndexOf(value: string, encoding?: string): number;
+  lastIndexOf(value: string, byteOffset?: number, encoding?: string): number;
+  lastIndexOf(value: Uint8Array, byteOffset?: number): number;
+  readBigInt64BE(offset?: number) : bigint;
+  readBigInt64LE(offset?: number) : bigint;
+  readBigUInt64BE(offset?: number) : bigint;
+  readBigUInt64LE(offset?: number) : bigint;
+  readDoubleBE(offset?: number) : number;
+  readDoubleLE(offset?: number) : number;
+  readFloatBE(offset?: number) : number;
+  readFloatLE(offset?: number) : number;
+  readInt8(offset?: number) : number;
+  readInt16BE(offset?: number) : number;
+  readInt16LE(offset?: number) : number;
+  readInt32BE(offset?: number) : number;
+  readInt32LE(offset?: number) : number;
+  readIntBE(offset?: number, byteLength?: number) : number;
+  readIntLE(offset?: number, byteLength?: number) : number;
+  readUInt8(offset?: number) : number;
+  readUInt16BE(offset?: number) : number;
+  readUInt16LE(offset?: number) : number;
+  readUInt32BE(offset?: number) : number;
+  readUInt32LE(offset?: number) : number;
+  readUIntBE(offset?: number, byteLength?: number) : number;
+  readUIntLE(offset?: number, byteLength?: number) : number;
+  swap16(): this;
+  swap32(): this;
+  swap64(): this;
+  toJSON(): {type: 'Buffer', data: number[]};
+  toString(encoding?: string, start?: number, end?: number): string;
+  write(string: string, encoding?: string): number;
+  write(string: string, offset?: number, encoding?: string): number;
+  write(string: string, offset?: number, length?: number, encoding?: string): number;
+  writeBigInt64BE(value: bigint, offset?: number): number;
+  writeBigInt64LE(value: bigint, offset?: number): number;
+  writeBigUInt64BE(value: bigint, offset?: number): number;
+  writeBigUInt64LE(value: bigint, offset?: number): number;
+  writeDoubleBE(value: number, offset?: number): number;
+  writeDoubleLE(value: number, offset?: number): number;
+  writeFloatBE(value: number, offset?: number): number;
+  writeFloatLE(value: number, offset?: number): number;
+  writeInt8(value: number, offset?: number): number;
+  writeInt16BE(value: number, offset?: number): number;
+  writeInt16LE(value: number, offset?: number): number;
+  writeInt32BE(value: number, offset?: number): number;
+  writeInt32LE(value: number, offset?: number): number;
+  writeIntBE(value: number, offset?: number, byteLength?: number): number;
+  writeIntLE(value: number, offset?: number, byteLength?: number): number;
+  writeUInt8(value: number, offset?: number): number;
+  writeUInt16BE(value: number, offset?: number): number;
+  writeUInt16LE(value: number, offset?: number): number;
+  writeUInt32BE(value: number, offset?: number): number;
+  writeUInt32LE(value: number, offset?: number): number;
+  writeUIntBE(value: number, offset?: number, byteLength?: number): number;
+  writeUIntLE(value: number, offset?: number, byteLength?: number): number;
+  new (array:Iterable<number>): Buffer;
+  new (arrayBuffer: ArrayBufferLike, byteOffset?: number, length?: number): Buffer;
+  new (buffer: ArrayBufferView): Buffer;
+  new (size: number): Buffer;
+  new (string: string, encoding?: string): Buffer;
+};
+
 type FillValue = string|number|ArrayBufferView;
 
 export function Buffer(value: number) : Buffer;
@@ -151,12 +241,12 @@ function _from(value: BufferSource,
                encodingOrOffset? : string|number,
                length?: number) : Buffer {
   if (typeof value === "string") {
-    return fromString(value, encodingOrOffset as string | undefined);
+    return fromString(value, encodingOrOffset as string | undefined) as Buffer;
   }
 
   if (typeof value === "object" && value != null) {
     if (isAnyArrayBuffer(value)) {
-      return fromArrayBuffer(value as ArrayBufferLike, encodingOrOffset as number, length);
+      return fromArrayBuffer(value as ArrayBufferLike, encodingOrOffset as number, length) as Buffer;
     }
 
     const valueOf = value?.valueOf();
@@ -165,25 +255,23 @@ function _from(value: BufferSource,
       return _from(valueOf as BufferSource, encodingOrOffset, length);
     }
 
-    if ((value as ArrayBufferLike|Buffer|Object).length !== undefined ||
-         isAnyArrayBuffer((value as ArrayBufferLike|Buffer|Object).buffer)) {
-      if (typeof (value as ArrayBufferLike|Buffer|Object).length !== "number") {
+    if ((value as any).length !== undefined || isAnyArrayBuffer((value as any).buffer)) {
+      if (typeof (value as any).length !== "number") {
         return createBuffer(0);
       }
 
-      return fromArrayLike(value as ArrayBufferLike|Buffer|Object);
+      return fromArrayLike(value as any) as Buffer;
     }
 
-    if ((value as ArrayBufferLike|Buffer|Object).type === "Buffer" &&
-         Array.isArray((value as ArrayBufferLike|Buffer|Object).data)) {
-      return fromArrayLike((value as ArrayBufferLike|Buffer|Object).data);
+    if ((value as any).type === "Buffer" && Array.isArray((value as any).data)) {
+      return fromArrayLike((value as any).data) as Buffer;
     }
 
     const toPrimitive = (value as any)[Symbol.toPrimitive];
     if (typeof toPrimitive === "function") {
       const primitive = toPrimitive("string");
       if (typeof primitive === "string") {
-        return fromString(primitive, encodingOrOffset as string | undefined);
+        return fromString(primitive, encodingOrOffset as string | undefined) as Buffer;
       }
     }
   }
@@ -280,7 +368,7 @@ Buffer.from = from;
 function of(...args: number[]) {
   const buf = Buffer.alloc(args.length);
   for (let k = 0; k < args.length; k++)
-    buf[k] = args[k];
+    buf[k] = args[k]!;
   return buf;
 }
 
@@ -300,7 +388,7 @@ function alloc(size: number, fill?: FillValue, encoding?: string) : Buffer {
     if (encoding !== undefined) {
       validateString(encoding, 'encoding');
     }
-    return buffer.fill(fill, encoding);
+    return buffer.fill(fill as any, encoding);
   }
   return buffer;
 }
@@ -365,8 +453,8 @@ Buffer.concat = function concat(list: (Buffer|Uint8Array)[], length?: number) {
   if (length === undefined) {
     length = 0;
     for (let i = 0; i < list.length; i++) {
-      if (list[i].length !== undefined) {
-        length += list[i].length;
+      if (list[i]!.length !== undefined) {
+        length += list[i]!.length;
       } else {
         throw new ERR_INVALID_ARG_TYPE('list', '(Buffer|Uint8Array)[]', list[i]);
       }
@@ -562,7 +650,7 @@ function includes(
     val: string|number|Buffer|Uint8Array,
     byteOffset?: number,
     encoding?: string) {
-  return this.indexOf(val, byteOffset, encoding) !== -1;
+  return this.indexOf(val as any, byteOffset, encoding) !== -1;
 }
 
 Buffer.prototype.includes = includes;
@@ -910,8 +998,8 @@ Buffer.prototype.readUint32LE =
       }
 
       return first +
-        this[++offset] * 2 ** 8 +
-        this[++offset] * 2 ** 16 +
+        this[++offset]! * 2 ** 8 +
+        this[++offset]! * 2 ** 16 +
         last * 2 ** 24;
     };
 
@@ -927,11 +1015,11 @@ Buffer.prototype.readBigUint64LE =
       if (first === undefined || last === undefined) {
         boundsError(offset, this.length - 8);
       }
-      const lo = first + this[++offset] * 2 ** 8 +
-        this[++offset] * 2 ** 16 +
-        this[++offset] * 2 ** 24;
-      const hi = this[++offset] + this[++offset] * 2 ** 8 +
-        this[++offset] * 2 ** 16 + last * 2 ** 24;
+      const lo = first + this[++offset]! * 2 ** 8 +
+        this[++offset]! * 2 ** 16 +
+        this[++offset]! * 2 ** 24;
+      const hi = this[++offset]! + this[++offset]! * 2 ** 8 +
+        this[++offset]! * 2 ** 16 + last * 2 ** 24;
       return BigInt(lo) + (BigInt(hi) << BigInt(32));
     };
 
@@ -945,10 +1033,10 @@ Buffer.prototype.readBigUint64BE =
       if (first === undefined || last === undefined) {
         boundsError(offset, this.length - 8);
       }
-      const hi = first * 2 ** 24 + this[++offset] * 2 ** 16 +
-        this[++offset] * 2 ** 8 + this[++offset];
-      const lo = this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 +
-        this[++offset] * 2 ** 8 + last;
+      const hi = first * 2 ** 24 + this[++offset]! * 2 ** 16 +
+        this[++offset]! * 2 ** 8 + this[++offset]!;
+      const lo = this[++offset]! * 2 ** 24 + this[++offset]! * 2 ** 16 +
+        this[++offset]! * 2 ** 8 + last;
       return (BigInt(hi) << BigInt(32)) + BigInt(lo);
     };
 
@@ -1059,12 +1147,12 @@ Buffer.prototype.readBigInt64LE = function readBigInt64LE(this: Buffer, offset: 
   if (first === undefined || last === undefined) {
     boundsError(offset, this.length - 8);
   }
-  const val = this[offset + 4] + this[offset + 5] * 2 ** 8 +
-    this[offset + 6] * 2 ** 16 + (last << 24);
+  const val = this[offset + 4]! + this[offset + 5]! * 2 ** 8 +
+    this[offset + 6]! * 2 ** 16 + (last << 24);
   return (BigInt(val) << BigInt(32)) +
     BigInt(
-      first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 +
-        this[++offset] * 2 ** 24,
+      first + this[++offset]! * 2 ** 8 + this[++offset]! * 2 ** 16 +
+        this[++offset]! * 2 ** 24,
     );
 };
 
@@ -1076,12 +1164,12 @@ Buffer.prototype.readBigInt64BE = function readBigInt64BE(this: Buffer, offset: 
   if (first === undefined || last === undefined) {
     boundsError(offset, this.length - 8);
   }
-  const val = (first << 24) + this[++offset] * 2 ** 16 +
-    this[++offset] * 2 ** 8 + this[++offset];
+  const val = (first << 24) + this[++offset]! * 2 ** 16 +
+    this[++offset]! * 2 ** 8 + this[++offset]!;
   return (BigInt(val) << BigInt(32)) +
     BigInt(
-      this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 +
-        this[++offset] * 2 ** 8 + last,
+      this[++offset]! * 2 ** 24 + this[++offset]! * 2 ** 16 +
+        this[++offset]! * 2 ** 8 + last,
     );
 };
 
@@ -1456,7 +1544,7 @@ Buffer.prototype.fill = function fill(
   }
 
   if (isArrayBufferView(val)) {
-    if (val.byteLength === 0) {
+    if ((val as ArrayBufferView).byteLength === 0) {
       throw new ERR_INVALID_ARG_VALUE('value', 'zero-length');
     }
     bufferUtil.fillImpl(this, val as ArrayBufferView, start as number, end as number);
@@ -1470,7 +1558,7 @@ Buffer.prototype.fill = function fill(
   }
   val ??= 0;
 
-  Uint8Array.prototype.fill.call(this, val, start, end);
+  Uint8Array.prototype.fill.call(this, val as number, start, end);
 
   return this;
 };
@@ -1526,10 +1614,10 @@ function readUInt48LE(buf: Buffer|Uint8Array, offset: number = 0) {
   }
 
   return first +
-    buf[++offset] * 2 ** 8 +
-    buf[++offset] * 2 ** 16 +
-    buf[++offset] * 2 ** 24 +
-    (buf[++offset] + last * 2 ** 8) * 2 ** 32;
+    buf[++offset]! * 2 ** 8 +
+    buf[++offset]! * 2 ** 16 +
+    buf[++offset]! * 2 ** 24 +
+    (buf[++offset]! + last * 2 ** 8) * 2 ** 32;
 }
 
 function readUInt40LE(buf: Buffer|Uint8Array, offset: number = 0) {
@@ -1541,9 +1629,9 @@ function readUInt40LE(buf: Buffer|Uint8Array, offset: number = 0) {
   }
 
   return first +
-    buf[++offset] * 2 ** 8 +
-    buf[++offset] * 2 ** 16 +
-    buf[++offset] * 2 ** 24 +
+    buf[++offset]! * 2 ** 8 +
+    buf[++offset]! * 2 ** 16 +
+    buf[++offset]! * 2 ** 24 +
     last * 2 ** 32;
 }
 
@@ -1555,7 +1643,7 @@ function readUInt24LE(buf: Buffer|Uint8Array, offset: number = 0) {
     boundsError(offset, buf.length - 3);
   }
 
-  return first + buf[++offset] * 2 ** 8 + last * 2 ** 16;
+  return first + buf[++offset]! * 2 ** 8 + last * 2 ** 16;
 }
 
 function readUInt48BE(buf: Buffer|Uint8Array, offset: number = 0) {
@@ -1566,10 +1654,10 @@ function readUInt48BE(buf: Buffer|Uint8Array, offset: number = 0) {
     boundsError(offset, buf.length - 6);
   }
 
-  return (first * 2 ** 8 + buf[++offset]) * 2 ** 32 +
-    buf[++offset] * 2 ** 24 +
-    buf[++offset] * 2 ** 16 +
-    buf[++offset] * 2 ** 8 +
+  return (first * 2 ** 8 + buf[++offset]!) * 2 ** 32 +
+    buf[++offset]! * 2 ** 24 +
+    buf[++offset]! * 2 ** 16 +
+    buf[++offset]! * 2 ** 8 +
     last;
 }
 
@@ -1582,9 +1670,9 @@ function readUInt40BE(buf: Buffer|Uint8Array, offset: number = 0) {
   }
 
   return first * 2 ** 32 +
-    buf[++offset] * 2 ** 24 +
-    buf[++offset] * 2 ** 16 +
-    buf[++offset] * 2 ** 8 +
+    buf[++offset]! * 2 ** 24 +
+    buf[++offset]! * 2 ** 16 +
+    buf[++offset]! * 2 ** 8 +
     last;
 }
 
@@ -1596,7 +1684,7 @@ function readUInt24BE(buf: Buffer|Uint8Array, offset: number = 0) {
     boundsError(offset, buf.length - 3);
   }
 
-  return first * 2 ** 16 + buf[++offset] * 2 ** 8 + last;
+  return first * 2 ** 16 + buf[++offset]! * 2 ** 8 + last;
 }
 
 function readUInt16BE(this: Buffer, offset: number = 0) {
@@ -1619,8 +1707,8 @@ function readUInt32BE(this: Buffer, offset: number = 0) {
   }
 
   return first * 2 ** 24 +
-    this[++offset] * 2 ** 16 +
-    this[++offset] * 2 ** 8 +
+    this[++offset]! * 2 ** 16 +
+    this[++offset]! * 2 ** 8 +
     last;
 }
 
@@ -1633,12 +1721,12 @@ function readDoubleBackwards(buffer: Buffer|Uint8Array, offset: number = 0) {
   }
 
   uInt8Float64Array[7] = first;
-  uInt8Float64Array[6] = buffer[++offset];
-  uInt8Float64Array[5] = buffer[++offset];
-  uInt8Float64Array[4] = buffer[++offset];
-  uInt8Float64Array[3] = buffer[++offset];
-  uInt8Float64Array[2] = buffer[++offset];
-  uInt8Float64Array[1] = buffer[++offset];
+  uInt8Float64Array[6] = buffer[++offset]!;
+  uInt8Float64Array[5] = buffer[++offset]!;
+  uInt8Float64Array[4] = buffer[++offset]!;
+  uInt8Float64Array[3] = buffer[++offset]!;
+  uInt8Float64Array[2] = buffer[++offset]!;
+  uInt8Float64Array[1] = buffer[++offset]!;
   uInt8Float64Array[0] = last;
   return float64Array[0];
 }
@@ -1652,45 +1740,45 @@ function readDoubleForwards(buffer: Buffer|Uint8Array, offset: number = 0) {
   }
 
   uInt8Float64Array[0] = first;
-  uInt8Float64Array[1] = buffer[++offset];
-  uInt8Float64Array[2] = buffer[++offset];
-  uInt8Float64Array[3] = buffer[++offset];
-  uInt8Float64Array[4] = buffer[++offset];
-  uInt8Float64Array[5] = buffer[++offset];
-  uInt8Float64Array[6] = buffer[++offset];
+  uInt8Float64Array[1] = buffer[++offset]!;
+  uInt8Float64Array[2] = buffer[++offset]!;
+  uInt8Float64Array[3] = buffer[++offset]!;
+  uInt8Float64Array[4] = buffer[++offset]!;
+  uInt8Float64Array[5] = buffer[++offset]!;
+  uInt8Float64Array[6] = buffer[++offset]!;
   uInt8Float64Array[7] = last;
   return float64Array[0];
 }
 
 function writeDoubleForwards(buffer: Buffer|Uint8Array, val: number, offset: number = 0) {
   val = +val;
-  checkBounds(buffer, offset, 7);
+  checkBounds(buffer as any, offset, 7);
 
   float64Array[0] = val;
-  buffer[offset++] = uInt8Float64Array[0];
-  buffer[offset++] = uInt8Float64Array[1];
-  buffer[offset++] = uInt8Float64Array[2];
-  buffer[offset++] = uInt8Float64Array[3];
-  buffer[offset++] = uInt8Float64Array[4];
-  buffer[offset++] = uInt8Float64Array[5];
-  buffer[offset++] = uInt8Float64Array[6];
-  buffer[offset++] = uInt8Float64Array[7];
+  buffer[offset++] = uInt8Float64Array[0]!;
+  buffer[offset++] = uInt8Float64Array[1]!;
+  buffer[offset++] = uInt8Float64Array[2]!;
+  buffer[offset++] = uInt8Float64Array[3]!;
+  buffer[offset++] = uInt8Float64Array[4]!;
+  buffer[offset++] = uInt8Float64Array[5]!;
+  buffer[offset++] = uInt8Float64Array[6]!;
+  buffer[offset++] = uInt8Float64Array[7]!;
   return offset;
 }
 
 function writeDoubleBackwards(buffer: Buffer|Uint8Array, val: number, offset: number = 0) {
   val = +val;
-  checkBounds(buffer, offset, 7);
+  checkBounds(buffer as any, offset, 7);
 
   float64Array[0] = val;
-  buffer[offset++] = uInt8Float64Array[7];
-  buffer[offset++] = uInt8Float64Array[6];
-  buffer[offset++] = uInt8Float64Array[5];
-  buffer[offset++] = uInt8Float64Array[4];
-  buffer[offset++] = uInt8Float64Array[3];
-  buffer[offset++] = uInt8Float64Array[2];
-  buffer[offset++] = uInt8Float64Array[1];
-  buffer[offset++] = uInt8Float64Array[0];
+  buffer[offset++] = uInt8Float64Array[7]!;
+  buffer[offset++] = uInt8Float64Array[6]!;
+  buffer[offset++] = uInt8Float64Array[5]!;
+  buffer[offset++] = uInt8Float64Array[4]!;
+  buffer[offset++] = uInt8Float64Array[3]!;
+  buffer[offset++] = uInt8Float64Array[2]!;
+  buffer[offset++] = uInt8Float64Array[1]!;
+  buffer[offset++] = uInt8Float64Array[0]!;
   return offset;
 }
 
@@ -1703,8 +1791,8 @@ function readFloatBackwards(buffer: Buffer|Uint8Array, offset: number = 0) {
   }
 
   uInt8Float32Array[3] = first;
-  uInt8Float32Array[2] = buffer[++offset];
-  uInt8Float32Array[1] = buffer[++offset];
+  uInt8Float32Array[2] = buffer[++offset]!;
+  uInt8Float32Array[1] = buffer[++offset]!;
   uInt8Float32Array[0] = last;
   return float32Array[0];
 }
@@ -1718,33 +1806,33 @@ function readFloatForwards(buffer: Buffer|Uint8Array, offset: number = 0) {
   }
 
   uInt8Float32Array[0] = first;
-  uInt8Float32Array[1] = buffer[++offset];
-  uInt8Float32Array[2] = buffer[++offset];
+  uInt8Float32Array[1] = buffer[++offset]!;
+  uInt8Float32Array[2] = buffer[++offset]!;
   uInt8Float32Array[3] = last;
   return float32Array[0];
 }
 
 function writeFloatForwards(buffer: Buffer|Uint8Array, val: number, offset: number = 0) {
   val = +val;
-  checkBounds(buffer, offset, 3);
+  checkBounds(buffer as any, offset, 3);
 
   float32Array[0] = val;
-  buffer[offset++] = uInt8Float32Array[0];
-  buffer[offset++] = uInt8Float32Array[1];
-  buffer[offset++] = uInt8Float32Array[2];
-  buffer[offset++] = uInt8Float32Array[3];
+  buffer[offset++] = uInt8Float32Array[0]!;
+  buffer[offset++] = uInt8Float32Array[1]!;
+  buffer[offset++] = uInt8Float32Array[2]!;
+  buffer[offset++] = uInt8Float32Array[3]!;
   return offset;
 }
 
 function writeFloatBackwards(buffer: Buffer|Uint8Array, val: number, offset: number = 0) {
   val = +val;
-  checkBounds(buffer, offset, 3);
+  checkBounds(buffer as any, offset, 3);
 
   float32Array[0] = val;
-  buffer[offset++] = uInt8Float32Array[3];
-  buffer[offset++] = uInt8Float32Array[2];
-  buffer[offset++] = uInt8Float32Array[1];
-  buffer[offset++] = uInt8Float32Array[0];
+  buffer[offset++] = uInt8Float32Array[3]!;
+  buffer[offset++] = uInt8Float32Array[2]!;
+  buffer[offset++] = uInt8Float32Array[1]!;
+  buffer[offset++] = uInt8Float32Array[0]!;
   return offset;
 }
 
@@ -1756,7 +1844,7 @@ function readInt24LE(buf: Buffer|Uint8Array, offset: number = 0) {
     boundsError(offset, buf.length - 3);
   }
 
-  const val = first + buf[++offset] * 2 ** 8 + last * 2 ** 16;
+  const val = first + buf[++offset]! * 2 ** 8 + last * 2 ** 16;
   return val | (val & 2 ** 23) * 0x1fe;
 }
 
@@ -1770,9 +1858,9 @@ function readInt40LE(buf: Buffer|Uint8Array, offset: number = 0) {
 
   return (last | (last & 2 ** 7) * 0x1fffffe) * 2 ** 32 +
     first +
-    buf[++offset] * 2 ** 8 +
-    buf[++offset] * 2 ** 16 +
-    buf[++offset] * 2 ** 24;
+    buf[++offset]! * 2 ** 8 +
+    buf[++offset]! * 2 ** 16 +
+    buf[++offset]! * 2 ** 24;
 }
 
 function readInt48LE(buf: Buffer|Uint8Array, offset: number = 0) {
@@ -1783,12 +1871,12 @@ function readInt48LE(buf: Buffer|Uint8Array, offset: number = 0) {
     boundsError(offset, buf.length - 6);
   }
 
-  const val = buf[offset + 4] + last * 2 ** 8;
+  const val = buf[offset + 4]! + last * 2 ** 8;
   return (val | (val & 2 ** 15) * 0x1fffe) * 2 ** 32 +
     first +
-    buf[++offset] * 2 ** 8 +
-    buf[++offset] * 2 ** 16 +
-    buf[++offset] * 2 ** 24;
+    buf[++offset]! * 2 ** 8 +
+    buf[++offset]! * 2 ** 16 +
+    buf[++offset]! * 2 ** 24;
 }
 
 function readInt24BE(buf: Buffer|Uint8Array, offset: number = 0) {
@@ -1799,7 +1887,7 @@ function readInt24BE(buf: Buffer|Uint8Array, offset: number = 0) {
     boundsError(offset, buf.length - 3);
   }
 
-  const val = first * 2 ** 16 + buf[++offset] * 2 ** 8 + last;
+  const val = first * 2 ** 16 + buf[++offset]! * 2 ** 8 + last;
   return val | (val & 2 ** 23) * 0x1fe;
 }
 
@@ -1811,11 +1899,11 @@ function readInt48BE(buf: Buffer|Uint8Array, offset: number = 0) {
     boundsError(offset, buf.length - 6);
   }
 
-  const val = buf[++offset] + first * 2 ** 8;
+  const val = buf[++offset]! + first * 2 ** 8;
   return (val | (val & 2 ** 15) * 0x1fffe) * 2 ** 32 +
-    buf[++offset] * 2 ** 24 +
-    buf[++offset] * 2 ** 16 +
-    buf[++offset] * 2 ** 8 +
+    buf[++offset]! * 2 ** 24 +
+    buf[++offset]! * 2 ** 16 +
+    buf[++offset]! * 2 ** 8 +
     last;
 }
 
@@ -1828,9 +1916,9 @@ function readInt40BE(buf: Buffer|Uint8Array, offset: number = 0) {
   }
 
   return (first | (first & 2 ** 7) * 0x1fffffe) * 2 ** 32 +
-    buf[++offset] * 2 ** 24 +
-    buf[++offset] * 2 ** 16 +
-    buf[++offset] * 2 ** 8 +
+    buf[++offset]! * 2 ** 24 +
+    buf[++offset]! * 2 ** 16 +
+    buf[++offset]! * 2 ** 8 +
     last;
 }
 

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -333,6 +333,12 @@ export class ERR_UNKNOWN_ENCODING extends NodeTypeError {
   }
 }
 
+export class ERR_STREAM_PREMATURE_CLOSE extends NodeTypeError {
+  constructor() {
+    super("ERR_STREAM_PREMATURE_CLOSE", "Premature close");
+  }
+}
+
 export class AbortError extends Error {
   code: string;
 
@@ -388,6 +394,12 @@ export class ERR_INVALID_RETURN_VALUE extends NodeTypeError {
   }
 }
 
+export class ERR_MULTIPLE_CALLBACK extends NodeError {
+  constructor() {
+    super("ERR_MULTIPLE_CALLBACK", "Callback called multiple times");
+  }
+}
+
 export class ERR_MISSING_ARGS extends NodeTypeError {
   constructor(...args: (string | string[])[]) {
     let msg = "The ";
@@ -425,16 +437,70 @@ export class ERR_FALSY_VALUE_REJECTION extends NodeError {
   }
 }
 
-export default {
-  ERR_AMBIGUOUS_ARGUMENT,
-  ERR_BUFFER_OUT_OF_BOUNDS,
-  ERR_FALSY_VALUE_REJECTION,
-  ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_ARG_VALUE,
-  ERR_INVALID_BUFFER_SIZE,
-  ERR_INVALID_THIS,
-  ERR_MISSING_ARGS,
-  ERR_OUT_OF_RANGE,
-  ERR_UNHANDLED_ERROR,
-  ERR_UNKNOWN_ENCODING,
-};
+export class ERR_METHOD_NOT_IMPLEMENTED extends NodeError {
+  constructor(name: string|symbol) {
+    if (typeof name === 'symbol') {
+      name = (name as symbol).description!;
+    }
+    super("ERR_METHOD_NOT_IMPLEMENTED", `The ${name} method is not implemented`);
+  }
+}
+
+export class ERR_STREAM_CANNOT_PIPE extends NodeError {
+  constructor() {
+    super("ERR_STREAM_CANNOT_PIPE", "Cannot pipe, not readable");
+  }
+}
+export class ERR_STREAM_DESTROYED extends NodeError {
+  constructor(name: string|symbol) {
+    if (typeof name === 'symbol') {
+      name = (name as symbol).description!;
+    }
+    super("ERR_STREAM_DESTROYED", `Cannot call ${name} after a stream was destroyed`);
+  }
+}
+export class ERR_STREAM_ALREADY_FINISHED extends NodeError {
+  constructor(name: string|symbol) {
+    if (typeof name === 'symbol') {
+      name = (name as symbol).description!;
+    }
+    super("ERR_STREAM_ALREADY_FINISHED", `Cannot call ${name} after a stream was finished`);
+  }
+}
+export class ERR_STREAM_NULL_VALUES extends NodeTypeError {
+  constructor() {
+    super("ERR_STREAM_NULL_VALUES", "May not write null values to stream");
+  }
+}
+export class ERR_STREAM_WRITE_AFTER_END extends NodeError {
+  constructor() {
+    super("ERR_STREAM_WRITE_AFTER_END", "write after end");
+  }
+}
+
+export class ERR_STREAM_PUSH_AFTER_EOF extends NodeError {
+  constructor() {
+    super("ERR_STREAM_PUSH_AFTER_EOF", "stream.push() after EOF");
+  }
+}
+
+export class ERR_STREAM_UNSHIFT_AFTER_END_EVENT extends NodeError {
+  constructor() {
+    super("ERR_STREAM_UNSHIFT_AFTER_END_EVENT", "stream.unshift() after end event");
+  }
+}
+
+export function aggregateTwoErrors(innerError: any, outerError: any) {
+  if (innerError && outerError && innerError !== outerError) {
+    if (Array.isArray(outerError.errors)) {
+      // If `outerError` is already an `AggregateError`.
+      outerError.errors.push(innerError);
+      return outerError;
+    }
+    const err = new AggregateError([outerError, innerError], outerError.message);
+    (err as any).code = outerError.code;
+    return err;
+  }
+  return innerError || outerError
+}
+

--- a/src/node/internal/internal_stringdecoder.ts
+++ b/src/node/internal/internal_stringdecoder.ts
@@ -64,19 +64,20 @@ export interface StringDecoder {
   write(buf: ArrayBufferView|DataView|string): string;
   end(buf?: ArrayBufferView|DataView|string): string;
   text(buf: ArrayBufferView|DataView|string, offset?: number): string;
+  new (encoding?: string): StringDecoder;
 }
 
 interface InternalDecoder extends StringDecoder {
   [kNativeDecoder]: Buffer;
 }
 
-export function StringDecoder(this: any, encoding: string = 'utf8') {
+export function StringDecoder(this: StringDecoder, encoding: string = 'utf8') {
   const normalizedEncoding = normalizeEncoding(encoding);
   if (!isEncoding(normalizedEncoding)) {
     throw new ERR_UNKNOWN_ENCODING(encoding);
   }
-  this[kNativeDecoder] = Buffer.alloc(kSize);
-  this[kNativeDecoder][kEncoding] = encodings[normalizedEncoding!]!;
+  (this as InternalDecoder)[kNativeDecoder] = Buffer.alloc(kSize);
+  (this as InternalDecoder)[kNativeDecoder][kEncoding] = encodings[normalizedEncoding!]!;
   this.encoding = normalizedEncoding!;
 }
 
@@ -123,8 +124,6 @@ StringDecoder.prototype.write = write;
 StringDecoder.prototype.end = end;
 StringDecoder.prototype.text = text;
 
-interface Buffer extends Uint8Array {};
-
 Object.defineProperties(StringDecoder.prototype, {
   lastChar: {
     enumerable: true,
@@ -133,7 +132,7 @@ Object.defineProperties(StringDecoder.prototype, {
         throw new ERR_INVALID_THIS('StringDecoder');
       }
       return (this as InternalDecoder)[kNativeDecoder].subarray(
-        kIncompleteCharactersStart, kIncompleteCharactersEnd);
+        kIncompleteCharactersStart, kIncompleteCharactersEnd) as Buffer;
     },
   },
   lastNeed: {

--- a/src/node/internal/internal_utils.ts
+++ b/src/node/internal/internal_utils.ts
@@ -192,3 +192,20 @@ export function getOwnNonIndexProperties(
   }
   return result;
 }
+
+export function createDeferredPromise() {
+  let resolve;
+  let reject;
+
+  // eslint-disable-next-line promise/param-names
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  })
+  return {
+    promise,
+    resolve,
+    reject,
+  };
+}
+

--- a/src/node/internal/streams_compose.js
+++ b/src/node/internal/streams_compose.js
@@ -1,0 +1,180 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import {
+  pipeline,
+} from 'node-internal:streams_pipeline';
+import {
+  Duplex,
+} from 'node-internal:streams_duplex';
+import {
+  Readable as ReadableConstructor,
+  from
+} from 'node-internal:streams_readable';
+import {
+  isNodeStream,
+  isReadable,
+  isWritable,
+  destroyer,
+} from 'node-internal:streams_util';
+import {
+  AbortError,
+  ERR_INVALID_ARG_VALUE,
+  ERR_MISSING_ARGS,
+} from 'node-internal:internal_errors';
+
+export function compose(...streams) {
+  if (streams.length === 0) {
+    throw new ERR_MISSING_ARGS('streams');
+  }
+  if (streams.length === 1) {
+    return from(Duplex, streams[0]);
+  }
+  const orgStreams = [...streams];
+  if (typeof streams[0] === 'function') {
+    streams[0] = from(Duplex, streams[0]);
+  }
+  if (typeof streams[streams.length - 1] === 'function') {
+    const idx = streams.length - 1;
+    streams[idx] = from(Duplex, streams[idx]);
+  }
+  for (let n = 0; n < streams.length; ++n) {
+    if (!isNodeStream(streams[n])) {
+      // TODO(ronag): Add checks for non streams.
+      continue;
+    }
+    if (n < streams.length - 1 && !isReadable(streams[n])) {
+      throw new ERR_INVALID_ARG_VALUE(`streams[${n}]`, orgStreams[n], 'must be readable');
+    }
+    if (n > 0 && !isWritable(streams[n])) {
+      throw new ERR_INVALID_ARG_VALUE(`streams[${n}]`, orgStreams[n], 'must be writable');
+    }
+  }
+  let ondrain;
+  let onfinish;
+  let onreadable;
+  let onclose;
+  let d;
+  function onfinished(err) {
+    const cb = onclose;
+    onclose = null;
+    if (cb) {
+      cb(err);
+    } else if (err) {
+      d.destroy(err);
+    } else if (!readable && !writable) {
+      d.destroy();
+    }
+  }
+  const head = streams[0];
+  const tail = pipeline(streams, onfinished);
+  const writable = !!isWritable(head);
+  const readable = !!isReadable(tail);
+
+  // TODO(ronag): Avoid double buffering.
+  // Implement Writable/Readable/Duplex traits.
+  // See, https://github.com/nodejs/node/pull/33515.
+  d = new Duplex({
+    // TODO (ronag): highWaterMark?
+    writableObjectMode: !!(head !== null && head !== undefined && head.writableObjectMode),
+    readableObjectMode: !!(tail !== null && tail !== undefined && tail.writableObjectMode),
+    writable,
+    readable
+  });
+  if (writable) {
+    const w = head;
+    d._write = function (chunk, encoding, callback) {
+      if (head.write(chunk, encoding)) {
+        callback();
+      } else {
+        ondrain = callback;
+      }
+    };
+    d._final = function (callback) {
+      w.end();
+      onfinish = callback;
+    };
+    w.on('drain', function () {
+      if (ondrain) {
+        const cb = ondrain;
+        ondrain = null;
+        cb();
+      }
+    });
+    tail.on('finish', function () {
+      if (onfinish) {
+        const cb = onfinish;
+        onfinish = null;
+        cb();
+      }
+    });
+  }
+  if (readable) {
+    tail.on('readable', function () {
+      if (onreadable) {
+        const cb = onreadable;
+        onreadable = null;
+        cb();
+      }
+    });
+    tail.on('end', function () {
+      d.push(null);
+    });
+    d._read = function (_n) {
+      while (true) {
+        const buf = tail.read();
+        if (buf === null) {
+          onreadable = d._read;
+          return;
+        }
+        if (!d.push(buf)) {
+          return;
+        }
+      }
+    };
+  }
+  d._destroy = function (err, callback) {
+    if (!err && onclose !== null) {
+      err = new AbortError();
+    }
+    onreadable = null;
+    ondrain = null;
+    onfinish = null;
+    if (onclose === null) {
+      callback(err);
+    } else {
+      onclose = callback;
+      destroyer(tail, err);
+    }
+  };
+  return d;
+}
+
+ReadableConstructor.prototype.compose = function(...streams) {
+  return compose(this, ...streams);
+};

--- a/src/node/internal/streams_duplex.js
+++ b/src/node/internal/streams_duplex.js
@@ -1,0 +1,509 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import {
+  Readable,
+  from,
+} from 'node-internal:streams_readable';
+
+import {
+  Writable,
+} from 'node-internal:streams_writable';
+
+import {
+  createDeferredPromise,
+} from 'node-internal:internal_utils';
+
+import * as process from 'node-internal:process';
+
+import {
+  destroyer,
+  eos,
+  isReadable,
+  isWritable,
+  isIterable,
+  isNodeStream,
+  isReadableNodeStream,
+  isWritableNodeStream,
+  isDuplexNodeStream,
+} from 'node-internal:streams_util';
+
+import {
+  AbortError,
+  ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_RETURN_VALUE,
+} from 'node-internal:internal_errors';
+
+Object.setPrototypeOf(Duplex.prototype, Readable.prototype);
+Object.setPrototypeOf(Duplex, Readable);
+{
+  const keys = Object.keys(Writable.prototype);
+  // Allow the keys array to be GC'ed.
+  for (let i = 0; i < keys.length; i++) {
+    const method = keys[i];
+    if (!Duplex.prototype[method]) Duplex.prototype[method] = Writable.prototype[method];
+  }
+}
+
+export function isDuplexInstance(obj) {
+  return obj instanceof Duplex;
+}
+
+export function Duplex(options) {
+  if (!(this instanceof Duplex)) return new Duplex(options);
+  Readable.call(this, options);
+  Writable.call(this, options);
+  if (options) {
+    this.allowHalfOpen = options.allowHalfOpen !== false;
+    if (options.readable === false) {
+      this._readableState.readable = false;
+      this._readableState.ended = true;
+      this._readableState.endEmitted = true;
+    }
+    if (options.writable === false) {
+      this._writableState.writable = false;
+      this._writableState.ending = true;
+      this._writableState.ended = true;
+      this._writableState.finished = true;
+    }
+  } else {
+    this.allowHalfOpen = true;
+  }
+}
+Object.defineProperties(Duplex.prototype, {
+  writable: {
+    ...Object.getOwnPropertyDescriptor(Writable.prototype, 'writable')
+  },
+  writableHighWaterMark: {
+    ...Object.getOwnPropertyDescriptor(Writable.prototype, 'writableHighWaterMark')
+  },
+  writableObjectMode: {
+    ...Object.getOwnPropertyDescriptor(Writable.prototype, 'writableObjectMode')
+  },
+  writableBuffer: {
+    ...Object.getOwnPropertyDescriptor(Writable.prototype, 'writableBuffer')
+  },
+  writableLength: {
+    ...Object.getOwnPropertyDescriptor(Writable.prototype, 'writableLength')
+  },
+  writableFinished: {
+    ...Object.getOwnPropertyDescriptor(Writable.prototype, 'writableFinished')
+  },
+  writableCorked: {
+    ...Object.getOwnPropertyDescriptor(Writable.prototype, 'writableCorked')
+  },
+  writableEnded: {
+    ...Object.getOwnPropertyDescriptor(Writable.prototype, 'writableEnded')
+  },
+  writableNeedDrain: {
+    ...Object.getOwnPropertyDescriptor(Writable.prototype, 'writableNeedDrain')
+  },
+  destroyed: {
+    get() {
+      if (this._readableState === undefined || this._writableState === undefined) {
+        return false
+      }
+      return this._readableState.destroyed && this._writableState.destroyed
+    },
+    set(value) {
+      // Backward compatibility, the user is explicitly
+      // managing destroyed.
+      if (this._readableState && this._writableState) {
+        this._readableState.destroyed = value
+        this._writableState.destroyed = value
+      }
+    }
+  }
+});
+
+// let webStreamsAdapters
+
+// // Lazy to avoid circular references
+// function lazyWebStreams() {
+//   if (webStreamsAdapters === undefined) webStreamsAdapters = {}
+//   return webStreamsAdapters
+// }
+// Duplex.fromWeb = function (pair, options) {
+//   return lazyWebStreams().newStreamDuplexFromReadableWritablePair(pair, options)
+// }
+// Duplex.toWeb = function (duplex) {
+//   return lazyWebStreams().newReadableWritablePairFromDuplex(duplex)
+// }
+
+// ======================================================================================
+
+Duplex.from = function (body) {
+  return duplexify(body, 'body')
+}
+
+function isBlob(b) {
+  return b instanceof Blob;
+}
+
+// This is needed for pre node 17.
+class Duplexify extends (Duplex) {
+  constructor(options) {
+    super(options);
+    // https://github.com/nodejs/node/pull/34385
+
+    if ((options === null || options === undefined ? undefined : options.readable) === false) {
+      this['_readableState'].readable = false;
+      this['_readableState'].ended = true;
+      this['_readableState'].endEmitted = true;
+    }
+    if ((options === null || options === undefined ? undefined : options.writable) === false) {
+      this['_readableState'].writable = false;
+      this['_readableState'].ending = true;
+      this['_readableState'].ended = true;
+      this['_readableState'].finished = true;
+    }
+  }
+}
+
+function duplexify(body, name) {
+  if (isDuplexNodeStream(body)) {
+    return body;
+  }
+  if (isReadableNodeStream(body)) {
+    return _duplexify({
+      readable: body
+    });
+  }
+  if (isWritableNodeStream(body)) {
+    return _duplexify({
+      writable: body
+    });
+  }
+  if (isNodeStream(body)) {
+    return _duplexify({
+      writable: false,
+      readable: false
+    });
+  }
+
+  // TODO: Webstreams
+  // if (isReadableStream(body)) {
+  //   return _duplexify({ readable: Readable.fromWeb(body) });
+  // }
+
+  // TODO: Webstreams
+  // if (isWritableStream(body)) {
+  //   return _duplexify({ writable: Writable.fromWeb(body) });
+  // }
+
+  if (typeof body === 'function') {
+    const { value, write, final, destroy } = fromAsyncGen(body)
+    if (isIterable(value)) {
+      return from(Duplexify, value, {
+        // TODO (ronag): highWaterMark?
+        objectMode: true,
+        write,
+        final,
+        destroy
+      });
+    }
+    const then = value.then;
+    if (typeof then === 'function') {
+      let d;
+      const promise = Reflect.apply(then, value, [
+        (val) => {
+          if (val != null) {
+            throw new ERR_INVALID_RETURN_VALUE('nully', 'body', val)
+          }
+        },
+        (err) => {
+          destroyer(d, err)
+        }
+      ]);
+
+      return (d = new Duplexify({
+        // TODO (ronag): highWaterMark?
+        objectMode: true,
+        readable: false,
+        write,
+        final(cb) {
+          final(async () => {
+            try {
+              await promise
+              process.nextTick(cb, null);
+            } catch (err) {
+              process.nextTick(cb, err);
+            }
+          })
+        },
+        destroy
+      }));
+    }
+    throw new ERR_INVALID_RETURN_VALUE('Iterable, AsyncIterable or AsyncFunction', name, value)
+  }
+  if (isBlob(body)) {
+    return duplexify(body.arrayBuffer(), name);
+  }
+  if (isIterable(body)) {
+    return from(Duplexify, body, {
+      // TODO (ronag): highWaterMark?
+      objectMode: true,
+      writable: false
+    })
+  }
+
+  // TODO: Webstreams.
+  // if (
+  //   isReadableStream(body?.readable) &&
+  //   isWritableStream(body?.writable)
+  // ) {
+  //   return Duplexify.fromWeb(body);
+  // }
+
+  if (
+    typeof (body === null || body === undefined ? undefined : body.writable) === 'object' ||
+    typeof (body === null || body === undefined ? undefined : body.readable) === 'object'
+  ) {
+    const readable =
+      body !== null && body !== undefined && body.readable
+        ? isReadableNodeStream(body === null || body === undefined ? undefined : body.readable)
+          ? body === null || body === undefined
+            ? undefined
+            : body.readable
+          : duplexify(body.readable, name)
+        : undefined;
+    const writable =
+      body !== null && body !== undefined && body.writable
+        ? isWritableNodeStream(body === null || body === undefined ? undefined : body.writable)
+          ? body === null || body === undefined
+            ? undefined
+            : body.writable
+          : duplexify(body.writable, name)
+        : undefined;
+    return _duplexify({
+      readable,
+      writable
+    });
+  }
+  const then = body?.then
+  if (typeof then === 'function') {
+    let d;
+    Reflect.apply(then, body, [
+      (val) => {
+        if (val != null) {
+          d.push(val);
+        }
+        d.push(null);
+      },
+      (err) => {
+        destroyer(d, err);
+      }
+    ]);
+
+    return (d = new Duplexify({
+      objectMode: true,
+      writable: false,
+      read() {}
+    }));
+  }
+  throw new ERR_INVALID_ARG_TYPE(
+    name,
+    [
+      'Blob',
+      'ReadableStream',
+      'WritableStream',
+      'Stream',
+      'Iterable',
+      'AsyncIterable',
+      'Function',
+      '{ readable, writable } pair',
+      'Promise'
+    ],
+    body
+  )
+}
+
+function fromAsyncGen(fn) {
+  let { promise, resolve } = createDeferredPromise()
+  const ac = new AbortController()
+  const signal = ac.signal
+  const value = fn(
+    (async function* () {
+      while (true) {
+        const _promise = promise;
+        promise = null;
+        const { chunk, done, cb } = await _promise;
+        process.nextTick(cb);
+        if (done) return;
+        if (signal.aborted)
+          throw new AbortError(undefined, {
+            cause: signal.reason
+          });
+        ({ promise, resolve } = createDeferredPromise());
+        yield chunk;
+      }
+    })(),
+    {
+      signal
+    }
+  );
+  return {
+    value,
+    write(chunk, _encoding, cb) {
+      const _resolve = resolve;
+      resolve = null;
+      _resolve({
+        chunk,
+        done: false,
+        cb
+      })
+    },
+    final(cb) {
+      const _resolve = resolve;
+      resolve = null;
+      (_resolve)({
+        done: true,
+        cb
+      });
+    },
+    destroy(err, cb) {
+      ac.abort();
+      cb(err);
+    }
+  }
+}
+
+function _duplexify(pair) {
+  const r = pair.readable && typeof pair.readable.read !== 'function' ? Readable.wrap(pair.readable) : pair.readable;
+  const w = pair.writable;
+  let readable = !!isReadable(r);
+  let writable = !!isWritable(w);
+  let ondrain;
+  let onfinish;
+  let onreadable;
+  let onclose;
+  let d;
+  function onfinished(err) {
+    const cb = onclose
+    onclose = null
+    if (cb) {
+      cb(err)
+    } else if (err) {
+      d.destroy(err)
+    } else if (!readable && !writable) {
+      d.destroy()
+    }
+  }
+
+  // TODO(ronag): Avoid double buffering.
+  // Implement Writable/Readable/Duplex traits.
+  // See, https://github.com/nodejs/node/pull/33515.
+  d = new Duplexify({
+    // TODO (ronag): highWaterMark?
+    readableObjectMode: !!(r !== null && r !== undefined && r.readableObjectMode),
+    writableObjectMode: !!(w !== null && w !== undefined && w.writableObjectMode),
+    readable,
+    writable
+  });
+  if (writable) {
+    eos(w, (err) => {
+      writable = false;
+      if (err) {
+        destroyer(r, err);
+      }
+      onfinished(err);
+    });
+    d._write = function (chunk, encoding, callback) {
+      if (w.write(chunk, encoding)) {
+        callback();
+      } else {
+        ondrain = callback;
+      }
+    };
+    d._final = function (callback) {
+      w.end();
+      onfinish = callback;
+    };
+    w.on('drain', function () {
+      if (ondrain) {
+        const cb = ondrain;
+        ondrain = null;
+        cb();
+      }
+    });
+    w.on('finish', function () {
+      if (onfinish) {
+        const cb = onfinish;
+        onfinish = null;
+        cb();
+      }
+    });
+  }
+  if (readable) {
+    eos(r, (err) => {
+      readable = false;
+      if (err) {
+        destroyer(r, err);
+      }
+      onfinished(err);
+    });
+    r.on('readable', function () {
+      if (onreadable) {
+        const cb = onreadable;
+        onreadable = null;
+        cb();
+      }
+    });
+    r.on('end', function () {
+      d.push(null);
+    });
+    d._read = function () {
+      while (true) {
+        const buf = r.read();
+        if (buf === null) {
+          onreadable = d._read;
+          return;
+        }
+        if (!d.push(buf)) {
+          return;
+        }
+      }
+    };
+  }
+  d._destroy = function (err, callback) {
+    if (!err && onclose !== null) {
+      err = new AbortError();
+    }
+    onreadable = null;
+    ondrain = null;
+    onfinish = null;
+    if (onclose === null) {
+      callback(err);
+    } else {
+      onclose = callback;
+      destroyer(w, err);
+      destroyer(r, err);
+    }
+  }
+  return d;
+}

--- a/src/node/internal/streams_legacy.js
+++ b/src/node/internal/streams_legacy.js
@@ -1,0 +1,115 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import {
+  EventEmitter,
+} from 'node-internal:events';
+
+import {
+  Buffer,
+} from 'node-internal:internal_buffer';
+
+export function Stream(opts) {
+  EventEmitter.call(this, opts||{});
+}
+
+Object.setPrototypeOf(Stream.prototype, EventEmitter.prototype);
+Object.setPrototypeOf(Stream, EventEmitter);
+
+Stream.prototype.pipe = function (dest, options) {
+  const source = this;
+  function ondata(chunk) {
+    if (dest.writable && dest.write(chunk) === false && source.pause) {
+      source.pause();
+    }
+  }
+  source.on('data', ondata);
+  function ondrain() {
+    if (source.readable && source.resume) {
+      source.resume();
+    }
+  }
+  dest.on('drain', ondrain);
+
+  // If the 'end' option is not supplied, dest.end() will be called when
+  // source gets the 'end' or 'close' events.  Only dest.end() once.
+  if (!dest._isStdio && (!options || options.end !== false)) {
+    source.on('end', onend);
+    source.on('close', onclose);
+  }
+  let didOnEnd = false;
+  function onend() {
+    if (didOnEnd) return;
+    didOnEnd = true;
+    dest.end();
+  }
+  function onclose() {
+    if (didOnEnd) return;
+    didOnEnd = true;
+    if (typeof dest.destroy === 'function') dest.destroy();
+  }
+
+  // Don't leave dangling pipes when there are errors.
+  function onerror(er) {
+    cleanup();
+    if (EventEmitter.listenerCount(this, 'error') === 0) {
+      this.emit('error', er);
+    }
+  }
+  source.prependListener('error', onerror);
+  dest.prependListener('error', onerror);
+
+  // Remove all the event listeners that were added.
+  function cleanup() {
+    source.removeListener('data', ondata);
+    dest.removeListener('drain', ondrain);
+    source.removeListener('end', onend);
+    source.removeListener('close', onclose);
+    source.removeListener('error', onerror);
+    dest.removeListener('error', onerror);
+    source.removeListener('end', cleanup);
+    source.removeListener('close', cleanup);
+    dest.removeListener('close', cleanup);
+  }
+  source.on('end', cleanup);
+  source.on('close', cleanup);
+  dest.on('close', cleanup);
+  dest.emit('pipe', source);
+
+  // Allow for unix-like usage: A.pipe(B).pipe(C)
+  return dest;
+}
+
+// Backwards-compat with node 0.4.x
+Stream.Stream = Stream
+Stream._isUint8Array = function isUint8Array(value) {
+  return value instanceof Uint8Array;
+}
+Stream._uint8ArrayToBuffer = function _uint8ArrayToBuffer(chunk) {
+  return Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+}

--- a/src/node/internal/streams_pipeline.js
+++ b/src/node/internal/streams_pipeline.js
@@ -1,0 +1,402 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import {
+  once,
+  isIterable,
+  isReadable,
+  isReadableNodeStream,
+  isNodeStream,
+  eos,
+  destroyer as destroyerImpl,
+} from 'node-internal:streams_util';
+
+import * as process from 'node-internal:process';
+
+import { PassThrough } from 'node-internal:streams_transform';
+import { Duplex } from 'node-internal:streams_duplex';
+import { Readable, from } from 'node-internal:streams_readable';
+import {
+  aggregateTwoErrors,
+  ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_RETURN_VALUE,
+  ERR_MISSING_ARGS,
+  ERR_STREAM_DESTROYED,
+  ERR_STREAM_PREMATURE_CLOSE,
+  AbortError
+} from 'node-internal:internal_errors';
+import {
+  validateFunction,
+  validateAbortSignal,
+} from 'node-internal:validators';
+
+function destroyer(stream, reading, writing) {
+  let finished = false;
+  stream.on('close', () => {
+    finished = true;
+  });
+  const cleanup = eos(
+    stream,
+    {
+      readable: reading,
+      writable: writing
+    },
+    (err) => {
+      finished = !err
+    }
+  );
+  return {
+    destroy: (err) => {
+      if (finished) return;
+      finished = true;
+      destroyerImpl(stream, err || new ERR_STREAM_DESTROYED('pipe'));
+    },
+    cleanup
+  };
+}
+
+function popCallback(streams) {
+  // Streams should never be an empty array. It should always contain at least
+  // a single stream. Therefore optimize for the average case instead of
+  // checking for length === 0 as well.
+  validateFunction(streams[streams.length - 1], 'streams[stream.length - 1]');
+  return streams.pop();
+}
+
+function makeAsyncIterable(val) {
+  if (isIterable(val)) {
+    return val;
+  } else if (isReadableNodeStream(val)) {
+    // Legacy streams are not Iterable.
+    return fromReadable(val);
+  }
+  throw new ERR_INVALID_ARG_TYPE('val', ['Readable', 'Iterable', 'AsyncIterable'], val);
+}
+
+async function* fromReadable(val) {
+  yield* Readable.prototype[Symbol.asyncIterator].call(val);
+}
+
+async function pump(iterable, writable, finish, { end }) {
+  let error;
+  let onresolve = null;
+  const resume = (err) => {
+    if (err) {
+      error = err;
+    }
+    if (onresolve) {
+      const callback = onresolve;
+      onresolve = null;
+      callback();
+    }
+  }
+  const wait = () => {
+    return new Promise((resolve, reject) => {
+      if (error) {
+        reject(error);
+      } else {
+        onresolve = () => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        };
+      }
+    });
+  };
+  writable.on('drain', resume);
+  const cleanup = eos(
+    writable,
+    {
+      readable: false
+    },
+    resume
+  );
+  try {
+    if (writable.writableNeedDrain) {
+      await wait();
+    }
+    for await (const chunk of iterable) {
+      if (!writable.write(chunk)) {
+        await wait();
+      }
+    }
+    if (end) {
+      writable.end();
+    }
+    await wait();
+    finish();
+  } catch (err) {
+    finish(error !== err ? aggregateTwoErrors(error, err) : err);
+  } finally {
+    cleanup();
+    writable.off('drain', resume);
+  }
+}
+
+export function pipeline(...streams) {
+  return pipelineImpl(streams, once(popCallback(streams)));
+}
+
+export function pipelineImpl(streams, callback, opts) {
+  if (streams.length === 1 && Array.isArray(streams[0])) {
+    streams = streams[0];
+  }
+  if (streams.length < 2) {
+    throw new ERR_MISSING_ARGS('streams');
+  }
+  const ac = new AbortController();
+  const signal = ac.signal;
+  const outerSignal = opts?.signal;
+
+  // Need to cleanup event listeners if last stream is readable
+  // https://github.com/nodejs/node/issues/35452
+  const lastStreamCleanup = [];
+  validateAbortSignal(outerSignal, 'options.signal');
+  function abort() {
+    finishImpl(new AbortError());
+  }
+  outerSignal === null || outerSignal === undefined ? undefined : outerSignal.addEventListener('abort', abort);
+  let error;
+  let value;
+  const destroys = [];
+  let finishCount = 0;
+  function finish(err) {
+    finishImpl(err, --finishCount === 0);
+  }
+  function finishImpl(err, final) {
+    if (err && (!error || error.code === 'ERR_STREAM_PREMATURE_CLOSE')) {
+      error = err;
+    }
+    if (!error && !final) {
+      return;
+    }
+    while (destroys.length) {
+      destroys.shift()(error);
+    }
+    outerSignal === null || outerSignal === undefined ? undefined : outerSignal.removeEventListener('abort', abort);
+    ac.abort();
+    if (final) {
+      if (!error) {
+        lastStreamCleanup.forEach((fn) => fn());
+      }
+      process.nextTick(callback, error, value);
+    }
+  }
+  let ret;
+  for (let i = 0; i < streams.length; i++) {
+    const stream = streams[i];
+    const reading = i < streams.length - 1;
+    const writing = i > 0;
+    const end = reading || (opts === null || opts === undefined ? undefined : opts.end) !== false;
+    const isLastStream = i === streams.length - 1;
+    if (isNodeStream(stream)) {
+      if (end) {
+        const { destroy, cleanup } = destroyer(stream, reading, writing);
+        destroys.push(destroy);
+        if (isReadable(stream) && isLastStream) {
+          lastStreamCleanup.push(cleanup);
+        }
+      }
+
+      // Catch stream errors that occur after pipe/pump has completed.
+      function onError(err) {
+        if (err && err.name !== 'AbortError' && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
+          finish(err);
+        }
+      }
+      stream.on('error', onError);
+      if (isReadable(stream) && isLastStream) {
+        lastStreamCleanup.push(() => {
+          stream.removeListener('error', onError);
+        })
+      }
+    }
+    if (i === 0) {
+      if (typeof stream === 'function') {
+        ret = stream({
+          signal
+        });
+        if (!isIterable(ret)) {
+          throw new ERR_INVALID_RETURN_VALUE('Iterable, AsyncIterable or Stream', 'source', ret);
+        }
+      } else if (isIterable(stream) || isReadableNodeStream(stream)) {
+        ret = stream;
+      } else {
+        ret = from(Duplex, stream);
+      }
+    } else if (typeof stream === 'function') {
+      ret = makeAsyncIterable(ret);
+      ret = stream(ret, {
+        signal
+      });
+      if (reading) {
+        if (!isIterable(ret, true)) {
+          throw new ERR_INVALID_RETURN_VALUE('AsyncIterable', `transform[${i - 1}]`, ret);
+        }
+      } else {
+        let _ret;
+        // If the last argument to pipeline is not a stream
+        // we must create a proxy stream so that pipeline(...)
+        // always returns a stream which can be further
+        // composed through `.pipe(stream)`.
+
+        const pt = new PassThrough({
+          objectMode: true
+        });
+
+        // Handle Promises/A+ spec, `then` could be a getter that throws on
+        // second use.
+        const then = (_ret = ret) === null || _ret === undefined ? undefined : _ret.then
+        if (typeof then === 'function') {
+          finishCount++;
+          then.call(
+            ret,
+            (val) => {
+              value = val;
+              if (val != null) {
+                pt.write(val);
+              }
+              if (end) {
+                pt.end();
+              }
+              process.nextTick(finish);
+            },
+            (err) => {
+              pt.destroy(err);
+              process.nextTick(finish, err);
+            }
+          );
+        } else if (isIterable(ret, true)) {
+          finishCount++;
+          pump(ret, pt, finish, {
+            end
+          });
+        } else {
+          throw new ERR_INVALID_RETURN_VALUE('AsyncIterable or Promise', 'destination', ret);
+        }
+        ret = pt;
+        const { destroy, cleanup } = destroyer(ret, false, true);
+        destroys.push(destroy);
+        if (isLastStream) {
+          lastStreamCleanup.push(cleanup);
+        }
+      }
+    } else if (isNodeStream(stream)) {
+      if (isReadableNodeStream(ret)) {
+        finishCount += 2;
+        const cleanup = pipe(ret, stream, finish, {
+          end
+        });
+        if (isReadable(stream) && isLastStream) {
+          lastStreamCleanup.push(cleanup);
+        }
+      } else if (isIterable(ret)) {
+        finishCount++;
+        pump(ret, stream, finish, {
+          end
+        });
+      } else {
+        throw new ERR_INVALID_ARG_TYPE('val', ['Readable', 'Iterable', 'AsyncIterable'], ret);
+      }
+      ret = stream;
+    } else {
+      ret = from(Duplex, stream);
+    }
+  }
+  if (
+    (signal !== null && signal !== undefined && signal.aborted) ||
+    (outerSignal !== null && outerSignal !== undefined && outerSignal.aborted)
+  ) {
+    process.nextTick(abort);
+  }
+  return ret;
+}
+
+export function pipe(src, dst, finish, { end }) {
+  let ended = false;
+  dst.on('close', () => {
+    if (!ended) {
+      // Finish if the destination closes before the source has completed.
+      finish(new ERR_STREAM_PREMATURE_CLOSE());
+    }
+  })
+  src.pipe(dst, {
+    end
+  });
+  if (end) {
+    // Compat. Before node v10.12.0 stdio used to throw an error so
+    // pipe() did/does not end() stdio destinations.
+    // Now they allow it but "secretly" don't close the underlying fd.
+    src.once('end', () => {
+      ended = true
+      dst.end()
+    });
+  } else {
+    finish();
+  }
+  eos(
+    src,
+    {
+      readable: true,
+      writable: false
+    },
+    (err) => {
+      const rState = src._readableState;
+      if (
+        err &&
+        err.code === 'ERR_STREAM_PREMATURE_CLOSE' &&
+        rState &&
+        rState.ended &&
+        !rState.errored &&
+        !rState.errorEmitted
+      ) {
+        // Some readable streams will emit 'close' before 'end'. However, since
+        // this is on the readable side 'end' should still be emitted if the
+        // stream has been ended and no error emitted. This should be allowed in
+        // favor of backwards compatibility. Since the stream is piped to a
+        // destination this should not result in any observable difference.
+        // We don't need to check if this is a writable premature close since
+        // eos will only fail with premature close on the reading side for
+        // duplex streams.
+        src.once('end', finish).once('error', finish);
+      } else {
+        finish(err);
+      }
+    }
+  );
+  return eos(
+    dst,
+    {
+      readable: false,
+      writable: true
+    },
+    finish
+  );
+}

--- a/src/node/internal/streams_promises.js
+++ b/src/node/internal/streams_promises.js
@@ -1,0 +1,69 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import {
+  isIterable,
+  isNodeStream,
+  finished,
+} from 'node-internal:streams_util';
+
+import {
+  pipelineImpl as pl
+} from 'node-internal:streams_pipeline';
+
+function pipeline(...streams) {
+  return new Promise((resolve, reject) => {
+    let signal;
+    let end;
+    const lastArg = streams[streams.length - 1];
+    if (lastArg && typeof lastArg === 'object' && !isNodeStream(lastArg) && !isIterable(lastArg)) {
+      const options = streams.pop();
+      signal = options.signal;
+      end = options.end;
+    }
+    pl(
+      streams,
+      (err, value) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(value);
+        }
+      },
+      {
+        signal,
+        end
+      }
+    );
+  });
+}
+
+export const promises = {
+  pipeline,
+  finished,
+};

--- a/src/node/internal/streams_readable.js
+++ b/src/node/internal/streams_readable.js
@@ -1,0 +1,1785 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import {
+  nop,
+  getHighWaterMark,
+  getDefaultHighWaterMark,
+  kPaused,
+  addAbortSignal,
+  BufferList,
+  eos,
+  construct,
+  destroy,
+  destroyer,
+  undestroy,
+  errorOrDestroy,
+  finished,
+} from 'node-internal:streams_util';
+
+import * as process from 'node-internal:process';
+
+import {
+  EventEmitter,
+} from 'node-internal:events';
+
+import {
+  Stream,
+} from 'node-internal:streams_legacy';
+
+import {
+  Buffer,
+} from 'node-internal:internal_buffer';
+
+import {
+  AbortError,
+  aggregateTwoErrors,
+  ERR_INVALID_ARG_TYPE,
+  ERR_METHOD_NOT_IMPLEMENTED,
+  ERR_MISSING_ARGS,
+  ERR_OUT_OF_RANGE,
+  ERR_STREAM_PUSH_AFTER_EOF,
+  ERR_STREAM_UNSHIFT_AFTER_END_EVENT,
+  ERR_STREAM_NULL_VALUES,
+} from 'node-internal:internal_errors';
+
+import {
+  validateObject,
+  validateAbortSignal,
+  validateInteger,
+} from 'node-internal:validators';
+
+import { StringDecoder } from 'node-internal:internal_stringdecoder';
+
+import { isDuplexInstance } from 'node-internal:streams_duplex';
+
+// ======================================================================================
+// ReadableState
+
+function ReadableState(options, stream, isDuplex) {
+  // Duplex streams are both readable and writable, but share
+  // the same options object.
+  // However, some cases require setting options to different
+  // values for the readable and the writable sides of the duplex stream.
+  // These options can be provided separately as readableXXX and writableXXX.
+  if (typeof isDuplex !== 'boolean') isDuplex = isDuplexInstance(stream);
+
+  // Object stream flag. Used to make read(n) ignore n and to
+  // make all the buffer merging and length checks go away.
+  this.objectMode = !!(options?.objectMode);
+  if (isDuplex) this.objectMode = this.objectMode || !!(options?.readableObjectMode);
+
+  // The point at which it stops calling _read() to fill the buffer
+  // Note: 0 is a valid value, means "don't call _read preemptively ever"
+  this.highWaterMark = options
+    ? getHighWaterMark(this, options, 'readableHighWaterMark', isDuplex)
+    : getDefaultHighWaterMark(false);
+
+  // A linked list is used to store data chunks instead of an array because the
+  // linked list can remove elements from the beginning faster than
+  // array.shift().
+  this.buffer = new BufferList();
+  this.length = 0;
+  this.pipes = [];
+  this.flowing = null;
+  this.ended = false;
+  this.endEmitted = false;
+  this.reading = false;
+
+  // Stream is still being constructed and cannot be
+  // destroyed until construction finished or failed.
+  // Async construction is opt in, therefore we start as
+  // constructed.
+  this.constructed = true;
+
+  // A flag to be able to tell if the event 'readable'/'data' is emitted
+  // immediately, or on a later tick.  We set this to true at first, because
+  // any actions that shouldn't happen until "later" should generally also
+  // not happen before the first read call.
+  this.sync = true;
+
+  // Whenever we return null, then we set a flag to say
+  // that we're awaiting a 'readable' event emission.
+  this.needReadable = false;
+  this.emittedReadable = false;
+  this.readableListening = false;
+  this.resumeScheduled = false;
+  this[kPaused] = null;
+
+  // True if the error was already emitted and should not be thrown again.
+  this.errorEmitted = false;
+
+  // Should close be emitted on destroy. Defaults to true.
+  this.emitClose = !options || options.emitClose !== false;
+
+  // Should .destroy() be called after 'end' (and potentially 'finish').
+  this.autoDestroy = !options || options.autoDestroy !== false;
+
+  // Has it been destroyed.
+  this.destroyed = false;
+
+  // Indicates whether the stream has errored. When true no further
+  // _read calls, 'data' or 'readable' events should occur. This is needed
+  // since when autoDestroy is disabled we need a way to tell whether the
+  // stream has failed.
+  this.errored = null;
+
+  // Indicates whether the stream has finished destroying.
+  this.closed = false;
+
+  // True if close has been emitted or would have been emitted
+  // depending on emitClose.
+  this.closeEmitted = false;
+
+  // Crypto is kind of old and crusty.  Historically, its default string
+  // encoding is 'binary' so we have to make this configurable.
+  // Everything else in the universe uses 'utf8', though.
+  this.defaultEncoding = options?.defaultEncoding || 'utf8';
+
+  // Ref the piped dest which we need a drain event on it
+  // type: null | Writable | Set<Writable>.
+  this.awaitDrainWriters = null;
+  this.multiAwaitDrain = false;
+
+  // If true, a maybeReadMore has been scheduled.
+  this.readingMore = false;
+  this.dataEmitted = false;
+  this.decoder = null;
+  this.encoding = null;
+  if (options && options.encoding) {
+    this.decoder = new StringDecoder(options.encoding);
+    this.encoding = options.encoding;
+  }
+}
+
+// ======================================================================================
+// Readable
+
+Readable.ReadableState = ReadableState;
+
+Object.setPrototypeOf(Readable.prototype, Stream.prototype);
+Object.setPrototypeOf(Readable, Stream);
+
+export function Readable(options) {
+  if (!(this instanceof Readable)) return new Readable(options);
+
+  // Checking for a Stream.Duplex instance is faster here instead of inside
+  // the ReadableState constructor, at least with V8 6.5.
+  const isDuplex = isDuplexInstance(this);
+  this._readableState = new ReadableState(options, this, isDuplex);
+  if (options) {
+    if (typeof options.read === 'function') this._read = options.read;
+    if (typeof options.destroy === 'function') this._destroy = options.destroy;
+    if (typeof options.construct === 'function') this._construct = options.construct;
+    if (options.signal && !isDuplex) addAbortSignal(options.signal, this);
+  }
+  Stream.call(this, options);
+  construct(this, () => {
+    if (this._readableState.needReadable) {
+      maybeReadMore(this, this._readableState);
+    }
+  });
+}
+Readable.prototype.destroy = destroy
+Readable.prototype._undestroy = undestroy
+Readable.prototype._destroy = function (err, cb) {
+  if (cb) cb(err);
+}
+
+Readable.prototype[EventEmitter.captureRejectionSymbol] = function (err) {
+  this.destroy(err);
+}
+
+// Manually shove something into the read() buffer.
+// This returns true if the highWaterMark has not been hit yet,
+// similar to how Writable.write() returns true if you should
+// write() some more.
+Readable.prototype.push = function (chunk, encoding) {
+  return readableAddChunk(this, chunk, encoding, false);
+}
+
+// Unshift should *always* be something directly out of read().
+Readable.prototype.unshift = function (chunk, encoding) {
+  return readableAddChunk(this, chunk, encoding, true);
+}
+
+function readableAddChunk(stream, chunk, encoding, addToFront) {
+  const state = stream._readableState;
+  let err;
+  if (!state.objectMode) {
+    if (typeof chunk === 'string') {
+      encoding ||= state.defaultEncoding;
+      if (state.encoding !== encoding) {
+        if (addToFront && state.encoding) {
+          // When unshifting, if state.encoding is set, we have to save
+          // the string in the BufferList with the state encoding.
+          chunk = Buffer.from(chunk, encoding).toString(state.encoding);
+        } else {
+          chunk = Buffer.from(chunk, encoding);
+          encoding = '';
+        }
+      }
+    } else if (chunk instanceof Buffer) {
+      encoding = ''
+    } else if (Stream._isUint8Array(chunk)) {
+      chunk = Stream._uint8ArrayToBuffer(chunk);
+      encoding = '';
+    } else if (chunk != null) {
+      err = new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer', 'Uint8Array'], chunk);
+    }
+  }
+  if (err) {
+    errorOrDestroy(stream, err);
+  } else if (chunk === null) {
+    state.reading = false;
+    onEofChunk(stream, state);
+  } else if (state.objectMode || (chunk && chunk.length > 0)) {
+    if (addToFront) {
+      if (state.endEmitted) errorOrDestroy(stream, new ERR_STREAM_UNSHIFT_AFTER_END_EVENT());
+      else if (state.destroyed || state.errored) return false;
+      else addChunk(stream, state, chunk, true);
+    } else if (state.ended) {
+      errorOrDestroy(stream, new ERR_STREAM_PUSH_AFTER_EOF());
+    } else if (state.destroyed || state.errored) {
+      return false;
+    } else {
+      state.reading = false;
+      if (state.decoder && !encoding) {
+        chunk = state.decoder.write(chunk);
+        if (state.objectMode || chunk.length !== 0) addChunk(stream, state, chunk, false);
+        else maybeReadMore(stream, state);
+      } else {
+        addChunk(stream, state, chunk, false);
+      }
+    }
+  } else if (!addToFront) {
+    state.reading = false;
+    maybeReadMore(stream, state);
+  }
+
+  // We can push more data if we are below the highWaterMark.
+  // Also, if we have no data yet, we can stand some more bytes.
+  // This is to work around cases where hwm=0, such as the repl.
+  return !state.ended && (state.length < state.highWaterMark || state.length === 0);
+}
+
+function addChunk(stream, state, chunk, addToFront) {
+  if (state.flowing && state.length === 0 && !state.sync && stream.listenerCount('data') > 0) {
+    // Use the guard to avoid creating `Set()` repeatedly
+    // when we have multiple pipes.
+    if (state.multiAwaitDrain) {
+      state.awaitDrainWriters.clear();
+    } else {
+      state.awaitDrainWriters = null;
+    }
+    state.dataEmitted = true;
+    stream.emit('data', chunk);
+  } else {
+    // Update the buffer info.
+    state.length += state.objectMode ? 1 : chunk.length;
+    if (addToFront) state.buffer.unshift(chunk);
+    else state.buffer.push(chunk);
+    if (state.needReadable) emitReadable(stream);
+  }
+  maybeReadMore(stream, state);
+}
+
+Readable.prototype.isPaused = function () {
+  const state = this._readableState;
+  return state[kPaused] === true || state.flowing === false;
+}
+
+// Backwards compatibility.
+Readable.prototype.setEncoding = function (enc) {
+  const decoder = new StringDecoder(enc);
+  this._readableState.decoder = decoder;
+  // If setEncoding(null), decoder.encoding equals utf8.
+  this._readableState.encoding = decoder.encoding;
+  const buffer = this._readableState.buffer;
+  // Iterate over current buffer to convert already stored Buffers:
+  let content = '';
+  for (const data of buffer) {
+    content += decoder.write(data);
+  }
+  buffer.clear();
+  if (content !== '') buffer.push(content);
+  this._readableState.length = content.length;
+  return this;
+}
+
+// Don't raise the hwm > 1GB.
+const MAX_HWM = 0x40000000;
+function computeNewHighWaterMark(n) {
+  if (n > MAX_HWM) {
+    throw new ERR_OUT_OF_RANGE('size', '<= 1GiB', n);
+  } else {
+    // Get the next highest power of 2 to prevent increasing hwm excessively in
+    // tiny amounts.
+    n--;
+    n |= n >>> 1;
+    n |= n >>> 2;
+    n |= n >>> 4;
+    n |= n >>> 8;
+    n |= n >>> 16;
+    n++;
+  }
+  return n;
+}
+
+// This function is designed to be inlinable, so please take care when making
+// changes to the function body.
+function howMuchToRead(n, state) {
+  if (n <= 0 || (state.length === 0 && state.ended)) return 0;
+  if (state.objectMode) return 1;
+  if (Number.isNaN(n)) {
+    // Only flow one buffer at a time.
+    if (state.flowing && state.length) return state.buffer.first().length;
+    return state.length;
+  }
+  if (n <= state.length) return n;
+  return state.ended ? state.length : 0;
+}
+
+// You can override either this method, or the async _read(n) below.
+Readable.prototype.read = function (n) {
+  // Same as parseInt(undefined, 10), however V8 7.3 performance regressed
+  // in this scenario, so we are doing it manually.
+  if (n === undefined) {
+    n = NaN;
+  } else if (!Number.isInteger(n)) {
+    n = Number.parseInt(`${n}`, 10);
+  }
+  const state = this._readableState;
+  const nOrig = n;
+
+  // If we're asking for more than the current hwm, then raise the hwm.
+  if (n > state.highWaterMark) state.highWaterMark = computeNewHighWaterMark(n);
+  if (n !== 0) state.emittedReadable = false;
+
+  // If we're doing read(0) to trigger a readable event, but we
+  // already have a bunch of data in the buffer, then just trigger
+  // the 'readable' event and move on.
+  if (
+    n === 0 &&
+    state.needReadable &&
+    ((state.highWaterMark !== 0 ? state.length >= state.highWaterMark : state.length > 0) || state.ended)) {
+    if (state.length === 0 && state.ended) endReadable(this);
+    else emitReadable(this);
+    return null;
+  }
+  n = howMuchToRead(n, state);
+
+  // If we've ended, and we're now clear, then finish it up.
+  if (n === 0 && state.ended) {
+    if (state.length === 0) endReadable(this);
+    return null;
+  }
+
+  // All the actual chunk generation logic needs to be
+  // *below* the call to _read.  The reason is that in certain
+  // synthetic stream cases, such as passthrough streams, _read
+  // may be a completely synchronous operation which may change
+  // the state of the read buffer, providing enough data when
+  // before there was *not* enough.
+  //
+  // So, the steps are:
+  // 1. Figure out what the state of things will be after we do
+  // a read from the buffer.
+  //
+  // 2. If that resulting state will trigger a _read, then call _read.
+  // Note that this may be asynchronous, or synchronous.  Yes, it is
+  // deeply ugly to write APIs this way, but that still doesn't mean
+  // that the Readable class should behave improperly, as streams are
+  // designed to be sync/async agnostic.
+  // Take note if the _read call is sync or async (ie, if the read call
+  // has returned yet), so that we know whether or not it's safe to emit
+  // 'readable' etc.
+  //
+  // 3. Actually pull the requested chunks out of the buffer and return.
+
+  // if we need a readable event, then we need to do some reading.
+  let doRead = state.needReadable;
+
+  // If we currently have less than the highWaterMark, then also read some.
+  if (state.length === 0 || state.length - n < state.highWaterMark) {
+    doRead = true;
+  }
+
+  // However, if we've ended, then there's no point, if we're already
+  // reading, then it's unnecessary, if we're constructing we have to wait,
+  // and if we're destroyed or errored, then it's not allowed,
+  if (state.ended || state.reading || state.destroyed || state.errored || !state.constructed) {
+    doRead = false;
+  } else if (doRead) {
+    state.reading = true;
+    state.sync = true;
+    // If the length is currently zero, then we *need* a readable event.
+    if (state.length === 0) state.needReadable = true;
+
+    // Call internal read method
+    try {
+      this._read(state.highWaterMark);
+    } catch (err) {
+      errorOrDestroy(this, err);
+    }
+    state.sync = false;
+    // If _read pushed data synchronously, then `reading` will be false,
+    // and we need to re-evaluate how much data we can return to the user.
+    if (!state.reading) n = howMuchToRead(nOrig, state);
+  }
+  let ret;
+  if (n > 0) ret = fromList(n, state);
+  else ret = null;
+  if (ret === null) {
+    state.needReadable = state.length <= state.highWaterMark;
+    n = 0;
+  } else {
+    state.length -= n;
+    if (state.multiAwaitDrain) {
+      state.awaitDrainWriters.clear();
+    } else {
+      state.awaitDrainWriters = null;
+    }
+  }
+  if (state.length === 0) {
+    // If we have nothing in the buffer, then we want to know
+    // as soon as we *do* get something into the buffer.
+    if (!state.ended) state.needReadable = true
+
+    // If we tried to read() past the EOF, then emit end on the next tick.
+    if (nOrig !== n && state.ended) endReadable(this)
+  }
+  if (ret !== null && !state.errorEmitted && !state.closeEmitted) {
+    state.dataEmitted = true
+    this.emit('data', ret)
+  }
+  return ret
+}
+
+function onEofChunk(stream, state) {
+  if (state.ended) return;
+  if (state.decoder) {
+    const chunk = state.decoder.end();
+    if (chunk && chunk.length) {
+      state.buffer.push(chunk);
+      state.length += state.objectMode ? 1 : chunk.length;
+    }
+  }
+  state.ended = true;
+  if (state.sync) {
+    // If we are sync, wait until next tick to emit the data.
+    // Otherwise we risk emitting data in the flow()
+    // the readable code triggers during a read() call.
+    emitReadable(stream);
+  } else {
+    // Emit 'readable' now to make sure it gets picked up.
+    state.needReadable = false;
+    state.emittedReadable = true;
+    // We have to emit readable now that we are EOF. Modules
+    // in the ecosystem (e.g. dicer) rely on this event being sync.
+    emitReadable_(stream);
+  }
+}
+
+// Don't emit readable right away in sync mode, because this can trigger
+// another read() call => stack overflow.  This way, it might trigger
+// a nextTick recursion warning, but that's not so bad.
+function emitReadable(stream) {
+  const state = stream._readableState;
+  state.needReadable = false;
+  if (!state.emittedReadable) {
+    state.emittedReadable = true;
+    process.nextTick(emitReadable_, stream);
+  }
+}
+
+function emitReadable_(stream) {
+  const state = stream._readableState;
+  if (!state.destroyed && !state.errored && (state.length || state.ended)) {
+    stream.emit('readable');
+    state.emittedReadable = false;
+  }
+
+  // The stream needs another readable event if:
+  // 1. It is not flowing, as the flow mechanism will take
+  //    care of it.
+  // 2. It is not ended.
+  // 3. It is below the highWaterMark, so we can schedule
+  //    another readable later.
+  state.needReadable = !state.flowing && !state.ended && state.length <= state.highWaterMark;
+  flow(stream);
+}
+
+// At this point, the user has presumably seen the 'readable' event,
+// and called read() to consume some data.  that may have triggered
+// in turn another _read(n) call, in which case reading = true if
+// it's in progress.
+// However, if we're not ended, or reading, and the length < hwm,
+// then go ahead and try to read some more preemptively.
+function maybeReadMore(stream, state) {
+  if (!state.readingMore && state.constructed) {
+    state.readingMore = true;
+    process.nextTick(maybeReadMore_, stream, state);
+  }
+}
+
+function maybeReadMore_(stream, state) {
+  // Attempt to read more data if we should.
+  //
+  // The conditions for reading more data are (one of):
+  // - Not enough data buffered (state.length < state.highWaterMark). The loop
+  //   is responsible for filling the buffer with enough data if such data
+  //   is available. If highWaterMark is 0 and we are not in the flowing mode
+  //   we should _not_ attempt to buffer any extra data. We'll get more data
+  //   when the stream consumer calls read() instead.
+  // - No data in the buffer, and the stream is in flowing mode. In this mode
+  //   the loop below is responsible for ensuring read() is called. Failing to
+  //   call read here would abort the flow and there's no other mechanism for
+  //   continuing the flow if the stream consumer has just subscribed to the
+  //   'data' event.
+  //
+  // In addition to the above conditions to keep reading data, the following
+  // conditions prevent the data from being read:
+  // - The stream has ended (state.ended).
+  // - There is already a pending 'read' operation (state.reading). This is a
+  //   case where the stream has called the implementation defined _read()
+  //   method, but they are processing the call asynchronously and have _not_
+  //   called push() with new data. In this case we skip performing more
+  //   read()s. The execution ends in this method again after the _read() ends
+  //   up calling push() with more data.
+  while (
+    !state.reading &&
+    !state.ended &&
+    (state.length < state.highWaterMark || (state.flowing && state.length === 0))
+  ) {
+    const len = state.length;
+    stream.read(0);
+    if (len === state.length)
+      // Didn't get any data, stop spinning.
+      break;
+  }
+  state.readingMore = false;
+}
+
+// Abstract method.  to be overridden in specific implementation classes.
+// call cb(er, data) where data is <= n in length.
+// for virtual (non-string, non-buffer) streams, "length" is somewhat
+// arbitrary, and perhaps not very meaningful.
+Readable.prototype._read = function (_size) {
+  throw new ERR_METHOD_NOT_IMPLEMENTED('_read()');
+}
+
+Readable.prototype.pipe = function (dest, pipeOpts) {
+  const src = this;
+  const state = this._readableState;
+  if (state.pipes.length === 1) {
+    if (!state.multiAwaitDrain) {
+      state.multiAwaitDrain = true;
+      state.awaitDrainWriters = new Set<Writable>(
+          state.awaitDrainWriters ? [state.awaitDrainWriters] : []);
+    }
+  }
+  state.pipes.push(dest);
+  const doEnd = (!pipeOpts || pipeOpts.end !== false);
+  const endFn = doEnd ? onend : unpipe;
+  if (state.endEmitted) process.nextTick(endFn);
+  else src.once('end', endFn);
+  dest.on('unpipe', onunpipe);
+  function onunpipe(readable, unpipeInfo) {
+    if (readable === src) {
+      if (unpipeInfo && unpipeInfo.hasUnpiped === false) {
+        unpipeInfo.hasUnpiped = true;
+        cleanup();
+      }
+    }
+  }
+  function onend() {
+    dest.end();
+  }
+  let ondrain;
+  let cleanedUp = false;
+  function cleanup() {
+    // Cleanup event handlers once the pipe is broken.
+    dest.removeListener('close', onclose);
+    dest.removeListener('finish', onfinish);
+    if (ondrain) {
+      dest.removeListener('drain', ondrain);
+    }
+    dest.removeListener('error', onerror);
+    dest.removeListener('unpipe', onunpipe);
+    src.removeListener('end', onend);
+    src.removeListener('end', unpipe);
+    src.removeListener('data', ondata);
+    cleanedUp = true;
+
+    // If the reader is waiting for a drain event from this
+    // specific writer, then it would cause it to never start
+    // flowing again.
+    // So, if this is awaiting a drain, then we just call it now.
+    // If we don't know, then assume that we are waiting for one.
+    if (ondrain && state.awaitDrainWriters && (!dest._writableState || dest._writableState.needDrain)) ondrain();
+  }
+  function pause() {
+    // If the user unpiped during `dest.write()`, it is possible
+    // to get stuck in a permanently paused state if that write
+    // also returned false.
+    // => Check whether `dest` is still a piping destination.
+    if (!cleanedUp) {
+      if (state.pipes.length === 1 && state.pipes[0] === dest) {
+        state.awaitDrainWriters = dest;
+        state.multiAwaitDrain = false;
+      } else if (state.pipes.length > 1 && state.pipes.includes(dest)) {
+        state.awaitDrainWriters.add(dest);
+      }
+      src.pause();
+    }
+    if (!ondrain) {
+      // When the dest drains, it reduces the awaitDrain counter
+      // on the source.  This would be more elegant with a .once()
+      // handler in flow(), but adding and removing repeatedly is
+      // too slow.
+      ondrain = pipeOnDrain(src, dest);
+      dest.on('drain', ondrain);
+    }
+  }
+  src.on('data', ondata);
+  function ondata(chunk) {
+    const ret = dest.write(chunk);
+    if (ret === false) {
+      pause();
+    }
+  }
+
+  // If the dest has an error, then stop piping into it.
+  // However, don't suppress the throwing behavior for this.
+  function onerror(er) {
+    unpipe();
+    dest.removeListener('error', onerror);
+    if (dest.listenerCount('error') === 0) {
+      const s = dest._writableState || dest._readableState;
+      if (s && !s.errorEmitted) {
+        // User incorrectly emitted 'error' directly on the stream.
+        errorOrDestroy(dest, er);
+      } else {
+        dest.emit('error', er);
+      }
+    }
+  }
+
+  // Make sure our error handler is attached before userland ones.
+  dest.prependListener('error', onerror);
+
+  // Both close and finish should trigger unpipe, but only once.
+  function onclose() {
+    dest.removeListener('finish', onfinish);
+    unpipe();
+  }
+  dest.once('close', onclose);
+  function onfinish() {
+    dest.removeListener('close', onclose);
+    unpipe();
+  }
+  dest.once('finish', onfinish);
+  function unpipe() {
+    src.unpipe(dest);
+  }
+
+  // Tell the dest that it's being piped to.
+  dest.emit('pipe', src);
+
+  // Start the flow if it hasn't been started already.
+
+  if (dest.writableNeedDrain === true) {
+    if (state.flowing) {
+      pause();
+    }
+  } else if (!state.flowing) {
+    src.resume();
+  }
+  return dest;
+}
+
+function pipeOnDrain(src, dest) {
+  return function pipeOnDrainFunctionResult() {
+    const state = src._readableState;
+
+    // `ondrain` will call directly,
+    // `this` maybe not a reference to dest,
+    // so we use the real dest here.
+    if (state.awaitDrainWriters === dest) {
+      state.awaitDrainWriters = null;
+    } else if (state.multiAwaitDrain) {
+      state.awaitDrainWriters.delete(dest);
+    }
+    if ((!state.awaitDrainWriters || state.awaitDrainWriters.size === 0) &&
+        src.listenerCount('data')) {
+      src.resume();
+    }
+  }
+}
+
+Readable.prototype.unpipe = function (dest) {
+  const state = this._readableState;
+  const unpipeInfo = {
+    hasUnpiped: false
+  };
+
+  // If we're not piping anywhere, then do nothing.
+  if (state.pipes.length === 0) return this;
+  if (!dest) {
+    // remove all.
+    const dests = state.pipes;
+    state.pipes = [];
+    this.pause();
+    for (let i = 0; i < dests.length; i++)
+      dests[i].emit('unpipe', this, {
+        hasUnpiped: false
+      })
+    return this;
+  }
+
+  // Try to find the right one.
+  const index = state.pipes.indexOf(dest);
+  if (index === -1) return this;
+  state.pipes.splice(index, 1);
+  if (state.pipes.length === 0) this.pause();
+  dest.emit('unpipe', this, unpipeInfo);
+  return this;
+}
+
+// Set up data events if they are asked for
+// Ensure readable listeners eventually get something.
+Readable.prototype.on = function (ev, fn) {
+  const res = Stream.prototype.on.call(this, ev, fn);
+  const state = this._readableState;
+  if (ev === 'data') {
+    // Update readableListening so that resume() may be a no-op
+    // a few lines down. This is needed to support once('readable').
+    state.readableListening = this.listenerCount('readable') > 0;
+
+    // Try start flowing on next tick if stream isn't explicitly paused.
+    if (state.flowing !== false) this.resume();
+  } else if (ev === 'readable') {
+    if (!state.endEmitted && !state.readableListening) {
+      state.readableListening = state.needReadable = true;
+      state.flowing = false;
+      state.emittedReadable = false;
+      if (state.length) {
+        emitReadable(this);
+      } else if (!state.reading) {
+        process.nextTick(nReadingNextTick, this);
+      }
+    }
+  }
+  return res;
+}
+Readable.prototype.addListener = Readable.prototype.on
+Readable.prototype.removeListener = function (ev, fn) {
+  const res = Stream.prototype.removeListener.call(this, ev, fn);
+  if (ev === 'readable') {
+    // We need to check if there is someone still listening to
+    // readable and reset the state. However this needs to happen
+    // after readable has been emitted but before I/O (nextTick) to
+    // support once('readable', fn) cycles. This means that calling
+    // resume within the same tick will have no
+    // effect.
+    process.nextTick(updateReadableListening, this);
+  }
+  return res;
+}
+Readable.prototype.off = Readable.prototype.removeListener
+Readable.prototype.removeAllListeners = function (ev) {
+  const res = Stream.prototype.removeAllListeners.apply(this, arguments);
+  if (ev === 'readable' || ev === undefined) {
+    // We need to check if there is someone still listening to
+    // readable and reset the state. However this needs to happen
+    // after readable has been emitted but before I/O (nextTick) to
+    // support once('readable', fn) cycles. This means that calling
+    // resume within the same tick will have no
+    // effect.
+    process.nextTick(updateReadableListening, this);
+  }
+  return res;
+}
+
+function updateReadableListening(self) {
+  const state = self._readableState;
+  state.readableListening = self.listenerCount('readable') > 0;
+  if (state.resumeScheduled && state[kPaused] === false) {
+    // Flowing needs to be set to true now, otherwise
+    // the upcoming resume will not flow.
+    state.flowing = true;
+
+    // Crude way to check if we should resume.
+  } else if (self.listenerCount('data') > 0) {
+    self.resume();
+  } else if (!state.readableListening) {
+    state.flowing = null;
+  }
+}
+
+function nReadingNextTick(self) {
+  self.read(0);
+}
+
+// pause() and resume() are remnants of the legacy readable stream API
+// If the user uses them, then switch into old mode.
+Readable.prototype.resume = function () {
+  const state = this._readableState;
+  if (!state.flowing) {
+    // We flow only if there is no one listening
+    // for readable, but we still have to call
+    // resume().
+    state.flowing = !state.readableListening;
+    resume(this, state);
+  }
+  state[kPaused] = false;
+  return this;
+}
+
+function resume(stream, state) {
+  if (!state.resumeScheduled) {
+    state.resumeScheduled = true;
+    process.nextTick(resume_, stream, state);
+  }
+}
+
+function resume_(stream, state) {
+  if (!state.reading) {
+    stream.read(0);
+  }
+  state.resumeScheduled = false;
+  stream.emit('resume');
+  flow(stream);
+  if (state.flowing && !state.reading) stream.read(0);
+}
+
+Readable.prototype.pause = function () {
+  if (this._readableState.flowing !== false) {
+    this._readableState.flowing = false;
+    this.emit('pause');
+  }
+  this._readableState[kPaused] = true;
+  return this;
+}
+
+function flow(stream) {
+  const state = stream._readableState;
+  while (state.flowing && stream.read() !== null);
+}
+
+// Wrap an old-style stream as the async data source.
+// This is *not* part of the readable stream interface.
+// It is an ugly unfortunate mess of history.
+Readable.prototype.wrap = function (stream) {
+  let paused = false;
+
+  // TODO (ronag): Should this.destroy(err) emit
+  // 'error' on the wrapped stream? Would require
+  // a static factory method, e.g. Readable.wrap(stream).
+  stream.on('data', (chunk) => {
+    if (!this.push(chunk) && stream.pause) {
+      paused = true;
+      stream.pause();
+    }
+  });
+
+  stream.on('end', () => {
+    this.push(null);
+  });
+  stream.on('error', (err) => {
+    errorOrDestroy(this, err);
+  });
+  stream.on('close', () => {
+    this.destroy();
+  });
+  stream.on('destroy', () => {
+    this.destroy();
+  });
+  this._read = () => {
+    if (paused && stream.resume) {
+      paused = false;
+      stream.resume();
+    }
+  };
+
+  // Proxy all the other methods. Important when wrapping filters and duplexes.
+  const streamKeys = Object.keys(stream);
+  for (let j = 1; j < streamKeys.length; j++) {
+    const i = streamKeys[j];
+    if (this[i] === undefined && typeof stream[i] === 'function') {
+      this[i] = stream[i].bind(stream);
+    }
+  }
+  return this;
+}
+
+Readable.prototype[Symbol.asyncIterator] = function () {
+  return streamToAsyncIterator(this);
+}
+
+Readable.prototype.iterator = function (options) {
+  if (options !== undefined) {
+    validateObject(options, 'options', options);
+  }
+  return streamToAsyncIterator(this, options);
+}
+
+function streamToAsyncIterator(stream, options) {
+  if (typeof stream.read !== 'function') {
+    stream = Readable.wrap(stream, {
+      objectMode: true
+    });
+  }
+  const iter = createAsyncIterator(stream, options);
+  iter.stream = stream;
+  return iter;
+}
+
+async function* createAsyncIterator(stream, options) {
+  let callback = nop;
+  function next(resolve) {
+    if (this === stream) {
+      callback();
+      callback = nop;
+    } else {
+      callback = resolve;
+    }
+  }
+  stream.on('readable', next);
+  let error;
+  const cleanup = eos(
+    stream,
+    {
+      writable: false
+    },
+    (err) => {
+      error = err ? aggregateTwoErrors(error, err) : null
+      callback()
+      callback = nop
+    }
+  );
+  try {
+    while (true) {
+      const chunk = stream.destroyed ? null : stream.read();
+      if (chunk !== null) {
+        yield chunk;
+      } else if (error) {
+        throw error;
+      } else if (error === null) {
+        return;
+      } else {
+        await new Promise(next);
+      }
+    }
+  } catch (err) {
+    error = aggregateTwoErrors(error, err);
+    throw error;
+  } finally {
+    if (
+      (error || (options === null || options === undefined ? undefined : options.destroyOnReturn) !== false) &&
+      (error === undefined || stream._readableState.autoDestroy)
+    ) {
+      destroyer(stream, null);
+    } else {
+      stream.off('readable', next);
+      cleanup();
+    }
+  }
+}
+
+// Making it explicit these properties are not enumerable
+// because otherwise some prototype manipulation in
+// userland will fail.
+Object.defineProperties(Readable.prototype, {
+  readable: {
+    get() {
+      const r = this._readableState;
+      // r.readable === false means that this is part of a Duplex stream
+      // where the readable side was disabled upon construction.
+      // Compat. The user might manually disable readable side through
+      // deprecated setter.
+      return !!r && r.readable !== false && !r.destroyed && !r.errorEmitted && !r.endEmitted;
+    },
+    set(val) {
+      // Backwards compat.
+      if (this._readableState) {
+        this._readableState.readable = !!val;
+      }
+    }
+  },
+  readableDidRead: {
+    enumerable: false,
+    get: function () {
+      return !!(this._readableState?.dataEmitted);
+    }
+  },
+  readableAborted: {
+    enumerable: false,
+    get: function () {
+      return !!(
+        this._readableState?.readable !== false &&
+        (this._readableState?.destroyed || this._readableState?.errored) &&
+        !this._readableState?.endEmitted
+      );
+    }
+  },
+  readableHighWaterMark: {
+    enumerable: false,
+    get: function () {
+      return this._readableState?.highWaterMark;
+    }
+  },
+  readableBuffer: {
+    enumerable: false,
+    get: function () {
+      return this._readableState?.buffer;
+    }
+  },
+  readableFlowing: {
+    enumerable: false,
+    get: function () {
+      return !!(this._readableState?.flowing);
+    },
+    set: function (state) {
+      if (this._readableState) {
+        this._readableState.flowing = state
+      }
+    }
+  },
+  readableLength: {
+    enumerable: false,
+    get() {
+      return this._readableState?.length | 0;
+    }
+  },
+  readableObjectMode: {
+    enumerable: false,
+    get() {
+      return this._readableState ? this._readableState.objectMode : false;
+    }
+  },
+  readableEncoding: {
+    enumerable: false,
+    get() {
+      return this._readableState?.encoding || null;
+    }
+  },
+  errored: {
+    enumerable: false,
+    get() {
+      return this._readableState?.errored || null;
+    }
+  },
+  closed: {
+    get() {
+      return !!(this._readableState?.closed);
+    }
+  },
+  destroyed: {
+    enumerable: false,
+    get() {
+      return !!(this._readableState?.destroyed);
+    },
+    set(value) {
+      // We ignore the value if the stream
+      // has not been initialized yet.
+      if (!this._readableState) {
+        return
+      }
+
+      // Backward compatibility, the user is explicitly
+      // managing destroyed.
+      this._readableState.destroyed = value
+    }
+  },
+  readableEnded: {
+    enumerable: false,
+    get() {
+      return !!(this._readableState?.endEmitted);
+    }
+  }
+});
+
+Object.defineProperties(ReadableState.prototype, {
+  // Legacy getter for `pipesCount`.
+  pipesCount: {
+    get() {
+      return this.pipes.length
+    }
+  },
+  // Legacy property for `paused`.
+  paused: {
+    get() {
+      return this[kPaused] !== false
+    },
+    set(value) {
+      this[kPaused] = !!value
+    }
+  }
+});
+
+// Exposed for testing purposes only.
+Readable._fromList = fromList
+
+// Pluck off n bytes from an array of buffers.
+// Length is the combined lengths of all the buffers in the list.
+// This function is designed to be inlinable, so please take care when making
+// changes to the function body.
+function fromList(n, state) {
+  // nothing buffered.
+  if (state.length === 0) return null
+  let ret
+  if (state.objectMode) ret = state.buffer.shift()
+  else if (!n || n >= state.length) {
+    // Read it all, truncate the list.
+    if (state.decoder) ret = state.buffer.join('')
+    else if (state.buffer.length === 1) ret = state.buffer.first();
+    else ret = state.buffer.concat(state.length);
+    state.buffer.clear()
+  } else {
+    // read part of list.
+    ret = state.buffer.consume(n, !!state.decoder);
+  }
+  return ret
+}
+
+function endReadable(stream) {
+  const state = stream._readableState
+  if (!state.endEmitted) {
+    state.ended = true;
+    process.nextTick(endReadableNT, state, stream);
+  }
+}
+
+function endReadableNT(state, stream) {
+  // Check that we didn't get one last unshift.
+  if (!state.errored && !state.closeEmitted && !state.endEmitted && state.length === 0) {
+    state.endEmitted = true
+    stream.emit('end')
+    if (stream.writable && stream.allowHalfOpen === false) {
+      process.nextTick(endWritableNT, stream);
+    } else if (state.autoDestroy) {
+      // In case of duplex streams we need a way to detect
+      // if the writable side is ready for autoDestroy as well.
+      const wState = stream._writableState
+      const autoDestroy =
+        !wState ||
+        (wState.autoDestroy &&
+          // We don't expect the writable to ever 'finish'
+          // if writable is explicitly set to false.
+          (wState.finished || wState.writable === false))
+      if (autoDestroy) {
+        stream.destroy()
+      }
+    }
+  }
+}
+
+function endWritableNT(stream) {
+  const writable = stream.writable && !stream.writableEnded && !stream.destroyed
+  if (writable) {
+    stream.end()
+  }
+}
+
+// let webStreamsAdapters
+
+// // Lazy to avoid circular references
+// function lazyWebStreams() {
+//   if (webStreamsAdapters === undefined) webStreamsAdapters = {}
+//   return webStreamsAdapters
+// }
+// Readable.fromWeb = function (readableStream, options) {
+//   return lazyWebStreams().newStreamReadableFromReadableStream(readableStream, options)
+// }
+// Readable.toWeb = function (streamReadable, options) {
+//   return lazyWebStreams().newReadableStreamFromStreamReadable(streamReadable, options)
+// }
+
+Readable.wrap = function (src, options) {
+  let _ref, _src$readableObjectMo;
+  return new Readable({
+    objectMode:
+      (_ref =
+        (_src$readableObjectMo = src.readableObjectMode) !== null && _src$readableObjectMo !== undefined
+          ? _src$readableObjectMo
+          : src.objectMode) !== null && _ref !== undefined
+        ? _ref
+        : true,
+    ...options,
+    destroy(err, callback) {
+      destroyer(src, err)
+      callback(err)
+    }
+  }).wrap(src);
+};
+
+// ======================================================================================
+//
+
+Readable.from = function (iterable, opts) {
+  return from(Readable, iterable, opts)
+};
+
+export function from(Readable, iterable, opts) {
+  let iterator;
+  if (typeof iterable === 'string' || iterable instanceof Buffer) {
+    return new Readable({
+      objectMode: true,
+      ...opts,
+      read() {
+        this.push(iterable)
+        this.push(null)
+      }
+    })
+  }
+  let isAsync;
+  if (iterable && iterable[Symbol.asyncIterator]) {
+    isAsync = true
+    iterator = iterable[Symbol.asyncIterator]()
+  } else if (iterable && iterable[Symbol.iterator]) {
+    isAsync = false
+    iterator = iterable[Symbol.iterator]()
+  } else {
+    throw new ERR_INVALID_ARG_TYPE('iterable', ['Iterable'], iterable)
+  }
+  const readable = new Readable({
+    objectMode: true,
+    highWaterMark: 1,
+    // TODO(ronag): What options should be allowed?
+    ...opts
+  })
+
+  // Flag to protect against _read
+  // being called before last iteration completion.
+  let reading = false
+  readable._read = function () {
+    if (!reading) {
+      reading = true
+      next()
+    }
+  }
+  readable._destroy = function (error, cb) {
+    close(error).then(
+      () => process.nextTick(cb, error),
+      (err) => process.nextTick(cb, err || error));
+  }
+  async function close(error) {
+    const hadError = error !== undefined && error !== null
+    const hasThrow = typeof iterator.throw === 'function'
+    if (hadError && hasThrow) {
+      const { value, done } = await iterator.throw(error)
+      await value
+      if (done) {
+        return
+      }
+    }
+    if (typeof iterator.return === 'function') {
+      const { value } = await iterator.return()
+      await value
+    }
+  }
+  async function next() {
+    for (;;) {
+      try {
+        const { value, done } = isAsync ? await iterator.next() : iterator.next()
+        if (done) {
+          readable.push(null)
+        } else {
+          const res = value && typeof value.then === 'function' ? await value : value
+          if (res === null) {
+            reading = false
+            throw new ERR_STREAM_NULL_VALUES()
+          } else if (readable.push(res)) {
+            continue
+          } else {
+            reading = false
+          }
+        }
+      } catch (err) {
+        readable.destroy(err)
+      }
+      break
+    }
+  }
+  return readable
+}
+
+// ======================================================================================
+// Operators
+
+const kWeakHandler = Symbol('kWeak')
+const kEmpty = Symbol('kEmpty')
+const kEof = Symbol('kEof')
+
+function map(fn, options) {
+  if (typeof fn !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE('fn', ['Function', 'AsyncFunction'], fn)
+  }
+  if (options != null) {
+    validateObject(options, 'options', options);
+  }
+  if (options?.signal != null) {
+    validateAbortSignal(options.signal, 'options.signal');
+  }
+  let concurrency = 1;
+  if (options?.concurrency != null) {
+    concurrency = Math.floor(options.concurrency);
+  }
+  validateInteger(concurrency, 'concurrency', 1);
+  return async function* map() {
+    let _options$signal, _options$signal2;
+    const ac = new AbortController();
+    const stream = this;
+    const queue = [];
+    const signal = ac.signal;
+    const signalOpt = {
+      signal
+    };
+    const abort = () => ac.abort();
+    if (
+      options !== null &&
+      options !== undefined &&
+      (_options$signal = options.signal) !== null &&
+      _options$signal !== undefined &&
+      _options$signal.aborted
+    ) {
+      abort();
+    }
+    options === null || options === undefined
+      ? undefined
+      : (_options$signal2 = options.signal) === null || _options$signal2 === undefined
+      ? undefined
+      : _options$signal2.addEventListener('abort', abort);
+    let next;
+    let resume;
+    let done = false;
+    function onDone() {
+      done = true;
+    }
+    async function pump() {
+      try {
+        for await (let val of stream) {
+          let _val;
+          if (done) {
+            return;
+          }
+          if (signal.aborted) {
+            throw new AbortError();
+          }
+          try {
+            val = fn(val, signalOpt);
+          } catch (err) {
+            val = Promise.reject(err);
+          }
+          if (val === kEmpty) {
+            continue;
+          }
+          if (typeof ((_val = val) === null || _val === undefined ? undefined : _val.catch) === 'function') {
+            val.catch(onDone);
+          }
+          queue.push(val);
+          if (next) {
+            next();
+            next = null;
+          }
+          if (!done && queue.length && queue.length >= concurrency) {
+            await new Promise<any>((resolve) => {
+              resume = resolve;
+            });
+          }
+        }
+        queue.push(kEof);
+      } catch (err) {
+        const val = Promise.reject(err);
+        val.then(undefined, onDone);;
+        queue.push(val);
+      } finally {
+        let _options$signal3;
+        done = true;
+        if (next) {
+          next();
+          next = null;
+        }
+        options === null || options === undefined
+          ? undefined
+          : (_options$signal3 = options.signal) === null || _options$signal3 === undefined
+          ? undefined
+          : _options$signal3.removeEventListener('abort', abort);
+      }
+    }
+    pump();
+    try {
+      while (true) {
+        while (queue.length > 0) {
+          const val = await queue[0];
+          if (val === kEof) {
+            return;
+          }
+          if (signal.aborted) {
+            throw new AbortError();
+          }
+          if (val !== kEmpty) {
+            yield val;
+          }
+          queue.shift()
+          if (resume) {
+            resume();
+            resume = null;
+          }
+        }
+        await new Promise((resolve) => {
+          next = resolve
+        });
+      }
+    } finally {
+      ac.abort();
+      done = true;
+      if (resume) {
+        resume();
+        resume = null;
+      }
+    }
+  }.call(this);
+}
+
+function asIndexedPairs(options) {
+  if (options != null) {
+    validateObject(options, 'options', options);
+  }
+  if ((options === null || options === undefined ? undefined : options.signal) != null) {
+    validateAbortSignal(options.signal, 'options.signal');
+  }
+  return async function* asIndexedPairs() {
+    let index = 0;
+    for await (const val of this) {
+      let _options$signal4;
+      if (
+        options !== null &&
+        options !== undefined &&
+        (_options$signal4 = options.signal) !== null &&
+        _options$signal4 !== undefined &&
+        _options$signal4.aborted
+      ) {
+        throw new AbortError('Aborted', {
+          cause: options.signal?.reason
+        });
+      }
+      yield [index++, val];
+    }
+  }.call(this);
+}
+
+async function some(fn, options) {
+  if (typeof fn !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE('fn', ['Function', 'AsyncFunction'], fn);
+  }
+  for await (const _ of filter.call(this, fn, options)) {
+    return true;
+  }
+  return false;
+}
+
+async function every(fn, options) {
+  if (typeof fn !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE('fn', ['Function', 'AsyncFunction'], fn);
+  }
+  // https://en.wikipedia.org/wiki/De_Morgan%27s_laws
+  return !(await some.call(
+    this,
+    async (...args) => {
+      return !(await fn(...args))
+    },
+    options
+  ));
+}
+
+async function find(fn, options) {
+  for await (const result of filter.call(this, fn, options)) {
+    return result;
+  }
+  return undefined;
+}
+
+async function forEach(fn, options) {
+  if (typeof fn !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE('fn', ['Function', 'AsyncFunction'], fn)
+  }
+  async function forEachFn(value, options) {
+    await fn(value, options);
+    return kEmpty
+  }
+  // eslint-disable-next-line no-unused-vars
+  for await (const _ of map.call(this, forEachFn, options));
+}
+
+function filter(fn, options) {
+  if (typeof fn !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE('fn', ['Function', 'AsyncFunction'], fn)
+  }
+  async function filterFn(value, options) {
+    if (await fn(value, options)) {
+      return value
+    }
+    return kEmpty
+  }
+  return map.call(this, filterFn, options)
+}
+
+// Specific to provide better error to reduce since the argument is only
+// missing if the stream has no items in it - but the code is still appropriate
+class ReduceAwareErrMissingArgs extends ERR_MISSING_ARGS {
+  constructor() {
+    super('reduce')
+    this.message = 'Reduce of an empty stream requires an initial value'
+  }
+}
+
+async function reduce(reducer, initialValue, options) {
+  let _options$signal5;
+  if (typeof reducer !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE('reducer', ['Function', 'AsyncFunction'], reducer);
+  }
+  if (options != null) {
+    validateObject(options, 'options', options);
+  }
+  if (options?.signal != null) {
+    validateAbortSignal(options?.signal, 'options.signal');
+  }
+  let hasInitialValue = arguments.length > 1;
+  if (
+    options !== null &&
+    options !== undefined &&
+    (_options$signal5 = options.signal) !== null &&
+    _options$signal5 !== undefined &&
+    _options$signal5.aborted
+  ) {
+    const err = new AbortError(undefined, {
+      cause: options.signal?.reason
+    })
+    this.once('error', () => {}); // The error is already propagated
+    await finished(this.destroy(err));
+    throw err;
+  }
+  const ac = new AbortController();
+  const signal = ac.signal;
+  if (options?.signal) {
+    const opts = {
+      once: true,
+      [kWeakHandler]: this
+    };
+    options.signal.addEventListener('abort', () => ac.abort(), opts);
+  }
+  let gotAnyItemFromStream = false;
+  try {
+    for await (const value of this) {
+      let _options$signal6;
+      gotAnyItemFromStream = true;
+      if (
+        options !== null &&
+        options !== undefined &&
+        (_options$signal6 = options.signal) !== null &&
+        _options$signal6 !== undefined &&
+        _options$signal6.aborted
+      ) {
+        throw new AbortError();
+      }
+      if (!hasInitialValue) {
+        initialValue = value;
+        hasInitialValue = true;
+      } else {
+        initialValue = await reducer(initialValue, value, {
+          signal
+        });
+      }
+    }
+    if (!gotAnyItemFromStream && !hasInitialValue) {
+      throw new ReduceAwareErrMissingArgs();
+    }
+  } finally {
+    ac.abort();
+  }
+  return initialValue;
+}
+
+async function toArray(options) {
+  if (options != null) {
+    validateObject(options, 'options', options);
+  }
+  if (options?.signal != null) {
+    validateAbortSignal(options?.signal, 'options.signal')
+  }
+  const result = [];
+  for await (const val of this) {
+    let _options$signal7;
+    if (
+      options !== null &&
+      options !== undefined &&
+      (_options$signal7 = options.signal) !== null &&
+      _options$signal7 !== undefined &&
+      _options$signal7.aborted
+    ) {
+      throw new AbortError(undefined, {
+        cause: options.signal?.reason
+      });
+    }
+    result.push(val);
+  }
+  return result;
+}
+
+function flatMap(fn, options) {
+  const values = map.call(this, fn, options)
+  return async function* flatMap() {
+    for await (const val of values) {
+      yield* val
+    }
+  }.call(this)
+}
+
+function toIntegerOrInfinity(number) {
+  // We coerce here to align with the spec
+  // https://github.com/tc39/proposal-iterator-helpers/issues/169
+  number = Number(number)
+  if (Number.isNaN(number)) {
+    return 0
+  }
+  if (number < 0) {
+    throw new ERR_OUT_OF_RANGE('number', '>= 0', number)
+  }
+  return number
+}
+
+function drop(number, options) {
+  if (options != null) {
+    validateObject(options, 'options', options);
+  }
+  if (options?.signal != null) {
+    validateAbortSignal(options?.signal, 'options.signal');
+  }
+  number = toIntegerOrInfinity(number);
+  return async function* drop() {
+    let _options$signal8;
+    if (
+      options !== null &&
+      options !== undefined &&
+      (_options$signal8 = options.signal) !== null &&
+      _options$signal8 !== undefined &&
+      _options$signal8.aborted
+    ) {
+      throw new AbortError();
+    }
+    for await (const val of this) {
+      let _options$signal9;
+      if (
+        options !== null &&
+        options !== undefined &&
+        (_options$signal9 = options.signal) !== null &&
+        _options$signal9 !== undefined &&
+        _options$signal9.aborted
+      ) {
+        throw new AbortError();
+      }
+      if (number-- <= 0) {
+        yield val;
+      }
+    }
+  }.call(this);
+}
+
+function take(number, options) {
+  if (options != null) {
+    validateObject(options, 'options', options);
+  }
+  if (options?.signal != null) {
+    validateAbortSignal(options?.signal, 'options.signal');
+  }
+  number = toIntegerOrInfinity(number);
+  return async function* take() {
+    let _options$signal10;
+    if (
+      options !== null &&
+      options !== undefined &&
+      (_options$signal10 = options.signal) !== null &&
+      _options$signal10 !== undefined &&
+      _options$signal10.aborted
+    ) {
+      throw new AbortError();
+    }
+    for await (const val of this) {
+      let _options$signal11;
+      if (
+        options !== null &&
+        options !== undefined &&
+        (_options$signal11 = options.signal) !== null &&
+        _options$signal11 !== undefined &&
+        _options$signal11.aborted
+      ) {
+        throw new AbortError();
+      }
+      if (number-- > 0) {
+        yield val;
+      } else {
+        return;
+      }
+    }
+  }.call(this);
+}
+
+Readable.prototype.map = function(fn, options) {
+  return from(Readable, map.call(this, fn, options));
+}
+
+Readable.prototype.asIndexedPairs = function(options) {
+  return from(Readable, asIndexedPairs.call(this, options));
+}
+
+Readable.prototype.drop = function(number, options) {
+  return from(Readable, drop.call(this, number, options));
+}
+
+Readable.prototype.filter = function(fn, options) {
+  return from(Readable, filter.call(this, fn, options));
+}
+
+Readable.prototype.flatMap = function(fn, options) {
+  return from(Readable, flatMap.call(this, fn, options));
+};
+
+Readable.prototype.take = function(number, options) {
+  return from(Readable, take.call(this, number, options));
+}
+
+Readable.prototype.every = every;
+Readable.prototype.forEach = forEach;
+Readable.prototype.reduce = reduce;
+Readable.prototype.toArray = toArray;
+Readable.prototype.some = some;
+Readable.prototype.find = find;
+

--- a/src/node/internal/streams_transform.js
+++ b/src/node/internal/streams_transform.js
@@ -1,0 +1,218 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+
+// a transform stream is a readable/writable stream where you do
+// something with the data.  Sometimes it's called a "filter",
+// but that's not a great name for it, since that implies a thing where
+// some bits pass through, and others are simply ignored.  (That would
+// be a valid example of a transform, of course.)
+//
+// While the output is causally related to the input, it's not a
+// necessarily symmetric or synchronous transformation.  For example,
+// a zlib stream might take multiple plain-text writes(), and then
+// emit a single compressed chunk some time in the future.
+//
+// Here's how this works:
+//
+// The Transform stream has all the aspects of the readable and writable
+// stream classes.  When you write(chunk), that calls _write(chunk,cb)
+// internally, and returns false if there's a lot of pending writes
+// buffered up.  When you call read(), that calls _read(n) until
+// there's enough pending readable data buffered up.
+//
+// In a transform stream, the written data is placed in a buffer.  When
+// _read(n) is called, it transforms the queued up data, calling the
+// buffered _write cb's as it consumes chunks.  If consuming a single
+// written chunk would result in multiple output chunks, then the first
+// outputted bit calls the readcb, and subsequent chunks just go into
+// the read buffer, and will cause it to emit 'readable' if necessary.
+//
+// This way, back-pressure is actually determined by the reading side,
+// since _read has to be called to start processing a new chunk.  However,
+// a pathological inflate type of transform can cause excessive buffering
+// here.  For example, imagine a stream where every byte of input is
+// interpreted as an integer from 0-255, and then results in that many
+// bytes of output.  Writing the 4 bytes {ff,ff,ff,ff} would result in
+// 1kb of data being output.  In this case, you could write a very small
+// amount of input, and end up with a very large amount of output.  In
+// such a pathological inflating mechanism, there'd be no way to tell
+// the system to stop doing the transform.  A single 4MB write could
+// cause the system to run out of memory.
+//
+// However, even in such a pathological case, only a single written chunk
+// would be consumed, and then the rest would wait (un-transformed) until
+// the results of the previous transformed chunk were consumed.
+
+'use strict'
+
+import {
+  ERR_METHOD_NOT_IMPLEMENTED
+} from 'node-internal:internal_errors';
+
+import {
+  Duplex,
+} from 'node-internal:streams_duplex';
+
+import {
+  getHighWaterMark,
+} from 'node-internal:streams_util';
+
+Object.setPrototypeOf(Transform.prototype, Duplex.prototype);
+Object.setPrototypeOf(Transform, Duplex);
+
+const kCallback = Symbol('kCallback');
+
+export function Transform(options) {
+  if (!(this instanceof Transform)) return new Transform(options);
+
+  // TODO (ronag): This should preferably always be
+  // applied but would be semver-major. Or even better;
+  // make Transform a Readable with the Writable interface.
+  const readableHighWaterMark = options ? getHighWaterMark(options, 'readableHighWaterMark', true) : null;
+  if (readableHighWaterMark === 0) {
+    // A Duplex will buffer both on the writable and readable side while
+    // a Transform just wants to buffer hwm number of elements. To avoid
+    // buffering twice we disable buffering on the writable side.
+    options = {
+      ...options,
+      highWaterMark: null,
+      readableHighWaterMark,
+      // TODO (ronag): 0 is not optimal since we have
+      // a "bug" where we check needDrain before calling _write and not after.
+      // Refs: https://github.com/nodejs/node/pull/32887
+      // Refs: https://github.com/nodejs/node/pull/35941
+      writableHighWaterMark: options?.writableHighWaterMark || 0
+    };
+  }
+  Duplex.call(this, options);
+
+  // We have implemented the _read method, and done the other things
+  // that Readable wants before the first _read call, so unset the
+  // sync guard flag.
+  this._readableState.sync = false;
+  this[kCallback] = null;
+  if (options) {
+    if (typeof options.transform === 'function') this._transform = options.transform;
+    if (typeof options.flush === 'function') this._flush = options.flush;
+  }
+
+  // When the writable side finishes, then flush out anything remaining.
+  // Backwards compat. Some Transform streams incorrectly implement _final
+  // instead of or in addition to _flush. By using 'prefinish' instead of
+  // implementing _final we continue supporting this unfortunate use case.
+  this.on('prefinish', prefinish);
+}
+
+function final(cb) {
+  if (typeof this._flush === 'function' && !this.destroyed) {
+    this._flush((er, data) => {
+      if (er) {
+        if (cb) {
+          cb(er);
+        } else {
+          this.destroy(er);
+        }
+        return;
+      }
+      if (data != null) {
+        this.push(data);
+      }
+      this.push(null);
+      if (cb) {
+        cb();
+      }
+    })
+  } else {
+    this.push(null);
+    if (cb) {
+      cb();
+    }
+  }
+}
+
+function prefinish() {
+  if (this._final !== final) {
+    final.call(this);
+  }
+}
+Transform.prototype._final = final;
+
+Transform.prototype._transform = function () {
+  throw new ERR_METHOD_NOT_IMPLEMENTED('_transform()')
+}
+
+Transform.prototype._write = function (chunk, encoding, callback) {
+  const rState = this._readableState;
+  const wState = this._writableState;
+  const length = rState.length;
+  this._transform(chunk, encoding, (err, val) => {
+    if (err) {
+      callback(err);
+      return;
+    }
+    if (val != null) {
+      this.push(val);
+    }
+    if (
+      wState.ended ||
+      // Backwards compat.
+      length === rState.length ||
+      // Backwards compat.
+      rState.length < rState.highWaterMark
+    ) {
+      callback();
+    } else {
+      this[kCallback] = callback;
+    }
+  })
+}
+
+Transform.prototype._read = function (_size) {
+  if (this[kCallback]) {
+    const callback = this[kCallback];
+    this[kCallback] = null;
+    callback();
+  }
+}
+
+Object.setPrototypeOf(PassThrough.prototype, Transform.prototype);
+Object.setPrototypeOf(PassThrough, Transform);
+
+export function PassThrough(options) {
+  if (!(this instanceof PassThrough)) return new PassThrough(options);
+  Transform.call(this, {
+    ...options,
+    transform: undefined,
+    flush: undefined,
+  });
+}
+
+PassThrough.prototype._transform = function (chunk, _, cb) {
+  cb(null, chunk);
+}

--- a/src/node/internal/streams_util.js
+++ b/src/node/internal/streams_util.js
@@ -1,0 +1,1025 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+export const kDestroyed = Symbol('kDestroyed');
+export const kIsErrored = Symbol('kIsErrored');
+export const kIsReadable = Symbol('kIsReadable');
+export const kIsDisturbed = Symbol('kIsDisturbed');
+export const kPaused = Symbol('kPaused');
+export const kOnFinished = Symbol('kOnFinished');
+export const kDestroy = Symbol('kDestroy');
+export const kConstruct = Symbol('kConstruct');
+
+import {
+  AbortError,
+  ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_ARG_VALUE,
+  ERR_STREAM_PREMATURE_CLOSE,
+  ERR_MULTIPLE_CALLBACK,
+  aggregateTwoErrors,
+} from 'node-internal:internal_errors';
+
+import * as process from 'node-internal:process';
+
+import { Buffer } from 'node-internal:internal_buffer';
+
+import {
+  validateAbortSignal,
+  validateFunction,
+  validateObject,
+} from 'node-internal:validators';
+
+export function isReadableNodeStream(obj, strict = false) {
+  let _obj$_readableState;
+  return !!(
+    (
+      obj &&
+      typeof obj.pipe === 'function' &&
+      typeof obj.on === 'function' &&
+      (!strict || (typeof obj.pause === 'function' &&
+                   typeof obj.resume === 'function')) &&
+      (!obj._writableState ||
+        ((_obj$_readableState = obj._readableState) === null ||
+          _obj$_readableState === undefined ? undefined
+            : _obj$_readableState.readable) !== false) &&
+      // Duplex
+      (!obj._writableState || obj._readableState)
+    ) // Writable has .pipe.
+  );
+}
+
+export function isWritableNodeStream(obj) {
+  let _obj$_writableState;
+  return !!(
+    (
+      obj &&
+      typeof obj.write === 'function' &&
+      typeof obj.on === 'function' &&
+      (!obj._readableState ||
+        ((_obj$_writableState = obj._writableState) === null ||
+          _obj$_writableState === undefined ? undefined
+            : _obj$_writableState.writable) !== false)
+    ) // Duplex
+  );
+}
+
+export function isDuplexNodeStream(obj) {
+  return !!(
+    obj &&
+    typeof obj.pipe === 'function' &&
+    obj._readableState &&
+    typeof obj.on === 'function' &&
+    typeof obj.write === 'function'
+  );
+}
+
+export function isNodeStream(obj) {
+  return (
+    obj &&
+    (obj._readableState ||
+      obj._writableState ||
+      (typeof obj.write === 'function' &&
+       typeof obj.on === 'function') ||
+      (typeof obj.pipe === 'function' &&
+       typeof obj.on === 'function'))
+  );
+}
+
+export function isIterable(obj, isAsync = false) {
+  if (obj == null) return false;
+  if (isAsync === true) return typeof obj[Symbol.asyncIterator] === 'function';
+  if (isAsync === false) return typeof obj[Symbol.iterator] === 'function';
+  return typeof obj[Symbol.asyncIterator] === 'function' ||
+         typeof obj[Symbol.iterator] === 'function';
+}
+
+export function isDestroyed(stream) {
+  if (!isNodeStream(stream)) return null;
+  const wState = stream._writableState;
+  const rState = stream._readableState;
+  const state = wState || rState;
+  return !!(stream.destroyed || stream[kDestroyed] || (state !== null && state !== undefined && state.destroyed));
+}
+
+export function isWritableEnded(stream) {
+  if (!isWritableNodeStream(stream)) return null;
+  if (stream.writableEnded === true) return true;
+  const wState = stream._writableState;
+  if (wState !== null && wState !== undefined && wState.errored) return false;
+  if (typeof (wState === null || wState === undefined ? undefined : wState.ended) !== 'boolean') return null;
+  return wState.ended;
+}
+
+export function isWritableFinished(stream, strict = false) {
+  if (!isWritableNodeStream(stream)) return null;
+  if (stream.writableFinished === true) return true;
+  const wState = stream._writableState;
+  if (wState !== null && wState !== undefined && wState.errored) return false;
+  if (typeof (wState === null || wState === undefined ? undefined : wState.finished) !== 'boolean') return null;
+  return !!(wState.finished || (strict === false && wState.ended === true && wState.length === 0));
+}
+
+export function isReadableEnded(stream) {
+  if (!isReadableNodeStream(stream)) return null;
+  if (stream.readableEnded === true) return true;
+  const rState = stream._readableState;
+  if (!rState || rState.errored) return false;
+  if (typeof (rState === null || rState === undefined ? undefined : rState.ended) !== 'boolean') return null;
+  return rState.ended;
+}
+
+export function isReadableFinished(stream, strict = false) {
+  if (!isReadableNodeStream(stream)) return null;
+  const rState = stream._readableState;
+  if (rState !== null && rState !== undefined && rState.errored) return false;
+  if (typeof (rState === null || rState === undefined ? undefined : rState.endEmitted) !== 'boolean') return null;
+  return !!(rState.endEmitted || (strict === false && rState.ended === true && rState.length === 0));
+}
+
+export function isReadable(stream) {
+  if (stream && stream[kIsReadable] != null) return stream[kIsReadable];
+  if (typeof (stream === null || stream === undefined ? undefined : stream.readable) !== 'boolean') return null;
+  if (isDestroyed(stream)) return false;
+  return isReadableNodeStream(stream) && stream.readable && !isReadableFinished(stream);
+}
+
+export function isWritable(stream) {
+  if (typeof (stream === null || stream === undefined ? undefined : stream.writable) !== 'boolean') return null;
+  if (isDestroyed(stream)) return false;
+  return isWritableNodeStream(stream) && stream.writable && !isWritableEnded(stream);
+}
+
+export function isFinished(stream, opts = {}) {
+  if (!isNodeStream(stream)) {
+    return null;
+  }
+  if (isDestroyed(stream)) {
+    return true;
+  }
+  if ((opts === null || opts === undefined ? undefined : opts.readable) !== false &&
+       isReadable(stream)) {
+    return false;
+  }
+  if ((opts === null || opts === undefined ? undefined : opts.writable) !== false &&
+       isWritable(stream)) {
+    return false;
+  }
+  return true;
+}
+
+export function isWritableErrored(stream) {
+  let _stream$_writableStat, _stream$_writableStat2;
+  if (!isNodeStream(stream)) {
+    return null;
+  }
+  if (stream.writableErrored) {
+    return stream.writableErrored;
+  }
+  return (_stream$_writableStat =
+    (_stream$_writableStat2 = stream._writableState) === null || _stream$_writableStat2 === undefined
+      ? undefined
+      : _stream$_writableStat2.errored) !== null && _stream$_writableStat !== undefined
+    ? _stream$_writableStat
+    : null;
+}
+
+export function isReadableErrored(stream) {
+  let _stream$_readableStat, _stream$_readableStat2;
+  if (!isNodeStream(stream)) {
+    return null;
+  }
+  if (stream.readableErrored) {
+    return stream.readableErrored;
+  }
+  return (_stream$_readableStat =
+    (_stream$_readableStat2 = stream._readableState) === null || _stream$_readableStat2 === undefined
+      ? undefined
+      : _stream$_readableStat2.errored) !== null && _stream$_readableStat !== undefined
+    ? _stream$_readableStat
+    : null;
+}
+
+export function isClosed(stream) {
+  if (!isNodeStream(stream)) {
+    return null
+  }
+  if (typeof stream.closed === 'boolean') {
+    return stream.closed
+  }
+  const wState = stream._writableState
+  const rState = stream._readableState
+  if (
+    typeof (wState === null || wState === undefined ? undefined : wState.closed) === 'boolean' ||
+    typeof (rState === null || rState === undefined ? undefined : rState.closed) === 'boolean'
+  ) {
+    return (
+      (wState === null || wState === undefined ? undefined : wState.closed) ||
+      (rState === null || rState === undefined ? undefined : rState.closed)
+    )
+  }
+  if (typeof stream._closed === 'boolean' && isOutgoingMessage(stream)) {
+    return stream._closed
+  }
+  return null
+}
+
+// TODO(later): We do not actually support OutgoingMessage yet. Might not ever?
+// Keeping this here tho just to keep things simple.
+export function isOutgoingMessage(stream) {
+  return (
+    typeof stream._closed === 'boolean' &&
+    typeof stream._defaultKeepAlive === 'boolean' &&
+    typeof stream._removedConnection === 'boolean' &&
+    typeof stream._removedContLen === 'boolean'
+  );
+}
+
+// TODO(later): We do not actually support Server Response yet. Might not ever?
+// Keeping this here tho just to keep things simple.
+export function isServerResponse(stream) {
+  return typeof stream._sent100 === 'boolean' && isOutgoingMessage(stream);
+}
+
+// TODO(later): We do not actually support Server Request yet. Might not ever?
+// Keeping this here tho just to keep things simple.
+export function isServerRequest(stream) {
+  let _stream$req;
+  return (
+    typeof stream._consuming === 'boolean' &&
+    typeof stream._dumped === 'boolean' &&
+    ((_stream$req = stream.req) === null || _stream$req === undefined ? undefined : _stream$req.upgradeOrConnect) ===
+      undefined
+  );
+}
+
+export function willEmitClose(stream) {
+  if (!isNodeStream(stream)) return null;
+  const wState = stream._writableState;
+  const rState = stream._readableState;
+  const state = wState || rState;
+  return (
+    (!state && isServerResponse(stream)) || !!(state && state.autoDestroy && state.emitClose && state.closed === false)
+  );
+}
+
+export function isDisturbed(stream) {
+  let _stream$kIsDisturbed;
+  return !!(
+    stream &&
+    ((_stream$kIsDisturbed = stream[kIsDisturbed]) !== null && _stream$kIsDisturbed !== undefined
+      ? _stream$kIsDisturbed
+      : stream.readableDidRead || stream.readableAborted)
+  );
+}
+
+export function isErrored(stream) {
+  var _ref,
+    _ref2,
+    _ref3,
+    _ref4,
+    _ref5,
+    _stream$kIsErrored,
+    _stream$_readableStat3,
+    _stream$_writableStat3,
+    _stream$_readableStat4,
+    _stream$_writableStat4
+  return !!(
+    stream &&
+    ((_ref =
+      (_ref2 =
+        (_ref3 =
+          (_ref4 =
+            (_ref5 =
+              (_stream$kIsErrored = stream[kIsErrored]) !== null && _stream$kIsErrored !== undefined
+                ? _stream$kIsErrored
+                : stream.readableErrored) !== null && _ref5 !== undefined
+              ? _ref5
+              : stream.writableErrored) !== null && _ref4 !== undefined
+            ? _ref4
+            : (_stream$_readableStat3 = stream._readableState) === null || _stream$_readableStat3 === undefined
+            ? undefined
+            : _stream$_readableStat3.errorEmitted) !== null && _ref3 !== undefined
+          ? _ref3
+          : (_stream$_writableStat3 = stream._writableState) === null || _stream$_writableStat3 === undefined
+          ? undefined
+          : _stream$_writableStat3.errorEmitted) !== null && _ref2 !== undefined
+        ? _ref2
+        : (_stream$_readableStat4 = stream._readableState) === null || _stream$_readableStat4 === undefined
+        ? undefined
+        : _stream$_readableStat4.errored) !== null && _ref !== undefined
+      ? _ref
+      : (_stream$_writableStat4 = stream._writableState) === null || _stream$_writableStat4 === undefined
+      ? undefined
+      : _stream$_writableStat4.errored)
+  )
+}
+
+export const nop = () => {};
+
+export function once(callback) {
+  let called = false
+  return function (...args) {
+    if (called) {
+      return
+    }
+    called = true
+    callback.apply(this, args)
+  }
+}
+
+// ======================================================================================
+// highWaterMark handling
+
+export function highWaterMarkFrom(options, isDuplex, duplexKey) {
+  return options.highWaterMark != null ? options.highWaterMark :
+      isDuplex ? options[duplexKey] : null
+}
+
+export function getDefaultHighWaterMark(objectMode = false) {
+  return objectMode ? 16 : 16 * 1024
+}
+
+export function getHighWaterMark(state, options, duplexKey, isDuplex) {
+  const hwm = highWaterMarkFrom(options, isDuplex, duplexKey)
+  if (hwm != null) {
+    if (!Number.isInteger(hwm) || hwm < 0) {
+      const name = isDuplex ? `options.${duplexKey}` : 'options.highWaterMark';
+      throw new ERR_INVALID_ARG_VALUE(name, hwm, name);
+    }
+    return Math.floor(hwm);
+  }
+
+  // Default value
+  return getDefaultHighWaterMark(state.objectMode)
+}
+
+// ======================================================================================
+// addAbortSignal
+
+export function addAbortSignal(signal, stream) {
+  validateAbortSignal(signal, 'signal');
+  if (!isNodeStream(stream)) {
+    throw new ERR_INVALID_ARG_TYPE('stream', 'stream.Stream', stream);
+  }
+  const onAbort = () => {
+    stream.destroy(
+      new AbortError(undefined, {
+        cause: signal.reason
+      })
+    );
+  }
+  if (signal.aborted) {
+    onAbort();
+  } else {
+    signal.addEventListener('abort', onAbort);
+    eos(stream, () => signal.removeEventListener('abort', onAbort));
+  }
+  return stream;
+}
+
+// ======================================================================================
+// BufferList
+
+export class BufferList {
+  head = null;
+  tail = null;
+  length = 0;
+
+  push(v) {
+    const entry = {
+      data: v,
+      next: null,
+    }
+    if (this.length > 0) this.tail.next = entry;
+    else this.head = entry;
+    this.tail = entry;
+    ++this.length;
+  }
+  unshift(v) {
+    const entry = {
+      data: v,
+      next: this.head,
+    }
+    if (this.length === 0) this.tail = entry;
+    this.head = entry;
+    ++this.length;
+  }
+  shift() {
+    if (this.length === 0) return;
+    const ret = this.head.data;
+    if (this.length === 1) this.head = this.tail = null;
+    else this.head = this.head.next;
+    --this.length;
+    return ret;
+  }
+
+  clear() {
+    this.head = this.tail = null;
+    this.length = 0;
+  }
+
+  join(s) {
+    if (this.length === 0) return '';
+    let p = this.head;
+    let ret = '' + p.data;
+    while ((p = p.next) !== null) ret += s + p.data;
+    return ret;
+  }
+
+  concat(n) {
+    if (this.length === 0) return Buffer.alloc(0);
+    const ret = Buffer.allocUnsafe(n >>> 0);
+    let p = this.head;
+    let i = 0;
+    while (p) {
+      ret.set(p.data, i);
+      i += p.data.length;
+      p = p.next;
+    }
+    return ret;
+  }
+
+  consume(n, hasStrings = false) {
+    const data = this.head.data;
+    if (n < data.length) {
+      // `slice` is the same for buffers and strings.
+      const slice = data.slice(0, n);
+      this.head.data = data.slice(n);
+      return slice;
+    }
+    if (n === data.length) {
+      // First chunk is a perfect match.
+      return this.shift();
+    }
+    // Result spans more than one buffer.
+    return hasStrings ? this._getString(n) : this._getBuffer(n);
+  }
+
+  first() {
+    return this.head.data;
+  }
+
+  *[Symbol.iterator]() {
+    for (let p = this.head; p; p = p.next) {
+      yield p.data;
+    }
+  }
+
+  _getString(n) {
+    let ret = '';
+    let p = this.head;
+    let c = 0;
+    do {
+      const str = p.data;
+      if (n > str.length) {
+        ret += str;
+        n -= str.length;
+      } else {
+        if (n === str.length) {
+          ret += str
+          ++c
+          if (p.next) this.head = p.next;
+          else this.head = this.tail = null;
+        } else {
+          ret += str.slice(0, n);
+          this.head = p;
+          p.data = str.slice(n);
+        }
+        break;
+      }
+      ++c;
+    } while ((p = p.next) !== null);
+    this.length -= c;
+    return ret;
+  }
+
+  _getBuffer(n) {
+    const ret = Buffer.allocUnsafe(n);
+    const retLen = n;
+    let p = this.head;
+    let c = 0;
+    do {
+      const buf = p.data;
+      if (n > buf.length) {
+        ret.set(buf, retLen - n);
+        n -= buf.length;
+      } else {
+        if (n === buf.length) {
+          ret.set(buf, retLen - n);
+          ++c;
+          if (p.next) this.head = p.next;
+          else this.head = this.tail = null;
+        } else {
+          ret.set(new Uint8Array(buf.buffer, buf.byteOffset, n), retLen - n);
+          this.head = p;
+          p.data = buf.slice(n);
+        }
+        break;
+      }
+      ++c
+    } while ((p = p.next) !== null);
+    this.length -= c;
+    return ret;
+  }
+}
+
+// ======================================================================================
+
+// TODO(later): We do not current implement Node.js' Request object. Might never?
+function isRequest(stream) {
+  return stream && stream.setHeader && typeof stream.abort === 'function'
+}
+
+export function eos(stream, options, callback) {
+  let _options$readable, _options$writable;
+  if (arguments.length === 2) {
+    callback = options;
+    options = {};
+  } else if (options == null) {
+    options = {};
+  } else {
+    validateObject(options, 'options', options);
+  }
+  validateFunction(callback, 'callback');
+  validateAbortSignal(options.signal, 'options.signal');
+  callback = once(callback);
+  const readable =
+    (_options$readable = options.readable) !== null && _options$readable !== undefined
+      ? _options$readable
+      : isReadableNodeStream(stream);
+  const writable =
+    (_options$writable = options.writable) !== null && _options$writable !== undefined
+      ? _options$writable
+      : isWritableNodeStream(stream);
+  if (!isNodeStream(stream)) {
+    // TODO: Webstreams.
+    throw new ERR_INVALID_ARG_TYPE('stream', 'Stream', stream);
+  }
+  const wState = stream._writableState;
+  const rState = stream._readableState;
+  const onlegacyfinish = () => {
+    if (!stream.writable) {
+      onfinish();
+    }
+  };
+
+  // TODO (ronag): Improve soft detection to include core modules and
+  // common ecosystem modules that do properly emit 'close' but fail
+  // this generic check.
+  let _willEmitClose =
+    willEmitClose(stream) && isReadableNodeStream(stream) === readable && isWritableNodeStream(stream) === writable;
+  let writableFinished = isWritableFinished((stream), false);
+  const onfinish = () => {
+    writableFinished = true;
+    // Stream should not be destroyed here. If it is that
+    // means that user space is doing something differently and
+    // we cannot trust willEmitClose.
+    if (stream.destroyed) {
+      _willEmitClose = false;
+    }
+    if (_willEmitClose && (!stream.readable || readable)) {
+      return;
+    }
+    if (!readable || readableFinished) {
+      callback.call(stream);
+    }
+  };
+  let readableFinished = isReadableFinished(stream, false);
+  const onend = () => {
+    readableFinished = true;
+    // Stream should not be destroyed here. If it is that
+    // means that user space is doing something differently and
+    // we cannot trust willEmitClose.
+    if (stream.destroyed) {
+      _willEmitClose = false;
+    }
+    if (_willEmitClose && (!stream.writable || writable)) {
+      return;
+    }
+    if (!writable || writableFinished) {
+      callback.call(stream);
+    }
+  };
+  const onerror = (err) => {
+    callback.call(stream, err);
+  };
+  let closed = isClosed(stream);
+  const onclose = () => {
+    closed = true;
+    const errored = isWritableErrored(stream) || isReadableErrored(stream)
+    if (errored && typeof errored !== 'boolean') {
+      return callback.call(stream, errored);
+    }
+    if (readable && !readableFinished && isReadableNodeStream(stream, true)) {
+      if (!isReadableFinished(stream, false)) return callback.call(stream, new ERR_STREAM_PREMATURE_CLOSE());
+    }
+    if (writable && !writableFinished) {
+      if (!isWritableFinished(stream, false)) return callback.call(stream, new ERR_STREAM_PREMATURE_CLOSE());
+    }
+    callback.call(stream);
+  };
+  const onrequest = () => {
+    stream.req.on('finish', onfinish);
+  };
+  if (isRequest(stream)) {
+    stream.on('complete', onfinish);
+    if (!_willEmitClose) {
+      stream.on('abort', onclose);
+    }
+    if (stream.req) {
+      onrequest();
+    } else {
+      stream.on('request', onrequest);
+    }
+  } else if (writable && !wState) {
+    // legacy streams
+    stream.on('end', onlegacyfinish);
+    stream.on('close', onlegacyfinish);
+  }
+
+  // Not all streams will emit 'close' after 'aborted'.
+  if (!_willEmitClose && typeof stream.aborted === 'boolean') {
+    stream.on('aborted', onclose);
+  }
+  stream.on('end', onend);
+  stream.on('finish', onfinish);
+  if (options.error !== false) {
+    stream.on('error', onerror);
+  }
+  stream.on('close', onclose);
+  if (closed) {
+    process.nextTick(onclose);
+  } else if (
+    (wState !== null && wState !== undefined && wState.errorEmitted) ||
+    (rState !== null && rState !== undefined && rState.errorEmitted)
+  ) {
+    if (!_willEmitClose) {
+      process.nextTick(onclose);
+    }
+  } else if (
+    !readable &&
+    (!_willEmitClose || isReadable(stream)) &&
+    (writableFinished || isWritable(stream) === false)
+  ) {
+    process.nextTick(onclose);
+  } else if (
+    !writable &&
+    (!_willEmitClose || isWritable(stream)) &&
+    (readableFinished || isReadable(stream) === false)
+  ) {
+    process.nextTick(onclose);
+  } else if (rState && stream.req && stream.aborted) {
+    process.nextTick(onclose);
+  }
+  const cleanup = () => {
+    callback = nop;
+    stream.removeListener('aborted', onclose);
+    stream.removeListener('complete', onfinish);
+    stream.removeListener('abort', onclose);
+    stream.removeListener('request', onrequest);
+    if (stream.req) stream .req.removeListener('finish', onfinish);
+    stream.removeListener('end', onlegacyfinish);
+    stream.removeListener('close', onlegacyfinish);
+    stream.removeListener('finish', onfinish);
+    stream.removeListener('end', onend);
+    stream.removeListener('error', onerror);
+    stream.removeListener('close', onclose);
+  }
+  if (options.signal && !closed) {
+    const abort = () => {
+      // Keep it because cleanup removes it.
+      const endCallback = callback
+      cleanup()
+      endCallback.call(
+        stream,
+        new AbortError(undefined, {
+          cause: options.signal?.reason
+        })
+      )
+    }
+    if (options.signal.aborted) {
+      process.nextTick(abort);
+    } else {
+      const originalCallback = callback;
+      callback = once((...args) => {
+        options.signal.removeEventListener('abort', abort)
+        originalCallback.apply(stream, args);
+      });
+      options.signal.addEventListener('abort', abort);
+    }
+  }
+  return cleanup;
+}
+
+export function finished(stream, opts) {
+  return new Promise((resolve, reject) => {
+    eos(stream, opts, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    })
+  });
+}
+
+eos.finished = finished;
+
+// ======================================================================================
+// Destroy
+
+function checkError(err, w, r) {
+  if (err) {
+    // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
+    err.stack; // eslint-disable-line no-unused-expressions
+
+    if (w && !w.errored) {
+      w.errored = err;
+    }
+    if (r && !r.errored) {
+      r.errored = err;
+    }
+  }
+}
+
+export function destroy(err, cb) {
+  const r = this._readableState;
+  const w = this._writableState;
+  // With duplex streams we use the writable side for state.
+  const s = w || r;
+  if ((w && w.destroyed) || (r && r.destroyed)) {
+    if (typeof cb === 'function') {
+      cb();
+    }
+    return this;
+  }
+
+  // We set destroyed to true before firing error callbacks in order
+  // to make it re-entrance safe in case destroy() is called within callbacks
+  checkError(err, w, r);
+  if (w) {
+    w.destroyed = true;
+  }
+  if (r) {
+    r.destroyed = true;
+  }
+
+  // If still constructing then defer calling _destroy.
+  if (!s.constructed) {
+    this.once(kDestroy, function (er) {
+      _destroy(this, aggregateTwoErrors(er, err), cb);
+    });
+  } else {
+    _destroy(this, err, cb);
+  }
+  return this;
+}
+
+function _destroy(self, err, cb) {
+  let called = false;
+  function onDestroy(err) {
+    if (called) {
+      return;
+    }
+    called = true;
+    const r = self._readableState;
+    const w = self._writableState;
+    checkError(err, w, r);
+    if (w) {
+      w.closed = true;
+    }
+    if (r) {
+      r.closed = true;
+    }
+    if (typeof cb === 'function') {
+      cb(err);
+    }
+    if (err) {
+      process.nextTick(emitErrorCloseNT, self, err);
+    } else {
+      process.nextTick(emitCloseNT, self);
+    }
+  }
+  try {
+    self._destroy(err || null, onDestroy);
+  } catch (err) {
+    onDestroy(err);
+  }
+}
+
+function emitErrorCloseNT(self, err) {
+  emitErrorNT(self, err);
+  emitCloseNT(self);
+}
+
+function emitCloseNT(self) {
+  const r = self._readableState;
+  const w = self._writableState;
+  if (w) {
+    w.closeEmitted = true;
+  }
+  if (r) {
+    r.closeEmitted = true;
+  }
+  if ((w && w.emitClose) || (r && r.emitClose)) {
+    self.emit('close');
+  }
+}
+
+function emitErrorNT(self, err) {
+  const r = self._readableState;
+  const w = self._writableState;
+  if ((w && w.errorEmitted) || (r && r.errorEmitted)) {
+    return;
+  }
+  if (w) {
+    w.errorEmitted = true;
+  }
+  if (r) {
+    r.errorEmitted = true;
+  }
+  self.emit('error', err);
+}
+
+export function undestroy() {
+  const r = this._readableState;
+  const w = this._writableState;
+  if (r) {
+    r.constructed = true;
+    r.closed = false;
+    r.closeEmitted = false;
+    r.destroyed = false;
+    r.errored = null;
+    r.errorEmitted = false;
+    r.reading = false;
+    r.ended = r.readable === false;
+    r.endEmitted = r.readable === false;
+  }
+  if (w) {
+    w.constructed = true;
+    w.destroyed = false;
+    w.closed = false;
+    w.closeEmitted = false;
+    w.errored = null;
+    w.errorEmitted = false;
+    w.finalCalled = false;
+    w.prefinished = false;
+    w.ended = w.writable === false;
+    w.ending = w.writable === false;
+    w.finished = w.writable === false;
+  }
+}
+
+export function errorOrDestroy(stream, err, sync = false) {
+  // We have tests that rely on errors being emitted
+  // in the same tick, so changing this is semver major.
+  // For now when you opt-in to autoDestroy we allow
+  // the error to be emitted nextTick. In a future
+  // semver major update we should change the default to this.
+
+  const r = stream._readableState;
+  const w = stream._writableState;
+  if ((w && w.destroyed) || (r && r.destroyed)) {
+    return;
+  }
+  if ((r && r.autoDestroy) || (w && w.autoDestroy)) stream.destroy(err);
+  else if (err) {
+    // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
+    err.stack; // eslint-disable-line no-unused-expressions
+
+    if (w && !w.errored) {
+      w.errored = err;
+    }
+    if (r && !r.errored) {
+      r.errored = err;
+    }
+    if (sync) {
+      process.nextTick(emitErrorNT, stream, err);
+    } else {
+      emitErrorNT(stream, err)
+    }
+  }
+}
+
+export function construct(stream, cb) {
+  if (typeof stream._construct !== 'function') {
+    return;
+  }
+  const r = stream._readableState;
+  const w = stream._writableState;
+  if (r) {
+    r.constructed = false;
+  }
+  if (w) {
+    w.constructed = false;
+  }
+  stream.once(kConstruct, cb)
+  if (stream.listenerCount(kConstruct) > 1) {
+    // Duplex
+    return;
+  }
+  process.nextTick(constructNT, stream);
+}
+
+function constructNT(stream) {
+  let called = false;
+  function onConstruct(err) {
+    if (called) {
+      errorOrDestroy(stream, err !== null && err !== undefined ? err : new ERR_MULTIPLE_CALLBACK());
+      return;
+    }
+    called = true;
+    const r = stream._readableState;
+    const w = stream._writableState;
+    const s = w || r;
+    if (r) {
+      r.constructed = true;
+    }
+    if (w) {
+      w.constructed = true;
+    }
+    if (s.destroyed) {
+      stream.emit(kDestroy, err);
+    } else if (err) {
+      errorOrDestroy(stream, err, true);
+    } else {
+      process.nextTick(emitConstructNT, stream);
+    }
+  }
+  try {
+    stream._construct(onConstruct);
+  } catch (err) {
+    onConstruct(err);
+  }
+}
+
+function emitConstructNT(stream) {
+  stream.emit(kConstruct);
+}
+
+function emitCloseLegacy(stream) {
+  stream.emit('close');
+}
+
+function emitErrorCloseLegacy(stream, err) {
+  stream.emit('error', err);
+  process.nextTick(emitCloseLegacy, stream);
+}
+
+// Normalize destroy for legacy.
+export function destroyer(stream, err) {
+  if (!stream || isDestroyed(stream)) {
+    return;
+  }
+  if (!err && !isFinished(stream)) {
+    err = new AbortError();
+  }
+
+  // TODO: Remove isRequest branches.
+  if (isServerRequest(stream)) {
+    stream.socket = null;
+    stream.destroy(err);
+  } else if (isRequest(stream)) {
+    stream.abort();
+  } else if (isRequest(stream.req)) {
+    stream.req.abort();
+  } else if (typeof stream.destroy === 'function') {
+    stream.destroy(err);
+  } else if (typeof stream.close === 'function') {
+    // TODO: Don't lose err?
+    stream.close();
+  } else if (err) {
+    process.nextTick(emitErrorCloseLegacy, stream, err);
+  } else {
+    process.nextTick(emitCloseLegacy, stream);
+  }
+  if (!stream.destroyed) {
+    stream[kDestroyed] = true;
+  }
+}
+

--- a/src/node/internal/streams_writable.js
+++ b/src/node/internal/streams_writable.js
@@ -1,0 +1,845 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import {
+  EventEmitter,
+} from 'node-internal:events';
+
+import {
+  Stream
+} from 'node-internal:streams_legacy';
+
+import {
+  Buffer,
+} from 'node-internal:internal_buffer';
+
+import * as process from 'node-internal:process';
+
+import {
+  nop,
+  kOnFinished,
+  getHighWaterMark,
+  getDefaultHighWaterMark,
+  addAbortSignal,
+  construct,
+  destroy,
+  undestroy,
+  errorOrDestroy,
+} from 'node-internal:streams_util';
+
+import {
+  ERR_INVALID_ARG_TYPE,
+  ERR_METHOD_NOT_IMPLEMENTED,
+  ERR_MULTIPLE_CALLBACK,
+  ERR_STREAM_CANNOT_PIPE,
+  ERR_STREAM_DESTROYED,
+  ERR_STREAM_ALREADY_FINISHED,
+  ERR_STREAM_NULL_VALUES,
+  ERR_STREAM_WRITE_AFTER_END,
+  ERR_UNKNOWN_ENCODING
+} from 'node-internal:internal_errors';
+
+import { isDuplexInstance } from 'node-internal:streams_duplex';
+
+// ======================================================================================
+// WritableState
+
+function WritableState(options, stream, isDuplex) {
+  // Duplex streams are both readable and writable, but share
+  // the same options object.
+  // However, some cases require setting options to different
+  // values for the readable and the writable sides of the duplex stream,
+  // e.g. options.readableObjectMode vs. options.writableObjectMode, etc.
+  if (typeof isDuplex !== 'boolean') isDuplex = isDuplexInstance(stream);
+
+  // Object stream flag to indicate whether or not this stream
+  // contains buffers or objects.
+  this.objectMode = !!(options?.objectMode);
+  if (isDuplex) this.objectMode = this.objectMode || !!(options?.writableObjectMode);
+
+  // The point at which write() starts returning false
+  // Note: 0 is a valid value, means that we always return false if
+  // the entire buffer is not flushed immediately on write().
+  this.highWaterMark = options
+    ? getHighWaterMark(this, options, 'writableHighWaterMark', isDuplex)
+    : getDefaultHighWaterMark(false);
+
+  // if _final has been called.
+  this.finalCalled = false;
+
+  // drain event flag.
+  this.needDrain = false;
+  // At the start of calling end()
+  this.ending = false;
+  // When end() has been called, and returned.
+  this.ended = false;
+  // When 'finish' is emitted.
+  this.finished = false;
+
+  // Has it been destroyed
+  this.destroyed = false;
+
+  // Should we decode strings into buffers before passing to _write?
+  // this is here so that some node-core streams can optimize string
+  // handling at a lower level.
+  const noDecode = !!(options?.decodeStrings === false);
+  this.decodeStrings = !noDecode;
+
+  // Crypto is kind of old and crusty.  Historically, its default string
+  // encoding is 'binary' so we have to make this configurable.
+  // Everything else in the universe uses 'utf8', though.
+  this.defaultEncoding = (options?.defaultEncoding) || 'utf8';
+
+  // Not an actual buffer we keep track of, but a measurement
+  // of how much we're waiting to get pushed to some underlying
+  // socket or file.
+  this.length = 0;
+
+  // A flag to see when we're in the middle of a write.
+  this.writing = false;
+
+  // When true all writes will be buffered until .uncork() call.
+  this.corked = 0;
+
+  // A flag to be able to tell if the onwrite cb is called immediately,
+  // or on a later tick.  We set this to true at first, because any
+  // actions that shouldn't happen until "later" should generally also
+  // not happen before the first write call.
+  this.sync = true;
+
+  // A flag to know if we're processing previously buffered items, which
+  // may call the _write() callback in the same tick, so that we don't
+  // end up in an overlapped onwrite situation.
+  this.bufferProcessing = false;
+
+  // The callback that's passed to _write(chunk, cb).
+  this.onwrite = (err) => onwrite.call(undefined, stream, err);
+
+  // The callback that the user supplies to write(chunk, encoding, cb).
+  this.writecb = null;
+
+  // The amount that is being written when _write is called.
+  this.writelen = 0;
+
+  // Storage for data passed to the afterWrite() callback in case of
+  // synchronous _write() completion.
+  this.afterWriteTickInfo = null;
+  resetBuffer(this);
+
+  // Number of pending user-supplied write callbacks
+  // this must be 0 before 'finish' can be emitted.
+  this.pendingcb = 0;
+
+  // Stream is still being constructed and cannot be
+  // destroyed until construction finished or failed.
+  // Async construction is opt in, therefore we start as
+  // constructed.
+  this.constructed = true;
+
+  // Emit prefinish if the only thing we're waiting for is _write cbs
+  // This is relevant for synchronous Transform streams.
+  this.prefinished = false;
+
+  // True if the error was already emitted and should not be thrown again.
+  this.errorEmitted = false;
+
+  // Should close be emitted on destroy. Defaults to true.
+  this.emitClose = !options || options.emitClose !== false;
+
+  // Should .destroy() be called after 'finish' (and potentially 'end').
+  this.autoDestroy = !options || options.autoDestroy !== false;
+
+  // Indicates whether the stream has errored. When true all write() calls
+  // should return false. This is needed since when autoDestroy
+  // is disabled we need a way to tell whether the stream has failed.
+  this.errored = null;
+
+  // Indicates whether the stream has finished destroying.
+  this.closed = false;
+
+  // True if close has been emitted or would have been emitted
+  // depending on emitClose.
+  this.closeEmitted = false;
+  this[kOnFinished] = [];
+}
+
+function resetBuffer(state) {
+  state.buffered = [];
+  state.bufferedIndex = 0;
+  state.allBuffers = true;
+  state.allNoop = true;
+}
+
+WritableState.prototype.getBuffer = function getBuffer() {
+  return this.buffered.slice(this.bufferedIndex);
+}
+
+Object.defineProperty(WritableState.prototype, 'bufferedRequestCount', {
+  get() {
+    return this.buffered.length - this.bufferedIndex;
+  }
+});
+
+// ======================================================================================
+// Writable
+
+Writable.WritableState = WritableState;
+
+Object.setPrototypeOf(Writable.prototype, Stream.prototype);
+Object.setPrototypeOf(Writable, Stream);
+
+export function Writable(options) {
+  // Writable ctor is applied to Duplexes, too.
+  // `realHasInstance` is necessary because using plain `instanceof`
+  // would return false, as no `_writableState` property is attached.
+
+  // Trying to use the custom `instanceof` for Writable here will also break the
+  // Node.js LazyTransform implementation, which has a non-trivial getter for
+  // `_writableState` that would lead to infinite recursion.
+
+  // Checking for a Stream.Duplex instance is faster here instead of inside
+  // the WritableState constructor, at least with V8 6.5.
+  const isDuplex = isDuplexInstance(this);
+  if (!isDuplex && !Writable[Symbol.hasInstance](this)) return new Writable(options);
+  this._writableState = new WritableState(options, this, isDuplex)
+  if (options) {
+    if (typeof options.write === 'function') this._write = options.write;
+    if (typeof options.writev === 'function') this._writev = options.writev;
+    if (typeof options.destroy === 'function') this._destroy = options.destroy;
+    if (typeof options.final === 'function') this._final = options.final;
+    if (typeof options.construct === 'function') this._construct = options.construct;
+    if (options.signal) addAbortSignal(options.signal, this);
+  }
+  Stream.call(this, options);
+  construct(this, () => {
+    const state = this._writableState;
+    if (!state.writing) {
+      clearBuffer(this, state);
+    }
+    finishMaybe(this, state);
+  })
+}
+
+Object.defineProperty(Writable, Symbol.hasInstance, {
+  value: function (object) {
+    if (Function.prototype[Symbol.hasInstance].call(this, object)) return true;
+    if (this !== Writable) return false;
+    return object?._writableState instanceof WritableState;
+  }
+})
+
+// Otherwise people can pipe Writable streams, which is just wrong.
+Writable.prototype.pipe = function (_1, _2) {
+  errorOrDestroy(this, new ERR_STREAM_CANNOT_PIPE());
+}
+
+function _write(stream, chunk, encoding, cb) {
+  const state = stream._writableState;
+  if (typeof encoding === 'function') {
+    cb = encoding;
+    encoding = state.defaultEncoding;
+  } else {
+    if (!encoding) encoding = state.defaultEncoding;
+    else if (encoding !== 'buffer' && !Buffer.isEncoding(encoding)) {
+      throw new ERR_UNKNOWN_ENCODING(encoding);
+    }
+    if (typeof cb !== 'function') cb = nop;
+  }
+  if (chunk === null) {
+    throw new ERR_STREAM_NULL_VALUES();
+  } else if (!state.objectMode) {
+    if (typeof chunk === 'string') {
+      if (state.decodeStrings !== false) {
+        chunk = Buffer.from(chunk, encoding);
+        encoding = 'buffer';
+      }
+    } else if (chunk instanceof Buffer) {
+      encoding = 'buffer';
+    } else if (Stream._isUint8Array(chunk)) {
+      chunk = Stream._uint8ArrayToBuffer(chunk);
+      encoding = 'buffer';
+    } else {
+      throw new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer', 'Uint8Array'], chunk);
+    }
+  }
+  let err;
+  if (state.ending) {
+    err = new ERR_STREAM_WRITE_AFTER_END();
+  } else if (state.destroyed) {
+    err = new ERR_STREAM_DESTROYED('write');
+  }
+  if (err) {
+    process.nextTick(cb, err);
+    errorOrDestroy(stream, err, true);
+    return err;
+  }
+  state.pendingcb++;
+  return writeOrBuffer(stream, state, chunk, encoding, cb);
+}
+
+function write(chunk, encoding, cb) {
+  return _write(this, chunk, encoding, cb) === true;
+}
+
+Writable.prototype.write = write;
+
+Writable.prototype.cork = function () {
+  this._writableState.corked++;
+}
+
+Writable.prototype.uncork = function () {
+  const state = this._writableState;
+  if (state.corked) {
+    state.corked--;
+    if (!state.writing) clearBuffer(this, state);
+  }
+}
+
+function setDefaultEncoding(encoding) {
+  if (typeof encoding === 'string') encoding = encoding.toLowerCase();
+  if (!Buffer.isEncoding(encoding)) throw new ERR_UNKNOWN_ENCODING(encoding);
+  this._writableState.defaultEncoding = encoding;
+  return this;
+}
+
+Writable.prototype.setDefaultEncoding = setDefaultEncoding;
+
+// If we're already writing something, then just put this
+// in the queue, and wait our turn.  Otherwise, call _write
+// If we return false, then we need a drain event, so set that flag.
+function writeOrBuffer(stream, state, chunk, encoding, callback) {
+  const len = state.objectMode ? 1 : chunk.length;
+  state.length += len;
+
+  // stream._write resets state.length
+  const ret = state.length < state.highWaterMark;
+  // We must ensure that previous needDrain will not be reset to false.
+  if (!ret) state.needDrain = true;
+  if (state.writing || state.corked || state.errored || !state.constructed) {
+    state.buffered.push({
+      chunk,
+      encoding,
+      callback,
+    });
+    if (state.allBuffers && encoding !== 'buffer') {
+      state.allBuffers = false;
+    }
+    if (state.allNoop && callback !== nop) {
+      state.allNoop = false;
+    }
+  } else {
+    state.writelen = len;
+    state.writecb = callback;
+    state.writing = true;
+    state.sync = true;
+    stream._write(chunk, encoding, state.onwrite);
+    state.sync = false;
+  }
+
+  // Return false if errored or destroyed in order to break
+  // any synchronous while(stream.write(data)) loops.
+  return ret && !state.errored && !state.destroyed;
+}
+
+function doWrite(stream, state, writev, len, chunk, encoding, cb) {
+  state.writelen = len;
+  state.writecb = cb;
+  state.writing = true;
+  state.sync = true;
+  if (state.destroyed) state.onwrite(new ERR_STREAM_DESTROYED('write'));
+  else if (writev) stream._writev(chunk, state.onwrite);
+  else stream._write(chunk, encoding, state.onwrite);
+  state.sync = false;
+}
+
+function onwriteError(stream, state, er, cb) {
+  --state.pendingcb;
+  cb(er);
+  // Ensure callbacks are invoked even when autoDestroy is
+  // not enabled. Passing `er` here doesn't make sense since
+  // it's related to one specific write, not to the buffered
+  // writes.
+  errorBuffer(state);
+  // This can emit error, but error must always follow cb.
+  errorOrDestroy(stream, er);
+}
+
+function onwrite(stream, er) {
+  const state = stream._writableState;
+  const sync = state.sync;
+  const cb = state.writecb;
+  if (typeof cb !== 'function') {
+    errorOrDestroy(stream, new ERR_MULTIPLE_CALLBACK());
+    return;
+  }
+  state.writing = false;
+  state.writecb = null;
+  state.length -= state.writelen;
+  state.writelen = 0;
+  if (er) {
+    // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
+    er.stack; // eslint-disable-line no-unused-expressions
+
+    if (!state.errored) {
+      state.errored = er;
+    }
+
+    // In case of duplex streams we need to notify the readable side of the
+    // error.
+    if (stream._readableState && !stream._readableState.errored) {
+      stream._readableState.errored = er;
+    }
+    if (sync) {
+      process.nextTick(onwriteError, stream, state, er, cb);
+    } else {
+      onwriteError(stream, state, er, cb);
+    }
+  } else {
+    if (state.buffered.length > state.bufferedIndex) {
+      clearBuffer(stream, state);
+    }
+    if (sync) {
+      // It is a common case that the callback passed to .write() is always
+      // the same. In that case, we do not schedule a new nextTick(), but
+      // rather just increase a counter, to improve performance and avoid
+      // memory allocations.
+      if (state.afterWriteTickInfo !== null && state.afterWriteTickInfo.cb === cb) {
+        state.afterWriteTickInfo.count++;
+      } else {
+        state.afterWriteTickInfo = {
+          count: 1,
+          cb,
+          stream,
+          state
+        };
+        process.nextTick(afterWriteTick, state.afterWriteTickInfo);
+      }
+    } else {
+      afterWrite(stream, state, 1, cb);
+    }
+  }
+}
+
+function afterWriteTick({ stream, state, count, cb }) {
+  state.afterWriteTickInfo = null;
+  return afterWrite(stream, state, count, cb);
+}
+
+function afterWrite(stream, state, count, cb) {
+  const needDrain = !state.ending && !stream.destroyed && state.length === 0 && state.needDrain;
+  if (needDrain) {
+    state.needDrain = false;
+    stream.emit('drain');
+  }
+  while (count-- > 0) {
+    state.pendingcb--;
+    cb();
+  }
+  if (state.destroyed) {
+    errorBuffer(state);
+  }
+  finishMaybe(stream, state);
+}
+
+// If there's something in the buffer waiting, then invoke callbacks.
+function errorBuffer(state) {
+  if (state.writing) {
+    return;
+  }
+  for (let n = state.bufferedIndex; n < state.buffered.length; ++n) {
+    let _state$errored;
+    const { chunk, callback } = state.buffered[n];
+    const len = state.objectMode ? 1 : chunk.length;
+    state.length -= len;
+    callback(
+      (_state$errored = state.errored) !== null && _state$errored !== undefined
+        ? _state$errored
+        : new ERR_STREAM_DESTROYED('write'));
+  }
+  const onfinishCallbacks = state[kOnFinished].splice(0);
+  for (let i = 0; i < onfinishCallbacks.length; i++) {
+    let _state$errored2;
+    onfinishCallbacks[i](
+      (_state$errored2 = state.errored) !== null && _state$errored2 !== undefined
+        ? _state$errored2
+        : new ERR_STREAM_DESTROYED('end'));
+  }
+  resetBuffer(state);
+}
+
+// If there's something in the buffer waiting, then process it.
+function clearBuffer(stream, state) {
+  if (state.corked || state.bufferProcessing || state.destroyed || !state.constructed) {
+    return;
+  }
+  const { buffered, bufferedIndex, objectMode } = state;
+  const bufferedLength = buffered.length - bufferedIndex;
+  if (!bufferedLength) {
+    return;
+  }
+  let i = bufferedIndex;
+  state.bufferProcessing = true;
+  if (bufferedLength > 1 && stream._writev) {
+    state.pendingcb -= bufferedLength - 1;
+    const callback = state.allNoop
+      ? nop
+      : (err) => {
+          for (let n = i; n < buffered.length; ++n) {
+            buffered[n].callback(err)
+          }
+        };
+    // Make a copy of `buffered` if it's going to be used by `callback` above,
+    // since `doWrite` will mutate the array.
+    const chunks = state.allNoop && i === 0 ? buffered : buffered.slice(i);
+    chunks.allBuffers = state.allBuffers;
+    doWrite(stream, state, true, state.length, chunks, '', callback);
+    resetBuffer(state);
+  } else {
+    do {
+      const { chunk, encoding, callback } = buffered[i];
+      buffered[i++] = null;
+      const len = objectMode ? 1 : chunk.length;
+      doWrite(stream, state, false, len, chunk, encoding, callback);
+    } while (i < buffered.length && !state.writing)
+    if (i === buffered.length) {
+      resetBuffer(state);
+    } else if (i > 256) {
+      buffered.splice(0, i);
+      state.bufferedIndex = 0;
+    } else {
+      state.bufferedIndex = i;
+    }
+  }
+  state.bufferProcessing = false;
+}
+
+Writable.prototype._write = function (chunk, encoding, cb) {
+  if (this._writev) {
+    this._writev(
+      [
+        {
+          chunk,
+          encoding
+        }
+      ],
+      cb,
+    );
+  } else {
+    throw new ERR_METHOD_NOT_IMPLEMENTED('_write()');
+  }
+}
+
+Writable.prototype._writev = null;
+
+function end(chunk, encoding, cb) {
+  const state = this._writableState;
+  if (typeof chunk === 'function') {
+    cb = chunk;
+    chunk = null;
+    encoding = null;
+  } else if (typeof encoding === 'function') {
+    cb = encoding;
+    encoding = null;
+  }
+  let err;
+  if (chunk !== null && chunk !== undefined) {
+    const ret = _write(this, chunk, encoding);
+    if (ret instanceof Error) {
+      err = ret;
+    }
+  }
+
+  // .end() fully uncorks.
+  if (state.corked) {
+    state.corked = 1;
+    this.uncork();
+  }
+  if (err) {
+    // Do nothing...
+  } else if (!state.errored && !state.ending) {
+    // This is forgiving in terms of unnecessary calls to end() and can hide
+    // logic errors. However, usually such errors are harmless and causing a
+    // hard error can be disproportionately destructive. It is not always
+    // trivial for the user to determine whether end() needs to be called
+    // or not.
+
+    state.ending = true;
+    finishMaybe(this, state, true);
+    state.ended = true;
+  } else if (state.finished) {
+    err = new ERR_STREAM_ALREADY_FINISHED('end');
+  } else if (state.destroyed) {
+    err = new ERR_STREAM_DESTROYED('end');
+  }
+  if (typeof cb === 'function') {
+    if (err || state.finished) {
+      process.nextTick(cb, err);
+    } else {
+      state[kOnFinished].push(cb);
+    }
+  }
+  return this;
+}
+
+Writable.prototype.end = end;
+
+function needFinish(state) {
+  return (
+    state.ending &&
+    !state.destroyed &&
+    state.constructed &&
+    state.length === 0 &&
+    !state.errored &&
+    state.buffered.length === 0 &&
+    !state.finished &&
+    !state.writing &&
+    !state.errorEmitted &&
+    !state.closeEmitted
+  );
+}
+
+function callFinal(stream, state) {
+  let called = false;
+  function onFinish(err) {
+    if (called) {
+      errorOrDestroy(stream, err || new ERR_MULTIPLE_CALLBACK());
+      return;
+    }
+    called = true;
+    state.pendingcb--;
+    if (err) {
+      const onfinishCallbacks = state[kOnFinished].splice(0);
+      for (let i = 0; i < onfinishCallbacks.length; i++) {
+        onfinishCallbacks[i](err);
+      }
+      errorOrDestroy(stream, err, state.sync);
+    } else if (needFinish(state)) {
+      state.prefinished = true;
+      stream.emit('prefinish');
+      // Backwards compat. Don't check state.sync here.
+      // Some streams assume 'finish' will be emitted
+      // asynchronously relative to _final callback.
+      state.pendingcb++;
+      process.nextTick(finish, stream, state);
+    }
+  }
+  state.sync = true;
+  state.pendingcb++;
+  try {
+    stream._final(onFinish);
+  } catch (err) {
+    onFinish(err);
+  }
+  state.sync = false;
+}
+
+function prefinish(stream, state) {
+  if (!state.prefinished && !state.finalCalled) {
+    if (typeof stream._final === 'function' && !state.destroyed) {
+      state.finalCalled = true;
+      callFinal(stream, state);
+    } else {
+      state.prefinished = true;
+      stream.emit('prefinish');
+    }
+  }
+}
+
+function finishMaybe(stream, state, sync = false) {
+  if (needFinish(state)) {
+    prefinish(stream, state);
+    if (state.pendingcb === 0) {
+      if (sync) {
+        state.pendingcb++;
+        process.nextTick(() => {
+          ((stream, state) => {
+            if (needFinish(state)) {
+              finish(stream, state);
+            } else {
+              state.pendingcb--;
+            }
+          })(stream, state);
+        });
+      } else if (needFinish(state)) {
+        state.pendingcb++;
+        finish(stream, state);
+      }
+    }
+  }
+}
+
+function finish(stream, state) {
+  state.pendingcb--;
+  state.finished = true;
+  const onfinishCallbacks = state[kOnFinished].splice(0);
+  for (let i = 0; i < onfinishCallbacks.length; i++) {
+    onfinishCallbacks[i]();
+  }
+  stream.emit('finish');
+  if (state.autoDestroy) {
+    // In case of duplex streams we need a way to detect
+    // if the readable side is ready for autoDestroy as well.
+    const rState = stream._readableState;
+    const autoDestroy =
+      !rState ||
+      (rState.autoDestroy &&
+        // We don't expect the readable to ever 'end'
+        // if readable is explicitly set to false.
+        (rState.endEmitted || rState.readable === false));
+    if (autoDestroy) {
+      stream.destroy();
+    }
+  }
+}
+
+Object.defineProperties(Writable.prototype, {
+  closed: {
+    get() {
+      return !!(this._writableState?.closed);
+    }
+  },
+  destroyed: {
+    get() {
+      return !!(this._writableState?.destroyed);
+    },
+    set(value) {
+      // Backward compatibility, the user is explicitly managing destroyed.
+      if (this._writableState) {
+        this._writableState.destroyed = value
+      }
+    }
+  },
+  errored: {
+    enumerable: false,
+    get() {
+      return this._writableState?.errored || null;
+    }
+  },
+  writable: {
+    get() {
+      const w = this._writableState
+      // w.writable === false means that this is part of a Duplex stream
+      // where the writable side was disabled upon construction.
+      // Compat. The user might manually disable writable side through
+      // deprecated setter.
+      return !!w && w.writable !== false && !w.destroyed && !w.errored && !w.ending && !w.ended;
+    },
+    set(val) {
+      // Backwards compatible.
+      if (this._writableState) {
+        this._writableState.writable = !!val;
+      }
+    }
+  },
+  writableFinished: {
+    get() {
+      return !!(this._writableState?.finished);
+    }
+  },
+  writableObjectMode: {
+    get() {
+      return !!(this._writableState?.objectMode);
+    }
+  },
+  writableBuffer: {
+    get() {
+      return this._writableState?.getBuffer();
+    }
+  },
+  writableEnded: {
+    get() {
+      return !!(this._writableState?.ending);
+    }
+  },
+  writableNeedDrain: {
+    get() {
+      const wState = this._writableState;
+      if (!wState) return false;
+      return !wState.destroyed && !wState.ending && wState.needDrain;
+    }
+  },
+  writableHighWaterMark: {
+    get() {
+      return this._writableState?.highWaterMark;
+    }
+  },
+  writableCorked: {
+    get() {
+      return this._writableState?.corked | 0;
+    }
+  },
+  writableLength: {
+    get() {
+      return this._writableState?.length;
+    }
+  },
+  writableAborted: {
+    enumerable: false,
+    get() {
+      return !!(
+        this._writableState.writable !== false &&
+        (this._writableState.destroyed || this._writableState.errored) &&
+        !this._writableState.finished
+      )
+    }
+  }
+});
+
+Writable.prototype.destroy = function (err, cb) {
+  const state = this._writableState;
+
+  // Invoke pending callbacks.
+  if (!state.destroyed && (state.bufferedIndex < state.buffered.length || state[kOnFinished].length)) {
+    process.nextTick(errorBuffer, state);
+  }
+  destroy.call(this, err, cb);
+  return this;
+}
+
+Writable.prototype._undestroy = undestroy
+
+Writable.prototype._destroy = function (err, cb) {
+  if (cb) cb(err);
+}
+Writable.prototype[EventEmitter.captureRejectionSymbol] = function (err) {
+  this.destroy(err);
+}
+
+// let webStreamsAdapters
+
+// // Lazy to avoid circular references
+// function lazyWebStreams() {
+//   if (webStreamsAdapters === undefined) webStreamsAdapters = {}
+//   return webStreamsAdapters
+// }
+// Writable.fromWeb = function (writableStream, options) {
+//   return lazyWebStreams().newStreamWritableFromWritableStream(writableStream, options)
+// }
+// Writable.toWeb = function (streamWritable) {
+//   return lazyWebStreams().newWritableStreamFromStreamWritable(streamWritable)
+// }

--- a/src/node/internal/validators.ts
+++ b/src/node/internal/validators.ts
@@ -31,7 +31,11 @@
 // import { hideStackFrames } from "node-internal:hide-stack-frames";
 import { isArrayBufferView } from "node-internal:internal_types";
 import { normalizeEncoding } from "node-internal:internal_utils";
-import { default as codes } from "node-internal:internal_errors";
+import {
+  ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_ARG_VALUE,
+  ERR_OUT_OF_RANGE,
+} from "node-internal:internal_errors";
 
 // TODO(someday): Not current implementing parseFileMode, validatePort
 
@@ -40,7 +44,7 @@ export const isUint32 = (value: any) => value === (value >>> 0);
 
 export function validateBuffer(buffer: unknown, name = "buffer") {
   if (!isArrayBufferView(buffer)) {
-    throw new codes.ERR_INVALID_ARG_TYPE(
+    throw new ERR_INVALID_ARG_TYPE(
       name,
       ["Buffer", "TypedArray", "DataView"],
       buffer,
@@ -54,13 +58,13 @@ export function validateInteger(
     min = Number.MIN_SAFE_INTEGER,
     max = Number.MAX_SAFE_INTEGER) {
   if (typeof value !== "number") {
-    throw new codes.ERR_INVALID_ARG_TYPE(name, "number", value);
+    throw new ERR_INVALID_ARG_TYPE(name, "number", value);
   }
   if (!Number.isInteger(value)) {
-    throw new codes.ERR_OUT_OF_RANGE(name, "an integer", value);
+    throw new ERR_OUT_OF_RANGE(name, "an integer", value);
   }
   if (value < min || value > max) {
-    throw new codes.ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
+    throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
   }
 }
 
@@ -82,64 +86,64 @@ export function validateObject(value: unknown, name: string, options: ValidateOb
       !allowFunction || typeof value !== "function"
     ))
   ) {
-    throw new codes.ERR_INVALID_ARG_TYPE(name, "Object", value);
+    throw new ERR_INVALID_ARG_TYPE(name, "Object", value);
   }
 };
 
 export function validateInt32(value: any, name: string, min = -2147483648, max = 2147483647) {
   if (!isInt32(value)) {
     if (typeof value !== "number") {
-      throw new codes.ERR_INVALID_ARG_TYPE(name, "number", value);
+      throw new ERR_INVALID_ARG_TYPE(name, "number", value);
     }
 
     if (!Number.isInteger(value)) {
-      throw new codes.ERR_OUT_OF_RANGE(name, "an integer", value);
+      throw new ERR_OUT_OF_RANGE(name, "an integer", value);
     }
 
-    throw new codes.ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
+    throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
   }
 
   if (value < min || value > max) {
-    throw new codes.ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
+    throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
   }
 }
 
 export function validateUint32(value: unknown, name: string, positive?: boolean) {
   if (!isUint32(value)) {
     if (typeof value !== "number") {
-      throw new codes.ERR_INVALID_ARG_TYPE(name, "number", value);
+      throw new ERR_INVALID_ARG_TYPE(name, "number", value);
     }
     if (!Number.isInteger(value)) {
-      throw new codes.ERR_OUT_OF_RANGE(name, "an integer", value);
+      throw new ERR_OUT_OF_RANGE(name, "an integer", value);
     }
     const min = positive ? 1 : 0;
     // 2 ** 32 === 4294967296
-    throw new codes.ERR_OUT_OF_RANGE(
+    throw new ERR_OUT_OF_RANGE(
       name,
       `>= ${min} && < 4294967296`,
       value,
     );
   }
   if (positive && value === 0) {
-    throw new codes.ERR_OUT_OF_RANGE(name, ">= 1 && < 4294967296", value);
+    throw new ERR_OUT_OF_RANGE(name, ">= 1 && < 4294967296", value);
   }
 }
 
 export function validateString(value: unknown, name: string) {
   if (typeof value !== "string") {
-    throw new codes.ERR_INVALID_ARG_TYPE(name, "string", value);
+    throw new ERR_INVALID_ARG_TYPE(name, "string", value);
   }
 }
 
 export function validateNumber(value: unknown, name: string) {
   if (typeof value !== "number") {
-    throw new codes.ERR_INVALID_ARG_TYPE(name, "number", value);
+    throw new ERR_INVALID_ARG_TYPE(name, "number", value);
   }
 }
 
 export function validateBoolean(value: unknown, name: string) {
   if (typeof value !== "boolean") {
-    throw new codes.ERR_INVALID_ARG_TYPE(name, "boolean", value);
+    throw new ERR_INVALID_ARG_TYPE(name, "boolean", value);
   }
 }
 
@@ -154,7 +158,7 @@ export function validateOneOf(value: unknown, name: string, oneOf: any[]) {
     );
     const reason = "must be one of: " + allowed;
 
-    throw new codes.ERR_INVALID_ARG_VALUE(name, value, reason);
+    throw new ERR_INVALID_ARG_VALUE(name, value, reason);
   }
 }
 
@@ -163,7 +167,7 @@ export function validateEncoding(data: unknown, encoding: string): void {
   const length = (data as any).length;
 
   if (normalizedEncoding === "hex" && length % 2 !== 0) {
-    throw new codes.ERR_INVALID_ARG_VALUE(
+    throw new ERR_INVALID_ARG_VALUE(
       "encoding",
       encoding,
       `is invalid for data of length ${length}`,
@@ -178,23 +182,23 @@ export function validateAbortSignal(signal: unknown, name: string) {
       typeof signal !== "object" ||
       !("aborted" in signal))
   ) {
-    throw new codes.ERR_INVALID_ARG_TYPE(name, "AbortSignal", signal);
+    throw new ERR_INVALID_ARG_TYPE(name, "AbortSignal", signal);
   }
 };
 
 export function validateFunction(value: unknown, name: string) {
   if (typeof value !== "function") {
-    throw new codes.ERR_INVALID_ARG_TYPE(name, "Function", value);
+    throw new ERR_INVALID_ARG_TYPE(name, "Function", value);
   }
 }
 
 export function validateArray(value: unknown, name: string, minLength = 0) {
   if (!Array.isArray(value)) {
-    throw new codes.ERR_INVALID_ARG_TYPE(name, "Array", value);
+    throw new ERR_INVALID_ARG_TYPE(name, "Array", value);
   }
   if (value.length < minLength) {
     const reason = `must be longer than ${minLength}`;
-    throw new codes.ERR_INVALID_ARG_VALUE(name, value, reason);
+    throw new ERR_INVALID_ARG_VALUE(name, value, reason);
   }
 }
 

--- a/src/node/stream.js
+++ b/src/node/stream.js
@@ -1,0 +1,72 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+
+/* eslint-disable */
+
+// TODO(soon): Remove this once assert is out of experimental
+import { default as CompatibilityFlags } from 'workerd:compatibility-flags';
+if (!CompatibilityFlags.workerdExperimental) {
+  throw new Error('node:stream is experimental.');
+}
+
+import { pipeline } from 'node-internal:streams_pipeline';
+import {
+  destroyer,
+  eos,
+  isErrored,
+  isDisturbed,
+  isReadable,
+  addAbortSignal,
+} from 'node-internal:streams_util';
+import {
+  compose,
+} from 'node-internal:streams_compose';
+import { Stream } from 'node-internal:streams_legacy';
+import { Writable } from 'node-internal:streams_writable';
+import { Readable } from 'node-internal:streams_readable';
+import { Duplex } from 'node-internal:streams_duplex';
+import { Transform, PassThrough } from 'node-internal:streams_transform';
+import { promises } from 'node-internal:streams_promises';
+
+export const _isUint8Array = Stream._isUint8Array;
+export const _uint8ArrayToBuffer = Stream._uint8ArrayToBuffer;
+const destroy = destroyer;
+const finished = eos;
+
+export {
+  addAbortSignal,
+  compose,
+  destroy,
+  finished,
+  isErrored,
+  isDisturbed,
+  isReadable,
+  pipeline,
+  Stream,
+  Writable,
+  Readable,
+  Duplex,
+  Transform,
+  PassThrough,
+  promises,
+};
+
+Stream.addAbortSignal = addAbortSignal;
+Stream.compose = compose;
+Stream.destroy = destroy;
+Stream.finished = finished;
+Stream.isReadable = isReadable;
+Stream.isErrored = isErrored;
+Stream.isErrored = isDisturbed;
+Stream.pipeline = pipeline;
+Stream.Stream = Stream;
+Stream.Writable = Writable;
+Stream.Readable = Readable;
+Stream.Duplex = Duplex;
+Stream.Transform = Transform;
+Stream.PassThrough = PassThrough;
+Stream.promises = promises;
+
+export default Stream;

--- a/src/workerd/api/node/streams-test.js
+++ b/src/workerd/api/node/streams-test.js
@@ -1,0 +1,1942 @@
+import {
+  deepEqual,
+  deepStrictEqual,
+  doesNotMatch,
+  doesNotReject,
+  doesNotThrow,
+  equal,
+  fail,
+  ifError,
+  match,
+  notDeepEqual,
+  notDeepStrictEqual,
+  notEqual,
+  notStrictEqual,
+  ok,
+  rejects,
+  strictEqual,
+  throws,
+} from 'node:assert';
+
+import {
+  Buffer,
+} from 'node:buffer';
+
+import {
+  Readable,
+  Writable,
+  Duplex,
+  Transform,
+  PassThrough,
+  addAbortSignal,
+  destroy,
+  finished,
+  pipeline,
+} from 'node:stream';
+
+function deferredPromise() {
+  let resolve, reject;
+  const promise = new Promise((a, b) => {
+    resolve = a;
+    reject = b;
+  });
+  return {
+    promise,
+    resolve,
+    reject,
+  };
+}
+
+function countedDeferred(n, action) {
+  let resolve;
+  const promise = new Promise((a) => {
+    resolve = a;
+  });
+  return {
+    promise,
+    resolve(...args) {
+      action(...args);
+      if (--n === 0) resolve();
+    }
+  };
+}
+
+export const legacyAliases = {
+  async test(ctrl, env, ctx) {
+    strictEqual(Readable, (await import('node:_stream_readable')).Readable);
+    strictEqual(Writable, (await import('node:_stream_writable')).Writable);
+    strictEqual(Duplex, (await import('node:_stream_duplex')).Duplex);
+    strictEqual(Transform, (await import('node:_stream_transform')).Transform);
+    strictEqual(PassThrough, (await import('node:_stream_passthrough')).PassThrough);
+  }
+};
+
+export const addAbortSignalTest = {
+  test(ctrl, env, ctx) {
+    const ac = new AbortController();
+    addAbortSignal(ac.signal, new Readable());
+
+    {
+      throws(() => {
+        addAbortSignal('INVALID_SIGNAL');
+      }, /ERR_INVALID_ARG_TYPE/);
+
+      throws(() => {
+        addAbortSignal(ac.signal, 'INVALID_STREAM');
+      }, /ERR_INVALID_ARG_TYPE/);
+    }
+  }
+};
+
+export const autoDestroy = {
+  async test(ctrl, env, ctx) {
+    {
+      const rDestroyed = deferredPromise();
+      const rEnded = deferredPromise();
+      const rClosed = deferredPromise();
+
+      const r = new Readable({
+        autoDestroy: true,
+        read() {
+          this.push('hello');
+          this.push('world');
+          this.push(null);
+        },
+        destroy(err, cb) {
+          rDestroyed.resolve();
+          cb();
+        }
+      });
+
+      let ended = false;
+      r.resume();
+      r.on('end', rEnded.resolve);
+      r.on('close', rClosed.resolve);
+
+      await Promise.all([
+        rDestroyed.promise,
+        rEnded.promise,
+        rClosed.promise,
+      ]);
+    }
+
+    {
+      const rDestroyed = deferredPromise();
+      const rFinished = deferredPromise();
+      const rClosed = deferredPromise();
+
+      const w = new Writable({
+        autoDestroy: true,
+        write(data, enc, cb) {
+          cb(null);
+        },
+        destroy(err, cb) {
+          rDestroyed.resolve();
+          cb();
+        }
+      });
+
+      w.write('hello');
+      w.write('world');
+      w.end();
+
+      w.on('finish', rFinished.resolve);
+      w.on('close', rClosed.resolve);
+
+      await Promise.all([
+        rDestroyed.promise,
+        rFinished.promise,
+        rClosed.promise,
+      ]);
+    }
+
+    {
+      const rDestroyed = deferredPromise();
+      const rEnded = deferredPromise();
+      const rFinished = deferredPromise();
+      const rClosed = deferredPromise();
+
+      const t = new Transform({
+        autoDestroy: true,
+        transform(data, enc, cb) {
+          cb(null, data);
+        },
+        destroy(err, cb) {
+          rDestroyed.resolve();
+          cb();
+        }
+      });
+
+      t.write('hello');
+      t.write('world');
+      t.end();
+
+      t.resume();
+
+      t.on('end', rEnded.resolve);
+      t.on('finish', rFinished.resolve);
+      t.on('close', rClosed.resolve);
+
+      await Promise.all([
+        rDestroyed.promise,
+        rEnded.promise,
+        rFinished.promise,
+        rClosed.promise,
+      ]);
+    }
+
+    {
+      const rDestroyed = deferredPromise();
+
+      const err = new Error('fail');
+
+      const r = new Readable({
+        read() {
+          r2.emit('error', err);
+        }
+      });
+      const r2 = new Readable({
+        autoDestroy: true,
+        destroy(err, cb) {
+          rDestroyed.resolve(err);
+        }
+      });
+
+      r.pipe(r2);
+
+      const check = await rDestroyed.promise;
+      strictEqual(check, err);
+    }
+
+    {
+      const rDestroyed = deferredPromise();
+      const err = new Error('fail');
+      const r = new Readable({
+        read() {
+          w.emit('error', err);
+        }
+      });
+
+      const w = new Writable({
+        autoDestroy: true,
+        destroy(err, cb) {
+          rDestroyed.resolve(err);
+          cb();
+        }
+      });
+
+      r.pipe(w);
+
+      const check = await rDestroyed.promise;
+      strictEqual(check, err);
+    }
+  }
+};
+
+export const awaitDrainWritersInSyncRecursionWrite = {
+  async test(ctrl, env, ctx) {
+
+    const encode = new PassThrough({
+      highWaterMark: 1
+    });
+
+    const decode = new PassThrough({
+      highWaterMark: 1
+    });
+
+    const send = countedDeferred(4, (buf) => {
+      encode.write(buf);
+    });
+
+    let i = 0;
+    const onData = () => {
+      if (++i === 2) {
+        send.resolve(Buffer.from([0x3]));
+        send.resolve(Buffer.from([0x4]));
+      }
+    };
+
+    encode.pipe(decode).on('data', onData);
+
+    send.resolve(Buffer.from([0x1]));
+    send.resolve(Buffer.from([0x2]));
+
+    await send.promise;
+
+  }
+};
+
+export const backpressure = {
+  async test(ctrl, env, ctx) {
+    let pushes = 0;
+    const total = 65500 + 40 * 1024;
+    let reads = 0;
+    let writes = 0;
+    const rs = new Readable({
+      read() {
+        if (++reads > 11) throw new Error('incorrect number of reads');
+        if (pushes++ === 10) {
+          this.push(null);
+          return;
+        }
+
+        const length = this._readableState.length;
+
+        // We are at most doing two full runs of _reads
+        // before stopping, because Readable is greedy
+        // to keep its buffer full
+        ok(length <= total);
+
+        this.push(Buffer.alloc(65500));
+        for (let i = 0; i < 40; i++) {
+          this.push(Buffer.alloc(1024));
+        }
+
+        // We will be over highWaterMark at this point
+        // but a new call to _read is scheduled anyway.
+      }
+    });
+
+    const closed = deferredPromise();
+
+    const ws = Writable({
+      write(data, enc, cb) {
+        queueMicrotask(cb);
+        if (++writes === 410) closed.resolve();
+      }
+    });
+
+    rs.pipe(ws);
+
+    await closed.promise;
+  }
+};
+
+export const bigPacket = {
+  async test(ctrl, env, ctx) {
+    const rPassed = deferredPromise();
+
+    class TestStream extends Transform {
+      _transform(chunk, encoding, done) {
+        // Char 'a' only exists in the last write
+        if (chunk.includes('a'))
+          rPassed.resolve();
+        done();
+      }
+    }
+
+    const s1 = new Transform({
+      transform(chunk, encoding, cb) {
+        queueMicrotask(() => cb(null, chunk));
+      }
+    });
+    const s2 = new PassThrough();
+    const s3 = new TestStream();
+    s1.pipe(s3);
+    // Don't let s2 auto close which may close s3
+    s2.pipe(s3, { end: false });
+
+    // We must write a buffer larger than highWaterMark
+    const big = Buffer.alloc(s1.writableHighWaterMark + 1, 'x');
+
+    // Since big is larger than highWaterMark, it will be buffered internally.
+    ok(!s1.write(big));
+    // 'tiny' is small enough to pass through internal buffer.
+    ok(s2.write('tiny'));
+
+    // Write some small data in next IO loop, which will never be written to s3
+    // Because 'drain' event is not emitted from s1 and s1 is still paused
+    queueMicrotask(() => s1.write('later'));
+
+    await rPassed.promise;
+  }
+};
+
+export const bigPush = {
+  async test(ctrl, env, ctx) {
+    const str = 'asdfasdfasdfasdfasdf';
+
+    const r = new Readable({
+      highWaterMark: 5,
+      encoding: 'utf8'
+    });
+
+    let reads = 0;
+
+    function _read() {
+      if (reads === 0) {
+        setTimeout(() => {
+          r.push(str);
+        }, 1);
+        reads++;
+      } else if (reads === 1) {
+        const ret = r.push(str);
+        strictEqual(ret, false);
+        reads++;
+      } else {
+        r.push(null);
+      }
+    }
+
+    const read = countedDeferred(3, _read);
+    const ended = deferredPromise();
+
+    r._read = read.resolve;
+    r.on('end', ended.resolve);
+
+    // Push some data in to start.
+    // We've never gotten any read event at this point.
+    const ret = r.push(str);
+    // Should be false.  > hwm
+    ok(!ret);
+    let chunk = r.read();
+    strictEqual(chunk, str);
+    chunk = r.read();
+    strictEqual(chunk, null);
+
+    r.once('readable', () => {
+      // This time, we'll get *all* the remaining data, because
+      // it's been added synchronously, as the read WOULD take
+      // us below the hwm, and so it triggered a _read() again,
+      // which synchronously added more, which we then return.
+      chunk = r.read();
+      strictEqual(chunk, str + str);
+
+      chunk = r.read();
+      strictEqual(chunk, null);
+    });
+
+    await Promise.all([
+      read.promise,
+      ended.promise,
+    ]);
+  }
+};
+
+export const catchRejections = {
+  async test(ctrl, env, ctx) {
+    {
+      const rErrored = deferredPromise();
+
+      const r = new Readable({
+        captureRejections: true,
+        read() {
+        }
+      });
+      r.push('hello');
+      r.push('world');
+
+      const err = new Error('kaboom');
+
+      r.on('error', (_err) => {
+        strictEqual(err, _err);
+        strictEqual(r.destroyed, true);
+        rErrored.resolve();
+      });
+
+      r.on('data', async () => {
+        throw err;
+      });
+
+      await rErrored.promise;
+    }
+
+    {
+      const wErrored = deferredPromise();
+
+      const w = new Writable({
+        captureRejections: true,
+        highWaterMark: 1,
+        write(chunk, enc, cb) {
+          queueMicrotask(cb);
+        }
+      });
+
+      const err = new Error('kaboom');
+
+      w.write('hello', () => {
+        w.write('world');
+      });
+
+      w.on('error', (_err) => {
+        strictEqual(err, _err);
+        strictEqual(w.destroyed, true);
+        wErrored.resolve();
+      });
+
+      w.on('drain', async () => {
+        throw err;
+      });
+
+      await wErrored.promise;
+    }
+  }
+};
+
+export const construct = {
+  async test(ctrl, env, ctx) {
+    {
+      const errored = deferredPromise();
+      // Multiple callback.
+      new Writable({
+        construct: (callback) => {
+          callback();
+          callback();
+        }
+      }).on('error', (err) => {
+        errored.resolve(err);
+      });
+
+      const check = await errored.promise;
+      strictEqual(check.message, 'Callback called multiple times');
+    }
+
+    {
+      const errored = deferredPromise();
+      // Multiple callback.
+      new Readable({
+        construct: (callback) => {
+          callback();
+          callback();
+        }
+      }).on('error', (err) => {
+        errored.resolve(err);
+      });
+
+      const check = await errored.promise;
+      strictEqual(check.message, 'Callback called multiple times');
+    }
+
+    {
+      // Synchronous error.
+      const errored = deferredPromise();
+      const err = new Error('test');
+      new Writable({
+        construct: (callback) => {
+          callback(err);
+        }
+      }).on('error', (err) => {
+        errored.resolve(err);
+      });
+
+      const check = await errored.promise;
+      strictEqual(check, err);
+    }
+
+    {
+      const errored = deferredPromise();
+      const err = new Error('test');
+
+      new Readable({
+        construct: (callback) => {
+          callback(err);
+        }
+      }).on('error', (err) => {
+        errored.resolve(err);
+      });
+
+      const check = await errored.promise;
+      strictEqual(check, err);
+    }
+
+    {
+      // Asynchronous error.
+      const errored = deferredPromise();
+      const err = new Error('test');
+
+      new Writable({
+        construct: (callback) => {
+          queueMicrotask(() => callback(err));
+        }
+      }).on('error', (err) => {
+        errored.resolve(err);
+      });
+
+      const check = await errored.promise;
+      strictEqual(check, err);
+    }
+
+    {
+      // Asynchronous error.
+      const errored = deferredPromise();
+      const err = new Error('test');
+
+      new Readable({
+        construct: (callback) => {
+          queueMicrotask(() => callback(err));
+        }
+      }).on('error', errored.resolve);
+
+      const check = await errored.promise;
+      strictEqual(check, err);
+    }
+
+    async function testDestroy(factory) {
+      {
+        const constructed = deferredPromise();
+        const closed = deferredPromise();
+        const s = factory({
+          construct: (cb) => {
+            constructed.resolve();
+            queueMicrotask(cb);
+          }
+        });
+        s.on('close', closed.resolve);
+        s.destroy();
+        await Promise.all([
+          constructed.promise,
+          closed.promise,
+        ]);
+      }
+
+      {
+        const constructed = deferredPromise();
+        const closed = deferredPromise();
+        const destroyed = deferredPromise();
+        const s = factory({
+          construct: (cb) => {
+            constructed.resolve();
+            queueMicrotask(cb);
+          }
+        });
+        s.on('close', closed.resolve);
+        s.destroy(null, () => {
+          destroyed.resolve();
+        });
+
+        await Promise.all([
+          constructed.promise,
+          closed.promise,
+          destroyed.promise,
+        ]);
+      }
+
+      {
+        const constructed = deferredPromise();
+        const closed = deferredPromise();
+        const s = factory({
+          construct: (cb) => {
+            constructed.resolve();
+            queueMicrotask(cb);
+          }
+        });
+        s.on('close', closed.resolve);
+        s.destroy();
+        await Promise.all([
+          constructed.promise,
+          closed.promise,
+        ]);
+      }
+
+
+      {
+        const constructed = deferredPromise();
+        const closed = deferredPromise();
+        const errored = deferredPromise();
+
+        const s = factory({
+          construct: (cb) => {
+            constructed.resolve();
+            queueMicrotask(cb);
+          }
+        });
+        s.on('close', closed.resolve);
+        s.on('error', (err) => {
+          strictEqual(err.message, 'kaboom');
+          errored.resolve();
+        });
+        s.destroy(new Error('kaboom'), (err) => {
+          strictEqual(err.message, 'kaboom');
+        });
+        await Promise.all([
+          constructed.promise,
+          closed.promise,
+          errored.promise,
+        ]);
+      }
+
+      {
+        const constructed = deferredPromise();
+        const errored = deferredPromise();
+        const closed = deferredPromise();
+        const s = factory({
+          construct: (cb) => {
+            constructed.resolve();
+            queueMicrotask(cb);
+          }
+        });
+        s.on('error', errored.resolve);
+        s.on('close', closed.resolve);
+        s.destroy(new Error());
+
+        await Promise.all([
+          constructed.promise,
+          closed.promise,
+          errored.promise,
+        ]);
+      }
+    }
+    await testDestroy((opts) => new Readable({
+      read: () => { throw new Error("must not call"); },
+      ...opts
+    }));
+    await testDestroy((opts) => new Writable({
+      write: () => { throw new Error("must not call"); },
+      final: () => { throw new Error("must not call"); },
+      ...opts
+    }));
+
+    {
+      const constructed = deferredPromise();
+      const read = deferredPromise();
+      const closed = deferredPromise();
+
+      const r = new Readable({
+        autoDestroy: true,
+        construct: (cb) => {
+          constructed.resolve();
+          queueMicrotask(cb);
+        },
+        read: () => {
+          r.push(null);
+          read.resolve();
+        }
+      });
+      r.on('close', closed.resolve);
+      r.on('data', () => { throw new Error('should not call'); });
+
+      await Promise.all([
+        constructed.promise,
+        read.promise,
+        closed.promise,
+      ]);
+    }
+
+    {
+      const constructed = deferredPromise();
+      const write = deferredPromise();
+      const final = deferredPromise();
+      const closed = deferredPromise();
+
+      const w = new Writable({
+        autoDestroy: true,
+        construct: (cb) => {
+          constructed.resolve();
+          queueMicrotask(cb);
+        },
+        write: (chunk, encoding, cb) => {
+          write.resolve();
+          queueMicrotask(cb);
+        },
+        final: (cb) => {
+          final.resolve();
+          queueMicrotask(cb);
+        }
+      });
+      w.on('close', closed.resolve);
+      w.end('data');
+
+      await Promise.all([
+        constructed.promise,
+        write.promise,
+        final.promise,
+        closed.promise,
+      ]);
+    }
+
+    {
+      const constructed = deferredPromise();
+      const final = deferredPromise();
+      const closed = deferredPromise();
+      const w = new Writable({
+        autoDestroy: true,
+        construct: (cb) => {
+          constructed.resolve();
+          queueMicrotask(cb);
+        },
+        write: () => { throw new Error('should not call'); },
+        final: (cb) => {
+          final.resolve();
+          queueMicrotask(cb);
+        }
+      });
+      w.on('close', closed.resolve);
+      w.end();
+
+      await Promise.all([
+        constructed.promise,
+        final.promise,
+        closed.promise,
+      ]);
+    }
+
+    {
+      let constructed = true;
+      new Duplex({
+        construct() {
+          constructed = true;
+        }
+      });
+      ok(constructed);
+    }
+
+    {
+      // https://github.com/nodejs/node/issues/34448
+
+      const constructed = deferredPromise();
+      const closed = deferredPromise();
+      const d = new Duplex({
+        readable: false,
+        construct: (callback) => {
+          queueMicrotask(() => {
+            constructed.resolve();
+            callback();
+          });
+        },
+        write(chunk, encoding, callback) {
+          callback();
+        },
+        read() {
+          this.push(null);
+        }
+      });
+      d.resume();
+      d.end('foo');
+      d.on('close', closed.resolve);
+
+      await Promise.all([
+        constructed.promise,
+        closed.promise,
+      ]);
+    }
+
+    {
+      // Construct should not cause stream to read.
+      new Readable({
+        construct: (callback) => {
+          callback();
+        },
+        read() {
+          throw new Error('should not call');
+        }
+      });
+    }
+  }
+};
+
+export const decoderObjectMode = {
+  test(ctrl, env, ctx) {
+    const readable = new Readable({
+      read: () => {},
+      encoding: 'utf16le',
+      objectMode: true
+    });
+
+    readable.push(Buffer.from('abc', 'utf16le'));
+    readable.push(Buffer.from('def', 'utf16le'));
+    readable.push(null);
+
+    // Without object mode, these would be concatenated into a single chunk.
+    strictEqual(readable.read(), 'abc');
+    strictEqual(readable.read(), 'def');
+    strictEqual(readable.read(), null);
+  }
+};
+
+export const destroyEventOrder = {
+  async test(ctrl, env, ctx) {
+    const destroyed = deferredPromise();
+    const events = [];
+    const rs = new Readable({
+      read() {}
+    });
+
+    let closed = false;
+    let errored = false;
+
+    rs.on('close', () => events.push('close'));
+
+    rs.on('error', (err) => events.push('errored'));
+
+    rs.destroy(new Error('kaboom'), () => {
+      strictEqual(events, ['errored', 'close']);
+      destroyed.resolve();
+    });
+
+    await destroyed;
+  }
+};
+
+export const destroyTests = {
+  async test(ctrl, env, ctx) {
+    {
+      const errored = deferredPromise();
+      const closed = deferredPromise();
+      const r = new Readable({ read() {} });
+      destroy(r);
+      strictEqual(r.destroyed, true);
+      r.on('error', errored.resolve);
+      r.on('close', closed.resolve);
+      const check = await errored.promise;
+      strictEqual(check.name, 'AbortError');
+      await closed.promise;
+    }
+
+    {
+      const errored = deferredPromise();
+      const closed = deferredPromise();
+      const err = new Error('asd');
+      const r = new Readable({ read() {} });
+      destroy(r, err);
+      strictEqual(r.destroyed, true);
+      r.on('error', errored.resolve);
+      r.on('close', closed.resolve);
+      const check = await errored.promise;
+      strictEqual(check, err);
+      await closed.promise;
+    }
+
+    {
+      const errored = deferredPromise();
+      const closed = deferredPromise();
+      const w = new Writable({ write() {} });
+      destroy(w);
+      strictEqual(w.destroyed, true);
+      w.on('error', errored.resolve);
+      w.on('close', closed.resolve);
+      const check = await errored.promise;
+      strictEqual(check.name, 'AbortError');
+      await closed.promise;
+    }
+
+    {
+      const errored = deferredPromise();
+      const closed = deferredPromise();
+      const err = new Error('asd');
+      const w = new Writable({ write() {} });
+      destroy(w, err);
+      strictEqual(w.destroyed, true);
+      w.on('error', errored.resolve);
+      w.on('close', closed.resolve);
+      const check = await errored.promise;
+      strictEqual(check, err);
+      await closed.promise;
+    }
+  }
+};
+
+export const duplexDestroy = {
+  async test(ctrl, env, ctx) {
+    {
+      const closed = deferredPromise();
+
+      const duplex = new Duplex({
+        write(chunk, enc, cb) { cb(); },
+        read() {}
+      });
+
+      duplex.resume();
+
+      duplex.on('end', () => { throw new Error('should not call') });
+      duplex.on('finish', () => { throw new Error('should not call') });
+      duplex.on('close', closed.resolve);
+
+      duplex.destroy();
+      strictEqual(duplex.destroyed, true);
+      await closed.promise;
+    }
+
+    {
+      const errored = deferredPromise();
+      const closed = deferredPromise();
+      const duplex = new Duplex({
+        write(chunk, enc, cb) { cb(); },
+        read() {}
+      });
+      duplex.resume();
+
+      const expected = new Error('kaboom');
+
+      duplex.on('end', closed.reject);
+      duplex.on('finish', closed.reject);
+      duplex.on('close', closed.resolve);
+      duplex.on('error', errored.resolve);
+
+      duplex.destroy(expected);
+      strictEqual(duplex.destroyed, true);
+      const check = await errored.promise;
+      strictEqual(check, expected);
+      await closed.promise;
+    }
+
+    {
+      const errored = deferredPromise();
+      const destroyCalled = deferredPromise();
+      const duplex = new Duplex({
+        write(chunk, enc, cb) { cb(); },
+        read() {}
+      });
+
+      const expected = new Error('kaboom');
+
+      duplex._destroy = function(err, cb) {
+        strictEqual(err, expected);
+        cb(err);
+        destroyCalled.resolve();
+      };
+
+      duplex.on('finish', errored.reject);
+      duplex.on('error', errored.resolve);
+
+      duplex.destroy(expected);
+      strictEqual(duplex.destroyed, true);
+      const check = await errored.promise;
+      strictEqual(check, expected);
+      await destroyCalled.promise;
+    }
+
+    {
+      const closed = deferredPromise();
+      const destroyCalled = deferredPromise();
+      const expected = new Error('kaboom');
+      const duplex = new Duplex({
+        write(chunk, enc, cb) { cb(); },
+        read() {},
+        destroy: function(err, cb) {
+          strictEqual(err, expected);
+          cb();
+          destroyCalled.resolve();
+        }
+      });
+      duplex.resume();
+
+      duplex.on('end', closed.reject);
+      duplex.on('finish', closed.reject);
+
+      // Error is swallowed by the custom _destroy
+      duplex.on('error', closed.reject);
+      duplex.on('close', closed.resolve);
+
+      duplex.destroy(expected);
+      strictEqual(duplex.destroyed, true);
+      await Promise.all([
+        closed.promise,
+        destroyCalled.promise,
+      ]);
+    }
+
+    {
+      const destroyCalled = deferredPromise();
+      const duplex = new Duplex({
+        write(chunk, enc, cb) { cb(); },
+        read() {}
+      });
+
+      duplex._destroy = function(err, cb) {
+        strictEqual(err, null);
+        cb();
+        destroyCalled.resolve();
+      };
+
+      duplex.destroy();
+      strictEqual(duplex.destroyed, true);
+      await destroyCalled.promise;
+    }
+
+    {
+      const destroyCalled = deferredPromise();
+      const closed = deferredPromise();
+      const duplex = new Duplex({
+        write(chunk, enc, cb) { cb(); },
+        read() {}
+      });
+      duplex.resume();
+
+      duplex._destroy = function(err, cb) {
+        strictEqual(err, null);
+        queueMicrotask(() => {
+          this.push(null);
+          this.end();
+          cb();
+          destroyCalled.resolve();
+        });
+      };
+
+      const fail = closed.reject;
+
+      duplex.on('finish', fail);
+      duplex.on('end', fail);
+
+      duplex.destroy();
+
+      duplex.removeListener('end', fail);
+      duplex.removeListener('finish', fail);
+      duplex.on('end', fail);
+      duplex.on('finish', fail);
+      duplex.on('close', closed.resolve);
+      strictEqual(duplex.destroyed, true);
+      await Promise.all([
+        closed.promise,
+        destroyCalled.promise,
+      ]);
+    }
+
+    {
+      const destroyCalled = deferredPromise();
+      const errored = deferredPromise();
+      const duplex = new Duplex({
+        write(chunk, enc, cb) { cb(); },
+        read() {}
+      });
+
+      const expected = new Error('kaboom');
+
+      duplex._destroy = function(err, cb) {
+        strictEqual(err, null);
+        cb(expected);
+        destroyCalled.resolve();
+      };
+
+      duplex.on('error', errored.resolve);
+
+      duplex.destroy();
+      strictEqual(duplex.destroyed, true);
+      const check = await errored.promise;
+      strictEqual(check, expected);
+      await destroyCalled.promise;
+    }
+
+    {
+      const closed = deferredPromise();
+      const duplex = new Duplex({
+        write(chunk, enc, cb) { cb(); },
+        read() {},
+        allowHalfOpen: true
+      });
+      duplex.resume();
+
+      duplex.on('finish', closed.reject);
+      duplex.on('end', closed.reject);
+      duplex.on('close', closed.resolve);
+
+      duplex.destroy();
+      strictEqual(duplex.destroyed, true);
+      await closed.promise;
+    }
+
+    {
+      const closed = deferredPromise();
+      const duplex = new Duplex({
+        write(chunk, enc, cb) { cb(); },
+        read() {},
+        destroy() {
+          throw new Error('should not be called');
+        },
+      });
+
+      duplex.destroyed = true;
+      strictEqual(duplex.destroyed, true);
+
+      duplex.destroy();
+    }
+
+    {
+      function MyDuplex() {
+        strictEqual(this.destroyed, false);
+        this.destroyed = false;
+        Duplex.call(this);
+      }
+
+      Object.setPrototypeOf(MyDuplex.prototype, Duplex.prototype);
+      Object.setPrototypeOf(MyDuplex, Duplex);
+
+      new MyDuplex();
+    }
+
+    {
+      const closed = deferredPromise();
+      const duplex = new Duplex({
+        writable: false,
+        autoDestroy: true,
+        write(chunk, enc, cb) { cb(); },
+        read() {},
+      });
+      duplex.push(null);
+      duplex.resume();
+      duplex.on('close', closed.resolve);
+      await closed.promise;
+    }
+
+    {
+      const closed = deferredPromise();
+      const duplex = new Duplex({
+        readable: false,
+        autoDestroy: true,
+        write(chunk, enc, cb) { cb(); },
+        read() {},
+      });
+      duplex.end();
+      duplex.on('close', closed.resolve);
+      await closed.promise;
+    }
+
+    {
+      const closed = deferredPromise();
+      const duplex = new Duplex({
+        allowHalfOpen: false,
+        autoDestroy: true,
+        write(chunk, enc, cb) { cb(); },
+        read() {},
+      });
+      duplex.push(null);
+      duplex.resume();
+      const orgEnd = duplex.end;
+      duplex.end = closed.reject;
+      duplex.on('end', () => {
+        // Ensure end() is called in next tick to allow
+        // any pending writes to be invoked first.
+        queueMicrotask(() => {
+          duplex.end = orgEnd;
+        });
+      });
+      duplex.on('close', closed.resolve);
+      await closed.promise;
+    }
+
+    {
+      // Check abort signal
+      const closed = deferredPromise();
+      const errored = deferredPromise();
+      const controller = new AbortController();
+      const { signal } = controller;
+      const duplex = new Duplex({
+        write(chunk, enc, cb) { cb(); },
+        read() {},
+        signal,
+      });
+      let count = 0;
+      duplex.on('error', (e) => {
+        strictEqual(count++, 0); // Ensure not called twice
+        strictEqual(e.name, 'AbortError');
+        errored.resolve();
+      });
+      duplex.on('close', closed.resolve);
+      controller.abort();
+      await Promise.all([
+        errored.promise,
+        closed.promise,
+      ]);
+    }
+  }
+};
+
+export const duplexEnd = {
+  async test(ctrl, env, ctx) {
+    {
+      const stream = new Duplex({
+        read() {}
+      });
+      strictEqual(stream.allowHalfOpen, true);
+      stream.on('finish', () => {
+        throw new Error('should not have been called');
+      });
+      strictEqual(stream.listenerCount('end'), 0);
+      stream.resume();
+      stream.push(null);
+    }
+
+    {
+      const finishedCalled = deferredPromise();
+      const stream = new Duplex({
+        read() {},
+        allowHalfOpen: false
+      });
+      strictEqual(stream.allowHalfOpen, false);
+      stream.on('finish', finishedCalled.resolve);
+      strictEqual(stream.listenerCount('end'), 0);
+      stream.resume();
+      stream.push(null);
+      await finishedCalled.promise;
+    }
+
+    {
+      const stream = new Duplex({
+        read() {},
+        allowHalfOpen: false
+      });
+      strictEqual(stream.allowHalfOpen, false);
+      stream._writableState.ended = true;
+      stream.on('finish', () => {
+        throw new Error('Should not have been called');
+      });
+      strictEqual(stream.listenerCount('end'), 0);
+      stream.resume();
+      stream.push(null);
+    }
+  }
+};
+
+export const duplexProps = {
+  test(ctrl, env, ctx) {
+    {
+      const d = new Duplex({
+        objectMode: true,
+        highWaterMark: 100
+      });
+
+      strictEqual(d.writableObjectMode, true);
+      strictEqual(d.writableHighWaterMark, 100);
+      strictEqual(d.readableObjectMode, true);
+      strictEqual(d.readableHighWaterMark, 100);
+    }
+
+    {
+      const d = new Duplex({
+        readableObjectMode: false,
+        readableHighWaterMark: 10,
+        writableObjectMode: true,
+        writableHighWaterMark: 100
+      });
+
+      strictEqual(d.writableObjectMode, true);
+      strictEqual(d.writableHighWaterMark, 100);
+      strictEqual(d.readableObjectMode, false);
+      strictEqual(d.readableHighWaterMark, 10);
+    }
+
+  }
+};
+
+export const duplexReadableEnd = {
+  async test(ctrl, env, ctx) {
+    const ended = deferredPromise();
+    let loops = 5;
+
+    const src = new Readable({
+      read() {
+        if (loops--)
+          this.push(Buffer.alloc(20000));
+      }
+    });
+
+    const dst = new Transform({
+      transform(chunk, output, fn) {
+        this.push(null);
+        fn();
+      }
+    });
+
+    src.pipe(dst);
+
+    dst.on('data', () => { });
+    dst.on('end', () => {
+      strictEqual(loops, 3);
+      ok(src.isPaused());
+      ended.resolve();
+    });
+
+    await ended.promise;
+  }
+};
+
+export const duplexReadableWritable = {
+  async test(ctrl, env, ctx) {
+    {
+      const errored = deferredPromise();
+      const duplex = new Duplex({
+        readable: false
+      });
+      strictEqual(duplex.readable, false);
+      duplex.push('asd');
+      duplex.on('error', (err) => {
+        strictEqual(err.code, 'ERR_STREAM_PUSH_AFTER_EOF');
+        errored.resolve();
+      });
+      duplex.on('data', errored.reject);
+      duplex.on('end', errored.reject);
+      await errored.promise;
+    }
+
+    {
+      const closed = deferredPromise();
+      const errored = deferredPromise();
+      const duplex = new Duplex({
+        writable: false,
+        write: closed.reject,
+      });
+      strictEqual(duplex.writable, false);
+      duplex.write('asd');
+      duplex.on('error', (err) => {
+        strictEqual(err.code, 'ERR_STREAM_WRITE_AFTER_END');
+        errored.resolve();
+      });
+      duplex.on('finish', closed.reject);
+      duplex.on('close', closed.resolve);
+      await Promise.all([
+        closed.promise,
+        errored.promise,
+      ]);
+    }
+
+    {
+      const closed = deferredPromise();
+      const duplex = new Duplex({
+        readable: false
+      });
+      strictEqual(duplex.readable, false);
+      duplex.on('data', closed.reject);
+      duplex.on('end', closed.reject);
+      duplex.on('close', closed.resolve);
+      async function run() {
+        for await (const chunk of duplex) {
+          assert(false, chunk);
+        }
+      }
+      await Promise.all([
+        run(),
+        closed.promise,
+      ]);
+    }
+  }
+};
+
+export const duplexWritableFinished = {
+  async test(ctrl, env, ctx) {
+    {
+      // Find it on Duplex.prototype
+      ok(Object.hasOwn(Duplex.prototype, 'writableFinished'));
+    }
+
+    // event
+    {
+      const finishedCalled = deferredPromise();
+      const ended = deferredPromise();
+      const duplex = new Duplex();
+
+      duplex._write = (chunk, encoding, cb) => {
+        // The state finished should start in false.
+        strictEqual(duplex.writableFinished, false);
+        cb();
+      };
+
+      duplex.on('finish', () => {
+        strictEqual(duplex.writableFinished, true);
+        finishedCalled.resolve();
+      });
+
+      duplex.end('testing finished state', () => {
+        strictEqual(duplex.writableFinished, true);
+        ended.resolve();
+      });
+
+      await Promise.all([
+        finishedCalled.promise,
+        ended.promise,
+      ]);
+    }
+  }
+}
+
+export const duplex = {
+  async test(ctrl, env, ctx) {
+    const stream = new Duplex({ objectMode: true });
+
+    ok(Duplex() instanceof Duplex);
+    ok(stream._readableState.objectMode);
+    ok(stream._writableState.objectMode);
+    ok(stream.allowHalfOpen);
+    strictEqual(stream.listenerCount('end'), 0);
+
+    let written;
+    let read;
+
+    stream._write = (obj, _, cb) => {
+      written = obj;
+      cb();
+    };
+
+    stream._read = () => {};
+
+    stream.on('data', (obj) => {
+      read = obj;
+    });
+
+    stream.push({ val: 1 });
+    stream.end({ val: 2 });
+
+    // We have no equivalent for on('exit') ... should we?
+    // process.on('exit', () => {
+    //   assert.strictEqual(read.val, 1);
+    //   assert.strictEqual(written.val, 2);
+    // });
+
+    // TODO(later): We do not yet implement fromWeb/toWeb
+    // // Duplex.fromWeb
+    // {
+    //   const dataToRead = Buffer.from('hello');
+    //   const dataToWrite = Buffer.from('world');
+
+    //   const readable = new ReadableStream({
+    //     start(controller) {
+    //       controller.enqueue(dataToRead);
+    //     },
+    //   });
+
+    //   const writable = new WritableStream({
+    //     write: common.mustCall((chunk) => {
+    //       assert.strictEqual(chunk, dataToWrite);
+    //     })
+    //   });
+
+    //   const pair = { readable, writable };
+    //   const duplex = Duplex.fromWeb(pair);
+
+    //   duplex.write(dataToWrite);
+    //   duplex.once('data', common.mustCall((chunk) => {
+    //     assert.strictEqual(chunk, dataToRead);
+    //   }));
+    // }
+    //
+    // // Duplex.fromWeb - using utf8 and objectMode
+    // {
+    //   const dataToRead = 'hello';
+    //   const dataToWrite = 'world';
+
+    //   const readable = new ReadableStream({
+    //     start(controller) {
+    //       controller.enqueue(dataToRead);
+    //     },
+    //   });
+
+    //   const writable = new WritableStream({
+    //     write: common.mustCall((chunk) => {
+    //       assert.strictEqual(chunk, dataToWrite);
+    //     })
+    //   });
+
+    //   const pair = {
+    //     readable,
+    //     writable
+    //   };
+    //   const duplex = Duplex.fromWeb(pair, { encoding: 'utf8', objectMode: true });
+
+    //   duplex.write(dataToWrite);
+    //   duplex.once('data', common.mustCall((chunk) => {
+    //     assert.strictEqual(chunk, dataToRead);
+    //   }));
+    // }
+
+    // // Duplex.toWeb
+    // {
+    //   const dataToRead = Buffer.from('hello');
+    //   const dataToWrite = Buffer.from('world');
+
+    //   const duplex = Duplex({
+    //     read() {
+    //       this.push(dataToRead);
+    //       this.push(null);
+    //     },
+    //     write: common.mustCall((chunk) => {
+    //       assert.strictEqual(chunk, dataToWrite);
+    //     })
+    //   });
+
+    //   const { writable, readable } = Duplex.toWeb(duplex);
+    //   writable.getWriter().write(dataToWrite);
+
+    //   readable.getReader().read().then(common.mustCall((result) => {
+    //     assert.deepStrictEqual(Buffer.from(result.value), dataToRead);
+    //   }));
+    // }
+  }
+};
+
+export const end_of_streams = {
+  async test(ctrl, env, ctx) {
+    throws(
+      () => {
+        // Passing empty object to mock invalid stream
+        // should throw error
+        finished({}, () => {});
+      },
+      { code: 'ERR_INVALID_ARG_TYPE' }
+    );
+
+    const streamObj = new Duplex();
+    streamObj.end();
+    // Below code should not throw any errors as the
+    // streamObj is `Stream`
+    finished(streamObj, () => {});
+  }
+};
+
+export const end_paused = {
+  async test(ctrl, env, ctx) {
+    const calledRead = deferredPromise();
+    const ended = deferredPromise();
+    const stream = new Readable();
+    stream._read = function() {
+      this.push(null);
+      calledRead.resolve();
+    };
+
+    stream.on('data', ended.reject);
+    stream.on('end', ended.resolve);
+    stream.pause();
+
+    setTimeout(function() {
+      stream.resume();
+    });
+
+    await Promise.all([
+      calledRead.promise,
+      ended.promise,
+    ]);
+  }
+};
+
+export const error_once = {
+  async test(ctrl, env, ctx) {
+    {
+      const errored = deferredPromise();
+      const writable = new Writable();
+      writable.on('error', errored.resolve);
+      writable.end();
+      writable.write('h');
+      writable.write('h');
+      await errored.promise;
+    }
+
+    {
+      const errored = deferredPromise();
+      const readable = new Readable();
+      readable.on('error', errored.resolve);
+      readable.push(null);
+      readable.push('h');
+      readable.push('h');
+      await errored.promise;
+    }
+
+  }
+};
+
+export const finishedTest = {
+  async test(ctrl, env, ctx) {
+    const promisify = (await import('node:util')).promisify;
+    {
+      const finishedOk = deferredPromise();
+      const rs = new Readable({
+        read() {}
+      });
+
+      finished(rs, (err) => {
+        if (err == null) finishedOk.resolve();
+        else finishedOk.reject(err);
+      });
+
+      rs.push(null);
+      rs.resume();
+
+      await finishedOk.promise;
+    }
+
+    {
+      const finishedOk = deferredPromise();
+
+      const ws = new Writable({
+        write(data, enc, cb) {
+          cb();
+        }
+      });
+
+      finished(ws, (err) => {
+        if (err == null) finishedOk.resolve();
+        else finishedOk.reject(err);
+      });
+
+      ws.end();
+
+      await finishedOk.promise;
+    }
+
+    {
+      const finishedOk = deferredPromise();
+      const tr = new Transform({
+        transform(data, enc, cb) {
+          cb();
+        }
+      });
+
+      let finish = false;
+      let ended = false;
+
+      tr.on('end', () => {
+        ended = true;
+      });
+
+      tr.on('finish', () => {
+        finish = true;
+      });
+
+      finished(tr, (err) => {
+        ok(finish);
+        ok(ended);
+        if (err == null) finishedOk.resolve();
+        else finishedOk.reject(err);
+      });
+
+      tr.end();
+      tr.resume();
+
+      await finishedOk.promise;
+    }
+
+    {
+      const finishedCalled = deferredPromise();
+      const rs = new Readable({
+        read() {
+          this.push(enc.encode("a"));
+          this.push(enc.encode("b"));
+          this.push(null);
+        }
+      });
+
+      rs.resume();
+      finished(rs, finishedCalled.resolve);
+      await finishedCalled.promise;
+    }
+
+    {
+      const finishedPromise = promisify(finished);
+
+      async function run() {
+        const enc = new TextEncoder();
+        const rs = new Readable({
+          read() {
+            this.push(enc.encode("a"));
+            this.push(enc.encode("b"));
+            this.push(null);
+          }
+        });
+
+        let ended = false;
+        rs.resume();
+        rs.on('end', () => {
+          ended = true;
+        });
+        await finishedPromise(rs);
+        ok(ended);
+      }
+
+      await run();
+    }
+
+    {
+      // Check pre-cancelled
+      const signal = new EventTarget();
+      signal.aborted = true;
+
+      const rs = Readable.from((function* () {})());
+      const errored = deferredPromise();
+      finished(rs, { signal }, errored.resolve);
+      const check = await errored.promise;
+      strictEqual(check.name, 'AbortError');
+    }
+
+    {
+      // Check cancelled before the stream ends sync.
+      const ac = new AbortController();
+      const { signal } = ac;
+
+      const errored = deferredPromise();
+      const rs = Readable.from((function* () {})());
+      finished(rs, { signal }, errored.resolve);
+      ac.abort();
+      const check = await errored.promise;
+      strictEqual(check.name, 'AbortError');
+    }
+
+    {
+      // Check cancelled before the stream ends async.
+      const ac = new AbortController();
+      const { signal } = ac;
+
+      const rs = Readable.from((function* () {})());
+      setTimeout(() => ac.abort(), 1);
+      const errored = deferredPromise();
+      finished(rs, { signal }, errored.resolve);
+      const check = await errored.promise;
+      strictEqual(check.name, 'AbortError');
+    }
+
+    {
+      // Check cancelled after doesn't throw.
+      const ac = new AbortController();
+      const { signal } = ac;
+
+      const rs = Readable.from((function* () {
+        yield 5;
+        queueMicrotask(() => ac.abort());
+      })());
+      rs.resume();
+      const finishedOk = deferredPromise();
+      finished(rs, { signal }, finishedOk.resolve);
+      const check = await finishedOk.promise;
+      strictEqual(check.name, 'AbortError');
+    }
+
+    {
+      // Promisified abort works
+      const finishedPromise = promisify(finished);
+      async function run() {
+        const ac = new AbortController();
+        const { signal } = ac;
+        const rs = Readable.from((function* () {})());
+        queueMicrotask(() => ac.abort());
+        await finishedPromise(rs, { signal });
+      }
+
+      await rejects(run, { name: 'AbortError' });
+    }
+
+    {
+      // Promisified pre-aborted works
+      const finishedPromise = promisify(finished);
+      async function run() {
+        const signal = new EventTarget();
+        signal.aborted = true;
+        const rs = Readable.from((function* () {})());
+        await finishedPromise(rs, { signal });
+      }
+
+      await rejects(run, { name: 'AbortError' });
+    }
+
+    {
+      const rs = new Readable();
+
+      const finishedOk = deferredPromise();
+
+      finished(rs, finishedOk.resolve);
+
+      rs.push(null);
+      rs.emit('close'); // Should not trigger an error
+      rs.resume();
+
+      const check = await finishedOk.promise;
+      ifError(check);
+    }
+
+    {
+      const rs = new Readable();
+      const errored = deferredPromise();
+
+      finished(rs, errored.resolve);
+
+      rs.emit('close'); // Should trigger error
+      rs.push(null);
+      rs.resume();
+
+      const check = await errored.promise;
+      ok(check);
+    }
+
+    // Test faulty input values and options.
+    {
+      const rs = new Readable({
+        read() {}
+      });
+
+      throws(
+        () => finished(rs, 'foo'),
+        {
+          code: 'ERR_INVALID_ARG_TYPE',
+          message: /callback/
+        }
+      );
+      throws(
+        () => finished(rs, 'foo', () => {}),
+        {
+          code: 'ERR_INVALID_ARG_TYPE',
+          message: /options/
+        }
+      );
+      throws(
+        () => finished(rs, {}, 'foo'),
+        {
+          code: 'ERR_INVALID_ARG_TYPE',
+          message: /callback/
+        }
+      );
+
+      const finishedOk = deferredPromise();
+      finished(rs, null, finishedOk.resolve);
+
+      rs.push(null);
+      rs.resume();
+
+      const check = await finishedOk.promise;
+      ifError(check);
+    }
+
+    // Test that calling returned function removes listeners
+    {
+      const ws = new Writable({
+        write(data, env, cb) {
+          cb();
+        }
+      });
+      const removeListener = finished(ws, () => {
+        throw new Error('should not have been called');
+      });
+      removeListener();
+      ws.end();
+    }
+
+    {
+      const rs = new Readable();
+      const removeListeners = finished(rs, () => {
+        throw new Error('should not have been called');
+      });
+      removeListeners();
+
+      rs.emit('close');
+      rs.push(null);
+      rs.resume();
+    }
+
+    {
+      const EventEmitter = (await import("node:events")).EventEmitter;
+      const streamLike = new EventEmitter();
+      streamLike.readableEnded = true;
+      streamLike.readable = true;
+      throws(
+        () => {
+          finished(streamLike, () => {});
+        },
+        { code: 'ERR_INVALID_ARG_TYPE' }
+      );
+      streamLike.emit('close');
+    }
+
+    {
+      const writable = new Writable({ write() {} });
+      writable.writable = false;
+      writable.destroy();
+      const errored = deferredPromise();
+      finished(writable, errored.resolve);
+      const check = await errored.promise;
+      strictEqual(check.code, 'ERR_STREAM_PREMATURE_CLOSE');
+    }
+
+    {
+      const readable = new Readable();
+      readable.readable = false;
+      readable.destroy();
+      const errored = deferredPromise();
+      finished(readable, errored.resolve);
+      const check = await errored.promise;
+      strictEqual(check.code, 'ERR_STREAM_PREMATURE_CLOSE');
+    }
+  }
+};

--- a/src/workerd/api/node/streams-test.wd-test
+++ b/src/workerd/api/node/streams-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "streams-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "streams-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat", "experimental"]
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
While there is still a lot to do here to finish up adding tests, adding the Web streams adapters, and implementing the utility consumers, this PR is already rather large at 7700+ lines changed. It's still gated as experimental so I'll iterate on this to take care of the remaining todos in a separate PR.

Derived from: https://github.com/nodejs/readable-stream

TODO:
* [ ] Tests, Tests, and more Tests
* [ ] Node.js streams <=> Web streams adapters (https://nodejs.org/dist/latest-v19.x/docs/api/stream.html#streamreadabletowebstreamreadable-options)
* [ ] Utility consumers (https://nodejs.org/dist/latest-v19.x/docs/api/webstreams.html#utility-consumers)
* [ ] Documentation
* [x] Samples