### PR TITLE
Add a script to fix missing copyrights on sources and apply it

### DIFF
--- a/samples/async-context/worker.js
+++ b/samples/async-context/worker.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import { AsyncLocalStorage, AsyncResource } from 'node:async_hooks';
 
 const als = new AsyncLocalStorage();

--- a/samples/durable-objects-chat/chat.js
+++ b/samples/durable-objects-chat/chat.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // This is the Edge Chat Demo Worker, built using Durable Objects!
 
 // ===============================

--- a/samples/extensions/binding.js
+++ b/samples/extensions/binding.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import { BurritoShop } from "burrito-shop-internal:burrito-shop-impl";
 
 function makeBinding(env) {

--- a/samples/extensions/burrito-shop-impl.js
+++ b/samples/extensions/burrito-shop-impl.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // burrito-shop-impl is an internal module and can't be imported by user code
 
 

--- a/samples/extensions/burrito-shop.js
+++ b/samples/extensions/burrito-shop.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // implementation details are not directly accessible to the user
 import { BurritoShop } from "burrito-shop-internal:burrito-shop-impl";
 

--- a/samples/extensions/kitchen.js
+++ b/samples/extensions/kitchen.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // kitchen.js is an internal module and can't be imported by user code.
 
 const prices = { "rice": 1, "meat": 5, "beans": 1, "cheese": 1, "salsa": 1, "guacamole": 6, };

--- a/samples/extensions/worker.js
+++ b/samples/extensions/worker.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import { BurritoShop } from "burrito-shop:burrito-shop";
 
 export default {

--- a/samples/helloworld/worker.js
+++ b/samples/helloworld/worker.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 addEventListener('fetch', event => {
   event.respondWith(handle(event.request));
 });

--- a/samples/helloworld_esm/worker.js
+++ b/samples/helloworld_esm/worker.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 export default {
   async fetch(req, env) {
     return new Response("Hello World\n");

--- a/samples/static-files-from-disk/static.js
+++ b/samples/static-files-from-disk/static.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // An example Worker that serves static files from disk. This includes logic to do things like
 // set Content-Type based on file extension, look for `index.html` in directories, etc.
 //

--- a/samples/tcp/gopher.js
+++ b/samples/tcp/gopher.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // This is an ESM module implementing a simple Gopher client. Gopher is an old alternative to HTTP,
 // it is also a simple protocol which makes it ideal for demoing TCP sockets in workerd.
 //

--- a/samples/unit-tests/worker.js
+++ b/samples/unit-tests/worker.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // Exporting a test is like exporting a `fetch()` handler.
 //
 // It's common to want to write multiple tests in one file. We can export each

--- a/src/cloudflare/email.ts
+++ b/src/cloudflare/email.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // TODO: c++ built-ins do not yet support named exports
 import { default as email } from 'cloudflare-internal:email';
 export const { EmailMessage } = email;

--- a/src/cloudflare/internal/d1-api.ts
+++ b/src/cloudflare/internal/d1-api.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 interface Fetcher {
   fetch: typeof fetch
 }

--- a/src/cloudflare/internal/email.d.ts
+++ b/src/cloudflare/internal/email.d.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // Type definitions for c++ implementation.
 
 export class EmailMessage {

--- a/src/cloudflare/internal/sockets.d.ts
+++ b/src/cloudflare/internal/sockets.d.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // Type definitions for c++ implementation.
 
 export class Socket {

--- a/src/cloudflare/internal/test/d1-api-test.js
+++ b/src/cloudflare/internal/test/d1-api-test.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import * as assert from 'node:assert'
 
 // TODO: how to import this from d1-mock.js?

--- a/src/cloudflare/internal/test/d1-mock.js
+++ b/src/cloudflare/internal/test/d1-mock.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 const MOCK_USER_ROWS = {
   1: { user_id: 1, name: 'Albert Ross', home: 'sky', features: 'wingspan' },
   2: { user_id: 2, name: 'Al Dente', home: 'bowl', features: 'mouthfeel' },

--- a/src/cloudflare/sockets.ts
+++ b/src/cloudflare/sockets.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // TODO: c++ built-ins do not yet support named exports
 import sockets from 'cloudflare-internal:sockets';
 export function connect(

--- a/src/workerd/api/actor-alarms-delete-test.js
+++ b/src/workerd/api/actor-alarms-delete-test.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // This test is aimed towards validating a correct deleteAlarm behavior in workerd.
 // Currently running alarms cannot be deleted within alarm() handler, but can delete it everywhere
 // else.

--- a/src/workerd/api/actor-alarms-test.js
+++ b/src/workerd/api/actor-alarms-test.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import * as assert from 'node:assert'
 
 export class DurableObjectExample {

--- a/src/workerd/api/blob-test.js
+++ b/src/workerd/api/blob-test.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 function assertEqual(a, b) {
   if (a !== b) {
     throw new Error(a + " !== " + b);

--- a/src/workerd/api/crypto-impl-asymmetric-test.js
+++ b/src/workerd/api/crypto-impl-asymmetric-test.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import * as assert from 'node:assert';
 
 export const rsa_reject_infinite_loop_test = {

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #include "queue.h"
 #include "util.h"
 

--- a/src/workerd/api/queue.h
+++ b/src/workerd/api/queue.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #pragma once
 
 #include <atomic>

--- a/src/workerd/api/rtti-test.js
+++ b/src/workerd/api/rtti-test.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "node:assert";
 import rtti from "workerd:rtti";
 

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import * as assert from 'node:assert'
 
 function requireException(callback, expectStr, errCheck = () => {}) {

--- a/src/workerd/api/streams/identitytransformstream-backpressure-test.js
+++ b/src/workerd/api/streams/identitytransformstream-backpressure-test.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import {
   notStrictEqual,
   strictEqual,

--- a/src/workerd/io/actor-storage.c++
+++ b/src/workerd/io/actor-storage.c++
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #include "actor-storage.h"
 
 #include <workerd/jsg/jsg.h>

--- a/src/workerd/io/actor-storage.h
+++ b/src/workerd/io/actor-storage.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #pragma once
 
 #include <kj/common.h>

--- a/src/workerd/io/features.c++
+++ b/src/workerd/io/features.c++
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #include "features.h"
 #include "worker.h"
 

--- a/src/workerd/io/features.h
+++ b/src/workerd/io/features.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #pragma once
 
 #include <workerd/io/compatibility-date.capnp.h>

--- a/src/workerd/io/request-tracker.c++
+++ b/src/workerd/io/request-tracker.c++
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #include "request-tracker.h"
 
 namespace workerd {

--- a/src/workerd/io/request-tracker.h
+++ b/src/workerd/io/request-tracker.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #pragma once
 
 #include <kj/common.h>

--- a/src/workerd/jsg/exception.c++
+++ b/src/workerd/jsg/exception.c++
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #include "exception.h"
 
 #include <kj/debug.h>

--- a/src/workerd/jsg/v8-platform-wrapper.c++
+++ b/src/workerd/jsg/v8-platform-wrapper.c++
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #include "v8-platform-wrapper.h"
 #include <v8-isolate.h>
 #include "jsg.h"

--- a/src/workerd/jsg/v8-platform-wrapper.h
+++ b/src/workerd/jsg/v8-platform-wrapper.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #pragma once
 
 #include <v8-platform.h>

--- a/src/workerd/server/tests/extensions/binding.js
+++ b/src/workerd/server/tests/extensions/binding.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 export function wrap(env) {
   if (!env.secret) {
     throw new Error("secret internal binding is not specified");

--- a/src/workerd/server/tests/extensions/extensions-test.js
+++ b/src/workerd/server/tests/extensions/extensions-test.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import * as assert from "node:assert";
 import { openDoor } from "test:module";
 

--- a/src/workerd/server/tests/extensions/internal-module.js
+++ b/src/workerd/server/tests/extensions/internal-module.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 export default {
   caveKey: "0p3n s3sam3",
 }

--- a/src/workerd/server/tests/extensions/module.js
+++ b/src/workerd/server/tests/extensions/module.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import secret from "test-internal:internal-module";
 
 export function openDoor(key) {

--- a/src/workerd/tests/performance-test.js
+++ b/src/workerd/tests/performance-test.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 if (typeof globalThis.performance === 'undefined') {
   throw new Error('performance is not defined');
 }

--- a/src/workerd/tests/test-fixture-test.c++
+++ b/src/workerd/tests/test-fixture-test.c++
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #include <kj/test.h>
 #include "test-fixture.h"
 

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #include <algorithm>
 
 #include <workerd/api/global-scope.h>

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #pragma once
 
 #include <kj/function.h>

--- a/src/workerd/util/symbolizer.c++
+++ b/src/workerd/util/symbolizer.c++
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 #ifndef EKAM_BUILD
 
 #include <cstdint>

--- a/tools/unix/fix-copyrights.sh
+++ b/tools/unix/fix-copyrights.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Copyright (c) ${date_range} Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+SCRIPT_DIR=$(realpath $(dirname "$0"))/../..
+CURRENT_YEAR=$(date +"%Y")
+
+function copyright() {
+  local source_file="$1"
+  local date_range="$2"
+  local wip_file=$(mktemp -t $(basename "${source_file}"))
+  cat <<EOF > "${wip_file}"
+// Copyright (c) ${date_range} Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+EOF
+  cat "${source_file}" >> "${wip_file}"
+  mv "${wip_file}" "${source_file}"
+}
+
+cd "${SCRIPT_DIR}"
+for source_file in $(find . -name '*.c++' -o -name '*.h' -o -name '*.ts' -o -name '*.js') ; do
+  if grep -Liq copyright "${source_file}" ; then
+    continue
+  fi
+  if [[ "${source_file}" = *"node"* ]]; then
+    continue
+  fi
+  commit=$(git log --oneline --format="%as %h %s" --reverse ${source_file} | head -1)
+  commit_date=$(echo ${commit}| sed -e 's/ .*//')
+  commit_year=$(echo ${commit_date}| sed -e 's/-.*//')
+  if [ "${commit_date}" = "2022-09-13" -o "${commit_date}" = "2022-09-19" ]; then
+    copyright "${source_file}" "2017-2023"
+  elif [ "${commit_year}" = "${CURRENT_YEAR}" ]; then
+    copyright "${source_file}" "${CURRENT_YEAR}"
+  else
+    copyright "${source_file}" "${commit_year}-${CURRENT_YEAR}"
+  fi
+done

--- a/types/.eslintrc.js
+++ b/types/.eslintrc.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 module.exports = {
   parser: "@typescript-eslint/parser",
   extends: ["plugin:prettier/recommended"],

--- a/types/defines/d1.d.ts
+++ b/types/defines/d1.d.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 interface D1Result<T = unknown> {
   results: T[];
   success: true;

--- a/types/defines/email.d.ts
+++ b/types/defines/email.d.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 /**
  * An email message that can be sent from a Worker.
  */

--- a/types/defines/pages.d.ts
+++ b/types/defines/pages.d.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 type Params<P extends string = any> = Record<P, string | string[]>;
 
 type EventContext<Env, P extends string, Data> = {

--- a/types/defines/pubsub.d.ts
+++ b/types/defines/pubsub.d.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // https://developers.cloudflare.com/pub-sub/
 
 // PubSubMessage represents an incoming PubSub message.

--- a/types/defines/sockets.d.ts
+++ b/types/defines/sockets.d.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 declare module "cloudflare:sockets" {
   function _connect(address: string | SocketAddress, options?: SocketOptions): Socket;
   export { _connect as connect };

--- a/types/defines/wfp.d.ts
+++ b/types/defines/wfp.d.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 // https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/
 
 

--- a/types/src/generator/index.ts
+++ b/types/src/generator/index.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import {
   FunctionType,

--- a/types/src/generator/parameter-names.ts
+++ b/types/src/generator/parameter-names.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import fs from "node:fs";
 
 let paramNameData: Map<string, Parameter> = new Map();

--- a/types/src/generator/structure.ts
+++ b/types/src/generator/structure.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import {
   Constant,

--- a/types/src/generator/type.ts
+++ b/types/src/generator/type.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import {
   ArrayType,

--- a/types/src/print.ts
+++ b/types/src/print.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import ts, { factory as f } from "typescript";
 
 const placeholderFile = ts.createSourceFile(

--- a/types/src/program.ts
+++ b/types/src/program.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import path from "path";
 import ts from "typescript";
 

--- a/types/src/transforms/ambient.ts
+++ b/types/src/transforms/ambient.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import ts from "typescript";
 import { ensureStatementModifiers } from "./helpers";
 

--- a/types/src/transforms/comments.ts
+++ b/types/src/transforms/comments.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import ts from "typescript";
 import { ParsedTypeDefinition } from "../standards";

--- a/types/src/transforms/globals.ts
+++ b/types/src/transforms/globals.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import ts from "typescript";
 

--- a/types/src/transforms/helpers.ts
+++ b/types/src/transforms/helpers.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import * as ts from "typescript";
 import { printNode } from "../print";

--- a/types/src/transforms/importable.ts
+++ b/types/src/transforms/importable.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import ts from "typescript";
 import { ensureStatementModifiers } from "./helpers";
 

--- a/types/src/transforms/index.ts
+++ b/types/src/transforms/index.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 export * from "./globals";
 export * from "./iterators";
 export * from "./overrides";

--- a/types/src/transforms/iterators.ts
+++ b/types/src/transforms/iterators.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import ts from "typescript";
 import { printNode } from "../print";

--- a/types/src/transforms/overrides/compiler.ts
+++ b/types/src/transforms/overrides/compiler.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import path from "path";
 import { StructureGroups } from "@workerd/jsg/rtti.capnp.js";

--- a/types/src/transforms/overrides/index.ts
+++ b/types/src/transforms/overrides/index.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import ts from "typescript";
 import { isUnsatisfiable } from "../../generator/type";

--- a/types/test/generator/index.spec.ts
+++ b/types/test/generator/index.spec.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import { test } from "node:test";
 import {

--- a/types/test/generator/structure.spec.ts
+++ b/types/test/generator/structure.spec.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import { test } from "node:test";
 import { JsgImplType_Type, Structure } from "@workerd/jsg/rtti.capnp.js";

--- a/types/test/generator/type.spec.ts
+++ b/types/test/generator/type.spec.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import { test } from "node:test";
 import {

--- a/types/test/print.spec.ts
+++ b/types/test/print.spec.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import { test } from "node:test";
 import ts, { factory as f } from "typescript";

--- a/types/test/transforms/globals.spec.ts
+++ b/types/test/transforms/globals.spec.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import { test } from "node:test";
 import path from "path";

--- a/types/test/transforms/iterators.spec.ts
+++ b/types/test/transforms/iterators.spec.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import { test } from "node:test";
 import path from "path";

--- a/types/test/transforms/overrides/index.spec.ts
+++ b/types/test/transforms/overrides/index.spec.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 import assert from "assert";
 import { test } from "node:test";
 import path from "path";

--- a/types/test/types/cf.ts
+++ b/types/test/types/cf.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
 function expectType<T>(_value: T) {}
 
 export const handler: ExportedHandler<{ SERVICE: Fetcher }> = {


### PR DESCRIPTION
Adds tools/unix/fix-copyrights.sh which looks for sources where the copyright may have been unintentionally missed.

Noticed we'd missed a few the other day and saw this note about [github sources](https://wiki.cfdata.org/display/LAW/Open+Source+Compliance#:~:text=put%20it%20on%20the%20Cloudflare%20GitHub).