### PR TITLE
Do not sanitize internal error messages in jsg::annotateBroken()

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -330,7 +330,7 @@ void reportStartupError(
 
       auto& ex = permanentException.emplace(kj::mv(*limitError));
       KJ_IF_MAYBE(e, errorReporter) {
-        e->addError(kj::mv(description));
+        e->addError(kj::heapString(description));
       } else KJ_IF_MAYBE(i, inspector) {
         // We want to extend just enough cpu time as is necessary to report the exception
         // to the inspector here. 10 milliseconds should be more than enough.

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -117,7 +117,7 @@ struct TypeErrorContext {
 void throwIllegalConstructor(const v8::FunctionCallbackInfo<v8::Value>& args);
 // Callback used when attempting to construct a type that can't be constructed from JavaScript.
 
-kj::String extractTunneledExceptionDescription(kj::StringPtr message);
+kj::StringPtr extractTunneledExceptionDescription(kj::StringPtr message);
 
 kj::Exception createTunneledException(v8::Isolate* isolate, v8::Local<v8::Value> exception);
 // Given a JavaScript exception, returns a KJ exception that contains a tunneled exception type that


### PR DESCRIPTION
This commit does the following:
- Preserves the original message for internal exceptions that pass through jsg::annotateBroken(). It turns out that we only expect to see non-JSG messages in situations where `Worker::Actor::Impl::makeStorage()` throws. Up until recently, all storage interfaces had trivial construction, so it was never an issue. Since this is difficult to do in a testing environment, I have verified the messages manually.
- Reorganizes cases when making a `DecodedException` so that kj exceptions get their own branch with a default exception.
- Sanitizes jsg-internal exceptions when extracting descriptions for use with the worker logging.
- Logs at info level when we annotate an exception with brokenness.