### PR TITLE
Add toStringTag value on JSG resource types

### DIFF
--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -47,7 +47,7 @@ namespace workerd::jsg {
       ::workerd::jsg::JsgKind::RESOURCE; \
   using jsgSuper = jsgThis; \
   using jsgThis = Type; \
-  inline kj::StringPtr jsgGetName() const { return #Type##_kjc; } \
+  static inline kj::StringPtr jsgGetName() { return #Type##_kjc; } \
   inline kj::StringPtr jsgGetMemoryName() const override { return #Type##_kjc; } \
   inline size_t jsgGetMemorySelfSize() const override { return sizeof(Type); } \
   inline void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const override { \

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -47,6 +47,7 @@ namespace workerd::jsg {
       ::workerd::jsg::JsgKind::RESOURCE; \
   using jsgSuper = jsgThis; \
   using jsgThis = Type; \
+  inline kj::StringPtr jsgGetName() const { return #Type##_kjc; } \
   inline kj::StringPtr jsgGetMemoryName() const override { return #Type##_kjc; } \
   inline size_t jsgGetMemorySelfSize() const override { return sizeof(Type); } \
   inline void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const override { \

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -681,7 +681,7 @@ struct ResourceTypeBuilder {
       v8::PropertyAttribute::ReadOnly | v8::PropertyAttribute::DontEnum));
 
     auto toStringTagSymbol = v8::Symbol::GetToStringTag(isolate);
-    prototype->Set(toStringTagSymbol, v8StrIntern(isolate, typeWrapper.jsgGetName()), static_cast<v8::PropertyAttribute>(0));
+    prototype->Set(toStringTagSymbol, v8StrIntern(isolate, Self::jsgGetName()), static_cast<v8::PropertyAttribute>(0));
   }
 
   template <typename Type, typename GetNamedMethod, GetNamedMethod getNamedMethod>

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -681,7 +681,7 @@ struct ResourceTypeBuilder {
       v8::PropertyAttribute::ReadOnly | v8::PropertyAttribute::DontEnum));
 
     auto toStringTagSymbol = v8::Symbol::GetToStringTag(isolate);
-    prototype->Set(toStringTagSymbol, v8StrIntern(isolate, typeWrapper.jsgGetName()), v8::PropertyAttribute::ReadOnly);
+    prototype->Set(toStringTagSymbol, v8StrIntern(isolate, typeWrapper.jsgGetName()), 0);
   }
 
   template <typename Type, typename GetNamedMethod, GetNamedMethod getNamedMethod>

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -681,7 +681,7 @@ struct ResourceTypeBuilder {
       v8::PropertyAttribute::ReadOnly | v8::PropertyAttribute::DontEnum));
 
     auto toStringTagSymbol = v8::Symbol::GetToStringTag(isolate);
-    prototype->Set(toStringTagSymbol, v8StrIntern(isolate, typeWrapper.jsgGetName()), 0);
+    prototype->Set(toStringTagSymbol, v8StrIntern(isolate, typeWrapper.jsgGetName()), static_cast<v8::PropertyAttribute>(0));
   }
 
   template <typename Type, typename GetNamedMethod, GetNamedMethod getNamedMethod>

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -653,6 +653,16 @@ struct WildcardPropertyCallbacks<
   }
 };
 
+template<typename TypeWrapper>
+decltype(std::declval<TypeWrapper&>().jsgGetMemoryName()) typeWrapperName(TypeWrapper &typeWrapper) {
+  return typeWrapper.jsgGetMemoryName();
+}
+
+template<typename TypeWrapper>
+kj::StringPtr typeWrapperName(TypeWrapper &typeWrapper) {
+  return "Object"_kj;
+}
+
 // ======================================================================================
 
 // Used by the JSG_METHOD macro to register a method on a resource type.
@@ -679,6 +689,9 @@ struct ResourceTypeBuilder {
     inspectProperties = v8::ObjectTemplate::New(isolate);
     prototype->Set(symbol, inspectProperties, static_cast<v8::PropertyAttribute>(
       v8::PropertyAttribute::ReadOnly | v8::PropertyAttribute::DontEnum));
+
+    auto toStringTagSymbol = v8::Symbol::GetToStringTag(isolate);
+    prototype->Set(toStringTagSymbol, v8StrIntern(isolate, typeWrapperName(typeWrapper)), v8::PropertyAttribute::ReadOnly);
   }
 
   template <typename Type, typename GetNamedMethod, GetNamedMethod getNamedMethod>

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -653,16 +653,6 @@ struct WildcardPropertyCallbacks<
   }
 };
 
