### PR TITLE
Enable event timeout for hibernatable web sockets

### DIFF
--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -460,6 +460,13 @@ public:
   // Get the last auto response timestamp or null
   kj::Maybe<kj::Date> getWebSocketAutoResponseTimestamp(jsg::Ref<WebSocket> ws);
 
+  // Sets or unsets the timeout for hibernatable websocket events, preventing the execution of
+  // the event from taking longer than the specified timeout, if set.
+  void setHibernatableWebSocketEventTimeout(jsg::Optional<uint32_t> timeoutMs);
+
+  // Get the currently set hibernatable websocket event timeout if set, or kj::none if not.
+  kj::Maybe<uint32_t> getHibernatableWebSocketEventTimeout();
+
   JSG_RESOURCE_TYPE(DurableObjectState, CompatibilityFlags::Reader flags) {
     JSG_METHOD(waitUntil);
     JSG_READONLY_INSTANCE_PROPERTY(id, getId);
@@ -470,6 +477,8 @@ public:
     JSG_METHOD(setWebSocketAutoResponse);
     JSG_METHOD(getWebSocketAutoResponse);
     JSG_METHOD(getWebSocketAutoResponseTimestamp);
+    JSG_METHOD(setHibernatableWebSocketEventTimeout);
+    JSG_METHOD(getHibernatableWebSocketEventTimeout);
 
     if (flags.getWorkerdExperimental()) {
       // TODO(someday): This currently exists for testing purposes only but maybe it could be

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -422,6 +422,9 @@ public:
   // been committed yet.
   void abort(jsg::Optional<kj::String> reason);
 
+  // Sets and returns a new hibernation manager in an actor if there's none or returns the existing.
+  Worker::Actor::HibernationManager& maybeInitHibernationManager(Worker::Actor& actor);
+
   // Adds a WebSocket to the set attached to this object.
   // `ws.accept()` must NOT have been called separately.
   // Once called, any incoming messages will be delivered

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -304,20 +304,26 @@ public:
   jsg::Promise<void> test(
       Worker::Lock& lock, kj::Maybe<ExportedHandler&> exportedHandler);
 
+  kj::Promise<void> eventTimeoutPromise(uint32_t timeoutMs);
+  kj::Promise<void> setHibernatableEventTimeout(kj::Promise<void> event, kj::Maybe<uint32_t> eventTimeoutMs);
+
   void sendHibernatableWebSocketMessage(
       kj::OneOf<kj::String, kj::Array<byte>> message,
+      kj::Maybe<uint32_t> eventTimeoutMs,
       kj::String websocketId,
       Worker::Lock& lock,
       kj::Maybe<ExportedHandler&> exportedHandler);
 
   void sendHibernatableWebSocketClose(
       HibernatableSocketParams::Close close,
+      kj::Maybe<uint32_t> eventTimeoutMs,
       kj::String websocketId,
       Worker::Lock& lock,
       kj::Maybe<ExportedHandler&> exportedHandler);
 
   void sendHibernatableWebSocketError(
       kj::Exception e,
+      kj::Maybe<uint32_t> eventTimeoutMs,
       kj::String websocketId,
       Worker::Lock& lock,
       kj::Maybe<ExportedHandler&> exportedHandler);

--- a/src/workerd/api/hibernatable-web-socket.h
+++ b/src/workerd/api/hibernatable-web-socket.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <kj/debug.h>
+#include <kj/time.h>
 
 #include <workerd/io/worker-interface.capnp.h>
 #include <workerd/io/worker-interface.h>
@@ -84,6 +85,7 @@ private:
   uint16_t typeId;
   kj::TaskSet& waitUntilTasks;
   kj::OneOf<HibernatableSocketParams, kj::Own<HibernationReader>> params;
+  kj::Maybe<uint32_t> timeoutMs;
   kj::Maybe<Worker::Actor::HibernationManager&> manager;
 };
 

--- a/src/workerd/api/hibernation-event-params.h
+++ b/src/workerd/api/hibernation-event-params.h
@@ -32,6 +32,7 @@ namespace workerd::api {
 
     kj::OneOf<Text, Data, Close, Error> eventType;
     kj::String websocketId;
+    kj::Maybe<uint32_t> eventTimeoutMs;
 
     explicit HibernatableSocketParams(kj::String message, kj::String id)
         : eventType(Text { kj::mv(message) }), websocketId(kj::mv(id)) {}
@@ -46,6 +47,10 @@ namespace workerd::api {
 
     bool isCloseEvent() {
       return eventType.is<Close>();
+    }
+
+    void setTimeout(kj::Maybe<uint32_t> timeoutMs) {
+      eventTimeoutMs = kj::mv(timeoutMs);
     }
   };
 }; // namespace workerd::api

--- a/src/workerd/io/hibernation-manager.h
+++ b/src/workerd/io/hibernation-manager.h
@@ -44,6 +44,13 @@ public:
 
   friend class api::HibernatableWebSocketEvent;
 
+  // Sets/Unset the maximum time in milliseconds that an hibernatable websocket event can run for.
+  // If the timeout is reached, event is canceled.
+  void setEventTimeout(kj::Maybe<uint32_t> timeoutMs) override;
+
+  // Gets the event timeout if set.
+  kj::Maybe<uint32_t> getEventTimeout() override;
+
 private:
   class HibernatableWebSocket;
 
@@ -194,5 +201,6 @@ private:
   kj::TaskSet readLoopTasks;
   kj::Own<AutoRequestResponsePair> autoResponsePair = kj::heap<AutoRequestResponsePair>();
   kj::Maybe<TimerChannel&> timer;
+  kj::Maybe<uint32_t> eventTimeoutMs;
 };
 }; // namespace workerd

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -158,6 +158,7 @@ struct HibernatableWebSocketEventMessage {
     # TODO(someday): This could be an Exception instead of Text.
   }
   websocketId @6: Text;
+  eventTimeoutMs @7: UInt32;
 }
 
 struct HibernatableWebSocketResponse {

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -621,6 +621,8 @@ public:
     virtual kj::Maybe<jsg::Ref<api::WebSocketRequestResponsePair>> getWebSocketAutoResponse() = 0;
     virtual void setTimerChannel(TimerChannel& timerChannel) = 0;
     virtual kj::Own<HibernationManager> addRef() = 0;
+    virtual void setEventTimeout(kj::Maybe<uint32_t> timeoutMs) = 0;
+    virtual kj::Maybe<uint32_t> getEventTimeout() = 0;
   };
 
   // Create a new Actor hosted by this Worker. Note that this Actor object may only be manipulated


### PR DESCRIPTION
This PR adds new methods for setting event timeouts for hibernatable websockets. 
When a timeout is, it defines the maximum amount of time that a single event of any type is allowed to run before the event will be canceled.

The added methods are `void DurableObjectState::setEventTimeout(int timeoutMs)` and `void DurableObjectState::gettEventTimeout()`.

The timeout acts in global-scope, preventing an event handler to run for more than the desired duration.