### PR TITLE
Add type for D1Result meta

### DIFF
--- a/types/defines/d1.d.ts
+++ b/types/defines/d1.d.ts
@@ -1,7 +1,17 @@
+interface D1Meta {
+  duration: number;
+  size_after: number;
+  rows_read: number;
+  rows_written: number;
+  last_row_id: number;
+  changed_db: boolean;
+  changes: number;
+}
+
 interface D1Result<T = unknown> {
   results: T[];
   success: true;
-  meta: any;
+  meta: D1Meta & Record<string, unknown>;
   error?: never;
 }
 


### PR DESCRIPTION
Hi :wave:

The published types for `D1Result` currently have meta defined as any, and error defined as never:
https://github.com/cloudflare/workerd/blob/713d9824a4cbc988d6a622813a3087b6a894650f/types/defines/d1.d.ts#L1-L6
This PR aims to clean them up, based on the binding types:
https://github.com/cloudflare/workerd/blob/713d9824a4cbc988d6a622813a3087b6a894650f/src/cloudflare/internal/d1-api.ts#L9-L14
the binding mapper function:
https://github.com/cloudflare/workerd/blob/713d9824a4cbc988d6a622813a3087b6a894650f/src/cloudflare/internal/d1-api.ts#L302-L316
the client API docs:
https://developers.cloudflare.com/d1/platform/client-api/#return-object
and Q5 in the pricing FAQ:
https://developers.cloudflare.com/d1/platform/pricing/#frequently-asked-questions

cc @geelen and @mrbbot per `git blame`