### PR TITLE
performance.now() must return excatly what Date.now() returns.

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -712,9 +712,9 @@ jsg::Promise<jsg::Ref<Response>> ServiceWorkerGlobalScope::fetch(
 }
 
 double Performance::now() {
-  // Time never progresses outside of an IoContext.
-  if (!IoContext::hasCurrent()) return 0.0;
-  return IoContext::current().performanceNow();
+  // We define performance.now() for compatibility purposes, but due to spectre concerns it
+  // returns exactly what Date.now() returns.
+  return dateNow();
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -41,8 +41,18 @@ public:
 class Performance: public jsg::Object {
 public:
   double getTimeOrigin() { return 0.0; }
-  // We always return a time origin of 0. For us this represents the time at which the
-  // IoContext was created.
+  // We always return a time origin of 0, making performance.now() equivalent to Date.now(). There
+  // is no other appropriate time origin to use given that the Worker platform is intended to be
+  // treated like one big computer rather than many individual instances. In particular, if and
+  // when we start snapshotting applications after startup and then starting instances from that
+  // snapshot, what would the right time origin be? The time when the snapshot was created? This
+  // seems to leak implementation details in a weird way.
+  //
+  // Note that the purpose of `timeOrigin` is normally to allow `now()` to return a more-precise
+  // measurement. Measuring against a recent time allows the values returned by `now()` to be
+  // smaller in magnitude, which allows them to be more precise due to the nature of floating
+  // point numbers. In our case, though, we don't return precise measurements from this interface
+  // anyway, for Spectre reasons -- it returns the same as Date.now().
 
   double now();
 

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -825,15 +825,6 @@ kj::Date IoContext::now() {
   return now(getCurrentIncomingRequest());
 }
 
-double IoContext::performanceNow() {
-  // If there are no incoming requests, this should always return 0.0.
-  // Otherwise, the time origin for an incoming request should always be set.
-  if (!incomingRequests.empty()) {
-    return (now() - kj::UNIX_EPOCH) / kj::NANOSECONDS * 1e-6;
-  }
-  return 0.0;
-}
-
 kj::Own<WorkerInterface> IoContext::getSubrequestNoChecks(
     kj::FunctionParam<kj::Own<WorkerInterface>(SpanBuilder&, IoChannelFactory&)> func,
     SubrequestOptions options) {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -700,8 +700,6 @@ public:
   kj::Date now();
   // Access the event loop's current time point. This will remain constant between ticks.
 
-  double performanceNow();
-
   kj::Promise<void> atTime(kj::Date when) { return getIoChannelFactory().getTimer().atTime(when); }
   // Returns a promise that resolves once `now() >= when`.
 


### PR DESCRIPTION
Returning higher precision might impact our Spectre risk. We cannot do this without careful study.