### PR TITLE
Add Node.js compat path module

### DIFF
--- a/samples/nodejs-compat/worker.js
+++ b/samples/nodejs-compat/worker.js
@@ -11,6 +11,19 @@ import {
   format,
 } from 'node:util';
 
+import { default as path } from 'node:path';
+
+console.log(path.resolve('a', 'b', 'c'));
+console.log(path.basename('/a/b/c/d.foo'));
+console.log(path.extname('/a/b/c/d.foo'));
+
+// Note that the path.win32 variants of the path API are not yet implemented.
+// While workerd is capable of running on Windows, we assume that the environment
+// is POSIX-like for now.
+throws(() => path.win32.resolve('a', 'b', 'c'), {
+  message: 'path.win32.resolve() is not implemented.'
+});
+
 // Callback function
 function doSomething(a, cb) {
   setTimeout(() => cb(null, a), 1);

--- a/src/node/internal/constants.ts
+++ b/src/node/internal/constants.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+export const CHAR_UPPERCASE_A = 65; /* A */
+export const CHAR_LOWERCASE_A = 97; /* a */
+export const CHAR_UPPERCASE_Z = 90; /* Z */
+export const CHAR_LOWERCASE_Z = 122; /* z */
+export const CHAR_UPPERCASE_C = 67; /* C */
+export const CHAR_LOWERCASE_B = 98; /* b */
+export const CHAR_LOWERCASE_E = 101; /* e */
+export const CHAR_LOWERCASE_N = 110; /* n */
+export const CHAR_DOT = 46; /* . */
+export const CHAR_FORWARD_SLASH = 47; /* / */
+export const CHAR_BACKWARD_SLASH = 92; /* \ */
+export const CHAR_VERTICAL_LINE = 124; /* | */
+export const CHAR_COLON = 58; /* : */
+export const CHAR_QUESTION_MARK = 63; /* ? */
+export const CHAR_UNDERSCORE = 95; /* _ */
+export const CHAR_LINE_FEED = 10; /* \n */
+export const CHAR_CARRIAGE_RETURN = 13; /* \r */
+export const CHAR_TAB = 9; /* \t */
+export const CHAR_FORM_FEED = 12; /* \f */
+export const CHAR_EXCLAMATION_MARK = 33; /* ! */
+export const CHAR_HASH = 35; /* # */
+export const CHAR_SPACE = 32; /*   */
+export const CHAR_NO_BREAK_SPACE = 160; /* \u00A0 */
+export const CHAR_ZERO_WIDTH_NOBREAK_SPACE = 65279; /* \uFEFF */
+export const CHAR_LEFT_SQUARE_BRACKET = 91; /* [ */
+export const CHAR_RIGHT_SQUARE_BRACKET = 93; /* ] */
+export const CHAR_LEFT_ANGLE_BRACKET = 60; /* < */
+export const CHAR_RIGHT_ANGLE_BRACKET = 62; /* > */
+export const CHAR_LEFT_CURLY_BRACKET = 123; /* { */
+export const CHAR_RIGHT_CURLY_BRACKET = 125; /* } */
+export const CHAR_HYPHEN_MINUS = 45; /* - */
+export const CHAR_PLUS = 43; /* + */
+export const CHAR_DOUBLE_QUOTE = 34; /* " */
+export const CHAR_SINGLE_QUOTE = 39; /* ' */
+export const CHAR_PERCENT = 37; /* % */
+export const CHAR_SEMICOLON = 59; /* ; */
+export const CHAR_CIRCUMFLEX_ACCENT = 94; /* ^ */
+export const CHAR_GRAVE_ACCENT = 96; /* ` */
+export const CHAR_AT = 64; /* @ */
+export const CHAR_AMPERSAND = 38; /* & */
+export const CHAR_EQUAL = 61; /* = */
+export const CHAR_0 = 48; /* 0 */
+export const CHAR_9 = 57; /* 9 */
+export const EOL = '\;';

--- a/src/node/internal/internal_path.ts
+++ b/src/node/internal/internal_path.ts
@@ -1,0 +1,640 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import {
+  CHAR_DOT,
+  CHAR_FORWARD_SLASH,
+} from 'node-internal:constants';
+
+import {
+  validateObject,
+  validateString,
+} from 'node-internal:validators';
+
+function isPosixPathSeparator(code : number) {
+  return code === CHAR_FORWARD_SLASH;
+}
+
+// Resolves . and .. elements in a path with directory names
+function normalizeString(path: string, allowAboveRoot: boolean, separator: string, isPathSeparator: (code:number) => boolean) {
+  let res = '';
+  let lastSegmentLength = 0;
+  let lastSlash = -1;
+  let dots = 0;
+  let code = 0;
+  for (let i = 0; i <= path.length; ++i) {
+    if (i < path.length)
+      code = path.charCodeAt(i);
+    else if (isPathSeparator(code))
+      break;
+    else
+      code = CHAR_FORWARD_SLASH;
+
+    if (isPathSeparator(code)) {
+      if (lastSlash === i - 1 || dots === 1) {
+        // NOOP
+      } else if (dots === 2) {
+        if (res.length < 2 || lastSegmentLength !== 2 ||
+            res.charCodeAt(res.length - 1) !== CHAR_DOT ||
+            res.charCodeAt(res.length - 2) !== CHAR_DOT) {
+          if (res.length > 2) {
+            const lastSlashIndex = res.lastIndexOf(separator);
+            if (lastSlashIndex === -1) {
+              res = '';
+              lastSegmentLength = 0;
+            } else {
+              res = res.slice(0, lastSlashIndex);
+              lastSegmentLength =
+                res.length - 1 - res.lastIndexOf(separator);
+            }
+            lastSlash = i;
+            dots = 0;
+            continue;
+          } else if (res.length !== 0) {
+            res = '';
+            lastSegmentLength = 0;
+            lastSlash = i;
+            dots = 0;
+            continue;
+          }
+        }
+        if (allowAboveRoot) {
+          res += res.length > 0 ? `${separator}..` : '..';
+          lastSegmentLength = 2;
+        }
+      } else {
+        if (res.length > 0)
+          res += `${separator}${path.slice(lastSlash + 1, i)}`;
+        else
+          res = path.slice(lastSlash + 1, i);
+        lastSegmentLength = i - lastSlash - 1;
+      }
+      lastSlash = i;
+      dots = 0;
+    } else if (code === CHAR_DOT && dots !== -1) {
+      ++dots;
+    } else {
+      dots = -1;
+    }
+  }
+  return res;
+}
+
+function formatExt(ext : string) {
+  return ext ? `${ext[0] === '.' ? '' : '.'}${ext}` : '';
+}
+
+/**
+ * @param {string} sep
+ * @param {{
+ *  dir?: string;
+ *  root?: string;
+ *  base?: string;
+ *  name?: string;
+ *  ext?: string;
+ *  }} pathObject
+ * @returns {string}
+ */
+
+type PathObject = {
+  dir?: string;
+  root?: string;
+  base?: string;
+  name?: string;
+  ext?: string;
+};
+
+function _format(sep : string, pathObject : PathObject) {
+  validateObject(pathObject, 'pathObject', {});
+  const dir = pathObject.dir || pathObject.root;
+  const base = pathObject.base ||
+    `${pathObject.name || ''}${formatExt(pathObject.ext!)}`;
+  if (!dir) {
+    return base;
+  }
+  return dir === pathObject.root ? `${dir}${base}` : `${dir}${sep}${base}`;
+}
+
+// We currently do not implement the path.win32 subset.
+const win32 = {
+  resolve(..._: [string[], string]) {
+    throw new Error('path.win32.resolve() is not implemented.');
+  },
+
+  normalize(_ : string) {
+    throw new Error('path.win32.normalize() is not implemented.');
+  },
+
+  isAbsolute(_ : string) {
+    throw new Error('path.win32.isAbsolute() is not implemented.');
+  },
+
+  join(..._ : string[]) {
+    throw new Error('path.win32.join() is not implemented.');
+  },
+
+  relative(_0 : string, _1 : string) {
+    throw new Error('path.win32.relative() is not implemented.');
+  },
+
+  toNamespacedPath(_ : string) {
+    throw new Error('path.win32.toNamedspacedPath() is not implemented.');
+  },
+
+  dirname(_ : string) {
+    throw new Error('path.win32.dirname() is not implemented.');
+  },
+
+  basename(_0 : string, _1? : string) {
+    throw new Error('path.win32.basename() is not implemented.');
+  },
+
+  extname(_ : string) {
+    throw new Error('path.win32.extname() is not implemented.');
+  },
+
+  format(_ : PathObject) {
+    throw new Error('path.win32.format() is not implemented.');
+  },
+
+  parse(_: string) {
+    throw new Error('path.win32.parse() is not implemented.');
+  },
+
+  sep: '\\',
+  delimiter: ';',
+  win32: null as Object|null,
+  posix: null as Object|null,
+};
+
+const posix = {
+  /**
+   * path.resolve([from ...], to)
+   * @param {...string} args
+   * @returns {string}
+   */
+  resolve(...args: string[]) {
+    let resolvedPath = '';
+    let resolvedAbsolute = false;
+
+    for (let i = args.length - 1; i >= -1 && !resolvedAbsolute; i--) {
+      const path = i >= 0 ? args[i] : '/';
+
+      validateString(path, 'path');
+
+      // Skip empty entries
+      if (path!.length === 0) {
+        continue;
+      }
+
+      resolvedPath = `${path}/${resolvedPath}`;
+      resolvedAbsolute = path!.charCodeAt(0) === CHAR_FORWARD_SLASH;
+    }
+
+    // At this point the path should be resolved to a full absolute path, but
+    // handle relative paths to be safe (might happen when process.cwd() fails)
+
+    // Normalize the path
+    resolvedPath = normalizeString(resolvedPath, !resolvedAbsolute, '/',
+                                   isPosixPathSeparator);
+
+    if (resolvedAbsolute) {
+      return `/${resolvedPath}`;
+    }
+    return resolvedPath.length > 0 ? resolvedPath : '.';
+  },
+
+  /**
+   * @param {string} path
+   * @returns {string}
+   */
+  normalize(path : string) {
+    validateString(path, 'path');
+
+    if (path.length === 0)
+      return '.';
+
+    const isAbsolute = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+    const trailingSeparator = path.charCodeAt(path.length - 1) === CHAR_FORWARD_SLASH;
+
+    // Normalize the path
+    path = normalizeString(path, !isAbsolute, '/', isPosixPathSeparator);
+
+    if (path.length === 0) {
+      if (isAbsolute)
+        return '/';
+      return trailingSeparator ? './' : '.';
+    }
+    if (trailingSeparator)
+      path += '/';
+
+    return isAbsolute ? `/${path}` : path;
+  },
+
+  /**
+   * @param {string} path
+   * @returns {boolean}
+   */
+  isAbsolute(path : string) {
+    validateString(path, 'path');
+    return path.length > 0 && path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+  },
+
+  /**
+   * @param {...string} args
+   * @returns {string}
+   */
+  join(...args : string[]) {
+    if (args.length === 0)
+      return '.';
+    let joined;
+    for (let i = 0; i < args.length; ++i) {
+      const arg = args[i];
+      validateString(arg, 'path');
+      if (arg!.length > 0) {
+        if (joined === undefined)
+          joined = arg;
+        else
+          joined += `/${arg}`;
+      }
+    }
+    if (joined === undefined)
+      return '.';
+    return posix.normalize(joined);
+  },
+
+  /**
+   * @param {string} from
+   * @param {string} to
+   * @returns {string}
+   */
+  relative(from: string, to : string) {
+    validateString(from, 'from');
+    validateString(to, 'to');
+
+    if (from === to)
+      return '';
+
+    // Trim leading forward slashes.
+    from = posix.resolve(from);
+    to = posix.resolve(to);
+
+    if (from === to)
+      return '';
+
+    const fromStart = 1;
+    const fromEnd = from.length;
+    const fromLen = fromEnd - fromStart;
+    const toStart = 1;
+    const toLen = to.length - toStart;
+
+    // Compare paths to find the longest common path from root
+    const length = (fromLen < toLen ? fromLen : toLen);
+    let lastCommonSep = -1;
+    let i = 0;
+    for (; i < length; i++) {
+      const fromCode = from.charCodeAt(fromStart + i);
+      if (fromCode !== to.charCodeAt(toStart + i))
+        break;
+      else if (fromCode === CHAR_FORWARD_SLASH)
+        lastCommonSep = i;
+    }
+    if (i === length) {
+      if (toLen > length) {
+        if (to.charCodeAt(toStart + i) === CHAR_FORWARD_SLASH) {
+          // We get here if `from` is the exact base path for `to`.
+          // For example: from='/foo/bar'; to='/foo/bar/baz'
+          return to.slice(toStart + i + 1);
+        }
+        if (i === 0) {
+          // We get here if `from` is the root
+          // For example: from='/'; to='/foo'
+          return to.slice(toStart + i);
+        }
+      } else if (fromLen > length) {
+        if (from.charCodeAt(fromStart + i) === CHAR_FORWARD_SLASH) {
+          // We get here if `to` is the exact base path for `from`.
+          // For example: from='/foo/bar/baz'; to='/foo/bar'
+          lastCommonSep = i;
+        } else if (i === 0) {
+          // We get here if `to` is the root.
+          // For example: from='/foo/bar'; to='/'
+          lastCommonSep = 0;
+        }
+      }
+    }
+
+    let out = '';
+    // Generate the relative path based on the path difference between `to`
+    // and `from`.
+    for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i) {
+      if (i === fromEnd || from.charCodeAt(i) === CHAR_FORWARD_SLASH) {
+        out += out.length === 0 ? '..' : '/..';
+      }
+    }
+
+    // Lastly, append the rest of the destination (`to`) path that comes after
+    // the common path parts.
+    return `${out}${to.slice(toStart + lastCommonSep)}`;
+  },
+
+  /**
+   * @param {string} path
+   * @returns {string}
+   */
+  toNamespacedPath(path : string) {
+    // Non-op on posix systems
+    return path;
+  },
+
+  /**
+   * @param {string} path
+   * @returns {string}
+   */
+  dirname(path : string) {
+    validateString(path, 'path');
+    if (path.length === 0)
+      return '.';
+    const hasRoot = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+    let end = -1;
+    let matchedSlash = true;
+    for (let i = path.length - 1; i >= 1; --i) {
+      if (path.charCodeAt(i) === CHAR_FORWARD_SLASH) {
+        if (!matchedSlash) {
+          end = i;
+          break;
+        }
+      } else {
+        // We saw the first non-path separator
+        matchedSlash = false;
+      }
+    }
+
+    if (end === -1)
+      return hasRoot ? '/' : '.';
+    if (hasRoot && end === 1)
+      return '//';
+    return path.slice(0, end);
+  },
+
+  /**
+   * @param {string} path
+   * @param {string} [suffix]
+   * @returns {string}
+   */
+  basename(path : string, suffix? : string) {
+    if (suffix !== undefined)
+      validateString(suffix, 'ext');
+    validateString(path, 'path');
+
+    let start = 0;
+    let end = -1;
+    let matchedSlash = true;
+
+    if (suffix !== undefined && suffix.length > 0 && suffix.length <= path.length) {
+      if (suffix === path)
+        return '';
+      let extIdx = suffix.length - 1;
+      let firstNonSlashEnd = -1;
+      for (let i = path.length - 1; i >= 0; --i) {
+        const code = path.charCodeAt(i);
+        if (code === CHAR_FORWARD_SLASH) {
+          // If we reached a path separator that was not part of a set of path
+          // separators at the end of the string, stop now
+          if (!matchedSlash) {
+            start = i + 1;
+            break;
+          }
+        } else {
+          if (firstNonSlashEnd === -1) {
+            // We saw the first non-path separator, remember this index in case
+            // we need it if the extension ends up not matching
+            matchedSlash = false;
+            firstNonSlashEnd = i + 1;
+          }
+          if (extIdx >= 0) {
+            // Try to match the explicit extension
+            if (code === suffix.charCodeAt(extIdx)) {
+              if (--extIdx === -1) {
+                // We matched the extension, so mark this as the end of our path
+                // component
+                end = i;
+              }
+            } else {
+              // Extension does not match, so our result is the entire path
+              // component
+              extIdx = -1;
+              end = firstNonSlashEnd;
+            }
+          }
+        }
+      }
+
+      if (start === end)
+        end = firstNonSlashEnd;
+      else if (end === -1)
+        end = path.length;
+      return path.slice(start, end);
+    }
+    for (let i = path.length - 1; i >= 0; --i) {
+      if (path.charCodeAt(i) === CHAR_FORWARD_SLASH) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          start = i + 1;
+          break;
+        }
+      } else if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // path component
+        matchedSlash = false;
+        end = i + 1;
+      }
+    }
+
+    if (end === -1)
+      return '';
+    return path.slice(start, end);
+  },
+
+  /**
+   * @param {string} path
+   * @returns {string}
+   */
+  extname(path : string) {
+    validateString(path, 'path');
+    let startDot = -1;
+    let startPart = 0;
+    let end = -1;
+    let matchedSlash = true;
+    // Track the state of characters (if any) we see before our first dot and
+    // after any path separator we find
+    let preDotState = 0;
+    for (let i = path.length - 1; i >= 0; --i) {
+      const code = path.charCodeAt(i);
+      if (code === CHAR_FORWARD_SLASH) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          startPart = i + 1;
+          break;
+        }
+        continue;
+      }
+      if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // extension
+        matchedSlash = false;
+        end = i + 1;
+      }
+      if (code === CHAR_DOT) {
+        // If this is our first dot, mark it as the start of our extension
+        if (startDot === -1)
+          startDot = i;
+        else if (preDotState !== 1)
+          preDotState = 1;
+      } else if (startDot !== -1) {
+        // We saw a non-dot and non-path separator before our dot, so we should
+        // have a good chance at having a non-empty extension
+        preDotState = -1;
+      }
+    }
+
+    if (startDot === -1 ||
+        end === -1 ||
+        // We saw a non-dot character immediately before the dot
+        preDotState === 0 ||
+        // The (right-most) trimmed path component is exactly '..'
+        (preDotState === 1 &&
+         startDot === end - 1 &&
+         startDot === startPart + 1)) {
+      return '';
+    }
+    return path.slice(startDot, end);
+  },
+
+  format: _format.bind(null, '/'),
+
+  /**
+   * @param {string} path
+   * @returns {{
+   *   dir: string;
+   *   root: string;
+   *   base: string;
+   *   name: string;
+   *   ext: string;
+   *   }}
+   */
+  parse(path: string) : PathObject {
+    validateString(path, 'path');
+
+    const ret = { root: '', dir: '', base: '', ext: '', name: '' };
+    if (path.length === 0)
+      return ret;
+    const isAbsolute =
+      path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+    let start;
+    if (isAbsolute) {
+      ret.root = '/';
+      start = 1;
+    } else {
+      start = 0;
+    }
+    let startDot = -1;
+    let startPart = 0;
+    let end = -1;
+    let matchedSlash = true;
+    let i = path.length - 1;
+
+    // Track the state of characters (if any) we see before our first dot and
+    // after any path separator we find
+    let preDotState = 0;
+
+    // Get non-dir info
+    for (; i >= start; --i) {
+      const code = path.charCodeAt(i);
+      if (code === CHAR_FORWARD_SLASH) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          startPart = i + 1;
+          break;
+        }
+        continue;
+      }
+      if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // extension
+        matchedSlash = false;
+        end = i + 1;
+      }
+      if (code === CHAR_DOT) {
+        // If this is our first dot, mark it as the start of our extension
+        if (startDot === -1)
+          startDot = i;
+        else if (preDotState !== 1)
+          preDotState = 1;
+      } else if (startDot !== -1) {
+        // We saw a non-dot and non-path separator before our dot, so we should
+        // have a good chance at having a non-empty extension
+        preDotState = -1;
+      }
+    }
+
+    if (end !== -1) {
+      const start = startPart === 0 && isAbsolute ? 1 : startPart;
+      if (startDot === -1 ||
+          // We saw a non-dot character immediately before the dot
+          preDotState === 0 ||
+          // The (right-most) trimmed path component is exactly '..'
+          (preDotState === 1 &&
+          startDot === end - 1 &&
+          startDot === startPart + 1)) {
+        ret.base = ret.name = path.slice(start, end);
+      } else {
+        ret.name = path.slice(start, startDot);
+        ret.base = path.slice(start, end);
+        ret.ext = path.slice(startDot, end);
+      }
+    }
+
+    if (startPart > 0)
+      ret.dir = path.slice(0, startPart - 1);
+    else if (isAbsolute)
+      ret.dir = '/';
+
+    return ret;
+  },
+
+  sep: '/',
+  delimiter: ':',
+  win32: null as Object|null,
+  posix: null as Object|null,
+};
+
+posix.win32 = win32.win32 = win32;
+posix.posix = win32.posix = posix;
+
+export default posix;
+export { posix, win32 };

