### PR TITLE
sql: increase SQLITE_LIMIT_COMPOUND_SELECT to 5

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -199,6 +199,11 @@ async function test(storage) {
   // Should match results in the format "2023-06-01 15:30:03"
   assert.match(resultTimestamp[0]["current_timestamp"], /^\d{4}-\d{2}-\d{2}\s{1}\d{2}:\d{2}:\d{2}$/)
 
+  // Validate that the SQLITE_LIMIT_COMPOUND_SELECT limit is enforced as expected
+  const compoundWithinLimits = [...sql.exec("SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5")];
+  assert.equal(compoundWithinLimits.length, 5);
+  requireException(() => sql.exec("SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6"), "too many terms in compound SELECT");
+
   // Can't start transactions or savepoints.
   requireException(() => sql.exec("BEGIN TRANSACTION"), "not authorized");
   requireException(() => sql.exec("SAVEPOINT foo"), "not authorized");

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -683,7 +683,9 @@ void SqliteDatabase::setupSecurity() {
   sqlite3_limit(db, SQLITE_LIMIT_SQL_LENGTH, 100000);
   sqlite3_limit(db, SQLITE_LIMIT_COLUMN, 100);
   sqlite3_limit(db, SQLITE_LIMIT_EXPR_DEPTH, 20);
-  sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 3);
+  // Enforces limits on UNION/UNION ALL/INTERSECT/etc
+  // https://www.sqlite.org/limits.html#max_compound_select
+  sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 5);
   sqlite3_limit(db, SQLITE_LIMIT_VDBE_OP, 25000);
   sqlite3_limit(db, SQLITE_LIMIT_FUNCTION_ARG, 32);
   sqlite3_limit(db, SQLITE_LIMIT_ATTACHED, 0);


### PR DESCRIPTION
Fixes #795 

This PR increases the `SQLITE_MAX_COMPOUND_SELECT` limit (https://www.sqlite.org/limits.html#max_compound_select) from the [dark arts recommended](https://www.sqlite.org/security.html) `3` to a slightly more permissive `5` based on user feedback. The SQLite default is 500.