### PR TITLE
Add brotli scaffolding

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -64,7 +64,7 @@ build:unix --cxxopt='-Wno-ignored-qualifiers' --host_cxxopt='-Wno-ignored-qualif
 # zlib release (https://github.com/madler/zlib/issues/633)
 build:unix --per_file_copt='external/zlib[~/].*\.c@-std=c90' --host_per_file_copt='external/zlib[~/].*\.c@-std=c90'
 
-build:unix --@capnp-cpp//src/kj:openssl=True --@capnp-cpp//src/kj:zlib=True --@capnp-cpp//src/kj:libdl=True
+build:unix --@capnp-cpp//src/kj:openssl=True --@capnp-cpp//src/kj:zlib=True --@capnp-cpp//src/kj:brotli=True --@capnp-cpp//src/kj:libdl=True
 
 build:linux --config=unix
 build:macos --config=unix

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,11 +35,16 @@ rules_foreign_cc_dependencies()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "d51c3ca9062d4fbd64f66722b08aafe18976aff3e9965aa0958a0afd4323d4b8",
-    strip_prefix = "capnproto-capnproto-b2afb7f/c++",
+    sha256 = "f5acb23912b9526b1b424132e9b14266089106620c5ba2a55030eb46f3598069",
+    strip_prefix = "capnproto-capnproto-f438b61/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/b2afb7f8fe393466a38e2fd2ad98482c34aafcee"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/f438b61c135d694870f7dc9a7789b6f74a0a549b"],
 )
+
+# Fetch brotli via capnproto. While workerd does not use brotli directly, this is required to work
+# around bazel shenanigans.
+load("@capnp-cpp//:build/load_br.bzl", "load_brotli")
+load_brotli()
 
 http_archive(
     name = "ssl",

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -29,7 +29,8 @@ class TransformStreamDefaultController;
 
 enum class StreamEncoding {
   IDENTITY,
-  GZIP
+  GZIP,
+  BROTLI
 };
 
 struct ReadResult {

--- a/src/workerd/api/system-streams.c++
+++ b/src/workerd/api/system-streams.c++
@@ -68,6 +68,20 @@ kj::Promise<size_t> EncodedAsyncInputStream::tryRead(
         "Gzip compressed stream ended prematurely."_kj },
       { "gzip decompression failed"_kj,
         "Gzip decompression failed." },
+      { "brotli state allocation failed"_kj,
+        "Brotli state allocation failed." },
+      { "invalid brotli window size"_kj,
+        "Invalid brotli window size." },
+      { "invalid brotli compression level"_kj,
+        "Invalid brotli compression level." },
+      { "brotli window size too big"_kj,
+        "Brotli window size too big." },
+      { "brotli decompression failed"_kj,
+        "Brotli decompression failed." },
+      { "brotli compression failed"_kj,
+        "Brotli compression failed." },
+      { "brotli compressed stream ended prematurely"_kj,
+        "Brotli compressed stream ended prematurely." },
     })) {
       return kj::mv(*e);
     }

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -51,6 +51,7 @@ wd_cc_library(
         "//src/workerd/util:sqlite",
         "@capnp-cpp//src/kj:kj-async",
         "@capnp-cpp//src/kj/compat:kj-gzip",
+        "@capnp-cpp//src/kj/compat:kj-brotli",
         "@capnp-cpp//src/capnp/compat:http-over-capnp",
         "@capnp-cpp//src/capnp:capnp-rpc",
         "@com_cloudflare_lol_html//:lolhtml",


### PR DESCRIPTION
Adds support for the brotli Content-Encoding. Brotli compression/decompression is applied in `api/system-streams.c++`, the changes in `api/worker.c++` are just used to have brotli support when decompressing responses in the Workers preview network tab. The underlying brotli streams are implemented in Capnproto.