### PR TITLE
Rename `QueueMessage` type parameter

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -213,7 +213,7 @@ struct ExportedHandler {
     type ExportedHandlerQueueHandler<Env = unknown, Message = unknown> = (batch: MessageBatch<Message>, env: Env, ctx: ExecutionContext) => void | Promise<void>;
     type ExportedHandlerTestHandler<Env = unknown> = (controller: TestController, env: Env, ctx: ExecutionContext) => void | Promise<void>;
   );
-  JSG_STRUCT_TS_OVERRIDE(<Env = unknown, QueueMessage = unknown, CfHostMetadata = unknown> {
+  JSG_STRUCT_TS_OVERRIDE(<Env = unknown, QueueHandlerMessage = unknown, CfHostMetadata = unknown> {
     email?: EmailExportedHandler<Env>;
     fetch?: ExportedHandlerFetchHandler<Env, CfHostMetadata>;
     tail?: ExportedHandlerTailHandler<Env>;
@@ -223,7 +223,7 @@ struct ExportedHandler {
     webSocketMessage: never;
     webSocketClose: never;
     webSocketError: never;
-    queue?: ExportedHandlerQueueHandler<Env, QueueMessage>;
+    queue?: ExportedHandlerQueueHandler<Env, QueueHandlerMessage>;
     test?: ExportedHandlerTestHandler<Env>;
   });
   // Make `env` parameter generic


### PR DESCRIPTION
`QueueMessage` is renamed to `Message` in its override...

https://github.com/cloudflare/workerd/blob/d073c092e57c96895e8eccbfe21d27aefb4b0604/src/workerd/api/queue.h#L133

...but the rename transform is not type parameter aware. To ensure the type parameter is still used, rename it to something that shouldn't be renamed.

Fixes #758