### PR TITLE
Bump compatibility date to `2023-09-08` for release

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -8,7 +8,7 @@ using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("workerd");
 $Cxx.allowCancellation;
 
-const supportedCompatibilityDate :Text = "2023-09-04";
+const supportedCompatibilityDate :Text = "2023-09-08";
 # Newest compatibility date that can safely be set using code compiled from this repo. Trying to
 # run a Worker with a newer compatibility date than this will fail.
 #


### PR DESCRIPTION
Hey! 👋 We'd like to do pre-releases of Miniflare & Wrangler including #1129. For this, we'll need a `workerd` release. Ideally, this would be a pre-release too. Our CI is setup to do pre-release npm publishes, but not GitHub pre-releases. With this in mind, I suggest we just do a regular `workerd` release, so our Git tags/GitHub releases/npm releases all stay in sync. Miniflare & Wrangler's `workerd` dependency is pinned, so they won't pick up this new release automatically. 👍 