### PR TITLE
workerd: Use --single-threaded-gc

### DIFF
--- a/build-releases.sh
+++ b/build-releases.sh
@@ -15,12 +15,9 @@ TAG_NAME=$(curl -sL https://api.github.com/repos/cloudflare/workerd/releases/lat
 git checkout $TAG_NAME
 
 # Build macOS binary
-#
-# This is using fastbuild rather than opt until SIGBUS issue with the opt binary are resolved.
-# The issue is tracked in https://github.com/cloudflare/workers-sdk/issues/2386.
-pnpm exec bazelisk build -c fastbuild //src/workerd/server:workerd
-echo Stripping binary
-strip bazel-bin/src/workerd/server/workerd -o ./workerd-darwin-arm64
+pnpm exec bazelisk build --disk_cache=./.bazel-cache -c opt //src/workerd/server:workerd
+
+cp bazel-bin/src/workerd/server/workerd ./workerd-darwin-arm64
 
 docker buildx build --platform linux/arm64 -f Dockerfile.release -t workerd:$TAG_NAME --target=artifact --output type=local,dest=$(pwd) .
 

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -114,6 +114,17 @@ V8System::V8System(kj::Own<v8::Platform> platformParam, kj::ArrayPtr<const kj::S
   // more flags.)
   v8::V8::SetFlagsFromString("--noincremental-marking");
 
+#ifdef __APPLE__
+  // On macOS arm64, we find that V8 can be collecting pages that contain compiled code when
+  // handling requests in short succession. There are some specific differences for macOS arm64
+  // that may be a factor:
+  //   https://chromium.googlesource.com/v8/v8.git/+/refs/tags/11.5.150.4/src/heap/heap.h#2523
+  //
+  // Bugs attributable to this are https://github.com/cloudflare/workers-sdk/issues/2386 and
+  // CUSTESC-29094.
+  v8::V8::SetFlagsFromString("--single-threaded-gc");
+#endif  // __APPLE__
+
 #ifdef WORKERD_ICU_DATA_EMBED
   // V8's bazel build files currently don't support the option to embed ICU data, so we do it
   // ourselves. `WORKERD_ICU_DATA_EMBED`, if defined, will refer to a `kj::ArrayPtr<const byte>`


### PR DESCRIPTION
workerd: Use --single-threaded-gc

Consecutive requests could lead to calling into the isolate whilst code pages are being collected. This problem has only been observed on macOS arm64.

Bug: CUSTESC-29094
Bug: https://github.com/cloudflare/workers-sdk/issues/2386