### PR TITLE
Remove explicitly unimplemented importScripts

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -133,12 +133,14 @@ class WorkerGlobalScope: public EventTarget, public jsg::ContextGlobal {
 public:
   jsg::Unimplemented importScripts(kj::String s) { return {}; };
 
-  JSG_RESOURCE_TYPE(WorkerGlobalScope) {
+  JSG_RESOURCE_TYPE(WorkerGlobalScope, CompatibilityFlags::Reader flags) {
     JSG_INHERIT(EventTarget);
 
     JSG_NESTED_TYPE(EventTarget);
 
-    JSG_METHOD(importScripts);
+    if (!flags.getNoImportScripts()) {
+      JSG_METHOD(importScripts);
+    }
 
     JSG_TS_DEFINE(type WorkerGlobalScopeEventMap = {
       fetch: FetchEvent;

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -361,4 +361,10 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # The client stub is currently guarded by the experimental flag, however, we don't want to let
   # experimental clients call JS methods over RPC if the Worker receiving the request hasn't
   # explicitly exposed its methods to RPC.
+
+  noImportScripts @40 :Bool
+      $compatEnableFlag("no_global_importscripts")
+      $compatDisableFlag("global_importscripts")
+      $compatEnableDate("2024-03-04");
+  # Removes the non-implemented importScripts() function from the global scope.
 }


### PR DESCRIPTION
We have no plans to ever implement `importScripts()` and having it defined but marked explicitly non-implemented is causing issues with using certain third-party libraries in workers. So let's just remove it entirely.

Refs: https://github.com/cloudflare/workerd/issues/1521