### PR TITLE
Automatically wrap SQLite usage in transactions and respect OutputGate.

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -161,6 +161,10 @@ function test(sql) {
   let jsonResult =
       [...sql.exec("SELECT '{\"a\":2,\"c\":[4,5,{\"f\":7}]}' -> '$.c' AS value")][0].value;
   assert.equal(jsonResult, "[4,5,{\"f\":7}]");
+
+  // Can't start transactions or savepoints.
+  requireException(() => sql.exec("BEGIN TRANSACTION"), "not authorized");
+  requireException(() => sql.exec("SAVEPOINT foo"), "not authorized");
 }
 
 export class DurableObjectExample {

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -172,9 +172,27 @@ export class DurableObjectExample {
     this.state = state;
   }
 
-  async fetch() {
-    test(this.state.storage.sql);
-    return new Response();
+  async fetch(req) {
+    if (req.url.endsWith("/sql-test")) {
+      test(this.state.storage.sql);
+      return new Response();
+    } else if (req.url.endsWith("/increment")) {
+      let val = (await this.state.storage.get("counter")) || 0;
+      ++val;
+      this.state.storage.put("counter", val);
+      return Response.json(val);
+    } else if (req.url.endsWith("/break")) {
+      // This `put()` should be discarded due to the actor aborting immediately after.
+      this.state.storage.put("counter", 888);
+
+      // Abort the actor, which also cancels unflushed writes.
+      this.state.abort("test broken");
+
+      // abort() always throws.
+      throw new Error("can't get here")
+    }
+
+    throw new Error("unknown url: " + req.url);
   }
 }
 
@@ -182,6 +200,33 @@ export default {
   async test(ctrl, env, ctx) {
     let id = env.ns.idFromName("A");
     let obj = env.ns.get(id);
-    await obj.fetch("http://foo");
+    await obj.fetch("http://foo/sql-test");
+
+    // Now let's test persistence through breakage and atomic write coalescing.
+    let doReq = async path => {
+      let resp = await obj.fetch("http://foo/" + path);
+      return await resp.json();
+    };
+
+    // Some increments.
+    assert.equal(await doReq("increment"), 1);
+    assert.equal(await doReq("increment"), 2);
+
+    // Now induce a failure.
+    try {
+      await doReq("break");
+      throw new Error("expected failure");
+    } catch (err) {
+      if (err.message != "test broken") {
+        throw err;
+      }
+      assert.equal(err.durableObjectReset, true);
+    }
+
+    // Get a new stub.
+    obj = env.ns.get(id);
+
+    // Everything's still consistent.
+    assert.equal(await doReq("increment"), 3);
   }
 }

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -34,6 +34,17 @@ void SqlStorage::onError(kj::StringPtr message) {
   JSG_ASSERT(false, Error, message);
 }
 
+bool SqlStorage::allowTransactions() {
+  if (IoContext::hasCurrent()) {
+    IoContext::current().logWarningOnce(
+        "To execute a transaction, please use the state.storage.transaction() API instead of the "
+        "SQL BEGIN TRANSACTION or SAVEPOINT statements. The JavaScript API is safer because it "
+        "will automatically roll back on exceptions, and because it interacts correctly with "
+        "Durable Objects' automatic atomic write coalescing.");
+  }
+  return false;
+}
+
 SqlStorage::Cursor::State::State(
     kj::RefcountedWrapper<SqliteDatabase::Statement>& statement,
     kj::Array<BindingValue> bindingsParam)

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -43,6 +43,7 @@ private:
   bool isAllowedName(kj::StringPtr name) override;
   bool isAllowedTrigger(kj::StringPtr name) override;
   void onError(kj::StringPtr message) override;
+  bool allowTransactions() override;
 
   IoPtr<SqliteDatabase> sqlite;
   jsg::Ref<DurableObjectStorage> storage;

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -31,6 +31,8 @@ public:
   // the returned promise. This can be used e.g. when the database needs to be replicated to other
   // machines before being considered durable.
 
+  bool isCommitScheduled() { return commitScheduled; }
+
   kj::Maybe<SqliteDatabase&> getSqliteDatabase() override { return *db; }
 
   kj::OneOf<kj::Maybe<Value>, kj::Promise<kj::Maybe<Value>>> get(

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -54,6 +54,10 @@ public:
 private:
   kj::Own<SqliteDatabase> db;
   SqliteKv kv;
+
+  kj::Maybe<kj::Exception> broken;
+
+  void requireNotBroken();
 };
 
 }  // namespace workerd

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -392,6 +392,9 @@ public:
   // aborted, e.g. because its CPU time expired. This should be joined with any promises for
   // incoming tasks.
 
