### PR TITLE
Bugfix: re-instate threadId guard in currentTimeMS

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -451,8 +451,11 @@ public:
     } else {
       auto lockedState = state.lockExclusive();
       KJ_IF_MAYBE(info, lockedState->inspectorTimerInfo) {
-        timePoint = info->timer.now() + info->timerOffset
-                  - kj::origin<kj::TimePoint>() + kj::UNIX_EPOCH;
+        if (info->threadId == getCurrentThreadId()) {
+          // We're on an inspector-serving thread.
+          timePoint = info->timer.now() + info->timerOffset
+                    - kj::origin<kj::TimePoint>() + kj::UNIX_EPOCH;
+        }
       }
       // We're at script startup time -- just return the Epoch.
     }


### PR DESCRIPTION
Fixes a use-after-free for a stack allocated timer.

Bug: EW-7719
Test: See EW-7719