### PR TITLE
Simplify ValueReadable/ByteReadable

### DIFF
--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -16,8 +16,6 @@ using ByobController = jsg::Ref<ReadableByteStreamController>;
 
 struct ValueReadable;
 struct ByteReadable;
-KJ_DECLARE_NON_POLYMORPHIC(ValueReadable);
-KJ_DECLARE_NON_POLYMORPHIC(ByteReadable);
 
 // =======================================================================================
 // The Unlocked, Locked, ReaderLocked, and WriterLocked structs


### PR DESCRIPTION
Continuing on with necessary simplifications of the js-backed streams implementation. This carries on from the previous `AllReader` and `PumpToReader` change to further simplify