### PR TITLE
fix reading from ended compression stream with high minBytes

### DIFF
--- a/src/workerd/api/streams/compression.c++
+++ b/src/workerd/api/streams/compression.c++
@@ -256,7 +256,9 @@ private:
     // If the output currently contains >= minBytes, then we'll fulfill
     // the read immediately, removing as many bytes as possible from the
     // output queue.
-    if (output.size() >= minBytes) {
+    // If we reached the end, resolve the read immediately as well, since no
+    // new data is expected.
+    if (output.size() >= minBytes || state.template is<Ended>()) {
       return copyIntoBuffer(dest);
     }
 


### PR DESCRIPTION
if the stream has already completed and output is too small the resulting promise will never get resolved.

I wasn't able to test this separately because we do not expose this functionality directly.

This is the actual underlying issue of #970