### PR TITLE
Remove extraneous `"` from `listen-inspector` control message

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2706,7 +2706,7 @@ void Server::startServices(jsg::V8System& v8System, config::Config::Reader confi
     auto registrar = kj::heap<InspectorServiceIsolateRegistrar>();
     auto port = startInspector(inspectorAddress, *registrar);
     KJ_IF_SOME(stream, controlOverride) {
-      auto message = kj::str("{\"event\":\"listen-inspector\",\"port\":\"", port, "}\n");
+      auto message = kj::str("{\"event\":\"listen-inspector\",\"port\":", port, "}\n");
       try {
         stream->write(message.begin(), message.size());
       } catch (kj::Exception& e) {


### PR DESCRIPTION
An extra `"` snuck into #1127, leading to invalid JSON being logged. Ooops!