### PR TITLE
Implement node.js compat diagnostics_channel

### DIFF
--- a/samples/nodejs-compat-diagnosticschannel/README.md
+++ b/samples/nodejs-compat-diagnosticschannel/README.md
@@ -1,0 +1,28 @@
+# Node.js Compat Example
+
+To run the example on http://localhost:8080
+
+```sh
+$ ./workerd serve config.capnp
+```
+
+To run using bazel
+
+```sh
+$ bazel run //src/workerd/server:workerd -- serve ~/cloudflare/workerd/samples/nodejs-compat/config.capnp
+```
+
+To create a standalone binary that can be run:
+
+```sh
+$ ./workerd compile config.capnp > nodejs-compat
+
+$ ./nodejs-compat
+```
+
+To test:
+
+```sh
+% curl http://localhost:8080
+Hello World
+```

--- a/samples/nodejs-compat-diagnosticschannel/config.capnp
+++ b/samples/nodejs-compat-diagnosticschannel/config.capnp
@@ -1,0 +1,36 @@
+# Imports the base schema for workerd configuration files.
+
+# Refer to the comments in /src/workerd/server/workerd.capnp for more details.
+
+using Workerd = import "/workerd/workerd.capnp";
+
+# A constant of type Workerd.Config defines the top-level configuration for an
+# instance of the workerd runtime. A single config file can contain multiple
+# Workerd.Config definitions and must have at least one.
+const helloWorldExample :Workerd.Config = (
+
+  # Every workerd instance consists of a set of named services. A worker, for instance,
+  # is a type of service. Other types of services can include external servers, the
+  # ability to talk to a network, or accessing a disk directory. Here we create a single
+  # worker service. The configuration details for the worker are defined below.
+  services = [ (name = "main", worker = .helloWorld) ],
+
+  # Every configuration defines the one or more sockets on which the server will listene.
+  # Here, we create a single socket that will listen on localhost port 8080, and will
+  # dispatch to the "main" service that we defined above.
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ]
+);
+
+# The definition of the actual helloWorld worker exposed using the "main" service.
+# In this example the worker is implemented as a single simple script (see worker.js).
+# The compatibilityDate is required. For more details on compatibility dates see:
+#   https://developers.cloudflare.com/workers/platform/compatibility-dates/
+
+const helloWorld :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js"),
+    (name = "library", esModule = embed "library.js"),
+  ],
+  compatibilityDate = "2023-02-28",
+  compatibilityFlags = ["nodejs_compat"]
+);

--- a/samples/nodejs-compat-diagnosticschannel/library.js
+++ b/samples/nodejs-compat-diagnosticschannel/library.js
@@ -1,0 +1,7 @@
+import { channel } from "node:diagnostics_channel";
+
+const theChannel = channel('test');
+
+export function doSomething() {
+  theChannel.publish('Hello from worker!');
+}

--- a/samples/nodejs-compat-diagnosticschannel/worker.js
+++ b/samples/nodejs-compat-diagnosticschannel/worker.js
@@ -1,0 +1,46 @@
+import {
+  subscribe,
+  channel,
+  tracingChannel,
+  Channel,
+} from "node:diagnostics_channel";
+import { doSomething } from "library";
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+// The library will send a diagnostic message when the doSomething
+// method is called. We listen for that event here. When using
+// Tail Workers, the event will also be included in the tail events.
+subscribe('test', (message) => {
+  console.log('Diagnostic message received:', message);
+});
+
+const als1 = new AsyncLocalStorage();
+const als2 = new AsyncLocalStorage();
+const c = channel('bar');
+c.bindStore(als1);
+c.bindStore(als2, (data) => {return { data }});
+
+const tc = tracingChannel('foo');
+tc.start.bindStore(als1);
+tc.start.subscribe(() => console.log('start', als1.getStore()));
+tc.end.subscribe(() => console.log('end'));
+tc.asyncStart.subscribe(() => console.log('async start'));
+tc.asyncEnd.subscribe(() => console.log('async end'));
+
+export default {
+  async fetch(request) {
+    doSomething();
+
+    console.log(c.runStores(1, (...args) => {
+      console.log(this, ...args, als1.getStore(), als2.getStore());
+      return 1;
+    }, {}, 1, 2, 3));
+
+    await tc.tracePromise(async function() {
+      console.log('....', this);
+    }, {a:1});
+
+    return new Response("ok");
+  }
+};

