### PR TITLE
Allow overriding the received (this) of a jsg::Function, update forEach impls

### DIFF
--- a/src/workerd/api/form-data.h
+++ b/src/workerd/api/form-data.h
@@ -98,9 +98,8 @@ public:
 
   void forEach(
       jsg::Lock& js,
-      jsg::V8Ref<v8::Function> callback,
-      jsg::Optional<jsg::Value> thisArg,
-      const jsg::TypeHandler<EntryType>& handler);
+      jsg::Function<void(EntryType, kj::StringPtr, jsg::Ref<FormData>)> callback,
+      jsg::Optional<jsg::Value> thisArg);
 
   JSG_RESOURCE_TYPE(FormData, CompatibilityFlags::Reader flags) {
     JSG_METHOD(append);

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -101,8 +101,8 @@ public:
   void append(jsg::ByteString name, jsg::ByteString value);
   void delete_(jsg::ByteString name);
   void forEach(jsg::Lock& js,
-      jsg::V8Ref<v8::Function>,
-      jsg::Optional<jsg::Value>);
+               jsg::Function<void(kj::StringPtr, kj::StringPtr, jsg::Ref<Headers>)>,
+               jsg::Optional<jsg::Value>);
 
   JSG_ITERATOR(EntryIterator, entries,
                 kj::Array<jsg::ByteString>,

--- a/src/workerd/api/url-standard.h
+++ b/src/workerd/api/url-standard.h
@@ -116,10 +116,9 @@ public:
                IteratorState,
                valueIteratorNext)
 
-  void forEach(
-      jsg::Lock& js,
-      jsg::V8Ref<v8::Function> callback,
-      jsg::Optional<jsg::Value> thisArg);
+  void forEach(jsg::Lock&,
+               jsg::Function<void(jsg::UsvStringPtr, jsg::UsvStringPtr, jsg::Ref<URLSearchParams>)>,
+               jsg::Optional<jsg::Value>);
 
   jsg::UsvString toString();
 

--- a/src/workerd/api/url.h
+++ b/src/workerd/api/url.h
@@ -161,10 +161,9 @@ public:
                 IteratorState,
                 valueIteratorNext)
 
-  void forEach(
-      jsg::Lock& js,
-      jsg::V8Ref<v8::Function> callback,
-      jsg::Optional<jsg::Value> thisArg);
+  void forEach(jsg::Lock&,
+               jsg::Function<void(kj::StringPtr, kj::StringPtr, jsg::Ref<URLSearchParams>)>,
+               jsg::Optional<jsg::Value>);
 
   kj::String toString();
 


### PR DESCRIPTION
The jsg::Function will automatically set the receiver when mapping
from a JS function to jsg::Function. This is not always what we want.
In many cases we have to be able to override the receiver on a case
by case basis. This pr introduces the ability to change the receiver
on a jsg::Function, and updates the various forEach method impls to
use jsg::Function instead of directly using v8::Function calls.