### PR TITLE
[Vectorize] Update types to allow filtering metadata for equality

### DIFF
--- a/src/cloudflare/internal/test/vectorize/vectorize-api-test.js
+++ b/src/cloudflare/internal/test/vectorize/vectorize-api-test.js
@@ -83,6 +83,28 @@ export const test_vector_search_vector_query = {
       };
       assert.deepStrictEqual(results, expected);
     }
+
+    {
+      // with returnValues = unset (false), returnMetadata = unset (false), filter = "Peter Piper picked a peck of pickled peppers"
+      const results = await IDX.query(new Float32Array(new Array(5).fill(0)), {
+        topK: 1,
+        filter: {
+          text: { $eq: "Peter Piper picked a peck of pickled peppers" },
+        },
+      });
+      assert.equal(true, results.count > 0);
+      /** @type {VectorizeMatches}  */
+      const expected = {
+        matches: [
+          {
+            id: "a44706aa-a366-48bc-8cc1-3feffd87d548",
+            score: 0.68913,
+          },
+        ],
+        count: 1,
+      };
+      assert.deepStrictEqual(results, expected);
+    }
   },
 };
 

--- a/src/cloudflare/internal/test/vectorize/vectorize-mock.js
+++ b/src/cloudflare/internal/test/vectorize/vectorize-mock.js
@@ -104,7 +104,17 @@ export default {
           throw Error(
             "expected to get `queryMetadataOptional` compat flag with a value of true"
           );
-        const returnSet = exampleVectorMatches;
+        let returnSet = structuredClone(exampleVectorMatches);
+        if (
+          body?.filter?.["text"] &&
+          typeof body?.filter?.["text"] === "object" &&
+          body?.filter?.["text"]?.["$eq"] !== undefined
+        ) {
+          const criteria = body?.filter?.["text"]?.["$eq"];
+          returnSet = returnSet.filter(
+            (m) => m.metadata?.["text"] === criteria
+          );
+        }
         if (!body?.returnValues)
           returnSet.forEach((v) => {
             delete v.values;

--- a/src/cloudflare/internal/vectorize.d.ts
+++ b/src/cloudflare/internal/vectorize.d.ts
@@ -11,14 +11,15 @@
  ****************************** /
 
 /**
+ * Data types supported for holding vector metadata.
+ */
+type VectorizeVectorMetadataValue = string | number | boolean | string[];
+/**
  * Additional information to associate with a vector.
  */
 type VectorizeVectorMetadata =
-  | string
-  | number
-  | boolean
-  | string[]
-  | Record<string, string | number | boolean | string[]>;
+  | VectorizeVectorMetadataValue
+  | Record<string, VectorizeVectorMetadataValue>;
 
 type VectorFloatArray = Float32Array | Float64Array;
 
@@ -26,6 +27,28 @@ interface VectorizeError {
   code?: number;
   error: string;
 }
+
+/**
+ * Comparison logic/operation to use for metadata filtering.
+ *
+ * This list is expected to grow as support for more operations are released.
+ */
+type VectorizeVectorMetadataFilterOp = "$eq" | "$ne";
+
+/**
+ * Filter criteria for vector metadata used to limit the retrieved query result set.
+ */
+type VectorizeVectorMetadataFilter = {
+  [field: string]:
+    | Exclude<VectorizeVectorMetadataValue, string[]>
+    | null
+    | {
+        [Op in VectorizeVectorMetadataFilterOp]?: Exclude<
+          VectorizeVectorMetadataValue,
+          string[]
+        > | null;
+      };
+};
 
 /**
  * Supported distance metrics for an index.
@@ -38,6 +61,7 @@ interface VectorizeQueryOptions {
   namespace?: string;
   returnValues?: boolean;
   returnMetadata?: boolean;
+  filter?: VectorizeVectorMetadataFilter;
 }
 
 /**

--- a/types/defines/vectorize.d.ts
+++ b/types/defines/vectorize.d.ts
@@ -3,14 +3,15 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 /**
+ * Data types supported for holding vector metadata.
+ */
+type VectorizeVectorMetadataValue = string | number | boolean | string[];
+/**
  * Additional information to associate with a vector.
  */
 type VectorizeVectorMetadata =
-  | string
-  | number
-  | boolean
-  | string[]
-  | Record<string, string | number | boolean | string[]>;
+  | VectorizeVectorMetadataValue
+  | Record<string, VectorizeVectorMetadataValue>;
 
 type VectorFloatArray = Float32Array | Float64Array;
 
@@ -18,6 +19,28 @@ interface VectorizeError {
   code?: number;
   error: string;
 }
+
+/**
+ * Comparison logic/operation to use for metadata filtering.
+ *
+ * This list is expected to grow as support for more operations are released.
+ */
+type VectorizeVectorMetadataFilterOp = "$eq" | "$ne";
+
+/**
+ * Filter criteria for vector metadata used to limit the retrieved query result set.
+ */
+type VectorizeVectorMetadataFilter = {
+  [field: string]:
+    | Exclude<VectorizeVectorMetadataValue, string[]>
+    | null
+    | {
+        [Op in VectorizeVectorMetadataFilterOp]?: Exclude<
+          VectorizeVectorMetadataValue,
+          string[]
+        > | null;
+      };
+};
 
 /**
  * Supported distance metrics for an index.
@@ -30,6 +53,7 @@ interface VectorizeQueryOptions {
   namespace?: string;
   returnValues?: boolean;
   returnMetadata?: boolean;
+  filter?: VectorizeVectorMetadataFilter;
 }
 
 /**


### PR DESCRIPTION
## overview.
We're adding filtering support for Vectorize metadata when querying. For now, this is limited to basic equality checks, though we plan to expand on this work in the near future to allow for more operations.

## what.
This primarily just updates the types to account for the new option - we were already sending the full option object to the Vectorize binding so no actual logic changes to the binding are necessary.