### PR TITLE
macOS build and release updates for workerd

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "workerd debug",
+      "name": "workerd (dbg)",
       "preLaunchTask": "Bazel build workerd (dbg)",
       "program": "workerd",
       "request": "launch",
@@ -13,14 +13,12 @@
       "cwd": "${workspaceFolder}",
       "program": "${workspaceFolder}/bazel-bin/src/workerd/server/workerd",
       "linux": {
-        "name": "workerd debug",
         "type": "cppdbg",
         "request": "launch",
         "MIMode": "gdb",
         "miDebuggerArgs": "-d ${workspaceFolder}",
       },
       "osx": {
-        "name": "workerd debug",
         "type": "cppdbg",
         "request": "launch",
         "MIMode": "lldb",
@@ -32,7 +30,6 @@
          },
       },
       "windows": {
-        "name": "workerd debug",
         "type": "cppvsdbg",
         "request": "launch",
       },
@@ -44,21 +41,20 @@
       "externalConsole": false,
     },
     {
-      "name": "workerd debug with inspector enabled",
-      "preLaunchTask": "Bazel build workerd (dbg)",
-      "type": "cppdbg",
+      "name": "workerd (opt)",
+      "preLaunchTask": "Bazel build workerd (opt)",
+      "program": "workerd",
       "request": "launch",
+      "type": "cppdbg",
       "cwd": "${workspaceFolder}",
       "program": "${workspaceFolder}/bazel-bin/src/workerd/server/workerd",
       "linux": {
-        "name": "workerd debug with inspector enabled",
         "type": "cppdbg",
         "request": "launch",
         "MIMode": "gdb",
         "miDebuggerArgs": "-d ${workspaceFolder}",
       },
       "osx": {
-        "name": "workerd debug with inspector enabled",
         "type": "cppdbg",
         "request": "launch",
         "MIMode": "lldb",
@@ -70,7 +66,41 @@
          },
       },
       "windows": {
-        "name": "workerd debug with inspector enabled",
+        "type": "cppvsdbg",
+        "request": "launch",
+      },
+      "args": [
+        "serve",
+        "${input:workerdConfig}"
+      ],
+      "stopAtEntry": false,
+      "externalConsole": false,
+    },
+    {
+      "name": "workerd with inspector enabled (dbg)",
+      "preLaunchTask": "Bazel build workerd (dbg)",
+      "type": "cppdbg",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "program": "${workspaceFolder}/bazel-bin/src/workerd/server/workerd",
+      "linux": {
+        "type": "cppdbg",
+        "request": "launch",
+        "MIMode": "gdb",
+        "miDebuggerArgs": "-d ${workspaceFolder}",
+      },
+      "osx": {
+        "type": "cppdbg",
+        "request": "launch",
+        "MIMode": "lldb",
+        "sourceFileMap": {
+          "src" : "${workspaceFolder}/src",
+          "bazel-bin" : "${workspaceFolder}/bazel-bin",
+          "bazel-out" : "${workspaceFolder}/bazel-out",
+          "external" : "${workspaceFolder}/external"
+         },
+      },
+      "windows": {
         "type": "cppvsdbg",
         "request": "launch",
       },
@@ -84,14 +114,50 @@
       "externalConsole": false
     },
     {
-      "name": "workerd test case",
+      "name": "workerd with inspector enabled (opt)",
+      "preLaunchTask": "Bazel build workerd (opt)",
+      "type": "cppdbg",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "program": "${workspaceFolder}/bazel-bin/src/workerd/server/workerd",
+      "linux": {
+        "type": "cppdbg",
+        "request": "launch",
+        "MIMode": "gdb",
+        "miDebuggerArgs": "-d ${workspaceFolder}",
+      },
+      "osx": {
+        "type": "cppdbg",
+        "request": "launch",
+        "MIMode": "lldb",
+        "sourceFileMap": {
+          "src" : "${workspaceFolder}/src",
+          "bazel-bin" : "${workspaceFolder}/bazel-bin",
+          "bazel-out" : "${workspaceFolder}/bazel-out",
+          "external" : "${workspaceFolder}/external"
+         },
+      },
+      "windows": {
+        "type": "cppvsdbg",
+        "request": "launch",
+      },
+      "args": [
+        "serve",
+        "-i0.0.0.0",
+        "--verbose",
+        "${input:workerdConfig}"
+      ],
+      "stopAtEntry": false,
+      "externalConsole": false
+    },
+    {
+      "name": "workerd test case (dbg)",
       "preLaunchTask": "Bazel build all (dbg)",
       "program": "${workspaceFolder}/${input:testToDebug}",
       "cwd": "${workspaceFolder}",
       "type": "cppdbg",
       "request": "launch",
       "linux": {
-        "name": "workerd test case",
         "type": "cppdbg",
         "request": "launch",
         "MIMode": "gdb",
@@ -99,7 +165,6 @@
         "program": "${workspaceFolder}/${input:testToDebug}",
       },
       "osx": {
-        "name": "workerd test case",
         "type": "cppdbg",
         "request": "launch",
         "MIMode": "lldb",
@@ -113,7 +178,6 @@
          "program": "${workspaceFolder}/${input:testToDebug}",
       },
       "windows": {
-        "name": "workerd test case",
         "type": "cppvsdbg",
         "request": "launch",
         "program": "${workspaceFolder}/${input:testToDebug}",
@@ -122,7 +186,7 @@
       "externalConsole": false
     },
     {
-      "name": "workerd wdtest case",
+      "name": "workerd wd-test case (dbg)",
       "preLaunchTask": "Bazel build all (dbg)",
       "program": "${workspaceFolder}/bazel-bin/src/workerd/server/workerd",
       "args": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,17 +2,16 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Bazel build workerd (dbg)",
+      "label": "Bazel build all (dbg)",
       "type": "shell",
       "command": "bazel",
-      "args": ["build", "-c", "dbg", "//src/workerd/server:workerd"],
+      "args": ["build", "-c", "dbg", "//..."],
       "osx": {
-        // OS X needs additional build options for symbols to work correctly
-        // (https://github.com/bazelbuild/bazel/issues/6327), hence the additional
-        // flags for the spawn_strategy and oso_prefix. Ideally these would
-        // be in a platform specific config in .bazelrc, but this is not supported
-        // (https://github.com/bazelbuild/bazel/issues/5055).
-        "args": ["build", "-c", "dbg", "--spawn_strategy=local", "--features=oso_prefix_is_pwd", "//src/workerd/server:workerd"],
+        // OS X needs to set the bazel `spawn_strategy` option to `local` for symbols to work
+        // correctly (https://github.com/bazelbuild/bazel/issues/6327). This `spawn_strategy`
+        // precludes the use of sandboxing during the build (see
+        // https://bazel.build/docs/user-manual#execution-strategy).
+        "args": ["build", "-c", "dbg", "--spawn_strategy=local", "//..."],
       },
       "group": {
         "kind": "build",
@@ -29,17 +28,16 @@
       }
     },
     {
-      "label": "Bazel build all (dbg)",
+      "label": "Bazel build workerd (dbg)",
       "type": "shell",
       "command": "bazel",
-      "args": ["build", "-c", "dbg", "//..."],
+      "args": ["build", "-c", "dbg", "//src/workerd/server:workerd"],
       "osx": {
-        // OS X needs additional build option for symbols to work correctly
-        // (https://github.com/bazelbuild/bazel/issues/6327), hence the additional
-        // flags for the spawn_strategy and oso_prefix. Ideally these would
-        // be in a platform specific config in .bazelrc, but this is not supported
-        // (https://github.com/bazelbuild/bazel/issues/5055).
-        "args": ["build", "-c", "dbg", "--features=oso_prefix_is_pwd", "//..."],
+        // OS X needs to set the bazel `spawn_strategy` option to `local` for symbols to work
+        // correctly (https://github.com/bazelbuild/bazel/issues/6327). This `spawn_strategy`
+        // precludes the use of sandboxing during the build (see
+        // https://bazel.build/docs/user-manual#execution-strategy).
+        "args": ["build", "-c", "dbg", "--spawn_strategy=local", "//src/workerd/server:workerd"],
       },
       "group": {
         "kind": "build",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -39,7 +39,7 @@
         // flags for the spawn_strategy and oso_prefix. Ideally these would
         // be in a platform specific config in .bazelrc, but this is not supported
         // (https://github.com/bazelbuild/bazel/issues/5055).
-        "args": ["build", "-c", "dbg","--features=oso_prefix_is_pwd", "//..."],
+        "args": ["build", "-c", "dbg", "--features=oso_prefix_is_pwd", "//..."],
       },
       "group": {
         "kind": "build",
@@ -79,6 +79,8 @@
       "type": "shell",
       "command": "bazel",
       "args": ["build", "-c", "opt", "//src/workerd/server:workerd"],
+      // To enable debug symbols for an optimized build, add the following args for bazel:
+      // "--strategy=local", "--copt='-g'", "--cxxopt='-g'", "--host_copt='-g'", "--host_cxxopt='-g'", "--strip=never"
       "group": {
         "kind": "build",
         "isDefault": false

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,7 +24,7 @@
         "focus": false,
         "panel": "shared",
         "showReuseMessage": false,
-        "clear": true
+        "clear": false
       }
     },
     {
@@ -50,7 +50,7 @@
         "focus": false,
         "panel": "shared",
         "showReuseMessage": false,
-        "clear": true
+        "clear": false
       }
     },
     {
@@ -69,7 +69,7 @@
         "focus": false,
         "panel": "shared",
         "showReuseMessage": false,
-        "clear": true
+        "clear": false
       }
     },
     {
@@ -90,7 +90,7 @@
         "focus": false,
         "panel": "shared",
         "showReuseMessage": false,
-        "clear": true
+        "clear": false
       }
     },
     {
@@ -108,7 +108,7 @@
         "focus": false,
         "panel": "shared",
         "showReuseMessage": false,
-        "clear": true
+        "clear": false
       }
     },
     {
@@ -126,7 +126,7 @@
         "focus": false,
         "panel": "shared",
         "showReuseMessage": false,
-        "clear": true
+        "clear": false
       }
     },
     {
@@ -145,7 +145,7 @@
         "focus": false,
         "panel": "shared",
         "showReuseMessage": false,
-        "clear": true
+        "clear": false
       }
     },
     {
@@ -164,7 +164,7 @@
         "focus": false,
         "panel": "shared",
         "showReuseMessage": false,
-        "clear": true
+        "clear": false
       }
     },
     {
@@ -183,7 +183,7 @@
         "focus": false,
         "panel": "shared",
         "showReuseMessage": false,
-        "clear": true
+        "clear": false
       }
     },
     {

--- a/build-releases.sh
+++ b/build-releases.sh
@@ -15,9 +15,12 @@ TAG_NAME=$(curl -sL https://api.github.com/repos/cloudflare/workerd/releases/lat
 git checkout $TAG_NAME
 
 # Build macOS binary
-pnpm exec bazelisk build --disk_cache=./.bazel-cache -c opt //src/workerd/server:workerd
-
-cp bazel-bin/src/workerd/server/workerd ./workerd-darwin-arm64
+#
+# This is using fastbuild rather than opt until SIGBUS issue with the opt binary are resolved.
+# The issue is tracked in https://github.com/cloudflare/workers-sdk/issues/2386.
+pnpm exec bazelisk build -c fastbuild //src/workerd/server:workerd
+echo Stripping binary
+strip bazel-bin/src/workerd/server/workerd -o ./workerd-darwin-arm64
 
 docker buildx build --platform linux/arm64 -f Dockerfile.release -t workerd:$TAG_NAME --target=artifact --output type=local,dest=$(pwd) .
 

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -56,17 +56,17 @@ target with the debugger attached.
 
 The main targets of interest are:
 
-* workerd debug
-* workerd debug with inspector enabled
-* workerd test case
-* workerd wdtest case
+* workerd (dbg)
+* workerd with inspector enabled (dbg)
+* workerd test case (dbg)
+* workerd wd-test case (dbg)
 
-Launching either "workerd debug" or "workerd debug with inspector enabled" will prompt for a workerd configuration for
+Launching either "workerd (dbg)" or "workerd with inspector enabled (dbg)" will prompt for a workerd configuration for
 workerd to serve, the default is [${workspaceFolder}/samples/helloworld/config.capnp](../samples/helloworld/config.capnp).
 
-Launching "workerd test case" will prompt for a test binary to debug, the default is `bazel-bin/src/workerd/jsg/jsg-test`.
+Launching "workerd test case (dbg)" will prompt for a test binary to debug, the default is `bazel-bin/src/workerd/jsg/jsg-test`.
 
-Launching "workerd wdtest case" will prompt for wd-test file to provide to workerd to debug, the default is `src/workerd/api/node/path-test.wd-test`.
+Launching "workerd wd-test case (dbg)" will prompt for wd-test file to provide to workerd to debug, the default is `src/workerd/api/node/path-test.wd-test`.
 
 ## Generating compile_commands.json
 


### PR DESCRIPTION
* Use fastbuild for release temporarily.
* Add opt builds for vscode
* Trivial clean-up of macOS build options