### PR TITLE
A couple of improvements relating to clangd

### DIFF
--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -2,11 +2,9 @@
 -stdlib=libc++
 -xc++
 -nostdinc
--Ibazel-bin
--Ibazel-bin/external/capnp-cpp/src
 -Ibazel-bin/external/com_googlesource_chromium_base_trace_event_common/_virtual_includes/trace_event_common
 -Ibazel-bin/external/dawn/include
--Iexternal/capnp-cpp/src
+-Ibazel-bin/external/com_cloudflare_lol_html/_virtual_includes/lolhtml
 -Iexternal/com_google_benchmark/include/
 -Iexternal/dawn/include
 -Isrc
@@ -19,9 +17,19 @@
 -isystem/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Versions/Current/Headers
 -isystemC:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.35.32215\include
 -isystemc:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt
+-isystembazel-bin/_virtual_includes/icudata-embed
+-isystembazel-bin/external/capnp-cpp/src
+-isystembazel-bin/external/capnp-cpp/src/capnp/_virtual_includes/capnp
+-isystembazel-bin/external/capnp-cpp/src/capnp/compat/_virtual_includes/http-over-capnp
+-isystembazel-bin/external/capnp-cpp/src/capnp/compat/_virtual_includes/json
+-isystembazel-bin/external/capnp-cpp/src/kj/_virtual_includes/kj
+-isystembazel-bin/external/capnp-cpp/src/kj/_virtual_includes/kj-async
+-isystembazel-bin/external/capnp-cpp/src/kj/compat/_virtual_includes/kj-http
+-isystembazel-bin/external/capnp-cpp/src/kj/compat/_virtual_includes/kj-tls
 -isystembazel-bin/external/v8
 -isystembazel-bin/external/v8/icu
 -isystembazel-bin/src
+-isystembazel-workerd/external/ssl/src/include
 -isystemexternal/brotli/c/include
 -isystemexternal/com_googlesource_chromium_icu/source/common
 -isystemexternal/icu

--- a/tools/unix/clangd-check.sh
+++ b/tools/unix/clangd-check.sh
@@ -5,10 +5,46 @@
 
 output_dir=$(mktemp -d)
 top_of_tree=$(git rev-parse --show-toplevel)
+declare -a job_pids
+
+# Guess at number of CPUs (could be probed, but portable requires work).
+jobs_max=8
+
+# Check bash version to see if `wait -n` is supported. This allows waiting on first of any
+# process specified as an argument to wait to exit rather than waiting for all the processes
+# specified to exit. (ie batch vs stream).
+bash_major=$(echo $BASH_VERSION | sed -e 's/\..*/0000/')
+bash_minor=$(echo $BASH_VERSION | sed -e 's/^[^.]*\.//' -e 's/\..*//')
+bash_linear=$(($bash_major + $bash_minor))
+if [ ${bash_linear} -ge 50001 ]; then
+  wait_args="-n"
+fi
 
 cd "${top_of_tree}"
 for i in $(find . -name '*.h' -o -name '*.c++'); do
+    if [ ${#job_pids[*]} -eq ${jobs_max} ]; then
+        # macOS inparticular is stuck on an older version of bash and does not support `wait -n`
+        # here so child processes will run as batch waiting for all to complete there.
+        wait ${wait_args} "${job_pids[@]}"
+        for job_pid in "${job_pids[@]}"; do
+          if ! kill -0 ${job_pid} 2>/dev/null ; then
+            unset job_pids[${job_pid}]
+          fi
+        done
+    fi
     j=${output_dir}/$(echo $i | sed  -e 's@^\./@@' -e s@/@_@g)
-    echo Scanning $i =\> $j
-    clangd --check=$i 1>$j 2>&1
+    echo -n Scanning $i =\> $j
+    clangd --check=$i 1>$j 2>&1 &
+    echo " [$!]"
+    job_pids[$!]=$!
 done
+
+echo "Checking for broken includes."
+grep "not found" ${output_dir}/*
+
+cat <<EOF
+
+You may also want to inspect the output files for other issues.
+
+Please update compile_flags.txt to resolve any issues found.
+EOF


### PR DESCRIPTION
* update include paths in compile_flags.txt.
* parallelize the execution of clangd in the clangd-check.sh script.

Manual check: server.cc has no clangd include errors in vscode.