### PR TITLE
Ignore disturbed status of ReadableStream when detaching for startTls.

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -169,7 +169,7 @@ jsg::Ref<Socket> Socket::startTls(jsg::Lock& js, jsg::Optional<TlsOptions> tlsOp
   //
   // Detach the AsyncIoStream from the Writable/Readable streams and make them unusable.
   writable->removeSink(js);
-  readable->detach(js);
+  readable = readable->detach(js, true);
   closeFulfiller.resolver.resolve();
 
   auto acceptedHostname = domain.asPtr();

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -31,8 +31,8 @@ class Socket: public jsg::Object {
 public:
   Socket(jsg::Lock& js, jsg::Ref<ReadableStream> readableParam, jsg::Ref<WritableStream> writable,
       jsg::PromiseResolverPair<void> close, kj::Promise<void> connDisconnPromise,
-      jsg::Optional<SocketOptions> options, kj::TlsStarterCallback tlsStarter, bool isSecureSocket,
-      kj::String domain)
+      jsg::Optional<SocketOptions> options, kj::Own<kj::TlsStarterCallback> tlsStarter,
+      bool isSecureSocket, kj::String domain)
       : readable(kj::mv(readableParam)), writable(kj::mv(writable)),
         closeFulfiller(kj::mv(close)),
         closedPromise(kj::mv(closeFulfiller.promise)),
@@ -83,7 +83,7 @@ private:
   jsg::MemoizedIdentity<jsg::Promise<void>> closedPromise;
   jsg::Promise<void> writeDisconnectedPromise;
   jsg::Optional<SocketOptions> options;
-  kj::TlsStarterCallback tlsStarter;
+  kj::Own<kj::TlsStarterCallback> tlsStarter;
   // Callback used to upgrade the existing connection to a secure one.
   bool isSecureSocket;
   // Set to true on sockets created with `useSecureTransport` set to true or a socket returned by

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -609,10 +609,10 @@ ReadableStreamController::Tee ReadableStreamInternalController::tee(jsg::Lock& j
 }
 
 kj::Maybe<kj::Own<ReadableStreamSource>> ReadableStreamInternalController::removeSource(
-    jsg::Lock& js) {
+    jsg::Lock& js, bool ignoreDisturbed) {
   JSG_REQUIRE(!isLockedToReader(), TypeError,
                "This ReadableStream is currently locked to a reader.");
-  JSG_REQUIRE(!disturbed, TypeError, "This ReadableStream is disturbed.");
+  JSG_REQUIRE(!disturbed || ignoreDisturbed, TypeError, "This ReadableStream is disturbed.");
 
   readState.init<Locked>();
   disturbed = true;

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -147,7 +147,7 @@ public:
 
   Tee tee(jsg::Lock& js) override;
 
-  kj::Maybe<kj::Own<ReadableStreamSource>> removeSource(jsg::Lock& js);
+  kj::Maybe<kj::Own<ReadableStreamSource>> removeSource(jsg::Lock& js, bool ignoreDisturbed=false);
 
   bool isClosedOrErrored() const override {
     return state.is<StreamStates::Closed>() || state.is<StreamStates::Errored>();

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -447,13 +447,13 @@ jsg::Promise<void> ReadableStream::returnFunction(
   return js.resolvedPromise();
 }
 
-jsg::Ref<ReadableStream> ReadableStream::detach(jsg::Lock& js) {
-  JSG_REQUIRE(!isDisturbed(), TypeError, "The ReadableStream has already been read.");
+jsg::Ref<ReadableStream> ReadableStream::detach(jsg::Lock& js, bool ignoreDisturbed) {
+  JSG_REQUIRE(!isDisturbed() || ignoreDisturbed, TypeError, "The ReadableStream has already been read.");
   JSG_REQUIRE(!isLocked(), TypeError, "The ReadableStream has been locked to a reader.");
   KJ_SWITCH_ONEOF(controller) {
     KJ_CASE_ONEOF(c, kj::Own<ReadableStreamInternalController>) {
       return jsg::alloc<ReadableStream>(IoContext::current(),
-          KJ_REQUIRE_NONNULL(c->removeSource(js)));
+          KJ_REQUIRE_NONNULL(c->removeSource(js, ignoreDisturbed)));
     }
     KJ_CASE_ONEOF(c, kj::Own<ReadableStreamJsController>) {
       auto stream = jsg::alloc<ReadableStream>(c->detach(js));

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -338,7 +338,7 @@ public:
     // value-oriented streams.
   }
 
-  jsg::Ref<ReadableStream> detach(jsg::Lock& js);
+  jsg::Ref<ReadableStream> detach(jsg::Lock& js, bool ignoreDisturbed=false);
   // Detaches this ReadableStream from it's underlying controller state, returning a
   // new ReadableStream instance that takes over the underlying state. This is used to
   // support the "create a proxy" of a ReadableStream algorithm in the streams spec


### PR DESCRIPTION
Without this detaching the ReadableStream fails when the stream was read from before `startTls` was called.