### PR TITLE
Implement experimental module fallback service for testing

### DIFF
--- a/samples/module_fallback/README.md
+++ b/samples/module_fallback/README.md
@@ -1,0 +1,28 @@
+# Module Fallback Example
+
+To run the example on http://localhost:8080
+
+```sh
+$ ./workerd serve config.capnp
+```
+
+To run using bazel
+
+```sh
+$ bazel run //src/workerd/server:workerd -- serve ~/cloudflare/workerd/samples/module_fallback/config.capnp
+```
+
+To create a standalone binary that can be run:
+
+```sh
+$ ./workerd compile config.capnp > helloworld
+
+$ ./helloworld
+```
+
+To test:
+
+```sh
+% curl http://localhost:8080
+Hello World
+```

--- a/samples/module_fallback/cjs.js
+++ b/samples/module_fallback/cjs.js
@@ -1,0 +1,5 @@
+const assert = require('assert');
+const vm = require('vm');
+assert(vm !== undefined);
+
+module.exports = {};

--- a/samples/module_fallback/config.capnp
+++ b/samples/module_fallback/config.capnp
@@ -1,0 +1,19 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const helloWorldExample :Workerd.Config = (
+  services = [
+    (name = "main", worker = .helloWorld),
+  ],
+
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ]
+);
+
+const helloWorld :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js"),
+    (name = "cjs", nodeJsCompatModule = embed "cjs.js"),
+  ],
+  compatibilityDate = "2023-02-28",
+  compatibilityFlags = ["nodejs_compat"],
+  moduleFallback = "localhost:8888",
+);

--- a/samples/module_fallback/fallback.js
+++ b/samples/module_fallback/fallback.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+const { createServer } = require('http');
+
+const server = createServer((req, res) => {
+  // The response from the fallback service must be a vaid JSON
+  // serialization of a Worker::Module config.
+
+  // The x-resolve-method tells us if the module was imported or required.
+  console.log(req.headers['x-resolve-method']);
+
+  // The req.url query params tell us what we are importing
+  const url = new URL(req.url, "http://example.org");
+  const specifier = url.searchParams.get('specifier');
+  const referrer = url.searchParams.get('referrer');
+  console.log(specifier, referrer);
+
+  // The fallback service can tell the client to map the request
+  // specifier to another specifier using a 301 redirect, using
+  // the location header to specify the alternative specifier.
+  if (specifier == "/foo") {
+    console.log('Redirecting /foo to /baz');
+    res.writeHead(301, { location: '/baz' });
+    res.end();
+    return;
+  }
+
+  if (specifier == "/bar") {
+    res.writeHead(404);
+    res.end();
+    return;
+  }
+
+  console.log(`Returning module spec for ${specifier}`);
+  // Returning the name is optional. If it is included, then it MUST match the
+  // request specifier!
+  res.end(`{
+  "name": "${specifier}",
+  "esModule":"export default 1;"
+}`);
+});
+
+server.listen(8888, () => {
+  console.log('ready...');
+});

