### PR TITLE
Fixup gc visitation in streams readers and writers

### DIFF
--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -1838,7 +1838,7 @@ void WritableStreamInternalController::visitForGc(jsg::GcVisitor& visitor) {
   for (auto& event : queue) {
     KJ_SWITCH_ONEOF(event.event) {
       KJ_CASE_ONEOF(write, Write) {
-        visitor.visit(write.promise, write.ref);
+        visitor.visit(write.promise);
       }
       KJ_CASE_ONEOF(close, Close) {
         visitor.visit(close.promise);

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -283,7 +283,6 @@ private:
     kj::Maybe<jsg::Promise<void>::Resolver> promise;
     std::shared_ptr<v8::BackingStore> ownBytes;
     kj::ArrayPtr<const kj::byte> bytes;
-    kj::Maybe<jsg::Ref<WritableStream>> ref;
   };
   struct Close {
     kj::Maybe<jsg::Promise<void>::Resolver> promise;

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -81,10 +81,9 @@ public:
 
   bool isLockedToReader() const override { return !readState.is<Unlocked>(); }
 
-  bool lockReader(jsg::Lock& js, Reader& reader) override;
+  bool lockReader(jsg::Lock& js, kj::Own<WeakRef<Reader>> reader) override;
 
-  void releaseReader(Reader& reader, kj::Maybe<jsg::Lock&> maybeJs) override;
-  // See the comment for releaseReader in common.h for details on the use of maybeJs
+  void releaseReader(jsg::Lock& js, Reader& reader) override;
 
   kj::Maybe<PipeController&> tryPipeLock(jsg::Ref<WritableStream> destination) override;
 
@@ -201,9 +200,9 @@ public:
 
   bool isLockedToWriter() const override { return !writeState.is<Unlocked>(); }
 
-  bool lockWriter(jsg::Lock& js, Writer& writer) override;
+  bool lockWriter(jsg::Lock& js, kj::Own<WeakRef<Writer>> writer) override;
 
-  void releaseWriter(Writer& writer, kj::Maybe<jsg::Lock&> maybeJs) override;
+  void releaseWriter(jsg::Lock& js, Writer& writer) override;
   // See the comment for releaseWriter in common.h for details on the use of maybeJs
 
   kj::Maybe<v8::Local<v8::Value>> isErroring(jsg::Lock& js) override {

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -155,6 +155,9 @@ void ReaderImpl::releaseLock(jsg::Lock& js) {
 }
 
 void ReaderImpl::visitForGc(jsg::GcVisitor& visitor) {
+  KJ_IF_SOME(readable, state.tryGet<Attached>()) {
+    visitor.visit(readable);
+  }
   visitor.visit(closedPromise);
 }
 

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -35,6 +35,10 @@ public:
 
   void visitForGc(jsg::GcVisitor& visitor);
 
+  inline kj::Own<WeakRef<ReadableStreamController::Reader>> addWeakRef() {
+    return self->addRef();
+  }
+
 private:
   struct Initial {};
   // While a Reader is attached to a ReadableStream, it holds a strong reference to the
@@ -52,6 +56,8 @@ private:
 
   kj::OneOf<Initial, Attached, StreamStates::Closed, Released> state = Initial();
   kj::Maybe<jsg::MemoizedIdentity<jsg::Promise<void>>> closedPromise;
+
+  kj::Own<WeakRef<ReadableStreamController::Reader>> self;
 
   friend class ReadableStreamDefaultReader;
   friend class ReadableStreamBYOBReader;
@@ -96,6 +102,8 @@ public:
   void lockToStream(jsg::Lock& js, ReadableStream& stream);
 
   inline bool isByteOriented() const override { return false; }
+
+  kj::Own<WeakRef<Reader>> addWeakRef() override { return impl.addWeakRef(); }
 
 private:
   ReaderImpl impl;
@@ -161,6 +169,8 @@ public:
   void lockToStream(jsg::Lock& js, ReadableStream& stream);
 
   inline bool isByteOriented() const override { return true; }
+
+  kj::Own<WeakRef<Reader>> addWeakRef() override { return impl.addWeakRef(); }
 
 private:
   ReaderImpl impl;

--- a/src/workerd/api/streams/writable.c++
+++ b/src/workerd/api/streams/writable.c++
@@ -197,6 +197,9 @@ bool WritableStream::inspectExpectsBytes() {
 }
 
 void WritableStreamDefaultWriter::visitForGc(jsg::GcVisitor& visitor) {
+  KJ_IF_SOME(writable, state.tryGet<Attached>()) {
+    visitor.visit(writable);
+  }
   visitor.visit(closedPromise, readyPromise);
 }
 

--- a/src/workerd/api/streams/writable.h
+++ b/src/workerd/api/streams/writable.h
@@ -12,11 +12,9 @@ class WritableStreamDefaultWriter: public jsg::Object,
                                    public WritableStreamController::Writer {
 public:
   explicit WritableStreamDefaultWriter();
-
-  ~WritableStreamDefaultWriter() noexcept(false) override;
+  ~WritableStreamDefaultWriter() override;
 
   // JavaScript API
-
   static jsg::Ref<WritableStreamDefaultWriter> constructor(
       jsg::Lock& js,
       jsg::Ref<WritableStream> stream);
@@ -75,6 +73,8 @@ public:
 
   void replaceReadyPromise(jsg::Promise<void> readyPromise) override;
 
+  inline kj::Own<WeakRef<Writer>> addWeakRef() override { return self->addRef(); }
+
 private:
   struct Initial {};
   // While a Writer is attached to a WritableStream, it holds a strong reference to the
@@ -92,6 +92,8 @@ private:
 
   kj::Maybe<jsg::MemoizedIdentity<jsg::Promise<void>>> closedPromise;
   kj::Maybe<jsg::MemoizedIdentity<jsg::Promise<void>>> readyPromise;
+
+  kj::Own<WeakRef<WritableStreamController::Writer>> self;
 
   void visitForGc(jsg::GcVisitor& visitor);
 };

--- a/src/workerd/util/weak-refs.h
+++ b/src/workerd/util/weak-refs.h
@@ -94,6 +94,10 @@ public:
   inline kj::Own<WeakRef> addRef() { return kj::addRef(*this); }
   inline bool isValid() const { return maybeThing != kj::none; }
 
+  inline void invalidate(kj::Badge<T>) {
+    invalidate();
+  }
+
 private:
   friend T;
 


### PR DESCRIPTION
PR does a couple of things:

1. Ensures the the Reader/Writer is gc visiting the strong ref to the ReadableStream/WritableStream
2. Switches to uses a WeakRef rather than a Maybe bare ref from the ReadableStream/WritableStream to the Reader