### PR TITLE
Added explicit `sql.savepoint` API

### DIFF
--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -194,6 +194,8 @@ public:
       jsg::Function<jsg::Promise<jsg::Value>(jsg::Ref<DurableObjectTransaction>)> closure,
       jsg::Optional<TransactionOptions> options);
 
+  jsg::Value transactionSync(jsg::Lock& js, jsg::Function<jsg::Value()> callback);
+
   jsg::Promise<void> deleteAll(jsg::Lock& js, jsg::Optional<PutOptions> options);
 
   jsg::Promise<void> sync(jsg::Lock& js);
@@ -211,8 +213,10 @@ public:
     JSG_METHOD(setAlarm);
     JSG_METHOD(deleteAlarm);
     JSG_METHOD(sync);
+
     if (flags.getWorkerdExperimental()) {
       JSG_LAZY_INSTANCE_PROPERTY(sql, getSql);
+      JSG_METHOD(transactionSync);
     }
 
     JSG_TS_OVERRIDE({
@@ -228,6 +232,7 @@ public:
       delete(keys: string[], options?: DurableObjectPutOptions): Promise<number>;
 
       transaction<T>(closure: (txn: DurableObjectTransaction) => Promise<T>): Promise<T>;
+      transactionSync<T>(closure: () => T): T;
     });
   }
 

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -13,7 +13,8 @@ function requireException(callback, expectStr) {
   throw new Error(`Expected exception '${expectStr}' but none was thrown`);
 }
 
