### PR TITLE
[CI] Do not allow stale cache to be used

### DIFF
--- a/.github/workflows/npm-types.yml
+++ b/.github/workflows/npm-types.yml
@@ -28,9 +28,6 @@ jobs:
         with:
           path: ~/bazel-disk-cache
           key: capnp-cache-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
-          # Use cache from older version.
-          restore-keys: |
-            capnp-cache-${{ runner.os }}-
       - name: build capnp
         run: |
           bazel build --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev @capnp-cpp//src/capnp:capnp_tool
@@ -52,8 +49,6 @@ jobs:
           # The types cache is significantly smaller than the whole cache (350MB as of writing), so
           # we can probably afford for it to have its own cache key.
           key: bazel-disk-cache-types-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
-          restore-keys: |
-            bazel-disk-cache-types-${{ runner.os }}-
 
       - name: install dependencies
         run: |

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -28,8 +28,6 @@ jobs:
         with:
           path: ~/bazel-disk-cache
           key: capnp-cache-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
-          restore-keys: |
-            capnp-cache-${{ runner.os }}-
       - name: build capnp
         run: |
           bazel build --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev @capnp-cpp//src/capnp:capnp_tool

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           path: ~/bazel-disk-cache
           key: capnp-cache-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
-          restore-keys: |
-            capnp-cache-${{ runner.os }}-
       - name: build capnp
         run: |
           bazel build --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev @capnp-cpp//src/capnp:capnp_tool
@@ -51,8 +49,6 @@ jobs:
           # Use a different cache key than for tests here, otherwise the release cache could end up
           # being used for test builds, where it provides little benefit.
           key: bazel-disk-cache-release-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
-          restore-keys: |
-            bazel-disk-cache-${{ runner.os }}-${{ runner.arch }}-
       - name: Setup Linux
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,9 @@ jobs:
         with:
           path: ~/bazel-disk-cache
           key: bazel-disk-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
-          # Use an older cache key, if available.
-          restore-keys: |
-            bazel-disk-cache-${{ runner.os }}-${{ runner.arch }}-
+          # Intentionally not reusing an older cache entry using a key prefix, bazel frequently
+          # ends up with a larger cache at the end when starting with an available cache entry,
+          # resulting in a snowballing cache size and cache download/upload times.
       - name: Setup Linux
         if: runner.os == 'Linux'
         # Install dependencies, including clang via through LLVM APT repository. Note that this


### PR DESCRIPTION
The potential cache issue mentioned in #980 does end up happening and on a larger scale than expected: Unfortunately, bazel ends up with a significantly larger cache after running, causing caches to grow unacceptably big over several cycles of creating a new cache entry based on an old cache entry. For example, the Linux release cache is ~300MB when generated from scratch, but the cache using the key `bazel-disk-cache-release-Linux-X64-e28f1163e74e6d1aedb49ec825177f2daa557137cdcce3a89271b392de3df1d4` is 2.5 GB large. This causes CI runners to take a long time downloading/uploading the cache data, which is the opposite of what cache reuse is intended to do.