### PR TITLE
Update v8 to pull in PromiseContextScope patch

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -290,6 +290,7 @@ git_repository(
         "//:patches/v8/0008-Disable-bazel-whole-archive-build.patch",
         "//:patches/v8/0009-Make-v8-Locker-automatically-call-isolate-Enter.patch",
         "//:patches/v8/0010-Add-an-API-to-capture-and-restore-the-cage-base-poin.patch",
+        "//:patches/v8/0011-Implement-PromiseContextScope-and-promise_context_ta.patch",
     ],
 )
 

--- a/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
+++ b/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
@@ -1,4 +1,4 @@
-From ed7c34024854a8539c5640137a3a42f477d88596 Mon Sep 17 00:00:00 2001
+From 92b80a49a273eb7fc061f04da104147f500d61e9 Mon Sep 17 00:00:00 2001
 From: Alex Robinson <arobinson@cloudflare.com>
 Date: Wed, 2 Mar 2022 15:58:04 -0600
 Subject: Allow manually setting ValueDeserializer format version

--- a/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
+++ b/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
@@ -1,4 +1,4 @@
-From 97b6eeae945d630297147c6569d3ad5e0544fc00 Mon Sep 17 00:00:00 2001
+From da249e0fa0ffb5366dadceebd0bda17021cf1ae4 Mon Sep 17 00:00:00 2001
 From: James M Snell <jasnell@gmail.com>
 Date: Wed, 16 Mar 2022 08:59:21 -0700
 Subject: Allow manually setting ValueSerializer format version

--- a/patches/v8/0003-Make-icudata-target-public.patch
+++ b/patches/v8/0003-Make-icudata-target-public.patch
@@ -1,4 +1,4 @@
-From b092a30de5789ab99e5e3f222e2f195c629331eb Mon Sep 17 00:00:00 2001
+From ccb07be8597f82e005405d7a4dcb0875f9c332b9 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Sat, 17 Sep 2022 11:11:15 -0500
 Subject: Make `:icudata` target public.

--- a/patches/v8/0004-Add-ArrayBuffer-MaybeNew.patch
+++ b/patches/v8/0004-Add-ArrayBuffer-MaybeNew.patch
@@ -1,4 +1,4 @@
-From 9f9703297cc4fb282faba598721d46f7cfe604a1 Mon Sep 17 00:00:00 2001
+From 4522e54d998fb05d9011e1981362a6850a191978 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Fri, 16 Sep 2022 21:41:45 -0500
 Subject: Add `ArrayBuffer::MaybeNew()`.

--- a/patches/v8/0005-Allow-compiling-on-macOS-catalina-and-ventura.patch
+++ b/patches/v8/0005-Allow-compiling-on-macOS-catalina-and-ventura.patch
@@ -1,4 +1,4 @@
-From 69914af325585c0a41a75fe3923d371a487cbdb9 Mon Sep 17 00:00:00 2001
+From 67bae187fad4e707f87629f08435e83e62363ee6 Mon Sep 17 00:00:00 2001
 From: Dhi Aurrahman <dio@rockybars.com>
 Date: Thu, 27 Oct 2022 12:45:05 +0700
 Subject: Allow compiling on macOS catalina and ventura

--- a/patches/v8/0006-Fix-v8-code_generator-imports.patch
+++ b/patches/v8/0006-Fix-v8-code_generator-imports.patch
@@ -1,4 +1,4 @@
-From 476c6a6b8bb1cc1db9b2152e1320b4eec3103e5b Mon Sep 17 00:00:00 2001
+From b29856be12301070a95eec0dfd4d619beca02b3f Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Wed, 8 Mar 2023 16:15:31 -0500
 Subject: Fix v8 code_generator imports

--- a/patches/v8/0007-Allow-Windows-builds-under-Bazel.patch
+++ b/patches/v8/0007-Allow-Windows-builds-under-Bazel.patch
@@ -1,4 +1,4 @@
-From 28943bde4166fd83446a97da57c3b711a7e2b16f Mon Sep 17 00:00:00 2001
+From efd2250221baf6d33abbfe88d3a0d129fa6669eb Mon Sep 17 00:00:00 2001
 From: Brendan Coll <bcoll@cloudflare.com>
 Date: Thu, 16 Mar 2023 11:56:10 +0000
 Subject: Allow Windows builds under Bazel

