### PR TITLE
Update docs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "eamodio.gitlens",
     "llvm-vs-code-extensions.vscode-clangd",
     "ms-vscode.cpptools",
-    "abronan.capnproto-syntax"
+    "abronan.capnproto-syntax",
+    "DavidAnson.vscode-markdownlint"
   ]
 }

--- a/docs/v8-updates.md
+++ b/docs/v8-updates.md
@@ -2,18 +2,18 @@
 
 To update the version of V8 used by workerd, the steps are:
 
-1. Check https://omahaproxy.appspot.com/ and identify the latest version of V8 used by the beta versions of Chrome beta.
+1. Check <https://omahaproxy.appspot.com/> and identify the latest version of V8 used by the beta versions of Chrome beta.
 
 2. Install depot_tools if it is not already present on your machine.
 
-   https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up
+   <https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up>
 
 3. Fetch a local copy of V8:
 
-   ```
-   $ mkdir v8
-   $ cd v8
-   $ fetch v8
+   ```sh
+   mkdir v8
+   cd v8
+   fetch v8
    ```
 
 4. Sync the local copy of V8 to the version used by workerd.
@@ -22,25 +22,25 @@ To update the version of V8 used by workerd, the steps are:
 
    Then sync your fetched version v8 so that it corresponds to that hash.
 
-   ```
-   $ cd v8/v8
-   $ git checkout <commit_hash>
-   $ gclient sync
+   ```sh
+   cd v8/v8
+   git checkout <commit_hash>
+   gclient sync
    ```
 
 5. Create a V8 branch for workerd's V8 patches in your local copy of V8.
 
