### PR TITLE
Clarify error message when disallowed operations are called within global scope

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1126,9 +1126,11 @@ void IoContext::runImpl(Runnable& runnable, bool takePendingEvent,
 }
 
 static constexpr auto kAsyncIoErrorMessage =
-    "Some functionality, such as asynchronous I/O, timeouts, and "
-    "generating random values, can only be performed while handling a "
-    "request.";
+    "Disallowed operation called within global scope. Asynchronous I/O "
+    "(ex: fetch() or connect()), setting a timeout, and generating random "
+    "values are not allowed within global scope. To fix this error, perform this "
+    "operation within a handler. "
+    "https://developers.cloudflare.com/workers/runtime-apis/handlers/";
 
 IoContext& IoContext::current() {
   if (threadLocalRequest == nullptr) {


### PR DESCRIPTION
Improves the error message that we show when someone attempts to call `fetch()` or do some other async work in global scope.

Consider the following code:


```js

await fetch('https://cloudflare.com')

export default {
  async fetch(request, env, ctx) {
    return new Response('Hello World!');
  },
};

```

This error message could be improved:

```
 ⛅️ wrangler 3.22.1
-------------------
⎔ Starting local server...
✘ [ERROR] service core:user:top-level-await-fail: Uncaught Error: Some functionality, such as asynchronous I/O, timeouts, and generating random values, can only be performed while handling a request.
```

- Doesn't tell you what to do next
- Uses language that is specific to a "request", even though there are ways of invoking workers that don't involve an HTTP request (ex: Queue Consumer, Email Worker, etc.)

Also refs DEVX-1127