### PR TITLE
Reland TransformStream cancel algorithm

### DIFF
--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -142,6 +142,7 @@ struct Transformer {
   using StartAlgorithm = jsg::Promise<void>(Controller);
   using TransformAlgorithm = jsg::Promise<void>(v8::Local<v8::Value>, Controller);
   using FlushAlgorithm = jsg::Promise<void>(Controller);
+  using CancelAlgorithm = jsg::Promise<void>(jsg::JsValue reason);
 
   jsg::Optional<kj::String> readableType;
   jsg::Optional<kj::String> writableType;
@@ -149,17 +150,20 @@ struct Transformer {
   jsg::Optional<jsg::Function<StartAlgorithm>> start;
   jsg::Optional<jsg::Function<TransformAlgorithm>> transform;
   jsg::Optional<jsg::Function<FlushAlgorithm>> flush;
+  jsg::Optional<jsg::Function<CancelAlgorithm>> cancel;
 
   // The expectedLength is a non-standard extension used to support specifying the
   // content-length when using a TransformStream readable side as the body of a
   // request or response.
   jsg::Optional<uint64_t> expectedLength;
 
-  JSG_STRUCT(readableType, writableType, start, transform, flush, expectedLength);
+  JSG_STRUCT(readableType, writableType, start, transform, flush, cancel, expectedLength);
   JSG_STRUCT_TS_OVERRIDE(<I = any, O = any> {
     start?: (controller: TransformStreamDefaultController<O>) => void | Promise<void>;
     transform?: (chunk: I, controller: TransformStreamDefaultController<O>) => void | Promise<void>;
     flush?: (controller: TransformStreamDefaultController<O>) => void | Promise<void>;
+    cancel?: (reason: any) => void | Promise<void>;
+    expectedLength?: number;
   });
 };
 

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -1932,6 +1932,14 @@ ReadableStreamDefaultController::ReadableStreamDefaultController(
     : ioContext(tryGetIoContext()),
       impl(kj::mv(underlyingSource), kj::mv(queuingStrategy)) {}
 
+kj::Maybe<StreamStates::Errored> ReadableStreamDefaultController::getMaybeErrorState(
+    jsg::Lock& js) {
+  KJ_IF_SOME(errored, impl.state.tryGet<StreamStates::Errored>()) {
+    return errored.addRef(js);
+  }
+  return kj::none;
+}
+
 void ReadableStreamDefaultController::start(jsg::Lock& js) {
   impl.start(js, JSG_THIS);
 }
@@ -3769,8 +3777,31 @@ jsg::Promise<void> TransformStreamDefaultController::write(
 jsg::Promise<void> TransformStreamDefaultController::abort(
     jsg::Lock& js,
     v8::Local<v8::Value> reason) {
-  error(js, reason);
-  return js.resolvedPromise();
+  KJ_IF_SOME(finish, algorithms.maybeFinish) {
+    return finish.whenResolved(js);
+  }
+  return algorithms.maybeFinish.emplace(maybeRunAlgorithm(js, algorithms.cancel,
+      JSG_VISITABLE_LAMBDA(
+          (this, ref=JSG_THIS, reason = jsg::JsRef(js, jsg::JsValue(reason))),
+          (ref, reason),
+          (jsg::Lock& js) -> jsg::Promise<void> {
+    // If the readable side is errored, return a rejected promise with the stored error
+    KJ_IF_SOME(controller, tryGetReadableController()) {
+      KJ_IF_SOME(error, controller.getMaybeErrorState(js)) {
+        return js.rejectedPromise<void>(kj::mv(error));
+      } else {}  // Else block to avert dangling else compiler warning.
+    } else {}  // Else block to avert dangling else compiler warning.
+
+    // Otherwise... error with the given reason and resolve the abort promise
+    error(js, reason.getHandle(js));
+    return js.resolvedPromise();
+  }), JSG_VISITABLE_LAMBDA(
+      (this, ref=JSG_THIS),
+      (ref),
+      (jsg::Lock& js, jsg::Value reason) -> jsg::Promise<void> {
+    error(js, reason.getHandle(js));
+    return js.rejectedPromise<void>(kj::mv(reason));
+  }), jsg::JsValue(reason))).whenResolved(js);
 }
 
 jsg::Promise<void> TransformStreamDefaultController::close(jsg::Lock& js) {
@@ -3806,9 +3837,25 @@ jsg::Promise<void> TransformStreamDefaultController::pull(jsg::Lock& js) {
 jsg::Promise<void> TransformStreamDefaultController::cancel(
     jsg::Lock& js,
     v8::Local<v8::Value> reason) {
-  readable = kj::none;
-  errorWritableAndUnblockWrite(js, reason);
-  return js.resolvedPromise();
+  KJ_IF_SOME(finish, algorithms.maybeFinish) {
+    return finish.whenResolved(js);
+  }
+  return algorithms.maybeFinish.emplace(maybeRunAlgorithm(js, algorithms.cancel,
+      JSG_VISITABLE_LAMBDA(
+          (this, ref=JSG_THIS, reason = jsg::JsRef(js, jsg::JsValue(reason))),
+          (ref, reason),
+          (jsg::Lock& js) -> jsg::Promise<void> {
+    readable = kj::none;
+    errorWritableAndUnblockWrite(js, reason.getHandle(js));
+    return js.resolvedPromise();
+  }), JSG_VISITABLE_LAMBDA(
+      (this, ref=JSG_THIS),
+      (ref),
+      (jsg::Lock& js, jsg::Value reason) -> jsg::Promise<void> {
+    readable = kj::none;
+    errorWritableAndUnblockWrite(js, reason.getHandle(js));
+    return js.rejectedPromise<void>(kj::mv(reason));
+  }), jsg::JsValue(reason))).whenResolved(js);
 }
 
 jsg::Promise<void> TransformStreamDefaultController::performTransform(
@@ -3905,6 +3952,10 @@ void TransformStreamDefaultController::init(
 
   KJ_IF_SOME(flush, transformer.flush) {
     algorithms.flush = kj::mv(flush);
+  }
+
+  KJ_IF_SOME(cancel, transformer.cancel) {
+    algorithms.cancel = kj::mv(cancel);
   }
 
   setBackpressure(js, true);

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -431,6 +431,8 @@ public:
     tracker.trackField("impl", impl);
   }
 
+  kj::Maybe<StreamStates::Errored> getMaybeErrorState(jsg::Lock& js);
+
 private:
   kj::Maybe<IoContext&> ioContext;
   ReadableImpl impl;
@@ -669,6 +671,9 @@ private:
   struct Algorithms {
     kj::Maybe<jsg::Function<Transformer::TransformAlgorithm>> transform;
     kj::Maybe<jsg::Function<Transformer::FlushAlgorithm>> flush;
+    kj::Maybe<jsg::Function<Transformer::CancelAlgorithm>> cancel;
+
+    kj::Maybe<jsg::Promise<void>> maybeFinish = kj::none;
 
     Algorithms() {};
     Algorithms(Algorithms&& other) = default;
@@ -677,10 +682,11 @@ private:
     inline void clear() {
       transform = kj::none;
       flush = kj::none;
+      cancel = kj::none;
     }
 
     inline void visitForGc(jsg::GcVisitor& visitor) {
-      visitor.visit(transform, flush);
+      visitor.visit(transform, flush, cancel, maybeFinish);
     }
   };
 

--- a/src/workerd/api/tests/streams-test.js
+++ b/src/workerd/api/tests/streams-test.js
@@ -259,6 +259,55 @@ export const readAllTextFailed = {
   }
 };
 
+export const tsCancel = {
+  async test() {
+    // Verify that a TransformStream's cancel function is called when the
+    // readable is canceled or the writable is aborted. Verify also that
+    // errors thrown by the cancel function are propagated.
+    {
+      let cancelCalled = false;
+      const { readable } = new TransformStream({
+        async cancel(reason) {
+          strictEqual(reason, 'boom');
+          await scheduler.wait(10);
+          cancelCalled = true;
+        }
+      });
+      ok(!cancelCalled);
+      await readable.cancel('boom');
+      ok(cancelCalled);
+    }
+
+    {
+      let cancelCalled = false;
+      const { writable } = new TransformStream({
+        async cancel(reason) {
+          strictEqual(reason, 'boom');
+          await scheduler.wait(10);
+          cancelCalled = true;
+        }
+      });
+      ok(!cancelCalled);
+      await writable.abort('boom');
+      ok(cancelCalled);
+    }
+
+    {
+      const { writable } = new TransformStream({
+        async cancel(reason) {
+          throw new Error('boomy');
+        }
+      });
+      try {
+        await writable.abort('boom');
+        throw new Error('expected to throw');
+      } catch (err) {
+        strictEqual(err.message, 'boomy');
+      }
+    }
+  }
+};
+
 export default {
   async fetch(request, env) {
     strictEqual(request.headers.get('content-length'), '10');


### PR DESCRIPTION
Previously landed but reverted while tracking down some other issue. Adds support for the new TransformStream cancel algorithm