### PR TITLE
Fix more mistakes in SQLite allowlist.

### DIFF
--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -165,13 +165,11 @@ static constexpr kj::StringPtr ALLOWED_SQLITE_FUNCTIONS[] = {
   "stftime"_kj,
 
   // https://www.sqlite.org/lang_aggfunc.html
-  "aggfilter"_kj,
-  "aggfunclist"_kj,
   "avg"_kj,
   "count"_kj,
   "group_concat"_kj,
-  "max_agg"_kj,
-  "min_agg"_kj,
+  "max"_kj,
+  "min"_kj,
   "sum"_kj,
   "total"_kj,
 


### PR DESCRIPTION
Clearly the regex I used to process lang_aggfunc.html didn't work. Each of these document pages is formatted a little differently. Grr.