### PR TITLE
JSRPC: Support "serializing" functions by turning them into stubs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -450,6 +450,7 @@ http_archive(
         "//:patches/v8/0012-Always-enable-continuation-preserved-data-in-the-bui.patch",
         "//:patches/v8/0013-Attach-continuation-context-to-Promise-thenable-task.patch",
         "//:patches/v8/0014-increase-visibility-of-virtual-method.patch",
+        "//:patches/v8/0015-Add-ValueSerializer-SetTreatFunctionsAsHostObjects.patch",
     ],
     integrity = "sha256-jcBk1hBhzrMHRL0EDTgHKBVrJPsP1SLZL6A5/l6arrs=",
     strip_prefix = "v8-12.2.281.18",

--- a/patches/v8/0015-Add-ValueSerializer-SetTreatFunctionsAsHostObjects.patch
+++ b/patches/v8/0015-Add-ValueSerializer-SetTreatFunctionsAsHostObjects.patch
@@ -1,0 +1,103 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kenton Varda <kenton@cloudflare.com>
+Date: Sat, 2 Mar 2024 09:00:18 -0600
+Subject: Add ValueSerializer::SetTreatFunctionsAsHostObjects().
+
+Previously, ValueSerializer would always refuse to serialize functions. This commit gives the embedder the option to handle them as host objects.
+
+This is intended for use in an RPC system, where a function can be "serialized" by replacing it with a stub which, when invoked, performs an RPC back to the originating isolate in order to execute the original function there.
+
+diff --git a/include/v8-value-serializer.h b/include/v8-value-serializer.h
+index 596be18adeb3a5a81794aaa44b1d347dec6c0c7d..141f138e08de849e3e02b3b2b346e643b9e40c70 100644
+--- a/include/v8-value-serializer.h
++++ b/include/v8-value-serializer.h
+@@ -195,6 +195,15 @@ class V8_EXPORT ValueSerializer {
+    */
+   void SetTreatArrayBufferViewsAsHostObjects(bool mode);
+ 
++  /**
++   * Indicate whether to treat Functions as host objects,
++   * i.e. pass them to Delegate::WriteHostObject. This should not be
++   * called when no Delegate was passed.
++   *
++   * The default is not to treat Functions as host objects.
++   */
++  void SetTreatFunctionsAsHostObjects(bool mode);
++
+   /**
+    * Write raw data in various common formats to the buffer.
+    * Note that integer types are written in base-128 varint format, not with a
+diff --git a/src/api/api.cc b/src/api/api.cc
+index 336aaf5512f743d1202d503e388d2ac9ef5a9377..d736a92e87c758a82247af6623d5a706c646c978 100644
+--- a/src/api/api.cc
++++ b/src/api/api.cc
+@@ -3577,6 +3577,10 @@ void ValueSerializer::SetTreatArrayBufferViewsAsHostObjects(bool mode) {
+   private_->serializer.SetTreatArrayBufferViewsAsHostObjects(mode);
+ }
+ 
++void ValueSerializer::SetTreatFunctionsAsHostObjects(bool mode) {
++  private_->serializer.SetTreatFunctionsAsHostObjects(mode);
++}
++
+ Maybe<bool> ValueSerializer::WriteValue(Local<Context> context,
+                                         Local<Value> value) {
+   auto i_isolate = reinterpret_cast<i::Isolate*>(context->GetIsolate());
+diff --git a/src/objects/value-serializer.cc b/src/objects/value-serializer.cc
+index f0b1956253fe603ad6da30a41fb923078ef6bd78..23eff3120d5b20ce4ac1ec8d3700e82a49150308 100644
+--- a/src/objects/value-serializer.cc
++++ b/src/objects/value-serializer.cc
+@@ -304,6 +304,10 @@ void ValueSerializer::SetTreatArrayBufferViewsAsHostObjects(bool mode) {
+   treat_array_buffer_views_as_host_objects_ = mode;
+ }
+ 
++void ValueSerializer::SetTreatFunctionsAsHostObjects(bool mode) {
++  treat_functions_as_host_objects_ = mode;
++}
++
+ void ValueSerializer::WriteTag(SerializationTag tag) {
+   uint8_t raw_tag = static_cast<uint8_t>(tag);
+   WriteRawBytes(&raw_tag, sizeof(raw_tag));
+@@ -572,8 +576,13 @@ Maybe<bool> ValueSerializer::WriteJSReceiver(Handle<JSReceiver> receiver) {
+ 
+   // Eliminate callable and exotic objects, which should not be serialized.
+   InstanceType instance_type = receiver->map()->instance_type();
+-  if (IsCallable(*receiver) || (IsSpecialReceiverInstanceType(instance_type) &&
+-                                instance_type != JS_SPECIAL_API_OBJECT_TYPE)) {
++  if (IsCallable(*receiver)) {
++    if (treat_functions_as_host_objects_) {
++      return WriteHostObject(Handle<JSObject>::cast(receiver));
++    }
++    return ThrowDataCloneError(MessageTemplate::kDataCloneError, receiver);
++  } else if (IsSpecialReceiverInstanceType(instance_type) &&
++             instance_type != JS_SPECIAL_API_OBJECT_TYPE) {
+     return ThrowDataCloneError(MessageTemplate::kDataCloneError, receiver);
+   }
+ 
+diff --git a/src/objects/value-serializer.h b/src/objects/value-serializer.h
+index 4747119155007e1fa0075440fefa1dfee036c48a..68be2829f36633a386f54668ce9147267c377272 100644
+--- a/src/objects/value-serializer.h
++++ b/src/objects/value-serializer.h
+@@ -102,6 +102,15 @@ class ValueSerializer {
+    */
+   void SetTreatArrayBufferViewsAsHostObjects(bool mode);
+ 
++  /*
++   * Indicate whether to treat Functions as host objects,
++   * i.e. pass them to Delegate::WriteHostObject. This should not be
++   * called when no Delegate was passed.
++   *
++   * The default is not to treat Functions as host objects.
++   */
++  void SetTreatFunctionsAsHostObjects(bool mode);
++
+  private:
+   // Managing allocations of the internal buffer.
+   Maybe<bool> ExpandBuffer(size_t required_capacity);
+@@ -181,6 +190,7 @@ class ValueSerializer {
+   size_t buffer_capacity_ = 0;
+   bool has_custom_host_objects_ = false;
+   bool treat_array_buffer_views_as_host_objects_ = false;
++  bool treat_functions_as_host_objects_ = false;
+   bool out_of_memory_ = false;
+   Zone zone_;
+   uint32_t version_;

--- a/src/node/internal/internal_assert.ts
+++ b/src/node/internal/internal_assert.ts
@@ -846,10 +846,7 @@ function isValidThenable(maybeThennable: any): boolean {
     return true;
   }
 
-  const isThenable = typeof maybeThennable.then === "function" &&
-    typeof maybeThennable.catch === "function";
-
-  return isThenable && typeof maybeThennable !== "function";
+  return typeof maybeThennable.then === "function";
 }
 
 export { AssertionError };

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -142,6 +142,10 @@ export class MyService extends WorkerEntrypoint {
   async getNonRpcClass() {
     return {obj: new NonRpcClass()};
   }
+
+  async getFunction() {
+    return (a, b) => a ^ b;
+  }
 }
 
 export class MyActor extends DurableObject {
@@ -239,6 +243,20 @@ export let namedServiceBinding = {
       let counter = await env.MyService.objectProperty.counter5;
       assert.strictEqual(await counter.increment(3), 8);
       assert.strictEqual(await counter.increment(7), 15);
+    }
+
+    {
+      let func = await env.MyService.objectProperty.func;
+      assert.strictEqual(await func(3, 7), 21);
+    }
+    {
+      let func = await env.MyService.getFunction();
+      assert.strictEqual(await func(3, 6), 5);
+    }
+    {
+      // Pipeline the function call.
+      let func = env.MyService.getFunction();
+      assert.strictEqual(await func(3, 6), 5);
     }
 
     // A property that returns a Promise will wait for the Promise.

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -144,7 +144,9 @@ export class MyService extends WorkerEntrypoint {
   }
 
   async getFunction() {
-    return (a, b) => a ^ b;
+    let func = (a, b) => a ^ b;
+    func.someProperty = 123;
+    return func;
   }
 }
 
@@ -252,11 +254,13 @@ export let namedServiceBinding = {
     {
       let func = await env.MyService.getFunction();
       assert.strictEqual(await func(3, 6), 5);
+      assert.strictEqual(await func.someProperty, 123);
     }
     {
       // Pipeline the function call.
       let func = env.MyService.getFunction();
       assert.strictEqual(await func(3, 6), 5);
+      assert.strictEqual(await func.someProperty, 123);
     }
 
     // A property that returns a Promise will wait for the Promise.

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -1,17 +1,6 @@
 import assert from 'node:assert';
 import {WorkerEntrypoint,DurableObject,RpcStub,RpcTarget} from 'cloudflare:workers';
 
-// Monkey-patch assert.rejects so that it automatically converts the return value of the function
-// to a Promise. Otherwise it gets confused when the callback returns a thenable that happens to
-// be callable; it thinks it has received a function rather than a promise.
-// TODO(cleanup): This is needed because `isValidThenable()` in internal_asserts.ts explicitly
-//   refuses to accept functions, even if the function has `then` and `catch` methods. Can we
-//   change that? If so we could remove this hack here.
-let originalRejects = assert.rejects.bind(assert);
-assert.rejects = (func, err) => {
-  return originalRejects(() => Promise.resolve(func()), err);
-}
-
 class MyCounter extends RpcTarget {
   constructor(i = 0) {
     super();

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -358,9 +358,9 @@ export let namedServiceBinding = {
 
     // Can't serialize instances of classes that aren't derived from RpcTarget.
     await assert.rejects(() => Promise.resolve(env.MyService.getNonRpcClass()), {
-      // TODO(bug): Why isn't this a DOMException?
-      name: "Error",
-      message: "#<NonRpcClass> could not be cloned."
+      name: "DataCloneError",
+      message: 'Could not serialize object of type "NonRpcClass". This type does not support ' +
+               'serialization.'
     });
   },
 }

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -138,6 +138,10 @@ export class MyService extends WorkerEntrypoint {
   async tryUseGlobalRpcPromisePipeline() {
     return await globalRpcPromise.increment(1);
   }
+
+  async getNonRpcClass() {
+    return {obj: new NonRpcClass()};
+  }
 }
 
 export class MyActor extends DurableObject {
@@ -350,6 +354,13 @@ export let namedServiceBinding = {
     await assert.rejects(() => env.MyService.objectProperty.ctx.waitUntil(), {
       name: "TypeError",
       message: "The RPC receiver does not implement the method \"ctx\"."
+    });
+
+    // Can't serialize instances of classes that aren't derived from RpcTarget.
+    await assert.rejects(() => Promise.resolve(env.MyService.getNonRpcClass()), {
+      // TODO(bug): Why isn't this a DOMException?
+      name: "Error",
+      message: "#<NonRpcClass> could not be cloned."
     });
   },
 }

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -834,6 +834,18 @@ void JsRpcTarget::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   });
 }
 
