### PR TITLE
Implement crypto.pbkdf2

### DIFF
--- a/src/node/crypto.ts
+++ b/src/node/crypto.ts
@@ -34,6 +34,12 @@ import {
   checkPrimeSync,
 } from 'node-internal:crypto_random';
 
+import {
+  pbkdf2,
+  pbkdf2Sync,
+  ArrayLike,
+} from 'node-internal:crypto_pbkdf2';
+
 export {
   randomBytes,
   randomFillSync,
@@ -47,6 +53,9 @@ export {
   generatePrimeSync,
   checkPrime,
   checkPrimeSync,
+  pbkdf2,
+  pbkdf2Sync,
+  ArrayLike as arrayLike,
 }
 
 // We do not implement the openssl secure heap.
@@ -85,6 +94,9 @@ export default {
   generatePrimeSync,
   checkPrime,
   checkPrimeSync,
+  // Pbkdf2
+  pbkdf2,
+  pbkdf2Sync,
   // Misc
   secureHeapUsed,
   setEngine,
@@ -173,8 +185,8 @@ export default {
 // * Key Derivation
 //   * [ ] crypto.hkdf(digest, ikm, salt, info, keylen, callback)
 //   * [ ] crypto.hkdfSync(digest, ikm, salt, info, keylen)
-//   * [ ] crypto.pbkdf2(password, salt, iterations, keylen, digest, callback)
-//   * [ ] crypto.pbkdf2Sync(password, salt, iterations, keylen, digest)
+//   * [x] crypto.pbkdf2(password, salt, iterations, keylen, digest, callback)
+//   * [x] crypto.pbkdf2Sync(password, salt, iterations, keylen, digest)
 //   * [ ] crypto.scrypt(password, salt, keylen[, options], callback)
 //   * [ ] crypto.scryptSync(password, salt, keylen[, options])
 // * WebCrypto

--- a/src/node/internal/crypto.d.ts
+++ b/src/node/internal/crypto.d.ts
@@ -1,7 +1,15 @@
 // Copyright (c) 2017-2022 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
+import {
+    Buffer,
+} from 'node-internal:internal_buffer';
 
+// random
 export function getRandomInt(min: number, max: number): number;
 export function checkPrimeSync(candidate: ArrayBufferView, num_checks: number): boolean;
 export function randomPrime(size: number, safe: boolean, add?: ArrayBufferView|undefined, rem?: ArrayBufferView|undefined): ArrayBuffer;
+
+// pbkdf2
+export type ArrayLike = ArrayBuffer|SharedArrayBuffer|string|Buffer|DataView;
+export function getPbkdf(password: ArrayLike, salt: ArrayLike, iterations: number, keylen: number, digest: string): ArrayBuffer;

--- a/src/node/internal/crypto.d.ts
+++ b/src/node/internal/crypto.d.ts
@@ -11,5 +11,5 @@ export function checkPrimeSync(candidate: ArrayBufferView, num_checks: number): 
 export function randomPrime(size: number, safe: boolean, add?: ArrayBufferView|undefined, rem?: ArrayBufferView|undefined): ArrayBuffer;
 
 // pbkdf2
-export type ArrayLike = ArrayBuffer|SharedArrayBuffer|string|Buffer|DataView;
+export type ArrayLike = ArrayBuffer|string|Buffer|ArrayBufferView;
 export function getPbkdf(password: ArrayLike, salt: ArrayLike, iterations: number, keylen: number, digest: string): ArrayBuffer;

--- a/src/node/internal/crypto_pbkdf2.ts
+++ b/src/node/internal/crypto_pbkdf2.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Adapted from Deno and Node.js:
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+//
+// Adapted from Node.js. Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+'use strict';
+
+import { default as cryptoImpl } from 'node-internal:crypto';
+type ArrayLike = cryptoImpl.ArrayLike;
+export {ArrayLike};
+
+import {
+    Buffer,
+} from 'node-internal:internal_buffer';
+
+import {
+  validateInt32,
+  validateFunction,
+  validateString,
+} from 'node-internal:validators';
+
+import {
+  getArrayBufferOrView,
+} from 'node-internal:crypto_util';
+
+export function pbkdf2Sync(password: ArrayLike, salt: ArrayLike, iterations: number,
+                           keylen: number, digest: string): Buffer {
+  ({ password, salt, iterations, keylen, digest } =
+    check(password, salt, iterations, keylen, digest));
+
+  const result = cryptoImpl.getPbkdf(password, salt, iterations, keylen, digest);
+  return Buffer.from(result);
+}
+
+export type Pbkdf2Callback = (err?: Error|null, result?: Buffer) => void;
+export function pbkdf2(password: ArrayLike, salt: ArrayLike, iterations: number, keylen: number,
+                       digest: string, callback: Pbkdf2Callback): void {
+  if (typeof digest === 'function') {
+    // Appease node test cases
+    validateString(undefined, 'digest');
+  }
+  validateFunction(callback, 'callback');
+  ({ password, salt, iterations, keylen, digest } =
+    check(password, salt, iterations, keylen, digest));
+
+  new Promise<ArrayBuffer>((res, rej) => {
+    try {
+      res(cryptoImpl.getPbkdf(password, salt, iterations, keylen, digest));
+    } catch(err) {
+      rej(err);
+    }
+  }).then((val) => callback(null, Buffer.from(val)), (err) => callback(err));
+}
+
+function check(password: ArrayLike|ArrayBufferView, salt: ArrayLike|ArrayBufferView, iterations: number, keylen: number,
+               digest: string): any {
+  validateString(digest, 'digest');
+
+  password = getArrayBufferOrView(password, 'password');
+  salt = getArrayBufferOrView(salt, 'salt');
+  // OpenSSL uses a signed int to represent these values, so we are restricted
+  // to the 31-bit range here (which is plenty).
+  validateInt32(iterations, 'iterations', 1);
+  validateInt32(keylen, 'keylen', 0);
+
+  return { password, salt, iterations, keylen, digest };
+}

--- a/src/node/internal/crypto_random.ts
+++ b/src/node/internal/crypto_random.ts
@@ -243,7 +243,7 @@ export function randomUUID(options?: any) {
   return crypto.randomUUID();
 }
 
-export type PrimeNum = ArrayBuffer | SharedArrayBuffer | Buffer | DataView | bigint;
+export type PrimeNum = ArrayBuffer | ArrayBufferView | Buffer | bigint;
 export interface GeneratePrimeOptions {
   add?: PrimeNum;
   rem?: PrimeNum;

--- a/src/node/internal/crypto_util.ts
+++ b/src/node/internal/crypto_util.ts
@@ -41,7 +41,7 @@ import {
     ERR_INVALID_ARG_TYPE,
   } from 'node-internal:internal_errors';
 
-export function getArrayBufferOrView(buffer: ArrayBuffer | ArrayBufferView | SharedArrayBuffer | string, name: string, encoding?: string): Buffer | ArrayBuffer | ArrayBufferView | SharedArrayBuffer {
+export function getArrayBufferOrView(buffer: Buffer | ArrayBuffer | ArrayBufferView | string, name: string, encoding?: string): Buffer | ArrayBuffer | ArrayBufferView {
   if (isAnyArrayBuffer(buffer))
     return buffer as ArrayBuffer;
   if (typeof buffer === 'string') {

--- a/src/node/internal/crypto_util.ts
+++ b/src/node/internal/crypto_util.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Adapted from Deno and Node.js:
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+//
+// Adapted from Node.js. Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+import {
+  Buffer,
+} from 'node-internal:internal_buffer';
+
+import {
+    isAnyArrayBuffer,
+    isArrayBufferView,
+} from 'node-internal:internal_types';
+
+import {
+    ERR_INVALID_ARG_TYPE,
+  } from 'node-internal:internal_errors';
+
+export function getArrayBufferOrView(buffer: ArrayBuffer | ArrayBufferView | SharedArrayBuffer | string, name: string, encoding?: string): Buffer | ArrayBuffer | ArrayBufferView | SharedArrayBuffer {
+  if (isAnyArrayBuffer(buffer))
+    return buffer as ArrayBuffer;
+  if (typeof buffer === 'string') {
+    if (encoding === undefined || encoding === 'buffer')
+      encoding = 'utf8';
+    return Buffer.from(buffer, encoding);
+  }
+  if (!isArrayBufferView(buffer)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      name,
+      [
+        'string',
+        'ArrayBuffer',
+        'Buffer',
+        'TypedArray',
+        'DataView',
+      ],
+      buffer,
+    );
+  }
+  return buffer;
+}

--- a/src/workerd/api/node/crypto.h
+++ b/src/workerd/api/node/crypto.h
@@ -10,9 +10,13 @@ public:
       jsg::Optional<kj::Array<kj::byte>> add, jsg::Optional<kj::Array<kj::byte>> rem);
 
   bool checkPrimeSync(kj::Array<kj::byte> bufferView, uint32_t num_checks);
+  // Pbkdf2
+  kj::Array<kj::byte> getPbkdf(kj::Array<kj::byte> password, kj::Array<kj::byte> salt,
+                               uint32_t num_iterations, uint32_t keylen, kj::String name);
   JSG_RESOURCE_TYPE(CryptoImpl) {
     JSG_METHOD(randomPrime);
     JSG_METHOD(checkPrimeSync);
+    JSG_METHOD(getPbkdf);
   }
 };
 

--- a/src/workerd/api/node/crypto_pbkdf2-test.js
+++ b/src/workerd/api/node/crypto_pbkdf2-test.js
@@ -1,0 +1,305 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Adapted from Node.js. Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+import * as assert from 'node:assert';
+import * as crypto from 'node:crypto';
+
+function deferredPromise() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return {
+    promise,
+    resolve,
+    reject,
+  }
+}
+
+function mustNotCall(){return () => {};}
+
+async function runPBKDF2(password, salt, iterations, keylen, hash) {
+  const syncResult =
+    crypto.pbkdf2Sync(password, salt, iterations, keylen, hash);
+
+  const p = deferredPromise();
+  crypto.pbkdf2(password, salt, iterations, keylen, hash,
+                (err, asyncResult) => {
+                  assert.deepStrictEqual(asyncResult, syncResult);
+                  p.resolve();
+                });
+  await p.promise;
+
+  return syncResult;
+}
+
+async function testPBKDF2(password, salt, iterations, keylen, expected, encoding) {
+  const actual = await runPBKDF2(password, salt, iterations, keylen, 'sha256');
+  assert.strictEqual(actual.toString(encoding || 'latin1'), expected);
+}
+
+//
+// Test PBKDF2 with RFC 6070 test vectors (except #4)
+//
+
+export const pbkdf2_correctness_tests = {
+  async test(ctrl, env, ctx) {
+    await testPBKDF2('password', 'salt', 1, 20,
+               '\x12\x0f\xb6\xcf\xfc\xf8\xb3\x2c\x43\xe7\x22\x52' +
+               '\x56\xc4\xf8\x37\xa8\x65\x48\xc9');
+
+    await testPBKDF2('password', 'salt', 2, 20,
+               '\xae\x4d\x0c\x95\xaf\x6b\x46\xd3\x2d\x0a\xdf\xf9' +
+               '\x28\xf0\x6d\xd0\x2a\x30\x3f\x8e');
+
+    await testPBKDF2('password', 'salt', 4096, 20,
+               '\xc5\xe4\x78\xd5\x92\x88\xc8\x41\xaa\x53\x0d\xb6' +
+               '\x84\x5c\x4c\x8d\x96\x28\x93\xa0');
+
+    await testPBKDF2('passwordPASSWORDpassword',
+               'saltSALTsaltSALTsaltSALTsaltSALTsalt',
+               4096,
+               25,
+               '\x34\x8c\x89\xdb\xcb\xd3\x2b\x2f\x32\xd8\x14\xb8\x11' +
+               '\x6e\x84\xcf\x2b\x17\x34\x7e\xbc\x18\x00\x18\x1c');
+
+    await testPBKDF2('pass\0word', 'sa\0lt', 4096, 16,
+               '\x89\xb6\x9d\x05\x16\xf8\x29\x89\x3c\x69\x62\x26\x65' +
+               '\x0a\x86\x87');
+
+    await testPBKDF2('password', 'salt', 32, 32,
+               '64c486c55d30d4c5a079b8823b7d7cb37ff0556f537da8410233bcec330ed956',
+               'hex');
+  }
+}
+
+export const pbkdf2_no_callback_test = {
+  test(ctrl, env, ctx) {
+    // Error path should not leak memory (check with valgrind).
+    assert.throws(
+      () => crypto.pbkdf2('password', 'salt', 1, 20, 'sha1'),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError'
+      }
+    );
+  }
+}
+
+export const pbkdf2_out_of_range_tests = {
+  test(ctrl, env, ctx) {
+    for (const iterations of [-1, 0, 2147483648]) {
+      assert.throws(
+        () => crypto.pbkdf2Sync('password', 'salt', iterations, 20, 'sha1'),
+        {
+          code: 'ERR_OUT_OF_RANGE',
+          name: 'RangeError',
+        }
+      );
+    }
+
+    ['str', null, undefined, [], {}].forEach((notNumber) => {
+      assert.throws(
+        () => {
+          crypto.pbkdf2Sync('password', 'salt', 1, notNumber, 'sha256');
+        }, {
+          code: 'ERR_INVALID_ARG_TYPE',
+          name: 'TypeError',
+        });
+    });
+
+    [Infinity, -Infinity, NaN].forEach((input) => {
+      assert.throws(
+        () => {
+          crypto.pbkdf2('password', 'salt', 1, input, 'sha256',
+                        mustNotCall());
+        }, {
+          code: 'ERR_OUT_OF_RANGE',
+          name: 'RangeError',
+          message: 'The value of "keylen" is out of range. It ' +
+                   `must be an integer. Received ${input}`
+        });
+    });
+
+    [-1, 2147483648, 4294967296].forEach((input) => {
+      assert.throws(
+        () => {
+          crypto.pbkdf2('password', 'salt', 1, input, 'sha256',
+                        mustNotCall());
+        }, {
+          code: 'ERR_OUT_OF_RANGE',
+          name: 'RangeError',
+        });
+    });
+  }
+}
+
+export const empty_pwd_test = {
+  async test(ctrl, env, ctx) {
+    // Should not get FATAL ERROR with empty password and salt
+    // https://github.com/nodejs/node/issues/8571
+    const p = deferredPromise();
+    crypto.pbkdf2('', '', 1, 32, 'sha256', (err, prime) => {
+      p.resolve();
+    });
+    await p.promise;
+  }
+}
+
+export const invalid_arg_tests = {
+  test(ctrl, env, ctx) {
+    assert.throws(
+      () => crypto.pbkdf2('password', 'salt', 8, 8, mustNotCall()),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError',
+        message: 'The "digest" argument must be of type string. ' +
+                 'Received undefined'
+      });
+
+    assert.throws(
+      () => crypto.pbkdf2Sync('password', 'salt', 8, 8),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError',
+        message: 'The "digest" argument must be of type string. ' +
+                 'Received undefined'
+      });
+
+    assert.throws(
+      () => crypto.pbkdf2Sync('password', 'salt', 8, 8, null),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError',
+        message: 'The "digest" argument must be of type string. ' +
+                 'Received null'
+      });
+    [1, {}, [], true, undefined, null].forEach((input) => {
+      assert.throws(
+        () => crypto.pbkdf2(input, 'salt', 8, 8, 'sha256', mustNotCall()),
+        {
+          code: 'ERR_INVALID_ARG_TYPE',
+          name: 'TypeError',
+        }
+      );
+
+      assert.throws(
+        () => crypto.pbkdf2('pass', input, 8, 8, 'sha256', mustNotCall()),
+        {
+          code: 'ERR_INVALID_ARG_TYPE',
+          name: 'TypeError',
+        }
+      );
+
+      assert.throws(
+        () => crypto.pbkdf2Sync(input, 'salt', 8, 8, 'sha256'),
+        {
+          code: 'ERR_INVALID_ARG_TYPE',
+          name: 'TypeError',
+        }
+      );
+
+      assert.throws(
+        () => crypto.pbkdf2Sync('pass', input, 8, 8, 'sha256'),
+        {
+          code: 'ERR_INVALID_ARG_TYPE',
+          name: 'TypeError',
+        }
+      );
+    });
+
+    ['test', {}, [], true, undefined, null].forEach((i) => {
+      assert.throws(
+        () => crypto.pbkdf2('pass', 'salt', i, 8, 'sha256', mustNotCall()),
+        {
+          code: 'ERR_INVALID_ARG_TYPE',
+          name: 'TypeError',
+        }
+      );
+
+      assert.throws(
+        () => crypto.pbkdf2Sync('pass', 'salt', i, 8, 'sha256'),
+        {
+          code: 'ERR_INVALID_ARG_TYPE',
+          name: 'TypeError',
+        }
+      );
+    });
+  }
+}
+
+export const TypedArray_tests = {
+  async test(ctrl, env, ctx) {
+    // Any TypedArray should work for password and salt.
+    for (const SomeArray of [Uint8Array, Uint16Array, Uint32Array, Float32Array,
+                             Float64Array, ArrayBuffer]) {
+      await runPBKDF2(new SomeArray(10), 'salt', 8, 8, 'sha256');
+      await runPBKDF2('pass', new SomeArray(10), 8, 8, 'sha256');
+    }
+  }
+}
+
+export const invalid_digest_tests = {
+  async test(ctrl, env, ctx) {
+    {
+      const p = deferredPromise();
+      crypto.pbkdf2('pass', 'salt', 8, 8, 'md55',
+        (err, prime) => {
+        if (err) return p.reject(err);
+      });
+      await assert.rejects(p.promise);
+    }
+
+    assert.throws(
+      () => crypto.pbkdf2Sync('pass', 'salt', 8, 8, 'md55'),
+      {
+        name: 'TypeError',
+      }
+    );
+
+    // TODO(soon): Enable this once crypto.getHashes() is available. Note that shake* is not
+    // supported by boringssl so there's no need to filter it out, but we may want to filter other
+    // functions.
+    // const kNotPBKDF2Supported = ['shake128', 'shake256'];
+    // crypto.getHashes()
+    //   .filter((hash) => !kNotPBKDF2Supported.includes(hash))
+    //   .forEach((hash) => {
+    //     runPBKDF2(new Uint8Array(10), 'salt', 8, 8, hash);
+    //   });
+
+    {
+      // This should not crash.
+      assert.throws(
+        () => crypto.pbkdf2Sync('1', '2', 1, 1, '%'),
+        {
+          name: 'TypeError',
+        }
+      );
+    }
+  }
+}

