### PR TITLE
JSRPC: Ensure logging `RpcStub`s doesn't dispose them (skip getting `entries()` for RPC types)

### DIFF
--- a/src/node/internal/workers.d.ts
+++ b/src/node/internal/workers.d.ts
@@ -1,0 +1,9 @@
+declare namespace _default {
+  class WorkerEntrypoint {}
+  class DurableObject {}
+  class RpcPromise {}
+  class RpcProperty {}
+  class RpcStub {}
+  class RpcTarget {}
+}
+export default _default;

--- a/src/node/tsconfig.json
+++ b/src/node/tsconfig.json
@@ -29,7 +29,8 @@
       "node:*": ["./*"],
       "node:stream/*": ["./*"],
       "node-internal:*": ["./internal/*"],
-      "workerd:compatibility-flags": ["./internal/compatibility-flags.d.ts"]
+      "cloudflare-internal:workers": ["./internal/workers.d.ts"],
+      "workerd:compatibility-flags": ["./internal/compatibility-flags.d.ts"],
     }
   },
   "include": [

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -873,17 +873,17 @@ export let serializeRpcPromiseOrProprety = {
     // NOTE: We could choose to make this work later.
     await assert.rejects(() => env.MyService.getNestedRpcPromise(func), {
       name: "DataCloneError",
-      message: 'Could not serialize object of type "JsRpcPromise". This type does not support ' +
+      message: 'Could not serialize object of type "RpcPromise". This type does not support ' +
                'serialization.'
     });
     await assert.rejects(() => env.MyService.getNestedRpcPromise(func).value, {
       name: "DataCloneError",
-      message: 'Could not serialize object of type "JsRpcPromise". This type does not support ' +
+      message: 'Could not serialize object of type "RpcPromise". This type does not support ' +
                'serialization.'
     });
     await assert.rejects(() => env.MyService.getNestedRpcPromise(func).value.x, {
       name: "DataCloneError",
-      message: 'Could not serialize object of type "JsRpcPromise". This type does not support ' +
+      message: 'Could not serialize object of type "RpcPromise". This type does not support ' +
                'serialization.'
     });
 
@@ -903,17 +903,17 @@ export let serializeRpcPromiseOrProprety = {
     assert.strictEqual(await env.MyService.getRpcProperty(func).x, 456)
     await assert.rejects(() => env.MyService.getNestedRpcProperty(func), {
       name: "DataCloneError",
-      message: 'Could not serialize object of type "JsRpcProperty". This type does not support ' +
+      message: 'Could not serialize object of type "RpcProperty". This type does not support ' +
                'serialization.'
     });
     await assert.rejects(() => env.MyService.getNestedRpcProperty(func).value, {
       name: "DataCloneError",
-      message: 'Could not serialize object of type "JsRpcProperty". This type does not support ' +
+      message: 'Could not serialize object of type "RpcProperty". This type does not support ' +
                'serialization.'
     });
     await assert.rejects(() => env.MyService.getNestedRpcProperty(func).value.x, {
       name: "DataCloneError",
-      message: 'Could not serialize object of type "JsRpcProperty". This type does not support ' +
+      message: 'Could not serialize object of type "RpcProperty". This type does not support ' +
                'serialization.'
     });
 
@@ -1171,5 +1171,17 @@ export let canUseGetPutDelete = {
     assert.strictEqual(await env.MyService.get(12), 13);
     assert.strictEqual(await env.MyService.put(5, 7), 12);
     assert.strictEqual(await env.MyService.delete(3), 2);
+  }
+}
+
+// Test that stubs can still be used after logging them.
+export let logging = {
+  async test(controller, env, ctx) {
+    let counter = new MyCounter(0);
+    let stub = new RpcStub(counter);
+    assert.strictEqual(await stub.increment(1), 1);
+    assert.strictEqual(await stub.increment(1), 2);
+    console.log(stub);
+    assert.strictEqual(await stub.increment(1), 3);
   }
 }

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -479,6 +479,8 @@ public:
   JSG_RESOURCE_TYPE(EntrypointsModule) {
     JSG_NESTED_TYPE(WorkerEntrypoint);
     JSG_NESTED_TYPE_NAMED(DurableObjectBase, DurableObject);
+    JSG_NESTED_TYPE_NAMED(JsRpcPromise, RpcPromise);
+    JSG_NESTED_TYPE_NAMED(JsRpcProperty, RpcProperty);
     JSG_NESTED_TYPE_NAMED(JsRpcStub, RpcStub);
     JSG_NESTED_TYPE_NAMED(JsRpcTarget, RpcTarget);
   }


### PR DESCRIPTION
Previously, code like this would fail:

```js
const counter = new Counter();
const stub = new RpcStub(counter);
console.log(await stub.increment()); // 1
console.log(await stub.increment()); // 2
console.log(stub);
console.log(await stub.increment()); // Fails with "Error: RPC stub used after being disposed."
```

The `util.inspect()` function has special handling for JSG resource types. In particular, it tries to call the `entries()` function if it's defined for `Map`-like formatting. Because `RpcStub`s and other JSRPC types define wildcard property handlers, `entries()` existed, but attempting to call it and iterate through the resulting value ended up triggering this line:

https://github.com/cloudflare/workerd/blob/bfcfe9a7b2518a93d6c6d176be2f45d27e7c0913/src/workerd/api/worker-rpc.c%2B%2B#L836

This change ensures we never call `entries()` if a resource type defines a wildcard handler. It's unlikely this will return the expected value here.

The solution defines a well-known symbol on the prototype of types with wildcard handlers, similar to custom inspect properties. Other solutions considered were checking whether something like `"crazyUnguessablePropertyThatNoOneWouldEverAdd" + Math.random()` was defined, or adding a method to check if a value had a defined property handler.