### PR TITLE
Fixup importing built-ins from module "subdirectories"

### DIFF
--- a/src/workerd/api/tests/module-test.js
+++ b/src/workerd/api/tests/module-test.js
@@ -1,7 +1,7 @@
 import * as assert from 'a/b/c';
 import * as assert3 from 'node:assert';
 
-export const abortcontroller = {
+export const basics = {
   async test() {
     const assert2 = await import('a/b/c');
     if (assert !== assert2 && assert !== assert3) {

--- a/src/workerd/api/tests/module-test.js
+++ b/src/workerd/api/tests/module-test.js
@@ -1,0 +1,11 @@
+import * as assert from 'a/b/c';
+import * as assert3 from 'node:assert';
+
+export const abortcontroller = {
+  async test() {
+    const assert2 = await import('a/b/c');
+    if (assert !== assert2 && assert !== assert3) {
+      throw new Error('bad things happened');
+    }
+  }
+};

--- a/src/workerd/api/tests/module-test.wd-test
+++ b/src/workerd/api/tests/module-test.wd-test
@@ -1,0 +1,17 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "module-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "module-test.js"),
+          (name = "a/b/c",
+           esModule = "import * as assert from 'node:assert'; await import('node:buffer'); export default assert;"),
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat"]
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
there's probably more elegant additional cleanups that can be made in here but this fixes the immediate issue.