### PR TITLE
Add `--log-response` argument to serve

### DIFF
--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -37,6 +37,8 @@ public:
   void allowExperimental() { experimental = true; }
   // Permit experimental features to be used. These features may break backwards compatibility
   // in the future.
+  
+  void allowLogResponse() { responseLog = true; }
 
   void overrideSocket(kj::String name, kj::Own<kj::ConnectionReceiver> port) {
     socketOverrides.upsert(kj::mv(name), kj::mv(port));
@@ -75,6 +77,7 @@ private:
   kj::Function<void(kj::String)> reportConfigError;
 
   bool experimental = false;
+  bool responseLog = false;
 
   kj::HashMap<kj::String, kj::OneOf<kj::String, kj::Own<kj::ConnectionReceiver>>> socketOverrides;
   kj::HashMap<kj::String, kj::String> directoryOverrides;

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -579,7 +579,10 @@ public:
                    "Useful for development, but not recommended in production.")
         .addOption({"experimental"}, [this]() { server.allowExperimental(); return true; },
                    "Permit the use of experimental features which may break backwards "
-                   "compatibility in a future release.");
+                   "compatibility in a future release.")
+        .addOption({"log-response"}, [this]() { server.allowLogResponse(); return true; },
+                   "Print response information for each request to workerd. "
+                   "This includes method, url, and status");
   }
 
   kj::MainFunc addServeOptions(kj::MainBuilder& builder) {


### PR DESCRIPTION
Addresses [this issue](https://github.com/cloudflare/workers-sdk/issues/2722). Miniflare 3 uses workerd to handle requests and needs a way to have nice output for requests.

`--log-response` will print out the response method, url, and status for each request made to workerd