### PR TITLE
Remove test fixture compileAndRunScript and compileAndInstantiateModule

### DIFF
--- a/src/workerd/tests/test-fixture-test.c++
+++ b/src/workerd/tests/test-fixture-test.c++
@@ -114,8 +114,7 @@ KJ_TEST("runInIoContext re-throwing js exception") {
   try {
     fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
       runCount++;
-      env.compileAndRunScript("throw new Error('let_me_through');");
-      return kj::READY_NOW;
+      env.js.throwException(env.js.error("let_me_through"));
     }, kj::arr("test_error"_kj));
   } catch (kj::Exception& e) {
     KJ_EXPECT(e.getDescription() == "jsg.Error: let_me_through"_kj);
@@ -132,57 +131,10 @@ KJ_TEST("runInIoContext consuming ignored js exception") {
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
     runCount++;
-    env.compileAndRunScript("throw new Error('test_error');");
-    return kj::READY_NOW;
+    env.js.throwException(env.js.error("test_error"));
   }, kj::arr("test_error"_kj));
 
   KJ_EXPECT(runCount == 1);
-}
-
-KJ_TEST("compileAndRunScript") {
-  TestFixture fixture;
-  uint runCount = 0;
-
-  fixture.runInIoContext([&](const TestFixture::Environment& env) {
-    runCount++;
-    auto result = env.compileAndRunScript("42;");
-    v8::String::Utf8Value value(env.isolate, result);
-    KJ_EXPECT(*value == "42"_kj);
-  });
-  KJ_EXPECT(runCount == 1);
-}
-
-KJ_TEST("compileAndRunScript context access") {
-  TestFixture fixture;
-  uint runCount = 0;
-
-  fixture.runInIoContext([&](const TestFixture::Environment& env) {
-    runCount++;
-    auto result = env.compileAndRunScript("btoa([1,2,3,4,5]);");
-    v8::String::Utf8Value value(env.isolate, result);
-    KJ_EXPECT(*value == "MSwyLDMsNCw1"_kj);
-  });
-  KJ_EXPECT(runCount == 1);
-}
-
-KJ_TEST("compileAndRunScript exception handling") {
-  TestFixture fixture;
-  uint runCount = 0;
-  uint exceptionCount = 0;
-
-  try {
-    fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
-      runCount++;
-      env.compileAndRunScript("throw new Error('test_error');");
-      KJ_FAIL_REQUIRE("shouldn't happen");
-    });
-  } catch (kj::Exception& e) {
-    exceptionCount++;
-    KJ_EXPECT(e.getDescription() == "jsg.Error: test_error"_kj);
-  }
-
-  KJ_EXPECT(runCount == 1);
-  KJ_EXPECT(exceptionCount == 1);
 }
 
 KJ_TEST("compileAndInstantiateModule") {

--- a/src/workerd/tests/test-fixture-test.c++
+++ b/src/workerd/tests/test-fixture-test.c++
@@ -137,27 +137,6 @@ KJ_TEST("runInIoContext consuming ignored js exception") {
   KJ_EXPECT(runCount == 1);
 }
 
-KJ_TEST("compileAndInstantiateModule") {
-  TestFixture fixture;
-  uint runCount = 0;
-
-  fixture.runInIoContext([&](const TestFixture::Environment& env) {
-    runCount++;
-    auto context = env.isolate->GetCurrentContext();
-
-    auto ns = env.compileAndInstantiateModule("testFixtureTest",
-        "export function init() { return 42; }"_kj);
-    auto fn = env.js.v8Get(ns, "init"_kj);
-    KJ_EXPECT(fn->IsFunction());
-    auto callResult = v8::Function::Cast(*fn)->
-        Call(context, context->Global(), 0, nullptr).ToLocalChecked();
-    v8::String::Utf8Value value(env.isolate, callResult);
-    KJ_EXPECT(*value == "42"_kj);
-  });
-
-  KJ_EXPECT(runCount == 1);
-}
-
 KJ_TEST("runRequest") {
   TestFixture fixture({
     .mainModuleSource = R"SCRIPT(

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -340,21 +340,4 @@ TestFixture::Response TestFixture::runRequest(
   return { .statusCode = response.statusCode, .body = response.body->str() };
 }
 
-v8::Local<v8::Object> TestFixture::V8Environment::compileAndInstantiateModule(
-    kj::StringPtr name, kj::ArrayPtr<const char> src) const {
-  v8::Local<v8::Module> module;
-
-  v8::ScriptCompiler::Source source(jsg::v8Str(isolate, src),
-  v8::ScriptOrigin(isolate, jsg::v8StrIntern(isolate, name),
-      false, false, false, -1, {}, false, false, true /* is_module */));
-
-  if (!v8::ScriptCompiler::CompileModule(isolate, &source).ToLocal(&module)) {
-    KJ_FAIL_REQUIRE("error parsing code");
-  }
-
-  auto& js = jsg::Lock::from(isolate);
-  jsg::instantiateModule(js, module);
-  return module->GetModuleNamespace()->ToObject(isolate->GetCurrentContext()).ToLocalChecked();
-}
-
 }  // namespace workerd

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -340,26 +340,6 @@ TestFixture::Response TestFixture::runRequest(
   return { .statusCode = response.statusCode, .body = response.body->str() };
 }
 
-v8::Local<v8::Value> TestFixture::V8Environment::compileAndRunScript(
-    kj::StringPtr code) const {
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  v8::Local<v8::String> source = jsg::v8Str(isolate, code);
-  v8::Local<v8::Script> script;
-  if (!v8::Script::Compile(context, source).ToLocal(&script)) {
-    KJ_FAIL_REQUIRE("error parsing code", code);
-  }
-
-  v8::TryCatch catcher(isolate);
-  v8::Local<v8::Value> result;
-  if (script->Run(context).ToLocal(&result)) {
-    return result;
-  } else {
-    KJ_REQUIRE(catcher.HasCaught());
-    catcher.ReThrow();
-    throw jsg::JsExceptionThrown();
-  }
-}
-
 v8::Local<v8::Object> TestFixture::V8Environment::compileAndInstantiateModule(
     kj::StringPtr name, kj::ArrayPtr<const char> src) const {
   v8::Local<v8::Module> module;

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -29,10 +29,6 @@ struct TestFixture {
 
   struct V8Environment {
     v8::Isolate* isolate;
-
-    // Compile and instantiate esm module. Returns module namespace object.
-    v8::Local<v8::Object> compileAndInstantiateModule(
-      kj::StringPtr name, kj::ArrayPtr<const char> src) const;
   };
 
   struct Environment : public V8Environment {

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -30,9 +30,6 @@ struct TestFixture {
   struct V8Environment {
     v8::Isolate* isolate;
 
-    // Compile and run the script. Returns the result of last statement.
-    v8::Local<v8::Value> compileAndRunScript(kj::StringPtr script) const;
-
     // Compile and instantiate esm module. Returns module namespace object.
     v8::Local<v8::Object> compileAndInstantiateModule(
       kj::StringPtr name, kj::ArrayPtr<const char> src) const;


### PR DESCRIPTION
The utility methods are unused in workerd other than to test themselves.
Removing this removes a number of direct uses of v8 apis in the code that just appear to be unnecessary.

In the internal equivalent the `compileAndRunScript` utility is also unused and can safely be removed.

An argument can be made to keep `compileAndInstantiateModule` since internally that is used in a handful of fuzzing tests but it's not clear if those will ever be ported out to workerd and the internal `test-fixture` impl has it's own copy of `compileAndInstantiateModule`. Removing this in a separate commit here so that, if necessary, we can revert removing `compileAndInstantiateModule` separately if necessary.