### PR TITLE
Implement heap snapsnot memory tracking for Event, EventTarget

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -744,4 +744,45 @@ CustomEvent::CustomEventInit::operator Event::Init() {
   };
 }
 
+size_t EventTarget::EventHandler::JavaScriptHandler::jsgGetMemorySelfSize() const {
+  return sizeof(JavaScriptHandler);
+}
+
+void EventTarget::EventHandler::JavaScriptHandler::jsgGetMemoryInfo(
+    jsg::MemoryTracker& tracker) const {
+  tracker.trackField("identity", identity);
+  tracker.trackField("callback", callback);
+  if (abortHandler != kj::none) {
+    tracker.trackFieldWithSize("abortHandler", sizeof(kj::Own<NativeHandler>) +
+                                                sizeof(NativeHandler));
+  }
+}
+
+size_t EventTarget::EventHandler::jsgGetMemorySelfSize() const {
+  return sizeof(EventHandler);
+}
+
+void EventTarget::EventHandler::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
+  KJ_SWITCH_ONEOF(handler) {
+    KJ_CASE_ONEOF(js, JavaScriptHandler) {
+      tracker.trackField("js", js);
+    }
+    KJ_CASE_ONEOF(native, NativeHandlerRef) {
+      tracker.trackFieldWithSize("native", sizeof(NativeHandlerRef));
+    }
+  }
+}
+
+size_t EventTarget::EventHandlerSet::jsgGetMemorySelfSize() const {
+  return sizeof(EventHandlerSet);
+}
+
+void EventTarget::EventHandlerSet::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
+  tracker.trackField("handlers", handlers, kj::none, kj::none, false);
+}
+
+void EventTarget::visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+  tracker.trackField("typeMap", typeMap);
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -148,6 +148,11 @@ public:
     JSG_STATIC_CONSTANT(BUBBLING_PHASE);
   }
 
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackField("type", ownType);
+    tracker.trackField("target", target);
+  }
+
 private:
   kj::StringPtr type;
   kj::String ownType;
@@ -213,6 +218,10 @@ public:
   JSG_RESOURCE_TYPE(CustomEvent) {
     JSG_INHERIT(Event);
     JSG_READONLY_PROTOTYPE_PROPERTY(detail, getDetail);
+  }
+
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackField("detail", detail);
   }
 
 private:
@@ -334,6 +343,8 @@ public:
       jsg::Function<void(jsg::Ref<Event>)> func,
       bool once = false);
 
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
+
 private:
   void addNativeListener(jsg::Lock& js, NativeHandler& handler);
   bool removeNativeListener(NativeHandler& handler);
@@ -352,6 +363,10 @@ private:
           handler->visitForGc(visitor);
         }
       }
+
+      kj::StringPtr jsgGetMemoryName() const { return "JavaScriptHandler"_kjc; }
+      size_t jsgGetMemorySelfSize() const;
+      void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const;
     };
 
     struct NativeHandlerRef {
@@ -367,6 +382,10 @@ private:
 
     // When once is true, the handler will be removed after it is invoked one time.
     bool once = false;
+
+    kj::StringPtr jsgGetMemoryName() const { return "EventHandler"_kjc; }
+    size_t jsgGetMemorySelfSize() const;
+    void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const;
   };
 
   struct EventHandlerHashCallbacks {
@@ -389,6 +408,10 @@ private:
 
     EventHandlerSet()
         : handlers(EventHandlerHashCallbacks(), {}) {}
+
+    kj::StringPtr jsgGetMemoryName() const { return "EventHandlerSet"_kjc; }
+    size_t jsgGetMemorySelfSize() const;
+    void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const;
   };
 
   EventHandlerSet& getOrCreate(kj::StringPtr str) KJ_LIFETIMEBOUND;
@@ -492,6 +515,13 @@ public:
 
   RefcountedCanceler& getCanceler();
 
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    EventTarget::visitForMemoryInfo(tracker);
+    tracker.trackInlineFieldWithSize("IoOwn<RefcountedCanceler>",
+        sizeof(IoOwn<RefcountedCanceler>));
+    tracker.trackField("reason", reason);
+  }
+
 private:
   IoOwn<RefcountedCanceler> canceler;
   Flag flag;
