### PR TITLE
Assorted `npm` release fixes

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -7,7 +7,7 @@ RUN apt-get install -y curl clang libc++-dev libc++abi-dev
 
 COPY . .
 COPY .bazel-cache /bazel-disk-cache
-RUN npm install -g pnpm
+RUN npm install -g pnpm@latest-7
 RUN pnpm install
 
 RUN pnpm exec bazelisk build --disk_cache=/bazel-disk-cache -c opt //src/workerd/server:workerd

--- a/npm/lib/node-install.ts
+++ b/npm/lib/node-install.ts
@@ -177,7 +177,9 @@ function maybeOptimizePackage(binPath: string): void {
   // just running the binary executable directly.
   //
   // Here we optimize for this by replacing the JavaScript file with the binary
-  // executable at install time.
+  // executable at install time. This optimization does not work on Windows
+  // because on Windows the binary executable must be called "workerd.exe"
+  // instead of "workerd".
   //
   // This doesn't work with Yarn both because of lack of support for binary
   // files in Yarn 2+ (see https://github.com/yarnpkg/berry/issues/882) and
@@ -187,7 +189,7 @@ function maybeOptimizePackage(binPath: string): void {
   //
   // This optimization also doesn't apply when npm's "--ignore-scripts" flag is
   // used since in that case this install script will not be run.
-  if (!isYarn()) {
+  if (os.platform() !== "win32" && !isYarn()) {
     const tempPath = path.join(__dirname, "bin-workerd");
     try {
       // First link the binary with a temporary file. If this fails and throws an

--- a/npm/workerd-linux-64/package.json
+++ b/npm/workerd-linux-64/package.json
@@ -8,8 +8,7 @@
     "node": ">=16"
   },
   "os": [
-    "linux",
-    "win32"
+    "linux"
   ],
   "cpu": [
     "x64"


### PR DESCRIPTION
A few more fixes for the `npm` release, now that Windows is supported natively. See commit descriptions for rationale.