### PR TITLE
JSRPC: Support passing RPC stubs across other RPCs

### DIFF
--- a/src/cloudflare/internal/workers.d.ts
+++ b/src/cloudflare/internal/workers.d.ts
@@ -11,3 +11,10 @@ export class WorkerEntrypoint {
   public ctx: unknown;
   public env: unknown;
 }
+
+export class RpcStub {
+  public constructor(server: object);
+}
+
+export class RpcTarget {
+}

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -9,3 +9,5 @@ import entrypoints from 'cloudflare-internal:workers';
 
 export const WorkerEntrypoint = entrypoints.WorkerEntrypoint;
 export const DurableObject = entrypoints.DurableObject;
+export const RpcStub = entrypoints.RpcStub;
+export const RpcTarget = entrypoints.RpcTarget;

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1869,13 +1869,13 @@ jsg::Promise<jsg::Ref<Response>> Fetcher::fetch(
 }
 
 kj::Maybe<Fetcher::RpcFunction> Fetcher::getRpcMethod(jsg::Lock& js, kj::StringPtr name) {
-  // This is like JsRpcCapability::getRpcMethod(), but we also initiate a whole new JS RPC session
+  // This is like JsRpcStub::getRpcMethod(), but we also initiate a whole new JS RPC session
   // each time the method is called.
   return RpcFunction(JSG_VISITABLE_LAMBDA(
       (methodName = kj::str(name), self = JSG_THIS),
       (self),
       (jsg::Lock& js, const v8::FunctionCallbackInfo<v8::Value>& args) -> jsg::Promise<jsg::Value> {
-    // Same as JsRpcCapability::getRpcMethod(), we want to prevent calling on the wrong `this`.
+    // Same as JsRpcStub::getRpcMethod(), we want to prevent calling on the wrong `this`.
     JSG_REQUIRE(args.This() == KJ_ASSERT_NONNULL(self.tryGetHandle(js)), TypeError,
         "Illegal invocation");
 
@@ -1884,7 +1884,7 @@ kj::Maybe<Fetcher::RpcFunction> Fetcher::getRpcMethod(jsg::Lock& js, kj::StringP
     auto event = kj::heap<api::JsRpcSessionCustomEventImpl>(
         JsRpcSessionCustomEventImpl::WORKER_RPC_EVENT_TYPE);
 
-    auto result = JsRpcCapability::sendJsRpc(js, event->getCap(), methodName, args);
+    auto result = JsRpcStub::sendJsRpc(js, event->getCap(), methodName, args);
 
     // Arrange to cancel the CustomEvent if our I/O context is destroyed. But otherwise, we don't
     // actually care about the result of the event. If it throws, the membrane will already have

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1871,6 +1871,12 @@ jsg::Promise<jsg::Ref<Response>> Fetcher::fetch(
 kj::Maybe<Fetcher::RpcFunction> Fetcher::getRpcMethod(jsg::Lock& js, kj::StringPtr name) {
   // This is like JsRpcStub::getRpcMethod(), but we also initiate a whole new JS RPC session
   // each time the method is called.
+
+  // Do not return a method for `then`, otherwise JavaScript decides this is a thenable, i.e. a
+  // custom Promise, which will mean a Promise that resolves to this object will attempt to chain
+  // with it, which is not what you want!
+  if (name == "then"_kj) return kj::none;
+
   return RpcFunction(JSG_VISITABLE_LAMBDA(
       (methodName = kj::str(name), self = JSG_THIS),
       (self),

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -1,5 +1,17 @@
 import assert from 'node:assert';
-import {WorkerEntrypoint,DurableObject} from 'cloudflare:workers';
+import {WorkerEntrypoint,DurableObject,RpcStub,RpcTarget} from 'cloudflare:workers';
+
+class MyCounter extends RpcTarget {
+  constructor(i = 0) {
+    super();
+    this.i = i;
+  }
+
+  async increment(j) {
+    this.i += j;
+    return this.i;
+  }
+}
 
 export let nonClass = {
   async noArgs(x, env, ctx) {
@@ -242,5 +254,13 @@ export let defaultExportClass = {
   async test(controller, env, ctx) {
     let resp = await env.defaultExport.fetch("http://foo");
     assert.strictEqual(await resp.text(), "default service 12");
+  },
+}
+
+export let loopbackJsRpcTarget = {
+  async test(controller, env, ctx) {
+    let stub = new RpcStub(new MyCounter(4));
+    assert.strictEqual(await stub.increment(5), 9);
+    assert.strictEqual(await stub.increment(7), 16);
   },
 }

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -63,6 +63,15 @@ export class MyService extends WorkerEntrypoint {
     return i * j + this.env.twelve;
   }
 
+  async makeCounter(i) {
+    // TODO(soon): Create `RpcStub` implicitly.
+    return new RpcStub(new MyCounter(i));
+  }
+
+  async incrementCounter(counter, i) {
+    return await counter.increment(i);
+  }
+
   async fetch(req, x) {
     assert.strictEqual(x, undefined);
     return new Response("method = " + req.method + ", url = " + req.url);
@@ -262,5 +271,21 @@ export let loopbackJsRpcTarget = {
     let stub = new RpcStub(new MyCounter(4));
     assert.strictEqual(await stub.increment(5), 9);
     assert.strictEqual(await stub.increment(7), 16);
+  },
+}
+
+export let sendStubOverRpc = {
+  async test(controller, env, ctx) {
+    let stub = new RpcStub(new MyCounter(4));
+    assert.strictEqual(await env.MyService.incrementCounter(stub, 5), 9);
+    assert.strictEqual(await stub.increment(7), 16);
+  },
+}
+
+export let receiveStubOverRpc = {
+  async test(controller, env, ctx) {
+    let stub = await env.MyService.makeCounter(17);
+    assert.strictEqual(await stub.increment(2), 19);
+    assert.strictEqual(await stub.increment(-10), 9);
   },
 }

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -64,8 +64,7 @@ export class MyService extends WorkerEntrypoint {
   }
 
   async makeCounter(i) {
-    // TODO(soon): Create `RpcStub` implicitly.
-    return new RpcStub(new MyCounter(i));
+    return new MyCounter(i);
   }
 
   async incrementCounter(counter, i) {

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -148,6 +148,11 @@ jsg::Promise<jsg::Value> JsRpcStub::sendJsRpc(
 
 kj::Maybe<JsRpcStub::RpcFunction> JsRpcStub::getRpcMethod(
     jsg::Lock& js, kj::StringPtr name) {
+  // Do not return a method for `then`, otherwise JavaScript decides this is a thenable, i.e. a
+  // custom Promise, which will mean a Promise that resolves to this object will attempt to chain
+  // with it, which is not what you want!
+  if (name == "then"_kj) return kj::none;
+
   return RpcFunction(JSG_VISITABLE_LAMBDA(
       (methodName = kj::str(name), self = JSG_THIS),
       (self),

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -94,7 +94,7 @@ private:
 
 } // namespace
 
-jsg::Promise<jsg::Value> JsRpcCapability::sendJsRpc(
+jsg::Promise<jsg::Value> JsRpcStub::sendJsRpc(
     jsg::Lock& js,
     rpc::JsRpcTarget::Client client,
     kj::StringPtr name,
@@ -130,7 +130,7 @@ jsg::Promise<jsg::Value> JsRpcCapability::sendJsRpc(
   });
 }
 
-kj::Maybe<JsRpcCapability::RpcFunction> JsRpcCapability::getRpcMethod(
+kj::Maybe<JsRpcStub::RpcFunction> JsRpcStub::getRpcMethod(
     jsg::Lock& js, kj::StringPtr name) {
   return RpcFunction(JSG_VISITABLE_LAMBDA(
       (methodName = kj::str(name), self = JSG_THIS),
@@ -144,7 +144,7 @@ kj::Maybe<JsRpcCapability::RpcFunction> JsRpcCapability::getRpcMethod(
     // native function with the wrong `this`.)
     //
     // TODO(cleanup): Ideally, we'd actually obtain `self` by unwrapping `args.This()` to a
-    // `jsg::Ref<JsRpcCapability>` instead of capturing it, but there isn't a JSG-blessed way to do
+    // `jsg::Ref<JsRpcStub>` instead of capturing it, but there isn't a JSG-blessed way to do
     // that.
     JSG_REQUIRE(args.This() == KJ_ASSERT_NONNULL(self.tryGetHandle(js)), TypeError,
         "Illegal invocation");
@@ -454,7 +454,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
   // only makes a difference in the case that some sort of an error occurred. We don't strictly
   // have to revoke the capabilities as they are probably already broken anyway, but revoking them
   // helps to ensure that the underlying transport isn't "held open" waiting for the JS garbage
-  // collector to actually collect the JsRpcCapability objects.
+  // collector to actually collect the JsRpcStub objects.
   auto revokePaf = kj::newPromiseAndFulfiller<void>();
 
   KJ_DEFER({

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -75,6 +75,10 @@ public:
   static jsg::Ref<JsRpcTarget> constructor() { return jsg::alloc<JsRpcTarget>(); }
 
   JSG_RESOURCE_TYPE(JsRpcTarget) {}
+
+  // Serializes to JsRpcStub.
+  void serialize(jsg::Lock& js, jsg::Serializer& serializer);
+  JSG_ONEWAY_SERIALIZABLE(rpc::SerializationTag::JS_RPC_STUB);
 };
 
 // A JsRpcStub object forwards JS method calls to the remote Worker/Durable Object over RPC.

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -183,9 +183,40 @@ interface HibernatableWebSocketEventDispatcher {
   # Run a hibernatable websocket event
 }
 
+enum SerializationTag {
+  # Tag values for all serializable types supported by the Workers API.
+
+  invalid @0;
+  # Not assigned to anything. Reserved to make things less weird if a zero-valued tag gets written
+  # by accident.
+
+  jsRpcStub @1;
+}
+
 struct JsValue {
+  # A serialized JavaScript value being passed over RPC.
+
   v8Serialized @0 :Data;
   # JS value that has been serialized for network transport.
+
+  externals @1 :List(External);
+  # The serialized data may contain "externals" -- references to external resources that cannot
+  # simply be serialized. If so, they are placed in this separate list of externals.
+  #
+  # (We could also call these "capabilities", but that word is pretty overloaded already.)
+
+  struct External {
+    union {
+      invalid @0 :Void;
+      # Invalid default value to reduce confusion if an External wasn't initialized properly.
+      # This should never appear in a real JsValue.
+
+      rpcTarget @1 :JsRpcTarget;
+      # An object that can be called over RPC.
+
+      # TODO(soon): Streams, Request, Response, etc.
+    }
+  }
 }
 
 interface JsRpcTarget {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -484,6 +484,12 @@ using HasGetTemplateOverload = decltype(
     wrapper.initReflection(this, __VA_ARGS__); \
   }
 
+// Declares the type serializable. See jsg::Serializer for usage.
+#define JSG_SERIALIZABLE(TAG, ...) \
+  static_assert(static_cast<uint>(jsgSuper::jsgSerializeTag) != static_cast<uint>(TAG)); \
+  static constexpr auto jsgSerializeTag = TAG; \
+  static constexpr decltype(jsgSerializeTag) jsgSerializeOldTags[] = {__VA_ARGS__}
+
 // Declares a wildcart property getter. If a property is requested that isn't already present on
 // the object or its prototypes, the wildcard property getter will be given a chance to return the
 // property.
@@ -1065,6 +1071,10 @@ public:
   static constexpr bool jsgHasReflection = false;
   template <typename TypeWrapper>
   inline void jsgInitReflection(TypeWrapper& wrapper) {}
+
+  // Dummy invalid serialization tag. This is only used to detect when a subclass has defined their
+  // own tag.
+  static constexpr uint jsgSerializeTag = kj::maxValue;
 
 private:
   inline void visitForMemoryInfo(MemoryTracker& tracker) const {}

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -494,6 +494,11 @@ using HasGetTemplateOverload = decltype(
 // the object or its prototypes, the wildcard property getter will be given a chance to return the
 // property.
 //
+// WARNING: Be very careful about the property named "then". If it exists and is a function, V8
+//   will treat your type as a custom thenable, i.e. as a kind of Promise, which means among other
+//   things that any time a Promise would resolve to it, it will try to chain with it. You should
+//   probably return kj::none when "then" is requested.
+//
 // Example:
 //
 //   struct MyType {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -488,7 +488,19 @@ using HasGetTemplateOverload = decltype(
 #define JSG_SERIALIZABLE(TAG, ...) \
   static_assert(static_cast<uint>(jsgSuper::jsgSerializeTag) != static_cast<uint>(TAG)); \
   static constexpr auto jsgSerializeTag = TAG; \
-  static constexpr decltype(jsgSerializeTag) jsgSerializeOldTags[] = {__VA_ARGS__}
+  static constexpr decltype(jsgSerializeTag) jsgSerializeOldTags[] = {__VA_ARGS__}; \
+  static constexpr auto jsgSerializeOneway = false
+
+// Like JSG_SERIALIZABLE(), but the type has only a serialize() method and no deserialize(). It
+// is expected that the specified tag actually belongs to some other type, so a serialization
+// round trip will have the effect of replacing this type with that other type.
+//
+// Used e.g. for JsRpcTarget, which becomes JsRpcStub after serialization.
+#define JSG_ONEWAY_SERIALIZABLE(TAG) \
+  static_assert(static_cast<uint>(jsgSuper::jsgSerializeTag) != static_cast<uint>(TAG)); \
+  static constexpr auto jsgSerializeTag = TAG; \
+  static constexpr decltype(jsgSerializeTag) jsgSerializeOldTags[] = {}; \
+  static constexpr auto jsgSerializeOneway = true
 
 // Declares a wildcart property getter. If a property is requested that isn't already present on
 // the object or its prototypes, the wildcard property getter will be given a chance to return the

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -596,6 +596,11 @@ private:
 
   // Maps type_info values to functions that can be used to get the associated template. Used by
   // ResourceWrapper.
+  //
+  // Fun fact: Comparing type_index on Linux is a simple pointer comparison. On Windows it is a
+  // string comparison (of the type names). On Mac arm64 it could be either, there's a special bit
+  // in the type_info that indicates if it is known to be unique. See
+  // _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION in <typeinfo> for more.
   kj::HashMap<std::type_index, GetTypeInfoFunc*> resourceTypeMap;
 
   template <typename, typename>

--- a/src/workerd/jsg/ser-test.c++
+++ b/src/workerd/jsg/ser-test.c++
@@ -1,0 +1,252 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "jsg-test.h"
+#include "ser.h"
+
+namespace workerd::jsg::test {
+namespace {
+
+V8System v8System;
+class ContextGlobalObject: public jsg::Object, public ContextGlobal {};
+
+kj::Array<kj::byte> lastSerializedData;
+
+struct SerTestContext: public ContextGlobalObject {
+  enum class SerializationTag {
+    FOO,
+    BAR,
+    BAZ,
+  };
+
+  struct Foo: public jsg::Object {
+    uint i;
+    Foo(uint i): i(i) {}
+
+    static jsg::Ref<Foo> constructor(uint i) {
+      return jsg::alloc<Foo>(i);
+    }
+
+    int getI() {
+      return i;
+    }
+
+    JSG_RESOURCE_TYPE(Foo) {
+      JSG_READONLY_PROTOTYPE_PROPERTY(i, getI);
+    }
+
+    void serialize(jsg::Lock& js, jsg::Serializer& serializer) {
+      serializer.writeRawUint32(i);
+    }
+    static jsg::Ref<Foo> deserialize(Lock& js, SerializationTag tag, Deserializer& deserializer) {
+      KJ_ASSERT(tag == SerializationTag::FOO);
+
+      // Intentionally deserialize differently so we can detect it.
+      return jsg::alloc<Foo>(deserializer.readRawUint32() + 2);
+    }
+    JSG_SERIALIZABLE(SerializationTag::FOO);
+  };
+
+  struct Bar: public jsg::Object {
+    kj::String text;
+    Bar(kj::String text): text(kj::mv(text)) {}
+
+    static jsg::Ref<Bar> constructor(kj::String text) {
+      return jsg::alloc<Bar>(kj::mv(text));
+    }
+
+    kj::String getText() {
+      return kj::str(text);
+    }
+
+    JSG_RESOURCE_TYPE(Bar) {
+      JSG_READONLY_PROTOTYPE_PROPERTY(text, getText);
+    }
+
+    void serialize(jsg::Lock& js, jsg::Serializer& serializer) {
+      serializer.writeRawUint64(text.size());
+      serializer.writeRawBytes(text.asBytes());
+    }
+    static jsg::Ref<Bar> deserialize(Lock& js, SerializationTag tag, Deserializer& deserializer) {
+      KJ_ASSERT(tag == SerializationTag::BAR);
+
+      size_t size = deserializer.readRawUint64();
+      auto bytes = deserializer.readRawBytes(size);
+      // Intentionally deserialize differently so we can detect it.
+      return jsg::alloc<Bar>(kj::str(bytes.asChars(), '!'));
+    }
+    JSG_SERIALIZABLE(SerializationTag::BAR);
+  };
+
+  struct Baz: public jsg::Object {
+    bool serializeThrows;
+    Baz(bool serializeThrows): serializeThrows(serializeThrows) {}
+    static jsg::Ref<Baz> constructor(bool serializeThrows) {
+      return jsg::alloc<Baz>(serializeThrows);
+    }
+
+    JSG_RESOURCE_TYPE(Baz) {}
+
+    void serialize(jsg::Lock& js, jsg::Serializer& serializer) {
+      JSG_REQUIRE(!serializeThrows, Error, "throw from serialize()");
+    }
+    static jsg::Ref<Bar> deserialize(Lock& js, SerializationTag tag, Deserializer& deserializer) {
+      JSG_FAIL_REQUIRE(Error, "throw from deserialize()");
+    }
+    JSG_SERIALIZABLE(SerializationTag::BAZ);
+  };
+
+  JsValue roundTrip(Lock& js, JsValue in) {
+    auto content = ({
+      Serializer ser(js);
+      ser.write(js, in);
+      ser.release();
+    });
+
+    auto result = ({
+      Deserializer deser(js, content);
+      deser.readValue(js);
+    });
+
+    // Save the last serialization off to the side.
+    lastSerializedData = kj::mv(content.data);
+
+    return result;
+  }
+
+  JSG_RESOURCE_TYPE(SerTestContext) {
+    JSG_NESTED_TYPE(Foo);
+    JSG_NESTED_TYPE(Bar);
+    JSG_NESTED_TYPE(Baz);
+    JSG_METHOD(roundTrip);
+  }
+};
+JSG_DECLARE_ISOLATE_TYPE(
+    SerTestIsolate, SerTestContext, SerTestContext::Foo, SerTestContext::Bar, SerTestContext::Baz);
+
+// Define a whole second JSG isolate type that contains "updated" code where Bar no longer wraps
+// a string, it wraps an arbitrary value.
+struct SerTestContextV2: public ContextGlobalObject {
+  enum class SerializationTag {
+    FOO,
+    BAR_OLD,
+    BAZ,
+    BAR_V2
+  };
+
+  struct Bar: public jsg::Object {
+    JsRef<JsValue> val;
+    Bar(JsRef<JsValue> val): val(kj::mv(val)) {}
+
+    static jsg::Ref<Bar> constructor(JsRef<JsValue> val) {
+      return jsg::alloc<Bar>(kj::mv(val));
+    }
+
+    JsRef<JsValue> getVal(Lock& js) {
+      return val.addRef(js);
+    }
+
+    JSG_RESOURCE_TYPE(Bar) {
+      JSG_READONLY_PROTOTYPE_PROPERTY(val, getVal);
+    }
+
+    void serialize(jsg::Lock& js, jsg::Serializer& serializer) {
+      // V2 just writes a value!
+      serializer.write(js, JsValue(val.getHandle(js)));
+    }
+    static jsg::Ref<Bar> deserialize(Lock& js, SerializationTag tag, Deserializer& deserializer) {
+      if (tag == SerializationTag::BAR_OLD) {
+        // Oh, it's an old value.
+        size_t size = deserializer.readRawUint64();
+        auto bytes = deserializer.readRawBytes(size);
+
+        return jsg::alloc<Bar>(JsRef<JsValue>(js, js.str(kj::str("old:", bytes.asChars()))));
+      } else {
+        KJ_ASSERT(tag == SerializationTag::BAR_V2);
+
+        return jsg::alloc<Bar>(JsRef<JsValue>(js, deserializer.readValue(js)));
+      }
+    }
+    JSG_SERIALIZABLE(SerializationTag::BAR_V2, SerializationTag::BAR_OLD);
+  };
+
+  JsValue roundTrip(Lock& js, JsValue in) {
+    auto content = ({
+      Serializer ser(js);
+      ser.write(js, in);
+      ser.release();
+    });
+
+    auto result = ({
+      Deserializer deser(js, content);
+      deser.readValue(js);
+    });
+
+    // Save the last serialization off to the side.
+    lastSerializedData = kj::mv(content.data);
+
+    return result;
+  }
+
+  JsValue deserializeLast(Lock& js) {
+    Deserializer deser(js, lastSerializedData);
+    return deser.readValue(js);
+  }
+
+  JSG_RESOURCE_TYPE(SerTestContextV2) {
+    JSG_NESTED_TYPE(Bar);
+    JSG_METHOD(roundTrip);
+    JSG_METHOD(deserializeLast);
+  }
+};
+JSG_DECLARE_ISOLATE_TYPE(SerTestIsolateV2, SerTestContextV2, SerTestContextV2::Bar);
+
+KJ_TEST("serialization") {
+  Evaluator<SerTestContext, SerTestIsolate> e(v8System);
+
+  // Test serializing built-in values.
+  e.expectEval("roundTrip(123)", "number", "123");
+  e.expectEval("JSON.stringify(roundTrip({foo: 123}))", "string", "{\"foo\":123}");
+
+  // Test serializing host objects.
+  e.expectEval("roundTrip(new Foo(123)).i", "number", "125");
+  e.expectEval("roundTrip(new Bar(\"hello\")).text", "string", "hello!");
+
+  // Test throwing from serialize/deserialize
+  e.expectEval("roundTrip(new Baz(true)).text", "throws", "Error: throw from serialize()");
+  e.expectEval("roundTrip(new Baz(false)).text", "throws", "Error: throw from deserialize()");
+
+  // Let's set up the "new version" of the code.
+  Evaluator<SerTestContextV2, SerTestIsolateV2> e2(v8System);
+
+  // This will deserialize the last-serialized bytes from above, where we serialized Bar("hello").
+  // However, it is using a "new version" of the code where Bar's serialization has changed, but
+  // the old version is still accepted.
+  e2.expectEval("deserializeLast().val", "string", "old:hello");
+
+  // Also try round-tripping the new version. It now accepts arbitrary values, not just strings.
+  e2.expectEval("roundTrip(new Bar(123)).val", "number", "123");
+
+  // Note that cycles through host objects are correcty serialized!
+  //
+  // V8 BUG ALERT: The below works if we use `obj` as the root of serialization, but NOT if we
+  //   use `bar` as the root. The reason is a flaw in the design of V8's callbacks for parsing
+  //   host objects. V8 makes a single callback to the embedder which fully reads the object and
+  //   returns a handle. However, this means that V8 cannot put the object into the backreference
+  //   table until this callback returns. If, while parsing the object, we encounter a
+  //   backreference to the object itself (a cycle), the deserializer will find the backreference
+  //   is not in the table and therefore raises an error. This is not a problem for native objects
+  //   because V8 allocates the object first, then immediately adds it to the backreference table,
+  //   and only then parses its content -- and this is why everything works fine if we start with
+  //   a native object as the root, as in this test. The API for host objects needs to be extended
+  //   somehow to allow the object to be inserted into the table before parsing its content.
+  e2.expectEval(
+      "let obj = {i: 321};\n"
+      "let bar = new Bar(obj);\n"
+      "obj.bar = bar;\n"
+      "roundTrip(obj).bar.val.bar.val.bar.val.i", "number", "321");
+}
+
+}  // namespace
+}  // namespace workerd::jsg::test


### PR DESCRIPTION
The first four commits (mainly the third commit) add a framework to allow JSG types to declare themselves serializable. @jasnell I know you were also working on something here so sorry if this overlaps. I did take some inspiration from your design doc. But, it occurred to me that instead of writing a tag and a version, we could combine these: whenever a type decides it needs a new serialization version, it allocates a whole new tag for it. This way we save some bytes on the wire.

The remaining commits, after some bug fixes and refactoring, introduce `RpcTarget` as a new type which classes can extend to mark themselves as being RPC objects -- without being a top-level entrypoint. Instances of these types can then be sent in RPC messages. The receiving side gets an `RpcStub` instead, which allows calls back to the original object.

Example:

```
import {WorkerEntrypoint,RpcTarget} from 'cloudflare:workers';

class Counter extends RpcTarget {
  i = 0;
  async increment(j) {
    this.i += j;
    return this.i;
  }
}

export class CounterService extends WorkerEntrypoint {
  async makeCounter() {
    return new Counter();
  }
}
```

```
let counter = await env.COUNTER_SERVICE.makeCounter();
await counter.increment(5);  // returns 5
await counter.increment(3);  // returns 8
```

NOT done in this PR, but needed before this is production-ready:
* resource management
  * close() methods
  * auto-close parameter caps after call returns
  * inject close method on returned object if it contains nested stubs
* promise pipelining
* streams, etc.