### PR TITLE
Randomize the initial value of V8 Inspectors's ExecutionContextId

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -319,6 +319,7 @@ http_archive(
         "//:patches/v8/0010-Implement-Promise-Context-Tagging.patch",
         "//:patches/v8/0011-Enable-V8-shared-linkage.patch",
         "//:patches/v8/0012-Fix-ICU-build.patch",
+        "//:patches/v8/0013-Randomize-the-initial-ExecutionContextId-used-by-the.patch",
     ],
     strip_prefix = "v8-v8-97c6f93",
     type = "tgz",

--- a/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
+++ b/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
@@ -1,4 +1,4 @@
-From 4b56ec11d01ce9d18620635036e263e8c45bd95d Mon Sep 17 00:00:00 2001
+From 403eafcc365826cb36977500307a872c7fb0f535 Mon Sep 17 00:00:00 2001
 From: Alex Robinson <arobinson@cloudflare.com>
 Date: Wed, 2 Mar 2022 15:58:04 -0600
 Subject: Allow manually setting ValueDeserializer format version

--- a/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
+++ b/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
@@ -1,4 +1,4 @@
-From e480982cb9311de5092093b267b81b94ed416834 Mon Sep 17 00:00:00 2001
+From db9013995a63651e6ad3c979842a29aa6a2a52de Mon Sep 17 00:00:00 2001
 From: James M Snell <jasnell@gmail.com>
 Date: Wed, 16 Mar 2022 08:59:21 -0700
 Subject: Allow manually setting ValueSerializer format version

--- a/patches/v8/0003-Make-icudata-target-public.patch
+++ b/patches/v8/0003-Make-icudata-target-public.patch
@@ -1,4 +1,4 @@
-From 476fd6163a1352f9855652dfd913e0ffc180cc33 Mon Sep 17 00:00:00 2001
+From 822c3e9dfae97b84982490b6d2b031f0036afafe Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Sat, 17 Sep 2022 11:11:15 -0500
 Subject: Make `:icudata` target public.

--- a/patches/v8/0004-Add-ArrayBuffer-MaybeNew.patch
+++ b/patches/v8/0004-Add-ArrayBuffer-MaybeNew.patch
@@ -1,4 +1,4 @@
-From 19bff3c9180e93eef7eaeb1d58f758afafb8d083 Mon Sep 17 00:00:00 2001
+From 6c8b6aa177de3d9f5b84502875c60bb759757929 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Fri, 16 Sep 2022 21:41:45 -0500
 Subject: Add `ArrayBuffer::MaybeNew()`.

--- a/patches/v8/0005-Allow-Windows-builds-under-Bazel.patch
+++ b/patches/v8/0005-Allow-Windows-builds-under-Bazel.patch
@@ -1,4 +1,4 @@
-From 7c312b357a7bff99eebc4ce0a597803a6808b132 Mon Sep 17 00:00:00 2001
+From cf4f84d83de528b100ddc89149429e6d84d19f96 Mon Sep 17 00:00:00 2001
 From: Brendan Coll <bcoll@cloudflare.com>
 Date: Thu, 16 Mar 2023 11:56:10 +0000
 Subject: Allow Windows builds under Bazel

--- a/patches/v8/0006-Disable-bazel-whole-archive-build.patch
+++ b/patches/v8/0006-Disable-bazel-whole-archive-build.patch
@@ -1,4 +1,4 @@
-From e42ca0d1ef84b0627bc24eabbbbe530ea2bf49ed Mon Sep 17 00:00:00 2001
+From 681660d0f50393a77793ba7d9344ab6827e3404f Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Tue, 11 Apr 2023 14:41:31 -0400
 Subject: Disable bazel whole-archive build

--- a/patches/v8/0007-Make-v8-Locker-automatically-call-isolate-Enter.patch
+++ b/patches/v8/0007-Make-v8-Locker-automatically-call-isolate-Enter.patch
@@ -1,4 +1,4 @@
-From ad4178ec8b97b7b31a923cb154fda05385c3f08c Mon Sep 17 00:00:00 2001
+From 0732ab078b1fc91387812c95201103dbf680c3eb Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Tue, 23 May 2023 09:18:57 -0500
 Subject: Make v8::Locker automatically call isolate->Enter().

