### PR TITLE
Implement performance.now/timeOrigin

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -711,4 +711,10 @@ jsg::Promise<jsg::Ref<Response>> ServiceWorkerGlobalScope::fetch(
   return fetchImpl(js, nullptr, kj::mv(requestOrUrl), kj::mv(requestInit), featureFlags);
 }
 
+double Performance::now() {
+  // Time never progresses outside of an IoContext.
+  if (!IoContext::hasCurrent()) return 0.0;
+  return IoContext::current().performanceNow();
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -38,6 +38,20 @@ public:
   }
 };
 
+class Performance: public jsg::Object {
+public:
+  double getTimeOrigin() { return 0.0; }
+  // We always return a time origin of 0. For us this represents the time at which the
+  // IoContext was created.
+
+  double now();
+
+  JSG_RESOURCE_TYPE(Performance) {
+    JSG_READONLY_INSTANCE_PROPERTY(timeOrigin, getTimeOrigin);
+    JSG_METHOD(now);
+  }
+};
+
 class PromiseRejectionEvent: public Event {
 public:
   PromiseRejectionEvent(
@@ -334,6 +348,10 @@ public:
     return jsg::alloc<Navigator>();
   }
 
+  jsg::Ref<Performance> getPerformance() {
+    return jsg::alloc<Performance>();
+  }
+
   jsg::Unimplemented getOrigin() { return {}; }
   // TODO(conform): A browser-side service worker returns the origin for the URL on which it was
   //   installed, e.g. https://www.example.com for a service worker downloaded from
@@ -386,6 +404,7 @@ public:
     JSG_LAZY_INSTANCE_PROPERTY(crypto, getCrypto);
     JSG_LAZY_INSTANCE_PROPERTY(caches, getCaches);
     JSG_LAZY_INSTANCE_PROPERTY(scheduler, getScheduler);
+    JSG_LAZY_INSTANCE_PROPERTY(performance, getPerformance);
     JSG_READONLY_INSTANCE_PROPERTY(origin, getOrigin);
 
     JSG_NESTED_TYPE(Event);
@@ -599,6 +618,7 @@ private:
   api::ExportedHandler,                                  \
   api::ServiceWorkerGlobalScope::StructuredCloneOptions, \
   api::PromiseRejectionEvent,                            \
-  api::Navigator
+  api::Navigator,                                        \
+  api::Performance
 // The list of global-scope.h types that are added to worker.c++'s JSG_DECLARE_ISOLATE_TYPE
 }  // namespace workerd::api

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -824,6 +824,15 @@ kj::Date IoContext::now() {
   return now(getCurrentIncomingRequest());
 }
 
+double IoContext::performanceNow() {
+  // If there are no incoming requests, this should always return 0.0.
+  // Otherwise, the time origin for an incoming request should always be set.
+  if (!incomingRequests.empty()) {
+    return (now() - kj::UNIX_EPOCH) / kj::NANOSECONDS * 1e-6;
+  }
+  return 0.0;
+}
+
 kj::Own<WorkerInterface> IoContext::getSubrequestNoChecks(
     kj::FunctionParam<kj::Own<WorkerInterface>(SpanBuilder&, IoChannelFactory&)> func,
     SubrequestOptions options) {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -699,6 +699,8 @@ public:
   kj::Date now();
   // Access the event loop's current time point. This will remain constant between ticks.
 
+  double performanceNow();
+
   kj::Promise<void> atTime(kj::Date when) { return getIoChannelFactory().getTimer().atTime(when); }
   // Returns a promise that resolves once `now() >= when`.
 

--- a/src/workerd/tests/performance-test.js
+++ b/src/workerd/tests/performance-test.js
@@ -1,0 +1,26 @@
+if (typeof globalThis.performance === 'undefined') {
+  throw new Error('performance is not defined');
+}
+
+if (globalThis.performance.timeOrigin !== 0.0) {
+  throw new Error('performance.timeOrigin is not 0.0');
+}
+
+if (globalThis.performance.now() !== 0.0) {
+  throw new Error('performance.now() is not 0.0');
+}
+
+export const test = {
+  async test(ctrl, env, ctx) {
+    const start = performance.now();
+    // There should be at least some time elapsed.
+    if (start == 0.0) {
+      throw new Error('performance.now() is 0.0');
+    }
+    await scheduler.wait(10);
+    if (start == performance.now()) {
+      throw new Error('performance.now() is not increasing');
+    }
+  }
+};
+

--- a/src/workerd/tests/performance-test.wd-test
+++ b/src/workerd/tests/performance-test.wd-test
@@ -1,0 +1,14 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "performance-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "performance-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
Provides a basic implementation for performance.now in a manner that follows the same rules as Date.now().

This is potentially one way of accomplishing this. @kentonv not sure if you have an alternative idea in mind.