### PR TITLE
Uses memory snapshot from WorkerBundle for Python.

### DIFF
--- a/src/pyodide/internal/metadata.js
+++ b/src/pyodide/internal/metadata.js
@@ -7,3 +7,4 @@ export const IS_TRACING = MetadataReader.isTracing();
 export const WORKERD_INDEX_URL = PYODIDE_BUCKET.PYODIDE_PACKAGE_BUCKET_URL;
 export const REQUIREMENTS = MetadataReader.getRequirements();
 export const MAIN_MODULE_NAME = MetadataReader.getMainModule();
+export const BUNDLE_MEMORY_SNAPSHOT = MetadataReader.getMemorySnapshot();

--- a/src/pyodide/internal/python.js
+++ b/src/pyodide/internal/python.js
@@ -10,6 +10,7 @@ import {
 } from "pyodide-internal:setupPackages";
 import { default as TarReader } from "pyodide-internal:packages_tar_reader";
 import processScriptImports from "pyodide-internal:process_script_imports.py";
+import { BUNDLE_MEMORY_SNAPSHOT } from "pyodide-internal:metadata";
 
 /**
  * This file is a simplified version of the Pyodide loader:
@@ -491,7 +492,7 @@ function simpleRunPython(emscriptenModule, code) {
 let TEST_SNAPSHOT = undefined;
 (function () {
   // Lookup memory snapshot from artifact store.
-  const memorySnapshot = ArtifactBundler.getMemorySnapshot();
+  const memorySnapshot = BUNDLE_MEMORY_SNAPSHOT || ArtifactBundler.getMemorySnapshot();
   if (!memorySnapshot) {
     // snapshots are disabled or there isn't one yet
     return;

--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -105,7 +105,7 @@ jsg::Ref<PyodideMetadataReader> makePyodideMetadataReader(Worker::Reader conf) {
   }
   return jsg::alloc<PyodideMetadataReader>(kj::mv(mainModule), names.finish(), contents.finish(),
                                            requirements.finish(), true /* isWorkerd */,
-                                           false /* isTracing */);
+                                           false /* isTracing */, kj::none /* memorySnapshot */);
 }
 
 } // namespace workerd::api::pyodide

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -33,13 +33,16 @@ private:
   kj::Array<kj::String> requirements;
   bool isWorkerdFlag;
   bool isTracingFlag;
+  kj::Maybe<kj::Array<kj::byte>> memorySnapshot;
 
 public:
   PyodideMetadataReader(kj::String mainModule, kj::Array<kj::String> names,
                         kj::Array<kj::Array<kj::byte>> contents, kj::Array<kj::String> requirements,
-                        bool isWorkerd, bool isTracing)
+                        bool isWorkerd, bool isTracing,
+                        kj::Maybe<kj::Array<kj::byte>> memorySnapshot)
       : mainModule(kj::mv(mainModule)), names(kj::mv(names)), contents(kj::mv(contents)),
-        requirements(kj::mv(requirements)), isWorkerdFlag(isWorkerd), isTracingFlag(isTracing) {}
+        requirements(kj::mv(requirements)), isWorkerdFlag(isWorkerd), isTracingFlag(isTracing),
+        memorySnapshot(kj::mv(memorySnapshot)) {}
 
   bool isWorkerd() {
     return this->isWorkerdFlag;
@@ -51,6 +54,10 @@ public:
 
   kj::String getMainModule() {
     return kj::str(this->mainModule);
+  }
+
+  kj::Maybe<kj::Array<kj::byte>> getMemorySnapshot() {
+    return kj::mv(memorySnapshot);
   }
 
   kj::Array<jsg::JsRef<jsg::JsString>> getNames(jsg::Lock& js);
@@ -69,6 +76,7 @@ public:
     JSG_METHOD(getNames);
     JSG_METHOD(getSizes);
     JSG_METHOD(read);
+    JSG_METHOD(getMemorySnapshot);
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {


### PR DESCRIPTION
Implements functionality to grab the memory snapshot from the WorkerBundle (without disabling grabbing it from the ArtifactStorage, though WorkerBundle snapshot is prioritised).