+void RpcSerializerExternalHander::serializeFunction(
+    jsg::Lock& js, jsg::Serializer& serializer, v8::Local<v8::Function> func) {
+  serializer.writeRawUint32(static_cast<uint>(rpc::SerializationTag::JS_RPC_STUB));
+
+  auto handle = jsg::JsRef<jsg::JsObject>(js, jsg::JsObject(func));
+  rpc::JsRpcTarget::Client cap = kj::heap<TransientJsRpcTarget>(
+      IoContext::current(), kj::mv(handle), true);
+  write([cap = kj::mv(cap)](rpc::JsValue::External::Builder builder) mutable {
+    builder.setRpcTarget(kj::mv(cap));
+  });
+}
+
 // JsRpcTarget implementation specific to entrypoints. This is used to deliver the first, top-level
 // call of an RPC session.
 class EntrypointJsRpcTarget final: public JsRpcTargetBase {

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -45,6 +45,7 @@ void serializeJsValue(jsg::Lock& js, jsg::JsValue value, Func makeBuilder) {
   jsg::Serializer serializer(js, jsg::Serializer::Options {
     .version = 15,
     .omitHeader = false,
+    .treatClassInstancesAsPlainObjects = false,
     .externalHandler = externalHandler,
   });
   serializer.write(js, value);

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -659,6 +659,9 @@ private:
             } else if (object.isInstanceOf<JsRpcTarget>(js)) {
               // Yes. It's a JsRpcTarget.
               allowInstanceProperties = false;
+            } else if (jsg::JsValue(object).isFunction()) {
+              // Yes. It's a function.
+              allowInstanceProperties = true;
             } else {
               failLookup(name);
             }

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -141,6 +141,10 @@ public:
     JSG_METHOD(finally);
   }
 
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackField("inner", inner);
+  }
+
 private:
   jsg::JsRef<jsg::JsPromise> inner;
   IoOwn<rpc::JsRpcTarget::CallResults::Pipeline> pipeline;
