### PR TITLE
Add getTags() for websocket hibernation

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -966,6 +966,10 @@ kj::Maybe<uint32_t> DurableObjectState::getHibernatableWebSocketEventTimeout() {
   return kj::none;
 }
 
+kj::Array<kj::StringPtr> DurableObjectState::getTags(jsg::Lock& js, jsg::Ref<api::WebSocket> ws) {
+  return ws->getHibernatableTags();
+}
+
 kj::Array<kj::byte> serializeV8Value(jsg::Lock& js, const jsg::JsValue& value) {
   jsg::Serializer serializer(js, jsg::Serializer::Options {
     .version = 15,

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -470,6 +470,10 @@ public:
   // Get the currently set hibernatable websocket event timeout if set, or kj::none if not.
   kj::Maybe<uint32_t> getHibernatableWebSocketEventTimeout();
 
+  // Gets an array of tags that this websocket was accepted with. If the given websocket is not
+  // hibernatable, we'll throw an error because regular websockets do not have tags.
+  kj::Array<kj::StringPtr> getTags(jsg::Lock& js, jsg::Ref<api::WebSocket> ws);
+
   JSG_RESOURCE_TYPE(DurableObjectState, CompatibilityFlags::Reader flags) {
     JSG_METHOD(waitUntil);
     JSG_READONLY_INSTANCE_PROPERTY(id, getId);
@@ -482,6 +486,7 @@ public:
     JSG_METHOD(getWebSocketAutoResponseTimestamp);
     JSG_METHOD(setHibernatableWebSocketEventTimeout);
     JSG_METHOD(getHibernatableWebSocketEventTimeout);
+    JSG_METHOD(getTags);
 
     if (flags.getWorkerdExperimental()) {
       // TODO(someday): This currently exists for testing purposes only but maybe it could be

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -513,6 +513,7 @@ void ServiceWorkerGlobalScope::sendHibernatableWebSocketClose(
   auto releasePackage = event->prepareForRelease(lock, websocketId);
   auto websocket = kj::mv(releasePackage.webSocketRef);
   websocket->initiateHibernatableRelease(lock, kj::mv(releasePackage.ownedWebSocket),
+      kj::mv(releasePackage.tags),
       api::WebSocket::HibernatableReleaseState::CLOSE);
   KJ_IF_SOME(h, exportedHandler) {
     KJ_IF_SOME(handler, h.webSocketClose) {
@@ -539,6 +540,7 @@ void ServiceWorkerGlobalScope::sendHibernatableWebSocketError(
   auto releasePackage = event->prepareForRelease(lock, websocketId);
   auto& websocket = releasePackage.webSocketRef;
   websocket->initiateHibernatableRelease(lock, kj::mv(releasePackage.ownedWebSocket),
+      kj::mv(releasePackage.tags),
       WebSocket::HibernatableReleaseState::ERROR);
   jsg::Lock& js(lock);
 

--- a/src/workerd/api/hibernatable-web-socket.c++
+++ b/src/workerd/api/hibernatable-web-socket.c++
@@ -28,11 +28,12 @@ HibernatableWebSocketEvent::ItemsForRelease HibernatableWebSocketEvent::prepareF
   // the HibernatableWebSocket (it removes it from `webSocketsForEventHandler`).
   auto websocketRef = hibernatableWebSocket.value->getActiveOrUnhibernate(lock);
   auto ownedWebSocket = kj::mv(KJ_REQUIRE_NONNULL(hibernatableWebSocket.value->ws));
+  auto tags = hibernatableWebSocket.value->cloneTags();
 
   // Now that we've obtained the websocket for the event, let's free up the slots we had allocated.
   manager.webSocketsForEventHandler.erase(hibernatableWebSocket);
 
-  return ItemsForRelease(kj::mv(websocketRef), kj::mv(ownedWebSocket));
+  return ItemsForRelease(kj::mv(websocketRef), kj::mv(ownedWebSocket), kj::mv(tags));
 }
 
 jsg::Ref<WebSocket> HibernatableWebSocketEvent::claimWebSocket(jsg::Lock& lock,
@@ -173,8 +174,8 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
 }
 
 HibernatableWebSocketEvent::ItemsForRelease::ItemsForRelease(
-    jsg::Ref<WebSocket> ref, kj::Own<kj::WebSocket> owned)
-    : webSocketRef(kj::mv(ref)), ownedWebSocket(kj::mv(owned)) {}
+    jsg::Ref<WebSocket> ref, kj::Own<kj::WebSocket> owned, kj::Array<kj::String> tags)
+    : webSocketRef(kj::mv(ref)), ownedWebSocket(kj::mv(owned)), tags(kj::mv(tags)) {}
 
 HibernatableWebSocketCustomEventImpl::HibernatableWebSocketCustomEventImpl(
     uint16_t typeId,

--- a/src/workerd/io/hibernation-manager.h
+++ b/src/workerd/io/hibernation-manager.h
@@ -82,6 +82,17 @@ private:
     ~HibernatableWebSocket() noexcept(false);
     KJ_DISALLOW_COPY_AND_MOVE(HibernatableWebSocket);
 
+    // Returns the tags associated with this HibernatableWebSocket.
+    kj::Array<kj::StringPtr> getTags();
+
+    // Returns the tags associated with this HibernatableWebSocket.
+    // Note that this returns an array of Strings, unlike `getTags()`.
+    // Copying the strings each time tags are requested would be expensive,
+    // so we only do it when we're delivering a close/error event because
+    // we will be destroying the HibernatableWebSocket object,
+    // which the tags need to outlive.
+    kj::Array<kj::String> cloneTags();
+
     // Returns a reference to the active websocket. If the websocket is currently hibernating,
     // we have to unhibernate it first. The process moves values from the HibernatableWebSocket
     // to the api::WebSocket.


### PR DESCRIPTION
This method was requested during the hibernation Beta. Previously, if you wanted to get back the tags associated with a hibernatable websocket you would have had to store them in the websocket's attachments (limited) or DO storage (slow + need to ID websocket somehow).