### PR TITLE
JSG Completion: Use new js.withinHandleScope utility in actor-state

### DIFF
--- a/src/workerd/api/actor-state-test.c++
+++ b/src/workerd/api/actor-state-test.c++
@@ -35,29 +35,29 @@ KJ_TEST("v8 serialization version tag hasn't changed") {
   ActorStateIsolate &actorStateIsolate = e.getIsolate();
   jsg::V8StackScope stackScope;
   ActorStateIsolate::Lock isolateLock(actorStateIsolate, stackScope);
-  auto* isolate = isolateLock.v8Isolate;
-  v8::HandleScope handleScope(isolate);
-  auto v8Context = isolateLock.newContext<ActorStateContext>().getHandle(isolate);
-  v8::Context::Scope contextScope(v8Context);
+  isolateLock.withinHandleScope([&] {
+    auto v8Context = isolateLock.newContext<ActorStateContext>().getHandle(isolateLock.v8Isolate);
+    auto contextScope = isolateLock.enterContextScope(v8Context);
 
-  auto trueVal = v8::True(isolate);
-  auto buf = serializeV8Value(isolateLock, trueVal);
+    auto trueVal = v8::True(isolateLock.v8Isolate);
+    auto buf = serializeV8Value(isolateLock, trueVal);
 
-  // Confirm that a version header is appropriately written and that it contains the expected
-  // current version. When the version increases, we need to write a v8 patch that allows it to
-  // continue writing data at the old version so that we can do a rolling upgrade without any bugs
-  // caused by old processes failing to read data written by new ones.
-  KJ_EXPECT(buf[0] == 0xFF);
-  KJ_EXPECT(buf[1] == 0x0F); // v8 serializer version
+    // Confirm that a version header is appropriately written and that it contains the expected
+    // current version. When the version increases, we need to write a v8 patch that allows it to
+    // continue writing data at the old version so that we can do a rolling upgrade without any bugs
+    // caused by old processes failing to read data written by new ones.
+    KJ_EXPECT(buf[0] == 0xFF);
+    KJ_EXPECT(buf[1] == 0x0F); // v8 serializer version
 
-  // And this just confirms that the deserializer agrees on the version.
-  v8::ValueDeserializer deserializer(isolate, buf.begin(), buf.size());
-  auto maybeHeader = deserializer.ReadHeader(isolate->GetCurrentContext());
-  KJ_EXPECT(jsg::check(maybeHeader));
-  KJ_EXPECT(deserializer.GetWireFormatVersion() == 15);
+    // And this just confirms that the deserializer agrees on the version.
+    v8::ValueDeserializer deserializer(isolateLock.v8Isolate, buf.begin(), buf.size());
+    auto maybeHeader = deserializer.ReadHeader(isolateLock.v8Context());
+    KJ_EXPECT(jsg::check(maybeHeader));
+    KJ_EXPECT(deserializer.GetWireFormatVersion() == 15);
 
-  // Just for kicks, make sure it deserializes properly too.
-  KJ_EXPECT(deserializeV8Value(isolateLock, "some-key"_kj, buf)->IsTrue());
+    // Just for kicks, make sure it deserializes properly too.
+    KJ_EXPECT(deserializeV8Value(isolateLock, "some-key"_kj, buf)->IsTrue());
+  });
 }
 
 KJ_TEST("we support deserializing up to v15") {
@@ -65,21 +65,21 @@ KJ_TEST("we support deserializing up to v15") {
   ActorStateIsolate &actorStateIsolate = e.getIsolate();
   jsg::V8StackScope stackScope;
   ActorStateIsolate::Lock isolateLock(actorStateIsolate, stackScope);
-  auto* isolate = isolateLock.v8Isolate;
-  v8::HandleScope handleScope(isolate);
-  auto v8Context = isolateLock.newContext<ActorStateContext>().getHandle(isolate);
-  v8::Context::Scope contextScope(v8Context);
+  isolateLock.withinHandleScope([&] {
+    auto v8Context = isolateLock.newContext<ActorStateContext>().getHandle(isolateLock.v8Isolate);
+    auto contextScope = isolateLock.enterContextScope(v8Context);
 
-  kj::Vector<kj::StringPtr> testCases;
-  testCases.add("54");
-  testCases.add("FF0D54");
-  testCases.add("FF0E54");
-  testCases.add("FF0F54");
+    kj::Vector<kj::StringPtr> testCases;
+    testCases.add("54");
+    testCases.add("FF0D54");
+    testCases.add("FF0E54");
+    testCases.add("FF0F54");
 
-  for (const auto& hexStr : testCases) {
-    auto dataIn = kj::decodeHex(hexStr.asArray());
-		KJ_EXPECT(deserializeV8Value(isolateLock, "some-key"_kj, dataIn)->IsTrue());
-  }
+    for (const auto& hexStr : testCases) {
+      auto dataIn = kj::decodeHex(hexStr.asArray());
+      KJ_EXPECT(deserializeV8Value(isolateLock, "some-key"_kj, dataIn)->IsTrue());
+    }
+  });
 }
 
 // This is hacky, but we want to compare the old deserialization logic that's been in prod from when
@@ -114,26 +114,26 @@ KJ_TEST("wire format version does not change deserialization behavior on real da
   ActorStateIsolate &actorStateIsolate = e.getIsolate();
   jsg::V8StackScope stackScope;
   ActorStateIsolate::Lock isolateLock(actorStateIsolate, stackScope);
-  auto* isolate = isolateLock.v8Isolate;
-  v8::HandleScope handleScope(isolate);
-  auto v8Context = isolateLock.newContext<ActorStateContext>().getHandle(isolate);
-  v8::Context::Scope contextScope(v8Context);
+  isolateLock.withinHandleScope([&] {
+    auto v8Context = isolateLock.newContext<ActorStateContext>().getHandle(isolateLock.v8Isolate);
+    auto contextScope = isolateLock.enterContextScope(v8Context);
 
-  // Read in data line by line and verify that it round trips (serializes and then deserializes)
-  // back to the exact same data as the input.
-  std::string hexStr;
-  const auto key = "some-key"_kj;
-  while (std::getline(file, hexStr)) {
-    auto dataIn = kj::decodeHex(kj::ArrayPtr(hexStr.c_str(), hexStr.size()));
-    KJ_EXPECT(!dataIn.hadErrors, hexStr);
+    // Read in data line by line and verify that it round trips (serializes and then deserializes)
+    // back to the exact same data as the input.
+    std::string hexStr;
+    const auto key = "some-key"_kj;
+    while (std::getline(file, hexStr)) {
+      auto dataIn = kj::decodeHex(kj::ArrayPtr(hexStr.c_str(), hexStr.size()));
+      KJ_EXPECT(!dataIn.hadErrors, hexStr);
 
-    auto oldVal = oldDeserializeV8Value(isolateLock, key, dataIn);
-    auto oldOutput = serializeV8Value(isolateLock, oldVal);
+      auto oldVal = oldDeserializeV8Value(isolateLock, key, dataIn);
+      auto oldOutput = serializeV8Value(isolateLock, oldVal);
 
-    auto newVal = deserializeV8Value(isolateLock, key, dataIn);
-    auto newOutput = serializeV8Value(isolateLock, newVal);
-    KJ_EXPECT(oldOutput == newOutput, hexStr);
-  }
+      auto newVal = deserializeV8Value(isolateLock, key, dataIn);
+      auto newOutput = serializeV8Value(isolateLock, newVal);
+      KJ_EXPECT(oldOutput == newOutput, hexStr);
+    }
+  });
 }
 
 }  // namespace

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -244,9 +244,11 @@ kj::StringPtr Lock::getUuid() const {
 }
 
 Lock::ContextScope Lock::enterContextScope(kj::Maybe<v8::Local<v8::Context>> maybeContext) {
-  v8::Local<v8::Context> context = v8Context();
+  v8::Local<v8::Context> context;
   KJ_IF_MAYBE(c, maybeContext) {
     context = *c;
+  } else {
+    context = v8Context();
   }
   KJ_ASSERT(!context.IsEmpty(), "unable to enter invalid v8::Context");
   return ContextScope(context);


### PR DESCRIPTION
Start conversion of v8::HandleScope uses over to new jsg utility