### PR TITLE
Move compile_flags.txt to the tools/ directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ node_modules
 /npm/workerd/install.js
 /npm/workerd/lib/
 
+# compile_flags.txt is store in tools/ and copied into place when VSCode opens up a workspace.
+/compile_flags.txt
+
 # The external link for compile_flags.txt: Differs on Windows vs macOS/Linux, so we can't check it in. The pattern needs to not have a trailing / because it's a symlink on macOS/Linux.
 /external
 # Bazel output symlinks: Same reasoning as /external. You need the * because people can change the name of the directory your repository is cloned into, changing the bazel-<workspace_name> symlink.

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -220,6 +220,28 @@
         "reevaluateOnRerun": false,
         "runOn": "folderOpen"
       }
+    },
+    {
+      "label": "Setup compile_flags.txt",
+      "linux": {
+        "command": "cp \"${workspaceFolder}/tools/compile_flags.txt\" \"${workspaceFolder}/compile_flags.txt\""
+      },
+      "osx": {
+        "command": "cp \"${workspaceFolder}/tools/compile_flags.txt\" \"${workspaceFolder}/compile_flags.txt\""
+      },
+      "windows": {
+        "command": "Copy-Item \"${workspaceFolder}/tools/compile_flags.txt\" \"${workspaceFolder}/compile_flags.txt\""
+      },
+      "group": "none",
+      "type": "shell",
+      "presentation": {
+        "reveal": "never",
+        "panel": "dedicated"
+      },
+      "runOptions": {
+        "reevaluateOnRerun": false,
+        "runOn":"folderOpen"
+      },
     }
   ]
 }

--- a/tools/compile_flags.txt
+++ b/tools/compile_flags.txt
@@ -1,3 +1,6 @@
+# The master copy of this file lives under ${workspaceFolder}/tools/compile_flags.txt. For
+# standalone workerd development it is copied by vscode on startup to
+# ${workspaceFolder}/compile_flags.txt.
 -std=c++20
 -stdlib=libc++
 -xc++


### PR DESCRIPTION
When opening workerd in vscode, the "Setup compile_flags.txt" task copies compile_flags.txt into place.

This is custom step is because internal code and workerd have different dependencies and settings. When developing internal code, we don't want to use the standalone workerd compile_flags.txt