### PR TITLE
AbortSignal.timeout inner exception should be DISCONNECTED

### DIFF
--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -506,7 +506,8 @@ public:
   // Returns an AbortSignal that is triggered after delay milliseconds.
   static jsg::Ref<AbortSignal> timeout(jsg::Lock& js, double delay);
 
-  void triggerAbort(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason);
+  void triggerAbort(jsg::Lock& js,
+                    jsg::Optional<kj::OneOf<kj::Exception, jsg::JsValue>> maybeReason);
 
   static jsg::Ref<AbortSignal> any(
       jsg::Lock& js,
@@ -548,7 +549,7 @@ public:
 
   static kj::Exception abortException(
       jsg::Lock& js,
-      jsg::Optional<jsg::JsValue> reason = kj::none);
+      jsg::Optional<kj::OneOf<kj::Exception, jsg::JsValue>> reason = kj::none);
 
   RefcountedCanceler& getCanceler();
 


### PR DESCRIPTION
Fixes: https://github.com/cloudflare/workerd/issues/1020

Previously, `AbortSignal.timeout()` would cause the `AbortSignal` to trigger with an exception not marked as `DISCONNECTED`. This would mean that when the signal is used to cancel, for instance, a fetch POST, the exception passed on via the internal canceler would end up being logged as an uncaught exception as reported in the github issue. This commit updates things such that AbortSignal.timeout properly reports a `DISCONNECTED` kj::Exception when the timeout fires. It also makes that path slightly more efficient by avoiding an extraneous kj::Exception->JS exception->kj::Exception round trip.