### PR TITLE
Support overriding connect() behavior via callbacks for specified addrs

### DIFF
--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -150,7 +150,7 @@ jsg::Ref<Socket> setupSocket(
     bool isSecureSocket, kj::String domain, bool isDefaultFetchPort);
 
 jsg::Ref<Socket> connectImplNoOutputLock(
-    jsg::Lock& js, jsg::Ref<Fetcher> fetcher, AnySocketAddress address,
+    jsg::Lock& js, kj::Maybe<jsg::Ref<Fetcher>> fetcher, AnySocketAddress address,
     jsg::Optional<SocketOptions> options);
 
 jsg::Ref<Socket> connectImpl(

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -12,6 +12,7 @@
 #include <workerd/util/xthreadnotifier.h>
 #include <workerd/api/actor-state.h>
 #include <workerd/api/global-scope.h>
+#include <workerd/api/sockets.h>
 #include <workerd/api/streams.h>  // for api::StreamEncoding
 #include <workerd/jsg/async-context.h>
 #include <workerd/jsg/jsg.h>
@@ -2963,6 +2964,14 @@ kj::Promise<Worker::AsyncLock> Worker::takeAsyncLockWhenActorCacheReady(
   }
 
   return getIsolate().takeAsyncLockImpl(kj::mv(lockTiming));
+}
+
+void Worker::setConnectOverride(kj::String networkAddress, ConnectFn connectFn) {
+  connectOverrides.upsert(kj::mv(networkAddress), kj::mv(connectFn));
+}
+
+kj::Maybe<Worker::ConnectFn&> Worker::getConnectOverride(kj::StringPtr networkAddress) {
+  return connectOverrides.find(networkAddress);
 }
 
 Worker::Actor::Actor(const Worker& worker, kj::Maybe<RequestTracker&> tracker, Actor::Id actorId,


### PR DESCRIPTION
Such that internal machinery can generate special hostnames that will behave differently when connected to. This is useful, for example, to connect allow generic client libraries to connect to private local services using just a provided address (rather than requiring them them to support being passed a binding to call binding.connect() on).