### PR TITLE
Start migrating to kj::Rc/kj::rc

### DIFF
--- a/src/workerd/api/streams/compression.c++
+++ b/src/workerd/api/streams/compression.c++
@@ -392,15 +392,15 @@ jsg::Ref<CompressionStream> CompressionStream::constructor(jsg::Lock& js, kj::St
                "The compression format must be either 'deflate', 'deflate-raw' or 'gzip'.");
 
   auto readableSide =
-      kj::refcounted<CompressionStreamImpl<Context::Mode::COMPRESS>>(kj::mv(format),
-                                                                     Context::ContextFlags::NONE);
-  auto writableSide = kj::addRef(*readableSide);
+      kj::rc<CompressionStreamImpl<Context::Mode::COMPRESS>>(kj::mv(format),
+                                                             Context::ContextFlags::NONE);
+  auto writableSide = readableSide.addRef();
 
   auto& ioContext = IoContext::current();
 
   return jsg::alloc<CompressionStream>(
-    jsg::alloc<ReadableStream>(ioContext, kj::mv(readableSide)),
-    jsg::alloc<WritableStream>(ioContext, kj::mv(writableSide)));
+    jsg::alloc<ReadableStream>(ioContext, readableSide.toOwn()),
+    jsg::alloc<WritableStream>(ioContext, writableSide.toOwn()));
 }
 
 jsg::Ref<DecompressionStream> DecompressionStream::constructor(jsg::Lock& js, kj::String format) {
@@ -408,18 +408,18 @@ jsg::Ref<DecompressionStream> DecompressionStream::constructor(jsg::Lock& js, kj
                "The compression format must be either 'deflate', 'deflate-raw' or 'gzip'.");
 
   auto readableSide =
-      kj::refcounted<CompressionStreamImpl<Context::Mode::DECOMPRESS>>(
+      kj::rc<CompressionStreamImpl<Context::Mode::DECOMPRESS>>(
           kj::mv(format),
           FeatureFlags::get(js).getStrictCompression() ?
               Context::ContextFlags::STRICT :
               Context::ContextFlags::NONE);
-  auto writableSide = kj::addRef(*readableSide);
+  auto writableSide = readableSide.addRef();
 
   auto& ioContext = IoContext::current();
 
   return jsg::alloc<DecompressionStream>(
-    jsg::alloc<ReadableStream>(ioContext, kj::mv(readableSide)),
-    jsg::alloc<WritableStream>(ioContext, kj::mv(writableSide)));
+    jsg::alloc<ReadableStream>(ioContext, readableSide.toOwn()),
+    jsg::alloc<WritableStream>(ioContext, writableSide.toOwn()));
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -258,7 +258,7 @@ public:
     }
   };
 
-  WritableImpl(kj::Own<WeakRef<WritableStreamJsController>> owner);
+  WritableImpl(kj::Rc<WeakRef<WritableStreamJsController>> owner);
 
   jsg::Promise<void> abort(jsg::Lock& js,
                             jsg::Ref<Self> self,
@@ -347,7 +347,7 @@ private:
 
   struct Writable {};
 
-  kj::Own<WeakRef<WritableStreamJsController>> owner;
+  kj::Rc<WeakRef<WritableStreamJsController>> owner;
   jsg::Ref<AbortSignal> signal;
   kj::OneOf<StreamStates::Closed,
             StreamStates::Errored,
@@ -416,12 +416,12 @@ public:
     });
   }
 
-  kj::Own<WeakRef<ReadableStreamDefaultController>> getWeakRef();
+  kj::Rc<WeakRef<ReadableStreamDefaultController>> getWeakRef();
 
 private:
   kj::Maybe<IoContext&> ioContext;
   ReadableImpl impl;
-  kj::Own<WeakRef<ReadableStreamDefaultController>> weakRef;
+  kj::Rc<WeakRef<ReadableStreamDefaultController>> weakRef;
 
   void visitForGc(jsg::GcVisitor& visitor);
 };
