### PR TITLE
Enable windows-debug github runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,6 @@ jobs:
           # Skip the matrix generated Windows non-debug config to use the one added above.
           - os:     { name : windows, image : windows-2022 }
             config: { suffix: '', bazel-args: '' }
-          # Skip the matrix generated Windows debug config due to //src/workerd/jsg:string-test
-          # for Windows debug, probably caused by macro mis-configuration (TODO: fix).
-          - os:     { name : windows, image : windows-2022 }
-            config: { suffix: -debug, bazel-args: --config=debug }
       fail-fast: false
     runs-on: ${{ matrix.os.image }}
     name: test (${{ matrix.os.name }}${{ matrix.config.suffix }})

--- a/src/workerd/jsg/string-test.c++
+++ b/src/workerd/jsg/string-test.c++
@@ -355,13 +355,8 @@ struct UsvStringContext: public jsg::Object, public jsg::ContextGlobal {
     return kj::mv(str).orDefault(usv("undefined"));
   }
 
-  UsvStringPtr testUsvPtr(jsg::Optional<UsvString> str) {
-    return kj::mv(str).orDefault(usv("undefined"));
-  }
-
   JSG_RESOURCE_TYPE(UsvStringContext) {
     JSG_METHOD(testUsv);
-    JSG_METHOD(testUsvPtr);
   }
 };
 JSG_DECLARE_ISOLATE_TYPE(UsvStringIsolate, UsvStringContext);
@@ -370,7 +365,6 @@ KJ_TEST("JavaScript USVStrings") {
   Evaluator<UsvStringContext, UsvStringIsolate> e(v8System);
 
   e.expectEval("testUsv('hello')", "string", "hello");
-  e.expectEval("testUsvPtr('hello')", "string", "hello");
   e.expectEval(u8"testUsv('hello\xd8')", "string", u8"hello�");
   e.expectEval("testUsv(1)", "string", "1");
   e.expectEval("testUsv(false)", "string", "false");


### PR DESCRIPTION
The windows-debug config exposed a UAF for the `testUsvPtr()` test in
the `KJ_TEST("JavaScript USVStrings")` since the debug build on Windows
overwrites freed memory which shows up as corruption if used after
free. The issue is described in #1334.

Fix: https://github.com/cloudflare/workerd/issues/1334
Test: `bazel test -c dbg --cache_test_results=no //...`