--- a/src/node/path.ts
+++ b/src/node/path.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+
+/* eslint-disable */
+
+import {
+  posix,
+  win32,
+} from 'node-internal:internal_path';
+
+const {
+  resolve,
+  normalize,
+  isAbsolute,
+  join,
+  relative,
+  toNamespacedPath,
+  dirname,
+  basename,
+  extname,
+  format,
+  parse,
+  sep,
+  delimiter,
+} = posix;
+
+export {
+  resolve,
+  normalize,
+  isAbsolute,
+  join,
+  relative,
+  toNamespacedPath,
+  dirname,
+  basename,
+  extname,
+  format,
+  parse,
+  sep,
+  delimiter,
+  posix,
+  win32,
+};
+
+export { default } from 'node-internal:internal_path';

--- a/src/node/path/posix.ts
+++ b/src/node/path/posix.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+
+import { posix } from 'node-internal:internal_path';
+export default posix;

--- a/src/node/path/win32.ts
+++ b/src/node/path/win32.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+
+import { win32 } from 'node-internal:internal_path';
+export default win32;

--- a/src/workerd/api/node/path-test.js
+++ b/src/workerd/api/node/path-test.js
@@ -1,0 +1,543 @@
+import {
+  deepEqual,
+  deepStrictEqual,
+  doesNotMatch,
+  doesNotReject,
+  doesNotThrow,
+  equal,
+  fail,
+  ifError,
+  match,
+  notDeepEqual,
+  notDeepStrictEqual,
+  notEqual,
+  notStrictEqual,
+  ok,
+  rejects,
+  strictEqual,
+  throws,
+} from 'node:assert';
+
+import { default as path } from 'node:path';
+
+export const test_path = {
+  test(ctrl, env, ctx) {
+
+    // Test thrown TypeErrors
+    const typeErrorTests = [true, false, 7, null, {}, undefined, [], NaN];
+
+    function fail(fn) {
+      const args = Array.from(arguments).slice(1);
+
+      throws(() => {
+        fn.apply(null, args);
+      }, { code: 'ERR_INVALID_ARG_TYPE', name: 'TypeError' });
+    }
+
+    typeErrorTests.forEach((test) => {
+      [path.posix].forEach((namespace) => {
+        fail(namespace.join, test);
+        fail(namespace.resolve, test);
+        fail(namespace.normalize, test);
+        fail(namespace.isAbsolute, test);
+        fail(namespace.relative, test, 'foo');
+        fail(namespace.relative, 'foo', test);
+        fail(namespace.parse, test);
+        fail(namespace.dirname, test);
+        fail(namespace.basename, test);
+        fail(namespace.extname, test);
+
+        // Undefined is a valid value as the second argument to basename
+        if (test !== undefined) {
+          fail(namespace.basename, 'foo', test);
+        }
+      });
+    });
+
+    // path.sep tests
+    // windows
+    strictEqual(path.win32.sep, '\\');
+    // posix
+    strictEqual(path.posix.sep, '/');
+
+    // path.delimiter tests
+    // windows
+    strictEqual(path.win32.delimiter, ';');
+    // posix
+    strictEqual(path.posix.delimiter, ':');
+
+    strictEqual(path, path.posix);
+  }
+};
+
+export const test_path_zero_length_strings = {
+  test(ctrl, env, ctx) {
+    // Join will internally ignore all the zero-length strings and it will return
+    // '.' if the joined string is a zero-length string.
+    strictEqual(path.posix.join(''), '.');
+    strictEqual(path.posix.join('', ''), '.');
+    strictEqual(path.join('/'), '/');
+    strictEqual(path.join('/', ''), '/');
+
+    // Normalize will return '.' if the input is a zero-length string
+    strictEqual(path.posix.normalize(''), '.');
+    strictEqual(path.normalize('/'), '/');
+
+    // Since '' is not a valid path in any of the common environments, return false
+    strictEqual(path.posix.isAbsolute(''), false);
+
+    // Resolve, internally ignores all the zero-length strings and returns the
+    // current working directory
+    strictEqual(path.resolve(''), '/');
+    strictEqual(path.resolve('', ''), '/');
+
+    // Relative, internally calls resolve. So, '' is actually the current directory
+    strictEqual(path.relative('', '/'), '');
+    strictEqual(path.relative('/', ''), '');
+    strictEqual(path.relative('/', '/'), '');
+  }
+};
+
+export const test_path_resolve = {
+  test(ctrl, env, ctx) {
+    const failures = [];
+    const posixyCwd = '/';
+
+    const resolveTests = [
+      [['/var/lib', '../', 'file/'], '/var/file'],
+      [['/var/lib', '/../', 'file/'], '/file'],
+      [['a/b/c/', '../../..'], posixyCwd],
+      [['.'], posixyCwd],
+      [['/some/dir', '.', '/absolute/'], '/absolute'],
+      [['/foo/tmp.3/', '../tmp.3/cycles/root.js'], '/foo/tmp.3/cycles/root.js'],
+    ];
+    resolveTests.forEach(([test, expected]) => {
+        const actual = path.resolve.apply(null, test);
+        const message =
+          `path.posix.resolve(${test.map(JSON.stringify).join(',')})\n  expect=${
+            JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
+        if (actual !== expected)
+          failures.push(message);
+    });
+    strictEqual(failures.length, 0, failures.join('\n'));
+  }
+}
+
+export const test_path_relative = {
+  test(ctrl, env, ctx) {
+    const failures = [];
+
+    const relativeTests = [
+      ['/var/lib', '/var', '..'],
+      ['/var/lib', '/bin', '../../bin'],
+      ['/var/lib', '/var/lib', ''],
+      ['/var/lib', '/var/apache', '../apache'],
+      ['/var/', '/var/lib', 'lib'],
+      ['/', '/var/lib', 'var/lib'],
+      ['/foo/test', '/foo/test/bar/package.json', 'bar/package.json'],
+      ['/Users/a/web/b/test/mails', '/Users/a/web/b', '../..'],
+      ['/foo/bar/baz-quux', '/foo/bar/baz', '../baz'],
+      ['/foo/bar/baz', '/foo/bar/baz-quux', '../baz-quux'],
+      ['/baz-quux', '/baz', '../baz'],
+      ['/baz', '/baz-quux', '../baz-quux'],
+      ['/page1/page2/foo', '/', '../../..'],
+    ];
+    relativeTests.forEach((test) => {
+      const actual = path.relative(test[0], test[1]);
+      const expected = test[2];
+      if (actual !== expected) {
+        const message = `path.posix.relative(${
+          test.slice(0, 2).map(JSON.stringify).join(',')})\n  expect=${
+          JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
+        failures.push(`\n${message}`);
+      }
+    });
+    strictEqual(failures.length, 0, failures.join(''));
+  }
+};
+
+export const test_path_parse_format = {
+  test(ctrl, env, ctx) {
+    const unixPaths = [
+      // [path, root]
+      ['/home/user/dir/file.txt', '/'],
+      ['/home/user/a dir/another File.zip', '/'],
+      ['/home/user/a dir//another&File.', '/'],
+      ['/home/user/a$$$dir//another File.zip', '/'],
+      ['user/dir/another File.zip', ''],
+      ['file', ''],
+      ['.\\file', ''],
+      ['./file', ''],
+      ['C:\\foo', ''],
+      ['/', '/'],
+      ['', ''],
+      ['.', ''],
+      ['..', ''],
+      ['/foo', '/'],
+      ['/foo.', '/'],
+      ['/foo.bar', '/'],
+      ['/.', '/'],
+      ['/.foo', '/'],
+      ['/.foo.bar', '/'],
+      ['/foo/bar.baz', '/'],
+    ];
+
+    const unixSpecialCaseFormatTests = [
+      [{ dir: 'some/dir' }, 'some/dir/'],
+      [{ base: 'index.html' }, 'index.html'],
+      [{ root: '/' }, '/'],
+      [{ name: 'index', ext: '.html' }, 'index.html'],
+      [{ dir: 'some/dir', name: 'index', ext: '.html' }, 'some/dir/index.html'],
+      [{ root: '/', name: 'index', ext: '.html' }, '/index.html'],
+      [{}, ''],
+    ];
+
+    const errors = [
+      { method: 'parse', input: [null] },
+      { method: 'parse', input: [{}] },
+      { method: 'parse', input: [true] },
+      { method: 'parse', input: [1] },
+      { method: 'parse', input: [] },
+      { method: 'format', input: [null] },
+      { method: 'format', input: [''] },
+      { method: 'format', input: [true] },
+      { method: 'format', input: [1] },
+    ];
+
+    checkParseFormat(unixPaths);
+    checkErrors();
+    checkFormat(unixSpecialCaseFormatTests);
+
+    // Test removal of trailing path separators
+    const trailingTests = [
+      ['./', { root: '', dir: '', base: '.', ext: '', name: '.' }],
+      ['//', { root: '/', dir: '/', base: '', ext: '', name: '' }],
+      ['///', { root: '/', dir: '/', base: '', ext: '', name: '' }],
+      ['/foo///', { root: '/', dir: '/', base: 'foo', ext: '', name: 'foo' }],
+      ['/foo///bar.baz',
+       { root: '/', dir: '/foo//', base: 'bar.baz', ext: '.baz', name: 'bar' },
+      ],
+    ];
+    const failures = [];
+    trailingTests.forEach((test) => {
+      const actual = path.parse(test[0]);
+      const expected = test[1];
+      const message = `path.posix.parse(${JSON.stringify(test[0])})\n  expect=${
+        JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
+      const actualKeys = Object.keys(actual);
+      const expectedKeys = Object.keys(expected);
+      let failed = (actualKeys.length !== expectedKeys.length);
+      if (!failed) {
+        for (let i = 0; i < actualKeys.length; ++i) {
+          const key = actualKeys[i];
+          if (!expectedKeys.includes(key) || actual[key] !== expected[key]) {
+            failed = true;
+            break;
+          }
+        }
+      }
+      if (failed)
+        failures.push(`\n${message}`);
+    });
+    strictEqual(failures.length, 0, failures.join(''));
+
+    function checkErrors() {
+      errors.forEach(({ method, input }) => {
+        throws(() => {
+          path[method].apply(path, input);
+        }, {
+          code: 'ERR_INVALID_ARG_TYPE',
+          name: 'TypeError'
+        });
+      });
+    }
+
+    function checkParseFormat(paths) {
+      paths.forEach(([element, root]) => {
+        const output = path.parse(element);
+        strictEqual(typeof output.root, 'string');
+        strictEqual(typeof output.dir, 'string');
+        strictEqual(typeof output.base, 'string');
+        strictEqual(typeof output.ext, 'string');
+        strictEqual(typeof output.name, 'string');
+        strictEqual(path.format(output), element);
+        strictEqual(output.root, root);
+        ok(output.dir.startsWith(output.root));
+        strictEqual(output.dir, output.dir ? path.dirname(element) : '');
+        strictEqual(output.base, path.basename(element));
+        strictEqual(output.ext, path.extname(element));
+      });
+    }
+
+    function checkFormat(testCases) {
+      testCases.forEach(([element, expect]) => {
+        strictEqual(path.format(element), expect);
+      });
+
+      [null, undefined, 1, true, false, 'string'].forEach((pathObject) => {
+        throws(() => {
+          path.format(pathObject);
+        }, {
+          code: 'ERR_INVALID_ARG_TYPE',
+          name: 'TypeError',
+        });
+      });
+    }
+
+    // See https://github.com/nodejs/node/issues/44343
+    strictEqual(path.format({ name: 'x', ext: 'png' }), 'x.png');
+    strictEqual(path.format({ name: 'x', ext: '.png' }), 'x.png');
+  }
+};
+
+export const test_path_normalize = {
+  test(ctrl, env, ctx) {
+    strictEqual(path.posix.normalize('./fixtures///b/../b/c.js'), 'fixtures/b/c.js');
+    strictEqual(path.posix.normalize('/foo/../../../bar'), '/bar');
+    strictEqual(path.posix.normalize('a//b//../b'), 'a/b');
+    strictEqual(path.posix.normalize('a//b//./c'), 'a/b/c');
+    strictEqual(path.posix.normalize('a//b//.'), 'a/b');
+    strictEqual(path.posix.normalize('/a/b/c/../../../x/y/z'), '/x/y/z');
+    strictEqual(path.posix.normalize('///..//./foo/.//bar'), '/foo/bar');
+    strictEqual(path.posix.normalize('bar/foo../../'), 'bar/');
+    strictEqual(path.posix.normalize('bar/foo../..'), 'bar');
+    strictEqual(path.posix.normalize('bar/foo../../baz'), 'bar/baz');
+    strictEqual(path.posix.normalize('bar/foo../'), 'bar/foo../');
+    strictEqual(path.posix.normalize('bar/foo..'), 'bar/foo..');
+    strictEqual(path.posix.normalize('../foo../../../bar'), '../../bar');
+    strictEqual(path.posix.normalize('../.../.././.../../../bar'),
+        '../../bar');
+    strictEqual(path.posix.normalize('../../../foo/../../../bar'),
+        '../../../../../bar');
+    strictEqual(path.posix.normalize('../../../foo/../../../bar/../../'),
+        '../../../../../../');
+    strictEqual(path.posix.normalize('../foobar/barfoo/foo/../../../bar/../../'),
+                '../../');
+    strictEqual(path.posix.normalize('../.../../foobar/../../../bar/../../baz'),
+                '../../../../baz');
+    strictEqual(path.posix.normalize('foo/bar\\baz'), 'foo/bar\\baz');
+  }
+};
+
+export const test_path_join = {
+  test(ctrl, env, ctx) {
+    const failures = [];
+    const backslashRE = /\\/g;
+
+    const joinTests = [
+      [['.', 'x/b', '..', '/b/c.js'], 'x/b/c.js'],
+      [[], '.'],
+      [['/.', 'x/b', '..', '/b/c.js'], '/x/b/c.js'],
+      [['/foo', '../../../bar'], '/bar'],
+      [['foo', '../../../bar'], '../../bar'],
+      [['foo/', '../../../bar'], '../../bar'],
+      [['foo/x', '../../../bar'], '../bar'],
+      [['foo/x', './bar'], 'foo/x/bar'],
+      [['foo/x/', './bar'], 'foo/x/bar'],
+      [['foo/x/', '.', 'bar'], 'foo/x/bar'],
+      [['./'], './'],
+      [['.', './'], './'],
+      [['.', '.', '.'], '.'],
+      [['.', './', '.'], '.'],
+      [['.', '/./', '.'], '.'],
+      [['.', '/////./', '.'], '.'],
+      [['.'], '.'],
+      [['', '.'], '.'],
+      [['', 'foo'], 'foo'],
+      [['foo', '/bar'], 'foo/bar'],
+      [['', '/foo'], '/foo'],
+      [['', '', '/foo'], '/foo'],
+      [['', '', 'foo'], 'foo'],
+      [['foo', ''], 'foo'],
+      [['foo/', ''], 'foo/'],
+      [['foo', '', '/bar'], 'foo/bar'],
+      [['./', '..', '/foo'], '../foo'],
+      [['./', '..', '..', '/foo'], '../../foo'],
+      [['.', '..', '..', '/foo'], '../../foo'],
+      [['', '..', '..', '/foo'], '../../foo'],
+      [['/'], '/'],
+      [['/', '.'], '/'],
+      [['/', '..'], '/'],
+      [['/', '..', '..'], '/'],
+      [[''], '.'],
+      [['', ''], '.'],
+      [[' /foo'], ' /foo'],
+      [[' ', 'foo'], ' /foo'],
+      [[' ', '.'], ' '],
+      [[' ', '/'], ' /'],
+      [[' ', ''], ' '],
+      [['/', 'foo'], '/foo'],
+      [['/', '/foo'], '/foo'],
+      [['/', '//foo'], '/foo'],
+      [['/', '', '/foo'], '/foo'],
+      [['', '/', 'foo'], '/foo'],
+      [['', '/', '/foo'], '/foo'],
+    ];
+
+    joinTests.forEach((test) => {
+      const actual = path.join.apply(null, test[0]);
+      const expected = test[1];
+      if (actual !== expected && actualAlt !== expected) {
+        const delimiter = test[0].map(JSON.stringify).join(',');
+        const message = `path.posix.join(${delimiter})\n  expect=${
+          JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
+        failures.push(`\n${message}`);
+      }
+    });
+    strictEqual(failures.length, 0, failures.join(''));
+  }
+};
+
+export const test_path_isabsolute = {
+  test(ctrl, env, ctx) {
+    strictEqual(path.posix.isAbsolute('/home/foo'), true);
+    strictEqual(path.posix.isAbsolute('/home/foo/..'), true);
+    strictEqual(path.posix.isAbsolute('bar/'), false);
+    strictEqual(path.posix.isAbsolute('./baz'), false);
+    strictEqual(path.isAbsolute('/home/foo'), true);
+    strictEqual(path.isAbsolute('/home/foo/..'), true);
+    strictEqual(path.isAbsolute('bar/'), false);
+    strictEqual(path.isAbsolute('./baz'), false);
+  }
+};
+
+export const test_path_extname = {
+  test(ctrl, env, ctx) {
+    const failures = [];
+    const slashRE = /\//g;
+
+    [
+      ['', ''],
+      ['/path/to/file', ''],
+      ['/path/to/file.ext', '.ext'],
+      ['/path.to/file.ext', '.ext'],
+      ['/path.to/file', ''],
+      ['/path.to/.file', ''],
+      ['/path.to/.file.ext', '.ext'],
+      ['/path/to/f.ext', '.ext'],
+      ['/path/to/..ext', '.ext'],
+      ['/path/to/..', ''],
+      ['file', ''],
+      ['file.ext', '.ext'],
+      ['.file', ''],
+      ['.file.ext', '.ext'],
+      ['/file', ''],
+      ['/file.ext', '.ext'],
+      ['/.file', ''],
+      ['/.file.ext', '.ext'],
+      ['.path/file.ext', '.ext'],
+      ['file.ext.ext', '.ext'],
+      ['file.', '.'],
+      ['.', ''],
+      ['./', ''],
+      ['.file.ext', '.ext'],
+      ['.file', ''],
+      ['.file.', '.'],
+      ['.file..', '.'],
+      ['..', ''],
+      ['../', ''],
+      ['..file.ext', '.ext'],
+      ['..file', '.file'],
+      ['..file.', '.'],
+      ['..file..', '.'],
+      ['...', '.'],
+      ['...ext', '.ext'],
+      ['....', '.'],
+      ['file.ext/', '.ext'],
+      ['file.ext//', '.ext'],
+      ['file/', ''],
+      ['file//', ''],
+      ['file./', '.'],
+      ['file.//', '.'],
+    ].forEach((test) => {
+      const expected = test[1];
+      const actual = path.extname(test[0]);
+      const message = `path.posix.extname(${JSON.stringify(test[0])})\n  expect=${
+        JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
+      if (actual !== expected)
+        failures.push(`\n${message}`);
+    });
+
+    strictEqual(failures.length, 0, failures.join(''));
+
+    // On *nix, backslash is a valid name component like any other character.
+    strictEqual(path.posix.extname('.\\'), '');
+    strictEqual(path.posix.extname('..\\'), '.\\');
+    strictEqual(path.posix.extname('file.ext\\'), '.ext\\');
+    strictEqual(path.posix.extname('file.ext\\\\'), '.ext\\\\');
+    strictEqual(path.posix.extname('file\\'), '');
+    strictEqual(path.posix.extname('file\\\\'), '');
+    strictEqual(path.posix.extname('file.\\'), '.\\');
+    strictEqual(path.posix.extname('file.\\\\'), '.\\\\');
+  }
+};
+
+export const test_path_dirname = {
+  test(ctrl, env, ctx) {
+    strictEqual(path.posix.dirname('/a/b/'), '/a');
+    strictEqual(path.posix.dirname('/a/b'), '/a');
+    strictEqual(path.posix.dirname('/a'), '/');
+    strictEqual(path.posix.dirname(''), '.');
+    strictEqual(path.posix.dirname('/'), '/');
+    strictEqual(path.posix.dirname('////'), '/');
+    strictEqual(path.posix.dirname('//a'), '//');
+    strictEqual(path.posix.dirname('foo'), '.');
+    strictEqual(path.dirname('/a/b/'), '/a');
+    strictEqual(path.dirname('/a/b'), '/a');
+    strictEqual(path.dirname('/a'), '/');
+    strictEqual(path.dirname(''), '.');
+    strictEqual(path.dirname('/'), '/');
+    strictEqual(path.dirname('////'), '/');
+    strictEqual(path.dirname('//a'), '//');
+    strictEqual(path.dirname('foo'), '.');
+  }
+};
+
+export const test_path_basename = {
+  test(ctrl, env, ctx) {
+    strictEqual(path.basename('.js', '.js'), '');
+    strictEqual(path.basename('js', '.js'), 'js');
+    strictEqual(path.basename('file.js', '.ts'), 'file.js');
+    strictEqual(path.basename('file', '.js'), 'file');
+    strictEqual(path.basename('file.js.old', '.js.old'), 'file');
+    strictEqual(path.basename(''), '');
+    strictEqual(path.basename('/dir/basename.ext'), 'basename.ext');
+    strictEqual(path.basename('/basename.ext'), 'basename.ext');
+    strictEqual(path.basename('basename.ext'), 'basename.ext');
+    strictEqual(path.basename('basename.ext/'), 'basename.ext');
+    strictEqual(path.basename('basename.ext//'), 'basename.ext');
+    strictEqual(path.basename('aaa/bbb', '/bbb'), 'bbb');
+    strictEqual(path.basename('aaa/bbb', 'a/bbb'), 'bbb');
+    strictEqual(path.basename('aaa/bbb', 'bbb'), 'bbb');
+    strictEqual(path.basename('aaa/bbb//', 'bbb'), 'bbb');
+    strictEqual(path.basename('aaa/bbb', 'bb'), 'b');
+    strictEqual(path.basename('aaa/bbb', 'b'), 'bb');
+    strictEqual(path.basename('/aaa/bbb', '/bbb'), 'bbb');
+    strictEqual(path.basename('/aaa/bbb', 'a/bbb'), 'bbb');
+    strictEqual(path.basename('/aaa/bbb', 'bbb'), 'bbb');
+    strictEqual(path.basename('/aaa/bbb//', 'bbb'), 'bbb');
+    strictEqual(path.basename('/aaa/bbb', 'bb'), 'b');
+    strictEqual(path.basename('/aaa/bbb', 'b'), 'bb');
+    strictEqual(path.basename('/aaa/bbb'), 'bbb');
+    strictEqual(path.basename('/aaa/'), 'aaa');
+    strictEqual(path.basename('/aaa/b'), 'b');
+    strictEqual(path.basename('/a/b'), 'b');
+    strictEqual(path.basename('//a'), 'a');
+    strictEqual(path.basename('a', 'a'), '');
+
+    // On unix a backslash is just treated as any other character.
+    strictEqual(path.posix.basename('\\dir\\basename.ext'),
+                       '\\dir\\basename.ext');
+    strictEqual(path.posix.basename('\\basename.ext'), '\\basename.ext');
+    strictEqual(path.posix.basename('basename.ext'), 'basename.ext');
+    strictEqual(path.posix.basename('basename.ext\\'), 'basename.ext\\');
+    strictEqual(path.posix.basename('basename.ext\\\\'), 'basename.ext\\\\');
+    strictEqual(path.posix.basename('foo'), 'foo');
+
+    // POSIX filenames may include control characters
+    // c.f. http://www.dwheeler.com/essays/fixing-unix-linux-filenames.html
+    const controlCharFilename = `Icon${String.fromCharCode(13)}`;
+    strictEqual(path.posix.basename(`/a/b/${controlCharFilename}`),
+                       controlCharFilename);
+  }
+};

--- a/src/workerd/api/node/path-test.wd-test
+++ b/src/workerd/api/node/path-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "path-nodejs-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "path-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat"]
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
Implements only the path.posix variant. The path.win32 variant is present but all of the methods will throw an error if called.