### PR TITLE
Fixup gc tracing in EventTarget

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -658,7 +658,7 @@ void EventTarget::visitForGc(jsg::GcVisitor& visitor) {
           visitor.visit(js);
         }
         KJ_CASE_ONEOF(native, EventHandler::NativeHandlerRef) {
-          visitor.visit(native.handler);
+          // This is just a ref to the native handler, no need to visit.
         }
       }
     }


### PR DESCRIPTION
No need to visit the native handler ref here.