### PR TITLE
Cleanup a handful of workerd/io headers

### DIFF
--- a/src/workerd/io/request-tracker.h
+++ b/src/workerd/io/request-tracker.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <kj/common.h>
-#include <kj/debug.h>
 #include <kj/refcount.h>
 
 namespace workerd {
@@ -22,7 +20,7 @@ public:
   };
 
   // An object that should be associated with (attached to) a request.
-  class ActiveRequest {
+  class ActiveRequest final {
   public:
     // On creation, if the parent RequestTracker has 0 active requests, we call the `active()` hook.
     // On destruction, if the RequestTracker has 0 active requests, we call the `inactive()` hook.

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -541,4 +541,32 @@ kj::Promise<T> WorkerEntrypoint::maybeAddGcPassForTest(
   return kj::mv(promise);
 }
 
+kj::Own<WorkerInterface> newWorkerEntrypoint(
+    ThreadContext& threadContext,
+    kj::Own<const Worker> worker,
+    kj::Maybe<kj::StringPtr> entrypointName,
+    kj::Maybe<kj::Own<Worker::Actor>> actor,
+    kj::Own<LimitEnforcer> limitEnforcer,
+    kj::Own<void> ioContextDependency,
+    kj::Own<IoChannelFactory> ioChannelFactory,
+    kj::Own<RequestObserver> metrics,
+    kj::TaskSet& waitUntilTasks,
+    bool tunnelExceptions,
+    kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
+    kj::Maybe<kj::String> cfBlobJson) {
+  return WorkerEntrypoint::construct(
+      threadContext,
+      kj::mv(worker),
+      kj::mv(entrypointName),
+      kj::mv(actor),
+      kj::mv(limitEnforcer),
+      kj::mv(ioContextDependency),
+      kj::mv(ioChannelFactory),
+      kj::mv(metrics),
+      waitUntilTasks,
+      tunnelExceptions,
+      kj::mv(workerTracer),
+      kj::mv(cfBlobJson));
+}
+
 } // namespace workerd

--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -106,4 +106,18 @@ public:  // For kj::heap() only; pretend this is private.
                    kj::Maybe<kj::String> cfBlobJson);
 };
 
+kj::Own<WorkerInterface> newWorkerEntrypoint(
+    ThreadContext& threadContext,
+    kj::Own<const Worker> worker,
+    kj::Maybe<kj::StringPtr> entrypointName,
+    kj::Maybe<kj::Own<Worker::Actor>> actor,
+    kj::Own<LimitEnforcer> limitEnforcer,
+    kj::Own<void> ioContextDependency,
+    kj::Own<IoChannelFactory> ioChannelFactory,
+    kj::Own<RequestObserver> metrics,
+    kj::TaskSet& waitUntilTasks,
+    bool tunnelExceptions,
+    kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
+    kj::Maybe<kj::String> cfBlobJson);
+
 } // namespace workerd

