### PR TITLE
Log Actor ID on V8 deserialization errors

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -101,10 +101,19 @@ wd_cc_capnp_library(
     ["**/*-test.c++"],
     exclude = [
         "api-rtti-test.c++",
+        "actor-state-iocontext-test.c++",
         "cf-property-test.c++",
         "node/*-test.c++",
     ],
 )]
+
+kj_test(
+    src = "actor-state-iocontext-test.c++",
+    deps = [
+        "//src/workerd/io",
+        "//src/workerd/tests:test-fixture",
+    ]
+)
 
 kj_test(
     src = "node/buffer-test.c++",

--- a/src/workerd/api/actor-state-iocontext-test.c++
+++ b/src/workerd/api/actor-state-iocontext-test.c++
@@ -1,0 +1,96 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include <algorithm>
+
+#include <kj/test.h>
+#include <kj/encoding.h>
+
+#include <workerd/api/actor-state.h>
+#include <workerd/tests/test-fixture.h>
+
+namespace workerd::api {
+namespace {
+
+using workerd::TestFixture;
+
+bool contains(kj::StringPtr haystack, kj::StringPtr needle) {
+  return std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end())
+    != haystack.end();
+}
+
+class MockActorId : public ActorIdFactory::ActorId {
+public:
+  MockActorId(kj::String id) : id(kj::mv(id)) {}
+  kj::String toString() const override {
+    return kj::str("MockActorId<", id, ">");
+  }
+
+  kj::Maybe<kj::StringPtr> getName() const override {
+    return kj::none;
+  }
+
+  bool equals(const ActorId& other) const override {
+    return false;
+  }
+
+  kj::Own<ActorId> clone() const override {
+    return kj::heap<MockActorId>(kj::heapString(id));
+  }
+
+  virtual ~MockActorId() {};
+private:
+  kj::String id;
+};
+
+void runBadDeserialization(jsg::Lock& lock, kj::StringPtr expectedId) {
+  // FF = kVersion token, 0E = version 15, 06 = an unknown tag value
+  kj::StringPtr invalidV8Hex = "FF0E06"_kj;
+  auto invalidV8Value = kj::decodeHex(invalidV8Hex.asArray());
+  try {
+    deserializeV8Value(lock, "some-key"_kj, invalidV8Value);
+    KJ_FAIL_ASSERT("deserializeV8Value should have failed.");
+  } catch (kj::Exception& ex) {
+    if (ex.getDescription().startsWith("actor storage deserialization failed")) {
+      KJ_ASSERT(contains(ex.getDescription(), expectedId));
+    } else {
+      throw;
+    }
+  }
+}
+
+void runBadDeserializationInIoContext(TestFixture& fixture, kj::StringPtr expectedId) {
+  fixture.runInIoContext(
+    [expectedId](const workerd::TestFixture::Environment& env) -> kj::Promise<void> {
+      runBadDeserialization(env.lock, expectedId);
+      return kj::READY_NOW;
+  });
+}
+
+// TODO(maybe) It would be nice to have a test that tests the case when there's no IoContext,
+// but that's a royal pain to set up in this test file we'd basically only test that we don't
+// crash, which the actor-state-test.c++ does for us.
+
+KJ_TEST("no actor specified") {
+  TestFixture fixture;
+  runBadDeserializationInIoContext(fixture, "actorId = ;"_kj);
+}
+
+KJ_TEST("actor specified with string id") {
+  Worker::Actor::Id id = kj::str("testActorId");
+  TestFixture fixture(TestFixture::SetupParams{.actorId = kj::mv(id)});
+  runBadDeserializationInIoContext(fixture, "actorId = testActorId;"_kj);
+}
+
+KJ_TEST("actor specified with ActorId object") {
+  kj::Own<ActorIdFactory::ActorId> mockActorId = kj::heap<MockActorId>(kj::str("testActorId"));
+  Worker::Actor::Id id = kj::mv(mockActorId);
+  TestFixture fixture(TestFixture::SetupParams{
+      .actorId = kj::mv(id),
+  });
+  runBadDeserializationInIoContext(fixture, "actorId = MockActorId<testActorId>;"_kj);
+}
+
+} // namespace
+} // namespace workerd::api

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -115,53 +115,6 @@ static kj::Vector<char> escapeJsonString(kj::StringPtr text) {
   return escaped;
 }
 
