### PR TITLE
extending module registry lifetime

### DIFF
--- a/src/workerd/api/streams/queue-test.c++
+++ b/src/workerd/api/streams/queue-test.c++
@@ -24,7 +24,7 @@ struct Preamble {
   v8::Local<v8::Context> context;
   v8::Context::Scope contextScope;
   Preamble()
-    : isolate(v8System),
+    : isolate(v8System, kj::heap<jsg::IsolateObserver>()),
       lock(isolate, stackScope),
       scope(lock.v8Isolate),
       context(lock.newContext<QueueContext>().getHandle(lock.v8Isolate)),

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -51,11 +51,11 @@ wd_cc_library(
         "//src/workerd/jsg",
         "//src/workerd/jsg:rtti",
         "//src/workerd/util:sqlite",
-        "@capnp-cpp//src/kj:kj-async",
-        "@capnp-cpp//src/kj/compat:kj-gzip",
-        "@capnp-cpp//src/kj/compat:kj-brotli",
-        "@capnp-cpp//src/capnp/compat:http-over-capnp",
         "@capnp-cpp//src/capnp:capnp-rpc",
+        "@capnp-cpp//src/capnp/compat:http-over-capnp",
+        "@capnp-cpp//src/kj:kj-async",
+        "@capnp-cpp//src/kj/compat:kj-brotli",
+        "@capnp-cpp//src/kj/compat:kj-gzip",
         "@com_cloudflare_lol_html//:lolhtml",
     ],
 )
