### PR TITLE
[nfc] Lint bazel files using buildifier

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,9 +1,9 @@
-load("@capnp-cpp//src/capnp:cc_capnp_library.bzl", "cc_capnp_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_link_package", "npm_package")
-load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@npm//:capnpc-ts/package_json.bzl", capnpc_ts_bin = "bin")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@capnp-cpp//src/capnp:cc_capnp_library.bzl", "cc_capnp_library")
+load("@npm//:capnpc-ts/package_json.bzl", capnpc_ts_bin = "bin")
+load("@npm//:defs.bzl", "npm_link_all_packages")
 
 cc_capnp_library(
     name = "icudata-embed",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,8 +3,8 @@ workspace(name = "workerd")
 # ========================================================================================
 # Bazel basics
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 http_archive(
     name = "bazel_skylib",

--- a/build/BUILD.dawn
+++ b/build/BUILD.dawn
@@ -1,5 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_binary")
 load("@py_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary")
 
 py_binary(
     name = "dawn_json_generator",

--- a/build/kj_test.bzl
+++ b/build/kj_test.bzl
@@ -14,7 +14,7 @@ def kj_test(
             "//conditions:default": ["@workerd//src/workerd/util:symbolizer"],
         }) + deps,
         linkopts = select({
-          "@//:use_dead_strip": ["-Wl,-dead_strip", "-Wl,-no_exported_symbols"],
-          "//conditions:default": [""],
+            "@//:use_dead_strip": ["-Wl,-dead_strip", "-Wl,-no_exported_symbols"],
+            "//conditions:default": [""],
         }),
     )

--- a/build/run_binary_target.bzl
+++ b/build/run_binary_target.bzl
@@ -5,7 +5,7 @@
 
 def _run_binary_target_impl(ctx):
     tool = ctx.attr.tool[DefaultInfo].files_to_run.executable
-    flags = [ ctx.expand_location(a) if "$(location" in a else a for a in ctx.attr.args ]
+    flags = [ctx.expand_location(a) if "$(location" in a else a for a in ctx.attr.args]
 
     cmd = " ".join([tool.path] + flags)
     ctx.actions.run_shell(
@@ -32,6 +32,7 @@ run_binary_target = rule(
         "tool": attr.label(
             executable = True,
             cfg = "target",
-            mandatory = True),
+            mandatory = True,
+        ),
     },
 )

--- a/build/wd_cc_binary.bzl
+++ b/build/wd_cc_binary.bzl
@@ -21,8 +21,8 @@ def wd_cc_binary(
         # (mac-specific feature). In particular, the symbol table is not affected (the name of the
         # flag is misleading here).
         linkopts = linkopts + select({
-          "@//:use_dead_strip": ["-Wl,-dead_strip", "-Wl,-no_exported_symbols"],
-          "//conditions:default": [""],
+            "@//:use_dead_strip": ["-Wl,-dead_strip", "-Wl,-no_exported_symbols"],
+            "//conditions:default": [""],
         }),
         visibility = visibility,
         **kwargs

--- a/build/wd_test.bzl
+++ b/build/wd_test.bzl
@@ -61,7 +61,7 @@ def _wd_test_impl(ctx):
     return [
         DefaultInfo(
             executable = executable,
-            runfiles = ctx.runfiles(files = ctx.files.data)
+            runfiles = ctx.runfiles(files = ctx.files.data),
         ),
     ]
 
@@ -78,5 +78,5 @@ _wd_test = rule(
         "flags": attr.string_list(),
         "data": attr.label_list(allow_files = True),
         "_platforms_os_windows": attr.label(default = "@platforms//os:windows"),
-    }
+    },
 )

--- a/build/wd_ts_type_test.bzl
+++ b/build/wd_ts_type_test.bzl
@@ -1,6 +1,5 @@
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("//:build/typescript.bzl", "module_name")
 load("@npm//:typescript/package_json.bzl", tsc_bin = "bin")
+load("//:build/typescript.bzl", "module_name")
 
 def wd_ts_type_test(src, **kwargs):
     """Bazel rule to test TypeScript file type-checks under @cloudflare/workers-types"""

