### PR TITLE
Add support for brotli content encoding, if enabled through compat flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -64,7 +64,7 @@ build:unix --cxxopt='-Wno-ignored-qualifiers' --host_cxxopt='-Wno-ignored-qualif
 # zlib release (https://github.com/madler/zlib/issues/633)
 build:unix --per_file_copt='external/zlib[~/].*\.c@-std=c90' --host_per_file_copt='external/zlib[~/].*\.c@-std=c90'
 
-build:unix --@capnp-cpp//src/kj:openssl=True --@capnp-cpp//src/kj:zlib=True --@capnp-cpp//src/kj:libdl=True
+build:unix --@capnp-cpp//src/kj:openssl=True --@capnp-cpp//src/kj:zlib=True --@capnp-cpp//src/kj:brotli=True --@capnp-cpp//src/kj:libdl=True
 
 build:linux --config=unix
 build:macos --config=unix

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,10 +35,10 @@ rules_foreign_cc_dependencies()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "35221b010ce1d47bca41e9cc925fffc4cd628d5a79ab7c91002763133714626c",
-    strip_prefix = "capnproto-capnproto-1a314a8/c++",
+    sha256 = "dfca9b050b0e3b381c39f44a998cbb6885b36ab650bc041b6ade55b11473e0d4",
+    strip_prefix = "capnproto-capnproto-6e26d26/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/1a314a8d667f8c80efd6219ddf91d5a06d315cd9"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/6e26d260d1d91e0465ca12bbb5230a1dfa28f00d"],
 )
 
 # Fetch brotli via capnproto. While workerd does not use brotli directly, this is required to work

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,11 +35,16 @@ rules_foreign_cc_dependencies()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "d51c3ca9062d4fbd64f66722b08aafe18976aff3e9965aa0958a0afd4323d4b8",
-    strip_prefix = "capnproto-capnproto-b2afb7f/c++",
+    sha256 = "35221b010ce1d47bca41e9cc925fffc4cd628d5a79ab7c91002763133714626c",
+    strip_prefix = "capnproto-capnproto-1a314a8/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/b2afb7f8fe393466a38e2fd2ad98482c34aafcee"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/1a314a8d667f8c80efd6219ddf91d5a06d315cd9"],
 )
+
+# Fetch brotli via capnproto. While workerd does not use brotli directly, this is required to work
+# around bazel shenanigans.
+load("@capnp-cpp//:build/load_br.bzl", "load_brotli")
+load_brotli()
 
 http_archive(
     name = "ssl",

--- a/src/workerd/api/cache.c++
+++ b/src/workerd/api/cache.c++
@@ -138,8 +138,8 @@ jsg::Promise<jsg::Optional<jsg::Ref<Response>>> Cache::match(
   });
 }
 
