### PR TITLE
Implement MemoryTracker for Heap Snapshots

### DIFF
--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -18,6 +18,7 @@ wd_cc_library(
         exclude = [
             "exception.h",
             "observer.h",
+            "memory.h",
             "rtti.h",
             "url-test-corpus-failures.h",
             "url-test-corpus-success.h",
@@ -26,6 +27,7 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":exception",
+        ":memory-tracker",
         ":modules_capnp",
         ":observer",
         ":url",
@@ -33,6 +35,16 @@ wd_cc_library(
         "//src/workerd/util:sentry",
         "//src/workerd/util:thread-scopes",
         "//src/workerd/util:autogate",
+        "@capnp-cpp//src/kj",
+        "@workerd-v8//:v8",
+    ],
+)
+
+wd_cc_library(
+    name = "memory-tracker",
+    hdrs = ["memory.h"],
+    visibility = ["//visibility:public"],
+    deps = [
         "@capnp-cpp//src/kj",
         "@workerd-v8//:v8",
     ],
@@ -48,6 +60,7 @@ wd_cc_library(
     deps = [
         "@capnp-cpp//src/kj",
         "@ada-url",
+        ":memory-tracker",
     ],
 )
 

--- a/src/workerd/jsg/buffersource.h
+++ b/src/workerd/jsg/buffersource.h
@@ -207,6 +207,10 @@ public:
     return BackingStore(backingStore, byteLength, byteOffset, elementSize, ctor, integerType);
   }
 
+  JSG_MEMORY_INFO(BackingStore) {
+    tracker.trackFieldWithSize("buffer", size());
+  }
+
 private:
   std::shared_ptr<v8::BackingStore> backingStore;
   size_t byteLength;
@@ -362,6 +366,13 @@ public:
   // Sets the detach key that must be provided with the detach(...) method
   // to successfully detach the backing store.
   void setDetachKey(Lock& js, v8::Local<v8::Value> key);
+
+  JSG_MEMORY_INFO(BufferSource) {
+    tracker.trackField("handle", handle);
+    KJ_IF_SOME(backing, maybeBackingStore) {
+      tracker.trackField("backing", backing);
+    }
+  }
 
 private:
   Value handle;

--- a/src/workerd/jsg/dom-exception.c++
+++ b/src/workerd/jsg/dom-exception.c++
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "dom-exception.h"
+#include <workerd/jsg/memory.h>
 #include <kj/string.h>
 #include <map>
 

--- a/src/workerd/jsg/dom-exception.h
+++ b/src/workerd/jsg/dom-exception.h
@@ -106,6 +106,12 @@ public:
 #undef JSG_DOM_EXCEPTION_CONSTANT_CXX
 #undef JSG_DOM_EXCEPTION_CONSTANT_JS
 
+  void visitForMemoryInfo(MemoryTracker& tracker) const {
+    tracker.trackField("message", message);
+    tracker.trackField("name", name);
+    tracker.trackField("errorForStack", errorForStack);
+  }
+
 private:
   kj::String message;
   kj::String name;

--- a/src/workerd/jsg/function-test.c++
+++ b/src/workerd/jsg/function-test.c++
@@ -8,7 +8,7 @@ namespace workerd::jsg::test {
 namespace {
 
 V8System v8System;
-class ContextGlobalObject: public Object, public ContextGlobal { };
+class ContextGlobalObject: public Object, public ContextGlobal {};
 
 struct CallbackContext: public ContextGlobalObject {
   kj::String callCallback(Lock& js, jsg::Function<kj::String(kj::StringPtr, double)> function) {

--- a/src/workerd/jsg/iterator-test.c++
+++ b/src/workerd/jsg/iterator-test.c++
@@ -10,6 +10,7 @@ namespace {
 V8System v8System;
 
 struct GeneratorContext: public Object, public ContextGlobal {
+
   uint generatorTest(Lock& js, Generator<kj::String> generator) {
 
     KJ_DEFER(generator.forEach(js, [](auto& js, auto, auto&) {

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -35,7 +35,7 @@ static_assert(kj::_::isDisallowedInCoroutine<Lock*>());
 // ========================================================================================
 
 V8System v8System;
-class ContextGlobalObject: public Object, public ContextGlobal { };
+class ContextGlobalObject: public Object, public ContextGlobal {};
 
 struct TestContext: public ContextGlobalObject {
   JSG_RESOURCE_TYPE(TestContext) {}

--- a/src/workerd/jsg/jsvalue-test.c++
+++ b/src/workerd/jsg/jsvalue-test.c++
@@ -8,7 +8,7 @@ namespace workerd::jsg::test {
 namespace {
 
 V8System v8System;
-class ContextGlobalObject: public Object, public ContextGlobal { };
+class ContextGlobalObject: public Object, public ContextGlobal {};
 
 struct JsValueContext: public ContextGlobalObject {
   JsRef<JsValue> persisted;

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -455,12 +455,18 @@ public:
   operator V8Ref<U>() && { return kj::mv(value).template cast<U>(
       Lock::from(v8::Isolate::GetCurrent())); }
 
+  JSG_MEMORY_INFO(JsRef) {
+    tracker.trackField("value", value);
+  }
+
 private:
   Value value;
   friend class JsValue;
 #define V(Name) friend class Js##Name;
   JS_TYPE_CLASSES(V)
 #undef V
+
+  friend class MemoryTracker;
 };
 
 template <typename T, typename Self>

--- a/src/workerd/jsg/memory-test.c++
+++ b/src/workerd/jsg/memory-test.c++
@@ -1,0 +1,110 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "jsg-test.h"
+#include <workerd/jsg/memory.h>
+#include <v8-profiler.h>
+#include <kj/map.h>
+
+namespace workerd::jsg::test {
+namespace {
+
+V8System v8System;
+class ContextGlobalObject: public Object, public ContextGlobal {};
+
+struct Foo: public Object {
+  kj::String bar = kj::str("test");
+
+  JSG_RESOURCE_TYPE(Foo) {}
+  void visitForMemoryInfo(MemoryTracker& tracker) const {
+    tracker.trackField("bar", bar);
+  }
+};
+
+struct MemoryTrackerContext: public ContextGlobalObject {
+  JSG_RESOURCE_TYPE(MemoryTrackerContext) {}
+};
+JSG_DECLARE_ISOLATE_TYPE(MemoryTrackerIsolate, MemoryTrackerContext, Foo);
+
+void runTest(auto callback) {
+  MemoryTrackerIsolate isolate(v8System, kj::heap<jsg::IsolateObserver>());
+  isolate.runInLockScope([&](MemoryTrackerIsolate::Lock& lock) {
+    JSG_WITHIN_CONTEXT_SCOPE(lock,
+        lock.newContext<MemoryTrackerContext>().getHandle(lock),
+        [&](jsg::Lock& js) {
+      callback(js, lock.getTypeHandler<Ref<Foo>>());
+    });
+  });
+}
+
+KJ_TEST("MemoryTracker test") {
+
+  // Verifies that workerd details are included in the heapsnapshot.
+  // This is not a comprehensive test of the heapsnapshot content,
+  // it is designed just to make sure that we are, in fact, publishing
+  // internal details to the snapshot.
+
+  runTest([&](jsg::Lock& js, const TypeHandler<Ref<Foo>>& fooHandler) {
+    kj::Vector<char> serialized;
+    HeapSnapshotActivity activity([](auto, auto) {
+      return true;
+    });
+    HeapSnapshotWriter writer([&](kj::Maybe<kj::ArrayPtr<char>> maybeChunk) {
+      KJ_IF_SOME(chunk, maybeChunk) {
+        serialized.addAll(chunk);
+      }
+      return true;
+    });
+
+    IsolateBase& base = IsolateBase::from(js.v8Isolate);
+    base.getUuid();
+
+    auto foo = fooHandler.wrap(js, alloc<Foo>());
+    KJ_ASSERT(foo->IsObject());
+
+    auto profiler = js.v8Isolate->GetHeapProfiler();
+
+    HeapSnapshotDeleter deleter;
+
+    auto snapshot = kj::Own<const v8::HeapSnapshot>(
+      profiler->TakeHeapSnapshot(&activity, nullptr, true, true),
+      deleter);
+    snapshot->Serialize(&writer, v8::HeapSnapshot::kJSON);
+
+    auto parsed = js.parseJson(serialized.asPtr());
+    JsValue value = JsValue(parsed.getHandle(js));
+    KJ_ASSERT(value.isObject());
+
+    JsObject obj = KJ_ASSERT_NONNULL(value.tryCast<JsObject>());
+
+    auto strings = obj.get(js, "strings");
+    KJ_ASSERT(strings.isArray());
+
+    JsArray array = KJ_ASSERT_NONNULL(strings.tryCast<JsArray>());
+
+    size_t count = 0;
+
+    kj::HashSet<kj::String> checks;
+    checks.insert(kj::str("workerd / IsolateBase"));
+    checks.insert(kj::str("workerd / kj::String"));
+    checks.insert(kj::str("workerd / HeapTracer"));
+    checks.insert(kj::str("workerd / CppgcShim"));
+    checks.insert(kj::str("workerd / MemoryTrackerContext"));
+    checks.insert(kj::str("workerd / Foo"));
+
+    // Find what we're looking for... this is slow but, you know
+    for (size_t n = 0; n < array.size(); n++) {
+      JsValue check = array.get(js, n);
+      auto str = check.toString(js);
+      if (str.startsWith("workerd /")) {
+        count++;
+        KJ_ASSERT(checks.find(str) != kj::none);
+      }
+    }
+    KJ_ASSERT(count == checks.size());
+  });
+}
+
+}  // namespace
+}  // namespace workerd::jsg::test

--- a/src/workerd/jsg/memory.h
+++ b/src/workerd/jsg/memory.h
@@ -1,0 +1,810 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Implements mechanism for incorporating details about the native (c++) objects
+// in a v8 heap snapshot. The design of the API and implementation were heavily
+// influenced by Node.js' implementation of the same feature.
+
+#pragma once
+
+#include <kj/common.h>
+#include <kj/debug.h>
+#include <kj/exception.h>
+#include <kj/hash.h>
+#include <kj/table.h>
+#include <kj/string.h>
+#include <v8-profiler.h>
+#include <v8.h>
+#include <stack>
+#include <string>
+
+namespace workerd::jsg {
+
+class MemoryTracker;
+class MemoryRetainerNode;
+
+template <typename T> class V8Ref;
+template <typename T> class Ref;
+
+enum class MemoryInfoDetachedState {
+  UNKNOWN,
+  ATTACHED,
+  DETACHED,
+};
+
+template <typename T>
+concept MemoryRetainer = requires(const T* a) {
+  std::is_member_function_pointer_v<decltype(&T::jsgGetMemoryInfo)>;
+  std::is_member_function_pointer_v<decltype(&T::jsgGetMemoryName)>;
+  std::is_member_function_pointer_v<decltype(&T::jsgGetMemorySelfSize)>;
+};
+
+template <typename T>
+concept MemoryRetainerObject = requires(T a) {
+  MemoryRetainer<T>;
+  std::is_member_function_pointer_v<decltype(&T::jsgGetMemoryInfoWrapperObject)>;
+};
+
+template <typename T>
+concept MemoryRetainerDetachedState = requires(T a) {
+  MemoryRetainer<T>;
+  std::is_member_function_pointer_v<decltype(&T::jsgGetMemoryInfoDetachedState)>;
+};
+
+template <typename T>
+concept MemoryRetainerIsRootNode = requires(T a) {
+  MemoryRetainer<T>;
+  std::is_member_function_pointer_v<decltype(&T::jsgGetMemoryInfoIsRootNode)>;
+};
+
+template <typename T>
+concept V8Value = requires(T a) {
+  std::is_assignable_v<v8::Value, T>;
+};
+
+#define JSG_MEMORY_INFO(Name)                                                            \
+  kj::StringPtr jsgGetMemoryName() const {                                               \
+    return #Name ## _kjc;                                                                \
+  }                                                                                      \
+  size_t jsgGetMemorySelfSize() const { return sizeof(Name); }                           \
+  void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const
+
+#define JSG_MEMORY_INFO_GET_DETACHED_STATE()                                             \
+  MemoryInfoDetachedState jsgGetMemoryInfoDetachedState() const
+
+#define JSG_MEMORY_INFO_GET_DETACHEDNESS()                                               \
+  MemoryInfoDetachedState jsgGetMemoryInfoDetachedState()
+
+#define JSG_MEMORY_INFO_IS_ROOTNODE()                                                    \
+  bool jsgGetMemoryInfoIsRootNode() const
+
+class MemoryTracker final {
+public:
+  inline MemoryTracker& trackFieldWithSize(
+      kj::StringPtr edgeName, size_t size,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  inline MemoryTracker& trackInlineFieldWithSize(
+      kj::StringPtr edgeName, size_t size,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <MemoryRetainer T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const kj::Own<T>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <MemoryRetainer T, typename D>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const std::unique_ptr<T, D>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <MemoryRetainer T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const std::shared_ptr<T>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <V8Value T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const V8Ref<T>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <MemoryRetainer T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const Ref<T>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <MemoryRetainer T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const T& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <typename T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const kj::Maybe<T>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <typename T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const kj::Maybe<T&>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const kj::String& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <typename T,
+            typename test = typename std::
+                enable_if<std::numeric_limits<T>::is_specialized, bool>::type,
+            typename dummy = bool>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const kj::Array<T>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <MemoryRetainer T, typename ... Indexes>
+  MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const kj::Table<T, Indexes...>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none,
+      kj::Maybe<kj::StringPtr> elementName = kj::none,
+      bool subtractFromSelf = true) KJ_LIFETIMEBOUND;
+
+  template <MemoryRetainer T, typename Iterator = typename T::const_iterator>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const T& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none,
+      kj::Maybe<kj::StringPtr> elementName = kj::none,
+      bool subtractFromSelf = true) KJ_LIFETIMEBOUND;
+
+  template <MemoryRetainer T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const kj::ArrayPtr<T>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none,
+      kj::Maybe<kj::StringPtr> elementName = kj::none,
+      bool subtractFromSelf = true) KJ_LIFETIMEBOUND;
+
+  template <MemoryRetainer T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const kj::ArrayPtr<T* const>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none,
+      kj::Maybe<kj::StringPtr> elementName = kj::none,
+      bool subtractFromSelf = true) KJ_LIFETIMEBOUND;
+
+  template <MemoryRetainer T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const T* value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <typename T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const std::basic_string<T>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <typename T,
+            typename test_for_number = typename std::
+                enable_if<std::numeric_limits<T>::is_specialized, bool>::type,
+            typename dummy = bool>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const T& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <V8Value T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const v8::Eternal<T>& value,
+      kj::StringPtr nodeName) KJ_LIFETIMEBOUND;
+
+  template <V8Value T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const v8::PersistentBase<T>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <V8Value T>
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const v8::Local<T>& value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  inline MemoryTracker& trackField(
+      kj::StringPtr edgeName,
+      const v8::BackingStore* value,
+      kj::Maybe<kj::StringPtr> nodeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <MemoryRetainer T>
+  inline MemoryTracker& track(
+      const T* retainer,
+      kj::Maybe<kj::StringPtr> edgeName = kj::none) KJ_LIFETIMEBOUND;
+
+  template <MemoryRetainer T>
+  inline MemoryTracker& trackInlineField(
+      const T* retainer,
+      kj::Maybe<kj::StringPtr> edgeName = kj::none) KJ_LIFETIMEBOUND;
+
+  inline v8::EmbedderGraph* graph() { return graph_; }
+  inline v8::Isolate* isolate() { return isolate_; }
+
+  KJ_DISALLOW_COPY_AND_MOVE(MemoryTracker);
+
+private:
+
+  struct NodeMapEntry {
+    const void* retainer;
+    MemoryRetainerNode* node;
+  };
+
+  struct NodeMapCallbacks {
+    const void* keyForRow(const NodeMapEntry& row) const {
+      return row.retainer;
+    }
+    bool matches(const NodeMapEntry& row, const void* key) const {
+      return row.retainer == key;
+    }
+    kj::uint hashCode(const void* row) const {
+      return kj::hashCode(row);
+    }
+  };
+
+  using NodeMap = kj::Table<NodeMapEntry, kj::HashIndex<NodeMapCallbacks>,
+                                          kj::InsertionOrderIndex>;
+
+  v8::Isolate* isolate_;
+  v8::EmbedderGraph* graph_;
+  std::stack<MemoryRetainerNode*> nodeStack_;
+  NodeMap seen_;
+  KJ_DISALLOW_AS_COROUTINE_PARAM;
+
+  inline explicit MemoryTracker(v8::Isolate* isolate,
+                                v8::EmbedderGraph* graph)
+    : isolate_(isolate),
+      graph_(graph),
+      seen_(NodeMapCallbacks(), {}) {}
+
+  inline kj::Maybe<MemoryRetainerNode&> getCurrentNode() const;
+
+  template <MemoryRetainer T>
+  inline MemoryRetainerNode* addNode(const T* retainer,
+                                     kj::Maybe<kj::StringPtr> edgeName = kj::none);
+
+  template <MemoryRetainer T>
+  inline MemoryRetainerNode* pushNode(const T* retainer,
+                                      kj::Maybe<kj::StringPtr> edgeName = kj::none);
+
+  inline MemoryRetainerNode* addNode(kj::StringPtr node_name,
+                                     size_t size,
+                                     kj::Maybe<kj::StringPtr> edgeName = kj::none);
+  inline MemoryRetainerNode* pushNode(kj::StringPtr node_name,
+                                      size_t size,
+                                      kj::Maybe<kj::StringPtr> edgeName = kj::none);
+  inline void popNode();
+
+  inline static kj::StringPtr getNodeName(kj::Maybe<kj::StringPtr> nodeName,
+                                          kj::StringPtr edgeName) {
+    KJ_IF_SOME(name, nodeName) { return name; }
+    return edgeName;
+  }
+
+  friend class IsolateBase;
+};
+
+class MemoryRetainerNode final : public v8::EmbedderGraph::Node {
+public:
+  static constexpr auto PREFIX = "workerd /";
+
+  const char* Name() override { return name_.cStr(); }
+
+  const char* NamePrefix() override { return PREFIX; }
+
+  size_t SizeInBytes() override { return size_; }
+
+  bool IsRootNode() override {
+    KJ_IF_SOME(check, checkIsRootNode) {
+      return check();
+    }
+    return isRootNode_;
+  }
+
+  v8::EmbedderGraph::Node::Detachedness GetDetachedness() override {
+    return detachedness_;
+  }
+
+  inline Node* JSWrapperNode() { return wrapper_node_; }
+
+  KJ_DISALLOW_COPY_AND_MOVE(MemoryRetainerNode);
+  ~MemoryRetainerNode() noexcept(true) {}
+
+private:
+  static inline v8::EmbedderGraph::Node::Detachedness fromDetachedState(
+      MemoryInfoDetachedState state) {
+    switch (state) {
+      case MemoryInfoDetachedState::UNKNOWN:
+        return v8::EmbedderGraph::Node::Detachedness::kUnknown;
+      case MemoryInfoDetachedState::ATTACHED:
+        return v8::EmbedderGraph::Node::Detachedness::kAttached;
+      case MemoryInfoDetachedState::DETACHED:
+        return v8::EmbedderGraph::Node::Detachedness::kDetached;
+    }
+    KJ_UNREACHABLE;
+  }
+
+  template <MemoryRetainer T>
+  inline MemoryRetainerNode(MemoryTracker* tracker,
+                            const T* retainer)
+      : retainer_(retainer) {
+    KJ_ASSERT(retainer_ != nullptr);
+    v8::HandleScope handle_scope(tracker->isolate());
+    if constexpr (MemoryRetainerObject<T>) {
+      v8::Local<v8::Object> obj =
+          const_cast<T*>(retainer)->jsgGetMemoryInfoWrapperObject(tracker->isolate());
+      if (!obj.IsEmpty()) wrapper_node_ = tracker->graph()->V8Node(obj);
+    }
+    if constexpr (MemoryRetainerIsRootNode<T>) {
+      checkIsRootNode = [retainer]() { return retainer->jsgGetMemoryInfoIsRootNode(); };
+    }
+
+    name_ = retainer->jsgGetMemoryName();
+    size_ = retainer->jsgGetMemorySelfSize();
+    if constexpr (MemoryRetainerDetachedState<T>) {
+      detachedness_ = fromDetachedState(retainer->jsgGetMemoryInfoDetachedState());
+    }
+  }
+
+  inline MemoryRetainerNode(MemoryTracker* tracker,
+                            kj::StringPtr name,
+                            size_t size,
+                            bool isRootNode = false)
+      : isRootNode_(isRootNode),
+        name_(name),
+        size_(size) {}
+
+  const void* retainer_ = nullptr;
+  v8::EmbedderGraph::Node* wrapper_node_ = nullptr;
+
+  kj::Maybe<kj::Function<bool()>> checkIsRootNode = kj::none;
+
+  bool isRootNode_ = false;
+  kj::StringPtr name_;
+  size_t size_ = 0;
+  v8::EmbedderGraph::Node::Detachedness detachedness_ =
+      v8::EmbedderGraph::Node::Detachedness::kUnknown;
+
+  friend class MemoryTracker;
+};
+
+// ======================================================================================
+
+kj::Maybe<MemoryRetainerNode&> MemoryTracker::getCurrentNode() const {
+  if (nodeStack_.empty()) return kj::none;
+  return *nodeStack_.top();
+}
+
+MemoryTracker& MemoryTracker::trackFieldWithSize(
+    kj::StringPtr edgeName, size_t size,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  if (size > 0) addNode(getNodeName(nodeName, edgeName), size, edgeName);
+  return *this;
+}
+
+MemoryTracker& MemoryTracker::trackInlineFieldWithSize(
+    kj::StringPtr edgeName, size_t size,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  if (size > 0) addNode(getNodeName(nodeName, edgeName), size, edgeName);
+  KJ_ASSERT_NONNULL(getCurrentNode()).size_ = size;
+  return *this;
+}
+
+// ======================================================================================
+
+template <MemoryRetainer T>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const kj::Own<T>& value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  if (value.get() == nullptr) return *this;
+  return trackField(edgeName, value.get(), nodeName);
+}
+
+template <MemoryRetainer T, typename D>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const std::unique_ptr<T, D>& value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  if (value.get() == nullptr) return *this;
+  return trackField(edgeName, value.get(), nodeName);
+}
+
+template <MemoryRetainer T>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const std::shared_ptr<T>& value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  if (value.get() == nullptr) return *this;
+  return trackField(edgeName, value.get(), nodeName);
+}
+
+template <typename T>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const kj::Maybe<T>& value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  KJ_IF_SOME(v, value) {
+    trackField(edgeName, v, nodeName);
+  }
+  return *this;
+}
+
+template <typename T>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const kj::Maybe<T&>& value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  KJ_IF_SOME(v, value) {
+    trackField(edgeName, v, nodeName);
+  }
+  return *this;
+}
+
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const kj::String& value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  return trackFieldWithSize(edgeName, value.size(), "kj::String"_kjc);
+}
+
+template <typename T>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const std::basic_string<T>& value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  return trackFieldWithSize(edgeName, value.size() * sizeof(T), "std::basic_string"_kjc);
+}
+
+template <typename T, typename test, typename dummy>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const kj::Array<T>& value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  return trackFieldWithSize(edgeName, value.size() * sizeof(T), "kj::Array<T>"_kjc);
+}
+
+template <MemoryRetainer T, typename ... Indexes>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const kj::Table<T, Indexes...>& value,
+    kj::Maybe<kj::StringPtr> nodeName,
+    kj::Maybe<kj::StringPtr> elementName,
+    bool subtractFromSelf) {
+  if (value.begin() == value.end()) return *this;
+  KJ_IF_SOME(currentNode, getCurrentNode()) {
+    if (subtractFromSelf) {
+      currentNode.size_ -= sizeof(T);
+    }
+  }
+  pushNode(getNodeName(nodeName, edgeName), sizeof(T), edgeName);
+  for (auto it = value.begin(); it != value.end(); ++it) {
+    // Use nullptr as edge names so the elements appear as indexed properties
+    trackField(nullptr, *it, elementName);
+  }
+  popNode();
+  return *this;
+}
+
+template <MemoryRetainer T, typename Iterator>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const T& value,
+    kj::Maybe<kj::StringPtr> nodeName,
+    kj::Maybe<kj::StringPtr> elementName,
+    bool subtractFromSelf) {
+  if (value.begin() == value.end()) return *this;
+  KJ_IF_SOME(currentNode, getCurrentNode()) {
+    if (subtractFromSelf) {
+      currentNode.size_ -= sizeof(T);
+    }
+  }
+  pushNode(getNodeName(nodeName, edgeName), sizeof(T), edgeName);
+  for (Iterator it = value.begin(); it != value.end(); ++it) {
+    // Use nullptr as edge names so the elements appear as indexed properties
+    trackField(nullptr, *it, elementName);
+  }
+  popNode();
+  return *this;
+}
+
+template <MemoryRetainer T>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const kj::ArrayPtr<T>& value,
+    kj::Maybe<kj::StringPtr> nodeName,
+    kj::Maybe<kj::StringPtr> elementName,
+    bool subtractFromSelf) {
+  if (value.begin() == value.end()) return *this;
+  KJ_IF_SOME(currentNode, getCurrentNode()) {
+    if (subtractFromSelf) {
+      currentNode.size_ -= sizeof(T);
+    }
+  }
+  pushNode(getNodeName(nodeName, edgeName), sizeof(T), edgeName);
+  for (const auto item : value) {
+    // Use nullptr as edge names so the elements appear as indexed properties
+    trackField(nullptr, item, elementName);
+  }
+  popNode();
+  return *this;
+}
+
+template <MemoryRetainer T>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const kj::ArrayPtr<T* const>& value,
+    kj::Maybe<kj::StringPtr> nodeName,
+    kj::Maybe<kj::StringPtr> elementName,
+    bool subtractFromSelf) {
+  if (value.begin() == value.end()) return *this;
+  KJ_IF_SOME(currentNode, getCurrentNode()) {
+    if (subtractFromSelf) {
+      currentNode.size_ -= sizeof(T);
+    }
+  }
+  pushNode(getNodeName(nodeName, edgeName), sizeof(T), edgeName);
+  for (const auto item : value) {
+    // Use nullptr as edge names so the elements appear as indexed properties
+    trackField(nullptr, item, elementName);
+  }
+  popNode();
+  return *this;
+}
+
+template <MemoryRetainer T>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const T& value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  return trackField(edgeName, &value, nodeName);
+}
+
+template <MemoryRetainer T>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const T* value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  if (value == nullptr) return *this;
+  KJ_IF_SOME(found, seen_.find(value)) {
+    KJ_IF_SOME(currentNode, getCurrentNode()) {
+      graph_->AddEdge(&currentNode, found.node, edgeName.cStr());
+    } else {
+      graph_->AddEdge(nullptr, found.node, edgeName.cStr());
+    }
+    return *this;
+  }
+
+  return track(value, edgeName);
+}
+
+template <typename T, typename test_for_number, typename dummy>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const T& value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  KJ_ASSERT_NONNULL(getCurrentNode()).size_ += sizeof(T);
+  return *this;
+}
+
+template <V8Value T>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const v8::Eternal<T>& value,
+    kj::StringPtr nodeName) {
+  return trackField(edgeName, value.Get(isolate_));
+}
+
+template <V8Value T>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const v8::PersistentBase<T>& value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  if (value.IsWeak()) return *this;
+  return trackField(edgeName, value.Get(isolate_));
+}
+
+template <V8Value T>
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const v8::Local<T>& value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  if (!value.IsEmpty()) {
+    KJ_IF_SOME(currentNode, getCurrentNode()) {
+      graph_->AddEdge(&currentNode, graph_->V8Node(value), edgeName.cStr());
+    } else {
+      graph_->AddEdge(nullptr, graph_->V8Node(value), edgeName.cStr());
+    }
+  }
+  return *this;
+}
+
+MemoryTracker& MemoryTracker::trackField(
+    kj::StringPtr edgeName,
+    const v8::BackingStore* value,
+    kj::Maybe<kj::StringPtr> nodeName) {
+  return trackFieldWithSize(edgeName, value->ByteLength(), "BackingStore"_kjc);
+}
+
+// Put a memory container into the graph, create an edge from
+// the current node if there is one on the stack.
+template <MemoryRetainer T>
+MemoryTracker& MemoryTracker::track(const T* retainer, kj::Maybe<kj::StringPtr> edgeName) {
+  v8::HandleScope handle_scope(isolate_);
+  KJ_IF_SOME(found, seen_.find(retainer)) {
+    KJ_IF_SOME(currentNode, getCurrentNode()) {
+      KJ_IF_SOME(name, edgeName) {
+        graph_->AddEdge(&currentNode, found.node, name.cStr());
+      } else {
+        graph_->AddEdge(&currentNode, found.node, nullptr);
+      }
+    }
+    return *this;
+  }
+
+  MemoryRetainerNode* n = pushNode(retainer, edgeName);
+  retainer->jsgGetMemoryInfo(*this);
+  KJ_ASSERT(&KJ_ASSERT_NONNULL(getCurrentNode()) == n);
+  KJ_ASSERT(n->size_ != 0);
+  popNode();
+  return *this;
+}
+
+// Useful for parents that do not wish to perform manual
+// adjustments to its `SelfSize()` when embedding retainer
+// objects inline.
+// Put a memory container into the graph, create an edge from
+// the current node if there is one on the stack - there should
+// be one, of the container object which the current field is part of.
+// Reduce the size of memory from the container so as to avoid
+// duplication in accounting.
+template <MemoryRetainer T>
+MemoryTracker& MemoryTracker::trackInlineField(
+    const T* retainer,
+    kj::Maybe<kj::StringPtr> edgeName) {
+  track(retainer, edgeName);
+  KJ_ASSERT_NONNULL(getCurrentNode()).size_ -= retainer->getMemorySelfSize();
+  return *this;
+}
+
+template <MemoryRetainer T>
+MemoryRetainerNode* MemoryTracker::addNode(const T* retainer,
+                                           kj::Maybe<kj::StringPtr> edgeName) {
+  KJ_IF_SOME(found, seen_.find(retainer)) { return found.node; }
+
+  MemoryRetainerNode* n = new MemoryRetainerNode(this, retainer);
+  graph_->AddNode(std::unique_ptr<v8::EmbedderGraph::Node>(n));
+  seen_.upsert({retainer, n},[](auto&,auto&&) {});
+
+  KJ_IF_SOME(currentNode, getCurrentNode()) {
+    KJ_IF_SOME(name, edgeName) {
+      graph_->AddEdge(&currentNode, n, name.cStr());
+    } else {
+      graph_->AddEdge(&currentNode, n, nullptr);
+    }
+  }
+
+  if (n->JSWrapperNode() != nullptr) {
+    graph_->AddEdge(n, n->JSWrapperNode(), "native_to_javascript");
+    graph_->AddEdge(n->JSWrapperNode(), n, "javascript_to_native");
+  }
+
+  return n;
+}
+
+MemoryRetainerNode* MemoryTracker::addNode(kj::StringPtr nodeName,
+                                           size_t size,
+                                           kj::Maybe<kj::StringPtr> edgeName) {
+  MemoryRetainerNode* n = new MemoryRetainerNode(this, nodeName, size);
+  graph_->AddNode(std::unique_ptr<v8::EmbedderGraph::Node>(n));
+
+  KJ_IF_SOME(currentNode, getCurrentNode()) {
+    KJ_IF_SOME(name, edgeName) {
+      graph_->AddEdge(&currentNode, n, name.cStr());
+    } else {
+      graph_->AddEdge(&currentNode, n, nullptr);
+    }
+  }
+
+  return n;
+}
+
+template <MemoryRetainer T>
+MemoryRetainerNode* MemoryTracker::pushNode(const T* retainer,
+                                            kj::Maybe<kj::StringPtr> edgeName) {
+  MemoryRetainerNode* n = addNode(retainer, edgeName);
+  nodeStack_.push(n);
+  return n;
+}
+
+MemoryRetainerNode* MemoryTracker::pushNode(kj::StringPtr nodeName,
+                                            size_t size,
+                                            kj::Maybe<kj::StringPtr> edgeName) {
+  MemoryRetainerNode* n = addNode(nodeName, size, edgeName);
+  nodeStack_.push(n);
+  return n;
+}
+
+void MemoryTracker::popNode() {
+  nodeStack_.pop();
+}
+
+template <typename T>
+inline void visitSubclassForMemoryInfo(const T* obj, MemoryTracker& tracker) {
+  if constexpr (&T::visitForMemoryInfo != &T::jsgSuper::visitForMemoryInfo) {
+    obj->visitForMemoryInfo(tracker);
+  }
+}
+
+// ======================================================================================
+
+class HeapSnapshotActivity final: public v8::ActivityControl {
+public:
+  using Callback = kj::Function<bool(uint32_t done, uint32_t total)>;
+
+  inline HeapSnapshotActivity(Callback callback): callback(kj::mv(callback)) {}
+  ~HeapSnapshotActivity() noexcept(true) = default;
+
+  inline ControlOption ReportProgressValue(uint32_t done, uint32_t total) override {
+    return callback(done, total) ?
+        ControlOption::kContinue :
+        ControlOption::kAbort;
+  }
+
+private:
+  Callback callback;
+};
+
+class HeapSnapshotWriter final: public v8::OutputStream {
+public:
+  using Callback = kj::Function<bool(kj::Maybe<kj::ArrayPtr<char>>)>;
+
+  inline HeapSnapshotWriter(Callback callback, size_t chunkSize = 65536)
+      : callback(kj::mv(callback)),
+        chunkSize(chunkSize) {}
+  inline ~HeapSnapshotWriter() noexcept(true) {}
+
+  inline void EndOfStream() override {
+    callback(kj::none);
+  }
+
+  inline int GetChunkSize() override { return chunkSize; }
+
+  inline v8::OutputStream::WriteResult WriteAsciiChunk(char* data, int size) override {
+    return callback(kj::ArrayPtr<char>(data, size)) ?
+        v8::OutputStream::WriteResult::kContinue :
+        v8::OutputStream::WriteResult::kAbort;
+  }
+
+private:
+  Callback callback;
+  size_t chunkSize;
+};
+
+struct HeapSnapshotDeleter: public kj::Disposer {
+  inline void disposeImpl(void* ptr) const override {
+    auto snapshot = const_cast<v8::HeapSnapshot*>(static_cast<const v8::HeapSnapshot*>(ptr));
+    snapshot->Delete();
+  }
+};
+
+}  // namespace workerd::jsg

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -27,6 +27,11 @@ public:
   JSG_RESOURCE_TYPE(CommonJsModuleObject) {
     JSG_INSTANCE_PROPERTY(exports, getExports, setExports);
   }
