### PR TITLE
Clean up the line placement of some template declarations in io-context

### DIFF
--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -497,17 +497,17 @@ public:
   // DEPRECATED: Use version which passes a Lock.
   template <typename T, typename Func>
   jsg::PromiseForResult<Func, T, false> awaitIo(kj::Promise<T> promise, Func&& func);
-  template <typename T, typename Func>
 
+  template <typename T, typename Func>
   jsg::PromiseForResult<Func, T, true> awaitIo(
       jsg::Lock& js, kj::Promise<T> promise, Func&& func);
-  template <typename T, typename Func, typename ErrorFunc>
 
+  template <typename T, typename Func, typename ErrorFunc>
   jsg::PromiseForResult<Func, T, true> awaitIo(
       jsg::Lock& js, kj::Promise<T> promise, Func&& func, ErrorFunc&& errorFunc);
-  template <typename T>
 
   // DEPRECATED: Use version which passes a Lock.
+  template <typename T>
   jsg::Promise<T> awaitIo(kj::Promise<T> promise);
 
   // Waits for some background I/O to complete, then executes `func` on the result, returning a


### PR DESCRIPTION
I'm not sure how just these got messed up without any of the other template declarations in the file being similarly affected, but these are the only ones I noticed. I haven't checked any other files for something similar.

Looks like these got affected by the comment cleanup in d3f25fc1e6f073155ee6bf5c7656c153f241be80