### PR TITLE
Remove a few copies in the queue event handler code

### DIFF
--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -225,13 +225,11 @@ jsg::Value deserialize(jsg::Lock& js, kj::Array<kj::byte> body, kj::Maybe<kj::St
   auto type = contentType.orDefault(IncomingQueueMessage::ContentType::V8);
 
   if (type == IncomingQueueMessage::ContentType::TEXT) {
-    auto str = kj::heapString(body.asChars());
-    return jsg::Value(js.v8Isolate, js.wrapString(str));
+    return jsg::Value(js.v8Isolate, jsg::v8Str(js.v8Isolate, body.asChars()));
   } else if (type == IncomingQueueMessage::ContentType::BYTES) {
     return jsg::Value(js.v8Isolate, js.wrapBytes(kj::mv(body)));
   } else if (type == IncomingQueueMessage::ContentType::JSON) {
-    auto str = kj::heapString(body.asChars());
-    return js.parseJson(str);
+    return js.parseJson(jsg::v8Str(js.v8Isolate, body.asChars()));
   } else if (type == IncomingQueueMessage::ContentType::V8) {
     return jsg::Value(js.v8Isolate, jsg::Deserializer(js.v8Isolate, kj::mv(body)).readValue());
   } else {
@@ -247,14 +245,12 @@ jsg::Value deserialize(jsg::Lock& js, rpc::QueueMessage::Reader message) {
   }
 
   if (type == IncomingQueueMessage::ContentType::TEXT) {
-    auto str = kj::heapString(message.getData().asChars());
-    return jsg::Value(js.v8Isolate, js.wrapString(str));
+    return jsg::Value(js.v8Isolate, jsg::v8Str(js.v8Isolate, message.getData().asChars()));
   } else if (type == IncomingQueueMessage::ContentType::BYTES) {
     kj::Array<kj::byte> bytes = kj::heapArray(message.getData().asBytes());
     return jsg::Value(js.v8Isolate, js.wrapBytes(kj::mv(bytes)));
   } else if (type == IncomingQueueMessage::ContentType::JSON) {
-    auto str = kj::heapString(message.getData().asChars());
-    return js.parseJson(str);
+    return js.parseJson(jsg::v8Str(js.v8Isolate, message.getData().asChars()));
   } else if (type == IncomingQueueMessage::ContentType::V8) {
     return jsg::Value(js.v8Isolate, jsg::Deserializer(js.v8Isolate, message.getData()).readValue());
   } else {

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -145,6 +145,12 @@ Value Lock::parseJson(kj::StringPtr text) {
       jsg::check(v8::JSON::Parse(v8Isolate->GetCurrentContext(), v8Str(v8Isolate, text))));
 }
 
+Value Lock::parseJson(v8::Local<v8::String> text) {
+  v8::HandleScope scope(v8Isolate);
+  return jsg::Value(v8Isolate,
+      jsg::check(v8::JSON::Parse(v8Isolate->GetCurrentContext(), text)));
+}
+
 kj::String Lock::serializeJson(v8::Local<v8::Value> value) {
   v8::HandleScope scope(v8Isolate);
   return toString(jsg::check(

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1750,6 +1750,7 @@ public:
   }
 
   Value parseJson(kj::StringPtr text);
+  Value parseJson(v8::Local<v8::String> text);
   template <typename T>
   kj::String serializeJson(V8Ref<T>& value) { return serializeJson(value.getHandle(*this)); }
   template <typename T>


### PR DESCRIPTION
Not massively important, just a fun little quick win to improve a couple copies introduced by #690 

cc @jasnell for the new `jsg::parseJson` variant