### PR TITLE
VS-18: make Vectorize index preset a generic string

### DIFF
--- a/src/cloudflare/internal/vectorize.d.ts
+++ b/src/cloudflare/internal/vectorize.d.ts
@@ -28,15 +28,6 @@ interface VectorizeError {
 }
 
 /**
- * A pre-configured list of known models.
- * These can be supplied in place of configuring explicit dimensions.
- */
-type VectorizePreset =
-  | "openapi-text-embedding-ada-002"
-  | "workers-ai/bge-small-en"
-  | "cohere/embed-multilingual-v2.0";
-
-/**
  * Supported distance metrics for an index.
  * Distance metrics determine how other "similar" vectors are determined.
  */
@@ -57,7 +48,7 @@ type VectorizeIndexConfig =
       metric: VectorizeDistanceMetric;
     }
   | {
-      preset: VectorizePreset;
+      preset: string; // keep this generic, as we'll be adding more presets in the future and this is only in a read capacity
     };
 
 /**

--- a/types/defines/vectorize.d.ts
+++ b/types/defines/vectorize.d.ts
@@ -20,15 +20,6 @@ interface VectorizeError {
 }
 
 /**
- * A pre-configured list of known models.
- * These can be supplied in place of configuring explicit dimensions.
- */
-type VectorizePreset =
-  | "openapi-text-embedding-ada-002"
-  | "workers-ai/bge-small-en"
-  | "cohere/embed-multilingual-v2.0";
-
-/**
  * Supported distance metrics for an index.
  * Distance metrics determine how other "similar" vectors are determined.
  */
@@ -49,7 +40,7 @@ type VectorizeIndexConfig =
       metric: VectorizeDistanceMetric;
     }
   | {
-      preset: VectorizePreset;
+      preset: string; // keep this generic, as we'll be adding more presets in the future and this is only in a read capacity
     };
 
 /**


### PR DESCRIPTION
This list will grow fairly rapidly over time. As this list is only used in a GET-like readonly capacity, using a generic string is okay without sacrificing much in the way of user DX.