### PR TITLE
Remove IsolateShutdownScope

### DIFF
--- a/src/workerd/util/thread-scopes.c++
+++ b/src/workerd/util/thread-scopes.c++
@@ -13,7 +13,6 @@ using kj::uint;
 namespace {
 
 thread_local uint allowV8BackgroundThreadScopeCount = 0;
-thread_local uint isolateShutdownThreadScopeCount = 0;
 
 bool multiTenantProcess = false;
 bool predictableMode = false;
@@ -35,18 +34,6 @@ AllowV8BackgroundThreadsScope::~AllowV8BackgroundThreadsScope() noexcept(false) 
 
 bool AllowV8BackgroundThreadsScope::isActive() {
   return allowV8BackgroundThreadScopeCount > 0;
-}
-
-IsolateShutdownScope::IsolateShutdownScope() {
-  ++isolateShutdownThreadScopeCount;
-}
-
-IsolateShutdownScope::~IsolateShutdownScope() noexcept(false) {
-  --isolateShutdownThreadScopeCount;
-}
-
-bool IsolateShutdownScope::isActive() {
-  return isolateShutdownThreadScopeCount > 0;
 }
 
 bool isMultiTenantProcess() {

--- a/src/workerd/util/thread-scopes.h
+++ b/src/workerd/util/thread-scopes.h
@@ -32,18 +32,6 @@ public:
   KJ_DISALLOW_COPY_AND_MOVE(AllowV8BackgroundThreadsScope);
 };
 
-// Create this on the stack when tearing down isolates. This hints to the PageAllocator that all
-// page discards should be deferred until the whole cage is destroyed.
-class IsolateShutdownScope {
-public:
-  IsolateShutdownScope();
-  ~IsolateShutdownScope() noexcept(false);
-
-  static bool isActive();
-
-  KJ_DISALLOW_COPY_AND_MOVE(IsolateShutdownScope);
-};
-
 // Tracks whether the process hosts isolates from multiple parties that don't know about each
 // other. In such a case, we must take additional precautions against Spectre, and prohibit
 // functionality which cannot be made spectre-safe.


### PR DESCRIPTION
This is not used in workerd anywhere. It is here only to support a single use on the internal repo. I've got a PR to add the impl to the internal repo. Once that lands, this can be removed.