### PR TITLE
JSRPC: Support capnp-over-http for external server bindings

### DIFF
--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -309,8 +309,8 @@ export let namedServiceBinding = {
     assert.strictEqual(sawFinally, true);
 
     // `fetch()` is special, the params get converted into a Request.
-    let resp = await env.MyService.fetch("http://foo", {method: "POST"});
-    assert.strictEqual(await resp.text(), "method = POST, url = http://foo");
+    let resp = await env.MyService.fetch("http://foo/", {method: "POST"});
+    assert.strictEqual(await resp.text(), "method = POST, url = http://foo/");
 
     await assert.rejects(() => env.MyService.instanceMethod(), {
       name: "TypeError",
@@ -653,3 +653,23 @@ export let testAsyncStackTrace = {
     }
   }
 }
+
+function withRealSocket(inner) {
+  return {
+    async test(controller, env, ctx) {
+      let subEnv = {...env};
+      subEnv.MyService = subEnv.MyServiceOverRealSocket;
+      await inner.test(controller, subEnv, ctx);
+    }
+  }
+}
+
+// Export versions of various tests above using MyService over a real socket. We only bother
+// with thests that use MyService. The `z_` prefix makes these tests run last.
+export let z_namedServiceBinding_realSocket = withRealSocket(namedServiceBinding);
+export let z_sendStubOverRpc_realSocket = withRealSocket(sendStubOverRpc);
+export let z_receiveStubOverRpc_realSocket = withRealSocket(receiveStubOverRpc);
+export let z_promisePipelining_realSocket = withRealSocket(promisePipelining);
+export let z_crossContextSharingDoesntWork_realSocket = withRealSocket(crossContextSharingDoesntWork);
+export let z_serializeRpcPromiseOrProprety_realSocket = withRealSocket(serializeRpcPromiseOrProprety);
+export let z_testAsyncStackTrace_realSocket = withRealSocket(testAsyncStackTrace);

--- a/src/workerd/api/tests/js-rpc-test.wd-test
+++ b/src/workerd/api/tests/js-rpc-test.wd-test
@@ -12,6 +12,7 @@ const unitTests :Workerd.Config = (
         bindings = [
           (name = "self", service = (name = "js-rpc-test", entrypoint = "nonClass")),
           (name = "MyService", service = (name = "js-rpc-test", entrypoint = "MyService")),
+          (name = "MyServiceOverRealSocket", service = "loop"),
           (name = "MyActor", durableObjectNamespace = "MyActor"),
           (name = "ActorNoExtends", durableObjectNamespace = "ActorNoExtends"),
           (name = "defaultExport", service = "js-rpc-test"),
@@ -26,5 +27,18 @@ const unitTests :Workerd.Config = (
         durableObjectStorage = (inMemory = void),
       )
     ),
+    ( name = "loop",
+      external = (
+        address = "loopback:loop",
+        http = (capnpConnectHost = "cappy")
+      )
+    )
+  ],
+  sockets = [
+    ( name = "loop",
+      address = "loopback:loop",
+      service = (name = "js-rpc-test", entrypoint = "MyService"),
+      http = (capnpConnectHost = "cappy")
+    )
   ],
 );

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -334,3 +334,13 @@ interface EventDispatcher @0xf20697475ec1752d {
   # Other methods might be added to handle other kinds of events, e.g. TCP connections, or maybe
   # even native Cap'n Proto RPC eventually.
 }
+
+interface WorkerdBootstrap {
+  # Bootstrap interface exposed by workerd when serving Cap'n Proto RPC.
+
+  startEvent @0 () -> (dispatcher :EventDispatcher);
+  # Start a new event. Exactly one event should be delivered to the returned EventDispatcher.
+  #
+  # TODO(someday): Pass cfBlobJson? Currently doesn't matter since the cf blob is only present for
+  #   HTTP requests which can be delivered over regular HTTP instead of capnp.
+}

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -11,6 +11,7 @@
 #include <kj/encoding.h>
 #include <kj/map.h>
 #include <capnp/message.h>