-// An ActorStorage implementation which will always respond to reads as if the state is empty,
-// and will fail any writes.
-class EmptyReadOnlyActorStorageImpl final: public rpc::ActorStorage::Stage::Server {
-public:
-  kj::Promise<void> get(GetContext context) override {
-    return kj::READY_NOW;
-  }
-  kj::Promise<void> getMultiple(GetMultipleContext context) override {
-    return context.getParams().getStream().endRequest(capnp::MessageSize {2, 0})
-        .send().ignoreResult();
-  }
-  kj::Promise<void> list(ListContext context) override {
-    return context.getParams().getStream().endRequest(capnp::MessageSize {2, 0})
-        .send().ignoreResult();
-  }
-  kj::Promise<void> getAlarm(GetAlarmContext context) override {
-    return kj::READY_NOW;
-  }
-  kj::Promise<void> txn(TxnContext context) override {
-    auto results = context.getResults(capnp::MessageSize {2, 1});
-    results.setTransaction(kj::heap<TransactionImpl>());
-    return kj::READY_NOW;
-  }
-
-private:
-  class TransactionImpl final: public rpc::ActorStorage::Stage::Transaction::Server {
-  protected:
-    kj::Promise<void> get(GetContext context) override {
-      return kj::READY_NOW;
-    }
-    kj::Promise<void> getMultiple(GetMultipleContext context) override {
-      return context.getParams().getStream().endRequest(capnp::MessageSize {2, 0})
-          .send().ignoreResult();
-    }
-    kj::Promise<void> list(ListContext context) override {
-      return context.getParams().getStream().endRequest(capnp::MessageSize {2, 0})
-          .send().ignoreResult();
-    }
-    kj::Promise<void> getAlarm(GetAlarmContext context) override {
-      return kj::READY_NOW;
-    }
-    kj::Promise<void> commit(CommitContext context) override {
-      return kj::READY_NOW;
-    }
-  };
-};
-
 }  // namespace
 
 // =======================================================================================

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -205,4 +205,51 @@ private:
                                     kj::ForkedPromise<void>& forkedDrainWhen);
 };
 
+// An ActorStorage implementation which will always respond to reads as if the state is empty,
+// and will fail any writes.
+class EmptyReadOnlyActorStorageImpl final: public rpc::ActorStorage::Stage::Server {
+public:
+  kj::Promise<void> get(GetContext context) override {
+    return kj::READY_NOW;
+  }
+  kj::Promise<void> getMultiple(GetMultipleContext context) override {
+    return context.getParams().getStream().endRequest(capnp::MessageSize {2, 0})
+        .send().ignoreResult();
+  }
+  kj::Promise<void> list(ListContext context) override {
+    return context.getParams().getStream().endRequest(capnp::MessageSize {2, 0})
+        .send().ignoreResult();
+  }
+  kj::Promise<void> getAlarm(GetAlarmContext context) override {
+    return kj::READY_NOW;
+  }
+  kj::Promise<void> txn(TxnContext context) override {
+    auto results = context.getResults(capnp::MessageSize {2, 1});
+    results.setTransaction(kj::heap<TransactionImpl>());
+    return kj::READY_NOW;
+  }
+
+private:
+  class TransactionImpl final: public rpc::ActorStorage::Stage::Transaction::Server {
+  protected:
+    kj::Promise<void> get(GetContext context) override {
+      return kj::READY_NOW;
+    }
+    kj::Promise<void> getMultiple(GetMultipleContext context) override {
+      return context.getParams().getStream().endRequest(capnp::MessageSize {2, 0})
+          .send().ignoreResult();
+    }
+    kj::Promise<void> list(ListContext context) override {
+      return context.getParams().getStream().endRequest(capnp::MessageSize {2, 0})
+          .send().ignoreResult();
+    }
+    kj::Promise<void> getAlarm(GetAlarmContext context) override {
+      return kj::READY_NOW;
+    }
+    kj::Promise<void> commit(CommitContext context) override {
+      return kj::READY_NOW;
+    }
+  };
+};
+
 }  // namespace workerd::server

