### PR TITLE
Update test.yml to use node16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+runs:
+  using: 'node16'
+
 on:
   pull_request:
     paths-ignore:


### PR DESCRIPTION
Fixes github runner failures stemming from default version of node that is deprecated:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/