### PR TITLE
[CI] Update action versions, fix deprecation warnings and silence progress messages

### DIFF
--- a/.github/workflows/fixup.yml
+++ b/.github/workflows/fixup.yml
@@ -7,7 +7,7 @@ jobs:
   block-fixup:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Block Fixup Commit Merge
       uses: 13rac1/block-fixup-merge-action@v2.0.0
 

--- a/.github/workflows/npm-types.yml
+++ b/.github/workflows/npm-types.yml
@@ -21,7 +21,7 @@ jobs:
       release_version: ${{ steps.echo.outputs.release_version }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: echo
         run: |
           echo "date=$(cat src/workerd/io/supported-compatibility-date.txt)" >> $GITHUB_OUTPUT;
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-22.04
     needs: version
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/bazel-disk-cache
           # The types cache is significantly smaller than the whole cache (350MB as of writing), so

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -21,7 +21,7 @@ jobs:
       release_version: ${{ steps.echo.outputs.release_version }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: echo
         run: |
           echo "date=$(cat src/workerd/io/supported-compatibility-date.txt)" >> $GITHUB_OUTPUT;
@@ -37,12 +37,12 @@ jobs:
         arch: [darwin-64, darwin-arm64, linux-64, linux-arm64, windows-64]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Use Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
@@ -51,7 +51,7 @@ jobs:
         env:
           WORKERD_VERSION: ${{ needs.version.outputs.version }}
           LATEST_COMPATIBILITY_DATE: ${{ needs.version.outputs.date }}
-      - uses: robinraju/release-downloader@v1.6
+      - uses: robinraju/release-downloader@v1.9
         with:
           tag: v${{ needs.version.outputs.release_version }}
           fileName: workerd-${{ matrix.arch }}.gz
@@ -78,12 +78,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Use Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     # the build job uses 20.04 for libc compatibility.
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: echo
         run: |
           echo "::set-output name=version::1.$(cat src/workerd/io/supported-compatibility-date.txt | tr -d '-').0"
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: mukunku/tag-exists-action@v1.3.0
+      - uses: mukunku/tag-exists-action@v1.6.0
         id: check_tag
         with:
           tag: v${{ needs.version.outputs.version }}
@@ -42,7 +42,7 @@ jobs:
     if: ${{ needs.check-tag.outputs.exists != 'true' }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: git tag v${{ needs.version.outputs.version }} && git push origin v${{ needs.version.outputs.version }}
@@ -67,10 +67,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: build (${{ matrix.os-name }})
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Cache
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/bazel-disk-cache
           # Use a different cache key than for tests here, otherwise the release cache could end up
@@ -114,7 +116,7 @@ jobs:
           # generated for the release configuration. Regular symbols are still included.
           strip -S bazel-bin/src/workerd/server/workerd
       - name: Upload binary
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: ${{ runner.os }}-${{ runner.arch }}-binary
           path: bazel-bin/src/workerd/server/workerd${{ runner.os == 'Windows' && '.exe' || '' }}
@@ -168,16 +170,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout workers-sdk
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cloudflare/workers-sdk
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: 8.8.0
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
           cache: "pnpm"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,10 +40,12 @@ jobs:
     runs-on: ${{ matrix.os.image }}
     name: test (${{ matrix.os.name }}${{ matrix.config.suffix }})
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Cache
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/bazel-disk-cache
           key: bazel-disk-cache-${{ matrix.os.name }}-${{ runner.arch }}${{ matrix.config.suffix }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}


### PR DESCRIPTION
- Node 16 support for actions will be dropped in the future. This updates most packages where deprecation warnings for node or other features apply.
- Use `show-progress: false` as introduced in checkout@v4 to not print the current progress when fetching a repository during build steps. This makes logs slightly smaller and more readable.

There are still some actions after this that use node 16 – some have not been updated to node 20 yet, with actions/download-artifact and actions/upload-artifact we'd need to check carefully if the breaking changes of v5 affect us, and actions/upload-release-asset (using node 12!) is EOL and needs to be replaced. This is only intended as a first patch to get the ball rolling on this.
We could use `show-progress: false` every time we use checkout, but outside of the main build options there's usually no need to look at the full logs.