-jsg::Promise<void> Cache::put(
-    jsg::Lock& js, Request::Info requestOrUrl, jsg::Ref<Response> jsResponse) {
+jsg::Promise<void> Cache::put(jsg::Lock& js, Request::Info requestOrUrl,
+    jsg::Ref<Response> jsResponse, CompatibilityFlags::Reader flags) {
   // Send a PUT request to the cache whose URL is the original request URL and whose body is the
   // HTTP response we'd like to cache for that request.
   //
@@ -278,7 +278,7 @@ jsg::Promise<void> Cache::put(
     // We need to send the response to our serializer immediately in order to fulfill Cache.put()'s
     // contract: the caller should be able to observe that the response body is disturbed as soon
     // as put() returns.
-    auto serializePromise = jsResponse->send(js, serializer, {}, nullptr);
+    auto serializePromise = jsResponse->send(js, serializer, {}, nullptr, flags);
     auto payload = serializer.getPayload();
 
     // TODO(someday): Implement Cache API in preview. This bail-out lives all the way down here,

--- a/src/workerd/api/cache.h
+++ b/src/workerd/api/cache.h
@@ -44,8 +44,8 @@ public:
       jsg::Lock& js, Request::Info request, jsg::Optional<CacheQueryOptions> options,
       CompatibilityFlags::Reader flags);
 
-  jsg::Promise<void> put(
-      jsg::Lock& js, Request::Info request, jsg::Ref<Response> response);
+  jsg::Promise<void> put(jsg::Lock& js, Request::Info request, jsg::Ref<Response> response,
+      CompatibilityFlags::Reader flags);
 
   jsg::Promise<bool> delete_(
       jsg::Lock& js, Request::Info request, jsg::Optional<CacheQueryOptions> options);

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1285,7 +1285,7 @@ jsg::Ref<Response> Response::clone(jsg::Lock& js, CompatibilityFlags::Reader fla
 
 kj::Promise<DeferredProxy<void>> Response::send(
     jsg::Lock& js, kj::HttpService::Response& outer, SendOptions options,
-    kj::Maybe<const kj::HttpHeaders&> maybeReqHeaders) {
+    kj::Maybe<const kj::HttpHeaders&> maybeReqHeaders, CompatibilityFlags::Reader flags) {
   JSG_REQUIRE(!getBodyUsed(), TypeError, "Body has already been used. "
       "It can only be used once. Use tee() first if you need to read it twice.");
 
@@ -1353,7 +1353,7 @@ kj::Promise<DeferredProxy<void>> Response::send(
     }
     return wsPromise;
   } else KJ_IF_MAYBE(jsBody, getBody()) {
-    auto encoding = getContentEncoding(context, outHeaders, bodyEncoding);
+    auto encoding = getContentEncoding(context, outHeaders, flags, bodyEncoding);
     auto maybeLength = (*jsBody)->tryGetLength(encoding);
     auto stream = newSystemStream(
         outer.send(statusCode, statusText, outHeaders, maybeLength),
@@ -1808,7 +1808,7 @@ jsg::Ref<Response> makeHttpResponse(
   kj::Maybe<Body::ExtractedBody> responseBody = nullptr;
   if (method != kj::HttpMethod::HEAD && !isNullBodyStatusCode(statusCode)) {
     responseBody = Body::ExtractedBody(jsg::alloc<ReadableStream>(context,
-        newSystemStream(kj::mv(body), getContentEncoding(context, headers, bodyEncoding))));
+        newSystemStream(kj::mv(body), getContentEncoding(context, headers, flags, bodyEncoding))));
   }
 
   // The Fetch spec defines "response URLs" as having no fragments. Since the last URL in the list

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -912,7 +912,7 @@ public:
   };
   kj::Promise<DeferredProxy<void>> send(
       jsg::Lock& js, kj::HttpService::Response& outer, SendOptions options,
-      kj::Maybe<const kj::HttpHeaders&> maybeReqHeaders);
+      kj::Maybe<const kj::HttpHeaders&> maybeReqHeaders, CompatibilityFlags::Reader flags);
   // Helper not exposed to JavaScript.
 
   int getStatus();

--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -42,7 +42,8 @@ public:
   jsg::Promise<GetResult> get(
       jsg::Lock& js,
       kj::String name,
-      jsg::Optional<kj::OneOf<kj::String, GetOptions>> options);
+      jsg::Optional<kj::OneOf<kj::String, GetOptions>> options,
+      CompatibilityFlags::Reader flags);
 
   struct GetWithMetadataResult {
     GetResult value;
@@ -58,7 +59,8 @@ public:
   jsg::Promise<GetWithMetadataResult> getWithMetadata(
       jsg::Lock& js,
       kj::String name,
-      jsg::Optional<kj::OneOf<kj::String, GetOptions>> options);
+      jsg::Optional<kj::OneOf<kj::String, GetOptions>> options,
+      CompatibilityFlags::Reader flags);
 
   struct ListOptions {
     jsg::Optional<int> limit;
@@ -69,7 +71,8 @@ public:
     JSG_STRUCT_TS_OVERRIDE(KVNamespaceListOptions);
   };
 
-  jsg::Promise<jsg::Value> list(jsg::Lock& js, jsg::Optional<ListOptions> options);
+  jsg::Promise<jsg::Value> list(jsg::Lock& js, jsg::Optional<ListOptions> options,
+      CompatibilityFlags::Reader flags);
 
   struct PutOptions {
     // Optional parameter for passing options into a Fetcher::put. Initially

--- a/src/workerd/api/r2-admin.c++
+++ b/src/workerd/api/r2-admin.c++
@@ -49,7 +49,7 @@ jsg::Promise<jsg::Ref<R2Bucket>> R2Admin::create(jsg::Lock& js, kj::String name,
 jsg::Promise<R2Admin::ListResult> R2Admin::list(jsg::Lock& js,
     jsg::Optional<ListOptions> options,
     const jsg::TypeHandler<jsg::Ref<RetrievedBucket>>& retrievedBucketType,
-    const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
+    const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType, CompatibilityFlags::Reader flags) {
   auto& context = IoContext::current();
   auto client = context.getHttpClient(subrequestChannel, true, nullptr, "r2_delete"_kj);
 
@@ -72,7 +72,7 @@ jsg::Promise<R2Admin::ListResult> R2Admin::list(jsg::Lock& js,
   }
 
   auto requestJson = json.encode(requestBuilder);
-  auto promise = doR2HTTPGetRequest(kj::mv(client), kj::mv(requestJson), nullptr, jwt);
+  auto promise = doR2HTTPGetRequest(kj::mv(client), kj::mv(requestJson), nullptr, jwt, flags);
 
   return context.awaitIo(js, kj::mv(promise),
       [this, &retrievedBucketType, &errorType](jsg::Lock& js, R2Result r2Result) mutable {

--- a/src/workerd/api/r2-admin.h
+++ b/src/workerd/api/r2-admin.h
@@ -85,7 +85,7 @@ public:
       const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType);
   jsg::Promise<ListResult> list(jsg::Lock& js, jsg::Optional<ListOptions> options,
       const jsg::TypeHandler<jsg::Ref<RetrievedBucket>>& retrievedBucketType,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType);
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType, CompatibilityFlags::Reader flags);
 
   JSG_RESOURCE_TYPE(R2Admin) {
     JSG_METHOD(create);

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -310,11 +310,11 @@ public:
 
   jsg::Promise<kj::Maybe<jsg::Ref<HeadResult>>> head(
       jsg::Lock& js, kj::String key,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType, CompatibilityFlags::Reader flags
   );
   jsg::Promise<kj::OneOf<kj::Maybe<jsg::Ref<GetResult>>, jsg::Ref<HeadResult>>> get(
       jsg::Lock& js, kj::String key, jsg::Optional<GetOptions> options,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType, CompatibilityFlags::Reader flags
   );
   jsg::Promise<kj::Maybe<jsg::Ref<HeadResult>>> put(jsg::Lock& js,
       kj::String key, kj::Maybe<R2PutValue> value, jsg::Optional<PutOptions> options,
@@ -334,7 +334,7 @@ public:
   );
   jsg::Promise<ListResult> list(
       jsg::Lock& js, jsg::Optional<ListOptions> options,
-      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType
+      const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType, CompatibilityFlags::Reader flags
   );
 
   JSG_RESOURCE_TYPE(R2Bucket, CompatibilityFlags::Reader flags) {

--- a/src/workerd/api/r2-rpc.h
+++ b/src/workerd/api/r2-rpc.h
@@ -79,7 +79,7 @@ kj::Promise<R2Result> doR2HTTPGetRequest(
     kj::Own<kj::HttpClient> client,
     kj::String metadataPayload,
     kj::ArrayPtr<kj::StringPtr> path,
-    kj::Maybe<kj::StringPtr> jwt);
+    kj::Maybe<kj::StringPtr> jwt, CompatibilityFlags::Reader flags);
 
 kj::Promise<R2Result> doR2HTTPPutRequest(
     jsg::Lock& js,

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -29,7 +29,8 @@ class TransformStreamDefaultController;
 
 enum class StreamEncoding {
   IDENTITY,
-  GZIP
+  GZIP,
+  BROTLI
 };
 
 struct ReadResult {

--- a/src/workerd/api/system-streams.h
+++ b/src/workerd/api/system-streams.h
@@ -8,6 +8,7 @@
 
 #include "streams.h"
 #include "http.h"
+#include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/io/io-context.h>
 
 namespace workerd::api {
@@ -41,6 +42,7 @@ SystemMultiStream newSystemMultiStream(
 // A combo ReadableStreamSource and WritableStreamSink.
 
 StreamEncoding getContentEncoding(IoContext& context, const kj::HttpHeaders& headers,
+                                  CompatibilityFlags::Reader flags,
                                   Response::BodyEncoding bodyEncoding = Response::BodyEncoding::AUTO);
 // Get the Content-Encoding header from an HttpHeaders object as a StreamEncoding enum. Unsupported
 // encodings return IDENTITY.

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -51,6 +51,7 @@ wd_cc_library(
         "//src/workerd/util:sqlite",
         "@capnp-cpp//src/kj:kj-async",
         "@capnp-cpp//src/kj/compat:kj-gzip",
+        "@capnp-cpp//src/kj/compat:kj-brotli",
         "@capnp-cpp//src/capnp/compat:http-over-capnp",
         "@capnp-cpp//src/capnp:capnp-rpc",
         "@com_cloudflare_lol_html//:lolhtml",

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -62,8 +62,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   annotation neededByFl @0xbd23aff9deefc308 (field) :Void;
   # A tag to tell us which fields we'll need to propagate to FL on subrequests and responses.
   #
-  # ("FL" refers to Cloudflare's HTTP proxy stack which is used for all outbound requests. Flags
-  # with this annotation have no effect when `workerd` is used outside of Cloudflare.)
+  # ("FL" refers to Cloudflare's HTTP proxy stack which is used for all outbound requests. Except
+  # for `brotliContentEncoding`, flags with this annotation have no effect when `workerd` is used
+  # outside of Cloudflare.)
 
   annotation experimental @0xe3e5a63e76284d88 (field):Void;
   # Flags with this annotation can only be used when workerd is run with the --experimental flag.
@@ -312,4 +313,14 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Perform additional error checking in the Web Compression API and throw an error if a
   # DecompressionStream has trailing data or gets closed before the full compressed data has been
   # provided.
+
+  brotliContentEncoding @32 :Bool
+      $compatEnableFlag("brotli_content_encoding")
+      $compatDisableFlag("no_brotli_content_encoding")
+      $neededByFl;
+  # Enables compression/decompression support for the brotli compression algorithm.
+  # With the flag enabled workerd will support the "br" content encoding in the Request and
+  # Response APIs and compress or decompress data accordingly as with gzip.
+  # Note that brotli support also requires backend support from the production environment which
+  # may not be available at this time, limiting the functionality of the flag.
 }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -19,6 +19,7 @@
 #include <workerd/io/compatibility-date.h>
 #include <capnp/compat/json.h>
 #include <kj/compat/gzip.h>
+#include <kj/compat/brotli.h>
 #include <kj/encoding.h>
 #include <kj/filesystem.h>
 #include <kj/map.h>
@@ -3202,7 +3203,11 @@ public:
       : constIsolate(kj::mv(isolate)), requestId(kj::mv(requestId)), inner(kj::mv(inner)),
         requestMetrics(requestMetrics) {
     if (encoding == api::StreamEncoding::GZIP) {
-      gz.emplace(decodedBuf, kj::GzipOutputStream::DECOMPRESS);
+      compStream.emplace().init<kj::GzipOutputStream>(decodedBuf,
+          kj::GzipOutputStream::DECOMPRESS);
+    } else if (encoding == api::StreamEncoding::BROTLI) {
+      compStream.emplace().init<kj::BrotliOutputStream>(decodedBuf,
+          kj::BrotliOutputStream::DECOMPRESS);
     }
   }
 
@@ -3248,13 +3253,23 @@ public:
     rawSize += buffer.size();
 
     auto prevDecodedSize = decodedBuf.getWrittenSize();
-    KJ_IF_MAYBE(gzip, gz) {
-      // On invalid gzip discard the previously decoded body and rethrow to stop the stream.
-      // This way we will report sizes up to this point but won't read any more invalid data.
-      KJ_ON_SCOPE_FAILURE(decodedBuf.reset());
+    KJ_IF_MAYBE(comp, compStream) {
+      KJ_SWITCH_ONEOF(*comp) {
+        KJ_CASE_ONEOF(gzip, kj::GzipOutputStream) {
+          // On invalid gzip discard the previously decoded body and rethrow to stop the stream.
+          // This way we will report sizes up to this point but won't read any more invalid data.
+          KJ_ON_SCOPE_FAILURE(decodedBuf.reset());
 
-      gzip->write(buffer.begin(), buffer.size());
-      gzip->flush();
+          gzip.write(buffer.begin(), buffer.size());
+          gzip.flush();
+        }
+        KJ_CASE_ONEOF(brotli, kj::BrotliOutputStream) {
+          KJ_ON_SCOPE_FAILURE(decodedBuf.reset());
+
+          brotli.write(buffer.begin(), buffer.size());
+          brotli.flush();
+        }
+      }
     } else {
       decodedBuf.write(buffer.begin(), buffer.size());
     }
@@ -3294,7 +3309,7 @@ private:
   kj::Own<kj::AsyncOutputStream> inner;
   size_t rawSize = 0;
   LimitedBodyWrapper decodedBuf;
-  kj::Maybe<kj::GzipOutputStream> gz;
+  kj::Maybe<kj::OneOf<kj::GzipOutputStream, kj::BrotliOutputStream>> compStream;
   RequestObserver& requestMetrics;
 };
 
@@ -3426,6 +3441,8 @@ kj::Promise<void> Worker::Isolate::SubrequestClient::request(
     KJ_IF_MAYBE(encodingStr, headers.get(contentEncodingHeaderId)) {
       if (*encodingStr == "gzip") {
         encoding = api::StreamEncoding::GZIP;
+      } else if (*encodingStr == "br") {
+        encoding = api::StreamEncoding::BROTLI;
       }
     }
 


### PR DESCRIPTION
Creating a new PR since there are significant changes compared to the previous PR ([diff](https://github.com/cloudflare/workerd/compare/felix/brotlify...felix/brotlify-v2) after rebasing [old PR](https://github.com/cloudflare/workerd/pull/624)). 
This is the first time I'm adding a compat flag – suggestions on the name, description and how to best pass the flags object are welcome. There also needs to be a proper compatibility date defined.