### PR TITLE
Unbreak `bazel shutdown`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@ build --verbose_failures
 build --build_tag_filters=-off-by-default
 
 # Enable webgpu
-common --//src/workerd/io:enable_experimental_webgpu=True
+build --//src/workerd/io:enable_experimental_webgpu=True
 
 # Our dependencies (ICU, zlib, etc.) produce a lot of these warnings, so we disable them.
 build --per_file_copt='external/com_googlesource_chromium_icu@-Wno-ambiguous-reversed-operator,-Wno-deprecated-declarations'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,8 +77,10 @@ jobs:
         run: |
             bazelisk build --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --verbose_failures //...
       - name: Bazel tests
+        # Run tests and check that there are no .bazelrc issues that prevent shutdown.
         run: |
             bazelisk test --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --verbose_failures --keep_going --test_output=errors //...
+            bazelisk shutdown
       - name: Report disk usage
         if: always()
         shell: bash


### PR DESCRIPTION
Enabling webgpu added a common option that is not supported by `bazel shutdown` resulting in:

ERROR: Unrecognized arguments: --//src/workerd/io:enable_experimental_webgpu=True

This change moves the webgpu config from `bazel common` to `bazel build` and adds a check to the github test workflow to avoid similar issues in future.

Test: manual invocation of webgpu tests continues to work, e.g.
  bazel-bin/src/workerd/server/workerd test                       \
    `realpath src/workerd/api/gpu/webgpu-buffer-test.gpu-wd-test` \
     --verbose --experimental