### PR TITLE
Refactor / cleanup sqlite integration

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,10 +35,10 @@ rules_foreign_cc_dependencies()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "8bb47cfa7d7c6349764d7c696c67e6f545d9c6d2987620441f72e6c91b03e60f",
-    strip_prefix = "capnproto-capnproto-d3702c0/c++",
+    sha256 = "62e337ef35061c774678be5d0b0abc8b69f78a0481b253bffe4992e74f649757",
+    strip_prefix = "capnproto-capnproto-6a3dd15/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/d3702c026f36e22d5475922e520669e79a0f89aa"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/6a3dd152d0d1245b1c44af8e76c78169cedadf03"],
 )
 
 http_archive(

--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -141,7 +141,7 @@ jsg::Value listResultsToMap(v8::Isolate* isolate, ActorCache::GetResultList valu
   size_t cachedReadBytes = 0;
   size_t uncachedReadBytes = 0;
   for (auto entry: value) {
-    auto& bytesRef = entry.status == ActorCacheInterface::CacheStatus::CACHED
+    auto& bytesRef = entry.status == ActorCacheOps::CacheStatus::CACHED
                    ? cachedReadBytes : uncachedReadBytes;
     bytesRef += entry.key.size() + entry.value.size();
     jsg::check(map->Set(context, jsg::v8Str(isolate, entry.key),
@@ -179,7 +179,7 @@ kj::Function<jsg::Value(v8::Isolate*, ActorCache::GetResultList)> getMultipleRes
     uint32_t cachedUnits = 0;
     uint32_t uncachedUnits = 0;
     for (auto entry: value) {
-      auto& unitsRef = entry.status == ActorCacheInterface::CacheStatus::CACHED
+      auto& unitsRef = entry.status == ActorCacheOps::CacheStatus::CACHED
                     ? cachedUnits : uncachedUnits;
       unitsRef += billingUnits(entry.key.size() + entry.value.size());
       jsg::check(map->Set(context, jsg::v8Str(isolate, entry.key),
@@ -581,7 +581,7 @@ jsg::Promise<int> DurableObjectStorageOperations::deleteMultiple(
   });
 }
 
-ActorCacheInterface& DurableObjectStorage::getCache(OpName op) {
+ActorCacheOps& DurableObjectStorage::getCache(OpName op) {
   KJ_SWITCH_ONEOF(cache) {
     KJ_CASE_ONEOF(actorCache, IoPtr<ActorCache>) {
       return *actorCache;
@@ -675,7 +675,7 @@ jsg::Promise<void> DurableObjectStorage::sync(jsg::Lock& js) {
   KJ_UNREACHABLE;
 }
 
-ActorCacheInterface& DurableObjectTransaction::getCache(OpName op) {
+ActorCacheOps& DurableObjectTransaction::getCache(OpName op) {
   JSG_REQUIRE(!rolledBack, Error, kj::str("Cannot ", op, " on rolled back transaction"));
   auto& result = *JSG_REQUIRE_NONNULL(cacheTxn, Error,
       kj::str("Cannot call ", op,

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -142,7 +142,7 @@ protected:
     return op == OP_GET || op == OP_LIST || op == OP_ROLLBACK;
   }
 
-  virtual ActorCacheInterface& getCache(OpName op) = 0;
+  virtual ActorCacheOps& getCache(OpName op) = 0;
 
   virtual bool useDirectIo() = 0;
   // Whether to skip caching and allow concurrency on all operations.
@@ -228,7 +228,7 @@ public:
   }
 
 protected:
-  ActorCacheInterface& getCache(kj::StringPtr op) override;
+  ActorCacheOps& getCache(kj::StringPtr op) override;
 
   bool useDirectIo() override {
     return false;
@@ -281,7 +281,7 @@ public:
   }
 
 protected:
-  ActorCacheInterface& getCache(kj::StringPtr op) override;
+  ActorCacheOps& getCache(kj::StringPtr op) override;
 
   bool useDirectIo() override {
     return false;

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -36,7 +36,7 @@ public:
     jsg::Optional<bool> allowConcurrency;
     jsg::Optional<bool> noCache;
 
-    inline operator ActorCache::ReadOptions() const {
+    inline operator ActorCacheOps::ReadOptions() const {
       return {
         .noCache = noCache.orDefault(false)
       };
@@ -70,7 +70,7 @@ public:
     jsg::Optional<bool> allowConcurrency;
     jsg::Optional<bool> noCache;
 
-    inline operator ActorCache::ReadOptions() const {
+    inline operator ActorCacheOps::ReadOptions() const {
       return {
         .noCache = noCache.orDefault(false)
       };
@@ -87,7 +87,7 @@ public:
     jsg::Optional<bool> allowUnconfirmed;
     jsg::Optional<bool> noCache;
 
-    inline operator ActorCache::WriteOptions() const {
+    inline operator ActorCacheOps::WriteOptions() const {
       return {
         .allowUnconfirmed = allowUnconfirmed.orDefault(false),
         .noCache = noCache.orDefault(false)
@@ -112,7 +112,7 @@ public:
     jsg::Optional<bool> allowUnconfirmed;
     // We don't allow noCache for alarm puts.
 
-    inline operator ActorCache::WriteOptions() const {
+    inline operator ActorCacheOps::WriteOptions() const {
       return {
         .allowUnconfirmed = allowUnconfirmed.orDefault(false),
       };
@@ -177,7 +177,7 @@ class DurableObjectTransaction;
 
 class DurableObjectStorage: public jsg::Object, public DurableObjectStorageOperations {
 public:
-  DurableObjectStorage(IoPtr<ActorCache> cache)
+  DurableObjectStorage(IoPtr<ActorCacheInterface> cache)
     : cache(kj::mv(cache)) {}
   DurableObjectStorage(IoPtr<ActorSqlite> sqliteKv)
     : cache(kj::mv(sqliteKv)) {}
@@ -235,12 +235,12 @@ protected:
   }
 
 private:
-  kj::OneOf<IoPtr<ActorCache>, IoPtr<ActorSqlite>> cache;
+  kj::OneOf<IoPtr<ActorCacheInterface>, IoPtr<ActorSqlite>> cache;
 };
 
 class DurableObjectTransaction final: public jsg::Object, public DurableObjectStorageOperations {
 public:
-  DurableObjectTransaction(IoOwn<ActorCache::Transaction> cacheTxn)
+  DurableObjectTransaction(IoOwn<ActorCacheInterface::Transaction> cacheTxn)
     : cacheTxn(kj::mv(cacheTxn)) {}
 
   kj::Promise<void> maybeCommit();
@@ -288,7 +288,7 @@ protected:
   }
 
 private:
-  kj::Maybe<IoOwn<ActorCache::Transaction>> cacheTxn;
+  kj::Maybe<IoOwn<ActorCacheInterface::Transaction>> cacheTxn;
   // Becomes null when committed or rolled back.
 
   bool rolledBack = false;

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -15,7 +15,6 @@
 #include <workerd/io/promise-wrapper.h>
 #include "util.h"
 #include <workerd/io/actor-cache.h>
-#include <workerd/io/actor-sqlite.h>
 
 namespace workerd::api {
 
@@ -179,8 +178,6 @@ class DurableObjectStorage: public jsg::Object, public DurableObjectStorageOpera
 public:
   DurableObjectStorage(IoPtr<ActorCacheInterface> cache)
     : cache(kj::mv(cache)) {}
-  DurableObjectStorage(IoPtr<ActorSqlite> sqliteKv)
-    : cache(kj::mv(sqliteKv)) {}
 
   struct TransactionOptions {
     jsg::Optional<kj::Date> asOfTime;
@@ -235,7 +232,7 @@ protected:
   }
 
 private:
-  kj::OneOf<IoPtr<ActorCacheInterface>, IoPtr<ActorSqlite>> cache;
+  IoPtr<ActorCacheInterface> cache;
 };
 
 class DurableObjectTransaction final: public jsg::Object, public DurableObjectStorageOperations {

--- a/src/workerd/io/actor-cache-test.c++
+++ b/src/workerd/io/actor-cache-test.c++
@@ -136,7 +136,7 @@ struct ActorCacheConvenienceWrappers {
   // This is formulated as a mixin inherited by ActorCacheTest, below, so that it can be reused
   // for transactions as well.
 
-  ActorCacheConvenienceWrappers(ActorCacheInterface& target): target(target) {}
+  ActorCacheConvenienceWrappers(ActorCacheOps& target): target(target) {}
 
   auto get(kj::StringPtr key, ActorCache::ReadOptions options = {}) {
     return stringifyValues(target.get(kj::str(key), options));
@@ -186,7 +186,7 @@ struct ActorCacheConvenienceWrappers {
   }
 
 private:
-  ActorCacheInterface& target;
+  ActorCacheOps& target;
 };
 
 struct ActorCacheTestOptions {

--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -12,6 +12,10 @@
 #include <workerd/io/io-gate.h>
 #include <workerd/util/sentry.h>
 
+// TODO(cleanup): Break dependency on IoContext. ActorCache is intended to be independent of the
+//   rest of the codebase.
+#include <workerd/io/io-context.h>
+
 namespace workerd {
 
 static constexpr size_t MAX_ACTOR_STORAGE_RPC_WORDS = (16u << 20) / sizeof(capnp::word);

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -43,7 +43,7 @@ struct ActorCacheWriteOptions {
   // key.  Hence, `noCache` does not affect consistency, only performance.
 };
 
-class ActorCacheInterface {
+class ActorCacheOps {
   // Common interface between ActorCache and ActorCache::Transaction.
 public:
   typedef kj::String Key;
@@ -157,7 +157,7 @@ public:
   // from underlying storage. The promise also applies backpressure if needed, as with put().
 };
 
-class ActorCache final: public ActorCacheInterface {
+class ActorCache final: public ActorCacheOps {
   // An in-memory caching layer on top of ActorStorage.Stage RPC interface.
   //
   // This cache assumes that it is the only client of the underlying storage -- which is, of
@@ -202,7 +202,7 @@ public:
   kj::OneOf<uint, kj::Promise<uint>> delete_(kj::Array<Key> keys, WriteOptions options) override;
   kj::Maybe<kj::Promise<void>> setAlarm(kj::Maybe<kj::Date> newAlarmTime, WriteOptions options) override;
   kj::Maybe<kj::Promise<void>> onNoPendingFlush();
-  // See ActorCacheInterface.
+  // See ActorCacheOps.
 
   struct DeleteAllResults {
     // We split these up so client code that doesn't need the count doesn't have to
@@ -212,7 +212,7 @@ public:
   };
 
   DeleteAllResults deleteAll(WriteOptions options);
-  // Delete everything in the actor's storage. This is not part of ActorCacheInterface because it
+  // Delete everything in the actor's storage. This is not part of ActorCacheOps because it
   // is not supported as part of a transaction.
   //
   // The returned count only includes keys that were actually deleted from storage, not keys in
@@ -669,10 +669,10 @@ private:
   class GetMultiStreamImpl;
   class ForwardListStreamImpl;
   class ReverseListStreamImpl;
-  friend class ActorCacheInterface::GetResultList;
+  friend class ActorCacheOps::GetResultList;
 };
 
-class ActorCacheInterface::GetResultList {
+class ActorCacheOps::GetResultList {
   using Entry = ActorCache::Entry;
 public:
   class Iterator {
@@ -806,7 +806,7 @@ private:
   friend class ActorCache;
 };
 
-class ActorCache::Transaction final: public ActorCacheInterface {
+class ActorCache::Transaction final: public ActorCacheOps {
   // A transaction represents a set of writes that haven't been committed. The transaction can be
   // discarded without committing.
   //

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -6,7 +6,6 @@
 
 #include <kj/async.h>
 #include <workerd/io/actor-storage.h>
-#include <workerd/io/io-context.h>
 #include <kj/one-of.h>
 #include <kj/map.h>
 #include <kj/list.h>

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -7,17 +7,17 @@
 
 namespace workerd {
 
-kj::OneOf<kj::Maybe<ActorCacheInterface::Value>,
-          kj::Promise<kj::Maybe<ActorCacheInterface::Value>>>
+kj::OneOf<kj::Maybe<ActorCacheOps::Value>,
+          kj::Promise<kj::Maybe<ActorCacheOps::Value>>>
     ActorSqlite::get(Key key, ReadOptions options) {
-  kj::Maybe<ActorCacheInterface::Value> result;
+  kj::Maybe<ActorCacheOps::Value> result;
   kv.get(key, [&](ValuePtr value) {
     result = kj::heapArray(value);
   });
   return result;
 }
 
-kj::OneOf<ActorCacheInterface::GetResultList, kj::Promise<ActorCacheInterface::GetResultList>>
+kj::OneOf<ActorCacheOps::GetResultList, kj::Promise<ActorCacheOps::GetResultList>>
     ActorSqlite::get(kj::Array<Key> keys, ReadOptions options) {
   kj::Vector<KeyValuePair> results;
   for (auto& key: keys) {
@@ -36,7 +36,7 @@ kj::OneOf<kj::Maybe<kj::Date>, kj::Promise<kj::Maybe<kj::Date>>> ActorSqlite::ge
   JSG_FAIL_REQUIRE(Error, "getAlarm() is not yet implemented for SQLite-backed Durable Objects");
 }
 
-kj::OneOf<ActorCacheInterface::GetResultList, kj::Promise<ActorCacheInterface::GetResultList>>
+kj::OneOf<ActorCacheOps::GetResultList, kj::Promise<ActorCacheOps::GetResultList>>
     ActorSqlite::list(Key begin, kj::Maybe<Key> end, kj::Maybe<uint> limit, ReadOptions options) {
   kj::Vector<KeyValuePair> results;
   kv.list(begin, end, limit, SqliteKv::FORWARD, [&](KeyPtr key, ValuePtr value) {
@@ -47,7 +47,7 @@ kj::OneOf<ActorCacheInterface::GetResultList, kj::Promise<ActorCacheInterface::G
   return GetResultList(kj::mv(results));
 }
 
-kj::OneOf<ActorCacheInterface::GetResultList, kj::Promise<ActorCacheInterface::GetResultList>>
+kj::OneOf<ActorCacheOps::GetResultList, kj::Promise<ActorCacheOps::GetResultList>>
     ActorSqlite::listReverse(Key begin, kj::Maybe<Key> end, kj::Maybe<uint> limit,
                                ReadOptions options) {
   kj::Vector<KeyValuePair> results;

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -91,4 +91,42 @@ kj::Maybe<kj::Promise<void>> ActorSqlite::setAlarm(
   JSG_FAIL_REQUIRE(Error, "getAlarm() is not yet implemented for SQLite-backed Durable Objects");
 }
 
+kj::Own<ActorCacheInterface::Transaction> ActorSqlite::startTransaction() {
+  // TODO(sqlite): Implement transactions.
+  JSG_FAIL_REQUIRE(Error, "transaction() not yet implemented for SQLite-backed storage");
+}
+
+ActorCacheInterface::DeleteAllResults ActorSqlite::deleteAll(WriteOptions options) {
+  uint count = kv.deleteAll();
+  return {
+    .backpressure = nullptr,
+    .count = count,
+  };
+}
+
+kj::Maybe<kj::Promise<void>> ActorSqlite::evictStale(kj::Date now) {
+  // TODO(sqlite): This is called every time the isolate lock is taken. We can temporarily delay
+  //   the lock by returning a promise. This could be a good time to apply backpressure on the
+  //   application e.g. while waiting for an asynchronous checkpoint to complete or for replication
+  //   buffers to go down.
+  return nullptr;
+}
+
+void ActorSqlite::shutdown(kj::Maybe<const kj::Exception&> maybeException) {
+  // Nothing here (yet).
+}
+
+kj::Maybe<kj::Own<void>> ActorSqlite::armAlarmHandler(kj::Date scheduledTime, bool noCache) {
+  JSG_FAIL_REQUIRE(Error, "alarms are not yet implemented for SQLite-backed Durable Objects");
+}
+
+void ActorSqlite::cancelDeferredAlarmDeletion() {
+  JSG_FAIL_REQUIRE(Error, "alarms are not yet implemented for SQLite-backed Durable Objects");
+}
+
+kj::Maybe<kj::Promise<void>> ActorSqlite::onNoPendingFlush() {
+  // TODO(sqlite): onNoPendingFlush() should wait for replication if applicable.
+  return nullptr;
+}
+
 }  // namespace workerd

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -4,6 +4,7 @@
 
 #include "actor-sqlite.h"
 #include <algorithm>
+#include <workerd/jsg/jsg.h>
 
 namespace workerd {
 

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -9,8 +9,8 @@
 
 namespace workerd {
 
-class ActorSqlite final: public ActorCacheInterface {
-  // An implementation of ActorCacheInterface that is backed by SqliteKv.
+class ActorSqlite final: public ActorCacheOps {
+  // An implementation of ActorCacheOps that is backed by SqliteKv.
   //
   // TODO(perf): This interface is not designed ideally for wrapping SqliteKv. In particular, we
   //   end up allocating extra copies of all the results. It would be nicer if we could actually

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2813,13 +2813,13 @@ kj::Maybe<jsg::Value> Worker::Actor::getTransient(Worker::Lock& lock) {
   return impl->transient.map([&](jsg::Value& val) { return val.addRef(lock.getIsolate()); });
 }
 
-kj::Maybe<ActorCache&> Worker::Actor::getPersistent() {
+kj::Maybe<ActorCacheInterface&> Worker::Actor::getPersistent() {
   return impl->actorCache;
 }
 
 kj::Maybe<jsg::Ref<api::DurableObjectStorage>>
     Worker::Actor::makeStorageForSwSyntax(Worker::Lock& lock) {
-  return impl->actorCache.map([&](ActorCache& cache) {
+  return impl->actorCache.map([&](ActorCacheInterface& cache) {
     return impl->makeStorage(lock, *worker->getIsolate().apiIsolate, cache);
   });
 }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2527,7 +2527,7 @@ struct Worker::Actor::Impl final: public kj::TaskSet::ErrorHandler {
   kj::Own<ActorObserver> metrics;
 
   kj::Maybe<jsg::Value> transient;
-  kj::Maybe<ActorCache> actorCache;
+  kj::Maybe<kj::Own<ActorCacheInterface>> actorCache;
 
   struct NoClass {};
   struct Initializing {};
@@ -2615,7 +2615,7 @@ struct Worker::Actor::Impl final: public kj::TaskSet::ErrorHandler {
   // Used to handle deduplication of alarm requests
 
   Impl(Worker::Actor& self, Worker::Lock& lock, Actor::Id actorId,
-       bool hasTransient, kj::Maybe<rpc::ActorStorage::Stage::Client> persistent,
+       bool hasTransient, MakeActorCacheFunc makeActorCache,
        MakeStorageFunc makeStorage, TimerChannel& timerChannel,
        kj::Own<ActorObserver> metricsParam,
        kj::PromiseFulfillerPair<void> paf = kj::newPromiseAndFulfiller<void>())
@@ -2633,10 +2633,7 @@ struct Worker::Actor::Impl final: public kj::TaskSet::ErrorHandler {
       transient.emplace(isolate, v8::Object::New(isolate));
     }
 
-    KJ_IF_MAYBE(p, persistent) {
-      actorCache.emplace(kj::mv(*p), self.worker->getIsolate().impl->actorCacheLru,
-                         outputGate);
-    }
+    actorCache = makeActorCache(self.worker->getIsolate().impl->actorCacheLru, outputGate);
   }
 
   void taskFailed(kj::Exception&& e) override {
@@ -2650,7 +2647,7 @@ kj::Promise<Worker::AsyncLock> Worker::takeAsyncLockWhenActorCacheReady(
       .tryCreateLockTiming(kj::Maybe<RequestObserver&>(request));
 
   KJ_IF_MAYBE(c, actor.impl->actorCache) {
-    KJ_IF_MAYBE(p, c->evictStale(now)) {
+    KJ_IF_MAYBE(p, c->get()->evictStale(now)) {
       // Got backpressure, wait for it.
       // TODO(someday): Count this time period differently in lock timing data?
       return p->then([this, lockTiming = kj::mv(lockTiming)]() mutable {
@@ -2663,12 +2660,12 @@ kj::Promise<Worker::AsyncLock> Worker::takeAsyncLockWhenActorCacheReady(
 }
 
 Worker::Actor::Actor(const Worker& worker, kj::Maybe<RequestTracker&> tracker, Actor::Id actorId,
-    bool hasTransient, kj::Maybe<rpc::ActorStorage::Stage::Client> persistent,
+    bool hasTransient, MakeActorCacheFunc makeActorCache,
     kj::Maybe<kj::StringPtr> className, MakeStorageFunc makeStorage, Worker::Lock& lock,
     TimerChannel& timerChannel,
     kj::Own<ActorObserver> metrics)
     : worker(kj::atomicAddRef(worker)), tracker(tracker) {
-  impl = kj::heap<Impl>(*this, lock, kj::mv(actorId), hasTransient, kj::mv(persistent),
+  impl = kj::heap<Impl>(*this, lock, kj::mv(actorId), hasTransient, kj::mv(makeActorCache),
                         kj::mv(makeStorage), timerChannel, kj::mv(metrics));
 
   KJ_IF_MAYBE(c, className) {
@@ -2689,7 +2686,7 @@ void Worker::Actor::ensureConstructed(IoContext& context) {
 
       kj::Maybe<jsg::Ref<api::DurableObjectStorage>> storage;
       KJ_IF_MAYBE(c, impl->actorCache) {
-        storage = impl->makeStorage(lock, *worker->getIsolate().apiIsolate, *c);
+        storage = impl->makeStorage(lock, *worker->getIsolate().apiIsolate, **c);
       }
       auto handler = cls(lock,
           jsg::alloc<api::DurableObjectState>(cloneId(), kj::mv(storage)),
@@ -2762,7 +2759,7 @@ void Worker::Actor::shutdown(uint16_t reasonCode, kj::Maybe<const kj::Exception&
 
 void Worker::Actor::shutdownActorCache(kj::Maybe<const kj::Exception&> error) {
   KJ_IF_MAYBE(ac, impl->actorCache) {
-    ac->shutdown(error);
+    ac->get()->shutdown(error);
   } else {
     // The actor was aborted before the actor cache was constructed, nothing to do.
   }
@@ -2819,8 +2816,8 @@ kj::Maybe<ActorCacheInterface&> Worker::Actor::getPersistent() {
 
 kj::Maybe<jsg::Ref<api::DurableObjectStorage>>
     Worker::Actor::makeStorageForSwSyntax(Worker::Lock& lock) {
-  return impl->actorCache.map([&](ActorCacheInterface& cache) {
-    return impl->makeStorage(lock, *worker->getIsolate().apiIsolate, cache);
+  return impl->actorCache.map([&](kj::Own<ActorCacheInterface>& cache) {
+    return impl->makeStorage(lock, *worker->getIsolate().apiIsolate, *cache);
   });
 }
 
@@ -2878,7 +2875,7 @@ kj::Promise<void> Worker::Actor::makeAlarmTaskForPreview(kj::Date scheduledTime)
 
   auto runAlarm = [this, &context](kj::Date scheduledTime)
       -> kj::Promise<WorkerInterface::AlarmResult> {
-    auto& persistent = KJ_ASSERT_NONNULL(impl->actorCache);
+    auto& persistent = *KJ_ASSERT_NONNULL(impl->actorCache);
 
     auto maybeDeferredDelete = persistent.armAlarmHandler(scheduledTime);
 
@@ -2904,7 +2901,7 @@ kj::Promise<void> Worker::Actor::makeAlarmTaskForPreview(kj::Date scheduledTime)
               .outcome = EventOutcome::OK,
             };
           }, [this](kj::Exception&& e) {
-            auto& persistent = KJ_ASSERT_NONNULL(impl->actorCache);
+            auto& persistent = *KJ_ASSERT_NONNULL(impl->actorCache);
             persistent.cancelDeferredAlarmDeletion();
 
             LOG_EXCEPTION_IF_INTERNAL("alarmRetry", e);

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -36,7 +36,7 @@ namespace api {
 }
 
 class IoContext;
-class ActorCache;
+class ActorCacheInterface;
 class InputGate;
 class OutputGate;
 
@@ -634,7 +634,7 @@ class Worker::Actor final: public kj::Refcounted {
 
 public:
   using MakeStorageFunc = kj::Function<jsg::Ref<api::DurableObjectStorage>(
-      jsg::Lock& js, const ApiIsolate& apiIsolate, ActorCache& actorCache)>;
+      jsg::Lock& js, const ApiIsolate& apiIsolate, ActorCacheInterface& actorCache)>;
 
   using Id = kj::OneOf<kj::Own<ActorIdFactory::ActorId>, kj::String>;
 
@@ -679,7 +679,7 @@ public:
   const Id& getId();
   Id cloneId();
   kj::Maybe<jsg::Value> getTransient(Worker::Lock& lock);
-  kj::Maybe<ActorCache&> getPersistent();
+  kj::Maybe<ActorCacheInterface&> getPersistent();
 
   kj::Maybe<jsg::Ref<api::DurableObjectStorage>> makeStorageForSwSyntax(Worker::Lock& lock);
   // Make the storage object for use in Service Workers syntax. This should not be used for

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -16,6 +16,7 @@
 #include <workerd/io/io-channels.h>
 #include <workerd/io/actor-storage.capnp.h>
 #include <workerd/io/request-tracker.h>
+#include <workerd/io/actor-cache.h>  // because we can't forward-declare ActorCache::SharedLru.
 
 namespace v8 { class Isolate; }
 
@@ -36,7 +37,6 @@ namespace api {
 }
 
 class IoContext;
-class ActorCacheInterface;
 class InputGate;
 class OutputGate;
 
@@ -633,13 +633,24 @@ class Worker::Actor final: public kj::Refcounted {
   // objects backing `event.actorState`. Multiple `Actor`s can be created within a single `Worker`.
 
 public:
+  using MakeActorCacheFunc = kj::Function<kj::Maybe<kj::Own<ActorCacheInterface>>(
+      const ActorCache::SharedLru& sharedLru, OutputGate& outputGate)>;
+  // Callback which constructs the `ActorCacheInterface` instance (if any) for the Actor. This
+  // can be used to customize the storage implementation. This will be called synchronously in
+  // the constructor.
+
   using MakeStorageFunc = kj::Function<jsg::Ref<api::DurableObjectStorage>(
       jsg::Lock& js, const ApiIsolate& apiIsolate, ActorCacheInterface& actorCache)>;
+  // Callback which constructs the `DurableObjectStorage` instance for an actor. This can be used
+  // to customize the JavaScript API.
+  //
+  // TODO(cleanup): Can we refactor the (internal-codebase) user of this so that it doesn't need
+  //   to customize the JS API but only the underlying ActorCacheInterface?
 
   using Id = kj::OneOf<kj::Own<ActorIdFactory::ActorId>, kj::String>;
 
   Actor(const Worker& worker, kj::Maybe<RequestTracker&> tracker, Id actorId,
-        bool hasTransient, kj::Maybe<rpc::ActorStorage::Stage::Client> persistent,
+        bool hasTransient, MakeActorCacheFunc makeActorCache,
         kj::Maybe<kj::StringPtr> className, MakeStorageFunc makeStorage, Worker::Lock& lock,
         TimerChannel& timerChannel, kj::Own<ActorObserver> metrics);
   // Create a new Actor hosted by this Worker. Note that this Actor object may only be manipulated

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1277,7 +1277,7 @@ public:
           });
 
           auto makeStorage = [actorSqlite](jsg::Lock& js, const Worker::ApiIsolate& apiIsolate,
-                                           ActorCache& actorCache)
+                                           ActorCacheInterface& actorCache)
                             -> jsg::Ref<api::DurableObjectStorage> {
             KJ_IF_MAYBE(a, actorSqlite) {
               return jsg::alloc<api::DurableObjectStorage>(

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1281,7 +1281,7 @@ public:
                             -> jsg::Ref<api::DurableObjectStorage> {
             KJ_IF_MAYBE(a, actorSqlite) {
               return jsg::alloc<api::DurableObjectStorage>(
-                  IoContext::current().addObject(*a));
+                  IoContext::current().addObject(kj::implicitCast<ActorCacheInterface&>(*a)));
             } else {
               return jsg::alloc<api::DurableObjectStorage>(
                   IoContext::current().addObject(actorCache));

--- a/src/workerd/util/sqlite-kv.c++
+++ b/src/workerd/util/sqlite-kv.c++
@@ -31,8 +31,9 @@ bool SqliteKv::delete_(KeyPtr key) {
   return query.changeCount() > 0;
 }
 
-void SqliteKv::deleteAll() {
-  stmtDeleteAll.run();
+uint SqliteKv::deleteAll() {
+  auto query = stmtDeleteAll.run();
+  return query.changeCount();
 }
 
 }  // namespace workerd

--- a/src/workerd/util/sqlite-kv.h
+++ b/src/workerd/util/sqlite-kv.h
@@ -47,7 +47,7 @@ public:
   bool delete_(KeyPtr key);
   // Delete the key and return whether it was matched.
 
-  void deleteAll();
+  uint deleteAll();
 
   // TODO(perf): Should we provide multi-get, multi-put, and multi-delete? It's a bit tricky to
   //   implement them as single SQL queries, while still using prepared statements. The c-array


### PR DESCRIPTION
This factors out a new abstract interface implemented by `ActorCache` and `ActorSqlite`, thus allowing `DurableObjectStorage` to use that interface and do away with the ugly `OneOf` situation.

`ActorCache` already implements an interface `ActorCacheInterface` which is shared with `Transaction`, but is too narrow for our new use case. So we need a new interface in between. I felt it would be too confusing for the existing `ActorCacheInterface` to keep that name, so I renamed it to `ActorCacheOps`. I then couldn't think of any good name for the new intermediate interface, so I made it `ActorCacheInterface`. Hopefully this doesn't create too much confusion but I am open to other names if anyone has any ideas.

This also changes the constructor of `Worker::Actor` to allow customization of which `ActorCacheInterface` implementation it creates, thus allowing us to clean up the mess at the call site in `server.c++`.

cc @trevorcf although @bcaimano is probably the preferred reviewer here.