### PR TITLE
[SQLite] Add `.columnNames` property on Cursor

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -536,7 +536,9 @@ async function test(storage) {
     assert.deepEqual(rawResults[3], [4,5,6,1,2,3])
 
     // Once an iterator is consumed, it can no longer access the columnNames.
-    assert.deepEqual(iterator.columnNames, [])
+    requireException(() => {
+      iterator.columnNames
+    }, "Error: Cannot call .getColumnNames after Cursor iterator has been consumed.")
 
     // Also works with cursors returned from .exec
     const execIterator = sql.exec(`SELECT * FROM abc, cde`)

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -128,7 +128,7 @@ kj::Array<jsg::V8Ref<v8::String>> SqlStorage::Cursor::getColumnNames(jsg::Lock& 
       return name.addRef(js);
     };
   } else {
-    kj::throwFatalException(JSG_KJ_EXCEPTION(FAILED, Error, "Cannot call .getColumnNames after Cursor iterator has been consumed."));
+    JSG_FAIL_REQUIRE(Error, "Cannot call .getColumnNames after Cursor iterator has been consumed.");
   }
 }
 

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -118,6 +118,9 @@ jsg::Ref<SqlStorage::Cursor::RawIterator> SqlStorage::Cursor::raw(jsg::Lock&) {
   return jsg::alloc<RawIterator>(JSG_THIS);
 }
 
+// Returns the set of column names for the current Cursor. An exception will be thrown if the
+// iterator has already been fully consumed. The resulting columns may contain duplicate entries,
+// for instance a `SELECT *` across a join of two tables that share a column name.
 kj::Array<jsg::V8Ref<v8::String>> SqlStorage::Cursor::getColumnNames(jsg::Lock& js) {
   KJ_IF_MAYBE(s, state) {
     cachedColumnNames.ensureInitialized(js, (*s)->query);
@@ -125,7 +128,7 @@ kj::Array<jsg::V8Ref<v8::String>> SqlStorage::Cursor::getColumnNames(jsg::Lock& 
       return name.addRef(js);
     };
   } else {
-    return kj::Array<jsg::V8Ref<v8::String>>();
+    kj::throwFatalException(JSG_KJ_EXCEPTION(FAILED, Error, "Cannot call .getColumnNames after Cursor iterator has been consumed."));
   }
 }
 

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -118,6 +118,17 @@ jsg::Ref<SqlStorage::Cursor::RawIterator> SqlStorage::Cursor::raw(jsg::Lock&) {
   return jsg::alloc<RawIterator>(JSG_THIS);
 }
 
+kj::Array<jsg::V8Ref<v8::String>> SqlStorage::Cursor::getColumnNames(jsg::Lock& js) {
+  KJ_IF_MAYBE(s, state) {
+    cachedColumnNames.ensureInitialized(js, (*s)->query);
+    return KJ_MAP(name, this->cachedColumnNames.get()) {
+      return name.addRef(js);
+    };
+  } else {
+    return kj::Array<jsg::V8Ref<v8::String>>();
+  }
+}
+
 kj::Maybe<kj::Array<SqlStorage::Cursor::Value>> SqlStorage::Cursor::rawIteratorNext(
     jsg::Lock& js, jsg::Ref<Cursor>& obj) {
   return iteratorImpl(js, obj,

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -97,10 +97,13 @@ public:
         cachedColumnNames(cachedColumnNames) {}
   ~Cursor() noexcept(false);
 
+  kj::Array<jsg::V8Ref<v8::String>> getColumnNames(jsg::Lock& js);
   JSG_RESOURCE_TYPE(Cursor, CompatibilityFlags::Reader flags) {
     JSG_ITERABLE(rows);
     JSG_METHOD(raw);
+    JSG_READONLY_PROTOTYPE_PROPERTY(columnNames, getColumnNames);
   }
+
 
   using Value = kj::Maybe<kj::OneOf<kj::Array<byte>, kj::StringPtr, double>>;
   // One value returned from SQL. Note that we intentionally return StringPtr instead of String


### PR DESCRIPTION
(Replaces #696 as I renamed the remote branch name and the other PR got closed)

This PR adds a `.columnNames` property that can be called on a Cursor before iterating over the result:

```js
// Given the following data:
sql.exec(`CREATE TABLE abc (a INT, b INT, c INT);`)
sql.exec(`CREATE TABLE cde (c INT, d INT, e INT);`)
sql.exec(`INSERT INTO abc VALUES (1,2,3),(4,5,6);`)
sql.exec(`INSERT INTO cde VALUES (7,8,9),(1,2,3);`)

const iterator = sql.prepare(`SELECT * FROM abc, cde`)();
console.log(iterator.columnNames)
// ["a","b","c","c","d","e"]
console.log(Array.from(iterator.raw()))
// [
//   [1, 2, 3, 7, 8, 9],
//   [1, 2, 3, 1, 2, 3],
//   [4, 5, 6, 7, 8, 9],
//   [4, 5, 6, 1, 2, 3],
// ]
```

This helps us get around the issue where the default iterator swallows data when column names collide:

```js
const iterator = sql.prepare(`SELECT * FROM abc, cde`)();
console.log(Array.from(iterator))
// [
//   { a: 1, b: 2, c: 7, d: 8, e: 9 },
//   { a: 1, b: 2, c: 1, d: 2, e: 3 },
//   { a: 4, b: 5, c: 7, d: 8, e: 9 },
//   { a: 4, b: 5, c: 1, d: 2, e: 3 },
// ]
```

As a separate PR, we could make the default iterator error if duplicate columns are detected, but I want to move D1 entirely over to using `.all()` internally first.