### PR TITLE
JSRPC: Support resource management for RPC stubs

### DIFF
--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -622,7 +622,8 @@ export let disposal = {
 
     // A more complex case with testDispose().
     {
-      let obj = await env.MyService.testDispose(new MyCounter(3));
+      let counter = new MyCounter(3);
+      let obj = await env.MyService.testDispose(counter);
 
       // The counter was able to be incremented during the call.
       assert.strictEqual(obj.count, 8);
@@ -650,8 +651,8 @@ export let disposal = {
         message: "RPC stub used after being disposed."
       });
 
-      // TODO(now): Check counter is disposed. However, this doesn't work yet because the pipeline
-      // is not disposed.
+      await counter.onDisposed();
+      assert.strictEqual(counter.disposed, true);
     }
   },
 }

--- a/src/workerd/api/tests/js-rpc-test.wd-test
+++ b/src/workerd/api/tests/js-rpc-test.wd-test
@@ -41,4 +41,5 @@ const unitTests :Workerd.Config = (
       http = (capnpConnectHost = "cappy")
     )
   ],
+  v8Flags = [ "--expose-gc" ],
 );

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -160,7 +160,7 @@ public:
   kj::Maybe<jsg::Ref<JsRpcProperty>> getProperty(jsg::Lock& js, kj::String name);
 
   JSG_RESOURCE_TYPE(JsRpcPromise) {
-    JSG_METHOD(dispose);
+    JSG_DISPOSE(dispose);
     JSG_CALLABLE(call);
     JSG_WILDCARD_PROPERTY(getProperty);
     JSG_METHOD(then);
@@ -304,7 +304,7 @@ public:
 
   JSG_RESOURCE_TYPE(JsRpcStub) {
     JSG_METHOD(dup);
-    JSG_METHOD(dispose);
+    JSG_DISPOSE(dispose);
     JSG_CALLABLE(call);
     JSG_WILDCARD_PROPERTY(getRpcMethod);
   }

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -318,6 +318,12 @@ public:
   // If there is a current IoContext, return its WeakRef.
   static kj::Maybe<kj::Own<WeakRef>> tryGetWeakRefForCurrent();
 
+  // Like requireCurrentOrThrowJs() but works on a WeakRef.
+  static void requireCurrentOrThrowJs(WeakRef& weak);
+
+  // Just throw the error that requireCurrentOrThrowJs() would throw on failure.
+  [[noreturn]] static void throwNotCurrentJsError();
+
   // -----------------------------------------------------------------
   // Task scheduling and object storage
 

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -650,7 +650,11 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
   this->incomingRequest = kj::none;
 
   auto& context = incomingRequest->getContext();
-  auto promise = event->run(kj::mv(incomingRequest), entrypointName).attach(kj::mv(event));
+  auto promise = event->run(kj::mv(incomingRequest), entrypointName).attach(kj::mv(event))
+      .exclusiveJoin(context.onAbort().then([]() -> WorkerInterface::CustomEvent::Result {
+    // onAbort() should always throw
+    KJ_UNREACHABLE;
+  }));
 
   // TODO(cleanup): In theory `context` may have been destroyed by now if `event->run()` dropped
   //   the `incomingRequest` synchronously. No current implementation does that, and

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -283,7 +283,7 @@ interface JsRpcTarget $Cxx.allowCancellation {
     }
   }
 
-  call @0 CallParams -> (result :JsValue, callPipeline :JsRpcTarget);
+  call @0 CallParams -> (result :JsValue, callPipeline :JsRpcTarget, hasDisposer :Bool);
   # Runs a Worker/DO's RPC method.
   #
   # `callPipeline` allows the caller to begin sending other stuff before the callee has actually
