### PR TITLE
Move use of ASAN_OPTIONS to code

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -101,7 +101,6 @@ build:sanitizer-common --copt="-fno-omit-frame-pointer" --copt="-mno-omit-leaf-f
 # address sanitizer (https://github.com/google/sanitizers/wiki/AddressSanitizer)
 build:asan --config=sanitizer-common
 build:asan --copt="-fsanitize=address" --linkopt="-fsanitize=address"
-build:asan --test_env=ASAN_OPTIONS=abort_on_error=true
 
 #
 # Linux and macOS

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -22,6 +22,10 @@
 #include <workerd/io/supported-compatibility-date.capnp.h>
 #include <workerd/util/autogate.h>
 
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+#include <workerd/util/asan-options.h>
+#endif
+
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
 #include <workerd/api/gpu/gpu.h>
 #endif
@@ -1307,6 +1311,12 @@ private:
 };
 
 }  // namespace workerd::server
+
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+// Sets up the ASAN Runtime
+SANITIZER_HOOK_ATTRIBUTE const char* __asan_default_options() { return ASAN_DEFAULT_OPTIONS }
+#endif
+
 
 int main(int argc, char* argv[]) {
   ::kj::TopLevelProcessContext context(argv[0]);

--- a/src/workerd/util/asan-options.h
+++ b/src/workerd/util/asan-options.h
@@ -1,0 +1,15 @@
+namespace edgeworker {
+
+constexpr const char* ASAN_DEFAULT_OPTIONS =
+    "abort_on_error=true detect_leaks=false allow_user_poisoning=false";
+}  // namespace edgeworker
+
+#define SANITIZER_HOOK_ATTRIBUTE                                           \
+  extern "C"                                                               \
+  __attribute__((no_sanitize("address", "memory", "thread", "undefined"))) \
+  __attribute__((visibility("default")))                                   \
+  __attribute__((retain, used))
+
+// SANITIZER_HOOK_ATTRIBUTE instead of just `extern "C"` solely to make the
+// symbol externally visible, and to prevent the linker/compiler from optimizing out any sanitizer
+// hooks made.


### PR DESCRIPTION
Configuration of the ASAN runtime is now done in workerd.c++