### PR TITLE
SRS: fix typo - stftime -> strftime

### DIFF
--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -168,7 +168,7 @@ static constexpr kj::StringPtr ALLOWED_SQLITE_FUNCTIONS[] = {
   "datetime"_kj,
   "julianday"_kj,
   "unixepoch"_kj,
-  "stftime"_kj,
+  "strftime"_kj,
 
   // https://www.sqlite.org/lang_aggfunc.html
   "avg"_kj,


### PR DESCRIPTION
fixes #717 

The function was not allowlisted correctly.
