### PR TITLE
Update to V8 12.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -52,7 +52,7 @@ build:thin-lto --linkopt='-flto=thin'
 # configuration used for performance profiling
 build:profile --config=thin-lto
 build:profile --copt="-fno-omit-frame-pointer" --copt="-mno-omit-leaf-frame-pointer"
-build:profile --copt='-gline-tables-only' --linkopt='-gline-tables-only' --strip=never
+build:profile --copt='-g1' --linkopt='-g1' --strip=never
 
 # configuration used for performance benchmarking is the same as profiling for consistency
 build:benchmark --config=profile
@@ -65,8 +65,8 @@ build:unix --cxxopt='-gsimple-template-names' --host_cxxopt='-gsimple-template-n
 
 # Define a config mode which is fastbuild but with basic debug info.
 build:fastdbg -c fastbuild
-build:fastdbg --cxxopt='-gline-tables-only' --host_cxxopt='-gline-tables-only'
-build:fastdbg --linkopt='-gline-tables-only' --host_linkopt='-gline-tables-only'
+build:fastdbg --cxxopt='-g1' --host_cxxopt='-g1'
+build:fastdbg --linkopt='-g1' --host_linkopt='-g1'
 build:fastdbg --strip=never
 build:fastdbg --//:dead_strip=False
 
@@ -109,8 +109,6 @@ build:asan --test_env=ASAN_OPTIONS=abort_on_error=true
 build:unix --workspace_status_command=./tools/unix/workspace-status.sh
 
 build:unix --cxxopt='-std=c++20' --host_cxxopt='-std=c++20'
-build:unix --cxxopt='-stdlib=libc++' --host_cxxopt='-stdlib=libc++'
-build:unix --linkopt='-stdlib=libc++' --host_linkopt='-stdlib=libc++'
 build:unix --@capnp-cpp//src/kj:libdl=True
 
 build:unix --action_env=BAZEL_COMPILER=clang
@@ -139,6 +137,8 @@ build:macos --config=unix
 build:macos --macos_minimum_os=11.0 --host_macos_minimum_os=11.0
 
 # On Linux, always link libc++ statically to avoid compatibility issues with different OS versions.
+build:linux --cxxopt='-stdlib=libc++' --host_cxxopt='-stdlib=libc++'
+build:linux --linkopt='-stdlib=libc++' --host_linkopt='-stdlib=libc++'
 build:linux --action_env=BAZEL_LINKLIBS='-l%:libc++.a -lm -static-libgcc'
 
 # On Linux, enable PIC. In macos pic is the default, and the objc_library rule does not work

--- a/.bazelrc
+++ b/.bazelrc
@@ -35,6 +35,11 @@ build:windows --per_file_copt='external/v8/src/compiler/graph-visualizer.cc@/std
 build:windows --per_file_copt='external/dawn@-Wno-macro-redefined'
 build:windows --host_per_file_copt='external/dawn@-Wno-macro-redefined'
 
+# V8 is experiencing crashes on (at least) arm64 macOS as of 12.0 without enabling external code
+# spaces. This flag is enabled in the default GN build anyway, so define it on all platforms for
+# now.
+build --per_file_copt='external/v8@-DV8_EXTERNAL_CODE_SPACE'
+
 # Speed up sandboxed compilation, particularly on I/O-constrained and non-Linux systems
 # https://bazel.build/reference/command-line-reference#flag--reuse_sandbox_directories
 build --reuse_sandbox_directories

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -347,28 +347,28 @@ http_archive(
         "//:patches/v8/0012-Fix-V8-ICU-build.patch",
         "//:patches/v8/0013-Randomize-the-initial-ExecutionContextId-used-by-the.patch",
     ],
-    sha256 = "5a28ff9feff6d5efee118b11ba994319c63224192f25530e4e296464cf7b8f96",
-    strip_prefix = "v8-v8-934b99f",
+    sha256 = "1202ec7841f98d7dda35f998dc0e29f177f01c2d573adcde900d8633da4668dc",
+    strip_prefix = "v8-v8-5eefc59",
     type = "tgz",
-    url = "https://github.com/v8/v8/tarball/934b99feafeaaafca2d9e587d586afc8687dea80",
+    url = "https://github.com/v8/v8/tarball/5eefc590c868d8dfb411e53053c963fe42dcda74",
 )
 
 new_git_repository(
     name = "com_googlesource_chromium_icu",
     build_file = "@v8//:bazel/BUILD.icu",
-    commit = "de4ce0071eb47ed54cbda54869001210cf3a8ae5",
+    commit = "a622de35ac311c5ad390a7af80724634e5dc61ed",
     patch_cmds = ["find source -name BUILD.bazel | xargs rm"],
     patch_cmds_win = ["Get-ChildItem -Path source -File -Include BUILD.bazel -Recurse | Remove-Item"],
     remote = "https://chromium.googlesource.com/chromium/deps/icu.git",
-    shallow_since = "1690331196 +0000",
+    shallow_since = "1697047535 +0000",
 )
 
 new_git_repository(
     name = "com_googlesource_chromium_base_trace_event_common",
     build_file = "@v8//:bazel/BUILD.trace_event_common",
-    commit = "147f65333c38ddd1ebf554e89965c243c8ce50b3",
+    commit = "29ac73db520575590c3aceb0a6f1f58dda8934f6",
     remote = "https://chromium.googlesource.com/chromium/src/base/trace_event/common.git",
-    shallow_since = "1676317690 -0800",
+    shallow_since = "1695357423 -0700",
 )
 
 # This sets up a hermetic python3, rather than depending on what is installed.

--- a/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
+++ b/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
@@ -1,4 +1,4 @@
-From 884d0da5db2919b55b885a690f513d8437ad07f9 Mon Sep 17 00:00:00 2001
+From ba9d172709f77de0953f158e321d81d6ca333fe5 Mon Sep 17 00:00:00 2001
 From: Alex Robinson <arobinson@cloudflare.com>
 Date: Wed, 2 Mar 2022 15:58:04 -0600
 Subject: Allow manually setting ValueDeserializer format version
@@ -40,10 +40,10 @@ index 0cb3e045bc46ec732956318b980e749d1847d06d..40ad805c7970cc9379e69f046205836d
     * Reads raw data in various common formats to the buffer.
     * Note that integer types are read in base-128 varint format, not with a
 diff --git a/src/api/api.cc b/src/api/api.cc
