### PR TITLE
Fix stack traces for native async functions that throw.

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1606,13 +1606,18 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(
     } else {
       nativeRequest = client->request(jsRequest->getMethodEnum(), url, headers, uint64_t(0));
     }
+
+    auto responsePromise = KJ_ASSERT_NONNULL(nativeRequest).response
+        .then([client = kj::mv(client)](kj::HttpClient::Response&& response) mutable {
+      response.body = response.body.attach(kj::mv(client));
+      return kj::mv(response);
+    });
+
     return ioContext.awaitIo(js,
-        AbortSignal::maybeCancelWrap(signal, kj::mv(KJ_ASSERT_NONNULL(nativeRequest).response)),
-        [fetcher = kj::mv(fetcher), jsRequest = kj::mv(jsRequest),
-         urlList = kj::mv(urlList), client = kj::mv(client)]
+        AbortSignal::maybeCancelWrap(signal, kj::mv(responsePromise)),
+        [fetcher = kj::mv(fetcher), jsRequest = kj::mv(jsRequest), urlList = kj::mv(urlList)]
         (jsg::Lock& js, kj::HttpClient::Response&& response) mutable
             -> jsg::Promise<jsg::Ref<Response>> {
-      response.body = response.body.attach(kj::mv(client));
       return handleHttpResponse(
           js, kj::mv(fetcher), kj::mv(jsRequest), kj::mv(urlList), kj::mv(response));
     });

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -483,3 +483,20 @@ export let crossContextSharingDoesntWork = {
     await assert.rejects(() => env.MyService.tryUseGlobalRpcPromisePipeline(), expectedError);
   },
 }
+
+// Test that exceptions thrown from async native functions have a proper stack trace. (This is
+// not specific to RPC but RPC is a convenient place to test it since we can easily define the
+// callee to throw an exception.)
+//
+// Note that it's only a *local* stack trace of the client-side stack leading up to the call. The
+// stack on the server side is not, at present, transmitted to the client.
+export let testAsyncStackTrace = {
+  async test(controller, env, ctx) {
+    try {
+      await env.MyService.throwingMethod();
+    } catch (e) {
+      // verify stack trace was produced
+      assert.strictEqual(e.stack.includes("at async Object.test"), true);
+    }
+  }
+}


### PR DESCRIPTION
I can't believe this was sitting under our nose this entire time!

Until now, when a native function returned a Promise that eventually rejected, the rejection Error would have an empty stack trace, making it very hard to figure out where the problem came from.

For years, we've known this is a big problem, but I thought it would be much harder to solve. Something like four years ago I was trying to figure out how to make async stack traces work, and I learned that native async stack traces require using the inspector API. But, we don't enable the inspector in production; only when debugging. So it seemed like we couldn't use this.

I'd learned this from a former V8 team member, but that person probably wasn't aware than in 2019 (after he had left) V8 added a new built-in async tracing mechanism, documented here:

https://docs.google.com/document/d/13Sy_kBIJGP0XT34V1CV3nkWya4TwYx9L3Yv45LdGB6Q/edit

This mechanism will automatically add an async trace to errors _as long as_ the Error is constructed inside a JavaScript promise continuation.

The problem for us is, native async code doesn't necessarily run in JS promise continuations. It runs in KJ promises. We were reporting errors by creating a resolver at the beginning of the operation, and then calling `resolver.reject()` at the end. `reject()` would convert the KJ exception into a JS error, but it was not being called from a JS promise continuation.

The solution is to have the resolver be for a value that is `OneOf<Result, kj::Exception>`. Then, add a `.then()` to the promise which pulls out the `kj::Exception` and converts it into a rejection. This way, the Error is constructed inside a promise continuation, and the tracing mechanism works.