### PR TITLE
JSRPC: Promise Pipelining (and property access)

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1878,7 +1878,8 @@ kj::Maybe<jsg::Ref<JsRpcProperty>> Fetcher::getRpcMethod(jsg::Lock& js, kj::Stri
   return jsg::alloc<JsRpcProperty>(JSG_THIS, kj::mv(name));
 }
 
-rpc::JsRpcTarget::Client Fetcher::getClientForOneCall(jsg::Lock& js) {
+rpc::JsRpcTarget::Client Fetcher::getClientForOneCall(
+    jsg::Lock& js, kj::Vector<kj::StringPtr>& path) {
   auto& ioContext = IoContext::current();
   auto worker = getClient(ioContext, kj::none, "jsRpcSession"_kjc);
   auto event = kj::heap<api::JsRpcSessionCustomEventImpl>(
@@ -1893,6 +1894,8 @@ rpc::JsRpcTarget::Client Fetcher::getClientForOneCall(jsg::Lock& js) {
   // caught elsewhere.
   ioContext.addTask(worker->customEvent(kj::mv(event)).attach(kj::mv(worker))
       .then([](auto&&) {}, [](kj::Exception&&) {}));
+
+  // (Don't extend `path` because we're the root.)
 
   return result;
 }

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1866,7 +1866,7 @@ jsg::Promise<jsg::Ref<Response>> Fetcher::fetch(
   return fetchImpl(js, JSG_THIS, kj::mv(requestOrUrl), kj::mv(requestInit));
 }
 
-kj::Maybe<jsg::Ref<JsRpcProperty>> Fetcher::getRpcMethod(jsg::Lock& js, kj::StringPtr name) {
+kj::Maybe<jsg::Ref<JsRpcProperty>> Fetcher::getRpcMethod(jsg::Lock& js, kj::String name) {
   // This is like JsRpcStub::getRpcMethod(), but we also initiate a whole new JS RPC session
   // each time the method is called (handled by `getClientForOneCall()`, below).
 
@@ -1875,7 +1875,7 @@ kj::Maybe<jsg::Ref<JsRpcProperty>> Fetcher::getRpcMethod(jsg::Lock& js, kj::Stri
   // with it, which is not what you want!
   if (name == "then"_kj) return kj::none;
 
-  return jsg::alloc<JsRpcProperty>(JSG_THIS, kj::str(name));
+  return jsg::alloc<JsRpcProperty>(JSG_THIS, kj::mv(name));
 }
 
 rpc::JsRpcTarget::Client Fetcher::getClientForOneCall(jsg::Lock& js) {

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -562,7 +562,8 @@ public:
     return getRpcMethod(js, kj::mv(name));
   }
 
-  rpc::JsRpcTarget::Client getClientForOneCall(jsg::Lock& js) override;
+  rpc::JsRpcTarget::Client getClientForOneCall(
+      jsg::Lock& js, kj::Vector<kj::StringPtr>& path) override;
 
   JSG_RESOURCE_TYPE(Fetcher, CompatibilityFlags::Reader flags) {
     // WARNING: New JSG_METHODs on Fetcher must be gated via compatibility flag to prevent

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -557,9 +557,9 @@ public:
 
   jsg::Promise<ScheduledResult> scheduled(jsg::Lock& js, jsg::Optional<ScheduledOptions> options);
 
-  kj::Maybe<jsg::Ref<JsRpcProperty>> getRpcMethod(jsg::Lock& js, kj::StringPtr name);
+  kj::Maybe<jsg::Ref<JsRpcProperty>> getRpcMethod(jsg::Lock& js, kj::String name);
   kj::Maybe<jsg::Ref<JsRpcProperty>> getRpcMethodForTestOnly(jsg::Lock& js, kj::String name) {
-    return getRpcMethod(js, name);
+    return getRpcMethod(js, kj::mv(name));
   }
 
   rpc::JsRpcTarget::Client getClientForOneCall(jsg::Lock& js) override;

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -388,6 +388,12 @@ export let receiveStubOverRpc = {
     let stub = await env.MyService.makeCounter(17);
     assert.strictEqual(await stub.increment(2), 19);
     assert.strictEqual(await stub.increment(-10), 9);
+
+    // Do multiple concurrent calls, they should be delivered in the order in which they were made.
+    let promise1 = stub.increment(6);
+    let promise2 = stub.increment(4);
+    let promise3 = stub.increment(3);
+    assert.deepEqual(await Promise.all([promise1, promise2, promise3]), [15, 19, 22]);
   },
 }
 

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -175,8 +175,7 @@ export let namedServiceBinding = {
     });
 
     let getByName = name => {
-      let func = env.MyService.getRpcMethodForTestOnly(name);
-      return func.bind(env.MyService);
+      return env.MyService.getRpcMethodForTestOnly(name);
     };
 
     // Check getRpcMethodForTestOnly() actually works.

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -119,6 +119,14 @@ export class MyService extends WorkerEntrypoint {
   get rejectingPromiseProperty() {
     return Promise.reject(new Error("REJECTED"));
   }
+
+  get throwingProperty() {
+    throw new Error("PROPERTY THREW");
+  }
+
+  throwingMethod() {
+    throw new Error("METHOD THREW");
+  }
 }
 
 export class MyActor extends DurableObject {
@@ -243,6 +251,15 @@ export let namedServiceBinding = {
     await assert.rejects(() => Promise.resolve(env.MyService.instanceObject), {
       name: "TypeError",
       message: "The RPC receiver does not implement the method \"instanceObject\"."
+    });
+
+    await assert.rejects(() => Promise.resolve(env.MyService.throwingProperty), {
+      name: "Error",
+      message: "PROPERTY THREW"
+    });
+    await assert.rejects(() => Promise.resolve(env.MyService.throwingMethod()), {
+      name: "Error",
+      message: "METHOD THREW"
     });
 
     await assert.rejects(() => Promise.resolve(env.MyService.rejectingPromiseProperty), {

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -86,6 +86,10 @@ export class MyService extends WorkerEntrypoint {
     return await counter.increment(i);
   }
 
+  async getAnObject(i) {
+    return {foo: 123 + i, counter: new MyCounter(i)};
+  }
+
   async fetch(req, x) {
     assert.strictEqual(x, undefined);
     return new Response("method = " + req.method + ", url = " + req.url);
@@ -384,5 +388,14 @@ export let receiveStubOverRpc = {
     let stub = await env.MyService.makeCounter(17);
     assert.strictEqual(await stub.increment(2), 19);
     assert.strictEqual(await stub.increment(-10), 9);
+  },
+}
+
+export let promisePipelining = {
+  async test(controller, env, ctx) {
+    assert.strictEqual(await env.MyService.makeCounter(12).increment(3), 15);
+
+    assert.strictEqual(await env.MyService.getAnObject(5).foo, 128);
+    assert.strictEqual(await env.MyService.getAnObject(5).counter.increment(7), 12);
   },
 }

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -202,13 +202,13 @@ rpc::JsRpcTarget::Client JsRpcStub::getClientForOneCall(jsg::Lock& js) {
 }
 
 kj::Maybe<jsg::Ref<JsRpcProperty>> JsRpcStub::getRpcMethod(
-    jsg::Lock& js, kj::StringPtr name) {
+    jsg::Lock& js, kj::String name) {
   // Do not return a method for `then`, otherwise JavaScript decides this is a thenable, i.e. a
   // custom Promise, which will mean a Promise that resolves to this object will attempt to chain
   // with it, which is not what you want!
   if (name == "then"_kj) return kj::none;
 
-  return jsg::alloc<JsRpcProperty>(JSG_THIS, kj::str(name));
+  return jsg::alloc<JsRpcProperty>(JSG_THIS, kj::mv(name));
 }
 
 void JsRpcStub::serialize(jsg::Lock& js, jsg::Serializer& serializer) {

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -264,7 +264,11 @@ public:
     return typeId;
   }
 
-  rpc::JsRpcTarget::Client getCap() { return clientCap; }
+  rpc::JsRpcTarget::Client getCap() {
+    auto result = kj::mv(KJ_ASSERT_NONNULL(clientCap, "can only call getCap() once"));
+    clientCap = kj::none;
+    return result;
+  }
 
   // Event ID for jsRpcSession.
   //
@@ -278,7 +282,7 @@ private:
 
   // We need to set the client/server capability on the event itself to get around CustomEvent's
   // limited return type.
-  rpc::JsRpcTarget::Client clientCap;
+  kj::Maybe<rpc::JsRpcTarget::Client> clientCap;
   uint16_t typeId;
 
   class ServerTopLevelMembrane;

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -144,7 +144,7 @@ public:
   // for testing to be able to construct a loopback stub.
   static jsg::Ref<JsRpcStub> constructor(jsg::Lock& js, jsg::Ref<JsRpcTarget> object);
 
-  kj::Maybe<jsg::Ref<JsRpcProperty>> getRpcMethod(jsg::Lock& js, kj::StringPtr name);
+  kj::Maybe<jsg::Ref<JsRpcProperty>> getRpcMethod(jsg::Lock& js, kj::String name);
 
   JSG_RESOURCE_TYPE(JsRpcStub) {
     JSG_WILDCARD_PROPERTY(getRpcMethod);

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -166,8 +166,14 @@ public:
   kj::Maybe<jsg::Ref<JsRpcProperty>> getProperty(jsg::Lock& js, kj::String name);
 
   JSG_RESOURCE_TYPE(JsRpcProperty) {
+    // You can call the property as a function. We'll assume it is a method in this case.
     JSG_CALLABLE(call);
+
+    // You can access further nested properties. We'll assume the property is an object in this
+    // case.
     JSG_WILDCARD_PROPERTY(getProperty);
+
+    // You can treat the property as a promise. This returns the value of the property.
     JSG_METHOD(then);
     JSG_METHOD_NAMED(catch, catch_);
     JSG_METHOD(finally);

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -220,11 +220,33 @@ struct JsValue {
 }
 
 interface JsRpcTarget {
-  call @0 (methodName :Text, args :JsValue) -> (result :JsValue);
+  struct CallParams {
+    union {
+      methodName @0 :Text;
+      # Equivalent to `methodPath` where the list has only one element equal to this.
+
+      methodPath @2 :List(Text);
+      # Path of properties to follow from the JsRpcTarget itself to find the method being called.
+      # E.g. if the application does:
+      #
+      #     myRpcTarget.foo.bar.baz()
+      #
+      # Then the path is ["foo", "bar", "baz"].
+      #
+      # The path can also be empty, which means that the JsRpcTarget itself is being invoked as a
+      # function.
+    }
+
+    args @1 :JsValue;
+    # Arguments to the function. This is a JsValue that always encodes a JavaScript Array
+    # containing the arguments to the call.
+    #
+    # If `args` is null (but is still the active member of the union), this indicates that the
+    # argument list is empty.
+  }
+
+  call @0 CallParams -> (result :JsValue);
   # Runs a Worker/DO's RPC method.
-  #
-  # `methodName` is the name of the method to run, and `args` is a JsValue that is always a
-  # JavaScript Array, containing the arguments to the call.
 }
 
 interface EventDispatcher @0xf20697475ec1752d {

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -266,8 +266,17 @@ interface JsRpcTarget {
     }
   }
 
-  call @0 CallParams -> (result :JsValue);
+  call @0 CallParams -> (result :JsValue, callPipeline :JsRpcTarget);
   # Runs a Worker/DO's RPC method.
+  #
+  # `callPipeline` allows the caller to begin sending other stuff before the callee has actually
+  # returned from the call. In particular:
+  # * The caller can make pipelined calls on the anticipated return value of the call, invoking
+  #   methods on capabilities that it expects will be present in the return value. Since
+  #   `CallPipeline` extends `JsRpcTarget`, these calls are made using callPipeline.call().
+  #   Typically these calls would use `methodPath` to specify a path to a specific subobject of
+  #   the returned value.
+  # * TODO(soon): streams
 }
 
 interface EventDispatcher @0xf20697475ec1752d {

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -237,12 +237,33 @@ interface JsRpcTarget {
       # function.
     }
 
-    args @1 :JsValue;
-    # Arguments to the function. This is a JsValue that always encodes a JavaScript Array
-    # containing the arguments to the call.
-    #
-    # If `args` is null (but is still the active member of the union), this indicates that the
-    # argument list is empty.
+    operation :union {
+      callWithArgs @1 :JsValue;
+      # Call the property as a function. This is a JsValue that always encodes a JavaScript Array
+      # containing the arguments to the call.
+      #
+      # If `callWithArgs` is null (but is still the active member of the union), this indicates
+      # that the argument list is empty.
+
+      getProperty @3 :Void;
+      # This indicates that we are not actually calling a method at all, but rather retrieving the
+      # value of a property. RPC classes are allowed to define properties that can be fetched
+      # asynchronously, although more commonly properties will be RPC targets themselves and their
+      # methods will be invoked by sending a `methodPath` with more than one element. That is,
+      # imagine you have:
+      #
+      #     myRpcTarget.foo.bar();
+      #
+      # This code makes a single RPC call with a path of ["foo", "bar"]. However, you could also
+      # write:
+      #
+      #     let foo = await myRpcTarget.foo;
+      #     foo.bar();
+      #
+      # This will make two separate calls. The first call is to "foo" and `getProperty` is used.
+      # This returns a new JsRpcTarget. The second call is on that target, invoking the method
+      # "bar".
+    }
   }
 
   call @0 CallParams -> (result :JsValue);

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -219,7 +219,7 @@ struct JsValue {
   }
 }
 
-interface JsRpcTarget {
+interface JsRpcTarget $Cxx.allowCancellation {
   struct CallParams {
     union {
       methodName @0 :Text;
@@ -314,7 +314,7 @@ interface EventDispatcher @0xf20697475ec1752d {
   # the success of the batch, including which messages should be considered acknowledged and which
   # should be retried.
 
-  jsRpcSession @9 () -> (topLevel :JsRpcTarget);
+  jsRpcSession @9 () -> (topLevel :JsRpcTarget) $Cxx.allowCancellation;
   # Opens a JS rpc "session". The call does not return until the session is complete.
   #
   # `topLevel` is the top-level RPC target, on which exactly one method call can be made. This

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -373,7 +373,7 @@ struct InterceptContext: public ContextGlobalObject {
     int getBar() { return 123; }
 
     // JSG_WILDCARD_PROPERTY implementation
-    kj::Maybe<kj::StringPtr> testGetNamed(jsg::Lock& js, kj::StringPtr name) {
+    kj::Maybe<kj::StringPtr> testGetNamed(jsg::Lock& js, kj::String name) {
       if (name == "foo") {
         return "bar"_kj;
       } else if (name == "abc") {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2392,6 +2392,9 @@ private:
   void* previousData;
 
   bool warningsLogged;
+
+  friend class JsObject;
+  virtual kj::Maybe<Object&> getInstance(v8::Local<v8::Object> obj, const std::type_info& type) = 0;
 };
 
 // Ensures that the given fn is run within both a handlescope and the context scope.

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -312,6 +312,20 @@ public:
 
 class JsObject final : public JsBase<v8::Object, JsObject> {
 public:
+  template <typename T>
+  bool isInstanceOf(Lock& js) {
+    return js.getInstance(inner, typeid(T)) != kj::none;
+  }
+
+  template <typename T>
+  kj::Maybe<jsg::Ref<T>> tryUnwrapAs(Lock& js) {
+    KJ_IF_SOME(ins, js.getInstance(inner, typeid(T))) {
+      return _jsgThis(static_cast<T*>(&ins));
+    } else {
+      return kj::none;
+    }
+  }
+
   void set(Lock& js, const JsValue& name, const JsValue& value);
   void set(Lock& js, kj::StringPtr name, const JsValue& value);
   JsValue get(Lock& js, const JsValue& name) KJ_WARN_UNUSED_RESULT;

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -645,9 +645,9 @@ template <typename TypeWrapper, typename T, typename GetNamedMethod, GetNamedMet
 struct WildcardPropertyCallbacks;
 
 template <typename TypeWrapper, typename T, typename U, typename Ret,
-          kj::Maybe<Ret> (U::*getNamedMethod)(jsg::Lock&, kj::StringPtr)>
+          kj::Maybe<Ret> (U::*getNamedMethod)(jsg::Lock&, kj::String)>
 struct WildcardPropertyCallbacks<
-    TypeWrapper, T, kj::Maybe<Ret> (U::*)(jsg::Lock&, kj::StringPtr), getNamedMethod>
+    TypeWrapper, T, kj::Maybe<Ret> (U::*)(jsg::Lock&, kj::String), getNamedMethod>
     : public v8::NamedPropertyHandlerConfiguration {
   WildcardPropertyCallbacks() : v8::NamedPropertyHandlerConfiguration(
     getter,

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -484,6 +484,18 @@ public:
 
   private:
     Isolate& jsgIsolate;
+
+    virtual kj::Maybe<Object&> getInstance(
+        v8::Local<v8::Object> obj, const std::type_info& type) override {
+      auto instance = v8::Local<v8::Object>(obj)->FindInstanceInPrototypeChain(
+          jsgIsolate.wrapper->getDynamicTypeInfo(v8Isolate, type).tmpl);
+      if (instance.IsEmpty()) {
+        return kj::none;
+      } else {
+        return *reinterpret_cast<Object*>(
+            instance->GetAlignedPointerFromInternalField(Wrappable::WRAPPED_OBJECT_FIELD_INDEX));
+      }
+    }
   };
 
   // The func must be a callback with the signature: void(jsg::Lock&)


### PR DESCRIPTION
You can now access properties on an RPC object by just awaiting them:

    let value = await stub.someProperty;

And you can access properties on a _promise_ returned by an RPC call, in order to make speculative calls on stubs that you expect to be returned:

    await stub.someMethod().someOtherMethod();

Both of these are achieved via custom thenables rather than regular promises. This allows us to return a value that can be awaited, but which also has a wildcard property.