### PR TITLE
Implements startTls for TCP sockets.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,10 +35,10 @@ rules_foreign_cc_dependencies()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "72dfd487fcdec4223bd6475a4f481b07f7a8884e09185e0c68b67730f1711f0b",
-    strip_prefix = "capnproto-capnproto-9b1acb2/c++",
+    sha256 = "8bb47cfa7d7c6349764d7c696c67e6f545d9c6d2987620441f72e6c91b03e60f",
+    strip_prefix = "capnproto-capnproto-d3702c0/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/9b1acb2f642fef318576c10a215bf6590c77538b"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/d3702c026f36e22d5475922e520669e79a0f89aa"],
 )
 
 http_archive(

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -5,6 +5,7 @@
 #include "sockets.h"
 #include "system-streams.h"
 #include <workerd/io/worker-interface.h>
+#include "url-standard.h"
 
 
 namespace workerd::api {
@@ -40,10 +41,51 @@ bool isValidHost(kj::StringPtr host) {
   return true;
 }
 
+jsg::Ref<Socket> setupSocket(
+    jsg::Lock& js, kj::Own<kj::AsyncIoStream> connection,
+    jsg::Optional<SocketOptions> options, kj::TlsStarterCallback tlsStarter, bool isSecureSocket,
+    kj::String domain) {
+  auto& ioContext = IoContext::current();
+  auto connDisconnPromise = connection->whenWriteDisconnected();
+
+  // Initialise the readable/writable streams with the readable/writable sides of an AsyncIoStream.
+  auto sysStreams = newSystemMultiStream(kj::mv(connection), ioContext);
+  auto readable = jsg::alloc<ReadableStream>(ioContext, kj::mv(sysStreams.readable));
+  readable->initEofResolverPair(js);
+  auto writable = jsg::alloc<WritableStream>(ioContext, kj::mv(sysStreams.writable));
+
+  auto closeFulfiller = jsg::newPromiseAndResolver<void>(ioContext.getCurrentLock().getIsolate());
+  closeFulfiller.promise.markAsHandled();
+
+  auto result = jsg::alloc<Socket>(
+      js, kj::mv(readable), kj::mv(writable), kj::mv(closeFulfiller), kj::mv(connDisconnPromise),
+      kj::mv(options), kj::mv(tlsStarter), isSecureSocket, kj::mv(domain));
+  result->handleReadableEof(js);
+  return result;
+}
+
 jsg::Ref<Socket> connectImplNoOutputLock(
     jsg::Lock& js, jsg::Ref<Fetcher> fetcher, AnySocketAddress address,
     jsg::Optional<SocketOptions> options) {
 
+  // Extract the domain/ip we are connecting to from the address.
+  kj::String domain;
+  KJ_SWITCH_ONEOF(address) {
+    KJ_CASE_ONEOF(str, kj::String) {
+      // We need just the hostname part of the address, i.e. we want to strip out the port.
+      // We do this using the standard URL parser since it will handle IPv6 for us as well.
+      auto record = JSG_REQUIRE_NONNULL(url::URL::parse(jsg::usv(kj::str("https://", str))),
+          TypeError, "Specified address could not be parsed.");
+      auto& host = JSG_REQUIRE_NONNULL(record.host, TypeError,
+          "Specified address is missing hostname.");
+      domain = host.toStr();
+    }
+    KJ_CASE_ONEOF(record, SocketAddress) {
+      domain = kj::heapString(record.hostname);
+    }
+  }
+
+  // Convert the address to a string that we can pass to kj.
   auto addressStr = kj::str("");
   KJ_SWITCH_ONEOF(address) {
     KJ_CASE_ONEOF(str, kj::String) {
@@ -70,27 +112,18 @@ jsg::Ref<Socket> connectImplNoOutputLock(
   KJ_IF_MAYBE(opts, options) {
     httpConnectSettings.useTls = opts->useSecureTransport;
   }
+  kj::TlsStarterCallback tlsStarter;
+  httpConnectSettings.tlsStarter = &tlsStarter;
   auto request = httpClient->connect(addressStr, *headers, httpConnectSettings);
   request.connection = request.connection.attach(kj::mv(httpClient));
-  auto connDisconnPromise = request.connection->whenWriteDisconnected();
 
-  // Initialise the readable/writable streams with the readable/writable sides of an AsyncIoStream.
-  auto sysStreams = newSystemMultiStream(kj::mv(request.connection), ioContext);
-  auto readable = jsg::alloc<ReadableStream>(ioContext, kj::mv(sysStreams.readable));
-  readable->initEofResolverPair(js);
-  auto writable = jsg::alloc<WritableStream>(ioContext, kj::mv(sysStreams.writable));
-
-  auto closeFulfiller = kj::heap<jsg::PromiseResolverPair<void>>(
-      jsg::newPromiseAndResolver<void>(ioContext.getCurrentLock().getIsolate()));
-  closeFulfiller->promise.markAsHandled();
-
-  auto result = jsg::alloc<Socket>(
-      js, kj::mv(readable), kj::mv(writable), kj::mv(closeFulfiller), kj::mv(connDisconnPromise),
-      kj::mv(options));
+  auto result = setupSocket(
+      js, kj::mv(request.connection), kj::mv(options), kj::mv(tlsStarter),
+      httpConnectSettings.useTls, kj::mv(domain));
   // `handleProxyStatus` needs an initialised refcount to use `JSG_THIS`, hence it cannot be
-  // called in Socket's constructor.
+  // called in Socket's constructor. Also it's only necessary when creating a Socket as a result of
+  // a `connect`.
   result->handleProxyStatus(js, kj::mv(request.status));
-  result->handleReadableEof(js);
   return result;
 }
 
@@ -122,6 +155,32 @@ jsg::Promise<void> Socket::close(jsg::Lock& js) {
       return js.resolvedPromise();
     });
   }, [this](jsg::Lock& js, jsg::Value err) { return errorHandler(js, kj::mv(err)); });
+}
+
+jsg::Ref<Socket> Socket::startTls(jsg::Lock& js, jsg::Optional<TlsOptions> tlsOptions) {
+  JSG_REQUIRE(!isSecureSocket, TypeError, "Cannot startTls on a TLS socket.");
+  // TODO: Track closed state of socket properly and assert that it hasn't been closed here.
+  JSG_REQUIRE(domain != nullptr, TypeError, "startTLS can only be called once.");
+
+  // The current socket's writable buffers need to be flushed. The socket's WritableStream is backed
+  // by an AsyncIoStream which doesn't implement any buffering, so we don't need to worry about
+  // flushing. But this is something to keep in mind in case this assumption no longer holds in
+  // the future.
+  //
+  // Detach the AsyncIoStream from the Writable/Readable streams and make them unusable.
+  writable->removeSink(js);
+  readable->detach(js);
+  closeFulfiller.resolver.resolve();
+
+  auto acceptedHostname = domain.asPtr();
+  KJ_IF_MAYBE(s, tlsOptions) {
+    KJ_IF_MAYBE(expectedHost, s->expectedServerHostname) {
+      acceptedHostname = *expectedHost;
+    }
+  }
+  // All non-secure sockets should have a tlsStarter.
+  kj::Own<kj::AsyncIoStream> secure = KJ_ASSERT_NONNULL(tlsStarter)(acceptedHostname);
+  return setupSocket(js, kj::mv(secure), kj::mv(options), nullptr, true, kj::mv(domain));
 }
 
 void Socket::handleProxyStatus(
@@ -170,7 +229,7 @@ jsg::Promise<void> Socket::maybeCloseWriteSide(jsg::Lock& js) {
     // We only want to ensure that the writable stream is flushed before closing the socket.
     // With the above we are certain that it was flushed, so we are safe to close.
   }).then(js, JSG_VISITABLE_LAMBDA((ref=JSG_THIS), (ref), (jsg::Lock& js) {
-    ref->closeFulfiller->resolver.resolve();
+    ref->closeFulfiller.resolver.resolve();
   }));
 }
 


### PR DESCRIPTION
Capnproto: https://github.com/capnproto/capnproto/pull/1635

**Note**: Tests will fail here until I merge the capnproto change.

### Test Plan

With script: https://gist.github.com/dom96/68f1ecf9b4f148696551cf637b7de2e4

```
$ bazel run @workerd//src/workerd/server:workerd -- serve $PWD/deps/workerd/samples/tcp/config.capnp --watch --verbose --experimental
$ curl -v localhost:8080
```

Logs: https://gist.github.com/dom96/0de7148b7b5a99de709b48a00d095187