### PR TITLE
Address long-standing todo to rename ApiIsolate

### DIFF
--- a/src/workerd/api/crypto.c++
+++ b/src/workerd/api/crypto.c++
@@ -124,9 +124,9 @@ static kj::Maybe<const CryptoAlgorithm&> lookupAlgorithm(kj::StringPtr name) {
 
   auto iter = ALGORITHMS.find(CryptoAlgorithm {name});
   if (iter == ALGORITHMS.end()) {
-    // No such built-in algorithm, so fall back to checking if the ApiIsolate has a custom
+    // No such built-in algorithm, so fall back to checking if the Api has a custom
     // algorithm registered.
-    return Worker::ApiIsolate::current().getCryptoAlgorithm(name);
+    return Worker::Api::current().getCryptoAlgorithm(name);
   } else {
     return *iter;
   }

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -504,7 +504,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEventImpl::run(
       (Worker::Lock& lock) mutable {
     jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
 
-    auto& typeHandler = lock.getWorker().getIsolate().getApiIsolate().getQueueTypeHandler(lock);
+    auto& typeHandler = lock.getWorker().getIsolate().getApi().getQueueTypeHandler(lock);
     queueEvent->event = startQueueEvent(lock.getGlobalScope(), kj::mv(params), context.addObject(result), lock,
         lock.getExportedHandler(entrypointName, context.getActor()), typeHandler);
   }));

--- a/src/workerd/io/features.c++
+++ b/src/workerd/io/features.c++
@@ -10,13 +10,13 @@ namespace workerd {
 CompatibilityFlags::Reader FeatureFlags::get(jsg::Lock&) {
   // Note that the jsg::Lock& argument here is not actually used. We require
   // that a jsg::Lock reference is passed in as proof that current() is called
-  // from within a valid isolate lock so that the Worker::ApiIsolate::current()
+  // from within a valid isolate lock so that the Worker::Api::current()
   // call below will work as expected.
-  // TODO(later): Use of Worker::ApiIsolate::current() here implies that there
+  // TODO(later): Use of Worker::Api::current() here implies that there
   // is only one set of compatibility flags relevant at a time within each thread
   // context. For now that holds true. Later it is possible that may not be the
   // case which will require us to further adapt this model.
-  return Worker::ApiIsolate::current().getFeatureFlags();
+  return Worker::Api::current().getFeatureFlags();
 }
 
 }  // namespace workerd

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -511,7 +511,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
 namespace {
 void requestGc(const Worker& worker) {
   jsg::V8StackScope stackScope;
-  auto lock = worker.getIsolate().getApiIsolate().lock(stackScope);
+  auto lock = worker.getIsolate().getApi().lock(stackScope);
   lock->requestGcForTesting();
 }
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1474,7 +1474,7 @@ Worker::Worker(kj::Own<const Script> scriptParam,
           lock.v8Set(bindingsScope, global.name, global.value);
         }
 
-        compileBindings(lock, script->isolate.getApi(), bindingsScope);
+        compileBindings(lock, script->isolate->getApi(), bindingsScope);
 
         // Execute script.
         currentSpan = maybeMakeSpan("lw:top_level_execution"_kjc);

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -73,7 +73,7 @@ public:
   class Script;
   class Isolate;
   class Api;
-  using ApiIsolate = Api;
+  using ApiIsolate [[deprecated("Use Workerd::Api")]] = Api;
 
   class ValidationErrorReporter {
   public:

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1760,7 +1760,7 @@ public:
             });
           };
 
-          auto makeStorage = [](jsg::Lock& js, const Worker::ApiIsolate& apiIsolate,
+          auto makeStorage = [](jsg::Lock& js, const Worker::Api& api,
                                 ActorCacheInterface& actorCache)
                             -> jsg::Ref<api::DurableObjectStorage> {
             return jsg::alloc<api::DurableObjectStorage>(
@@ -2515,8 +2515,8 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
   auto worker = kj::atomicRefcounted<Worker>(
       kj::mv(script),
       kj::atomicRefcounted<WorkerObserver>(),
-      [&](jsg::Lock& lock, const Worker::ApiIsolate& apiIsolate, v8::Local<v8::Object> target) {
-        return kj::downcast<const WorkerdApiIsolate>(apiIsolate).compileGlobals(
+      [&](jsg::Lock& lock, const Worker::Api& api, v8::Local<v8::Object> target) {
+        return kj::downcast<const WorkerdApiIsolate>(api).compileGlobals(
             lock, globals, target, 1);
       },
       IsolateObserver::StartType::COLD,

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -10,14 +10,16 @@
 
 namespace workerd::server {
 
-// An ApiIsolate implementation with support for all the APIs supported by the OSS runtime.
-class WorkerdApiIsolate final: public Worker::ApiIsolate {
+// A Worker::Api implementation with support for all the APIs supported by the OSS runtime.
+class WorkerdApi final: public Worker::Api {
 public:
-  WorkerdApiIsolate(jsg::V8System& v8System,
+  WorkerdApi(jsg::V8System& v8System,
       CompatibilityFlags::Reader features,
       IsolateLimitEnforcer& limitEnforcer,
       kj::Own<jsg::IsolateObserver> observer);
-  ~WorkerdApiIsolate() noexcept(false);
+  ~WorkerdApi() noexcept(false);
+
+  static const WorkerdApi& from(const Worker::Api&);
 
   kj::Own<jsg::Lock> lock(jsg::V8StackScope& stackScope) const override;
   CompatibilityFlags::Reader getFeatureFlags() const override;

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -259,7 +259,7 @@ TestFixture::TestFixture(SetupParams&& params)
     threadContext(*timer, *entropySource, threadContextHeaderBundle, httpOverCapnpFactory, byteStreamFactory, false),
     isolateLimitEnforcer(kj::heap<MockIsolateLimitEnforcer>()),
     errorReporter(kj::heap<MockErrorReporter>()),
-    api(kj::heap<server::WorkerdApiIsolate>(
+    api(kj::heap<server::WorkerdApi>(
       testV8System,
       params.featureFlags.orDefault(CompatibilityFlags::Reader()),
       *isolateLimitEnforcer,
@@ -273,7 +273,7 @@ TestFixture::TestFixture(SetupParams&& params)
     workerScript(kj::atomicRefcounted<Worker::Script>(
       kj::atomicAddRef(*workerIsolate),
       scriptId,
-      server::WorkerdApiIsolate::extractSource(mainModuleName, config, *errorReporter,
+      server::WorkerdApi::extractSource(mainModuleName, config, *errorReporter,
           capnp::List<server::config::Extension>::Reader{}),
       IsolateObserver::StartType::COLD, false, nullptr)),
     worker(kj::atomicRefcounted<Worker>(

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -98,7 +98,7 @@ private:
   ThreadContext threadContext;
   kj::Own<IsolateLimitEnforcer> isolateLimitEnforcer;
   kj::Own<Worker::ValidationErrorReporter> errorReporter;
-  kj::Own<Worker::ApiIsolate> apiIsolate;
+  kj::Own<Worker::Api> api;
   kj::Own<Worker::Isolate> workerIsolate;
   kj::Own<Worker::Script> workerScript;
   kj::Own<Worker> worker;


### PR DESCRIPTION
Rename `Worker::ApiIsolate` to just `Worker::Api`... aliasing the old name along with a `[[deprecated]]` attribute until the internal repo can be updated to use the new name.

Renaming `ApiIsolate` has been a long standing todo since the `Isolate` name is rather overloaded.