### PR TITLE
Add missing types for Durable Object Hibernation API handlers

### DIFF
--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -91,6 +91,9 @@ public:
     JSG_TS_DEFINE(interface DurableObject {
       fetch(request: Request): Response | Promise<Response>;
       alarm?(): void | Promise<void>;
+      webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): void | Promise<void>;
+      webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean): void | Promise<void>;
+      webSocketError(ws: WebSocket, error: unknown): void | Promise<void>;
     });
     JSG_TS_OVERRIDE(DurableObjectStub);
     // Rename this resource type to DurableObjectStub, and make DurableObject


### PR DESCRIPTION
This PR adds `webSocketMessage`, `webSocketClose` and `webSocketError` handlers to the `DurableObject` interface type definition.

Ref: [docs](https://developers.cloudflare.com/workers/runtime-apis/durable-objects/#websocketmessage-handler-method)

cc @mrbbot 


Fixes #846