### PR TITLE
webgpu: ensure instaceof checks work

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -491,6 +491,11 @@ public:
 
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
     // WebGPU
+    JSG_NESTED_TYPE_NAMED(api::gpu::GPUAdapter, GPUAdapter);
+    JSG_NESTED_TYPE_NAMED(api::gpu::GPUOutOfMemoryError, GPUOutOfMemoryError);
+    JSG_NESTED_TYPE_NAMED(api::gpu::GPUValidationError, GPUValidationError);
+    JSG_NESTED_TYPE_NAMED(api::gpu::GPUInternalError, GPUInternalError);
+    JSG_NESTED_TYPE_NAMED(api::gpu::GPUDeviceLostInfo, GPUDeviceLostInfo);
     JSG_NESTED_TYPE_NAMED(api::gpu::GPUBufferUsage, GPUBufferUsage);
     JSG_NESTED_TYPE_NAMED(api::gpu::GPUShaderStage, GPUShaderStage);
     JSG_NESTED_TYPE_NAMED(api::gpu::GPUMapMode, GPUMapMode);

--- a/src/workerd/api/gpu/webgpu-errors-test.js
+++ b/src/workerd/api/gpu/webgpu-errors-test.js
@@ -9,6 +9,7 @@ export const read_sync_stack = {
 
     const adapter = await navigator.gpu.requestAdapter();
     ok(adapter);
+    ok(adapter instanceof GPUAdapter);
 
     const device = await adapter.requestDevice();
     ok(device);


### PR DESCRIPTION
Some webgpu libraries use `instaceof`checks on objects returned from the API. Ensure that these work for some objects.