### PR TITLE
Add compatibility flag for queues JSON format by default

### DIFF
--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -5,6 +5,7 @@
 #include "queue.h"
 #include "util.h"
 
+#include <workerd/io/features.h>
 #include <workerd/jsg/buffersource.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/ser.h>
@@ -193,6 +194,9 @@ kj::Promise<void> WorkerQueue::send(jsg::Lock& js,
   KJ_IF_SOME(type, contentType) {
     headers.add("X-Msg-Fmt", type);
     serialized = serialize(js, body, type, SerializeArrayBufferBehavior::DEEP_COPY);
+  } else if (workerd::FeatureFlags::get(js).getQueuesJsonMessages()) {
+    headers.add("X-Msg-Fmt", IncomingQueueMessage::ContentType::JSON);
+    serialized = serialize(js, body, IncomingQueueMessage::ContentType::JSON, SerializeArrayBufferBehavior::DEEP_COPY);
   } else {
     // TODO(cleanup) send message format header (v8) by default
     serialized = serializeV8(js, body);
@@ -242,7 +246,11 @@ kj::Promise<void> WorkerQueue::sendBatch(jsg::Lock& js, jsg::Sequence<MessageSen
       item.contentType = validateContentType(contentType);
       item.body = serialize(js, body, contentType,
           SerializeArrayBufferBehavior::SHALLOW_REFERENCE);
-    } else {
+    } else if (workerd::FeatureFlags::get(js).getQueuesJsonMessages()) {
+      item.contentType = IncomingQueueMessage::ContentType::JSON;
+      item.body = serialize(js, body, IncomingQueueMessage::ContentType::JSON, SerializeArrayBufferBehavior::SHALLOW_REFERENCE);
+    }
+    else {
       item.body = serializeV8(js, body);
     }
 

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -377,4 +377,10 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatDisableFlag("no_nodejs_als");
   # Enables the availability of the Node.js AsyncLocalStorage API independently of the full
   # node.js compatibility option.
+
+  queuesJsonMessages @42 :Bool
+      $compatEnableFlag("queues_json_messages")
+      $compatDisableFlag("no_queues_json_messages")
+      $compatEnableDate("2024-03-04");
+  # Queues bindings serialize messages to JSON format by default (the previous default was v8 format)
 }


### PR DESCRIPTION
Adds a new compat flag + date to switch to JSON as the default message format for Queues.