### PR TITLE
Replace scriptVersionId with scriptVersion object in worker trace events

### DIFF
--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -45,6 +45,16 @@ private:
   }
 };
 
+struct ScriptVersion {
+  explicit ScriptVersion(workerd::ScriptVersion::Reader version);
+
+  jsg::Optional<kj::String> id;
+  jsg::Optional<kj::String> tag;
+  jsg::Optional<kj::String> message;
+
+  JSG_STRUCT(id, tag, message);
+};
+
 class TraceItem final: public jsg::Object {
 public:
   class FetchEventInfo;
@@ -71,11 +81,7 @@ public:
   kj::ArrayPtr<jsg::Ref<TraceException>> getExceptions();
   kj::ArrayPtr<jsg::Ref<TraceDiagnosticChannelEvent>> getDiagnosticChannelEvents();
   kj::Maybe<kj::StringPtr> getScriptName();
-  // TODO(someday): we expose this as jsg::Optional for now, since that ensures that the property will
-  // not show up when calling JSON.stringify() on the object if it has not been explicitly set.
-  // At some point, we may want to align the behaviour with getScriptName() which shows up as
-  // `null` when not explicitly set.
-  jsg::Optional<kj::StringPtr> getScriptVersionId();
+  jsg::Optional<ScriptVersion> getScriptVersion();
   jsg::Optional<kj::StringPtr> getDispatchNamespace();
   jsg::Optional<kj::Array<kj::StringPtr>> getScriptTags();
   kj::StringPtr getOutcome();
@@ -90,7 +96,7 @@ public:
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(exceptions, getExceptions);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(diagnosticsChannelEvents, getDiagnosticChannelEvents);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptName, getScriptName);
-    JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptVersionId, getScriptVersionId);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptVersion, getScriptVersion);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(dispatchNamespace, getDispatchNamespace);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptTags, getScriptTags);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(outcome, getOutcome);
@@ -103,7 +109,7 @@ private:
   kj::Array<jsg::Ref<TraceException>> exceptions;
   kj::Array<jsg::Ref<TraceDiagnosticChannelEvent>> diagnosticChannelEvents;
   kj::Maybe<kj::String> scriptName;
-  jsg::Optional<kj::String> scriptVersionId;
+  kj::Maybe<kj::Own<workerd::ScriptVersion::Reader>> scriptVersion;
   kj::Maybe<kj::String> dispatchNamespace;
   jsg::Optional<kj::Array<kj::String>> scriptTags;
   kj::String outcome;
@@ -433,6 +439,7 @@ private:
 };
 
 #define EW_TRACE_ISOLATE_TYPES                \
+  api::ScriptVersion,                         \
   api::TailEvent,                             \
   api::TraceItem,                             \
   api::TraceItem::AlarmEventInfo,             \

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -141,6 +141,7 @@ wd_cc_capnp_library(
     visibility = ["//visibility:public"],
     deps = [
         ":outcome_capnp",
+        ":script_version_capnp",
         ":trimmed-supported-compatibility-date",
         "@capnp-cpp//src/capnp/compat:http-over-capnp_capnp",
     ],
@@ -149,6 +150,12 @@ wd_cc_capnp_library(
 wd_cc_capnp_library(
     name = "outcome_capnp",
     srcs = ["outcome.capnp"],
+    visibility = ["//visibility:public"],
+)
+
+wd_cc_capnp_library(
+    name = "script_version_capnp",
+    srcs = ["script-version.capnp"],
     visibility = ["//visibility:public"],
 )
 

--- a/src/workerd/io/script-version.capnp
+++ b/src/workerd/io/script-version.capnp
@@ -1,0 +1,17 @@
+# Copyright (c) 2023 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+@0xd3b6bb739ff1b77a;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("workerd");
+
+struct ScriptVersion {
+  id @0 :Text;
+  # An ID that should be used to uniquely identify this version.
+  tag @1 :Text;
+  # An optional tag to associate with this version.
+  message @2 :Text;
+  # An optional message that can be used to describe this version.
+}

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -50,8 +50,8 @@ enum class PipelineLogLevel {
 class Trace final : public kj::Refcounted {
 public:
   explicit Trace(kj::Maybe<kj::String> stableId, kj::Maybe<kj::String> scriptName,
-      kj::Maybe<kj::String> scriptVersionId, kj::Maybe<kj::String> dispatchNamespace,
-      kj::Array<kj::String> scriptTags);
+      kj::Maybe<kj::Own<ScriptVersion::Reader>> scriptVersion,
+      kj::Maybe<kj::String> dispatchNamespace, kj::Array<kj::String> scriptTags);
   Trace(rpc::Trace::Reader reader);
   ~Trace() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(Trace);
@@ -233,7 +233,7 @@ public:
   // trace, if any.
 
   kj::Maybe<kj::String> scriptName;
-  kj::Maybe<kj::String> scriptVersionId;
+  kj::Maybe<kj::Own<ScriptVersion::Reader>> scriptVersion;
   kj::Maybe<kj::String> dispatchNamespace;
   kj::Array<kj::String> scriptTags;
 
@@ -295,7 +295,7 @@ public:
   kj::Own<WorkerTracer> makeWorkerTracer(PipelineLogLevel pipelineLogLevel,
                                          kj::Maybe<kj::String> stableId,
                                          kj::Maybe<kj::String> scriptName,
-                                         kj::Maybe<kj::String> scriptVersionId,
+                                         kj::Maybe<kj::Own<ScriptVersion::Reader>> scriptVersion,
                                          kj::Maybe<kj::String> dispatchNamespace,
                                          kj::Array<kj::String> scriptTags);
   // Makes a tracer for a worker stage.

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -12,6 +12,7 @@ $Cxx.namespace("workerd::rpc");
 using import "/capnp/compat/http-over-capnp.capnp".HttpMethod;
 using import "/capnp/compat/http-over-capnp.capnp".HttpService;
 using import "/workerd/io/outcome.capnp".EventOutcome;
+using import "/workerd/io/script-version.capnp".ScriptVersion;
 
 struct Trace @0x8e8d911203762d34 {
   logs @0 :List(Log);
@@ -39,7 +40,7 @@ struct Trace @0x8e8d911203762d34 {
 
   outcome @2 :EventOutcome;
   scriptName @4 :Text;
-  scriptVersionId @19 :Text;
+  scriptVersion @19 :ScriptVersion;
 
   eventTimestampNs @5 :Int64;
 


### PR DESCRIPTION
Follow up to https://github.com/cloudflare/workerd/pull/1445.

We have since decided that we want to expose additional fields (provisionally `tag` and `message`) associated with the script version. As such, we replace the string `scriptVersionId` field with a `scriptVersion` object in the JS API.

The API is not used yet so we don't need to worry about backwards compatibility here.