-async function test(sql, storage) {
+async function test(storage) {
+  const sql = storage.sql
   // Test numeric results
   const resultNumber = [...sql.exec("SELECT 123")];
   assert.equal(resultNumber.length, 1);
@@ -377,6 +378,37 @@ async function test(sql, storage) {
     txn.rollback();
   });
   assert.equal(await storage.get("txnTest"), 3);
+
+  // Test savepoints, success
+  {
+    await scheduler.wait(1);
+    const result = storage.transactionSync(() => {
+      sql.exec("CREATE TABLE IF NOT EXISTS should_succeed (VALUE text);");
+      return "some data"
+    })
+
+    assert.equal(result, "some data")
+
+    const results = Array.from(sql.exec(`
+      SELECT * FROM sqlite_master WHERE tbl_name = 'should_succeed'
+    `))
+    assert.equal(results.length, 1)
+  }
+
+  // Test savepoints, failure
+  {
+    await scheduler.wait(1);
+
+    requireException(() => storage.transactionSync(() => {
+      sql.exec("CREATE TABLE should_be_rolled_back (VALUE text);");
+      sql.exec("SELECT * FROM misspelled_table_name;")
+    }), "Error: no such table: misspelled_table_name")
+
+    const results = Array.from(sql.exec(`
+      SELECT * FROM sqlite_master WHERE tbl_name = 'should_be_rolled_back'
+    `))
+    assert.equal(results.length, 0)
+  }
 }
 
 export class DurableObjectExample {
@@ -386,7 +418,7 @@ export class DurableObjectExample {
 
   async fetch(req) {
     if (req.url.endsWith("/sql-test")) {
-      await test(this.state.storage.sql, this.state.storage);
+      await test(this.state.storage);
       return new Response();
     } else if (req.url.endsWith("/increment")) {
       let val = (await this.state.storage.get("counter")) || 0;

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -13,7 +13,7 @@ function requireException(callback, expectStr) {
   throw new Error(`Expected exception '${expectStr}' but none was thrown`);
 }
 
-async function test(sql) {
+async function test(sql, storage) {
   // Test numeric results
   const resultNumber = [...sql.exec("SELECT 123")];
   assert.equal(resultNumber.length, 1);
@@ -322,6 +322,61 @@ async function test(sql) {
   assert.equal(sql.voluntarySizeLimit, 1073741823 * 4096);
   sql.voluntarySizeLimit = 65536;
   assert.equal(sql.voluntarySizeLimit, 65536);
+
+  storage.put("txnTest", 0);
+
+  // Try a transaction while no implicit transaction is open.
+  await scheduler.wait(1);  // finish implicit txn
+  await storage.transaction(async () => {
+    storage.put("txnTest", 1);
+    assert.equal(await storage.get("txnTest"), 1);
+  });
+  assert.equal(await storage.get("txnTest"), 1);
+
+  // Try a transaction while an implicit transaction is open first.
+  storage.put("txnTest", 2);
+  await storage.transaction(async () => {
+    storage.put("txnTest", 3);
+    assert.equal(await storage.get("txnTest"), 3);
+  });
+  assert.equal(await storage.get("txnTest"), 3);
+
+
+  // Try a transaction that is explicitly rolled back.
+  await storage.transaction(async txn => {
+    storage.put("txnTest", 4);
+    assert.equal(await storage.get("txnTest"), 4);
+    txn.rollback();
+  });
+  assert.equal(await storage.get("txnTest"), 3);
+
+  // Try a transaction that is implicitly rolled back by throwing an exception.
+  try {
+    await storage.transaction(async txn => {
+      storage.put("txnTest", 5);
+      assert.equal(await storage.get("txnTest"), 5);
+      throw new Error("txn failure");
+    });
+    throw new Error("expected errror");
+  } catch (err) {
+    assert.equal(err.message, "txn failure");
+  }
+  assert.equal(await storage.get("txnTest"), 3);
+
+  // Try a nested transaction.
+  await storage.transaction(async txn => {
+    storage.put("txnTest", 6);
+    assert.equal(await storage.get("txnTest"), 6);
+    await storage.transaction(async txn2 => {
+      storage.put("txnTest", 7);
+      assert.equal(await storage.get("txnTest"), 7);
+      // Let's even do an await in here for good measure.
+      await scheduler.wait(1);
+    });
+    assert.equal(await storage.get("txnTest"), 7);
+    txn.rollback();
+  });
+  assert.equal(await storage.get("txnTest"), 3);
 }
 
 export class DurableObjectExample {
@@ -331,7 +386,7 @@ export class DurableObjectExample {
 
   async fetch(req) {
     if (req.url.endsWith("/sql-test")) {
-      await test(this.state.storage.sql);
+      await test(this.state.storage.sql, this.state.storage);
       return new Response();
     } else if (req.url.endsWith("/increment")) {
       let val = (await this.state.storage.get("counter")) || 0;

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -342,6 +342,12 @@ SqliteDatabase::~SqliteDatabase() noexcept(false) {
   KJ_REQUIRE(err == SQLITE_OK, sqlite3_errstr(err)) { break; }
 }
 
+void SqliteDatabase::notifyWrite() {
+  KJ_IF_MAYBE(cb, onWriteCallback) {
+    (*cb)();
+  }
+}
+
 kj::Own<sqlite3_stmt> SqliteDatabase::prepareSql(
     Regulator& regulator, kj::StringPtr sqlCode, uint prepFlags, Multi multi) {
   // Set up the regulator that will be used for authorizer callbacks while preparing this

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -75,6 +75,11 @@ public:
   //
   // Durable Objects uses this to automatically begin a transaction and close the output gate.
 
+  void notifyWrite();
+  // Indicates that a statement is about to be executed and so a new transaction should be opened.
+  // This is useful when the particular statement is considered "read only" but has some side-effect
+  // that requires it to be run inside a transaction, e.g. SAVEPOINT
+
 private:
   sqlite3* db;
 


### PR DESCRIPTION
Not sure if this code is idiomatic, but I was able to get something working that means we can let users use [savepoints](https://www.sqlite.org/lang_savepoint.html) in lieu of transactions:

```js
const { success, error, result } = sql.savepoint(() => {
  sql.exec("CREATE TABLE should_be_rolled_back (VALUE text);");
  sql.exec("SELECT * FROM misspelled_table_name;")
})

// Returns { success: false, error: "Error: no such table: misspelled_table_name", result: null }

Array.from(sql.exec(`
  SELECT * FROM sqlite_master WHERE tbl_name = 'should_be_rolled_back'
`))
// Returns `[]` — all changes within the savepoint block are rolled back, just like a transaction.
```

This is distinct from the `storage.transaction` interface in that it's not async, doesn't block concurrency, doesn't inject a "transaction" object into the callback (that the user must remember to use), and doesn't interfere with the normal (implicit) transactions. So you could have many of these savepoints in a single implicit transaction, allowing you to group related operations:

```js
const { success } = sql.savepoint(() => {
  sql.prepare("UPDATE sales SET value = value + ? WHERE id = ?;")(cost, product_id);
  sql.prepare("UPDATE balances SET value = value - ? WHERE id = ?;")(cost, user_id); // fails trigger
})

if (!success) {
  sql.prepare("UPDATE failed_checkouts SET count = count + 1 WHERE id = ?")(user_id)
  return { success: false, message: "You don't have enough balance" }
} else {
  return { success: true, message: `Purchased items for ${cost}` }
}
```