### PR TITLE
Update Node version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -257,18 +257,26 @@ rust_analyzer_dependencies()
 #
 # workerd uses Node.js scripts for generating TypeScript types.
 
+# Fetch rules_nodejs before aspect_rules_js, otherwise we'll get an outdated rules_nodejs version.
+http_archive(
+    name = "rules_nodejs",
+    sha256 = "162f4adfd719ba42b8a6f16030a20f434dc110c65dc608660ef7b3411c9873f9",
+    strip_prefix = "rules_nodejs-6.0.2",
+    url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.0.2/rules_nodejs-v6.0.2.tar.gz",
+)
+
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "686d5b345592c1958b4aea24049d935ada11b83ae5538658d22b84b353cfbb1e",
-    strip_prefix = "rules_js-1.13.1",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.13.1.tar.gz",
+    sha256 = "72e8b34ed850a5acc39b4c85a8d5a0a5063e519e4688200ee41076bb0c979207",
+    strip_prefix = "rules_js-1.33.1",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.33.1.tar.gz",
 )
 
 http_archive(
     name = "aspect_rules_ts",
-    sha256 = "6406905c5f7c5ca6dedcca5dacbffbf32bb2a5deb77f50da73e7195b2b7e8cbc",
-    strip_prefix = "rules_ts-1.0.5",
-    url = "https://github.com/aspect-build/rules_ts/archive/refs/tags/v1.0.5.tar.gz",
+    sha256 = "4c3f34fff9f96ffc9c26635d8235a32a23a6797324486c7d23c1dfa477e8b451",
+    strip_prefix = "rules_ts-1.4.5",
+    url = "https://github.com/aspect-build/rules_ts/archive/refs/tags/v1.4.5.tar.gz",
 )
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
@@ -284,7 +292,7 @@ nodejs_register_toolchains(
         # "WORKERS_MIRROR_URL/https://nodejs.org/dist/v{version}/{filename}",
         "https://nodejs.org/dist/v{version}/{filename}",
     ],
-    node_version = "18.10.0",
+    node_version = "20.8.0",
 )
 
 load("@aspect_rules_ts//ts:repositories.bzl", "rules_ts_dependencies", TS_LATEST_VERSION = "LATEST_VERSION")

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "devDependencies": {
     "@bazel/bazelisk": "~1.12.1",
-    "@types/debug": "^4.1.7",
-    "@types/node": "^18.8.5",
+    "@types/debug": "^4.1.10",
+    "@types/node": "^20.8.10",
     "@types/prettier": "^2.7.1",
     "@typescript-eslint/eslint-plugin": "^5.40.0",
     "@typescript-eslint/parser": "^5.40.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: 5.4
 
 specifiers:
   '@bazel/bazelisk': ~1.12.1
-  '@types/debug': ^4.1.7
-  '@types/node': ^18.8.5
+  '@types/debug': ^4.1.10
+  '@types/node': ^20.8.10
   '@types/prettier': ^2.7.1
   '@typescript-eslint/eslint-plugin': ^5.40.0
   '@typescript-eslint/parser': ^5.40.0
@@ -24,8 +24,8 @@ dependencies:
 
 devDependencies:
   '@bazel/bazelisk': 1.12.1
-  '@types/debug': 4.1.7
-  '@types/node': 18.8.5
+  '@types/debug': 4.1.10
+  '@types/node': 20.8.10
   '@types/prettier': 2.7.1
   '@typescript-eslint/eslint-plugin': 5.40.0_ik43yucnjuzsopqc3tao6tk3x4
   '@typescript-eslint/parser': 5.40.0_l76llshcx5hpzqzl7lfng4kpb4
@@ -119,8 +119,8 @@ packages:
       fastq: 1.13.0
     dev: true
 
-  /@types/debug/4.1.7:
-    resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
+  /@types/debug/4.1.10:
+    resolution: {integrity: sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==}
     dependencies:
       '@types/ms': 0.7.31
     dev: true
@@ -137,8 +137,10 @@ packages:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
     dev: true
 
-  /@types/node/18.8.5:
-    resolution: {integrity: sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==}
+  /@types/node/20.8.10:
+    resolution: {integrity: sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /@types/prettier/2.7.1:
@@ -1723,6 +1725,10 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+    dev: true
+
+  /undici-types/5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
   /uri-js/4.4.1:

--- a/src/node/tsconfig.json
+++ b/src/node/tsconfig.json
@@ -9,6 +9,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "exactOptionalPropertyTypes": true,
+    "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
Updates aspect_rules_js, aspect_rules_ts and Node.js versions in several spots. As I understand these are primarily used for generating types, testing and linting, but please lmk if you have any concerns about breakage here.