+
+  void visitForMemoryInfo(MemoryTracker& tracker) const {
+    tracker.trackField("exports", exports);
+  }
+
 private:
   jsg::Value exports;
 };
@@ -52,6 +57,12 @@ public:
   }
 
   jsg::Ref<CommonJsModuleObject> module;
+
+  void visitForMemoryInfo(MemoryTracker& tracker) const {
+    tracker.trackField("exports", exports);
+    tracker.trackFieldWithSize("path", path.size());
+  }
+
 private:
   kj::Path path;
   jsg::Value exports;
@@ -90,6 +101,12 @@ public:
     JSG_INSTANCE_PROPERTY(exports, getExports, setExports);
     JSG_READONLY_INSTANCE_PROPERTY(path, getPath);
   }
+
+  void visitForMemoryInfo(MemoryTracker& tracker) const {
+    tracker.trackField("exports", exports);
+    tracker.trackField("path", path);
+  }
+
 private:
   jsg::Value exports;
   kj::String path;
@@ -131,6 +148,12 @@ public:
   }
 
   jsg::Ref<NodeJsModuleObject> module;
+
+  void visitForMemoryInfo(MemoryTracker& tracker) const {
+    tracker.trackField("exports", exports);
+    tracker.trackFieldWithSize("path", path.size());
+  }
+
 private:
   kj::Path path;
   jsg::Value exports;
