### PR TITLE
Fix generated `TextEncoder#encode()` return type

### DIFF
--- a/src/workerd/api/encoding.h
+++ b/src/workerd/api/encoding.h
@@ -220,6 +220,13 @@ public:
     } else {
       JSG_READONLY_INSTANCE_PROPERTY(encoding, getEncoding);
     }
+
+    // `encode()` returns `jsg::BufferSource`, which may be an `ArrayBuffer` or `ArrayBufferView`,
+    // but the implementation uses `jsg::BufferSource::tryAlloc()` which always tries to allocate a
+    // `Uint8Array`. The spec defines that this function returns a `Uint8Array` too.
+    JSG_TS_OVERRIDE({
+      encode(input?: string): Uint8Array;
+    });
   }
 };
 


### PR DESCRIPTION
Hey! 👋  This PR fixes the auto-generated return type of `TextEncoder#encode()`. https://github.com/cloudflare/workerd/pull/1047 updated this function to return a `jsg::BufferSource`. This generates `ArrayBuffer | ArrayBufferView` as the TypeScript type, as `jsg::BufferSource` [retains the input type when passed back out to JavaScript](https://github.com/cloudflare/workerd/blob/main/src/workerd/jsg/README.md#typedarrays-kjarraykjbyte-and-jsgbuffersource). `TextEnoder::encode()` uses `BufferSource::tryAlloc()` though which always gives a `Uint8Array`: https://github.com/cloudflare/workerd/blob/2182afdd8ca9ac35fb18b76205308fabd5000d01/src/workerd/jsg/buffersource.c%2B%2B#L89
Therefore, an override has been added to force a `Uint8Array` return type as required by [the spec](https://encoding.spec.whatwg.org/#interface-textencoder).

Fixes https://github.com/cloudflare/workerd/issues/1149