### PR TITLE
Support for custom thenables in PromiseWrapper with compat flag

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -402,4 +402,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   #
   # To make room for people to define their own RPC methods with these names, this compat flag
   # makes them no longer defined.
+
+  unwrapCustomThenables @45 :Bool
+      $compatEnableFlag("unwrap_custom_thenables")
+      $compatDisableFlag("no_unwrap_custom_thenables")
+      $compatEnableDate("2024-04-01");
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1937,7 +1937,19 @@ class GeneratorContext;
 
 struct JsgConfig {
   bool noSubstituteNull = false;
+  bool unwrapCustomThenables = false;
 };
+
+static JsgConfig DEFAULT_JSG_CONFIG = {};
+
+template <typename Config>
+static const JsgConfig& getConfig(const Config& config) {
+  if constexpr (kj::isSameType<Config, JsgConfig>() || kj::canConvert<Config, JsgConfig>()) {
+    return config;
+  } else {
+    return DEFAULT_JSG_CONFIG;
+  }
+}
 
 // -----------------------------------------------------------------------------
 

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -710,25 +710,6 @@ public:
       return Promise<T>(context->GetIsolate(), promise);
     } else {
       // Input is a resolved value (not a promise). Try to unwrap it now.
-
-      // TODO(temporary): We want to update the code to allow use of custom thenables
-      // as well as Promises. However, we'd like to be able to do so without introducing
-      // a compat flag for it. To do that, we need to have a reasonable idea about whether
-      // anyone is actually passing objects through that could be interpreted as thenables.
-      //
-      // We use LOG_WARNING_PERIODICALLY here to avoid spamming the logs with warnings. We
-      // don't really need to know how often this happens, just whether it happens at all.
-      //
-      // This logging will be removed once we determine if it's happening in the wild
-      if (handle->IsObject()) {
-        auto obj = handle.As<v8::Object>();
-        auto then = check(obj->Get(context, v8StrIntern(context->GetIsolate(), "then")));
-        if (then->IsFunction()) {
-          LOG_WARNING_PERIODICALLY("NOSENTRY jsg::Promise::tryUnwrap() found a non-Promise "
-              "object with a `then` method.");
-        }
-      }
-
       if constexpr (isVoid<T>()) {
         // When expecting Promise<void>, we treat absolutely any non-promise value as being
         // an immediately-resolved promise. This is consistent with JavaScript where you'd

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -403,7 +403,8 @@ public:
   template <typename MetaConfiguration>
   TypeWrapper(v8::Isolate* isolate, MetaConfiguration&& configuration)
       : TypeWrapperBase<Self, T>(configuration)...,
-        MaybeWrapper<Self>(configuration) {
+        MaybeWrapper<Self>(configuration),
+        PromiseWrapper<Self>(configuration) {
     isolate->SetData(1, this);
   }
   KJ_DISALLOW_COPY_AND_MOVE(TypeWrapper);

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -563,22 +563,11 @@ public:
   }
 };
 
-static JsgConfig DEFAULT_JSG_CONFIG = {};
-
 // TypeWrapper mixin for maybes.
 template <typename TypeWrapper>
 class MaybeWrapper {
 
 public:
-  template <typename Config>
-  static const JsgConfig& getConfig(const Config& config) {
-    if constexpr (kj::isSameType<Config, JsgConfig>() || kj::canConvert<Config, JsgConfig>()) {
-      return config;
-    } else {
-      return DEFAULT_JSG_CONFIG;
-    }
-  }
-
   // The constructor here is a bit of a hack. The config is optional and might not be a JsgConfig
   // object (or convertible to a JsgConfig) if is provided. However, because of the way TypeWrapper
   // inherits MaybeWrapper, we always end up passing a config option (which might be std::nullptr_t)

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -116,6 +116,7 @@ struct WorkerdApi::Impl {
         : features(*impl.features),
           jsgConfig(jsg::JsgConfig {
             .noSubstituteNull = features.getNoSubstituteNull(),
+            .unwrapCustomThenables = features.getUnwrapCustomThenables(),
           }) {}
     operator const CompatibilityFlags::Reader() const { return features; }
     operator const jsg::JsgConfig&() const { return jsgConfig; }


### PR DESCRIPTION
Adds a new compat flag that enables support for accepting custom thenables in the jsg `PromiseWrapper`.

Note that this is on received values only (e.g. `tryUnwrap(...)`.