### PR TITLE
Enabling SQLite FTS5 extension (full text search)

### DIFF
--- a/build/BUILD.sqlite3
+++ b/build/BUILD.sqlite3
@@ -8,5 +8,6 @@ cc_library(
     defines = [
         "SQLITE_MAX_ALLOCATION_SIZE=16777216",  # 16MB
         "SQLITE_PRINTF_PRECISION_LIMIT=100000",
+        "SQLITE_ENABLE_FTS5",
     ]
 )

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -180,6 +180,85 @@ function test(sql) {
       [...sql.exec("SELECT '{\"a\":2,\"c\":[4,5,{\"f\":7}]}' -> '$.c' AS value")][0].value;
   assert.equal(jsonResult, "[4,5,{\"f\":7}]");
 
+  // Full text search extension
+
+  sql.exec(`
+    CREATE TABLE documents (
+      id INTEGER PRIMARY KEY,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL
+    );
+  `);
+  sql.exec(`
+    CREATE VIRTUAL TABLE documents_fts USING fts5(id, title, content, tokenize = porter);
+  `);
+  sql.exec(`
+    CREATE TRIGGER documents_fts_insert 
+    AFTER INSERT ON documents 
+    BEGIN 
+      INSERT INTO documents_fts(id, title, content) 
+        VALUES(new.id, new.title, new.content); 
+    END;
+  `);
+  sql.exec(`
+    CREATE TRIGGER documents_fts_update 
+    AFTER UPDATE ON documents 
+    BEGIN 
+      UPDATE documents_fts SET title=new.title, content=new.content WHERE id=old.id; 
+    END;
+  `);
+  sql.exec(`
+    CREATE TRIGGER documents_fts_delete 
+    AFTER DELETE ON documents 
+    BEGIN 
+      DELETE FROM documents_fts WHERE id=old.id; 
+    END;
+  `);
+  sql.exec(`
+    INSERT INTO documents (title, content) VALUES ('Document 1', 'This is the contents of document 1 (of 2).');
+  `);
+  sql.exec(`
+    INSERT INTO documents (title, content) VALUES ('Document 2', 'This is the content of document 2 (of 2).');
+  `);
+  // Porter stemming makes 'contents' and 'content' the same
+  {
+    let results = Array.from(sql.exec(`
+      SELECT * FROM documents_fts WHERE documents_fts MATCH 'content' ORDER BY rank;
+    `));
+    assert.equal(results.length, 2)
+    assert.equal(results[0].id, 1) // Stemming makes doc 1 match first
+    assert.equal(results[1].id, 2)
+  }
+  // Ranking functions
+  {
+    let results = Array.from(sql.exec(`
+      SELECT *, bm25(documents_fts) FROM documents_fts WHERE documents_fts MATCH '2' ORDER BY rank;
+    `));
+    assert.equal(results.length, 2)
+    assert.equal(results[0]['bm25(documents_fts)'] < results[1]['bm25(documents_fts)'], true) // Better matches have lower bm25 (since they're all negative
+    assert.equal(results[0].id, 2) // Doc 2 comes first (sorted by rank)
+    assert.equal(results[1].id, 1)
+  }
+  // highlight() function
+  {
+    let results = Array.from(sql.exec(`
+        SELECT highlight(documents_fts, 2, '<b>', '</b>') as output FROM documents_fts WHERE documents_fts MATCH '2' ORDER BY rank;
+    `));
+    assert.equal(results.length, 2)
+    assert.equal(results[0].output, `This is the content of document <b>2</b> (of <b>2</b>).`) // two matches, two highlights
+    assert.equal(results[1].output, `This is the contents of document 1 (of <b>2</b>).`)
+  }
+  // snippet() function
+  {
+    let results = Array.from(sql.exec(`
+        SELECT snippet(documents_fts, 2, '<b>', '</b>', '...', 4) as output FROM documents_fts WHERE documents_fts MATCH '2' ORDER BY rank;
+    `));
+    assert.equal(results.length, 2)
+    assert.equal(results[0].output, `...document <b>2</b> (of <b>2</b>).`) // two matches, two highlights
+    assert.equal(results[1].output, `...document 1 (of <b>2</b>).`)
+  }
+
+
   // Complex queries
 
   // List num tables and total DB size
@@ -204,8 +283,8 @@ function test(sql) {
             ) as page_size
         );`)];
     assert.equal(result.length, 1);
-    assert.equal(result[0].num_tables, 1);
-    assert.equal(result[0].db_size, 12288);
+    assert.equal(result[0].num_tables, 8);
+    assert.equal(result[0].db_size, 36864);
   }
 
   // List table info
@@ -218,9 +297,11 @@ function test(sql) {
           AND tbl_name NOT LIKE "sqlite_%"
           AND tbl_name NOT LIKE "d1_%"
           AND tbl_name NOT LIKE "_cf_%"`)];
-    assert.equal(result.length, 1);
+    assert.equal(result.length, 2);
     assert.equal(result[0].tbl_name, 'myTable');
     assert.equal(result[0].num_columns, 2);
