### PR TITLE
Add mechanism to inject a JWT + account name

### DIFF
--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -15,6 +15,7 @@
 namespace workerd::api::public_beta {
 
 kj::Array<kj::byte> cloneByteArray(const kj::Array<kj::byte>& arr);
+kj::ArrayPtr<kj::StringPtr> fillR2Path(kj::StringPtr pathStorage[2], const kj::Maybe<kj::String>& admin, const kj::Maybe<kj::String>& bucket);
 
 class R2MultipartUpload;
 
@@ -38,6 +39,9 @@ public:
 
   explicit R2Bucket(FeatureFlags featureFlags, uint clientIndex, kj::String bucket, friend_tag_t)
       : featureFlags(featureFlags), clientIndex(clientIndex), adminBucket(kj::mv(bucket)) {}
+
+  explicit R2Bucket(FeatureFlags featureFlags, uint clientIndex, kj::String bucket, kj::String account, kj::String jwt, friend_tag_t)
+      : featureFlags(featureFlags), clientIndex(clientIndex), adminBucket(kj::mv(bucket)), adminAccount(kj::mv(account)), jwt(kj::mv(jwt)) {}
 
   struct Range {
     jsg::Optional<double> offset;
@@ -403,6 +407,8 @@ private:
   FeatureFlags featureFlags;
   uint clientIndex;
   kj::Maybe<kj::String> adminBucket;
+  kj::Maybe<kj::String> adminAccount;
+  kj::Maybe<kj::String> jwt;
 
   friend class R2Admin;
   friend class R2MultipartUpload;

--- a/src/workerd/api/r2-multipart.c++
+++ b/src/workerd/api/r2-multipart.c++
@@ -45,8 +45,10 @@ jsg::Promise<R2MultipartUpload::UploadedPart> R2MultipartUpload::uploadPart(
     auto requestJson = json.encode(requestBuilder);
     auto bucket = this->bucket->adminBucket.map([](auto&& s) { return kj::str(s); });
 
+    kj::StringPtr components[2];
+    auto path = fillR2Path(components, nullptr, this->bucket->adminBucket);
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), kj::mv(value), nullptr,
-                                      kj::mv(requestJson), kj::mv(bucket));
+                                      kj::mv(requestJson), path, nullptr);
 
     return context.awaitIo(js, kj::mv(promise),
         [&errorType, partNumber]
@@ -98,10 +100,10 @@ jsg::Promise<jsg::Ref<R2Bucket::HeadResult>> R2MultipartUpload::complete(
 
     auto requestJson = json.encode(requestBuilder);
 
-    auto bucket = this->bucket->adminBucket.map([](auto&& s) { return kj::str(s); });
-
+    kj::StringPtr components[2];
+    auto path = fillR2Path(components, nullptr, this->bucket->adminBucket);
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr, kj::mv(requestJson),
-        kj::mv(bucket));
+                                      path, nullptr);
 
     return context.awaitIo(js, kj::mv(promise),
         [&errorType]
@@ -134,10 +136,10 @@ jsg::Promise<void> R2MultipartUpload::abort(jsg::Lock& js, const jsg::TypeHandle
 
     auto requestJson = json.encode(requestBuilder);
 
-    auto bucket = this->bucket->adminBucket.map([](auto&& s) { return kj::str(s); });
-
+    kj::StringPtr components[2];
+    auto path = fillR2Path(components, nullptr, this->bucket->adminBucket);
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr, kj::mv(requestJson),
-        kj::mv(bucket));
+                                      path, nullptr);
 
     return context.awaitIo(js, kj::mv(promise), [&errorType](jsg::Lock& js, R2Result r) {
       if (r.objectNotFound()) {

--- a/src/workerd/api/r2-rpc.h
+++ b/src/workerd/api/r2-rpc.h
@@ -73,7 +73,8 @@ struct R2Result {
 kj::Promise<R2Result> doR2HTTPGetRequest(
     kj::Own<kj::HttpClient> client,
     kj::String metadataPayload,
-    kj::Maybe<kj::String> path);
+    kj::ArrayPtr<kj::StringPtr> path,
+    kj::Maybe<kj::StringPtr> jwt);
 
 kj::Promise<R2Result> doR2HTTPPutRequest(
     jsg::Lock& js,
@@ -82,6 +83,7 @@ kj::Promise<R2Result> doR2HTTPPutRequest(
     kj::Maybe<uint64_t> streamSize,
     // Deprecated. For internal beta API only.
     kj::String metadataPayload,
-    kj::Maybe<kj::String> path);
+    kj::ArrayPtr<kj::StringPtr> path,
+    kj::Maybe<kj::StringPtr> jwt);
 
 } // namespace workerd::api

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -138,6 +138,7 @@ ThreadContext::HeaderIdBundle::HeaderIdBundle(kj::HttpHeaderTable::Builder& buil
       cfR2ErrorHeader(builder.add("CF-R2-Error")),
       cfBlobMetadataSize(builder.add("CF-R2-Metadata-Size")),
       cfBlobRequest(builder.add("CF-R2-Request")),
+      authorization(builder.add("Authorization")),
       secWebSocketProtocol(builder.add("Sec-WebSocket-Protocol")) {}
 
 ThreadContext::ThreadContext(

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -61,6 +61,7 @@ public:
     const kj::HttpHeaderId cfR2ErrorHeader;       // used by R2 binding implementation
     const kj::HttpHeaderId cfBlobMetadataSize;    // used by R2 binding implementation
     const kj::HttpHeaderId cfBlobRequest;         // used by R2 binding implementation
+    const kj::HttpHeaderId authorization;         // used by R2 binding implementation
     const kj::HttpHeaderId secWebSocketProtocol;
   };
 


### PR DESCRIPTION
To allow greater flexibility in how R2 RPC operations can be performed, introducing the jwt as optional attribute. Also refactored the way R2 paths are built and passed to the doR2HTTP<verb>Request functions, since we expect to support greater variety of paths.

Introduced concept of R2CrossAccount, which will leverage the new underlying flexibility to perform cross account operations with proper auth.