### PR TITLE
Intentionally break arm builds to test internal CI notifications

### DIFF
--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -14,6 +14,10 @@
 #include <workerd/server/alarm-scheduler.h>
 #include <kj/compat/http.h>
 
+#if __aarch64__
+#error "Testing broken arm build"
+#endif
+
 namespace kj {
   class TlsContext;
 }


### PR DESCRIPTION
Hey! 👋 This PR intentionally adds code that will fail arm builds. We automatically build for Linux and macOS arm on every merge to `main` using internal CI runners. We recently added configuration to report internal build failures to our internal chat, and want to test this system works. Once this PR has been merged, it should be immediately reverted.