### PR TITLE
Use 'compatibility flag' language consistently

### DIFF
--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -104,7 +104,7 @@ public:
   JSG_RESOURCE_TYPE(Event, CompatibilityFlags::Reader flags) {
     // Previously, we were setting all properties as instance properties,
     // which broke the ability to subclass the Event object. With the
-    // feature flag set, we instead attach the properties to the
+    // compatibility flag set, we instead attach the properties to the
     // prototype.
     if (flags.getJsgPropertyOnPrototypeTemplate()) {
       JSG_READONLY_PROTOTYPE_PROPERTY(type, getType);

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1555,7 +1555,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(
 
   if (headers.isWebSocket()) {
     if (!FeatureFlags::get(js).getWebSocketCompression()) {
-      // If we haven't enabled the websocket compression feature flag, strip the header from the
+      // If we haven't enabled the websocket compression compatibility flag, strip the header from the
       // subrequest.
       headers.unset(kj::HttpHeaderId::SEC_WEBSOCKET_EXTENSIONS);
     }

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -336,7 +336,7 @@ public:
     bool detachBuffer = true;
     // True if the given buffer should be detached. Per the spec, we should always be
     // detaching a BYOB buffer but the original Workers implementation did not.
-    // To avoid breaking backwards compatibility, a feature flag is provided to turn
+    // To avoid breaking backwards compatibility, a compatibility flag is provided to turn
     // detach on/off as appropriate.
   };
 

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -485,7 +485,8 @@ jsg::Ref<ReadableStream> ReadableStream::constructor(
   JSG_REQUIRE(FeatureFlags::get(js).getStreamsJavaScriptControllers(),
                Error,
                "To use the new ReadableStream() constructor, enable the "
-               "streams_enable_constructors feature flag.");
+               "streams_enable_constructors compatibility flag. "
+               "Refer to the docs for more information: https://developers.cloudflare.com/workers/platform/compatibility-dates/#compatibility-flags");
   auto stream = jsg::alloc<ReadableStream>(newReadableStreamJsController());
   stream->getController().setup(js, kj::mv(underlyingSource), kj::mv(queuingStrategy));
   return kj::mv(stream);

--- a/src/workerd/api/streams/transform.c++
+++ b/src/workerd/api/streams/transform.c++
@@ -109,13 +109,14 @@ jsg::Ref<TransformStream> TransformStream::constructor(
 
   // The old implementation just defers to IdentityTransformStream. If any of the arguments
   // are specified we throw because it's most likely that they want the standard implementation
-  // but the feature flag is not set.
+  // but the compatibility flag is not set.
   if (maybeTransformer != nullptr ||
       maybeWritableStrategy != nullptr ||
       maybeReadableStrategy != nullptr) {
     IoContext::current().logWarningOnce(
         "To use the new TransformStream() constructor with a "
-        "custom transformer, enable the transformstream_enable_standard_constructor feature flag.");
+        "custom transformer, enable the transformstream_enable_standard_constructor compatibility flag. "
+        "Refer to the docs for more information: https://developers.cloudflare.com/workers/platform/compatibility-dates/#compatibility-flags");
   }
 
   return IdentityTransformStream::constructor(js);

--- a/src/workerd/api/streams/transform.h
+++ b/src/workerd/api/streams/transform.h
@@ -17,7 +17,7 @@ class TransformStream: public jsg::Object {
   // passthrough that only handled byte data. No actual transformation of the value was performed.
   // The original version did not conform to the streams standard. That original version has been
   // migrated into the IdentityTransformStream class. If the transformstream_enable_standard_constructor
-  // feature flag is not enabled, then TransformStream is just an alias for IdentityTransformStream
+  // compatibility flag is not enabled, then TransformStream is just an alias for IdentityTransformStream
   // and continues to implement the non-standard behavior. With the transformstream_enable_standard_constructor
   // flag set, however, the TransformStream implements standardized behavior.
 

--- a/src/workerd/api/streams/writable.c++
+++ b/src/workerd/api/streams/writable.c++
@@ -253,7 +253,8 @@ jsg::Ref<WritableStream> WritableStream::constructor(
   JSG_REQUIRE(FeatureFlags::get(js).getStreamsJavaScriptControllers(),
                Error,
                "To use the new WritableStream() constructor, enable the "
-               "streams_enable_constructors feature flag.");
+               "streams_enable_constructors compatibility flag. "
+               "Refer to the docs for more information: https://developers.cloudflare.com/workers/platform/compatibility-dates/#compatibility-flags");
   auto stream = jsg::alloc<WritableStream>(newWritableStreamJsController());
   stream->getController().setup(js, kj::mv(underlyingSink), kj::mv(queuingStrategy));
   return kj::mv(stream);

--- a/src/workerd/api/url.h
+++ b/src/workerd/api/url.h
@@ -61,7 +61,7 @@ public:
   JSG_RESOURCE_TYPE(URL, CompatibilityFlags::Reader flags) {
     // Previously, we were setting all properties as instance properties,
     // which broke the ability to subclass the URL object. With the
-    // feature flag set, we instead attach the properties to the
+    // compatibility flag set, we instead attach the properties to the
     // prototype.
     if (flags.getJsgPropertyOnPrototypeTemplate()) {
       JSG_PROTOTYPE_PROPERTY(href, getHref, setHref);

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -237,7 +237,7 @@ jsg::Ref<WebSocket> WebSocket::constructor(
   // By default, browsers set the compression extension header for `new WebSocket()`.
 
   if (!FeatureFlags::get(js).getWebSocketCompression()) {
-    // If we haven't enabled the websocket compression feature flag, strip the header from the
+    // If we haven't enabled the websocket compression compatibility flag, strip the header from the
     // subrequest.
     headers.unset(kj::HttpHeaderId::SEC_WEBSOCKET_EXTENSIONS);
   }

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -414,7 +414,7 @@ public:
 
     // Previously, we were setting all properties as instance properties,
     // which broke the ability to subclass the Event object. With the
-    // feature flag set, we instead attach the properties to the
+    // compatibility flag set, we instead attach the properties to the
     // prototype.
     if (flags.getJsgPropertyOnPrototypeTemplate()) {
       JSG_READONLY_PROTOTYPE_PROPERTY(readyState, getReadyState);

--- a/src/workerd/io/compatibility-date-test.c++
+++ b/src/workerd/io/compatibility-date-test.c++
@@ -117,7 +117,7 @@ KJ_TEST("compatibility flag parsing") {
   expectCompileCompatibilityFlags("2021-11-03", {"formdata_parser_converts_files_to_strings"},
       "(formDataParserSupportsFiles = false)");
 
-  // Test feature flag overrides.
+  // Test compatibility flag overrides.
   expectCompileCompatibilityFlags("2021-05-17", {"formdata_parser_supports_files"_kj},
       "(formDataParserSupportsFiles = true)");
   expectCompileCompatibilityFlags("2021-05-17", {"fetch_refuses_unknown_protocols"_kj},
@@ -135,7 +135,7 @@ KJ_TEST("compatibility flag parsing") {
   expectCompileCompatibilityFlags("2021-05-17",
       {"formdata_parser_supports_files"_kj, "formdata_parser_supports_files"_kj},
       "(formDataParserSupportsFiles = true)",
-      {"Feature flag specified multiple times: formdata_parser_supports_files"});
+      {"Compatibility flag specified multiple times: formdata_parser_supports_files"});
   expectCompileCompatibilityFlags("2021-05-17",
       {"formdata_parser_supports_files"_kj, "formdata_parser_converts_files_to_strings"_kj},
       "(formDataParserSupportsFiles = true)",
@@ -147,7 +147,7 @@ KJ_TEST("compatibility flag parsing") {
       {"The compatibility flag formdata_parser_supports_files became the default as of "
        "2021-11-03 so does not need to be specified anymore."});
   expectCompileCompatibilityFlags("2021-05-17", {"unknown_feature"_kj}, "()",
-      {"No such feature flag: unknown_feature"});
+      {"No such compatibility flag: unknown_feature"});
 
   expectCompileCompatibilityFlags("2252-04-01", {}, "()",
       {"Can't set compatibility date in the future: 2252-04-01"},
@@ -182,10 +182,10 @@ KJ_TEST("compatibility flag parsing") {
        "another_feature"_kj, "formdata_parser_supports_files"_kj},
       "(formDataParserSupportsFiles = true, fetchRefusesUnknownProtocols = true)",
       {"Invalid compatibility date: abcd",
-       "Feature flag specified multiple times: fetch_refuses_unknown_protocols",
-       "Feature flag specified multiple times: formdata_parser_supports_files",
-       "No such feature flag: another_feature",
-       "No such feature flag: unknown_feature"});
+       "Compatibility flag specified multiple times: fetch_refuses_unknown_protocols",
+       "Compatibility flag specified multiple times: formdata_parser_supports_files",
+       "No such compatibility flag: another_feature",
+       "No such compatibility flag: unknown_feature"});
 
   // Can explicitly disable flag that's enabled for all dates.s
   expectCompileCompatibilityFlags("2021-05-17", {"r2_internal_beta_bindings"}, "()", {},

--- a/src/workerd/io/compatibility-date.c++
+++ b/src/workerd/io/compatibility-date.c++
@@ -118,7 +118,7 @@ void compileCompatibilityFlags(kj::StringPtr compatDate, capnp::List<capnp::Text
   kj::HashSet<kj::String> flagSet;
   for (auto flag: compatFlags) {
     flagSet.upsert(kj::str(flag), [&](auto& existing, auto&& newValue) {
-      errorReporter.addError(kj::str("Feature flag specified multiple times: ", flag));
+      errorReporter.addError(kj::str("Compatibility flag specified multiple times: ", flag));
     });
   }
 
@@ -197,7 +197,7 @@ void compileCompatibilityFlags(kj::StringPtr compatDate, capnp::List<capnp::Text
   }
 
   for (auto& flag: flagSet) {
-    errorReporter.addError(kj::str("No such feature flag: ", flag));
+    errorReporter.addError(kj::str("No such compatibility flag: ", flag));
   }
 }
 


### PR DESCRIPTION
refs EW-7514

- Previously we used the language "feature flag" and "compatibility flag" interchangeably
- This was ambiguous, since on Cloudflare and other platforms, "feature flag" refers to a separate concept and system, that requires internal action to enable.
- This PR updates all references to "feature flag" to use the "compatibility flag" language, to ensure that when people encounter error messages, it is clear that these are in reference to compatibility flags, as described [here](https://developers.cloudflare.com/workers/platform/compatibility-dates/#compatibility-flags) in the Workers docs.