### PR TITLE
d1: enable UPDATE_DELETE and STAT4 at build

### DIFF
--- a/build/BUILD.sqlite3
+++ b/build/BUILD.sqlite3
@@ -8,5 +8,7 @@ cc_library(
     defines = [
         "SQLITE_MAX_ALLOCATION_SIZE=16777216",  # 16MB
         "SQLITE_PRINTF_PRECISION_LIMIT=100000",
+        "SQLITE_ENABLE_UPDATE_DELETE_LIMIT=1", # https://sqlite.org/draft/compile.html#enable_update_delete_limit
+        "SQLITE_ENABLE_STAT4=1", # https://sqlite.org/draft/compile.html#enable_stat4
     ]
 )


### PR DESCRIPTION
Enables two SQLite options:

* The STAT4 query planner, which is enabled in the alpha: https://sqlite.org/draft/compile.html#enable_stat4 - the "downside" is that the query planner becomes less deterministic ("non-stable"), which matters more in embedded use-cases.
* The ability to define `ORDER BY` and `LIMIT` clauses on `UPDATE` and `DELETE` statements - https://sqlite.org/draft/compile.html#enable_update_delete_limit - this has no clear downside (outside of being a non-std build opt) and makes it easier for devs familiar with MySQL to use D1.