### PR TITLE
Improve "Body has already been used" error

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -626,8 +626,8 @@ bool Body::getBodyUsed() {
 jsg::Promise<kj::Array<byte>> Body::arrayBuffer(jsg::Lock& js) {
   KJ_IF_MAYBE(i, impl) {
     return js.evalNow([&] {
-      JSG_REQUIRE(!i->stream->isDisturbed(), TypeError, "Body has already been used. "
-          "It can only be used once. Use tee() first if you need to read it twice.");
+      JSG_REQUIRE(!i->stream->isDisturbed(), TypeError, "The body of this response has already been used."
+          "It can only be used once. Use Response.body.tee() or Response.clone() if you need to read the body twice.");
       return i->stream->getController().readAllBytes(js,
           IoContext::current().getLimitEnforcer().getBufferingLimit());
     });


### PR DESCRIPTION
refs https://github.com/cloudflare/cloudflare-docs/issues/8723

...it's not intuitive at first glance why this doesn't work:

```
export default {
	async fetch(request) {
		const httpResponse = new Response(JSON.stringify({url: "foo.bar"}), {
			headers: {
			  'Content-Type': 'application/json'
			}
		  });
		  let cache = caches.default;
		  await cache.put(request, httpResponse);
		  return httpResponse;
	},
};
```

`> Uncaught (in response) TypeError: Body has already been used. It can only be used once. Use tee() first if you need to read it twice.`

This isn't immediately obvious, because to you, it doesn't appear like you have tried to read the body of a response already. The body is being implicitly read in both `return httpResponse` and `cache.put`.

We can and should improve docs — but also this error message. (see diff)