### PR TITLE
Add support for debugging wdtests in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -120,6 +120,42 @@
       },
       "stopAtEntry": false,
       "externalConsole": false
+    },
+    {
+      "name": "workerd wdtest case",
+      "preLaunchTask": "Bazel build all (dbg)",
+      "program": "${workspaceFolder}/bazel-bin/src/workerd/server/workerd",
+      "args": [
+        "test",
+        "${input:wdtestToDebug}"
+      ],
+      "cwd": "${workspaceFolder}",
+      "type": "cppdbg",
+      "request": "launch",
+      "stopAtEntry": false,
+      "externalConsole": false,
+      "linux": {
+        "type": "cppdbg",
+        "request": "launch",
+        "MIMode": "gdb",
+        "miDebuggerArgs": "-d ${workspaceFolder}",
+      },
+      "osx": {
+        "type": "cppdbg",
+        "request": "launch",
+        "MIMode": "lldb",
+        "targetArchitecture": "arm64",
+        "sourceFileMap": {
+          "src" : "${workspaceFolder}/src",
+          "bazel-bin" : "${workspaceFolder}/bazel-bin",
+          "bazel-out" : "${workspaceFolder}/bazel-out",
+          "external" : "${workspaceFolder}/external"
+         },
+      },
+      "windows": {
+        "type": "cppvsdbg",
+        "request": "launch",
+      },
     }
   ],
   "inputs": [
@@ -172,6 +208,32 @@
         "bazel-bin/src/workerd/api/node/buffer-test",
         "bazel-bin/src/workerd/api/crypto-impl-asymmetric-test",
         "bazel-bin/src/workerd/api/url-standard-test",
+      ],
+    },
+    {
+      "id": "wdtestToDebug",
+      "description": "Workerd Driven Test to debug",
+      "type": "pickString",
+      "default": "src/workerd/api/node/path-test.wd-test",
+      "options": [
+        "src/workerd/api/blob-test.wd-test",
+        "src/workerd/api/node/assert-test.wd-test",
+        "src/workerd/api/node/buffer-nodejs-test.wd-test",
+        "src/workerd/api/node/crypto_keys-test.wd-test",
+        "src/workerd/api/node/crypto_pbkdf2-test.wd-test",
+        "src/workerd/api/node/crypto_random-test.wd-test",
+        "src/workerd/api/node/path-test.wd-test",
+        "src/workerd/api/node/streams-test.wd-test",
+        "src/workerd/api/node/string-decoder-test.wd-test",
+        "src/workerd/api/streams/identitytransformstream-backpressure-test.wd-test",
+        "src/workerd/server/tests/extensions/extensions-test.wd-test",
+        "src/workerd/tests/performance-test.wd-test",
+        // The following tests are not supported yet in vscode. They require
+        // TEST_TMPDIR to be defined, usually this comes from bazel. There needs to
+        // be some logic to create the test directory and set the environment variable
+        // for the test.
+        // "src/workerd/api/actor-alarms-test.wd-test",
+        // "src/workerd/api/sql-test.wd-test",
       ],
     }
   ]

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -53,11 +53,14 @@ The main targets of interest are:
 * workerd debug
 * workerd debug with inspector enabled
 * workerd test case
+* workerd wdtest case
 
 Launching either "workerd debug" or "workerd debug with inspector enabled" will prompt for a workerd configuration for
 workerd to serve, the default is [${workspaceFolder}/samples/helloworld/config.capnp](../samples/helloworld/config.capnp).
 
-Launching "workerd test case" will prompt for a test to debug, the default is `bazel-bin/src/workerd/jsg/jsg-test`.
+Launching "workerd test case" will prompt for a test binary to debug, the default is `bazel-bin/src/workerd/jsg/jsg-test`.
+
+Launching "workerd wdtest case" will prompt for wd-test file to provide to workerd to debug, the default is `src/workerd/api/node/path-test.wd-test`.
 
 ## Generating compile_commands.json
 


### PR DESCRIPTION
This change adds the majority of workerd's wdtests to vscode as launch targets for debugging. The two tests that require a temporary directory (actor-alarms-test.wd-test, sql-test.wd-test) are not included.

Test: manually run wdtests with breakpoints