### PR TITLE
Bind Sqlite to JavaScript

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -20,6 +20,7 @@
 #include "scheduled.h"
 #include "blob.h"
 #include "sockets.h"
+#include "sql.h"
 
 namespace workerd::api {
 
@@ -394,6 +395,12 @@ public:
     JSG_NESTED_TYPE(Response);
     JSG_NESTED_TYPE(WebSocket);
     JSG_NESTED_TYPE(WebSocketPair);
+
+    if (flags.getWorkerdExperimental() || true) {
+      JSG_NESTED_TYPE(SqlDatabase);
+      JSG_NESTED_TYPE(SqlPreparedStatement);
+      JSG_NESTED_TYPE(SqlResult);
+    }
 
     JSG_NESTED_TYPE(AbortController);
     JSG_NESTED_TYPE(AbortSignal);

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -1,0 +1,111 @@
+import * as assert from 'node:assert'
+
+function requireException(callback, expectStr) {
+  try {
+    callback();
+  } catch (err) {
+    const errStr = `${err}`;
+    if (!errStr.includes(expectStr)) {
+      throw new Error(`Got unexpected exception '${errStr}', expected: '${expectStr}'`);
+    }
+    return;
+  }
+  throw new Error(`Expected exception '${expectStr}' but none was thrown`);
+}
+
+function test(sql) {
+  // Test numeric results
+  const resultNumber = [...sql.exec("SELECT 123")];
+  assert.equal(resultNumber.length, 1);
+  assert.equal(resultNumber[0]["123"], 123);
+
+  // Test string results
+  const resultStr = [...sql.exec("SELECT 'hello'")];
+  assert.equal(resultStr.length, 1);
+  assert.equal(resultStr[0]["'hello'"], "hello");
+
+  // Test blob results
+  const resultBlob = [...sql.exec("SELECT x'ff'")];
+  assert.equal(resultBlob.length, 1);
+  const blob = resultBlob[0]["x'ff'"];
+  assert.equal(blob.length, 1);
+  assert.equal(blob[0], 255);
+  // Test binding values
+  const resultBinding = [...sql.exec("SELECT ?", {bindValues: [456]})];
+  assert.equal(resultBinding.length, 1);
+  assert.equal(resultBinding[0]["?"], 456);
+
+  // Empty statements
+  requireException(() => sql.exec(""),
+    "SQL code did not contain a statement");
+  requireException(() => sql.exec(";"),
+    "SQL code did not contain a statement");
+
+  // Invalid statements
+  requireException(() => sql.exec("SELECT ;"),
+    "syntax error");
+
+  // Incorrect number of binding values
+  requireException(() => sql.exec("SELECT ?"),
+    "wrong number of bindings for SQLite query");
+
+  // Prepared statement
+  const prepared = sql.prepare("SELECT 789");
+  const resultPrepared = [...prepared()];
+  assert.equal(resultPrepared.length, 1);
+  assert.equal(resultPrepared[0]["789"], 789);
+
+  // Prepared statement with binding values
+  const preparedWithBinding = sql.prepare("SELECT ?");
+  const resultPreparedWithBinding = [...preparedWithBinding({bindValues: [789]})];
+  assert.equal(resultPreparedWithBinding.length, 1);
+  assert.equal(resultPreparedWithBinding[0]["?"], 789);
+
+  // Prepared statement (incorrect number of binding values)
+  requireException(() => preparedWithBinding({bindValues: []}),
+    "wrong number of bindings for SQLite query");
+
+  // Create and access hidden _cf_ table as admin
+  sql.exec("CREATE TABLE _cf_test (name TEXT)", {admin: true});
+  sql.exec("SELECT * FROM _cf_test", {admin: true});
+
+  // Accessing a hidden _cf_ table
+  requireException(() => sql.exec("CREATE TABLE _cf_invalid (name TEXT)"),
+    "not authorized");
+  requireException(() => sql.exec("SELECT * FROM _cf_test"),
+    "access to _cf_test.name is prohibited");
+
+  // Accessing pragmas without and withn admin
+  requireException(() => sql.exec("PRAGMA hard_heap_limit = 1024"),
+    "not authorized");
+  sql.exec("PRAGMA hard_heap_limit = 1024", {admin: true});
+
+  // Transactions without and withn admin
+  requireException(() => sql.exec("BEGIN TRANSACTION; END TRANSACTION"),
+    "not authorized");
+  sql.exec("BEGIN TRANSACTION; END TRANSACTION", {admin: true});
+}
+
+export class DurableObjectExample {
+  constructor(state, env) {
+    this.state = state;
+  }
+
+  async fetch() {
+    test(this.state.storage.sql);
+    return new Response();
+  }
+}
+
+export default {
+  async fetch(request, env) {
+    return await handleRequest(request, env);
+  }
+}
+
+async function handleRequest(request, env) {
+  let id = env.DurableObjectExample.idFromName("A");
+  let obj = env.DurableObjectExample.get(id);
+  await obj.fetch(request.url);
+  return new Response();
+}

--- a/src/workerd/api/sql-test.wd-test
+++ b/src/workerd/api/sql-test.wd-test
@@ -1,0 +1,43 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (name = "main", worker = .mainWorker),
+    ( name = "my-disk",
+      disk = (
+        path = "/tmp/do-storage",
+        writable = true,
+      )
+    ),
+  ],
+
+  sockets = [
+    # Serve HTTP on port 8080.
+    ( name = "http",
+      address = "*:8080",
+      http = (),
+      service = "main"
+    ),
+  ]
+);
+
+const mainWorker :Workerd.Worker = (
+  compatibilityDate = "2022-09-16",
+  compatibilityFlags = ["experimental", "nodejs_compat"],
+
+  modules = [
+    (name = "worker", esModule = embed "sql-test.js"),
+  ],
+
+  durableObjectNamespaces = [
+    (className = "DurableObjectExample", uniqueKey = "210bd0cbd803ef7883a1ee9d86cce06e"),
+  ],
+
+  durableObjectStorage = (localDisk = "my-disk"),
+
+  # We must declare bindings to allow us to call back to our own Durable Object namespaces. These
+  # show up as properties on the `env` object passed to `fetch()`.
+  bindings = [
+    (name = "DurableObjectExample", durableObjectNamespace = "DurableObjectExample"),
+  ],
+);

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -1,0 +1,166 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "sql.h"
+#include <sqlite3.h>
+
+namespace workerd::api {
+
+SqlResult::SqlResult(SqliteDatabase::Query&& queryMoved): query(kj::mv(queryMoved)) {}
+
+jsg::Ref<SqlResult::RowIterator> SqlResult::rows(
+    jsg::Lock&,
+    CompatibilityFlags::Reader featureFlags) {
+  return jsg::alloc<RowIterator>(JSG_THIS);
+}
+
+kj::Maybe<jsg::Dict<SqliteDatabase::Query::ValueOwned>> SqlResult::rowIteratorNext(jsg::Lock& js, jsg::Ref<SqlResult>& state) {
+  auto& query = state->query;
+  if (query.isDone()) {
+    return nullptr;
+  }
+
+  kj::Vector<jsg::Dict<SqliteDatabase::Query::ValueOwned>::Field> fields;
+  for (uint i = 0; i < query.columnCount(); ++i) {
+    fields.add(jsg::Dict<SqliteDatabase::Query::ValueOwned>::Field{
+      .name = kj::heapString(query.getColumnName(i)),
+      .value = query.getValueOwned(i)
+    });
+  }
+  auto dict = jsg::Dict<SqliteDatabase::Query::ValueOwned>{.fields = fields.releaseAsArray()};
+  query.nextRow();
+  return dict;
+}
+
+SqlPreparedStatement::SqlPreparedStatement(jsg::Ref<SqlDatabase>&& sqlDb, SqliteDatabase::Statement&& statement):
+  sqlDatabase(kj::mv(sqlDb)),
+  statement(kj::mv(statement)) {
+}
+
+void fillBindValues(
+  kj::Vector<SqliteDatabase::Query::ValuePtr>& bindValues, kj::Maybe<kj::Array<ValueBind>>& bindValuesOptional) {
+  KJ_IF_MAYBE(values, bindValuesOptional) {
+    for (auto& value : *values) {
+      KJ_SWITCH_ONEOF(value) {
+        KJ_CASE_ONEOF(val, kj::Array<const byte>) {
+          bindValues.add(val.asPtr());
+        }
+        KJ_CASE_ONEOF(val, kj::String) {
+          bindValues.add(val.asPtr());
+        }
+        KJ_CASE_ONEOF(val, double) {
+          bindValues.add(val);
+        }
+      }
+    }
+  }
+}
+
+jsg::Ref<SqlResult> SqlPreparedStatement::run(jsg::Optional<SqlRunOptions> options) {
+  kj::Vector<SqliteDatabase::Query::ValuePtr> bindValues;
+
+  KJ_IF_MAYBE(o, options) {
+    fillBindValues(bindValues, o->bindValues);
+  }
+
+  kj::ArrayPtr<const SqliteDatabase::Query::ValuePtr> boundValues = bindValues.asPtr();
+  SqliteDatabase::Query query(sqlDatabase->sqlite, statement, boundValues);
+  return jsg::alloc<SqlResult>(kj::mv(query));
+}
+
+SqlDatabase::SqlDatabase(SqliteDatabase& sqlite):
+  sqlite(sqlite) {
+  sqlite3* db = sqlite;
+  sqlite3_set_authorizer(db, authorize, this);
+}
+
+SqlDatabase::~SqlDatabase() {
+  sqlite3* db = sqlite;
+  sqlite3_set_authorizer(db, nullptr, nullptr);
+}
+
+const char* getAuthorizorTableName(int actionCode, const char* param1, const char* param2) {
+  switch (actionCode) {
+    case SQLITE_CREATE_INDEX:        return param2;
+    case SQLITE_CREATE_TABLE:        return param1;
+    case SQLITE_CREATE_TEMP_INDEX:   return param2;
+    case SQLITE_CREATE_TEMP_TABLE:   return param1;
+    case SQLITE_CREATE_TEMP_TRIGGER: return param2;
+    case SQLITE_CREATE_TRIGGER:      return param2;
+    case SQLITE_DELETE:              return param1;
+    case SQLITE_DROP_INDEX:          return param2;
+    case SQLITE_DROP_TABLE:          return param1;
+    case SQLITE_DROP_TEMP_INDEX:     return param2;
+    case SQLITE_DROP_TEMP_TABLE:     return param1;
+    case SQLITE_DROP_TEMP_TRIGGER:   return param2;
+    case SQLITE_DROP_TRIGGER:        return param2;
+    case SQLITE_INSERT:              return param1;
+    case SQLITE_READ:                return param1;
+    case SQLITE_UPDATE:              return param1;
+    case SQLITE_ALTER_TABLE:         return param2;
+    case SQLITE_ANALYZE:             return param1;
+    case SQLITE_CREATE_VTABLE:       return param1;
+    case SQLITE_DROP_VTABLE:         return param1;
+  }
+  return "";
+}
+
+int SqlDatabase::authorize(
+  void* userdata,
+  int actionCode,
+  const char* param1,
+  const char* param2,
+  const char* dbName,
+  const char* triggerName) {
+  SqlDatabase* self = reinterpret_cast<SqlDatabase*>(userdata);
+
+  if (self->isAdmin) {
+    return SQLITE_OK;
+  }
+
+  kj::StringPtr tableName = getAuthorizorTableName(actionCode, param1, param2);
+  if (tableName.startsWith("_cf_")) {
+    return SQLITE_DENY;
+  }
+
+  if (actionCode == SQLITE_PRAGMA) {
+    return SQLITE_DENY;
+  }
+
+  if (actionCode == SQLITE_TRANSACTION) {
+    return SQLITE_DENY;
+  }
+  return SQLITE_OK;
+}
+
+jsg::Ref<SqlResult> SqlDatabase::exec(jsg::Lock& js, kj::String querySql, jsg::Optional<SqlExecOptions> options) {
+  kj::Vector<SqliteDatabase::Query::ValuePtr> bindValues;
+
+  KJ_IF_MAYBE(o, options) {
+    fillBindValues(bindValues, o->bindValues);
+    isAdmin = o->admin;
+  }
+
+  kj::String error;
+  kj::ArrayPtr<const SqliteDatabase::Query::ValuePtr> boundValues = bindValues.asPtr();
+
+  ErrorCallback errorCb = ErrorCallback([](const char* errStr) {
+    JSG_ASSERT(false, Error, errStr);
+  });
+  SqliteDatabase::Query query = sqlite.run(querySql, boundValues);
+  isAdmin = false;
+  return jsg::alloc<SqlResult>(kj::mv(query));
+}
+
+jsg::Ref<SqlPreparedStatement> SqlDatabase::prepare(jsg::Lock& js, kj::String query, jsg::Optional<SqlPrepareOptions> options) {
+  KJ_IF_MAYBE(o, options) {
+    isAdmin = o->admin;
+  }
+
+  SqliteDatabase::Statement statement = sqlite.prepare(query);
+  isAdmin = false;
+  return jsg::alloc<SqlPreparedStatement>(JSG_THIS, kj::mv(statement));
+}
+
+}  // namespace workerd::api

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -1,0 +1,118 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <workerd/jsg/jsg.h>
+#include "basics.h"
+
+namespace workerd::api {
+
+class DurableObjectStorage;
+
+typedef kj::OneOf<kj::Array<const byte>, kj::String, double> ValueBind;
+class SqlDatabase;
+
+class SqlResult final: public jsg::Object {
+public:
+  SqlResult(SqliteDatabase::Query&& query);
+
+  JSG_RESOURCE_TYPE(SqlResult, CompatibilityFlags::Reader flags) {
+    JSG_ITERABLE(rows);
+  }
+
+  JSG_ITERATOR(RowIterator, rows,
+                jsg::Dict<SqliteDatabase::Query::ValueOwned>,
+                jsg::Ref<SqlResult>,
+                rowIteratorNext);
+
+  static kj::Maybe<jsg::Dict<SqliteDatabase::Query::ValueOwned>> rowIteratorNext(jsg::Lock& js, jsg::Ref<SqlResult>& state);
+private:
+  SqliteDatabase::Query query;
+};
+
+class SqlPreparedStatement final: public jsg::Object {
+public:
+  SqlPreparedStatement(jsg::Ref<SqlDatabase>&& sqlDb, SqliteDatabase::Statement&& statement);
+
+  struct SqlRunOptions {
+    kj::Maybe<kj::Array<ValueBind>> bindValues;
+    JSG_STRUCT(bindValues);
+  };
+
+  jsg::Ref<SqlResult> run(jsg::Optional<SqlRunOptions> options);
+
+  JSG_RESOURCE_TYPE(SqlPreparedStatement, CompatibilityFlags::Reader flags) {
+    JSG_CALLABLE(run);
+  }
+
+private:
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(sqlDatabase);
+  }
+
+  jsg::Ref<SqlDatabase> sqlDatabase;
+  SqliteDatabase::Statement statement;
+};
+
+class SqlDatabase final: public jsg::Object {
+public:
+  friend class SqlPreparedStatement;
+  friend class DurableObjectStorage;
+  SqlDatabase(SqliteDatabase& sqlite);
+  ~SqlDatabase();
+
+  struct SqlExecOptions {
+    bool admin = false;
+    kj::Maybe<kj::Array<ValueBind>> bindValues;
+    JSG_STRUCT(admin, bindValues);
+  };
+
+  jsg::Ref<SqlResult> exec(jsg::Lock& js, kj::String query, jsg::Optional<SqlExecOptions> options);
+
+  struct SqlPrepareOptions {
+    bool admin = false;
+    JSG_STRUCT(admin);
+  };
+
+  jsg::Ref<SqlPreparedStatement> prepare(jsg::Lock& js, kj::String query, jsg::Optional<SqlPrepareOptions> options);
+
+  JSG_RESOURCE_TYPE(SqlDatabase, CompatibilityFlags::Reader flags) {
+    JSG_METHOD(exec);
+    JSG_METHOD(prepare);
+  }
+
+private:
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(storage);
+  }
+
+  static int authorize(
+    void* userdata,
+    int actionCode,
+    const char* param1,
+    const char* param2,
+    const char* dbName,
+    const char* triggerName);
+
+  void onError(const char* errStr);
+
+  SqliteDatabase& sqlite;
+  kj::Maybe<jsg::Ref<DurableObjectStorage>> storage;
+
+  bool isAdmin = false;
+};
+
+#define EW_SQL_ISOLATE_TYPES                \
+  api::SqlDatabase,                         \
+  api::SqlPreparedStatement,                \
+  api::SqlResult,                           \
+  api::SqlResult::RowIterator,              \
+  api::SqlResult::RowIterator::Next,        \
+  api::SqlPreparedStatement::SqlRunOptions, \
+  api::SqlDatabase::SqlExecOptions,         \
+  api::SqlDatabase::SqlPrepareOptions
+// The list of sql.h types that are added to worker.c++'s JSG_DECLARE_ISOLATE_TYPE
+
+}  // namespace workerd::api

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -20,7 +20,9 @@ class ActorSqlite final: public ActorCacheInterface {
 
 public:
   ActorSqlite(SqliteDatabase::Vfs& vfs, kj::PathPtr path)
-      : db(vfs, path, kj::WriteMode::CREATE | kj::WriteMode::MODIFY | kj::WriteMode::CREATE_PARENT),
+      : db(vfs, path, ErrorCallback([](const char* errStr) {
+          JSG_ASSERT(false, Error, errStr);
+        }), kj::WriteMode::CREATE | kj::WriteMode::MODIFY | kj::WriteMode::CREATE_PARENT),
         kv(db) {}
 
   kj::OneOf<kj::Maybe<Value>, kj::Promise<kj::Maybe<Value>>> get(
@@ -46,8 +48,8 @@ public:
   kj::Maybe<kj::Promise<void>> sync() { return nullptr; }
   // TODO(sqlite): synk() should wait for replication if applicable.
 
-private:
   SqliteDatabase db;
+private:
   SqliteKv kv;
 };
 

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -33,6 +33,20 @@ class PrimitiveWrapper {
   // because ResourceWrapper<TW, T>::wrap() needs the context to create new object instances.
 
 public:
+  static constexpr const char* getName(nullptr_t*) { return "null"; }
+
+  v8::Local<v8::Primitive> wrap(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator,
+      nullptr_t value) {
+    return wrap(context->GetIsolate(), creator, value);
+  }
+
+  v8::Local<v8::Primitive> wrap(
+      v8::Isolate* isolate, kj::Maybe<v8::Local<v8::Object>> creator,
+      nullptr_t value) {
+    return v8::Null(isolate);
+  }
+
   static constexpr const char* getName(double*) { return "number"; }
 
   v8::Local<v8::Number> wrap(

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -15,6 +15,7 @@
 #include <workerd/api/global-scope.h>
 #include <workerd/api/kv.h>
 #include <workerd/api/sockets.h>
+#include <workerd/api/sql.h>
 #include <workerd/api/r2.h>
 #include <workerd/api/r2-admin.h>
 #include <workerd/api/urlpattern.h>
@@ -64,6 +65,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
   EW_URL_STANDARD_ISOLATE_TYPES,
   EW_URLPATTERN_ISOLATE_TYPES,
   EW_WEBSOCKET_ISOLATE_TYPES,
+  EW_SQL_ISOLATE_TYPES,
   EW_NODE_ISOLATE_TYPES,
 
   jsg::TypeWrapperExtension<PromiseWrapper>,

--- a/src/workerd/tools/api-encoder.c++
+++ b/src/workerd/tools/api-encoder.c++
@@ -43,6 +43,7 @@
   F("url-standard", EW_URL_STANDARD_ISOLATE_TYPES)                             \
   F("url-pattern", EW_URLPATTERN_ISOLATE_TYPES)                                \
   F("websocket", EW_WEBSOCKET_ISOLATE_TYPES)                                   \
+  F("sql", EW_SQL_ISOLATE_TYPES)                                               \
   F("sockets", EW_SOCKETS_ISOLATE_TYPES)                                       \
   F("node", EW_NODE_ISOLATE_TYPES)
 

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -12,9 +12,18 @@
 
 namespace workerd {
 
+#define SQLITE_ASSERT(condition, errMsg, ...) \
+    KJ_IF_MAYBE(onErrorCb, onError) { \
+      if (!(condition)) { \
+        (*onErrorCb)(errMsg); \
+      } \
+    } else { \
+      KJ_ASSERT((condition), "SQLite failed: ", errMsg, ##__VA_ARGS__); \
+    }
+
 #define SQLITE_CALL_NODB(code, ...) do { \
     int _ec = code; \
-    KJ_ASSERT(_ec == SQLITE_OK, "SQLite failed: " #code, sqlite3_errstr(_ec), ##__VA_ARGS__); \
+    SQLITE_ASSERT(_ec == SQLITE_OK, sqlite3_errstr(_ec), " " #code, ##__VA_ARGS__) \
   } while (false)
 // Make a SQLite call and check the returned error code. Use this version when the call is not
 // associated with an open DB connection.
@@ -23,14 +32,14 @@ namespace workerd {
     int _ec = code; \
     /* SQLITE_MISUSE doesn't put error info on the database object, so check it separately */ \
     KJ_ASSERT(_ec != SQLITE_MISUSE, "SQLite misused: " #code, ##__VA_ARGS__); \
-    KJ_ASSERT(_ec == SQLITE_OK, "SQLite failed: " #code, sqlite3_errmsg(db), ##__VA_ARGS__); \
+    SQLITE_ASSERT(_ec == SQLITE_OK, sqlite3_errmsg(db), " " #code, ##__VA_ARGS__); \
   } while (false)
 // This version requires the scope to contain a variable named `db` which is of type sqlite3*, or
 // can convert to it.
 
 #define SQLITE_CALL_FAILED(code, error, ...) do { \
     KJ_ASSERT(error != SQLITE_MISUSE, "SQLite misused: " code, ##__VA_ARGS__); \
-    KJ_ASSERT(error == SQLITE_OK, "SQLite failed: " code, sqlite3_errmsg(db), ##__VA_ARGS__); \
+    SQLITE_ASSERT(error == SQLITE_OK, sqlite3_errmsg(db), " " code, ##__VA_ARGS__); \
   } while (false);
 // Version of `SQLITE_CALL` that can be called after inspecting the error code, in case some codes
 // aren't really errors.
@@ -63,12 +72,12 @@ kj::Own<T> ownSqlite(T* obj) {
 
 // =======================================================================================
 
-SqliteDatabase::SqliteDatabase(Vfs& vfs, kj::PathPtr path) {
+SqliteDatabase::SqliteDatabase(Vfs& vfs, kj::PathPtr path, ErrorCallback onErrorCb): onError(kj::mv(onErrorCb)) {
   SQLITE_CALL_NODB(sqlite3_open_v2(path.toString().cStr(), &db,
                                    SQLITE_OPEN_READONLY, vfs.getName().cStr()));
 }
 
-SqliteDatabase::SqliteDatabase(Vfs& vfs, kj::PathPtr path, kj::WriteMode mode) {
+SqliteDatabase::SqliteDatabase(Vfs& vfs, kj::PathPtr path, ErrorCallback onErrorCb, kj::WriteMode mode): onError(kj::mv(onErrorCb)) {
   int flags = SQLITE_OPEN_READWRITE;
   if (kj::has(mode, kj::WriteMode::CREATE)) {
     flags |= SQLITE_OPEN_CREATE;
@@ -97,26 +106,26 @@ SqliteDatabase::~SqliteDatabase() noexcept(false) {
   KJ_REQUIRE(err == SQLITE_OK, sqlite3_errstr(err)) { break; }
 }
 
-kj::Own<sqlite3_stmt> SqliteDatabase::prepareSql(sqlite3* db, kj::StringPtr sqlCode, uint prepFlags,
+kj::Own<sqlite3_stmt> SqliteDatabase::prepareSql(sqlite3* db, ErrorCallback& onError, kj::StringPtr sqlCode, uint prepFlags,
                                                  Multi multi) {
   for (;;) {
     sqlite3_stmt* result;
     const char* tail;
 
     SQLITE_CALL(sqlite3_prepare_v3(db, sqlCode.begin(), sqlCode.size(), prepFlags, &result, &tail));
-    KJ_REQUIRE(result != nullptr, "SQL code did not contain a statement", sqlCode);
+    SQLITE_ASSERT(result != nullptr, "SQL code did not contain a statement", sqlCode);
     auto ownResult = ownSqlite(result);
 
     while (*tail == ' ' || *tail == '\n') ++tail;
 
     switch (multi) {
       case SINGLE:
-        KJ_REQUIRE(tail == sqlCode.end(), "sqlite statement had leftover code", tail);
+        SQLITE_ASSERT(tail == sqlCode.end(), "sqlite statement had leftover code", tail);
         break;
 
       case MULTI:
         if (tail != sqlCode.end()) {
-          KJ_REQUIRE(sqlite3_bind_parameter_count(result) == 0,
+          SQLITE_ASSERT(sqlite3_bind_parameter_count(result) == 0,
               "only the last statement in a multi-statement query can have parameters");
 
           // This isn't the last statement in the code. Execute it immediately.
@@ -140,26 +149,35 @@ kj::Own<sqlite3_stmt> SqliteDatabase::prepareSql(sqlite3* db, kj::StringPtr sqlC
   }
 }
 
-SqliteDatabase::Statement SqliteDatabase::prepare(kj::StringPtr sqlCode) {
-  return Statement(*this, prepareSql(db, sqlCode, SQLITE_PREPARE_PERSISTENT, SINGLE));
+SqliteDatabase::Statement SqliteDatabase::prepare(kj::StringPtr sqlCode, ErrorCallback onError) {
+  return Statement(*this, prepareSql(db, onError, sqlCode, SQLITE_PREPARE_PERSISTENT, SINGLE));
+}
+
+SqliteDatabase::Query::Query(Query&& query):
+  db(query.db),
+  onError(query.onError),
+  ownStatement(kj::mv(query.ownStatement)),
+  statement(query.statement),
+  done(query.done) {
+  query.statement = nullptr;
 }
 
 SqliteDatabase::Query::Query(SqliteDatabase& db, Statement& statement,
                              kj::ArrayPtr<const ValuePtr> bindings)
-    : db(db), statement(statement) {
+    : db(db), onError(db.onError), statement(statement) {
   init(bindings);
 }
 
 SqliteDatabase::Query::Query(SqliteDatabase& db, kj::StringPtr sqlCode,
                              kj::ArrayPtr<const ValuePtr> bindings)
-    : db(db), ownStatement(prepareSql(db, sqlCode, 0, SINGLE)), statement(ownStatement) {
+    : db(db), onError(db.onError), ownStatement(prepareSql(db, db.onError, sqlCode, 0, MULTI)), statement(ownStatement) {
   init(bindings);
 }
 
 SqliteDatabase::Query::~Query() noexcept(false) {
   // We only need to reset the statement if we don't own it. If we own it, it's about to be
   // destroyed anyway.
-  if (ownStatement.get() == nullptr) {
+  if (ownStatement.get() == nullptr && statement) {
     // The error code returned by sqlite3_reset() actually represents the last error encountered
     // when stepping the statement. This doesn't mean that the reset failed.
     sqlite3_reset(statement);
@@ -172,7 +190,7 @@ SqliteDatabase::Query::~Query() noexcept(false) {
 
 void SqliteDatabase::Query::checkRequirements(size_t size) {
   KJ_REQUIRE(!sqlite3_stmt_busy(statement), "only one Query can run at a time");
-  KJ_REQUIRE(size == sqlite3_bind_parameter_count(statement),
+  SQLITE_ASSERT(size == sqlite3_bind_parameter_count(statement),
       "wrong number of bindings for SQLite query");
 }
 
@@ -255,6 +273,24 @@ SqliteDatabase::Query::ValuePtr SqliteDatabase::Query::getValue(uint column) {
     case SQLITE_NULL:    return nullptr;
   }
   KJ_UNREACHABLE;
+}
+
+SqliteDatabase::Query::ValueOwned SqliteDatabase::Query::getValueOwned(uint column) {
+  switch (sqlite3_column_type(statement, column)) {
+    case SQLITE_INTEGER: {
+      int64_t value = getInt64(column);
+      return static_cast<double>(value);
+    }
+    case SQLITE_FLOAT:   return getDouble(column);
+    case SQLITE_TEXT:    return kj::heapString(getText(column));
+    case SQLITE_BLOB:    return kj::heapArray<const byte>(getBlob(column));
+    case SQLITE_NULL:    return nullptr;
+  }
+  KJ_UNREACHABLE;
+}
+
+kj::StringPtr SqliteDatabase::Query::getColumnName(uint column) {
+  return sqlite3_column_name(statement, column);
 }
 
 kj::ArrayPtr<const byte> SqliteDatabase::Query::getBlob(uint column) {

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -19,6 +19,7 @@ namespace workerd {
 
 using kj::byte;
 using kj::uint;
+using ErrorCallback = kj::Maybe<kj::Function<void(const char*)>>;
 
 class SqliteDatabase {
   // C++/KJ API for SQLite.
@@ -34,8 +35,8 @@ public:
   class Query;
   class Statement;
 
-  SqliteDatabase(Vfs& vfs, kj::PathPtr path);
-  SqliteDatabase(Vfs& vfs, kj::PathPtr path, kj::WriteMode mode);
+  SqliteDatabase(Vfs& vfs, kj::PathPtr path, ErrorCallback onError);
+  SqliteDatabase(Vfs& vfs, kj::PathPtr path, ErrorCallback onError, kj::WriteMode mode);
   ~SqliteDatabase() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(SqliteDatabase);
 
@@ -43,7 +44,7 @@ public:
   // Allows a SqliteDatabase to be passed directly into SQLite API functions where `sqlite*` is
   // expected.
 
-  Statement prepare(kj::StringPtr sqlCode);
+  Statement prepare(kj::StringPtr sqlCode, ErrorCallback onError = nullptr);
   // Prepares the given SQL code as a persistent statement that can be used across several queries.
   // Don't use this for one-off queries; pass the code to the Query constructor.
 
@@ -59,12 +60,14 @@ public:
 private:
   sqlite3* db;
 
+  ErrorCallback onError;
+
   void close();
 
   enum Multi { SINGLE, MULTI };
 
   static kj::Own<sqlite3_stmt> prepareSql(
-      sqlite3* db, kj::StringPtr sqlCode, uint prepFlags, Multi multi);
+      sqlite3* db, ErrorCallback& onError, kj::StringPtr sqlCode, uint prepFlags, Multi multi);
   // Helper to call sqlite3_prepare_v3().
   //
   // In SINGLE mode, an exception is thrown if `sqlCode` contains multiple statements.
@@ -103,6 +106,9 @@ class SqliteDatabase::Query {
 public:
   using ValuePtr = kj::OneOf<kj::ArrayPtr<const byte>, kj::StringPtr, int64_t, double,
                              decltype(nullptr)>;
+  using ValueOwned = kj::OneOf<kj::Array<const byte>, kj::String, int64_t, double,
+                             decltype(nullptr)>;
+  Query(Query&& query);
 
   Query(SqliteDatabase& db, Statement& statement, kj::ArrayPtr<const ValuePtr> bindings);
   // Begin a query executing a prepared statement.
@@ -116,19 +122,19 @@ public:
 
   template <typename... Params>
   Query(SqliteDatabase& db, Statement& statement, Params&&... bindings)
-      : db(db), statement(statement) {
+      : db(db), onError(db.onError), statement(statement) {
     bindAll(std::index_sequence_for<Params...>(), kj::fwd<Params>(bindings)...);
   }
   template <typename... Params>
   Query(SqliteDatabase& db, kj::StringPtr sqlCode, Params&&... bindings)
-      : db(db), ownStatement(prepareSql(db, sqlCode, 0, MULTI)), statement(ownStatement) {
+      : db(db), onError(db.onError), ownStatement(prepareSql(db, db.onError, sqlCode, 0, MULTI)), statement(ownStatement) {
     bindAll(std::index_sequence_for<Params...>(), kj::fwd<Params>(bindings)...);
   }
   // These versions of the constructor accept the binding values as positional parameters. This
   // may be convenient when the number of bindings is statically known.
 
   ~Query() noexcept(false);
-  KJ_DISALLOW_COPY_AND_MOVE(Query);
+  KJ_DISALLOW_COPY(Query);
 
   bool isDone() { return done; }
   // If true, there are no more rows. (When true, the methods below must not be called.)
@@ -148,6 +154,12 @@ public:
   //
   // Returned pointers (strings and blobs) remain valid only until either (a) nextRow() is called,
   // or (b) a different get method is called on the same column but with a different type.
+
+  ValueOwned getValueOwned(uint column);
+  // Get the value at the given column, as whatever type was actually returned.
+
+  kj::StringPtr getColumnName(uint column);
+  // Get the name of a specific column.
 
   kj::ArrayPtr<const byte> getBlob(uint column);
   kj::StringPtr getText(uint column);
@@ -175,6 +187,7 @@ public:
 
 private:
   sqlite3* db;
+  ErrorCallback& onError;
   kj::Own<sqlite3_stmt> ownStatement;   // for one-off queries
   sqlite3_stmt* statement;
   bool done = false;


### PR DESCRIPTION
This binds sqlite to JavaScript and puts access to it behind the flag `sql_binding`. This is a stepping stone to getting SQL support for D1, and currently only instantiates an in memory sqlite database using the virtual filesystem provided by KJ. This introduces three classes: SqlDatabase which holds the instantiation of sqlite and can run statements, SqlPreparedStatement which stores a pre-parsed SQL statement and allows multiple executions, and SqlResult which stores and returns the results (once) of a query as rows of objects that map column names to column values of that row in the format: `Record<string, number | Blob | string>[]`. Both `SqlDatabase.exec` and `SqlPreparedStatement.run` accept an array of binding values for SQL, or null for no binding values.