### PR TITLE
JSExceptionThrown noexcept default

### DIFF
--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -30,6 +30,7 @@ typedef unsigned int uint;
 class JsExceptionThrown: public std::exception {
 public:
   JsExceptionThrown();
+  ~JsExceptionThrown() noexcept = default;  // We must match `std::exception`'s noexcept.
   const char* what() const noexcept override;
 
 private:


### PR DESCRIPTION
Necessary for compatibility with this capnp change: https://github.com/capnproto/capnproto/pull/1800/files