--- a/src/node/diagnostics_channel.ts
+++ b/src/node/diagnostics_channel.ts
@@ -1,0 +1,269 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* eslint-disable */
+import {
+  default as diagnosticsChannel,
+} from 'node-internal:diagnostics_channel';
+
+import type {
+  Channel as ChannelType,
+  MessageCallback,
+} from 'node-internal:diagnostics_channel';
+
+import {
+  ERR_INVALID_ARG_TYPE,
+} from 'node-internal:internal_errors';
+
+import {
+  validateObject,
+} from 'node-internal:validators';
+
+export const { Channel } = diagnosticsChannel;
+
+export function hasSubscribers(name: string|symbol): boolean {
+  return diagnosticsChannel.hasSubscribers(name);
+}
+
+export function channel(name: string|symbol): ChannelType {
+  return diagnosticsChannel.channel(name);
+}
+
+export function subscribe(name: string|symbol, callback: MessageCallback): void {
+  diagnosticsChannel.subscribe(name, callback);
+}
+
+export function unsubscribe(name: string|symbol, callback: MessageCallback): void {
+  diagnosticsChannel.unsubscribe(name, callback);
+}
+
+export interface TracingChannelSubscriptions {
+  start?: MessageCallback;
+  end?: MessageCallback;
+  asyncStart?: MessageCallback;
+  asyncEnd?: MessageCallback;
+  error?: MessageCallback;
+}
+
+export interface TracingChannels {
+  start: ChannelType,
+  end: ChannelType,
+  asyncStart: ChannelType,
+  asyncEnd: ChannelType,
+  error: ChannelType,
+}
+
+const kStart = Symbol('kStart');
+const kEnd = Symbol('kEnd');
+const kAsyncStart = Symbol('kAsyncStart');
+const kAsyncEnd = Symbol('kAsyncEnd');
+const kError = Symbol('kError');
+
+export class TracingChannel {
+  private [kStart]?: ChannelType;
+  private [kEnd]?: ChannelType;
+  private [kAsyncStart]?: ChannelType;
+  private [kAsyncEnd]?: ChannelType;
+  private [kError]?: ChannelType;
+
+  public constructor() {
+    throw new Error('Use diagnostic_channel.tracingChannels() to create TracingChannel');
+  }
+
+  public get start(): ChannelType { return this[kStart]!; }
+  public get end(): ChannelType { return this[kEnd]!; }
+  public get asyncStart(): ChannelType { return this[kAsyncStart]!; }
+  public get asyncEnd(): ChannelType { return this[kAsyncEnd]!; }
+  public get error(): ChannelType { return this[kError]!; }
+
+  public subscribe(subscriptions: TracingChannelSubscriptions) {
+    if (subscriptions.start !== undefined)
+      this[kStart]!.subscribe(subscriptions.start);
+    if (subscriptions.end !== undefined)
+      this[kEnd]!.subscribe(subscriptions.end);
+    if (subscriptions.asyncStart !== undefined)
+      this[kAsyncStart]!.subscribe(subscriptions.asyncStart);
+    if (subscriptions.asyncEnd !== undefined)
+      this[kAsyncEnd]!.subscribe(subscriptions.asyncEnd);
+    if (subscriptions.error !== undefined)
+      this[kError]!.subscribe(subscriptions.error);
+  }
+
+  public unsubscribe(subscriptions: TracingChannelSubscriptions) {
+    if (subscriptions.start !== undefined)
+      this[kStart]!.unsubscribe(subscriptions.start);
+    if (subscriptions.end !== undefined)
+      this[kEnd]!.unsubscribe(subscriptions.end);
+    if (subscriptions.asyncStart !== undefined)
+      this[kAsyncStart]!.unsubscribe(subscriptions.asyncStart);
+    if (subscriptions.asyncEnd !== undefined)
+      this[kAsyncEnd]!.unsubscribe(subscriptions.asyncEnd);
+    if (subscriptions.error !== undefined)
+      this[kError]!.unsubscribe(subscriptions.error);
+  }
+
+  public traceSync(fn : (...args: any[]) => any,
+            context: unknown = {},
+            thisArg: any = globalThis,
+            ...args: any[]): any {
+    const { start, end, error } = this;
+
+    return start.runStores(context, () => {
+      try {
+        const result = Reflect.apply(fn, thisArg, args);
+        (context as any).result = result;
+        return result;
+      } catch (err) {
+        (context as any).error = err;
+        error.publish(context);
+        throw err;
+      } finally {
+        end.publish(context);
+      }
+    }, thisArg);
+  }
+
+  public tracePromise(fn : (...args: any[]) => any,
+            context: unknown = {},
+            thisArg: any = globalThis,
+            ...args: any[]): any {
+    const { start, end, asyncStart, asyncEnd, error } = this;
+
+    function reject(err: any) {
+      (context as any).error = err;
+      error.publish(context);
+      asyncStart.publish(context);
+      asyncEnd.publish(context);
+      return Promise.reject(err);
+    }
+
+    function resolve(result: any) {
+      (context as any).result = result;
+      asyncStart.publish(context);
+      asyncEnd.publish(context);
+      return result;
+    }
+
+    return start.runStores(context, () => {
+      try {
+        let promise = Reflect.apply(fn, thisArg, args);
+        // Convert thenables to native promises
+        if (!(promise instanceof Promise)) {
+          promise = Promise.resolve(promise);
+        }
+        return promise.then(resolve, reject);
+      } catch (err) {
+        (context as any).error = err;
+        error.publish(context);
+        throw err;
+      } finally {
+        end.publish(context);
+      }
+    }, thisArg);
+  }
+
+  public traceCallback(fn : (...args: any[]) => any,
+                position = -1,
+                context: unknown = {},
+                thisArg: any = globalThis,
+                ...args: any[]): any {
+    const { start, end, asyncStart, asyncEnd, error } = this;
+
+    function wrappedCallback(this: any, err: any, res: any) {
+      if (err) {
+        (context as any).error = err;
+        error.publish(context);
+      } else {
+        (context as any).result = res;
+      }
+
+      // Using runStores here enables manual context failure recovery
+      asyncStart.runStores(context, () => {
+        try {
+          if (callback) {
+            return Reflect.apply(callback, this, arguments);
+          }
+        } finally {
+          asyncEnd.publish(context);
+        }
+      }, thisArg);
+    }
+
+    const callback = args[position];
+    if (typeof callback !== 'function') {
+      throw new ERR_INVALID_ARG_TYPE('callback', ['function'], callback);
+    }
+    args.splice(position, 1, wrappedCallback);
+
+    return start.runStores(context, () => {
+      try {
+        return Reflect.apply(fn, thisArg, args);
+      } catch (err) {
+        (context as any).error = err;
+        error.publish(context);
+        throw err;
+      } finally {
+        end.publish(context);
+      }
+    }, thisArg);
+  }
+}
+
+function validateChannel(channel: any, name: string) {
+  if (!(channel instanceof Channel)) {
+    throw new ERR_INVALID_ARG_TYPE(name, 'Channel', channel);
+  }
+  return channel as ChannelType;
+}
+
+export function tracingChannel(nameOrChannels : string|TracingChannels) : TracingChannel {
+  return Reflect.construct(function (this: TracingChannel) {
+    if (typeof nameOrChannels === 'string') {
+      const name = nameOrChannels as string;
+      this[kStart] = channel(`tracing:${name}:start`);
+      this[kEnd] = channel(`tracing:${name}:end`);
+      this[kAsyncStart] = channel(`tracing:${name}:asyncStart`);
+      this[kAsyncEnd] = channel(`tracing:${name}:asyncEnd`);
+      this[kError] = channel(`tracing:${name}:error`);
+    } else {
+      validateObject(nameOrChannels, 'channels', {});
+      const channels = nameOrChannels as TracingChannels;
+      this[kStart] = validateChannel(channels.start, 'channels.start');
+      this[kEnd] = validateChannel(channels.end, 'channels.end');
+      this[kAsyncStart] = validateChannel(channels.asyncStart, 'channels.asyncStart');
+      this[kAsyncEnd] = validateChannel(channels.asyncEnd, 'channels.asyncEnd');
+      this[kError] = validateChannel(channels.error, 'channels.error');
+    }
+  }, [], TracingChannel) as TracingChannel;
+}
+
+export default {
+  hasSubscribers,
+  channel,
+  subscribe,
+  unsubscribe,
+  tracingChannel,
+  Channel,
+};

