### PR TITLE
Implements Jaeger tracing for Python.

### DIFF
--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -104,7 +104,8 @@ jsg::Ref<PyodideMetadataReader> makePyodideMetadataReader(Worker::Reader conf) {
     names.add(kj::str(module.getName()));
   }
   return jsg::alloc<PyodideMetadataReader>(kj::mv(mainModule), names.finish(), contents.finish(),
-                                           requirements.finish(), true);
+                                           requirements.finish(), true /* isWorkerd */,
+                                           false /* isTracing */);
 }
 
 } // namespace workerd::api::pyodide

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -32,16 +32,21 @@ private:
   kj::Array<kj::Array<kj::byte>> contents;
   kj::Array<kj::String> requirements;
   bool isWorkerdFlag;
+  bool isTracingFlag;
 
 public:
   PyodideMetadataReader(kj::String mainModule, kj::Array<kj::String> names,
                         kj::Array<kj::Array<kj::byte>> contents, kj::Array<kj::String> requirements,
-                        bool isWorkerd)
+                        bool isWorkerd, bool isTracing)
       : mainModule(kj::mv(mainModule)), names(kj::mv(names)), contents(kj::mv(contents)),
-        requirements(kj::mv(requirements)), isWorkerdFlag(isWorkerd) {}
+        requirements(kj::mv(requirements)), isWorkerdFlag(isWorkerd), isTracingFlag(isTracing) {}
 
   bool isWorkerd() {
     return this->isWorkerdFlag;
+  }
+
+  bool isTracing() {
+    return this->isTracingFlag;
   }
 
   kj::String getMainModule() {
@@ -58,6 +63,7 @@ public:
 
   JSG_RESOURCE_TYPE(PyodideMetadataReader) {
     JSG_METHOD(isWorkerd);
+    JSG_METHOD(isTracing);
     JSG_METHOD(getMainModule);
     JSG_METHOD(getRequirements);
     JSG_METHOD(getNames);
@@ -151,6 +157,16 @@ private:
   bool hasUploaded;
 };
 
+
+class DisabledInternalJaeger : public jsg::Object {
+public:
+  static jsg::Ref<DisabledInternalJaeger> create() {
+    return jsg::alloc<DisabledInternalJaeger>();
+  }
+  JSG_RESOURCE_TYPE(DisabledInternalJaeger) {
+  }
+};
+
 using Worker = server::config::Worker;
 
 jsg::Ref<PyodideMetadataReader> makePyodideMetadataReader(Worker::Reader conf);
@@ -158,7 +174,8 @@ jsg::Ref<PyodideMetadataReader> makePyodideMetadataReader(Worker::Reader conf);
 #define EW_PYODIDE_ISOLATE_TYPES       \
   api::pyodide::PackagesTarReader,     \
   api::pyodide::PyodideMetadataReader, \
-  api::pyodide::ArtifactBundler
+  api::pyodide::ArtifactBundler,       \
+  api::pyodide::DisabledInternalJaeger
 
 template <class Registry> void registerPyodideModules(Registry& registry, auto featureFlags) {
   if (featureFlags.getPythonWorkers()) {

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -436,6 +436,23 @@ void WorkerdApi::compileModules(
         },
             jsg::ModuleRegistry::Type::INTERNAL);
       }
+
+      // Inject jaeger internal tracer in a disabled state (we don't have a use for it in workerd)
+      {
+        using ModuleInfo = jsg::ModuleRegistry::ModuleInfo;
+        using ObjectModuleInfo = jsg::ModuleRegistry::ObjectModuleInfo;
+        using ResolveMethod = jsg::ModuleRegistry::ResolveMethod;
+        auto specifier = "pyodide-internal:jaeger";
+        modules->addBuiltinModule(
+            specifier,
+            [specifier = kj::str(specifier)](
+                jsg::Lock& js, ResolveMethod, kj::Maybe<const kj::Path&>&) mutable {
+              auto& wrapper = JsgWorkerdIsolate_TypeWrapper::from(js.v8Isolate);
+              auto wrap = wrapper.wrap(js.v8Context(), kj::none, DisabledInternalJaeger::create());
+              return kj::Maybe(ModuleInfo(js, specifier, kj::none, ObjectModuleInfo(js, wrap)));
+            },
+            jsg::ModuleRegistry::Type::INTERNAL);
+      }
     }
 
     for (auto module: confModules) {


### PR DESCRIPTION
This assumes that we disallow access to `pyodide-internal` from the Python code.

TODOs left:
- [x] Currently this only adds a few spans, will add more before merging but want to get this to review asap.
- [x] Need to set up a disabled internal jaeger tracer in workerd-api.

Tested upstream.