### PR TITLE
BLD Move dependencies on //src/node to targets where used

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -64,6 +64,7 @@ wd_cc_library(
     deps = [
         ":html-rewriter",
         "//src/workerd/io",
+        "//src/node",
     ],
 )
 

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -62,7 +62,6 @@ wd_cc_library(
         ":trace",
         ":worker-interface",
         "//src/cloudflare",
-        "//src/node",
         "//src/workerd/api:analytics-engine_capnp",
         "//src/workerd/api:r2-api_capnp",
         "//src/workerd/jsg",

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -98,6 +98,7 @@ wd_cc_library(
         "//src/workerd/api:rtti",
         "//src/workerd/io",
         "//src/workerd/jsg",
+        "//src/node",
     ],
 )
 

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -18,6 +18,7 @@ wd_cc_library(
         "//src/workerd/io",
         "//src/workerd/jsg",
         "//src/workerd/jsg:rtti",
+        "//src/node",
         "@capnp-cpp//src/capnp",
     ],
 )


### PR DESCRIPTION
As far as I can tell, src/workerd/io has no actual dependency on src/node, what depends on it are the workerd, server, and tools modules. These depend on io so they were getting node indirectly by requiring that.
