### PR TITLE
JSG Completion: Replace v8 PerformMicrotaskCheckpoint with js.runMicrotasks()

### DIFF
--- a/src/workerd/api/streams/queue-test.c++
+++ b/src/workerd/api/streams/queue-test.c++
@@ -197,7 +197,7 @@ KJ_TEST("ValueQueue with single consumer") {
 
   prp.promise.then(js, readContinuation);
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 KJ_TEST("ValueQueue with multiple consumers") {
@@ -263,7 +263,7 @@ KJ_TEST("ValueQueue with multiple consumers") {
   read(js, consumer1).then(js, read1Continuation)
                      .then(js, read2Continuation);
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 
   // Closing the queue causes both consumers to be closed...
   queue.close(js);
@@ -276,7 +276,7 @@ KJ_TEST("ValueQueue with multiple consumers") {
   read(js, consumer1).then(js, close1Continuation)
                      .then(js, close2Continuation);
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 KJ_TEST("ValueQueue consumer with multiple-reads") {
@@ -313,7 +313,7 @@ KJ_TEST("ValueQueue consumer with multiple-reads") {
 
   queue.close(js);
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 KJ_TEST("ValueQueue errors consumer with multiple-reads") {
@@ -335,7 +335,7 @@ KJ_TEST("ValueQueue errors consumer with multiple-reads") {
 
   queue.error(js, js.v8Ref(v8::Exception::Error(jsg::v8StrIntern(js.v8Isolate, "boom"_kj))));
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 KJ_TEST("ValueQueue with multiple consumers with pending reads") {
@@ -371,7 +371,7 @@ KJ_TEST("ValueQueue with multiple consumers with pending reads") {
 
   queue.push(js, getEntry(js, 2));
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 #pragma endregion ValueQueue Tests
@@ -481,7 +481,7 @@ KJ_TEST("ByteQueue with single consumer") {
 
   prp.promise.then(js, readContinuation);
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 KJ_TEST("ByteQueue with single byob consumer") {
@@ -536,7 +536,7 @@ KJ_TEST("ByteQueue with single byob consumer") {
   KJ_ASSERT(queue.size() == 0);
   KJ_ASSERT(consumer.size() == 0);
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 KJ_TEST("ByteQueue with byob consumer and default consumer") {
@@ -594,7 +594,7 @@ KJ_TEST("ByteQueue with byob consumer and default consumer") {
   KJ_ASSERT(consumer1.size() == 0);
   KJ_ASSERT(consumer2.size() == 3);
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 
   MustCall<ReadContinuation> read2Continuation([&](jsg::Lock& js, auto&& result) -> auto {
     KJ_ASSERT(!result.done);
@@ -625,7 +625,7 @@ KJ_TEST("ByteQueue with byob consumer and default consumer") {
   ));
   prp2.promise.then(js, read2Continuation);
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 KJ_TEST("ByteQueue with multiple byob consumers") {
@@ -682,7 +682,7 @@ KJ_TEST("ByteQueue with multiple byob consumers") {
   KJ_ASSERT(nextPending->isInvalidated());
   KJ_ASSERT(queue.nextPendingByobReadRequest() == nullptr);
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 KJ_TEST("ByteQueue with multiple byob consumers") {
@@ -739,7 +739,7 @@ KJ_TEST("ByteQueue with multiple byob consumers") {
   KJ_ASSERT(nextPending->isInvalidated());
   KJ_ASSERT(queue.nextPendingByobReadRequest() == nullptr);
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 KJ_TEST("ByteQueue with multiple byob consumers (multi-reads)") {
@@ -822,7 +822,7 @@ KJ_TEST("ByteQueue with multiple byob consumers (multi-reads)") {
     respond(js, *pending);
   }
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 KJ_TEST("ByteQueue with multiple byob consumers (multi-reads, 2)") {
@@ -904,7 +904,7 @@ KJ_TEST("ByteQueue with multiple byob consumers (multi-reads, 2)") {
     respond(js, *pending);
   }
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 KJ_TEST("ByteQueue with default consumer with atLeast") {
@@ -994,7 +994,7 @@ KJ_TEST("ByteQueue with default consumer with atLeast") {
   // It will be read once the microtask queue is drained.
   KJ_ASSERT(queue.size() == 1);
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 KJ_TEST("ByteQueue with multiple default consumers with atLeast (same rate)") {
@@ -1104,7 +1104,7 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (same rate)") {
   // It will be read once the microtask queue is drained.
   KJ_ASSERT(queue.size() == 1);
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 KJ_TEST("ByteQueue with multiple default consumers with atLeast (different rate)") {
@@ -1236,7 +1236,7 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (different rate)
   KJ_ASSERT(queue.desiredSize() = 1);
   KJ_ASSERT(queue.size() == 1);
 
-  js.v8Isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 }
 
 #pragma endregion ByteQueue Tests

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2236,11 +2236,11 @@ public:
     // Run microtasks in case the user made an async call.
     if (maybeLimitError == nullptr) {
       auto limitScope = isolate.getLimitEnforcer().enterInspectorJs(*lock, maybeLimitError);
-      lock->v8Isolate->PerformMicrotaskCheckpoint();
+      lock->runMicrotasks();
     } else {
       // Oops, we already exceeded the limit, so force the microtask queue to be thrown away.
-      lock->v8Isolate->TerminateExecution();
-      lock->v8Isolate->PerformMicrotaskCheckpoint();
+      lock->terminateExecution();
+      lock->runMicrotasks();
     }
 
     KJ_IF_MAYBE(limitError, maybeLimitError) {

--- a/src/workerd/jsg/iterator-test.c++
+++ b/src/workerd/jsg/iterator-test.c++
@@ -77,7 +77,7 @@ struct GeneratorContext: public Object, public ContextGlobal {
       KJ_FAIL_ASSERT("Should not have been called");
     });
 
-    js.v8Isolate->PerformMicrotaskCheckpoint();
+    js.runMicrotasks();
 
     KJ_ASSERT(finished);
 
@@ -97,7 +97,7 @@ struct GeneratorContext: public Object, public ContextGlobal {
       return js.resolvedPromise();
     });
 
-    js.v8Isolate->PerformMicrotaskCheckpoint();
+    js.runMicrotasks();
 
     return count;
   }

--- a/src/workerd/jsg/jsg-test.h
+++ b/src/workerd/jsg/jsg-test.h
@@ -137,11 +137,11 @@ public:
   void runMicrotasks() {
     V8StackScope stackScope;
     typename IsolateType::Lock lock(getIsolate(), stackScope);
-    lock.v8Isolate->PerformMicrotaskCheckpoint();
+    lock.runMicrotasks();
   }
 
   void runMicrotasks(typename IsolateType::Lock& lock) {
-    lock.v8Isolate->PerformMicrotaskCheckpoint();
+    lock.runMicrotasks();
   }
 
 private:

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -248,6 +248,14 @@ Lock::ContextScope Lock::enterContextScope(v8::Local<v8::Context> context) {
   return ContextScope(context);
 }
 
+void Lock::runMicrotasks() {
+  v8Isolate->PerformMicrotaskCheckpoint();
+}
+
+void Lock::terminateExecution() {
+  v8Isolate->TerminateExecution();
+}
+
 Name Lock::newSymbol(kj::StringPtr symbol) {
   return Name(*this, v8::Symbol::New(v8Isolate, v8StrIntern(v8Isolate, symbol)));
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2168,6 +2168,9 @@ public:
   JS_V8_SYMBOLS(V)
 #undef V
 
+  void runMicrotasks();
+  void terminateExecution();
+
 private:
   friend class IsolateBase;
   template <typename TypeWrapper>

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -319,7 +319,7 @@ void instantiateModule(jsg::Lock& js, v8::Local<v8::Module>& module) {
 
   jsg::check(module->InstantiateModule(context, &resolveCallback));
   auto prom = jsg::check(module->Evaluate(context)).As<v8::Promise>();
-  isolate->PerformMicrotaskCheckpoint();
+  js.runMicrotasks();
 
   switch (prom->State()) {
     case v8::Promise::kPending:

--- a/src/workerd/jsg/promise-test.c++
+++ b/src/workerd/jsg/promise-test.c++
@@ -80,7 +80,7 @@ struct PromiseContext: public jsg::Object, public jsg::ContextGlobal {
       resolved++;
     });
 
-    js.v8Isolate->PerformMicrotaskCheckpoint();
+    js.runMicrotasks();
     KJ_ASSERT(resolved == 2);
 
     {


### PR DESCRIPTION
Reduce direct usage of v8::Isolate APIs