### PR TITLE
Switch workerd/util to idiomatic comment style

### DIFF
--- a/src/workerd/util/abortable.h
+++ b/src/workerd/util/abortable.h
@@ -42,16 +42,16 @@ private:
   RefcountedCanceler::Listener onCancel;
 };
 
+// An InputStream that can be disconnected in response to RefcountedCanceler.
+// This is similar to NeuterableInputStream in global-scope.c++ but uses an
+// external kj::Canceler to trigger the disconnect.
+// This is currently only used in fetch() requests that use an AbortSignal.
+// The AbortableInputStream is created using a RefcountedCanceler,
+// which will be triggered when the AbortSignal is triggered.
+// TODO(later): It would be good to see if both this and NeuterableInputStream
+// could be combined into a single utility.
 class AbortableInputStream final: public kj::AsyncInputStream,
                                   public kj::Refcounted {
-  // An InputStream that can be disconnected in response to RefcountedCanceler.
-  // This is similar to NeuterableInputStream in global-scope.c++ but uses an
-  // external kj::Canceler to trigger the disconnect.
-  // This is currently only used in fetch() requests that use an AbortSignal.
-  // The AbortableInputStream is created using a RefcountedCanceler,
-  // which will be triggered when the AbortSignal is triggered.
-  // TODO(later): It would be good to see if both this and NeuterableInputStream
-  // could be combined into a single utility.
 public:
   AbortableInputStream(kj::Own<kj::AsyncInputStream> inner, RefcountedCanceler& canceler)
       : impl(kj::mv(inner), canceler) {}
@@ -76,12 +76,12 @@ private:
   AbortableImpl<kj::AsyncInputStream> impl;
 };
 
