### PR TITLE
Fix release build versioning

### DIFF
--- a/.github/workflows/npm-types.yml
+++ b/.github/workflows/npm-types.yml
@@ -19,7 +19,7 @@ jobs:
       version: ${{ steps.echo.outputs.version }}
       date: ${{ steps.echo.outputs.date }}
       release_version: ${{ steps.echo.outputs.release_version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: bazelbuild/setup-bazelisk@v2
@@ -38,7 +38,7 @@ jobs:
           echo "version=${{ inputs.prerelease == false && '4' || '0'}}.$(bazel-bin/external/capnp-cpp/src/capnp/capnp_tool eval src/workerd/io/compatibility-date.capnp supportedCompatibilityDate | tr -d '-' | tr -d '"').${{ inputs.patch }}" >> $GITHUB_OUTPUT;
           echo "release_version=1.$(bazel-bin/external/capnp-cpp/src/capnp/capnp_tool eval src/workerd/io/compatibility-date.capnp supportedCompatibilityDate | tr -d '-' | tr -d '"').0" >> $GITHUB_OUTPUT;
   build-and-publish-types:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: version
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -19,7 +19,7 @@ jobs:
       version: ${{ steps.echo.outputs.version }}
       date: ${{ steps.echo.outputs.date }}
       release_version: ${{ steps.echo.outputs.release_version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: bazelbuild/setup-bazelisk@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,9 @@ jobs:
   version:
     outputs:
       version: ${{ steps.echo.outputs.version }}
-    runs-on: ubuntu-20.04
+    # version job uses ubuntu 22.04, this way we don't have to install the updated clang while
+    # the build job uses 20.04 for libc compatibility.
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: bazelbuild/setup-bazelisk@v2


### PR DESCRIPTION
#800 changed the Linux runner image to Ubuntu 20.04, but only adjusted the clang version for the main test and release builds, causing other jobs that need to compile capnp_tool to fail.