### PR TITLE
[nfc] Break JSG observer dependency on V8

### DIFF
--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -109,7 +109,6 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@capnp-cpp//src/kj",
-        "@workerd-v8//:v8",
     ],
 )
 

--- a/src/workerd/jsg/observer.h
+++ b/src/workerd/jsg/observer.h
@@ -6,7 +6,12 @@
 
 #include <kj/common.h>
 #include <kj/string.h>
-#include <v8.h>
+
+// Forward declare v8::Isolate here, this allows us to avoid including the V8 header and compile
+// some targets without depending on V8.
+namespace v8 {
+  class Isolate;
+}
 
 namespace workerd::jsg {
 


### PR DESCRIPTION
This will allow us to compile some upstream targets without depending on V8, resulting in better link performance. Upstream PR to follow.