### PR TITLE
Introduce js.withinHandleScope(...) utility

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -94,70 +94,71 @@ void EventTarget::addEventListener(jsg::Lock& js, kj::String type,
                 "the global addEventListener()."));
   }
 
-  v8::HandleScope scope(js.v8Isolate);
+  js.withinHandleScope([&] {
 
-  // Per the spec, the handler can be either a Function, or an object with a
-  // handleEvent member function.
-  HandlerFunction handlerFn = ([&]() {
-    KJ_SWITCH_ONEOF(handler.unwrapped) {
-      KJ_CASE_ONEOF(fn, HandlerFunction) {
-        return kj::mv(fn);
+    // Per the spec, the handler can be either a Function, or an object with a
+    // handleEvent member function.
+    HandlerFunction handlerFn = ([&]() {
+      KJ_SWITCH_ONEOF(handler.unwrapped) {
+        KJ_CASE_ONEOF(fn, HandlerFunction) {
+          return kj::mv(fn);
+        }
+        KJ_CASE_ONEOF(obj, HandlerObject) {
+          return kj::mv(obj.handleEvent);
+        }
       }
-      KJ_CASE_ONEOF(obj, HandlerObject) {
-        return kj::mv(obj.handleEvent);
+      KJ_UNREACHABLE;
+    })();
+
+    bool once = false;
+    kj::Maybe<jsg::Ref<AbortSignal>> maybeSignal;
+    KJ_IF_MAYBE(value, maybeOptions) {
+      KJ_SWITCH_ONEOF(*value) {
+        KJ_CASE_ONEOF(b, bool) {
+          JSG_REQUIRE(!b, TypeError, "addEventListener(): useCapture must be false.");
+        }
+        KJ_CASE_ONEOF(opts, AddEventListenerOptions) {
+          JSG_REQUIRE(!opts.capture.orDefault(false), TypeError,
+                      "addEventListener(): options.capture must be false.");
+          JSG_REQUIRE(!opts.passive.orDefault(false), TypeError,
+                      "addEventListener(): options.passive must be false.");
+          once = opts.once.orDefault(false);
+          maybeSignal = kj::mv(opts.signal);
+        }
       }
     }
-    KJ_UNREACHABLE;
-  })();
-
-  bool once = false;
-  kj::Maybe<jsg::Ref<AbortSignal>> maybeSignal;
-  KJ_IF_MAYBE(value, maybeOptions) {
-    KJ_SWITCH_ONEOF(*value) {
-      KJ_CASE_ONEOF(b, bool) {
-        JSG_REQUIRE(!b, TypeError, "addEventListener(): useCapture must be false.");
-      }
-      KJ_CASE_ONEOF(opts, AddEventListenerOptions) {
-        JSG_REQUIRE(!opts.capture.orDefault(false), TypeError,
-                     "addEventListener(): options.capture must be false.");
-        JSG_REQUIRE(!opts.passive.orDefault(false), TypeError,
-                     "addEventListener(): options.passive must be false.");
-        once = opts.once.orDefault(false);
-        maybeSignal = kj::mv(opts.signal);
+    KJ_IF_MAYBE(signal, maybeSignal) {
+      // If the AbortSignal has already been triggered, then we need to stop here.
+      // Return without adding the event listener.
+      if ((*signal)->getAborted()) {
+        return;
       }
     }
-  }
-  KJ_IF_MAYBE(signal, maybeSignal) {
-    // If the AbortSignal has already been triggered, then we need to stop here.
-    // Return without adding the event listener.
-    if ((*signal)->getAborted()) {
-      return;
-    }
-  }
 
-  auto& set = getOrCreate(type);
+    auto& set = getOrCreate(type);
 
-  auto maybeAbortHandler = maybeSignal.map([&](jsg::Ref<AbortSignal>& signal) {
-    auto func = JSG_VISITABLE_LAMBDA(
-        (this, type = kj::mv(type), handler = handler.identity.addRef(js)),
-        (handler),
-        (jsg::Lock& js, jsg::Ref<Event>) {
-      removeEventListener(js, kj::mv(type), kj::mv(handler), nullptr);
+    auto maybeAbortHandler = maybeSignal.map([&](jsg::Ref<AbortSignal>& signal) {
+      auto func = JSG_VISITABLE_LAMBDA(
+          (this, type = kj::mv(type), handler = handler.identity.addRef(js)),
+          (handler),
+          (jsg::Lock& js, jsg::Ref<Event>) {
+        removeEventListener(js, kj::mv(type), kj::mv(handler), nullptr);
+      });
+
+      return kj::heap<NativeHandler>(js, *signal, kj::str("abort"), kj::mv(func), true);
     });
 
-    return kj::heap<NativeHandler>(js, *signal, kj::str("abort"), kj::mv(func), true);
+    EventHandler eventHandler {
+      .handler = EventHandler::JavaScriptHandler {
+        .identity = kj::mv(handler.identity),
+        .callback = kj::mv(handlerFn),
+        .abortHandler = kj::mv(maybeAbortHandler),
+      },
+      .once = once,
+    };
+
+    set.handlers.upsert(kj::mv(eventHandler), [&](auto&&...) {});
   });
-
-  EventHandler eventHandler {
-    .handler = EventHandler::JavaScriptHandler {
-      .identity = kj::mv(handler.identity),
-      .callback = kj::mv(handlerFn),
-      .abortHandler = kj::mv(maybeAbortHandler),
-    },
-    .once = once,
-  };
-
-  set.handlers.upsert(kj::mv(eventHandler), [&](auto&&...) {});
 }
 
 void EventTarget::removeEventListener(jsg::Lock& js, kj::String type,
@@ -175,10 +176,11 @@ void EventTarget::removeEventListener(jsg::Lock& js, kj::String type,
     }
   }
 
-  v8::HandleScope scope(js.v8Isolate);
-  KJ_IF_MAYBE(handlerSet, typeMap.find(type)) {
-    handlerSet->handlers.eraseMatch(handler);
-  }
+  js.withinHandleScope([&] {
+    KJ_IF_MAYBE(handlerSet, typeMap.find(type)) {
+      handlerSet->handlers.eraseMatch(handler);
+    }
+  });
 }
 
 void EventTarget::addNativeListener(jsg::Lock& js, NativeHandler& handler) {
@@ -213,143 +215,144 @@ bool EventTarget::dispatchEventImpl(jsg::Lock& js, jsg::Ref<Event> event) {
 
   // First, gather all the function handles that we plan to call. This is important to ensure that
   // the callback can add or remove listeners without affecting the current event's processing.
-  v8::HandleScope scope(js.v8Isolate);
 
-  struct Callback {
-    EventHandler::Handler handler;
-    bool once = false;
-    bool oldStyle = false;
-  };
+  return js.withinHandleScope([&] {
+    struct Callback {
+      EventHandler::Handler handler;
+      bool once = false;
+      bool oldStyle = false;
+    };
 
-  kj::Vector<Callback> callbacks;
+    kj::Vector<Callback> callbacks;
 
-  // Check if there is an `on<event>` property on this object. If so, we treat that as an event
-  // handler, in addition to the ones registered with addEventListener().
-  KJ_IF_MAYBE(onProp, onEvents.get(js, kj::str("on", event->getType()))) {
-    // If the on-event is not a function, we silently ignore it rather than raise an error.
-    KJ_IF_MAYBE(cb, onProp->tryGet<HandlerFunction>()) {
-      callbacks.add(Callback {
-        .handler = EventHandler::JavaScriptHandler {
-          .identity = nullptr,  // won't be used below if oldStyle is true and once is false
-          .callback = kj::mv(*cb),
-        },
-        .oldStyle = true,
-      });
-    }
-  }
-
-  auto maybeHandlerSet = typeMap.find(event->getType());
-  KJ_IF_MAYBE(handlerSet, maybeHandlerSet) {
-    for (auto& handler: handlerSet->handlers.ordered<kj::InsertionOrderIndex>()) {
-      KJ_SWITCH_ONEOF(handler.handler) {
-        KJ_CASE_ONEOF(jsh, EventHandler::JavaScriptHandler) {
-          callbacks.add(Callback {
-            .handler = EventHandler::JavaScriptHandler {
-              .identity = jsh.identity.addRef(js),
-              .callback = jsh.callback.addRef(js)
-            },
-            .once = handler.once,
-          });
-        }
-        KJ_CASE_ONEOF(native, EventHandler::NativeHandlerRef) {
-          callbacks.add(Callback {
-            .handler = EventHandler::NativeHandlerRef {
-              .handler = native.handler,
-            },
-            .once = handler.once,
-          });
-        }
-      }
-    }
-  }
-
-  const auto isRemoved = [&](auto& handler) {
-    // This is not the most efficient way to do this but it's what works right now.
-    // Instead of capturing direct references to the handler structs, we copy those
-    // into the Callbacks vector, which means we need to look up the actual handler
-    // again to see if it still exists in the list. The entire way the storage of the
-    // handlers is done here can be improved to make this more efficient.
-    auto& handlerSet = KJ_ASSERT_NONNULL(maybeHandlerSet);
-    KJ_SWITCH_ONEOF(handler) {
-      KJ_CASE_ONEOF(js, EventHandler::JavaScriptHandler) {
-        return handlerSet.handlers.find(js.identity) == nullptr;
-      }
-      KJ_CASE_ONEOF(native, EventHandler::NativeHandlerRef) {
-        return handlerSet.handlers.find(native.handler) == nullptr;
-      }
-    }
-    KJ_UNREACHABLE;
-  };
-
-  for (auto& callback: callbacks) {
-    if (event->isStopped()) {
-      // stopImmediatePropagation() was called; don't call any further listeners
-      break;
-    }
-
-    // If the handler gets removed by an earlier run handler, then we need to
-    // make sure we don't run it. Skip over and continue.
-    if (!callback.oldStyle && isRemoved(callback.handler)) {
-      continue;
-    }
-
-    if (callback.once) {
-      KJ_SWITCH_ONEOF(callback.handler) {
-        KJ_CASE_ONEOF(jsh, EventHandler::JavaScriptHandler) {
-          removeEventListener(js, kj::str(event->getType()),
-                              jsh.identity.addRef(js),
-                              nullptr);
-        }
-        KJ_CASE_ONEOF(native, EventHandler::NativeHandlerRef) {
-          native.handler.detach(true /* defer clearing the data field */);
-        }
+    // Check if there is an `on<event>` property on this object. If so, we treat that as an event
+    // handler, in addition to the ones registered with addEventListener().
+    KJ_IF_MAYBE(onProp, onEvents.get(js, kj::str("on", event->getType()))) {
+      // If the on-event is not a function, we silently ignore it rather than raise an error.
+      KJ_IF_MAYBE(cb, onProp->tryGet<HandlerFunction>()) {
+        callbacks.add(Callback {
+          .handler = EventHandler::JavaScriptHandler {
+            .identity = nullptr,  // won't be used below if oldStyle is true and once is false
+            .callback = kj::mv(*cb),
+          },
+          .oldStyle = true,
+        });
       }
     }
 
-    KJ_SWITCH_ONEOF(callback.handler) {
-      KJ_CASE_ONEOF(jsh, EventHandler::JavaScriptHandler) {
-        // Per the standard, the event listener is not supposed to return any value, and if it
-        // does, that value is ignored. That can be somewhat problematic if the user passes an
-        // async function as the event handler. Doing so counts as undefined behavior and can
-        // introduce subtle and difficult to diagnose bugs. Here, if the handler does return a
-        // value, we're going to emit a warning but otherwise ignore it. The warning will only
-        // be emitted at most once per EventEmitter instance.
-        auto ret = jsh.callback(js, event.addRef());
-        // Note: We used to run each handler in its own v8::TryCatch. However, due to a
-        //   misunderstanding of the V8 API, we incorrectly believed that TryCatch mishandled
-        //   termination (or maybe it actually did at the time), so we changed things such that
-        //   we don't catch exceptions so the first handler to throw an exception terminates the
-        //   loop, and the exception flows out of dispatchEvent(). In theory if multiple
-        //   handlers were registered then maybe we ought to be running all of them even if one
-        //   fails. This isn't entirely clear, though: in the case of 'fetch' handlers, in
-        //   fail-closed mode, an exception from any handler should make the whole request fail,
-        //   but then who cares if the remaining handlers run? Meanwhile, in fail-open mode, for
-        //   consistency, we should probably trigger fallback behavior if any handler throws, so
-        //   again it doesn't matter. For other types of handlers, e.g. WebSocket 'message', it's
-        //   not clear why one would ever register multiple handlers.
-        if (warnOnHandlerReturn) KJ_IF_MAYBE(r, ret) {
-          warnOnHandlerReturn = false;
-          // To help make debugging easier, let's tailor the warning a bit if it was a promise.
-          auto handle = r->getHandle(js);
-          if (handle->IsPromise()) {
-            js.logWarning(
-                kj::str("An event handler returned a promise that will be ignored. Event handlers "
-                        "should not have a return value and should not be async functions."));
-          } else {
-            js.logWarning(
-                kj::str("An event handler returned a value of type \"",
-                        handle->TypeOf(js.v8Isolate),
-                        "\" that will be ignored. Event handlers should not have a return value."));
+    auto maybeHandlerSet = typeMap.find(event->getType());
+    KJ_IF_MAYBE(handlerSet, maybeHandlerSet) {
+      for (auto& handler: handlerSet->handlers.ordered<kj::InsertionOrderIndex>()) {
+        KJ_SWITCH_ONEOF(handler.handler) {
+          KJ_CASE_ONEOF(jsh, EventHandler::JavaScriptHandler) {
+            callbacks.add(Callback {
+              .handler = EventHandler::JavaScriptHandler {
+                .identity = jsh.identity.addRef(js),
+                .callback = jsh.callback.addRef(js)
+              },
+              .once = handler.once,
+            });
+          }
+          KJ_CASE_ONEOF(native, EventHandler::NativeHandlerRef) {
+            callbacks.add(Callback {
+              .handler = EventHandler::NativeHandlerRef {
+                .handler = native.handler,
+              },
+              .once = handler.once,
+            });
           }
         }
       }
-      KJ_CASE_ONEOF(native, EventHandler::NativeHandlerRef) {
-        native.handler(js, event.addRef());
+    }
+
+    const auto isRemoved = [&](auto& handler) {
+      // This is not the most efficient way to do this but it's what works right now.
+      // Instead of capturing direct references to the handler structs, we copy those
+      // into the Callbacks vector, which means we need to look up the actual handler
+      // again to see if it still exists in the list. The entire way the storage of the
+      // handlers is done here can be improved to make this more efficient.
+      auto& handlerSet = KJ_ASSERT_NONNULL(maybeHandlerSet);
+      KJ_SWITCH_ONEOF(handler) {
+        KJ_CASE_ONEOF(js, EventHandler::JavaScriptHandler) {
+          return handlerSet.handlers.find(js.identity) == nullptr;
+        }
+        KJ_CASE_ONEOF(native, EventHandler::NativeHandlerRef) {
+          return handlerSet.handlers.find(native.handler) == nullptr;
+        }
+      }
+      KJ_UNREACHABLE;
+    };
+
+    for (auto& callback: callbacks) {
+      if (event->isStopped()) {
+        // stopImmediatePropagation() was called; don't call any further listeners
+        break;
+      }
+
+      // If the handler gets removed by an earlier run handler, then we need to
+      // make sure we don't run it. Skip over and continue.
+      if (!callback.oldStyle && isRemoved(callback.handler)) {
+        continue;
+      }
+
+      if (callback.once) {
+        KJ_SWITCH_ONEOF(callback.handler) {
+          KJ_CASE_ONEOF(jsh, EventHandler::JavaScriptHandler) {
+            removeEventListener(js, kj::str(event->getType()),
+                                jsh.identity.addRef(js),
+                                nullptr);
+          }
+          KJ_CASE_ONEOF(native, EventHandler::NativeHandlerRef) {
+            native.handler.detach(true /* defer clearing the data field */);
+          }
+        }
+      }
+
+      KJ_SWITCH_ONEOF(callback.handler) {
+        KJ_CASE_ONEOF(jsh, EventHandler::JavaScriptHandler) {
+          // Per the standard, the event listener is not supposed to return any value, and if it
+          // does, that value is ignored. That can be somewhat problematic if the user passes an
+          // async function as the event handler. Doing so counts as undefined behavior and can
+          // introduce subtle and difficult to diagnose bugs. Here, if the handler does return a
+          // value, we're going to emit a warning but otherwise ignore it. The warning will only
+          // be emitted at most once per EventEmitter instance.
+          auto ret = jsh.callback(js, event.addRef());
+          // Note: We used to run each handler in its own v8::TryCatch. However, due to a
+          //   misunderstanding of the V8 API, we incorrectly believed that TryCatch mishandled
+          //   termination (or maybe it actually did at the time), so we changed things such that
+          //   we don't catch exceptions so the first handler to throw an exception terminates the
+          //   loop, and the exception flows out of dispatchEvent(). In theory if multiple
+          //   handlers were registered then maybe we ought to be running all of them even if one
+          //   fails. This isn't entirely clear, though: in the case of 'fetch' handlers, in
+          //   fail-closed mode, an exception from any handler should make the whole request fail,
+          //   but then who cares if the remaining handlers run? Meanwhile, in fail-open mode, for
+          //   consistency, we should probably trigger fallback behavior if any handler throws, so
+          //   again it doesn't matter. For other types of handlers, e.g. WebSocket 'message', it's
+          //   not clear why one would ever register multiple handlers.
+          if (warnOnHandlerReturn) KJ_IF_MAYBE(r, ret) {
+            warnOnHandlerReturn = false;
+            // To help make debugging easier, let's tailor the warning a bit if it was a promise.
+            auto handle = r->getHandle(js);
+            if (handle->IsPromise()) {
+              js.logWarning(
+                  kj::str("An event handler returned a promise that will be ignored. Event handlers "
+                          "should not have a return value and should not be async functions."));
+            } else {
+              js.logWarning(
+                  kj::str("An event handler returned a value of type \"",
+                          handle->TypeOf(js.v8Isolate),
+                          "\" that will be ignored. Event handlers should not have a return value."));
+            }
+          }
+        }
+        KJ_CASE_ONEOF(native, EventHandler::NativeHandlerRef) {
+          native.handler(js, event.addRef());
+        }
       }
     }
-  }
 
-  return !event->isPreventDefault();
+    return !event->isPreventDefault();
+  });
 }
 
 bool EventTarget::dispatchEvent(jsg::Lock& js, jsg::Ref<Event> event) {

--- a/src/workerd/jsg/README.md
+++ b/src/workerd/jsg/README.md
@@ -493,9 +493,9 @@ jsg::V8Ref<v8::Boolean> boolRef2 = boolRef1.addRef(js);
 
 KJ_DBG(boolRef1 == boolRef2);  // prints "true"
 
-// Getting the v8::Local<T> from the V8Ref requires a v8::HandleScope.
-v8::HandleScope scope(js.v8Isolate);
-v8::Local<v8::Boolean> boolLocal = boolRef1.getHandle(js);
+// Getting the v8::Local<T> from the V8Ref requires a v8::HandleScope to be
+// on the stack. We provide a convenience method on jsg::Lock to ensure that:
+v8::Local<v8::Boolean> boolLocal = js.withinHandleScope([&] { return boolRef1.getHandle(js); });
 ```
 
 The `jsg::HashableV8Ref<T>` type is a subclass of `jsg::V8Ref<T>` that also implements
@@ -524,10 +524,11 @@ jsg::Ref<Foo> foo = jsg::alloc<Foo>();
 
 jsg::Ref<Foo> foo2 = foo.addRef();
 
-v8::HandleScope scope(js.v8Isolate);
-KJ_IF_MAYBE(handle, foo.tryGetHandle(js.v8Isolate)) {
-  // If handle is non-null, it is the Foo instance's JavaScript wrapper.
-}
+js.withinHandleScope([&] {
+  KJ_IF_MAYBE(handle, foo.tryGetHandle(js.v8Isolate)) {
+    // If handle is non-null, it is the Foo instance's JavaScript wrapper.
+  }
+});
 ```
 
 ### Memoized and Identified types

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -18,22 +18,6 @@ namespace workerd::jsg {
 // At present this is used privately in the Promise implementation, but we could consider making
 // wrapOpaque() more public if it is useful.
 
-template <typename T>
-constexpr bool isV8Ref(T*) { return false; }
-template <typename T>
-constexpr bool isV8Ref(V8Ref<T>*) { return true; }
-
-template <typename T>
-constexpr bool isV8Ref() { return isV8Ref((T*)nullptr); }
-
-template <typename T>
-constexpr bool isV8Local(T*) { return false; }
-template <typename T>
-constexpr bool isV8Local(v8::Local<T>*) { return true; }
-
-template <typename T>
-constexpr bool isV8Local() { return isV8Local((T*)nullptr); }
-
 template <typename T, bool = isGcVisitable<T>()>
 struct OpaqueWrappable;
 


### PR DESCRIPTION
Proposes the introduction of a new js.withinHandleScope(...) utility that replaces direct use of v8::HandleScope. While the utility is not ideal it does help avoid direct use of an obscure but necessary v8 API and makes it easier when dealing with v8::HandleScope vs. v8::EscapableHandleScope, as well as working with v8::Context::Scope.

The naming is, admitedly, a bit clumsy, and I'm not entirely sold on the approach here yet, so definitely open to suggestions.

```cpp
js.withinHandleScope([&] {
  // Everything here is within a v8::HandleScope!
  return foo;  // returns whatever the inner lambda returns
});

js.withinHandleScope([&]() -> v8::Local<v8::Value> {
  // Everything here is within a v8::EscapableHandleScope!
  return v8::Object::New(js.v8Isolate);  // The returned v8::Local<...> is passed through scope.Escape(...)
});
```