### PR TITLE
Remove cache individual PUT size limit

### DIFF
--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -728,7 +728,6 @@ private:
 
   constexpr static size_t GB = 1 << 30;
   constexpr static size_t MAX_TOTAL_PUT_SIZE = 5 * GB;
-  constexpr static size_t MAX_INDIVIDUAL_PUT_SIZE = 5 * GB;
   kj::Promise<size_t> cachePutQuota = MAX_TOTAL_PUT_SIZE;
 
   kj::TaskSet waitUntilTasks;


### PR DESCRIPTION
- The total PUT size limit for a worker request continues to apply.

Note that this is effectively a NO-OP since the individual and total PUT limit are identical. Merging this first will still help us make the total PUT limit configurable – ongoing work is on the `felix/cache-put-limit` branch here and in the internal repository, but being familiar with it shouldn't be needed to review this PR.
Also updates an outdated comment, the put size limit has been 5GB for a while.