### PR TITLE
Implement `abortAllDurableObjects()` function

### DIFF
--- a/src/workerd/api/modules.h
+++ b/src/workerd/api/modules.h
@@ -9,6 +9,7 @@
 #include <workerd/api/pyodide/pyodide.h>
 #include <workerd/api/rtti.h>
 #include <workerd/api/sockets.h>
+#include <workerd/api/unsafe.h>
 #include <workerd/io/worker.h>
 #include <cloudflare/cloudflare.capnp.h>
 
@@ -21,6 +22,9 @@ void registerModules(Registry& registry, auto featureFlags) {
   registerUnsafeModules(registry, featureFlags);
   if (featureFlags.getRttiApi()) {
     registerRTTIModule(registry);
+  }
+  if (featureFlags.getUnsafeModule()) {
+    registerUnsafeModule(registry);
   }
   registerSocketsModule(registry, featureFlags);
   registry.addBuiltinBundle(CLOUDFLARE_BUNDLE);

--- a/src/workerd/api/unsafe.c++
+++ b/src/workerd/api/unsafe.c++
@@ -99,4 +99,11 @@ jsg::JsValue UnsafeEval::newWasmModule(jsg::Lock& js, kj::Array<kj::byte> src) {
   return jsg::JsValue(jsg::check(maybeWasmModule));
 }
 
+jsg::Promise<void> UnsafeModule::abortAllDurableObjects(jsg::Lock& js) {
+  auto& context = IoContext::current();
+  // Abort all actors asynchronously to avoid recursively taking isolate lock in actor destructor
+  auto promise = kj::evalLater([&] () { return context.abortAllActors(); });
+  return context.awaitIo(js, kj::mv(promise));
+}
+
 } // namespace workerd::api

--- a/src/workerd/api/unsafe.h
+++ b/src/workerd/api/unsafe.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <workerd/jsg/jsg.h>
+#include <workerd/io/io-context.h>
 
 namespace workerd::api {
 
@@ -59,7 +60,23 @@ public:
   }
 };
 
-#define EW_UNSAFE_ISOLATE_TYPES api::UnsafeEval
+class UnsafeModule: public jsg::Object {
+public:
+  jsg::Promise<void> abortAllDurableObjects(jsg::Lock& js);
+
+  JSG_RESOURCE_TYPE(UnsafeModule) {
+    JSG_METHOD(abortAllDurableObjects);
+  }
+};
+
+template <class Registry>
+void registerUnsafeModule(Registry& registry) {
+  registry.template addBuiltinModule<UnsafeModule>("workerd:unsafe",
+    workerd::jsg::ModuleRegistry::Type::BUILTIN);
+}
+
+#define EW_UNSAFE_ISOLATE_TYPES api::UnsafeEval, \
+  api::UnsafeModule
 
 template <class Registry> void registerUnsafeModules(Registry& registry, auto featureFlags) {
   registry.template addBuiltinModule<UnsafeEval>("internal:unsafe-eval",

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -346,4 +346,11 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatDisableFlag("vectorize_query_original");
   # Vectorize query option change to allow returning of metadata to be optional. Accompanying this:
   # a return format change to move away from a nested object with the VectorizeVector.
+
+  unsafeModule @38 :Bool
+      $compatEnableFlag("unsafe_module")
+      $experimental;
+  # Enables the `workerd:unsafe` module for performing dangerous operations from JavaScript.
+  # Intended for local development and testing use cases. Currently just supports aborting all
+  # Durable Objects running in a `workerd` process.
 }

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -6,6 +6,7 @@
 
 #include "actor-id.h"
 #include <kj/string.h>
+#include <kj/debug.h>
 #include <workerd/io/trace.h>
 
 namespace kj { class HttpClient; }
@@ -147,6 +148,11 @@ public:
   // Get an actor stub from the given namespace for the actor with the given name.
   virtual kj::Own<ActorChannel> getColoLocalActor(uint channel, kj::StringPtr id,
       SpanParent parentSpan) = 0;
+
+  // Aborts all actors except those in namespaces marked with `preventEviction`.
+  virtual void abortAllActors() {
+    KJ_UNIMPLEMENTED("Only implemented by single-tenant workerd runtime");
+  }
 };
 
 } // namespace workerd

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -639,6 +639,10 @@ public:
     return getIoChannelFactory().getColoLocalActor(channel, id, kj::mv(parentSpan));
   }
 
