### PR TITLE
Experimental perfetto support for workerd

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -388,6 +388,31 @@ new_git_repository(
     shallow_since = "1697047535 +0000",
 )
 
+git_repository(
+    name = "perfetto",
+    commit = "d136f355bb32288122dd2a0273e4fab280654d3a",
+    remote = "https://android.googlesource.com/platform/external/perfetto.git",
+    patches = [
+        "//:patches/perfetto/0001-Rename-ui-build-to-ui-build.sh-to-allow-bazel-build-.patch",
+    ],
+    patch_args = ["-p1"],
+    repo_mapping = {"@perfetto_dep_zlib" : "@zlib"},
+)
+
+# For use with perfetto
+new_git_repository(
+    name = "com_google_protobuf",
+    commit = "6a59a2ad1f61d9696092f79b6d74368b4d7970a3",
+    remote = "https://chromium.googlesource.com/external/github.com/google/protobuf"
+)
+
+# For use with perfetto
+new_local_repository(
+    name = "perfetto_cfg",
+    path = "build/perfetto",
+    build_file_content = ""
+)
+
 new_git_repository(
     name = "com_googlesource_chromium_base_trace_event_common",
     build_file = "@v8//:bazel/BUILD.trace_event_common",
@@ -445,11 +470,14 @@ bind(
 # We indirect through `@workerd-v8` to allow dependents to override how and where `v8` is built.
 #
 # TODO(cleanup): There must be a better way to do this?
+# TODO(soon): Figure out how to build v8 with perfetto enabled. It does not appear
+#             as if the v8 bazel build currently includes support for building with
+#             perfetto enabled as an option.
 new_local_repository(
     name = "workerd-v8",
     build_file_content = """cc_library(
         name = "v8",
-        deps = ["@v8//:v8_icu", "@workerd//:icudata-embed"],
+        deps = [ "@v8//:v8_icu", "@workerd//:icudata-embed" ],
         visibility = ["//visibility:public"])""",
     path = "empty",
 )

--- a/build/perfetto/perfetto_cfg.bzl
+++ b/build/perfetto/perfetto_cfg.bzl
@@ -1,0 +1,139 @@
+# Copyright (C) 2019 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Noop function used to override rules we don't want to support in standalone.
+def _noop_override(**kwargs):
+    pass
+
+PERFETTO_CONFIG = struct(
+    # This is used to refer to deps within perfetto's BUILD files.
+    # In standalone and bazel-based embedders use '//', because perfetto has its
+    # own repository, and //xxx would be relative to @perfetto//xxx.
+    # In Google internal builds, instead, this is set to //third_party/perfetto,
+    # because perfetto doesn't have its own repository there.
+    root = "//",
+
+    # These variables map dependencies to perfetto third-party projects. This is
+    # to allow perfetto embedders (e.g. gapid) and google internal builds to
+    # override paths and target names to their own third_party.
+    deps = struct(
+        # Target exposing the build config header. It should be a valid
+        # cc_library dependency as it will become a dependency of every
+        # perfetto_cc_library target. It needs to expose a
+        # "perfetto_build_flags.h" file that can be included via:
+        # #include "perfetto_build_flags.h".
+        build_config = ["//:build_config_hdr"],
+
+        # Target exposing the PERFETTO_VERSION_STRING() and
+        # PERFETTO_VERSION_SCM_REVISION() macros. This is overridden in google
+        # internal builds.
+        version_header = ["//:cc_perfetto_version_header"],
+
+        # Target exposing platform-specific functionality for base. This is
+        # overriden in Google internal builds.
+        base_platform = ["//:perfetto_base_default_platform"],
+
+        zlib = ["@perfetto_dep_zlib//:zlib"],
+        jsoncpp = ["@perfetto_dep_jsoncpp//:jsoncpp"],
+        linenoise = ["@perfetto_dep_linenoise//:linenoise"],
+        sqlite = ["@perfetto_dep_sqlite//:sqlite"],
+        sqlite_ext_percentile = ["@perfetto_dep_sqlite_src//:percentile_ext"],
+        protoc = ["@com_google_protobuf//:protoc"],
+        protoc_lib = ["@com_google_protobuf//:protoc_lib"],
+        protobuf_lite = ["@com_google_protobuf//:protobuf_lite"],
+        protobuf_full = ["@com_google_protobuf//:protobuf"],
+        protobuf_descriptor_proto = ["@com_google_protobuf//:descriptor_proto"],
+
+        # The Python targets are empty on the standalone build because we assume
+        # any relevant deps are installed on the system or are not applicable.
+        protobuf_py = [],
+        pandas_py = [],
+        tp_vendor_py = [],
+
+        # There are multiple configurations for the function name demangling
+        # logic in trace processor:
+        # (1) The following defaults include a subset of demangling sources
+        #     from llvm-project. This is the most complete implementation.
+        # (2) You can avoid the llvm dependency by setting "llvm_demangle = []"
+        #     here and PERFETTO_LLVM_DEMANGLE to false in your
+        #     perfetto_build_flags.h. Then the implementation will use a
+        #     demangler from the c++ runtime, which will most likely handle
+        #     only itanium mangling, and is unavailable on some platforms (e.g.
+        #     Windows, where it becomes a nop).
+        # (3) You can override the whole demangle_wrapper below, and provide
+        #     your own demangling implementation.
+        demangle_wrapper = [ "//:src_trace_processor_demangle" ],
+        llvm_demangle = ["@perfetto_dep_llvm_demangle//:llvm_demangle"],
+    ),
+
+    # This struct allows embedders to customize the cc_opts for Perfetto
+    # 3rd party dependencies. They only have an effect if the dependencies are
+    # initialized with the Perfetto build files (i.e. via perfetto_deps()).
+    deps_copts = struct(
+        zlib = [],
+        jsoncpp = [],
+        linenoise = [],
+        sqlite = [],
+        llvm_demangle = [],
+    ),
+
+    # Allow Bazel embedders to change the visibility of "public" targets.
+    # This variable has been introduced to limit the change to Bazel and avoid
+    # making the targets fully public in the google internal tree.
+    public_visibility = [
+        "//visibility:public",
+    ],
+
+    # Allow Bazel embedders to change the visibility of the proto targets.
+    # This variable has been introduced to limit the change to Bazel and avoid
+    # making the targets public in the google internal tree.
+    proto_library_visibility = "//visibility:private",
+
+    # Allow Bazel embedders to change the visibility of the Go protos.
+    # Go protos have all sorts of strange behaviour in Google3 so need special
+    # handling as the rules for other languages do not work for Go.
+    go_proto_library_visibility = "//visibility:private",
+
+    # This struct allows the embedder to customize copts and other args passed
+    # to rules like cc_binary. Prefixed rules (e.g. perfetto_cc_binary) will
+    # look into this struct before falling back on native.cc_binary().
+    # This field is completely optional, the embedder can omit the whole
+    # |rule_overrides| or invidivual keys. They are assigned to None or noop
+    # actions here just for documentation purposes.
+    rule_overrides = struct(
+        proto_library = None,
+
+        cc_binary = None,
+        cc_library = None,
+        cc_proto_library = None,
+
+        # Supporting java rules pulls in the JDK and generally is not something
+        # we need for most embedders.
+        java_proto_library = _noop_override,
+        java_lite_proto_library = _noop_override,
+
+        py_binary = None,
+        py_library = None,
+        py_proto_library = None,
+
+        go_proto_library = None,
+
+        jspb_proto_library = None,
+    ),
+
+    # The default copts which we use to compile C++ code.
+    default_copts = [
+        "-std=c++17",
+    ]
+)

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -6,6 +6,7 @@
 -Ibazel-bin/external/dawn/include
 -Ibazel-bin/external/ada-url/_virtual_includes/ada-url/
 -Ibazel-bin/external/com_cloudflare_lol_html/_virtual_includes/lolhtml
+-Iexternal/perfetto-sdk/sdk/
 -Iexternal/ada-url/
 -Iexternal/com_google_benchmark/include/
 -Iexternal/dawn/include
@@ -44,6 +45,7 @@
 -isystemexternal/v8/include
 -isystemexternal/zlib
 -isystemexternal/sqlite3
+-isystemexternal/perfetto-sdk/sdk
 -D_FORTIFY_SOURCE=1
 -DCAPNP_VERSION=11000
 -DDEBUG
@@ -86,6 +88,9 @@
 -DV8_TARGET_ARCH_X64
 -DV8_TARGET_OS_LINUX
 -DV8_TYPED_ARRAY_MAX_SIZE_IN_HEAP=64
+-DV8_USE_PERFETTO
+-DWORKERD_USE_PERFETTO
+-DPERFETTO_ENABLE_LEGACY_TRACE_EVENTS=1
 -DWORKERD_ICU_DATA_EMBED
 -Wall
 -Werror=dangling

--- a/patches/perfetto/0001-Rename-ui-build-to-ui-build.sh-to-allow-bazel-build-.patch
+++ b/patches/perfetto/0001-Rename-ui-build-to-ui-build.sh-to-allow-bazel-build-.patch
@@ -1,0 +1,17 @@
+From ce2bc7a2ee9ce1a52f2c17b3b9a83329b58bf2f7 Mon Sep 17 00:00:00 2001
+From: James M Snell <jasnell@gmail.com>
+Date: Tue, 5 Dec 2023 08:04:46 -0800
+Subject: [PATCH] Rename ui/build to ui/build.sh to allow bazel build to work
+
+---
+ ui/{build => build.sh} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+ rename ui/{build => build.sh} (100%)
+
+diff --git a/ui/build b/ui/build.sh
+similarity index 100%
+rename from ui/build
+rename to ui/build.sh
+-- 
+2.40.1
+

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -21,6 +21,7 @@
 #include <workerd/api/hibernatable-web-socket.h>
 #include <workerd/api/util.h>
 #include <workerd/util/stream-utils.h>
+#include <workerd/util/use-perfetto-categories.h>
 
 namespace workerd::api {
 
@@ -103,6 +104,7 @@ kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::request(
     kj::AsyncInputStream& requestBody, kj::HttpService::Response& response,
     kj::Maybe<kj::StringPtr> cfBlobJson,
     Worker::Lock& lock, kj::Maybe<ExportedHandler&> exportedHandler) {
+  TRACE_EVENT("workerd", "ServiceWorkerGlobalScope::request()");
   // To construct a ReadableStream object, we're supposed to pass in an Own<AsyncInputStream>, so
   // that it can drop the reference whenever it gets GC'd. But in this case the stream's lifetime
   // is not under our control -- it's attached to the request. So, we wrap it in a

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -86,6 +86,7 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":capnp",
+        "//src/workerd/util:perfetto",
         "//src/workerd/util:own-util",
         "//src/workerd/util:thread-scopes",
         "@capnp-cpp//src/kj:kj-async",

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -22,6 +22,9 @@
 #include <kj/function.h>
 #include <capnp/dynamic.h>
 #include <workerd/util/weak-refs.h>
+#include <workerd/io/limit-enforcer.h>
+#include <workerd/io/io-channels.h>
+#include <workerd/util/perfetto-tracing.h>
 
 namespace capnp { class HttpOverCapnpFactory; }
 

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -51,6 +51,7 @@ wd_cc_binary(
         ":server",
         ":workerd-meta_capnp",
         ":workerd_capnp",
+        "//src/workerd/util:perfetto",
         "@capnp-cpp//src/capnp:capnpc",
     ] + select({
         "@platforms//os:windows": [],
@@ -99,6 +100,7 @@ wd_cc_library(
         "//src/workerd/api:rtti",
         "//src/workerd/io",
         "//src/workerd/jsg",
+        "//src/workerd/util:perfetto",
     ],
 )
 

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -1,6 +1,28 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//:build/kj_test.bzl", "kj_test")
 load("//:build/wd_cc_library.bzl", "wd_cc_library")
 load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
+
+wd_cc_library(
+    name = "perfetto",
+    srcs = ["perfetto-tracing.c++"],
+    hdrs = ["perfetto-tracing.h", "use-perfetto-categories.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj"
+    ] + select({
+        "@platforms//os:windows": ["@workerd-v8//:v8"],
+        "//conditions:default": ["@perfetto//:libperfetto_client_experimental"],
+    }),
+    defines = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["WORKERD_USE_PERFETTO"],
+    }),
+)
+# TODO(later): Currently perfetto support is not enabled on Windows simply because the
+# perfetto bazel build fails on windows for some reason and it's currently not worth
+# the time to invest of figuring out why. If some intrepid soul wishes to figure out
+# why the Windows build is failing, we could simplify things here a bit.
 
 wd_cc_library(
     name = "util",
@@ -12,7 +34,8 @@ wd_cc_library(
             "symbolizer.c++",
             "sqlite*.c++",
             "thread-scopes.c++",
-            "autogate.c++"
+            "autogate.c++",
+            "perfetto-tracing.c++",
         ],
     ),
     hdrs = glob(
@@ -23,7 +46,8 @@ wd_cc_library(
             "own-util.h",
             "thread-scopes.h",
             "sentry.h",
-            "autogate.h"
+            "autogate.h",
+            "perfetto-tracing.h",
         ],
     ),
     visibility = ["//visibility:public"],

--- a/src/workerd/util/perfetto-tracing.c++
+++ b/src/workerd/util/perfetto-tracing.c++
@@ -1,0 +1,111 @@
+#include "perfetto-tracing.h"
+
+#if defined(WORKERD_USE_PERFETTO)
+
+#include <kj/debug.h>
+#include <kj/filesystem.h>
+#include <kj/memory.h>
+#include <kj/vector.h>
+#include <fcntl.h>
+#include <perfetto/tracing/track_event_legacy.h>
+#include "protos/perfetto/config/data_source_config.gen.h"
+#include "protos/perfetto/config/trace_config.gen.h"
+#include "protos/perfetto/config/track_event/track_event_config.gen.h"
+
+PERFETTO_TRACK_EVENT_STATIC_STORAGE_IN_NAMESPACE(workerd::traces);
+
+namespace workerd {
+namespace {
+kj::AutoCloseFd openTraceFile(kj::StringPtr path) {
+  int fd = open(path.cStr(), O_RDWR | O_CREAT | O_TRUNC, 0600);
+  KJ_REQUIRE(fd >= 0, "Unable to open tracing file");
+  return kj::AutoCloseFd(fd);
+}
+
+void initializePerfettoOnce() {
+  if (perfetto::Tracing::IsInitialized()) return;
+  perfetto::TracingInitArgs args;
+  args.backends |= perfetto::kInProcessBackend;
+  perfetto::Tracing::Initialize(args);
+  PerfettoSession::registerWorkerdTracks();
+}
+
+std::unique_ptr<perfetto::TracingSession> createTracingSession(int fd, kj::StringPtr categories) {
+  initializePerfettoOnce();
+  perfetto::protos::gen::TrackEventConfig track_event_cfg;
+  track_event_cfg.add_disabled_categories("*");
+
+  // The categories is a comma-separated list
+  auto cats = PerfettoSession::parseCategories(categories);
+  for (auto category : cats) {
+    auto view = std::string(category.begin(), category.size());
+    track_event_cfg.add_enabled_categories(view);
+  }
+
+  perfetto::TraceConfig cfg;
+  cfg.add_buffers()->set_size_kb(1024);  // Record up to 1 MiB.
+  auto* ds_cfg = cfg.add_data_sources()->mutable_config();
+  ds_cfg->set_name("track_event");
+  ds_cfg->set_track_event_config_raw(track_event_cfg.SerializeAsString());
+  std::unique_ptr<perfetto::TracingSession> tracing_session(
+      perfetto::Tracing::NewTrace());
+  tracing_session->Setup(cfg, fd);
+  return kj::mv(tracing_session);
+}
+}  // namespace
+
+void PerfettoSession::registerWorkerdTracks() {
+  static bool once = true;
+  KJ_ASSERT(once, "workerd perfetto tracks are already registered");
+  if (perfetto::Tracing::IsInitialized()) {
+    workerd::traces::TrackEvent::Register();
+    once = false;
+  }
+}
+
+kj::Array<kj::ArrayPtr<const char>> PerfettoSession::parseCategories(kj::StringPtr categories) {
+  kj::Vector<kj::ArrayPtr<const char>> results;
+  while (categories.size() > 0) {
+    KJ_IF_SOME(pos, categories.findFirst(',')) {
+      results.add(categories.slice(0, pos));
+      categories = categories.slice(pos + 1);
+    } else {
+      results.add(categories);
+      categories = nullptr;
+    }
+  }
+  return results.releaseAsArray();
+}
+
+struct PerfettoSession::Impl {
+  kj::AutoCloseFd fd;
+  std::unique_ptr<perfetto::TracingSession> session;
+
+  Impl(int fd, kj::StringPtr categories)
+      : fd(fd), session(createTracingSession(fd, categories)) {
+    session->StartBlocking();
+  }
+};
+
+PerfettoSession::PerfettoSession(kj::StringPtr path, kj::StringPtr categories)
+    : impl(kj::heap<Impl>(openTraceFile(path), categories)) {}
+
+PerfettoSession::PerfettoSession(int fd, kj::StringPtr categories)
+    : impl(kj::heap<Impl>(fd, categories)) {}
+
+PerfettoSession::~PerfettoSession() noexcept(false) {
+  if (impl) {
+    impl->session->FlushBlocking();
+    impl->session->StopBlocking();
+  }
+}
+
+void PerfettoSession::flush() {
+  if (impl) {
+    impl->session->FlushBlocking();
+  }
+}
+
+}  // namespace workerd
+
+#endif  // defined(WORKERD_USE_PERFETTO)

--- a/src/workerd/util/perfetto-tracing.h
+++ b/src/workerd/util/perfetto-tracing.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#if defined(WORKERD_USE_PERFETTO)
+#include <kj/memory.h>
+#include <kj/string.h>
+#define PERFETTO_ENABLE_LEGACY_TRACE_EVENTS 1
+#include "perfetto/tracing.h"
+
+PERFETTO_DEFINE_CATEGORIES_IN_NAMESPACE(
+    workerd::traces,
+    perfetto::Category("workerd"));
+
+namespace workerd {
+
+// The PerfettoSession initializes a Perfetto tracing session, initializing the
+// Perfetto subsystem on first initialization and writing events to the given
+// file path.
+class PerfettoSession {
+public:
+  explicit PerfettoSession(kj::StringPtr path, kj::StringPtr categories);
+
+  // Create a PerfettoSession on an existing fd (the constructor will handle
+  // wrapping the fd in kj::AutocloseFd)
+  explicit PerfettoSession(int fd, kj::StringPtr categories);
+  PerfettoSession(PerfettoSession&&) = default;
+  PerfettoSession& operator=(PerfettoSession&&) = default;
+  KJ_DISALLOW_COPY(PerfettoSession);
+  ~PerfettoSession() noexcept(false);
+
+  void flush();
+
+  // Receives a comma-separated list of trace categories and returns an array.
+  static kj::Array<kj::ArrayPtr<const char>> parseCategories(kj::StringPtr categories);
+
+  // Called by embedders at most once to register the workerd track events.
+  static void registerWorkerdTracks();
+
+private:
+  struct Impl;
+  kj::Own<Impl> impl;
+
+  friend constexpr bool _kj_internal_isPolymorphic(PerfettoSession::Impl*);
+};
+
+KJ_DECLARE_NON_POLYMORPHIC(PerfettoSession::Impl);
+}  // workerd
+
+#else  // defined(WORKERD_USE_PERFETTO)
+// We define non-op versions of the instrumentation macros here so that we can
+// still instrument and build when perfetto is not enabled.
+#define TRACE_EVENT(...)
+#define TRACE_EVENT_BEGIN(...)
+#define TRACE_EVENT_END(...)
+#define TRACE_EVENT_INSTANT(...)
+#define TRACE_COUNTER(...)
+#define TRACE_EVENT_CATEGORY_ENABLED(...) false
+#endif  // defined(WORKERD_USE_PERFETTO)

--- a/src/workerd/util/use-perfetto-categories.h
+++ b/src/workerd/util/use-perfetto-categories.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <workerd/util/perfetto-tracing.h>
+
+// This header is to be imported by any translation unit (c++ file) that
+// is instrumenting with perfetto traces (e.g. TRACE_EVENT). Header files
+// that include instrumentation but are imported by embedders should instead
+// use PERFETTO_USE_CATEGORY_FROM_NAMESPACE_SCOPED within function or block
+// scopes that are to be instrumented.
+
+#if defined(WORKERD_USE_PERFETTO)
+PERFETTO_USE_CATEGORIES_FROM_NAMESPACE(workerd::traces);
+#endif


### PR DESCRIPTION
Adds a new `-p {file}={categories}` option to `workerd serve` and `workerd test` that will generate a perfetto trace at `{file}` with `{categories}` enabled. Currently will only capture trace events from workerd as there is currently no way to enable perfetto in v8 using v8's current bazel build. Enabling that will be a follow up step.

Example:

```
workerd serve -p /tmp/PERFETTO_TRACE=workerd /path/to/config.capnp
```

The PR also starts to add `TRACE_EVENT` instrumentation to various locations.

The Windows build is explicitly excluded from the party for now. Kept running into issues building perfetto on windows here and couldn't easily determine if it was the way I was calling the bazel build or if it's a problem with perfetto's own bazel build... and at the moment it's not worth the effort to keep investigating. I'll leave enabling windows support for perfetto to some other brave soul.