### PR TITLE
Fixes memory snapshot upload for Python Workers.

### DIFF
--- a/src/pyodide/python-entrypoint-helper.js
+++ b/src/pyodide/python-entrypoint-helper.js
@@ -6,6 +6,7 @@ import {
   mountLib,
   canonicalizePackageName,
   enterJaegerSpan,
+  uploadArtifacts,
 } from "pyodide-internal:python";
 import { default as LOCKFILE } from "pyodide-internal:generated/pyodide-lock.json";
 import { default as MetadataReader } from "pyodide-internal:runtime-generated/metadata";
@@ -193,6 +194,8 @@ function makeHandler(pyHandlerName) {
     } catch (e) {
       console.warn(e.stack);
       throw e;
+    } finally {
+      args[2].waitUntil(uploadArtifacts());
     }
   };
 }

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -726,6 +726,15 @@ public:
       const WarningAggregator::Key& key,
       kj::Function<kj::Own<WarningAggregator>(IoContext&)> load);
 
+  // The IoChannelFactory must be accessed through the
+  // currentIncomingRequest because it has some tracing context built in.
+  //
+  // TODO(later): this is made public for Python Workers. It should be possible to make this private
+  // again later.
+  IoChannelFactory& getIoChannelFactory() {
+    return *getCurrentIncomingRequest().ioChannelFactory;
+  }
+
 private:
   ThreadContext& thread;
 
@@ -860,9 +869,6 @@ private:
   IncomingRequest& getCurrentIncomingRequest() {
     KJ_REQUIRE(!incomingRequests.empty(), "the IoContext has no current IncomingRequest");
     return incomingRequests.front();
-  }
-  IoChannelFactory& getIoChannelFactory() {
-    return *getCurrentIncomingRequest().ioChannelFactory;
   }
 
   // Run the given callback within the scope of this IoContext. This encapsultes the


### PR DESCRIPTION
This PR:

* Moves upload outside the global scope
* Makes certain methods in IoContext  public so they can be used in EW.

Tested in EW.