### PR TITLE
Polyfill internal process.nextTick for Node.js compat

### DIFF
--- a/src/node/internal/events.ts
+++ b/src/node/internal/events.ts
@@ -41,6 +41,9 @@ import {
   validateFunction,
 } from "node-internal:validators";
 
+
+import * as process from "node-internal:process";
+
 import { spliceOne } from "node-internal:internal_utils";
 
 import { default as async_hooks } from "node-internal:async_hooks";
@@ -234,9 +237,7 @@ function addCatch(that : any, promise : Promise<unknown>, type : string | symbol
       then.call(promise, undefined, function (err) {
         // The callback is called with nextTick to avoid a follow-up
         // rejection from this promise.
-        queueMicrotask(() => {
-          emitUnhandledRejectionOrErr(that, err, type, args);
-        });
+        process.nextTick(emitUnhandledRejectionOrErr, that, err, type, args);
       });
     }
   } catch (err) {

--- a/src/node/internal/process.ts
+++ b/src/node/internal/process.ts
@@ -1,0 +1,14 @@
+// Our implementation of process.nextTick is just queueMicrotask. The timing
+// of when the queue is drained is different, as is the error handling so this
+// is only an approximation of process.nextTick semantics. Hopefully it's good
+// enough because we really do not want to implement Node.js' idea of a nextTick
+// queue.
+/* eslint-disable */
+
+export function nextTick(cb: Function, ...args: unknown[]) {
+  queueMicrotask(() => { cb(...args); });
+};
+
+export default {
+  nextTick,
+};


### PR DESCRIPTION
Provides an "implementation" of process.nextTick intended only for internal module use. The idea here is to make porting of existing Node.js built-ins easier. The polyfill is really just an alias for queueMicrotask, which implements different timing and error handling semantics but should be close enough for it hopefully not to matter.