### PR TITLE
No longer return promise result in websocket couple()

### DIFF
--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -333,7 +333,8 @@ kj::Promise<DeferredProxy<void>> WebSocket::couple(kj::Own<kj::WebSocket> other)
   if (locality == LOCAL) {
     // Since the WebSocket is terminated locally, we need the IoContext to stay live while
     // it is active.
-    co_return co_await promise;
+    co_await promise;
+    co_return;
   } else {
     // Since the WebSocket is just proxying through, we can do the pump in a deferred proxy task.
     // Note that we don't need to (and can't) register any pending events in this case since the


### PR DESCRIPTION
In #953 the behaivor of this function was accidentally changed to return the result of the pumpTo promise.