### PR TITLE
Implement per IoContext request ID

### DIFF
--- a/src/cloudflare/internal/request-context.d.ts
+++ b/src/cloudflare/internal/request-context.d.ts
@@ -1,0 +1,3 @@
+// Type definitions for c++ implementation.
+
+export function getRequestId(): string;

--- a/src/cloudflare/request-context.ts
+++ b/src/cloudflare/request-context.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import requestCtx from 'cloudflare-internal:request-context';
+export function getRequestId(): string {
+  return requestCtx.getRequestId();
+}

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -499,6 +499,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEventImpl::run(
        &metrics = incomingRequest->getMetrics()]
       (Worker::Lock& lock) mutable {
     jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+    jsg::AsyncContextFrame::StorageScope requestIdScope = context.makeRequestIdStorageScope(lock);
 
     auto& typeHandler = lock.getWorker().getIsolate().getApiIsolate().getQueueTypeHandler(lock);
     queueEvent->event = startQueueEvent(lock.getGlobalScope(), kj::mv(params), context.addObject(result), lock,

--- a/src/workerd/api/request-context.c++
+++ b/src/workerd/api/request-context.c++
@@ -1,0 +1,19 @@
+#include "request-context.h"
+#include <workerd/jsg/async-context.h>
+#include <workerd/jsg/jsg.h>
+#include <workerd/io/io-context.h>
+
+namespace workerd::api {
+
+kj::Maybe<jsg::Value> RequestContextModule::getRequestId(jsg::Lock& js) {
+  if (IoContext::hasCurrent()) {
+    KJ_IF_MAYBE(frame, jsg::AsyncContextFrame::current(js)) {
+      return frame->get(IoContext::current().getRequestIdKey()).map([&](jsg::Value& val) {
+        return val.addRef(js);
+      });
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace workerd::api

--- a/src/workerd/api/request-context.h
+++ b/src/workerd/api/request-context.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <workerd/jsg/jsg.h>
+#include <workerd/jsg/modules.h>
+
+namespace workerd::api {
+
+class RequestContextModule: public jsg::Object {
+public:
+  kj::Maybe<jsg::Value> getRequestId(jsg::Lock& js);
+
+  JSG_RESOURCE_TYPE(RequestContextModule) {
+    JSG_METHOD(getRequestId);
+  }
+};
+
+template <typename TypeWrapper>
+void registerRequestContextModule(
+    workerd::jsg::ModuleRegistryImpl<TypeWrapper>& registry, auto featureFlags) {
+  registry.template addBuiltinModule<RequestContextModule>("cloudflare-internal:request-context",
+    workerd::jsg::ModuleRegistry::Type::INTERNAL);
+}
+
+#define EW_REQUEST_CONTEXT_ISOLATE_TYPES     \
+  api::RequestContextModule
+
+}  // namespace workerd::api

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -451,6 +451,7 @@ kj::Promise<void> sendTracesToExportedHandler(
         [&context, traces=mapAddRef(traces), entrypointName=kj::mv(entrypointName)]
         (Worker::Lock& lock) mutable {
       jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+      jsg::AsyncContextFrame::StorageScope requestIdScope = context.makeRequestIdStorageScope(lock);
 
       auto handler = lock.getExportedHandler(entrypointName, context.getActor());
       lock.getGlobalScope().sendTraces(traces, lock, handler);

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -852,6 +852,9 @@ public:
 
   v8::Local<v8::Object> getPromiseContextTag(jsg::Lock& js);
 
+  inline jsg::AsyncContextFrame::StorageKey& getRequestIdKey() { return *requestIdKey; }
+  jsg::AsyncContextFrame::StorageScope makeRequestIdStorageScope(jsg::Lock& js);
+
 private:
   ThreadContext& thread;
 
@@ -1058,6 +1061,9 @@ private:
   IoChannelFactory& getIoChannelFactory() {
     return *getCurrentIncomingRequest().ioChannelFactory;
   }
+
+  kj::String requestId;
+  kj::Own<jsg::AsyncContextFrame::StorageKey> requestIdKey;
 
   class ThreadScope;
   class Scope;

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -161,6 +161,7 @@ kj::Promise<void> WorkerEntrypoint::request(
        &wrappedResponse = *wrappedResponse, entrypointName = entrypointName]
       (Worker::Lock& lock) mutable {
     jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+    jsg::AsyncContextFrame::StorageScope requestIdScope = context.makeRequestIdStorageScope(lock);
 
     return lock.getGlobalScope().request(
         method, url, headers, requestBody, wrappedResponse,
@@ -361,6 +362,7 @@ kj::Promise<WorkerInterface::ScheduledResult> WorkerEntrypoint::runScheduled(
        &metrics = incomingRequest->getMetrics()]
       (Worker::Lock& lock) mutable {
     jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+    jsg::AsyncContextFrame::StorageScope requestIdScope = context.makeRequestIdStorageScope(lock);
 
     lock.getGlobalScope().startScheduled(scheduledTime, cron, lock,
         lock.getExportedHandler(entrypointName, context.getActor()));
@@ -428,6 +430,8 @@ kj::Promise<WorkerInterface::AlarmResult> WorkerEntrypoint::runAlarmImpl(
         auto result = co_await context.run(
             [scheduledTime, entrypointName=entrypointName, &context](Worker::Lock& lock){
           jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+          jsg::AsyncContextFrame::StorageScope requestIdScope =
+              context.makeRequestIdStorageScope(lock);
 
           auto handler = lock.getExportedHandler(entrypointName, context.getActor());
           return lock.getGlobalScope().runAlarm(scheduledTime, lock, handler);
@@ -478,6 +482,7 @@ kj::Promise<bool> WorkerEntrypoint::test() {
       [entrypointName=entrypointName, &context, &metrics = incomingRequest->getMetrics()]
       (Worker::Lock& lock) mutable -> kj::Promise<void> {
     jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+    jsg::AsyncContextFrame::StorageScope requestIdScope = context.makeRequestIdStorageScope(lock);
 
     return context.awaitJs(lock.getGlobalScope()
         .test(lock, lock.getExportedHandler(entrypointName, context.getActor())));

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1090,9 +1090,28 @@ Worker::Isolate::Isolate(kj::Own<ApiIsolate> apiIsolateParam,
     // a method of ServiceWorkerGlobalScope, which is the context object. So we should be able to
     // do something like unwrap(isolate->GetCurrentContext()).emitPromiseRejection(). However, JSG
     // doesn't currently provide an easy way to do this.
+
+    auto needsRequestIdStorageScope = [&](IoContext& context) {
+      auto& lock = context.getCurrentLock();
+      KJ_IF_MAYBE(frame, jsg::AsyncContextFrame::current(lock)) {
+        return frame->get(context.getRequestIdKey()) == nullptr;
+      }
+      return true;
+    };
+
     if (IoContext::hasCurrent()) {
       try {
-        IoContext::current().reportPromiseRejectEvent(message);
+        auto& context = IoContext::current();
+
+        // Make sure that the current IoContext's request ID is set in the async context when
+        // the rejection occurs so that the rejection can be properly associated with the
+        // request in which the rejection occurred.
+        if (needsRequestIdStorageScope(context)) {
+          auto requestIdStorage = context.makeRequestIdStorageScope(context.getCurrentLock());
+          context.reportPromiseRejectEvent(message);
+        } else {
+          context.reportPromiseRejectEvent(message);
+        }
       } catch (jsg::JsExceptionThrown&) {
         // V8 expects us to just return.
         return;

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -18,6 +18,7 @@
 #include <workerd/api/html-rewriter.h>
 #include <workerd/api/kv.h>
 #include <workerd/api/queue.h>
+#include <workerd/api/request-context.h>
 #include <workerd/api/scheduled.h>
 #include <workerd/api/sockets.h>
 #include <workerd/api/streams/standard.h>
@@ -78,6 +79,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
   EW_WEBSOCKET_ISOLATE_TYPES,
   EW_SQL_ISOLATE_TYPES,
   EW_NODE_ISOLATE_TYPES,
+  EW_REQUEST_CONTEXT_ISOLATE_TYPES,
 
   jsg::TypeWrapperExtension<PromiseWrapper>,
   jsg::InjectConfiguration<CompatibilityFlags::Reader>,
@@ -376,6 +378,7 @@ kj::Own<jsg::ModuleRegistry> WorkerdApiIsolate::compileModules(
   }
 
   api::registerSocketsModule(*modules, getFeatureFlags());
+  api::registerRequestContextModule(*modules, getFeatureFlags());
   modules->addBuiltinBundle(CLOUDFLARE_BUNDLE);
 
   jsg::setModulesForResolveCallback<JsgWorkerdIsolate_TypeWrapper>(lock, modules);


### PR DESCRIPTION
Assigns every IoContext a unique uuid and makes it available via async context tracking to the worker via a new cloudflare:request-context import.

The motivating purpose here is to ensure that every unhandledrejection event can be properly associated with the particular IoContext within which it was triggered (but there are other use cases) since there are cases where such rejection events can occur outside the scope of any user-code provided AsyncLocalStorage instances.

The API can also be used as a reliable means of determine if code is running within the context of a request or not.