### PR TITLE
Temporarily disable Node-style logging for service workers

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2484,7 +2484,7 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
       name,
       kj::mv(limitEnforcer),
       inspectorPolicy,
-      consoleMode);
+      conf.isServiceWorkerScript() ? Worker::ConsoleMode::INSPECTOR_ONLY : consoleMode);
 
   // If we are using the inspector, we need to register the Worker::Isolate
   // with the inspector service.


### PR DESCRIPTION
Hey! 👋 https://github.com/cloudflare/workerd/pull/1294 broke `console.log()`ing in local development for service workers. It looks like this fix for this might be slightly more involved than initially expected. While we work on a permanent solution, this PR reverts the change if service workers are used. In Wrangler, we can re-enable inspector style logging if we detect the bundle is a service worker.

Ref: https://github.com/cloudflare/workerd/issues/1362