### PR TITLE
Support calling the queue() handler of a worker via a service binding

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -286,4 +286,10 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Enables the tunneling of exceptions from a dynamic dispatch callee back into the caller.
   # Previously any uncaught exception in the callee would be returned to the caller as an empty
   # HTTP 500 response.
+
+   serviceBindingExtraHandlers @28 :Bool
+      $compatEnableFlag("service_binding_extra_handlers")
+      $experimental;
+  # Allows service bindings to call additional event handler methods on the target Worker.
+  # Initially only includes support for calling the queue() handler.
 }


### PR DESCRIPTION
This is protected by a new compatibility flag since the current plan is
to only allow it in local development. As such, I've marked it as
experimental since AFAIK doing so is the way to prevent users from
enabling it in production. But I don't know if that'll make it awkward
for miniflare to use, and if so what our possible alternatives are.

---

Ignore the first commit, it's just #543. The second commit is what's new here.