### PR TITLE
Remove unused `Body` type parameter from `EmailMessage`

### DIFF
--- a/types/defines/email.d.ts
+++ b/types/defines/email.d.ts
@@ -1,7 +1,7 @@
 /**
  * A email message that is sent to a consumer Worker.
  */
-interface EmailMessage<Body = unknown> {
+interface EmailMessage {
   /**
    * Envelope From attribute of the email message.
    */


### PR DESCRIPTION
Very small change to remove unused type parameter from the `EmailMessage` type. This was causing issues when the [`noUnusedParameters`](https://www.typescriptlang.org/tsconfig#noUnusedParameters) option was enabled.

Closes #395