### PR TITLE
Do not refcount Trace instances in TraceItem API

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -347,11 +347,11 @@ void ServiceWorkerGlobalScope::sendTraces(kj::ArrayPtr<kj::Own<Trace>> traces,
 
   KJ_IF_MAYBE(h, exportedHandler) {
     KJ_IF_MAYBE(f, h->tail) {
-      auto tailEvent = jsg::alloc<TailEvent>("tail"_kj, traces);
+      auto tailEvent = jsg::alloc<TailEvent>(lock, "tail"_kj, traces);
       auto promise = (*f)(lock, tailEvent->getEvents(), h->env.addRef(isolate), h->getCtx(isolate));
       tailEvent->waitUntil(kj::mv(promise));
     } else KJ_IF_MAYBE(f, h->trace) {
-      auto traceEvent = jsg::alloc<TailEvent>("trace"_kj, traces);
+      auto traceEvent = jsg::alloc<TailEvent>(lock, "trace"_kj, traces);
       auto promise = (*f)(lock, traceEvent->getEvents(), h->env.addRef(isolate), h->getCtx(isolate));
       traceEvent->waitUntil(kj::mv(promise));
     } else {
@@ -363,8 +363,8 @@ void ServiceWorkerGlobalScope::sendTraces(kj::ArrayPtr<kj::Own<Trace>> traces,
   } else {
     // Fire off the handlers.
     // We only create both events here.
-    auto tailEvent = jsg::alloc<TailEvent>("tail"_kj, traces);
-    auto traceEvent = jsg::alloc<TailEvent>("trace"_kj, traces);
+    auto tailEvent = jsg::alloc<TailEvent>(lock, "tail"_kj, traces);
+    auto traceEvent = jsg::alloc<TailEvent>(lock, "trace"_kj, traces);
     dispatchEventImpl(lock, tailEvent.addRef());
     dispatchEventImpl(lock, traceEvent.addRef());
 

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -21,29 +21,26 @@ class TraceLog;
 
 class TailEvent final: public ExtendableEvent {
 public:
-  explicit TailEvent(kj::StringPtr type, kj::ArrayPtr<kj::Own<Trace>> events);
+  explicit TailEvent(jsg::Lock& js, kj::StringPtr type, kj::ArrayPtr<kj::Own<Trace>> events);
 
   static jsg::Ref<TailEvent> constructor(kj::String type) = delete;
   // TODO(soon): constructor?
 
-  // TODO(perf): more efficient to build/return cached array object?  Or iterator?
   kj::Array<jsg::Ref<TraceItem>> getEvents();
 
   JSG_RESOURCE_TYPE(TailEvent) {
     JSG_INHERIT(ExtendableEvent);
 
-    JSG_READONLY_INSTANCE_PROPERTY(events, getEvents);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(events, getEvents);
     // Deprecated. Please, use `events` instead.
-    JSG_READONLY_INSTANCE_PROPERTY(traces, getEvents);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(traces, getEvents);
   }
 
 private:
   kj::Array<jsg::Ref<TraceItem>> events;
 
   void visitForGc(jsg::GcVisitor& visitor) {
-    for (auto& e: events) {
-      visitor.visit(e);
-    }
+    visitor.visitAll(events);
   }
 };
 
@@ -56,17 +53,16 @@ public:
   class EmailEventInfo;
   class CustomEventInfo;
 
-  explicit TraceItem(kj::Own<Trace> trace);
+  explicit TraceItem(jsg::Lock& js, const Trace& trace);
 
   typedef kj::OneOf<jsg::Ref<FetchEventInfo>, jsg::Ref<ScheduledEventInfo>,
       jsg::Ref<AlarmEventInfo>, jsg::Ref<QueueEventInfo>,
       jsg::Ref<EmailEventInfo>, jsg::Ref<CustomEventInfo>> EventInfo;
-  kj::Maybe<EventInfo> getEvent();
-  // TODO(someday): support more event types (trace, email) via kj::OneOf.
+  kj::Maybe<EventInfo> getEvent(jsg::Lock& js);
   kj::Maybe<double> getEventTimestamp();
 
-  kj::Array<jsg::Ref<TraceLog>> getLogs();
-  kj::Array<jsg::Ref<TraceException>> getExceptions();
+  kj::ArrayPtr<jsg::Ref<TraceLog>> getLogs();
+  kj::ArrayPtr<jsg::Ref<TraceException>> getExceptions();
   kj::Maybe<kj::StringPtr> getScriptName();
   jsg::Optional<kj::StringPtr> getDispatchNamespace();
   jsg::Optional<kj::Array<kj::StringPtr>> getScriptTags();
@@ -76,19 +72,37 @@ public:
   uint getWallTime();
 
   JSG_RESOURCE_TYPE(TraceItem) {
-    JSG_READONLY_INSTANCE_PROPERTY(event, getEvent);
-    JSG_READONLY_INSTANCE_PROPERTY(eventTimestamp, getEventTimestamp);
-    JSG_READONLY_INSTANCE_PROPERTY(logs, getLogs);
-    JSG_READONLY_INSTANCE_PROPERTY(exceptions, getExceptions);
-    JSG_READONLY_INSTANCE_PROPERTY(scriptName, getScriptName);
-    JSG_READONLY_INSTANCE_PROPERTY(dispatchNamespace, getDispatchNamespace);
-    JSG_READONLY_INSTANCE_PROPERTY(scriptTags, getScriptTags);
-    JSG_READONLY_INSTANCE_PROPERTY(outcome, getOutcome);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(event, getEvent);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(eventTimestamp, getEventTimestamp);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(logs, getLogs);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(exceptions, getExceptions);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptName, getScriptName);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(dispatchNamespace, getDispatchNamespace);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptTags, getScriptTags);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(outcome, getOutcome);
   }
 
 private:
-  kj::Own<Trace> trace;
+  kj::Maybe<EventInfo> eventInfo;
+  kj::Maybe<double> eventTimestamp;
+  kj::Array<jsg::Ref<TraceLog>> logs;
+  kj::Array<jsg::Ref<TraceException>> exceptions;
+  kj::Maybe<kj::String> scriptName;
+  kj::Maybe<kj::String> dispatchNamespace;
+  jsg::Optional<kj::Array<kj::String>> scriptTags;
+  kj::String outcome;
+  uint cpuTime;
+  uint wallTime;
 };
+
+// When adding a new TraceItem eventInfo type, it is important not to
+// try keeping a reference to the Trace and Trace::*EventInfo inputs.
+// They are kj heap objects that have a lifespan that is managed independently
+// of the TraceItem object. Each of the implementations here extract the
+// necessary detail on creation and use LAZY instance properties to minimize
+// copying and allocation necessary when accessing these values.
+// TODO(cleanup): Later we can further optimize by creating the JS objects
+// immediately on creation.
 
 class TraceItem::FetchEventInfo final: public jsg::Object {
   // While this class is named FetchEventInfo, it encapsulates both the actual
@@ -104,7 +118,9 @@ public:
   class Request;
   class Response;
 
-  explicit FetchEventInfo(kj::Own<Trace> trace, const Trace::FetchEventInfo& eventInfo,
+  explicit FetchEventInfo(jsg::Lock& js,
+                          const Trace& trace,
+                          const Trace::FetchEventInfo& eventInfo,
                           kj::Maybe<const Trace::FetchResponseInfo&> responseInfo);
 
   jsg::Ref<Request> getRequest();
@@ -112,21 +128,35 @@ public:
 
   // TODO(cleanup) Use struct types more?
   JSG_RESOURCE_TYPE(FetchEventInfo) {
-    JSG_READONLY_INSTANCE_PROPERTY(response, getResponse);
-    JSG_READONLY_INSTANCE_PROPERTY(request, getRequest);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(response, getResponse);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(request, getRequest);
   }
 
 private:
-  kj::Own<Trace> trace;
-  const Trace::FetchEventInfo& eventInfo;
-  kj::Maybe<const Trace::FetchResponseInfo&> responseInfo;
+  jsg::Ref<Request> request;
+  jsg::Optional<jsg::Ref<Response>> response;
 };
 
 class TraceItem::FetchEventInfo::Request final: public jsg::Object {
 public:
-  explicit Request(kj::Own<Trace> trace, const Trace::FetchEventInfo& eventInfo);
+  struct Detail : public kj::Refcounted {
+    jsg::Optional<jsg::V8Ref<v8::Object>> cf;
+    kj::Array<Trace::FetchEventInfo::Header> headers;
+    kj::String method;
+    kj::String url;
 
-  jsg::Optional<v8::Local<v8::Object>> getCf(v8::Isolate* isolate);
+    Detail(jsg::Optional<jsg::V8Ref<v8::Object>> cf,
+           kj::Array<Trace::FetchEventInfo::Header> headers,
+           kj::String method,
+           kj::String url);
+  };
+
+  explicit Request(jsg::Lock& js, const Trace& trace, const Trace::FetchEventInfo& eventInfo);
+
+  explicit Request(Detail& detail, bool redacted = true);
+  // Creates a possibly unredacted instance that shared a ref of the Detail
+
+  jsg::Optional<jsg::V8Ref<v8::Object>> getCf(jsg::Lock& js);
   jsg::Dict<jsg::ByteString, jsg::ByteString> getHeaders();
   kj::StringPtr getMethod();
   kj::String getUrl();
@@ -134,151 +164,150 @@ public:
   jsg::Ref<Request> getUnredacted();
 
   JSG_RESOURCE_TYPE(Request) {
-    JSG_READONLY_INSTANCE_PROPERTY(cf, getCf);
-    JSG_READONLY_INSTANCE_PROPERTY(headers, getHeaders);
-    JSG_READONLY_INSTANCE_PROPERTY(method, getMethod);
-    JSG_READONLY_INSTANCE_PROPERTY(url, getUrl);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(cf, getCf);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(headers, getHeaders);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(method, getMethod);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(url, getUrl);
 
     JSG_METHOD(getUnredacted);
   }
 
 private:
-  kj::Own<Trace> trace;
-  const Trace::FetchEventInfo& eventInfo;
   bool redacted = true;
+  kj::Own<Detail> detail;
 };
 
 class TraceItem::FetchEventInfo::Response final: public jsg::Object {
 public:
-  explicit Response(kj::Own<Trace> trace, const Trace::FetchResponseInfo& responseInfo);
+  explicit Response(const Trace& trace, const Trace::FetchResponseInfo& responseInfo);
 
   uint16_t getStatus();
 
   JSG_RESOURCE_TYPE(Response) {
-    JSG_READONLY_INSTANCE_PROPERTY(status, getStatus);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(status, getStatus);
   }
 
 private:
-  kj::Own<Trace> trace;
-  const Trace::FetchResponseInfo& responseInfo;
+  uint16_t status;
 };
 
 class TraceItem::ScheduledEventInfo final: public jsg::Object {
 public:
-  explicit ScheduledEventInfo(kj::Own<Trace> trace, const Trace::ScheduledEventInfo& eventInfo);
+  explicit ScheduledEventInfo(const Trace& trace, const Trace::ScheduledEventInfo& eventInfo);
 
   double getScheduledTime();
   kj::StringPtr getCron();
 
   JSG_RESOURCE_TYPE(ScheduledEventInfo) {
-    JSG_READONLY_INSTANCE_PROPERTY(scheduledTime, getScheduledTime);
-    JSG_READONLY_INSTANCE_PROPERTY(cron, getCron);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(scheduledTime, getScheduledTime);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(cron, getCron);
   }
 
 private:
-  kj::Own<Trace> trace;
-  const Trace::ScheduledEventInfo& eventInfo;
+  double scheduledTime;
+  kj::String cron;
 };
 
 class TraceItem::AlarmEventInfo final: public jsg::Object {
 public:
-  explicit AlarmEventInfo(kj::Own<Trace> trace, const Trace::AlarmEventInfo& eventInfo);
+  explicit AlarmEventInfo(const Trace& trace, const Trace::AlarmEventInfo& eventInfo);
 
   kj::Date getScheduledTime();
 
   JSG_RESOURCE_TYPE(AlarmEventInfo) {
-    JSG_READONLY_INSTANCE_PROPERTY(scheduledTime, getScheduledTime);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(scheduledTime, getScheduledTime);
   }
 
 private:
-  kj::Own<Trace> trace;
-  const Trace::AlarmEventInfo& eventInfo;
+  kj::Date scheduledTime;
 };
 
 class TraceItem::QueueEventInfo final: public jsg::Object {
 public:
-  explicit QueueEventInfo(kj::Own<Trace> trace, const Trace::QueueEventInfo& eventInfo);
+  explicit QueueEventInfo(const Trace& trace, const Trace::QueueEventInfo& eventInfo);
 
   kj::StringPtr getQueueName();
   uint32_t getBatchSize();
   // TODO(now): Add something about the timestamp(s) of the newest/oldest message(s) in the batch?
 
   JSG_RESOURCE_TYPE(QueueEventInfo) {
-    JSG_READONLY_INSTANCE_PROPERTY(queue, getQueueName);
-    JSG_READONLY_INSTANCE_PROPERTY(batchSize, getBatchSize);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(queue, getQueueName);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(batchSize, getBatchSize);
   }
 
 private:
-  kj::Own<Trace> trace;
-  const Trace::QueueEventInfo& eventInfo;
+  kj::String queueName;
+  uint32_t batchSize;
 };
 
 class TraceItem::EmailEventInfo final: public jsg::Object {
 public:
-  explicit EmailEventInfo(kj::Own<Trace> trace, const Trace::EmailEventInfo& eventInfo);
+  explicit EmailEventInfo(const Trace& trace, const Trace::EmailEventInfo& eventInfo);
 
   kj::StringPtr getMailFrom();
   kj::StringPtr getRcptTo();
   uint32_t getRawSize();
 
   JSG_RESOURCE_TYPE(EmailEventInfo) {
-    JSG_READONLY_INSTANCE_PROPERTY(mailFrom, getMailFrom);
-    JSG_READONLY_INSTANCE_PROPERTY(rcptTo, getRcptTo);
-    JSG_READONLY_INSTANCE_PROPERTY(rawSize, getRawSize);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(mailFrom, getMailFrom);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(rcptTo, getRcptTo);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(rawSize, getRawSize);
   }
 
 private:
-  kj::Own<Trace> trace;
-  const Trace::EmailEventInfo& eventInfo;
+  kj::String mailFrom;
+  kj::String rcptTo;
+  uint32_t rawSize;
 };
 
 class TraceItem::CustomEventInfo final: public jsg::Object {
 public:
-  explicit CustomEventInfo(kj::Own<Trace> trace, const Trace::CustomEventInfo& eventInfo);
+  explicit CustomEventInfo(const Trace& trace, const Trace::CustomEventInfo& eventInfo);
 
   JSG_RESOURCE_TYPE(CustomEventInfo) {}
 
 private:
-  kj::Own<Trace> trace;
   const Trace::CustomEventInfo& eventInfo;
 };
 
 class TraceLog final: public jsg::Object {
 public:
-  TraceLog(kj::Own<Trace> trace, const Trace::Log& log);
+  TraceLog(jsg::Lock& js, const Trace& trace, const Trace::Log& log);
 
   double getTimestamp();
   kj::StringPtr getLevel();
-  v8::Local<v8::Object> getMessage(v8::Isolate* isolate);
+  jsg::V8Ref<v8::Object> getMessage(jsg::Lock& js);
 
   JSG_RESOURCE_TYPE(TraceLog) {
-    JSG_READONLY_INSTANCE_PROPERTY(timestamp, getTimestamp);
-    JSG_READONLY_INSTANCE_PROPERTY(level, getLevel);
-    JSG_READONLY_INSTANCE_PROPERTY(message, getMessage);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(timestamp, getTimestamp);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(level, getLevel);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(message, getMessage);
   }
 
 private:
-  kj::Own<Trace> trace;
-  const Trace::Log& log;
+  double timestamp;
+  kj::String level;
+  jsg::V8Ref<v8::Object> message;
 };
 
 class TraceException final: public jsg::Object {
 public:
-  TraceException(kj::Own<Trace> trace, const Trace::Exception& exception);
+  TraceException(const Trace& trace, const Trace::Exception& exception);
 
   double getTimestamp();
   kj::StringPtr getName();
   kj::StringPtr getMessage();
 
   JSG_RESOURCE_TYPE(TraceException) {
-    JSG_READONLY_INSTANCE_PROPERTY(timestamp, getTimestamp);
-    JSG_READONLY_INSTANCE_PROPERTY(message, getMessage);
-    JSG_READONLY_INSTANCE_PROPERTY(name, getName);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(timestamp, getTimestamp);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(message, getMessage);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(name, getName);
   }
 
 private:
-  kj::Own<Trace> trace;
-  const Trace::Exception& exception;
+  double timestamp;
+  kj::String name;
+  kj::String message;
 };
 
 class TraceMetrics final : public jsg::Object {


### PR DESCRIPTION
The underlying io Trace objects are kj heap allocated. They cannot be referenced unprotected by the TraceItem jsg object and we do not want to restrict them to the IoContext lifetime. Instead we'll extract the detail we need on TraceItem creation.