### PR TITLE
Bazel linker improvements and cleanup

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -48,8 +48,10 @@ build --@capnp-cpp//src/kj:deprecate_empty_maybe_from_nullptr=False
 # rust-level LTO is not enabled, LLVM bitcode is not needed so -C embed-bitcode=n provides a free
 # improvement to build speed and rust-deps code size.
 build --@rules_rust//:extra_rustc_flags=-C,panic=abort,-C,debug-assertions=n,-C,embed-bitcode=n
+build --@rules_rust//:extra_exec_rustc_flags=-C,panic=abort,-C,debug-assertions=n,-C,embed-bitcode=n
 
 build:fastdbg --@rules_rust//:extra_rustc_flags=-C,panic=unwind,-C,debug-assertions=y,-C,debuginfo=1,-C,embed-bitcode=n
+build:fastdbg --@rules_rust//:extra_exec_rustc_flags=-C,panic=unwind,-C,debug-assertions=y,-C,debuginfo=1,-C,embed-bitcode=n
 
 # TODO(later): -C codegen-units=1 improves code size and quality, should be enabled in a future
 # release configuration even if lto is off. Similarly, adding -C lto=thin would improve binary size
@@ -118,6 +120,13 @@ build:linux --action_env=BAZEL_LINKLIBS='-l%:libc++.a -lm -static-libgcc'
 # https://github.com/bazelbuild/bazel/issues/12439#issuecomment-914449079
 build:linux --force_pic
 
+# TODO(later): rustc's -C,codegen-units=1 and ld/lld's -Wl,-O2 on Linux/possibly Windows should
+# bring an additional binary size improvement. These should only be enabled in opt mode which won't
+# be possible in bazelrc without establishing a release configuration, but it can be done using the
+# extra_rustc_flags parameter in rust_register_toolchains() and by modifying linkopts in kj_test()
+# and wd_cc_binary() similar to how the use_dead_strip flag is used. The binary size improvement is
+# modest (~ 300kb), but if we encounter size concerns again this would be a good place to start.
+
 #
 # Windows
 #
@@ -151,12 +160,15 @@ build:windows_no_dbg --features=-smaller_binary --features=-disable_assertions_f
 
 build:windows --cxxopt='/std:c++20' --host_cxxopt='/std:c++20'
 build:windows --cxxopt='/await' --host_cxxopt='/await'
-build:windows --cxxopt='/wo4503' --host_cxxopt='/wo4503'
-build:windows --cxxopt='/DWINDOWS_LEAN_AND_MEAN' --host_cxxopt='/DWINDOWS_LEAN_AND_MEAN'
-build:windows --cxxopt='/D_CRT_USE_BUILTIN_OFFSETOF' --host_cxxopt='/D_CRT_USE_BUILTIN_OFFSETOF'
-# The `/std:c++14` argument is unused during boringssl compilation and we don't
+build:windows --copt='/D_CRT_USE_BUILTIN_OFFSETOF' --host_copt='/D_CRT_USE_BUILTIN_OFFSETOF'
+build:windows --copt='/DWINDOWS_LEAN_AND_MEAN' --host_copt='/DWINDOWS_LEAN_AND_MEAN'
+# The `/std:c++20` argument is unused during boringssl compilation and we don't
 # want a warning when compiling each file.
-build:windows --cxxopt='-Wno-unused-command-line-argument' --host_cxxopt='-Wno-unused-command-line-argument'
+build:windows --copt='-Wno-unused-command-line-argument' --host_copt='-Wno-unused-command-line-argument'
+
+# MSVC disappointingly sets __cplusplus to 199711L by default. Defining /Zc:__cplusplus makes it
+# set the correct value. We currently don't check __cplusplus, but some dependencies do.
+build:windows --cxxopt='/Zc:__cplusplus' --host_cxxopt='/Zc:__cplusplus'
 
 # The following are required on github runners temporarily due to
 # https://github.com/actions/runner-images/issues/8125

--- a/build/kj_test.bzl
+++ b/build/kj_test.bzl
@@ -14,7 +14,7 @@ def kj_test(
             "//conditions:default": ["@workerd//src/workerd/util:symbolizer"],
         }) + deps,
         linkopts = select({
-          "@//:use_dead_strip": ["-Wl,-dead_strip"],
+          "@//:use_dead_strip": ["-Wl,-dead_strip", "-Wl,-no_exported_symbols"],
           "//conditions:default": [""],
         }),
     )

