### PR TITLE
Implement EventSource

### DIFF
--- a/samples/eventsource/README.md
+++ b/samples/eventsource/README.md
@@ -1,0 +1,13 @@
+# EventSource Example
+
+To run the example on http://localhost:8080
+
+```sh
+$ ./workerd serve config.capnp
+```
+
+To run using bazel
+
+```sh
+$ bazel run //src/workerd/server:workerd -- serve ~/cloudflare/workerd/samples/eventsource/config.capnp
+```

--- a/samples/eventsource/config.capnp
+++ b/samples/eventsource/config.capnp
@@ -1,0 +1,22 @@
+# Copyright (c) 2017-2024 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+using Workerd = import "/workerd/workerd.capnp";
+
+const eventSourceExample :Workerd.Config = (
+
+  services = [
+    (name = "main", worker = .eventsource),
+    (name = "internet", network = (allow = ["private"]))
+  ],
+
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ]
+);
+
+const eventsource :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js")
+  ],
+  compatibilityDate = "2024-05-31",
+);

--- a/samples/eventsource/server.js
+++ b/samples/eventsource/server.js
@@ -1,0 +1,38 @@
+// Copyright (c) 2017-2024 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// This is a simple SSE server written for Node.js ... it sends a message every second
+// for 10 seconds, then disconnects. The worker.js file will use the EventSource API to
+// connect to this server.
+
+const { createServer } = require('http');
+
+let counter = 0;
+
+function getMessage(txt) {
+  return `data: ${txt}\nid: ${counter++}\n\n`;
+}
+
+const server = createServer((req, res) => {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive'
+  });
+
+  res.write(getMessage('Hello World'));
+
+  let t = setInterval(() => {
+    res.write(getMessage('Hello World'));
+    if (counter === 10) {
+      clearInterval(t);
+      res.end();
+      counter = 0;
+    }
+  }, 1000);
+});
+
+server.listen(8888, () => {
+  console.log('Server is running...');
+});

--- a/samples/eventsource/worker.js
+++ b/samples/eventsource/worker.js
@@ -1,0 +1,31 @@
+// Copyright (c) 2017-2024 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+export default {
+  async fetch(req, env) {
+    const ev = new EventSource('http://localhost:8888');
+
+    // Note that as a non-standard extension, within workers it is possible to
+    // create an EventSource from an existing ReadableStream.
+    //
+    // const ev = EventSource.from(readable);
+
+    ev.onopen = () => {
+      console.log('open!');
+    };
+
+    ev.onerror = (event) => {
+      console.log('error!', event.error);
+    };
+
+    ev.onmessage = (event) => {
+      console.log('message!', event.data, event.lastEventId);
+    };
+
+    // We'll keep the connection open and running for 20 seconds...
+    await scheduler.wait(20000);
+
+    return new Response("Hello World\n");
+  }
+};

