### PR TITLE
Provide compressed release artifacts

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for label
-        if: ${{ contains(github.event.*.labels.*.name, 'needs-internal-pr') }}
+        if: contains(github.event.*.labels.*.name, 'needs-internal-pr')
         run: |
           echo "Pull request is labeled as 'needs-internal-pr'"
           echo "This workflow fails so the pull request cannot be merged"

--- a/.github/workflows/npm-types.yml
+++ b/.github/workflows/npm-types.yml
@@ -50,7 +50,7 @@ jobs:
           path: ~/bazel-disk-cache
           key: ${{ runner.os }}-${{ runner.arch }}-bazel-disk-cache-types
       - name: install dependencies
-        if: ${{ runner.os == 'Linux' }}
+        if: runner.os == 'Linux'
         run: |
             export DEBIAN_FRONTEND=noninteractive
             sudo apt-get install -y build-essential git clang libc++-dev

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -38,7 +38,7 @@ jobs:
           echo "version=${{ inputs.prerelease == false && '1' || '0'}}.$(bazel-bin/external/capnp-cpp/src/capnp/capnp_tool eval src/workerd/io/compatibility-date.capnp supportedCompatibilityDate | tr -d '-' | tr -d '"').${{ inputs.patch }}" >> $GITHUB_OUTPUT;
           echo "release_version=1.$(bazel-bin/external/capnp-cpp/src/capnp/capnp_tool eval src/workerd/io/compatibility-date.capnp supportedCompatibilityDate | tr -d '-' | tr -d '"').0" >> $GITHUB_OUTPUT;
   publish-arch-specific:
-    # if: ${{ github.repository_owner == 'cloudflare' }}
+    # if: github.repository_owner == 'cloudflare'
     name: Publish arch-specific packages to npm
     needs: version
     runs-on: ubuntu-latest
@@ -64,22 +64,25 @@ jobs:
       - uses: robinraju/release-downloader@v1.5
         with:
           tag: v${{ needs.version.outputs.release_version }}
-          fileName: workerd-${{ matrix.arch }}${{ matrix.arch == 'windows-64' && '.exe' || '' }}
+          fileName: workerd-${{ matrix.arch }}.gz
           tarBall: false
           zipBall: false
           out-file-path: "release-downloads"
           token: ${{ secrets.GITHUB_TOKEN }}
-      - run: chmod +x $GITHUB_WORKSPACE/release-downloads/workerd-${{ matrix.arch }}
-        if: ${{ matrix.arch != 'windows-64' }}
+        # release-downloader does not support .gz files (unlike .tar.gz), decompress manually
+        # Using the -N flag the right file name should be restored
+      - run: gzip -dN workerd-${{ matrix.arch }}.gz
+      - run: chmod +x $GITHUB_WORKSPACE/release-downloads/workerd
+        if: matrix.arch != 'windows-64'
       - run: mkdir npm/workerd-${{ matrix.arch }}/bin
-      - run: cp $GITHUB_WORKSPACE/release-downloads/workerd-${{ matrix.arch }}${{ matrix.arch == 'windows-64' && '.exe' || '' }} npm/workerd-${{ matrix.arch }}/bin/workerd${{ matrix.arch == 'windows-64' && '.exe' || '' }}
+      - run: cp $GITHUB_WORKSPACE/release-downloads/workerd${{ matrix.arch == 'windows-64' && '.exe' || '' }} npm/workerd-${{ matrix.arch }}/bin/workerd${{ matrix.arch == 'windows-64' && '.exe' || '' }}
       - run: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > npm/workerd-${{ matrix.arch }}/.npmrc
       - run: cd npm/workerd-${{ matrix.arch }} && npm publish --access public --tag ${{ inputs.prerelease == true && 'beta' || 'latest'}}
         env:
           NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
 
   publish-wrapper:
-    # if: ${{ github.repository_owner == 'cloudflare' }}
+    # if: github.repository_owner == 'cloudflare'
     name: Publish `workerd` to NPM
     needs: [version, publish-arch-specific]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,18 +40,26 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-bazel-disk-cache
 
       - name: Setup Linux