--- a/patches/v8/0008-Disable-bazel-whole-archive-build.patch
+++ b/patches/v8/0008-Disable-bazel-whole-archive-build.patch
@@ -1,4 +1,4 @@
-From 30f97af7945ad6c417048d3e76ef384c9f811c27 Mon Sep 17 00:00:00 2001
+From 3c32329667827a0290426cf4c3066e09247aaeb6 Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Tue, 11 Apr 2023 14:41:31 -0400
 Subject: Disable bazel whole-archive build

--- a/patches/v8/0009-Make-v8-Locker-automatically-call-isolate-Enter.patch
+++ b/patches/v8/0009-Make-v8-Locker-automatically-call-isolate-Enter.patch
@@ -1,4 +1,4 @@
-From 2891c2e81b224163b9e9e0cb10cdefc1d4e60825 Mon Sep 17 00:00:00 2001
+From 067cab736e2d60aace22c66dbcff7842fd0a523e Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Tue, 23 May 2023 09:18:57 -0500
 Subject: Make v8::Locker automatically call isolate->Enter().

--- a/patches/v8/0010-Add-an-API-to-capture-and-restore-the-cage-base-poin.patch
+++ b/patches/v8/0010-Add-an-API-to-capture-and-restore-the-cage-base-poin.patch
@@ -1,4 +1,4 @@
-From 7e53b1e03b559ac80c42d7be04e277a206d2062b Mon Sep 17 00:00:00 2001
+From efcf3df0fbb0e28cbb32f75dd87c6fad5ee45aa0 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Tue, 23 May 2023 09:24:11 -0500
 Subject: Add an API to capture and restore the cage base pointers.

--- a/patches/v8/0011-Implement-PromiseContextScope-and-promise_context_ta.patch
+++ b/patches/v8/0011-Implement-PromiseContextScope-and-promise_context_ta.patch
@@ -28,7 +28,7 @@ index 1d079ac0bb1dd3921d680bcd1958da4bbc114e9e..f4fbe23e4ac6e333719a7a519a46ed18
 @@ -1635,6 +1635,8 @@ class V8_EXPORT Isolate {
     */
    void LocaleConfigurationChangeNotification();
- 
+
 +  class PromiseContextScope;
 +
    Isolate() = delete;
@@ -37,7 +37,7 @@ index 1d079ac0bb1dd3921d680bcd1958da4bbc114e9e..f4fbe23e4ac6e333719a7a519a46ed18
 @@ -1678,6 +1680,21 @@ MaybeLocal<T> Isolate::GetDataFromSnapshotOnce(size_t index) {
    return Local<T>::FromSlot(slot);
  }
- 
+
 +class Isolate::PromiseContextScope {
 +public:
 +  explicit PromiseContextScope(Isolate* v8_isolate, int32_t tag);
@@ -54,7 +54,7 @@ index 1d079ac0bb1dd3921d680bcd1958da4bbc114e9e..f4fbe23e4ac6e333719a7a519a46ed18
 +};
 +
  }  // namespace v8
- 
+
  #endif  // INCLUDE_V8_ISOLATE_H_
 diff --git a/src/api/api.cc b/src/api/api.cc
 index bddda91dbb07500eac71274fe859603a416821b8..90d76b2f46398fd501532f5d43598536590b69a3 100644
@@ -63,35 +63,35 @@ index bddda91dbb07500eac71274fe859603a416821b8..90d76b2f46398fd501532f5d43598536
 @@ -11610,6 +11610,18 @@ std::string SourceLocation::ToString() const {
    return std::string(function_) + "@" + file_ + ":" + std::to_string(line_);
  }
- 
+
 +Isolate::PromiseContextScope::PromiseContextScope(Isolate* v8_isolate, int32_t tag)
 +    : i_isolate_(reinterpret_cast<i::Isolate*>(v8_isolate)),
 +      current_tag_(tag),
 +      previous_tag_(i_isolate_->promise_context_tag()) {
-+  DCHECK_EQ(previous_tag_, 0);
++  CHECK_EQ(previous_tag_, 0);
 +  i_isolate_->set_promise_context_tag(tag);
 +}
 +
 +Isolate::PromiseContextScope::~PromiseContextScope() {
-+  DCHECK_EQ(i_isolate_->promise_context_tag(), (int32_t)current_tag_);  i_isolate_->set_promise_context_tag(previous_tag_);
++  CHECK_EQ(i_isolate_->promise_context_tag(), (int32_t)current_tag_);  i_isolate_->set_promise_context_tag(previous_tag_);
 +}
 +
  }  // namespace v8
