### PR TITLE
SRS: allowlist current_(timestamp,time,date) functions

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -177,8 +177,15 @@ async function test(storage) {
   const jsonResult =
       [...sql.exec("SELECT '{\"a\":2,\"c\":[4,5,{\"f\":7}]}' -> '$.c' AS value")][0].value;
   assert.equal(jsonResult, "[4,5,{\"f\":7}]");
-
-
+  
+  // current_{time,timestamp,date} functions work
+  const resultTime = [...sql.exec("SELECT current_time")];
+  assert.equal(resultTime.length, 1)
+  const resultTimestamp = [...sql.exec("SELECT current_timestamp")];
+  assert.equal(resultTimestamp.length, 1);
+  const resultDate = [...sql.exec("SELECT current_date")];
+  assert.equal(resultDate.length, 1);
+  
   // Can't start transactions or savepoints.
   requireException(() => sql.exec("BEGIN TRANSACTION"), "not authorized");
   requireException(() => sql.exec("SAVEPOINT foo"), "not authorized");

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -178,13 +178,21 @@ async function test(storage) {
       [...sql.exec("SELECT '{\"a\":2,\"c\":[4,5,{\"f\":7}]}' -> '$.c' AS value")][0].value;
   assert.equal(jsonResult, "[4,5,{\"f\":7}]");
   
-  // current_{time,timestamp,date} functions work
-  const resultTime = [...sql.exec("SELECT current_time")];
-  assert.equal(resultTime.length, 1)
-  const resultTimestamp = [...sql.exec("SELECT current_timestamp")];
-  assert.equal(resultTimestamp.length, 1);
+  // current_{date,time,timestamp} functions work
   const resultDate = [...sql.exec("SELECT current_date")];
   assert.equal(resultDate.length, 1);
+  // Should match results in the format "2023-06-01"
+  assert.match(resultDate[0]["current_date"], /^\d{4}-\d{2}-\d{2}$/)
+  
+  const resultTime = [...sql.exec("SELECT current_time")];
+  assert.equal(resultTime.length, 1)
+  // Should match results in the format "15:30:03"
+  assert.match(resultTime[0]["current_time"], /^\d{2}:\d{2}:\d{2}$/)
+  
+  const resultTimestamp = [...sql.exec("SELECT current_timestamp")];
+  assert.equal(resultTimestamp.length, 1);
+  // Should match results in the format "2023-06-01 15:30:03"
+  assert.match(resultTimestamp[0]["current_timestamp"], /^\d{4}-\d{2}-\d{2}\s{1}\d{2}:\d{2}:\d{2}$/)
   
   // Can't start transactions or savepoints.
   requireException(() => sql.exec("BEGIN TRANSACTION"), "not authorized");

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -169,6 +169,9 @@ static constexpr kj::StringPtr ALLOWED_SQLITE_FUNCTIONS[] = {
   "julianday"_kj,
   "unixepoch"_kj,
   "strftime"_kj,
+  "current_date"_kj,
+  "current_time"_kj,
+  "current_timestamp"_kj,
 
   // https://www.sqlite.org/lang_aggfunc.html
   "avg"_kj,


### PR DESCRIPTION
Fixes #718 

These are built-ins that aren't documented in https://www.sqlite.org/lang_datefunc.html but are required to use `current_timestamp`, `current_date` and `current_time` in queries per https://github.com/smparkes/sqlite/blob/8caf9219240123fbe6cff67b1e0da778c62d7621/src/date.c#L1072-L1079 (GitHub mirror)

```sh
sqlite> SELECT current_timestamp;
2023-05-31 20:59:38
sqlite> SELECT current_time;
21:00:51
sqlite> SELECT current_date;
2023-05-31
```
```sh
➜  wrangler d1 execute db-enam --command "SELECT current_date"

🌀 Mapping SQL input into an array of statements
🌀 Parsing 1 statements
🌀 Executing on db-enam (4006a897-c765-4999-9ff1-465a8cf1ec00):

✘ [ERROR] A request to the Cloudflare API (/accounts/d458dbe698b8eef41837f941d73bc5b3/d1/database/4006a897-c765-4999-9ff1-465a8cf1ec00/query) failed.

  not authorized to use function: current_date [code: 7500]
```