### PR TITLE
Revised the extension sample README.md

### DIFF
--- a/samples/extensions/README.md
+++ b/samples/extensions/README.md
@@ -20,3 +20,72 @@ $ bazel run //src/workerd/server:workerd -- serve $(pwd)/samples/extensions/conf
 $ curl localhost:8080 -X POST -d 'veggie'
 9
 ```
+
+
+## Demonstrated Methods
+
+### Importable Module
+
+#### Usage
+The module `burrito-shop:burrito-shop`, which is defined in the config [burrito-shop.capnp](burrito-shop.capnp), is an importable module.
+
+You can import it as shown below:
+
+```javascript
+import { BurritoShop } from "burrito-shop:burrito-shop";
+```
+
+#### Definition
+This import definition is demonstrated in [burrito-shop.js](burrito-shop.js).
+As shown in 
+
+### Environment Variable (with internal initialization from environment variables)
+
+#### Usage
+
+The module `burrito-shop:binding` is defined in the config [burrito-shop.capnp](burrito-shop.capnp) and is provided as an environment variable.
+
+You can access it as shown below in [worker.js](worker.js) provided the modules name is shop(as defined in the bindings section of [config.capnp](config.capnp)
+
+```javascript
+env.shop
+```
+
+The initialization is demonstrated in [binding.js](binding.js).
+
+##### Definition
+
+- The environment name of `shop` is provided in [config.capnp](config.capnp) with the field `name` located under bindings.
+```
+  bindings = [
+    ( 
+        ...
+        name = "shop"
+        ...
+    )]
+```
+- An environment binding must be marked as internal.
+
+#### Using a exported function that isn't default as the entrypoint
+A default exported entrypoint is not required for binding as long as you define a different entrypoint with `entrypoint = "methodname"`, for example you can define a non-default function as the entrypoint in [config.capnp](config.capnp).
+An example is provided below
+
+In [binding.js](binding.js)
+```javascript
+export function makeMagicBurritoBinding(env) {
+    return new BurritoShop(env.recipes);
+}
+```
+
+In [config.capnp](config.capnp)
+```
+    (
+      name = "shop",
+      wrapped = (
+        ...
+        entrypoint = "makeMagicBurritoBinding"
+        ...
+    )
+```
+
+


### PR DESCRIPTION
I found the example code great, but as there are a few very similarly named files for the extension sample with two different ways of using the burrito-shop, it wasn't clear without a deep look into exactly what was happening or why specific things were defined as they were. 

As such, I put my thoughts into a README.md so the next person doesn't have to build the same mental model from scratch.

Ideally I'd have split this into two different samples, with one being the environment binding and another being the imported module, but I choose to use this as a stepping stone since it's my first PR.