### PR TITLE
Add `2023-03-01` and `2023-07-01` types entrypoints

### DIFF
--- a/npm/workers-types/README.md
+++ b/npm/workers-types/README.md
@@ -60,7 +60,15 @@ The Cloudflare Workers runtime manages backwards compatibility through the use o
 
 - `@cloudflare/workers-types/2022-11-30`
 
-  This entrypoint exposes the runtime types for a compatibility date after `2022-11-30`.
+  This entrypoint exposes the runtime types for a compatibility date between `2022-11-30` and `2023-03-01`.
+
+- `@cloudflare/workers-types/2023-03-01`
+
+  This entrypoint exposes the runtime types for a compatibility date between `2023-03-01` and `2023-07-01`.
+
+- `@cloudflare/workers-types/2023-07-01`
+
+  This entrypoint exposes the runtime types for a compatibility date after `2023-07-01`.
 
 - `@cloudflare/workers-types/experimental`
 

--- a/src/workerd/api/url-standard.h
+++ b/src/workerd/api/url-standard.h
@@ -123,7 +123,7 @@ public:
 
   inline uint getSize() { return list.size(); }
 
-  JSG_RESOURCE_TYPE(URLSearchParams) {
+  JSG_RESOURCE_TYPE(URLSearchParams, CompatibilityFlags::Reader flags) {
     JSG_READONLY_PROTOTYPE_PROPERTY(size, getSize);
     JSG_METHOD(append);
     JSG_METHOD_NAMED(delete, delete_);
@@ -139,12 +139,24 @@ public:
     JSG_METHOD(toString);
     JSG_ITERABLE(entries);
 
-    JSG_TS_OVERRIDE(URLSearchParams {
-      entries(): IterableIterator<[key: string, value: string]>;
-      [Symbol.iterator](): IterableIterator<[key: string, value: string]>;
+    if (flags.getUrlSearchParamsDeleteHasValueArg()) {
+      JSG_TS_OVERRIDE(URLSearchParams {
+        entries(): IterableIterator<[key: string, value: string]>;
+        [Symbol.iterator](): IterableIterator<[key: string, value: string]>;
 
-      forEach<This = unknown>(callback: (this: This, value: string, key: string, parent: URLSearchParams) => void, thisArg?: This): void;
-    });
+        forEach<This = unknown>(callback: (this: This, value: string, key: string, parent: URLSearchParams) => void, thisArg?: This): void;
+      });
+    } else {
+      JSG_TS_OVERRIDE(URLSearchParams {
+        delete(name: string): void;
+        has(name: string): boolean;
+
+        entries(): IterableIterator<[key: string, value: string]>;
+        [Symbol.iterator](): IterableIterator<[key: string, value: string]>;
+
+        forEach<This = unknown>(callback: (this: This, value: string, key: string, parent: URLSearchParams) => void, thisArg?: This): void;
+      });
+    }
     // Rename from urlURLSearchParams
   }
 

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -52,6 +52,10 @@ compat_dates = [
     # https://developers.cloudflare.com/workers/platform/compatibility-dates/#streams-constructors
     # https://developers.cloudflare.com/workers/platform/compatibility-dates/#compliant-transformstream-constructor
     ("2022-11-30", "2022-11-30"),
+    # https://github.com/cloudflare/workerd/blob/fcb6f33d10c71975cb2ce68dbf1924a1eeadbd8a/src/workerd/io/compatibility-date.capnp#L275-L280 (http_headers_getsetcookie)
+    ("2023-03-01", "2023-03-01"),
+    # https://github.com/cloudflare/workerd/blob/fcb6f33d10c71975cb2ce68dbf1924a1eeadbd8a/src/workerd/io/compatibility-date.capnp#L307-L312 (urlsearchparams_delete_has_value_arg)
+    ("2023-07-01", "2023-07-01"),
     # Latest compatibility date (note these types should be the same as the previous entry)
     (None, "experimental"),
 ]


### PR DESCRIPTION
Hey! 👋 This PR adds `@cloudflare/workers-types` entrypoints for compatibility dates `2023-03-01` and `2023-07-01`. These are the default on dates for `http_headers_getsetcookie` and `urlsearchparams_delete_has_value_arg`, both of which have user facing types changes. We're still planning to build a better system for this, that will allow users to generate types for any combination of compatibility dates and flags.