### PR TITLE
Account for CR in prepared statements, add tests

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -143,7 +143,7 @@ async function test(storage) {
   )
 
   // Prepared statement with whitespace
-  const whitespace = [' ', '\t', '\n', '\r', '\v', '\f']
+  const whitespace = [' ', '\t', '\n', '\r', '\v', '\f', '\r\n']
 
   for (const char of whitespace) {
     const prepared = sql.prepare(`SELECT 1;${char}`);

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -142,6 +142,29 @@ async function test(storage) {
     'Error: Wrong number of parameter bindings for SQL query.'
   )
 
+  // Prepared statement with whitespace
+  const preparedWithSpace = sql.prepare('SELECT 1; ')
+  const resultPreparedWithSpace = [...preparedWithSpace()]
+
+  const preparedWithCr = sql.prepare('SELECT 1;\r')
+  const resultPreparedWithCr = [...preparedWithCr()]
+
+  const preparedWithLf = sql.prepare('SELECT 1;\n')
+  const resultPreparedWithLf = [...preparedWithLf()]
+
+  const preparedWithCrlf = sql.prepare('SELECT 1;\r\n')
+  const resultPreparedWithCrlf = [...preparedWithCrlf()]
+
+  assert.equal(resultPreparedWithSpace.length, 1)
+  assert.equal(resultPreparedWithCr.length, 1)
+  assert.equal(resultPreparedWithLf.length, 1)
+  assert.equal(resultPreparedWithCrlf.length, 1)
+
+  // Prepared statement with multiple statements
+  assert.throws(() => {
+    sql.prepare('SELECT 1; SELECT 2;');
+  }, /A prepared SQL statement must contain only one statement./)
+
   // Accessing a hidden _cf_ table
   assert.throws(
     () => sql.exec('CREATE TABLE _cf_invalid (name TEXT)'),

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -143,22 +143,14 @@ async function test(storage) {
   )
 
   // Prepared statement with whitespace
-  const preparedWithSpace = sql.prepare('SELECT 1; ')
-  const resultPreparedWithSpace = [...preparedWithSpace()]
+  const whitespace = [' ', '\t', '\n', '\r', '\v', '\f']
 
-  const preparedWithCr = sql.prepare('SELECT 1;\r')
-  const resultPreparedWithCr = [...preparedWithCr()]
+  for (const char of whitespace) {
+    const prepared = sql.prepare(`SELECT 1;${char}`);
+    const result = [...prepared()]
 
-  const preparedWithLf = sql.prepare('SELECT 1;\n')
-  const resultPreparedWithLf = [...preparedWithLf()]
-
-  const preparedWithCrlf = sql.prepare('SELECT 1;\r\n')
-  const resultPreparedWithCrlf = [...preparedWithCrlf()]
-
-  assert.equal(resultPreparedWithSpace.length, 1)
-  assert.equal(resultPreparedWithCr.length, 1)
-  assert.equal(resultPreparedWithLf.length, 1)
-  assert.equal(resultPreparedWithCrlf.length, 1)
+    assert.equal(result.length, 1)
+  }
 
   // Prepared statement with multiple statements
   assert.throws(() => {

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -387,7 +387,7 @@ kj::Own<sqlite3_stmt> SqliteDatabase::prepareSql(
     SQLITE_REQUIRE(result != nullptr, "SQL code did not contain a statement.", sqlCode);
     auto ownResult = ownSqlite(result);
 
-    while (*tail == ' ' || *tail == '\n') ++tail;
+    while (*tail == ' ' || *tail == '\r' || *tail == '\n') ++tail;
 
     switch (multi) {
       case SINGLE:

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -387,7 +387,7 @@ kj::Own<sqlite3_stmt> SqliteDatabase::prepareSql(
     SQLITE_REQUIRE(result != nullptr, "SQL code did not contain a statement.", sqlCode);
     auto ownResult = ownSqlite(result);
 
-    while (*tail == ' ' || *tail == '\r' || *tail == '\n') ++tail;
+    while (*tail == ' ' || *tail == '\t' || *tail == '\n' || *tail == '\r' || *tail == '\v' || *tail == '\f') ++tail;
 
     switch (multi) {
       case SINGLE:


### PR DESCRIPTION
Closes https://github.com/cloudflare/workerd/issues/1300

This PR adds `\r` into the logic that makes sure there is nothing more than whitespace at the end of a prepared statement, otherwise it will throw an error indicating that a prepared statement can only contain one statement.

Accompanying tests have been added to make sure that spaces, CR, LF and CRLF are accepted as whitespace as well that multiple statements are rejected.