### PR TITLE
Fix Node-like `console.log()`ing when spawning from Node

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1674,6 +1674,7 @@ void Worker::handleLog(jsg::Lock& js, ConsoleMode consoleMode, LogLevel level,
     args[length] = v8::Boolean::New(js.v8Isolate, colors);
     auto formatted = js.toString(jsg::check(formatLog->Call(context, recv, length + 1, args)));
     fprintf(fd, "%s\n", formatted.cStr());
+    fflush(fd);
   }
 }
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1649,7 +1649,7 @@ void Worker::handleLog(jsg::Lock& js, ConsoleMode consoleMode, LogLevel level,
     KJ_LOG(INFO, "console.log()", message());
   } else {
     // Write to stdio if allowed by console mode
-    static bool PERMITS_COLOR = permitsColor();
+    static ColorMode COLOR_MODE = permitsColor();
 #if _WIN32
     static bool STDOUT_TTY = _isatty(_fileno(stdout));
     static bool STDERR_TTY = _isatty(_fileno(stderr));
@@ -1662,7 +1662,8 @@ void Worker::handleLog(jsg::Lock& js, ConsoleMode consoleMode, LogLevel level,
     auto useStderr = level >= LogLevel::WARN;
     auto fd  = useStderr ? stderr     : stdout;
     auto tty = useStderr ? STDERR_TTY : STDOUT_TTY;
-    auto colors = PERMITS_COLOR && tty;
+    auto colors = COLOR_MODE == ColorMode::ENABLED ||
+      (COLOR_MODE == ColorMode::ENABLED_IF_TTY && tty);
 
     // TODO(now): does this need to run within a handle scope?
     auto registry = jsg::ModuleRegistry::from(js);

--- a/src/workerd/util/color-util.h
+++ b/src/workerd/util/color-util.h
@@ -9,17 +9,29 @@
 
 namespace workerd {
 
+enum class ColorMode {
+  // Always output colors to the console
+  ENABLED,
+  // Output colors to the console if it's a TTY
+  ENABLED_IF_TTY,
+  // Never output colors to the console
+  DISABLED
+};
+
 // Returns whether we can output color to the console. Even if this returns `true`,
 // we'll only write color codes if the output file is a TTY.
 // TODO(someday): adopt more of Node.js's checks:
 //  https://github.com/nodejs/node/blob/ac2a68c/lib/internal/tty.js#L106
-static bool permitsColor() {
+static ColorMode permitsColor() {
   const char* forceColorValue = getenv("FORCE_COLOR");
   if (forceColorValue != nullptr) {
     auto f = kj::StringPtr(forceColorValue);
-    return f == "" || f == "1" || f == "2" || f == "3" || f == "true";
+    auto enabled = f == "" || f == "1" || f == "2" || f == "3" || f == "true";
+    return enabled ? ColorMode::ENABLED : ColorMode::DISABLED;
+  } else {
+    auto enabled = getenv("NO_COLOR") == nullptr && getenv("CI") == nullptr;
+    return enabled ? ColorMode::ENABLED_IF_TTY : ColorMode::DISABLED;
   }
-  return getenv("NO_COLOR") == nullptr && getenv("CI") == nullptr;
 }
 
 }


### PR DESCRIPTION
Hey! 👋 This PR addresses a couple of issues from #1294 that we encountered when integrating this with Wrangler.

When spawning `workerd` from Node, we configure [`stdout` and `stderr` as `pipe`s](https://nodejs.org/api/child_process.html#optionsstdio), rather than inheriting stdio from the parent. This allows us to intercept output and explicitly log it with `console.log()` _(Wrangler uses a library called Ink for rendering its interface. Ink monkeypatches `console` methods so UI elements remain in the correct place after logging)_. Unfortunately, using `pipe` requires explicit flushes on `stdout`/`stderr` before data is delivered. Additionally, `pipe` isn't a TTY, so logs would never use colour. This PR adds explicit flushes, and always logs in colour when the `FORCE_COLOR` environment variable is set, regardless of TTY state (Node's behaviour).