### PR TITLE
Update queues debug logging to ignore aborted requests

### DIFF
--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -127,8 +127,8 @@ public:
   kj::Promise<void> drain();
 
   // Waits for all "waitUntil" tasks to finish, up to the time limit for scheduled events, as
-  // defined by `scheduledTimeoutMs` in `WorkerLimits`. Returns a bool indicating `true` if the
-  // event completed successfully, or `false`, if it was canceled early.
+  // defined by `scheduledTimeoutMs` in `WorkerLimits`. Returns an enum indicating if the
+  // event completed successfully, hit a timeout, or was aborted.
   //
   // Note that, while this is similar in some ways to `drain()`, `finishScheduled()` is intended
   // to be called synchronously during request handling, i.e. where a client is waiting for the
@@ -138,7 +138,8 @@ public:
   // This method is also used by some custom event handlers (see WorkerInterface::CustomEvent) that
   // need similar behavior, as well as the test handler. TODO(cleanup): Rename to something more
   // generic?
-  kj::Promise<bool> finishScheduled();
+  enum class FinishScheduledResult { COMPLETED, ABORTED, TIMEOUT };
+  kj::Promise<FinishScheduledResult> finishScheduled();
 
   RequestObserver& getMetrics() { return *metrics; }
 

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -491,7 +491,8 @@ kj::Promise<WorkerInterface::ScheduledResult> WorkerEntrypoint::runScheduled(
                                              kj::Own<IoContext::IncomingRequest> request)
       -> kj::Promise<WorkerInterface::ScheduledResult> {
     TRACE_EVENT("workerd", "WorkerEntrypoint::runScheduled() waitForFinished()");
-    bool completed = co_await request->finishScheduled();
+    auto result = co_await request->finishScheduled();
+    bool completed = result == IoContext_IncomingRequest::FinishScheduledResult::COMPLETED;
     co_return WorkerInterface::ScheduledResult {
       .retry = context.shouldRetryScheduled(),
       .outcome = completed ? context.waitUntilStatus() : EventOutcome::EXCEEDED_CPU
@@ -634,7 +635,8 @@ kj::Promise<bool> WorkerEntrypoint::test() {
                                              kj::Own<IoContext::IncomingRequest> request)
       -> kj::Promise<bool> {
     TRACE_EVENT("workerd", "WorkerEntrypoint::test() waitForFinished()");
-    bool completed = co_await request->finishScheduled();
+    auto result = co_await request->finishScheduled();
+    bool completed = result == IoContext_IncomingRequest::FinishScheduledResult::COMPLETED;
     auto outcome = completed ? context.waitUntilStatus() : EventOutcome::EXCEEDED_CPU;
     co_return outcome == EventOutcome::OK;
   };


### PR DESCRIPTION
WIP

- Ignore "aborted" requests and only log info on timeouts
- TODO: Add more contextual info (user account ID)


CC: @a-robinson 