-        if: ${{ runner.os == 'Linux' }}
+        if: runner.os == 'Linux'
         run: |
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get install -y build-essential git clang libc++-dev
       - name: Setup Windows
-        if: ${{ runner.os == 'Windows' }}
+        if: runner.os == 'Windows'
         run: |
           [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
 
       - name: Bazel build
         run: |
           bazelisk build --disk_cache=~/bazel-disk-cache  --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev -c opt //src/workerd/server:workerd
+      - name: Strip debug symbols
+        if: runner.os != 'Windows'
+        run: |
+          # bazel makes the output directory read-only, fix permissions for binary
+          chmod +w bazel-bin/src/workerd/server/workerd
+          # Strip debug information from the binary, this is acceptable as debug symbols are not
+          # generated for the release configuration. Regular symbols are still included.
+          strip -S bazel-bin/src/workerd/server/workerd
       - name: Upload binary
         uses: actions/upload-artifact@v3.1.0
         with:
@@ -116,16 +124,25 @@ jobs:
         with:
           name: ${{ matrix.name }}-binary
           path: /tmp
-      - run: mv /tmp/workerd${{ matrix.arch == 'windows-64' && '.exe' || '' }} /tmp/workerd-${{ matrix.arch }}
-      - run: chmod +x /tmp/workerd-${{ matrix.arch }}
-        if: ${{ matrix.arch != 'windows-64' }}
-      - name: Upload Release Asset
+      # Set execute permissions before compressing the binary
+      - if: matrix.arch != 'windows-64'
+        run: chmod +x /tmp/workerd
+      - name: Compress release binary
+        run: |
+            # As of release v1.20230404.0 the Linux x64 binary after debug_strip is 65.8 MB,
+            # 21.0 MB with gzip and 17.3 MB with brotli -9. Use gzip as a widely supported format
+            # which still produces an acceptable compressed size.
+            gzip -9N /tmp/workerd${{ matrix.arch == 'windows-64' && '.exe' || '' }}
+      - run: mv /tmp/workerd${{ matrix.arch == 'windows-64' && '.exe' || '' }}.gz /tmp/workerd-${{ matrix.arch }}.gz
+      # Upload compressed release binaries – one set of artifacts is sufficient with gzip being
+      # widely supported
+      - name: Upload Release Assets
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.tag-and-release.outputs.upload_url }}
-          asset_path: /tmp/workerd-${{ matrix.arch }}
-          asset_name: workerd-${{ matrix.arch }}${{ matrix.arch == 'windows-64' && '.exe' || '' }}
-          asset_content_type: application/octet-stream
+          asset_path: /tmp/workerd-${{ matrix.arch }}.gz
+          asset_name: workerd-${{ matrix.arch }}.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,12 @@ jobs:
           path: ~/bazel-disk-cache
           key: ${{ runner.os }}-${{ runner.arch }}-bazel-disk-cache
       - name: Setup Linux
-        if: ${{ runner.os == 'Linux' }}
+        if: runner.os == 'Linux'
         run: |
             export DEBIAN_FRONTEND=noninteractive
             sudo apt-get install -y build-essential git clang libc++-dev
       - name: Setup Windows
-        if: ${{ runner.os == 'Windows' }}
+        if: runner.os == 'Windows'
         run: |
             [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
       - name: Bazel build


### PR DESCRIPTION
- Compress release binaries using gzip and provide compressed executables on the release page. This significantly reduces download sizes (see comments)
- Non-compressed binaries are no longer available – before merging we should make sure wrangler is prepared for this change
- Release binaries are stripped of debug symbols. There shouldn't be many debug symbols in the first place since workerd is compiled without -g, but this still improves the file size (~4MB on Linux)
- Some Github Actions refactoring, `${{ }}`expression syntax is not required in if conditions

There should be no need to upload compressed NPM binaries directly – the NPM publish action will download and decompress the release binary and then use npm pack/publish to create a compressed tarball as before.