### PR TITLE
Cleanup: Only log interesting exceptions when an actor cache flush fails

### DIFF
--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -2546,7 +2546,11 @@ kj::Promise<void> ActorCache::flushImpl(uint retryCount) {
       }
       return kj::mv(e);
     } else {
-      LOG_EXCEPTION("actorCacheFlush", e);
+      if (isInterestingException(e)) {
+        LOG_EXCEPTION("actorCacheFlush", e);
+      } else {
+        LOG_NOSENTRY(ERROR, "actor cache flush failed", e);
+      }
       return KJ_EXCEPTION(FAILED, "broken.outputGateBroken; jsg.Error: Internal error in Durable "
           "Object storage write caused object to be reset.");
     }


### PR DESCRIPTION
With this change, we won't spam logs when we have issues with our storage api servers. (These errors are generally obvious in metrics and other error logs.)