### PR TITLE
Additional nullptr -> kj::none in src/workerd/io

### DIFF
--- a/src/workerd/io/actor-cache-test.c++
+++ b/src/workerd/io/actor-cache-test.c++
@@ -268,7 +268,7 @@ KJ_TEST("ActorCache single-key basics") {
         .thenReturn(CAPNP());
 
     auto result = promise.wait(ws);
-    KJ_EXPECT(result == nullptr);
+    KJ_EXPECT(result == kj::none);
   }
 
   // Get cached.
@@ -278,7 +278,7 @@ KJ_TEST("ActorCache single-key basics") {
   }
   {
     auto result = expectCached(test.get("bar"));
-    KJ_EXPECT(result == nullptr);
+    KJ_EXPECT(result == kj::none);
   }
 
   // Overwrite with a put().
@@ -305,7 +305,7 @@ KJ_TEST("ActorCache single-key basics") {
 
   {
     auto result = expectCached(test.get("foo"));
-    KJ_EXPECT(result == nullptr);
+    KJ_EXPECT(result == kj::none);
   }
 }
 
@@ -421,14 +421,14 @@ KJ_TEST("ActorCache more deletes") {
     auto promise = expectUncached(test.delete_("foo"));
 
     // Value is immediately in cache.
-    KJ_ASSERT(expectCached(test.get("foo")) == nullptr);
+    KJ_ASSERT(expectCached(test.get("foo")) == kj::none);
 
     auto mockDelete = mockStorage->expectCall("delete", ws)
         .withParams(CAPNP(keys = ["foo"]));
 
     // Still in cache during flush.
     KJ_ASSERT(!promise.poll(ws));
-    KJ_ASSERT(expectCached(test.get("foo")) == nullptr);
+    KJ_ASSERT(expectCached(test.get("foo")) == kj::none);
 
     kj::mv(mockDelete).thenReturn(CAPNP(numDeleted = 1));
 
@@ -437,7 +437,7 @@ KJ_TEST("ActorCache more deletes") {
   }
 
   // Still in cache after transaction completion.
-  KJ_ASSERT(expectCached(test.get("foo")) == nullptr);
+  KJ_ASSERT(expectCached(test.get("foo")) == kj::none);
 
   // Try a case where the key isn't on disk.
   {
@@ -479,7 +479,7 @@ KJ_TEST("ActorCache more deletes") {
         .thenReturn(CAPNP(numDeleted = 1));
   }
 
-  KJ_ASSERT(expectCached(test.get("foo")) == nullptr);
+  KJ_ASSERT(expectCached(test.get("foo")) == kj::none);
 }
 
 KJ_TEST("ActorCache more multi-puts") {
@@ -3654,7 +3654,7 @@ KJ_TEST("ActorCache evict on timeout") {
   auto& mockStorage = test.mockStorage;
 
   auto timePoint = kj::UNIX_EPOCH;
-  KJ_ASSERT(test.cache.evictStale(timePoint) == nullptr);
+  KJ_ASSERT(test.cache.evictStale(timePoint) == kj::none);
 
   auto ackFlush = [&]() {
     mockStorage->expectCall("put", ws).thenReturn(CAPNP());
@@ -3666,9 +3666,9 @@ KJ_TEST("ActorCache evict on timeout") {
   test.put("bar", "456");
   ackFlush();
 
-  KJ_ASSERT(test.cache.evictStale(timePoint + 100 * kj::MILLISECONDS) == nullptr);
-  KJ_ASSERT(test.cache.evictStale(timePoint + 200 * kj::MILLISECONDS) == nullptr);
-  KJ_ASSERT(test.cache.evictStale(timePoint + 500 * kj::MILLISECONDS) == nullptr);
+  KJ_ASSERT(test.cache.evictStale(timePoint + 100 * kj::MILLISECONDS) == kj::none);
+  KJ_ASSERT(test.cache.evictStale(timePoint + 200 * kj::MILLISECONDS) == kj::none);
+  KJ_ASSERT(test.cache.evictStale(timePoint + 500 * kj::MILLISECONDS) == kj::none);
 
   expectCached(test.get("foo"));
   expectCached(test.get("bar"));
@@ -4846,13 +4846,13 @@ KJ_TEST("ActorCache alarm get/put") {
     mockStorage->expectCall("getAlarm", ws)
       .thenReturn(CAPNP(scheduledTimeMs = 0));
 
-    KJ_ASSERT(time.wait(ws) == nullptr);
+    KJ_ASSERT(time.wait(ws) == kj::none);
   }
 
   {
     auto time = expectCached(test.getAlarm());
 
-    KJ_ASSERT(time == nullptr);
+    KJ_ASSERT(time == kj::none);
   }
 
   auto oneMs = 1 * kj::MILLISECONDS + kj::UNIX_EPOCH;
@@ -4895,11 +4895,11 @@ KJ_TEST("ActorCache alarm get/put") {
   {
     auto time = expectCached(test.getAlarm());
 
-    KJ_ASSERT(time == nullptr);
+    KJ_ASSERT(time == kj::none);
   }
 
   // we have a cached time == nullptr, so we should not attempt to run an alarm
-  KJ_ASSERT(test.cache.armAlarmHandler(10 * kj::SECONDS + kj::UNIX_EPOCH, false) == nullptr);
+  KJ_ASSERT(test.cache.armAlarmHandler(10 * kj::SECONDS + kj::UNIX_EPOCH, false) == kj::none);
 
   {
     test.setAlarm(oneMs);
@@ -4962,7 +4962,7 @@ KJ_TEST("ActorCache alarm get/put") {
     mockStorage->expectCall("getAlarm", ws)
       .thenReturn(CAPNP(scheduledTimeMs = 0));
 
-    KJ_ASSERT(time.wait(ws) == nullptr);
+    KJ_ASSERT(time.wait(ws) == kj::none);
   }
 }
 
@@ -5007,7 +5007,7 @@ KJ_TEST("ActorCache alarm delete when flush fails") {
     auto handle = test.cache.armAlarmHandler(oneMs, false);
 
     auto time = expectCached(test.getAlarm());
-    KJ_ASSERT(time == nullptr);
+    KJ_ASSERT(time == kj::none);
   }
 
   for(auto i = 0; i < 2; i++) {

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -510,7 +510,7 @@ kj::Promise<bool> IoContext::IncomingRequest::finishScheduled() {
   //   cannot assume that just because an async task fails while the scheduled event is running,
   //   that the scheduled event itself failed -- the failure could have been a task initiated by
   //   an unrelated concurrent event.
-  KJ_ASSERT(context->actor == nullptr,
+  KJ_ASSERT(context->actor == kj::none,
       "this code isn't designed to allow scheduled events to be delivered to actors");
 
   // Mark ourselves so we know that we made a best effort attempt to wait for waitUntilTasks.
@@ -679,7 +679,7 @@ void IoContext::TimeoutManagerImpl::setTimeoutImpl(IoContext& context, Iterator 
 
       if (state.isCanceled) {
         // We've been canceled before running. Nothing more to do.
-        KJ_ASSERT(state.maybePromise == nullptr);
+        KJ_ASSERT(state.maybePromise == kj::none);
         return;
       }
 
@@ -710,7 +710,7 @@ void IoContext::TimeoutManagerImpl::setTimeoutImpl(IoContext& context, Iterator 
           unwindDetector.catchExceptionsIfUnwinding([&] {
             if (state.isCanceled) {
               // The user's callback has called clearInterval(), nothing more to do.
-              KJ_ASSERT(state.maybePromise == nullptr);
+              KJ_ASSERT(state.maybePromise == kj::none);
               return;
             }
 
@@ -1108,8 +1108,8 @@ public:
         handleScope(workerLock.getIsolate()),
         jsContextScope(workerLock.getContext()),
         promiseContextScope(workerLock.getIsolate(), context.getPromiseContextTag(workerLock)) {
-    KJ_REQUIRE(context.currentInputLock == nullptr);
-    KJ_REQUIRE(context.currentLock == nullptr);
+    KJ_REQUIRE(context.currentInputLock == kj::none);
+    KJ_REQUIRE(context.currentLock == kj::none);
     context.currentInputLock = kj::mv(inputLock);
     context.currentLock = workerLock;
 
@@ -1267,7 +1267,7 @@ auto IoContext::tryGetWeakRefForCurrent() -> kj::Maybe<kj::Own<WeakRef>> {
 }
 
 void IoContext::runFinalizers(Worker::AsyncLock& asyncLock) {
-  KJ_ASSERT(actor == nullptr);  // we don't finalize actor requests
+  KJ_ASSERT(actor == kj::none);  // we don't finalize actor requests
 
   tasks = kj::none;
   // Tasks typically have callbacks that dereference IoOwns. Since those callbacks

--- a/src/workerd/io/promise-wrapper.h
+++ b/src/workerd/io/promise-wrapper.h
@@ -39,7 +39,7 @@ public:
         kj::Maybe<v8::Local<v8::Object>> parentObject) {
     auto& wrapper = static_cast<Self&>(*this);
     auto jsPromise = KJ_UNWRAP_OR_RETURN(wrapper.tryUnwrap(
-        context, handle, (jsg::Promise<T>*)nullptr, parentObject), nullptr);
+        context, handle, (jsg::Promise<T>*)nullptr, parentObject), kj::none);
     auto& js = jsg::Lock::from(context->GetIsolate());
     return IoContext::current().awaitJs(js, kj::mv(jsPromise));
   }

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -342,7 +342,7 @@ kj::Promise<WorkerInterface::ScheduledResult> WorkerEntrypoint::runScheduled(
   incomingRequest->delivered();
   auto& context = incomingRequest->getContext();
 
-  KJ_ASSERT(context.getActor() == nullptr);
+  KJ_ASSERT(context.getActor() == kj::none);
   // This code currently doesn't work with actors because cancellations occur immediately, without
   // calling context->drain(). We don't ever send scheduled events to actors. If we do, we'll have
   // to think more about this.


### PR DESCRIPTION
Bug: EW-7618
Test: bazel build //...