### PR TITLE
Fix unchecked malloc

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -720,8 +720,8 @@ static void stopProfiling(jsg::Lock& js,
       }
 
       auto hitLineCount = allNodes[i]->GetHitLineCount();
-      v8::CpuProfileNode::LineTick lineBuffer[hitLineCount];
-      allNodes[i]->GetLineTicks(lineBuffer, hitLineCount);
+      auto lineBuffer = kj::heapArray<v8::CpuProfileNode::LineTick>(hitLineCount);
+      allNodes[i]->GetLineTicks(lineBuffer.begin(), lineBuffer.size());
 
       auto positionTicks = nodeBuilder.initPositionTicks(hitLineCount);
       for (uint j=0; j < hitLineCount; j++) {

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -720,10 +720,7 @@ static void stopProfiling(jsg::Lock& js,
       }
 
       auto hitLineCount = allNodes[i]->GetHitLineCount();
-      v8::CpuProfileNode::LineTick* lineBuffer =
-          (v8::CpuProfileNode::LineTick*)malloc(
-          hitLineCount * sizeof(v8::CpuProfileNode::LineTick));
-      KJ_DEFER(free(lineBuffer));
+      v8::CpuProfileNode::LineTick lineBuffer[hitLineCount];
       allNodes[i]->GetLineTicks(lineBuffer, hitLineCount);
 
       auto positionTicks = nodeBuilder.initPositionTicks(hitLineCount);


### PR DESCRIPTION
The original code did not check if the allocation succeeded, leading to possible issues if malloc() returns null. 

This PR should fix that by simply replacing the malloc with a stack allocation.