### PR TITLE
Fix recently-introduced onAbort() in WorkerEntrypoint::customEvent().

### DIFF
--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -650,11 +650,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
   this->incomingRequest = kj::none;
 
   auto& context = incomingRequest->getContext();
-  auto promise = event->run(kj::mv(incomingRequest), entrypointName).attach(kj::mv(event))
-      .exclusiveJoin(context.onAbort().then([]() -> WorkerInterface::CustomEvent::Result {
-    // onAbort() should always throw
-    KJ_UNREACHABLE;
-  }));
+  auto promise = event->run(kj::mv(incomingRequest), entrypointName).attach(kj::mv(event));
 
   // TODO(cleanup): In theory `context` may have been destroyed by now if `event->run()` dropped
   //   the `incomingRequest` synchronously. No current implementation does that, and


### PR DESCRIPTION
The `IoContext` will be destroyed during the course of `event->run()`, at which point this `onAbort()` will reject with a "PromiseFulfiller destroyed without fulfilling promise" exception. I don't know why this doesn't happen in tests but it seems to happen a lot in prod?

Anyway, I moved the `onAbort()` handling into the JSRPC CustomEvent implementation, which is the place I needed it for my purposes. I suspect many CustomEvent implementations do not honor onAbort(), though, which will need to be fixed later.