### PR TITLE
Provide WebSocket ready state constants to follow the Web IDL definition

### DIFF
--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -375,9 +375,16 @@ public:
     JSG_METHOD(deserializeAttachment);
 
     JSG_STATIC_CONSTANT(READY_STATE_CONNECTING);
+    JSG_STATIC_CONSTANT_NAMED(CONNECTING, WebSocket::READY_STATE_CONNECTING);
+
     JSG_STATIC_CONSTANT(READY_STATE_OPEN);
+    JSG_STATIC_CONSTANT_NAMED(OPEN, WebSocket::READY_STATE_OPEN);
+
     JSG_STATIC_CONSTANT(READY_STATE_CLOSING);
+    JSG_STATIC_CONSTANT_NAMED(CLOSING, WebSocket::READY_STATE_CLOSING);
+
     JSG_STATIC_CONSTANT(READY_STATE_CLOSED);
+    JSG_STATIC_CONSTANT_NAMED(CLOSED, WebSocket::READY_STATE_CLOSED);
 
     // Previously, we were setting all properties as instance properties,
     // which broke the ability to subclass the Event object. With the

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -410,6 +410,20 @@ namespace workerd::jsg {
     registry.template registerStaticConstant<NAME, decltype(Self::name)>(Self::name); \
   } while (false)
 
+// This works the same as JSG_STATIC_CONSTANT but allows us to provide an alias to an arbitrary c++
+// constant instead. For example:
+//     struct Interface {
+//       static Interface constructor()
+//       JSG_RESOURCE_TYPE {
+//         JSG_STATIC_CONSTANT_NAMED(FOO_BAR, SOME_SYSTEM_CONSTANT);
+//       }
+//     };
+#define JSG_STATIC_CONSTANT_NAMED(name, constant) \
+  do { \
+    static const char NAME[] = #name; \
+    registry.template registerStaticConstant<NAME, decltype(constant)>(constant); \
+  } while (false)
+
 // Use inside a JSG_RESOURCE_TYPE block to declare that this type inherits from another type,
 // which must also have a JSG_RESOURCE_TYPE block. This type must singly, non-virtually inherit
 // from the specified type. (Multiple inheritance and virtual inheritance will not work since we


### PR DESCRIPTION
See https://github.com/cloudflare/workerd/issues/1370. I also added in a little macro so that we could reuse the existing constants for both new and old js constants.