### PR TITLE
Upgrade to macOS 13 runner and switch to LLVM 15 on Linux

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -134,7 +134,8 @@ build:macos --config=unix
 
 # Support macOS 11 as the minimum version. There should be at least a warning when backward
 # compatibility is broken as -Wunguarded-availability-new is enabled by default.
-build:macos --macos_minimum_os=11.0 --host_macos_minimum_os=11.0
+# TODO (cleanup): macOS 11.X is now EOL, bump this to macOS 12.5 soon.
+build:macos --macos_minimum_os=11.5 --host_macos_minimum_os=11.5
 
 # On Linux, always link libc++ statically to avoid compatibility issues with different OS versions.
 # macOS links with dynamic libc++ by default, which has good backwards compatibility.

--- a/.bazelrc
+++ b/.bazelrc
@@ -137,6 +137,7 @@ build:macos --config=unix
 build:macos --macos_minimum_os=11.0 --host_macos_minimum_os=11.0
 
 # On Linux, always link libc++ statically to avoid compatibility issues with different OS versions.
+# macOS links with dynamic libc++ by default, which has good backwards compatibility.
 build:linux --cxxopt='-stdlib=libc++' --host_cxxopt='-stdlib=libc++'
 build:linux --linkopt='-stdlib=libc++' --host_linkopt='-stdlib=libc++'
 build:linux --action_env=BAZEL_LINKLIBS='-l%:libc++.a -lm -static-libgcc'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,12 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-2022]
+        os: [ubuntu-20.04, macos-13, windows-2022]
         include:
           - os-name: linux
             os: ubuntu-20.04
           - os-name: macOS
-            os: macos-latest
+            os: macos-13
           - os-name: windows
             os: windows-2022
     runs-on: ${{ matrix.os }}
@@ -82,10 +82,14 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 14
-          sudo apt-get install -y libunwind-14 libc++abi1-14 libc++1-14 libc++-14-dev
-          echo "build:linux --action_env=CC=/usr/lib/llvm-14/bin/clang --action_env=CXX=/usr/lib/llvm-14/bin/clang++" >> .bazelrc
-          echo "build:linux --host_action_env=CC=/usr/lib/llvm-14/bin/clang --host_action_env=CXX=/usr/lib/llvm-14/bin/clang++" >> .bazelrc
+          sudo ./llvm.sh 15
+          sudo apt-get install -y libunwind-15 libc++abi1-15 libc++1-15 libc++-15-dev
+          echo "build:linux --action_env=CC=/usr/lib/llvm-15/bin/clang --action_env=CXX=/usr/lib/llvm-15/bin/clang++" >> .bazelrc
+          echo "build:linux --host_action_env=CC=/usr/lib/llvm-15/bin/clang --host_action_env=CXX=/usr/lib/llvm-15/bin/clang++" >> .bazelrc
+      - name: Setup macOS
+        if: runner.os == 'macOS'
+        run: |
+          sudo xcode-select -s "/Applications/Xcode_14.3.1.app"
       - name: Setup Windows
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           [
             { name : linux, image : ubuntu-20.04 },
-            { name : macOS, image : macos-latest },
+            { name : macOS, image : macos-13 },
             { name : windows, image : windows-2022 }
           ]
         config:
@@ -54,7 +54,7 @@ jobs:
         if: matrix.os.name == 'linux'
         # Install dependencies, including clang via through LLVM APT repository. Note that this
         # will also install lldb and clangd alongside dependencies, which can be removed with
-        # `sudo apt-get remove -y lldb-14 clangd-14; sudo apt-get autoremove -y` if space is
+        # `sudo apt-get remove -y lldb-15 clangd-15; sudo apt-get autoremove -y` if space is
         # limited.
         # libunwind, libc++abi1 and libc++1 should be automatically installed as dependencies of
         # libc++, but this appears to cause errors so they are also being explicitly installed.
@@ -64,21 +64,23 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 14
-          sudo apt-get install -y libunwind-14 libc++abi1-14 libc++1-14 libc++-14-dev libclang-rt-14-dev
-          echo "build:linux --action_env=CC=/usr/lib/llvm-14/bin/clang --action_env=CXX=/usr/lib/llvm-14/bin/clang++" >> .bazelrc
-          echo "build:linux --host_action_env=CC=/usr/lib/llvm-14/bin/clang --host_action_env=CXX=/usr/lib/llvm-14/bin/clang++" >> .bazelrc
-          sed -i -e "s%llvm-symbolizer%/usr/lib/llvm-14/bin/llvm-symbolizer%" .bazelrc
+          sudo ./llvm.sh 15
+          sudo apt-get install -y libunwind-15 libc++abi1-15 libc++1-15 libc++-15-dev libclang-rt-15-dev
+          echo "build:linux --action_env=CC=/usr/lib/llvm-15/bin/clang --action_env=CXX=/usr/lib/llvm-15/bin/clang++" >> .bazelrc
+          echo "build:linux --host_action_env=CC=/usr/lib/llvm-15/bin/clang --host_action_env=CXX=/usr/lib/llvm-15/bin/clang++" >> .bazelrc
+          sed -i -e "s%llvm-symbolizer%/usr/lib/llvm-15/bin/llvm-symbolizer%" .bazelrc
       - name: Setup macOS
         if: matrix.os.name == 'macOS'
         # TODO: We want to symbolize stacks for crashes on CI. Xcode is currently based on LLVM 15
