### PR TITLE
Deprecate tcp_sockets_support compat flag.

### DIFF
--- a/samples/tcp/config.capnp
+++ b/samples/tcp/config.capnp
@@ -27,7 +27,6 @@ const gopherWorker :Workerd.Worker = (
     (name = "worker", esModule = embed "gopher.js")
   ],
   compatibilityDate = "2023-02-28",
-  compatibilityFlags = ["tcp_sockets_support"],
   # In order to access our configured proxy we need to specify it as a binding. This will allow
   # it to be accessible via `env.proxy` in the JS script.
   bindings = [

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -481,9 +481,7 @@ public:
 
   JSG_RESOURCE_TYPE(Fetcher, CompatibilityFlags::Reader flags) {
     JSG_METHOD(fetch);
-    if (flags.getTcpSocketsSupport()) {
-      JSG_METHOD(connect);
-    }
+    JSG_METHOD(connect);
 
     if (flags.getServiceBindingExtraHandlers()) {
       JSG_METHOD(queue);

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -155,9 +155,6 @@ jsg::Ref<Socket> connectImpl(
     jsg::Lock& js, kj::Maybe<jsg::Ref<Fetcher>> fetcher, AnySocketAddress address,
     jsg::Optional<SocketOptions> options,
     CompatibilityFlags::Reader featureFlags) {
-  // `connect()` should be hidden when the feature flag is off, so we shouldn't even get here.
-  KJ_ASSERT(featureFlags.getTcpSocketsSupport());
-
   jsg::Ref<Fetcher> actualFetcher = nullptr;
   KJ_IF_MAYBE(f, fetcher) {
     actualFetcher = kj::mv(*f);

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -141,9 +141,7 @@ public:
   }
 
   JSG_RESOURCE_TYPE(SocketsModule, CompatibilityFlags::Reader flags) {
-    if (flags.getTcpSocketsSupport()) {
-      JSG_METHOD(connect);
-    }
+    JSG_METHOD(connect);
   }
 };
 

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -236,12 +236,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatDisableFlag("no_nodejs_compat");
   # Enables nodejs compat imports in the application.
 
-  tcpSocketsSupport @22 :Bool
-      $compatEnableFlag("tcp_sockets_support")
-      $experimental;
-  # Enables TCP sockets in workerd.
-  # These are still under development and therefore subject to change.
-  # WARNING: DO NOT depend on this feature as its API is still subject to change.
+  obsolete22 @22 :Bool
+      $compatEnableFlag("tcp_sockets_support");
+  # Used to enables TCP sockets in workerd.
 
   specCompliantResponseRedirect @23 :Bool
       $compatEnableDate("2023-03-14")


### PR DESCRIPTION
### Test Plan

```
$ bazel run @workerd//src/workerd/server:workerd -- serve $PWD/deps/workerd/samples/tcp/config.capnp --watch --verbose
$ curl localhost:8080
```