@@ -294,6 +294,10 @@ interface JsRpcTarget $Cxx.allowCancellation {
   #   Typically these calls would use `methodPath` to specify a path to a specific subobject of
   #   the returned value.
   # * TODO(soon): streams
+  #
+  # If `hasDisposer` is true, the server side returned an object (not a stub) with a dispose()
+  # method. Dropping the `callPipeline` will invoke this method. The client should take care that
+  # this is not done until `dispose()` is invoked on the client side.
 }
 
 interface EventDispatcher @0xf20697475ec1752d {

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -263,6 +263,13 @@ Name Lock::newApiSymbol(kj::StringPtr symbol) {
   return Name(*this, v8::Symbol::ForApi(v8Isolate, v8StrIntern(v8Isolate, symbol)));
 }
 
+JsSymbol Lock::symbolDispose() {
+  return IsolateBase::from(v8Isolate).getSymbolDispose();
+}
+JsSymbol Lock::symbolAsyncDispose() {
+  return IsolateBase::from(v8Isolate).getSymbolAsyncDispose();
+}
+
 Name::Name(kj::String string)
     : hash(kj::hashCode(string)),
       inner(kj::mv(string)) {}

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -320,4 +320,8 @@ kj::String Name::toString(jsg::Lock& js) {
   KJ_UNREACHABLE;
 }
 
+bool isInGcDestructor() {
+  return HeapTracer::isInCppgcDestructor();
+}
+
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2442,6 +2442,10 @@ auto runInV8Stack(auto callback) {
   return V8StackScope::runInV8StackImpl(__builtin_frame_address(0), kj::mv(callback));
 };
 
+// Returns true if we are currently executing C++ destructors as a result of garbage collection
+// occurring.
+bool isInGcDestructor();
+
 // =======================================================================================
 // inline implementation details
 

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -251,6 +251,17 @@ namespace workerd::jsg {
     registry.template registerAsyncIterable<NAME, decltype(&Self::method), &Self::method>(); \
   } while (false)
 
+#define JSG_DISPOSE(method) \
+  do { \
+    static const char NAME[] = #method; \
+    registry.template registerDispose<NAME, decltype(&Self::method), &Self::method>(); \
+  } while (false)
+#define JSG_ASYNC_DISPOSE(method) \
+  do { \
+    static const char NAME[] = #method; \
+    registry.template registerAsyncDispose<NAME, decltype(&Self::method), &Self::method>(); \
+  } while (false)
+
 // Use inside a JSG_RESOURCE_TYPE block to declare a property on this object that should be
 // accessible to JavaScript. `name` is the JavaScript member name, while `getter` and `setter` are
 // the names of C++ methods that get and set this property.
@@ -2367,6 +2378,8 @@ public:
 #define V(Name) JsSymbol symbol##Name() KJ_WARN_UNUSED_RESULT;
   JS_V8_SYMBOLS(V)
 #undef V
+  JsSymbol symbolDispose() KJ_WARN_UNUSED_RESULT;
+  JsSymbol symbolAsyncDispose() KJ_WARN_UNUSED_RESULT;
 
   void runMicrotasks();
   void terminateExecution();

--- a/src/workerd/jsg/rtti-test.c++
+++ b/src/workerd/jsg/rtti-test.c++
@@ -208,7 +208,8 @@ KJ_TEST("resource structure") {
   KJ_EXPECT(tStructure<Base>() == "(name = \"Base\", members = [], "
       "extends = (intrinsic = (name = \"v8::kIteratorPrototype\")), "
       "iterable = false, asyncIterable = false, "
-      "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::Base\", tsRoot = false)");
+      "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::Base\", tsRoot = false, "
+      "disposable = false, asyncDisposable = false)");
 
   KJ_EXPECT(tStructure<TestResource>() == "(name = \"TestResource\", members = ["
       "(method = (name = \"instanceMethod\", returnType = (voidt = void), args = [(number = (name = \"int\")), (number = (name = \"double\"))], static = false)), "
@@ -222,7 +223,8 @@ KJ_TEST("resource structure") {
       "(constructor = (args = [(maybe = (value = (string = (name = \"kj::String\")), name = \"jsg::Optional\"))]))], "
       "extends = (structure = (name = \"Base\", fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::Base\")), "
       "iterable = false, asyncIterable = false, "
-      "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestResource\", tsRoot = false)");
+      "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestResource\", tsRoot = false, "
+      "disposable = false, asyncDisposable = false)");
 }
 
 struct TestNested : jsg::Object {
@@ -237,12 +239,13 @@ KJ_TEST("nested structure") {
     "extends = (intrinsic = (name = \"v8::kIteratorPrototype\")), "
     "iterable = false, asyncIterable = false, "
     "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::Base\", "
-    "tsRoot = false"
+    "tsRoot = false, disposable = false, asyncDisposable = false"
     "), "
     "name = \"Base\"))"
     "], "
     "iterable = false, asyncIterable = false, "
-    "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestNested\", tsRoot = false)");
+    "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestNested\", tsRoot = false, "
+    "disposable = false, asyncDisposable = false)");
 }
 
 struct TestConstant : jsg::Object {
@@ -264,7 +267,7 @@ KJ_TEST("constant members") {
     "(constant = (name = \"CIRCLE\", value = 2))], "
     "iterable = false, asyncIterable = false, "
     "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestConstant\", "
-    "tsRoot = false)");
+    "tsRoot = false, disposable = false, asyncDisposable = false)");
 }
 
 
