### PR TITLE
Fix hibernatable websocket disconnect bug

### DIFF
--- a/src/workerd/io/hibernation-manager.c++
+++ b/src/workerd/io/hibernation-manager.c++
@@ -134,7 +134,7 @@ kj::Promise<void> HibernationManagerImpl::handleSocketTermination(
       auto workerInterface = loopback->getWorker(IoChannelFactory::SubrequestMetadata{});
       event = workerInterface->customEvent(kj::heap<api::HibernatableWebSocketCustomEventImpl>(
           hibernationEventType, readLoopTasks, kj::mv(params), *this))
-          .then([&](auto _) { hib.hasDispatchedClose = true; });
+          .then([&](auto _) { hib.hasDispatchedClose = true; }).attach(kj::mv(workerInterface));
     } else {
       // Otherwise, we need to dispatch an error event!
       auto params = api::HibernatableSocketParams(kj::mv(*error));
@@ -142,7 +142,8 @@ kj::Promise<void> HibernationManagerImpl::handleSocketTermination(
       // Dispatch the error event.
       auto workerInterface = loopback->getWorker(IoChannelFactory::SubrequestMetadata{});
       event = workerInterface->customEvent(kj::heap<api::HibernatableWebSocketCustomEventImpl>(
-          hibernationEventType, readLoopTasks, kj::mv(params), *this)).ignoreResult();
+          hibernationEventType, readLoopTasks, kj::mv(params), *this)).ignoreResult()
+              .attach(kj::mv(workerInterface));
     }
   }
 

--- a/src/workerd/io/hibernation-manager.h
+++ b/src/workerd/io/hibernation-manager.h
@@ -176,7 +176,7 @@ private:
   // Allows the HibernatableWebSocket event handler that is currently running to access the
   // HibernatableWebSocket that it needs to execute.
 
-  const size_t ACTIVE_CONNECTION_LIMIT = 1024 * 64;
+  const size_t ACTIVE_CONNECTION_LIMIT = 1024 * 32;
   // The maximum number of Hibernatable WebSocket connections a single HibernationManagerImpl
   // instance can manage.
 


### PR DESCRIPTION
We weren't moving the promised worker interface into the event dispatch promise, so we would destroy it before the event ran, causing issues.