### PR TITLE
Overhaul bazel disk cache management

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -106,6 +106,20 @@ build:windows --enable_runfiles
 # used by some KJ macros, and understands the `.c++` extension by default.
 build:windows --compiler=clang-cl
 
+# The Windows fastbuild bazel configuration is broken in that it necessarily generates PDB debug
+# information while the Linux and macOS toolchains only compile with debug information in the dbg
+# configuration or when requested with the -g flag. This causes huge increases in compile time and
+# disk/cache space usage – a single test may come with a 490MB PDB file.
+# In an optional configuration, use the opt configuration and manually disable optimizations as a
+# workaround.
+
+build:windows_no_dbg -c opt
+build:windows_no_dbg --copt='-O0' --host_copt='-O0'
+build:windows_no_dbg --copt='/Od' --host_copt='/Od'
+build:windows_no_dbg --copt='/INCREMENTAL:NO' --host_copt='/INCREMENTAL:NO'
+build:windows_no_dbg --noincompatible_use_host_features
+build:windows_no_dbg --features=-smaller_binary --features=-disable_assertions_feature
+
 build:windows --cxxopt='/std:c++20' --host_cxxopt='/std:c++20'
 build:windows --cxxopt='/await' --host_cxxopt='/await'
 build:windows --cxxopt='/wo4503' --host_cxxopt='/wo4503'

--- a/.github/workflows/npm-types.yml
+++ b/.github/workflows/npm-types.yml
@@ -27,7 +27,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/bazel-disk-cache
-          key: capnp-cache
+          key: capnp-cache-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
+          # Use cache from older version.
+          restore-keys: |
+            capnp-cache-${{ runner.os }}-
       - name: build capnp
         run: |
           bazel build --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev @capnp-cpp//src/capnp:capnp_tool
@@ -46,7 +49,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/bazel-disk-cache
-          key: ${{ runner.os }}-${{ runner.arch }}-bazel-disk-cache-types
+          # The types cache is significantly smaller than the whole cache (350MB as of writing), so
+          # we can probably afford for it to have its own cache key.
+          key: bazel-disk-cache-types-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
+          restore-keys: |
+            bazel-disk-cache-types-${{ runner.os }}-
+
       - name: install dependencies
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/npm-types.yml
+++ b/.github/workflows/npm-types.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: bazelbuild/setup-bazelisk@v2
       - name: Cache
         id: cache
         uses: actions/cache@v3
@@ -42,7 +41,6 @@ jobs:
     needs: version
     steps:
       - uses: actions/checkout@v3
-      - uses: bazelbuild/setup-bazelisk@v2
       - name: Cache
         id: cache
         uses: actions/cache@v3

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -27,7 +27,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/bazel-disk-cache
-          key: capnp-cache
+          key: capnp-cache-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
+          restore-keys: |
+            capnp-cache-${{ runner.os }}-
       - name: build capnp
         run: |
           bazel build --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev @capnp-cpp//src/capnp:capnp_tool

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: bazelbuild/setup-bazelisk@v2
       - name: Cache
         id: cache
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/bazel-disk-cache
-          key: capnp-cache
+          key: capnp-cache-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
+          restore-keys: |
+            capnp-cache-${{ runner.os }}-
       - name: build capnp
         run: |
           bazel build --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev @capnp-cpp//src/capnp:capnp_tool
@@ -48,8 +50,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/bazel-disk-cache
-          key: ${{ runner.os }}-${{ runner.arch }}-bazel-disk-cache
-
+          key: bazel-disk-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
+          restore-keys: |
+            bazel-disk-cache-${{ runner.os }}-${{ runner.arch }}-
       - name: Setup Linux
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: bazelbuild/setup-bazelisk@v2
       - name: Cache
         id: cache
         uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/bazel-disk-cache
-          key: ${{ runner.os }}-${{ runner.arch }}-bazel-disk-cache
+          key: bazel-disk-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
+          # Use an older cache key, if available.
+          restore-keys: |
+            bazel-disk-cache-${{ runner.os }}-${{ runner.arch }}-
       - name: Setup Linux
         if: runner.os == 'Linux'
         # Install dependencies, including clang via through LLVM APT repository. Note that this
@@ -54,13 +57,15 @@ jobs:
         run: |
             [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
       - name: Bazel build
+        # timestamps are no longer being added here, the GitHub logs include timestamps (Use
+        # 'Show timestamps' on the web interface)
         run: |
             bazelisk build --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --verbose_failures //...
       - name: Bazel tests
         run: |
-            bazelisk test --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --verbose_failures --show_timestamps --keep_going --test_output=errors //...
+            bazelisk test --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --verbose_failures --keep_going --test_output=errors //...
       - name: Report disk usage
-        if: success() || failure()
+        if: always()
         shell: bash
         run: |
             BAZEL_OUTPUT_BASE=$(bazel info --ui_event_filters=-WARNING output_base)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,12 @@ jobs:
             echo "build:linux --host_action_env=CC=/usr/lib/llvm-14/bin/clang --host_action_env=CXX=/usr/lib/llvm-14/bin/clang++" >> .bazelrc
       - name: Setup Windows
         if: runner.os == 'Windows'
+        # Set a custom output dir and disable generating debug information on Windows. By default,
+        # bazel generates huge amounts of debug information on Windows which slows down the build
+        # and takes up an excessive amount of cache space.
         run: |
             [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
+            [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'build:windows --config=windows_no_dbg')
       - name: Bazel build
         # timestamps are no longer being added here, the GitHub logs include timestamps (Use
         # 'Show timestamps' on the web interface)


### PR DESCRIPTION
We currently do not utilize the actions/cache-based CI bazel disk cache well: On recent Linux CI build runs, there was a disk cache hit for only 10 out of 5575 build actions. This is because we always use the same cache key when building for the same platform, which means that the actual cache entries being used are still the ones that were first added for the platform (or a  have been evictions based on the cache size limit). This means very old cached data is provided, which largely can't be used if the compile options or V8 version has changed.

This PR introduces a new cache key scheme based on https://github.com/actions/cache/blob/main/examples.md#---bazel that changes the cache key/updates the cache whenever the OS version, bazel version or major build options or dependencies as defined in .bazelrc and WORKSPACE change.

One concern I have is that our cached items approach the Cache action 10GB limit even after compression is applied, in which case keys will be evicted frequently. Fortunately, the restore-keys command should mitigate this somewhat.

Open to feedback on the naming scheme and the key components – It may take several attempts to get the cache setup right, but if it works as intended this will significantly improve disk cache utilization.

Background on actions/cache: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows

This now also includes some cleanup for the CI files, notably `bazelbuild/setup-bazelisk@v2` is no longer included as the runner images include bazelisk by default. Additionally, there is an optional configuration that disables generating debug information on Windows (on by default on fastbuild, which is not the case on Linux and Mac), which speeds up builds and results in a more acceptable cache output size.