### PR TITLE
2023-12-06 Update Rust crates, brotli

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,11 +32,11 @@ http_archive(
 
 http_archive(
     name = "ssl",
-    sha256 = "81bd4b20f53b0aa4bccc3f8bc7c5eda18550a91697ba956668dbeba0e3d0965d",
-    strip_prefix = "google-boringssl-f7cf966",
+    sha256 = "57261442e663ad0a0dc5c4eae59322440bfce61f1edc4fe4338179a6abc14034",
+    strip_prefix = "google-boringssl-8ae84b5",
     type = "tgz",
     # from master-with-bazel branch
-    urls = ["https://github.com/google/boringssl/tarball/f7cf966f3ddc6923104f6a354bf0ba5c618f3320"],
+    urls = ["https://github.com/google/boringssl/tarball/8ae84b558b3d3af50a323c7e3800998764e77375"],
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,14 +70,12 @@ load("@com_google_benchmark//:bazel/benchmark_deps.bzl", "benchmark_deps")
 
 benchmark_deps()
 
-# Using latest brotli commit due to macOS and clang-cl compile issues with v1.0.9, switch to a
-# release version later.
 http_archive(
     name = "brotli",
-    sha256 = "9795b1b2afcc62c254012b1584e849e0c628ceb306756efee8d4539b4c583c09",
-    strip_prefix = "google-brotli-ec107cf",
+    sha256 = "e720a6ca29428b803f4ad165371771f5398faba397edf6778837a18599ea13ff",
+    strip_prefix = "brotli-1.1.0",
     type = "tgz",
-    urls = ["https://github.com/google/brotli/tarball/ec107cf015139c791f79afac0f96c3a2c45e157f"],
+    urls = ["https://github.com/google/brotli/archive/refs/tags/v1.1.0.tar.gz"],
 )
 
 http_archive(
@@ -177,39 +175,66 @@ http_archive(
 # the build process. To update the dependency, update the reference commit in
 # rust-deps/BUILD.bazel and run `bazel run //rust-deps:crates_vendor -- --repin`
 
+# Based on https://github.com/bazelbuild/bazel/blob/master/third_party/zlib/BUILD.
+_zlib_build = """
+cc_library(
+    name = "zlib",
+    srcs = glob(["*.c"]),
+    hdrs = glob(["*.h"]),
+    includes = ["."],
+    # Workaround for zlib warnings and mac compilation. Some issues were resolved in v1.3, but there are still implicit function declarations.
+    copts = [
+        "-w",
+        "-Dverbose=-1",
+    ] + select({
+        "@platforms//os:macos": [ "-Wno-implicit-function-declaration" ],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+"""
+
+http_archive(
+    name = "zlib",
+    build_file_content = _zlib_build,
+    sha256 = "8a9ba2898e1d0d774eca6ba5b4627a11e5588ba85c8851336eb38de4683050a7",
+    strip_prefix = "zlib-1.3",
+    urls = ["https://zlib.net/zlib-1.3.tar.xz"],
+)
+
 http_file(
     name = "cargo_bazel_linux_x64",
     executable = True,
-    sha256 = "802c67ce797673f74f6053206b30c38df5d213cfe576505bd70c3ed85e65687a",
+    sha256 = "cd19f960cb97b1ee7f31c9297f8e6f7f08a229e28ab4bb1c2c776a7aba2e211d",
     urls = [
-        "https://github.com/bazelbuild/rules_rust/releases/download/0.28.0/cargo-bazel-x86_64-unknown-linux-gnu",
+        "https://github.com/bazelbuild/rules_rust/releases/download/0.32.0/cargo-bazel-x86_64-unknown-linux-gnu",
     ],
 )
 
 http_file(
     name = "cargo_bazel_linux_arm64",
     executable = True,
-    sha256 = "ac65915f702b97479924b290895dd9d759e0883b8a60bce44b9cc43ba4cca18b",
+    sha256 = "0d9c9b089737b3d3dea5cc5ce2c42ea5cbcfd0e103c47a00ab29953d65dc0b2d",
     urls = [
-        "https://github.com/bazelbuild/rules_rust/releases/download/0.28.0/cargo-bazel-aarch64-unknown-linux-gnu",
+        "https://github.com/bazelbuild/rules_rust/releases/download/0.32.0/cargo-bazel-aarch64-unknown-linux-gnu",
     ],
 )
 
 http_file(
     name = "cargo_bazel_macos_x64",
     executable = True,
-    sha256 = "756f26c97d46b88fa94f098de0805ae9b6cc25d01708dd7606af57d632bc504a",
+    sha256 = "b3f02c5691ceeac06869ce1a7aff06094879b51941fadd57393a55ee0598448f",
     urls = [
-        "https://github.com/bazelbuild/rules_rust/releases/download/0.28.0/cargo-bazel-x86_64-apple-darwin",
+        "https://github.com/bazelbuild/rules_rust/releases/download/0.32.0/cargo-bazel-x86_64-apple-darwin",
     ],
 )
 
 http_file(
     name = "cargo_bazel_macos_arm64",
     executable = True,
-    sha256 = "73ea17706d2b875ecce78015c8534435536211ff52d3ff8e23797457a386bfea",
+    sha256 = "f9968243c677349a8cbbea360e39e3f9bb696cf853c031ece57e887ecd1bf523",
     urls = [
-        "https://github.com/bazelbuild/rules_rust/releases/download/0.28.0/cargo-bazel-aarch64-apple-darwin",
+        "https://github.com/bazelbuild/rules_rust/releases/download/0.32.0/cargo-bazel-aarch64-apple-darwin",
     ],
 )
 
@@ -217,17 +242,17 @@ http_file(
     name = "cargo_bazel_win_x64",
     downloaded_file_path = "downloaded.exe",  # .exe extension required for Windows to recognise as executable
     executable = True,
-    sha256 = "838f456e84c04b5ba939adcaa017a6bcf87e0d8c9673524463c12c76c314e9a5",
+    sha256 = "6da386d85533ce38d7501a41bd072fb5cd27c7f9d801d2336150eeb9f8cf3849",
     urls = [
-        "https://github.com/bazelbuild/rules_rust/releases/download/0.28.0/cargo-bazel-x86_64-pc-windows-msvc.exe",
+        "https://github.com/bazelbuild/rules_rust/releases/download/0.32.0/cargo-bazel-x86_64-pc-windows-msvc.exe",
     ],
 )
 
 http_archive(
     name = "rules_rust",
-    sha256 = "c46bdafc582d9bd48a6f97000d05af4829f62d5fee10a2a3edddf2f3d9a232c1",
+    sha256 = "1e7114ea2af800c6987ca38daeee13e3ae6e934875b4f7ca24b798857f95431e",
     urls = [
-        "https://github.com/bazelbuild/rules_rust/releases/download/0.28.0/rules_rust-v0.28.0.tar.gz",
+        "https://github.com/bazelbuild/rules_rust/releases/download/0.32.0/rules_rust-v0.32.0.tar.gz",
     ],
 )
 

--- a/build/BUILD.boringssl
+++ b/build/BUILD.boringssl
@@ -1,5 +1,0 @@
-filegroup(
-    name = "src",
-    srcs = glob(["**/*"]),
-)
-

--- a/rust-deps/crates/BUILD.ahash-0.8.6.bazel
+++ b/rust-deps/crates/BUILD.ahash-0.8.6.bazel
@@ -16,7 +16,7 @@ package(default_visibility = ["//visibility:public"])
 # ])
 
 rust_library(
-    name = "libc",
+    name = "ahash",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -29,33 +29,44 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "default",
-        "std",
-    ],
     crate_root = "src/lib.rs",
-    edition = "2015",
+    edition = "2018",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=libc",
+        "crate-name=ahash",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "0.2.148",
+    version = "0.8.6",
     deps = [
-        "@crates_vendor__libc-0.2.148//:build_script_build",
-    ],
+        "@crates_vendor__ahash-0.8.6//:build_script_build",
+        "@crates_vendor__cfg-if-1.0.0//:cfg_if",
+        "@crates_vendor__zerocopy-0.7.29//:zerocopy",
+    ] + select({
+        "@rules_rust//rust/platform:aarch64-apple-darwin": [
+            "@crates_vendor__once_cell-1.18.0//:once_cell",  # cfg(not(all(target_arch = "arm", target_os = "none")))
+        ],
+        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": [
+            "@crates_vendor__once_cell-1.18.0//:once_cell",  # cfg(not(all(target_arch = "arm", target_os = "none")))
+        ],
+        "@rules_rust//rust/platform:x86_64-apple-darwin": [
+            "@crates_vendor__once_cell-1.18.0//:once_cell",  # cfg(not(all(target_arch = "arm", target_os = "none")))
+        ],
+        "@rules_rust//rust/platform:x86_64-pc-windows-msvc": [
+            "@crates_vendor__once_cell-1.18.0//:once_cell",  # cfg(not(all(target_arch = "arm", target_os = "none")))
+        ],
+        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": [
+            "@crates_vendor__once_cell-1.18.0//:once_cell",  # cfg(not(all(target_arch = "arm", target_os = "none")))
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "ahash_build_script",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-        "default",
-        "std",
-    ],
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
@@ -69,23 +80,26 @@ cargo_build_script(
             "WORKSPACE.bazel",
         ],
     ),
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=libc",
+        "crate-name=ahash",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "0.2.148",
+    version = "0.8.6",
     visibility = ["//visibility:private"],
+    deps = [
+        "@crates_vendor__version_check-0.9.4//:version_check",
+    ],
 )
 
 alias(
     name = "build_script_build",
-    actual = "libc_build_script",
+    actual = "ahash_build_script",
     tags = ["manual"],
 )

--- a/rust-deps/crates/BUILD.bazel
+++ b/rust-deps/crates/BUILD.bazel
@@ -33,13 +33,13 @@ alias(
 
 alias(
     name = "clang-ast",
-    actual = "@crates_vendor__clang-ast-0.1.20//:clang_ast",
+    actual = "@crates_vendor__clang-ast-0.1.21//:clang_ast",
     tags = ["manual"],
 )
 
 alias(
     name = "flate2",
-    actual = "@crates_vendor__flate2-1.0.27//:flate2",
+    actual = "@crates_vendor__flate2-1.0.28//:flate2",
     tags = ["manual"],
 )
 
@@ -63,12 +63,12 @@ alias(
 
 alias(
     name = "serde",
-    actual = "@crates_vendor__serde-1.0.188//:serde",
+    actual = "@crates_vendor__serde-1.0.193//:serde",
     tags = ["manual"],
 )
 
 alias(
     name = "serde_json",
-    actual = "@crates_vendor__serde_json-1.0.107//:serde_json",
+    actual = "@crates_vendor__serde_json-1.0.108//:serde_json",
     tags = ["manual"],
 )

--- a/rust-deps/crates/BUILD.bitflags-2.4.1.bazel
+++ b/rust-deps/crates/BUILD.bitflags-2.4.1.bazel
@@ -11,11 +11,11 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # Unlicense OR MIT
+#     "TODO",  # MIT OR Apache-2.0
 # ])
 
 rust_library(
-    name = "memchr",
+    name = "bitflags",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -28,20 +28,15 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "alloc",
-        "default",
-        "std",
-    ],
     crate_root = "src/lib.rs",
     edition = "2021",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=memchr",
+        "crate-name=bitflags",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "2.6.3",
+    version = "2.4.1",
 )

--- a/rust-deps/crates/BUILD.byteorder-1.5.0.bazel
+++ b/rust-deps/crates/BUILD.byteorder-1.5.0.bazel
@@ -11,11 +11,11 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # BSD-3-Clause
+#     "TODO",  # Unlicense OR MIT
 # ])
 
 rust_library(
-    name = "lol_html",
+    name = "byteorder",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -28,29 +28,19 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
+    crate_features = [
+        "default",
+        "std",
+    ],
     crate_root = "src/lib.rs",
     edition = "2021",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=lol_html",
+        "crate-name=byteorder",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.1.1",
-    deps = [
-        "@crates_vendor__bitflags-2.4.1//:bitflags",
-        "@crates_vendor__cfg-if-1.0.0//:cfg_if",
-        "@crates_vendor__cssparser-0.27.2//:cssparser",
-        "@crates_vendor__encoding_rs-0.8.33//:encoding_rs",
-        "@crates_vendor__hashbrown-0.13.2//:hashbrown",
-        "@crates_vendor__lazy_static-1.4.0//:lazy_static",
-        "@crates_vendor__lazycell-1.3.0//:lazycell",
-        "@crates_vendor__memchr-2.6.4//:memchr",
-        "@crates_vendor__mime-0.3.17//:mime",
-        "@crates_vendor__safemem-0.3.3//:safemem",
-        "@crates_vendor__selectors-0.22.0//:selectors",
-        "@crates_vendor__thiserror-1.0.50//:thiserror",
-    ],
+    version = "1.5.0",
 )

--- a/rust-deps/crates/BUILD.cc-1.0.83.bazel
+++ b/rust-deps/crates/BUILD.cc-1.0.83.bazel
@@ -41,16 +41,16 @@ rust_library(
     version = "1.0.83",
     deps = select({
         "@rules_rust//rust/platform:aarch64-apple-darwin": [
-            "@crates_vendor__libc-0.2.148//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.150//:libc",  # cfg(unix)
         ],
         "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": [
-            "@crates_vendor__libc-0.2.148//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.150//:libc",  # cfg(unix)
         ],
         "@rules_rust//rust/platform:x86_64-apple-darwin": [
-            "@crates_vendor__libc-0.2.148//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.150//:libc",  # cfg(unix)
         ],
         "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": [
-            "@crates_vendor__libc-0.2.148//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.150//:libc",  # cfg(unix)
         ],
         "//conditions:default": [],
     }),

--- a/rust-deps/crates/BUILD.clang-ast-0.1.21.bazel
+++ b/rust-deps/crates/BUILD.clang-ast-0.1.21.bazel
@@ -38,9 +38,9 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "0.1.20",
+    version = "0.1.21",
     deps = [
         "@crates_vendor__rustc-hash-1.1.0//:rustc_hash",
-        "@crates_vendor__serde-1.0.188//:serde",
+        "@crates_vendor__serde-1.0.193//:serde",
     ],
 )

--- a/rust-deps/crates/BUILD.cssparser-0.27.2.bazel
+++ b/rust-deps/crates/BUILD.cssparser-0.27.2.bazel
@@ -49,7 +49,7 @@ rust_library(
         "@crates_vendor__itoa-0.4.8//:itoa",
         "@crates_vendor__matches-0.1.10//:matches",
         "@crates_vendor__phf-0.8.0//:phf",
-        "@crates_vendor__smallvec-1.11.1//:smallvec",
+        "@crates_vendor__smallvec-1.11.2//:smallvec",
     ],
 )
 
@@ -83,7 +83,7 @@ cargo_build_script(
     version = "0.27.2",
     visibility = ["//visibility:private"],
     deps = [
-        "@crates_vendor__proc-macro2-1.0.67//:proc_macro2",
+        "@crates_vendor__proc-macro2-1.0.70//:proc_macro2",
         "@crates_vendor__quote-1.0.33//:quote",
         "@crates_vendor__syn-1.0.109//:syn",
     ],

--- a/rust-deps/crates/BUILD.cssparser-macros-0.6.1.bazel
+++ b/rust-deps/crates/BUILD.cssparser-macros-0.6.1.bazel
@@ -41,6 +41,6 @@ rust_proc_macro(
     version = "0.6.1",
     deps = [
         "@crates_vendor__quote-1.0.33//:quote",
-        "@crates_vendor__syn-2.0.37//:syn",
+        "@crates_vendor__syn-2.0.39//:syn",
     ],
 )

--- a/rust-deps/crates/BUILD.derive_more-0.99.17.bazel
+++ b/rust-deps/crates/BUILD.derive_more-0.99.17.bazel
@@ -69,7 +69,7 @@ rust_proc_macro(
     version = "0.99.17",
     deps = [
         "@crates_vendor__convert_case-0.4.0//:convert_case",
-        "@crates_vendor__proc-macro2-1.0.67//:proc_macro2",
+        "@crates_vendor__proc-macro2-1.0.70//:proc_macro2",
         "@crates_vendor__quote-1.0.33//:quote",
         "@crates_vendor__syn-1.0.109//:syn",
     ],

--- a/rust-deps/crates/BUILD.flate2-1.0.28.bazel
+++ b/rust-deps/crates/BUILD.flate2-1.0.28.bazel
@@ -6,7 +6,7 @@
 #     bazel run @//rust-deps:crates_vendor
 ###############################################################################
 
-load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
+load("@rules_rust//rust:defs.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,8 +14,8 @@ package(default_visibility = ["//visibility:public"])
 #     "TODO",  # MIT OR Apache-2.0
 # ])
 
-rust_proc_macro(
-    name = "thiserror_impl",
+rust_library(
+    name = "flate2",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -28,20 +28,25 @@ rust_proc_macro(
             "WORKSPACE.bazel",
         ],
     ),
+    crate_features = [
+        "any_impl",
+        "default",
+        "miniz_oxide",
+        "rust_backend",
+    ],
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2018",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=thiserror-impl",
+        "crate-name=flate2",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.49",
+    version = "1.0.28",
     deps = [
-        "@crates_vendor__proc-macro2-1.0.67//:proc_macro2",
-        "@crates_vendor__quote-1.0.33//:quote",
-        "@crates_vendor__syn-2.0.37//:syn",
+        "@crates_vendor__crc32fast-1.3.2//:crc32fast",
+        "@crates_vendor__miniz_oxide-0.7.1//:miniz_oxide",
     ],
 )

--- a/rust-deps/crates/BUILD.fxhash-0.2.1.bazel
+++ b/rust-deps/crates/BUILD.fxhash-0.2.1.bazel
@@ -40,6 +40,6 @@ rust_library(
     ],
     version = "0.2.1",
     deps = [
-        "@crates_vendor__byteorder-1.4.3//:byteorder",
+        "@crates_vendor__byteorder-1.5.0//:byteorder",
     ],
 )

--- a/rust-deps/crates/BUILD.getrandom-0.1.16.bazel
+++ b/rust-deps/crates/BUILD.getrandom-0.1.16.bazel
@@ -48,16 +48,16 @@ rust_library(
         "@crates_vendor__getrandom-0.1.16//:build_script_build",
     ] + select({
         "@rules_rust//rust/platform:aarch64-apple-darwin": [
-            "@crates_vendor__libc-0.2.148//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.150//:libc",  # cfg(unix)
         ],
         "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": [
-            "@crates_vendor__libc-0.2.148//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.150//:libc",  # cfg(unix)
         ],
         "@rules_rust//rust/platform:x86_64-apple-darwin": [
-            "@crates_vendor__libc-0.2.148//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.150//:libc",  # cfg(unix)
         ],
         "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": [
-            "@crates_vendor__libc-0.2.148//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.150//:libc",  # cfg(unix)
         ],
         "//conditions:default": [],
     }),

--- a/rust-deps/crates/BUILD.hashbrown-0.13.2.bazel
+++ b/rust-deps/crates/BUILD.hashbrown-0.13.2.bazel
@@ -45,6 +45,6 @@ rust_library(
     ],
     version = "0.13.2",
     deps = [
-        "@crates_vendor__ahash-0.8.3//:ahash",
+        "@crates_vendor__ahash-0.8.6//:ahash",
     ],
 )

--- a/rust-deps/crates/BUILD.libc-0.2.150.bazel
+++ b/rust-deps/crates/BUILD.libc-0.2.150.bazel
@@ -16,7 +16,7 @@ package(default_visibility = ["//visibility:public"])
 # ])
 
 rust_library(
-    name = "serde_json",
+    name = "libc",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -34,26 +34,23 @@ rust_library(
         "std",
     ],
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2015",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=serde_json",
+        "crate-name=libc",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.107",
+    version = "0.2.150",
     deps = [
-        "@crates_vendor__itoa-1.0.9//:itoa",
-        "@crates_vendor__ryu-1.0.15//:ryu",
-        "@crates_vendor__serde-1.0.188//:serde",
-        "@crates_vendor__serde_json-1.0.107//:build_script_build",
+        "@crates_vendor__libc-0.2.150//:build_script_build",
     ],
 )
 
 cargo_build_script(
-    name = "serde_json_build_script",
+    name = "libc_build_script",
     srcs = glob(["**/*.rs"]),
     crate_features = [
         "default",
@@ -72,23 +69,23 @@ cargo_build_script(
             "WORKSPACE.bazel",
         ],
     ),
-    edition = "2021",
+    edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=serde_json",
+        "crate-name=libc",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.107",
+    version = "0.2.150",
     visibility = ["//visibility:private"],
 )
 
 alias(
     name = "build_script_build",
-    actual = "serde_json_build_script",
+    actual = "libc_build_script",
     tags = ["manual"],
 )

--- a/rust-deps/crates/BUILD.lolhtml-1.1.1.bazel
+++ b/rust-deps/crates/BUILD.lolhtml-1.1.1.bazel
@@ -37,8 +37,8 @@ rust_library(
     version = "1.1.1",
     deps = [
         "@crates_vendor__encoding_rs-0.8.33//:encoding_rs",
-        "@crates_vendor__libc-0.2.148//:libc",
+        "@crates_vendor__libc-0.2.150//:libc",
         "@crates_vendor__lol_html-1.1.1//:lol_html",
-        "@crates_vendor__thiserror-1.0.49//:thiserror",
+        "@crates_vendor__thiserror-1.0.50//:thiserror",
     ],
 )

--- a/rust-deps/crates/BUILD.memchr-2.6.4.bazel
+++ b/rust-deps/crates/BUILD.memchr-2.6.4.bazel
@@ -11,11 +11,11 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # MIT OR Apache-2.0
+#     "TODO",  # Unlicense OR MIT
 # ])
 
 rust_library(
-    name = "bitflags",
+    name = "memchr",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -28,15 +28,20 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
+    crate_features = [
+        "alloc",
+        "default",
+        "std",
+    ],
     crate_root = "src/lib.rs",
     edition = "2021",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=bitflags",
+        "crate-name=memchr",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "2.4.0",
+    version = "2.6.4",
 )

--- a/rust-deps/crates/BUILD.phf_macros-0.8.0.bazel
+++ b/rust-deps/crates/BUILD.phf_macros-0.8.0.bazel
@@ -45,7 +45,7 @@ rust_proc_macro(
     deps = [
         "@crates_vendor__phf_generator-0.8.0//:phf_generator",
         "@crates_vendor__phf_shared-0.8.0//:phf_shared",
-        "@crates_vendor__proc-macro2-1.0.67//:proc_macro2",
+        "@crates_vendor__proc-macro2-1.0.70//:proc_macro2",
         "@crates_vendor__quote-1.0.33//:quote",
         "@crates_vendor__syn-1.0.109//:syn",
     ],

--- a/rust-deps/crates/BUILD.proc-macro2-1.0.70.bazel
+++ b/rust-deps/crates/BUILD.proc-macro2-1.0.70.bazel
@@ -16,7 +16,7 @@ package(default_visibility = ["//visibility:public"])
 # ])
 
 rust_library(
-    name = "serde",
+    name = "proc_macro2",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -31,37 +31,31 @@ rust_library(
     ),
     crate_features = [
         "default",
-        "derive",
-        "serde_derive",
-        "std",
+        "proc-macro",
     ],
     crate_root = "src/lib.rs",
-    edition = "2018",
-    proc_macro_deps = [
-        "@crates_vendor__serde_derive-1.0.188//:serde_derive",
-    ],
+    edition = "2021",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=serde",
+        "crate-name=proc-macro2",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.188",
+    version = "1.0.70",
     deps = [
-        "@crates_vendor__serde-1.0.188//:build_script_build",
+        "@crates_vendor__proc-macro2-1.0.70//:build_script_build",
+        "@crates_vendor__unicode-ident-1.0.12//:unicode_ident",
     ],
 )
 
 cargo_build_script(
-    name = "serde_build_script",
+    name = "proc-macro2_build_script",
     srcs = glob(["**/*.rs"]),
     crate_features = [
         "default",
-        "derive",
-        "serde_derive",
-        "std",
+        "proc-macro",
     ],
     crate_name = "build_script_build",
     crate_root = "build.rs",
@@ -76,23 +70,23 @@ cargo_build_script(
             "WORKSPACE.bazel",
         ],
     ),
-    edition = "2018",
+    edition = "2021",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=serde",
+        "crate-name=proc-macro2",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.188",
+    version = "1.0.70",
     visibility = ["//visibility:private"],
 )
 
 alias(
     name = "build_script_build",
-    actual = "serde_build_script",
+    actual = "proc-macro2_build_script",
     tags = ["manual"],
 )

--- a/rust-deps/crates/BUILD.quote-1.0.33.bazel
+++ b/rust-deps/crates/BUILD.quote-1.0.33.bazel
@@ -44,6 +44,6 @@ rust_library(
     ],
     version = "1.0.33",
     deps = [
-        "@crates_vendor__proc-macro2-1.0.67//:proc_macro2",
+        "@crates_vendor__proc-macro2-1.0.70//:proc_macro2",
     ],
 )

--- a/rust-deps/crates/BUILD.rand-0.7.3.bazel
+++ b/rust-deps/crates/BUILD.rand-0.7.3.bazel
@@ -58,22 +58,22 @@ rust_library(
         "@crates_vendor__rand_pcg-0.2.1//:rand_pcg",
     ] + select({
         "@rules_rust//rust/platform:aarch64-apple-darwin": [
-            "@crates_vendor__libc-0.2.148//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.150//:libc",  # cfg(unix)
             "@crates_vendor__rand_chacha-0.2.2//:rand_chacha",  # cfg(not(target_os = "emscripten"))
         ],
         "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": [
-            "@crates_vendor__libc-0.2.148//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.150//:libc",  # cfg(unix)
             "@crates_vendor__rand_chacha-0.2.2//:rand_chacha",  # cfg(not(target_os = "emscripten"))
         ],
         "@rules_rust//rust/platform:x86_64-apple-darwin": [
-            "@crates_vendor__libc-0.2.148//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.150//:libc",  # cfg(unix)
             "@crates_vendor__rand_chacha-0.2.2//:rand_chacha",  # cfg(not(target_os = "emscripten"))
         ],
         "@rules_rust//rust/platform:x86_64-pc-windows-msvc": [
             "@crates_vendor__rand_chacha-0.2.2//:rand_chacha",  # cfg(not(target_os = "emscripten"))
         ],
         "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": [
-            "@crates_vendor__libc-0.2.148//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.150//:libc",  # cfg(unix)
             "@crates_vendor__rand_chacha-0.2.2//:rand_chacha",  # cfg(not(target_os = "emscripten"))
         ],
         "//conditions:default": [],

--- a/rust-deps/crates/BUILD.rustc_version-0.4.0.bazel
+++ b/rust-deps/crates/BUILD.rustc_version-0.4.0.bazel
@@ -40,6 +40,6 @@ rust_library(
     ],
     version = "0.4.0",
     deps = [
-        "@crates_vendor__semver-1.0.19//:semver",
+        "@crates_vendor__semver-1.0.20//:semver",
     ],
 )

--- a/rust-deps/crates/BUILD.selectors-0.22.0.bazel
+++ b/rust-deps/crates/BUILD.selectors-0.22.0.bazel
@@ -53,7 +53,7 @@ rust_library(
         "@crates_vendor__precomputed-hash-0.1.1//:precomputed_hash",
         "@crates_vendor__selectors-0.22.0//:build_script_build",
         "@crates_vendor__servo_arc-0.1.1//:servo_arc",
-        "@crates_vendor__smallvec-1.11.1//:smallvec",
+        "@crates_vendor__smallvec-1.11.2//:smallvec",
         "@crates_vendor__thin-slice-0.1.1//:thin_slice",
     ],
 )

--- a/rust-deps/crates/BUILD.semver-1.0.20.bazel
+++ b/rust-deps/crates/BUILD.semver-1.0.20.bazel
@@ -43,9 +43,9 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.19",
+    version = "1.0.20",
     deps = [
-        "@crates_vendor__semver-1.0.19//:build_script_build",
+        "@crates_vendor__semver-1.0.20//:build_script_build",
     ],
 )
 
