### PR TITLE
Refactor out supportedCompatibilityDate

### DIFF
--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -133,6 +133,7 @@ wd_cc_capnp_library(
         "actor-storage.capnp",
         "cdp.capnp",
         "compatibility-date.capnp",
+        "supported-compatibility-date.capnp",
         "worker-interface.capnp",
     ],
     visibility = ["//visibility:public"],

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -8,19 +8,6 @@ using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("workerd");
 $Cxx.allowCancellation;
 
-const supportedCompatibilityDate :Text = embed "/trimmed-supported-compatibility-date.txt";
-# Newest compatibility date that can safely be set using code compiled from this repo. Trying to
-# run a Worker with a newer compatibility date than this will fail.
-#
-# This should be updated to the current date on a regular basis. The reason this exists is so that
-# if you build an old version of the code and try to run a new Worker with it, you get an
-# appropriate error, rather than have the code run with the wrong compatibility mode.
-#
-# Note that the production Cloudflare Workers upload API always accepts any date up to the current
-# date regardless of this constant, on the assumption that Cloudflare is always running the latest
-# version of the code. This constant is more to protect users who are self-hosting the runtime and
-# could be running an older version.
-
 struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Flags that change the basic behavior of the runtime API, especially for
   # backwards-compatibility with old bugs.

--- a/src/workerd/io/compatibility-date.h
+++ b/src/workerd/io/compatibility-date.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <workerd/io/compatibility-date.capnp.h>
+#include <workerd/io/supported-compatibility-date.capnp.h>
 #include <workerd/io/worker.h>
 
 namespace workerd {

--- a/src/workerd/io/supported-compatibility-date.capnp
+++ b/src/workerd/io/supported-compatibility-date.capnp
@@ -1,0 +1,22 @@
+# Copyright (c) 2017-2022 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+@0x9877d11df1c5f4ab;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("workerd");
+$Cxx.allowCancellation;
+
+const supportedCompatibilityDate :Text = embed "/trimmed-supported-compatibility-date.txt";
+# Newest compatibility date that can safely be set using code compiled from this repo. Trying to
+# run a Worker with a newer compatibility date than this will fail.
+#
+# This should be updated to the current date on a regular basis. The reason this exists is so that
+# if you build an old version of the code and try to run a new Worker with it, you get an
+# appropriate error, rather than have the code run with the wrong compatibility mode.
+#
+# Note that the production Cloudflare Workers upload API always accepts any date up to the current
+# date regardless of this constant, on the assumption that Cloudflare is always running the latest
+# version of the code. This constant is more to protect users who are self-hosting the runtime and
+# could be running an older version.

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -19,6 +19,7 @@
 #include <workerd/jsg/setup.h>
 #include <openssl/rand.h>
 #include <workerd/io/compatibility-date.capnp.h>
+#include <workerd/io/supported-compatibility-date.capnp.h>
 
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
 #include <workerd/api/gpu/gpu.h>


### PR DESCRIPTION
Some external systems vendor compatibility-date.capnp without running workerd's build process. This fixes issues with that vendoring process that arose in https://github.com/cloudflare/workerd/commit/e1e67c38d449bc3f4b3c870a36c17776890e6474#diff-025905f76d1858e597340d2c52fcd507c5928fedf61392257cbb22197175d5e7 by factoring out the generated supportedCompatibilityDate text from the static CompatibilityFlags struct.