### PR TITLE
jsg::Lock cleanup

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -387,7 +387,7 @@ void AbortSignal::throwIfAborted(jsg::Lock& js) {
 jsg::Ref<AbortSignal> AbortSignal::timeout(jsg::Lock& js, double delay) {
   auto signal = jsg::alloc<AbortSignal>();
 
-  auto context = js.v8Isolate->GetCurrentContext();
+  auto context = js.v8Context();
 
   auto& global = jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(
       context, context->Global());
@@ -477,7 +477,7 @@ kj::Promise<void> Scheduler::wait(
   //   the abort signal to support wrapping jsg promises.
   auto paf = kj::newPromiseAndFulfiller<void>();
 
-  auto context = js.v8Isolate->GetCurrentContext();
+  auto context = js.v8Context();
 
   auto& global = jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(
       context, context->Global());

--- a/src/workerd/api/crypto.c++
+++ b/src/workerd/api/crypto.c++
@@ -479,7 +479,7 @@ jsg::Promise<kj::Array<kj::byte>> SubtleCrypto::wrapKey(jsg::Lock& js,
       }
       KJ_CASE_ONEOF(jwk, JsonWebKey) {
         auto jwkValue = jwkHandler.wrap(js, kj::mv(jwk));
-        auto stringified = jsg::check(v8::JSON::Stringify(isolate->GetCurrentContext(), jwkValue));
+        auto stringified = jsg::check(v8::JSON::Stringify(js.v8Context(), jwkValue));
         kj::Vector<kj::byte> converted;
 
         auto serializedLength = stringified->Utf8Length(isolate);
@@ -530,7 +530,7 @@ jsg::Promise<jsg::Ref<CryptoKey>> SubtleCrypto::unwrapKey(jsg::Lock& js, kj::Str
     if (format == "jwk") {
       auto jsonJwk = jsg::v8Str(isolate, bytes.asChars());
 
-      auto jwkDict = jsg::check(v8::JSON::Parse(isolate->GetCurrentContext(), jsonJwk));
+      auto jwkDict = jsg::check(v8::JSON::Parse(js.v8Context(), jsonJwk));
 
       importData = JSG_REQUIRE_NONNULL(jwkHandler.tryUnwrap(js, jwkDict), DOMDataError,
           "Missing \"kty\" field or corrupt JSON unwrapping key?");

--- a/src/workerd/api/form-data.c++
+++ b/src/workerd/api/form-data.c++
@@ -423,7 +423,7 @@ void FormData::forEach(
   // from JavaScript, which means a Headers JS wrapper object must already exist.
   auto localParams = KJ_ASSERT_NONNULL(JSG_THIS.tryGetHandle(isolate));
 
-  auto context = isolate->GetCurrentContext();  // Needed later for Call().
+  auto context = js.v8Context();  // Needed later for Call().
 
   // On each iteration of the for loop, a JavaScript callback is invokved. If a new
   // item is appended to the URLSearchParams within that function, the loop must pick

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -617,7 +617,7 @@ TimeoutId::NumberType ServiceWorkerGlobalScope::setTimeout(
       [function = function.addRef(js),
        argv = kj::mv(argv)]
        (jsg::Lock& js) mutable {
-    auto context = js.v8Isolate->GetCurrentContext();
+    auto context = js.v8Context();
     auto localFunction = function.getHandle(js);
     auto localArgs = KJ_MAP(arg, argv) {
       return arg.getHandle(js);
@@ -651,7 +651,7 @@ TimeoutId::NumberType ServiceWorkerGlobalScope::setInterval(
       [function = function.addRef(js),
        argv = kj::mv(argv)]
        (jsg::Lock& js) mutable {
-    auto context = js.v8Isolate->GetCurrentContext();
+    auto context = js.v8Context();
     auto localFunction = function.getHandle(js);
     auto localArgs = KJ_MAP(arg, argv) {
       return arg.getHandle(js);

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -409,7 +409,7 @@ void Headers::forEach(
   // from JavaScript, which means a Headers JS wrapper object must already exist.
   auto localHeaders = KJ_ASSERT_NONNULL(JSG_THIS.tryGetHandle(isolate));
 
-  auto context = isolate->GetCurrentContext();  // Needed later for Call().
+  auto context = js.v8Context();  // Needed later for Call().
   for (auto& entry: getDisplayedHeaders(featureFlags)) {
     static constexpr auto ARG_COUNT = 3;
     v8::Local<v8::Value> args[ARG_COUNT] = {

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -39,7 +39,7 @@ static void parseListMetadata(jsg::Lock& js, v8::Local<v8::Value> listResponse) 
   v8::HandleScope handleScope(isolate);
   KJ_ASSERT(listResponse->IsObject());
   v8::Local<v8::Object> obj = listResponse.As<v8::Object>();
-  auto context = isolate->GetCurrentContext();
+  auto context = js.v8Context();
   auto keyName = jsg::v8Str(isolate, "keys"_kj);
   auto keys = jsg::check(obj->Get(context, keyName));
   if (keys->IsArray()) {

--- a/src/workerd/api/node/async-hooks.c++
+++ b/src/workerd/api/node/async-hooks.c++
@@ -20,7 +20,7 @@ v8::Local<v8::Value> AsyncLocalStorage::run(
     argv.add(arg.getHandle(js));
   }
 
-  auto context = js.v8Isolate->GetCurrentContext();
+  auto context = js.v8Context();
 
   jsg::AsyncContextFrame::StorageScope scope(js, *key, js.v8Ref(store));
 
@@ -121,7 +121,7 @@ v8::Local<v8::Function> AsyncResource::bind(
   // Per Node.js documentation (https://nodejs.org/dist/latest-v19.x/docs/api/async_context.html#asyncresourcebindfn-thisarg), the returned function "will have an
   // asyncResource property referencing the AsyncResource to which the function
   // is bound".
-  jsg::check(bound->Set(js.v8Isolate->GetCurrentContext(),
+  jsg::check(bound->Set(js.v8Context(),
              jsg::v8StrIntern(js.v8Isolate, "asyncResource"_kj),
              handler.wrap(js, JSG_THIS)));
   return bound;
@@ -137,7 +137,7 @@ v8::Local<v8::Value> AsyncResource::runInAsyncScope(
     argv.add(arg.getHandle(js));
   }
 
-  auto context = js.v8Isolate->GetCurrentContext();
+  auto context = js.v8Context();
 
   jsg::AsyncContextFrame::Scope scope(js, getFrame());
 

--- a/src/workerd/api/r2-admin.c++
+++ b/src/workerd/api/r2-admin.c++
@@ -80,7 +80,7 @@ jsg::Promise<R2Admin::ListResult> R2Admin::list(jsg::Lock& js,
     r2Result.throwIfError("listBucket", errorType);
 
     auto isolate = js.v8Isolate;
-    auto context = isolate->GetCurrentContext();
+    auto context = js.v8Context();
 
     capnp::MallocMessageBuilder responseMessage;
     capnp::JsonCodec json;

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -25,7 +25,7 @@ static bool isWholeNumber(double x) {
 // concerns about the user overriding the methods we're invoking.
 static kj::Date parseDate(jsg::Lock& js, kj::StringPtr value) {
   auto isolate = js.v8Isolate;
-  const auto context = isolate->GetCurrentContext();
+  const auto context = js.v8Context();
   const auto tmp = jsg::check(v8::Date::New(context, 0));
   KJ_REQUIRE(tmp->IsDate());
   const auto constructor = jsg::check(tmp.template As<v8::Date>()->Get(
@@ -43,7 +43,7 @@ static jsg::ByteString toUTCString(jsg::Lock& js, kj::Date date) {
   // NOTE: If you need toISOString just unify it into this function as the only difference will be
   // the function name called.
   auto isolate = js.v8Isolate;
-  const auto context = isolate->GetCurrentContext();
+  const auto context = js.v8Context();
   const auto converted = jsg::check(v8::Date::New(
       context, (date - kj::UNIX_EPOCH) / kj::MILLISECONDS));
   KJ_REQUIRE(converted->IsDate());

--- a/src/workerd/api/streams/encoding.c++
+++ b/src/workerd/api/streams/encoding.c++
@@ -24,7 +24,7 @@ jsg::Ref<TextEncoderStream> TextEncoderStream::constructor(
     Transformer {
       .transform = jsg::Function<Transformer::TransformAlgorithm>(
           [](jsg::Lock& js, auto chunk, auto controller) {
-      auto str = jsg::check(chunk->ToString(js.v8Isolate->GetCurrentContext()));
+      auto str = jsg::check(chunk->ToString(js.v8Context()));
       auto maybeBuffer = v8::ArrayBuffer::MaybeNew(js.v8Isolate, str->Utf8Length(js.v8Isolate));
       JSG_ASSERT(!maybeBuffer.IsEmpty(), RangeError,
                   "Cannot allocate space for TextEncoder.encode");

--- a/src/workerd/api/urlpattern.c++
+++ b/src/workerd/api/urlpattern.c++
@@ -388,7 +388,7 @@ Part::Modifier maybeTokenToModifier(kj::Maybe<Token&> modifierToken) {
 // TODO (later): Investigate whether there is a more efficient way to handle this.
 bool protocolComponentMatchesSpecialScheme(jsg::Lock& js, URLPatternComponent& component) {
   auto handle = component.regex.getHandle(js);
-  auto context = js.v8Isolate->GetCurrentContext();
+  auto context = js.v8Context();
 
   const auto checkIt = [&handle, &js, &context](const char* name) {
     return !jsg::check(handle->Exec(context, jsg::v8Str(js.v8Isolate, name)))->IsNullOrUndefined();
@@ -1125,7 +1125,7 @@ RegexAndNameList generateRegularExpressionAndNameList(
   // regular expression syntax is invalid as opposed to the default SyntaxError
   // that V8 throws.
   return js.tryCatch([&]() {
-    auto context = js.v8Isolate->GetCurrentContext();
+    auto context = js.v8Context();
     return RegexAndNameList {
       js.v8Ref(jsg::check(v8::RegExp::New(context,
                         v8Str(js.v8Isolate, result.finish()),
@@ -1835,7 +1835,7 @@ kj::Maybe<URLPattern::URLPatternComponentResult> execRegex(
     jsg::UsvStringPtr input) {
   using Groups = jsg::Dict<jsg::UsvString, jsg::UsvString>;
 
-  auto context = js.v8Isolate->GetCurrentContext();
+  auto context = js.v8Context();
 
   auto execResult =
       jsg::check(component.regex.getHandle(js)->Exec(

--- a/src/workerd/api/util.c++
+++ b/src/workerd/api/util.c++
@@ -342,7 +342,7 @@ void maybeWrapBotManagement(v8::Isolate* isolate, v8::Local<v8::Object> handle) 
         }
         if (args[0]->IsObject()) {
           return jsg::check(args[0].As<v8::Object>()->Get(
-              js.v8Isolate->GetCurrentContext(), args[1]));
+              js.v8Context(), args[1]));
         } else {
           return js.v8Undefined();
         }

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -919,9 +919,8 @@ kj::Own<CacheClient> IoContext::getCacheClient() {
 
 jsg::AsyncContextFrame::StorageScope IoContext::makeAsyncTraceScope(Worker::Lock& lock) {
   jsg::Lock& js = lock;
-  auto context = js.v8Isolate->GetCurrentContext();
   auto ioOwnSpanParent = IoContext::current().addObject(kj::heap(getMetrics().getSpan()));
-  auto spanHandle = jsg::wrapOpaque(context, kj::mv(ioOwnSpanParent));
+  auto spanHandle = jsg::wrapOpaque(js.v8Context(), kj::mv(ioOwnSpanParent));
   return jsg::AsyncContextFrame::StorageScope(
       js, lock.getTraceAsyncContextKey(), js.v8Ref(spanHandle));
 }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1006,8 +1006,7 @@ Worker::Isolate::Isolate(kj::Own<ApiIsolate> apiIsolateParam,
         // on the stack? Once logMessage is updated to take a jsg::Lock reference we
         // can remove the v8::HandleScope here.
         v8::HandleScope scope(js.v8Isolate);
-        logMessage(js.v8Isolate->GetCurrentContext(),
-                    static_cast<uint16_t>(cdp::LogType::WARNING), message);
+        logMessage(js.v8Context(), static_cast<uint16_t>(cdp::LogType::WARNING), message);
       }
       KJ_LOG(INFO, "console warning", message);
     });
@@ -1355,7 +1354,7 @@ Worker::Worker(kj::Own<const Script> scriptParam,
       KJ_SWITCH_ONEOF(script->impl->unboundScriptOrMainModule) {
         KJ_CASE_ONEOF(unboundScript, jsg::NonModuleScript) {
           auto limitScope = script->isolate->getLimitEnforcer().enterStartupJs(lock, maybeLimitError);
-          unboundScript.run(lock.v8Isolate->GetCurrentContext());
+          unboundScript.run(lock.v8Context());
         }
         KJ_CASE_ONEOF(mainModule, kj::Path) {
           // const_cast OK because we hold the lock.
@@ -1478,7 +1477,7 @@ void Worker::handleLog(jsg::Lock& js, LogLevel level, const v8::FunctionCallback
       //
       // Otherwise we stringify the argument.
       v8::HandleScope handleScope(js.v8Isolate);
-      auto context = js.v8Isolate->GetCurrentContext();
+      auto context = js.v8Context();
       bool shouldSerialiseToJson = false;
       if (arg->IsNull() || arg->IsNumber() || arg->IsArray() || arg->IsBoolean() || arg->IsString() ||
           arg->IsUndefined()) { // This is special cased for backwards compatibility.

--- a/src/workerd/jsg/async-context.c++
+++ b/src/workerd/jsg/async-context.c++
@@ -70,14 +70,11 @@ v8::Local<v8::Function> AsyncContextFrame::wrap(
 }
 
 v8::Local<v8::Function> AsyncContextFrame::wrapSnapshot(Lock& js) {
-  auto isolate = js.v8Isolate;
-  auto context = isolate->GetCurrentContext();
-
-  return js.wrapReturningFunction(context, JSG_VISITABLE_LAMBDA(
+  return js.wrapReturningFunction(js.v8Context(), JSG_VISITABLE_LAMBDA(
     (frame = AsyncContextFrame::currentRef(js)),
     (frame),
     (Lock& js, const v8::FunctionCallbackInfo<v8::Value>& args) {
-      auto context = js.v8Isolate->GetCurrentContext();
+      auto context = js.v8Context();
       JSG_REQUIRE(args[0]->IsFunction(), TypeError, "The first argument must be a function");
       auto fn = args[0].As<v8::Function>();
       kj::Vector<v8::Local<v8::Value>> argv(args.Length() - 1);
@@ -95,8 +92,7 @@ v8::Local<v8::Function> AsyncContextFrame::wrap(
     Lock& js,
     v8::Local<v8::Function> fn,
     kj::Maybe<v8::Local<v8::Value>> thisArg) {
-  auto isolate = js.v8Isolate;
-  auto context = isolate->GetCurrentContext();
+  auto context = js.v8Context();
 
   return js.wrapReturningFunction(context, JSG_VISITABLE_LAMBDA(
       (
@@ -107,7 +103,7 @@ v8::Local<v8::Function> AsyncContextFrame::wrap(
       (frame, thisArg, fn),
       (Lock& js, const v8::FunctionCallbackInfo<v8::Value>& args) {
     auto function = fn.getHandle(js);
-    auto context = js.v8Isolate->GetCurrentContext();
+    auto context = js.v8Context();
 
     kj::Vector<v8::Local<v8::Value>> argv(args.Length());
     for (int n = 0; n < args.Length(); n++) {
@@ -123,8 +119,7 @@ v8::Local<v8::Function> AsyncContextFrame::wrapRoot(
     Lock& js,
     v8::Local<v8::Function> fn,
     kj::Maybe<v8::Local<v8::Value>> thisArg) {
-  auto isolate = js.v8Isolate;
-  auto context = isolate->GetCurrentContext();
+  auto context = js.v8Context();
 
   return js.wrapReturningFunction(context, JSG_VISITABLE_LAMBDA(
       (
@@ -134,7 +129,7 @@ v8::Local<v8::Function> AsyncContextFrame::wrapRoot(
       (thisArg, fn),
       (Lock& js, const v8::FunctionCallbackInfo<v8::Value>& args) {
     auto function = fn.getHandle(js);
-    auto context = js.v8Isolate->GetCurrentContext();
+    auto context = js.v8Context();
 
     kj::Vector<v8::Local<v8::Value>> argv(args.Length());
     for (int n = 0; n < args.Length(); n++) {

--- a/src/workerd/jsg/dom-exception.c++
+++ b/src/workerd/jsg/dom-exception.c++
@@ -42,8 +42,7 @@ int DOMException::getCode() {
 
 v8::Local<v8::Value> DOMException::getStack(Lock& js) {
   return check(errorForStack.getHandle(js)->Get(
-      js.v8Isolate->GetCurrentContext(),
-      v8StrIntern(js.v8Isolate, "stack")));
+      js.v8Context(), v8StrIntern(js.v8Isolate, "stack")));
 }
 
 void DOMException::visitForGc(GcVisitor& visitor) {

--- a/src/workerd/jsg/function.h
+++ b/src/workerd/jsg/function.h
@@ -342,7 +342,7 @@ public:
       auto& typeWrapper = TypeWrapper::from(isolate);
 
       v8::HandleScope scope(isolate);
-      auto context = isolate->GetCurrentContext();
+      auto context = js.v8Context();
       v8::Local<v8::Value> argv[sizeof...(Args)] {
         typeWrapper.wrap(context, nullptr, kj::fwd<Args>(args))...
       };
@@ -378,7 +378,7 @@ public:
       auto& typeWrapper = TypeWrapper::from(isolate);
 
       v8::HandleScope scope(isolate);
-      auto context = isolate->GetCurrentContext();
+      auto context = js.v8Context();
       v8::Local<v8::Value> argv[sizeof...(Args)] {
         typeWrapper.wrap(context, nullptr, kj::fwd<Args>(args))...
       };

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1839,6 +1839,8 @@ public:
   // The underlying V8 isolate, useful for directly calling V8 APIs. Hopefully, this is rarely
   // needed outside JSG itself.
 
+  v8::Local<v8::Context> v8Context() { return v8Isolate->GetCurrentContext(); }
+
   static Lock& from(v8::Isolate* v8Isolate) {
     // Get the current Lock for the given V8 isolate. Segfaults if the isolate is not locked.
     //
@@ -2112,7 +2114,7 @@ v8::Local<v8::Value> deepClone(v8::Local<v8::Context> context, v8::Local<v8::Val
 
 template <typename T>
 V8Ref<T> V8Ref<T>::deepClone(jsg::Lock& js) {
-  return js.v8Ref(jsg::deepClone(js.v8Isolate->GetCurrentContext(), getHandle(js))
+  return js.v8Ref(jsg::deepClone(js.v8Context(), getHandle(js))
       .template As<T>());
 }
 

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -277,7 +277,7 @@ NonModuleScript NonModuleScript::compile(kj::StringPtr code, jsg::Lock& js, kj::
 void instantiateModule(jsg::Lock& js, v8::Local<v8::Module>& module) {
   KJ_ASSERT(!module.IsEmpty());
   auto isolate = js.v8Isolate;
-  auto context = isolate->GetCurrentContext();
+  auto context = js.v8Context();
 
   jsg::check(module->InstantiateModule(context, &resolveCallback));
   auto prom = jsg::check(module->Evaluate(context)).As<v8::Promise>();

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -123,7 +123,7 @@ public:
 
   static inline ModuleRegistry* from(jsg::Lock& js) {
     return static_cast<ModuleRegistry*>(
-        js.v8Isolate->GetCurrentContext()->GetAlignedPointerFromEmbedderData(2));
+        js.v8Context()->GetAlignedPointerFromEmbedderData(2));
   }
 
   struct CapnpModuleInfo {
@@ -157,7 +157,7 @@ public:
         kj::StringPtr content) {
       v8::ScriptOrigin origin(lock.v8Isolate, v8StrIntern(lock.v8Isolate, name));
       v8::ScriptCompiler::Source source(v8Str(lock.v8Isolate, content), origin);
-      auto context = lock.v8Isolate->GetCurrentContext();
+      auto context = lock.v8Context();
       auto handle = lock.wrap(context, moduleContext.addRef());
       auto fn = jsg::check(v8::ScriptCompiler::CompileFunction(
           context,
@@ -304,7 +304,7 @@ public:
   void addBuiltinModule(kj::StringPtr specifier, Type type = Type::BUILTIN) {
     addBuiltinModule(specifier, [specifier=kj::str(specifier)](Lock& js) {
       auto& wrapper = TypeWrapper::from(js.v8Isolate);
-      auto wrap = wrapper.wrap(js.v8Isolate->GetCurrentContext(), nullptr, alloc<T>());
+      auto wrap = wrapper.wrap(js.v8Context(), nullptr, alloc<T>());
       return ModuleInfo(js, specifier, nullptr, ObjectModuleInfo(js, wrap));
     }, type);
   }
@@ -523,7 +523,7 @@ v8::MaybeLocal<v8::Promise> dynamicImportCallback(v8::Local<v8::Context> context
 template <typename TypeWrapper>
 void setModulesForResolveCallback(jsg::Lock& js, ModuleRegistry* table) {
   KJ_ASSERT(table != nullptr);
-  js.v8Isolate->GetCurrentContext()->SetAlignedPointerInEmbedderData(2, table);
+  js.v8Context()->SetAlignedPointerInEmbedderData(2, table);
   js.v8Isolate->SetHostImportModuleDynamicallyCallback(dynamicImportCallback<TypeWrapper>);
 }
 

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -557,13 +557,13 @@ class TypeWrapper<Self, Types...>::TypeHandlerImpl final: public TypeHandler<T> 
 public:
   v8::Local<v8::Value> wrap(Lock& js, T value) const override {
     auto isolate = js.v8Isolate;
-    auto context = isolate->GetCurrentContext();
+    auto context = js.v8Context();
     return TypeWrapper::from(isolate).wrap(context, nullptr, kj::mv(value));
   }
 
   kj::Maybe<T> tryUnwrap(Lock& js, v8::Local<v8::Value> handle) const override {
     auto isolate = js.v8Isolate;
-    auto context = isolate->GetCurrentContext();
+    auto context = js.v8Context();
     return TypeWrapper::from(isolate).tryUnwrap(context, handle, (T*)nullptr, nullptr);
   }
 };

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -129,7 +129,7 @@ struct WorkerdApiIsolate::Impl {
   static v8::Local<v8::Value> compileJsonGlobal(JsgWorkerdIsolate::Lock& lock,
       capnp::Text::Reader reader) {
     return jsg::check(v8::JSON::Parse(
-        lock.v8Isolate->GetCurrentContext(),
+        lock.v8Context(),
         lock.wrapNoContext(reader)));
   };
 
@@ -155,7 +155,7 @@ jsg::JsContext<api::ServiceWorkerGlobalScope>
 jsg::Dict<NamedExport> WorkerdApiIsolate::unwrapExports(
     jsg::Lock& lock, v8::Local<v8::Value> moduleNamespace) const {
   return kj::downcast<JsgWorkerdIsolate::Lock>(lock)
-      .unwrap<jsg::Dict<NamedExport>>(lock.v8Isolate->GetCurrentContext(), moduleNamespace);
+      .unwrap<jsg::Dict<NamedExport>>(lock.v8Context(), moduleNamespace);
 }
 const jsg::TypeHandler<Worker::ApiIsolate::ErrorInterface>&
     WorkerdApiIsolate::getErrorInterfaceTypeHandler(jsg::Lock& lock) const {
@@ -480,7 +480,7 @@ static v8::Local<v8::Value> createBindingValue(
     const WorkerdApiIsolate::Global& global,
     CompatibilityFlags::Reader featureFlags) {
   using Global = WorkerdApiIsolate::Global;
-  auto context = lock.v8Isolate->GetCurrentContext();
+  auto context = lock.v8Context();
 
   v8::Local<v8::Value> value;
 
@@ -602,7 +602,7 @@ void WorkerdApiIsolate::compileGlobals(
     uint32_t ownerId) const {
   auto& lock = kj::downcast<JsgWorkerdIsolate::Lock>(lockParam);
   v8::HandleScope scope(lock.v8Isolate);
-  auto context = lock.v8Isolate->GetCurrentContext();
+  auto context = lock.v8Context();
   auto& featureFlags = *impl->features;
 
   for (auto& global: globals) {


### PR DESCRIPTION
Addresses a couple cleanup items on PR #547:

- Renames a few cases of `jsgLock` variables to `js` to match convention.
- Adds a `jsg::Lock::v8Context()` convenience function and updates code to use it.