### PR TITLE
Update install-deps.bat to LLVM 16

### DIFF
--- a/tools/windows/install-deps.bat
+++ b/tools/windows/install-deps.bat
@@ -73,7 +73,11 @@ call :AddToUserPathInEnvironment C:\msys64\usr\bin
 
 echo.
 echo.* Step 7: Install LLVM compiler toolchain.
-winget install "LLVM" --version 15.0.7
+@rem workerd is tied to 16.0.6 for the time being (https://github.com/cloudflare/workerd/pull/1092).
+winget install "LLVM" --version 16.0.6
+@rem Work around for clang / bazel not agreeing on install location, will be fixed by
+@rem https://github.com/bazelbuild/bazel/pull/1939.
+move "C:\Program Files\LLVM\lib\clang\16" "C:\Program Files\LLVM\lib\clang\16.0.6"
 
 echo.
 echo.* Step 8: Install bazelisk as %LOCALAPPDATA%\Programs\bazelisk\bazel.exe.


### PR DESCRIPTION
Sync with .bazelrc changes in d9338a6c425b57999be38661133282629ade1f69 (https://github.com/cloudflare/workerd/pull/1092)

The script now installs LLVM 16.0.6 and moves the clang include dir to match the expectations in .bazelrc. Hopefully, the .bazelrc changes can be dropped soon, but in the interim ensure local setup and build continues to work.