### PR TITLE
webgpu: check for empty features list

### DIFF
--- a/src/workerd/api/gpu/gpu-adapter.c++
+++ b/src/workerd/api/gpu/gpu-adapter.c++
@@ -69,12 +69,12 @@ GPUAdapter::requestDevice(jsg::Lock& js, jsg::Optional<GPUDeviceDescriptor> desc
   wgpu::DeviceDescriptor desc{};
   kj::Vector<wgpu::FeatureName> requiredFeatures;
   wgpu::RequiredLimits limits;
-  KJ_IF_SOME (d, descriptor) {
-    KJ_IF_SOME (label, d.label) {
+  KJ_IF_SOME(d, descriptor) {
+    KJ_IF_SOME(label, d.label) {
       desc.label = label.cStr();
     }
 
-    KJ_IF_SOME (features, d.requiredFeatures) {
+    KJ_IF_SOME(features, d.requiredFeatures) {
       for (auto& required : features) {
         requiredFeatures.add(parseFeatureName(required));
       }
@@ -83,7 +83,7 @@ GPUAdapter::requestDevice(jsg::Lock& js, jsg::Optional<GPUDeviceDescriptor> desc
       desc.requiredFeatures = requiredFeatures.begin();
     }
 
-    KJ_IF_SOME (requiredLimits, d.requiredLimits) {
+    KJ_IF_SOME(requiredLimits, d.requiredLimits) {
       for (auto& f : requiredLimits.fields) {
         setLimit(limits, f.name, f.value);
       }
@@ -118,7 +118,9 @@ jsg::Ref<GPUSupportedFeatures> GPUAdapter::getFeatures() {
   wgpu::Adapter adapter(adapter_.Get());
   size_t count = adapter.EnumerateFeatures(nullptr);
   kj::Array<wgpu::FeatureName> features = kj::heapArray<wgpu::FeatureName>(count);
-  adapter.EnumerateFeatures(&features[0]);
+  if (count > 0) {
+    adapter.EnumerateFeatures(&features[0]);
+  }
   return jsg::alloc<GPUSupportedFeatures>(kj::mv(features));
 }
 

--- a/src/workerd/api/gpu/gpu-device.c++
+++ b/src/workerd/api/gpu/gpu-device.c++
@@ -487,7 +487,9 @@ jsg::Ref<GPUSupportedFeatures> GPUDevice::getFeatures() {
   wgpu::Device device(device_.Get());
   size_t count = device.EnumerateFeatures(nullptr);
   kj::Array<wgpu::FeatureName> features = kj::heapArray<wgpu::FeatureName>(count);
-  device.EnumerateFeatures(&features[0]);
+  if (count > 0) {
+    device.EnumerateFeatures(&features[0]);
+  }
   return jsg::alloc<GPUSupportedFeatures>(kj::mv(features));
 }
 

--- a/src/workerd/api/gpu/webgpu-errors-test.js
+++ b/src/workerd/api/gpu/webgpu-errors-test.js
@@ -17,6 +17,7 @@ export class DurableObjectExample {
 
     const device = await adapter.requestDevice();
     ok(device);
+    ok(device.features.keys());
 
     let callbackCalled = false;
     device.addEventListener("uncapturederror", (event) => {


### PR DESCRIPTION
Don't attempt to deference the first element of an empty array.