### PR TITLE
Move autogate from server to util

### DIFF
--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -47,7 +47,7 @@ wd_cc_binary(
     tags = ["no-arm64"],
     visibility = ["//visibility:public"],
     deps = [
-        ":autogate",
+        "//src/workerd/util:autogate",
         ":server",
         ":workerd-meta_capnp",
         ":workerd_capnp",
@@ -107,7 +107,9 @@ wd_cc_capnp_library(
     srcs = ["workerd.capnp"],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/workerd/util:autogate_capnp",
     ],
+    includes = ["//"]
 )
 
 wd_cc_capnp_library(
@@ -117,14 +119,6 @@ wd_cc_capnp_library(
     deps = [
         ":workerd_capnp",
     ],
-)
-
-wd_cc_library(
-    name = "autogate",
-    srcs = ["autogate.c++"],
-    hdrs = ["autogate.h"],
-    visibility = ["//visibility:public"],
-    deps = ["@capnp-cpp//src/kj:kj", ":workerd_capnp", "//src/workerd/util:sentry"],
 )
 
 [kj_test(

--- a/src/workerd/server/workerd-meta.capnp
+++ b/src/workerd/server/workerd-meta.capnp
@@ -6,3 +6,4 @@ $import "/capnp/c++.capnp".namespace("workerd::server");
 
 const cppCapnpSchema :Text = embed "/capnp/c++.capnp";
 const workerdCapnpSchema :Text = embed "workerd.capnp";
+const autogateCapnpSchema :Text = embed "../util/autogate.capnp";

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -20,7 +20,7 @@
 #include <openssl/rand.h>
 #include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/io/supported-compatibility-date.capnp.h>
-#include <workerd/server/autogate.h>
+#include <workerd/util/autogate.h>
 
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
 #include <workerd/api/gpu/gpu.h>
@@ -477,6 +477,8 @@ kj::Maybe<kj::Own<capnp::SchemaFile>> tryImportBulitin(kj::StringPtr name) {
     return kj::heap<BuiltinSchemaFileImpl>("/capnp/c++.capnp", CPP_CAPNP_SCHEMA);
   } else if (name == "/workerd/workerd.capnp") {
     return kj::heap<BuiltinSchemaFileImpl>("/workerd/workerd.capnp", WORKERD_CAPNP_SCHEMA);
+  } else if (name == "/workerd/util/autogate.capnp") {
+    return kj::heap<BuiltinSchemaFileImpl>("/workerd/util/autogate.capnp", AUTOGATE_CAPNP_SCHEMA);
   } else {
     return kj::none;
   }
@@ -848,9 +850,11 @@ public:
       }
     }
 
-    KJ_IF_SOME(c, config) {
-      Autogate::initAutogate(c);
-    }
+    // We'll fail at getConfig() if there are multiple top level Config objects.
+    // The error message says that you have to specify which config to use, but
+    // it's not clear that there is any mechanism to do that??
+    config::Config::Reader config = getConfig();
+    util::Autogate::initAutogate(config.getAutogates());
   }
 
   void setConstName(kj::StringPtr name) {

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -38,6 +38,8 @@ using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("workerd::server::config");
 $Cxx.allowCancellation;
 
+using import "/workerd/util/autogate.capnp".Autogate;
+
 struct Config {
   # Top-level configuration for a workerd instance.
 
@@ -81,10 +83,6 @@ struct Config {
   # A list of gates and a corresponding value of whether they are enabled.
   # These are used to gate features/changes in workerd and in our internal repo. See the equivalent
   # config definition in our internal repo for more details.
-  struct Autogate {
-    enabled @0 :Bool;
-    name @1 :Text;
-  }
 }
 
 # ========================================================================================

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//:build/kj_test.bzl", "kj_test")
 load("//:build/wd_cc_library.bzl", "wd_cc_library")
+load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
 
 wd_cc_library(
     name = "util",
@@ -11,6 +12,7 @@ wd_cc_library(
             "symbolizer.c++",
             "sqlite*.c++",
             "thread-scopes.c++",
+            "autogate.c++"
         ],
     ),
     hdrs = glob(
@@ -21,6 +23,7 @@ wd_cc_library(
             "own-util.h",
             "thread-scopes.h",
             "sentry.h",
+            "autogate.h"
         ],
     ),
     visibility = ["//visibility:public"],
@@ -94,6 +97,23 @@ wd_cc_library(
         "@capnp-cpp//src/kj/compat:kj-http",
     ],
 )
+
+wd_cc_capnp_library(
+    name = "autogate_capnp",
+    srcs = ["autogate.capnp"],
+    visibility = ["//visibility:public"],
+    deps = [],
+)
+
+wd_cc_library(
+    name = "autogate",
+    srcs = ["autogate.c++"],
+    hdrs = ["autogate.h"],
+    visibility = ["//visibility:public"],
+    deps = [":autogate_capnp", ":sentry"],
+)
+
+exports_files(["autogate.h"])
 
 [kj_test(
     src = f,

--- a/src/workerd/util/autogate.capnp
+++ b/src/workerd/util/autogate.capnp
@@ -1,0 +1,9 @@
+@0x8c73baaf4250210f;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("workerd::util::autogate");
+
+struct Autogate {
+  enabled @0 :Bool;
+  name @1 :Text;
+}

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -5,9 +5,9 @@
 
 #include "kj/debug.h"
 #include <kj/map.h>
-#include <workerd/server/workerd.capnp.h>
+#include <workerd/util/autogate.capnp.h>
 
-namespace workerd::server {
+namespace workerd::util {
 
 // Workerd-specific list of autogate keys (can also be used in internal repo).
 enum class AutogateKey {
@@ -36,15 +36,15 @@ public:
   //
   // This function is not thread safe, it should be called exactly once close to the start of the
   // process before any threads are created.
-  static void initAutogate(config::Config::Reader config);
   static void initAutogate(
-      capnp::List<config::Config::Autogate, capnp::Kind::STRUCT>::Reader autogates);
+      capnp::List<autogate::Autogate, capnp::Kind::STRUCT>::Reader autogates);
   // Destroys an initialised global Autogate instance. Used only for testing.
   static void deinitAutogate();
 private:
   kj::HashMap<AutogateKey, bool> gates;
 
-  Autogate(capnp::List<config::Config::Autogate, capnp::Kind::STRUCT>::Reader autogates);
+  Autogate() {};
+  void addGates(capnp::List<autogate::Autogate, capnp::Kind::STRUCT>::Reader autogates);
 };
 
 // Retrieves the name of the gate.


### PR DESCRIPTION
I moved the definition of the Autogate struct into its own small capnp file so that autogate.h could have access to just that part of the server config definition. This file also has to get embedded in the binary to use at runtime.

An alternate approach that would could make sense here is to make the autogate accept a non-capnp data structure like a list of structs and convert. But this is a little more efficient.

Before this there were various code paths that could allow the Autogate not to be initialized at all, which will make gate checks warn (before correctly returning false). In order to ensure that we get the right config in all cases I get it from `getConfig` just after initialization. It might be a good idea to rename the `CliMain.config` member variable, say to `_config` or `_ownedConfig` because there are cases where we have a valid config but `CliMain.config` is null and this is pretty confusing.