- 
+
  #include "src/api/api-macros-undef.h"
 diff --git a/src/builtins/promise-abstract-operations.tq b/src/builtins/promise-abstract-operations.tq
 index 2e2dd0e1ef71e9a7c2e2ca6bea3cb5d551f6ed4e..d88a930204511fd4d5cc071cf385674c84b7182c 100644
 --- a/src/builtins/promise-abstract-operations.tq
 +++ b/src/builtins/promise-abstract-operations.tq
 @@ -20,6 +20,9 @@ PromiseResolveAfterResolved(implicit context: Context)(JSPromise, JSAny): JSAny;
- 
+
  extern transitioning runtime
  PromiseRejectEventFromStack(implicit context: Context)(JSPromise, JSAny): JSAny;
 +
 +extern transitioning runtime
 +PromiseContextCheck(implicit context: Context)(Object): JSAny;
  }
- 
+
  // https://tc39.es/ecma262/#sec-promise-abstract-operations
 @@ -451,6 +454,7 @@ transitioning macro PerformPromiseThenImpl(implicit context: Context)(
      // PromiseReaction holding both the onFulfilled and onRejected callbacks.
@@ -106,14 +106,14 @@ index b502eabf05f614ed58c058487e3117fea68973bd..e9277f72e5ded2564df34dcfb5dd7ed9
 --- a/src/builtins/promise-constructor.tq
 +++ b/src/builtins/promise-constructor.tq
 @@ -14,6 +14,9 @@ DebugPopPromise(implicit context: Context)(): JSAny;
- 
+
  extern transitioning runtime
  PromiseHookInit(implicit context: Context)(Object, Object): JSAny;
 +
 +extern transitioning runtime
 +PromiseContextInit(implicit context: Context)(Object): JSAny;
  }
- 
+
  // https://tc39.es/ecma262/#sec-promise-constructor
 @@ -74,6 +77,7 @@ PromiseConstructor(
      result = UnsafeCast<JSPromise>(
@@ -122,7 +122,7 @@ index b502eabf05f614ed58c058487e3117fea68973bd..e9277f72e5ded2564df34dcfb5dd7ed9
 +    PromiseContextInit(result);
      RunAnyPromiseHookInit(result, Undefined);
    }
- 
+
 diff --git a/src/builtins/promise-misc.tq b/src/builtins/promise-misc.tq
 index 199fc313193e82d149a9f389a12081bf1110a105..31ce2e11ffbb3554c4ce7fd136c23e22de582767 100644
 --- a/src/builtins/promise-misc.tq
@@ -146,7 +146,7 @@ index 199fc313193e82d149a9f389a12081bf1110a105..31ce2e11ffbb3554c4ce7fd136c23e22
 @@ -217,6 +219,11 @@ transitioning macro RunContextPromiseHook(implicit context: Context)(
    }
  }