-template<typename TypeWrapper>
-decltype(std::declval<TypeWrapper&>().jsgGetMemoryName()) typeWrapperName(TypeWrapper &typeWrapper) {
-  return typeWrapper.jsgGetMemoryName();
-}
-
-template<typename TypeWrapper>
-kj::StringPtr typeWrapperName(TypeWrapper &typeWrapper) {
-  return "Object"_kj;
-}
-
 // ======================================================================================
 
 // Used by the JSG_METHOD macro to register a method on a resource type.
@@ -691,7 +681,7 @@ struct ResourceTypeBuilder {
       v8::PropertyAttribute::ReadOnly | v8::PropertyAttribute::DontEnum));
 
     auto toStringTagSymbol = v8::Symbol::GetToStringTag(isolate);
-    prototype->Set(toStringTagSymbol, v8StrIntern(isolate, typeWrapperName(typeWrapper)), v8::PropertyAttribute::ReadOnly);
+    prototype->Set(toStringTagSymbol, v8StrIntern(isolate, typeWrapper.jsgGetName()), v8::PropertyAttribute::ReadOnly);
   }
 
   template <typename Type, typename GetNamedMethod, GetNamedMethod getNamedMethod>

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -681,7 +681,7 @@ struct ResourceTypeBuilder {
       v8::PropertyAttribute::ReadOnly | v8::PropertyAttribute::DontEnum));
 
     auto toStringTagSymbol = v8::Symbol::GetToStringTag(isolate);
-    prototype->Set(toStringTagSymbol, v8StrIntern(isolate, Self::jsgGetName()), static_cast<v8::PropertyAttribute>(0));
+    prototype->Set(toStringTagSymbol, v8StrIntern(isolate, Self::jsgGetName()), v8::PropertyAttribute::None);
   }
 
   template <typename Type, typename GetNamedMethod, GetNamedMethod getNamedMethod>

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -472,6 +472,7 @@ private:
   class Type##_TypeWrapper final: public Type##_TypeWrapperBase { \
   public: \
     using Type##_TypeWrapperBase::TypeWrapper; \
+    kj::StringPtr jsgGetName() const { return #Type##_kjc; } \
   }; \
   class Type final: public ::workerd::jsg::Isolate<Type##_TypeWrapper> { \
   public: \

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -472,7 +472,6 @@ private:
   class Type##_TypeWrapper final: public Type##_TypeWrapperBase { \
   public: \
     using Type##_TypeWrapperBase::TypeWrapper; \
-    kj::StringPtr jsgGetName() const { return #Type##_kjc; } \
   }; \
   class Type final: public ::workerd::jsg::Isolate<Type##_TypeWrapper> { \
   public: \

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -118,7 +118,7 @@ public:
   virtual void jsgVisitForGc(GcVisitor& visitor);
 
   virtual kj::StringPtr jsgGetMemoryName() const {
-    KJ_UNIMPLEMENTED("jsgGetTypeName is not implemented. "
+    KJ_UNIMPLEMENTED("jsgGetMemoryName is not implemented. "
                      "It must be overridden by subclasses");
   }
 


### PR DESCRIPTION
This PR ensures that Object.prototype.toString() returns the correct values for built-in objects (i.e. ResourceTypes). 