### PR TITLE
Remove Fetcher methods get(), put(), delete() with compat flag.

### DIFF
--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -581,13 +581,14 @@ public:
       JSG_METHOD(scheduled);
     }
 
-    // TODO(soon): Deprecate get/put/delete convenience methods, remove via compat flag. These were
-    // never documented for service bindings. Extremely old KV bindings relied on them, before
-    // KV had its own separate API implementation -- anyone with such old KV bindings may have to
-    // recreate them when updating their compat flags for this removal.
-    JSG_METHOD(get);
-    JSG_METHOD(put);
-    JSG_METHOD_NAMED(delete, delete_);
+    if (!flags.getFetcherNoGetPutDelete()) {
+      // These helpers just map to `fetch()` with the corresponding HTTP method. They were never
+      // documented and probably never should have been defined. We are removing them to make room
+      // for RPC.
+      JSG_METHOD(get);
+      JSG_METHOD(put);
+      JSG_METHOD_NAMED(delete, delete_);
+    }
 
     if (flags.getWorkerdExperimental()) {
       JSG_WILDCARD_PROPERTY(getRpcMethod);

--- a/src/workerd/api/tests/js-rpc-flag.js
+++ b/src/workerd/api/tests/js-rpc-flag.js
@@ -12,6 +12,10 @@ export class DurableObjectExample {
   foo() {
     return 123;
   }
+
+  fetch(req) {
+    return new Response(req.method + " " + req.url);
+  }
 }
 
 export default {
@@ -19,6 +23,10 @@ export default {
     let id = env.ns.idFromName("foo");
     let obj = env.ns.get(id);
     assert.strictEqual(await obj.foo(), 123);
+
+    // Test that the object has the old helper get() method that wraps fetch(). This is deprecated,
+    // but enabled because this test's compat date is before the date when these went away.
+    assert.strictEqual(await obj.get("http://foo"), "GET http://foo");
   }
 }
 

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -185,6 +185,16 @@ export class MyService extends WorkerEntrypoint {
     result.value = callback.foo;
     return result;
   }
+
+  get(a) {
+    return a + 1;
+  }
+  put(a, b) {
+    return a + b;
+  }
+  delete(a) {
+    return a - 1;
+  }
 }
 
 export class MyActor extends DurableObject {
@@ -654,6 +664,15 @@ export let testAsyncStackTrace = {
   }
 }
 
+// Test that get(), put(), and delete() are valid RPC method names, not hijacked by Fetcher.
+export let canUseGetPutDelete = {
+  async test(controller, env, ctx) {
+    assert.strictEqual(await env.MyService.get(12), 13);
+    assert.strictEqual(await env.MyService.put(5, 7), 12);
+    assert.strictEqual(await env.MyService.delete(3), 2);
+  }
+}
+
 function withRealSocket(inner) {
   return {
     async test(controller, env, ctx) {
@@ -673,3 +692,4 @@ export let z_promisePipelining_realSocket = withRealSocket(promisePipelining);
 export let z_crossContextSharingDoesntWork_realSocket = withRealSocket(crossContextSharingDoesntWork);
 export let z_serializeRpcPromiseOrProprety_realSocket = withRealSocket(serializeRpcPromiseOrProprety);
 export let z_testAsyncStackTrace_realSocket = withRealSocket(testAsyncStackTrace);
+export let z_canUseGetPutDelete_realSocket = withRealSocket(canUseGetPutDelete);

--- a/src/workerd/api/tests/js-rpc-test.wd-test
+++ b/src/workerd/api/tests/js-rpc-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "js-rpc-test.js")
         ],
         compatibilityDate = "2024-01-01",
-        compatibilityFlags = ["nodejs_compat","experimental"],
+        compatibilityFlags = ["nodejs_compat","fetcher_no_get_put_delete","experimental"],
         bindings = [
           (name = "self", service = (name = "js-rpc-test", entrypoint = "nonClass")),
           (name = "MyService", service = (name = "js-rpc-test", entrypoint = "MyService")),

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -390,4 +390,16 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Python modules are restricted in EWC.
   #
   # WARNING: Python Workers are still an experimental feature and thus subject to change.
+
+  fetcherNoGetPutDelete @44 :Bool
+      $compatEnableFlag("fetcher_no_get_put_delete")
+      $compatDisableFlag("fetcher_has_get_put_delete")
+      $compatEnableDate("2024-03-26");
+  # Historically, the `Fetcher` type -- which is the type of Service Bindings, and also the parent
+  # type of Durable Object stubs -- had special methods `get()`, `put()`, and `delete()`, which
+  # were shortcuts for calling `fetch()` with the corresponding HTTP method. These methods were
+  # never documented.
+  #
+  # To make room for people to define their own RPC methods with these names, this compat flag
+  # makes them no longer defined.
 }


### PR DESCRIPTION
These were intended to be convenient wrappers around `fetch()` that perform the respective HTTP method. It was a bad idea (my fault). Luckily it was never documented and probably few people depend on it.

Note that a long time ago, KV namespace bindings were Fetchers rather than being the specific KvNamespace type. This had lots of problems, but sort of worked as long as your key names were URL-safe. It's possible very old scripts are in production that still depend on these old-style bindings, but they won't be broken since they obviously have ancient compat dates as well. (In fact... they predate compat dates...)