- 
+
 +transitioning macro PromiseContextInit(implicit context: Context)(
 +    promise: JSPromise): void {
 +  runtime::PromiseContextInit(promise);
@@ -186,7 +186,7 @@ index cdf8e309e6213193e63a12fb66f14b1b78f03afe..fad55cb80f1cbf6a40c512095180e93f
 +  /* request. */                                                               \
 +  T(PromiseContextTagMismatch,                                                 \
 +      "Cannot await a promise from a different request")
- 
+
  enum class MessageTemplate {
  #define TEMPLATE(NAME, STRING) k##NAME,
 diff --git a/src/compiler/js-create-lowering.cc b/src/compiler/js-create-lowering.cc
@@ -217,11 +217,11 @@ index 40d1b394ef30c7cdf1d5aa05a051d3a497abf28e..64b3130c52bcebd3a1320c130dce7650
 +      promise_context_tag_(0) {
    TRACE_ISOLATE(constructor);
    CheckIsolateLayout();
- 
+
 @@ -6208,5 +6209,11 @@ void DefaultWasmAsyncResolvePromiseCallback(
    CHECK(ret.IsJust() ? ret.FromJust() : isolate->IsExecutionTerminating());
  }
- 
+
 +int32_t Isolate::promise_context_tag() { return promise_context_tag_; }
 +
 +void Isolate::set_promise_context_tag(int32_t tag) {
@@ -235,9 +235,9 @@ index 5a0972dee86aa993c2526a4f9596af12eeaf647d..1d5eeb3729f573303e2ae91e2b7fa6dc
 --- a/src/execution/isolate.h
 +++ b/src/execution/isolate.h
 @@ -2052,6 +2052,9 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
- 
+
    void VerifyStaticRoots();
- 
+
 +  int32_t promise_context_tag();
 +  void set_promise_context_tag(int32_t tag);
 +
@@ -247,7 +247,7 @@ index 5a0972dee86aa993c2526a4f9596af12eeaf647d..1d5eeb3729f573303e2ae91e2b7fa6dc
 @@ -2509,6 +2512,8 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
    SimulatorData* simulator_data_ = nullptr;
  #endif
- 
+
 +  int32_t promise_context_tag_ = 0;
 +
    friend class heap::HeapTester;
@@ -275,7 +275,7 @@ index 25c7e1f76c72996eb1d8fb3d93cbfc06f4f41bf3..4a68e642eb64a506688bd4d68b685658
    flags: SmiTagged<JSPromiseFlags>;
 +  context_tag: Smi;
  }
- 
+
  @doNotGenerateCast
 diff --git a/src/runtime/runtime-promise.cc b/src/runtime/runtime-promise.cc
 index 5fa806068b5185b7293a5d00d50da26f5cdcb1a9..350f1ece5affb0091a8f33b4a7e64137589809c8 100644
@@ -284,7 +284,7 @@ index 5fa806068b5185b7293a5d00d50da26f5cdcb1a9..350f1ece5affb0091a8f33b4a7e64137
 @@ -216,5 +216,24 @@ RUNTIME_FUNCTION(Runtime_ConstructInternalAggregateErrorHelper) {
    return *result;
  }
- 
+
 +RUNTIME_FUNCTION(Runtime_PromiseContextInit) {
 +  HandleScope scope(isolate);
 +  DCHECK_EQ(1, args.length());
@@ -318,6 +318,6 @@ index e11c08398c50c1978270d8a181c7c5cf27d77fff..453e34803e8639777885cdcba3f1df95
 +  F(ConstructInternalAggregateErrorHelper, -1 /* <= 5*/, 1) \
 +  F(PromiseContextInit, 1, 1) \
 +  F(PromiseContextCheck, 1, 1)
- 
+
  #define FOR_EACH_INTRINSIC_PROXY(F, I) \
    F(CheckProxyGetSetTrapResult, 2, 1)  \

--- a/patches/v8/0011-Implement-PromiseContextScope-and-promise_context_ta.patch
+++ b/patches/v8/0011-Implement-PromiseContextScope-and-promise_context_ta.patch
@@ -1,0 +1,323 @@
+From 1b1fef9e8a209cdac74b93900d7223416c2eb686 Mon Sep 17 00:00:00 2001
+From: James M Snell <jasnell@gmail.com>
+Date: Wed, 14 Jun 2023 12:45:50 -0700
+Subject: Implement PromiseContextScope and promise_context_tag
+
+Allows optional detection of promises created and waited on within
+different context scopes.
+---
+ include/v8-isolate.h                        | 17 +++++++++++++++++
+ src/api/api.cc                              | 12 ++++++++++++
+ src/builtins/promise-abstract-operations.tq |  4 ++++
+ src/builtins/promise-constructor.tq         |  4 ++++
+ src/builtins/promise-misc.tq                |  9 +++++++++
+ src/common/message-template.h               |  7 ++++++-
+ src/compiler/js-create-lowering.cc          |  4 +++-
+ src/execution/isolate.cc                    |  9 ++++++++-
+ src/execution/isolate.h                     |  5 +++++
+ src/heap/factory.cc                         |  1 +
+ src/objects/js-promise.tq                   |  1 +
+ src/runtime/runtime-promise.cc              | 19 +++++++++++++++++++
+ src/runtime/runtime.h                       |  4 +++-
+ 13 files changed, 92 insertions(+), 4 deletions(-)
+
+diff --git a/include/v8-isolate.h b/include/v8-isolate.h
+index 1d079ac0bb1dd3921d680bcd1958da4bbc114e9e..f4fbe23e4ac6e333719a7a519a46ed184d36318d 100644
+--- a/include/v8-isolate.h
++++ b/include/v8-isolate.h
+@@ -1635,6 +1635,8 @@ class V8_EXPORT Isolate {
+    */
+   void LocaleConfigurationChangeNotification();
+ 
++  class PromiseContextScope;
++
+   Isolate() = delete;
+   ~Isolate() = delete;
+   Isolate(const Isolate&) = delete;
+@@ -1678,6 +1680,21 @@ MaybeLocal<T> Isolate::GetDataFromSnapshotOnce(size_t index) {
+   return Local<T>::FromSlot(slot);
+ }
+ 
++class Isolate::PromiseContextScope {
++public:
++  explicit PromiseContextScope(Isolate* v8_isolate, int32_t tag);
++  PromiseContextScope(const PromiseContextScope&) = delete;
++  PromiseContextScope(PromiseContextScope&&) = delete;
++  PromiseContextScope& operator=(const PromiseContextScope&) = delete;
++  PromiseContextScope& operator=(PromiseContextScope&&) = delete;
++  ~PromiseContextScope();
++
++private:
++  internal::Isolate* i_isolate_;
++  int32_t current_tag_;
++  int32_t previous_tag_ = 0;
++};
++
+ }  // namespace v8
+ 
+ #endif  // INCLUDE_V8_ISOLATE_H_
+diff --git a/src/api/api.cc b/src/api/api.cc
+index bddda91dbb07500eac71274fe859603a416821b8..90d76b2f46398fd501532f5d43598536590b69a3 100644
+--- a/src/api/api.cc
++++ b/src/api/api.cc
+@@ -11610,6 +11610,18 @@ std::string SourceLocation::ToString() const {
+   return std::string(function_) + "@" + file_ + ":" + std::to_string(line_);
+ }
+ 
++Isolate::PromiseContextScope::PromiseContextScope(Isolate* v8_isolate, int32_t tag)
++    : i_isolate_(reinterpret_cast<i::Isolate*>(v8_isolate)),
++      current_tag_(tag),
++      previous_tag_(i_isolate_->promise_context_tag()) {
++  DCHECK_EQ(previous_tag_, 0);
++  i_isolate_->set_promise_context_tag(tag);
++}
++
++Isolate::PromiseContextScope::~PromiseContextScope() {
++  DCHECK_EQ(i_isolate_->promise_context_tag(), (int32_t)current_tag_);  i_isolate_->set_promise_context_tag(previous_tag_);
++}
++
+ }  // namespace v8
+ 
+ #include "src/api/api-macros-undef.h"
+diff --git a/src/builtins/promise-abstract-operations.tq b/src/builtins/promise-abstract-operations.tq
+index 2e2dd0e1ef71e9a7c2e2ca6bea3cb5d551f6ed4e..d88a930204511fd4d5cc071cf385674c84b7182c 100644
+--- a/src/builtins/promise-abstract-operations.tq
++++ b/src/builtins/promise-abstract-operations.tq
+@@ -20,6 +20,9 @@ PromiseResolveAfterResolved(implicit context: Context)(JSPromise, JSAny): JSAny;
+ 
+ extern transitioning runtime
+ PromiseRejectEventFromStack(implicit context: Context)(JSPromise, JSAny): JSAny;
++
++extern transitioning runtime
++PromiseContextCheck(implicit context: Context)(Object): JSAny;
+ }
+ 
+ // https://tc39.es/ecma262/#sec-promise-abstract-operations
+@@ -451,6 +454,7 @@ transitioning macro PerformPromiseThenImpl(implicit context: Context)(
+     // PromiseReaction holding both the onFulfilled and onRejected callbacks.
+     // Once the {promise} is resolved we decide on the concrete handler to
+     // push onto the microtask queue.
++    runtime::PromiseContextCheck(promise);
+     const handlerContext = ExtractHandlerContext(onFulfilled, onRejected);
+     const promiseReactions =
+         UnsafeCast<(Zero | PromiseReaction)>(promise.reactions_or_result);
+diff --git a/src/builtins/promise-constructor.tq b/src/builtins/promise-constructor.tq
+index b502eabf05f614ed58c058487e3117fea68973bd..e9277f72e5ded2564df34dcfb5dd7ed9f51b9c69 100644
+--- a/src/builtins/promise-constructor.tq
++++ b/src/builtins/promise-constructor.tq
+@@ -14,6 +14,9 @@ DebugPopPromise(implicit context: Context)(): JSAny;
+ 
+ extern transitioning runtime
+ PromiseHookInit(implicit context: Context)(Object, Object): JSAny;
++
++extern transitioning runtime
++PromiseContextInit(implicit context: Context)(Object): JSAny;
+ }
+ 
+ // https://tc39.es/ecma262/#sec-promise-constructor
+@@ -74,6 +77,7 @@ PromiseConstructor(
+     result = UnsafeCast<JSPromise>(
+         FastNewObject(context, promiseFun, UnsafeCast<JSReceiver>(newTarget)));
+     PromiseInit(result);
++    PromiseContextInit(result);
+     RunAnyPromiseHookInit(result, Undefined);
+   }
+ 
+diff --git a/src/builtins/promise-misc.tq b/src/builtins/promise-misc.tq
+index 199fc313193e82d149a9f389a12081bf1110a105..31ce2e11ffbb3554c4ce7fd136c23e22de582767 100644
+--- a/src/builtins/promise-misc.tq
++++ b/src/builtins/promise-misc.tq
+@@ -42,6 +42,7 @@ macro PromiseHasHandler(promise: JSPromise): bool {
+ @export
+ macro PromiseInit(promise: JSPromise): void {
+   promise.reactions_or_result = kZero;
++  promise.context_tag = 0;
+   promise.flags = SmiTag(JSPromiseFlags{
+     status: PromiseState::kPending,
+     has_handler: false,
+@@ -62,6 +63,7 @@ macro InnerNewJSPromise(implicit context: Context)(): JSPromise {
+   promise.properties_or_hash = kEmptyFixedArray;
+   promise.elements = kEmptyFixedArray;
+   promise.reactions_or_result = kZero;
++  promise.context_tag = 0;
+   promise.flags = SmiTag(JSPromiseFlags{
+     status: PromiseState::kPending,
+     has_handler: false,
+@@ -217,6 +219,11 @@ transitioning macro RunContextPromiseHook(implicit context: Context)(
+   }
+ }
+ 
++transitioning macro PromiseContextInit(implicit context: Context)(
++    promise: JSPromise): void {
++  runtime::PromiseContextInit(promise);
++}
++
+ transitioning macro RunAnyPromiseHookInit(implicit context: Context)(
+     promise: JSPromise, parent: Object): void {
+   const promiseHookFlags = PromiseHookFlags();
+@@ -242,6 +249,7 @@ transitioning macro NewJSPromise(implicit context: Context)(parent: Object):
+     JSPromise {
+   const instance = InnerNewJSPromise();
+   PromiseInit(instance);
++  PromiseContextInit(instance);
+   RunAnyPromiseHookInit(instance, parent);
+   return instance;
+ }
+@@ -264,6 +272,7 @@ transitioning macro NewJSPromise(implicit context: Context)(
+   instance.reactions_or_result = result;
+   instance.SetStatus(status);
+   promise_internal::ZeroOutEmbedderOffsets(instance);
++  PromiseContextInit(instance);
+   RunAnyPromiseHookInit(instance, Undefined);
+   return instance;
+ }
+diff --git a/src/common/message-template.h b/src/common/message-template.h
+index cdf8e309e6213193e63a12fb66f14b1b78f03afe..fad55cb80f1cbf6a40c512095180e93f0dc3b120 100644
+--- a/src/common/message-template.h
++++ b/src/common/message-template.h
+@@ -716,7 +716,12 @@ namespace internal {
+   /* AggregateError */                                                         \
+   T(AllPromisesRejected, "All promises were rejected")                         \
+   T(CannotDeepFreezeObject, "Cannot DeepFreeze object of type %")              \
+-  T(CannotDeepFreezeValue, "Cannot DeepFreeze non-const value %")
++  T(CannotDeepFreezeValue, "Cannot DeepFreeze non-const value %")              \
++  /* PromiseContextTagMismatch is a Cloudflare-specific error used to */       \
++  /* indicate that an attempt was made to wait on a promise from a different */\
++  /* request. */                                                               \
++  T(PromiseContextTagMismatch,                                                 \
++      "Cannot await a promise from a different request")
+ 
+ enum class MessageTemplate {
+ #define TEMPLATE(NAME, STRING) k##NAME,
+diff --git a/src/compiler/js-create-lowering.cc b/src/compiler/js-create-lowering.cc
+index 335a66d9e78bcacb2e470ad4bfbdd870b3986df3..eb87ef9984e1896cb87078a19127d913b23b2adb 100644
+--- a/src/compiler/js-create-lowering.cc
++++ b/src/compiler/js-create-lowering.cc
+@@ -1081,7 +1081,9 @@ Reduction JSCreateLowering::ReduceJSCreatePromise(Node* node) {
+   static_assert(v8::Promise::kPending == 0);
+   a.Store(AccessBuilder::ForJSObjectOffset(JSPromise::kFlagsOffset),
+           jsgraph()->ZeroConstant());
+-  static_assert(JSPromise::kHeaderSize == 5 * kTaggedSize);
++  a.Store(AccessBuilder::ForJSObjectOffset(JSPromise::kContextTagOffset),
++          jsgraph()->ZeroConstant());
++  static_assert(JSPromise::kHeaderSize == 6 * kTaggedSize);
+   for (int offset = JSPromise::kHeaderSize;
+        offset < JSPromise::kSizeWithEmbedderFields; offset += kTaggedSize) {
+     a.Store(AccessBuilder::ForJSObjectOffset(offset),
+diff --git a/src/execution/isolate.cc b/src/execution/isolate.cc
+index 40d1b394ef30c7cdf1d5aa05a051d3a497abf28e..64b3130c52bcebd3a1320c130dce7650c070a791 100644
+--- a/src/execution/isolate.cc
++++ b/src/execution/isolate.cc
+@@ -3433,7 +3433,8 @@ Isolate::Isolate(std::unique_ptr<i::IsolateAllocator> isolate_allocator)
+ #endif
+       next_module_async_evaluating_ordinal_(
+           SourceTextModule::kFirstAsyncEvaluatingOrdinal),
+-      cancelable_task_manager_(new CancelableTaskManager()) {
++      cancelable_task_manager_(new CancelableTaskManager()),
++      promise_context_tag_(0) {
+   TRACE_ISOLATE(constructor);
+   CheckIsolateLayout();
+ 
+@@ -6208,5 +6209,11 @@ void DefaultWasmAsyncResolvePromiseCallback(
+   CHECK(ret.IsJust() ? ret.FromJust() : isolate->IsExecutionTerminating());
+ }
+ 
++int32_t Isolate::promise_context_tag() { return promise_context_tag_; }
++
++void Isolate::set_promise_context_tag(int32_t tag) {
++  promise_context_tag_ = tag;
++}
++
+ }  // namespace internal
+ }  // namespace v8
+diff --git a/src/execution/isolate.h b/src/execution/isolate.h
+index 5a0972dee86aa993c2526a4f9596af12eeaf647d..1d5eeb3729f573303e2ae91e2b7fa6dc67e9193d 100644
+--- a/src/execution/isolate.h
++++ b/src/execution/isolate.h
+@@ -2052,6 +2052,9 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
+ 
+   void VerifyStaticRoots();
+ 
++  int32_t promise_context_tag();
++  void set_promise_context_tag(int32_t tag);
++
+  private:
+   explicit Isolate(std::unique_ptr<IsolateAllocator> isolate_allocator);
+   ~Isolate();
+@@ -2509,6 +2512,8 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
+   SimulatorData* simulator_data_ = nullptr;
+ #endif
+ 
++  int32_t promise_context_tag_ = 0;
++
+   friend class heap::HeapTester;
+   friend class GlobalSafepoint;
+   friend class TestSerializer;
+diff --git a/src/heap/factory.cc b/src/heap/factory.cc
+index 16bbb62bf9dd97d112c6b55dd338d7ab1709aade..4f6bc2d9e34fbda2085d585728cdf40900a0ef72 100644
+--- a/src/heap/factory.cc
++++ b/src/heap/factory.cc
+@@ -4019,6 +4019,7 @@ Handle<JSPromise> Factory::NewJSPromiseWithoutHook() {
+   JSPromise raw = *promise;
+   raw.set_reactions_or_result(Smi::zero(), SKIP_WRITE_BARRIER);
+   raw.set_flags(0);
++  raw.set_context_tag(isolate()->promise_context_tag());
+   // TODO(v8) remove once embedder data slots are always zero-initialized.
+   InitEmbedderFields(*promise, Smi::zero());
+   DCHECK_EQ(raw.GetEmbedderFieldCount(), v8::Promise::kEmbedderFieldCount);
+diff --git a/src/objects/js-promise.tq b/src/objects/js-promise.tq
+index 25c7e1f76c72996eb1d8fb3d93cbfc06f4f41bf3..4a68e642eb64a506688bd4d68b6856584b01b537 100644
+--- a/src/objects/js-promise.tq
++++ b/src/objects/js-promise.tq
+@@ -34,6 +34,7 @@ extern class JSPromise extends JSObjectWithEmbedderSlots {
+   // not settled yet, otherwise the result.
+   reactions_or_result: Zero|PromiseReaction|JSAny;
+   flags: SmiTagged<JSPromiseFlags>;
++  context_tag: Smi;
+ }
+ 
+ @doNotGenerateCast
+diff --git a/src/runtime/runtime-promise.cc b/src/runtime/runtime-promise.cc
+index 5fa806068b5185b7293a5d00d50da26f5cdcb1a9..350f1ece5affb0091a8f33b4a7e64137589809c8 100644
+--- a/src/runtime/runtime-promise.cc
++++ b/src/runtime/runtime-promise.cc
+@@ -216,5 +216,24 @@ RUNTIME_FUNCTION(Runtime_ConstructInternalAggregateErrorHelper) {
+   return *result;
+ }
+ 
++RUNTIME_FUNCTION(Runtime_PromiseContextInit) {
++  HandleScope scope(isolate);
++  DCHECK_EQ(1, args.length());
++  args.at<JSPromise>(0)->set_context_tag(isolate->promise_context_tag());
++  return ReadOnlyRoots(isolate).undefined_value();
++}
++
++RUNTIME_FUNCTION(Runtime_PromiseContextCheck) {
++  HandleScope scope(isolate);
++  DCHECK_EQ(1, args.length());
++  int32_t promise_tag = args.at<JSPromise>(0)->context_tag();
++  // We only do the comparison if the promise_tag is not zero.
++  if (promise_tag != 0 && promise_tag != isolate->promise_context_tag()) {
++    THROW_NEW_ERROR_RETURN_FAILURE(isolate, NewError(
++        MessageTemplate::kPromiseContextTagMismatch));
++  }
++  return ReadOnlyRoots(isolate).undefined_value();
++}
++
+ }  // namespace internal
+ }  // namespace v8
+diff --git a/src/runtime/runtime.h b/src/runtime/runtime.h
+index e11c08398c50c1978270d8a181c7c5cf27d77fff..453e34803e8639777885cdcba3f1df9525c2daac 100644
+--- a/src/runtime/runtime.h
++++ b/src/runtime/runtime.h
+@@ -399,7 +399,9 @@ namespace internal {
+   F(PromiseRejectAfterResolved, 2, 1)    \
+   F(PromiseResolveAfterResolved, 2, 1)   \
+   F(ConstructAggregateErrorHelper, 4, 1) \
+-  F(ConstructInternalAggregateErrorHelper, -1 /* <= 5*/, 1)
++  F(ConstructInternalAggregateErrorHelper, -1 /* <= 5*/, 1) \
++  F(PromiseContextInit, 1, 1) \
++  F(PromiseContextCheck, 1, 1)
+ 
+ #define FOR_EACH_INTRINSIC_PROXY(F, I) \
+   F(CheckProxyGetSetTrapResult, 2, 1)  \

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -853,6 +853,8 @@ public:
   inline jsg::AsyncContextFrame::StorageKey& getRequestIdKey() { return *requestIdKey; }
   jsg::AsyncContextFrame::StorageScope makeRequestIdStorageScope(jsg::Lock& js);
 
+  inline int32_t getPromiseContextTag() const { return promiseContextTag;  }
+
 private:
   ThreadContext& thread;
 
@@ -1060,6 +1062,7 @@ private:
 
   kj::String requestId;
   kj::Own<jsg::AsyncContextFrame::StorageKey> requestIdKey;
+  int32_t promiseContextTag;
 
   class ThreadScope;
   class Scope;

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -136,6 +136,8 @@ public:
     bool released = false;
   };
 
+  int32_t getNextPromiseContextTag() const;
+
 private:
   kj::Own<const Script> script;
 


### PR DESCRIPTION
Adds a mechanism to v8 to allow us to reliably detect when a request waits on a promise created within another request, resulting in a catchable error thrown at the point of await rather than later when the cross request I/O violation is detected.

The mechanism here works by patching v8's `JSPromise` built-in to include a new `context_tag`... an int32 in the valid Smi range, then whenever a promise continuation is scheduled (either via await or then, etc) the `context_tag` is checked to ensure that it matches the current tag for the isolate.

The isolate's current tag value is established using a new `v8::Isolate::PromiseContextScope` that is created when we enter the `IoContext::Scope` and exited when that `IoContext::Scope` is exited.
