### PR TITLE
Update capnproto submodule to pick up KJ_IF_SOME

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,6 +39,10 @@ build:fastdbg --//:dead_strip=False
 build --@capnp-cpp//src/kj:openssl=True --@capnp-cpp//src/kj:zlib=True --@capnp-cpp//src/kj:brotli=True
 build --cxxopt="-fbracket-depth=512" --host_cxxopt="-fbracket-depth=512"
 
+# Disable the new Maybe deprecations until we have converted more of the codebase.
+build --@capnp-cpp//src/kj:deprecate_kj_if_maybe=False
+build --@capnp-cpp//src/kj:deprecate_empty_maybe_from_nullptr=False
+
 # Additional Rust flags (see https://doc.rust-lang.org/rustc/codegen-options/index.html)
 # Need to disable debug-assertions for fastbuild, should be off automatically for opt. As long as
 # rust-level LTO is not enabled, LLVM bitcode is not needed so -C embed-bitcode=n provides a free

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,10 +24,10 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "0b9b07d26dd7ea2eff3ec05757c0ae745e9c813941e06fcdcb93d6e4d2750d01",
-    strip_prefix = "capnproto-capnproto-24f476f/c++",
+    sha256 = "ebdee7a4c091cc96b15b05f786523f5f20e4098d0e5d3502cd1b5dd21e9add5c",
+    strip_prefix = "capnproto-capnproto-2818ef1/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/24f476fcdb3019135eb00ac7787d0a0f1985f897"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/2818ef1435057c62401ec6fbb7b50c65afee7957"],
 )
 
 http_archive(


### PR DESCRIPTION
For now, I'm disabling the new deprecation warnings, since they are very noisy.

Depends on https://github.com/capnproto/capnproto/pull/1777