### PR TITLE
Revisiting SQL limits

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -320,6 +320,10 @@ async function test(storage) {
 
   // Test database size interface.
   assert.equal(sql.databaseSize, 36864);
+  sql.exec(`CREATE TABLE should_make_one_more_page(VALUE text);`)
+  assert.equal(sql.databaseSize, 36864 + 4096);
+  sql.exec(`DROP TABLE should_make_one_more_page;`)
+  assert.equal(sql.databaseSize, 36864);
 
   storage.put("txnTest", 0);
 

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -320,9 +320,6 @@ async function test(storage) {
 
   // Test database size interface.
   assert.equal(sql.databaseSize, 36864);
-  assert.equal(sql.voluntarySizeLimit, 1073741823 * 4096);
-  sql.voluntarySizeLimit = 65536;
-  assert.equal(sql.voluntarySizeLimit, 65536);
 
   storage.put("txnTest", 0);
 

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -27,22 +27,6 @@ double SqlStorage::getDatabaseSize() {
   return pages * getPageSize();
 }
 
-double SqlStorage::getVoluntarySizeLimit() {
-  int64_t pages = execMemoized(pragmaGetMaxPageCount, "PRAGMA max_page_count;").getInt64(0);
-  return pages * getPageSize();
-}
-
-void SqlStorage::setVoluntarySizeLimit(int64_t value) {
-  JSG_REQUIRE(value > 0, TypeError, "Size limit must be a positive integer.");
-
-  uint64_t pages = value / getPageSize();
-
-  // Annoyingly, pragmas cannot be parameterized. Apparently there's an alternate syntax where
-  // they can be but I couldn't figure it out. So whatever. `pages` is just an integer so no
-  // injection is possible here.
-  sqlite->run(SqliteDatabase::TRUSTED, kj::str("PRAGMA max_page_count = ", pages, ";"));
-}
-
 bool SqlStorage::isAllowedName(kj::StringPtr name) {
   return !name.startsWith("_cf_");
 }

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -23,7 +23,10 @@ jsg::Ref<SqlStorage::Statement> SqlStorage::prepare(jsg::Lock& js, kj::String qu
 }
 
 double SqlStorage::getDatabaseSize() {
-  int64_t pages = execMemoized(pragmaPageCount, "PRAGMA page_count;").getInt64(0);
+  int64_t pages = execMemoized(
+      pragmaPageCount,
+      "select (select * from pragma_page_count) - (select * from pragma_freelist_count);"
+  ).getInt64(0);
   return pages * getPageSize();
 }
 

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -29,15 +29,11 @@ public:
 
   double getDatabaseSize();
 
-  double getVoluntarySizeLimit();
-  void setVoluntarySizeLimit(int64_t value);
-
   JSG_RESOURCE_TYPE(SqlStorage, CompatibilityFlags::Reader flags) {
     JSG_METHOD(exec);
     JSG_METHOD(prepare);
 
     JSG_READONLY_PROTOTYPE_PROPERTY(databaseSize, getDatabaseSize);
-    JSG_PROTOTYPE_PROPERTY(voluntarySizeLimit, getVoluntarySizeLimit, setVoluntarySizeLimit);
 
     JSG_NESTED_TYPE(Cursor);
     JSG_NESTED_TYPE(Statement);


### PR DESCRIPTION
Hitting the `voluntartySizeLimit` kills the current DB connection, rolling back the current implicit transaction (not just the statement that failed), and resulting in unwanted behaviour (like a `SQLITE_MISUSE` error trying to reuse a prepared statement from the now-dead connection). This PR removes it.

It also changes the semantics of `getDatabaseSize` to take `freelist_count` into consideration. From the docs: https://www.sqlite.org/pragma.html#pragma_freelist_count

> Return the number of unused pages in the database file.

When you delete a table, or enough rows that an entire page can be reclaimed, the result `PRAGMA page_count` doesn't change until you do a VACUUM (it represents the size of the file on-disk).

Currently, VACUUMs aren't supported (error message is `cannot VACUUM from within a transaction`), and in any case, we might want to control when and how VACUUMs take place, so I don't think we should couple it to size calculations.

By including `freelist_count` the user sees their "database size" immediately decrease after deleting some data.