### PR TITLE
Modify SQLite allowlists and limits as needed for D1.

### DIFF
--- a/build/BUILD.sqlite3
+++ b/build/BUILD.sqlite3
@@ -8,5 +8,6 @@ cc_library(
     defines = [
         "SQLITE_MAX_ALLOCATION_SIZE=16777216",  # 16MB
         "SQLITE_PRINTF_PRECISION_LIMIT=100000",
+        "SQLITE_ENABLE_FTS5",
     ]
 )

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -140,17 +140,14 @@ async function test(sql) {
 
   // Test reading read-only pragmas
   {
-    const result = [...sql.exec("pragma max_page_count;")];
+    const result = [...sql.exec("pragma data_version;")];
     assert.equal(result.length, 1);
-    assert.equal(result[0]["max_page_count"], 1073741823);
-  }
-  {
-    const result = [...sql.exec("pragma page_size;")];
-    assert.equal(result.length, 1);
-    assert.equal(result[0]["page_size"], 4096);
+    assert.equal(result[0]["data_version"], 2);
   }
 
   // Trying to write to read-only pragmas is not allowed
+  requireException(() => sql.exec("PRAGMA data_version = 5"),
+    "not authorized");
   requireException(() => sql.exec("PRAGMA max_page_count = 65536"),
     "not authorized");
   requireException(() => sql.exec("PRAGMA page_size = 8192"),
@@ -263,32 +260,6 @@ async function test(sql) {
   }
 
   // Complex queries
-
-  // List num tables and total DB size
-  {
-    let result = [...sql.exec(`
-        SELECT (
-            SELECT count(1)
-            FROM sqlite_master
-            WHERE TYPE = "table"
-                AND tbl_name NOT LIKE "sqlite_%"
-                AND tbl_name NOT LIKE "d1_%"
-                AND tbl_name NOT LIKE "_cf_%"
-        ) as num_tables,
-        page_size * (total_pages - num_free) as db_size
-        FROM (
-            SELECT (
-                SELECT * from pragma_freelist_count
-            ) as num_free, (
-                SELECT * from pragma_page_count
-            ) as total_pages, (
-                SELECT * from pragma_page_size
-            ) as page_size
-        );`)];
-    assert.equal(result.length, 1);
-    assert.equal(result[0].num_tables, 8);
-    assert.equal(result[0].db_size, 36864);
-  }
 
   // List table info
   {

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -316,6 +316,12 @@ async function test(sql) {
   assertInvalidBool("abcd");
   assertInvalidBool("\"foo\"");
   assertInvalidBool("'yes", "unrecognized token");
+
+  // Test database size interface.
+  assert.equal(sql.databaseSize, 36864);
+  assert.equal(sql.voluntarySizeLimit, 1073741823 * 4096);
+  sql.voluntarySizeLimit = 65536;
+  assert.equal(sql.voluntarySizeLimit, 65536);
 }
 
 export class DurableObjectExample {

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -22,6 +22,27 @@ jsg::Ref<SqlStorage::Statement> SqlStorage::prepare(jsg::Lock& js, kj::String qu
   return jsg::alloc<Statement>(sqlite->prepare(*this, query));
 }
 
+double SqlStorage::getDatabaseSize() {
+  int64_t pages = execMemoized(pragmaPageCount, "PRAGMA page_count;").getInt64(0);
+  return pages * getPageSize();
+}
+
+double SqlStorage::getVoluntarySizeLimit() {
+  int64_t pages = execMemoized(pragmaGetMaxPageCount, "PRAGMA max_page_count;").getInt64(0);
+  return pages * getPageSize();
+}
+
+void SqlStorage::setVoluntarySizeLimit(int64_t value) {
+  JSG_REQUIRE(value > 0, TypeError, "Size limit must be a positive integer.");
+
+  uint64_t pages = value / getPageSize();
+
+  // Annoyingly, pragmas cannot be parameterized. Apparently there's an alternate syntax where
+  // they can be but I couldn't figure it out. So whatever. `pages` is just an integer so no
+  // injection is possible here.
+  sqlite->run(SqliteDatabase::TRUSTED, kj::str("PRAGMA max_page_count = ", pages, ";"));
+}
+
 bool SqlStorage::isAllowedName(kj::StringPtr name) {
   return !name.startsWith("_cf_");
 }

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -256,12 +256,6 @@ struct PragmaInfo {
 static constexpr PragmaInfo ALLOWED_PRAGMAS[] = {
   // We allowlist these SQLite pragmas (for read only, never with arguments).
   { "data_version"_kj, PragmaSignature::NO_ARG },
-  { "page_count"_kj, PragmaSignature::NO_ARG },
-  { "freelist_count"_kj, PragmaSignature::NO_ARG },
-
-  // Let a user see some internal stats?
-  { "max_page_count"_kj, PragmaSignature::NO_ARG },
-  { "page_size"_kj, PragmaSignature::NO_ARG },
 
   // We allowlist some SQLite pragmas for changing internal state
 

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -530,11 +530,11 @@ void SqliteDatabase::setupSecurity() {
   // We use the suggested limits from the web site. Note that sqlite3_limit() does NOT return an
   // error code; it returns the old limit.
   sqlite3_limit(db, SQLITE_LIMIT_LENGTH, 1000000);
-  sqlite3_limit(db, SQLITE_LIMIT_SQL_LENGTH, 100000);
+  sqlite3_limit(db, SQLITE_LIMIT_SQL_LENGTH, 1000000);
   sqlite3_limit(db, SQLITE_LIMIT_COLUMN, 100);
-  sqlite3_limit(db, SQLITE_LIMIT_EXPR_DEPTH, 10);
-  sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 3);
-  sqlite3_limit(db, SQLITE_LIMIT_VDBE_OP, 25000);
+  sqlite3_limit(db, SQLITE_LIMIT_EXPR_DEPTH, 20);
+  sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 500);
+  sqlite3_limit(db, SQLITE_LIMIT_VDBE_OP, 131072);
   sqlite3_limit(db, SQLITE_LIMIT_FUNCTION_ARG, 8);
   sqlite3_limit(db, SQLITE_LIMIT_ATTACHED, 0);
   sqlite3_limit(db, SQLITE_LIMIT_LIKE_PATTERN_LENGTH, 50);

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -469,7 +469,7 @@ bool SqliteDatabase::isAuthorized(int actionCode,
 
     case SQLITE_FUNCTION           :   /* NULL            Function Name   */
       {
-        const kj::HashSet<kj::StringPtr> allowSet = []() {
+        static const kj::HashSet<kj::StringPtr> allowSet = []() {
           kj::HashSet<kj::StringPtr> result;
           for (const kj::StringPtr& func: ALLOWED_SQLITE_FUNCTIONS) {
             result.insert(func);

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -21,6 +21,10 @@
 #include <kj/mutex.h>
 #include <atomic>
 
+#if _WIN32
+#define strncasecmp _strnicmp
+#endif
+
 namespace workerd {
 
 #define SQLITE_REQUIRE(condition, errorMessage, ...) \

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -234,6 +234,12 @@ static constexpr kj::StringPtr ALLOWED_SQLITE_FUNCTIONS[] = {
   "json_group_object"_kj,
   "json_each"_kj,
   "json_tree"_kj,
+
+  // https://www.sqlite.org/fts5.html
+  "match"_kj,
+  "highlight"_kj,
+  "bm25"_kj,
+  "snippet"_kj,
 };
 
 // https://www.sqlite.org/pragma.html
@@ -539,8 +545,15 @@ bool SqliteDatabase::isAuthorized(int actionCode,
 
     case SQLITE_CREATE_VTABLE      :   /* Table Name      Module Name     */
     case SQLITE_DROP_VTABLE        :   /* Table Name      Module Name     */
-      // Virtual tables are tables backed by some native-code callbacks. We don't support these.
-      return false;
+      // Virtual tables are tables backed by some native-code callbacks. We don't support these except for FTS5 (Full Text Search) https://www.sqlite.org/fts5.html
+      {
+        KJ_IF_MAYBE (moduleName, param2) {
+          if (*moduleName == "fts5") {
+            return true;
+          }
+        }
+        return false;
+      }
 
     case SQLITE_ATTACH             :   /* Filename        NULL            */
     case SQLITE_DETACH             :   /* Database Name   NULL            */

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -619,11 +619,11 @@ void SqliteDatabase::setupSecurity() {
   // We use the suggested limits from the web site. Note that sqlite3_limit() does NOT return an
   // error code; it returns the old limit.
   sqlite3_limit(db, SQLITE_LIMIT_LENGTH, 1000000);
-  sqlite3_limit(db, SQLITE_LIMIT_SQL_LENGTH, 1000000);
+  sqlite3_limit(db, SQLITE_LIMIT_SQL_LENGTH, 100000);
   sqlite3_limit(db, SQLITE_LIMIT_COLUMN, 100);
   sqlite3_limit(db, SQLITE_LIMIT_EXPR_DEPTH, 20);
-  sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 500);
-  sqlite3_limit(db, SQLITE_LIMIT_VDBE_OP, 131072);
+  sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 3);
+  sqlite3_limit(db, SQLITE_LIMIT_VDBE_OP, 25000);
   sqlite3_limit(db, SQLITE_LIMIT_FUNCTION_ARG, 8);
   sqlite3_limit(db, SQLITE_LIMIT_ATTACHED, 0);
   sqlite3_limit(db, SQLITE_LIMIT_LIKE_PATTERN_LENGTH, 50);

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -450,7 +450,7 @@ bool SqliteDatabase::isAuthorized(int actionCode,
         if (pragma == "table_list") {
           // Annoyingly, this will list internal tables. However, the existence of these tables
           // isn't really a secret, we just don't want people to access them.
-          return param2 == nullptr;  // should always be true?
+          return true;
         } else if (pragma == "table_info") {
           // Allow if the specific named table is not protected.
           KJ_IF_MAYBE(name, param2) {


### PR DESCRIPTION
This is Glen's #606 and #607, plus some commits of my own.

My commits:
- Refactor the code a bit to enforce pragma signatures more precisely.
- Roll back some of the permissions that I'm not sure we want to grant.
- Introduce a new JavaScript API to query the database size and set a "voluntary size limit" based on the max_page_count pragma.