### PR TITLE
webgpu: implement more api objects related to rendering

### DIFF
--- a/src/workerd/api/gpu/gpu-bindgroup-layout.c++
+++ b/src/workerd/api/gpu/gpu-bindgroup-layout.c++
@@ -25,9 +25,15 @@ wgpu::BufferBindingType parseBufferBindingType(kj::StringPtr bType) {
 wgpu::BufferBindingLayout parseBufferBindingLayout(GPUBufferBindingLayout& buffer) {
   wgpu::BufferBindingLayout l;
 
+  // the Dawn default here is Undefined, so we stick with what's in the spec
   l.type = parseBufferBindingType(buffer.type.orDefault([] { return "uniform"_kj; }));
-  l.hasDynamicOffset = buffer.hasDynamicOffset.orDefault(false);
-  l.minBindingSize = buffer.minBindingSize.orDefault(0);
+
+  KJ_IF_SOME(hasDynamicOffset, buffer.hasDynamicOffset) {
+    l.hasDynamicOffset = hasDynamicOffset;
+  }
+  KJ_IF_SOME(minBindingSize, buffer.minBindingSize) {
+    l.minBindingSize = minBindingSize;
+  }
 
   return kj::mv(l);
 }

--- a/src/workerd/api/gpu/gpu-bindgroup-layout.c++
+++ b/src/workerd/api/gpu/gpu-bindgroup-layout.c++
@@ -23,19 +23,19 @@ wgpu::BufferBindingType parseBufferBindingType(kj::StringPtr bType) {
 }
 
 wgpu::BufferBindingLayout parseBufferBindingLayout(GPUBufferBindingLayout& buffer) {
-  wgpu::BufferBindingLayout l;
+  wgpu::BufferBindingLayout layout;
 
   // the Dawn default here is Undefined, so we stick with what's in the spec
-  l.type = parseBufferBindingType(buffer.type.orDefault([] { return "uniform"_kj; }));
+  layout.type = parseBufferBindingType(buffer.type.orDefault([] { return "uniform"_kj; }));
 
   KJ_IF_SOME(hasDynamicOffset, buffer.hasDynamicOffset) {
-    l.hasDynamicOffset = hasDynamicOffset;
+    layout.hasDynamicOffset = hasDynamicOffset;
   }
   KJ_IF_SOME(minBindingSize, buffer.minBindingSize) {
-    l.minBindingSize = minBindingSize;
+    layout.minBindingSize = minBindingSize;
   }
 
-  return kj::mv(l);
+  return kj::mv(layout);
 }
 
 wgpu::SamplerBindingType parseSamplerBindingType(kj::StringPtr bType) {
@@ -55,10 +55,9 @@ wgpu::SamplerBindingType parseSamplerBindingType(kj::StringPtr bType) {
 }
 
 wgpu::SamplerBindingLayout parseSamplerBindingLayout(GPUSamplerBindingLayout& sampler) {
-  wgpu::SamplerBindingLayout s;
-  s.type = parseSamplerBindingType(sampler.type.orDefault([] { return "filtering"_kj; }));
-
-  return kj::mv(s);
+  wgpu::SamplerBindingLayout layout;
+  layout.type = parseSamplerBindingType(sampler.type.orDefault([] { return "filtering"_kj; }));
+  return kj::mv(layout);
 }
 
 wgpu::TextureSampleType parseTextureSampleType(kj::StringPtr sType) {
@@ -86,49 +85,50 @@ wgpu::TextureSampleType parseTextureSampleType(kj::StringPtr sType) {
 }
 
 wgpu::TextureBindingLayout parseTextureBindingLayout(GPUTextureBindingLayout& texture) {
-  wgpu::TextureBindingLayout t;
-  t.sampleType = parseTextureSampleType(texture.sampleType.orDefault([] { return "float"_kj; }));
-  t.viewDimension =
+  wgpu::TextureBindingLayout layout;
+  layout.sampleType =
+      parseTextureSampleType(texture.sampleType.orDefault([] { return "float"_kj; }));
+  layout.viewDimension =
       parseTextureViewDimension(texture.viewDimension.orDefault([] { return "2d"_kj; }));
-  t.multisampled = texture.multisampled.orDefault(false);
+  layout.multisampled = texture.multisampled.orDefault(false);
 
-  return kj::mv(t);
+  return kj::mv(layout);
 }
 
 wgpu::StorageTextureBindingLayout
 parseStorageTextureBindingLayout(GPUStorageTextureBindingLayout& storage) {
 
-  wgpu::StorageTextureBindingLayout s;
-  s.access = parseStorageAccess(storage.access.orDefault([] { return "write-only"_kj; }));
-  s.format = parseTextureFormat(storage.format);
-  s.viewDimension =
+  wgpu::StorageTextureBindingLayout layout;
+  layout.access = parseStorageAccess(storage.access.orDefault([] { return "write-only"_kj; }));
+  layout.format = parseTextureFormat(storage.format);
+  layout.viewDimension =
       parseTextureViewDimension(storage.viewDimension.orDefault([] { return "2d"_kj; }));
 
-  return kj::mv(s);
+  return kj::mv(layout);
 }
 
 wgpu::BindGroupLayoutEntry parseBindGroupLayoutEntry(GPUBindGroupLayoutEntry& entry) {
-  wgpu::BindGroupLayoutEntry e;
-  e.binding = entry.binding;
-  e.visibility = static_cast<wgpu::ShaderStage>(entry.visibility);
+  wgpu::BindGroupLayoutEntry layoutEntry;
+  layoutEntry.binding = entry.binding;
+  layoutEntry.visibility = static_cast<wgpu::ShaderStage>(entry.visibility);
 
   KJ_IF_SOME(buffer, entry.buffer) {
-    e.buffer = parseBufferBindingLayout(buffer);
+    layoutEntry.buffer = parseBufferBindingLayout(buffer);
   }
 
   KJ_IF_SOME(sampler, entry.sampler) {
-    e.sampler = parseSamplerBindingLayout(sampler);
+    layoutEntry.sampler = parseSamplerBindingLayout(sampler);
   }
 
   KJ_IF_SOME(texture, entry.texture) {
-    e.texture = parseTextureBindingLayout(texture);
+    layoutEntry.texture = parseTextureBindingLayout(texture);
   }
 
   KJ_IF_SOME(storage, entry.storageTexture) {
-    e.storageTexture = parseStorageTextureBindingLayout(storage);
+    layoutEntry.storageTexture = parseStorageTextureBindingLayout(storage);
   }
 
-  return kj::mv(e);
+  return kj::mv(layoutEntry);
 };
 
 } // namespace workerd::api::gpu

--- a/src/workerd/api/gpu/gpu-compute-pass-encoder.c++
+++ b/src/workerd/api/gpu/gpu-compute-pass-encoder.c++
@@ -29,14 +29,14 @@ void GPUComputePassEncoder::setBindGroup(
     jsg::Optional<jsg::Sequence<GPUBufferDynamicOffset>> dynamicOffsets) {
   wgpu::BindGroup bg = nullptr;
 
-  KJ_IF_SOME (bgroup, bindGroup) {
+  KJ_IF_SOME(bgroup, bindGroup) {
     bg = *bgroup;
   }
 
   uint32_t* offsets = nullptr;
   uint32_t num_offsets = 0;
 
-  KJ_IF_SOME (dos, dynamicOffsets) {
+  KJ_IF_SOME(dos, dynamicOffsets) {
     offsets = dos.begin();
     num_offsets = dos.size();
   }

--- a/src/workerd/api/gpu/gpu-device.c++
+++ b/src/workerd/api/gpu/gpu-device.c++
@@ -168,20 +168,34 @@ wgpu::MipmapFilterMode parseMipmapFilterMode(kj::StringPtr mode) {
 jsg::Ref<GPUSampler> GPUDevice::createSampler(GPUSamplerDescriptor descriptor) {
   wgpu::SamplerDescriptor desc{};
 
-  desc.addressModeU =
-      parseAddressMode(descriptor.addressModeU.orDefault([] { return "clamp-to-edge"_kj; }));
-  desc.addressModeV =
-      parseAddressMode(descriptor.addressModeV.orDefault([] { return "clamp-to-edge"_kj; }));
-  desc.addressModeW =
-      parseAddressMode(descriptor.addressModeW.orDefault([] { return "clamp-to-edge"_kj; }));
-  desc.magFilter = parseFilterMode(descriptor.magFilter.orDefault([] { return "nearest"_kj; }));
-  desc.minFilter = parseFilterMode(descriptor.minFilter.orDefault([] { return "nearest"_kj; }));
-  desc.mipmapFilter =
-      parseMipmapFilterMode(descriptor.mipmapFilter.orDefault([] { return "nearest"_kj; }));
-  desc.lodMinClamp = descriptor.lodMinClamp.orDefault(0);
-  desc.lodMaxClamp = descriptor.lodMaxClamp.orDefault(32);
+  KJ_IF_SOME(addressModeU, descriptor.addressModeU) {
+    desc.addressModeU = parseAddressMode(addressModeU);
+  }
+  KJ_IF_SOME(addressModeV, descriptor.addressModeV) {
+    desc.addressModeV = parseAddressMode(addressModeV);
+  }
+  KJ_IF_SOME(addressModeW, descriptor.addressModeW) {
+    desc.addressModeW = parseAddressMode(addressModeW);
+  }
+  KJ_IF_SOME(magFilter, descriptor.magFilter) {
+    desc.magFilter = parseFilterMode(magFilter);
+  }
+  KJ_IF_SOME(minFilter, descriptor.minFilter) {
+    desc.minFilter = parseFilterMode(minFilter);
+  }
+  KJ_IF_SOME(mipmapFilter, descriptor.mipmapFilter) {
+    desc.mipmapFilter = parseMipmapFilterMode(mipmapFilter);
+  }
+  KJ_IF_SOME(lodMinClamp, descriptor.lodMinClamp) {
+    desc.lodMinClamp = lodMinClamp;
+  }
+  KJ_IF_SOME(lodMaxClamp, descriptor.lodMaxClamp) {
+    desc.lodMaxClamp = lodMaxClamp;
+  }
   desc.compare = parseCompareFunction(descriptor.compare);
-  desc.maxAnisotropy = descriptor.maxAnisotropy.orDefault(1);
+  KJ_IF_SOME(maxAnisotropy, descriptor.maxAnisotropy) {
+    desc.maxAnisotropy = maxAnisotropy;
+  }
 
   KJ_IF_SOME(label, descriptor.label) {
     desc.label = label.cStr();
@@ -255,11 +269,18 @@ struct ParsedRenderPipelineDescriptor {
 
 void parseStencilFaceState(wgpu::StencilFaceState& out, jsg::Optional<GPUStencilFaceState>& in) {
   KJ_IF_SOME(stencilFront, in) {
-    out.compare = parseCompareFunction(stencilFront.compare.orDefault([] { return "always"_kj; }));
-    out.failOp = parseStencilOperation(stencilFront.failOp.orDefault([] { return "keep"_kj; }));
-    out.depthFailOp =
-        parseStencilOperation(stencilFront.depthFailOp.orDefault([] { return "keep"_kj; }));
-    out.passOp = parseStencilOperation(stencilFront.passOp.orDefault([] { return "keep"_kj; }));
+    KJ_IF_SOME(compare, stencilFront.compare) {
+      out.compare = parseCompareFunction(compare);
+    }
+    KJ_IF_SOME(failOp, stencilFront.failOp) {
+      out.failOp = parseStencilOperation(failOp);
+    }
+    KJ_IF_SOME(depthFailOp, stencilFront.depthFailOp) {
+      out.depthFailOp = parseStencilOperation(depthFailOp);
+    }
+    KJ_IF_SOME(passOp, stencilFront.passOp) {
+      out.passOp = parseStencilOperation(passOp);
+    }
   }
 }
 
@@ -308,17 +329,18 @@ parseRenderPipelineDescriptor(GPURenderPipelineDescriptor& descriptor) {
       parsedDesc.desc.nextInChain = parsedDesc.depthClip;
     }
 
-    parsedDesc.desc.primitive.topology =
-        parsePrimitiveTopology(primitive.topology.orDefault([] { return "triangle-list"_kj; }));
-
+    KJ_IF_SOME(topology, primitive.topology) {
+      parsedDesc.desc.primitive.topology = parsePrimitiveTopology(topology);
+    }
     KJ_IF_SOME(indexFormat, primitive.stripIndexFormat) {
       parsedDesc.desc.primitive.stripIndexFormat = parseIndexFormat(indexFormat);
     }
-
-    parsedDesc.desc.primitive.frontFace =
-        parseFrontFace(primitive.frontFace.orDefault([] { return "ccw"_kj; }));
-    parsedDesc.desc.primitive.cullMode =
-        parseCullMode(primitive.cullMode.orDefault([] { return "none"_kj; }));
+    KJ_IF_SOME(frontFace, primitive.frontFace) {
+      parsedDesc.desc.primitive.frontFace = parseFrontFace(frontFace);
+    }
+    KJ_IF_SOME(cullMode, primitive.cullMode) {
+      parsedDesc.desc.primitive.cullMode = parseCullMode(cullMode);
+    }
   }
 
   KJ_IF_SOME(depthStencil, descriptor.depthStencil) {
@@ -329,21 +351,36 @@ parseRenderPipelineDescriptor(GPURenderPipelineDescriptor& descriptor) {
     parseStencilFaceState(depthStencilState->stencilFront, depthStencil.stencilFront);
     parseStencilFaceState(depthStencilState->stencilBack, depthStencil.stencilBack);
 
-    depthStencilState->stencilReadMask = depthStencil.stencilReadMask.orDefault(0xFFFFFFFF);
-    depthStencilState->stencilWriteMask = depthStencil.stencilWriteMask.orDefault(0xFFFFFFFF);
-    depthStencilState->depthBias = depthStencil.depthBias.orDefault(0);
-    depthStencilState->depthBiasSlopeScale = depthStencil.depthBiasSlopeScale.orDefault(0);
-    depthStencilState->depthBiasClamp = depthStencil.depthBiasClamp.orDefault(0);
+    KJ_IF_SOME(stencilReadMask, depthStencil.stencilReadMask) {
+      depthStencilState->stencilReadMask = stencilReadMask;
+    }
+    KJ_IF_SOME(stencilWriteMask, depthStencil.stencilWriteMask) {
+      depthStencilState->stencilWriteMask = stencilWriteMask;
+    }
+    KJ_IF_SOME(depthBias, depthStencil.depthBias) {
+      depthStencilState->depthBias = depthBias;
+    }
+    KJ_IF_SOME(depthBiasSlopeScale, depthStencil.depthBiasSlopeScale) {
+      depthStencilState->depthBiasSlopeScale = depthBiasSlopeScale;
+    }
+    KJ_IF_SOME(depthBiasClamp, depthStencil.depthBiasClamp) {
+      depthStencilState->depthBiasClamp = depthBiasClamp;
+    }
 
     parsedDesc.stencilState = kj::mv(depthStencilState);
     parsedDesc.desc.depthStencil = parsedDesc.stencilState;
   }
 
   KJ_IF_SOME(multisample, descriptor.multisample) {
-    parsedDesc.desc.multisample.count = multisample.count.orDefault(1);
-    parsedDesc.desc.multisample.mask = multisample.mask.orDefault(0xFFFFFFFF);
-    parsedDesc.desc.multisample.alphaToCoverageEnabled =
-        multisample.alphaToCoverageEnabled.orDefault(false);
+    KJ_IF_SOME(count, multisample.count) {
+      parsedDesc.desc.multisample.count = count;
+    }
+    KJ_IF_SOME(mask, multisample.mask) {
+      parsedDesc.desc.multisample.mask = mask;
+    }
+    KJ_IF_SOME(alphaToCoverageEnabled, multisample.alphaToCoverageEnabled) {
+      parsedDesc.desc.multisample.alphaToCoverageEnabled = alphaToCoverageEnabled;
+    }
   }
 
   KJ_IF_SOME(fragment, descriptor.fragment) {

--- a/src/workerd/api/gpu/gpu-utils.c++
+++ b/src/workerd/api/gpu/gpu-utils.c++
@@ -7,6 +7,8 @@
 
 namespace workerd::api::gpu {
 
+// TODO(soon): use a static std::map for most of these functions, as seen
+// in kj::StringPtr CryptoImpl::getAsymmetricKeyType().
 wgpu::FeatureName parseFeatureName(GPUFeatureName& str) {
   if (str == "depth-clip-control") {
     return wgpu::FeatureName::DepthClipControl;
@@ -927,6 +929,190 @@ wgpu::StencilOperation parseStencilOperation(kj::StringPtr operation) {
   }
 
   JSG_FAIL_REQUIRE(TypeError, "unknown stencil operation: ", operation);
+}
+
+wgpu::VertexStepMode parseVertexStepMode(kj::StringPtr stepMode) {
+  if (stepMode == "vertex") {
+    return wgpu::VertexStepMode::Vertex;
+  }
+
+  if (stepMode == "instance") {
+    return wgpu::VertexStepMode::Instance;
+  }
+
+  JSG_FAIL_REQUIRE(TypeError, "unknown vertex step mode: ", stepMode);
+}
+
+wgpu::VertexFormat parseVertexFormat(kj::StringPtr format) {
+  if (format == "uint8x2") {
+    return wgpu::VertexFormat::Uint8x2;
+  }
+  if (format == "uint8x4") {
+    return wgpu::VertexFormat::Uint8x4;
+  }
+  if (format == "sint8x2") {
+    return wgpu::VertexFormat::Sint8x2;
+  }
+  if (format == "sint8x4") {
+    return wgpu::VertexFormat::Sint8x2;
+  }
+  if (format == "unorm8x2") {
+    return wgpu::VertexFormat::Unorm8x2;
+  }
+  if (format == "unorm8x4") {
+    return wgpu::VertexFormat::Unorm8x4;
+  }
+  if (format == "snorm8x2") {
+    return wgpu::VertexFormat::Snorm8x2;
+  }
+  if (format == "snorm8x4") {
+    return wgpu::VertexFormat::Snorm8x4;
+  }
+  if (format == "uint16x2") {
+    return wgpu::VertexFormat::Uint16x2;
+  }
+  if (format == "uint16x4") {
+    return wgpu::VertexFormat::Uint16x4;
+  }
+  if (format == "sint16x2") {
+    return wgpu::VertexFormat::Sint16x2;
+  }
+  if (format == "sint16x4") {
+    return wgpu::VertexFormat::Sint16x4;
+  }
+  if (format == "unorm16x2") {
+    return wgpu::VertexFormat::Unorm16x2;
+  }
+  if (format == "unorm16x4") {
+    return wgpu::VertexFormat::Unorm16x4;
+  }
+  if (format == "snorm16x2") {
+    return wgpu::VertexFormat::Snorm16x2;
+  }
+  if (format == "snorm16x4") {
+    return wgpu::VertexFormat::Snorm16x4;
+  }
+  if (format == "float16x2") {
+    return wgpu::VertexFormat::Float16x2;
+  }
+  if (format == "float16x4") {
+    return wgpu::VertexFormat::Float16x4;
+  }
+  if (format == "float32") {
+    return wgpu::VertexFormat::Float32;
+  }
+  if (format == "float32x2") {
+    return wgpu::VertexFormat::Float32x2;
+  }
+  if (format == "float32x3") {
+    return wgpu::VertexFormat::Float32x3;
+  }
+  if (format == "float32x4") {
+    return wgpu::VertexFormat::Float32x4;
+  }
+  if (format == "uint32") {
+    return wgpu::VertexFormat::Uint32;
+  }
+  if (format == "uint32x2") {
+    return wgpu::VertexFormat::Uint32x2;
+  }
+  if (format == "uint32x3") {
+    return wgpu::VertexFormat::Uint32x3;
+  }
+  if (format == "uint32x4") {
+    return wgpu::VertexFormat::Uint32x4;
+  }
+  if (format == "sint32") {
+    return wgpu::VertexFormat::Sint32;
+  }
+  if (format == "sint32x2") {
+    return wgpu::VertexFormat::Sint32x2;
+  }
+  if (format == "sint32x3") {
+    return wgpu::VertexFormat::Sint32x3;
+  }
+  if (format == "sint32x4") {
+    return wgpu::VertexFormat::Sint32x4;
+  }
+
+  JSG_FAIL_REQUIRE(TypeError, "unknown vertex format: ", format);
+}
+
+wgpu::BlendFactor parseBlendFactor(kj::StringPtr factor) {
+
+  if (factor == "zero") {
+    return wgpu::BlendFactor::Zero;
+  }
+
+  if (factor == "one") {
+    return wgpu::BlendFactor::One;
+  }
+
+  if (factor == "src") {
+    return wgpu::BlendFactor::Src;
+  }
+
+  if (factor == "one-minus-src") {
+    return wgpu::BlendFactor::OneMinusSrc;
+  }
+
+  if (factor == "src-alpha") {
+    return wgpu::BlendFactor::SrcAlpha;
+  }
+
+  if (factor == "one-minus-src-alpha") {
+    return wgpu::BlendFactor::OneMinusSrcAlpha;
+  }
+
+  if (factor == "dst") {
+    return wgpu::BlendFactor::Dst;
+  }
+
+  if (factor == "one-minus-dst") {
+    return wgpu::BlendFactor::OneMinusDst;
+  }
+
+  if (factor == "dst-alpha") {
+    return wgpu::BlendFactor::DstAlpha;
+  }
+
+  if (factor == "one-minus-dst-alpha") {
+    return wgpu::BlendFactor::OneMinusDstAlpha;
+  }
+
+  if (factor == "src-alpha-saturated") {
+    return wgpu::BlendFactor::SrcAlphaSaturated;
+  }
+
+  if (factor == "constant") {
+    return wgpu::BlendFactor::Constant;
+  }
+
+  if (factor == "one-minus-constant") {
+    return wgpu::BlendFactor::OneMinusConstant;
+  }
+
+  JSG_FAIL_REQUIRE(TypeError, "unknown blend factor: ", factor);
+}
+
+wgpu::BlendOperation parseBlendOperation(kj::StringPtr operation) {
+  if (operation == "add") {
+    return wgpu::BlendOperation::Add;
+  }
+  if (operation == "subtract") {
+    return wgpu::BlendOperation::Subtract;
+  }
+  if (operation == "reverse-subtract") {
+    return wgpu::BlendOperation::ReverseSubtract;
+  }
+  if (operation == "min") {
+    return wgpu::BlendOperation::Min;
+  }
+  if (operation == "max") {
+    return wgpu::BlendOperation::Max;
+  }
+
+  JSG_FAIL_REQUIRE(TypeError, "unknown blend operation: ", operation);
 }
 
 } // namespace workerd::api::gpu

--- a/src/workerd/api/gpu/gpu-utils.h
+++ b/src/workerd/api/gpu/gpu-utils.h
@@ -146,5 +146,9 @@ wgpu::IndexFormat parseIndexFormat(kj::StringPtr format);
 wgpu::FrontFace parseFrontFace(kj::StringPtr frontFace);
 wgpu::CullMode parseCullMode(kj::StringPtr mode);
 wgpu::StencilOperation parseStencilOperation(kj::StringPtr operation);
+wgpu::VertexStepMode parseVertexStepMode(kj::StringPtr stepMode);
+wgpu::VertexFormat parseVertexFormat(kj::StringPtr format);
+wgpu::BlendFactor parseBlendFactor(kj::StringPtr factor);
+wgpu::BlendOperation parseBlendOperation(kj::StringPtr operation);
 
 } // namespace workerd::api::gpu

--- a/src/workerd/api/gpu/webgpu-windowless-test.js
+++ b/src/workerd/api/gpu/webgpu-windowless-test.js
@@ -106,6 +106,21 @@ export class DurableObjectExample {
     });
     ok(renderPipeline);
 
+    const encoder = device.createCommandEncoder();
+
+    const renderPassDescriptor = {
+      colorAttachments: [
+        {
+          clearValue: { r: 0.1, g: 0.2, b: 0.3, a: 1.0 },
+          loadOp: "clear",
+          storeOp: "store",
+          view: textureView,
+        },
+      ],
+    };
+    const renderPass = encoder.beginRenderPass(renderPassDescriptor);
+    ok(renderPass);
+
     return new Response("OK");
   }
 }


### PR DESCRIPTION
- Rely on Dawn defaults instead of having them in workerd code
- Finished work on parsing RenderPipelineDescriptor.
- Since the above descriptor is parsed on a separate function, we can't rely on stack variables being in scope, so we use an auxiliar object to maintain ownership of allocated objects until we can free them after the Dawn call.