### PR TITLE
Fix use-after-free when constructing `QueueMessage` on Windows

### DIFF
--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -147,7 +147,7 @@ QueueMessage::QueueMessage(
     v8::Isolate* isolate, IncomingQueueMessage message, IoPtr<QueueEventResult> result)
     : id(kj::mv(message.id)),
       timestamp(message.timestamp),
-      body(isolate, jsg::Deserializer(isolate, kj::mv(message.body)).readValue()),
+      body(isolate, jsg::Deserializer(isolate, message.body.asPtr()).readValue()),
       result(result) {}
 
 jsg::Value QueueMessage::getBody(jsg::Lock& js) {


### PR DESCRIPTION
Hey! 👋 One of our Miniflare tests for Queues was occasionally failing on Windows with `Error: Unable to deserialize cloned data`. From debugging, it looked like message bodies were correctly being passed to: https://github.com/cloudflare/workerd/blob/8f4274db3823772dc86fade66c631775405dca30/src/workerd/api/queue.c%2B%2B#L217

When constructing `QueueMessage`s though, `kj::mv` was used to avoid copying the message body. It looks like `jsg::Deserializer` doesn't take ownership of the data:

https://github.com/cloudflare/workerd/blob/8f4274db3823772dc86fade66c631775405dca30/src/workerd/jsg/ser.h#L74

...meaning it was dropped after the constructor, and the `readValue()` back in `QueueMessage` could end up reading garbage. Maybe this isn't usually a problem because of the `inline` on the `jsg::Deserializer` constructor?

Either way, this seemed to fix things. 🙂 