@@ -523,6 +553,10 @@ public:
       JSG_READONLY_INSTANCE_PROPERTY(signal, getSignal);
     }
     JSG_METHOD(abort);
+  }
+
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackField("signal", signal);
   }
 
 private:

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -122,6 +122,11 @@ public:
     JSG_READONLY_INSTANCE_PROPERTY(reason, getReason);
   }
 
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackField("promise", promise);
+    tracker.trackField("reason", reason);
+  }
+
 private:
   jsg::V8Ref<v8::Promise> promise;
   jsg::Value reason;
@@ -655,6 +660,10 @@ public:
 
   TimeoutId::Generator timeoutIdGenerator;
   // The generator for all timeout IDs associated with this scope.
+
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackField("unhandledRejections", unhandledRejections);
+  }
 
 private:
   jsg::UnhandledRejectionHandler unhandledRejections;

--- a/src/workerd/api/gpu/gpu-device.h
+++ b/src/workerd/api/gpu/gpu-device.h
@@ -120,6 +120,10 @@ public:
     JSG_READONLY_INSTANCE_PROPERTY(error, getError);
   }
 
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackField("error", error_);
+  }
+
 private:
   jsg::Ref<GPUError> error_;
 

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -67,6 +67,10 @@ public:
     });
   }
 
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackField("data", data);
+  }
+
 private:
   jsg::JsRef<jsg::JsValue> data;
 
@@ -112,6 +116,10 @@ public:
     // CloseEvent will be referenced from the `WebSocketEventMap` define
   }
 
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackField("reason", reason);
+  }
+
 private:
   int code;
   kj::String reason;
@@ -145,6 +153,11 @@ public:
 
     JSG_TS_ROOT();
     // ErrorEvent will be referenced from the `WebSocketEventMap` define
+  }
+
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackField("message", message);
+    tracker.trackField("error", error);
   }
 
 private:

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -10,6 +10,7 @@ wd_cc_library(
         ["*.c++"],
         exclude = [
             "exception.c++",
+            "memory.c++",
             "*-test.c++",
         ],
     ),
