### PR TITLE
SQLite: Support explicit transaction API. 

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -634,13 +634,13 @@ jsg::Value DurableObjectStorage::transactionSync(jsg::Lock& js, jsg::Function<js
     // SAVEPOINT is a readonly statement, but we need to trigger an outer TRANSACTION
     sqlite->notifyWrite();
     // TODO(sqlite) allow nested savepoints, using a new savepoint name for each depth
-    sqlite->prepare("SAVEPOINT _cf_savepoint;").run();
+    sqlite->run("SAVEPOINT _cf_savepoint;");
     return js.tryCatch([&]() {
       auto result = callback(js);
-      sqlite->prepare("RELEASE _cf_savepoint;").run();
+      sqlite->run("RELEASE _cf_savepoint;");
       return kj::mv(result);
     }, [&](jsg::Value exception) -> jsg::Value {
-      sqlite->prepare("ROLLBACK TO _cf_savepoint;").run();
+      sqlite->run("ROLLBACK TO _cf_savepoint;");
       js.throwException(kj::mv(exception));
     });
   } else {

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -245,6 +245,7 @@ protected:
 
 private:
   IoPtr<ActorCacheInterface> cache;
+  uint transactionSyncDepth = 0;
 };
 
 class DurableObjectTransaction final: public jsg::Object, public DurableObjectStorageOperations {

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -194,6 +194,8 @@ public:
       jsg::Function<jsg::Promise<jsg::Value>(jsg::Ref<DurableObjectTransaction>)> closure,
       jsg::Optional<TransactionOptions> options);
 
+  jsg::Value transactionSync(jsg::Lock& js, jsg::Function<jsg::Value()> callback);
+
   jsg::Promise<void> deleteAll(jsg::Lock& js, jsg::Optional<PutOptions> options);
 
   jsg::Promise<void> sync(jsg::Lock& js);
@@ -211,8 +213,10 @@ public:
     JSG_METHOD(setAlarm);
     JSG_METHOD(deleteAlarm);
     JSG_METHOD(sync);
+
     if (flags.getWorkerdExperimental()) {
       JSG_LAZY_INSTANCE_PROPERTY(sql, getSql);
+      JSG_METHOD(transactionSync);
     }
 
     JSG_TS_OVERRIDE({
@@ -228,6 +232,7 @@ public:
       delete(keys: string[], options?: DurableObjectPutOptions): Promise<number>;
 
       transaction<T>(closure: (txn: DurableObjectTransaction) => Promise<T>): Promise<T>;
+      transactionSync<T>(closure: () => T): T;
     });
   }
 

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -13,7 +13,7 @@ function requireException(callback, expectStr) {
   throw new Error(`Expected exception '${expectStr}' but none was thrown`);
 }
 