--- a/src/node/internal/diagnostics_channel.d.ts
+++ b/src/node/internal/diagnostics_channel.d.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import { AsyncLocalStorage } from "node-internal:async_hooks";
+
+export type TransformCallback = (value: any) => any;
+
+export abstract class Channel {
+  hasSubscribers(): boolean;
+  publish(message: any): void;
+  subscribe(callback: MessageCallback): void;
+  unsubscribe(callback: MessageCallback): void;
+  bindStore(context: AsyncLocalStorage<any>,
+            transform?: TransformCallback): void;
+  unbindStore(context: AsyncLocalStorage<any>): void;
+  runStores(context: any,
+            fn: (...args: any[]) => any,
+            receiver?: any,
+            ...args: any[]): any;
+}
+
+export type MessageCallback = (message: any, name: string|symbol) => void;
+export function hasSubscribers(name: string|symbol) : boolean;
+export function channel(name: string|symbol) : Channel;
+export function subscribe(name: string|symbol, callback: MessageCallback) : void;
+export function unsubscribe(name: string|symbol, callback: MessageCallback) : void;

--- a/src/workerd/api/node/async-hooks.c++
+++ b/src/workerd/api/node/async-hooks.c++
@@ -148,4 +148,8 @@ v8::Local<v8::Value> AsyncResource::runInAsyncScope(
       argv.begin()));
 }
 
