### PR TITLE
Implement `EmbedderRootsHandler::TryResetRoot()`.

### DIFF
--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -113,7 +113,6 @@ V8System::V8System(kj::Own<v8::Platform> platformParam, kj::ArrayPtr<const kj::S
   // (It turns out you can call v8::V8::SetFlagsFromString() as many times as you want to add
   // more flags.)
   v8::V8::SetFlagsFromString("--noincremental-marking");
-  v8::V8::SetFlagsFromString("--single_threaded_gc");
 
 #ifdef WORKERD_ICU_DATA_EMBED
   // V8's bazel build files currently don't support the option to embed ICU data, so we do it
@@ -240,6 +239,13 @@ void HeapTracer::ResetRoot(const v8::TracedReference<v8::Value>& handle) {
   // if the wrapable has strong references, which means that its outgoing references need to be
   // upgraded to strong).
   detachLater.add(&wrappable);
+}
+
+bool HeapTracer::TryResetRoot(const v8::TracedReference<v8::Value>& handle) {
+  // This method is potentially called on a separate thread. Our ResetRoot() implementation,
+  // though, only works on the main thread. Return false to request V8 schedule the call for the
+  // main thread later on.
+  return false;
 }
 
 namespace {

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -194,6 +194,7 @@ public:
   // implements EmbedderRootsHandler -------------------------------------------
   bool IsRoot(const v8::TracedReference<v8::Value>& handle) override;
   void ResetRoot(const v8::TracedReference<v8::Value>& handle) override;
+  bool TryResetRoot(const v8::TracedReference<v8::Value>& handle) override;
 
 private:
   v8::Isolate* isolate;


### PR DESCRIPTION
In V8 11.5, things changed so that the `ResetRoot()` callback might be called on a background thread. A new method, `TryResetRoot()`, can be implemented to return false in order to prevent this and force `ResetRoot()` back to the main thread. However, its default implementation just calls `ResetRoot()` (on the background thread), hence the default behavior changed.

https://chromium-review.googlesource.com/c/v8/v8/+/4474708

Our `ResetRoot()` must be called on the main thread, so we must implement `TryResetRoot()` to return false.

This allows us to remove the `single_threaded_gc` flag we added recently as a work-around. It turns out that flag isn't actually sufficient to avoid the problem anyway.