### PR TITLE
Simplify Windows setup and build

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,17 +7,17 @@
     {
       "name": "workerd debug",
       "preLaunchTask": "Bazel Build (dbg)",
-      "program": "linux-or-os-only",
+      "program": "workerd",
       "request": "launch",
       "type": "cppdbg",
+      "cwd": "${workspaceFolder}",
       "linux": {
         "name": "workerd debug",
         "type": "cppdbg",
         "request": "launch",
         "MIMode": "gdb",
         "miDebuggerArgs": "-d ${workspaceFolder}",
-        "program": "workerd",
-        "cwd": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd.runfiles/workerd/src/workerd/server/",
+        "program": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd.runfiles/workerd/src/workerd/server/workerd",
       },
       "osx": {
         "name": "workerd debug",
@@ -31,29 +31,34 @@
           "bazel-out" : "${workspaceFolder}/bazel-out",
           "external" : "${workspaceFolder}/external"
          },
-         "cwd": "${workspaceFolder}",
+      },
+      "windows": {
+        "name": "workerd debug",
+        "type": "cppvsdbg",
+        "request": "launch",
+        "program": "${workspaceRoot}\\bazel-out\\x64_windows-dbg\\bin\\src\\workerd\\server\\workerd.exe",
       },
       "args": [
         "serve",
         "${input:workerdConfig}"
       ],
       "stopAtEntry": false,
-      "externalConsole": false
+      "externalConsole": false,
     },
     {
       "name": "workerd debug with inspector enabled",
       "preLaunchTask": "Bazel Build (dbg)",
-      "program": "linux-or-os-only",
+      "program": "workerd",
       "type": "cppdbg",
       "request": "launch",
+      "cwd": "${workspaceFolder}",
       "linux": {
         "name": "workerd debug with inspector enabled",
         "type": "cppdbg",
         "request": "launch",
         "MIMode": "gdb",
         "miDebuggerArgs": "-d ${workspaceFolder}",
-        "program": "workerd",
-        "cwd": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd.runfiles/workerd/src/workerd/server/",
+        "program": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd.runfiles/workerd/src/workerd/server/workerd",
       },
       "osx": {
         "name": "workerd debug with inspector enabled",
@@ -67,7 +72,12 @@
           "bazel-out" : "${workspaceFolder}/bazel-out",
           "external" : "${workspaceFolder}/external"
          },
-         "cwd": "${workspaceFolder}",
+      },
+      "windows": {
+        "name": "workerd debug",
+        "type": "cppvsdbg",
+        "request": "launch",
+        "program": "${workspaceRoot}\\bazel-out\\x64_windows-dbg\\bin\\src\\workerd\\server\\workerd.exe",
       },
       "args": [
         "serve",
@@ -75,7 +85,6 @@
         "--verbose",
         "${input:workerdConfig}"
       ],
-      "cwd": "${workspaceFolder}/bazel-out/k8-dbg/bin/src/workerd/server/workerd.runfiles/workerd",
       "stopAtEntry": false,
       "externalConsole": false
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,11 @@
     },
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
-    "editor.tabSize": 2
+    "editor.tabSize": 2,
+    "terminal.integrated.env.windows": {
+        "BAZEL_LLVM" : "C:\\Program Files\\LLVM",
+        "BAZEL_SH" : "C:\\msys64\\usr\\bin\\bash.exe",
+        "BAZEL_VC" : "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC",
+        "BAZEL_WINSDK_FULL_VERSION" : "10.0.22000.0",
+    },
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,9 +5,7 @@
       "label": "Bazel Build (dbg)",
       "type": "shell",
       "command": "bazel",
