### PR TITLE
Update to include changes to support startTls with http-over-capnp.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,10 +35,10 @@ rules_foreign_cc_dependencies()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "d361f4405ee941e97d68c08c62534c3d246ef841ec464a16aeaffa8f96a6062c",
-    strip_prefix = "capnproto-capnproto-cdcebca/c++",
+    sha256 = "d51c3ca9062d4fbd64f66722b08aafe18976aff3e9965aa0958a0afd4323d4b8",
+    strip_prefix = "capnproto-capnproto-b2afb7f/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/cdcebca7f9caa9f3fa3f63b2a370392b0093d908"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/b2afb7f8fe393466a38e2fd2ad98482c34aafcee"],
 )
 
 http_archive(

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -36,11 +36,13 @@ struct TlsOptions {
 
 class Socket: public jsg::Object {
 public:
-  Socket(jsg::Lock& js, jsg::Ref<ReadableStream> readableParam, jsg::Ref<WritableStream> writable,
+  Socket(jsg::Lock& js, kj::Own<kj::RefcountedWrapper<kj::Own<kj::AsyncIoStream>>> connectionStream,
+      jsg::Ref<ReadableStream> readableParam, jsg::Ref<WritableStream> writable,
       jsg::PromiseResolverPair<void> close, kj::Promise<void> connDisconnPromise,
       jsg::Optional<SocketOptions> options, kj::Own<kj::TlsStarterCallback> tlsStarter,
       bool isSecureSocket, kj::String domain)
-      : readable(kj::mv(readableParam)), writable(kj::mv(writable)),
+      : connectionStream(kj::mv(connectionStream)),
+        readable(kj::mv(readableParam)), writable(kj::mv(writable)),
         closeFulfiller(kj::mv(close)),
         closedPromise(kj::mv(closeFulfiller.promise)),
         // Listen for abrupt disconnects and resolve the `closed` promise when they occur.
@@ -83,6 +85,7 @@ public:
   }
 
 private:
+  kj::Own<kj::RefcountedWrapper<kj::Own<kj::AsyncIoStream>>> connectionStream;
   jsg::Ref<ReadableStream> readable;
   jsg::Ref<WritableStream> writable;
   jsg::PromiseResolverPair<void> closeFulfiller;


### PR DESCRIPTION
Capnproto PR: https://github.com/capnproto/capnproto/pull/1653

Verified same as #440.

(Tests might fail as this PR doesn't point at capnproto PR yet)