### PR TITLE
chore: simplify CustomEvent type override

### DIFF
--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -218,8 +218,7 @@ public:
   JSG_RESOURCE_TYPE(CustomEvent) {
     JSG_INHERIT(Event);
     JSG_READONLY_PROTOTYPE_PROPERTY(detail, getDetail);
-    JSG_TS_OVERRIDE(<T = any> extends Event {
-      constructor(type: string, init?: CustomEventCustomEventInit);
+    JSG_TS_OVERRIDE(<T = any> {
       get detail(): T;
     });
   }


### PR DESCRIPTION
This simplifies this type override as reported by @mrbbot in https://github.com/cloudflare/workerd/pull/1759#discussion_r1513493487.

It produces the same output:
```typescript
export class CustomEvent<T = any> extends Event {
  constructor(type: string, init?: CustomEventCustomEventInit);
  get detail(): T;
}
```