--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -12,6 +12,10 @@ namespace workerd {
 
 class WorkerTracer;
 
+// TODO(soon): There's no reason to expose the WorkerEntrypoint class here given that it
+// doesn't expose any additional API beyond WorkerInterface. Uses of WorkerEntrypoint::construct
+// should be replaced with newWorkerEntrypoint(...) and this separate header will go away.
+
 // Wrapper around a Worker that handles receiving a new event from the outside. In particular,
 // this handles:
 // - Creating a IoContext and making it current.

--- a/src/workerd/io/worker-interface.c++
+++ b/src/workerd/io/worker-interface.c++
@@ -10,6 +10,7 @@ using kj::uint;
 
 namespace workerd {
 
+namespace {
 // A WorkerInterface that delays requests until some promise resolves, then forwards them to the
 // interface the promise resolved to.
 class PromisedWorkerInterface final: public kj::Refcounted, public WorkerInterface {
@@ -93,6 +94,7 @@ private:
   kj::ForkedPromise<void> promise;
   kj::Maybe<kj::Own<WorkerInterface>> worker;
 };
+}
 
 kj::Own<WorkerInterface> newPromisedWorkerInterface(
     kj::TaskSet& waitUntilTasks, kj::Promise<kj::Own<WorkerInterface>> promise) {
@@ -104,7 +106,7 @@ kj::Own<kj::HttpClient> asHttpClient(kj::Own<WorkerInterface> workerInterface) {
 }
 
 // =======================================================================================
-
+namespace {
 // A Revocable WebSocket wrapper, revoked when revokeProm rejects
 class RevocableWebSocket final: public kj::WebSocket {
 public:
@@ -265,6 +267,8 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
     RevocableWebSocketWorkerInterface::customEvent(kj::Own<CustomEvent> event) {
   return worker.customEvent(kj::mv(event));
 }
+
+}  // namespace
 
 kj::Own<WorkerInterface> newRevocableWebSocketWorkerInterface(
     kj::Own<WorkerInterface> worker,

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -6,17 +6,10 @@
 
 #include <kj/compat/http.h>
 #include <capnp/compat/http-over-capnp.h>
-
 #include <workerd/io/outcome.capnp.h>
 #include <workerd/io/worker-interface.capnp.h>
 
 namespace workerd {
-
-namespace jsg { class Lock; }
-namespace api {
-  class EventTarget;
-  struct ExportedHandler;
-}
 
 class IoContext_IncomingRequest;
 

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -143,26 +143,8 @@ kj::Own<kj::HttpClient> asHttpClient(kj::Own<WorkerInterface> workerInterface);
 
 // A WorkerInterface that cancels WebSockets when revokeProm is rejected.
 // Currently only supports cancelling for upgrades.
-class RevocableWebSocketWorkerInterface final: public WorkerInterface {
-public:
-  RevocableWebSocketWorkerInterface(WorkerInterface& worker, kj::Promise<void> revokeProm);
-  kj::Promise<void> request(
-      kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
-      kj::AsyncInputStream& requestBody, Response& response) override;
-  kj::Promise<void> connect(kj::StringPtr host, const kj::HttpHeaders& headers,
-      kj::AsyncIoStream& connection, ConnectResponse& response,
-      kj::HttpConnectSettings settings) override;
-  void prewarm(kj::StringPtr url) override;
-  kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override;
-  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override;
-  kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override;
-
-private:
-  WorkerInterface& worker;
-  kj::ForkedPromise<void> revokeProm;
-};
-
-kj::Own<RevocableWebSocketWorkerInterface> newRevocableWebSocketWorkerInterface(kj::Own<WorkerInterface> worker,
+kj::Own<WorkerInterface> newRevocableWebSocketWorkerInterface(
+    kj::Own<WorkerInterface> worker,
     kj::Promise<void> revokeProm);
 
 // Implementation of WorkerInterface on top of rpc::EventDispatcher. Since an EventDispatcher

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3778,32 +3778,4 @@ kj::Own<WorkerInterface> Worker::Isolate::wrapSubrequestClient(
   return client;
 }
 
-kj::Own<WorkerInterface> newWorkerEntrypoint(
-    ThreadContext& threadContext,
-    kj::Own<const Worker> worker,
-    kj::Maybe<kj::StringPtr> entrypointName,
-    kj::Maybe<kj::Own<Worker::Actor>> actor,
-    kj::Own<LimitEnforcer> limitEnforcer,
-    kj::Own<void> ioContextDependency,
-    kj::Own<IoChannelFactory> ioChannelFactory,
-    kj::Own<RequestObserver> metrics,
-    kj::TaskSet& waitUntilTasks,
-    bool tunnelExceptions,
-    kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
-    kj::Maybe<kj::String> cfBlobJson) {
-  return WorkerEntrypoint::construct(
-      threadContext,
-      kj::mv(worker),
-      kj::mv(entrypointName),
-      kj::mv(actor),
-      kj::mv(limitEnforcer),
-      kj::mv(ioContextDependency),
-      kj::mv(ioChannelFactory),
-      kj::mv(metrics),
-      waitUntilTasks,
-      tunnelExceptions,
-      kj::mv(workerTracer),
-      kj::mv(cfBlobJson));
-}
-
 }  // namespace workerd

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3367,18 +3367,6 @@ kj::Own<const Worker::Script> Worker::Isolate::newScript(
                                       startType, logNewScript, errorReporter);
 }
 
-kj::Own<WorkerInterface> Worker::Isolate::wrapSubrequestClient(
-    kj::Own<WorkerInterface> client,
-    kj::HttpHeaderId contentEncodingHeaderId,
-    RequestObserver& requestMetrics) const {
-  if (impl->inspector != kj::none) {
-    client = kj::heap<SubrequestClient>(
-        kj::atomicAddRef(*this), kj::mv(client), contentEncodingHeaderId, requestMetrics);
-  }
-
-  return client;
-}
-
 void Worker::Isolate::completedRequest() const {
   limitEnforcer->completedRequest(id);
 }
@@ -3526,6 +3514,34 @@ private:
   LimitedBodyWrapper decodedBuf;
   kj::Maybe<kj::OneOf<kj::GzipOutputStream, kj::BrotliOutputStream>> compStream;
   RequestObserver& requestMetrics;
+};
+
+class Worker::Isolate::SubrequestClient final: public WorkerInterface {
+public:
+  explicit SubrequestClient(kj::Own<const Isolate> isolate,
+      kj::Own<WorkerInterface> inner, kj::HttpHeaderId contentEncodingHeaderId,
+      RequestObserver& requestMetrics)
+      : constIsolate(kj::mv(isolate)), inner(kj::mv(inner)),
+        contentEncodingHeaderId(contentEncodingHeaderId),
+        requestMetrics(kj::addRef(requestMetrics)) {}
+  KJ_DISALLOW_COPY_AND_MOVE(SubrequestClient);
+  kj::Promise<void> request(
+      kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
+      kj::AsyncInputStream& requestBody, kj::HttpService::Response& response) override;
+  kj::Promise<void> connect(
+      kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& connection,
+      kj::HttpService::ConnectResponse& tunnel,
+      kj::HttpConnectSettings settings) override;
+  void prewarm(kj::StringPtr url) override;
+  kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override;
+  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override;
+  kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override;
+
+private:
+  kj::Own<const Isolate> constIsolate;
+  kj::Own<WorkerInterface> inner;
+  kj::HttpHeaderId contentEncodingHeaderId;
+  kj::Own<RequestObserver> requestMetrics;
 };
 
 kj::Promise<void> Worker::Isolate::SubrequestClient::request(
@@ -3747,6 +3763,18 @@ kj::Promise<WorkerInterface::AlarmResult> Worker::Isolate::SubrequestClient::run
 kj::Promise<WorkerInterface::CustomEvent::Result>
     Worker::Isolate::SubrequestClient::customEvent(kj::Own<CustomEvent> event) {
   return inner->customEvent(kj::mv(event));
+}
+
+kj::Own<WorkerInterface> Worker::Isolate::wrapSubrequestClient(
+    kj::Own<WorkerInterface> client,
+    kj::HttpHeaderId contentEncodingHeaderId,
+    RequestObserver& requestMetrics) const {
+  if (impl->inspector != kj::none) {
+    client = kj::heap<SubrequestClient>(
+        kj::atomicAddRef(*this), kj::mv(client), contentEncodingHeaderId, requestMetrics);
+  }
+
+  return client;
 }
 
 }  // namespace workerd

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -6,6 +6,7 @@
 #include <workerd/io/worker.h>
 #include <workerd/io/promise-wrapper.h>
 #include "actor-cache.h"
+#include "worker-entrypoint.h"
 #include <workerd/util/batch-queue.h>
 #include <workerd/util/color-util.h>
 #include <workerd/util/mimetype.h>
@@ -3775,6 +3776,34 @@ kj::Own<WorkerInterface> Worker::Isolate::wrapSubrequestClient(
   }
 
   return client;
+}
+
+kj::Own<WorkerInterface> newWorkerEntrypoint(
+    ThreadContext& threadContext,
+    kj::Own<const Worker> worker,
+    kj::Maybe<kj::StringPtr> entrypointName,
+    kj::Maybe<kj::Own<Worker::Actor>> actor,
+    kj::Own<LimitEnforcer> limitEnforcer,
+    kj::Own<void> ioContextDependency,
+    kj::Own<IoChannelFactory> ioChannelFactory,
+    kj::Own<RequestObserver> metrics,
+    kj::TaskSet& waitUntilTasks,
+    bool tunnelExceptions,
+    kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
+    kj::Maybe<kj::String> cfBlobJson) {
+  return WorkerEntrypoint::construct(
+      threadContext,
+      kj::mv(worker),
+      kj::mv(entrypointName),
+      kj::mv(actor),
+      kj::mv(limitEnforcer),
+      kj::mv(ioContextDependency),
+      kj::mv(ioChannelFactory),
+      kj::mv(metrics),
+      waitUntilTasks,
+      tunnelExceptions,
+      kj::mv(workerTracer),
+      kj::mv(cfBlobJson));
 }
 
 }  // namespace workerd

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -884,18 +884,4 @@ private:
   friend class Worker::AsyncLock;
 };
 
-kj::Own<WorkerInterface> newWorkerEntrypoint(
-    ThreadContext& threadContext,
-    kj::Own<const Worker> worker,
-    kj::Maybe<kj::StringPtr> entrypointName,
-    kj::Maybe<kj::Own<Worker::Actor>> actor,
-    kj::Own<LimitEnforcer> limitEnforcer,
-    kj::Own<void> ioContextDependency,
-    kj::Own<IoChannelFactory> ioChannelFactory,
-    kj::Own<RequestObserver> metrics,
-    kj::TaskSet& waitUntilTasks,
-    bool tunnelExceptions,
-    kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
-    kj::Maybe<kj::String> cfBlobJson);
-
 } // namespace workerd

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -23,6 +23,14 @@ namespace v8 { class Isolate; }
 
 namespace workerd {
 
+namespace jsg {
+  // TODO(cleanup): While this isn't used directly in worker.h or worker.c++, it is
+  // used transitively by internal repo source files. Those will need to be updated
+  // to import or define jsg::V8System where appropriate before we can remove this
+  // declaration.
+  class V8System;
+}
+
 namespace api {
   class DurableObjectState;
   class DurableObjectStorage;

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -446,34 +446,7 @@ private:
   // enum, which unfortunately we cannot forward-declare, ugh.
   void logMessage(jsg::Lock& js, uint16_t type, kj::StringPtr description);
 
-  class SubrequestClient final: public WorkerInterface {
-  public:
-    explicit SubrequestClient(kj::Own<const Isolate> isolate,
-        kj::Own<WorkerInterface> inner, kj::HttpHeaderId contentEncodingHeaderId,
-        RequestObserver& requestMetrics)
-        : constIsolate(kj::mv(isolate)), inner(kj::mv(inner)),
-          contentEncodingHeaderId(contentEncodingHeaderId),
-          requestMetrics(kj::addRef(requestMetrics)) {}
-    KJ_DISALLOW_COPY_AND_MOVE(SubrequestClient);
-    kj::Promise<void> request(
-        kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
-        kj::AsyncInputStream& requestBody, kj::HttpService::Response& response) override;
-    kj::Promise<void> connect(
-        kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& connection,
-        kj::HttpService::ConnectResponse& tunnel,
-        kj::HttpConnectSettings settings) override;
-    void prewarm(kj::StringPtr url) override;
-    kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override;
-    kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override;
-    kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override;
-
-  private:
-    kj::Own<const Isolate> constIsolate;
-    kj::Own<WorkerInterface> inner;
-    kj::HttpHeaderId contentEncodingHeaderId;
-    kj::Own<RequestObserver> requestMetrics;
-  };
-
+  class SubrequestClient;
   class ResponseStreamWrapper;
   class LimitedBodyWrapper;
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -35,6 +35,7 @@ namespace api {
   class WebSocketRequestResponsePair;
 }
 
+class ThreadContext;
 class IoContext;
 class InputGate;
 class OutputGate;
@@ -882,5 +883,19 @@ private:
   friend class Worker::Isolate;
   friend class Worker::AsyncLock;
 };
+
+kj::Own<WorkerInterface> newWorkerEntrypoint(
+    ThreadContext& threadContext,
+    kj::Own<const Worker> worker,
+    kj::Maybe<kj::StringPtr> entrypointName,
+    kj::Maybe<kj::Own<Worker::Actor>> actor,
+    kj::Own<LimitEnforcer> limitEnforcer,
+    kj::Own<void> ioContextDependency,
+    kj::Own<IoChannelFactory> ioChannelFactory,
+    kj::Own<RequestObserver> metrics,
+    kj::TaskSet& waitUntilTasks,
+    bool tunnelExceptions,
+    kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
+    kj::Maybe<kj::String> cfBlobJson);
 
 } // namespace workerd

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -23,13 +23,6 @@ namespace v8 { class Isolate; }
 
 namespace workerd {
 
-namespace jsg {
-  class V8System;
-  class V8StackScope;
-  class DOMException;
-  class ModuleRegistry;
-}
-
 namespace api {
   class DurableObjectState;
   class DurableObjectStorage;

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -13,6 +13,7 @@
 #include <capnp/compat/json.h>
 #include <workerd/api/analytics-engine.capnp.h>
 #include <workerd/io/worker-interface.h>
+#include <workerd/io/worker-entrypoint.h>
 #include <workerd/io/compatibility-date.h>
 #include <workerd/io/io-context.h>
 #include <workerd/io/worker.h>

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -13,7 +13,6 @@
 #include <capnp/compat/json.h>
 #include <workerd/api/analytics-engine.capnp.h>
 #include <workerd/io/worker-interface.h>
-#include <workerd/io/worker-entrypoint.h>
 #include <workerd/io/compatibility-date.h>
 #include <workerd/io/io-context.h>
 #include <workerd/io/worker.h>
@@ -1354,7 +1353,7 @@ public:
   kj::Own<WorkerInterface> startRequest(
       IoChannelFactory::SubrequestMetadata metadata, kj::Maybe<kj::StringPtr> entrypointName,
       kj::Maybe<kj::Own<Worker::Actor>> actor = kj::none) {
-    return WorkerEntrypoint::construct(
+    return newWorkerEntrypoint(
         threadContext,
         kj::atomicAddRef(*worker),
         entrypointName,

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -10,7 +10,6 @@
 #include <workerd/io/io-channels.h>
 #include <workerd/io/limit-enforcer.h>
 #include <workerd/io/observer.h>
-#include <workerd/io/worker-entrypoint.h>
 #include <workerd/jsg/modules.h>
 #include <workerd/server/server.h>
 #include <workerd/server/workerd-api.h>


### PR DESCRIPTION
No functional changes here. Just cleaning up headers a bit by moving a couple of class definitions out of the header and into the c++ they are used. Plus removing a couple of unnecessary symbol definitions.