### PR TITLE
Bugfix: WebSockets can already be released when we finish pumping

### DIFF
--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -287,9 +287,12 @@ private:
     kj::Maybe<kj::Own<ActorObserver>> actorMetrics;
   };
   struct Released {};
+  using NativeState =
+      kj::OneOf<AwaitingConnection, AwaitingAcceptanceOrCoupling, Accepted, Released>;
+  friend kj::StringPtr KJ_STRINGIFY(const NativeState&);
 
   struct Native {
-    kj::OneOf<AwaitingConnection, AwaitingAcceptanceOrCoupling, Accepted, Released> state;
+    NativeState state;
 
     bool isPumping = false;
     // Is there currently a task running to pump outgoing messages?


### PR DESCRIPTION
We await a `jsg::Promise` at the end of pumping. This means someone else could release our state before the final continuation runs. That's fine.