### PR TITLE
Report port each socket is listening on when ready

### DIFF
--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -53,6 +53,9 @@ public:
   void enableInspector(kj::String addr) {
     inspectorOverride = kj::mv(addr);
   }
+  void enableControl(uint fd) {
+    controlOverride = kj::heap<kj::FdOutputStream>(fd);
+  }
 
   kj::Promise<void> run(jsg::V8System& v8System, config::Config::Reader conf,
                         kj::Promise<void> drainWhen = kj::NEVER_DONE);
@@ -89,6 +92,7 @@ private:
   // code that parses strings from the config file.
 
   kj::Maybe<kj::String> inspectorOverride;
+  kj::Maybe<kj::Own<kj::FdOutputStream>> controlOverride;
 
   struct GlobalContext;
   kj::Own<GlobalContext> globalContext;

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -611,6 +611,9 @@ public:
         .addOptionWithArg({'S', "socket-fd"}, CLI_METHOD(overrideSocketFd), "<name>=<fd>",
                           "Override the socket named <name> to listen on the already-open socket "
                           "descriptor <fd> instead of the address specified in the config file.")
+        .addOptionWithArg({"control-fd"}, CLI_METHOD(enableControl), "<fd>",
+                          "Enable sending of control messages on descriptor <fd>. Currently this "
+                          "only reports the port each socket is listening on when ready.")
         .callAfterParsing(CLI_METHOD(serve))
         .build();
   }
@@ -769,6 +772,12 @@ public:
 
   void enableInspector(kj::StringPtr param) {
     server.enableInspector(kj::str(param));
+  }
+
+  void enableControl(kj::StringPtr param) {
+    int fd = KJ_UNWRAP_OR(param.tryParseAs<uint>(),
+        CLI_ERROR("Output value must be a file descriptor (non-negative integer)."));
+    server.enableControl(fd);
   }
 
   void watch() {


### PR DESCRIPTION
Hey! 👋 This PR adds a `--control-fd` flag that allows an additional file descriptor to be passed (probably a pipe) for reporting control messages. I wasn't really sure what to name this flag, but this seemed like we could extend it with more messages later on if needed. Each message is a JSON-object terminated by a newline. Currently we only report the port each socket is listening on when it's ready. There's definitely a bug here if the socket name includes characters like `"`, `\n`, `\`, etc, but it also seems like this is a problem in inspector endpoints too, and it seems unlikely these characters would appear here: https://github.com/cloudflare/workerd/blob/89199545cf23160ff30efd5ba331a933fc8310f1/src/workerd/server/server.c%2B%2B#L1083

Tested on macOS and Windows with the following script:

```js
import childProcess from "child_process";
const process = childProcess.spawn(
  "bazel-bin/src/workerd/server/workerd",
  [
    "serve",
    "samples/helloworld/config.capnp",
    "--verbose",
    "--control-fd=3",
  ],
  { stdio: ["inherit", "inherit", "inherit", "pipe"] }
);
const controlPipe = process.stdio[3];
controlPipe.on("data", (chunk) => {
  console.log(chunk.toString());
});
```

Closes #426

Ref: cloudflare/miniflare#532