### PR TITLE
Implement node crypto algorithm listings, crypto error message fixes

### DIFF
--- a/src/node/crypto.ts
+++ b/src/node/crypto.ts
@@ -115,6 +115,18 @@ export {
   createSecretKey,
 }
 
+export function getCiphers() {
+  return ["aes-128-cbc", "aes-192-cbc", "aes-256-cbc", "aes-128-ctr", "aes-192-ctr", "aes-256-ctr",
+  "aes-128-ecb", "aes-192-ecb", "aes-256-ecb", "aes-128-gcm", "aes-192-gcm", "aes-256-gcm",
+  "aes-128-ofb", "aes-192-ofb", "aes-256-ofb", "des-ecb", "des-ede", "des-ede-cbc", "rc2-cbc"];
+}
+
+export function getCurves() {
+  // Hardcoded list of supported curves. Note that prime256v1 is equivalent to secp256r1, we follow
+  // OpenSSL's and bssl's nomenclature here.
+  return ['secp224r1', 'prime256v1', 'secp384r1', 'secp521r1'];
+}
+
 export function getHashes() {
   // Hardcoded list of hashes supported in boringssl, node's approach looks pretty clunky. This is
   // expected to change infrequently based of bssl's stability-focused approach.
@@ -187,6 +199,8 @@ export default {
   pbkdf2,
   pbkdf2Sync,
   // Misc
+  getCiphers,
+  getCurves,
   secureHeapUsed,
   setEngine,
   timingSafeEqual,
@@ -255,8 +269,8 @@ export default {
 //   * [ ] crypto.verify(algorithm, data, key, signature[, callback])
 // * Misc
 //   * [ ] crypto.getCipherInfo(nameOrNid[, options])
-//   * [ ] crypto.getCiphers()
-//   * [ ] crypto.getCurves()
+//   * [x] crypto.getCiphers()
+//   * [x] crypto.getCurves()
 //   * [x] crypto.secureHeapUsed()
 //   * [x] crypto.setEngine(engine[, flags])
 //   * [x] crypto.timingSafeEqual(a, b)

--- a/src/workerd/api/crypto-impl-asymmetric.c++
+++ b/src/workerd/api/crypto-impl-asymmetric.c++
@@ -1332,7 +1332,7 @@ public:
 
     JSG_REQUIRE(getAlgorithm().which() == publicKey->getAlgorithm().which(), DOMInvalidAccessError,
         "Base ", getAlgorithmName(), " private key cannot be used to derive a "
-        "key from a peer ", getAlgorithmName(), " public key");
+        "key from a peer ", publicKey->getAlgorithmName(), " public key");
 
     JSG_REQUIRE(getAlgorithmName() == publicKey->getAlgorithmName(), DOMInvalidAccessError,
         "Private key for derivation is using \"", getAlgorithmName(),
@@ -2055,7 +2055,7 @@ public:
 
     JSG_REQUIRE(getAlgorithm().which() == publicKey->getAlgorithm().which(), DOMInvalidAccessError,
         "Base ", getAlgorithmName(), " private key cannot be used to derive a "
-        "key from a peer ", getAlgorithmName(), " public key");
+        "key from a peer ", publicKey->getAlgorithmName(), " public key");
 
     JSG_REQUIRE(getAlgorithmName() == publicKey->getAlgorithmName(), DOMInvalidAccessError,
         "Private key for derivation is using \"", getAlgorithmName(),

--- a/src/workerd/api/node/crypto_dh.c++
+++ b/src/workerd/api/node/crypto_dh.c++
@@ -72,8 +72,8 @@ CryptoImpl::DiffieHellmanHandle::DiffieHellmanHandle(kj::String& name) : verifyE
 
 bool CryptoImpl::DiffieHellmanHandle::InitGroup(kj::String& name) {
   auto group = FindDiffieHellmanGroup(name.begin());
-  JSG_REQUIRE(group != nullptr, Error, "Failed to init DiffieHellmanGroup: invalid group. At "
-              "this time, only group 'modp5' is supported.");
+  JSG_REQUIRE(group != nullptr, Error, "Failed to init DiffieHellmanGroup: invalid group. Only "
+              "groups {modp14, modp15, modp16, modp17, modp18} are supported.");
   auto groupKey = group(nullptr);
   KJ_ASSERT(groupKey != nullptr);
 


### PR DESCRIPTION
See getHashes() for the rationale for hardcoding getCiphers() and getCurves(). The second commit fixes several error messages, see the commit description.