### PR TITLE
workerd: make debugging in vscode work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea
 .DS_Store
 
+/*.code-workspace
+
 /rust-deps/target
 /rust-deps/Cargo.toml
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,27 +6,44 @@
   "configurations": [
     {
       "name": "workerd debug",
-      "preLaunchTask": "Bazel Build",
+      "preLaunchTask": "Bazel Build (dbg)",
       "type": "cppdbg",
       "request": "launch",
       "MIMode": "gdb",
-      "program": "${workspaceFolder}/bazel-out/k8-fastbuild/bin/src/workerd/server/workerd",
+      "miDebuggerArgs": "-d ${workspaceFolder}",
+      "program": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd",
       "args": [
-        // A prompt will be displayed asking for the configuration
-        // arguments for the workerd process
-        "${input:debugargs}"
+        "serve",
+        "${input:workerdConfig}"
       ],
-      "cwd": "${workspaceFolder}/bazel-out/k8-fastbuild/bin/src/workerd/server/workerd.runfiles/workerd",
-
+      "cwd": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd.runfiles/workerd",
+      "stopAtEntry": false,
+      "externalConsole": false
+    },
+    {
+      "name": "workerd debug with inspector enabled",
+      "preLaunchTask": "Bazel Build (dbg)",
+      "type": "cppdbg",
+      "request": "launch",
+      "MIMode": "gdb",
+      "miDebuggerArgs": "-d ${workspaceFolder}",
+      "program": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd",
+      "args": [
+        "serve",
+        "-i0.0.0.0",
+        "--verbose",
+        "${input:workerdConfig}"
+      ],
+      "cwd": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd.runfiles/workerd",
       "stopAtEntry": false,
       "externalConsole": false
     }
   ],
   "inputs": [
     {
-      "id": "debugargs",
-      "description": "workerd arguments",
-      "default": "--help",
+      "id": "workerdConfig",
+      "description": "Workerd configuration to serve",
+      "default": "${workspaceFolder}/samples/helloworld/config.capnp",
       "type": "promptString"
     }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,27 +7,68 @@
     {
       "name": "workerd debug",
       "preLaunchTask": "Bazel Build (dbg)",
-      "type": "cppdbg",
+      "program": "linux-or-os-only",
       "request": "launch",
-      "MIMode": "gdb",
-      "miDebuggerArgs": "-d ${workspaceFolder}",
-      "program": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd",
+      "type": "cppdbg",
+      "linux": {
+        "name": "workerd debug",
+        "type": "cppdbg",
+        "request": "launch",
+        "MIMode": "gdb",
+        "miDebuggerArgs": "-d ${workspaceFolder}",
+        "program": "workerd",
+        "cwd": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd.runfiles/workerd/src/workerd/server/",
+      },
+      "osx": {
+        "name": "workerd debug",
+        "type": "cppdbg",
+        "request": "launch",
+        "MIMode": "lldb",
+        "program": "${workspaceFolder}/bazel-out/darwin_arm64-dbg/bin/src/workerd/server/workerd.runfiles/workerd/src/workerd/server/workerd",
+        "targetArchitecture": "arm64",
+        "sourceFileMap": {
+          "src" : "${workspaceFolder}/src",
+          "bazel-out" : "${workspaceFolder}/bazel-out",
+          "external" : "${workspaceFolder}/external"
+         },
+         "cwd": "${workspaceFolder}",
+      },
       "args": [
         "serve",
         "${input:workerdConfig}"
       ],
-      "cwd": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd.runfiles/workerd",
       "stopAtEntry": false,
       "externalConsole": false
     },
     {
       "name": "workerd debug with inspector enabled",
       "preLaunchTask": "Bazel Build (dbg)",
+      "program": "linux-or-os-only",
       "type": "cppdbg",
       "request": "launch",
-      "MIMode": "gdb",
-      "miDebuggerArgs": "-d ${workspaceFolder}",
-      "program": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd",
+      "linux": {
+        "name": "workerd debug with inspector enabled",
+        "type": "cppdbg",
+        "request": "launch",
+        "MIMode": "gdb",
+        "miDebuggerArgs": "-d ${workspaceFolder}",
+        "program": "workerd",
+        "cwd": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd.runfiles/workerd/src/workerd/server/",
+      },
+      "osx": {
+        "name": "workerd debug with inspector enabled",
+        "type": "cppdbg",
+        "request": "launch",
+        "MIMode": "lldb",
+        "program": "${workspaceFolder}/bazel-out/darwin_arm64-dbg/bin/src/workerd/server/workerd.runfiles/workerd/src/workerd/server/workerd",
+        "targetArchitecture": "arm64",
+        "sourceFileMap": {
+          "src" : "${workspaceFolder}/src",
+          "bazel-out" : "${workspaceFolder}/bazel-out",
+          "external" : "${workspaceFolder}/external"
+         },
+         "cwd": "${workspaceFolder}",
+      },
       "args": [
         "serve",
         "-i0.0.0.0",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,10 +2,29 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Bazel Build",
+      "label": "Bazel Build (dbg)",
       "type": "shell",
       "command": "bazel",
-      "args": ["build", "//src/workerd/server"],
+      "args": ["build", "-c", "dbg", "//src/workerd/server:workerd"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": "$gcc",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      }
+    },
+    {
+      "label": "Bazel Build (fastbuild)",
+      "type": "shell",
+      "command": "bazel",
+      "args": ["build", "--config", "fastbuild", "//src/workerd/server:workerd"],
       "group": {
         "kind": "build",
         "isDefault": true
@@ -24,7 +43,7 @@
       "label": "Bazel Build (opt)",
       "type": "shell",
       "command": "bazel",
-      "args": ["build", "-c", "opt", "//src/workerd/server"],
+      "args": ["build", "-c", "opt", "//src/workerd/server:workerd"],
       "group": {
         "kind": "build",
         "isDefault": false

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,17 @@
       "label": "Bazel Build (dbg)",
       "type": "shell",
       "command": "bazel",
-      "args": ["build", "-c", "dbg", "//src/workerd/server:workerd"],
+      "linux": {
+        "args": ["build", "-c", "dbg", "//src/workerd/server:workerd"],
+      },
+      "osx": {
+        // OS X needs additional build options for symbols to work correctly
+        // (https://github.com/bazelbuild/bazel/issues/6327), hence the additional
+        // flags for the spawn_strategy and oso_prefix. Ideally these would
+        // be in a platform specific config in .bazelrc, but this is not supported
+        // (https://github.com/bazelbuild/bazel/issues/5055).
+        "args": ["build", "-c", "dbg", "--spawn_strategy=local", "--features=oso_prefix_is_pwd", "//src/workerd/server:workerd"],
+      },
       "group": {
         "kind": "build",
         "isDefault": true

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -18,6 +18,16 @@ Microsoft Intellisense extension for this project.
 $ bazel run //:refresh_compile_commands
 ```
 
+If this command fails, try again after running:
+
+```sh
+$ bazel clean --expunge
+$ bazel test //...
+```
+
+There is an issue between workerd's bazel setup and Hedron's compile_commands.json generator (tracked in
+https://github.com/cloudflare/workerd/issues/506).
+
 ## VSCode Tasks
 
 There is a `.vscode/tasks.json` file included in the project that is seeded with a few useful
@@ -26,4 +36,11 @@ tasks for building and testing.
 ## Debugging
 
 There is a `.vscode/launch.json` file included in the project that is with a single configuration
-for debugging the `workerd` binary.
+for debugging the `workerd` binary on Linux.
+
+The debug from vscode, first ensure that you have saved a vscode workspace for workerd,
+`File -> Save Workspace As...`, then `Run -> Start Debugging (F5)`.
+
+Running the project will prompt you for workerd configuration and proceed to serve it from workerd
+running under `gdb`. To use the helloworld sample, the configuration argument would be
+`serve ${workspaceFolder}/samples/helloworld/config.capnp`.

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -35,12 +35,11 @@ tasks for building and testing.
 
 ## Debugging
 
-There is a `.vscode/launch.json` file included in the project that is with a single configuration
-for debugging the `workerd` binary on Linux.
+There is a `.vscode/launch.json` file included in the project for launching the `workerd` binary with
+the debugger attached from VSCode. This is supported on Linux (x64) and OS X (arm64).
 
 The debug from vscode, first ensure that you have saved a vscode workspace for workerd,
 `File -> Save Workspace As...`, then `Run -> Start Debugging (F5)`.
 
-Running the project will prompt you for workerd configuration and proceed to serve it from workerd
-running under `gdb`. To use the helloworld sample, the configuration argument would be
-`serve ${workspaceFolder}/samples/helloworld/config.capnp`.
+Running the project will prompt you for workerd configuration. To use the helloworld sample, the
+configuration argument would be `serve ${workspaceFolder}/samples/helloworld/config.capnp`.


### PR DESCRIPTION
The existing launch.json would only allow debugging workerd commands taking single arguments and didn't support inspecting source code or locals. The single argument problem is discussed in https://github.com/microsoft/vscode/issues/83678.

This change sets the source directory location and uses a debug build that supports symbols. This change assumes that the user is debugging the workerd serve command and they are prompted for a config to run.