### PR TITLE
fix: CustomEvent generic type

### DIFF
--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -218,6 +218,10 @@ public:
   JSG_RESOURCE_TYPE(CustomEvent) {
     JSG_INHERIT(Event);
     JSG_READONLY_PROTOTYPE_PROPERTY(detail, getDetail);
+    JSG_TS_OVERRIDE(<T = any> extends Event {
+      constructor(type: string, init?: CustomEventCustomEventInit);
+      get detail(): T;
+    });
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workerd/issues/1504

This overrides the `CustomEvent` types to better match other implementations.

This is my first time contributing to `workerd`, and really using JSG at all, so apologies if there's anything weird with this change. If there's a better way to do this, please just let me know.

Old output:
```typescript
export declare class CustomEvent extends Event {
  constructor(type: string, init?: CustomEventCustomEventInit);
  get detail(): any | undefined;
}
```

New output:
```typescript
export declare class CustomEvent<T = any> extends Event {
  constructor(type: string, init?: CustomEventCustomEventInit);
  get detail(): T;
}
```

TypeScript `lib.dom.d.ts` reference: https://github.com/microsoft/TypeScript/blob/1d6d962d3132a901f5fb48be4a389c45faf5a74e/src/lib/dom.generated.d.ts#L5935