+  void abortAllActors() {
+    return getIoChannelFactory().abortAllActors();
+  }
+
   // Get an HttpClient to use for Cache API subrequests.
   kj::Own<CacheClient> getCacheClient();
 

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -178,6 +178,9 @@ private:
       kj::HttpHeaderTable::Builder& headerTableBuilder,
       capnp::List<config::Extension>::Reader extensions);
 
+  // Aborts all actors in this server except those in namespaces marked with `preventEviction`.
+  void abortAllActors();
+
   // Can only be called in the link stage.
   Service& lookupService(config::ServiceDesignator::Reader designator, kj::String errorContext);
 

--- a/src/workerd/server/tests/unsafe-module/BUILD.bazel
+++ b/src/workerd/server/tests/unsafe-module/BUILD.bazel
@@ -1,0 +1,10 @@
+load("//:build/wd_test.bzl", "wd_test")
+
+wd_test(
+    src = "unsafe-module-test.wd-test",
+    data = glob([
+        "*.js",
+        "*.capnp",
+    ]),
+    args = ["--experimental"],
+)

--- a/src/workerd/server/tests/unsafe-module/unsafe-module-test.js
+++ b/src/workerd/server/tests/unsafe-module/unsafe-module-test.js
@@ -1,0 +1,55 @@
+import assert from "node:assert";
+import unsafe from "workerd:unsafe";
+
+function createTestObject(type) {
+  return class {
+    id = crypto.randomUUID();
+    fetch() {
+      return new Response(`${type}:${this.id}`);
+    }
+  }
+}
+export const TestDurableObject = createTestObject("durable");
+export const TestDurableObjectPreventEviction = createTestObject("durable-prevent-eviction");
+export const TestEphemeralObject = createTestObject("ephemeral");
+export const TestEphemeralObjectPreventEviction = createTestObject("ephemeral-prevent-eviction");
+
+export const test_abort_all_durable_objects = {
+  async test(ctrl, env, ctx) {
+    const durableId = env.DURABLE.newUniqueId();
+    const durablePreventEvictionId = env.DURABLE_PREVENT_EVICTION.newUniqueId();
+
+    const durableStub = env.DURABLE.get(durableId);
+    const durablePreventEvictionStub = env.DURABLE_PREVENT_EVICTION.get(durablePreventEvictionId);
+    const ephemeralStub = env.EPHEMERAL.get("thing");
+    const ephemeralPreventEvictionStub = env.EPHEMERAL_PREVENT_EVICTION.get("thing");
+
+    const durableRes1 = await (await durableStub.fetch("http://x")).text();
+    const durablePreventEvictionRes1 = await (await durablePreventEvictionStub.fetch("http://x")).text();
+    const ephemeralRes1 = await (await ephemeralStub.fetch("http://x")).text();
+    const ephemeralPreventEvictionRes1 = await (await ephemeralPreventEvictionStub.fetch("http://x")).text();
+
+    await unsafe.abortAllDurableObjects();
+
+    const durableRes2 = await (await durableStub.fetch("http://x")).text();
+    const durablePreventEvictionRes2 = await (await durablePreventEvictionStub.fetch("http://x")).text();
+    const ephemeralRes2 = await (await ephemeralStub.fetch("http://x")).text();
+    const ephemeralPreventEvictionRes2 = await (await ephemeralPreventEvictionStub.fetch("http://x")).text();
+
+    // Irrespective of abort status, verify responses start with expected prefix
+    assert.match(durableRes1, /^durable:/);
+    assert.match(durableRes2, /^durable:/);
+    assert.match(durablePreventEvictionRes1, /^durable-prevent-eviction:/);
+    assert.match(ephemeralRes1, /^ephemeral:/);
+    assert.match(ephemeralRes2, /^ephemeral:/);
+    assert.match(ephemeralPreventEvictionRes1, /^ephemeral-prevent-eviction:/);
+
+    // Response from aborted objects should change
+    assert.notStrictEqual(durableRes1, durableRes2);
+    assert.notStrictEqual(ephemeralRes1, ephemeralRes2);
+
+    // Response from objects in namespaces that have prevent eviction set shouldn't change
+    assert.strictEqual(durablePreventEvictionRes1, durablePreventEvictionRes2);
+    assert.strictEqual(ephemeralPreventEvictionRes1, ephemeralPreventEvictionRes2);
+  }
+}

