### PR TITLE
Fix ECDH key import when strict_crypto_checks is enabled

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -329,5 +329,5 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatDisableFlag("no_strict_crypto_checks")
       $compatEnableDate("2023-08-01");
   # Perform additional error checking in the Web Crypto API to conform with the specification as
-  # well as reject key parameters that may be unsafe based on the modulus or key length.
+  # well as reject key parameters that may be unsafe based on key length or public exponent.
 }


### PR DESCRIPTION
With the `strict_crypto_checks` flag enabled, imported ECDH keys were required to have empty usages, but for private keys the usage set should be allowed to include deriveBits and deriveKey.
Since the compatibility date for the flag has not yet passed, this is unlikely to have had a significant effect.

Also updates a compat flag description to clarify that the public exponent is limited to a certain set of values.