### PR TITLE
Moves global TCP socket `connect` to `cloudflare:sockets` module.

### DIFF
--- a/src/cloudflare/internal/sockets.d.ts
+++ b/src/cloudflare/internal/sockets.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for c++ implementation.
+
+export class Socket {
+  public readonly readable: any
+  public readonly writable: any
+  public readonly closed: Promise<void>
+  public close(): Promise<void>
+  public startTls(options: TlsOptions): Socket
+}
+
+export type TlsOptions = {
+  expectedServerHostname?: string
+}
+
+export type SocketAddress = {
+  hostname: string
+  port: number
+}
+
+export type SocketOptions = {
+  useSecureTransport: boolean
+  allowHalfOpen: boolean
+}
+
+export function connect(address: string | SocketAddress, options?: SocketOptions): Socket;

--- a/src/cloudflare/sockets.ts
+++ b/src/cloudflare/sockets.ts
@@ -1,0 +1,7 @@
+// TODO: c++ built-ins do not yet support named exports
+import sockets from 'cloudflare-internal:sockets';
+export function connect(
+  address: string | sockets.SocketAddress, options: sockets.SocketOptions
+): sockets.Socket {
+  return sockets.connect(address, options);
+}

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -671,10 +671,4 @@ jsg::Promise<jsg::Ref<Response>> ServiceWorkerGlobalScope::fetch(
   return fetchImpl(js, nullptr, kj::mv(requestOrUrl), kj::mv(requestInit), featureFlags);
 }
 
-jsg::Ref<Socket> ServiceWorkerGlobalScope::connect(
-    jsg::Lock& js, AnySocketAddress address, jsg::Optional<SocketOptions> options,
-    CompatibilityFlags::Reader featureFlags) {
-  return connectImpl(js, nullptr, kj::mv(address), kj::mv(options), featureFlags);
-}
-
 }  // namespace workerd::api

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -315,10 +315,6 @@ public:
       jsg::Optional<Request::Initializer> requestInitr,
       CompatibilityFlags::Reader featureFlags);
 
-  jsg::Ref<Socket> connect(
-      jsg::Lock& js, AnySocketAddress address, jsg::Optional<SocketOptions> options,
-      CompatibilityFlags::Reader featureFlags);
-
   jsg::Ref<ServiceWorkerGlobalScope> getSelf() {
     return JSG_THIS;
   }
@@ -460,9 +456,6 @@ public:
     JSG_NESTED_TYPE(FixedLengthStream);
     JSG_NESTED_TYPE(IdentityTransformStream);
     JSG_NESTED_TYPE(HTMLRewriter);
-    if (flags.getTcpSocketsSupport()) {
-      JSG_METHOD(connect);
-    }
 
     JSG_TS_ROOT();
     JSG_TS_DEFINE(

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -349,6 +349,8 @@ kj::Own<jsg::ModuleRegistry> WorkerdApiIsolate::compileModules(
     api::node::registerNodeJsCompatModules(*modules, getFeatureFlags());
   }
 
+  api::registerSocketsModule(*modules, getFeatureFlags());
+
   jsg::setModulesForResolveCallback<JsgWorkerdIsolate_TypeWrapper>(lock, modules);
 
   // todo(perf): we'd like to find a way to precompile these on server startup and use isolate


### PR DESCRIPTION
Tested upstream. The `connect` method now needs to be imported via the `cloudflare:sockets` module.