### PR TITLE
lazy cf property parsing

### DIFF
--- a/src/workerd/api/cf-property.c++
+++ b/src/workerd/api/cf-property.c++
@@ -1,0 +1,131 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "cf-property.h"
+#include <workerd/io/features.h>
+
+namespace workerd::api {
+
+static constexpr auto kDefaultBotManagementValue = R"DATA({
+  "corporateProxy": false,
+  "verifiedBot": false,
+  "jsDetection": { "passed": false },
+  "staticResource": false,
+  "detectionIds": {},
+  "score": 99
+})DATA";
+
+static void handleDefaultBotManagement(jsg::Lock& js, v8::Local<v8::Object> handle) {
+  // When the cfBotManagementNoOp compatibility flag is set, we'll check the
+  // request cf blob to see if it contains a botManagement field. If it does
+  // *not* we will add it using the following default fields.
+  // Note that if the botManagement team changes any of the fields they provide,
+  // this default value may need to be changed also.
+  auto context = js.v8Context();
+  if (!js.v8Has(handle, "botManagement"_kj)) {
+    auto sym = v8::Private::ForApi(js.v8Isolate,
+        jsg::v8StrIntern(js.v8Isolate, "botManagement"_kj));
+    // For performance reasons, we only want to construct the default values
+    // once per isolate so we cache the constructed value using an internal
+    // private field on the global scope. Whenever we need to use it again we
+    // pull the exact same value.
+    auto defaultBm = jsg::check(context->Global()->GetPrivate(context, sym));
+    if (defaultBm->IsUndefined()) {
+      auto bm = js.parseJson(kj::StringPtr(kDefaultBotManagementValue));
+      KJ_DASSERT(bm.getHandle(js)->IsObject());
+      js.recursivelyFreeze(bm);
+      defaultBm = bm.getHandle(js);
+      jsg::check(context->Global()->SetPrivate(context, sym, defaultBm));
+    }
+    js.v8Set(handle, "botManagement"_kj, defaultBm);
+  }
+}
+
+jsg::Optional<v8::Local<v8::Object>> CfProperty::get(jsg::Lock& js) {
+  return getRef(js).map([&js](jsg::V8Ref<v8::Object>&& ref) mutable {
+    return ref.getHandle(js);
+  });
+}
+
+jsg::Optional<jsg::V8Ref<v8::Object>> CfProperty::getRef(jsg::Lock& js) {
+  KJ_IF_MAYBE(cf, value) {
+    KJ_SWITCH_ONEOF(*cf) {
+      KJ_CASE_ONEOF(parsed, jsg::V8Ref<v8::Object>) {
+        return parsed.addRef(js);
+      }
+      KJ_CASE_ONEOF(unparsed, kj::String) {
+        KJ_DBG(unparsed.asPtr());
+        auto parsed = js.parseJson(unparsed);
+        auto handle = parsed.getHandle(js);
+        KJ_ASSERT(handle->IsObject());
+
+        auto objectHandle = handle.As<v8::Object>();
+        if (!FeatureFlags::get(js).getNoCfBotManagementDefault()) {
+          handleDefaultBotManagement(js, objectHandle);
+        }
+
+        // For the inbound request, we make the `cf` blob immutable.
+        js.recursivelyFreeze(parsed);
+
+        // replace unparsed string with a parsed v8 object
+        auto parsedObject = parsed.cast<v8::Object>(js);
+        this->value = parsedObject.addRef(js);
+        return kj::mv(parsedObject);
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+
+kj::Maybe<kj::String> CfProperty::serialize(jsg::Lock& js) {
+  KJ_IF_MAYBE(cf, value) {
+    KJ_SWITCH_ONEOF(*cf) {
+      KJ_CASE_ONEOF(parsed, jsg::V8Ref<v8::Object>) {
+        return js.serializeJson(parsed);
+      }
+      KJ_CASE_ONEOF(unparsed, kj::String) {
+        if (!FeatureFlags::get(js).getNoCfBotManagementDefault()) {
+          // we mess up with the value on this code path,
+          // need to parse it, fix it and serialize back
+          return js.serializeJson(KJ_ASSERT_NONNULL(getRef(js)));
+        }
+
+        return kj::str(unparsed);
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+CfProperty CfProperty::deepClone(jsg::Lock& js) {
+  KJ_IF_MAYBE(cf, value) {
+    KJ_SWITCH_ONEOF(*cf) {
+      KJ_CASE_ONEOF(parsed, jsg::V8Ref<v8::Object>) {
+        auto ref = parsed.deepClone(js);
+        return CfProperty(kj::mv(ref));
+      }
+      KJ_CASE_ONEOF(unparsed, kj::String) {
+        return CfProperty(unparsed.asPtr());
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+void CfProperty::visitForGc(jsg::GcVisitor& visitor) {
+  KJ_IF_MAYBE(cf, value) {
+    KJ_SWITCH_ONEOF(*cf) {
+      KJ_CASE_ONEOF(parsed, jsg::V8Ref<v8::Object>) {
+        visitor.visit(parsed);
+      }
+      KJ_CASE_ONEOF_DEFAULT {}
+    }
+  }
+}
+
+} // namespace workerd::api

--- a/src/workerd/api/cf-property.h
+++ b/src/workerd/api/cf-property.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+// Common functionality to manage cf headers and properties.
+
+#include <workerd/jsg/jsg.h>
+
+namespace workerd::api {
+
+class CfProperty {
+  // A holder for Cf header property value.
+  // The string header is parsed on demand and the parsed value cached.
+
+public:
+  KJ_DISALLOW_COPY(CfProperty);
+
+  explicit CfProperty() {}
+  CfProperty(decltype(nullptr)) {}
+  CfProperty(CfProperty&&) = default;
+  CfProperty& operator=(CfProperty&&) = default;
+
+  explicit CfProperty(kj::Maybe<kj::StringPtr> unparsed) {
+    KJ_IF_MAYBE(str, unparsed) {
+      value = kj::str(*str);
+    }
+  }
+
+  explicit CfProperty(kj::Maybe<jsg::V8Ref<v8::Object>>&& parsed) {
+    KJ_IF_MAYBE(v, parsed) {
+      value = kj::mv(*v);
+    }
+  }
+
+  jsg::Optional<v8::Local<v8::Object>> get(jsg::Lock& js);
+  // Get parsed value
+
+  jsg::Optional<jsg::V8Ref<v8::Object>> getRef(jsg::Lock& js);
+  // Get parsed value as a global ref
+
+  kj::Maybe<kj::String> serialize(jsg::Lock& js);
+  // Serialize to string
+
+  CfProperty deepClone(jsg::Lock& js);
+  // Clone by deep cloning parsed v8 object (if any).
+
+  void visitForGc(jsg::GcVisitor& visitor);
+
+private:
+  kj::Maybe<kj::OneOf<kj::String, jsg::V8Ref<v8::Object>>> value;
+};
+
+
+} // namespace workerd::api

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -10,6 +10,7 @@
 #include <kj/compat/http.h>
 #include <map>
 #include "basics.h"
+#include "cf-property.h"
 #include "streams.h"
 #include "form-data.h"
 #include "web-socket.h"
@@ -643,7 +644,7 @@ public:
 
   Request(kj::HttpMethod method, kj::StringPtr url, Redirect redirect,
           jsg::Ref<Headers> headers, kj::Maybe<jsg::Ref<Fetcher>> fetcher,
-          kj::Maybe<jsg::Ref<AbortSignal>> signal, kj::Maybe<jsg::V8Ref<v8::Object>> cf,
+          kj::Maybe<jsg::Ref<AbortSignal>> signal, CfProperty&& cf,
           kj::Maybe<Body::ExtractedBody> body)
     : Body(kj::mv(body), *headers), method(method), url(kj::str(url)),
       redirect(redirect), headers(kj::mv(headers)), fetcher(kj::mv(fetcher)),
@@ -830,7 +831,7 @@ private:
   // an optional AbortSignal passed in with the options), and "this' signal", which is an
   // AbortSignal that is always available via the request.signal accessor. When signal is
   // used explicity, thisSignal will not be.
-  kj::Maybe<jsg::V8Ref<v8::Object>> cf;
+  CfProperty cf;
 
   void visitForGc(jsg::GcVisitor& visitor) {
     visitor.visit(headers, fetcher, signal, thisSignal, cf);
@@ -845,7 +846,7 @@ public:
   };
 
   Response(jsg::Lock& js, int statusCode, kj::String statusText, jsg::Ref<Headers> headers,
-           kj::Maybe<jsg::V8Ref<v8::Object>> cf, kj::Maybe<Body::ExtractedBody> body,
+           CfProperty&& cf, kj::Maybe<Body::ExtractedBody> body,
            kj::Array<kj::String> urlList = {},
            kj::Maybe<jsg::Ref<WebSocket>> webSocket = nullptr,
            Response::BodyEncoding bodyEncoding = Response::BodyEncoding::AUTO);
@@ -997,7 +998,7 @@ private:
   int statusCode;
   kj::String statusText;
   jsg::Ref<Headers> headers;
-  kj::Maybe<jsg::V8Ref<v8::Object>> cf;
+  CfProperty cf;
 
   kj::Array<kj::String> urlList;
   // The URL list, per the Fetch spec. Only Responses actually created by fetch() have a non-empty

--- a/src/workerd/api/util.h
+++ b/src/workerd/api/util.h
@@ -104,9 +104,6 @@ double dateNow();
 
 // =======================================================================================
 
-kj::Maybe<jsg::V8Ref<v8::Object>> cloneRequestCf(
-    jsg::Lock& js, kj::Maybe<jsg::V8Ref<v8::Object>> maybeCf);
-
 void maybeWarnIfNotText(kj::StringPtr str);
 
 }  // namespace workerd::api


### PR DESCRIPTION
Extracted all logic to handle the value to a separate class.

Most customers don't need this. Shaves off 6-10ns (10%) on hello world :)

lazy cf parsing:

`iteration_duration.............: avg=76.65µs min=52.06µs med=65.46µs max=25.35ms  p(90)=91.45µs p(95)=108.09µs`

main:

`iteration_duration.............: avg=87.73µs min=58.69µs med=74.47µs max=20.27ms  p(90)=107.58µs p(95)=120.31µs`