### PR TITLE
Fixup json error message in r2-rpc.c++.

### DIFF
--- a/src/workerd/api/r2-rpc.c++
+++ b/src/workerd/api/r2-rpc.c++
@@ -115,7 +115,7 @@ kj::Promise<R2Result> doR2HTTPGetRequest(kj::Own<kj::HttpClient> client,
                          response.statusCode);
       }
       auto error = response.headers->get(headerIds.cfR2ErrorHeader).orDefault(
-          "Unspecified error"_kj);
+          "{\"version\":0,\"v4code\":0,\"message\":\"Unspecified error\"}"_kj);
       R2Result result = {
         .httpStatus = response.statusCode,
         .toThrow = toError(response.statusCode, error),
@@ -257,7 +257,7 @@ kj::Promise<R2Result> doR2HTTPPutRequest(jsg::Lock& js, kj::Own<kj::HttpClient> 
                             response.statusCode);
           }
           auto error = response.headers->get(headerIds.cfR2ErrorHeader).orDefault(
-              "Unspecified error"_kj);
+              "{\"version\":0,\"v4code\":0,\"message\":\"Unspecified error\"}"_kj);
 
           return R2Result {
             .httpStatus = response.statusCode,


### PR DESCRIPTION
The default error message must be a json object.. I missed this previously