### PR TITLE
Ensure proper socket error handling when write controller abort fails

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -257,7 +257,7 @@ jsg::Promise<void> Socket::close(jsg::Lock& js) {
     return abortPromise.then(js, [this](jsg::Lock& js) {
       resolveFulfiller(js, nullptr);
       return js.resolvedPromise();
-    });
+    }, [this](jsg::Lock& js, jsg::Value err) { return errorHandler(js, kj::mv(err)); });
   }, [this](jsg::Lock& js, jsg::Value err) { return errorHandler(js, kj::mv(err)); });
 }
 


### PR DESCRIPTION
The way this was previously written, the errorHandler would correctly run if the readable contoller's cancel promise rejects, but not if the writable controller's abort promise rejects. This fixes that, since it does appear possible for the abort promise to reject, for example in WritableStreamDefaultWriter::abort.

Unless for some off chance we don't want `errorHandler` to be called if the readable contoller's cancel promise succeeds? If that's the case, I'm happy to close this.

---

I noticed this when looking into some `The script will never generate a response.` issues when running in edge preview on the new internal type I'm working on, although I doubt this is actually the cause -- I’m more suspicious about whether I need to add something similar to the `handleProxyStatus` method for that type after setting up the socket.