### PR TITLE
Handling explicit null bindings in SQLite

### DIFF
--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -197,16 +197,20 @@ SqlStorage::Statement::Statement(SqliteDatabase::Statement&& statement)
 kj::Array<const SqliteDatabase::Query::ValuePtr> SqlStorage::Cursor::mapBindings(
     kj::ArrayPtr<BindingValue> values) {
   return KJ_MAP(value, values) -> SqliteDatabase::Query::ValuePtr {
-    KJ_SWITCH_ONEOF(value) {
-      KJ_CASE_ONEOF(data, kj::Array<const byte>) {
-        return data.asPtr();
+    KJ_IF_MAYBE(v, value) {
+      KJ_SWITCH_ONEOF(*v) {
+        KJ_CASE_ONEOF(data, kj::Array<const byte>) {
+          return data.asPtr();
+        }
+        KJ_CASE_ONEOF(text, kj::String) {
+          return text.asPtr();
+        }
+        KJ_CASE_ONEOF(d, double) {
+          return d;
+        }
       }
-      KJ_CASE_ONEOF(text, kj::String) {
-        return text.asPtr();
-      }
-      KJ_CASE_ONEOF(d, double) {
-        return d;
-      }
+    } else {
+      return nullptr;
     }
     KJ_UNREACHABLE;
   };

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -18,7 +18,7 @@ public:
   SqlStorage(SqliteDatabase& sqlite, jsg::Ref<DurableObjectStorage> storage);
   ~SqlStorage();
 
-  using BindingValue = kj::OneOf<kj::Array<const byte>, kj::String, double>;
+  using BindingValue = kj::Maybe<kj::OneOf<kj::Array<const byte>, kj::String, double>>;
 
   class Cursor;
   class Statement;


### PR DESCRIPTION
These were being implicitly coerced into a string before reaching the `SqliteDatabase::Query::bind` function.

I've also added tests to confirm that you can inject BLOBs by binding a `Uint8Array`