+  void abort(kj::Exception&& e) { abortFulfiller->reject(kj::mv(e)); }
+  // Force context abort now.
+
   bool isFailOpen() { return failOpen; }
   // Has event.passThroughOnException() been called?
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1182,7 +1182,7 @@ public:
 
     actorNamespaces.reserve(actorClasses.size());
     for (auto& entry: actorClasses) {
-      ActorNamespace ns(*this, entry.key, entry.value);
+      auto ns = kj::heap<ActorNamespace>(*this, entry.key, entry.value);
       actorNamespaces.insert(entry.key, kj::mv(ns));
     }
   }
@@ -1202,7 +1202,11 @@ public:
   }
 
   kj::Maybe<ActorNamespace&> getActorNamespace(kj::StringPtr name) {
-    return actorNamespaces.find(name);
+    KJ_IF_MAYBE(a, actorNamespaces.find(name)) {
+      return **a;
+    } else {
+      return nullptr;
+    }
   }
 
   kj::Own<WorkerInterface> startRequest(
@@ -1236,10 +1240,10 @@ public:
         kj::mv(metadata.cfBlobJson));
   }
 
-  class ActorNamespace {
+  class ActorNamespace final: private kj::TaskSet::ErrorHandler {
   public:
     ActorNamespace(WorkerService& service, kj::StringPtr className, const ActorConfig& config)
-        : service(service), className(className), config(config) {}
+        : service(service), className(className), config(config), onBrokenTasks(*this) {}
 
     const ActorConfig& getConfig() { return config; }
 
@@ -1262,6 +1266,12 @@ public:
     kj::StringPtr className;
     const ActorConfig& config;
     kj::HashMap<kj::String, kj::Own<Worker::Actor>> actors;
+    kj::TaskSet onBrokenTasks;
+
+    void taskFailed(kj::Exception&& exception) override {
+      // Error from `actors.erase()`?
+      KJ_LOG(ERROR, exception);
+    }
 
     class Loopback : public Worker::Actor::Loopback, public kj::Refcounted {
     public:
@@ -1338,6 +1348,14 @@ public:
               className, kj::mv(makeStorage), lock, kj::mv(loopback),
               timerChannel, kj::refcounted<ActorObserver>());
 
+          // If the actor becomes broken, remove it from the map, so a new one will be created
+          // next time.
+          onBrokenTasks.add(newActor->onBroken()
+              .catch_([](kj::Exception&&) {})
+              .then([this, idStr = idStr.asPtr(), &actor = *newActor]() {
+            actors.erase(idStr);
+          }));
+
           // TODO(sqlite): Now that actors are backed by real disk, we should shut them down after
           //   a minute of inactivity...
           return kj::HashMap<kj::String, kj::Own<Worker::Actor>>::Entry {
@@ -1380,7 +1398,7 @@ private:
   kj::Own<const Worker> worker;
   kj::Maybe<kj::HashSet<kj::String>> defaultEntrypointHandlers;
   kj::HashMap<kj::String, EntrypointService> namedEntrypoints;
-  kj::HashMap<kj::StringPtr, ActorNamespace> actorNamespaces;
+  kj::HashMap<kj::StringPtr, kj::Own<ActorNamespace>> actorNamespaces;
   kj::TaskSet waitUntilTasks;
 
   class ActorChannelImpl final: public IoChannelFactory::ActorChannel {

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1322,7 +1322,8 @@ public:
                 auto db = kj::heap<SqliteDatabase>(**as,
                     kj::Path({d.uniqueKey, kj::str(idStr, ".sqlite")}),
                     kj::WriteMode::CREATE | kj::WriteMode::MODIFY | kj::WriteMode::CREATE_PARENT);
-                return kj::heap<ActorSqlite>(kj::mv(db));
+                return kj::heap<ActorSqlite>(kj::mv(db), outputGate,
+                    []() -> kj::Promise<void> { return kj::READY_NOW; });
               } else {
                 // Create an ActorCache backed by a fake, empty storage. Elsewhere, we configure
                 // ActorCache never to flush, so this effectively creates in-memory storage.

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -340,5 +340,21 @@ KJ_TEST("SQLite Regulator") {
       KJ_EXPECT(getBar.run().getInt(0) == 456));
 }
 
+KJ_TEST("SQLite onWrite callback") {
+  auto dir = kj::newInMemoryDirectory(kj::nullClock());
+  SqliteDatabase::Vfs vfs(*dir);
+  SqliteDatabase db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
+
+  bool sawWrite = false;
+  db.onWrite([&]() { sawWrite = true; });
+
+  setupSql(db);
+  KJ_EXPECT(sawWrite);
+  sawWrite = false;
+
+  checkSql(db);
+  KJ_EXPECT(!sawWrite);  // checkSql() only does reads
+}
+
 }  // namespace
 }  // namespace workerd

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -625,6 +625,12 @@ void SqliteDatabase::Query::checkRequirements(size_t size) {
       "A SQL prepared statement can only be executed once at a time.");
   SQLITE_REQUIRE(size == sqlite3_bind_parameter_count(statement),
       "Wrong number of parameter bindings for SQL query.");
+
+  KJ_IF_MAYBE(cb, db.onWriteCallback) {
+    if (!sqlite3_stmt_readonly(statement)) {
+      (*cb)();
+    }
+  }
 }
 
 void SqliteDatabase::Query::init(kj::ArrayPtr<const ValuePtr> bindings) {

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -432,15 +432,16 @@ bool SqliteDatabase::isAuthorized(int actionCode,
         KJ_ASSERT(op == "BEGIN" || op == "ROLLBACK" || op == "COMMIT", op);
       }
       KJ_ASSERT(param2 == nullptr);
-      return true;
+      return regulator.allowTransactions();
 
     case SQLITE_SAVEPOINT          :   /* Operation       Savepoint Name  */
       {
         // Verify param1 is one of the values we expect.
         kj::StringPtr op = KJ_ASSERT_NONNULL(param1);
-        KJ_ASSERT(op == "BEGIN" || op == "ROLLBACK" || op == "COMMIT", op);
+        KJ_ASSERT(op == "BEGIN" || op == "ROLLBACK" || op == "RELEASE", op);
       }
-      return regulator.isAllowedName(KJ_ASSERT_NONNULL(param2));
+      return regulator.allowTransactions() &&
+          regulator.isAllowedName(KJ_ASSERT_NONNULL(param2));
 
     case SQLITE_PRAGMA             :   /* Pragma Name     1st arg or NULL */
       // We currently only permit a few pragmas.

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -467,8 +467,6 @@ bool SqliteDatabase::isAuthorized(int actionCode,
       return false;
 
     case SQLITE_FUNCTION           :   /* NULL            Function Name   */
-      // TODO(sqlite): Decide which function are OK.
-
       {
         const kj::HashSet<kj::StringPtr> allowSet = []() {
           kj::HashSet<kj::StringPtr> result;

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -70,11 +70,19 @@ public:
   Query run(const char (&sqlCode)[size], Params&&... bindings);
   // When the input is a string literal, we automatically use the TRUSTED regulator.
 
+  void onWrite(kj::Function<void()> callback) { onWriteCallback = kj::mv(callback); }
+  // Invokes the given callback whenever a query begins which may write to the database. The
+  // callback is called just before executing the query.
+  //
+  // Durable Objects uses this to automatically begin a transaction and close the output gate.
+
 private:
   sqlite3* db;
 
   kj::Maybe<Regulator&> currentRegulator;
   // Set while a query is compiling.
+
+  kj::Maybe<kj::Function<void()>> onWriteCallback;
 
   void close();
 

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -130,6 +130,15 @@ public:
   // KJ exceptions in all cases. This is because SQLITE_MISUSE indicates a bug that could lead to
   // undefined behavior. Such bugs are always in C++ code; JavaScript application code must be
   // prohibited from causing such errors in the first place.
+
+  virtual bool allowTransactions() { return true; }
+  // Are BEGIN TRANSACTION and SAVEPOINT statements allowed? Note that if allowed, SAVEPOINT will
+  // also be subject to `isAllowedName()` for the savepoint name. If denied, the application will
+  // not be able to create any sort of transaction.
+  //
+  // In Durable Objects, we disallow these statements because the platform provides an explicit
+  // API for transactions that is safer (e.g. it automatically rolls back on throw). Also, the
+  // platform automatically wraps every entry into the isolate lock in a transaction.
 };
 
 class SqliteDatabase::Statement {


### PR DESCRIPTION
Per the old blog post:

https://blog.cloudflare.com/durable-objects-easy-fast-correct-choose-three/

All writes that occur without an `await` in between are supposed to be automatically coalesced and submitted atomically.

With this change, the SQLite-based DO storage respects this requirement, by automatically creating a transaction.

As it turns out, this actually makes SQLite more efficient. Multiple changes to the same pages will be coalesced, and fsync()s will only be needed at commit time.