### PR TITLE
Remove Cache API PUT limit

### DIFF
--- a/src/workerd/io/limit-enforcer.h
+++ b/src/workerd/io/limit-enforcer.h
@@ -146,9 +146,6 @@ public:
 
   // Report resource usage metrics to the given request metrics object.
   virtual void reportMetrics(RequestObserver& requestMetrics) = 0;
-
-  // Quota for total PUTs to cache in MB, or kj::none for the default.
-  virtual kj::Maybe<uint64_t> getCachePUTLimitMB() = 0;
 };
 
 }  // namespace workerd

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2173,11 +2173,6 @@ private:
   kj::Promise<void> onLimitsExceeded() override { return kj::NEVER_DONE; }
   void requireLimitsNotExceeded() override {}
   void reportMetrics(RequestObserver& requestMetrics) override {}
-
-  // Unlike the other metrics, use the 5GB default limit here. Ideally this limit would be
-  // configurable at runtime for better testing, but in this case going beyond the default limit
-  // should rarely be needed.
-  kj::Maybe<uint64_t> getCachePUTLimitMB() override { return kj::none; }
 };
 
 struct FutureSubrequestChannel {

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -136,7 +136,6 @@ struct MockLimitEnforcer final: public LimitEnforcer {
   kj::Maybe<EventOutcome> getLimitsExceeded() override { return kj::none; }
   kj::Promise<void> onLimitsExceeded() override { return kj::NEVER_DONE; }
   void requireLimitsNotExceeded() override {}
-  kj::Maybe<uint64_t> getCachePUTLimitMB() override { return kj::none; }
   void reportMetrics(RequestObserver& requestMetrics) override {}
 
 };


### PR DESCRIPTION
After further discussions within the team, we will be lifting the limit entirely as limits defined in the Cache backend will be sufficient. This enables significant cleanup, including the limit functions defined in #1772 and the existing cache stream setup.

Also see the corresponding downstream PR.