### PR TITLE
Change delivery of websocket for hibernation event

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -285,16 +285,19 @@ public:
 
   void sendHibernatableWebSocketMessage(
       kj::OneOf<kj::String, kj::Array<byte>> message,
+      kj::String websocketId,
       Worker::Lock& lock,
       kj::Maybe<ExportedHandler&> exportedHandler);
 
   void sendHibernatableWebSocketClose(
       HibernatableSocketParams::Close close,
+      kj::String websocketId,
       Worker::Lock& lock,
       kj::Maybe<ExportedHandler&> exportedHandler);
 
   void sendHibernatableWebSocketError(
       kj::Exception e,
+      kj::String websocketId,
       Worker::Lock& lock,
       kj::Maybe<ExportedHandler&> exportedHandler);
 

--- a/src/workerd/api/hibernation-event-params.h
+++ b/src/workerd/api/hibernation-event-params.h
@@ -32,13 +32,16 @@ namespace workerd::api {
     };
 
     kj::OneOf<Text, Data, Close, Error> eventType;
+    kj::String websocketId;
 
-    explicit HibernatableSocketParams(kj::String message): eventType(Text { kj::mv(message) }) {}
-    explicit HibernatableSocketParams(kj::Array<kj::byte> message)
-        : eventType(Data { kj::mv(message) }) {}
-    explicit HibernatableSocketParams(int code, kj::String reason, bool wasClean)
-        : eventType(Close { code, kj::mv(reason), wasClean }) {}
-    explicit HibernatableSocketParams(kj::Exception e): eventType(Error { kj::mv(e) }) {}
+    explicit HibernatableSocketParams(kj::String message, kj::String id)
+        : eventType(Text { kj::mv(message) }), websocketId(kj::mv(id)) {}
+    explicit HibernatableSocketParams(kj::Array<kj::byte> message, kj::String id)
+        : eventType(Data { kj::mv(message) }), websocketId(kj::mv(id)) {}
+    explicit HibernatableSocketParams(int code, kj::String reason, bool wasClean, kj::String id)
+        : eventType(Close { code, kj::mv(reason), wasClean }), websocketId(kj::mv(id)) {}
+    explicit HibernatableSocketParams(kj::Exception e, kj::String id)
+        : eventType(Error { kj::mv(e) }), websocketId(kj::mv(id)) {}
 
     HibernatableSocketParams(HibernatableSocketParams&& other) = default;
 

--- a/src/workerd/io/hibernation-manager.h
+++ b/src/workerd/io/hibernation-manager.h
@@ -176,9 +176,14 @@ private:
   uint16_t hibernationEventType;
   // Passed to HibernatableWebSocket custom event as the typeId.
 
-  kj::Maybe<HibernatableWebSocket&> webSocketForEventHandler;
-  // Allows the HibernatableWebSocket event handler that is currently running to access the
-  // HibernatableWebSocket that it needs to execute.
+  kj::HashMap<kj::String, HibernatableWebSocket*> webSocketsForEventHandler;
+  // A map of { ID -> HibernatableWebSocket } that allows the event handler that is currently
+  // running to access the HibernatableWebSocket that it needs to execute.
+  //
+  // Dispatching events tends to result in races when events are received on different websockets
+  // around the same time. Suppose there are two websockets that disconnect at the same time.
+  // It is possible that both of them will be added to the map (i.e. their `receive()`
+  // will throw) before the first event is dispatched and manages to obtain its associated websocket.
 
   const size_t ACTIVE_CONNECTION_LIMIT = 1024 * 32;
   // The maximum number of Hibernatable WebSocket connections a single HibernationManagerImpl

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -138,6 +138,7 @@ struct HibernatableWebSocketEventMessage {
     error @5 :Text;
     # TODO(someday): This could be an Exception instead of Text.
   }
+  websocketId @6: Text;
 }
 
 struct HibernatableWebSocketResponse {


### PR DESCRIPTION
We noticed the `webSocketForEventHandler` reference was being overwritten by subsequent events before an event that set it could read the value.

To fix this, we use a map of `ID`s to `HibernatableWebSocket`s and pass the ID to the event itself so it can find its associated websocket.