### PR TITLE
Verify close() works in ws close handler

### DIFF
--- a/src/workerd/api/tests/websocket-hibernation.js
+++ b/src/workerd/api/tests/websocket-hibernation.js
@@ -1,0 +1,86 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// A simple test to confirm we can close() a websocket from the close handler.
+export class DurableObjectExample {
+  constructor(state) {
+    this.reset = true;
+    this.state = state;
+  }
+
+  async fetch(request) {
+    // Confirm this is a websocket request.
+    const upgradeHeader = request.headers.get('Upgrade');
+    if (!upgradeHeader || upgradeHeader !== 'websocket') {
+      return new Response('Expected Upgrade: websocket', { status: 426 });
+    }
+
+    let pair = new WebSocketPair();
+    let server = pair[0];
+    if (request.url.endsWith("/hibernation")) {
+      this.state.acceptWebSocket(server);
+    } else {
+      server.accept();
+      server.addEventListener("message", () => {
+        server.send("regular message from DO");
+      })
+      server.addEventListener("close", () => {
+        server.close(1000, "regular close from DO");
+      });
+    }
+
+    return new Response(null, {
+      status: 101,
+      webSocket: pair[1],
+    });
+  }
+
+  webSocketMessage(ws) {
+    ws.send(`Hibernatable message from DO.`)
+  }
+
+  webSocketClose(ws, code, reason, wasClean) {
+    ws.close(1000, "Hibernatable close from DO");
+  }
+}
+
+export default {
+  async test(ctrl, env, ctx) {
+    let id = env.ns.idFromName("foo");
+    let obj = env.ns.get(id);
+
+    // Test to make sure that we can call ws.close() from the DO's close handler.
+    let webSocketTest = async (obj, url, expected) => {
+      let req = await obj.fetch(url, {
+        headers: {
+          Upgrade: 'websocket',
+        },
+      });
+
+      let ws = req.webSocket;
+      if (!ws) {
+        return new Error("Failed to get ws");
+      }
+      ws.accept();
+      let prom = new Promise((resolve, reject) => {
+        ws.addEventListener("close", (close) => {
+          if (close.code != 1000 & close.reason != expected) {
+            reject(`got ${close.reason}`);
+          }
+          resolve();
+        });
+      });
+
+      ws.send("Hi from Worker!")
+      ws.close(1000, "bye from Worker!")
+
+      await prom;
+    }
+
+    // Normal websocket
+    await webSocketTest(obj, "http://example.com/", "regular close from DO");
+    // Hibernatable Websocket.
+    await webSocketTest(obj, "http://example.com/hibernation", "Hibernatable close from DO");
+  }
+}

--- a/src/workerd/api/tests/websocket-hibernation.wd-test
+++ b/src/workerd/api/tests/websocket-hibernation.wd-test
@@ -1,0 +1,28 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (name = "main", worker = .mainWorker),
+    (name = "TEST_TMPDIR", disk = (writable = true)),
+  ],
+);
+
+const mainWorker :Workerd.Worker = (
+  compatibilityDate = "2023-12-18",
+  compatibilityFlags = ["experimental", "nodejs_compat"],
+
+  modules = [
+    (name = "worker", esModule = embed "websocket-hibernation.js"),
+  ],
+
+  durableObjectNamespaces = [
+    (className = "DurableObjectExample", uniqueKey = "210bd0cbd803ef7883a1ee9d86cce06e"),
+  ],
+
+  durableObjectStorage = (localDisk = "TEST_TMPDIR"),
+
+  bindings = [
+    (name = "ns", durableObjectNamespace = "DurableObjectExample"),
+  ],
+);
+

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -728,7 +728,21 @@ void WebSocket::ensurePumping(jsg::Lock& js) {
           reportError(js, KJ_EXCEPTION(DISCONNECTED, "WebSocket peer disconnected"));
         }
       } else if (native.closedIncoming && native.closedOutgoing) {
-        if (native.state.is<Accepted>()) {
+        if (awaitingHibernatableRelease()) {
+          // TODO(someday): These async races can be pretty complicated, and while it's good to have
+          // tests to make sure we're not broken, it would be nice to refactor this code eventually.
+
+          // Hibernatable WebSockets had a subtle race condition where one pump() promise would
+          // start right after a previous pump() completed, but before this continuation ran.
+          //
+          // This race prevented close messages from being sent from inside the webSocketClose()
+          // handler because prior to the CLOSE getting sent in the second pump(), the promise
+          // continuation following the first pump() would transition us from Accepted to Released,
+          // triggering the canceler and cancelling the outgoing CLOSE of the second pump() promise.
+          //
+          // For a more detailed explanation, see https://github.com/cloudflare/workerd/pull/1535.
+          tryReleaseNative(js);
+        } else if (native.state.is<Accepted>()) {
           // Native WebSocket no longer needed; release.
           native.state.init<Released>();
         } else if (native.state.is<Released>()) {


### PR DESCRIPTION
It looks like we're failing to send websocket `close()` events in the `webSocketClose()` handler for hibernatable websockets. Print debugging suggests we queue a close message to be sent but then never get past waiting for the `GatedMessage::outputLock` promise.

Strangely, the test seems to pass if a 1ms wait is added between a websocket send and a websocket close.