### PR TITLE
Replace strstr with StringPtr::contains

### DIFF
--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -276,11 +276,11 @@ jsg::Dict<jsg::ByteString, jsg::ByteString> TraceItem::FetchEventInfo::Request::
       //(name == "authorization"_kj) || // covered below
       (name == "cookie"_kj) ||
       (name == "set-cookie"_kj) ||
-      (strstr(name.cStr(), "auth") != nullptr) ||
-      (strstr(name.cStr(), "jwt") != nullptr) ||
-      (strstr(name.cStr(), "key") != nullptr) ||
-      (strstr(name.cStr(), "secret") != nullptr) ||
-      (strstr(name.cStr(), "token") != nullptr)
+      name.contains("auth"_kjc) ||
+      name.contains("jwt"_kjc) ||
+      name.contains("key"_kjc) ||
+      name.contains("secret"_kjc) ||
+      name.contains("token"_kjc)
     );
   };
 

--- a/src/workerd/api/util.c++
+++ b/src/workerd/api/util.c++
@@ -81,7 +81,7 @@ kj::Maybe<kj::String> readContentTypeParameter(kj::StringPtr contentType,
 kj::Maybe<kj::Exception> translateKjException(const kj::Exception& exception,
     std::initializer_list<ErrorTranslation> translations) {
   for (auto& t: translations) {
-    if (strstr(exception.getDescription().cStr(), t.kjDescription.cStr()) != nullptr) {
+    if (exception.getDescription().contains(t.kjDescription)) {
       return kj::Exception(kj::Exception::Type::FAILED, __FILE__, __LINE__,
           kj::str(JSG_EXCEPTION(TypeError) ": ", t.jsDescription));
     }

--- a/src/workerd/jsg/exception.c++
+++ b/src/workerd/jsg/exception.c++
@@ -153,7 +153,7 @@ bool isTunneledException(kj::StringPtr internalMessage) {
 }
 
 bool isDoNotLogException(kj::StringPtr internalMessage) {
-  return strstr(internalMessage.cStr(), "worker_do_not_log") != nullptr;
+  return internalMessage.contains("worker_do_not_log"_kjc);
 }
 
 kj::String annotateBroken(kj::StringPtr internalMessage, kj::StringPtr brokennessReason) {

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -315,7 +315,7 @@ void TestFixture::runInIoContext(
     kj::ArrayPtr<kj::StringPtr> errorsToIgnore) {
   auto ignoreDescription = [&errorsToIgnore](kj::StringPtr description) {
     return std::any_of(errorsToIgnore.begin(), errorsToIgnore.end(), [&description](auto error) {
-      return strstr(description.cStr(), error.cStr());
+      return description.contains(error);
     });
   };
 


### PR DESCRIPTION
This series of commits replaces uses of strstr with StringPtr::contains.

There's still 1 place where workerd uses strstr, but that's doing index arithmetic and I'll fix it in a follow-up PR.