### PR TITLE
Update `docs/v8-update.md`

### DIFF
--- a/docs/v8-updates.md
+++ b/docs/v8-updates.md
@@ -2,9 +2,9 @@
 
 To update the version of V8 used by workerd, the steps are:
 
-1. Check <https://omahaproxy.appspot.com/> and identify the latest version of V8 used by the beta versions of Chrome beta.
+1. Check <https://chromiumdash.appspot.com/> and identify the latest version of V8 used by the beta versions of Chrome beta.
 
-2. Install depot_tools if it is not already present on your machine.
+2. Install `depot_tools` if it is not already present on your machine.
 
    <https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up>
 
@@ -18,12 +18,12 @@ To update the version of V8 used by workerd, the steps are:
 
 4. Sync the local copy of V8 to the version used by workerd.
 
-   First find, the tag of the "v8" `http_archive` in the workerd [WORKSPACE](../WORKSPACE) file.
+   First find, the tag of the V8 `http_archive` (`name = "v8"`) in the workerd [WORKSPACE](../WORKSPACE) file.
 
    Then sync your fetched version v8 based on the tag.
 
    ```sh
-   cd v8/v8
+   cd <path_to_v8>/v8
    git checkout <tag>
    gclient sync
    ```
@@ -52,11 +52,11 @@ To update the version of V8 used by workerd, the steps are:
    the command would be:
 
    ```sh
-   git format-patch --full-index -k --no-signature HEAD~8
+   git format-patch --full-index -k --no-signature --no-stat HEAD~8
    ```
 
-8. Remove the existing patches from `workerd/patches/v8` and copy the latest patches
-   for the V8 directory there.
+8. Remove the existing patches from `workerd/patches/v8` and copy over the latest generated patches
+from the V8 directory.
 
 9. Update the `http_archive` for V8 in the `workerd/WORKSPACE` file.
 
@@ -66,17 +66,20 @@ To update the version of V8 used by workerd, the steps are:
     `strip_prefix` and `url` in the `http_archive` for V8 should be updated based on the new V8
     version/tag.
 
+    The `integrity` check needs to be updated to the new value. You can get the new value in
+    bazel's preferred format just by looking into the mismatch error while trying to compile
+    workerd using the newer V8 version.
+
     See [V8 http_archive in WORKSPACE](https://github.com/cloudflare/workerd/blob/587ad90dd1e91d2660c271018056f4189fca3501/WORKSPACE#L408)
 
 10. Update V8's dependencies in `workerd/WORKSPACE`.
 
-    The `v8/.gclient_entries` file contains the commit versions for V8's dependencies.
+    You can find the commit versions for V8's dependencies under `v8/DEPS` and the ones
+    that are carried through to workerd in the `workerd/WORKSPACE` file.
 
-    You can find V8's dependencies that are carried through to workerd in the `WORKSPACE` file.
-
-    You will usually update `com_google_chromium_icu`, but other projects may need updating
-    too. Typically you'll get a build failure if the projects are out of sync. Copy the
-    commit versions from `v8/.gclient_entries` to the `WORKSPACE` file.
+    These currently include `abseil`, `com_google_chromium_icu` and `trace_event_common`.
+    Typically you'll get a build failure if the projects are out of sync. Copy the
+    commit versions from `v8/DEPS` to the `WORKSPACE` file.
 
 11. Check workerd's tests pass with the updated V8.
 


### PR DESCRIPTION
Just a few updates to our V8 update process. Also, I added the `--no-stat` flag to the `git format-patch` command, since when I attempted to use the current version of the command, I also got some summaries of the changes (files and additions/deletions) at the end of the generated patches.