### PR TITLE
Fix workers-types release version

### DIFF
--- a/.github/workflows/npm-types.yml
+++ b/.github/workflows/npm-types.yml
@@ -25,7 +25,7 @@ jobs:
       - id: echo
         run: |
           echo "date=$(cat src/workerd/io/supported-compatibility-date.txt)" >> $GITHUB_OUTPUT;
-          echo "version=${{ inputs.prerelease == false && '1' || '0'}}.$(cat src/workerd/io/supported-compatibility-date.txt | tr -d '-').${{ inputs.patch }}" >> $GITHUB_OUTPUT;
+          echo "version=${{ inputs.prerelease == false && '4' || '0'}}.$(cat src/workerd/io/supported-compatibility-date.txt | tr -d '-').${{ inputs.patch }}" >> $GITHUB_OUTPUT;
           echo "release_version=1.$(cat src/workerd/io/supported-compatibility-date.txt | tr -d '-').0" >> $GITHUB_OUTPUT;
   build-and-publish-types:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Hi :wave:

I was wondering why renovate wasn't screaming at me to update workers-types after the release yesterday, turns out that it was released under 1.x.

This PR should fix that and use 4.x which is the latest currently.

Also noticed by @phanect in #1430.

cc @mrbbot