### PR TITLE
SQL rollbacks

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -328,15 +328,15 @@ async function test(storage) {
   {
     await scheduler.wait(1);
     sql.exec("DROP TABLE IF EXISTS __tmp;")
-    sql.exec("SAVEPOINT aaa;")
+    sql.savepoint()
     let result;
     try {
       sql.exec("CREATE TABLE should_be_rolled_back (VALUE text);");
       sql.exec("SELECT * FROM misspelled_table_name;")
-      result = sql.exec("RELEASE aaa;")
+      sql.release()
     } catch (e) {
       console.log({e: `${e}`})
-      sql.exec("ROLLBACK TO aaa;")
+      sql.rollback()
       console.log(e.message)
       result = { success: false, error: e.message }
     }
@@ -347,7 +347,7 @@ async function test(storage) {
     assert.equal(results.length, 0)
   }
 
-/*
+  /*
   // Test snapshots
   {
     await scheduler.wait(1);
@@ -361,7 +361,6 @@ async function test(storage) {
     const results = Array.from(sql.exec("SELECT * FROM sqlite_master WHERE tbl_name = 'should_be_rolled_back'"))
     assert.equal(results.length, 0)
   }
-
   // Test snapshots (implicit)
   {
     await scheduler.wait(1);

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -18,6 +18,16 @@ jsg::Ref<SqlStorage::Cursor> SqlStorage::exec(jsg::Lock& js, kj::String querySql
   return jsg::alloc<Cursor>(*sqlite, regulator, querySql, kj::mv(bindings));
 }
 
+void SqlStorage::savepoint(jsg::Lock& js) {
+  sqlite->prepare("SAVEPOINT __USER_SAVEPOINT__;").run();
+}
+void SqlStorage::release(jsg::Lock& js) {
+  sqlite->prepare("RELEASE __USER_SAVEPOINT__;").run();
+}
+void SqlStorage::rollback(jsg::Lock& js) {
+  sqlite->prepare("ROLLBACK TO __USER_SAVEPOINT__;").run();
+}
+
 jsg::Ref<SqlStorage::Statement> SqlStorage::prepare(jsg::Lock& js, kj::String query) {
   return jsg::alloc<Statement>(sqlite->prepare(*this, query));
 }

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -25,6 +25,10 @@ public:
 
   jsg::Ref<Cursor> exec(jsg::Lock& js, kj::String query, jsg::Arguments<BindingValue> bindings);
 
+  void savepoint(jsg::Lock& js);
+  void release(jsg::Lock& js);
+  void rollback(jsg::Lock& js);
+
   jsg::Ref<Statement> prepare(jsg::Lock& js, kj::String query);
 
   double getDatabaseSize();
@@ -34,6 +38,9 @@ public:
 
   JSG_RESOURCE_TYPE(SqlStorage, CompatibilityFlags::Reader flags) {
     JSG_METHOD(exec);
+    JSG_METHOD(savepoint);
+    JSG_METHOD(release);
+    JSG_METHOD(rollback);
     JSG_METHOD(prepare);
 
     JSG_READONLY_PROTOTYPE_PROPERTY(databaseSize, getDatabaseSize);

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -483,8 +483,7 @@ bool SqliteDatabase::isAuthorized(int actionCode,
         kj::StringPtr op = KJ_ASSERT_NONNULL(param1);
         KJ_ASSERT(op == "BEGIN" || op == "ROLLBACK" || op == "RELEASE", op);
       }
-      return regulator.allowTransactions() &&
-          regulator.isAllowedName(KJ_ASSERT_NONNULL(param2));
+      return regulator.isAllowedName(KJ_ASSERT_NONNULL(param2));
 
     case SQLITE_PRAGMA             :   /* Pragma Name     1st arg or NULL */
       // We currently only permit a few pragmas.

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -483,7 +483,8 @@ bool SqliteDatabase::isAuthorized(int actionCode,
         kj::StringPtr op = KJ_ASSERT_NONNULL(param1);
         KJ_ASSERT(op == "BEGIN" || op == "ROLLBACK" || op == "RELEASE", op);
       }
-      return regulator.isAllowedName(KJ_ASSERT_NONNULL(param2));
+      return regulator.allowTransactions() &&
+               regulator.isAllowedName(KJ_ASSERT_NONNULL(param2));
 
     case SQLITE_PRAGMA             :   /* Pragma Name     1st arg or NULL */
       // We currently only permit a few pragmas.


### PR DESCRIPTION
WIP, currently just added a test case to show that failing queries don't cause the implicit transaction to rollback, which we rely on for D1 batch-processing. Also sketched out what using JS transactions to capture the same thing might look like, but that throws with `Error: transaction() not yet implemented for SQLite-backed storage` for now.

I'm not sure what the best API is here. Normal DO transactions implicitly call `blockConcurrencyWhile` and, as a result, reset the DO if you don't catch the errors, which feels like massive overkill as SQL statements can fail all the time.

Then again, _most_ of the time you can use a DO without thinking about implicit transactions, but implicit _rollbacks_ might be too surprising:

```js
sql.exec("CREATE TABLE uniques (id INTEGER PRIMARY KEY, value TEXT UNIQUE);")
sql.exec("INSERT INTO uniques (value) VALUES ('one'),('two'),('three');")
sql.exec("INSERT INTO uniques (value) VALUES ('three'),('four'),('five');")
```

With no `await` in between, this will throw on line 3, but should it roll back the changes from the first two lines?

```js
sql.exec("CREATE TABLE uniques (id INTEGER PRIMARY KEY, value TEXT UNIQUE);")
await scheduler.wait(1)
sql.exec("INSERT INTO uniques (value) VALUES ('one'),('two'),('three');")
await scheduler.wait(1)
sql.exec("INSERT INTO uniques (value) VALUES ('three'),('four'),('five');")
```

By adding `await scheduler.wait(1)`, a user can effectively commit after each statement, so they can ensure the DB is left with a `uniques` table and three rows. So maybe implicit rollbacks aren't too bad?

But then, it becomes super awkward to catch errors. You might think you're being defensive by wrapping statements in a try/catch:

```js
sql.exec("CREATE TABLE uniques (id INTEGER PRIMARY KEY, value TEXT UNIQUE);")
try {
  sql.exec("INSERT INTO uniques (value) VALUES ('one'),('two'),('three');")
} catch (e) {}
try {
  sql.exec("INSERT INTO uniques (value) VALUES ('three'),('four'),('five');")
} catch (e) {}
```

But depending on how we implement implicit rollbacks, the failure of one statement could have already rolled back the txn.

I think potentially we should introduce a lighter-weight SQL-specific transaction syntax:

```js
sql.exec("CREATE TABLE uniques (id INTEGER PRIMARY KEY, value TEXT UNIQUE);")
// Note: not async, and doesn't get a txn object passed in. Exceptions are rollbacks.
const result = sql.transaction(() => {
  sql.exec("INSERT INTO uniques (value) VALUES ('one'),('two'),('three');")
  sql.exec("INSERT INTO uniques (value) VALUES ('three'),('four'),('five');")
});
// result: {success: boolean, changeCount, error: string}
```

This could be implemented using `SAVEPOINT`s, so these could be nested within the outer, implicit transaction.