### PR TITLE
Check lower bound returned by atoi()

### DIFF
--- a/src/workerd/api/r2-rpc.c++
+++ b/src/workerd/api/r2-rpc.c++
@@ -98,6 +98,7 @@ kj::Promise<R2Result> doR2HTTPGetRequest(kj::Own<kj::HttpClient> client,
     // finds a corner case for the heuristic so that we don't fail the GET with an opaque
     // internal error.
     KJ_REQUIRE(metadataSize <= 1024 * 1024, "R2 metadata size seems way too large");
+    KJ_REQUIRE(metadataSize >= 0, "R2 metadata size parsed as negative");
 
     auto metadataBuffer = kj::heapArray<char>(metadataSize);
     auto metadataReadLength =


### PR DESCRIPTION
A potential negative value returned by atoi() may cause an excessive memory allocation. This PR adds a check that the returned value is nonnegative.