### PR TITLE
Add experimental flags to experimental types entrypoint

### DIFF
--- a/src/workerd/io/compatibility-date.c++
+++ b/src/workerd/io/compatibility-date.c++
@@ -87,13 +87,6 @@ struct CompatDate {
   }
 };
 
-static constexpr uint64_t COMPAT_ENABLE_FLAG_ANNOTATION_ID = 0xb6dabbc87cd1b03eull;
-static constexpr uint64_t COMPAT_DISABLE_FLAG_ANNOTATION_ID = 0xd145cf1adc42577cull;
-static constexpr uint64_t COMPAT_ENABLE_DATE_ANNOTATION_ID = 0x91a5d5d7244cf6d0ull;
-static constexpr uint64_t COMPAT_ENABLE_ALL_DATES_ANNOTATION_ID = 0x9a1d37c8030d9418;
-static constexpr uint64_t EXPERIMENTAl_ANNOTATION_ID = 0xe3e5a63e76284d88;
-static constexpr uint64_t NEEDED_BY_FL = 0xbd23aff9deefc308ull;
-
 }  // namespace
 
 void compileCompatibilityFlags(kj::StringPtr compatDate, capnp::List<capnp::Text>::Reader compatFlags,

--- a/src/workerd/io/compatibility-date.h
+++ b/src/workerd/io/compatibility-date.h
@@ -48,4 +48,11 @@ kj::Array<kj::StringPtr> decompileCompatibilityFlagsForFl(CompatibilityFlags::Re
 kj::Maybe<kj::String> normalizeCompatDate(kj::StringPtr date);
 // Exposed to unit test the parser.
 
+static constexpr uint64_t COMPAT_ENABLE_FLAG_ANNOTATION_ID = 0xb6dabbc87cd1b03eull;
+static constexpr uint64_t COMPAT_DISABLE_FLAG_ANNOTATION_ID = 0xd145cf1adc42577cull;
+static constexpr uint64_t COMPAT_ENABLE_DATE_ANNOTATION_ID = 0x91a5d5d7244cf6d0ull;
+static constexpr uint64_t COMPAT_ENABLE_ALL_DATES_ANNOTATION_ID = 0x9a1d37c8030d9418;
+static constexpr uint64_t EXPERIMENTAl_ANNOTATION_ID = 0xe3e5a63e76284d88;
+static constexpr uint64_t NEEDED_BY_FL = 0xbd23aff9deefc308ull;
+
 }  // namespace workerd

--- a/src/workerd/io/compatibility-date.h
+++ b/src/workerd/io/compatibility-date.h
@@ -48,6 +48,7 @@ kj::Array<kj::StringPtr> decompileCompatibilityFlagsForFl(CompatibilityFlags::Re
 kj::Maybe<kj::String> normalizeCompatDate(kj::StringPtr date);
 // Exposed to unit test the parser.
 
+// These values come from src/workerd/io/compatibility-date.capnp
 static constexpr uint64_t COMPAT_ENABLE_FLAG_ANNOTATION_ID = 0xb6dabbc87cd1b03eull;
 static constexpr uint64_t COMPAT_DISABLE_FLAG_ANNOTATION_ID = 0xd145cf1adc42577cull;
 static constexpr uint64_t COMPAT_ENABLE_DATE_ANNOTATION_ID = 0x91a5d5d7244cf6d0ull;

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -52,7 +52,7 @@ compat_dates = [
     # https://developers.cloudflare.com/workers/platform/compatibility-dates/#compliant-transformstream-constructor
     ("2022-11-30", "2022-11-30"),
     # Latest compatibility date (note these types should be the same as the previous entry)
-    ("2030-01-01", "experimental"),
+    (None, "experimental"),
 ]
 
 filegroup(
@@ -61,11 +61,11 @@ filegroup(
         "//src/workerd/tools:api_encoder_" + label
         for (date, label) in compat_dates
     ],
-    visibility = ["//visibility:public"],
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    visibility = ["//visibility:public"],
 )
 
 [
@@ -75,15 +75,16 @@ filegroup(
         args = [
             "--output",
             "$(location " + label + ".api.capnp.bin)",
+        ] + ([
             "--compatibility-date",
             date,
-        ],
-        tool = "api_encoder_bin",
-        visibility = ["//visibility:public"],
+        ] if date else []),
         target_compatible_with = select({
             "@platforms//os:windows": ["@platforms//:incompatible"],
             "//conditions:default": [],
         }),
+        tool = "api_encoder_bin",
+        visibility = ["//visibility:public"],
     )
     for (date, label) in compat_dates
 ]
@@ -98,16 +99,20 @@ cc_ast_dump(
     name = "dump_api_ast",
     src = api_encoder_src,
     out = "api.ast.json.gz",
-    deps = [":api_encoder_lib"],
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    deps = [":api_encoder_lib"],
 )
 
 rust_binary(
     name = "param_extractor_bin",
     srcs = ["param-extractor.rs"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [
         "@crates_vendor//:anyhow",
         "@crates_vendor//:clang-ast",
@@ -116,10 +121,6 @@ rust_binary(
         "@crates_vendor//:serde",
         "@crates_vendor//:serde_json",
     ],
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
 )
 
 run_binary(
@@ -134,10 +135,10 @@ run_binary(
         "--output",
         "$(location param-names.json)",
     ],
-    tool = "param_extractor_bin",
-    visibility = ["//visibility:public"],
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    tool = "param_extractor_bin",
+    visibility = ["//visibility:public"],
 )

--- a/src/workerd/tools/api-encoder.c++
+++ b/src/workerd/tools/api-encoder.c++
@@ -116,14 +116,53 @@ struct ApiEncoderMain {
     return kj::mv(reader);
   }
 
+  void compileAllCompatibilityFlags(CompatibilityFlags::Builder output) {
+
+  auto schema = capnp::Schema::from<CompatibilityFlags>();
+  auto dynamicOutput = capnp::toDynamic(output);
+
+  for (auto field: schema.getFields()) {
+    bool isNode = false;
+
+    kj::StringPtr enableFlagName;
+
+    for (auto annotation: field.getProto().getAnnotations()) {
+      if (annotation.getId() == COMPAT_ENABLE_FLAG_ANNOTATION_ID) {
+        enableFlagName = annotation.getValue().getText();
+        // Exclude nodejs_compat, since the type generation scripts don't support node:* imports
+        // TODO: Figure out typing for node compat
+        if(enableFlagName == "nodejs_compat") {
+          isNode = true;
+        }
+      }
+    }
+
+    dynamicOutput.set(field, !isNode);
+  }
+}
+
+  CompatibilityFlags::Reader
+  compileAllFlags(capnp::MessageBuilder &message) {
+
+    auto output = message.initRoot<CompatibilityFlags>();
+
+    compileAllCompatibilityFlags(output);
+
+    auto reader = output.asReader();
+    return kj::mv(reader);
+  }
+
   bool run() {
-    // Create RTTI builder with all non-experimental compatibility flags enabled
+    // Create RTTI builder with either:
+    //  * All (non-experimental) compatibility flags as of a specific compatibility date (if one is specified)
+    //  * All (including experimental, but excluding nodejs_compat) compatibility flags (if no compatibility date is provided)
+
     capnp::MallocMessageBuilder flagsMessage;
     CompatibilityFlags::Reader flags;
     KJ_IF_MAYBE (date, compatibilityDate) {
       flags = compileFlags(flagsMessage, *date, false, {});
     } else {
-      flags = compileFlags(flagsMessage, "2021-01-01", false, {});
+      flags = compileAllFlags(flagsMessage);
     }
     auto builder = rtti::Builder(flags);
 


### PR DESCRIPTION
Add _all_ compatibility flags (except nodejs) to the `experimental` types entrypoint