### PR TITLE
Add support for alternative content types when sending and receiving Queue messages

### DIFF
--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -114,6 +114,7 @@ struct QueueMessage @0x944adb18c0352295 {
   id @0 :Text;
   timestampNs @1 :Int64;
   data @2 :Data;
+  contentType @3 :Text;
 }
 
 struct QueueResponse @0x90e98932c0bfc0de {


### PR DESCRIPTION
Previously, queue messages were always serialized and stored in v8 format, and deserialized from v8 format before being passed to a `queue()` event handler via dynamic dispatch.

This PR adds support for alternative content types:
* A new `contentType` option can be specified when calling `send()` or `sendBatch()` on a Queue. The message will be stored in the desired format, enabling it to be retrieved in the same format later.
* The `contentType` is used to determine the serialization format for the message, before sending it off for storage
* The `contentType` is used to determine the deserialization format for incoming messages from the Queue.

