### PR TITLE
Actor destroy method and custom event

### DIFF
--- a/src/workerd/api/actor-destroy.c++
+++ b/src/workerd/api/actor-destroy.c++
@@ -1,0 +1,55 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "actor-destroy.h"
+#include <workerd/api/global-scope.h>
+#include <workerd/jsg/ser.h>
+
+namespace workerd::api {
+
+ActorDestroyEvent::ActorDestroyEvent() : ExtendableEvent("actorDestroy"){};
+
+kj::Promise<WorkerInterface::CustomEvent::Result>
+ActorDestroyCustomEventImpl::run(kj::Own<IoContext::IncomingRequest> incomingRequest,
+                                 kj::Maybe<kj::StringPtr> entrypointName) {
+
+  auto& context = incomingRequest->getContext();
+
+  // Mark the request as delivered because we're about to run some JS.
+  incomingRequest->delivered();
+
+  EventOutcome outcome = EventOutcome::OK;
+
+  try {
+    co_return co_await context.run(
+        [entrypointName = entrypointName, &context](Worker::Lock& lock) mutable {
+          return lock.getGlobalScope().actorDestroy(
+              lock, lock.getExportedHandler(entrypointName, context.getActor()));
+        });
+  } catch (kj::Exception e) {
+    if (auto desc = e.getDescription();
+        !jsg::isTunneledException(desc) && !jsg::isDoNotLogException(desc)) {
+      LOG_EXCEPTION("ActorDestroyCustomEventImpl"_kj, e);
+    }
+    outcome = EventOutcome::EXCEPTION;
+  }
+
+  co_return Result{
+      .outcome = outcome,
+  };
+}
+
+kj::Promise<WorkerInterface::CustomEvent::Result> ActorDestroyCustomEventImpl::sendRpc(
+    capnp::HttpOverCapnpFactory& httpOverCapnpFactory, capnp::ByteStreamFactory& byteStreamFactory,
+    kj::TaskSet& waitUntilTasks, rpc::EventDispatcher::Client dispatcher) {
+  auto req = dispatcher.castAs<rpc::EventDispatcher>().actorDestroyRequest();
+
+  return req.send().then([](auto resp) {
+    return WorkerInterface::CustomEvent::Result{
+        .outcome = resp.getOutcome(),
+    };
+  });
+}
+
+} // namespace workerd::api

--- a/src/workerd/api/actor-destroy.h
+++ b/src/workerd/api/actor-destroy.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <kj/debug.h>
+
+#include <workerd/api/basics.h>
+#include <workerd/io/worker-interface.capnp.h>
+#include <workerd/io/worker-interface.h>
+
+namespace workerd::api {
+
+class ActorDestroyEvent final : public ExtendableEvent {
+public:
+  explicit ActorDestroyEvent();
+
+  static jsg::Ref<ActorDestroyEvent> constructor(kj::String type) = delete;
+
+  JSG_RESOURCE_TYPE(ActorDestroyEvent) {
+    JSG_INHERIT(ExtendableEvent);
+  }
+};
+
+class ActorDestroyCustomEventImpl final : public WorkerInterface::CustomEvent,
+                                          public kj::Refcounted {
+public:
+  ActorDestroyCustomEventImpl(uint16_t typeId) : typeId(typeId) {}
+
+  kj::Promise<Result> run(kj::Own<IoContext_IncomingRequest> incomingRequest,
+                          kj::Maybe<kj::StringPtr> entrypointName) override;
+
+  kj::Promise<Result> sendRpc(capnp::HttpOverCapnpFactory& httpOverCapnpFactory,
+                              capnp::ByteStreamFactory& byteStreamFactory,
+                              kj::TaskSet& waitUntilTasks,
+                              rpc::EventDispatcher::Client dispatcher) override;
+
+  uint16_t getType() override {
+    return typeId;
+  }
+
+private:
+  uint16_t typeId;
+};
+
+} // namespace workerd::api

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -170,11 +170,9 @@ public:
   // Creates a subnamespace with the jurisdiction hardcoded.
   jsg::Ref<DurableObjectNamespace> jurisdiction(kj::String jurisdiction);
 
-  kj::Promise<void> destroy(jsg::Ref<DurableObjectId> id);
-
   // Destroys the durable object identified with id in this namespace including all data associated
   // to it. This variation will get a durable object by ID if it already exists.