+kj::Own<jsg::AsyncContextFrame::StorageKey> AsyncLocalStorage::getKey() {
+  return kj::addRef(*key);
+}
+
 }  // namespace workerd::api::node

--- a/src/workerd/api/node/async-hooks.h
+++ b/src/workerd/api/node/async-hooks.h
@@ -87,6 +87,8 @@ public:
     }
   }
 
+  kj::Own<jsg::AsyncContextFrame::StorageKey> getKey();
+
 private:
   kj::Own<jsg::AsyncContextFrame::StorageKey> key;
 };

--- a/src/workerd/api/node/diagnostics-channel-test.js
+++ b/src/workerd/api/node/diagnostics-channel-test.js
@@ -1,0 +1,118 @@
+import {
+  ok,
+  strictEqual,
+} from 'node:assert';
+
+import {
+  hasSubscribers,
+  channel,
+  subscribe,
+  unsubscribe,
+  tracingChannel,
+  Channel,
+} from 'node:diagnostics_channel';
+
+import {
+  AsyncLocalStorage,
+} from 'node:async_hooks';
+
+function deferredPromise() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export const test_basics = {
+  async test(ctrl, env, ctx) {
+    ok(!hasSubscribers('foo'));
+    const channel1 = channel('foo');
+    const channel2 = channel('foo');
+    strictEqual(channel1, channel2);
+    ok(channel1 instanceof Channel);
+
+    const messagePromise = deferredPromise();
+
+    const listener = (message) => {
+      try {
+        strictEqual(message, 'hello');
+        messagePromise.resolve();
+      } catch (err) {
+        messagePromise.reject(err);
+      }
+    };
+
+    subscribe('foo', listener);
+
+    ok(hasSubscribers('foo'));
+
+    channel1.publish('hello');
+
+    unsubscribe('foo', listener);
+
+    ok(!hasSubscribers('foo'));
+
+    await messagePromise.promise;
+  }
+};
+
+export const test_tracing = {
+  async test(ctrl, env, ctx) {
+    const tc = tracingChannel('bar');
+    ok(tc.start instanceof Channel);
+    ok(tc.end instanceof Channel);
+    ok(tc.asyncStart instanceof Channel);
+    ok(tc.asyncEnd instanceof Channel);
+    ok(tc.error instanceof Channel);
+
+    const als = new AsyncLocalStorage();
+    tc.start.bindStore(als);
+
+    const promises = [
+      deferredPromise(),
+      deferredPromise(),
+      deferredPromise(),
+      deferredPromise(),
+      deferredPromise(),
+    ];
+
+    const context = {};
+
+    tc.subscribe({
+      start(_, name) {
+        try {
+          // Since the als is bound to tc.start, the context should be
+          // propagated here to the listener.
+          strictEqual(als.getStore(), context);
+          strictEqual(name, 'tracing:bar:start');
+          promises[0].resolve();
+        } catch (err) {
+          promises[0].reject(err);
+        }
+      },
+      end(_, name) {
+        try {
+          // Since the als is bound to tc.start, the context should be
+          // propagated here to the other listeners even if they aren't
+          // explicitly bound to als.
+          strictEqual(als.getStore(), context);
+          strictEqual(name, 'tracing:bar:end');
+          promises[1].resolve();
+        } catch (err) {
+          promises[1].reject(err);
+        }
+      },
+      asyncStart() { promises[2].resolve(); },
+      asyncEnd() { promises[3].resolve(); },
+      error() { promises[4].resolve(); },
+    });
+
+    tc.tracePromise(async () => {
+      throw new Error('boom');
+    }, context);
+
+    await Promise.all(promises.map(p => p.promise));
+  }
+};

