### PR TITLE
Macros to periodically warn

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -374,11 +374,8 @@ void reportStartupError(
           // TODO(soon): We add logging here to see if this hack is still necessary or if it can be
           // removed. Adding this additional logging should be temporary! If we hit this log in
           // sentry even once, then we'll keep the hack, otherwise we can likely safely remove it.
-          static bool logOnce KJ_UNUSED = ([] {
-            KJ_LOG(WARNING, "reportStartupError() customer-specific SyntaxError hack "
-                            "is still relevant.");
-            return true;
-          })();
+          JSG_WARN_ONCE("reportStartupError() customer-specific SyntaxError hack "
+                        "is still relevant.");
         } else {
           KJ_LOG(ERROR, "script startup threw exception", id, description, trace);
           KJ_FAIL_REQUIRE("script startup threw exception");

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -38,14 +38,17 @@
   KJ_FAIL_REQUIRE(kj::str(JSG_EXCEPTION(jsErrorType) ": ", ##__VA_ARGS__))
 // JSG_REQUIRE + KJ_FAIL_REQUIRE
 
+#define JSG_WARN_ONCE(msg, ...) \
+    static bool logOnce KJ_UNUSED = ([&] { \
+      KJ_LOG(WARNING, msg, ##__VA_ARGS__); \
+      return true; \
+    })() \
+
 // Conditionally log a warning, at most once. Useful for determining if code changes would break
 // any existing scripts.
-#define JSG_WARN_ONCE_IF(cond, msg) \
+#define JSG_WARN_ONCE_IF(cond, msg, ...) \
   if (cond) { \
-    static bool logOnce KJ_UNUSED = ([] { \
-      KJ_LOG(WARNING, msg); \
-      return true; \
-    })(); \
+    JSG_WARN_ONCE(msg, ##__VA_ARGS__); \
   }
 
 // These are passthrough functions to KJ. We expect the error string to be


### PR DESCRIPTION
While I was at it, I decided to cleanup some spots where we weren't using `JSG_WARN_ONCE`. I also improved those
macros to accept a variadic number of macro args (btw I noticed `LOG_IF_INTERESTING` and `LOG_NOSENTRY` may be misusing `__VA_ARGS__` in the 0 variadic args case - missing a `##` but I decided not to touch them to avoid scope creep).

I seem to have lost permission to the main workerd repo so I've forked for now until I figure out how to restore.

Hmm... bugs.ew-test is failing when I migrate
```
Worker tried to Send 'Expect' header
```
in edgeworker.c++ for some reason. The error gets printed in the logs but doesn't match the `@LOG` test directive. Hmm...