### PR TITLE
Implement URL.canParse

### DIFF
--- a/src/workerd/api/url-standard-test.c++
+++ b/src/workerd/api/url-standard-test.c++
@@ -778,6 +778,15 @@ KJ_TEST("Parse protocol with state override") {
   }
 }
 
+
+KJ_TEST("Can parse") {
+  {
+    KJ_ASSERT(URL::canParse(jsg::usv("http://example.org")));
+    KJ_ASSERT(URL::canParse(jsg::usv("foo"), jsg::usv("http://example.org")));
+    KJ_ASSERT(!URL::canParse(jsg::usv("this is not a parseable URL")));
+    KJ_ASSERT(!URL::canParse(jsg::usv("foo"), jsg::usv("base is not a URL")));
+  }
+}
 }  // namespace
 }  // namespace workerd::api::url
 

--- a/src/workerd/api/url-standard.c++
+++ b/src/workerd/api/url-standard.c++
@@ -1639,6 +1639,21 @@ URL::~URL() noexcept(false) {
   }
 }
 
+bool URL::canParse(jsg::UsvString url, jsg::Optional<jsg::UsvString> maybeBase) {
+  KJ_IF_MAYBE(base, maybeBase) {
+    KJ_IF_MAYBE(parsedBase, URL::parse(*base)) {
+      KJ_IF_MAYBE(parsed, URL::parse(url, *parsedBase)) {
+        return true;
+      }
+    }
+  } else {
+    KJ_IF_MAYBE(parsed, URL::parse(url)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 jsg::UsvString URL::getOrigin() {
   KJ_SWITCH_ONEOF(inner.getOrigin()) {
     KJ_CASE_ONEOF(opaque, OpaqueOrigin) {

--- a/src/workerd/api/url-standard.h
+++ b/src/workerd/api/url-standard.h
@@ -298,6 +298,19 @@ public:
 
   UrlRecord& getRecord() KJ_LIFETIMEBOUND { return inner; }
 
+  static bool canParse(jsg::UsvString url,
+                       jsg::Optional<jsg::UsvString> base = nullptr);
+  // Standard utility that returns true if the given input can be
+  // successfully parsed as a URL. This is useful for validating
+  // URL inputs without incurring the additional cost of constructing
+  // and throwing an error. For example:
+  //
+  // const urls = [
+  //   'https://example.org/good',
+  //   'not a url'
+  // ].filter((test) => URL.canParse(test));
+  //
+
   JSG_RESOURCE_TYPE(URL) {
     JSG_READONLY_PROTOTYPE_PROPERTY(origin, getOrigin);
     JSG_PROTOTYPE_PROPERTY(href, getHref, setHref);
@@ -313,6 +326,7 @@ public:
     JSG_READONLY_PROTOTYPE_PROPERTY(searchParams, getSearchParams);
     JSG_METHOD_NAMED(toJSON, getHref);
     JSG_METHOD_NAMED(toString, getHref);
+    JSG_STATIC_METHOD(canParse);
 
     JSG_TS_OVERRIDE(URL {
       constructor(url: string | URL, base?: string | URL);


### PR DESCRIPTION
Added as part of the standard URL API as a mechanism for validating that a URL string can be parsed without incurring the additional cost of creating and catching an error.