### PR TITLE
[nfc] move static code into anonymous namespaces

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -118,23 +118,6 @@ ActorObserver& currentActorMetrics() {
   return IoContext::current().getActorOrThrow().getMetrics();
 }
 
-}  // namespace
-
-jsg::Promise<jsg::Value> DurableObjectStorageOperations::get(
-    kj::OneOf<kj::String, kj::Array<kj::String>> keys, jsg::Optional<GetOptions> maybeOptions,
-    v8::Isolate* isolate) {
-  auto options = configureOptions(kj::mv(maybeOptions).orDefault(GetOptions{}));
-  KJ_SWITCH_ONEOF(keys) {
-    KJ_CASE_ONEOF(s, kj::String) {
-      return getOne(kj::mv(s), options, isolate);
-    }
-    KJ_CASE_ONEOF(a, kj::Array<kj::String>) {
-      return getMultiple(kj::mv(a), options, isolate);
-    }
-  }
-  KJ_UNREACHABLE
-}
-
 jsg::Value listResultsToMap(v8::Isolate* isolate, ActorCacheOps::GetResultList value, bool completelyCached) {
   v8::HandleScope scope(isolate);
   auto context = isolate->GetCurrentContext();
@@ -208,6 +191,23 @@ kj::Function<jsg::Value(v8::Isolate*, ActorCacheOps::GetResultList)> getMultiple
 
     return jsg::Value(isolate, map);
   };
