### PR TITLE
SQL: Count rows read and written

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,10 +42,10 @@ http_archive(
 http_archive(
     name = "sqlite3",
     build_file = "//:build/BUILD.sqlite3",
-    sha256 = "49112cc7328392aa4e3e5dae0b2f6736d0153430143d21f69327788ff4efe734",
-    strip_prefix = "sqlite-amalgamation-3400100",
+    sha256 = "5064126aa50db20c35578b612b56c3129425c0506ed4d1610efa4a0f01bdf8d0",
+    strip_prefix = "sqlite-src-3400100",
     type = "zip",
-    url = "https://sqlite.org/2022/sqlite-amalgamation-3400100.zip",
+    url = "https://sqlite.org/2022/sqlite-src-3400100.zip",
 )
 
 http_archive(
@@ -54,6 +54,17 @@ http_archive(
     strip_prefix = "rules_python-0.23.1",
     url = "https://github.com/bazelbuild/rules_python/releases/download/0.23.1/rules_python-0.23.1.tar.gz",
 )
+
+# For building patched SQLite.
+http_archive(
+    name = "rules_foreign_cc",
+    sha256 = "c62873142a36001b3dc0ae72d2df743ee47a223720dbd3c26dc4faf09a284da8",
+    strip_prefix = "bazelbuild-rules_foreign_cc-816905a",
+    type = "tgz",
+    url = "https://github.com/bazelbuild/rules_foreign_cc/tarball/816905a078773405803e86635def78b61d2f782d",
+)
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+rules_foreign_cc_dependencies()
 
 # Using latest brotli commit due to macOS and clang-cl compile issues with v1.0.9, switch to a
 # release version later.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,6 +42,10 @@ http_archive(
 http_archive(
     name = "sqlite3",
     build_file = "//:build/BUILD.sqlite3",
+    patch_args = ["-p1"],
+    patches = [
+        "//:patches/sqlite/0001-row-counts.patch",
+    ],
     sha256 = "5064126aa50db20c35578b612b56c3129425c0506ed4d1610efa4a0f01bdf8d0",
     strip_prefix = "sqlite-src-3400100",
     type = "zip",

--- a/build/BUILD.sqlite3
+++ b/build/BUILD.sqlite3
@@ -1,3 +1,34 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)
+
+# Amalgamates all the source files into the three files given in targets, but does not compile the
+# amalgamated files.
+#
+# configure_make expects to build libraries, binaries, or both. We tell it that our generated
+# source files are binaries.
+configure_make(
+    name = "amalgamation",
+    lib_source = "@sqlite3//:all_files",
+    targets = ["sqlite3.h sqlite3ext.h sqlite3.c"],
+    out_bin_dir = ".",
+    out_binaries = ["sqlite3.h", "sqlite3.c", "sqlite3ext.h"],
+    postfix_script = "cp sqlite3.h sqlite3.c sqlite3ext.h $INSTALLDIR/"
+)
+
+# The binary outputs of the sqlite_amalgamation rule can't be consumed by the cc_library rule below
+# because they're in the wrong place(?). However, if we copy them with this genrule, then
+# they become acceptable to cc_library.
+genrule(
+    name = "amalgamation-in-right-location",
+    outs = ["sqlite3.h", "sqlite3ext.h", "sqlite3.c"],
+    srcs = [":amalgamation"],
+    cmd = "cp -r $(locations :amalgamation) $(RULEDIR)/",
+)
+
 cc_library(
     name = "sqlite3",
     hdrs = ["sqlite3.h", "sqlite3ext.h"],

--- a/patches/sqlite/0001-row-counts.patch
+++ b/patches/sqlite/0001-row-counts.patch
@@ -1,0 +1,248 @@
+diff -u5 -r sqlite-src-3400100-pristine/src/shell.c.in sqlite-src-3400100-modified/src/shell.c.in
+--- sqlite-src-3400100-pristine/src/shell.c.in	2023-08-03 14:15:24.760062869 -0700
++++ sqlite-src-3400100-modified/src/shell.c.in	2023-08-03 14:15:53.042646929 -0700
+@@ -2952,10 +2952,15 @@
+     raw_printf(pArg->out, "Reprepare operations:                %d\n", iCur);
+     iCur = sqlite3_stmt_status(pArg->pStmt, SQLITE_STMTSTATUS_RUN, bReset);
+     raw_printf(pArg->out, "Number of times run:                 %d\n", iCur);
+     iCur = sqlite3_stmt_status(pArg->pStmt, SQLITE_STMTSTATUS_MEMUSED, bReset);
+     raw_printf(pArg->out, "Memory used by prepared stmt:        %d\n", iCur);
++
++    iCur = sqlite3_stmt_status(pArg->pStmt, LIBSQL_STMTSTATUS_ROWS_READ, bReset);
++    raw_printf(pArg->out, "Rows read:                           %d\n", iCur);
++    iCur = sqlite3_stmt_status(pArg->pStmt, LIBSQL_STMTSTATUS_ROWS_WRITTEN, bReset);
++    raw_printf(pArg->out, "Rows written:                        %d\n", iCur);
+   }
+ 
+ #ifdef __linux__
+   displayLinuxIoStats(pArg->out);
+ #endif
+diff -u5 -r sqlite-src-3400100-pristine/src/sqlite.h.in sqlite-src-3400100-modified/src/sqlite.h.in
+--- sqlite-src-3400100-pristine/src/sqlite.h.in	2022-12-28 06:26:33.000000000 -0800
++++ sqlite-src-3400100-modified/src/sqlite.h.in	2023-08-03 14:18:49.490588655 -0700
+@@ -8615,10 +8615,18 @@
+ ** used to store the prepared statement.  ^This value is not actually
+ ** a counter, and so the resetFlg parameter to sqlite3_stmt_status()
+ ** is ignored when the opcode is SQLITE_STMTSTATUS_MEMUSED.
+ ** </dd>
+ ** </dl>
++**
++** [[LIBSQL_STMTSTATUS_ROWS_READ]]
++** [[LIBSQL_STMTSTATUS_ROWS_WRITTEN]] 
++** <dt>LIBSQL_STMTSTATUS_ROWS_READ<br>
++** LIBSQL_STMTSTATUS_ROWS_WRITTEN</dt>
++** <dd>^LIBSQL_STMTSTATUS_ROWS_READ is the number of rows read when executing
++** this statement. LIBSQL_STMTSTATUS_ROWS_WRITTEN value is the number of
++** rows written.
+ */
+ #define SQLITE_STMTSTATUS_FULLSCAN_STEP     1
+ #define SQLITE_STMTSTATUS_SORT              2
+ #define SQLITE_STMTSTATUS_AUTOINDEX         3
+ #define SQLITE_STMTSTATUS_VM_STEP           4
+@@ -8626,10 +8634,14 @@
+ #define SQLITE_STMTSTATUS_RUN               6
+ #define SQLITE_STMTSTATUS_FILTER_MISS       7
+ #define SQLITE_STMTSTATUS_FILTER_HIT        8
+ #define SQLITE_STMTSTATUS_MEMUSED           99
+ 
++#define LIBSQL_STMTSTATUS_BASE              1024
++#define LIBSQL_STMTSTATUS_ROWS_READ         LIBSQL_STMTSTATUS_BASE + 1
++#define LIBSQL_STMTSTATUS_ROWS_WRITTEN      LIBSQL_STMTSTATUS_BASE + 2
++
+ /*
+ ** CAPI3REF: Custom Page Cache Object
+ **
+ ** The sqlite3_pcache type is opaque.  It is implemented by
+ ** the pluggable module.  The SQLite core has no knowledge of
+diff -u5 -r sqlite-src-3400100-pristine/src/vdbeapi.c sqlite-src-3400100-modified/src/vdbeapi.c
+--- sqlite-src-3400100-pristine/src/vdbeapi.c	2022-12-28 06:26:33.000000000 -0800
++++ sqlite-src-3400100-modified/src/vdbeapi.c	2023-08-03 14:19:40.916453104 -0700
+@@ -1826,11 +1826,11 @@
+ int sqlite3_stmt_status(sqlite3_stmt *pStmt, int op, int resetFlag){
+   Vdbe *pVdbe = (Vdbe*)pStmt;
+   u32 v;
+ #ifdef SQLITE_ENABLE_API_ARMOR
+   if( !pStmt 
+-   || (op!=SQLITE_STMTSTATUS_MEMUSED && (op<0||op>=ArraySize(pVdbe->aCounter)))
++   || (op!=SQLITE_STMTSTATUS_MEMUSED && (op<0||(op>=ArraySize(pVdbe->aCounter)&&op<LIBSQL_STMTSTATUS_BASE)))
+   ){
+     (void)SQLITE_MISUSE_BKPT;
+     return 0;
+   }
+ #endif
+@@ -1843,10 +1843,13 @@
+     db->lookaside.pEnd = db->lookaside.pStart;
+     sqlite3VdbeDelete(pVdbe);
+     db->pnBytesFreed = 0;
+     db->lookaside.pEnd = db->lookaside.pTrueEnd;
+     sqlite3_mutex_leave(db->mutex);
++  }else if( op>=LIBSQL_STMTSTATUS_BASE ){
++    v = pVdbe->aLibsqlCounter[op - LIBSQL_STMTSTATUS_BASE];
++    if( resetFlag ) pVdbe->aLibsqlCounter[op - LIBSQL_STMTSTATUS_BASE] = 0;
+   }else{
+     v = pVdbe->aCounter[op];
+     if( resetFlag ) pVdbe->aCounter[op] = 0;
+   }
+   return (int)v;
+diff -u5 -r sqlite-src-3400100-pristine/src/vdbe.c sqlite-src-3400100-modified/src/vdbe.c
+--- sqlite-src-3400100-pristine/src/vdbe.c	2022-12-28 06:26:33.000000000 -0800
++++ sqlite-src-3400100-modified/src/vdbe.c	2023-08-03 14:26:29.473777273 -0700
+@@ -3582,10 +3582,11 @@
+   if( pOp->p3 ){
+     nEntry = sqlite3BtreeRowCountEst(pCrsr);
+   }else{
+     nEntry = 0;  /* Not needed.  Only used to silence a warning. */
+     rc = sqlite3BtreeCount(db, pCrsr, &nEntry);
++    p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE] += nEntry;
+     if( rc ) goto abort_due_to_error;
+   }
+   pOut = out2Prerelease(p, pOp);
+   pOut->u.i = nEntry;
+   goto check_for_interrupt;
+@@ -4741,10 +4742,11 @@
+     if( eqOnly && r.eqSeen==0 ){
+       assert( res!=0 );
+       goto seek_not_found;
+     }
+   }
++  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
+ #ifdef SQLITE_TEST
+   sqlite3_search_count++;
+ #endif
+   if( oc>=OP_SeekGE ){  assert( oc==OP_SeekGE || oc==OP_SeekGT );
+     if( res<0 || (res==0 && oc==OP_SeekGT) ){
+@@ -5309,10 +5311,11 @@
+   pC->nullRow = 0;
+   pC->cacheStatus = CACHE_STALE;
+   pC->deferredMoveto = 0;
+   VdbeBranchTaken(res!=0,2);
+   pC->seekResult = res;
++  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
+   if( res!=0 ){
+     assert( rc==SQLITE_OK );
+     if( pOp->p2==0 ){
+       rc = SQLITE_CORRUPT_BKPT;
+     }else{
+@@ -5565,10 +5568,11 @@
+     }
+   }
+   if( pOp->p5 & OPFLAG_ISNOOP ) break;
+ #endif
+ 
++  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
+   if( pOp->p5 & OPFLAG_NCHANGE ) p->nChange++;
+   if( pOp->p5 & OPFLAG_LASTROWID ) db->lastRowid = x.nKey;
+   assert( (pData->flags & (MEM_Blob|MEM_Str))!=0 || pData->n==0 );
+   x.pData = pData->z;
+   x.nData = pData->n;
+@@ -5748,10 +5752,11 @@
+   pC->seekResult = 0;
+   if( rc ) goto abort_due_to_error;
+ 
+   /* Invoke the update-hook if required. */
+   if( opflags & OPFLAG_NCHANGE ){
++    p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
+     p->nChange++;
+     if( db->xUpdateCallback && ALWAYS(pTab!=0) && HasRowid(pTab) ){
+       db->xUpdateCallback(db->pUpdateArg, SQLITE_DELETE, zDb, pTab->zName,
+           pC->movetoTarget);
+       assert( pC->iDb>=0 );
+@@ -6035,10 +6040,11 @@
+   rc = sqlite3BtreeLast(pCrsr, &res);
+   pC->nullRow = (u8)res;
+   pC->deferredMoveto = 0;
+   pC->cacheStatus = CACHE_STALE;
+   if( rc ) goto abort_due_to_error;
++  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
+   if( pOp->p2>0 ){
+     VdbeBranchTaken(res!=0,2);
+     if( res ) goto jump_to_p2;
+   }
+   break;
+@@ -6139,10 +6145,11 @@
+     pC->deferredMoveto = 0;
+     pC->cacheStatus = CACHE_STALE;
+   }
+   if( rc ) goto abort_due_to_error;
+   pC->nullRow = (u8)res;
++  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
+   assert( pOp->p2>0 && pOp->p2<p->nOp );
+   VdbeBranchTaken(res!=0,2);
+   if( res ) goto jump_to_p2;
+   break;
+ }
+@@ -6243,10 +6250,11 @@
+   pC->cacheStatus = CACHE_STALE;
+   VdbeBranchTaken(rc==SQLITE_OK,2);
+   if( rc==SQLITE_OK ){
+     pC->nullRow = 0;
+     p->aCounter[pOp->p5]++;
++    p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
+ #ifdef SQLITE_TEST
+     sqlite3_search_count++;
+ #endif
+     goto jump_to_p2_and_check_for_interrupt;
+   }
+@@ -6294,10 +6302,11 @@
+   assert( pC!=0 );
+   assert( !isSorter(pC) );
+   pIn2 = &aMem[pOp->p2];
+   assert( (pIn2->flags & MEM_Blob) || (pOp->p5 & OPFLAG_PREFORMAT) );
+   if( pOp->p5 & OPFLAG_NCHANGE ) p->nChange++;
++  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
+   assert( pC->eCurType==CURTYPE_BTREE );
+   assert( pC->isTable==0 );
+   rc = ExpandBlob(pIn2);
+   if( rc ) goto abort_due_to_error;
+   x.nKey = pIn2->n;
+@@ -6694,10 +6703,11 @@
+   assert( p->readOnly==0 );
+   assert( DbMaskTest(p->btreeMask, pOp->p2) );
+   rc = sqlite3BtreeClearTable(db->aDb[pOp->p2].pBt, (u32)pOp->p1, &nChange);
+   if( pOp->p3 ){
+     p->nChange += nChange;
++    p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE] += nChange;
+     if( pOp->p3>0 ){
+       assert( memIsValid(&aMem[pOp->p3]) );
+       memAboutToChange(p, &aMem[pOp->p3]);
+       aMem[pOp->p3].u.i += nChange;
+     }
+@@ -8176,10 +8186,11 @@
+   ** some other method is next invoked on the save virtual table cursor.
+   */
+   rc = pModule->xNext(pCur->uc.pVCur);
+   sqlite3VtabImportErrmsg(p, pVtab);
+   if( rc ) goto abort_due_to_error;
++  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
+   res = pModule->xEof(pCur->uc.pVCur);
+   VdbeBranchTaken(!res,2);
+   if( !res ){
+     /* If there is data, jump to P2 */
+     goto jump_to_p2_and_check_for_interrupt;
+@@ -8297,10 +8308,11 @@
+         rc = SQLITE_OK;
+       }else{
+         p->errorAction = ((pOp->p5==OE_Replace) ? OE_Abort : pOp->p5);
+       }
+     }else{
++      p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
+       p->nChange++;
+     }
+     if( rc ) goto abort_due_to_error;
+   }
+   break;
+diff -u5 -r sqlite-src-3400100-pristine/src/vdbeInt.h sqlite-src-3400100-modified/src/vdbeInt.h
+--- sqlite-src-3400100-pristine/src/vdbeInt.h	2022-12-28 06:26:33.000000000 -0800
++++ sqlite-src-3400100-modified/src/vdbeInt.h	2023-08-03 14:26:54.088987824 -0700
+@@ -468,10 +468,11 @@
+   bft readOnly:1;         /* True for statements that do not write */
+   bft bIsReader:1;        /* True for statements that read */
+   yDbMask btreeMask;      /* Bitmask of db->aDb[] entries referenced */
+   yDbMask lockMask;       /* Subset of btreeMask that requires a lock */
+   u32 aCounter[9];        /* Counters used by sqlite3_stmt_status() */
++  u32 aLibsqlCounter[3];  /* libSQL extension: Counters used by sqlite3_stmt_status()*/
+   char *zSql;             /* Text of the SQL statement that generated this */
+ #ifdef SQLITE_ENABLE_NORMALIZE
+   char *zNormSql;         /* Normalization of the associated SQL statement */
+   DblquoteStr *pDblStr;   /* List of double-quoted string literals */
+ #endif

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -31,6 +31,14 @@ double SqlStorage::getDatabaseSize() {
   return pages * getPageSize();
 }
 
