### PR TITLE
Rough sketch of jsg::TracedRef

### DIFF
--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -216,6 +216,9 @@ HeapTracer::HeapTracer(v8::Isolate* isolate): isolate(isolate) {
 
   isolate->AddGCEpilogueCallback(
       [](v8::Isolate* isolate, v8::GCType type, v8::GCCallbackFlags flags, void* data) {
+#ifdef KJ_DEBUG
+    TracedRefRegistry::current().checkTraceObserversAfterGc();
+#endif
     auto& self = *reinterpret_cast<HeapTracer*>(data);
     for (Wrappable* wrappable: self.detachLater) {
       wrappable->detachWrapper(true);


### PR DESCRIPTION
This is an extremely rough early sketch of a jsg::TracedRef<T> alternative to jsg::Ref<T> that includes debug time post-gc checks to see if the reference was actually traced. This is based on a quick conversation with Kenton about finding better ways of tracking down refs that should be traced but aren't. This is still very early just to start playing with the idea.

There are a few questions outstanding still...

1. Does this really need to be a separate type from Ref<T>? These essentially need to act like Ref<T> in the common case but it would also be nice to simplify the complexity around the sometimes strong, sometimes weak Ref<T> semantics.
2. Should these always be considered weak? Not sure it actually can be in case the parent has no strong refs.
3. This currently just uses a static thread local registry to track the trace state for warnings but is that ok? Can these end up being traced across multiple threads?

This PR is just intended to give us something to kick around.