### PR TITLE
fix use-after-move

### DIFF
--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -178,16 +178,16 @@ Name Lock::newApiSymbol(kj::StringPtr symbol) {
 }
 
 Name::Name(kj::String string)
-    : inner(kj::mv(string)),
-      hash(kj::hashCode(string)) {}
+    : hash(kj::hashCode(string)),
+      inner(kj::mv(string)) {}
 
 Name::Name(kj::StringPtr string)
-    : inner(kj::str(string)),
-      hash(kj::hashCode(string)) {}
+    : hash(kj::hashCode(string)),
+      inner(kj::str(string)) {}
 
 Name::Name(Lock& js, v8::Local<v8::Symbol> symbol)
-    : inner(js.v8Ref(symbol)),
-      hash(symbol->GetIdentityHash()) {}
+    : hash(symbol->GetIdentityHash()),
+      inner(js.v8Ref(symbol)) {}
 
 kj::OneOf<kj::StringPtr, v8::Local<v8::Symbol>> Name::getUnwrapped(v8::Isolate* isolate) {
   KJ_SWITCH_ONEOF(inner) {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1277,8 +1277,8 @@ public:
   inline int hashCode() const { return hash; }
 
 private:
-  kj::OneOf<kj::String, V8Ref<v8::Symbol>> inner;
   int hash;
+  kj::OneOf<kj::String, V8Ref<v8::Symbol>> inner;
 
   kj::OneOf<kj::StringPtr, v8::Local<v8::Symbol>> getUnwrapped(v8::Isolate* isolate);
 


### PR DESCRIPTION
as it is written now hash will always be computed of an empty string.