### PR TITLE
[nfc] benchmark for GlobalScope::request serving function

### DIFF
--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -54,3 +54,9 @@ wd_cc_benchmark(
         "@capnp-cpp//src/kj/compat:kj-http",
     ],
 )
+
+wd_cc_benchmark(
+    name = "bench-global-scope",
+    srcs = ["bench-global-scope.c++"],
+    deps = [":test-fixture"],
+)

--- a/src/workerd/tests/bench-global-scope.c++
+++ b/src/workerd/tests/bench-global-scope.c++
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include <workerd/tests/bench-tools.h>
+#include <workerd/tests/test-fixture.h>
+
+// A benchmark for GlobalScope functionality.
+
+namespace workerd {
+namespace {
+
+struct GlobalScopeBenchmark: public benchmark::Fixture {
+  virtual ~GlobalScopeBenchmark() noexcept(true) {}
+
+  void SetUp(benchmark::State& state) noexcept(true) override {
+    TestFixture::SetupParams params = {
+      .mainModuleSource = R"(
+        export default {
+          async fetch(request) {
+            return new Response("OK");
+          },
+        };
+      )"_kj};
+    fixture = kj::heap<TestFixture>(params);
+  }
+
+  void TearDown(benchmark::State& state) noexcept(true) override {
+    fixture = nullptr;
+  }
+
+  kj::Own<TestFixture> fixture;
+};
+
+BENCHMARK_F(GlobalScopeBenchmark, request)(benchmark::State& state) {
+  for (auto _ : state) {
+    auto result = fixture->runRequest(kj::HttpMethod::POST, "http://www.example.com"_kj, "TEST"_kj);
+    KJ_EXPECT(result.statusCode == 200);
+  }
+}
+
+} // namespace
+} // namespace workerd


### PR DESCRIPTION
this benchmarks request handling innards without networking overhead.

on my laptop:

```
Run on (16 X 2531.17 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1280 KiB (x8)
  L3 Unified 24576 KiB (x1)
Load Average: 8.29, 9.28, 11.45
-----------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations
-----------------------------------------------------------------------
GlobalScopeBenchmark/request      12805 ns        12787 ns        56261
```
