### PR TITLE
Simplify access to env parameter from fastapi

### DIFF
--- a/samples/pyodide-fastapi/config.capnp
+++ b/samples/pyodide-fastapi/config.capnp
@@ -19,7 +19,13 @@ const mainWorker :Workerd.Worker = (
   modules = [
     (name = "worker.py", pythonModule = embed "./worker.py"),
     (name = "fastapi", pythonRequirement = ""),
-    (name = "ssl", pythonRequirement = ""),
+    (name = "anyio", pythonRequirement = ""),
+  ],
+  bindings = [
+    (
+      name = "secret",
+      text = "thisisasecret"
+    ),
   ],
   compatibilityDate = "2023-12-18",
   compatibilityFlags = ["python_workers"],

--- a/samples/pyodide-fastapi/worker.py
+++ b/samples/pyodide-fastapi/worker.py
@@ -1,7 +1,9 @@
+from asgi import env
+
 async def on_fetch(request):
     import asgi
 
-    return await asgi.fetch(app, request)
+    return await asgi.fetch(app, request, env)
 
 
 def test():
@@ -14,21 +16,20 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 
 
-my_awesome_api = FastAPI()
-app = my_awesome_api
+app = FastAPI()
 
 
-@my_awesome_api.get("/hello")
-async def root():
-    return {"message": "Hello World"}
+@app.get("/hello")
+async def root(env=env):
+    return {"message": "Hello World", "secret": env.secret}
 
 
-@my_awesome_api.get("/route")
+@app.get("/route")
 async def root():
     return {"message": "this is my custom route"}
 
 
-@my_awesome_api.get("/favicon.ico")
+@app.get("/favicon.ico")
 async def root():
     return {"message": "here's a favicon I guess?"}
 


### PR DESCRIPTION
According to the suggestion I got here:
https://github.com/tiangolo/fastapi/discussions/11219#discussioncomment-8625938 this makes it possible to get access to `env` in fastapi as follows:
```py
from asgi import env

@app.get("/hello")
async def root(env=env):
    return {"message": "Hello World", "secret": env.secret}
```