### PR TITLE
TCP ingress worker support

### DIFF
--- a/samples/tcp-ingress/config.capnp
+++ b/samples/tcp-ingress/config.capnp
@@ -1,0 +1,19 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const tcpIngressExample :Workerd.Config = (
+  services = [
+    (name = "main", worker = .worker),
+  ],
+
+  sockets = [
+    ( name = "http", address = "*:8080", http = (), service = "main" ),
+    ( name = "tcp", address = "*:8081", tcp = (), service = "main" )
+  ]
+);
+
+const worker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js")
+  ],
+  compatibilityDate = "2023-02-28",
+);

--- a/samples/tcp-ingress/worker.js
+++ b/samples/tcp-ingress/worker.js
@@ -1,0 +1,11 @@
+
+export default {
+  async fetch(req) {
+    return new Response("ok");
+  },
+
+  connect({inbound, cf}) {
+    console.log(cf);
+    return inbound.pipeThrough(new IdentityTransformStream());
+  }
+};

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -115,6 +115,86 @@ void ServiceWorkerGlobalScope::clear() {
   unhandledRejections.clear();
 }
 
+kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::connect(
+    kj::AsyncIoStream& connection,
+    kj::HttpService::ConnectResponse& response,
+    kj::Maybe<kj::StringPtr> cfBlobJson,
+    Worker::Lock& lock,
+    kj::Maybe<ExportedHandler&> exportedHandler) {
+  ExportedHandler& eh = JSG_REQUIRE_NONNULL(exportedHandler, Error,
+      "Connect ingress is not currently supported with Service Workers syntax.");
+
+  kj::HttpHeaderTable table;
+  kj::HttpHeaders headers(table);
+
+  KJ_IF_SOME(handler, eh.connect) {
+    // Has a connect handler!
+    response.accept(200, "OK", headers);
+
+    auto ownConnection = newNeuterableIoStream(connection);
+    auto deferredNeuter = kj::defer([ownConnection = kj::addRef(*ownConnection)]() mutable {
+      ownConnection->neuter(makeNeuterException(NeuterReason::CLIENT_DISCONNECTED));
+    });
+    KJ_ON_SCOPE_FAILURE(ownConnection->neuter(makeNeuterException(NeuterReason::THREW_EXCEPTION)));
+    auto conn2 = kj::addRef(*ownConnection);
+
+    auto& ioContext = IoContext::current();
+    jsg::Lock& js = lock;
+
+    CfProperty cf(cfBlobJson);
+
+    auto conn = newSystemMultiStream(kj::addRef(*ownConnection), ioContext);
+    auto jsInbound = jsg::alloc<ReadableStream>(ioContext, kj::mv(conn.readable));
+
+    kj::Maybe<SpanBuilder> span = ioContext.makeTraceSpan("connect_handler"_kjc);
+    auto event = jsg::alloc<ConnectEvent>(kj::mv(jsInbound), kj::mv(cf));
+    auto promise = handler(js, kj::mv(event), eh.env.addRef(js), eh.getCtx());
+
+    struct RefcountedBool: public kj::Refcounted {
+      bool value;
+      RefcountedBool(bool value): value(value) {}
+    };
+    auto canceled = kj::refcounted<RefcountedBool>(false);
+
+    return ioContext.awaitJs(js, promise.then(js, ioContext.addFunctor(
+        [canceled = kj::addRef(*canceled),
+         outbound = kj::mv(conn.writable),
+         span = kj::mv(span)]
+        (jsg::Lock& js, jsg::Ref<ReadableStream> jsOutbound) mutable
+            -> IoOwn<kj::Promise<DeferredProxy<void>>> {
+      auto& context = IoContext::current();
+      span = kj::none;
+      if (canceled->value) {
+        // The client disconnected before the response was ready. The outbound
+        // is a dangling reference, let's not use it.
+        return context.addObject(kj::heap(addNoopDeferredProxy(kj::READY_NOW)));
+      } else {
+        return context.addObject(kj::heap(jsOutbound->pumpTo(js, kj::mv(outbound), true)));
+      }
+    }))).attach(kj::defer([canceled = kj::mv(canceled)]() mutable { canceled->value = true; }))
+        .then([ownConnection = kj::mv(ownConnection), deferredNeuter = kj::mv(deferredNeuter)]
+              (DeferredProxy<void> deferredProxy) mutable {
+      deferredProxy.proxyTask = deferredProxy.proxyTask
+          .then([connection = kj::addRef(*ownConnection)]() mutable {
+        connection->neuter(makeNeuterException(NeuterReason::SENT_RESPONSE));
+      }, [connection = kj::addRef(*ownConnection)](kj::Exception&& e) mutable {
+        connection->neuter(makeNeuterException(NeuterReason::THREW_EXCEPTION));
+        kj::throwFatalException(kj::mv(e));
+      }).attach(kj::mv(deferredNeuter));
+
+      return deferredProxy;
+    }, [connection = kj::mv(conn2)](kj::Exception&& e) mutable -> DeferredProxy<void> {
+      // HACK: We depend on the fact that the success-case lambda above hasn't been destroyed yet
+      //   so `deferredNeuter` hasn't been destroyed yet.
+      connection->neuter(makeNeuterException(NeuterReason::THREW_EXCEPTION));
+      kj::throwFatalException(kj::mv(e));
+    });
+  }
+  lock.logWarningOnce("Received a connect event but we lack a handler. "
+      "Did you remember to export a connect() function?");
+  JSG_FAIL_REQUIRE(Error, "Handler does not export a connect() function.");
+}
+
 kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::request(
     kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
     kj::AsyncInputStream& requestBody, kj::HttpService::Response& response,

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -131,6 +131,9 @@ kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::connect(
     // Has a connect handler!
     response.accept(200, "OK", headers);
 
+    // TODO(cleanup): There's a fair amount of duplication between this and
+    // the request() method, and much of this could likely be cleaned up to
+    // use co_awaits rather than the promise syntax.
     auto ownConnection = newNeuterableIoStream(connection);
     auto deferredNeuter = kj::defer([ownConnection = kj::addRef(*ownConnection)]() mutable {
       ownConnection->neuter(makeNeuterException(NeuterReason::CLIENT_DISCONNECTED));

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -123,6 +123,8 @@ kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::connect(
     kj::Maybe<ExportedHandler&> exportedHandler) {
   ExportedHandler& eh = JSG_REQUIRE_NONNULL(exportedHandler, Error,
       "Connect ingress is not currently supported with Service Workers syntax.");
+  KJ_REQUIRE(FeatureFlags::get(lock).getWorkerdExperimental(),
+              "TCP ingress requires the experimental flag.");
 
   kj::HttpHeaderTable table;
   kj::HttpHeaders headers(table);

--- a/src/workerd/api/tests/tcp-ingress-test.js
+++ b/src/workerd/api/tests/tcp-ingress-test.js
@@ -1,0 +1,29 @@
+import { connect } from 'cloudflare:sockets';
+import {
+  ok,
+  strictEqual,
+} from 'assert';
+
+export const newFunction = {
+  async test() {
+    const socket = connect('localhost:8081');
+    await socket.opened;
+    const dec = new TextDecoder();
+    let result = '';
+    for await (const chunk of socket.readable) {
+      result += dec.decode(chunk, { stream: true });
+    }
+    result += dec.decode();
+    strictEqual(result, 'hello');
+    await socket.closed;
+  }
+};
+
+export default {
+  connect({inbound, cf}) {
+    const enc = new TextEncoder();
+    ok(inbound instanceof ReadableStream);
+    strictEqual(typeof cf.clientIp, 'string');
+    return ReadableStream.from([enc.encode('hello')]);
+  },
+};

--- a/src/workerd/api/tests/tcp-ingress-test.wd-test
+++ b/src/workerd/api/tests/tcp-ingress-test.wd-test
@@ -1,0 +1,19 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "tcp-ingress-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "tcp-ingress-test.js"),
+        ],
+        compatibilityDate = "2024-06-03",
+        compatibilityFlags = ["nodejs_compat_v2", "experimental"],
+      )
+    ),
+    ( name = "internet", network = ( allow = ["private"] ) )
+  ],
+  sockets = [
+    (name = "tcp", address = "*:8081", tcp = (), service = "tcp-ingress-test")
+  ]
+);

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -68,6 +68,7 @@ class TraceItem final: public jsg::Object {
 public:
   class FetchEventInfo;
   class JsRpcEventInfo;
+  class ConnectEventInfo;
   class ScheduledEventInfo;
   class AlarmEventInfo;
   class QueueEventInfo;
@@ -80,6 +81,7 @@ public:
 
   typedef kj::OneOf<jsg::Ref<FetchEventInfo>,
                     jsg::Ref<JsRpcEventInfo>,
+                    jsg::Ref<ConnectEventInfo>,
                     jsg::Ref<ScheduledEventInfo>,
                     jsg::Ref<AlarmEventInfo>,
                     jsg::Ref<QueueEventInfo>,
@@ -266,6 +268,21 @@ public:
 
 private:
   kj::String rpcMethod;
+};
+
+class TraceItem::ConnectEventInfo final: public jsg::Object {
+public:
+  explicit ConnectEventInfo(jsg::Lock& js, const Trace& trace,
+                            const Trace::ConnectEventInfo& eventInfo);
+
+  jsg::Optional<jsg::V8Ref<v8::Object>> getCf(jsg::Lock& js);
+
+  JSG_RESOURCE_TYPE(ConnectEventInfo) {
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(cf, getCf);
+  }
+
+private:
+  jsg::Optional<jsg::V8Ref<v8::Object>> cf;
 };
 
 class TraceItem::ScheduledEventInfo final: public jsg::Object {
@@ -616,6 +633,7 @@ private:
   api::TailEvent,                                                 \
   api::TraceItem,                                                 \
   api::TraceItem::AlarmEventInfo,                                 \
+  api::TraceItem::ConnectEventInfo,                               \
   api::TraceItem::CustomEventInfo,                                \
   api::TraceItem::ScheduledEventInfo,                             \
   api::TraceItem::QueueEventInfo,                                 \

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -101,6 +101,16 @@ public:
     void copyTo(rpc::Trace::JsRpcEventInfo::Builder builder);
   };
 
