### PR TITLE
Add mirror for nodejs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -212,7 +212,11 @@ load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 
 nodejs_register_toolchains(
     name = "nodejs",
-    node_version = "18.10.0",
+    node_version = "18.12.0",
+    node_urls = [
+        "https://dl.workers-for-platforms.workers.dev/https://nodejs.org/dist/v{version}/{filename}",
+        "https://nodejs.org/dist/v{version}/{filename}",
+   ]
 )
 
 load("@aspect_rules_ts//ts:repositories.bzl", TS_LATEST_VERSION = "LATEST_VERSION", "rules_ts_dependencies")


### PR DESCRIPTION
Update nodejs to version 18.12 to sync with edgeworker.