### PR TITLE
Use `IncomingRequestCfProperties` in Pages `EventContext`

### DIFF
--- a/types/defines/pages.d.ts
+++ b/types/defines/pages.d.ts
@@ -1,7 +1,7 @@
 type Params<P extends string = any> = Record<P, string | string[]>;
 
 type EventContext<Env, P extends string, Data> = {
-  request: Request;
+  request: Request<unknown, IncomingRequestCfProperties<unknown>>;
   functionPath: string;
   waitUntil: (promise: Promise<any>) => void;
   passThroughOnException: () => void;
@@ -18,7 +18,7 @@ type PagesFunction<
 > = (context: EventContext<Env, Params, Data>) => Response | Promise<Response>;
 
 type EventPluginContext<Env, P extends string, Data, PluginArgs> = {
-  request: Request;
+  request: Request<unknown, IncomingRequestCfProperties<unknown>>;
   functionPath: string;
   waitUntil: (promise: Promise<any>) => void;
   passThroughOnException: () => void;


### PR DESCRIPTION
Whilst I wasn't able to reproduce the error from #1327, it did surface that the incoming request doesn't have the correct `cf` type. Currently, it's implicitly typed with `CfProperties` which includes both incoming and outgoing types, whereas we know this is an incoming request, so only `IncomingRequestCfProperties` are valid. This PR fixes that.

Closes #1327