+#include <capnp/rpc-twoparty.h>
 #include <capnp/compat/json.h>
 #include <workerd/api/analytics-engine.capnp.h>
 #include <workerd/io/actor-id.h>
@@ -29,6 +30,7 @@
 #include <workerd/api/actor-state.h>
 #include <workerd/util/mimetype.h>
 #include <workerd/util/use-perfetto-categories.h>
+#include <workerd/api/worker-rpc.h>
 #include "workerd-api.h"
 #include "workerd/io/hibernation-manager.h"
 #include <stdlib.h>
@@ -260,6 +262,9 @@ public:
     if (httpOptions.hasCfBlobHeader()) {
       cfBlobHeader = headerTableBuilder.add(httpOptions.getCfBlobHeader());
     }
+    if (httpOptions.hasCapnpConnectHost()) {
+      capnpConnectHost = httpOptions.getCapnpConnectHost();
+    }
   }
 
   bool hasCfBlobHeader() {
@@ -348,10 +353,15 @@ public:
     responseInjector.apply(headers);
   }
 
+  kj::Maybe<kj::StringPtr> getCapnpConnectHost() {
+    return capnpConnectHost;
+  }
+
 private:
   config::HttpOptions::Style style;
   kj::Maybe<kj::HttpHeaderId> forwardedProtoHeader;
   kj::Maybe<kj::HttpHeaderId> cfBlobHeader;
+  kj::Maybe<kj::StringPtr> capnpConnectHost;
 
   class HeaderInjector {
   public:
@@ -518,18 +528,24 @@ private:
 };
 
 // Service used when the service is configured as external HTTP service.
