### PR TITLE
Distinguish initial alarm invocations from retries.

### DIFF
--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -245,9 +245,10 @@ interface EventDispatcher @0xf20697475ec1752d {
   # the outcome and whether the run should be retried. This does not complete immediately.
 
 
-  runAlarm @4 (scheduledTime :Int64) -> (result :AlarmRun);
+  runAlarm @4 (scheduledTime :Int64, retryCount :UInt32) -> (result :AlarmRun);
   # Runs a worker's alarm.
   # scheduledTime is a unix timestamp in milliseconds for when the alarm should be run
+  # retryCount indicates the retry count, if it's a retry. Else it'll be 0.
   # Returns an AlarmRun, detailing information about the run such as
   # the outcome and whether the run should be retried. This does not complete immediately.
   #

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -80,7 +80,7 @@ public:
   virtual kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) = 0;
 
   // Trigger an alarm event with the given scheduled (unix timestamp) time.
-  virtual kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) = 0;
+  virtual kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime, uint32_t retryCount) = 0;
 
   // Run the test handler. The returned promise resolves to true or false to indicate that the test
   // passed or failed. In the case of a failure, information should have already been written to
@@ -178,7 +178,7 @@ public:
 
   void prewarm(kj::StringPtr url) override;
   kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override;
-  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override;
+  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime, uint32_t retryCount) override;
   kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override;
 
 private:

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3216,7 +3216,7 @@ void Worker::Actor::Impl::HooksImpl::updateAlarmInMemory(kj::Maybe<kj::Date> new
     for (auto i : kj::zeroTo(WorkerInterface::ALARM_RETRY_MAX_TRIES)) {
       co_await timerChannel.atTime(scheduledTime);
       auto result = co_await loopback->getWorker(IoChannelFactory::SubrequestMetadata{})
-          ->runAlarm(originalTime);
+          ->runAlarm(originalTime, i);
 
       if (result.outcome == EventOutcome::OK || !result.retry) {
         break;
@@ -3585,7 +3585,7 @@ public:
       kj::HttpConnectSettings settings) override;
   void prewarm(kj::StringPtr url) override;
   kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override;
-  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override;
+  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime, uint32_t retryCount) override;
   kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override;
 
 private:
@@ -3810,8 +3810,8 @@ kj::Promise<WorkerInterface::ScheduledResult> Worker::Isolate::SubrequestClient:
   return inner->runScheduled(scheduledTime, cron);
 }
 kj::Promise<WorkerInterface::AlarmResult> Worker::Isolate::SubrequestClient::runAlarm(
-    kj::Date scheduledTime) {
-  return inner->runAlarm(scheduledTime);
+    kj::Date scheduledTime, uint32_t retryCount) {
+  return inner->runAlarm(scheduledTime, retryCount);
 }
 kj::Promise<WorkerInterface::CustomEvent::Result>
     Worker::Isolate::SubrequestClient::customEvent(kj::Own<CustomEvent> event) {

--- a/src/workerd/server/alarm-scheduler.h
+++ b/src/workerd/server/alarm-scheduler.h
@@ -112,7 +112,7 @@ private:
     bool retry;
     bool retryCountsAgainstLimit;
   };
-  kj::Promise<RetryInfo> runAlarm(const ActorKey& actor, kj::Date scheduledTime);
+  kj::Promise<RetryInfo> runAlarm(const ActorKey& actor, kj::Date scheduledTime, uint32_t retryCount);
 
   void setAlarmInMemory(kj::Own<ActorKey> actor, kj::Date scheduledTime);
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -504,7 +504,7 @@ private:
   kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override {
     throwUnsupported();
   }
-  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override {
+  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime, uint32_t retryCount) override {
     throwUnsupported();
   }
   kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override {
@@ -578,7 +578,7 @@ private:
     kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override {
       throwUnsupported();
     }
-    kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override {
+    kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime, uint32_t retryCount) override {
       throwUnsupported();
     }
     kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override {
@@ -736,7 +736,7 @@ private:
   kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override {
     throwUnsupported();
   }
-  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override {
+  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime, uint32_t retryCount) override {
     throwUnsupported();
   }
   kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override {
@@ -992,7 +992,7 @@ private:
   kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override {
     throwUnsupported();
   }
-  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime) override {
+  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime, uint32_t retryCount) override {
     throwUnsupported();
   }
   kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override {


### PR DESCRIPTION
This PR adds a new `runAlarm` parameter to keep track of alarm invocation retries.