### PR TITLE
Revert "Revert "Add implementations for getPreferredExtensions""

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,10 +39,10 @@ apple_support_dependencies()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "3b07a3b3f685ea5a8b0f4e27c336e26035c6efe7e23ef787a870fb978a633c24",
-    strip_prefix = "capnproto-capnproto-20be408/c++",
+    sha256 = "bed3c01caad985c91b58c8123cedfe46c4135d1698303d89c89bc49d3deb3697",
+    strip_prefix = "capnproto-capnproto-6480280/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/20be408666207623fbfd5002628455c41d15e3b9"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/64802802df1d7780625eeb07b71d249fe49fb68d"],
 )
 
 http_archive(

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1306,7 +1306,7 @@ kj::Promise<DeferredProxy<void>> Response::send(
       KJ_IF_SOME(config, ws->getPreferredExtensions(kj::WebSocket::ExtensionsContext::RESPONSE)) {
         // We try to get extensions for use in a response (i.e. for a server side websocket).
         // This allows us to `optimizedPumpTo()` `webSocket`.
-        outHeaders.set(kj::HttpHeaderId::SEC_WEBSOCKET_EXTENSIONS, config);
+        outHeaders.set(kj::HttpHeaderId::SEC_WEBSOCKET_EXTENSIONS, kj::mv(config));
       } else {
         // `webSocket` is not a WebSocketImpl, we want to support whatever valid config the client
         // requested, so we'll just use the client's requested headers.

--- a/src/workerd/io/worker-interface.c++
+++ b/src/workerd/io/worker-interface.c++
@@ -160,6 +160,10 @@ public:
     return wrap<void>(other.pumpTo(getInner()));
   }
 
+  kj::Maybe<kj::String> getPreferredExtensions(ExtensionsContext ctx) override {
+    return getInner().getPreferredExtensions(ctx);
+  };
+
   uint64_t sentByteCount() override { return 0; }
   uint64_t receivedByteCount() override { return 0; }
 

--- a/src/workerd/util/abortable.h
+++ b/src/workerd/util/abortable.h
@@ -134,6 +134,11 @@ public:
     return impl.getInner().receivedByteCount();
   }
 
+  kj::Maybe<kj::String> getPreferredExtensions(ExtensionsContext ctx) override {
+    return impl.getInner().getPreferredExtensions(ctx);
+  };
+
+
 private:
   AbortableImpl<kj::WebSocket> impl;
 };


### PR DESCRIPTION
This reverts commit 25172d0c0a8415c284cdae0933b11a70f9813d58, and includes a bugfix in a caller of `getPreferredExtensions()`.

Capnp PR: https://github.com/capnproto/capnproto/pull/1943