### PR TITLE
Move python-entrypoint.js into a top level Capnp constant

### DIFF
--- a/src/pyodide/BUILD.bazel
+++ b/src/pyodide/BUILD.bazel
@@ -17,24 +17,37 @@ capnp_embed(
 )
 
 copy_file(
-    name = "packages_capnp_file",
-    src = "pyodide_packages.capnp",
-    out = "generated/pyodide_packages.capnp",
+    name = "python_entrypoint_file",
+    src = "python-entrypoint.js",
+    out = "generated/python-entrypoint.js"
 )
 
 capnp_embed(
-    name = "packages_capnp_file_embed",
-    src = "generated/pyodide_packages.capnp",
-    deps = ["packages_capnp_file"],
+    name = "python_entrypoint_file_embed",
+    src = "generated/python-entrypoint.js",
+    deps = ["python_entrypoint_file"],
+)
+
+copy_file(
+    name = "pyodide_extra_capnp_file",
+    src = "pyodide_extra.capnp",
+    out = "generated/pyodide_extra.capnp",
+)
+
+capnp_embed(
+    name = "pyodide_extra_file_embed",
+    src = "generated/pyodide_extra.capnp",
+    deps = ["pyodide_extra_capnp_file"],
 )
 
 cc_capnp_library(
-    name = "pyodide_packages_capnp",
-    srcs = ["generated/pyodide_packages.capnp"],
+    name = "pyodide_extra_capnp",
+    srcs = ["generated/pyodide_extra.capnp"],
     visibility = ["//visibility:public"],
     deps = [
-        ":packages_capnp_file_embed",
+        ":pyodide_extra_file_embed",
         ":pyodide_packages_archive_embed",
+        ":python_entrypoint_file_embed"
     ],
 )
 
@@ -94,10 +107,7 @@ expand_template(
 
 wd_js_bundle(
     name = "pyodide",
-    builtin_modules = glob([
-        "*.js",
-        "internal/patches/*.py",
-    ]),
+    builtin_modules = ["python-entrypoint-helper.js"],
     import_name = "pyodide",
     internal_data_modules = ["generated/python_stdlib.zip"] + glob([
         "internal/*.py",

--- a/src/pyodide/pyodide_extra.capnp
+++ b/src/pyodide/pyodide_extra.capnp
@@ -1,3 +1,4 @@
 @0x96c290dbf479ac0c;
 
+const pythonEntrypoint :Text = embed "python-entrypoint.js";
 const pyodidePackagesTar :Data = embed "pyodide_packages.tar";

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -63,13 +63,13 @@ wd_cc_library(
     hdrs = [
         "rtti.h",
         "modules.h",
-        "//src/pyodide:generated/pyodide_packages.capnp.h"
+        "//src/pyodide:generated/pyodide_extra.capnp.h"
     ],
     visibility = ["//visibility:public"],
     deps = [
         ":html-rewriter",
         "//src/workerd/io",
-        "//src/pyodide:pyodide_packages_capnp",
+        "//src/pyodide:pyodide_extra_capnp",
     ],
 )
 
@@ -89,12 +89,12 @@ wd_cc_library(
 wd_cc_library(
     name = "pyodide",
     srcs = ["pyodide.c++"],
-    hdrs = ["pyodide.h", "//src/pyodide:generated/pyodide_packages.capnp.h"],
+    hdrs = ["pyodide.h", "//src/pyodide:generated/pyodide_extra.capnp.h"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/workerd/server:workerd_capnp",
         "//src/pyodide:pyodide",
-        "//src/pyodide:pyodide_packages_capnp",
+        "//src/pyodide:pyodide_extra_capnp",
     ],
 )
 

--- a/src/workerd/api/pyodide.c++
+++ b/src/workerd/api/pyodide.c++
@@ -9,21 +9,6 @@
 
 namespace workerd::api::pyodide {
 
-namespace _ {
-kj::StringPtr lookupModule(kj::StringPtr name) {
-  for (auto m : PYODIDE_BUNDLE->getModules()) {
-    if (m.getName() == name) {
-      return m.getSrc().asChars().begin();
-    }
-  }
-  KJ_UNREACHABLE;
-}
-}
-
-kj::StringPtr getPyodideBootstrap() {
-  return _::lookupModule("pyodide:python-entrypoint");
-}
-
 kj::String generatePyodideMetadata(server::config::Worker::Reader conf) {
   capnp::JsonCodec jsonCodec;
   jsonCodec.setPrettyPrint(false);

--- a/src/workerd/api/pyodide.h
+++ b/src/workerd/api/pyodide.h
@@ -9,8 +9,6 @@
 
 namespace workerd::api::pyodide {
 
-kj::StringPtr getPyodideBootstrap();
-
 kj::String generatePyodideMetadata(server::config::Worker::Reader conf);
 
 bool hasPythonModules(capnp::List<server::config::Worker::Module>::Reader modules);

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -2,7 +2,7 @@
 
 #include <kj/common.h>
 #include <pyodide/pyodide.capnp.h>
-#include <pyodide/generated/pyodide_packages.capnp.h>
+#include <pyodide/generated/pyodide_extra.capnp.h>
 #include <workerd/util/autogate.h>
 
 namespace workerd::api::pyodide {

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -64,7 +64,7 @@ wd_cc_library(
         "//src/cloudflare",
         "//src/node",
         "//src/pyodide",
-        "//src/pyodide:pyodide_packages_capnp",
+        "//src/pyodide:pyodide_extra_capnp",
         "//src/workerd/api:analytics-engine_capnp",
         "//src/workerd/api:r2-api_capnp",
         "//src/workerd/jsg",

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -370,17 +370,17 @@ void WorkerdApi::compileModules(
     using namespace workerd::api::pyodide;
     if (util::Autogate::isEnabled(util::AutogateKey::BUILTIN_WASM_MODULES) &&
         hasPythonModules(confModules)) {
-      // Inject pyodide bootstrap module.
+      // Inject pyodide entrypoint module.
       {
         auto mainModule = confModules.begin();
         capnp::MallocMessageBuilder message;
         auto module = message.getRoot<config::Worker::Module>();
-        module.setEsModule(getPyodideBootstrap());
+        module.setEsModule(PYTHON_ENTRYPOINT);
         auto info = tryCompileModule(lockParam, module, modules->getObserver(), getFeatureFlags());
         auto path = kj::Path::parse(mainModule->getName());
         modules->add(path, kj::mv(KJ_REQUIRE_NONNULL(info)));
       }
-      // Inject metadata that the bootstrap module will read.
+      // Inject metadata that the entrypoint module will read.
       {
         using ModuleInfo = jsg::ModuleRegistry::ModuleInfo;
         using JsonModuleInfo = jsg::ModuleRegistry::JsonModuleInfo;


### PR DESCRIPTION
So we don't have to search for it in the module list. It's not meant to be imported by the user anyways.