### PR TITLE
Add runtime API for accessing RTTI & include internal/built-in modules

### DIFF
--- a/build/wd_js_bundle.bzl
+++ b/build/wd_js_bundle.bzl
@@ -11,7 +11,10 @@ const {const_name} :Modules.Bundle = (
 ]);
 """
 
-MODULE_TEMPLATE = """(name = "{name}", src = embed "{path}", internal = {internal})"""
+MODULE_TEMPLATE = """(name = "{name}", src = embed "{path}", {ts_declaration}internal = {internal})"""
+
+def _to_d_ts(file_name):
+    return file_name.removesuffix(".js") + ".d.ts"
 
 def _relative_path(file_path, dir_path):
     if not file_path.startswith(dir_path):
@@ -30,6 +33,12 @@ def _gen_api_bundle_capnpn_impl(ctx):
                 ctx.expand_location("$(location {})".format(label), ctx.attr.data),
                 output_dir,
             ),
+            ts_declaration = (
+                "tsDeclaration = embed \"" + _relative_path(
+                    ctx.expand_location("$(location {})".format(ctx.attr.declarations[name]), ctx.attr.data),
+                    output_dir,
+                ) + "\", "
+            ) if name in ctx.attr.declarations else "",
             internal = "true" if internal else "false",
         )
 
@@ -56,23 +65,32 @@ gen_api_bundle_capnpn = rule(
         "out": attr.output(mandatory = True),
         "builtin_modules": attr.label_keyed_string_dict(allow_files = True),
         "internal_modules": attr.label_keyed_string_dict(allow_files = True),
+        "declarations": attr.string_dict(),
         "data": attr.label_list(allow_files = True),
         "const_name": attr.string(mandatory = True),
     },
 )
 
-def _copy_modules(modules):
+def _copy_modules(modules, declarations):
     """Copy files from the modules map to the current package.
 
     Returns new module map using file copies.
     This is necessary since capnp compiler doesn't allow embeds outside of current subidrectory.
     """
     result = dict()
+    declarations_result = dict()
     for m in modules:
         new_filename = modules[m].replace(":", "_").replace("/", "_")
         copy_file(name = new_filename + "@copy", src = m, out = new_filename)
+
+        m_d_ts = _to_d_ts(m)
+        if m_d_ts in declarations:
+            new_d_ts_filename = new_filename + ".d.ts"
+            copy_file(name = new_d_ts_filename + "@copy", src = m_d_ts, out = new_d_ts_filename)
+            declarations_result[modules[m]] = str(native.package_relative_label(new_d_ts_filename))
+
         result[new_filename] = modules[m]
-    return result
+    return result, declarations_result
 
 def wd_js_bundle(
         name,
@@ -80,6 +98,7 @@ def wd_js_bundle(
         const_name,
         builtin_modules = {},
         internal_modules = {},
+        declarations = [],
         **kwargs):
     """Generate cc capnp library with js api bundle.
 
