### PR TITLE
More perfetto instrumentation and fixes

### DIFF
--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -197,7 +197,7 @@ Worker::Script::Source WorkerdApi::extractSource(kj::StringPtr name,
     config::Worker::Reader conf,
     Worker::ValidationErrorReporter& errorReporter,
     capnp::List<config::Extension>::Reader extensions) {
-  TRACE_EVENT("workerd", "WorkerdApiIsolate::extractSource()");
+  TRACE_EVENT("workerd", "WorkerdApi::extractSource()");
   switch (conf.which()) {
     case config::Worker::MODULES: {
       auto modules = conf.getModules();
@@ -243,7 +243,7 @@ kj::Array<Worker::Script::CompiledGlobal> WorkerdApi::compileScriptGlobals(
       jsg::Lock& lockParam, config::Worker::Reader conf,
       Worker::ValidationErrorReporter& errorReporter,
       const jsg::CompilationObserver& observer) const {
-  TRACE_EVENT("workerd", "WorkerdApiIsolate::compileScriptGlobals()");
+  TRACE_EVENT("workerd", "WorkerdApi::compileScriptGlobals()");
   // For Service Worker scripts, we support Wasm modules as globals, but they need to be loaded
   // at script load time.
 
@@ -274,14 +274,14 @@ void WorkerdApi::compileModules(
     jsg::Lock& lockParam, config::Worker::Reader conf,
     Worker::ValidationErrorReporter& errorReporter,
     capnp::List<config::Extension>::Reader extensions) const {
-  TRACE_EVENT("workerd", "WorkerdApiIsolate::compileModules()");
+  TRACE_EVENT("workerd", "WorkerdApi::compileModules()");
   auto& lock = kj::downcast<JsgWorkerdIsolate::Lock>(lockParam);
   lockParam.withinHandleScope([&] {
     auto modules = jsg::ModuleRegistryImpl<JsgWorkerdIsolate_TypeWrapper>::from(lockParam);
 
     for (auto module: conf.getModules()) {
       auto path = kj::Path::parse(module.getName());
-      TRACE_EVENT("workerd", "WorkerdApiIsolate::compileModules() module",
+      TRACE_EVENT("workerd", "WorkerdApi::compileModules() module",
                   "path", path.toString(true).cStr());
 
       switch (module.which()) {
@@ -642,7 +642,7 @@ void WorkerdApi::compileGlobals(
     jsg::Lock& lockParam, kj::ArrayPtr<const Global> globals,
     v8::Local<v8::Object> target,
     uint32_t ownerId) const {
-  TRACE_EVENT("workerd", "WorkerdApiIsolate::compileGlobals()");
+  TRACE_EVENT("workerd", "WorkerdApi::compileGlobals()");
   auto& lock = kj::downcast<JsgWorkerdIsolate::Lock>(lockParam);
   lockParam.withinHandleScope([&] {
     auto& featureFlags = *impl->features;

--- a/src/workerd/util/perfetto-tracing.c++
+++ b/src/workerd/util/perfetto-tracing.c++
@@ -81,8 +81,8 @@ struct PerfettoSession::Impl {
   kj::AutoCloseFd fd;
   std::unique_ptr<perfetto::TracingSession> session;
 
-  Impl(int fd, kj::StringPtr categories)
-      : fd(fd), session(createTracingSession(fd, categories)) {
+  Impl(kj::AutoCloseFd dest, kj::StringPtr categories)
+      : fd(kj::mv(dest)), session(createTracingSession(fd.get(), categories)) {
     session->StartBlocking();
   }
 };
@@ -91,7 +91,7 @@ PerfettoSession::PerfettoSession(kj::StringPtr path, kj::StringPtr categories)
     : impl(kj::heap<Impl>(openTraceFile(path), categories)) {}
 
 PerfettoSession::PerfettoSession(int fd, kj::StringPtr categories)
-    : impl(kj::heap<Impl>(fd, categories)) {}
+    : impl(kj::heap<Impl>(kj::AutoCloseFd(fd), categories)) {}
 
 PerfettoSession::~PerfettoSession() noexcept(false) {
   if (impl) {

--- a/src/workerd/util/perfetto-tracing.h
+++ b/src/workerd/util/perfetto-tracing.h
@@ -42,10 +42,15 @@ private:
   friend constexpr bool _kj_internal_isPolymorphic(PerfettoSession::Impl*);
 };
 
+#define PERFETTO_FLOW_FROM_POINTER(ptr) perfetto::Flow::FromPointer(ptr)
+#define PERFETTO_TERMINATING_FLOW_FROM_POINTER(ptr) perfetto::TerminatingFlow::FromPointer(ptr)
+#define PERFETTO_TRACK_FROM_POINTER(ptr) perfetto::Track::FromPointer(ptr)
+
 KJ_DECLARE_NON_POLYMORPHIC(PerfettoSession::Impl);
 }  // workerd
 
 #else  // defined(WORKERD_USE_PERFETTO)
+struct PerfettoNoop {};
 // We define non-op versions of the instrumentation macros here so that we can
 // still instrument and build when perfetto is not enabled.
 #define TRACE_EVENT(...)
@@ -54,4 +59,7 @@ KJ_DECLARE_NON_POLYMORPHIC(PerfettoSession::Impl);
 #define TRACE_EVENT_INSTANT(...)
 #define TRACE_COUNTER(...)
 #define TRACE_EVENT_CATEGORY_ENABLED(...) false
+#define PERFETTO_FLOW_FROM_POINTER(ptr) PerfettoNoop {}
+#define PERFETTO_TERMINATING_FLOW_FROM_POINTER(ptr) PerfettoNoop {}
+#define PERFETTO_TRACK_FROM_POINTER(ptr) PerfettoNoop {}
 #endif  // defined(WORKERD_USE_PERFETTO)


### PR DESCRIPTION
Fixes a minor bug in the workerd perfetto fd tracking and adds more spans to worker-entrypoint for illustration.

This starts to make use of custom tracks and flows to track activity through kj promises ... 

![image](https://github.com/cloudflare/workerd/assets/439929/0a0368a0-083d-4436-bf8a-510805b96bba)
![image](https://github.com/cloudflare/workerd/assets/439929/3ac1bc38-bcb5-4ab6-8aa0-2cd1d40774ef)
![image](https://github.com/cloudflare/workerd/assets/439929/ff4ca2c9-85ab-48be-9751-4f8e8cd59ab9)

