### PR TITLE
Add `wrangler` team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,12 @@
 * @cloudflare/workers-runtime-1 @cloudflare/workers-durable-objects
+.github/workflows/npm.yml @cloudflare/wrangler
+.github/workflows/npm-types.yml @cloudflare/wrangler
+.github/workflows/release.yml @cloudflare/wrangler
+npm/ @cloudflare/wrangler
+build-npm-package.sh @cloudflare/wrangler
+RELEASE.md @cloudflare/wrangler
+package.json @cloudflare/wrangler
+pnpm-lock.yaml @cloudflare/wrangler
+types/ @cloudflare/wrangler
+src/workerd/tools/ @cloudflare/wrangler
+src/workerd/io/compatibility-date.capnp @cloudflare/wrangler

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 .github/workflows/npm-types.yml @cloudflare/wrangler
 .github/workflows/release.yml @cloudflare/wrangler
 npm/ @cloudflare/wrangler
-build-npm-package.sh @cloudflare/wrangler
+build-releases.sh @cloudflare/wrangler
 RELEASE.md @cloudflare/wrangler
 package.json @cloudflare/wrangler
 pnpm-lock.yaml @cloudflare/wrangler


### PR DESCRIPTION
Following the agreed ownership boundaries from https://wiki.cfdata.org/display/WX/Ownership, this ensures that the Wrangler team is able to release `workerd` and `workers-types` to `npm` without requiring approval from the runtime or durable objects teams