### PR TITLE
Implement global origin property

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -364,12 +364,8 @@ public:
     return jsg::alloc<Performance>();
   }
 
-  jsg::Unimplemented getOrigin() { return {}; }
-  // TODO(conform): A browser-side service worker returns the origin for the URL on which it was
-  //   installed, e.g. https://www.example.com for a service worker downloaded from
-  //   https://www.example.com/sw.js. This seems like something we could provide to scripts during
-  //   a FetchEvent callback (in between .request() and FetchEvent.respondWith()), and otherwise
-  //   throw.
+  kj::StringPtr getOrigin() { return "null"; }
+  // The origin is unknown, return "null" as advocated in https://developer.mozilla.org/en-US/docs/Web/API/origin.
 
   jsg::Ref<CacheStorage> getCaches() {
     return jsg::alloc<CacheStorage>();

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -365,7 +365,8 @@ public:
   }
 
   kj::StringPtr getOrigin() { return "null"; }
-  // The origin is unknown, return "null" as advocated in https://developer.mozilla.org/en-US/docs/Web/API/origin.
+  // The origin is unknown, return "null" as described in
+  // https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque.
 
   jsg::Ref<CacheStorage> getCaches() {
     return jsg::alloc<CacheStorage>();


### PR DESCRIPTION
Changes the origin property from unimplemented to undefined. If origin is unimplemented, then it causes an exception to be thrown when the inspector queries the origin property, and this subsequently trips checks in v8 that cause process termination.