### PR TITLE
Fix initial executionContextId range

### DIFF
--- a/patches/v8/0013-Randomize-the-initial-ExecutionContextId-used-by-the.patch
+++ b/patches/v8/0013-Randomize-the-initial-ExecutionContextId-used-by-the.patch
@@ -19,7 +19,7 @@ index 60ad12aece057b4ff8eb12f99b830a4a44e12cc0..20d06e4f011714977e053b5409fb2600
        m_debugger(new V8Debugger(isolate, this)),
        m_lastExceptionId(0),
 -      m_lastContextId(0),
-+      m_lastContextId(static_cast<int32_t>(generateUniqueId())),
++      m_lastContextId(static_cast<int32_t>(generateUniqueId() & 0x1fff'ffe0)),
        m_isolateId(generateUniqueId()) {
    v8::debug::SetInspector(m_isolate, this);
    v8::debug::SetConsoleDelegate(m_isolate, console());


### PR DESCRIPTION
Avoid a Smi range exception when picking a random initial executionContextId.

Not a fix for #1201, but discovered looking into the problem.

Bug: 🐛 Bug Report — `workerd` sometimes doesn't send `Debugger.scriptParsed` events #1201