### PR TITLE
Implement `Fetcher#scheduled()` for dispatching `scheduled` events

### DIFF
--- a/src/workerd/api/http-test.js
+++ b/src/workerd/api/http-test.js
@@ -1,0 +1,34 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import assert from "node:assert";
+
+let scheduledLastCtrl;
+
+export default {
+  async scheduled(ctrl, env, ctx) {
+    scheduledLastCtrl = ctrl;
+    if (ctrl.cron === "* * * * 30") ctrl.noRetry();
+  },
+
+  async test(ctrl, env, ctx) {
+    // Call `scheduled()` with no options
+    {
+      const result = await env.SERVICE.scheduled();
+      assert.strictEqual(result.outcome, "ok");
+      assert(!result.noRetry);
+      assert(Math.abs(Date.now() - scheduledLastCtrl.scheduledTime) < 3_000);
+      assert.strictEqual(scheduledLastCtrl.cron, "");
+    }
+
+    // Call `scheduled()` with options, and noRetry()
+    {
+      const result = await env.SERVICE.scheduled({ scheduledTime: 1000, cron: "* * * * 30" });
+      assert.strictEqual(result.outcome, "ok");
+      assert(result.noRetry);
+      assert.strictEqual(scheduledLastCtrl.scheduledTime, 1000);
+      assert.strictEqual(scheduledLastCtrl.cron, "* * * * 30");
+    }
+  }
+}

--- a/src/workerd/api/http-test.wd-test
+++ b/src/workerd/api/http-test.wd-test
@@ -1,0 +1,18 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "http-test",
+      worker = (
+        modules = [
+          ( name = "worker", esModule = embed "http-test.js" )
+        ],
+        bindings = [
+          ( name = "SERVICE", service = "http-test" )
+        ],
+        compatibilityDate = "2023-08-01",
+        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -468,8 +468,34 @@ public:
     });
   };
 
-  jsg::Promise<QueueResponse> queue(
+  struct QueueResult {
+    kj::String outcome;
+    bool retryAll;
+    bool ackAll;
+    kj::Array<kj::String> explicitRetries;
+    kj::Array<kj::String> explicitAcks;
+
+    JSG_STRUCT(outcome, retryAll, ackAll, explicitRetries, explicitAcks);
+  };
+
+  jsg::Promise<QueueResult> queue(
       jsg::Lock& js, kj::String queueName, kj::Array<ServiceBindingQueueMessage> messages);
+
+  struct ScheduledOptions {
+    jsg::Optional<kj::Date> scheduledTime;
+    jsg::Optional<kj::String> cron;
+
+    JSG_STRUCT(scheduledTime, cron);
+  };
+
+  struct ScheduledResult {
+    kj::String outcome;
+    bool noRetry;
+
+    JSG_STRUCT(outcome, noRetry);
+  };
+
+  jsg::Promise<ScheduledResult> scheduled(jsg::Lock& js, jsg::Optional<ScheduledOptions> options);
 
   JSG_RESOURCE_TYPE(Fetcher, CompatibilityFlags::Reader flags) {
     JSG_METHOD(fetch);
@@ -477,6 +503,7 @@ public:
 
     if (flags.getServiceBindingExtraHandlers()) {
       JSG_METHOD(queue);
+      JSG_METHOD(scheduled);
     }
 
     JSG_METHOD(get);
@@ -1075,6 +1102,9 @@ kj::String makeRandomBoundaryCharacters();
   api::Request::InitializerDict,      \
   api::Fetcher,                       \
   api::Fetcher::PutOptions,           \
+  api::Fetcher::ScheduledOptions,     \
+  api::Fetcher::ScheduledResult,      \
+  api::Fetcher::QueueResult,          \
   api::Fetcher::ServiceBindingQueueMessage
 
 // The list of http.h types that are added to worker.c++'s JSG_DECLARE_ISOLATE_TYPE

--- a/src/workerd/api/queue-test.js
+++ b/src/workerd/api/queue-test.js
@@ -92,7 +92,7 @@ export default {
       { id: "#2", timestamp, body: { c: { d: 10 } } },
       { id: "#3", timestamp, body: timestamp },
     ]);
-    assert.strictEqual(response.outcome, /* OK */ 1);
+    assert.strictEqual(response.outcome, "ok");
     assert(!response.retryAll);
     assert(response.ackAll);
     assert.deepStrictEqual(response.explicitRetries, ["#2"]);

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -1342,7 +1342,7 @@ KJ_TEST("Server: call queue handler on service binding") {
   test.server.allowExperimental();
   test.start();
   auto conn = test.connect("test-addr");
-  conn.httpGet200("/", "queue outcome: 1, ackAll: true");
+  conn.httpGet200("/", "queue outcome: ok, ackAll: true");
 }
 
 KJ_TEST("Server: Durable Objects (in memory)") {


### PR DESCRIPTION
Hey! 👋 This PR implements a `Fetcher#scheduled()` method for dispatching `scheduled` events to bound services. This will allow us to add support for triggering scheduled events in Miniflare without transforming user code. Like `Fetcher#queue()`, this is gated behind the experimental `service_binding_extra_handlers` compatibility flag.