### PR TITLE
Migrate core of URLPattern parsing to jsg::UrlPattern

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -263,6 +263,7 @@
         "bazel-bin/src/workerd/jsg/buffersource-test",
         "bazel-bin/src/workerd/jsg/struct-test",
         "bazel-bin/src/workerd/jsg/jsg-test",
+        "bazel-bin/src/workerd/jsg/url-test",
         "bazel-bin/src/workerd/jsg/iterator-test",
         "bazel-bin/src/workerd/server/server-test",
         "bazel-bin/src/workerd/api/actor-state-test",

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -41,8 +41,11 @@ wd_cc_library(
     hdrs = ["url.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "@v8//:v8_icu",
+        "@workerd//:icudata-embed",
         "@capnp-cpp//src/kj",
         "@ada-url",
+        ":exception",
     ],
 )
 

--- a/src/workerd/jsg/url-pattern-test-corpus-failures.h
+++ b/src/workerd/jsg/url-pattern-test-corpus-failures.h
@@ -1,0 +1,433 @@
+
+// Per the Web Platform Tests, all of these should fail to compile successfully
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("(café)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.username = kj::str("(café)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.password = kj::str("(café)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("(café)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("(café)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.search = kj::str("(café)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hash = kj::str("(café)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("example.com/foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("data:foobar"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://{sub.}?example{.com/}foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("{https://}example.com/foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("(https://)example.com/foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://{sub{.}}example.com/foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("(café)://foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("[\\:\\:xY\\::num]"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("*\\:1]"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://foo{{@}}example.com"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://foo{@example.com"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/:id/:id"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo"), .baseUrl = kj::str(""),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/foo"_kj, UrlPattern::CompileOptions {
+  .baseUrl = ""_kj
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad#hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad%hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad/hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad\\:hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad<hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad>hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad?hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad@hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad[hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad]hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad\\\\hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad^hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad|hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad\nhostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad\rhostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("bad	hostname"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("{[\\:\\:fé\\::num]}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("{[\\:\\::num\\:fé]}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+    KJ_FAIL_ASSERT("Test case should have failed");
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    // ok!
+  }
+}

--- a/src/workerd/jsg/url-pattern-test-corpus-success.h
+++ b/src/workerd/jsg/url-pattern-test-corpus-success.h
@@ -1,0 +1,2774 @@
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?otherquery#otherhash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),.baseUrl = kj::str("https://example.com?query#hash"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/([^\\/]+?)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/:bar*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/*+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/**"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/**"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/**"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/**"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/**"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/(.*)*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/**"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo{/bar}*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str(":café"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.username = kj::str(":café"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.password = kj::str(":café"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str(":café"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/:café"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.search = kj::str(":café"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hash = kj::str(":café"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str(":℘"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.username = kj::str(":℘"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.password = kj::str(":℘"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str(":℘"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/:℘"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.search = kj::str(":℘"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hash = kj::str(":℘"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str(":㐀"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.username = kj::str(":㐀"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.password = kj::str(":㐀"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str(":㐀"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/:㐀"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.search = kj::str(":㐀"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hash = kj::str(":㐀"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("foo-bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.username = kj::str("caf%C3%A9"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.username = kj::str("café"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.username = kj::str("caf%c3%a9"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.password = kj::str("caf%C3%A9"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.password = kj::str("café"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.password = kj::str("caf%c3%a9"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("xn--caf-dma.com"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("café.com"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("http"),.port = kj::str("80"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("http"),.port = kj::str("80{20}?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.port = kj::str("80"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("http{s}?"),.port = kj::str("80"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.port = kj::str("80"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.port = kj::str("(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/baz"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/caf%C3%A9"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/café"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/caf%c3%a9"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/../bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("./foo/bar"),.baseUrl = kj::str("https://example.com"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.baseUrl = kj::str("https://example.com"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("{/bar}"),.baseUrl = kj::str("https://example.com/foo/"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("\\/bar"),.baseUrl = kj::str("https://example.com/foo/"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("b"),.baseUrl = kj::str("https://example.com/foo/"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("foo/bar"),.baseUrl = kj::str("https://example.com"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str(":name.html"),.baseUrl = kj::str("https://example.com"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.search = kj::str("q=caf%C3%A9"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.search = kj::str("q=café"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.search = kj::str("q=caf%c3%a9"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hash = kj::str("caf%C3%A9"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hash = kj::str("café"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hash = kj::str("caf%c3%a9"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("about"),.pathname = kj::str("(blank|sourcedoc)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("data"),.pathname = kj::str(":number([0-9]+)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo!"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo\\:"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo\\{"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo\\("),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("javascript"),.pathname = kj::str("var x = 1;"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("var x = 1;"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("javascript"),.pathname = kj::str("var x = 1;"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("(data|javascript)"),.pathname = kj::str("var x = 1;"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("(https|javascript)"),.pathname = kj::str("var x = 1;"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("var x = 1;"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com:8080/foo?bar#baz"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/foo?bar#baz"_kj, UrlPattern::CompileOptions {.baseUrl = "https://example.com:8080"_kj})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("http{s}?://{*.}?example.com/:product/:endpoint"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com?foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com#foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com:8080?foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com:8080#foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com/?foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com/#foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com/*?foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com/*\?foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com/:name?foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com/:name\?foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com/(bar)?foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com/(bar)\?foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com/{bar}?foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com/{bar}\?foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com/"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("data\\:foobar"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://{sub.}?example.com/foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://(sub.)?example.com/foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://(sub.)?example(.com/)foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://(sub(?:.))?example.com/foo"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("file:///foo/bar"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("data:"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("foo://bar"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com/foo?bar#baz"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("?bar#baz"_kj, UrlPattern::CompileOptions {.baseUrl = "https://example.com/foo"_kj})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("?bar"_kj, UrlPattern::CompileOptions {.baseUrl = "https://example.com/foo#baz"_kj})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("#baz"_kj, UrlPattern::CompileOptions {.baseUrl = "https://example.com/foo?bar"_kj})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("#baz"_kj, UrlPattern::CompileOptions {.baseUrl = "https://example.com/foo"_kj})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://foo\\:bar@example.com"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://foo@example.com"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://\\:bar@example.com"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://:user::pass@example.com"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https\\:foo\\:bar@example.com"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("data\\:foo\\:bar@example.com"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://foo{\\:}bar@example.com"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("data{\\:}channel.html"_kj, UrlPattern::CompileOptions {.baseUrl = "https://example.com"_kj})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("http://[\\:\\:1]/"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("http://[\\:\\:1]:8080/"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("http://[\\:\\:a]/"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("http://[:address]/"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("http://[\\:\\:AB\\::num]/"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("[\\:\\:AB\\::num]"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("{[\\:\\:ab\\::num]}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("{[\\:\\::num\\:1]}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hostname = kj::str("[*\\:1]"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("data\\:text/javascript,let x = 100/:tens?5;"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str(":name*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str(":name+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str(":name"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str(":name*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str(":name+"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str(":name"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("(foo)(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("{(foo)bar}(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("(foo)?(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("{:foo}(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("{:foo}(barbaz)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("{:foo}{(.*)}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("{:foo}{(.*)bar}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("{:foo}{bar(.*)}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("{:foo}:bar(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("{:foo}?(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("{:foo\bar}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("{:foo\\.bar}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("{:foo(foo)bar}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("{:foo}bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str(":foo\bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str(":foo{}(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str(":foo{}bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str(":foo{}?bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("*{}**?"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str(":foo(baz)(.*)"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str(":foo(baz)bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("*/*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("*\\/*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("*/{*}"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("*//*"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/:foo."),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/:foo.."),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("./foo"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("../foo"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str(":foo./"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str(":foo../"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/:foo\bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.pathname = kj::str("/foo/bar"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://example.com:8080/foo?bar#baz"_kj)) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/foo?bar#baz"_kj, UrlPattern::CompileOptions {.baseUrl = "https://example.com:8080"_kj})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.protocol = kj::str("http{s}?:"),.search = kj::str("?bar"),.hash = kj::str("#baz"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.search = kj::str("foo"),.baseUrl = kj::str("https://example.com/a/+/b"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+.hash = kj::str("foo"),.baseUrl = kj::str("https://example.com/?q=*&v=?&hmm={}&umm=()"),
+})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}
+
+KJ_SWITCH_ONEOF(UrlPattern::tryCompile("#foo"_kj, UrlPattern::CompileOptions {.baseUrl = "https://example.com/?q=*&v=?&hmm={}&umm=()"_kj})) {
+  KJ_CASE_ONEOF(pattern, UrlPattern) {
+  }
+  KJ_CASE_ONEOF(err, kj::String) {
+    KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
+  }
+}

--- a/src/workerd/jsg/url-test.c++
+++ b/src/workerd/jsg/url-test.c++
@@ -5,6 +5,8 @@
 #include "jsg-test.h"
 #include "url.h"
 #include <kj/table.h>
