### PR TITLE
Prevent queuing writes while internal writable is being piped

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -140,8 +140,17 @@ wd_cc_capnp_library(
         "actor-state-iocontext-test.c++",
         "cf-property-test.c++",
         "node/*-test.c++",
+        "streams/internal-test.c++",
     ],
 )]
+
+kj_test(
+    src = "streams/internal-test.c++",
+    deps = [
+        "//src/workerd/io",
+        "//src/workerd/tests:test-fixture",
+    ],
+)
 
 kj_test(
     src = "actor-state-iocontext-test.c++",

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -227,6 +227,7 @@ public:
   void setHighWaterMark(uint64_t highWaterMark);
 
   bool isClosedOrClosing() override;
+  bool isPiping();
   bool isErrored() override;
 
   inline bool isByteOriented() const override { return true; }


### PR DESCRIPTION
In some uses we end up enqueuing a write event to a `WritableStreamInternalController` while it is being piped to, leading to an assertion given that we expect the `Pipe` event to be the last event in the queue while it is being piped. To match the behavior seen when using the `WritableStreamDefaultWriter`, we should reject attempts to write, close, or flush while the pipe is still going.

Also improves the logging around the assertion that was being hit and fixes another apparent latent bug in the pipe source close check.