### PR TITLE
Use `.exe` extension in Windows npm releases

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -64,14 +64,15 @@ jobs:
       - uses: robinraju/release-downloader@v1.5
         with:
           tag: v${{ needs.version.outputs.release_version }}
-          fileName: workerd-${{ matrix.arch }}
+          fileName: workerd-${{ matrix.arch }}${{ matrix.arch == 'windows-64' && '.exe' || '' }}
           tarBall: false
           zipBall: false
           out-file-path: "release-downloads"
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: chmod +x $GITHUB_WORKSPACE/release-downloads/workerd-${{ matrix.arch }}
+        if: ${{ matrix.arch != 'windows-64' }}
       - run: mkdir npm/workerd-${{ matrix.arch }}/bin
-      - run: cp $GITHUB_WORKSPACE/release-downloads/workerd-${{ matrix.arch }} npm/workerd-${{ matrix.arch }}/bin/workerd
+      - run: cp $GITHUB_WORKSPACE/release-downloads/workerd-${{ matrix.arch }}${{ matrix.arch == 'windows-64' && '.exe' || '' }} npm/workerd-${{ matrix.arch }}/bin/workerd${{ matrix.arch == 'windows-64' && '.exe' || '' }}
       - run: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > npm/workerd-${{ matrix.arch }}/.npmrc
       - run: cd npm/workerd-${{ matrix.arch }} && npm publish --access public --tag ${{ inputs.prerelease == true && 'beta' || 'latest'}}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/upload-artifact@v3.1.0
         with:
           name: ${{ runner.os }}-${{ runner.arch }}-binary
-          path: bazel-bin/src/workerd/server/workerd
+          path: bazel-bin/src/workerd/server/workerd${{ runner.os == 'Windows' && '.exe' || '' }}
   check-tag:
     name: Check tag is new
     outputs:
@@ -116,8 +116,9 @@ jobs:
         with:
           name: ${{ matrix.name }}-binary
           path: /tmp
-      - run: mv /tmp/workerd /tmp/workerd-${{ matrix.arch }}
+      - run: mv /tmp/workerd${{ matrix.arch == 'windows-64' && '.exe' || '' }} /tmp/workerd-${{ matrix.arch }}
       - run: chmod +x /tmp/workerd-${{ matrix.arch }}
+        if: ${{ matrix.arch != 'windows-64' }}
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -126,5 +127,5 @@ jobs:
         with:
           upload_url: ${{ needs.tag-and-release.outputs.upload_url }}
           asset_path: /tmp/workerd-${{ matrix.arch }}
-          asset_name: workerd-${{ matrix.arch }}
+          asset_name: workerd-${{ matrix.arch }}${{ matrix.arch == 'windows-64' && '.exe' || '' }}
           asset_content_type: application/octet-stream

--- a/npm/lib/node-platform.ts
+++ b/npm/lib/node-platform.ts
@@ -20,6 +20,8 @@ export const knownPackages: Record<string, string> = {
   "win32 x64 LE": "@cloudflare/workerd-windows-64",
 };
 
+const maybeExeExtension = process.platform === "win32" ? ".exe" : "";
+
 export function pkgAndSubpathForCurrentPlatform(): {
   pkg: string;
   subpath: string;
@@ -30,7 +32,7 @@ export function pkgAndSubpathForCurrentPlatform(): {
 
   if (platformKey in knownPackages) {
     pkg = knownPackages[platformKey];
-    subpath = "bin/workerd";
+    subpath = `bin/workerd${maybeExeExtension}`;
   } else {
     throw new Error(`Unsupported platform: ${platformKey}`);
   }
@@ -58,7 +60,7 @@ function pkgForSomeOtherPlatform(): string | null {
 
 export function downloadedBinPath(pkg: string, subpath: string): string {
   const libDir = path.dirname(require.resolve("workerd"));
-  return path.join(libDir, `downloaded-${pkg.replace("/", "-")}-${path.basename(subpath)}`);
+  return path.join(libDir, `downloaded-${pkg.replace("/", "-")}-${path.basename(subpath)}${maybeExeExtension}`);
 }
 
 export function generateBinPath(): { binPath: string } {


### PR DESCRIPTION
_(followup to #502, thanks @c0b41 for spotting the missing binaries)_

Windows uses the `.exe` extension to recognise files as executable. Bazel outputs `workerd.exe` instead of `workerd` on Windows. These changes make sure we always include the extension where necessary.