+}
+
+}  // namespace
+
+jsg::Promise<jsg::Value> DurableObjectStorageOperations::get(
+    kj::OneOf<kj::String, kj::Array<kj::String>> keys, jsg::Optional<GetOptions> maybeOptions,
+    v8::Isolate* isolate) {
+  auto options = configureOptions(kj::mv(maybeOptions).orDefault(GetOptions{}));
+  KJ_SWITCH_ONEOF(keys) {
+    KJ_CASE_ONEOF(s, kj::String) {
+      return getOne(kj::mv(s), options, isolate);
+    }
+    KJ_CASE_ONEOF(a, kj::Array<kj::String>) {
+      return getMultiple(kj::mv(a), options, isolate);
+    }
+  }
+  KJ_UNREACHABLE
 }
 
 jsg::Promise<jsg::Value> DurableObjectStorageOperations::getOne(

--- a/src/workerd/api/crypto-impl-asymmetric.c++
+++ b/src/workerd/api/crypto-impl-asymmetric.c++
@@ -791,6 +791,8 @@ kj::Maybe<T> fromBignum(kj::ArrayPtr<kj::byte> value) {
   return asUnsigned;
 }
 
+namespace {
+
 void validateRsaParams(int modulusLength, kj::ArrayPtr<kj::byte> publicExponent,
     bool warnImport = false) {
   // The W3C standard itself doesn't describe any parameter validation but the conformance tests
@@ -833,6 +835,8 @@ void validateRsaParams(int modulusLength, kj::ArrayPtr<kj::byte> publicExponent,
         "got a number larger than 2^32.");
   }
 }
+
+} // namespace
 
 kj::OneOf<jsg::Ref<CryptoKey>, CryptoKeyPair> CryptoKey::Impl::generateRsa(
     kj::StringPtr normalizedName,

--- a/src/workerd/api/html-rewriter.c++
+++ b/src/workerd/api/html-rewriter.c++
@@ -396,6 +396,8 @@ Rewriter::Rewriter(
       ioContext(IoContext::current()),
       maybeAsyncContext(jsg::AsyncContextFrame::currentRef(js)) {}
 
+namespace {
+
 // The stack size floor enforced by kj. We could go lower,
 // but it'd always be increased to this anyway.
 const size_t FIBER_STACK_SIZE = 1024 * 64;
@@ -404,6 +406,8 @@ const kj::FiberPool& getFiberPool() {
   const static kj::FiberPool FIBER_POOL(FIBER_STACK_SIZE);
   return FIBER_POOL;
 }
+
+} // namespace
 
 kj::Promise<void> Rewriter::write(const void* buffer, size_t size) {
   KJ_ASSERT(maybeWaitScope == nullptr);

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1823,6 +1823,8 @@ jsg::Ref<Response> makeHttpResponse(
         nullptr, kj::mv(responseBody), flags, kj::mv(urlList), kj::mv(webSocket));
 }
 
+namespace {
+
 jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(
     jsg::Lock& js,
     kj::Maybe<jsg::Ref<Fetcher>> fetcher,
@@ -1866,6 +1868,8 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(
                                  featureFlags);
   });
 }
+
+} // namespace
 
 jsg::Promise<jsg::Ref<Response>> fetchImpl(
     jsg::Lock& js,

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -10,6 +10,7 @@
 
 namespace workerd::api {
 
+namespace {
 
 bool isValidHost(kj::StringPtr host) {
   // This function performs some basic length and characters checks, it does not guarantee that
@@ -101,6 +102,8 @@ jsg::Ref<Socket> setupSocket(
   }
   return result;
 }
+
+} // namespace
 
 jsg::Ref<Socket> connectImplNoOutputLock(
     jsg::Lock& js, jsg::Ref<Fetcher> fetcher, AnySocketAddress address,

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -122,6 +122,8 @@ void WebSocket::initConnection(jsg::Lock& js, kj::Promise<PackedWebSocket> prom)
   // whichever comes first.
 }
 
+namespace {
+
 // See item 10 of https://datatracker.ietf.org/doc/html/rfc6455#section-4.1
 bool validProtoToken(const kj::StringPtr protocol) {
   if (kj::size(protocol) == 0) {
@@ -159,6 +161,8 @@ bool validProtoToken(const kj::StringPtr protocol) {
   }
   return true;
 }
+
+} // namespace
 
 jsg::Ref<WebSocket> WebSocket::constructor(
     jsg::Lock& js,
@@ -711,6 +715,7 @@ void WebSocket::ensurePumping(jsg::Lock& js) {
 }
 
 namespace {
+
 size_t countBytesFromMessage(const kj::WebSocket::Message& message) {
   // This does not count the extra data of the RPC frame or the savings from any compression.
   // We're incentivizing customers to use reasonably sized messages, not trying to get an exact
@@ -733,7 +738,8 @@ size_t countBytesFromMessage(const kj::WebSocket::Message& message) {
 
   KJ_UNREACHABLE;
 }
-}
+
+} // namespace
 
 kj::Promise<void> WebSocket::pump(
     IoContext& context, OutgoingMessagesMap& outgoingMessages, kj::WebSocket& ws, Native& native) {

--- a/src/workerd/io/io-gate.c++
+++ b/src/workerd/io/io-gate.c++
@@ -336,7 +336,11 @@ bool OutputGate::isBroken() {
   return brokenState.is<kj::Exception>();
 }
 
+namespace {
+
 void END_OUTPUT_LOCK_CANCELATION_STACK_START_WAITER_STACK() {}
+
+} // namespace
 
 kj::Exception OutputGate::makeUnfulfilledException() {
   return kj::getDestructionReason(

--- a/src/workerd/jsg/exception.h
+++ b/src/workerd/jsg/exception.h
@@ -103,6 +103,9 @@ namespace workerd::jsg {
     }                                                                                              \
   } while (0)
 
+kj::StringPtr stripRemoteExceptionPrefix(kj::StringPtr internalMessage);
+// Given a KJ exception's description, strips any leading "remote exception: " prefixes.
+
 bool isTunneledException(kj::StringPtr internalMessage);
 // Given a KJ exception's description, returns whether it contains a tunneled exception that could
 // be converted back to JavaScript via makeInternalError().

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -125,9 +125,6 @@ kj::Exception createTunneledException(v8::Isolate* isolate, v8::Local<v8::Value>
 //
 // Equivalent to throwing the exception returned by `createTunneledException(exception)`.
 
-kj::StringPtr stripRemoteExceptionPrefix(kj::StringPtr internalMessage);
-// Given a KJ exception's description, strips any leading "remote exception: " prefixes.
-
 template <typename T>
 v8::Local<T> check(v8::MaybeLocal<T> maybe) {
   // V8 usually returns a MaybeLocal to mean that the function can throw a JavaScript exception.

--- a/src/workerd/server/alarm-scheduler.c++
+++ b/src/workerd/server/alarm-scheduler.c++
@@ -11,6 +11,8 @@ int AlarmScheduler::maxJitterMsForDelay(kj::Duration delay) {
   return std::floor(RETRY_JITTER_FACTOR * delayMs);
 }
 
+namespace {
+
 std::default_random_engine makeSeededRandomEngine() {
   // Using the time as a seed here is fine, we just want to have some randomness for retry jitter
   auto time = kj::systemPreciseMonotonicClock().now();
@@ -19,6 +21,8 @@ std::default_random_engine makeSeededRandomEngine() {
   std::default_random_engine engine(seed);
   return engine;
 }
+
+} // namespace
 
 AlarmScheduler::AlarmScheduler(
     const kj::Clock& clock,

--- a/src/workerd/util/wait-list.c++
+++ b/src/workerd/util/wait-list.c++
@@ -11,9 +11,9 @@ namespace {
 thread_local CrossThreadWaitList::WaiterMap threadLocalWaiters;
 // Optimization: If the same wait list is waited multiple times in the same thread, we want to
 // share the signal rather than send two cross-thread signals.
-}  // namespace
 
 void END_WAIT_LIST_CANCELER_STACK_START_CANCELEE_STACK() {}
+}  // namespace
 
 CrossThreadWaitList::CrossThreadWaitList(Options options)
     : state(kj::atomicRefcounted<State>(options)) {}


### PR DESCRIPTION
This looks cleaner and occasionally results in better inlining decisions. It should also help us enable `-Wmissing-prototypes` on code owned by us in the future to ensure that the compiler knows which functions are only used locally and that source files always include the headers where their function prototypes are defined.