### PR TITLE
Multiple minor worker.h related cleanups

### DIFF
--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -72,16 +72,6 @@ namespace workerd::api {
 
 namespace {
 
-struct EncoderErrorReporterImpl : public Worker::ValidationErrorReporter {
-  void addError(kj::String error) override { errors.add(kj::mv(error)); }
-  void addHandler(kj::Maybe<kj::StringPtr> exportName,
-                  kj::StringPtr type) override {
-    KJ_UNREACHABLE;
-  }
-
-  kj::Vector<kj::String> errors;
-};
-
 struct EncoderModuleRegistryImpl {
   struct CppModuleContents {
     CppModuleContents(kj::String structureName) : structureName(kj::mv(structureName)) {}
@@ -140,7 +130,7 @@ CompatibilityFlags::Reader compileFlags(capnp::MessageBuilder &message, kj::Stri
   }
 
   auto output = message.initRoot<CompatibilityFlags>();
-  EncoderErrorReporterImpl errorReporter;
+  SimpleWorkerErrorReporter errorReporter;
 
   compileCompatibilityFlags(compatDate, flagList.asReader(), output,
                             errorReporter, experimental,

--- a/src/workerd/io/compatibility-date-test.c++
+++ b/src/workerd/io/compatibility-date-test.c++
@@ -79,17 +79,7 @@ KJ_TEST("compatibility flag parsing") {
     auto outputOrphan = orphanage.newOrphan<CompatibilityFlags>();
     auto output = outputOrphan.get();
 
-    struct ErrorReporterImpl: public Worker::ValidationErrorReporter {
-      void addError(kj::String error) override {
-        errors.add(kj::mv(error));
-      }
-      void addHandler(kj::Maybe<kj::StringPtr> exportName, kj::StringPtr type) override {
-        KJ_UNREACHABLE;
-      }
-
-      kj::Vector<kj::String> errors;
-    };
-    ErrorReporterImpl errorReporter;
+    SimpleWorkerErrorReporter errorReporter;
     compileCompatibilityFlags(compatDate, flagList.asReader(), output, errorReporter, experimental,
                               dateValidation);
 
@@ -210,17 +200,7 @@ KJ_TEST("encode to flag list for FL") {
     auto outputOrphan = orphanage.newOrphan<CompatibilityFlags>();
     auto output = outputOrphan.get();
 
-    struct ErrorReporterImpl: public Worker::ValidationErrorReporter {
-      void addError(kj::String error) override {
-        errors.add(kj::mv(error));
-      }
-      void addHandler(kj::Maybe<kj::StringPtr> exportName, kj::StringPtr type) override {
-        KJ_UNREACHABLE;
-      }
-
-      kj::Vector<kj::String> errors;
-    };
-    ErrorReporterImpl errorReporter;
+    SimpleWorkerErrorReporter errorReporter;
 
     compileCompatibilityFlags(compatDate, flagList.asReader(), output, errorReporter, experimental,
                               dateValidation);

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -223,4 +223,18 @@ public:
   virtual void shutdown(uint16_t reasonCode, LimitEnforcer& limitEnforcer) {}
 };
 
+// RAII object to call `teardownFinished()` on an observer for you.
+template <typename Observer>
+class TeardownFinishedGuard {
+public:
+  TeardownFinishedGuard(Observer& ref): ref(ref) {}
+  ~TeardownFinishedGuard() noexcept(false) {
+    ref.teardownFinished();
+  }
+  KJ_DISALLOW_COPY_AND_MOVE(TeardownFinishedGuard);
+
+private:
+  Observer& ref;
+};
+
 }  // namespace workerd

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -82,7 +82,7 @@ public:
 
   class LockType;
 
-  enum ConsoleMode {
+  enum class ConsoleMode {
     // Only send `console.log`s to the inspector. Default, production behaviour.
     INSPECTOR_ONLY,
     // Send `console.log`s to the inspector and stdout/err. Behaviour running `workerd` locally.

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -163,6 +163,7 @@ private:
 
   class InspectorClient;
   class AsyncWaiter;
+  friend constexpr bool _kj_internal_isPolymorphic(AsyncWaiter*);
 
   static void handleLog(jsg::Lock& js, ConsoleMode mode, LogLevel level,
                           const v8::Global<v8::Function>& original,
@@ -795,43 +796,6 @@ private:
 
 inline const Worker::Isolate& Worker::getIsolate() const { return *script->isolate; }
 
-// Represents a thread's attempt to take an async lock. Each Isolate has a linked list of
-// `AsyncWaiter`s. A particular thread only ever owns one `AsyncWaiter` at a time.
-class Worker::AsyncWaiter: public kj::Refcounted {
-public:
-  AsyncWaiter(kj::Own<const Isolate> isolate);
-  ~AsyncWaiter() noexcept;
-  KJ_DISALLOW_COPY_AND_MOVE(AsyncWaiter);
-
-private:
-  // Executor for this waiter's thread.
-  const kj::Executor& executor;
-
-  // The isolate for which this waiter is currently waiting.
-  kj::Own<const Isolate> isolate;
-
-  // Promise/fulfiller to fire when the waiter reaches the front of the list for the corresponding
-  // isolate.
-  kj::ForkedPromise<void> readyPromise = nullptr;
-  kj::Own<kj::CrossThreadPromiseFulfiller<void>> readyFulfiller;
-
-  // Promise/fulfiller to fire when the AsyncLock is finally released. This is used when a thread
-  // tries to take locks on multiple different isolates concurrently, in order to serialize the
-  // locks so only one is taken at a time. This is NOT a cross-thread fulfiller; it can only be
-  // fulfilled by the thread that owns the waiter.
-  kj::ForkedPromise<void> releasePromise = nullptr;
-  kj::Own<kj::PromiseFulfiller<void>> releaseFulfiller;
-
-  // Protected by the lock on `Isolate::asyncWaiters` for the isolate identified by
-  // `currentIsolate`. Must be null if `currentIsolate` is null. (All other members of `Waiter`
-  // can only be accessed by the thread that created the `Waiter`.)
-  kj::Maybe<AsyncWaiter&> next;
-  kj::Maybe<AsyncWaiter&>* prev;
-
-  static thread_local AsyncWaiter* threadCurrentWaiter;
-
-  friend class Worker::Isolate;
-  friend class Worker::AsyncLock;
-};
+KJ_DECLARE_NON_POLYMORPHIC(Worker::AsyncWaiter);
 
 } // namespace workerd

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -150,20 +150,6 @@ public:
 private:
   kj::Own<const Script> script;
 
-  // RAII object to call `teardownFinished()` on an observer for you.
-  template <typename Observer>
-  class TeardownFinishedGuard {
-  public:
-    TeardownFinishedGuard(Observer& ref): ref(ref) {}
-    ~TeardownFinishedGuard() noexcept(false) {
-      ref.teardownFinished();
-    }
-    KJ_DISALLOW_COPY_AND_MOVE(TeardownFinishedGuard);
-
-  private:
-    Observer& ref;
-  };
-
   kj::Own<WorkerObserver> metrics;
 
   // metrics needs to be first to be destroyed last to correctly capture destruction timing.
@@ -366,7 +352,7 @@ private:
   kj::Maybe<kj::String> featureFlagsForFl;
 
   kj::Own<IsolateObserver> metrics;
-  Worker::TeardownFinishedGuard<IsolateObserver&> teardownGuard { *metrics };
+  TeardownFinishedGuard<IsolateObserver&> teardownGuard { *metrics };
 
   struct Impl;
   kj::Own<Impl> impl;

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -798,4 +798,18 @@ inline const Worker::Isolate& Worker::getIsolate() const { return *script->isola
 
 KJ_DECLARE_NON_POLYMORPHIC(Worker::AsyncWaiter);
 
+// An implementation of Worker::ValidationErrorReporter that collects errors into
+// a kj::Vector<kj::String>.
+struct SimpleWorkerErrorReporter final : public Worker::ValidationErrorReporter {
+  void addError(kj::String error) override { errors.add(kj::mv(error)); }
+  void addHandler(kj::Maybe<kj::StringPtr> exportName,
+                  kj::StringPtr type) override {
+    KJ_UNREACHABLE;
+  }
+
+  SimpleWorkerErrorReporter() = default;
+  KJ_DISALLOW_COPY_AND_MOVE(SimpleWorkerErrorReporter);
+  kj::Vector<kj::String> errors;
+};
+
 } // namespace workerd

--- a/src/workerd/tools/api-encoder.c++
+++ b/src/workerd/tools/api-encoder.c++
@@ -80,16 +80,6 @@ namespace {
 
 using namespace jsg;
 
-struct ApiEncoderErrorReporterImpl : public Worker::ValidationErrorReporter {
-  void addError(kj::String error) override { errors.add(kj::mv(error)); }
-  void addHandler(kj::Maybe<kj::StringPtr> exportName,
-                  kj::StringPtr type) override {
-    KJ_UNREACHABLE;
-  }
-
-  kj::Vector<kj::String> errors;
-};
-
 struct ApiEncoderMain {
   explicit ApiEncoderMain(kj::ProcessContext &context) : context(context) {}
 
@@ -128,7 +118,7 @@ struct ApiEncoderMain {
     }
 
     auto output = message.initRoot<CompatibilityFlags>();
-    ApiEncoderErrorReporterImpl errorReporter;
+    SimpleWorkerErrorReporter errorReporter;
 
     compileCompatibilityFlags(compatDate, flagList.asReader(), output,
                               errorReporter, experimental,

--- a/src/workerd/util/thread-scopes.h
+++ b/src/workerd/util/thread-scopes.h
@@ -109,4 +109,22 @@ private:
 
   friend class Watchdog;
 };
+
+// ======================================================================================
+
+// Create on stack in scopes where any attempt to take an isolate lock should log a warning.
+// Isolate locks can block for a relatively long time, so we especially try to avoid taking
+// them while any other locks are held.
+class WarnAboutIsolateLockScope {
+public:
+  WarnAboutIsolateLockScope();
+  ~WarnAboutIsolateLockScope() noexcept(false);
+  KJ_DISALLOW_COPY(WarnAboutIsolateLockScope);
+  WarnAboutIsolateLockScope(WarnAboutIsolateLockScope&&);
+  void release();
+
+  static void maybeWarn();
+private:
+  bool released = false;
+};
 }  // namespace workerd


### PR DESCRIPTION
More work towards cleaning up the workerd public API surface

* Move WarnAbourtIsolateLockScope out of worker.h into thread-scopes.h 
* Move TeardownFinishedGuard out of worker.h into observer.h
* Move AsyncWaiter definition out of worker.h into worker.c++ (it's only used in there)
* Eliminate duplicate `ValidatorErrorReporter` impls
* Make ConsoleModule an enum class.