### PR TITLE
Add requested comments / debug checks on V8StackScope.

### DIFF
--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -210,4 +210,8 @@ void Name::visitForGc(GcVisitor& visitor) {
   }
 }
 
+V8StackScope::V8StackScope() {
+  kj::requireOnStack(this, "V8StackScope must be allocated on the stack");
+}
+
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2062,6 +2062,9 @@ class V8StackScope {
   // allocated on the heap. The purpose of V8StackScope is to capture the start of the stack
   // range that V8 must scan when performing conservative stack-scanning garbage collection.
 public:
+  V8StackScope();
+  KJ_DISALLOW_COPY_AND_MOVE(V8StackScope);
+
   // No interface.
 
 private:

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -310,8 +310,12 @@ public:
     // constructing a `Lock` on the stack.
 
   public:
-    Lock(const Isolate& isolate, V8StackScope& scope)
+    Lock(const Isolate& isolate, V8StackScope&)
         : jsg::Lock(isolate.ptr), jsgIsolate(const_cast<Isolate&>(isolate)) {
+      // `V8StackScope` must be provided to prove that one has been created on the stack before
+      // taking a lock. Any GC'dp ointers stored on the stack must be kept within this scope in
+      // order for V8's stack-scanning GC to find them.
+
       jsgIsolate.clearDestructionQueue();
     }
 


### PR DESCRIPTION
As requested in review of #544.

(I didn't update `jsg/README.md` because that document currently doesn't cover how to obtain an isolate lock in the first place, which is where it would make sense to mention this.)