### PR TITLE
[CI] Reduce Windows debug binary size

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -207,8 +207,13 @@ build:windows_no_dbg -c opt
 build:windows_no_dbg --copt='-O0' --host_copt='-O0'
 build:windows_no_dbg --copt='/Od' --host_copt='/Od'
 build:windows_no_dbg --copt='/INCREMENTAL:NO' --host_copt='/INCREMENTAL:NO'
-build:windows_no_dbg --noincompatible_use_host_features
 build:windows_no_dbg --features=-smaller_binary --features=-disable_assertions_feature
+
+# Mitigate the large size impact of Windows debug binaries somewhat by applying string merging and
+# linker garbage collection.
+build:windows_dbg --config=debug
+build:windows_dbg --copt='/Gy' --copt='/Gw' --copt='/GF'
+build:windows_dbg --linkopt='/OPT:REF'
 
 build:windows --cxxopt='/std:c++20' --host_cxxopt='/std:c++20'
 build:windows --cxxopt='/await' --host_cxxopt='/await'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,14 @@ jobs:
           # Windows has a custom non-debug bazel config.
           - os:     { name : windows, image : windows-2022 }
             config: { suffix: '', bazel-args: --config=windows_no_dbg }
+          - os:     { name : windows, image : windows-2022 }
+            config: { suffix: -debug, bazel-args: --config=windows_dbg }
         exclude:
           # Skip the matrix generated Windows non-debug config to use the one added above.
           - os:     { name : windows, image : windows-2022 }
             config: { suffix: '', bazel-args: '' }
+          - os:     { name : windows, image : windows-2022 }
+            config: { suffix: -debug, bazel-args: --config=debug }
       fail-fast: false
     runs-on: ${{ matrix.os.image }}
     name: test (${{ matrix.os.name }}${{ matrix.config.suffix }})


### PR DESCRIPTION
This resolves CI failures due to running out of disk space, at least for
the near term. Also drops a flag modifying features for windows_no_dbg,
disabling optimizations when building for the host configuration is not
necessary.

I picked common MSVC flags that are safe to use with debug info here. When I last measured this, the bazel output + cache takes up 60GB with this on a fully cached Windows-debug build whereas the build previously ran out of space upon reaching 70GB. Based on those numbers this is just a short-term fix unfortunately, a larger improvement would be possible by changing cache behavior (70GB is only reached when binaries are duplicated between disk cache and regular bazel output) or by patching bazel to make opting out of PDB generation possible.