-index eede52c9cc9baf599dca3b9279a9b263a75062da..486cadf9eb807166556cdd20179484e51f1edb98 100644
+index 766fa25e8b7c2f8bb8ba401cc5d2b5f9dc478cb9..5703f0f3da3981af216a9057cee3d598481680b4 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -3607,6 +3607,10 @@ uint32_t ValueDeserializer::GetWireFormatVersion() const {
+@@ -3622,6 +3622,10 @@ uint32_t ValueDeserializer::GetWireFormatVersion() const {
    return private_->deserializer.GetWireFormatVersion();
  }
  
@@ -55,7 +55,7 @@ index eede52c9cc9baf599dca3b9279a9b263a75062da..486cadf9eb807166556cdd20179484e5
    PREPARE_FOR_EXECUTION(context, ValueDeserializer, ReadValue, Value);
    i::MaybeHandle<i::Object> result;
 diff --git a/src/objects/value-serializer.h b/src/objects/value-serializer.h
-index f5ccdcbf0a5f0c61c739a6a36f5fbe5bedf43934..f3d35e9498b664ff02e77da0e5ef3240c3e054b4 100644
+index 9b2d97cf79a21ff6d352172efaf53fdca4ac8e7b..8d9602b129a6156f051690ed595ca699bb132af4 100644
 --- a/src/objects/value-serializer.h
 +++ b/src/objects/value-serializer.h
 @@ -217,6 +217,13 @@ class ValueDeserializer {

--- a/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
+++ b/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
@@ -1,4 +1,4 @@
-From eb14f78eff4a92b08f0668c22a07c22b8e62f791 Mon Sep 17 00:00:00 2001
+From a8f62f70ab91dc492f4f7ea5694543361ce5c328 Mon Sep 17 00:00:00 2001
 From: James M Snell <jasnell@gmail.com>
 Date: Wed, 16 Mar 2022 08:59:21 -0700
 Subject: Allow manually setting ValueSerializer format version
@@ -28,10 +28,10 @@ index 40ad805c7970cc9379e69f046205836dbd760373..596be18adeb3a5a81794aaa44b1d347d
     * Writes out a header, which includes the format version.
     */
 diff --git a/src/api/api.cc b/src/api/api.cc
-index 486cadf9eb807166556cdd20179484e51f1edb98..4ab15c368cba3e86f611dfbfa5a6f6be7a493510 100644
+index 5703f0f3da3981af216a9057cee3d598481680b4..600fd75068e46e2160cb537c242b4449b6223dd6 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -3474,6 +3474,10 @@ ValueSerializer::ValueSerializer(Isolate* v8_isolate, Delegate* delegate)
+@@ -3489,6 +3489,10 @@ ValueSerializer::ValueSerializer(Isolate* v8_isolate, Delegate* delegate)
  
  ValueSerializer::~ValueSerializer() { delete private_; }
  
@@ -43,7 +43,7 @@ index 486cadf9eb807166556cdd20179484e51f1edb98..4ab15c368cba3e86f611dfbfa5a6f6be
  
  void ValueSerializer::SetTreatArrayBufferViewsAsHostObjects(bool mode) {
 diff --git a/src/objects/value-serializer.cc b/src/objects/value-serializer.cc
-index d6251bc840631697ecd281131a9679c3ee4794b9..8b93c9c6a288c63455c3970f2cbc64a771b9e6e5 100644
+index 6cde1bbf19b559ac42434f59be9fe13bfbb7f9de..bda96357a9de989bbe9f241455d0e97ed1acc012 100644
 --- a/src/objects/value-serializer.cc
 +++ b/src/objects/value-serializer.cc
 @@ -266,6 +266,7 @@ ValueSerializer::ValueSerializer(Isolate* isolate,
@@ -73,7 +73,7 @@ index d6251bc840631697ecd281131a9679c3ee4794b9..8b93c9c6a288c63455c3970f2cbc64a7
  }
  
  void ValueSerializer::SetTreatArrayBufferViewsAsHostObjects(bool mode) {
-@@ -1005,10 +1014,12 @@ Maybe<bool> ValueSerializer::WriteJSArrayBufferView(JSArrayBufferView view) {
+@@ -1010,10 +1019,12 @@ Maybe<bool> ValueSerializer::WriteJSArrayBufferView(
    WriteVarint(static_cast<uint8_t>(tag));
    WriteVarint(static_cast<uint32_t>(view->byte_offset()));
    WriteVarint(static_cast<uint32_t>(view->byte_length()));
@@ -89,7 +89,7 @@ index d6251bc840631697ecd281131a9679c3ee4794b9..8b93c9c6a288c63455c3970f2cbc64a7
  }
  
 diff --git a/src/objects/value-serializer.h b/src/objects/value-serializer.h
-index f3d35e9498b664ff02e77da0e5ef3240c3e054b4..d3d839ad108c8ce39437119e0dbae393fad1467a 100644
+index 8d9602b129a6156f051690ed595ca699bb132af4..4747119155007e1fa0075440fefa1dfee036c48a 100644
 --- a/src/objects/value-serializer.h
 +++ b/src/objects/value-serializer.h
 @@ -54,6 +54,11 @@ class ValueSerializer {

--- a/patches/v8/0003-Make-icudata-target-public.patch
+++ b/patches/v8/0003-Make-icudata-target-public.patch
@@ -1,4 +1,4 @@
-From 4b730384778e24d4d317ccc20d71f70d7477a935 Mon Sep 17 00:00:00 2001
+From 36e20764261268ac3b6a0e834786854aa0a0ddbf Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Sat, 17 Sep 2022 11:11:15 -0500
 Subject: Make `:icudata` target public.

--- a/patches/v8/0004-Add-ArrayBuffer-MaybeNew.patch
+++ b/patches/v8/0004-Add-ArrayBuffer-MaybeNew.patch
@@ -1,4 +1,4 @@
-From 774a632084763381b4da39a038798527575d87a9 Mon Sep 17 00:00:00 2001
+From 783d4bdbb3af8f45ea22aedafe22e6bebc1f9102 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Fri, 16 Sep 2022 21:41:45 -0500
 Subject: Add `ArrayBuffer::MaybeNew()`.

--- a/patches/v8/0005-Allow-Windows-builds-under-Bazel.patch
+++ b/patches/v8/0005-Allow-Windows-builds-under-Bazel.patch
@@ -1,4 +1,4 @@
-From ed0aca8cd1673f3ff6e3f197058114d94fb51c7a Mon Sep 17 00:00:00 2001
+From da7ffe97fe6ba0514759f995345dcde12e452360 Mon Sep 17 00:00:00 2001
 From: Brendan Coll <bcoll@cloudflare.com>
 Date: Thu, 16 Mar 2023 11:56:10 +0000
 Subject: Allow Windows builds under Bazel
@@ -10,10 +10,10 @@ Subject: Allow Windows builds under Bazel
  3 files changed, 84 insertions(+), 12 deletions(-)
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index e6c21c523fa70388d12cedb599b1d2de2e98c55c..67442408206c3221317e32606e7f18fb349ec2e2 100644
+index becfc1304cace93babe4460a878473ec4866c500..a723ce02345a342da06ec4627926a93d8bdcaa36 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -689,6 +689,7 @@ filegroup(
+@@ -702,6 +702,7 @@ filegroup(
          "src/base/platform/mutex.h",
          "src/base/platform/platform.cc",
          "src/base/platform/platform.h",
@@ -21,7 +21,7 @@ index e6c21c523fa70388d12cedb599b1d2de2e98c55c..67442408206c3221317e32606e7f18fb
          "src/base/platform/semaphore.cc",
          "src/base/platform/semaphore.h",
          "src/base/platform/time.cc",
-@@ -728,7 +729,6 @@ filegroup(
+@@ -742,7 +743,6 @@ filegroup(
      ] + select({
          "@v8//bazel/config:is_posix": [
              "src/base/platform/platform-posix.cc",
@@ -29,7 +29,7 @@ index e6c21c523fa70388d12cedb599b1d2de2e98c55c..67442408206c3221317e32606e7f18fb
              "src/base/platform/platform-posix-time.cc",
              "src/base/platform/platform-posix-time.h",
          ],
-@@ -751,6 +751,7 @@ filegroup(
+@@ -765,6 +765,7 @@ filegroup(
          "@v8//bazel/config:is_windows": [
              "src/base/debug/stack_trace_win.cc",
              "src/base/platform/platform-win32.cc",
@@ -37,7 +37,7 @@ index e6c21c523fa70388d12cedb599b1d2de2e98c55c..67442408206c3221317e32606e7f18fb
              "src/base/win32-headers.h",
          ],
      }),
-@@ -1135,6 +1136,7 @@ filegroup(
+@@ -1151,6 +1152,7 @@ filegroup(
          "include/v8-wasm-trap-handler-posix.h",
          "src/api/api.cc",
          "src/api/api.h",
@@ -45,7 +45,7 @@ index e6c21c523fa70388d12cedb599b1d2de2e98c55c..67442408206c3221317e32606e7f18fb
          "src/api/api-arguments.cc",
          "src/api/api-arguments.h",
          "src/api/api-arguments-inl.h",
-@@ -2537,6 +2539,11 @@ filegroup(
+@@ -2567,6 +2569,11 @@ filegroup(
              "src/trap-handler/handler-inside-posix.cc",
              "src/trap-handler/handler-outside-posix.cc",
          ],
@@ -57,7 +57,7 @@ index e6c21c523fa70388d12cedb599b1d2de2e98c55c..67442408206c3221317e32606e7f18fb
          "//conditions:default": [],
      }) + select({
          "@v8//bazel/config:v8_arm64_simulator": [
-@@ -2544,13 +2551,6 @@ filegroup(
+@@ -2574,13 +2581,6 @@ filegroup(
              "src/trap-handler/trap-handler-simulator.h",
          ],
          "//conditions:default": [],
@@ -71,7 +71,7 @@ index e6c21c523fa70388d12cedb599b1d2de2e98c55c..67442408206c3221317e32606e7f18fb
      }) + select({
          "@v8//bazel/config:is_windows_64bit": [
              "src/diagnostics/unwinding-info-win64.cc",
-@@ -3405,6 +3405,9 @@ filegroup(
+@@ -3470,6 +3470,9 @@ filegroup(
          "@v8//bazel/config:is_msvc_asm_ia32": ["src/heap/base/asm/ia32/push_registers_masm.asm"],
          "@v8//bazel/config:is_msvc_asm_x64": ["src/heap/base/asm/x64/push_registers_masm.asm"],
          "@v8//bazel/config:is_msvc_asm_arm64": ["src/heap/base/asm/arm64/push_registers_masm.S"],
@@ -81,7 +81,7 @@ index e6c21c523fa70388d12cedb599b1d2de2e98c55c..67442408206c3221317e32606e7f18fb
      }),
  )
  
-@@ -3768,9 +3771,11 @@ filegroup(
+@@ -3833,9 +3836,11 @@ filegroup(
          "src/d8/d8-js.cc",
          "src/d8/d8-platforms.cc",
          "src/d8/d8-platforms.h",
@@ -95,7 +95,7 @@ index e6c21c523fa70388d12cedb599b1d2de2e98c55c..67442408206c3221317e32606e7f18fb
  )
  
  genrule(
-@@ -4103,7 +4108,7 @@ py_test(
+@@ -4168,7 +4173,7 @@ py_test(
          ":noicu/d8",
          ":noicu/v8_build_config",
          "//testing/pybase",
@@ -104,7 +104,7 @@ index e6c21c523fa70388d12cedb599b1d2de2e98c55c..67442408206c3221317e32606e7f18fb
      main = "tools/run-tests.py",
      python_version = "PY3",
      tags = [
-@@ -4133,7 +4138,7 @@ py_test(
+@@ -4198,7 +4203,7 @@ py_test(
          ":icu/d8",
          ":icu/v8_build_config",
          "//testing/pybase",
@@ -183,7 +183,7 @@ index 67454fa90eea460e70e286623fb1c99edd22c650..7efff1ab909dc7048a216e511c2e71c7
      name = "is_clang",
      match_any = [
 diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index 09844919a5b572184d61530a99036c2c5116535b..b77cc065b2f5881c5dfb8da39d2019f5d62428a2 100644
+index b0b5eab46219f2abd263221de12c07a5cc7b2b10..0c59518819cb685fe9f68080d6bdbeb0b7ff5033 100644
 --- a/bazel/defs.bzl
 +++ b/bazel/defs.bzl
 @@ -117,6 +117,24 @@ def _default_args():

--- a/patches/v8/0006-Disable-bazel-whole-archive-build.patch
+++ b/patches/v8/0006-Disable-bazel-whole-archive-build.patch
@@ -1,4 +1,4 @@
-From 701efdfea314ed50cc891909f5f7ea46a9d46e6a Mon Sep 17 00:00:00 2001
+From 333416eabea56d35811db3f93dd4309ec03675da Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Tue, 11 Apr 2023 14:41:31 -0400
 Subject: Disable bazel whole-archive build

--- a/patches/v8/0007-Make-v8-Locker-automatically-call-isolate-Enter.patch
+++ b/patches/v8/0007-Make-v8-Locker-automatically-call-isolate-Enter.patch
@@ -1,4 +1,4 @@
-From 4720632c8dd43200a8b6239e294854c9e0ad542d Mon Sep 17 00:00:00 2001
+From 2b3cf4416ac4112cfadab1adaadc3bef0ce8c471 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Tue, 23 May 2023 09:18:57 -0500
 Subject: Make v8::Locker automatically call isolate->Enter().
@@ -13,7 +13,7 @@ This is a major change in API semantics, however, which makes it unlikely to be 
  1 file changed, 2 insertions(+)
 
 diff --git a/src/execution/v8threads.cc b/src/execution/v8threads.cc
-index be4f4a7f209e3e8d784d8ab57d0ef77a58df8790..fb525314d9fb6dca143dbe45bfd6dbf53af132c8 100644
+index 9d4437c75e62cd003f957bdf7147c30c96a7d010..6cca4773929fc526d03cb64b0a448925f8f3f813 100644
 --- a/src/execution/v8threads.cc
 +++ b/src/execution/v8threads.cc
 @@ -40,6 +40,7 @@ void Locker::Initialize(v8::Isolate* isolate) {

--- a/patches/v8/0008-Add-an-API-to-capture-and-restore-the-cage-base-poin.patch
+++ b/patches/v8/0008-Add-an-API-to-capture-and-restore-the-cage-base-poin.patch
@@ -1,4 +1,4 @@
-From 2dcafa63669e7bb6dd626d20dc0278cab4e0f4d6 Mon Sep 17 00:00:00 2001
+From ac99498f6339d5610bd1c969d3b80286523083e6 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Tue, 23 May 2023 09:24:11 -0500
 Subject: Add an API to capture and restore the cage base pointers.
@@ -60,7 +60,7 @@ index 22b7a8767a83a702a2601bdfd4c0f71206df0ad5..fee48faffe82400595dca17197c5bbee
  
  #endif  // INCLUDE_V8_LOCKER_H_
 diff --git a/src/execution/v8threads.cc b/src/execution/v8threads.cc
-index fb525314d9fb6dca143dbe45bfd6dbf53af132c8..231eb53a7bd8c5545009580b712e22b084cabc65 100644
+index 6cca4773929fc526d03cb64b0a448925f8f3f813..c8ec9ee02356eba8977ef14a9de42ef9c23cb69e 100644
 --- a/src/execution/v8threads.cc
 +++ b/src/execution/v8threads.cc
 @@ -6,6 +6,7 @@
@@ -71,7 +71,7 @@ index fb525314d9fb6dca143dbe45bfd6dbf53af132c8..231eb53a7bd8c5545009580b712e22b0
  #include "src/debug/debug.h"
  #include "src/execution/execution.h"
  #include "src/execution/isolate-inl.h"
-@@ -318,4 +319,35 @@ void ThreadManager::IterateArchivedThreads(ThreadVisitor* v) {
+@@ -330,4 +331,35 @@ void ThreadManager::IterateArchivedThreads(ThreadVisitor* v) {
  ThreadId ThreadManager::CurrentId() { return ThreadId::Current(); }
  
  }  // namespace internal

--- a/patches/v8/0009-Speed-up-V8-bazel-build-by-always-using-target-cfg.patch
+++ b/patches/v8/0009-Speed-up-V8-bazel-build-by-always-using-target-cfg.patch
@@ -1,4 +1,4 @@
-From 4f79d6ff2fab319f0c61fba66ba80feb1ff5d05e Mon Sep 17 00:00:00 2001
+From b9440c851a29e834ea7834e794cc279210473bfc Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Wed, 7 Jun 2023 21:40:54 -0400
 Subject: Speed up V8 bazel build by always using target cfg
@@ -16,7 +16,7 @@ this also improves build times.
  2 files changed, 57 insertions(+), 16 deletions(-)
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 67442408206c3221317e32606e7f18fb349ec2e2..baaa3d6b1a14c23f017c9e4c7675de0a99df10ea 100644
+index a723ce02345a342da06ec4627926a93d8bdcaa36..cb12609f12374905c31892534cf9d44d555202bd 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
 @@ -17,6 +17,7 @@ load(
@@ -27,7 +27,7 @@ index 67442408206c3221317e32606e7f18fb349ec2e2..baaa3d6b1a14c23f017c9e4c7675de0a
  )
  load(":bazel/v8-non-pointer-compression.bzl", "v8_binary_non_pointer_compression")
  
-@@ -3778,22 +3779,20 @@ filegroup(
+@@ -3843,22 +3844,20 @@ filegroup(
      }),
  )
  
@@ -56,7 +56,7 @@ index 67442408206c3221317e32606e7f18fb349ec2e2..baaa3d6b1a14c23f017c9e4c7675de0a
  )
  
  v8_mksnapshot(
-@@ -3990,8 +3989,6 @@ v8_binary(
+@@ -4055,8 +4054,6 @@ v8_binary(
      srcs = [
          "src/regexp/gen-regexp-special-case.cc",
          "src/regexp/special-case.h",
@@ -65,7 +65,7 @@ index 67442408206c3221317e32606e7f18fb349ec2e2..baaa3d6b1a14c23f017c9e4c7675de0a
      ],
      copts = ["-Wno-implicit-fallthrough"],
      defines = [
-@@ -4003,6 +4000,7 @@ v8_binary(
+@@ -4068,6 +4065,7 @@ v8_binary(
      ],
      deps = [
          "//external:absl_optional",
@@ -74,7 +74,7 @@ index 67442408206c3221317e32606e7f18fb349ec2e2..baaa3d6b1a14c23f017c9e4c7675de0a
      ],
  )
 diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index b77cc065b2f5881c5dfb8da39d2019f5d62428a2..6b5482d259ceadff5f9926244eb14a0f6e9eb5ca 100644
+index 0c59518819cb685fe9f68080d6bdbeb0b7ff5033..7053ca31b999ae7423e7485ee6392a09f9de4aa9 100644
 --- a/bazel/defs.bzl
 +++ b/bazel/defs.bzl
 @@ -336,6 +336,15 @@ def v8_library(
@@ -127,7 +127,7 @@ index b77cc065b2f5881c5dfb8da39d2019f5d62428a2..6b5482d259ceadff5f9926244eb14a0f
  )
  
  def v8_mksnapshot(name, args, suffix = ""):
-@@ -635,3 +647,34 @@ def v8_build_config(name):
+@@ -636,3 +648,34 @@ def v8_build_config(name):
          outs = ["icu/" + name + ".json"],
          cmd = "echo '" + build_config_content(cpu, "true") + "' > \"$@\"",
      )

--- a/patches/v8/0010-Implement-Promise-Context-Tagging.patch
+++ b/patches/v8/0010-Implement-Promise-Context-Tagging.patch
@@ -1,4 +1,4 @@
-From 76470310f1f3d20e3e46f912078fa72864c29a22 Mon Sep 17 00:00:00 2001
+From e93c7b6f7914d4429c37c0716f840bc5a7d95f9f Mon Sep 17 00:00:00 2001
 From: James M Snell <jasnell@gmail.com>
 Date: Thu, 22 Jun 2023 15:29:26 -0700
 Subject: Implement Promise Context Tagging
@@ -23,12 +23,12 @@ Subject: Implement Promise Context Tagging
  16 files changed, 182 insertions(+), 5 deletions(-)
 
 diff --git a/include/v8-callbacks.h b/include/v8-callbacks.h
-index 897b1b0b079efd721bf4c14c9906c05c45fd2c85..17741803083b245781e4957f88538d83326bdd12 100644
+index 2a25b9ee04e003ee69ec91a614769b43be9cd2eb..8736ed62924d12ff679cd99fdb100df6919ebd8d 100644
 --- a/include/v8-callbacks.h
 +++ b/include/v8-callbacks.h
-@@ -424,6 +424,15 @@ using PrepareStackTraceCallback = MaybeLocal<Value> (*)(Local<Context> context,
-                                                         Local<Value> error,
-                                                         Local<Array> sites);
+@@ -463,6 +463,15 @@ using FilterETWSessionByURLCallback =
+     bool (*)(Local<Context> context, const std::string& etw_filter_payload);
+ #endif  // V8_OS_WIN
  
 +/**
 + * PromiseCrossContextCallback is called when following a promise and the
@@ -43,10 +43,10 @@ index 897b1b0b079efd721bf4c14c9906c05c45fd2c85..17741803083b245781e4957f88538d83
  
  #endif  // INCLUDE_V8_ISOLATE_CALLBACKS_H_
 diff --git a/include/v8-isolate.h b/include/v8-isolate.h
-index 02bdd6eaad381a218024148798f1c24d9b7421f7..34c9ab6a33285223dba1e1b17ba10a43a34c431a 100644
+index efec02d3bbc8d3e76313abb256c68418f425f7ef..740093089bdfc4c94331a17b4b62a78c87c28e88 100644
 --- a/include/v8-isolate.h
 +++ b/include/v8-isolate.h
-@@ -1667,6 +1667,9 @@ class V8_EXPORT Isolate {
+@@ -1680,6 +1680,9 @@ class V8_EXPORT Isolate {
     */
    void LocaleConfigurationChangeNotification();
  
@@ -56,7 +56,7 @@ index 02bdd6eaad381a218024148798f1c24d9b7421f7..34c9ab6a33285223dba1e1b17ba10a43
    Isolate() = delete;
    ~Isolate() = delete;
    Isolate(const Isolate&) = delete;
-@@ -1711,6 +1714,19 @@ MaybeLocal<T> Isolate::GetDataFromSnapshotOnce(size_t index) {
+@@ -1724,6 +1727,19 @@ MaybeLocal<T> Isolate::GetDataFromSnapshotOnce(size_t index) {
    return Local<T>::FromSlot(slot);
  }
  
@@ -77,10 +77,10 @@ index 02bdd6eaad381a218024148798f1c24d9b7421f7..34c9ab6a33285223dba1e1b17ba10a43
  
  #endif  // INCLUDE_V8_ISOLATE_H_
 diff --git a/src/api/api.cc b/src/api/api.cc
-index 4ab15c368cba3e86f611dfbfa5a6f6be7a493510..e1019c4e70e7ca1d06279c128b7a8c7efab90b10 100644
+index 600fd75068e46e2160cb537c242b4449b6223dd6..2e390a741514771ef5690a5f7ff9a1ab8ce07ac4 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -11511,6 +11511,23 @@ std::string SourceLocation::ToString() const {
+@@ -11767,6 +11767,23 @@ std::string SourceLocation::ToString() const {
    return std::string(function_) + "@" + file_ + ":" + std::to_string(line_);
  }
  
@@ -105,20 +105,20 @@ index 4ab15c368cba3e86f611dfbfa5a6f6be7a493510..e1019c4e70e7ca1d06279c128b7a8c7e
  
  #include "src/api/api-macros-undef.h"
 diff --git a/src/builtins/promise-abstract-operations.tq b/src/builtins/promise-abstract-operations.tq
-index 2e2dd0e1ef71e9a7c2e2ca6bea3cb5d551f6ed4e..d5a6d3ac1d7131666c9b09e8b6afe0f4b9397fee 100644
+index 047c94578d5c3e4293e4875270a43cf19fbe2b41..136a5f5f7cf52c4a416c8a20310c142aa8f94ce6 100644
 --- a/src/builtins/promise-abstract-operations.tq
 +++ b/src/builtins/promise-abstract-operations.tq
-@@ -20,6 +20,9 @@ PromiseResolveAfterResolved(implicit context: Context)(JSPromise, JSAny): JSAny;
+@@ -20,6 +20,9 @@ extern transitioning runtime PromiseResolveAfterResolved(
  
- extern transitioning runtime
- PromiseRejectEventFromStack(implicit context: Context)(JSPromise, JSAny): JSAny;
+ extern transitioning runtime PromiseRejectEventFromStack(
+     implicit context: Context)(JSPromise, JSAny): JSAny;
 +
-+extern transitioning runtime
-+PromiseContextCheck(implicit context: Context)(JSPromise): JSPromise;
++extern transitioning runtime PromiseContextCheck(
++    implicit context: Context)(JSPromise): JSPromise;
  }
  
  // https://tc39.es/ecma262/#sec-promise-abstract-operations
-@@ -451,13 +454,15 @@ transitioning macro PerformPromiseThenImpl(implicit context: Context)(
+@@ -445,13 +448,15 @@ transitioning macro PerformPromiseThenImpl(
      // PromiseReaction holding both the onFulfilled and onRejected callbacks.
      // Once the {promise} is resolved we decide on the concrete handler to
      // push onto the microtask queue.
@@ -136,7 +136,7 @@ index 2e2dd0e1ef71e9a7c2e2ca6bea3cb5d551f6ed4e..d5a6d3ac1d7131666c9b09e8b6afe0f4
    } else {
      const reactionsOrResult = promise.reactions_or_result;
      let microtask: PromiseReactionJobTask;
-@@ -479,8 +484,8 @@ transitioning macro PerformPromiseThenImpl(implicit context: Context)(
+@@ -473,8 +478,8 @@ transitioning macro PerformPromiseThenImpl(
          }
        }
      EnqueueMicrotask(handlerContext, microtask);
@@ -147,20 +147,20 @@ index 2e2dd0e1ef71e9a7c2e2ca6bea3cb5d551f6ed4e..d5a6d3ac1d7131666c9b09e8b6afe0f4
  
  // https://tc39.es/ecma262/#sec-performpromisethen
 diff --git a/src/builtins/promise-constructor.tq b/src/builtins/promise-constructor.tq
-index b502eabf05f614ed58c058487e3117fea68973bd..604a4a49d7c15b9752be5132002734aa699a759c 100644
+index 5611e228b50cfdccdc0a15e5736a6446c8785fa7..f644158394705f1313a505f1c5e517f01d66630e 100644
 --- a/src/builtins/promise-constructor.tq
 +++ b/src/builtins/promise-constructor.tq
-@@ -14,6 +14,9 @@ DebugPopPromise(implicit context: Context)(): JSAny;
+@@ -13,6 +13,9 @@ extern transitioning runtime DebugPopPromise(implicit context: Context)(): JSAny
  
- extern transitioning runtime
- PromiseHookInit(implicit context: Context)(Object, Object): JSAny;
+ extern transitioning runtime PromiseHookInit(
+     implicit context: Context)(Object, Object): JSAny;
 +
-+extern transitioning runtime
-+PromiseContextInit(implicit context: Context)(JSPromise): JSAny;
++extern transitioning runtime PromiseContextInit(
++    implicit context: Context)(JSPromise): JSAny;
  }
  
  // https://tc39.es/ecma262/#sec-promise-constructor
-@@ -74,6 +77,7 @@ PromiseConstructor(
+@@ -70,6 +73,7 @@ transitioning javascript builtin PromiseConstructor(
      result = UnsafeCast<JSPromise>(
          FastNewObject(context, promiseFun, UnsafeCast<JSReceiver>(newTarget)));
      PromiseInit(result);
@@ -169,10 +169,10 @@ index b502eabf05f614ed58c058487e3117fea68973bd..604a4a49d7c15b9752be5132002734aa
    }
  
 diff --git a/src/builtins/promise-misc.tq b/src/builtins/promise-misc.tq
-index 199fc313193e82d149a9f389a12081bf1110a105..fdbf039d0c1926ec51dc4739ea5f0a23fbdfb3b8 100644
+index 95e300ff8dfcbcbfb6936b2d0adbeb7685ccae06..bc8c8d4ebcb1a0b920b43b825edde4810ba33c53 100644
 --- a/src/builtins/promise-misc.tq
 +++ b/src/builtins/promise-misc.tq
-@@ -49,6 +49,7 @@ macro PromiseInit(promise: JSPromise): void {
+@@ -48,6 +48,7 @@ macro PromiseInit(promise: JSPromise): void {
      is_silent: false,
      async_task_id: 0
    });
@@ -180,7 +180,7 @@ index 199fc313193e82d149a9f389a12081bf1110a105..fdbf039d0c1926ec51dc4739ea5f0a23
    promise_internal::ZeroOutEmbedderOffsets(promise);
  }
  
-@@ -69,6 +70,7 @@ macro InnerNewJSPromise(implicit context: Context)(): JSPromise {
+@@ -68,6 +69,7 @@ macro InnerNewJSPromise(implicit context: Context)(): JSPromise {
      is_silent: false,
      async_task_id: 0
    });
@@ -188,7 +188,7 @@ index 199fc313193e82d149a9f389a12081bf1110a105..fdbf039d0c1926ec51dc4739ea5f0a23
    return promise;
  }
  
-@@ -242,6 +244,7 @@ transitioning macro NewJSPromise(implicit context: Context)(parent: Object):
+@@ -247,6 +249,7 @@ transitioning macro NewJSPromise(implicit context: Context)(parent: Object):
      JSPromise {
    const instance = InnerNewJSPromise();
    PromiseInit(instance);
@@ -196,7 +196,7 @@ index 199fc313193e82d149a9f389a12081bf1110a105..fdbf039d0c1926ec51dc4739ea5f0a23
    RunAnyPromiseHookInit(instance, parent);
    return instance;
  }
-@@ -264,6 +267,7 @@ transitioning macro NewJSPromise(implicit context: Context)(
+@@ -270,6 +273,7 @@ transitioning macro NewJSPromise(
    instance.reactions_or_result = result;
    instance.SetStatus(status);
    promise_internal::ZeroOutEmbedderOffsets(instance);
@@ -205,10 +205,10 @@ index 199fc313193e82d149a9f389a12081bf1110a105..fdbf039d0c1926ec51dc4739ea5f0a23
    return instance;
  }
 diff --git a/src/compiler/js-create-lowering.cc b/src/compiler/js-create-lowering.cc
-index a0b0538d8ce877f62420a6f821059a52ee40c3d7..9831b9d9851e37adb15713bb5abd019e6fa64671 100644
+index d2735b8223fd40c47e357807d45b7bf2c48008ee..1879bf87728975640347cca4829620a23ca337ea 100644
 --- a/src/compiler/js-create-lowering.cc
 +++ b/src/compiler/js-create-lowering.cc
-@@ -1079,10 +1079,12 @@ Reduction JSCreateLowering::ReduceJSCreatePromise(Node* node) {
+@@ -1081,10 +1081,12 @@ Reduction JSCreateLowering::ReduceJSCreatePromise(Node* node) {
            jsgraph()->EmptyFixedArrayConstant());
    a.Store(AccessBuilder::ForJSObjectOffset(JSPromise::kReactionsOrResultOffset),
            jsgraph()->ZeroConstant());
@@ -223,10 +223,10 @@ index a0b0538d8ce877f62420a6f821059a52ee40c3d7..9831b9d9851e37adb15713bb5abd019e
         offset < JSPromise::kSizeWithEmbedderFields; offset += kTaggedSize) {
      a.Store(AccessBuilder::ForJSObjectOffset(offset),
 diff --git a/src/diagnostics/objects-printer.cc b/src/diagnostics/objects-printer.cc
-index da2f5f4b3b67f83bcfb35c941fc84512bb042949..c5059a9e945b0e6e689d4a106ad510d1f00a3227 100644
+index b070a9aa8612fd6db7b83712f1f2596f28f55093..915a2a667ede3c00d2da6fb6778250957cc4ce56 100644
 --- a/src/diagnostics/objects-printer.cc
 +++ b/src/diagnostics/objects-printer.cc
-@@ -711,6 +711,7 @@ void JSPromise::JSPromisePrint(std::ostream& os) {
+@@ -714,6 +714,7 @@ void JSPromise::JSPromisePrint(std::ostream& os) {
    os << "\n - has_handler: " << has_handler();
    os << "\n - handled_hint: " << handled_hint();
    os << "\n - is_silent: " << is_silent();
@@ -235,14 +235,14 @@ index da2f5f4b3b67f83bcfb35c941fc84512bb042949..c5059a9e945b0e6e689d4a106ad510d1
  }
  
 diff --git a/src/execution/isolate-inl.h b/src/execution/isolate-inl.h
-index 07721dda57a3c929c3d756b87bdfbe78112020ce..7f3831a6be1cf5d672977ed9e596d7ffa873adbe 100644
+index 91a0147173df32f271e7957eee4c07cdddc99dbc..a5e318d767d9a0723589ae8add95403d01e80898 100644
 --- a/src/execution/isolate-inl.h
 +++ b/src/execution/isolate-inl.h
 @@ -125,6 +125,26 @@ bool Isolate::is_execution_terminating() {
           i::ReadOnlyRoots(this).termination_exception();
  }
  
-+Object Isolate::promise_context_tag() {
++Tagged<Object> Isolate::promise_context_tag() {
 +  return promise_context_tag_;
 +}
 +
@@ -254,7 +254,7 @@ index 07721dda57a3c929c3d756b87bdfbe78112020ce..7f3831a6be1cf5d672977ed9e596d7ff
 +  set_promise_context_tag(ReadOnlyRoots(this).the_hole_value());
 +}
 +
-+void Isolate::set_promise_context_tag(Object tag) {
++void Isolate::set_promise_context_tag(Tagged<Object> tag) {
 +  promise_context_tag_ = tag;
 +}
 +
@@ -263,13 +263,13 @@ index 07721dda57a3c929c3d756b87bdfbe78112020ce..7f3831a6be1cf5d672977ed9e596d7ff
 +}
 +
  #ifdef DEBUG
- Object Isolate::VerifyBuiltinsResult(Object result) {
+ Tagged<Object> Isolate::VerifyBuiltinsResult(Tagged<Object> result) {
    DCHECK_EQ(has_pending_exception(), result == ReadOnlyRoots(this).exception());
 diff --git a/src/execution/isolate.cc b/src/execution/isolate.cc
-index 15882a9e57e1f132afafa7198c9c5cf10ab511d2..51770d27238cf87abafa1d4ed75dd0d3a9a4171a 100644
+index 378d9dd67397695bd520806e29ad8bc003e05d97..05a9ae0569c5b2156cf501ba2bf30d1326630580 100644
 --- a/src/execution/isolate.cc
 +++ b/src/execution/isolate.cc
-@@ -575,6 +575,8 @@ void Isolate::Iterate(RootVisitor* v, ThreadLocalTop* thread) {
+@@ -572,6 +572,8 @@ void Isolate::Iterate(RootVisitor* v, ThreadLocalTop* thread) {
                        FullObjectSlot(&thread->context_));
    v->VisitRootPointer(Root::kStackRoots, nullptr,
                        FullObjectSlot(&thread->scheduled_exception_));
@@ -278,7 +278,7 @@ index 15882a9e57e1f132afafa7198c9c5cf10ab511d2..51770d27238cf87abafa1d4ed75dd0d3
  
    for (v8::TryCatch* block = thread->try_catch_handler_; block != nullptr;
         block = block->next_) {
-@@ -4588,6 +4590,7 @@ bool Isolate::Init(SnapshotData* startup_snapshot_data,
+@@ -4755,6 +4757,7 @@ bool Isolate::Init(SnapshotData* startup_snapshot_data,
      shared_heap_object_cache_.push_back(ReadOnlyRoots(this).undefined_value());
    }
  
@@ -286,7 +286,7 @@ index 15882a9e57e1f132afafa7198c9c5cf10ab511d2..51770d27238cf87abafa1d4ed75dd0d3
    InitializeThreadLocal();
  
    // Profiler has to be created after ThreadLocal is initialized
-@@ -6375,5 +6378,39 @@ void DefaultWasmAsyncResolvePromiseCallback(
+@@ -6564,5 +6567,39 @@ void DefaultWasmAsyncResolvePromiseCallback(
    CHECK(ret.IsJust() ? ret.FromJust() : isolate->IsExecutionTerminating());
  }
  
@@ -327,17 +327,17 @@ index 15882a9e57e1f132afafa7198c9c5cf10ab511d2..51770d27238cf87abafa1d4ed75dd0d3
  }  // namespace internal
  }  // namespace v8
 diff --git a/src/execution/isolate.h b/src/execution/isolate.h
-index c7b1d2d422f47a8bee318f23d8417d7a35874ec9..13137d138a9fb40d869336b7410f0dcc5934e678 100644
+index 68c1fa25c559ab0da5f721e18227c9be6c89f02d..7bd8d52891a027f189dff8b492bd3778079ac958 100644
 --- a/src/execution/isolate.h
 +++ b/src/execution/isolate.h
-@@ -2091,6 +2091,14 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
+@@ -2144,6 +2144,14 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
      return enable_ro_allocation_for_snapshot_;
    }
  
-+  inline Object promise_context_tag();
++  inline Tagged<Object> promise_context_tag();
 +  inline bool has_promise_context_tag();
 +  inline void clear_promise_context_tag();
-+  inline void set_promise_context_tag(Object tag);
++  inline void set_promise_context_tag(Tagged<Object> tag);
 +  inline void set_promise_cross_context_callback(PromiseCrossContextCallback callback);
 +  MaybeHandle<JSPromise> RunPromiseCrossContextCallback(Handle<NativeContext> context,
 +                                                        Handle<JSPromise> promise);
@@ -345,11 +345,11 @@ index c7b1d2d422f47a8bee318f23d8417d7a35874ec9..13137d138a9fb40d869336b7410f0dcc
   private:
    explicit Isolate(std::unique_ptr<IsolateAllocator> isolate_allocator);
    ~Isolate();
-@@ -2562,10 +2570,17 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
+@@ -2622,10 +2630,17 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
    SimulatorData* simulator_data_ = nullptr;
  #endif
  
-+  Object promise_context_tag_;
++  Tagged<Object> promise_context_tag_;
 +  PromiseCrossContextCallback promise_cross_context_callback_;
 +  bool in_promise_cross_context_callback_ = false;
 +
@@ -364,10 +364,10 @@ index c7b1d2d422f47a8bee318f23d8417d7a35874ec9..13137d138a9fb40d869336b7410f0dcc
  
  // The current entered Isolate and its thread data. Do not access these
 diff --git a/src/heap/factory.cc b/src/heap/factory.cc
-index 6d8048ea4d19f653e3bf87722773d2c15ac3a032..a4936b0ededd1b1c3421bf5a7c504d3a5d03690a 100644
+index 98464d4e8209ad21c59213c5baa0bdc11993daa7..ca04bd88dfe9404a56e9be475861df81b0f25aeb 100644
 --- a/src/heap/factory.cc
 +++ b/src/heap/factory.cc
-@@ -4042,6 +4042,12 @@ Handle<JSPromise> Factory::NewJSPromiseWithoutHook() {
+@@ -3956,6 +3956,12 @@ Handle<JSPromise> Factory::NewJSPromiseWithoutHook() {
    DisallowGarbageCollection no_gc;
    Tagged<JSPromise> raw = *promise;
    raw->set_reactions_or_result(Smi::zero(), SKIP_WRITE_BARRIER);
@@ -393,24 +393,24 @@ index 25c7e1f76c72996eb1d8fb3d93cbfc06f4f41bf3..5afde92d7cdbd7d1b06060a2c047474a
  }
  
 diff --git a/src/profiler/heap-snapshot-generator.cc b/src/profiler/heap-snapshot-generator.cc
-index a9fd215ad558d3a03e35395c58629693617c5b97..9a2e6b96f470cd9971c4490e52b697893f15741f 100644
+index 225812c94161d95d32d47482a2fc0613dea29a39..3fa6af396c66ef4d0f41a3bdecde485ec305a566 100644
 --- a/src/profiler/heap-snapshot-generator.cc
 +++ b/src/profiler/heap-snapshot-generator.cc
-@@ -1792,6 +1792,9 @@ void V8HeapExplorer::ExtractJSPromiseReferences(HeapEntry* entry,
+@@ -1816,6 +1816,9 @@ void V8HeapExplorer::ExtractJSPromiseReferences(HeapEntry* entry,
    SetInternalReference(entry, "reactions_or_result",
                         promise->reactions_or_result(),
                         JSPromise::kReactionsOrResultOffset);
 +  SetInternalReference(entry, "context_tag",
-+                       promise.context_tag(),
++                       promise->context_tag(),
 +                       JSPromise::kContextTagOffset);
  }
  
  void V8HeapExplorer::ExtractJSGeneratorObjectReferences(
 diff --git a/src/runtime/runtime-promise.cc b/src/runtime/runtime-promise.cc
-index 61b313c938bdba7612508638d72113226f3b0a2a..48bf6b8beabf2020f7d5d24f3103d45c63452790 100644
+index 297f5872b5dbe2d63481500ea16756919e549bed..e76343dc4e8da9745d5bee6e305a1a959bd87596 100644
 --- a/src/runtime/runtime-promise.cc
 +++ b/src/runtime/runtime-promise.cc
-@@ -216,5 +216,40 @@ RUNTIME_FUNCTION(Runtime_ConstructInternalAggregateErrorHelper) {
+@@ -209,5 +209,40 @@ RUNTIME_FUNCTION(Runtime_ConstructInternalAggregateErrorHelper) {
    return *result;
  }
  
@@ -435,7 +435,7 @@ index 61b313c938bdba7612508638d72113226f3b0a2a..48bf6b8beabf2020f7d5d24f3103d45c
 +  // If promise.context_tag() is strict equal to isolate.promise_context_tag(),
 +  // or if the promise being checked does not have a context tag, we'll just return
 +  // promise directly.
-+  Object obj = promise->context_tag();
++  Tagged<Object> obj = promise->context_tag();
 +  if (obj == Smi::zero() || obj == isolate->promise_context_tag()) {
 +    return *promise;
 +  }
@@ -452,10 +452,10 @@ index 61b313c938bdba7612508638d72113226f3b0a2a..48bf6b8beabf2020f7d5d24f3103d45c
  }  // namespace internal
  }  // namespace v8
 diff --git a/src/runtime/runtime.h b/src/runtime/runtime.h
-index 433a8eca19a340f2af85ce3c1dc5b12711f6a59a..21a70c0eaf9cc5c03ad0c112e76de97a18bb9471 100644
+index f3a7f598fdd4469bd4ac4101e5527efa7cdd4366..f421a1b594e1bb8addb72370bbce96e9812a0fea 100644
 --- a/src/runtime/runtime.h
 +++ b/src/runtime/runtime.h
-@@ -403,7 +403,9 @@ namespace internal {
+@@ -401,7 +401,9 @@ namespace internal {
    F(PromiseRejectAfterResolved, 2, 1)    \
    F(PromiseResolveAfterResolved, 2, 1)   \
    F(ConstructAggregateErrorHelper, 4, 1) \

--- a/patches/v8/0011-Enable-V8-shared-linkage.patch
+++ b/patches/v8/0011-Enable-V8-shared-linkage.patch
@@ -1,4 +1,4 @@
-From 690eb0dd5093ce8b29d22629bfe12654085f645c Mon Sep 17 00:00:00 2001
+From 4e589192991d3ce2358dc78b27267dd883d8471b Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Sun, 9 Jul 2023 18:46:20 -0400
 Subject: Enable V8 shared linkage
@@ -9,10 +9,10 @@ Subject: Enable V8 shared linkage
  2 files changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index baaa3d6b1a14c23f017c9e4c7675de0a99df10ea..3c0fb68f710778b969ef5a90c70da32814f3fbd6 100644
+index cb12609f12374905c31892534cf9d44d555202bd..4ec995b8140f39e3b1ec25f7e8fc487262067e66 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -1400,7 +1400,6 @@ filegroup(
+@@ -1416,7 +1416,6 @@ filegroup(
          "src/execution/futex-emulation.h",
          "src/execution/interrupts-scope.cc",
          "src/execution/interrupts-scope.h",
@@ -20,7 +20,7 @@ index baaa3d6b1a14c23f017c9e4c7675de0a99df10ea..3c0fb68f710778b969ef5a90c70da328
          "src/execution/isolate.h",
          "src/execution/isolate-data.h",
          "src/execution/isolate-inl.h",
-@@ -3458,6 +3457,10 @@ filegroup(
+@@ -3523,6 +3522,10 @@ filegroup(
          "src/snapshot/snapshot-empty.cc",
          "src/snapshot/static-roots-gen.cc",
          "src/snapshot/static-roots-gen.h",
@@ -31,7 +31,7 @@ index baaa3d6b1a14c23f017c9e4c7675de0a99df10ea..3c0fb68f710778b969ef5a90c70da328
      ],
  )
  
-@@ -3910,6 +3913,8 @@ v8_library(
+@@ -3975,6 +3978,8 @@ v8_library(
      name = "v8",
      srcs = [
          ":v8_inspector_files",
@@ -41,7 +41,7 @@ index baaa3d6b1a14c23f017c9e4c7675de0a99df10ea..3c0fb68f710778b969ef5a90c70da328
          ":is_not_v8_enable_turbofan": [
              # With Turbofan disabled, we only include the stubbed-out API.
 diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index 6b5482d259ceadff5f9926244eb14a0f6e9eb5ca..a4d39a373657b81a7397e432c6c75cfc54dfd429 100644
+index 7053ca31b999ae7423e7485ee6392a09f9de4aa9..8f47a6477e8e99fd330dac5338f3f1d5f536ec64 100644
 --- a/bazel/defs.bzl
 +++ b/bazel/defs.bzl
 @@ -293,7 +293,6 @@ def v8_library(

--- a/patches/v8/0012-Fix-V8-ICU-build.patch
+++ b/patches/v8/0012-Fix-V8-ICU-build.patch
@@ -1,4 +1,4 @@
-From abcde551a7250a782f17de08ad1d00828a170c54 Mon Sep 17 00:00:00 2001
+From d444292cf748824683144c754b702a8a3a97a709 Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Wed, 26 Jul 2023 18:40:13 +0200
 Subject: Fix V8/ICU build
@@ -16,10 +16,10 @@ Subject: Fix V8/ICU build
  2 files changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 3c0fb68f710778b969ef5a90c70da32814f3fbd6..7c2adbb0c4aa584a37170328e5adbac66d6e5384 100644
+index 4ec995b8140f39e3b1ec25f7e8fc487262067e66..f271a38f7d65a2ac46e37be971dbfb9755c01fb3 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -4004,7 +4004,6 @@ v8_binary(
+@@ -4069,7 +4069,6 @@ v8_binary(
          "UNISTR_FROM_CHAR_EXPLICIT=",
      ],
      deps = [

--- a/patches/v8/0013-Randomize-the-initial-ExecutionContextId-used-by-the.patch
+++ b/patches/v8/0013-Randomize-the-initial-ExecutionContextId-used-by-the.patch
@@ -1,4 +1,4 @@
-From 2d534151fc4a0f852876f33b816321bf03cdd554 Mon Sep 17 00:00:00 2001
+From f8aac383c1e5f3e075a084cde64007cadf1219f2 Mon Sep 17 00:00:00 2001
 From: Orion Hodson <orion@cloudflare.com>
 Date: Wed, 13 Sep 2023 15:38:15 +0100
 Subject: Randomize the initial ExecutionContextId used by the inspector
@@ -11,7 +11,7 @@ live workers (https://chat.google.com/room/AAAAnS2bXT4/GX5-pa8O0ts).
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/inspector/v8-inspector-impl.cc b/src/inspector/v8-inspector-impl.cc
-index 60ad12aece057b4ff8eb12f99b830a4a44e12cc0..20d06e4f011714977e053b5409fb26003ea94cb9 100644
+index 60ad12aece057b4ff8eb12f99b830a4a44e12cc0..4edf6bf7a41ca3471cc6b38418fe3d943b7fc5c8 100644
 --- a/src/inspector/v8-inspector-impl.cc
 +++ b/src/inspector/v8-inspector-impl.cc
 @@ -66,7 +66,7 @@ V8InspectorImpl::V8InspectorImpl(v8::Isolate* isolate,


### PR DESCRIPTION
This requires defining `V8_EXTERNAL_CODE_SPACE` for V8's mksnapshot build tool to not crash based on https://bugs.chromium.org/p/v8/issues/detail?id=14486. While this changes how V8 is compiled, it should be a benign change as V8_EXTERNAL_CODE_SPACE is enabled in GN (V8's default build system) by default, bringing the bazel build closer to the reference builds that receive more extensive testing.
Few changes are needed otherwise, patches are unchanged except for `0010-Implement-Promise-Context-Tagging.patch` which needed to be updated based on increased usage of `Tagged<>` in the codebase.