### PR TITLE
[Vectorize] Fix (and test) compatibility flag loading in Vectorize

### DIFF
--- a/src/cloudflare/internal/test/vectorize/tsconfig.json
+++ b/src/cloudflare/internal/test/vectorize/tsconfig.json
@@ -2,13 +2,8 @@
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "checkJs": true,
-    "noEmit": true,
+    "noEmit": true
   },
-  "include": [
-    "*.ts",
-    "*.js",
-  ],
-  "files": [
-    "../../../../../types/defines/vectorize.d.ts"
-  ]
+  "include": ["*.ts", "*.js"],
+  "files": ["../../../../../types/defines/vectorize.d.ts"]
 }

--- a/src/cloudflare/internal/test/vectorize/vectorize-api-test.js
+++ b/src/cloudflare/internal/test/vectorize/vectorize-api-test.js
@@ -13,10 +13,10 @@ import { KnownModel, DistanceMetric } from "cloudflare:vectorize";
 
 export const test_vector_search_vector_query = {
   /**
-   * @param {unknown} ctr
+   * @param {unknown} _
    * @param {Env} env
    */
-  async test(ctr, env) {
+  async test(_, env) {
     const IDX = env["vector-search"];
     {
       // with returnValues = true, returnMetadata = true
@@ -88,10 +88,10 @@ export const test_vector_search_vector_query = {
 
 export const test_vector_search_vector_insert = {
   /**
-   * @param {unknown} ctr
+   * @param {unknown} _
    * @param {Env} env
    */
-  async test(ctr, env) {
+  async test(_, env) {
     const IDX = env["vector-search"];
     {
       /** @type {Array<VectorizeVector>}  */
@@ -115,10 +115,10 @@ export const test_vector_search_vector_insert = {
 
 export const test_vector_search_vector_insert_error = {
   /**
-   * @param {unknown} ctr
+   * @param {unknown} _
    * @param {Env} env
    */
-  async test(ctr, env) {
+  async test(_, env) {
     const IDX = env["vector-search"];
     {
       /** @type {Array<VectorizeVector>}  */
@@ -147,10 +147,10 @@ export const test_vector_search_vector_insert_error = {
 
 export const test_vector_search_vector_upsert = {
   /**
-   * @param {unknown} ctr
+   * @param {unknown} _
    * @param {Env} env
    */
-  async test(ctr, env) {
+  async test(_, env) {
     const IDX = env["vector-search"];
     {
       /** @type {Array<VectorizeVector>}  */
@@ -174,10 +174,10 @@ export const test_vector_search_vector_upsert = {
 
 export const test_vector_search_vector_delete_ids = {
   /**
-   * @param {unknown} ctr
+   * @param {unknown} _
    * @param {Env} env
    */
-  async test(ctr, env) {
+  async test(_, env) {
     const IDX = env["vector-search"];
     {
       const results = await IDX.deleteByIds([
@@ -195,10 +195,10 @@ export const test_vector_search_vector_delete_ids = {
 
 export const test_vector_search_vector_get_ids = {
   /**
-   * @param {unknown} ctr
+   * @param {unknown} _
    * @param {Env} env
    */
-  async test(ctr, env) {
+  async test(_, env) {
     const IDX = env["vector-search"];
     {
       const results = await IDX.getByIds([

--- a/src/cloudflare/internal/test/vectorize/vectorize-api-test.wd-test
+++ b/src/cloudflare/internal/test/vectorize/vectorize-api-test.wd-test
@@ -7,7 +7,7 @@ const unitTests :Workerd.Config = (
         modules = [
           ( name = "worker", esModule = embed "vectorize-api-test.js" )
         ],
-        compatibilityDate = "2023-01-15",
+        compatibilityDate = "2023-11-21",
         compatibilityFlags = ["nodejs_compat"],
         bindings = [
           ( name = "vector-search",
@@ -24,7 +24,7 @@ const unitTests :Workerd.Config = (
     ),
     ( name = "vector-search-mock",
       worker = (
-        compatibilityDate = "2023-01-15",
+        compatibilityDate = "2023-11-21",
         modules = [
           ( name = "worker", esModule = embed "vectorize-mock.js" )
         ],

--- a/src/cloudflare/internal/test/vectorize/vectorize-mock.js
+++ b/src/cloudflare/internal/test/vectorize/vectorize-mock.js
@@ -100,7 +100,10 @@ export default {
         /** @type {VectorizeQueryOptions & {vector: number[], compat: { queryMetadataOptional: boolean }}} */
         const body = await request.json();
         // check that the compatibility flags are set
-        if (!body.compat.queryMetadataOptional) throw Error('expected to get `queryMetadataOptional` compat flag with a value of true')
+        if (!body.compat.queryMetadataOptional)
+          throw Error(
+            "expected to get `queryMetadataOptional` compat flag with a value of true"
+          );
         const returnSet = exampleVectorMatches;
         if (!body?.returnValues)
           returnSet.forEach((v) => {

--- a/src/cloudflare/internal/test/vectorize/vectorize-mock.js
+++ b/src/cloudflare/internal/test/vectorize/vectorize-mock.js
@@ -62,7 +62,7 @@ export default {
             name: "my-first-index",
             config: {
               dimensions: 1536,
-              preset: "openapi-text-embedding-ada-002",
+              preset: "openai/text-embedding-ada-002",
               metric: "euclidean",
             },
             vectorsCount: 500000,
@@ -85,7 +85,7 @@ export default {
           name: pathname.split("/")[2] || "my-index",
           config: {
             dimensions: 1536,
-            preset: "openapi-text-embedding-ada-002",
+            preset: "openai/text-embedding-ada-002",
             metric: "euclidean",
           },
           vectorsCount: 850850,
@@ -97,8 +97,10 @@ export default {
       ) {
         return Response.json({});
       } else if (request.method === "POST" && pathname.endsWith("/query")) {
-        /** @type {VectorizeQueryOptions & {vector: number[]}} */
+        /** @type {VectorizeQueryOptions & {vector: number[], compat: { queryMetadataOptional: boolean }}} */
         const body = await request.json();
+        // check that the compatibility flags are set
+        if (!body.compat.queryMetadataOptional) throw Error('expected to get `queryMetadataOptional` compat flag with a value of true')
         const returnSet = exampleVectorMatches;
         if (!body?.returnValues)
           returnSet.forEach((v) => {

--- a/src/cloudflare/internal/vectorize-api.ts
+++ b/src/cloudflare/internal/vectorize-api.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-import { default as flags } from 'workerd:compatibility-flags'
+import { default as flags } from "workerd:compatibility-flags";
 
 interface Fetcher {
   fetch: typeof fetch;
@@ -20,7 +20,7 @@ class VectorizeIndexImpl implements VectorizeIndex {
   public constructor(
     private readonly fetcher: Fetcher,
     private readonly indexId: string
-  ) { }
+  ) {}
 
   public async describe(): Promise<VectorizeIndexDetails> {
     const res = await this._send(
@@ -38,7 +38,9 @@ class VectorizeIndexImpl implements VectorizeIndex {
     vector: VectorFloatArray | number[],
     options: VectorizeQueryOptions
   ): Promise<VectorizeMatches> {
-    const compat = { queryMetadataOptional: flags.vectorizeQueryMetadataOptional };
+    const compat = {
+      queryMetadataOptional: flags.vectorizeQueryMetadataOptional,
+    };
     const res = await this._send(
       Operation.VECTOR_QUERY,
       `indexes/${this.indexId}/query`,
@@ -52,7 +54,7 @@ class VectorizeIndexImpl implements VectorizeIndex {
         headers: {
           "content-type": "application/json",
           accept: "application/json",
-          "cf-vector-search-query-compat": JSON.stringify(compat)
+          "cf-vector-search-query-compat": JSON.stringify(compat),
         },
       }
     );
@@ -169,13 +171,16 @@ class VectorizeIndexImpl implements VectorizeIndex {
       try {
         const errResponse = (await res.json()) as VectorizeError;
         err = new Error(
-          `${Operation[operation]}_ERROR${typeof errResponse.code === "number" ? ` (code = ${errResponse.code})` : ""
+          `${Operation[operation]}_ERROR${
+            typeof errResponse.code === "number"
+              ? ` (code = ${errResponse.code})`
+              : ""
           }: ${errResponse.error}`,
           {
             cause: new Error(errResponse.error),
           }
         );
-      } catch (e) { }
+      } catch (e) {}
 
       if (err) {
         throw err;
@@ -200,9 +205,10 @@ async function toJson<T = unknown>(response: Response): Promise<T> {
     return JSON.parse(body) as T;
   } catch (e) {
     throw new Error(
-      `Failed to parse body as JSON, got: ${body.length > maxBodyLogChars
-        ? `${body.slice(0, maxBodyLogChars)}…`
-        : body
+      `Failed to parse body as JSON, got: ${
+        body.length > maxBodyLogChars
+          ? `${body.slice(0, maxBodyLogChars)}…`
+          : body
       }`
     );
   }

--- a/src/cloudflare/internal/vectorize.d.ts
+++ b/src/cloudflare/internal/vectorize.d.ts
@@ -85,10 +85,11 @@ interface VectorizeVector {
 /**
  * Represents a matched vector for a query along with its score and (if specified) the matching vector information.
  */
-type VectorizeMatch = Pick<Partial<VectorizeVector>, 'values'> & Omit<VectorizeVector, 'values'> & {
-  /** The score or rank for similarity, when returned as a result */
-  score: number;
-}
+type VectorizeMatch = Pick<Partial<VectorizeVector>, "values"> &
+  Omit<VectorizeVector, "values"> & {
+    /** The score or rank for similarity, when returned as a result */
+    score: number;
+  };
 
 /**
  * A set of vector {@link VectorizeMatch} for a particular query.


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workerd/issues/1435

Compatiblity flags are a default export: the way they were loaded (with a `*`) the value was always undefined (instead living at `flags.default.vectorizeQueryMetadataOptional`), which got coerced into a falsey value