### PR TITLE
Extends `IsolateObserver` to include reporting of internal exceptions

### DIFF
--- a/src/workerd/jsg/observer.h
+++ b/src/workerd/jsg/observer.h
@@ -6,6 +6,7 @@
 
 #include <kj/common.h>
 #include <kj/string.h>
+#include <kj/exception.h>
 
 // Forward declare v8::Isolate here, this allows us to avoid including the V8 header and compile
 // some targets without depending on V8.
@@ -37,8 +38,22 @@ struct CompilationObserver {
   }
 };
 
+struct InternalExceptionObserver {
+  virtual ~InternalExceptionObserver() noexcept(false) { }
 
-struct IsolateObserver : public CompilationObserver {
+struct Detail {
+  bool isInternal;
+  bool isFromRemote;
+  bool isDurableObjectReset;
+};
+
+  // Called when an internal exception is created (see makeInternalError).
+  // Used to collect metrics on various internal error conditions.
+  virtual void reportInternalException(const kj::Exception&, Detail detail) { }
+};
+
+struct IsolateObserver : public CompilationObserver,
+                         public InternalExceptionObserver {
   virtual ~IsolateObserver() noexcept(false) { }
 };
 

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -268,6 +268,12 @@ v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::Exception&& exc
   auto tunneledException = decodeTunneledException(isolate, desc);
 
   if (tunneledException.isInternal) {
+    auto& observer = IsolateBase::from(isolate).getObserver();
+    observer.reportInternalException(exception, {
+      .isInternal = tunneledException.isInternal,
+      .isFromRemote = tunneledException.isFromRemote,
+      .isDurableObjectReset = tunneledException.isDurableObjectReset,
+    });
     // Don't log exceptions that have been explicitly marked with worker_do_not_log or are
     // DISCONNECTED exceptions as these are unlikely to represent bugs worth tracking.
     if (exception.getType() != kj::Exception::Type::DISCONNECTED &&


### PR DESCRIPTION
This is a quick POC for a request from @bcaimano for how to make it easier to collect metrics for certain kinds of internal exceptions. This PR may not be complete or may change significantly so keeping it as a draft for now.