-class Server::ExternalHttpService final: public Service {
+class Server::ExternalHttpService final: public Service, private kj::TaskSet::ErrorHandler {
 public:
   ExternalHttpService(kj::Own<kj::NetworkAddress> addrParam,
                       kj::Own<HttpRewriter> rewriter, kj::HttpHeaderTable& headerTable,
-                      kj::Timer& timer, kj::EntropySource& entropySource)
+                      kj::Timer& timer, kj::EntropySource& entropySource,
+                      capnp::ByteStreamFactory& byteStreamFactory,
+                      capnp::HttpOverCapnpFactory& httpOverCapnpFactory)
       : addr(kj::mv(addrParam)),
         inner(kj::newHttpClient(timer, headerTable, *addr, {
           .entropySource = entropySource,
           .webSocketCompressionMode = kj::HttpClientSettings::MANUAL_COMPRESSION
         })),
         serviceAdapter(kj::newHttpService(*inner)),
-        rewriter(kj::mv(rewriter)) {}
+        rewriter(kj::mv(rewriter)),
+        headerTable(headerTable),
+        byteStreamFactory(byteStreamFactory),
+        httpOverCapnpFactory(httpOverCapnpFactory),
+        waitUntilTasks(*this) {}
 
   kj::Own<WorkerInterface> startRequest(IoChannelFactory::SubrequestMetadata metadata) override {
     return kj::heap<WorkerInterfaceImpl>(*this, kj::mv(metadata));
@@ -546,6 +562,55 @@ private:
   kj::Own<kj::HttpService> serviceAdapter;
 
   kj::Own<HttpRewriter> rewriter;
+
+  kj::HttpHeaderTable& headerTable;
+  capnp::ByteStreamFactory& byteStreamFactory;
+  capnp::HttpOverCapnpFactory& httpOverCapnpFactory;
+  kj::TaskSet waitUntilTasks;
+
+  void taskFailed(kj::Exception&& exception) override {
+    LOG_EXCEPTION("externalServiceWaitUntilTasks", exception);
+  }
+
+  struct CapnpClient {
+    kj::Own<kj::AsyncIoStream> connection;
+    capnp::TwoPartyClient rpcSystem;
+
+    CapnpClient(kj::Own<kj::AsyncIoStream> connectionParam)
+        : connection(kj::mv(connectionParam)), rpcSystem(*connection) {}
+  };
+
+  // capnpClient is created on-demand when RPC is needed.
+  kj::Maybe<CapnpClient> capnpClient;
+
+  // This task nulls out `capnpClient` when the connection is lost.
+  kj::Promise<void> clearCapnpClientTask = nullptr;
+
+  // Get an WorkerdBootstrap representing the service on the other end of an HTTP connection. May
+  // reuse an existing connection, or form a new one over `client`.
+  rpc::WorkerdBootstrap::Client getOutgoingCapnp(kj::HttpClient& client) {
+    KJ_IF_SOME(c, capnpClient) {
+      return c.rpcSystem.bootstrap().castAs<rpc::WorkerdBootstrap>();
+    }
+
+    // No existing client, need to create a new one.
+    kj::StringPtr host = KJ_UNWRAP_OR(rewriter->getCapnpConnectHost(), {
+      return JSG_KJ_EXCEPTION(FAILED, Error, "This ExternalServer not configured for RPC.");
+    });
+
+    auto req = client.connect(host, kj::HttpHeaders(headerTable), {});
+    auto& c = capnpClient.emplace(kj::mv(req.connection));
+
+    // Arrange that when the connection is lost, we'll null out `capnpClient`. This ensures that
+    // on the next event, we'll attempt to reconnect.
+    //
+    // TODO(perf): Time out idle connections?
+    clearCapnpClientTask = c.rpcSystem.onDisconnect()
+        .attach(kj::defer([this]() { capnpClient = kj::none; }))
+        .eagerlyEvaluate(nullptr);
+
+    return c.rpcSystem.bootstrap().castAs<rpc::WorkerdBootstrap>();
+  }
 
   class WorkerInterfaceImpl final: public WorkerInterface, private kj::HttpService::Response {
   public:
@@ -581,8 +646,15 @@ private:
     kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime, uint32_t retryCount) override {
       throwUnsupported();
     }
+
     kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override {
-      throwUnsupported();
+      // We'll use capnp RPC for custom events.
+      auto bootstrap = parent.getOutgoingCapnp(*parent.inner);
+      auto dispatcher =
+          bootstrap.startEventRequest(capnp::MessageSize {4, 0}).send().getDispatcher();
+      return event->sendRpc(parent.httpOverCapnpFactory, parent.byteStreamFactory,
+                            parent.waitUntilTasks, kj::mv(dispatcher))
+          .attach(kj::mv(event));
     }
 
   private:
@@ -649,7 +721,8 @@ kj::Own<Server::Service> Server::makeExternalService(
       auto addr = kj::heap<PromisedNetworkAddress>(network.parseAddress(addrStr, 80));
       return kj::heap<ExternalHttpService>(
           kj::mv(addr), kj::mv(rewriter), headerTableBuilder.getFutureTable(),
-          timer, entropySource);
+          timer, entropySource, globalContext->byteStreamFactory,
+          globalContext->httpOverCapnpFactory);
     }
     case config::ExternalServer::HTTPS: {
       auto httpsConf = conf.getHttps();
@@ -662,7 +735,8 @@ kj::Own<Server::Service> Server::makeExternalService(
           makeTlsNetworkAddress(httpsConf.getTlsOptions(), addrStr, certificateHost, 443));
       return kj::heap<ExternalHttpService>(
           kj::mv(addr), kj::mv(rewriter), headerTableBuilder.getFutureTable(),
-          timer, entropySource);
+          timer, entropySource, globalContext->byteStreamFactory,
+          globalContext->httpOverCapnpFactory);
     }
     case config::ExternalServer::TCP: {
       auto tcpConf = conf.getTcp();
@@ -2935,9 +3009,11 @@ class Server::HttpListener final: public kj::Refcounted {
 public:
   HttpListener(Server& owner, kj::Own<kj::ConnectionReceiver> listener, Service& service,
                kj::StringPtr physicalProtocol, kj::Own<HttpRewriter> rewriter,
-               kj::HttpHeaderTable& headerTable, kj::Timer& timer)
+               kj::HttpHeaderTable& headerTable, kj::Timer& timer,
+               capnp::HttpOverCapnpFactory& httpOverCapnpFactory)
       : owner(owner), listener(kj::mv(listener)), service(service),
         headerTable(headerTable), timer(timer),
+        httpOverCapnpFactory(httpOverCapnpFactory),
         physicalProtocol(physicalProtocol),
         rewriter(kj::mv(rewriter)) {}
 
@@ -3008,8 +3084,101 @@ private:
   Service& service;
   kj::HttpHeaderTable& headerTable;
   kj::Timer& timer;
+  capnp::HttpOverCapnpFactory& httpOverCapnpFactory;
   kj::StringPtr physicalProtocol;
   kj::Own<HttpRewriter> rewriter;
+
+  kj::Maybe<capnp::TwoPartyServer> capnpServer;
+
+  kj::Promise<void> acceptCapnpConnection(kj::AsyncIoStream& conn) {
+    KJ_IF_SOME(s, capnpServer) {
+      return s.accept(conn);
+    }
+
+    // Capnp server not initialized. Create in now.
+    auto& s = capnpServer.emplace(kj::heap<WorkerdBootstrapImpl>(*this));
+    return s.accept(conn);
+  }
+
+  class WorkerdBootstrapImpl final: public rpc::WorkerdBootstrap::Server {
+  public:
+    WorkerdBootstrapImpl(HttpListener& parent): parent(parent) {}
+
+    kj::Promise<void> startEvent(StartEventContext context) {
+      // TODO(someday): Use cfBlobJson from the connection if there is one, or from RPC params
+      //   if we add that? (Note that if a connection-level cf blob exists, it should take
+      //   priority; we should only accept a cf blob from the client if we have a cfBlobHeader
+      //   configrued, which hints that this service trusts the client to provide the cf blob.)
+
+      context.initResults(capnp::MessageSize {4, 1}).setDispatcher(
+          kj::heap<EventDispatcherImpl>(parent, parent.service.startRequest({})));
+      return kj::READY_NOW;
+    }
+
+  private:
+    HttpListener& parent;
+  };
+
+  class EventDispatcherImpl final: public rpc::EventDispatcher::Server {
+  public:
+    EventDispatcherImpl(HttpListener& parent, kj::Own<WorkerInterface> worker)
+        : parent(parent), worker(kj::mv(worker)) {}
+
+    kj::Promise<void> getHttpService(GetHttpServiceContext context) override {
+      context.initResults(capnp::MessageSize{4, 1})
+          .setHttp(parent.httpOverCapnpFactory.kjToCapnp(getWorker()));
+      return kj::READY_NOW;
+    }
+
+    kj::Promise<void> sendTraces(SendTracesContext context) override {
+      throwUnsupported();
+    }
+
+    kj::Promise<void> prewarm(PrewarmContext context) override {
+      throwUnsupported();
+    }
+
+    kj::Promise<void> runScheduled(RunScheduledContext context) override {
+      throwUnsupported();
+    }
+
+    kj::Promise<void> runAlarm(RunAlarmContext context) override {
+      throwUnsupported();
+    }
+
+    kj::Promise<void> queue(QueueContext context) override {
+      throwUnsupported();
+    }
+
+    kj::Promise<void> jsRpcSession(JsRpcSessionContext context) override {
+      auto customEvent = kj::heap<api::JsRpcSessionCustomEventImpl>(
+          api::JsRpcSessionCustomEventImpl::WORKER_RPC_EVENT_TYPE);
+
+      auto cap = customEvent->getCap();
+      capnp::PipelineBuilder<JsRpcSessionResults> pipelineBuilder;
+      pipelineBuilder.setTopLevel(cap);
+      context.setPipeline(pipelineBuilder.build());
+      context.getResults().setTopLevel(kj::mv(cap));
+
+      auto worker = getWorker();
+      return worker->customEvent(kj::mv(customEvent)).ignoreResult().attach(kj::mv(worker));
+    }
+
+  private:
+    HttpListener& parent;
+    kj::Maybe<kj::Own<WorkerInterface>> worker;
+
+    kj::Own<WorkerInterface> getWorker() {
+      auto result = kj::mv(KJ_ASSERT_NONNULL(worker,
+          "EventDispatcher can only be used for one request"));
+      worker = kj::none;
+      return result;
+    }
+
+    [[noreturn]] void throwUnsupported() {
+      JSG_FAIL_REQUIRE(Error, "RPC connections don't yet support this event type.");
+    }
+  };
 
   struct Connection final: public kj::HttpService, public kj::HttpServerErrorHandler {
     Connection(HttpListener& parent, kj::Maybe<kj::String> cfBlobJson)
@@ -3080,6 +3249,24 @@ private:
       }
     }
 
