### PR TITLE
Refactor: awaitIo() captures callback in KJ promise, not JSG.

### DIFF
--- a/src/workerd/api/cache.c++
+++ b/src/workerd/api/cache.c++
@@ -467,7 +467,7 @@ jsg::Promise<void> Cache::put(jsg::Lock& js, Request::Info requestOrUrl,
         }
       };
 
-      return context.awaitDeferredProxy(handleSerialize(
+      return context.awaitDeferredProxy(js, handleSerialize(
           kj::mv(serializePromise),
           kj::mv(httpClient),
           kj::mv(nativeRequest.response),

--- a/src/workerd/api/crypto.c++
+++ b/src/workerd/api/crypto.c++
@@ -742,7 +742,7 @@ DigestStream::DigestStream(
 jsg::Ref<DigestStream> DigestStream::constructor(jsg::Lock& js, Algorithm algorithm) {
   auto paf = kj::newPromiseAndFulfiller<kj::Array<kj::byte>>();
 
-  auto jsPromise = IoContext::current().awaitIoLegacy(kj::mv(paf.promise));
+  auto jsPromise = IoContext::current().awaitIoLegacy(js, kj::mv(paf.promise));
   jsPromise.markAsHandled(js);
 
   return jsg::alloc<DigestStream>(

--- a/src/workerd/api/gpu/gpu-buffer.c++
+++ b/src/workerd/api/gpu/gpu-buffer.c++
@@ -100,7 +100,8 @@ void GPUBuffer::unmap(jsg::Lock& js) {
   }
 }
 
-jsg::Promise<void> GPUBuffer::mapAsync(GPUFlagsConstant mode, jsg::Optional<GPUSize64> offset,
+jsg::Promise<void> GPUBuffer::mapAsync(jsg::Lock& js, GPUFlagsConstant mode,
+                                       jsg::Optional<GPUSize64> offset,
                                        jsg::Optional<GPUSize64> size) {
   wgpu::MapMode md = static_cast<wgpu::MapMode>(mode);
 
@@ -166,7 +167,7 @@ jsg::Promise<void> GPUBuffer::mapAsync(GPUFlagsConstant mode, jsg::Optional<GPUS
       ctx);
 
   auto& context = IoContext::current();
-  return context.awaitIo(kj::mv(paf.promise));
+  return context.awaitIo(js, kj::mv(paf.promise));
 }
 
 } // namespace workerd::api::gpu

--- a/src/workerd/api/gpu/gpu-buffer.h
+++ b/src/workerd/api/gpu/gpu-buffer.h
@@ -92,7 +92,7 @@ private:
 
   void unmap(jsg::Lock& js);
   void destroy(jsg::Lock& js);
-  jsg::Promise<void> mapAsync(GPUFlagsConstant mode, jsg::Optional<GPUSize64> offset,
+  jsg::Promise<void> mapAsync(jsg::Lock&, GPUFlagsConstant mode, jsg::Optional<GPUSize64> offset,
                               jsg::Optional<GPUSize64> size);
   void DetachMappings(jsg::Lock& js);
 };

--- a/src/workerd/api/gpu/gpu-device.c++
+++ b/src/workerd/api/gpu/gpu-device.c++
@@ -579,7 +579,7 @@ GPUDevice::createComputePipeline(GPUComputePipelineDescriptor descriptor) {
   return jsg::alloc<GPUComputePipeline>(kj::mv(pipeline));
 }
 
-jsg::Promise<kj::Maybe<jsg::Ref<GPUError>>> GPUDevice::popErrorScope() {
+jsg::Promise<kj::Maybe<jsg::Ref<GPUError>>> GPUDevice::popErrorScope(jsg::Lock& js) {
   struct Context {
     kj::Own<kj::PromiseFulfiller<kj::Maybe<jsg::Ref<GPUError>>>> fulfiller;
     AsyncTask task;
@@ -621,11 +621,11 @@ jsg::Promise<kj::Maybe<jsg::Ref<GPUError>>> GPUDevice::popErrorScope() {
       ctx);
 
   auto& context = IoContext::current();
-  return context.awaitIo(kj::mv(paf.promise));
+  return context.awaitIo(js, kj::mv(paf.promise));
 }
 
 jsg::Promise<jsg::Ref<GPUComputePipeline>>
-GPUDevice::createComputePipelineAsync(GPUComputePipelineDescriptor descriptor) {
+GPUDevice::createComputePipelineAsync(jsg::Lock& js, GPUComputePipelineDescriptor descriptor) {
   wgpu::ComputePipelineDescriptor desc = parseComputePipelineDescriptor(descriptor);
 
   struct Context {
@@ -658,7 +658,7 @@ GPUDevice::createComputePipelineAsync(GPUComputePipelineDescriptor descriptor) {
       ctx);
 
   auto& context = IoContext::current();
-  return context.awaitIo(kj::mv(paf.promise));
+  return context.awaitIo(js, kj::mv(paf.promise));
 }
 
 jsg::Ref<GPUQueue> GPUDevice::getQueue() {

--- a/src/workerd/api/gpu/gpu-device.h
+++ b/src/workerd/api/gpu/gpu-device.h
@@ -74,14 +74,14 @@ private:
   jsg::Ref<GPUComputePipeline> createComputePipeline(GPUComputePipelineDescriptor descriptor);
   jsg::Ref<GPURenderPipeline> createRenderPipeline(GPURenderPipelineDescriptor descriptor);
   jsg::Promise<jsg::Ref<GPUComputePipeline>>
-  createComputePipelineAsync(GPUComputePipelineDescriptor descriptor);
+  createComputePipelineAsync(jsg::Lock& js, GPUComputePipelineDescriptor descriptor);
   jsg::Ref<GPUCommandEncoder>
   createCommandEncoder(jsg::Optional<GPUCommandEncoderDescriptor> descriptor);
   jsg::Ref<GPUQueue> getQueue();
   void destroy();
   jsg::Ref<GPUQuerySet> createQuerySet(GPUQuerySetDescriptor descriptor);
   void pushErrorScope(GPUErrorFilter filter);
-  jsg::Promise<kj::Maybe<jsg::Ref<GPUError>>> popErrorScope();
+  jsg::Promise<kj::Maybe<jsg::Ref<GPUError>>> popErrorScope(jsg::Lock& js);
   jsg::MemoizedIdentity<jsg::Promise<jsg::Ref<GPUDeviceLostInfo>>>& getLost();
   jsg::Ref<GPUSupportedFeatures> getFeatures();
   jsg::Ref<GPUSupportedLimits> getLimits();

--- a/src/workerd/api/gpu/gpu-shader-module.c++
+++ b/src/workerd/api/gpu/gpu-shader-module.c++
@@ -7,7 +7,7 @@
 
 namespace workerd::api::gpu {
 
-jsg::Promise<jsg::Ref<GPUCompilationInfo>> GPUShaderModule::getCompilationInfo() {
+jsg::Promise<jsg::Ref<GPUCompilationInfo>> GPUShaderModule::getCompilationInfo(jsg::Lock& js) {
 
   struct Context {
     kj::Own<kj::PromiseFulfiller<jsg::Ref<GPUCompilationInfo>>> fulfiller;
@@ -35,7 +35,7 @@ jsg::Promise<jsg::Ref<GPUCompilationInfo>> GPUShaderModule::getCompilationInfo()
       ctx);
 
   auto& context = IoContext::current();
-  return context.awaitIo(kj::mv(paf.promise));
+  return context.awaitIo(js, kj::mv(paf.promise));
 }
 
 } // namespace workerd::api::gpu

--- a/src/workerd/api/gpu/gpu-shader-module.h
+++ b/src/workerd/api/gpu/gpu-shader-module.h
@@ -95,7 +95,7 @@ public:
 private:
   wgpu::ShaderModule shader_;
   kj::Own<AsyncRunner> async_;
-  jsg::Promise<jsg::Ref<GPUCompilationInfo>> getCompilationInfo();
+  jsg::Promise<jsg::Ref<GPUCompilationInfo>> getCompilationInfo(jsg::Lock& js);
 };
 
 struct GPUShaderModuleDescriptor {

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -114,7 +114,7 @@ public:
     auto& cb = KJ_REQUIRE_NONNULL(uploadMemorySnapshotCb);
     hasUploaded = true;
     auto& context = IoContext::current();
-    return context.awaitIo(cb(kj::mv(snapshot)));
+    return context.awaitIo(js, cb(kj::mv(snapshot)));
   };
 
   jsg::Optional<kj::Array<kj::byte>> getMemorySnapshot(jsg::Lock& js) {

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -123,7 +123,7 @@ jsg::Ref<Socket> setupSocket(
   auto closedPrPair = js.newPromiseAndResolver<void>();
   closedPrPair.promise.markAsHandled(js);
 
-  ioContext.awaitIo(js, kj::mv(disconnectedPaf.promise),
+  ioContext.awaitIo(js, kj::mv(disconnectedPaf.promise)).then(js,
       [resolver = closedPrPair.resolver.addRef(js)](jsg::Lock& js, bool canceled) mutable {
     // We want to silently ignore the canceled case, without ever resolving anything. Note that
     // if the application actually fetches the `closed` promise, then the JSG glue will prevent

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -557,7 +557,7 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
       // no need to drop the isolate lock and take it again every time some data is read/written.
       // That's a larger refactor, though.
       auto& ioContext = IoContext::current();
-      return ioContext.awaitIoLegacy(kj::mv(promise)).then(js,
+      return ioContext.awaitIoLegacy(js, kj::mv(promise)).then(js,
           ioContext.addFunctor([this,store = kj::mv(store), byteOffset, byteLength]
           (jsg::Lock& js, size_t amount) mutable -> jsg::Promise<ReadResult> {
         readPending = false;
@@ -1453,7 +1453,7 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
       // jsg::Promises and not kj::Promises, so that it doesn't look like I/O at all, and there's
       // no need to drop the isolate lock and take it again every time some data is read/written.
       // That's a larger refactor, though.
-      return ioContext.awaitIoLegacy(kj::mv(promise)).then(js,
+      return ioContext.awaitIoLegacy(js, kj::mv(promise)).then(js,
           ioContext.addFunctor(
             [this, check, maybeAbort, amountToWrite](jsg::Lock& js) -> jsg::Promise<void> {
         auto& request = check();
@@ -1949,7 +1949,7 @@ jsg::Promise<kj::Array<byte>> ReadableStreamInternalController::readAllBytes(
     KJ_CASE_ONEOF(readable, Readable) {
       auto source = KJ_ASSERT_NONNULL(removeSource(js));
       auto& context = IoContext::current();
-      return context.awaitIoLegacy(source->readAllBytes(limit).attach(kj::mv(source)));
+      return context.awaitIoLegacy(js, source->readAllBytes(limit).attach(kj::mv(source)));
     }
   }
   KJ_UNREACHABLE;
@@ -1976,7 +1976,7 @@ jsg::Promise<kj::String> ReadableStreamInternalController::readAllText(
     KJ_CASE_ONEOF(readable, Readable) {
       auto source = KJ_ASSERT_NONNULL(removeSource(js));
       auto& context = IoContext::current();
-      return context.awaitIoLegacy(source->readAllText(limit).attach(kj::mv(source)));
+      return context.awaitIoLegacy(js, source->readAllText(limit).attach(kj::mv(source)));
     }
   }
   KJ_UNREACHABLE;

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -3188,7 +3188,7 @@ private:
                 // dropped causing the hold on the sink to be released. If that is
                 // released while the write is still pending we can end up with an
                 // error further up the destruct chain.
-                return ioContext.awaitIo(js, reader.canceler.wrap(kj::mv(promise)),
+                return ioContext.awaitIo(js, reader.canceler.wrap(kj::mv(promise))).then(js,
                     [](jsg::Lock& js) -> kj::Maybe<jsg::Value> {
                   // The write completed successfully.
                   return kj::Maybe<jsg::Value>(kj::none);

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -3055,7 +3055,7 @@ private:
       }
       KJ_CASE_ONEOF(closed, StreamStates::Closed) {
         return end ?
-            ioContext.awaitIoLegacy(sink->end().attach(kj::mv(sink))) :
+            ioContext.awaitIoLegacy(js, sink->end().attach(kj::mv(sink))) :
             js.resolvedPromise();
       }
       KJ_CASE_ONEOF(errored, kj::Exception) {

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -481,7 +481,7 @@ void WebSocket::startReadLoop(jsg::Lock& js, kj::Maybe<kj::Own<InputGate::Critic
   //   accepted locally is implemented completely in JavaScript space, using jsg::Promise instead
   //   of kj::Promise, and then only use awaitIo() on truely remote WebSockets.
   // TODO(cleanup): Should addWaitUntil() take jsg::Promise instead of kj::Promise?
-  context.addWaitUntil(context.awaitJs(js, context.awaitIoLegacy(kj::mv(promise))
+  context.addWaitUntil(context.awaitJs(js, context.awaitIoLegacy(js, kj::mv(promise))
       .then(js, [this, thisHandle = JSG_THIS]
                 (jsg::Lock& js, kj::Maybe<kj::Exception>&& maybeError) mutable {
     auto& native = *farNative;
@@ -724,7 +724,8 @@ void WebSocket::ensurePumping(jsg::Lock& js) {
     //   In that case, the pump can hang if accept() is never called on the other end. Ideally,
     //   this scenario would be handled in-isolate using jsg::Promise, but that would take some
     //   refactoring.
-    context.awaitIoLegacy(kj::mv(promise)).then(js, [this, thisHandle = JSG_THIS](jsg::Lock& js) {
+    context.awaitIoLegacy(js, kj::mv(promise))
+        .then(js, [this, thisHandle = JSG_THIS](jsg::Lock& js) {
       auto& native = *farNative;
       if (native.outgoingAborted) {
         if (awaitingHibernatableRelease()) {

--- a/src/workerd/io/promise-wrapper.h
+++ b/src/workerd/io/promise-wrapper.h
@@ -29,7 +29,8 @@ public:
   v8::Local<v8::Promise> wrap(
       v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator,
       kj::Promise<T> promise) {
-    auto jsPromise = IoContext::current().awaitIoLegacy(kj::mv(promise));
+    auto& js = jsg::Lock::from(context->GetIsolate());
+    auto jsPromise = IoContext::current().awaitIoLegacy(js, kj::mv(promise));
     return static_cast<Self&>(*this).wrap(context, kj::mv(creator), kj::mv(jsPromise));
   }
 


### PR DESCRIPTION
Previously, awaitIoImpl() would return a jsg::Promise. If awaitIo() had been called with a continuation callback, then this was appended to the promise chain by calling `.then()` on the JSG promise.

This required a lot of hackery. Many such callbacks capture KJ I/O types, so the callback had to be wrapped in an IoOwn. Similarly, the *parameter* to the callback could contain KJ I/O types, so had to be wrapped in IoOwn. Also lots of JavaScript allocation and V8 API back-and-forth is needed to schedule JSG promises like this. Finally, it could become a bit difficult to reason about whether the callback would actually outlive the KJ promise -- but many call sites require this.

Instead, we can pass the callback down and capture it via the KJ promise chain, so it never has to be "owned" by JSG and we don't need any implicit IoOwns. This also makes it very clear that the callback outlives the KJ promise, as it's directly part of the KJ promise chain.