### PR TITLE
MQ-498: Add support for delayed retries in Queues

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -2054,10 +2054,10 @@ jsg::Promise<Fetcher::QueueResult> Fetcher::queue(
       [event=kj::mv(event)](jsg::Lock& js, WorkerInterface::CustomEvent::Result result) {
     return Fetcher::QueueResult{
         .outcome=kj::str(result.outcome),
-        .retryAll=event->getRetryAll(),
         .ackAll=event->getAckAll(),
-        .explicitRetries=event->getExplicitRetries(),
+        .retryBatch=event->getRetryBatch(),
         .explicitAcks=event->getExplicitAcks(),
+        .retryMessages=event->getRetryMessages(),
     };
   });
 }

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -19,6 +19,7 @@
 #include "blob.h"
 #include <workerd/io/compatibility-date.capnp.h>
 #include "worker-rpc.h"
+#include "queue.h"
 
 namespace workerd::api {
 
@@ -530,16 +531,15 @@ public:
 
   struct QueueResult {
     kj::String outcome;
-    bool retryAll;
     bool ackAll;
-    kj::Array<kj::String> explicitRetries;
+    QueueRetryBatch retryBatch;
     kj::Array<kj::String> explicitAcks;
-
-    JSG_STRUCT(outcome, retryAll, ackAll, explicitRetries, explicitAcks);
+    kj::Array<QueueRetryMessage> retryMessages;
+    JSG_STRUCT(outcome, ackAll, retryBatch, explicitAcks, retryMessages);
   };
 
-  jsg::Promise<QueueResult> queue(
-      jsg::Lock& js, kj::String queueName, kj::Array<ServiceBindingQueueMessage> messages);
+  jsg::Promise<QueueResult> queue(jsg::Lock& js, kj::String queueName,
+                                  kj::Array<ServiceBindingQueueMessage> messages);
 
   struct ScheduledOptions {
     jsg::Optional<kj::Date> scheduledTime;

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -147,14 +147,31 @@ struct QueueMessage @0x944adb18c0352295 {
   contentType @3 :Text;
 }
 
+struct QueueRetryBatch {
+  retry @0 :Bool;
+  union {
+    undefined @1 :Void;
+    delaySeconds @2 :Int32;
+  }
+}
+
+struct QueueRetryMessage {
+  msgId @0 :Text;
+  union {
+    undefined @1 :Void;
+    delaySeconds @2 :Int32;
+  }
+}
+
 struct QueueResponse @0x90e98932c0bfc0de {
   outcome @0 :EventOutcome;
-  retryAll @1 :Bool;
-  ackAll @2 :Bool;
-  explicitRetries @3 :List(Text);
-  # List of Message IDs that were explicitly marked for retry
-  explicitAcks @4 :List(Text);
-  # List of Message IDs that were explicitly marked as acknowledged
+  ackAll @1 :Bool;
+  retryBatch @2 :QueueRetryBatch;
+  # Retry options for the batch.
+  explicitAcks @3 :List(Text);
+  # List of Message IDs that were explicitly marked as acknowledged.
+  retryMessages @4 :List(QueueRetryMessage);
+  # List of retry options for messages that were explicitly marked for retry.
 }
 
 struct HibernatableWebSocketEventMessage {


### PR DESCRIPTION
This patch updates the queues api so that a delay value can be specified (from the consumer side) when retrying a batch or a message. Existing retry fields in capnp structs were maintained to prevent breaking changes. These fields are consolidated with the new ones on the broker side.