### PR TITLE
Decompose io-context.h/c++ into multiple headers/c++ files

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -14,6 +14,7 @@
 #include "hibernation-event-params.h"
 #include "blob.h"
 #include "streams.h"
+#include <workerd/io/io-timers.h>
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
 #include <workerd/api/gpu/gpu.h>
 #endif

--- a/src/workerd/api/gpu/gpu-async-runner.h
+++ b/src/workerd/api/gpu/gpu-async-runner.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "workerd/io/io-context.h"
+#include <workerd/io/io-timers.h>
 #include <kj/timer.h>
 #include <webgpu/webgpu_cpp.h>
 

--- a/src/workerd/api/gpu/gpu-shader-module.c++
+++ b/src/workerd/api/gpu/gpu-shader-module.c++
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "gpu-shader-module.h"
+#include <workerd/io/io-context.h>
 
 namespace workerd::api::gpu {
 

--- a/src/workerd/io/actor-cache-test.c++
+++ b/src/workerd/io/actor-cache-test.c++
@@ -1325,7 +1325,7 @@ KJ_TEST("ActorCache flush hard failure") {
   {
     mockStorage->expectCall("put", ws)
         .withParams(CAPNP(entries = [(key = "foo", value = "123")]))
-        .thenThrow(JSG_KJ_EXCEPTION(FAILED, Error, "flush failed hard"));
+        .thenThrow(KJ_EXCEPTION(FAILED, "jsg.Error: flush failed hard"));
   }
 
   KJ_EXPECT_THROW_MESSAGE("broken.outputGateBroken; jsg.Error: flush failed hard", promise.wait(ws));
@@ -1350,7 +1350,7 @@ KJ_TEST("ActorCache flush hard failure with output gate bypass") {
   {
     mockStorage->expectCall("put", ws)
         .withParams(CAPNP(entries = [(key = "foo", value = "123")]))
-        .thenThrow(JSG_KJ_EXCEPTION(FAILED, Error, "flush failed hard"));
+        .thenThrow(KJ_EXCEPTION(FAILED, "jsg.Error: flush failed hard"));
   }
 
   // The failure was still propagated to the output gate.

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -125,29 +125,6 @@ public:
   kj::Maybe<kj::Promise<void>> maybePromise;
 };
 
-ThreadContext::HeaderIdBundle::HeaderIdBundle(kj::HttpHeaderTable::Builder& builder)
-    : table(builder.getFutureTable()),
-      contentEncoding(builder.add("Content-Encoding")),
-      cfCacheStatus(builder.add("CF-Cache-Status")),
-      cacheControl(builder.add("Cache-Control")),
-      cfCacheNamespace(builder.add("CF-Cache-Namespace")),
-      cfKvMetadata(builder.add("CF-KV-Metadata")),
-      cfR2ErrorHeader(builder.add("CF-R2-Error")),
-      cfBlobMetadataSize(builder.add("CF-R2-Metadata-Size")),
-      cfBlobRequest(builder.add("CF-R2-Request")),
-      authorization(builder.add("Authorization")),
-      secWebSocketProtocol(builder.add("Sec-WebSocket-Protocol")) {}
-
-ThreadContext::ThreadContext(
-    kj::Timer& timer, kj::EntropySource& entropySource,
-    HeaderIdBundle headerIds, capnp::HttpOverCapnpFactory& httpOverCapnpFactory, capnp::ByteStreamFactory& byteStreamFactory, bool fiddle)
-    : timer(timer),
-      entropySource(entropySource),
-      headerIds(headerIds),
-      httpOverCapnpFactory(httpOverCapnpFactory),
-      byteStreamFactory(byteStreamFactory),
-      fiddle(fiddle) {}
-
 IoContext::IoContext(ThreadContext& thread,
                                kj::Own<const Worker> workerParam,
                                kj::Maybe<Worker::Actor&> actorParam,

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -21,19 +21,6 @@ static void* getThreadId() {
   return threadId;
 }
 
-void IoContext::DeleteQueue::scheduleDeletion(OwnedObject* object) const {
-  if (threadLocalRequest != nullptr && threadLocalRequest->deleteQueue.get() == this) {
-    // Deletion from same thread. No need to enqueue.
-    kj::AllowAsyncDestructorsScope scope;
-    OwnedObjectList::unlink(*object);
-  } else {
-    auto lock = crossThreadDeleteQueue.lockExclusive();
-    KJ_IF_SOME(state, *lock) {
-      state.queue.add(object);
-    }
-  }
-}
-
 class IoContext::TimeoutManagerImpl final: public TimeoutManager {
 public:
   class TimeoutState;
@@ -975,64 +962,6 @@ void IoContext::checkFarGet(const DeleteQueue* expectedQueue) {
   }
 }
 
-IoContext::OwnedObjectList::~OwnedObjectList() noexcept(false) {
-  while (head != kj::none) {
-    // We want to have the same order of operations as the recursive destructor here. Without this
-    // optimization, `~SpecificOwnedObject<T>` is invoked first, then `~OwnedObject()` which
-    // destructs the next node which continues the process. The key takeaway is that we destroy each
-    // node's `T` before we move onto the next node. This duplicates that behavior by unlinking
-    // forward through the list, which hopefully should keep our stack size low no matter how many
-    // `OwnedObject` instances we have.
-    unlink(*KJ_ASSERT_NONNULL(head));
-  }
-}
-
-void IoContext::OwnedObjectList::unlink(OwnedObject& object) {
-  KJ_IF_SOME(next, object.next) {
-    next.get()->prev = object.prev;
-  }
-  *object.prev = kj::mv(object.next);
-}
-
-void IoContext::OwnedObjectList::link(kj::Own<OwnedObject> object) {
-  KJ_IF_SOME(f, object->finalizer) {
-    if (finalizersRan) {
-      KJ_LOG(ERROR, "somehow new objects are being added after finalizers already ran",
-             kj::getStackTrace());
-      f.finalize();
-    }
-  }
-
-  object->next = kj::mv(head);
-  KJ_IF_SOME(next, object->next) {
-    next.get()->prev = &object->next;
-  }
-  object->prev = &head;
-  head = kj::mv(object);
-}
-
-kj::Vector<kj::StringPtr> IoContext::OwnedObjectList::finalize() {
-  KJ_ASSERT(!finalizersRan);
-  finalizersRan = true;
-
-  kj::Vector<kj::StringPtr> warnings;
-  auto* link = &head;
-  while (*link != kj::none) {
-    auto& l = KJ_ASSERT_NONNULL(*link);
-    KJ_IF_SOME(f, l->finalizer) {
-      KJ_IF_SOME(w, f.finalize()) {
-        warnings.add(w);
-      }
-#ifdef KJ_DEBUG
-      f.finalized = true;
-#endif
-    }
-    link = &l->next;
-  }
-
-  return warnings;
-}
-
 Worker::Actor& IoContext::getActorOrThrow() {
   return KJ_ASSERT_NONNULL(actor, "not an actor request");
 }
@@ -1272,22 +1201,6 @@ void IoContext::runFinalizers(Worker::AsyncLock& asyncLock) {
 
   promiseContextTag = kj::none;
 }
-
-#ifdef KJ_DEBUG
-
-IoContext::Finalizeable::Finalizeable(): context(IoContext::current()) {
-  if (context.actor != kj::none) {
-    // Disable the destructor check because finalization doesn't apply to actors.
-    finalized = true;
-  }
-}
-IoContext::Finalizeable::~Finalizeable() noexcept(false) {
-  KJ_ASSERT(finalized || !context.isFinalized(),
-      "Finalizeable object survived request finalization without being finalized. This usually "
-      "means it was not passed to IoContext::addObject<T>() as a Finalizeable T.");
-}
-
-#endif
 
 namespace {
 

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -548,19 +548,6 @@ kj::Own<void> IoContext::registerPendingEvent() {
   }
 }
 
-TimeoutId TimeoutId::Generator::getNext() {
-  // The maximum integer value that we can represent as a double to convey to jsg.
-  constexpr ValueType MAX_SAFE_INTEGER = (1ull << 53) - 1;
-
-  auto id = nextId++;
-  if (nextId > MAX_SAFE_INTEGER) {
-    KJ_LOG(WARNING, "Unable to set timeout because there are no more unique ids");
-    JSG_FAIL_REQUIRE(Error, "Unable to set timeout because there are no more unique ids "
-        "less than Number.MAX_SAFE_INTEGER.");
-  }
-  return TimeoutId(id);
-}
-
 IoContext::TimeoutManagerImpl::TimeoutState::TimeoutState(
     TimeoutManagerImpl& manager, TimeoutParameters params)
     : manager(manager), params(kj::mv(params)) {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -6,6 +6,7 @@
 
 #include "io-channels.h"
 #include "io-gate.h"
+#include "io-own.h"
 #include "io-timers.h"
 #include "io-thread-context.h"
 #include "limit-enforcer.h"
@@ -24,19 +25,6 @@
 namespace capnp { class HttpOverCapnpFactory; }
 
 namespace workerd {
-
-template <typename T> class IoOwn;
-template <typename T> class IoPtr;
-
-template <typename T>
-struct RemoveIoOwn_ { typedef T Type; static constexpr bool is = false; };
-template <typename T>
-struct RemoveIoOwn_<IoOwn<T>> { typedef T Type; static constexpr bool is = true; };
-
-template <typename T>
-constexpr bool isIoOwn() { return RemoveIoOwn_<T>::is; }
-template <typename T>
-using RemoveIoOwn = typename RemoveIoOwn_<T>::Type;
 
 [[noreturn]] void throwExceededMemoryLimit(bool isActor);
 
@@ -474,44 +462,6 @@ public:
   template <typename Func>
   auto addFunctor(Func&& func);
 
-  // If an object passed to addObject(Own<T>) implements Finalizeable, then once it is known to
-  // be the case that no code will ever run in the context of this IoContext again,
-  // finalize() will be called.
-  //
-  // This is primarily used to proactively fail out hanging promises once we know they can never
-  // be fulfilled, so that requests fail fast rather than hang forever.
-  //
-  // Finalizers should NOT call into JavaScript or really do much of anything except for calling
-  // reject() on some Fulfiller object. It can optionally return a warning which should be
-  // logged if the inspector is attached.
-  class Finalizeable {
-  public:
-
-    KJ_DISALLOW_COPY_AND_MOVE(Finalizeable);
-
-#ifdef KJ_DEBUG
-    Finalizeable();
-    ~Finalizeable() noexcept(false);
-    // In debug mode, we assert that this object was actually finalized. A Finalizeable object that
-    // doesn't get finalized typically arises when a derived class multiply-inherits from
-    // Finalizeable and some other non-Finalizeable class T, then gets passed to
-    // `IoContext::addObject()` as a T. This can be a source of baffling bugs.
-#else
-    Finalizeable() = default;
-#endif
-
-  private:
-    virtual kj::Maybe<kj::StringPtr> finalize() = 0;
-    friend class IoContext;
-
-#ifdef KJ_DEBUG
-    IoContext& context;
-
-    // Set true by IoContext::runFinalizers();
-    bool finalized = false;
-#endif
-  };
-
   // Call this to indicate that the caller expects to call into JavaScript in this IoContext
   // at some point in the future, in response to some *external* event that the caller is waiting
   // for. Then, hold on to the returned handle until that time. This prevents finalizers from being
@@ -750,80 +700,6 @@ private:
   kj::Maybe<Worker::Lock&> currentLock;
   kj::Maybe<InputGate::Lock> currentInputLock;
 
-  struct OwnedObject {
-    kj::Maybe<kj::Own<OwnedObject>> next;
-    kj::Maybe<kj::Own<OwnedObject>>* prev;
-    kj::Maybe<Finalizeable&> finalizer;
-  };
-
-  template <typename T>
-  struct SpecificOwnedObject: public OwnedObject {
-    SpecificOwnedObject(kj::Own<T> ptr): ptr(kj::mv(ptr)) {}
-    kj::Own<T> ptr;
-  };
-
-  class OwnedObjectList {
-  public:
-    OwnedObjectList() = default;
-    KJ_DISALLOW_COPY_AND_MOVE(OwnedObjectList);
-    ~OwnedObjectList() noexcept(false);
-
-    void link(kj::Own<OwnedObject> object);
-    static void unlink(OwnedObject& object);
-
-    // Runs the finalizer for each object in forward order and returns a vector of any warnings
-    // returned from those finalizers.
-    kj::Vector<kj::StringPtr> finalize();
-
-    bool isFinalized() {
-      return finalizersRan;
-    }
-
-  private:
-    kj::Maybe<kj::Own<OwnedObject>> head;
-
-    bool finalizersRan = false;
-  };
-
-  // Object which receives possibly-cross-thread deletions of owned objects.
-  class DeleteQueue: public kj::AtomicRefcounted {
-  public:
-    DeleteQueue()
-        : crossThreadDeleteQueue(State { kj::Vector<OwnedObject*>() }) {}
-
-    void scheduleDeletion(OwnedObject* object) const;
-
-    struct State {
-      kj::Vector<OwnedObject*> queue;
-    };
-
-    // Pointers from IoOwns that were dropped in other threads, and therefore should be deleted
-    // whenever the IoContext gets around to it. The maybe is changed to kj::none when the
-    // IoContext goes away, at which point all OwnedObjects have already been deleted so
-    // cross-thread deletions can just be ignored.
-    kj::MutexGuarded<kj::Maybe<State>> crossThreadDeleteQueue;
-
-    // Implements the corresponding methods of IoContext and ActorContext.
-    template <typename T> IoOwn<T> addObject(kj::Own<T> obj, OwnedObjectList& ownedObjects);
-  };
-
-  // When the IoContext is destroyed, we need to null out the DeleteQueue. Complicating
-  // matters a bit, we need to cancel all tasks (destroy the TaskSet) before this happens, so
-  // we can't just do it in IoContext's destrucrtor. As a hack, we customize our pointer
-  // to the delete queue to get the tear-down order right.
-  class DeleteQueuePtr: public kj::Own<DeleteQueue> {
-  public:
-    DeleteQueuePtr(kj::Own<DeleteQueue> value)
-        : kj::Own<DeleteQueue>(kj::mv(value)) {}
-    KJ_DISALLOW_COPY_AND_MOVE(DeleteQueuePtr);
-    ~DeleteQueuePtr() noexcept(false) {
-      auto ptr = get();
-      if (ptr != nullptr) {
-        *ptr->crossThreadDeleteQueue.lockExclusive() = kj::none;
-      }
-    }
-  };
-
   DeleteQueuePtr deleteQueue;
 
   kj::Own<kj::PromiseFulfiller<void>> abortFulfiller;
@@ -932,72 +808,9 @@ private:
 
   class ThreadScope;
   class Scope;
-};
 
-// Owned pointer held by a V8 heap object, pointing to a KJ event loop object. Cannot be
-// dereferenced unless the isolate is executing on the appropriate event loop thread.
-template <typename T>
-class IoOwn {
-
-public:
-  IoOwn(IoOwn&& other);
-  IoOwn(decltype(nullptr)): item(nullptr) {}
-  ~IoOwn() noexcept(false);
-  KJ_DISALLOW_COPY(IoOwn);
-
-  T* operator->();
-  T& operator*() { return *operator->(); }
-  operator kj::Own<T>() &&;
-  IoOwn& operator=(IoOwn&& other);
-  IoOwn& operator=(decltype(nullptr));
-
-  // Releases this object from the IoOwn, but instead of deleting it, attaches it to the
-  // IoContext (or ActorContext) such that it won't be destroyed until that context is torn
-  // down.
-  //
-  // This may need to be used in cases where an application could directly observe the destruction
-  // of this object. If that's the case, then the object cannot be destroyed during GC, as this
-  // would let the application observe GC, which might enable side channels. So, the destructor
-  // of the owning object must manually call `deferGcToContext()` to pass all such objects away
-  // to their respective contexts.
-  //
-  // Since this is expected to be called during GC, it is safe to call from a thread other than
-  // the one that owns the IoContext.
-  void deferGcToContext() &&;
-
-private:
-  friend class IoContext;
-
-  kj::Own<const IoContext::DeleteQueue> deleteQueue;
-  IoContext::SpecificOwnedObject<T>* item;
-
-  IoOwn(kj::Own<const IoContext::DeleteQueue> deleteQueue,
-         IoContext::SpecificOwnedObject<T>* item)
-      : deleteQueue(kj::mv(deleteQueue)), item(item) {}
-};
-
-// Reference held by a V8 heap object, pointing to a KJ event loop object. Cannot be
-// dereferenced unless the isolate is executing on the appropriate event loop thread.
-template <typename T>
-class IoPtr {
-public:
-  IoPtr(const IoPtr& other)
-      : deleteQueue(kj::atomicAddRef(*other.deleteQueue)), ptr(other.ptr) {}
-  IoPtr(IoPtr&& other) = default;
-
-  T* operator->();
-  T& operator*() { return *operator->(); }
-  IoPtr& operator=(decltype(nullptr));
-
-private:
-  friend class IoContext;
-
-  kj::Own<const IoContext::DeleteQueue> deleteQueue;
-  T* ptr;
-
-  IoPtr(kj::Own<const IoContext::DeleteQueue> deleteQueue,
-         T* ptr)
-      : deleteQueue(kj::mv(deleteQueue)), ptr(ptr) {}
+  friend class Finalizeable;
+  friend class DeleteQueue;
 };
 
 // =======================================================================================
@@ -1246,7 +1059,7 @@ jsg::Promise<IoContext::MaybeIoOwn<addIoOwn, T>> IoContext::awaitIoImpl(
 template <typename T>
 kj::_::ReducePromises<RemoveIoOwn<T>> IoContext::awaitJs(jsg::Lock& js, jsg::Promise<T> jsPromise) {
   auto paf = kj::newPromiseAndFulfiller<RemoveIoOwn<T>>();
-  struct RefcountedFulfiller: public IoContext::Finalizeable, public kj::Refcounted {
+  struct RefcountedFulfiller: public Finalizeable, public kj::Refcounted {
     kj::Own<kj::PromiseFulfiller<RemoveIoOwn<T>>> fulfiller;
     bool isDone = false;
 
@@ -1331,34 +1144,6 @@ inline IoOwn<T> IoContext::addObject(kj::Own<T> obj) {
 }
 
 template <typename T>
-inline IoOwn<T> IoContext::DeleteQueue::addObject(
-    kj::Own<T> obj, OwnedObjectList& ownedObjects) {
-  auto& ref = *obj;
-
-  // HACK: We need an Own<OwnedObject>, but we actually need to allocate it as the subclass
-  //   SpecificOwnedObject<T>. OwnedObject is not polymorphic, which means kj::Own will refuse
-  //   to upcast kj::Own<SpecificOwnedObject<T>> to kj::Own<OwnedObject> since it can't guarantee
-  //   the disposers are compatible. However, since we're only using single inheritance here, the
-  //   disposers *are* compatible (the numeric value of pointers to SpecificOwnedObject<T> and
-  //   its parent OwnedObject are equal). So, instead of forcing OwnedObject to be polymorphic
-  //   (which would have forced a bunch of useless vtables and vtable pointers)... I'm manually
-  //   constructing the kj::Own<> using a disposer that I know is compatible.
-  // TODO(cleanup): Can KJ be made to support this use case?
-  kj::Own<OwnedObject> ownedObject(
-      new SpecificOwnedObject<T>(kj::mv(obj)),
-      kj::_::HeapDisposer<SpecificOwnedObject<T>>::instance);
-
-  if constexpr (kj::canConvert<T&, Finalizeable&>()) {
-    ownedObject->finalizer = ref;
-  }
-
-  IoOwn<T> result(kj::atomicAddRef(*this),
-      static_cast<SpecificOwnedObject<T>*>(ownedObject.get()));
-  ownedObjects.link(kj::mv(ownedObject));
-  return result;
-}
-
-template <typename T>
 inline IoPtr<T> IoContext::addObject(T& obj) {
   requireCurrent();
   return IoPtr<T>(kj::atomicAddRef(*deleteQueue), &obj);
@@ -1388,79 +1173,6 @@ auto IoContext::addFunctorIoOwnParam(Func&& func) {
       return (*func)(kj::mv(*param));
     };
   }
-}
-
-template <typename T>
-IoOwn<T>::IoOwn(IoOwn&& other)
-    : deleteQueue(kj::mv(other.deleteQueue)),
-      item(other.item) {
-  other.item = nullptr;
-}
-
-template <typename T>
-IoOwn<T>::~IoOwn() noexcept(false) {
-  if (item != nullptr) {
-    deleteQueue->scheduleDeletion(item);
-  }
-}
-
-template <typename T>
-inline T* IoOwn<T>::operator->() {
-  IoContext::current().checkFarGet(deleteQueue.get());
-  return item->ptr;
-}
-
-template <typename T>
-inline IoOwn<T>::operator kj::Own<T>() && {
-  auto& context = IoContext::current();
-  context.checkFarGet(deleteQueue);
-  auto result = kj::mv(item->ptr);
-  IoContext::OwnedObjectList::unlink(*item);
-  item = nullptr;
-  deleteQueue = nullptr;  // not needed anymore, might as well drop the refcount
-  return result;
-}
-
-template <typename T>
-IoOwn<T>& IoOwn<T>::operator=(IoOwn<T>&& other) {
-  if (item != nullptr) {
-    deleteQueue->scheduleDeletion(item);
-  }
-  deleteQueue = kj::mv(other.deleteQueue);
-  item = other.item;
-  other.item = nullptr;
-  return *this;
-}
-
-template <typename T>
-IoOwn<T>& IoOwn<T>::operator=(decltype(nullptr)) {
-  if (item != nullptr) {
-    deleteQueue->scheduleDeletion(item);
-  }
-  deleteQueue = nullptr;
-  item = nullptr;
-  return *this;
-}
-
-template <typename T>
-void IoOwn<T>::deferGcToContext() && {
-  // Turns out, if we simply *don't* enqueue the item for deletion, we get the behavior we want.
-  // So we can just null out the pointers here...
-  item = nullptr;
-  deleteQueue = nullptr;
-}
-
-template <typename T>
-inline T* IoPtr<T>::operator->() {
-  IoContext::current().checkFarGet(deleteQueue.get());
-  return ptr;
-}
-
-template <typename T>
-IoPtr<T>& IoPtr<T>::operator=(decltype(nullptr)) {
-  deleteQueue = nullptr;
-  ptr = nullptr;
-  return *this;
 }
 
 template <typename Func>

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -6,6 +6,7 @@
 
 #include "io-channels.h"
 #include "io-gate.h"
+#include "io-timers.h"
 #include "io-thread-context.h"
 #include "limit-enforcer.h"
 #include "trace.h"
@@ -40,96 +41,6 @@ using RemoveIoOwn = typename RemoveIoOwn_<T>::Type;
 [[noreturn]] void throwExceededMemoryLimit(bool isActor);
 
 class IoContext;
-
-// A TimeoutId is a positive non-zero integer value that explicitly identifies a timeout set on an
-// isolate.
-//
-// Lastly, timeout ids can experience integer roll over. It is expected that the
-// setTimeout/clearTimeout implementation will enforce id uniqueness for *active* timeouts. This
-// does not mean that an external user cannot have cached a timeout id for a long expired timeout.
-// However, clearTimeout implementations are expected to only have access to timeouts set via that
-// same implementation.
-class TimeoutId {
-public:
-  // Use a double so that we can exceed the maximum value for uint32_t.
-  using NumberType = double;
-
-  // Store as a uint64_t so that we treat this id as an integer.
-  using ValueType = uint64_t;
-
-  class Generator;
-
-  // Convert an externally provided double into a TimeoutId. If you are making a new TimeoutId,
-  // use a Generator instead.
-  static TimeoutId fromNumber(NumberType id) {
-    return TimeoutId(ValueType(id));
-  }
-
-  // Convert a TimeoutId to an integer-covertable double for external consumption.
-  // Note that this is expected to be less than or equal to JavaScript Number.MAX_SAFE_INTEGER
-  // (2^53 - 1). To reach greater than that value in normal operation, we'd need a Generator to
-  // live far far longer than our normal release/restart cycle, be initialized with a large
-  // starting value, or experience active concurrency _somehow_.
-  NumberType toNumber() const {
-    return value;
-  }
-
-  bool operator<(TimeoutId id) const {
-    return value < id.value;
-  }
-
-private:
-  constexpr explicit TimeoutId(ValueType value): value(value) {}
-
-  ValueType value;
-};
-
-class TimeoutId::Generator {
-public:
-  Generator() = default;
-  Generator(const Generator&) = delete;
-  Generator& operator=(const Generator&) = delete;
-  Generator(Generator&&) = delete;
-  Generator& operator=(Generator&&) = delete;
-
-  // Get the next TimeoutId for this generator. This function will never return a TimeoutId <= 0.
-  TimeoutId getNext();
-
-private:
-  // We always skip 0 per the spec:
-  // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers.
-  TimeoutId::ValueType nextId = 1;
-};
-
-class TimeoutManager {
-public:
-  // Upper bound on the number of timeouts a user can *ever* have active.
-  constexpr static auto MAX_TIMEOUTS = 10'000;
-
-  struct TimeoutParameters {
-    TimeoutParameters(bool repeat, int64_t msDelay, jsg::Function<void()> function)
-        : repeat(repeat), msDelay(msDelay), function(kj::mv(function)) {
-      // Don't allow pushing Date.now() backwards! This should be checked before TimeoutParameters
-      // is created but just in case...
-      if (msDelay < 0) {
-        this->msDelay = 0;
-      }
-    }
-
-    bool repeat;
-    int64_t msDelay;
-
-    // This is a maybe to allow cancel to clear it and free the reference
-    // when it is no longer needed.
-    kj::Maybe<jsg::Function<void()>> function;
-  };
-
-  virtual TimeoutId setTimeout(
-      IoContext& context, TimeoutId::Generator& generator, TimeoutParameters params) = 0;
-  virtual void clearTimeout(IoContext& context, TimeoutId id) = 0;
-  virtual size_t getTimeoutCount() const = 0;
-  virtual kj::Maybe<kj::Date> getNextTimeout() const = 0;
-};
 
 // Represents one incoming request being handled by a IoContext. In non-actor scenarios,
 // there is only ever one IncomingRequest per IoContext, but with actors there could be many.

--- a/src/workerd/io/io-gate.c++
+++ b/src/workerd/io/io-gate.c++
@@ -153,8 +153,8 @@ InputGate::CriticalSection::~CriticalSection() noexcept(false) {
       // The initial wait() had better have been canceled... but we have no way to tell here.
       break;
     case RUNNING:
-      failed(JSG_KJ_EXCEPTION(FAILED, Error,
-          "A critical section within this Durable Object awaited a Promise that "
+      failed(KJ_EXCEPTION(FAILED,
+          "jsg.Error: A critical section within this Durable Object awaited a Promise that "
           "apparently will never complete. This could happen in particular if a critical section "
           "awaits a task that was initiated outside of the critical section. Since a critical "
           "section blocks all other tasks from completing, this leads to deadlock."));

--- a/src/workerd/io/io-gate.h
+++ b/src/workerd/io/io-gate.h
@@ -23,7 +23,6 @@
 #include <kj/async.h>
 #include <kj/one-of.h>
 #include <kj/list.h>
-#include <workerd/jsg/jsg.h>
 
 #include <type_traits>
 

--- a/src/workerd/io/io-own.c++
+++ b/src/workerd/io/io-own.c++
@@ -1,0 +1,97 @@
+#include "io-own.h"
+#include "io-context.h"
+
+namespace workerd {
+
+#ifdef KJ_DEBUG
+Finalizeable::Finalizeable(): context(IoContext::current()) {
+  if (context.actor != kj::none) {
+    // Disable the destructor check because finalization doesn't apply to actors.
+    finalized = true;
+  }
+}
+
+Finalizeable::~Finalizeable() noexcept(false) {
+  KJ_ASSERT(finalized || !context.isFinalized(),
+      "Finalizeable object survived request finalization without being finalized. This usually "
+      "means it was not passed to IoContext::addObject<T>() as a Finalizeable T.");
+}
+
+#endif
+
+void DeleteQueue::scheduleDeletion(OwnedObject* object) const {
+  if (IoContext::hasCurrent() && IoContext::current().deleteQueue.get() == this) {
+    // Deletion from same thread. No need to enqueue.
+    kj::AllowAsyncDestructorsScope scope;
+    OwnedObjectList::unlink(*object);
+  } else {
+    auto lock = crossThreadDeleteQueue.lockExclusive();
+    KJ_IF_SOME(state, *lock) {
+      state.queue.add(object);
+    }
+  }
+}
+
+void DeleteQueue::checkFarGet(const DeleteQueue* deleteQueue) {
+  IoContext::current().checkFarGet(deleteQueue);
+}
+
+OwnedObjectList::~OwnedObjectList() noexcept(false) {
+  while (head != kj::none) {
+    // We want to have the same order of operations as the recursive destructor here. Without this
+    // optimization, `~SpecificOwnedObject<T>` is invoked first, then `~OwnedObject()` which
+    // destructs the next node which continues the process. The key takeaway is that we destroy each
+    // node's `T` before we move onto the next node. This duplicates that behavior by unlinking
+    // forward through the list, which hopefully should keep our stack size low no matter how many
+    // `OwnedObject` instances we have.
+    unlink(*KJ_ASSERT_NONNULL(head));
+  }
+}
+
+void OwnedObjectList::unlink(OwnedObject& object) {
+  KJ_IF_SOME(next, object.next) {
+    next.get()->prev = object.prev;
+  }
+  *object.prev = kj::mv(object.next);
+}
+
+void OwnedObjectList::link(kj::Own<OwnedObject> object) {
+  KJ_IF_SOME(f, object->finalizer) {
+    if (finalizersRan) {
+      KJ_LOG(ERROR, "somehow new objects are being added after finalizers already ran",
+             kj::getStackTrace());
+      f.finalize();
+    }
+  }
+
+  object->next = kj::mv(head);
+  KJ_IF_SOME(next, object->next) {
+    next.get()->prev = &object->next;
+  }
+  object->prev = &head;
+  head = kj::mv(object);
+}
+
+kj::Vector<kj::StringPtr> OwnedObjectList::finalize() {
+  KJ_ASSERT(!finalizersRan);
+  finalizersRan = true;
+
+  kj::Vector<kj::StringPtr> warnings;
+  auto* link = &head;
+  while (*link != kj::none) {
+    auto& l = KJ_ASSERT_NONNULL(*link);
+    KJ_IF_SOME(f, l->finalizer) {
+      KJ_IF_SOME(w, f.finalize()) {
+        warnings.add(w);
+      }
+#ifdef KJ_DEBUG
+      f.finalized = true;
+#endif
+    }
+    link = &l->next;
+  }
+
+  return warnings;
+}
+
+}  // namespace workerd

--- a/src/workerd/io/io-own.h
+++ b/src/workerd/io/io-own.h
@@ -1,0 +1,309 @@
+#pragma once
+
+#include <kj/common.h>
+#include <kj/mutex.h>
+#include <kj/refcount.h>
+#include <kj/string.h>
+#include <kj/vector.h>
+
+namespace workerd {
+
+class IoContext;
+
+template <typename T> class IoOwn;
+template <typename T> class IoPtr;
+
+template <typename T>
+struct RemoveIoOwn_ { typedef T Type; static constexpr bool is = false; };
+template <typename T>
+struct RemoveIoOwn_<IoOwn<T>> { typedef T Type; static constexpr bool is = true; };
+
+template <typename T>
+constexpr bool isIoOwn() { return RemoveIoOwn_<T>::is; }
+template <typename T>
+using RemoveIoOwn = typename RemoveIoOwn_<T>::Type;
+
+// If an object passed to addObject(Own<T>) implements Finalizeable, then once it is known to
+// be the case that no code will ever run in the context of this IoContext again,
+// finalize() will be called.
+//
+// This is primarily used to proactively fail out hanging promises once we know they can never
+// be fulfilled, so that requests fail fast rather than hang forever.
+//
+// Finalizers should NOT call into JavaScript or really do much of anything except for calling
+// reject() on some Fulfiller object. It can optionally return a warning which should be
+// logged if the inspector is attached.
+class Finalizeable {
+public:
+  KJ_DISALLOW_COPY_AND_MOVE(Finalizeable);
+
+#ifdef KJ_DEBUG
+  Finalizeable();
+  ~Finalizeable() noexcept(false);
+  // In debug mode, we assert that this object was actually finalized. A Finalizeable object that
+  // doesn't get finalized typically arises when a derived class multiply-inherits from
+  // Finalizeable and some other non-Finalizeable class T, then gets passed to
+  // `IoContext::addObject()` as a T. This can be a source of baffling bugs.
+#else
+  Finalizeable() = default;
+#endif
+
+private:
+  virtual kj::Maybe<kj::StringPtr> finalize() = 0;
+  friend class IoContext;
+
+#ifdef KJ_DEBUG
+  IoContext& context;
+
+  // Set true by IoContext::runFinalizers();
+  bool finalized = false;
+#endif
+
+  friend class OwnedObjectList;
+};
+
+struct OwnedObject {
+  kj::Maybe<kj::Own<OwnedObject>> next;
+  kj::Maybe<kj::Own<OwnedObject>>* prev;
+  kj::Maybe<Finalizeable&> finalizer;
+};
+
+template <typename T>
+struct SpecificOwnedObject: public OwnedObject {
+  SpecificOwnedObject(kj::Own<T> ptr): ptr(kj::mv(ptr)) {}
+  kj::Own<T> ptr;
+};
+
+class OwnedObjectList {
+public:
+  OwnedObjectList() = default;
+  KJ_DISALLOW_COPY_AND_MOVE(OwnedObjectList);
+  ~OwnedObjectList() noexcept(false);
+
+  void link(kj::Own<OwnedObject> object);
+  static void unlink(OwnedObject& object);
+
+  // Runs the finalizer for each object in forward order and returns a vector of any warnings
+  // returned from those finalizers.
+  kj::Vector<kj::StringPtr> finalize();
+
+  bool isFinalized() {
+    return finalizersRan;
+  }
+
+private:
+  kj::Maybe<kj::Own<OwnedObject>> head;
+
+  bool finalizersRan = false;
+};
+
+// Object which receives possibly-cross-thread deletions of owned objects.
+class DeleteQueue: public kj::AtomicRefcounted {
+public:
+  DeleteQueue()
+      : crossThreadDeleteQueue(State { kj::Vector<OwnedObject*>() }) {}
+
+  void scheduleDeletion(OwnedObject* object) const;
+
+  struct State {
+    kj::Vector<OwnedObject*> queue;
+  };
+
+  // Pointers from IoOwns that were dropped in other threads, and therefore should be deleted
+  // whenever the IoContext gets around to it. The maybe is changed to kj::none when the
+  // IoContext goes away, at which point all OwnedObjects have already been deleted so
+  // cross-thread deletions can just be ignored.
+  kj::MutexGuarded<kj::Maybe<State>> crossThreadDeleteQueue;
+
+  // Implements the corresponding methods of IoContext and ActorContext.
+  template <typename T> IoOwn<T> addObject(kj::Own<T> obj, OwnedObjectList& ownedObjects);
+
+  static void checkFarGet(const DeleteQueue* deleteQueue);
+};
+
+template <typename T>
+inline IoOwn<T> DeleteQueue::addObject(
+    kj::Own<T> obj, OwnedObjectList& ownedObjects) {
+  auto& ref = *obj;
+
+  // HACK: We need an Own<OwnedObject>, but we actually need to allocate it as the subclass
+  //   SpecificOwnedObject<T>. OwnedObject is not polymorphic, which means kj::Own will refuse
+  //   to upcast kj::Own<SpecificOwnedObject<T>> to kj::Own<OwnedObject> since it can't guarantee
+  //   the disposers are compatible. However, since we're only using single inheritance here, the
+  //   disposers *are* compatible (the numeric value of pointers to SpecificOwnedObject<T> and
+  //   its parent OwnedObject are equal). So, instead of forcing OwnedObject to be polymorphic
+  //   (which would have forced a bunch of useless vtables and vtable pointers)... I'm manually
+  //   constructing the kj::Own<> using a disposer that I know is compatible.
+  // TODO(cleanup): Can KJ be made to support this use case?
+  kj::Own<OwnedObject> ownedObject(
+      new SpecificOwnedObject<T>(kj::mv(obj)),
+      kj::_::HeapDisposer<SpecificOwnedObject<T>>::instance);
+
+  if constexpr (kj::canConvert<T&, Finalizeable&>()) {
+    ownedObject->finalizer = ref;
+  }
+
+  IoOwn<T> result(kj::atomicAddRef(*this),
+      static_cast<SpecificOwnedObject<T>*>(ownedObject.get()));
+  ownedObjects.link(kj::mv(ownedObject));
+  return result;
+}
+
+// When the IoContext is destroyed, we need to null out the DeleteQueue. Complicating
+// matters a bit, we need to cancel all tasks (destroy the TaskSet) before this happens, so
+// we can't just do it in IoContext's destrucrtor. As a hack, we customize our pointer
+// to the delete queue to get the tear-down order right.
+class DeleteQueuePtr: public kj::Own<DeleteQueue> {
+public:
+  DeleteQueuePtr(kj::Own<DeleteQueue> value)
+      : kj::Own<DeleteQueue>(kj::mv(value)) {}
+  KJ_DISALLOW_COPY_AND_MOVE(DeleteQueuePtr);
+  ~DeleteQueuePtr() noexcept(false) {
+    auto ptr = get();
+    if (ptr != nullptr) {
+      *ptr->crossThreadDeleteQueue.lockExclusive() = kj::none;
+    }
+  }
+};
+
+// Owned pointer held by a V8 heap object, pointing to a KJ event loop object. Cannot be
+// dereferenced unless the isolate is executing on the appropriate event loop thread.
+template <typename T>
+class IoOwn {
+
+public:
+  IoOwn(IoOwn&& other);
+  IoOwn(decltype(nullptr)): item(nullptr) {}
+  ~IoOwn() noexcept(false);
+  KJ_DISALLOW_COPY(IoOwn);
+
+  T* operator->();
+  T& operator*() { return *operator->(); }
+  operator kj::Own<T>() &&;
+  IoOwn& operator=(IoOwn&& other);
+  IoOwn& operator=(decltype(nullptr));
+
+  // Releases this object from the IoOwn, but instead of deleting it, attaches it to the
+  // IoContext (or ActorContext) such that it won't be destroyed until that context is torn
+  // down.
+  //
+  // This may need to be used in cases where an application could directly observe the destruction
+  // of this object. If that's the case, then the object cannot be destroyed during GC, as this
+  // would let the application observe GC, which might enable side channels. So, the destructor
+  // of the owning object must manually call `deferGcToContext()` to pass all such objects away
+  // to their respective contexts.
+  //
+  // Since this is expected to be called during GC, it is safe to call from a thread other than
+  // the one that owns the IoContext.
+  void deferGcToContext() &&;
+
+private:
+  friend class IoContext;
+  friend class DeleteQueue;
+
+  kj::Own<const DeleteQueue> deleteQueue;
+  SpecificOwnedObject<T>* item;
+
+  IoOwn(kj::Own<const DeleteQueue> deleteQueue,
+        SpecificOwnedObject<T>* item)
+      : deleteQueue(kj::mv(deleteQueue)), item(item) {}
+};
+
+// Reference held by a V8 heap object, pointing to a KJ event loop object. Cannot be
+// dereferenced unless the isolate is executing on the appropriate event loop thread.
+template <typename T>
+class IoPtr {
+public:
+  IoPtr(const IoPtr& other)
+      : deleteQueue(kj::atomicAddRef(*other.deleteQueue)), ptr(other.ptr) {}
+  IoPtr(IoPtr&& other) = default;
+
+  T* operator->();
+  T& operator*() { return *operator->(); }
+  IoPtr& operator=(decltype(nullptr));
+
+private:
+  friend class IoContext;
+  friend class DeleteQueue;
+
+  kj::Own<const DeleteQueue> deleteQueue;
+  T* ptr;
+
+  IoPtr(kj::Own<const DeleteQueue> deleteQueue,
+         T* ptr)
+      : deleteQueue(kj::mv(deleteQueue)), ptr(ptr) {}
+};
+
+template <typename T>
+IoOwn<T>::IoOwn(IoOwn&& other)
+    : deleteQueue(kj::mv(other.deleteQueue)),
+      item(other.item) {
+  other.item = nullptr;
+}
+
+template <typename T>
+IoOwn<T>::~IoOwn() noexcept(false) {
+  if (item != nullptr) {
+    deleteQueue->scheduleDeletion(item);
+  }
+}
+
+template <typename T>
+IoOwn<T>& IoOwn<T>::operator=(IoOwn<T>&& other) {
+  if (item != nullptr) {
+    deleteQueue->scheduleDeletion(item);
+  }
+  deleteQueue = kj::mv(other.deleteQueue);
+  item = other.item;
+  other.item = nullptr;
+  return *this;
+}
+
+template <typename T>
+IoOwn<T>& IoOwn<T>::operator=(decltype(nullptr)) {
+  if (item != nullptr) {
+    deleteQueue->scheduleDeletion(item);
+  }
+  deleteQueue = nullptr;
+  item = nullptr;
+  return *this;
+}
+
+template <typename T>
+void IoOwn<T>::deferGcToContext() && {
+  // Turns out, if we simply *don't* enqueue the item for deletion, we get the behavior we want.
+  // So we can just null out the pointers here...
+  item = nullptr;
+  deleteQueue = nullptr;
+}
+
+template <typename T>
+IoPtr<T>& IoPtr<T>::operator=(decltype(nullptr)) {
+  deleteQueue = nullptr;
+  ptr = nullptr;
+  return *this;
+}
+
+template <typename T>
+inline T* IoOwn<T>::operator->() {
+  DeleteQueue::checkFarGet(deleteQueue);
+  return item->ptr;
+}
+
+template <typename T>
+inline IoOwn<T>::operator kj::Own<T>() && {
+  DeleteQueue::checkFarGet(deleteQueue);
+  auto result = kj::mv(item->ptr);
+  OwnedObjectList::unlink(*item);
+  item = nullptr;
+  deleteQueue = nullptr;  // not needed anymore, might as well drop the refcount
+  return result;
+}
+
+template <typename T>
+inline T* IoPtr<T>::operator->() {
+  DeleteQueue::checkFarGet(deleteQueue);
+  return ptr;
+}
+
+}  // namespace workerd

--- a/src/workerd/io/io-thread-context.c++
+++ b/src/workerd/io/io-thread-context.c++
@@ -1,0 +1,28 @@
+#include "io-thread-context.h"
+
+namespace workerd {
+
+ThreadContext::HeaderIdBundle::HeaderIdBundle(kj::HttpHeaderTable::Builder& builder)
+    : table(builder.getFutureTable()),
+      contentEncoding(builder.add("Content-Encoding")),
+      cfCacheStatus(builder.add("CF-Cache-Status")),
+      cacheControl(builder.add("Cache-Control")),
+      cfCacheNamespace(builder.add("CF-Cache-Namespace")),
+      cfKvMetadata(builder.add("CF-KV-Metadata")),
+      cfR2ErrorHeader(builder.add("CF-R2-Error")),
+      cfBlobMetadataSize(builder.add("CF-R2-Metadata-Size")),
+      cfBlobRequest(builder.add("CF-R2-Request")),
+      authorization(builder.add("Authorization")),
+      secWebSocketProtocol(builder.add("Sec-WebSocket-Protocol")) {}
+
+ThreadContext::ThreadContext(
+    kj::Timer& timer, kj::EntropySource& entropySource,
+    HeaderIdBundle headerIds, capnp::HttpOverCapnpFactory& httpOverCapnpFactory, capnp::ByteStreamFactory& byteStreamFactory, bool fiddle)
+    : timer(timer),
+      entropySource(entropySource),
+      headerIds(headerIds),
+      httpOverCapnpFactory(httpOverCapnpFactory),
+      byteStreamFactory(byteStreamFactory),
+      fiddle(fiddle) {}
+
+}  // namespace workerd

--- a/src/workerd/io/io-thread-context.h
+++ b/src/workerd/io/io-thread-context.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <kj/compat/http.h>
+#include <capnp/compat/http-over-capnp.h>
+
+namespace workerd {
+
+// Thread-level stuff needed to construct a IoContext. One of these is created for each
+// request-handling thread.
+class ThreadContext {
+public:
+  struct HeaderIdBundle {
+    HeaderIdBundle(kj::HttpHeaderTable::Builder& builder);
+
+    const kj::HttpHeaderTable& table;
+
+    const kj::HttpHeaderId contentEncoding;
+    const kj::HttpHeaderId cfCacheStatus;         // used by cache API implementation
+    const kj::HttpHeaderId cacheControl;
+    const kj::HttpHeaderId cfCacheNamespace;       // used by Cache binding implementation
+    const kj::HttpHeaderId cfKvMetadata;          // used by KV binding implementation
+    const kj::HttpHeaderId cfR2ErrorHeader;       // used by R2 binding implementation
+    const kj::HttpHeaderId cfBlobMetadataSize;    // used by R2 binding implementation
+    const kj::HttpHeaderId cfBlobRequest;         // used by R2 binding implementation
+    const kj::HttpHeaderId authorization;         // used by R2 binding implementation
+    const kj::HttpHeaderId secWebSocketProtocol;
+  };
+
+  ThreadContext(
+      kj::Timer& timer, kj::EntropySource& entropySource,
+      HeaderIdBundle headerIds, capnp::HttpOverCapnpFactory& httpOverCapnpFactory,
+          capnp::ByteStreamFactory& byteStreamFactory, bool isFiddle);
+
+  // This should only be used to costruct TimerChannel. Everything else should use TimerChannel.
+  inline kj::Timer& getUnsafeTimer() const { return timer; }
+  inline kj::EntropySource& getEntropySource() const { return entropySource; }
+  inline const kj::HttpHeaderTable& getHeaderTable() const { return headerIds.table; }
+  inline const HeaderIdBundle& getHeaderIds() const { return headerIds; }
+  inline capnp::HttpOverCapnpFactory& getHttpOverCapnpFactory() const {
+    return httpOverCapnpFactory;
+  }
+  inline capnp::ByteStreamFactory& getByteStreamFactory() const {
+    return byteStreamFactory;
+  }
+  inline bool isFiddle() const { return fiddle; }
+
+private:
+  // NOTE: This timer only updates when entering the event loop!
+  kj::Timer& timer;
+  kj::EntropySource& entropySource;
+  HeaderIdBundle headerIds;
+  capnp::HttpOverCapnpFactory& httpOverCapnpFactory;
+  capnp::ByteStreamFactory& byteStreamFactory;
+  bool fiddle;
+};
+
+}  // namespace workerd

--- a/src/workerd/io/io-timers.c++
+++ b/src/workerd/io/io-timers.c++
@@ -1,0 +1,28 @@
+#include "io-timers.h"
+
+namespace workerd {
+
+TimeoutId TimeoutId::Generator::getNext() {
+  // The maximum integer value that we can represent as a double to convey to jsg.
+  constexpr ValueType MAX_SAFE_INTEGER = (1ull << 53) - 1;
+
+  auto id = nextId++;
+  if (nextId > MAX_SAFE_INTEGER) {
+    KJ_LOG(WARNING, "Unable to set timeout because there are no more unique ids");
+    JSG_FAIL_REQUIRE(Error, "Unable to set timeout because there are no more unique ids "
+        "less than Number.MAX_SAFE_INTEGER.");
+  }
+  return TimeoutId(id);
+}
+
+TimeoutManager::TimeoutParameters::TimeoutParameters(
+    bool repeat, int64_t msDelay, jsg::Function<void()> function)
+    : repeat(repeat), msDelay(msDelay), function(kj::mv(function)) {
+  // Don't allow pushing Date.now() backwards! This should be checked before TimeoutParameters
+  // is created but just in case...
+  if (msDelay < 0) {
+    this->msDelay = 0;
+  }
+}
+
+}  // namespace workerd

--- a/src/workerd/io/io-timers.h
+++ b/src/workerd/io/io-timers.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <workerd/jsg/jsg.h>
+
+namespace workerd {
+
+class IoContext;
+
+// A TimeoutId is a positive non-zero integer value that explicitly identifies a timeout set on an
+// isolate.
+//
+// Lastly, timeout ids can experience integer roll over. It is expected that the
+// setTimeout/clearTimeout implementation will enforce id uniqueness for *active* timeouts. This
+// does not mean that an external user cannot have cached a timeout id for a long expired timeout.
+// However, clearTimeout implementations are expected to only have access to timeouts set via that
+// same implementation.
+class TimeoutId {
+public:
+  // Use a double so that we can exceed the maximum value for uint32_t.
+  using NumberType = double;
+
+  // Store as a uint64_t so that we treat this id as an integer.
+  using ValueType = uint64_t;
+
+  class Generator;
+
+  // Convert an externally provided double into a TimeoutId. If you are making a new TimeoutId,
+  // use a Generator instead.
+  inline static TimeoutId fromNumber(NumberType id) {
+    return TimeoutId(ValueType(id));
+  }
+
+  // Convert a TimeoutId to an integer-covertable double for external consumption.
+  // Note that this is expected to be less than or equal to JavaScript Number.MAX_SAFE_INTEGER
+  // (2^53 - 1). To reach greater than that value in normal operation, we'd need a Generator to
+  // live far far longer than our normal release/restart cycle, be initialized with a large
+  // starting value, or experience active concurrency _somehow_.
+  inline NumberType toNumber() const {
+    return value;
+  }
+
+  inline bool operator<(TimeoutId id) const {
+    return value < id.value;
+  }
+
+private:
+  constexpr explicit TimeoutId(ValueType value): value(value) {}
+
+  ValueType value;
+};
+
+class TimeoutId::Generator {
+public:
+  Generator() = default;
+  KJ_DISALLOW_COPY_AND_MOVE(Generator);
+
+  // Get the next TimeoutId for this generator. This function will never return a TimeoutId <= 0.
+  TimeoutId getNext();
+
+private:
+  // We always skip 0 per the spec:
+  // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers.
+  TimeoutId::ValueType nextId = 1;
+};
+
+class TimeoutManager {
+public:
+  // Upper bound on the number of timeouts a user can *ever* have active.
+  constexpr static auto MAX_TIMEOUTS = 10'000;
+
+  struct TimeoutParameters {
+    TimeoutParameters(bool repeat, int64_t msDelay, jsg::Function<void()> function);
+
+    bool repeat;
+    int64_t msDelay;
+
+    // This is a maybe to allow cancel to clear it and free the reference
+    // when it is no longer needed.
+    kj::Maybe<jsg::Function<void()>> function;
+  };
+
+  virtual TimeoutId setTimeout(
+      IoContext& context, TimeoutId::Generator& generator, TimeoutParameters params) = 0;
+  virtual void clearTimeout(IoContext& context, TimeoutId id) = 0;
+  virtual size_t getTimeoutCount() const = 0;
+  virtual kj::Maybe<kj::Date> getNextTimeout() const = 0;
+};
+
+}  // namespace workerd


### PR DESCRIPTION
Start pulling things out of io-content.h into separate headers/c++ ... generally make io-content.h smaller and more focused.