### PR TITLE
Fix GC visitation in stream readers and writers

### DIFF
--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -742,6 +742,12 @@ public:
     return canceler;
   }
 
+  void clear() {
+    reader = kj::none;
+    closedFulfiller = kj::none;
+    canceler = kj::none;
+  }
+
 private:
   kj::Maybe<ReadableStreamController::Reader&> reader;
   kj::Maybe<jsg::Promise<void>::Resolver> closedFulfiller;
@@ -786,6 +792,12 @@ public:
       readyFulfiller = kj::mv(pair.resolver);
       w.replaceReadyPromise(kj::mv(pair.promise));
     }
+  }
+
+  void clear() {
+    writer = kj::none;
+    closedFulfiller = kj::none;
+    readyFulfiller = kj::none;
   }
 
 private:

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -1838,7 +1838,7 @@ void WritableStreamInternalController::visitForGc(jsg::GcVisitor& visitor) {
   for (auto& event : queue) {
     KJ_SWITCH_ONEOF(event.event) {
       KJ_CASE_ONEOF(write, Write) {
-        visitor.visit(write.promise, write.ref);
+        visitor.visit(write.promise);
       }
       KJ_CASE_ONEOF(close, Close) {
         visitor.visit(close.promise);

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -283,7 +283,6 @@ private:
     kj::Maybe<jsg::Promise<void>::Resolver> promise;
     std::shared_ptr<v8::BackingStore> ownBytes;
     kj::ArrayPtr<const kj::byte> bytes;
-    kj::Maybe<jsg::Ref<WritableStream>> ref;
   };
   struct Close {
     kj::Maybe<jsg::Promise<void>::Resolver> promise;

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -155,6 +155,9 @@ void ReaderImpl::releaseLock(jsg::Lock& js) {
 }
 
 void ReaderImpl::visitForGc(jsg::GcVisitor& visitor) {
+  KJ_IF_SOME(readable, state.tryGet<Attached>()) {
+    visitor.visit(readable);
+  }
   visitor.visit(closedPromise);
 }
 

--- a/src/workerd/api/streams/writable.c++
+++ b/src/workerd/api/streams/writable.c++
@@ -197,6 +197,9 @@ bool WritableStream::inspectExpectsBytes() {
 }
 
 void WritableStreamDefaultWriter::visitForGc(jsg::GcVisitor& visitor) {
+  KJ_IF_SOME(writable, state.tryGet<Attached>()) {
+    visitor.visit(writable);
+  }
   visitor.visit(closedPromise, readyPromise);
 }
 


### PR DESCRIPTION
Fixes a memory leak in certain uses of streams.

This is a simpler version of #1598. I was able to directly fix the problem that the WeakRef refactor also solved.