### PR TITLE
bazel: Reuse sandbox directories

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,10 @@ build --cxxopt='-Wno-ignored-qualifiers' --host_cxxopt='-Wno-ignored-qualifiers'
 #   for workerd?
 build --cxxopt='-Wno-ambiguous-reversed-operator' --host_cxxopt='-Wno-ambiguous-reversed-operator'
 
+# Speed up sandboxed compilation, particularly on I/O-constrained and non-Linux systems
+# https://bazel.build/reference/command-line-reference#flag--reuse_sandbox_directories
+build --reuse_sandbox_directories
+
 
 # optimized LTO build. you'll need a fairly recent clang for this to work
 build:thin-lto -c opt


### PR DESCRIPTION
[reuse_sandbox_directories](https://bazel.build/reference/command-line-reference#flag--reuse_sandbox_directories) should be a flag worth using in all cases. While there is scant documentation the only potential issue with it I was able to find is [bazel #17310](https://github.com/bazelbuild/bazel/issues/17310) (resolved on upstream bazel but not yet released, unlikely to affect us though). It is a non-experimental option since bazel v6.
The flag significantly reduces the sandbox setup/teardown overhead and provides a large compilation speedup on M1 macOS and a noticeable speedup on Linux x86, especially on systems with slow disk I/O (based on Orion's testing), it should be worth enabling globally.

Let's merge this once we have integrated #361, that way we can use the non-experimental flag. I can gather some additional performance metrics at that time.