### PR TITLE
Socket's connect API now takes a secureTransport enum instead of bool.

### DIFF
--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -11,6 +11,12 @@
 
 namespace workerd::api {
 
+enum class SecureTransportKind {
+  OFF, // plain-text
+  STARTTLS, // plain-text at first, with `startTls` available to upgrade at a later time
+  ON // TLS enabled immediately
+};
+
 struct SocketAddress {
   kj::String hostname;
   uint16_t port;
@@ -18,9 +24,9 @@ struct SocketAddress {
 };
 
 struct SocketOptions {
-  bool useSecureTransport = false;
+  jsg::Optional<kj::String> secureTransport;
   bool allowHalfOpen = false;
-  JSG_STRUCT(useSecureTransport, allowHalfOpen);
+  JSG_STRUCT(secureTransport, allowHalfOpen);
 };
 
 struct TlsOptions {


### PR DESCRIPTION
Changes the `connect`'s options API to take a secureTransport enum instead of a bool:

```js
connect("address:port", { secureTransport: "off" })
connect("address:port", { secureTransport: "allow" })
connect("address:port", { secureTransport: "use" })
```

Context: https://github.com/cloudflare/workerd/pull/562#discussion_r1176646406