### PR TITLE
Make broken prefix before jsg.Error for event timeouts.

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -488,8 +488,8 @@ kj::Promise<void> ServiceWorkerGlobalScope::eventTimeoutPromise(uint32_t timeout
   co_await IoContext::current().afterLimitTimeout(timeoutMs * kj::MILLISECONDS);
   // This is the ActorFlushReason for eviction in Cloudflare's internal implementation.
   auto evictionCode = 2;
-  actor.shutdown(evictionCode, JSG_KJ_EXCEPTION(DISCONNECTED, Error,
-    "broken.dropped; Actor exceeded event execution time and was disconnected."));
+  actor.shutdown(evictionCode, KJ_EXCEPTION(DISCONNECTED,
+    "broken.dropped; jsg.Error: Actor exceeded event execution time and was disconnected."));
 }
 
 kj::Promise<void> ServiceWorkerGlobalScope::setHibernatableEventTimeout(kj::Promise<void> event,


### PR DESCRIPTION
This PR changes prefix ordering for event timeout error messages, ensuring the brokenness reason comes before the `jsg.Error`.

We do this also in:
https://github.com/cloudflare/workerd/blob/9ea0e090d7f32e89239a6c687a25ef70376ea906/src/workerd/api/actor-state.c%2B%2B#L817-L836 