### PR TITLE
Simplify "named intercept"

### DIFF
--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -55,7 +55,7 @@ kj::Promise<capnp::Response<rpc::JsRpcTarget::CallResults>> WorkerRpc::sendWorke
     JSG_ASSERT(ser.size() <= MAX_JS_RPC_MESSAGE_SIZE, Error,
         "Serialized RPC requests are limited to 1MiB, but the size of this request was: ",
         ser.size(), " bytes.");
-    builder.initSerializedArgs().setV8Serialized(kj::mv(ser));
+    builder.initArgs().setV8Serialized(kj::mv(ser));
   }
 
   auto callResult = builder.send();
@@ -99,7 +99,7 @@ public:
   // Handles the delivery of JS RPC method calls.
   kj::Promise<void> call(CallContext callContext) override {
     auto methodName = kj::heapString(callContext.getParams().getMethodName());
-    auto serializedArgs = callContext.getParams().getSerializedArgs().getV8Serialized().asBytes();
+    auto serializedArgs = callContext.getParams().getArgs().getV8Serialized().asBytes();
 
     // We want to fulfill the callPromise so customEvent can continue executing
     // regardless of the outcome of `call()`.

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -72,7 +72,7 @@ kj::Promise<capnp::Response<rpc::JsRpcTarget::CallResults>> WorkerRpc::sendWorke
       }));
 }
 