@@ -189,6 +193,11 @@ public:
     JSG_METHOD(then);
     JSG_METHOD_NAMED(catch, catch_);
     JSG_METHOD(finally);
+  }
+
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackField("parent", parent);
+    tracker.trackField("name", name);
   }
 
 private:

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -193,14 +193,6 @@ private:
   void visitForGc(jsg::GcVisitor& visitor) {
     visitor.visit(parent);
   }
-
-  struct PromiseAndPipleine {
-    jsg::JsPromise promise;
-    rpc::JsRpcTarget::CallResults::Pipeline pipeline;
-  };
-
-  template <typename FillOpFunc>
-  PromiseAndPipleine callImpl(jsg::Lock& js, FillOpFunc&& fillOpFunc);
 };
 
 // A JsRpcStub object forwards JS method calls to the remote Worker/Durable Object over RPC.

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -144,6 +144,10 @@ public:
 private:
   jsg::JsRef<jsg::JsPromise> inner;
   IoOwn<rpc::JsRpcTarget::CallResults::Pipeline> pipeline;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(inner);
+  }
 };
 
 // Represents a property -- possibly, a method -- of a remote RPC object.

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -46,6 +46,10 @@ public:
 
   size_t size() { return externals.size(); }
 
+  // We serialize functions by turning them into RPC stubs.
+  void serializeFunction(
+      jsg::Lock& js, jsg::Serializer& serializer, v8::Local<v8::Function> func) override;
+
 private:
   kj::Vector<BuilderCallback> externals;
 };

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -113,6 +113,9 @@ public:
   rpc::JsRpcTarget::Client getClientForOneCall(
       jsg::Lock& js, kj::Vector<kj::StringPtr>& path) override;
 
