### PR TITLE
Allow builtin data modules

### DIFF
--- a/build/wd_js_bundle.bzl
+++ b/build/wd_js_bundle.bzl
@@ -126,7 +126,7 @@ def wd_js_bundle(
      builtin_modules: js src label -> module name dictionary
      internal_modules: js src label -> module name dictionary
      internal_wasm_modules: wasm src label -> module name dictionary
-     internal_data_modules: wasm src label -> module name dictionary
+     internal_data_modules: data src label -> module name dictionary
      declarations: d.ts label set
      const_name: capnp constant name that will contain bundle definition
      schema_id: capnpn schema id

--- a/build/wd_js_bundle.bzl
+++ b/build/wd_js_bundle.bzl
@@ -57,6 +57,10 @@ def _gen_api_bundle_capnpn_impl(ctx):
         _render_module(ctx.attr.internal_wasm_modules[m], m.label,  "wasm", "internal")
         for m in ctx.attr.internal_wasm_modules
     ]
+    modules += [
+        _render_module(ctx.attr.internal_data_modules[m], m.label,  "wasm", "internal")
+        for m in ctx.attr.internal_data_modules
+    ]
 
     content = CAPNP_TEMPLATE.format(
         schema_id = ctx.attr.schema_id,
@@ -73,6 +77,7 @@ gen_api_bundle_capnpn = rule(
         "builtin_modules": attr.label_keyed_string_dict(allow_files = True),
         "internal_modules": attr.label_keyed_string_dict(allow_files = True),
         "internal_wasm_modules": attr.label_keyed_string_dict(allow_files = True),
+        "internal_data_modules": attr.label_keyed_string_dict(allow_files = True),
         "declarations": attr.string_dict(),
         "data": attr.label_list(allow_files = True),
         "const_name": attr.string(mandatory = True),
@@ -107,6 +112,7 @@ def wd_js_bundle(
         builtin_modules = {},
         internal_modules = {},
         internal_wasm_modules = {},
+        internal_data_modules = {},
         declarations = [],
         **kwargs
 ):
@@ -120,6 +126,7 @@ def wd_js_bundle(
      builtin_modules: js src label -> module name dictionary
      internal_modules: js src label -> module name dictionary
      internal_wasm_modules: wasm src label -> module name dictionary
+     internal_data_modules: wasm src label -> module name dictionary
      declarations: d.ts label set
      const_name: capnp constant name that will contain bundle definition
      schema_id: capnpn schema id
@@ -130,17 +137,20 @@ def wd_js_bundle(
     internal_modules, internal_declarations = _copy_modules(
         internal_modules, declarations
     )
-    internal_wasm_modules, internal_wasm_declarations = _copy_modules(
+    internal_wasm_modules, _ = _copy_modules(
         internal_wasm_modules, declarations
+    )
+    internal_data_modules, _ = _copy_modules(
+        internal_data_modules, declarations
     )
 
     data = (
         list(builtin_modules)
         + list(internal_modules)
         + list(internal_wasm_modules)
+        + list(internal_data_modules)
         + list(builtin_declarations.values())
         + list(internal_declarations.values())
-        + list(internal_wasm_declarations.values())
     )
 
     gen_api_bundle_capnpn(
@@ -151,7 +161,8 @@ def wd_js_bundle(
         builtin_modules = builtin_modules,
         internal_modules = internal_modules,
         internal_wasm_modules = internal_wasm_modules,
-        declarations = builtin_declarations | internal_declarations | internal_wasm_declarations,
+        internal_data_modules = internal_data_modules,
+        declarations = builtin_declarations | internal_declarations,
         data = data,
     )
 

--- a/build/wd_js_bundle.bzl
+++ b/build/wd_js_bundle.bzl
@@ -58,7 +58,7 @@ def _gen_api_bundle_capnpn_impl(ctx):
         for m in ctx.attr.internal_wasm_modules
     ]
     modules += [
-        _render_module(ctx.attr.internal_data_modules[m], m.label,  "wasm", "internal")
+        _render_module(ctx.attr.internal_data_modules[m], m.label,  "data", "internal")
         for m in ctx.attr.internal_data_modules
     ]
 

--- a/build/wd_ts_bundle.bzl
+++ b/build/wd_ts_bundle.bzl
@@ -22,6 +22,7 @@ def wd_ts_bundle(
         tsconfig_json,
         eslintrc_json,
         internal_wasm_modules = [],
+        internal_data_modules = [],
         lint = True,
         deps = []):
     """Compiles typescript modules and generates api bundle with the result.
@@ -75,7 +76,7 @@ def wd_ts_bundle(
                 if not m.endswith(".d.ts")
             ]
         ),
-        internal_wasm_modules=dict(
+        internal_wasm_modules = dict(
             [
                 (
                     m,
@@ -84,6 +85,17 @@ def wd_ts_bundle(
                     + m.removeprefix("internal/").removesuffix(".wasm"),
                 )
                 for m in internal_wasm_modules
+            ]
+        ),
+        internal_data_modules = dict(
+            [
+                (
+                    m,
+                    import_name
+                    + "-internal:"
+                    + m.removeprefix("internal/"),
+                )
+                for m in internal_data_modules
             ]
         ),
         declarations = declarations,

--- a/src/workerd/jsg/modules.capnp
+++ b/src/workerd/jsg/modules.capnp
@@ -17,7 +17,7 @@ struct Module {
   union {
     src @1 :Data; # JS / TS code
     wasm @4 :Data; # Wasm module
-    data @5: Data; # Binary data module
+    data @5 :Data; # Binary data module
   }
   tsDeclaration @3 :Text;
 

--- a/src/workerd/jsg/modules.capnp
+++ b/src/workerd/jsg/modules.capnp
@@ -17,6 +17,7 @@ struct Module {
   union {
     src @1 :Data; # JS / TS code
     wasm @4 :Data; # Wasm module
+    data @5: Data; # Binary data module
   }
   tsDeclaration @3 :Text;
 

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -397,7 +397,7 @@ public:
       auto type = module.getType();
       auto filter = maybeFilter.orDefault(type);
       if (type == filter) {
-        if (module.which() == Module::WASM) {
+        if (module.which() != Module::SRC) {
           if (!util::Autogate::isEnabled(util::AutogateKey::BUILTIN_WASM_MODULES)) {
             LOG_ERROR_ONCE("Builtin wasm module used without passing builtin-wasm-modules autogate flag");
             continue;
@@ -408,25 +408,53 @@ public:
           if (type == Type::BUILTIN && entries.find(Key(path, Type::BUNDLE)) != kj::none) {
             continue;
           }
+          switch(module.which()) {
+          case Module::WASM:
+            // The body of this callback is copied from `compileWasmGlobal` in src/workerd/server/workerd-api.c++.
+            addBuiltinModule(specifier, [specifier, module, this](Lock& lock) {
+              lock.setAllowEval(true);
+              KJ_DEFER(lock.setAllowEval(false));
 
-          // The body of this callback is copied from `compileWasmGlobal` in src/workerd/server/workerd-api.c++.
-          addBuiltinModule(specifier, [specifier, module, this](Lock& lock) {
-            lock.setAllowEval(true);
-            KJ_DEFER(lock.setAllowEval(false));
+              // Allow Wasm compilation to spawn a background thread for tier-up, i.e. recompiling
+              // Wasm with optimizations in the background. Otherwise Wasm startup is way too slow.
+              // Until tier-up finishes, requests will be handled using Liftoff-generated code, which
+              // compiles fast but runs slower.
+              AllowV8BackgroundThreadsScope scope;
+              auto wasmModule = jsg::compileWasmModule(lock, module.getWasm().asBytes(), this->observer);
+              return jsg::ModuleRegistry::ModuleInfo(
+                    lock,
+                    specifier,
+                    kj::none,
+                    jsg::ModuleRegistry::WasmModuleInfo(lock, wasmModule));
+            }, type);
+            continue;
+          case Module::DATA:
+            addBuiltinModule(specifier, [specifier, module](Lock& lock) {
+              auto value = kj::heapArray(module.getData().asBytes().asBytes());
+              v8::Local<v8::ArrayBuffer> data;
+              {
+                // Code duplicated from ArrayBufferWrapper::wrap in value.h because I
+                // couldn't figure out how to use ArrayBufferWrapper directly.
+                // TODO: Avoid code duplication
+                byte* begin = value.begin();
+                size_t size = value.size();
+                auto ownerPtr = new kj::Array<byte>(kj::mv(value));
 
-            // Allow Wasm compilation to spawn a background thread for tier-up, i.e. recompiling
-            // Wasm with optimizations in the background. Otherwise Wasm startup is way too slow.
-            // Until tier-up finishes, requests will be handled using Liftoff-generated code, which
-            // compiles fast but runs slower.
-            AllowV8BackgroundThreadsScope scope;
-            auto wasmModule = jsg::compileWasmModule(lock, module.getWasm().asBytes(), this->observer);
-            return jsg::ModuleRegistry::ModuleInfo(
-                  lock,
-                  specifier,
-                  kj::none,
-                  jsg::ModuleRegistry::WasmModuleInfo(lock, wasmModule));
-          }, type);
-          continue;
+                std::unique_ptr<v8::BackingStore> backing =
+                    v8::ArrayBuffer::NewBackingStore(begin, size,
+                        [](void* begin, size_t size, void* ownerPtr){
+                          delete reinterpret_cast<kj::Array<byte>*>(ownerPtr);
+                        }, ownerPtr);
+                data = v8::ArrayBuffer::New(lock.v8Isolate, kj::mv(backing));
+              }
+
+              return jsg::ModuleRegistry::ModuleInfo(lock, specifier, kj::none,
+                                                     jsg::ModuleRegistry::DataModuleInfo(lock, data));
+            }, type);
+            continue;
+          case Module::SRC:
+            KJ_UNREACHABLE
+          }
         }
         // TODO: asChars() might be wrong for wide characters
         addBuiltinModule(module.getName(), module.getSrc().asChars(), type);

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -400,7 +400,7 @@ public:
         if (module.which() != Module::SRC) {
           if (!util::Autogate::isEnabled(util::AutogateKey::BUILTIN_WASM_MODULES)) {
             LOG_ERROR_ONCE(
-                "Builtin wasm module used without passing builtin-wasm-modules autogate flag");
+                "Builtin wasm module or data module used without passing builtin-wasm-modules autogate flag");
             continue;
           }
           using Key = typename Entry::Key;


### PR DESCRIPTION
Followup of #1402. We need data modules for Pyodide too.
Currently targeting the wasm-builtin branch pending that PR being merged.
No automated tests for this, but I've tested it manually on my branch that builds pyodide into workerd with bazel.  