### PR TITLE
Add Node.js Compat module type

### DIFF
--- a/samples/nodejs-compat-module/README.md
+++ b/samples/nodejs-compat-module/README.md
@@ -1,0 +1,28 @@
+# Node.js Compat Example
+
+To run the example on http://localhost:8080
+
+```sh
+$ ./workerd serve config.capnp
+```
+
+To run using bazel
+
+```sh
+$ bazel run //src/workerd/server:workerd -- serve ~/cloudflare/workerd/samples/nodejs-compat/config.capnp
+```
+
+To create a standalone binary that can be run:
+
+```sh
+$ ./workerd compile config.capnp > nodejs-compat
+
+$ ./nodejs-compat
+```
+
+To test:
+
+```sh
+% curl http://localhost:8080
+Hello World
+```

--- a/samples/nodejs-compat-module/bar.js
+++ b/samples/nodejs-compat-module/bar.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/samples/nodejs-compat-module/config.capnp
+++ b/samples/nodejs-compat-module/config.capnp
@@ -1,0 +1,37 @@
+# Imports the base schema for workerd configuration files.
+
+# Refer to the comments in /src/workerd/server/workerd.capnp for more details.
+
+using Workerd = import "/workerd/workerd.capnp";
+
+# A constant of type Workerd.Config defines the top-level configuration for an
+# instance of the workerd runtime. A single config file can contain multiple
+# Workerd.Config definitions and must have at least one.
+const helloWorldExample :Workerd.Config = (
+
+  # Every workerd instance consists of a set of named services. A worker, for instance,
+  # is a type of service. Other types of services can include external servers, the
+  # ability to talk to a network, or accessing a disk directory. Here we create a single
+  # worker service. The configuration details for the worker are defined below.
+  services = [ (name = "main", worker = .helloWorld) ],
+
+  # Every configuration defines the one or more sockets on which the server will listene.
+  # Here, we create a single socket that will listen on localhost port 8080, and will
+  # dispatch to the "main" service that we defined above.
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ]
+);
+
+# The definition of the actual helloWorld worker exposed using the "main" service.
+# In this example the worker is implemented as a single simple script (see worker.js).
+# The compatibilityDate is required. For more details on compatibility dates see:
+#   https://developers.cloudflare.com/workers/platform/compatibility-dates/
+
+const helloWorld :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js"),
+    (name = "foo", nodeJsCompatModule = embed "foo.js"),
+    (name = "bar", nodeJsCompatModule = embed "bar.js")
+  ],
+  compatibilityDate = "2023-02-28",
+  compatibilityFlags = ["nodejs_compat"]
+);

--- a/samples/nodejs-compat-module/foo.js
+++ b/samples/nodejs-compat-module/foo.js
@@ -1,0 +1,23 @@
+// process is a global in Node.js so comes as a global for nodeJsCompatModules.
+process.nextTick(() => {
+  console.log('this should work', __filename, __dirname, module.path);
+});
+
+module.exports = {
+  // Buffer is a global in Node.js so comes as a global for nodeJsCompatModules.
+  Buffer,
+  // require can be called synchronously inline.
+  util: require('util'),
+}
+
+try {
+  // Requiring Node.js built-ins that we do not implement will fail,
+  // even if there are similarly named modules in the worker bundle.
+  require('fs');
+} catch (err) {
+  console.log('attempt was made to load the fs module, which is not implemented');
+}
+
+// As long as the module being required is not a Node.js built-in, requiring
+// it from the worker bundle works just fine.
+const bar = require('bar');

--- a/samples/nodejs-compat-module/worker.js
+++ b/samples/nodejs-compat-module/worker.js
@@ -1,0 +1,13 @@
+import { default as foo } from 'foo';
+const {
+  Buffer,
+  util,
+} = foo;
+
+export default {
+  async fetch(request) {
+    console.log(Buffer);
+    console.log(util);
+    return new Response("ok");
+  }
+};

--- a/src/node/internal/process.ts
+++ b/src/node/internal/process.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
 // Our implementation of process.nextTick is just queueMicrotask. The timing
 // of when the queue is drained is different, as is the error handling so this
 // is only an approximation of process.nextTick semantics. Hopefully it's good

--- a/src/node/internal/streams_adapters.js
+++ b/src/node/internal/streams_adapters.js
@@ -1,3 +1,30 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
 import {
   Readable,
 } from 'node-internal:streams_readable';

--- a/src/node/process.ts
+++ b/src/node/process.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+
+export * from 'node-internal:process';
+export { default } from 'node-internal:process';

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -248,6 +248,12 @@ struct Worker {
 
       json @6 :Text;
       # Importing this will produce the result of parsing the given text as JSON.
+
+      nodeJsCompatModule @7 :Text;
+      # A Node.js module is a specialization of a commonJsModule that:
+      # (a) allows for importing Node.js-compat built-ins without the node: specifier-prefix
+      # (b) exposes the subset of common Node.js globals such as process, Buffer, etc that
+      #     we implement in the workerd runtime.
     }
   }
 


### PR DESCRIPTION
Just an initial proof-of-concept on the idea of a Node.js module type.

This type of module that can be included in the worker bundle allows for requiring node.js built-ins without the `node:` specifier-prefix and would expose the common Node.js globals

There is some complexity here that would still need to be worked through. This will remain a draft PR until we determine if this is the way we'd want to go.