### PR TITLE
Dedicated Python memory snapshots

### DIFF
--- a/src/pyodide/BUILD.bazel
+++ b/src/pyodide/BUILD.bazel
@@ -119,12 +119,6 @@ REPLACEMENTS = [
         "crypto.getRandomValues",
         "getRandomValues"
     ],
-    [
-        # Expose recursiveDependencies for use in setupPackages
-        # TODO: upstream this.
-        'o(Ct,"recursiveDependencies");',
-        'o(Ct,"recursiveDependencies");API.recursiveDependencies=Ct;'
-    ]
 ]
 
 load("//:build/pyodide_bucket.bzl", "PYODIDE_PACKAGE_BUCKET_URL")

--- a/src/pyodide/internal/jaeger.js
+++ b/src/pyodide/internal/jaeger.js
@@ -1,0 +1,13 @@
+import { default as internalJaeger } from "pyodide-internal:internalJaeger";
+
+/**
+ * Used for tracing via Jaeger.
+ */
+export function enterJaegerSpan(span, callback) {
+  if (!internalJaeger.traceId) {
+    // Jaeger tracing not enabled or traceId is not present in request.
+    return callback();
+  }
+
+  return internalJaeger.enterSpan(span, callback);
+}

--- a/src/pyodide/internal/metadata.js
+++ b/src/pyodide/internal/metadata.js
@@ -1,0 +1,9 @@
+import { default as MetadataReader } from "pyodide-internal:runtime-generated/metadata";
+export { default as LOCKFILE } from "pyodide-internal:generated/pyodide-lock.json";
+import { default as PYODIDE_BUCKET } from "pyodide-internal:generated/pyodide-bucket.json";
+
+export const IS_WORKERD = MetadataReader.isWorkerd();
+export const IS_TRACING = MetadataReader.isTracing();
+export const WORKERD_INDEX_URL = PYODIDE_BUCKET.PYODIDE_PACKAGE_BUCKET_URL;
+export const REQUIREMENTS = MetadataReader.getRequirements();
+export const MAIN_MODULE_NAME = MetadataReader.getMainModule();

--- a/src/pyodide/internal/process_script_imports.py
+++ b/src/pyodide/internal/process_script_imports.py
@@ -1,0 +1,37 @@
+def _do_it():
+    import ast
+    from pathlib import Path
+
+    def find_imports(source: str) -> list[str]:
+        try:
+            mod = ast.parse(source)
+        except SyntaxError:
+            return []
+        imports = set()
+        for node in ast.walk(mod):
+            if isinstance(node, ast.Import):
+                for name in node.names:
+                    imports.add(name.name)
+            elif isinstance(node, ast.ImportFrom):
+                module_name = node.module
+                if module_name is None:
+                    continue
+                imports.add(module_name)
+        return list(sorted(imports))
+
+    def process_script(script):
+        for mod in find_imports(script):
+            try:
+                __import__(mod)
+            except ImportError:
+                pass
+
+    def process_scripts():
+        for script in Path("/session/metadata").glob("**/*.py"):
+            process_script(script.read_text())
+
+    process_scripts()
+
+
+_do_it()
+del _do_it