@@ -80,7 +80,7 @@ cargo_build_script(
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.19",
+    version = "1.0.20",
     visibility = ["//visibility:private"],
 )
 

--- a/rust-deps/crates/BUILD.serde-1.0.193.bazel
+++ b/rust-deps/crates/BUILD.serde-1.0.193.bazel
@@ -16,7 +16,7 @@ package(default_visibility = ["//visibility:public"])
 # ])
 
 rust_library(
-    name = "ahash",
+    name = "serde",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -29,43 +29,40 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
+    crate_features = [
+        "default",
+        "derive",
+        "serde_derive",
+        "std",
+    ],
     crate_root = "src/lib.rs",
     edition = "2018",
+    proc_macro_deps = [
+        "@crates_vendor__serde_derive-1.0.193//:serde_derive",
+    ],
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=ahash",
+        "crate-name=serde",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "0.8.3",
+    version = "1.0.193",
     deps = [
-        "@crates_vendor__ahash-0.8.3//:build_script_build",
-        "@crates_vendor__cfg-if-1.0.0//:cfg_if",
-    ] + select({
-        "@rules_rust//rust/platform:aarch64-apple-darwin": [
-            "@crates_vendor__once_cell-1.18.0//:once_cell",  # cfg(not(all(target_arch = "arm", target_os = "none")))
-        ],
-        "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": [
-            "@crates_vendor__once_cell-1.18.0//:once_cell",  # cfg(not(all(target_arch = "arm", target_os = "none")))
-        ],
-        "@rules_rust//rust/platform:x86_64-apple-darwin": [
-            "@crates_vendor__once_cell-1.18.0//:once_cell",  # cfg(not(all(target_arch = "arm", target_os = "none")))
-        ],
-        "@rules_rust//rust/platform:x86_64-pc-windows-msvc": [
-            "@crates_vendor__once_cell-1.18.0//:once_cell",  # cfg(not(all(target_arch = "arm", target_os = "none")))
-        ],
-        "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": [
-            "@crates_vendor__once_cell-1.18.0//:once_cell",  # cfg(not(all(target_arch = "arm", target_os = "none")))
-        ],
-        "//conditions:default": [],
-    }),
+        "@crates_vendor__serde-1.0.193//:build_script_build",
+    ],
 )
 
 cargo_build_script(
-    name = "ahash_build_script",
+    name = "serde_build_script",
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "derive",
+        "serde_derive",
+        "std",
+    ],
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
@@ -85,20 +82,17 @@ cargo_build_script(
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=ahash",
+        "crate-name=serde",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "0.8.3",
+    version = "1.0.193",
     visibility = ["//visibility:private"],
-    deps = [
-        "@crates_vendor__version_check-0.9.4//:version_check",
-    ],
 )
 
 alias(
     name = "build_script_build",
-    actual = "ahash_build_script",
+    actual = "serde_build_script",
     tags = ["manual"],
 )