@@ -90,15 +109,16 @@ def wd_js_bundle(
      name: cc_capnp_library rule name
      builtin_modules: js src label -> module name dictionary
      internal_modules: js src label -> module name dictionary
+     declarations: d.ts label set
      const_name: capnp constant name that will contain bundle definition
      schema_id: capnpn schema id
      **kwargs: rest of cc_capnp_library arguments
     """
 
-    builtin_modules = _copy_modules(builtin_modules)
-    internal_modules = _copy_modules(internal_modules)
+    builtin_modules, builtin_declarations = _copy_modules(builtin_modules, declarations)
+    internal_modules, internal_declarations = _copy_modules(internal_modules, declarations)
 
-    data = list(builtin_modules) + list(internal_modules)
+    data = list(builtin_modules) + list(internal_modules) + list(builtin_declarations.values()) + list(internal_declarations.values())
 
     gen_api_bundle_capnpn(
         name = name + "@gen",
@@ -107,6 +127,7 @@ def wd_js_bundle(
         const_name = const_name,
         builtin_modules = builtin_modules,
         internal_modules = internal_modules,
+        declarations = builtin_declarations | internal_declarations,
         data = data,
     )
 

--- a/build/wd_ts_bundle.bzl
+++ b/build/wd_ts_bundle.bzl
@@ -7,6 +7,9 @@ def _to_js(file_name):
         return file_name.removesuffix(".ts") + ".js"
     return file_name
 
+def _to_d_ts(file_name):
+    return file_name.removesuffix(".ts") + ".d.ts"
+
 def _to_name(file_name):
     return file_name.removesuffix(".ts").removesuffix(".js")
 
@@ -42,11 +45,13 @@ def wd_ts_bundle(
 
     srcs = modules + internal_modules
     ts_srcs = [src for src in srcs if src.endswith(".ts")]
+    declarations = [_to_d_ts(src) for src in ts_srcs if not src.endswith(".d.ts")]
 
     ts_project(
         name = name + "@tsproject",
         srcs = ts_srcs,
         allow_js = True,
+        declaration = True,
         tsconfig = name + "@tsconfig",
         deps = deps,
     )
@@ -63,6 +68,7 @@ def wd_ts_bundle(
             _to_js(m),
             import_name + "-internal:" + _to_name(m.removeprefix("internal/")),
         ) for m in internal_modules if not m.endswith(".d.ts")]),
+        declarations = declarations,
         schema_id = schema_id,
     )
 

--- a/src/cloudflare/tsconfig.json
+++ b/src/cloudflare/tsconfig.json
@@ -18,6 +18,7 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "esModuleInterop": true,
+    "declaration": true,
     "types": [
       // todo: consume generated workerd types
       // "@cloudflare/workers-types"

--- a/src/node/tsconfig.json
+++ b/src/node/tsconfig.json
@@ -18,6 +18,7 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "esModuleInterop": true,
+    "declaration": true,
     "types": [
       // todo: consume generated workerd types
       // "@cloudflare/workers-types"

--- a/src/workerd/api/modules.h
+++ b/src/workerd/api/modules.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <workerd/api/node/node.h>
+#include <workerd/api/rtti.h>
+#include <workerd/api/sockets.h>
+#include <cloudflare/cloudflare.capnp.h>
+
+namespace workerd::api {
+
+template <class Registry>
+void registerModules(Registry& registry, auto featureFlags) {
+  if (featureFlags.getNodeJsCompat()) {
+    node::registerNodeJsCompatModules(registry, featureFlags);
+  }
+  if (featureFlags.getRttiApi()) {
+    registerRTTIModule(registry);
+  }
+  registerSocketsModule(registry, featureFlags);
+  registry.addBuiltinBundle(CLOUDFLARE_BUNDLE);
+}
+
+}  // namespace workerd::api

--- a/src/workerd/api/node/async-hooks.h
+++ b/src/workerd/api/node/async-hooks.h
@@ -72,19 +72,15 @@ public:
     JSG_STATIC_METHOD(bind);
     JSG_STATIC_METHOD(snapshot);
 
-    if (flags.getNodeJsCompat()) {
-      JSG_TS_OVERRIDE(AsyncLocalStorage<T> {
-        getStore(): T | undefined;
-        run<R, TArgs extends any[]>(store: T, callback: (...args: TArgs) => R, ...args: TArgs): R;
-        exit<R, TArgs extends any[]>(callback: (...args: TArgs) => R, ...args: TArgs): R;
-        disable(): void;
-        enterWith(store: T): void;
-        static bind<Func extends (...args: any[]) => any>(fn: Func): Func;
-        static snapshot<R, TArgs extends any[]>() : ((...args: TArgs) => R, ...args: TArgs) => R;
-      });
-    } else {
-      JSG_TS_OVERRIDE(type AsyncLocalStorage = never);
-    }
+    JSG_TS_OVERRIDE(AsyncLocalStorage<T> {
+      getStore(): T | undefined;
+      run<R, TArgs extends any[]>(store: T, callback: (...args: TArgs) => R, ...args: TArgs): R;
+      exit<R, TArgs extends any[]>(callback: (...args: TArgs) => R, ...args: TArgs): R;
+      enterWith(store: T): never;
+      disable(): never;
+      static bind<Func extends (...args: any[]) => any>(fn: Func): Func;
+      static snapshot<R, TArgs extends any[]>(): (fn: (...args: TArgs) => R, ...args: TArgs) => R;
+    });
   }
 
   kj::Own<jsg::AsyncContextFrame::StorageKey> getKey();
@@ -144,7 +140,6 @@ public:
     // that we do not implement. We can simply omit it here. There's no risk of
     // bugs or unexpected behavior by doing so.
 
-    JSG_STRUCT_TS_OVERRIDE(type AsyncResourceOptions = never);
     JSG_STRUCT(triggerAsyncId);
   };
 
@@ -190,27 +185,13 @@ public:
     JSG_METHOD(bind);
     JSG_METHOD(runInAsyncScope);
 
-    if (flags.getNodeJsCompat()) {
-      JSG_TS_OVERRIDE(interface AsyncResourceOptions {
-        triggerAsyncId?: number;
-      });
+    JSG_TS_OVERRIDE(AsyncResource {
+      constructor(type: string, options?: AsyncResourceOptions);
+      static bind<Func extends (this: ThisArg, ...args: any[]) => any, ThisArg>(fn: Func, type?: string, thisArg?: ThisArg): Func;
+      bind<Func extends (...args: any[]) => any>(fn: Func): Func;
+      runInAsyncScope<This, Result>(fn: (this: This, ...args: any[]) => Result, thisArg?: This, ...args: any[]): Result;
+    });
 
-      JSG_TS_OVERRIDE(AsyncResource {
-        constructor(type: string, options?: AsyncResourceOptions);
-        static bind<Func extends (this: ThisArg, ...args: any[]) => any, ThisArg>(
-            fn: Func,
-            type?: string,
-            thisArg?: ThisArg): Func & { asyncResource: AsyncResource; };
-        bind<Func extends (...args: any[]) => any>(
-            fn: Func ): Func & { asyncResource: AsyncResource; };
-        runInAsyncScope<This, Result>(fn: (this: This, ...args: any[]) => Result, thisArg?: This,
-                                      ...args: any[]): Result;
-        asyncId(): number;
-        triggerAsyncId(): number;
-      });
-    } else {
-      JSG_TS_OVERRIDE(type AsyncResource = never);
-    }
   }
 
   kj::Maybe<jsg::AsyncContextFrame&> getFrame();
@@ -231,16 +212,9 @@ class AsyncHooksModule final: public jsg::Object {
   // Node.js.
 public:
 
-  JSG_RESOURCE_TYPE(AsyncHooksModule, CompatibilityFlags::Reader flags) {
+  JSG_RESOURCE_TYPE(AsyncHooksModule) {
     JSG_NESTED_TYPE(AsyncLocalStorage);
     JSG_NESTED_TYPE(AsyncResource);
-
-    if (flags.getNodeJsCompat()) {
-      JSG_TS_ROOT();
-      JSG_TS_OVERRIDE(AsyncHooksModule {});
-    } else {
-      JSG_TS_OVERRIDE(type AsyncHooksModule = never);
-    }
   }
 };
 

--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -30,9 +30,9 @@ public:
   }
 };
 
-template <typename TypeWrapper>
+template <class Registry>
 void registerNodeJsCompatModules(
-    workerd::jsg::ModuleRegistryImpl<TypeWrapper>& registry, auto featureFlags) {
+    Registry& registry, auto featureFlags) {
 
 #define NODEJS_MODULES(V)                                                       \
   V(CompatibilityFlags, "workerd:compatibility-flags")                          \

--- a/src/workerd/api/rtti-test.js
+++ b/src/workerd/api/rtti-test.js
@@ -1,0 +1,9 @@
+import assert from "node:assert";
+import rtti from "workerd:rtti";
+
+export default {
+  async test(ctrl, env, ctx) {
+    const buffer = rtti.exportTypes("2023-05-18", ["nodejs_compat"]);
+    assert(buffer.byteLength > 0);
+  }
+}

--- a/src/workerd/api/rtti-test.wd-test
+++ b/src/workerd/api/rtti-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "rtti-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "rtti-test.js")
+        ],
+        compatibilityDate = "2023-05-18",
+        compatibilityFlags = ["nodejs_compat", "rtti_api"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -64,70 +64,173 @@
 namespace workerd::api {
 
 namespace {
-  struct EncoderErrorReporterImpl : public Worker::ValidationErrorReporter {
-    void addError(kj::String error) override { errors.add(kj::mv(error)); }
-    void addHandler(kj::Maybe<kj::StringPtr> exportName,
-                    kj::StringPtr type) override {
-      KJ_UNREACHABLE;
-    }
 
-    kj::Vector<kj::String> errors;
+struct EncoderErrorReporterImpl : public Worker::ValidationErrorReporter {
+  void addError(kj::String error) override { errors.add(kj::mv(error)); }
+  void addHandler(kj::Maybe<kj::StringPtr> exportName,
+                  kj::StringPtr type) override {
+    KJ_UNREACHABLE;
+  }
+
+  kj::Vector<kj::String> errors;
+};
+
+struct EncoderModuleRegistryImpl {
+  struct CppModuleContents {
+    CppModuleContents(kj::String structureName) : structureName(kj::mv(structureName)) {}
+
+    kj::String structureName;
+  };
+  struct TypeScriptModuleContents {
+    TypeScriptModuleContents(kj::StringPtr tsDeclarations) : tsDeclarations(tsDeclarations) {}
+
+    kj::StringPtr tsDeclarations;
+  };
+  struct ModuleInfo {
+    ModuleInfo(kj::StringPtr specifier, bool internal, kj::OneOf<CppModuleContents,
+                TypeScriptModuleContents> contents)
+        : specifier(specifier),
+          internal(internal),
+          contents(kj::mv(contents)) {}
+
+    kj::StringPtr specifier;
+    bool internal;
+    kj::OneOf<CppModuleContents, TypeScriptModuleContents> contents;
   };
 
-  CompatibilityFlags::Reader compileFlags(capnp::MessageBuilder &message, kj::StringPtr compatDate,
-                                          bool experimental, kj::ArrayPtr<kj::String> compatFlags) {
-    // Based on src/workerd/io/compatibility-date-test.c++
-    auto orphanage = message.getOrphanage();
-    auto flagListOrphan =
-        orphanage.newOrphan<capnp::List<capnp::Text>>(compatFlags.size());
-    auto flagList = flagListOrphan.get();
-    for (auto i : kj::indices(compatFlags)) {
-      flagList.set(i, compatFlags.begin()[i]);
+  void addBuiltinBundle(jsg::Bundle::Reader bundle) {
+    for (auto module: bundle.getModules()) {
+      TypeScriptModuleContents contents (module.getTsDeclaration());
+      ModuleInfo info (module.getName(), module.getInternal(), kj::mv(contents));
+      modules.add(kj::mv(info));
     }
-
-    auto output = message.initRoot<CompatibilityFlags>();
-    EncoderErrorReporterImpl errorReporter;
-
-    compileCompatibilityFlags(compatDate, flagList.asReader(), output,
-                              errorReporter, experimental,
-                              CompatibilityDateValidation::FUTURE_FOR_TEST);
-
-    if (!errorReporter.errors.empty()) {
-      // TODO: AggregateError?
-      JSG_FAIL_REQUIRE(Error, errorReporter.errors[0]);
-    }
-
-    auto reader = output.asReader();
-    return kj::mv(reader);
   }
+
+  template <typename T>
+  void addBuiltinModule(kj::StringPtr specifier, jsg::ModuleRegistry::Type type = jsg::ModuleRegistry::Type::BUILTIN) {
+    auto internal = type == jsg::ModuleRegistry::Type::INTERNAL;
+    auto structureName = jsg::fullyQualifiedTypeName(typeid(T));
+    CppModuleContents contents (kj::mv(structureName));
+    ModuleInfo info (specifier, internal, kj::mv(contents));
+    modules.add(kj::mv(info));
+  }
+
+  kj::Vector<ModuleInfo> modules;
+};
+
+CompatibilityFlags::Reader compileFlags(capnp::MessageBuilder &message, kj::StringPtr compatDate,
+                                        bool experimental, kj::ArrayPtr<kj::String> compatFlags) {
+  // Based on src/workerd/io/compatibility-date-test.c++
+  auto orphanage = message.getOrphanage();
+  auto flagListOrphan =
+      orphanage.newOrphan<capnp::List<capnp::Text>>(compatFlags.size());
+  auto flagList = flagListOrphan.get();
+  for (auto i : kj::indices(compatFlags)) {
+    flagList.set(i, compatFlags.begin()[i]);
+  }
+
+  auto output = message.initRoot<CompatibilityFlags>();
+  EncoderErrorReporterImpl errorReporter;
+
+  compileCompatibilityFlags(compatDate, flagList.asReader(), output,
+                            errorReporter, experimental,
+                            CompatibilityDateValidation::FUTURE_FOR_TEST);
+
+  if (!errorReporter.errors.empty()) {
+    // TODO(someday): throw an `AggregateError` containing all errors
+    JSG_FAIL_REQUIRE(Error, errorReporter.errors[0]);
+  }
+
+  auto reader = output.asReader();
+  return kj::mv(reader);
 }
 
-kj::Array<byte> TypesEncoder::encode() {
-  capnp::MallocMessageBuilder flagsMessage;
-  CompatibilityFlags::Reader flags = compileFlags(flagsMessage, compatDate, false, compatFlags);
+struct TypesEncoder {
+public:
+  TypesEncoder(kj::String compatDate, kj::Array<kj::String> compatFlags): compatDate(kj::mv(compatDate)), compatFlags(kj::mv(compatFlags)) {}
 
-  capnp::MallocMessageBuilder message;
-  auto root = message.initRoot<jsg::rtti::StructureGroups>();
+  kj::Array<byte> encode() {
+    capnp::MallocMessageBuilder flagsMessage;
+    CompatibilityFlags::Reader flags = compileFlags(flagsMessage, compatDate, false, compatFlags);
 
-  // Encode RTTI structures
-  auto builder = jsg::rtti::Builder(flags);
+    capnp::MallocMessageBuilder message;
+    auto root = message.initRoot<jsg::rtti::StructureGroups>();
+
+    // Encode RTTI structures
+    auto builder = jsg::rtti::Builder(flags);
 
 #define EW_TYPE_GROUP_COUNT(Name, Types) groupsSize++;
 #define EW_TYPE_GROUP_WRITE(Name, Types) writeGroup<Types>(groups, builder, Name);
 
-  unsigned int groupsSize = 0;
-  EW_TYPE_GROUP_FOR_EACH(EW_TYPE_GROUP_COUNT)
-  auto groups = root.initGroups(groupsSize);
-  groupsIndex = 0;
-  EW_TYPE_GROUP_FOR_EACH(EW_TYPE_GROUP_WRITE)
-  KJ_ASSERT(groupsIndex == groupsSize);
+    unsigned int groupsSize = 0;
+    EW_TYPE_GROUP_FOR_EACH(EW_TYPE_GROUP_COUNT)
+    auto groups = root.initGroups(groupsSize);
+    groupsIndex = 0;
+    EW_TYPE_GROUP_FOR_EACH(EW_TYPE_GROUP_WRITE)
+    KJ_ASSERT(groupsIndex == groupsSize);
 
 #undef EW_TYPE_GROUP_COUNT
 #undef EW_TYPE_GROUP_WRITE
 
-  auto words = capnp::messageToFlatArray(message);
-  auto bytes = words.asBytes();
-  return kj::heapArray(bytes);
+    // Encode modules
+    EncoderModuleRegistryImpl registry;
+    registerModules(registry, flags);
+
+    unsigned int i = 0;
+    auto modulesBuilder = root.initModules(registry.modules.size());
+    for (auto moduleBuilder: modulesBuilder) {
+      auto& module = registry.modules[i++];
+      moduleBuilder.setSpecifier(module.specifier);
+      moduleBuilder.setInternal(module.internal);
+      KJ_SWITCH_ONEOF(module.contents) {
+        KJ_CASE_ONEOF(contents, EncoderModuleRegistryImpl::CppModuleContents) {
+          moduleBuilder.setStructureName(contents.structureName);
+        }
+        KJ_CASE_ONEOF(contents, EncoderModuleRegistryImpl::TypeScriptModuleContents) {
+          moduleBuilder.setTsDeclarations(contents.tsDeclarations);
+        }
+      }
+    }
+
+    auto words = capnp::messageToFlatArray(message);
+    auto bytes = words.asBytes();
+    return kj::heapArray(bytes);
+  }
+
+private:
+  template <typename Type>
+  void writeStructure(jsg::rtti::Builder<CompatibilityFlags::Reader> &builder,
+                      capnp::List<jsg::rtti::Structure>::Builder structures) {
+    auto reader = builder.structure<Type>();
+    structures.setWithCaveats(structureIndex++, reader);
+  }
+
+  template <typename... Types>
+  void writeGroup(
+      capnp::List<jsg::rtti::StructureGroups::StructureGroup>::Builder &groups,
+      jsg::rtti::Builder<CompatibilityFlags::Reader> &builder, kj::StringPtr name) {
+    auto group = groups[groupsIndex++];
+    group.setName(name);
+
+    unsigned int structuresSize = sizeof...(Types);
+    auto structures = group.initStructures(structuresSize);
+    structureIndex = 0;
+    (writeStructure<Types>(builder, structures), ...);
+    KJ_ASSERT(structureIndex == structuresSize);
+  }
+
+  kj::String compatDate;
+  kj::Array<kj::String> compatFlags;
+
+  unsigned int groupsIndex = 0;
+  unsigned int structureIndex = 0;
+};
+
+} // namespace
+
+kj::Array<byte> RTTIModule::exportTypes(kj::String compatDate, kj::Array<kj::String> compatFlags) {
+  TypesEncoder encoder(kj::mv(compatDate), kj::mv(compatFlags));
+  return encoder.encode();
 }
 
-}
+} // namespace workerd::api

--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -1,0 +1,133 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "rtti.h"
+
+#include <kj/map.h>
+#include <capnp/serialize-packed.h>
+
+#include <workerd/api/actor.h>
+#include <workerd/api/actor-state.h>
+#include <workerd/api/analytics-engine.h>
+#include <workerd/api/cache.h>
+#include <workerd/api/crypto.h>
+#include <workerd/api/encoding.h>
+#include <workerd/api/global-scope.h>
+#include <workerd/api/html-rewriter.h>
+#include <workerd/api/kv.h>
+#include <workerd/api/modules.h>
+#include <workerd/api/queue.h>
+#include <workerd/api/r2.h>
+#include <workerd/api/r2-admin.h>
+#include <workerd/api/sockets.h>
+#include <workerd/api/scheduled.h>
+#include <workerd/api/sql.h>
+#include <workerd/api/streams/standard.h>
+#include <workerd/api/trace.h>
+#include <workerd/api/urlpattern.h>
+#include <workerd/api/node/node.h>
+#include <workerd/jsg/modules.capnp.h>
+
+#include <cloudflare/cloudflare.capnp.h>
+
+#define EW_TYPE_GROUP_FOR_EACH(F)                                              \
+  F("dom-exception", jsg::DOMException)                                        \
+  F("global-scope", EW_GLOBAL_SCOPE_ISOLATE_TYPES)                             \
+  F("durable-objects", EW_ACTOR_ISOLATE_TYPES)                                 \
+  F("durable-objects-state", EW_ACTOR_STATE_ISOLATE_TYPES)                     \
+  F("analytics-engine", EW_ANALYTICS_ENGINE_ISOLATE_TYPES)                     \
+  F("basics", EW_BASICS_ISOLATE_TYPES)                                         \
+  F("blob", EW_BLOB_ISOLATE_TYPES)                                             \
+  F("cache", EW_CACHE_ISOLATE_TYPES)                                           \
+  F("crypto", EW_CRYPTO_ISOLATE_TYPES)                                         \
+  F("encoding", EW_ENCODING_ISOLATE_TYPES)                                     \
+  F("form-data", EW_FORMDATA_ISOLATE_TYPES)                                    \
+  F("html-rewriter", EW_HTML_REWRITER_ISOLATE_TYPES)                           \
+  F("http", EW_HTTP_ISOLATE_TYPES)                                             \
+  F("kv", EW_KV_ISOLATE_TYPES)                                                 \
+  F("queue", EW_QUEUE_ISOLATE_TYPES)                                           \
+  F("r2-admin", EW_R2_PUBLIC_BETA_ADMIN_ISOLATE_TYPES)                         \
+  F("r2", EW_R2_PUBLIC_BETA_ISOLATE_TYPES)                                     \
+  F("scheduled", EW_SCHEDULED_ISOLATE_TYPES)                                   \
+  F("streams", EW_STREAMS_ISOLATE_TYPES)                                       \
+  F("trace", EW_TRACE_ISOLATE_TYPES)                                           \
+  F("url", EW_URL_ISOLATE_TYPES)                                               \
+  F("url-standard", EW_URL_STANDARD_ISOLATE_TYPES)                             \
+  F("url-pattern", EW_URLPATTERN_ISOLATE_TYPES)                                \
+  F("websocket", EW_WEBSOCKET_ISOLATE_TYPES)                                   \
+  F("sql", EW_SQL_ISOLATE_TYPES)                                               \
+  F("sockets", EW_SOCKETS_ISOLATE_TYPES)                                       \
+  F("node", EW_NODE_ISOLATE_TYPES)                                             \
+  F("rtti", EW_RTTI_ISOLATE_TYPES)
+
+namespace workerd::api {
+
+namespace {
+  struct EncoderErrorReporterImpl : public Worker::ValidationErrorReporter {
+    void addError(kj::String error) override { errors.add(kj::mv(error)); }
+    void addHandler(kj::Maybe<kj::StringPtr> exportName,
+                    kj::StringPtr type) override {
+      KJ_UNREACHABLE;
+    }
+
+    kj::Vector<kj::String> errors;
+  };
+
+  CompatibilityFlags::Reader compileFlags(capnp::MessageBuilder &message, kj::StringPtr compatDate,
+                                          bool experimental, kj::ArrayPtr<kj::String> compatFlags) {
+    // Based on src/workerd/io/compatibility-date-test.c++
+    auto orphanage = message.getOrphanage();
+    auto flagListOrphan =
+        orphanage.newOrphan<capnp::List<capnp::Text>>(compatFlags.size());
+    auto flagList = flagListOrphan.get();
+    for (auto i : kj::indices(compatFlags)) {
+      flagList.set(i, compatFlags.begin()[i]);
+    }
+
+    auto output = message.initRoot<CompatibilityFlags>();
+    EncoderErrorReporterImpl errorReporter;
+
+    compileCompatibilityFlags(compatDate, flagList.asReader(), output,
+                              errorReporter, experimental,
+                              CompatibilityDateValidation::FUTURE_FOR_TEST);
+
+    if (!errorReporter.errors.empty()) {
+      // TODO: AggregateError?
+      JSG_FAIL_REQUIRE(Error, errorReporter.errors[0]);
+    }
+
+    auto reader = output.asReader();
+    return kj::mv(reader);
+  }
+}
+
+kj::Array<byte> TypesEncoder::encode() {
+  capnp::MallocMessageBuilder flagsMessage;
+  CompatibilityFlags::Reader flags = compileFlags(flagsMessage, compatDate, false, compatFlags);
+
+  capnp::MallocMessageBuilder message;
+  auto root = message.initRoot<jsg::rtti::StructureGroups>();
+
+  // Encode RTTI structures
+  auto builder = jsg::rtti::Builder(flags);
+
+#define EW_TYPE_GROUP_COUNT(Name, Types) groupsSize++;
+#define EW_TYPE_GROUP_WRITE(Name, Types) writeGroup<Types>(groups, builder, Name);
+
+  unsigned int groupsSize = 0;
+  EW_TYPE_GROUP_FOR_EACH(EW_TYPE_GROUP_COUNT)
+  auto groups = root.initGroups(groupsSize);
+  groupsIndex = 0;
+  EW_TYPE_GROUP_FOR_EACH(EW_TYPE_GROUP_WRITE)
+  KJ_ASSERT(groupsIndex == groupsSize);
+
+#undef EW_TYPE_GROUP_COUNT
+#undef EW_TYPE_GROUP_WRITE
+
+  auto words = capnp::messageToFlatArray(message);
+  auto bytes = words.asBytes();
+  return kj::heapArray(bytes);
+}
+
+}

--- a/src/workerd/api/rtti.h
+++ b/src/workerd/api/rtti.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <initializer_list>
+#include <kj/array.h>
+#include <kj/string.h>
+#include <workerd/io/compatibility-date.h>
+#include <workerd/jsg/modules.h>
+#include <workerd/jsg/rtti.h>
+
+namespace workerd::api {
+
+struct TypesEncoder {
+public:
+  TypesEncoder(kj::String compatDate, kj::Array<kj::String> compatFlags): compatDate(kj::mv(compatDate)), compatFlags(kj::mv(compatFlags)) {}
+
+  kj::Array<byte> encode();
+
+private:
+  template <typename Type>
+  void writeStructure(jsg::rtti::Builder<CompatibilityFlags::Reader> &builder,
+                      capnp::List<jsg::rtti::Structure>::Builder structures) {
+    auto reader = builder.structure<Type>();
+    structures.setWithCaveats(structureIndex++, reader);
+  }
+
+  template <typename... Types>
+  void writeGroup(
+      capnp::List<jsg::rtti::StructureGroups::StructureGroup>::Builder &groups,
+      jsg::rtti::Builder<CompatibilityFlags::Reader> &builder, kj::StringPtr name) {
+    auto group = groups[groupsIndex++];
+    group.setName(name);
+
+    unsigned int structuresSize = sizeof...(Types);
+    auto structures = group.initStructures(structuresSize);
+    structureIndex = 0;
+    (writeStructure<Types>(builder, structures), ...);
+    KJ_ASSERT(structureIndex == structuresSize);
+  }
+
+  kj::String compatDate;
+  kj::Array<kj::String> compatFlags;
+
+  unsigned int groupsIndex = 0;
+  unsigned int structureIndex = 0;
+};
+
+class RTTIModule final: public jsg::Object {
+public:
+  kj::Array<byte> exportTypes(kj::String compatDate, kj::Array<kj::String> compatFlags) {
+    TypesEncoder encoder(kj::mv(compatDate), kj::mv(compatFlags));
+    return encoder.encode();
+  }
+
+  JSG_RESOURCE_TYPE(RTTIModule) {
+    JSG_METHOD(exportTypes);
+  }
+};
+
+template <class Registry>
+void registerRTTIModule(Registry& registry) {
+  registry.template addBuiltinModule<RTTIModule>("workerd:rtti",
+    workerd::jsg::ModuleRegistry::Type::BUILTIN);
+}
+
+#define EW_RTTI_ISOLATE_TYPES api::RTTIModule
+
+}

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -154,9 +154,9 @@ public:
   }
 };
 
-template <typename TypeWrapper>
+template <class Registry>
 void registerSocketsModule(
-    workerd::jsg::ModuleRegistryImpl<TypeWrapper>& registry, auto featureFlags) {
+    Registry& registry, auto featureFlags) {
   registry.template addBuiltinModule<SocketsModule>("cloudflare-internal:sockets",
     workerd::jsg::ModuleRegistry::Type::INTERNAL);
 

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -48,6 +48,7 @@ wd_cc_library(
         "//src/workerd/api:analytics-engine_capnp",
         "//src/workerd/api:r2-api_capnp",
         "//src/workerd/jsg",
+        "//src/workerd/jsg:rtti",
         "//src/workerd/util:sqlite",
         "@capnp-cpp//src/kj:kj-async",
         "@capnp-cpp//src/kj/compat:kj-gzip",

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -44,6 +44,7 @@ wd_cc_library(
         ":observer",
         ":trace",
         ":worker-interface",
+        "//src/cloudflare",
         "//src/node",
         "//src/workerd/api:analytics-engine_capnp",
         "//src/workerd/api:r2-api_capnp",

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -330,4 +330,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatEnableDate("2023-08-01");
   # Perform additional error checking in the Web Crypto API to conform with the specification as
   # well as reject key parameters that may be unsafe based on key length or public exponent.
+
+  rttiApi @34 :Bool
+      $compatEnableFlag("rtti_api")
+      $experimental;
+  # Enables the `workerd:rtti` module for querying runtime-type-information from JavaScript.
 }

--- a/src/workerd/jsg/modules.capnp
+++ b/src/workerd/jsg/modules.capnp
@@ -15,6 +15,7 @@ struct Module {
 
   name @0 :Text;
   src @1 :Data;
+  tsDeclaration @3 :Text;
 
   internal @2 :Bool;
   # internal modules can't be imported by user's code

--- a/src/workerd/jsg/rtti.capnp
+++ b/src/workerd/jsg/rtti.capnp
@@ -275,10 +275,17 @@ struct Constructor {
   args @0 :List(Type);
 }
 
+struct Module {
+  specifier @0 :Text;
+  internal @1 :Bool;
+  union {
+    structureName @2 :Text;
+    tsDeclarations @3 :Text;
+  }
+}
+
 struct StructureGroups {
   # Collection of structure groups, consumed by TypeScript definitions generator
-
-  groups @0 :List(StructureGroup);
 
   struct StructureGroup {
     # Collection of related structures
@@ -287,4 +294,8 @@ struct StructureGroups {
 
     structures @1 :List(Structure);
   }
+
+  groups @0 :List(StructureGroup);
+
+  modules @1 :List(Module);
 }

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -13,6 +13,7 @@
 #include <capnp/message.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/rtti.capnp.h>
+#include <kj/map.h>
 
 namespace workerd::jsg::rtti {
 

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -76,7 +76,6 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":workerd_capnp",
-        "//src/cloudflare",
         ":alarm-scheduler",
         "@capnp-cpp//src/capnp:capnpc",
         "//src/workerd/io",

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -18,6 +18,7 @@
 #include <workerd/api/html-rewriter.h>
 #include <workerd/api/kv.h>
 #include <workerd/api/queue.h>
+#include <workerd/api/rtti.h>
 #include <workerd/api/scheduled.h>
 #include <workerd/api/sockets.h>
 #include <workerd/api/streams/standard.h>
@@ -78,6 +79,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
   EW_WEBSOCKET_ISOLATE_TYPES,
   EW_SQL_ISOLATE_TYPES,
   EW_NODE_ISOLATE_TYPES,
+  EW_RTTI_ISOLATE_TYPES,
 
   jsg::TypeWrapperExtension<PromiseWrapper>,
   jsg::InjectConfiguration<CompatibilityFlags::Reader>,
@@ -373,6 +375,9 @@ kj::Own<jsg::ModuleRegistry> WorkerdApiIsolate::compileModules(
 
   if (getFeatureFlags().getNodeJsCompat()) {
     api::node::registerNodeJsCompatModules(*modules, getFeatureFlags());
+  }
+  if (getFeatureFlags().getRttiApi()) {
+    api::registerRTTIModule(registry);
   }
 
   api::registerSocketsModule(*modules, getFeatureFlags());

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -17,8 +17,8 @@
 #include <workerd/api/global-scope.h>
 #include <workerd/api/html-rewriter.h>
 #include <workerd/api/kv.h>
+#include <workerd/api/modules.h>
 #include <workerd/api/queue.h>
-#include <workerd/api/rtti.h>
 #include <workerd/api/scheduled.h>
 #include <workerd/api/sockets.h>
 #include <workerd/api/streams/standard.h>
@@ -34,8 +34,6 @@
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
 
-#include <cloudflare/cloudflare.capnp.h>
-
 namespace workerd::server {
 
 JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
@@ -50,8 +48,8 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
   // types defined in worker.c++ or as part of jsg.
   //
   // When adding a new NNNN_ISOLATE_TYPES macro, remember to add it to
-  // src/workerd/tools/api-encoder.c++ too, so it gets included in the
-  // TypeScript types.
+  // src/workerd/api/rtti.c++ too (and tools/api-encoder.c++ for the
+  // time being), so it gets included in the TypeScript types.
   EW_GLOBAL_SCOPE_ISOLATE_TYPES,
 
   EW_ACTOR_ISOLATE_TYPES,
@@ -373,15 +371,7 @@ kj::Own<jsg::ModuleRegistry> WorkerdApiIsolate::compileModules(
     }
   }
 
-  if (getFeatureFlags().getNodeJsCompat()) {
-    api::node::registerNodeJsCompatModules(*modules, getFeatureFlags());
-  }
-  if (getFeatureFlags().getRttiApi()) {
-    api::registerRTTIModule(registry);
-  }
-
-  api::registerSocketsModule(*modules, getFeatureFlags());
-  modules->addBuiltinBundle(CLOUDFLARE_BUNDLE);
+  api::registerModules(*modules, getFeatureFlags());
 
   jsg::setModulesForResolveCallback<JsgWorkerdIsolate_TypeWrapper>(lock, modules);
 


### PR DESCRIPTION
Hey! 👋 This PR adds a `workerd:rtti` module (gated behind an experimental `rtti_api` compatibility flag), for accessing RTTI.

This allows us to move automatic type generation for `@cloudflare/workers-types` into a worker, and dynamically generate types based on compatibility dates and flags. This worker would be accessible by the quick editor, and `wrangler` for local dev (we could also run this worker locally for fully-offline development).

TypeScript declaration files for internal and builtin modules are also included in JavaScript bundles, allowing us to include these in generated types (i.e. we can now include types for the `nodejs_compat` flag in `@cloudflare/workers-types`).

Once we have this worker setup, we should be able to remove `src/workerd/tools/api-encoder.c++`.