--- a/src/workerd/api/node/diagnostics-channel-test.wd-test
+++ b/src/workerd/api/node/diagnostics-channel-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "diagnostics-channel-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "diagnostics-channel-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat"]
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/node/diagnostics-channel.c++
+++ b/src/workerd/api/node/diagnostics-channel.c++
@@ -1,0 +1,158 @@
+#include "diagnostics-channel.h"
+#include <workerd/io/io-context.h>
+#include <workerd/io/trace.h>
+#include <workerd/jsg/ser.h>
+
+namespace workerd::api::node {
+
+jsg::Value Channel::identityTransform(jsg::Lock& js, jsg::Value value) {
+  return value.addRef(js);
+}
+
+Channel::Channel(jsg::Name name) : name(kj::mv(name)) {}
+
+const jsg::Name& Channel::getName() const { return name; }
+
+bool Channel::hasSubscribers() {
+  return subscribers.size() != 0;
+}
+
+void Channel::publish(jsg::Lock& js, jsg::Value message) {
+  for (auto& sub : subscribers) {
+    sub.value(js, message.addRef(js), name.clone(js));
+  }
+
+  auto& context = IoContext::current();
+  KJ_IF_MAYBE(tracer, context.getWorkerTracer()) {
+    jsg::Serializer ser(js.v8Isolate, jsg::Serializer::Options {
+      .omitHeader = false,
+    });
+    ser.write(message.getHandle(js));
+    auto tmp = ser.release();
+    JSG_REQUIRE(tmp.sharedArrayBuffers.size() == 0 &&
+                tmp.transferedArrayBuffers.size() == 0, Error,
+                "Diagnostic events cannot be published with SharedArrayBuffer or "
+                "transferred ArrayBuffer instances");
+    tracer->addDiagnosticChannelEvent(context.now(), name.toString(js), kj::mv(tmp.data));
+  }
+}
+
+void Channel::subscribe(jsg::Lock& js, jsg::Identified<MessageCallback> callback) {
+  subscribers.upsert(kj::mv(callback.identity),
+                     kj::mv(callback.unwrapped),
+                     [&](auto&, auto&&) {});
+}
+
+void Channel::unsubscribe(jsg::Lock& js, jsg::Identified<MessageCallback> callback) {
+  subscribers.erase(callback.identity);
+}
+
+void Channel::bindStore(jsg::Lock& js, jsg::Ref<AsyncLocalStorage> als,
+                        jsg::Optional<TransformCallback> maybeTransform) {
+  auto key = als->getKey();
+  KJ_IF_MAYBE(entry, stores.find(*key)) {
+    KJ_IF_MAYBE(transform, maybeTransform) {
+      entry->transform = kj::mv(*transform);
+    } else {
+      entry->transform = [](jsg::Lock& js, jsg::Value value) {
+        return identityTransform(js, kj::mv(value));
+      };
+    }
+    return;
+  }
+
+  KJ_IF_MAYBE(transform, maybeTransform) {
+    stores.insert({
+      .key = kj::mv(key),
+      .transform = kj::mv(*transform)
+    });
+  } else {
+    stores.insert({
+      .key = kj::mv(key),
+      .transform = [](jsg::Lock& js, jsg::Value value) {
+        return identityTransform(js, kj::mv(value));
+      }
+    });
+  }
+}
+
+void Channel::unbindStore(jsg::Lock& js, jsg::Ref<AsyncLocalStorage> als) {
+  auto key = als->getKey();
+  stores.eraseMatch(*key);
+}
+
+v8::Local<v8::Value> Channel::runStores(
+    jsg::Lock& js, jsg::Value message,
+    v8::Local<v8::Function> callback,
+    jsg::Optional<v8::Local<v8::Value>> maybeReceiver,
+    jsg::Varargs args) {
+  auto storageScopes = KJ_MAP(store, stores) {
+    return kj::heap<jsg::AsyncContextFrame::StorageScope>(js, *store.key,
+        store.transform(js, message.addRef(js)));
+  };
+
+  publish(js, message.addRef(js));
+
+  auto context = js.v8Context();
+  auto receiver = maybeReceiver.orDefault([&]() -> v8::Local<v8::Value> {
+    return context->Global();
+  });
+
+  auto arguments = KJ_MAP(arg, args) -> v8::Local<v8::Value> {
+    return arg.getHandle(js);
+  };
+
+  return jsg::check(
+      callback->Call(context, receiver, arguments.size(), arguments.begin()));
+}
+
+void Channel::visitForGc(jsg::GcVisitor& visitor) {
+  for (auto& sub : subscribers) {
+    visitor.visit(sub.key, sub.value);
+  }
+  for (auto& store: stores) {
+    visitor.visit(store.transform);
+  }
+}
+
+bool DiagnosticsChannelModule::hasSubscribers(jsg::Lock& js, jsg::Name name) {
+  return tryGetChannel(js, name).map([&](Channel& channel) {
+    return channel.hasSubscribers();
+  }).orDefault(false);
+}
+
+void DiagnosticsChannelModule::subscribe(jsg::Lock& js,
+                                         jsg::Name name,
+                                         jsg::Identified<Channel::MessageCallback> callback) {
+  channel(js, kj::mv(name))->subscribe(js, kj::mv(callback));
+}
+
+void DiagnosticsChannelModule::unsubscribe(jsg::Lock& js,
+                                           jsg::Name name,
+                                           jsg::Identified<Channel::MessageCallback> callback) {
+  KJ_IF_MAYBE(channel, tryGetChannel(js, name)) {
+    channel->unsubscribe(js, kj::mv(callback));
+  }
+}
+
+jsg::Ref<Channel> DiagnosticsChannelModule::channel(jsg::Lock& js, jsg::Name channel) {
+  kj::String name = channel.toString(js);
+  return channels.findOrCreate(name, [&, channel=kj::mv(channel)]() mutable ->
+      kj::HashMap<kj::String, jsg::Ref<Channel>>::Entry{
+    return { kj::mv(name), jsg::alloc<Channel>(kj::mv(channel)) };
+  }).addRef();
+}
+
+kj::Maybe<Channel&> DiagnosticsChannelModule::tryGetChannel(jsg::Lock& js, jsg::Name& name) {
+  return channels.find(name.toString(js)).map([](jsg::Ref<Channel>& channel) -> Channel& {
+    return *channel;
+  });
+}
+
+void DiagnosticsChannelModule::visitForGc(jsg::GcVisitor& visitor) {
+  for (auto& channel : channels) {
+    visitor.visit(channel.value);
+  }
+}
+
+}  // namespace workerd::api::node

