### PR TITLE
Add debug information for queue handler timeouts caused by lingering waituntils

### DIFF
--- a/src/workerd/api/queue.h
+++ b/src/workerd/api/queue.h
@@ -196,12 +196,28 @@ public:
     tracker.trackFieldWithSize("IoPtr<QueueEventResult>", sizeof(IoPtr<QueueEventResult>));
   }
 
+  struct Incomplete {};
+  struct CompletedSuccessfully {};
+  struct CompletedWithError {
+    kj::Exception error;
+  };
+  typedef kj::OneOf<Incomplete, CompletedSuccessfully, CompletedWithError> CompletionStatus;
+
+  void setCompletionStatus(CompletionStatus status) {
+    completionStatus = status;
+  }
+
+  CompletionStatus getCompletionStatus() const {
+    return completionStatus;
+  }
+
 private:
   // TODO(perf): Should we store these in a v8 array directly rather than this intermediate kj
   // array to avoid one intermediate copy?
   kj::Array<jsg::Ref<QueueMessage>> messages;
   kj::String queueName;
   IoPtr<QueueEventResult> result;
+  CompletionStatus completionStatus = Incomplete{};
 
   void visitForGc(jsg::GcVisitor& visitor) {
     visitor.visitAll(messages);


### PR DESCRIPTION
@a-robinson and I are trying to add some debug information to help identify the cause of an issue where queue events seem to hang for 15 minutes (the timeout duration).

This info should tell us:
* Is the user's queue() handler function actually finishing?
* Are there other waitUntil tasks that are causing the event to run for 15 minutes then timeout?