-        # and the macos-12 image has llvm@15 installed:
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
+        # and the macos-13 image has llvm@15 installed:
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
         #
         # Not enabled because symbolication does not work on workerd macOS builds yet and running
         # llvm-symbolizer in the currently broken state causes some tests to time out on the
         # runner.
+        # Use Xcode 14.3.1 for now, upgrade once 15.1 is available on the runner image.
         run: |
+          sudo xcode-select -s "/Applications/Xcode_14.3.1.app"
           # export LLVM_SYMBOLIZER=$(brew --prefix llvm@15)/bin/llvm-symbolizer
           # sed -i -e "s%llvm-symbolizer%${LLVM_SYMBOLIZER}%" .bazelrc
       - name: Setup Windows

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -7,11 +7,11 @@ RUN apt-get install -y curl build-essential git lsb-release wget software-proper
 
 RUN wget https://apt.llvm.org/llvm.sh
 RUN chmod +x llvm.sh
-RUN ./llvm.sh 14 all
+RUN ./llvm.sh 15 all
 COPY . .
 
-RUN echo "build:linux --action_env=CC=/usr/lib/llvm-14/bin/clang --action_env=CXX=/usr/lib/llvm-14/bin/clang++" >> .bazelrc
-RUN echo "build:linux --host_action_env=CC=/usr/lib/llvm-14/bin/clang --host_action_env=CXX=/usr/lib/llvm-14/bin/clang++" >> .bazelrc
+RUN echo "build:linux --action_env=CC=/usr/lib/llvm-15/bin/clang --action_env=CXX=/usr/lib/llvm-15/bin/clang++" >> .bazelrc
+RUN echo "build:linux --host_action_env=CC=/usr/lib/llvm-15/bin/clang --host_action_env=CXX=/usr/lib/llvm-15/bin/clang++" >> .bazelrc
 COPY .bazel-cache /bazel-disk-cache
 RUN npm install -g pnpm@latest-7
 RUN pnpm install

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,3 +1,6 @@
+# TODO(later): llvm-toolchain-16 is expected to be backported to Bullseye with the 11.9 point
+# release (https://tracker.debian.org/pkg/llvm-toolchain-16). Switch to using the regular packages
+# instead of packages from LLVM's APT repo once 11.9 is available and we have upgraded to LLVM 16.
 FROM node:bullseye AS builder
 
 WORKDIR /workerd

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ To build `workerd`, you need:
 * [Bazel](https://bazel.build/)
   * If you use [Bazelisk](https://github.com/bazelbuild/bazelisk) (recommended), it will automatically download and use the right version of Bazel for building workerd.
 * On Linux:
-  * Clang 11+ (e.g. package `clang` on Debian Bullseye)
-  * libc++ 11+ (e.g. packages `libc++-dev` and `libc++abi-dev` on Debian Bullseye)
-  * LLD 11+ (e.g. package `lld` on Debian Bullseye)
+  * We use the clang/LLVM toolchain to build workerd and support version 15 and higher. Earlier versions of clang may still work, but are not officially supported.
+  * Clang 15+ (e.g. package `clang-15` on Debian Bookworm).
+  * libc++ 15+ (e.g. packages `libc++-15-dev` and `libc++abi-15-dev`)
+  * LLD 15+ (e.g. package `lld-15`).
   * `python3`, `python3-distutils`, and `tcl8.6`
 * On macOS:
-  * Xcode 13+ installation
-  * macOS 11 or higher
+  * Xcode 14.3+ installation (available on macOS 13 and higher)
   * Homebrew installed `tcl-tk` package (provides Tcl 8.6)
 * On Windows:
   * Install [App Installer](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget)

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Prebuilt binaries are distributed via `npm`. Run `npx workerd ...` to use these.
 * On Linux:
   * glibc 2.31 or higher (already included on e.g. Ubuntu 20.04, Debian Bullseye)
 * On macOS:
-  * macOS 11 or higher
+  * macOS 11.5 or higher
   * The Xcode command line tools, which can be installed with `xcode-select --install`
 
 ### Local Worker development with `wrangler`


### PR DESCRIPTION
Upgrade the build to LLVM 15 on macOS and Linux – this allows us to benefit from many compiler improvements and aligns the build closer to the versions used for Windows and for the upstream repository. On macOS, this is achieved by upgrading to the macOS 13 runner and using Xcode 14.3.1. Note that while the clang version in the Xcode release is defined as `Apple clang version 14.0.3 (clang-1403.0.22.14.1)`, it is actually [based on](https://en.wikipedia.org/wiki/Xcode#Xcode_11.0_-_14.x_(since_SwiftUI_framework)_2) LLVM 15.

Please disregard the previous comments – they address potential issues and benefits related to upgrading to LLVM 16/Xcode 15, but this will be done in a later PR.