### PR TITLE
Update Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,14 +56,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - if: ${{ needs.check-tag.outputs.exists != 'true' }}
-        run: git tag v${{ needs.version.outputs.version }} && git push origin v${{ needs.version.outputs.version }}
+      - id: commit_ref
+        run: echo "prerelease_version=0.0.0-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - id: release_tag
+        run: echo "tag=${{ needs.check-tag.outputs.exists == 'true' && steps.commit_ref.outputs.prerelease_version || needs.version.outputs.version}}" >> $GITHUB_OUTPUT
+      - run: git tag v${{ steps.release_tag.outputs.tag }} && git push origin v${{ steps.release_tag.outputs.tag }}
       - uses: ncipollo/release-action@v1
         id: create_release
         with:
           generateReleaseNotes: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: v${{ needs.version.outputs.version }}
+          tag: v${{ steps.release_tag.outputs.tag }}
           prerelease: ${{ needs.check-tag.outputs.exists == 'true' }}
           
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,44 @@ jobs:
       - id: echo
         run: |
           echo "::set-output name=version::1.$(bazel-bin/external/capnp-cpp/src/capnp/capnp_tool eval src/workerd/io/compatibility-date.capnp supportedCompatibilityDate | tr -d '-' | tr -d '"').0"
+  check-tag:
+    name: Check tag is new
+    outputs:
+      exists: ${{ steps.check_tag.outputs.exists }}
+    needs: [version]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: mukunku/tag-exists-action@v1.1.0
+        id: check_tag
+        with:
+          tag: v${{ needs.version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  tag-and-release:
+    name: Tag & Release
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    needs: [check-tag, version]
+    runs-on: ubuntu-latest
+    if: needs.check-tag.outputs.exists != 'true'
+    steps:
+      - run: echo ${{ needs.check-tag.outputs.exists }}
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git tag v${{ needs.version.outputs.version }} && git push origin v${{ needs.version.outputs.version }}
+      - uses: ncipollo/release-action@v1
+        id: create_release
+        with:
+          generateReleaseNotes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: v${{ needs.version.outputs.version }}
   build:
     strategy:
       matrix:
@@ -87,48 +125,10 @@ jobs:
         with:
           name: ${{ runner.os }}-${{ runner.arch }}-binary
           path: bazel-bin/src/workerd/server/workerd${{ runner.os == 'Windows' && '.exe' || '' }}
-  check-tag:
-    name: Check tag is new
-    outputs:
-      exists: ${{ steps.check_tag.outputs.exists }}
-    needs: [version, build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: mukunku/tag-exists-action@v1.1.0
-        id: check_tag
-        with:
-          tag: v${{ needs.version.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  tag-and-release:
-    name: Tag & Release
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-    needs: [check-tag, version, build]
-    runs-on: ubuntu-latest
-    if: needs.check-tag.outputs.exists != 'true'
-    steps:
-      - run: echo ${{ needs.check-tag.outputs.exists }}
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - run: git tag v${{ needs.version.outputs.version }} && git push origin v${{ needs.version.outputs.version }}
-      - uses: ncipollo/release-action@v1
-        id: create_release
-        with:
-          generateReleaseNotes: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: v${{ needs.version.outputs.version }}
-
+  
   upload-artifacts:
     name: Upload Artifacts
-    needs: [tag-and-release]
+    needs: [tag-and-release, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - run: git tag v${{ needs.version.outputs.version }} && git push origin v${{ needs.version.outputs.version }}
+      - if: ${{ needs.check-tag.outputs.exists != 'true' }}
+        run: git tag v${{ needs.version.outputs.version }} && git push origin v${{ needs.version.outputs.version }}
       - uses: ncipollo/release-action@v1
         id: create_release
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     needs: [check-tag, version]
     runs-on: ubuntu-latest
-    if: needs.check-tag.outputs.exists != 'true'
     steps:
       - run: echo ${{ needs.check-tag.outputs.exists }}
       - name: Checkout Repo
@@ -64,6 +63,8 @@ jobs:
           generateReleaseNotes: true
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: v${{ needs.version.outputs.version }}
+          prerelease: ${{ needs.check-tag.outputs.exists == 'true' }}
+          
   build:
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 You might use it:  
 
 * **As an application server**, to self-host applications designed for Cloudflare Workers.
-* **As a development tool**, to develop and test such code locally.
+* **As a development tool**, to develop and test such code locally. 
 * **As a programmable HTTP proxy** (forward or reverse), to efficiently intercept, modify, and
   route network requests.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `workerd` (pronounced: "worker-dee") is a JavaScript / Wasm server runtime based on the same code that powers [Cloudflare Workers](https://workers.dev).
 
-You might use it:
+You might use it:  
 
 * **As an application server**, to self-host applications designed for Cloudflare Workers.
 * **As a development tool**, to develop and test such code locally.


### PR DESCRIPTION
This includes two major changes to the release workflow, in preparation for building in more environments.
* Generate a release _before_ the builds have finished, rather than afterwards
* _Always_ generate a release when committing to `main`. If the version has been seen before then mark it as a pre-release. This will ease testing of pre-release builds of `workerd` (previously they'd have to be built locally)