### PR TITLE
Allow `Fetcher#queue()` to accept V8 serialised bodies

### DIFF
--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -461,11 +461,17 @@ public:
     // worker via a service binding.
     kj::String id;
     kj::Date timestamp;
-    jsg::Value body;
-    JSG_STRUCT(id, timestamp, body);
-    JSG_STRUCT_TS_OVERRIDE(ServiceBindingQueueMessage<Body = unknown> {
-      body: Body;
-    });
+    jsg::Optional<jsg::Value> body;
+    jsg::Optional<kj::Array<kj::byte>> serializedBody;
+
+    JSG_STRUCT(id, timestamp, body, serializedBody);
+    JSG_STRUCT_TS_OVERRIDE(type ServiceBindingQueueMessage<Body = unknown> = {
+      id: string;
+      timestamp: Date;
+    } & (
+      | { body: Body }
+      | { serializedBody: ArrayBuffer | ArrayBufferView }
+    ));
   };
 
   struct QueueResult {

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -292,6 +292,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $experimental;
   # Allows service bindings to call additional event handler methods on the target Worker.
   # Initially only includes support for calling the queue() handler.
+  # WARNING: this flag exposes the V8 deserialiser to users via `Fetcher#queue()` `serializedBody`.
+  # Historically, this has required a trusted environment to be safe. If we decide to make this
+  # flag non-experimental, we must ensure we take appropriate precuations.
 
   noCfBotManagementDefault @29 :Bool
       $compatEnableFlag("no_cf_botmanagement_default")


### PR DESCRIPTION
Hey! 👋 This PR adds support for passing V8 serialised bodies (as received from `queue` producer bindings), to `Fetcher#queue()` for dispatch to user `queue` event handlers. This is a stop-gap solution until we implement an in-memory message dispatcher within `workerd` itself. Note this change exposes the V8 deserialiser to users. This function is gated behind the experimental `service_binding_extra_handlers` compatibility flag though.