### PR TITLE
Improve `ReadableStream` type for email message

### DIFF
--- a/types/defines/email.d.ts
+++ b/types/defines/email.d.ts
@@ -19,7 +19,7 @@ interface ForwardableEmailMessage extends EmailMessage {
   /**
    * Stream of the email message content.
    */
-  readonly raw: ReadableStream;
+  readonly raw: ReadableStream<Uint8Array>;
   /**
    * An [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers).
    */


### PR DESCRIPTION
A type `Uint8Array` is missing in a generic to retrieve the raw data.

An issue (#1500) was created and converted into discussion #1501 with the following answer.

> [jasnell](https://github.com/cloudflare/workerd/discussions/1501#discussioncomment-7918779)
> In this case, the value should always be a `Uint8Array`.