### PR TITLE
[SQLite] Discussion: how to handle duplicate column names in result set?

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -510,20 +510,11 @@ async function test(storage) {
     sql.exec(`CREATE TABLE cde (c INT, d INT, e INT);`)
     sql.exec(`INSERT INTO abc VALUES (1,2,3),(4,5,6);`)
     sql.exec(`INSERT INTO cde VALUES (7,8,9),(1,2,3);`)
-    const fullJoin = sql.prepare(`SELECT * FROM abc, cde`)
 
-    // Raw results include both 'c' columns
-    const rawResults = Array.from(fullJoin().raw())
-    assert.equal(rawResults.length, 4)
-    assert.equal(rawResults[0].length, 6)
-    assert.equal(rawResults[1].length, 6)
-    assert.equal(rawResults[2].length, 6)
-    assert.equal(rawResults[3].length, 6)
+    const stmt = sql.prepare(`SELECT * FROM abc, cde`)
 
-    // TODO: how to get column names from .raw() iterator?
-
-    // Without .raw(), data is lost
-    const objResults = Array.from(fullJoin())
+    // In normal iteration, data is lost
+    const objResults = Array.from(stmt())
     assert.equal(Object.values(objResults[0]).length, 5) // duplicate column 'c' dropped
     assert.equal(Object.values(objResults[1]).length, 5) // duplicate column 'c' dropped
     assert.equal(Object.values(objResults[2]).length, 5) // duplicate column 'c' dropped
@@ -533,6 +524,19 @@ async function test(storage) {
     assert.equal(objResults[1].c, 1) // Value of 'c' is the second in the join
     assert.equal(objResults[2].c, 7) // Value of 'c' is the second in the join
     assert.equal(objResults[3].c, 1) // Value of 'c' is the second in the join
+
+    // Iterator has a 'columnNames' property, with .raw() that lets us get the full data
+    const iterator = stmt();
+    assert.deepEqual(iterator.columnNames, ["a","b","c","c","d","e"])
+    const rawResults = Array.from(iterator.raw())
+    assert.equal(rawResults.length, 4)
+    assert.deepEqual(rawResults[0], [1,2,3,7,8,9])
+    assert.deepEqual(rawResults[1], [1,2,3,1,2,3])
+    assert.deepEqual(rawResults[2], [4,5,6,7,8,9])
+    assert.deepEqual(rawResults[3], [4,5,6,1,2,3])
+
+    // Once an iterator is consumed, it can no longer access the columnNames.
+    assert.deepEqual(iterator.columnNames, [])
   }
 
   await scheduler.wait(1);

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -118,6 +118,17 @@ jsg::Ref<SqlStorage::Cursor::RawIterator> SqlStorage::Cursor::raw(jsg::Lock&) {
   return jsg::alloc<RawIterator>(JSG_THIS);
 }
 
+kj::Array<jsg::V8Ref<v8::String>> SqlStorage::Cursor::getColumnNames(jsg::Lock& js) {
+  KJ_IF_MAYBE(s, state) {
+    cachedColumnNames.ensureInitialized(js, (*s)->query);
+    return KJ_MAP(name, this->cachedColumnNames.get()) {
+      return name.addRef(js);
+    };
+  } else {
+    return kj::Array<jsg::V8Ref<v8::String>>();
+  }
+}
+
 kj::Maybe<kj::Array<SqlStorage::Cursor::Value>> SqlStorage::Cursor::rawIteratorNext(
     jsg::Lock& js, jsg::Ref<Cursor>& obj) {
   return iteratorImpl(js, obj,

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -97,10 +97,13 @@ public:
         cachedColumnNames(cachedColumnNames) {}
   ~Cursor() noexcept(false);
 
+  kj::Array<jsg::V8Ref<v8::String>> getColumnNames(jsg::Lock& js);
   JSG_RESOURCE_TYPE(Cursor, CompatibilityFlags::Reader flags) {
     JSG_ITERABLE(rows);
     JSG_METHOD(raw);
+    JSG_READONLY_PROTOTYPE_PROPERTY(columnNames, getColumnNames);
   }
+
 
   using Value = kj::Maybe<kj::OneOf<kj::Array<byte>, kj::StringPtr, double>>;
   // One value returned from SQL. Note that we intentionally return StringPtr instead of String


### PR DESCRIPTION
If you have the following SQL:

```sql
CREATE TABLE abc (a INT, b INT, c INT);
CREATE TABLE cde (c INT, d INT, e INT);
INSERT INTO abc VALUES (1,2,3),(4,5,6);
INSERT INTO cde VALUES (7,8,9),(1,2,3);

SELECT * FROM abc, cde;
```

You get (in real sqlite in 'table' output mode):

```
+---+---+---+---+---+---+
| a | b | c | c | d | e |
+---+---+---+---+---+---+
| 1 | 2 | 3 | 7 | 8 | 9 |
| 1 | 2 | 3 | 1 | 2 | 3 |
| 4 | 5 | 6 | 7 | 8 | 9 |
| 4 | 5 | 6 | 1 | 2 | 3 |
+---+---+---+---+---+---+
```

(Note the repeated column name `c`)

Doing that in workerd's SQLite:

```js
Array.from(sql.prepare(`SELECT * FROM abc, cde`)())
// =>
[
  {"a":1,"b":2,"c":7,"d":8,"e":9},
  {"a":1,"b":2,"c":1,"d":2,"e":3},
  {"a":4,"b":5,"c":7,"d":8,"e":9},
  {"a":4,"b":5,"c":1,"d":2,"e":3}
]
```

Note that the second value of `c`, `7`, has overwritten the first value `3`.

Using `.raw()` gets the right data:

```js
Array.from(sql.prepare(`SELECT * FROM abc, cde`)().raw())
// =>
[
  [1,2,3,7,8,9],
  [1,2,3,1,2,3],
  [4,5,6,7,8,9],
  [4,5,6,1,2,3]
]
```

But currently, the D1 shim assumes `.raw()` can always be retrieved from the `Object.values` of the "object" response type. We'll be changing the shim but, for backwards compatibility, should we endeavour to make the default response format _never_ drop data, by preferring to instead mangle the column names?

```js
[
  {"a":1,"b":2,"c":3,"c_1":7,"d":8,"e":9},
]
```

Note the `c_1` key meaning "first duplicate of c" column. We could also use `.` as a separator, or even `~` if we wanted to channel DOS filenames... :)

Alternatively, we could throw an exception if this case occurs, though that might be painful for people who do something like: `SELECT * FROM users, projects WHERE projects.user_id = users.user_id`. There's a duplicate column name but the data is always the same, so is that really bad? The fact that the `raw()` and normal responses have different lengths of responses is still not great though...

As an aside, it's a shame the [full_column_names](https://www.sqlite.org/pragma.html#pragma_full_column_names) pragma is deprecated (and has no effect). It would have solved this nicely for anyone who relied on `select *` a bunch in their app...