@@ -555,7 +555,7 @@ class WritableStreamDefaultController: public jsg::Object {
 public:
   using WritableImpl = WritableImpl<WritableStreamDefaultController>;
 
-  explicit WritableStreamDefaultController(kj::Own<WeakRef<WritableStreamJsController>> owner);
+  explicit WritableStreamDefaultController(kj::Rc<WeakRef<WritableStreamJsController>> owner);
 
   jsg::Promise<void> abort(jsg::Lock& js, v8::Local<v8::Value> reason);
 
@@ -680,8 +680,8 @@ private:
   kj::Maybe<ReadableStreamDefaultController&> tryGetReadableController();
   kj::Maybe<WritableStreamJsController&> tryGetWritableController();
 
-  kj::Maybe<kj::Own<WeakRef<ReadableStreamDefaultController>>> maybeReadableController;
-  kj::Maybe<kj::Own<WeakRef<WritableStreamJsController>>> maybeWritableController;
+  kj::Maybe<kj::Rc<WeakRef<ReadableStreamDefaultController>>> maybeReadableController;
+  kj::Maybe<kj::Rc<WeakRef<WritableStreamJsController>>> maybeWritableController;
   Algorithms algorithms;
   bool backpressure = false;
   kj::Maybe<jsg::PromiseResolverPair<void>> maybeBackpressureChange;

--- a/src/workerd/api/streams/transform.c++
+++ b/src/workerd/api/streams/transform.c++
@@ -137,8 +137,8 @@ jsg::Ref<TransformStream> TransformStream::constructor(
 jsg::Ref<IdentityTransformStream> IdentityTransformStream::constructor(
     jsg::Lock& js,
     jsg::Optional<IdentityTransformStream::QueuingStrategy> maybeQueuingStrategy) {
-  auto readableSide = kj::refcounted<IdentityTransformStreamImpl>();
-  auto writableSide = kj::addRef(*readableSide);
+  auto readableSide = kj::rc<IdentityTransformStreamImpl>();
+  auto writableSide = readableSide.addRef();
 
   auto& ioContext = IoContext::current();
 
@@ -148,8 +148,8 @@ jsg::Ref<IdentityTransformStream> IdentityTransformStream::constructor(
   }
 
   return jsg::alloc<IdentityTransformStream>(
-      jsg::alloc<ReadableStream>(ioContext, kj::mv(readableSide)),
-      jsg::alloc<WritableStream>(ioContext, kj::mv(writableSide), maybeHighWaterMark));
+      jsg::alloc<ReadableStream>(ioContext, readableSide.toOwn()),
+      jsg::alloc<WritableStream>(ioContext, writableSide.toOwn(), maybeHighWaterMark));
 }
 
 jsg::Ref<FixedLengthStream> FixedLengthStream::constructor(
@@ -161,8 +161,8 @@ jsg::Ref<FixedLengthStream> FixedLengthStream::constructor(
   JSG_REQUIRE(expectedLength <= MAX_SAFE_INTEGER, TypeError,
       "FixedLengthStream requires an integer expected length less than 2^53.");
 
-  auto readableSide = kj::refcounted<IdentityTransformStreamImpl>(uint64_t(expectedLength));
-  auto writableSide = kj::addRef(*readableSide);
+  auto readableSide = kj::rc<IdentityTransformStreamImpl>(uint64_t(expectedLength));
+  auto writableSide = readableSide.addRef();
 
   auto& ioContext = IoContext::current();
 
@@ -175,8 +175,8 @@ jsg::Ref<FixedLengthStream> FixedLengthStream::constructor(
   }
 
   return jsg::alloc<FixedLengthStream>(
-      jsg::alloc<ReadableStream>(ioContext, kj::mv(readableSide)),
-      jsg::alloc<WritableStream>(ioContext, kj::mv(writableSide), maybeHighWaterMark));
+      jsg::alloc<ReadableStream>(ioContext, readableSide.toOwn()),
+      jsg::alloc<WritableStream>(ioContext, writableSide.toOwn(), maybeHighWaterMark));
 }
 
 }  // namespace workerd::api

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -452,6 +452,7 @@ public:
   // 2. Can be safely destroyed from any thread.
   // 3. Invalidates itself when the request ends (such that dereferencing throws).
   template <typename T> IoOwn<T> addObject(kj::Own<T> obj);
+  template <typename T> IoOwn<T> addObject(kj::Rc<T> obj);
 
   // Wraps a reference in a wrapper which:
   // 1. Will throw an exception if dereferenced while the IoContext is not current for the
@@ -1154,6 +1155,11 @@ template <typename T>
 inline IoOwn<T> IoContext::addObject(kj::Own<T> obj) {
   requireCurrent();
   return deleteQueue->addObject(kj::mv(obj), ownedObjects);
+}
+
+template <typename T>
+inline IoOwn<T> IoContext::addObject(kj::Rc<T> obj) {
+  return addObject(obj.toOwn());
 }
 
 template <typename T>


### PR DESCRIPTION
The new kj::Rc<T> has landed in capnp/kj... it is intended to clarify usage of refcounted types. This change is a first step in migrating away from kj::Own<T>/kj::refcounted, largely to start helping to identify if there are any issues to address before a larger-scale migration.

Question: For `IoOwn<T>` ... should we continue to just have the single `IoOwn<T>` or should we consider introducing an `IoRc<T>` to mirror `kj::Rc<T>`?