### PR TITLE
Fix receiver argument in toUTCString in r2-bucket.c++

### DIFF
--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -54,7 +54,7 @@ static jsg::ByteString toUTCString(jsg::Lock& js, kj::Date date) {
       context, jsg::v8StrIntern(isolate, "toUTCString")));
   JSG_REQUIRE(stringify->IsFunction(), TypeError, "toUTCString on a Date is not a function");
   const auto stringified = jsg::check(stringify.template As<v8::Function>()->Call(
-      context, stringify, 0, nullptr));
+      context, converted, 0, nullptr));
   JSG_REQUIRE(stringified->IsString(), TypeError, "toUTCString on a Date did not return a string");
 
   const auto str = stringified.template As<v8::String>();


### PR DESCRIPTION
Changes the the invocation of the toUTCString JavaScript method so that the receiver is a Date.

Bug: https://github.com/cloudflare/workerd/issues/851
Bug: EW-7623