### PR TITLE
Fail WorkerEntrypoint::connect with a JSG error

### DIFF
--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -319,7 +319,7 @@ kj::Promise<void> WorkerEntrypoint::request(
 kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host, const kj::HttpHeaders& headers,
     kj::AsyncIoStream& connection, ConnectResponse& response,
     kj::HttpConnectSettings settings) {
-  KJ_UNIMPLEMENTED("Incoming CONNECT on a worker not supported");
+  JSG_FAIL_REQUIRE(TypeError, "Incoming CONNECT on a worker not supported");
 }
 
 void WorkerEntrypoint::prewarm(kj::StringPtr url) {


### PR DESCRIPTION
### Test Plan

```
$ bazel run @workerd//src/workerd/server:workerd -- serve $PWD/deps/workerd/samples/tcp/config.capnp --watch --verbose --experimental
```

Verified that the gopher example still works with proxy.