### PR TITLE
[nfc] wd_cc_benchmark can generate csv report

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,6 @@
 common --enable_platform_specific_config
 build --verbose_failures
+build --build_tag_filters=-off-by-default
 
 # Our dependencies (ICU, zlib, etc.) produce a lot of these warnings, so we disable them.
 build --per_file_copt='external/com_googlesource_chromium_icu@-Wno-ambiguous-reversed-operator,-Wno-deprecated-declarations'

--- a/build/wd_cc_benchmark.bzl
+++ b/build/wd_cc_benchmark.bzl
@@ -23,6 +23,15 @@ def wd_cc_benchmark(
         ],
         # Only run benchmarks when explicitly requested, at least until we have some more of them
         # and can define a benchmark suite.
-        tags = ["manual", "benchmark"],
+        tags = ["off-by-default", "benchmark"],
         **kwargs
+    )
+
+    # generate benchmark report
+    native.genrule(
+      name = name + "@benchmark.csv",
+      outs = [name + ".benchmark.csv"],
+      srcs = [name],
+      cmd = "./$(location {}) --benchmark_format=csv > \"$@\"".format(name),
+      tags = ["off-by-default", "benchmark_report"],
     )


### PR DESCRIPTION
```
$ bazel build --config=benchmark //... --build_tag_filters="benchmark_report"
$ find ./bazel-bin/ -name "*.benchmark.csv"
./bazel-bin/src/workerd/tests/bench-json.benchmark.csv
./bazel-bin/src/workerd/tests/bench-mimetype.benchmark.csv
$ cat ./bazel-bin/src/workerd/tests/bench-json.benchmark.csv
name,iterations,real_time,cpu_time,time_unit,bytes_per_second,items_per_second,label,error_occurred,error_message
"Test_JSON_ENC",96561,7.23878,7.23829,us,,,,,
"Test_JSON_DEC",81347,7.12574,7.12138,us,,,,,
```

cc @irvinebroque 