--- a/rust-deps/crates/BUILD.serde_derive-1.0.193.bazel
+++ b/rust-deps/crates/BUILD.serde_derive-1.0.193.bazel
@@ -6,16 +6,16 @@
 #     bazel run @//rust-deps:crates_vendor
 ###############################################################################
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
 
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # Unlicense OR MIT
+#     "TODO",  # MIT OR Apache-2.0
 # ])
 
-rust_library(
-    name = "byteorder",
+rust_proc_macro(
+    name = "serde_derive",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -30,17 +30,21 @@ rust_library(
     ),
     crate_features = [
         "default",
-        "std",
     ],
     crate_root = "src/lib.rs",
-    edition = "2018",
+    edition = "2015",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=byteorder",
+        "crate-name=serde_derive",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.4.3",
+    version = "1.0.193",
+    deps = [
+        "@crates_vendor__proc-macro2-1.0.70//:proc_macro2",
+        "@crates_vendor__quote-1.0.33//:quote",
+        "@crates_vendor__syn-2.0.39//:syn",
+    ],
 )

--- a/rust-deps/crates/BUILD.serde_json-1.0.108.bazel
+++ b/rust-deps/crates/BUILD.serde_json-1.0.108.bazel
@@ -16,7 +16,7 @@ package(default_visibility = ["//visibility:public"])
 # ])
 
 rust_library(
-    name = "syn",
+    name = "serde_json",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -30,50 +30,34 @@ rust_library(
         ],
     ),
     crate_features = [
-        "clone-impls",
         "default",
-        "derive",
-        "extra-traits",
-        "fold",
-        "full",
-        "parsing",
-        "printing",
-        "proc-macro",
-        "quote",
+        "std",
     ],
     crate_root = "src/lib.rs",
-    edition = "2018",
+    edition = "2021",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=syn",
+        "crate-name=serde_json",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.109",
+    version = "1.0.108",
     deps = [
-        "@crates_vendor__proc-macro2-1.0.70//:proc_macro2",
-        "@crates_vendor__quote-1.0.33//:quote",
-        "@crates_vendor__syn-1.0.109//:build_script_build",
-        "@crates_vendor__unicode-ident-1.0.12//:unicode_ident",
+        "@crates_vendor__itoa-1.0.9//:itoa",
+        "@crates_vendor__ryu-1.0.15//:ryu",
+        "@crates_vendor__serde-1.0.193//:serde",
+        "@crates_vendor__serde_json-1.0.108//:build_script_build",
     ],
 )
 
 cargo_build_script(
-    name = "syn_build_script",
+    name = "serde_json_build_script",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "clone-impls",
         "default",
-        "derive",
-        "extra-traits",
-        "fold",
-        "full",
-        "parsing",
-        "printing",
-        "proc-macro",
-        "quote",
+        "std",
     ],
     crate_name = "build_script_build",
     crate_root = "build.rs",
