### PR TITLE
Adds python_workers compatibility flag

### DIFF
--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -156,11 +156,12 @@ jsg::Ref<PyodideMetadataReader> makePyodideMetadataReader(Worker::Reader conf);
   api::pyodide::ArtifactBundler
 
 template <class Registry> void registerPyodideModules(Registry& registry, auto featureFlags) {
-  if (featureFlags.getWorkerdExperimental()) {
+  if (featureFlags.getPythonWorkers()) {
+    // We add `pyodide:` packages here including python-entrypoint-helper.js.
     registry.addBuiltinBundle(PYODIDE_BUNDLE, kj::none);
+    registry.template addBuiltinModule<PackagesTarReader>(
+        "pyodide-internal:packages_tar_reader", workerd::jsg::ModuleRegistry::Type::INTERNAL);
   }
-  registry.template addBuiltinModule<PackagesTarReader>(
-      "pyodide-internal:packages_tar_reader", workerd::jsg::ModuleRegistry::Type::INTERNAL);
 }
 
 } // namespace workerd::api::pyodide

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -383,4 +383,11 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatDisableFlag("no_queues_json_messages")
       $compatEnableDate("2024-03-18");
   # Queues bindings serialize messages to JSON format by default (the previous default was v8 format)
+
+  pythonWorkers @43 :Bool
+      $compatEnableFlag("python_workers");
+  # Enables Python Workers. Access to this flag is not restricted, instead bundles containing
+  # Python modules are restricted in EWC.
+  #
+  # WARNING: Python Workers are still an experimental feature and thus subject to change.
 }

--- a/src/workerd/server/tests/python/env-param/env.wd-test
+++ b/src/workerd/server/tests/python/env-param/env.wd-test
@@ -14,7 +14,7 @@ const unitTests :Workerd.Config = (
           ),
         ],
         compatibilityDate = "2024-01-15",
-        compatibilityFlags = ["experimental"],
+        compatibilityFlags = ["python_workers"],
       )
     ),
   ],

--- a/src/workerd/server/tests/python/hello/hello.wd-test
+++ b/src/workerd/server/tests/python/hello/hello.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker.py", pythonModule = embed "worker.py")
         ],
         compatibilityDate = "2024-01-15",
-        compatibilityFlags = ["experimental"],
+        compatibilityFlags = ["python_workers"],
       )
     ),
   ],

--- a/src/workerd/server/tests/python/langchain/langchain.wd-test
+++ b/src/workerd/server/tests/python/langchain/langchain.wd-test
@@ -12,7 +12,7 @@ const unitTests :Workerd.Config = (
           (name = "openai==0.28.1", pythonRequirement = ""),
         ],
         compatibilityDate = "2024-01-15",
-        compatibilityFlags = ["experimental"],
+        compatibilityFlags = ["python_workers"],
       )
     ),
   ],

--- a/src/workerd/server/tests/python/subdirectory/subdirectory.wd-test
+++ b/src/workerd/server/tests/python/subdirectory/subdirectory.wd-test
@@ -10,7 +10,7 @@ const unitTests :Workerd.Config = (
           (name = "subdir/a.py", pythonModule = embed "./subdir/a.py"),
         ],
         compatibilityDate = "2023-12-18",
-        compatibilityFlags = ["experimental"],
+        compatibilityFlags = ["python_workers"],
       )
     ),
   ],

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -382,8 +382,8 @@ void WorkerdApi::compileModules(
     using namespace workerd::api::pyodide;
     auto featureFlags = getFeatureFlags();
     if (hasPythonModules(confModules)) {
-      KJ_REQUIRE(featureFlags.getWorkerdExperimental(),
-          "The experimental compatibility flag is required to use Python.");
+      KJ_REQUIRE(featureFlags.getPythonWorkers(),
+          "The python_workers compatibility flag is required to use Python.");
       // Inject pyodide bootstrap module.
       {
         auto mainModule = confModules.begin();


### PR DESCRIPTION
This is necessary in order to allow upload for non-cloudflare users. This is safe because EWC has custom logic for blocking the upload of bundles containing Python modules, so only certain users will be allowed to upload.