### PR TITLE
Add support for a storageClass option for R2 objects

### DIFF
--- a/src/workerd/api/r2-api.capnp
+++ b/src/workerd/api/r2-api.capnp
@@ -105,12 +105,14 @@ struct R2PutRequest {
   sha256 @6 :Data $Json.hex;
   sha384 @7 :Data $Json.hex;
   sha512 @8 :Data $Json.hex;
+  storageClass @9 :Text;
 }
 
 struct R2CreateMultipartUploadRequest {
   object @0 :Text;
   customFields @1 :List(Record);
   httpFields @2 :R2HttpFields;
+  storageClass @3 :Text;
 }
 
 struct R2UploadPartRequest {
@@ -214,6 +216,10 @@ struct R2HeadResponse {
 
   checksums @8 :R2Checksums;
   # If set, the available checksums for this object
+
+  storageClass @9 :Text;
+  # The storage class of the object. Standard or Infrequent Access.
+  # Provided on object creation to specify which storage tier R2 should use for this object.
 }
 
 using R2GetResponse = R2HeadResponse;

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -132,7 +132,7 @@ static jsg::Ref<T> parseObjectMetadata(R2HeadResponse::Reader responseReader,
   return jsg::alloc<T>(kj::str(responseReader.getName()),
       kj::str(responseReader.getVersion()), responseReader.getSize(),
       kj::str(responseReader.getEtag()), kj::mv(checksums), uploaded, kj::mv(httpMetadata),
-      kj::mv(customMetadata), range, kj::fwd<Args>(args)...);
+      kj::mv(customMetadata), range, kj::str(responseReader.getStorageClass()), kj::fwd<Args>(args)...);
 }
 
 template <HeadResultT T, typename... Args>
@@ -525,6 +525,9 @@ R2Bucket::put(jsg::Lock& js, kj::String name, kj::Maybe<R2PutValue> value,
           }
         }
       }
+      KJ_IF_SOME(s, o.storageClass) {
+        putBuilder.setStorageClass(s);
+      }
     }
 
     auto requestJson = json.encode(requestBuilder);
@@ -612,6 +615,9 @@ jsg::Promise<jsg::Ref<R2MultipartUpload>> R2Bucket::createMultipartUpload(jsg::L
         KJ_IF_SOME(ce, httpMetadata.cacheExpiry) {
           fields.setCacheExpiry((ce - kj::UNIX_EPOCH) / kj::MILLISECONDS);
         }
+      }
+      KJ_IF_SOME(s, o.storageClass) {
+        createMultipartUploadBuilder.setStorageClass(s);
       }
     }
 

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -171,27 +171,32 @@ public:
     jsg::Optional<kj::OneOf<kj::Array<kj::byte>, jsg::NonCoercible<kj::String>>> sha256;
     jsg::Optional<kj::OneOf<kj::Array<kj::byte>, jsg::NonCoercible<kj::String>>> sha384;
     jsg::Optional<kj::OneOf<kj::Array<kj::byte>, jsg::NonCoercible<kj::String>>> sha512;
+    jsg::Optional<kj::String> storageClass;
 
-    JSG_STRUCT(onlyIf, httpMetadata, customMetadata, md5, sha1, sha256, sha384, sha512);
+    JSG_STRUCT(onlyIf, httpMetadata, customMetadata, md5, sha1, sha256, sha384, sha512, storageClass);
     JSG_STRUCT_TS_OVERRIDE(R2PutOptions);
   };
 
   struct MultipartOptions {
     jsg::Optional<kj::OneOf<HttpMetadata, jsg::Ref<Headers>>> httpMetadata;
     jsg::Optional<jsg::Dict<kj::String>> customMetadata;
+    jsg::Optional<kj::String> storageClass;
 
-    JSG_STRUCT(httpMetadata, customMetadata);
+    JSG_STRUCT(httpMetadata, customMetadata, storageClass);
     JSG_STRUCT_TS_OVERRIDE(R2MultipartOptions);
   };
 
   class HeadResult: public jsg::Object {
   public:
     HeadResult(kj::String name, kj::String version, double size,
-               kj::String etag, jsg::Ref<Checksums> checksums, kj::Date uploaded, jsg::Optional<HttpMetadata> httpMetadata,
-               jsg::Optional<jsg::Dict<kj::String>> customMetadata, jsg::Optional<Range> range):
+               kj::String etag, jsg::Ref<Checksums> checksums, kj::Date uploaded,
+               jsg::Optional<HttpMetadata> httpMetadata,
+               jsg::Optional<jsg::Dict<kj::String>> customMetadata, jsg::Optional<Range> range,
+               kj::String storageClass):
         name(kj::mv(name)), version(kj::mv(version)), size(size), etag(kj::mv(etag)),
         checksums(kj::mv(checksums)), uploaded(uploaded), httpMetadata(kj::mv(httpMetadata)),