--- a/src/workerd/api/node/crypto_pbkdf2-test.wd-test
+++ b/src/workerd/api/node/crypto_pbkdf2-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "crypto_pbkdf2-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "crypto_pbkdf2-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat", "experimental"]
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/node/crypto_pbkdf2.c++
+++ b/src/workerd/api/node/crypto_pbkdf2.c++
@@ -1,0 +1,37 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+// Copyright Joyent and Node contributors. All rights reserved. MIT license.
+
+#include "crypto.h"
+#include <openssl/evp.h>
+#include <workerd/jsg/jsg.h>
+#include <workerd/api/crypto-impl.h>
+
+namespace workerd::api::node {
+
+kj::Array<kj::byte> CryptoImpl::getPbkdf(kj::Array<kj::byte> password,
+kj::Array<kj::byte> salt, uint32_t num_iterations, uint32_t keylen, kj::String name) {
+  // Should not be needed based on current memory limits, still good to have
+    JSG_REQUIRE(password.size() < INT32_MAX, RangeError,
+        "Pbkdf2 failed: password is too large");
+    JSG_REQUIRE(salt.size() < INT32_MAX, RangeError,
+        "Pbkdf2 failed: password is too large");
+
+  const EVP_MD* digest = EVP_get_digestbyname(name.begin());
+  JSG_REQUIRE(digest != nullptr, TypeError, "Invalid Pbkdf2 digest: ", name, internalDescribeOpensslErrors());
+
+  // Both pass and salt may be zero length here.
+  auto buf = kj::heapArray<byte>(keylen);
+  OSSLCALL(PKCS5_PBKDF2_HMAC((const char *)password.begin(),
+                        password.size(),
+                        salt.begin(),
+                        salt.size(),
+                        num_iterations,
+                        digest,
+                        keylen,
+                        buf.begin()));
+  return buf;
+}
+
+}  // namespace workerd::api::node

