### PR TITLE
Github Actions fixes/cleanup

### DIFF
--- a/.github/workflows/npm-types.yml
+++ b/.github/workflows/npm-types.yml
@@ -56,10 +56,8 @@ jobs:
             bazel-disk-cache-types-${{ runner.os }}-
 
       - name: install dependencies
-        if: runner.os == 'Linux'
         run: |
             export DEBIAN_FRONTEND=noninteractive
-            sudo apt-get install -y build-essential git clang libc++-dev
       - name: build types
         run: |
             bazel build --disk_cache=~/bazel-disk-cache  --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev //types:types

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/bazel-disk-cache
-          key: bazel-disk-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
+          # Use a different cache key than for tests here, otherwise the release cache could end up
+          # being used for test builds, where it provides little benefit.
+          key: bazel-disk-cache-release-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
           restore-keys: |
             bazel-disk-cache-${{ runner.os }}-${{ runner.arch }}-
       - name: Setup Linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,6 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get install -y build-essential git lsb-release wget software-properties-common gnupg
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,10 @@ jobs:
         # limited.
         # libunwind, libc++abi1 and libc++1 should be automatically installed as dependencies of
         # libc++, but this appears to cause errors so they are also being explicitly installed.
+        # Since the GitHub runner image comes with a number of preinstalled packages, we don't need
+        # to use APT much otherwise.
         run: |
             export DEBIAN_FRONTEND=noninteractive
-            sudo apt-get install -y build-essential git lsb-release wget software-properties-common gnupg
             wget https://apt.llvm.org/llvm.sh
             chmod +x llvm.sh
             sudo ./llvm.sh 14


### PR DESCRIPTION
This includes some Github Actions CI cleanup and fixes an issue with the new disk cache approach implemented in #800.
- Simplify CI setup: The GitHub runner images have many packages installed already, which makes setup significantly easier.
- Use a split cache for CI test and release builds: In the previous cache overhaul a shared cache key was used, resulting in a release cache being used for test builds when a main branch release build finished before the test build. This made the cache less effective for test builds, which are more frequent and more expensive.

Another issue with the new cache setup is that when a stale cache is being used after there are build system changes and a new cache is subsequently generated, the new cache ends up being larger – bazel likely adds data based on the new build setup to the cache without evicting all of the old data. We could avoid this by not allowing stale caches to be reused, but that would also slow down some builds so let's evaluate it at a different time. For now, the size of a full cache set including split cache should be well below half of the 10GB limit based on recent improvements to the build process, so this change should still be safe.