### PR TITLE
Implements embedding of Python packages in workerd.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -111,6 +111,14 @@ http_archive(
     build_file = "//:build/BUILD.pyodide",
 )
 
+http_archive(
+    name = "pyodide_packages",
+    sha256 = "f8fca2c4ecc09a57c86a2ed8d217e955d7599a83dad73fb989c86206706fdff6",
+    type = "zip",
+    urls = ["https://github.com/dom96/pyodide_packages/releases/download/v0.1/pyodide_packages_unzipped_0.1.tar.zip"],
+    build_file = "//:build/BUILD.pyodide_packages",
+)
+
 # ========================================================================================
 # Dawn
 #

--- a/build/BUILD.pyodide_packages
+++ b/build/BUILD.pyodide_packages
@@ -1,0 +1,3 @@
+exports_files(
+    ["pyodide_packages_unzipped_0.1.tar"],
+)

--- a/src/pyodide/BUILD.bazel
+++ b/src/pyodide/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:copy_directory.bzl", "copy_directory")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@workerd//:build/wd_js_bundle.bzl", "wd_js_bundle")
 
@@ -12,6 +13,12 @@ copy_file(
     name = "python_stdlib.zip@rule",
     src = "@pyodide//:pyodide/python_stdlib.zip",
     out = "generated/python_stdlib.zip",
+)
+
+copy_file(
+    name = "pyodide_packages_file.zip@rule",
+    src = "@pyodide_packages//:pyodide_packages_unzipped_0.1.tar",
+    out = "generated/pyodide_packages_unzipped_0.1.tar",
 )
 
 PRELUDE = """
@@ -39,6 +46,7 @@ wd_js_bundle(
     name = "pyodide",
     builtin_modules = [
         "python.js",
+        "generated/pyodide_packages_unzipped_0.1.tar"
     ] + glob(["internal/patches/*.py"]),
     import_name = "pyodide",
     internal_data_modules = ["generated/python_stdlib.zip"],
@@ -53,5 +61,6 @@ wd_js_bundle(
         "pyodide.asm.js@rule",
         "pyodide.asm.wasm@rule",
         "python_stdlib.zip@rule",
+        "pyodide_packages_file.zip@rule"
     ],
 )

--- a/src/workerd/api/pyodide.h
+++ b/src/workerd/api/pyodide.h
@@ -28,4 +28,15 @@ kj::StringPtr getPyodidePatch(kj::StringPtr name) {
   return _::lookupModule(kj::str("pyodide:internal/patches/", name));
 }
 
+capnp::Data::Reader getPyodideEmbeddedPackages() {
+  // TODO(later): strip the version from this.
+  auto moduleName = "pyodide:generated/pyodide_packages_unzipped_0.1.tar";
+  for (auto m : PYODIDE_BUNDLE->getModules()) {
+    if (m.getName() == moduleName) {
+      return m.getSrc();
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
 }  // namespace workerd


### PR DESCRIPTION
Embeds a tarball containing a Python `site-packages` which includes all the packages necessary to run a langchain + openai demo without the need to download anything at runtime.

Tested upstream via `python-langchain.ew-test`.