### PR TITLE
fix: treat `kj::Array(Ptr)<const char>`s as TypeScript `string`s

### DIFF
--- a/types/test/generator/type.spec.ts
+++ b/types/test/generator/type.spec.ts
@@ -130,16 +130,20 @@ test("createTypeNode: array types", () => {
   array.setName("kj::Array");
   array.initElement().initNumber().setName("int");
   assert.strictEqual(printNode(createTypeNode(type)), "number[]");
+  // If element is a char, then this is a string
+  array.setName("kj::ArrayPtr");
+  array.initElement().initNumber().setName("char");
+  assert.strictEqual(printNode(createTypeNode(type)), "string");
   // If element is a byte, then this is an ArrayBuffer, ArrayBufferView or both
   array.setName("kj::Array");
-  array.initElement().initNumber().setName("char");
+  array.initElement().initNumber().setName("unsigned char");
   assert.strictEqual(printNode(createTypeNode(type)), "ArrayBuffer");
   assert.strictEqual(
     printNode(createTypeNode(type, true)),
     "ArrayBuffer | ArrayBufferView"
   );
   array.setName("kj::ArrayPtr");
-  array.initElement().initNumber().setName("char");
+  array.initElement().initNumber().setName("unsigned char");
   assert.strictEqual(printNode(createTypeNode(type)), "ArrayBufferView");
   assert.strictEqual(
     printNode(createTypeNode(type, true)),


### PR DESCRIPTION
Hey! 👋 This PR ensures `kj::Array(Ptr)<const char>`s are treated as `string`s when generating TypeScript types. 

Previously we assumed both `char`s and `unsigned char`s were byte arrays. This isn't quite right, `kj::byte` is defined as `unsigned char` and `char` arrays represent `string`s in JSG. This PR updates the TypeScript generator to only treat `unsigned char` arrays as byte arrays.

This results in the following diff for the `experimental` entrypoint (all compatibility flags enabled) from `@cloudflare/workers-types@4.20240222.0` (the last correct types version) to the types with this change:

<details>
<summary>Diff</summary>

```diff
diff --git a/node_modules/@cloudflare/workers-types/experimental/index.d.ts b/bazel/definitions/experimental/index.d.ts
index 1ef970c..2c5f491 100755
--- a/node_modules/@cloudflare/workers-types/experimental/index.d.ts
+++ b/bazel/definitions/experimental/index.d.ts
@@ -308,6 +308,7 @@ declare interface TestController {}
 declare interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  abort(reason?: any): void;
 }
 declare type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -381,6 +382,10 @@ declare interface Performance {
   readonly timeOrigin: number;
   now(): number;
 }
+declare interface AlarmInvocationInfo {
+  readonly isRetry: boolean;
+  readonly retryCount: number;
+}
 declare interface DurableObject {
   fetch(request: Request): Response | Promise<Response>;
   alarm?(): void | Promise<void>;
@@ -651,9 +656,9 @@ declare interface SchedulerWaitOptions {
 declare abstract class ExtendableEvent extends Event {
   waitUntil(promise: Promise<any>): void;
 }
-declare class CustomEvent extends Event {
+declare class CustomEvent<T = any> extends Event {
   constructor(type: string, init?: CustomEventCustomEventInit);
-  get detail(): any | undefined;
+  get detail(): T;
 }
 declare interface CustomEventCustomEventInit {
   bubbles?: boolean;
@@ -1144,11 +1149,7 @@ declare abstract class Fetcher {
     messages: ServiceBindingQueueMessage[]
   ): Promise<FetcherQueueResult>;
   scheduled(options?: FetcherScheduledOptions): Promise<FetcherScheduledResult>;
-  getRpcMethodForTestOnly(name: string): (() => any | Promise<any>) | null;
-}
-declare interface FetcherPutOptions {
-  expiration?: number;
-  expirationTtl?: number;
+  getRpcMethodForTestOnly(name: string): JsRpcProperty | null;
 }
 declare interface FetcherScheduledOptions {
   scheduledTime?: Date;
@@ -1160,10 +1161,10 @@ declare interface FetcherScheduledResult {
 }
 declare interface FetcherQueueResult {
   outcome: string;
-  retryAll: boolean;
   ackAll: boolean;
-  explicitRetries: string[];
+  retryBatch: QueueRetryBatch;
   explicitAcks: string[];
+  retryMessages: QueueRetryMessage[];
 }
 declare type ServiceBindingQueueMessage<Body = unknown> = {
   id: string;
@@ -1289,32 +1290,51 @@ declare interface KVNamespaceGetWithMetadataResult<Value, Metadata> {
 declare type QueueContentType = "text" | "bytes" | "json" | "v8";
 declare interface Queue<Body = unknown> {
   send(message: Body, options?: QueueSendOptions): Promise<void>;
-  sendBatch(messages: Iterable<MessageSendRequest<Body>>): Promise<void>;
+  sendBatch(
+    messages: Iterable<MessageSendRequest<Body>>,
+    options?: QueueSendBatchOptions
+  ): Promise<void>;
 }
 declare interface QueueSendOptions {
   contentType?: QueueContentType;
+  delaySeconds?: number;
+}
+declare interface QueueSendBatchOptions {
+  delaySeconds?: number;
 }
 declare interface MessageSendRequest<Body = unknown> {
   body: Body;
   contentType?: QueueContentType;
+  delaySeconds?: number;
+}
+declare interface QueueRetryBatch {
+  retry: boolean;
+  delaySeconds?: number;
+}
+declare interface QueueRetryMessage {
+  msgId: string;
+  delaySeconds?: number;
+}
+declare interface QueueRetryOptions {
+  delaySeconds?: number;
 }
 declare interface Message<Body = unknown> {
   readonly id: string;
   readonly timestamp: Date;
   readonly body: Body;
-  retry(): void;
+  retry(options?: QueueRetryOptions): void;
   ack(): void;
 }
 declare interface QueueEvent<Body = unknown> extends ExtendableEvent {
   readonly messages: readonly Message<Body>[];
   readonly queue: string;
-  retryAll(): void;
+  retryAll(options?: QueueRetryOptions): void;
   ackAll(): void;
 }
 declare interface MessageBatch<Body = unknown> {
   readonly messages: readonly Message<Body>[];
   readonly queue: string;
-  retryAll(): void;
+  retryAll(options?: QueueRetryOptions): void;
   ackAll(): void;
 }
 declare interface R2Error extends Error {
@@ -1480,6 +1500,11 @@ declare type R2Objects = {
       truncated: false;
     }
 );
+declare interface JsRpcProperty {
+  then(handler: Function, errorHandler?: Function): any;
+  catch(errorHandler: Function): any;
+  finally(onFinally: Function): any;
+}
 declare abstract class ScheduledEvent extends ExtendableEvent {
   readonly scheduledTime: number;
   readonly cron: string;
@@ -1919,7 +1944,11 @@ declare class URLSearchParams {
   [Symbol.iterator](): IterableIterator<[key: string, value: string]>;
 }
 declare class URLPattern {
-  constructor(input?: string | URLPatternURLPatternInit, baseURL?: string);
+  constructor(
+    input?: string | URLPatternURLPatternInit,
+    baseURL?: string,
+    patternOptions?: URLPatternURLPatternOptions
+  );
   get protocol(): string;
   get username(): string;
   get password(): string;
@@ -1960,6 +1989,9 @@ declare interface URLPatternURLPatternResult {
   search: URLPatternURLPatternComponentResult;
   hash: URLPatternURLPatternComponentResult;
 }
+declare interface URLPatternURLPatternOptions {
+  ignoreCase?: boolean;
+}
 declare class CloseEvent extends Event {
   constructor(type: string, initializer: CloseEventInit);
   /** Returns the WebSocket connection close code provided by the server. */
@@ -2136,9 +2168,9 @@ declare interface gpuGPUBuffer {
   unmap(): void;
   destroy(): void;
   mapAsync(
-    mode: number,
-    offset?: number | bigint,
-    size?: number | bigint
+    offset: number,
+    size?: number | bigint,
+    param3?: number | bigint
   ): Promise<void>;
   get size(): number | bigint;
   get usage(): number;
```

</details>

Fixes https://github.com/cloudflare/workerd/issues/1818