### PR TITLE
Add back `#include <compare>` to `jsg/string.h`

### DIFF
--- a/src/workerd/jsg/string.h
+++ b/src/workerd/jsg/string.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "jsg.h"
+#include <compare>
 
 namespace workerd::jsg {
 


### PR DESCRIPTION
This was removed in #618 but is needed to build `workerd` in our Linux arm64 Docker container. I suspect this is because it's using LLVM 11, which we say we support in our `README`.