### PR TITLE
Fix the dbg config on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,7 +13,8 @@ build --host_per_file_copt='external/dawn@-Wno-shorten-64-to-32,-Wno-unneeded-in
 
 # Enable C++20 to support std::unordered_map::contains(). Not sure why this is needed here, V8
 # is supposed to work with C++14.
-build --per_file_copt='external/v8/src/compiler/graph-visualizer.cc@-std=c++20'
+build:unix --per_file_copt='external/v8/src/compiler/graph-visualizer.cc@-std=c++20'
+build:windows --per_file_copt='external/v8/src/compiler/graph-visualizer.cc@/std:c++20'
 
 # Speed up sandboxed compilation, particularly on I/O-constrained and non-Linux systems
 # https://bazel.build/reference/command-line-reference#flag--reuse_sandbox_directories

--- a/tools/windows/create-external.bat
+++ b/tools/windows/create-external.bat
@@ -7,9 +7,12 @@ FOR /f %%i IN ('bazel info output_path') do SET "output_path=%%i"
 FOR /f %%i IN ('bazel info workspace') do SET "workspace=%%i"
 SET "external=%output_path%\..\..\..\external"
 
-IF NOT EXIST "%workspace%\external" (
-  MKLINK /J "%workspace%\external" "%external%"
-)
+@REM Delete the convenience junction external if it exists (it maybe stale if it does).
+rmdir  "%workspace%\external" 2>NUL
+
+@REM Create the convenience junction external anew for easy access to sources and for
+@REM VSCode to be able to open files at points of error when compilation fails.
+MKLINK /J "%workspace%\external" "%external%"
 
 SET "compile_commands=%workspace%\compile_commands.json"
 IF EXIST "%compile_commands%" (


### PR DESCRIPTION
clang-cl has a different syntax for specifying the C++ standard version so was rejecting the fix added in #1184 for the DCHECK in V8's graph-visualizer.cc that needs C++20. V8 DCHECKs are enabled for dbg builds. This is fixed in .bazelrc.

To add to my own confusion when looking into this issue, the junction we create in the workspace folder, `external`, was stable. The junction is created to make it easy to find sources to downloaded dependencies and also to help VSCode find the right sources when bazel build emits compilation errors. Unfortunately, the junction was stale locally so following the error links reported in VSCode went to an old version of V8 on the disk with entirely different code that could not possibly have caused the error observed. As a result, the script that creates the junction when VSCode opens the project is updated to delete any existing `external` junction and create it anew.