### PR TITLE
fix release script: remove .gz files before building new ones

### DIFF
--- a/build-releases.sh
+++ b/build-releases.sh
@@ -6,8 +6,8 @@ if [[ $(uname -m) == 'x86_64' ]]; then
   exit 1
 fi
 
-rm -f workerd-darwin-arm64
-rm -f workerd-linux-arm64
+rm -f workerd-darwin-arm64 workerd-darwin-arm64.gz
+rm -f workerd-linux-arm64 workerd-linux-arm64.gz
 
 # Get the tag associated with the latest release, to ensure parity between binaries
 TAG_NAME=$(curl -sL https://api.github.com/repos/cloudflare/workerd/releases/latest | jq -r ".tag_name")


### PR DESCRIPTION
The build script failed for me but I didn't notice and inferred that it succeeded from the presence of the .gz files

This should make it more obvious in the future