### PR TITLE
Add expectedLength for JS streams

### DIFF
--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -92,7 +92,11 @@ struct UnderlyingSource {
   jsg::Optional<jsg::Function<PullAlgorithm>> pull;
   jsg::Optional<jsg::Function<CancelAlgorithm>> cancel;
 
-  JSG_STRUCT(type, autoAllocateChunkSize, start, pull, cancel);
+  // The expectedLength is a non-standard extension used to support specifying the
+  // content-length when using a ReadableStream as the body of a request or response.
+  jsg::Optional<uint64_t> expectedLength;
+
+  JSG_STRUCT(type, autoAllocateChunkSize, start, pull, cancel, expectedLength);
   JSG_STRUCT_TS_DEFINE(interface UnderlyingByteSource {
     type: "bytes";
     autoAllocateChunkSize?: number;
@@ -149,7 +153,12 @@ struct Transformer {
   jsg::Optional<jsg::Function<TransformAlgorithm>> transform;
   jsg::Optional<jsg::Function<FlushAlgorithm>> flush;
 
-  JSG_STRUCT(readableType, writableType, start, transform, flush);
+  // The expectedLength is a non-standard extension used to support specifying the
+  // content-length when using a TransformStream readable side as the body of a
+  // request or response.
+  jsg::Optional<uint64_t> expectedLength;
+
+  JSG_STRUCT(readableType, writableType, start, transform, flush, expectedLength);
   JSG_STRUCT_TS_OVERRIDE(<I = any, O = any> {
     start?: (controller: TransformStreamDefaultController<O>) => void | Promise<void>;
     transform?: (chunk: I, controller: TransformStreamDefaultController<O>) => void | Promise<void>;

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -702,6 +702,8 @@ private:
             kj::Own<ValueReadable>,
             kj::Own<ByteReadable>> state = StreamStates::Closed();
 
+  kj::Maybe<uint64_t> expectedLength = kj::none;
+
   // The lock state is separate because a closed or errored stream can still be locked.
   ReadableLockImpl lock;
 
@@ -2588,6 +2590,8 @@ void ReadableStreamJsController::setup(
   auto queuingStrategy = kj::mv(maybeQueuingStrategy).orDefault({});
   auto type = underlyingSource.type.map([](kj::StringPtr s) { return s; }).orDefault(""_kj);
 
+  expectedLength = underlyingSource.expectedLength;
+
   if (type == "bytes") {
     auto autoAllocateChunkSize = underlyingSource.autoAllocateChunkSize.orDefault(
         UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE);
@@ -3325,7 +3329,7 @@ kj::Own<ReadableStreamController> ReadableStreamJsController::detach(jsg::Lock& 
 }
 
 kj::Maybe<uint64_t> ReadableStreamJsController::tryGetLength(StreamEncoding encoding) {
-  return kj::none;
+  return expectedLength;
 }
 
 kj::Promise<DeferredProxy<void>> ReadableStreamJsController::pumpTo(

--- a/src/workerd/api/tests/streams-test.js
+++ b/src/workerd/api/tests/streams-test.js
@@ -1,0 +1,47 @@
+import {
+  strictEqual,
+  ok,
+  throws
+} from 'node:assert';
+
+const enc = new TextEncoder();
+
+export const rs = {
+  async test(ctrl, env) {
+    const resp = await env.subrequest.fetch('http://example.org', {
+      method: 'POST',
+      body: new ReadableStream({
+        expectedLength: 10,
+        start(c) {
+          c.enqueue(enc.encode('hellohello'));
+          c.close();
+        }
+      })
+    });
+    for await (const _ of resp.body) {}
+  }
+};
+
+export const ts = {
+  async test(ctrl, env) {
+    const { readable, writable } = new TransformStream({
+      expectedLength: 10,
+    });
+    const writer = writable.getWriter();
+    writer.write(enc.encode('hellohello'));
+    writer.close();
+    const resp = await env.subrequest.fetch('http://example.org', {
+      method: 'POST',
+      body: readable
+    });
+    for await (const _ of resp.body) {}
+  }
+};
+
+export default {
+  async fetch(request, env) {
+    strictEqual(request.headers.get('content-length'), '10');
+    return new Response(request.body);
+  }
+};
+

--- a/src/workerd/api/tests/streams-test.wd-test
+++ b/src/workerd/api/tests/streams-test.wd-test
@@ -1,0 +1,18 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "streams-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "streams-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat"],
+        bindings = [
+          (name = "subrequest", service = "streams-test")
+        ]
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
Allows setting an `expectedLength` option for JS-backed readable and transform streams. When the readable stream is used as the body of a request or response, the expectedLength is used as the value of the content-length header. When set, chunked encoding will not be used.