### PR TITLE
Fixup `cf` types

### DIFF
--- a/build/wd_ts_type_test.bzl
+++ b/build/wd_ts_type_test.bzl
@@ -1,0 +1,21 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("//:build/typescript.bzl", "module_name")
+load("@npm//:typescript/package_json.bzl", tsc_bin = "bin")
+
+def wd_ts_type_test(src, **kwargs):
+    """Bazel rule to test TypeScript file type-checks under @cloudflare/workers-types"""
+    name = module_name(src)
+    tsc_bin.tsc_test(
+        name = name,
+        args = [
+            "--project",
+            "$(location //types:test/types/tsconfig.json)",
+            "--types",
+            "../../definitions/experimental",
+        ],
+        data = [
+            "//types:types",
+            "//types:test/types/tsconfig.json",
+            src,
+        ],
+    )

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -161,14 +161,14 @@ struct ExportedHandler {
   // include it in type definitions.
 
   JSG_STRUCT_TS_DEFINE(
-    type ExportedHandlerFetchHandler<Env = unknown> = (request: Request, env: Env, ctx: ExecutionContext) => Response | Promise<Response>;
+    type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>, env: Env, ctx: ExecutionContext) => Response | Promise<Response>;
     type ExportedHandlerTraceHandler<Env = unknown> = (traces: TraceItem[], env: Env, ctx: ExecutionContext) => void | Promise<void>;
     type ExportedHandlerScheduledHandler<Env = unknown> = (controller: ScheduledController, env: Env, ctx: ExecutionContext) => void | Promise<void>;
     type ExportedHandlerQueueHandler<Env = unknown, Message = unknown> = (batch: MessageBatch<Message>, env: Env, ctx: ExecutionContext) => void | Promise<void>;
     type ExportedHandlerTestHandler<Env = unknown> = (controller: TestController, env: Env, ctx: ExecutionContext) => void | Promise<void>;
   );
