### PR TITLE
Add API for current date string based on CompatDate

### DIFF
--- a/src/workerd/io/compatibility-date.c++
+++ b/src/workerd/io/compatibility-date.c++
@@ -87,6 +87,10 @@ struct CompatDate {
 
 }  // namespace
 
+kj::String currentDateStr() {
+  return CompatDate::today().toString();
+}
+
 void compileCompatibilityFlags(kj::StringPtr compatDate, capnp::List<capnp::Text>::Reader compatFlags,
                          CompatibilityFlags::Builder output,
                          Worker::ValidationErrorReporter& errorReporter,

--- a/src/workerd/io/compatibility-date.h
+++ b/src/workerd/io/compatibility-date.h
@@ -48,6 +48,9 @@ kj::Array<kj::StringPtr> decompileCompatibilityFlagsForFl(CompatibilityFlags::Re
 kj::Maybe<kj::String> normalizeCompatDate(kj::StringPtr date);
 // Exposed to unit test the parser.
 
+kj::String currentDateStr();
+// Returns the current date as a string formatted by CompatDate.
+
 // These values come from src/workerd/io/compatibility-date.capnp
 static constexpr uint64_t COMPAT_ENABLE_FLAG_ANNOTATION_ID = 0xb6dabbc87cd1b03eull;
 static constexpr uint64_t COMPAT_DISABLE_FLAG_ANNOTATION_ID = 0xd145cf1adc42577cull;


### PR DESCRIPTION
This makes it possible to more easily set up compatibility flags based on the current date and avoids putting the entire CompatDate class in the header. Also see the upstream PR.