### PR TITLE
Bump compatibility date to `2023-06-28` for release

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -8,7 +8,7 @@ using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("workerd");
 $Cxx.allowCancellation;
 
-const supportedCompatibilityDate :Text = "2023-05-18";
+const supportedCompatibilityDate :Text = "2023-06-28";
 # Newest compatibility date that can safely be set using code compiled from this repo. Trying to
 # run a Worker with a newer compatibility date than this will fail.
 #


### PR DESCRIPTION
We're hoping to get a Wrangler release out today (assuming LDW exception granted), with a `workerd` bump. `workerd` releases can take a few hours to get ready, so creating this PR now. We'll still need to manually trigger the npm publish, so if the exception isn't granted, we can just abort the release. 👍 