### PR TITLE
Add `cloudflare:request-context` utility

### DIFF
--- a/src/cloudflare/request-context.js
+++ b/src/cloudflare/request-context.js
@@ -1,0 +1,7 @@
+import { default as inner } from 'cloudflare-internal:request-context';
+
+export function getRequestContext() {
+  return inner.getRequestContext();
+};
+
+export default getRequestContext;

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -627,6 +627,15 @@ private:
   // be monkeypatchable / mutable at the global scope.
 };
 
+class RequestContextModule: public jsg::Object {
+public:
+  kj::Maybe<jsg::JsArray> getRequestContext(jsg::Lock& js);
+
+  JSG_RESOURCE_TYPE(RequestContextModule) {
+    JSG_METHOD(getRequestContext);
+  }
+};
+
 #define EW_GLOBAL_SCOPE_ISOLATE_TYPES                    \
   api::WorkerGlobalScope,                                \
   api::ServiceWorkerGlobalScope,                         \
@@ -636,6 +645,7 @@ private:
   api::ServiceWorkerGlobalScope::StructuredCloneOptions, \
   api::PromiseRejectionEvent,                            \
   api::Navigator,                                        \
-  api::Performance
+  api::Performance,                                      \
+  api::RequestContextModule
 // The list of global-scope.h types that are added to worker.c++'s JSG_DECLARE_ISOLATE_TYPE
 }  // namespace workerd::api

--- a/src/workerd/api/modules.h
+++ b/src/workerd/api/modules.h
@@ -7,6 +7,7 @@
 #include <workerd/api/node/node.h>
 #include <workerd/api/rtti.h>
 #include <workerd/api/sockets.h>
+#include <workerd/api/global-scope.h>
 #include <cloudflare/cloudflare.capnp.h>
 
 namespace workerd::api {
@@ -21,6 +22,9 @@ void registerModules(Registry& registry, auto featureFlags) {
   }
   registerSocketsModule(registry, featureFlags);
   registry.addBuiltinBundle(CLOUDFLARE_BUNDLE);
+
+  registry.template addBuiltinModule<RequestContextModule>("cloudflare-internal:request-context",
+      workerd::jsg::ModuleRegistry::Type::INTERNAL);
 }
 
 }  // namespace workerd::api

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -967,6 +967,13 @@ SpanBuilder IoContext::makeTraceSpan(kj::ConstString operationName) {
   return getCurrentTraceSpan().newChild(kj::mv(operationName));
 }
 