--- a/patches/v8/0008-Add-an-API-to-capture-and-restore-the-cage-base-poin.patch
+++ b/patches/v8/0008-Add-an-API-to-capture-and-restore-the-cage-base-poin.patch
@@ -1,4 +1,4 @@
-From ef816c90859a9fa0efb2292a087d82281766f1a0 Mon Sep 17 00:00:00 2001
+From 6f12e633233cb1fdbe544d31979deef8f51979fc Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Tue, 23 May 2023 09:24:11 -0500
 Subject: Add an API to capture and restore the cage base pointers.

--- a/patches/v8/0009-Speed-up-V8-bazel-build-by-always-using-target-cfg.patch
+++ b/patches/v8/0009-Speed-up-V8-bazel-build-by-always-using-target-cfg.patch
@@ -1,4 +1,4 @@
-From 6535d61fbad30298d8276e5587ebf08cf656b4a2 Mon Sep 17 00:00:00 2001
+From 9672ba40b81a441a33f27c42073bbb4f1ebbbe7a Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Wed, 7 Jun 2023 21:40:54 -0400
 Subject: Speed up V8 bazel build by always using target cfg

--- a/patches/v8/0010-Implement-Promise-Context-Tagging.patch
+++ b/patches/v8/0010-Implement-Promise-Context-Tagging.patch
@@ -1,4 +1,4 @@
-From 9471acf76b2b0bf083093ff5a78abc004d9293a0 Mon Sep 17 00:00:00 2001
+From 50b61731597577601919c42c7c4a3c90d3caaae5 Mon Sep 17 00:00:00 2001
 From: James M Snell <jasnell@gmail.com>
 Date: Thu, 22 Jun 2023 15:29:26 -0700
 Subject: Implement Promise Context Tagging

--- a/patches/v8/0011-Enable-V8-shared-linkage.patch
+++ b/patches/v8/0011-Enable-V8-shared-linkage.patch
@@ -1,4 +1,4 @@
-From 9d84807250d5a3ec1070676c44c60a1a22399e30 Mon Sep 17 00:00:00 2001
+From 35471a3b938449a6c320282fb7bf91b7c5f6a6c5 Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Sun, 9 Jul 2023 18:46:20 -0400
 Subject: Enable V8 shared linkage

--- a/patches/v8/0012-Fix-ICU-build.patch
+++ b/patches/v8/0012-Fix-ICU-build.patch
@@ -1,4 +1,4 @@
-From 5286d0fe8115c3b2ea07e74a47a53d45ebb13ed7 Mon Sep 17 00:00:00 2001
+From 248d8efa62f940b68801676c18aab00f7f3313c4 Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Wed, 26 Jul 2023 18:40:13 +0200
 Subject: Fix ICU build

--- a/patches/v8/0013-Randomize-the-initial-ExecutionContextId-used-by-the.patch
+++ b/patches/v8/0013-Randomize-the-initial-ExecutionContextId-used-by-the.patch
@@ -1,0 +1,25 @@
+From bd8270cf0c4491308c420744cfe74949d0c5aa08 Mon Sep 17 00:00:00 2001
+From: Orion Hodson <orion@cloudflare.com>
+Date: Wed, 13 Sep 2023 15:38:15 +0100
+Subject: Randomize the initial ExecutionContextId used by the inspector
+
+This is to help the devtools sources panel when workerd is re-started
+by miniflare. This happens because workerd does not support re-loading
+live workers (https://chat.google.com/room/AAAAnS2bXT4/GX5-pa8O0ts).
+---
+ src/inspector/v8-inspector-impl.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/inspector/v8-inspector-impl.cc b/src/inspector/v8-inspector-impl.cc
+index 60ad12aece057b4ff8eb12f99b830a4a44e12cc0..20d06e4f011714977e053b5409fb26003ea94cb9 100644
+--- a/src/inspector/v8-inspector-impl.cc
++++ b/src/inspector/v8-inspector-impl.cc
+@@ -66,7 +66,7 @@ V8InspectorImpl::V8InspectorImpl(v8::Isolate* isolate,
+       m_client(client),
+       m_debugger(new V8Debugger(isolate, this)),
+       m_lastExceptionId(0),
+-      m_lastContextId(0),
++      m_lastContextId(static_cast<int32_t>(generateUniqueId())),
+       m_isolateId(generateUniqueId()) {
+   v8::debug::SetInspector(m_isolate, this);
+   v8::debug::SetConsoleDelegate(m_isolate, console());


### PR DESCRIPTION
This is to help the devtools sources inspector detect when workerd has been restarted by miniflare.

Discussed in https://chat.google.com/room/AAAAnS2bXT4/GX5-pa8O0ts