### PR TITLE
Use jsg::Lock passing variant of jsg::Promise::then

### DIFF
--- a/src/workerd/api/cache.c++
+++ b/src/workerd/api/cache.c++
@@ -480,9 +480,9 @@ jsg::Promise<bool> Cache::delete_(
     auto nativeRequest = httpClient->request(
         kj::HttpMethod::PURGE, validateUrl(jsRequest->getUrl()), requestHeaders, uint64_t(0));
 
-    return context.awaitIo(kj::mv(nativeRequest.response),
+    return context.awaitIo(js, kj::mv(nativeRequest.response),
         [httpClient = kj::mv(httpClient)]
-        (kj::HttpClient::Response&& response) -> bool {
+        (jsg::Lock&, kj::HttpClient::Response&& response) -> bool {
       if (response.statusCode == 200) {
         return true;
       } else if (response.statusCode == 404) {

--- a/src/workerd/api/crypto-impl-aes-test.c++
+++ b/src/workerd/api/crypto-impl-aes-test.c++
@@ -137,14 +137,14 @@ KJ_TEST("AES-CTR key wrap") {
       kj::heapArray(unwrappedKeyMaterial.asPtr()),
       kj::mv(importAlgorithm),
       true, kj::arr(kj::str("decrypt")))
-          .then([&] (jsg::Ref<CryptoKey> toWrap) {
+          .then(js, [&] (jsg::Lock&, jsg::Ref<CryptoKey> toWrap) {
     SubtleCrypto::EncryptAlgorithm enc;
     enc.name = kj::str("AES-CTR");
     enc.counter = kj::arr<uint8_t>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
     enc.length = 5;
     return subtle.wrapKey(isolateLock, kj::str("raw"), *toWrap, *wrappingKey,
                           kj::mv(enc), *jwkHandler);
-  }).then([&] (kj::Array<kj::byte> wrapped) {
+  }).then(js, [&] (jsg::Lock&, kj::Array<kj::byte> wrapped) {
     SubtleCrypto::EncryptAlgorithm enc;
     enc.name = kj::str("AES-CTR");
     enc.counter = kj::arr<uint8_t>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
@@ -159,7 +159,7 @@ KJ_TEST("AES-CTR key wrap") {
                      kj::arr(kj::str("encrypt")), *jwkHandler);
   }).then(js, [&] (jsg::Lock& js, jsg::Ref<CryptoKey> unwrapped) {
     return subtle.exportKey(js, kj::str("raw"), *unwrapped);
-  }).then([&] (api::SubtleCrypto::ExportKeyData roundTrippedKeyMaterial) {
+  }).then(js, [&] (jsg::Lock&, api::SubtleCrypto::ExportKeyData roundTrippedKeyMaterial) {
     KJ_ASSERT(roundTrippedKeyMaterial.get<kj::Array<kj::byte>>() == unwrappedKeyMaterial);
     completed = true;
   });

--- a/src/workerd/api/crypto.c++
+++ b/src/workerd/api/crypto.c++
@@ -767,11 +767,11 @@ DigestStream::DigestStream(
         kj::heap<DigestStreamSink>(kj::mv(algorithm), kj::mv(fulfiller))),
       promise(kj::mv(promise)) {}
 
-jsg::Ref<DigestStream> DigestStream::constructor(Algorithm algorithm) {
+jsg::Ref<DigestStream> DigestStream::constructor(jsg::Lock& js, Algorithm algorithm) {
   auto paf = kj::newPromiseAndFulfiller<kj::Array<kj::byte>>();
 
   auto jsPromise = IoContext::current().awaitIoLegacy(kj::mv(paf.promise));
-  jsPromise.markAsHandled();
+  jsPromise.markAsHandled(js);
 
   return jsg::alloc<DigestStream>(
       interpretAlgorithmParam(kj::mv(algorithm)),

--- a/src/workerd/api/crypto.h
+++ b/src/workerd/api/crypto.h
@@ -614,7 +614,7 @@ public:
       kj::Own<kj::PromiseFulfiller<kj::Array<kj::byte>>> fulfiller,
       jsg::Promise<kj::Array<kj::byte>> promise);
 
-  static jsg::Ref<DigestStream> constructor(Algorithm algorithm);
+  static jsg::Ref<DigestStream> constructor(jsg::Lock& js, Algorithm algorithm);
 
   jsg::MemoizedIdentity<jsg::Promise<kj::Array<kj::byte>>>& getDigest() { return promise; }
 

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -324,7 +324,7 @@ kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::request(
     };
     auto canceled = kj::refcounted<RefcountedBool>(false);
 
-    return ioContext.awaitJs(promise->then(kj::implicitCast<jsg::Lock&>(lock),
+    return ioContext.awaitJs(lock ,promise->then(kj::implicitCast<jsg::Lock&>(lock),
         ioContext.addFunctor(
             [&response, allowWebSocket = headers.isWebSocket(),
              canceled = kj::addRef(*canceled), &headers]

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1444,7 +1444,7 @@ void FetchEvent::respondWith(jsg::Lock& js, jsg::Promise<jsg::Ref<Response>> pro
     auto& context = IoContext::current();
 
     KJ_IF_MAYBE(p, context.waitForOutputLocksIfNecessary()) {
-      return context.awaitIo(kj::mv(*p), [response = kj::mv(response)]() mutable {
+      return context.awaitIo(js, kj::mv(*p), [response = kj::mv(response)](jsg::Lock&) mutable {
         return kj::mv(response);
       });
     } else {

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -205,17 +205,17 @@ jsg::Promise<KvNamespace::GetWithMetadataResult> KvNamespace::getWithMetadata(
       // NOTE: In theory we should be using awaitIoLegacy() here since ReadableStreamSource is
       //   supposed to handle pending events on its own, but we also know that the HTTP client
       //   backing a KV namepsace is never implemented in local JavaScript, so whatever.
-      result = context.awaitIo(
+      result = context.awaitIo(js,
           stream->readAllText(context.getLimitEnforcer().getBufferingLimit())
               .attach(kj::mv(stream)),
-          [](kj::String text) {
+          [](jsg::Lock&, kj::String text) {
         return KvNamespace::GetResult(kj::mv(text));
       });
     } else if (typeName == "arrayBuffer") {
-      result = context.awaitIo(
+      result = context.awaitIo(js,
           stream->readAllBytes(context.getLimitEnforcer().getBufferingLimit())
               .attach(kj::mv(stream)),
-          [](kj::Array<byte> text) {
+          [](jsg::Lock&, kj::Array<byte> text) {
         return KvNamespace::GetResult(kj::mv(text));
       });
     } else if (typeName == "json") {

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -118,7 +118,7 @@ jsg::Promise<KvNamespace::GetResult> KvNamespace::get(
     CompatibilityFlags::Reader flags) {
   return js.evalNow([&] {
     auto resp = getWithMetadata(js, kj::mv(name), kj::mv(options));
-    return resp.then([](KvNamespace::GetWithMetadataResult result) {
+    return resp.then(js, [](jsg::Lock&, KvNamespace::GetWithMetadataResult result) {
       return kj::mv(result.value);
     });
   });

--- a/src/workerd/api/r2-admin.c++
+++ b/src/workerd/api/r2-admin.c++
@@ -37,9 +37,9 @@ jsg::Promise<jsg::Ref<R2Bucket>> R2Admin::create(jsg::Lock& js, kj::String name,
   auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr,
                                     kj::mv(requestJson), nullptr, jwt);
 
-  return context.awaitIo(kj::mv(promise),
+  return context.awaitIo(js, kj::mv(promise),
       [this, subrequestChannel = subrequestChannel, name = kj::mv(name), &errorType]
-      (R2Result r2Result) mutable {
+      (jsg::Lock&, R2Result r2Result) mutable {
     r2Result.throwIfError("createBucket", errorType);
     return jsg::alloc<R2Bucket>(featureFlags, subrequestChannel, kj::mv(name),
         R2Bucket::friend_tag_t{});
@@ -128,7 +128,7 @@ jsg::Promise<void> R2Admin::delete_(jsg::Lock& js, kj::String name,
   auto promise = doR2HTTPPutRequest(js, kj::mv(client), nullptr, nullptr,
                                     kj::mv(requestJson), nullptr, jwt);
 
-  return context.awaitIo(kj::mv(promise), [&errorType](R2Result r2Result) mutable {
+  return context.awaitIo(js, kj::mv(promise), [&errorType](jsg::Lock&, R2Result r2Result) mutable {
     r2Result.throwIfError("deleteBucket", errorType);
   });
 }

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -336,7 +336,7 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::head(
     auto promise = doR2HTTPGetRequest(kj::mv(client), kj::mv(requestJson), path, jwt,
         flags);
 
-    return context.awaitIo(kj::mv(promise), [&errorType](R2Result r2Result) {
+    return context.awaitIo(js, kj::mv(promise), [&errorType](jsg::Lock&, R2Result r2Result) {
       return parseObjectMetadata<HeadResult>("head", r2Result, errorType);
     });
   });
@@ -373,7 +373,8 @@ R2Bucket::get(jsg::Lock& js, kj::String name, jsg::Optional<GetOptions> options,
     auto promise = doR2HTTPGetRequest(kj::mv(client), kj::mv(requestJson), path, jwt,
         flags);
 
-    return context.awaitIo(kj::mv(promise), [&context, &errorType](R2Result r2Result)
+    return context.awaitIo(js, kj::mv(promise),
+        [&context, &errorType](jsg::Lock&, R2Result r2Result)
         -> kj::OneOf<kj::Maybe<jsg::Ref<GetResult>>, jsg::Ref<HeadResult>> {
       kj::OneOf<kj::Maybe<jsg::Ref<GetResult>>, jsg::Ref<HeadResult>> result;
 
@@ -805,9 +806,9 @@ jsg::Promise<R2Bucket::ListResult> R2Bucket::list(
     auto promise = doR2HTTPGetRequest(kj::mv(client), kj::mv(requestJson), path, jwt,
         flags);
 
-    return context.awaitIo(kj::mv(promise),
+    return context.awaitIo(js, kj::mv(promise),
         [expectedOptionalFields = expectedOptionalFields.releaseAsArray(), &errorType]
-        (R2Result r2Result) {
+        (jsg::Lock&, R2Result r2Result) {
       r2Result.throwIfError("list", errorType);
 
       R2Bucket::ListResult result;

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -277,7 +277,7 @@ jsg::Ref<Socket> Socket::startTls(jsg::Lock& js, jsg::Optional<TlsOptions> tlsOp
   //
   // Detach the AsyncIoStream from the Writable/Readable streams and make them unusable.
   auto& context = IoContext::current();
-  auto secureStreamPromise = context.awaitJs(writable->flush(js).then(js,
+  auto secureStreamPromise = context.awaitJs(js, writable->flush(js).then(js,
       [this, domain = kj::heapString(domain), tlsOptions = kj::mv(tlsOptions),
       tlsStarter = kj::mv(tlsStarter)](jsg::Lock& js) mutable {
     writable->removeSink(js);

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -116,7 +116,7 @@ jsg::Ref<Socket> setupSocket(
   });
 
   auto closedPrPair = js.newPromiseAndResolver<void>();
-  closedPrPair.promise.markAsHandled();
+  closedPrPair.promise.markAsHandled(js);
 
   ioContext.awaitIo(js, kj::mv(disconnectedPaf.promise),
       [resolver = closedPrPair.resolver.addRef(js)](jsg::Lock& js, bool canceled) mutable {
@@ -322,11 +322,11 @@ void Socket::handleProxyStatus(
       auto exc = kj::Exception(kj::Exception::Type::FAILED, __FILE__, __LINE__,
         kj::str(JSG_EXCEPTION(Error), msg));
       resolveFulfiller(js, exc);
-      readable->getController().cancel(js, nullptr).markAsHandled();
-      writable->getController().abort(js, nullptr).markAsHandled();
+      readable->getController().cancel(js, nullptr).markAsHandled(js);
+      writable->getController().abort(js, nullptr).markAsHandled(js);
     }
   });
-  result.markAsHandled();
+  result.markAsHandled(js);
 }
 
 void Socket::handleReadableEof(jsg::Lock& js, jsg::Promise<void> onEof) {
@@ -335,7 +335,7 @@ void Socket::handleReadableEof(jsg::Lock& js, jsg::Promise<void> onEof) {
   onEof.then(js,
       JSG_VISITABLE_LAMBDA((ref=JSG_THIS), (ref), (jsg::Lock& js) {
     return ref->maybeCloseWriteSide(js);
-  })).markAsHandled();
+  })).markAsHandled(js);
 }
 
 jsg::Promise<void> Socket::maybeCloseWriteSide(jsg::Lock& js) {

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -584,8 +584,8 @@ public:
 
     void fail(v8::Local<v8::Value> reason);
 
-    inline jsg::Promise<void> whenResolved() {
-      return promise.whenResolved();
+    inline jsg::Promise<void> whenResolved(jsg::Lock& js) {
+      return promise.whenResolved(js);
     }
 
     inline jsg::Promise<void> whenResolved(auto&& func) {

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -797,7 +797,7 @@ jsg::Promise<T> rejectedMaybeHandledPromise(
     bool handled) {
   auto prp = js.newPromiseAndResolver<T>();
   if (handled) {
-    prp.promise.markAsHandled();
+    prp.promise.markAsHandled(js);
   }
   prp.resolver.reject(reason);
   return kj::mv(prp.promise);

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -914,7 +914,7 @@ jsg::Promise<void> WritableStreamInternalController::doAbort(
     }
 
     maybePendingAbort = PendingAbort(js, reason, options.reject);
-    auto promise = KJ_ASSERT_NONNULL(maybePendingAbort).whenResolved();
+    auto promise = KJ_ASSERT_NONNULL(maybePendingAbort).whenResolved(js);
     if (options.handled) {
       promise.markAsHandled(js);
     }

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -896,7 +896,7 @@ jsg::Promise<void> WritableStreamInternalController::doAbort(
   // instead of trying to schedule another.
   KJ_IF_MAYBE(pendingAbort, maybePendingAbort) {
     pendingAbort->reject = options.reject;
-    auto promise = pendingAbort->whenResolved();
+    auto promise = pendingAbort->whenResolved(js);
     if (options.handled) {
       promise.markAsHandled(js);
     }
@@ -1179,8 +1179,7 @@ void WritableStreamInternalController::doError(jsg::Lock& js, v8::Local<v8::Valu
 void WritableStreamInternalController::ensureWriting(jsg::Lock& js) {
   auto& ioContext = IoContext::current();
   if (queue.size() == 1) {
-    ioContext.addTask(ioContext.awaitJs(
-        writeLoop(js, ioContext)).attach(addRef()));
+    ioContext.addTask(ioContext.awaitJs(js, writeLoop(js, ioContext)).attach(addRef()));
   }
 }
 
@@ -1428,7 +1427,7 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
       };
 
       KJ_IF_MAYBE(promise, request.source.tryPumpTo(*writable, !request.preventClose)) {
-        return handlePromise(js, ioContext.awaitIo(
+        return handlePromise(js, ioContext.awaitIo(js,
             AbortSignal::maybeCancelWrap(request.maybeSignal, kj::mv(*promise))));
       }
 
@@ -1444,7 +1443,7 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
       auto& writable = state.get<Writable>();
       auto check = makeChecker(request);
 
-      return ioContext.awaitIo(writable->end()).then(js,
+      return ioContext.awaitIo(js, writable->end()).then(js,
           ioContext.addFunctor([this, check](jsg::Lock& js) {
         auto& request = check();
         maybeResolvePromise(request.promise);
@@ -1521,8 +1520,11 @@ jsg::Promise<void> WritableStreamInternalController::Pipe::write(v8::Local<v8::V
     byteOffset = view->ByteOffset();
   }
   kj::byte* data = reinterpret_cast<kj::byte*>(store->Data()) + byteOffset;
-  return IoContext::current().awaitIo(
-      writable->write(data, byteLength).attach(kj::mv(store)), []{});
+  // TODO(cleanup): Have this method accept a jsg::Lock& from the caller instead of using
+  // v8::Isolate::GetCurrent();
+  jsg::Lock& js = jsg::Lock::from(v8::Isolate::GetCurrent());
+  return IoContext::current().awaitIo(js,
+      writable->write(data, byteLength).attach(kj::mv(store)), [](jsg::Lock&){});
 }
 
 jsg::Promise<void> WritableStreamInternalController::Pipe::pipeLoop(jsg::Lock& js) {
@@ -1581,7 +1583,7 @@ jsg::Promise<void> WritableStreamInternalController::Pipe::pipeLoop(jsg::Lock& j
       if (!parent.isClosedOrClosing()) {
         // We'll only be here if the sink is in the Writable state.
         auto& ioContext = IoContext::current();
-        return ioContext.awaitIo(parent.state.get<Writable>()->end(), []{}).then(js,
+        return ioContext.awaitIo(js, parent.state.get<Writable>()->end(), [](jsg::Lock&){}).then(js,
             ioContext.addFunctor([this](jsg::Lock& js) { parent.finishClose(js); }),
             ioContext.addFunctor([this](jsg::Lock& js, jsg::Value reason) {
               parent.finishError(js, reason.getHandle(js));

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -641,7 +641,7 @@ bool ReadableStreamInternalController::lockReader(jsg::Lock& js, Reader& reader)
   }
 
   auto prp = js.newPromiseAndResolver<void>();
-  prp.promise.markAsHandled();
+  prp.promise.markAsHandled(js);
 
   auto lock = ReaderLocked(reader, kj::mv(prp.resolver),
       IoContext::current().addObject(kj::heap<kj::Canceler>()));
@@ -796,7 +796,7 @@ void WritableStreamInternalController::updateBackpressure(jsg::Lock& js, bool ba
       // ready promise on the writer with a new pending promise, regardless of whether
       // the existing one is resolved or not.
       auto prp = js.newPromiseAndResolver<void>();
-      prp.promise.markAsHandled();
+      prp.promise.markAsHandled(js);
       writerLock->setReadyFulfiller(prp);
       return;
     }
@@ -830,7 +830,7 @@ jsg::Promise<void> WritableStreamInternalController::close(
     KJ_CASE_ONEOF(writable, Writable) {
       auto prp = js.newPromiseAndResolver<void>();
       if (markAsHandled) {
-        prp.promise.markAsHandled();
+        prp.promise.markAsHandled(js);
       }
       queue.push_back(WriteEvent {
         .outputLock = IoContext::current().waitForOutputLocksIfNecessaryIoOwn(),
@@ -864,7 +864,7 @@ jsg::Promise<void> WritableStreamInternalController::flush(
     KJ_CASE_ONEOF(writable, Writable) {
       auto prp = js.newPromiseAndResolver<void>();
       if (markAsHandled) {
-        prp.promise.markAsHandled();
+        prp.promise.markAsHandled(js);
       }
       queue.push_back(WriteEvent {
         .outputLock = IoContext::current().waitForOutputLocksIfNecessaryIoOwn(),
@@ -898,7 +898,7 @@ jsg::Promise<void> WritableStreamInternalController::doAbort(
     pendingAbort->reject = options.reject;
     auto promise = pendingAbort->whenResolved();
     if (options.handled) {
-      promise.markAsHandled();
+      promise.markAsHandled(js);
     }
     return kj::mv(promise);
   }
@@ -916,7 +916,7 @@ jsg::Promise<void> WritableStreamInternalController::doAbort(
     maybePendingAbort = PendingAbort(js, reason, options.reject);
     auto promise = KJ_ASSERT_NONNULL(maybePendingAbort).whenResolved();
     if (options.handled) {
-      promise.markAsHandled();
+      promise.markAsHandled(js);
     }
     return kj::mv(promise);
   }
@@ -1031,7 +1031,7 @@ kj::Maybe<jsg::Promise<void>> WritableStreamInternalController::tryPipeFrom(
   // pending Pipe event we queue below.
   auto prp = js.newPromiseAndResolver<void>();
   if (pipeThrough) {
-    prp.promise.markAsHandled();
+    prp.promise.markAsHandled(js);
   }
   queue.push_back(WriteEvent {
     .outputLock = IoContext::current().waitForOutputLocksIfNecessaryIoOwn(),
@@ -1096,10 +1096,10 @@ bool WritableStreamInternalController::lockWriter(jsg::Lock& js, Writer& writer)
   }
 
   auto closedPrp = js.newPromiseAndResolver<void>();
-  closedPrp.promise.markAsHandled();
+  closedPrp.promise.markAsHandled(js);
 
   auto readyPrp = js.newPromiseAndResolver<void>();
-  readyPrp.promise.markAsHandled();
+  readyPrp.promise.markAsHandled(js);
 
   auto lock = WriterLocked(writer, kj::mv(closedPrp.resolver), kj::mv(readyPrp.resolver));
 

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -392,7 +392,7 @@ jsg::Ref<ReadableStream> ReadableStream::pipeThrough(
     return js.resolvedPromise();
   }), JSG_VISITABLE_LAMBDA((self = JSG_THIS), (self), (jsg::Lock& js, auto&& exception) {
     return js.rejectedPromise<void>(kj::mv(exception));
-  })).markAsHandled();
+  })).markAsHandled(js);
   return kj::mv(transform.readable);
 }
 

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -1081,7 +1081,7 @@ jsg::Promise<void> WritableImpl<Self>::abort(
   KJ_IF_MAYBE(pendingAbort, maybePendingAbort) {
     // Notice here that, per the spec, the reason given in this call of abort is
     // intentionally ignored if there is already an abort pending.
-    return pendingAbort->whenResolved();
+    return pendingAbort->whenResolved(js);
   }
 
   bool wasAlreadyErroring = false;
@@ -2869,7 +2869,7 @@ public:
         // that the PumpToReader, and the sink it owns, are always accessed from the right
         // IoContext. Thw WeakRef ensures that if the PumpToReader is freed while
         // the JS continuation is pending, there won't be a dangling reference.
-        return ioContext.awaitJs(
+        return ioContext.awaitJs(js,
             pumpLoop(js, ioContext, kj::mv(readable), ioContext.addObject(addWeakRef())));
       }
       KJ_CASE_ONEOF(pumping, Pumping) {
@@ -3357,7 +3357,7 @@ jsg::Promise<void> WritableStreamJsController::abort(
   // promise each time. That's a bit cumbersome here with jsg::Promise so we intentionally just
   // return a continuation branch off the same promise.
   KJ_IF_MAYBE(abortPromise, maybeAbortPromise) {
-    return abortPromise->whenResolved();
+    return abortPromise->whenResolved(js);
   }
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -184,7 +184,7 @@ bool ReadableLockImpl<Controller>::lockReader(
   }
 
   auto prp = js.newPromiseAndResolver<void>();
-  prp.promise.markAsHandled();
+  prp.promise.markAsHandled(js);
 
   auto lock = ReaderLocked(reader, kj::mv(prp.resolver));
 
@@ -317,9 +317,9 @@ bool WritableLockImpl<Controller>::lockWriter(jsg::Lock& js, Controller& self, W
   }
 
   auto closedPrp = js.newPromiseAndResolver<void>();
-  closedPrp.promise.markAsHandled();
+  closedPrp.promise.markAsHandled(js);
   auto readyPrp = js.newPromiseAndResolver<void>();
-  readyPrp.promise.markAsHandled();
+  readyPrp.promise.markAsHandled(js);
 
   auto lock = WriterLocked(writer, kj::mv(closedPrp.resolver), kj::mv(readyPrp.resolver));
 
@@ -3486,7 +3486,7 @@ void WritableStreamJsController::maybeRejectReadyPromise(
       maybeRejectPromise<void>(writerLock->getReadyFulfiller(), reason);
     } else {
       auto prp = js.newPromiseAndResolver<void>();
-      prp.promise.markAsHandled();
+      prp.promise.markAsHandled(js);
       prp.resolver.reject(reason);
       writerLock->setReadyFulfiller(prp);
     }
@@ -3609,7 +3609,7 @@ jsg::Promise<void> WritableStreamJsController::pipeLoop(jsg::Lock& js) {
     if (!preventClose) {
       auto promise = close(js);
       if (pipeThrough) {
-        promise.markAsHandled();
+        promise.markAsHandled(js);
       }
       return kj::mv(promise);
     }
@@ -3690,7 +3690,7 @@ void WritableStreamJsController::updateBackpressure(jsg::Lock& js, bool backpres
       // ready promise on the writer with a new pending promise, regardless of whether
       // the existing one is resolved or not.
       auto prp = js.newPromiseAndResolver<void>();
-      prp.promise.markAsHandled();
+      prp.promise.markAsHandled(js);
       return writerLock->setReadyFulfiller(prp);
     }
 
@@ -3887,7 +3887,7 @@ void TransformStreamDefaultController::setBackpressure(jsg::Lock& js, bool newBa
     prp->resolver.resolve();
   }
   maybeBackpressureChange = js.newPromiseAndResolver<void>();
-  KJ_ASSERT_NONNULL(maybeBackpressureChange).promise.markAsHandled();
+  KJ_ASSERT_NONNULL(maybeBackpressureChange).promise.markAsHandled(js);
   backpressure = newBackpressure;
 }
 

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -630,11 +630,11 @@ public:
             jsg::Ref<WritableStream>& writable,
             jsg::Optional<Transformer> maybeTransformer);
 
-  inline jsg::Promise<void> getStartPromise() {
+  inline jsg::Promise<void> getStartPromise(jsg::Lock& js) {
     // The startPromise is used by both the readable and writable sides in their respective
     // start algorithms. The promise itself is resolved within the init function when the
     // transformers own start algorithm completes.
-    return startPromise.promise.whenResolved();
+    return startPromise.promise.whenResolved(js);
   }
 
   kj::Maybe<int> getDesiredSize();

--- a/src/workerd/api/streams/transform.c++
+++ b/src/workerd/api/streams/transform.c++
@@ -52,7 +52,7 @@ jsg::Ref<TransformStream> TransformStream::constructor(
                   (controller = controller.addRef()),
                   (controller),
                   (jsg::Lock& js, auto c) mutable {
-            return controller->getStartPromise();
+            return controller->getStartPromise(js);
           })),
           .pull = maybeAddFunctor<UnderlyingSource::PullAlgorithm>(JSG_VISITABLE_LAMBDA(
                   (controller = controller.addRef()),
@@ -77,7 +77,7 @@ jsg::Ref<TransformStream> TransformStream::constructor(
                   (controller = controller.addRef()),
                   (controller),
                   (jsg::Lock& js, auto c) mutable {
-            return controller->getStartPromise();
+            return controller->getStartPromise(js);
           })),
           .write = maybeAddFunctor<UnderlyingSink::WriteAlgorithm>(JSG_VISITABLE_LAMBDA(
                   (controller = controller.addRef()),

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -459,7 +459,7 @@ void WebSocket::startReadLoop(jsg::Lock& js) {
   //   accepted locally is implemented completely in JavaScript space, using jsg::Promise instead
   //   of kj::Promise, and then only use awaitIo() on truely remote WebSockets.
   // TODO(cleanup): Should addWaitUntil() take jsg::Promise instead of kj::Promise?
-  context.addWaitUntil(context.awaitJs(context.awaitIoLegacy(kj::mv(promise))
+  context.addWaitUntil(context.awaitJs(js, context.awaitIoLegacy(kj::mv(promise))
       .then(js, [this, thisHandle = JSG_THIS]
                 (jsg::Lock& js, kj::Maybe<kj::Exception>&& maybeError) mutable {
     auto& native = *farNative;

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1362,7 +1362,7 @@ jsg::Promise<kj::Maybe<IoOwn<kj::AsyncInputStream>>> IoContext::makeCachePutStre
 
   KJ_DEFER(cachePutQuota = kj::mv(paf.promise));
 
-  return awaitIo(cachePutQuota.then(
+  return awaitIo(js, cachePutQuota.then(
       [fulfiller = kj::mv(paf.fulfiller), stream = kj::mv(stream)](size_t quota) mutable
           -> kj::Maybe<kj::Own<kj::AsyncInputStream>> {
     if (quota == 0) {
@@ -1394,7 +1394,7 @@ jsg::Promise<kj::Maybe<IoOwn<kj::AsyncInputStream>>> IoContext::makeCachePutStre
       // will refuse to allow the initiation of any further PUT requests.
       return kj::heap<CacheQuotaInputStream>(kj::mv(stream), quota, kj::mv(fulfiller));
     }
-  }), [this](kj::Maybe<kj::Own<kj::AsyncInputStream>> result) {
+  }), [this](jsg::Lock&, kj::Maybe<kj::Own<kj::AsyncInputStream>> result) {
     return kj::mv(result).map(
         [&](kj::Own<kj::AsyncInputStream>&& obj) { return addObject(kj::mv(obj)); });
   });

--- a/src/workerd/io/promise-wrapper.h
+++ b/src/workerd/io/promise-wrapper.h
@@ -40,7 +40,8 @@ public:
     auto& wrapper = static_cast<Self&>(*this);
     auto jsPromise = KJ_UNWRAP_OR_RETURN(wrapper.tryUnwrap(
         context, handle, (jsg::Promise<T>*)nullptr, parentObject), nullptr);
-    return IoContext::current().awaitJs(kj::mv(jsPromise));
+    auto& js = jsg::Lock::from(context->GetIsolate());
+    return IoContext::current().awaitJs(js, kj::mv(jsPromise));
   }
 
   template <typename T>

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -476,7 +476,7 @@ kj::Promise<bool> WorkerEntrypoint::test() {
       (Worker::Lock& lock) mutable -> kj::Promise<void> {
     jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
 
-    return context.awaitJs(lock.getGlobalScope()
+    return context.awaitJs(lock, lock.getGlobalScope()
         .test(lock, lock.getExportedHandler(entrypointName, context.getActor())));
   }));
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -854,7 +854,7 @@ struct Worker::Script::Impl {
         auto& ioContext = IoContext::current();
         auto& worker = ioContext.getWorker();
 
-        return ioContext.awaitIo(
+        return ioContext.awaitIo(js,
             kj::evalLater([&worker, handler = kj::mv(handler),
                            asyncContext = jsg::AsyncContextFrame::currentRef(js)]() mutable {
           return worker.takeAsyncLockWithoutRequest(nullptr)
@@ -894,7 +894,7 @@ struct Worker::Script::Impl {
             }
             return { .value = jsg::Value(isolate, tryCatch.Exception()), .isException = true };
           });
-        }).attach(kj::atomicAddRef(worker)), [isolate=js.v8Isolate](auto result) {
+        }).attach(kj::atomicAddRef(worker)), [isolate=js.v8Isolate](jsg::Lock&, auto result) {
           if (result.isException) {
             return jsg::rejectedPromise<jsg::Value>(isolate, kj::mv(result.value));
           }

--- a/src/workerd/jsg/iterator.h
+++ b/src/workerd/jsg/iterator.h
@@ -842,7 +842,7 @@ private:
         };
 
         KJ_IF_MAYBE(current, inner.impl.maybeCurrent()) {
-          auto promise = current->whenResolved().then(js, kj::mv(callNext));
+          auto promise = current->whenResolved(js).then(js, kj::mv(callNext));
           pushCurrent(js, promise.whenResolved(js));
           return kj::mv(promise);
         }
@@ -898,7 +898,7 @@ private:
         // If there is something on the pending stack, we are going to wait for that promise
         // to resolve then call callReturn.
         KJ_IF_MAYBE(current, inner.impl.maybeCurrent()) {
-          return current->whenResolved().then(js, kj::mv(callReturn));
+          return current->whenResolved(js).then(js, kj::mv(callReturn));
         }
 
         // Otherwise, we call callReturn immediately.

--- a/src/workerd/jsg/iterator.h
+++ b/src/workerd/jsg/iterator.h
@@ -790,7 +790,7 @@ private:
 
   void pushCurrent(jsg::Lock& js, jsg::Promise<void> promise) {
     auto& inner = state.template get<InnerState>();
-    inner.impl.pushCurrent(promise.whenResolved().then(js,
+    inner.impl.pushCurrent(promise.whenResolved(js).then(js,
         [this, self = JSG_THIS](jsg::Lock& js) {
       // If state is Finished, then there's nothing we need to do here.
       KJ_IF_MAYBE(inner, state.template tryGet<InnerState>()) {
@@ -826,7 +826,7 @@ private:
             }
             KJ_CASE_ONEOF(inner, InnerState) {
               auto promise = nextFunc(js, inner.state);
-              pushCurrent(js, promise.whenResolved());
+              pushCurrent(js, promise.whenResolved(js));
               return promise.then(js,
                   [this, self = kj::mv(self)](Lock& js, kj::Maybe<Type> maybeResult) mutable {
                 KJ_IF_MAYBE(result, maybeResult) {
@@ -843,7 +843,7 @@ private:
 
         KJ_IF_MAYBE(current, inner.impl.maybeCurrent()) {
           auto promise = current->whenResolved().then(js, kj::mv(callNext));
-          pushCurrent(js, promise.whenResolved());
+          pushCurrent(js, promise.whenResolved(js));
           return kj::mv(promise);
         }
 

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -413,27 +413,37 @@ public:
   // TODO(clenaup): Update all call sites to the version that passes locks. Then, remove these and
   //   also remove the `isolate` parameter from this class.
 
-  void markAsHandled() { markAsHandled(Lock::from(deprecatedIsolate)); }
+
+  void markAsHandled() KJ_DEPRECATED("Use variant that takes Lock as the first param") {
+    markAsHandled(Lock::from(deprecatedIsolate));
+  }
+
   template <typename Func, typename ErrorFunc>
-  auto then(Func&& func, ErrorFunc&& errorFunc) {
+  auto then(Func&& func, ErrorFunc&& errorFunc)
+      KJ_DEPRECATED("Use variant that takes Lock as the first param") {
     return then<false>(Lock::from(deprecatedIsolate),
         kj::fwd<Func>(func), kj::fwd<ErrorFunc>(errorFunc));
   }
   template <typename Func>
-  auto then(Func&& func) {
+  auto then(Func&& func)
+      KJ_DEPRECATED("Use variant that takes Lock as the first param") {
     return then<false>(Lock::from(deprecatedIsolate), kj::fwd<Func>(func));
   }
   template <typename ErrorFunc>
-  auto catch_(ErrorFunc&& errorFunc) {
+  auto catch_(ErrorFunc&& errorFunc)
+      KJ_DEPRECATED("Use variant that takes Lock as the first param") {
     return catch_<false>(Lock::from(deprecatedIsolate), kj::fwd<ErrorFunc>(errorFunc));
   }
-  Promise<void> whenResolved() {
+  Promise<void> whenResolved()
+      KJ_DEPRECATED("Use variant that takes Lock as the first param") {
     return whenResolved(Lock::from(deprecatedIsolate));
   }
-  v8::Local<v8::Promise> consumeHandle(v8::Isolate* isolate) {
+  v8::Local<v8::Promise> consumeHandle(v8::Isolate* isolate)
+      KJ_DEPRECATED("Use variant that takes Lock as the first param") {
     return consumeHandle(Lock::from(isolate));
   }
-  kj::Maybe<T> tryConsumeResolved() {
+  kj::Maybe<T> tryConsumeResolved()
+      KJ_DEPRECATED("Use variant that takes Lock as the first param") {
     return tryConsumeResolved(Lock::from(deprecatedIsolate));
   }
 

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -208,7 +208,7 @@ void promiseContinuation(const v8::FunctionCallbackInfo<v8::Value>& args) {
       // special handling of promises, where it tries to catch exceptions and merge them into the
       // promise. We don't need to do this, because this is being called as a .then() which already
       // catches exceptions and does the right thing.
-      return v8::Local<v8::Value>(callFunc().consumeHandle(isolate));
+      return v8::Local<v8::Value>(callFunc().consumeHandle(Lock::from(isolate)));
     } else if constexpr (isV8Ref<Output>()) {
       return callFunc().getHandle(isolate);
     } else {
@@ -360,7 +360,7 @@ public:
       // Resolve to another Promise.
       auto isolate = js.v8Isolate;
       check(v8Resolver.getHandle(isolate)->Resolve(
-          js.v8Context(), promise.consumeHandle(isolate)));
+          js.v8Context(), promise.consumeHandle(js)));
     }
 
     void reject(Lock& js, v8::Local<v8::Value> exception) {
@@ -428,18 +428,6 @@ public:
   auto catch_(ErrorFunc&& errorFunc)
       KJ_DEPRECATED("Use variant that takes Lock as the first param") {
     return catch_<false>(Lock::from(deprecatedIsolate), kj::fwd<ErrorFunc>(errorFunc));
-  }
-  Promise<void> whenResolved()
-      KJ_DEPRECATED("Use variant that takes Lock as the first param") {
-    return whenResolved(Lock::from(deprecatedIsolate));
-  }
-  v8::Local<v8::Promise> consumeHandle(v8::Isolate* isolate)
-      KJ_DEPRECATED("Use variant that takes Lock as the first param") {
-    return consumeHandle(Lock::from(isolate));
-  }
-  kj::Maybe<T> tryConsumeResolved()
-      KJ_DEPRECATED("Use variant that takes Lock as the first param") {
-    return tryConsumeResolved(Lock::from(deprecatedIsolate));
   }
 
 private:

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -299,7 +299,7 @@ public:
     // returned by whenResolved().
     auto promise = Promise<void>(js.v8Isolate, getInner(js));
     if (markedAsHandled) {
-      promise.markAsHandled();
+      promise.markAsHandled(js);
     }
     return kj::mv(promise);
   }
@@ -412,11 +412,6 @@ public:
   //   require a lock. These versions also do not pass a `Lock` to the callback.
   // TODO(clenaup): Update all call sites to the version that passes locks. Then, remove these and
   //   also remove the `isolate` parameter from this class.
-
-
-  void markAsHandled() KJ_DEPRECATED("Use variant that takes Lock as the first param") {
-    markAsHandled(Lock::from(deprecatedIsolate));
-  }
 
   template <typename Func, typename ErrorFunc>
   auto then(Func&& func, ErrorFunc&& errorFunc)

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -668,7 +668,8 @@ public:
     auto then = check(v8::Function::New(context,
         &thenWrap<TypeWrapper, T>, creator.orDefault({}), 1, v8::ConstructorBehavior::kThrow));
 
-    auto ret = check(promise.consumeHandle(context->GetIsolate())->Then(context, then));
+    auto& js = jsg::Lock::from(context->GetIsolate());
+    auto ret = check(promise.consumeHandle(js)->Then(context, then));
     // Although we added a .then() to the promise to translate the value to JavaScript, we would
     // like things to behave as if the C++ code returned this Promise directly to JavaScript. In
     // particular, if the C++ code marked the Promise handled, then the derived JavaScript promise


### PR DESCRIPTION
Fairly large but largely non-functional change. Addresses a long standing todo for consistently passing js::Lock& references where needed and moves us away from deprecated methods.