### PR TITLE
Enable websocket compression compat date

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -224,13 +224,15 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Obsolete flag. Has no effect.
 
   webSocketCompression @20 :Bool
-      $compatEnableFlag("web_socket_compression");
+      $compatEnableFlag("web_socket_compression")
+      $compatEnableDate("2023-08-15")
+      $compatDisableFlag("no_web_socket_compression");
   # Enables WebSocket compression. Without this flag, all attempts to negotiate compression will
-  # be refused, so WebSockets will never use compression. With this flag, the system will
-  # automatically negotiate the use of the permesssage-deflate extension where appropriate.
-  # The Worker can also request specific compression settings by specifying a valid
-  # Sec-WebSocket-Extensions header, or setting the header to the empty string to explicitly
-  # request that no compression be used.
+  # be refused for scripts prior to the compat date, so WebSockets will never use compression.
+  # With this flag, the system will automatically negotiate the use of the permessage-deflate
+  # extension where appropriate. The Worker can also request specific compression settings by
+  # specifying a valid Sec-WebSocket-Extensions header, or setting the header to the empty string
+  # to explicitly request that no compression be used.
 
   nodeJsCompat @21 :Bool
       $compatEnableFlag("nodejs_compat")


### PR DESCRIPTION
This does not enable compression for all compatibility dates.