### PR TITLE
Implement Secure Curves API

### DIFF
--- a/src/workerd/api/crypto.c++
+++ b/src/workerd/api/crypto.c++
@@ -118,6 +118,7 @@ static kj::Maybe<const CryptoAlgorithm&> lookupAlgorithm(kj::StringPtr name) {
     {"ECDSA"_kj,             &CryptoKey::Impl::importEcdsa, &CryptoKey::Impl::generateEcdsa},
     {"ECDH"_kj,              &CryptoKey::Impl::importEcdh, &CryptoKey::Impl::generateEcdh},
     {"NODE-ED25519"_kj,      &CryptoKey::Impl::importEddsa, &CryptoKey::Impl::generateEddsa},
+    {"Ed25519"_kj,           &CryptoKey::Impl::importEddsa, &CryptoKey::Impl::generateEddsa},
     {"RSA-RAW"_kj,           &CryptoKey::Impl::importRsaRaw},
   };
 

--- a/src/workerd/api/crypto.c++
+++ b/src/workerd/api/crypto.c++
@@ -119,6 +119,7 @@ static kj::Maybe<const CryptoAlgorithm&> lookupAlgorithm(kj::StringPtr name) {
     {"ECDH"_kj,              &CryptoKey::Impl::importEcdh, &CryptoKey::Impl::generateEcdh},
     {"NODE-ED25519"_kj,      &CryptoKey::Impl::importEddsa, &CryptoKey::Impl::generateEddsa},
     {"Ed25519"_kj,           &CryptoKey::Impl::importEddsa, &CryptoKey::Impl::generateEddsa},
+    {"X25519"_kj,            &CryptoKey::Impl::importEddsa, &CryptoKey::Impl::generateEddsa},
     {"RSA-RAW"_kj,           &CryptoKey::Impl::importRsaRaw},
   };
 

--- a/src/workerd/api/crypto.h
+++ b/src/workerd/api/crypto.h
@@ -14,7 +14,7 @@
 
 namespace workerd::api {
 namespace {
-class EdDsaKey;
+class EdDsaKeyBase;
 class EllipticKey;
 }
 
@@ -230,7 +230,7 @@ private:
 
   friend class SubtleCrypto;
   friend class EllipticKey;
-  friend class EdDsaKey;
+  friend class EdDsaKeyBase;
 };
 
 struct CryptoKeyPair {


### PR DESCRIPTION
This patch implements the Web Crypto Secure Curves X25519 and Ed25519.

Caveats/Potential issues:
- Error messages for NODE-ED25519 have been largely updated to refer to Ed25519. This reduces code complexity and still results in descriptive messages as Ed25519 is the underlying algorithm.
- Node no longer allows raw private imports for NODE-ED25519 – comments about deviating from Node's approach are no longer needed
- Is there a better name for `EdDsaKey` now that it's shared between both Eddsa and Eddh?
- There's ternary operator in a few spots – I can switch to branches if that style is preferred
- It might be possible to do this in one class using `kj::OneOf<KeyAlgorithm, EllipticKeyAlgorithm >` – I wanted to avoid breaking the JSG integration for now
- Test cases to be added