### PR TITLE
Consolidate entropy source impls into a single source

### DIFF
--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -48,6 +48,7 @@ wd_cc_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//src/workerd/util:autogate",
+        "//src/workerd/util:entropy",
         ":server",
         ":workerd-meta_capnp",
         ":workerd_capnp",

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -21,12 +21,15 @@ wd_cc_library(
         "//src/workerd/io",
         "//src/workerd/jsg",
         "//src/workerd/server",
+        "//src/workerd/util:entropy",
     ],
 )
 
 kj_test(
     src = "test-fixture-test.c++",
-    deps = [":test-fixture"],
+    deps = [
+        ":test-fixture",
+    ],
 )
 
 # Use `bazel run //src/workerd/tests:bench-json` to benchmark

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -15,6 +15,7 @@
 #include <workerd/server/server.h>
 #include <workerd/server/workerd-api.h>
 #include <workerd/util/stream-utils.h>
+#include <workerd/util/entropy.h>
 
 #include "test-fixture.h"
 
@@ -101,26 +102,6 @@ static constexpr kj::StringPtr mainModuleSource = R"SCRIPT(
 static constexpr kj::StringPtr mainModuleName = "main"_kj;
 
 static constexpr kj::StringPtr scriptId = "script"_kj;
-
-class MockEntropySource final: public kj::EntropySource {
-public:
-  ~MockEntropySource() {}
-  void generate(kj::ArrayPtr<kj::byte> buffer) override {
-    for (kj::byte& b: buffer) {
-     b = counter++;
-    }
-  }
-
-  template <typename T>
-  T rand() {
-    T r;
-    this->generate(kj::arrayPtr(&r, 1).asBytes());
-    return r;
-  }
-
-private:
-  kj::byte counter = 0;
-};
 
 struct MockLimitEnforcer final: public LimitEnforcer {
   kj::Own<void> enterJs(jsg::Lock& lock, IoContext& context) override { return {}; }
@@ -263,7 +244,7 @@ TestFixture::TestFixture(SetupParams&& params)
     io(params.waitScope == kj::none ? kj::Maybe(kj::setupAsyncIo()) : kj::Maybe<kj::AsyncIoContext>(kj::none)),
     timer(kj::heap<MockTimer>()),
     timerChannel(kj::heap<MockTimerChannel>()),
-    entropySource(kj::heap<MockEntropySource>()),
+    entropySource(getMockEntropySource()),
     threadContextHeaderBundle(headerTableBuilder),
     httpOverCapnpFactory(byteStreamFactory,
       capnp::HttpOverCapnpFactory::HeaderIdBundle(headerTableBuilder)),

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -128,12 +128,24 @@ wd_cc_library(
     deps = [":sentry", "@capnp-cpp//src/kj", "@capnp-cpp//src/capnp"],
 )
 
+wd_cc_library(
+    name = "entropy",
+    srcs = ["entropy.c++"],
+    hdrs = ["entropy.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+      "@ssl",
+      "@capnp-cpp//src/kj/compat:kj-http",
+    ]
+)
+
 exports_files(["autogate.h"])
 
 [kj_test(
     src = f,
     deps = [
         ":util",
+        ":entropy",
     ],
 ) for f in glob(
     ["*-test.c++"],

--- a/src/workerd/util/entropy-test.c++
+++ b/src/workerd/util/entropy-test.c++
@@ -1,0 +1,38 @@
+#include "entropy.h"
+#include <kj/test.h>
+
+namespace workerd {
+namespace {
+
+KJ_TEST("Mock entropy source (uses a counter)") {
+  kj::byte buffer[10];
+  auto mock = getMockEntropySource();
+  mock->generate(buffer);
+  for (int i = 0; i < 10; i++) {
+    KJ_ASSERT(buffer[i] == i);
+  }
+  mock->generate(buffer);
+  for (int i = 0; i < 10; i++) {
+    KJ_ASSERT(buffer[i] == i + 10);
+  }
+}
+
+KJ_TEST("Mock entropy source (uses a fixed char)") {
+  kj::byte buffer[10];
+  auto mock = getMockEntropySource('a');
+  mock->generate(buffer);
+  for (int i = 0; i < 10; i++) {
+    KJ_ASSERT(buffer[i] == 'a');
+  }
+}
+
+KJ_TEST("Fake entropy source (uses a fixed sequence)") {
+  kj::byte buffer[10];
+  getFakeEntropySource().generate(buffer);
+  for (int i = 0; i < 10; i++) {
+    KJ_ASSERT(buffer[i] == (i % 4) * 22 + 12);
+  }
+}
+
+}  // namespace
+}  // namespace workerd

--- a/src/workerd/util/entropy.c++
+++ b/src/workerd/util/entropy.c++
@@ -1,0 +1,69 @@
+#include "entropy.h"
+#include <openssl/rand.h>
+
+namespace workerd {
+
+namespace {
+
+class EntropySourceImpl final: public kj::EntropySource {
+public:
+  void generate(kj::ArrayPtr<kj::byte> buffer) override {
+    KJ_ASSERT(RAND_bytes(buffer.begin(), buffer.size()) == 1);
+  }
+};
+
+// TODO(cleanup): Do we actually need these variations? They are used in
+// various tests but the variations may not actually be useful.
+class MockEntropySource final: public kj::EntropySource {
+public:
+  void generate(kj::ArrayPtr<kj::byte> buffer) override {
+    for (kj::byte& b: buffer) {
+     b = counter++;
+    }
+  }
+private:
+  kj::byte counter = 0;
+};
+
+class FakeEntropySource final: public kj::EntropySource {
+public:
+  void generate(kj::ArrayPtr<kj::byte> buffer) override {
+    static constexpr kj::byte DUMMY[4] = {12, 34, 56, 78};
+
+    for (auto i: kj::indices(buffer)) {
+      buffer[i] = DUMMY[i % sizeof(DUMMY)];
+    }
+  }
+};
+
+class FixedCharEntropySource final: public kj::EntropySource {
+public:
+  FixedCharEntropySource(char filler): filler(filler) {}
+  void generate(kj::ArrayPtr<kj::byte> buffer) {
+    memset(buffer.begin(), filler, buffer.size());
+  }
+
+private:
+  char filler;
+};
+
+}  // namespace
+
+kj::EntropySource& getEntropySource() {
+  static EntropySourceImpl instance;
+  return instance;
+}
+
+kj::Own<kj::EntropySource> getMockEntropySource(kj::Maybe<char> filler) {
+  KJ_IF_SOME(f, filler) {
+    return kj::heap<FixedCharEntropySource>(f);
+  }
+  return kj::heap<MockEntropySource>();
+}
+
+kj::EntropySource& getFakeEntropySource() {
+  static FakeEntropySource instance;
+  return instance;
+}
+
+}  // namespace workerd

--- a/src/workerd/util/entropy.h
+++ b/src/workerd/util/entropy.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <kj/compat/http.h>
+
+namespace workerd {
+
+// Returns a singleton instance of the production entropy source.
+kj::EntropySource& getEntropySource();
+
+// Used for testing purposes only.
+kj::Own<kj::EntropySource> getMockEntropySource(
+    kj::Maybe<char> filler = kj::none);
+
+// Used for testing purposes only.
+kj::EntropySource& getFakeEntropySource();
+
+}  // namespace workerd


### PR DESCRIPTION
Reduction of code duplication across workerd and internal code bases. We have several duplicated implementations of kj::EntropySource.