### PR TITLE
Add dispatch metrics

### DIFF
--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -62,6 +62,9 @@ public:
     return kj::mv(client);
   }
 
+  // Used to record when a worker has a dynamic dispatch binding (Called on the dispatching side)
+  virtual void setHasDispatchBinding() {};
+
   virtual SpanParent getSpan() { return nullptr; }
 
   virtual void addedContextTask() {}


### PR DESCRIPTION
Allows RequestObservers to receive metrics on dynamic dispatch.j