### PR TITLE
Add WarningAggregator, improve unused stream warning

### DIFF
--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -362,7 +362,7 @@ public:
     kj::String toString(jsg::Lock& js) override {
       auto handle = exception.getHandle(js);
       auto obj = KJ_ASSERT_NONNULL(handle.tryCast<jsg::JsObject>());
-      obj.set(js, "name"_kjc, js.str("Unused stream created at:"_kjc));
+      obj.set(js, "name"_kjc, js.str("Unused stream created:"_kjc));
       return obj.get(js, "stack"_kjc).toString(js);
     }
 

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1325,4 +1325,53 @@ jsg::JsObject IoContext::getPromiseContextTag(jsg::Lock& js) {
   return KJ_REQUIRE_NONNULL(promiseContextTag).getHandle(js);
 }
 
+// ======================================================================================
+
+WarningAggregator::WarningAggregator(IoContext& context, EmitCallback emitter)
+    : worker(kj::atomicAddRef(context.getWorker())),
+      requestMetrics(kj::addRef(context.getMetrics())),
+      emitter(kj::mv(emitter)) {}
+
+WarningAggregator::~WarningAggregator() noexcept(false) {
+  auto lock = warnings.lockExclusive();
+  if (lock->size() > 0) {
+    auto emitter = kj::mv(this->emitter);
+    auto warnings = lock->releaseAsArray();
+    if (IoContext::hasCurrent()) {
+      // We are currently in a JavaScript execution context. The object is likely being
+      // destroyed during garbage collection. V8 does not like having most of its API
+      // invoked in the middle of GC. So we'll delay our warning until GC finished.
+      auto& context = IoContext::current();
+      context.addTask(context.run(
+          [emitter=kj::mv(emitter), warnings=kj::mv(warnings)](Worker::Lock& lock) mutable {
+        emitter(lock, kj::mv(warnings));
+      }));
+    } else {
+      // We aren't in any JavaScript context. The object might be being destroyed during
+      // IoContext shutdown or maybe even during deferred proxying. So, avoid touching
+      // the IoContext. Instead, we'll lock the worker directly.
+      worker->runInLockScope(Worker::Lock::TakeSynchronously(*requestMetrics),
+          [emitter=kj::mv(emitter), warnings=kj::mv(warnings)](Worker::Lock& lock) mutable {
+        JSG_WITHIN_CONTEXT_SCOPE(lock, lock.getContext(), [&](jsg::Lock& js) {
+          emitter(lock, kj::mv(warnings));
+        });
+      });
+    }
+  }
+}
+
+void WarningAggregator::add(kj::Own<WarningContext> warning) const {
+  warnings.lockExclusive()->add(kj::mv(warning));
+}
+
+kj::Own<WarningAggregator> IoContext::getWarningAggregator(
+    const WarningAggregator::Key& key,
+    kj::Function<kj::Own<WarningAggregator>(IoContext&)> load) {
+  auto& instance = warningAggregatorMap.findOrCreate(key,
+      [this, load=kj::mv(load), &key]() mutable -> WarningAggregator::Map::Entry {
+    return {key, load(*this)};
+  });
+  return kj::atomicAddRef(*instance);
+}
+
 }  // namespace workerd

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -35,6 +35,53 @@ namespace workerd {
 
 class IoContext;
 
+// A WarningAggregator is a helper utility for deduplicating related warning messages.
+// It is a ref-counted object that is initially acquired from the IoContext, but is
+// capable of outliving the IoContext. When destroyed, if there are any pending warnings,
+// those will be emitted all at once with a single header message followed by contextual
+// information for each individual collected instance.
+class WarningAggregator final: public kj::AtomicRefcounted {
+public:
+
+  // The IoContext will maintain a map of WarningAggregators based on an opaque key.
+  class Key final {
+  public:
+    Key() : hash(kj::hashCode(this)) {}
+    KJ_DISALLOW_COPY_AND_MOVE(Key);
+    inline uint hashCode() const { return hash; }
+    inline bool operator==(const Key& other) const { return this == &other; }
+  private:
+    uint hash;
+  };
+
+  // Captures the contextual information for a specific aggregated warning.
+  class WarningContext {
+  public:
+    virtual ~WarningContext() noexcept(false) = default;
+    virtual kj::String toString(jsg::Lock& js) = 0;
+  };
+
+  // The EmitCallback is called when the WarningAggregator is destroyed. It is
+  // responsible for actually emitting the warnings that are collected. It will
+  // only be called once and only if there are any collected warnings.
+  using EmitCallback = kj::Function<void(
+      Worker::Lock& lock,
+      kj::Array<kj::Own<WarningContext>> warnings)>;
+
+  WarningAggregator(IoContext& context, EmitCallback emitter);
+  ~WarningAggregator() noexcept(false);
+
+  void add(kj::Own<WarningContext> warning) const;
+
+  using Map = kj::HashMap<const Key&, kj::Own<WarningAggregator>>;
+
+private:
+  kj::Own<const Worker> worker;
+  kj::Own<RequestObserver> requestMetrics;
+  EmitCallback emitter;
+  kj::MutexGuarded<kj::Vector<kj::Own<WarningContext>>> warnings;
+};
+
 // Represents one incoming request being handled by a IoContext. In non-actor scenarios,
 // there is only ever one IncomingRequest per IoContext, but with actors there could be many.
 //
@@ -674,6 +721,11 @@ public:
 
   jsg::JsObject getPromiseContextTag(jsg::Lock& js);
 
+  // Returns the existing WarningAggregator for the specified key, or calls load to create one.
+  kj::Own<WarningAggregator> getWarningAggregator(
+      const WarningAggregator::Key& key,
+      kj::Function<kj::Own<WarningAggregator>(IoContext&)> load);
+
 private:
   ThreadContext& thread;
 
@@ -708,6 +760,8 @@ private:
 
   kj::Maybe<PendingEvent&> pendingEvent;
   kj::Maybe<kj::Promise<void>> runFinalizersTask;
+
+  WarningAggregator::Map warningAggregatorMap;
 
   // Objects pointed to by IoOwn<T>s.
   // NOTE: This must live below `deleteQueue`, as some of these OwnedObjects may own attachctx()'ed


### PR DESCRIPTION
EW-8204

The unused stream warning emitted when a tee'd branch of an internal stream is left unconsumed is spammy and not very helpful. This change improves things by ensuring that only one instance of the warning per IoContext is emitted, aggregating all of the information about branches that are not read. The warning message is further augmented to include the JavaScript stack trace locations where each of the unconsumed branches were created.

![image](https://github.com/cloudflare/workerd/assets/439929/34f5f267-11f6-45f2-8cca-e43caada3662)
