### PR TITLE
MQ-576: Add attempts to QueueMessage

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -2287,12 +2287,14 @@ jsg::Promise<Fetcher::QueueResult> Fetcher::queue(
           .id=kj::mv(msg.id),
           .timestamp=msg.timestamp,
           .body=serializer.release().data,
+          .attempts=msg.attempts
       });
     } else KJ_IF_SOME(b, msg.serializedBody) {
       encodedMessages.add(IncomingQueueMessage{
           .id=kj::mv(msg.id),
           .timestamp=msg.timestamp,
           .body=kj::mv(b),
+          .attempts=msg.attempts
       });
     } else {
       JSG_FAIL_REQUIRE(TypeError, "Expected one of body or serializedBody for each message");

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -525,11 +525,13 @@ public:
     kj::Date timestamp;
     jsg::Optional<jsg::Value> body;
     jsg::Optional<kj::Array<kj::byte>> serializedBody;
+    uint16_t attempts;
 
-    JSG_STRUCT(id, timestamp, body, serializedBody);
+    JSG_STRUCT(id, timestamp, body, serializedBody, attempts);
     JSG_STRUCT_TS_OVERRIDE(type ServiceBindingQueueMessage<Body = unknown> = {
       id: string;
       timestamp: Date;
+      attempts: number;
     } & (
       | { body: Body }
       | { serializedBody: ArrayBuffer | ArrayBufferView }

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -359,6 +359,7 @@ QueueMessage::QueueMessage(jsg::Lock& js,
     : id(kj::str(message.getId())),
       timestamp(message.getTimestampNs() * kj::NANOSECONDS + kj::UNIX_EPOCH),
       body(deserialize(js, message).addRef(js)),
+      attempts(message.getAttempts()),
       result(result) {}
 // Note that we must make deep copies of all data here since the incoming Reader may be
 // deallocated while JS's GC wrappers still exist.
@@ -368,6 +369,7 @@ QueueMessage::QueueMessage(
     : id(kj::mv(message.id)),
       timestamp(message.timestamp),
       body(deserialize(js, kj::mv(message.body), message.contentType).addRef(js)),
+      attempts(message.attempts),
       result(result) {}
 
 jsg::JsValue QueueMessage::getBody(jsg::Lock& js) {
@@ -626,6 +628,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEventImpl::sendRpc(
         KJ_IF_SOME(contentType, p.messages[i].contentType) {
           messages[i].setContentType(contentType);
         }
+        messages[i].setAttempts(p.messages[i].attempts);
       }
     }
   }

--- a/src/workerd/api/queue.h
+++ b/src/workerd/api/queue.h
@@ -98,7 +98,8 @@ struct IncomingQueueMessage {
   kj::Date timestamp;
   kj::Array<kj::byte> body;
   kj::Maybe<kj::String> contentType;
-  JSG_STRUCT(id, timestamp, body, contentType);
+  uint16_t attempts;
+  JSG_STRUCT(id, timestamp, body, contentType, attempts);
 
   struct ContentType {
     static constexpr kj::StringPtr TEXT = "text"_kj;
@@ -158,6 +159,7 @@ public:
   kj::StringPtr getId() { return id; }
   kj::Date getTimestamp() { return timestamp; }
   jsg::JsValue getBody(jsg::Lock& js);
+  uint16_t getAttempts() { return attempts; };
 
   void retry(jsg::Optional<QueueRetryOptions> options);
   void ack();
@@ -168,6 +170,7 @@ public:
     JSG_READONLY_INSTANCE_PROPERTY(id, getId);
     JSG_READONLY_INSTANCE_PROPERTY(timestamp, getTimestamp);
     JSG_READONLY_INSTANCE_PROPERTY(body, getBody);
+    JSG_READONLY_INSTANCE_PROPERTY(attempts, getAttempts);
     JSG_METHOD(retry);
     JSG_METHOD(ack);
 
@@ -186,6 +189,7 @@ private:
   kj::String id;
   kj::Date timestamp;
   jsg::JsRef<jsg::JsValue> body;
+  uint16_t attempts;
   IoPtr<QueueEventResult> result;
 
   void visitForGc(jsg::GcVisitor& visitor) {

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -146,6 +146,7 @@ struct QueueMessage @0x944adb18c0352295 {
   timestampNs @1 :Int64;
   data @2 :Data;
   contentType @3 :Text;
+  attempts @4 :UInt16;
 }
 
 struct QueueRetryBatch {

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -1422,8 +1422,8 @@ KJ_TEST("Server: call queue handler on service binding") {
                 `export default {
                 `  async fetch(request, env) {
                 `    let result = await env.service2.queue("queueName1", [
-                `        {id: "1", timestamp: 12345, body: "my message"},
-                `        {id: "msg2", timestamp: 23456, body: 22},
+                `        {id: "1", timestamp: 12345, body: "my message", attempts: 1},
+                `        {id: "msg2", timestamp: 23456, body: 22, attempts: 2},
                 `    ]);
                 `    return new Response(`queue outcome: ${result.outcome}, ackAll: ${result.ackAll}`);
                 `  }
@@ -1449,9 +1449,11 @@ KJ_TEST("Server: call queue handler on service binding") {
                 `        event.messages[0].id == "1" &&
                 `        event.messages[0].timestamp.getTime() == 12345 &&
                 `        event.messages[0].body == "my message" &&
+                `        event.messages[0].attempts == 1 &&
                 `        event.messages[1].id == "msg2" &&
                 `        event.messages[1].timestamp.getTime() == 23456 &&
-                `        event.messages[1].body == 22) {
+                `        event.messages[1].body == 22 &&
+                `        event.messages[1].attempts == 2) {
                 `      event.ackAll();
                 `      return;
                 `    }


### PR DESCRIPTION
This patch updates the queue message capnp schema so that the number of attempts is included within each message, allowing queue consumers to implement backoff logic based on that. Note this is a breaking change and we are making sure that all clients are updated accordingly before this change gets released.