-  JSG_STRUCT_TS_OVERRIDE(<Env = unknown, QueueMessage = unknown> {
-    fetch?: ExportedHandlerFetchHandler<Env>;
+  JSG_STRUCT_TS_OVERRIDE(<Env = unknown, QueueMessage = unknown, CfHostMetadata = unknown> {
+    fetch?: ExportedHandlerFetchHandler<Env, CfHostMetadata>;
     trace?: ExportedHandlerTraceHandler<Env>;
     scheduled?: ExportedHandlerScheduledHandler<Env>;
     alarm: never;

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -473,7 +473,7 @@ public:
     JSG_METHOD_NAMED(delete, delete_);
 
     JSG_TS_OVERRIDE({
-      fetch(input: RequestInfo, init?: RequestInit<RequestInitCfProperties>): Promise<Response>;
+      fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
       get: never;
       put: never;
       delete: never;
@@ -578,10 +578,10 @@ struct RequestInitializerDict {
 
   JSG_STRUCT(method, headers, body, redirect, fetcher, cf, mode, credentials, cache,
              referrer, referrerPolicy, integrity, signal);
-  JSG_STRUCT_TS_OVERRIDE(RequestInit<CfType = IncomingRequestCfProperties | RequestInitCfProperties> {
+  JSG_STRUCT_TS_OVERRIDE(RequestInit<Cf = CfProperties> {
     headers?: HeadersInit;
     body?: BodyInit | null;
-    cf?: CfType;
+    cf?: Cf;
   });
 };
 
@@ -715,7 +715,7 @@ public:
 
     JSG_METHOD(clone);
 
-    JSG_TS_DEFINE(type RequestInfo = Request | string | URL);
+    JSG_TS_DEFINE(type RequestInfo<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> = Request<CfHostMetadata, Cf> | string | URL);
     // All type aliases get inlined when exporting RTTI, but this type alias is included by
     // the official TypeScript types, so users might be depending on it.
 
@@ -737,13 +737,14 @@ public:
       JSG_READONLY_PROTOTYPE_PROPERTY(integrity, getIntegrity);
       JSG_READONLY_PROTOTYPE_PROPERTY(keepalive, getKeepalive);
 
-      JSG_TS_OVERRIDE(<CfHostMetadata = unknown> {
-        constructor(input: RequestInfo, init?: RequestInit);
-        clone(): Request<CfHostMetadata>;
-        get cf(): IncomingRequestCfProperties<CfHostMetadata> | undefined;
+      JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
+        constructor(input: RequestInfo<CfProperties>, init?: RequestInit<Cf>);
+        clone(): Request<CfHostMetadata, Cf>;
+        get cf(): Cf | undefined;
       });
       // Use `RequestInfo` and `RequestInit` type aliases in constructor instead of inlining.
-      // `IncomingRequestCfProperties` is defined in `/types/defines/cf.d.ts`.
+      // `CfProperties` is defined in `/types/defines/cf.d.ts`. We only really need a single `Cf`
+      // type parameter here, but it would be a breaking type change to remove `CfHostMetadata`.
     } else {
       JSG_READONLY_INSTANCE_PROPERTY(method, getMethod);
       JSG_READONLY_INSTANCE_PROPERTY(url, getUrl);
@@ -762,13 +763,11 @@ public:
       JSG_READONLY_INSTANCE_PROPERTY(integrity, getIntegrity);
       JSG_READONLY_INSTANCE_PROPERTY(keepalive, getKeepalive);
 
-      JSG_TS_OVERRIDE(<CfHostMetadata = unknown> {
-        constructor(input: RequestInfo, init?: RequestInit);
-        clone(): Request<CfHostMetadata>;
-        readonly cf?: IncomingRequestCfProperties<CfHostMetadata>;
+      JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
+        constructor(input: RequestInfo<CfProperties>, init?: RequestInit<Cf>);
+        clone(): Request<CfHostMetadata, Cf>;
+        readonly cf?: Cf;
       });
-      // Use `RequestInfo` and `RequestInit` type aliases in constructor instead of inlining.
-      // `IncomingRequestCfProperties` is defined in `/types/defines/cf.d.ts`.
     }
   }
 

--- a/types/BUILD.bazel
+++ b/types/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary", "js_test")
 load("//:build/wd_ts_project.bzl", "wd_ts_project")
 load("//:build/wd_ts_test.bzl", "wd_ts_test")
+load("//:build/wd_ts_type_test.bzl", "wd_ts_type_test")
 
 wd_ts_project(
     name = "types_lib",
@@ -50,4 +51,9 @@ js_run_binary(
         deps = [":types_lib"],
     )
     for src in glob(["test/**/*.spec.ts"])
+]
+
+[
+    wd_ts_type_test(src = src)
+    for src in glob(["test/types/**/*.ts"])
 ]

--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -79,7 +79,7 @@ interface BasicImageTransformationsGravityCoordinates {
  * Note: Currently, these properties cannot be tested in the
  * playground.
  */
-interface RequestInitCfProperties {
+interface RequestInitCfProperties extends Record<string, unknown> {
   cacheEverything?: boolean;
   /**
    * A request's cache key is what determines if two requests are
@@ -267,7 +267,7 @@ type IncomingRequestCfProperties<HostMetadata = unknown> =
     IncomingRequestCfPropertiesGeographicInformation &
     IncomingRequestCfPropertiesCloudflareAccessOrApiShield;
 
-interface IncomingRequestCfPropertiesBase {
+interface IncomingRequestCfPropertiesBase extends Record<string, unknown> {
   /**
    * [ASN](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) of the incoming request.
    *
@@ -465,88 +465,82 @@ interface IncomingRequestCfPropertiesExportedAuthenticatorMetadata {
 /**
  * Geographic data about the request's origin.
  */
-type IncomingRequestCfPropertiesGeographicInformation =
-  | {
-      /* No geographic data was found for the incoming request. */
-    }
-  | {
-      /** The country code `"T1"` is used for requests originating on TOR  */
-      country: "T1";
-    }
-  | {
-      /**
-       * The [ISO 3166-1 Alpha 2](https://www.iso.org/iso-3166-country-codes.html) country code the request originated from.
-       *
-       * If your worker is [configured to accept TOR connections](https://support.cloudflare.com/hc/en-us/articles/203306930-Understanding-Cloudflare-Tor-support-and-Onion-Routing), this may also be `"T1"`, indicating a request that originated over TOR.
-       *
-       * If Cloudflare is unable to determine where the request originated this property is omitted.
-       *
-       * @example "GB"
-       */
-      country: Iso3166Alpha2Code;
-      /**
-       * If present, this property indicates that the request originated in the EU
-       *
-       * @example "1"
-       */
-      isEUCountry?: "1";
-      /**
-       * A two-letter code indicating the continent the request originated from.
-       *
-       * @example "AN"
-       */
-      continent: ContinentCode;
-      /**
-       * The city the request originated from
-       *
-       * @example "Austin"
-       */
-      city?: string;
-      /**
-       * Postal code of the incoming request
-       *
-       * @example "78701"
-       */
-      postalCode?: string;
-      /**
-       * Latitude of the incoming request
-       *
-       * @example "30.27130"
-       */
-      latitude?: string;
-      /**
-       * Longitude of the incoming request
-       *
-       * @example "-97.74260"
-       */
-      longitude?: string;
-      /**
-       * Timezone of the incoming request
-       *
-       * @example "America/Chicago"
-       */
-      timezone?: string;
-      /**
-       * If known, the ISO 3166-2 name for the first level region associated with
-       * the IP address of the incoming request
-       *
-       * @example "Texas"
-       */
-      region?: string;
-      /**
-       * If known, the ISO 3166-2 code for the first-level region associated with
-       * the IP address of the incoming request
-       *
-       * @example "TX"
-       */
-      regionCode?: string;
-      /**
-       * Metro code (DMA) of the incoming request
-       *
-       * @example "635"
-       */
-      metroCode?: string;
-    };
+interface IncomingRequestCfPropertiesGeographicInformation {
+  /**
+   * The [ISO 3166-1 Alpha 2](https://www.iso.org/iso-3166-country-codes.html) country code the request originated from.
+   *
+   * If your worker is [configured to accept TOR connections](https://support.cloudflare.com/hc/en-us/articles/203306930-Understanding-Cloudflare-Tor-support-and-Onion-Routing), this may also be `"T1"`, indicating a request that originated over TOR.
+   *
+   * If Cloudflare is unable to determine where the request originated this property is omitted.
+   *
+   * The country code `"T1"` is used for requests originating on TOR.
+   *
+   * @example "GB"
+   */
+  country?: Iso3166Alpha2Code | "T1";
+  /**
+   * If present, this property indicates that the request originated in the EU
+   *
+   * @example "1"
+   */
+  isEUCountry?: "1";
+  /**
+   * A two-letter code indicating the continent the request originated from.
+   *
+   * @example "AN"
+   */
+  continent?: ContinentCode;
+  /**
+   * The city the request originated from
+   *
+   * @example "Austin"
+   */
+  city?: string;
+  /**
+   * Postal code of the incoming request
+   *
+   * @example "78701"
+   */
+  postalCode?: string;
+  /**
+   * Latitude of the incoming request
+   *
+   * @example "30.27130"
+   */
+  latitude?: string;
+  /**
+   * Longitude of the incoming request
+   *
+   * @example "-97.74260"
+   */
+  longitude?: string;
+  /**
+   * Timezone of the incoming request
+   *
+   * @example "America/Chicago"
+   */
+  timezone?: string;
+  /**
+   * If known, the ISO 3166-2 name for the first level region associated with
+   * the IP address of the incoming request
+   *
+   * @example "Texas"
+   */
+  region?: string;
+  /**
+   * If known, the ISO 3166-2 code for the first-level region associated with
+   * the IP address of the incoming request
+   *
+   * @example "TX"
+   */
+  regionCode?: string;
+  /**
+   * Metro code (DMA) of the incoming request
+   *
+   * @example "635"
+   */
+  metroCode?: string;
+}
 
 /** Data about the incoming request's TLS certificate */
 interface IncomingRequestCfPropertiesTLSClientAuth {
@@ -945,3 +939,7 @@ declare type Iso3166Alpha2Code =
 
 /** The 2-letter continent codes Cloudflare uses */
 declare type ContinentCode = "AF" | "AN" | "AS" | "EU" | "NA" | "OC" | "SA";
+
+type CfProperties<HostMetadata = unknown> =
+  | IncomingRequestCfProperties<HostMetadata>
+  | RequestInitCfProperties;

--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -249,6 +249,49 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * the origin.
    */
   "origin-auth"?: "share-publicly";
+  /**
+   * Adds a border around the image. The border is added after resizing. Border
+   * width takes dpr into account, and can be specified either using a single
+   * width property, or individually for each side.
+   */
+  border?:
+    | {
+        color: string;
+        width: number;
+      }
+    | {
+        color: string;
+        top: number;
+        right: number;
+        bottom: number;
+        left: number;
+      };
+  /**
+   * Increase brightness by a factor. A value of 1.0 equals no change, a value
+   * of 0.5 equals half brightness, and a value of 2.0 equals twice as bright.
+   * 0 is ignored.
+   */
+  brightness?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  contrast?: number;
+  /**
+   * Increase exposure by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
+   */
+  gamma?: number;
+  /**
+   * Slightly reduces latency on a cache miss by selecting a
+   * quickest-to-compress file format, at a cost of increased file size and
+   * lower image quality. It will usually override the format option and choose
+   * JPEG over WebP or AVIF. We do not recommend using this option, except in
+   * unusual circumstances like resizing uncacheable dynamically-generated
+   * images.
+   */
+  compression?: "fast";
 }
 
 interface RequestInitCfPropertiesImageMinify {

--- a/types/test/types/cf.ts
+++ b/types/test/types/cf.ts
@@ -1,0 +1,38 @@
+function expectType<T>(_value: T) {}
+
+export const handler: ExportedHandler<{ SERVICE: Fetcher }> = {
+  async fetch(request, env) {
+    // Can access incoming cf properties without narrowing
+    expectType<string | undefined>(request.cf?.colo);
+    // ...but cannot access request init cf properties
+    expectType<unknown>(request.cf?.cacheEverything);
+
+    // Can forward request as is (unknown cf properties ignored)
+    await fetch(request);
+
+    // Can forward request to different URL  (unknown cf properties ignored)
+    await fetch("https://example.com", request);
+
+    // Can fetch with request init cf properties
+    await fetch("https://example.com", {
+      cf: { cacheEverything: true },
+    });
+
+    // Can fetch to service binding with incoming properties to simulate incoming request
+    await env.SERVICE.fetch("https://example.com", {
+      cf: { colo: "LHR" },
+    });
+
+    // Can fetch to service binding with custom properties
+    await env.SERVICE.fetch("https://example.com", {
+      cf: { token: "thing" },
+    });
+    // ...and can safely access that on the incoming request
+    expectType<unknown>(request.cf?.token);
+    if (typeof request.cf?.token === "string") {
+      expectType<string>(request.cf.token);
+    }
+
+    return new Response();
+  },
+};

--- a/types/test/types/tsconfig.json
+++ b/types/test/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["esnext"],
+    "strict": true,
+    "types": ["../../../bazel-bin/types/definitions/experimental"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -21,5 +21,8 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts"
+  ],
+  "exclude": [
+    "test/types/**/*.ts"
   ]
 }


### PR DESCRIPTION
- Type `Request#cf` based on type parameter, allowing `Request` construction with `RequestInitCfProperties`
- Make `RequestInitCfProperties` and `IncomingRequestCfProperties` extend `Record<string, unknown>`, allowing incoming requests to be passed directly to fetch, and custom properties to added when making requests to service bindings
- Make all `IncomingRequestCfPropertiesGeographicInformation` fields optional, making it easier to access `cf` geo-properties whilst still maintaining correctness

Closes #324
Closes #397 