### PR TITLE
Fix Windows compilation by enabling kj-brotli

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -99,4 +99,4 @@ build:windows --cxxopt='-Wno-unused-command-line-argument' --host_cxxopt='-Wno-u
 # TODO(soon): Integrate this into V8 instead
 build:windows --cxxopt='-Wno-invalid-offsetof' --host_cxxopt='-Wno-invalid-offsetof'
 
-build:windows --@capnp-cpp//src/kj:openssl=True --@capnp-cpp//src/kj:zlib=True
+build:windows --@capnp-cpp//src/kj:openssl=True --@capnp-cpp//src/kj:zlib=True --@capnp-cpp//src/kj:brotli=True

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
   build:
     strategy:
       matrix:
-        # TODO(soon): Using windows-2019 as build is broken on windows-latest runner, develop a
-        # fix and go back to the latest version
+        # TODO(soon): Using windows-2019 as build is broken on windows-latest runner due to another
+        # bazel bug https://github.com/bazelbuild/bazel/issues/18592
         os: [ubuntu-22.04, macos-latest, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     strategy:
       matrix:
-        # TODO(soon): Using windows-2019 as build is broken on windows-latest runner, develop a
-        # fix and go back to the latest version
+        # TODO(soon): Using windows-2019 as build is broken on windows-latest runner due to another
+        # bazel bug https://github.com/bazelbuild/bazel/issues/18592
         os: [ubuntu-22.04, macos-latest, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,11 +41,6 @@ http_archive(
     urls = ["https://github.com/capnproto/capnproto/tarball/6e26d260d1d91e0465ca12bbb5230a1dfa28f00d"],
 )
 
-# Fetch brotli via capnproto. While workerd does not use brotli directly, this is required to work
-# around bazel shenanigans.
-load("@capnp-cpp//:build/load_br.bzl", "load_brotli")
-load_brotli()
-
 http_archive(
     name = "ssl",
     sha256 = "81bd4b20f53b0aa4bccc3f8bc7c5eda18550a91697ba956668dbeba0e3d0965d",
@@ -71,6 +66,19 @@ http_archive(
     type = "zip",
     sha256 = "49112cc7328392aa4e3e5dae0b2f6736d0153430143d21f69327788ff4efe734",
     build_file = "//:build/BUILD.sqlite3",
+)
+
+# Using latest brotli commit due to macOS compile issues with v1.0.9, switch to a release version
+# later.
+# TODO(soon): Using a modified build file as brotli bazel build is broken using clang-cl on
+# Windows, make a PR to fix this soon.
+http_archive(
+    name = "brotli",
+    sha256 = "e33f397d86aaa7f3e786bdf01a7b5cff4101cfb20041c04b313b149d34332f64",
+    strip_prefix = "google-brotli-ed1995b",
+    type = "tgz",
+    urls = ["https://github.com/google/brotli/tarball/ed1995b6bda19244070ab5d331111f16f67c8054"],
+    build_file = "//:build/BUILD.brotli",
 )
 
 # ========================================================================================

--- a/build/BUILD.brotli
+++ b/build/BUILD.brotli
@@ -1,0 +1,151 @@
+# Description:
+#   Brotli is a generic-purpose lossless compression algorithm.
+
+# Build file is the same as in brotli, but with STRICT_C_OPTIONS disabled as elaborated below.
+
+load(":compiler_config_setting.bzl", "create_msvc_config")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])  # MIT
+
+exports_files(["LICENSE"])
+
+config_setting(
+    name = "darwin",
+    values = {"cpu": "darwin"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin_x86_64",
+    values = {"cpu": "darwin_x86_64"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "windows_msvc",
+    values = {"cpu": "x64_windows_msvc"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "windows_msys",
+    values = {"cpu": "x64_windows_msys"},
+    visibility = ["//visibility:public"],
+)
+
+create_msvc_config()
+
+# Disable strict C options, rely on workerd-level warnings instead
+STRICT_C_OPTIONS = select({
+    ":msvc": [],
+    "//conditions:default": [
+        # clang-cl does not support --pedantic-errors
+        # "--pedantic-errors",
+        # "-Wall",
+        # "-Wconversion",
+        # "-Werror",
+        # "-Wextra",
+        # "-Wlong-long",
+        # "-Wmissing-declarations",
+        # "-Wmissing-prototypes",
+        # "-Wno-strict-aliasing",
+        # "-Wshadow",
+        # "-Wsign-compare",
+    ],
+})
+
+filegroup(
+    name = "public_headers",
+    srcs = glob(["c/include/brotli/*.h"]),
+)
+
+filegroup(
+    name = "common_headers",
+    srcs = glob(["c/common/*.h"]),
+)
+
+filegroup(
+    name = "common_sources",
+    srcs = glob(["c/common/*.c"]),
+)
+
+filegroup(
+    name = "dec_headers",
+    srcs = glob(["c/dec/*.h"]),
+)
+
+filegroup(
+    name = "dec_sources",
+    srcs = glob(["c/dec/*.c"]),
+)
+
+filegroup(
+    name = "enc_headers",
+    srcs = glob(["c/enc/*.h"]),
+)
+
+filegroup(
+    name = "enc_sources",
+    srcs = glob(["c/enc/*.c"]),
+)
+
+cc_library(
+    name = "brotli_inc",
+    hdrs = [":public_headers"],
+    copts = STRICT_C_OPTIONS,
+    strip_include_prefix = "c/include",
+)
+
+cc_library(
+    name = "brotlicommon",
+    srcs = [":common_sources"],
+    hdrs = [":common_headers"],
+    copts = STRICT_C_OPTIONS,
+    deps = [":brotli_inc"],
+)
+
+cc_library(
+    name = "brotlidec",
+    srcs = [":dec_sources"],
+    hdrs = [":dec_headers"],
+    copts = STRICT_C_OPTIONS,
+    deps = [":brotlicommon"],
+)
+
+cc_library(
+    name = "brotlienc",
+    srcs = [":enc_sources"],
+    hdrs = [":enc_headers"],
+    copts = STRICT_C_OPTIONS,
+    linkopts = select({
+        ":msvc": [],
+        "//conditions:default": ["-lm"],
+    }),
+    deps = [":brotlicommon"],
+)
+
+cc_binary(
+    name = "brotli",
+    srcs = ["c/tools/brotli.c"],
+    copts = STRICT_C_OPTIONS,
+    linkstatic = 1,
+    deps = [
+        ":brotlidec",
+        ":brotlienc",
+    ],
+)
+
+filegroup(
+    name = "dictionary",
+    srcs = ["c/common/dictionary.bin"],
+)


### PR DESCRIPTION
kj-brotli was only included in the build for unix platforms, which caused the Windows runner to fail. Not sure how this slipped through CI previously, all tests passed on the PR for this.

Edit: Looks like the `Build & Release` job is what's failing, that's why it wasn't caught earlier