### PR TITLE
Additional minor cleanups for worker.h

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -22,6 +22,7 @@
 #include <workerd/api/util.h>
 #include <workerd/util/stream-utils.h>
 #include <workerd/util/use-perfetto-categories.h>
+#include <workerd/util/uncaught-exception-source.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -13,6 +13,7 @@
 #include <workerd/util/thread-scopes.h>
 #include <workerd/util/own-util.h>
 #include <workerd/util/uuid.h>
+#include <workerd/util/uncaught-exception-source.h>
 
 namespace workerd::api {
 

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -9,6 +9,7 @@
 #include <kj/debug.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/util/sentry.h>
+#include <workerd/util/uncaught-exception-source.h>
 #include <map>
 
 namespace workerd {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -25,6 +25,7 @@
 #include <workerd/io/limit-enforcer.h>
 #include <workerd/io/io-channels.h>
 #include <workerd/util/perfetto-tracing.h>
+#include <workerd/util/uncaught-exception-source.h>
 
 namespace capnp { class HttpOverCapnpFactory; }
 

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -11,6 +11,7 @@
 #include <workerd/util/sentry.h>
 #include <workerd/util/thread-scopes.h>
 #include <workerd/util/use-perfetto-categories.h>
+#include <workerd/util/uncaught-exception-source.h>
 #include <kj/compat/http.h>
 
 namespace workerd {

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3279,6 +3279,14 @@ kj::Maybe<uint16_t> Worker::Actor::getHibernationEventType() {
   return impl->hibernationEventType;
 }
 
+kj::Own<Worker::Actor> Worker::Actor::addRef() {
+  KJ_IF_SOME(t, tracker) {
+    return kj::addRef(*this).attach(t.get()->startRequest());
+  } else {
+    return kj::addRef(*this);
+  }
+}
+
 // =======================================================================================
 
 uint Worker::Isolate::getCurrentLoad() const {

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -114,18 +114,6 @@ const capnp::JsonCodec& getCdpJsonCodec() {
 
 // =======================================================================================
 
-kj::StringPtr KJ_STRINGIFY(UncaughtExceptionSource value) {
-  switch (value) {
-    case UncaughtExceptionSource::INTERNAL:         return "Uncaught"_kj;
-    case UncaughtExceptionSource::INTERNAL_ASYNC:   return "Uncaught (in promise)"_kj;
-    case UncaughtExceptionSource::ASYNC_TASK:       return "Uncaught (async)"_kj;
-    case UncaughtExceptionSource::REQUEST_HANDLER:  return "Uncaught (in response)"_kj;
-    case UncaughtExceptionSource::TRACE_HANDLER:    return "Uncaught (in trace)"_kj;
-    case UncaughtExceptionSource::ALARM_HANDLER:    return "Uncaught (in alarm)"_kj;
-  };
-  KJ_UNREACHABLE;
-}
-
 namespace {
 
 // Inform the inspector of an exception thrown.

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -21,6 +21,7 @@
 #include <workerd/io/actor-cache.h>  // because we can't forward-declare ActorCache::SharedLru.
 #include <workerd/util/weak-refs.h>
 #include <workerd/util/thread-scopes.h>
+#include <workerd/util/uncaught-exception-source.h>
 
 namespace v8 { class Isolate; }
 
@@ -464,19 +465,6 @@ public:
     // By default does nothing.
   }
 };
-
-enum class UncaughtExceptionSource {
-  INTERNAL,
-  INTERNAL_ASYNC,
-  // We catch, log, and rethrow some exceptions at these intermediate levels, in case higher-level
-  // handlers fail.
-
-  ASYNC_TASK,
-  REQUEST_HANDLER,
-  TRACE_HANDLER,
-  ALARM_HANDLER,
-};
-kj::StringPtr KJ_STRINGIFY(UncaughtExceptionSource value);
 
 // A Worker may bounce between threads as it handles multiple requests, but can only actually
 // execute on one thread at a time. Each thread must therefore lock the Worker while executing

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -105,10 +105,11 @@ public:
   ~Worker() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(Worker);
 
-  const Script& getScript() const { return *script; }
-  const Isolate& getIsolate() const;
+  inline const Script& getScript() const { return *script; }
 
-  const WorkerObserver& getMetrics() const { return *metrics; }
+  inline const Isolate& getIsolate() const;
+
+  inline const WorkerObserver& getMetrics() const { return *metrics; }
 
   class Lock;
 
@@ -180,9 +181,8 @@ public:
   KJ_DISALLOW_COPY_AND_MOVE(Script);
 
   inline kj::StringPtr getId() const { return id; }
-  const Isolate& getIsolate() const { return *isolate; }
-
-  bool isModular() const { return modular; }
+  inline const Isolate& getIsolate() const { return *isolate; }
+  inline bool isModular() const { return modular; }
 
   struct CompiledGlobal {
     jsg::V8Ref<v8::String> name;
@@ -264,7 +264,7 @@ public:
   ~Isolate() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(Isolate);
 
-  const IsolateObserver& getMetrics() const { return *metrics; }
+  inline const IsolateObserver& getMetrics() const { return *metrics; }
 
   inline kj::StringPtr getId() const { return id; }
 
@@ -274,9 +274,9 @@ public:
       IsolateObserver::StartType startType, bool logNewScript = false,
       kj::Maybe<ValidationErrorReporter&> errorReporter = kj::none) const;
 
-  const IsolateLimitEnforcer& getLimitEnforcer() const { return *limitEnforcer; }
+  inline const IsolateLimitEnforcer& getLimitEnforcer() const { return *limitEnforcer; }
 
-  const Api& getApi() const { return *api; }
+  inline const Api& getApi() const { return *api; }
 
   // Returns the number of threads currently blocked trying to lock this isolate's mutex (using
   // takeAsyncLock()).
@@ -314,7 +314,7 @@ public:
       kj::HttpHeaderId contentEncodingHeaderId,
       RequestObserver& requestMetrics) const;
 
-  kj::Maybe<kj::StringPtr> getFeatureFlagsForFl() const {
+  inline kj::Maybe<kj::StringPtr> getFeatureFlagsForFl() const {
     return featureFlagsForFl;
   }
 
@@ -712,7 +712,7 @@ public:
   // Only needs to be called when allocating a HibernationManager!
   kj::Maybe<uint16_t> getHibernationEventType();
 
-  const Worker& getWorker() { return *worker; }
+  inline const Worker& getWorker() { return *worker; }
 
   void assertCanSetAlarm();
   kj::Promise<void> makeAlarmTaskForPreview(kj::Date scheduledTime);
@@ -729,13 +729,8 @@ public:
   // cancelling it).
   kj::Promise<WorkerInterface::ScheduleAlarmResult> scheduleAlarm(kj::Date scheduledTime);
 
-  kj::Own<Worker::Actor> addRef() {
-    KJ_IF_SOME(t, tracker) {
-      return kj::addRef(*this).attach(t.get()->startRequest());
-    } else {
-      return kj::addRef(*this);
-    }
-  }
+  kj::Own<Worker::Actor> addRef();
+
 private:
   kj::Promise<WorkerInterface::ScheduleAlarmResult> handleAlarm(kj::Date scheduledTime);
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -75,7 +75,6 @@ public:
   class Script;
   class Isolate;
   class Api;
-  using ApiIsolate [[deprecated("Use Workerd::Api")]] = Api;
 
   class ValidationErrorReporter {
   public:
@@ -278,7 +277,6 @@ public:
   const IsolateLimitEnforcer& getLimitEnforcer() const { return *limitEnforcer; }
 
   const Api& getApi() const { return *api; }
-  [[deprecated("use getApi()")]] const Api& getApiIsolate() const { return *api; }
 
   // Returns the number of threads currently blocked trying to lock this isolate's mutex (using
   // takeAsyncLock()).

--- a/src/workerd/util/uncaught-exception-source.h
+++ b/src/workerd/util/uncaught-exception-source.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <kj/string.h>
+
+namespace workerd {
+
+enum class UncaughtExceptionSource {
+  INTERNAL,
+  INTERNAL_ASYNC,
+  // We catch, log, and rethrow some exceptions at these intermediate levels, in case higher-level
+  // handlers fail.
+
+  ASYNC_TASK,
+  REQUEST_HANDLER,
+  TRACE_HANDLER,
+  ALARM_HANDLER,
+};
+
+inline kj::StringPtr KJ_STRINGIFY(UncaughtExceptionSource value) {
+  switch (value) {
+    case UncaughtExceptionSource::INTERNAL:         return "Uncaught"_kj;
+    case UncaughtExceptionSource::INTERNAL_ASYNC:   return "Uncaught (in promise)"_kj;
+    case UncaughtExceptionSource::ASYNC_TASK:       return "Uncaught (async)"_kj;
+    case UncaughtExceptionSource::REQUEST_HANDLER:  return "Uncaught (in response)"_kj;
+    case UncaughtExceptionSource::TRACE_HANDLER:    return "Uncaught (in trace)"_kj;
+    case UncaughtExceptionSource::ALARM_HANDLER:    return "Uncaught (in alarm)"_kj;
+  };
+  KJ_UNREACHABLE;
+}
+
+}  // namespace workerd


### PR DESCRIPTION
The headers are generally cleaned up. Will be turning attention to splitting more of the v8::Inspector stuff out of the worker.c++ file.