### PR TITLE
Switch to api.ast.json.gz instead of api.ast.json

### DIFF
--- a/build/cc_ast_dump.bzl
+++ b/build/cc_ast_dump.bzl
@@ -37,7 +37,7 @@ def _cc_ast_dump_impl(ctx):
     inputs = depset(direct = [ctx.file.src], transitive = [cc_toolchain.all_files] + [cc_info.compilation_context.headers])
     env = cc_common.get_environment_variables(feature_configuration = feature_configuration, action_name = CPP_COMPILE_ACTION_NAME, variables = variables)
 
-    command = " ".join([executable] + arguments + [">", ctx.outputs.out.path])
+    command = " ".join([executable] + arguments + ["|", "gzip", "-3", "-", ">", ctx.outputs.out.path])
 
     # run_shell until https://github.com/bazelbuild/bazel/issues/5511 is fixed
     ctx.actions.run_shell(

--- a/rust-deps/BUILD.bazel
+++ b/rust-deps/BUILD.bazel
@@ -108,6 +108,9 @@ crates_vendor(
         "clang-ast": crate.spec(
             version = "0.1",
         ),
+        "flate2": crate.spec(
+            version = "1.0.24",
+        ),
         "serde": crate.spec(
             version = "1.0",
             features = ["default", "derive"],

--- a/rust-deps/crates/BUILD.bazel
+++ b/rust-deps/crates/BUILD.bazel
@@ -58,6 +58,12 @@ alias(
 )
 
 alias(
+    name = "flate2",
+    actual = "@crates_vendor__flate2-1.0.24//:flate2",
+    tags = ["manual"],
+)
+
+alias(
     name = "libc",
     actual = "@crates_vendor__libc-0.2.137//:libc",
     tags = ["manual"],

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -89,7 +89,7 @@ filegroup(
 cc_ast_dump(
     name = "dump_api_ast",
     src = api_encoder_src,
-    out = "api.ast.json",
+    out = "api.ast.json.gz",
     deps = [":api_encoder_lib"],
 )
 
@@ -99,6 +99,7 @@ rust_binary(
     deps = [
         "@crates_vendor//:anyhow",
         "@crates_vendor//:clang-ast",
+        "@crates_vendor//:flate2",
         "@crates_vendor//:pico-args",
         "@crates_vendor//:serde",
         "@crates_vendor//:serde_json",


### PR DESCRIPTION
api.ast.json consumes 2.5GB in the output directory, compressing it saves 2.4GB of storage. The saving is useful in devhouse and for github actions (linux SSD size 14GB).

Test: build bazel //... && bazel test //...