### PR TITLE
Fixes logspam in sockets (handleProxyError).

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -372,8 +372,8 @@ void Socket::handleProxyStatus(jsg::Lock& js, kj::Promise<kj::Maybe<kj::Exceptio
 }
 
 void Socket::handleProxyError(jsg::Lock& js, kj::Exception e) {
-  resolveFulfiller(js, kj::mv(e));
-  openedResolver.reject(js, kj::cp(e));
+  resolveFulfiller(js, kj::cp(e));
+  openedResolver.reject(js, kj::mv(e));
   readable->getController().cancel(js, kj::none).markAsHandled(js);
   writable->getController().abort(js, js.error(e.getDescription())).markAsHandled(js);
 }


### PR DESCRIPTION
Accidentally rejecting with a `nullptr` lead to exception being logged.