### PR TITLE
Refactor IoContext::Scope and ThreadScope into callback-based API

### DIFF
--- a/src/workerd/api/actor-state-test.c++
+++ b/src/workerd/api/actor-state-test.c++
@@ -32,9 +32,7 @@ JSG_DECLARE_ISOLATE_TYPE(ActorStateIsolate, ActorStateContext);
 
 KJ_TEST("v8 serialization version tag hasn't changed") {
   jsg::test::Evaluator<ActorStateContext, ActorStateIsolate> e(v8System);
-  ActorStateIsolate &actorStateIsolate = e.getIsolate();
-  jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-    ActorStateIsolate::Lock isolateLock(actorStateIsolate, stackScope);
+  e.getIsolate().runInLockScope([&](ActorStateIsolate::Lock& isolateLock) {
     isolateLock.withinHandleScope([&] {
       auto v8Context = isolateLock.newContext<ActorStateContext>().getHandle(isolateLock);
       auto contextScope = isolateLock.enterContextScope(v8Context);
@@ -62,9 +60,7 @@ KJ_TEST("v8 serialization version tag hasn't changed") {
 
 KJ_TEST("we support deserializing up to v15") {
   jsg::test::Evaluator<ActorStateContext, ActorStateIsolate> e(v8System);
-  ActorStateIsolate &actorStateIsolate = e.getIsolate();
-  jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-    ActorStateIsolate::Lock isolateLock(actorStateIsolate, stackScope);
+  e.getIsolate().runInLockScope([&](ActorStateIsolate::Lock& isolateLock) {
     isolateLock.withinHandleScope([&] {
       auto v8Context = isolateLock.newContext<ActorStateContext>().getHandle(isolateLock);
       auto contextScope = isolateLock.enterContextScope(v8Context);
@@ -108,9 +104,7 @@ KJ_TEST("wire format version does not change deserialization behavior on real da
   }
 
   jsg::test::Evaluator<ActorStateContext, ActorStateIsolate> e(v8System);
-  ActorStateIsolate &actorStateIsolate = e.getIsolate();
-  jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-    ActorStateIsolate::Lock isolateLock(actorStateIsolate, stackScope);
+  e.getIsolate().runInLockScope([&](ActorStateIsolate::Lock& isolateLock) {
     isolateLock.withinHandleScope([&] {
       auto v8Context = isolateLock.newContext<ActorStateContext>().getHandle(isolateLock);
       auto contextScope = isolateLock.enterContextScope(v8Context);

--- a/src/workerd/api/crypto-impl-aes-test.c++
+++ b/src/workerd/api/crypto-impl-aes-test.c++
@@ -27,9 +27,7 @@ KJ_TEST("AES-KW key wrap") {
   // Basic test that I wrote when I was seeing heap corruption. Found it easier to iterate on with
   // ASAN/valgrind than using our conformance tests with test-runner.
   jsg::test::Evaluator<CryptoContext, CryptoIsolate> e(v8System);
-  CryptoIsolate &cryptoIsolate = e.getIsolate();
-  jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-    CryptoIsolate::Lock isolateLock(cryptoIsolate, stackScope);
+  e.getIsolate().runInLockScope([&](CryptoIsolate::Lock& isolateLock) {
     auto isolate = isolateLock.v8Isolate;
     auto& js = jsg::Lock::from(isolate);
 
@@ -96,16 +94,14 @@ KJ_TEST("AES-CTR key wrap") {
   // wrap if it didn't have "encrypt" in its usages when created.
 
   jsg::test::Evaluator<CryptoContext, CryptoIsolate> e(v8System);
-  CryptoIsolate &cryptoIsolate = e.getIsolate();
-  jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-    CryptoIsolate::Lock isolateLock(cryptoIsolate, stackScope);
+  e.getIsolate().runInLockScope([&](CryptoIsolate::Lock& isolateLock) {
     auto isolate = isolateLock.v8Isolate;
 
     isolateLock.withinHandleScope([&] {
       auto context = isolateLock.newContext<CryptoContext>().getHandle(isolateLock);
       auto contextScope = isolateLock.enterContextScope(context);
 
-      auto& js = jsg::Lock::from(isolate);
+      jsg::Lock& js = isolateLock;
 
       SubtleCrypto subtle;
 

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -415,8 +415,8 @@ public:
         //
         // Synchronous lock is OK here since it only happens during preview. We don't have a
         // metrics object to provide ,though.
-        jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-          Worker::Lock lock(*worker, Worker::Lock::TakeSynchronously(*requestMetrics), stackScope);
+        worker->runInLockScope(Worker::Lock::TakeSynchronously(*requestMetrics),
+            [&](Worker::Lock& lock) {
           lock.logWarning(msg);
         });
       }

--- a/src/workerd/api/streams/queue-test.c++
+++ b/src/workerd/api/streams/queue-test.c++
@@ -18,8 +18,7 @@ JSG_DECLARE_ISOLATE_TYPE(QueueIsolate, QueueContext);
 
 void preamble(auto callback) {
   QueueIsolate isolate(v8System, kj::heap<jsg::IsolateObserver>());
-  jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-    QueueIsolate::Lock lock(isolate, stackScope);
+  isolate.runInLockScope([&](QueueIsolate::Lock& lock) {
     lock.withinHandleScope([&] {
       v8::Local<v8::Context> context = lock.newContext<QueueContext>().getHandle(lock);
       v8::Context::Scope contextScope(context);

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -815,8 +815,12 @@ private:
     return *getCurrentIncomingRequest().ioChannelFactory;
   }
 
-  class ThreadScope;
-  class Scope;
+  // Run the given callback within the scope of this IoContext. This encapsultes the
+  // setup of a number of scopes that must be entered prior to running within the
+  // context, including entering the V8StackScope and acquiring the Worker::Lock.
+  void runInContextScope(Worker::LockType lockType,
+                         kj::Maybe<InputGate::Lock> inputLock,
+                         kj::Function<void(Worker::Lock&)> func);
 
   friend class Finalizeable;
   friend class DeleteQueue;

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -138,10 +138,12 @@ public:
 
   // Use like so:
   //
-  //   auto lockTiming = MetricsCollector::ScriptReplica::LockTiming::tryCreate(script, maybeRequest);
+  //   auto lockTiming = MetricsCollector::ScriptReplica::LockTiming::tryCreate(
+  //       script, maybeRequest);
   //   MetricsCollector::ScriptReplica::LockRecord record(lockTiming);
-  //   JsgWorkerIsolate::Lock lock(isolate);
-  //   record.locked();
+  //   isolate.runInLockScope([&](MyIsolate::Lock& lock) {
+  //     record.locked();
+  //   });
   //
   // And `record()` will report the time spent waiting for the lock (including any asynchronous
   // time you might insert between the construction of `lockTiming` and `LockRecord()`), plus

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1035,7 +1035,7 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
     });
 
     // The PromiseCrossContextCallback is used to allow cross-IoContext promise following.
-    // When the IoContext::Scope is entered, we set the "promise context tag" associated
+    // When the IoContext scope is entered, we set the "promise context tag" associated
     // with the IoContext on the Isolate that is locked. Any Promise that is created within
     // that scope will be tagged with the same promise context tag. When an attempt to
     // follow a promise occurs (e.g. either using Promise.prototype.then() or await, etc)

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -552,6 +552,7 @@ private:
   friend class Worker::Isolate;
 };
 
+// The func must be a callback with the signature: T (jsg::Lock&), where T is any type.
 auto Worker::runInLockScope(LockType lockType, auto func) const {
   return jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) -> auto {
     Worker::Lock lock(*this, lockType, stackScope);

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -319,8 +319,7 @@ JSG_DECLARE_ISOLATE_TYPE(LockLogIsolate, LockLogContext);
 KJ_TEST("jsg::Lock logWarning") {
   LockLogIsolate isolate(v8System, kj::heap<IsolateObserver>());
   bool called = false;
-  jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-    LockLogIsolate::Lock lock(isolate, stackScope);
+  isolate.runInLockScope([&](LockLogIsolate::Lock& lock) {
     lock.setLoggerCallback([&called](jsg::Lock& js, auto message) {
       KJ_ASSERT(message == "Yes that happened"_kj);
       called = true;
@@ -421,13 +420,15 @@ JSG_DECLARE_ISOLATE_TYPE(IsolateUuidIsolate, IsolateUuidContext);
 
 KJ_TEST("jsg::Lock getUuid") {
   IsolateUuidIsolate isolate(v8System, kj::heap<IsolateObserver>());
-  jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-    IsolateUuidIsolate::Lock lock(isolate, stackScope);
+  bool called = false;
+  isolate.runInLockScope([&](IsolateUuidIsolate::Lock& lock) {
     // Returns the same value
     KJ_ASSERT(lock.getUuid() == lock.getUuid());
     KJ_ASSERT(isolate.getUuid() == lock.getUuid());
     KJ_ASSERT(lock.getUuid().size() == 36);
+    called = true;
   });
+  KJ_ASSERT(called);
 }
 
 }  // namespace

--- a/src/workerd/jsg/jsg-test.h
+++ b/src/workerd/jsg/jsg-test.h
@@ -27,119 +27,115 @@ public:
     return isolate;
   }
 
-  void expectEvalModule(kj::StringPtr code, kj::StringPtr expectedType, kj::StringPtr expectedValue) {
-    jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-      typename IsolateType::Lock lock(getIsolate(), stackScope);
+  void expectEvalModule(kj::StringPtr code,
+                        kj::StringPtr expectedType,
+                        kj::StringPtr expectedValue) {
+    getIsolate().runInLockScope([&](typename IsolateType::Lock& lock) {
+      jsg::Lock& js = lock;
+      js.withinHandleScope([&] {
+        // Create a new context.
+        auto jsContext = lock.template newContext<ContextType>();
+        v8::Local<v8::Context> context = jsContext.getHandle(lock.v8Isolate);
 
-      // Create a stack-allocated handle scope.
-      v8::HandleScope handleScope(lock.v8Isolate);
+        // Enter the context for the module
+        v8::Context::Scope contextScope(context);
 
-      // Create a new context.
-      auto jsContext = lock.template newContext<ContextType>();
-      v8::Local<v8::Context> context = jsContext.getHandle(lock.v8Isolate);
+        // Compile code as "main" module
+        CompilationObserver observer;
+        auto modules = ModuleRegistryImpl<ContextType>::from(lock);
+        auto p = kj::Path::parse("main");
+        modules->add(p, jsg::ModuleRegistry::ModuleInfo(
+            lock, "main", code, ModuleInfoCompileOption::BUNDLE, observer));
 
-      // Enter the context for the module
-      v8::Context::Scope contextScope(context);
+        // Instantiate the module
+        auto& moduleInfo = KJ_REQUIRE_NONNULL(modules->resolve(lock, p));
+        auto module = moduleInfo.module.getHandle(lock);
+        jsg::instantiateModule(lock, module);
 
-      // Compile code as "main" module
-      CompilationObserver observer;
-      auto modules = ModuleRegistryImpl<ContextType>::from(lock);
-      auto p = kj::Path::parse("main");
-      modules->add(p, jsg::ModuleRegistry::ModuleInfo(
-          lock, "main", code, ModuleInfoCompileOption::BUNDLE, observer));
+        // Module has to export "run" function
+        auto moduleNs = check(module->GetModuleNamespace()->ToObject(context));
+        auto runValue = check(moduleNs->Get(context, v8StrIntern(lock.v8Isolate, "run"_kj)));
 
-      // Instantiate the module
-      auto& moduleInfo = KJ_REQUIRE_NONNULL(modules->resolve(lock, p));
-      auto module = moduleInfo.module.getHandle(lock);
-      jsg::instantiateModule(lock, module);
+        v8::TryCatch catcher(lock.v8Isolate);
 
-      // Module has to export "run" function
-      auto moduleNs = check(module->GetModuleNamespace()->ToObject(context));
-      auto runValue = check(moduleNs->Get(context, v8StrIntern(lock.v8Isolate, "run"_kj)));
+        // Run the function to get the result.
+        v8::Local<v8::Value> result;
+        if (v8::Function::Cast(*runValue)->Call(context, context->Global(), 0, nullptr)
+                .ToLocal(&result)) {
+          v8::String::Utf8Value type(lock.v8Isolate, result->TypeOf(lock.v8Isolate));
+          v8::String::Utf8Value value(lock.v8Isolate, result);
 
-      v8::TryCatch catcher(lock.v8Isolate);
+          KJ_EXPECT(*type == expectedType, *type, expectedType);
+          KJ_EXPECT(*value == expectedValue, *value, expectedValue);
+        } else if (catcher.HasCaught()) {
+          v8::String::Utf8Value message(lock.v8Isolate, catcher.Exception());
 
-      // Run the function to get the result.
-      v8::Local<v8::Value> result;
-      if (v8::Function::Cast(*runValue)->Call(context, context->Global(), 0, nullptr).ToLocal(&result)) {
-        v8::String::Utf8Value type(lock.v8Isolate, result->TypeOf(lock.v8Isolate));
-        v8::String::Utf8Value value(lock.v8Isolate, result);
-
-        KJ_EXPECT(*type == expectedType, *type, expectedType);
-        KJ_EXPECT(*value == expectedValue, *value, expectedValue);
-      } else if (catcher.HasCaught()) {
-        v8::String::Utf8Value message(lock.v8Isolate, catcher.Exception());
-
-        KJ_EXPECT(expectedType == "throws", expectedType, catcher.Exception());
-        KJ_EXPECT(*message == expectedValue, *message, expectedValue);
-      } else {
-        KJ_FAIL_EXPECT("returned empty handle but didn't throw exception?");
-      }
+          KJ_EXPECT(expectedType == "throws", expectedType, catcher.Exception());
+          KJ_EXPECT(*message == expectedValue, *message, expectedValue);
+        } else {
+          KJ_FAIL_EXPECT("returned empty handle but didn't throw exception?");
+        }
+      });
     });
   }
 
   void expectEval(kj::StringPtr code, kj::StringPtr expectedType, kj::StringPtr expectedValue) {
-    jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-      typename IsolateType::Lock lock(getIsolate(), stackScope);
+    getIsolate().runInLockScope([&](typename IsolateType::Lock& lock) {
+      jsg::Lock& js = lock;
+      js.withinHandleScope([&] {
+        // Create a new context.
+        v8::Local<v8::Context> context =
+            lock.template newContext<ContextType>().getHandle(lock.v8Isolate);
 
-      // Create a stack-allocated handle scope.
-      v8::HandleScope handleScope(lock.v8Isolate);
+        // Enter the context for compiling and running the hello world script.
+        v8::Context::Scope contextScope(context);
 
-      // Create a new context.
-      v8::Local<v8::Context> context =
-          lock.template newContext<ContextType>().getHandle(lock.v8Isolate);
+        // Create a string containing the JavaScript source code.
+        v8::Local<v8::String> source = jsg::v8Str(lock.v8Isolate, code);
 
-      // Enter the context for compiling and running the hello world script.
-      v8::Context::Scope contextScope(context);
+        // Compile the source code.
+        v8::Local<v8::Script> script;
+        if (!v8::Script::Compile(context, source).ToLocal(&script)) {
+          KJ_FAIL_EXPECT("code didn't parse", code);
+          return;
+        }
 
-      // Create a string containing the JavaScript source code.
-      v8::Local<v8::String> source = jsg::v8Str(lock.v8Isolate, code);
+        v8::TryCatch catcher(lock.v8Isolate);
 
-      // Compile the source code.
-      v8::Local<v8::Script> script;
-      if (!v8::Script::Compile(context, source).ToLocal(&script)) {
-        KJ_FAIL_EXPECT("code didn't parse", code);
-        return;
-      }
+        // Run the script to get the result.
+        v8::Local<v8::Value> result;
+        if (script->Run(context).ToLocal(&result)) {
+          v8::String::Utf8Value type(lock.v8Isolate, result->TypeOf(lock.v8Isolate));
+          v8::String::Utf8Value value(lock.v8Isolate, result);
 
-      v8::TryCatch catcher(lock.v8Isolate);
+          KJ_EXPECT(*type == expectedType, *type, expectedType);
+          KJ_EXPECT(*value == expectedValue, *value, expectedValue);
+        } else if (catcher.HasCaught()) {
+          v8::String::Utf8Value message(lock.v8Isolate, catcher.Exception());
 
-      // Run the script to get the result.
-      v8::Local<v8::Value> result;
-      if (script->Run(context).ToLocal(&result)) {
-        v8::String::Utf8Value type(lock.v8Isolate, result->TypeOf(lock.v8Isolate));
-        v8::String::Utf8Value value(lock.v8Isolate, result);
-
-        KJ_EXPECT(*type == expectedType, *type, expectedType);
-        KJ_EXPECT(*value == expectedValue, *value, expectedValue);
-      } else if (catcher.HasCaught()) {
-        v8::String::Utf8Value message(lock.v8Isolate, catcher.Exception());
-
-        KJ_EXPECT(expectedType == "throws", expectedType, catcher.Exception());
-        KJ_EXPECT(*message == expectedValue, *message, expectedValue);
-      } else {
-        KJ_FAIL_EXPECT("returned empty handle but didn't throw exception?");
-      }
+          KJ_EXPECT(expectedType == "throws", expectedType, catcher.Exception());
+          KJ_EXPECT(*message == expectedValue, *message, expectedValue);
+        } else {
+          KJ_FAIL_EXPECT("returned empty handle but didn't throw exception?");
+        }
+      });
     });
   }
 
   void setAllowEval(bool b) {
-    jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-      typename IsolateType::Lock lock(getIsolate(), stackScope);
+    getIsolate().runInLockScope([&](typename IsolateType::Lock& lock) {
       lock.setAllowEval(b);
     });
   }
 
   void setCaptureThrowsAsRejections(bool b) {
-    jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-      typename IsolateType::Lock lock(getIsolate(), stackScope);
+    getIsolate().runInLockScope([&](typename IsolateType::Lock& lock) {
       lock.setCaptureThrowsAsRejections(b);
     });
   }
 
   void runMicrotasks() {
-    jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-      typename IsolateType::Lock lock(getIsolate(), stackScope);
+    getIsolate().runInLockScope([&](typename IsolateType::Lock& lock) {
       lock.runMicrotasks();
     });
   }

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -301,8 +301,7 @@ TestFixture::TestFixture(SetupParams&& params)
     waitUntilTasks(*errorHandler),
     headerTable(headerTableBuilder.build()) {
   KJ_IF_SOME(id, params.actorId) {
-    jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-      auto lock = Worker::Lock(*worker, Worker::Lock::TakeSynchronously(kj::none), stackScope);
+    worker->runInLockScope(Worker::Lock::TakeSynchronously(kj::none), [&](Worker::Lock& lock) {
       auto makeActorCache = [](const ActorCache::SharedLru& sharedLru,
                                OutputGate& outputGate,
                                ActorCache::Hooks& hooks) {


### PR DESCRIPTION
Continued work refactoring the Lock-taking APIs to a callback-style API .... There's still more to do but this PR is large enough already. Will keep working in increments