@@ -281,7 +284,8 @@ KJ_TEST("lazyJsProperty") {
   "(property = (name = \"JsProperty\", type = (jsBuiltin = (module = \"js-module\", export = \"JsProperty\")), readonly = false, lazy = true, prototype = false)), "
   "(property = (name = \"JsReadonlyProperty\", type = (jsBuiltin = (module = \"js-readonly-module\", export = \"JsReadonlyProperty\")), readonly = true, lazy = true, prototype = false))], "
   "iterable = false, asyncIterable = false, fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestLazyJsProperty\", tsRoot = false, "
-  "builtinModules = [(specifier = \"testBundle:internal\", tsDeclarations = \"foo: string\")])");
+  "builtinModules = [(specifier = \"testBundle:internal\", tsDeclarations = \"foo: string\")], "
+  "disposable = false, asyncDisposable = false)");
 }
 
 struct TestStruct {
@@ -300,7 +304,7 @@ KJ_TEST("struct structure") {
       "(property = (name = \"b\", type = (boolt = void), readonly = false, lazy = false, prototype = false))], "
       "iterable = false, asyncIterable = false, "
       "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestStruct\", "
-      "tsRoot = false)");
+      "tsRoot = false, disposable = false, asyncDisposable = false)");
 }
 
 struct TestSymbolTable: public jsg::Object {
@@ -323,7 +327,7 @@ KJ_TEST("symbol table") {
       "(method = (name = \"recursiveTypeFunction\", returnType = (voidt = void), args = [(structure = (name = \"TestSymbolTable\", fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestSymbolTable\"))], static = false))], "
       "iterable = false, asyncIterable = false, "
       "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestSymbolTable\", "
-      "tsRoot = false)");
+      "tsRoot = false, disposable = false, asyncDisposable = false)");
 
   KJ_EXPECT(builder.structure("workerd::jsg::rtti::(anonymous namespace)::TestSymbolTable"_kj) != kj::none);
   KJ_EXPECT(builder.structure("workerd::jsg::rtti::(anonymous namespace)::TestResource"_kj) != kj::none);
@@ -358,14 +362,16 @@ KJ_TEST("typescript macros") {
       "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestTypeScriptResourceType\", "
       "tsRoot = true, "
       "tsOverride = \"{ readonly thing: 42 }\", "
-      "tsDefine = \"interface Define {}\")");
+      "tsDefine = \"interface Define {}\", "
+      "disposable = false, asyncDisposable = false)");
   KJ_EXPECT(tStructure<TestTypeScriptStruct>() == "(name = \"TestTypeScriptStruct\", members = ["
       "(property = (name = \"structThing\", type = (number = (name = \"int\")), readonly = false, lazy = false, prototype = false))], "
       "iterable = false, asyncIterable = false, "
       "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestTypeScriptStruct\", "
       "tsRoot = true, "
       "tsOverride = \"RenamedStructThing { structThing: 42 }\", "
-      "tsDefine = \"interface StructDefine {}\")");
+      "tsDefine = \"interface StructDefine {}\", "
+      "disposable = false, asyncDisposable = false)");
 }
 
 } // namespace

