### PR TITLE
Implement navigator.sendBeacon

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -47,7 +47,10 @@ public:
   jsg::Ref<api::gpu::GPU> getGPU(CompatibilityFlags::Reader flags);
 #endif
 
+  bool sendBeacon(jsg::Lock& js, jsg::UsvString url, jsg::Optional<Body::Initializer> body);
+
   JSG_RESOURCE_TYPE(Navigator) {
+    JSG_METHOD(sendBeacon);
     JSG_READONLY_INSTANCE_PROPERTY(userAgent, getUserAgent);
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
     JSG_READONLY_INSTANCE_PROPERTY(gpu, getGPU);

--- a/src/workerd/api/tests/navigator-beacon-test.js
+++ b/src/workerd/api/tests/navigator-beacon-test.js
@@ -1,0 +1,29 @@
+import {
+  ok,
+  strictEqual,
+} from 'node:assert';
+
+const enc = new TextEncoder();
+
+// This one returns false with no error thrown because we're not in an IoContext
+ok(!navigator.sendBeacon('http://example.org', 'does not work'));
+
+export const navigatorBeaconTest = {
+  async test(ctrl, env, ctx) {
+    ok(navigator.sendBeacon('http://example.org', 'beacon'));
+    ok(navigator.sendBeacon('http://example.org', new ReadableStream({
+      start(c) {
+        c.enqueue(enc.encode('beacon'));
+        c.close();
+      }
+    })));
+    ok(navigator.sendBeacon('http://example.org', enc.encode('beacon')));
+  }
+};
+
+export default {
+  async fetch(req, env) {
+    strictEqual(await req.text(), 'beacon');
+    return new Response(null, { status: 204 });
+  }
+};

--- a/src/workerd/api/tests/navigator-beacon-test.wd-test
+++ b/src/workerd/api/tests/navigator-beacon-test.wd-test
@@ -1,0 +1,16 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const worker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "navigator-beacon-test.js")
+  ],
+  compatibilityDate = "2023-01-15",
+  compatibilityFlags = ["nodejs_compat"],
+);
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "navigator-beacon-test", worker = .worker ),
+    ( name = "internet", worker = .worker )
+  ],
+);


### PR DESCRIPTION
A POC simplistic implementation of the standard `navigator.sendBeacon()` API -- https://www.w3.org/TR/beacon/#sendbeacon-method

`navigator.sendBeacon()` is essentially a simplified fire-and-forget POST request that eliminates a fair amount of boilerplate that is necessary when using fetch. For example, within a request:

```js
const promise = fetch('https://example.com', { method: 'POST', body: 'hello world' });
ctx.waitUntil(promise);
```

Can be replaced with simply:

```js
navigator.sendBeacon('https://example.com', 'hello world');
```

This implementation uses the global fetch (and therefore configured 'internet' service). Similar implementation could be added to any `Fetcher`, however, allowing this pattern to be used with bindings also. However, this PR just sticks with the standardized `navigator.sendBeacon()`.

Per the standard, `sendBeacon()` is supposed to be processed with a lower priority. We currently do not implement any priority scheme for subrequests. There is also some degree of deferred/batched processing that is permitted per the spec but this impl just takes as simple/rudimentary approach as possible.

Ultimately the idea here is to simplify some of the logging cases that we have seen where folks are using `waitUntil` to wait on fetch operations for logging purposes.