+    assert.equal(result[1].tbl_name, 'documents');
+    assert.equal(result[1].num_columns, 3);
   }
 }
 

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -134,8 +134,26 @@ function test(sql) {
   requireException(() => sql.exec("SELECT * FROM _cf_KV"),
     "access to _cf_KV.key is prohibited");
 
-  // Accessing pragmas is not allowed
+  // Some pragmas are completely not allowed
   requireException(() => sql.exec("PRAGMA hard_heap_limit = 1024"),
+    "not authorized");
+
+  // Test reading read-only pragmas
+  {
+    const result = [...sql.exec("pragma max_page_count;")];
+    assert.equal(result.length, 1);
+    assert.equal(result[0]["max_page_count"], 1073741823);
+  }
+  {
+    const result = [...sql.exec("pragma page_size;")];
+    assert.equal(result.length, 1);
+    assert.equal(result[0]["page_size"], 4096);
+  }
+
+  // Trying to write to read-only pragmas is not allowed
+  requireException(() => sql.exec("PRAGMA max_page_count = 65536"),
+    "not authorized");
+  requireException(() => sql.exec("PRAGMA page_size = 8192"),
     "not authorized");
 
   // PRAGMA table_info is allowed.
@@ -161,6 +179,49 @@ function test(sql) {
   let jsonResult =
       [...sql.exec("SELECT '{\"a\":2,\"c\":[4,5,{\"f\":7}]}' -> '$.c' AS value")][0].value;
   assert.equal(jsonResult, "[4,5,{\"f\":7}]");
+
+  // Complex queries
+
+  // List num tables and total DB size
+  {
+    let result = [...sql.exec(`
+        SELECT (
+            SELECT count(1)
+            FROM sqlite_master
+            WHERE TYPE = "table"
+                AND tbl_name NOT LIKE "sqlite_%"
+                AND tbl_name NOT LIKE "d1_%"
+                AND tbl_name NOT LIKE "_cf_%"
+        ) as num_tables,
+        page_size * (total_pages - num_free) as db_size
+        FROM (
+            SELECT (
+                SELECT * from pragma_freelist_count
+            ) as num_free, (
+                SELECT * from pragma_page_count
+            ) as total_pages, (
+                SELECT * from pragma_page_size
+            ) as page_size
+        );`)];
+    assert.equal(result.length, 1);
+    assert.equal(result[0].num_tables, 1);
+    assert.equal(result[0].db_size, 12288);
+  }
+
+  // List table info
+  {
+    let result = [...sql.exec(`
+        SELECT name as tbl_name,
+               ncol as num_columns
+        FROM pragma_table_list
+        WHERE TYPE = "table"
+          AND tbl_name NOT LIKE "sqlite_%"
+          AND tbl_name NOT LIKE "d1_%"
+          AND tbl_name NOT LIKE "_cf_%"`)];
+    assert.equal(result.length, 1);
+    assert.equal(result[0].tbl_name, 'myTable');
+    assert.equal(result[0].num_columns, 2);
+  }
 }
 
 export class DurableObjectExample {

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -470,7 +470,7 @@ bool SqliteDatabase::isAuthorized(int actionCode,
       // TODO(sqlite): Decide which function are OK.
 
       {
-        const kj::HashSet<kj::StringPtr> allowSet = []() {
+        static const kj::HashSet<kj::StringPtr> allowSet = []() {
           kj::HashSet<kj::StringPtr> result;
           for (const kj::StringPtr& func: ALLOWED_SQLITE_FUNCTIONS) {
             result.insert(func);

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -531,11 +531,11 @@ void SqliteDatabase::setupSecurity() {
   // We use the suggested limits from the web site. Note that sqlite3_limit() does NOT return an
   // error code; it returns the old limit.
   sqlite3_limit(db, SQLITE_LIMIT_LENGTH, 1000000);
-  sqlite3_limit(db, SQLITE_LIMIT_SQL_LENGTH, 100000);
+  sqlite3_limit(db, SQLITE_LIMIT_SQL_LENGTH, 1000000);
   sqlite3_limit(db, SQLITE_LIMIT_COLUMN, 100);
-  sqlite3_limit(db, SQLITE_LIMIT_EXPR_DEPTH, 10);
-  sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 3);
-  sqlite3_limit(db, SQLITE_LIMIT_VDBE_OP, 25000);
+  sqlite3_limit(db, SQLITE_LIMIT_EXPR_DEPTH, 20);
+  sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 500);
+  sqlite3_limit(db, SQLITE_LIMIT_VDBE_OP, 131072);
   sqlite3_limit(db, SQLITE_LIMIT_FUNCTION_ARG, 8);
   sqlite3_limit(db, SQLITE_LIMIT_ATTACHED, 0);
   sqlite3_limit(db, SQLITE_LIMIT_LIKE_PATTERN_LENGTH, 50);

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -449,7 +449,7 @@ bool SqliteDatabase::isAuthorized(int actionCode,
         if (pragma == "table_list") {
           // Annoyingly, this will list internal tables. However, the existence of these tables
           // isn't really a secret, we just don't want people to access them.
-          return param2 == nullptr;  // should always be true?
+          return true;
         } else if (pragma == "table_info") {
           // Allow if the specific named table is not protected.
           KJ_IF_MAYBE(name, param2) {

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -236,6 +236,37 @@ static constexpr kj::StringPtr ALLOWED_SQLITE_FUNCTIONS[] = {
   "json_tree"_kj,
 };
 
+// https://www.sqlite.org/pragma.html
+static constexpr kj::StringPtr ALLOWED_READ_PRAGMAS[] = {
+  // We allowlist these SQLite pragmas (for read only, never with arguments).
+  "data_version"_kj,
+  "page_count"_kj,
+  "freelist_count"_kj,
+
+  // Let a user see some internal stats?
+  "max_page_count"_kj,
+  "page_size"_kj,
+};
+
+static constexpr kj::StringPtr ALLOWED_WRITE_PRAGMAS[] = {
+  // We allowlist some SQLite pragmas for changing internal state
+
+  // Toggle constraints on/off
+  "case_sensitive_like"_kj,
+  "foreign_keys"_kj,
+  "defer_foreign_keys"_kj,
+  "ignore_check_constraints"_kj,
+  "recursive_triggers"_kj,
+  "reverse_unordered_selects"_kj,
+
+  // Not "writable", but takes an argument of table name
+  "foreign_key_check"_kj,
+  "foreign_key_list"_kj,
+  "index_info"_kj,
+  "index_list"_kj,
+  "index_xinfo"_kj,
+};
+
 }  // namespace
 
 // =======================================================================================
@@ -446,21 +477,45 @@ bool SqliteDatabase::isAuthorized(int actionCode,
       // We currently only permit a few pragmas.
       {
         kj::StringPtr pragma = KJ_ASSERT_NONNULL(param1);
+
         if (pragma == "table_list") {
           // Annoyingly, this will list internal tables. However, the existence of these tables
           // isn't really a secret, we just don't want people to access them.
           return true;
+          // TODO function_list & pragma_list should be authorized but return
+          // ALLOWED_SQLITE_FUNCTIONS & ALLOWED_[READ|WRITE]_PRAGMAS
+          // respectively
         } else if (pragma == "table_info") {
           // Allow if the specific named table is not protected.
-          KJ_IF_MAYBE(name, param2) {
+          KJ_IF_MAYBE (name, param2) {
             return regulator.isAllowedName(*name);
           } else {
-            return false;  // shouldn't happen?
+            return false; // shouldn't happen?
           }
-        } else if (pragma == "data_version") {
+        }
+
+        static const kj::HashSet<kj::StringPtr> allowedWritePragmas = []() {
+          kj::HashSet<kj::StringPtr> result;
+          for (const kj::StringPtr& func: ALLOWED_WRITE_PRAGMAS) {
+            result.insert(func);
+          }
+          return result;
+        }();
+
+        if (allowedWritePragmas.contains(pragma)) {
           return true;
-        } else if (pragma == "foreign_keys") {
-          return true;
+        }
+
+        static const kj::HashSet<kj::StringPtr> allowedReadPragmas = []() {
+          kj::HashSet<kj::StringPtr> result;
+          for (const kj::StringPtr& func: ALLOWED_READ_PRAGMAS) {
+            result.insert(func);
+          }
+          return result;
+        }();
+        if (allowedReadPragmas.contains(pragma)) {
+          // Only return true if there's no second argument.
+          return param2 == nullptr;
         }
       }
 

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -234,6 +234,12 @@ static constexpr kj::StringPtr ALLOWED_SQLITE_FUNCTIONS[] = {
   "json_group_object"_kj,
   "json_each"_kj,
   "json_tree"_kj,
+
+  // https://www.sqlite.org/fts5.html
+  "match"_kj,
+  "highlight"_kj,
+  "bm25"_kj,
+  "snippet"_kj,
 };
 
 // https://www.sqlite.org/pragma.html
@@ -540,8 +546,15 @@ bool SqliteDatabase::isAuthorized(int actionCode,
 
     case SQLITE_CREATE_VTABLE      :   /* Table Name      Module Name     */
     case SQLITE_DROP_VTABLE        :   /* Table Name      Module Name     */
-      // Virtual tables are tables backed by some native-code callbacks. We don't support these.
-      return false;
+      // Virtual tables are tables backed by some native-code callbacks. We don't support these except for FTS5 (Full Text Search) https://www.sqlite.org/fts5.html
+      {
+        KJ_IF_MAYBE (moduleName, param2) {
+          if (*moduleName == "fts5") {
+            return true;
+          }
+        }
+        return false;
+      }
 
     case SQLITE_ATTACH             :   /* Filename        NULL            */
     case SQLITE_DETACH             :   /* Database Name   NULL            */


### PR DESCRIPTION
Builds upon #606.

Module is described here: https://www.sqlite.org/fts5.html

This adds a single build flag, `SQLITE_ENABLE_FTS5`, and 4 functions to the allowlist: `match`,`highlight`,`bm25` and `snippet`.