### PR TITLE
Clean up warnings on Windows/with LLVM16

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,16 +5,24 @@ build --build_tag_filters=-off-by-default
 # Enable webgpu
 build --//src/workerd/io:enable_experimental_webgpu=True
 
-# Our dependencies (ICU, zlib, etc.) produce a lot of these warnings, so we disable them.
+# Our dependencies (ICU, zlib, etc.) produce a lot of these warnings, so we disable them. Depending
+# on the clang version, zlib either produces warnings for -Wdeprecated-non-prototype or does not
+# have that option, so disable -Wunknown-warning-option there too.
 build --per_file_copt='external/com_googlesource_chromium_icu@-Wno-ambiguous-reversed-operator,-Wno-deprecated-declarations'
 build --host_per_file_copt='external/com_googlesource_chromium_icu@-Wno-ambiguous-reversed-operator,-Wno-deprecated-declarations'
 build --per_file_copt='external/dawn@-Wno-shorten-64-to-32,-Wno-unneeded-internal-declaration'
 build --host_per_file_copt='external/dawn@-Wno-shorten-64-to-32,-Wno-unneeded-internal-declaration'
+build --per_file_copt='external/zlib@-Wno-unknown-warning-option,-Wno-deprecated-non-prototype'
+build --host_per_file_copt='external/zlib@-Wno-unknown-warning-option,-Wnodeprecated-non-prototype'
 
 # Enable C++20 to support std::unordered_map::contains(). Not sure why this is needed here, V8
 # is supposed to work with C++14.
 build:unix --per_file_copt='external/v8/src/compiler/graph-visualizer.cc@-std=c++20'
 build:windows --per_file_copt='external/v8/src/compiler/graph-visualizer.cc@/std:c++20'
+
+# Need to redefine _WIN32_WINNT to build dawn on Windows
+build:windows --per_file_copt='external/dawn@-Wno-macro-redefined'
+build:windows --host_per_file_copt='external/dawn@-Wno-macro-redefined'
 
 # Speed up sandboxed compilation, particularly on I/O-constrained and non-Linux systems
 # https://bazel.build/reference/command-line-reference#flag--reuse_sandbox_directories
@@ -111,10 +119,6 @@ build:unix --cxxopt='-Wno-sign-compare' --host_cxxopt='-Wno-sign-compare'
 build:unix --cxxopt='-Wno-unused-parameter' --host_cxxopt='-Wno-unused-parameter'
 build:unix --cxxopt='-Wno-missing-field-initializers' --host_cxxopt='-Wno-missing-field-initializers'
 build:unix --cxxopt='-Wno-ignored-qualifiers' --host_cxxopt='-Wno-ignored-qualifiers'
-
-# Temporary workaround for zlib warnings and mac compilation, should no longer be needed with next
-# zlib release (https://github.com/madler/zlib/issues/633)
-build:unix --per_file_copt='external/zlib[~/].*\.c@-std=c90' --host_per_file_copt='external/zlib[~/].*\.c@-std=c90'
 
 build:linux --config=unix
 build:macos --config=unix

--- a/build/BUILD.dawn
+++ b/build/BUILD.dawn
@@ -798,10 +798,9 @@ cc_library(
     name = "dawn_native_windows",
     srcs = DAWN_SRCS + DAWN_DIRECTX_SRCS,
     hdrs = DAWN_HDRS,
-    defines = [
+    local_defines = [
         # From dawn/src/dawn/common/BUILD.gn:internal_config
         "DAWN_ENABLE_BACKEND_D3D12",
-        "WIN32_LEAN_AND_MEAN",
         "_WIN32_WINNT=0x0A00",
     ],
     includes = [


### PR DESCRIPTION
We have ~500 warnings on Windows CI runs, this should fix most of them.
- We need to redefine `_WIN32_WINNT` to have DirectX12 available when building dawn (unlike WIN32_LEAN_AND_MEAN, which is already defined in .bazelrc). Disable `-Wmacro-redefined` when building dawn on Windows.
- Adjust zlib warning settings since some workarounds are no longer needed with version 1.3, but there is also a new warning in newer clang/LLVM versions