### PR TITLE
Use static universal memory snapshot

### DIFF
--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -89,6 +89,11 @@ public:
         uploadMemorySnapshotCb(kj::mv(uploadMemorySnapshotCb)),
         hasUploaded(false) {};
 
+  ArtifactBundler(kj::Maybe<kj::Array<kj::byte>> existingSnapshot)
+      : existingSnapshot(kj::mv(existingSnapshot)),
+        uploadMemorySnapshotCb(kj::none),
+        hasUploaded(false) {};
+
   ArtifactBundler()
       : existingSnapshot(kj::none),
         uploadMemorySnapshotCb(kj::none),


### PR DESCRIPTION
Just a small change to enable creating the artifact storage without an upload callback specified.