### PR TITLE
Use shared linkage for benchmarks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,9 @@ jobs:
         # Exclude large benchmarking binaries created in debug and asan configurations to avoid
         # running out of disk space on the runner (nominally 14GB). We typically have two copies
         # of generated artifacts: one under bazel output-base and one in the bazel disk cache.
-        if: contains(matrix.config.suffix, 'debug') || contains(matrix.config.suffix, 'asan')
+        # This should not be needed on Linux, where we can use shared linkage so binary sizes are
+        # much less of an issue.
+        if: matrix.os.name != 'linux' && (contains(matrix.config.suffix, 'debug') || contains(matrix.config.suffix, 'asan'))
         shell: bash
         run: |
           cat <<EOF >> .bazelrc

--- a/build/wd_cc_benchmark.bzl
+++ b/build/wd_cc_benchmark.bzl
@@ -12,6 +12,13 @@ def wd_cc_benchmark(
     native.cc_binary(
         name = name,
         defines = ["WD_IS_BENCHMARK"],
+        # Use shared linkage for benchmarks, matching the approach used for tests. Unfortunately,
+        # bazel does not support shared linkage on macOS and it is broken on Windows, so only
+        # enable this on Linux.
+        linkstatic = select({
+          "@platforms//os:linux": 0,
+          "//conditions:default": 1,
+        }),
         linkopts = linkopts + select({
           "@//:use_dead_strip": ["-Wl,-dead_strip"],
           "//conditions:default": [""],


### PR DESCRIPTION
We already use shared linkage for tests – `cc_test` uses shared linkage by default. This allows us to compile benchmark binaries for CI debug/ASAN builds, which would otherwise be prohibitively large.