### PR TITLE
initialize Promise::markedAsHandled

### DIFF
--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -442,7 +442,7 @@ private:
   // the isolate pointer every time.
 
   kj::Maybe<V8Ref<v8::Promise>> v8Promise;
-  bool markedAsHandled;
+  bool markedAsHandled = false;
 
   v8::Local<v8::Promise> getInner(Lock& js) {
     return KJ_REQUIRE_NONNULL(v8Promise, "jsg::Promise can only be used once")


### PR DESCRIPTION
unless there's something subtle going on, this field is not initialized.