### PR TITLE
[nfc] Refactor bazel dependencies

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//:build/kj_test.bzl", "kj_test")
 load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
+load("//:build/wd_cc_library.bzl", "wd_cc_library")
 load("//:build/wd_test.bzl", "wd_test")
 
 filegroup(
@@ -8,12 +9,16 @@ filegroup(
         "//src/workerd/io:set_enable_experimental_webgpu": glob(
             ["**/*.c++"],
             exclude = [
+                "html-rewriter.c++",
+                "rtti.c++",
                 "**/*test*.c++",
             ],
         ),
         "//conditions:default": glob(
             ["**/*.c++"],
             exclude = [
+                "html-rewriter.c++",
+                "rtti.c++",
                 "**/*test*.c++",
                 "gpu/*.c++",
             ],
@@ -28,18 +33,51 @@ filegroup(
         "//src/workerd/io:set_enable_experimental_webgpu": glob(
             ["**/*.h"],
             exclude = [
+                "html-rewriter.h",
+                "modules.h",
+                "rtti.h",
                 "**/*test*.h",
             ],
         ),
         "//conditions:default": glob(
             ["**/*.h"],
             exclude = [
+                "html-rewriter.h",
+                "modules.h",
+                "rtti.h",
                 "**/*test*.h",
                 "gpu/*.h",
             ],
         ),
     }),
     visibility = ["//visibility:public"],
+)
+
+wd_cc_library(
+    name = "rtti",
+    srcs = ["rtti.c++"],
+    hdrs = [
+        "rtti.h",
+        "modules.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":html-rewriter",
+        "//src/workerd/io",
+    ],
+)
+
+# Moved out of io library so that it does not depend on lolhtml and the associated rust crates.
+# This reduces the linker input size for tests based on io.
+wd_cc_library(
+    name = "html-rewriter",
+    srcs = ["html-rewriter.c++"],
+    hdrs = ["html-rewriter.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/workerd/io",
+        "@com_cloudflare_lol_html//:lolhtml",
+    ],
 )
 
 wd_cc_capnp_library(
@@ -58,11 +96,11 @@ wd_cc_capnp_library(
     src = f,
     deps = [
         "//src/workerd/io",
-        "//src/workerd/jsg:rtti",
     ],
 ) for f in glob(
     ["**/*-test.c++"],
     exclude = [
+        "api-rtti-test.c++",
         "cf-property-test.c++",
         "node/*-test.c++",
     ],
@@ -71,6 +109,15 @@ wd_cc_capnp_library(
 kj_test(
     src = "node/buffer-test.c++",
     deps = ["//src/workerd/tests:test-fixture"],
+)
+
+kj_test(
+    src = "api-rtti-test.c++",
+    deps = [
+        ":html-rewriter",
+        "//src/workerd/io",
+        "//src/workerd/jsg:rtti",
+    ],
 )
 
 kj_test(

--- a/src/workerd/api/html-rewriter.h
+++ b/src/workerd/api/html-rewriter.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
+#include "workerd/api/http.h"
 #include <workerd/jsg/jsg.h>
 #include <v8.h>
-#include "http.h"
 
 struct lol_html_HtmlRewriterBuilder;
 struct lol_html_HtmlRewriter;

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -72,7 +72,6 @@ wd_cc_library(
         "@capnp-cpp//src/kj:kj-async",
         "@capnp-cpp//src/kj/compat:kj-brotli",
         "@capnp-cpp//src/kj/compat:kj-gzip",
-        "@com_cloudflare_lol_html//:lolhtml",
     ] + select({
         ":set_enable_experimental_webgpu": ["@dawn"],
         "//conditions:default": [],

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -76,9 +76,13 @@ wd_cc_library(
     deps = [
         ":rtti_capnp",
         ":jsg",
-        # todo: move text encoding out
-        "@capnp-cpp//src/capnp:capnpc",
     ],
+)
+
+wd_cc_library(
+    name = "macro-meta",
+    hdrs = ["macro-meta.h"],
+    visibility = ["//visibility:public"],
 )
 
 wd_cc_capnp_library(
@@ -106,10 +110,21 @@ wd_cc_library(
     ["*-test.c++"],
     exclude = [
         # defined below
+        "macro-meta-test.c++",
         "resource-test.c++",
         "rtti-test.c++",
     ],
 )]
+
+# Moved out as macro-meta-test does not depend on V8 or JSG proper, this makes the test much
+# smaller.
+kj_test(
+    src = "macro-meta-test.c++",
+    tags = ["no-arm64"],
+    deps = [
+        ":macro-meta",
+    ],
+)
 
 kj_test(
     src = "rtti-test.c++",
@@ -117,6 +132,8 @@ kj_test(
     deps = [
         ":rtti",
         ":rtti_test_capnp",
+        # todo: move text encoding out
+        "@capnp-cpp//src/capnp:capnpc",
     ],
 )
 

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -50,6 +50,7 @@ wd_cc_binary(
         ":server",
         ":workerd-meta_capnp",
         ":workerd_capnp",
+        "@capnp-cpp//src/capnp:capnpc",
     ] + select({
         "@platforms//os:windows": [],
         "//conditions:default": ["@workerd//src/workerd/util:symbolizer"],
@@ -93,9 +94,10 @@ wd_cc_library(
     deps = [
         ":alarm-scheduler",
         ":workerd_capnp",
+        "//src/workerd/api:html-rewriter",
+        "//src/workerd/api:rtti",
         "//src/workerd/io",
         "//src/workerd/jsg",
-        "@capnp-cpp//src/capnp:capnpc",
     ],
 )
 

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -14,10 +14,11 @@ load("//:build/wd_cc_library.bzl", "wd_cc_library")
 wd_cc_library(
     name = "api_encoder_lib",
     deps = [
+        "//src/workerd/api:html-rewriter",
         "//src/workerd/io",
         "//src/workerd/jsg",
         "//src/workerd/jsg:rtti",
-        "@capnp-cpp//src/capnp:capnpc",
+        "@capnp-cpp//src/capnp",
     ],
 )
 


### PR DESCRIPTION
This allows us to avoid superfluous linker includes, for example the rust-deps library no longer need to be parsed for most api tests.

Full description to follow.