--- a/rust-deps/BUILD.bazel
+++ b/rust-deps/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@rules_rust//crate_universe:defs.bzl", "crate", "crates_vendor")
 load("@rules_rust//rust:defs.bzl", "rust_static_library")
-load("@bazel_skylib//lib:selects.bzl", "selects")
 load("packages.bzl", "PACKAGES")
 
 selects.config_setting_group(

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
 load("//:build/kj_test.bzl", "kj_test")
+load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
 load("//:build/wd_test.bzl", "wd_test")
 
 filegroup(

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -1,7 +1,7 @@
-load("//:build/kj_test.bzl", "kj_test")
-load("//:build/wd_cc_library.bzl", "wd_cc_library")
-load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("//:build/kj_test.bzl", "kj_test")
+load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
+load("//:build/wd_cc_library.bzl", "wd_cc_library")
 
 # Flag to enable WebGPU support via the Dawn library
 bool_flag(

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -1,8 +1,8 @@
-load("//:build/wd_cc_library.bzl", "wd_cc_library")
-load("//:build/js_capnp_library.bzl", "js_capnp_library")
-load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
-load("//:build/kj_test.bzl", "kj_test")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("//:build/js_capnp_library.bzl", "js_capnp_library")
+load("//:build/kj_test.bzl", "kj_test")
+load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
+load("//:build/wd_cc_library.bzl", "wd_cc_library")
 
 wd_cc_library(
     name = "jsg",

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -1,9 +1,9 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//:build/kj_test.bzl", "kj_test")
-load("//:build/wd_cc_library.bzl", "wd_cc_library")
 load("//:build/wd_cc_binary.bzl", "wd_cc_binary")
 load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("@bazel_skylib//lib:selects.bzl", "selects")
+load("//:build/wd_cc_library.bzl", "wd_cc_library")
 
 config_setting(
     name = "is_linux",

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//:build/kj_test.bzl", "kj_test")
-load("//:build/wd_cc_library.bzl", "wd_cc_library")
 load("//:build/wd_cc_benchmark.bzl", "wd_cc_benchmark")
+load("//:build/wd_cc_library.bzl", "wd_cc_library")
 
 wd_cc_library(
     name = "bench-tools",

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -1,9 +1,9 @@
-load("//:build/wd_cc_binary.bzl", "wd_cc_binary")
-load("//:build/wd_cc_library.bzl", "wd_cc_library")
-load("//:build/cc_ast_dump.bzl", "cc_ast_dump")
-load("//:build/run_binary_target.bzl", "run_binary_target")
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//:build/cc_ast_dump.bzl", "cc_ast_dump")
+load("//:build/run_binary_target.bzl", "run_binary_target")
+load("//:build/wd_cc_binary.bzl", "wd_cc_binary")
+load("//:build/wd_cc_library.bzl", "wd_cc_library")
 
 # ========================================================================================
 # C++ deps for API extraction

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//:build/wd_cc_library.bzl", "wd_cc_library")
 load("//:build/kj_test.bzl", "kj_test")
+load("//:build/wd_cc_library.bzl", "wd_cc_library")
 
 wd_cc_library(
     name = "util",
@@ -51,7 +51,7 @@ wd_cc_library(
 wd_cc_library(
     name = "test-util",
     srcs = ["capnp-mock.c++"],
-    hdrs = glob(["capnp-mock.h"]),
+    hdrs = ["capnp-mock.h"],
     visibility = ["//visibility:public"],
     deps = [
         "@capnp-cpp//src/capnp:capnpc",

--- a/types/BUILD.bazel
+++ b/types/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary", "js_test")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
 load("//:build/wd_ts_project.bzl", "wd_ts_project")
 load("//:build/wd_ts_test.bzl", "wd_ts_test")
 load("//:build/wd_ts_type_test.bzl", "wd_ts_type_test")


### PR DESCRIPTION
This largely reorders statements to fix lint messages in VSCode, behavior is not affected.