+  // Expect that the call is itself going to return a function... and call that.
+  jsg::Ref<JsRpcPromise> call(const v8::FunctionCallbackInfo<v8::Value>& args);
+
   // Implement standard Promise interface, especially `then()` so that this works as a custom
   // thenable.
   //
@@ -131,6 +134,7 @@ public:
   kj::Maybe<jsg::Ref<JsRpcProperty>> getProperty(jsg::Lock& js, kj::String name);
 
   JSG_RESOURCE_TYPE(JsRpcPromise) {
+    JSG_CALLABLE(call);
     JSG_WILDCARD_PROPERTY(getProperty);
     JSG_METHOD(then);
     JSG_METHOD_NAMED(catch, catch_);
@@ -225,9 +229,13 @@ public:
   // for testing to be able to construct a loopback stub.
   static jsg::Ref<JsRpcStub> constructor(jsg::Lock& js, jsg::Ref<JsRpcTarget> object);
 
+  // Call the stub itself as a function.
+  jsg::Ref<JsRpcPromise> call(const v8::FunctionCallbackInfo<v8::Value>& args);
+
   kj::Maybe<jsg::Ref<JsRpcProperty>> getRpcMethod(jsg::Lock& js, kj::String name);
 
   JSG_RESOURCE_TYPE(JsRpcStub) {
+    JSG_CALLABLE(call);
     JSG_WILDCARD_PROPERTY(getRpcMethod);
   }
 

--- a/src/workerd/jsg/ser.h
+++ b/src/workerd/jsg/ser.h
@@ -66,10 +66,10 @@ public:
   // appropriate exception should be thrown.
   class ExternalHandler {
   public:
-    // We declare the destructor just so that this class has a virtual method, which ensures it is
-    // polymorphic (has a vtable) so that dynamic_cast can be used on it. We mark this method pure
-    // (`= 0`) so that `ExternalHandler` itself cannot be instantiated.
-    virtual ~ExternalHandler() noexcept(false) = 0;
+    // Tries to serialize a function as an external. The default implementation throws
+    // DataCloneError.
+    virtual void serializeFunction(
+        jsg::Lock& js, jsg::Serializer& serializer, v8::Local<v8::Function> func);
   };
 
   struct Options {

--- a/src/workerd/jsg/ser.h
+++ b/src/workerd/jsg/ser.h
@@ -146,6 +146,12 @@ public:
   }
 
 private:
+  // Throw a DataCloneError, complaining that the given object cannot be serialized. (This is
+  // similar to ThrowDataCloneError() except that it formats the error message itself, and it
+  // is expected to be called from KJ-ish code so it throws JsExceptionThrown rather than
+  // returning.)
+  [[noreturn]] void throwDataCloneErrorForObject(jsg::Lock& js, v8::Local<v8::Object> obj);
+
   // v8::ValueSerializer::Delegate implementation
   void ThrowDataCloneError(v8::Local<v8::String> message) override;
   bool HasCustomHostObject(v8::Isolate* isolate) override;


### PR DESCRIPTION
It's simple: If you send someone a function, they get an RpcStub. The stub is callable. Calling it makes an RPC back to the isolate where the function was created, calling the original object there.

To reiterate, because this keeps confusing people: The function's code is NOT serialized. We are NOT magically moving code around. Closures strictly execute in the isolate where they were created.

I also went ahead and said that functions are allowed to have properties, but these work like properties on an RpcTarget. That is, they are not marshalled proactively when sending the function, but you can access them by accessing properties of the RpcStub representing the function.

There are also some other commits thrown in this PR because I did them at the same time:
* First two commits: Prevent sending instances of application-defined classes over RPC, and improve error messages around inability to serialize.
* Last two commits: Implement `visitForGc()` and `visitForMemoryInfo()`.

There are a lot of commits here but they are each pretty light...