### PR TITLE
Try to take lock when delivering websocket events

### DIFF
--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -580,6 +580,10 @@ private:
     kj::Maybe<kj::String> extensions;
   };
 
+  // If we created this WebSocket inside a critical section (ex. a blockConcurrencyWhile callback)
+  // then we need to get the InputGate::Lock and pass it to context.run() when delivering events.
+  kj::Maybe<InputGate::CriticalSection&> maybeCriticalSection;
+
   // So that each end of a WebSocketPair can keep track of its pair.
   kj::Maybe<jsg::Ref<WebSocket>> maybePair;
 


### PR DESCRIPTION
WebSocket events weren't being delivered when the WebSocket was created in a blockConcurrencyWhile callback if the callback depended on a websocket event completing.