### PR TITLE
Implement backpressure signaling for IdentityTransformStream writable

### DIFF
--- a/src/workerd/api/streams.h
+++ b/src/workerd/api/streams.h
@@ -37,6 +37,7 @@ namespace workerd::api {
   api::TransformStream,                                     \
   api::FixedLengthStream,                                   \
   api::IdentityTransformStream,                             \
+  api::IdentityTransformStream::QueuingStrategy,            \
   api::ReadableStream::ValuesOptions,                       \
   api::ReadableStream::ReadableStreamAsyncIterator,         \
   api::ReadableStream::ReadableStreamAsyncIterator::Next,   \

--- a/src/workerd/api/streams/identitytransformstream-backpressure-test.js
+++ b/src/workerd/api/streams/identitytransformstream-backpressure-test.js
@@ -1,0 +1,141 @@
+import {
+  notStrictEqual,
+  strictEqual,
+} from 'node:assert';
+
+export const identityTransformStream = {
+  async test(ctrl, env, ctx) {
+    const ts = new IdentityTransformStream({ highWaterMark: 10 });
+    const writer = ts.writable.getWriter();
+    const reader = ts.readable.getReader();
+
+    strictEqual(writer.desiredSize, 10);
+
+    // We shouldn't have to wait here.
+    const firstReady = writer.ready;
+    await writer.ready;
+
+    writer.write(new Uint8Array(1));
+    strictEqual(writer.desiredSize, 9);
+
+    // Let's write a second chunk that will be buffered. This one
+    // should impact the desiredSize and the backpressure signal.
+    writer.write(new Uint8Array(9));
+    strictEqual(writer.desiredSize, 0);
+
+    // The ready promise should have been replaced
+    notStrictEqual(firstReady, writer.ready);
+
+    async function waitForReady() {
+      strictEqual(writer.desiredSize, 0);
+      await writer.ready;
+      // The backpressure should have been relieved a bit,
+      // but only by the amount of what we've currently read.
+      strictEqual(writer.desiredSize, 1);
+    }
+
+    await Promise.all([
+      // We call the waitForReady first to ensure that we set up waiting on
+      // the ready promise before we relieve the backpressure using the read.
+      // If the backpressure signal is not working correctly, the test will
+      // fail with an error indicating that a hanging promise was canceled.
+      waitForReady(),
+      reader.read(),
+    ]);
+
+    // If we read again, the backpressure should be fully resolved.
+    await reader.read();
+    strictEqual(writer.desiredSize, 10);
+  }
+};
+
+export const identityTransformStreamNoHWM = {
+  async test(ctrl, env, ctx) {
+    // Test that the original default behavior still works as expected.
+
+    const ts = new IdentityTransformStream();
+    const writer = ts.writable.getWriter();
+    const reader = ts.readable.getReader();
+
+    strictEqual(writer.desiredSize, 1);
+
+    // We shouldn't have to wait here.
+    const firstReady = writer.ready;
+    await writer.ready;
+
+    writer.write(new Uint8Array(1));
+    strictEqual(writer.desiredSize, 1);
+
+    // Let's write a second chunk that will be buffered. There should
+    // be no indication that the desired size has changed.
+    writer.write(new Uint8Array(9));
+    strictEqual(writer.desiredSize, 1);
+
+    // The ready promise should be exactly the same...
+    strictEqual(firstReady, writer.ready);
+
+    async function waitForReady() {
+      strictEqual(writer.desiredSize, 1);
+      await writer.ready;
+      strictEqual(writer.desiredSize, 1);
+    }
+
+    await Promise.all([
+      // We call the waitForReady first to ensure that we set up waiting on
+      // the ready promise before we relieve the backpressure using the read.
+      // If the backpressure signal is not working correctly, the test will
+      // fail with an error indicating that a hanging promise was canceled.
+      waitForReady(),
+      reader.read(),
+    ]);
+
+    // If we read again, the backpressure should be fully resolved.
+    await reader.read();
+    strictEqual(writer.desiredSize, 1);
+  }
+};
+
+export const fixedLengthStream = {
+  async test(ctrl, env, ctx) {
+    const ts = new FixedLengthStream(10, { highWaterMark: 100 });
+    const writer = ts.writable.getWriter();
+    const reader = ts.readable.getReader();
+
+    // Even tho we specified 100 as our highWaterMark, we only expect 10
+    // bytes total, so we'll make that our highWaterMark instead.
+    strictEqual(writer.desiredSize, 10);
+
+    // We shouldn't have to wait here.
+    const firstReady = writer.ready;
+    await writer.ready;
+
+    writer.write(new Uint8Array(1));
+    strictEqual(writer.desiredSize, 9);
+
+    // Let's write a second chunk that will be buffered. This one
+    // should impact the desiredSize and the backpressure signal.
+    writer.write(new Uint8Array(9));
+    strictEqual(writer.desiredSize, 0);
+
+    // The ready promise should have been replaced
+    notStrictEqual(firstReady, writer.ready);
+
+    async function waitForReady() {
+      await writer.ready;
+      // The backpressure should have been relieved a bit,
+      // but only by the amount of what we've currently read.
+      strictEqual(writer.desiredSize, 1);
+    }
+
+    await Promise.all([
+      // We call the waitForReady first to ensure that we set up waiting on
+      // the ready promise before we relieve the backpressure using the read.
+      waitForReady(),
+      reader.read(),
+    ]);
+
+    // If we read again, the backpressure should be fully resolved.
+    await reader.read();
+    strictEqual(writer.desiredSize, 10);
+  }
+};

--- a/src/workerd/api/streams/identitytransformstream-backpressure-test.wd-test
+++ b/src/workerd/api/streams/identitytransformstream-backpressure-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "identitytransformstream-backpressure-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "identitytransformstream-backpressure-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat"]
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/streams/transform.h
+++ b/src/workerd/api/streams/transform.h
@@ -81,7 +81,15 @@ class IdentityTransformStream: public TransformStream {
 public:
   using TransformStream::TransformStream;
 
-  static jsg::Ref<IdentityTransformStream> constructor(jsg::Lock& js);
+  struct QueuingStrategy {
+    jsg::Optional<uint64_t> highWaterMark;
+
+    JSG_STRUCT(highWaterMark);
+  };
+
+  static jsg::Ref<IdentityTransformStream> constructor(
+      jsg::Lock& js,
+      jsg::Optional<QueuingStrategy> queuingStrategy = nullptr);
 
   JSG_RESOURCE_TYPE(IdentityTransformStream) {
     JSG_INHERIT(TransformStream);
@@ -98,7 +106,10 @@ class FixedLengthStream: public IdentityTransformStream {
 public:
   using IdentityTransformStream::IdentityTransformStream;
 
-  static jsg::Ref<FixedLengthStream> constructor(jsg::Lock& js, uint64_t expectedLength);
+  static jsg::Ref<FixedLengthStream> constructor(
+      jsg::Lock& js,
+      uint64_t expectedLength,
+      jsg::Optional<QueuingStrategy> queuingStrategy = nullptr);
 
   JSG_RESOURCE_TYPE(FixedLengthStream) {
     JSG_INHERIT(IdentityTransformStream);

--- a/src/workerd/api/streams/writable.c++
+++ b/src/workerd/api/streams/writable.c++
@@ -188,9 +188,11 @@ void WritableStreamDefaultWriter::visitForGc(jsg::GcVisitor& visitor) {
 
 WritableStream::WritableStream(
     IoContext& ioContext,
-    kj::Own<WritableStreamSink> sink)
+    kj::Own<WritableStreamSink> sink,
+    kj::Maybe<uint64_t> maybeHighWaterMark)
     : ioContext(ioContext),
-      controller(kj::heap<WritableStreamInternalController>(ioContext.addObject(kj::mv(sink)))) {
+      controller(kj::heap<WritableStreamInternalController>(ioContext.addObject(kj::mv(sink)),
+                                                            maybeHighWaterMark)) {
   getController().setOwnerRef(*this);
 }
 

--- a/src/workerd/api/streams/writable.h
+++ b/src/workerd/api/streams/writable.h
@@ -102,7 +102,8 @@ public:
                                kj::Own<WritableStreamJsController>>;
 
   explicit WritableStream(IoContext& ioContext,
-                          kj::Own<WritableStreamSink> sink);
+                          kj::Own<WritableStreamSink> sink,
+                          kj::Maybe<uint64_t> maybeHighWaterMark = nullptr);
 
   explicit WritableStream(Controller controller);
 


### PR DESCRIPTION
Enables optional use of writer.desiredSize/writer.ready for backpressure signaling with IdentityTransformStream and FixedLengthStream. See included test for example use.