### PR TITLE
Application-level auto-response for hibernatable web sockets 

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -458,6 +458,7 @@ public:
     JSG_NESTED_TYPE(Response);
     JSG_NESTED_TYPE(WebSocket);
     JSG_NESTED_TYPE(WebSocketPair);
+    JSG_NESTED_TYPE(WebSocketRequestResponsePair);
 
     JSG_NESTED_TYPE(AbortController);
     JSG_NESTED_TYPE(AbortSignal);

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -664,6 +664,15 @@ void WebSocket::serializeAttachment(jsg::Lock& js, v8::Local<v8::Value> attachme
   serializedAttachment = kj::mv(released.data);
 }
 
+void WebSocket::setAutoResponseTimestamp(kj::Maybe<kj::Date> time) {
+  autoResponseTimestamp = time;
+}
+
+
+kj::Maybe<kj::Date> WebSocket::getAutoResponseTimestamp() {
+  return autoResponseTimestamp;
+}
+
 void WebSocket::dispatchOpen(jsg::Lock& js) {
   dispatchEventImpl(js, jsg::alloc<Event>("open"));
 }

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -385,6 +385,11 @@ public:
   // Used to get/set the attachment for hibernation.
   // If the object isn't serialized, it will not survive hibernation.
 
+  void setAutoResponseTimestamp(kj::Maybe<kj::Date> time);
+  kj::Maybe<kj::Date> getAutoResponseTimestamp();
+  // Used to get/store the last auto request/response timestamp for this WebSocket.
+  // These methods are c++ only and are not exposed to our js interface.
+
   int getReadyState();
 
   bool isAccepted();
@@ -441,6 +446,7 @@ private:
   kj::Maybe<kj::String> url;
   kj::Maybe<kj::String> protocol = kj::String();
   kj::Maybe<kj::String> extensions = kj::String();
+  kj::Maybe<kj::Date> autoResponseTimestamp;
   kj::Maybe<kj::Array<byte>> serializedAttachment;
   // All WebSockets have this property. It starts out null but can
   // be assigned to any serializable value. The property will survive hibernation.

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3110,6 +3110,9 @@ kj::Maybe<Worker::Actor::HibernationManager&> Worker::Actor::getHibernationManag
 
 void Worker::Actor::setHibernationManager(kj::Own<HibernationManager> hib) {
   KJ_REQUIRE(impl->hibernationManager == nullptr);
+  hib->setTimerChannel(impl->timerChannel);
+  // Not the cleanest way to provide hibernation manager with a timer channel reference, but
+  // where HibernationManager is constructed (actor-state), we don't have a timer channel ref.
   impl->hibernationManager = kj::mv(hib);
 }
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -38,6 +38,7 @@ namespace api {
   struct CryptoAlgorithm;
   struct QueueExportedHandler;
   class WebSocket;
+  class WebSocketRequestResponsePair;
 }
 
 class IoContext;
@@ -684,6 +685,10 @@ public:
         jsg::Lock& js,
         kj::Maybe<kj::StringPtr> tag) = 0;
     virtual void hibernateWebSockets(Worker::Lock& lock) = 0;
+    virtual void setWebSocketAutoResponse(jsg::Ref<api::WebSocketRequestResponsePair> reqResp) = 0;
+    virtual void unsetWebSocketAutoResponse() = 0;
+    virtual kj::Maybe<jsg::Ref<api::WebSocketRequestResponsePair>> getWebSocketAutoResponse() = 0;
+    virtual void setTimerChannel(TimerChannel& timerChannel) = 0;
   };
 
   Actor(const Worker& worker, kj::Maybe<RequestTracker&> tracker, Id actorId,


### PR DESCRIPTION
When a specific `request` is set for hiberntabale web socket, they must respond with `response`, store the timestamp and if currently hibernating, should stay hibernated.
This PR adds a new `DurableObjectState::setWebSocketAutoresponse(request: string, response: string);` and `WebSocket::getAutoresponseTimestamp();`. 