### PR TITLE
Add AnalyticsEngine binding type to workerd

### DIFF
--- a/src/workerd/api/analytics-engine-test.js
+++ b/src/workerd/api/analytics-engine-test.js
@@ -1,0 +1,28 @@
+import * as assert from 'node:assert';
+
+let written = false;
+async function isWritten(timeout) {
+  const start = Date.now();
+  do {
+    if (written) return true;
+    await scheduler.wait(100);
+  } while ((Date.now() - start) < timeout);
+  throw new Error("Test never received request from analytics engine handler");
+}
+
+export default { 
+  async fetch(ctrl, env, ctx) {
+    written = true
+    return new Response("");
+  },
+  async test(ctrl, env, ctx) {
+    env.aebinding.writeDataPoint({
+      'blobs': ["TestBlob"],
+      'doubles': [25],
+      'indexes': ["testindex"],
+    });
+
+    assert.equal(await isWritten(5000), true);
+    return new Response("");
+  }, 
+}

--- a/src/workerd/api/analytics-engine-test.wd-test
+++ b/src/workerd/api/analytics-engine-test.wd-test
@@ -1,0 +1,37 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const analyticsWorker :Workerd.Worker = (
+  modules  = [
+    (name = "worker", esModule =
+      `import * as assert from 'node:assert';
+      `export default {
+      `  async fetch(request, env, ctx) {
+      `    let val = await request.json();
+      `    console.log(JSON.stringify(val));
+      `    assert.deepStrictEqual(val['dataset'], [97,110,97,108,121,116,105,99,115]);
+      `    assert.deepStrictEqual(val['double1'], 25);
+      `    assert.deepStrictEqual(val['blob1'], [84,101,115,116,66,108,111,98]);
+      `    await env.main.fetch("http://w/");
+      `    return new Response('');
+      `  },
+      `};
+      ),
+    ],
+  compatibilityFlags = ["experimental", "nodejs_compat"],
+  compatibilityDate = "2023-02-28",
+  bindings = [ ( name = "main", service = "main" ) ]
+);
+
+const mainWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "analytics-engine-test.js"),
+  ],
+  compatibilityFlags = ["experimental", "nodejs_compat"],
+  compatibilityDate = "2023-02-28",
+
+  bindings = [ ( name = "aebinding", analyticsEngine = "analytics") ]
+);
+
+const unitTests :Workerd.Config = (
+    services = [ (name = "main", worker = .mainWorker), (name = "analytics", worker = .analyticsWorker) ],
+);

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1908,6 +1908,10 @@ static kj::Maybe<WorkerdApiIsolate::Global> createBinding(
       }
     }
 
+    case config::Worker::Binding::ANALYTICS_ENGINE: {
+      //TODO Setup request channel
+      return makeGlobal(Global::AnalyticsEngine{});
+    }
   }
   errorReporter.addError(kj::str(
       errorContext, "has unrecognized type. Was the config compiled with a newer version of "

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -487,7 +487,8 @@ private:
 static v8::Local<v8::Value> createBindingValue(
     JsgWorkerdIsolate::Lock& lock,
     const WorkerdApiIsolate::Global& global,
-    CompatibilityFlags::Reader featureFlags) {
+    CompatibilityFlags::Reader featureFlags,
+    uint32_t ownerId) {
   using Global = WorkerdApiIsolate::Global;
   auto context = lock.v8Context();
 
@@ -561,6 +562,10 @@ static v8::Local<v8::Value> createBindingValue(
           kj::heap<ActorIdFactoryImpl>(ns.uniqueKey)));
     }
 
+    KJ_CASE_ONEOF(ns, Global::AnalyticsEngine) {
+        value = lock.wrap(context, jsg::alloc<api::AnalyticsEngine>(ns.logfwdrChannel, kj::str(ns.dataset), ns.version, ownerId));
+    }
+
     KJ_CASE_ONEOF(text, kj::String) {
       value = lock.wrap(context, kj::mv(text));
     }
@@ -585,7 +590,7 @@ static v8::Local<v8::Value> createBindingValue(
         for (const auto& innerBinding: wrapped.innerBindings) {
           jsg::check(env->Set(context,
               lock.wrapString(innerBinding.name),
-              createBindingValue(lock, innerBinding, featureFlags)));
+              createBindingValue(lock, innerBinding, featureFlags, ownerId)));
         }
 
         // obtain exported function to call
@@ -620,7 +625,7 @@ void WorkerdApiIsolate::compileGlobals(
 
     // Don't use String's usual TypeHandler here because we want to intern the string.
     auto name = jsg::v8StrIntern(lock.v8Isolate, global.name);
-    auto value = createBindingValue(lock, global, featureFlags);
+    auto value = createBindingValue(lock, global, featureFlags, ownerId);
 
     KJ_ASSERT(!value.IsEmpty(), "global did not produce v8::Value");
     bool setResult = jsg::check(target->Set(context, name, value));
@@ -664,6 +669,9 @@ WorkerdApiIsolate::Global WorkerdApiIsolate::Global::clone() const {
       result.value = ns.clone();
     }
     KJ_CASE_ONEOF(ns, Global::DurableActorNamespace) {
+      result.value = ns.clone();
+    }
+    KJ_CASE_ONEOF(ns, Global::AnalyticsEngine) {
       result.value = ns.clone();
     }
     KJ_CASE_ONEOF(text, kj::String) {

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -562,8 +562,10 @@ static v8::Local<v8::Value> createBindingValue(
           kj::heap<ActorIdFactoryImpl>(ns.uniqueKey)));
     }
 
