### PR TITLE
Add separate enterStartupPython limiter specifically for Python

### DIFF
--- a/src/workerd/io/limit-enforcer.h
+++ b/src/workerd/io/limit-enforcer.h
@@ -34,6 +34,10 @@ public:
   virtual kj::Own<void> enterStartupJs(
       jsg::Lock& lock, kj::Maybe<kj::Exception>& error) const = 0;
 
+  // used to enforce limits on Python script startup.
+  virtual kj::Own<void> enterStartupPython(
+      jsg::Lock& lock, kj::Maybe<kj::Exception>& error) const = 0;
+
   // Like enterStartupJs(), but used when compiling a dynamically-imported module.
   virtual kj::Own<void> enterDynamicImportJs(
       jsg::Lock& lock, kj::Maybe<kj::Exception>& error) const = 0;

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -200,7 +200,9 @@ public:
 
     // Callback which will construct the module registry and load all the modules into it.
     kj::Function<void(jsg::Lock& lock, const Api& api)> compileModules;
+    bool isPython;
   };
+  bool isPython;
   using Source = kj::OneOf<ScriptSource, ModulesSource>;
 
 private:

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2619,6 +2619,10 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
         jsg::Lock& lock, kj::Maybe<kj::Exception>& error) const override {
       return {};
     }
+    kj::Own<void> enterStartupPython(
+        jsg::Lock& lock, kj::Maybe<kj::Exception>& error) const override {
+      return {};
+    }
     kj::Own<void> enterDynamicImportJs(
         jsg::Lock& lock, kj::Maybe<kj::Exception>& error) const override {
       return {};

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -230,11 +230,13 @@ Worker::Script::Source WorkerdApi::extractSource(kj::StringPtr name,
         goto invalid;
       }
 
+      bool isPython = api::pyodide::hasPythonModules(modules);
       return Worker::Script::ModulesSource {
         modules[0].getName(),
         [conf,&errorReporter, extensions](jsg::Lock& lock, const Worker::Api& api) {
           return WorkerdApi::from(api).compileModules(lock, conf, errorReporter, extensions);
-        }
+        },
+        isPython
       };
     }
     case config::Worker::SERVICE_WORKER_SCRIPT:

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -157,6 +157,10 @@ struct MockIsolateLimitEnforcer final: public IsolateLimitEnforcer {
         jsg::Lock& lock, kj::Maybe<kj::Exception>& error) const override {
       return {};
     }
+    kj::Own<void> enterStartupPython(
+        jsg::Lock& lock, kj::Maybe<kj::Exception>& error) const override {
+      return {};
+    }
     kj::Own<void> enterDynamicImportJs(
         jsg::Lock& lock, kj::Maybe<kj::Exception>& error) const override {
       return {};


### PR DESCRIPTION
Currently it isn't very different but this gives us a bit of additional flexibility for configuring Python startup limits.