### PR TITLE
Assorted CI dependency cleanup

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.2.0
+        uses: contributor-assistant/github-action@v2.3.0
         env:
           # CLA Action uses this in-built GitHub token to make the API calls for interacting with GitHub.
           # It is built into Github Actions and does not need to be manually specified in your secrets store.

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           WORKERD_VERSION: ${{ needs.version.outputs.version }}
           LATEST_COMPATIBILITY_DATE: ${{ needs.version.outputs.date }}
-      - uses: robinraju/release-downloader@v1.5
+      - uses: robinraju/release-downloader@v1.6
         with:
           tag: v${{ needs.version.outputs.release_version }}
           fileName: workerd-${{ matrix.arch }}.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: mukunku/tag-exists-action@v1.1.0
+      - uses: mukunku/tag-exists-action@v1.3.0
         id: check_tag
         with:
           tag: v${{ needs.version.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   tag-and-release:
     name: Tag & Release
@@ -142,7 +140,7 @@ jobs:
             name: Windows-X64
     steps:
       - name: Download ${{ matrix.name }}
-        uses: actions/download-artifact@v3.0.0
+        uses: actions/download-artifact@v3.0.2
         with:
           name: ${{ matrix.name }}-binary
           path: /tmp

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,6 +66,10 @@ http_archive(
     url = "https://github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz",
 )
 
+load("@com_google_benchmark//:bazel/benchmark_deps.bzl", "benchmark_deps")
+
+benchmark_deps()
+
 # Using latest brotli commit due to macOS and clang-cl compile issues with v1.0.9, switch to a
 # release version later.
 http_archive(


### PR DESCRIPTION
See details in the commit descriptions. Note: This removes esbuild which appears to be unused but might be useful for future JS/TS work, feel free to add it back if needed or lmk if you want to keep it.