### PR TITLE
Add TransformStream cancel algorithm

### DIFF
--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -145,6 +145,7 @@ struct Transformer {
   using StartAlgorithm = jsg::Promise<void>(Controller);
   using TransformAlgorithm = jsg::Promise<void>(v8::Local<v8::Value>, Controller);
   using FlushAlgorithm = jsg::Promise<void>(Controller);
+  using CancelAlgorithm = jsg::Promise<void>(jsg::JsValue reason);
 
   jsg::Optional<kj::String> readableType;
   jsg::Optional<kj::String> writableType;
@@ -152,17 +153,20 @@ struct Transformer {
   jsg::Optional<jsg::Function<StartAlgorithm>> start;
   jsg::Optional<jsg::Function<TransformAlgorithm>> transform;
   jsg::Optional<jsg::Function<FlushAlgorithm>> flush;
+  jsg::Optional<jsg::Function<CancelAlgorithm>> cancel;
 
   // The expectedLength is a non-standard extension used to support specifying the
   // content-length when using a TransformStream readable side as the body of a
   // request or response.
   jsg::Optional<uint64_t> expectedLength;
 
-  JSG_STRUCT(readableType, writableType, start, transform, flush, expectedLength);
+  JSG_STRUCT(readableType, writableType, start, transform, flush, cancel, expectedLength);
   JSG_STRUCT_TS_OVERRIDE(<I = any, O = any> {
     start?: (controller: TransformStreamDefaultController<O>) => void | Promise<void>;
     transform?: (chunk: I, controller: TransformStreamDefaultController<O>) => void | Promise<void>;
     flush?: (controller: TransformStreamDefaultController<O>) => void | Promise<void>;
+    cancel?: (reason: any) => void | Promise<void>;
+    expectedLength?: number | bigint;
   });
 };
 

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -435,6 +435,8 @@ public:
     tracker.trackField("impl", impl);
   }
 
+  kj::Maybe<StreamStates::Errored> getMaybeErrorState(jsg::Lock& js);
+
 private:
   kj::Maybe<IoContext&> ioContext;
   ReadableImpl impl;
@@ -688,6 +690,9 @@ private:
   struct Algorithms {
     kj::Maybe<jsg::Function<Transformer::TransformAlgorithm>> transform;
     kj::Maybe<jsg::Function<Transformer::FlushAlgorithm>> flush;
+    kj::Maybe<jsg::Function<Transformer::CancelAlgorithm>> cancel;
+
+    kj::Maybe<jsg::Promise<void>> maybeFinish = kj::none;
 
     Algorithms() {};
     Algorithms(Algorithms&& other) = default;
@@ -696,10 +701,11 @@ private:
     inline void clear() {
       transform = kj::none;
       flush = kj::none;
+      cancel = kj::none;
     }
 
     inline void visitForGc(jsg::GcVisitor& visitor) {
-      visitor.visit(transform, flush);
+      visitor.visit(transform, flush, cancel, maybeFinish);
     }
   };
 


### PR DESCRIPTION
The cancel algorithm for TransformStreams was recently added to the spec. This implements it. See the new test for example use.

Refs: https://streams.spec.whatwg.org/#callbackdef-transformercancelcallback