@@ -78,7 +78,10 @@ wd_cc_library(
     name = "observer",
     hdrs = ["observer.h"],
     visibility = ["//visibility:public"],
-    deps = [":trace"],
+    deps = [
+        ":trace",
+        "//src/workerd/jsg:observer",
+    ],
 )
 
 wd_cc_library(

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -12,6 +12,7 @@
 #include <kj/time.h>
 #include <kj/compat/http.h>
 #include <workerd/io/trace.h>
+#include <workerd/jsg/observer.h>
 
 namespace workerd {
 
@@ -72,8 +73,10 @@ public:
   virtual void setFailedOpen(bool value) {}
 };
 
-class IsolateObserver: public kj::AtomicRefcounted {
+class IsolateObserver: public kj::AtomicRefcounted, public jsg::IsolateObserver {
 public:
+  virtual ~IsolateObserver() noexcept(false) { }
+
   virtual void created() {};
   // Called when Worker::Isolate is created.
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -180,7 +180,7 @@ public:
   inline kj::StringPtr getId() const { return id; }
   const Isolate& getIsolate() const { return *isolate; }
 
-  bool isModular() const;
+  bool isModular() const { return modular; }
 
   struct CompiledGlobal {
     jsg::V8Ref<v8::String> name;
@@ -196,7 +196,7 @@ public:
     // Name of the script, used as the script origin for stack traces. Pointer is valid only until
     // the Script constructor returns.
 
-    kj::Function<kj::Array<CompiledGlobal>(jsg::Lock& lock, const ApiIsolate& apiIsolate)>
+    kj::Function<kj::Array<CompiledGlobal>(jsg::Lock& lock, const ApiIsolate& apiIsolate, const jsg::CompilationObserver& observer)>
         compileGlobals;
     // Callback which will compile the script-level globals, returning a list of them.
   };
@@ -205,8 +205,7 @@ public:
     // Path to the main module, which can be looked up in the module registry. Pointer is valid
     // only until the Script constructor returns.
 
-    kj::Function<kj::Own<jsg::ModuleRegistry>(jsg::Lock& lock, const ApiIsolate& apiIsolate)>
-        compileModules;
+    kj::Function<void(jsg::Lock& lock, const ApiIsolate& apiIsolate)> compileModules;
     // Callback which will construct the module registry and load all the modules into it.
   };
   using Source = kj::OneOf<ScriptSource, ModulesSource>;
@@ -214,6 +213,7 @@ public:
 private:
   kj::Own<const Isolate> isolate;
   kj::String id;
+  bool modular;
 
   struct Impl;
   kj::Own<Impl> impl;

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -17,6 +17,7 @@ wd_cc_library(
         ["*.h"],
         exclude = [
             "exception.h",
+            "observer.h",
             "rtti.h",
         ],
     ),
@@ -24,6 +25,7 @@ wd_cc_library(
     deps = [
         ":exception",
         ":modules_capnp",
+        ":observer",
         "//src/workerd/util",
         "//src/workerd/util:sentry",
         "//src/workerd/util:thread-scopes",
@@ -83,6 +85,16 @@ wd_cc_capnp_library(
     name = "modules_capnp",
     srcs = ["modules.capnp"],
     visibility = ["//visibility:public"],
+)
+
+wd_cc_library(
+    name = "observer",
+    hdrs = ["observer.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj",
+        "@workerd-v8//:v8",
+    ],
 )
 
 [kj_test(

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -311,7 +311,7 @@ struct LockLogContext: public Object {
 JSG_DECLARE_ISOLATE_TYPE(LockLogIsolate, LockLogContext);
 
 KJ_TEST("jsg::Lock logWarning") {
-  LockLogIsolate isolate(v8System);
+  LockLogIsolate isolate(v8System, kj::heap<IsolateObserver>());
   bool called = false;
   V8StackScope stackScope;
   LockLogIsolate::Lock lock(isolate, stackScope);
@@ -369,7 +369,7 @@ struct IsolateUuidContext: public Object {
 JSG_DECLARE_ISOLATE_TYPE(IsolateUuidIsolate, IsolateUuidContext);
 
 KJ_TEST("jsg::Lock getUuid") {
-  IsolateUuidIsolate isolate(v8System);
+  IsolateUuidIsolate isolate(v8System, kj::heap<IsolateObserver>());
   V8StackScope stackScope;
   IsolateUuidIsolate::Lock lock(isolate, stackScope);
   // Returns the same value

--- a/src/workerd/jsg/jsg-test.h
+++ b/src/workerd/jsg/jsg-test.h
@@ -24,7 +24,7 @@ public:
 
   IsolateType& getIsolate() {
     // Slightly more efficient to only instantiate each isolate type once (17s vs. 20s):
-    static IsolateType isolate(v8System, ConfigurationType());
+    static IsolateType isolate(v8System, ConfigurationType(), kj::heap<IsolateObserver>());
     return isolate;
   }
 

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-#include "modules.h"
+#include "jsg.h"
 #include "promise.h"
 #include <kj/mutex.h>
 #include <set>
@@ -342,6 +342,15 @@ void instantiateModule(jsg::Lock& js, v8::Local<v8::Module>& module) {
 // ===================================================================================
 
 namespace {
+
+static CompilationObserver::Option convertOption(ModuleInfoCompileOption option) {
+  switch (option) {
+    case ModuleInfoCompileOption::BUILTIN: return CompilationObserver::Option::BUILTIN;
+    case ModuleInfoCompileOption::BUNDLE: return CompilationObserver::Option::BUNDLE;
+  }
+  KJ_UNREACHABLE;
+}
+
 v8::Local<v8::Module> compileEsmModule(
     jsg::Lock& js,
     kj::StringPtr name,
@@ -349,7 +358,7 @@ v8::Local<v8::Module> compileEsmModule(
     ModuleInfoCompileOption option,
     const CompilationObserver& observer) {
   // destroy the observer after compilation finished to indicate the end of the process.
-  auto compilationObserver = observer.onEsmCompilationStart(js.v8Isolate, name, option);
+  auto compilationObserver = observer.onEsmCompilationStart(js.v8Isolate, name, convertOption(option));
 
   // Must pass true for `is_module`, but we can skip everything else.
   const int resourceLineOffset = 0;

--- a/src/workerd/jsg/observer.h
+++ b/src/workerd/jsg/observer.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <kj/common.h>
+#include <kj/string.h>
+#include <v8.h>
+
+namespace workerd::jsg {
+
+struct CompilationObserver {
+  virtual ~CompilationObserver() noexcept(false) { }
+
+  // see ModuleInfoCompileOption
+  enum class Option { BUNDLE, BUILTIN };
+
+  // Monitors behavior of compilation processes.
+
+  virtual kj::Own<void> onEsmCompilationStart(
+      v8::Isolate* isolate, kj::StringPtr name, Option option) const { return kj::Own<void>(); }
+  // Called at the start of module compilation.
+  // Returned value will be destroyed when module compilation finishes.
+  // It is guaranteed that isolate lock is held during both invocations.
+
+  virtual kj::Own<void> onWasmCompilationStart(v8::Isolate* isolate, size_t codeSize) const { return kj::Own<void>(); }
+  // Called at the start of wasm compilation.
+  // Returned value will be destroyed when module compilation finishes.
+  // It is guaranteed that isolate lock is held during both invocations.
+};
+
+
+struct IsolateObserver : public CompilationObserver {
+  virtual ~IsolateObserver() noexcept(false) { }
+};
+
+
+} // namespace workerd::jsg

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <kj/async.h>
+#include <kj/table.h>
 #include "jsg.h"
 #include "util.h"
 #include "wrappable.h"

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -861,7 +861,9 @@ public:
   }
 
   template <typename... Args>
-  JsContext<T> newContext(v8::Isolate* isolate, T*, Args&&... args) {
+  JsContext<T> newContext(v8::Isolate* isolate,
+      CompilationObserver& compilationObserver,
+      T*, Args&&... args) {
     // Construct an instance of this type to be used as the Javascript global object, creating
     // a new JavaScript context. Unfortunately, we have to do some things differently in this
     // case, because of quirks in how V8 handles the global object. There appear to be bugs
@@ -906,7 +908,8 @@ public:
     // Expose the type of the global scope in the global scope itself.
     exposeGlobalScopeType(isolate, context);
 
-    return JsContext<T>(context, kj::mv(ptr));
+    auto moduleManager = ModuleRegistryImpl<TypeWrapper>::install(isolate, context, compilationObserver);
+    return JsContext<T>(context, kj::mv(ptr), kj::mv(moduleManager));
   }
 
   kj::Maybe<T&> tryUnwrap(

--- a/src/workerd/jsg/setup-test.c++
+++ b/src/workerd/jsg/setup-test.c++
@@ -66,7 +66,7 @@ JSG_DECLARE_ISOLATE_TYPE(ConfigIsolate, ConfigContext, ConfigContext::Nested,
 
 KJ_TEST("configuration values reach nested type declarations") {
   {
-    ConfigIsolate isolate(v8System, 123);
+    ConfigIsolate isolate(v8System, 123, kj::heap<IsolateObserver>());
     V8StackScope stackScope;
     ConfigIsolate::Lock lock(isolate, stackScope);
     v8::HandleScope handleScope(lock.v8Isolate);
@@ -75,7 +75,7 @@ KJ_TEST("configuration values reach nested type declarations") {
   {
     KJ_EXPECT_LOG(ERROR, "failed: expected configuration == 123");
 
-    ConfigIsolate isolate(v8System, 456);
+    ConfigIsolate isolate(v8System, 456, kj::heap<IsolateObserver>());
     V8StackScope stackScope;
     ConfigIsolate::Lock lock(isolate, stackScope);
     v8::HandleScope handleScope(lock.v8Isolate);

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -271,10 +271,11 @@ namespace {
   }
 }
 
-IsolateBase::IsolateBase(const V8System& system, v8::Isolate::CreateParams&& createParams)
+IsolateBase::IsolateBase(const V8System& system, v8::Isolate::CreateParams&& createParams, kj::Own<IsolateObserver> observer)
     : system(system),
       ptr(newIsolate(kj::mv(createParams))),
-      heapTracer(ptr) {
+      heapTracer(ptr),
+      observer(kj::mv(observer)) {
   V8StackScope stackScope;
 
   v8::CppHeapCreateParams params {

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1999,12 +1999,13 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
     void reportMetrics(IsolateObserver& isolateMetrics) const override {}
   };
 
+  auto observer = kj::atomicRefcounted<IsolateObserver>();
   auto limitEnforcer = kj::heap<NullIsolateLimitEnforcer>();
   auto api = kj::heap<WorkerdApiIsolate>(globalContext->v8System,
-      featureFlags.asReader(), *limitEnforcer);
+      featureFlags.asReader(), *limitEnforcer, kj::atomicAddRef(*observer));
   auto isolate = kj::atomicRefcounted<Worker::Isolate>(
       kj::mv(api),
-      kj::atomicRefcounted<IsolateObserver>(),
+      kj::mv(observer),
       name,
       kj::mv(limitEnforcer),
       // For workerd, if the inspector is enabled, it is always fully trusted.

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -6,6 +6,7 @@
 
 #include <workerd/io/worker.h>
 #include <workerd/server/workerd.capnp.h>
+#include <workerd/jsg/setup.h>
 
 namespace workerd::server {
 
@@ -14,7 +15,8 @@ class WorkerdApiIsolate final: public Worker::ApiIsolate {
 public:
   WorkerdApiIsolate(jsg::V8System& v8System,
       CompatibilityFlags::Reader features,
-      IsolateLimitEnforcer& limitEnforcer);
+      IsolateLimitEnforcer& limitEnforcer,
+      kj::Own<jsg::IsolateObserver> observer);
   ~WorkerdApiIsolate() noexcept(false);
 
   kj::Own<jsg::Lock> lock(jsg::V8StackScope& stackScope) const override;
@@ -156,10 +158,14 @@ private:
   kj::Own<Impl> impl;
 
   kj::Array<Worker::Script::CompiledGlobal> compileScriptGlobals(
-      jsg::Lock& lock, config::Worker::Reader conf,
-      Worker::ValidationErrorReporter& errorReporter) const;
-  kj::Own<jsg::ModuleRegistry> compileModules(
-      jsg::Lock& lock, config::Worker::Reader conf,
+      jsg::Lock& lock,
+      config::Worker::Reader conf,
+      Worker::ValidationErrorReporter& errorReporter,
+      const jsg::CompilationObserver& observer) const;
+
+  void compileModules(
+      jsg::Lock& lock,
+      config::Worker::Reader conf,
       Worker::ValidationErrorReporter& errorReporter,
       capnp::List<config::Extension>::Reader extensions) const;
 };

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -261,7 +261,8 @@ TestFixture::TestFixture(SetupParams params)
     apiIsolate(kj::heap<server::WorkerdApiIsolate>(
       testV8System,
       params.featureFlags.orDefault(CompatibilityFlags::Reader()),
-      *isolateLimitEnforcer)),
+      *isolateLimitEnforcer,
+      kj::atomicRefcounted<IsolateObserver>())),
     workerIsolate(kj::atomicRefcounted<Worker::Isolate>(
       kj::mv(apiIsolate),
       kj::atomicRefcounted<IsolateObserver>(),


### PR DESCRIPTION
this change moves the ownership of `ModuleRegistry` to `JsgContext`. The goal is to always have it available for every context to be able to compile and use bootstrap js modules.

To properly support observability it brings `CompilationObserver` into `IsolateObserver` hierarchy.

Internal PR 5780