### PR TITLE
Log fatal errors in `Server`

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2335,6 +2335,7 @@ kj::Own<Server::Service> Server::makeService(
 }
 
 void Server::taskFailed(kj::Exception&& exception) {
+  KJ_LOG(ERROR, exception);
   fatalFulfiller->reject(kj::mv(exception));
 }
 


### PR DESCRIPTION
Hey! 👋 Currently if you try to start a second `workerd` instance with a socket listening on the same port, it will just exit with a zero exit code and won't log anything. This makes [debugging issues pretty tricky](https://github.com/cloudflare/workers-sdk/pull/3695#issuecomment-1714511869).

With this change, fatal errors are now logged. This seemed like a reasonable place to put this log, but I'm worried this is just addressing a symptom of a slightly bigger problem...

Looking at comments, it seems like `wait()` is supposed to throw an exception when the promise rejects:
https://github.com/cloudflare/workerd/blob/e6644c61245f31d8f9aa8560793ef577122c21c2/src/workerd/server/workerd.c%2B%2B#L1035
...but I added some logs added after this line and they're hit even when a fatal error is thrown, hence the "clean" zero exit. This seems to suggest `Server::run()` isn't actually throwing on fatal exceptions?
https://github.com/cloudflare/workerd/blob/e6644c61245f31d8f9aa8560793ef577122c21c2/src/workerd/server/server.c%2B%2B#L2574
Not sure if this is due to the recent coroutine conversions maybe?