### PR TITLE
Implement Node.js compat process.env

### DIFF
--- a/samples/nodejs-compat-module/foo.js
+++ b/samples/nodejs-compat-module/foo.js
@@ -1,4 +1,8 @@
 // process is a global in Node.js so comes as a global for nodeJsCompatModules.
+
+process.env.FOO = 1;
+console.log(process.env.FOO);
+
 process.nextTick(() => {
   console.log('this should work', __filename, __dirname, module.path);
 });

--- a/src/node/internal/process.ts
+++ b/src/node/internal/process.ts
@@ -8,10 +8,61 @@
 // queue.
 /* eslint-disable */
 
+import {
+  validateObject,
+} from 'node-internal:validators';
+
+import {
+  ERR_INVALID_ARG_VALUE,
+} from 'node-internal:internal_errors'
+
 export function nextTick(cb: Function, ...args: unknown[]) {
   queueMicrotask(() => { cb(...args); });
 };
 
+// Note that there is no process-level environment in workers so the process.env
+// object is initially empty. This is different from Node.js where process.env
+// picks up values from the operating system environment. The configured bindings
+// for the worker are accessible from the env argument passed into the fetch
+// handler and have no impact here.
+
+export const env = new Proxy({}, {
+  // Per Node.js rules. process.env values must be coerced to strings.
+  // When defined using defineProperty, the property descriptor must be writable,
+  // configurable, and enumerable using just a falsy check. Getters and setters
+  // are not permitted.
+  set(obj: object, prop: PropertyKey, value: any) {
+    return Reflect.set(obj, prop, `${value}`);
+  },
+  defineProperty(obj: object, prop: PropertyKey, descriptor: PropertyDescriptor) {
+    validateObject(descriptor, 'descriptor', {});
+    if (Reflect.has(descriptor, 'get') || Reflect.has(descriptor, 'set')) {
+      throw new ERR_INVALID_ARG_VALUE('descriptor', descriptor,
+        'process.env value must not have getter/setter');
+    }
+    if (!descriptor.configurable) {
+      throw new ERR_INVALID_ARG_VALUE('descriptor.configurable', descriptor,
+        'process.env value must be configurable')
+    }
+    if (!descriptor.enumerable) {
+      throw new ERR_INVALID_ARG_VALUE('descriptor.enumerable', descriptor,
+        'process.env value must be enumerable')
+    }
+    if (!descriptor.writable) {
+      throw new ERR_INVALID_ARG_VALUE('descriptor.writable', descriptor,
+        'process.env value must be writable')
+    }
+    if (Reflect.has(descriptor, 'value')) {
+      Reflect.set(descriptor, 'value', `${descriptor.value}`);
+    } else {
+      throw new ERR_INVALID_ARG_VALUE('descriptor.value', descriptor,
+        'process.env value must be specified explicitly');
+    }
+    return Reflect.defineProperty(obj, prop, descriptor);
+  }
+});
+
 export default {
   nextTick,
+  env,
 };


### PR DESCRIPTION
Exposes text bindings from the worker via process.env

Requires internal changes and CI also.