### PR TITLE
Clean up builtin-wasm-modules autogate (used for Python)

### DIFF
--- a/samples/pyodide-fastapi/config.capnp
+++ b/samples/pyodide-fastapi/config.capnp
@@ -13,11 +13,6 @@ const config :Workerd.Config = (
       service = "main"
     ),
   ],
-  autogates = [
-    # Pyodide is included as a builtin wasm module so it requires the
-    # corresponding autogate flag.
-    "workerd-autogate-builtin-wasm-modules",
-  ]
 );
 
 const mainWorker :Workerd.Worker = (

--- a/samples/pyodide-langchain/config.capnp
+++ b/samples/pyodide-langchain/config.capnp
@@ -13,11 +13,6 @@ const config :Workerd.Config = (
       service = "main"
     ),
   ],
-  autogates = [
-    # Pyodide is included as a builtin wasm module so it requires the
-    # corresponding autogate flag.
-    "workerd-autogate-builtin-wasm-modules",
-  ]
 );
 
 const mainWorker :Workerd.Worker = (

--- a/samples/pyodide/config.capnp
+++ b/samples/pyodide/config.capnp
@@ -13,11 +13,6 @@ const config :Workerd.Config = (
       service = "main"
     ),
   ],
-  autogates = [
-    # Pyodide is included as a builtin wasm module so it requires the
-    # corresponding autogate flag.
-    "workerd-autogate-builtin-wasm-modules",
-  ]
 );
 
 const mainWorker :Workerd.Worker = (

--- a/src/pyodide/README.md
+++ b/src/pyodide/README.md
@@ -6,8 +6,7 @@ files from the Pyodide release as public to workerd) and
 `workerd/api/pyodide/pyodide.h` which adds the bundle to the module registry if
 the appropriate flags are set.
 
-It requires the `workerd-autogate-builtin-wasm-modules` autogate flag and the
-`experimental` compatibility flag to enable.
+It requires the `experimental` compatibility flag to enable.
 
 See `samples/pyodide/` for an example using this in its current state.
 

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -34,8 +34,7 @@ public:
 #define EW_PYODIDE_ISOLATE_TYPES api::pyodide::PackagesTarReader
 
 template <class Registry> void registerPyodideModules(Registry& registry, auto featureFlags) {
-  if (featureFlags.getWorkerdExperimental() &&
-      util::Autogate::isEnabled(util::AutogateKey::BUILTIN_WASM_MODULES)) {
+  if (featureFlags.getWorkerdExperimental()) {
     registry.addBuiltinBundle(PYODIDE_BUNDLE, kj::none);
   }
   registry.template addBuiltinModule<PackagesTarReader>("pyodide-internal:packages_tar_reader",

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -443,11 +443,6 @@ public:
       auto filter = maybeFilter.orDefault(type);
       if (type == filter) {
         if (module.which() != Module::SRC) {
-          if (!util::Autogate::isEnabled(util::AutogateKey::BUILTIN_WASM_MODULES)) {
-            LOG_ERROR_ONCE(
-                "Builtin wasm module or data module used without passing builtin-wasm-modules autogate flag");
-            continue;
-          }
           using Key = typename Entry::Key;
           auto specifier = module.getName();
           auto path = kj::Path::parse(specifier);

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -632,8 +632,6 @@ KJ_TEST("Server: serve basic modular Worker") {
       )
     ]
   ))"_kj));
-  // TODO(later): init these properly and remove this
-  KJ_EXPECT_LOG(ERROR, "Autogates not initialised, check for builtin-wasm-modules will have no effect");
   test.start();
   auto conn = test.connect("test-addr");
   conn.httpGet200("/", "Hello: http://foo/");

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -13,8 +13,6 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
   switch (key) {
     case AutogateKey::TEST_WORKERD:
       return "test-workerd"_kj;
-    case AutogateKey::BUILTIN_WASM_MODULES:
-      return "builtin-wasm-modules"_kj;
     case AutogateKey::SOCKETS_AWAIT_PROXY_BEFORE_CLOSE:
       return "sockets-await-proxy-before-close"_kj;
     case AutogateKey::NumOfKeys:

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -13,9 +13,6 @@ namespace workerd::util {
 // Workerd-specific list of autogate keys (can also be used in internal repo).
 enum class AutogateKey {
   TEST_WORKERD,
-  // Allow builtin modules to be wasm modules. Used for Python project.
-  // Gates code in jsg/modules.h
-  BUILTIN_WASM_MODULES,
   // Enable new behaviour of Socket::close (specifically waiting for proxy result before closing).
   SOCKETS_AWAIT_PROXY_BEFORE_CLOSE,
   NumOfKeys // Reserved for iteration.


### PR DESCRIPTION
This is no longer required upstream.