### PR TITLE
[nfc] Clean up includes, refactor bazel dependencies

### DIFF
--- a/src/workerd/api/actor-state-test.c++
+++ b/src/workerd/api/actor-state-test.c++
@@ -3,12 +3,13 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include <kj/test.h>
+#include <kj/encoding.h>
 
 #include <fstream>
 #include <iostream>
 
-#include "streams.h"
 #include <workerd/api/util.h>
+#include <workerd/api/actor-state.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/ser.h>
 #include <workerd/jsg/setup.h>

--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -4,12 +4,10 @@
 
 #include "actor-state.h"
 #include "actor.h"
-#include <workerd/api/global-scope.h>
+#include "util.h"
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/ser.h>
 #include <workerd/jsg/util.h>
-#include <workerd/util/sentry.h>
-#include <capnp/message.h>
 #include <v8.h>
 #include <workerd/io/actor-cache.h>
 #include <workerd/io/actor-storage.h>

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -12,8 +12,6 @@
 #include <workerd/io/actor-storage.capnp.h>
 #include <kj/async.h>
 #include <v8.h>
-#include <workerd/io/promise-wrapper.h>
-#include "util.h"
 #include <workerd/io/actor-cache.h>
 #include "sql.h"
 

--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -4,7 +4,6 @@
 
 #include "actor.h"
 #include "util.h"
-#include "system-streams.h"
 #include <kj/encoding.h>
 #include <kj/compat/http.h>
 #include <capnp/compat/byte-stream.h>

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -9,7 +9,6 @@
 // to expect something that looked more specifically like Erlang, whereas our actors are much more
 // abstractly related.
 
-#include <kj/async.h>
 #include <capnp/compat/byte-stream.h>
 #include <capnp/compat/http-over-capnp.h>
 #include <workerd/api/http.h>

