### PR TITLE
Fix hash tables that assume hashes don't collide

### DIFF
--- a/src/workerd/api/url-standard.h
+++ b/src/workerd/api/url-standard.h
@@ -165,7 +165,7 @@ private:
     Entry& operator=(Entry&&) = default;
 
     inline uint hashCode() const { return hash; }
-    inline bool operator==(const Entry& other) const { return hash == other.hash; }
+    inline bool operator==(const Entry& other) const { return name == other.name; }
   };
 
   kj::Vector<Entry> list;

--- a/src/workerd/jsg/promise.c++
+++ b/src/workerd/jsg/promise.c++
@@ -126,13 +126,13 @@ void UnhandledRejectionHandler::handledAfterRejection(
   // emit another warning indicating that it's been handled.
   KJ_DEFER(ensureProcessingWarnings(js));
 
-  uint hash = promise.getHandle(js)->GetIdentityHash();
+  HashedPromise key(promise.getHandle(js));
 
-  if (unhandledRejections.eraseMatch(hash)) {
+  if (unhandledRejections.eraseMatch(key)) {
     return;
   }
 
-  KJ_IF_MAYBE(item, warnedRejections.find(hash)) {
+  KJ_IF_MAYBE(item, warnedRejections.find(key)) {
     auto promise = getLocal(js.v8Isolate, item->promise);
     if (!promise.IsEmpty()) {
       // TODO(later): Chromium handles this differently... essentially when the

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -800,12 +800,25 @@ private:
     uint hashCode() const { return hash; }
   };
 
+  struct HashedPromise {
+    // A v8::Promise with memoized hash code.
+    v8::Local<v8::Promise> promise;
+    uint hash;
+
+    HashedPromise(v8::Local<v8::Promise> promise)
+        : promise(promise), hash(promise->GetIdentityHash()) {}
+  };
+
   struct UnhandledRejectionCallbacks {
-    inline uint keyForRow(const UnhandledRejection& row) const { return row.hashCode(); }
-    inline bool matches(const UnhandledRejection& a, uint& hash) const {
-      return a.hashCode() == hash;
+    inline const UnhandledRejection& keyForRow(const UnhandledRejection& row) const { return row; }
+    inline bool matches(const UnhandledRejection& a, const UnhandledRejection& b) const {
+      return a.promise == b.promise;
     }
-    inline uint hashCode(uint hash) const { return hash; }
+    inline bool matches(const UnhandledRejection& a, const HashedPromise& b) const {
+      return a.promise == b.promise;
+    }
+    inline uint hashCode(const UnhandledRejection& row) const { return row.hashCode(); }
+    inline uint hashCode(const HashedPromise& key) const { return key.hash; }
   };
 
   kj::Function<Handler> handler;


### PR DESCRIPTION
In both these cases, hash collisions are expected to happen from time to time, so assuming equality on equal hash code is not safe.