### PR TITLE
Account for botManagement proxy in structuredClone

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -728,6 +728,10 @@ kj::Array<kj::byte> serializeV8Value(v8::Local<v8::Value> value, v8::Isolate* is
     .version = 15,
     .omitHeader = false,
   });
+  // TODO(soon): Remove this terrible, horrible, no-good, very bad hack when we remove
+  // the cf.botManagement logging. The issue here is that Proxy objects are not cloneable
+  // via structuredClone.
+  value = maybeUnwrapBotManagement(isolate, value);
   serializer.write(value);
   auto released = serializer.release();
   return kj::mv(released.data);

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -588,6 +588,12 @@ v8::Local<v8::Value> ServiceWorkerGlobalScope::structuredClone(
   // clone the object and access proxied fields we'd normally log but that seems to
   // be an edge case not worth handling here.
   NoRequestCfProxyLoggingScope noLoggingScope;
+
+  // TODO(soon): Remove this terrible, horrible, no-good, very bad hack when we remove
+  // the cf.botManagement logging. The issue here is that Proxy objects are not cloneable
+  // via structuredClone.
+  value = maybeUnwrapBotManagement(isolate, value);
+
   return jsg::structuredClone(value, isolate, transfers);
 }
 

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -2025,7 +2025,11 @@ jsg::Promise<QueueResponse> Fetcher::queue(
         .version = 15,
         .omitHeader = false,
     });
-    serializer.write(kj::mv(msg.body));
+    // TODO(soon): Remove this terrible, horrible, no-good, very bad hack when we remove
+    // the cf.botManagement logging. The issue here is that Proxy objects are not cloneable
+    // via structuredClone.
+    auto value = maybeUnwrapBotManagement(js.v8Isolate, msg.body.getHandle(js.v8Isolate));
+    serializer.write(value);
     encodedMessages.add(IncomingQueueMessage{
         .id=kj::mv(msg.id),
         .timestamp=msg.timestamp,

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -17,6 +17,10 @@ kj::Promise<void> WorkerQueue::send(
     .version = 15,
     .omitHeader = false,
   });
+  // TODO(soon): Remove this terrible, horrible, no-good, very bad hack when we remove
+  // the cf.botManagement logging. The issue here is that Proxy objects are not cloneable
+  // via structuredClone.
+  body = maybeUnwrapBotManagement(isolate, body);
   serializer.write(body);
   kj::Array<kj::byte> serialized = serializer.release().data;
 
@@ -68,7 +72,11 @@ kj::Promise<void> WorkerQueue::sendBatch(
       .version = 15,
       .omitHeader = false,
     });
-    serializer.write(kj::mv(message.body));
+    // TODO(soon): Remove this terrible, horrible, no-good, very bad hack when we remove
+    // the cf.botManagement logging. The issue here is that Proxy objects are not cloneable
+    // via structuredClone.
+    auto value = maybeUnwrapBotManagement(isolate, message.body.getHandle(isolate));
+    serializer.write(value);
     builder.add(serializer.release().data);
     totalSize += builder.back().size();
     largestMessage = kj::max(largestMessage, builder.back().size());

--- a/src/workerd/api/util.h
+++ b/src/workerd/api/util.h
@@ -148,4 +148,12 @@ kj::Maybe<jsg::V8Ref<v8::Object>> cloneRequestCf(
     jsg::Lock& js, kj::Maybe<jsg::V8Ref<v8::Object>> maybeCf);
 void maybeWrapBotManagement(v8::Isolate* isolate, v8::Local<v8::Object> handle);
 
+v8::Local<v8::Value> maybeUnwrapBotManagement(v8::Isolate* isolate, v8::Local<v8::Value> value);
+// This is a bit of a hack that fortunately we shouldn't need to live with forever. Specifically,
+// in order to facilitate logging of the request.cf.botManagement uses, we wrap it in a JS Proxy
+// object. Unfortunately, there are cases where we serialize request.cf using the structured
+// clone algorithm (v8::Serializer), which does not support proxies. So in those cases we need
+// to intercept the value and unwrap the proxy before we serialize. We should be able to drop
+// this as soon as we are no longer logging cf.botManagement accesses.
+
 }  // namespace workerd::api


### PR DESCRIPTION
This is ugly and horrible but hopefully temporary. While we are logging the cf.botManagement uses, since we are using a Proxy to catch accesses and Proxy is not supported via structuredClone, we end up having to intercept and handle the case where `request.cf` is passed off to structuredClone.

It's *possible* we might have to do this elsewhere if folks are passing request.cf off to other things that using the v8 serializer? I certainly hope not.