### PR TITLE
Fix comment conversion in actor-cache.h.

### DIFF
--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -219,11 +219,10 @@ public:
 
   virtual kj::Maybe<kj::Promise<void>> onNoPendingFlush() = 0;
 
-  virtual kj::Promise<kj::String> getCurrentBookmark();
-  virtual kj::Promise<kj::String> getBookmarkForTime(kj::Date timestamp);
-
   // Implements the respective PITR API calls. The default implementations throw JSG errors saying
   // PITR is not implemented.
+  virtual kj::Promise<kj::String> getCurrentBookmark();
+  virtual kj::Promise<kj::String> getBookmarkForTime(kj::Date timestamp);
   virtual kj::Promise<kj::String> onNextSessionRestoreBookmark(kj::StringPtr bookmark);
 };
 


### PR DESCRIPTION
This set of three methods had been grouped together, with a single comment under them applying to all three. d3f25fc1e6f073155ee6bf5c7656c153f241be80 broke apart the group and placed the comment so it appears to apply only to the third method.

I'm not sure if there may have been more instances like this around the codebase. I just happened to see this.