### PR TITLE
Add issues workflow

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,16 @@
+name: Issue
+
+on:
+  issues:
+    types: [opened, labeled, transferred]
+
+jobs:
+  add-to-project:
+    name: Add issue to GH project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/cloudflare/projects/1
+          github-token: ${{ secrets.DEVPROD_PAT }}
+          labeled: types


### PR DESCRIPTION
Add an issues workflow that assigns issues labeled with `types` label to the [workers-sdk GH project](https://github.com/orgs/cloudflare/projects/1)