### PR TITLE
micro optimization: do not serialize PLAINTEXT mimetype

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -516,7 +516,7 @@ Body::ExtractedBody Body::extractBody(jsg::Lock& js, Initializer init) {
       return kj::mv(stream);
     }
     KJ_CASE_ONEOF(text, kj::String) {
-      contentType = MimeType::PLAINTEXT.toString();
+      contentType = kj::str(MimeType::PLAINTEXT_STRING);
       buffer = kj::mv(text);
     }
     KJ_CASE_ONEOF(bytes, kj::Array<byte>) {

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -360,7 +360,7 @@ jsg::Promise<void> KvNamespace::put(
 
     KJ_SWITCH_ONEOF(supportedBody) {
       KJ_CASE_ONEOF(text, kj::String) {
-        headers.set(kj::HttpHeaderId::CONTENT_TYPE, MimeType::PLAINTEXT.toString());
+        headers.set(kj::HttpHeaderId::CONTENT_TYPE, MimeType::PLAINTEXT_STRING);
         expectedBodySize = uint64_t(text.size());
       }
       KJ_CASE_ONEOF(data, kj::Array<byte>) {

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3654,10 +3654,10 @@ kj::Promise<void> Worker::Isolate::SubrequestClient::request(
         }
 
       } else {
-        response.setMimeType(MimeType::PLAINTEXT.toString());
+        response.setMimeType(MimeType::PLAINTEXT_STRING);
       }
     } else {
-      response.setMimeType(MimeType::PLAINTEXT.toString());
+      response.setMimeType(MimeType::PLAINTEXT_STRING);
     }
     headersToCDP(headers, response.initHeaders());
 

--- a/src/workerd/util/mimetype.c++
+++ b/src/workerd/util/mimetype.c++
@@ -312,7 +312,8 @@ kj::String KJ_STRINGIFY(const MimeType& mimeType) {
   return mimeType.toString();
 }
 
-const MimeType MimeType::PLAINTEXT = MimeType::parse("text/plain;charset=UTF-8"_kj);
+const kj::StringPtr MimeType::PLAINTEXT_STRING = "text/plain;charset=UTF-8"_kj;
+const MimeType MimeType::PLAINTEXT = MimeType::parse(PLAINTEXT_STRING);
 const MimeType MimeType::CSS = MimeType("text"_kj, "css"_kj);
 const MimeType MimeType::HTML = MimeType("text"_kj, "html"_kj);
 const MimeType MimeType::TEXT_JAVASCRIPT = MimeType("text"_kj, "javascript"_kj);

--- a/src/workerd/util/mimetype.h
+++ b/src/workerd/util/mimetype.h
@@ -93,6 +93,9 @@ public:
   static const MimeType VTT;
   static const MimeType EVENT_STREAM;
 
+  // exposed directly for performance reasons
+  static const kj::StringPtr PLAINTEXT_STRING;
+
 private:
   kj::String type_;
   kj::String subtype_;


### PR DESCRIPTION
mimetype serialization is surprisingly complex and involves heap allocations (kj::strTree). Fix it for simple case while waiting for a proper toString improvement.