### PR TITLE
Manually tell V8 where the stack starts whenever we enter it.

### DIFF
--- a/src/workerd/api/actor-state-test.c++
+++ b/src/workerd/api/actor-state-test.c++
@@ -32,7 +32,8 @@ JSG_DECLARE_ISOLATE_TYPE(ActorStateIsolate, ActorStateContext);
 KJ_TEST("v8 serialization version tag hasn't changed") {
   jsg::test::Evaluator<ActorStateContext, ActorStateIsolate> e(v8System);
   ActorStateIsolate &actorStateIsolate = e.getIsolate();
-  ActorStateIsolate::Lock isolateLock(actorStateIsolate);
+  jsg::V8StackScope stackScope;
+  ActorStateIsolate::Lock isolateLock(actorStateIsolate, stackScope);
   auto* isolate = isolateLock.v8Isolate;
   v8::HandleScope handleScope(isolate);
   auto v8Context = isolateLock.newContext<ActorStateContext>().getHandle(isolate);
@@ -61,7 +62,8 @@ KJ_TEST("v8 serialization version tag hasn't changed") {
 KJ_TEST("we support deserializing up to v15") {
   jsg::test::Evaluator<ActorStateContext, ActorStateIsolate> e(v8System);
   ActorStateIsolate &actorStateIsolate = e.getIsolate();
-  ActorStateIsolate::Lock isolateLock(actorStateIsolate);
+  jsg::V8StackScope stackScope;
+  ActorStateIsolate::Lock isolateLock(actorStateIsolate, stackScope);
   auto* isolate = isolateLock.v8Isolate;
   v8::HandleScope handleScope(isolate);
   auto v8Context = isolateLock.newContext<ActorStateContext>().getHandle(isolate);
@@ -109,7 +111,8 @@ KJ_TEST("wire format version does not change deserialization behavior on real da
 
   jsg::test::Evaluator<ActorStateContext, ActorStateIsolate> e(v8System);
   ActorStateIsolate &actorStateIsolate = e.getIsolate();
-  ActorStateIsolate::Lock isolateLock(actorStateIsolate);
+  jsg::V8StackScope stackScope;
+  ActorStateIsolate::Lock isolateLock(actorStateIsolate, stackScope);
   auto* isolate = isolateLock.v8Isolate;
   v8::HandleScope handleScope(isolate);
   auto v8Context = isolateLock.newContext<ActorStateContext>().getHandle(isolate);

--- a/src/workerd/api/crypto-impl-aes-test.c++
+++ b/src/workerd/api/crypto-impl-aes-test.c++
@@ -85,7 +85,8 @@ KJ_TEST("AES-CTR key wrap") {
 
   jsg::test::Evaluator<CryptoContext, CryptoIsolate> e(v8System);
   CryptoIsolate &cryptoIsolate = e.getIsolate();
-  CryptoIsolate::Lock isolateLock(cryptoIsolate);
+  jsg::V8StackScope stackScope;
+  CryptoIsolate::Lock isolateLock(cryptoIsolate, stackScope);
   auto isolate = isolateLock.v8Isolate;
   v8::HandleScope handleScope(isolate);
   auto context = isolateLock.newContext<CryptoContext>().getHandle(isolate);

--- a/src/workerd/api/crypto-impl-asymmetric-test.c++
+++ b/src/workerd/api/crypto-impl-asymmetric-test.c++
@@ -50,7 +50,8 @@ KJ_TEST("RSA-PSS generateKey infinite loop") {
 KJ_TEST("EDDSA ED25519 generateKey") {
   jsg::test::Evaluator<CryptoContext, CryptoIsolate> e(v8System);
   CryptoIsolate &cryptoIsolate = e.getIsolate();
-  CryptoIsolate::Lock isolateLock(cryptoIsolate);
+  jsg::V8StackScope stackScope;
+  CryptoIsolate::Lock isolateLock(cryptoIsolate, stackScope);
   auto isolate = isolateLock.v8Isolate;
   v8::HandleScope handleScope(isolate);
   auto context = isolateLock.newContext<CryptoContext>().getHandle(isolate);

--- a/src/workerd/api/streams/queue-test.c++
+++ b/src/workerd/api/streams/queue-test.c++
@@ -18,13 +18,14 @@ JSG_DECLARE_ISOLATE_TYPE(QueueIsolate, QueueContext);
 
 struct Preamble {
   QueueIsolate isolate;
+  jsg::V8StackScope stackScope;
   QueueIsolate::Lock lock;
   v8::HandleScope scope;
   v8::Local<v8::Context> context;
   v8::Context::Scope contextScope;
   Preamble()
     : isolate(v8System),
-      lock(isolate),
+      lock(isolate, stackScope),
       scope(lock.v8Isolate),
       context(lock.newContext<QueueContext>().getHandle(lock.v8Isolate)),
       contextScope(context) {}

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -471,12 +471,14 @@ void WorkerEntrypoint::maybeAddGcPassForTest(
     auto worker = kj::atomicAddRef(context.getWorker());
     if constexpr (kj::isSameType<T, void>()) {
       promise = promise.then([worker = kj::mv(worker)]() {
-        auto lock = worker->getIsolate().getApiIsolate().lock();
+        jsg::V8StackScope stackScope;
+        auto lock = worker->getIsolate().getApiIsolate().lock(stackScope);
         lock->requestGcForTesting();
       });
     } else {
       promise = promise.then([worker = kj::mv(worker)](auto res) {
-        auto lock = worker->getIsolate().getApiIsolate().lock();
+        jsg::V8StackScope stackScope;
+        auto lock = worker->getIsolate().getApiIsolate().lock(stackScope);
         lock->requestGcForTesting();
         return res;
       });

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -24,6 +24,7 @@ namespace workerd {
 
 namespace jsg {
   class V8System;
+  class V8StackScope;
   class DOMException;
   class ModuleRegistry;
 }
@@ -464,7 +465,7 @@ public:
   // TODO(cleanup): This is a hack thrown in quickly because IoContext::curent() dosen't work in
   //   the global scope (when no request is running). We need a better design here.
 
-  virtual kj::Own<jsg::Lock> lock() const = 0;
+  virtual kj::Own<jsg::Lock> lock(jsg::V8StackScope& stackScope) const = 0;
   // Take a lock on the isolate.
   //
   // TODO(cleanup): Change all locking to a synchrenous callback style rather than RAII style, so
@@ -515,6 +516,8 @@ class Worker::Lock {
   // A Worker may bounce between threads as it handles multiple requests, but can only actually
   // execute on one thread at a time. Each thread must therefore lock the Worker while executing
   // code.
+  //
+  // A Worker::Lock MUST be allocated on the stack.
 
 public:
   class TakeSynchronously {
@@ -582,6 +585,7 @@ public:
 private:
   struct Impl;
 
+  jsg::V8StackScope stackScope;
   Worker& worker;
   kj::Own<Impl> impl;
 

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -313,7 +313,8 @@ JSG_DECLARE_ISOLATE_TYPE(LockLogIsolate, LockLogContext);
 KJ_TEST("jsg::Lock logWarning") {
   LockLogIsolate isolate(v8System);
   bool called = false;
-  LockLogIsolate::Lock lock(isolate);
+  V8StackScope stackScope;
+  LockLogIsolate::Lock lock(isolate, stackScope);
   lock.setLoggerCallback([&called](jsg::Lock& js, auto message) {
     KJ_ASSERT(message == "Yes that happened"_kj);
     called = true;
@@ -369,7 +370,8 @@ JSG_DECLARE_ISOLATE_TYPE(IsolateUuidIsolate, IsolateUuidContext);
 
 KJ_TEST("jsg::Lock getUuid") {
   IsolateUuidIsolate isolate(v8System);
-  IsolateUuidIsolate::Lock lock(isolate);
+  V8StackScope stackScope;
+  IsolateUuidIsolate::Lock lock(isolate, stackScope);
   // Returns the same value
   KJ_ASSERT(lock.getUuid() == lock.getUuid());
   KJ_ASSERT(isolate.getUuid() == lock.getUuid());

--- a/src/workerd/jsg/jsg-test.h
+++ b/src/workerd/jsg/jsg-test.h
@@ -29,7 +29,8 @@ public:
   }
 
   void expectEval(kj::StringPtr code, kj::StringPtr expectedType, kj::StringPtr expectedValue) {
-    typename IsolateType::Lock lock(getIsolate());
+    V8StackScope stackScope;
+    typename IsolateType::Lock lock(getIsolate(), stackScope);
 
     // Create a stack-allocated handle scope.
     v8::HandleScope handleScope(lock.v8Isolate);
@@ -72,17 +73,20 @@ public:
   }
 
   void setAllowEval(bool b) {
-    typename IsolateType::Lock lock(getIsolate());
+    V8StackScope stackScope;
+    typename IsolateType::Lock lock(getIsolate(), stackScope);
     lock.setAllowEval(b);
   }
 
   void setCaptureThrowsAsRejections(bool b) {
-    typename IsolateType::Lock lock(getIsolate());
+    V8StackScope stackScope;
+    typename IsolateType::Lock lock(getIsolate(), stackScope);
     lock.setCaptureThrowsAsRejections(b);
   }
 
   void runMicrotasks() {
-    typename IsolateType::Lock lock(getIsolate());
+    V8StackScope stackScope;
+    typename IsolateType::Lock lock(getIsolate(), stackScope);
     lock.v8Isolate->PerformMicrotaskCheckpoint();
   }
 

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2053,6 +2053,26 @@ private:
   bool warningsLogged;
 };
 
+class V8StackScope {
+  // One of this MUST be allocated on the stack before taking an isolate lock. It must be allocated
+  // before any handles on the stack. This MUST NOT be allocated on the heap.
+  //
+  // The reason why Isolate::Lock doesn't take care of this automatically is because it is often
+  // allocated on the heap. The purpose of V8StackScope is to capture the start of the stack
+  // range that V8 must scan when performing conservative stack-scanning garbage collection.
+public:
+  // No interface.
+
+private:
+#if V8_HAS_STACK_START_MARKER
+  // This currently depends on a V8 patch which hasn't been upstreamed. Note that workerd does
+  // not use this patch; it's only used internally. The patch is needed in order to work around
+  // oddities of our internal environment which do not apply to workerd. For workerd, V8's default
+  // behavior is just fine.
+  v8::StackStartMarker v8Marker;
+#endif
+};
+
 // =======================================================================================
 // inline implementation details
 

--- a/src/workerd/jsg/setup-test.c++
+++ b/src/workerd/jsg/setup-test.c++
@@ -22,14 +22,16 @@ KJ_TEST("eval() is blocked") {
       "throws", "EvalError: Code generation from strings disallowed for this context");
 
   {
-    EvalIsolate::Lock(e.getIsolate()).setAllowEval(true);
+    V8StackScope stackScope;
+    EvalIsolate::Lock(e.getIsolate(), stackScope).setAllowEval(true);
   }
 
   e.expectEval("eval('123')", "number", "123");
   e.expectEval("new Function('a', 'b', 'return a + b;')(123, 321)", "number", "444");
 
   {
-    EvalIsolate::Lock(e.getIsolate()).setAllowEval(false);
+    V8StackScope stackScope;
+    EvalIsolate::Lock(e.getIsolate(), stackScope).setAllowEval(false);
   }
 
   e.expectEval("eval('123')",
@@ -65,7 +67,8 @@ JSG_DECLARE_ISOLATE_TYPE(ConfigIsolate, ConfigContext, ConfigContext::Nested,
 KJ_TEST("configuration values reach nested type declarations") {
   {
     ConfigIsolate isolate(v8System, 123);
-    ConfigIsolate::Lock lock(isolate);
+    V8StackScope stackScope;
+    ConfigIsolate::Lock lock(isolate, stackScope);
     v8::HandleScope handleScope(lock.v8Isolate);
     lock.newContext<ConfigContext>().getHandle(lock.v8Isolate);
   }
@@ -73,7 +76,8 @@ KJ_TEST("configuration values reach nested type declarations") {
     KJ_EXPECT_LOG(ERROR, "failed: expected configuration == 123");
 
     ConfigIsolate isolate(v8System, 456);
-    ConfigIsolate::Lock lock(isolate);
+    V8StackScope stackScope;
+    ConfigIsolate::Lock lock(isolate, stackScope);
     v8::HandleScope handleScope(lock.v8Isolate);
     lock.newContext<ConfigContext>().getHandle(lock.v8Isolate);
   }

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -310,7 +310,7 @@ public:
     // constructing a `Lock` on the stack.
 
   public:
-    Lock(const Isolate& isolate)
+    Lock(const Isolate& isolate, V8StackScope& scope)
         : jsg::Lock(isolate.ptr), jsgIsolate(const_cast<Isolate&>(isolate)) {
       jsgIsolate.clearDestructionQueue();
     }

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -138,8 +138,8 @@ WorkerdApiIsolate::WorkerdApiIsolate(jsg::V8System& v8System,
     : impl(kj::heap<Impl>(v8System, features, limitEnforcer)) {}
 WorkerdApiIsolate::~WorkerdApiIsolate() noexcept(false) {}
 
-kj::Own<jsg::Lock> WorkerdApiIsolate::lock() const {
-  return kj::heap<JsgWorkerdIsolate::Lock>(impl->jsgIsolate);
+kj::Own<jsg::Lock> WorkerdApiIsolate::lock(jsg::V8StackScope& stackScope) const {
+  return kj::heap<JsgWorkerdIsolate::Lock>(impl->jsgIsolate, stackScope);
 }
 CompatibilityFlags::Reader WorkerdApiIsolate::getFeatureFlags() const {
   return *impl->features;

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -18,7 +18,7 @@ public:
       IsolateLimitEnforcer& limitEnforcer);
   ~WorkerdApiIsolate() noexcept(false);
 
-  kj::Own<jsg::Lock> lock() const override;
+  kj::Own<jsg::Lock> lock(jsg::V8StackScope& stackScope) const override;
   CompatibilityFlags::Reader getFeatureFlags() const override;
   jsg::JsContext<api::ServiceWorkerGlobalScope> newContext(jsg::Lock& lock) const override;
   jsg::Dict<NamedExport> unwrapExports(


### PR DESCRIPTION
This uses a V8 patch. If the patch isn't present, it automatically skips it and relies on V8 to figure things out the normal way.

The patch is needed in order to work around issues in our internal environment, especially the fact that /proc/self/maps is not accessible. The patch isn't needed when using workerd stand-alone.