+kj::Maybe<jsg::AsyncContextFrame::StorageKey&> IoContext::getRequestContextKey() {
+  KJ_IF_SOME(lock, currentLock) {
+    return lock.getRequestContextKey();
+  }
+  return kj::none;
+}
+
 void IoContext::taskFailed(kj::Exception&& exception) {
   if (waitUntilStatusValue == EventOutcome::OK) {
     KJ_IF_SOME(status, limitEnforcer->getLimitsExceeded()) {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -859,6 +859,8 @@ public:
   // information from the current async context, if available.
   SpanParent getCurrentTraceSpan();
 
+  kj::Maybe<jsg::AsyncContextFrame::StorageKey&> getRequestContextKey();
+
   // Returns a builder for recording tracing spans (or a no-op builder if tracing is inactive).
   // If called while the JS lock is held, uses the trace information from the current async
   // context, if available.

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1033,7 +1033,8 @@ Worker::Isolate::Isolate(kj::Own<ApiIsolate> apiIsolateParam,
       metrics(kj::mv(metricsParam)),
       impl(kj::heap<Impl>(*apiIsolate, *metrics, *limitEnforcer, inspectorPolicy)),
       weakIsolateRef(kj::atomicRefcounted<WeakIsolateRef>(this)),
-      traceAsyncContextKey(kj::refcounted<jsg::AsyncContextFrame::StorageKey>()) {
+      traceAsyncContextKey(kj::refcounted<jsg::AsyncContextFrame::StorageKey>()),
+      requestContextKey(kj::refcounted<jsg::AsyncContextFrame::StorageKey>()) {
   metrics->created();
   // We just created our isolate, so we don't need to use Isolate::Impl::Lock (nor an async lock).
   jsg::V8StackScope stackScope;
@@ -1706,6 +1707,12 @@ jsg::AsyncContextFrame::StorageKey& Worker::Lock::getTraceAsyncContextKey() {
   // const_cast OK because we are a lock on this isolate.
   auto& isolate = const_cast<Isolate&>(worker.getIsolate());
   return *(isolate.traceAsyncContextKey);
+}
+
+jsg::AsyncContextFrame::StorageKey& Worker::Lock::getRequestContextKey() {
+  // const_cast OK because we are a lock on this isolate.
+  auto& isolate = const_cast<Isolate&>(worker.getIsolate());
+  return *(isolate.requestContextKey);
 }
 
 bool Worker::Lock::isInspectorEnabled() {

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -469,6 +469,7 @@ private:
 
   size_t nextRequestId = 0;
   kj::Own<jsg::AsyncContextFrame::StorageKey> traceAsyncContextKey;
+  kj::Own<jsg::AsyncContextFrame::StorageKey> requestContextKey;
 
   friend class Worker;
 };
@@ -608,6 +609,9 @@ public:
 
   // Get the opaque storage key to use for recording trace information in async contexts.
   jsg::AsyncContextFrame::StorageKey& getTraceAsyncContextKey();
+
+  // Get the opaque storage key to use for accessing request context and env.
+  jsg::AsyncContextFrame::StorageKey& getRequestContextKey();
 
 private:
   struct Impl;

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2072,6 +2072,8 @@ public:
 
   virtual v8::Local<v8::Promise> wrapSimplePromise(Promise<Value> promise) = 0;
 
+  virtual v8::Local<v8::Value> wrapJsgObject(Ref<Object> obj) = 0;
+
   bool toBool(v8::Local<v8::Value> value);
   virtual kj::String toString(v8::Local<v8::Value> value) = 0;
   virtual jsg::Dict<v8::Local<v8::Value>> toDict(v8::Local<v8::Value> value) = 0;

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -386,6 +386,9 @@ public:
     v8::Local<v8::Promise> wrapSimplePromise(jsg::Promise<jsg::Value> promise) override {
       return jsgIsolate.wrapper->wrap(v8Context(), nullptr, kj::mv(promise));
     }
+    v8::Local<v8::Value> wrapJsgObject(jsg::Ref<jsg::Object> object) override {
+      return jsgIsolate.wrapper->wrap(v8Context(), nullptr, kj::mv(object));
+    }
     jsg::Promise<jsg::Value> toPromise(v8::Local<v8::Promise> promise) override {
       return jsgIsolate.wrapper->template unwrap<jsg::Promise<jsg::Value>>(
           v8Isolate->GetCurrentContext(), promise, jsg::TypeErrorContext::other());


### PR DESCRIPTION
This mechanism uses async context propagation to store references to the request, env, and ctx such that they can be retrieved without having to pass those explicitly through various layers. This is helpful, of instance, when using third party libraries and you need to access something like a configured binding. One could use AsyncLocalStorage directly for this but there are use cases where we do not necessarily want to require enabling nodejs_compat. It also reduces common boilerplate.

```
// (does not require nodejs_compat to be enabled)
import getRequestContext from 'cloudflare:request-context';

function doSomethingWithCtx() {
  const [ req, env, ctx ] = getRequestContext();
  // do something...
}

export default {
  async fetch(req) {
    // do something that eventually leads to doSomethingWithCtx....
  }
}
```

The alternative using `AsyncLocalStorage` would be:

```
// (requires nodejs_compat to be enabled)
import { AsyncLocalStorage } from 'node:async_hooks';
const reqCtx = new AsyncLocalStorage();

function doSomethingWithCtx() {
  const [req, env, ctx] = reqCtx.getStore();
  // do something...
}

export default {
  async fetch(req, env, ctx) {
    return reqCtx.run([req, env, ctx], () => {
      // do something that eventually leads to doSomethingWithCtx
    });
  }
}
```

/cc @dario-piotrowicz 