### PR TITLE
Add TraceEventInfo for TraceItem

### DIFF
--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -52,6 +52,7 @@ public:
   class AlarmEventInfo;
   class QueueEventInfo;
   class EmailEventInfo;
+  class TailEventInfo;
   class CustomEventInfo;
 
   explicit TraceItem(jsg::Lock& js, const Trace& trace);
@@ -61,6 +62,7 @@ public:
                     jsg::Ref<AlarmEventInfo>,
                     jsg::Ref<QueueEventInfo>,
                     jsg::Ref<EmailEventInfo>,
+                    jsg::Ref<TailEventInfo>,
                     jsg::Ref<CustomEventInfo>> EventInfo;
   kj::Maybe<EventInfo> getEvent(jsg::Lock& js);
   kj::Maybe<double> getEventTimestamp();
@@ -266,6 +268,36 @@ private:
   uint32_t rawSize;
 };
 
+class TraceItem::TailEventInfo final: public jsg::Object {
+public:
+  class TailItem;
+
+  explicit TailEventInfo(const Trace& trace, const Trace::TraceEventInfo& eventInfo);
+
+  kj::Array<jsg::Ref<TailItem>> getConsumedEvents();
+
+  JSG_RESOURCE_TYPE(TailEventInfo) {
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(consumedEvents, getConsumedEvents);
+  }
+
+private:
+  kj::Array<jsg::Ref<TailItem>> consumedEvents;
+};
+
+class TraceItem::TailEventInfo::TailItem final: public jsg::Object {
+public:
+  explicit TailItem(const Trace::TraceEventInfo::TraceItem& traceItem);
+
+  kj::Maybe<kj::StringPtr> getScriptName();
+
+  JSG_RESOURCE_TYPE(TailItem) {
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptName, getScriptName);
+  }
+
+private:
+  kj::Maybe<kj::String> scriptName;
+};
+
 class TraceItem::CustomEventInfo final: public jsg::Object {
 public:
   explicit CustomEventInfo(const Trace& trace, const Trace::CustomEventInfo& eventInfo);
@@ -401,6 +433,8 @@ private:
   api::TraceItem::ScheduledEventInfo,         \
   api::TraceItem::QueueEventInfo,             \
   api::TraceItem::EmailEventInfo,             \
+  api::TraceItem::TailEventInfo,              \
+  api::TraceItem::TailEventInfo::TailItem,    \
   api::TraceItem::FetchEventInfo,             \
   api::TraceItem::FetchEventInfo::Request,    \
   api::TraceItem::FetchEventInfo::Response,   \

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -126,6 +126,28 @@ public:
     void copyTo(rpc::Trace::EmailEventInfo::Builder builder);
   };
 
+  class TraceEventInfo {
+  public:
+    class TraceItem;
+
+    explicit TraceEventInfo(kj::ArrayPtr<kj::Own<Trace>> traces);
+    TraceEventInfo(rpc::Trace::TraceEventInfo::Reader reader);
+
+    class TraceItem {
+    public:
+      explicit TraceItem(kj::Maybe<kj::String> scriptName);
+      TraceItem(rpc::Trace::TraceEventInfo::TraceItem::Reader reader);
+
+      kj::Maybe<kj::String> scriptName;
+
+      void copyTo(rpc::Trace::TraceEventInfo::TraceItem::Builder builder);
+    };
+
+    kj::Vector<TraceItem> traces;
+
+    void copyTo(rpc::Trace::TraceEventInfo::Builder builder);
+  };
+
   class CustomEventInfo {
   public:
     explicit CustomEventInfo() {};
@@ -202,7 +224,7 @@ public:
   kj::Date eventTimestamp = kj::UNIX_EPOCH;
 
   typedef kj::OneOf<FetchEventInfo, ScheduledEventInfo, AlarmEventInfo, QueueEventInfo,
-          EmailEventInfo, CustomEventInfo> EventInfo;
+          EmailEventInfo, TraceEventInfo, CustomEventInfo> EventInfo;
   kj::Maybe<EventInfo> eventInfo;
   // TODO(someday): Support more event types.
   // TODO(someday): Work out what sort of information we may want to convey about the parent

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -50,6 +50,7 @@ struct Trace @0x8e8d911203762d34 {
     queue @15 :QueueEventInfo;
     custom @13 :CustomEventInfo;
     email @16 :EmailEventInfo;
+    trace @18 :TraceEventInfo;
   }
   struct FetchEventInfo {
     method @0 :HttpMethod;
@@ -81,6 +82,14 @@ struct Trace @0x8e8d911203762d34 {
     mailFrom @0 :Text;
     rcptTo @1 :Text;
     rawSize @2 :UInt32;
+  }
+
+  struct TraceEventInfo {
+    struct TraceItem {
+      scriptName @0 :Text;
+    }
+
+    traces @0 :List(TraceItem);
   }
 
   struct CustomEventInfo {}


### PR DESCRIPTION
This adds a new TraceItem::EventType union member - TraceEventInfo. This allows event info for invocations of a trace or tail worker to show up when tailing it (i.e. attaching a tail to a tail worker).

TraceEventInfo only contains an array "traces" of objects with a single "scriptName", i.e. the script that the script _you're_ tracing was tracing. There's hypothetically more that could be included on these items, but any sort of recursive could ballon the size of these events or even get into circular references, so it's kept simple for now.