--- a/src/workerd/api/eventsource.c++
+++ b/src/workerd/api/eventsource.c++
@@ -1,0 +1,527 @@
+// Copyright (c) 2017-2024 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "eventsource.h"
+#include "http.h"
+#include "streams/common.h"
+#include <workerd/io/features.h>
+#include <workerd/jsg/exception.h>
+#include <workerd/util/mimetype.h>
+
+namespace workerd::api {
+
+namespace {
+class EventSourceSink final: public WritableStreamSink {
+public:
+  EventSourceSink(EventSource& eventSource) : eventSource(eventSource) {}
+
+  kj::Promise<void> write(kj::ArrayPtr<const kj::byte> buffer) override {
+    // The event stream is a new-line delimited format where each line represents an event.
+    // We need to scan the buffer for end-of-line characters. When we find one, everything before
+    // it is pushed into the event queue and we keep scanning. If we do not find an end-of-line
+    // sequence in the remaining input, we buffer it and wait for the next write to continue
+    // scanning, or until the stream is ended or aborted.
+
+    if (eventSource == kj::none) {
+      // Write was received after end() or abort() was called.
+      // We'll just ignore the write.
+      return kj::READY_NOW;
+    }
+
+    auto input = buffer.asChars();
+
+    // The stream may or may not begin with the UTF-8 BOM (%xFEFF). If this is the
+    // first write, we need to check for it and skip it if it is present.
+    // The BOM is a 3-byte sequence (0xEF, 0xBB, 0xBF) that encodes the Unicode
+    // codepoint U+FEFF. We only want to check for this once.
+    if (!bomChecked) {
+      bomChecked = true;
+      if (input.size() >= 3 &&
+          input[0] == '\xEF' &&
+          input[1] == '\xBB' &&
+          input[2] == '\xBF') {
+        input = input.slice(3);
+      }
+    }
+
+    while (input != nullptr) {
+      KJ_IF_SOME(found, findEndOfLine(input)) {
+          auto prefix = kept.releaseAsArray();
+          // Feed the line into the processor.
+          feed(kj::str(prefix, input.slice(0, found.pos)));
+          input = found.remaining;
+          // If we've reached the end of the input, input will == nullptr here.
+      } else {
+        // No end-of-line found, buffer the input.
+        kept.addAll(input.begin(), input.end());
+        input = nullptr;
+      }
+    }
+
+    // Release any buffered events to the EventSource
+    release();
+
+    return kj::READY_NOW;
+  }
+
+  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces) override {
+    for (auto& piece : pieces) {
+      co_await write(piece);
+    }
+    co_return;
+  }
+
+  kj::Promise<void> end() override {
+    // The stream has finished. There's really nothing left to do here. Any partially
+    // filled data will be dropped on the floor.
+    clear();
+    return kj::READY_NOW;
+  }
+
+  void abort(kj::Exception reason) override {
+    // There's really nothing to do here.
+    clear();
+  }
+
+private:
+  kj::Maybe<EventSource&> eventSource;
+
+  // Retained bytes to be processed in the next write.
+  kj::Vector<char> kept;
+
+  // The collected messages that are pending to be dispatched as events
+  kj::Vector<EventSource::PendingMessage> pendingMessages;
+
+  // The message that is currently being processed.
+  kj::Maybe<EventSource::PendingMessage> currentPendingMessage;
+
+  // Set to true once the byte-order-mark has been checked
+  bool bomChecked = false;
+
+  EventSource::PendingMessage& getPendingMessage() {
+    KJ_IF_SOME(pending, currentPendingMessage) {
+      return pending;
+    }
+    return currentPendingMessage.emplace();
+  }
+
+  void feed(kj::String line) {
+    // Parse line according to the event stream format and dispatch the event.
+
+    // stream        = [ bom ] *event
+    // event         = *( comment / field ) end-of-line
+    // comment       = colon *any-char end-of-line
+    // field         = 1*name-char [ colon [ space ] *any-char ] end-of-line
+    // end-of-line   = ( cr lf / cr / lf )
+
+    // ; characters
+    // lf            = %x000A ; U+000A LINE FEED (LF)
+    // cr            = %x000D ; U+000D CARRIAGE RETURN (CR)
+    // space         = %x0020 ; U+0020 SPACE
+    // colon         = %x003A ; U+003A COLON (:)
+    // bom           = %xFEFF ; U+FEFF BYTE ORDER MARK
+    // name-char     = %x0000-0009 / %x000B-000C / %x000E-0039 / %x003B-10FFFF
+    //                 ; a scalar value other than U+000A LINE FEED (LF), U+000D CARRIAGE RETURN
+    //                   (CR), or U+003A COLON (:)
+    // any-char      = %x0000-0009 / %x000B-000C / %x000E-10FFFF
+    //                 ; a scalar value other than U+000A LINE FEED (LF) or U+000D CARRIAGE
+    //                   RETURN (CR)
+
+    // Note that the BOM (if present) is filtered out in the write() method.
+
+    if (line.size() == 0) {
+      // Dispatch the current pending message and clear it. If there is no
+      // pending message, we'll just ignore the line.
+      KJ_IF_SOME(pending, currentPendingMessage) {
+        // This message is done and ready to be dispatched. Add it to the
+        // pendingMessages list. The next time release() is called, it will
+        // be passed off to the EventSource.
+        pending.id = kj::str(KJ_ASSERT_NONNULL(eventSource).getLastEventId());
+        pendingMessages.add(kj::mv(pending));
+        currentPendingMessage = kj::none;
+      }
+    } else if (line[0] == ':') {
+      // Ignore the line.
+    } else {
+      static constexpr auto handle =
+          [](auto& self, kj::ArrayPtr<const char> field, kj::ArrayPtr<const char> value) {
+        auto& pending = self.getPendingMessage();
+        auto& ev = KJ_ASSERT_NONNULL(self.eventSource);
+        // Per the spec, only one space after the colon is optional and trimmed.
+        // Any other whitespace, or additional spaces aren't accounted for so would
+        // be part of the value.
+        if (value.size() > 0 && value[0] == ' ') {
+          value = value.slice(1);
+        }
+        if (field == "data"_kjc) {
+          pending.data.add(kj::str(value));
+        } else if (field == "event"_kjc) {
+          pending.event = kj::str(value);
+        } else if (field == "id"_kjc) {
+          ev.setLastEventId(kj::str(value));
+        } else if (field == "retry"_kjc) {
+          KJ_IF_SOME(time, kj::str(value).tryParseAs<uint32_t>()) {
+            KJ_ASSERT_NONNULL(self.eventSource).setReconnectionTime(time);
+          }
+          // Ignore the line if it cannot be successfully parsed as a uint32_t
+        }
+      };
+
+      KJ_IF_SOME(pos, line.findFirst(':')) {
+        handle(*this, line.slice(0, pos), line.slice(pos + 1));
+      } else {
+        handle(*this, line, ""_kjc);
+      }
+    }
+  }
+
+  void release() {
+    if (pendingMessages.size() == 0) return;
+    auto pending = pendingMessages.releaseAsArray();
+    // If the event source is gone, just drop the messages on the floor.
+    KJ_IF_SOME(es, eventSource) {
+      es.enqueueMessages(kj::mv(pending));
+    }
+  }
+
+  void clear() {
+    eventSource = kj::none;
+    kept.clear();
+    pendingMessages.clear();
+    currentPendingMessage = kj::none;
+  }
+
+  struct EndOfLine {
+    size_t pos;
+    kj::ArrayPtr<const char> remaining;
+  };
+  kj::Maybe<EndOfLine> findEndOfLine(kj::ArrayPtr<const char> input) {
+    // The end-of-line marker is either \n, \r, or \r\n
+    size_t pos = 0;
+    while (pos < input.size()) {
+      if (input[pos] == '\n') {
+        return EndOfLine{pos, input.slice(pos + 1)};
+      } else if (input[pos] == '\r') {
+        if (pos + 1 < input.size() && input[pos + 1] == '\n') {
+          return EndOfLine{pos, input.slice(pos + 2)};
+        }
+        return EndOfLine{pos, input.slice(pos + 1)};
+      }
+      pos++;
+    }
+    return kj::none;
+  }
+};
+
+kj::Promise<void> processBody(IoContext& context, kj::Promise<DeferredProxy<void>> promise) {
+  try {
+    co_await context.waitForDeferredProxy(kj::mv(promise));
+  } catch (...) {
+    auto ex = kj::getCaughtExceptionAsKj();
+    // We would see a disconnection exception if the eventstream is closed for
+    // multiple kinds of reasons. If it's a network error and we know we can
+    // reconnect, we should try to reconnect.
+    if (ex.getType() == kj::Exception::Type::DISCONNECTED) {
+      co_return;
+    }
+    // Propagate the exception up.
+    throw;
+  }
+}
+}  // namespace
+
+jsg::Ref<EventSource> EventSource::constructor(
+    jsg::Lock& js,
+    kj::String url,
+    jsg::Optional<EventSourceInit> init) {
+  JSG_REQUIRE(IoContext::hasCurrent(), DOMNotSupportedError,
+      "An EventSource can only be created within the context of a worker request.");
+
+  KJ_IF_SOME(i, init) {
+    KJ_IF_SOME(withCredentials, i.withCredentials) {
+      JSG_REQUIRE(!withCredentials, DOMNotSupportedError,
+          "The init.withCredentials option is not supported. It must be false or undefined.");
+    }
+  }
+
+  auto eventsource = jsg::alloc<EventSource>(js,
+      JSG_REQUIRE_NONNULL(jsg::Url::tryParse(url.asPtr()),
+          DOMSyntaxError,
+          kj::str("Cannot open an EventSource to '", url ,"'. The URL is invalid.")),
+      kj::mv(init));
+  eventsource->start(js);
+  return kj::mv(eventsource);
+}
+
+jsg::Ref<EventSource> EventSource::from(jsg::Lock& js, jsg::Ref<ReadableStream> readable) {
+  JSG_REQUIRE(IoContext::hasCurrent(), DOMNotSupportedError,
+      "An EventSource can only be created within the context of a worker request.");
+  JSG_REQUIRE(!readable->isLocked(), TypeError,
+               "This ReadableStream is locked.");
+  JSG_REQUIRE(!readable->isDisturbed(), TypeError,
+              "This ReadableStream has already been read from.");
+  auto eventsource = jsg::alloc<EventSource>(js);
+  eventsource->run(js, kj::mv(readable), false /* No reconnection attempts */);
+  return kj::mv(eventsource);
+}
+
+EventSource::EventSource(jsg::Lock& js, jsg::Url url, kj::Maybe<EventSourceInit> init)
+    : context(IoContext::current()),
+      impl({
+        .url = kj::mv(url),
+        .options = kj::mv(init).orDefault({}),
+      }),
+      abortController(jsg::alloc<AbortController>()),
+      readyState(State::CONNECTING) {}
+
+EventSource::EventSource(jsg::Lock& js)
+    : context(IoContext::current()),
+      abortController(jsg::alloc<AbortController>()),
+      readyState(State::CONNECTING) {}
+
+void EventSource::notifyError(jsg::Lock& js, const jsg::JsValue& error, bool reconnecting) {
+  if (readyState == State::CLOSED) return;
+
+  // Abort the connection if it hasn't already been. This will be a non-op if the
+  // controller has already been aborted.
+  abortController->abort(js, error);
+
+  if (!reconnecting) readyState = State::CLOSED;
+  else readyState = State::CONNECTING;
+
+  // Dispatch the error event.
+  dispatchEventImpl(js, jsg::alloc<ErrorEvent>(js, error));
+
+  // Log the error as an uncaught exception for debugging purposes.
+  IoContext::current().logUncaughtException(UncaughtExceptionSource::ASYNC_TASK, error);
+}
+
+void EventSource::notifyOpen(jsg::Lock& js) {
+  if (readyState == State::CLOSED) return;
+  readyState = State::OPEN;
+  dispatchEventImpl(js, jsg::alloc<OpenEvent>());
+}
+
+void EventSource::notifyMessages(jsg::Lock& js, kj::Array<PendingMessage> messages) {
+  if (readyState == State::CLOSED) return;
+  js.tryCatch([&] {
+    for (auto& message : messages) {
+        auto data = kj::str(kj::delimited(kj::mv(message.data), "\n"_kjc));
+        if (data.size() == 0) continue;
+        dispatchEventImpl(js, jsg::alloc<MessageEvent>(
+            kj::mv(message.event),
+            kj::mv(data),
+            kj::mv(message.id),
+            impl.map([](FetchImpl& i) -> jsg::Url& { return i.url; })));
+    }
+  }, [&](jsg::Value exception) {
+    // If we end up with an exception being thrown in one of the event handlers, we will
+    // stop trying to process the messages and instead just error the EventSource.
+    notifyError(js, jsg::JsValue(exception.getHandle(js)));
+  });
+}
+
+void EventSource::reconnect(jsg::Lock& js) {
+  KJ_ASSERT(impl != kj::none);
+  readyState = State::CONNECTING;
+  abortController = jsg::alloc<AbortController>();
+  auto signal = abortController->getSignal();
+  context.awaitIo(js, signal->wrap(context.afterLimitTimeout(reconnectionTime)))
+      .then(js, JSG_VISITABLE_LAMBDA((self=JSG_THIS), (self), (jsg::Lock& js) mutable {
+    self->start(js);
+  }), JSG_VISITABLE_LAMBDA((self=JSG_THIS),(self),(jsg::Lock& js, jsg::Value exception) {
+    // In this case, it is most likely the EventSource was closed by the user or
+    // there was some other failure. We should not continue trying to reconnect.
+    self->notifyError(js, jsg::JsValue(exception.getHandle(js)));
+  }));
+}
+
+void EventSource::start(jsg::Lock& js) {
+  auto& i = KJ_ASSERT_NONNULL(impl);
+  if (readyState == State::CLOSED) return;
+
+  auto fetcher = i.options.fetcher.map([](jsg::Ref<Fetcher>& f) { return f.addRef(); });
+
+  static auto handleError = [](auto& js, auto& self, kj::String message) {
+    auto ex = js.domException(kj::str("AbortError"), kj::mv(message));
+    auto handle = KJ_ASSERT_NONNULL(ex.tryGetHandle(js));
+    self->notifyError(js, jsg::JsValue(handle));
+    return js.resolvedPromise();
+  };
+
+  auto onSuccess = JSG_VISITABLE_LAMBDA(
+      (self=JSG_THIS,
+       fetcher = fetcher.map([](jsg::Ref<Fetcher>& f) -> jsg::Ref<Fetcher> { return f.addRef(); })),
+      (self, fetcher),
+      (jsg::Lock& js, jsg::Ref<Response> response) {
+    if (self->readyState == State::CLOSED) return js.resolvedPromise();
+    auto& impl = KJ_ASSERT_NONNULL(self->impl);
+    if (!response->getOk()) {
+      // Response status code is not 2xx, so we fail.
+      // No reconnection attempt should be made.
+      return handleError(js, self,
+          kj::str("The response status code was ", response->getStatus(), "."));
+    }
+
+    // TODO(cleanup): Using jsg::ByteString here is really annoying. It would be nice to have
+    // an internal alternative that doesn't require an allocation.
+    KJ_IF_SOME(contentType, response->getHeaders(js)->get(
+        jsg::ByteString(kj::str("content-type")))) {
+      bool invalid = false;
+      KJ_IF_SOME(parsed, MimeType::tryParse(contentType)) {
+        invalid = parsed != MimeType::EVENT_STREAM;
+      } else {
+        invalid = true;
+      }
+      if (invalid) {
+        // No reconnection attempt should be made.
+        return handleError(js, self, kj::str("The content type '", contentType, "' is invalid."));
+      }
+    } else {
+      // No reconnection attempt should be made.
+      return handleError(js, self, kj::str("No content type header was present in the response."));
+    }
+
+    // If the request was redirected, update the URL to the new location.
+    if (response->getRedirected()) {
+      KJ_IF_SOME(newUrl, jsg::Url::tryParse(response->getUrl())) {
+        impl.url = kj::mv(newUrl);
+      } else {}  // Extra else block to squash compiler warning
+    }
+
+    KJ_IF_SOME(body, response->getBody()) {
+      // Well, ok! We're ready to start trying to process the stream! We do so by
+      // pumping the body into an EventSourceSink until the body is closed, canceled,
+      // or errored.
+      self->run(js, kj::mv(body), true, response.addRef(), kj::mv(fetcher));
+      return js.resolvedPromise();
+    } else {
+      auto& i = KJ_ASSERT_NONNULL(self->impl);
+      // If there is no body, there's nothing to do. We'll treat this as if
+      // the server disconnected. If it only happens once, we'll try to reconnect.
+      // If it happens again, we'll fail the connection as it is likely indicative
+      // of a bug in the server or along the path to the server.
+      if (i.previousNoBody) {
+         self->notifyError(js, js.error("The server provided no content."));
+      } else {
+        i.previousNoBody = true;
+        self->notifyError(js,
+            js.error("The server provided no content. Will try reconnecting."),
+            true /* reconnecting */);
+        self->reconnect(js);
+      }
+      return js.resolvedPromise();
+    }
+  });
+
+  auto onFailed = JSG_VISITABLE_LAMBDA(
+      (self=JSG_THIS),
+      (self),
+      (jsg::Lock& js, jsg::Value exception) {
+    self->notifyError(js, jsg::JsValue(exception.getHandle(js)));
+    return js.resolvedPromise();
+  });
+
+  auto headers = jsg::alloc<Headers>();
+  headers->set(jsg::ByteString(kj::str("accept")),
+               jsg::ByteString(MimeType::EVENT_STREAM.essence()));
+  headers->set(jsg::ByteString(kj::str("cache-control")),
+               jsg::ByteString(kj::str("no-cache")));
+  if (lastEventId != ""_kjc) {
+    headers->set(jsg::ByteString(kj::str("last-event-id")),
+                 jsg::ByteString(kj::str(lastEventId)));
+  }
+
+  fetchImpl(js, kj::mv(fetcher), kj::str(i.url), RequestInitializerDict {
+    .headers = kj::mv(headers),
+    .signal = abortController->getSignal(),
+  }).then(js, kj::mv(onSuccess), kj::mv(onFailed));
+}
+
+namespace {
+template <typename T>
+kj::Maybe<jsg::Ref<T>> addRef(kj::Maybe<jsg::Ref<T>>& ref) {
+  return ref.map([](jsg::Ref<T>& r) { return r.addRef(); });
+}
+}  // namespace
+
+void EventSource::run(jsg::Lock& js,
+                      jsg::Ref<ReadableStream> readable,
+                      bool withReconnection,
+                      kj::Maybe<jsg::Ref<Response>> response,
+                      kj::Maybe<jsg::Ref<Fetcher>> fetcher) {
+  notifyOpen(js);
+
+  auto onSuccess = JSG_VISITABLE_LAMBDA(
+      (self=JSG_THIS, readable=readable.addRef(), withReconnection,
+       response=addRef(response),
+       fetcher=addRef(fetcher)),
+      (self, readable, response, fetcher),
+      (jsg::Lock& js) {
+    // The pump finished. Did the server disconnect? If so, try reconnecting if we can.
+    self->notifyError(js, js.error("The server disconnected."), withReconnection);
+    if (withReconnection) self->reconnect(js);
+  });
+
+  auto onFailed = JSG_VISITABLE_LAMBDA(
+      (self=JSG_THIS, response=addRef(response), fetcher=addRef(fetcher)),
+      (self, response, fetcher),
+      (jsg::Lock& js, jsg::Value exception) {
+    // If the pump fails, catch the error and convert it into an error event.
+    // If we got here, it likely isn't just a DISCONNECT event. Let's not
+    // try to reconnect at this point.
+    self->notifyError(js, jsg::JsValue(exception.getHandle(js)));
+  });
+
+  // Well, ok! We're ready to start trying to process the stream! We do so by
+  // pumping the body into an EventSourceSink until the body is closed, canceled,
+  // or errored.
+  context.awaitIo(js,
+      processBody(context, readable->pumpTo(js, kj::heap<EventSourceSink>(*this), true)))
+          .then(js, kj::mv(onSuccess), kj::mv(onFailed));
+}
+
+void EventSource::close(jsg::Lock& js) {
+  if (closeCalled) return;
+  closeCalled = true;
+  abortController->abort(js, kj::none);
+  readyState = State::CLOSED;
+}
+
+void EventSource::enqueueMessages(kj::Array<PendingMessage> messages) {
+  context.addTask(context.run([this, messages=kj::mv(messages)](auto& lock) mutable {
+    notifyMessages(lock, kj::mv(messages));
+  }));
+}
+
+void EventSource::setReconnectionTime(uint32_t time) {
+  // We enforce both a min and max reconnection time. The minimum is 1 second,
+  // and the maximum is 10 seconds.
+  reconnectionTime =
+      kj::max(kj::min(time, MAX_RECONNECTION_TIME), MIN_RECONNECTION_TIME) * kj::MILLISECONDS;
+}
+
+kj::StringPtr EventSource::getLastEventId() { return lastEventId; }
+
+void EventSource::setLastEventId(kj::String id) {
+  lastEventId = kj::mv(id);
+}
+
+void EventSource::visitForGc(jsg::GcVisitor& visitor) {
+  KJ_IF_SOME(i, impl) {
+    visitor.visit(i.options.fetcher);
+  }
+  visitor.visit(abortController);
+}
+
+void EventSource::visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+  KJ_IF_SOME(i, impl) {
+    tracker.trackField("fetcher", i.options.fetcher);
+    tracker.trackField("url", i.url);
+  }
+  tracker.trackField("abortController", abortController);
+  tracker.trackField("lastEventId", lastEventId);
+}
+
+}  // namespace workerd::api

