### PR TITLE
Temporarily disable github runner for Windows 2022

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,14 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-2022]
+        os: [ubuntu-20.04, macos-latest] # windows-2022 disabled due to actions/runner-images#812
         include:
           - os-name: linux
             os: ubuntu-20.04
           - os-name: macOS
             os: macos-latest
-          - os-name: windows
-            os: windows-2022
+          # - os-name: windows
+          #   os: windows-2022
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.os-name }})
     steps:


### PR DESCRIPTION
Broken by actions/runner-images#812

Unforunately upgrading to LLVM16 per scikit-image/scikit-image#7109 appears to be hampered by https://github.com/bazelbuild/bazel/issues/17863. Working around this, there is a static assertion failure in Google benchmark.