### PR TITLE
Fixup MessageEvent.data regression

### DIFF
--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -844,8 +844,8 @@ kj::Promise<kj::Maybe<kj::Exception>> WebSocket::readLoop() {
                 jsg::alloc<MessageEvent>(js, js.str(text)));
           }
           KJ_CASE_ONEOF(data, kj::Array<byte>) {
-            dispatchEventImpl(js,
-                jsg::alloc<MessageEvent>(js, jsg::JsValue(js.bytes(kj::mv(data)).getHandle(js))));
+            dispatchEventImpl(js, jsg::alloc<MessageEvent>(js,
+                jsg::JsValue(js.arrayBuffer(kj::mv(data)).getHandle(js))));
           }
           KJ_CASE_ONEOF(close, kj::WebSocket::Close) {
             native.closedIncoming = true;

--- a/src/workerd/jsg/buffersource.h
+++ b/src/workerd/jsg/buffersource.h
@@ -408,4 +408,8 @@ public:
   }
 };
 
+inline BufferSource Lock::arrayBuffer(kj::Array<kj::byte> data) {
+  return BufferSource(*this, BackingStore::from<v8::ArrayBuffer>(kj::mv(data)));
+}
+
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2170,7 +2170,12 @@ public:
   JsDate date(kj::Date date) KJ_WARN_UNUSED_RESULT;
   JsDate date(kj::StringPtr date) KJ_WARN_UNUSED_RESULT;
 
+  // Returns a jsg::BufferSource whose underlying JavaScript handle is a Uint8Array.
   BufferSource bytes(kj::Array<kj::byte> data) KJ_WARN_UNUSED_RESULT;
+
+  // Returns a jsg::BufferSource whose underlying JavaScript handle is an ArrayBuffer
+  // as opposed to the default Uint8Array.
+  BufferSource arrayBuffer(kj::Array<kj::byte> data) KJ_WARN_UNUSED_RESULT;
 
   enum RegExpFlags {
     kNONE = v8::RegExp::Flags::kNone,


### PR DESCRIPTION
MessageEvent.data should be an `ArrayBuffer` if the data is bytes. The recent JsValue conversion accidentally changed it to `Uint8Array`.