### PR TITLE
Add Queues message contentType to types

### DIFF
--- a/src/workerd/api/queue.h
+++ b/src/workerd/api/queue.h
@@ -37,7 +37,7 @@ public:
 
     JSG_STRUCT(contentType);
     JSG_STRUCT_TS_OVERRIDE(QueueSendOptions {
-      contentType: never;
+      contentType?: QueueContentType;
     });
     // NOTE: Any new fields added here should also be added to MessageSendRequest below.
   };
@@ -51,7 +51,7 @@ public:
     JSG_STRUCT(body, contentType);
     JSG_STRUCT_TS_OVERRIDE(MessageSendRequest<Body = unknown> {
       body: Body;
-      contentType: never;
+      contentType?: QueueContentType;
     });
     // NOTE: Any new fields added to SendOptions must also be added here.
   };
@@ -67,9 +67,10 @@ public:
 
     JSG_TS_ROOT();
     JSG_TS_OVERRIDE(Queue<Body> {
-      send(message: Body): Promise<void>;
+      send(message: Body, options?: QueueSendOptions): Promise<void>;
       sendBatch(messages: Iterable<MessageSendRequest<Body>>): Promise<void>;
     });
+    JSG_TS_DEFINE(type QueueContentType = "text" | "bytes" | "json" | "v8");
   }
 
 private:


### PR DESCRIPTION
Following on from #690, this PR changes the type definitions for the Queues message `.send()` and `.sendBatch()` functions to reflect the new `contentType` option. This was originally left out of the generated types so it could be tested before it was documented (see [here](https://github.com/cloudflare/workerd/pull/690#discussion_r1203024274))

(cc @jbwcloudflare)