### PR TITLE
Webcrypto refactor, fix type of publicExponent

### DIFF
--- a/src/workerd/api/crypto-impl-aes.c++
+++ b/src/workerd/api/crypto-impl-aes.c++
@@ -124,7 +124,7 @@ protected:
   }
 
 private:
-  CryptoKey::AlgorithmVariant getAlgorithm() const override final { return keyAlgorithm; }
+  CryptoKey::AlgorithmVariant getAlgorithm(jsg::Lock& js) const override final { return keyAlgorithm; }
 
   SubtleCrypto::ExportKeyData exportKey(kj::StringPtr format) const override final {
     JSG_REQUIRE(format == "raw" || format == "jwk", DOMNotSupportedError,

--- a/src/workerd/api/crypto-impl-asymmetric-test.js
+++ b/src/workerd/api/crypto-impl-asymmetric-test.js
@@ -51,3 +51,22 @@ export const eddsa_test = {
     assert.ok(edKey.publicKey.algorithm.name == "NODE-ED25519");
   }
 }
+
+export const publicExponent_type_test = {
+  async test(ctrl, env, ctx) {
+    const key = await crypto.subtle.generateKey(
+      {
+        name: "RSA-PSS",
+        hash: "SHA-256",
+        modulusLength: 1024,
+        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+      },
+      false,
+      ["sign", "verify"]
+    );
+
+    // Check that a Uint8Array is used for publicExponent. Without the
+    // crypto_preserve_public_exponent feature flag, this would incorrectly return an ArrayBuffer.
+    assert.ok(key.publicKey.algorithm.publicExponent[Symbol.toStringTag] == "Uint8Array");
+  }
+}

--- a/src/workerd/api/crypto-impl-asymmetric-test.wd-test
+++ b/src/workerd/api/crypto-impl-asymmetric-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "crypto-impl-asymmetric-test.js")
         ],
         compatibilityDate = "2023-05-18",
-        compatibilityFlags = ["experimental", "nodejs_compat"],
+        compatibilityFlags = ["experimental", "nodejs_compat", "crypto_preserve_public_exponent"],
       )
     ),
   ],

--- a/src/workerd/api/crypto-impl-hkdf.c++
+++ b/src/workerd/api/crypto-impl-hkdf.c++
@@ -18,7 +18,8 @@ public:
 
 private:
   kj::Array<kj::byte> deriveBits(
-      SubtleCrypto::DeriveKeyAlgorithm&& algorithm, kj::Maybe<uint32_t> maybeLength) const override {
+      jsg::Lock& js, SubtleCrypto::DeriveKeyAlgorithm&& algorithm,
+      kj::Maybe<uint32_t> maybeLength) const override {
     kj::StringPtr hashName = api::getAlgorithmName(JSG_REQUIRE_NONNULL(algorithm.hash, TypeError,
         "Missing field \"hash\" in \"algorithm\"."));
     const EVP_MD* hashType = lookupDigestAlgorithm(hashName).second;
@@ -51,7 +52,7 @@ private:
   }
 
   kj::StringPtr getAlgorithmName() const override { return "HKDF"; }
-  CryptoKey::AlgorithmVariant getAlgorithm() const override { return keyAlgorithm; }
+  CryptoKey::AlgorithmVariant getAlgorithm(jsg::Lock& js) const override { return keyAlgorithm; }
 
   bool equals(const CryptoKey::Impl& other) const override final {
     return this == &other || (other.getType() == "secret"_kj && other.equals(keyData));

--- a/src/workerd/api/crypto-impl-hmac.c++
+++ b/src/workerd/api/crypto-impl-hmac.c++
@@ -82,7 +82,7 @@ private:
   }
 
   kj::StringPtr getAlgorithmName() const override { return "HMAC"; }
