### PR TITLE
Zero out raw key data when freed

### DIFF
--- a/src/workerd/api/crypto-impl-aes.c++
+++ b/src/workerd/api/crypto-impl-aes.c++
@@ -166,7 +166,7 @@ private:
   }
 
 protected:
-  kj::Array<kj::byte> keyData;
+  ZeroOnFree keyData;
   CryptoKey::AesKeyAlgorithm keyAlgorithm;
 };
 
@@ -563,7 +563,7 @@ private:
     auto cipherContext = makeCipherContext();
     // For CTR, it really does not matter whether we are encrypting or decrypting, so set enc to 0.
     JSG_REQUIRE(EVP_CipherInit_ex(cipherContext.get(), cipher, nullptr,
-        keyData.asBytes().begin(), counter.asBytes().begin(), 0),
+        keyData.asPtr().asBytes().begin(), counter.asBytes().begin(), 0),
         InternalDOMOperationError, "Error doing ", getAlgorithmName(), " encrypt/decrypt",
         internalDescribeOpensslErrors());
 

--- a/src/workerd/api/crypto-impl-hkdf.c++
+++ b/src/workerd/api/crypto-impl-hkdf.c++
@@ -63,7 +63,7 @@ private:
            CRYPTO_memcmp(keyData.begin(), other.begin(), keyData.size()) == 0;
   }
 
-  kj::Array<kj::byte> keyData;
+  ZeroOnFree keyData;
   CryptoKey::KeyAlgorithm keyAlgorithm;
 };
 

--- a/src/workerd/api/crypto-impl-hmac.c++
+++ b/src/workerd/api/crypto-impl-hmac.c++
@@ -93,7 +93,7 @@ private:
            CRYPTO_memcmp(keyData.begin(), other.begin(), keyData.size()) == 0;
   }
 
-  kj::Array<kj::byte> keyData;
+  ZeroOnFree keyData;
   CryptoKey::HmacKeyAlgorithm keyAlgorithm;
 };
 

--- a/src/workerd/api/crypto-impl-pbkdf2.c++
+++ b/src/workerd/api/crypto-impl-pbkdf2.c++
@@ -46,7 +46,7 @@ private:
         "PBKDF2 iteration counts above 100000 are not supported (requested ", iterations, ").");
 
     auto output = kj::heapArray<kj::byte>(length / 8);
-    OSSLCALL(PKCS5_PBKDF2_HMAC(keyData.asChars().begin(), keyData.size(),
+    OSSLCALL(PKCS5_PBKDF2_HMAC(keyData.asPtr().asChars().begin(), keyData.size(),
                                salt.begin(), salt.size(),
                                iterations, hashType, output.size(), output.begin()));
     return kj::mv(output);
@@ -76,7 +76,7 @@ private:
            CRYPTO_memcmp(keyData.begin(), other.begin(), keyData.size()) == 0;
   }
 
-  kj::Array<kj::byte> keyData;
+  ZeroOnFree keyData;
   CryptoKey::KeyAlgorithm keyAlgorithm;
 };
 

--- a/src/workerd/api/crypto-impl.c++
+++ b/src/workerd/api/crypto-impl.c++
@@ -206,4 +206,8 @@ bool CryptoKey::Impl::equals(const kj::Array<kj::byte>& other) const {
   KJ_FAIL_REQUIRE("Unable to compare raw key material for this key");
 }
 
+ZeroOnFree::~ZeroOnFree() noexcept(false) {
+  OPENSSL_cleanse(inner.begin(), inner.size());
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/node/crypto-keys.c++
+++ b/src/workerd/api/node/crypto-keys.c++
@@ -51,7 +51,7 @@ public:
   }
 
 private:
-  kj::Array<kj::byte> keyData;
+  ZeroOnFree keyData;
 };
 }  // namespace
 


### PR DESCRIPTION
For various `CryptoKey::Impl`s we use a `kj::Array<kj::byte>` internally to store the raw key data in memory. When these structures are freed, we really ought to be zeroing out that memory before returning it.

This, of course, does not fully guarantee that the all copies of the key data in memory are zeroed. If the CryptoKey is exported, for example, the exported copy may still exist. Rather, this just ensures that the internal storage used by the various `CryptoKey::Impl`s are zeroed out