--- a/src/pyodide/internal/setupPackages.js
+++ b/src/pyodide/internal/setupPackages.js
@@ -1,0 +1,135 @@
+import { parseTarInfo } from "pyodide-internal:tar";
+import { createTarFS } from "pyodide-internal:tarfs";
+import { createMetadataFS } from "pyodide-internal:metadatafs";
+import { default as LOCKFILE } from "pyodide-internal:generated/pyodide-lock.json";
+import { IS_WORKERD, REQUIREMENTS } from "pyodide-internal:metadata";
+
+const canonicalizeNameRegex = /[-_.]+/g;
+
+/**
+ * Canonicalize a package name. Port of Python's packaging.utils.canonicalize_name.
+ * @param name The package name to canonicalize.
+ * @returns The canonicalize package name.
+ * @private
+ */
+export function canonicalizePackageName(name) {
+  return name.replace(canonicalizeNameRegex, "-").toLowerCase();
+}
+
+// The "name" field in the lockfile is not canonicalized
+const STDLIB_PACKAGES = Object.values(LOCKFILE.packages)
+  .filter(({ install_dir }) => install_dir === "stdlib")
+  .map(({ name }) => canonicalizePackageName(name));
+
+export function buildSitePackages(requirements) {
+  const [origTarInfo, _] = parseTarInfo();
+  if (IS_WORKERD) {
+    return origTarInfo;
+  }
+  const newTarInfo = {
+    children: new Map(),
+    mode: 0o777,
+    type: 5,
+    modtime: 0,
+    size: 0,
+    path: "",
+    name: "",
+    parts: [],
+  };
+
+  for (const req of new Set([...STDLIB_PACKAGES, ...requirements])) {
+    const child = origTarInfo.children.get(req);
+    if (!child) {
+      throw new Error(`Requirement ${req} not found in pyodide packages tar`);
+    }
+    child.children.forEach((val, key) => {
+      if (newTarInfo.children.has(key)) {
+        throw new Error(
+          `File/folder ${key} being written by multiple packages`,
+        );
+      }
+      newTarInfo.children.set(key, val);
+    });
+  }
+
+  return newTarInfo;
+}
+
+/**
+ * Patch loadPackage:
+ *  - in workerd, disable integrity checks
+ *  - otherwise, disable it entirely
+ */
+export function patchLoadPackage(pyodide) {
+  if (!IS_WORKERD) {
+    pyodide.loadPackage = disabledLoadPackage;
+    return;
+  }
+  const origLoadPackage = pyodide.loadPackage;
+  function loadPackage(packages, options) {
+    return origLoadPackage(packages, {
+      checkIntegrity: false,
+      ...options,
+    });
+  }
+  pyodide.loadPackage = loadPackage;
+}
+
+function disabledLoadPackage() {
+  throw new Error("We only use loadPackage in workerd");
+}
+
+export function getTransitiveRequirements() {
+  const requirements = REQUIREMENTS.map(canonicalizePackageName);
+  // resolve transitive dependencies of requirements and if IN_WORKERD install them from the cdn.
+  const packageDatas = recursiveDependencies(LOCKFILE, requirements);
+  return new Set(packageDatas.map(({ name }) => canonicalizePackageName(name)));
+}
+
+export function mountLib(pyodide, info) {
+  const tarFS = createTarFS(pyodide._module);
+  const mdFS = createMetadataFS(pyodide._module);
+  const pymajor = pyodide._module._py_version_major();
+  const pyminor = pyodide._module._py_version_minor();
+  const site_packages = `/session/lib/python${pymajor}.${pyminor}/site-packages`;
+  pyodide.FS.mkdirTree(site_packages);
+  pyodide.FS.mkdirTree("/session/metadata");
+  pyodide.FS.mount(tarFS, { info }, site_packages);
+  pyodide.FS.mount(mdFS, {}, "/session/metadata");
+  const sys = pyodide.pyimport("sys");
+  sys.path.push(site_packages);
+  sys.path.push("/session/metadata");
+  sys.destroy();
+}
+
+export function recursiveDependencies(lockfile, names) {
+  const toLoad = new Map();
+  for (const name of names) {
+    addPackageToLoad(lockfile, name, toLoad);
+  }
+  return Array.from(toLoad.values());
+}
+
+/**
+ * Recursively add a package and its dependencies to toLoad.
+ * A helper function for recursiveDependencies.
+ * @param name The package to add
+ * @param toLoad The set of names of packages to load
+ * @private
+ */
+function addPackageToLoad(lockfile, name, toLoad) {
+  const normalizedName = canonicalizePackageName(name);
+  if (toLoad.has(normalizedName)) {
+    return;
+  }
+  const pkgInfo = lockfile.packages[normalizedName];
+  if (!pkgInfo) {
+    throw new Error(`No known package with name '${name}'`);
+  }
+
+  toLoad.set(normalizedName, pkgInfo);
+
+  for (let depName of pkgInfo.depends) {
+    addPackageToLoad(lockfile, depName, toLoad);
+  }
+}

