### PR TITLE
Move trace info async storage key from IoContext to Worker::Isolate

### DIFF
--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -810,7 +810,7 @@ public:
   kj::Own<CacheClient> getCacheClient();
   // Get an HttpClient to use for Cache API subrequests.
 
-  jsg::AsyncContextFrame::StorageScope makeAsyncTraceScope(jsg::Lock& js) KJ_WARN_UNUSED_RESULT;
+  jsg::AsyncContextFrame::StorageScope makeAsyncTraceScope(Worker::Lock& lock) KJ_WARN_UNUSED_RESULT;
   // Returns an object that ensures an async JS operation started in the current scope captures the
   // current request's trace span.
 
@@ -966,8 +966,6 @@ private:
 
   kj::TaskSet waitUntilTasks;
   EventOutcome waitUntilStatusValue = EventOutcome::OK;
-
-  kj::Own<jsg::AsyncContextFrame::StorageKey> traceAsyncContextKey;
 
   void setTimeoutImpl(TimeoutId timeoutId, bool repeat, jsg::V8Ref<v8::Function> function,
     double msDelay, kj::Array<jsg::Value> args);

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -12,6 +12,7 @@
 #include <workerd/io/worker-interface.capnp.h>
 #include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/jsg/jsg.h>
+#include <workerd/jsg/async-context.h>
 #include <kj/mutex.h>
 #include <workerd/io/io-channels.h>
 #include <workerd/io/actor-storage.capnp.h>
@@ -444,6 +445,7 @@ private:
   class LimitedBodyWrapper;
 
   size_t nextRequestId = 0;
+  kj::Own<jsg::AsyncContextFrame::StorageKey> traceAsyncContextKey;
 
   friend class Worker;
   friend class IsolateChannelImpl;
@@ -581,6 +583,9 @@ public:
 
   api::ServiceWorkerGlobalScope& getGlobalScope();
   // Get the C++ object representing the global scope.
+
+  jsg::AsyncContextFrame::StorageKey& getTraceAsyncContextKey();
+  // Get the opaque storage key to use for recording trace information in async contexts.
 
 private:
   struct Impl;


### PR DESCRIPTION
Should allow better support of tracing in use cases where there are multiple IoContexts per Isolate.