### PR TITLE
Added more data to help debug timeout id collisions

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -592,7 +592,8 @@ auto IoContext::TimeoutManagerImpl::addState(
     auto& state = it->second;
     auto delay = state.params.msDelay;
     auto repeat = state.params.repeat;
-    KJ_FAIL_ASSERT("Saw a timeout id collision", getTimeoutCount(), id.toNumber(), delay, repeat);
+    KJ_FAIL_ASSERT("Saw a timeout id collision", getTimeoutCount(), timeoutsStarted, id.toNumber(),
+        delay, repeat);
   }
 
   return { id, it };


### PR DESCRIPTION
The error now reports the total number of timeouts started instead of just the number of outstanding timeouts.