@@ -184,6 +207,10 @@ public:
   ModuleRegistry() { }
 
   using Type = ModuleType;
+
+  JSG_MEMORY_INFO(ModuleRegistry) {
+    // TODO(soon): Implement memory tracking for ModuleRegistry
+  }
 
   enum class ResolveOption {
     // Default resolution. Check the worker bundle first, then builtins.

--- a/src/workerd/jsg/promise.c++
+++ b/src/workerd/jsg/promise.c++
@@ -203,4 +203,9 @@ void UnhandledRejectionHandler::ensureProcessingWarnings(jsg::Lock& js) {
   });
 }
 
+void UnhandledRejectionHandler::UnhandledRejection::visitForMemoryInfo(
+    MemoryTracker& tracker) const {
+  tracker.trackField("asyncContextFrame", asyncContextFrame);
+}
+
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/resource-test.c++
+++ b/src/workerd/jsg/resource-test.c++
@@ -9,7 +9,7 @@ namespace workerd::jsg::test {
 namespace {
 
 V8System v8System;
-class ContextGlobalObject: public Object, public ContextGlobal { };
+class ContextGlobalObject: public Object, public ContextGlobal {};
 
 struct BoxContext: public ContextGlobalObject {
   JSG_RESOURCE_TYPE(BoxContext) {
@@ -356,6 +356,7 @@ struct StaticContext: public ContextGlobalObject {
     static Unimplemented unimplementedStaticMethod() { return {}; }
 
     static void delete_() {}
+
 
     JSG_RESOURCE_TYPE(StaticMethods) {
       JSG_STATIC_METHOD(passThrough);

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -18,6 +18,7 @@
 #include "wrappable.h"
 #include <typeindex>
 #include "meta.h"
+#include <workerd/jsg/memory.h>
 #include <workerd/jsg/modules.capnp.h>
 
 // The signature of SetAccessor changes in v8 12.1 to drop the v8::AccessControl

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -9,6 +9,7 @@
 #include "async-context.h"
 #include "type-wrapper.h"
 #include "v8-platform-wrapper.h"
+#include "v8-profiler.h"
 #include <workerd/util/batch-queue.h>
 #include <kj/map.h>
 #include <kj/mutex.h>
@@ -124,9 +125,17 @@ public:
 
   IsolateObserver& getObserver() { return *observer; }
 
+  // Implementation of MemoryRetainer
+  void jsgGetMemoryInfo(MemoryTracker& tracker) const;
+  kj::StringPtr jsgGetMemoryName() const { return "IsolateBase"_kjc; }
+  size_t jsgGetMemorySelfSize() const { return sizeof(IsolateBase); }
+  bool jsgGetMemoryInfoIsRootNode() const { return true; }
+
 private:
   template <typename TypeWrapper>
   friend class Isolate;
+
+  static void buildEmbedderGraph(v8::Isolate* isolate, v8::EmbedderGraph* graph, void* data);
 
   // The internals of a jsg::Ref<T> to be deleted.
   class RefToDelete {

--- a/src/workerd/jsg/string.c++
+++ b/src/workerd/jsg/string.c++
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "string.h"
+#include <workerd/jsg/memory.h>
 #include <unicode/utf8.h>
 #include <unicode/utf16.h>
 #include <algorithm>

--- a/src/workerd/jsg/string.h
+++ b/src/workerd/jsg/string.h
@@ -369,6 +369,10 @@ public:
     return slice(start.position(), end.position());
   }
 
+  JSG_MEMORY_INFO(UsvString) {
+    tracker.trackField("buffer", buffer);
+  }
+
 private:
   kj::Array<uint32_t> buffer;
 

--- a/src/workerd/jsg/type-wrapper-test.c++
+++ b/src/workerd/jsg/type-wrapper-test.c++
@@ -8,7 +8,7 @@ namespace workerd::jsg::test {
 namespace {
 
 V8System v8System;
-class ContextGlobalObject: public Object, public ContextGlobal { };
+class ContextGlobalObject: public Object, public ContextGlobal {};
 
 struct InfoContext: public ContextGlobalObject {
   struct WantInfo: public Object {

--- a/src/workerd/jsg/url.h
+++ b/src/workerd/jsg/url.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <kj/string.h>
 #include <kj/common.h>
+#include <workerd/jsg/memory.h>
 
 namespace workerd::jsg {
 
@@ -98,6 +99,16 @@ public:
   // Convert a Unicode hostname to ASCII.
   static kj::Array<const char> idnToAscii(kj::ArrayPtr<const char> value) KJ_WARN_UNUSED_RESULT;
 
+  JSG_MEMORY_INFO(Url) {
+    tracker.trackFieldWithSize("inner", getProtocol().size() +
+                                        getUsername().size() +
+                                        getPassword().size() +
+                                        getHost().size() +
+                                        getPathname().size() +
+                                        getHash().size() +
+                                        getSearch().size());
+  }
+
 private:
   Url(kj::Own<void> inner);
   kj::Own<void> inner;
@@ -164,6 +175,10 @@ public:
   EntryIterator getEntries() const KJ_LIFETIMEBOUND KJ_WARN_UNUSED_RESULT;
 
   kj::Array<const char> toStr() const KJ_WARN_UNUSED_RESULT;
+
+  JSG_MEMORY_INFO(Url) {
+    tracker.trackField("inner", toStr());
+  }
 
 private:
   UrlSearchParams(kj::Own<void> inner);

--- a/src/workerd/jsg/util-test.c++
+++ b/src/workerd/jsg/util-test.c++
@@ -11,7 +11,7 @@ namespace workerd::jsg::test {
 namespace {
 
 V8System v8System;
-class ContextGlobalObject: public Object, public ContextGlobal { };
+class ContextGlobalObject: public Object, public ContextGlobal {};
 
 struct FreezeContext: public ContextGlobalObject {
   void recursivelyFreeze(v8::Local<v8::Value> value, v8::Isolate* isolate) {

--- a/src/workerd/jsg/value-test.c++
+++ b/src/workerd/jsg/value-test.c++
@@ -8,7 +8,7 @@ namespace workerd::jsg::test {
 namespace {
 
 V8System v8System;
-class ContextGlobalObject: public Object, public ContextGlobal { };
+class ContextGlobalObject: public Object, public ContextGlobal {};
 
 struct BoolContext: public ContextGlobalObject {
   kj::String takeBool(bool b) {


### PR DESCRIPTION
This is adapted from Node.js' implementation.

This extends workerd's v8::HeapSnapshot collection process to allow including more detailed information about internal/native objects.  Best illustrated with a screenshot... 
<img width="1259" alt="image" src="https://github.com/cloudflare/workerd/assets/439929/fc260deb-90ae-4014-9e8a-739f70fb0aca">

This PR includes the core part of the implementation. It provides a straightforward implementation of `jsg::Object`s / `jsg::Wrappable` snapshot tracing along with a handful of other types. It does *NOT add all of the instrumentation to all of the various objects.

Those familiar with the GC tracing mechanism should find this familiar.

Look at the memory-test.c++ for an example of how it's used.

To keep things as simple as possible, to instrument your typical `jsg::Object` type (anything using `JSG_RESOURCE_TYPE`, you only need to provide an implementation of the `visitForMemoryInfo(...)` method:

```cpp
struct Foo: public Object {
  kj::String bar = kj::str("test");

  JSG_RESOURCE_TYPE(Foo) {}
  
void visitForMemoryInfo(MemoryTracker& tracker) const {
    tracker.trackField("bar", bar);
  }
};
```

This should be familiar to anyone who has implemented support for GC tracing (using the `visitForGc(...)` method).

Any fields you want to include in the heap snapshot are registered using `trackField(...)` or `trackFieldWithSize(...)`. 

If you want anything else to be trackable, then it will need to implement all three of the following methods:

```cpp
kj::StringPtr getMemoryInfoName() const { return "TheName"_kjc; }
size_t getMemoryInfoSelfSize() const { return sizeof(ThisThing); }
void getMemoryInfo(MemoryTracker& tracker) const {
   // register the fields here
}
```

To check to see if a type if trackable, you can test it using something like:

```
static constexpr bool IS_TESTABLE = MemoryRetainer<T>;
```

From the typical day-to-day use there wouldn't be much more than that. There a few more advanced cases to consider and we might want to expand the `trackField(...)` implementations in `memory.h` to add support for various types, but for the most part this was designed to be as minimally intrusive as possible.