### PR TITLE
Fix ubsan warnings, apply additional hardening for Date parsing

### DIFF
--- a/src/workerd/api/crypto-impl-aes-test.c++
+++ b/src/workerd/api/crypto-impl-aes-test.c++
@@ -85,6 +85,11 @@ KJ_TEST("AES-KW key wrap") {
   }
 }
 
+// Disable null pointer checks (a subset of UBSan) here due to the null reference being passed for
+// jwkHandler. Using attribute push as annotating just the test itself didn't seem to work.
+#if __clang__ && __has_feature(undefined_behavior_sanitizer)
+#pragma clang attribute push (__attribute__((no_sanitize("null"))), apply_to=function)
+#endif
 KJ_TEST("AES-CTR key wrap") {
   // Basic test that let me repro an issue where using an AES key that's not AES-KW would fail to
   // wrap if it didn't have "encrypt" in its usages when created.
@@ -169,6 +174,9 @@ KJ_TEST("AES-CTR key wrap") {
     KJ_ASSERT(completed, "Microtasks did not run fully.");
   });
 }
+#if __clang__ && __has_feature(undefined_behavior_sanitizer)
+#pragma clang attribute pop // __attribute__((no_sanitize("null"))
+#endif
 
 }  // namespace
 }  // namespace workerd::api

