### PR TITLE
Remove .clang-format to suppress VSCode autoformatting.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,0 @@
-WhitespaceSensitiveMacros:
-  # clang format doesn't understand TypeScript, so make sure it doesn't mangle
-  # overrides and additional definitions
-  - JSG_TS_OVERRIDE
-  - JSG_TS_DEFINE
-  - JSG_STRUCT_TS_OVERRIDE
-  - JSG_STRUCT_TS_DEFINE


### PR DESCRIPTION
This is necessary to suppress formatting when people are working on workerd in a VSCode workspace with "format on save" enabled.