### PR TITLE
bazel: fix resources paths to work correctly from external repo

### DIFF
--- a/build/wd_ts_bundle.bzl
+++ b/build/wd_ts_bundle.bzl
@@ -68,7 +68,8 @@ def wd_ts_bundle(
         eslint_bin.eslint_test(
             name = name + "@eslint",
             args = [
-                "--config $(location {})".format(eslintrc_json),
+                "--config $(execpath {})".format(eslintrc_json),
+                "--parser-options project:$(execpath {})".format(tsconfig_json),
                 "-f stylish",
                 "--report-unused-disable-directives",
             ] + ["$(location " + src + ")" for src in ts_srcs],


### PR DESCRIPTION
upstream pr 5249