### PR TITLE
Enforce message size limit for JS RPC

### DIFF
--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -52,6 +52,9 @@ kj::Promise<capnp::Response<rpc::JsRpcTarget::CallResults>> WorkerRpc::sendWorke
   // Note that we may fail to serialize some element, in which case this will throw back to JS.
   if (argv.size() > 0) {
     auto ser = serializeV8(js, js.arr(argv.asPtr()));
+    // TODO(soon): We will drop this requirement once we support streaming.
+    JSG_ASSERT(ser.size() < MAX_JS_RPC_MESSAGE_SIZE, Error,
+        "Serialized RPC request is too large: ", ser.size(), " <= ", MAX_JS_RPC_MESSAGE_SIZE);
     builder.initSerializedArgs().setV8Serialized(kj::mv(ser));
   }
 
@@ -124,6 +127,10 @@ public:
       return ctx.awaitJs(js, js.toPromise(invokeFn(js, fn, handle, serializedArgs))
           .then(js, ctx.addFunctor([callContext](jsg::Lock& js, jsg::Value value) mutable {
         auto result = serializeV8(js, jsg::JsValue(value.getHandle(js)));
+        // TODO(soon): We will drop this requirement once we support streaming.
+        JSG_ASSERT(result.size() < MAX_JS_RPC_MESSAGE_SIZE, Error,
+            "Serialized RPC response is too large: ", result.size(),
+            " <= ", MAX_JS_RPC_MESSAGE_SIZE);
         auto builder = callContext.initResults(capnp::MessageSize { result.size() / 8 + 8, 0 });
         builder.initResult().setV8Serialized(kj::mv(result));
       })));

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -20,6 +20,11 @@
 
 namespace workerd::api {
 
+// TODO(soon): This size limit is loosely based on Cap'n Proto's 'traversalLimitInWords'.
+// JS RPC does not support streaming messages yet, and until it does we should prevent
+// large messages from being sent.
+constexpr size_t MAX_JS_RPC_MESSAGE_SIZE = 32 * 1024 * 1024;
+
 // A WorkerRpc object forwards JS method calls to the remote Worker/Durable Object over RPC.
 // Since methods are not known until runtime, WorkerRpc doesn't define any JS methods.
 // Instead, we use JSG_NAMED_INTERCEPT to intercept property accesses of names that are not known at


### PR DESCRIPTION
We're adding a limit to the size of JS RPC messages until we support streaming.