-        customMetadata(kj::mv(customMetadata)), range(kj::mv(range)) {}
+        customMetadata(kj::mv(customMetadata)), range(kj::mv(range)),
+        storageClass(kj::mv(storageClass)) {}
 
     kj::String getName() const { return kj::str(name); }
     kj::String getVersion() const { return kj::str(version); }
@@ -200,6 +205,7 @@ public:
     kj::String getHttpEtag() const { return kj::str('"', etag, '"'); }
     jsg::Ref<Checksums> getChecksums() { return checksums.addRef();}
     kj::Date getUploaded() const { return uploaded; }
+    kj::StringPtr getStorageClass() const { return storageClass; }
 
     jsg::Optional<HttpMetadata> getHttpMetadata() const {
       return httpMetadata.map([](const HttpMetadata& m) { return m.clone(); });
@@ -233,6 +239,7 @@ public:
       JSG_LAZY_READONLY_INSTANCE_PROPERTY(httpMetadata, getHttpMetadata);
       JSG_LAZY_READONLY_INSTANCE_PROPERTY(customMetadata, getCustomMetadata);
       JSG_LAZY_READONLY_INSTANCE_PROPERTY(range, getRange);
+      JSG_LAZY_READONLY_INSTANCE_PROPERTY(storageClass, getStorageClass);
       JSG_METHOD(writeHttpMetadata);
       JSG_TS_OVERRIDE(R2Object);
     }
@@ -257,6 +264,7 @@ public:
     jsg::Optional<jsg::Dict<kj::String>> customMetadata;
 
     jsg::Optional<Range> range;
+    kj::String storageClass;
     friend class R2Bucket;
   };
 
@@ -264,11 +272,11 @@ public:
   public:
     GetResult(kj::String name, kj::String version, double size,
               kj::String etag, jsg::Ref<Checksums> checksums, kj::Date uploaded, jsg::Optional<HttpMetadata> httpMetadata,
-              jsg::Optional<jsg::Dict<kj::String>> customMetadata, jsg::Optional<Range> range,
+              jsg::Optional<jsg::Dict<kj::String>> customMetadata, jsg::Optional<Range> range, kj::String storageClass,
               jsg::Ref<ReadableStream> body)
       : HeadResult(
           kj::mv(name), kj::mv(version), size, kj::mv(etag), kj::mv(checksums), uploaded,
-          kj::mv(KJ_ASSERT_NONNULL(httpMetadata)), kj::mv(KJ_ASSERT_NONNULL(customMetadata)), range),
+          kj::mv(KJ_ASSERT_NONNULL(httpMetadata)), kj::mv(KJ_ASSERT_NONNULL(customMetadata)), range, kj::mv(storageClass)),
           body(kj::mv(body)) {}
 
     jsg::Ref<ReadableStream> getBody() {


### PR DESCRIPTION
Adds an string option called storageClass for the R2 binding PutObject and CreateMultipartUpload methods. R2 will interpret this string to determine the storage class of the newly created object.

Adds a field to HeadResult, and by extension GetResult and ListResult, that R2 will use to return the storage class to the binding.

There is a corresponding internal PR for this change.