-  CryptoKey::AlgorithmVariant getAlgorithm() const override { return keyAlgorithm; }
+  CryptoKey::AlgorithmVariant getAlgorithm(jsg::Lock& js) const override { return keyAlgorithm; }
 
   bool equals(const CryptoKey::Impl& other) const override final {
     return this == &other || (other.getType() == "secret"_kj && other.equals(keyData));

--- a/src/workerd/api/crypto-impl-pbkdf2.c++
+++ b/src/workerd/api/crypto-impl-pbkdf2.c++
@@ -17,7 +17,7 @@ public:
 
 private:
   kj::Array<kj::byte> deriveBits(
-      SubtleCrypto::DeriveKeyAlgorithm&& algorithm,
+      jsg::Lock& js, SubtleCrypto::DeriveKeyAlgorithm&& algorithm,
       kj::Maybe<uint32_t> maybeLength) const override {
     kj::StringPtr hashName = api::getAlgorithmName(JSG_REQUIRE_NONNULL(algorithm.hash, TypeError,
         "Missing field \"hash\" in \"algorithm\"."));
@@ -65,7 +65,7 @@ private:
 //   }
 
   kj::StringPtr getAlgorithmName() const override { return "PBKDF2"; }
-  CryptoKey::AlgorithmVariant getAlgorithm() const override { return keyAlgorithm; }
+  CryptoKey::AlgorithmVariant getAlgorithm(jsg::Lock& js) const override { return keyAlgorithm; }
 
   bool equals(const CryptoKey::Impl& other) const override final {
     return this == &other || (other.getType() == "secret"_kj && other.equals(keyData));

--- a/src/workerd/api/crypto-impl.h
+++ b/src/workerd/api/crypto-impl.h
@@ -158,6 +158,7 @@ public:
   }
 
   virtual kj::Array<kj::byte> deriveBits(
+      jsg::Lock& js,
       SubtleCrypto::DeriveKeyAlgorithm&& algorithm, kj::Maybe<uint32_t> length) const {
     JSG_FAIL_REQUIRE(DOMNotSupportedError,
         "The deriveKey and deriveBits operations are not implemented for \"",
@@ -210,7 +211,7 @@ public:
 
   // JS API implementation
 
-  virtual AlgorithmVariant getAlgorithm() const = 0;
+  virtual AlgorithmVariant getAlgorithm(jsg::Lock& js) const = 0;
   virtual kj::StringPtr getType() const { return "secret"_kj; }
 
   virtual bool equals(const Impl& other) const = 0;

--- a/src/workerd/api/crypto.c++
+++ b/src/workerd/api/crypto.c++
@@ -272,7 +272,7 @@ template <typename T, typename = kj::EnableIf<kj::isSameType<
 CryptoKey::CryptoKey(kj::Own<Impl> impl): impl(kj::mv(impl)) {}
 CryptoKey::~CryptoKey() noexcept(false) {}
 kj::StringPtr CryptoKey::getAlgorithmName() const { return impl->getAlgorithmName(); }
-CryptoKey::AlgorithmVariant CryptoKey::getAlgorithm() const { return impl->getAlgorithm(); }
+CryptoKey::AlgorithmVariant CryptoKey::getAlgorithm(jsg::Lock& js) const { return impl->getAlgorithm(js); }
 kj::StringPtr CryptoKey::getType() const { return impl->getType(); }
 bool CryptoKey::getExtractable() const { return impl->isExtractable(); }
 kj::Array<kj::StringPtr> CryptoKey::getUsages() const {
@@ -429,7 +429,7 @@ jsg::Promise<jsg::Ref<CryptoKey>> SubtleCrypto::deriveKey(
 
     auto length = getKeyLength(derivedKeyAlgorithm);
 
-    auto secret = baseKey.impl->deriveBits(kj::mv(algorithm), length);
+    auto secret = baseKey.impl->deriveBits(js, kj::mv(algorithm), length);
 
     // TODO(perf): For conformance, importKey() makes a copy of `secret`. In this case we really
     //   don't need to, but rather we ought to call the appropriate CryptoKey::Impl::import*()
@@ -456,7 +456,7 @@ jsg::Promise<kj::Array<kj::byte>> SubtleCrypto::deriveBits(
 
   return js.evalNow([&] {
     validateOperation(baseKey, algorithm.name, CryptoKeyUsageSet::deriveBits());
-    return baseKey.impl->deriveBits(kj::mv(algorithm), length);
+    return baseKey.impl->deriveBits(js, kj::mv(algorithm), length);
   });
 }
 

--- a/src/workerd/api/crypto.h
+++ b/src/workerd/api/crypto.h
@@ -16,7 +16,7 @@ namespace node {
 class CryptoImpl;
 }
 namespace {
-class EdDsaKeyBase;
+class EdDsaKey;
 class EllipticKey;
 }
 
@@ -260,7 +260,7 @@ private:
 
   friend class SubtleCrypto;
   friend class EllipticKey;
-  friend class EdDsaKeyBase;
+  friend class EdDsaKey;
   friend class node::CryptoImpl;
 };
 

--- a/src/workerd/api/crypto.h
+++ b/src/workerd/api/crypto.h
@@ -6,6 +6,8 @@
 // WebCrypto API
 
 #include <bit>
+#include <workerd/io/features.h>
+#include <workerd/jsg/buffersource.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/buffersource.h>
 #include <openssl/err.h>
@@ -160,14 +162,33 @@ public:
     // The length, in bits, of the RSA modulus. The spec would have this be an unsigned long.
     uint16_t modulusLength;
 
-    // The length, in bits, of the RSA modulus. The spec would have this be an unsigned long.
-    BigInteger publicExponent;
+     // The RSA public exponent (in unsigned big-endian form)
+    kj::OneOf<BigInteger, jsg::BufferSource> publicExponent;
 
     // The hash algorithm that is used with this key.
     jsg::Optional<KeyAlgorithm> hash;
 
-    RsaKeyAlgorithm clone() const {
-      return { name, modulusLength, kj::heapArray(publicExponent.asPtr()), hash };
+    RsaKeyAlgorithm clone(jsg::Lock& js) const {
+      auto fixPublicExp = FeatureFlags::get(js).getCryptoPreservePublicExponent();
+      KJ_SWITCH_ONEOF(publicExponent) {
+        KJ_CASE_ONEOF(array, BigInteger) {
+          if (fixPublicExp) {
+            auto expCopy = kj::heapArray<kj::byte>(array.asPtr());
+            jsg::BackingStore expBack = jsg::BackingStore::from(kj::mv(expCopy));
+            return { name, modulusLength, jsg::BufferSource(js, kj::mv(expBack)), hash };
+          } else {
+            return { name, modulusLength, kj::heapArray(array.asPtr()), hash };
+          }
+        }
+        KJ_CASE_ONEOF(source, jsg::BufferSource) {
+          // Should only happen if the flag is enabled and an algorithm field is cloned twice.
+          KJ_ASSERT(fixPublicExp == true);
+          auto expCopy = kj::heapArray<kj::byte>(source.asArrayPtr());
+          jsg::BackingStore expBack = jsg::BackingStore::from(kj::mv(expCopy));
+          return { name, modulusLength, jsg::BufferSource(js, kj::mv(expBack)), hash };
+        }
+      }
+      KJ_UNREACHABLE;
     }
 
     JSG_STRUCT(name, modulusLength, publicExponent, hash);
@@ -186,7 +207,7 @@ public:
   // Catch-all that can be used for extension algorithms. Combines fields of several known types.
   struct ArbitraryKeyAlgorithm {
     // TODO(cleanup): Should we just replace AlgorithmVariant with this? Note we'd have to add
-    //   `pulicExponent` which is currently a problem because it makes the type non-copyable...
+    //   `publicExponent` which is currently a problem because it makes the type non-copyable...
     //   Alternatively, should we create some better way to abstract this?
 
     kj::StringPtr name;
@@ -205,7 +226,7 @@ public:
     jsg::Optional<kj::Array<kj::byte>> publicExponent;
     jsg::Optional<kj::String> hashAlgorithm;
     jsg::Optional<kj::String> mgf1HashAlgorithm;
-    jsg::Optional<double> saltLength;
+    jsg::Optional<uint32_t> saltLength;
     jsg::Optional<uint32_t> divisorLength;
     jsg::Optional<kj::String> namedCurve;
     JSG_STRUCT(modulusLength,
@@ -229,7 +250,7 @@ public:
       KeyAlgorithm, AesKeyAlgorithm, HmacKeyAlgorithm, RsaKeyAlgorithm,
       EllipticKeyAlgorithm, ArbitraryKeyAlgorithm>;
 
-  AlgorithmVariant getAlgorithm() const;
+  AlgorithmVariant getAlgorithm(jsg::Lock& js) const;
   kj::StringPtr getType() const;
   bool getExtractable() const;
   kj::Array<kj::StringPtr> getUsages() const;

--- a/src/workerd/api/node/crypto-keys.c++
+++ b/src/workerd/api/node/crypto-keys.c++
@@ -19,7 +19,7 @@ public:
         keyData(kj::mv(keyData)) {}
 
   kj::StringPtr getAlgorithmName() const override { return "secret"_kj; }
-  CryptoKey::AlgorithmVariant getAlgorithm() const override {
+  CryptoKey::AlgorithmVariant getAlgorithm(jsg::Lock& js) const override {
     return CryptoKey::KeyAlgorithm {
       .name = kj::str("secret"_kj)
     };

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -344,4 +344,12 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   webgpu @35 :Bool
       $compatEnableFlag("webgpu")
       $experimental;
+
+  cryptoPreservePublicExponent @36 :Bool
+      $compatEnableFlag("crypto_preserve_public_exponent")
+      $compatDisableFlag("no_crypto_preserve_public_exponent")
+      $compatEnableDate("2023-12-01");
+  # In the WebCrypto API, the `publicExponent` field of the algorithm of RSA keys would previously
+  # be an ArrayBuffer. Using this flag, publicExponent is a Uint8Array as mandated by the
+  # specification.
 }


### PR DESCRIPTION
This addresses #48 and refactors the `EdDsaKey` class. 
- In terms of refactoring, we can combine the EdDsaKey and EdDsaCurveKey classes as they are largely identical, the subtle difference in the naming of the algorithm field can be handled in getAlgorithm() alone.
- For the issue I primarily changed the clone() method of RsaKeyAlgorithm to return the correct type for publicExponent instead of making more invasive changes, this should minimize the risk of introducing bugs. The change is behind the new `cryptoPreservePublicExponent` compat flag, the other changes are for adding a test and introducing additional scaffolding
- Some additional questions regarding potential refactoring came up while reviewing the code to look for any other situations where we might be returning the wrong type, see comments.