### PR TITLE
[bazel] Do not compile wd_cc_library by default

### DIFF
--- a/build/wd_cc_library.bzl
+++ b/build/wd_cc_library.bzl
@@ -1,9 +1,10 @@
 """wd_cc_library definition"""
 
-def wd_cc_library(strip_include_prefix = "/src", **kwargs):
+def wd_cc_library(strip_include_prefix = "/src", tags = ["off-by-default"], **kwargs):
     """Wrapper for cc_library that sets common attributes
     """
     native.cc_library(
         strip_include_prefix = strip_include_prefix,
+        tags = tags,
         **kwargs
     )

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -20,6 +20,10 @@ wd_cc_library(
         "//src/workerd/jsg:rtti",
         "@capnp-cpp//src/capnp",
     ],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 api_encoder_src = "api-encoder.c++"

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -10,7 +10,7 @@ wd_cc_library(
     deps = [
         "@capnp-cpp//src/kj"
     ] + select({
-        "@platforms//os:windows": ["@workerd-v8//:v8"],
+        "@platforms//os:windows": [],
         "//conditions:default": ["@perfetto//:libperfetto_client_experimental"],
     }),
     defines = select({


### PR DESCRIPTION
Mark library targets as off-by-default. We do not ship any libraries as part of workerd releases or use them outside of bazel, so there is generally no need to build them explicitly. This allows us to not build library targets by default. Note that on macOS (and likely Windows) library targets will still be built as dependencies of other targets such as tests and workerd itself as `start_stop_lib` is not supported – on Linux binaries are built directly from object files so there's no need to build the library files.
This reduces the size of the build output folder from 6.1GB to 5.9GB on Linux CI builds.