+    kj::Promise<void> connect(kj::StringPtr host,
+                              const kj::HttpHeaders& headers,
+                              kj::AsyncIoStream& connection,
+                              ConnectResponse& response,
+                              kj::HttpConnectSettings settings) override {
+      KJ_IF_SOME(h, parent.rewriter->getCapnpConnectHost()) {
+        if (h == host) {
+          // Client is requesting to open a capnp session!
+          response.accept(200, "OK", kj::HttpHeaders(parent.headerTable));
+          return parent.acceptCapnpConnection(connection);
+        }
+      }
+
+      // TODO(someday): Deliver connect() event to to worker? For now we call the default
+      //   implementation which throws an exception.
+      return kj::HttpService::connect(host, headers, connection, response, kj::mv(settings));
+    }
+
     // ---------------------------------------------------------------------------
     // implements kj::HttpServerErrorHandler
 
@@ -3098,7 +3285,8 @@ kj::Promise<void> Server::listenHttp(
     kj::StringPtr physicalProtocol, kj::Own<HttpRewriter> rewriter) {
   auto obj = kj::refcounted<HttpListener>(*this, kj::mv(listener), service,
                                           physicalProtocol, kj::mv(rewriter),
-                                          globalContext->headerTable, timer);
+                                          globalContext->headerTable, timer,
+                                          globalContext->httpOverCapnpFactory);
   co_return co_await obj->run();
 }
 

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -205,7 +205,8 @@ private:
 
   kj::Promise<void> listenOnSockets(config::Config::Reader config,
                                     kj::HttpHeaderTable::Builder& headerTableBuilder,
-                                    kj::ForkedPromise<void>& forkedDrainWhen);
+                                    kj::ForkedPromise<void>& forkedDrainWhen,
+                                    bool forTest = false);
 };
 
 // An ActorStorage implementation which will always respond to reads as if the state is empty,

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -804,6 +804,12 @@ struct HttpOptions {
     # If null, the header will be removed.
   }
 
+  capnpConnectHost @5 :Text;
+  # A CONNECT request for this host+port will be treated as a request to form a Cap'n Proto RPC
+  # connection. The server will expose a WorkerdBootstrap as the bootstrap interface, allowing
+  # events to be delivered to the target worker via capnp. Clients will use capnp for non-HTTP
+  # event types (especially JSRPC).
+
   # TODO(someday): When we support TCP, include an option to deliver CONNECT requests to the
   #   TCP handler.
 }


### PR DESCRIPTION
This PR makes it possible to configure incoming sockets and outgoing ExternalServers to allow negotiating a Cap'n Proto connection over HTTP. Miniflare will need this to allow RPC over service bindings to be tested, since miniflare currently implements service bindings by running each worker in a separate workerd instance.

Currently, this works by using an HTTP CONNECT request specifying a magic hostname (hostname chosen in the config). In theory it might be better to use `Upgrade`, but that would require extensions to KJ HTTP. It could also make sense to use a WebSocket endpoint, but that would have been more work. We can support those as alternatives in the future if there is demand.

I also went ahead and used this new code path to enhance js-rpc-test, so that it actually tests running over a real socket. This actually caught a bug!