### PR TITLE
Pass scriptId in Trace

### DIFF
--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -52,8 +52,8 @@ class Trace final : public kj::Refcounted {
 public:
   explicit Trace(kj::Maybe<kj::String> stableId, kj::Maybe<kj::String> scriptName,
       kj::Maybe<kj::Own<ScriptVersion::Reader>> scriptVersion,
-      kj::Maybe<kj::String> dispatchNamespace, kj::Array<kj::String> scriptTags,
-      kj::Maybe<kj::String> entrypoint);
+      kj::Maybe<kj::String> dispatchNamespace, kj::Maybe<kj::String> scriptId,
+      kj::Array<kj::String> scriptTags, kj::Maybe<kj::String> entrypoint);
   Trace(rpc::Trace::Reader reader);
   ~Trace() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(Trace);
@@ -275,6 +275,7 @@ public:
   kj::Maybe<kj::String> scriptName;
   kj::Maybe<kj::Own<ScriptVersion::Reader>> scriptVersion;
   kj::Maybe<kj::String> dispatchNamespace;
+  kj::Maybe<kj::String> scriptId;
   kj::Array<kj::String> scriptTags;
   kj::Maybe<kj::String> entrypoint;
 
@@ -334,6 +335,7 @@ public:
   }
 
   kj::Own<WorkerTracer> makeWorkerTracer(PipelineLogLevel pipelineLogLevel,
+                                         kj::Maybe<kj::String> scriptId,
                                          kj::Maybe<kj::String> stableId,
                                          kj::Maybe<kj::String> scriptName,
                                          kj::Maybe<kj::Own<ScriptVersion::Reader>> scriptVersion,

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -43,6 +43,7 @@ struct Trace @0x8e8d911203762d34 {
   outcome @2 :EventOutcome;
   scriptName @4 :Text;
   scriptVersion @19 :ScriptVersion;
+  scriptId @23 :Text;
 
   eventTimestampNs @5 :Int64;
 


### PR DESCRIPTION
Passes `scriptId` and `sourcemapsAvailable` through various usages of `Trace`.