### PR TITLE
SQLite: add streaming input SQL endpoint `sql.ingest`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,6 +61,7 @@ http_archive(
     patches = [
         "//:patches/sqlite/0001-row-counts-plain.patch",
         "//:patches/sqlite/0002-macOS-missing-PATH-fix.patch",
+        "//:patches/sqlite/0003-sqlite-complete-early-exit.patch",
     ],
     sha256 = "ab9aae38a11b931f35d8d1c6d62826d215579892e6ffbf89f20bdce106a9c8c5",
     strip_prefix = "sqlite-src-3440000",

--- a/patches/sqlite/0003-sqlite-complete-early-exit.patch
+++ b/patches/sqlite/0003-sqlite-complete-early-exit.patch
@@ -1,0 +1,61 @@
+--- sqlite-src-pristine/src/complete.c	2023-11-01 22:31:37
++++ sqlite-src-modified/src/complete.c	2024-03-14 12:51:32
+@@ -99,14 +99,21 @@
+ **
+ ** If we compile with SQLITE_OMIT_TRIGGER, all of the computation needed
+ ** to recognize the end of a trigger can be omitted.  All we have to do
+ ** is look for a semicolon that is not part of an string or comment.
+ */
+-int sqlite3_complete(const char *zSql){
++int sqlite3_complete(const char *zSql) {
++    return sqlite3_complete_length(zSql, 0) != 0;
++}
++
++int sqlite3_complete_length(const char *zSql, int firstOnly){
+   u8 state = 0;   /* Current state, using numbers defined in header comment */
+   u8 token;       /* Value of the next token */
+
++  /* Store the original pointer for later index calculations */
++  const char *initialZSql = zSql;
++
+ #ifndef SQLITE_OMIT_TRIGGER
+   /* A complex statement machine used to detect the end of a CREATE TRIGGER
+   ** statement.  This is the normal case.
+   */
+   static const u8 trans[8][8] = {
+@@ -254,12 +261,16 @@
+         break;
+       }
+     }
+     state = trans[state][token];
+     zSql++;
++
++    // Once we have found a single complete statement, return its length
++    if (firstOnly && state==1) return zSql - initialZSql;
+   }
+-  return state==1;
++  // Otherwise only return the length if the entire input is valid
++  return state==1 ? zSql - initialZSql : 0;
+ }
+
+ #ifndef SQLITE_OMIT_UTF16
+ /*
+ ** This routine is the same as the sqlite3_complete() routine described
+diff -u5 -r sqlite-src-pristine/src/sqlite.h.in sqlite-src-modified/src/sqlite.h.in
+--- sqlite-src-pristine/src/sqlite.h.in	2023-11-01 22:31:37
++++ sqlite-src-modified/src/sqlite.h.in	2024-03-12 12:48:37
+@@ -2775,10 +2775,14 @@
+ ** UTF-16 string in native byte order.
+ */
+ int sqlite3_complete(const char *sql);
+ int sqlite3_complete16(const void *sql);
+
++// workerd addition: measure the length of the first (or all) complete
++// statements in the input.
++int sqlite3_complete_length(const char *sql, int firstOnly);
++
+ /*
+ ** CAPI3REF: Register A Callback To Handle SQLITE_BUSY Errors
+ ** KEYWORDS: {busy-handler callback} {busy handler}
+ ** METHOD: sqlite3
+ **

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -60,6 +60,36 @@ async function test(storage) {
     assert.equal(result[2]['value'], 3)
   }
 
+
+  // Test partial query ingestion
+  assert.deepEqual(sql.ingest(`SELECT 123; SELECT 456;    `), '    ')
+  assert.deepEqual(sql.ingest(`SELECT 123; SELECT 456;`), '')
+  assert.deepEqual(sql.ingest(`SELECT 123; SELECT 456`), ' SELECT 456')
+  assert.deepEqual(sql.ingest(`SELECT 123; SELECT 45`), ' SELECT 45')
+  assert.deepEqual(sql.ingest(`SELECT 123; SELECT 4`), ' SELECT 4')
+  assert.deepEqual(sql.ingest(`SELECT 123; SELECT `), ' SELECT ')
+  assert.deepEqual(sql.ingest(`SELECT 123; SELECT`), ' SELECT')
+  assert.deepEqual(sql.ingest(`SELECT 123; SELEC`), ' SELEC')
+  assert.deepEqual(sql.ingest(`SELECT 123; SELE`), ' SELE')
+  assert.deepEqual(sql.ingest(`SELECT 123; SEL`), ' SEL')
+  assert.deepEqual(sql.ingest(`SELECT 123; SE`), ' SE')
+  assert.deepEqual(sql.ingest(`SELECT 123; S`), ' S')
+  assert.deepEqual(sql.ingest(`SELECT 123; `), ' ')
+  assert.deepEqual(sql.ingest(`SELECT 123;`), '')
+  assert.deepEqual(sql.ingest(`SELECT 123`), 'SELECT 123')
+  assert.deepEqual(sql.ingest(`SELECT 12`), 'SELECT 12')
+  assert.deepEqual(sql.ingest(`SELECT 1`), 'SELECT 1')
+
+  // Exec throws with trailing comments
+  assert.throws(
+    () => sql.exec('SELECT 123; SELECT 456; -- trailing comment'),
+    /SQL code did not contain a statement/
+  )
+  // Ingest does not
+  assert.deepEqual(
+    sql.ingest(`SELECT 123; SELECT 456; -- trailing comment`),
+    ' -- trailing comment'
+  )
   // Test count
   {
     const result = [

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -91,6 +91,11 @@ async function test(storage) {
     ' -- trailing comment'
   )
 
+  // Ingest throws if statement looks "complete" but is actually a syntax error:
+  assert.throws(() => sql.ingest(`SELECT * bunk;`), /Error: near "bunk": syntax error at offset/)
+  assert.throws(() => sql.ingest(`INSER INTO xyz VALUES ('a'),('b');`), /Error: near "INSER": syntax error/)
+  assert.throws(() => sql.ingest(`INSERT INTO xyz VALUES ('a')('b');`), /Error: near "\(": syntax error/)
+
   // Test execution of ingested queries by taking an input of 6 INSERT statements, that all
   // add 6 rows of data, then splitting that into a bunch of chunks, then ingesting them all
   {

--- a/src/workerd/api/sql-test.wd-test
+++ b/src/workerd/api/sql-test.wd-test
@@ -10,7 +10,7 @@ const config :Workerd.Config = (
 );
 
 const mainWorker :Workerd.Worker = (
-  compatibilityDate = "2022-09-16",
+  compatibilityDate = "2024-03-04",
   compatibilityFlags = ["experimental", "nodejs_compat"],
 
   modules = [

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -19,6 +19,11 @@ jsg::Ref<SqlStorage::Cursor> SqlStorage::exec(jsg::Lock& js, kj::String querySql
   return jsg::alloc<Cursor>(*sqlite, regulator, querySql, kj::mv(bindings));
 }
 
+kj::String SqlStorage::ingest(jsg::Lock& js, kj::String querySql) {
+  SqliteDatabase::Regulator& regulator = *this;
+  return kj::str(sqlite->ingestSql(regulator, querySql));
+}
+
 jsg::Ref<SqlStorage::Statement> SqlStorage::prepare(jsg::Lock& js, kj::String query) {
   return jsg::alloc<Statement>(sqlite->prepare(*this, query));
 }

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -24,6 +24,7 @@ public:
   class Statement;
 
   jsg::Ref<Cursor> exec(jsg::Lock& js, kj::String query, jsg::Arguments<BindingValue> bindings);
+  kj::String ingest(jsg::Lock& js, kj::String query);
 
   jsg::Ref<Statement> prepare(jsg::Lock& js, kj::String query);
 
@@ -31,6 +32,7 @@ public:
 
   JSG_RESOURCE_TYPE(SqlStorage) {
     JSG_METHOD(exec);
+    JSG_METHOD(ingest);
     JSG_METHOD(prepare);
 
     JSG_READONLY_PROTOTYPE_PROPERTY(databaseSize, getDatabaseSize);

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -30,10 +30,15 @@ public:
 
   double getDatabaseSize();
 
-  JSG_RESOURCE_TYPE(SqlStorage) {
+  JSG_RESOURCE_TYPE(SqlStorage, CompatibilityFlags::Reader flags) {
     JSG_METHOD(exec);
-    JSG_METHOD(ingest);
     JSG_METHOD(prepare);
+
+    // Make sure that the 'ingest' function is still experimental-only if and when
+    // the SQL API becomes publicly available.
+    if (flags.getWorkerdExperimental()) {
+      JSG_METHOD(ingest);
+    }
 
     JSG_READONLY_PROTOTYPE_PROPERTY(databaseSize, getDatabaseSize);
 

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -89,6 +89,11 @@ public:
   // debug logs.
   kj::StringPtr getCurrentQueryForDebug();
 
+  // Helper to execute a chunk of SQL that may not be complete.
+  // Executes every valid statement provided, and returns the remaining portion of the input
+  // that was not processed. This is used for streaming SQL ingestion.
+  kj::StringPtr ingestSql(Regulator& regulator, kj::StringPtr sqlCode);
+
 private:
   sqlite3* db;
 


### PR DESCRIPTION
This PR adds the required APIs to enable ingesting a ReadableStream of data from a Request and, in a single transaction, applying all the statements to the DB. For example:

```js
const reader = request.body.getReader()
const decoder = new TextDecoder()

await storage.transaction(async () => {
  let buffer = ''
  while (true) {
    const { value, done } = await reader.read()
    if (done) break
    const chunk = decoder.decode(value, { stream: true })

    // Append the new chunk to the existing buffer
    buffer += chunk

    // Ingest any complete statements and snip those chars off the buffer
    buffer = sql.ingest(buffer)
  }
})
```

This is made possible by a new API, `sql.ingest(string)` that immediately executes all valid SQL statements in the string, returning the substring of the input that is yet to be processed (which may be ''). Using this, and an outer transaction, you can safely consume the input a chunk at a time, enabling ingestion of SQL inputs way larger than the Worker could keep in memory.

To do this, we needed to alter the behaviour of SQLite's internal `sqlite3_complete` function to return true if there was at least one valid statement in the given input (rather than the entire input being complete). To keep the diff as small as possible, we extracted a new internal `sqlite3_complete_length` with an optional `firstOnly` param and wired the existing `sqlite3_complete` function up.

Note that `exec` will continue to happily compile & execute a statement without a trailing `;` (i.e. `SELECT 123`), but `ingest` will see no "complete" statements in that string and return the string unchanged. This matches the behaviour of `sqlite_complete` versus `sqlite3_prepare_v3`, as that's what those functions are calling under the hood.