### PR TITLE
DO NOT MERGE: Test Apple silicon support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
             os: ubuntu-20.04
           - os-name: macOS
             os: macos-latest
+          - os-name: macOS ARM
+            os: macos-latest-xlarge
           - os-name: windows
             os: windows-2022
       fail-fast: false


### PR DESCRIPTION
See https://github.blog/changelog/2023-10-02-github-actions-apple-silicon-m1-macos-runners-are-now-available-in-public-beta/