+  class ConnectEventInfo {
+  public:
+    explicit ConnectEventInfo(kj::String cfJson);
+    explicit ConnectEventInfo(rpc::Trace::ConnectEventInfo::Reader reader);
+
+    kj::String cfJson;
+
+    void copyTo(rpc::Trace::ConnectEventInfo::Builder builder);
+  };
+
   class ScheduledEventInfo {
   public:
     explicit ScheduledEventInfo(double scheduledTime, kj::String cron);
@@ -266,7 +276,7 @@ public:
 
   typedef kj::OneOf<FetchEventInfo, JsRpcEventInfo, ScheduledEventInfo, AlarmEventInfo,
           QueueEventInfo, EmailEventInfo, TraceEventInfo, HibernatableWebSocketEventInfo,
-          CustomEventInfo> EventInfo;
+          CustomEventInfo, ConnectEventInfo> EventInfo;
   kj::Maybe<EventInfo> eventInfo;
   // TODO(someday): Support more event types.
   // TODO(someday): Work out what sort of information we may want to convey about the parent

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -438,7 +438,129 @@ kj::Promise<void> WorkerEntrypoint::request(
 kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host, const kj::HttpHeaders& headers,
     kj::AsyncIoStream& connection, ConnectResponse& response,
     kj::HttpConnectSettings settings) {
-  JSG_FAIL_REQUIRE(TypeError, "Incoming CONNECT on a worker not supported");
+  auto incomingRequest = kj::mv(KJ_REQUIRE_NONNULL(this->incomingRequest,
+                                "connect() can only be called once"));
+  this->incomingRequest = kj::none;
+  incomingRequest->delivered();
+  auto& context = incomingRequest->getContext();
+  bool isActor = context.getActor() != kj::none;
+
+  KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
+    auto timestamp = context.now();
+    kj::String cfJson;
+    KJ_IF_SOME(c, cfBlobJson) {
+      cfJson = kj::str(c);
+    }
+
+    t.setEventInfo(timestamp, Trace::ConnectEventInfo(kj::mv(cfJson)));
+  }
+
+  auto metricsForCatch = kj::addRef(incomingRequest->getMetrics());
+
+  return context.run(
+      [this, &context, &connection, &response, entrypointName = entrypointName]
+      (Worker::Lock& lock) mutable {
+    jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+
+    return lock.getGlobalScope().connect(
+        connection, response, cfBlobJson, lock,
+        lock.getExportedHandler(entrypointName, context.getActor()));
+  }).then([this](api::DeferredProxy<void> deferredProxy) {
+    proxyTask = kj::mv(deferredProxy.proxyTask);
+  }).exclusiveJoin(context.onAbort())
+      .catch_([this,&context](kj::Exception&& exception) mutable -> kj::Promise<void> {
+
+    // Log JS exceptions to the JS console, if fiddle is attached. This also has the effect of
+    // logging internal errors to syslog.
+    loggedExceptionEarlier = true;
+    context.logUncaughtExceptionAsync(UncaughtExceptionSource::REQUEST_HANDLER,
+                                      kj::cp(exception));
+
+    // Do not allow the exception to escape the isolate without waiting for the output gate to
+    // open. Note that in the success path, this is taken care of in `FetchEvent::respondWith()`.
+    return context.waitForOutputLocks()
+        .then([exception = kj::mv(exception)]() mutable
+              -> kj::Promise<void> { return kj::mv(exception); });
+  }).attach(kj::defer([this,incomingRequest = kj::mv(incomingRequest),&context]() mutable {
+    // The request has been canceled, but allow it to continue executing in the background.
+    auto promise = incomingRequest->drain().attach(kj::mv(incomingRequest));
+    waitUntilTasks.add(maybeAddGcPassForTest(context, kj::mv(promise)));
+  })).then([this]() -> kj::Promise<void> {
+    // Now that the IoContext is dropped (unless it had waitUntil()s), we can finish proxying
+    // without pinning it or the isolate into memory.
+    KJ_IF_SOME(p, proxyTask) {
+      return kj::mv(p);
+    } else {
+      return kj::READY_NOW;
+    }
+  }).attach(kj::defer([this]() mutable {
+    // If we're being cancelled, we need to make sure `proxyTask` gets canceled.
+    proxyTask = kj::none;
+  })).catch_([this, isActor, &response, metrics = kj::mv(metricsForCatch)]
+             (kj::Exception&& exception) mutable -> kj::Promise<void> {
+    // Don't return errors to end user.
+
+    auto isInternalException = !jsg::isTunneledException(exception.getDescription())
+        && !jsg::isDoNotLogException(exception.getDescription());
+    if (!loggedExceptionEarlier) {
+      // This exception seems to have originated during the deferred proxy task, so it was not
+      // logged to the IoContext earlier.
+      if (exception.getType() != kj::Exception::Type::DISCONNECTED && isInternalException) {
+        LOG_EXCEPTION("workerEntrypoint", exception);
+      } else {
+        KJ_LOG(INFO, exception);  // Run with --verbose to see exception logs.
+      }
+    }
+
+    auto exceptionToPropagate = [&]() {
+      if (isInternalException) {
+        // We've already logged it here, the only thing that matters to the client is that we failed
+        // due to an internal error. Note that this does not need to be labeled "remote." since jsg
+        // will sanitize it as an internal error. Note that we use `setDescription()` to preserve
+        // the exception type for `cjfs::makeInternalError(...)` downstream.
+        exception.setDescription(kj::str(
+            "worker_do_not_log; Request failed due to internal error"));
+        return kj::mv(exception);
+      } else {
+        // We do not care how many remote capnp servers this went through since we are returning
+        // it to the worker via jsg.
+        // TODO(someday) We also do this stripping when making the tunneled exception for
+        // `jsg::isTunneledException(...)`. It would be lovely if we could simply store some type
+        // instead of `loggedExceptionEarlier`. It would save use some work.
+        auto description = jsg::stripRemoteExceptionPrefix(exception.getDescription());
+        if (!description.startsWith("remote.")) {
+          // If we already were annotated as remote from some other worker entrypoint, no point
+          // adding an additional prefix.
+          exception.setDescription(kj::str("remote.", description));
+        }
+        return kj::mv(exception);
+      }
+
+    };
+
+    if (isActor || tunnelExceptions) {
+      // We want to tunnel exceptions from actors back to the caller.
+      // TODO(cleanup): We'd really like to tunnel exceptions any time a worker is calling another
+      // worker, not just for actors (and W2W below), but getting that right will require cleaning
+      // up error handling more generally.
+      return exceptionToPropagate();
+    } else {
+      // Return error.
+
+      // We're catching the exception and replacing it with 5xx, but metrics should still indicate
+      // an exception.
+      metrics->reportFailure(exception);
+
+      kj::HttpHeaders headers(threadContext.getHeaderTable());
+      if (exception.getType() == kj::Exception::Type::OVERLOADED) {
+        response.reject(503, "Service Unavailable", headers, uint64_t(0));
+      } else {
+        response.reject(500, "Internal Server Error", headers, uint64_t(0));
+      }
+
+      return kj::READY_NOW;
+    }
+  });
 }
 
 void WorkerEntrypoint::prewarm(kj::StringPtr url) {

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -58,6 +58,7 @@ struct Trace @0x8e8d911203762d34 {
     email @16 :EmailEventInfo;
     trace @18 :TraceEventInfo;
     hibernatableWebSocket @20 :HibernatableWebSocketEventInfo;
+    connect @24 :ConnectEventInfo;
   }
   struct FetchEventInfo {
     method @0 :HttpMethod;
@@ -73,6 +74,10 @@ struct Trace @0x8e8d911203762d34 {
 
   struct JsRpcEventInfo {
     methodName @0 :Text;
+  }
+
+  struct ConnectEventInfo {
+    cfJson @0 :Text;
   }
 
   struct ScheduledEventInfo {

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -28,10 +28,10 @@
 #include <workerd/io/request-tracker.h>
 #include <workerd/util/http-util.h>
 #include <workerd/api/actor-state.h>
-#include <workerd/util/mimetype.h>
-#include <workerd/util/uuid.h>
-#include <workerd/util/use-perfetto-categories.h>
 #include <workerd/api/worker-rpc.h>
+#include <workerd/util/mimetype.h>
+#include <workerd/util/use-perfetto-categories.h>
+#include <workerd/util/stream-utils.h>
 #include "workerd-api.h"
 #include "workerd/io/hibernation-manager.h"
 #include <stdlib.h>
@@ -3351,6 +3351,92 @@ private:
   };
 };
 
+class Server::TcpListener final: public kj::Refcounted {
+public:
+  TcpListener(Server& owner, kj::Own<kj::ConnectionReceiver> listener, Service& service,
+              kj::HttpHeaderTable& headerTable, kj::Own<HttpRewriter> rewriter)
+      : owner(owner),
+        listener(kj::mv(listener)),
+        service(service),
+        headerTable(headerTable),
+        rewriter(kj::mv(rewriter)) {}
+
+  kj::Promise<void> run() {
+    for (;;) {
+      kj::AuthenticatedStream stream = co_await listener->acceptAuthenticated();
+
+      kj::Maybe<kj::String> cfBlobJson;
+      if (!rewriter->hasCfBlobHeader()) {
+        // Construct a cf blob describing the client identity.
+
+        kj::PeerIdentity* peerId;
+
+        KJ_IF_SOME(tlsId,
+            kj::dynamicDowncastIfAvailable<kj::TlsPeerIdentity>(*stream.peerIdentity)) {
+          peerId = &tlsId.getNetworkIdentity();
+
+          // TODO(someday): Add client certificate info to the cf blob? At present, KJ only
+          //   supplies the common name, but that doesn't even seem to be one of the fields that
+          //   Cloudflare-hosted Workers receive. We should probably try to match those.
+        } else {
+          peerId = stream.peerIdentity;
+        }
+
+        KJ_IF_SOME(remote,
+            kj::dynamicDowncastIfAvailable<kj::NetworkPeerIdentity>(*peerId)) {
+          cfBlobJson = kj::str("{\"clientIp\": \"", escapeJsonString(remote.toString()), "\"}");
+        } else KJ_IF_SOME(local,
+            kj::dynamicDowncastIfAvailable<kj::LocalPeerIdentity>(*peerId)) {
+          auto creds = local.getCredentials();
+
+          kj::Vector<kj::String> parts;
+          KJ_IF_SOME(p, creds.pid) {
+            parts.add(kj::str("\"clientPid\":", p));
+          }
+          KJ_IF_SOME(u, creds.uid) {
+            parts.add(kj::str("\"clientUid\":", u));
+          }
+
+          cfBlobJson = kj::str("{", kj::strArray(parts, ","), "}");
+        }
+      }
+
+      IoChannelFactory::SubrequestMetadata metadata;
+      metadata.cfBlobJson = cfBlobJson.map([](kj::StringPtr s) { return kj::str(s); });
+      auto req = service.startRequest(kj::mv(metadata));
+      auto response = kj::heap<ResponseWrapper>();
+      kj::HttpHeaders headers(headerTable);
+      // The empty string here is the host parameter that is required by the API
+      // but is not actually used in the implementation at this point.
+      owner.tasks.add(req->connect(""_kj, headers, *stream.stream, *response, {})
+          .attach(kj::mv(stream.stream), kj::mv(response)).attach(kj::mv(req)));
+    }
+  }
+
+private:
+  Server& owner;
+  kj::Own<kj::ConnectionReceiver> listener;
+  Service& service;
+  kj::HttpHeaderTable& headerTable;
+  kj::Own<HttpRewriter> rewriter;
+
+  struct ResponseWrapper final: public kj::HttpService::ConnectResponse {
+    void accept(uint statusCode,
+                kj::StringPtr statusText,
+                const kj::HttpHeaders& headers) override {
+      // Ok.. we're accepting the connection... anything to do?
+    }
+    kj::Own<kj::AsyncOutputStream> reject(
+        uint statusCode,
+        kj::StringPtr statusText,
+        const kj::HttpHeaders& headers,
+        kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+      // Doh... we're rejecting the connection... anything to do?
+      return newNullOutputStream();
+    }
+  };
+};
+
 kj::Promise<void> Server::listenHttp(
     kj::Own<kj::ConnectionReceiver> listener, Service& service,
     kj::StringPtr physicalProtocol, kj::Own<HttpRewriter> rewriter) {
@@ -3358,6 +3444,16 @@ kj::Promise<void> Server::listenHttp(
                                           physicalProtocol, kj::mv(rewriter),
                                           globalContext->headerTable, timer,
                                           globalContext->httpOverCapnpFactory);
+  co_return co_await obj->run();
+}
+
+kj::Promise<void> Server::listenTcp(
+    kj::Own<kj::ConnectionReceiver> listener,
+    Service& service,
+    kj::Own<HttpRewriter> rewriter) {
+  auto obj = kj::refcounted<TcpListener>(*this, kj::mv(listener), service,
+                                         globalContext->headerTable,
+                                         kj::mv(rewriter));
   co_return co_await obj->run();
 }
 
@@ -3624,18 +3720,31 @@ kj::Promise<void> Server::listenOnSockets(config::Config::Reader config,
     config::HttpOptions::Reader httpOptions;
     kj::Maybe<kj::Own<kj::TlsContext>> tls;
     kj::StringPtr physicalProtocol;
+    bool isHttp = false;
     switch (sock.which()) {
       case config::Socket::HTTP:
+        isHttp = true;
         defaultPort = 80;
         httpOptions = sock.getHttp();
         physicalProtocol = "http";
         goto validSocket;
       case config::Socket::HTTPS: {
+        isHttp = true;
         auto https = sock.getHttps();
         defaultPort = 443;
         httpOptions = https.getOptions();
         tls = makeTlsContext(https.getTlsOptions());
         physicalProtocol = "https";
+        goto validSocket;
+      }
+      case config::Socket::TCP: {
+        isHttp = false;
+        auto tcp = sock.getTcp();
+        // No default port
+        // No physical protocol mention here.
+        if (tcp.hasTlsOptions()) {
+          tls = makeTlsContext(tcp.getTlsOptions());
+        }
         goto validSocket;
       }
     }
@@ -3665,27 +3774,47 @@ kj::Promise<void> Server::listenOnSockets(config::Config::Reader config,
       })(kj::mv(listener), kj::mv(t));
     }
 
-    // Need to create rewriter before waiting on anything since `headerTableBuilder` will no longer
-    // be available later.
+    // Need to create rewriter before waiting on anything since `headerTableBuilder` will
+    // no longer be available later.
     auto rewriter = kj::heap<HttpRewriter>(httpOptions, headerTableBuilder);
 
-    auto handle = kj::coCapture(
-        [this, &service, rewriter = kj::mv(rewriter), physicalProtocol, name]
-        (kj::Promise<kj::Own<kj::ConnectionReceiver>> promise)
-            mutable -> kj::Promise<void> {
-      TRACE_EVENT("workerd", "setup listenHttp");
-      auto listener = co_await promise;
-      KJ_IF_SOME(stream, controlOverride) {
-        auto message = kj::str("{\"event\":\"listen\",\"socket\":\"", name, "\",\"port\":", listener->getPort(), "}\n");
-        try {
-          stream->write(message.asBytes());
-        } catch (kj::Exception& e) {
-          KJ_LOG(ERROR, e);
+    if (isHttp) {
+      auto handle = kj::coCapture(
+          [this, &service, rewriter = kj::mv(rewriter), physicalProtocol, name]
+          (kj::Promise<kj::Own<kj::ConnectionReceiver>> promise)
+              mutable -> kj::Promise<void> {
+        TRACE_EVENT("workerd", "setup listenHttp");
+        auto listener = co_await promise;
+        KJ_IF_SOME(stream, controlOverride) {
+          auto message = kj::str("{\"event\":\"listen\",\"socket\":\"", name, "\",\"port\":", listener->getPort(), "}\n");
+          try {
+            stream->write(message.asBytes());
+          } catch (kj::Exception& e) {
+            KJ_LOG(ERROR, e);
+          }
         }
-      }
-      co_await listenHttp(kj::mv(listener), service, physicalProtocol, kj::mv(rewriter));
-    });
-    tasks.add(handle(kj::mv(listener)).exclusiveJoin(forkedDrainWhen.addBranch()));
+        co_await listenHttp(kj::mv(listener), service, physicalProtocol, kj::mv(rewriter));
+      });
+      tasks.add(handle(kj::mv(listener)).exclusiveJoin(forkedDrainWhen.addBranch()));
+    } else {
+      auto handle = kj::coCapture(
+          [this,&service, rewriter = kj::mv(rewriter), name]
+          (kj::Promise<kj::Own<kj::ConnectionReceiver>> promise)
+              mutable -> kj::Promise<void> {
+        TRACE_EVENT("workerd", "setup listenTcp");
+        auto listener = co_await promise;
+        KJ_IF_SOME(stream, controlOverride) {
+          auto message = kj::str("{\"event\":\"listen\",\"socket\":\"", name, "\",\"port\":", listener->getPort(), "}\n");
+          try {
+            stream->write(message.asBytes());
+          } catch (kj::Exception& e) {
+            KJ_LOG(ERROR, e);
+          }
+        }
+        co_await listenTcp(kj::mv(listener), service, kj::mv(rewriter));
+      });
+      tasks.add(handle(kj::mv(listener)).exclusiveJoin(forkedDrainWhen.addBranch()));
+    }
   }
 
   for (auto& unmatched: socketOverrides) {

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -207,6 +207,9 @@ private:
   kj::Promise<void> listenHttp(kj::Own<kj::ConnectionReceiver> listener, Service& service,
                                kj::StringPtr physicalProtocol, kj::Own<HttpRewriter> rewriter);
 
+  kj::Promise<void> listenTcp(kj::Own<kj::ConnectionReceiver> listener, Service& service,
+                              kj::Own<HttpRewriter> rewriter);
+
   class InvalidConfigService;
   class ExternalHttpService;
   class ExternalTcpService;
@@ -215,6 +218,7 @@ private:
   class WorkerService;
   class WorkerEntrypointService;
   class HttpListener;
+  class TcpListener;
 
   void startServices(jsg::V8System& v8System, config::Config::Reader config,
                      kj::HttpHeaderTable::Builder& headerTableBuilder,

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -118,6 +118,9 @@ struct Socket {
       options @3 :HttpOptions;
       tlsOptions @4 :TlsOptions;
     }
+    tcp :group {
+      tlsOptions @6 :TlsOptions;
+    }
 
     # TODO(someday): TCP, TCP proxy, SMTP, Cap'n Proto, ...
   }

--- a/src/workerd/util/stream-utils.c++
+++ b/src/workerd/util/stream-utils.c++
@@ -208,7 +208,7 @@ kj::Own<NeuterableInputStream> newNeuterableInputStream(kj::AsyncInputStream& in
 }
 
 kj::Own<NeuterableIoStream> newNeuterableIoStream(kj::AsyncIoStream& inner) {
-  return kj::heap<NeuterableIoStreamImpl>(inner);
+  return kj::refcounted<NeuterableIoStreamImpl>(inner);
 }
 
 }  // namespace workerd

--- a/src/workerd/util/stream-utils.h
+++ b/src/workerd/util/stream-utils.h
@@ -18,7 +18,8 @@ public:
   virtual void neuter(kj::Exception ex) = 0;
 };
 
