### PR TITLE
Surface websocket protocol errors to user applications

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -130,8 +130,8 @@ git_repository(
 
 # tcmalloc requires Abseil.
 #
-# WARNING: This MUST appear before rules_fuzzing_depnedencies(), below. Otherwise,
-#   rules_fuzzing_depnedencies() will choose to pull in a different version of Abseil that is too
+# WARNING: This MUST appear before rules_fuzzing_dependencies(), below. Otherwise,
+#   rules_fuzzing_dependencies() will choose to pull in a different version of Abseil that is too
 #   old for tcmalloc. Absurdly, Bazel simply ignores later attempts to define the same repo name,
 #   rather than erroring out. Thus this leads to confusing compiler errors in tcmalloc complaining
 #   that ABSL_ATTRIBUTE_PURE_FUNCTION is not defined.

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -26,6 +26,7 @@
 #include <workerd/util/http-util.h>
 #include <workerd/api/actor-state.h>
 #include <workerd/util/mimetype.h>
+#include "src/workerd/api/web-socket.h"
 #include "workerd-api.h"
 #include "workerd/io/hibernation-manager.h"
 #include <stdlib.h>
@@ -2771,11 +2772,13 @@ private:
         : parent(parent), cfBlobJson(kj::mv(cfBlobJson)),
           listedHttp(parent.owner, parent.timer, parent.headerTable, *this, kj::HttpServerSettings {
             .errorHandler = *this,
+            .webSocketErrorHandler = this->webSocketErrorHandler,
             .webSocketCompressionMode = kj::HttpServerSettings::MANUAL_COMPRESSION
           }) {}
 
     HttpListener& parent;
     kj::Maybe<kj::String> cfBlobJson;
+    workerd::api::WebSocketErrorHandler webSocketErrorHandler;
     ListedHttpServer listedHttp;
 
     class ResponseWrapper final: public kj::HttpService::Response {


### PR DESCRIPTION
Currently, if a websocket client sends bad data[1] to an application, the application just receives a generic error message with no indication of what went wrong. Also, the client just gets an aborted[2] websocket connection without any clue as to what they did wrong.

This commit changes two things: first, the application now gets an error event describing what was wrong with the received data. This gives the application's owner some clue what's going wrong.

Second, we now send a Close frame to the client with an appropriate error code, as we SHOULD do[3]. In an ideal world, this will let the client's owner figure out what they're doing wrong and fix it.

[1] Invalid according to RFC 6455, for example sending a continuation frame without a preceding start frame or sending a frame with reserved bits (RSV1, RSV2, and RSV3; see
https://datatracker.ietf.org/doc/html/rfc6455#section-5.2) set.

[2] The underlying TCP connection is closed without first sending a websocket "Close" frame.

[3] https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.7