### PR TITLE
Implement new URLSearchParams has and delete second argument

### DIFF
--- a/src/workerd/api/url-standard.h
+++ b/src/workerd/api/url-standard.h
@@ -96,10 +96,12 @@ public:
   }
 
   void append(jsg::UsvString name, jsg::UsvString value);
-  void delete_(jsg::UsvString name, jsg::Optional<jsg::Value> value);
+  void delete_(jsg::UsvString name, jsg::Optional<jsg::UsvString> value,
+               CompatibilityFlags::Reader featureFlags);
   kj::Maybe<jsg::UsvStringPtr> get(jsg::UsvString name);
   kj::Array<jsg::UsvStringPtr> getAll(jsg::UsvString name);
-  bool has(jsg::UsvString name, jsg::Optional<jsg::Value> value);
+  bool has(jsg::UsvString name, jsg::Optional<jsg::UsvString> value,
+           CompatibilityFlags::Reader featureFlags);
   void set(jsg::UsvString name, jsg::UsvString value);
   void sort();
 

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -297,4 +297,11 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # This one operates a bit backwards. With the flag *enabled* no default cfBotManagement
   # data will be included. The the flag *disable*, default cfBotManagement data will be
   # included in the request.cf if the field is not present.
+
+  urlSearchParamsDeleteHasValueArg @30 :Bool
+      $compatEnableFlag("urlsearchparams_delete_has_value_arg")
+      $compatDisableFlag("no_urlsearchparams_delete_has_value_arg")
+      $compatEnableDate("2023-07-01");
+  # When enabled, the delete() and has() methods of the standard URLSearchParams object
+  # (see url-standard.h) will have the recently added second value argument enabled.
 }


### PR DESCRIPTION
The whatwg url spec was updated to add a second optional argument to delete() and has(). While it was determined that it likely didn't break browser users, the change could break at least a couple existing deployed workers so we have to gate support behind a compat flag.

Tests are added in the internal PR.