--- a/src/workerd/api/analytics-engine.c++
+++ b/src/workerd/api/analytics-engine.c++
@@ -3,7 +3,6 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "analytics-engine.h"
-#include <capnp/serialize-text.h>
 #include <workerd/io/io-context.h>
 
 namespace workerd::api {

--- a/src/workerd/api/analytics-engine.h
+++ b/src/workerd/api/analytics-engine.h
@@ -8,7 +8,6 @@
 #include <workerd/api/analytics-engine-impl.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/api/analytics-engine.capnp.h>
-#include <kj/async.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -11,7 +11,7 @@
 #include <workerd/util/canceler.h>
 #include <kj/function.h>
 #include <kj/map.h>
-#include <workerd/io/io-context.h>
+#include <workerd/io/compatibility-date.capnp.h>
 #include "actor-state.h"
 
 namespace workerd::api {

--- a/src/workerd/api/blob.c++
+++ b/src/workerd/api/blob.c++
@@ -3,7 +3,8 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "blob.h"
-#include "system-streams.h"
+#include "streams.h"
+#include "util.h"
 
 namespace workerd::api {
 

--- a/src/workerd/api/cache.h
+++ b/src/workerd/api/cache.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <workerd/jsg/jsg.h>
-#include <kj/async.h>
 #include "util.h"
 #include "http.h"
 

--- a/src/workerd/api/crypto-impl-aes.c++
+++ b/src/workerd/api/crypto-impl-aes.c++
@@ -9,7 +9,6 @@
 #include <openssl/bn.h>
 #include <openssl/err.h>
 #include <workerd/io/io-context.h>
-#include <set>
 
 namespace workerd::api {
 namespace {

--- a/src/workerd/api/crypto-impl-asymmetric.c++
+++ b/src/workerd/api/crypto-impl-asymmetric.c++
@@ -10,7 +10,6 @@
 #include <openssl/crypto.h>
 #include <openssl/curve25519.h>
 #include <map>
-#include <set>
 #include <kj/function.h>
 #include <type_traits>
 #include "util.h"

--- a/src/workerd/api/crypto-impl-hkdf.c++
+++ b/src/workerd/api/crypto-impl-hkdf.c++
@@ -3,8 +3,6 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "crypto-impl.h"
-#include <set>
-#include <openssl/err.h>
 #include <openssl/hkdf.h>
 
 namespace workerd::api {

--- a/src/workerd/api/crypto-impl-hmac.c++
+++ b/src/workerd/api/crypto-impl-hmac.c++
@@ -7,7 +7,6 @@
 #include <workerd/io/io-context.h>
 #include <openssl/hmac.h>
 #include <openssl/mem.h>
-#include <set>
 
 namespace workerd::api {
 namespace {

--- a/src/workerd/api/crypto-impl-pbkdf2.c++
+++ b/src/workerd/api/crypto-impl-pbkdf2.c++
@@ -3,7 +3,6 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "crypto-impl.h"
-#include <set>
 
 namespace workerd::api {
 namespace {

--- a/src/workerd/api/crypto-impl-test.c++
+++ b/src/workerd/api/crypto-impl-test.c++
@@ -6,6 +6,7 @@
 
 #include "crypto-impl.h"
 
+#include <openssl/err.h>
 #include <openssl/rsa.h>
 #include <openssl/ec.h>
 

--- a/src/workerd/api/crypto-impl.h
+++ b/src/workerd/api/crypto-impl.h
@@ -8,6 +8,7 @@
 // Don't include this file unless your name is "crypto*.c++".
 
 #include "crypto.h"
+#include <kj/encoding.h>
 #include <openssl/evp.h>
 
 #define OSSLCALL(...) if ((__VA_ARGS__) != 1) \

--- a/src/workerd/api/crypto.c++
+++ b/src/workerd/api/crypto.c++
@@ -11,7 +11,6 @@
 #include "util.h"
 #include <workerd/io/io-context.h>
 #include <workerd/util/uuid.h>
-#include <map>
 #include <set>
 #include <algorithm>
 #include <limits>

--- a/src/workerd/api/encoding.c++
+++ b/src/workerd/api/encoding.c++
@@ -3,13 +3,10 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "encoding.h"
-#include "util.h"
-#include <kj/encoding.h>
 #include <unicode/ucnv.h>
 #include <unicode/utf8.h>
 #include <algorithm>
-#include <array>
-#include <workerd/io/io-context.h>
+
 namespace workerd::api {
 
 // =======================================================================================

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -10,11 +10,8 @@
 #include <workerd/jsg/async-context.h>
 #include <workerd/jsg/ser.h>
 #include <workerd/jsg/util.h>
-#include <workerd/io/trace.h>
 #include <workerd/io/io-context.h>
 #include <workerd/util/sentry.h>
-#include <workerd/util/sentry.h>
-#include <workerd/util/own-util.h>
 #include <workerd/util/thread-scopes.h>
 
 namespace workerd::api {

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -22,6 +22,8 @@
 #include "hibernatable-web-socket.h"
 #include "blob.h"
 #include "sockets.h"
+#include "streams.h"
+#include "streams/standard.h"
 
 namespace workerd::api {
 

--- a/src/workerd/api/hibernatable-web-socket.c++
+++ b/src/workerd/api/hibernatable-web-socket.c++
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "hibernatable-web-socket.h"
+#include <workerd/api/global-scope.h>
 #include <workerd/jsg/ser.h>
 
 namespace workerd::api {

--- a/src/workerd/api/hibernatable-web-socket.h
+++ b/src/workerd/api/hibernatable-web-socket.h
@@ -7,8 +7,9 @@
 #include <kj/debug.h>
 
 #include <workerd/io/worker-interface.capnp.h>
-#include <workerd/api/global-scope.h>
 #include <workerd/io/worker-interface.h>
+#include <workerd/api/basics.h>
+#include <workerd/api/web-socket.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/html-rewriter.c++
+++ b/src/workerd/api/html-rewriter.c++
@@ -3,10 +3,9 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "html-rewriter.h"
-#include "system-streams.h"
+#include "streams.h"
 #include "util.h"
 #include "c-api/include/lol_html.h"
-#include <workerd/io/promise-wrapper.h>
 #include <workerd/io/io-context.h>
 
 struct lol_html_HtmlRewriter {};

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -5,7 +5,7 @@
 #include "kv.h"
 #include "util.h"
 #include "system-streams.h"
-#include "workerd/io/limit-enforcer.h"
+#include <workerd/io/limit-enforcer.h>
 #include <workerd/util/http-util.h>
 #include <workerd/io/io-context.h>
 #include <kj/encoding.h>

--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -6,8 +6,9 @@
 
 #include <workerd/jsg/jsg.h>
 #include "http.h"
-#include "workerd/io/io-context.h"
+#include <workerd/io/limit-enforcer.h>
 
+namespace workerd { class IoContext; }
 namespace workerd::api {
 
 class KvNamespace: public jsg::Object {

--- a/src/workerd/api/node/async-hooks.h
+++ b/src/workerd/api/node/async-hooks.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <workerd/jsg/jsg.h>
-#include <workerd/io/compatibility-date.h>
+#include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/jsg/async-context.h>
 #include <kj/table.h>
 

--- a/src/workerd/api/node/buffer.c++
+++ b/src/workerd/api/node/buffer.c++
@@ -7,7 +7,6 @@
 #include "buffer-base64.h"
 #include "buffer-string-search.h"
 #include <workerd/jsg/buffersource.h>
-#include <workerd/api/crypto-impl.h>
 #include <kj/encoding.h>
 #include <algorithm>
 

--- a/src/workerd/api/node/buffer.h
+++ b/src/workerd/api/node/buffer.h
@@ -6,7 +6,6 @@
 #include <workerd/jsg/jsg.h>
 #include <workerd/io/compatibility-date.h>
 #include <workerd/jsg/async-context.h>
-#include <kj/table.h>
 
 namespace workerd::api::node {
 

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -2,6 +2,7 @@
 
 #include <workerd/jsg/ser.h>
 #include <workerd/api/global-scope.h>
+#include <kj/encoding.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/r2-admin.c++
+++ b/src/workerd/api/r2-admin.c++
@@ -5,7 +5,6 @@
 #include "r2-admin.h"
 #include "r2-rpc.h"
 #include <workerd/api/util.h>
-#include <workerd/api/system-streams.h>
 #include <kj/compat/http.h>
 #include <capnp/compat/json.h>
 #include <workerd/util/http-util.h>

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -9,6 +9,7 @@
 #include <math.h>
 #include <workerd/api/util.h>
 #include <workerd/api/system-streams.h>
+#include <kj/encoding.h>
 #include <kj/compat/http.h>
 #include <capnp/compat/json.h>
 #include <workerd/util/http-util.h>

--- a/src/workerd/api/r2-multipart.c++
+++ b/src/workerd/api/r2-multipart.c++
@@ -8,7 +8,6 @@
 #include <array>
 #include <math.h>
 #include <workerd/api/util.h>
-#include <workerd/api/system-streams.h>
 #include <kj/compat/http.h>
 #include <capnp/compat/json.h>
 #include <workerd/util/http-util.h>

--- a/src/workerd/api/scheduled.h
+++ b/src/workerd/api/scheduled.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <workerd/jsg/jsg.h>
-#include <kj/async.h>
 #include "basics.h"
 
 namespace workerd::api {

--- a/src/workerd/api/streams.h
+++ b/src/workerd/api/streams.h
@@ -12,7 +12,6 @@
 #include "streams/transform.h"
 #include "streams/compression.h"
 #include "streams/encoding.h"
-#include "streams/standard.h"
 
 namespace workerd::api {
 

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -5,14 +5,8 @@
 #pragma once
 
 #include <workerd/jsg/jsg.h>
-#include <kj/async-io.h>
-#include <kj/vector.h>
 #include <workerd/io/io-context.h>
 #include "../basics.h"
-#include "../util.h"
-
-#include <deque>
-#include <queue>
 
 #if _MSC_VER
 typedef long long ssize_t;

--- a/src/workerd/api/streams/compression.c++
+++ b/src/workerd/api/streams/compression.c++
@@ -3,7 +3,6 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "compression.h"
-#include "internal.h"
 #include <zlib.h>
 #include <deque>
 #include <vector>

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -5,8 +5,8 @@
 #include "internal.h"
 #include "readable.h"
 #include "writable.h"
-#include "transform.h"
 #include <workerd/jsg/jsg.h>
+#include <kj/vector.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -6,6 +6,7 @@
 
 #include "common.h"
 #include <workerd/io/io-context.h>
+#include <deque>
 
 namespace workerd::api {
 

--- a/src/workerd/api/streams/queue.h
+++ b/src/workerd/api/streams/queue.h
@@ -7,9 +7,7 @@
 #include "common.h"
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/buffersource.h>
-#include <algorithm>
 #include <deque>
-#include <kj/table.h>
 #include <set>
 
 namespace workerd::api {

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -6,7 +6,7 @@
 #include "readable.h"
 #include "writable.h"
 #include <workerd/jsg/buffersource.h>
-#include <iterator>
+#include <kj/vector.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -5,10 +5,8 @@
 #pragma once
 
 #include "common.h"
-#include "internal.h"
 #include "queue.h"
 #include <workerd/jsg/function.h>
-#include <workerd/jsg/buffersource.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/streams/transform.c++
+++ b/src/workerd/api/streams/transform.c++
@@ -4,8 +4,8 @@
 
 #include "transform.h"
 #include "standard.h"
+#include "internal.h"
 #include <workerd/jsg/function.h>
-#include <cmath>
 
 namespace workerd::api {
 

--- a/src/workerd/api/urlpattern.c++
+++ b/src/workerd/api/urlpattern.c++
@@ -4,6 +4,7 @@
 
 #include "urlpattern.h"
 #include "url-standard.h"
+#include "util.h"
 #include <kj/vector.h>
 #include <unicode/uchar.h>
 #include <algorithm>

--- a/src/workerd/api/util.h
+++ b/src/workerd/api/util.h
@@ -6,10 +6,9 @@
 
 #include <kj/async-io.h>
 #include <kj/compat/url.h>
-#include <kj/encoding.h>
+#include <kj/string.h>
 #include <workerd/jsg/jsg.h>
 #include <v8.h>
-#include <queue>
 
 namespace workerd::api {
 

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -7,6 +7,7 @@
 #include <workerd/io/io-context.h>
 #include <workerd/io/worker.h>
 #include <workerd/util/sentry.h>
+#include <kj/compat/url.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <workerd/jsg/jsg.h>
-#include <workerd/jsg/string.h>
 #include <kj/compat/http.h>
 #include "basics.h"
 #include <workerd/io/io-context.h>

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -50,6 +50,9 @@ wd_cc_library(
         "//src/workerd/jsg",
         "//src/workerd/util:sqlite",
         "@capnp-cpp//src/kj:kj-async",
+        "@capnp-cpp//src/kj/compat:kj-gzip",
+        "@capnp-cpp//src/capnp/compat:http-over-capnp",
+        "@capnp-cpp//src/capnp:capnp-rpc",
         "@com_cloudflare_lol_html//:lolhtml",
     ],
 )

--- a/src/workerd/io/actor-cache-test.c++
+++ b/src/workerd/io/actor-cache-test.c++
@@ -6,7 +6,6 @@
 #include <kj/test.h>
 #include <kj/debug.h>
 #include <capnp/dynamic.h>
-#include <capnp/serialize-text.h>
 #include <kj/list.h>
 #include "io-gate.h"
 #include <kj/thread.h>

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -12,7 +12,6 @@
 #include <kj/time.h>
 #include <kj/mutex.h>
 #include <atomic>
-#include <workerd/util/wait-list.h>
 
 namespace workerd {
 

--- a/src/workerd/io/compatibility-date.c++
+++ b/src/workerd/io/compatibility-date.c++
@@ -2,14 +2,12 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+#include <stdio.h>
 #include "compatibility-date.h"
 #include "time.h"
 #include <capnp/schema.h>
 #include <capnp/dynamic.h>
-
-#if _WIN32
-#include <stdio.h>
-#endif
+#include <kj/map.h>
 
 namespace workerd {
 

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <kj/string.h>
+#include <kj/compat/http.h>
 #include <workerd/io/trace.h>
 #include <workerd/io/worker-interface.h>
 

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -8,9 +8,7 @@
 #include <kj/threadlocal.h>
 #include <kj/debug.h>
 #include <workerd/jsg/jsg.h>
-#include <capnp/message.h>
 #include <workerd/util/sentry.h>
-#include <workerd/util/own-util.h>
 #include <map>
 
 namespace workerd {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -8,7 +8,6 @@
 #include <kj/compat/http.h>
 #include <kj/mutex.h>
 #include <kj/function.h>
-#include <kj/map.h>
 
 #include <workerd/io/trace.h>
 #include <workerd/io/worker.h>

--- a/src/workerd/io/promise-wrapper-test.c++
+++ b/src/workerd/io/promise-wrapper-test.c++
@@ -8,7 +8,6 @@
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/setup.h>
 #include <workerd/jsg/jsg-test.h>
-#include <array>
 
 namespace workerd::jsg::test {  // workerd
 namespace {

--- a/src/workerd/io/promise-wrapper.h
+++ b/src/workerd/io/promise-wrapper.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <workerd/io/io-context.h>
-#include <workerd/io/worker.h>
 #include <workerd/jsg/jsg.h>
 
 namespace workerd {

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -7,7 +7,6 @@
 #include <kj/compat/http.h>
 #include <kj/debug.h>
 #include <cstdlib>
-#include <workerd/util/thread-scopes.h>
 
 namespace workerd {
 

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -7,7 +7,6 @@
 #include <workerd/jsg/jsg.h>
 #include <workerd/util/sentry.h>
 #include <workerd/api/global-scope.h>
-#include <workerd/util/own-util.h>
 #include <workerd/util/thread-scopes.h>
 
 namespace workerd {

--- a/src/workerd/io/worker-interface.c++
+++ b/src/workerd/io/worker-interface.c++
@@ -4,7 +4,6 @@
 
 #include "worker-interface.h"
 #include <kj/debug.h>
-#include <workerd/util/own-util.h>
 
 namespace workerd {
 

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -9,6 +9,7 @@
 #include <capnp/compat/http-over-capnp.h>
 
 #include <workerd/io/outcome.capnp.h>
+#include <workerd/io/worker-interface.capnp.h>
 
 namespace workerd {
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -5,18 +5,16 @@
 #include <workerd/io/worker.h>
 #include <workerd/io/promise-wrapper.h>
 #include "actor-cache.h"
+#include <workerd/util/batch-queue.h>
 #include <workerd/util/thread-scopes.h>
 #include <workerd/api/global-scope.h>
-#include <workerd/api/system-streams.h>  // for api::StreamEncoding
+#include <workerd/api/streams.h>  // for api::StreamEncoding
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/modules.h>
 #include <workerd/jsg/util.h>
-#include <workerd/jsg/setup.h>
 #include <workerd/io/cdp.capnp.h>
 #include <workerd/io/compatibility-date.h>
-#include <workerd/util/wait-list.h>
 #include <capnp/compat/json.h>
-#include <capnp/schema-loader.h>
 #include <kj/compat/gzip.h>
 #include <kj/encoding.h>
 #include <kj/filesystem.h>
@@ -2619,7 +2617,6 @@ struct Worker::Actor::Impl final: public kj::TaskSet::ErrorHandler {
 
   kj::Maybe<kj::Own<IoContext>> ioContext;
   // `ioContext` is initialized upon delivery of the first request.
-  // TODO(cleanup): Rename IoContext to IoContext.
 
   kj::Maybe<kj::Own<kj::PromiseFulfiller<kj::Promise<void>>>> abortFulfiller;
   // If onBroken() is called while `ioContext` is still null, this is initialized. When

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -8,6 +8,7 @@
 #include "wrappable.h"
 #include "jsg.h"
 #include "web-idl.h"
+#include <kj/async.h>
 
 namespace workerd::jsg {
 

--- a/src/workerd/jsg/rtti-test.c++
+++ b/src/workerd/jsg/rtti-test.c++
@@ -2,8 +2,9 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+#include <capnp/message.h>
 #include <capnp/serialize-text.h>
-#include <workerd/jsg/jsg-test.h>
+#include <kj/test.h>
 #include <workerd/jsg/rtti.h>
 
 struct MockConfig {};

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -9,11 +9,9 @@
 // Can be used to generate typescript type, dynamically invoke methods, fuzz, check backward
 // compatibility etc.
 
-#include <type_traits>
-#include <capnp/message.h>
-#include <kj/table.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/rtti.capnp.h>
+#include <kj/map.h>
 
 namespace workerd::jsg::rtti {
 

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -8,7 +8,6 @@
 #endif
 
 #include "setup.h"
-#include "async-context.h"
 #include <workerd/util/uuid.h>
 #include "libplatform/libplatform.h"
 #include <v8-cppgc.h>

--- a/src/workerd/jsg/string.c++
+++ b/src/workerd/jsg/string.c++
@@ -3,11 +3,8 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "string.h"
-#include <unicode/uchar.h>
-#include <unicode/ustring.h>
 #include <unicode/utf8.h>
 #include <unicode/utf16.h>
-#include <kj/encoding.h>
 #include <algorithm>
 
 namespace workerd::jsg {

--- a/src/workerd/jsg/string.h
+++ b/src/workerd/jsg/string.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "jsg.h"
-#include <compare>
 
 namespace workerd::jsg {
 

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -7,7 +7,6 @@
 //
 // This file contains misc utility functions used elsewhere.
 
-#include <kj/async.h>
 #include <kj/debug.h>
 #include <kj/string.h>
 #include <kj/exception.h>

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -13,7 +13,6 @@
 #include "jsg.h"
 #include "web-idl.h"
 #include <kj/time.h>
-#include <kj/tuple.h>
 #include <kj/debug.h>
 #include <kj/one-of.h>
 

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -6,6 +6,7 @@
 #include "jsg.h"
 #include "setup.h"
 #include <kj/debug.h>
+#include <kj/async.h>
 #include <v8-cppgc.h>
 #include <cppgc/allocation.h>
 #include <cppgc/garbage-collected.h>

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -11,7 +11,6 @@
 #include <kj/common.h>
 #include <kj/refcount.h>
 #include <kj/vector.h>
-#include <kj/string.h>
 #include <kj/list.h>
 #include <v8.h>
 

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -5,7 +5,6 @@
 #include "server.h"
 #include <kj/test.h>
 #include <workerd/util/capnp-mock.h>
-#include <capnp/serialize-text.h>
 #include <workerd/jsg/setup.h>
 #include <kj/async-queue.h>
 #include <regex>

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -11,8 +11,6 @@
 #include <kj/map.h>
 #include <workerd/io/worker-interface.h>
 #include <workerd/io/worker-entrypoint.h>
-#include <workerd/io/worker.h>
-#include <workerd/jsg/setup.h>
 #include <workerd/io/compatibility-date.h>
 #include <workerd/io/io-context.h>
 #include <workerd/io/worker.h>

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -21,6 +21,7 @@
 #include <workerd/api/r2-admin.h>
 #include <workerd/api/urlpattern.h>
 #include <workerd/api/node/node.h>
+#include <workerd/io/promise-wrapper.h>
 #include <workerd/util/thread-scopes.h>
 #include <openssl/sha.h>
 #include <openssl/hmac.h>

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <workerd/io/worker.h>
-#include <workerd/api/analytics-engine.h>
 #include <workerd/server/workerd.capnp.h>
 
 namespace workerd::server {

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -18,7 +18,7 @@
 #include "server.h"
 #include <workerd/jsg/setup.h>
 #include <openssl/rand.h>
-#include <workerd/io/compatibility-date.h>
+#include <workerd/io/compatibility-date.capnp.h>
 
 #if _WIN32
 #include <iostream>

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -8,7 +8,6 @@
 #include <workerd/io/worker-entrypoint.h>
 #include <workerd/jsg/modules.h>
 #include <workerd/server/workerd-api.h>
-#include <workerd/server/workerd-api.h>
 
 #include "test-fixture.h"
 

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -25,9 +25,6 @@ wd_cc_library(
     ),
     visibility = ["//visibility:public"],
     deps = [
-        "@capnp-cpp//src/capnp:capnp-rpc",
-        "@capnp-cpp//src/capnp/compat:http-over-capnp",
-        "@capnp-cpp//src/kj/compat:kj-gzip",
         "@capnp-cpp//src/kj/compat:kj-http",
         "@capnp-cpp//src/kj/compat:kj-tls",
     ],
@@ -56,7 +53,6 @@ wd_cc_library(
     hdrs = glob(["capnp-mock.h"]),
     visibility = ["//visibility:public"],
     deps = [
-        "@capnp-cpp//src/capnp:capnp-rpc",
         "@capnp-cpp//src/capnp:capnpc",
     ],
 )

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -5,6 +5,7 @@
 #include "sqlite.h"
 #include <kj/test.h>
 #include <kj/thread.h>
+#include <stdlib.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <atomic>

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -4,6 +4,7 @@
 
 #include "sqlite.h"
 #include <kj/debug.h>
+#include <kj/refcount.h>
 
 #if _WIN32
 #include <kj/win32-api-version.h>

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <kj/filesystem.h>
-#include <kj/async.h>
 #include <kj/one-of.h>
 #include <utility>
 


### PR DESCRIPTION
First part of the includes cleanup effort, which should make compilation faster. Where needed, headers are added when a source file needs them and previously included them indirectly. Overall the impact on compile times is smaller than expected as many include dependencies are hard to break up, but for small files that include many headers (e.g. `api/crypto-impl-pbkdf2.c++`) there is as much as a 3x speedup in debug compile time with the full comment cleanup.
Also includes a small simplification of the build system by not requiring some capnp libraries for the util target.
Also see the upstream PR.