-    KJ_CASE_ONEOF(ns, Global::AnalyticsEngine) {
-        value = lock.wrap(context, jsg::alloc<api::AnalyticsEngine>(ns.logfwdrChannel, kj::str(ns.dataset), ns.version, ownerId));
+    KJ_CASE_ONEOF(ae, Global::AnalyticsEngine) {
+        // Use subrequestChannel as logfwdrChannel
+        value = lock.wrap(context, jsg::alloc<api::AnalyticsEngine>(ae.subrequestChannel,
+                    kj::str(ae.dataset), ae.version, ownerId));
     }
 
     KJ_CASE_ONEOF(text, kj::String) {
@@ -671,8 +673,8 @@ WorkerdApiIsolate::Global WorkerdApiIsolate::Global::clone() const {
     KJ_CASE_ONEOF(ns, Global::DurableActorNamespace) {
       result.value = ns.clone();
     }
-    KJ_CASE_ONEOF(ns, Global::AnalyticsEngine) {
-      result.value = ns.clone();
+    KJ_CASE_ONEOF(ae, Global::AnalyticsEngine) {
+      result.value = ae.clone();
     }
     KJ_CASE_ONEOF(text, kj::String) {
       result.value = kj::str(text);

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -142,12 +142,12 @@ public:
       }
     };
     struct AnalyticsEngine {
-      uint logfwdrChannel;
+      uint subrequestChannel;
       kj::String dataset;
       int64_t version;
       AnalyticsEngine clone() const {
         return AnalyticsEngine {
-          .logfwdrChannel = logfwdrChannel,
+          .subrequestChannel = subrequestChannel,
           .dataset = kj::str(dataset),
           .version = version
         };
@@ -155,7 +155,8 @@ public:
     };
     kj::String name;
     kj::OneOf<Json, Fetcher, KvNamespace, R2Bucket, R2Admin, CryptoKey, EphemeralActorNamespace,
-              DurableActorNamespace, QueueBinding, kj::String, kj::Array<byte>, Wrapped, AnalyticsEngine> value;
+              DurableActorNamespace, QueueBinding, kj::String, kj::Array<byte>, Wrapped,
+              AnalyticsEngine> value;
 
     Global clone() const;
   };

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -141,9 +141,21 @@ public:
         };
       }
     };
+    struct AnalyticsEngine {
+      uint logfwdrChannel;
+      kj::String dataset;
+      int64_t version;
+      AnalyticsEngine clone() const {
+        return AnalyticsEngine {
+          .logfwdrChannel = logfwdrChannel,
+          .dataset = kj::str(dataset),
+          .version = version
+        };
+      }
+    };
     kj::String name;
     kj::OneOf<Json, Fetcher, KvNamespace, R2Bucket, R2Admin, CryptoKey, EphemeralActorNamespace,
-              DurableActorNamespace, QueueBinding, kj::String, kj::Array<byte>, Wrapped> value;
+              DurableActorNamespace, QueueBinding, kj::String, kj::Array<byte>, Wrapped, AnalyticsEngine> value;
 
     Global clone() const;
   };

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -339,6 +339,7 @@ struct Worker {
 
       wrapped @14 :WrappedBinding;
       # Wraps a collection of inner bindings in a common api functionality.
+      
 
       queue @15 :ServiceDesignator;
       # A Queue binding, implemented by the named service. Requests to the
@@ -351,7 +352,9 @@ struct Worker {
       # `getenv()` with that name. If the environment variable isn't set, the binding value is
       # `null`.
 
-      # TODO(someday): dispatch, analyticsEngine, other new features
+      analyticsEngine @17 :ServiceDesignator; 
+
+      # TODO(someday): dispatch, other new features
     }
 
     struct Type {
@@ -372,6 +375,7 @@ struct Worker {
         r2Bucket @9 :Void;
         r2Admin @10 :Void;
         queue @11 :Void;
+        analyticsEngine @12 : Void;
       }
     }
 

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -339,7 +339,6 @@ struct Worker {
 
       wrapped @14 :WrappedBinding;
       # Wraps a collection of inner bindings in a common api functionality.
-      
 
       queue @15 :ServiceDesignator;
       # A Queue binding, implemented by the named service. Requests to the
@@ -352,7 +351,10 @@ struct Worker {
       # `getenv()` with that name. If the environment variable isn't set, the binding value is
       # `null`.
 
-      analyticsEngine @17 :ServiceDesignator; 
+      analyticsEngine @17 :ServiceDesignator;
+      # A binding for Analytics Engine. Allows workers to store information through Analytics Engine Events.
+      # workerd will forward AnalyticsEngineEvents to designated service in the body of HTTP requests
+      # This binding is subject to change and requires the `--experimental` flag
 
       # TODO(someday): dispatch, other new features
     }


### PR DESCRIPTION
Closes #536 

This implementation will forward analytics engine events in the body of http requests to a provided service. The binding is marked as experimental and requires the `--experimental` flag to use