### PR TITLE
LOG_ERROR_PERIODICALLY() would not log in the first hour after system boot.

### DIFF
--- a/src/workerd/util/sentry.h
+++ b/src/workerd/util/sentry.h
@@ -63,7 +63,7 @@ inline kj::StringPtr maybeOmitColoFromSentry(uint32_t coloId) {
 #define LOG_ERROR_PERIODICALLY(...)                                            \
   do {                                                                         \
     static kj::TimePoint KJ_UNIQUE_NAME(lastLogged) =                          \
-        kj::origin<kj::TimePoint>();                                           \
+        kj::origin<kj::TimePoint>() - 1 * kj::HOURS;                           \
     const auto now = kj::systemCoarseMonotonicClock().now();                   \
     const auto elapsed = now - KJ_UNIQUE_NAME(lastLogged);                     \
     if (KJ_UNLIKELY(elapsed >= 1 * kj::HOURS)) {                               \


### PR DESCRIPTION
Since it uses the monotonic clock, the "origin" time is system boot time. So the first time LOG_ERROR_PERIODICALLY() runs, it thinks it last logged at system boot time, and it only logs again if it's been more than an hour since then.

We'll just subtract an hour from the origin. Monotonic time is never negative so this should be sufficient.