@@ -88,23 +72,23 @@ cargo_build_script(
             "WORKSPACE.bazel",
         ],
     ),
-    edition = "2018",
+    edition = "2021",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=syn",
+        "crate-name=serde_json",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.109",
+    version = "1.0.108",
     visibility = ["//visibility:private"],
 )
 
 alias(
     name = "build_script_build",
-    actual = "syn_build_script",
+    actual = "serde_json_build_script",
     tags = ["manual"],
 )

--- a/rust-deps/crates/BUILD.smallvec-1.11.2.bazel
+++ b/rust-deps/crates/BUILD.smallvec-1.11.2.bazel
@@ -38,5 +38,5 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "1.11.1",
+    version = "1.11.2",
 )

--- a/rust-deps/crates/BUILD.syn-2.0.39.bazel
+++ b/rust-deps/crates/BUILD.syn-2.0.39.bazel
@@ -6,7 +6,6 @@
 #     bazel run @//rust-deps:crates_vendor
 ###############################################################################
 
-load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 load("@rules_rust//rust:defs.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -16,7 +15,7 @@ package(default_visibility = ["//visibility:public"])
 # ])
 
 rust_library(
-    name = "proc_macro2",
+    name = "syn",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -30,63 +29,30 @@ rust_library(
         ],
     ),
     crate_features = [
+        "clone-impls",
         "default",
+        "derive",
+        "extra-traits",
+        "full",
+        "parsing",
+        "printing",
         "proc-macro",
+        "quote",
     ],
     crate_root = "src/lib.rs",
     edition = "2021",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=proc-macro2",
+        "crate-name=syn",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.67",
+    version = "2.0.39",
     deps = [
-        "@crates_vendor__proc-macro2-1.0.67//:build_script_build",
+        "@crates_vendor__proc-macro2-1.0.70//:proc_macro2",
+        "@crates_vendor__quote-1.0.33//:quote",
         "@crates_vendor__unicode-ident-1.0.12//:unicode_ident",
     ],
-)
-
-cargo_build_script(
-    name = "proc-macro2_build_script",
-    srcs = glob(["**/*.rs"]),
-    crate_features = [
-        "default",
-        "proc-macro",
-    ],
-    crate_name = "build_script_build",
-    crate_root = "build.rs",
-    data = glob(
-        include = ["**"],
-        exclude = [
-            "**/* *",
-            ".tmp_git_root/**/*",
-            "BUILD",
-            "BUILD.bazel",
-            "WORKSPACE",
-            "WORKSPACE.bazel",
-        ],
-    ),
-    edition = "2021",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    tags = [
-        "cargo-bazel",
-        "crate-name=proc-macro2",
-        "manual",
-        "noclippy",
-        "norustfmt",
-    ],
-    version = "1.0.67",
-    visibility = ["//visibility:private"],
-)
-
-alias(
-    name = "build_script_build",
-    actual = "proc-macro2_build_script",
-    tags = ["manual"],
 )

