### PR TITLE
Adding resultsFormat to d1-api.ts to fix .raw() bug

### DIFF
--- a/src/cloudflare/internal/d1-api.ts
+++ b/src/cloudflare/internal/d1-api.ts
@@ -6,30 +6,47 @@ interface Fetcher {
   fetch: typeof fetch
 }
 
-interface D1Result<T = unknown> {
-  results: T[]
+type D1Response = {
   success: true
   meta: Record<string, unknown>
   error?: never
 }
 
-interface D1UpstreamFailure {
+type D1Result<T = unknown> = D1Response & {
+  results: T[]
+}
+
+type D1UpstreamFailure = {
   results?: never
   error: string
   success: false
   meta: Record<string, unknown>
 }
 
-type D1UpstreamResponse<T = unknown> = D1Result<T> | D1UpstreamFailure
+type D1RowsColumns<T = unknown> = D1Response & {
+  results: {
+    columns: string[]
+    rows: T[][]
+  }
+}
 
-interface D1ExecResult {
+type D1UpstreamSuccess<T = unknown> =
+  | D1Result<T>
+  | D1Response
+  | D1RowsColumns<T>
+
+type D1UpstreamResponse<T = unknown> = D1UpstreamSuccess<T> | D1UpstreamFailure
+
+type D1ExecResult = {
   count: number
   duration: number
 }
 
-interface SQLError {
+type SQLError = {
   error: string
 }
+
+type ResultsFormat = 'ARRAY_OF_OBJECTS' | 'ROWS_AND_COLUMNS' | 'NONE'
 
 class D1Database {
   private readonly fetcher: Fetcher
@@ -42,6 +59,7 @@ class D1Database {
     return new D1PreparedStatement(this, query)
   }
 
+  // DEPRECATED, TO BE REMOVED WITH NEXT BREAKING CHANGE
   public async dump(): Promise<ArrayBuffer> {
     const response = await this.fetcher.fetch('http://d1/dump', {
       method: 'POST',
@@ -70,15 +88,15 @@ class D1Database {
     const exec = await this._sendOrThrow(
       '/query',
       statements.map((s: D1PreparedStatement) => s.statement),
-      statements.map((s: D1PreparedStatement) => s.params)
-    )
-    return exec as D1Result<T>[]
+      statements.map((s: D1PreparedStatement) => s.params),
+      'ROWS_AND_COLUMNS'
+    ) as D1UpstreamSuccess<T>[]
+    return exec.map(toArrayOfObjects)
   }
 
   public async exec(query: string): Promise<D1ExecResult> {
-    // should be /execute - see CFSQL-52
     const lines = query.trim().split('\n')
-    const _exec = await this._send('/query', lines, [])
+    const _exec = await this._send('/execute', lines, [], 'NONE')
     const exec = Array.isArray(_exec) ? _exec : [_exec]
     const error = exec
       .map((r) => {
@@ -108,29 +126,31 @@ class D1Database {
 
   public async _sendOrThrow<T = unknown>(
     endpoint: string,
-    query: unknown,
-    params: unknown[]
-  ): Promise<D1Result<T>[] | D1Result<T>> {
-    const results = await this._send(endpoint, query, params)
+    query: string | string[],
+    params: unknown[],
+    resultsFormat: ResultsFormat
+  ): Promise<D1UpstreamSuccess<T>[] | D1UpstreamSuccess<T>> {
+    const results = await this._send(endpoint, query, params, resultsFormat)
     const firstResult = firstIfArray(results)
     if (!firstResult.success) {
       throw new Error(`D1_ERROR: ${firstResult.error}`, {
         cause: new Error(firstResult.error),
       })
     } else {
-      return results as D1Result<T>[] | D1Result<T>
+      return results as D1UpstreamSuccess<T>[] | D1UpstreamSuccess<T>
     }
   }
 
   public async _send<T = unknown>(
     endpoint: string,
-    query: unknown,
-    params: unknown[]
+    query: string | string[],
+    params: unknown[],
+    resultsFormat: ResultsFormat
   ): Promise<D1UpstreamResponse<T>[] | D1UpstreamResponse<T>> {
     /* this needs work - we currently only support ordered ?n params */
     const body = JSON.stringify(
-      typeof query == 'object'
-        ? (query as string[]).map((s: string, index: number) => {
+      Array.isArray(query)
+        ? query.map((s: string, index: number) => {
             return { sql: s, params: params[index] }
           })
         : {
@@ -139,7 +159,9 @@ class D1Database {
           }
     )
 
-    const response = await this.fetcher.fetch(new URL(endpoint, 'http://d1'), {
+    const url = new URL(endpoint, 'http://d1')
+    url.searchParams.set('resultsFormat', resultsFormat)
+    const response = await this.fetcher.fetch(url.href, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -235,11 +257,12 @@ class D1PreparedStatement {
       await this.database._sendOrThrow<Record<string, T>>(
         '/query',
         this.statement,
-        this.params
+        this.params,
+        'ROWS_AND_COLUMNS'
       )
     )
 
-    const results = info.results
+    const results = toArrayOfObjects(info).results
     const hasResults = results.length > 0
     if (!hasResults) return null
 
@@ -256,22 +279,26 @@ class D1PreparedStatement {
     }
   }
 
-  public async run<T = Record<string, unknown>>(): Promise<D1Result<T>> {
+  public async run<T = Record<string, unknown>>(): Promise<D1Response> {
     return firstIfArray(
       await this.database._sendOrThrow<T>(
         '/execute',
         this.statement,
-        this.params
+        this.params,
+        'NONE'
       )
     )
   }
 
   public async all<T = Record<string, unknown>>(): Promise<D1Result<T[]>> {
-    return firstIfArray(
-      await this.database._sendOrThrow<T[]>(
-        '/query',
-        this.statement,
-        this.params
+    return toArrayOfObjects(
+      firstIfArray(
+        await this.database._sendOrThrow<T[]>(
+          '/query',
+          this.statement,
+          this.params,
+          'ROWS_AND_COLUMNS'
+        )
       )
     )
   }
@@ -281,22 +308,56 @@ class D1PreparedStatement {
       await this.database._sendOrThrow<Record<string, unknown>>(
         '/query',
         this.statement,
-        this.params
+        this.params,
+        'ROWS_AND_COLUMNS'
       )
     )
-    const raw: T[] = []
-    for (const row of s.results) {
-      const entry = Object.keys(row).map((k) => {
-        return row[k]
-      })
-      raw.push(entry as T)
+    // If no results returned, return empty array
+    if (!('results' in s)) return []
+
+    // If ARRAY_OF_OBJECTS returned, extract cells
+    if (Array.isArray(s.results)) {
+      const raw: T[] = []
+      for (const row of s.results) {
+        const entry = Object.keys(row).map((k) => {
+          return row[k]
+        })
+        raw.push(entry as T)
+      }
+      return raw
+    } else {
+      // Otherwise, data is already in the correct format
+      return s.results.rows as T[]
     }
-    return raw
   }
 }
 
 function firstIfArray<T>(results: T | T[]): T {
   return Array.isArray(results) ? results[0]! : results
+}
+
+// This shim may be used against an older version of D1 that doesn't support
+// the ROWS_AND_COLUMNS/NONE interchange format, so be permissive here
+function toArrayOfObjects<T>(response: D1UpstreamSuccess<T>): D1Result<T> {
+  // If 'results' is missing from upstream, add an empty array
+  if (!('results' in response))
+    return {
+      ...response,
+      results: [],
+    }
+
+  const results = response.results
+  if (Array.isArray(results)) {
+    return { ...response, results }
+  } else {
+    const { rows, columns } = results
+    return {
+      ...response,
+      results: rows.map((row) =>
+        Object.fromEntries(row.map((cell, i) => [columns[i], cell]))
+      ),
+    }
+  }
 }
 
 function mapD1Result<T>(result: D1UpstreamResponse<T>): D1UpstreamResponse<T> {
@@ -311,12 +372,13 @@ function mapD1Result<T>(result: D1UpstreamResponse<T>): D1UpstreamResponse<T> {
     : {
         success: true,
         meta: result.meta || {},
-        results: result.results || [],
+        ...('results' in result ? { results: result.results } : {}),
       }
 }
 
 async function toJson<T = unknown>(response: Response): Promise<T> {
   const body = await response.text()
+  console.log({ body })
   try {
     return JSON.parse(body) as T
   } catch (e) {

--- a/src/cloudflare/internal/d1-api.ts
+++ b/src/cloudflare/internal/d1-api.ts
@@ -378,7 +378,6 @@ function mapD1Result<T>(result: D1UpstreamResponse<T>): D1UpstreamResponse<T> {
 
 async function toJson<T = unknown>(response: Response): Promise<T> {
   const body = await response.text()
-  console.log({ body })
   try {
     return JSON.parse(body) as T
   } catch (e) {

--- a/src/cloudflare/internal/test/d1/BUILD.bazel
+++ b/src/cloudflare/internal/test/d1/BUILD.bazel
@@ -2,6 +2,7 @@ load("//:build/wd_test.bzl", "wd_test")
 
 wd_test(
     src = "d1-api-test.wd-test",
+    args = ["--experimental"],
     data = glob([
         "*.js",
         "*.capnp",

--- a/src/cloudflare/internal/test/d1/d1-api-test.js
+++ b/src/cloudflare/internal/test/d1/d1-api-test.js
@@ -333,7 +333,7 @@ export const test_d1_api = test(async (DB) => {
   )
 
   await itShould(
-    'not lose data for duplicate columns in a join using raw',
+    'not lose data for duplicate columns in a join using raw()',
     () => DB.prepare(`SELECT * FROM abc, cde;`).raw(),
     [
       [1, 2, 3, 'A', 'B', 'C'],
@@ -346,8 +346,38 @@ export const test_d1_api = test(async (DB) => {
   )
 
   await itShould(
+    'add columns using  .raw({ columnNames: true })',
+    () => DB.prepare(`SELECT * FROM abc, cde;`).raw({ columnNames: true }),
+    [
+      ['a', 'b', 'c', 'c', 'd', 'e'],
+      [1, 2, 3, 'A', 'B', 'C'],
+      [1, 2, 3, 'D', 'E', 'F'],
+      [1, 2, 3, 'G', 'H', 'I'],
+      [4, 5, 6, 'A', 'B', 'C'],
+      [4, 5, 6, 'D', 'E', 'F'],
+      [4, 5, 6, 'G', 'H', 'I'],
+    ]
+  )
+
+  await itShould(
+    'not add columns using  .raw({ columnNames: false })',
+    () => DB.prepare(`SELECT * FROM abc, cde;`).raw({ columnNames: false }),
+    [
+      [1, 2, 3, 'A', 'B', 'C'],
+      [1, 2, 3, 'D', 'E', 'F'],
+      [1, 2, 3, 'G', 'H', 'I'],
+      [4, 5, 6, 'A', 'B', 'C'],
+      [4, 5, 6, 'D', 'E', 'F'],
+      [4, 5, 6, 'G', 'H', 'I'],
+    ]
+  )
+
+  await itShould(
     'return 0 rows_written for IN clauses',
-    () => DB.prepare(`SELECT * from cde WHERE c IN ('A','B','C','X','Y','Z')`).all(),
+    () =>
+      DB.prepare(
+        `SELECT * from cde WHERE c IN ('A','B','C','X','Y','Z')`
+      ).all(),
     {
       success: true,
       results: [{ c: 'A', d: 'B', e: 'C' }],

--- a/src/cloudflare/internal/test/d1/d1-api-test.wd-test
+++ b/src/cloudflare/internal/test/d1/d1-api-test.wd-test
@@ -2,6 +2,7 @@ using Workerd = import "/workerd/workerd.capnp";
 
 const unitTests :Workerd.Config = (
   services = [
+    ( name = "TEST_TMPDIR", disk = (writable = true) ),
     ( name = "d1-api-test",
       worker = (
         modules = [
@@ -10,26 +11,34 @@ const unitTests :Workerd.Config = (
         compatibilityDate = "2023-01-15",
         compatibilityFlags = ["nodejs_compat"],
         bindings = [
-          (
-            name = "d1",
-            wrapped = (
-              moduleName = "cloudflare-internal:d1-api",
-              innerBindings = [(
-                name = "fetcher",
-                service = "d1-mock"
-              )],
-            )
+        (
+          name = "d1",
+          wrapped = (
+            moduleName = "cloudflare-internal:d1-api",
+            innerBindings = [(
+              name = "fetcher",
+              service = "d1-mock"
+            )],
           )
+        )
         ],
       )
     ),
     ( name = "d1-mock",
-     worker = (
-       compatibilityDate = "2023-01-15",
-       modules = [
-         (name = "worker", esModule = embed "d1-mock.js")
-       ],
-     )
+      worker = (
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["experimental", "nodejs_compat"],
+        modules = [
+          (name = "worker", esModule = embed "d1-mock.js")
+        ],
+        durableObjectNamespaces = [
+          (className = "D1MockDO", uniqueKey = "210bd0cbd803ef7883a1ee9d86cce06e"),
+        ],
+        durableObjectStorage = (localDisk = "TEST_TMPDIR"),
+        bindings = [
+          (name = "db", durableObjectNamespace = "D1MockDO"),
+        ],
+      )
     )
   ]
 );

--- a/src/cloudflare/internal/test/d1/d1-mock.js
+++ b/src/cloudflare/internal/test/d1/d1-mock.js
@@ -2,39 +2,53 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-const MOCK_USER_ROWS = {
-  1: { user_id: 1, name: 'Albert Ross', home: 'sky', features: 'wingspan' },
-  2: { user_id: 2, name: 'Al Dente', home: 'bowl', features: 'mouthfeel' },
-}
+export class D1MockDO {
+  constructor(state, env) {
+    this.state = state
+    this.sql = this.state.storage.sql
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS users (
+          user_id INTEGER PRIMARY KEY,
+          name TEXT,
+          home TEXT,
+          features TEXT
+      );`)
+    this.sql.exec(`DELETE FROM users;`)
+    this.sql.exec(`INSERT INTO users (name, home, features) VALUES 
+      ('Albert Ross', 'sky', 'wingspan'),
+      ('Al Dente', 'bowl', 'mouthfeel');
+    `)
+  }
 
-function mockQuery({ sql, params }) {
-  switch (sql.trim()) {
-    case 'select 1;':
-      return ok({ 1: 1 })
-    case 'select * from users;':
-      return ok(...Object.values(MOCK_USER_ROWS))
-    case 'select * from users where user_id = ?;':
-      return ok(MOCK_USER_ROWS[params[0]])
-    default:
-      throw new Error(`Unmocked query: ${sql}`)
+  async fetch(request) {
+    const { pathname } = new URL(request.url)
+    if (request.method === 'POST' && pathname.match(/^\/(query|execute)$/)) {
+      const body = await request.json()
+      return Response.json(
+        Array.isArray(body)
+          ? body.map((query) => this.runQuery(query))
+          : this.runQuery(body)
+      )
+    } else {
+      return Response.json({ error: 'Not found' }, { status: 404 })
+    }
+  }
+
+  runQuery(query) {
+    const { sql, params = [] } = query
+    const results = Array.from(this.sql.exec(sql, ...params))
+    return {
+      results,
+      meta: { duration: 0.001, served_by: 'd1-mock' },
+    }
   }
 }
 
 export default {
   async fetch(request, env, ctx) {
     try {
-      const { pathname } = new URL(request.url)
-
-      if (request.method === 'POST' && pathname.startsWith('/query')) {
-        const body = await request.json()
-        return Response.json(
-          Array.isArray(body)
-            ? body.map((query) => mockQuery(query))
-            : mockQuery(body)
-        )
-      } else {
-        return Response.json({ error: 'Not found' }, { status: 404 })
-      }
+      const stub = env.db.get(env.db.idFromName('test'))
+      return stub.fetch(request)
     } catch (err) {
       return Response.json(
         { error: err.message, stack: err.stack },
@@ -42,11 +56,4 @@ export default {
       )
     }
   },
-}
-
-function ok(...results) {
-  return {
-    results,
-    meta: { duration: 0.001, served_by: 'd1-mock' },
-  }
 }

--- a/types/defines/d1.d.ts
+++ b/types/defines/d1.d.ts
@@ -8,11 +8,14 @@ interface D1Meta {
   changes: number;
 }
 
-interface D1Result<T = unknown> {
-  results: T[];
+interface D1Response {
   success: true;
   meta: D1Meta & Record<string, unknown>;
   error?: never;
+}
+
+type D1Result<T = unknown> = D1Response & {
+  results: T[];
 }
 
 interface D1ExecResult {
@@ -31,7 +34,7 @@ declare abstract class D1PreparedStatement {
   bind(...values: unknown[]): D1PreparedStatement;
   first<T = unknown>(colName: string): Promise<T | null>;
   first<T = Record<string, unknown>>(): Promise<T | null>;
-  run<T = Record<string, unknown>>(): Promise<D1Result<T>>;
+  run(): Promise<D1Response>;
   all<T = Record<string, unknown>>(): Promise<D1Result<T>>;
   raw<T = unknown[]>(): Promise<T[]>;
 }


### PR DESCRIPTION
This PR does a couple of things:

* Massively improves the realism of the D1 test suite. I've also got d1-api.ts and d1-api-test.js being imported into D1's internal test suite to verify these are correct, but the new d1-mock now much more closely mirrors the real system.
* Adds a resultsFormat flag to better control what D1 returns behind the scenes, with a default to `ROWS_AND_COLUMNS`, which should be more efficient (see below).
* Fixes `.run()` to no longer return `.results` property, as per the docs.
* Makes `.raw()` effectively the default and derives `.all()`/`.first()` from that, rather than the other way around.

In particular, this change fixes a long-standing bug with D1 where joining tables with the same column names was losing data, e.g.

```js
await DB.exec(`
  CREATE TABLE abc (a INT, b INT, c INT);
  CREATE TABLE cde (c INT, d INT, e INT);
  INSERT INTO abc VALUES (1,2,3),(4,5,6);
  INSERT INTO cde VALUES (7,8,9),(1,2,3);
`),

const { results } = await DB.prepare(`SELECT * FROM abc, cde;`).all()
//>  results: [
//>     { a: 1, b: 2, c: 7, d: 8, e: 9 },
//>     { a: 1, b: 2, c: 1, d: 2, e: 3 },
//>     { a: 4, b: 5, c: 7, d: 8, e: 9 },
//>     { a: 4, b: 5, c: 1, d: 2, e: 3 },
//>   ]
```

Note that `cde.c` is overriding `abc.c` in each of the rows as it's a simple object map and last-one-wins.

The intended solution was to be able to use `.raw()` to skip the step of building JS objects from each row:

```js
await DB.prepare(`SELECT * FROM abc, cde;`).raw()
//>  [
//>    [1, 2, 3, 7, 8, 9],
//>    [1, 2, 3, 1, 2, 3],
//>    [4, 5, 6, 7, 8, 9],
//>    [4, 5, 6, 1, 2, 3],
//>  ]
```

But previously that wasn't working as the D1 service was building the objects before sending them back, so by the time your worker got a response the data was already missing. In fact, `.raw()` previously just did a `Object.values()` on each row of the response, which is some real alpha code (sorry everyone).

That's now fixed, if you pass `?resultsFormat=ROWS_AND_COLUMNS` you get `{ results: { columns: [...], rows: [[...],[...], ...]}` instead of `{ results: [{ ... }, { ... }, ...]}` and you can reconstruct the object form for `.all()` just fine. But since this code is going to roll out independently of the backend changes, this PR was slightly complicated by having to support both old and new response types.

**One outstanding question**: should we find a way to return `.columns` to the user at all? As it stands, `.raw()` returns a simple array: `[ row1_values, row2_values, ... ]`, which doesn't really leave space for a `.columns` property (even if that would be technically possible to jam in there). Perhaps we should make `.raw(true)` return a `{ rows, columns }` object?

Leaving this as draft PR for now as I'm not 100% that this API doesn't need further changes, but would appreciate any 👀 from workerd folks.