### PR TITLE
Resurrect Windows-2022 with LLVM 16

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -148,6 +148,20 @@ build:windows --cxxopt='/std:c++20' --host_cxxopt='/std:c++20'
 build:windows --cxxopt='/await' --host_cxxopt='/await'
 build:windows --cxxopt='/wo4503' --host_cxxopt='/wo4503'
 build:windows --cxxopt='/DWINDOWS_LEAN_AND_MEAN' --host_cxxopt='/DWINDOWS_LEAN_AND_MEAN'
+build:windows --cxxopt='/D_CRT_USE_BUILTIN_OFFSETOF' --host_cxxopt='/D_CRT_USE_BUILTIN_OFFSETOF'
 # The `/std:c++14` argument is unused during boringssl compilation and we don't
 # want a warning when compiling each file.
 build:windows --cxxopt='-Wno-unused-command-line-argument' --host_cxxopt='-Wno-unused-command-line-argument'
+
+# The following are required on github runners temporarily due to
+# https://github.com/actions/runner-images/issues/8125
+# For reasons TBD, clang in LLVM 16 is including the MSFT version emmintrin.h in
+# preference to the very packaged in LLVM 16 when compiling these files. The compiler
+# command-line and environment set by Bazel is the same, modulo the LLVM version
+# strings.
+build:windows --per_file_copt='external/ssl/src/crypto/fipsmodule/bcm.\c@-imsvcC:\\Program Files\\LLVM\\lib\\clang\\16.0.6\\include' --host_per_file_copt='external/ssl/src/crypto/fipsmodule/bcm\.c@-imsvcC:\\Program Files\\LLVM\\lib\\clang\\16.0.6\\include'
+build:windows --per_file_copt='external/ssl/src/crypto/hrss/hrss\.c@-imsvcC:\\Program Files\\LLVM\\lib\\clang\\16.0.6\\include' --host_per_file_copt='external/ssl/src/crypto/hrss/hrss\.c@-imsvcC:\\Program Files\\LLVM\\lib\\clang\\16.0.6\\include'
+build:windows --per_file_copt='external/ssl/src/crypto/poly1305/poly1305_vec\.c@-imsvcC:\\Program Files\\LLVM\\lib\\clang\\16.0.6\\include' --host_per_file_copt='external/ssl/src/crypto/poly1305/poly1305_vec.c@-imsvcC:\\Program Files\\LLVM\\lib\\clang\\16.0.6\\include'
+build:windows --per_file_copt='external/v8/src/objects/literal-objects\.cc@-imsvcC:\\Program Files\\LLVM\\lib\\clang\\16.0.6\\include' --host_per_file_copt='external/v8/src/objects/literal-objects.cc@-imsvcC:\\Program Files\\LLVM\\lib\\clang\\16.0.6\\include'
+build:windows --per_file_copt='external/v8/src/runtime/runtime-object\.cc@-imsvcC:\\Program Files\\LLVM\\lib\\clang\\16.0.6\\include' --host_per_file_copt='external/v8/src/runtime/runtime-object.cc@-imsvcC:\\Program Files\\LLVM\\lib\\clang\\16.0.6\\include'
+build:windows --per_file_copt='external/v8/src/objects/swiss-name-dictionary\.cc@-imsvcC:\\Program Files\\LLVM\\lib\\clang\\16.0.6\\include' --host_per_file_copt='external/v8/src/objects/swiss-name-dictionary.cc@-imsvcC:\\Program Files\\LLVM\\lib\\clang\\16.0.6\\include'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,11 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
-
+          # Upgrade to LLVM 16.0.6, default install is currently 15 (https://github.com/actions/runner-images/issues/8125).
+          # When we need to upgrade beyond LLVM 16.0.6, ${WORKSPACE}/.bazelrc will need updating.
+          choco upgrade llvm --version=16.0.6
+          # Work around bazel clang 16 include path bug (https://github.com/bazelbuild/bazel/issues/17863)
+          Move-Item -Path "C:\Program Files\LLVM\lib\clang\16" -Destination "C:\Program Files\LLVM\lib\clang\16.0.6"
       - name: Bazel build
         run: |
           bazelisk build --disk_cache=~/bazel-disk-cache  --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev -c opt //src/workerd/server:workerd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,14 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest] # windows-2022 disabled due to actions/runner-images#812
+        os: [ubuntu-20.04, macos-latest, windows-2022]
         include:
           - os-name: linux
             os: ubuntu-20.04
           - os-name: macOS
             os: macos-latest
-          # - os-name: windows
-          #   os: windows-2022
+          - os-name: windows
+            os: windows-2022
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.os-name }})
@@ -60,6 +60,11 @@ jobs:
         run: |
             [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
             [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'build:windows --config=windows_no_dbg')
+            # Upgrade to LLVM 16.0.6, default install is currently 15 (https://github.com/actions/runner-images/issues/8125).
+            # When we need to upgrade beyond LLVM 16.0.6, ${WORKSPACE}/.bazelrc will need updating.
+            choco upgrade llvm --version=16.0.6
+            # Work around bazel clang 16 include path bug (https://github.com/bazelbuild/bazel/issues/17863)
+            Move-Item -Path "C:\Program Files\LLVM\lib\clang\16" -Destination "C:\Program Files\LLVM\lib\clang\16.0.6"
       - name: Bazel build
         # timestamps are no longer being added here, the GitHub logs include timestamps (Use
         # 'Show timestamps' on the web interface)


### PR DESCRIPTION
This is required due to https://github.com/actions/runner-images/issues/8125

An assortment of changes to enable building with the LLVM16 toolchain on Windows:
- add Windows-2022 back to the test strategy matrix in test.yml.
- add an LLVM upgrade step to test.yml to install LLVM 16
- add command to test.yml to fix the include path for LLVM includes
  (Bazel issue https://github.com/bazelbuild/bazel/issues/17863).
- add a macro definition to .bazelrc to prefer __builtin_offsetof
  (the offsetof macro without this is broken under LLVM16).
- add enforced include path override to files including emmintrin.h.
  clang-cl.exe in LLVM15 picks up the LLVM version of this file, but
  LLVM16 was picking up the MSFT version and preventing the compiler
  from replacing intrinsics. It looks like there is a change in
  precedence between LLVM15 and LLVM16 for the include path setup by
  Bazel in the INCLUDE environment variable.

```
Test: Install LLVM16, fix the LLVM include directory location for bazel, then
      run `bazel test //...`
```