### PR TITLE
Build `kv-asset-handler` before running Miniflare tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,9 @@ jobs:
       - name: Make workerd binary executable
         run: chmod +x /tmp/workerd
 
+      - name: Build Miniflare and dependencies
+        run: pnpm turbo build --filter miniflare
+
       - name: Run Miniflare tests
         id: miniflare-test
         continue-on-error: true


### PR DESCRIPTION
We recently moved `@cloudflare/kv-asset-handler` into the `workers-sdk` package. Miniflare's tests depend on this to verify Workers Sites work. Previously, when this was outside of `workers-sdk`, we installed built files from `npm`. Now that it's in `workers-sdk`, we're responsible for building it before using it. This change makes sure we build it before running Miniflare's tests.