### PR TITLE
Implement climem memory monitor service

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -10,6 +10,7 @@
 #include <workerd/util/color-util.h>
 #include <workerd/util/mimetype.h>
 #include <workerd/util/stream-utils.h>
+#include <workerd/util/string-buffer.h>
 #include <workerd/util/thread-scopes.h>
 #include <workerd/util/xthreadnotifier.h>
 #include <workerd/api/actor-state.h>
@@ -1243,6 +1244,10 @@ Worker::Script::~Script() noexcept(false) {
     }
     impl = nullptr;
   });
+}
+
+const jsg::MemStats Worker::Isolate::getCurrentMemStats(jsg::Lock& lock) const {
+  return api->getCurrentMemStats(lock);
 }
 
 const Worker::Isolate& Worker::Isolate::from(jsg::Lock& js) {

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -334,6 +334,8 @@ public:
 
   kj::Own<const WeakIsolateRef> getWeakRef() const;
 
+  const jsg::MemStats getCurrentMemStats(jsg::Lock&) const;
+
 private:
   kj::Promise<AsyncLock> takeAsyncLockImpl(
       kj::Maybe<kj::Own<IsolateObserver::LockTiming>> lockTiming) const;
@@ -440,6 +442,10 @@ public:
   // WebCrypto algorithms supported.
   virtual kj::Maybe<const api::CryptoAlgorithm&> getCryptoAlgorithm(kj::StringPtr name) const {
     return kj::none;
+  }
+
+  virtual const jsg::MemStats getCurrentMemStats(jsg::Lock&) const {
+    return {};
   }
 
   // Set the module fallback service callback, if any.

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2302,6 +2302,25 @@ auto runInV8Stack(auto callback) {
   return V8StackScope::runInV8StackImpl(__builtin_frame_address(0), kj::mv(callback));
 };
 
+
+// =======================================================================================
+struct MemStats {
+  size_t total_heap_size;
+  size_t total_heap_size_executable;
+  size_t total_physical_size;
+  size_t total_available_size;
+  size_t total_global_handles_size;
+  size_t used_global_handles_size;
+  size_t used_heap_size;
+  size_t heap_size_limit;
+  size_t malloced_memory;
+  size_t external_memory;
+  size_t peak_malloced_memory;
+  size_t number_of_native_contexts;
+  size_t number_of_detached_contexts;
+  kj::String toString(kj::Maybe<size_t> maybeRss) const;
+};
+
 // =======================================================================================
 // inline implementation details
 

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -124,6 +124,26 @@ public:
 
   IsolateObserver& getObserver() { return *observer; }
 
+  inline const MemStats getCurrentMemStats(Lock&) const {
+    v8::HeapStatistics stats;
+    ptr->GetHeapStatistics(&stats);
+    return {
+      .total_heap_size = stats.total_heap_size(),
+      .total_heap_size_executable = stats.total_heap_size_executable(),
+      .total_physical_size = stats.total_physical_size(),
+      .total_available_size = stats.total_available_size(),
+      .total_global_handles_size = stats.total_global_handles_size(),
+      .used_global_handles_size = stats.used_global_handles_size(),
+      .used_heap_size = stats.used_heap_size(),
+      .heap_size_limit = stats.heap_size_limit(),
+      .malloced_memory = stats.malloced_memory(),
+      .external_memory = stats.external_memory(),
+      .peak_malloced_memory = stats.peak_malloced_memory(),
+      .number_of_native_contexts = stats.number_of_native_contexts(),
+      .number_of_detached_contexts = stats.number_of_detached_contexts(),
+    };
+  }
+
 private:
   template <typename TypeWrapper>
   friend class Isolate;

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -54,6 +54,9 @@ public:
   void enableInspector(kj::String addr) {
     inspectorOverride = kj::mv(addr);
   }
+  void enableClimem(kj::String addr) {
+    climemOverride = kj::mv(addr);
+  }
   void enableControl(uint fd) {
     controlOverride = kj::heap<kj::FdOutputStream>(fd);
   }
@@ -83,6 +86,8 @@ public:
   class InspectorService;
   class InspectorServiceIsolateRegistrar;
 
+  class ClimemServiceRegistrar;
+
 private:
   kj::Filesystem& fs;
   kj::Timer& timer;
@@ -104,7 +109,9 @@ private:
   kj::HashMap<kj::String, kj::String> externalOverrides;
 
   kj::Maybe<kj::String> inspectorOverride;
+  kj::Maybe<kj::String> climemOverride;
   kj::Maybe<kj::Own<InspectorServiceIsolateRegistrar>> inspectorIsolateRegistrar;
+  kj::Maybe<kj::Own<ClimemServiceRegistrar>> climemServiceRegistrar;
   kj::Maybe<kj::Own<kj::FdOutputStream>> controlOverride;
 
   struct GlobalContext;

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -746,6 +746,10 @@ WorkerdApi::Global WorkerdApi::Global::clone() const {
   return result;
 }
 
+const jsg::MemStats WorkerdApi::getCurrentMemStats(jsg::Lock& js) const {
+  return impl->jsgIsolate.getCurrentMemStats(js);
+}
+
 const WorkerdApi& WorkerdApi::from(const Worker::Api& api) {
   return kj::downcast<const WorkerdApi>(api);
 }

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -195,6 +195,8 @@ public:
   void setModuleFallbackCallback(
        kj::Function<ModuleFallbackCallback>&& callback) const override;
 
+  const jsg::MemStats getCurrentMemStats(jsg::Lock&) const override;
+
 private:
   struct Impl;
   kj::Own<Impl> impl;

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -593,6 +593,8 @@ public:
                           "<addr> instead of the address specified in the config file.")
         .addOptionWithArg({'i', "inspector-addr"}, CLI_METHOD(enableInspector), "<addr>",
                           "Enable the inspector protocol to connect to the address <addr>.")
