### PR TITLE
Add discussion category and template for Python packages

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/python_package_request.yml
+++ b/.github/DISCUSSION_TEMPLATE/python_package_request.yml
@@ -1,0 +1,16 @@
+title: "Python Package Request"
+labels: ["Python Package Request"]
+body:
+  - type: input
+    id: improvements
+    attributes:
+      label: Package Name
+      description: "Name of the Python package you want to work on Workers"
+      value: ...
+      render: bash
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Context


### PR DESCRIPTION
Creates a template for submitting requests to support additional Python packages in the Workers Runtime.

- Will show up here: https://github.com/cloudflare/workerd/discussions/new/choose
- This will be directly linkable, so we can direct people to it from error states cc @garrettgu10 
- Will show up as its own discussion category so that we can easily filter for just this.