### PR TITLE
JSG Completion: Convert some direct uses of v8::HandleScope to new utility

### DIFF
--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -81,12 +81,13 @@ SqlStorage::Cursor::~Cursor() noexcept(false) {
 void SqlStorage::Cursor::CachedColumnNames::ensureInitialized(
     jsg::Lock& js, SqliteDatabase::Query& source) {
   if (names == nullptr) {
-    v8::HandleScope scope(js.v8Isolate);
-    auto builder = kj::heapArrayBuilder<jsg::V8Ref<v8::String>>(source.columnCount());
-    for (auto i: kj::zeroTo(builder.capacity())) {
-      builder.add(js.v8Isolate, jsg::v8StrIntern(js.v8Isolate, source.getColumnName(i)));
-    }
-    names = builder.finish();
+    js.withinHandleScope([&] {
+      auto builder = kj::heapArrayBuilder<jsg::V8Ref<v8::String>>(source.columnCount());
+      for (auto i: kj::zeroTo(builder.capacity())) {
+        builder.add(js.v8Isolate, jsg::v8StrIntern(js.v8Isolate, source.getColumnName(i)));
+      }
+      names = builder.finish();
+    });
   }
 }
 


### PR DESCRIPTION
Use js.withinHandleScope to replace a number of direct uses of v8::HandleScope. There are more to do but it touches a lot of files and I prefer to make the changes incrementally.