### PR TITLE
Change KJ_THREADLOCAL_PTR to thread_local.

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -5,7 +5,6 @@
 #include "io-context.h"
 #include <workerd/io/io-gate.h>
 #include <workerd/io/worker.h>
-#include <kj/threadlocal.h>
 #include <kj/debug.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/util/sentry.h>
@@ -14,8 +13,8 @@
 
 namespace workerd {
 
-KJ_THREADLOCAL_PTR(IoContext) threadLocalRequest = nullptr;
-KJ_THREADLOCAL_PTR(void) threadId = nullptr;
+static thread_local IoContext* threadLocalRequest = nullptr;
+static thread_local void* threadId = nullptr;
 
 static void* getThreadId() {
   if (threadId == nullptr) threadId = new int;


### PR DESCRIPTION
KJ_THREADLOCAL_PTR is going away: https://github.com/capnproto/capnproto/pull/1890

(This PR needs to be merged before the capnp PR lands.)