+        .addOptionWithArg({'m', "climem"}, CLI_METHOD(enableClimem), "<addr>",
+                          "Enable a local memory-monitor service")
 #if defined(WORKERD_USE_PERFETTO)
         // TODO(later): In the future, we might want to enable providing a perfetto
         // TraceConfig structure here rather than just the categories.
@@ -785,6 +787,10 @@ public:
 
   void enableInspector(kj::StringPtr param) {
     server.enableInspector(kj::str(param));
+  }
+
+  void enableClimem(kj::StringPtr param) {
+    server.enableClimem(kj::str(param));
   }
 
   void enableControl(kj::StringPtr param) {

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -26,6 +26,7 @@ wd_cc_library(
 wd_cc_library(
     name = "util",
     srcs = [
+        "mem-utils.c++",
         "mimetype.c++",
         "stream-utils.c++",
         "uuid.c++",

--- a/src/workerd/util/mem-utils.c++
+++ b/src/workerd/util/mem-utils.c++
@@ -1,0 +1,47 @@
+#include "mem-utils.h"
+
+#include <kj/debug.h>
+#include <kj/filesystem.h>
+
+#if !_WIN32
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#endif
+
+namespace workerd::util {
+
+#if defined(__linux__)
+kj::Maybe<size_t> tryGetResidentSetMemory() {
+  int fd_;
+  KJ_SYSCALL(fd_ = open("/proc/self/stat", O_RDONLY));
+  kj::AutoCloseFd fd(fd_);
+  auto text = kj::FdInputStream(kj::mv(fd)).readAllText();
+  auto p = text.begin();
+  for (kj::uint i = 0; i < 23; i++) {
+    p = strchr(p, ' ');
+    KJ_ASSERT(p != nullptr, "/proc/self/stat format not understood", text);
+    ++p;
+  }
+  auto rss = strtoull(p, nullptr, 10);
+  size_t result = rss * getpagesize();
+  return result;
+}
+#elif defined(__APPLE__)
+kj::Maybe<size_t> tryGetResidentSetMemory() {
+  // TODO(soon): Implement etting the RSS for macOS
+  return kj::none;
+}
+#elif defined(_WIN32)
+kj::Maybe<size_t> tryGetResidentSetMemory() {
+  // TODO(soon): Implement getting the RSS for Windows
+  return kj::none;
+}
+#elif
+kj::Maybe<size_t> tryGetResidentSetMemory() {
+  // For all other platforms we simply return nothing
+  return kj::none;
+}
+#endif
+
+}  // namespace workerd::util

--- a/src/workerd/util/mem-utils.h
+++ b/src/workerd/util/mem-utils.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <kj/common.h>
+
+namespace workerd::util {
+
+kj::Maybe<size_t> tryGetResidentSetMemory();
+
+}  // namespace workerd::util


### PR DESCRIPTION
[`climem`](https://www.npmjs.com/package/climem) is a tool that I've used extensively in the past for diagnosing memory leaks in node.js applications. It provides simple monitoring of v8 memory usage and rss for the application and displays it in a chart in the terminal.

This PR implements support for climem directly within workerd. The workerd portion of it is implemented as a simple TCP server (per isolate) that, when connected, generates a json-serialized log of the current memory stats for the process/isolate. 

To use, specify the `-m localhost` option when running workerd serve. Then install `climem` from npm and run it, pointing at the tcp port that worker tells you the climem server is running on.

It's extremely rudimentary but that's the goal. Keep it simple.

/cc  @mcollina who wrote `climem`