### PR TITLE
webgpu: add labels to objects

### DIFF
--- a/src/workerd/api/gpu/gpu-command-encoder.h
+++ b/src/workerd/api/gpu/gpu-command-encoder.h
@@ -13,8 +13,10 @@ namespace workerd::api::gpu {
 
 class GPUCommandEncoder : public jsg::Object {
 public:
-  explicit GPUCommandEncoder(wgpu::CommandEncoder e) : encoder_(kj::mv(e)){};
+  explicit GPUCommandEncoder(wgpu::CommandEncoder e, kj::String label)
+      : encoder_(kj::mv(e)), label_(kj::mv(label)){};
   JSG_RESOURCE_TYPE(GPUCommandEncoder) {
+    JSG_READONLY_PROTOTYPE_PROPERTY(label, getLabel);
     JSG_METHOD(beginComputePass);
     JSG_METHOD(copyBufferToBuffer);
     JSG_METHOD(finish);
@@ -22,6 +24,11 @@ public:
 
 private:
   wgpu::CommandEncoder encoder_;
+  kj::String label_;
+  kj::StringPtr getLabel() {
+    return label_;
+  }
+
   jsg::Ref<GPUComputePassEncoder>
   beginComputePass(jsg::Optional<GPUComputePassDescriptor> descriptor);
   jsg::Ref<GPUCommandBuffer> finish(jsg::Optional<GPUCommandBufferDescriptor>);

--- a/src/workerd/api/gpu/gpu-device.c++
+++ b/src/workerd/api/gpu/gpu-device.c++
@@ -212,14 +212,16 @@ jsg::Ref<GPUCommandEncoder>
 GPUDevice::createCommandEncoder(jsg::Optional<GPUCommandEncoderDescriptor> descriptor) {
   wgpu::CommandEncoderDescriptor desc{};
 
+  kj::String label = kj::str("");
   KJ_IF_MAYBE (d, descriptor) {
-    KJ_IF_MAYBE (label, d->label) {
-      desc.label = label->cStr();
+    KJ_IF_MAYBE (l, d->label) {
+      label = kj::mv(*l);
+      desc.label = label.cStr();
     }
   }
 
   auto encoder = device_.CreateCommandEncoder(&desc);
-  return jsg::alloc<GPUCommandEncoder>(kj::mv(encoder));
+  return jsg::alloc<GPUCommandEncoder>(kj::mv(encoder), kj::mv(label));
 }
 
 wgpu::ComputePipelineDescriptor

--- a/src/workerd/api/gpu/webgpu-compute-test.js
+++ b/src/workerd/api/gpu/webgpu-compute-test.js
@@ -1,4 +1,4 @@
-import { deepEqual, ok } from "node:assert";
+import { deepEqual, ok, equal } from "node:assert";
 
 // run manually for now
 // bazel run --//src/workerd/io:enable_experimental_webgpu //src/workerd/server:workerd -- test `realpath ./src/workerd/api/gpu/webgpu-compute-test.gpu-wd-test` --verbose --experimental
@@ -226,8 +226,9 @@ export const read_sync_stack = {
     ok(bindGroupAutoLayout);
 
     // Commands submission
-    const commandEncoder = device.createCommandEncoder();
+    const commandEncoder = device.createCommandEncoder({ label: "label1" });
     ok(commandEncoder);
+    equal(commandEncoder.label, "label1");
 
     const passEncoder = commandEncoder.beginComputePass();
     ok(passEncoder);


### PR DESCRIPTION
Most objects will need to expose a label, which has a default value of an empty string. This is an attempt to validate a pattern that will be applied to the rest of the webgpu objects.