### PR TITLE
Create runtime-apis.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/runtime-apis.md
+++ b/.github/ISSUE_TEMPLATE/runtime-apis.md
@@ -1,0 +1,8 @@
+---
+name: runtime-apis
+about: Report an issue with an API provided by workerd
+title: '🐛 Bug Report — Runtime APIs'
+labels: runtime-api
+
+---
+


### PR DESCRIPTION
Add an issue template for reporting bugs with runtime APIs. 

Without this, the only options presented when going to report an issue are for `workers-types` and reporting a security vulnerability, with a tiny fallback to "open a blank issue".

Gives us somewhere more direct to link to from docs and other places.