--- a/src/workerd/api/urlpattern.c++
+++ b/src/workerd/api/urlpattern.c++
@@ -411,7 +411,6 @@ bool isAsciiDigit(auto c) { return c >= '0' && c <= '9'; };
 
 jsg::UsvString canonicalizeProtocol(jsg::UsvStringPtr input, kj::Maybe<jsg::UsvStringPtr>) {
   if (input.size() == 0) return jsg::usv();
-  url::UrlRecord dummyUrl;
 
   auto& suffix = getCommonStrings().DUMMY_URL;
 
@@ -422,7 +421,7 @@ jsg::UsvString canonicalizeProtocol(jsg::UsvStringPtr input, kj::Maybe<jsg::UsvS
   auto str = builder.finish();
 
   auto result = JSG_REQUIRE_NONNULL(
-      url::URL::parse(str, kj::none, dummyUrl),
+      url::URL::parse(str, kj::none, kj::none),
       TypeError,
       "Invalid protocol scheme.");
 
@@ -431,21 +430,20 @@ jsg::UsvString canonicalizeProtocol(jsg::UsvStringPtr input, kj::Maybe<jsg::UsvS
 
 jsg::UsvString canonicalizeUsername(jsg::UsvStringPtr input, kj::Maybe<jsg::UsvStringPtr>) {
   if (input.size() == 0) return jsg::usv();
-  url::UrlRecord dummyUrl;
+  url::UrlRecord dummyUrl {};
   dummyUrl.setUsername(input);
   return kj::mv(dummyUrl.username);
 }
 
 jsg::UsvString canonicalizePassword(jsg::UsvStringPtr input, kj::Maybe<jsg::UsvStringPtr>) {
   if (input.size() == 0) return jsg::usv();
-  url::UrlRecord dummyUrl;
+  url::UrlRecord dummyUrl {};
   dummyUrl.setPassword(input);
   return kj::mv(dummyUrl.password);
 }
 
 jsg::UsvString canonicalizeHostname(jsg::UsvStringPtr input, kj::Maybe<jsg::UsvStringPtr>) {
   if (input.size() == 0) return jsg::usv();
-  url::UrlRecord dummyUrl;
 
   // This additional check deals with a known bug in the URLPattern spec. The URL parser will
   // allow (and generally ignore) invalid characters in the hostname when running with the
@@ -465,7 +463,7 @@ jsg::UsvString canonicalizeHostname(jsg::UsvStringPtr input, kj::Maybe<jsg::UsvS
   }
 
   auto result = JSG_REQUIRE_NONNULL(
-      url::URL::parse(input, kj::none, dummyUrl, url::URL::ParseState::HOSTNAME),
+      url::URL::parse(input, kj::none, kj::none, url::URL::ParseState::HOSTNAME),
       TypeError,
       "Invalid URL hostname component.");
 
@@ -489,7 +487,7 @@ jsg::UsvString canonicalizePort(
     jsg::UsvStringPtr input,
     kj::Maybe<jsg::UsvStringPtr> maybeProtocol) {
   if (input.size() == 0) return jsg::usv();
-  url::UrlRecord dummyUrl;
+  url::UrlRecord dummyUrl {};
   KJ_IF_SOME(protocol, maybeProtocol) {
     dummyUrl.scheme = jsg::usv(protocol);
   }
@@ -544,9 +542,8 @@ jsg::UsvString canonicalizePort(
 
 jsg::UsvString canonicalizePathname(jsg::UsvStringPtr input, kj::Maybe<jsg::UsvStringPtr>) {
   if (input.size() == 0) return jsg::usv();
-  url::UrlRecord dummyUrl;
   auto result = JSG_REQUIRE_NONNULL(
-    url::URL::parse(input, kj::none, dummyUrl, url::URL::ParseState::PATH_START),
+    url::URL::parse(input, kj::none, kj::none, url::URL::ParseState::PATH_START),
     TypeError,
     "Invalid URL pathname component.");
 
@@ -563,7 +560,7 @@ jsg::UsvString canonicalizeOpaquePathname(
     jsg::UsvStringPtr input,
     kj::Maybe<jsg::UsvStringPtr>) {
   if (input.size() == 0) return jsg::usv();
-  url::UrlRecord dummyUrl;
+  url::UrlRecord dummyUrl {};
   dummyUrl.path = jsg::usv();
   auto result = JSG_REQUIRE_NONNULL(
       url::URL::parse(input, kj::none, dummyUrl, url::URL::ParseState::OPAQUE_PATH),
@@ -574,7 +571,7 @@ jsg::UsvString canonicalizeOpaquePathname(
 
 jsg::UsvString canonicalizeSearch(jsg::UsvStringPtr input, kj::Maybe<jsg::UsvStringPtr>) {
   if (input.size() == 0) return jsg::usv();
-  url::UrlRecord dummyUrl;
+  url::UrlRecord dummyUrl {};
   dummyUrl.query = jsg::usv();
   auto result = JSG_REQUIRE_NONNULL(
     url::URL::parse(input, kj::none, dummyUrl, url::URL::ParseState::QUERY),
@@ -588,7 +585,7 @@ jsg::UsvString canonicalizeSearch(jsg::UsvStringPtr input, kj::Maybe<jsg::UsvStr
 
 jsg::UsvString canonicalizeHash(jsg::UsvStringPtr input, kj::Maybe<jsg::UsvStringPtr>) {
   if (input.size() == 0) return jsg::usv();
-  url::UrlRecord dummyUrl;
+  url::UrlRecord dummyUrl {};
   dummyUrl.fragment = jsg::usv();
   auto result = JSG_REQUIRE_NONNULL(
     url::URL::parse(input, kj::none, dummyUrl, url::URL::ParseState::FRAGMENT),

--- a/src/workerd/io/compatibility-date.c++
+++ b/src/workerd/io/compatibility-date.c++
@@ -50,7 +50,7 @@ struct CompatDate {
     uint year, month, day;
     // TODO(someday): use `kj::parse` here instead
     auto result = sscanf(text.cStr(), "%d-%d-%d", &year, &month, &day);
-    if (result == EOF) return kj::none;
+    if (result == EOF || result < 3) return kj::none;
     // Basic validation, notably this will happily accept invalid dates like 2022-02-30
     if (year < 2000 || year >= 3000) return kj::none;
     if (month < 1 || month > 12) return kj::none;


### PR DESCRIPTION
I know that we plan to replace the existing URL parsing implementation soon, but fixing undefined behavior here felt like a quick win.
Credit for discovering the missing parser check goes to Martin Schwarzl.