### PR TITLE
d1: Fix exec to return D1ExecResult correctly.

### DIFF
--- a/types/defines/d1.d.ts
+++ b/types/defines/d1.d.ts
@@ -5,11 +5,16 @@ interface D1Result<T = unknown> {
   meta: any;
 }
 
+interface D1ExecResult<T = unknown> {
+  count: number;
+  duration: number;
+}
+
 declare abstract class D1Database {
   prepare(query: string): D1PreparedStatement;
   dump(): Promise<ArrayBuffer>;
   batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]>;
-  exec<T = unknown>(query: string): Promise<D1Result<T>>;
+  exec<T = unknown>(query: string): Promise<D1ExecResult<T>>;
 }
 
 declare abstract class D1PreparedStatement {


### PR DESCRIPTION
The D1 API returns a `D1ExecResult` shaped object on calls to `.exec`. This fixes the types to match what D1 returns.