+double SqlStorage::getRowsRead() {
+  return static_cast<double>(sqlite->getRowsRead());
+}
+
+double SqlStorage::getRowsWritten() {
+  return static_cast<double>(sqlite->getRowsWritten());
+}
+
 bool SqlStorage::isAllowedName(kj::StringPtr name) {
   return !name.startsWith("_cf_");
 }

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -28,12 +28,16 @@ public:
   jsg::Ref<Statement> prepare(jsg::Lock& js, kj::String query);
 
   double getDatabaseSize();
+  double getRowsRead();
+  double getRowsWritten();
 
   JSG_RESOURCE_TYPE(SqlStorage, CompatibilityFlags::Reader flags) {
     JSG_METHOD(exec);
     JSG_METHOD(prepare);
 
     JSG_READONLY_PROTOTYPE_PROPERTY(databaseSize, getDatabaseSize);
+    JSG_READONLY_PROTOTYPE_PROPERTY(rowsRead, getRowsRead);
+    JSG_READONLY_PROTOTYPE_PROPERTY(rowsWritten, getRowsWritten);
 
     JSG_NESTED_TYPE(Cursor);
     JSG_NESTED_TYPE(Statement);

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "sqlite.h"
+#include <cstdint>
 #include <kj/test.h>
 #include <kj/thread.h>
 #include <stdlib.h>
@@ -364,6 +365,266 @@ KJ_TEST("SQLite onWrite callback") {
   )");
   KJ_EXPECT(q.getInt(0) == 3);
   KJ_EXPECT(sawWrite);
+}
+
+struct RowCounts {
+  int64_t found;
+  int64_t read;
+  int64_t written;
+};
+
+template<typename ...Params>
+RowCounts countRowsTouched(SqliteDatabase& db, SqliteDatabase::Regulator& regulator, kj::StringPtr sqlCode, Params... bindParams) {
+  int64_t readBefore = db.getRowsRead();
+  int64_t writtenBefore = db.getRowsWritten();
+  int64_t rowsFound = 0;
+
+  // Runs a query; retrieves and discards all the data.
+  auto query = db.run(regulator, sqlCode, bindParams...);
+  while (!query.isDone()) {
+    rowsFound++;
+    query.nextRow();
+  }
+
+  return {.found = rowsFound,
+          .read = db.getRowsRead() - readBefore,
+          .written = db.getRowsWritten() - writtenBefore};
+}
+
+template<typename ...Params>
+RowCounts countRowsTouched(SqliteDatabase& db, kj::StringPtr sqlCode, Params... bindParams) {
+  return countRowsTouched(db, SqliteDatabase::TRUSTED, sqlCode, std::forward<Params>(bindParams)...);
+}
+
+KJ_TEST("SQLite read row counters (basic)") {
+  auto dir = kj::newInMemoryDirectory(kj::nullClock());
+  SqliteDatabase::Vfs vfs(*dir);
+  SqliteDatabase db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
+
+  db.run(R"(
+    CREATE TABLE things (
+      id INTEGER PRIMARY KEY,
+      unindexed_int INTEGER,
+      value TEXT
+    );
+  )");
+
+  constexpr int dbRowCount = 1000;
+  auto insertStmt = db.prepare("INSERT INTO things (id, unindexed_int, value) VALUES (?, ?, ?)");
+  for (int i = 0; i < dbRowCount; i++) {
+    insertStmt.run(i, i * 1000, kj::str("value", i));
+  }
+
+  // Sanity check that the inserts worked.
+  {
+    auto getCount = db.prepare("SELECT COUNT(*) FROM things");
+    KJ_EXPECT(getCount.run().getInt(0) == dbRowCount);
+  }
+
+  // Selecting all the rows reads all the rows.
+  {
+    RowCounts stats = countRowsTouched(db, "SELECT * FROM things");
+    KJ_EXPECT(stats.found == dbRowCount);
+    KJ_EXPECT(stats.read == dbRowCount);
+    KJ_EXPECT(stats.written == 0);
+  }
+
+  // Selecting one row using an index reads one row.
+  {
+    RowCounts stats = countRowsTouched(db,"SELECT * FROM things WHERE id=?", 5);
+    KJ_EXPECT(stats.found == 1);
+    KJ_EXPECT(stats.read == 1);
+    KJ_EXPECT(stats.written == 0);
+  }
+
+  // Selecting one row using an reads one row, even if that row is in the middle of the table.
+  {
+    RowCounts stats = countRowsTouched(db,"SELECT * FROM things WHERE id=?", dbRowCount / 2);
+    KJ_EXPECT(stats.found == 1);
+    KJ_EXPECT(stats.read == 1);
+    KJ_EXPECT(stats.written == 0);
+  }
+
+  // Selecting a row by an unindexed value reads the whole table.
+  {
+    RowCounts stats = countRowsTouched(db, "SELECT * FROM things WHERE unindexed_int = ?", 5000);
+    KJ_EXPECT(stats.found == 1);
+    KJ_EXPECT(stats.read == dbRowCount);
+    KJ_EXPECT(stats.written == 0);
+  }
+
+  // Selecting two rows with an IN clause reads four rows and writes two, apparently. XXX why?
+  {
+    RowCounts stats = countRowsTouched(db, "SELECT * FROM things WHERE id IN (2, 3)");
+    KJ_EXPECT(stats.read == 4);
+    KJ_EXPECT(stats.written == 2);
+  }
+
+  // Selecting an unindexed aggregate scans all the rows, which counts as reading them.
+  {
+    RowCounts stats = countRowsTouched(db, "SELECT MAX(unindexed_int) FROM things");
+    KJ_EXPECT(stats.found == 1);
+    KJ_EXPECT(stats.read == dbRowCount);
+    KJ_EXPECT(stats.written == 0);
+  }
+
+  // Selecting an indexed aggregate can use the index, so it only reads the row it found.
+  {
+    RowCounts stats = countRowsTouched(db, "SELECT MIN(id) FROM things");
+    KJ_EXPECT(stats.found == 1);
+    KJ_EXPECT(stats.read == 1);
+    KJ_EXPECT(stats.written == 0);
+  }
+
+  // Selecting with a limit only reads the returned rows.
+  {
+    RowCounts stats = countRowsTouched(db, "SELECT * FROM things LIMIT 5");
+    KJ_EXPECT(stats.found == 5);
+    KJ_EXPECT(stats.read == 5);
+    KJ_EXPECT(stats.written == 0);
+
+  }
+}
+
+KJ_TEST("SQLite write row counters (basic)") {
+  auto dir = kj::newInMemoryDirectory(kj::nullClock());
+  SqliteDatabase::Vfs vfs(*dir);
+  SqliteDatabase db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
+
+  db.run(R"(
+    CREATE TABLE things (
+      id INTEGER PRIMARY KEY
+    );
+  )");
+
+  db.run(R"(
+    CREATE TABLE unindexed_things (
+      id INTEGER
+    );
+  )");
+
+  // Inserting a row counts as one row written.
+  {
+    RowCounts stats = countRowsTouched(db, "INSERT INTO unindexed_things (id) VALUES (?)", 1);
+    KJ_EXPECT(stats.read == 0);
+    KJ_EXPECT(stats.written == 1);
+  }
+
+  // Inserting a row into a table with a primary key will also do a read (to ensure there's no
+  // duplicate PK).
+  {
+    RowCounts stats = countRowsTouched(db, "INSERT INTO things (id) VALUES (?)", 1);
+    KJ_EXPECT(stats.read == 1);
+    KJ_EXPECT(stats.written == 1);
+  }
+
+  // Deleting a row counts as a write.
+  {
+    RowCounts stats = countRowsTouched(db, "INSERT INTO things (id) VALUES (?)", 123);
+    KJ_EXPECT(stats.written == 1);
+
+    stats = countRowsTouched(db, "DELETE FROM things WHERE id=?", 123);
+    KJ_EXPECT(stats.read == 1);
+    KJ_EXPECT(stats.written == 1);
+  }
+
+  // Deleting nothing is not a write.
+  {
+    RowCounts stats = countRowsTouched(db, "DELETE FROM things WHERE id=?", 998877112233);
+    KJ_EXPECT(stats.written == 0);
+  }
+
+  // Inserting many things is many writes.
+  {
+    db.run("DELETE FROM things");
+    db.run("INSERT INTO things (id) VALUES (1)");
+    db.run("INSERT INTO things (id) VALUES (3)");
+    db.run("INSERT INTO things (id) VALUES (5)");
+
+    RowCounts stats = countRowsTouched(db, "INSERT INTO unindexed_things (id) SELECT id FROM things");
+    KJ_EXPECT(stats.read == 3);
+    KJ_EXPECT(stats.written == 3);
+  }
+
+  // Each updated row is a write.
+  {
+    db.run("DELETE FROM unindexed_things");
+    db.run("INSERT INTO unindexed_things (id) VALUES (1)");
+    db.run("INSERT INTO unindexed_things (id) VALUES (2)");
+    db.run("INSERT INTO unindexed_things (id) VALUES (3)");
+    db.run("INSERT INTO unindexed_things (id) VALUES (4)");
+
+    RowCounts stats = countRowsTouched(db, "UPDATE unindexed_things SET id = id * 10 WHERE id >= 3");
+    KJ_EXPECT(stats.written == 2);
+  }
+
+  // On an indexed table, each updated row is two writes. XXX why?
+  {
+    db.run("DELETE FROM things");
+    db.run("INSERT INTO things (id) VALUES (1)");
+    db.run("INSERT INTO things (id) VALUES (2)");
+    db.run("INSERT INTO things (id) VALUES (3)");
+    db.run("INSERT INTO things (id) VALUES (4)");
+
+    RowCounts stats = countRowsTouched(db, "UPDATE things SET id = id * 10 WHERE id >= 3");
+    KJ_EXPECT(stats.written == 4);
+  }
+}
+
+KJ_TEST("SQLite row counters with triggers") {
+  auto dir = kj::newInMemoryDirectory(kj::nullClock());
+  SqliteDatabase::Vfs vfs(*dir);
+  SqliteDatabase db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
+
+  class RegulatorImpl: public SqliteDatabase::Regulator {
+  public:
+    RegulatorImpl() = default;
+
+    bool isAllowedTrigger(kj::StringPtr name) override {
+      // SqliteDatabase::TRUSTED doesn't let us use triggers at all.
+      return true;
+    }
+  };
+
+  RegulatorImpl regulator;
+
+  db.run(R"(
+    CREATE TABLE things (
+      id INTEGER PRIMARY KEY
+    );
+
+    CREATE TABLE log (
+      id INTEGER,
+      verb TEXT
+    );
+
+    CREATE TRIGGER log_inserts AFTER INSERT ON things
+    BEGIN
+      insert into log (id, verb) VALUES (NEW.id, "INSERT");
+    END;
+
+    CREATE TRIGGER log_deletes AFTER DELETE ON things
+    BEGIN
+      insert into log (id, verb) VALUES (OLD.id, "DELETE");
+    END;
+  )");
+
+  // Each insert counts as two writes: one for the row in `things` and one for the row in `log`.
+  {
+    RowCounts stats = countRowsTouched(db, regulator, "INSERT INTO things (id) VALUES (1)");
+    KJ_EXPECT(stats.written == 2);
+  }
+
+  // A deletion counts as two writes: one for the row and one for the log.
+  {
+    db.run(regulator, "DELETE FROM things");
+    db.run(regulator, "INSERT INTO things (id) VALUES (1)");
+    db.run(regulator, "INSERT INTO things (id) VALUES (2)");
+    db.run(regulator, "INSERT INTO things (id) VALUES (3)");
+
+    RowCounts stats = countRowsTouched(db, regulator, "DELETE FROM things");
+    KJ_EXPECT(stats.written == 6);
+  }
 }
 
 }  // namespace

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -860,6 +860,8 @@ void SqliteDatabase::Query::nextRow() {
 
   int err = sqlite3_step(statement);
   if (err == SQLITE_DONE) {
+    db.addRowsRead(sqlite3_stmt_status(statement, LIBSQL_STMTSTATUS_ROWS_READ, 0));
+    db.addRowsWritten(sqlite3_stmt_status(statement, LIBSQL_STMTSTATUS_ROWS_WRITTEN, 0));
     done = true;
   } else if (err != SQLITE_ROW) {
     SQLITE_CALL_FAILED("sqlite3_step()", err);


### PR DESCRIPTION
In a durable object, `state.storage.sql` now has two new properties: `rowsRead` and `rowsWritten`. These count the number of rows read and written by the underlying SQLite database.

This is more than just the number of rows returned from queries or the number of records inserted/updated; it counts all rows read by the database engine in the processing of a query. For example, `SELECT MAX(unindexed_column) FROM a_table` returns a single result but reads every row from disk, and `rowsRead` reflects that.