### PR TITLE
workerd add tests that can be debugged within vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
   "configurations": [
     {
       "name": "workerd debug",
-      "preLaunchTask": "Bazel Build (dbg)",
+      "preLaunchTask": "Bazel build workerd (dbg)",
       "program": "workerd",
       "request": "launch",
       "type": "cppdbg",
@@ -47,7 +47,7 @@
     },
     {
       "name": "workerd debug with inspector enabled",
-      "preLaunchTask": "Bazel Build (dbg)",
+      "preLaunchTask": "Bazel build workerd (dbg)",
       "program": "workerd",
       "type": "cppdbg",
       "request": "launch",
@@ -74,7 +74,7 @@
          },
       },
       "windows": {
-        "name": "workerd debug",
+        "name": "workerd debug with inspector enabled",
         "type": "cppvsdbg",
         "request": "launch",
         "program": "${workspaceRoot}\\bazel-out\\x64_windows-dbg\\bin\\src\\workerd\\server\\workerd.exe",
@@ -87,6 +87,43 @@
       ],
       "stopAtEntry": false,
       "externalConsole": false
+    },
+    {
+      "name": "workerd test case",
+      "preLaunchTask": "Bazel build all (dbg)",
+      "program": "${workspaceFolder}/${input:testToDebug}",
+      "cwd": "${workspaceFolder}",
+      "type": "cppdbg",
+      "request": "launch",
+      "linux": {
+        "name": "workerd test case",
+        "type": "cppdbg",
+        "request": "launch",
+        "MIMode": "gdb",
+        "miDebuggerArgs": "-d ${workspaceFolder}",
+        "program": "${workspaceFolder}/${input:testToDebug}",
+      },
+      "osx": {
+        "name": "workerd test case",
+        "type": "cppdbg",
+        "request": "launch",
+        "MIMode": "lldb",
+        "targetArchitecture": "arm64",
+        "sourceFileMap": {
+          "src" : "${workspaceFolder}/src",
+          "bazel-out" : "${workspaceFolder}/bazel-out",
+          "external" : "${workspaceFolder}/external"
+         },
+         "program": "${workspaceFolder}/${input:testToDebug}",
+      },
+      "windows": {
+        "name": "workerd test case",
+        "type": "cppvsdbg",
+        "request": "launch",
+        "program": "${workspaceFolder}/${input:testToDebug}",
+      },
+      "stopAtEntry": false,
+      "externalConsole": false
     }
   ],
   "inputs": [
@@ -95,6 +132,51 @@
       "description": "Workerd configuration to serve",
       "default": "${workspaceFolder}/samples/helloworld/config.capnp",
       "type": "promptString"
+    },
+    {
+      "id": "testToDebug",
+      "description": "Test to debug",
+      "type": "pickString",
+      "default": "bazel-bin/src/workerd/jsg/jsg-test",
+      "options": [
+        "bazel-bin/src/workerd/util/sqlite-test",
+        "bazel-bin/src/workerd/util/wait-list-test",
+        "bazel-bin/src/workerd/util/batch-queue-test",
+        "bazel-bin/src/workerd/util/sqlite-kv-test",
+        "bazel-bin/src/workerd/io/io-gate-test",
+        "bazel-bin/src/workerd/io/compatibility-date-test",
+        "bazel-bin/src/workerd/io/promise-wrapper-test",
+        "bazel-bin/src/workerd/io/actor-cache-test",
+        "bazel-bin/src/workerd/tests/test-fixture-test",
+        "bazel-bin/src/workerd/jsg/promise-test",
+        "bazel-bin/src/workerd/jsg/resource-test",
+        "bazel-bin/src/workerd/jsg/string-test",
+        "bazel-bin/src/workerd/jsg/tracing-test",
+        "bazel-bin/src/workerd/jsg/web-idl-test",
+        "bazel-bin/src/workerd/jsg/util-test",
+        "bazel-bin/src/workerd/jsg/dom-exception-test",
+        "bazel-bin/src/workerd/jsg/type-wrapper-test",
+        "bazel-bin/src/workerd/jsg/macro-meta-test",
+        "bazel-bin/src/workerd/jsg/rtti-test",
+        "bazel-bin/src/workerd/jsg/value-test",
+        "bazel-bin/src/workerd/jsg/setup-test",
+        "bazel-bin/src/workerd/jsg/function-test",
+        "bazel-bin/src/workerd/jsg/buffersource-test",
+        "bazel-bin/src/workerd/jsg/struct-test",
+        "bazel-bin/src/workerd/jsg/jsg-test",
+        "bazel-bin/src/workerd/jsg/iterator-test",
+        "bazel-bin/src/workerd/server/server-test",
+        "bazel-bin/src/workerd/api/actor-state-test",
+        "bazel-bin/src/workerd/api/basics-test",
+        "bazel-bin/src/workerd/api/streams/queue-test",
+        "bazel-bin/src/workerd/api/crypto-impl-aes-test",
+        "bazel-bin/src/workerd/api/crypto-impl-test",
+        "bazel-bin/src/workerd/api/util-test",
+        "bazel-bin/src/workerd/api/api-rtti-test",
+        "bazel-bin/src/workerd/api/node/buffer-test",
+        "bazel-bin/src/workerd/api/crypto-impl-asymmetric-test",
+        "bazel-bin/src/workerd/api/url-standard-test",
+      ],
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Bazel Build (dbg)",
+      "label": "Bazel build workerd (dbg)",
       "type": "shell",
       "command": "bazel",
       "args": ["build", "-c", "dbg", "//src/workerd/server:workerd"],
@@ -29,7 +29,36 @@
       }
     },
     {
-      "label": "Bazel Build (fastbuild)",
+      "label": "Bazel build all (dbg)",
+      "type": "shell",
+      "command": "bazel",
+      "linux": {
+        "args": ["build", "-c", "dbg", "//..."],
+      },
+      "osx": {
+        // OS X needs additional build option for symbols to work correctly
+        // (https://github.com/bazelbuild/bazel/issues/6327), hence the additional
+        // flags for the spawn_strategy and oso_prefix. Ideally these would
+        // be in a platform specific config in .bazelrc, but this is not supported
+        // (https://github.com/bazelbuild/bazel/issues/5055).
+        "args": ["build", "-c", "dbg","--features=oso_prefix_is_pwd", "//..."],
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": "$gcc",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      }
+    },
+    {
+      "label": "Bazel build workerd (fastbuild)",
       "type": "shell",
       "command": "bazel",
       "args": ["build", "--config", "fastbuild", "//src/workerd/server:workerd"],
@@ -48,7 +77,7 @@
       }
     },
     {
-      "label": "Bazel Build (opt)",
+      "label": "Bazel build workerd (opt)",
       "type": "shell",
       "command": "bazel",
       "args": ["build", "-c", "opt", "//src/workerd/server:workerd"],
@@ -67,7 +96,7 @@
       }
     },
     {
-      "label": "Bazel Test",
+      "label": "Bazel run all tests",
       "type": "shell",
       "command": "bazel",
       "args": ["test", "--cache_test_results=no", "//..."],

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -15,6 +15,8 @@ Microsoft Intellisense extension for this project.
 ## Generate a compile_commands.json file
 
 ```sh
+# Build workerd to ensure all generated sources are present.
+$ bazel build //...
 $ bazel run //:refresh_compile_commands
 ```
 
@@ -30,16 +32,32 @@ https://github.com/cloudflare/workerd/issues/506).
 
 ## VSCode Tasks
 
-There is a `.vscode/tasks.json` file included in the project that is seeded with a few useful
-tasks for building and testing.
+The [.vscode/tasks.json](../.vscode/tasks.json) file included provides a few useful tasks for use within VSCode:
+
+* Bazel build workerd (dbg)
+* Bazel build workerd (fastbuild)
+* Bazel build workerd (opt)
+* Bazel build all (dbg)
+* Bazel run all tests
 
 ## Debugging
 
-There is a `.vscode/launch.json` file included in the project for launching the `workerd` binary with
-the debugger attached from VSCode. This is supported on Linux (x64) and OS X (arm64).
+There are workerd debugging targets within Visual Studio Code. These
+are supported on Linux (x64) and OS X (arm64).
 
-The debug from vscode, first ensure that you have saved a vscode workspace for workerd,
+The file [.vscode/launch.json](../.vscode/launch.json) has launch targets to that can be debugged within VSCode.
+
+Before you start debugging, ensure that you have saved a vscode workspace for workerd,
 `File -> Save Workspace As...`, then `Run -> Start Debugging (F5)`.
 
-Running the project will prompt you for workerd configuration. To use the helloworld sample, the
-configuration argument would be `serve ${workspaceFolder}/samples/helloworld/config.capnp`.
+The main targets of interest are:
+
+* `workerd debug`
+* `workerd debug with inspector enabled`
+* `workerd test case`
+
+Launching either `workerd debug` or `workerd debug with inspector enabled` will prompt for a workerd configuration to launch
+workerd with, the default is `${workspaceFolder}/samples/helloworld/config.capnp`.
+
+Launching `workerd test case` will prompt for a test to debug, the default is `bazel-bin/src/workerd/jsg/jsg-test`.
+


### PR DESCRIPTION
Adds an additional launch target 'workerd test case' to make it easy to debug tests.