### PR TITLE
srs: allowlist table_xinfo

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -154,13 +154,18 @@ async function test(storage) {
   requireException(() => sql.exec("PRAGMA page_size = 8192"),
     "not authorized");
 
-  // PRAGMA table_info is allowed.
+  // PRAGMA table_info and PRAGMA table_xinfo are allowed.
   sql.exec("CREATE TABLE myTable (foo TEXT, bar INTEGER)");
   {
     let info = [...sql.exec("PRAGMA table_info(myTable)")];
     assert.equal(info.length, 2);
     assert.equal(info[0].name, "foo");
     assert.equal(info[1].name, "bar");
+
+    let xInfo = [...sql.exec("PRAGMA table_xinfo(myTable)")];
+    assert.equal(xInfo.length, 2);
+    assert.equal(xInfo[0].name, "foo");
+    assert.equal(xInfo[1].name, "bar");
   }
 
   // Can't get table_info for _cf_KV.

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -528,7 +528,7 @@ bool SqliteDatabase::isAuthorized(int actionCode,
           // TODO function_list & pragma_list should be authorized but return
           // ALLOWED_SQLITE_FUNCTIONS & ALLOWED_[READ|WRITE]_PRAGMAS
           // respectively
-        } else if (pragma == "table_info") {
+        } else if (pragma == "table_info" || pragma == "table_xinfo") {
           // Allow if the specific named table is not protected.
           KJ_IF_MAYBE (name, param2) {
             return regulator.isAllowedName(*name);


### PR DESCRIPTION
This PR:

* Allowlists `table_xinfo` (https://www.sqlite.org/pragma.html#pragma_table_xinfo) - which shows generated columns (https://github.com/cloudflare/cloudflare-docs/pull/9420) that `table_info` does not.
* Expands an existing test to ensure `table_xinfo` works.