### PR TITLE
Implement MimeType parser and class

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -61,6 +61,7 @@ build:unix --cxxopt='-Wno-sign-compare' --host_cxxopt='-Wno-sign-compare'
 build:unix --cxxopt='-Wno-unused-parameter' --host_cxxopt='-Wno-unused-parameter'
 build:unix --cxxopt='-Wno-missing-field-initializers' --host_cxxopt='-Wno-missing-field-initializers'
 build:unix --cxxopt='-Wno-ignored-qualifiers' --host_cxxopt='-Wno-ignored-qualifiers'
+build:unix --cxxopt="-fbracket-depth=512" --host_cxxopt="-fbracket-depth=512"
 
 # Temporary workaround for zlib warnings and mac compilation, should no longer be needed with next
 # zlib release (https://github.com/madler/zlib/issues/633)
@@ -107,5 +108,6 @@ build:windows --cxxopt='-Wno-unused-command-line-argument' --host_cxxopt='-Wno-u
 # being detected as clang...
 # TODO(soon): Integrate this into V8 instead
 build:windows --cxxopt='-Wno-invalid-offsetof' --host_cxxopt='-Wno-invalid-offsetof'
+build:windows --cxxopt="-fbracket-depth=512" --host_cxxopt="-fbracket-depth=512"
 
 build:windows --@capnp-cpp//src/kj:openssl=True --@capnp-cpp//src/kj:zlib=True --@capnp-cpp//src/kj:brotli=True

--- a/src/node/internal/util.d.ts
+++ b/src/node/internal/util.d.ts
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export abstract class MIMEType {
+  public constructor(input: string);
+  public type: string;
+  public subtype: string;
+  public readonly essence: string;
+  public readonly params: MIMEParams;
+  public toString(): string;
+  public toJSON(): string;
+}
+
+export abstract class MIMEParams {
+  public constructor();
+  public delete(name: string): void;
+  public get(name: string): string|undefined;
+  public has(name: string): boolean;
+  public set(name: string, value: string): void;
+  public entries(): Iterable<string[]>;
+  public keys(): Iterable<string>;
+  public values(): Iterable<string>;
+}

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -6,6 +6,7 @@
 /* eslint-disable */
 
 import { default as internalTypes } from 'node-internal:internal_types';
