### PR TITLE
Limit alarm handler walltime to 15minutes

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -303,6 +303,7 @@ public:
   // Received runAlarm (called from C++, not JS).
   kj::Promise<WorkerInterface::AlarmResult> runAlarm(
       kj::Date scheduledTime,
+      kj::Duration timeout,
       Worker::Lock& lock, kj::Maybe<ExportedHandler&> exportedHandler);
 
   // Received test() (called from C++, not JS). See WorkerInterface::test(). This version returns

--- a/src/workerd/io/limit-enforcer.h
+++ b/src/workerd/io/limit-enforcer.h
@@ -120,6 +120,9 @@ public:
   // Like limitDrain() but applies a time limit to scheduled event processing.
   virtual kj::Promise<void> limitScheduled() = 0;
 
+  // Like limitDrain() and limitScheduled() but applies a time limit to alarm event processing.
+  virtual kj::Duration getAlarmLimit() = 0;
+
   // Gets a byte size limit to apply to operations that will buffer a possibly large amount of
   // data in C++ memory, such as reading an entire HTTP response into an `ArrayBuffer`.
   virtual size_t getBufferingLimit() = 0;

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2091,6 +2091,7 @@ private:
   void newAnalyticsEngineRequest() override {}
   kj::Promise<void> limitDrain() override { return kj::NEVER_DONE; }
   kj::Promise<void> limitScheduled() override { return kj::NEVER_DONE; }
+  kj::Duration getAlarmLimit() override { return 0 * kj::MILLISECONDS; }
   size_t getBufferingLimit() override { return kj::maxValue; }
   kj::Maybe<EventOutcome> getLimitsExceeded() override { return kj::none; }
   kj::Promise<void> onLimitsExceeded() override { return kj::NEVER_DONE; }

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -130,6 +130,7 @@ struct MockLimitEnforcer final: public LimitEnforcer {
   void newAnalyticsEngineRequest() override {}
   kj::Promise<void> limitDrain() override { return kj::NEVER_DONE; }
   kj::Promise<void> limitScheduled() override { return kj::NEVER_DONE; }
+  kj::Duration getAlarmLimit() override { return 0 * kj::MILLISECONDS; }
   size_t getBufferingLimit() override { return kj::maxValue; }
   kj::Maybe<EventOutcome> getLimitsExceeded() override { return kj::none; }
   kj::Promise<void> onLimitsExceeded() override { return kj::NEVER_DONE; }


### PR DESCRIPTION
This PR adds a wall time timeout for alarm handlers. 

When the timeout for an alarm it hit, we cancel deferred alarm deletion and abort the currently running handler. 

The alarm timeouts are counted against limits, so they get deleted once the maximum retry limit is reached.