--- a/src/workerd/api/eventsource.h
+++ b/src/workerd/api/eventsource.h
@@ -1,0 +1,264 @@
+// Copyright (c) 2017-2024 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+#include <workerd/jsg/jsg.h>
+#include <workerd/jsg/url.h>
+#include "basics.h"
+
+namespace workerd::api {
+
+using kj::uint;
+class Fetcher;
+class ReadableStream;
+class Response;
+
+// Implements the web standard EventSource API
+// https://developer.mozilla.org/en-US/docs/Web/API/EventSource
+class EventSource: public EventTarget {
+public:
+  class ErrorEvent final: public Event {
+  public:
+    ErrorEvent(jsg::Lock& js, const jsg::JsValue& error)
+        : Event(kj::str("error")),
+          error(js, error) {}
+
+    static jsg::Ref<ErrorEvent> constructor() = delete;
+    JSG_RESOURCE_TYPE(ErrorEvent) {
+      JSG_INHERIT(Event);
+      JSG_LAZY_READONLY_INSTANCE_PROPERTY(error, getError);
+    }
+
+  private:
+    jsg::JsRef<jsg::JsValue> error;
+
+    jsg::JsValue getError(jsg::Lock& js) { return error.getHandle(js); }
+  };
+
+  class OpenEvent final: public Event {
+  public:
+    OpenEvent() : Event(kj::str("open")) {}
+    static jsg::Ref<OpenEvent> constructor() = delete;
+    JSG_RESOURCE_TYPE(OpenEvent) {
+      JSG_INHERIT(Event);
+    }
+  };
+
+  class MessageEvent final: public Event {
+  public:
+    explicit MessageEvent(kj::Maybe<kj::String> type,
+                 kj::String data,
+                 kj::String lastEventId,
+                 kj::Maybe<jsg::Url&> url)
+        : Event(kj::mv(type).orDefault([] { return kj::str("message");})),
+          data(kj::mv(data)),
+          lastEventId(kj::mv(lastEventId)),
+          origin(url.map([](auto& url) { return url.getOrigin(); })) {}
+
+    static jsg::Ref<MessageEvent> constructor() = delete;
+    JSG_RESOURCE_TYPE(MessageEvent) {
+      JSG_INHERIT(Event);
+      JSG_LAZY_READONLY_INSTANCE_PROPERTY(data, getData);
+      JSG_LAZY_READONLY_INSTANCE_PROPERTY(origin, getOrigin);
+      JSG_LAZY_READONLY_INSTANCE_PROPERTY(lastEventId, getLastEventId);
+    }
+
+  private:
+    kj::String data;
+    kj::String lastEventId;
+    kj::Maybe<kj::Array<const char>> origin;
+
+    kj::StringPtr getData() { return data; }
+    kj::StringPtr getLastEventId() { return lastEventId; }
+    kj::Maybe<kj::ArrayPtr<const char>> getOrigin() {
+      return origin.map([](auto& a) -> kj::ArrayPtr<const char> { return a.asPtr(); });
+    }
+  };
+
+  struct EventSourceInit {
+    // We don't actually make use of the standard withCredentials option. If this is set to
+    // any truthy value, we'll throw.
+    jsg::Optional<bool> withCredentials;
+
+    // This is a non-standard workers-specific extension that allows the EventSource to
+    // use a custom Fetcher instance.
+    jsg::Optional<jsg::Ref<Fetcher>> fetcher;
+    JSG_STRUCT(withCredentials, fetcher);
+  };
+
+  enum class State {
+    CONNECTING = 0,
+    OPEN = 1,
+    CLOSED = 2,
+  };
+
+  EventSource(jsg::Lock& js, jsg::Url url, kj::Maybe<EventSourceInit> init = kj::none);
+
+  EventSource(jsg::Lock& js);
+
+  static jsg::Ref<EventSource> constructor(jsg::Lock& js,
+                                           kj::String url,
+                                           jsg::Optional<EventSourceInit> init);
+
+  kj::ArrayPtr<const char> getUrl() const {
+    KJ_IF_SOME(i, impl) {
+      return i.url.getHref();
+    }
+    return nullptr;
+  }
+  bool getWithCredentials() const { return false; }
+  uint getReadyState() const { return static_cast<uint>(readyState); }
+
+  void close(jsg::Lock& js);
+
+  // A non-standard extension that creates an EventSource instance around a ReadableStream
+  // instance. In this instance, automatic reconnection is disabled since there is no URL
+  // or underlying fetch used. The ReadableStream instance must produce bytes. It will be
+  // locked and disturbed, and will be read until it either ends or errors. Calling close()
+  // will cause the stream to be canceled.
+  static jsg::Ref<EventSource> from(jsg::Lock& js, jsg::Ref<ReadableStream> stream);
+
+  kj::Maybe<jsg::JsValue> getOnOpen(jsg::Lock& js) {
+    return onopenValue.map([&](jsg::JsRef<jsg::JsValue>& ref) -> jsg::JsValue {
+      return ref.getHandle(js);
+    });
+  }
+  void setOnOpen(jsg::Lock& js, jsg::JsValue value) {
+    if (!value.isObject() && !value.isFunction()) {
+      onopenValue = kj::none;
+    } else {
+      onopenValue = jsg::JsRef<jsg::JsValue>(js, value);
+    }
+  }
+  kj::Maybe<jsg::JsValue> getOnMessage(jsg::Lock& js) {
+    return onmessageValue.map([&](jsg::JsRef<jsg::JsValue>& ref) -> jsg::JsValue {
+      return ref.getHandle(js);
+    });
+  }
+  void setOnMessage(jsg::Lock& js, jsg::JsValue value) {
+    if (!value.isObject() && !value.isFunction()) {
+      onmessageValue = kj::none;
+    } else {
+      onmessageValue = jsg::JsRef<jsg::JsValue>(js, value);
+    }
+  }
+  kj::Maybe<jsg::JsValue> getOnError(jsg::Lock& js) {
+    return onerrorValue.map([&](jsg::JsRef<jsg::JsValue>& ref) -> jsg::JsValue {
+      return ref.getHandle(js);
+    });
+  }
+  void setOnError(jsg::Lock& js, jsg::JsValue value) {
+    if (!value.isObject() && !value.isFunction()) {
+      onerrorValue = kj::none;
+    } else {
+      onerrorValue = jsg::JsRef<jsg::JsValue>(js, value);
+    }
+  }
+
+  JSG_RESOURCE_TYPE(EventSource) {
+    JSG_METHOD(close);
+    JSG_READONLY_PROTOTYPE_PROPERTY(url, getUrl);
+    JSG_READONLY_PROTOTYPE_PROPERTY(withCredentials, getWithCredentials);
+    JSG_READONLY_PROTOTYPE_PROPERTY(readyState, getReadyState);
+    JSG_PROTOTYPE_PROPERTY(onopen, getOnOpen, setOnOpen);
+    JSG_PROTOTYPE_PROPERTY(onmessage, getOnMessage, setOnMessage);
+    JSG_PROTOTYPE_PROPERTY(onerror, getOnError, setOnError);
+    JSG_STATIC_CONSTANT_NAMED(CONNECTING, static_cast<uint>(State::CONNECTING));
+    JSG_STATIC_CONSTANT_NAMED(OPEN, static_cast<uint>(State::OPEN));
+    JSG_STATIC_CONSTANT_NAMED(CLOSED, static_cast<uint>(State::CLOSED));
+    JSG_STATIC_METHOD(from);
+
+    // EventSource is not defined by the spec as being disposable using ERM, but
+    // it makes sense to do so. The dispose operation simply defers to close().
+    // This will enable `using eventsource = new EventSource(...)`
+    JSG_DISPOSE(close);
+  }
+
+  struct PendingMessage {
+    kj::Vector<kj::String> data;
+    kj::Maybe<kj::String> event;
+    kj::String id;
+  };
+
+  // Called by the internal implementation to notify the EventSource about messages
+  // received from the server.
+  void enqueueMessages(kj::Array<PendingMessage> messages);
+
+  // Called by the internal implementation to notify the EventSource that the server
+  // has provided a new reconnection time.
+  void setReconnectionTime(uint32_t time);
+
+  // Called by the internal implementation to retrieve the last event id that was
+  // specified by the server.
+  kj::StringPtr getLastEventId();
+
+  // Called by the internal implementation to set the last event id that was specified
+  // by the server.
+  void setLastEventId(kj::String id);
+
+  void visitForGc(jsg::GcVisitor& visitor);
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
+
+private:
+  IoContext& context;
+  struct FetchImpl {
+    jsg::Url url;
+    EventSourceInit options;
+    // Indicates that the server previously responded with no content after a
+    // successful connection. This is likely indicative of a bug on the server.
+    // If this happens once, we'll try to reconnect. If it happens again, we'll
+    // fail the connection.
+    bool previousNoBody = false;
+  };
+  // Used when the EventSource is created using the constructor. This
+  // is the normal mode of operation, when the EventSource uses fetch
+  // under the covers to connect, and reconnect, to the server. This
+  // will be kj::none when the EventSource is created using the from()
+  // method.
+  kj::Maybe<FetchImpl> impl;
+  jsg::Ref<AbortController> abortController;
+  State readyState;
+  kj::String lastEventId = kj::String();
+
+  // Indicates that the close method has been previously called.
+  bool closeCalled = false;
+
+  // The EventSource spec defines onopen, onmessage, and onerror as prototype
+  // properties on the class.
+  kj::Maybe<jsg::JsRef<jsg::JsValue>> onopenValue;
+  kj::Maybe<jsg::JsRef<jsg::JsValue>> onmessageValue;
+  kj::Maybe<jsg::JsRef<jsg::JsValue>> onerrorValue;
+
+  // The default reconnection wait time. This is fairly arbitrary and is left
+  // entirely up to the implementation. The event stream can provide a new value.
+  static constexpr auto DEFAULT_RECONNECTION_TIME = 2 * kj::SECONDS;
+  static constexpr uint32_t MIN_RECONNECTION_TIME = 1000;
+  static constexpr uint32_t MAX_RECONNECTION_TIME = 10 * 1000;
+
+  kj::Duration reconnectionTime = DEFAULT_RECONNECTION_TIME;
+
+  void notifyOpen(jsg::Lock& js);
+  void notifyError(jsg::Lock& js, const jsg::JsValue& error, bool reconnecting = false);
+  void notifyMessages(jsg::Lock& js, kj::Array<PendingMessage> messages);
+
+  // The run() method handles the actual processing of the stream.
+  void run(jsg::Lock& js,
+           jsg::Ref<ReadableStream> stream,
+           bool withReconnection = true,
+           kj::Maybe<jsg::Ref<Response>> response = kj::none,
+           kj::Maybe<jsg::Ref<Fetcher>> fetcher = kj::none);
+  // The start() method initializes the fetch and the processing of the
+  // stream by calling run.
+  void start(jsg::Lock& js);
+  void reconnect(jsg::Lock& js);
+};
+
+}  // namespace workerd::api
+
+#define EW_EVENTSOURCE_ISOLATE_TYPES      \
+  api::EventSource,                       \
+  api::EventSource::ErrorEvent,           \
+  api::EventSource::OpenEvent,            \
+  api::EventSource::MessageEvent,         \
+  api::EventSource::EventSourceInit

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -8,6 +8,7 @@
 #include "basics.h"
 #include "events.h"
 #include "http.h"
