### PR TITLE
Implement microbenchmark

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -59,6 +59,13 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_python/releases/download/0.23.1/rules_python-0.23.1.tar.gz",
 )
 
+http_archive(
+    name = "com_google_benchmark",
+    sha256 = "2aab2980d0376137f969d92848fbb68216abb07633034534fc8c65cc4e7a0e93",
+    strip_prefix = "benchmark-1.8.2",
+    url = "https://github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz",
+)
+
 # Using latest brotli commit due to macOS and clang-cl compile issues with v1.0.9, switch to a
 # release version later.
 http_archive(

--- a/build/wd_cc_benchmark.bzl
+++ b/build/wd_cc_benchmark.bzl
@@ -1,0 +1,28 @@
+"""wd_cc_benchmark definition"""
+
+def wd_cc_benchmark(
+        name,
+        linkopts = [],
+        deps = [],
+        visibility = None,
+        **kwargs):
+    """Wrapper for cc_binary that sets common attributes and links the benchmark library.
+    """
+
+    native.cc_binary(
+        name = name,
+        defines = ["WD_IS_BENCHMARK"],
+        linkopts = linkopts + select({
+          "@//:use_dead_strip": ["-Wl,-dead_strip"],
+          "//conditions:default": [""],
+        }),
+        visibility = visibility,
+        deps = deps + [
+          "@com_google_benchmark//:benchmark_main",
+          "//src/workerd/tests:bench-tools"
+        ],
+        # Only run benchmarks when explicitly requested, at least until we have some more of them
+        # and can define a benchmark suite.
+        tags = ["manual"],
+        **kwargs
+    )

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -7,6 +7,7 @@
 -Ibazel-bin/external/com_googlesource_chromium_base_trace_event_common/_virtual_includes/trace_event_common
 -Ibazel-bin/external/dawn/include
 -Iexternal/capnp-cpp/src
+-Iexternal/com_google_benchmark/include/
 -Iexternal/dawn/include
 -Isrc
 -isystem/usr/include

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -1,5 +1,16 @@
 load("//:build/kj_test.bzl", "kj_test")
 load("//:build/wd_cc_library.bzl", "wd_cc_library")
+load("//:build/wd_cc_benchmark.bzl", "wd_cc_benchmark")
+
+wd_cc_library(
+    name = "bench-tools",
+    hdrs = ["bench-tools.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj:kj-test",
+         "@com_google_benchmark//:benchmark",
+    ],
+)
 
 wd_cc_library(
     name = "test-fixture",
@@ -16,4 +27,14 @@ wd_cc_library(
 kj_test(
     src = "test-fixture-test.c++",
     deps = [":test-fixture"],
+)
+
+# Use `bazel run //src/workerd/tests:bench-json` to benchmark
+wd_cc_benchmark(
+    name = "bench-json",
+    srcs = ["bench-json.c++"],
+    deps = [
+        "@capnp-cpp//src/kj",
+        "//src/workerd/api:r2-api_capnp",
+    ],
 )

--- a/src/workerd/tests/bench-json.c++
+++ b/src/workerd/tests/bench-json.c++
@@ -1,0 +1,52 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include <benchmark/benchmark.h>
+#include <workerd/tests/bench-tools.h>
+#include <workerd/api/r2-api.capnp.h>
+#include "capnp/compat/json.h"
+#include <kj/string.h>
+#include <kj/test.h>
+
+static void Test_JSON_ENC(benchmark::State& state) {
+  // Example test, derived from capnproto's json test.
+  capnp::JsonCodec json;
+  // Perform setup here
+
+  for (auto _ : state) {
+    // This code gets timed
+    KJ_EXPECT(json.encode(capnp::VOID) == "null");
+    KJ_EXPECT(json.encode(true) == "true");
+    KJ_EXPECT(json.encode(false) == "false");
+    KJ_EXPECT(json.encode(123) == "123");
+    KJ_EXPECT(json.encode(-5.5) == "-5.5");
+    KJ_EXPECT(json.encode(capnp::Text::Reader("foo")) == "\"foo\"");
+    KJ_EXPECT(json.encode(capnp::Text::Reader("ab\"cd\\ef\x03")) == "\"ab\\\"cd\\\\ef\\u0003\"");
+
+    json.setPrettyPrint(false);
+    kj::byte bytes[] = {12, 34, 56};
+    KJ_EXPECT(json.encode(capnp::Data::Reader(bytes, 3)) == "[12,34,56]");
+
+    json.setPrettyPrint(true);
+    KJ_EXPECT(json.encode(capnp::Data::Reader(bytes, 3)) == "[12, 34, 56]");
+  }
+}
+
+static void Test_JSON_DEC(benchmark::State& state) {
+  //Test R2BindingRequest, a more complex example
+  capnp::JsonCodec json;
+  capnp::MallocMessageBuilder responseMessage;
+  json.handleByAnnotation<workerd::api::public_beta::R2BindingRequest>();
+  kj::StringPtr dummy = "{\"version\":1,\"method\":\"completeMultipartUpload\",\"object\":\"multipart_object_name4\",\"uploadId\":\"uploadId\",\"parts\":[{\"etag\":\"1234\",\"part\":1},{\"etag\":\"56789\",\"part\":2}]}"_kj;
+
+  for (auto _ : state) {
+    auto responseBuilder = responseMessage.initRoot<workerd::api::public_beta::R2BindingRequest>();
+    json.decode(dummy, responseBuilder);
+  }
+}
+
+WD_BENCHMARK(Test_JSON_ENC);
+WD_BENCHMARK(Test_JSON_DEC);
+// Register both functions as benchmarks – we link benchmark_main so there's no need for a main
+// function.

--- a/src/workerd/tests/bench-tools.h
+++ b/src/workerd/tests/bench-tools.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+// Used to provide support tools for benchmarking. Many use cases will already be covered by the
+// microbenchmark API.
+
+#include <benchmark/benchmark.h>
+
+#define WD_BENCHMARK(X) BENCHMARK(X)->Unit(benchmark::kMicrosecond)
+// Define a benchmark. Use microseconds instead of nanoseconds by default, most tests run long
+// enough to not need ns precision.
+
+#define WD_BENCH(description) \
+  /* Macro inspired by KJ_TEST() to enable benchmarking without requiring the benchmark::State */ \
+  /* argument and make it easy to convert tests to benchmarks. */ \
+  /* Make sure the linker fails if tests are not in anonymous namespaces. */ \
+  extern int KJ_CONCAT(YouMustWrapTestsInAnonymousNamespace, __COUNTER__) KJ_UNUSED; \
+  void KJ_UNIQUE_NAME(Bench)(); \
+  void KJ_UNIQUE_NAME(BenchImpl)(benchmark::State& state) { \
+    for (auto _ : state) { \
+      KJ_UNIQUE_NAME(Bench)(); \
+    } \
+  } \
+  WD_BENCHMARK(KJ_UNIQUE_NAME(BenchImpl))->Name(description); \
+  void KJ_UNIQUE_NAME(Bench)()


### PR DESCRIPTION
Implements a microbenchmark based on [google/microbenchmark](https://github.com/google/microbenchmark). This includes bazel integration for the library, defining the `wd_cc_benchmark()` target rule and adding an example benchmark.
There is also a header with convenience macros for benchmarking, including `WD_BENCH()` which is not yet used but can serve as a drop-in replacement for KJ_TEST() to make it easy to benchmark many of our existing tests. The felix/microbench-poc branch expands on this, but contains more experimental work; this PR is intended to land the microbenchmark and allow developers to define simple benchmarks, use `bazel run //src/workerd/tests:bench-json` to check it out!