### PR TITLE
Partially revert #568, fixing mac compilation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -58,6 +58,10 @@ build:unix --cxxopt='-Wno-unused-parameter' --host_cxxopt='-Wno-unused-parameter
 build:unix --cxxopt='-Wno-missing-field-initializers' --host_cxxopt='-Wno-missing-field-initializers'
 build:unix --cxxopt='-Wno-ignored-qualifiers' --host_cxxopt='-Wno-ignored-qualifiers'
 
+# Temporary workaround for zlib warnings and mac compilation, should no longer be needed with next
+# zlib release (https://github.com/madler/zlib/issues/633)
+build:unix --per_file_copt='external/zlib[~/].*\.c@-std=c90' --host_per_file_copt='external/zlib[~/].*\.c@-std=c90'
+
 build:unix --@capnp-cpp//src/kj:openssl=True --@capnp-cpp//src/kj:zlib=True --@capnp-cpp//src/kj:libdl=True
 
 build:linux --config=unix


### PR DESCRIPTION
While #578 pulled in the updated capnproto version which includes zlib compilation fixes, this is still needed in workerd – capnproto defines the zlib compile options in its WORKSPACE file, which is not accessed by workerd.