+#include "eventsource.h"
 #include "hibernation-event-params.h"
 #include <workerd/io/io-timers.h>
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
@@ -524,6 +525,8 @@ public:
     JSG_NESTED_TYPE(ByteLengthQueuingStrategy);
     JSG_NESTED_TYPE(CountQueuingStrategy);
     JSG_NESTED_TYPE(ErrorEvent);
+
+    JSG_NESTED_TYPE(EventSource);
 
     if (flags.getStreamsJavaScriptControllers()) {
       JSG_NESTED_TYPE(ReadableStreamBYOBRequest);

--- a/src/workerd/api/tests/eventsource-test.js
+++ b/src/workerd/api/tests/eventsource-test.js
@@ -1,0 +1,598 @@
+// Copyright (c) 2017-2024 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+import {
+  strictEqual,
+  ok,
+  throws
+} from 'node:assert';
+
+export const acceptEventStreamTest = {
+  async test(ctrl, env) {
+    const eventsource = new EventSource('http://example.org/accept-event-stream',
+                                        { fetcher: env.subrequest });
+    strictEqual(eventsource.readyState, EventSource.CONNECTING);
+    const { promise, resolve } = Promise.withResolvers();
+    let opened = false;
+    eventsource.onopen = () => {
+      strictEqual(eventsource.readyState, EventSource.OPEN);
+      opened = true;
+    };
+    eventsource.onmessage = (event) => {
+      strictEqual(event.data, 'text/event-stream');
+      strictEqual(event.origin, 'http://example.org');
+      eventsource.close();
+      strictEqual(eventsource.readyState, EventSource.CLOSED);
+      resolve();
+    };
+    await promise;
+    ok(opened);
+  }
+};
+
+export const cacheControlEventStreamTest = {
+  async test(ctrl, env) {
+    const eventsource = new EventSource('http://example.org/cache-control-event-stream',
+                                        { fetcher: env.subrequest });
+    const { promise, resolve } = Promise.withResolvers();
+    eventsource.onmessage = (event) => {
+      strictEqual(event.data, 'no-cache');
+      eventsource.close();
+      resolve();
+    };
+    await promise;
+  }
+};
+
+export const lastEventIdTest = {
+  async test(ctrl, env) {
+    const eventsource = new EventSource('http://example.org/last-event-id',
+                                        { fetcher: env.subrequest });
+    const { promise, resolve } = Promise.withResolvers();
+    let first = true;
+    eventsource.onmessage = (event) => {
+      if (first) {
+        strictEqual(event.data, 'first');
+        first = false;
+      } else {
+        strictEqual(event.data, '1');
+        eventsource.close();
+        resolve();
+      }
+    };
+    await promise;
+  }
+};
+
+export const eventIdPersistsTest = {
+  async test(ctrl, env) {
+    const eventsource = new EventSource('http://example.org/event-id-persists',
+                                        { fetcher: env.subrequest });
+    const { promise, resolve } = Promise.withResolvers();
+    eventsource.onmessage = (event) => {
+      switch (event.data) {
+        case 'first':
+          strictEqual(event.lastEventId, '1');
+          break;
+        case 'second':
+          strictEqual(event.lastEventId, '1');
+          break;
+        case 'third':
+          strictEqual(event.lastEventId, '2');
+          break;
+        case 'fourth':
+          strictEqual(event.lastEventId, '2');
+          eventsource.close();
+          resolve();
+          break;
+        default:
+          throw new Error(`Unexpected message: ${event.data}`);
+      }
+    };
+    await promise;
+  }
+};
+
+export const eventIdResetsTest = {
+  async test(ctrl, env) {
+    const eventsource = new EventSource('http://example.org/event-id-resets',
+                                        { fetcher: env.subrequest });
+    const { promise, resolve } = Promise.withResolvers();
+    eventsource.onmessage = (event) => {
+      switch (event.data) {
+        case 'first':
+          strictEqual(event.lastEventId, '1');
+          break;
+        case 'second':
+          strictEqual(event.lastEventId, '');
+          eventsource.close();
+          resolve();
+          break;
+        default:
+          throw new Error(`Unexpected message: ${event.data}`);
+      }
+    };
+    await promise;
+  }
+};
+
+export const eventIdResets2Test = {
+  async test(ctrl, env) {
+    const eventsource = new EventSource('http://example.org/event-id-resets-2',
+                                        { fetcher: env.subrequest });
+    const { promise, resolve } = Promise.withResolvers();
+    eventsource.onmessage = (event) => {
+      switch (event.data) {
+        case 'first':
+          strictEqual(event.lastEventId, '1');
+          break;
+        case 'second':
+          strictEqual(event.lastEventId, '');
+          eventsource.close();
+          resolve();
+          break;
+        default:
+          throw new Error(`Unexpected message: ${event.data}`);
+      }
+    };
+    await promise;
+  }
+};
+
+export const messageTest = {
+  async test(ctrl, env) {
+    const eventsource = new EventSource('http://example.org/message',
+                                        { fetcher: env.subrequest });
+    const { promise, resolve } = Promise.withResolvers();
+    // We should get two messages...
+    let count = 0;
+    eventsource.onmessage = (event) => {
+      switch (count++) {
+        case 0: {
+          strictEqual(event.data, 'one\ntwo');
+          break;
+        }
+        case 1: {
+          strictEqual(event.data, 'end');
+          eventsource.close();
+          resolve();
+          break;
+        }
+      }
+    };
+    await promise;
+  }
+};
+
+export const reconnectFailTest = {
+  async test(ctrl, env) {
+    const eventsource = new EventSource('http://example.org/reconnect-fail',
+                                        { fetcher: env.subrequest });
+    const { promise, resolve } = Promise.withResolvers();
+    let count = 0;
+    eventsource.onmessage = (event) => {
+      switch (count++) {
+        case 0: {
+          strictEqual(event.data, 'opened');
+          break;
+        }
+        case 1: {
+          strictEqual(event.data, 'reconnected');
+          break;
+        }
+      }
+    };
+    // Should be called four times.
+    let errorCount = 0;
+    eventsource.onerror = (event) => {
+      if (errorCount < 3) {
+        strictEqual(eventsource.readyState, EventSource.CONNECTING);
+      }
+      if (++errorCount === 4) {
+        strictEqual(eventsource.readyState, EventSource.CLOSED);
+        resolve();
+      }
+    };
+    await promise;
+  }
+};
+
+export const statusErrorTest = {
+  async test(ctrl, env) {
+    const eventsource = new EventSource('http://example.org/status-error',
+                                        { fetcher: env.subrequest });
+    const { promise, resolve } = Promise.withResolvers();
+    eventsource.onopen = () => {
+      throw new Error('should not be called');
+    };
+    eventsource.onerror = (event) => {
+      strictEqual(eventsource.readyState, EventSource.CLOSED);
+      resolve();
+    };
+    await promise;
+  }
+}
+
+export const eventTest = {
+  async test(ctrl, env) {
+    const eventsource = new EventSource('http://example.org/event',
+                                        { fetcher: env.subrequest });
+    const { promise, resolve } = Promise.withResolvers();
+    let count = 0;
+    eventsource.ontest = (event) => {
+      switch (count++) {
+        case 0: {
+          strictEqual(event.data, 'first');
+          break;
+        }
+        case 1: {
+          strictEqual(event.data, 'second');
+          eventsource.close();
+          resolve();
+          break;
+        }
+      }
+    };
+    await promise;
+  }
+};
+
+export const retryTest = {
+  async test(ctrl, env) {
+    const eventsource = new EventSource('http://example.org/retry',
+                                        { fetcher: env.subrequest });
+    const { promise, resolve } = Promise.withResolvers();
+    let count = 0;
+    eventsource.onmessage = (event) => {
+      switch (count++) {
+        case 0: {
+          strictEqual(event.data, 'first');
+          break;
+        }
+        case 1: {
+          strictEqual(event.data, 'second');
+          break;
+        }
+        case 2: {
+          strictEqual(event.data, 'first');
+          break;
+        }
+        case 3: {
+          strictEqual(event.data, 'second');
+          eventsource.close();
+          resolve();
+          break;
+        }
+      }
+    };
+    await promise;
+  }
+};
+
+export const constructorTest = {
+  test() {
+    throws(() => new EventSource('not a valid url'), {
+      name: 'SyntaxError',
+      message: 'Cannot open an EventSource to \'not a valid url\'. The URL is invalid.'
+    });
+
+    throws(() => new EventSource(123), {
+      name: 'SyntaxError',
+      message: 'Cannot open an EventSource to \'123\'. The URL is invalid.'
+    });
+
+    throws(() => new EventSource('http://example.org', { withCredentials: true }), {
+      name: 'NotSupportedError',
+      message: 'The init.withCredentials option is not supported. It must be false or undefined.'
+    });
+
+    // Doesn't throw
+    (new EventSource('http://example.org/message')).close();
+    (new EventSource('http://example.org/message', { withCredentials: false })).close();
+    (new EventSource('http://example.org/message', { withCredentials: undefined })).close();
+  }
+};
+
+export const eventSourceFromTest = {
+  async test() {
+    const enc = new TextEncoder();
+    const chunks = [
+      'data: first\n\n',
+      'data: second\n\n',
+      'data: third\n\n',
+    ];
+    const rs = new ReadableStream({
+      async pull(c) {
+        await scheduler.wait(10);
+        c.enqueue(enc.encode(chunks.shift()));
+        if (chunks.length === 0) {
+          c.close();
+        }
+      }
+    });
+    const { promise, resolve } = Promise.withResolvers();
+    const eventsource = EventSource.from(rs);
+    // Should happen three times
+    let count = 0;
+    eventsource.onmessage = (event) => {
+      switch (count++) {
+        case 0: {
+          strictEqual(event.data, 'first');
+          break;
+        }
+        case 1: {
+          strictEqual(event.data, 'second');
+          break;
+        }
+        case 2: {
+          strictEqual(event.data, 'third');
+          eventsource.close();
+          resolve();
+          break;
+        }
+      }
+    };
+    await promise;
+  }
+};
+
+export const eventSourceFromWithBOMTest = {
+  async test() {
+    const enc = new TextEncoder();
+    // The first chunk is going to include the UTF-8 BOM, which should
+    // be ignored and filtered out by the parser.
+    const chunks = [
+      '\uFEFFdata: first\n\n',
+      'data: second\n\n',
+      'data: third\n\n',
+    ];
+    const rs = new ReadableStream({
+      async pull(c) {
+        await scheduler.wait(10);
+        c.enqueue(enc.encode(chunks.shift()));
+        if (chunks.length === 0) {
+          c.close();
+        }
+      }
+    });
+    const { promise, resolve } = Promise.withResolvers();
+    const eventsource = EventSource.from(rs);
+    // Should happen three times
+    let count = 0;
+    eventsource.onmessage = (event) => {
+      switch (count++) {
+        case 0: {
+          strictEqual(event.data, 'first');
+          break;
+        }
+        case 1: {
+          strictEqual(event.data, 'second');
+          break;
+        }
+        case 2: {
+          strictEqual(event.data, 'third');
+          eventsource.close();
+          resolve();
+          break;
+        }
+      }
+    };
+    await promise;
+  }
+};
+
+export const prototypePropertyTest = {
+  test() {
+    strictEqual(EventSource.prototype.constructor, EventSource);
+    strictEqual(EventSource.prototype.CLOSED, 2);
+    strictEqual(EventSource.prototype.CONNECTING, 0);
+    strictEqual(EventSource.prototype.OPEN, 1);
+    ok('onopen' in EventSource.prototype);
+    ok('onmessage' in EventSource.prototype);
+    ok('onerror' in EventSource.prototype);
+    ok('close' in EventSource.prototype);
+    ok('readyState' in EventSource.prototype);
+    ok('url' in EventSource.prototype);
+    ok('withCredentials' in EventSource.prototype);
+  }
+};
+
+export const disposable = {
+  test() {
+    // EventSource is not defined by the spec as being disposable using ERM, but
+    // it makes sense to do so. The dispose operation simply defers to close()
+    const rs = new ReadableStream();
+    const eventsource = EventSource.from(rs);
+    strictEqual(eventsource.readyState, EventSource.OPEN);
+    eventsource[Symbol.dispose]();
+    strictEqual(eventsource.readyState, EventSource.CLOSED);
+  }
+};
+
+// ======================================================================================
+
+const handlers = {
+  '/accept-event-stream': acceptEventStream,
+  '/cache-control-event-stream': cacheControlEventStream,
+  '/last-event-id': lastEventId,
+  '/event-id-persists': eventIdPersists,
+  '/event-id-resets': eventIdResets,
+  '/event-id-resets-2': eventIdResets2,
+  '/message': message,
+  '/reconnect-fail': reconnectFail,
+  '/status-error': statusError,
+  '/event': event,
+  '/retry': retry,
+};
+
+async function acceptEventStream(request) {
+  return new Response(`data: ${request.headers.get('accept')}\n\n`, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+    },
+  });
+}
+
+async function cacheControlEventStream(request) {
+  return new Response(`data: ${request.headers.get('cache-control')}\n\n`, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+    },
+  });
+}
+
+async function lastEventId(request) {
+  const lastEventId = request.headers.get('last-event-id');
+  if (lastEventId == null) {
+    return new Response('id: 1\ndata: first\n\n', {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache'
+      },
+    });
+  } else {
+    return new Response(`data: ${lastEventId}\n\n`, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache'
+      },
+    });
+  }
+}
+
+async function eventIdPersists(request) {
+  return new Response(
+    'id: 1\ndata: first\n\n' +
+    'data: second\n\n' +
+    'id: 2\ndata: third\n\n' +
+    'data: fourth\n\n', {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache'
+    },
+  });
+}
+
+async function eventIdResets(request) {
+  return new Response(
+    'id: 1\ndata: first\n\n' +
+    'id: \ndata: second\n\n', {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache'
+    },
+  });
+}
+
+async function eventIdResets2(request) {
+  return new Response(
+    'id: 1\ndata: first\n\n' +
+    'id\ndata: second\n\n', {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache'
+    },
+  });
+}
+
+async function message(request) {
+  // The response payload contains a couple of messages with different structures.
+  // including good messages, comments, and bad fields.
+  return new Response(
+    'data: one\n' +
+    'data: two\n\n' +
+    ': comment' +
+    'falsefield:msg\n\n' +
+    'falsefield:msg\n' +
+    'Data: data\n\n' +
+    'data\n\n' +
+    'data:end\n\n', {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache'
+    },
+  });
+
+}
+
+let reconnectTestCount = 0;
+async function reconnectFail(request) {
+  switch (reconnectTestCount++) {
+    case 0: {
+      return new Response(
+        'data: opened\n\n', {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache'
+        },
+      });
+    }
+    case 1: {
+      return new Response(
+        'data: reconnected\n\n', {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache'
+        },
+      });
+    }
+    case 2:
+      // Fall-through
+    case 3: {
+      return new Response(
+        null, {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache'
+        },
+        status: 204
+      });
+
+    }
+  }
+}
+
+async function statusError(request) {
+  return new Response(null, {
+    status: 500
+  });
+}
+
+async function event(request) {
+  return new Response(
+    'event: test\n' +
+    'data: first\n\n' +
+    'event: test\n' +
+    'data: second\n\n', {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache'
+    },
+  });
+}
+
+async function retry(request) {
+  return new Response(
+    'retry: 3000\n\n' +
+    'data: first\n\n' +
+    'data: second\n\n', {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache'
+    },
+  });
+}
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url, 'http://example.org/');
+    const handler = handlers[url.pathname];
+    if (handler === undefined) {
+      throw new Error('Not found');
+    }
+    return await handler(request);
+  }
+};
+

