### PR TITLE
Add some const accessors.

### DIFF
--- a/src/workerd/api/blob.h
+++ b/src/workerd/api/blob.h
@@ -34,8 +34,8 @@ public:
 
   static jsg::Ref<Blob> constructor(jsg::Optional<Bits> bits, jsg::Optional<Options> options);
 
-  int getSize() { return data.size(); }
-  kj::StringPtr getType() { return type; }
+  int getSize() const { return data.size(); }
+  kj::StringPtr getType() const { return type; }
 
   jsg::Ref<Blob> slice(jsg::Optional<int> start, jsg::Optional<int> end,
                         jsg::Optional<kj::String> type);

--- a/src/workerd/api/form-data.h
+++ b/src/workerd/api/form-data.h
@@ -19,6 +19,11 @@ class URLSearchParams;
 class FormData: public jsg::Object {
   // Implements the FormData interface as prescribed by:
   // https://xhr.spec.whatwg.org/#interface-formdata
+  //
+  // NOTE: This class is actually reused by some internal code implementing the fiddle service, for
+  //   lack of any other C++ form data parser implementation. In that usage, there is no isolate.
+  //   It uses `parse()` and `getData()`. This relies on the ability to construct `File` objects
+  //   without an isolate.
 private:
   using EntryType = kj::OneOf<jsg::Ref<File>, kj::String>;
   using EntryIteratorType = kj::Array<EntryType>;

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1048,6 +1048,10 @@ public:
   T* operator->() { return inner.get(); }
   T* get() { return inner.get(); }
 
+  const T& operator*() const { return *inner; }
+  const T* operator->() const { return inner.get(); }
+  const T* get() const { return inner.get(); }
+
   Ref addRef() & {
     return Ref(kj::addRef(*inner));
   }

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -199,7 +199,10 @@ v8::Local<v8::Object> Wrappable::getHandle(v8::Isolate* isolate) {
 }
 
 void Wrappable::addStrongRef() {
-  KJ_DREQUIRE(v8::Isolate::TryGetCurrent() != nullptr, "referencing wrapper without isolate lock");
+  // The `isolate == nullptr` check here ensures that `jsg::alloc<T>()` can be used with no
+  // isolate, simply allocating the object as a normal C++ heap object.
+  KJ_DREQUIRE(isolate == nullptr || v8::Isolate::TryGetCurrent() != nullptr,
+      "referencing wrapper without isolate lock");
   if (strongRefcount++ == 0) {
     // This object previously had no strong references, but now it has one.
     KJ_IF_MAYBE(w, wrapper) {


### PR DESCRIPTION
`api::FormData::getData()` (an interface meant for C++ callers, not JS) returns a const array, but the array contains instances of `jsg::Ref<File>`. Before this commit, those refs couldn't actually be used due to the constness.

(To be used in some internal code.)