### PR TITLE
Improve support for clang 16+

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -48,7 +48,6 @@ build:thin-lto --@rules_rust//:extra_rustc_flags=-C,panic=abort,-C,codegen-units
 # Linux and macOS
 #
 build:unix --cxxopt='-std=c++20' --host_cxxopt='-std=c++20'
-build:unix --cxxopt='-fcoroutines-ts' --host_cxxopt='-fcoroutines-ts'
 build:unix --cxxopt='-stdlib=libc++' --host_cxxopt='-stdlib=libc++'
 build:unix --linkopt='-stdlib=libc++' --host_linkopt='-stdlib=libc++'
 build:unix --@capnp-cpp//src/kj:libdl=True

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,10 +24,10 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "56177a2b3e03a1ee3518a0663a537d0eeb601fd23e4c4926a0b7ae65aab6e194",
-    strip_prefix = "capnproto-capnproto-78e751a/c++",
+    sha256 = "3078dff4cc99f656cf7eac71180717973751d136ee16afaef998ed527e37fe2f",
+    strip_prefix = "capnproto-capnproto-93da777/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/78e751abceb4d376da5a200e986011f881f965a4"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/93da77776dd3fa3d258cc3de49fc0c948ea38019"],
 )
 
 http_archive(

--- a/src/workerd/api/url-standard.h
+++ b/src/workerd/api/url-standard.h
@@ -58,7 +58,6 @@ struct UrlRecord {
   void setPassword(jsg::UsvStringPtr password);
 
   bool operator==(UrlRecord& other);
-  bool operator!=(UrlRecord& other) { return !operator==(other); }
 
   bool equivalentTo(UrlRecord& other, GetHrefOption option = GetHrefOption::NONE);
 };

--- a/src/workerd/api/urlpattern.c++
+++ b/src/workerd/api/urlpattern.c++
@@ -206,14 +206,6 @@ struct Token {
     KJ_UNREACHABLE;
   }
 
-  bool operator!=(jsg::UsvString& other) {
-    return !(*this == other);
-  }
-
-  bool operator!=(uint32_t other) {
-    return !(*this == other);
-  }
-
   static Token asterisk(size_t index) {
     return {
       .type = Type::ASTERISK,

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -927,7 +927,6 @@ public:
     inline ptrdiff_t operator- (const Iterator& other) const { return index - other.index; }
 
     inline bool operator==(const Iterator& other) const { return index == other.index && &args == &other.args; }
-    inline bool operator!=(const Iterator& other) const { return index != other.index || &args != &other.args; }
 
   private:
     size_t index;

--- a/src/workerd/jsg/string.h
+++ b/src/workerd/jsg/string.h
@@ -188,10 +188,6 @@ public:
     return pos == other.pos;
   }
 
-  inline bool operator!=(const UsvStringIterator& other) const {
-    return pos != other.pos;
-  }
-
   inline size_t position() const { return pos; }
   // Informational. Identifies the iterators current codepoint position.
   // When position() == size(), this iterator has reached the end.
@@ -236,10 +232,8 @@ public:
   uint32_t operator[](size_t index) const { return getCodepointAt(index); }
 
   inline bool operator==(UsvStringPtr& other) { return ptr == other.ptr; }
-  inline bool operator!=(UsvStringPtr& other) { return ptr != other.ptr; };
 
   inline bool operator==(const UsvStringPtr& other) const { return ptr == other.ptr; }
-  inline bool operator!=(const UsvStringPtr& other) const { return ptr != other.ptr; };
 
   std::weak_ordering operator<=>(const UsvString& other) const;
   std::weak_ordering operator<=>(const UsvStringPtr& other) const;
@@ -331,10 +325,8 @@ public:
   uint32_t operator[](size_t index) const { return getCodepointAt(index); }
 
   inline bool operator==(UsvString& other) { return buffer == other.buffer; }
-  inline bool operator!=(UsvString& other) { return buffer != other.buffer; };
 
   inline bool operator==(const UsvString& other) const { return buffer == other.buffer; }
-  inline bool operator!=(const UsvString& other) const { return buffer != other.buffer; };
 
   std::weak_ordering operator<=>(const UsvString& other) const;
   std::weak_ordering operator<=>(const UsvStringPtr& other) const;

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -393,9 +393,7 @@ public:
       return false;
     }
   }
-  bool operator!=(const SchemaFile& other) const override {
-    return !operator==(other);
-  }
+
   size_t hashCode() const override {
     return kj::hashCode(fullPath);
   }
@@ -458,9 +456,7 @@ public:
       return false;
     }
   }
-  bool operator!=(const SchemaFile& other) const override {
-    return !operator==(other);
-  }
+
   size_t hashCode() const override {
     return kj::hashCode(name);
   }

--- a/src/workerd/util/mimetype.c++
+++ b/src/workerd/util/mimetype.c++
@@ -302,10 +302,6 @@ bool MimeType::operator==(const MimeType& other) const {
   return this == &other || (type_ == other.type_ && subtype_ == other.subtype_);
 }
 
-bool MimeType::operator!=(const MimeType& other) const {
-  return !(*this == other);
-}
-
 MimeType::operator kj::String() const { return toString(); }
 
 kj::String KJ_STRINGIFY(const MimeType& mimeType) {

--- a/src/workerd/util/mimetype.h
+++ b/src/workerd/util/mimetype.h
@@ -64,10 +64,6 @@ public:
   // parameters in the comparison.
   bool operator==(const MimeType& other) const;
 
-  // Compares only the essence of the MimeType (type and subtype). Ignores
-  // parameters in the comparison.
-  bool operator!=(const MimeType& other) const;
-
   operator kj::String() const;
 
   static bool isXml(const MimeType& mimeType);


### PR DESCRIPTION
- As long as -std=c++20 is specified, clang supports coroutines without `-fcoroutines-ts` since version 10; the flag is also deprecated in clang 16 and no longer supported in clang 17, which will be released next month.
- Remove a number of != operators, these are not needed if operator== is present and can prevent the compiler from finding the right operator under C++20.

Also see the corresponding upstream and capnproto PRs.