### PR TITLE
Move AlarmFulfiller impl out of worker.h

### DIFF
--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -408,7 +408,7 @@ kj::Promise<WorkerInterface::AlarmResult> WorkerEntrypoint::runAlarmImpl(
 
   auto scheduleAlarmResult = co_await actor.scheduleAlarm(scheduledTime);
   KJ_SWITCH_ONEOF(scheduleAlarmResult) {
-    KJ_CASE_ONEOF(af, Worker::Actor::AlarmFulfiller) {
+    KJ_CASE_ONEOF(af, WorkerInterface::AlarmFulfiller) {
       // We're now in charge of running this alarm!
       auto cancellationGuard = kj::defer([&af]() {
         // Our promise chain was cancelled, let's cancel our fulfiller for any other requests
@@ -442,7 +442,7 @@ kj::Promise<WorkerInterface::AlarmResult> WorkerEntrypoint::runAlarmImpl(
         throw;
       }
     }
-    KJ_CASE_ONEOF(result, Worker::Actor::AlarmResult) {
+    KJ_CASE_ONEOF(result, WorkerInterface::AlarmResult) {
       // The alarm was cancelled while we were waiting to run, go ahead and return the result.
       co_return result;
     }

--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -94,7 +94,7 @@ private:
   template <typename T>
   kj::Promise<T> maybeAddGcPassForTest(IoContext& context, kj::Promise<T> promise);
 
-  kj::Promise<WorkerEntrypoint::AlarmResult> runAlarmImpl(
+  kj::Promise<WorkerInterface::AlarmResult> runAlarmImpl(
       kj::Own<IoContext::IncomingRequest> incomingRequest, kj::Date scheduledTime);
 
 public:  // For kj::heap() only; pretend this is private.

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -56,6 +56,24 @@ public:
     EventOutcome outcome = EventOutcome::UNKNOWN;
   };
 
+  class AlarmFulfiller {
+  public:
+    AlarmFulfiller(kj::Own<kj::PromiseFulfiller<AlarmResult>> fulfiller);
+    KJ_DISALLOW_COPY(AlarmFulfiller);
+    AlarmFulfiller(AlarmFulfiller&&) = default;
+    AlarmFulfiller& operator=(AlarmFulfiller&&) = default;
+    ~AlarmFulfiller() noexcept(false);
+    void fulfill(const AlarmResult& result);
+    void reject(const kj::Exception& e);
+    void cancel();
+
+  private:
+    kj::Maybe<kj::Own<kj::PromiseFulfiller<AlarmResult>>> maybeFulfiller;
+    kj::Maybe<kj::PromiseFulfiller<AlarmResult>&> getFulfiller();
+  };
+
+  using ScheduleAlarmResult = kj::OneOf<AlarmResult, AlarmFulfiller>;
+
   // Trigger a scheduled event with the given scheduled (unix timestamp) time and cron string.
   // The cron string must be valid until the returned promise completes.
   // Async work is queued in a "waitUntil" task set.


### PR DESCRIPTION
Further simplification of worker.h

* Move the class definition in WorkerInterface alongside AlarmResult (with which it is closely related)
* Move the implementation in worker-interface.c++