### PR TITLE
Breaking out trace and thread-scopes

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -43,7 +43,7 @@ wd_cc_capnp_library(
 ) for f in glob(
     ["**/*-test.c++"],
     exclude = [
-        "node/*-test.c++"
+        "node/*-test.c++",
     ],
 )]
 
@@ -54,8 +54,8 @@ kj_test(
 
 [wd_test(
     src = f,
-    data = [f.removesuffix(".wd-test") + ".js"],
     args = ["--experimental"],
+    data = [f.removesuffix(".wd-test") + ".js"],
 ) for f in glob(
     ["**/*.wd-test"],
 )]

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -10,21 +10,45 @@ wd_cc_library(
     # TODO(cleaunp): Fix this.
     srcs = glob(
         ["*.c++"],
-        exclude = ["*-test.c++"],
+        exclude = [
+            "*-test.c++",
+            "trace.c++",
+        ],
     ) + ["//src/workerd/api:srcs"],
-    hdrs = glob(["*.h"]) + ["//src/workerd/api:hdrs"],
+    hdrs = glob(
+        ["*.h"],
+        exclude = [
+            "trace.h",
+        ],
+    ) + ["//src/workerd/api:hdrs"],
     visibility = ["//visibility:public"],
     deps = [
         ":capnp",
-        "@capnp-cpp//src/kj:kj-async",
-        "@com_cloudflare_lol_html//:lolhtml",
+        ":trace",
+        "//src/node:bundle",
         "//src/workerd/api:analytics-engine_capnp",
         "//src/workerd/api:r2-api_capnp",
         "//src/workerd/jsg",
         "//src/workerd/util:sqlite",
-        "//src/node:bundle",
+        "@capnp-cpp//src/kj:kj-async",
+        "@com_cloudflare_lol_html//:lolhtml",
     ],
 )
+
+wd_cc_library(
+    name = "trace",
+    srcs = ["trace.c++"],
+    hdrs = ["trace.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":capnp",
+        "//src/workerd/util:own-util",
+        "//src/workerd/util:thread-scopes",
+        "@capnp-cpp//src/kj:kj-async",
+        "@capnp-cpp//src/kj/compat:kj-http",
+    ],
+)
+
 
 wd_cc_capnp_library(
     name = "capnp",

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <kj/string.h>
-#include "trace.h"
-#include "worker-interface.h"
+#include <workerd/io/trace.h>
+#include <workerd/io/worker-interface.h>
 
 namespace workerd {
 

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -4,7 +4,7 @@
 
 #include "io-context.h"
 #include <workerd/io/io-gate.h>
-#include "worker.h"
+#include <workerd/io/worker.h>
 #include <kj/threadlocal.h>
 #include <kj/debug.h>
 #include <workerd/jsg/jsg.h>

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -10,16 +10,16 @@
 #include <kj/function.h>
 #include <kj/map.h>
 
-#include "trace.h"
-#include "worker.h"
+#include <workerd/io/trace.h>
+#include <workerd/io/worker.h>
 #include <workerd/jsg/async-context.h>
 #include <workerd/jsg/jsg.h>
 #include <v8.h>
-#include "io-gate.h"
+#include <workerd/io/io-gate.h>
 #include <workerd/api/util.h>
 #include <capnp/dynamic.h>
-#include "limit-enforcer.h"
-#include "io-channels.h"
+#include <workerd/io/limit-enforcer.h>
+#include <workerd/io/io-channels.h>
 
 namespace capnp { class HttpOverCapnpFactory; }
 

--- a/src/workerd/io/io-gate.c++
+++ b/src/workerd/io/io-gate.c++
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-#include "io-gate.h"
+#include <workerd/io/io-gate.h>
 #include <kj/debug.h>
 
 namespace workerd {

--- a/src/workerd/io/limit-enforcer.h
+++ b/src/workerd/io/limit-enforcer.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <workerd/jsg/jsg.h>
-#include "observer.h"
+#include <workerd/io/observer.h>
 
 namespace workerd {
 

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -11,7 +11,7 @@
 #include <kj/exception.h>
 #include <kj/time.h>
 #include <kj/compat/http.h>
-#include "trace.h"
+#include <workerd/io/trace.h>
 
 namespace workerd {
 

--- a/src/workerd/io/promise-wrapper.h
+++ b/src/workerd/io/promise-wrapper.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "io-context.h"
-#include "worker.h"
+#include <workerd/io/io-context.h>
+#include <workerd/io/worker.h>
 #include <workerd/jsg/jsg.h>
 
 namespace workerd {

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-#include "trace.h"
+#include <workerd/io/trace.h>
 #include <capnp/schema.h>
 #include <kj/compat/http.h>
 #include <kj/debug.h>

--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "io-context.h"
-#include "trace.h"
+#include <workerd/io/trace.h>
 #include "worker-interface.h"
 #include <kj/compat/http.h>
 

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "trace.h"
+#include <workerd/io/trace.h>
 #include <kj/compat/http.h>
 #include <capnp/compat/http-over-capnp.h>
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2,8 +2,8 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-#include "worker.h"
-#include "promise-wrapper.h"
+#include <workerd/io/worker.h>
+#include <workerd/io/promise-wrapper.h>
 #include "actor-cache.h"
 #include <workerd/util/thread-scopes.h>
 #include <workerd/api/global-scope.h>

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -5,15 +5,15 @@
 #pragma once
 // Classes to manage lifetime of workers, scripts, and isolates.
 
-#include "worker-interface.h"
-#include "limit-enforcer.h"
+#include <workerd/io/worker-interface.h>
+#include <workerd/io/limit-enforcer.h>
 #include <kj/compat/http.h>
 #include <workerd/io/outcome.capnp.h>
 #include <workerd/io/worker-interface.capnp.h>
 #include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/jsg/jsg.h>
 #include <kj/mutex.h>
-#include "io-channels.h"
+#include <workerd/io/io-channels.h>
 #include <workerd/io/actor-storage.capnp.h>
 
 namespace v8 { class Isolate; }

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -17,6 +17,8 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":modules_capnp",
+        "//src/workerd/util:sentry",
+        "//src/workerd/util:thread-scopes",
         "//src/workerd/util",
         "@capnp-cpp//src/kj",
         "@workerd-v8//:v8",

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -10,13 +10,17 @@ wd_cc_library(
             "capnp-mock.c++",
             "symbolizer.c++",
             "sqlite*.c++",
+            "thread-scopes.c++",
         ],
     ),
     hdrs = glob(
         ["*.h"],
         exclude = [
             "capnp-mock.h",
-            "sqlite*.h"
+            "sqlite*.h",
+            "own-util.h",
+            "thread-scopes.h",
+            "sentry.h",
         ],
     ),
     visibility = ["//visibility:public"],
@@ -31,13 +35,19 @@ wd_cc_library(
 
 wd_cc_library(
     name = "sqlite",
-    srcs = [ "sqlite.c++", "sqlite-kv.c++" ],
-    hdrs = [ "sqlite.h", "sqlite-kv.h" ],
+    srcs = [
+        "sqlite.c++",
+        "sqlite-kv.c++",
+    ],
+    hdrs = [
+        "sqlite.h",
+        "sqlite-kv.h",
+    ],
     visibility = ["//visibility:public"],
     deps = [
-        "@sqlite3//:sqlite3",
         "@capnp-cpp//src/kj:kj-async",
-    ]
+        "@sqlite3",
+    ],
 )
 
 wd_cc_library(
@@ -61,12 +71,37 @@ wd_cc_library(
     alwayslink = 1,
 )
 
+wd_cc_library(
+    name = "own-util",
+    hdrs = ["own-util.h"],
+    visibility = ["//visibility:public"],
+)
+
+wd_cc_library(
+    name = "sentry",
+    hdrs = ["sentry.h"],
+    visibility = ["//visibility:public"],
+)
+
+wd_cc_library(
+    name = "thread-scopes",
+    srcs = ["thread-scopes.c++"],
+    hdrs = ["thread-scopes.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj/compat:kj-http",
+    ],
+)
+
 [kj_test(
     src = f,
     deps = [
         ":util",
     ],
-) for f in glob(["*-test.c++"], exclude = ["sqlite-*.c++"])]
+) for f in glob(
+    ["*-test.c++"],
+    exclude = ["sqlite-*.c++"],
+)]
 
 kj_test(
     src = "sqlite-test.c++",


### PR DESCRIPTION
This commit allows for the use of traces without needing to bring all of workerd/io with them.

thread-scopes.h is used fairly often just to get
isPredictableModeForTest() so it makes sense not to pull all of workerd/util for one function.

Additionally a linter was run workerd/jsg/BUILD