--- a/src/workerd/api/node/diagnostics-channel.h
+++ b/src/workerd/api/node/diagnostics-channel.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "async-hooks.h"
+#include <workerd/jsg/jsg.h>
+#include <kj/map.h>
+#include <kj/table.h>
+
+namespace workerd::api::node {
+
+class Channel : public jsg::Object {
+public:
+  using MessageCallback = jsg::Function<void(jsg::Value, jsg::Name)>;
+  using TransformCallback = jsg::Function<jsg::Value(jsg::Value)>;
+
+  static jsg::Value identityTransform(jsg::Lock& js, jsg::Value value);
+
+  Channel(jsg::Name name);
+
+  bool hasSubscribers();
+  void publish(jsg::Lock& js, jsg::Value message);
+  void subscribe(jsg::Lock& js, jsg::Identified<MessageCallback> callback);
+  void unsubscribe(jsg::Lock& js, jsg::Identified<MessageCallback> callback);
+  void bindStore(jsg::Lock& js, jsg::Ref<AsyncLocalStorage> als,
+                 jsg::Optional<TransformCallback> maybeTransform);
+  void unbindStore(jsg::Lock& js, jsg::Ref<AsyncLocalStorage> als);
+  v8::Local<v8::Value> runStores(jsg::Lock& js, jsg::Value message,
+                                 v8::Local<v8::Function> callback,
+                                 jsg::Optional<v8::Local<v8::Value>> maybeReceiver,
+                                 jsg::Varargs args);
+
+  JSG_RESOURCE_TYPE(Channel) {
+    JSG_METHOD(hasSubscribers);
+    JSG_METHOD(publish);
+    JSG_METHOD(subscribe);
+    JSG_METHOD(unsubscribe);
+    JSG_METHOD(bindStore);
+    JSG_METHOD(unbindStore);
+    JSG_METHOD(runStores);
+  }
+
+  const jsg::Name& getName() const;
+
+private:
+
+  struct StoreEntry {
+    kj::Own<jsg::AsyncContextFrame::StorageKey> key;
+    TransformCallback transform;
+  };
+
+  struct StoreCallbacks {
+    auto& keyForRow(StoreEntry& row) const {
+      return *row.key;
+    }
+
+    bool matches(const StoreEntry& a, jsg::AsyncContextFrame::StorageKey& key) const {
+      return a.key.get() == &key;
+    }
+
+    uint hashCode(jsg::AsyncContextFrame::StorageKey& key) const {
+      return key.hashCode();
+    }
+  };
+
+  jsg::Name name;
+  kj::HashMap<jsg::HashableV8Ref<v8::Object>, MessageCallback> subscribers;
+  kj::Table<StoreEntry, kj::HashIndex<StoreCallbacks>> stores;
+
+  void visitForGc(jsg::GcVisitor& visitor);
+};
+
+class DiagnosticsChannelModule : public jsg::Object {
+public:
+  bool hasSubscribers(jsg::Lock& js, jsg::Name name);
+  jsg::Ref<Channel> channel(jsg::Lock& js, jsg::Name name);
+  void subscribe(jsg::Lock& js, jsg::Name name, jsg::Identified<Channel::MessageCallback> callback);
+  void unsubscribe(jsg::Lock& js, jsg::Name name, jsg::Identified<Channel::MessageCallback> callback);
+  // TODO: Support tracing channels
+
+  JSG_RESOURCE_TYPE(DiagnosticsChannelModule) {
+    JSG_METHOD(hasSubscribers);
+    JSG_METHOD(channel);
+    JSG_METHOD(subscribe);
+    JSG_METHOD(unsubscribe);
+    JSG_NESTED_TYPE(Channel);
+  }
+
+  kj::Maybe<Channel&> tryGetChannel(jsg::Lock& js, jsg::Name& name);
+
+private:
+  kj::HashMap<kj::String, jsg::Ref<Channel>> channels;
+
+  void visitForGc(jsg::GcVisitor& visitor);
+};
+
+#define EW_NODE_DIAGNOSTICCHANNEL_ISOLATE_TYPES        \
+    api::node::Channel,                                \
+    api::node::DiagnosticsChannelModule
+
+}  // namespace workerd::api::node

