### PR TITLE
Implement v8::Exception::CaptureStackTrace for DOMException

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -440,6 +440,7 @@ http_archive(
         "//:patches/v8/0013-Always-enable-continuation-preserved-data-in-the-bui.patch",
         "//:patches/v8/0014-Attach-continuation-context-to-Promise-thenable-task.patch",
         "//:patches/v8/0015-increase-visibility-of-virtual-method.patch",
+        "//:patches/v8/0016-Implement-v8-Exception-CaptureStackTrace.patch",
     ],
     integrity = "sha256-jcBk1hBhzrMHRL0EDTgHKBVrJPsP1SLZL6A5/l6arrs=",
     strip_prefix = "v8-12.2.281.18",

--- a/patches/v8/0016-Implement-v8-Exception-CaptureStackTrace.patch
+++ b/patches/v8/0016-Implement-v8-Exception-CaptureStackTrace.patch
@@ -1,0 +1,65 @@
+From ae6cd1d7637e57bbcad9b113596bbcaf041e4d9e Mon Sep 17 00:00:00 2001
+From: James M Snell <jasnell@gmail.com>
+Date: Fri, 23 Feb 2024 15:55:43 -0800
+Subject: [PATCH] Implement v8::Exception::CaptureStackTrace
+
+---
+ include/v8-exception.h |  3 +++
+ src/api/api.cc         | 20 ++++++++++++++++++++
+ 2 files changed, 23 insertions(+)
+
+diff --git a/include/v8-exception.h b/include/v8-exception.h
+index 86f8b3a4baf..7c329ac1468 100644
+--- a/include/v8-exception.h
++++ b/include/v8-exception.h
+@@ -8,6 +8,7 @@
+ #include <stddef.h>
+ 
+ #include "v8-local-handle.h"  // NOLINT(build/include_directory)
++#include "v8-object.h"        // NOLINT(build/include_directory)
+ #include "v8config.h"         // NOLINT(build/include_directory)
+ 
+ namespace v8 {
+@@ -58,6 +59,8 @@ class V8_EXPORT Exception {
+    * of a given exception, or an empty handle if not available.
+    */
+   static Local<StackTrace> GetStackTrace(Local<Value> exception);
++
++  static Maybe<bool> CaptureStackTrace(Local<Context> context, Local<Object> object);
+ };
+ 
+ /**
+diff --git a/src/api/api.cc b/src/api/api.cc
+index bcfb18d74a1..c0bfc7a16f8 100644
+--- a/src/api/api.cc
++++ b/src/api/api.cc
+@@ -10703,6 +10703,26 @@ Local<Message> Exception::CreateMessage(Isolate* v8_isolate,
+       scope.CloseAndEscape(i_isolate->CreateMessage(obj, nullptr)));
+ }
+ 
++Maybe<bool> Exception::CaptureStackTrace(Local<Context> context, Local<Object> object) {
++  auto i_isolate = reinterpret_cast<i::Isolate*>(context->GetIsolate());
++  ENTER_V8_NO_SCRIPT(i_isolate, context, Exception, CaptureStackTrace,
++                     i::HandleScope);
++  auto obj = Utils::OpenHandle(*object);
++  if (!IsJSObject(*obj)) return Just(false);
++
++  auto js_obj = i::Handle<i::JSObject>::cast(obj);
++
++  i::FrameSkipMode mode = i::FrameSkipMode::SKIP_FIRST;
++
++  auto result = i::ErrorUtils::CaptureStackTrace(i_isolate, js_obj, mode,
++      i::Handle<i::Object>());
++
++  i::Handle<i::Object> handle;
++  has_exception = !result.ToHandle(&handle);
++  RETURN_ON_FAILED_EXECUTION_PRIMITIVE(bool);
++  return Just(true);
++}
++
+ Local<StackTrace> Exception::GetStackTrace(Local<Value> exception) {
+   auto obj = Utils::OpenHandle(*exception);
+   if (!IsJSObject(*obj)) return Local<StackTrace>();
+-- 
+2.40.1
+

--- a/src/workerd/jsg/dom-exception-test.c++
+++ b/src/workerd/jsg/dom-exception-test.c++
@@ -12,8 +12,16 @@ namespace {
 V8System v8System;
 
 struct DOMExceptionContext: public Object, public ContextGlobal {
+
+  JsObject tryGetError(jsg::Lock& js) {
+    auto obj = js.obj();
+    v8::Exception::CaptureStackTrace(js.v8Context(), obj);
+    return obj;
+  }
+
   JSG_RESOURCE_TYPE(DOMExceptionContext) {
     JSG_NESTED_TYPE(DOMException);
+    JSG_METHOD(tryGetError);
   }
 };
 JSG_DECLARE_ISOLATE_TYPE(DOMExceptionIsolate, DOMExceptionContext);
@@ -67,6 +75,14 @@ KJ_TEST("DOMException has legacy code constants") {
   e.expectEval(
       "DOMException.DATA_CLONE_ERR === 25",
       "boolean", "true"
+  );
+}
+
+KJ_TEST("CaptureStackTrace test") {
+  Evaluator<DOMExceptionContext, DOMExceptionIsolate> e(v8System);
+  e.expectEval(
+    "const m = tryGetError(); m.stack", "string",
+    "Error\n    at <anonymous>:1:11"
   );
 }
 

--- a/src/workerd/jsg/dom-exception.c++
+++ b/src/workerd/jsg/dom-exception.c++
@@ -10,14 +10,31 @@
 namespace workerd::jsg {
 
 Ref<DOMException> DOMException::constructor(
-    Lock& js,
+    const v8::FunctionCallbackInfo<v8::Value>& args,
     Optional<kj::String> message,
     Optional<kj::String> name) {
+  jsg::Lock& js = jsg::Lock::from(args.GetIsolate());
   kj::String errMessage = kj::mv(message).orDefault([&] { return kj::String(); });
+
+  // V8 gives Error objects a non-standard (but widely known) `stack` property, and Web IDL
+  // requires that DOMException get any non-standard properties that Error gets. Chrome honors
+  // this requirement only for runtime-generated DOMExceptions -- script-generated DOMExceptions
+  // don't get `stack`, even though script-generated Errors do. It's more convenient and, IMO,
+  // more conformant to just give all DOMExceptions a `stack` property.
+  jsg::check(v8::Exception::CaptureStackTrace(js.v8Context(), args.This()));
+
+  // This part is a bit of a hack. By default, the various properties on JavaScript errors
+  // are not enumerable. However, our implementation of DOMException has always defined
+  // them as enumerable, which means just setting the stack above would be a breaking change.
+  // To maintain backwards compat we have to define the stack as enumerable here.
+  v8::PropertyDescriptor prop;
+  prop.set_enumerable(true);
+  v8::Local<v8::String> stackName = js.str("stack"_kjc);
+  jsg::check(args.This()->DefineProperty(js.v8Context(), stackName, prop));
+
   return jsg::alloc<DOMException>(
       kj::mv(errMessage),
-      kj::mv(name).orDefault([] { return kj::str("Error"); }),
-      js.v8Ref(v8::Exception::Error(v8Str(js.v8Isolate, errMessage)).As<v8::Object>()));
+      kj::mv(name).orDefault([] { return kj::str("Error"); }));
 }
 
 kj::StringPtr DOMException::getName() {
@@ -41,12 +58,6 @@ int DOMException::getCode() {
   return 0;
 }
 
-v8::Local<v8::Value> DOMException::getStack(Lock& js) {
-  return js.v8Get(errorForStack.getHandle(js), "stack"_kj);
-}
-
-void DOMException::visitForGc(GcVisitor& visitor) {
-  visitor.visit(errorForStack);
-}
+void DOMException::visitForGc(GcVisitor& visitor) {}
 
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/dom-exception.h
+++ b/src/workerd/jsg/dom-exception.h
@@ -49,24 +49,19 @@ namespace workerd::jsg {
 // "DOMException".
 class DOMException: public Object {
 public:
-  DOMException(kj::String message,
-               kj::String name,
-               V8Ref<v8::Object> errorForStack)
+  DOMException(kj::String message, kj::String name)
       : message(kj::mv(message)),
-        name(kj::mv(name)),
-        errorForStack(kj::mv(errorForStack)) {}
+        name(kj::mv(name)) {}
 
   // JS API
 
-  static Ref<DOMException> constructor(Lock& js,
+  static Ref<DOMException> constructor(const v8::FunctionCallbackInfo<v8::Value>& args,
                                        Optional<kj::String> message,
                                        Optional<kj::String> name);
 
   kj::StringPtr getName();
   kj::StringPtr getMessage();
   int getCode();
-
-  v8::Local<v8::Value> getStack(Lock& js);
 
 #define JSG_DOM_EXCEPTION_CONSTANT_CXX(name, code, friendlyName) \
     static constexpr int name = code;
@@ -88,17 +83,6 @@ public:
     JSG_READONLY_INSTANCE_PROPERTY(name, getName);
     JSG_READONLY_INSTANCE_PROPERTY(code, getCode);
 
-    JSG_LAZY_READONLY_INSTANCE_PROPERTY(stack, getStack);
-    // V8 gives Error objects a non-standard (but widely known) `stack` property, and Web IDL
-    // requires that DOMException get any non-standard properties that Error gets. Chrome honors
-    // this requirement only for runtime-generated DOMExceptions -- script-generated DOMExceptions
-    // don't get `stack`, even though script-generated Errors do. It's more convenient and, IMO,
-    // more conformant to just give all DOMExceptions a `stack` property.
-    //
-    // Note that Chrome makes this a mutable property, presumably because Error properties are
-    // mutable in JavaScript. Maybe we should do that? It's easier to implement as a read-only
-    // property, though.
-
     // Declare static JS constants for every INDEX_SIZE_ERR, DOMSTRING_SIZE_ERR, etc.
     JSG_DOM_EXCEPTION_FOR_EACH_ERROR_NAME(JSG_DOM_EXCEPTION_CONSTANT_JS)
   }
@@ -109,16 +93,11 @@ public:
   void visitForMemoryInfo(MemoryTracker& tracker) const {
     tracker.trackField("message", message);
     tracker.trackField("name", name);
-    tracker.trackField("errorForStack", errorForStack);
   }
 
 private:
   kj::String message;
   kj::String name;
-
-  // We implement the `stack` property in a similarly hacky way as Chrome: store an Error object
-  // and use its `stack`.
-  V8Ref<v8::Object> errorForStack;
 
   void visitForGc(GcVisitor& visitor);
 };


### PR DESCRIPTION
To support adding the stack property to DOMException, we used to create a dummy internal Error object when the the DOMException was created. This is wasteful and requires an additional object allocation. Instead, let's tap into v8's built-in stack capture mechanism and and add the stack directly to the DOMException wrapper object.