### PR TITLE
Roll V8, remove unused compat flags arg

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -404,10 +404,10 @@ http_archive(
         "//:patches/v8/0012-Fix-V8-ICU-build.patch",
         "//:patches/v8/0013-Randomize-the-initial-ExecutionContextId-used-by-the.patch",
     ],
-    sha256 = "1202ec7841f98d7dda35f998dc0e29f177f01c2d573adcde900d8633da4668dc",
-    strip_prefix = "v8-v8-5eefc59",
+    sha256 = "6a2d63f1d877e8065d63ba3125e6c4d1fde2b62e46048dab68fe6ea8baca5b27",
+    strip_prefix = "v8-12.0.267.14",
     type = "tgz",
-    url = "https://github.com/v8/v8/tarball/5eefc590c868d8dfb411e53053c963fe42dcda74",
+    url = "https://github.com/v8/v8/archive/refs/tags/12.0.267.14.tar.gz",
 )
 
 new_git_repository(

--- a/src/workerd/api/node/async-hooks.h
+++ b/src/workerd/api/node/async-hooks.h
@@ -63,7 +63,7 @@ public:
     KJ_UNIMPLEMENTED("asyncLocalStorage.disable() is not implemented");
   }
 
-  JSG_RESOURCE_TYPE(AsyncLocalStorage, CompatibilityFlags::Reader flags) {
+  JSG_RESOURCE_TYPE(AsyncLocalStorage) {
     JSG_METHOD(run);
     JSG_METHOD(exit);
     JSG_METHOD(getStore);
@@ -181,7 +181,7 @@ public:
       jsg::Optional<v8::Local<v8::Value>> thisArg,
       jsg::Arguments<jsg::Value>);
 
-  JSG_RESOURCE_TYPE(AsyncResource, CompatibilityFlags::Reader flags) {
+  JSG_RESOURCE_TYPE(AsyncResource) {
     JSG_STATIC_METHOD_NAMED(bind, staticBind);
     JSG_METHOD(asyncId);
     JSG_METHOD(triggerAsyncId);

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -29,7 +29,7 @@ public:
 
   double getDatabaseSize();
 
-  JSG_RESOURCE_TYPE(SqlStorage, CompatibilityFlags::Reader flags) {
+  JSG_RESOURCE_TYPE(SqlStorage) {
     JSG_METHOD(exec);
     JSG_METHOD(prepare);
 
@@ -101,7 +101,7 @@ public:
   double getRowsWritten();
 
   kj::Array<jsg::JsRef<jsg::JsString>> getColumnNames(jsg::Lock& js);
-  JSG_RESOURCE_TYPE(Cursor, CompatibilityFlags::Reader flags) {
+  JSG_RESOURCE_TYPE(Cursor) {
     JSG_ITERABLE(rows);
     JSG_METHOD(raw);
     JSG_READONLY_PROTOTYPE_PROPERTY(columnNames, getColumnNames);
@@ -200,7 +200,7 @@ public:
 
   jsg::Ref<Cursor> run(jsg::Arguments<BindingValue> bindings);
 
-  JSG_RESOURCE_TYPE(Statement, CompatibilityFlags::Reader flags) {
+  JSG_RESOURCE_TYPE(Statement) {
     JSG_CALLABLE(run);
   }
 

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -168,7 +168,7 @@ public:
   jsg::Ref<WebSocket> getFirst() { return sockets[0].addRef(); }
   jsg::Ref<WebSocket> getSecond() { return sockets[1].addRef(); }
 
-  JSG_RESOURCE_TYPE(WebSocketPair, CompatibilityFlags::Reader flags) {
+  JSG_RESOURCE_TYPE(WebSocketPair) {
     // TODO(soon): These really should be using an indexed property handler rather
     // than named instance properties but jsg does not yet have support for that.
     JSG_READONLY_INSTANCE_PROPERTY(0, getFirst);


### PR DESCRIPTION
- V8 roll is pretty minor, primarily adding this to transition to the tagged version
- Binary size impact of cleaning up the compat flag arg is less than expected/rather low (~6K for macOS debug), still good to clean up the affected headers a bit