--- a/rust-deps/crates/BUILD.thiserror-1.0.50.bazel
+++ b/rust-deps/crates/BUILD.thiserror-1.0.50.bazel
@@ -32,7 +32,7 @@ rust_library(
     crate_root = "src/lib.rs",
     edition = "2021",
     proc_macro_deps = [
-        "@crates_vendor__thiserror-impl-1.0.49//:thiserror_impl",
+        "@crates_vendor__thiserror-impl-1.0.50//:thiserror_impl",
     ],
     rustc_flags = ["--cap-lints=allow"],
     tags = [
@@ -42,9 +42,9 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.49",
+    version = "1.0.50",
     deps = [
-        "@crates_vendor__thiserror-1.0.49//:build_script_build",
+        "@crates_vendor__thiserror-1.0.50//:build_script_build",
     ],
 )
 
@@ -75,7 +75,7 @@ cargo_build_script(
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.49",
+    version = "1.0.50",
     visibility = ["//visibility:private"],
 )
 

--- a/rust-deps/crates/BUILD.thiserror-impl-1.0.50.bazel
+++ b/rust-deps/crates/BUILD.thiserror-impl-1.0.50.bazel
@@ -6,7 +6,7 @@
 #     bazel run @//rust-deps:crates_vendor
 ###############################################################################
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,8 +14,8 @@ package(default_visibility = ["//visibility:public"])
 #     "TODO",  # MIT OR Apache-2.0
 # ])
 
-rust_library(
-    name = "flate2",
+rust_proc_macro(
+    name = "thiserror_impl",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -28,25 +28,20 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "any_impl",
-        "default",
-        "miniz_oxide",
-        "rust_backend",
-    ],
     crate_root = "src/lib.rs",
-    edition = "2018",
+    edition = "2021",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=flate2",
+        "crate-name=thiserror-impl",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.27",
+    version = "1.0.50",
     deps = [
-        "@crates_vendor__crc32fast-1.3.2//:crc32fast",
-        "@crates_vendor__miniz_oxide-0.7.1//:miniz_oxide",
+        "@crates_vendor__proc-macro2-1.0.70//:proc_macro2",
+        "@crates_vendor__quote-1.0.33//:quote",
+        "@crates_vendor__syn-2.0.39//:syn",
     ],
 )

--- a/rust-deps/crates/BUILD.zerocopy-0.7.29.bazel
+++ b/rust-deps/crates/BUILD.zerocopy-0.7.29.bazel
@@ -6,16 +6,16 @@
 #     bazel run @//rust-deps:crates_vendor
 ###############################################################################
 
-load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
+load("@rules_rust//rust:defs.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # MIT OR Apache-2.0
+#     "TODO",  # BSD-2-Clause OR Apache-2.0 OR MIT
 # ])
 
-rust_proc_macro(
-    name = "serde_derive",
+rust_library(
+    name = "zerocopy",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -29,22 +29,17 @@ rust_proc_macro(
         ],
     ),
     crate_features = [
-        "default",
+        "simd",
     ],
     crate_root = "src/lib.rs",
-    edition = "2015",
+    edition = "2018",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=serde_derive",
+        "crate-name=zerocopy",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.188",
-    deps = [
-        "@crates_vendor__proc-macro2-1.0.67//:proc_macro2",
-        "@crates_vendor__quote-1.0.33//:quote",
-        "@crates_vendor__syn-2.0.37//:syn",
-    ],
+    version = "0.7.29",
 )

--- a/rust-deps/crates/BUILD.zerocopy-derive-0.7.29.bazel
+++ b/rust-deps/crates/BUILD.zerocopy-derive-0.7.29.bazel
@@ -6,16 +6,16 @@
 #     bazel run @//rust-deps:crates_vendor
 ###############################################################################
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
 
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # MIT OR Apache-2.0
+#     "TODO",  # BSD-2-Clause OR Apache-2.0 OR MIT
 # ])
 
-rust_library(
-    name = "syn",
+rust_proc_macro(
+    name = "zerocopy_derive",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -28,31 +28,20 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "clone-impls",
-        "default",
-        "derive",
-        "extra-traits",
-        "full",
-        "parsing",
-        "printing",
-        "proc-macro",
-        "quote",
-    ],
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2018",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=syn",
+        "crate-name=zerocopy-derive",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "2.0.37",
+    version = "0.7.29",
     deps = [
-        "@crates_vendor__proc-macro2-1.0.67//:proc_macro2",
+        "@crates_vendor__proc-macro2-1.0.70//:proc_macro2",
         "@crates_vendor__quote-1.0.33//:quote",
-        "@crates_vendor__unicode-ident-1.0.12//:unicode_ident",
+        "@crates_vendor__syn-2.0.39//:syn",
     ],
 )

--- a/rust-deps/crates/defs.bzl
+++ b/rust-deps/crates/defs.bzl
@@ -297,12 +297,12 @@ _NORMAL_DEPENDENCIES = {
     "": {
         _COMMON_CONDITION: {
             "anyhow": "@crates_vendor__anyhow-1.0.75//:anyhow",
-            "clang-ast": "@crates_vendor__clang-ast-0.1.20//:clang_ast",
-            "flate2": "@crates_vendor__flate2-1.0.27//:flate2",
+            "clang-ast": "@crates_vendor__clang-ast-0.1.21//:clang_ast",
+            "flate2": "@crates_vendor__flate2-1.0.28//:flate2",
             "lolhtml": "@crates_vendor__lolhtml-1.1.1//:lolhtml",
             "pico-args": "@crates_vendor__pico-args-0.5.0//:pico_args",
-            "serde": "@crates_vendor__serde-1.0.188//:serde",
-            "serde_json": "@crates_vendor__serde_json-1.0.107//:serde_json",
+            "serde": "@crates_vendor__serde-1.0.193//:serde",
+            "serde_json": "@crates_vendor__serde_json-1.0.108//:serde_json",
         },
     },
 }
@@ -370,6 +370,7 @@ _BUILD_PROC_MACRO_ALIASES = {
 _CONDITIONS = {
     "aarch64-apple-darwin": ["@rules_rust//rust/platform:aarch64-apple-darwin"],
     "aarch64-unknown-linux-gnu": ["@rules_rust//rust/platform:aarch64-unknown-linux-gnu"],
+    "cfg(any())": [],
     "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": ["@rules_rust//rust/platform:aarch64-apple-darwin", "@rules_rust//rust/platform:aarch64-unknown-linux-gnu", "@rules_rust//rust/platform:x86_64-apple-darwin", "@rules_rust//rust/platform:x86_64-pc-windows-msvc", "@rules_rust//rust/platform:x86_64-unknown-linux-gnu"],
     "cfg(not(target_os = \"emscripten\"))": ["@rules_rust//rust/platform:aarch64-apple-darwin", "@rules_rust//rust/platform:aarch64-unknown-linux-gnu", "@rules_rust//rust/platform:x86_64-apple-darwin", "@rules_rust//rust/platform:x86_64-pc-windows-msvc", "@rules_rust//rust/platform:x86_64-unknown-linux-gnu"],
     "cfg(target_os = \"emscripten\")": [],
@@ -396,12 +397,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__ahash-0.8.3",
-        sha256 = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f",
+        name = "crates_vendor__ahash-0.8.6",
+        sha256 = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/ahash/0.8.3/download"],
-        strip_prefix = "ahash-0.8.3",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.ahash-0.8.3.bazel"),
+        urls = ["https://crates.io/api/v1/crates/ahash/0.8.6/download"],
+        strip_prefix = "ahash-0.8.6",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.ahash-0.8.6.bazel"),
     )
 
     maybe(
@@ -426,22 +427,22 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__bitflags-2.4.0",
-        sha256 = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635",
+        name = "crates_vendor__bitflags-2.4.1",
+        sha256 = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/bitflags/2.4.0/download"],
-        strip_prefix = "bitflags-2.4.0",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.bitflags-2.4.0.bazel"),
+        urls = ["https://crates.io/api/v1/crates/bitflags/2.4.1/download"],
+        strip_prefix = "bitflags-2.4.1",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.bitflags-2.4.1.bazel"),
     )
 
     maybe(
         http_archive,
-        name = "crates_vendor__byteorder-1.4.3",
-        sha256 = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610",
+        name = "crates_vendor__byteorder-1.5.0",
+        sha256 = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/byteorder/1.4.3/download"],
-        strip_prefix = "byteorder-1.4.3",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.byteorder-1.4.3.bazel"),
+        urls = ["https://crates.io/api/v1/crates/byteorder/1.5.0/download"],
+        strip_prefix = "byteorder-1.5.0",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.byteorder-1.5.0.bazel"),
     )
 
     maybe(
@@ -466,12 +467,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__clang-ast-0.1.20",
-        sha256 = "152da76e4e754905d7f915611170325310a95ab872a15ed8516c64c1ee4c0e13",
+        name = "crates_vendor__clang-ast-0.1.21",
+        sha256 = "15fd928f71f2ac27e00ee62e89293ddf696465db41434efa7f7699cddc034702",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/clang-ast/0.1.20/download"],
-        strip_prefix = "clang-ast-0.1.20",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.clang-ast-0.1.20.bazel"),
+        urls = ["https://crates.io/api/v1/crates/clang-ast/0.1.21/download"],
+        strip_prefix = "clang-ast-0.1.21",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.clang-ast-0.1.21.bazel"),
     )
 
     maybe(
@@ -556,12 +557,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__flate2-1.0.27",
-        sha256 = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010",
+        name = "crates_vendor__flate2-1.0.28",
+        sha256 = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/flate2/1.0.27/download"],
-        strip_prefix = "flate2-1.0.27",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.flate2-1.0.27.bazel"),
+        urls = ["https://crates.io/api/v1/crates/flate2/1.0.28/download"],
+        strip_prefix = "flate2-1.0.28",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.flate2-1.0.28.bazel"),
     )
 
     maybe(
@@ -636,12 +637,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__libc-0.2.148",
-        sha256 = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b",
+        name = "crates_vendor__libc-0.2.150",
+        sha256 = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/libc/0.2.148/download"],
-        strip_prefix = "libc-0.2.148",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.libc-0.2.148.bazel"),
+        urls = ["https://crates.io/api/v1/crates/libc/0.2.150/download"],
+        strip_prefix = "libc-0.2.150",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.libc-0.2.150.bazel"),
     )
 
     maybe(
@@ -687,12 +688,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__memchr-2.6.3",
-        sha256 = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c",
+        name = "crates_vendor__memchr-2.6.4",
+        sha256 = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/memchr/2.6.3/download"],
-        strip_prefix = "memchr-2.6.3",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.memchr-2.6.3.bazel"),
+        urls = ["https://crates.io/api/v1/crates/memchr/2.6.4/download"],
+        strip_prefix = "memchr-2.6.4",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.memchr-2.6.4.bazel"),
     )
 
     maybe(
@@ -827,12 +828,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__proc-macro2-1.0.67",
-        sha256 = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328",
+        name = "crates_vendor__proc-macro2-1.0.70",
+        sha256 = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/proc-macro2/1.0.67/download"],
-        strip_prefix = "proc-macro2-1.0.67",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.proc-macro2-1.0.67.bazel"),
+        urls = ["https://crates.io/api/v1/crates/proc-macro2/1.0.70/download"],
+        strip_prefix = "proc-macro2-1.0.70",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.proc-macro2-1.0.70.bazel"),
     )
 
     maybe(
@@ -947,42 +948,42 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__semver-1.0.19",
-        sha256 = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0",
+        name = "crates_vendor__semver-1.0.20",
+        sha256 = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/semver/1.0.19/download"],
-        strip_prefix = "semver-1.0.19",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.semver-1.0.19.bazel"),
+        urls = ["https://crates.io/api/v1/crates/semver/1.0.20/download"],
+        strip_prefix = "semver-1.0.20",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.semver-1.0.20.bazel"),
     )
 
     maybe(
         http_archive,
-        name = "crates_vendor__serde-1.0.188",
-        sha256 = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e",
+        name = "crates_vendor__serde-1.0.193",
+        sha256 = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/serde/1.0.188/download"],
-        strip_prefix = "serde-1.0.188",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.serde-1.0.188.bazel"),
+        urls = ["https://crates.io/api/v1/crates/serde/1.0.193/download"],
+        strip_prefix = "serde-1.0.193",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.serde-1.0.193.bazel"),
     )
 
     maybe(
         http_archive,
-        name = "crates_vendor__serde_derive-1.0.188",
-        sha256 = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2",
+        name = "crates_vendor__serde_derive-1.0.193",
+        sha256 = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/serde_derive/1.0.188/download"],
-        strip_prefix = "serde_derive-1.0.188",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.serde_derive-1.0.188.bazel"),
+        urls = ["https://crates.io/api/v1/crates/serde_derive/1.0.193/download"],
+        strip_prefix = "serde_derive-1.0.193",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.serde_derive-1.0.193.bazel"),
     )
 
     maybe(
         http_archive,
-        name = "crates_vendor__serde_json-1.0.107",
-        sha256 = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65",
+        name = "crates_vendor__serde_json-1.0.108",
+        sha256 = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/serde_json/1.0.107/download"],
-        strip_prefix = "serde_json-1.0.107",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.serde_json-1.0.107.bazel"),
+        urls = ["https://crates.io/api/v1/crates/serde_json/1.0.108/download"],
+        strip_prefix = "serde_json-1.0.108",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.serde_json-1.0.108.bazel"),
     )
 
     maybe(
@@ -1007,12 +1008,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__smallvec-1.11.1",
-        sha256 = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a",
+        name = "crates_vendor__smallvec-1.11.2",
+        sha256 = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/smallvec/1.11.1/download"],
-        strip_prefix = "smallvec-1.11.1",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.smallvec-1.11.1.bazel"),
+        urls = ["https://crates.io/api/v1/crates/smallvec/1.11.2/download"],
+        strip_prefix = "smallvec-1.11.2",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.smallvec-1.11.2.bazel"),
     )
 
     maybe(
@@ -1037,12 +1038,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__syn-2.0.37",
-        sha256 = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8",
+        name = "crates_vendor__syn-2.0.39",
+        sha256 = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/syn/2.0.37/download"],
-        strip_prefix = "syn-2.0.37",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.syn-2.0.37.bazel"),
+        urls = ["https://crates.io/api/v1/crates/syn/2.0.39/download"],
+        strip_prefix = "syn-2.0.39",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.syn-2.0.39.bazel"),
     )
 
     maybe(
@@ -1057,22 +1058,22 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__thiserror-1.0.49",
-        sha256 = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4",
+        name = "crates_vendor__thiserror-1.0.50",
+        sha256 = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/thiserror/1.0.49/download"],
-        strip_prefix = "thiserror-1.0.49",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.thiserror-1.0.49.bazel"),
+        urls = ["https://crates.io/api/v1/crates/thiserror/1.0.50/download"],
+        strip_prefix = "thiserror-1.0.50",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.thiserror-1.0.50.bazel"),
     )
 
     maybe(
         http_archive,
-        name = "crates_vendor__thiserror-impl-1.0.49",
-        sha256 = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc",
+        name = "crates_vendor__thiserror-impl-1.0.50",
+        sha256 = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/thiserror-impl/1.0.49/download"],
-        strip_prefix = "thiserror-impl-1.0.49",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.thiserror-impl-1.0.49.bazel"),
+        urls = ["https://crates.io/api/v1/crates/thiserror-impl/1.0.50/download"],
+        strip_prefix = "thiserror-impl-1.0.50",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.thiserror-impl-1.0.50.bazel"),
     )
 
     maybe(
@@ -1103,4 +1104,24 @@ def crate_repositories():
         urls = ["https://crates.io/api/v1/crates/wasi/0.9.0+wasi-snapshot-preview1/download"],
         strip_prefix = "wasi-0.9.0+wasi-snapshot-preview1",
         build_file = Label("@workerd//rust-deps/crates:BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "crates_vendor__zerocopy-0.7.29",
+        sha256 = "5d075cf85bbb114e933343e087b92f2146bac0d55b534cbb8188becf0039948e",
+        type = "tar.gz",
+        urls = ["https://crates.io/api/v1/crates/zerocopy/0.7.29/download"],
+        strip_prefix = "zerocopy-0.7.29",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.zerocopy-0.7.29.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "crates_vendor__zerocopy-derive-0.7.29",
+        sha256 = "86cd5ca076997b97ef09d3ad65efe811fa68c9e874cb636ccb211223a813b0c2",
+        type = "tar.gz",
+        urls = ["https://crates.io/api/v1/crates/zerocopy-derive/0.7.29/download"],
+        strip_prefix = "zerocopy-derive-0.7.29",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.zerocopy-derive-0.7.29.bazel"),
     )


### PR DESCRIPTION
This change also requires explicitly adding zlib as a dependency, which used to be pulled in via rules_rust.