### PR TITLE
Implement crypto.createHash(), Hash class

### DIFF
--- a/src/node/crypto.ts
+++ b/src/node/crypto.ts
@@ -43,6 +43,12 @@ import {
 } from 'node-internal:crypto_random';
 
 import {
+  createHash,
+  Hash,
+  HashOptions,
+} from 'node-internal:crypto_hash';
+
+import {
   pbkdf2,
   pbkdf2Sync,
   ArrayLike,
@@ -83,6 +89,10 @@ export {
   generatePrimeSync,
   checkPrime,
   checkPrimeSync,
+  // Hash
+  createHash,
+  Hash,
+  HashOptions,
   // Pbkdf2
   pbkdf2,
   pbkdf2Sync,
@@ -164,6 +174,8 @@ export default {
   checkPrime,
   checkPrimeSync,
   // Hash
+  Hash,
+  createHash,
   getHashes,
   // Pbkdf2
   pbkdf2,
@@ -189,7 +201,7 @@ export default {
 //   * [x] crypto.DiffieHellman
 //   * [x] crypto.DiffieHellmanGroup
 //   * [ ] crypto.ECDH
-//   * [ ] crypto.Hash
+//   * [x] crypto.Hash
 //   * [ ] crypto.Hmac
 //   * [ ] crypto.KeyObject
 //   * [ ] crypto.Sign
@@ -219,7 +231,7 @@ export default {
 //   * [ ] crypto.diffieHellman(options)
 //   * [x] crypto.getDiffieHellman(groupName)
 // * Hash
-//   * [ ] crypto.createHash(algorithm[, options])
+//   * [x] crypto.createHash(algorithm[, options])
 //   * [ ] crypto.createHmac(algorithm, key[, options])
 //   * [x] crypto.getHashes()
 // * Keys

--- a/src/node/internal/crypto.d.ts
+++ b/src/node/internal/crypto.d.ts
@@ -11,6 +11,14 @@ export function checkPrimeSync(candidate: ArrayBufferView, num_checks: number): 
 export function randomPrime(size: number, safe: boolean, add?: ArrayBufferView|undefined,
                             rem?: ArrayBufferView|undefined): ArrayBuffer;
 
+// Hash
+export class HashHandle {
+  public constructor(algorithm: string, xofLen: number);
+  public update(data: Buffer | ArrayBufferView): number;
+  public digest(): ArrayBuffer;
+  public copy(xofLen: number): HashHandle;
+}
+
 // pbkdf2
 export type ArrayLike = ArrayBuffer|string|Buffer|ArrayBufferView;
 export function getPbkdf(password: ArrayLike, salt: ArrayLike, iterations: number, keylen: number,

--- a/src/node/internal/crypto_hash.ts
+++ b/src/node/internal/crypto_hash.ts
@@ -1,0 +1,176 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import { default as cryptoImpl } from 'node-internal:crypto';
+
+import {
+  kFinalized,
+  kHandle,
+  kState,
+} from 'node-internal:crypto_util';
+
+import {
+  Buffer
+} from 'node-internal:internal_buffer';
+
+import {
+  ERR_CRYPTO_HASH_FINALIZED,
+  ERR_CRYPTO_HASH_UPDATE_FAILED,
+  ERR_INVALID_ARG_TYPE,
+} from 'node-internal:internal_errors';
+
+import {
+  validateEncoding,
+  validateString,
+  validateUint32,
+} from 'node-internal:validators';
+
+import {
+  normalizeEncoding
+} from 'node-internal:internal_utils';
+
+import {
+  isArrayBufferView
+} from 'node-internal:internal_types';
+
+import {
+  Transform,
+  TransformOptions,
+  TransformCallback,
+} from 'node-internal:streams_transform';
+
+export interface HashOptions extends TransformOptions {
+  outputLength?: number;
+}
+
+interface _kState {
+  [kFinalized]: boolean;
+}
+
+interface Hash extends Transform {
+  [kHandle]: cryptoImpl.HashHandle;
+  [kState]: _kState;
+}
+
+// These helper functions are needed because the constructors can
+// use new, in which case V8 cannot inline the recursive constructor call
+export function createHash(algorithm: string, options?: HashOptions): Hash {
+  return new Hash(algorithm, options);
+}
+
+let Hash = function(this: Hash, algorithm: string | cryptoImpl.HashHandle,
+  options?: HashOptions): Hash {
+  if (!(this instanceof Hash))
+    return new Hash(algorithm, options);
+
+  const xofLen = typeof options === 'object' ? options.outputLength : undefined;
+  if (xofLen !== undefined)
+    validateUint32(xofLen, 'options.outputLength');
+  if (algorithm instanceof cryptoImpl.HashHandle) {
+    this[kHandle] = algorithm.copy(xofLen as number);
+  } else {
+    validateString(algorithm, 'algorithm');
+    this[kHandle] = new cryptoImpl.HashHandle(algorithm, xofLen as number);
+  }
+  this[kState] = {
+    [kFinalized]: false,
+  };
+
+  Transform.call(this, options);
+  return this;
+} as any as { new (algorithm: string | cryptoImpl.HashHandle, options?: HashOptions): Hash; };
+
+Object.setPrototypeOf(Hash.prototype, Transform.prototype);
+Object.setPrototypeOf(Hash, Transform);
+
+Hash.prototype.copy = function(this: Hash, options?: HashOptions): Hash {
+  const state = this[kState];
+  if (state[kFinalized])
+    throw new ERR_CRYPTO_HASH_FINALIZED();
+
+  return new Hash(this[kHandle], options);
+}
+
+Hash.prototype._transform = function(this: Hash, chunk: Buffer | string | any, encoding: string,
+                                     callback: TransformCallback): void {
+  if (typeof chunk === 'string') {
+    encoding ??= 'utf-8';
+    validateEncoding(chunk, encoding);
+    encoding = normalizeEncoding(encoding)!;
+    chunk = Buffer.from(chunk, encoding);
+  }
+  this[kHandle].update(chunk);
+  callback();
+}
+
+Hash.prototype._flush = function(this: Hash, callback: TransformCallback): void {
+  this.push(Buffer.from(this[kHandle].digest()));
+  callback();
+}
+
+Hash.prototype.update = function(this: Hash, data: string | Buffer | ArrayBufferView,
+                                 encoding?: string): Hash {
+  encoding ??= 'utf8';
+  if (encoding === 'buffer') {
+    encoding = undefined;
+  }
+
+  const state = this[kState];
+  if (state[kFinalized])
+    throw new ERR_CRYPTO_HASH_FINALIZED();
+
+  if (typeof data === 'string') {
+    validateEncoding(data, encoding!);
+    encoding = normalizeEncoding(encoding);
+    data = Buffer.from(data, encoding);
+  } else if (!isArrayBufferView(data)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'data', ['string', 'Buffer', 'TypedArray', 'DataView'], data);
+  }
+
+  if (!this[kHandle].update(data))
+    throw new ERR_CRYPTO_HASH_UPDATE_FAILED();
+  return this;
+}
+
+Hash.prototype.digest = function(this: Hash, outputEncoding?: string): Buffer | string {
+  const state = this[kState];
+  if (state[kFinalized])
+    throw new ERR_CRYPTO_HASH_FINALIZED();
+
+  // Explicit conversion for backward compatibility.
+  const ret = Buffer.from(this[kHandle].digest());
+  state[kFinalized] = true;
+  if (outputEncoding !== undefined && outputEncoding !== 'buffer') {
+    return ret.toString(outputEncoding);
+  } else {
+    return ret;
+  }
+}
+
+export {Hash};

--- a/src/node/internal/crypto_util.ts
+++ b/src/node/internal/crypto_util.ts
@@ -42,6 +42,8 @@ import {
 } from 'node-internal:internal_errors';
 
 export const kHandle = Symbol('kHandle');
+export const kFinalized = Symbol('kFinalized');
+export const kState = Symbol('kFinalized');
 
 export function getArrayBufferOrView(buffer: Buffer | ArrayBuffer | ArrayBufferView | string, name: string, encoding?: string): Buffer | ArrayBuffer | ArrayBufferView {
   if (isAnyArrayBuffer(buffer))

--- a/src/node/internal/streams_transform.d.ts
+++ b/src/node/internal/streams_transform.d.ts
@@ -1,0 +1,369 @@
+/* This project is licensed under the MIT license.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. */
+
+// Derived from DefinitelyTyped https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/stream.d.ts#L1060
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import { EventEmitter } from 'node:events';
+
+interface WritableOptions {
+  highWaterMark?: number | undefined;
+  decodeStrings?: boolean | undefined;
+  defaultEncoding?: BufferEncoding | undefined;
+  objectMode?: boolean | undefined;
+  emitClose?: boolean | undefined;
+  write?(this: Writable, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
+  writev?(this: Writable, chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
+  destroy?(this: Writable, error: Error | null, callback: (error: Error | null) => void): void;
+  final?(this: Writable, callback: (error?: Error | null) => void): void;
+  autoDestroy?: boolean | undefined;
+}
+
+export class internal extends EventEmitter {
+  pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean | undefined; }): T;
+}
+
+export class Stream extends internal {
+  constructor(opts?: ReadableOptions);
+}
+
+interface ReadableOptions {
+  highWaterMark?: number | undefined;
+  encoding?: BufferEncoding | undefined;
+  objectMode?: boolean | undefined;
+  read?(this: Readable, size: number): void;
+  destroy?(this: Readable, error: Error | null, callback: (error: Error | null) => void): void;
+  autoDestroy?: boolean | undefined;
+}
+
+export class Readable extends Stream implements NodeJS.ReadableStream {
+  static from(iterable: Iterable<any> | AsyncIterable<any>, options?: ReadableOptions): Readable;
+
+  readable: boolean;
+  readonly readableEncoding: BufferEncoding | null;
+  readonly readableEnded: boolean;
+  readonly readableFlowing: boolean | null;
+  readonly readableHighWaterMark: number;
+  readonly readableLength: number;
+  readonly readableObjectMode: boolean;
+  destroyed: boolean;
+  constructor(opts?: ReadableOptions);
+  _read(size: number): void;
+  read(size?: number): any;
+  setEncoding(encoding: BufferEncoding): this;
+  pause(): this;
+  resume(): this;
+  isPaused(): boolean;
+  unpipe(destination?: NodeJS.WritableStream): this;
+  unshift(chunk: any, encoding?: BufferEncoding): void;
+  wrap(oldStream: NodeJS.ReadableStream): this;
+  push(chunk: any, encoding?: BufferEncoding): boolean;
+  _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
+  destroy(error?: Error): this;
+
+  addListener(event: "close", listener: () => void): this;
+  addListener(event: "data", listener: (chunk: any) => void): this;
+  addListener(event: "end", listener: () => void): this;
+  addListener(event: "error", listener: (err: Error) => void): this;
+  addListener(event: "pause", listener: () => void): this;
+  addListener(event: "readable", listener: () => void): this;
+  addListener(event: "resume", listener: () => void): this;
+  addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  emit(event: "close"): boolean;
+  emit(event: "data", chunk: any): boolean;
+  emit(event: "end"): boolean;
+  emit(event: "error", err: Error): boolean;
+  emit(event: "pause"): boolean;
+  emit(event: "readable"): boolean;
+  emit(event: "resume"): boolean;
+  emit(event: string | symbol, ...args: any[]): boolean;
+
+  on(event: "close", listener: () => void): this;
+  on(event: "data", listener: (chunk: any) => void): this;
+  on(event: "end", listener: () => void): this;
+  on(event: "error", listener: (err: Error) => void): this;
+  on(event: "pause", listener: () => void): this;
+  on(event: "readable", listener: () => void): this;
+  on(event: "resume", listener: () => void): this;
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  once(event: "close", listener: () => void): this;
+  once(event: "data", listener: (chunk: any) => void): this;
+  once(event: "end", listener: () => void): this;
+  once(event: "error", listener: (err: Error) => void): this;
+  once(event: "pause", listener: () => void): this;
+  once(event: "readable", listener: () => void): this;
+  once(event: "resume", listener: () => void): this;
+  once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  prependListener(event: "close", listener: () => void): this;
+  prependListener(event: "data", listener: (chunk: any) => void): this;
+  prependListener(event: "end", listener: () => void): this;
+  prependListener(event: "error", listener: (err: Error) => void): this;
+  prependListener(event: "pause", listener: () => void): this;
+  prependListener(event: "readable", listener: () => void): this;
+  prependListener(event: "resume", listener: () => void): this;
+  prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  prependOnceListener(event: "close", listener: () => void): this;
+  prependOnceListener(event: "data", listener: (chunk: any) => void): this;
+  prependOnceListener(event: "end", listener: () => void): this;
+  prependOnceListener(event: "error", listener: (err: Error) => void): this;
+  prependOnceListener(event: "pause", listener: () => void): this;
+  prependOnceListener(event: "readable", listener: () => void): this;
+  prependOnceListener(event: "resume", listener: () => void): this;
+  prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  removeListener(event: "close", listener: () => void): this;
+  removeListener(event: "data", listener: (chunk: any) => void): this;
+  removeListener(event: "end", listener: () => void): this;
+  removeListener(event: "error", listener: (err: Error) => void): this;
+  removeListener(event: "pause", listener: () => void): this;
+  removeListener(event: "readable", listener: () => void): this;
+  removeListener(event: "resume", listener: () => void): this;
+  removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+}
+
+export class Writable extends Stream implements NodeJS.WritableStream {
+  readonly writable: boolean;
+  readonly writableEnded: boolean;
+  readonly writableFinished: boolean;
+  readonly writableHighWaterMark: number;
+  readonly writableLength: number;
+  readonly writableObjectMode: boolean;
+  readonly writableCorked: number;
+  destroyed: boolean;
+  constructor(opts?: WritableOptions);
+  _write(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
+  _writev?(chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
+  _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
+  _final(callback: (error?: Error | null) => void): void;
+  write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
+  write(chunk: any, encoding: BufferEncoding, cb?: (error: Error | null | undefined) => void): boolean;
+  setDefaultEncoding(encoding: BufferEncoding): this;
+  end(cb?: () => void): this;
+  end(chunk: any, cb?: () => void): this;
+  end(chunk: any, encoding: BufferEncoding, cb?: () => void): this;
+  cork(): void;
+  uncork(): void;
+  destroy(error?: Error): this;
+
+  addListener(event: "close", listener: () => void): this;
+  addListener(event: "drain", listener: () => void): this;
+  addListener(event: "error", listener: (err: Error) => void): this;
+  addListener(event: "finish", listener: () => void): this;
+  addListener(event: "pipe", listener: (src: Readable) => void): this;
+  addListener(event: "unpipe", listener: (src: Readable) => void): this;
+  addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  emit(event: "close"): boolean;
+  emit(event: "drain"): boolean;
+  emit(event: "error", err: Error): boolean;
+  emit(event: "finish"): boolean;
+  emit(event: "pipe", src: Readable): boolean;
+  emit(event: "unpipe", src: Readable): boolean;
+  emit(event: string | symbol, ...args: any[]): boolean;
+
+  on(event: "close", listener: () => void): this;
+  on(event: "drain", listener: () => void): this;
+  on(event: "error", listener: (err: Error) => void): this;
+  on(event: "finish", listener: () => void): this;
+  on(event: "pipe", listener: (src: Readable) => void): this;
+  on(event: "unpipe", listener: (src: Readable) => void): this;
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  once(event: "close", listener: () => void): this;
+  once(event: "drain", listener: () => void): this;
+  once(event: "error", listener: (err: Error) => void): this;
+  once(event: "finish", listener: () => void): this;
+  once(event: "pipe", listener: (src: Readable) => void): this;
+  once(event: "unpipe", listener: (src: Readable) => void): this;
+  once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  prependListener(event: "close", listener: () => void): this;
+  prependListener(event: "drain", listener: () => void): this;
+  prependListener(event: "error", listener: (err: Error) => void): this;
+  prependListener(event: "finish", listener: () => void): this;
+  prependListener(event: "pipe", listener: (src: Readable) => void): this;
+  prependListener(event: "unpipe", listener: (src: Readable) => void): this;
+  prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  prependOnceListener(event: "close", listener: () => void): this;
+  prependOnceListener(event: "drain", listener: () => void): this;
+  prependOnceListener(event: "error", listener: (err: Error) => void): this;
+  prependOnceListener(event: "finish", listener: () => void): this;
+  prependOnceListener(event: "pipe", listener: (src: Readable) => void): this;
+  prependOnceListener(event: "unpipe", listener: (src: Readable) => void): this;
+  prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  removeListener(event: "close", listener: () => void): this;
+  removeListener(event: "drain", listener: () => void): this;
+  removeListener(event: "error", listener: (err: Error) => void): this;
+  removeListener(event: "finish", listener: () => void): this;
+  removeListener(event: "pipe", listener: (src: Readable) => void): this;
+  removeListener(event: "unpipe", listener: (src: Readable) => void): this;
+  removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+}
+
+
+export class Duplex extends Readable implements Writable {
+  readonly writable: boolean;
+  readonly writableEnded: boolean;
+  readonly writableFinished: boolean;
+  readonly writableHighWaterMark: number;
+  readonly writableLength: number;
+  readonly writableObjectMode: boolean;
+  readonly writableCorked: number;
+  allowHalfOpen: boolean;
+  constructor(opts?: DuplexOptions);
+  _write(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
+  _writev?(chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
+  _destroy(error: Error | null, callback: (error: Error | null) => void): void;
+  _final(callback: (error?: Error | null) => void): void;
+  write(chunk: any, encoding?: BufferEncoding, cb?: (error: Error | null | undefined) => void): boolean;
+  write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
+  setDefaultEncoding(encoding: BufferEncoding): this;
+  end(cb?: () => void): this;
+  end(chunk: any, cb?: () => void): this;
+  end(chunk: any, encoding?: BufferEncoding, cb?: () => void): this;
+  cork(): void;
+  uncork(): void;
+  addListener(event: 'close', listener: () => void): this;
+  addListener(event: 'data', listener: (chunk: any) => void): this;
+  addListener(event: 'drain', listener: () => void): this;
+  addListener(event: 'end', listener: () => void): this;
+  addListener(event: 'error', listener: (err: Error) => void): this;
+  addListener(event: 'finish', listener: () => void): this;
+  addListener(event: 'pause', listener: () => void): this;
+  addListener(event: 'pipe', listener: (src: Readable) => void): this;
+  addListener(event: 'readable', listener: () => void): this;
+  addListener(event: 'resume', listener: () => void): this;
+  addListener(event: 'unpipe', listener: (src: Readable) => void): this;
+  addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+  emit(event: 'close'): boolean;
+  emit(event: 'data', chunk: any): boolean;
+  emit(event: 'drain'): boolean;
+  emit(event: 'end'): boolean;
+  emit(event: 'error', err: Error): boolean;
+  emit(event: 'finish'): boolean;
+  emit(event: 'pause'): boolean;
+  emit(event: 'pipe', src: Readable): boolean;
+  emit(event: 'readable'): boolean;
+  emit(event: 'resume'): boolean;
+  emit(event: 'unpipe', src: Readable): boolean;
+  emit(event: string | symbol, ...args: any[]): boolean;
+  on(event: 'close', listener: () => void): this;
+  on(event: 'data', listener: (chunk: any) => void): this;
+  on(event: 'drain', listener: () => void): this;
+  on(event: 'end', listener: () => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'finish', listener: () => void): this;
+  on(event: 'pause', listener: () => void): this;
+  on(event: 'pipe', listener: (src: Readable) => void): this;
+  on(event: 'readable', listener: () => void): this;
+  on(event: 'resume', listener: () => void): this;
+  on(event: 'unpipe', listener: (src: Readable) => void): this;
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+  once(event: 'close', listener: () => void): this;
+  once(event: 'data', listener: (chunk: any) => void): this;
+  once(event: 'drain', listener: () => void): this;
+  once(event: 'end', listener: () => void): this;
+  once(event: 'error', listener: (err: Error) => void): this;
+  once(event: 'finish', listener: () => void): this;
+  once(event: 'pause', listener: () => void): this;
+  once(event: 'pipe', listener: (src: Readable) => void): this;
+  once(event: 'readable', listener: () => void): this;
+  once(event: 'resume', listener: () => void): this;
+  once(event: 'unpipe', listener: (src: Readable) => void): this;
+  once(event: string | symbol, listener: (...args: any[]) => void): this;
+  prependListener(event: 'close', listener: () => void): this;
+  prependListener(event: 'data', listener: (chunk: any) => void): this;
+  prependListener(event: 'drain', listener: () => void): this;
+  prependListener(event: 'end', listener: () => void): this;
+  prependListener(event: 'error', listener: (err: Error) => void): this;
+  prependListener(event: 'finish', listener: () => void): this;
+  prependListener(event: 'pause', listener: () => void): this;
+  prependListener(event: 'pipe', listener: (src: Readable) => void): this;
+  prependListener(event: 'readable', listener: () => void): this;
+  prependListener(event: 'resume', listener: () => void): this;
+  prependListener(event: 'unpipe', listener: (src: Readable) => void): this;
+  prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+  prependOnceListener(event: 'close', listener: () => void): this;
+  prependOnceListener(event: 'data', listener: (chunk: any) => void): this;
+  prependOnceListener(event: 'drain', listener: () => void): this;
+  prependOnceListener(event: 'end', listener: () => void): this;
+  prependOnceListener(event: 'error', listener: (err: Error) => void): this;
+  prependOnceListener(event: 'finish', listener: () => void): this;
+  prependOnceListener(event: 'pause', listener: () => void): this;
+  prependOnceListener(event: 'pipe', listener: (src: Readable) => void): this;
+  prependOnceListener(event: 'readable', listener: () => void): this;
+  prependOnceListener(event: 'resume', listener: () => void): this;
+  prependOnceListener(event: 'unpipe', listener: (src: Readable) => void): this;
+  prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+  removeListener(event: 'close', listener: () => void): this;
+  removeListener(event: 'data', listener: (chunk: any) => void): this;
+  removeListener(event: 'drain', listener: () => void): this;
+  removeListener(event: 'end', listener: () => void): this;
+  removeListener(event: 'error', listener: (err: Error) => void): this;
+  removeListener(event: 'finish', listener: () => void): this;
+  removeListener(event: 'pause', listener: () => void): this;
+  removeListener(event: 'pipe', listener: (src: Readable) => void): this;
+  removeListener(event: 'readable', listener: () => void): this;
+  removeListener(event: 'resume', listener: () => void): this;
+  removeListener(event: 'unpipe', listener: (src: Readable) => void): this;
+  removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+}
+
+interface DuplexOptions extends ReadableOptions, WritableOptions {
+  allowHalfOpen?: boolean | undefined;
+  readableObjectMode?: boolean | undefined;
+  writableObjectMode?: boolean | undefined;
+  readableHighWaterMark?: number | undefined;
+  writableHighWaterMark?: number | undefined;
+  writableCorked?: number | undefined;
+  read?(this: Duplex, size: number): void;
+  write?(this: Duplex, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
+  writev?(this: Duplex, chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
+  final?(this: Duplex, callback: (error?: Error | null) => void): void;
+  destroy?(this: Duplex, error: Error | null, callback: (error: Error | null) => void): void;
+}
+
+interface TransformOptions extends DuplexOptions {
+  read?(this: Transform, size: number): void;
+  write?(this: Transform, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
+  writev?(this: Transform, chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
+  final?(this: Transform, callback: (error?: Error | null) => void): void;
+  destroy?(this: Transform, error: Error | null, callback: (error: Error | null) => void): void;
+  transform?(this: Transform, chunk: any, encoding: BufferEncoding, callback: TransformCallback): void;
+  flush?(this: Transform, callback: TransformCallback): void;
+}
+
+type TransformCallback = (error?: Error | null, data?: any) => void;
+
+export class Transform extends Duplex {
+  constructor(opts?: TransformOptions);
+  _transform(chunk: any, encoding: BufferEncoding, callback: TransformCallback): void;
+  _flush(callback: TransformCallback): void;
+}

--- a/src/workerd/api/node/crypto_hash-test.js
+++ b/src/workerd/api/node/crypto_hash-test.js
@@ -1,0 +1,262 @@
+'use strict';
+
+import {
+  Buffer,
+} from 'node:buffer';
+import * as assert from 'node:assert';
+import * as crypto from 'node:crypto';
+import * as stream from 'node:stream';
+
+let cryptoType;
+let digest;
+
+export const hash_correctness_tests = {
+  async test(ctrl, env, ctx) {
+    const a1 = crypto.createHash('sha1').update('Test123').digest('hex');
+    const a2 = crypto.createHash('sha256').update('Test123').digest('base64');
+    const a3 = crypto.createHash('sha512').update('Test123').digest(); // buffer
+    const a4 = crypto.createHash('sha1').update('Test123').digest('buffer');
+
+    // stream interface
+    let a5 = crypto.createHash('sha512');
+    a5.end('Test123');
+    a5 = a5.read();
+
+    let a6 = crypto.createHash('sha512');
+    a6.write('Te');
+    a6.write('st');
+    a6.write('123');
+    a6.end();
+    a6 = a6.read();
+
+    let a7 = crypto.createHash('sha512');
+    a7.end();
+    a7 = a7.read();
+
+    let a8 = crypto.createHash('sha512');
+    a8.write('');
+    a8.end();
+    a8 = a8.read();
+
+    cryptoType = 'md5';
+    digest = 'latin1';
+    const a0 = crypto.createHash(cryptoType).update('Test123').digest(digest);
+    assert.strictEqual(
+      a0,
+      'h\u00ea\u00cb\u0097\u00d8o\fF!\u00fa+\u000e\u0017\u00ca\u00bd\u008c',
+      `${cryptoType} with ${digest} digest failed to evaluate to expected hash`
+    );
+
+    cryptoType = 'md5';
+    digest = 'hex';
+    assert.strictEqual(
+      a1,
+      '8308651804facb7b9af8ffc53a33a22d6a1c8ac2',
+      `${cryptoType} with ${digest} digest failed to evaluate to expected hash`);
+    cryptoType = 'sha256';
+    digest = 'base64';
+    assert.strictEqual(
+      a2,
+      '2bX1jws4GYKTlxhloUB09Z66PoJZW+y+hq5R8dnx9l4=',
+      `${cryptoType} with ${digest} digest failed to evaluate to expected hash`);
+
+    cryptoType = 'sha512';
+    digest = 'latin1';
+    assert.deepStrictEqual(
+      a3,
+      Buffer.from(
+        '\u00c1(4\u00f1\u0003\u001fd\u0097!O\'\u00d4C/&Qz\u00d4' +
+        '\u0094\u0015l\u00b8\u008dQ+\u00db\u001d\u00c4\u00b5}\u00b2' +
+        '\u00d6\u0092\u00a3\u00df\u00a2i\u00a1\u009b\n\n*\u000f' +
+        '\u00d7\u00d6\u00a2\u00a8\u0085\u00e3<\u0083\u009c\u0093' +
+        '\u00c2\u0006\u00da0\u00a1\u00879(G\u00ed\'',
+        'latin1'),
+      `${cryptoType} with ${digest} digest failed to evaluate to expected hash`);
+
+    cryptoType = 'sha1';
+    digest = 'hex';
+    assert.deepStrictEqual(
+      a4,
+      Buffer.from('8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'hex'),
+      `${cryptoType} with ${digest} digest failed to evaluate to expected hash`
+    );
+
+    cryptoType = 'sha1';
+    digest = 'hex';
+    assert.deepStrictEqual(
+      a4,
+      Buffer.from('8308651804FACB7B9AF8FFC53A33A22D6A1C8AC2', 'hex'),
+      `${cryptoType} with ${digest} digest failed to evaluate to expected hash`
+    );
+
+    // Stream interface should produce the same result.
+    assert.deepStrictEqual(a5, a3);
+    assert.deepStrictEqual(a6, a3);
+    assert.notStrictEqual(a7, undefined);
+    assert.notStrictEqual(a8, undefined);
+
+    // Test multiple updates to same hash
+    const h1 = crypto.createHash('sha1').update('Test123').digest('hex');
+    const h2 = crypto.createHash('sha1').update('Test').update('123').digest('hex');
+    assert.strictEqual(h1, h2);
+  }
+}
+
+export const hash_error_test = {
+  async test(ctrl, env, ctx) {
+    // Issue https://github.com/nodejs/node-v0.x-archive/issues/2227: unknown digest
+    // method should throw an error.
+    assert.throws(function() {
+      crypto.createHash('xyzzy');
+    }, /Digest method not supported/);
+
+    // Issue https://github.com/nodejs/node/issues/9819: throwing encoding used to
+    // segfault.
+    assert.throws(
+      () => crypto.createHash('sha256').digest({
+        toString: () => { throw new Error('boom'); },
+      }),
+      {
+        name: 'Error',
+        message: 'boom'
+      });
+
+    // Issue https://github.com/nodejs/node/issues/25487: error message for invalid
+    // arg type to update method should include all possible types
+    assert.throws(
+      () => crypto.createHash('sha256').update(),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError',
+      });
+
+    // Default UTF-8 encoding
+    const hutf8 = crypto.createHash('sha512').update('УТФ-8 text').digest('hex');
+    assert.strictEqual(
+      hutf8,
+      '4b21bbd1a68e690a730ddcb5a8bc94ead9879ffe82580767ad7ec6fa8ba2dea6' +
+            '43a821af66afa9a45b6a78c712fecf0e56dc7f43aef4bcfc8eb5b4d8dca6ea5b');
+
+    assert.notStrictEqual(
+      hutf8,
+      crypto.createHash('sha512').update('УТФ-8 text', 'latin1').digest('hex'));
+
+    const h3 = crypto.createHash('sha256');
+    h3.digest();
+
+    assert.throws(
+      () => h3.digest(),
+      {
+        code: 'ERR_CRYPTO_HASH_FINALIZED',
+        name: 'Error'
+      });
+
+    assert.throws(
+      () => h3.update('foo'),
+      {
+        code: 'ERR_CRYPTO_HASH_FINALIZED',
+        name: 'Error'
+      });
+
+    assert.strictEqual(
+      crypto.createHash('sha256').update('test').digest('ucs2'),
+      crypto.createHash('sha256').update('test').digest().toString('ucs2'));
+
+    assert.throws(
+      () => crypto.createHash(),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError',
+        message: 'The "algorithm" argument must be of type string. ' +
+                'Received undefined'
+      }
+    );
+
+    {
+      const Hash = crypto.Hash;
+      const instance = crypto.Hash('sha256');
+      assert.ok(instance instanceof Hash, 'Hash is expected to return a new instance' +
+                                      ' when called without `new`');
+    }
+
+    // shake*-based tests for XOF hash function are not supported in FIPS and have been removed.
+    {
+      // Non-XOF hash functions should accept valid outputLength options as well.
+      assert.strictEqual(crypto.createHash('sha224', { outputLength: 28 })
+                              .digest('hex'),
+                        'd14a028c2a3a2bc9476102bb288234c4' +
+                        '15a2b01f828ea62ac5b3e42f');
+
+      // Passing invalid sizes should throw during creation.
+      assert.throws(() => {
+        crypto.createHash('sha256', { outputLength: 28 });
+      }, {
+        name: 'Error'
+      });
+
+      for (const outputLength of [null, {}, 'foo', false]) {
+        assert.throws(() => crypto.createHash('sha256', { outputLength }),
+                      { code: 'ERR_INVALID_ARG_TYPE' });
+      }
+
+      for (const outputLength of [-1, .5, Infinity, 2 ** 90]) {
+        assert.throws(() => crypto.createHash('sha256', { outputLength }),
+                      { code: 'ERR_OUT_OF_RANGE' });
+      }
+    }
+  }
+}
+
+export const hash_copy_test = {
+  async test(ctrl, env, ctx) {
+    const h = crypto.createHash('sha512');
+    h.digest();
+    assert.throws(() => h.copy(), { code: 'ERR_CRYPTO_HASH_FINALIZED' });
+    assert.throws(() => h.digest(), { code: 'ERR_CRYPTO_HASH_FINALIZED' });
+
+    const a = crypto.createHash('sha512').update('abc');
+    const b = a.copy();
+    const c = b.copy().update('def');
+    const d = crypto.createHash('sha512').update('abcdef');
+    assert.strictEqual(a.digest('hex'), b.digest('hex'));
+    assert.strictEqual(c.digest('hex'), d.digest('hex'));
+  }
+}
+
+function deferredPromise() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return {
+    promise,
+    resolve,
+    reject,
+  }
+}
+
+export const hash_pipe_test = {
+  async test(ctrl, env, ctx) {
+    const p = deferredPromise();
+
+    const s = new stream.PassThrough();
+    const h = crypto.createHash('sha512');
+    const expect = 'fba055c6fd0c5b6645407749ed7a8b41' +
+                   'b8f629f2163c3ca3701d864adabda1f8' +
+                   '93c37bf82b22fdd151ba8e357f611da4' +
+                   '88a74b6a5525dd9b69554c6ce5138ad7';
+
+    s.pipe(h).on('data', function(c) {
+        // Calling digest() after piping into a stream with SHA3 should not cause
+        // a segmentation fault, see https://github.com/nodejs/node/issues/28245.
+        if (c !== expect || h.digest('hex') !== expect) {
+          p.reject("Unexpected value for stream-based hash");
+        }
+        p.resolve();
+    }).setEncoding('hex');
+
+    s.end('aoeu');
+    await p.promise;
+  }
+}

--- a/src/workerd/api/node/crypto_hash-test.wd-test
+++ b/src/workerd/api/node/crypto_hash-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "crypto_hash-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "crypto_hash-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat", "experimental"]
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/node/crypto_hash.c++
+++ b/src/workerd/api/node/crypto_hash.c++
@@ -1,0 +1,76 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+// Copyright Joyent and Node contributors. All rights reserved. MIT license.
+
+#include "crypto.h"
+#include "crypto_util.h"
+#include <v8.h>
+#include <openssl/evp.h>
+#include <workerd/jsg/jsg.h>
+#include <workerd/api/crypto-impl.h>
+
+namespace workerd::api::node {
+jsg::Ref<CryptoImpl::HashHandle> CryptoImpl::HashHandle::constructor(
+    jsg::Lock& js, kj::String algorithm, kj::Maybe<uint32_t> xofLen) {
+  return jsg::alloc<CryptoImpl::HashHandle>(algorithm, xofLen);
+}
+
+int CryptoImpl::HashHandle::update(jsg::Lock& js, kj::Array<kj::byte> data) {
+  JSG_REQUIRE(data.size() <= INT_MAX, RangeError, "data is too long");
+  OSSLCALL(EVP_DigestUpdate(md_ctx.get(), data.begin(), data.size()));
+  return 1;
+}
+
+kj::Array<kj::byte> CryptoImpl::HashHandle::digest(jsg::Lock& js) {
+  KJ_IF_MAYBE(_existing_digest, _digest) {
+    // Allow calling the internal digest several times, for the streams interface
+    return kj::heapArray<kj::byte>(_existing_digest->asPtr());
+  } else {
+    unsigned len = md_len;
+    auto digest = kj::heapArray<kj::byte>(md_len);
+    if (EVP_MD_CTX_size(md_ctx.get()) == md_len) {
+      JSG_REQUIRE(EVP_DigestFinal_ex(md_ctx.get(), digest.begin(), &len) == 1, Error,
+                  "failed to compute hash digest");
+      KJ_ASSERT(len == md_len);
+    } else {
+      JSG_REQUIRE(EVP_DigestFinalXOF(md_ctx.get(), digest.begin(), len) == 1, Error,
+                  "failed to compute XOF hash digest");
+    }
+    auto data_out = kj::heapArray<kj::byte>(digest);
+    _digest = kj::mv(digest);
+    return data_out;
+  }
+}
+
+jsg::Ref<CryptoImpl::HashHandle> CryptoImpl::HashHandle::copy(jsg::Lock& js,
+                                                              kj::Maybe<uint32_t> xofLen) {
+  return jsg::alloc<CryptoImpl::HashHandle>(this->md_ctx.get(), xofLen);
+}
+
+void CryptoImpl::HashHandle::checkDigestLength(const EVP_MD* md, kj::Maybe<uint32_t> xofLen) {
+  md_ctx = OSSL_NEW(EVP_MD_CTX);
+  OSSLCALL(EVP_DigestInit(md_ctx.get(), md));
+  md_len = EVP_MD_size(md);
+  KJ_IF_MAYBE(xof_md_len, xofLen) {
+    if (*xof_md_len != md_len) {
+      JSG_REQUIRE((EVP_MD_flags(md) & EVP_MD_FLAG_XOF) != 0, Error, "invalid digest size");
+      md_len = *xof_md_len;
+    }
+  }
+}
+
+CryptoImpl::HashHandle::HashHandle(EVP_MD_CTX* in_ctx, kj::Maybe<uint32_t> xofLen) {
+  const EVP_MD* md = EVP_MD_CTX_md(in_ctx);
+  KJ_ASSERT(md != nullptr);
+  checkDigestLength(md, xofLen);
+  OSSLCALL(EVP_MD_CTX_copy_ex(md_ctx.get(), in_ctx));
+};
+
+CryptoImpl::HashHandle::HashHandle(kj::String& algorithm, kj::Maybe<uint32_t> xofLen) {
+  const EVP_MD* md = EVP_get_digestbyname(algorithm.begin());
+  JSG_REQUIRE(md != nullptr, Error, "Digest method not supported");
+  checkDigestLength(md, xofLen);
+};
+
+} // namespace workerd::api::node


### PR DESCRIPTION
Builds upon the felix/node-crypto-prime branch.
Remaining issues:
- I couldn't quite figure out how to have TypeScript consider Hash to be an actual class and a type, fix this and get rid of the casts to `any`.
- Hash is supposed to extend `stream.transform`, but having it inherit from that class seems difficult to do without having Typescript bindings for a large proportion of stream-related code. This is needed for the stream-based test cases to work.