### PR TITLE
Review comments from V8 11.4.183.12 update (#678)

### DIFF
--- a/docs/v8-updates.md
+++ b/docs/v8-updates.md
@@ -8,7 +8,7 @@ To update the version of V8 used by workerd, the steps are:
 
    https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up
 
-3. Fetch V8
+3. Fetch a local copy of V8:
 
    ```
    $ mkdir v8
@@ -16,7 +16,7 @@ To update the version of V8 used by workerd, the steps are:
    $ fetch v8
    ```
 
-4. Sync V8 to the version of V8 currently used by workerd.
+4. Sync the local copy of V8 to the version used by workerd.
 
    First find, the commit hash of the "v8" `git_repository` in the workerd [WORKSPACE](../WORKSPACE) file.
 
@@ -28,14 +28,14 @@ To update the version of V8 used by workerd, the steps are:
    $ gclient sync
    ```
 
-5. Create a V8 branch for workerd's V8 patches in your recently fetch V8.
+5. Create a V8 branch for workerd's V8 patches in your local copy of V8.
 
    ```
    $ git checkout -b workerd-patches
    $ git am <path_to_workerd>/patches/v8/*
    ```
 
-7. Rebase workerd V8 changes onto the new version of V8. For example, assuming
+7. Rebase the workerd V8 changes onto the new version of V8. For example, assuming
    we are updating to 11.4.183.8 and there are 8 workerd patches for V8, the
    command would be:
 
@@ -43,31 +43,33 @@ To update the version of V8 used by workerd, the steps are:
    $ git rebase --onto 11.4.183.8 HEAD~8
    ```
 
-   There is usually some minor patch editing required during rebase.
+   There is usually some minor patch editing required during a rebase.
 
-   Ideally at this stage, you should be able to build and test V8 with the patches applied.
+   Ideally at this stage, you should be able to build and test the local V8 with the
+   patches applied. See the V8 [Testing](https://v8.dev/docs/test) page.
 
-8. Re-generate workerd's v8 patches. Assuming there are 8 workerd patches for V8,
+8. Re-generate workerd's V8 patches. Assuming there are 8 workerd patches for V8,
    the command would be:
 
    ```
-   $ git format-patch -k --no-signature HEAD~8
+   $ git format-patch --full-index -k --no-signature HEAD~8
    ```
 
-9. Remove existing patches from `workerd/patches/v8` and copy the latest patch there.
+9. Remove the existing patches from `workerd/patches/v8` and copy the latest patches
+   for the V8 directory there.
 
-10. Update the `git_repository` for "v8" in `workerd/WORKSPACE`
+10. Update the `git_repository` for V8 in the `workerd/WORKSPACE` file.
 
-    The list of patches should be refreshed if any patches are any new patches or any
-    that have been removed.
+    The list of patches should be refreshed if new patches are being added or existing
+    patches are being removed.
 
-    The `commit` in the `git_repository` for "v8" should be updated to match
-    the version corresponding to the version of v8 being updated. This can be found
-    by running `git rev-parse <version>` in the v8 git repo, e.g. `git rev-parse 11.4.183.8`.
+    The `commit` in the `git_repository` for V8 should be updated to match
+    the version corresponding to the version of V8 being updated. This can be found
+    by running `git rev-parse <version>` in the local V8 git repo, e.g. `git rev-parse 11.4.183.8`.
 
     See [V8 git_repository in WORKSPACE](https://github.com/cloudflare/workerd/blob/2d124ecd2d1132537d37bd5e166ac1aec4f7397f/WORKSPACE#L263)
 
-11. Update V8's dependencies in `workerd/WORKSPACE`
+11. Update V8's dependencies in `workerd/WORKSPACE`.
 
    The `v8/.gclient_entries` file contains the commit versions for V8's dependencies.
 
@@ -82,5 +84,15 @@ To update the version of V8 used by workerd, the steps are:
     ```
     $ bazel test //...
     ```
+
+    You may see advice in the build output about shallow-since dates for the V8 related
+    git repositories:
+
+    ```
+    DEBUG: Rule 'v8' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1683898886 +0000"
+    ```
+
+    You can follow the advice in these messages and update the shallow-since dates for
+    the V8 related git repositories in the WORKSPACE file.
 
 13. Commit your workerd changes and push them for review.

--- a/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
+++ b/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
@@ -1,4 +1,4 @@
-From 37f5892ec712f374124afbea8b45414c61193917 Mon Sep 17 00:00:00 2001
+From fa252bbeb7271ac8c25b0bae3e844f72b693c454 Mon Sep 17 00:00:00 2001
 From: Alex Robinson <arobinson@cloudflare.com>
 Date: Wed, 2 Mar 2022 15:58:04 -0600
 Subject: Allow manually setting ValueDeserializer format version
@@ -22,7 +22,7 @@ like:
  3 files changed, 18 insertions(+)
 
 diff --git a/include/v8-value-serializer.h b/include/v8-value-serializer.h
-index 0cb3e045bc..40ad805c79 100644
+index 0cb3e045bc46ec732956318b980e749d1847d06d..40ad805c7970cc9379e69f046205836dbd760373 100644
 --- a/include/v8-value-serializer.h
 +++ b/include/v8-value-serializer.h
 @@ -293,6 +293,13 @@ class V8_EXPORT ValueDeserializer {
@@ -40,7 +40,7 @@ index 0cb3e045bc..40ad805c79 100644
     * Reads raw data in various common formats to the buffer.
     * Note that integer types are read in base-128 varint format, not with a
 diff --git a/src/api/api.cc b/src/api/api.cc
-index 94b44c14c3..729dc91451 100644
+index 94b44c14c36462b263bcdc7d6c7a585c81edb9fe..729dc91451821dbfb30f86a31099784c2f2e2375 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
 @@ -3772,6 +3772,10 @@ uint32_t ValueDeserializer::GetWireFormatVersion() const {
@@ -55,7 +55,7 @@ index 94b44c14c3..729dc91451 100644
    PREPARE_FOR_EXECUTION(context, ValueDeserializer, ReadValue, Value);
    i::MaybeHandle<i::Object> result;
 diff --git a/src/objects/value-serializer.h b/src/objects/value-serializer.h
-index f5ccdcbf0a..f3d35e9498 100644
+index f5ccdcbf0a5f0c61c739a6a36f5fbe5bedf43934..f3d35e9498b664ff02e77da0e5ef3240c3e054b4 100644
 --- a/src/objects/value-serializer.h
 +++ b/src/objects/value-serializer.h
 @@ -217,6 +217,13 @@ class ValueDeserializer {

--- a/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
+++ b/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
@@ -1,4 +1,4 @@
-From 5143eda0e0e81242653d74dec690b239c2c6a578 Mon Sep 17 00:00:00 2001
+From 3700613acf643e5c45ccb66bb9636f48286b4499 Mon Sep 17 00:00:00 2001
 From: James M Snell <jasnell@gmail.com>
 Date: Wed, 16 Mar 2022 08:59:21 -0700
 Subject: Allow manually setting ValueSerializer format version
@@ -12,7 +12,7 @@ Refs: https://bitbucket.cfdata.org/projects/MIRRORS/repos/v8/pull-requests/2/ove
  4 files changed, 29 insertions(+), 3 deletions(-)
 
 diff --git a/include/v8-value-serializer.h b/include/v8-value-serializer.h
-index 40ad805c79..596be18ade 100644
+index 40ad805c7970cc9379e69f046205836dbd760373..596be18adeb3a5a81794aaa44b1d347dec6c0c7d 100644
 --- a/include/v8-value-serializer.h
 +++ b/include/v8-value-serializer.h
 @@ -154,6 +154,11 @@ class V8_EXPORT ValueSerializer {
@@ -28,7 +28,7 @@ index 40ad805c79..596be18ade 100644
     * Writes out a header, which includes the format version.
     */
 diff --git a/src/api/api.cc b/src/api/api.cc
-index 729dc91451..ecddc98f57 100644
+index 729dc91451821dbfb30f86a31099784c2f2e2375..ecddc98f57be97b21decbf37d87a530475525377 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
 @@ -3639,6 +3639,10 @@ ValueSerializer::ValueSerializer(Isolate* v8_isolate, Delegate* delegate)
@@ -43,7 +43,7 @@ index 729dc91451..ecddc98f57 100644
  
  void ValueSerializer::SetTreatArrayBufferViewsAsHostObjects(bool mode) {
 diff --git a/src/objects/value-serializer.cc b/src/objects/value-serializer.cc
-index 2efca82aaa..c57ff099dc 100644
+index 2efca82aaaa00da30fdab8d66d97275e3b162a51..c57ff099dc750f6872b5de0462718d873e95d53c 100644
 --- a/src/objects/value-serializer.cc
 +++ b/src/objects/value-serializer.cc
 @@ -266,6 +266,7 @@ ValueSerializer::ValueSerializer(Isolate* isolate,
@@ -89,7 +89,7 @@ index 2efca82aaa..c57ff099dc 100644
  }
  
 diff --git a/src/objects/value-serializer.h b/src/objects/value-serializer.h
-index f3d35e9498..d3d839ad10 100644
+index f3d35e9498b664ff02e77da0e5ef3240c3e054b4..d3d839ad108c8ce39437119e0dbae393fad1467a 100644
 --- a/src/objects/value-serializer.h
 +++ b/src/objects/value-serializer.h
 @@ -54,6 +54,11 @@ class ValueSerializer {

--- a/patches/v8/0003-Make-icudata-target-public.patch
+++ b/patches/v8/0003-Make-icudata-target-public.patch
@@ -1,4 +1,4 @@
-From 70f30fc43b5fffd95ff882a16328ad41ecbcece3 Mon Sep 17 00:00:00 2001
+From 65409c1d3c6b4ace5cc86043a855175b793f4de3 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Sat, 17 Sep 2022 11:11:15 -0500
 Subject: Make `:icudata` target public.
@@ -9,7 +9,7 @@ Dependencies are required to load this file, so it ought to be exposed for them 
  1 file changed, 1 insertion(+)
 
 diff --git a/bazel/BUILD.icu b/bazel/BUILD.icu
-index 2ae79a5784..4843ea09f9 100644
+index 2ae79a5784f252ab69b58cd47d131aec65d34701..4843ea09f99fa1b45bf66af8fd971adfd89efe45 100644
 --- a/bazel/BUILD.icu
 +++ b/bazel/BUILD.icu
 @@ -5,6 +5,7 @@

--- a/patches/v8/0004-Add-ArrayBuffer-MaybeNew.patch
+++ b/patches/v8/0004-Add-ArrayBuffer-MaybeNew.patch
@@ -1,4 +1,4 @@
-From f3a7ba35c5950b3cf12432a319bce04fbd1c1308 Mon Sep 17 00:00:00 2001
+From 011d7954e60346b47dee5697a41120a9858e92fd Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Fri, 16 Sep 2022 21:41:45 -0500
 Subject: Add `ArrayBuffer::MaybeNew()`.
@@ -11,7 +11,7 @@ In Cloudflare's edge runtime, this is part of a larger patch that allows gracefu
  1 file changed, 8 insertions(+)
 
 diff --git a/include/v8-array-buffer.h b/include/v8-array-buffer.h
-index 804fc42c4b..369e770351 100644
+index 804fc42c4b56dd9b79f0fdc49e94c0e101e510e8..369e770351b80c60cae43866139e3a5396de08bd 100644
 --- a/include/v8-array-buffer.h
 +++ b/include/v8-array-buffer.h
 @@ -210,6 +210,14 @@ class V8_EXPORT ArrayBuffer : public Object {

--- a/patches/v8/0005-Allow-compiling-on-macOS-catalina-and-ventura.patch
+++ b/patches/v8/0005-Allow-compiling-on-macOS-catalina-and-ventura.patch
@@ -1,4 +1,4 @@
-From 0c58281eb7ded742fba5d939d11b699cb3391832 Mon Sep 17 00:00:00 2001
+From 094a86545cd7a11e924cfd131bea6e7e6cb23a79 Mon Sep 17 00:00:00 2001
 From: Dhi Aurrahman <dio@rockybars.com>
 Date: Thu, 27 Oct 2022 12:45:05 +0700
 Subject: Allow compiling on macOS catalina and ventura
@@ -9,7 +9,7 @@ Signed-off-by: Dhi Aurrahman <dio@rockybars.com>
  1 file changed, 12 insertions(+)
 
 diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index 9024b1e14f..459979f163 100644
+index 9024b1e14f6f032d636e26e18f88db6d3365ee4c..459979f1637199e06a9ba5b0df6d63c3d778a460 100644
 --- a/bazel/defs.bzl
 +++ b/bazel/defs.bzl
 @@ -156,6 +156,18 @@ def _default_args():

--- a/patches/v8/0006-Fix-v8-code_generator-imports.patch
+++ b/patches/v8/0006-Fix-v8-code_generator-imports.patch
@@ -1,4 +1,4 @@
-From 8831ef5a2250f102861c0c56bf9f626a7555a8e8 Mon Sep 17 00:00:00 2001
+From a18ca013187714f2f1c7ae630fcedf1eb8579a4f Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Wed, 8 Mar 2023 16:15:31 -0500
 Subject: Fix v8 code_generator imports
@@ -8,7 +8,7 @@ Subject: Fix v8 code_generator imports
  1 file changed, 5 insertions(+)
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 83cb5a4d6b..366312ce07 100644
+index 83cb5a4d6b6fd19a83d863d7253c230109621d85..366312ce0735989b54090f53b88c035c239cd7b6 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
 @@ -3592,6 +3592,11 @@ py_binary(

--- a/patches/v8/0007-Allow-Windows-builds-under-Bazel.patch
+++ b/patches/v8/0007-Allow-Windows-builds-under-Bazel.patch
@@ -1,4 +1,4 @@
-From 66a373d938fd33f4af23523ba3d519bea9326196 Mon Sep 17 00:00:00 2001
+From 2d322cd7ad707adc0c01a9af78df666f8c596947 Mon Sep 17 00:00:00 2001
 From: Brendan Coll <bcoll@cloudflare.com>
 Date: Thu, 16 Mar 2023 11:56:10 +0000
 Subject: Allow Windows builds under Bazel
@@ -10,7 +10,7 @@ Subject: Allow Windows builds under Bazel
  3 files changed, 78 insertions(+), 12 deletions(-)
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 366312ce07..b416691dfd 100644
+index 366312ce0735989b54090f53b88c035c239cd7b6..b416691dfd3b68d728160a5bd26fba5d6a528084 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
 @@ -671,6 +671,7 @@ filegroup(
@@ -106,7 +106,7 @@ index 366312ce07..b416691dfd 100644
      python_version = "PY3",
      tags = [
 diff --git a/bazel/config/BUILD.bazel b/bazel/config/BUILD.bazel
-index 67454fa90e..7efff1ab90 100644
+index 67454fa90eea460e70e286623fb1c99edd22c650..7efff1ab909dc7048a216e511c2e71c72ee8847a 100644
 --- a/bazel/config/BUILD.bazel
 +++ b/bazel/config/BUILD.bazel
 @@ -286,6 +286,7 @@ selects.config_setting_group(
@@ -175,7 +175,7 @@ index 67454fa90e..7efff1ab90 100644
      name = "is_clang",
      match_any = [
 diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index 459979f163..1a167f2338 100644
+index 459979f1637199e06a9ba5b0df6d63c3d778a460..1a167f2338b70bb9e3152af2daaa74880b878b99 100644
 --- a/bazel/defs.bzl
 +++ b/bazel/defs.bzl
 @@ -117,6 +117,24 @@ def _default_args():

--- a/patches/v8/0008-Disable-bazel-whole-archive-build.patch
+++ b/patches/v8/0008-Disable-bazel-whole-archive-build.patch
@@ -1,4 +1,4 @@
-From 24225c29477562fd511dc8cc42299e40ac76b265 Mon Sep 17 00:00:00 2001
+From b1ec056cfcb3d00a092b1f4059f1c829a42239fb Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Tue, 11 Apr 2023 14:41:31 -0400
 Subject: Disable bazel whole-archive build
@@ -18,7 +18,7 @@ allows the linker to eliminate unused symbols.
  2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/bazel/BUILD.icu b/bazel/BUILD.icu
-index 4843ea09f9..73a25df55a 100644
+index 4843ea09f99fa1b45bf66af8fd971adfd89efe45..73a25df55abc380092a0177bb13364e6f216ce95 100644
 --- a/bazel/BUILD.icu
 +++ b/bazel/BUILD.icu
 @@ -56,7 +56,7 @@ cc_library(
@@ -40,7 +40,7 @@ index 4843ea09f9..73a25df55a 100644
  
  cc_library(
 diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index 1a167f2338..471682f0c3 100644
+index 1a167f2338b70bb9e3152af2daaa74880b878b99..471682f0c3ca427963b96c7353c63fd572e8eec2 100644
 --- a/bazel/defs.bzl
 +++ b/bazel/defs.bzl
 @@ -299,7 +299,7 @@ def v8_library(

--- a/patches/v8/0009-Make-v8-Locker-automatically-call-isolate-Enter.patch
+++ b/patches/v8/0009-Make-v8-Locker-automatically-call-isolate-Enter.patch
@@ -1,7 +1,7 @@
-From 38b40b1827ed6dc38dd9acd0e1de531b3b536c6a Mon Sep 17 00:00:00 2001
+From eb0c3315565b32732df70e60cabfe360b602fc79 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Tue, 23 May 2023 09:18:57 -0500
-Subject: [PATCH 09/10] Make v8::Locker automatically call isolate->Enter().
+Subject: Make v8::Locker automatically call isolate->Enter().
 
 This makes it no longer necessary to create a v8::Isolate::Scope after taking the lock.
 
@@ -13,7 +13,7 @@ This is a major change in API semantics, however, which makes it unlikely to be 
  1 file changed, 2 insertions(+)
 
 diff --git a/src/execution/v8threads.cc b/src/execution/v8threads.cc
-index be4f4a7f20..fb525314d9 100644
+index be4f4a7f209e3e8d784d8ab57d0ef77a58df8790..fb525314d9fb6dca143dbe45bfd6dbf53af132c8 100644
 --- a/src/execution/v8threads.cc
 +++ b/src/execution/v8threads.cc
 @@ -40,6 +40,7 @@ void Locker::Initialize(v8::Isolate* isolate) {
@@ -32,6 +32,3 @@ index be4f4a7f20..fb525314d9 100644
      isolate_->thread_manager()->Unlock();
    }
  }
--- 
-2.30.2
-

--- a/patches/v8/0010-Add-an-API-to-capture-and-restore-the-cage-base-poin.patch
+++ b/patches/v8/0010-Add-an-API-to-capture-and-restore-the-cage-base-poin.patch
@@ -1,8 +1,7 @@
-From 7f2c3441a5c4f93e49a7bff99d8e1386cee1a591 Mon Sep 17 00:00:00 2001
+From 51c0a45bc7f3a27912c6a548602d35d3aad88001 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Tue, 23 May 2023 09:24:11 -0500
-Subject: [PATCH 10/10] Add an API to capture and restore the cage base
- pointers.
+Subject: Add an API to capture and restore the cage base pointers.
 
 This will be used in workerd to ensure that the cage pointers propagate to background thread tasks/jobs correctly.
 
@@ -13,7 +12,7 @@ This is not the right solution. Instead, each background task/job implementation
  2 files changed, 62 insertions(+)
 
 diff --git a/include/v8-locker.h b/include/v8-locker.h
-index 22b7a8767a..fee48faffe 100644
+index 22b7a8767a83a702a2601bdfd4c0f71206df0ad5..fee48faffe82400595dca17197c5bbee680a6137 100644
 --- a/include/v8-locker.h
 +++ b/include/v8-locker.h
 @@ -6,6 +6,7 @@
@@ -61,7 +60,7 @@ index 22b7a8767a..fee48faffe 100644
  
  #endif  // INCLUDE_V8_LOCKER_H_
 diff --git a/src/execution/v8threads.cc b/src/execution/v8threads.cc
-index fb525314d9..231eb53a7b 100644
+index fb525314d9fb6dca143dbe45bfd6dbf53af132c8..231eb53a7bd8c5545009580b712e22b084cabc65 100644
 --- a/src/execution/v8threads.cc
 +++ b/src/execution/v8threads.cc
 @@ -6,6 +6,7 @@
@@ -108,6 +107,3 @@ index fb525314d9..231eb53a7b 100644
 +}
 +
  }  // namespace v8
--- 
-2.30.2
-


### PR DESCRIPTION
Incorporates review comments in #678 

Review comments from https://github.com/cloudflare/workerd/pull/678

* Documents that patches should be generated with --full-index
* Adds a note about git_repository shallow-since
* Some re-wording of vs-updates.md.

Bug: EW-7428
Test: bazel build //...