### PR TITLE
Implement the Web Platform standard CustomEvent

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -585,4 +585,27 @@ jsg::Optional<jsg::Ref<ActorState>> ExtendableEvent::getActorState() {
   });
 }
 
+CustomEvent::CustomEvent(kj::String ownType, CustomEventInit init)
+    : Event(kj::mv(ownType), (Event::Init)init),
+      detail(kj::mv(init.detail)) {}
+
+jsg::Ref<CustomEvent> CustomEvent::constructor(jsg::Lock& js, kj::String type,
+                                               jsg::Optional<CustomEventInit> init) {
+  return jsg::alloc<CustomEvent>(kj::mv(type), kj::mv(init).orDefault({}));
+}
+
+jsg::Optional<jsg::JsValue> CustomEvent::getDetail(jsg::Lock& js) {
+  return detail.map([&](jsg::JsRef<jsg::JsValue>& val) {
+    return val.getHandle(js);
+  });
+}
+
+CustomEvent::CustomEventInit::operator Event::Init() {
+  return {
+    .bubbles = this->bubbles.map([](auto& val) { return val; }),
+    .cancelable = this->cancelable.map([](auto& val) { return val; }),
+    .composed = this->composed.map([](auto& val) { return val; }),
+  };
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -190,6 +190,35 @@ public:
   }
 };
 
+// An implementation of the Web Platform Standard CustomEvent API
+class CustomEvent: public Event {
+public:
+  struct CustomEventInit final {
+    jsg::Optional<bool> bubbles;
+    jsg::Optional<bool> cancelable;
+    jsg::Optional<bool> composed;
+    jsg::Optional<jsg::JsRef<jsg::JsValue>> detail;
+    JSG_STRUCT(bubbles, cancelable, composed, detail);
+
+    operator Event::Init();
+  };
+
+  explicit CustomEvent(kj::String ownType, CustomEventInit init = CustomEventInit());
+
+  static jsg::Ref<CustomEvent> constructor(jsg::Lock& js, kj::String type,
+                                           jsg::Optional<CustomEventInit> init);
+
+  jsg::Optional<jsg::JsValue> getDetail(jsg::Lock& js);
+
+  JSG_RESOURCE_TYPE(CustomEvent) {
+    JSG_INHERIT(Event);
+    JSG_READONLY_PROTOTYPE_PROPERTY(detail, getDetail);
+  }
+
+private:
+  jsg::Optional<jsg::JsRef<jsg::JsValue>> detail;
+};
+
 // An implementation of the Web Platform Standard EventTarget API
 class EventTarget: public jsg::Object {
 public:
@@ -632,7 +661,9 @@ private:
     api::AbortSignal,                          \
     api::Scheduler,                            \
     api::Scheduler::WaitOptions,               \
-    api::ExtendableEvent
+    api::ExtendableEvent,                      \
+    api::CustomEvent,                          \
+    api::CustomEvent::CustomEventInit
 // The list of basics.h types that are added to worker.c++'s JSG_DECLARE_ISOLATE_TYPE
 
 }  // namespace workerd::api

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -413,6 +413,7 @@ public:
 
     JSG_NESTED_TYPE(Event);
     JSG_NESTED_TYPE(ExtendableEvent);
+    JSG_NESTED_TYPE(CustomEvent);
     JSG_NESTED_TYPE(PromiseRejectionEvent);
     JSG_NESTED_TYPE(FetchEvent);
     JSG_NESTED_TYPE(TailEvent);

--- a/src/workerd/api/tests/events-test.js
+++ b/src/workerd/api/tests/events-test.js
@@ -1,7 +1,8 @@
 import {
   deepStrictEqual,
   strictEqual,
-  throws
+  throws,
+  ok,
 } from 'node:assert';
 
 // Test for the Event and EventTarget standard Web API implementations.
@@ -367,5 +368,14 @@ export const nullUndefinedHandler = {
     const target = new EventTarget();
     // target.addEventListener('foo', null);
     // target.addEventListener('foo', undefined);
+  }
+};
+
+export const customEvent = {
+  test() {
+    const event = new CustomEvent('foo', { detail: { a: 123 } });
+    ok(event instanceof Event);
+    strictEqual(event.type, 'foo');
+    deepStrictEqual(event.detail, { a: 123 });
   }
 };


### PR DESCRIPTION
`CustomEvent`  is a Web platform standard API that is also supported by other WinterCG-compat runtimes (e.g., Node.js, Deno, etc). It is defined by DOM (https://dom.spec.whatwg.org/#interface-customevent) and is in fairly common use (https://github.com/search?type=code&q=new+CustomEvent+language%3AJavaScript&l=JavaScript). This PR just makes the API available for use within Workers.