### PR TITLE
[bazel] Enable dead code stripping on macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,9 +22,10 @@ build:fastdbg -c fastbuild
 build:fastdbg --cxxopt='-gline-tables-only' --host_cxxopt='-gline-tables-only'
 build:fastdbg --linkopt='-gline-tables-only' --host_linkopt='-gline-tables-only'
 build:fastdbg --strip=never
+build:fastdbg --//:dead_strip=False
 
 # Additional Rust flags (see https://doc.rust-lang.org/rustc/codegen-options/index.html)
-# Need to disable debug-assertions for fastdbg, should be off automatically for opt
+# Need to disable debug-assertions for fastbuild, should be off automatically for opt
 build --@rules_rust//:extra_rustc_flags=-C,panic=abort,-C,debug-assertions=n
 
 build:fastdbg --@rules_rust//:extra_rustc_flags=-C,panic=unwind,-C,debug-assertions=y,-C,debuginfo=1

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,8 @@ load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile
 load("@aspect_rules_js//npm:defs.bzl", "npm_link_package", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:capnpc-ts/package_json.bzl", capnpc_ts_bin = "bin")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//lib:selects.bzl", "selects")
 
 cc_capnp_library(
     name = "icudata-embed",
@@ -28,4 +30,42 @@ npm_link_package(
 capnpc_ts_bin.capnpc_ts_binary(
     name = "capnpc_ts",
     visibility = ["//visibility:public"],
+)
+
+# bazel enables the --ffunction-sections, --gc-sections flags used to remove dead code by default
+# on Linux opt builds. Enable the equivalent macOS flag -Wl,-dead_strip here to work around bazel
+# idiosyncrasies.
+# Note that the flag is defined for all non-debug builds of kj_test() and wd_cc_binary() on mac as
+# it surprisingly appears to be faster, perhaps because the linker generates and writes binaries
+# with much fewer symbols. This also helps reduce local and CI disk usage. If needed, dead code
+# stripping can be limited to optimized builds.
+config_setting(
+    name = "fast_build",
+    values = {"compilation_mode": "fastbuild"},
+)
+
+config_setting(
+    name = "opt_build",
+    values = {"compilation_mode": "opt"},
+)
+
+bool_flag(
+    name = "dead_strip",
+    build_setting_default = True,
+)
+
+config_setting(
+    name = "set_dead_strip",
+    flag_values = {"dead_strip": "True"},
+)
+
+# Workaround for bazel not supporting negated conditions (https://github.com/bazelbuild/bazel-skylib/issues/272)
+selects.config_setting_group(
+    name = "not_dbg_build",
+    match_any = [":fast_build", ":opt_build"],
+)
+
+selects.config_setting_group(
+    name = "use_dead_strip",
+    match_all = ["@platforms//os:macos", ":set_dead_strip", ":not_dbg_build"],
 )

--- a/build/kj_test.bzl
+++ b/build/kj_test.bzl
@@ -13,4 +13,8 @@ def kj_test(
             "@platforms//os:windows": [],
             "//conditions:default": ["@workerd//src/workerd/util:symbolizer"],
         }) + deps,
+        linkopts = select({
+          "@//:use_dead_strip": ["-Wl,-dead_strip"],
+          "//conditions:default": [""],
+        }),
     )

--- a/build/wd_cc_binary.bzl
+++ b/build/wd_cc_binary.bzl
@@ -2,12 +2,17 @@
 
 def wd_cc_binary(
         name,
+        linkopts = [],
         visibility = None,
         **kwargs):
     """Wrapper for cc_binary that sets common attributes
     """
     native.cc_binary(
         name = name,
+        linkopts = linkopts + select({
+          "@//:use_dead_strip": ["-Wl,-dead_strip"],
+          "//conditions:default": [""],
+        }),
         visibility = visibility,
         **kwargs
     )

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -2,7 +2,7 @@ load("//:build/kj_test.bzl", "kj_test")
 load("//:build/wd_cc_library.bzl", "wd_cc_library")
 load("//:build/wd_cc_binary.bzl", "wd_cc_binary")
 load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "int_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
 config_setting(


### PR DESCRIPTION
This adds the `-dead_strip` flag to the linker options on macOS when optimization is enabled, effectively replicating bazel's approach on Linux where `--ffunction-sections` `--gc-sections` flags are enabled by default under the `opt` configuration.
Based on the Mach-O binary format no compiler flag changes are needed, dead code stripping is linker-only.

optimized workerd binary size: `67.9MB -> 60.2MB`

Up for discussion: I wasn't planning to enable this for fastbuild mode and only modified the .bazelrc file to show that the change won't break test cases, but based on local testing it might be a tiny bit faster since the linker generates and writes binaries with much fewer symbols. For `crypto-impl-asymmetric-test`, linking takes 1.5s instead of 1.8s and fastbuild binary size is down from 172MB to 116MB. While these results may not be representative – I expected dead_strip builds to be slower – this may reduce CI disk usage and improve the local build experience.