### PR TITLE
Python: Share Python interpreter across requests

### DIFF
--- a/src/pyodide/python-entrypoint-helper.js
+++ b/src/pyodide/python-entrypoint-helper.js
@@ -194,7 +194,7 @@ async function setupPackages(pyodide) {
     );
     pyodide.pyimport("aiohttp_fetch_patch");
   }
-  if (requirements.includes("fastapi")) {
+  if (requirements.some(req => req.startsWith("fastapi"))) {
     const mod = await import("pyodide-internal:asgi.py");
     pyodide.FS.writeFile(
       "/lib/python3.11/site-packages/asgi.py",
@@ -210,16 +210,26 @@ async function setupPackages(pyodide) {
   return pyodide.pyimport(mainModule);
 }
 
+let mainModule;
+async function getMainModule() {
+  if (mainModule) {
+    return mainModule;
+  }
+  // TODO: investigate whether it is possible to run part of loadPyodide in top level scope
+  // When we do it in top level scope we seem to get a broken file system.
+  const pyodide = await loadPyodide();
+  mainModule = await setupPackages(pyodide);
+  return mainModule;
+}
+
 export default {
   async fetch(request, env) {
-    const pyodide = await loadPyodide();
-    const mainModule = await setupPackages(pyodide);
+    const mainModule = await getMainModule();
     return await mainModule.fetch(request);
   },
   async test() {
     try {
-      const pyodide = await loadPyodide();
-      const mainModule = await setupPackages(pyodide);
+      const mainModule = await getMainModule();
       return await mainModule.test();
     } catch (e) {
       console.warn(e);

--- a/src/pyodide/python-entrypoint-helper.js
+++ b/src/pyodide/python-entrypoint-helper.js
@@ -210,16 +210,18 @@ async function setupPackages(pyodide) {
   return pyodide.pyimport(mainModule);
 }
 
-let mainModule;
-async function getMainModule() {
-  if (mainModule) {
-    return mainModule;
+let mainModulePromise;
+function getMainModule() {
+  if (!mainModulePromise) {
+    return mainModulePromise;
   }
-  // TODO: investigate whether it is possible to run part of loadPyodide in top level scope
-  // When we do it in top level scope we seem to get a broken file system.
-  const pyodide = await loadPyodide();
-  mainModule = await setupPackages(pyodide);
-  return mainModule;
+  mainModulePromise = (async function() {
+    // TODO: investigate whether it is possible to run part of loadPyodide in top level scope
+    // When we do it in top level scope we seem to get a broken file system.
+    const pyodide = await loadPyodide();
+    return await setupPackages(pyodide);
+  })();
+  return mainModulePromise;
 }
 
 export default {

--- a/src/pyodide/python-entrypoint-helper.js
+++ b/src/pyodide/python-entrypoint-helper.js
@@ -212,7 +212,7 @@ async function setupPackages(pyodide) {
 
 let mainModulePromise;
 function getMainModule() {
-  if (!mainModulePromise) {
+  if (mainModulePromise !== undefined) {
     return mainModulePromise;
   }
   mainModulePromise = (async function() {


### PR DESCRIPTION
Before this PR we instantiate the Python interpreter from scratch on every request. This is slow and uses up a lot of memory. This switches to sharing an interpreter across requests. This makes per-request non-coldstart execution time and memory usage much lower.