### PR TITLE
Allow pumpTo() from unlocked, disturbed readable streams

### DIFF
--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -472,7 +472,6 @@ kj::Promise<DeferredProxy<void>> ReadableStream::pumpTo(
     bool end) {
   JSG_REQUIRE(IoContext::hasCurrent(), Error,
       "Unable to consume this ReadableStream outside of a request");
-  JSG_REQUIRE(!isDisturbed(), TypeError, "The ReadableStream has already been read.");
   JSG_REQUIRE(!isLocked(), TypeError, "The ReadableStream has been locked to a reader.");
   return getController().pumpTo(js, kj::mv(sink), end);
 }

--- a/src/workerd/api/streams/streams-test.js
+++ b/src/workerd/api/streams/streams-test.js
@@ -1,0 +1,28 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import {
+  notStrictEqual,
+  strictEqual,
+} from 'node:assert';
+
+export const partiallyReadStream= {
+  async test(ctrl, env, ctx) {
+    const enc = new TextEncoder();
+    const rs = new ReadableStream({
+      type: 'bytes',
+      start(controller) {
+        controller.enqueue(enc.encode('hello'));
+        controller.enqueue(enc.encode('world'));
+        controller.close();
+      }
+    });
+    const reader = rs.getReader({ mode: 'byob' });
+    await reader.read(new Uint8Array(5));
+    reader.releaseLock();
+
+    // Should not throw!
+    await env.KV.put("key", rs);
+  }
+};

--- a/src/workerd/api/streams/streams-test.wd-test
+++ b/src/workerd/api/streams/streams-test.wd-test
@@ -1,0 +1,31 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "streams-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "streams-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat"],
+        bindings = [ ( name = "KV", kvNamespace = "kv" ) ],
+      )
+    ),
+    ( name = "kv",
+      worker = (
+        modules = [
+          (name = "kv", esModule =
+            `export default {
+            `  async fetch(request, env, ctx) {
+            `    return new Response(await request.arrayBuffer());
+            `  }
+            `}
+          )
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat"]
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
Fixes: https://github.com/cloudflare/workerd/issues/892