### PR TITLE
Clearify dispatch metrics

### DIFF
--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -62,8 +62,8 @@ public:
     return kj::mv(client);
   }
 
-  // Used to record when a worker has a dynamic dispatch binding (Called on the dispatching side)
-  virtual void setHasDispatchBinding() {};
+  // Used to record when a worker has used a dynamic dispatch binding.
+  virtual void setHasDispatched() {};
 
   virtual SpanParent getSpan() { return nullptr; }
 


### PR DESCRIPTION
The metric indicates if a worker has actually dispatched to another, not that it has a dispatch binding.