-   ```
-   $ git checkout -b workerd-patches
-   $ git am <path_to_workerd>/patches/v8/*
+   ```sh
+   git checkout -b workerd-patches
+   git am <path_to_workerd>/patches/v8/*
    ```
 
-7. Rebase the workerd V8 changes onto the new version of V8. For example, assuming
+6. Rebase the workerd V8 changes onto the new version of V8. For example, assuming
    we are updating to 11.4.183.8 and there are 8 workerd patches for V8, the
    command would be:
 
-   ```
-   $ git rebase --onto 11.4.183.8 HEAD~8
+   ```sh
+   git rebase --onto 11.4.183.8 HEAD~8
    ```
 
    There is usually some minor patch editing required during a rebase.
@@ -48,17 +48,17 @@ To update the version of V8 used by workerd, the steps are:
    Ideally at this stage, you should be able to build and test the local V8 with the
    patches applied. See the V8 [Testing](https://v8.dev/docs/test) page.
 
-8. Re-generate workerd's V8 patches. Assuming there are 8 workerd patches for V8,
+7. Re-generate workerd's V8 patches. Assuming there are 8 workerd patches for V8,
    the command would be:
 
-   ```
-   $ git format-patch --full-index -k --no-signature HEAD~8
+   ```sh
+   git format-patch --full-index -k --no-signature HEAD~8
    ```
 
-9. Remove the existing patches from `workerd/patches/v8` and copy the latest patches
+8. Remove the existing patches from `workerd/patches/v8` and copy the latest patches
    for the V8 directory there.
 
-10. Update the `git_repository` for V8 in the `workerd/WORKSPACE` file.
+9. Update the `git_repository` for V8 in the `workerd/WORKSPACE` file.
 
     The list of patches should be refreshed if new patches are being added or existing
     patches are being removed.
@@ -69,30 +69,30 @@ To update the version of V8 used by workerd, the steps are:
 
     See [V8 git_repository in WORKSPACE](https://github.com/cloudflare/workerd/blob/2d124ecd2d1132537d37bd5e166ac1aec4f7397f/WORKSPACE#L263)
 
-11. Update V8's dependencies in `workerd/WORKSPACE`.
+10. Update V8's dependencies in `workerd/WORKSPACE`.
 
-   The `v8/.gclient_entries` file contains the commit versions for V8's dependencies.
+    The `v8/.gclient_entries` file contains the commit versions for V8's dependencies.
 
-   You can find V8's dependencies that are carried through to workerd in the `WORKSPACE` file.
+    You can find V8's dependencies that are carried through to workerd in the `WORKSPACE` file.
 
-   You will usually update `com_google_chromium_icu`, but other projects may need updating
-   too. Typically you'll get a build failure if the projects are out of sync. Copy the
-   commit versions from `v8/.gclient_entries` to the `WORKSPACE` file.
+    You will usually update `com_google_chromium_icu`, but other projects may need updating
+    too. Typically you'll get a build failure if the projects are out of sync. Copy the
+    commit versions from `v8/.gclient_entries` to the `WORKSPACE` file.
 
-12. Check workerd's tests pass with the updated V8.
+11. Check workerd's tests pass with the updated V8.
 
-    ```
-    $ bazel test //...
-    ```
+     ```sh
+     bazel test //...
+     ```
 
     You may see advice in the build output about shallow-since dates for the V8 related
     git repositories:
 
-    ```
+    ```sh
     DEBUG: Rule 'v8' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1683898886 +0000"
     ```
 
     You can follow the advice in these messages and update the shallow-since dates for
     the V8 related git repositories in the WORKSPACE file.
 
-13. Commit your workerd changes and push them for review.
+12. Commit your workerd changes and push them for review.

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -6,10 +6,9 @@ Visual Studio Code is a commonly used editor by workerd developers (other editor
 
 The recommended extensions to install are:
 
-* [LLVM clangd extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd)
-for code completion and navigation.
+* [LLVM clangd extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) for code completion and navigation.
 
-  For clangd to work well, you need to generate a `compile_commands.json` file. This is described below in [Generating compile_commands.json](#generating-compile_commandsjson).
+  This is described below in [Clangd code completion, navigation, language server](#clangd-code-completion-navigation-language-server).
 
 * [Microsoft C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) for debugging, syntax highlighting, etc.
 
@@ -18,6 +17,8 @@ for code completion and navigation.
 * [Capnproto-syntax extension](https://marketplace.visualstudio.com/items?itemName=abronan.capnproto-syntax) for syntax highlighting if you are editing `.capnp` files.
 
 * [GitLens extension](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) for super charged git functionality within Visual Studio Code.
+
+* [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) for creating well formed markdown documents.
 
 You can install all of these extensions with the **Extensions: Configure Recommended Extensions (Workspace Folder)** command. You can find this through the Visual Studio Code Command Palette (`shift+ctrl+p` on Linux / Windows, `shift+cmd+p` on OS X) and typing "Configure Recommended Extensions". The recommendations that will be installed can be found in the [.vscode/extensions.json](../.vscode/extensions.json) file.
 
@@ -48,7 +49,7 @@ There are workerd debugging targets within Visual Studio Code which are supporte
 The [.vscode/launch.json](../.vscode/launch.json) file has launch targets to that can be debugged within VSCode.
 
 Before you start debugging, ensure that you have saved a vscode workspace for workerd,
-"File → Save Workspace As...". For more information about workspaces, see https://code.visualstudio.com/docs/editor/workspaces.
+"File → Save Workspace As...". For more information about workspaces, see <https://code.visualstudio.com/docs/editor/workspaces>.
 
 The **Run and Debug** view in VSCode (accessible via `shift+ctrl+d` on Linux and Windows, `shift+cmd+d` on OS X) has a drop-down that allows you to choose which target to run and debug. After selecting a target, hitting `F5` will launch the
 target with the debugger attached.
@@ -73,13 +74,17 @@ We use clangd for code completion and navigation within the Visual Code. We use 
 [compile_flags.txt](../compile_flags.txt) option provide compiler arguments for clangd to analyze sources.
 
 If `compile_flags.txt` is not working well on your system, try running:
-```
+
+```sh
 bazel build --copt="-MD" --cxxopt="-MD" //src/workerd/server:workerd
 ```
+
 to generate dependency files and:
-```
+
+```sh
 find bazel-out/ -name '*.d'`
 ```
+
 to locate the generated dependency files. These files will help you align the include paths in
 `compile_flags.txt` with the ones that the bazel build is using.
 
@@ -89,7 +94,7 @@ Visual Studio Code.
 
 In the past we used [Hedron's Bazel Compile Commands Extractor](https://github.com/hedronvision/bazel-compile-commands-extractor)
 to generate a `compile_commands.json` file for clangd, but this was slow and unreliable for the `workerd` use case
-(see https://github.com/cloudflare/workerd/issues/506).
+(see <https://github.com/cloudflare/workerd/issues/506>).
 
 ## Miscellaneous tips
 


### PR DESCRIPTION
Fixes left over compile_commands.json text in docs/vscode.md.

Adds reference to markdownlint extension that was useful in revising doc and applies it to v8-updates.md too.