+import { default as utilImpl } from 'node-internal:util';
 
 import {
   validateFunction
@@ -23,6 +24,11 @@ export {
 import { format } from 'node-internal:internal_format';
 
 export const types = internalTypes;
+
+export const {
+  MIMEParams,
+  MIMEType,
+} = utilImpl;
 
 const callbackifyOnRejected = (reason: unknown, cb : Function) => {
   if (!reason) {
@@ -165,6 +171,8 @@ export default {
   format,
   inherits,
   _extend,
+  MIMEParams,
+  MIMEType,
 };
 
 // Node.js util APIs we're currently not supporting

--- a/src/workerd/api/html-rewriter.c++
+++ b/src/workerd/api/html-rewriter.c++
@@ -1042,12 +1042,14 @@ jsg::Ref<Response> HTMLRewriter::transform(jsg::Lock& js, jsg::Ref<Response> res
   auto outputSink = ts->getWritable()->removeSink(js);
 
   kj::String ownContentType;
-  kj::ArrayPtr<const char> encoding = "utf-8"_kj;
+  kj::String encoding = kj::str("utf-8");
   auto contentTypeKey = jsg::ByteString(kj::str("content-type"));
   KJ_IF_MAYBE(contentType, response->getHeaders(js)->get(kj::mv(contentTypeKey))) {
+    // TODO(cleanup): readContentTypeParameter can be replaced with using
+    // workerd/util/mimetype.h directly.
     KJ_IF_MAYBE(charset, readContentTypeParameter(*contentType, "charset")) {
       ownContentType = kj::mv(*contentType);
-      encoding = *charset;
+      encoding = kj::mv(*charset);
     }
   }
 

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -8,6 +8,7 @@
 #include <workerd/io/features.h>
 #include <workerd/io/limit-enforcer.h>
 #include <workerd/util/http-util.h>
+#include <workerd/util/mimetype.h>
 #include <workerd/io/io-context.h>
 #include <kj/encoding.h>
 #include <kj/compat/http.h>
@@ -338,7 +339,7 @@ jsg::Promise<void> KvNamespace::put(
 
     KJ_SWITCH_ONEOF(supportedBody) {
       KJ_CASE_ONEOF(text, kj::String) {
-        headers.set(kj::HttpHeaderId::CONTENT_TYPE, "text/plain;charset=UTF-8");
+        headers.set(kj::HttpHeaderId::CONTENT_TYPE, MimeType::PLAINTEXT.toString());
         expectedBodySize = uint64_t(text.size());
       }
       KJ_CASE_ONEOF(data, kj::Array<byte>) {

--- a/src/workerd/api/node/mimetype-test.js
+++ b/src/workerd/api/node/mimetype-test.js
@@ -1,0 +1,41 @@
+import {
+  deepStrictEqual,
+  ok,
+  strictEqual,
+} from 'node:assert';
+
+import { MIMEType } from 'node:util';
+
+
+export const test_ok = {
+  test() {
+    const mt = new MIMEType('TeXt/PlAiN; ChArsEt="utf-8"');
+    strictEqual(mt.type, 'text');
+    strictEqual(mt.subtype, 'plain');
+    strictEqual(mt.essence, 'text/plain');
+    strictEqual(mt.toString(), 'text/plain;charset=utf-8');
+    strictEqual(JSON.stringify(mt), '"text/plain;charset=utf-8"');
+    strictEqual(mt.params.get('charset'), 'utf-8');
+    ok(mt.params.has('charset'));
+    ok(!mt.params.has('boundary'));
+    mt.params.set('boundary', 'foo');
+    ok(mt.params.has('boundary'));
+    strictEqual(mt.toString(), 'text/plain;charset=utf-8;boundary=foo');
+
+    deepStrictEqual(Array.from(mt.params), [
+      ['charset', 'utf-8'],
+      ['boundary', 'foo']
+    ]);
+
+    deepStrictEqual(Array.from(mt.params.keys()), [
+      'charset', 'boundary'
+    ]);
+
+    deepStrictEqual(Array.from(mt.params.values()), [
+      'utf-8', 'foo'
+    ]);
+
+    mt.params.delete('boundary');
+    ok(!mt.params.has('boundary'));
+  }
+};

--- a/src/workerd/api/node/mimetype-test.wd-test
+++ b/src/workerd/api/node/mimetype-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "mimetype-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "mimetype-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat"]
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -4,6 +4,7 @@
 #include "buffer.h"
 #include "crypto.h"
 #include "diagnostics-channel.h"
+#include "util.h"
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/modules.h>
 #include <capnp/dynamic.h>
@@ -39,6 +40,7 @@ void registerNodeJsCompatModules(
   V(AsyncHooksModule, "node-internal:async_hooks")                              \
   V(BufferUtil, "node-internal:buffer")                                         \
   V(CryptoImpl, "node-internal:crypto")                                         \
+  V(UtilModule, "node-internal:util")                                           \
   V(DiagnosticsChannelModule, "node-internal:diagnostics_channel")
 
 #define NODEJS_MODULES_EXPERIMENTAL(V)
@@ -66,5 +68,7 @@ void registerNodeJsCompatModules(
   EW_NODE_BUFFER_ISOLATE_TYPES,            \
   EW_NODE_CRYPTO_ISOLATE_TYPES,            \
   EW_NODE_DIAGNOSTICCHANNEL_ISOLATE_TYPES, \
-  EW_NODE_ASYNCHOOKS_ISOLATE_TYPES
+  EW_NODE_ASYNCHOOKS_ISOLATE_TYPES,        \
+  EW_NODE_UTIL_ISOLATE_TYPES
+
 }  // namespace workerd::api::node

--- a/src/workerd/api/node/util.c++
+++ b/src/workerd/api/node/util.c++
@@ -1,0 +1,130 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+#include "util.h"
+#include <kj/vector.h>
+
+namespace workerd::api::node {
+
+MIMEParams::MIMEParams(kj::Maybe<MimeType&> mimeType) : mimeType(mimeType) {}
+
+jsg::Ref<MIMEParams> MIMEParams::constructor() {
+  // Oddly, Node.js allows creating MIMEParams directly but it's not actually
+  // functional. But, to match, we'll go ahead and allow it.
+  return jsg::alloc<MIMEParams>(nullptr);
+}
+
+void MIMEParams::delete_(kj::String name) {
+  KJ_IF_MAYBE(inner, mimeType) {
+    inner->eraseParam(name);
+  }
+}
+
+kj::Maybe<kj::StringPtr> MIMEParams::get(kj::String name) {
+  KJ_IF_MAYBE(inner, mimeType) {
+    return inner->params().find(name);
+  }
+  return nullptr;
+}
+
+bool MIMEParams::has(kj::String name) {
+  KJ_IF_MAYBE(inner, mimeType) {
+    return inner->params().find(name) != nullptr;
+  }
+  return false;
+}
+
+void MIMEParams::set(kj::String name, kj::String value) {
+  KJ_IF_MAYBE(inner, mimeType) {
+    JSG_REQUIRE(inner->addParam(name, value), TypeError,
+        "Not a valid MIME parameter");
+  }
+}
+
+kj::String MIMEParams::toString() {
+  KJ_IF_MAYBE(inner, mimeType) {
+    return inner->paramsToString();
+  }
+  return kj::str();
+}
+
+jsg::Ref<MIMEParams::EntryIterator> MIMEParams::entries(jsg::Lock&) {
+  kj::Vector<kj::Array<kj::String>> vec;
+  KJ_IF_MAYBE(inner, mimeType) {
+    for (const auto& entry : inner->params()) {
+      vec.add(kj::arr(kj::str(entry.key), kj::str(entry.value)));
+    }
+  }
+  return jsg::alloc<EntryIterator>(IteratorState<kj::Array<kj::String>> {
+    vec.releaseAsArray()
+  });
+}
+
+jsg::Ref<MIMEParams::KeyIterator> MIMEParams::keys(jsg::Lock&) {
+  kj::Vector<kj::String> vec;
+  KJ_IF_MAYBE(inner, mimeType) {
+    for (const auto& entry : inner->params()) {
+      vec.add(kj::str(entry.key));
+    }
+  }
+  return jsg::alloc<KeyIterator>(IteratorState<kj::String> {
+    vec.releaseAsArray()
+  });
+}
+
+jsg::Ref<MIMEParams::ValueIterator> MIMEParams::values(jsg::Lock&) {
+  kj::Vector<kj::String> vec;
+  KJ_IF_MAYBE(inner, mimeType) {
+    for (const auto& entry : inner->params()) {
+      vec.add(kj::str(entry.value));
+    }
+  }
+  return jsg::alloc<ValueIterator>(IteratorState<kj::String> {
+    vec.releaseAsArray()
+  });
+}
+
+MIMEType::MIMEType(MimeType inner)
+    : inner(kj::mv(inner)),
+      params(jsg::alloc<MIMEParams>(this->inner)) {}
+
+MIMEType::~MIMEType() noexcept(false) {
+  // Break the connection with the MIMEParams
+  params->mimeType = nullptr;
+}
+
+jsg::Ref<MIMEType> MIMEType::constructor(kj::String input) {
+  auto parsed = JSG_REQUIRE_NONNULL(MimeType::tryParse(input), TypeError,
+      "Not a valid MIME type: ", input);
+  return jsg::alloc<MIMEType>(kj::mv(parsed));
+}
+
+kj::StringPtr MIMEType::getType() {
+  return inner.type();
+}
+
+void MIMEType::setType(kj::String type) {
+  JSG_REQUIRE(inner.setType(type), TypeError, "Not a valid MIME type");
+}
+
+kj::StringPtr MIMEType::getSubtype() {
+  return inner.subtype();
+}
+
+void MIMEType::setSubtype(kj::String subtype) {
+  JSG_REQUIRE(inner.setSubtype(subtype), TypeError, "Not a valid MIME subtype");
+}
+
+kj::String MIMEType::getEssence() {
+  return inner.essence();
+}
+
+jsg::Ref<MIMEParams> MIMEType::getParams() {
+  return params.addRef();
+}
+
+kj::String MIMEType::toString() {
+  return inner.toString();
+}
+
+}  // namespace workerd::api::node

--- a/src/workerd/api/node/util.h
+++ b/src/workerd/api/node/util.h
@@ -1,0 +1,127 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+#pragma once
+
+#include <workerd/jsg/jsg.h>
+#include <workerd/util/mimetype.h>
+
+namespace workerd::api::node {
+
+class MIMEType;
+
+class MIMEParams final: public jsg::Object {
+private:
+  template <typename T>
+  struct IteratorState final {
+    kj::Array<T> values;
+    uint index = 0;
+  };
+
+public:
+  MIMEParams(kj::Maybe<MimeType&> mimeType = nullptr);
+
+  static jsg::Ref<MIMEParams> constructor();
+
+  void delete_(kj::String name);
+  kj::Maybe<kj::StringPtr> get(kj::String name);
+  bool has(kj::String name);
+  void set(kj::String name, kj::String value);
+  kj::String toString();
+
+  JSG_ITERATOR(EntryIterator, entries,
+               kj::Array<kj::String>,
+               IteratorState<kj::Array<kj::String>>,
+               iteratorNext<kj::Array<kj::String>>);
+  JSG_ITERATOR(KeyIterator, keys,
+                kj::String,
+                IteratorState<kj::String>,
+                iteratorNext<kj::String>);
+  JSG_ITERATOR(ValueIterator,
+                values,
+                kj::String,
+                IteratorState<kj::String>,
+                iteratorNext<kj::String>);
+
+  JSG_RESOURCE_TYPE(MIMEParams) {
+    JSG_METHOD_NAMED(delete, delete_);
+    JSG_METHOD(get);
+    JSG_METHOD(has);
+    JSG_METHOD(set);
+    JSG_METHOD(entries);
+    JSG_METHOD(keys);
+    JSG_METHOD(values);
+    JSG_METHOD(toString);
+    JSG_METHOD_NAMED(toJSON, toString);
+    JSG_ITERABLE(entries);
+  }
+
+private:
+  template <typename T>
+  static kj::Maybe<T> iteratorNext(jsg::Lock& js, IteratorState<T>& state) {
+    if (state.index >= state.values.size()) {
+      return nullptr;
+    }
+    auto& item = state.values[state.index++];
+    if constexpr (kj::isSameType<T, kj::Array<kj::String>>()) {
+      return KJ_MAP(i, item) { return kj::str(i); };
+    } else {
+      static_assert(kj::isSameType<T, kj::String>());
+      return kj::str(item);
+    }
+    KJ_UNREACHABLE;
+  }
+
+  kj::Maybe<MimeType&> mimeType;
+  friend class MIMEType;
+};
+
+class MIMEType final: public jsg::Object {
+public:
+  MIMEType(MimeType inner);
+  ~MIMEType() noexcept(false);
+  static jsg::Ref<MIMEType> constructor(kj::String input);
+
+  kj::StringPtr getType();
+  void setType(kj::String type);
+  kj::StringPtr getSubtype();
+  void setSubtype(kj::String subtype);
+  kj::String getEssence();
+  jsg::Ref<MIMEParams> getParams();
+  kj::String toString();
+
+  JSG_RESOURCE_TYPE(MIMEType) {
+    JSG_PROTOTYPE_PROPERTY(type, getType, setType);
+    JSG_PROTOTYPE_PROPERTY(subtype, getSubtype, setSubtype);
+    JSG_READONLY_PROTOTYPE_PROPERTY(essence, getEssence);
+    JSG_READONLY_PROTOTYPE_PROPERTY(params, getParams);
+    JSG_METHOD(toString);
+    JSG_METHOD_NAMED(toJSON, toString);
+  }
+
+private:
+  workerd::MimeType inner;
+  jsg::Ref<MIMEParams> params;
+};
+
+class UtilModule final: public jsg::Object {
+public:
+
+  JSG_RESOURCE_TYPE(UtilModule) {
+    JSG_NESTED_TYPE(MIMEType);
+    JSG_NESTED_TYPE(MIMEParams);
+  }
+};
+
+#define EW_NODE_UTIL_ISOLATE_TYPES              \
+    api::node::UtilModule,                      \
+    api::node::MIMEType,                        \
+    api::node::MIMEParams,                      \
+    api::node::MIMEParams::EntryIterator,       \
+    api::node::MIMEParams::ValueIterator,       \
+    api::node::MIMEParams::KeyIterator,         \
+    api::node::MIMEParams::EntryIterator::Next, \
+    api::node::MIMEParams::ValueIterator::Next, \
+    api::node::MIMEParams::KeyIterator::Next
+
+}  // namespace workerd::api::node

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -1,9 +1,10 @@
 #include "queue.h"
-#include "src/workerd/api/util.h"
-#include "src/workerd/jsg/jsg.h"
+#include "util.h"
 
 #include <workerd/jsg/buffersource.h>
+#include <workerd/jsg/jsg.h>
 #include <workerd/jsg/ser.h>
+#include <workerd/util/mimetype.h>
 #include <workerd/api/global-scope.h>
 #include <kj/encoding.h>
 
@@ -136,7 +137,7 @@ kj::Promise<void> WorkerQueue::send(
   }
 
   auto headers = kj::HttpHeaders(context.getHeaderTable());
-  headers.set(kj::HttpHeaderId::CONTENT_TYPE, "application/octet-stream");
+  headers.set(kj::HttpHeaderId::CONTENT_TYPE, MimeType::OCTET_STREAM.toString());
 
   Serialized serialized;
   KJ_IF_MAYBE(type, contentType) {
@@ -250,7 +251,7 @@ kj::Promise<void> WorkerQueue::sendBatch(
   headers.add("CF-Queue-Batch-Count"_kj, kj::str(messageCount));
   headers.add("CF-Queue-Batch-Bytes"_kj, kj::str(totalSize));
   headers.add("CF-Queue-Largest-Msg"_kj, kj::str(largestMessage));
-  headers.set(kj::HttpHeaderId::CONTENT_TYPE, "application/json"_kj);
+  headers.set(kj::HttpHeaderId::CONTENT_TYPE, MimeType::JSON.toString());
 
   auto req = client->request(kj::HttpMethod::POST, url, headers, body.size());
 

--- a/src/workerd/api/util-test.c++
+++ b/src/workerd/api/util-test.c++
@@ -16,8 +16,7 @@ void expectUnredacted(kj::StringPtr input) {
 }
 
 void expectContentTypeParameter(kj::StringPtr input, kj::StringPtr param, kj::StringPtr expected) {
-  auto res = readContentTypeParameter(input, param);
-  auto value = KJ_ASSERT_NONNULL(res);
+  auto value = KJ_ASSERT_NONNULL(readContentTypeParameter(input, param));
   KJ_EXPECT(value == expected);
 }
 
@@ -124,22 +123,20 @@ KJ_TEST("readContentTypeParameter can fetch boundary parameter") {
   );
 
   // handle non-closing quotes
-  KJ_ASSERT(readContentTypeParameter(
+  expectContentTypeParameter(
     R"(multipart/form-data; charset="boundary=;\"; boundary="__boundary__")",
-    "boundary"_kj
-  ) == nullptr);
+    "boundary"_kj,
+    "__boundary__"_kj);
 
-  // handle non-closing quotes on wanted param
-  KJ_ASSERT(readContentTypeParameter(
+  expectContentTypeParameter(
     R"(multipart/form-data; charset="boundary=;"; boundary="__boundary__\")",
-    "boundary"_kj
-  ) == nullptr);
+    "boundary"_kj,
+    "__boundary__"_kj);
 
-  // handle incorrect quotes
-  KJ_ASSERT(readContentTypeParameter(
+  expectContentTypeParameter(
     R"(multipart/form-data; charset=\"boundary=;\"; boundary=\"__boundary__\")",
-    "boundary"_kj
-  ) == nullptr);
+    "boundary"_kj,
+    R"(\"__boundary__\")");
 
   // spurious whitespace before ;
   expectContentTypeParameter(

--- a/src/workerd/api/util.h
+++ b/src/workerd/api/util.h
@@ -49,8 +49,8 @@ void parseQueryString(kj::Vector<kj::Url::QueryParam>& query, kj::ArrayPtr<const
 //
 // TODO(cleanup): Would be really nice to move this to kj-url.
 
-kj::Maybe<kj::ArrayPtr<const char>> readContentTypeParameter(kj::StringPtr contentType,
-                                                             kj::StringPtr param);
+kj::Maybe<kj::String> readContentTypeParameter(kj::StringPtr contentType,
+                                               kj::StringPtr param);
 // Given the value of a Content-Type header, returns the value of a single expected parameter.
 // For example:
 //
@@ -145,4 +145,7 @@ inline kj::Promise<DeferredProxy<void>> addNoopDeferredProxy(kj::Promise<void> p
 
 kj::Maybe<jsg::V8Ref<v8::Object>> cloneRequestCf(
     jsg::Lock& js, kj::Maybe<jsg::V8Ref<v8::Object>> maybeCf);
+
+void maybeWarnIfNotText(kj::StringPtr str);
+
 }  // namespace workerd::api

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -20,6 +20,7 @@
 #include <workerd/io/actor-cache.h>
 #include <workerd/io/actor-sqlite.h>
 #include <workerd/api/actor-state.h>
+#include <workerd/util/mimetype.h>
 #include "workerd-api.h"
 #include <stdlib.h>
 
@@ -804,7 +805,7 @@ private:
       switch (meta.type) {
         case kj::FsNode::Type::FILE: {
           kj::HttpHeaders headers(headerTable);
-          headers.set(kj::HttpHeaderId::CONTENT_TYPE, "application/octet-stream");
+          headers.set(kj::HttpHeaderId::CONTENT_TYPE, MimeType::OCTET_STREAM.toString());
           headers.set(hLastModified, httpTime(meta.lastModified));
 
           // We explicitly set the Content-Length header because if we don't, and we were called
@@ -835,7 +836,7 @@ private:
           auto dir = readable->openSubdir(path);
 
           kj::HttpHeaders headers(headerTable);
-          headers.set(kj::HttpHeaderId::CONTENT_TYPE, "application/json");
+          headers.set(kj::HttpHeaderId::CONTENT_TYPE, MimeType::JSON.toString());
           headers.set(hLastModified, httpTime(meta.lastModified));
 
           // We intentionally don't provide the expected size here in order to reserve the right
@@ -1054,12 +1055,12 @@ public:
     }
 
     if (url.endsWith("/json/version")) {
-      responseHeaders.set(kj::HttpHeaderId::CONTENT_TYPE, "application/json"_kj);
+      responseHeaders.set(kj::HttpHeaderId::CONTENT_TYPE, MimeType::JSON.toString());
       auto content = kj::str("{\"Browser\": \"workerd\", \"Protocol-Version\": \"1.3\" }");
       auto out = response.send(200, "OK", responseHeaders, content.size());
       return out->write(content.begin(), content.size()).attach(kj::mv(content), kj::mv(out));
     } else if (url.endsWith("/json") || url.endsWith("/json/list")) {
-      responseHeaders.set(kj::HttpHeaderId::CONTENT_TYPE, "application/json"_kj);
+      responseHeaders.set(kj::HttpHeaderId::CONTENT_TYPE, MimeType::JSON.toString());
 
       auto baseWsUrl = KJ_UNWRAP_OR(headers.get(kj::HttpHeaderId::HOST), {
         return response.sendError(400, "Bad Request", responseHeaders);

--- a/src/workerd/util/mimetype-test.c++
+++ b/src/workerd/util/mimetype-test.c++
@@ -1,0 +1,408 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+#include "mimetype.h"
+#include <kj/test.h>
+
+namespace workerd {
+namespace {
+
+KJ_TEST("Basic MimeType parsing works") {
+  struct TestCase {
+    kj::StringPtr input;
+    kj::StringPtr type;
+    kj::StringPtr subtype;
+    kj::StringPtr output;
+    kj::Maybe<kj::Array<MimeType::MimeParams::Entry>> params;
+  };
+  static TestCase kTests[] = {
+    {
+      .input = "text/plain"_kj,
+      .type = "text"_kj,
+      .subtype = "plain"_kj,
+      .output = "text/plain"_kj,
+    },
+    {
+      .input = "\r\t\n TeXt/PlAiN \t\r\n"_kj,
+      .type = "text"_kj,
+      .subtype = "plain"_kj,
+      .output = "text/plain"_kj,
+    },
+    {
+      .input = "text/plain; charset=utf-8"_kj,
+      .type = "text"_kj,
+      .subtype = "plain"_kj,
+      .output = "text/plain;charset=utf-8"_kj,
+      .params = kj::arr(MimeType::MimeParams::Entry {kj::str("charset"), kj::str("utf-8")})
+    },
+    {
+      .input = "text/plain; charset=\"utf-8\""_kj,
+      .type = "text"_kj,
+      .subtype = "plain"_kj,
+      .output = "text/plain;charset=utf-8"_kj,
+      .params = kj::arr(MimeType::MimeParams::Entry {kj::str("charset"), kj::str("utf-8")})
+    },
+    {
+      .input = "text/plain; charset=\"utf-8\"; \r\n\t"_kj,
+      .type = "text"_kj,
+      .subtype = "plain"_kj,
+      .output = "text/plain;charset=utf-8"_kj,
+      .params = kj::arr(MimeType::MimeParams::Entry {kj::str("charset"), kj::str("utf-8")})
+    },
+    {
+      .input = "text/plain; charset=\"utf-8\"; \r\n\ta=b"_kj,
+      .type = "text"_kj,
+      .subtype = "plain"_kj,
+      .output = "text/plain;charset=utf-8;a=b"_kj,
+      .params = kj::arr(
+        MimeType::MimeParams::Entry {kj::str("charset"), kj::str("utf-8")},
+        MimeType::MimeParams::Entry {kj::str("a"), kj::str("b")}
+      )
+    },
+    {
+      .input = "text/plain; charset=utf-8; a=b;a=a"_kj,
+      .type = "text"_kj,
+      .subtype = "plain"_kj,
+      .output = "text/plain;charset=utf-8;a=b"_kj,
+      .params = kj::arr(
+        MimeType::MimeParams::Entry {kj::str("charset"), kj::str("utf-8")},
+        MimeType::MimeParams::Entry {kj::str("a"), kj::str("b")}
+      )
+    },
+  };
+
+  for (auto& test : kTests) {
+    auto mimeType = KJ_ASSERT_NONNULL(MimeType::tryParse(test.input));
+    KJ_ASSERT(mimeType.type() == test.type);
+    KJ_ASSERT(mimeType.subtype() == test.subtype);
+    KJ_ASSERT(mimeType.toString() == test.output);
+
+    KJ_IF_MAYBE(params, test.params) {
+      for (auto& param : *params) {
+        auto& value = KJ_ASSERT_NONNULL(mimeType.params().find(param.key));
+        KJ_ASSERT(value == param.value);
+      }
+    }
+  }
+
+  struct ErrorTestCase {
+    kj::StringPtr input;
+  };
+  static ErrorTestCase kErrorTests[] = {
+    { "" },
+    { "text" },
+    { "text/" },
+    { "/plain" },
+    { "/" },
+    { " a/\x12" },
+    { " \x12/a" },
+    { " text/ plain" },
+    { " text /plain" },
+    { " text / plain" },
+    { ";charset=utf-8" },
+    { "javascript"},
+  };
+
+  for (auto& test : kErrorTests) {
+    KJ_ASSERT(MimeType::tryParse(test.input) == nullptr, test.input);
+  }
+}
+
+KJ_TEST("Building MimeType works") {
+  MimeType type("text", "plain");
+
+  KJ_ASSERT(!type.addParam(""_kj, ""_kj));
+  KJ_ASSERT(!type.addParam("\x12"_kj, ""_kj));
+  KJ_ASSERT(!type.addParam("B"_kj, "\12"_kj));
+
+  KJ_ASSERT(type.addParam("A"_kj, "b"_kj));
+  KJ_ASSERT(type.addParam("Z"_kj, "b"_kj));
+  type.eraseParam("Z");
+
+  KJ_ASSERT(type.toString() == "text/plain;a=b");
+
+  KJ_ASSERT(type.params().find("a"_kj) != nullptr);
+  KJ_ASSERT(type.params().find("b"_kj) == nullptr);
+  KJ_ASSERT(type.params().find("z"_kj) == nullptr);
+
+  // Comparing based solely on type/subtype works
+  KJ_ASSERT(MimeType::PLAINTEXT == type);
+}
+
+KJ_TEST("WHATWG tests") {
+  struct Test {
+    kj::StringPtr input;
+    kj::Maybe<kj::StringPtr> output;
+  };
+
+  static const Test kTests[] = {
+    {
+      .input = "text/html;charset=gbk"_kj,
+      .output = "text/html;charset=gbk"_kj,
+    },
+    {
+      .input = "TEXT/HTML;CHARSET=GBK"_kj,
+      .output = "text/html;charset=GBK"_kj,
+    },
+    // Legacy comment syntax
+    {
+      .input = "text/html;charset=gbk("_kj,
+      .output = "text/html;charset=\"gbk(\""_kj,
+    },
+    {
+      .input = "text/html;x=(;charset=gbk"_kj,
+      .output = "text/html;x=\"(\";charset=gbk"_kj,
+    },
+    // "Duplicate parameter",
+    {
+      .input = "text/html;charset=gbk;charset=windows-1255"_kj,
+      .output = "text/html;charset=gbk"_kj,
+    },
+    {
+      .input = "text/html;charset=();charset=GBK"_kj,
+      .output = "text/html;charset=\"()\""_kj,
+    },
+    // "Spaces",
+    {
+     .input = "text/html;charset =gbk"_kj,
+     .output = "text/html"_kj,
+    },
+    {
+     .input = "text/html ;charset=gbk"_kj,
+     .output = "text/html;charset=gbk"_kj,
+    },
+    {
+     .input = "text/html; charset=gbk"_kj,
+     .output = "text/html;charset=gbk"_kj,
+    },
+    {
+     .input = "text/html;charset= gbk"_kj,
+     .output = "text/html;charset=\" gbk\""_kj,
+    },
+    {
+     .input = "text/html;charset= \"gbk\""_kj,
+     .output = "text/html;charset=\" \\\"gbk\\\"\""_kj,
+    },
+    // "0x0B and 0x0C",
+    {
+      .input = "text/html;charset=\u000Bgbk"_kj,
+      .output = "text/html"_kj,
+    },
+    {
+      .input = "text/html;charset=\u000Cgbk"_kj,
+      .output = "text/html"_kj,
+    },
+    {
+      .input = "text/html;\u000Bcharset=gbk"_kj,
+      .output = "text/html"_kj,
+    },
+    {
+      .input = "text/html;\u000Ccharset=gbk"_kj,
+      .output = "text/html"_kj,
+    },
+    // "Single quotes are a token, not a delimiter",
+    {
+     .input = "text/html;charset='gbk'"_kj,
+     .output = "text/html;charset='gbk'"_kj,
+    },
+    {
+     .input = "text/html;charset='gbk"_kj,
+     .output = "text/html;charset='gbk"_kj,
+    },
+    {
+     .input = "text/html;charset=gbk'"_kj,
+     .output = "text/html;charset=gbk'"_kj,
+    },
+    {
+     .input = "text/html;charset=';charset=GBK"_kj,
+     .output = "text/html;charset='"_kj,
+    },
+    // "Invalid parameters",
+    {
+     .input = "text/html;test;charset=gbk"_kj,
+     .output = "text/html;charset=gbk"_kj,
+    },
+    {
+     .input = "text/html;test=;charset=gbk"_kj,
+     .output = "text/html;charset=gbk"_kj,
+    },
+    {
+     .input = "text/html;';charset=gbk"_kj,
+     .output = "text/html;charset=gbk"_kj,
+    },
+    {
+     .input = "text/html;\";charset=gbk"_kj,
+     .output = "text/html;charset=gbk"_kj,
+    },
+    {
+     .input = "text/html ; ; charset=gbk"_kj,
+     .output = "text/html;charset=gbk"_kj,
+    },
+    {
+     .input = "text/html;;;;charset=gbk"_kj,
+     .output = "text/html;charset=gbk"_kj,
+    },
+    {
+     .input = "text/html;charset= \"\u007F;charset=GBK"_kj,
+     .output = "text/html;charset=GBK"_kj,
+    },
+    {
+      .input = "text/html;charset=\"\u007F;charset=foo\";charset=GBK"_kj,
+      .output = "text/html;charset=GBK"_kj,
+    },
+    // "Double quotes",
+    {
+      .input = "text/html;charset=\"gbk\""_kj,
+      .output = "text/html;charset=gbk"_kj,
+    },
+    {
+     .input = "text/html;charset=\"gbk"_kj,
+     .output = "text/html;charset=gbk"_kj,
+    },
+    {
+     .input = "text/html;charset=gbk\""_kj,
+     .output = "text/html;charset=\"gbk\\\"\""_kj,
+    },
+    {
+     .input = "text/html;charset=\" gbk\""_kj,
+     .output = "text/html;charset=\" gbk\""_kj,
+    },
+    {
+     .input = "text/html;charset=\"gbk \""_kj,
+     .output = "text/html;charset=\"gbk \""_kj,
+    },
+    {
+     .input = "text/html;charset=\"\\ gbk\""_kj,
+     .output = "text/html;charset=\" gbk\""_kj,
+    },
+    {
+     .input = "text/html;charset=\"\\g\\b\\k\""_kj,
+     .output = "text/html;charset=gbk"_kj,
+    },
+    {
+     .input = "text/html;charset=\"gbk\"x"_kj,
+     .output = "text/html;charset=gbk"_kj,
+    },
+    {
+      .input = "text/html;charset=\"\";charset=GBK"_kj,
+      .output = "text/html;charset=\"\""_kj,
+    },
+    {
+     .input = "text/html;charset=\";charset=GBK"_kj,
+     .output = "text/html;charset=\";charset=GBK\""_kj,
+    },
+    // "Unexpected code points",
+    {
+     .input = "text/html;charset={gbk}"_kj,
+     .output = "text/html;charset=\"{gbk}\""_kj,
+    },
+    // "Parameter name longer than 127",
+    {
+      .input = "text/html;0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789=x;charset=gbk"_kj,
+      .output = "text/html;0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789=x;charset=gbk"_kj,
+    },
+    // "type/subtype longer than 127",
+    {
+      .input = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"_kj,
+      .output =  "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"_kj,
+    },
+    // "Valid",
+    {
+      .input = "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz/!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz;!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"_kj,
+      .output = "!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz/!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz;!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz=!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"_kj,
+    },
+    // TODO(soon): Extreme edge case, we currently don't pass it but not too concerned.
+    // {
+    //   .input = "x/x;x=\"\t !\\\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\""_kj,
+    //   .output = "x/x;x=\"\t !\\\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\""_kj,
+    // },
+    // "End-of-file handling",
+    {
+      .input = "x/x;test"_kj,
+      .output = "x/x"_kj,
+    },
+    // TODO(soon): Another edge case, we currently don't pass it but not too concerned.
+    // {
+    //  .input = "x/x;test=\"\\"_kj,
+    //  .output = "x/x;test=\"\\\\\""_kj,
+    // },
+    // "Whitespace (not handled by generated-mime-types.json or above)",
+    {
+      .input = "x/x;x= "_kj,
+      .output = "x/x"_kj,
+    },
+    {
+      .input = "x/x;x=\t"_kj,
+      .output = "x/x"_kj,
+    },
+    {
+      .input = "x/x\n\r\t ;x=x"_kj,
+      .output = "x/x;x=x"_kj,
+    },
+    {
+      .input = "\n\r\t x/x;x=x\n\r\t "_kj,
+      .output = "x/x;x=x"_kj,
+    },
+    {
+      .input = "x/x;\n\r\t x=x\n\r\t ;x=y"_kj,
+      .output = "x/x;x=x"_kj,
+    },
+    // "Latin1",
+    {
+      .input = "text/html;test=\u00FF;charset=gbk"_kj,
+      .output = "text/html;test=\"\u00FF\";charset=gbk"_kj,
+    },
+    // ">Latin1",
+    // TODO(soon): Another edge case, we currently don't pass it but not too concerned.
+    // {
+    //   .input = "x/x;test=\uFFFD;x=x"_kj,
+    //   .output = "x/x;x=x"_kj,
+    // },
+    // "Failure",
+    { .input = "\u000Bx/x"_kj, },
+    { .input = "\u000Cx/x"_kj },
+    { .input = "x/x\u000B"_kj },
+    { .input = "x/x\u000C"_kj },
+    { .input = ""_kj },
+    { .input = "\t"_kj },
+    { .input = "/"_kj },
+    { .input = "bogus"_kj },
+    { .input = "bogus/"_kj },
+    { .input = "bogus/ "_kj },
+    { .input = "bogus/bogus/;"_kj },
+    { .input = "</>"_kj },
+    { .input = "(/)"_kj },
+    { .input = "ÿ/ÿ"_kj },
+    { .input = "text/html(;doesnot=matter"_kj },
+    { .input = "{/}"_kj },
+    { .input = "\u0100/\u0100"_kj },
+    { .input = "text /html"_kj },
+    { .input = "text/ html"_kj },
+    { .input = "\"text/html\""_kj }
+  };
+
+  for (const auto& test : kTests) {
+    KJ_IF_MAYBE(output, test.output) {
+      auto result = KJ_ASSERT_NONNULL(MimeType::tryParse(test.input));
+      KJ_ASSERT(result.toString() == *output);
+    } else {
+      KJ_ASSERT(MimeType::tryParse(test.input) == nullptr);
+    }
+  }
+
+  KJ_ASSERT(MimeType::JSON ==
+            KJ_ASSERT_NONNULL(MimeType::tryParse("application/json;charset=nothing")));
+  KJ_ASSERT(MimeType::JSON ==
+            KJ_ASSERT_NONNULL(MimeType::tryParse("application/json;")));
+  KJ_ASSERT(MimeType::JSON ==
+            KJ_ASSERT_NONNULL(MimeType::tryParse("application/json;char=\"UTF-8\"")));
+  KJ_ASSERT(MimeType::isJson(MimeType::JSON));
+  KJ_ASSERT(MimeType::isJson(MimeType::MANIFEST_JSON));
+  KJ_ASSERT(MimeType::isJavascript(MimeType::JAVASCRIPT));
+  KJ_ASSERT(MimeType::isJavascript(MimeType::XJAVASCRIPT));
+  KJ_ASSERT(MimeType::isJavascript(MimeType::TEXT_JAVASCRIPT));
+}
+
+}  // namespace
+}  // namespace workerd
+

--- a/src/workerd/util/mimetype.c++
+++ b/src/workerd/util/mimetype.c++
@@ -1,0 +1,368 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+#include "mimetype.h"
+#include "strings.h"
+#include <kj/debug.h>
+#include <kj/string-tree.h>
+
+namespace workerd {
+
+namespace {
+bool isWhitespace(const char c) {
+  return (c == '\r' || c == '\n' || c == '\t' || c == ' ');
+}
+
+bool isTokenChar(const unsigned char c) {
+  return c == '!' || c == '#' || c == '$' || c == '%' || c == '&' || c == '\'' ||
+         c == '*' || c == '+' || c == '\\' || c == '-' || c == '.' || c == '^' ||
+         c == '_' || c == '`' || c == '|' || c == '~' || (c >= 'A' && c <= 'Z') ||
+         (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+}
+
+bool isQuotedStringTokenChar(const unsigned char c) {
+  return (c == '\t') || (c >= 0x20 && c <= 0x7e) || (c >= 0x80);
+}
+
+kj::StringPtr skipWhitespace(kj::StringPtr str) {
+  auto ptr = str.begin();
+  auto end = str.end();
+  while (ptr != end && isWhitespace(*ptr)) { ptr++; }
+  return str.slice(ptr - str.begin());
+}
+
+kj::ArrayPtr<const char> trimWhitespace(kj::ArrayPtr<const char> str) {
+  auto ptr = str.end();
+  while (ptr > str.begin() && isWhitespace(*(ptr - 1))) --ptr;
+  return str.slice(0, str.size() - (str.end() - ptr));
+}
+
+bool hasInvalidCodepoints(kj::ArrayPtr<const char> str, auto predicate) {
+  auto ptr = str.begin();
+  auto end = str.end();
+  while (ptr != end) {
+    if (predicate(static_cast<unsigned char>(*ptr))) {
+      ++ptr;
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+kj::Maybe<size_t> findParamDelimiter(kj::ArrayPtr<const char> str) {
+  auto ptr = str.begin();
+  while (ptr != str.end()) {
+    if (*ptr == ';' || *ptr == '=') return ptr - str.begin();
+    ++ptr;
+  }
+  return nullptr;
+}
+
+kj::String unescape(kj::ArrayPtr<const char> str) {
+  auto result = kj::strTree();
+  while (str.size() > 0) {
+    KJ_IF_MAYBE(pos, str.findFirst('\\')) {
+      result = kj::strTree(kj::mv(result), str.slice(0, *pos));
+      str = str.slice(*pos + 1, str.size());
+    } else {
+      // No more backslashes
+      result = kj::strTree(kj::mv(result), str);
+      break;
+    }
+  }
+  return result.flatten();
+}
+
+}  // namespace
+
+MimeType MimeType::parse(kj::StringPtr input, ParseOptions options) {
+  return KJ_ASSERT_NONNULL(tryParse(input, options));
+}
+
+kj::Maybe<MimeType> MimeType::tryParse(kj::StringPtr input, ParseOptions options) {
+  // Skip leading whitespace from start
+  input = skipWhitespace(input);
+  if (input.size() == 0) return nullptr;
+
+  kj::Maybe<kj::String> maybeType;
+  // Let's try to find the solidus that separates the type and subtype
+  KJ_IF_MAYBE(n, input.findFirst('/')) {
+    auto typeCandidate = input.slice(0, *n);
+    if (typeCandidate.size() == 0 || hasInvalidCodepoints(typeCandidate, isTokenChar)) {
+      return nullptr;
+    }
+    maybeType = kj::str(typeCandidate);
+    input = input.slice(*n + 1);
+  } else {
+    // If the solidus is not found, then it's not a valid mime type
+    return nullptr;
+  }
+  auto& type = KJ_ASSERT_NONNULL(maybeType);
+
+  // If there's nothing else to parse at this point, it's not a valid mime type.
+  if (input.size() == 0) return nullptr;
+
+  kj::Maybe<kj::String> maybeSubtype;
+  KJ_IF_MAYBE(n, input.findFirst(';')) {
+    // If a semi-colon is found, the subtype is everything up to that point
+    // minus trailing whitespace.
+    auto subtypeCandidate = trimWhitespace(input.slice(0, *n));
+    if (subtypeCandidate.size() == 0 || hasInvalidCodepoints(subtypeCandidate, isTokenChar)) {
+      return nullptr;
+    }
+    maybeSubtype = kj::str(subtypeCandidate);
+    input = input.slice(*n + 1);
+  } else {
+    auto subtypeCandidate = trimWhitespace(input.asArray());
+    if (subtypeCandidate.size() == 0 || hasInvalidCodepoints(subtypeCandidate, isTokenChar)) {
+      return nullptr;
+    }
+    maybeSubtype = kj::str(subtypeCandidate);
+    input = input.slice(input.size());
+  }
+  auto& subtype = KJ_ASSERT_NONNULL(maybeSubtype);
+
+  MimeType result(type, subtype);
+
+  if (!(options & ParseOptions::IGNORE_PARAMS)) {
+    // Parse the parameters...
+    while (input.size() > 0) {
+      input = skipWhitespace(input);
+      if (input.size() == 0) break;
+      KJ_IF_MAYBE(n, findParamDelimiter(input)) {
+        // If the delimiter found is a ; then the parameter is invalid here, and
+        // we will ignore it.
+        if (input[*n] == ';') {
+          input = input.slice(*n + 1);
+          continue;
+        }
+        KJ_ASSERT(input[*n] == '=');
+        auto nameCandidate = input.slice(0, *n);
+        input = input.slice(*n + 1);
+        if (nameCandidate.size() == 0 || hasInvalidCodepoints(nameCandidate, isTokenChar)) {
+          // The name is invalid, try skipping to the next...
+          KJ_IF_MAYBE(p, input.findFirst(';')) {
+            input = input.slice(*p + 1);
+            continue;
+          } else {
+            break;
+          }
+        }
+
+        // Check to see if the value starts off quoted or not.
+        if (*input.begin() == '"') {
+          input = input.slice(1);
+          // Our parameter value is quoted. Next we'll scan up until the next
+          // quote or until the end of the string.
+          KJ_IF_MAYBE(p, input.findFirst('"')) {
+            auto valueCandidate = input.slice(0, *p);
+            input = input.slice(*p + 1);
+            if (hasInvalidCodepoints(valueCandidate, isQuotedStringTokenChar)) {
+              continue;
+            }
+            result.addParam(nameCandidate, unescape(valueCandidate));
+            KJ_IF_MAYBE(y, input.findFirst(';')) {
+              input = input.slice(*y + 1);
+              continue;
+            }
+          } else if (!hasInvalidCodepoints(input, isQuotedStringTokenChar)) {
+            result.addParam(nameCandidate, unescape(input));
+          }
+          break;
+        } else {
+          // The parameter is not quoted. Let's scan ahead for the next semi-colon.
+          KJ_IF_MAYBE(p, input.findFirst(';')) {
+            auto valueCandidate = trimWhitespace(input.slice(0, *p));
+            input = input.slice(*p + 1);
+            if (valueCandidate.size() > 0 &&
+                !hasInvalidCodepoints(valueCandidate, isQuotedStringTokenChar)) {
+              result.addParam(nameCandidate, valueCandidate);
+            }
+            continue;
+          } else {
+            auto valueCandidate = trimWhitespace(input);
+            if (valueCandidate.size() > 0 &&
+                !hasInvalidCodepoints(valueCandidate, isQuotedStringTokenChar)) {
+              result.addParam(nameCandidate, valueCandidate);
+            }
+          }
+          break;
+        }
+        KJ_ASSERT(false);
+      } else {
+        // If we got here, we scanned input and did not find a semi-colon or equal
+        // sign before hitting the end of the input. We treat the remaining bits as
+        // invalid and ignore them.
+        break;
+      }
+    }
+  }
+
+  return kj::mv(result);
+}
+
+MimeType::MimeType(kj::StringPtr type,
+                   kj::StringPtr subtype,
+                   kj::Maybe<MimeParams> params)
+    : type_(toLowerCopy(type)),
+      subtype_(toLowerCopy(subtype)) {
+  KJ_IF_MAYBE(p, params) { params_ = kj::mv(*p); }
+}
+
+kj::StringPtr MimeType::type() const {
+  return type_;
+}
+
+bool MimeType::setType(kj::StringPtr type) {
+  if (type.size() == 0 || hasInvalidCodepoints(type, isTokenChar)) return false;
+  type_ = toLowerCopy(type);
+  return true;
+}
+
+kj::StringPtr MimeType::subtype() const {
+  return subtype_;
+}
+
+bool MimeType::setSubtype(kj::StringPtr type) {
+  if (type.size() == 0 || hasInvalidCodepoints(type, isTokenChar)) return false;
+  subtype_ = toLowerCopy(type);
+  return true;
+}
+
+const MimeType::MimeParams& MimeType::params() const {
+  return params_;
+}
+
+bool MimeType::addParam(kj::ArrayPtr<const char> name, kj::ArrayPtr<const char> value) {
+  if (name.size() == 0 ||
+      hasInvalidCodepoints(name, isTokenChar) ||
+      hasInvalidCodepoints(value, isQuotedStringTokenChar)) {
+    return false;
+  }
+  params_.upsert(toLowerCopy(name), kj::str(value), [](auto&, auto&&) {});
+  return true;
+}
+
+void MimeType::eraseParam(kj::StringPtr name) {
+  params_.erase(toLowerCopy(name));
+}
+
+kj::String MimeType::essence() const {
+  return kj::str(type(), "/", subtype());
+}
+
+kj::String MimeType::paramsToString() const {
+  auto str = kj::strTree();
+  bool first = true;
+  for (auto& param : params()) {
+    str = kj::strTree(kj::mv(str), first ? "" : ";", param.key, "=");
+    first = false;
+    if (param.value.size() == 0) {
+      str = kj::strTree(kj::mv(str), "\"\"");
+    } else if (hasInvalidCodepoints(param.value, isTokenChar)) {
+      auto view = param.value.asPtr();
+      str = kj::strTree(kj::mv(str), "\"");
+      while (view.size() > 0) {
+        KJ_IF_MAYBE(pos, view.findFirst('"')) {
+          str = kj::strTree(kj::mv(str), view.slice(0, *pos), "\\\"");
+          view = view.slice(*pos + 1);
+        } else {
+          str = kj::strTree(kj::mv(str), view);
+          view = view.slice(view.size());
+        }
+      }
+      str = kj::strTree(kj::mv(str), "\"");
+    } else {
+      str = kj::strTree(kj::mv(str), param.value);
+    }
+  }
+  return str.flatten();
+}
+
+kj::String MimeType::toString() const {
+  auto str = kj::strTree(type(), "/", subtype());
+  if (params_.size() > 0) {
+    str = kj::strTree(kj::mv(str), ";", paramsToString());
+  }
+  return str.flatten();
+}
+
+MimeType MimeType::clone(ParseOptions options) const {
+  MimeParams copy;
+  if (!(options & ParseOptions::IGNORE_PARAMS)) {
+    for (const auto& entry : params_) {
+      copy.insert(kj::str(entry.key), kj::str(entry.value));
+    }
+  }
+  return MimeType(type_, subtype_, kj::mv(copy));
+}
+
+bool MimeType::operator==(const MimeType& other) const {
+  return this == &other || (type_ == other.type_ && subtype_ == other.subtype_);
+}
+
+bool MimeType::operator!=(const MimeType& other) const {
+  return !(*this == other);
+}
+
+MimeType::operator kj::String() const { return toString(); }
+
+kj::String KJ_STRINGIFY(const MimeType& mimeType) {
+  return mimeType.toString();
+}
+
+const MimeType MimeType::PLAINTEXT = MimeType::parse("text/plain;charset=UTF-8"_kj);
+const MimeType MimeType::CSS = MimeType("text"_kj, "css"_kj);
+const MimeType MimeType::HTML = MimeType("text"_kj, "html"_kj);
+const MimeType MimeType::TEXT_JAVASCRIPT = MimeType("text"_kj, "javascript"_kj);
+const MimeType MimeType::JSON = MimeType("application"_kj, "json"_kj);
+const MimeType MimeType::FORM_URLENCODED = MimeType("application"_kj, "x-www-form-urlencoded"_kj);
+const MimeType MimeType::OCTET_STREAM = MimeType("application"_kj, "octet-stream"_kj);
+const MimeType MimeType::XHTML = MimeType("application"_kj, "xhtml+xml"_kj);
+const MimeType MimeType::JAVASCRIPT = MimeType("application"_kj, "javascript"_kj);
+const MimeType MimeType::XJAVASCRIPT = MimeType("application"_kj, "x-javascript"_kj);
+const MimeType MimeType::FORM_DATA = MimeType("multipart"_kj, "form-data"_kj);
+const MimeType MimeType::MANIFEST_JSON = MimeType("application"_kj, "manifest+json"_kj);
+const MimeType MimeType::VTT = MimeType("text"_kj, "vtt"_kj);
+const MimeType MimeType::EVENT_STREAM = MimeType("text"_kj, "event-stream"_kj);
+
+bool MimeType::isXml(const MimeType& mimeType) {
+  auto type = mimeType.type();
+  auto subtype = mimeType.subtype();
+  return (type == "text" || type == "application") &&
+         (subtype == "xml" || subtype.endsWith("+xml"));
+}
+
+bool MimeType::isJson(const MimeType& mimeType) {
+  auto type = mimeType.type();
+  auto subtype = mimeType.subtype();
+  return (type == "text" || type == "application") &&
+         (subtype == "json" || subtype.endsWith("+json"));
+}
+
+bool MimeType::isFont(const MimeType& mimeType) {
+  auto type = mimeType.type();
+  auto subtype = mimeType.subtype();
+  return (type == "font" || type == "application") &&
+         (subtype.startsWith("font-") || subtype.startsWith("x-font-"));
+}
+
+bool MimeType::isJavascript(const MimeType& mimeType) {
+  return JAVASCRIPT == mimeType ||
+         XJAVASCRIPT == mimeType ||
+         TEXT_JAVASCRIPT == mimeType;
+}
+
+bool MimeType::isImage(const MimeType& mimeType) {
+  return mimeType.type() == "image";
+}
+
+bool MimeType::isVideo(const MimeType& mimeType) {
+  return mimeType.type() == "video";
+}
+
+bool MimeType::isAudio(const MimeType& mimeType) {
+  return mimeType.type() == "audio";
+}
+}  // namespace workerd

--- a/src/workerd/util/mimetype.h
+++ b/src/workerd/util/mimetype.h
@@ -1,0 +1,104 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+#pragma once
+
+#include <kj/common.h>
+#include <kj/exception.h>
+#include <kj/map.h>
+#include <kj/string.h>
+
+namespace workerd {
+
+class MimeType final {
+public:
+  using MimeParams = kj::HashMap<kj::String, kj::String>;
+
+  enum ParseOptions {
+    DEFAULT,
+    IGNORE_PARAMS,
+  };
+
+  static kj::Maybe<MimeType> tryParse(kj::StringPtr input,
+                                      ParseOptions options = ParseOptions::DEFAULT);
+  // Returning nullptr implies that the input is not a valid mime type construction.
+  // If the ParseOptions::IGNORE_PARAMS option is set then the mime type parameters
+  // will be ignored and will not be included in the parsed result.
+
+  static MimeType parse(kj::StringPtr input,
+                        ParseOptions options = ParseOptions::DEFAULT);
+  // Asserts if the input could not be parsed as a valid MimeType. tryParse should
+  // be preferred for most cases.
+
+  explicit MimeType(kj::StringPtr type,
+                    kj::StringPtr subtype,
+                    kj::Maybe<MimeParams> params = nullptr);
+
+  MimeType(MimeType&&) = default;
+  MimeType& operator=(MimeType&&) = default;
+  KJ_DISALLOW_COPY(MimeType);
+
+  kj::StringPtr type() const;
+  kj::StringPtr subtype() const;
+
+  const MimeParams& params() const;
+
+  bool setType(kj::StringPtr type);
+  bool setSubtype(kj::StringPtr type);
+  bool addParam(kj::ArrayPtr<const char> name, kj::ArrayPtr<const char> value);
+  void eraseParam(kj::StringPtr name);
+
+  kj::String essence() const;
+  // Returns only the type/subtype
+
+  kj::String toString() const;
+  // Returns the type/subtype and all params.
+
+  kj::String paramsToString() const;
+
+  MimeType clone(ParseOptions options = ParseOptions::DEFAULT) const;
+  // Copy this MimeType. If the IGNORE_PARAMS option is set the clone
+  // will copy only the type and subtype and will omit all of the parameters.
+
+  bool operator==(const MimeType& other) const;
+  // Compares only the essence of the MimeType (type and subtype). Ignores
+  // parameters in the comparison.
+
+  bool operator!=(const MimeType& other) const;
+  // Compares only the essence of the MimeType (type and subtype). Ignores
+  // parameters in the comparison.
+
+  operator kj::String() const;
+
+  static bool isXml(const MimeType& mimeType);
+  static bool isJson(const MimeType& mimeType);
+  static bool isFont(const MimeType& mimeType);
+  static bool isJavascript(const MimeType& mimeType);
+  static bool isImage(const MimeType& mimeType);
+  static bool isVideo(const MimeType& mimeType);
+  static bool isAudio(const MimeType& mimeType);
+
+  static const MimeType JSON;
+  static const MimeType PLAINTEXT;
+  static const MimeType FORM_URLENCODED;
+  static const MimeType FORM_DATA;
+  static const MimeType OCTET_STREAM;
+  static const MimeType XHTML;
+  static const MimeType JAVASCRIPT;
+  static const MimeType XJAVASCRIPT;
+  static const MimeType HTML;
+  static const MimeType CSS;
+  static const MimeType TEXT_JAVASCRIPT;
+  static const MimeType MANIFEST_JSON;
+  static const MimeType VTT;
+  static const MimeType EVENT_STREAM;
+
+private:
+  kj::String type_;
+  kj::String subtype_;
+  MimeParams params_;
+};
+
+kj::String KJ_STRINGIFY(const MimeType& state);
+
+}  // namespace workerd

--- a/src/workerd/util/strings.h
+++ b/src/workerd/util/strings.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+#pragma once
+
+#include <kj/string.h>
+
+namespace workerd {
+
+inline kj::String toLowerCopy(kj::StringPtr ptr) {
+  auto str = kj::str(ptr);
+  for (char& c: str) {
+    if ('A' <= c && c <= 'Z') c += 'a' - 'A';
+  }
+  return kj::mv(str);
+}
+
+inline kj::String toLowerCopy(kj::ArrayPtr<const char> ptr) {
+  auto str = kj::str(ptr);
+  for (char& c: str) {
+    if ('A' <= c && c <= 'Z') c += 'a' - 'A';
+  }
+  return kj::mv(str);
+}
+
+}  // namespace workerd


### PR DESCRIPTION
Implements Node.js MIMEType API. Implemented in C++ because this also addresses a number of internal TODOs by implementing a proper MIME type parser internally.