### PR TITLE
fix Runtime APIs: "Called .text() on an HTTP body" detection false-positives

### DIFF
--- a/src/workerd/api/util.c++
+++ b/src/workerd/api/util.c++
@@ -228,20 +228,20 @@ void maybeWarnIfNotText(kj::StringPtr str) {
   // A common mistake is to call .text() on non-text content, e.g. because you're implementing a
   // search-and-replace across your whole site and you forgot that it'll apply to images too.
   // When running in the fiddle, let's warn the developer if they do this.
-  KJ_IF_MAYBE (mimeType, MimeType::tryParse(str)) {
-    if (mimeType.type() == "text" || mimeType.subtype() == "json" ||
-        mimeType.subtype() == "xml" || mimeType.subtype() == "javascript") {
+  KJ_IF_MAYBE(mimeType, MimeType::tryParse(str)) {
+    if (mimeType->type() == "text" || mimeType->subtype() == "json" ||
+        mimeType->subtype() == "xml" || mimeType->subtype() == "javascript") {
       return;
     }
-    KJ_IF_MAYBE (charset, mimeType.params().find("charset")) {
-      if (charset.value == "utf-8") {
+    // If content has charset param, it is text content.
+    KJ_IF_MAYBE(charset, mimeType->params().find("charset"_kj)) {
         return;
-      }
     }
     IoContext::current().logWarning(kj::str(
     "Called .text() on an HTTP body which does not appear to be text. The body's "
     "Content-Type is \"", str, "\". The result will probably be corrupted. Consider "
     "checking the Content-Type header before interpreting entities as text."));
   }
+
 }
 }  // namespace workerd::api

--- a/src/workerd/api/util.c++
+++ b/src/workerd/api/util.c++
@@ -242,6 +242,5 @@ void maybeWarnIfNotText(kj::StringPtr str) {
         "Content-Type is \"", str, "\". The result will probably be corrupted. Consider "
         "checking the Content-Type header before interpreting entities as text."));
   }
-
 }
 }  // namespace workerd::api

--- a/src/workerd/api/util.c++
+++ b/src/workerd/api/util.c++
@@ -238,9 +238,9 @@ void maybeWarnIfNotText(kj::StringPtr str) {
         return;
     }
     IoContext::current().logWarning(kj::str(
-    "Called .text() on an HTTP body which does not appear to be text. The body's "
-    "Content-Type is \"", str, "\". The result will probably be corrupted. Consider "
-    "checking the Content-Type header before interpreting entities as text."));
+        "Called .text() on an HTTP body which does not appear to be text. The body's "
+        "Content-Type is \"", str, "\". The result will probably be corrupted. Consider "
+        "checking the Content-Type header before interpreting entities as text."));
   }
 
 }

--- a/src/workerd/api/util.c++
+++ b/src/workerd/api/util.c++
@@ -228,16 +228,20 @@ void maybeWarnIfNotText(kj::StringPtr str) {
   // A common mistake is to call .text() on non-text content, e.g. because you're implementing a
   // search-and-replace across your whole site and you forgot that it'll apply to images too.
   // When running in the fiddle, let's warn the developer if they do this.
-  if (!str.startsWith("text/") &&
-      !str.endsWith("charset=UTF-8") &&
-      !str.endsWith("charset=utf-8") &&
-      !str.endsWith("xml") &&
-      !str.endsWith("json") &&
-      !str.endsWith("javascript")) {
+  KJ_IF_MAYBE (mimeType, MimeType::tryParse(str)) {
+    if (mimeType.type() == "text" || mimeType.subtype() == "json" ||
+        mimeType.subtype() == "xml" || mimeType.subtype() == "javascript") {
+      return;
+    }
+    KJ_IF_MAYBE (charset, mimeType.params().find("charset")) {
+      if (charset.value == "utf-8") {
+        return;
+      }
+    }
     IoContext::current().logWarning(kj::str(
-        "Called .text() on an HTTP body which does not appear to be text. The body's "
-        "Content-Type is \"", str, "\". The result will probably be corrupted. Consider "
-        "checking the Content-Type header before interpreting entities as text."));
+    "Called .text() on an HTTP body which does not appear to be text. The body's "
+    "Content-Type is \"", str, "\". The result will probably be corrupted. Consider "
+    "checking the Content-Type header before interpreting entities as text."));
   }
 }
 }  // namespace workerd::api


### PR DESCRIPTION
Hello, I fix https://github.com/cloudflare/workerd/issues/528 .

I think that if the mimeType meets any of the following conditions, it is a text content.
- mime-type  type is `text`
- mime-type subtype is one of `json` , `javascript`, `xml`
- mime-type has `charset` param

If the mime-type parser failed, we don't log warn.