--- a/src/workerd/api/node/crypto_pbkdf2.c++
+++ b/src/workerd/api/node/crypto_pbkdf2.c++
@@ -13,13 +13,12 @@ namespace workerd::api::node {
 kj::Array<kj::byte> CryptoImpl::getPbkdf(kj::Array<kj::byte> password,
 kj::Array<kj::byte> salt, uint32_t num_iterations, uint32_t keylen, kj::String name) {
   // Should not be needed based on current memory limits, still good to have
-    JSG_REQUIRE(password.size() < INT32_MAX, RangeError,
-        "Pbkdf2 failed: password is too large");
-    JSG_REQUIRE(salt.size() < INT32_MAX, RangeError,
-        "Pbkdf2 failed: password is too large");
+  JSG_REQUIRE(password.size() < INT32_MAX, RangeError, "Pbkdf2 failed: password is too large");
+  JSG_REQUIRE(salt.size() < INT32_MAX, RangeError, "Pbkdf2 failed: salt is too large");
 
   const EVP_MD* digest = EVP_get_digestbyname(name.begin());
-  JSG_REQUIRE(digest != nullptr, TypeError, "Invalid Pbkdf2 digest: ", name, internalDescribeOpensslErrors());
+  JSG_REQUIRE(digest != nullptr, TypeError, "Invalid Pbkdf2 digest: ", name,
+              internalDescribeOpensslErrors());
 
   // Both pass and salt may be zero length here.
   auto buf = kj::heapArray<byte>(keylen);


### PR DESCRIPTION
This patch implements the `crypto.pbkdf2Sync()` and `crypto.pbkdf2()` functions. Work is still needed in a few places, notably async has not been implemented. For some of these changes, it is probably better when some of the other crypto PRs get merged first, e.g. to establish `node-internal:crypto_util`.