### PR TITLE
JSRPC: Fill in trace (tail) events better.

### DIFF
--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -555,6 +555,10 @@ export let namedServiceBinding = {
       name: "TypeError",
       message: "\"nonFunctionProperty\" is not a function."
     });
+    await assert.rejects(() => getByName("nonFunctionProperty").foo(), {
+      name: "TypeError",
+      message: "\"nonFunctionProperty.foo\" is not a function."
+    });
 
     // Check that we can't access contents of a property that is a class but not derived from
     // RpcTarget.

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -195,6 +195,7 @@ TraceItem::TraceItem(jsg::Lock& js, const Trace& trace)
       exceptions(getTraceExceptions(trace)),
       diagnosticChannelEvents(getTraceDiagnosticChannelEvents(js, trace)),
       scriptName(trace.scriptName.map([](auto& name) { return kj::str(name); })),
+      entrypoint(trace.entrypoint.map([](auto& name) { return kj::str(name); })),
       scriptVersion(getTraceScriptVersion(trace)),
       dispatchNamespace(trace.dispatchNamespace.map([](auto& ns) { return kj::str(ns); })),
       scriptTags(getTraceScriptTags(trace)),
@@ -237,6 +238,10 @@ kj::ArrayPtr<jsg::Ref<TraceDiagnosticChannelEvent>> TraceItem::getDiagnosticChan
 
 kj::Maybe<kj::StringPtr> TraceItem::getScriptName() {
   return scriptName.map([](auto& name) -> kj::StringPtr { return name; });
+}
+
+jsg::Optional<kj::StringPtr> TraceItem::getEntrypoint() {
+  return entrypoint;
 }
 
 jsg::Optional<ScriptVersion> TraceItem::getScriptVersion() {

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -67,6 +67,7 @@ struct ScriptVersion {
 class TraceItem final: public jsg::Object {
 public:
   class FetchEventInfo;
+  class JsRpcEventInfo;
   class ScheduledEventInfo;
   class AlarmEventInfo;
   class QueueEventInfo;
@@ -78,6 +79,7 @@ public:
   explicit TraceItem(jsg::Lock& js, const Trace& trace);
 
   typedef kj::OneOf<jsg::Ref<FetchEventInfo>,
+                    jsg::Ref<JsRpcEventInfo>,
                     jsg::Ref<ScheduledEventInfo>,
                     jsg::Ref<AlarmEventInfo>,
                     jsg::Ref<QueueEventInfo>,
@@ -238,6 +240,29 @@ public:
 
 private:
   uint16_t status;
+};
+
+class TraceItem::JsRpcEventInfo final: public jsg::Object {
+public:
+  explicit JsRpcEventInfo(const Trace& trace, const Trace::JsRpcEventInfo& eventInfo);
+
+  // We call this `rpcMethod` to make clear this is an RPC event, since some tail workers rely
+  // on duck-typing EventInfo based on the properties present. (`methodName` might be ambiguous
+  // since HTTP also has methods.)
+  //
+  // TODO(someday): Clearly there should be a better way to distinguish event types?
+  kj::StringPtr getRpcMethod();
+
+  JSG_RESOURCE_TYPE(JsRpcEventInfo) {
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(rpcMethod, getRpcMethod);
+  }
+
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackField("rpcMethod", rpcMethod);
+  }
+
+private:
+  kj::String rpcMethod;
 };
 
 class TraceItem::ScheduledEventInfo final: public jsg::Object {
@@ -594,6 +619,7 @@ private:
   api::TraceItem::FetchEventInfo,                                 \
   api::TraceItem::FetchEventInfo::Request,                        \
   api::TraceItem::FetchEventInfo::Response,                       \
+  api::TraceItem::JsRpcEventInfo,                                 \
   api::TraceItem::HibernatableWebSocketEventInfo,                 \
   api::TraceItem::HibernatableWebSocketEventInfo::Message,        \
   api::TraceItem::HibernatableWebSocketEventInfo::Close,          \

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -94,6 +94,7 @@ public:
   kj::ArrayPtr<jsg::Ref<TraceException>> getExceptions();
   kj::ArrayPtr<jsg::Ref<TraceDiagnosticChannelEvent>> getDiagnosticChannelEvents();
   kj::Maybe<kj::StringPtr> getScriptName();
+  jsg::Optional<kj::StringPtr> getEntrypoint();
   jsg::Optional<ScriptVersion> getScriptVersion();
   jsg::Optional<kj::StringPtr> getDispatchNamespace();
   jsg::Optional<kj::Array<kj::StringPtr>> getScriptTags();
@@ -109,6 +110,7 @@ public:
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(exceptions, getExceptions);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(diagnosticsChannelEvents, getDiagnosticChannelEvents);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptName, getScriptName);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(entrypoint, getEntrypoint);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptVersion, getScriptVersion);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(dispatchNamespace, getDispatchNamespace);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptTags, getScriptTags);
@@ -124,6 +126,7 @@ private:
   kj::Array<jsg::Ref<TraceException>> exceptions;
   kj::Array<jsg::Ref<TraceDiagnosticChannelEvent>> diagnosticChannelEvents;
   kj::Maybe<kj::String> scriptName;
