### PR TITLE
D1: Adding `.raw({columnNames})` types and tests for `.run()`

### DIFF
--- a/types/defines/d1.d.ts
+++ b/types/defines/d1.d.ts
@@ -36,5 +36,6 @@ declare abstract class D1PreparedStatement {
   first<T = Record<string, unknown>>(): Promise<T | null>;
   run(): Promise<D1Response>;
   all<T = Record<string, unknown>>(): Promise<D1Result<T>>;
-  raw<T = unknown[]>(): Promise<T[]>;
+  raw<T = unknown[]>(options: {columnNames: true}): Promise<[string[], ...T[]]>;
+  raw<T = unknown[]>(options?: {columnNames?: false}): Promise<T[]>;
 }

--- a/types/test/types/d1.ts
+++ b/types/test/types/d1.ts
@@ -10,6 +10,16 @@ export const handler: ExportedHandler<{ DB: D1Database }> = {
   async fetch(request, env) {
     const stmt = env.DB.prepare(`SELECT * FROM tbl WHERE id = ?`);
 
+    // RUN
+    {
+      const response = await stmt.bind(1).run();
+      expectType<{
+        meta: Record<string, unknown>;
+        success: boolean;
+        results?: never;
+      }>(response);
+    }
+
     // ALL
     {
       const { results } = await stmt.bind(1).all();
@@ -26,8 +36,29 @@ export const handler: ExportedHandler<{ DB: D1Database }> = {
       expectType<unknown[][]>(results);
     }
     {
-      const results = await stmt.bind(1).raw<[string, string]>();
-      expectType<[string, string][]>(results);
+      const results = await stmt.bind(1).raw<[string, number, boolean]>();
+      expectType<[string, number, boolean][]>(results);
+    }
+    {
+      const results = await stmt.bind(1).raw<[string, number, boolean]>({});
+      expectType<[string, number, boolean][]>(results);
+    }
+    {
+      const results = await stmt
+        .bind(1)
+        .raw<[string, number, boolean]>({ columnNames: false });
+      expectType<[string, number, boolean][]>(results);
+    }
+    {
+      const results = await stmt.bind(1).raw({ columnNames: true });
+      expectType<[string[], ...unknown[]]>(results);
+    }
+    {
+      const [columns, ...rows] = await stmt
+        .bind(1)
+        .raw<[string, number, boolean]>({ columnNames: true });
+      expectType<string[]>(columns);
+      expectType<[string, number, boolean][]>(rows);
     }
 
     // FIRST


### PR DESCRIPTION
Now https://github.com/cloudflare/workerd/pull/1586 is shipped, I wanted to update the type definitions for `.raw()` to include `{columnNames: true}` which retrun as a special case. I believe this is the best way to express it:

```ts
  raw<T = unknown[]>(options: {columnNames: true}): Promise<[string[], ...T[]]>;
  raw<T = unknown[]>(options?: {columnNames?: false}): Promise<T[]>;
```

This means if you pass anything other than `{columnNames: true}` you get the old type signature, i.e. just the rows. But it validates that the following syntax is correctly typed:

```ts
const [columns, ...rows] = await stmt
  .bind(1)
  .raw<[string, number, boolean]>({ columnNames: true });
expectType<string[]>(columns);
expectType<[string, number, boolean][]>(rows);
```

I also added an assertion that `.run()` doesn't return a `.results` field as per the docs and the recent bugfix.