--- a/samples/module_fallback/worker.js
+++ b/samples/module_fallback/worker.js
@@ -1,0 +1,25 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import * as foo from 'foo';
+import * as baz from 'baz';
+import * as vm from 'node:vm';
+import { strictEqual } from 'node:assert';
+import * as cjs from 'cjs';
+
+try {
+  await import('bar');
+  throw new Error('bar should not have been imported');
+} catch {
+  console.log('tried to import bar which does not exist');
+};
+
+console.log(foo, baz, vm);
+
+export default {
+  async fetch(req, env) {
+    strictEqual(1 + 1, 2);
+    return new Response("Hello World\n");
+  }
+};

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1394,7 +1394,7 @@ Worker::Worker(kj::Own<const Script> scriptParam,
           }
           KJ_CASE_ONEOF(mainModule, kj::Path) {
             auto& registry = (*jsContext)->getModuleRegistry();
-            KJ_IF_SOME(entry, registry.resolve(lock, mainModule)) {
+            KJ_IF_SOME(entry, registry.resolve(lock, mainModule, kj::none)) {
               JSG_REQUIRE(entry.maybeSynthetic == kj::none, TypeError,
                           "Main module must be an ES module.");
               auto module = entry.module.getHandle(lock);

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -450,6 +450,19 @@ public:
   virtual kj::Maybe<const api::CryptoAlgorithm&> getCryptoAlgorithm(kj::StringPtr name) const {
     return kj::none;
   }
+
+  // Set the module fallback service callback, if any.
+  using ModuleFallbackCallback =
+      kj::Maybe<kj::OneOf<kj::String, jsg::ModuleRegistry::ModuleInfo>>(
+          jsg::Lock& js,
+          kj::StringPtr,
+          kj::Maybe<kj::String>,
+          jsg::CompilationObserver&,
+          jsg::ModuleRegistry::ResolveMethod);
+  virtual void setModuleFallbackCallback(
+      kj::Function<ModuleFallbackCallback>&& callback) const {
+    // By default does nothing.
+  }
 };
 
 enum class UncaughtExceptionSource {

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -1012,7 +1012,7 @@ struct JsSetup {
         auto& js = Lock::from(info.GetIsolate());
         auto context = js.v8Context();
         auto& moduleInfo = KJ_REQUIRE_NONNULL(
-            ModuleRegistry::from(js)->resolve(js, path, ModuleRegistry::ResolveOption::INTERNAL_ONLY),
+            ModuleRegistry::from(js)->resolve(js, path, kj::none, ModuleRegistry::ResolveOption::INTERNAL_ONLY),
             "Could not resolve bootstrap module", moduleName);
         auto module = moduleInfo.module.getHandle(js);
         jsg::instantiateModule(js, module);

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -185,6 +185,16 @@ public:
                       v8::Local<v8::Object> target,
                       uint32_t ownerId) const;
 
+  static kj::Maybe<jsg::ModuleRegistry::ModuleInfo> tryCompileModule(
+      jsg::Lock& js,
+      config::Worker::Module::Reader conf,
+      jsg::CompilationObserver& observer,
+      CompatibilityFlags::Reader featureFlags);
+
+  using ModuleFallbackCallback = Worker::Api::ModuleFallbackCallback;
+  void setModuleFallbackCallback(
+       kj::Function<ModuleFallbackCallback>&& callback) const override;
+
 private:
   struct Impl;
   kj::Own<Impl> impl;

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -589,6 +589,9 @@ struct Worker {
 
   # TODO(someday): Support distributing objects across a cluster. At present, objects are always
   #   local to one instance of the runtime.
+
+  moduleFallback @13 :Text;
+
 }
 
 struct ExternalServer {


### PR DESCRIPTION
Adds the ability to load modules lazily from a local http fallback service. The fallback service is a simple http server that returns the Worker::Module configuration for a module dynamically rather than embedded within the worker configuration. This is only usable for local dev. See samples/module_fallback for an example.

Not all modules will use the fallback service. In the worker configuration, a module has to be explicitly configured to use the fallback. Also, because of the nature of the ESM modules and the way v8 handles them, there really is no hot-module-reloading. Once a module is loaded for a worker it cannot be replaced without restarting the worker. Currently that's only possible by either shutting workerd down or using the `--watch` feature which watches for changes in the source configuration file on disk. We'll need to try work around that separately.

The module loading using the fallback service is lazy-ish. The fallback service won't be engaged until the module is actually imported but since most imports are static it will appear as if the fallback service is being accessed immediately on worker startup for most cases. You'll see the laziness of the loader in action if you're using dynamic imports or require (e.g. `import(...)` or `require(...)`). 

The fallback service is a simple http server that must return a properly JSON serialized form of the `Worker::Module` configuration as specified by the workerd.capnp schema. The request URL will be the specifier of the module in a `file://` URL form (e.g. a module specifier of `foo` will be passed to the fallback service as `file:///foo`. No other headers or details are passed in the `GET` request.

For now, every request to the fallback service spins up its own kj::Thread that is joined synchronously with the current thread. We could update that to use a single persistent thread with a queue but the current approach is simpler and raw performance really isn't a concern at this point. We can always tweak that more later.