### PR TITLE
Fix linux-arm64 build release process

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -3,11 +3,11 @@ FROM node:bullseye AS builder
 WORKDIR /workerd
 
 RUN apt-get update
-RUN apt-get install -y libunwind-14 libc++abi1-14 libc++1-14 libc++-14-dev curl build-essential git lsb-release wget software-properties-common gnupg
+RUN apt-get install -y curl build-essential git lsb-release wget software-properties-common gnupg
 
 RUN wget https://apt.llvm.org/llvm.sh
 RUN chmod +x llvm.sh
-RUN ./llvm.sh 14
+RUN ./llvm.sh 14 all
 COPY . .
 
 RUN echo "build:linux --action_env=CC=/usr/lib/llvm-14/bin/clang --action_env=CXX=/usr/lib/llvm-14/bin/clang++" >> .bazelrc

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -339,6 +339,7 @@ load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 
 python_register_toolchains(
     name = "python3_11",
+    ignore_root_user_error = True,
     # https://github.com/bazelbuild/rules_python/blob/main/python/versions.bzl
     python_version = "3.11",
 )


### PR DESCRIPTION
The version of the `rules_python` package seems to have been updated recently which introduced a new error when the builder was being run as `root`. Since we're running this builder in a container, we can use the [`ignore_root_user_error`](https://github.com/bazelbuild/rules_python/blob/23354a9b607ff0207e9a3c0cbe16724ec53997c1/tests/ignore_root_user_error/README.md) option.

There were also some issues installing the C++ toolchain and dependencies, so we're now deferring to the LLVM installation script to install these using the `all` argument.