### PR TITLE
SQL: increase EXPR_DEPTH from 20 -> 100

### DIFF
--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -705,7 +705,7 @@ void SqliteDatabase::setupSecurity() {
   sqlite3_limit(db, SQLITE_LIMIT_LENGTH, 1000000);
   sqlite3_limit(db, SQLITE_LIMIT_SQL_LENGTH, 100000);
   sqlite3_limit(db, SQLITE_LIMIT_COLUMN, 100);
-  sqlite3_limit(db, SQLITE_LIMIT_EXPR_DEPTH, 20);
+  sqlite3_limit(db, SQLITE_LIMIT_EXPR_DEPTH, 100);
   // Enforces limits on UNION/UNION ALL/INTERSECT/etc
   // https://www.sqlite.org/limits.html#max_compound_select
   sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 5);


### PR DESCRIPTION
This PR sets the maximum expression depth to 100 as an intermediate measure, accepting that it may not unblock every user.

Background: We're seeing developers (particularly those using ORMs) run into limitations when running queries against D1. It is not clear from an EQP (EXPLAIN QUERY PLAN) output what the expression depth of a query is, which makes it challenging to set this to a value that works for users without being unnecessarily high — the deeper the expression depth the more likely the query to just run into other limits.

For context:

* The SQLite default is 1000.
* Our current is 20
* The "Dark Arts" suggested value was 10 (https://www.sqlite.org/security.html)

Fixes [#4094](https://github.com/cloudflare/workers-sdk/issues/4094)