### PR TITLE
Improve the Error thrown by a Socket's WritableStream after closure

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -357,7 +357,7 @@ void Socket::handleProxyStatus(jsg::Lock& js, kj::Promise<kj::Maybe<kj::Exceptio
 void Socket::handleProxyError(jsg::Lock& js, kj::Exception e) {
   resolveFulfiller(js, kj::mv(e));
   readable->getController().cancel(js, nullptr).markAsHandled(js);
-  writable->getController().abort(js, nullptr).markAsHandled(js);
+  writable->getController().abort(js, js.error(e.getDescription())).markAsHandled(js);
 }
 
 void Socket::handleReadableEof(jsg::Lock& js, jsg::Promise<void> onEof) {

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -902,6 +902,9 @@ jsg::Promise<void> WritableStreamInternalController::flush(
 jsg::Promise<void> WritableStreamInternalController::abort(
     jsg::Lock& js,
     jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+  // While it may be confusing to users to throw `undefined` rather than a more helpful Error here,
+  // doing so is required by the relevant spec:
+  // https://streams.spec.whatwg.org/#writable-stream-abort
   return doAbort(js, maybeReason.orDefault(js.v8Undefined()));
 }
 


### PR DESCRIPTION
For all I know it has to be this way for compatibility reasons, but I have to say it confused me when I saw `undefined` getting thrown during some tests I was running, so I'm sending this out in case it wasn't intentional.

The error message was chosen to be analogous to what's used by ReadableStreamInternalController::doCancel ("Stream was cancelled."), but I'm not at all attached to it.

For clarity, I ran into this case due to Socket::handleProxyStatus calling `writable->getController().abort(js, nullptr)`. If for some reason this isn't something we want to add to the WritableStream implementation, I'll go ahead and change that call point instead.