### PR TITLE
Accept module names with and without a .py extension.

### DIFF
--- a/samples/pyodide/config.capnp
+++ b/samples/pyodide/config.capnp
@@ -22,7 +22,7 @@ const config :Workerd.Config = (
 
 const mainWorker :Workerd.Worker = (
   modules = [
-    (name = "worker", pythonModule = embed "./worker.py"),
+    (name = "worker.py", pythonModule = embed "./worker.py"),
   ],
   compatibilityDate = "2023-12-18",
   compatibilityFlags = ["experimental"],

--- a/src/pyodide/python-entrypoint-helper.js
+++ b/src/pyodide/python-entrypoint-helper.js
@@ -144,7 +144,9 @@ async function setupPackages(pyodide) {
   const micropipRequirements = [];
   for (const { name, value } of metadata.globals) {
     if (value.pythonModule !== undefined) {
-      pyodide.FS.writeFile(`/session/${name}.py`, value.pythonModule, {
+      // Support both modules names with the `.py` extension as well as without.
+      const pyFilename = name.endsWith(".py") ? name : `${name}.py`;
+      pyodide.FS.writeFile(`/session/${pyFilename}`, value.pythonModule, {
         canOwn: true,
       });
     }
@@ -201,7 +203,11 @@ async function setupPackages(pyodide) {
     );
   }
 
-  return pyodide.pyimport(metadata.mainModule);
+  // The main module can have a `.py` extension, strip it if it exists.
+  const mainName = metadata.mainModule;
+  const mainModule = mainName.endsWith(".py") ? mainName.slice(0, -3) : mainName;
+
+  return pyodide.pyimport(mainModule);
 }
 
 export default {


### PR DESCRIPTION
It looks like both are supported by JS Workers (both in EWC and in workerd). So this PR ensures the same is the case for Python Workers.

### Test Plan

```
$ bazel run @workerd//src/workerd/server:workerd -- serve $PWD/deps/workerd/samples/pyodide/config.capnp --experimental
```

+ test upstream
