### PR TITLE
Update compat date in samples, add flags to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,17 @@ const config :Workerd.Config = (
 
 const mainWorker :Workerd.Worker = (
   serviceWorkerScript = embed "hello.js",
-  compatibilityDate = "2022-09-16",
+  
+  # Compatibility dates and flags allow you to
+  # opt-in to backwards-incompatible changes.
+  #
+  # https://developers.cloudflare.com/workers/platform/compatibility-dates/
+  compatibilityDate = "2023-02-28",
+  
+  # The http_headers_getsetcookie flag is enabled by default
+  # as of 2023-03-01, which our compatibility date is older
+  # than, so we can enable it individually.
+  compatibilityFlags = ["http_headers_getsetcookie"],
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -132,17 +132,9 @@ const config :Workerd.Config = (
 
 const mainWorker :Workerd.Worker = (
   serviceWorkerScript = embed "hello.js",
-  
-  # Compatibility dates and flags allow you to
-  # opt-in to backwards-incompatible changes.
-  #
-  # https://developers.cloudflare.com/workers/platform/compatibility-dates/
   compatibilityDate = "2023-02-28",
-  
-  # The http_headers_getsetcookie flag is enabled by default
-  # as of 2023-03-01, which our compatibility date is older
-  # than, so we can enable it individually.
-  compatibilityFlags = ["http_headers_getsetcookie"],
+  # Learn more about compatibility dates at:
+  # https://developers.cloudflare.com/workers/platform/compatibility-dates/
 );
 ```
 

--- a/samples/async-context/config.capnp
+++ b/samples/async-context/config.capnp
@@ -30,6 +30,6 @@ const helloWorld :Workerd.Worker = (
   modules = [
     (name = "worker", esModule = embed "worker.js")
   ],
-  compatibilityDate = "2022-11-08",
+  compatibilityDate = "2023-02-28",
   compatibilityFlags = ["nodejs_compat"]
 );

--- a/samples/durable-objects-chat/config.capnp
+++ b/samples/durable-objects-chat/config.capnp
@@ -18,7 +18,7 @@ const chatWorker :Workerd.Worker = (
   # All Workers must declare a compatibility date, which ensures that if `workerd` is updated to
   # a newer version with breaking changes, it will emulate the API as it existed on this date, so
   # the Worker won't break.
-  compatibilityDate = "2022-09-16",
+  compatibilityDate = "2023-02-28",
 
   # This worker is modules-based.
   modules = [

--- a/samples/helloworld/config.capnp
+++ b/samples/helloworld/config.capnp
@@ -28,5 +28,5 @@ const helloWorldExample :Workerd.Config = (
 
 const helloWorld :Workerd.Worker = (
   serviceWorkerScript = embed "worker.js",
-  compatibilityDate = "2022-09-16",
+  compatibilityDate = "2023-02-28",
 );

--- a/samples/helloworld_esm/config.capnp
+++ b/samples/helloworld_esm/config.capnp
@@ -30,5 +30,5 @@ const helloWorld :Workerd.Worker = (
   modules = [
     (name = "worker", esModule = embed "worker.js")
   ],
-  compatibilityDate = "2022-09-16",
+  compatibilityDate = "2023-02-28",
 );

--- a/samples/nodejs-compat/config.capnp
+++ b/samples/nodejs-compat/config.capnp
@@ -30,6 +30,6 @@ const helloWorld :Workerd.Worker = (
   modules = [
     (name = "worker", esModule = embed "worker.js")
   ],
-  compatibilityDate = "2022-11-08",
+  compatibilityDate = "2023-02-28",
   compatibilityFlags = ["nodejs_compat"]
 );

--- a/samples/static-files-from-disk/config.capnp
+++ b/samples/static-files-from-disk/config.capnp
@@ -31,7 +31,7 @@ const siteWorker :Workerd.Worker = (
   # All Workers must declare a compatibility date, which ensures that if `workerd` is updated to
   # a newer version with breaking changes, it will emulate the API as it existed on this date, so
   # the Worker won't break.
-  compatibilityDate = "2022-09-16",
+  compatibilityDate = "2023-02-28",
 
   # This worker is modules-based.
   modules = [

--- a/samples/tcp/config.capnp
+++ b/samples/tcp/config.capnp
@@ -26,7 +26,7 @@ const gopherWorker :Workerd.Worker = (
   modules = [
     (name = "worker", esModule = embed "gopher.js")
   ],
-  compatibilityDate = "2022-09-26",
+  compatibilityDate = "2023-02-28",
   compatibilityFlags = ["tcp_sockets_support"],
   # In order to access our configured proxy we need to specify it as a binding. This will allow
   # it to be accessible via `env.proxy` in the JS script.

--- a/samples/unit-tests/config.capnp
+++ b/samples/unit-tests/config.capnp
@@ -31,5 +31,5 @@ const testWorker :Workerd.Worker = (
   modules = [
     (name = "worker", esModule = embed "worker.js")
   ],
-  compatibilityDate = "2023-01-15",
+  compatibilityDate = "2023-02-28",
 );


### PR DESCRIPTION
Updated the compatibility date in all the samples & tested they still work - of which they all do other than `nodejs-compat` which throws:

```
service main: Uncaught Error: No such module "node-internal:buffer".
  imported from "node-internal:internal_buffer"
```

However, this is unrelated to the compat date change.

Also added a small example of how compatibility dates & flags work in the sample config from the top-level README.