### PR TITLE
Implement AbortSignal.protototype.onabort

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -508,6 +508,16 @@ void AbortSignal::setOnAbort(jsg::Lock& js, jsg::Optional<jsg::JsValue> handler)
     if (h.isFunction() || h.isObject()) {
       onAbortHandler = jsg::JsRef(js, h);
       return;
+    } else {
+      // TODO(soon): Per the spec we are supposed o set the handler to null if it is not
+      // a function or an object. However, there's an ever so slight change that would
+      // be breaking. So let's go ahead and set the value in this case and log a warning.
+      // If we do not see any instances of the warning in logs, we can remove this and
+      // go with the default behavior.
+      LOG_WARNING_PERIODICALLY(
+          "NOSENTRY AbortSignal::setOnAbort set to non-function/non-object value");
+      onAbortHandler = jsg::JsRef(js, h);
+      return;
     }
   }
   onAbortHandler = kj::none;

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -493,6 +493,13 @@ public:
       kj::Array<jsg::Ref<AbortSignal>> signals,
       const jsg::TypeHandler<EventTarget::HandlerFunction>& handler);
 
+  // While AbortSignal extends EventTarget, and our EventTarget implementation will
+  // automatically support onabort being set as an own property, the spec defines
+  // onabort as a prototype property on the AbortSignal prototype. Therefore, we
+  // need to explicitly set it as a prototype property here.
+  kj::Maybe<jsg::JsValue> getOnAbort(jsg::Lock& js);
+  void setOnAbort(jsg::Lock& js, jsg::Optional<jsg::JsValue> handler);
+
   JSG_RESOURCE_TYPE(AbortSignal, CompatibilityFlags::Reader flags) {
     JSG_INHERIT(EventTarget);
     JSG_STATIC_METHOD(abort);
@@ -505,6 +512,7 @@ public:
       JSG_READONLY_INSTANCE_PROPERTY(aborted, getAborted);
       JSG_READONLY_INSTANCE_PROPERTY(reason, getReason);
     }
+    JSG_PROTOTYPE_PROPERTY(onabort, getOnAbort, setOnAbort);
     JSG_METHOD(throwIfAborted);
   }
 
@@ -543,6 +551,7 @@ private:
   IoOwn<RefcountedCanceler> canceler;
   Flag flag;
   kj::Maybe<jsg::JsRef<jsg::JsValue>> reason;
+  kj::Maybe<jsg::JsRef<jsg::JsValue>> onAbortHandler;
 
   void visitForGc(jsg::GcVisitor& visitor);
 

--- a/src/workerd/api/http-test.js
+++ b/src/workerd/api/http-test.js
@@ -129,7 +129,7 @@ export const inspect = {
   keepalive: false,
   integrity: '',
   cf: undefined,
-  signal: AbortSignal { reason: undefined, aborted: false },
+  signal: AbortSignal { onabort: null, reason: undefined, aborted: false },
   fetcher: null,
   redirect: 'follow',
   headers: Headers(1) { 'content-type' => 'text/plain', [immutable]: false },

--- a/src/workerd/api/tests/abortsignal-test.js
+++ b/src/workerd/api/tests/abortsignal-test.js
@@ -163,3 +163,32 @@ export const anyAbort3 = {
     strictEqual(any.reason, 123);
   }
 };
+
+export const onabortPrototypeProperty = {
+  test() {
+    const ac = new AbortController();
+    ok('onabort' in AbortSignal.prototype);
+    strictEqual(ac.signal.onabort, null);
+    delete ac.signal.onabort;
+    ok('onabort' in AbortSignal.prototype);
+    strictEqual(ac.signal.onabort, null);
+    let called = false;
+    ac.signal.onabort = () => {
+      called = true;
+    };
+    ac.abort();
+    ok(called);
+
+    // Setting the value to something other than a function or object
+    // should cause the value to become null.
+    [123, null, 'foo'].forEach((v) => {
+      ac.signal.onabort = () => {};
+      ac.signal.onabort = v;
+      strictEqual(ac.signal.onabort, null);
+    });
+
+    const handler = {};
+    ac.signal.onabort = handler;
+    strictEqual(ac.signal.onabort, handler);
+  }
+};

--- a/src/workerd/api/tests/abortsignal-test.js
+++ b/src/workerd/api/tests/abortsignal-test.js
@@ -184,7 +184,11 @@ export const onabortPrototypeProperty = {
     [123, null, 'foo'].forEach((v) => {
       ac.signal.onabort = () => {};
       ac.signal.onabort = v;
-      strictEqual(ac.signal.onabort, null);
+      // TODO(soon): For now, we are relaxing this check and will log a warning
+      // if the value is not a function or object. If we get no hits on that warning,
+      // we can return to checking for null here.
+      //strictEqual(ac.signal.onabort, null);
+      strictEqual(ac.signal.onabort, v);
     });
 
     const handler = {};


### PR DESCRIPTION
The spec defines `onabort` as a prototype property, implement it as such.

Technically speaking, this *could* be considered a breaking change :-/ ... I'm hoping we can get away with it without requiring a compat flag. It's a potentially breaking change because prior to this, the following operations would have different results:

* `'onabort' in AbortSignal.prototype`  ... previously, false, now true
* `delete signal.onabort` ... previously deletes the own property if set, now has no change
* `Object.keys(signal)` ... previously would include `onabort` if it was set, now always excludes it

One thing this PR doesn't do (that we can do later in a separate PR) is define the type mapping override for `onabort`.