### PR TITLE
Return errors for mutations on read-only files in the in-memory VFS (rather than crashing)

### DIFF
--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -1300,9 +1300,13 @@ const sqlite3_io_methods SqliteDatabase::Vfs::FileImpl::FILE_METHOD_TABLE = {
   .xWrite = [](sqlite3_file* file, const void* buffer, int iAmt,
                sqlite3_int64 iOfst) noexcept -> int {
     WRAP_METHOD(SQLITE_IOERR_WRITE, {
-      auto bytes = kj::arrayPtr(reinterpret_cast<const byte*>(buffer), iAmt);
-      KJ_REQUIRE_NONNULL(self.writableFile).write(iOfst, bytes);
-      return SQLITE_OK;
+      KJ_IF_SOME(writableFile, self.writableFile) {
+        auto bytes = kj::arrayPtr(reinterpret_cast<const byte*>(buffer), iAmt);
+        writableFile.write(iOfst, bytes);
+        return SQLITE_OK;
+      } else {
+        return SQLITE_READONLY;
+      }
     });
   },
 

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -1312,8 +1312,12 @@ const sqlite3_io_methods SqliteDatabase::Vfs::FileImpl::FILE_METHOD_TABLE = {
 
   .xTruncate = [](sqlite3_file* file, sqlite3_int64 size) noexcept -> int {
     WRAP_METHOD(SQLITE_IOERR_TRUNCATE, {
-      KJ_REQUIRE_NONNULL(self.writableFile).truncate(size);
-      return SQLITE_OK;
+      KJ_IF_SOME(writableFile, self.writableFile) {
+        writableFile.truncate(size);
+        return SQLITE_OK;
+      } else {
+        return SQLITE_READONLY;
+      }
     });
   },
 


### PR DESCRIPTION
There are two commits here:

1. Return error when writing a read-only file in the in-memory VFS
2. Return error when truncating a read-only file in the in-memory VFS

The commit message for the write commit has a bunch of detail on why we want that particular fix.  I'm ambivalent on the truncate commit and could see the wisdom of dropping that commit (especially since I don't know how to test it at a high level), but it does seem weird to fix write, but not fix truncate.