--- a/src/pyodide/internal/setupPackages.js
+++ b/src/pyodide/internal/setupPackages.js
@@ -2,7 +2,7 @@ import { parseTarInfo } from "pyodide-internal:tar";
 import { createTarFS } from "pyodide-internal:tarfs";
 import { createMetadataFS } from "pyodide-internal:metadatafs";
 import { default as LOCKFILE } from "pyodide-internal:generated/pyodide-lock.json";
-import { IS_WORKERD, REQUIREMENTS } from "pyodide-internal:metadata";
+import { REQUIREMENTS } from "pyodide-internal:metadata";
 
 const canonicalizeNameRegex = /[-_.]+/g;
 
@@ -12,7 +12,7 @@ const canonicalizeNameRegex = /[-_.]+/g;
  * @returns The canonicalize package name.
  * @private
  */
-export function canonicalizePackageName(name) {
+function canonicalizePackageName(name) {
   return name.replace(canonicalizeNameRegex, "-").toLowerCase();
 }
 
@@ -21,10 +21,33 @@ const STDLIB_PACKAGES = Object.values(LOCKFILE.packages)
   .filter(({ install_dir }) => install_dir === "stdlib")
   .map(({ name }) => canonicalizePackageName(name));
 
+/**
+ * This stitches together the view of the site packages directory. Each
+ * requirement corresponds to a folder in the original tar file. For each
+ * requirement in the list we grab the corresponding folder and stitch them
+ * together into a combined folder.
+ *
+ * This also returns the list of soFiles in the resulting site-packages
+ * directory so we can preload them.
+ */
 export function buildSitePackages(requirements) {
-  const [origTarInfo, _] = parseTarInfo();
-  if (IS_WORKERD) {
-    return origTarInfo;
+  const [origTarInfo, origSoFiles] = parseTarInfo();
+  // We'd like to set USE_LOAD_PACKAGE = IS_WORKERD but we also build a funny
+  // workerd with the downstream package set. We can distinguish between them by
+  // looking at the contents. This uses the fact that the downstream set is
+  // larger, but there are a lot of differences...
+  const USE_LOAD_PACKAGE = origTarInfo.children.size < 10;
+  if (USE_LOAD_PACKAGE) {
+    return [origTarInfo, [], USE_LOAD_PACKAGE];
+  }
+  requirements = new Set([...STDLIB_PACKAGES, ...requirements]);
+  const soFiles = [];
+  for (const soFile of origSoFiles) {
+    // If folder is in list of requirements include .so file in list to preload.
+    const [pkg, ...rest] = soFile.split("/");
+    if (requirements.has(pkg)) {
+      soFiles.push(rest);
+    }
   }
   const newTarInfo = {
     children: new Map(),
@@ -37,7 +60,7 @@ export function buildSitePackages(requirements) {
     parts: [],
   };
 
-  for (const req of new Set([...STDLIB_PACKAGES, ...requirements])) {
+  for (const req of requirements) {
     const child = origTarInfo.children.get(req);
     if (!child) {
       throw new Error(`Requirement ${req} not found in pyodide packages tar`);
@@ -52,16 +75,18 @@ export function buildSitePackages(requirements) {
     });
   }
 
-  return newTarInfo;
+  return [newTarInfo, soFiles, USE_LOAD_PACKAGE];
 }
 
 /**
  * Patch loadPackage:
  *  - in workerd, disable integrity checks
  *  - otherwise, disable it entirely
+ *
+ * TODO: stop using loadPackage in workerd.
  */
 export function patchLoadPackage(pyodide) {
-  if (!IS_WORKERD) {
+  if (!USE_LOAD_PACKAGE) {
     pyodide.loadPackage = disabledLoadPackage;
     return;
   }
@@ -79,30 +104,53 @@ function disabledLoadPackage() {
   throw new Error("We only use loadPackage in workerd");
 }
 
-export function getTransitiveRequirements() {
+/**
+ * Get the set of transitive requirements from the REQUIREMENTS metadata.
+ */
+function getTransitiveRequirements() {
   const requirements = REQUIREMENTS.map(canonicalizePackageName);
   // resolve transitive dependencies of requirements and if IN_WORKERD install them from the cdn.
   const packageDatas = recursiveDependencies(LOCKFILE, requirements);
   return new Set(packageDatas.map(({ name }) => canonicalizePackageName(name)));
 }
 
-export function mountLib(pyodide, info) {
-  const tarFS = createTarFS(pyodide._module);
-  const mdFS = createMetadataFS(pyodide._module);
-  const pymajor = pyodide._module._py_version_major();
-  const pyminor = pyodide._module._py_version_minor();
-  const site_packages = `/session/lib/python${pymajor}.${pyminor}/site-packages`;
-  pyodide.FS.mkdirTree(site_packages);
-  pyodide.FS.mkdirTree("/session/metadata");
-  pyodide.FS.mount(tarFS, { info }, site_packages);
-  pyodide.FS.mount(mdFS, {}, "/session/metadata");
-  const sys = pyodide.pyimport("sys");
-  sys.path.push(site_packages);
-  sys.path.push("/session/metadata");
-  sys.destroy();
+export function getSitePackagesPath(Module) {
+  const pymajor = Module._py_version_major();
+  const pyminor = Module._py_version_minor();
+  return `/session/lib/python${pymajor}.${pyminor}/site-packages`;
 }
 
-export function recursiveDependencies(lockfile, names) {
+/**
+ * This mounts the tarFS (which contains the packages) and metadataFS (which
+ * contains user code).
+ *
+ * This has to work before the runtime is initialized because of memory snapshot
+ * details, so even though we want these directories to be on sys.path, we
+ * handle that separately in adjustSysPath.
+ */
+export function mountLib(Module, info) {
+  const tarFS = createTarFS(Module);
+  const mdFS = createMetadataFS(Module);
+  const site_packages = getSitePackagesPath(Module);
+  Module.FS.mkdirTree(site_packages);
+  Module.FS.mkdirTree("/session/metadata");
+  Module.FS.mount(tarFS, { info }, site_packages);
+  Module.FS.mount(mdFS, {}, "/session/metadata");
+}
+
+/**
+ * Add the directories created by mountLib to sys.path.
+ * Has to run after the runtime is initialized.
+ */
+export function adjustSysPath(Module, simpleRunPython) {
+  const site_packages = getSitePackagesPath(Module);
+  simpleRunPython(
+    Module,
+    `import sys; sys.path.append("/session/metadata"); sys.path.append("${site_packages}"); del sys`,
+  );
+}
+
+function recursiveDependencies(lockfile, names) {
   const toLoad = new Map();
   for (const name of names) {
     addPackageToLoad(lockfile, name, toLoad);
@@ -133,3 +181,9 @@ function addPackageToLoad(lockfile, name, toLoad) {
     addPackageToLoad(lockfile, depName, toLoad);
   }
 }
+
+export { REQUIREMENTS };
+export const TRANSITIVE_REQUIREMENTS = getTransitiveRequirements();
+export const [SITE_PACKAGES_INFO, SITE_PACKAGES_SO_FILES, USE_LOAD_PACKAGE] = buildSitePackages(
+  TRANSITIVE_REQUIREMENTS,
+);

--- a/src/pyodide/python-entrypoint-helper.js
+++ b/src/pyodide/python-entrypoint-helper.js
@@ -1,20 +1,41 @@
 // This file is a BUILTIN module that provides the actual implementation for the
 // python-entrypoint.js USER module.
 
+import { loadPyodide, uploadArtifacts } from "pyodide-internal:python";
+import { enterJaegerSpan } from "pyodide-internal:jaeger";
 import {
-  loadPyodide,
+  buildSitePackages,
+  getTransitiveRequirements,
   mountLib,
-  canonicalizePackageName,
-  enterJaegerSpan,
-  uploadArtifacts,
-} from "pyodide-internal:python";
-import { default as LOCKFILE } from "pyodide-internal:generated/pyodide-lock.json";
-import { default as MetadataReader } from "pyodide-internal:runtime-generated/metadata";
-import { default as PYODIDE_BUCKET } from "pyodide-internal:generated/pyodide-bucket.json";
+  patchLoadPackage,
+} from "pyodide-internal:setupPackages";
+import {
+  IS_TRACING,
+  IS_WORKERD,
+  LOCKFILE,
+  MAIN_MODULE_NAME,
+  REQUIREMENTS,
+  WORKERD_INDEX_URL,
+} from "pyodide-internal:metadata";
 
-const IS_WORKERD = MetadataReader.isWorkerd();
-const IS_TRACING = MetadataReader.isTracing();
-const WORKERD_INDEX_URL = PYODIDE_BUCKET.PYODIDE_PACKAGE_BUCKET_URL;
+function pyimportMainModule(pyodide) {
+  if (!MAIN_MODULE_NAME.endsWith(".py")) {
+    throw new Error("Main module needs to end with a .py file extension");
+  }
+  const mainModuleName = MAIN_MODULE_NAME.slice(0, -3);
+  return pyodide.pyimport(mainModuleName);
+}
+
+let pyodidePromise;
+function getPyodide() {
+  return enterJaegerSpan("get_pyodide", () => {
+    if (pyodidePromise) {
+      return pyodidePromise;
+    }
+    pyodidePromise = loadPyodide(LOCKFILE, WORKERD_INDEX_URL);
+    return pyodidePromise;
+  });
+}
 
 /**
  * Import the data from the data module es6 import called jsModName.py into a module called
@@ -45,57 +66,25 @@ async function applyPatch(pyodide, patchName) {
 }
 
 /**
- * Patch loadPackage:
- *  - in workerd, disable integrity checks
- *  - otherwise, disable it entirely
+ * Set up Python packages:
+ *  - patch loadPackage to ignore integrity
+ *  - get requirements
+ *  - Use tar file + requirements to mount site packages directory
+ *  - if in workerd use loadPackage to load packages
+ *  - install patches to make various requests packages work
+ *
+ * TODO: move this into setupPackages.js. Can't now because the patch imports
+ * fail from there for some reason.
  */
-function patchLoadPackage(pyodide) {
-  if (!IS_WORKERD) {
-    pyodide.loadPackage = disabledLoadPackage;
-    return;
-  }
-  const origLoadPackage = pyodide.loadPackage;
-  function loadPackage(packages, options) {
-    return origLoadPackage(packages, {
-      checkIntegrity: false,
-      ...options,
-    });
-  }
-  pyodide.loadPackage = loadPackage;
-}
-
-function disabledLoadPackage() {
-  throw new Error("We only use loadPackage in workerd");
-}
-
-async function getTransitiveRequirements(pyodide, requirements) {
-  // resolve transitive dependencies of requirements and if IN_WORKERD install them from the cdn.
-  let packageDatas;
-  if (IS_WORKERD) {
-    packageDatas = await pyodide.loadPackage(requirements);
-  } else {
-    // TODO: if not IS_WORKERD, use packageDatas to control package visibility.
-    packageDatas = pyodide._api
-      .recursiveDependencies(requirements)
-      .values()
-      .map(({ packageData }) => packageData);
-  }
-  return new Set(packageDatas.map(({ name }) => name));
-}
-
-async function setupPackages(pyodide) {
+export async function setupPackages(pyodide) {
   return await enterJaegerSpan("setup_packages", async () => {
     patchLoadPackage(pyodide);
-    const requirements = MetadataReader.getRequirements().map(
-      canonicalizePackageName,
-    );
-    const transitiveRequirements = new Set(
-      Array.from(await getTransitiveRequirements(pyodide, requirements)).map(
-        canonicalizePackageName,
-      ),
-    );
-
-    mountLib(pyodide, transitiveRequirements, IS_WORKERD);
+    const transitiveRequirements = getTransitiveRequirements();
+    const info = buildSitePackages(transitiveRequirements);
+    mountLib(pyodide, info);
+    if (IS_WORKERD) {
+      await pyodide.loadPackage(REQUIREMENTS);
+    }
 
     // install any extra packages into the site-packages directory, so calculate where that is.
     const pymajor = pyodide._module._py_version_major();
@@ -112,26 +101,6 @@ async function setupPackages(pyodide) {
     if (transitiveRequirements.has("fastapi")) {
       await injectSitePackagesModule(pyodide, "asgi", "asgi");
     }
-  });
-}
-
-function pyimportMainModule(pyodide) {
-  let mainModuleName = MetadataReader.getMainModule();
-  if (!mainModuleName.endsWith(".py")) {
-    throw new Error("Main module needs to end with a .py file extension");
-  }
-  mainModuleName = mainModuleName.slice(0, -3);
-  return pyodide.pyimport(mainModuleName);
-}
-
-let pyodidePromise;
-function getPyodide() {
-  return enterJaegerSpan("get_pyodide", () => {
-    if (pyodidePromise) {
-      return pyodidePromise;
-    }
-    pyodidePromise = loadPyodide(LOCKFILE, WORKERD_INDEX_URL);
-    return pyodidePromise;
   });
 }
 
@@ -189,7 +158,10 @@ async function preparePython() {
 function makeHandler(pyHandlerName) {
   return async function (...args) {
     try {
-      const mainModule = await enterJaegerSpan("prep_python", async () => await preparePython());
+      const mainModule = await enterJaegerSpan(
+        "prep_python",
+        async () => await preparePython(),
+      );
       return await enterJaegerSpan("python_code", () => {
         return mainModule[pyHandlerName].callRelaxed(...args);
       });

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -442,7 +442,7 @@ void WorkerdApi::compileModules(
         using ModuleInfo = jsg::ModuleRegistry::ModuleInfo;
         using ObjectModuleInfo = jsg::ModuleRegistry::ObjectModuleInfo;
         using ResolveMethod = jsg::ModuleRegistry::ResolveMethod;
-        auto specifier = "pyodide-internal:jaeger";
+        auto specifier = "pyodide-internal:internalJaeger";
         modules->addBuiltinModule(
             specifier,
             [specifier = kj::str(specifier)](


### PR DESCRIPTION
This adds dedicated memory snapshots. It's pretty finicky how you load shared
libraries in a memory snapshot since their metadata needs to be allocated in the
same location whether starting from scratch or from the snapshot. The simplest
way to deal with it is to preload the libraries in a given order before the
runtime starts. This approach leaves us without a good way of figuring out which
ones are needed so we take a naive approach and preload all of them.

We then parse the user code into abstract syntax trees and look for import
nodes. We try to import all of these and catch and throw away if it fails.
Then we record which dynamic libraries have been dlopened and where the handles
are located. We put the handle data together with the heap snapshot.

This required pretty major surgery since some information about the packages is
needed much earlier than it was previously available. Some steps like
updating paths are not possible to do on the not-yet-initialized runtime and
have to be separated.

Tested downstream.