### PR TITLE
Bump `json5` to `1.0.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
     "typescript": "~4.7.4"
   },
   "devDependencies": {
-    "@bazel/bazelisk": "1.12",
+    "@bazel/bazelisk": "~1.12.1",
     "@types/debug": "^4.1.7",
-    "@types/node": "^18.7.18",
+    "@types/node": "^18.8.5",
     "@types/prettier": "^2.7.1",
-    "@typescript-eslint/eslint-plugin": "^5.37.0",
-    "@typescript-eslint/parser": "^5.37.0",
+    "@typescript-eslint/eslint-plugin": "^5.40.0",
+    "@typescript-eslint/parser": "^5.40.0",
     "capnpc-ts": "^0.7.0",
-    "esbuild": "^0.15.7",
-    "eslint": "^8.22.0",
+    "esbuild": "^0.15.10",
+    "eslint": "^8.25.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,16 +1,16 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@bazel/bazelisk': '1.12'
+  '@bazel/bazelisk': ~1.12.1
   '@types/debug': ^4.1.7
-  '@types/node': ^18.7.18
+  '@types/node': ^18.8.5
   '@types/prettier': ^2.7.1
-  '@typescript-eslint/eslint-plugin': ^5.37.0
-  '@typescript-eslint/parser': ^5.37.0
+  '@typescript-eslint/eslint-plugin': ^5.40.0
+  '@typescript-eslint/parser': ^5.40.0
   capnp-ts: ^0.7.0
   capnpc-ts: ^0.7.0
-  esbuild: ^0.15.7
-  eslint: ^8.22.0
+  esbuild: ^0.15.10
+  eslint: ^8.25.0
   eslint-config-prettier: ^8.5.0
   eslint-plugin-import: ^2.26.0
   eslint-plugin-prettier: ^4.2.1
@@ -1327,8 +1327,8 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
-  /json5/1.0.1:
-    resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
+  /json5/1.0.2:
+    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
     dependencies:
       minimist: 1.2.7
@@ -1677,7 +1677,7 @@ packages:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
       '@types/json5': 0.0.29
-      json5: 1.0.1
+      json5: 1.0.2
       minimist: 1.2.7
       strip-bom: 3.0.0
     dev: true


### PR DESCRIPTION
Hey! 👋 This PR bumps `json5` to https://github.com/advisories/GHSA-9c47-m6qq-7p4h. Whist this is only used as a transitive dev dependency to read trusted `tsconfig.json`s, GitHub was warning us about it when pushing. To prevent people getting conditioned to avoid security warnings, let's bump it. This patch was generated by running `pnpm upgrade json5` with `pnpm@7`. This also changed some of our package specifiers, but not the locked versions. 👍

Ref: https://github.com/cloudflare/workerd/pull/1065