### PR TITLE
[nfc] extracting io:observer and io:worker-interface libraries

### DIFF
--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -11,6 +11,7 @@ wd_cc_library(
     srcs = glob(
         ["*.c++"],
         exclude = [
+            "worker-interface.c++",
             "*-test.c++",
             "trace.c++",
         ],
@@ -32,11 +33,17 @@ wd_cc_library(
         # should be ok.
         #
         # TODO(soon): Fix this
+        exclude = [
+            "observer.h",
+            "worker-interface.h",
+        ],
     ) + ["//src/workerd/api:hdrs"],
     visibility = ["//visibility:public"],
     deps = [
         ":capnp",
+        ":observer",
         ":trace",
+        ":worker-interface",
         "//src/node",
         "//src/workerd/api:analytics-engine_capnp",
         "//src/workerd/api:r2-api_capnp",
@@ -61,6 +68,23 @@ wd_cc_library(
     ],
 )
 
+wd_cc_library(
+    name = "observer",
+    hdrs = ["observer.h"],
+    visibility = ["//visibility:public"],
+    deps = [":trace"],
+)
+
+wd_cc_library(
+    name = "worker-interface",
+    srcs = ["worker-interface.c++"],
+    hdrs = ["worker-interface.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":trace",
+        "@capnp-cpp//src/capnp/compat:http-over-capnp",
+    ],
+)
 
 wd_cc_capnp_library(
     name = "capnp",

--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -6,7 +6,7 @@
 
 #include "io-context.h"
 #include <workerd/io/trace.h>
-#include "worker-interface.h"
+#include <workerd/io/worker-interface.h>
 #include <kj/compat/http.h>
 
 namespace workerd {


### PR DESCRIPTION
They are commonly used without full io dependency