### PR TITLE
A couple of minor improvements to AsyncContextFrame::StorageKey

### DIFF
--- a/src/workerd/jsg/async-context.c++
+++ b/src/workerd/jsg/async-context.c++
@@ -22,8 +22,7 @@ inline void maybeSetV8ContinuationContext(
 }
 }  // namespace
 
-AsyncContextFrame::AsyncContextFrame(Lock& js, StorageEntry storageEntry)
-    : isolate(IsolateBase::from(js.v8Isolate)) {
+AsyncContextFrame::AsyncContextFrame(Lock& js, StorageEntry storageEntry) {
   KJ_IF_MAYBE(frame, current(js)) {
     // Propagate the storage context of the current frame (if any).
     // If current(js) returns nullptr, we assume we're in the root
@@ -33,6 +32,10 @@ AsyncContextFrame::AsyncContextFrame(Lock& js, StorageEntry storageEntry)
       storage.insert(entry.clone(js));
     }
   }
+
+  // This case is extremely unlikely to happen but let's handle it anyway
+  // just out of an excess of caution.
+  if (storageEntry.key->isDead()) return;
 
   storage.upsert(kj::mv(storageEntry), [](StorageEntry& existing, StorageEntry&& row) mutable {
     existing.value = kj::mv(row.value);

--- a/src/workerd/jsg/async-context.h
+++ b/src/workerd/jsg/async-context.h
@@ -66,10 +66,11 @@ public:
     // An opaque key that identifies an async-local storage cell within the frame.
   public:
     StorageKey() : hash(kj::hashCode(this)) {}
+    KJ_DISALLOW_COPY_AND_MOVE(StorageKey);
 
     void reset() { dead = true; }
     // The owner of the key should reset it when it goes away.
-    // The StorageKey is typically owned by an instance of AsyncLocalstorage (see
+    // The StorageKey is typically owned by an instance of AsyncLocalStorage (see
     // the api/node/async-hooks.h). When the ALS instance is garbage collected, it
     // must call reset to signal that this StorageKey is "dead" and can never be
     // looked up again. Subsequent accesses to a frame will remove dead keys from
@@ -83,7 +84,7 @@ public:
     bool isDead() const { return dead; }
     inline uint hashCode() const { return hash; }
     inline bool operator==(const StorageKey& other) const {
-      return hash == other.hash;
+      return this == &other;
     }
 
   private:
@@ -181,7 +182,7 @@ private:
     }
 
     bool matches(const StorageEntry& entry, StorageKey& key) const {
-      return entry.key->hashCode() == key.hashCode();
+      return entry.key.get() == &key;
     }
 
     uint hashCode(StorageKey& key) const {
@@ -191,8 +192,6 @@ private:
 
   using Storage = kj::Table<StorageEntry, kj::HashIndex<StorageEntryCallbacks>>;
   Storage storage;
-
-  IsolateBase& isolate;
 
   void jsgVisitForGc(GcVisitor& visitor) override;
 


### PR DESCRIPTION
* Reset the tracing storage key in IoContext when the context is destroyed.
* Do not store a key if the key has already been reset
* Compare pointers and not hash in operator=