### PR TITLE
Revert "Merge pull request #1042 from cloudflare/harris/kj-stack-arra…

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,10 +24,10 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "616d0671ae9b5ad8eb23b07c8a4735d8b6a10ba4a31be4f3a3415862a7da9415",
-    strip_prefix = "capnproto-capnproto-cd75213/c++",
+    sha256 = "19c489573aed8fe130f66e868e312d2cadfcdcb7b7640349b3b0f1cebfefe212",
+    strip_prefix = "capnproto-capnproto-99115bd/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/cd752137ebef4fdceac780b548a40d1ebed37162"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/99115bdd4b3b3227dfd363921c6399d8785017aa"],
 )
 
 http_archive(

--- a/src/workerd/api/encoding.c++
+++ b/src/workerd/api/encoding.c++
@@ -368,7 +368,7 @@ kj::Maybe<jsg::JsString> IcuDecoder::decode(
               buffer.size(),
               static_cast<size_t>(ucnv_toUCountPending(inner.get(), &status))));
 
-  kj::SmallArray<UChar, 512> result(limit);
+  KJ_STACK_ARRAY(UChar, result, limit, 512, 4096);
 
   auto dest = result.begin();
   auto source = reinterpret_cast<const char*>(buffer.begin());

--- a/src/workerd/api/node/buffer.c++
+++ b/src/workerd/api/node/buffer.c++
@@ -206,7 +206,7 @@ uint32_t writeInto(
           str.size());
     }
     case Encoding::HEX: {
-      kj::SmallArray<kj::byte, 1024> buf(string.length(js));
+      KJ_STACK_ARRAY(kj::byte, buf, string.length(js), 1024, 536870888);
       static constexpr jsg::JsString::WriteOptions options =
           static_cast<jsg::JsString::WriteOptions>(jsg::JsString::NO_NULL_TERMINATION |
                                                    jsg::JsString::REPLACE_INVALID_UTF8);
@@ -256,7 +256,7 @@ kj::Array<kj::byte> decodeStringImpl(
     case Encoding::BASE64URL: {
       // We do not use the kj::String conversion here because inline null-characters
       // need to be ignored.
-      kj::SmallArray<kj::byte, 1024> buf(length);
+      KJ_STACK_ARRAY(kj::byte, buf, length, 1024, 536870888);
       auto result = string.writeInto(js, buf, options);
       auto len = result.written;
       auto dest = kj::heapArray<kj::byte>(base64_decoded_size(buf.begin(), len));
@@ -268,7 +268,7 @@ kj::Array<kj::byte> decodeStringImpl(
       return dest.slice(0, len).attach(kj::mv(dest));
     }
     case Encoding::HEX: {
-      kj::SmallArray<kj::byte, 1024> buf(length);
+      KJ_STACK_ARRAY(kj::byte, buf, length, 1024, 536870888);
       string.writeInto(js, buf, options);
       return decodeHexTruncated(buf, strict);
     }

--- a/src/workerd/jsg/function.h
+++ b/src/workerd/jsg/function.h
@@ -433,7 +433,7 @@ public:
 
         v8::Local<v8::Value> result;
         if (args.size() > 0) {
-          kj::SmallArray<v8::Local<v8::Value>, 20> argv(args.size());
+          KJ_STACK_ARRAY(v8::Local<v8::Value>, argv, args.size(), 20, 20);
           for (size_t n = 0; n < args.size(); n++) {
             argv[n] = args[n].getHandle(js);
           }

--- a/src/workerd/jsg/iterator.h
+++ b/src/workerd/jsg/iterator.h
@@ -604,7 +604,7 @@ public:
       jsg::Sequence<U> sequence) {
     v8::Isolate* isolate = context->GetIsolate();
     v8::EscapableHandleScope handleScope(isolate);
-    kj::SmallArray<v8::Local<v8::Value>, MAX_STACK> items(sequence.size());
+    KJ_STACK_ARRAY(v8::Local<v8::Value>, items, sequence.size(), MAX_STACK, MAX_STACK);
     for (auto i: kj::indices(sequence)) {
       items[i] = static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(sequence[i]));
     }
@@ -618,7 +618,7 @@ public:
       jsg::Sequence<U>& sequence) {
     v8::Isolate* isolate = context->GetIsolate();
     v8::EscapableHandleScope handleScope(isolate);
-    kj::SmallArray<v8::Local<v8::Value>, MAX_STACK> items(sequence.size());
+    KJ_STACK_ARRAY(v8::Local<v8::Value>, items, sequence.size(), MAX_STACK, MAX_STACK);
     for (auto i: kj::indices(sequence)) {
       items[i] = static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(sequence[i]));
     }

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -92,7 +92,7 @@ V8System::V8System(kj::Own<v8::Platform> platformParam, kj::ArrayPtr<const kj::S
   // Especially annoying is that V8 expects an array of `char*` -- not `const`. It won't actually
   // modify the strings, so we'll just const_cast them here...
   int argc = flags.size() + 1;
-  kj::SmallArray<char*, 32> argv(flags.size() + 2);
+  KJ_STACK_ARRAY(char*, argv, flags.size() + 2, 32, 32);
   argv[0] = const_cast<char*>("fake-binary-name");
   for (auto i: kj::zeroTo(flags.size())) {
     argv[i + 1] = const_cast<char*>(flags[i].cStr());

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -30,7 +30,6 @@ typedef unsigned int uint;
 class JsExceptionThrown: public std::exception {
 public:
   JsExceptionThrown();
-  ~JsExceptionThrown() noexcept = default;  // We must match `std::exception`'s noexcept.
   const char* what() const noexcept override;
 
 private:

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -772,7 +772,7 @@ public:
     v8::EscapableHandleScope handleScope(isolate);
 
     auto len = array.size();
-    kj::SmallArray<v8::Local<v8::Value>, MAX_STACK> items(len);
+    KJ_STACK_ARRAY(v8::Local<v8::Value>, items, len, MAX_STACK, MAX_STACK);
     for (auto n = 0; n < len; n++) {
       items[n] = static_cast<TypeWrapper*>(this)->wrap(
           context, creator, kj::mv(array[n])).template As<v8::Value>();
@@ -789,7 +789,7 @@ public:
     v8::EscapableHandleScope handleScope(isolate);
 
     auto len = array.size();
-    kj::SmallArray<v8::Local<v8::Value>, MAX_STACK> items(len);
+    KJ_STACK_ARRAY(v8::Local<v8::Value>, items, len, MAX_STACK, MAX_STACK);
     for (auto n = 0; n < len; n++) {
       items[n] = static_cast<TypeWrapper*>(this)->wrap(
           context, creator, kj::mv(array[n])).template As<v8::Value>();


### PR DESCRIPTION
…y-no-longer-supports-vlas"

This reverts commit 028bdc6759921779cd02a15622483267756c6ec1, reversing changes made to 8aabe6a8de1d1e8c28ec45f85f4c9a1deb15cdff.

Instead of reverting our capnproto dependency back to what it was before the KJ_STACK_ARRAY removal PR, I have instead bumped it to a capnproto commit which is based on its origin/v2 branch, with the KJ_STACK_ARRAY revert on top.