### PR TITLE
Extend UUID API

### DIFF
--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -439,12 +439,8 @@ double TraceDiagnosticChannelEvent::getTimestamp() { return timestamp; }
 
 ScriptVersion::ScriptVersion(workerd::ScriptVersion::Reader version)
     : id{[&]() -> kj::Maybe<kj::String> {
-        auto upper = version.getId().getUpper();
-        auto lower = version.getId().getLower();
-        if (upper == 0 && lower == 0) {
-          return kj::none;
-        }
-        return UUIDToString(upper, lower);
+        return UUID::fromUpperLower(version.getId().getUpper(), version.getId().getLower())
+            .map([](const auto& uuid) { return uuid.toString(); });
       }()},
       tag{[&]() -> kj::Maybe<kj::String> {
         if (version.hasTag()) {

--- a/src/workerd/util/uuid-test.c++
+++ b/src/workerd/util/uuid-test.c++
@@ -8,16 +8,45 @@
 namespace workerd {
 namespace {
 
-KJ_TEST("UUIDToString") {
-  KJ_EXPECT(UUIDToString(0ull, 0ull) ==
-      "00000000-0000-0000-0000-000000000000");
-  KJ_EXPECT(UUIDToString(72340172838076673ull, 1157442765409226768ull) ==
-      "01010101-0101-0101-1010-101010101010");
-  KJ_EXPECT(UUIDToString(81985529216486895ull, 81985529216486895ull) ==
-      "01234567-89ab-cdef-0123-456789abcdef");
-  KJ_EXPECT(UUIDToString(16045690984833335023ull, 16045690984833335023ull) ==
-      "deadbeef-dead-beef-dead-beefdeadbeef");
+#define ASSERT_VALID_AND_EQUAL(upper, lower, str)                                                  \
+  do {                                                                                             \
+    auto a = KJ_ASSERT_NONNULL(UUID::fromUpperLower(upper, lower));                                \
+    auto b = KJ_ASSERT_NONNULL(UUID::fromString(str));                                             \
+    KJ_ASSERT(a.getUpper() == upper);                                                              \
+    KJ_ASSERT(a.getLower() == lower);                                                              \
+    KJ_ASSERT(b.getUpper() == upper);                                                              \
+    KJ_ASSERT(b.getLower() == lower);                                                              \
+    KJ_ASSERT(a == b);                                                                             \
+  } while (false)
+
+KJ_TEST("Valid UUIDs") {
+  ASSERT_VALID_AND_EQUAL(72340172838076673ull, 1157442765409226768ull,
+                         "01010101-0101-0101-1010-101010101010");
+  ASSERT_VALID_AND_EQUAL(81985529216486895ull, 81985529216486895ull,
+                         "01234567-89ab-cdef-0123-456789abcdef");
+  ASSERT_VALID_AND_EQUAL(16045690984833335023ull, 16045690984833335023ull,
+                         "deadbeef-dead-beef-dead-beefdeadbeef");
 }
 
-}  // namespace
-}  // namespace workerd
+KJ_TEST("Null UUIDs") {
+  KJ_EXPECT(UUID::fromUpperLower(0ull, 0ull) == kj::none);
+  KJ_EXPECT(UUID::fromString("00000000-0000-0000-0000-000000000000") == kj::none);
+}
+
+KJ_TEST("Invalid UUIDs") {
+  KJ_EXPECT(UUID::fromString("") == kj::none);
+  KJ_EXPECT(UUID::fromString("foo") == kj::none);
+  KJ_EXPECT(UUID::fromString("+_{};'<>?,.`/'!@#$%^&*()") == kj::none);
+  KJ_EXPECT(UUID::fromString("101010101-0101-0101-1010-101010101010") == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-10101-0101-1010-101010101010") == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-0101-10101-1010-101010101010") == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-0101-0101-10101-101010101010") == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-0101-0101-1010-1010101010101") == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-0101-0101-1010-101010101010-") == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-0101-0101-1010-10101010101-") == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-0101-0101-1010-10101010101g") == kj::none);
+  KJ_EXPECT(UUID::fromString("0123456789abcdef0123456789abcdef") == kj::none);
+}
+
+} // namespace
+} // namespace workerd

--- a/src/workerd/util/uuid.h
+++ b/src/workerd/util/uuid.h
@@ -6,6 +6,7 @@
 
 #include <kj/compat/http.h>
 #include <kj/string.h>
+#include <kj/hash.h>
 
 namespace workerd {
 
@@ -14,10 +15,55 @@ namespace workerd {
 // source, it is safe to assume that the output of this function is unique.
 kj::String randomUUID(kj::Maybe<kj::EntropySource&> optionalEntropySource);
 
-// Convert a UUID represented by two 64-bit integers to a string in the 8-4-4-4-12 format i.e.
-// a dash-separated hex string in the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
-// The `upper` parameter represents the most signficant bits and `lower` the least significant bits
-// of the UUID value.
-kj::String UUIDToString(uint64_t upper, uint64_t lower);
+// A 128-bit universally unique identifier (UUID).
+//
+// A UUID can be created from and converted between between two formats:
+// 1. Upper/lower format: an "upper" field representing the most signficant bits and "lower" field
+//    representings the least significant bits.
+// 2. Stringified 8-4-4-4-12 hex format.
+//
+// A "null UUID" (a UUID with a value of 0) is considered invalid and is not possible to create.
+class UUID {
+public:
+  // Create a UUID from upper and lower parts. If the UUID would be null, return kj::none.
+  //
+  // For example, creating a UUID from upper and lower values of 81985529216486895 and
+  // 81985529216486895 respectively yields a UUID which stringifies to
+  // "01234567-89ab-cdef-0123-456789abcdef".
+  static kj::Maybe<UUID> fromUpperLower(uint64_t upper, uint64_t lower);
 
-}
+  // Create a UUID from 8-4-4-4-12 hex format. If the provided string is not valid, or the UUID
+  // would be null, return kj::none.
+  static kj::Maybe<UUID> fromString(kj::StringPtr str);
+
+  uint64_t getUpper() const {
+    return upper;
+  }
+
+  uint64_t getLower() const {
+    return lower;
+  }
+
+  // Stringify the UUID to 8-4-4-4-12 hex format.
+  //
+  // Note that this is NOT just a debugging API. Its behaviour is relied upon to implement
+  // user-facing APIs.
+  kj::String toString() const;
+
+  bool operator==(const UUID& other) const {
+    return upper == other.upper && lower == other.lower;
+  }
+
+  size_t hashCode() const {
+    return kj::hashCode(upper, lower);
+  }
+
+private:
+  uint64_t upper;
+  uint64_t lower;
+
+  UUID(uint64_t upper, uint64_t lower) : upper(upper), lower(lower) {}
+};
+
+
+} // namespace workerd


### PR DESCRIPTION
`UUIDToString` has been moved to `UUID::toString()` and it's now possible to create a UUID from a string too.