### PR TITLE
Clean up fail-open fallback code.

### DIFF
--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -71,7 +71,7 @@ private:
   // Members initialized at startup.
 
   kj::Maybe<kj::Promise<void>> proxyTask;
-  kj::Maybe<kj::Own<kj::HttpClient>> failOpenClient;
+  kj::Maybe<kj::Own<WorkerInterface>> failOpenService;
   bool loggedExceptionEarlier = false;
   // Hacky members used to hold some temporary state while processing a request.
   // See gory details in WorkerEntrypoint::request().


### PR DESCRIPTION
The code was adaping an HttpService (WorkerInterface) into an HttpClient and then adapting that back into an HttpService. This change removes the two layers of adapters.

In addition to being more efficient, I'm hoping this fixes some weird sentry errors we're seeing from `LOG_EXCEPTION("failOpenFallback", e)`.