### PR TITLE
Move logic from `wd_ts_bundle` to `wd_js_bundle`

### DIFF
--- a/build/wd_js_bundle.bzl
+++ b/build/wd_js_bundle.bzl
@@ -15,6 +15,9 @@ const {const_name} :Modules.Bundle = (
 
 MODULE_TEMPLATE = """    (name = "{name}", {src_type} = embed "{path}", type = {type}, {ts_declaration})"""
 
+def _to_name(file_name):
+    return file_name.removesuffix(".js")
+
 def _to_d_ts(file_name):
     return file_name.removesuffix(".js") + ".d.ts"
 
@@ -54,11 +57,11 @@ def _gen_api_bundle_capnpn_impl(ctx):
         for m in ctx.attr.internal_modules
     ]
     modules += [
-        _render_module(ctx.attr.internal_wasm_modules[m], m.label,  "wasm", "internal")
+        _render_module(ctx.attr.internal_wasm_modules[m], m.label, "wasm", "internal")
         for m in ctx.attr.internal_wasm_modules
     ]
     modules += [
-        _render_module(ctx.attr.internal_data_modules[m], m.label,  "data", "internal")
+        _render_module(ctx.attr.internal_data_modules[m], m.label, "data", "internal")
         for m in ctx.attr.internal_data_modules
     ]
 
@@ -81,6 +84,7 @@ gen_api_bundle_capnpn = rule(
         "declarations": attr.string_dict(),
         "data": attr.label_list(allow_files = True),
         "const_name": attr.string(mandatory = True),
+        "deps": attr.label_list(),
     },
 )
 
@@ -107,15 +111,14 @@ def _copy_modules(modules, declarations):
 
 def wd_js_bundle(
         name,
+        import_name,
         schema_id,
-        const_name,
-        builtin_modules = {},
-        internal_modules = {},
-        internal_wasm_modules = {},
-        internal_data_modules = {},
+        builtin_modules,
+        internal_modules = [],
+        internal_wasm_modules = [],
+        internal_data_modules = [],
         declarations = [],
-        **kwargs
-):
+        deps = []):
     """Generate cc capnp library with js api bundle.
 
     NOTE: Due to capnpc embed limitation all modules must be in the same or sub directory of the
@@ -123,47 +126,75 @@ def wd_js_bundle(
 
     Args:
      name: cc_capnp_library rule name
-     builtin_modules: js src label -> module name dictionary
-     internal_modules: js src label -> module name dictionary
-     internal_wasm_modules: wasm src label -> module name dictionary
-     internal_data_modules: data src label -> module name dictionary
-     declarations: d.ts label set
-     const_name: capnp constant name that will contain bundle definition
+     import_name: The js import specifier. builtin modules are accessible from
+                  user code under `<import_name>:<module_name>`, internal modules
+                  are accessible from builtin modules under
+                  `<import_name>-internal:<module_name>`
+                  The capnproto bundle object generated will be called
+                  `import_name` + "Bundle"
      schema_id: capnpn schema id
-     **kwargs: rest of cc_capnp_library arguments
+     builtin_modules: list of js source files for builtin modules
+     internal_modules: list of js source files for internal modules
+     internal_wasm_modules: list of wasm source files
+     internal_data_modules: list of data source files
+     declarations: d.ts label set
+     deps: dependency list
     """
+    builtin_modules_dict = {
+        m: "{}:{}".format(import_name, _to_name(m))
+        for m in builtin_modules
+    }
+    internal_modules_dict = {
+        m: "{}-internal:{}".format(import_name, _to_name(m.removeprefix("internal/")))
+        for m in internal_modules
+    }
+    internal_wasm_modules_dict = {
+        m: "{}-internal:{}".format(import_name, m.removeprefix("internal/"))
+        for m in internal_wasm_modules
+    }
+    internal_data_modules_dict = {
+        m: "{}-internal:{}".format(import_name, m.removeprefix("internal/"))
+        for m in internal_data_modules
+    }
 