+#include <regex>
+#include <openssl/rand.h>
 
 namespace workerd::jsg::test {
 namespace {
@@ -100,5 +102,1147 @@ KJ_TEST("Search params (2)") {
   KJ_ASSERT(kj::str(params) == "a=z");
 }
 
+// ======================================================================================
+
+KJ_TEST("URLPattern - processInit Default") {
+  KJ_SWITCH_ONEOF(UrlPattern::processInit(UrlPattern::Init {})) {
+    KJ_CASE_ONEOF(result, UrlPattern::Init) {
+      KJ_ASSERT(result.baseUrl == kj::none);
+      KJ_ASSERT(result.protocol == kj::none);
+      KJ_ASSERT(result.username == kj::none);
+      KJ_ASSERT(result.password == kj::none);
+      KJ_ASSERT(result.hostname == kj::none);
+      KJ_ASSERT(result.port == kj::none);
+      KJ_ASSERT(result.pathname == kj::none);
+      KJ_ASSERT(result.search == kj::none);
+      KJ_ASSERT(result.hash == kj::none);
+    }
+    KJ_CASE_ONEOF(msg, kj::String) {
+      KJ_FAIL_ASSERT("Default processInit failed", msg);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - processInit PATTERN mode") {
+  KJ_SWITCH_ONEOF(UrlPattern::processInit(UrlPattern::Init {
+    // Since we're using PATTERN mode here (the default), the values
+    // for each field will not be canonicalized.
+    .protocol = kj::str("something"),
+    .username = kj::str("something"),
+    .password = kj::str("something"),
+    .hostname = kj::str("something"),
+    .port = kj::str("something"),
+    .pathname = kj::str("something"),
+    .search = kj::str("something"),
+    .hash = kj::str("something"),
+  })) {
+    KJ_CASE_ONEOF(result, UrlPattern::Init) {
+      KJ_ASSERT(result.baseUrl == kj::none);
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.protocol) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.hostname) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.pathname) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.username) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.password) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.port) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.search) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.hash) == "something");
+    }
+    KJ_CASE_ONEOF(msg, kj::String) {
+      KJ_FAIL_ASSERT("processInit failed", msg);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - processInit PATTERN mode") {
+  KJ_SWITCH_ONEOF(UrlPattern::processInit(UrlPattern::Init {
+    // Since we're using PATTERN mode here (the default), the values
+    // for each field will not be canonicalized.
+    .protocol = kj::str("something"),
+    .username = kj::str("something"),
+    .password = kj::str("something"),
+    .hostname = kj::str("something"),
+    .pathname = kj::str("something"),
+    .hash = kj::str("something"),
+  }, UrlPattern::ProcessInitOptions {
+    .port = "something"_kj,
+    .search = "something"_kj,
+  })) {
+    KJ_CASE_ONEOF(result, UrlPattern::Init) {
+      KJ_ASSERT(result.baseUrl == kj::none);
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.protocol) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.hostname) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.pathname) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.username) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.password) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.port) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.search) == "something");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.hash) == "something");
+    }
+    KJ_CASE_ONEOF(msg, kj::String) {
+      KJ_FAIL_ASSERT("processInit failed", msg);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - processInit base") {
+  KJ_SWITCH_ONEOF(UrlPattern::processInit(UrlPattern::Init {
+    .baseUrl = kj::str("https://example.org")
+  })) {
+    KJ_CASE_ONEOF(result, UrlPattern::Init) {
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.baseUrl) == "https://example.org");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.protocol) == "https");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.hostname) == "example.org");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.pathname) == "/");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.username) == "");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.password) == "");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.port) == "");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.search) == "");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.hash) == "");
+    }
+    KJ_CASE_ONEOF(msg, kj::String) {
+      KJ_FAIL_ASSERT("Default processInit failed", msg);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - processInit base relative path") {
+  KJ_SWITCH_ONEOF(UrlPattern::processInit(UrlPattern::Init {
+    .pathname = kj::str("d"),
+    .baseUrl = kj::str("https://example.org/a/b/c"),
+  }, UrlPattern::ProcessInitOptions {
+    .port = "1234"_kj
+  })) {
+    KJ_CASE_ONEOF(result, UrlPattern::Init) {
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.baseUrl) == "https://example.org/a/b/c");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.protocol) == "https");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.hostname) == "example.org");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.pathname) == "/a/b/d");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.username) == "");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.password) == "");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.port) == "1234");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.search) == "");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.hash) == "");
+    }
+    KJ_CASE_ONEOF(msg, kj::String) {
+      KJ_FAIL_ASSERT("Default processInit failed", msg);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - processInit invalid base") {
+  KJ_SWITCH_ONEOF(UrlPattern::processInit(UrlPattern::Init {
+    .baseUrl = kj::str("not a valid url")
+  })) {
+    KJ_CASE_ONEOF(result, UrlPattern::Init) {
+      KJ_FAIL_ASSERT("processInit should have failed");
+    }
+    KJ_CASE_ONEOF(msg, kj::String) {
+      KJ_ASSERT(msg == "Invalid base URL.");
+    }
+  }
+}
+
+KJ_TEST("URLPattern - processInit URL mode (default)") {
+  KJ_SWITCH_ONEOF(UrlPattern::processInit(UrlPattern::Init {
+  }, UrlPattern::ProcessInitOptions {
+    .mode = UrlPattern::ProcessInitOptions::Mode::URL
+  })) {
+    KJ_CASE_ONEOF(result, UrlPattern::Init) {
+      KJ_ASSERT(result.protocol == kj::none);
+    }
+    KJ_CASE_ONEOF(str, kj::String) {
+      KJ_FAIL_ASSERT("processInit URL mode failed", str);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - processInit URL mode (protocol, fake)") {
+  KJ_SWITCH_ONEOF(UrlPattern::processInit(UrlPattern::Init {
+    // The value will be canonicalized
+    .protocol = kj::str(" FaKe"),
+    .username = kj::str("  mE!:  "),
+    .password = kj::str(" @@@:@@@"),
+    .hostname = kj::str("FOO.bar."),
+    .port = kj::str("123"),
+    .pathname = kj::str("d"),
+    .search = kj::str("?yabba dabba doo"),
+    .hash = kj::str("# "),
+    .baseUrl = kj::str("http://ignored/a/b/c"),
+  }, UrlPattern::ProcessInitOptions {
+    .mode = UrlPattern::ProcessInitOptions::Mode::URL
+  })) {
+    KJ_CASE_ONEOF(result, UrlPattern::Init) {
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.protocol) == "fake");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.username) == "%20%20mE!%3A%20%20");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.password) == "%20%40%40%40%3A%40%40%40");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.hostname) == "FOO.bar.");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.port) == "123");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.pathname) == "/d");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.search) == "yabba%20dabba%20doo");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.hash) == "%20");
+    }
+    KJ_CASE_ONEOF(str, kj::String) {
+      KJ_FAIL_ASSERT("processInit URL mode failed", str);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - processInit URL mode (protocol, http)") {
+  KJ_SWITCH_ONEOF(UrlPattern::processInit(UrlPattern::Init {
+    .username = kj::str("  mE!:  "),
+    .password = kj::str(" @@@:@@@"),
+    .hostname = kj::str("123"),
+    .port = kj::str("80"),
+    .pathname = kj::str("d"),
+    .search = kj::str("?yabba dabba doo"),
+    .hash = kj::str("# "),
+    .baseUrl = kj::str("http://something/a/b/c"),
+  }, UrlPattern::ProcessInitOptions {
+    .mode = UrlPattern::ProcessInitOptions::Mode::URL
+  })) {
+    KJ_CASE_ONEOF(result, UrlPattern::Init) {
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.protocol) == "http");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.username) == "%20%20mE!%3A%20%20");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.password) == "%20%40%40%40%3A%40%40%40");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.hostname) == "0.0.0.123");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.port) == "");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.pathname) == "/a/b/d");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.search) == "yabba%20dabba%20doo");
+      KJ_ASSERT(KJ_ASSERT_NONNULL(result.hash) == "%20");
+    }
+    KJ_CASE_ONEOF(str, kj::String) {
+      KJ_FAIL_ASSERT("processInit URL mode failed", str);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - compile with empty init") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {})) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      // In this case, with an empty Init, all of the components should be
+      // interpreted as wildcards capable of matching any input.
+#define CHECK(Name)                                      \
+  KJ_ASSERT(pattern.get##Name().getPattern() == "*");    \
+  KJ_ASSERT(pattern.get##Name().getRegex() == "^(.*)$"); \
+  KJ_ASSERT(pattern.get##Name().getNames().size() == 1); \
+  KJ_ASSERT(pattern.get##Name().getNames()[0] == "0");
+      CHECK(Protocol);
+      CHECK(Username);
+      CHECK(Password);
+      CHECK(Hostname);
+      CHECK(Port);
+      CHECK(Pathname);
+      CHECK(Search);
+      CHECK(Hash);
+#undef CHECK
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("Compiling the empty pattern failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - compile with all wildcard init") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+    .protocol = kj::str("*"),
+    .username = kj::str("*"),
+    .password = kj::str("*"),
+    .hostname = kj::str("*"),
+    .port = kj::str("*"),
+    .pathname = kj::str("*"),
+    .search = kj::str("*"),
+    .hash = kj::str("*"),
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      // In this case, with an empty Init, all of the components should be
+      // interpreted as wildcards capable of matching any input.
+#define CHECK(Name)                                      \
+  KJ_ASSERT(pattern.get##Name().getPattern() == "*");    \
+  KJ_ASSERT(pattern.get##Name().getRegex() == "^(.*)$"); \
+  KJ_ASSERT(pattern.get##Name().getNames().size() == 1); \
+  KJ_ASSERT(pattern.get##Name().getNames()[0] == "0");
+      CHECK(Protocol);
+      CHECK(Username);
+      CHECK(Password);
+      CHECK(Hostname);
+      CHECK(Port);
+      CHECK(Pathname);
+      CHECK(Search);
+      CHECK(Hash);
+#undef CHECK
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("Compiling the wildcard pattern failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - compile with http protocol only") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+    .protocol = kj::str("http"),
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      auto& protocol = pattern.getProtocol();
+      KJ_ASSERT(protocol.getPattern() == "http");
+      KJ_ASSERT(protocol.getRegex() == "^http$");
+      KJ_ASSERT(protocol.getNames().size() == 0);
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("Compiling the empty pattern failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - compile with http{s}? protocol") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+    .protocol = kj::str("http{s}?"),
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      auto& protocol = pattern.getProtocol();
+      KJ_ASSERT(protocol.getPattern() == "http{s}?");
+      KJ_ASSERT(protocol.getRegex() == "^http(?:s)?$");
+      KJ_ASSERT(protocol.getNames().size() == 0);
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("Compiling the empty pattern failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - compile with http{s}+ protocol") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+    .protocol = kj::str("http{s}+"),
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      auto& protocol = pattern.getProtocol();
+      KJ_ASSERT(protocol.getPattern() == "http{s}+");
+      KJ_ASSERT(protocol.getRegex() == "^http(?:s)+$");
+      KJ_ASSERT(protocol.getNames().size() == 0);
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("Compiling the empty pattern failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - compile with http{s}* protocol") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+    .protocol = kj::str("http{s}*"),
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      auto& protocol = pattern.getProtocol();
+      KJ_ASSERT(protocol.getPattern() == "http{s}*");
+      KJ_ASSERT(protocol.getRegex() == "^http(?:s)*$");
+      KJ_ASSERT(protocol.getNames().size() == 0);
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("Compiling the empty pattern failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - compile with http(s)? protocol") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+    .protocol = kj::str("http(.)?"),
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      auto& protocol = pattern.getProtocol();
+      KJ_ASSERT(protocol.getPattern() == "http(.)?");
+      KJ_ASSERT(protocol.getRegex() == "^http(.)?$");
+      KJ_ASSERT(protocol.getNames().size() == 1);
+      KJ_ASSERT(protocol.getNames()[0] == "0");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("Compiling the empty pattern failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - compile with :foo:bar protocol") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+    .protocol = kj::str(":foo:bar"),
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      auto& protocol = pattern.getProtocol();
+      KJ_ASSERT(protocol.getPattern() == ":foo:bar");
+      KJ_ASSERT(protocol.getRegex() == "^([^]+)([^]+)$");
+      KJ_ASSERT(protocol.getNames().size() == 2);
+      KJ_ASSERT(protocol.getNames()[0] == "foo");
+      KJ_ASSERT(protocol.getNames()[1] == "bar");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("Compiling the empty pattern failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - compile with :foo(http) protocol") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+    .protocol = kj::str(":foo(http)"),
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      auto& protocol = pattern.getProtocol();
+      KJ_ASSERT(protocol.getPattern() == ":foo(http)");
+      KJ_ASSERT(protocol.getRegex() == "^(http)$");
+      KJ_ASSERT(protocol.getNames().size() == 1);
+      KJ_ASSERT(protocol.getNames()[0] == "foo");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("Compiling the empty pattern failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - compile with :foo(http{s}?) protocol") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile(UrlPattern::Init {
+    .protocol = kj::str(":foo(http[s]?)"),
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      auto& protocol = pattern.getProtocol();
+      KJ_ASSERT(protocol.getPattern() == ":foo(http[s]?)");
+      KJ_ASSERT(protocol.getRegex() == "^(http[s]?)$");
+      KJ_ASSERT(protocol.getNames().size() == 1);
+      KJ_ASSERT(protocol.getNames()[0] == "foo");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("Compiling the empty pattern failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - compile from empty string") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("")) {
+    KJ_CASE_ONEOF(init, UrlPattern) {
+      KJ_FAIL_ASSERT("URL pattern compile should have failed");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_ASSERT(err == "Syntax error in URL Pattern: a relative pattern must have a base URL.");
+    }
+  }
+}
+
+KJ_TEST("URLPattern - compile from empty string with base") {
+  static constexpr auto BASEURL = "http://example.com"_kjc;
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("", UrlPattern::CompileOptions {
+    .baseUrl = BASEURL,
+  })) {
+    KJ_CASE_ONEOF(init, UrlPattern) {
+      // ok!
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("Parsing from empty string with a base URL failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - compile from http{s}?: string") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("http{s}?:")) {
+    KJ_CASE_ONEOF(init, UrlPattern) {
+      KJ_ASSERT(init.getProtocol().getPattern() == "http{s}?");
+      KJ_ASSERT(init.getProtocol().getRegex() == "^http(?:s)?$");
+      KJ_ASSERT(init.getProtocol().getNames().size() == 0);
+      KJ_ASSERT(init.getUsername().getPattern() == "");
+      KJ_ASSERT(init.getUsername().getRegex() == "^$");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("Failed to parse empty string", err);
+    }
+  }
+}
+
+bool testPattern(kj::StringPtr regex,
+                 kj::ArrayPtr<const char> input,
+                 kj::ArrayPtr<kj::String> groups = nullptr) {
+  std::regex rx(regex.begin(), regex.size());
+  std::cmatch match;
+  bool result = std::regex_match(input.begin(), input.end(), match, rx);
+  if (result && groups != nullptr) {
+    KJ_ASSERT(match.size() == (groups.size() + 1));
+    for (int n = 1; n < match.size(); n++) {
+      KJ_ASSERT(groups[n-1] == match[n].str().c_str());
+    }
+  }
+  return result;
+}
+
+KJ_TEST("URLPattern - MDN example 1 - pathname: '/books'") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .pathname = kj::str("/books")
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      auto url = KJ_ASSERT_NONNULL(Url::tryParse("https://example.com/books"_kj));
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), url.getProtocol()));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), url.getHostname()));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), url.getPathname()));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 2 - pathname: '/books/:id'") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .pathname = kj::str("/books/:id")
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      auto url = KJ_ASSERT_NONNULL(Url::tryParse("https://example.com/books/123"_kj));
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), url.getProtocol()));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), url.getHostname()));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), url.getPathname(),
+                            kj::arr(kj::str("123"))));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 3 - pathname: '/books/:id(\\d+)' with base") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/books/:id(\\d+)"_kj, UrlPattern::CompileOptions {
+    .baseUrl = "https://example.com"_kj
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      auto url = KJ_ASSERT_NONNULL(Url::tryParse("https://example.com/books/123"_kj));
+      auto protocol = url.getProtocol();
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(),
+                            protocol.slice(0, protocol.size() - 1)));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), url.getHostname()));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), url.getPathname(),
+                            kj::arr(kj::str("123"))));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books/abc"_kj));
+      KJ_ASSERT(pattern.getPathname().getNames().size() == 1);
+      KJ_ASSERT(pattern.getPathname().getNames()[0] == "id");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 4 - pathame: '/:type(foo|bar)'") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .pathname = kj::str("/:type(foo|bar)")
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/foo"_kj, kj::arr(kj::str("foo"))));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/bar"_kj, kj::arr(kj::str("bar"))));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/baz"_kj));
+      KJ_ASSERT(pattern.getPathname().getNames().size() == 1);
+      KJ_ASSERT(pattern.getPathname().getNames()[0] == "type");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 5 - '/books/:id(\\d+) with base") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/books/:id(\\d+)"_kj, UrlPattern::CompileOptions {
+    .baseUrl = "https://example.com"_kj
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123"_kj,
+                            kj::arr(kj::str("123"))));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books/abc"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 6 - '/books/(\\d+)' with base") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/books/(\\d+)"_kj, UrlPattern::CompileOptions {
+    .baseUrl = "https://example.com"_kj
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123"_kj,
+                            kj::arr(kj::str("123"))));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books/abc"_kj));
+      KJ_ASSERT(pattern.getPathname().getNames()[0] == "0");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 7 - '/books/:id?' with base") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/books/:id?", UrlPattern::CompileOptions {
+    .baseUrl = "https://example.com"_kj
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), "https"_kj));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "example.com"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books/"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books/123/456"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books/123/456/789"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 8 - '/books/:id+' with base") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/books/:id+", UrlPattern::CompileOptions {
+    .baseUrl = "https://example.com"_kj
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), "https"_kj));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "example.com"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books/"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123/456"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123/456/789"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 9 - '/books/:id*' with base") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/books/:id*", UrlPattern::CompileOptions {
+    .baseUrl = "https://example.com"_kj
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), "https"_kj));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "example.com"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books/"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123/456"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123/456/789"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 10 - '/book{s}?' with base") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/book{s}?", UrlPattern::CompileOptions {
+    .baseUrl = "https://example.com"_kj
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), "https"_kj));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "example.com"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/book"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books/"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 11 - '/book{s}' with base") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/book{s}", UrlPattern::CompileOptions {
+    .baseUrl = "https://example.com"_kj
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), "https"_kj));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "example.com"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/book"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books/"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 12 - '/blog/:id(\\d+){-:title}?'") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .pathname = kj::str("/blog/:id(\\d+){-:title}?")
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), "https"_kj));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "example.com"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/blog/123-my-blog"_kj),
+                kj::arr(kj::str("123"), kj::str("my-blog")));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/blog/123"_kj),
+                kj::arr(kj::str("123"), kj::str()));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/blog/my-blog"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 13 - '/books/:id?' with base") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/books/:id?"_kj, UrlPattern::CompileOptions {
+    .baseUrl = "https://example.com"_kj
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), "https"_kj));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "example.com"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123"_kj),
+                kj::arr(kj::str("123")));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books"_kj), kj::arr(kj::str()));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books/"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 14 - '/books/:id+' with base") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/books/:id+"_kj, UrlPattern::CompileOptions {
+    .baseUrl = "https://example.com/abc"_kj
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), "https"_kj));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "example.com"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123"_kj,
+                kj::arr(kj::str("123"))));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123/456"_kj,
+                kj::arr(kj::str("123/456"))));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 15 - { hash: '/books/:id?' }") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({ .hash = kj::str("/books/:id?") })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), "https"_kj));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "example.com"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/"_kj));
+      KJ_ASSERT(testPattern(pattern.getHash().getRegex(), "/books/123"_kj));
+      KJ_ASSERT(testPattern(pattern.getHash().getRegex(), "/books/"_kj));
+      KJ_ASSERT(!testPattern(pattern.getHash().getRegex(), "/books"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 16 - { pathname: '/books/{:id}?' }") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({ .pathname = kj::str("/books/{:id}?") })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 17 - '/books/*' with base") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/books/*"_kj, UrlPattern::CompileOptions {
+    .baseUrl = "https://example.com"_kj
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/books"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/books/123/456"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 18 - '/books/*' with base") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("/*.png"_kj, UrlPattern::CompileOptions {
+    .baseUrl = "https://example.com"_kj
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/image.png"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/folder/image.png"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/.png"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/image.png/123"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 19 - hostname '{*.}?example.com'") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .hostname = kj::str("{*.}?example.com")
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "example.com"_kj,
+                            kj::arr(kj::str(""))));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "www.example.com"_kj,
+                            kj::arr(kj::str("www"))));
+      KJ_ASSERT(!testPattern(pattern.getHostname().getRegex(), "example.org"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 20") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("https://cdn-*.example.com/*.jpg"_kj)) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), "https"_kj));
+      KJ_ASSERT(!testPattern(pattern.getProtocol().getRegex(), "http"_kj));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "cdn-1234.example.com"_kj));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "cdn-foo.bar.example.com"_kj));
+      KJ_ASSERT(!testPattern(pattern.getHostname().getRegex(), "cdn.example.com"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/image.jpg"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/stuff/image.jpg"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/stuff/image.gif"_kj));
+      KJ_ASSERT(pattern.getProtocol().getPattern() == "https");
+      KJ_ASSERT(pattern.getHostname().getPattern() == "cdn-*.example.com");
+      KJ_ASSERT(pattern.getPathname().getPattern() == "/*.jpg");
+      KJ_ASSERT(pattern.getSearch().getPattern() == "");
+      KJ_ASSERT(pattern.getHash().getPattern() == "");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 21") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("data:foo*"_kj)) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_FAIL_ASSERT("URL Pattern compile should have failed");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_ASSERT(err == "Syntax error in URL Pattern: a relative pattern must have a base URL.");
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 22") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .hostname = kj::str("example.com"),
+    .pathname = kj::str("/foo/*"),
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/foo"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/foo/"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/foo/bar"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 23") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .pathname = kj::str("/foo/*"),
+    .baseUrl = kj::str("https://example.com")
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), "https"_kj));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "example.com"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/foo"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/foo/"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/foo/bar"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 24") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .hostname = kj::str("*.example.com")
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(!testPattern(pattern.getHostname().getRegex(), "example.com"_kj));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "www.example.com"_kj),
+                kj::arr(kj::str("www")));
+      KJ_ASSERT(pattern.getHostname().getNames()[0] == "0");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 25") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .pathname = kj::str("/:product/:user/:action")
+ })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/store/wanderview/view"_kj),
+                kj::arr(kj::str("store"), kj::str("wanderview"), kj::str("view")));
+      KJ_ASSERT(pattern.getPathname().getNames().size() == 3);
+      KJ_ASSERT(pattern.getPathname().getNames()[0] == "product");
+      KJ_ASSERT(pattern.getPathname().getNames()[1] == "user");
+      KJ_ASSERT(pattern.getPathname().getNames()[2] == "action");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 26") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .pathname = kj::str("/:product/:action+")
+ })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product/do/something/cool"_kj),
+                kj::arr(kj::str("product"), kj::str("do/something/cool")));
+      KJ_ASSERT(pattern.getPathname().getNames().size() == 2);
+      KJ_ASSERT(pattern.getPathname().getNames()[0] == "product");
+      KJ_ASSERT(pattern.getPathname().getNames()[1] == "action");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 27") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .pathname = kj::str("/:product/:action*")
+ })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product/do/something/cool"_kj),
+                kj::arr(kj::str("product"), kj::str("do/something/cool")));
+      KJ_ASSERT(pattern.getPathname().getNames().size() == 2);
+      KJ_ASSERT(pattern.getPathname().getNames()[0] == "product");
+      KJ_ASSERT(pattern.getPathname().getNames()[1] == "action");
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product"_kj),
+                kj::arr(kj::str("product"), kj::str("")));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/product/"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 28") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .hostname = kj::str("{:subdomain.}*example.com")
+ })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(pattern.getHostname().getNames().size() == 1);
+      KJ_ASSERT(pattern.getHostname().getNames()[0] == "subdomain");
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "example.com"_kj,
+                kj::arr(kj::str(""))));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "foo.bar.example.com"_kj,
+                kj::arr(kj::str("foo.bar"))));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 29") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .pathname = kj::str("/product{/}?")
+ })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product/"_kj));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/product/abc"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 32") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+      .protocol = kj::str("http{s}?"),
+      .username = kj::str(":user?"),
+      .password = kj::str(":pass?"),
+      .hostname = kj::str("{:subdomain.}*example.com"),
+      .pathname = kj::str("/product/:action*"),
+ })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(!testPattern(pattern.getProtocol().getRegex(), "ftp"_kj));
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), "http"_kj));
+      KJ_ASSERT(testPattern(pattern.getProtocol().getRegex(), "https"_kj));
+
+      KJ_ASSERT(testPattern(pattern.getUsername().getRegex(), "foo"_kj, kj::arr(kj::str("foo"))));
+      KJ_ASSERT(testPattern(pattern.getPassword().getRegex(), "bar"_kj, kj::arr(kj::str("bar"))));
+
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "example.com"_kj,
+                            kj::arr(kj::str(""))));
+      KJ_ASSERT(testPattern(pattern.getHostname().getRegex(), "www.example.com"_kj,
+                            kj::arr(kj::str("www"))));
+
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product/bar"_kj,
+                            kj::arr(kj::str("bar"))));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product"_kj,
+                            kj::arr(kj::str())));
+
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 33") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile("data\\:foo*"_kj)) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(pattern.getProtocol().getPattern() == "data");
+      KJ_ASSERT(pattern.getProtocol().getRegex() == "^data$");
+      KJ_ASSERT(pattern.getPathname().getPattern() == "foo*");
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "foobar"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 34") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .pathname = kj::str("/(foo|bar)")
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/foo"_kj, kj::arr(kj::str("foo"))));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/bar"_kj, kj::arr(kj::str("bar"))));
+      KJ_ASSERT(!testPattern(pattern.getPathname().getRegex(), "/baz"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 35a") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .pathname = kj::str("/product/(index.html)?")
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product/index.html"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 35b") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .pathname = kj::str("/product/:action?")
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product/view"_kj,
+                            kj::arr(kj::str("view"))));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product"_kj,
+                            kj::arr(kj::str())));
+      KJ_ASSERT(pattern.getPathname().getNames()[0] == "action");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - MDN example 35c") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+    .pathname = kj::str("/product/*?")
+  })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product/wanderview/view"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product/"_kj));
+      KJ_ASSERT(testPattern(pattern.getPathname().getRegex(), "/product"_kj));
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+}
+
+KJ_TEST("URLPattern - fun") {
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile(":café://:ሴ/:_✔️"_kj)) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_ASSERT(pattern.getProtocol().getPattern() == ":café"_kj);
+      KJ_ASSERT(pattern.getHostname().getPattern() == ":ሴ"_kj);
+      KJ_ASSERT(pattern.getPathname().getPattern() == "/:_%E2%9C%94%EF%B8%8F");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      KJ_FAIL_ASSERT("URL Pattern compile failed", err);
+    }
+  }
+
+  KJ_SWITCH_ONEOF(UrlPattern::tryCompile({ .hash = kj::str("=((") })) {
+    KJ_CASE_ONEOF(pattern, UrlPattern) {
+      KJ_FAIL_ASSERT("Parsing should have failed");
+    }
+    KJ_CASE_ONEOF(err, kj::String) {
+      // ok! This is what we would expect. The exact error is not important here,
+      // we just want to make sure this does not crash.
+    }
+  }
+}
+
+KJ_TEST("URLPattern - simple fuzzing") {
+  for (int n = 1; n < 100; n++) {
+    kj::Array<kj::byte> bufs = kj::heapArray<kj::byte>(9 * n);
+    RAND_bytes(bufs.begin(), 9 * n);
+    // We don't care if the compiling passes or fails, we just don't want crashes.
+    KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
+      .protocol = kj::str(bufs.slice(0, n )),
+      .username = kj::str(bufs.slice(n, n * 2)),
+      .password = kj::str(bufs.slice(n * 2, n * 3)),
+      .hostname = kj::str(bufs.slice(n * 3, n * 4)),
+      .port = kj::str(bufs.slice(n * 4, n * 5)),
+      .pathname = kj::str(bufs.slice(n * 5, n * 6)),
+      .search = kj::str(bufs.slice(n * 6, n * 7)),
+      .hash = kj::str(bufs.slice(n * 7, n * 8)),
+      .baseUrl = kj::str(bufs.slice(n * 8, n * 9))
+    })) {
+      KJ_CASE_ONEOF(str, kj::String) {}
+      KJ_CASE_ONEOF(pattern, UrlPattern) {}
+    }
+
+    auto input = kj::str(bufs);
+    KJ_SWITCH_ONEOF(UrlPattern::tryCompile(input.asPtr())) {
+      KJ_CASE_ONEOF(str, kj::String) {}
+      KJ_CASE_ONEOF(pattern, UrlPattern) {}
+    }
+
+    KJ_SWITCH_ONEOF(UrlPattern::tryCompile(input.asPtr(), UrlPattern::CompileOptions {
+      .baseUrl = input.asPtr()
+    })) {
+      KJ_CASE_ONEOF(str, kj::String) {}
+      KJ_CASE_ONEOF(pattern, UrlPattern) {}
+    }
+  }
+}
+
+// The following aren't a full test of the URL pattern... they test only whether
+// an input pattern compiles or fails to compile as expected. A complete test of
+// each of the patterns would require also running the match tests using the
+// generated regexp
+
+KJ_TEST("URLPattern - WPT compile failed") {
+#include "url-pattern-test-corpus-failures.h"
+}
+
+KJ_TEST("URLPattern - WPT compile success") {
+#include "url-pattern-test-corpus-success.h"
+}
+
 }  // namespace
 }  // namespace workerd::jsg::test
+

--- a/src/workerd/jsg/url.c++
+++ b/src/workerd/jsg/url.c++
@@ -1,4 +1,5 @@
 #include "url.h"
+#include "exception.h"
 #include <kj/hash.h>
 
 extern "C" {
@@ -6,7 +7,13 @@ extern "C" {
 }
 
 #include <kj/debug.h>
+#include <kj/string-tree.h>
 #include <kj/vector.h>
+#include <unicode/utf8.h>
+#include <unicode/uchar.h>
+#include <algorithm>
+#include <map>
+#include <regex>
 
 namespace workerd::jsg {
 
@@ -393,5 +400,1845 @@ kj::Maybe<UrlSearchParams::EntryIterator::Entry> UrlSearchParams::EntryIterator:
     .value = kj::ArrayPtr<const char>(next.value.data, next.value.length),
   };
 }
+
+// ======================================================================================
+// UrlPattern
+
+namespace {
+
+constexpr auto MODIFIER_OPTIONAL = "?"_kjc;
+constexpr auto MODIFIER_ZERO_OR_MORE = "*"_kjc;
+constexpr auto MODIFIER_ONE_OR_MORE = "+"_kjc;
+
+inline bool isAsciiDigit(char c) { return c >= '0' && c <= '9'; };
+
+inline bool isHexDigit(char c) {
+  // Check if `c` is the ASCII code of a hexadecimal digit.
+  return isAsciiDigit(c) || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F');
+}
+
+inline bool isAscii(char codepoint) { return codepoint >= 0x00 && codepoint <= 0x7f; };
+
+inline bool isForbiddenHostCodepoint(char c) {
+  return c == 0x00 || c == 0x09 /* Tab */ || c == 0x0a /* LF */ || c == 0x0d /* CR */ ||
+         c == ' ' || c == '#' || c == '%' || c == '/' || c == ':' ||
+         c == '<' || c == '>' || c == '?' || c == '@' || c == '[' || c == '\\' || c == ']' ||
+         c == '^' || c == '|';
+};
+
+// This is not meant to be a comprehensive validation that the hostname is
+// a proper IPv6 address. It's a quick check defined by the URLPattern spec.
+inline bool isIpv6(kj::ArrayPtr<const char> hostname) {
+  if (hostname.size() < 2) return false;
+  auto c1 = hostname[0];
+  auto c2 = hostname[1];
+  return (c1 == '[' || ((c1 == '{' || c1 == '\\') && c2 == '['));
+}
+
+// This additional check deals with a known bug in the URLPattern spec. The URL parser will
+// allow (and generally ignore) invalid characters in the hostname when running with the
+// HOST state override. The URLPattern spec, however, assumes that it doesn't.
+inline bool isValidHostnameInput(kj::StringPtr input) {
+  return isIpv6(input) || std::none_of(input.begin(), input.end(), isForbiddenHostCodepoint);
+}
+
+inline bool isValidCodepoint(uint32_t codepoint, bool first) {
+  // https://tc39.es/ecma262/#prod-IdentifierStart
+  if (first) {
+    return codepoint == '$' ||
+           codepoint == '_' ||
+           u_hasBinaryProperty(codepoint, UCHAR_ID_START);
+  }
+  return codepoint == '$' ||
+         codepoint == 0x200C || // Zero-width non-joiner
+         codepoint == 0x200D || // Zero-width joiner
+         u_hasBinaryProperty(codepoint, UCHAR_ID_CONTINUE);
+};
+
+inline kj::Maybe<kj::String> strFromMaybePtr(const kj::Maybe<kj::StringPtr>& ptr) {
+  return ptr.map([](const kj::StringPtr& ptr) { return kj::str(ptr); });
+}
+
+using Canonicalizer = kj::Maybe<kj::String>(kj::StringPtr, kj::Maybe<kj::StringPtr>);
+
+kj::Maybe<kj::String> canonicalizeProtocol(kj::StringPtr protocol,
+                                           kj::Maybe<kj::StringPtr> = kj::none) {
+  // @see https://wicg.github.io/urlpattern/#canonicalize-a-protocol
+  if (protocol.size() == 0) return kj::str();
+  auto input = kj::str(protocol, "://dummy.test");
+  KJ_IF_SOME(url, Url::tryParse(input.asPtr())) {
+    auto result = url.getProtocol();
+    return kj::str(result.slice(0, result.size() - 1));
+  }
+  return kj::none;
+}
+
+kj::Maybe<kj::String> canonicalizeUsername(kj::StringPtr username,
+                                           kj::Maybe<kj::StringPtr> = kj::none) {
+  // @see https://wicg.github.io/urlpattern/#canonicalize-a-username
+  if (username.size() == 0) return kj::str();
+  auto url = KJ_ASSERT_NONNULL(Url::tryParse("fake://dummy.test"_kj));
+  if (!url.setUsername(username)) return kj::none;
+  return kj::str(url.getUsername());
+}
+
+kj::Maybe<kj::String> canonicalizePassword(kj::StringPtr password,
+                                           kj::Maybe<kj::StringPtr> = kj::none) {
+  // @see https://wicg.github.io/urlpattern/#canonicalize-a-password
+  if (password.size() == 0) return kj::str();
+  auto url = KJ_ASSERT_NONNULL(Url::tryParse("fake://dummy.test"_kj));
+  if (!url.setPassword(password)) return kj::none;
+  return kj::str(url.getPassword());
+}
+
+kj::Maybe<kj::String> canonicalizeHostname(kj::StringPtr hostname,
+                                           kj::Maybe<kj::StringPtr> = kj::none) {
+  // @see https://wicg.github.io/urlpattern/#canonicalize-a-hostname
+  if (hostname.size() == 0) return kj::str();
+  auto url = KJ_ASSERT_NONNULL(Url::tryParse("fake://dummy.test"_kj));
+  if (!isValidHostnameInput(hostname)) return kj::none;
+  if (!url.setHostname(hostname)) return kj::none;
+  return kj::str(url.getHostname());
+}
+
+kj::Maybe<kj::String> canonicalizeIpv6Hostname(kj::StringPtr hostname,
+                                               kj::Maybe<kj::StringPtr> = kj::none) {
+  // @see https://wicg.github.io/urlpattern/#canonicalize-an-ipv6-hostname
+  if (!std::all_of(hostname.begin(), hostname.end(), [](char c) {
+    return isHexDigit(c) || c == '[' || c == ']' || c == ':';
+  })) {
+    return kj::none;
+  }
+  return kj::str(hostname);
+}
+
+kj::Maybe<kj::String> canonicalizePort(kj::StringPtr port, kj::Maybe<kj::StringPtr> protocol) {
+  // @see https://wicg.github.io/urlpattern/#canonicalize-a-port
+  if (port.size() == 0) return kj::str();
+  auto input = kj::str(protocol.orDefault("fake"_kj), "://dummy.test");
+  KJ_IF_SOME(url, Url::tryParse(input.asPtr())) {
+    if (!url.setPort(kj::Maybe(port))) return kj::none;
+    return kj::str(url.getPort());
+  }
+  return kj::none;
+}
+
+kj::Maybe<kj::String> canonicalizePathname(kj::StringPtr pathname,
+                                           kj::Maybe<kj::StringPtr> = kj::none) {
+  // @see https://wicg.github.io/urlpattern/#canonicalize-a-pathname
+  if (pathname.size() == 0) return kj::str();
+  bool leadingSlash = pathname[0] == '/';
+  auto input = kj::str("fake://fake-url", leadingSlash ? "" : "/-", pathname);
+  KJ_IF_SOME(url, Url::tryParse(input.asPtr())) {
+    auto result = url.getPathname();
+    return leadingSlash ? kj::str(result) : kj::str(result.slice(2));
+  }
+  return kj::none;
+}
+
+kj::Maybe<kj::String> canonicalizeOpaquePathname(kj::StringPtr pathname,
+                                                 kj::Maybe<kj::StringPtr> = kj::none) {
+  // @see https://wicg.github.io/urlpattern/#canonicalize-an-opaque-pathname
+  if (pathname.size() == 0) return kj::str();
+  auto str = kj::str("fake:", pathname);
+  auto url = KJ_ASSERT_NONNULL(Url::tryParse(str.asPtr()));
+  return kj::str(url.getPathname());
+}
+
+kj::Maybe<kj::String> canonicalizeSearch(kj::StringPtr search,
+                                         kj::Maybe<kj::StringPtr> = kj::none) {
+  // @see https://wicg.github.io/urlpattern/#canonicalize-a-search
+  if (search.size() == 0) return kj::str();
+  auto url = KJ_ASSERT_NONNULL(Url::tryParse("fake://dummy.test"_kj));
+  url.setSearch(kj::Maybe(search));
+  return url.getSearch().size() > 0 ? kj::str(url.getSearch().slice(1)) : kj::str();
+}
+
+kj::Maybe<kj::String> canonicalizeHash(kj::StringPtr hash,
+                                       kj::Maybe<kj::StringPtr> = kj::none) {
+  // @see https://wicg.github.io/urlpattern/#canonicalize-a-hash
+  if (hash.size() == 0) return kj::str();
+  auto url = KJ_ASSERT_NONNULL(Url::tryParse("fake://dummy.test"_kj));
+  url.setHash(kj::Maybe(hash));
+  return url.getHash().size() > 0 ? kj::str(url.getHash().slice(1)) : kj::str();
+}
+
+kj::Maybe<kj::String> chooseStr(kj::Maybe<kj::String> str, kj::Maybe<kj::StringPtr> other) {
+  KJ_IF_SOME(s, str) {
+    return kj::mv(s);
+  } else {
+    return strFromMaybePtr(other);
+  }
+}
+
+kj::String stripSuffixFromProtocol(kj::ArrayPtr<const char> data) {
+  if (data.back() == ':') {
+    return kj::str(data.slice(0, data.size() - 1));
+  }
+  return kj::str(data);
+}
+
+kj::String escape(kj::ArrayPtr<const char> str, auto predicate) {
+  // Best case we don't have to escape anything so size remains the same,
+  // but let's pad a little just in case.
+  kj::Vector<char> result(str.size() + 10);
+  auto it = str.begin();
+  while (it != str.end()) {
+    auto c = *it;
+    if (predicate(c)) result.add('\\');
+    result.add(c);
+    ++it;
+  }
+  result.add('\0');
+  return kj::String(result.releaseAsArray());
+}
+
+kj::String escapeRegexString(kj::ArrayPtr<const char> str) {
+  return escape(str, [](auto c) {
+    return c == '.' || c == '+' || c == '*' || c == '?' || c == '^' ||
+           c == '$' || c == '{' || c == '}' || c == '(' || c == ')' ||
+           c == '[' || c == ']' || c == '|' || c == '/' || c == '\\';
+  });
+}
+
+kj::String escapePatternString(kj::ArrayPtr<const char> str) {
+  return escape(str, [](auto c) {
+    return c == '+' || c == '*' || c == '?' || c == ':' ||
+        c == '{' || c == '}' || c == '(' || c == ')' ||
+        c == '\\';
+  });
+}
+
+struct CompileComponentOptions {
+  kj::Maybe<char> delimiter;
+  kj::Maybe<char> prefix;
+  kj::String segmentWildcardRegexp;
+
+  kj::String initSegmentWildcardRegexp() {
+    KJ_IF_SOME(c, delimiter) {
+      return kj::str("[^\\", c, "]+");
+    } else {
+      return kj::str("[^]+");
+    }
+  }
+
+  CompileComponentOptions(kj::Maybe<char> delimiter, kj::Maybe<char> prefix)
+      : delimiter(delimiter),
+        prefix(prefix),
+        segmentWildcardRegexp(initSegmentWildcardRegexp()) {}
+
+  static const CompileComponentOptions DEFAULT;
+  static const CompileComponentOptions HOSTNAME;
+  static const CompileComponentOptions PATHNAME;
+};
+const CompileComponentOptions CompileComponentOptions::DEFAULT(kj::none, kj::none);
+const CompileComponentOptions CompileComponentOptions::HOSTNAME('.', kj::none);
+const CompileComponentOptions CompileComponentOptions::PATHNAME('/', '/');
+
+// An individual piece of a URLPattern string. Used while parsing a URLPattern
+// string for the URLPattern constructor, test, or exec call.
+struct Part {
+  enum class Type {
+    FIXED_TEXT,
+    REGEXP,
+    SEGMENT_WILDCARD,
+    FULL_WILDCARD,
+  };
+
+  enum class Modifier {
+    NONE,
+    OPTIONAL,      // ?
+    ZERO_OR_MORE,  // *
+    ONE_OR_MORE,   // +
+  };
+
+  Type type;
+  Modifier modifier;
+  kj::String value;
+  kj::String name;
+  kj::Maybe<kj::String> prefix;
+  kj::Maybe<kj::String> suffix;
+};
+
+kj::Maybe<kj::StringPtr> modifierToString(const Part::Modifier& modifier) {
+  switch (modifier) {
+    case Part::Modifier::NONE: return kj::none;
+    case Part::Modifier::OPTIONAL: return MODIFIER_OPTIONAL;
+    case Part::Modifier::ZERO_OR_MORE: return MODIFIER_ZERO_OR_MORE;
+    case Part::Modifier::ONE_OR_MORE: return MODIFIER_ONE_OR_MORE;
+  }
+  KJ_UNREACHABLE;
+}
+
+// String inputs passed into URLPattern constructor are parsed by first
+// interpreting them into a list of Tokens. Each token has a type, a
+// position index in the input string, and a value. The value is either
+// a individual codepoint or a substring of input. Once the tokens are
+// determined, the parsing algorithms convert those into a Part list.
+// The part list is then used to generate the internal JavaScript RegExps
+// that are used for the actual matching operation.
+struct Token {
+  // Per the URLPattern spec, the tokenizer runs in one of two modes:
+  // Strict and Lenient. In Strict mode, invalid characters and sequences
+  // detected by the tokenizer will cause a TypeError to be thrown.
+  // In lenient mode, the invalid codepoints and sequences are marked
+  // but no error is thrown. When parsing a string passed to the
+  // URLPattern constructor, lenient mode is used. When parsing the
+  // pattern string for an individual component, strict mode is used.
+  enum class Policy {
+    STRICT,
+    LENIENT,
+  };
+
+  enum class Type {
+    INVALID_CHAR,    // 0
+    OPEN,            // 1
+    CLOSE,           // 2
+    REGEXP,          // 3
+    NAME,            // 4
+    CHAR,            // 5
+    ESCAPED_CHAR,    // 6
+    OTHER_MODIFIER,  // 7
+    ASTERISK,        // 8
+    END,             // 9
+  };
+
+  Type type = Type::INVALID_CHAR;
+  size_t index = 0;
+  kj::OneOf<char, kj::ArrayPtr<const char>> value = (char)0;
+  Part::Modifier modifier = Part::Modifier::NONE;
+
+  operator kj::String() const {
+    KJ_SWITCH_ONEOF(value) {
+      KJ_CASE_ONEOF(codepoint, char) {
+        return kj::str(codepoint);
+      }
+      KJ_CASE_ONEOF(ptr, kj::ArrayPtr<const char>) {
+        return kj::str(ptr);
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  bool operator==(const kj::String& other) const {
+    KJ_SWITCH_ONEOF(value) {
+      KJ_CASE_ONEOF(codepoint, char) {
+        return false;
+      }
+      KJ_CASE_ONEOF(string, kj::ArrayPtr<const char>) {
+        return other == string;
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  bool operator==(char other) {
+    KJ_SWITCH_ONEOF(value) {
+      KJ_CASE_ONEOF(codepoint, char) {
+        return codepoint == other;
+      }
+      KJ_CASE_ONEOF(string, kj::ArrayPtr<const char>) {
+        return false;
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  static Token asterisk(size_t index) {
+    return {
+      .type = Type::ASTERISK,
+      .index = index,
+      .value = '*',
+      .modifier = Part::Modifier::ZERO_OR_MORE,
+    };
+  }
+
+  static Token char_(size_t index, char codepoint) {
+    return {
+      .type = Type::CHAR,
+      .index = index,
+      .value = codepoint,
+    };
+  }
+
+  static Token close(size_t index) {
+    return {
+      .type = Type::CLOSE,
+      .index = index,
+    };
+  }
+
+  static Token end(size_t index) {
+    return {
+      .type = Type::END,
+      .index = index,
+    };
+  }
+
+  static Token escapedChar(size_t index, char codepoint) {
+    return {
+      .type = Type::ESCAPED_CHAR,
+      .index = index,
+      .value = codepoint,
+    };
+  }
+
+  static Token invalidChar(size_t index, char codepoint) {
+    return {
+      .index = index,
+      .value = codepoint,
+    };
+  }
+
+  static Token invalidSegment(size_t index, kj::ArrayPtr<const char> segment) {
+    return {
+      .type = Type::INVALID_CHAR,
+      .index = index,
+      .value = segment,
+    };
+  }
+
+  static Token name(size_t index, kj::ArrayPtr<const char> name) {
+    return {
+      .type = Type::NAME,
+      .index = index,
+      .value = name,
+    };
+  }
+
+  static Token open(size_t index) {
+    return {
+      .type = Type::OPEN,
+      .index = index,
+    };
+  }
+
+  static Token otherModifier(size_t index, char codepoint) {
+    KJ_DASSERT(codepoint == '?' || codepoint == '+');
+    return {
+      .type = Type::OTHER_MODIFIER,
+      .index = index,
+      .value = codepoint,
+      .modifier = codepoint == '?' ? Part::Modifier::OPTIONAL : Part::Modifier::ONE_OR_MORE,
+    };
+  }
+
+  static Token regex(size_t index, kj::ArrayPtr<const char> regex) {
+    return {
+      .type = Type::REGEXP,
+      .index = index,
+      .value = regex,
+    };
+  }
+};
+
+struct RegexAndNameList {
+  kj::String regex;
+  kj::Array<kj::String> names;
+};
+
+UrlPattern::Result<kj::Array<Token>> tokenize(kj::StringPtr input, Token::Policy policy) {
+  auto it = input.begin();
+  size_t pos = 0;
+  kj::Vector<Token> tokenList(input.size() + 1);
+  // Scan the input and advance both it and pos until the given predicate return false.
+  const auto scanCodepoints = [&](auto predicate) {
+    bool first = true;
+    while (it != input.end()) {
+      uint32_t codepoint;
+      size_t starting = pos;
+      // Reads to the next codepoint boundary, incrementing pos accordingly.
+      // We use U8_NEXT_OR_FFFD here because the input is a raw sequence of
+      // UTF8 bytes but the predicate needs to check the decoded codepoint
+      // rather than looking at individual bytes. The macro will advance pos
+      // at is scans.
+      U8_NEXT_OR_FFFD(input.begin(), pos, input.size(), codepoint);
+      KJ_DASSERT(pos <= input.size());
+      // If our read codepoint does not match the predicate, we do not want to
+      // advance and we stop scanning.
+      if (!predicate(codepoint, first)) {
+        pos = starting;
+        break;
+      }
+      it += pos - starting;
+      first = false;
+    }
+  };
+
+  while (it != input.end()) {
+    auto c = *it;
+    switch (c) {
+      case '*': {
+        tokenList.add(Token::asterisk(pos++));
+        break;
+      }
+      case '?': {
+        KJ_FALLTHROUGH;
+      }
+      case '+': {
+        tokenList.add(Token::otherModifier(pos++, c));
+        break;
+      }
+      case '\\': {
+        ++it;
+        // The escape character is invalid if it comes at the end!
+        if (it == input.end()) {
+          if (policy == Token::Policy::STRICT) {
+            return kj::str("Syntax error in URL Pattern: invalid escape character at ", pos);
+          }
+          tokenList.add(Token::invalidChar(pos++, c));
+        } else {
+          tokenList.add(Token::escapedChar(pos, *it));
+          pos += 2;
+        }
+        break;
+      }
+      case '{': {
+        tokenList.add(Token::open(pos++));
+        break;
+      }
+      case '}': {
+        tokenList.add(Token::close(pos++));
+        break;
+      }
+      case ':': {
+        ++it;
+        // The name token is invalid if it comes at the end!
+        if (it == input.end()) {
+          if (policy == Token::Policy::STRICT) {
+            return kj::str("Syntax error in URL Pattern: invalid name start at ", pos);
+          }
+          tokenList.add(Token::invalidChar(pos++, c));
+          break;
+        }
+        auto start = ++pos;
+        scanCodepoints(isValidCodepoint);
+        if (start == pos) {
+          // There was a name token suffix without a valid name! Oh, the inhumanity of it all.
+          if (policy == Token::Policy::STRICT) {
+            return kj::str("Syntax error in URL Pattern: invalid name start at ", pos - 1);
+          }
+          tokenList.add(Token::invalidChar(pos - 1, c));
+        } else {
+          if (it == input.end()) {
+            tokenList.add(Token::name(start - 1, input.slice(start)));
+          } else {
+            tokenList.add(Token::name(start - 1, input.slice(start, pos)));
+          }
+        }
+        // We purposefully do not increment the iterator here because we are
+        // already at the next position.
+
+        continue;
+      }
+      case '(': {
+        ++it;
+        // The group token is invalid if it comes at the end!
+        if (it == input.end()) {
+          if (policy == Token::Policy::STRICT) {
+            return kj::str("Syntax error in URL Pattern: invalid regex start at ", pos);
+          }
+          tokenList.add(Token::invalidChar(pos++, c));
+          break;
+        }
+        size_t depth = 1;
+        size_t start = ++pos;
+        bool error = false;
+        while (it != input.end()) {
+          auto rc = *it;
+          if (!isAscii(rc)) {
+            if (policy == Token::Policy::STRICT) {
+              return kj::str("Syntax error in URL Pattern: invalid regex character at ", pos);
+            }
+            tokenList.add(Token::invalidChar(pos, rc));
+            error = true;
+            break;
+          } else if (pos == start && rc == '?') {
+            if (policy == Token::Policy::STRICT) {
+              return kj::str("Syntax error in URL Pattern: invalid regex character at ", pos);
+            }
+            tokenList.add(Token::invalidChar(pos, rc));
+            error = true;
+            break;
+          } else if (rc == '\\') {
+            it++;
+            // The escape character is invalid if it comes at the end of input
+            if (it == input.end()) {
+              if (policy == Token::Policy::STRICT) {
+                return kj::str(
+                    "Syntax error in URL Pattern: invalid escape character in regex at ", pos);
+              }
+              tokenList.add(Token::invalidChar(pos, rc));
+              error = true;
+              break;
+            }
+            pos++;
+            rc = *it;
+            if (!isAscii(rc)) {
+              if (policy == Token::Policy::STRICT) {
+                return kj::str(
+                    "Syntax error in URL Pattern: invalid escaped character in regex at ", pos);
+              }
+              tokenList.add(Token::invalidChar(pos, rc));
+              error = true;
+              break;
+            }
+            pos++;
+            it++;
+            continue;
+          } else if (rc == ')') {
+            depth--;
+            if (depth == 0) {
+              pos++;
+              it++;
+              break;
+            }
+          } else if (rc == '(') {
+            depth++;
+            it++;
+            // The group open character is invalid if it comes at the end of input
+            if (it == input.end()) {
+              if (policy == Token::Policy::STRICT) {
+                return kj::str("Syntax error in URL Pattern: invalid group in regex at ", pos);
+              }
+              tokenList.add(Token::invalidChar(pos, rc));
+              error = true;
+              break;
+            }
+            pos++;
+            rc = *it;
+            if (rc != '?') {
+              if (policy == Token::Policy::STRICT) {
+                return kj::str("Syntax error in URL Pattern: invalid group in regex at ", pos);
+              }
+              tokenList.add(Token::invalidChar(pos, rc));
+              error = true;
+              break;
+            }
+          }
+          it++;
+          pos++;
+        }
+        if (error) continue;
+        if (depth > 0 || start == pos) {
+          if (policy == Token::Policy::STRICT) {
+            return kj::str("Syntax error in URL Pattern: invalid regex segment at ", start);
+          }
+          tokenList.add(Token::invalidSegment(start, input.slice(start, pos - 1)));
+        } else {
+          tokenList.add(Token::regex(start - 1, input.slice(start, pos - 1)));
+        }
+        // We purposefully do not increment the iterator here because we are
+        // already at the next position.
+        continue;
+      }
+      default: {
+        tokenList.add(Token::char_(pos++, c));
+        break;
+      }
+    }
+    if (it == input.end()) break;
+    ++it;
+  }
+
+  tokenList.add(Token::end(input.size()));
+  return tokenList.releaseAsArray();
+}
+
+UrlPattern::Result<kj::Array<Part>> parsePattern(
+    kj::StringPtr input,
+    Canonicalizer canonicalizer,
+    const CompileComponentOptions& options) {
+  kj::Array<Token> tokens = nullptr;
+  KJ_SWITCH_ONEOF(tokenize(input, Token::Policy::STRICT)) {
+    KJ_CASE_ONEOF(err, kj::String) {
+      return kj::mv(err);
+    }
+    KJ_CASE_ONEOF(list, kj::Array<Token>) {
+      tokens = kj::mv(list);
+    }
+  }
+  // There should be at least one token in the list (the end token)
+  KJ_DASSERT(tokens.size() > 0);
+  kj::Vector<Part> partList(tokens.size());
+  kj::Maybe<kj::StringTree> pendingFixedValue;
+  size_t index = 0;
+  size_t nextNumericName = 0;
+
+  auto segmentWildcardRegex = options.segmentWildcardRegexp.asPtr();
+
+  auto appendToPendingFixedValue = [&](kj::StringPtr value) mutable {
+    KJ_IF_SOME(pending, pendingFixedValue) {
+      pendingFixedValue = kj::strTree(kj::mv(pending), value);
+    } else {
+      pendingFixedValue = kj::strTree(kj::mv(value));
+    }
+  };
+
+  auto maybeAddPartFromPendingFixedValue = [&]() mutable -> bool {
+    KJ_IF_SOME(fixedValue, pendingFixedValue) {
+      auto value = fixedValue.flatten();
+      pendingFixedValue = kj::none;
+      if (value.size() == 0) return true;
+      KJ_IF_SOME(canonical, canonicalizer(value, kj::none)) {
+        partList.add(Part {
+          .type = Part::Type::FIXED_TEXT,
+          .modifier = Part::Modifier::NONE,
+          .value = kj::mv(canonical),
+        });
+        return true;
+      }
+      return false;
+    }
+    return true;
+  };
+
+  auto tryConsumeToken = [&](Token::Type type) -> kj::Maybe<Token&> {
+    KJ_DASSERT(index < tokens.size());
+    auto& next = tokens[index];
+    if (next.type != type) {
+      return kj::none;
+    }
+    index++;
+    return kj::Maybe<Token&>(next);
+  };
+
+  auto tryConsumeRegexOrWildcardToken = [&](kj::Maybe<Token&>& nameToken) {
+    auto token = tryConsumeToken(Token::Type::REGEXP);
+    if (nameToken == kj::none && token == kj::none) {
+      token = tryConsumeToken(Token::Type::ASTERISK);
+    }
+    return token;
+  };
+
+  auto tryConsumeModifierToken = [&]() -> kj::Maybe<Token&> {
+    KJ_IF_SOME(token, tryConsumeToken(Token::Type::OTHER_MODIFIER)) {
+      return kj::Maybe<Token&>(token);
+    }
+    return tryConsumeToken(Token::Type::ASTERISK);
+  };
+
+  auto consumeText = [&]() mutable -> kj::String {
+    kj::StringTree result = kj::strTree();
+    while (true) {
+      KJ_IF_SOME(token, tryConsumeToken(Token::Type::CHAR)) {
+        result = kj::strTree(kj::mv(result), kj::String(token));
+      } else KJ_IF_SOME(token, tryConsumeToken(Token::Type::ESCAPED_CHAR)) {
+        result = kj::strTree(kj::mv(result), kj::String(token));
+      } else {
+        break;
+      }
+    }
+    return result.flatten();
+  };
+
+  auto isDuplicateName = [&](kj::StringPtr name) -> bool {
+    return std::any_of(partList.begin(), partList.end(),
+        [&name](Part& part) { return part.name == name; });
+  };
+
+  auto maybeTokenToModifier = [](kj::Maybe<Token&> modifierToken) -> Part::Modifier {
+    KJ_IF_SOME(token, modifierToken) {
+      KJ_DASSERT(token.type == Token::Type::OTHER_MODIFIER ||
+                 token.type == Token::Type::ASTERISK);
+      return token.modifier;
+    }
+    return Part::Modifier::NONE;
+  };
+
+  auto addPart = [&]
+       (kj::Maybe<kj::String> maybePrefix,
+        kj::Maybe<Token&> nameToken,
+        kj::Maybe<Token&> regexOrWildcardToken,
+        kj::Maybe<kj::String> suffix,
+        kj::Maybe<Token&> modifierToken) mutable -> kj::Maybe<kj::String> {
+    auto modifier = maybeTokenToModifier(modifierToken);
+    if (nameToken == kj::none &&
+        regexOrWildcardToken == kj::none &&
+        modifier == Part::Modifier::NONE) {
+      KJ_IF_SOME(prefix, maybePrefix) {
+        appendToPendingFixedValue(prefix);
+      }
+      return kj::none;
+    }
+    if (!maybeAddPartFromPendingFixedValue()) {
+      return kj::str("Syntax error in URL Pattern");
+    }
+    if (nameToken == kj::none && regexOrWildcardToken == kj::none) {
+      KJ_DASSERT(suffix == kj::none || KJ_ASSERT_NONNULL(suffix).size() == 0);
+      KJ_IF_SOME(prefix, maybePrefix) {
+        if (prefix.size() > 0) {
+          KJ_IF_SOME(canonical, canonicalizer(prefix, kj::none)) {
+            partList.add(Part {
+              .type = Part::Type::FIXED_TEXT,
+              .modifier = modifier,
+              .value = kj::mv(canonical),
+            });
+          } else {
+            return kj::str("Syntax error in URL Pattern");
+          }
+        }
+      }
+      return kj::none;
+    }
+    auto regexValue = kj::str();
+    KJ_IF_SOME(token, regexOrWildcardToken) {
+      if (token.type == Token::Type::ASTERISK) {
+        regexValue = kj::str(".*");
+      } else {
+        regexValue = kj::String(token);
+      }
+    } else {
+      regexValue = kj::str(segmentWildcardRegex);
+    }
+    auto type = Part::Type::REGEXP;
+    if (regexValue == segmentWildcardRegex) {
+      type = Part::Type::SEGMENT_WILDCARD;
+      regexValue = kj::str();
+    } else if (regexValue == ".*") {
+      type = Part::Type::FULL_WILDCARD;
+      regexValue = kj::str();
+    }
+    auto name = kj::str();
+    KJ_IF_SOME(token, nameToken) {
+      name = kj::String(token);
+    } else if (regexOrWildcardToken != kj::none) {
+      name = kj::str(nextNumericName++);
+    }
+
+    if (isDuplicateName(name)) {
+      return kj::str("Syntax error in URL Pattern: Duplicated part names [", name, "]");
+    }
+
+    kj::Maybe<kj::String> encodedPrefix;
+    kj::Maybe<kj::String> encodedSuffix;
+    KJ_IF_SOME(prefix, maybePrefix) {
+      KJ_IF_SOME(canonical, canonicalizer(prefix, kj::none)) {
+        encodedPrefix = kj::mv(canonical);
+      } else {
+        return kj::str("Syntax error in URL Pattern");
+      }
+    }
+    KJ_IF_SOME(s, suffix) {
+      KJ_IF_SOME(canonical, canonicalizer(s, kj::none)) {
+        encodedSuffix = kj::mv(canonical);
+      } else {
+        return kj::str("Syntax error in URL Pattern");
+      }
+    }
+
+    partList.add(Part {
+      .type = type,
+      .modifier = modifier,
+      .value = kj::mv(regexValue),
+      .name = kj::mv(name),
+      .prefix = kj::mv(encodedPrefix),
+      .suffix = kj::mv(encodedSuffix),
+    });
+
+    return kj::none;
+  };
+
+  while (index < tokens.size()) {
+    kj::Maybe<Token&> charToken = tryConsumeToken(Token::Type::CHAR);
+    kj::Maybe<Token&> nameToken = tryConsumeToken(Token::Type::NAME);
+    auto regexOrWildcardToken = tryConsumeRegexOrWildcardToken(nameToken);
+
+    if (nameToken != kj::none || regexOrWildcardToken != kj::none) {
+      auto maybePrefix = charToken.map([](Token& token) {
+        return kj::String(token);
+      });
+
+      KJ_IF_SOME(prefix, maybePrefix) {
+        if (prefix.size() > 0) {
+          KJ_IF_SOME(c, options.prefix) {
+            kj::String s;
+            if (prefix[0] != c) {
+              appendToPendingFixedValue(prefix);
+              maybePrefix = kj::none;
+            }
+          } else {
+            // If prefix is not empty, and is not the prefixCodePoint
+            // (which it can't be if we're here given that there is
+            // no prefix char), when we append prefix to pendingFixedValue,
+            // and clear prefix.
+            appendToPendingFixedValue(prefix);
+            maybePrefix = kj::none;
+          }
+        }
+      }
+      if (!maybeAddPartFromPendingFixedValue()) {
+        return kj::str("Syntax error in URL Pattern");
+      }
+      auto modifierToken = tryConsumeModifierToken();
+      KJ_IF_SOME(err, addPart(kj::mv(maybePrefix), nameToken, regexOrWildcardToken,
+                              kj::none, modifierToken)) {
+        return kj::mv(err);
+      }
+      continue;
+    }
+
+    kj::Maybe<Token&> fixedToken = charToken;
+    if (fixedToken == kj::none) {
+      fixedToken = tryConsumeToken(Token::Type::ESCAPED_CHAR);
+    }
+    KJ_IF_SOME(token, fixedToken) {
+      appendToPendingFixedValue(kj::String(token));
+      continue;
+    }
+    if (tryConsumeToken(Token::Type::OPEN) != kj::none) {
+      auto maybePrefix = consumeText();
+      auto nameToken = tryConsumeToken(Token::Type::NAME);
+      regexOrWildcardToken = tryConsumeRegexOrWildcardToken(nameToken);
+      auto suffix = consumeText();
+      if (tryConsumeToken(Token::Type::CLOSE) == kj::none) {
+        return kj::str("Syntax error in URL Pattern: Missing required close token");
+      }
+      auto modifierToken = tryConsumeModifierToken();
+      KJ_IF_SOME(err, addPart(kj::mv(maybePrefix), nameToken, regexOrWildcardToken,
+                              kj::mv(suffix), modifierToken)) {
+        return kj::mv(err);
+      }
+      continue;
+    }
+    if (!maybeAddPartFromPendingFixedValue()) {
+      return kj::str("Syntax error in URL Pattern");
+    }
+
+    if (tryConsumeToken(Token::Type::END) == kj::none) {
+      return kj::str("Syntax error in URL Pattern: Missing required end token");
+    }
+  }
+
+  return partList.releaseAsArray();
+}
+
+RegexAndNameList generateRegexAndNameList(
+    kj::ArrayPtr<Part> partList,
+    const CompileComponentOptions& options) {
+  // Worst case is that the nameList is equal to partList, although that will almost never
+  // be the case, so let's be more conservative in what we reserve.
+  kj::Vector<kj::String> nameList(partList.size() / 2);
+  auto regex = kj::strTree("^");
+
+  for (auto& part : partList) {
+    if (part.type == Part::Type::FIXED_TEXT) {
+      auto escaped = escapeRegexString(part.value);
+      if (part.modifier == Part::Modifier::NONE) {
+        regex = kj::strTree(kj::mv(regex), kj::mv(escaped));
+      } else {
+        regex = kj::strTree(kj::mv(regex), "(?:", kj::mv(escaped), ")");
+        KJ_IF_SOME(c, modifierToString(part.modifier)) {
+          regex = kj::strTree(kj::mv(regex), c);
+        }
+      }
+      continue;
+    }
+
+    KJ_DASSERT(part.name.size() > 0);
+    nameList.add(kj::mv(part.name));
+    auto value = part.type == Part::Type::SEGMENT_WILDCARD ?
+        kj::str(options.segmentWildcardRegexp) :
+        part.type == Part::Type::FULL_WILDCARD ?
+            kj::str(".*") : kj::mv(part.value);
+
+    if (part.prefix == kj::none && part.suffix == kj::none) {
+      if (part.modifier == Part::Modifier::NONE || part.modifier == Part::Modifier::OPTIONAL) {
+        regex = kj::strTree(kj::mv(regex), "(", value, ")");
+        KJ_IF_SOME(c, modifierToString(part.modifier)) {
+          regex = kj::strTree(kj::mv(regex), c);
+        }
+      } else {
+        regex = kj::strTree(kj::mv(regex), "((?:", value, ")");
+        KJ_IF_SOME(c, modifierToString(part.modifier)) {
+          regex = kj::strTree(kj::mv(regex), c, ")");
+        } else {
+          regex = kj::strTree(kj::mv(regex), ")");
+        }
+      }
+      continue;
+    }
+
+    auto escapedPrefix = part.prefix.map([](kj::String& str) {
+      return escapeRegexString(str);
+    }).orDefault(kj::str());
+    auto escapedSuffix = part.suffix.map([](kj::String& str) {
+      return escapeRegexString(str);
+    }).orDefault(kj::str());
+
+    if (part.modifier == Part::Modifier::NONE || part.modifier == Part::Modifier::OPTIONAL) {
+      regex = kj::strTree(kj::mv(regex), "(?:", escapedPrefix, "(", value, ")", escapedSuffix, ")");
+      KJ_IF_SOME(c, modifierToString(part.modifier)) {
+        regex = kj::strTree(kj::mv(regex), c);
+      }
+      continue;
+    }
+
+    regex = kj::strTree(kj::mv(regex), "(?:", escapedPrefix, "((?:", value, ")(?:", escapedSuffix,
+                        escapedPrefix, "(?:", value, "))*)", escapedSuffix, ")");
+    if (part.modifier == Part::Modifier::ZERO_OR_MORE) {
+      regex = kj::strTree(kj::mv(regex), MODIFIER_ZERO_OR_MORE);
+    }
+  }
+
+  regex = kj::strTree(kj::mv(regex), "$");
+
+  return RegexAndNameList {
+    .regex = regex.flatten(),
+    .names = nameList.releaseAsArray(),
+  };
+}
+
+kj::String generatePatternString(kj::ArrayPtr<Part> partList,
+                                 const CompileComponentOptions& options) {
+  auto pattern = kj::strTree();
+  Part* previousPart = nullptr;
+  Part* nextPart = nullptr;
+  bool customName = false;
+  bool needsGrouping = false;
+  bool prefixIsEmpty = false;
+
+  const auto partPrefixEmpty = [](Part* part) {
+    if (part == nullptr) return true;
+    KJ_IF_SOME(prefix, part->prefix) {
+      return prefix.size() == 0;
+    }
+    return true;
+  };
+
+  const auto partSuffixEmpty = [](Part* part) {
+    if (part == nullptr) return true;
+    KJ_IF_SOME(prefix, part->suffix) {
+      return prefix.size() == 0;
+    }
+    return true;
+  };
+
+  const auto partSuffixIsValid = [&](Part* part) {
+    if (partSuffixEmpty(part)) return false;
+    auto& suffix = KJ_ASSERT_NONNULL(part->suffix);
+    return isValidCodepoint(suffix[0], false);
+  };
+
+  const auto checkNeedsGrouping = [&](Part& part) {
+    KJ_IF_SOME(suffix, part.suffix) {
+      if (suffix.size() > 0) return true;
+    }
+    KJ_IF_SOME(prefix, part.prefix) {
+      if (prefix.size() > 0) {
+        KJ_IF_SOME(c, options.prefix) {
+          return prefix[0] != c;
+        }
+      }
+    }
+    if (!needsGrouping &&
+        prefixIsEmpty &&
+        customName &&
+        part.type == Part::Type::SEGMENT_WILDCARD &&
+        part.modifier == Part::Modifier::NONE &&
+        nextPart != nullptr &&
+        partPrefixEmpty(nextPart) &&
+        partSuffixEmpty(nextPart)) {
+      if (nextPart->type == Part::Type::FIXED_TEXT) {
+        return nextPart->name.size() > 0 && isValidCodepoint(nextPart->name[0], false);
+      } else {
+        return nextPart->name.size() > 0 && isAsciiDigit(nextPart->name[0]);
+      }
+    }
+    return false;
+  };
+
+  for (size_t n = 0; n < partList.size(); n++) {
+    auto& part = partList[n];
+    previousPart = nullptr;
+    nextPart = nullptr;
+    if (n > 0) previousPart = &partList[n - 1];
+    if (n < partList.size() - 1) nextPart = &partList[n + 1];
+
+    if (part.type == Part::Type::FIXED_TEXT) {
+      if (part.modifier == Part::Modifier::NONE) {
+        pattern = kj::strTree(kj::mv(pattern), escapePatternString(part.value));
+        continue;
+      }
+      pattern = kj::strTree(kj::mv(pattern), "{", escapePatternString(part.value), "}");
+      KJ_IF_SOME(c, modifierToString(part.modifier)) {
+        pattern = kj::strTree(kj::mv(pattern), c);
+      }
+      continue;
+    }
+
+    KJ_DASSERT(part.name.size() > 0);
+    customName = !isAsciiDigit(part.name[0]);
+    prefixIsEmpty = partPrefixEmpty(&part);
+    needsGrouping = checkNeedsGrouping(part);
+
+    if (!needsGrouping && prefixIsEmpty && previousPart != nullptr) {
+      // These additional checks on previousPart have to be separated out from the outer
+      // if because in some cases, they may be evaluated before the previousPart != nullptr
+      // check.
+      if (previousPart->type == Part::Type::FIXED_TEXT &&
+          (previousPart->value.size() >0 &&
+           previousPart->value[previousPart->value.size() - 1] == options.prefix.orDefault(0))) {
+        needsGrouping = true;
+      }
+    }
+
+    auto subPattern = kj::strTree();
+    KJ_IF_SOME(prefix, part.prefix) {
+      subPattern = kj::strTree(kj::mv(subPattern), escapePatternString(prefix));
+    }
+    if (customName) {
+      subPattern = kj::strTree(kj::mv(subPattern), ":", part.name);
+    }
+
+    if (part.type == Part::Type::REGEXP) {
+      subPattern = kj::strTree(kj::mv(subPattern), "(", part.value, ")");
+    } else if (part.type == Part::Type::SEGMENT_WILDCARD && !customName) {
+      subPattern = kj::strTree(kj::mv(subPattern), "(", options.segmentWildcardRegexp, ")");
+    } else if (part.type == Part::Type::FULL_WILDCARD) {
+      if (!customName &&
+          (
+            previousPart == nullptr ||
+            previousPart->type == Part::Type::FIXED_TEXT ||
+            previousPart->modifier != Part::Modifier::NONE ||
+            needsGrouping ||
+            !prefixIsEmpty)) {
+        subPattern = kj::strTree(kj::mv(subPattern), MODIFIER_ZERO_OR_MORE);
+      } else {
+        subPattern = kj::strTree(kj::mv(subPattern), "(.*)");
+      }
+    }
+    if (part.type == Part::Type::SEGMENT_WILDCARD &&
+        customName &&
+        partSuffixIsValid(&part)) {
+      subPattern = kj::strTree(kj::mv(subPattern), "\\");
+    }
+
+    KJ_IF_SOME(suffix, part.suffix) {
+      subPattern = kj::strTree(kj::mv(subPattern), escapePatternString(suffix));
+    }
+
+    if (needsGrouping) {
+      subPattern = kj::strTree("{", kj::mv(subPattern), "}");
+    }
+
+    KJ_IF_SOME(c, modifierToString(part.modifier)) {
+      subPattern = kj::strTree(kj::mv(subPattern), c);
+    }
+
+    pattern = kj::strTree(kj::mv(pattern), kj::mv(subPattern));
+  }
+  return pattern.flatten();
+}
+
+UrlPattern::Result<UrlPattern::Component> tryCompileComponent(
+    kj::Maybe<kj::String>& input,
+    Canonicalizer canonicalizer,
+    const CompileComponentOptions& options) {
+  auto pattern = kj::mv(input).orDefault([] { return kj::str(MODIFIER_ZERO_OR_MORE); });
+  KJ_SWITCH_ONEOF(parsePattern(pattern, canonicalizer, options)) {
+    KJ_CASE_ONEOF(err, kj::String) {
+      return kj::mv(err);
+    }
+    KJ_CASE_ONEOF(partList, kj::Array<Part>) {
+      auto pattern = generatePatternString(partList, options);
+      auto regexAndNameList = generateRegexAndNameList(partList, options);
+      return UrlPattern::Component(kj::mv(pattern),
+                                   kj::mv(regexAndNameList.regex),
+                                   kj::mv(regexAndNameList.names));
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+bool protocolComponentMatchesSpecialScheme(kj::StringPtr regex,
+                                           const UrlPattern::CompileOptions& options) {
+  std::regex rx(regex.begin(), regex.size());
+  std::cmatch cmatch;
+  return std::regex_match("http", cmatch, rx) ||
+         std::regex_match("https", cmatch, rx) ||
+         std::regex_match("ws", cmatch, rx) ||
+         std::regex_match("wss", cmatch, rx) ||
+         std::regex_match("ftp", cmatch, rx);
+}
+
+UrlPattern::Result<UrlPattern::Init> tryParseConstructorString(
+    kj::StringPtr input,
+    const UrlPattern::CompileOptions& options) {
+  enum class State {
+    INIT,
+    PROTOCOL,
+    AUTHORITY,
+    USERNAME,
+    PASSWORD,
+    HOSTNAME,
+    PORT,
+    PATHNAME,
+    SEARCH,
+    HASH,
+    DONE,
+  };
+  State state = State::INIT;
+
+  size_t inc = 0;
+  size_t depth = 0;
+  size_t ipv6Depth = 0;
+  bool protocolMatchesSpecialScheme = false;
+
+  UrlPattern::Init result {
+    .baseUrl = strFromMaybePtr(options.baseUrl),
+  };
+
+  kj::Array<Token> tokens = nullptr;
+  KJ_SWITCH_ONEOF(tokenize(input, Token::Policy::LENIENT)) {
+    KJ_CASE_ONEOF(err, kj::String) {
+      return kj::mv(err);
+    }
+    KJ_CASE_ONEOF(list, kj::Array<Token>) {
+      tokens = kj::mv(list);
+    }
+  }
+
+  // There should always be at least one token, and it should be type end.
+  KJ_DASSERT(tokens.size() > 0);
+  KJ_DASSERT(tokens.back().type == Token::Type::END);
+  auto it = tokens.begin();
+  auto start = it;
+
+  const auto rewind = [&](kj::Maybe<State> maybeNewState = kj::none) {
+    KJ_DASSERT(start <= it);
+    it = start;
+    KJ_DASSERT(tokens.begin() <= it && it < tokens.end());
+    inc = 0;
+    KJ_IF_SOME(newState, maybeNewState) {
+      state = newState;
+    }
+  };
+
+  const auto makeComponentString = [&]() {
+    KJ_DASSERT(tokens.begin() <= it && it < tokens.end());
+    KJ_DASSERT(start->index <= it->index);
+    return kj::str(input.slice(start->index, it->index));
+  };
+
+  const auto changeState = [&](State newState, int skip) {
+    if (state != State::INIT && state != State::AUTHORITY && state != State::DONE) {
+      auto value = makeComponentString();
+      switch (state) {
+        case State::PROTOCOL: {
+          result.protocol = kj::mv(value);
+          break;
+        }
+        case State::USERNAME: {
+          result.username = kj::mv(value);
+          break;
+        }
+        case State::PASSWORD: {
+          result.password = kj::mv(value);
+          break;
+        }
+        case State::HOSTNAME: {
+          result.hostname = kj::mv(value);
+          break;
+        }
+        case State::PORT: {
+          result.port = kj::mv(value);
+          break;
+        }
+        case State::PATHNAME: {
+          result.pathname = kj::mv(value);
+          break;
+        }
+        case State::SEARCH: {
+          result.search = kj::mv(value);
+          break;
+        }
+        case State::HASH: {
+          result.hash = kj::mv(value);
+          break;
+        }
+        case State::INIT: {
+          KJ_FALLTHROUGH;
+        }
+        case State::AUTHORITY: {
+          KJ_FALLTHROUGH;
+        }
+        case State::DONE: {
+          KJ_UNREACHABLE;
+        }
+      }
+    }
+    state = newState;
+    KJ_DASSERT(it + skip <= tokens.end());
+    it += skip;
+    KJ_DASSERT(tokens.begin() <= it && it < tokens.end());
+    start = it;
+    inc = 0;
+  };
+
+  const auto isNonSpecialPatternChar = [&](auto iter, char c) {
+    KJ_DASSERT(tokens.begin() <= iter && iter < tokens.end());
+    Token& token = *iter;
+    return (token.type == Token::Type::CHAR ||
+            token.type == Token::Type::ESCAPED_CHAR ||
+            token.type == Token::Type::INVALID_CHAR) &&
+            token == c;
+  };
+
+  const auto isProtocolSuffix = [&]() {
+    return isNonSpecialPatternChar(it, ':');
+  };
+
+  const auto nextIsAuthoritySlashes = [&]() {
+    return isNonSpecialPatternChar(it + 1, '/') && isNonSpecialPatternChar(it + 2, '/');
+  };
+
+  const auto isIdentityTerminator = [&]() {
+    return isNonSpecialPatternChar(it, '@');
+  };
+
+  const auto isPasswordPrefix = [&]() {
+    return isNonSpecialPatternChar(it, ':');
+  };
+
+  const auto isPortPrefix = [&]() {
+    return isNonSpecialPatternChar(it, ':');
+  };
+
+  const auto isPathnameStart = [&]() {
+    return isNonSpecialPatternChar(it, '/');
+  };
+
+  const auto isSearchPrefix = [&]() {
+    if (isNonSpecialPatternChar(it, '?')) {
+      return true;
+    }
+    auto& token = *it;
+    if (token != '?') return false;
+
+    if (it == tokens.begin()) return true;
+
+    auto& previousToken = *(it - 1);
+    return previousToken.type != Token::Type::NAME &&
+           previousToken.type != Token::Type::REGEXP &&
+           previousToken.type != Token::Type::CLOSE &&
+           previousToken.type != Token::Type::ASTERISK;
+  };
+
+  const auto isHashPrefix = [&]() {
+    return isNonSpecialPatternChar(it, '#');
+  };
+
+  const auto isGroupOpen = [&]() {
+    return it->type == Token::Type::OPEN;
+  };
+
+  const auto isGroupClose = [&]() {
+    return it->type == Token::Type::CLOSE;
+  };
+
+  const auto isIPv6Open = [&]() {
+    return isNonSpecialPatternChar(it, '[');
+  };
+
+  const auto isIPv6Close = [&]() {
+    return isNonSpecialPatternChar(it, ']');
+  };
+
+  const auto computeMatchesSpecialScheme = [&] {
+    kj::Maybe<kj::String> input = makeComponentString();
+    KJ_SWITCH_ONEOF(tryCompileComponent(input, &canonicalizeProtocol,
+                                        CompileComponentOptions::DEFAULT)) {
+      KJ_CASE_ONEOF(err, kj::String) {
+        // Ignore any errors at this point. If the component is invalid we'll
+        // catch it later.
+        return false;
+      }
+      KJ_CASE_ONEOF(component, UrlPattern::Component) {
+        return protocolComponentMatchesSpecialScheme(component.getRegex(), options);
+      }
+    }
+    KJ_UNREACHABLE;
+  };
+
+  while (it != tokens.end()) {
+    Token& token = *it;
+    inc = 1;
+
+    if (token.type == Token::Type::END) {
+      if (state == State::INIT) {
+        rewind();
+        if (isHashPrefix()) {
+          changeState(State::HASH, 1);
+        } else if (isSearchPrefix()) {
+          changeState(State::SEARCH, 1);
+          result.hash = kj::str();
+        } else {
+          changeState(State::PATHNAME, 0);
+          result.search = kj::str();
+          result.hash = kj::str();
+        }
+        // Since we called rewind and we know that sets inc to zero,
+        // and we know that nothing else here changed inc, there's no
+        // need to try to advance. Just continue.
+        continue;
+      }
+      if (state == State::AUTHORITY) {
+        rewind(State::HOSTNAME);
+        // Since we called rewind and we know that sets inc to zero,
+        // there's no need to try to advance. Just continue.
+        continue;
+      }
+      // We hit the end and we're all done!
+      changeState(State::DONE, 0);
+      break;
+    }
+    if (isGroupOpen()) {
+      depth++;
+      it += inc;
+      continue;
+    }
+    if (depth > 0) {
+      if (isGroupClose()) {
+        depth--;
+      } else {
+        it += inc;
+        continue;
+      }
+    }
+
+    switch (state) {
+      case State::INIT: {
+        if (isProtocolSuffix()) {
+          result.username = kj::str();
+          result.password = kj::str();
+          result.hostname = kj::str();
+          result.port = kj::str();
+          result.pathname = kj::str();
+          result.search = kj::str();
+          result.hash = kj::str();
+          rewind(State::PROTOCOL);
+        }
+        break;
+      }
+      case State::PROTOCOL: {
+        if (isProtocolSuffix()) {
+          computeMatchesSpecialScheme();
+          if (protocolMatchesSpecialScheme) result.pathname = kj::str("/");
+          if (nextIsAuthoritySlashes()) changeState(State::AUTHORITY, 3);
+          else if (protocolMatchesSpecialScheme) changeState(State::AUTHORITY, 1);
+          else changeState(State::PATHNAME, 1);
+        }
+        break;
+      }
+      case State::AUTHORITY: {
+        if (isIdentityTerminator()) rewind(State::USERNAME);
+        else if (isPathnameStart() || isSearchPrefix() || isHashPrefix()) rewind(State::HOSTNAME);
+        break;
+      }
+      case State::USERNAME: {
+        if (isPasswordPrefix()) changeState(State::PASSWORD, 1);
+        else if (isIdentityTerminator()) changeState(State::HOSTNAME, 1);
+        break;
+      }
+      case State::PASSWORD: {
+        if (isIdentityTerminator()) changeState(State::HOSTNAME, 1);
+        break;
+      }
+      case State::HOSTNAME: {
+        if (isIPv6Open()) ipv6Depth++;
+        else if (isIPv6Close()) ipv6Depth--;
+        else if (isPortPrefix() && ipv6Depth == 0) changeState(State::PORT, 1);
+        else if (isPathnameStart()) changeState(State::PATHNAME, 0);
+        else if (isSearchPrefix()) changeState(State::SEARCH, 1);
+        else if (isHashPrefix()) changeState(State::HASH, 1);
+        break;
+      }
+      case State::PORT: {
+        if (isPathnameStart()) changeState(State::PATHNAME, 0);
+        else if (isSearchPrefix()) changeState(State::SEARCH, 1);
+        else if (isHashPrefix()) changeState(State::HASH, 1);
+        break;
+      }
+      case State::PATHNAME: {
+        if (isSearchPrefix()) changeState(State::SEARCH, 1);
+        else if (isHashPrefix()) changeState(State::HASH, 1);
+        break;
+      }
+      case State::SEARCH: {
+        if (isHashPrefix()) changeState(State::HASH, 1);
+        break;
+      }
+      case State::HASH: {
+        // Nothing to do.
+        break;
+      }
+      case State::DONE: {
+        KJ_UNREACHABLE;
+      }
+    }
+
+    it += inc;
+  }
+
+  if (result.protocol == kj::none && result.baseUrl == kj::none) {
+    return kj::str("Syntax error in URL Pattern: a relative pattern must have a base URL.");
+  }
+
+  return kj::mv(result);
+}
+}  // namespace
+
+UrlPattern::Component::Component(kj::String pattern,
+                                 kj::String regex,
+                                 kj::Array<kj::String> names)
+    : pattern(kj::mv(pattern)),
+      regex(kj::mv(regex)),
+      names(kj::mv(names)) {}
+
+UrlPattern::Result<UrlPattern> UrlPattern::tryCompileInit(
+    UrlPattern::Init init,
+    const UrlPattern::CompileOptions& options) {
+  kj::Vector<UrlPattern::Component> components(7);
+
+  bool matchesSpecialScheme = false;
+
+  KJ_SWITCH_ONEOF(tryCompileComponent(init.protocol, &canonicalizeProtocol,
+                                      CompileComponentOptions::DEFAULT)) {
+    KJ_CASE_ONEOF(err, kj::String) {
+      return kj::mv(err);
+    }
+    KJ_CASE_ONEOF(component, UrlPattern::Component) {
+      matchesSpecialScheme = protocolComponentMatchesSpecialScheme(component.getRegex(), options);
+      components.add(kj::mv(component));
+    }
+  }
+
+  const auto handleComponent = [&](auto& input, Canonicalizer canonicalizer,
+                                   const CompileComponentOptions& options)
+      -> kj::Maybe<kj::String> {
+    KJ_SWITCH_ONEOF(tryCompileComponent(input, canonicalizer, options)) {
+      KJ_CASE_ONEOF(err, kj::String) {
+        return kj::mv(err);
+      }
+      KJ_CASE_ONEOF(component, UrlPattern::Component) {
+        components.add(kj::mv(component));
+        return kj::none;
+      }
+    }
+    KJ_UNREACHABLE;
+  };
+
+  KJ_IF_SOME(err, handleComponent(init.username, &canonicalizeUsername,
+                                  CompileComponentOptions::DEFAULT)) {
+    return kj::mv(err);
+  }
+  KJ_IF_SOME(err, handleComponent(init.password,
+                                  &canonicalizePassword,
+                                  CompileComponentOptions::DEFAULT)) {
+    return kj::mv(err);
+  }
+
+  Canonicalizer* hostnameCanonicalizer = &canonicalizeHostname;
+  KJ_IF_SOME(hostname, init.hostname) {
+    if (isIpv6(hostname.asPtr())) {
+      hostnameCanonicalizer = &canonicalizeIpv6Hostname;
+    }
+  }
+  KJ_IF_SOME(err, handleComponent(init.hostname, hostnameCanonicalizer,
+                                  CompileComponentOptions::HOSTNAME)) {
+    return kj::mv(err);
+  }
+
+  KJ_IF_SOME(err, handleComponent(init.port, &canonicalizePort, CompileComponentOptions::DEFAULT)) {
+    return kj::mv(err);
+  }
+
+  KJ_IF_SOME(err, handleComponent(init.pathname,
+                       matchesSpecialScheme ? &canonicalizePathname : &canonicalizeOpaquePathname,
+                       matchesSpecialScheme ? CompileComponentOptions::PATHNAME :
+                                              CompileComponentOptions::DEFAULT)) {
+    return kj::mv(err);
+  }
+  KJ_IF_SOME(err, handleComponent(init.search, &canonicalizeSearch,
+                                  CompileComponentOptions::DEFAULT)) {
+    return kj::mv(err);
+  }
+  KJ_IF_SOME(err, handleComponent(init.hash, &canonicalizeHash,
+                                  CompileComponentOptions::DEFAULT)) {
+    return kj::mv(err);
+  }
+  return UrlPattern(components.releaseAsArray(), options.ignoreCase);
+}
+
+UrlPattern::Result<UrlPattern::Init> UrlPattern::processInit(
+    UrlPattern::Init init,
+    kj::Maybe<UrlPattern::ProcessInitOptions> maybeOptions) {
+  auto options = maybeOptions.orDefault({});
+
+  Init result;
+  kj::Maybe<Url> maybeBaseUrl;
+
+  const auto isAbsolutePathname = [&](kj::StringPtr str) {
+    if (str.size() == 0) return false;
+    char c = str[0];
+    if (c == '/') return true;
+    if (options.mode == ProcessInitOptions::Mode::URL) return false;
+    return str.size() > 1 && (c == '\\' || c == '{') && str[1] == '/';
+  };
+
+  KJ_IF_SOME(base, init.baseUrl) {
+    KJ_IF_SOME(url, Url::tryParse(base.asPtr())) {
+      result.protocol = stripSuffixFromProtocol(url.getProtocol());
+      result.username = kj::str(url.getUsername());
+      result.password = kj::str(url.getPassword());
+      result.hostname = kj::str(url.getHostname());
+      result.port = kj::str(url.getPort());
+      result.pathname = escapePatternString(url.getPathname());
+      if (url.getSearch().size() > 0) {
+        result.search = escapePatternString(url.getSearch().slice(1));
+      } else {
+        result.search = kj::str();
+      }
+      if (url.getHash().size() > 0) {
+        result.hash = escapePatternString(url.getHash().slice(1));
+      } else {
+        result.hash = kj::str();
+      }
+      result.baseUrl = kj::mv(base);
+      maybeBaseUrl = kj::mv(url);
+    } else {
+      return kj::str("Invalid base URL.");
+    }
+  }
+
+  if (options.mode == ProcessInitOptions::Mode::PATTERN) {
+    KJ_IF_SOME(protocol, chooseStr(kj::mv(init.protocol), options.protocol)
+        .map([](kj::String&& str) mutable {
+      // It's silly but the URL spec always includes the : suffix in the value,
+      // while the URLPattern spec always omits it. Silly specs.
+      return stripSuffixFromProtocol(str.asPtr());
+    })) {
+      result.protocol = kj::mv(protocol);
+    }
+    KJ_IF_SOME(username, chooseStr(kj::mv(init.username), options.username)) {
+      result.username = kj::mv(username);
+    }
+    KJ_IF_SOME(password, chooseStr(kj::mv(init.password), options.password)) {
+      result.password = kj::mv(password);
+    }
+    KJ_IF_SOME(hostname, chooseStr(kj::mv(init.hostname), options.hostname)) {
+      result.hostname = kj::mv(hostname);
+    }
+    KJ_IF_SOME(port, chooseStr(kj::mv(init.port), options.port)) {
+      result.port = kj::mv(port);
+    }
+    KJ_IF_SOME(pathname, chooseStr(kj::mv(init.pathname), options.pathname)) {
+      if (!isAbsolutePathname(pathname)) {
+        KJ_IF_SOME(url, maybeBaseUrl) {
+          auto basePathname = url.getPathname();
+          auto index = KJ_ASSERT_NONNULL(basePathname.findLast('/'));
+          result.pathname = kj::str(basePathname.slice(0, index + 1), pathname);
+        } else {
+          result.pathname = kj::mv(pathname);
+        }
+      } else {
+        result.pathname = kj::mv(pathname);
+      }
+    }
+    KJ_IF_SOME(search, chooseStr(kj::mv(init.search), options.search)) {
+      if (search.size() > 0 && search[0] == '?') {
+        result.search = kj::str(search.slice(1));
+      } else {
+        result.search = kj::mv(search);
+      }
+    }
+    KJ_IF_SOME(hash, chooseStr(kj::mv(init.hash), options.hash)) {
+      if (hash.size() > 0 && hash[0] == '#') {
+        result.hash = kj::str(hash.slice(1));
+      } else {
+        result.hash = kj::mv(hash);
+      }
+    }
+    return result;
+  }
+
+  KJ_DASSERT(options.mode == ProcessInitOptions::Mode::URL);
+
+  // Things are a bit more complicated in this case. The individual components
+  // of Init are interpreted as URL components. The processing here must convert
+  // those into a canonical form. Unfortunately, however, it's not *quite* as
+  // simple as constructing a URL string from the inputs, parsing it, and then
+  // deconstructing the result. The validation rules per the URLPattern spec are
+  // a bit different for some of the components than for the URL spec so we handle
+  // each individually.
+
+  bool isAbsolute = false;
+  auto scratch = ([&]() -> kj::OneOf<Url, kj::String> {
+    KJ_IF_SOME(protocol, chooseStr(kj::mv(init.protocol), options.protocol)) {
+      // The protocol value we are given might not be valid. We'll check by
+      // attempting to use it to parse a URL.
+      auto str = kj::str(protocol, protocol.asArray().back() == ':' ? "" : ":", "//a:b@fake-url");
+      KJ_IF_SOME(parsed, Url::tryParse(str.asPtr())) {
+        // Nice. We have a good protocol component. Let's set the normalized version
+        // on the result and return the parsed URL to use as our temporary.
+        result.protocol = stripSuffixFromProtocol(parsed.getProtocol());
+        // We set isAbsolute true here so that when we later want to normalize the
+        // pathname, we know not to try to resolve the path relative to the base.
+        isAbsolute = true;
+        return kj::mv(parsed);
+      } else {
+        // Doh, parsing failed. The protocol component is invalid.
+        return kj::str("Invalid URL protocol component");
+      }
+    } else {
+      // There was not protocol component in the init or options. We still might
+      // have a base URL protocol. If we do, we're going to use it to construct
+      // our temporary URL we will use to canonicalize the rest. If we do not,
+      // we'll use a fake URL scheme.
+      KJ_IF_SOME(protocol, result.protocol) {
+        // We only want to create the temporary URL here and return it.
+        auto str = kj::str(protocol, "://fake-url");
+        return KJ_ASSERT_NONNULL(Url::tryParse(str.asPtr()));
+      } else {
+        auto str = kj::str("fake://fake-url");
+        return KJ_ASSERT_NONNULL(Url::tryParse(str.asPtr()));
+      }
+    }
+  })();
+
+  KJ_SWITCH_ONEOF(scratch) {
+    KJ_CASE_ONEOF(err, kj::String) {
+      // Invalid URL protocol component.
+      return kj::mv(err);
+    }
+    KJ_CASE_ONEOF(url, Url) {
+      KJ_IF_SOME(username, chooseStr(kj::mv(init.username), options.username)) {
+        if (!url.setUsername(username.asPtr())) {
+          return kj::str("Invalid URL username component");
+        }
+        result.username = kj::str(url.getUsername());
+      }
+      KJ_IF_SOME(password, chooseStr(kj::mv(init.password), options.password)) {
+        if (!url.setPassword(password.asPtr())) {
+          return kj::str("Invalid URL password component");
+        }
+        result.password = kj::str(url.getPassword());
+      }
+      KJ_IF_SOME(hostname, chooseStr(kj::mv(init.hostname), options.hostname)) {
+        if (!isValidHostnameInput(hostname) ||
+            !url.setHostname(hostname.asPtr())) {
+          return kj::str("Invalid URL hostname component");
+        }
+        result.hostname = kj::str(url.getHostname());
+      }
+      KJ_IF_SOME(port, chooseStr(kj::mv(init.port), options.port)) {
+        if (port.size() >= 5 ||
+            !std::all_of(port.begin(), port.end(), isAsciiDigit) ||
+            !url.setPort(kj::Maybe(port.asPtr()))) {
+          return kj::str("Invalid URL port component");
+        }
+        result.port = kj::str(url.getPort());
+      }
+      KJ_IF_SOME(pathname, chooseStr(kj::mv(init.pathname), options.pathname)) {
+        if (isAbsolute) {
+          // isAbsolute is set only if we have an explicit protocol set for in init
+          // or options. This tells us that we are not going to resolve the path
+          // relative to the base URL at all.
+          if (!url.setPathname(pathname.asPtr())) {
+            return kj::str("Invalid URL pathname component");
+          }
+          result.pathname = kj::str(url.getPathname());
+        } else {
+          // Here, our init/options did not specify a protocol, so we're either relying
+          // on the base URL or the fake. If we have a base URL, then, we want to resolve
+          // the path relative to the base URL path.
+          KJ_IF_SOME(base, maybeBaseUrl) {
+            // If there is a base URL, then we'll normalize the path by attempting to
+            // resolve against the base.
+            KJ_IF_SOME(resolved, base.resolve(pathname.asPtr())) {
+              result.pathname = kj::str(resolved.getPathname());
+            } else {
+              return kj::str("Invalid URL pathname component");
+            }
+          } else {
+            if (!url.setPathname(pathname.asPtr())) {
+              return kj::str("Invalid URL pathname component");
+            }
+            result.pathname = kj::str(url.getPathname());
+          }
+        }
+      }
+      KJ_IF_SOME(search, chooseStr(kj::mv(init.search), options.search)) {
+        url.setSearch(kj::Maybe(search.asPtr()));
+        // We slice here because the URL getter will always include the ? prefix
+        // but the URLPattern spec does not want it.
+        if (url.getSearch().size() > 0) {
+          result.search = kj::str(url.getSearch().slice(1));
+        } else {
+          result.search = kj::str();
+        }
+      }
+      KJ_IF_SOME(hash, chooseStr(kj::mv(init.hash), options.hash)) {
+        url.setHash(kj::Maybe(hash.asPtr()));
+        // We slice here because the URL getter will always include the # prefix
+        // but the URLPattern spec does not want it.
+        if (url.getHash().size() > 0) {
+          result.hash = kj::str(url.getHash().slice(1));
+        } else {
+          result.hash = kj::str();
+        }
+      }
+      return result;
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+UrlPattern::Result<UrlPattern> UrlPattern::tryCompile(Init init,
+                                                      kj::Maybe<CompileOptions> maybeOptions) {
+  auto options = maybeOptions.orDefault({});
+  KJ_SWITCH_ONEOF(processInit(kj::mv(init))) {
+    KJ_CASE_ONEOF(err, kj::String) {
+      return kj::mv(err);
+    }
+    KJ_CASE_ONEOF(init, UrlPattern::Init) {
+      return tryCompileInit(kj::mv(init), options);
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+UrlPattern::Result<UrlPattern> UrlPattern::tryCompile(kj::StringPtr input,
+                                                      kj::Maybe<CompileOptions> maybeOptions) {
+  auto options = maybeOptions.orDefault({});
+  KJ_SWITCH_ONEOF(tryParseConstructorString(input, options)) {
+    KJ_CASE_ONEOF(err, kj::String) {
+      return kj::mv(err);
+    }
+    KJ_CASE_ONEOF(init, UrlPattern::Init) {
+      KJ_SWITCH_ONEOF(processInit(kj::mv(init))) {
+        KJ_CASE_ONEOF(err, kj::String) {
+          return kj::mv(err);
+        }
+        KJ_CASE_ONEOF(init, UrlPattern::Init) {
+          return tryCompileInit(kj::mv(init), options);
+        }
+      }
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+UrlPattern::UrlPattern(kj::Array<Component> components, bool ignoreCase)
+    : protocol(kj::mv(components[0])),
+      username(kj::mv(components[1])),
+      password(kj::mv(components[2])),
+      hostname(kj::mv(components[3])),
+      port(kj::mv(components[4])),
+      pathname(kj::mv(components[5])),
+      search(kj::mv(components[6])),
+      hash(kj::mv(components[7])),
+      ignoreCase(ignoreCase) {}
 
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/url.h
+++ b/src/workerd/jsg/url.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <kj/string.h>
 #include <kj/common.h>
+#include <kj/one-of.h>
 
 namespace workerd::jsg {
 
@@ -177,5 +178,123 @@ inline kj::String KJ_STRINGIFY(const Url& url) {
 inline kj::String KJ_STRINGIFY(const UrlSearchParams& searchParams) {
   return kj::str(searchParams.toStr());
 }
+
+// ======================================================================================
+
+// Encapsulates a parsed URLPattern.
+// @see https://wicg.github.io/urlpattern
+class UrlPattern final {
+public:
+  // If the value it T, the operation is successful.
+  // If the value is kj::String, that's an Error message.
+  template <typename T>
+  using Result = kj::OneOf<T, kj::String>;
+
+  // An individual, compiled component of a URLPattern.
+  class Component final {
+  public:
+    Component(kj::String pattern, kj::String regex, kj::Array<kj::String> names);
+
+    Component(Component&&) = default;
+    Component& operator=(Component&&) = default;
+    KJ_DISALLOW_COPY(Component);
+
+    inline kj::StringPtr getPattern() const KJ_LIFETIMEBOUND { return pattern; }
+    inline kj::StringPtr getRegex() const KJ_LIFETIMEBOUND { return regex; }
+    inline kj::ArrayPtr<const kj::String> getNames() const KJ_LIFETIMEBOUND {
+      return names.asPtr();
+    }
+
+  private:
+    // The normalized pattern for this component.
+    kj::String pattern = nullptr;
+
+    // The generated JavaScript regular expression for this component.
+    kj::String regex = nullptr;
+
+    // The list of sub-component names extracted for this component.
+    kj::Array<kj::String> names = nullptr;
+  };
+
+  // A structure providing matching patterns for individual components of a URL.
+  struct Init {
+    kj::Maybe<kj::String> protocol;
+    kj::Maybe<kj::String> username;
+    kj::Maybe<kj::String> password;
+    kj::Maybe<kj::String> hostname;
+    kj::Maybe<kj::String> port;
+    kj::Maybe<kj::String> pathname;
+    kj::Maybe<kj::String> search;
+    kj::Maybe<kj::String> hash;
+    kj::Maybe<kj::String> baseUrl;
+  };
+
+  struct ProcessInitOptions {
+    enum class Mode {
+      PATTERN,
+      URL,
+    };
+    Mode mode = Mode::PATTERN;
+    kj::Maybe<kj::StringPtr> protocol = kj::none;
+    kj::Maybe<kj::StringPtr> username = kj::none;
+    kj::Maybe<kj::StringPtr> password = kj::none;
+    kj::Maybe<kj::StringPtr> hostname = kj::none;
+    kj::Maybe<kj::StringPtr> port = kj::none;
+    kj::Maybe<kj::StringPtr> pathname = kj::none;
+    kj::Maybe<kj::StringPtr> search = kj::none;
+    kj::Maybe<kj::StringPtr> hash = kj::none;
+  };
+
+  // Processes the given init according to the specified mode and options.
+  // If a kj::String is returned, then processing failed and the string
+  // is the description to include in the error message (if any). This is
+  // exposed here for testing only.
+  static Result<Init> processInit(Init init,
+                                  kj::Maybe<ProcessInitOptions> options = kj::none)
+                                  KJ_WARN_UNUSED_RESULT;
+
+  struct CompileOptions {
+    // The base URL to use. Only used in the compile(kj::StringPtr, ...) variant.
+    kj::Maybe<kj::StringPtr> baseUrl;
+    bool ignoreCase = false;
+  };
+
+  static Result<UrlPattern> tryCompile(kj::StringPtr, kj::Maybe<CompileOptions> = kj::none)
+      KJ_WARN_UNUSED_RESULT;
+  static Result<UrlPattern> tryCompile(Init init, kj::Maybe<CompileOptions> = kj::none)
+      KJ_WARN_UNUSED_RESULT;
+
+  UrlPattern(UrlPattern&&) = default;
+  UrlPattern& operator=(UrlPattern&&) = default;
+  KJ_DISALLOW_COPY(UrlPattern);
+
+  inline const Component& getProtocol() const KJ_LIFETIMEBOUND { return protocol; }
+  inline const Component& getUsername() const KJ_LIFETIMEBOUND { return username; }
+  inline const Component& getPassword() const KJ_LIFETIMEBOUND { return password; }
+  inline const Component& getHostname() const KJ_LIFETIMEBOUND { return hostname; }
+  inline const Component& getPort() const KJ_LIFETIMEBOUND { return port; }
+  inline const Component& getPathname() const KJ_LIFETIMEBOUND { return pathname; }
+  inline const Component& getSearch() const KJ_LIFETIMEBOUND { return search; }
+  inline const Component& getHash() const KJ_LIFETIMEBOUND { return hash; }
+
+  // If ignoreCase is true, the JavaScript regular expression created for each pattern
+  // must use the `vi` flag. Otherwise, they must use the `v` flag.
+  inline bool getIgnoreCase() const { return ignoreCase; }
+
+private:
+  UrlPattern(kj::Array<Component> components, bool ignoreCase);
+
+  Component protocol;
+  Component username;
+  Component password;
+  Component hostname;
+  Component port;
+  Component pathname;
+  Component search;
+  Component hash;
+  bool ignoreCase;
+
+  static Result<UrlPattern> tryCompileInit(UrlPattern::Init init, const CompileOptions& options);
+};
 
 }  // namespace workerd::jsg


### PR DESCRIPTION
This is a rework of the URLPattern internals built around ada. This is necessary to decouple the URLPattern implementation from the older non-ada url implementation so that we can fully drop it in favor of ada. This does not just move the implementation over into jsg::UrlPattern, this refactors and simplifies out the part that validates and compiles the pattern. 

Why `jsg::UrlPattern`? This keeps all of the code relevant to `ada-url` contained within the `jsg/url.c++` file only, reducing any blast radius should we need to update or replace ada at any point in the future.