### PR TITLE
VS-46 Throw detailed errors properly

### DIFF
--- a/src/cloudflare/internal/test/vectorize/vectorize-api-test.js
+++ b/src/cloudflare/internal/test/vectorize/vectorize-api-test.js
@@ -120,6 +120,38 @@ export const test_vector_search_vector_insert = {
   },
 };
 
+export const test_vector_search_vector_insert_error = {
+  /**
+   * @param {unknown} ctr
+   * @param {Env} env
+   */
+  async test(ctr, env) {
+    const IDX = env["vector-search"];
+    {
+      /** @type {Array<VectorizeVector>}  */
+      const newVectors = [
+        {
+          id: "fail-with-test-error",
+          values: new Float32Array(),
+        },
+      ];
+
+      /** @type {Error | null} */
+      let error = null;
+      try {
+        await IDX.insert(newVectors);
+      } catch (e) {
+        error = e;
+      }
+
+      assert.equal(
+        error && error.message,
+        "VECTOR_INSERT_ERROR (code = 9999): You asked me for this error"
+      );
+    }
+  },
+}
+
 export const test_vector_search_vector_upsert = {
   /**
    * @param {unknown} ctr

--- a/src/cloudflare/internal/test/vectorize/vectorize-mock.js
+++ b/src/cloudflare/internal/test/vectorize/vectorize-mock.js
@@ -121,6 +121,15 @@ export default {
       } else if (request.method === "POST" && pathname.endsWith("/insert")) {
         /** @type {{vectors: Array<VectorizeVector>}} */
         const data = await request.json();
+        if (data.vectors.find((v) => v.id == 'fail-with-test-error')) {
+          return Response.json({
+            code: 9999,
+            error: 'You asked me for this error',
+          }, {
+            status: 400
+          });
+        };
+
         return Response.json({
           ids: [
             ...data.vectors.map(({ id }) => id),

--- a/src/cloudflare/internal/vectorize-api.ts
+++ b/src/cloudflare/internal/vectorize-api.ts
@@ -160,17 +160,22 @@ class VectorizeIndexImpl implements VectorizeIndex {
       init
     );
     if (res.status !== 200) {
+      let err: Error | null = null;
+
       try {
-        const err = (await res.json()) as VectorizeError;
-        throw new Error(
-          `${Operation[operation]}_ERROR ${
-            typeof err.code === "number" ? ` (code = ${err.code})` : ""
-          }: ${err.error}`,
+        const errResponse = (await res.json()) as VectorizeError;
+        err = new Error(
+          `${Operation[operation]}_ERROR ${typeof errResponse.code === "number" ? `(code = ${errResponse.code})` : ""
+          }: ${errResponse.error}`,
           {
-            cause: new Error(err.error),
+            cause: new Error(errResponse.error),
           }
         );
-      } catch (e) {
+      } catch (e) { }
+
+      if (err) {
+        throw err;
+      } else {
         throw new Error(
           `${Operation[operation]}_ERROR: Status + ${res.status}`,
           {


### PR DESCRIPTION
Previously the detailed error was always caught by the outer try/catch.