### PR TITLE
Add generic type default to Queue TS definition

### DIFF
--- a/src/workerd/api/queue.h
+++ b/src/workerd/api/queue.h
@@ -66,7 +66,7 @@ public:
     JSG_METHOD(sendBatch);
 
     JSG_TS_ROOT();
-    JSG_TS_OVERRIDE(Queue<Body> {
+    JSG_TS_OVERRIDE(Queue<Body = unknown> {
       send(message: Body, options?: QueueSendOptions): Promise<void>;
       sendBatch(messages: Iterable<MessageSendRequest<Body>>): Promise<void>;
     });


### PR DESCRIPTION
This PR adds the generic type default of `unknown` to the TS definition for Queues. It looks like there used to be a default type of `any`, but this regressed earlier (see [here](https://github.com/cloudflare/workerd/pull/541#discussion_r1165777988)). I used `unknown` instead of `any` for consistency with the rest of the Queues generic types.

Without this, the Workers templates generated by `create-cloudflare` will have incorrect initial typing, since they type the Queue bindings as `Queue` without any type parameter (see [here](https://github.com/cloudflare/workers-sdk/blob/main/packages/create-cloudflare/templates/hello-world/ts/src/worker.ts#L25)). 

(cc @jbwcloudflare // @jasnell @mrbbot)