### PR TITLE
StartTls will now fail if pipeTo is used on the socket's ReadableStream.

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -160,7 +160,9 @@ jsg::Promise<void> Socket::close(jsg::Lock& js) {
 jsg::Ref<Socket> Socket::startTls(jsg::Lock& js, jsg::Optional<TlsOptions> tlsOptions) {
   JSG_REQUIRE(!isSecureSocket, TypeError, "Cannot startTls on a TLS socket.");
   // TODO: Track closed state of socket properly and assert that it hasn't been closed here.
-  JSG_REQUIRE(domain != nullptr, TypeError, "startTLS can only be called once.");
+  JSG_REQUIRE(domain != nullptr, TypeError, "startTls can only be called once.");
+  JSG_REQUIRE(!readable->getPipeToCalled() && !writable->getPipeToCalled(), TypeError,
+      "Cannot call startTls after `pipeTo` was used.");
 
   // The current socket's writable buffers need to be flushed. The socket's WritableStream is backed
   // by an AsyncIoStream which doesn't implement any buffering, so we don't need to worry about

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -365,10 +365,13 @@ public:
   void initEofResolverPair(jsg::Lock& js);
   // By default the eofResolverPair is not initialised, calling this method will initialise it so
   // that the signalling is active.
+  bool getPipeToCalled() { return pipeToCalled; };
+  // Determines whether `pipeTo` was called on this ReadableStream.
 private:
   kj::Maybe<IoContext&> ioContext;
   Controller controller;
   kj::Maybe<jsg::Promise<void>> maybePipeThrough;
+  bool pipeToCalled;
 
   void visitForGc(jsg::GcVisitor& visitor) {
     visitor.visit(getController(), maybePipeThrough);

--- a/src/workerd/api/streams/writable.c++
+++ b/src/workerd/api/streams/writable.c++
@@ -192,13 +192,15 @@ WritableStream::WritableStream(
     kj::Maybe<uint64_t> maybeHighWaterMark)
     : ioContext(ioContext),
       controller(kj::heap<WritableStreamInternalController>(ioContext.addObject(kj::mv(sink)),
-                                                            maybeHighWaterMark)) {
+                                                            maybeHighWaterMark)),
+      pipeToCalled(false) {
   getController().setOwnerRef(*this);
 }
 
 WritableStream::WritableStream(Controller controller)
     : ioContext(tryGetIoContext()),
-      controller(kj::mv(controller)) {
+      controller(kj::mv(controller)),
+      pipeToCalled(false) {
   getController().setOwnerRef(*this);
 }
 

--- a/src/workerd/api/streams/writable.h
+++ b/src/workerd/api/streams/writable.h
@@ -152,9 +152,17 @@ public:
     });
   }
 
+  bool getPipeToCalled() { return pipeToCalled; };
+  // Determines whether this WritableStream had been the target of a pipeTo().
+
+  void setPipeToCalled() { pipeToCalled = true; };
+  // Sets a flag on the WritableStream. Used whenever this WritableStream has been the target
+  // of a pipeTo().
+
 private:
   kj::Maybe<IoContext&> ioContext;
   Controller controller;
+  bool pipeToCalled;
 
   void visitForGc(jsg::GcVisitor& visitor) {
     visitor.visit(getController());


### PR DESCRIPTION
Tested upstream.