-      "linux": {
-        "args": ["build", "-c", "dbg", "//src/workerd/server:workerd"],
-      },
+      "args": ["build", "-c", "dbg", "//src/workerd/server:workerd"],
       "osx": {
         // OS X needs additional build options for symbols to work correctly
         // (https://github.com/bazelbuild/bazel/issues/6327), hence the additional
@@ -101,7 +99,7 @@
         "panel": "dedicated"
       },
       "runOptions": {
-        "runOn": "folderOpen"
+        "runOn": "default"
       }
     },
     {
@@ -118,7 +116,7 @@
         "panel": "dedicated"
       },
       "runOptions": {
-        "runOn": "folderOpen"
+        "runOn": "default"
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -81,14 +81,13 @@ To build `workerd`, you need:
 * On macOS:
   * full XCode 13+ installation
 * On Windows:
-  * Visual Studio Community 2022, including "Desktop development with C++" features
-  * [LLVM 15](https://github.com/llvm/llvm-project/releases/)
-  * [MSYS2](https://www.msys2.org/) installed to `C:\tools\msys64` with the `BAZEL_SH` environment variable set to `C:\tools\msys64\usr\bin\bash.exe`
-  * [Python 3](https://www.python.org/downloads/) with a `python3` executable on the `PATH`
-  * GNU `patch` executable on the `PATH` (e.g. `pacman -S patch` in MSYS2 terminal, then copy `patch.exe` and `msys-2.0.dll` from `C:\tools\msys64\usr\bin` to a directory on the `PATH`)
-  * Add `startup --output_user_root=C:/tmp` to the `.bazelrc` file in your user directory
-  * Enable 8.3 filename support with `fsutil 8dot3name set 0` in an administrator command prompt
-  * Enable [developer mode](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development) for symlink support
+  * Install [App Installer](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget)
+    from the Microsoft Store for the `winget` package manager and then run
+    [install-deps.bat](tools/windows/install-deps.bat) from an administrator prompt to install
+    bazel, LLVM, and other dependencies required to build workerd on Windows.
+  * Add `startup --output_user_root=C:/tmp` to the `.bazelrc` file in your user directory.
+  * When developing at the command-line, run [bazel-env.bat](tools/windows/bazel-env.bat) in your shell first
+    to select tools and Windows SDK versions before running bazel.
 
 You may then build using:
 

--- a/tools/windows/bazel-env.bat
+++ b/tools/windows/bazel-env.bat
@@ -1,0 +1,10 @@
+@echo off
+echo.* Environment configured for workerd builds with bazel
+echo.
+
+rem Set environment variables for bazel to use when invoked from
+rem the command-line.
+set "BAZEL_LLVM=C:\Program Files\LLVM"
+set BAZEL_SH=C:\msys64\usr\bin\bash.exe
+set "BAZEL_VC=C:\Program Files\Microsoft Visual Studio\2022\Community\VC"
+set BAZEL_WINSDK_FULL_VERSION=10.0.22000.0

--- a/tools/windows/install-deps.bat
+++ b/tools/windows/install-deps.bat
@@ -1,0 +1,74 @@
+@echo off
+setlocal enabledelayedexpansion
+
+rem Check this script is being run from an elevated cmd binary.
+net session > NUL 2>&1
+if %ERRORLEVEL% NEQ 0 (
+  echo This script requires administrator privileges.
+  exit /b 1
+)
+
+cls
+
+echo.Workerd dependency installation
+echo.-------------------------------
+echo.
+echo.This script will configure your Windows machine for building workerd with
+echo.bazel on Windows.
+echo.
+echo.Some of the steps will open windows for you to approve.
+echo.
+echo.* Step 1: Enable developer mode features.
+echo.
+rem This is based on https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging
+reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock /v AllowDevelopmentWithoutDevLicense /t REG_DWORD /d 1 /f
+
+echo.
+echo.* Step 2: Enable 8.3 name support on this machine.
+fsutil 8dot3name set 0
+
+rem Install Visual Studio Code Community edition with Desktop development with C++ package.
+rem ----------------------------------------------------------------------------------------
+rem
+rem The config in vsconfig.json is the config for "Desktop development with C++".
+rem
+rem The config is determined by first installing Visual Studio Community Edition on your
+rem devbox. Then run `c:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe` and click
+rem `More -> Export Configuration Settings`, select an config file to write, then `Review Details`
+rem and select "Desktop development with C++".
+echo.
+echo.* Step 3: Install Visual Studio Code Community edition with Desktop development with C++ package.
+winget install "Microsoft.VisualStudio.2022.Community" --override "install --config %~dp0\vsconfig.json"
+
+echo.
+echo.* Step 4: Install Python 3.
+winget install Python3 -v 3.11.3 --override "/passive PrependPath=1"
+@rem bazel requires a bazel3.exe binary, create a symlink for it.
+mklink "%LOCALAPPDATA%\Programs\Python\Python311\python3.exe" "%LOCALAPPDATA%\Programs\Python\Python311\python.exe"
+
+echo.
+echo.* Step 5: Install msys2.
+winget install msys2.msys2
+setx BAZEL_SH "C:\msys64\usr\bin\bash.exe"
+
+echo.
+echo.* Step 6 Install msys2 tools suggested for bazel, from https://bazel.build/install/windows.
+@rem Invoking pacman like this reports an error updating GNU info files, no idea how to fix.
+c:\msys64\usr\bin\bash -c "/usr/bin/pacman -S --noconfirm zip unzip patch diffutils"
+
+echo.
+echo.* Step 7: Install LLVM compiler toolchain.
+winget install "LLVM" --version 15.0.7
+
+echo.
+echo.* Step 8: Install bazelisk as %LOCALAPPDATA%\Programs\bazelisk\bazel.exe.
+winget install bazelisk -l %LOCALAPPDATA%\Programs\bazelisk -r "bazel.exe"
+rem Add bazelisk to users path. First we need to extract users path from the registry, then extend.
+for /F "usebackq tokens=3 skip=2" %%P IN (`reg query "HKEY_CURRENT_USER\Environment" /v PATH`) do set "USERPATH=%%P"
+setx PATH "%LOCALAPPDATA%\Programs\bazelisk;!USERPATH!"
+echo Added %LOCALAPPDATA%\Programs\bazelisk to default PATH.
+
+echo.
+echo.* Setup complete.
+set /p GO="Press enter to exit."
+exit 0

--- a/tools/windows/vsconfig.json
+++ b/tools/windows/vsconfig.json
@@ -1,0 +1,33 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Component.CoreEditor",
+    "Microsoft.VisualStudio.Workload.CoreEditor",
+    "Microsoft.VisualStudio.Component.TypeScript.TSServer",
+    "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions",
+    "Microsoft.VisualStudio.Component.JavaScript.TypeScript",
+    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+    "Microsoft.Component.MSBuild",
+    "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
+    "Microsoft.VisualStudio.Component.TextTemplating",
+    "Microsoft.VisualStudio.Component.NuGet",
+    "Microsoft.VisualStudio.Component.Debugger.JustInTime",
+    "Component.Microsoft.VisualStudio.LiveShare.2022",
+    "Microsoft.VisualStudio.Component.IntelliCode",
+    "Microsoft.VisualStudio.Component.VC.CoreIde",
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+    "Microsoft.VisualStudio.Component.Graphics.Tools",
+    "Microsoft.VisualStudio.Component.VC.DiagnosticTools",
+    "Microsoft.VisualStudio.Component.Windows11SDK.22000",
+    "Microsoft.VisualStudio.Component.VC.ATL",
+    "Microsoft.VisualStudio.Component.SecurityIssueAnalysis",
+    "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
+    "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
+    "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.CMake",
+    "Microsoft.VisualStudio.Component.VC.CMake.Project",
+    "Microsoft.VisualStudio.Component.VC.TestAdapterForBoostTest",
+    "Microsoft.VisualStudio.Component.VC.TestAdapterForGoogleTest",
+    "Microsoft.VisualStudio.Component.VC.ASAN",
+    "Microsoft.VisualStudio.Workload.NativeDesktop"
+  ]
+}


### PR DESCRIPTION
Assorted changes to try to make setup and build on Windows simpler.

* Adds an installer script for the workerd's dependencies on Windows (tools/windows/install-deps.bat).
* Adds a command-line environment script to set up environment variables for building on Windows (tools/bazel-env.bat).
* Adds vscode settings to simplify setup on Windows.
* Defines BAZEL_WINSDK_FULL_VERSION and BAZEL_VC explicitly to address issues when the Windows machine has multiple versions of Visual Studio and/or the Windows SDK installed.