### PR TITLE
Implement jsg::JsValue and related types

### DIFF
--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -1480,7 +1480,7 @@ bool WritableStreamInternalController::Pipe::checkSignal(jsg::Lock& js) {
       auto reason = (*signal)->getReason(js);
       if (!preventAbort) {
         KJ_IF_MAYBE(writable, parent.state.tryGet<Writable>()) {
-          parent.state.get<Writable>()->abort(js.exceptionToKj(js.v8Ref(reason)));
+          parent.state.get<Writable>()->abort(js.exceptionToKj(reason));
           parent.drain(js, reason);
         } else {
           parent.writeState.init<Unlocked>();
@@ -1489,7 +1489,7 @@ bool WritableStreamInternalController::Pipe::checkSignal(jsg::Lock& js) {
         parent.writeState.init<Unlocked>();
       }
       if (!preventCancel) {
-        source.release(js, reason);
+        source.release(js, v8::Local<v8::Value>(reason));
       } else {
         source.release(js);
       }

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -419,13 +419,13 @@ kj::Maybe<jsg::Promise<void>> WritableLockImpl<Controller>::PipeLocked::checkSig
     if ((*signal)->getAborted()) {
       auto reason = (*signal)->getReason(js);
       if (!preventCancel) {
-        source.release(js, reason);
+        source.release(js, v8::Local<v8::Value>(reason));
       } else {
         source.release(js);
       }
       if (!preventAbort) {
         return self.abort(js, reason).then(js,
-            JSG_VISITABLE_LAMBDA((this, reason = js.v8Ref(reason), ref = self.addRef()),
+            JSG_VISITABLE_LAMBDA((this, reason = reason.addRef(js), ref = self.addRef()),
                                  (reason, ref), (jsg::Lock& js) {
           return rejectedMaybeHandledPromise<void>(
               js,
@@ -1071,7 +1071,7 @@ jsg::Promise<void> WritableImpl<Self>::abort(
     jsg::Lock& js,
     jsg::Ref<Self> self,
     v8::Local<v8::Value> reason) {
-  signal->triggerAbort(js, reason);
+  signal->triggerAbort(js, jsg::JsValue(reason));
 
   // We have to check this again after the AbortSignal is triggered.
   if (state.template is<StreamStates::Closed>() || state.template is<StreamStates::Errored>()) {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1770,6 +1770,40 @@ template <typename T>
 constexpr bool isV8MaybeLocal() { return isV8MaybeLocal((T*)nullptr); }
 
 class AsyncContextFrame;
+template <typename T> class JsRef;
+
+#define JS_V8_SYMBOLS(V) \
+  V(AsyncIterator) \
+  V(HasInstance) \
+  V(IsConcatSpreadable) \
+  V(Iterator) \
+  V(Match) \
+  V(Replace) \
+  V(Search) \
+  V(Split) \
+  V(ToPrimitive) \
+  V(ToStringTag) \
+  V(Unscopables)
+
+class JsValue;
+#define JS_TYPE_CLASSES(V) \
+  V(Object) \
+  V(Boolean) \
+  V(Array) \
+  V(String) \
+  V(Symbol) \
+  V(BigInt) \
+  V(Number) \
+  V(Int32) \
+  V(Uint32) \
+  V(Date) \
+  V(RegExp) \
+  V(Map) \
+  V(Set)
+
+#define V(Name) class Js##Name;
+  JS_TYPE_CLASSES(V)
+#undef V
 
 class Lock {
   // Represents an isolate lock, which allows the current thread to execute JavaScript code within
@@ -2063,6 +2097,71 @@ public:
   ContextScope enterContextScope(v8::Local<v8::Context> context);
   // Ensures that we are currently within the scope of the given v8::Context
 
+  // ====================================================================================
+  JsValue undefined() KJ_WARN_UNUSED_RESULT;
+  JsValue null() KJ_WARN_UNUSED_RESULT;
+  JsBoolean boolean(bool val) KJ_WARN_UNUSED_RESULT;
+  JsNumber num(double) KJ_WARN_UNUSED_RESULT;
+  JsNumber num(float) KJ_WARN_UNUSED_RESULT;
+  JsInt32 num(int8_t) KJ_WARN_UNUSED_RESULT;
+  JsInt32 num(int16_t) KJ_WARN_UNUSED_RESULT;
+  JsInt32 num(int32_t) KJ_WARN_UNUSED_RESULT;
+  JsUint32 num(uint8_t) KJ_WARN_UNUSED_RESULT;
+  JsUint32 num(uint16_t) KJ_WARN_UNUSED_RESULT;
+  JsUint32 num(uint32_t) KJ_WARN_UNUSED_RESULT;
+  JsBigInt bigInt(int64_t) KJ_WARN_UNUSED_RESULT;
+  JsBigInt bigInt(uint64_t) KJ_WARN_UNUSED_RESULT;
+  JsString str() KJ_WARN_UNUSED_RESULT;
+  JsString str(kj::ArrayPtr<const char16_t>) KJ_WARN_UNUSED_RESULT;
+  JsString str(kj::ArrayPtr<const uint16_t>) KJ_WARN_UNUSED_RESULT;
+  JsString str(kj::ArrayPtr<const char>) KJ_WARN_UNUSED_RESULT;
+  JsString str(kj::ArrayPtr<const kj::byte>) KJ_WARN_UNUSED_RESULT;
+  JsString strIntern(kj::StringPtr) KJ_WARN_UNUSED_RESULT;
+  JsString strExtern(kj::ArrayPtr<const char>) KJ_WARN_UNUSED_RESULT;
+  JsString strExtern(kj::ArrayPtr<const uint16_t>) KJ_WARN_UNUSED_RESULT;
+  JsSymbol symbol(kj::StringPtr) KJ_WARN_UNUSED_RESULT;
+  JsSymbol symbolShared(kj::StringPtr) KJ_WARN_UNUSED_RESULT;
+  JsSymbol symbolInternal(kj::StringPtr) KJ_WARN_UNUSED_RESULT;
+  JsObject obj() KJ_WARN_UNUSED_RESULT;
+  JsObject map() KJ_WARN_UNUSED_RESULT;
+  JsValue external(void*) KJ_WARN_UNUSED_RESULT;
+  JsValue error(kj::StringPtr message) KJ_WARN_UNUSED_RESULT;
+  JsValue typeError(kj::StringPtr message) KJ_WARN_UNUSED_RESULT;
+  JsValue rangeError(kj::StringPtr message) KJ_WARN_UNUSED_RESULT;
+  JsDate date(double timestamp) KJ_WARN_UNUSED_RESULT;
+  JsDate date(kj::Date date) KJ_WARN_UNUSED_RESULT;
+  JsDate date(kj::StringPtr date) KJ_WARN_UNUSED_RESULT;
+
+  BufferSource bytes(kj::Array<kj::byte> data) KJ_WARN_UNUSED_RESULT;
+
+  enum RegExpFlags {
+    kNONE = v8::RegExp::Flags::kNone,
+    kGLOBAL = v8::RegExp::Flags::kGlobal,
+    kIGNORE_CASE = v8::RegExp::Flags::kIgnoreCase,
+    kMULTILINE = v8::RegExp::Flags::kMultiline,
+    kSTICKY = v8::RegExp::Flags::kSticky,
+    kUNICODE = v8::RegExp::Flags::kUnicode,
+    kDOTALL = v8::RegExp::Flags::kDotAll,
+    kLINEAR = v8::RegExp::Flags::kLinear,
+    kHAS_INDICES = v8::RegExp::Flags::kHasIndices,
+    kUNICODE_SETS = v8::RegExp::Flags::kUnicodeSets,
+  };
+
+  JsRegExp regexp(kj::StringPtr pattern,
+                  RegExpFlags flags = RegExpFlags::kNONE,
+                  kj::Maybe<uint32_t> backtrackLimit = nullptr)
+                  KJ_WARN_UNUSED_RESULT;
+
+  template <typename...Args> requires (std::assignable_from<JsValue&, Args> && ...)
+  JsArray arr(const Args&...args) KJ_WARN_UNUSED_RESULT;
+
+  template <typename...Args> requires (std::assignable_from<JsValue&, Args> && ...)
+  JsSet set(const Args&...args) KJ_WARN_UNUSED_RESULT;
+
+#define V(Name) JsSymbol symbol##Name() KJ_WARN_UNUSED_RESULT;
+  JS_V8_SYMBOLS(V)
+#undef V
+
 private:
   friend class IsolateBase;
   template <typename TypeWrapper>
@@ -2177,6 +2276,7 @@ inline v8::Local<v8::Context> JsContext<T>::getHandle(Lock& js) {
 }  // namespace workerd::jsg
 
 // These two includes are needed for the JSG type glue macros to work.
+#include "buffersource.h"
 #include "modules.h"
 #include "resource.h"
 #include "dom-exception.h"
@@ -2184,3 +2284,4 @@ inline v8::Local<v8::Context> JsContext<T>::getHandle(Lock& js) {
 #include "promise.h"
 #include "function.h"
 #include "iterator.h"
+#include "jsvalue.h"

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1867,6 +1867,10 @@ public:
   // as an internal error: the KJ exception message is logged to stderr, and a JavaScript error
   // is returned with a generic description.
 
+  JsRef<JsValue> exceptionToJsValue(kj::Exception&& exception);
+
+  kj::Exception exceptionToKj(const JsValue& exception);
+
   kj::Exception exceptionToKj(Value&& exception);
   // Encodes the given JavaScript exception into a KJ exception, formatting the description in
   // such a way that hopefully exceptionToJs() can reproduce something equivalent to the original
@@ -1880,6 +1884,8 @@ public:
   [[noreturn]] void throwException(kj::Exception&& exception) {
     throwException(exceptionToJs(kj::mv(exception)));
   }
+
+  [[noreturn]] void throwException(const JsValue& exception);
 
   template <typename Func, typename ErrorHandler>
   auto tryCatch(Func&& func, ErrorHandler&& errorHandler) -> decltype(func()) {

--- a/src/workerd/jsg/jsvalue-test.c++
+++ b/src/workerd/jsg/jsvalue-test.c++
@@ -1,0 +1,119 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "jsg-test.h"
+#include "jsvalue.h"
+namespace workerd::jsg::test {
+namespace {
+
+V8System v8System;
+class ContextGlobalObject: public Object, public ContextGlobal { };
+
+struct JsValueContext: public ContextGlobalObject {
+  JsRef<JsValue> persisted;
+  JsValue takeJsValue(Lock& js, JsValue v) {
+    KJ_ASSERT(!v.isTruthy(js));
+    KJ_ASSERT(v.typeOf(js) == "boolean"_kj);
+    KJ_ASSERT(v.isBoolean());
+    KJ_ASSERT(!v.isObject());
+    JsBoolean b = KJ_ASSERT_NONNULL(v.tryCast<JsBoolean>());
+    KJ_ASSERT(!b.value(js));
+
+    return b;
+  }
+  JsValue takeJsString(Lock& js, Optional<JsString> v) {
+    return v.orDefault([&] { return js.str("bar"_kj); });
+  }
+  JsBoolean takeJsBoolean(Lock& js, JsBoolean v, const TypeHandler<bool>& handler) {
+    auto ref = v.addRef(js);
+
+    // Because Js* types are trivially assignable to v8::Local<v8::Value>,
+    // they work out of the box with the existing TypeHandler<T> model
+    // and can be converted into more specific types easily.
+    bool result = KJ_ASSERT_NONNULL(handler.tryUnwrap(js, v));
+    KJ_ASSERT(result == v.value(js));
+
+    return ref.getHandle(js);
+  }
+  JsObject takeJsObject(JsObject v) {
+    return v;
+  }
+  JsArray takeJsArray(Lock& js, JsArray v) {
+    KJ_ASSERT(v.size() == 3);
+    JsValue val = v.get(js, 0);
+    KJ_ASSERT(val.isNumber());
+    KJ_ASSERT(kj::str(val) == "1");
+    return v;
+  }
+  JsValue getString(Lock& js) {
+    return js.str("foo"_kj);
+  }
+  JsValue getStringIntern(Lock& js) {
+    return js.strIntern("foo");
+  }
+  JsObject getMap(Lock& js) {
+    auto map = js.map();
+    map.set(js, "foo", js.num(1));
+    return map;
+  }
+  JsArray getArray(Lock& js) {
+    return js.arr(js.undefined(), js.null(), js.num(1));
+  }
+  JsSet getSet(Lock& js) {
+    return js.set(js.num(1), js.num(1), js.str("foo"_kj), js.str("foo"_kj));
+  }
+  void setRef(Lock& js, JsRef<JsString> value) {
+    JsValue v = value.getHandle(js);
+    persisted = v.addRef(js);
+  }
+  JsValue getRef(Lock& js) {
+    return persisted.getHandle(js);
+  }
+  JsDate getDate(Lock& js) {
+    return js.date(0);
+  }
+
+  JSG_RESOURCE_TYPE(JsValueContext) {
+    JSG_METHOD(takeJsValue);
+    JSG_METHOD(takeJsString);
+    JSG_METHOD(takeJsBoolean);
+    JSG_METHOD(takeJsObject);
+    JSG_METHOD(takeJsArray);
+    JSG_METHOD(getString);
+    JSG_METHOD(getStringIntern);
+    JSG_METHOD(getMap);
+    JSG_METHOD(getArray);
+    JSG_METHOD(getSet);
+    JSG_METHOD(setRef);
+    JSG_METHOD(getRef);
+    JSG_METHOD(getDate);
+  }
+};
+JSG_DECLARE_ISOLATE_TYPE(JsValueIsolate, JsValueContext);
+
+KJ_TEST("simple") {
+  Evaluator<JsValueContext, JsValueIsolate> e(v8System);
+  e.expectEval("takeJsValue(false)", "boolean", "false");
+  e.expectEval("takeJsString(123)", "string", "123");
+  e.expectEval("takeJsString()", "string", "bar");
+  e.expectEval("takeJsBoolean(true)", "boolean", "true");
+  e.expectEval("takeJsBoolean('hi')", "boolean", "true");
+  e.expectEval("takeJsBoolean('')", "boolean", "false");
+  e.expectEval("const o = {}; o === takeJsObject(o);", "boolean", "true");
+  e.expectEval("const a = [1,2,3]; a[1] === takeJsArray(a)[1]", "boolean", "true");
+  e.expectEval("getString()", "string", "foo");
+  e.expectEval("getStringIntern()", "string", "foo");
+  e.expectEval("const m = getMap(); m.get('foo')", "number", "1");
+  e.expectEval("const s = getSet(); s.size === 2 && s.has(1) && s.has('foo') && !s.has('bar')",
+               "boolean", "true");
+  e.expectEval("const a = getArray(); a[2];", "number", "1");
+  e.expectEval("setRef('foo'); getRef('foo')", "string", "foo");
+  e.expectEval("takeJsObject(undefined)", "throws",
+               "TypeError: Failed to execute 'takeJsObject' on 'JsValueContext': parameter 1 "
+               "is not of type 'JsObject'.");
+  e.expectEval("getDate() instanceof Date", "boolean", "true");
+}
+
+}  // namespace
+}  // namespace workerd::jsg::test

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -1,0 +1,379 @@
+#include "jsvalue.h"
+#include "buffersource.h"
+
+namespace workerd::jsg {
+
+JsValue::JsValue(v8::Local<v8::Value> inner) : inner(inner) {
+  requireOnStack(this);
+}
+
+bool JsValue::operator==(const JsValue& other) const {
+  return inner == other.inner;
+}
+
+JsObject::JsObject(v8::Local<v8::Map> inner) : JsObject(inner.As<v8::Object>()) {}
+
+JsObject::operator JsMap() const {
+  KJ_ASSERT(inner->IsMap());
+  return JsMap(inner.As<v8::Map>());
+}
+
+void JsObject::set(Lock& js, const JsValue& name, const JsValue& value) {
+  if (inner->IsMap()) {
+    check(inner.As<v8::Map>()->Set(js.v8Context(), name.inner, value.inner));
+  } else {
+    check(inner->Set(js.v8Context(), name.inner, value.inner));
+  }
+}
+
+void JsObject::set(Lock& js, kj::StringPtr name, const JsValue& value) {
+  set(js, js.strIntern(name), value);
+}
+
+JsValue JsObject::get(Lock& js, const JsValue& name) {
+  if (inner->IsMap()) {
+    return JsValue(check(inner.As<v8::Map>()->Get(js.v8Context(), name.inner)));
+  } else {
+    return JsValue(check(inner->Get(js.v8Context(), name.inner)));
+  }
+}
+
+JsValue JsObject::get(Lock& js, kj::StringPtr name) {
+  return get(js, js.strIntern(name));
+}
+
+bool JsObject::has(Lock& js, const JsValue& name, HasOption option) {
+  if (inner->IsMap()) {
+    return check(inner.As<v8::Map>()->Has(js.v8Context(), name.inner));
+  } else {
+    if (option == HasOption::OWN) {
+      KJ_ASSERT(name.inner->IsName());
+      return check(inner->HasOwnProperty(js.v8Context(), name.inner.As<v8::Name>()));
+    } else {
+      return check(inner->Has(js.v8Context(), name.inner));
+    }
+  }
+}
+
+bool JsObject::has(Lock& js, kj::StringPtr name, HasOption option) {
+  return has(js, js.strIntern(name), option);
+}
+
+void JsObject::delete_(Lock& js, const JsValue& name) {
+  if (inner->IsMap()) {
+    check(inner.As<v8::Map>()->Delete(js.v8Context(), name.inner));
+  } else {
+    check(inner->Delete(js.v8Context(), name.inner));
+  }
+}
+
+void JsObject::delete_(Lock& js, kj::StringPtr name) {
+  delete_(js, js.strIntern(name));
+}
+
+void JsObject::setPrivate(Lock& js, kj::StringPtr name, const JsValue& value) {
+  auto p = v8::Private::ForApi(js.v8Isolate, v8StrIntern(js.v8Isolate, name));
+  check(inner->SetPrivate(js.v8Context(), p, value.inner));
+}
+
+JsValue JsObject::getPrivate(Lock& js, kj::StringPtr name) {
+  auto p = v8::Private::ForApi(js.v8Isolate, v8StrIntern(js.v8Isolate, name));
+  return JsValue(check(inner->GetPrivate(js.v8Context(), p)));
+}
+
+bool JsObject::hasPrivate(Lock& js, kj::StringPtr name) {
+  auto p = v8::Private::ForApi(js.v8Isolate, v8StrIntern(js.v8Isolate, name));
+  return check(inner->HasPrivate(js.v8Context(), p));
+}
+
+int JsObject::hashCode() const {
+  return inner->GetIdentityHash();
+}
+
+kj::String JsObject::getConstructorName() {
+  return kj::str(inner->GetConstructorName());
+}
+
+bool JsValue::isTruthy(Lock& js) const {
+  KJ_ASSERT(!inner.IsEmpty());
+  return inner->BooleanValue(js.v8Isolate);
+}
+
+kj::String JsValue::toString(Lock& js) const {
+  KJ_ASSERT(!inner.IsEmpty());
+  return kj::str(inner);
+}
+
+kj::String JsValue::typeOf(Lock& js) const {
+  KJ_ASSERT(!inner.IsEmpty());
+  return kj::str(inner->TypeOf(js.v8Isolate));
+}
+
+#define V(Type) bool JsValue::is##Type () const { return inner->Is##Type(); }
+JS_IS_TYPES(V)
+#undef V
+
+kj::String JsValue::toJson(Lock& js) const {
+  return kj::str(check(v8::JSON::Stringify(js.v8Context(), inner)));
+}
+
+JsValue JsValue::fromJson(Lock& js, kj::StringPtr input) {
+  return JsValue(check(v8::JSON::Parse(js.v8Context(), v8Str(js.v8Isolate, input))));
+}
+
+JsValue JsValue::fromJson(Lock& js, const JsValue& input) {
+  return JsValue(check(v8::JSON::Parse(js.v8Context(), input.inner.As<v8::String>())));
+}
+
+bool JsBoolean::value(Lock& js) const {
+  return inner->BooleanValue(js.v8Isolate);
+}
+
+uint32_t JsArray::size() const KJ_WARN_UNUSED_RESULT { return inner->Length(); }
+
+JsValue JsArray::get(Lock& js, uint32_t i) const {
+  return JsValue(check(inner->Get(js.v8Context(), i)));
+}
+
+JsArray::operator JsObject() const { return JsObject(inner.As<v8::Object>()); }
+
+int JsString::length(jsg::Lock& js) const {
+  return inner->Length();
+}
+
+int JsString::utf8Length(jsg::Lock& js) const {
+  return inner->Utf8Length(js.v8Isolate);
+}
+
+kj::String JsString::toString(jsg::Lock& js) const {
+  return kj::str(inner);
+}
+
+int JsString::hashCode() const {
+  return inner->GetIdentityHash();
+}
+
+JsString JsString::concat(Lock& js, const JsString& one, const JsString& two) {
+  return JsString(v8::String::Concat(js.v8Isolate, one.inner, two.inner));
+}
+
+bool JsString::operator==(const JsString& other) const {
+  return inner->StringEquals(other.inner);
+}
+
+kj::Maybe<JsArray> JsRegExp::operator()(Lock& js, const JsString& input) const {
+  auto result = check(inner->Exec(js.v8Context(), input));
+  if (result->IsNullOrUndefined()) return nullptr;
+  return JsArray(result.As<v8::Array>());
+}
+
+kj::Maybe<JsArray> JsRegExp::operator()(Lock& js, kj::StringPtr input) const {
+  auto result = check(inner->Exec(js.v8Context(), js.str(input)));
+  if (result->IsNullOrUndefined()) return nullptr;
+  return JsArray(result.As<v8::Array>());
+}
+
+jsg::ByteString JsDate::toUTCString(jsg::Lock& js) const {
+  // TODO(cleanup): Add a toUTCString method to v8::Date to avoid having to grab
+  // the implementation like this from the JS prototype.
+  const auto stringify = js.v8Get(inner, "toUTCString"_kj);
+  JSG_REQUIRE(stringify->IsFunction(), TypeError, "toUTCString on a Date is not a function");
+  const auto stringified = jsg::check(stringify.template As<v8::Function>()->Call(
+      js.v8Context(), inner, 0, nullptr));
+  JSG_REQUIRE(stringified->IsString(), TypeError, "toUTCString on a Date did not return a string");
+  JsString str(stringified.As<v8::String>());
+  return jsg::ByteString(str.toString(js));
+}
+
+JsDate::operator kj::Date() const {
+  return kj::UNIX_EPOCH + (int64_t(inner->ValueOf()) * kj::MILLISECONDS);
+}
+
+JsValue Lock::undefined() {
+  return JsValue(v8::Undefined(v8Isolate));
+}
+
+JsValue Lock::null() {
+  return JsValue(v8::Null(v8Isolate));
+}
+
+JsBoolean Lock::boolean(bool val) {
+  return JsBoolean(v8::Boolean::New(v8Isolate, val));
+}
+
+JsNumber Lock::num(double val) {
+  return JsNumber(v8::Number::New(v8Isolate, val));
+}
+
+JsNumber Lock::num(float val) {
+  return JsNumber(v8::Number::New(v8Isolate, val));
+}
+
+JsInt32 Lock::num(int8_t val) {
+  return JsInt32(v8::Integer::New(v8Isolate, val).As<v8::Int32>());
+}
+
+JsInt32 Lock::num(int16_t val) {
+  return JsInt32(v8::Integer::New(v8Isolate, val).As<v8::Int32>());
+}
+
+JsInt32 Lock::num(int32_t val) {
+  return JsInt32(v8::Integer::New(v8Isolate, val).As<v8::Int32>());
+}
+
+JsBigInt Lock::bigInt(int64_t val) {
+  return JsBigInt(v8::BigInt::New(v8Isolate, val));
+}
+
+JsUint32 Lock::num(uint8_t val) {
+  return JsUint32(v8::Integer::NewFromUnsigned(v8Isolate, val).As<v8::Uint32>());
+}
+
+JsUint32 Lock::num(uint16_t val) {
+  return JsUint32(v8::Integer::NewFromUnsigned(v8Isolate, val).As<v8::Uint32>());
+}
+
+JsUint32 Lock::num(uint32_t val) {
+  return JsUint32(v8::Integer::NewFromUnsigned(v8Isolate, val).As<v8::Uint32>());
+}
+
+JsBigInt Lock::bigInt(uint64_t val) {
+  return JsBigInt(v8::BigInt::NewFromUnsigned(v8Isolate, val));
+}
+
+JsString Lock::str() {
+  return JsString(v8::String::Empty(v8Isolate));
+}
+
+JsString Lock::str(kj::ArrayPtr<const char16_t> str) {
+  return JsString(check(v8::String::NewFromTwoByte(
+      v8Isolate,
+      reinterpret_cast<const uint16_t*>(str.begin()),
+      v8::NewStringType::kNormal,
+      str.size())));
+}
+
+JsString Lock::str(kj::ArrayPtr<const uint16_t> str) {
+  return JsString(check(v8::String::NewFromTwoByte(
+      v8Isolate,
+      str.begin(),
+      v8::NewStringType::kNormal,
+      str.size())));
+}
+
+JsString Lock::str(kj::ArrayPtr<const char> str) {
+  return JsString(check(v8::String::NewFromUtf8(
+      v8Isolate,
+      str.begin(),
+      v8::NewStringType::kNormal,
+      str.size())));
+}
+
+JsString Lock::str(kj::ArrayPtr<const kj::byte> str) {
+  return JsString(check(v8::String::NewFromOneByte(
+      v8Isolate,
+      str.begin(),
+      v8::NewStringType::kNormal,
+      str.size())));
+}
+
+JsString Lock::strIntern(kj::StringPtr str) {
+  return JsString(check(v8::String::NewFromUtf8(
+      v8Isolate,
+      str.begin(),
+      v8::NewStringType::kInternalized,
+      str.size())));
+}
+
+JsString Lock::strExtern(kj::ArrayPtr<const char> str) {
+  return JsString(newExternalOneByteString(*this, str));
+}
+
+JsString Lock::strExtern(kj::ArrayPtr<const uint16_t> str) {
+  return JsString(newExternalTwoByteString(*this, str));
+}
+
+JsRegExp Lock::regexp(kj::StringPtr str,
+                      RegExpFlags flags,
+                      kj::Maybe<uint32_t> backtrackLimit) {
+  KJ_IF_MAYBE(limit, backtrackLimit) {
+    return JsRegExp(check(v8::RegExp::NewWithBacktrackLimit(v8Context(), v8Str(v8Isolate, str),
+        static_cast<v8::RegExp::Flags>(flags), *limit)));
+  }
+  return JsRegExp(check(v8::RegExp::New(v8Context(), v8Str(v8Isolate, str),
+      static_cast<v8::RegExp::Flags>(flags))));
+}
+
+JsObject Lock::obj() {
+  return JsObject(v8::Object::New(v8Isolate));
+}
+
+JsObject Lock::map() {
+  return JsObject(v8::Map::New(v8Isolate));
+}
+
+JsValue Lock::external(void* ptr) {
+  return JsValue(v8::External::New(v8Isolate, ptr));
+}
+
+JsValue Lock::error(kj::StringPtr message) {
+  return JsValue(v8::Exception::Error(v8Str(v8Isolate, message)));
+}
+
+JsValue Lock::typeError(kj::StringPtr message) {
+  return JsValue(v8::Exception::TypeError(v8Str(v8Isolate, message)));
+}
+
+JsValue Lock::rangeError(kj::StringPtr message) {
+  return JsValue(v8::Exception::RangeError(v8Str(v8Isolate, message)));
+}
+
+BufferSource Lock::bytes(kj::Array<kj::byte> data) {
+  return BufferSource(*this, BackingStore::from(kj::mv(data)));
+}
+
+JsSymbol Lock::symbol(kj::StringPtr str) {
+  return JsSymbol(v8::Symbol::New(v8Isolate, v8StrIntern(v8Isolate, str)));
+}
+
+JsSymbol Lock::symbolShared(kj::StringPtr str) {
+  return JsSymbol(v8::Symbol::For(v8Isolate, v8StrIntern(v8Isolate, str)));
+}
+
+JsSymbol Lock::symbolInternal(kj::StringPtr str) {
+  return JsSymbol(v8::Symbol::ForApi(v8Isolate, v8StrIntern(v8Isolate, str)));
+}
+
+#define V(Name) \
+  JsSymbol Lock::symbol##Name() { \
+    return JsSymbol(v8::Symbol::Get##Name(v8Isolate)); }
+  JS_V8_SYMBOLS(V)
+#undef V
+
+JsDate Lock::date(double timestamp) {
+  return JsDate(check(v8::Date::New(v8Context(), timestamp)).As<v8::Date>());
+}
+
+JsDate Lock::date(kj::Date date) {
+  return JsDate(jsg::check(v8::Date::New(
+      v8Context(), (date - kj::UNIX_EPOCH) / kj::MILLISECONDS)).As<v8::Date>());
+}
+
+JsDate Lock::date(kj::StringPtr date) {
+  // TODO(cleanup): Add v8::Date::Parse API to avoid having to grab the constructor like this.
+  const auto tmp = jsg::check(v8::Date::New(v8Context(), 0));
+  KJ_REQUIRE(tmp->IsDate());
+  const auto constructor = v8Get(tmp.As<v8::Object>(), "constructor"_kj);
+  JSG_REQUIRE(constructor->IsFunction(), TypeError, "Date.constructor is not a function");
+  v8::Local<v8::Value> argv = str(date);
+  const auto converted = jsg::check(
+      constructor.template As<v8::Function>()->NewInstance(v8Context(), 1, &argv));
+  JSG_REQUIRE(converted->IsDate(), TypeError, "Date.constructor did not return a Date");
+  return JsDate(converted.As<v8::Date>());
+}
+
+JsRef<JsValue> JsValue::addRef(Lock& js) {
+  return JsRef<JsValue>(js, *this);
+}
+
+}  // namespace workerd::jsg

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -1,0 +1,468 @@
+#pragma once
+
+#include "jsg.h"
+#include <v8.h>
+
+namespace workerd::jsg {
+
+inline void requireOnStack(void* self) {
+#ifdef KJ_DEBUG
+  kj::requireOnStack(self, "JsValue types must be allocated on stack");
+#endif
+}
+
+// The types listed in the JS_IS_TYPES macro are translated into is{Name}()
+// methods on the JsValue type. These correspond directly to equivalent v8::Value
+// types and therefore must be kept in sync.
+#define JS_IS_TYPES(V) \
+  V(Undefined) \
+  V(Null) \
+  V(NullOrUndefined) \
+  V(True) \
+  V(False) \
+  V(ArgumentsObject) \
+  V(NativeError) \
+  V(Name) \
+  V(Function) \
+  V(AsyncFunction) \
+  V(GeneratorFunction) \
+  V(GeneratorObject) \
+  V(WeakMap) \
+  V(WeakSet) \
+  V(WeakRef) \
+  V(WasmNull) \
+  V(ModuleNamespaceObject) \
+  V(MapIterator) \
+  V(SetIterator) \
+  V(External) \
+  V(BigIntObject) \
+  V(BooleanObject) \
+  V(NumberObject) \
+  V(StringObject) \
+  V(SymbolObject) \
+  V(Promise) \
+  V(ArrayBuffer) \
+  V(ArrayBufferView) \
+  V(TypedArray) \
+  V(Uint8Array) \
+  V(Uint8ClampedArray) \
+  V(Int8Array) \
+  V(Uint16Array) \
+  V(Int16Array) \
+  V(Uint32Array) \
+  V(Int32Array) \
+  V(Float32Array) \
+  V(Float64Array) \
+  V(BigInt64Array) \
+  V(BigUint64Array) \
+  V(DataView) \
+  V(Proxy) \
+  V(SharedArrayBuffer) \
+  V(WasmMemoryObject) \
+  V(WasmModuleObject) \
+  JS_TYPE_CLASSES(V)
+
+template <typename TypeWrapper>
+struct JsValueWrapper;
+
+// A JsValue is an abstraction for a JavaScript value that has not been mapped
+// to a C++ type. It wraps an underlying v8::Local<T> in order to avoid direct
+// use of the v8 API in many cases. The JsValue (and JsRef<T>) are meant to
+// fully replace (eventually) the use of jsg::V8Ref<T> and jsg::Value in
+// addition to replacing direct use of v8::Local<T>.
+//
+// JsValue types (including the related JsBoolean, JsArray, JsObject, etc) can
+// only be stack allocated and are not suitable for persistent storage of the
+// value. To persist the JavaScript value, use JsRef<T>.
+//
+// The jsg::Lock instance is used to create instances of the Js* types. For
+// example:
+//
+//   auto& js = Lock::from(isolate);
+//   js.withinHandleScope([&] {
+//     JsString str = js.str("foo");
+//     JsNumber num = js.num(123);
+//     JsArray arr = js.arr(js.str("foo"), js.num(123));
+//     JsObject obj = js.obj();
+//     obj.set(js, "foo", js.str("bar"));
+//   });
+//
+// Note that the `js.withinHandleScope()` is only necessary if the code is not
+// already running within a handle scope (which jsg mapped methods on jsg::Object
+// instances always are).
+//
+// All of the Js* types can be trivially cast to JsValue via assignment.
+//
+//   JsValue val = js.str("foo");
+//
+// A JsValue can be trivially cast to a more specific type if the underlying
+// JS type is compatible.
+//
+//   JsValue val = js.str("foo");
+//   KJ_IF_MAYBE(str, val.tryCast<JsString>()) {
+//     // str is a JsString*
+//   }
+//   KJ_IF_MAYBE(num, val.tryCast<JsNumber>()) {
+//     // never happens since val is not a number
+//   }
+//
+// Because JsValue types are trivially assignable to v8::Local<v8::Value>
+// they can be used together with TypeHandler<T> to convert to specific C++
+// types:
+//
+//   auto obj = js.obj();
+//   const TypeHandler<MyStruct>& handler = // ...
+//   MyStruct v = KJ_ASSERT_NONNULL(handler.tryUnwrap(js, obj));
+class JsValue final {
+public:
+  template <typename T>
+  kj::Maybe<T> tryCast() const KJ_WARN_UNUSED_RESULT;
+
+  operator v8::Local<v8::Value>() const { return inner; }
+
+  bool operator==(const JsValue& other) const;
+
+  bool isTruthy(Lock& js) const KJ_WARN_UNUSED_RESULT;
+  kj::String toString(Lock& js) const KJ_WARN_UNUSED_RESULT;
+  kj::String typeOf(Lock& js) const KJ_WARN_UNUSED_RESULT;
+
+#define V(Type) bool is##Type() const KJ_WARN_UNUSED_RESULT;
+  JS_IS_TYPES(V)
+#undef V
+
+  kj::String toJson(Lock& js) const KJ_WARN_UNUSED_RESULT;
+  static JsValue fromJson(Lock& js, kj::StringPtr input) KJ_WARN_UNUSED_RESULT;
+  static JsValue fromJson(Lock& js, const JsValue& input) KJ_WARN_UNUSED_RESULT;
+
+  JsRef<JsValue> addRef(Lock& js) KJ_WARN_UNUSED_RESULT;
+
+  template <typename T>
+  static kj::Maybe<T&> tryGetExternal(Lock& js, const JsValue& value) KJ_WARN_UNUSED_RESULT;
+
+  explicit JsValue(v8::Local<v8::Value> inner);
+
+private:
+  v8::Local<v8::Value> inner;
+  friend class Lock;
+  template <typename TypeWrapper> friend struct JsValueWrapper;
+  template <typename T, typename Self> friend class JsBase;
+  template <typename T> friend class JsRef;
+
+#define V(Name) friend class Js##Name;
+  JS_TYPE_CLASSES(V)
+#undef V
+};
+
+template <typename T, typename Self>
+class JsBase {
+public:
+  operator v8::Local<v8::Value>() const { return inner; }
+  operator v8::Local<T>() const { return inner; }
+  operator JsValue() const { return JsValue(inner.template As<v8::Value>()); }
+  bool operator==(const JsValue& other) const KJ_WARN_UNUSED_RESULT {
+    return inner == other.inner;
+  }
+  explicit JsBase(v8::Local<T> inner) : inner(inner) { requireOnStack(this); }
+  JsRef<Self> addRef(Lock& js) KJ_WARN_UNUSED_RESULT;
+private:
+  v8::Local<T> inner;
+  friend class Lock;
+  friend class JsValue;
+#define V(Name) friend class Js##Name;
+  JS_TYPE_CLASSES(V)
+#undef V
+  template <typename TypeWrapper> friend struct JsValueWrapper;
+  template <typename U> friend class JsRef;
+};
+
+class JsBoolean final : public JsBase<v8::Boolean, JsBoolean> {
+public:
+  bool value(Lock& js) const KJ_WARN_UNUSED_RESULT;
+
+  using JsBase<v8::Boolean, JsBoolean>::JsBase;
+};
+
+class JsArray final : public JsBase<v8::Array, JsArray> {
+public:
+  operator JsObject() const;
+  uint32_t size() const KJ_WARN_UNUSED_RESULT;
+  JsValue get(Lock& js, uint32_t i) const KJ_WARN_UNUSED_RESULT;
+
+  using JsBase<v8::Array, JsArray>::JsBase;
+};
+
+class JsString final : public JsBase<v8::String, JsString> {
+public:
+  int length(Lock& js) const KJ_WARN_UNUSED_RESULT;
+  int utf8Length(Lock& js) const KJ_WARN_UNUSED_RESULT;
+  kj::String toString(Lock& js) const KJ_WARN_UNUSED_RESULT;
+  int hashCode() const;
+
+  bool operator==(const JsString& other) const;
+
+  static JsString concat(Lock& js, const JsString& one, const JsString& two)
+      KJ_WARN_UNUSED_RESULT;
+
+  enum WriteOptions {
+    NONE = v8::String::NO_OPTIONS,
+    MANY_WRITES_EXPETED = v8::String::HINT_MANY_WRITES_EXPECTED,
+    NO_NULL_TERMINATION = v8::String::NO_NULL_TERMINATION,
+    PRESERVE_ONE_BYTE_NULL = v8::String::PRESERVE_ONE_BYTE_NULL,
+    REPLACE_INVALID_UTF8 = v8::String::REPLACE_INVALID_UTF8,
+  };
+
+  template <typename T>
+  kj::Array<T> toArray(
+      Lock& js,
+      WriteOptions options = WriteOptions::NONE) const KJ_WARN_UNUSED_RESULT;
+
+  using JsBase<v8::String, JsString>::JsBase;
+};
+
+class JsRegExp final : public JsBase<v8::RegExp, JsRegExp> {
+public:
+  kj::Maybe<JsArray> operator()(Lock& js, const JsString& input) const KJ_WARN_UNUSED_RESULT;
+  kj::Maybe<JsArray> operator()(Lock& js, kj::StringPtr input) const KJ_WARN_UNUSED_RESULT;
+  using JsBase<v8::RegExp, JsRegExp>::JsBase;
+};
+
+class JsDate final : public JsBase<v8::Date, JsDate> {
+public:
+  jsg::ByteString toUTCString(Lock& js) const;
+  operator kj::Date() const;
+  using JsBase<v8::Date, JsDate>::JsBase;
+};
+
+#define V(Name) \
+  class Js##Name final : public JsBase<v8::Name, Js##Name> { \
+  public: \
+    using JsBase<v8::Name, Js##Name>::JsBase; \
+  };
+
+  V(Symbol)
+  V(BigInt)
+  V(Number)
+  V(Int32)
+  V(Uint32)
+  V(Map)
+  V(Set)
+
+#undef V
+
+class JsObject final : public JsBase<v8::Object, JsObject> {
+public:
+  operator JsMap() const;
+
+  void set(Lock& js, const JsValue& name, const JsValue& value);
+  void set(Lock& js, kj::StringPtr name, const JsValue& value);
+  JsValue get(Lock& js, const JsValue& name) KJ_WARN_UNUSED_RESULT;
+  JsValue get(Lock& js, kj::StringPtr name) KJ_WARN_UNUSED_RESULT;
+
+  enum class HasOption {
+    NONE,
+    OWN,
+  };
+
+  bool has(Lock& js, const JsValue& name, HasOption option = HasOption::NONE) KJ_WARN_UNUSED_RESULT;
+  bool has(Lock& js, kj::StringPtr name, HasOption option = HasOption::NONE) KJ_WARN_UNUSED_RESULT;
+  void delete_(Lock& js, const JsValue& name);
+  void delete_(Lock& js, kj::StringPtr name);
+
+  void setPrivate(Lock& js, kj::StringPtr name, const JsValue& value);
+  JsValue getPrivate(Lock& js, kj::StringPtr name) KJ_WARN_UNUSED_RESULT;
+  bool hasPrivate(Lock& js, kj::StringPtr name) KJ_WARN_UNUSED_RESULT;
+
+  int hashCode() const;
+
+  kj::String getConstructorName() KJ_WARN_UNUSED_RESULT;
+
+  using JsBase<v8::Object, JsObject>::JsBase;
+
+  explicit JsObject(v8::Local<v8::Map> inner);
+};
+
+template <typename T>
+inline kj::Maybe<T> JsValue::tryCast() const {
+  if constexpr (kj::isSameType<T, JsValue>()) { return JsValue(inner); }
+#define V(Name) \
+  else if constexpr (kj::isSameType<T, Js##Name>()) { \
+    if (!inner->Is##Name()) return nullptr; \
+    return T(inner.template As<v8::Name>()); \
+  }
+  JS_TYPE_CLASSES(V)
+#undef V
+  else { return nullptr; }
+}
+
+template <typename T>
+inline kj::Maybe<T&> JsValue::tryGetExternal(Lock& js, const JsValue& value) {
+  if (!value.isExternal()) return nullptr;
+  return kj::Maybe<T&>(*static_cast<T*>(value.inner.As<v8::External>()->Value()));
+}
+
+template <typename T>
+inline kj::Array<T> JsString::toArray(Lock& js, WriteOptions options) const {
+  if constexpr (kj::isSameType<T, kj::byte>()) {
+    KJ_ASSERT(inner->ContainsOnlyOneByte());
+    auto buf = kj::heapArray<kj::byte>(inner->Length());
+    inner->WriteOneByte(js.v8Isolate, buf.begin(), 0, buf.size(), options);
+    return kj::mv(buf);
+  } else {
+    auto buf = kj::heapArray<uint16_t>(inner->Length());
+    inner->Write(js.v8Isolate, buf.begin(), 0, buf.size(), options);
+    return kj::mv(buf);
+  }
+}
+
+template <typename...Args> requires (std::assignable_from<JsValue&, Args> && ...)
+inline JsArray Lock::arr(const Args&... args) {
+  v8::Local<v8::Value> values[] = { args... };
+  return JsArray(v8::Array::New(v8Isolate, &values[0], sizeof...(Args)));
+}
+
+template <typename...Args> requires (std::assignable_from<JsValue&, Args> && ...)
+inline JsSet Lock::set(const Args&...args) {
+  auto set = v8::Set::New(v8Isolate);
+  (check(set->Add(v8Context(), args.inner)), ...);
+  return JsSet(set);
+}
+
+// A persistent handle for a Js* type suitable for storage and gc visitable.
+//
+// For example,
+//
+//   class Foo : public jsg::Object {
+//   public:
+//     void setStored(jsg::Lock& js, jsg::JsValue value) {
+//       stored = value.addRef(js);
+//     }
+//     JsValue getStored(jsg::Lock& js) {
+//       return stored.getHandle(js);
+//     }
+//     JSG_RESOURCE_TYPE(Foo) {
+//       JSG_PROTOTYPE_PROPERTY(stored, getStored, setStored);
+//     }
+//   private:
+//     jsg::JsRef<JsValue> stored;
+//
+//     void visitForGc(GcVisitor& visitor) { visitor.visit(stored); }
+//   };
+template <typename T>
+class JsRef final {
+  static_assert(std::is_assignable_v<JsValue, T>, "JsRef<T>, T must be assignable to type JsValue");
+public:
+  JsRef(): JsRef(nullptr) {}
+  JsRef(decltype(nullptr)): value(nullptr) {}
+  JsRef(Lock& js, const T& value) : value(js.v8Isolate, value.inner) {}
+  JsRef(JsRef<T>& other) = delete;
+  JsRef(JsRef<T>&& other) = default;
+  template <typename U>
+  JsRef(Value&& v8Value) : value(kj::mv(v8Value)) {}
+  JsRef& operator=(JsRef<T>& other) = delete;
+  JsRef& operator=(JsRef<T>&& other) = default;
+
+  T getHandle(Lock& js) KJ_WARN_UNUSED_RESULT {
+    JsValue handle(value.getHandle(js));
+    return KJ_ASSERT_NONNULL(handle.tryCast<T>());
+  }
+
+  JsRef<T> addRef(Lock& js) KJ_WARN_UNUSED_RESULT {
+    return JsRef<T>(js, getHandle(js));
+  }
+
+  bool operator==(const JsRef<T>& other) {
+    return value == other.value;
+  }
+
+  void visitForGc(GcVisitor& visitor) {
+    visitor.visit(value);
+  }
+
+  // Supported only to allow for an easier transition for code that still
+  // requires V8Ref types.
+  template <typename U>
+  V8Ref<U> addV8Ref(Lock& js) KJ_WARN_UNUSED_RESULT { return value.addRef(js); }
+
+  // Supported only to allow for an easier transition for code that still
+  // requires V8Ref types.
+  template <typename U>
+  operator V8Ref<U>() && { return kj::mv(value).template cast<U>(
+      Lock::from(v8::Isolate::GetCurrent())); }
+
+private:
+  Value value;
+  friend class JsValue;
+#define V(Name) friend class Js##Name;
+  JS_TYPE_CLASSES(V)
+#undef V
+};
+
+template <typename T, typename Self>
+inline JsRef<Self> JsBase<T,Self>::addRef(Lock& js) {
+  return JsRef<Self>(js, *static_cast<Self*>(this));
+}
+
+inline kj::String KJ_STRINGIFY(const JsValue& value) {
+  return value.toString(Lock::from(v8::Isolate::GetCurrent()));
+}
+
+template <typename TypeWrapper>
+struct JsValueWrapper {
+#define TYPES_TO_WRAP(V) \
+  V(Value) \
+  JS_TYPE_CLASSES(V)
+
+  template <typename T, typename = kj::EnableIf<std::is_assignable_v<JsValue, T>>>
+  static constexpr const std::type_info& getName(T*) { return typeid(T); }
+
+  template <typename T, typename = kj::EnableIf<std::is_assignable_v<JsValue, T>>>
+  static constexpr const std::type_info& getName(JsRef<T>*) { return typeid(T); }
+
+#define V(Name) \
+  v8::Local<v8::Name> wrap(v8::Local<v8::Context> context, \
+                           kj::Maybe<v8::Local<v8::Object>> creator, \
+                           Js##Name value) { \
+    return value; \
+  } \
+  v8::Local<v8::Name> wrap(v8::Local<v8::Context> context, \
+                           kj::Maybe<v8::Local<v8::Object>> creator, \
+                           JsRef<Js##Name> value) { \
+    return value.getHandle(Lock::from(context->GetIsolate())); \
+  }
+
+  TYPES_TO_WRAP(V)
+#undef V
+
+  template <typename T, typename = kj::EnableIf<std::is_assignable_v<JsValue, T>>>
+  kj::Maybe<T> tryUnwrap(v8::Local<v8::Context> context,
+                         v8::Local<v8::Value> handle,
+                         T*, kj::Maybe<v8::Local<v8::Object>> parentObject) {
+    if constexpr (kj::isSameType<T, JsString>()) {
+      return T(check(handle->ToString(context)));
+    } else if constexpr (kj::isSameType<T, JsBoolean>()) {
+      return T(handle->ToBoolean(context->GetIsolate()));
+    } else {
+      JsValue value(handle);
+      KJ_IF_MAYBE(t, value.tryCast<T>()) {
+        return *t;
+      }
+      return nullptr;
+    }
+  }
+
+  template <typename T, typename = kj::EnableIf<std::is_assignable_v<JsValue, T>>>
+  kj::Maybe<JsRef<T>> tryUnwrap(v8::Local<v8::Context> context,
+                                v8::Local<v8::Value> handle,
+                                JsRef<T>*,
+                                kj::Maybe<v8::Local<v8::Object>> parentObject) {
+    auto isolate = context->GetIsolate();
+    auto& js = Lock::from(isolate);
+    KJ_IF_MAYBE(result, TypeWrapper::from(isolate)
+        .tryUnwrap(context, handle, (T*)nullptr, parentObject)) {
+      return JsRef(js, *result);
+    }
+    return nullptr;
+  }
+};
+
+}  // namespace workerd::jsg

--- a/src/workerd/jsg/rtti-test.c++
+++ b/src/workerd/jsg/rtti-test.c++
@@ -32,6 +32,39 @@ kj::String tStructure() {
   return codec.encode(type);
 }
 
+KJ_TEST("jsg::Js* types") {
+  KJ_EXPECT(tType<JsValue>() == "(unknown = void)");
+  KJ_EXPECT(tType<JsObject>() == "(object = void)");
+  KJ_EXPECT(tType<JsBoolean>() == "(boolt = void)");
+  KJ_EXPECT(tType<JsArray>() == "(array = (element = (unknown = void), name = \"jsg::JsArray\"))");
+  KJ_EXPECT(tType<JsString>() == "(string = (name = \"jsg::JsString\"))");
+  KJ_EXPECT(tType<JsBigInt>() == "(number = (name = \"jsg::JsBigInt\"))");
+  KJ_EXPECT(tType<JsNumber>() == "(number = (name = \"jsg::JsNumber\"))");
+  KJ_EXPECT(tType<JsInt32>() == "(number = (name = \"jsg::JsInt32\"))");
+  KJ_EXPECT(tType<JsUint32>() == "(number = (name = \"jsg::JsUint32\"))");
+  KJ_EXPECT(tType<JsDate>() == "(builtin = (type = kjDate))");
+  KJ_EXPECT(tType<JsRegExp>() == "(unknown = void)");
+  KJ_EXPECT(tType<JsMap>() == "(unknown = void)");
+  KJ_EXPECT(tType<JsSet>() == "(unknown = void)");
+  KJ_EXPECT(tType<JsSymbol>() == "(unknown = void)");
+
+  KJ_EXPECT(tType<JsRef<JsValue>>() == "(unknown = void)");
+  KJ_EXPECT(tType<JsRef<JsObject>>() == "(object = void)");
+  KJ_EXPECT(tType<JsRef<JsBoolean>>() == "(boolt = void)");
+  KJ_EXPECT(tType<JsRef<JsArray>>() ==
+            "(array = (element = (unknown = void), name = \"jsg::JsArray\"))");
+  KJ_EXPECT(tType<JsRef<JsString>>() == "(string = (name = \"jsg::JsString\"))");
+  KJ_EXPECT(tType<JsRef<JsBigInt>>() == "(number = (name = \"jsg::JsBigInt\"))");
+  KJ_EXPECT(tType<JsRef<JsNumber>>() == "(number = (name = \"jsg::JsNumber\"))");
+  KJ_EXPECT(tType<JsRef<JsInt32>>() == "(number = (name = \"jsg::JsInt32\"))");
+  KJ_EXPECT(tType<JsRef<JsUint32>>() == "(number = (name = \"jsg::JsUint32\"))");
+  KJ_EXPECT(tType<JsRef<JsDate>>() == "(builtin = (type = kjDate))");
+  KJ_EXPECT(tType<JsRef<JsRegExp>>() == "(unknown = void)");
+  KJ_EXPECT(tType<JsRef<JsMap>>() == "(unknown = void)");
+  KJ_EXPECT(tType<JsRef<JsSet>>() == "(unknown = void)");
+  KJ_EXPECT(tType<JsRef<JsSymbol>>() == "(unknown = void)");
+}
+
 KJ_TEST("primitive types") {
   KJ_EXPECT(tType<void>() == "(voidt = void)");
   KJ_EXPECT(tType<bool>() == "(boolt = void)");

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -142,9 +142,48 @@ struct BuildRtti<Configuration, bool> {
 };
 
 template<typename Configuration>
+struct BuildRtti<Configuration, jsg::JsBoolean> {
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) { builder.setBoolt(); }
+};
+
+template<typename Configuration>
 struct BuildRtti<Configuration, v8::Value> {
   static void build(Type::Builder builder, Builder<Configuration>& rtti) { builder.setUnknown(); }
 };
+
+template<typename Configuration>
+struct BuildRtti<Configuration, jsg::JsValue> {
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) { builder.setUnknown(); }
+};
+
+template<typename Configuration>
+struct BuildRtti<Configuration, jsg::JsRegExp> {
+  // This isn't really unknown but we currently do not expose these types at all, so
+  // this is ok for now.
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) { builder.setUnknown(); }
+};
+
+template<typename Configuration>
+struct BuildRtti<Configuration, jsg::JsMap> {
+  // This isn't really unknown but we currently do not expose these types at all, so
+  // this is ok for now.
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) { builder.setUnknown(); }
+};
+
+template<typename Configuration>
+struct BuildRtti<Configuration, jsg::JsSet> {
+  // This isn't really unknown but we currently do not expose these types at all, so
+  // this is ok for now.
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) { builder.setUnknown(); }
+};
+
+template<typename Configuration>
+struct BuildRtti<Configuration, jsg::JsSymbol> {
+  // This isn't really unknown but we currently do not expose these types at all, so
+  // this is ok for now.
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) { builder.setUnknown(); }
+};
+
 
 // Numbers
 
@@ -166,7 +205,11 @@ struct BuildRtti<Configuration, T> { \
   F(unsigned long) \
   F(long long) \
   F(unsigned long long) \
-  F(double)
+  F(double) \
+  F(jsg::JsNumber) \
+  F(jsg::JsInt32) \
+  F(jsg::JsUint32) \
+  F(jsg::JsBigInt)
 
 FOR_EACH_NUMBER_TYPE(DECLARE_NUMBER_TYPE)
 
@@ -187,7 +230,8 @@ struct BuildRtti<Configuration, T> { \
   F(v8::String) \
   F(ByteString) \
   F(UsvString) \
-  F(UsvStringPtr)
+  F(UsvStringPtr) \
+  F(jsg::JsString)
 
 FOR_EACH_STRING_TYPE(DECLARE_STRING_TYPE)
 
@@ -206,6 +250,11 @@ struct BuildRtti<Configuration, jsg::Object> {
   static void build(Type::Builder builder, Builder<Configuration>& rtti) { builder.setObject(); }
 };
 
+template<typename Configuration>
+struct BuildRtti<Configuration, jsg::JsObject> {
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) { builder.setObject(); }
+};
+
 // References
 
 template<typename Configuration, typename T>
@@ -217,6 +266,13 @@ struct BuildRtti<Configuration, Ref<T>> {
 
 template<typename Configuration, typename T>
 struct BuildRtti<Configuration, V8Ref<T>> {
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) {
+    BuildRtti<Configuration, T>::build(builder, rtti);
+  }
+};
+
+template<typename Configuration, typename T>
+struct BuildRtti<Configuration, JsRef<T>> {
   static void build(Type::Builder builder, Builder<Configuration>& rtti) {
     BuildRtti<Configuration, T>::build(builder, rtti);
   }
@@ -303,6 +359,15 @@ struct BuildRtti<Configuration, T<V>> { \
   F(kj::ArrayPtr) \
   F(jsg::Sequence)
 
+template<typename Configuration> \
+struct BuildRtti<Configuration, jsg::JsArray> { \
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) {
+    auto array = builder.initArray();
+    BuildRtti<Configuration, JsValue>::build(array.initElement(), rtti);
+    array.setName("jsg::JsArray");
+  }
+};
+
 FOR_EACH_ARRAY_TYPE(DECLARE_ARRAY_TYPE)
 
 #undef FOR_EACH_ARRAY_TYPE
@@ -382,7 +447,8 @@ struct BuildRtti<Configuration, T> { \
   F(v8::ArrayBufferView, BuiltinType::Type::V8_ARRAY_BUFFER_VIEW) \
   F(v8::ArrayBuffer, BuiltinType::Type::V8_ARRAY_BUFFER) \
   F(v8::Function, BuiltinType::Type::V8_FUNCTION) \
-  F(v8::Uint8Array, BuiltinType::Type::V8_UINT8_ARRAY)
+  F(v8::Uint8Array, BuiltinType::Type::V8_UINT8_ARRAY) \
+  F(jsg::JsDate, BuiltinType::Type::KJ_DATE)
 
 FOR_EACH_BUILTIN_TYPE(DECLARE_BUILTIN_TYPE)
 

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -15,6 +15,7 @@
 #include "function.h"
 #include "string.h"
 #include "buffersource.h"
+#include "jsvalue.h"
 #include "web-idl.h"
 
 namespace workerd::jsg {
@@ -338,7 +339,8 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
                    public ExceptionWrapper<Self>,
                    public ObjectWrapper<Self>,
                    public V8HandleWrapper,
-                   public UnimplementedWrapper {
+                   public UnimplementedWrapper,
+                   public JsValueWrapper<Self> {
   // The TypeWrapper class aggregates functionality to convert between C++ values and JavaScript
   // values. It primarily implements two methods:
   //
@@ -461,6 +463,7 @@ public:
   USING_WRAPPER(ObjectWrapper<Self>);
   USING_WRAPPER(V8HandleWrapper);
   USING_WRAPPER(UnimplementedWrapper);
+  USING_WRAPPER(JsValueWrapper<Self>);
 #undef USING_WRAPPER
 
   template <typename U>

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -181,6 +181,9 @@ void recursivelyFreeze(v8::Local<v8::Context> context, v8::Local<v8::Value> valu
 v8::Local<v8::Value> deepClone(v8::Local<v8::Context> context, v8::Local<v8::Value> value);
 // Make a deep clone of the given object.
 
+// TODO(cleanup): Call sites should migrate to the new js.str(...) variants on jsg::Lock
+// rather than calling v8Str directly. Once the migration is a big further along, v8Str
+// and it's variants will be explicitly marked deprecated.
 template <typename T>
 v8::Local<v8::String> v8Str(v8::Isolate* isolate, kj::ArrayPtr<T> ptr,
            v8::NewStringType newType = v8::NewStringType::kNormal) {

--- a/types/src/generator/type.ts
+++ b/types/src/generator/type.ts
@@ -67,7 +67,8 @@ function isBigNumber(number: NumberType) {
     name === "long" ||
     name === "unsigned long" ||
     name === "long long" ||
-    name === "unsigned long long"
+    name === "unsigned long long" ||
+    name === "jsg::JsBigInt"
   );
 }
 


### PR DESCRIPTION
These are a new abstraction meant to discourage use of v8::Local<T> directly in most cases.

See the included test for examples of use.

PR includes changes to `AbortSignal`/`AbortController` to illustrate how it is used and to verify it works.

~~Still todo:~~

* [x] ~~Update the RTTI handling to ensure typescript type generation for the Js* types works as expected~~
* [x] ~~More documentation~~