### PR TITLE
JSG Completion: add interim jsg::Lock::v8Set and jsg::Lock::v8Get

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -107,10 +107,10 @@ void handleDefaultBotManagement(jsg::Lock& js, jsg::Value& cf) {
   // Note that if the botManagement team changes any of the fields they provide,
   // this default value may need to be changed also.
   auto context = js.v8Context();
-  auto name = jsg::v8StrIntern(js.v8Isolate, "botManagement"_kj);
   auto handle = cf.getHandle(js).As<v8::Object>();
-  if (!jsg::check(handle->Has(context, name))) {
-    auto sym = v8::Private::ForApi(js.v8Isolate, name);
+  if (!js.v8Has(handle, "botManagement"_kj)) {
+    auto sym = v8::Private::ForApi(js.v8Isolate,
+        jsg::v8StrIntern(js.v8Isolate, "botManagement"_kj));
     // For performance reasons, we only want to construct the default values
     // once per isolate so we cache the constructed value using an internal
     // private field on the global scope. Whenever we need to use it again we
@@ -123,7 +123,7 @@ void handleDefaultBotManagement(jsg::Lock& js, jsg::Value& cf) {
       defaultBm = bm.getHandle(js);
       jsg::check(context->Global()->SetPrivate(context, sym, defaultBm));
     }
-    jsg::check(handle->Set(context, name, defaultBm));
+    js.v8Set(handle, "botManagement"_kj, defaultBm);
   }
 }
 

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1962,8 +1962,7 @@ jsg::Promise<Fetcher::GetResult> Fetcher::get(
                 -> jsg::Promise<GetResult> {
     uint status = response->getStatus();
     if (status == 404 || status == 410) {
-      return js.resolvedPromise(GetResult(
-          jsg::Value(js.v8Ref<v8::Value>(v8::Null(js.v8Isolate)))));
+      return js.resolvedPromise(GetResult(js.v8Ref(js.v8Null())));
     } else if (status < 200 || status >= 300) {
       // Manually construct exception so that we can incorporate method and status into the text
       // that JavaScript sees.

--- a/src/workerd/api/node/async-hooks.c++
+++ b/src/workerd/api/node/async-hooks.c++
@@ -121,9 +121,7 @@ v8::Local<v8::Function> AsyncResource::bind(
   // Per Node.js documentation (https://nodejs.org/dist/latest-v19.x/docs/api/async_context.html#asyncresourcebindfn-thisarg), the returned function "will have an
   // asyncResource property referencing the AsyncResource to which the function
   // is bound".
-  jsg::check(bound->Set(js.v8Context(),
-             jsg::v8StrIntern(js.v8Isolate, "asyncResource"_kj),
-             handler.wrap(js, JSG_THIS)));
+  js.v8Set(bound, "asyncResource"_kj, handler.wrap(js, JSG_THIS));
   return bound;
 }
 

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -31,8 +31,7 @@ static kj::Date parseDate(jsg::Lock& js, kj::StringPtr value) {
   const auto context = js.v8Context();
   const auto tmp = jsg::check(v8::Date::New(context, 0));
   KJ_REQUIRE(tmp->IsDate());
-  const auto constructor = jsg::check(tmp.template As<v8::Date>()->Get(
-      context, jsg::v8StrIntern(isolate, "constructor")));
+  const auto constructor = js.v8Get(tmp.As<v8::Object>(), "constructor"_kj);
   JSG_REQUIRE(constructor->IsFunction(), TypeError, "Date.constructor is not a function");
   v8::Local<v8::Value> argv = jsg::v8Str(isolate, value);
   const auto converted = jsg::check(
@@ -48,10 +47,9 @@ static jsg::ByteString toUTCString(jsg::Lock& js, kj::Date date) {
   auto isolate = js.v8Isolate;
   const auto context = js.v8Context();
   const auto converted = jsg::check(v8::Date::New(
-      context, (date - kj::UNIX_EPOCH) / kj::MILLISECONDS));
+      context, (date - kj::UNIX_EPOCH) / kj::MILLISECONDS)).As<v8::Object>();
   KJ_REQUIRE(converted->IsDate());
-  const auto stringify = jsg::check(converted.template As<v8::Date>()->Get(
-      context, jsg::v8StrIntern(isolate, "toUTCString")));
+  const auto stringify = js.v8Get(converted, "toUTCString"_kj);
   JSG_REQUIRE(stringify->IsFunction(), TypeError, "toUTCString on a Date is not a function");
   const auto stringified = jsg::check(stringify.template As<v8::Function>()->Call(
       context, converted, 0, nullptr));

--- a/src/workerd/api/r2-rpc.c++
+++ b/src/workerd/api/r2-rpc.c++
@@ -24,9 +24,7 @@ static kj::Own<R2Error> toError(uint statusCode, kj::StringPtr responseBody) {
 }
 
 v8::Local<v8::Value> R2Error::getStack(jsg::Lock& js) {
-  auto stackString = jsg::v8StrIntern(js.v8Isolate, "stack");
-  return jsg::check(KJ_ASSERT_NONNULL(errorForStack).Get(js.v8Isolate)->Get(
-      js.v8Context(), stackString));
+  return js.v8Get(KJ_ASSERT_NONNULL(errorForStack).Get(js.v8Isolate), "stack"_kj);
 }
 
 kj::Maybe<uint> R2Result::v4ErrorCode() {

--- a/src/workerd/api/urlpattern.c++
+++ b/src/workerd/api/urlpattern.c++
@@ -1854,7 +1854,7 @@ kj::Maybe<URLPattern::URLPatternComponentResult> execRegex(
   kj::Vector<Groups::Field> fields(length - 1);
 
   while (index < length) {
-    auto value = jsg::check(resultsArray->Get(context, index));
+    auto value = js.v8Get(resultsArray, index);
     fields.add(Groups::Field {
       .name = jsg::usv(component.nameList[index - 1]),
       .value = value->IsUndefined() ? jsg::usv() : jsg::usv(js.v8Isolate, value),

--- a/src/workerd/jsg/dom-exception.c++
+++ b/src/workerd/jsg/dom-exception.c++
@@ -41,8 +41,7 @@ int DOMException::getCode() {
 }
 
 v8::Local<v8::Value> DOMException::getStack(Lock& js) {
-  return check(errorForStack.getHandle(js)->Get(
-      js.v8Context(), v8StrIntern(js.v8Isolate, "stack")));
+  return js.v8Get(errorForStack.getHandle(js), "stack"_kj);
 }
 
 void DOMException::visitForGc(GcVisitor& visitor) {

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -209,6 +209,36 @@ void Lock::requestGcForTesting() const {
     v8::Isolate::GarbageCollectionType::kFullGarbageCollection);
 }
 
+void Lock::v8Set(v8::Local<v8::Object> obj,
+                 kj::StringPtr name,
+                 v8::Local<v8::Value> value) {
+  KJ_ASSERT(check(obj->Set(v8Context(), v8StrIntern(v8Isolate, name), value)));
+}
+
+void Lock::v8Set(v8::Local<v8::Object> obj, kj::StringPtr name, Value& value) {
+  v8Set(obj, name, value.getHandle(*this));
+}
+
+void Lock::v8Set(v8::Local<v8::Object> obj, V8Ref<v8::String>& name, Value& value) {
+  KJ_ASSERT(check(obj->Set(v8Context(), name.getHandle(*this), value.getHandle(*this))));
+}
+
+v8::Local<v8::Value> Lock::v8Get(v8::Local<v8::Object> obj, kj::StringPtr name) {
+  return check(obj->Get(v8Context(), v8StrIntern(v8Isolate, name)));
+}
+
+v8::Local<v8::Value> Lock::v8Get(v8::Local<v8::Array> obj, uint idx) {
+  return check(obj->Get(v8Context(), idx));
+}
+
+bool Lock::v8Has(v8::Local<v8::Object> obj, kj::StringPtr name) {
+  return check(obj->Has(v8Context(), v8StrIntern(v8Isolate, name)));
+}
+
+bool Lock::v8HasOwn(v8::Local<v8::Object> obj, kj::StringPtr name) {
+  return check(obj->HasOwnProperty(v8Context(), v8StrIntern(v8Isolate, name)));
+}
+
 kj::StringPtr Lock::getUuid() const {
   return IsolateBase::from(v8Isolate).getUuid();
 }

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -618,15 +618,14 @@ v8::Local<v8::Value> NodeJsModuleContext::require(kj::String specifier, v8::Isol
     jsg::throwTunneledException(isolate, module->GetException());
   }
 
-  return jsg::check(module->GetModuleNamespace().As<v8::Object>()
-      ->Get(context, jsg::v8StrIntern(isolate, "default")));
+  return js.v8Get(module->GetModuleNamespace().As<v8::Object>(), "default"_kj);
 }
 
 v8::Local<v8::Value> NodeJsModuleContext::getBuffer(jsg::Lock& js) {
   auto value = require(kj::str("node:buffer"), js.v8Isolate);
   JSG_REQUIRE(value->IsObject(), TypeError, "Invalid node:buffer implementation");
   auto module = value.As<v8::Object>();
-  auto buffer = jsg::check(module->Get(js.v8Context(), jsg::v8StrIntern(js.v8Isolate, "Buffer")));
+  auto buffer = js.v8Get(module, "Buffer"_kj);
   JSG_REQUIRE(buffer->IsFunction(), TypeError, "Invalid node:buffer implementation");
   return buffer;
 }

--- a/src/workerd/tests/test-fixture-test.c++
+++ b/src/workerd/tests/test-fixture-test.c++
@@ -195,7 +195,7 @@ KJ_TEST("compileAndInstantiateModule") {
 
     auto ns = env.compileAndInstantiateModule("testFixtureTest",
         "export function init() { return 42; }"_kj);
-    auto fn = ns->Get(context, jsg::v8StrIntern(env.isolate, "init")).ToLocalChecked();
+    auto fn = env.js.v8Get(ns, "init"_kj);
     KJ_EXPECT(fn->IsFunction());
     auto callResult = v8::Function::Cast(*fn)->
         Call(context, context->Global(), 0, nullptr).ToLocalChecked();


### PR DESCRIPTION
Help to eliminate v8 specific boilerplate when getting/setting values on v8::Object instances. This should be considered transitional. It helps to eliminate a number of direct uses of v8::Isolate and other v8 specific APIs but does not completely hide the v8 semantics.

For example,

```cpp
  jsg::check(bound->Set(js.v8Context(), jsg::v8StrIntern(js.v8Isolate, "foo"_kj), handler.wrap(js, JSG_THIS)));

  // becomes

  js.v8Set(bound, "asyncResource"_kj, handler.wrap(js, JSG_THIS));
```