### PR TITLE
Nest getActor tracing spans under "actor_subrequest" spans

### DIFF
--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -835,13 +835,14 @@ public:
   }
 
   kj::Own<IoChannelFactory::ActorChannel> getGlobalActorChannel(
-        uint channel, const ActorIdFactory::ActorId& id, kj::Maybe<kj::String> locationHint,
-        ActorGetMode mode) {
+      uint channel, const ActorIdFactory::ActorId& id, kj::Maybe<kj::String> locationHint,
+      ActorGetMode mode, SpanParent parentSpan) {
     return getIoChannelFactory().getGlobalActor(channel, id, kj::mv(locationHint), mode,
-        getCurrentTraceSpan());
+        kj::mv(parentSpan));
   }
-  kj::Own<IoChannelFactory::ActorChannel> getColoLocalActorChannel(uint channel, kj::StringPtr id) {
-    return getIoChannelFactory().getColoLocalActor(channel, id, getCurrentTraceSpan());
+  kj::Own<IoChannelFactory::ActorChannel> getColoLocalActorChannel(uint channel, kj::StringPtr id,
+      SpanParent parentSpan) {
+    return getIoChannelFactory().getColoLocalActor(channel, id, kj::mv(parentSpan));
   }
 
   // Get an HttpClient to use for Cache API subrequests.

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -786,7 +786,8 @@ public:
       kj::FunctionParam<kj::Own<WorkerInterface>(SpanBuilder&, IoChannelFactory&)> func,
       SubrequestOptions options);
 
-  // If creating a new subrequest is permitted, calls the given factory function to create one.
+  // If creating a new subrequest is permitted, calls the given factory function synchronously to
+  // create one.
   kj::Own<WorkerInterface> getSubrequest(
       kj::FunctionParam<kj::Own<WorkerInterface>(SpanBuilder&, IoChannelFactory&)> func,
       SubrequestOptions options);


### PR DESCRIPTION
Modify actor channel setup to let `getActor` tracing spans appear nested under `actor_subrequest` spans, instead of under the context's "current" span

This change does have the side effect of skipping the lazy actor stub initialization if an intervening step of the fetcher setup fails (e.g. when the worker is over request limits), but I think this is unlikely to have user-visible behavior, and may in fact be desirable, in that it avoids unnecessary `getActor()` calls.