### PR TITLE
Python perf: Don't report undefined symbols

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -121,9 +121,9 @@ http_archive(
 http_archive(
     name = "pyodide_packages",
     build_file = "//:build/BUILD.pyodide_packages",
-    sha256 = "f9aa1e044567f1f3e36c3516d066481093dbc116032c45294eee400628d8b4a2",
+    sha256 = "c4a4e0c1cb658a39abc0435cc07df902e5a2ecffc091e0528b96b0c295e309ea",
     type = "zip",
-    urls = ["https://github.com/dom96/pyodide_packages/releases/download/just-micropip/pyodide_packages.tar.zip"],
+    urls = ["https://github.com/dom96/pyodide_packages/releases/download/just-stdlib/pyodide_packages.tar.zip"],
 )
 
 load("//:build/pyodide_bucket.bzl", "PYODIDE_LOCK_SHA256", "PYODIDE_GITHUB_RELEASE_URL")

--- a/src/pyodide/BUILD.bazel
+++ b/src/pyodide/BUILD.bazel
@@ -89,6 +89,8 @@ import { newWasmModule, monotonicDateNow, wasmInstantiate, getRandomValues } fro
 const location = undefined;
 
 function addEventListener(){}
+
+function reportUndefinedSymbolsNoOp() {}
 """
 
 REPLACEMENTS = [
@@ -119,6 +121,10 @@ REPLACEMENTS = [
         "crypto.getRandomValues",
         "getRandomValues"
     ],
+    [
+        "reportUndefinedSymbols()",
+        "reportUndefinedSymbolsNoOp()"
+    ]
 ]
 
 load("//:build/pyodide_bucket.bzl", "PYODIDE_PACKAGE_BUCKET_URL")

--- a/src/pyodide/internal/setupPackages.js
+++ b/src/pyodide/internal/setupPackages.js
@@ -21,6 +21,7 @@ const STDLIB_PACKAGES = Object.values(LOCKFILE.packages)
   .filter(({ install_dir }) => install_dir === "stdlib")
   .map(({ name }) => canonicalizePackageName(name));
 
+
 /**
  * This stitches together the view of the site packages directory. Each
  * requirement corresponds to a folder in the original tar file. For each
@@ -38,9 +39,10 @@ export function buildSitePackages(requirements) {
   // larger, but there are a lot of differences...
   const USE_LOAD_PACKAGE = origTarInfo.children.size < 10;
   if (USE_LOAD_PACKAGE) {
-    return [origTarInfo, [], USE_LOAD_PACKAGE];
+    requirements = new Set([...STDLIB_PACKAGES]);
+  } else {
+    requirements = new Set([...STDLIB_PACKAGES, ...requirements]);
   }
-  requirements = new Set([...STDLIB_PACKAGES, ...requirements]);
   const soFiles = [];
   for (const soFile of origSoFiles) {
     // If folder is in list of requirements include .so file in list to preload.


### PR DESCRIPTION
In flame graphs this single call frame takes up a lot of loading time. It also is not necessary except for debugging purposes. This gets rid of it.