### PR TITLE
Roll deps

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -119,18 +119,19 @@ git_repository(
 #   that ABSL_ATTRIBUTE_PURE_FUNCTION is not defined.
 http_archive(
     name = "com_google_absl",
-    sha256 = "d5c91248c33269fcc7ab35897315a45cfa2c37abb4c6d4ed36cb5c82f366367a",
-    strip_prefix = "abseil-cpp-b3162b1da62711c663d0025e2eabeb83fd1f2728",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/b3162b1da62711c663d0025e2eabeb83fd1f2728.zip"],
+    sha256 = "3a889795d4dede1094572d98a3a85e9484573a83282a72a6491eae853af07d08",
+    strip_prefix = "abseil-abseil-cpp-861e53c",
+    type = "tgz",
+    url = "https://github.com/abseil/abseil-cpp/tarball/861e53c8f075c8c4d67bd4c82217c57239fc97cf",
 )
 
 # tcmalloc requires this "rules_fuzzing" package. Its build files fail analysis without it, even
 # though it is unused for our purposes.
 http_archive(
     name = "rules_fuzzing",
-    sha256 = "a5734cb42b1b69395c57e0bbd32ade394d5c3d6afbfe782b24816a96da24660d",
+    sha256 = "bc286c36bf40c5447d8e4ee047f471c934fe99d4acba0de7a866f38d2ea83a21",
     strip_prefix = "rules_fuzzing-0.1.1",
-    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.1.1.zip"],
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.1.1.tar.gz"],
 )
 
 load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
@@ -294,13 +295,12 @@ npm_repositories()
 # It would seem that googlesource would rather we use git protocol (ideally with shallow clones).
 # Fine, we can do that.
 #
-# Note that while there is an official mirror of V8 on GitHub, there do not appear to be
-# mirrors of the dependencies: zlib (Chromium fork), icu (Chromium fork), and trace_event. So
-# fetching from GitHub instead wouldn't really solve the problem.
+# There is an official mirror for V8 itself on GitHub, but not for dependencies like zlib (Chromium
+# fork), icu (Chromium fork), and trace_event, so we still have to use git for them.
 
-git_repository(
+http_archive(
     name = "v8",
-    commit = "578812b037096e4026447ee449786b60333b00d3",
+    sha256 = "b2e61fb39cdb6ea25ec0a9bef83717354a9020cdaf7f77e3210f2574d791c4b7",
     patch_args = ["-p1"],
     patches = [
         "//:patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch",
@@ -316,8 +316,9 @@ git_repository(
         "//:patches/v8/0011-Enable-V8-shared-linkage.patch",
         "//:patches/v8/0012-Fix-ICU-build.patch",
     ],
-    remote = "https://chromium.googlesource.com/v8/v8.git",
-    shallow_since = "1690276460 +0000",
+    strip_prefix = "v8-v8-97c6f93",
+    type = "tgz",
+    url = "https://github.com/v8/v8/tarball/97c6f935aa8ec6b786f7ff7726f86785316f30d0",
 )
 
 new_git_repository(

--- a/rust-deps/crates/BUILD.bitflags-2.4.0.bazel
+++ b/rust-deps/crates/BUILD.bitflags-2.4.0.bazel
@@ -38,5 +38,5 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "2.3.3",
+    version = "2.4.0",
 )

--- a/rust-deps/crates/BUILD.cc-1.0.82.bazel
+++ b/rust-deps/crates/BUILD.cc-1.0.82.bazel
@@ -38,5 +38,20 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.79",
+    version = "1.0.82",
+    deps = select({
+        "@rules_rust//rust/platform:aarch64-apple-darwin": [
+            "@crates_vendor__libc-0.2.147//:libc",  # cfg(unix)
+        ],
+        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": [
+            "@crates_vendor__libc-0.2.147//:libc",  # cfg(unix)
+        ],
+        "@rules_rust//rust/platform:x86_64-apple-darwin": [
+            "@crates_vendor__libc-0.2.147//:libc",  # cfg(unix)
+        ],
+        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": [
+            "@crates_vendor__libc-0.2.147//:libc",  # cfg(unix)
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/rust-deps/crates/BUILD.log-0.4.20.bazel
+++ b/rust-deps/crates/BUILD.log-0.4.20.bazel
@@ -38,5 +38,5 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "0.4.19",
+    version = "0.4.20",
 )

--- a/rust-deps/crates/BUILD.lol_html-1.1.1.bazel
+++ b/rust-deps/crates/BUILD.lol_html-1.1.1.bazel
@@ -40,7 +40,7 @@ rust_library(
     ],
     version = "1.1.1",
     deps = [
-        "@crates_vendor__bitflags-2.3.3//:bitflags",
+        "@crates_vendor__bitflags-2.4.0//:bitflags",
         "@crates_vendor__cfg-if-1.0.0//:cfg_if",
         "@crates_vendor__cssparser-0.27.2//:cssparser",
         "@crates_vendor__encoding_rs-0.8.32//:encoding_rs",

--- a/rust-deps/crates/BUILD.selectors-0.22.0.bazel
+++ b/rust-deps/crates/BUILD.selectors-0.22.0.bazel
@@ -47,7 +47,7 @@ rust_library(
         "@crates_vendor__bitflags-1.3.2//:bitflags",
         "@crates_vendor__cssparser-0.27.2//:cssparser",
         "@crates_vendor__fxhash-0.2.1//:fxhash",
-        "@crates_vendor__log-0.4.19//:log",
+        "@crates_vendor__log-0.4.20//:log",
         "@crates_vendor__matches-0.1.10//:matches",
         "@crates_vendor__phf-0.8.0//:phf",
         "@crates_vendor__precomputed-hash-0.1.1//:precomputed_hash",

--- a/rust-deps/crates/defs.bzl
+++ b/rust-deps/crates/defs.bzl
@@ -421,12 +421,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__bitflags-2.3.3",
-        sha256 = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42",
+        name = "crates_vendor__bitflags-2.4.0",
+        sha256 = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/bitflags/2.3.3/download"],
-        strip_prefix = "bitflags-2.3.3",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.bitflags-2.3.3.bazel"),
+        urls = ["https://crates.io/api/v1/crates/bitflags/2.4.0/download"],
+        strip_prefix = "bitflags-2.4.0",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.bitflags-2.4.0.bazel"),
     )
 
     maybe(
@@ -441,12 +441,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__cc-1.0.79",
-        sha256 = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f",
+        name = "crates_vendor__cc-1.0.82",
+        sha256 = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/cc/1.0.79/download"],
-        strip_prefix = "cc-1.0.79",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.cc-1.0.79.bazel"),
+        urls = ["https://crates.io/api/v1/crates/cc/1.0.82/download"],
+        strip_prefix = "cc-1.0.82",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.cc-1.0.82.bazel"),
     )
 
     maybe(
@@ -641,12 +641,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__log-0.4.19",
-        sha256 = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
+        name = "crates_vendor__log-0.4.20",
+        sha256 = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/log/0.4.19/download"],
-        strip_prefix = "log-0.4.19",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.log-0.4.19.bazel"),
+        urls = ["https://crates.io/api/v1/crates/log/0.4.20/download"],
+        strip_prefix = "log-0.4.20",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.log-0.4.20.bazel"),
     )
 
     maybe(

--- a/rust-deps/packages.bzl
+++ b/rust-deps/packages.bzl
@@ -3,24 +3,22 @@ load("@rules_rust//crate_universe:defs.bzl", "crate")
 RTTI_PACKAGES = {
     # Crates used for RTTI parameter extraction
     "anyhow": crate.spec(
-        features = ["default"],
         version = "1",
     ),
     "clang-ast": crate.spec(
         version = "0.1",
     ),
     "flate2": crate.spec(
-        version = "1.0.26",
+        version = "1.0",
     ),
     "serde": crate.spec(
         # TODO: Restore to "1.0" when https://github.com/bazelbuild/rules_rust/issues/2071
         # is resolved
         version = "=1.0.171",
-        features = ["default", "derive"],
+        features = ["derive"],
     ),
     "serde_json": crate.spec(
         version = "1.0",
-        features = ["default"],
     ),
     "pico-args": crate.spec(
         version = "0.5",


### PR DESCRIPTION
Changes:
- Update abseil
- Update V8 11.6.189.14 => 11.6.189.18
- Fetch V8 and rules_fuzzing as tar.gz dependencies, tar.gz is generally smaller than zip and in the case of V8 HTTP downloads are cached better by bazel than git repositories.
- Simplify rust-deps packages.bzl, default features do not need to be specified.
- Update various rust crates.