### PR TITLE
Noop for test GC pass when not in debug

### DIFF
--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -513,6 +513,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
 template <typename T>
 void WorkerEntrypoint::maybeAddGcPassForTest(
     IoContext& context, kj::Promise<T>& promise) {
+#ifdef KJ_DEBUG
   if (isPredictableModeForTest()) {
     auto worker = kj::atomicAddRef(context.getWorker());
     if constexpr (kj::isSameType<T, void>()) {
@@ -530,6 +531,7 @@ void WorkerEntrypoint::maybeAddGcPassForTest(
       });
     }
   }
+#endif
 }
 
 } // namespace workerd


### PR DESCRIPTION
To get accurate metrics when load testing an optimized build, the GC pass that is normally done per test is now disabled.