### PR TITLE
Update README for SQLite patches.

### DIFF
--- a/patches/sqlite/README
+++ b/patches/sqlite/README
@@ -1,39 +1,18 @@
-The patches for SQLite are a bit weird due to SQLite's idiosyncratic
-build process.
+The patches for SQLite are applied against the plain source, not the
+amalgamated source.
 
 SQLite comes in two forms. First, there's the "plain" form. It looks a
 lot like a typical open-source C project: there's a bunch of .c and .h
 files, a Makefile, a configure script, and various other files.
+workerd consumes this form.
 
 Second, there's the "amalgamation". This is all of SQLite combined
-into two .c and two .h files. workerd consumes this form.
+into two .c and two .h files. https://www.sqlite.org/download.html
+puts the amalgamation front and center, but don't be fooled.
 
-workerd has to patch SQLite, hence the patches in this directory.
-Patching the amalgamation is painful. The vast majority of the code is
-in a single 250,000-line .c file. Some pieces of code are duplicated
-in the building of the amalgamation, so both spots need patching.
-SQLite's tests are not included in the amalgamation, so testing an
-amalgamation patch is hard.
-
-Making workerd consume the plain form would also be painful. To build
-the amalgamation, SQLite uses a parser generator, a handful of
-utilities written in C, and a whole lot of tclsh scripts all invoked
-by a Makefile. To build all this from Bazel, we would need to either
-rewrite tens of thousands of lines of TCL or include TCL as a build
-dependency of workerd.
-
-Instead, we have this compromise solution. Each patch in here is
-duplicated: one copy for the plain form and one for the amalgamation.
-Bazel downloads the SQLite amalgamation and patches it.
-
-To update to a new SQLite version, obtain the new SQLite in both plain
-and amalgamated forms. Apply the plain-form patch to SQLite, fixing as
-necessary, and replace the plain-form patch with the fixed version.
-
-Then, use the patched SQLite to build an amalgamation. Diff that
-against the downloaded amalgamation to produce a new amalgamated-form
-patch, and replace the existing amalgamated patch with the new one.
-
+To update to a new SQLite version, obtain the new SQLite in plain
+form. Apply the patches to SQLite, fixing as necessary, and replace
+any patches that needed modification with their fixed versions.
 
 Example, assuming the new SQLite has been downloaded into the current
 directory:
@@ -42,9 +21,6 @@ $ unzip sqlite-src-$VERSION.zip
 $ mv sqlite-src-$VERSION sqlite-src-pristine
 $ unzip sqlite-src-$VERSION.zip  # yes, again
 $ mv sqlite-src-$VERSION sqlite-src-modified
-$ unzip sqlite-amalgamation-$VERSION.zip
-$ mv sqlite-amalgamation-$VERSION.zip sqlite-amalgamation-pristine
-$ mkdir sqlite-amalgamation-modified
 
 Now patch:
 
@@ -57,13 +33,5 @@ Make sure the tests pass. If the patch needed any modification, regenerate it:
 $ diff -u5 -r sqlite-src-pristine sqlite-src-modified \
     | grep -v "Only in sqlite-src-modified" \
     > /path/to/workerd/patches/sqlite/0001-row-counts-plain.patch
-
-Build the amalagamation and the patch:
-
-$ make sqlite3.c sqlite3.h sqlite3ext.h shell.c
-$ cp shell.c sqlite3.c sqlite3.h sqlite3ext.h ../sqlite-amalgamation-modified/
-$ cd ..
-$ diff -u5 -r sqlite-amalgamation-pristine sqlite-amalgamation-modified \
-    > /path/to/workerd/patches/sqlite/0001-row-counts-amalgamation.patch
 
 Repeat for each patch.


### PR DESCRIPTION
Commit 2c81b17a stopped workerd from using the SQLite amalgamation, making this README stale. I've updated it to remove all the now-useless bits about patching the amalgamation.