### PR TITLE
Rename trace diagnosticChannelEvents to diagnosticsChannelEvents

### DIFF
--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -81,7 +81,7 @@ public:
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(eventTimestamp, getEventTimestamp);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(logs, getLogs);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(exceptions, getExceptions);
-    JSG_LAZY_READONLY_INSTANCE_PROPERTY(diagnosticChannelEvents, getDiagnosticChannelEvents);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(diagnosticsChannelEvents, getDiagnosticChannelEvents);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptName, getScriptName);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(dispatchNamespace, getDispatchNamespace);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptTags, getScriptTags);


### PR DESCRIPTION
This hasn't yet gone out in a release so renaming is safe.

Per the suggestion from @tanushreesharma-cf 