### PR TITLE
Fix v8 deprecation warning

### DIFF
--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -237,7 +237,7 @@ void HeapTracer::ResetRoot(const v8::TracedReference<v8::Value>& handle) {
   // returned false earlier. It may still be reachable via C++, but we can recreate the wrapper
   // as needed if the C++ object is exported to JavaScript again later.
   auto& wrappable = *reinterpret_cast<Wrappable*>(
-      handle.As<v8::Object>()->GetAlignedPointerFromInternalField(
+      handle.As<v8::Object>().Get(isolate)->GetAlignedPointerFromInternalField(
           Wrappable::WRAPPED_OBJECT_FIELD_INDEX));
 
   // V8 gets angry if we do not EXPLICITLY call `Reset()` on the wrapper. If we merely destroy it


### PR DESCRIPTION
The warning
```
INFO: From Compiling src/workerd/jsg/setup.c++:
src/workerd/jsg/setup.c++:240:30: warning: 'operator->' is deprecated: Use Get to convert to Local instead [-Wdeprecated-declarations]
      handle.As<v8::Object>()->GetAlignedPointerFromInternalField(
                             ^
external/v8/include/v8-traced-handle.h:143:3: note: 'operator->' has been explicitly marked deprecated here
  V8_DEPRECATE_SOON("Use Get to convert to Local instead")
  ^
external/v8/include/v8config.h:554:39: note: expanded from macro 'V8_DEPRECATE_SOON'
# define V8_DEPRECATE_SOON(message) [[deprecated(message)]]
```