### PR TITLE
Upgrade to Xcode 15, avoid duplicate unwind info on x86 macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -144,6 +144,13 @@ build:macos --config=unix
 # TODO (cleanup): macOS 11.X is now EOL, bump this to macOS 12.5 soon.
 build:macos --macos_minimum_os=11.5 --host_macos_minimum_os=11.5
 
+# Avoid emitting duplicate unwind info where compact unwind info can be used. This reduces the
+# object size by ~5% on average, improving disk space usage and link times. The final binary size
+# is not affected. Note that this is on-by-default on arm64, but turning it on for all mac builds
+# is easier than adding the flag only on x86. See https://reviews.llvm.org/D122258 for detailed
+# information on the flag.
+build:macos --copt='-femit-dwarf-unwind=no-compact-unwind'
+
 # On Linux, always link libc++ statically to avoid compatibility issues with different OS versions.
 # macOS links with dynamic libc++ by default, which has good backwards compatibility.
 build:linux --cxxopt='-stdlib=libc++' --host_cxxopt='-stdlib=libc++'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Setup macOS
         if: runner.os == 'macOS'
         run: |
-          sudo xcode-select -s "/Applications/Xcode_14.3.1.app"
+          sudo xcode-select -s "/Applications/Xcode_15.1.app"
       - name: Setup Windows
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,8 @@ jobs:
         # libc++, but this appears to cause errors so they are also being explicitly installed.
         # Since the GitHub runner image comes with a number of preinstalled packages, we don't need
         # to use APT much otherwise.
+        # TODO(cleanup): Upgrade this to LLVM 16 as soon as it is available on the latest Ubuntu
+        # LTS release. Debian includes LLVM 16 since the Bookworm 12.4 point release.
         run: |
           export DEBIAN_FRONTEND=noninteractive
           wget https://apt.llvm.org/llvm.sh
@@ -71,16 +73,16 @@ jobs:
           sed -i -e "s%llvm-symbolizer%/usr/lib/llvm-15/bin/llvm-symbolizer%" .bazelrc
       - name: Setup macOS
         if: matrix.os.name == 'macOS'
-        # TODO: We want to symbolize stacks for crashes on CI. Xcode is currently based on LLVM 15
+        # TODO: We want to symbolize stacks for crashes on CI. Xcode is currently based on LLVM 16
         # and the macos-13 image has llvm@15 installed:
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
         #
         # Not enabled because symbolication does not work on workerd macOS builds yet and running
         # llvm-symbolizer in the currently broken state causes some tests to time out on the
         # runner.
-        # Use Xcode 14.3.1 for now, upgrade once 15.1 is available on the runner image.
+        # Use latest available Xcode version – runner still defaults to 14.3.1.
         run: |
-          sudo xcode-select -s "/Applications/Xcode_14.3.1.app"
+          sudo xcode-select -s "/Applications/Xcode_15.1.app"
           # export LLVM_SYMBOLIZER=$(brew --prefix llvm@15)/bin/llvm-symbolizer
           # sed -i -e "s%llvm-symbolizer%${LLVM_SYMBOLIZER}%" .bazelrc
       - name: Setup Windows

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To build `workerd`, you need:
   * LLD 15+ (e.g. package `lld-15`).
   * `python3`, `python3-distutils`, and `tcl8.6`
 * On macOS:
-  * Xcode 14.3+ installation (available on macOS 13 and higher)
+  * Xcode 15 installation (available on macOS 13 and higher)
   * Homebrew installed `tcl-tk` package (provides Tcl 8.6)
 * On Windows:
   * Install [App Installer](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget)


### PR DESCRIPTION
Xcode 15.1 is now available on the macos-13 runner image. Note that the unwind info flag introduces a hard requirement for Xcode 15 and by extension macOS 13 for compiling workerd, but Mac developers generally update to new versions quickly and the minimum supported version to run workerd will remain at 11.