-async function test(sql) {
+async function test(sql, storage) {
   // Test numeric results
   const resultNumber = [...sql.exec("SELECT 123")];
   assert.equal(resultNumber.length, 1);
@@ -322,6 +322,63 @@ async function test(sql) {
   assert.equal(sql.voluntarySizeLimit, 1073741823 * 4096);
   sql.voluntarySizeLimit = 65536;
   assert.equal(sql.voluntarySizeLimit, 65536);
+
+  storage.put("txnTest", 0);
+
+  // Try a transaction while no implicit transaction is open.
+  await scheduler.wait(1);  // finish implicit txn
+  let txnResult = await storage.transaction(async () => {
+    storage.put("txnTest", 1);
+    assert.equal(await storage.get("txnTest"), 1);
+    return "foo";
+  });
+  assert.equal(await storage.get("txnTest"), 1);
+  assert.equal(txnResult, "foo");
+
+  // Try a transaction while an implicit transaction is open first.
+  storage.put("txnTest", 2);
+  await storage.transaction(async () => {
+    storage.put("txnTest", 3);
+    assert.equal(await storage.get("txnTest"), 3);
+  });
+  assert.equal(await storage.get("txnTest"), 3);
+
+
+  // Try a transaction that is explicitly rolled back.
+  await storage.transaction(async txn => {
+    storage.put("txnTest", 4);
+    assert.equal(await storage.get("txnTest"), 4);
+    txn.rollback();
+  });
+  assert.equal(await storage.get("txnTest"), 3);
+
+  // Try a transaction that is implicitly rolled back by throwing an exception.
+  try {
+    await storage.transaction(async txn => {
+      storage.put("txnTest", 5);
+      assert.equal(await storage.get("txnTest"), 5);
+      throw new Error("txn failure");
+    });
+    throw new Error("expected errror");
+  } catch (err) {
+    assert.equal(err.message, "txn failure");
+  }
+  assert.equal(await storage.get("txnTest"), 3);
+
+  // Try a nested transaction.
+  await storage.transaction(async txn => {
+    storage.put("txnTest", 6);
+    assert.equal(await storage.get("txnTest"), 6);
+    await storage.transaction(async txn2 => {
+      storage.put("txnTest", 7);
+      assert.equal(await storage.get("txnTest"), 7);
+      // Let's even do an await in here for good measure.
+      await scheduler.wait(1);
+    });
+    assert.equal(await storage.get("txnTest"), 7);
+    txn.rollback();
+  });
+  assert.equal(await storage.get("txnTest"), 3);
 }
 
 export class DurableObjectExample {
@@ -331,7 +388,7 @@ export class DurableObjectExample {
 
   async fetch(req) {
     if (req.url.endsWith("/sql-test")) {
-      await test(this.state.storage.sql);
+      await test(this.state.storage.sql, this.state.storage);
       return new Response();
     } else if (req.url.endsWith("/increment")) {
       let val = (await this.state.storage.get("counter")) || 0;

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -342,6 +342,12 @@ SqliteDatabase::~SqliteDatabase() noexcept(false) {
   KJ_REQUIRE(err == SQLITE_OK, sqlite3_errstr(err)) { break; }
 }
 
+void SqliteDatabase::notifyWrite() {
+  KJ_IF_MAYBE(cb, onWriteCallback) {
+    (*cb)();
+  }
+}
+
 kj::Own<sqlite3_stmt> SqliteDatabase::prepareSql(
     Regulator& regulator, kj::StringPtr sqlCode, uint prepFlags, Multi multi) {
   // Set up the regulator that will be used for authorizer callbacks while preparing this

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -76,9 +76,14 @@ public:
   // Durable Objects uses this to automatically begin a transaction and close the output gate.
 
   void notifyWrite();
-  // Indicates that a statement is about to be executed and so a new transaction should be opened.
-  // This is useful when the particular statement is considered "read only" but has some side-effect
-  // that requires it to be run inside a transaction, e.g. SAVEPOINT
+  // Invoke the onWrite() callback.
+  //
+  // This is useful when the caller is about to execute a statement which SQLite considers
+  // read-only, but needs to be considered a write for our purposes. In particular, we use the
+  // onWrite callback to start automatic transactions, and we use the SAVEPOINT statement to
+  // implement explicit transactions. For synchronous transactions, the explicit transaction needs
+  // to be nested inside the automatic transaction, so we need to force an auto-transaction to
+  // start before the SAVEPOINT.
 
 private:
   sqlite3* db;

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -75,6 +75,11 @@ public:
   //
   // Durable Objects uses this to automatically begin a transaction and close the output gate.
 
+  void notifyWrite();
+  // Indicates that a statement is about to be executed and so a new transaction should be opened.
+  // This is useful when the particular statement is considered "read only" but has some side-effect
+  // that requires it to be run inside a transaction, e.g. SAVEPOINT
+
 private:
   sqlite3* db;
 


### PR DESCRIPTION
This is implementing the storage.transaction() API we've always had. SQLite queries will be included in the transaction.

Note that unlike the traditional implementation, this one does not require you to use the transaction object passed into the callback to access storage -- all storage access during the transaction is automatically included. There's no other choice since we'd need to have a second SQLite database connection to perform queries that bypass the transaction, and even then SQLite does not allow concurrent writers.