### PR TITLE
SQLite: Add point-in-time recovery API.

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -675,6 +675,18 @@ jsg::Ref<SqlStorage> DurableObjectStorage::getSql(jsg::Lock& js) {
   }
 }
 
+kj::Promise<kj::String> DurableObjectStorage::getCurrentBookmark() {
+  return cache->getCurrentBookmark();
+}
+
+kj::Promise<kj::String> DurableObjectStorage::getBookmarkForTime(kj::Date timestamp) {
+  return cache->getBookmarkForTime(timestamp);
+}
+
+kj::Promise<kj::String> DurableObjectStorage::onNextSessionRestoreBookmark(kj::String bookmark) {
+  return cache->onNextSessionRestoreBookmark(bookmark);
+}
+
 ActorCacheOps& DurableObjectTransaction::getCache(OpName op) {
   JSG_REQUIRE(!rolledBack, Error, kj::str("Cannot ", op, " on rolled back transaction"));
   auto& result = *JSG_REQUIRE_NONNULL(cacheTxn, Error,

--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -3268,4 +3268,21 @@ kj::Maybe<ActorCache::KeyPtr> ActorCache::Transaction::putImpl(
   }
 }
 
+// =======================================================================================
+
+kj::Promise<kj::String> ActorCacheInterface::getCurrentBookmark() {
+  JSG_FAIL_REQUIRE(Error,
+      "This Durable Object's storage back-end does not implement point-in-time recovery.");
+}
+
+kj::Promise<kj::String> ActorCacheInterface::getBookmarkForTime(kj::Date timestamp) {
+  JSG_FAIL_REQUIRE(Error,
+      "This Durable Object's storage back-end does not implement point-in-time recovery.");
+}
+
+kj::Promise<kj::String> ActorCacheInterface::onNextSessionRestoreBookmark(kj::StringPtr bookmark) {
+  JSG_FAIL_REQUIRE(Error,
+      "This Durable Object's storage back-end does not implement point-in-time recovery.");
+}
+
 }  // namespace workerd

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -219,6 +219,12 @@ public:
   virtual void cancelDeferredAlarmDeletion() = 0;
 
   virtual kj::Maybe<kj::Promise<void>> onNoPendingFlush() = 0;
+
+  virtual kj::Promise<kj::String> getCurrentBookmark();
+  virtual kj::Promise<kj::String> getBookmarkForTime(kj::Date timestamp);
+  virtual kj::Promise<kj::String> onNextSessionRestoreBookmark(kj::StringPtr bookmark);
+  // Implements the respective PITR API calls. The default implementations throw JSG errors saying
+  // PITR is not implemented.
 };
 
 class ActorCache final: public ActorCacheInterface {


### PR DESCRIPTION
Note: I think we may need an additional API to list the history of restorations, but I haven't defined that yet. This would be needed in particular for the case where a restoration is scheduled, but the "undo" bookmark is not successfully returned to the caller; the caller will need a way to fetch the undo bookmark after the fact. A history of restorations would provide that.