### PR TITLE
Make DOMException serializable/cloneable

### DIFF
--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -1226,3 +1226,22 @@ export let logging = {
     assert.strictEqual(await stub.increment(1), 3);
   }
 }
+
+// DOMException is structured cloneable
+export let domExceptionClone = {
+  test() {
+    const de1 = new DOMException("hello", "NotAllowedError");
+
+    // custom own properties on the instance are not preserved...
+    de1.foo = "ignored";
+
+    const de2 = structuredClone(de1);
+    assert.strictEqual(de1.name, de2.name);
+    assert.strictEqual(de1.message, de2.message);
+    assert.strictEqual(de1.stack, de2.stack);
+    assert.strictEqual(de1.code, de2.code);
+    assert.notStrictEqual(de1, de2);
+    assert.notStrictEqual(de1.foo, de2.foo);
+    assert.strictEqual(de2.foo, undefined);
+  }
+}

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -225,6 +225,11 @@ enum SerializationTag {
   headers @4;
   request @5;
   response @6;
+
+  domException @7;
+  # Keep this value in sync with the DOMException::SERIALIZATION_TAG in
+  # /src/workerd/jsg/dom-exception (but we can't actually change this value
+  # without breaking things).
 }
 
 enum StreamEncoding {

--- a/src/workerd/jsg/dom-exception.h
+++ b/src/workerd/jsg/dom-exception.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "jsg.h"
+#include "ser.h"
 
 #define JSG_DOM_EXCEPTION_FOR_EACH_ERROR_NAME(f) \
     f(INDEX_SIZE_ERR, 1, "IndexSizeError") \
@@ -111,6 +112,17 @@ public:
     tracker.trackField("name", name);
     tracker.trackField("errorForStack", errorForStack);
   }
+
+  // TODO(cleanup): The value is taken from worker-interface.capnp, which we can't
+  // depend on directly here because we cannot introduce the dependency into JSG.
+  // Therefore we have to set it manually. A better solution long term is to actually
+  // move DOMException into workerd/api, but we'll do that separately.
+  static const uint SERIALIZATION_TAG = 7;
+  JSG_SERIALIZABLE(SERIALIZATION_TAG);
+
+  void serialize(jsg::Lock& js, jsg::Serializer& serializer);
+  static jsg::Ref<DOMException> deserialize(
+      jsg::Lock& js, uint tag, jsg::Deserializer& deserializer);
 
 private:
   kj::String message;


### PR DESCRIPTION
Makes DOMException cloneable for use with jsrpc and `structuredClone()`