### PR TITLE
Removes old Socket::close implementation.

### DIFF
--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -84,6 +84,10 @@ public:
   }
 
   // Closes the socket connection.
+  //
+  // The closure is only performed after the socket connection is properly
+  // established through any configured proxy. This method also flushes the writable stream prior to
+  // closing.
   jsg::Promise<void> close(jsg::Lock& js);
 
   // Flushes write buffers then performs a TLS handshake on the current Socket connection.

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -13,8 +13,6 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
   switch (key) {
     case AutogateKey::TEST_WORKERD:
       return "test-workerd"_kj;
-    case AutogateKey::SOCKETS_AWAIT_PROXY_BEFORE_CLOSE:
-      return "sockets-await-proxy-before-close"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -13,8 +13,6 @@ namespace workerd::util {
 // Workerd-specific list of autogate keys (can also be used in internal repo).
 enum class AutogateKey {
   TEST_WORKERD,
-  // Enable new behaviour of Socket::close (specifically waiting for proxy result before closing).
-  SOCKETS_AWAIT_PROXY_BEFORE_CLOSE,
   NumOfKeys // Reserved for iteration.
 };
 


### PR DESCRIPTION
This has been rolled out via the autogate to RoW, so is safe to remove.

Tested upstream.