### PR TITLE
JSG Completion: use JsObject for promise context tag

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1306,7 +1306,7 @@ void IoContext::runFinalizers(Worker::AsyncLock& asyncLock) {
     runImpl(runnable, false, asyncLock, nullptr, true);
   }
 
-  promiseContextTag = nullptr;
+  promiseContextTag = kj::none;
 }
 
 #ifdef KJ_DEBUG
@@ -1429,9 +1429,9 @@ void IoContext::requireCurrentOrThrowJs() {
       "of Cloudflare Workers which allows us to improve overall performance.");
 }
 
-v8::Local<v8::Object> IoContext::getPromiseContextTag(jsg::Lock& js) {
-  if (promiseContextTag == nullptr) {
-    promiseContextTag = js.v8Ref(v8::Object::New(js.v8Isolate));
+jsg::JsObject IoContext::getPromiseContextTag(jsg::Lock& js) {
+  if (promiseContextTag == kj::none) {
+    promiseContextTag = jsg::JsRef(js, js.obj());
   }
   return KJ_REQUIRE_NONNULL(promiseContextTag).getHandle(js);
 }

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -885,7 +885,7 @@ public:
 
   void writeLogfwdr(uint channel, kj::FunctionParam<void(capnp::AnyPointer::Builder)> buildMessage);
 
-  v8::Local<v8::Object> getPromiseContextTag(jsg::Lock& js);
+  jsg::JsObject getPromiseContextTag(jsg::Lock& js);
 
 private:
   ThreadContext& thread;
@@ -1040,7 +1040,7 @@ private:
   void requireCurrent();
   void checkFarGet(const DeleteQueue* expectedQueue);
 
-  kj::Maybe<jsg::V8Ref<v8::Object>> promiseContextTag;
+  kj::Maybe<jsg::JsRef<jsg::JsObject>> promiseContextTag;
 
   class Runnable {
   public:


### PR DESCRIPTION
Reminder: the promise context tag is the mechanism I added to v8 to allow us to do cross-request i/o awaits