### PR TITLE
Fix flakey alarm tests

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -58,8 +58,4 @@ kj_test(
     data = [f.removesuffix(".wd-test") + ".js"],
 ) for f in glob(
     ["**/*.wd-test"],
-    exclude = [
-        # TODO(soon): actor-alarms-delete-test is flaky, fix it and enable it again
-        "actor-alarms-delete-test.wd-test",
-    ],
 )]

--- a/src/workerd/server/alarm-scheduler.c++
+++ b/src/workerd/server/alarm-scheduler.c++
@@ -171,10 +171,26 @@ AlarmScheduler::ScheduledAlarm AlarmScheduler::scheduleAlarm(
   return ScheduledAlarm { kj::mv(actor), scheduledTime, kj::mv(task) };
 }
 
+kj::Promise<void> AlarmScheduler::checkTimestamp(kj::Date now, kj::Date scheduledTime) {
+  // Since we are waiting on timer.afterDelay, it's possible that clock.now() was behind the real time
+  // by a few ms, leading to premature alarm() execution. This checks it the current time is >= than
+  // scheduledTime to ensure we run alarms only on or after their scheduled time.
+  if (now >= scheduledTime) {
+    return kj::READY_NOW;
+  }
+  // If it's not yet time to trigger the alarm, we shall wait a while longer until we can trigger it.
+  // This repeats until it's time for the alarm to run.
+  kj::Duration delay = scheduledTime - clock.now();
+  return timer.afterDelay(delay).then([this,scheduledTime]() mutable
+      -> kj::Promise<void> {
+    return checkTimestamp(clock.now(), scheduledTime);
+  });
+}
+
 kj::Promise<void> AlarmScheduler::makeAlarmTask(
     kj::Duration delay, const ActorKey& actorRef, kj::Date scheduledTime) {
-  return timer.afterDelay(delay).then([this, actor = actorRef.clone(), scheduledTime]() mutable
-      -> kj::Promise<RetryInfo> {
+  return checkTimestamp(clock.now(), scheduledTime)
+      .then([this, actor = actorRef.clone(), scheduledTime]() mutable -> kj::Promise<RetryInfo> {
     {
       auto& entry = KJ_ASSERT_NONNULL(alarms.findEntry(*actor));
       entry.value.status = AlarmStatus::STARTED;

--- a/src/workerd/server/alarm-scheduler.h
+++ b/src/workerd/server/alarm-scheduler.h
@@ -120,6 +120,8 @@ private:
 
   kj::Promise<void> makeAlarmTask(kj::Duration delay, const ActorKey& actor, kj::Date scheduledTime);
 
+  kj::Promise<void> checkTimestamp(kj::Date now, kj::Date scheduledTime);
+
   SqliteDatabase::Statement stmtSetAlarm = db->prepare(R"(
     INSERT INTO _cf_ALARM VALUES(?, ?, ?)
       ON CONFLICT DO UPDATE SET scheduled_time = excluded.scheduled_time;


### PR DESCRIPTION
This PR should fix flakey alarm tests.

During CI, it can happen that `Date.now() < scheduledTime` by a few ms. We could be less strict about this, adding a few ms margin.