### PR TITLE
Introduce configurable pbkdf2 iteration limit

### DIFF
--- a/src/workerd/api/crypto-impl-pbkdf2.c++
+++ b/src/workerd/api/crypto-impl-pbkdf2.c++
@@ -38,12 +38,12 @@ private:
         "PBKDF2 requires a positive iteration count (requested ", iterations, ").");
 
     // Note: The user could DoS us by selecting a very high iteration count. Our dead man's switch
-    //   would kick in, resulting in a process restart. We guard against this by limiting the maximum
-    //   iteration count a user can select -- this is an intentional non-conformity. Another approach
-    //   might be to fork OpenSSL's PKCS5_PBKDF2_HMAC() function and insert a check for
-    //   v8::Isolate::IsExecutionTerminating() in the loop, but for now a hard cap seems wisest.
-    JSG_REQUIRE(iterations <= 100000, DOMNotSupportedError,
-        "PBKDF2 iteration counts above 100000 are not supported (requested ", iterations, ").");
+    // would kick in, resulting in a process restart. We guard against this by limiting the
+    // maximum iteration count a user can select -- this is an intentional non-conformity.
+    // Another approach might be to fork OpenSSL's PKCS5_PBKDF2_HMAC() function and insert a
+    // check for v8::Isolate::IsExecutionTerminating() in the loop, but for now a hard cap seems
+    // wisest.
+    checkPbkdfLimits(js, iterations);
 
     auto output = kj::heapArray<kj::byte>(length / 8);
     OSSLCALL(PKCS5_PBKDF2_HMAC(keyData.asPtr().asChars().begin(), keyData.size(),

--- a/src/workerd/api/crypto-impl.h
+++ b/src/workerd/api/crypto-impl.h
@@ -339,6 +339,11 @@ private:
   kj::Array<kj::byte> inner;
 };
 
+// Check that the requested number of iterations for a key-derivation function
+// is acceptable. If the requested iterations is not acceptable, a JS error will
+// be thrown. Otherwise the method will return normally.
+void checkPbkdfLimits(jsg::Lock& js, size_t iterations);
+
 }  // namespace workerd::api
 
 KJ_DECLARE_NON_POLYMORPHIC(DH);

--- a/src/workerd/api/node/crypto.h
+++ b/src/workerd/api/node/crypto.h
@@ -110,8 +110,12 @@ public:
                               kj::Array<kj::byte> info, uint32_t length);
 
   // Pbkdf2
-  kj::Array<kj::byte> getPbkdf(kj::Array<kj::byte> password, kj::Array<kj::byte> salt,
-                               uint32_t num_iterations, uint32_t keylen, kj::String name);
+  kj::Array<kj::byte> getPbkdf(jsg::Lock& js,
+                               kj::Array<kj::byte> password,
+                               kj::Array<kj::byte> salt,
+                               uint32_t num_iterations,
+                               uint32_t keylen,
+                               kj::String name);
 
   // Keys
   struct KeyExportOptions {

--- a/src/workerd/api/node/crypto_pbkdf2.c++
+++ b/src/workerd/api/node/crypto_pbkdf2.c++
@@ -10,16 +10,19 @@
 
 namespace workerd::api::node {
 
-kj::Array<kj::byte> CryptoImpl::getPbkdf(kj::Array<kj::byte> password,
-kj::Array<kj::byte> salt, uint32_t num_iterations, uint32_t keylen, kj::String name) {
+kj::Array<kj::byte> CryptoImpl::getPbkdf(
+    jsg::Lock& js,
+    kj::Array<kj::byte> password,
+    kj::Array<kj::byte> salt,
+    uint32_t num_iterations,
+    uint32_t keylen,
+    kj::String name) {
   // Should not be needed based on current memory limits, still good to have
   JSG_REQUIRE(password.size() <= INT32_MAX, RangeError, "Pbkdf2 failed: password is too large");
   JSG_REQUIRE(salt.size() <= INT32_MAX, RangeError, "Pbkdf2 failed: salt is too large");
   // Note: The user could DoS us by selecting a very high iteration count. As with the Web Crypto
   // API, intentionally limit the maximum iteration count.
-  JSG_REQUIRE(num_iterations <= 100000, DOMNotSupportedError,
-              "Pbkdf2 failed: iteration counts above 100000 are not supported (requested ",
-              num_iterations, ").");
+  checkPbkdfLimits(js, num_iterations);
 
   const EVP_MD* digest = EVP_get_digestbyname(name.begin());
   JSG_REQUIRE(digest != nullptr, TypeError, "Invalid Pbkdf2 digest: ", name,

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -106,6 +106,12 @@ wd_cc_library(
 )
 
 wd_cc_library(
+    name = "limit-enforcer",
+    hdrs = ["limit-enforcer.h"],
+    visibility = ["//visibility:public"]
+)
+
+wd_cc_library(
     name = "worker-interface",
     srcs = ["worker-interface.c++"],
     hdrs = ["worker-interface.h"],

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -643,7 +643,8 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
 void requestGc(const Worker& worker) {
   TRACE_EVENT("workerd", "Debug: requestGc()");
   jsg::V8StackScope stackScope;
-  auto lock = worker.getIsolate().getApi().lock(stackScope);
+  auto& isolate = worker.getIsolate();
+  auto lock = isolate.getApi().lock(stackScope);
   lock->requestGcForTesting();
 }
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -264,6 +264,9 @@ public:
   ~Isolate() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(Isolate);
 
+  // Get the current Worker::Isolate from the current jsg::Lock
+  static const Isolate& from(jsg::Lock& js);
+
   inline const IsolateObserver& getMetrics() const { return *metrics; }
 
   inline kj::StringPtr getId() const { return id; }

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2524,12 +2524,18 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
     void completedRequest(kj::StringPtr id) const override {}
     bool exitJs(jsg::Lock& lock) const override { return false; }
     void reportMetrics(IsolateObserver& isolateMetrics) const override {}
+    kj::Maybe<size_t> checkPbkdfIterations(jsg::Lock& lock, size_t iterations) const override {
+      // No limit on the number of iterations in workerd
+      return kj::none;
+    }
   };
 
   auto observer = kj::atomicRefcounted<IsolateObserver>();
   auto limitEnforcer = kj::heap<NullIsolateLimitEnforcer>();
   auto api = kj::heap<WorkerdApi>(globalContext->v8System,
-      featureFlags.asReader(), *limitEnforcer, kj::atomicAddRef(*observer));
+                                  featureFlags.asReader(),
+                                  *limitEnforcer,
+                                  kj::atomicAddRef(*observer));
   auto inspectorPolicy = Worker::Isolate::InspectorPolicy::DISALLOW;
   if (inspectorOverride != kj::none) {
     // For workerd, if the inspector is enabled, it is always fully trusted.

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -170,7 +170,9 @@ struct MockIsolateLimitEnforcer final: public IsolateLimitEnforcer {
     void completedRequest(kj::StringPtr id) const override {}
     bool exitJs(jsg::Lock& lock) const override { return false; }
     void reportMetrics(IsolateObserver& isolateMetrics) const override {}
-
+    kj::Maybe<size_t> checkPbkdfIterations(jsg::Lock& lock, size_t iterations) const override {
+      return kj::none;
+    }
 };
 
 struct MockErrorReporter final: public Worker::ValidationErrorReporter {


### PR DESCRIPTION
Introduces the ability for workerd embedders to configure the max iteration limit for KDFs. Removes the limit for workerd by default. Keeps the current limit of 100,000 when not configured.

Refs: https://github.com/cloudflare/workerd/issues/1346