@@ -43,6 +44,7 @@ wd_cc_library(
 wd_cc_library(
     name = "memory-tracker",
     hdrs = ["memory.h"],
+    srcs = ["memory.c++"],
     visibility = ["//visibility:public"],
     deps = [
         "@capnp-cpp//src/kj",

--- a/src/workerd/jsg/iterator.h
+++ b/src/workerd/jsg/iterator.h
@@ -813,7 +813,7 @@ private:
       if constexpr (MemoryRetainer<State>) {
         tracker.trackField("state", state);
       } else {
-        tracker.trackField("state", sizeof(State));
+        tracker.trackFieldWithSize("state", sizeof(State));
       }
       tracker.trackField("impl", impl);
     }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -833,12 +833,12 @@ private:
 };
 
 template <V8Value T>
-MemoryTracker& MemoryTracker::trackField(
+void MemoryTracker::trackField(
     kj::StringPtr edgeName,
     const V8Ref<T>& value,
     kj::Maybe<kj::StringPtr> nodeName) {
   // Even though we're passing in a template T, casting to a v8::Value is sufficient here.
-  return trackField(edgeName, value.handle.Get(isolate_)
+  trackField(edgeName, value.handle.Get(isolate_)
       .template As<v8::Value>(), nodeName);
 }
 
@@ -1221,11 +1221,11 @@ private:
 };
 
 template <MemoryRetainer T>
-MemoryTracker& MemoryTracker::trackField(
+void MemoryTracker::trackField(
     kj::StringPtr edgeName,
     const Ref<T>& value,
     kj::Maybe<kj::StringPtr> nodeName) {
-  return trackField(edgeName, value.get(), nodeName);
+  trackField(edgeName, value.get(), nodeName);
 }
 
 template <typename T, typename... Params>

--- a/src/workerd/jsg/memory.c++
+++ b/src/workerd/jsg/memory.c++
@@ -1,0 +1,216 @@
+#pragma once
+
+#include "memory.h"
+#include <kj/one-of.h>
+
+namespace workerd::jsg {
+
+class MemoryRetainerNode final : public v8::EmbedderGraph::Node {
+public:
+  static constexpr auto PREFIX = "workerd /";
+
+  const char* Name() override { return name_.cStr(); }
+
+  const char* NamePrefix() override { return PREFIX; }
+
+  size_t SizeInBytes() override {
+    return size_;
+  }
+
+  bool IsRootNode() override {
+    KJ_SWITCH_ONEOF(isRootNode) {
+      KJ_CASE_ONEOF(b, bool) {
+        return b;
+      }
+      KJ_CASE_ONEOF(fn, kj::Function<bool()>) {
+        return fn();
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  v8::EmbedderGraph::Node::Detachedness GetDetachedness() override {
+    return detachedness_;
+  }
+
+  inline Node* JSWrapperNode() { return wrapper_node_; }
+
+  KJ_DISALLOW_COPY_AND_MOVE(MemoryRetainerNode);
+  ~MemoryRetainerNode() noexcept(true) {}
+
+private:
+  static v8::EmbedderGraph::Node::Detachedness fromDetachedState(
+      MemoryInfoDetachedState state) {
+    switch (state) {
+      case MemoryInfoDetachedState::UNKNOWN:
+        return v8::EmbedderGraph::Node::Detachedness::kUnknown;
+      case MemoryInfoDetachedState::ATTACHED:
+        return v8::EmbedderGraph::Node::Detachedness::kAttached;
+      case MemoryInfoDetachedState::DETACHED:
+        return v8::EmbedderGraph::Node::Detachedness::kDetached;
+    }
+    KJ_UNREACHABLE;
+  }
+
+  static v8::EmbedderGraph::Node* maybeWrapperNode(
+      MemoryTracker* tracker,
+      v8::Local<v8::Object> obj) {
+    if (!obj.IsEmpty()) return tracker->graph_->V8Node(obj);
+    return nullptr;
+  }
+
+  MemoryRetainerNode(MemoryTracker* tracker,
+                     const void* retainer,
+                     const kj::StringPtr name,
+                     const size_t size,
+                     v8::Local<v8::Object> obj,
+                     kj::Maybe<kj::Function<bool()>> checkIsRootNode,
+                     MemoryInfoDetachedState detachedness)
+      : name_(name),
+        size_(size),
+        wrapper_node_(maybeWrapperNode(tracker, obj)),
+        detachedness_(fromDetachedState(detachedness)) {
+    KJ_IF_SOME(fn, checkIsRootNode) {
+      isRootNode = kj::mv(fn);
+    }
+  }
+
+  MemoryRetainerNode(MemoryTracker* tracker,
+                     kj::StringPtr name,
+                     size_t size,
+                     bool isRootNode = false)
+      : name_(name),
+        size_(size),
+        isRootNode(isRootNode) {}
+
+  kj::StringPtr name_;
+  size_t size_ = 0;
+  v8::EmbedderGraph::Node* wrapper_node_ = nullptr;
+
+  kj::OneOf<bool, kj::Function<bool()>> isRootNode = false;
+
+  v8::EmbedderGraph::Node::Detachedness detachedness_ =
+      v8::EmbedderGraph::Node::Detachedness::kUnknown;
+
+  friend class MemoryTracker;
+};
+
+namespace {
+kj::Maybe<MemoryRetainerNode&> getCurrentNode(const std::stack<MemoryRetainerNode*> stack) {
+  if (stack.empty()) return kj::none;
+  return *stack.top();
+}
+}
+
+MemoryTracker::MemoryTracker(v8::Isolate* isolate, v8::EmbedderGraph* graph)
+    : isolate_(isolate),
+      graph_(graph) {}
+
+MemoryRetainerNode* MemoryTracker::addNode(const void* retainer,
+                                           const kj::StringPtr name,
+                                           const size_t size,
+                                           v8::Local<v8::Object> obj,
+                                           kj::Maybe<kj::Function<bool()>> checkIsRootNode,
+                                           MemoryInfoDetachedState detachedness,
+                                           kj::Maybe<kj::StringPtr> edgeName) {
+  KJ_IF_SOME(found, seen_.find(retainer)) { return found; }
+
+  MemoryRetainerNode* n = new MemoryRetainerNode(this, retainer, name, size,
+                                                 obj, kj::mv(checkIsRootNode),
+                                                 detachedness);
+  graph_->AddNode(std::unique_ptr<v8::EmbedderGraph::Node>(n));
+  seen_.insert(retainer, n);
+
+  KJ_IF_SOME(currentNode, getCurrentNode(nodeStack_)) {
+    KJ_IF_SOME(name, edgeName) {
+      graph_->AddEdge(&currentNode, n, name.cStr());
+    } else {
+      graph_->AddEdge(&currentNode, n, nullptr);
+    }
+  }
+
+  if (n->JSWrapperNode() != nullptr) {
+    graph_->AddEdge(n, n->JSWrapperNode(), "native_to_javascript");
+    graph_->AddEdge(n->JSWrapperNode(), n, "javascript_to_native");
+  }
+
+  return n;
+}
+
+MemoryRetainerNode* MemoryTracker::addNode(kj::StringPtr nodeName,
+                                           size_t size,
+                                           kj::Maybe<kj::StringPtr> edgeName) {
+  MemoryRetainerNode* n = new MemoryRetainerNode(this, nodeName, size);
+  graph_->AddNode(std::unique_ptr<v8::EmbedderGraph::Node>(n));
+
+  KJ_IF_SOME(currentNode, getCurrentNode(nodeStack_)) {
+    KJ_IF_SOME(name, edgeName) {
+      graph_->AddEdge(&currentNode, n, name.cStr());
+    } else {
+      graph_->AddEdge(&currentNode, n, nullptr);
+    }
+  }
+
+  return n;
+}
+
+MemoryRetainerNode* MemoryTracker::pushNode(kj::StringPtr nodeName,
+                                            size_t size,
+                                            kj::Maybe<kj::StringPtr> edgeName) {
+  MemoryRetainerNode* n = addNode(nodeName, size, edgeName);
+  nodeStack_.push(n);
+  return n;
+}
+
+void MemoryTracker::decCurrentNodeSize(size_t size) {
+  KJ_IF_SOME(currentNode, getCurrentNode(nodeStack_)) {
+    currentNode.size_ -= size;
+  }
+}
+
+void MemoryTracker::addEdge(v8::EmbedderGraph::Node* node, kj::StringPtr edgeName) {
+  KJ_IF_SOME(currentNode, getCurrentNode(nodeStack_)) {
+    graph_->AddEdge(&currentNode, node, edgeName.cStr());
+  } else {
+    graph_->AddEdge(nullptr, node, edgeName.cStr());
+  }
+}
+
+void MemoryTracker::addEdge(MemoryRetainerNode* node, kj::StringPtr edgeName) {
+  KJ_IF_SOME(currentNode, getCurrentNode(nodeStack_)) {
+    graph_->AddEdge(&currentNode, node, edgeName.cStr());
+  } else {
+    graph_->AddEdge(nullptr, node, edgeName.cStr());
+  }
+}
+
+// ======================================================================================
+
+HeapSnapshotActivity::HeapSnapshotActivity(Callback callback): callback(kj::mv(callback)) {}
+
+v8::ActivityControl::ControlOption HeapSnapshotActivity::ReportProgressValue(
+    uint32_t done, uint32_t total) {
+  return callback(done, total) ?
+      ControlOption::kContinue :
+      ControlOption::kAbort;
+}
+
+
+HeapSnapshotWriter::HeapSnapshotWriter(Callback callback, size_t chunkSize)
+      : callback(kj::mv(callback)),
+        chunkSize(chunkSize) {}
+
+void HeapSnapshotWriter::EndOfStream() {
+  callback(kj::none);
+}
+
+int HeapSnapshotWriter::GetChunkSize() { return chunkSize; }
+
+v8::OutputStream::WriteResult HeapSnapshotWriter::WriteAsciiChunk(
+    char* data, int size) {
+  return callback(kj::ArrayPtr<char>(data, size)) ?
+      v8::OutputStream::WriteResult::kContinue :
+      v8::OutputStream::WriteResult::kAbort;
+}
+
+}  // namespace workerd::jsg


### PR DESCRIPTION
Expands heap tracking memory tracking for handful of API types

~~Includes the context global in the heap tracking trace.~~ originally had some extra stuff in here for special-case handling of the context global in order for it to appear in the snapshot a certain way but it added way more complexity than it was worth. The non-special case handling is sufficient.

Refines a few bits and pieces in the memory tracker def