### PR TITLE
Convert script version ID capnp representation to UUID.

### DIFF
--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -47,6 +47,7 @@ private:
 
 struct ScriptVersion {
   explicit ScriptVersion(workerd::ScriptVersion::Reader version);
+  ScriptVersion(const ScriptVersion&);
 
   jsg::Optional<kj::String> id;
   jsg::Optional<kj::String> tag;
@@ -109,7 +110,7 @@ private:
   kj::Array<jsg::Ref<TraceException>> exceptions;
   kj::Array<jsg::Ref<TraceDiagnosticChannelEvent>> diagnosticChannelEvents;
   kj::Maybe<kj::String> scriptName;
-  kj::Maybe<kj::Own<workerd::ScriptVersion::Reader>> scriptVersion;
+  kj::Maybe<ScriptVersion> scriptVersion;
   kj::Maybe<kj::String> dispatchNamespace;
   jsg::Optional<kj::Array<kj::String>> scriptTags;
   kj::String outcome;

--- a/src/workerd/io/script-version.capnp
+++ b/src/workerd/io/script-version.capnp
@@ -8,10 +8,15 @@ using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("workerd");
 
 struct ScriptVersion {
-  id @0 :Text;
-  # An ID that should be used to uniquely identify this version.
-  tag @1 :Text;
+  id :group {
+    upper @0 :UInt64;
+    # Most significant bits of the UUID.
+    lower @1 :UInt64;
+    # Least significant bits of the UUID.
+  }
+  # A UUID identifying this version.
+  tag @2 :Text;
   # An optional tag to associate with this version.
-  message @2 :Text;
+  message @3 :Text;
   # An optional message that can be used to describe this version.
 }

--- a/src/workerd/util/uuid-test.c++
+++ b/src/workerd/util/uuid-test.c++
@@ -1,0 +1,23 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "uuid.h"
+#include <kj/test.h>
+
+namespace workerd {
+namespace {
+
+KJ_TEST("UUIDToString") {
+  KJ_EXPECT(UUIDToString(0ull, 0ull) ==
+      "00000000-0000-0000-0000-000000000000");
+  KJ_EXPECT(UUIDToString(72340172838076673ull, 1157442765409226768ull) ==
+      "01010101-0101-0101-1010-101010101010");
+  KJ_EXPECT(UUIDToString(81985529216486895ull, 81985529216486895ull) ==
+      "01234567-89ab-cdef-0123-456789abcdef");
+  KJ_EXPECT(UUIDToString(16045690984833335023ull, 16045690984833335023ull) ==
+      "deadbeef-dead-beef-dead-beefdeadbeef");
+}
+
+}  // namespace
+}  // namespace workerd

--- a/src/workerd/util/uuid.c++
+++ b/src/workerd/util/uuid.c++
@@ -8,6 +8,9 @@
 #include <kj/debug.h>
 
 namespace workerd {
+namespace {
+constexpr char HEX_DIGITS[] = "0123456789abcdef";
+}  // namespace
 
 kj::String randomUUID(kj::Maybe<kj::EntropySource&> optionalEntropySource) {
   kj::byte buffer[16];
@@ -19,8 +22,6 @@ kj::String randomUUID(kj::Maybe<kj::EntropySource&> optionalEntropySource) {
   }
   buffer[6] = kj::byte((buffer[6] & 0x0f) | 0x40);
   buffer[8] = kj::byte((buffer[8] & 0x3f) | 0x80);
-
-  static constexpr char HEX_DIGITS[] = "0123456789abcdef";
 
 #define HEX(b) (char)(HEX_DIGITS[(b >> 4) & 0xf]), (char)(HEX_DIGITS[b & 0xf])
 
@@ -66,6 +67,49 @@ kj::String randomUUID(kj::Maybe<kj::EntropySource&> optionalEntropySource) {
   ));
 
 #undef HEX
+}
+
+kj::String UUIDToString(uint64_t upper, uint64_t lower) {
+  // clang-format off
+  return kj::str(
+    HEX_DIGITS[(upper >> 60u) & 0xf],
+    HEX_DIGITS[(upper >> 56u) & 0xf],
+    HEX_DIGITS[(upper >> 52u) & 0xf],
+    HEX_DIGITS[(upper >> 48u) & 0xf],
+    HEX_DIGITS[(upper >> 44u) & 0xf],
+    HEX_DIGITS[(upper >> 40u) & 0xf],
+    HEX_DIGITS[(upper >> 36u) & 0xf],
+    HEX_DIGITS[(upper >> 32u) & 0xf],
+    '-',
+    HEX_DIGITS[(upper >> 28u) & 0xf],
+    HEX_DIGITS[(upper >> 24u) & 0xf],
+    HEX_DIGITS[(upper >> 20u) & 0xf],
+    HEX_DIGITS[(upper >> 16u) & 0xf],
+    '-',
+    HEX_DIGITS[(upper >> 12u) & 0xf],
+    HEX_DIGITS[(upper >>  8u) & 0xf],
+    HEX_DIGITS[(upper >>  4u) & 0xf],
+    HEX_DIGITS[(upper >>  0u) & 0xf],
+    '-',
+    HEX_DIGITS[(lower >> 60u) & 0xf],
+    HEX_DIGITS[(lower >> 56u) & 0xf],
+    HEX_DIGITS[(lower >> 52u) & 0xf],
+    HEX_DIGITS[(lower >> 48u) & 0xf],
+    '-',
+    HEX_DIGITS[(lower >> 44u) & 0xf],
+    HEX_DIGITS[(lower >> 40u) & 0xf],
+    HEX_DIGITS[(lower >> 36u) & 0xf],
+    HEX_DIGITS[(lower >> 32u) & 0xf],
+    HEX_DIGITS[(lower >> 28u) & 0xf],
+    HEX_DIGITS[(lower >> 24u) & 0xf],
+    HEX_DIGITS[(lower >> 20u) & 0xf],
+    HEX_DIGITS[(lower >> 16u) & 0xf],
+    HEX_DIGITS[(lower >> 12u) & 0xf],
+    HEX_DIGITS[(lower >>  8u) & 0xf],
+    HEX_DIGITS[(lower >>  4u) & 0xf],
+    HEX_DIGITS[(lower >>  0u) & 0xf]
+  );
+  // clang-format on
 }
 
 }

--- a/src/workerd/util/uuid.h
+++ b/src/workerd/util/uuid.h
@@ -14,4 +14,10 @@ namespace workerd {
 // source, it is safe to assume that the output of this function is unique.
 kj::String randomUUID(kj::Maybe<kj::EntropySource&> optionalEntropySource);
 
+// Convert a UUID represented by two 64-bit integers to a string in the 8-4-4-4-12 format i.e.
+// a dash-separated hex string in the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+// The `upper` parameter represents the most signficant bits and `lower` the least significant bits
+// of the UUID value.
+kj::String UUIDToString(uint64_t upper, uint64_t lower);
+
 }


### PR DESCRIPTION
We want to constrain the ID to be a UUID so let's enforce that constraint in the capnp interface.