### PR TITLE
Enable LLVM_SYMBOLIZER by default in tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -48,6 +48,8 @@ build:unix --action_env=BAZEL_COMPILER=clang
 build:unix --action_env=CC=clang
 build:unix --action_env=CXX=clang++
 
+build:unix --test_env=LLVM_SYMBOLIZER=llvm-symbolizer
+
 # Warning options.
 build:unix --cxxopt='-Wall' --host_cxxopt='-Wall'
 build:unix --cxxopt='-Wextra' --host_cxxopt='-Wextra'

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -34,7 +34,10 @@ wd_cc_binary(
         ":server",
         ":workerd_capnp",
         ":workerd-meta_capnp",
-    ],
+    ] + select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["@workerd//src/workerd/util:symbolizer"],
+    }),
     malloc = select({
         ":really_use_tcmalloc": "@com_google_tcmalloc//tcmalloc",
         "//conditions:default": "@bazel_tools//tools/cpp:malloc",

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -64,6 +64,7 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@capnp-cpp//src/kj",
+        ":sentry",
     ],
     alwayslink = 1,
     target_compatible_with = select({


### PR DESCRIPTION
Including in wd_tests, which requires linking into workerd.

This should make debugging a lot easier for people working on this repo.