+// A WebSocket wrapper that can be disconnected in response to a RefcountedCanceler.
+// This is currently only used when opening a WebSocket with a fetch() request that
+// is using an AbortSignal. The AbortableWebSocket is created using the AbortSignal's
+// RefcountedCanceler, which will be triggered when the AbortSignal is triggered.
 class AbortableWebSocket final: public kj::WebSocket,
                                 public kj::Refcounted {
-  // A WebSocket wrapper that can be disconnected in response to a RefcountedCanceler.
-  // This is currently only used when opening a WebSocket with a fetch() request that
-  // is using an AbortSignal. The AbortableWebSocket is created using the AbortSignal's
-  // RefcountedCanceler, which will be triggered when the AbortSignal is triggered.
 public:
   AbortableWebSocket(kj::Own<kj::WebSocket> inner, RefcountedCanceler& canceler)
       : impl(kj::mv(inner), canceler) {}

--- a/src/workerd/util/batch-queue.h
+++ b/src/workerd/util/batch-queue.h
@@ -12,38 +12,36 @@ namespace workerd {
 
 using kj::uint;
 
+// A double-buffered batch queue which enforces an upper bound on buffer growth.
+//
+// Objects of this type have two buffers -- the push buffer and the pop buffer -- and support
+// `push()` and `pop()` operations. `push()` adds elements to the push buffer. `pop()` swaps the
+// push and the pop buffers and returns a RAII object which provides a view onto the pop buffer.
+// When the RAII object is destroyed, it resets the size and capacity of the pop buffer.
+//
+// This class is useful when the cost of context switching between producers and consumers is
+// high and/or when you must be able to gracefully handle bursts of pushes, such as when
+// transferring objects between threads. Note that this class implements no cross-thread
+// synchronization itself, but it can become an effective multiple-producer, single-consumer queue
+// when wrapped as a `kj::MutexGuarded<BatchQueue<T>>`.
 template <typename T>
 class BatchQueue {
-  // A double-buffered batch queue which enforces an upper bound on buffer growth.
-  //
-  // Objects of this type have two buffers -- the push buffer and the pop buffer -- and support
-  // `push()` and `pop()` operations. `push()` adds elements to the push buffer. `pop()` swaps the
-  // push and the pop buffers and returns a RAII object which provides a view onto the pop buffer.
-  // When the RAII object is destroyed, it resets the size and capacity of the pop buffer.
-  //
-  // This class is useful when the cost of context switching between producers and consumers is
-  // high and/or when you must be able to gracefully handle bursts of pushes, such as when
-  // transferring objects between threads. Note that this class implements no cross-thread
-  // synchronization itself, but it can become an effective multiple-producer, single-consumer queue
-  // when wrapped as a `kj::MutexGuarded<BatchQueue<T>>`.
-
 public:
+  // `initialCapacity` is the number of elements of type T for which we should allocate space in the
+  // initial buffers, and any reconstructed buffers. Buffers will be reconstructed if they are
+  // observed to grow beyond `maxCapacity` after a completed pop operation.
   explicit BatchQueue(uint initialCapacity, uint maxCapacity)
       : pushBuffer(initialCapacity),
         popBuffer(initialCapacity),
         initialCapacity(initialCapacity),
         maxCapacity(maxCapacity) {}
-  // `initialCapacity` is the number of elements of type T for which we should allocate space in the
-  // initial buffers, and any reconstructed buffers. Buffers will be reconstructed if they are
-  // observed to grow beyond `maxCapacity` after a completed pop operation.
 
+  // This is the return type of `pop()` (in fact, `pop()` is the only way to construct a non-empty
+  // Batch). Default-constructible, moveable, and non-copyable.
+  //
+  // A Batch can be converted to an ArrayPtr<T>. When a Batch is destroyed, it clears the pop
+  // buffer and resets the pop buffer capacity to `initialCapacity` if necessary.
   class Batch {
-    // This is the return type of `pop()` (in fact, `pop()` is the only way to construct a non-empty
-    // Batch). Default-constructible, moveable, and non-copyable.
-    //
-    // A Batch can be converted to an ArrayPtr<T>. When a Batch is destroyed, it clears the pop
-    // buffer and resets the pop buffer capacity to `initialCapacity` if necessary.
-
   public:
     Batch() = default;
     Batch(Batch&&) = default;
@@ -67,18 +65,17 @@ public:
     // It's a Maybe so we can support move operations.
   };
 
+  // If a batch is available, swap the buffers and return a Batch object backed by the pop buffer.
+  // The caller should destroy the Batch object as soon as they are done with it. Destruction will
+  // clear the pop buffer and, if necessary, reconstruct it to stay under `maxCapacity`.
+  //
+  // Throws if `pop()` is called again before the previous Batch object was destroyed. Note
+  // that this exception is only reliable if the previous `pop()` returned a non-empty Batch.
+  //
+  // `pop()` accesses both buffers, so it must be synchronized with `push()` operations across
+  // threads. Batch objects and `push()` access different buffers, so they require no explicit
+  // cross-thread synchronization with each other.
   Batch pop() {
-    // If a batch is available, swap the buffers and return a Batch object backed by the pop buffer.
-    // The caller should destroy the Batch object as soon as they are done with it. Destruction will
-    // clear the pop buffer and, if necessary, reconstruct it to stay under `maxCapacity`.
-    //
-    // Throws if `pop()` is called again before the previous Batch object was destroyed. Note
-    // that this exception is only reliable if the previous `pop()` returned a non-empty Batch.
-    //
-    // `pop()` accesses both buffers, so it must be synchronized with `push()` operations across
-    // threads. Batch objects and `push()` access different buffers, so they require no explicit
-    // cross-thread synchronization with each other.
-
     KJ_REQUIRE(popBuffer.empty(), "pop()'s previous result not yet destroyed.");
 
     Batch batch;
@@ -91,16 +88,14 @@ public:
     return batch;
   }
 
+  // Add an item to the current batch.
   template <typename U>
   void push(U&& value) {
-    // Add an item to the current batch.
-
     pushBuffer.add(kj::fwd<U>(value));
   }
 
   auto empty() const { return pushBuffer.empty(); }
   auto size() const { return pushBuffer.size(); }
-  // Push buffer metadata.
 
 private:
   kj::Vector<T> pushBuffer;

--- a/src/workerd/util/canceler.h
+++ b/src/workerd/util/canceler.h
@@ -11,14 +11,14 @@
 
 namespace workerd {
 
+// A simple wrapper around kj::Canceler that can be safely
+// shared by multiple objects. This is used, for instance,
+// to support fetch() requests that use an AbortSignal.
+// The AbortSignal (see api/basics.h) creates an instance
+// of RefcountedCanceler then passes references to it out
+// to various other objects that will use it to wrap their
+// Promises.
 class RefcountedCanceler: public kj::Refcounted {
-  // A simple wrapper around kj::Canceler that can be safely
-  // shared by multiple objects. This is used, for instance,
-  // to support fetch() requests that use an AbortSignal.
-  // The AbortSignal (see api/basics.h) creates an instance
-  // of RefcountedCanceler then passes references to it out
-  // to various other objects that will use it to wrap their
-  // Promises.
 public:
   class Listener {
   public:

--- a/src/workerd/util/capnp-mock.h
+++ b/src/workerd/util/capnp-mock.h
@@ -102,11 +102,10 @@ public:
   }
 };
 
+// Infrastructure to mock a capability!
+//
+// TODO(cleanup): This should obviously go in Cap'n Proto!
 class MockServer: public kj::Refcounted {
-  // Infrastructure to mock a capability!
-  //
-  // TODO(cleanup): This should obviously go in Cap'n Proto!
-
   struct ReceivedCall;
 public:
   MockServer(capnp::InterfaceSchema schema): schema(schema) {}
@@ -156,36 +155,33 @@ public:
       return kj::mv(*this);
     }
 
+    // Helper for cases where the received call is expected to invoke some callback capability.
+    //
+    // Expect that the params contain a field named `callbackName` whose type is an interface.
+    // `func()` will be invoked and passed a `MockClient` representing this capability. It can
+    // then invoke the callback as it seems fit.
+    //
+    // Note that it's explicitly OK if `func` captures a `WaitScope` and uses it. In this way,
+    // the incoming call can be delayed from returning until the callback completes.
     template <typename Func>
     ExpectedCall useCallback(kj::StringPtr callbackName, Func&& func,
                              kj::SourceLocation location = {}) && KJ_WARN_UNUSED_RESULT {
-      // Helper for cases where the received call is expected to invoke some callback capability.
-      //
-      // Expect that the params contain a field named `callbackName` whose type is an interface.
-      // `func()` will be invoked and passed a `MockClient` representing this capability. It can
-      // then invoke the callback as it seems fit.
-      //
-      // Note that it's explicitly OK if `func` captures a `WaitScope` and uses it. In this way,
-      // the incoming call can be delayed from returning until the callback completes.
-
       auto& received = getReceived(location);
       func(received.context.getParams().get(callbackName).as<capnp::DynamicCapability>());
       return kj::mv(*this);
     }
 
+    // Causes the method to return the given result message, which is parsed from text.
     void thenReturn(kj::StringPtr message, kj::SourceLocation location = {}) && {
-      // Causes the method to return the given result message, which is parsed from text.
-
       auto& received = getReceived(location);
       TEXT_CODEC.decode(message, received.context.getResults());
       received.fulfiller.fulfill();
     }
 
+    // Causes the method to return the given result message, which is parsed from text.
+    // All capabilities in the result message will be filled in, with MockServer instances
+    // returned in the hashmap.
     kj::HashMap<kj::String, kj::Own<MockServer>> thenReturnWithMocks(kj::StringPtr message, kj::SourceLocation location = {}) && {
-      // Causes the method to return the given result message, which is parsed from text.
-      // All capabilities in the result message will be filled in, with MockServer instances
-      // returned in the hashmap.
-
       auto& received = getReceived(location);
       auto callResults = received.context.getResults();
       auto results = kj::HashMap<kj::String, kj::Own<MockServer>>();
@@ -203,18 +199,16 @@ public:
       return kj::mv(results);
     }
 
+    // Causes the method to throw an exception
     void thenThrow(kj::Exception&& e, kj::SourceLocation location = {}) && {
-      // Causes the method to throw an exception
-
       auto& received = getReceived(location);
       received.fulfiller.reject(kj::mv(e));
     }
 
+    // Return a new mock capability. The method result type is expected to contain a single
+    // field with the given name whose type is an interface type. It will be filled in with a
+    // new mock object, and the MockServer is returned in order to set further expectations.
     kj::Own<MockServer> returnMock(kj::StringPtr fieldName, kj::SourceLocation location = {}) && {
-      // Return a new mock capability. The method result type is expected to contain a single
-      // field with the given name whose type is an interface type. It will be filled in with a
-      // new mock object, and the MockServer is returned in order to set further expectations.
-
       auto& received = getReceived(location);
       auto field = received.method.getResultType().getFieldByName(fieldName);
       auto result = kj::refcounted<MockServer>(field.getType().asInterface());
@@ -348,10 +342,10 @@ private:
   };
 };
 
-#define CAPNP(...) ("(" #__VA_ARGS__ ")"_kj)
 // Wraps a "capnp struct literal". This actually just stringifies the arguments, adding enclosing
 // parentheses. The nice thing about it, though, is that you don't have to escape quotes inside
 // the literal.
+#define CAPNP(...) ("(" #__VA_ARGS__ ")"_kj)
 
 template<typename Schema, typename InitFunc>
 kj::String Capnp(InitFunc func) {

--- a/src/workerd/util/http-util.h
+++ b/src/workerd/util/http-util.h
@@ -8,11 +8,10 @@
 
 namespace workerd {
 
+// Attaches the given object to a `Request` so that it lives as long as the request's properties.
+// The given object must support `kj::addRef()` (e.g. `kj::Refcount`).
 template<typename T>
 kj::HttpClient::Request attachToRequest(kj::HttpClient::Request req, T&& rcAttachment) {
-  // Attaches the given object to a `Request` so that it lives as long as the request's properties.
-  // The given object must support `kj::addRef()` (e.g. `kj::Refcount`).
-
   req.body = req.body.attach(kj::addRef(*rcAttachment));
   req.response = req.response
       .then([rcAttachment = kj::mv(rcAttachment)](kj::HttpClient::Response&& response) mutable {
@@ -22,12 +21,11 @@ kj::HttpClient::Request attachToRequest(kj::HttpClient::Request req, T&& rcAttac
   return req;
 }
 
+// Attaches the given object to a `WebSocketResponse` promise so that it lives as long as the
+// returned response's properties.
 template<typename T>
 kj::Promise<kj::HttpClient::WebSocketResponse> attachToWebSocketResponse(
     kj::Promise<kj::HttpClient::WebSocketResponse> promise, T&& attachment) {
-  // Attaches the given object to a `WebSocketResponse` promise so that it lives as long as the
-  // returned response's properties.
-
   return promise.then([attachment = kj::mv(attachment)](
       kj::HttpClient::WebSocketResponse&& response) mutable {
     KJ_SWITCH_ONEOF(response.webSocketOrBody) {

--- a/src/workerd/util/mimetype.h
+++ b/src/workerd/util/mimetype.h
@@ -19,16 +19,16 @@ public:
     IGNORE_PARAMS,
   };
 
-  static kj::Maybe<MimeType> tryParse(kj::StringPtr input,
-                                      ParseOptions options = ParseOptions::DEFAULT);
   // Returning nullptr implies that the input is not a valid mime type construction.
   // If the ParseOptions::IGNORE_PARAMS option is set then the mime type parameters
   // will be ignored and will not be included in the parsed result.
+  static kj::Maybe<MimeType> tryParse(kj::StringPtr input,
+                                      ParseOptions options = ParseOptions::DEFAULT);
 
-  static MimeType parse(kj::StringPtr input,
-                        ParseOptions options = ParseOptions::DEFAULT);
   // Asserts if the input could not be parsed as a valid MimeType. tryParse should
   // be preferred for most cases.
+  static MimeType parse(kj::StringPtr input,
+                        ParseOptions options = ParseOptions::DEFAULT);
 
   explicit MimeType(kj::StringPtr type,
                     kj::StringPtr subtype,
@@ -48,25 +48,25 @@ public:
   bool addParam(kj::ArrayPtr<const char> name, kj::ArrayPtr<const char> value);
   void eraseParam(kj::StringPtr name);
 
-  kj::String essence() const;
   // Returns only the type/subtype
+  kj::String essence() const;
 
-  kj::String toString() const;
   // Returns the type/subtype and all params.
+  kj::String toString() const;
 
   kj::String paramsToString() const;
 
-  MimeType clone(ParseOptions options = ParseOptions::DEFAULT) const;
   // Copy this MimeType. If the IGNORE_PARAMS option is set the clone
   // will copy only the type and subtype and will omit all of the parameters.
+  MimeType clone(ParseOptions options = ParseOptions::DEFAULT) const;
 
+  // Compares only the essence of the MimeType (type and subtype). Ignores
+  // parameters in the comparison.
   bool operator==(const MimeType& other) const;
-  // Compares only the essence of the MimeType (type and subtype). Ignores
-  // parameters in the comparison.
 
-  bool operator!=(const MimeType& other) const;
   // Compares only the essence of the MimeType (type and subtype). Ignores
   // parameters in the comparison.
+  bool operator!=(const MimeType& other) const;
 
   operator kj::String() const;
 

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -20,9 +20,8 @@
 namespace workerd {
 namespace {
 
+// Initialize the database with some data.
 void setupSql(SqliteDatabase& db) {
-  // Initialize the database with some data.
-
   // TODO(sqlite): Do this automatically and don't permit it via run().
   db.run("PRAGMA journal_mode=WAL;");
 
@@ -44,10 +43,9 @@ void setupSql(SqliteDatabase& db) {
   }
 }
 
+// Do some read-only queries on `db` to check that it's in the state that `setupSql()` ought to
+// have left it in.
 void checkSql(SqliteDatabase& db) {
-  // Do some read-only queries on `db` to check that it's in the state that `setupSql()` ought to
-  // have left it in.
-
   {
     auto query = db.run("SELECT * FROM people ORDER BY name");
 
@@ -204,11 +202,10 @@ KJ_TEST("SQLite backed by real disk") {
   }
 }
 
+// Tests that concurrent database clients don't clobber each other. This verifies that the
+// LockManager interface is able to protect concurrent access and that our default implementation
+// works.
 void doLockTest(bool walMode) {
-  // Tests that concurrent database clients don't clobber each other. This verifies that the
-  // LockManager interface is able to protect concurrent access and that our default implementation
-  // works.
-
   auto dir = kj::newInMemoryDirectory(kj::nullClock());
   SqliteDatabase::Vfs vfs(*dir);
 

--- a/src/workerd/util/symbolizer.c++
+++ b/src/workerd/util/symbolizer.c++
@@ -23,11 +23,10 @@ namespace kj {
 
 namespace {
 
+// A simple subprocess wrapper with in/out pipes.
 struct Subprocess {
-  // A simple subprocess wrapper with in/out pipes.
-
+  // Execute command with a shell.
   static kj::Maybe<Subprocess> exec(const char* argv[]) noexcept {
-    // Execute command with a shell.
     // Since this is used during error handling we do not to try to free resources in
     // case of errors.
 

--- a/src/workerd/util/thread-scopes.c++
+++ b/src/workerd/util/thread-scopes.c++
@@ -18,10 +18,10 @@ thread_local uint isolateShutdownThreadScopeCount = 0;
 bool multiTenantProcess = false;
 bool predictableMode = false;
 
-thread_local ThreadProgressCounter* activeProgressCounter = nullptr;
 // This variable is read in signal handlers, so use atomic stores and compiler barriers as
 // needed in regular code. Atomic loads are unnecessary, because we're not synchronizing with
 // other threads.
+thread_local ThreadProgressCounter* activeProgressCounter = nullptr;
 
 }  // namespace
 

--- a/src/workerd/util/uuid.h
+++ b/src/workerd/util/uuid.h
@@ -9,9 +9,9 @@
 
 namespace workerd {
 
-kj::String randomUUID(kj::Maybe<kj::EntropySource&> optionalEntropySource);
 // Generates a random version 4 UUID using the given entropy source or a default
 // secure random number generator. Unless you pass in a predictable entropy
 // source, it is safe to assume that the output of this function is unique.
+kj::String randomUUID(kj::Maybe<kj::EntropySource&> optionalEntropySource);
 
 }

--- a/src/workerd/util/wait-list.c++
+++ b/src/workerd/util/wait-list.c++
@@ -8,9 +8,9 @@
 namespace workerd {
 
 namespace {
-thread_local CrossThreadWaitList::WaiterMap threadLocalWaiters;
 // Optimization: If the same wait list is waited multiple times in the same thread, we want to
 // share the signal rather than send two cross-thread signals.
+thread_local CrossThreadWaitList::WaiterMap threadLocalWaiters;
 
 void END_WAIT_LIST_CANCELER_STACK_START_CANCELEE_STACK() {}
 }  // namespace


### PR DESCRIPTION
Wanted to get a sense of how difficult and time consuming it would be to manually convert the comment style to the more idiomatic comments-before-declarations style. Turns out it's rather quick and generally painless. This batch took about 30 minutes with several interruptions. Most of it is purely mechanical. In a few cases it's obvious that a tool would be difficult since some comments are obviously impl details that do, for instance, belong inside a function body, while others are clearly meant to describe the declaration. Some judgement is required to pick those out case by case but it seems to be rather painless overall.