### PR TITLE
Enable for llvm-symbolizer for GitHub test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,15 @@ jobs:
             sudo apt-get install -y libunwind-14 libc++abi1-14 libc++1-14 libc++-14-dev
             echo "build:linux --action_env=CC=/usr/lib/llvm-14/bin/clang --action_env=CXX=/usr/lib/llvm-14/bin/clang++" >> .bazelrc
             echo "build:linux --host_action_env=CC=/usr/lib/llvm-14/bin/clang --host_action_env=CXX=/usr/lib/llvm-14/bin/clang++" >> .bazelrc
+            sed -i -e "s%llvm-symbolizer%/usr/lib/llvm-14/bin/llvm-symbolizer%" .bazelrc
+      - name: Setup macOS
+        if: runner.os == 'macOS'
+        # We want to symbolize stacks for crashes on CI. Xcode is currently based on LLVM 15
+        # and the macos-12 image has llvm@15 installed:
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
+        run: |
+            export LLVM_SYMBOLIZER=$(brew --prefix llvm@15)/bin/llvm-symbolizer
+            sed -i -e "s%llvm-symbolizer%${LLVM_SYMBOLIZER}%" .bazelrc
       - name: Setup Windows
         if: runner.os == 'Windows'
         # Set a custom output dir and disable generating debug information on Windows. By default,


### PR DESCRIPTION
During setup put the appropriate path for llvm-symbolizer into `.bazelrc` for Linux and macOS.

Bug: https://github.com/cloudflare/workerd/issues/1247