### PR TITLE
Fix request.cf's botManagement.score description

### DIFF
--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -392,8 +392,7 @@ interface IncomingRequestCfPropertiesBase extends Record<string, unknown> {
 interface IncomingRequestCfPropertiesBotManagementBase {
   /**
    * Cloudflare’s [level of certainty](https://developers.cloudflare.com/bots/concepts/bot-score/) that a request comes from a bot,
-   * represented as an integer percentage between `1` (almost certainly human)
-   * and `99` (almost certainly a bot).
+   * represented as an integer percentage between `1` (almost certainly a bot) and `99` (almost certainly human).
    *
    * @example 54
    */


### PR DESCRIPTION
The description was backwards. Score 1 is bot, 99 is human.