### PR TITLE
Refactor JSRPC to prepare for capability-based RPC

### DIFF
--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -97,7 +97,7 @@ private:
   kj::Maybe<kj::Own<IoChannelFactory::ActorChannel>> actorChannel;
 };
 
-jsg::Ref<WorkerRpc> ColoLocalActorNamespace::get(kj::String actorId) {
+jsg::Ref<Fetcher> ColoLocalActorNamespace::get(kj::String actorId) {
   JSG_REQUIRE(actorId.size() > 0 && actorId.size() <= 2048, TypeError,
       "Actor ID length must be in the range [1, 2048].");
 
@@ -108,7 +108,7 @@ jsg::Ref<WorkerRpc> ColoLocalActorNamespace::get(kj::String actorId) {
   auto outgoingFactory = context.addObject(kj::mv(factory));
 
   bool isInHouse = true;
-  return jsg::alloc<WorkerRpc>(
+  return jsg::alloc<Fetcher>(
       kj::mv(outgoingFactory), Fetcher::RequiresHostAndProtocol::YES, isInHouse);
 }
 

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -28,7 +28,7 @@ public:
   ColoLocalActorNamespace(uint channel)
     : channel(channel) {}
 
-  jsg::Ref<WorkerRpc> get(kj::String actorId);
+  jsg::Ref<Fetcher> get(kj::String actorId);
 
   JSG_RESOURCE_TYPE(ColoLocalActorNamespace) {
     JSG_METHOD(get);
@@ -71,19 +71,19 @@ private:
 };
 
 // Stub object used to send messages to a remote durable object.
-class DurableObject final: public WorkerRpc {
+class DurableObject final: public Fetcher {
 
 public:
   DurableObject(jsg::Ref<DurableObjectId> id, IoOwn<OutgoingFactory> outgoingFactory,
                 RequiresHostAndProtocol requiresHost)
-    : WorkerRpc(kj::mv(outgoingFactory), requiresHost, true /* isInHouse */),
+    : Fetcher(kj::mv(outgoingFactory), requiresHost, true /* isInHouse */),
       id(kj::mv(id)) {}
 
   jsg::Ref<DurableObjectId> getId() { return id.addRef(); };
   jsg::Optional<kj::StringPtr> getName() { return id->getName(); }
 
   JSG_RESOURCE_TYPE(DurableObject) {
-    JSG_INHERIT(WorkerRpc);
+    JSG_INHERIT(Fetcher);
 
     JSG_READONLY_INSTANCE_PROPERTY(id, getId);
     JSG_READONLY_INSTANCE_PROPERTY(name, getName);

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1869,13 +1869,13 @@ jsg::Promise<jsg::Ref<Response>> Fetcher::fetch(
 }
 
 kj::Maybe<Fetcher::RpcFunction> Fetcher::getRpcMethod(jsg::Lock& js, kj::StringPtr name) {
-  // This is like WorkerRpc::getRpcMethod(), but we also initiate a whole new JS RPC session each
-  // time the method is called.
+  // This is like JsRpcCapability::getRpcMethod(), but we also initiate a whole new JS RPC session
+  // each time the method is called.
   return RpcFunction(JSG_VISITABLE_LAMBDA(
       (methodName = kj::str(name), self = JSG_THIS),
       (self),
       (jsg::Lock& js, const v8::FunctionCallbackInfo<v8::Value>& args) -> jsg::Promise<jsg::Value> {
-    // Same as WorkerRpc::getRpcMethod(), we want to prevent calling on the wrong `this`.
+    // Same as JsRpcCapability::getRpcMethod(), we want to prevent calling on the wrong `this`.
     JSG_REQUIRE(args.This() == KJ_ASSERT_NONNULL(self.tryGetHandle(js)), TypeError,
         "Illegal invocation");
 
@@ -1884,7 +1884,7 @@ kj::Maybe<Fetcher::RpcFunction> Fetcher::getRpcMethod(jsg::Lock& js, kj::StringP
     auto event = kj::heap<api::JsRpcSessionCustomEventImpl>(
         JsRpcSessionCustomEventImpl::WORKER_RPC_EVENT_TYPE);
 
-    auto result = WorkerRpc::sendWorkerRpc(js, event->getCap(), methodName, args);
+    auto result = JsRpcCapability::sendJsRpc(js, event->getCap(), methodName, args);
 
     // Arrange to cancel the CustomEvent if our I/O context is destroyed. But otherwise, we don't
     // actually care about the result of the event. If it throws, the membrane will already have

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -565,6 +565,10 @@ public:
       JSG_METHOD(scheduled);
     }
 
+    // TODO(soon): Deprecate get/put/delete convenience methods, remove via compat flag. These were
+    // never documented for service bindings. Extremely old KV bindings relied on them, before
+    // KV had its own separate API implementation -- anyone with such old KV bindings may have to
+    // recreate them when updating their compat flags for this removal.
     JSG_METHOD(get);
     JSG_METHOD(put);
     JSG_METHOD_NAMED(delete, delete_);

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -410,13 +410,15 @@ struct SocketOptions;
 struct SocketAddress;
 typedef kj::OneOf<SocketAddress, kj::String> AnySocketAddress;
 
-// A capability to send HTTP requests to some destination other than the public internet.
-// This is the type of `request.fetcher` (if it is not null).
+// Represents a client to a remote "web service".
 //
-// Actually, this interface could support more than just HTTP. This interface is really the
-// JavaScript wapper around `WorkerInterface`. It is the type used by worker-to-worker bindings.
-// As we add support for non-HTTP event types that can be invoked remotely, they should be added
-// here.
+// Originally, this meant an HTTP service, and `Fetcher` had just one method, `fetch()`, hence the
+// name. However, `Fetcher` is really the JavaScript type for a `WorkerInterface`, and is used in
+// particular to represent service bindings as well as Durable Object stubs. As such, as Workers
+// have grown new ways to talk to other Workers, `Fetcher` has added methods other than `fetch()`.
+//
+// TODO(cleanup): This probably doesn't belong in `http.h` anymore. And perhaps it should be
+//   renamed, though I haven't heard any great suggestions for what the name should be.
 class Fetcher: public jsg::Object {
 public:
   // Should we use a fake https base url if we lack a scheme+authority?
@@ -554,9 +556,19 @@ public:
 
   jsg::Promise<ScheduledResult> scheduled(jsg::Lock& js, jsg::Optional<ScheduledOptions> options);
 
+  using RpcFunction = jsg::Function<jsg::Promise<jsg::Value>(
+      const v8::FunctionCallbackInfo<v8::Value>& info)>;
+
+  kj::Maybe<RpcFunction> getRpcMethod(jsg::Lock& js, kj::StringPtr name);
+
   JSG_RESOURCE_TYPE(Fetcher, CompatibilityFlags::Reader flags) {
-    // WARNING: New JSG_METHODs on Fetcher should be gated via compatibility flag to prevent
-    // objects that use WorkerRpc from breaking. See `worker-rpc.h` for more detail.
+    // WARNING: New JSG_METHODs on Fetcher must be gated via compatibility flag to prevent
+    // confilcts with JS RPC methods (implemented via the wildcard property). Ideally, we do not
+    // add any new methods here, and instead rely on RPC for all future needs.
+    //
+    // Similarly, subclasses of `Fetcher` (notably, `DurableObject`) must follow the same rule,
+    // as any methods added to them will shadow RPC methods of the same name.
+
     JSG_METHOD(fetch);
     JSG_METHOD(connect);
 
@@ -572,6 +584,10 @@ public:
     JSG_METHOD(get);
     JSG_METHOD(put);
     JSG_METHOD_NAMED(delete, delete_);
+
+    if (flags.getWorkerdExperimental()) {
+      JSG_WILDCARD_PROPERTY(getRpcMethod);
+    }
 
     JSG_TS_OVERRIDE({
       fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -93,7 +93,7 @@ private:
 
 } // namespace
 
-jsg::Promise<jsg::Value> WorkerRpc::sendWorkerRpc(
+jsg::Promise<jsg::Value> JsRpcCapability::sendJsRpc(
     jsg::Lock& js,
     rpc::JsRpcTarget::Client client,
     kj::StringPtr name,
@@ -129,7 +129,8 @@ jsg::Promise<jsg::Value> WorkerRpc::sendWorkerRpc(
   });
 }
 
-kj::Maybe<WorkerRpc::RpcFunction> WorkerRpc::getRpcMethod(jsg::Lock& js, kj::StringPtr name) {
+kj::Maybe<JsRpcCapability::RpcFunction> JsRpcCapability::getRpcMethod(
+    jsg::Lock& js, kj::StringPtr name) {
   return RpcFunction(JSG_VISITABLE_LAMBDA(
       (methodName = kj::str(name), self = JSG_THIS),
       (self),
@@ -147,7 +148,7 @@ kj::Maybe<WorkerRpc::RpcFunction> WorkerRpc::getRpcMethod(jsg::Lock& js, kj::Str
     JSG_REQUIRE(args.This() == KJ_ASSERT_NONNULL(self.tryGetHandle(js)), TypeError,
         "Illegal invocation");
 
-    return sendWorkerRpc(js, *self->capnpClient, methodName, args);
+    return sendJsRpc(js, *self->capnpClient, methodName, args);
   }));
 }
 
@@ -333,7 +334,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
   // only makes a difference in the case that some sort of an error occurred. We don't strictly
   // have to revoke the capabilities as they are probably already broken anyway, but revoking them
   // helps to ensure that the underlying transport isn't "held open" waiting for the JS garbage
-  // collector to actually collect the WorkerRpc objects.
+  // collector to actually collect the JsRpcCapability objects.
   auto revokePaf = kj::newPromiseAndFulfiller<void>();
 
   KJ_DEFER({

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -77,12 +77,12 @@ public:
     JSG_INHERIT(Fetcher);
   }
 private:
-    // Event ID for WorkerRpc.
-    //
-    // Similar to WebSocket hibernation, we define this event ID in the internal codebase, but since
-    // we don't create WorkerRpc stubs from our internal code, we can't pass the event type in --
-    // so we hardcode it here.
-    static constexpr uint16_t WORKER_RPC_EVENT_TYPE = 9;
+  // Event ID for WorkerRpc.
+  //
+  // Similar to WebSocket hibernation, we define this event ID in the internal codebase, but since
+  // we don't create WorkerRpc stubs from our internal code, we can't pass the event type in --
+  // so we hardcode it here.
+  static constexpr uint16_t WORKER_RPC_EVENT_TYPE = 9;
 };
 
 // `jsRpcSession` returns a capability that provides the client a way to call remote methods

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -119,6 +119,8 @@ private:
   // limited return type.
   rpc::JsRpcTarget::Client clientCap;
   uint16_t typeId;
+
+  class ServerTopLevelMembrane;
 };
 
 #define EW_WORKER_RPC_ISOLATE_TYPES  \

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -48,7 +48,7 @@ public:
   //
   // Note: Unlike usual KJ convention, it is NOT necessary to make sure the `WorkerRpc` object
   // outlives the returned Promise. This is handled internally.
-  kj::Promise<capnp::Response<rpc::JsRpcTarget::CallResults>> sendWorkerRpc(
+  jsg::Promise<jsg::Value> sendWorkerRpc(
       jsg::Lock& js,
       kj::StringPtr name,
       const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -8,7 +8,7 @@
 // delivering the RPC event.
 //
 // Upon invoking a method, the stub (WorkerRpc) obtains a capability (JsRpcTarget) by dispatching a
-// `getJsRpcTarget` custom event. See worker-interface.capnp for the definition.
+// `jsRpcSession` custom event. See worker-interface.capnp for the definition.
 // The stub then uses the JsRpcTarget capability to send the serialized method name and arguments
 // over RPC to the remote Worker/DO.
 
@@ -85,11 +85,11 @@ private:
     static constexpr uint16_t WORKER_RPC_EVENT_TYPE = 9;
 };
 
-// `getJsRpcTarget` returns a capability that provides the client a way to call remote methods
+// `jsRpcSession` returns a capability that provides the client a way to call remote methods
 // over RPC. We drain the IncomingRequest after the capability is used to run the relevant JS.
-class GetJsRpcTargetCustomEventImpl final: public WorkerInterface::CustomEvent {
+class JsRpcSessionCustomEventImpl final: public WorkerInterface::CustomEvent {
 public:
-  GetJsRpcTargetCustomEventImpl(uint16_t typeId,
+  JsRpcSessionCustomEventImpl(uint16_t typeId,
       kj::PromiseFulfillerPair<rpc::JsRpcTarget::Client> paf =
           kj::newPromiseAndFulfiller<rpc::JsRpcTarget::Client>())
     : capFulfiller(kj::mv(paf.fulfiller)),

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -45,6 +45,9 @@ public:
   // Serializes the method name and arguments, calls customEvent to get the capability, and uses
   // the capability to send our request to the remote Worker. This resolves once the RPC promise
   // resolves.
+  //
+  // Note: Unlike usual KJ convention, it is NOT necessary to make sure the `WorkerRpc` object
+  // outlives the returned Promise. This is handled internally.
   kj::Promise<capnp::Response<rpc::JsRpcTarget::CallResults>> sendWorkerRpc(
       jsg::Lock& js,
       kj::StringPtr name,

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -230,13 +230,17 @@ interface EventDispatcher @0xf20697475ec1752d {
   # the success of the batch, including which messages should be considered acknowledged and which
   # should be retried.
 
-  getJsRpcTarget @9 () -> (server :JsRpcTarget);
-  # Starts a JS rpc "session" (for now, a session is one request/response).
-  # The returned JsRpcTarget capability allows us to invoke remote methods on the destination
-  # Worker/Durable Object.
+  jsRpcSession @9 () -> (topLevel :JsRpcTarget);
+  # Opens a JS rpc "session". The call does not return until the session is complete.
   #
-  # We use customEvent() to dispatch this event.
-  # In the future, we can add an argument to pass a capability to the server.
+  # `topLevel` is the top-level RPC target, on which exactly one method call can be made. This
+  # call must be made using pipelining since `jsRpcSession()` won't return until after the call
+  # completes.
+  #
+  # If, through the one top-level call, new capabilities are exchanged between the client and
+  # server, then `jsRpcSession()` won't return until all those capabilities have been dropped.
+  #
+  # In C++, we use `WorkerInterface::customEvent()` to dispatch this event.
 
   obsolete5 @5();
   obsolete6 @6();


### PR DESCRIPTION
This is a series of small refactorings that prepares for the future where RPC params or return values can contain new RPC objects. For this to work, we need to disentangle the sending of one RPC call from the creation of RPC sessions, since one session may encompass many calls in both directions.