-kj::Maybe<jsg::JsValue> WorkerRpc::getNamed(jsg::Lock& js, kj::StringPtr name) {
+kj::Maybe<jsg::JsValue> WorkerRpc::getRpcMethod(jsg::Lock& js, kj::StringPtr name) {
   // Named intercept is enabled, this means we won't default to legacy behavior.
   // The return value of the function is a promise that resolves once the remote returns the result
   // of the RPC call.

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -50,7 +50,7 @@ public:
       kj::StringPtr name,
       const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  kj::Maybe<jsg::JsValue> getNamed(jsg::Lock& js, kj::StringPtr name);
+  kj::Maybe<jsg::JsValue> getRpcMethod(jsg::Lock& js, kj::StringPtr name);
 
   // WARNING: Adding a new JSG_METHOD to a class that extends WorkerRpc can conflict with RPC method
   // names defined on your remote target. For example, if you add a new method `bar()` to the
@@ -66,7 +66,7 @@ public:
   // change log.
   JSG_RESOURCE_TYPE(WorkerRpc, CompatibilityFlags::Reader flags) {
     if (flags.getWorkerdExperimental()) {
-      JSG_NAMED_INTERCEPT();
+      JSG_NAMED_INTERCEPT(getRpcMethod);
     }
     JSG_INHERIT(Fetcher);
   }

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -50,7 +50,10 @@ public:
       kj::StringPtr name,
       const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  kj::Maybe<jsg::JsValue> getRpcMethod(jsg::Lock& js, kj::StringPtr name);
+  using RpcFunction = jsg::Function<jsg::Promise<jsg::Value>(
+      const v8::FunctionCallbackInfo<v8::Value>& info)>;
+
+  kj::Maybe<RpcFunction> getRpcMethod(jsg::Lock& js, kj::StringPtr name);
 
   // WARNING: Adding a new JSG_METHOD to a class that extends WorkerRpc can conflict with RPC method
   // names defined on your remote target. For example, if you add a new method `bar()` to the

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -29,8 +29,8 @@ constexpr size_t MAX_JS_RPC_MESSAGE_SIZE = 1u << 20;
 
 // A WorkerRpc object forwards JS method calls to the remote Worker/Durable Object over RPC.
 // Since methods are not known until runtime, WorkerRpc doesn't define any JS methods.
-// Instead, we use JSG_NAMED_INTERCEPT to intercept property accesses of names that are not known at
-// compile time.
+// Instead, we use JSG_WILDCARD_PROPERTY to intercept property accesses of names that are not known
+// at compile time.
 //
 // WorkerRpc only supports method calls. You cannot, for instance, access a property of a
 // Durable Object over RPC.
@@ -69,7 +69,7 @@ public:
   // change log.
   JSG_RESOURCE_TYPE(WorkerRpc, CompatibilityFlags::Reader flags) {
     if (flags.getWorkerdExperimental()) {
-      JSG_NAMED_INTERCEPT(getRpcMethod);
+      JSG_WILDCARD_PROPERTY(getRpcMethod);
     }
     JSG_INHERIT(Fetcher);
   }

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -34,7 +34,7 @@ constexpr size_t MAX_JS_RPC_MESSAGE_SIZE = 1u << 20;
 //
 // WorkerRpc only supports method calls. You cannot, for instance, access a property of a
 // Durable Object over RPC.
-class WorkerRpc : public Fetcher, public jsg::NamedIntercept {
+class WorkerRpc : public Fetcher {
 public:
   WorkerRpc(
       IoOwn<OutgoingFactory> outgoingFactory,
@@ -50,7 +50,7 @@ public:
       kj::StringPtr name,
       const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  kj::Maybe<jsg::JsValue> getNamed(jsg::Lock& js, kj::StringPtr name) override;
+  kj::Maybe<jsg::JsValue> getNamed(jsg::Lock& js, kj::StringPtr name);
 
   // WARNING: Adding a new JSG_METHOD to a class that extends WorkerRpc can conflict with RPC method
   // names defined on your remote target. For example, if you add a new method `bar()` to the

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -189,11 +189,11 @@ struct JsValue {
 }
 
 interface JsRpcTarget {
-  call @0 (methodName :Text, serializedArgs :JsValue) -> (result :JsValue);
+  call @0 (methodName :Text, args :JsValue) -> (result :JsValue);
   # Runs a Worker/DO's RPC method.
   #
-  # `methodName` is the name of the method to run, and
-  # `serializedArgs` is an array of arguments that have been serialized by the v8 serializer.
+  # `methodName` is the name of the method to run, and `args` is a JsValue that is always a
+  # JavaScript Array, containing the arguments to the call.
 }
 
 interface EventDispatcher @0xf20697475ec1752d {

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -367,14 +367,13 @@ KJ_TEST("Test JSG_CALLABLE") {
 
 // ========================================================================================
 struct InterceptContext: public ContextGlobalObject {
-  struct ProxyImpl: public jsg::Object,
-                    public jsg::NamedIntercept {
+  struct ProxyImpl: public jsg::Object {
     static jsg::Ref<ProxyImpl> constructor() { return jsg::alloc<ProxyImpl>(); }
 
     int getBar() { return 123; }
 
-    // NamedIntercept implementation
-    kj::Maybe<jsg::JsValue> getNamed(jsg::Lock& js, kj::StringPtr name) override {
+    // JSG_NAMED_INTERCEPT implementation
+    kj::Maybe<jsg::JsValue> getNamed(jsg::Lock& js, kj::StringPtr name) {
       if (name == "foo") {
         return kj::Maybe(js.str("bar"_kj));
       } else if (name == "abc") {

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -373,7 +373,7 @@ struct InterceptContext: public ContextGlobalObject {
     int getBar() { return 123; }
 
     // JSG_NAMED_INTERCEPT implementation
-    kj::Maybe<jsg::JsValue> getNamed(jsg::Lock& js, kj::StringPtr name) {
+    kj::Maybe<jsg::JsValue> testGetNamed(jsg::Lock& js, kj::StringPtr name) {
       if (name == "foo") {
         return kj::Maybe(js.str("bar"_kj));
       } else if (name == "abc") {
@@ -384,7 +384,7 @@ struct InterceptContext: public ContextGlobalObject {
 
     JSG_RESOURCE_TYPE(ProxyImpl) {
       JSG_READONLY_PROTOTYPE_PROPERTY(bar, getBar);
-      JSG_NAMED_INTERCEPT();
+      JSG_NAMED_INTERCEPT(testGetNamed);
     }
   };
 

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -373,9 +373,9 @@ struct InterceptContext: public ContextGlobalObject {
     int getBar() { return 123; }
 
     // JSG_NAMED_INTERCEPT implementation
-    kj::Maybe<jsg::JsValue> testGetNamed(jsg::Lock& js, kj::StringPtr name) {
+    kj::Maybe<kj::StringPtr> testGetNamed(jsg::Lock& js, kj::StringPtr name) {
       if (name == "foo") {
-        return kj::Maybe(js.str("bar"_kj));
+        return "bar"_kj;
       } else if (name == "abc") {
         JSG_FAIL_REQUIRE(TypeError, "boom");
       }

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -383,10 +383,6 @@ struct InterceptContext: public ContextGlobalObject {
       return kj::none;
     }
 
-    kj::Array<kj::String> listNamed(Lock& js) override {
-      return kj::arr(kj::str("foo"));
-    }
-
     JSG_RESOURCE_TYPE(ProxyImpl) {
       JSG_READONLY_PROTOTYPE_PROPERTY(bar, getBar);
       JSG_NAMED_INTERCEPT();
@@ -401,10 +397,6 @@ JSG_DECLARE_ISOLATE_TYPE(InterceptIsolate, InterceptContext, InterceptContext::P
 
 KJ_TEST("Named interceptor") {
   Evaluator<InterceptContext, InterceptIsolate> e(v8System);
-  // Calling Object.keys(p) here just to verify that it does not throw.
-  // Also, the test tries modifying the known intercepted property foo but verifies
-  // that the value is readonly/unchanged.
-  e.expectEval("p = new ProxyImpl; Object.keys(p); p.foo = 123; p.foo", "string", "bar");
   e.expectEval("p = new ProxyImpl; p.bar", "number", "123");
   e.expectEval("p = new ProxyImpl; Reflect.has(p, 'foo')", "boolean", "true");
   e.expectEval("p = new ProxyImpl; Reflect.has(p, 'bar')", "boolean", "true");

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -372,7 +372,7 @@ struct InterceptContext: public ContextGlobalObject {
 
     int getBar() { return 123; }
 
-    // JSG_NAMED_INTERCEPT implementation
+    // JSG_WILDCARD_PROPERTY implementation
     kj::Maybe<kj::StringPtr> testGetNamed(jsg::Lock& js, kj::StringPtr name) {
       if (name == "foo") {
         return "bar"_kj;
@@ -384,7 +384,7 @@ struct InterceptContext: public ContextGlobalObject {
 
     JSG_RESOURCE_TYPE(ProxyImpl) {
       JSG_READONLY_PROTOTYPE_PROPERTY(bar, getBar);
-      JSG_NAMED_INTERCEPT(testGetNamed);
+      JSG_WILDCARD_PROPERTY(testGetNamed);
     }
   };
 

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -477,9 +477,9 @@ using HasGetTemplateOverload = decltype(
 
 // Configures the resource type to implement named property interception.
 // @see the definition of jsg::NamedIntercept in resource.h for more information.
-#define JSG_NAMED_INTERCEPT() \
+#define JSG_NAMED_INTERCEPT(method) \
   do { \
-   registry.template registerNamedIntercept<Self>(); \
+   registry.template registerNamedIntercept<Self, decltype(&Self::method), &Self::method>(); \
   } while (false)
 
 // Use inside a JSG_RESOURCE_TYPE block to declare that this type should be considered a "root" for

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -475,11 +475,24 @@ using HasGetTemplateOverload = decltype(
     wrapper.initReflection(this, __VA_ARGS__); \
   }
 
-// Configures the resource type to implement named property interception.
-// @see the definition of jsg::NamedIntercept in resource.h for more information.
-#define JSG_NAMED_INTERCEPT(method) \
+// Declares a wildcart property getter. If a property is requested that isn't already present on
+// the object or its prototypes, the wildcard property getter will be given a chance to return the
+// property.
+//
+// Example:
+//
+//   struct MyType {
+//     // Get the value of the named dynamic property. Returns none if the property doesn't exist.
+//     // `SomeType` can be any type that JSG is able to convert to JavaScript.
+//     kj::Maybe<SomeType> getWildcard(jsg::Lock& js, kj::StringPtr name);
+//
+//     JSG_RESOURCE_TYPE(MyType) {
+//       JSG_WILDCARD_PROPERTY(getWildcard);
+//     }
+//   };
+#define JSG_WILDCARD_PROPERTY(method) \
   do { \
-   registry.template registerNamedIntercept<Self, decltype(&Self::method), &Self::method>(); \
+   registry.template registerWildcardProperty<Self, decltype(&Self::method), &Self::method>(); \
   } while (false)
 
 // Use inside a JSG_RESOURCE_TYPE block to declare that this type should be considered a "root" for

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -559,20 +559,4 @@ NamedIntercept::getNamed(Lock&, kj::StringPtr) {
   return kj::none;
 }
 
-inline kj::Maybe<NamedIntercept::Attribute>
-NamedIntercept::queryNamed(Lock& js, kj::StringPtr name) {
-  // By default, we currently only support read only properties.
-  auto list = listNamed(js);
-  for (auto& item : list) {
-    if (item == name) return jsg::NamedIntercept::READ_ONLY_ATTRIBUTE;
-  }
-  return kj::none;
-}
-
-inline kj::Array<kj::String>
-NamedIntercept::listNamed(Lock&) {
-  return kj::Array<kj::String>();
-}
-
-
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -554,9 +554,4 @@ private:
   v8::Local<v8::Message> inner;
 };
 
-inline kj::Maybe<JsValue>
-NamedIntercept::getNamed(Lock&, kj::StringPtr) {
-  return kj::none;
-}
-
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/resource.c++
+++ b/src/workerd/jsg/resource.c++
@@ -8,9 +8,6 @@ namespace workerd::jsg {
 
 // TODO(cleanup): Factor out toObject(), getInterned() into some sort of v8 tools module?
 
-const NamedIntercept::Attribute NamedIntercept::READ_ONLY_ATTRIBUTE =
-    NamedIntercept::Attribute::READ_ONLY | NamedIntercept::Attribute::DONT_DELETE;
-
 void exposeGlobalScopeType(v8::Isolate* isolate, v8::Local<v8::Context> context) {
   auto global = context->Global();
 

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -604,19 +604,19 @@ private:
 };
 
 // ======================================================================================
-// NamedIntercept implementation
+// WildcardProperty implementation
 
 class JsValue;
 
 template <typename TypeWrapper, typename T, typename GetNamedMethod, GetNamedMethod getNamedMethod>
-struct NamedInterceptorCallbacks;
+struct WildcardPropertyCallbacks;
 
 template <typename TypeWrapper, typename T, typename U, typename Ret,
           kj::Maybe<Ret> (U::*getNamedMethod)(jsg::Lock&, kj::StringPtr)>
-struct NamedInterceptorCallbacks<
+struct WildcardPropertyCallbacks<
     TypeWrapper, T, kj::Maybe<Ret> (U::*)(jsg::Lock&, kj::StringPtr), getNamedMethod>
     : public v8::NamedPropertyHandlerConfiguration {
-  NamedInterceptorCallbacks() : v8::NamedPropertyHandlerConfiguration(
+  WildcardPropertyCallbacks() : v8::NamedPropertyHandlerConfiguration(
     getter,
     nullptr,
     nullptr,
@@ -681,9 +681,9 @@ struct ResourceTypeBuilder {
   }
 
   template <typename Type, typename GetNamedMethod, GetNamedMethod getNamedMethod>
-  inline void registerNamedIntercept() {
+  inline void registerWildcardProperty() {
     prototype->SetHandler(
-        NamedInterceptorCallbacks<TypeWrapper, Type, GetNamedMethod, getNamedMethod> {});
+        WildcardPropertyCallbacks<TypeWrapper, Type, GetNamedMethod, getNamedMethod> {});
   }
 
   template<typename Type>

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -549,8 +549,7 @@ struct BuildRtti<Configuration, const T&> {
 
 // count all members in the structure
 struct MemberCounter {
-  template <typename Type,
-            typename = kj::EnableIf<std::is_assignable_v<NamedIntercept, Type>>>
+  template <typename Type>
   inline void registerNamedIntercept() { /* not a member */}
 
   template<const char* name, typename Method, Method method>
@@ -818,8 +817,7 @@ struct MembersBuilder {
     }
   }
 
-  template <typename Type,
-            typename = kj::EnableIf<std::is_assignable_v<NamedIntercept, Type>>>
+  template <typename Type>
   inline void registerNamedIntercept() {
     // Nothing to do in this case.
   }

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -550,7 +550,7 @@ struct BuildRtti<Configuration, const T&> {
 // count all members in the structure
 struct MemberCounter {
   template <typename Type, typename GetNamedMethod, GetNamedMethod getNamedMethod>
-  inline void registerNamedIntercept() { /* not a member */}
+  inline void registerWildcardProperty() { /* not a member */}
 
   template<const char* name, typename Method, Method method>
   inline void registerMethod() { ++members; }
@@ -818,7 +818,7 @@ struct MembersBuilder {
   }
 
   template <typename Type, typename GetNamedMethod, GetNamedMethod getNamedMethod>
-  inline void registerNamedIntercept() {
+  inline void registerWildcardProperty() {
     // Nothing to do in this case.
   }
 };

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -549,7 +549,7 @@ struct BuildRtti<Configuration, const T&> {
 
 // count all members in the structure
 struct MemberCounter {
-  template <typename Type>
+  template <typename Type, typename GetNamedMethod, GetNamedMethod getNamedMethod>
   inline void registerNamedIntercept() { /* not a member */}
 
   template<const char* name, typename Method, Method method>
@@ -817,7 +817,7 @@ struct MembersBuilder {
     }
   }
 
-  template <typename Type>
+  template <typename Type, typename GetNamedMethod, GetNamedMethod getNamedMethod>
   inline void registerNamedIntercept() {
     // Nothing to do in this case.
   }


### PR DESCRIPTION
This implements the change we discussed previously, to allow the named property getter to return an arbitrary wrappable value.

I also came up with what I think is more intuitive name for this feature: "Wildcard property"