### PR TITLE
[nfc] remove off-by-default bench tag

### DIFF
--- a/build/wd_cc_benchmark.bzl
+++ b/build/wd_cc_benchmark.bzl
@@ -25,7 +25,7 @@ def wd_cc_benchmark(
         malloc = "//src/workerd/server:malloc",
         # Only run benchmarks when explicitly requested, at least until we have some more of them
         # and can define a benchmark suite.
-        tags = ["off-by-default", "benchmark"],
+        tags = ["benchmark"],
         **kwargs
     )
 

--- a/build/wd_cc_benchmark.bzl
+++ b/build/wd_cc_benchmark.bzl
@@ -23,8 +23,6 @@ def wd_cc_benchmark(
         ],
         # use the same malloc we use for server
         malloc = "//src/workerd/server:malloc",
-        # Only run benchmarks when explicitly requested, at least until we have some more of them
-        # and can define a benchmark suite.
         tags = ["benchmark"],
         **kwargs
     )


### PR DESCRIPTION
bazel doesn't build/run it otherwise. It doesn't hurt if there's none, since run target are not run by `bazel test`.