### PR TITLE
Remove admin account tag from path in R2 operations

### DIFF
--- a/src/workerd/api/r2-admin.h
+++ b/src/workerd/api/r2-admin.h
@@ -33,12 +33,10 @@ public:
 
   R2Admin(FeatureFlags featureFlags,
           uint subrequestChannel,
-          kj::String account,
           kj::String jwt,
           friend_tag_t)
       : featureFlags(featureFlags),
         subrequestChannel(subrequestChannel),
-        adminAccount(kj::mv(account)),
         jwt(kj::mv(jwt)) {}
   // This constructor is intended to be used by the R2CrossAccount binding, which has access to the
   // friend_tag
@@ -100,7 +98,6 @@ public:
 private:
   R2Bucket::FeatureFlags featureFlags;
   uint subrequestChannel;
-  kj::Maybe<kj::String> adminAccount;
   kj::Maybe<kj::String> jwt;
 
   friend class edgeworker::api::R2CrossAccount;

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -328,8 +328,8 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::head(
     headBuilder.setObject(name);
 
     auto requestJson = json.encode(requestBuilder);
-    kj::StringPtr components[2];
-    auto path = fillR2Path(components, adminAccount, adminBucket);
+    kj::StringPtr components[1];
+    auto path = fillR2Path(components, adminBucket);
     auto promise = doR2HTTPGetRequest(kj::mv(client), kj::mv(requestJson), path, jwt);
 
     return context.awaitIo(kj::mv(promise), [&errorType](R2Result r2Result) {
@@ -364,8 +364,8 @@ R2Bucket::get(jsg::Lock& js, kj::String name, jsg::Optional<GetOptions> options,
       initGetOptions(js, getBuilder, *o);
     }
     auto requestJson = json.encode(requestBuilder);
-    kj::StringPtr components[2];
-    auto path = fillR2Path(components, adminAccount, adminBucket);
+    kj::StringPtr components[1];
+    auto path = fillR2Path(components, adminBucket);
     auto promise = doR2HTTPGetRequest(kj::mv(client), kj::mv(requestJson), path, jwt);
 
     return context.awaitIo(kj::mv(promise), [&context, &errorType](R2Result r2Result)
@@ -554,8 +554,8 @@ R2Bucket::put(jsg::Lock& js, kj::String name, kj::Maybe<R2PutValue> value,
     auto requestJson = json.encode(requestBuilder);
 
     cancelReader.cancel();
-    kj::StringPtr components[2];
-    auto path = fillR2Path(components, adminAccount, adminBucket);
+    kj::StringPtr components[1];
+    auto path = fillR2Path(components, adminBucket);
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), kj::mv(value), nullptr,
                                       kj::mv(requestJson), path, jwt);
 
@@ -640,8 +640,8 @@ jsg::Promise<jsg::Ref<R2MultipartUpload>> R2Bucket::createMultipartUpload(jsg::L
     }
 
     auto requestJson = json.encode(requestBuilder);
-    kj::StringPtr components[2];
-    auto path = fillR2Path(components, adminAccount, adminBucket);
+    kj::StringPtr components[1];
+    auto path = fillR2Path(components, adminBucket);
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr, kj::mv(requestJson),
                                       path, jwt);
 
@@ -694,8 +694,8 @@ jsg::Promise<void> R2Bucket::delete_(jsg::Lock& js, kj::OneOf<kj::String, kj::Ar
 
     auto requestJson = json.encode(requestBuilder);
 
-    kj::StringPtr components[2];
-    auto path = fillR2Path(components, adminAccount, adminBucket);
+    kj::StringPtr components[1];
+    auto path = fillR2Path(components, adminBucket);
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr, kj::mv(requestJson),
                                       path, jwt);
 
@@ -795,8 +795,8 @@ jsg::Promise<R2Bucket::ListResult> R2Bucket::list(
 
     auto requestJson = json.encode(requestBuilder);
 
-    kj::StringPtr components[2];
-    auto path = fillR2Path(components, adminAccount, adminBucket);
+    kj::StringPtr components[1];
+    auto path = fillR2Path(components, adminBucket);
     auto promise = doR2HTTPGetRequest(kj::mv(client), kj::mv(requestJson), path, jwt);
 
     return context.awaitIo(kj::mv(promise),
@@ -1100,12 +1100,9 @@ kj::Maybe<jsg::Ref<R2Bucket::HeadResult>> parseHeadResultWrapper(
     return parseObjectMetadata<R2Bucket::HeadResult>(action, r2Result, errorType);
 }
 
-kj::ArrayPtr<kj::StringPtr> fillR2Path(kj::StringPtr pathStorage[2], const kj::Maybe<kj::String>& account, const kj::Maybe<kj::String>& bucket) {
+kj::ArrayPtr<kj::StringPtr> fillR2Path(kj::StringPtr pathStorage[1], const kj::Maybe<kj::String>& bucket) {
   int numComponents = 0;
 
-  KJ_IF_MAYBE(a, account) {
-    pathStorage[numComponents++] = *a;
-  }
   KJ_IF_MAYBE(b, bucket) {
     pathStorage[numComponents++] = *b;
   }

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -15,7 +15,7 @@
 namespace workerd::api::public_beta {
 
 kj::Array<kj::byte> cloneByteArray(const kj::Array<kj::byte>& arr);
-kj::ArrayPtr<kj::StringPtr> fillR2Path(kj::StringPtr pathStorage[2], const kj::Maybe<kj::String>& admin, const kj::Maybe<kj::String>& bucket);
+kj::ArrayPtr<kj::StringPtr> fillR2Path(kj::StringPtr pathStorage[1], const kj::Maybe<kj::String>& bucket);
 
 class R2MultipartUpload;
 
@@ -40,8 +40,8 @@ public:
   explicit R2Bucket(FeatureFlags featureFlags, uint clientIndex, kj::String bucket, friend_tag_t)
       : featureFlags(featureFlags), clientIndex(clientIndex), adminBucket(kj::mv(bucket)) {}
 
-  explicit R2Bucket(FeatureFlags featureFlags, uint clientIndex, kj::String bucket, kj::String account, kj::String jwt, friend_tag_t)
-      : featureFlags(featureFlags), clientIndex(clientIndex), adminBucket(kj::mv(bucket)), adminAccount(kj::mv(account)), jwt(kj::mv(jwt)) {}
+  explicit R2Bucket(FeatureFlags featureFlags, uint clientIndex, kj::String bucket, kj::String jwt, friend_tag_t)
+      : featureFlags(featureFlags), clientIndex(clientIndex), adminBucket(kj::mv(bucket)), jwt(kj::mv(jwt)) {}
 
   struct Range {
     jsg::Optional<double> offset;
@@ -407,7 +407,6 @@ private:
   FeatureFlags featureFlags;
   uint clientIndex;
   kj::Maybe<kj::String> adminBucket;
-  kj::Maybe<kj::String> adminAccount;
   kj::Maybe<kj::String> jwt;
 
   friend class R2Admin;

--- a/src/workerd/api/r2-multipart.c++
+++ b/src/workerd/api/r2-multipart.c++
@@ -44,8 +44,8 @@ jsg::Promise<R2MultipartUpload::UploadedPart> R2MultipartUpload::uploadPart(
     auto requestJson = json.encode(requestBuilder);
     auto bucket = this->bucket->adminBucket.map([](auto&& s) { return kj::str(s); });
 
-    kj::StringPtr components[2];
-    auto path = fillR2Path(components, nullptr, this->bucket->adminBucket);
+    kj::StringPtr components[1];
+    auto path = fillR2Path(components, this->bucket->adminBucket);
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), kj::mv(value), nullptr,
                                       kj::mv(requestJson), path, nullptr);
 
@@ -99,8 +99,8 @@ jsg::Promise<jsg::Ref<R2Bucket::HeadResult>> R2MultipartUpload::complete(
 
     auto requestJson = json.encode(requestBuilder);
 
-    kj::StringPtr components[2];
-    auto path = fillR2Path(components, nullptr, this->bucket->adminBucket);
+    kj::StringPtr components[1];
+    auto path = fillR2Path(components, this->bucket->adminBucket);
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr, kj::mv(requestJson),
                                       path, nullptr);
 
@@ -135,8 +135,8 @@ jsg::Promise<void> R2MultipartUpload::abort(jsg::Lock& js, const jsg::TypeHandle
 
     auto requestJson = json.encode(requestBuilder);
 
-    kj::StringPtr components[2];
-    auto path = fillR2Path(components, nullptr, this->bucket->adminBucket);
+    kj::StringPtr components[1];
+    auto path = fillR2Path(components, this->bucket->adminBucket);
     auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr, kj::mv(requestJson),
                                       path, nullptr);
 


### PR DESCRIPTION
The admin account is not needed in the path, only the jwt. This was an oversight from #577.