### PR TITLE
Rename `trace` handler to `tail`

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -23,6 +23,7 @@ bool isSpecialEventType(kj::StringPtr type) {
   //   leaving them out for now.
   return type == "fetch" ||
          type == "scheduled" ||
+         type == "tail" ||
          type == "trace" ||
          type == "alarm";
 }

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -14,14 +14,14 @@
 
 namespace workerd::api {
 
-TraceEvent::TraceEvent(kj::ArrayPtr<kj::Own<Trace>> traces)
-    : ExtendableEvent("trace"),
-      traces(KJ_MAP(t, traces) -> jsg::Ref<TraceItem> {
-        return jsg::alloc<TraceItem>(kj::addRef(*t));
+TailEvent::TailEvent(kj::StringPtr type, kj::ArrayPtr<kj::Own<Trace>> events)
+    : ExtendableEvent(kj::str(type)),
+      events(KJ_MAP(e, events) -> jsg::Ref<TraceItem> {
+        return jsg::alloc<TraceItem>(kj::addRef(*e));
       }) {}
 
-kj::Array<jsg::Ref<TraceItem>> TraceEvent::getTraces() {
-  return KJ_MAP(t, traces) -> jsg::Ref<TraceItem> { return t.addRef(); };
+kj::Array<jsg::Ref<TraceItem>> TailEvent::getEvents() {
+  return KJ_MAP(e, events) -> jsg::Ref<TraceItem> { return e.addRef(); };
 }
 
 TraceItem::TraceItem(kj::Own<Trace> trace) : trace(kj::mv(trace)) {}

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -19,28 +19,30 @@ class TraceItem;
 class TraceException;
 class TraceLog;
 
-class TraceEvent final: public ExtendableEvent {
+class TailEvent final: public ExtendableEvent {
 public:
-  explicit TraceEvent(kj::ArrayPtr<kj::Own<Trace>> traces);
+  explicit TailEvent(kj::StringPtr type, kj::ArrayPtr<kj::Own<Trace>> events);
 
-  static jsg::Ref<TraceEvent> constructor(kj::String type) = delete;
+  static jsg::Ref<TailEvent> constructor(kj::String type) = delete;
   // TODO(soon): constructor?
 
   // TODO(perf): more efficient to build/return cached array object?  Or iterator?
-  kj::Array<jsg::Ref<TraceItem>> getTraces();
+  kj::Array<jsg::Ref<TraceItem>> getEvents();
 
-  JSG_RESOURCE_TYPE(TraceEvent) {
+  JSG_RESOURCE_TYPE(TailEvent) {
     JSG_INHERIT(ExtendableEvent);
 
-    JSG_READONLY_INSTANCE_PROPERTY(traces, getTraces);
+    JSG_READONLY_INSTANCE_PROPERTY(events, getEvents);
+    // Deprecated. Please, use `events` instead.
+    JSG_READONLY_INSTANCE_PROPERTY(traces, getEvents);
   }
 
 private:
-  kj::Array<jsg::Ref<TraceItem>> traces;
+  kj::Array<jsg::Ref<TraceItem>> events;
 
   void visitForGc(jsg::GcVisitor& visitor) {
-    for (auto& t: traces) {
-      visitor.visit(t);
+    for (auto& e: events) {
+      visitor.visit(e);
     }
   }
 };
@@ -335,7 +337,7 @@ private:
 };
 
 #define EW_TRACE_ISOLATE_TYPES                \
-  api::TraceEvent,                            \
+  api::TailEvent,                             \
   api::TraceItem,                             \
   api::TraceItem::AlarmEventInfo,             \
   api::TraceItem::CustomEventInfo,            \


### PR DESCRIPTION
The existing `trace` handler is still available to maintain backwards compatibility.