### PR TITLE
Update to zlib 1.3.1, switch to fetching from GitHub

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -248,9 +248,11 @@ cc_library(
 http_archive(
     name = "zlib",
     build_file_content = _zlib_build,
-    sha256 = "8a9ba2898e1d0d774eca6ba5b4627a11e5588ba85c8851336eb38de4683050a7",
-    strip_prefix = "zlib-1.3",
-    urls = ["https://zlib.net/zlib-1.3.tar.xz"],
+    sha256 = "38ef96b8dfe510d42707d9c781877914792541133e1870841463bfa73f883e32",
+    strip_prefix = "zlib-1.3.1",
+    # Using the .tar.xz artifact from the release page – for many other dependencies we use a
+    # snapshot based on the tag of a release instead.
+    urls = ["https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.xz"],
 )
 
 http_file(


### PR DESCRIPTION
The zlib.net host eagerly deletes older zlib releases as they become obsolete, this can cause unexpected build failures whenever there is a new zlib version.