--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -3,6 +3,7 @@
 #include "async-hooks.h"
 #include "buffer.h"
 #include "crypto.h"
+#include "diagnostics-channel.h"
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/modules.h>
 #include <capnp/dynamic.h>
@@ -37,7 +38,8 @@ void registerNodeJsCompatModules(
   V(CompatibilityFlags, "workerd:compatibility-flags")                          \
   V(AsyncHooksModule, "node-internal:async_hooks")                              \
   V(BufferUtil, "node-internal:buffer")                                         \
-  V(CryptoImpl, "node-internal:crypto")
+  V(CryptoImpl, "node-internal:crypto")                                         \
+  V(DiagnosticsChannelModule, "node-internal:diagnostics_channel")
 
 #define NODEJS_MODULES_EXPERIMENTAL(V)
 // Add to the NODEJS_MODULES_EXPERIMENTAL list any currently in-development
@@ -59,9 +61,10 @@ void registerNodeJsCompatModules(
   registry.addBuiltinBundle(NODE_BUNDLE);
 }
 
-#define EW_NODE_ISOLATE_TYPES      \
-  api::node::CompatibilityFlags,   \
-  EW_NODE_BUFFER_ISOLATE_TYPES,    \
-  EW_NODE_CRYPTO_ISOLATE_TYPES,    \
+#define EW_NODE_ISOLATE_TYPES              \
+  api::node::CompatibilityFlags,           \
+  EW_NODE_BUFFER_ISOLATE_TYPES,            \
+  EW_NODE_CRYPTO_ISOLATE_TYPES,            \
+  EW_NODE_DIAGNOSTICCHANNEL_ISOLATE_TYPES, \
   EW_NODE_ASYNCHOOKS_ISOLATE_TYPES
 }  // namespace workerd::api::node

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -142,6 +142,22 @@ public:
     void copyTo(rpc::Trace::FetchResponseInfo::Builder builder);
   };
 
