### PR TITLE
fix entrypoiny.svg link for npmjs.com

### DIFF
--- a/npm/workers-types/README.md
+++ b/npm/workers-types/README.md
@@ -27,7 +27,7 @@ The following is a minimal `tsconfig.json` for use alongside this package:
 
 ### Compatibility dates
 
-![Entrypoints for compatibility dates](./entrypoints.svg)
+![Entrypoints for compatibility dates](https://github.com/cloudflare/workerd/blob/main/npm/workers-types/entrypoints.svg)
 
 The Cloudflare Workers runtime manages backwards compatibility through the use of [Compatibility Dates](https://developers.cloudflare.com/workers/platform/compatibility-dates/). Using different compatibility dates affects the runtime types available to your Worker, and so it's important you specify the correct entrypoint to the `workers-types` package to match your compatibility date (which is usually set in your `wrangler.toml` configuration file). `workers-types` currently exposes the following entrypoints to choose from:
 


### PR DESCRIPTION
Pretty minor, but on the npm website the link to the entrypoints.svg file is broken:

[![Screenshot 2024-03-25 at 14 58 18](https://github.com/cloudflare/workerd/assets/61631103/d8b83ae6-f348-4fd2-9eb9-eb270848d884)](https://www.npmjs.com/package/@cloudflare/workers-types)

and I think that to fix it we need to use an absolute URL instead of a relative one like now