### PR TITLE
Revert "[bazel] Do not compile wd_cc_library by default"

### DIFF
--- a/build/wd_cc_library.bzl
+++ b/build/wd_cc_library.bzl
@@ -1,10 +1,9 @@
 """wd_cc_library definition"""
 
-def wd_cc_library(strip_include_prefix = "/src", tags = ["off-by-default"], **kwargs):
+def wd_cc_library(strip_include_prefix = "/src", **kwargs):
     """Wrapper for cc_library that sets common attributes
     """
     native.cc_library(
         strip_include_prefix = strip_include_prefix,
-        tags = tags,
         **kwargs
     )

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -10,7 +10,7 @@ wd_cc_library(
     deps = [
         "@capnp-cpp//src/kj"
     ] + select({
-        "@platforms//os:windows": [],
+        "@platforms//os:windows": ["@workerd-v8//:v8"],
         "//conditions:default": ["@perfetto//:libperfetto_client_experimental"],
     }),
     defines = select({


### PR DESCRIPTION
this is very incovenient. `bazel build` commands pass without doing anything, while everything is broken.

Reverts cloudflare/workerd#1512