### PR TITLE
Remove `#pragma once` from memory.c++

### DIFF
--- a/src/workerd/jsg/memory.c++
+++ b/src/workerd/jsg/memory.c++
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "memory.h"
 #include <kj/one-of.h>
 


### PR DESCRIPTION
This fixes a warning from clang:

> INFO: From Compiling src/workerd/jsg/memory.c++:
> src/workerd/jsg/memory.c++:1:9: warning: #pragma once in main file [-Wpragma-once-outside-header]
> #pragma once
>         ^
> 1 warning generated.