### PR TITLE
Drastically reduce Windows build log size

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -92,5 +92,11 @@ build:windows --cxxopt='/DWINDOWS_LEAN_AND_MEAN' --host_cxxopt='/DWINDOWS_LEAN_A
 # The `/std:c++14` argument is unused during boringssl compilation and we don't
 # want a warning when compiling each file.
 build:windows --cxxopt='-Wno-unused-command-line-argument' --host_cxxopt='-Wno-unused-command-line-argument'
+# This warning is triggered on much of V8's code base, causing the build output to be much bigger
+# than it should be.
+# V8's bazel does disable it for clang-based toolchains, but unfortunately the Windows setup is not
+# being detected as clang...
+# TODO(soon): Integrate this into V8 instead
+build:windows --cxxopt='-Wno-invalid-offsetof' --host_cxxopt='-Wno-invalid-offsetof'
 
 build:windows --@capnp-cpp//src/kj:openssl=True --@capnp-cpp//src/kj:zlib=True


### PR DESCRIPTION
The Windows build log on CI is currently very large, ~12MB on a recent run with few changes compared to 400kb on Mac and Linux, which makes it more difficult to look at the build logs when tracking down Windows build failures on CI and is bad for the Windows DX.
This is caused largely by V8 needing the `-Wno-invalid-offsetof` flag to not throw a ton of warnings. V8's bazel enables the flag when using a clang-based compiler, but it doesn't realize that the Windows build uses clang.
Adding the warning reduces the build log to 1.1MB, likely even more on a regular build where the build settings don't change. 
I'm not sure if this is the right place for the flag though – it might make more sense to integrate it into V8's build system through a patch.