### PR TITLE
Simplify autogates config and optimise autogate storage.

### DIFF
--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -106,9 +106,7 @@ wd_cc_capnp_library(
     name = "workerd_capnp",
     srcs = ["workerd.capnp"],
     visibility = ["//visibility:public"],
-    deps = [
-        "//src/workerd/util:autogate_capnp",
-    ],
+    deps = [],
 )
 
 wd_cc_capnp_library(

--- a/src/workerd/server/workerd-meta.capnp
+++ b/src/workerd/server/workerd-meta.capnp
@@ -6,4 +6,3 @@ $import "/capnp/c++.capnp".namespace("workerd::server");
 
 const cppCapnpSchema :Text = embed "/capnp/c++.capnp";
 const workerdCapnpSchema :Text = embed "workerd.capnp";
-const autogateCapnpSchema :Text = embed "../util/autogate.capnp";

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -477,8 +477,6 @@ kj::Maybe<kj::Own<capnp::SchemaFile>> tryImportBulitin(kj::StringPtr name) {
     return kj::heap<BuiltinSchemaFileImpl>("/capnp/c++.capnp", CPP_CAPNP_SCHEMA);
   } else if (name == "/workerd/workerd.capnp") {
     return kj::heap<BuiltinSchemaFileImpl>("/workerd/workerd.capnp", WORKERD_CAPNP_SCHEMA);
-  } else if (name == "/workerd/util/autogate.capnp") {
-    return kj::heap<BuiltinSchemaFileImpl>("/workerd/util/autogate.capnp", AUTOGATE_CAPNP_SCHEMA);
   } else {
     return kj::none;
   }

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -34,14 +34,12 @@
 # afraid to fall back to code for anything the config cannot express, as Workers are very fast
 # to execute!
 
-using Cxx = import "/capnp/c++.capnp";
-$Cxx.namespace("workerd::server::config");
-$Cxx.allowCancellation;
-
 # Any capnp files imported here must be:
 # 1. embedded into workerd-meta.capnp
 # 2. added to `tryImportBulitin` in workerd.c++ (grep for '"/workerd/workerd.capnp"').
-using import "/workerd/util/autogate.capnp".Autogate;
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("workerd::server::config");
+$Cxx.allowCancellation;
 
 struct Config {
   # Top-level configuration for a workerd instance.
@@ -82,8 +80,8 @@ struct Config {
   # Extensions provide capabilities to all workers. Extensions are usually prepared separately
   # and are late-linked with the app using this config field.
 
-  autogates @4 :List(Autogate);
-  # A list of gates and a corresponding value of whether they are enabled.
+  autogates @4 :List(Text);
+  # A list of gates which are enabled.
   # These are used to gate features/changes in workerd and in our internal repo. See the equivalent
   # config definition in our internal repo for more details.
 }

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -98,19 +98,12 @@ wd_cc_library(
     ],
 )
 
-wd_cc_capnp_library(
-    name = "autogate_capnp",
-    srcs = ["autogate.capnp"],
-    visibility = ["//visibility:public"],
-    deps = [],
-)
-
 wd_cc_library(
     name = "autogate",
     srcs = ["autogate.c++"],
     hdrs = ["autogate.h"],
     visibility = ["//visibility:public"],
-    deps = [":autogate_capnp", ":sentry"],
+    deps = [":sentry", "@capnp-cpp//src/kj", "@capnp-cpp//src/capnp"],
 )
 
 [kj_test(

--- a/src/workerd/util/autogate.capnp
+++ b/src/workerd/util/autogate.capnp
@@ -1,9 +1,0 @@
-@0x8c73baaf4250210f;
-
-using Cxx = import "/capnp/c++.capnp";
-$Cxx.namespace("workerd::util::autogate");
-
-struct Autogate {
-  enabled @0 :Bool;
-  name @1 :Text;
-}

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -5,7 +5,8 @@
 
 #include "kj/debug.h"
 #include <kj/map.h>
-#include <workerd/util/autogate.capnp.h>
+#include <capnp/common.h>
+#include <capnp/list.h>
 
 namespace workerd::util {
 
@@ -37,13 +38,13 @@ public:
   // This function is not thread safe, it should be called exactly once close to the start of the
   // process before any threads are created.
   static void initAutogate(
-      capnp::List<autogate::Autogate, capnp::Kind::STRUCT>::Reader autogates);
+      capnp::List<capnp::Text>::Reader autogates);
   // Destroys an initialised global Autogate instance. Used only for testing.
   static void deinitAutogate();
 private:
-  kj::HashMap<AutogateKey, bool> gates;
+  bool gates[(unsigned long)AutogateKey::NumOfKeys];
 
-  Autogate(capnp::List<autogate::Autogate, capnp::Kind::STRUCT>::Reader autogates);
+  Autogate(capnp::List<capnp::Text>::Reader autogates);
 };
 
 // Retrieves the name of the gate.


### PR DESCRIPTION
Simplifies the autogate config to a simple list of autogate key names. Also optimises to use an array instead of a hashmap like @kentonv suggested.