### PR TITLE
Greatly simplify JS-backed ReadableStreams AllReader

### DIFF
--- a/src/workerd/api/streams/standard-test.c++
+++ b/src/workerd/api/streams/standard-test.c++
@@ -1,0 +1,865 @@
+#include "standard.h"
+#include "readable.h"
+#include <workerd/jsg/jsg.h>
+#include <workerd/jsg/jsg-test.h>
+#include <workerd/jsg/observer.h>
+
+namespace workerd::api {
+namespace {
+
+jsg::V8System v8System;
+
+struct RsContext: public jsg::Object, public jsg::ContextGlobal {
+  JSG_RESOURCE_TYPE(RsContext) {}
+};
+JSG_DECLARE_ISOLATE_TYPE(RsIsolate, RsContext, ReadResult);
+
+void preamble(auto callback) {
+  RsIsolate isolate(v8System, kj::heap<jsg::IsolateObserver>());
+  isolate.runInLockScope([&](RsIsolate::Lock& lock) {
+    JSG_WITHIN_CONTEXT_SCOPE(lock,
+        lock.newContext<RsContext>().getHandle(lock),
+        [&](jsg::Lock& js) {
+      callback(js);
+    });
+  });
+}
+
+v8::Local<v8::Value> toBytes(jsg::Lock& js, kj::String str) {
+  return jsg::BackingStore::from(str.asBytes().attach(kj::mv(str))).createHandle(js);
+}
+
+jsg::BufferSource toBufferSource(jsg::Lock& js, kj::String str) {
+  auto backing = jsg::BackingStore::from(str.asBytes().attach(kj::mv(str))).createHandle(js);
+  return jsg::BufferSource(js, kj::mv(backing));
+}
+
+jsg::BufferSource toBufferSource(jsg::Lock& js, kj::Array<kj::byte> bytes) {
+  auto backing = jsg::BackingStore::from(kj::mv(bytes)).createHandle(js);
+  return jsg::BufferSource(js, kj::mv(backing));
+}
+
+// ======================================================================================
+// Happy Cases
+
+KJ_TEST("ReadableStream read all text (value readable)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    rs->getController().setup(js, UnderlyingSource {
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        // Because we're using a value-based stream, two enqueue operations will
+        // require at least three reads to complete: one for the first chunk, 'hello, ',
+        // one for the second chunk, 'world!', and one to signal close.
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
+            checked++;
+            c->enqueue(js, toBytes(js, kj::str("Hello, ")));
+            c->enqueue(js, toBytes(js, kj::str("world!")));
+            c->close(js);
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
+        }
+        KJ_UNREACHABLE;
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllText(js, 20)
+      .then(js, [&](jsg::Lock& js, kj::String&& text) {
+        KJ_ASSERT(text == "Hello, world!"_kjc);
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 2);
+
+    // Reading everything successfully should cause the stream to close.
+    KJ_ASSERT(rs->getController().isClosed());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+KJ_TEST("ReadableStream read all text, rs ref held (value readable)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    rs->getController().setup(js, UnderlyingSource {
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        // Because we're using a value-based stream, two enqueue operations will
+        // require at least three reads to complete: one for the first chunk, 'hello, ',
+        // one for the second chunk, 'world!', and one to signal close.
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
+            checked++;
+            c->enqueue(js, toBytes(js, kj::str("Hello, ")));
+            c->enqueue(js, toBytes(js, kj::str("world!")));
+            c->close(js);
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
+        }
+        KJ_UNREACHABLE;
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllText(js, 20)
+      .then(js, [&](jsg::Lock& js, kj::String&& text) {
+        KJ_ASSERT(text == "Hello, world!"_kjc);
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Let's drop our ref to rs, things should still work as expected.
+    { auto drop = kj::mv(rs); }
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 2);
+  });
+}
+
+KJ_TEST("ReadableStream read all text (byte readable)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    rs->getController().setup(js, UnderlyingSource {
+      .type = kj::str("bytes"),
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        // Because we're using a value-based stream, two enqueue operations will
+        // require at least three reads to complete: one for the first chunk, 'hello, ',
+        // one for the second chunk, 'world!', and one to signal close.
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
+            checked++;
+            c->enqueue(js, toBufferSource(js, kj::str("Hello, ")));
+            c->enqueue(js, toBufferSource(js, kj::str("world!")));
+            c->close(js);
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
+        }
+        KJ_UNREACHABLE;
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllText(js, 20)
+      .then(js, [&](jsg::Lock& js, kj::String&& text) {
+        KJ_ASSERT(text == "Hello, world!"_kjc);
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 2);
+
+    // Reading everything successfully should cause the stream to close.
+    KJ_ASSERT(rs->getController().isClosed());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+KJ_TEST("ReadableStream read all bytes (value readable)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    rs->getController().setup(js, UnderlyingSource {
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        // Because we're using a value-based stream, two enqueue operations will
+        // require at least three reads to complete: one for the first chunk, 'hello, ',
+        // one for the second chunk, 'world!', and one to signal close.
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
+            checked++;
+            c->enqueue(js, toBytes(js, kj::str("Hello, ")));
+            c->enqueue(js, toBytes(js, kj::str("world!")));
+            c->close(js);
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
+        }
+        KJ_UNREACHABLE;
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllBytes(js, 20)
+      .then(js, [&](jsg::Lock& js, kj::Array<kj::byte>&& text) {
+        KJ_ASSERT(text == "Hello, world!"_kjc.asBytes());
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 2);
+
+    // Reading everything successfully should cause the stream to close.
+    KJ_ASSERT(rs->getController().isClosed());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+KJ_TEST("ReadableStream read all bytes (byte readable)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    rs->getController().setup(js, UnderlyingSource {
+      .type = kj::str("bytes"),
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        // Because we're using a value-based stream, two enqueue operations will
+        // require at least three reads to complete: one for the first chunk, 'hello, ',
+        // one for the second chunk, 'world!', and one to signal close.
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
+            checked++;
+            c->enqueue(js, toBufferSource(js, kj::str("Hello, ")));
+            c->enqueue(js, toBufferSource(js, kj::str("world!")));
+            c->close(js);
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
+        }
+        KJ_UNREACHABLE;
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllBytes(js, 20)
+      .then(js, [&](jsg::Lock& js, kj::Array<kj::byte>&& text) {
+        KJ_ASSERT(text == "Hello, world!"_kjc.asBytes());
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 2);
+
+    // Reading everything successfully should cause the stream to close.
+    KJ_ASSERT(rs->getController().isClosed());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+KJ_TEST("ReadableStream read all bytes (value readable, more reads)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    uint counter = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    auto chunks = kj::arr<kj::String>(
+      kj::str("H"),
+      kj::str("e"),
+      kj::str("l"),
+      kj::str("l"),
+      kj::str("o"),
+      kj::str(","),
+      kj::str(" "),
+      kj::str("w"),
+      kj::str("o"),
+      kj::str("r"),
+      kj::str("l"),
+      kj::str("d"),
+      kj::str("!")
+    );
+    rs->getController().setup(js, UnderlyingSource {
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        // Because we're using a value-based stream, two enqueue operations will
+        // require at least three reads to complete: one for the first chunk, 'hello, ',
+        // one for the second chunk, 'world!', and one to signal close.
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
+            checked++;
+            c->enqueue(js, toBytes(js, kj::mv(chunks[counter++])));
+            if (counter == chunks.size()) {
+              c->close(js);
+            }
+
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
+        }
+        KJ_UNREACHABLE;
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllBytes(js, 20)
+      .then(js, [&](jsg::Lock& js, kj::Array<kj::byte>&& text) {
+        KJ_ASSERT(text == "Hello, world!"_kjc.asBytes());
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 14);
+
+    // Reading everything successfully should cause the stream to close.
+    KJ_ASSERT(rs->getController().isClosed());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+KJ_TEST("ReadableStream read all bytes (byte readable, more reads)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    uint counter = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    auto chunks = kj::arr<kj::String>(
+      kj::str("H"),
+      kj::str("e"),
+      kj::str("l"),
+      kj::str("l"),
+      kj::str("o"),
+      kj::str(","),
+      kj::str(" "),
+      kj::str("w"),
+      kj::str("o"),
+      kj::str("r"),
+      kj::str("l"),
+      kj::str("d"),
+      kj::str("!")
+    );
+    rs->getController().setup(js, UnderlyingSource {
+      .type = kj::str("bytes"),
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        // Because we're using a value-based stream, two enqueue operations will
+        // require at least three reads to complete: one for the first chunk, 'hello, ',
+        // one for the second chunk, 'world!', and one to signal close.
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
+            checked++;
+            c->enqueue(js, toBufferSource(js, kj::mv(chunks[counter++])));
+            if (counter == chunks.size()) {
+              c->close(js);
+            }
+
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
+        }
+        KJ_UNREACHABLE;
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllBytes(js, 20)
+      .then(js, [&](jsg::Lock& js, kj::Array<kj::byte>&& text) {
+        KJ_ASSERT(text == "Hello, world!"_kjc.asBytes());
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 14);
+
+    // Reading everything successfully should cause the stream to close.
+    KJ_ASSERT(rs->getController().isClosed());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+KJ_TEST("ReadableStream read all bytes (byte readable, large data)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    uint counter = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    static constexpr uint BASE = 4097;
+    auto chunks = kj::arr<kj::Array<kj::byte>>(
+      kj::heapArray<kj::byte>(BASE),
+      kj::heapArray<kj::byte>(BASE * 2),
+      kj::heapArray<kj::byte>(BASE * 4)
+    );
+    memset(chunks[0].begin(), 'A', chunks[0].size());
+    memset(chunks[1].begin(), 'B', chunks[1].size());
+    memset(chunks[2].begin(), 'C', chunks[2].size());
+    rs->getController().setup(js, UnderlyingSource {
+      .type = kj::str("bytes"),
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        // Because we're using a value-based stream, two enqueue operations will
+        // require at least three reads to complete: one for the first chunk, 'hello, ',
+        // one for the second chunk, 'world!', and one to signal close.
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
+            checked++;
+            c->enqueue(js, toBufferSource(js, kj::mv(chunks[counter++])));
+            if (counter == chunks.size()) {
+              c->close(js);
+            }
+
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
+        }
+        KJ_UNREACHABLE;
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllBytes(js, (BASE * 7) + 1)
+      .then(js, [&](jsg::Lock& js, kj::Array<kj::byte>&& text) {
+        kj::byte check[BASE * 7];
+        memset(&check[0], 'A', BASE);
+        memset(&check[0] + BASE, 'B', BASE * 2);
+        memset(&check[0] + (BASE * 3), 'C', BASE * 4);
+        KJ_ASSERT(text.size() == BASE * 7);
+        KJ_ASSERT(check == text);
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 4);
+
+    // Reading everything successfully should cause the stream to close.
+    KJ_ASSERT(rs->getController().isClosed());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+// ======================================================================================
+// Fail cases
+
+KJ_TEST("ReadableStream read all bytes (value readable, wrong type)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    rs->getController().setup(js, UnderlyingSource {
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        // Because we're using a value-based stream, two enqueue operations will
+        // require at least three reads to complete: one for the first chunk, 'hello, ',
+        // one for the second chunk, 'world!', and one to signal close.
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
+            c->enqueue(js, js.str("wrong type"_kjc));
+            checked++;
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
+        }
+        KJ_UNREACHABLE;
+      },
+      .cancel = [&](jsg::Lock& js, auto reason) -> jsg::Promise<void> {
+        KJ_ASSERT(kj::str(reason) == "TypeError: This ReadableStream did not return bytes.");
+        checked++;
+        return js.resolvedPromise();
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllBytes(js, 20)
+      .then(js, [](jsg::Lock& js, kj::Array<kj::byte>&& text) {
+        KJ_UNREACHABLE;
+      }, [&](jsg::Lock& js, jsg::Value&& exception) {
+        KJ_ASSERT(kj::str(exception.getHandle(js)) ==
+            "TypeError: This ReadableStream did not return bytes.");
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 3);
+
+    KJ_ASSERT(rs->getController().isClosedOrErrored());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+KJ_TEST("ReadableStream read all bytes (value readable, to many bytes)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    rs->getController().setup(js, UnderlyingSource {
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        // Because we're using a value-based stream, two enqueue operations will
+        // require at least three reads to complete: one for the first chunk, 'hello, ',
+        // one for the second chunk, 'world!', and one to signal close.
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
+            c->enqueue(js, toBytes(js, kj::str("123456789012345678901")));
+            checked++;
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
+        }
+        KJ_UNREACHABLE;
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllBytes(js, 20)
+      .then(js, [](jsg::Lock& js, kj::Array<kj::byte>&& text) {
+        KJ_UNREACHABLE;
+      }, [&](jsg::Lock& js, jsg::Value&& exception) {
+        KJ_ASSERT(kj::str(exception.getHandle(js)) ==
+            "TypeError: Memory limit exceeded before EOF.");
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 2);
+
+    KJ_ASSERT(rs->getController().isClosedOrErrored());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+KJ_TEST("ReadableStream read all bytes (byte readable, to many bytes)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    rs->getController().setup(js, UnderlyingSource {
+      .type = kj::str("bytes"),
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        // Because we're using a value-based stream, two enqueue operations will
+        // require at least three reads to complete: one for the first chunk, 'hello, ',
+        // one for the second chunk, 'world!', and one to signal close.
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
+            c->enqueue(js, toBufferSource(js, kj::str("123456789012345678901")));
+            checked++;
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
+        }
+        KJ_UNREACHABLE;
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllBytes(js, 20)
+      .then(js, [](jsg::Lock& js, kj::Array<kj::byte>&& text) {
+        KJ_UNREACHABLE;
+      }, [&](jsg::Lock& js, jsg::Value&& exception) {
+        KJ_ASSERT(kj::str(exception.getHandle(js)) ==
+            "TypeError: Memory limit exceeded before EOF.");
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 2);
+
+    KJ_ASSERT(rs->getController().isClosedOrErrored());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+KJ_TEST("ReadableStream read all bytes (byte readable, failed read)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    rs->getController().setup(js, UnderlyingSource {
+      .type = kj::str("bytes"),
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        checked++;
+        return js.rejectedPromise<void>(js.error("boom"));
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllBytes(js, 20)
+      .then(js, [](jsg::Lock& js, kj::Array<kj::byte>&& text) {
+        KJ_UNREACHABLE;
+      }, [&](jsg::Lock& js, jsg::Value&& exception) {
+        KJ_ASSERT(kj::str(exception.getHandle(js)) == "Error: boom");
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 2);
+
+    KJ_ASSERT(rs->getController().isClosedOrErrored());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+KJ_TEST("ReadableStream read all bytes (value readable, failed read)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    rs->getController().setup(js, UnderlyingSource {
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        checked++;
+        return js.rejectedPromise<void>(js.error("boom"));
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllBytes(js, 20)
+      .then(js, [](jsg::Lock& js, kj::Array<kj::byte>&& text) {
+        KJ_UNREACHABLE;
+      }, [&](jsg::Lock& js, jsg::Value&& exception) {
+        KJ_ASSERT(kj::str(exception.getHandle(js)) == "Error: boom");
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 2);
+
+    KJ_ASSERT(rs->getController().isClosedOrErrored());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+KJ_TEST("ReadableStream read all bytes (byte readable, failed start)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    rs->getController().setup(js, UnderlyingSource {
+      .type = kj::str("bytes"),
+      .start = [&](jsg::Lock& js, UnderlyingSource::Controller controller) -> jsg::Promise<void> {
+        checked++;
+        return js.rejectedPromise<void>(js.error("boom"));
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllBytes(js, 20)
+      .then(js, [](jsg::Lock& js, kj::Array<kj::byte>&& text) {
+        KJ_UNREACHABLE;
+      }, [&](jsg::Lock& js, jsg::Value&& exception) {
+        KJ_ASSERT(kj::str(exception.getHandle(js)) == "Error: boom");
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 2);
+
+    KJ_ASSERT(rs->getController().isClosedOrErrored());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+KJ_TEST("ReadableStream read all bytes (byte readable, failed start 2)") {
+  preamble([](jsg::Lock& js) {
+    uint checked = 0;
+    auto rs = jsg::alloc<ReadableStream>(newReadableStreamJsController());
+    rs->getController().setup(js, UnderlyingSource {
+      .type = kj::str("bytes"),
+      .start = [&](jsg::Lock& js, UnderlyingSource::Controller controller) -> jsg::Promise<void> {
+        checked++;
+        JSG_FAIL_REQUIRE(Error, "boom");
+      }
+    // Setting a highWaterMark of 0 means the pull function above will not be called
+    // immediately on creation of the stream, but only when the first read in the
+    // readall call below happens.
+    }, StreamQueuingStrategy { .highWaterMark = 0 });
+
+    // Starts a read loop of javascript promises.
+    auto promise = rs->getController().readAllBytes(js, 20)
+      .then(js, [](jsg::Lock& js, kj::Array<kj::byte>&& text) {
+        KJ_UNREACHABLE;
+      }, [&](jsg::Lock& js, jsg::Value&& exception) {
+        KJ_ASSERT(kj::str(exception.getHandle(js)) == "Error: boom");
+        checked++;
+      });
+
+    // Reading left the stream locked and disturbed
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+
+    // Run the microtasks to completion. This should resolve the promise and
+    // run it to completion. The test is buggy if it fails to do so.
+    js.runMicrotasks();
+    KJ_ASSERT(checked == 2);
+
+    KJ_ASSERT(rs->getController().isClosedOrErrored());
+
+    // Add we should still be locked and disturbed.
+    KJ_ASSERT(rs->isLocked());
+    KJ_ASSERT(rs->isDisturbed());
+  });
+}
+
+}  // namespace
+}  // namespace workerd::api

--- a/src/workerd/api/tests/streams-test.js
+++ b/src/workerd/api/tests/streams-test.js
@@ -112,6 +112,153 @@ export const cancelWriteOnReleaseLock = {
   }
 };
 
+export const readAllTextRequestSmall = {
+  async test() {
+    const rs = new ReadableStream({
+      pull(c) {
+        c.enqueue(enc.encode('hello '));
+        c.enqueue(enc.encode('world!'));
+        c.close();
+      }
+    });
+    const request = new Request('http://example.org', { method: 'POST', body: rs });
+    const text = await request.text();
+    strictEqual(text, 'hello world!');
+  }
+};
+
+export const readAllTextResponseSmall = {
+  async test() {
+    const rs = new ReadableStream({
+      pull(c) {
+        c.enqueue(enc.encode('hello '));
+        c.enqueue(enc.encode('world!'));
+        c.close();
+      }
+    });
+    const response = new Response(rs);
+    const text = await response.text();
+    strictEqual(text, 'hello world!');
+  }
+};
+
+export const readAllTextRequestBig = {
+  async test() {
+    const chunks = [
+      'a'.repeat(4097),
+      'b'.repeat(4097 * 2),
+      'c'.repeat(4097 * 4),
+    ];
+    let check = '';
+    const enc = new TextEncoder();
+
+    const rs = new ReadableStream({
+      pull(c) {
+        if (chunks.length === 0) {
+          c.close();
+          return;
+        }
+        const chunk = chunks.shift();
+        check += chunk;
+        c.enqueue(enc.encode(chunk));
+      }
+    });
+    const request = new Request('http://example.org', { method: 'POST', body: rs });
+    const text = await request.text();
+    strictEqual(text.length, check.length);
+    strictEqual(text, check);
+  }
+};
+
+export const readAllTextResponseBig = {
+  async test() {
+    const chunks = [
+      'a'.repeat(4097),
+      'b'.repeat(4097 * 2),
+      'c'.repeat(4097 * 4),
+    ];
+    let check = '';
+    const enc = new TextEncoder();
+
+    const rs = new ReadableStream({
+      async pull(c) {
+        await scheduler.wait(10);
+        if (chunks.length === 0) {
+          c.close();
+          return;
+        }
+        const chunk = chunks.shift();
+        check += chunk;
+        c.enqueue(enc.encode(chunk));
+      }
+    });
+    const response = new Response(rs);
+    const promise = response.text();
+    const text = await promise;
+    strictEqual(text.length, check.length);
+    strictEqual(text, check);
+  }
+};
+
+export const readAllTextFailedPull = {
+  async test() {
+    const rs = new ReadableStream({
+      async pull(c) {
+        await scheduler.wait(10);
+        throw new Error('boom');
+      }
+    });
+    const response = new Response(rs);
+    const promise = response.text();
+    try {
+      await promise;
+      throw new Error('error was expected');
+    } catch (err) {
+      strictEqual(err.message, 'boom');
+    }
+  }
+};
+
+export const readAllTextFailedStart = {
+  async test() {
+    const rs = new ReadableStream({
+      async start(c) {
+        await scheduler.wait(10);
+        throw new Error('boom');
+      }
+    });
+    const response = new Response(rs);
+    const promise = response.text();
+    try {
+      await promise;
+      throw new Error('error was expected');
+    } catch (err) {
+      strictEqual(err.message, 'boom');
+    }
+  }
+};
+
+export const readAllTextFailed = {
+  async test() {
+    const rs = new ReadableStream({
+      async start(c) {
+        await scheduler.wait(10);
+        c.error(new Error('boom'));
+      }
+    });
+    const response = new Response(rs);
+    ok(!rs.locked);
+    const promise = response.text();
+    ok(rs.locked);
+    try {
+      await promise;
+      throw new Error('error was expected');
+    } catch (err) {
+      strictEqual(err.message, 'boom');
+    }
+  }
+};
+
 export default {
   async fetch(request, env) {
     strictEqual(request.headers.get('content-length'), '10');


### PR DESCRIPTION
The internal implementation of the JS-backed streams is rather overly complicated and has a few design flaws that make it difficult to debug and maintain. This, coupled with tests scattered across multiple repos with incomplete coverage. It's time to simplify the implementation and improve test coverage. This is the first of several clean up steps that will greatly simplify a number of cases. This commit focuses on one specific internal bit, follow on commits will touch other pieces. The plan is to do this as incrementally as possible spread over some time to ensure things don't break. The incomplete test coverage makes things a bit difficult so that will be a key focus.

Currently in a JS-backed `ReadableStream`, we have an underlying `ReadableStreamJsController` that has either a `kj::Own<ValueReadable>` or `kj::Own<ByteReadable>`. This owns a ref to the underlying `ReadableStreamDefaultController` or `ReadableByteStreamController` that actually provides the data along with a `kj::Own<Queue::Consumer>` that consumes the data from the underlying controller. In the existing design, we were rather needlessly passing ownership of the `ValueReadable` and `ByteReadable` to the `AllReader`. This proves to be problematic and unnecessary. Problematic because these are gc visitable types and changing the ownership ends up making the gc visitation semantics unnecessarily complicated and easy to get wrong (as a few recent fixed bugs demonstrate). Unnecessary because we can simply read directly from the `ReadableStream` instance itself without actually changing ownership of anything. The prior design was the result of a premature attempt at optimization that was completely unnecessary -- especially given the way v8 is able to optimistically gc the `ReadableStream` JS wrapper class.

This commit simplifies the `AllReader` to directly read from the `ReadableStream`. Rather than moving the `kj::Own<ValueReadable>` or `kj::Own<ByteReadable>` into the `AllReader`, we simply pass a jsg::Ref to the `ReadableStream` and read directly from it. We also remove some unnecessary book keeping around pending state changes since we only do serialized reads and can detect the state changes reliably when those complete. The commit also eliminates some duplication of the code to further simplify. Soon I will make a similar change to the `PumpToReader` and the couple of other places where we currently move the `kj::Own<ValueReadable>` and `kj::Own<ByteReadable>` out of the readable stream -- essentially the idea is through a couple of incremental PRs, completely eliminate moving that out.

The majority of added lines in this commit are in the form of new tests. The new tests (a set of c++ tests and new js tests) demonstrate the area of the api that is impacted by this commit.

A future new set of tests will seek to concretely and reliably verify the gc characteristics of the entire streams implementation.