-  kj::Promise<void> destroy(jsg::Lock& js, jsg::Ref<DurableObjectId> id);
+  jsg::Promise<void> destroy(jsg::Lock& js, jsg::Ref<DurableObjectId> id);
 
   JSG_RESOURCE_TYPE(DurableObjectNamespace, CompatibilityFlags::Reader flags) {
     JSG_METHOD(newUniqueId);

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -29,9 +29,13 @@ public:
     : channel(channel) {}
 
   jsg::Ref<WorkerRpc> get(kj::String actorId);
+  jsg::Promise<void> destroy(jsg::Lock& js, kj::String actorId);
 
-  JSG_RESOURCE_TYPE(ColoLocalActorNamespace) {
+  JSG_RESOURCE_TYPE(ColoLocalActorNamespace, CompatibilityFlags::Reader flags) {
     JSG_METHOD(get);
+    if (flags.getDurableObjectDestroy()){
+      JSG_METHOD(destroy);
+    }
   }
 
 private:

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -170,6 +170,12 @@ public:
   // Creates a subnamespace with the jurisdiction hardcoded.
   jsg::Ref<DurableObjectNamespace> jurisdiction(kj::String jurisdiction);
 
+  kj::Promise<void> destroy(jsg::Ref<DurableObjectId> id);
+
+  // Destroys the durable object identified with id in this namespace including all data associated
+  // to it. This variation will get a durable object by ID if it already exists.
+  kj::Promise<void> destroy(jsg::Lock& js, jsg::Ref<DurableObjectId> id);
+
   JSG_RESOURCE_TYPE(DurableObjectNamespace, CompatibilityFlags::Reader flags) {
     JSG_METHOD(newUniqueId);
     JSG_METHOD(idFromName);
@@ -179,6 +185,13 @@ public:
       JSG_METHOD(getExisting);
     }
     JSG_METHOD(jurisdiction);
+    if (flags.getDurableObjectDestroy()){
+      // We're only interested in supporting actors that have getExisting enabled. Any other
+      // actors should not have access to this method.
+      if (flags.getDurableObjectGetExisting()) {
+        JSG_METHOD(destroy);
+      }
+    }
 
     JSG_TS_ROOT();
     JSG_TS_OVERRIDE({
@@ -195,6 +208,8 @@ private:
       ActorGetMode mode,
       jsg::Ref<DurableObjectId> id,
       jsg::Optional<GetDurableObjectOptions> options);
+
+  kj::Promise<void> destroyImpl(jsg::Ref<DurableObjectId> id, ActorGetMode mode);
 };
 
 #define EW_ACTOR_ISOLATE_TYPES                      \

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -215,10 +215,14 @@ struct ExportedHandler {
   typedef kj::Promise<void> HibernatableWebSocketErrorHandler(jsg::Ref<WebSocket>, jsg::Value);
   jsg::LenientOptional<jsg::Function<HibernatableWebSocketErrorHandler>> webSocketError;
 
+  typedef jsg::Promise<void> ActorDestroyHandler();
+  jsg::LenientOptional<jsg::Function<ActorDestroyHandler>> destroy;
+
   // Self-ref potentially allows extracting other custom handlers from the object.
   jsg::SelfRef self;
 
-  JSG_STRUCT(fetch, tail, trace, scheduled, alarm, test, webSocketMessage, webSocketClose, webSocketError, self);
+  JSG_STRUCT(fetch, tail, trace, scheduled, alarm, test, webSocketMessage, webSocketClose,
+             webSocketError, destroy, self);
 
   JSG_STRUCT_TS_ROOT();
   // ExportedHandler isn't included in the global scope, but we still want to
@@ -243,6 +247,7 @@ struct ExportedHandler {
     webSocketClose: never;
     webSocketError: never;
     queue?: ExportedHandlerQueueHandler<Env, QueueHandlerMessage>;
+    destroy: never;
     test?: ExportedHandlerTestHandler<Env>;
   });
   // Make `env` parameter generic
@@ -329,6 +334,9 @@ public:
       kj::String websocketId,
       Worker::Lock& lock,
       kj::Maybe<ExportedHandler&> exportedHandler);
+
+  kj::Promise<WorkerInterface::CustomEvent::Result>
+  actorDestroy(Worker::Lock& lock, kj::Maybe<ExportedHandler&> exportedHandler);
 
   void emitPromiseRejection(
       jsg::Lock& js,

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -147,7 +147,8 @@ private:
         name == "alarm" ||
         name == "webSocketMessage" ||
         name == "webSocketClose" ||
-        name == "webSocketError") {
+        name == "webSocketError" ||
+        name == "destroy") {
       return true;
     }
     return false;

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -367,4 +367,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatDisableFlag("global_importscripts")
       $compatEnableDate("2024-03-04");
   # Removes the non-implemented importScripts() function from the global scope.
+
+  durableObjectDestroy @41 :Bool
+    $compatEnableFlag("durable_object_destroy")
+    $experimental;
+  # Enables namespace.destroy(id) durable object experimental API.
 }

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -226,6 +226,9 @@ interface EventDispatcher @0xf20697475ec1752d {
   # We use customEvent() to dispatch this event.
   # In the future, we can add an argument to pass a capability to the server.
 
+  actorDestroy @10 () -> (outcome :EventOutcome);
+  # Runs the actor destroy event.
+
   obsolete5 @5();
   obsolete6 @6();
   obsolete7 @7();


### PR DESCRIPTION
This PR lays the groundwork for DO deletion. 
Adds a new `destroy` method to Actor Namespace hooked into actor `IoChannelFactory`. 
Adds a new `ActorDestroy` custom event and `destroy` handler.