### PR TITLE
Use a weakref between WritableStream and WritableStreamDefaultController

### DIFF
--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -362,7 +362,7 @@ private:
   struct Writable {};
 
   // Sadly, we have to use a weak ref here rather than jsg::Ref. This is because
-  // the jsg::Ref<WritableStream> (via it's internal WritableStreamJsController
+  // the jsg::Ref<WritableStream> (via it's internal WritableStreamJsController)
   // holds a strong reference to the jsg::Ref<WritableStreamDefaultController> that
   // uses this WritableImpl. This creates a strong circular reference between jsg::Refs
   // that isn't allowed. GcTracing ends up with a stack overflow as the two jsg::Refs

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -7,6 +7,7 @@
 #include "common.h"
 #include "queue.h"
 #include <workerd/jsg/function.h>
+#include <workerd/util/weak-refs.h>
 
 namespace workerd::api {
 
@@ -265,7 +266,7 @@ public:
     }
   };
 
-  WritableImpl(jsg::Ref<WritableStream> owner);
+  WritableImpl(WritableStream& owner);
 
   jsg::Promise<void> abort(jsg::Lock& js,
                             jsg::Ref<Self> self,
@@ -360,7 +361,13 @@ private:
 
   struct Writable {};
 
-  kj::Maybe<jsg::Ref<WritableStream>> owner;
+  // Sadly, we have to use a weak ref here rather than jsg::Ref. This is because
+  // the jsg::Ref<WritableStream> (via it's internal WritableStreamJsController
+  // holds a strong reference to the jsg::Ref<WritableStreamDefaultController> that
+  // uses this WritableImpl. This creates a strong circular reference between jsg::Refs
+  // that isn't allowed. GcTracing ends up with a stack overflow as the two jsg::Refs
+  // try tracing each other.
+  kj::Maybe<kj::Own<WeakRef<WritableStream>>> owner;
   jsg::Ref<AbortSignal> signal;
   kj::OneOf<StreamStates::Closed,
             StreamStates::Errored,
@@ -575,7 +582,7 @@ class WritableStreamDefaultController: public jsg::Object {
 public:
   using WritableImpl = WritableImpl<WritableStreamDefaultController>;
 
-  explicit WritableStreamDefaultController(jsg::Ref<WritableStream> owner);
+  explicit WritableStreamDefaultController(WritableStream& owner);
 
   jsg::Promise<void> abort(jsg::Lock& js, v8::Local<v8::Value> reason);
 

--- a/src/workerd/api/tests/streams-test.js
+++ b/src/workerd/api/tests/streams-test.js
@@ -308,6 +308,14 @@ export const tsCancel = {
   }
 };
 
+export const writableStreamGcTraceFinishes = {
+  test() {
+    // TODO(soon): We really need better testing for gc visitation.
+    const ws = new WritableStream();
+    gc();
+  }
+};
+
 export default {
   async fetch(request, env) {
     strictEqual(request.headers.get('content-length'), '10');

--- a/src/workerd/api/tests/streams-test.wd-test
+++ b/src/workerd/api/tests/streams-test.wd-test
@@ -1,6 +1,7 @@
 using Workerd = import "/workerd/workerd.capnp";
 
 const unitTests :Workerd.Config = (
+  v8Flags = ["--expose-gc"],
   services = [
     ( name = "streams-test",
       worker = (


### PR DESCRIPTION
Partially undoes a prior change that removed the weakref between the WritableStream JS implementation and it's underlying WritableStreamDefaultController.