### PR TITLE
Revert "Revert "Revert "Add toStringTag value on JSG resource types"""

### DIFF
--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -47,7 +47,6 @@ namespace workerd::jsg {
       ::workerd::jsg::JsgKind::RESOURCE; \
   using jsgSuper = jsgThis; \
   using jsgThis = Type; \
-  static inline kj::StringPtr jsgGetName() { return #Type##_kjc; } \
   inline kj::StringPtr jsgGetMemoryName() const override { return #Type##_kjc; } \
   inline size_t jsgGetMemorySelfSize() const override { return sizeof(Type); } \
   inline void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const override { \

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -712,9 +712,6 @@ struct ResourceTypeBuilder {
     inspectProperties = v8::ObjectTemplate::New(isolate);
     prototype->Set(symbol, inspectProperties, static_cast<v8::PropertyAttribute>(
       v8::PropertyAttribute::ReadOnly | v8::PropertyAttribute::DontEnum));
-
-    auto toStringTagSymbol = v8::Symbol::GetToStringTag(isolate);
-    prototype->Set(toStringTagSymbol, v8StrIntern(isolate, Self::jsgGetName()), v8::PropertyAttribute::None);
   }
 
   template <typename Type, typename GetNamedMethod, GetNamedMethod getNamedMethod>

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -118,7 +118,7 @@ public:
   virtual void jsgVisitForGc(GcVisitor& visitor);
 
   virtual kj::StringPtr jsgGetMemoryName() const {
-    KJ_UNIMPLEMENTED("jsgGetMemoryName is not implemented. "
+    KJ_UNIMPLEMENTED("jsgGetTypeName is not implemented. "
                      "It must be overridden by subclasses");
   }
 


### PR DESCRIPTION
Reverts cloudflare/workerd#1714

It turns out that this change breaks some tests in miniflare -- I think we do in fact need to place it behind a compatibility flag. 

https://github.com/cloudflare/workers-sdk/blob/cab7e1c7f24ff0097e15d90030c805fe2785d173/packages/miniflare/src/workers/core/proxy.worker.ts#L81-L85