### PR TITLE
Provide Crypto/Compression API errors where safe, fix macOS compiler warning

### DIFF
--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -257,8 +257,6 @@ private:
   kj::UnixEventPort::FdObserver observer;
   kj::Vector<kj::AutoCloseFd> filesWatched;
 
-  bool sawChange = false;
-
   static kj::AutoCloseFd makeKqueue() {
     int fd_;
     KJ_SYSCALL(fd_ = kqueue());


### PR DESCRIPTION
Based on the `JSG_WARN_ONCE_IF()` statements added in recent changes to the Web Crypto/Compression Streams APIs, errors can be thrown without breaking existing code in several but not all situations where there should be an error.
As a first step, throw errors where we can safely do so, which simplifies the code in several spaces; a future PR will create configuration flags to return errors in the other cases without breaking existing code.

Also fix a compiler warning about an unused variable that occurs in the implementation of FileWatcher for macOS/BSD.

Also see the eponymous upstream branch.