### PR TITLE
Downgrade proc-macro-hack to 0.5.19

### DIFF
--- a/rust-deps/crates/BUILD.phf-0.8.0.bazel
+++ b/rust-deps/crates/BUILD.phf-0.8.0.bazel
@@ -39,7 +39,7 @@ rust_library(
     edition = "2018",
     proc_macro_deps = [
         "@crates_vendor__phf_macros-0.8.0//:phf_macros",
-        "@crates_vendor__proc-macro-hack-0.5.20-deprecated//:proc_macro_hack",
+        "@crates_vendor__proc-macro-hack-0.5.19//:proc_macro_hack",
     ],
     rustc_flags = ["--cap-lints=allow"],
     tags = [

--- a/rust-deps/crates/BUILD.phf_macros-0.8.0.bazel
+++ b/rust-deps/crates/BUILD.phf_macros-0.8.0.bazel
@@ -31,7 +31,7 @@ rust_proc_macro(
     crate_root = "src/lib.rs",
     edition = "2018",
     proc_macro_deps = [
-        "@crates_vendor__proc-macro-hack-0.5.20-deprecated//:proc_macro_hack",
+        "@crates_vendor__proc-macro-hack-0.5.19//:proc_macro_hack",
     ],
     rustc_flags = ["--cap-lints=allow"],
     tags = [

--- a/rust-deps/crates/BUILD.proc-macro-hack-0.5.19.bazel
+++ b/rust-deps/crates/BUILD.proc-macro-hack-0.5.19.bazel
@@ -39,9 +39,9 @@ rust_proc_macro(
         "noclippy",
         "norustfmt",
     ],
-    version = "0.5.20+deprecated",
+    version = "0.5.19",
     deps = [
-        "@crates_vendor__proc-macro-hack-0.5.20-deprecated//:build_script_build",
+        "@crates_vendor__proc-macro-hack-0.5.19//:build_script_build",
     ],
 )
 
@@ -72,7 +72,7 @@ cargo_build_script(
         "noclippy",
         "norustfmt",
     ],
-    version = "0.5.20+deprecated",
+    version = "0.5.19",
     visibility = ["//visibility:private"],
 )
 

--- a/rust-deps/crates/defs.bzl
+++ b/rust-deps/crates/defs.bzl
@@ -809,12 +809,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__proc-macro-hack-0.5.20-deprecated",
-        sha256 = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068",
+        name = "crates_vendor__proc-macro-hack-0.5.19",
+        sha256 = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/proc-macro-hack/0.5.20+deprecated/download"],
-        strip_prefix = "proc-macro-hack-0.5.20+deprecated",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.proc-macro-hack-0.5.20+deprecated.bazel"),
+        urls = ["https://crates.io/api/v1/crates/proc-macro-hack/0.5.19/download"],
+        strip_prefix = "proc-macro-hack-0.5.19",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.proc-macro-hack-0.5.19.bazel"),
     )
 
     maybe(


### PR DESCRIPTION
This should serve as a temporary fix for the rules_rust-related Windows compile issues. It likely works solely based on the shorter name which causes MSVC input file paths to be within the limit. A better solution is needed, but this should be enough to unblock us.