--- a/src/workerd/api/tests/eventsource-test.wd-test
+++ b/src/workerd/api/tests/eventsource-test.wd-test
@@ -1,0 +1,18 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "eventsource-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "eventsource-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat", "experimental"],
+        bindings = [
+          (name = "subrequest", service = "eventsource-test")
+        ]
+      )
+    ),
+  ],
+);

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -17,6 +17,7 @@
 #include <workerd/api/crypto/impl.h>
 #include <workerd/api/encoding.h>
 #include <workerd/api/events.h>
+#include <workerd/api/eventsource.h>
 #include <workerd/api/global-scope.h>
 #include <workerd/api/html-rewriter.h>
 #include <workerd/api/hyperdrive.h>
@@ -100,6 +101,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
   EW_NODE_ISOLATE_TYPES,
   EW_RTTI_ISOLATE_TYPES,
   EW_HYPERDRIVE_ISOLATE_TYPES,
+  EW_EVENTSOURCE_ISOLATE_TYPES,
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
   EW_WEBGPU_ISOLATE_TYPES,
 #endif

--- a/src/workerd/tools/api-encoder.c++
+++ b/src/workerd/tools/api-encoder.c++
@@ -36,6 +36,7 @@
 #include <workerd/api/urlpattern.h>
 #include <workerd/api/node/node.h>
 #include <workerd/api/hyperdrive.h>
