### PR TITLE
Revert "fix v8 deprecation warning (#909)"

### DIFF
--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -237,7 +237,7 @@ void HeapTracer::ResetRoot(const v8::TracedReference<v8::Value>& handle) {
   // returned false earlier. It may still be reachable via C++, but we can recreate the wrapper
   // as needed if the C++ object is exported to JavaScript again later.
   auto& wrappable = *reinterpret_cast<Wrappable*>(
-      handle.As<v8::Object>().Get(isolate)->GetAlignedPointerFromInternalField(
+      handle.As<v8::Object>()->GetAlignedPointerFromInternalField(
           Wrappable::WRAPPED_OBJECT_FIELD_INDEX));
 
   // V8 gets angry if we do not EXPLICITLY call `Reset()` on the wrapper. If we merely destroy it


### PR DESCRIPTION
This reverts commit ad65da8e4d7a1bbf5b800de35d13cc5a7eef73f0.

For some reason I have not yet determined, this change appears to be persistently breaking a couple of internal tests. Let's back it out for now while we investigate further.