### PR TITLE
[CI] Fix macOS build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,6 +60,7 @@ http_archive(
     patch_args = ["-p1"],
     patches = [
         "//:patches/sqlite/0001-row-counts-plain.patch",
+        "//:patches/sqlite/0002-macOS-missing-PATH-fix.patch",
     ],
     sha256 = "ab9aae38a11b931f35d8d1c6d62826d215579892e6ffbf89f20bdce106a9c8c5",
     strip_prefix = "sqlite-src-3440000",

--- a/patches/sqlite/0002-macOS-missing-PATH-fix.patch
+++ b/patches/sqlite/0002-macOS-missing-PATH-fix.patch
@@ -1,0 +1,19 @@
+diff --color -u5 -r sqlite-src-3440000-pristine/tool/mksqlite3c.tcl sqlite-src-3440000-modified/tool/mksqlite3c.tcl
+--- sqlite-src-3440000-pristine/tool/mksqlite3c.tcl	2023-11-01 07:31:37
++++ sqlite-src-3440000-modified/tool/mksqlite3c.tcl	2024-03-14 17:36:55
+@@ -84,11 +84,14 @@
+ set fname sqlite3.c
+ if {$enable_recover} { set fname sqlite3r.c }
+ set out [open $fname w]
+ # Force the output to use unix line endings, even on Windows.
+ fconfigure $out -translation lf
+-set today [clock format [clock seconds] -format "%Y-%m-%d %H:%M:%S UTC" -gmt 1]
++# The command below results in "couldn't find HOME environment variable to
++# expand path" errors on macOS CI runs. today is unused, so it is safe to
++# comment it out.
++# set today [clock format [clock seconds] -format "%Y-%m-%d %H:%M:%S UTC" -gmt 1]
+ puts $out [subst \
+ {/******************************************************************************
+ ** This file is an amalgamation of many separate C source files from SQLite
+ ** version $VERSION.  By combining all the individual C code files into this
+ ** single large file, the entire code can be compiled as a single translation


### PR DESCRIPTION
The macOS CI build consistently failed with "couldn't find HOME environment variable to expand path" errors on several branches. While I was unable to reproduce the error or figure out why it started appearing, this can be fixed by patching out the command that leads to HOME being queried (it is only used to define an unused variable anyway).