### PR TITLE
Automatically run webgpu tests if enable_experimental_webgpu is enabled

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,7 @@
 common --enable_platform_specific_config
 build --verbose_failures
 build --build_tag_filters=-off-by-default
+test --test_tag_filters=-off-by-default
 
 # Not using bzlmod for dependencies yet
 common --noenable_bzlmod

--- a/build/wd_test.bzl
+++ b/build/wd_test.bzl
@@ -9,7 +9,8 @@ def wd_test(
     Args:
      src: A .capnp config file defining the test. (`name` will be derived from this if not
         specified.) The extension `.wd-test` is also permitted instead of `.capnp`, in order to
-        avoid confusing other build systems that may assume a `.capnp` file should be complied.
+        avoid confusing other build systems that may assume a `.capnp` file should be compiled. As
+        an extension, `.gpu-wd-test` is supported to enable special handling for GPU tests.
      data: Files which the .capnp config file may embed. Typically JavaScript files.
      args: Additional arguments to pass to `workerd`. Typically used to pass `--experimental`.
     """
@@ -26,7 +27,7 @@ def wd_test(
 
     # Default name based on src.
     if name == None:
-        name = src.removesuffix(".capnp").removesuffix(".wd-test")
+        name = src.removesuffix(".capnp").removesuffix(".wd-test").removesuffix(".gpu-wd-test")
 
     _wd_test(
         name = name,

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -166,3 +166,19 @@ kj_test(
 ) for f in glob(
     ["**/*.wd-test"],
 )]
+
+# Enable GPU tests if experimental GPU support is enabled. Unfortunately, this depends on the right
+# drivers being available on Linux and macOS, so turn it off by default. Run GPU tests with
+# `bazel test //src/workerd/api:gpu/<test name>`.
+[wd_test(
+    src = f,
+    args = ["--experimental"],
+    data = [f.removesuffix(".gpu-wd-test") + ".js"],
+    tags = ["off-by-default"],
+    target_compatible_with = select({
+        "//src/workerd/io:set_enable_experimental_webgpu": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+) for f in glob(
+    ["**/*.gpu-wd-test"],
+)]

--- a/src/workerd/api/gpu/webgpu-buffer-test.js
+++ b/src/workerd/api/gpu/webgpu-buffer-test.js
@@ -1,8 +1,5 @@
 import { deepEqual, ok, equal } from "node:assert";
 
-// run manually for now
-// bazel run --//src/workerd/io:enable_experimental_webgpu //src/workerd/server:workerd -- test `realpath ./src/workerd/api/gpu/webgpu-buffer-test.gpu-wd-test` --verbose --experimental
-
 export class DurableObjectExample {
   constructor(state) {
     this.state = state;

--- a/src/workerd/api/gpu/webgpu-compute-test.js
+++ b/src/workerd/api/gpu/webgpu-compute-test.js
@@ -1,8 +1,5 @@
 import { deepEqual, ok, equal } from "node:assert";
 
-// run manually for now
-// bazel run --//src/workerd/io:enable_experimental_webgpu //src/workerd/server:workerd -- test `realpath ./src/workerd/api/gpu/webgpu-compute-test.gpu-wd-test` --verbose --experimental
-
 export class DurableObjectExample {
   constructor(state) {
     this.state = state;

--- a/src/workerd/api/gpu/webgpu-errors-test.js
+++ b/src/workerd/api/gpu/webgpu-errors-test.js
@@ -1,8 +1,5 @@
 import { ok, equal } from "node:assert";
 
-// run manually for now
-// bazel run --//src/workerd/io:enable_experimental_webgpu //src/workerd/server:workerd -- test `realpath ./src/workerd/api/gpu/webgpu-errors-test.gpu-wd-test` --verbose --experimental
-
 export class DurableObjectExample {
   constructor(state) {
     this.state = state;

--- a/src/workerd/api/gpu/webgpu-windowless-test.js
+++ b/src/workerd/api/gpu/webgpu-windowless-test.js
@@ -1,8 +1,5 @@
 import { ok, deepEqual, equal } from "node:assert";
 
-// run manually for now
-// bazel run --//src/workerd/io:enable_experimental_webgpu //src/workerd/server:workerd -- test `realpath ./src/workerd/api/gpu/webgpu-windowless-test.gpu-wd-test` --verbose --experimental
-
 async function hash(data) {
   const hashBuffer = await crypto.subtle.digest("SHA-256", data);
   const hashArray = Array.from(new Uint8Array(hashBuffer));

--- a/src/workerd/api/gpu/webgpu-write-test.js
+++ b/src/workerd/api/gpu/webgpu-write-test.js
@@ -1,8 +1,5 @@
 import { ok, deepEqual, equal } from "node:assert";
 
-// run manually for now
-// bazel run --//src/workerd/io:enable_experimental_webgpu //src/workerd/server:workerd -- test `realpath ./src/workerd/api/gpu/webgpu-write-test.gpu-wd-test` --verbose --experimental
-
 export class DurableObjectExample {
   constructor(state) {
     this.state = state;


### PR DESCRIPTION
The WebGPU tests were previously not included in the bazel build system. With this change we have 5 more tests that will run on CI and achieve better code coverage.