--- a/build/wd_cc_binary.bzl
+++ b/build/wd_cc_binary.bzl
@@ -9,8 +9,19 @@ def wd_cc_binary(
     """
     native.cc_binary(
         name = name,
+        # -dead_strip is the macOS equivalent of -ffunction-sections, -Wl,--gc-sections.
+        # -no_exported_symbols is used to not include the exports trie, which significantly reduces
+        # binary sizes. Unfortunately, the flag and the exports trie are poorly documented. Based
+        # on analyzing the binary sections with and without the flag, the information being removed
+        # consists of weak binding info, export binding info and stub bindings as described in
+        # http://www.newosxbook.com/articles/DYLD.html. The flag itself is described in
+        # https://www.wwdcnotes.com/notes/wwdc22/110362/.
+        # The affected sections appear to not be needed for debugging and are only used when
+        # external code needs to look up bindings in a binary, e.g. when loading a plugin
+        # (mac-specific feature). In particular, the symbol table is not affected (the name of the
+        # flag is misleading here).
         linkopts = linkopts + select({
-          "@//:use_dead_strip": ["-Wl,-dead_strip"],
+          "@//:use_dead_strip": ["-Wl,-dead_strip", "-Wl,-no_exported_symbols"],
           "//conditions:default": [""],
         }),
         visibility = visibility,

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -32,6 +32,14 @@ wd_cc_binary(
     name = "api_encoder_bin",
     srcs = [api_encoder_src],
     deps = [":api_encoder_lib"],
+    # Use dynamic linkage where possible to reduce binary size – unlike the workerd binary, we
+    # shouldn't need to distribute the api encoder.
+    linkstatic = 0,
+    # The dependent targets are not Windows-compatible, no need to compile this.
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 # All compatibility dates that changed public facing types.
@@ -133,12 +141,11 @@ rust_binary(
     ],
 )
 
-# Deliberately not marking this run_binary_target(): The exec configuration appears to use
-# different optimization settings, causing it to run markedly faster than the target configuration,
-# where param_extractor would otherwise take several minutes to run. The rules_rust documentation
-# does not indicate any reason why exec would use different settings. A different approach would be
-# to set `rustc_flags	= ["-C", "opt-level=3"],` for param_extractor_bin, although in this case
-# the binary dependencies shared with the rust-deps target would still need to be compiled twice.
+# Deliberately not marking this run_binary_target(): The exec configuration compiles with
+# optimization by default, causing it to run markedly faster than the (non-opt) target
+# configuration, where param_extractor would otherwise take several minutes to run. A different
+# approach would be to set `rustc_flags = ["-C", "opt-level=3"],` here, although in this case any
+# dependencies shared with the rust-deps target would still need to be compiled twice.
 run_binary(
     name = "param_extractor",
     srcs = [


### PR DESCRIPTION
This PR got significantly bigger than expected over time – please let me know if you find it difficult to review or have additional questions.

Changes:
- Set rust flags in the host configuration (used for e.g. rust build scripts, running param_extractor, but not for the actual workerd binary). This should save some time and make the bazel output directory smaller.
- Add a TODO message about flags that could disk space improvements. Expected savings are relatively small (~300K), so this is not worth prioritizing.
- Windows: Remove warning 4503, this is no longer being used since MSVC 2017. https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4503?view=msvc-170
- Enable the MSVC flags `/DWINDOWS_LEAN_AND_MEAN` and `-Wno-unused-command-line-argument` on C code, not just C++. This reduces the number of warnings for the Windows build and may speed up compilation.
- MSVC disappointingly sets `__cplusplus` to `199711L` by default to ensure compatibility with ancient systems. Defining `/Zc:__cplusplus` makes it set the correct value. We currently don't check __cplusplus, but some dependencies do.
- Add `-Wl,-no_exported_symbols` mac linker flag. This flag is poorly documented, see comments for an explanation. Using fastbuild the workerd binary shrinks from 232MB to 184MB, the opt binary is a few megabytes smaller too. Based on my understanding of the flag I am confident that this won't negatively affect debugging (see code comments), but for now the flag is enabled for fastbuild and opt modes only. Linking speed should be the same or better.
- Dynamically link api_encoder and don't build it on Windows. Since api_encoder is only used as one step in generating the workerd types, we don't need to distribute it, hence dynamic linkage is ok. Type generation is not supported on Windows, so there's no need to compile api_encoder there.
- Update a comment about param_extractor to more accurately describe how the exec configuration is used.


**Why do you care so much about disk space?**
It's not about disk space itself – no one's running out of disk space from building workerd and tests. A bigger concern is caching on CI, where the actions/cache-based disk cache needs to be downloaded and outputs not found in the disk cache is fetched from CI. Both operations will be slower when objects, binaries and subsequently the cache are larger. Another concern is linking – the macOS and Windows toolchains currently don't support dynamic linking. This means that all object code needs to be included in the test binaries, resulting in long link times and test binary sizes of 200+ MB in some cases. Mitigating the impact of slow local and CI builds can only improve the developer experience.