### PR TITLE
Fix multiple waits on maybeClosureWaitable

### DIFF
--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -257,6 +257,7 @@ private:
   // Used by Sockets code to ensure the connection is established before the associated
   // WritableStream is closed.
   kj::Maybe<jsg::Promise<void>> maybeClosureWaitable;
+  bool waitingOnClosureWritableAlready = false;
 
   void increaseCurrentWriteBufferSize(jsg::Lock& js, uint64_t amount);
   void decreaseCurrentWriteBufferSize(jsg::Lock& js, uint64_t amount);


### PR DESCRIPTION
The maybeClosureWaitable can only have then(...) called on it once. Use whenResolved() to support multiple branches.