### PR TITLE
Add strict `R2Objects` types

### DIFF
--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -275,7 +275,13 @@ public:
     kj::Array<kj::String> delimitedPrefixes;
 
     JSG_STRUCT(objects, truncated, cursor, delimitedPrefixes);
-    JSG_STRUCT_TS_OVERRIDE(R2Objects);
+    JSG_STRUCT_TS_OVERRIDE(type R2Objects = {
+      objects: R2Object[];
+      delimitedPrefixes: string[];
+    } & (
+      | { truncated: true; cursor: string }
+      | { truncated: false }
+    ));
   };
 
   struct ListOptions {


### PR DESCRIPTION
When listing R2 objects, a `cursor` is only returned when `truncated` is `true`. This change encodes this constraint in TypeScript, similar to `KVNamespaceListResult`.

Closes #315