### PR TITLE
Implement unsafe.newAsyncFunction for unsafe eval binding

### DIFF
--- a/src/workerd/api/tests/unsafe-test.js
+++ b/src/workerd/api/tests/unsafe-test.js
@@ -32,3 +32,27 @@ export const newFunction = {
     strictEqual(fn(fn), fn);
   }
 };
+
+export const newAsyncFunction = {
+  async test(ctx, env) {
+    const fn = env.unsafe.newAsyncFunction('return await m', 'bar', 'm');
+    strictEqual(fn.length, 1);
+    strictEqual(fn.name, 'bar');
+    strictEqual(await fn(), undefined);
+    strictEqual(await fn(1), 1);
+    strictEqual(await fn(fn), fn);
+    strictEqual(await fn(Promise.resolve(1)), 1);
+  }
+};
+
+export const newAsyncFunction2 = {
+  async test(ctx, env) {
+    const fn = env.unsafe.newAsyncFunction('return await arguments[0]');
+    strictEqual(fn.length, 0);
+    strictEqual(fn.name, 'anonymous');
+    strictEqual(await fn(), undefined);
+    strictEqual(await fn(1), 1);
+    strictEqual(await fn(fn), fn);
+    strictEqual(await fn(Promise.resolve(1)), 1);
+  }
+};

--- a/src/workerd/api/unsafe.h
+++ b/src/workerd/api/unsafe.h
@@ -36,9 +36,23 @@ public:
       jsg::Arguments<jsg::JsRef<jsg::JsString>> args,
       const jsg::TypeHandler<UnsafeEvalFunction>& handler);
 
+  // Compiles and returns a new Async Function using the given script. The function
+  // does not capture any part of the outer scope other than globalThis and globally
+  // scoped variables. The optional `name` will be set as the name of the function
+  // and will appear in stack traces for any errors thrown. An optional list of
+  // arguments names can be passed in. If your function needs to use the await
+  // key, use this instead of newFunction.
+  UnsafeEvalFunction newAsyncFunction(
+      jsg::Lock& js,
+      jsg::JsString script,
+      jsg::Optional<kj::String> name,
+      jsg::Arguments<jsg::JsRef<jsg::JsString>> args,
+      const jsg::TypeHandler<UnsafeEvalFunction>& handler);
+
   JSG_RESOURCE_TYPE(UnsafeEval) {
     JSG_METHOD(eval);
     JSG_METHOD(newFunction);
+    JSG_METHOD(newAsyncFunction);
   }
 };
 


### PR DESCRIPTION
A variation on unsafe.newFunction that returns an async function allowing internal use of await

Only impacts workerd/local-dev.