+  class DiagnosticChannelEvent {
+  public:
+    explicit DiagnosticChannelEvent(kj::Date timestamp,
+                                    kj::String channel,
+                                    kj::Array<kj::byte> message);
+    DiagnosticChannelEvent(rpc::Trace::DiagnosticChannelEvent::Reader reader);
+    DiagnosticChannelEvent(DiagnosticChannelEvent&&) = default;
+    KJ_DISALLOW_COPY(DiagnosticChannelEvent);
+
+    kj::Date timestamp;
+    kj::String channel;
+    kj::Array<kj::byte> message;
+
+    void copyTo(rpc::Trace::DiagnosticChannelEvent::Builder builder);
+  };
+
   class Log {
   public:
     explicit Log(kj::Date timestamp, LogLevel logLevel, kj::String message);
@@ -199,6 +215,8 @@ public:
   kj::Vector<Exception> exceptions;
   // A request's trace can have multiple exceptions due to separate request/waitUntil tasks.
 
+  kj::Vector<DiagnosticChannelEvent> diagnosticChannelEvents;
+
   EventOutcome outcome = EventOutcome::UNKNOWN;
 
   kj::Maybe<FetchResponseInfo> fetchResponseInfo;
@@ -208,6 +226,7 @@ public:
 
   bool exceededLogLimit = false;
   bool exceededExceptionLimit = false;
+  bool exceededDiagnosticChannelEventLimit = false;
   size_t bytesUsed = 0;
   // Trace data is recorded outside of the JS heap.  To avoid DoS, we keep an estimate of trace
   // data size, and we stop recording if too much is used.
@@ -284,6 +303,9 @@ public:
   //void setMetrics(...) // Or get from MetricsCollector::Request directly?
 
   void addException(kj::Date timestamp, kj::String name, kj::String message);
+
+  void addDiagnosticChannelEvent(kj::Date timestamp, kj::String channel,
+                                 kj::Array<kj::byte> message);
 
   void setEventInfo(kj::Date timestamp, Trace::EventInfo&&);
   // Adds info about the event that triggered the trace.  Must not be called more than once.

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -95,6 +95,13 @@ struct Trace @0x8e8d911203762d34 {
 
   dispatchNamespace @12 :Text;
   scriptTags @14 :List(Text);
+
+  diagnosticChannelEvents @17 :List(DiagnosticChannelEvent);
+  struct DiagnosticChannelEvent {
+    timestampNs @0 :Int64;
+    channel @1 :Text;
+    message @2 :Data;
+  }
 }
 
 struct ScheduledRun @0xd98fc1ae5c8095d0 {

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -251,6 +251,30 @@ void Name::visitForGc(GcVisitor& visitor) {
   }
 }
 
+Name Name::clone(jsg::Lock& js) {
+  KJ_SWITCH_ONEOF(inner) {
+    KJ_CASE_ONEOF(str, kj::String) {
+      return Name(kj::str(str));
+    }
+    KJ_CASE_ONEOF(symbol, V8Ref<v8::Symbol>) {
+      return Name(js, symbol.getHandle(js));
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+kj::String Name::toString(jsg::Lock& js) {
+  KJ_SWITCH_ONEOF(inner) {
+    KJ_CASE_ONEOF(str, kj::String) {
+      return kj::str(str);
+    }
+    KJ_CASE_ONEOF(sym, V8Ref<v8::Symbol>) {
+      return kj::str("Symbol(", sym.getHandle(js)->Description(js.v8Isolate), ")");
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
 V8StackScope::V8StackScope() {
   kj::requireOnStack(this, "V8StackScope must be allocated on the stack");
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1175,6 +1175,10 @@ public:
 
   inline int hashCode() const { return hash; }
 
+  Name clone(jsg::Lock& js);
+
+  kj::String toString(jsg::Lock& js);
+
 private:
   int hash;
   kj::OneOf<kj::String, V8Ref<v8::Symbol>> inner;

--- a/src/workerd/jsg/rtti.capnp
+++ b/src/workerd/jsg/rtti.capnp
@@ -171,6 +171,8 @@ struct JsgImplType {
     v8FunctionCallbackInfo @7;
 
     v8PropertyCallbackInfo @8;
+
+    jsgName @9;
   }
 
   type @0 :Type;

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -398,6 +398,7 @@ struct BuildRtti<Configuration, T> { \
 
 #define FOR_EACH_JSG_IMPL_TYPE(F, ...) \
   F(jsg::Lock, JsgImplType::Type::JSG_LOCK) \
+  F(jsg::Name, JsgImplType::Type::JSG_NAME) \
   F(jsg::SelfRef, JsgImplType::Type::JSG_SELF_REF) \
   F(jsg::Unimplemented, JsgImplType::Type::JSG_UNIMPLEMENTED) \
   F(jsg::Varargs, JsgImplType::Type::JSG_VARARGS) \

--- a/types/src/generator/type.ts
+++ b/types/src/generator/type.ts
@@ -357,6 +357,8 @@ export function createTypeNode(
           return f.createTypeReferenceNode("never");
         case JsgImplType_Type.JSG_VARARGS:
           return f.createArrayTypeNode(f.createTypeReferenceNode("any"));
+        case JsgImplType_Type.JSG_NAME:
+          return f.createTypeReferenceNode("PropertyKey");
         default:
           assert.fail(`Unknown JSG implementation type: ${impl}`);
       }

--- a/types/test/generator/type.spec.ts
+++ b/types/test/generator/type.spec.ts
@@ -185,10 +185,18 @@ test("createTypeNode: implementation types", () => {
     (member) => typeof member === "number"
   );
   for (const implType of implTypes) {
-    // VARARGS is the only type we care about which will be tested with function
-    // types, the rest should be ignored
-    if (implType === JsgImplType_Type.JSG_VARARGS) continue;
+    // VARARGS and NAME are the only types we care about which will be tested
+    // with function types, the rest should be ignored
+    if (
+      implType === JsgImplType_Type.JSG_VARARGS ||
+      implType === JsgImplType_Type.JSG_NAME
+    ) {
+      continue;
+    }
     impl.setType(implType);
     assert.strictEqual(printNode(createTypeNode(type)), "never");
   }
+
+  impl.setType(JsgImplType_Type.JSG_NAME);
+  assert.strictEqual(printNode(createTypeNode(type)), "PropertyKey");
 });


### PR DESCRIPTION
An implementation of Node.js diagnostics_channel.

* Supports TracingChannels
* Includes capturing diagnostic channel events to tail workers automatically.

Refs: https://nodejs.org/dist/latest-v20.x/docs/api/diagnostics_channel.html