### PR TITLE
[nfc] using malloc hooks to benchmark memory allocations too.

### DIFF
--- a/build/wd_cc_benchmark.bzl
+++ b/build/wd_cc_benchmark.bzl
@@ -13,25 +13,25 @@ def wd_cc_benchmark(
         name = name,
         defines = ["WD_IS_BENCHMARK"],
         linkopts = linkopts + select({
-          "@//:use_dead_strip": ["-Wl,-dead_strip"],
-          "//conditions:default": [""],
+            "@//:use_dead_strip": ["-Wl,-dead_strip"],
+            "//conditions:default": [""],
         }),
         visibility = visibility,
         deps = deps + [
-          "@com_google_benchmark//:benchmark_main",
-          "//src/workerd/tests:bench-tools"
+            "@workerd//src/workerd/tests:benchmark-main",
+            "@workerd//src/workerd/tests:bench-tools",
         ],
         # use the same malloc we use for server
-        malloc = "//src/workerd/server:malloc",
+        # malloc = "//src/workerd/server:malloc",
         tags = ["benchmark"],
         **kwargs
     )
 
     # generate benchmark report
     native.genrule(
-      name = name + "@benchmark.csv",
-      outs = [name + ".benchmark.csv"],
-      srcs = [name],
-      cmd = "./$(location {}) --benchmark_format=csv > \"$@\"".format(name),
-      tags = ["off-by-default", "benchmark_report"],
+        name = name + "@benchmark.csv",
+        outs = [name + ".benchmark.csv"],
+        srcs = [name],
+        cmd = "./$(location {}) --benchmark_format=csv > \"$@\"".format(name),
+        tags = ["off-by-default", "benchmark_report"],
     )

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -13,6 +13,31 @@ wd_cc_library(
 )
 
 wd_cc_library(
+    name = "benchmark-main",
+    srcs = ["benchmark-main.c++"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+    ] + select({
+        "@platforms//os:linux": [":malloc-memory-manager"],
+        "//conditions:default": [],
+    }),
+)
+
+wd_cc_library(
+    name = "malloc-memory-manager",
+    srcs = ["malloc-memory-manager.c++"],
+    hdrs = ["malloc-memory-manager.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        "@com_google_benchmark//:benchmark",
+    ],
+)
+
+wd_cc_library(
     name = "test-fixture",
     srcs = ["test-fixture.c++"],
     hdrs = ["test-fixture.h"],

--- a/src/workerd/tests/benchmark-main.c++
+++ b/src/workerd/tests/benchmark-main.c++
@@ -1,0 +1,22 @@
+#include <benchmark/benchmark.h>
+
+#ifdef __GLIBC__
+#include "malloc-memory-manager.h"
+#endif
+
+// Main function for benchmark.
+// Skeleton implementation comes from BENCHMARK_MAIN in benchmark.h
+int main(int argc, char** argv) {
+  benchmark::Initialize(&argc, argv);
+  if (benchmark::ReportUnrecognizedArguments(argc, argv))
+    return 1;
+
+#ifdef __GLIBC__
+  workerd::MallocMemoryManager memoryManager;
+  benchmark::RegisterMemoryManager(&memoryManager);
+#endif
+
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+  return 0;
+}

--- a/src/workerd/tests/malloc-memory-manager.c++
+++ b/src/workerd/tests/malloc-memory-manager.c++
@@ -1,0 +1,46 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "malloc-memory-manager.h"
+#include <malloc.h>
+
+namespace workerd {
+
+void* (*MallocMemoryManager::oldMallocHook)(size_t __size, const void*) = nullptr;
+
+std::atomic<size_t> MallocMemoryManager::allocCount = 0;
+std::atomic<size_t> MallocMemoryManager::allocSize = 0;
+
+#pragma clang diagnostic push
+// For some reason __malloc_hook is marked as deprecated.
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+void MallocMemoryManager::Start() {
+  allocCount = 0;
+  allocSize = 0;
+
+  oldMallocHook = __malloc_hook;
+  __malloc_hook = mallocHook;
+}
+
+void MallocMemoryManager::Stop(benchmark::MemoryManager::Result& result) {
+  result.total_allocated_bytes = allocSize;
+  result.num_allocs = allocCount;
+}
+
+void* MallocMemoryManager::mallocHook(size_t size, const void* caller) {
+  allocCount++;
+  allocSize += size;
+
+  __malloc_hook = oldMallocHook;
+  auto result = malloc(size);
+  oldMallocHook = __malloc_hook;
+  __malloc_hook = mallocHook;
+
+  return result;
+}
+
+#pragma clang diagnostic pop
+
+} // namespace workerd

--- a/src/workerd/tests/malloc-memory-manager.h
+++ b/src/workerd/tests/malloc-memory-manager.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+// Benchmarking memory manager. Uses glibc malloc hooks to track allocation statistics.
+// https://www.gnu.org/savannah-checkouts/gnu/libc/manual/html_node/Hooks-for-Malloc.html
+
+#include <benchmark/benchmark.h>
+
+namespace workerd {
+
+class MallocMemoryManager: public benchmark::MemoryManager {
+public:
+  void Start() override;
+  void Stop(benchmark::MemoryManager::Result& result) override;
+
+private:
+  static std::atomic<size_t> allocCount;
+  static std::atomic<size_t> allocSize;
+
+  static void *(*oldMallocHook)(size_t __size, const void *);
+  static void * mallocHook(size_t size, const void *caller);
+};
+
+}  // namespace workerd


### PR DESCRIPTION
according to https://github.com/google/benchmark/issues/1217 it is output only in .json format.

Results for bench-api-headers:

```
      "allocs_per_iter": 9.8750000000000000e+01,
      "max_bytes_used": 0,
      "total_allocated_bytes": 800105
```
