### PR TITLE
Subpipeline with logLevel none is now correctly respected.

### DIFF
--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -418,9 +418,11 @@ void SpanBuilder::addLog(kj::Date timestamp, kj::ConstString key, TagValue value
 }
 
 PipelineTracer::~PipelineTracer() noexcept(false) {
-  KJ_IF_SOME(p, parentTracer) {
-    for (auto& t: traces) {
-      p->traces.add(kj::addRef(*t));
+  if (logLevel != PipelineLogLevel::NONE) {
+    KJ_IF_SOME(p, parentTracer) {
+      for (auto& t: traces) {
+        p->traces.add(kj::addRef(*t));
+      }
     }
   }
   KJ_IF_SOME(f, completeFulfiller) {


### PR DESCRIPTION
When a subpipeline's logLevel is set to `none` the traces originating from it will no longer make it to its parent pipeline.

Tested upstream.

Refs: EW-7798