### PR TITLE
[CI] Partially remove Windows workaround

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,9 +63,6 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
-          # Upgrade to LLVM 16.0.6, default install is currently 15 (https://github.com/actions/runner-images/issues/8125).
-          # When we need to upgrade beyond LLVM 16.0.6, ${WORKSPACE}/.bazelrc will need updating.
-          choco upgrade llvm --version=16.0.6
           # Work around bazel clang 16 include path bug (https://github.com/bazelbuild/bazel/issues/17863)
           Move-Item -Path "C:\Program Files\LLVM\lib\clang\16" -Destination "C:\Program Files\LLVM\lib\clang\16.0.6"
       - name: Bazel build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,9 +60,6 @@ jobs:
         run: |
             [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
             [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'build:windows --config=windows_no_dbg')
-            # Upgrade to LLVM 16.0.6, default install is currently 15 (https://github.com/actions/runner-images/issues/8125).
-            # When we need to upgrade beyond LLVM 16.0.6, ${WORKSPACE}/.bazelrc will need updating.
-            choco upgrade llvm --version=16.0.6
             # Work around bazel clang 16 include path bug (https://github.com/bazelbuild/bazel/issues/17863)
             Move-Item -Path "C:\Program Files\LLVM\lib\clang\16" -Destination "C:\Program Files\LLVM\lib\clang\16.0.6"
       - name: Bazel build


### PR DESCRIPTION
The Github CI images now include LLVM 16.0.6 by default as of https://github.com/actions/runner-images/commit/4a0c3808de19abe49a8cbdbfe8254ae92ed026e5. We should also be able to remove the bazel workaround soon (https://github.com/bazelbuild/bazel/issues/19035)