### PR TITLE
SRS: Allowlist sqlite_rename_table for migrations

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -194,6 +194,28 @@ async function test(storage) {
   // Should match results in the format "2023-06-01 15:30:03"
   assert.match(resultTimestamp[0]["current_timestamp"], /^\d{4}-\d{2}-\d{2}\s{1}\d{2}:\d{2}:\d{2}$/)
   
+  // Can rename tables
+  sql.exec(`
+    CREATE TABLE beforerename (
+      id INTEGER
+    );
+  `)
+  sql.exec(`
+    ALTER TABLE beforerename
+    RENAME TO afterrename;
+  `)
+  
+  // Can rename columns within a table
+  sql.exec(`
+    CREATE TABLE renamecolumn (
+      meta TEXT
+     );
+  `);
+  sql.exec(`
+    ALTER TABLE renamecolumn
+    RENAME COLUMN meta TO metadata
+  `);
+  
   // Can't start transactions or savepoints.
   requireException(() => sql.exec("BEGIN TRANSACTION"), "not authorized");
   requireException(() => sql.exec("SAVEPOINT foo"), "not authorized");

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -249,6 +249,9 @@ static constexpr kj::StringPtr ALLOWED_SQLITE_FUNCTIONS[] = {
   "highlight"_kj,
   "bm25"_kj,
   "snippet"_kj,
+    
+  // https://www.sqlite.org/lang_altertable.html
+  "sqlite_rename_table"_kj,
 };
 
 enum class PragmaSignature {


### PR DESCRIPTION
Fixes #729 

- Allows users to rename tables and columns
- Unblocks migrations on the new backend, which would break if a migration includes renaming a table (this worked previously)
- Docs: https://www.sqlite.org/lang_altertable.html