### PR TITLE
[SQLite] Refactor Authorizer

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -549,15 +549,25 @@ async function test(storage) {
     RENAME TO afterrename;
   `)
 
-  // Can rename columns within a table
   sql.exec(`
-    CREATE TABLE renamecolumn (
+    CREATE TABLE altercolumns (
       meta TEXT
      );
   `);
+  // Can add columns
   sql.exec(`
-    ALTER TABLE renamecolumn
+    ALTER TABLE altercolumns
+    ADD COLUMN tobedeleted TEXT;
+  `);
+  // Can rename columns within a table
+  sql.exec(`
+    ALTER TABLE altercolumns
     RENAME COLUMN meta TO metadata
+  `);
+  // Can drop columns
+  sql.exec(`
+    ALTER TABLE altercolumns
+    DROP COLUMN tobedeleted
   `);
 
   // Can't create another temp table


### PR DESCRIPTION
Introduce VALUE_GATE macro to capture which "db names" (usually param3) are allowed for each actionCode

This replaces `isAuthorizedTemp`, by permitting "temp" as param3 to SQLITE_READ and SQLITE_UPDATE.

Also note that for SQLITE_ALTER_TABLE, "db name" is sent as param1 not param3 (afaik it's the only one that we support that does this). This might be a sqlite bug, as it conflicts with the following comment

> CAPI3REF: Authorizer Action Codes
> 
> The [sqlite3_set_authorizer()] interface registers a callback function
> that is invoked to authorize certain SQL statement actions.  The
> second parameter to the callback is an integer code that specifies
> what action is being authorized.  These are the integer action codes that
> the authorizer callback may be passed.
> 
> These action code values signify what kind of operation is to be
> authorized.  The 3rd and 4th parameters to the authorization
> callback function will be parameters or NULL depending on which of these
> codes is used as the second parameter.  **^(The 5th parameter to the
> authorizer callback is the name of the database ("main", "temp",
> etc.) if applicable.)^**  ^The 6th parameter to the authorizer callback
> is the name of the inner-most trigger or view that is responsible for
> the access attempt or NULL if this access attempt is directly from
> top-level SQL code.

I've also allow-listed a lot of `nullptr` values to match existing behaviour, but many of these SQLite actions don't actually need it. But I can do that as a separate PR.