### PR TITLE
JSG Completion: update ActorState to use jsg::JsValue

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -567,7 +567,9 @@ jsg::Optional<jsg::Ref<ActorState>> ExtendableEvent::getActorState() {
     auto& lock = context.getCurrentLock();
     auto persistent = actor.makeStorageForSwSyntax(lock);
     return jsg::alloc<api::ActorState>(
-        actor.cloneId(), actor.getTransient(lock), kj::mv(persistent));
+        actor.cloneId(),
+        actor.getTransient(lock),
+        kj::mv(persistent));
   });
 }
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -732,7 +732,7 @@ public:
   const Id& getId();
   Id cloneId();
   static Id cloneId(Id& id);
-  kj::Maybe<jsg::Value> getTransient(Worker::Lock& lock);
+  kj::Maybe<jsg::JsRef<jsg::JsValue>> getTransient(Worker::Lock& lock);
   kj::Maybe<ActorCacheInterface&> getPersistent();
   kj::Own<Loopback> getLoopback();
 


### PR DESCRIPTION
The new `jsg::JsValue` and `jsg::JsRef<...>` are replacements for `v8::Local<...>` and `jsg::V8Ref<...>` ... this starts the transition over to using the new abstractions, starting with `ActorState`.