### PR TITLE
Make setupSocket() callable by other API implementations

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -65,6 +65,8 @@ bool getAllowHalfOpen(jsg::Optional<SocketOptions>& opts) {
   return false;
 }
 
+} // namespace
+
 jsg::Ref<Socket> setupSocket(
     jsg::Lock& js, kj::Own<kj::AsyncIoStream> connection,
     jsg::Optional<SocketOptions> options, kj::Own<kj::TlsStarterCallback> tlsStarter,
@@ -156,8 +158,6 @@ jsg::Ref<Socket> setupSocket(
   }
   return result;
 }
-
-} // namespace
 
 jsg::Ref<Socket> connectImplNoOutputLock(
     jsg::Lock& js, jsg::Ref<Fetcher> fetcher, AnySocketAddress address,

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -129,6 +129,11 @@ private:
   }
 };
 
+jsg::Ref<Socket> setupSocket(
+    jsg::Lock& js, kj::Own<kj::AsyncIoStream> connection,
+    jsg::Optional<SocketOptions> options, kj::Own<kj::TlsStarterCallback> tlsStarter,
+    bool isSecureSocket, kj::String domain, bool isDefaultFetchPort);
+
 jsg::Ref<Socket> connectImplNoOutputLock(
     jsg::Lock& js, jsg::Ref<Fetcher> fetcher, AnySocketAddress address,
     jsg::Optional<SocketOptions> options);


### PR DESCRIPTION
So that they can return a properly configured Socket when appropriate.

This is used by an API I'm working on that will mostly be implemented internally, but wants to return a Socket.