-class NeuterableIoStream: public kj::AsyncIoStream {
+class NeuterableIoStream: public kj::AsyncIoStream,
+                          public kj::Refcounted {
 public:
   virtual void neuter(kj::Exception ex) = 0;
 };


### PR DESCRIPTION
Implements the connect handler and tcp-ingress for a worker

See the samples/tcp-ingress for an example

Note that this is only enabling this for local dev in workerd. A lot more additional work will need to be done internally to support TCP ingress in general but this at least lays the ground work. It also gives us some basic stuff we can use to test the Socket API and `node:net` implementation without relying on the internal production tests.

The proposed *experimental* API here is simple:

* The worker exports a `connect(event, env, ctx)` handler
* The `event` argument has two properties:
  * `inbound` -- A `ReadableStream` that provides access to the inbound data stream.
  * `cf` -- The JSON parsed `cf` structure
* The return value is expected to be a `ReadableStream` or a `Promise<ReadableStream>`, internally this will be piped back to the client in the same way the `fetch()` handler's `Response`.

```
interface ConnectEvent {
  inbound: ReadableStream;
  cf: object;
};

connect(event : ConnectEvent, env: WorkersEnv, ctx: WorkersContext) : Promise<ReadableStream>|ReadableStream
```

This is essentially the same model as the `fetch()` handler with the `Request` and `Response` objects stripped away. 

See this comment for more discussion of the API: https://github.com/cloudflare/workerd/pull/1429#issuecomment-2197791012