+  kj::Maybe<kj::String> entrypoint;
   kj::Maybe<ScriptVersion> scriptVersion;
   kj::Maybe<kj::String> dispatchNamespace;
   jsg::Optional<kj::Array<kj::String>> scriptTags;

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -52,7 +52,8 @@ class Trace final : public kj::Refcounted {
 public:
   explicit Trace(kj::Maybe<kj::String> stableId, kj::Maybe<kj::String> scriptName,
       kj::Maybe<kj::Own<ScriptVersion::Reader>> scriptVersion,
-      kj::Maybe<kj::String> dispatchNamespace, kj::Array<kj::String> scriptTags);
+      kj::Maybe<kj::String> dispatchNamespace, kj::Array<kj::String> scriptTags,
+      kj::Maybe<kj::String> entrypoint);
   Trace(rpc::Trace::Reader reader);
   ~Trace() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(Trace);
@@ -273,6 +274,7 @@ public:
   kj::Maybe<kj::Own<ScriptVersion::Reader>> scriptVersion;
   kj::Maybe<kj::String> dispatchNamespace;
   kj::Array<kj::String> scriptTags;
+  kj::Maybe<kj::String> entrypoint;
 
   kj::Vector<Log> logs;
   // A request's trace can have multiple exceptions due to separate request/waitUntil tasks.
@@ -334,7 +336,8 @@ public:
                                          kj::Maybe<kj::String> scriptName,
                                          kj::Maybe<kj::Own<ScriptVersion::Reader>> scriptVersion,
                                          kj::Maybe<kj::String> dispatchNamespace,
-                                         kj::Array<kj::String> scriptTags);
+                                         kj::Array<kj::String> scriptTags,
+                                         kj::Maybe<kj::String> entrypoint);
   // Makes a tracer for a worker stage.
 
 private:

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -90,6 +90,16 @@ public:
     void copyTo(rpc::Trace::FetchEventInfo::Builder builder);
   };
 
+  class JsRpcEventInfo {
+  public:
+    explicit JsRpcEventInfo(kj::String methodName);
+    JsRpcEventInfo(rpc::Trace::JsRpcEventInfo::Reader reader);
+
+    kj::String methodName;
+
+    void copyTo(rpc::Trace::JsRpcEventInfo::Builder builder);
+  };
+
   class ScheduledEventInfo {
   public:
     explicit ScheduledEventInfo(double scheduledTime, kj::String cron);
@@ -251,8 +261,9 @@ public:
   // We treat the origin value as "unset".
   kj::Date eventTimestamp = kj::UNIX_EPOCH;
 
-  typedef kj::OneOf<FetchEventInfo, ScheduledEventInfo, AlarmEventInfo, QueueEventInfo,
-          EmailEventInfo, TraceEventInfo, HibernatableWebSocketEventInfo, CustomEventInfo> EventInfo;
+  typedef kj::OneOf<FetchEventInfo, JsRpcEventInfo, ScheduledEventInfo, AlarmEventInfo,
+          QueueEventInfo, EmailEventInfo, TraceEventInfo, HibernatableWebSocketEventInfo,
+          CustomEventInfo> EventInfo;
   kj::Maybe<EventInfo> eventInfo;
   // TODO(someday): Support more event types.
   // TODO(someday): Work out what sort of information we may want to convey about the parent

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -48,6 +48,7 @@ struct Trace @0x8e8d911203762d34 {
   eventInfo :union {
     none @3 :Void;
     fetch @6 :FetchEventInfo;
+    jsRpc @21 :JsRpcEventInfo;
     scheduled @7 :ScheduledEventInfo;
     alarm @9 :AlarmEventInfo;
     queue @15 :QueueEventInfo;
@@ -66,6 +67,10 @@ struct Trace @0x8e8d911203762d34 {
       name @0 :Text;
       value @1 :Text;
     }
+  }
+
+  struct JsRpcEventInfo {
+    methodName @0 :Text;
   }
 
   struct ScheduledEventInfo {

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -125,6 +125,8 @@ struct Trace @0x8e8d911203762d34 {
   dispatchNamespace @12 :Text;
   scriptTags @14 :List(Text);
 
+  entrypoint @22 :Text;
+
   diagnosticChannelEvents @17 :List(DiagnosticChannelEvent);
   struct DiagnosticChannelEvent {
     timestampNs @0 :Int64;

--- a/src/workerd/util/own-util.h
+++ b/src/workerd/util/own-util.h
@@ -15,7 +15,7 @@ inline auto mapAddRef(kj::Maybe<kj::Own<T>>& maybe) -> kj::Maybe<kj::Own<T>> {
 }
 
 template <typename T>
-inline auto mapAddRef(kj::Maybe<T&>& maybe) -> kj::Maybe<kj::Own<T>> {
+inline auto mapAddRef(kj::Maybe<T&> maybe) -> kj::Maybe<kj::Own<T>> {
   return maybe.map([](T& t){ return kj::addRef(t); });
 }
 


### PR DESCRIPTION
eventInfo was being left null, causing wrangler tail not to report the event at all. Let's fill it in and specify the top-level method name.

Also added entrypoint name, which seems highly relevant to JSRPC.