+#include <workerd/api/eventsource.h>
 
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
 #include <workerd/api/gpu/gpu.h>
@@ -76,7 +77,8 @@
   F("sql", EW_SQL_ISOLATE_TYPES)                                               \
   F("sockets", EW_SOCKETS_ISOLATE_TYPES)                                       \
   F("node", EW_NODE_ISOLATE_TYPES)                                             \
-  F("webgpu", EW_WEBGPU_ISOLATE_TYPES)
+  F("webgpu", EW_WEBGPU_ISOLATE_TYPES)                                         \
+  F("eventsource", EW_EVENTSOURCE_ISOLATE_TYPES)
 
 namespace workerd::api {
 namespace {


### PR DESCRIPTION
SHIP-9206

~~This is just a draft proposal at the moment, but it should be functional for folks who want to give it a try.~~ Had a couple of folks ask me about this over the past few months so figured I'd go ahead and see about an actual implementation. The format is simple enough that it really doesn't require bringing in any dependencies.

Implements the web platform standard `EventSource` API (https://developer.mozilla.org/en-US/docs/Web/API/EventSource).

There are three non-standard extensions implemented to the API:

1. Passing in a custom fetcher

```js
const ev = new EventSource('https://...', { fetcher: env.myfetcher });
```

2. Creating an `EventSource` from an existing `ReadableStream`

```js
const ev = EventSource.from(readableStream);
```

3. The `EventSource` implements ERM `Symbol.dispose` (which simply defers to calling `eventsource.close()`

See the sample for an example.

Note that each time `EventStream` connects it counts as a subrequest and is subject to all of the same characteristics/limitations as other subrequests. Concurrent subrequest limits will apply.

~~This PR will need tests before it could land.~~