### PR TITLE
Define macOS 11 as earliest supported version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -71,6 +71,10 @@ build:unix --@capnp-cpp//src/kj:openssl=True --@capnp-cpp//src/kj:zlib=True --@c
 build:linux --config=unix
 build:macos --config=unix
 
+# Support macOS 11 as the minimum version. There should be at least a warning when backward
+# compatibility is broken as -Wunguarded-availability-new is enabled by default.
+build:macos --macos_minimum_os=11.0 --host_macos_minimum_os=11.0
+
 #
 # Windows
 #

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ To build `workerd`, you need:
   * LLD 11+ (e.g. package `lld` on Debian Bullseye)
   * `python3` and `python3-distutils`
 * On macOS:
-  * full XCode 13+ installation
+  * Xcode 13+ installation (or equivalent command line tools version)
+  * macOS 11 or higher
 * On Windows:
   * Install [App Installer](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget)
     from the Microsoft Store for the `winget` package manager and then run
@@ -179,9 +180,8 @@ Prebuilt binaries are distributed via `npm`. Run `npx workerd ...` to use these.
 * On Linux:
   * libc++ (e.g. the package `libc++1` on Debian Bullseye)
 * On macOS:
-  * The XCode command line tools, which can be installed with `xcode-select --install`
-
-> Note: if you're running `workerd` in Ubuntu in the GitHub Actions CI environment, you'll need to use `runs-on: ubuntu-22.04` rather than `runs-on: ubuntu-latest`
+  * macOS 11 or higher
+  * The Xcode command line tools, which can be installed with `xcode-select --install`
 
 ### Local Worker development with `wrangler`
 


### PR DESCRIPTION
macOS 11 is the oldest version still being maintained, V8 also depends on multithreading-related functions introduced with it. This is hopefully sufficient to fix https://github.com/cloudflare/workers-sdk/issues/3307 https://github.com/cloudflare/workers-sdk/issues/3315 https://github.com/cloudflare/workers-sdk/issues/3432 – macOS shouldn't require static linking of system libraries and at least two of the issues are on macOS 11.

Also updated the readme, the `ubuntu-latest` Github Actions runner image is now identical to ubuntu-22.04 so it works just fine. Based on #170 the commend-line tools should be sufficient for compiling.