### PR TITLE
Example showing that two DOs can have their own max_page_count limits

### DIFF
--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -463,6 +463,10 @@ bool SqliteDatabase::isAuthorized(int actionCode,
           return true;
         } else if (pragma == "foreign_keys") {
           return true;
+        } else if (pragma == "page_count") {
+          return true;
+        } else if (pragma == "max_page_count") {
+          return true;
         }
       }
 


### PR DESCRIPTION
We don't want users to be able to set `max_page_count`, but I _think_ this shows that each object's SQLite connection has its own limits, so we can use this to allow customisable data sizes (per object).