### PR TITLE
Add debugging for jsg::Data move operator=

### DIFF
--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -628,9 +628,7 @@ public:
       handle = kj::mv(other.handle);
       other.isolate = nullptr;
       KJ_IF_MAYBE(t, other.tracedHandle) {
-        handle.ClearWeak();
-        t->Reset();
-        other.tracedHandle = nullptr;
+        moveFromTraced(other, *t);
       }
     }
     assertInvariant();


### PR DESCRIPTION
#653 added more debugging checks to the jsg::Data constructor but missed the move operator=.