-    builtin_modules, builtin_declarations = _copy_modules(builtin_modules, declarations)
-    internal_modules, internal_declarations = _copy_modules(
-        internal_modules, declarations
+    builtin_modules_dict, builtin_declarations = _copy_modules(
+        builtin_modules_dict,
+        declarations,
     )
-    internal_wasm_modules, _ = _copy_modules(
-        internal_wasm_modules, declarations
+    internal_modules_dict, internal_declarations = _copy_modules(
+        internal_modules_dict,
+        declarations,
     )
-    internal_data_modules, _ = _copy_modules(
-        internal_data_modules, declarations
+    internal_wasm_modules_dict, _ = _copy_modules(
+        internal_wasm_modules_dict,
+        declarations,
+    )
+    internal_data_modules_dict, _ = _copy_modules(
+        internal_data_modules_dict,
+        declarations,
     )
 
     data = (
-        list(builtin_modules)
-        + list(internal_modules)
-        + list(internal_wasm_modules)
-        + list(internal_data_modules)
-        + list(builtin_declarations.values())
-        + list(internal_declarations.values())
+        list(builtin_modules_dict) +
+        list(internal_modules_dict) +
+        list(internal_wasm_modules_dict) +
+        list(internal_data_modules_dict) +
+        list(builtin_declarations.values()) +
+        list(internal_declarations.values())
     )
 
     gen_api_bundle_capnpn(
         name = name + "@gen",
         out = name + ".capnp",
         schema_id = schema_id,
-        const_name = const_name,
-        builtin_modules = builtin_modules,
-        internal_modules = internal_modules,
-        internal_wasm_modules = internal_wasm_modules,
-        internal_data_modules = internal_data_modules,
+        const_name = import_name + "Bundle",
+        builtin_modules = builtin_modules_dict,
+        internal_modules = internal_modules_dict,
+        internal_wasm_modules = internal_wasm_modules_dict,
+        internal_data_modules = internal_data_modules_dict,
         declarations = builtin_declarations | internal_declarations,
         data = data,
+        deps = deps,
     )
 
     cc_capnp_library(
@@ -173,5 +204,5 @@ def wd_js_bundle(
         visibility = ["//visibility:public"],
         data = data,
         deps = ["@workerd//src/workerd/jsg:modules_capnp"],
-        **kwargs
+        include_prefix = import_name,
     )

--- a/build/wd_ts_bundle.bzl
+++ b/build/wd_ts_bundle.bzl
@@ -1,6 +1,6 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
-load("@workerd//:build/wd_js_bundle.bzl", "wd_js_bundle")
 load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
+load("@workerd//:build/wd_js_bundle.bzl", "wd_js_bundle")
 
 def _to_js(file_name):
     if file_name.endswith(".ts"):
@@ -9,9 +9,6 @@ def _to_js(file_name):
 
 def _to_d_ts(file_name):
     return file_name.removesuffix(".ts") + ".d.ts"
-
-def _to_name(file_name):
-    return file_name.removesuffix(".ts").removesuffix(".js")
 
 def wd_ts_bundle(
         name,
@@ -34,9 +31,11 @@ def wd_ts_bundle(
           "<import_name>-internal:<module_name>".
       schema_id: bundle capnp schema id,
       modules: list of js and ts source files for builtin modules
-      internal_modules: list of js and ts source files for internal modules
+      internal_modules: list of js, ts, and d.ts source files for internal modules
       tsconfig_json: tsconfig.json label
       eslintrc_json: eslintrc.json label
+      internal_wasm_modules: list of wasm source files
+      internal_data_modules: list of data source files
       lint: enables/disables source linting
       deps: additional typescript dependencies
     """
@@ -60,46 +59,17 @@ def wd_ts_bundle(
 
     wd_js_bundle(
         name = name,
+        import_name = import_name,
         # builtin modules are accessible under "<import_name>:<module_name>" name
-        builtin_modules = dict([(_to_js(m), import_name + ":" + _to_name(m)) for m in modules]),
-        const_name = import_name + "Bundle",
-        include_prefix = import_name,
+        builtin_modules = [_to_js(m) for m in modules],
         # internal modules are accessible under "<import_name>-internal:<module_name>" name
         # without "internal/" folder prefix.
-        internal_modules = dict(
-            [
-                (
-                    _to_js(m),
-                    import_name + "-internal:" + _to_name(m.removeprefix("internal/")),
-                )
-                for m in internal_modules
-                if not m.endswith(".d.ts")
-            ]
-        ),
-        internal_wasm_modules = dict(
-            [
-                (
-                    m,
-                    import_name
-                    + "-internal:"
-                    + m.removeprefix("internal/").removesuffix(".wasm"),
-                )
-                for m in internal_wasm_modules
-            ]
-        ),
-        internal_data_modules = dict(
-            [
-                (
-                    m,
-                    import_name
-                    + "-internal:"
-                    + m.removeprefix("internal/"),
-                )
-                for m in internal_data_modules
-            ]
-        ),
+        internal_modules = [_to_js(m) for m in internal_modules if not m.endswith(".d.ts")],
+        internal_wasm_modules = internal_wasm_modules,
+        internal_data_modules = internal_data_modules,
         declarations = declarations,
         schema_id = schema_id,
+        deps = deps,
     )
 
     if lint:


### PR DESCRIPTION
Before this build, `wd_ts_bundle` has a bunch of logic for generating module specifiers, renaming modules, naming the capnp bundle, etc. This makes it problematic to use `wd_js_bundle` directly because ideally we'd want to exactly match the conventions in `wd_ts_bundle`.

So this fixes it by moving this logic into `wd_js_bundle`.

Split off from #1467 per @mikea's request.