### PR TITLE
Initial implementation of Secret Store CryptoKey binding

### DIFF
--- a/samples/secret-store/config.capnp
+++ b/samples/secret-store/config.capnp
@@ -1,0 +1,54 @@
+# Imports the base schema for workerd configuration files.
+
+# Refer to the comments in /src/workerd/server/workerd.capnp for more details.
+
+using Workerd = import "/workerd/workerd.capnp";
+
+# A constant of type Workerd.Config defines the top-level configuration for an
+# instance of the workerd runtime. A single config file can contain multiple
+# Workerd.Config definitions and must have at least one.
+const helloWorldExample :Workerd.Config = (
+
+  # Every workerd instance consists of a set of named services. A worker, for instance,
+  # is a type of service. Other types of services can include external servers, the
+  # ability to talk to a network, or accessing a disk directory. Here we create a single
+  # worker service. The configuration details for the worker are defined below.
+  services = [
+    (name = "main", worker = .helloWorld),
+    (name = "secrets", worker = .secrets),
+  ],
+
+  # Each configuration defines the sockets on which the server will listen.
+  # Here, we create a single socket that will listen on localhost port 8080, and will
+  # dispatch to the "main" service that we defined above.
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ]
+);
+
+# The definition of the actual helloWorld worker exposed using the "main" service.
+# In this example the worker is implemented as an ESM module (see worker.js).
+# The compatibilityDate is required. For more details on compatibility dates see:
+#   https://developers.cloudflare.com/workers/platform/compatibility-dates/
+
+const helloWorld :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js")
+  ],
+  compatibilityDate = "2023-02-28",
+  bindings = [
+    (
+      name = "SECRET",
+      secret = (
+        designator = "secrets",
+        id = "foo",
+        exportable = true,
+      )
+    )
+  ],
+);
+
+const secrets :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "secrets.js")
+  ],
+  compatibilityDate = "2023-02-28",
+);

--- a/samples/secret-store/secrets.js
+++ b/samples/secret-store/secrets.js
@@ -1,0 +1,15 @@
+export default {
+  fetch(req) {
+    // The req.url is currently used to communicate the identity of the secret to get.
+    if (req.url === "foo") {
+      // TODO(soon): Currently this returns the secret data directly as the
+      // body of the payload. Later we'll want this to be more structured,
+      // possibly returning a JSON document with additional metadata such
+      // as cache TTL, secret type, etc.
+      return new Response("THIS IS A SECRET... SHHHH!");
+    } else {
+      // For a secret that doesn't exist, return an error.
+      throw new Error("Nothing");
+    }
+  }
+};

--- a/samples/secret-store/worker.js
+++ b/samples/secret-store/worker.js
@@ -1,0 +1,15 @@
+
+const dec = new TextDecoder();
+async function getSecret(secret) {
+  return dec.decode(await crypto.subtle.exportKey("raw", secret));
+}
+
+export default {
+  async fetch(req, env) {
+    const SECRET = await getSecret(env.SECRET);
+
+    console.log(SECRET);
+
+    return new Response("ok");
+  }
+};

--- a/src/workerd/api/crypto-impl.h
+++ b/src/workerd/api/crypto-impl.h
@@ -201,6 +201,14 @@ public:
         "Unrecognized or unsupported export of \"", getAlgorithmName(), "\" requested.");
   }
 
+  // The tryExportKeyAsync variant supports cases where the key data must be exported
+  // asynchronously (e.g. for secret store crypto keys).
+  virtual kj::Maybe<jsg::Promise<SubtleCrypto::ExportKeyData>> tryExportKeyAsync(
+      jsg::Lock& js,
+      kj::StringPtr format) const {
+    return kj::none;
+  }
+
   virtual kj::StringPtr getAlgorithmName() const = 0;
 
   virtual CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail() const {
@@ -338,6 +346,12 @@ public:
 private:
   kj::Array<kj::byte> inner;
 };
+
+jsg::Ref<CryptoKey> newSecretStoreCryptoKey(
+    uint channel,
+    kj::StringPtr id,
+    bool exportable,
+    uint32_t ownerId);
 
 }  // namespace workerd::api
 

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -628,6 +628,13 @@ static v8::Local<v8::Value> createBindingValue(
     KJ_CASE_ONEOF(unsafe, Global::UnsafeEval) {
       value = lock.wrap(context, jsg::alloc<api::UnsafeEval>());
     }
+    KJ_CASE_ONEOF(secret, Global::Secret) {
+      value = lock.wrap(context, api::newSecretStoreCryptoKey(
+          secret.subrequestChannel,
+          secret.id,
+          secret.exportable,
+          ownerId));
+    }
   }
 
   return value;
@@ -703,6 +710,9 @@ WorkerdApiIsolate::Global WorkerdApiIsolate::Global::clone() const {
     }
     KJ_CASE_ONEOF(unsafe, Global::UnsafeEval) {
       result.value = Global::UnsafeEval {};
+    }
+    KJ_CASE_ONEOF(secret, Global::Secret) {
+      result.value = secret.clone();
     }
   }
 

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -170,10 +170,23 @@ public:
       }
     };
     struct UnsafeEval {};
+    struct Secret {
+      uint subrequestChannel;
+      kj::String id;
+      bool exportable;
+
+      Secret clone() const {
+        return {
+          .subrequestChannel = subrequestChannel,
+          .id = kj::str(id),
+          .exportable = exportable,
+        };
+      }
+    };
     kj::String name;
     kj::OneOf<Json, Fetcher, KvNamespace, R2Bucket, R2Admin, CryptoKey, EphemeralActorNamespace,
               DurableActorNamespace, QueueBinding, kj::String, kj::Array<byte>, Wrapped,
-              AnalyticsEngine, Hyperdrive, UnsafeEval> value;
+              AnalyticsEngine, Hyperdrive, UnsafeEval, Secret> value;
 
     Global clone() const;
   };

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -369,6 +369,8 @@ struct Worker {
       unsafeEval @23 :Void;
       # A simple binding that enables access to the UnsafeEval API.
 
+      secret @24 :Secret;
+
       # TODO(someday): dispatch, other new features
     }
 
@@ -484,6 +486,12 @@ struct Worker {
       # Inner bindings that will be created and passed in the env dictionary.
       # These bindings shall be used to implement end-user api, and are not available to the
       # binding consumers unless "re-exported" in wrapBindings function.
+    }
+
+    struct Secret {
+      designator @0 :ServiceDesignator;
+      id @1 :Text;
+      exportable @2 :Bool = true;
     }
   }
 


### PR DESCRIPTION
This is an initial proof-of-concept implementation of a secret store CryptoKey binding. 

```
// To run the server:
bazel run //src/workerd/server:workerd -- serve samples/secret-store/config.capnp --experimental --verbose --watch
```

See the samples/secret-store to see how to set it up.

```
// To test
curl localhost:8080
```