### PR TITLE
Relaxing sqlite constraints

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -134,8 +134,26 @@ function test(sql) {
   requireException(() => sql.exec("SELECT * FROM _cf_KV"),
     "access to _cf_KV.key is prohibited");
 
-  // Accessing pragmas is not allowed
+  // Some pragmas are completely not allowed
   requireException(() => sql.exec("PRAGMA hard_heap_limit = 1024"),
+    "not authorized");
+
+  // Test reading read-only pragmas
+  {
+    const result = [...sql.exec("pragma max_page_count;")];
+    assert.equal(result.length, 1);
+    assert.equal(result[0]["max_page_count"], 1073741823);
+  }
+  {
+    const result = [...sql.exec("pragma page_size;")];
+    assert.equal(result.length, 1);
+    assert.equal(result[0]["page_size"], 4096);
+  }
+
+  // Trying to write to read-only pragmas is not allowed
+  requireException(() => sql.exec("PRAGMA max_page_count = 65536"),
+    "not authorized");
+  requireException(() => sql.exec("PRAGMA page_size = 8192"),
     "not authorized");
 
   // PRAGMA table_info is allowed.
@@ -161,6 +179,49 @@ function test(sql) {
   let jsonResult =
       [...sql.exec("SELECT '{\"a\":2,\"c\":[4,5,{\"f\":7}]}' -> '$.c' AS value")][0].value;
   assert.equal(jsonResult, "[4,5,{\"f\":7}]");
+
+  // Complex queries
+
+  // List num tables and total DB size
+  {
+    let result = [...sql.exec(`
+        SELECT (
+            SELECT count(1)
+            FROM sqlite_master
+            WHERE TYPE = "table"
+                AND tbl_name NOT LIKE "sqlite_%"
+                AND tbl_name NOT LIKE "d1_%"
+                AND tbl_name NOT LIKE "_cf_%"
+        ) as num_tables,
+        page_size * (total_pages - num_free) as db_size
+        FROM (
+            SELECT (
+                SELECT * from pragma_freelist_count
+            ) as num_free, (
+                SELECT * from pragma_page_count
+            ) as total_pages, (
+                SELECT * from pragma_page_size
+            ) as page_size
+        );`)];
+    assert.equal(result.length, 1);
+    assert.equal(result[0].num_tables, 1);
+    assert.equal(result[0].db_size, 12288);
+  }
+
+  // List table info
+  {
+    let result = [...sql.exec(`
+        SELECT name as tbl_name,
+               ncol as num_columns
+        FROM pragma_table_list
+        WHERE TYPE = "table"
+          AND tbl_name NOT LIKE "sqlite_%"
+          AND tbl_name NOT LIKE "d1_%"
+          AND tbl_name NOT LIKE "_cf_%"`)];
+    assert.equal(result.length, 1);
+    assert.equal(result[0].tbl_name, 'myTable');
+    assert.equal(result[0].num_columns, 2);
+  }
 }
 
 export class DurableObjectExample {

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -470,7 +470,7 @@ bool SqliteDatabase::isAuthorized(int actionCode,
       // TODO(sqlite): Decide which function are OK.
 
       {
-        const kj::HashSet<kj::StringPtr> allowSet = []() {
+        static const kj::HashSet<kj::StringPtr> allowSet = []() {
           kj::HashSet<kj::StringPtr> result;
           for (const kj::StringPtr& func: ALLOWED_SQLITE_FUNCTIONS) {
             result.insert(func);

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -531,11 +531,11 @@ void SqliteDatabase::setupSecurity() {
   // We use the suggested limits from the web site. Note that sqlite3_limit() does NOT return an
   // error code; it returns the old limit.
   sqlite3_limit(db, SQLITE_LIMIT_LENGTH, 1000000);
-  sqlite3_limit(db, SQLITE_LIMIT_SQL_LENGTH, 100000);
+  sqlite3_limit(db, SQLITE_LIMIT_SQL_LENGTH, 1000000);
   sqlite3_limit(db, SQLITE_LIMIT_COLUMN, 100);
-  sqlite3_limit(db, SQLITE_LIMIT_EXPR_DEPTH, 10);
-  sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 3);
-  sqlite3_limit(db, SQLITE_LIMIT_VDBE_OP, 25000);
+  sqlite3_limit(db, SQLITE_LIMIT_EXPR_DEPTH, 20);
+  sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 500);
+  sqlite3_limit(db, SQLITE_LIMIT_VDBE_OP, 131072);
   sqlite3_limit(db, SQLITE_LIMIT_FUNCTION_ARG, 8);
   sqlite3_limit(db, SQLITE_LIMIT_ATTACHED, 0);
   sqlite3_limit(db, SQLITE_LIMIT_LIKE_PATTERN_LENGTH, 50);

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -449,7 +449,7 @@ bool SqliteDatabase::isAuthorized(int actionCode,
         if (pragma == "table_list") {
           // Annoyingly, this will list internal tables. However, the existence of these tables
           // isn't really a secret, we just don't want people to access them.
-          return param2 == nullptr;  // should always be true?
+          return true;
         } else if (pragma == "table_info") {
           // Allow if the specific named table is not protected.
           KJ_IF_MAYBE(name, param2) {

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -236,6 +236,37 @@ static constexpr kj::StringPtr ALLOWED_SQLITE_FUNCTIONS[] = {
   "json_tree"_kj,
 };
 
+// https://www.sqlite.org/pragma.html
+static constexpr kj::StringPtr ALLOWED_READ_PRAGMAS[] = {
+  // We allowlist these SQLite pragmas (for read only, never with arguments).
+  "data_version"_kj,
+  "page_count"_kj,
+  "freelist_count"_kj,
+
+  // Let a user see some internal stats?
+  "max_page_count"_kj,
+  "page_size"_kj,
+};
+
+static constexpr kj::StringPtr ALLOWED_WRITE_PRAGMAS[] = {
+  // We allowlist some SQLite pragmas for changing internal state
+
+  // Toggle constraints on/off
+  "case_sensitive_like"_kj,
+  "foreign_keys"_kj,
+  "defer_foreign_keys"_kj,
+  "ignore_check_constraints"_kj,
+  "recursive_triggers"_kj,
+  "reverse_unordered_selects"_kj,
+
+  // Not "writable", but takes an argument of table name
+  "foreign_key_check"_kj,
+  "foreign_key_list"_kj,
+  "index_info"_kj,
+  "index_list"_kj,
+  "index_xinfo"_kj,
+};
+
 }  // namespace
 
 // =======================================================================================
@@ -446,21 +477,45 @@ bool SqliteDatabase::isAuthorized(int actionCode,
       // We currently only permit a few pragmas.
       {
         kj::StringPtr pragma = KJ_ASSERT_NONNULL(param1);
+
         if (pragma == "table_list") {
           // Annoyingly, this will list internal tables. However, the existence of these tables
           // isn't really a secret, we just don't want people to access them.
           return true;
+          // TODO function_list & pragma_list should be authorized but return
+          // ALLOWED_SQLITE_FUNCTIONS & ALLOWED_[READ|WRITE]_PRAGMAS
+          // respectively
         } else if (pragma == "table_info") {
           // Allow if the specific named table is not protected.
-          KJ_IF_MAYBE(name, param2) {
+          KJ_IF_MAYBE (name, param2) {
             return regulator.isAllowedName(*name);
           } else {
-            return false;  // shouldn't happen?
+            return false; // shouldn't happen?
           }
-        } else if (pragma == "data_version") {
+        }
+
+        static const kj::HashSet<kj::StringPtr> allowedWritePragmas = []() {
+          kj::HashSet<kj::StringPtr> result;
+          for (const kj::StringPtr& func: ALLOWED_WRITE_PRAGMAS) {
+            result.insert(func);
+          }
+          return result;
+        }();
+
+        if (allowedWritePragmas.contains(pragma)) {
           return true;
-        } else if (pragma == "foreign_keys") {
-          return true;
+        }
+
+        static const kj::HashSet<kj::StringPtr> allowedReadPragmas = []() {
+          kj::HashSet<kj::StringPtr> result;
+          for (const kj::StringPtr& func: ALLOWED_READ_PRAGMAS) {
+            result.insert(func);
+          }
+          return result;
+        }();
+        if (allowedReadPragmas.contains(pragma)) {
+          // Only return true if there's no second argument.
+          return param2 == nullptr;
         }
       }
 


### PR DESCRIPTION
Commits in this PR:

* **Enabling `pragma table_list(tbl_name)`**
  This just limits the results of `table_list` to the given name, so should be safe.
* **Making function allowlist HashSet static**
  This should prevent it from being rebuilt on every function usage, right?
* **Relaxed a few input limits**
  Still keeping them small, but trying to avoid things being overly restrictive.
* **Expand list of allowed PRAGMAs**
  See https://github.com/cloudflare/workerd/pull/514#discussion_r1159282647 for more discussion
* **Add more detailed authorizer tests**
  Show more complex queries (SQLITE_LIMIT_EXPR_DEPTH > 10), read-only pragmas, etc.

---

Re limits, this relaxes a bunch of the constraints that were introduced in #514:

```
SQLITE_LIMIT_LENGTH

The maximum size of any string or BLOB or table row, in bytes.
```

Kept at 1M.

```
SQLITE_LIMIT_SQL_LENGTH

The maximum length of an SQL statement, in bytes.
```

Set from 100K to 1M. This should be no lower than the above, otherwise you can't insert a full row. But it's also possible that people will want to run `INSERT INTO x VALUES (x,y,z), (w,u,v), ...` statements to insert 1000s of rows at once. 1MB feels like a decent limit there?

```
SQLITE_LIMIT_COLUMN

** The maximum number of columns in a table definition or in the
** result set of a [SELECT] or the maximum number of columns in an index
** or in an ORDER BY or GROUP BY clause.
```

Kept at 100.

```
SQLITE_LIMIT_EXPR_DEPTH

The maximum depth of the parse tree on any expression.
```

Set from 10 to 20 (default is 1K). This is the thing I hit immediately with a fairly simple query with a bit of nesting, but with a bit more exploration, queries that _look_ complex are mostly below 10 anyway. So 10 is definitely too small but I found it tough to generate a query that needed more than 20, so I picked 20.

```
SQLITE_LIMIT_VDBE_OP

** <dd>The maximum number of instructions in a virtual machine program
** used to implement an SQL statement.  If [sqlite3_prepare_v2()] or
** the equivalent tries to allocate space for more than this many opcodes
** in a single prepared statement, an SQLITE_NOMEM error is returned.</dd>
```

Set from 25K to 131072. Did some local testing, executing the following file:

```sql
CREATE TABLE uuid (id INTEGER PRIMARY KEY, value TEXT, num_alpha INTEGER, num_numeric INTEGER, longest_alpha TEXT, longest_numeric TEXT);

INSERT INTO uuid (value, num_alpha, num_numeric, longest_alpha, longest_numeric)
VALUES ("bd9801ef-2e09-48ce-b41e-e1ca699e5d37",14,18,"ceb","9801"),
("8dee2674-415e-492f-831a-a0520d0ca9f2",11,21,"dee","2674415"),
("fc34e5b8-a8ac-4462-ae93-88e7924fa6f9",13,19,"fc","4462"),
("23085940-9878-4c66-9c27-99977b527403",3,29,"c","2308594098784"),
...
```

with 10,000 entries in a single statement came to just over 600kb and broke when I set `.limit vdbe_op` to any less than `65536`. Doing 20k (1.3M file) broke below `131072` (seems to only step up in powers of 2). So I think if we want to support a 1mb max row/statement, then we should set this to `131072`.

```
SQLITE_LIMIT_FUNCTION_ARG

The maximum number of arguments on a function.
```

Kept at 8.

```
SQLITE_LIMIT_LIKE_PATTERN_LENGTH

** <dd>The maximum length of the pattern argument to the [LIKE] or
** [GLOB] operators.</dd>
```

Kept at 50.

```
SQLITE_LIMIT_VARIABLE_NUMBER

The maximum index number of any [parameter] in an SQL statement.
```

Set from 10 to 100, so you can at least parameterise a whole 100-column row. (Default is 999).

```
SQLITE_LIMIT_TRIGGER_DEPTH
The maximum depth of recursion for triggers.
```

Kept at 10.