### PR TITLE
Set up Pyodide in the top level scope

### DIFF
--- a/src/pyodide/BUILD.bazel
+++ b/src/pyodide/BUILD.bazel
@@ -74,7 +74,7 @@ copy_file(
 # TODO: all of these should be fixed by linking our own Pyodide or by upstreaming.
 
 PRELUDE = """
-import { newWasmModule, monotonicDateNow, wasmInstantiate } from "pyodide-internal:builtin_wrappers";
+import { newWasmModule, monotonicDateNow, wasmInstantiate, getRandomValues } from "pyodide-internal:builtin_wrappers";
 
 // Pyodide uses `new URL(some_url, location)` to resolve the path in `loadPackage`. Setting
 // `location = undefined` makes this throw an error if some_url is not an absolute url. Which is what
@@ -107,6 +107,10 @@ REPLACEMENTS = [
     [
         "Date.now",
         "monotonicDateNow",
+    ],
+    [
+        "crypto.getRandomValues",
+        "getRandomValues"
     ],
     [
         # Expose recursiveDependencies for use in setupPackages

--- a/src/pyodide/internal/python.js
+++ b/src/pyodide/internal/python.js
@@ -70,39 +70,6 @@ import stdlib from "pyodide-internal:generated/python_stdlib.zip";
 let MEMORY = undefined;
 
 /**
- * This is passed as a preRun hook in EmscriptenSettings, run just before
- * main(). It ensures that the file system includes the stuff that main() needs,
- * most importantly the Python standard library.
- *
- * Put the Python + Pyodide standard libraries into a zip file in the
- * appropriate location /lib/python311.zip . Python will import stuff directly
- * from this zip file using ZipImporter.
- *
- * ZipImporter is quite useful here -- the Python runtime knows how to unpack a
- * bunch of different archive formats but it is not possible to use these until
- * the runtime state is initialized. So ZipImporter breaks this bootstrapping
- * knot for us.
- *
- * We also make an empty home directory and an empty global site-packages
- * directory `/lib/pythonv.vv/site-packages`.
- *
- * This is a simpified version of the `prepareFileSystem` function here:
- * https://github.com/pyodide/pyodide/blob/main/src/js/module.ts
- */
-function prepareFileSystem(Module) {
-  const pymajor = Module._py_version_major();
-  const pyminor = Module._py_version_minor();
-  Module.FS.mkdirTree("/lib");
-  Module.FS.mkdirTree(`/lib/python${pymajor}.${pyminor}/site-packages`);
-  Module.FS.writeFile(
-    `/lib/python${pymajor}${pyminor}.zip`,
-    new Uint8Array(stdlib),
-    { canOwn: true },
-  );
-  Module.FS.mkdir(Module.API.config.env.HOME);
-}
-
-/**
  * A hook that the Emscripten runtime calls to perform the WebAssembly
  * instantiation action. Once instantiated, this callback function should call
  * ``successCallback()`` with the generated WebAssembly Instance object.
@@ -130,6 +97,46 @@ function instantiateWasm(wasmImports, successCallback) {
 }
 
 /**
+ * This is passed as a preRun hook in EmscriptenSettings, run just before
+ * main(). It ensures that the file system includes the stuff that main() needs,
+ * most importantly the Python standard library.
+ *
+ * Put the Python + Pyodide standard libraries into a zip file in the
+ * appropriate location /lib/python311.zip . Python will import stuff directly
+ * from this zip file using ZipImporter.
+ *
+ * ZipImporter is quite useful here -- the Python runtime knows how to unpack a
+ * bunch of different archive formats but it is not possible to use these until
+ * the runtime state is initialized. So ZipImporter breaks this bootstrapping
+ * knot for us.
+ *
+ * We also make an empty home directory and an empty global site-packages
+ * directory `/lib/pythonv.vv/site-packages`.
+ *
+ * This is a simpified version of the `prepareFileSystem` function here:
+ * https://github.com/pyodide/pyodide/blob/main/src/js/module.ts
+ */
+function prepareFileSystem(Module) {
+  try {
+    const pymajor = Module._py_version_major();
+    const pyminor = Module._py_version_minor();
+    Module.FS.mkdirTree(`/lib/python${pymajor}.${pyminor}/site-packages`);
+    Module.FS.writeFile(
+      `/lib/python${pymajor}${pyminor}.zip`,
+      new Uint8Array(stdlib),
+      { canOwn: true },
+    );
+    Module.FS.mkdirTree(Module.API.config.env.HOME);
+  } catch (e) {
+    console.warn(e);
+  }
+}
+
+function setEnv(Module) {
+  Object.assign(Module.ENV, Module.API.config.env);
+}
+
+/**
  * The Emscripten settings object
  *
  * This isn't public API of Pyodide so it's a bit fiddly.
@@ -139,7 +146,12 @@ function getEmscriptenSettings(lockfile, indexURL) {
     // jsglobals is used for the js module.
     jsglobals: globalThis,
     // environment variables go here
-    env: { HOME: "/session" },
+    env: {
+      HOME: "/session",
+      // We don't have access to cryptographic rng at startup so we cannot support hash
+      // randomization. Setting `PYTHONHASHSEED` disables it.
+      PYTHONHASHSEED: "111",
+    },
     // This is the index that we use as the base URL to fetch the wheels.
     indexURL,
   };
@@ -151,7 +163,7 @@ function getEmscriptenSettings(lockfile, indexURL) {
     // preRun hook to set up the file system before running main
     // The preRun hook gets run independently of noInitialRun, which is
     // important because the file system lives outside of linear memory.
-    preRun: [prepareFileSystem],
+    preRun: [prepareFileSystem, setEnv],
     instantiateWasm,
     noInitialRun: !!MEMORY, // skip running main() if we have a snapshot
     API, // Pyodide requires we pass this in.
@@ -350,7 +362,7 @@ export function mountLib(pyodide, requirements, isWorkerd) {
   sys.destroy();
 }
 
-export async function loadPyodide(context, lockfile, indexURL) {
+export async function loadPyodide(lockfile, indexURL) {
   // Lookup memory snapshot from artifact store.
   const maybeMemorySnapshot = ArtifactBundler.getMemorySnapshot();
   if (maybeMemorySnapshot) {

--- a/src/pyodide/python-entrypoint-helper.js
+++ b/src/pyodide/python-entrypoint-helper.js
@@ -173,7 +173,6 @@ async function preparePython() {
   return await getMainModule();
 }
 
-// Error.stackTraceLimit = Infinity;
 
 export default {
   async fetch(request, env, ctx) {

--- a/src/pyodide/python-entrypoint-helper.js
+++ b/src/pyodide/python-entrypoint-helper.js
@@ -80,7 +80,17 @@ async function getTransitiveRequirements(pyodide, requirements) {
   return new Set(packageDatas.map(({ name }) => name));
 }
 
-async function setupPackages(pyodide, transitiveRequirements) {
+async function setupPackages(pyodide) {
+  patchLoadPackage(pyodide);
+  const requirements = MetadataReader.getRequirements().map(
+    canonicalizePackageName,
+  );
+  const transitiveRequirements = new Set(
+    Array.from(await getTransitiveRequirements(pyodide, requirements)).map(
+      canonicalizePackageName,
+    ),
+  );
+
   mountLib(pyodide, transitiveRequirements, IS_WORKERD);
 
   // install any extra packages into the site-packages directory, so calculate where that is.
@@ -109,35 +119,66 @@ function pyimportMainModule(pyodide) {
   return pyodide.pyimport(mainModuleName);
 }
 
+let pyodidePromise;
+function getPyodide() {
+  if (pyodidePromise) {
+    return pyodidePromise;
+  }
+  pyodidePromise = loadPyodide(LOCKFILE, WORKERD_INDEX_URL);
+  return pyodidePromise;
+}
+
 let mainModulePromise;
-function getPyodide(ctx) {
-  if (mainModulePromise !== undefined) {
+function getMainModule() {
+  if (mainModulePromise) {
     return mainModulePromise;
   }
   mainModulePromise = (async function () {
-    // TODO: investigate whether it is possible to run part of loadPyodide in top level scope
-    // When we do it in top level scope we seem to get a broken file system.
-    const pyodide = await loadPyodide(ctx, LOCKFILE, WORKERD_INDEX_URL);
-    patchLoadPackage(pyodide);
-    const requirements = MetadataReader.getRequirements().map(
-      canonicalizePackageName,
-    );
-    const transitiveRequirements = new Set(
-      Array.from(await getTransitiveRequirements(pyodide, requirements)).map(
-        canonicalizePackageName,
-      ),
-    );
-    await setupPackages(pyodide, transitiveRequirements);
-    const mainModule = pyimportMainModule(pyodide);
-    return { mainModule };
+    const pyodide = await getPyodide();
+    await setupPackages(pyodide);
+    return pyimportMainModule(pyodide);
   })();
   return mainModulePromise;
 }
 
+if (IS_WORKERD) {
+  // If we're in workerd, we have to do setupPackages in the IoContext, so don't start it yet.
+  // TODO: fix this.
+  await getPyodide();
+} else {
+  // If we're not in workerd, setupPackages doesn't require IO so we can do it all here.
+  await getMainModule();
+}
+
+/**
+ * Have to reseed randomness in the IoContext of the first request since we gave a low quality seed
+ * when it was seeded at top level.
+ */
+let isSeeded = false;
+function reseedRandom(pyodide) {
+  if (isSeeded) {
+    return;
+  }
+  isSeeded = true;
+  pyodide.runPython(`
+    from random import seed
+    seed()
+    del seed
+  `);
+}
+
+async function preparePython() {
+  const pyodide = await getPyodide();
+  reseedRandom(pyodide);
+  return await getMainModule();
+}
+
+// Error.stackTraceLimit = Infinity;
+
 export default {
   async fetch(request, env, ctx) {
     try {
-      const { mainModule } = await getPyodide(ctx);
+      const mainModule = await preparePython();
       if (mainModule.on_fetch === undefined) {
         throw new Error("Python Worker should define an on_fetch method");
       }
@@ -149,7 +190,7 @@ export default {
   },
   async test(ctrl, env, ctx) {
     try {
-      const { mainModule } = await getPyodide(ctx);
+      const mainModule = await preparePython();
       return await mainModule.test.callRelaxed(ctrl, env, ctx);
     } catch (e) {
       console.warn(e.stack);


### PR DESCRIPTION
This ensures that Pyodide instantiation and package loading happens inside of the enterStartupJs limitEnforcer. In workerd, we can't yet load packages outside of an IoContext because we make actual requests to load the packages. So in workerd, only run loadPyodide at top level and run setupPackages at first request. In the internal runtime, we can do the whole thing at top level.

As a side effect, we have to disable hash randomization because normally the hash comes from `crypto.getRandomValues` but this crashes at top level. Likewise, Python initializes the `random` module's random seed using `crypto.getRandomValues`. We replace `crypto.getRandomValues` with a function that tries to call `crypto.getRandomValues` but if it throws an Error saying `"Disallowed operation called within global scope"` then we fall back to doing nothing. We reseed the rng in the first request context. Note however that hash randomization can only happen at startup, if we don't have access to crypographic rng at startup we can't enable hash randomization later.