### PR TITLE
Bump compatibility date to `2023-09-14` for release

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,8 @@ build --verbose_failures
 build --build_tag_filters=-off-by-default
 
 # Enable webgpu
-common --//src/workerd/io:enable_experimental_webgpu=True
+# TODO(soon): enable this by default again
+# common --//src/workerd/io:enable_experimental_webgpu=True
 
 # Our dependencies (ICU, zlib, etc.) produce a lot of these warnings, so we disable them.
 build --per_file_copt='external/com_googlesource_chromium_icu@-Wno-ambiguous-reversed-operator,-Wno-deprecated-declarations'

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -8,7 +8,7 @@ using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("workerd");
 $Cxx.allowCancellation;
 
-const supportedCompatibilityDate :Text = "2023-09-08";
+const supportedCompatibilityDate :Text = "2023-09-14";
 # Newest compatibility date that can safely be set using code compiled from this repo. Trying to
 # run a Worker with a newer compatibility date than this will fail.
 #


### PR DESCRIPTION
Hey! 👋 This PR bumps the compatibility date for release as usual, but disables WebGPU temporarily. See internal discussions for why we're doing this.