--- a/src/workerd/jsg/rtti.capnp
+++ b/src/workerd/jsg/rtti.capnp
@@ -212,6 +212,16 @@ struct Structure {
   asyncIterator @7 :Method;
   # Method returning async iterator if the structure is async iterable
 
+  disposable @13 :Bool;
+  # true if the structure is disposable
+  dispose @14 :Method;
+  # dispose method
+
+  asyncDisposable @15 :Bool;
+  # true if the structure is async disposable
+  asyncDispose @16 :Method;
+  # asyncDispose method
+
   tsRoot @8 :Bool;
   # See `JSG_TS_ROOT`'s documentation in the `## TypeScript` section of the JSG README.md.
   # If `JSG_(STRUCT_)TS_ROOT` is declared for a type, this value will be `true`.

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -568,6 +568,12 @@ struct MemberCounter {
   template<const char* name, typename Method, Method method>
   inline void registerAsyncIterable() { /* not a member */ }
 
+  template<const char* name, typename Method, Method method>
+  inline void registerDispose() { /* not a member */ }
+
+  template<const char* name, typename Method, Method method>
+  inline void registerAsyncDispose() { /* not a member */ }
+
   template<typename Type, const char* name>
   inline void registerNestedType() { ++members; }
 
@@ -786,6 +792,30 @@ struct MembersBuilder {
     structure.setAsyncIterable(true);
 
     auto method = structure.initAsyncIterator();
+    method.setName(name);
+    using Traits = FunctionTraits<Method>;
+    BuildRtti<Configuration, typename Traits::ReturnType>::build(method.initReturnType(), rtti);
+    using Args = typename Traits::ArgsTuple;
+    TupleRttiBuilder<Configuration, Args>::build(method.initArgs(std::tuple_size_v<Args>), rtti);
+  }
+
+  template<const char* name, typename Method, Method>
+  inline void registerDispose() {
+    structure.setDisposable(true);
+
+    auto method = structure.initDispose();
+    method.setName(name);
+    using Traits = FunctionTraits<Method>;
+    BuildRtti<Configuration, typename Traits::ReturnType>::build(method.initReturnType(), rtti);
+    using Args = typename Traits::ArgsTuple;
+    TupleRttiBuilder<Configuration, Args>::build(method.initArgs(std::tuple_size_v<Args>), rtti);
+  }
+
+  template<const char* name, typename Method, Method>
+  inline void registerAsyncDispose() {
+    structure.setAsyncDisposable(true);
+
+    auto method = structure.initAsyncDispose();
     method.setName(name);
     using Traits = FunctionTraits<Method>;
     BuildRtti<Configuration, typename Traits::ReturnType>::build(method.initReturnType(), rtti);

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -138,6 +138,13 @@ public:
   size_t jsgGetMemorySelfSize() const { return sizeof(IsolateBase); }
   bool jsgGetMemoryInfoIsRootNode() const { return true; }
 
+  JsSymbol getSymbolDispose() {
+    return JsSymbol(symbolDispose.Get(ptr));
+  }
+  JsSymbol getSymbolAsyncDispose() {
+    return JsSymbol(symbolAsyncDispose.Get(ptr));
+  }
+
 private:
   template <typename TypeWrapper>
   friend class Isolate;
@@ -188,6 +195,10 @@ private:
   // FunctionTemplate used by Wrappable::attachOpaqueWrapper(). Just a constructor for an empty
   // object with 2 internal fields.
   v8::Global<v8::FunctionTemplate> opaqueTemplate;
+
+  // Polyfilled Symbol.dispose and Symbol.asyncDispose.
+  v8::Global<v8::Symbol> symbolDispose;
+  v8::Global<v8::Symbol> symbolAsyncDispose;
 
   // We expect queues to remain relatively small -- 8 is the largest size I have observed from local
   // testing.


### PR DESCRIPTION
* RpcStubs and RpcPromises now have `Symbol.dispose`.
* Stubs passed in call parameters are automatically disposed upon return.
* If the result of a call is an object, a disposer will be added to it, which disposes all stubs therein. (If it's not an object, it can't possibly contain any stubs...)
* Stubs also have a `dup()` method which creates a separately-disposed copy of the stub, in case you want to keep a stub past when it would otherwise be automatically disposed.
* Of course, when the I/O context is destroyed, everything is implicitly disposed.

Note: The first few commits use a method named "dispose" but the last commit changes it to `Symbol.dispose`. Maybe I should have done that first, oh well.