### PR TITLE
Consolidate multiple defs/impls of WeakRef

### DIFF
--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -713,7 +713,7 @@ public:
   KJ_DISALLOW_COPY_AND_MOVE(WritableStreamJsController);
 
   ~WritableStreamJsController() noexcept(false) override {
-    weakRef->reset();
+    weakRef->invalidate();
   }
 
   jsg::Promise<void> abort(jsg::Lock& js,
@@ -1542,9 +1542,10 @@ kj::Maybe<T&> tryGetAs(auto& ref) {
 
 class AllReaderBase {
 public:
-  AllReaderBase() : ref(kj::refcounted<WeakRef<AllReaderBase>>(*this)) {}
+  AllReaderBase()
+      : ref(kj::refcounted<WeakRef<AllReaderBase>>(kj::Badge<AllReaderBase>(), *this)) {}
   virtual ~AllReaderBase() noexcept(false) {
-    ref->reset();
+    ref->invalidate();
   }
   KJ_DISALLOW_COPY_AND_MOVE(AllReaderBase);
 
@@ -1892,10 +1893,11 @@ ReadableStreamDefaultController::ReadableStreamDefaultController(
     StreamQueuingStrategy queuingStrategy)
     : ioContext(tryGetIoContext()),
       impl(kj::mv(underlyingSource), kj::mv(queuingStrategy)),
-      weakRef(kj::refcounted<WeakRef<ReadableStreamDefaultController>>(*this)) {}
+      weakRef(kj::refcounted<WeakRef<ReadableStreamDefaultController>>(
+          kj::Badge<ReadableStreamDefaultController>(), *this)) {}
 
 ReadableStreamDefaultController::~ReadableStreamDefaultController() noexcept(false) {
-  weakRef->reset();
+  weakRef->invalidate();
 }
 
 kj::Own<WeakRef<ReadableStreamDefaultController>> ReadableStreamDefaultController::getWeakRef() {
@@ -3372,15 +3374,18 @@ jsg::Promise<void> WritableStreamDefaultController::write(
 // ======================================================================================
 WritableStreamJsController::WritableStreamJsController()
     : ioContext(tryGetIoContext()),
-      weakRef(kj::refcounted<WeakRef<WritableStreamJsController>>(*this)) {}
+      weakRef(kj::refcounted<WeakRef<WritableStreamJsController>>(
+          kj::Badge<WritableStreamJsController>(), *this)) {}
 
 WritableStreamJsController::WritableStreamJsController(StreamStates::Closed closed)
     : ioContext(tryGetIoContext()), state(closed),
-      weakRef(kj::refcounted<WeakRef<WritableStreamJsController>>(*this)) {}
+      weakRef(kj::refcounted<WeakRef<WritableStreamJsController>>(
+          kj::Badge<WritableStreamJsController>(), *this)) {}
 
 WritableStreamJsController::WritableStreamJsController(StreamStates::Errored errored)
     : ioContext(tryGetIoContext()), state(kj::mv(errored)),
-      weakRef(kj::refcounted<WeakRef<WritableStreamJsController>>(*this)) {}
+      weakRef(kj::refcounted<WeakRef<WritableStreamJsController>>(
+          kj::Badge<WritableStreamJsController>(), *this)) {}
 
 jsg::Promise<void> WritableStreamJsController::abort(
     jsg::Lock& js,

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -7,6 +7,7 @@
 #include "common.h"
 #include "queue.h"
 #include <workerd/jsg/function.h>
+#include <workerd/util/weak-refs.h>
 
 namespace workerd::api {
 
@@ -122,20 +123,6 @@ namespace workerd::api {
 
 class ReadableStreamJsController;
 class WritableStreamJsController;
-
-template <typename T>
-class WeakRef: public kj::Refcounted {
-  // Used to allow holding safe weak pointers to type T
-public:
-  WeakRef(T& ref) : ref(ref) {}
-  KJ_DISALLOW_COPY_AND_MOVE(WeakRef);
-  kj::Maybe<T&> tryGet() { return ref; }
-  kj::Own<WeakRef> addRef() { return kj::addRef(*this); }
-private:
-  void reset() { ref = nullptr; }
-  kj::Maybe<T&> ref;
-  friend T;
-};
 
 // =======================================================================================
 // The ReadableImpl provides implementation that is common to both the

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -299,7 +299,7 @@ IoContext::IncomingRequest::~IoContext_IncomingRequest() noexcept(false) {
 
 IoContext::~IoContext() noexcept(false) {
   // Kill the sentinel so that no weak references can refer to this IoContext anymore.
-  selfRef->kill();
+  selfRef->invalidate();
 }
 
 InputGate::Lock IoContext::getInputLock() {
@@ -738,7 +738,7 @@ void IoContext::TimeoutManagerImpl::setTimeoutImpl(IoContext& context, Iterator 
     // If the promise is being destroyed due to IoContext teardown then IoChannelFactory may
     // no longer be available, but we can just skip starting a new timer in that case as it'd be
     // canceled anyway.
-    if (context.selfRef->maybeContext != kj::none) {
+    if (context.selfRef->isValid()) {
       bool isNext = timeoutTimes.begin()->key == timeoutTimesKey;
       timeoutTimes.erase(timeoutTimesKey);
       if (isNext) resetTimerTask(context.getIoChannelFactory().getTimer());


### PR DESCRIPTION
We had multiple WeakRef impls that were nearly identical. Consolidate those to reduce duplication.