--- a/src/workerd/server/tests/unsafe-module/unsafe-module-test.wd-test
+++ b/src/workerd/server/tests/unsafe-module/unsafe-module-test.wd-test
@@ -1,0 +1,28 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "unsafe-module-test",
+      worker = (
+        modules = [
+          ( name = "worker", esModule = embed "unsafe-module-test.js" ),
+        ],
+        compatibilityDate = "2023-12-06",
+        compatibilityFlags = ["nodejs_compat", "unsafe_module"],
+        durableObjectNamespaces = [
+          ( className = "TestDurableObject", uniqueKey = "durable" ),
+          ( className = "TestDurableObjectPreventEviction", uniqueKey = "durable-prevent-eviction", preventEviction = true ),
+          ( className = "TestEphemeralObject", ephemeralLocal = void ),
+          ( className = "TestEphemeralObjectPreventEviction", ephemeralLocal = void, preventEviction = true ),
+        ],
+        durableObjectStorage = (inMemory = void),
+        bindings = [
+          ( name = "DURABLE", durableObjectNamespace = "TestDurableObject" ),
+          ( name = "DURABLE_PREVENT_EVICTION", durableObjectNamespace = "TestDurableObjectPreventEviction" ),
+          ( name = "EPHEMERAL", durableObjectNamespace = "TestEphemeralObject" ),
+          ( name = "EPHEMERAL_PREVENT_EVICTION", durableObjectNamespace = "TestEphemeralObjectPreventEviction" ),
+        ],
+     )
+    ),
+  ],
+);


### PR DESCRIPTION
Hey! 👋 This PR implements a function for aborting all Durable Objects in the current `workerd` process, except those marked with `preventEviction`. We're currently porting Miniflare 2's Vitest unit testing environment to Miniflare 3, and would like a function like this for a couple of reasons:

1. Vitest ideally needs to reuse the same `workerd` process between test reruns. This is so it can retain its module cache and only rerun tests that have had their dependencies changed (effectively HMR for tests). The `workerd` process takes just about a second to startup and initialise Vitest too, so we don't really want to be doing this on each rerun. Even though we're reusing processes, we'd like each test rerun to execute in a clean environment, **including Durable Object in-memory state**. This means we need some way of evicting all previously created Durable Objects (except those managing the WebSocket RPC connection with Node.js). Resetting `setTimeout()`s, outbound requests, etc created in the Durable Object also means these won't interfere with future test runs.
2. Miniflare 2 previously supported [isolated per-test storage](https://legacy.miniflare.dev/testing/vitest#isolated-storage). Effectively, any storage write operations performed in a test were undone at the end of the test. We previously implemented this with SQLite `SAVEPOINT`s, but it looks like this approach might be tricky to implement with `workerd`'s SQLite-backed Durable Object storage. Instead, we have a solution working by "pushing" `.sqlite` files to an on-disk stack at the start of tests, and "popping" them afterwards. Aborting all objects before the "push" operation causes an implicit WAL checkpoint, meaning we only need to copy the `.sqlite` file, and not the WAL.