--- a/src/workerd/tests/bench-global-scope.c++
+++ b/src/workerd/tests/bench-global-scope.c++
@@ -22,7 +22,7 @@ struct GlobalScopeBenchmark: public benchmark::Fixture {
           },
         };
       )"_kj};
-    fixture = kj::heap<TestFixture>(params);
+    fixture = kj::heap<TestFixture>(kj::mv(params));
   }
 
   void TearDown(benchmark::State& state) noexcept(true) override {

--- a/src/workerd/tests/bench-regex.c++
+++ b/src/workerd/tests/bench-regex.c++
@@ -32,7 +32,7 @@ struct RegExpBenchmark: public benchmark::Fixture {
         }
       )"_kj
     };
-    fixture = kj::heap<TestFixture>(params);
+    fixture = kj::heap<TestFixture>(kj::mv(params));
   }
 
   void TearDown(benchmark::State& state) noexcept(true) override {

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -234,7 +234,7 @@ struct MockResponse final: public kj::HttpService::Response {
 
 
 TestFixture::TestFixture(SetupParams params)
-  : params(params),
+  : waitScope(params.waitScope),
     config(buildConfig(params, configArena)),
     io(params.waitScope == kj::none ? kj::Maybe(kj::setupAsyncIo()) : kj::Maybe<kj::AsyncIoContext>(kj::none)),
     timer(kj::heap<MockTimer>()),

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -233,7 +233,7 @@ struct MockResponse final: public kj::HttpService::Response {
 } // namespace
 
 
-TestFixture::TestFixture(SetupParams params)
+TestFixture::TestFixture(SetupParams&& params)
   : waitScope(params.waitScope),
     config(buildConfig(params, configArena)),
     io(params.waitScope == kj::none ? kj::Maybe(kj::setupAsyncIo()) : kj::Maybe<kj::AsyncIoContext>(kj::none)),

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -23,6 +23,8 @@ struct TestFixture {
     kj::Maybe<kj::WaitScope&> waitScope;
     kj::Maybe<CompatibilityFlags::Reader> featureFlags;
     kj::Maybe<kj::StringPtr> mainModuleSource;
+    // If set, make a stub of an Actor with the given id.
+    kj::Maybe<Worker::Actor::Id> actorId;
   };
 
   TestFixture(SetupParams&& params = { });
@@ -88,6 +90,7 @@ private:
   kj::Own<kj::Timer> timer;
   kj::Own<TimerChannel> timerChannel;
   kj::Own<kj::EntropySource> entropySource;
+  kj::Maybe<kj::Own<Worker::Actor>> actor;
   capnp::ByteStreamFactory byteStreamFactory;
   kj::HttpHeaderTable::Builder headerTableBuilder;
   ThreadContext::HeaderIdBundle threadContextHeaderBundle;

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -50,7 +50,7 @@ struct TestFixture {
       -> typename RunReturnType<decltype(callback(kj::instance<const Environment&>()))>::Type {
     auto request = createIncomingRequest();
     kj::WaitScope* waitScope;
-    KJ_IF_SOME(ws, params.waitScope) {
+    KJ_IF_SOME(ws, this->waitScope) {
       waitScope = &ws;
     } else {
       waitScope = &KJ_REQUIRE_NONNULL(io).waitScope;
@@ -80,7 +80,7 @@ struct TestFixture {
   Response runRequest(kj::HttpMethod method, kj::StringPtr url, kj::StringPtr body);
 
 private:
-  SetupParams params;
+  kj::Maybe<kj::WaitScope&> waitScope;
   capnp::MallocMessageBuilder configArena;
   workerd::server::config::Worker::Reader config;
   kj::Maybe<kj::AsyncIoContext> io;

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -25,7 +25,7 @@ struct TestFixture {
     kj::Maybe<kj::StringPtr> mainModuleSource;
   };
 
-  TestFixture(SetupParams params = { });
+  TestFixture(SetupParams&& params = { });
 
   struct V8Environment {
     v8::Isolate* isolate;


### PR DESCRIPTION
When V8 deserialization fails, it’s likely due to corruption somewhere
between the Actor in JS and the storage layer.  In order to aid
debugging, log the actor id if we know of one.
