### PR TITLE
Python: Make capnp field for pythonRequirement void

### DIFF
--- a/samples/pyodide-fastapi/config.capnp
+++ b/samples/pyodide-fastapi/config.capnp
@@ -23,8 +23,8 @@ const config :Workerd.Config = (
 const mainWorker :Workerd.Worker = (
   modules = [
     (name = "worker", pythonModule = embed "./worker.py"),
-    (name = "fastapi==0.103.2", pythonRequirement = ""),
-    (name = "ssl", pythonRequirement = ""),
+    (name = "fastapi==0.103.2", pythonRequirement = void),
+    (name = "ssl", pythonRequirement = void),
   ],
   compatibilityDate = "2023-12-18",
   compatibilityFlags = ["experimental"],

--- a/samples/pyodide-langchain/config.capnp
+++ b/samples/pyodide-langchain/config.capnp
@@ -23,10 +23,10 @@ const config :Workerd.Config = (
 const mainWorker :Workerd.Worker = (
   modules = [
     (name = "worker", pythonModule = embed "./worker.py"),
-    (name = "aiohttp", pythonRequirement = "aiohttp"),
-    (name = "ssl", pythonRequirement = "ssl"),
-    (name = "langchain==0.0.339", pythonRequirement = ""),
-    (name = "openai==0.28.1", pythonRequirement = ""),
+    (name = "aiohttp", pythonRequirement = void),
+    (name = "ssl", pythonRequirement = void),
+    (name = "langchain==0.0.339", pythonRequirement = void),
+    (name = "openai==0.28.1", pythonRequirement = void),
   ],
   compatibilityDate = "2023-12-18",
   compatibilityFlags = ["experimental"],

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -267,7 +267,7 @@ struct Worker {
       # A Python module. All bundles containing this value type are converted into a JS/WASM Worker
       # Bundle prior to execution.
 
-      pythonRequirement @9 :Text;
+      pythonRequirement @9 :Void;
       # A Python package that is required by this bundle. The package must be supported by
       # Pyodide (https://pyodide.org/en/stable/usage/packages-in-pyodide.html). All packages listed
       # will be installed prior to the execution of the worker.


### PR DESCRIPTION
The requirement is in the name of the "module" and the field value is unused. Marking the field void makes that clear.