### PR TITLE
Add exception stack traces to trace/tail events.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,10 +39,10 @@ apple_support_dependencies()
 
 http_archive(
     name = "capnp-cpp",
-    sha256 = "e9220640c1e6453e2d27cf512a97933bfa59a92e708b566719b59326778827fc",
-    strip_prefix = "capnproto-capnproto-eef235d/c++",
+    sha256 = "21ae72a199a995b72e9bd359d4815539158d93a15cf36e284ef201fde7338c3c",
+    strip_prefix = "capnproto-capnproto-8ba7a6e/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/eef235dfa7aa40087605538ee3942b75a8910787"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/8ba7a6ef987eb56e8d41e7f11e080dabcbf2a04f"],
 )
 
 http_archive(

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -543,7 +543,8 @@ jsg::V8Ref<v8::Object> TraceLog::getMessage(jsg::Lock& js) {
 TraceException::TraceException(const Trace& trace, const Trace::Exception& exception)
     : timestamp(getTraceExceptionTimestamp(exception)),
       name(kj::str(exception.name)),
-      message(kj::str(exception.message)) {}
+      message(kj::str(exception.message)),
+      stack(exception.stack.map([](kj::StringPtr s) { return kj::str(s); })) {}
 
 double TraceException::getTimestamp() {
   return timestamp;
@@ -555,6 +556,10 @@ kj::StringPtr TraceException::getMessage() {
 
 kj::StringPtr TraceException::getName() {
   return name;
+}
+
+jsg::Optional<kj::StringPtr> TraceException::getStack(jsg::Lock& js) {
+  return stack;
 }
 
 TraceMetrics::TraceMetrics(uint cpuTime, uint wallTime) : cpuTime(cpuTime), wallTime(wallTime) {}

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -535,11 +535,13 @@ public:
   double getTimestamp();
   kj::StringPtr getName();
   kj::StringPtr getMessage();
+  jsg::Optional<kj::StringPtr> getStack(jsg::Lock& js);
 
   JSG_RESOURCE_TYPE(TraceException) {
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(timestamp, getTimestamp);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(message, getMessage);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(name, getName);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(stack, getStack);
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
@@ -551,6 +553,7 @@ private:
   double timestamp;
   kj::String name;
   kj::String message;
+  kj::Maybe<kj::String> stack;
 };
 
 class TraceMetrics final : public jsg::Object {

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -237,8 +237,9 @@ Trace::Log::Log(kj::Date timestamp, LogLevel logLevel, kj::String message)
       logLevel(logLevel),
       message(kj::mv(message)) {}
 
-Trace::Exception::Exception(kj::Date timestamp, kj::String name, kj::String message)
-    : timestamp(timestamp), name(kj::mv(name)), message(kj::mv(message)) {}
+Trace::Exception::Exception(kj::Date timestamp, kj::String name, kj::String message,
+                            kj::Maybe<kj::String> stack)
+    : timestamp(timestamp), name(kj::mv(name)), message(kj::mv(message)), stack(kj::mv(stack)) {}
 
 Trace::Trace(kj::Maybe<kj::String> stableId, kj::Maybe<kj::String> scriptName,
     kj::Maybe<kj::Own<ScriptVersion::Reader>> scriptVersion,
@@ -356,6 +357,9 @@ void Trace::Exception::copyTo(rpc::Trace::Exception::Builder builder) {
   builder.setTimestampNs((timestamp - kj::UNIX_EPOCH) / kj::NANOSECONDS);
   builder.setName(name);
   builder.setMessage(message);
+  KJ_IF_SOME(s, stack) {
+    builder.setStack(s);
+  }
 }
 
 void Trace::mergeFrom(rpc::Trace::Reader reader, PipelineLogLevel pipelineLogLevel) {
@@ -448,7 +452,11 @@ Trace::Log::Log(rpc::Trace::Log::Reader reader)
 Trace::Exception::Exception(rpc::Trace::Exception::Reader reader)
     : timestamp(kj::UNIX_EPOCH + reader.getTimestampNs() * kj::NANOSECONDS),
       name(kj::str(reader.getName())),
-      message(kj::str(reader.getMessage())) {}
+      message(kj::str(reader.getMessage())) {
+  if (reader.hasStack()) {
+    stack = kj::str(reader.getStack());
+  }
+}
 
 SpanBuilder& SpanBuilder::operator=(SpanBuilder &&other) {
   end();
@@ -566,7 +574,8 @@ void WorkerTracer::log(kj::Date timestamp, LogLevel logLevel, kj::String message
   trace->logs.add(timestamp, logLevel, kj::mv(message));
 }
 
-void WorkerTracer::addException(kj::Date timestamp, kj::String name, kj::String message) {
+void WorkerTracer::addException(kj::Date timestamp, kj::String name, kj::String message,
+                                kj::Maybe<kj::String> stack) {
   if (trace->exceededExceptionLimit) {
     return;
   }
@@ -577,15 +586,19 @@ void WorkerTracer::addException(kj::Date timestamp, kj::String name, kj::String 
     return;
   }
   size_t newSize = trace->bytesUsed + sizeof(Trace::Exception) + name.size() + message.size();
+  KJ_IF_SOME(s, stack) {
+    newSize += s.size();
+  }
   if (newSize > MAX_TRACE_BYTES) {
     trace->exceededExceptionLimit = true;
     trace->exceptions.add(
         timestamp, kj::str("Error"),
-        kj::str("Trace resource limit exceeded; subsequent exceptions not recorded."));
+        kj::str("Trace resource limit exceeded; subsequent exceptions not recorded."),
+        kj::none);
     return;
   }
   trace->bytesUsed = newSize;
-  trace->exceptions.add(timestamp, kj::mv(name), kj::mv(message));
+  trace->exceptions.add(timestamp, kj::mv(name), kj::mv(message), kj::mv(stack));
 }
 
 void WorkerTracer::addDiagnosticChannelEvent(kj::Date timestamp,

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -240,7 +240,8 @@ public:
 
   class Exception {
   public:
-    explicit Exception(kj::Date timestamp, kj::String name, kj::String message);
+    explicit Exception(kj::Date timestamp, kj::String name, kj::String message,
+                       kj::Maybe<kj::String> stack);
     Exception(rpc::Trace::Exception::Reader reader);
     Exception(Exception&&) = default;
     KJ_DISALLOW_COPY(Exception);
@@ -250,8 +251,9 @@ public:
     kj::Date timestamp;
 
     kj::String name;
-    // TODO(someday): record exception source, line/column number, stack trace?
     kj::String message;
+
+    kj::Maybe<kj::String> stack;
 
     void copyTo(rpc::Trace::Exception::Builder builder);
   };
@@ -366,7 +368,8 @@ public:
   // TODO(soon): Eventually:
   //void setMetrics(...) // Or get from MetricsCollector::Request directly?
 
-  void addException(kj::Date timestamp, kj::String name, kj::String message);
+  void addException(kj::Date timestamp, kj::String name, kj::String message,
+                    kj::Maybe<kj::String> stack);
 
   void addDiagnosticChannelEvent(kj::Date timestamp, kj::String channel,
                                  kj::Array<kj::byte> message);

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -37,6 +37,7 @@ struct Trace @0x8e8d911203762d34 {
     timestampNs @0 :Int64;
     name @1 :Text;
     message @2 :Text;
+    stack @3 :Text;
   }
 
   outcome @2 :EventOutcome;

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -447,7 +447,8 @@ public:
   struct ErrorInterface {
     jsg::Optional<kj::String> name;
     jsg::Optional<kj::String> message;
-    JSG_STRUCT(name, message);
+    jsg::Optional<kj::String> stack;
+    JSG_STRUCT(name, message, stack);
   };
   virtual const jsg::TypeHandler<ErrorInterface>&
       getErrorInterfaceTypeHandler(jsg::Lock& lock) const = 0;
@@ -529,9 +530,18 @@ public:
   void logUncaughtException(kj::StringPtr description);
 
   // Logs an exception to the debug console or trace, if active.
+  //
+  // If the caller already has a copy of the exception stack, it can pass this in as an
+  // optimization. This value will be passed along to the trace handler, if there is one, rather
+  // than querying the property from the exception itself. This is also useful in the case that
+  // the exception itself is not the original and the stack is missing.
   void logUncaughtException(UncaughtExceptionSource source,
                             const jsg::JsValue& exception,
                             const jsg::JsMessage& message = jsg::JsMessage());
+
+  // Version that takes a kj::Exception. If it has a serialized JS error attached as a detail, that
+  // error may be extracted and used.
+  void logUncaughtException(UncaughtExceptionSource source, kj::Exception&& exception);
 
   void reportPromiseRejectEvent(v8::PromiseRejectMessage& message);
 

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -17,6 +17,8 @@
 
 namespace workerd::jsg {
 
+class Lock;
+
 typedef unsigned int uint;
 
 // When a C++ callback wishes to throw a JavaScript exception, it should first call
@@ -60,6 +62,11 @@ void throwInternalError(v8::Isolate* isolate, kj::StringPtr internalMessage);
 
 // calls makeInternalError() and then tells the isolate to throw it.
 void throwInternalError(v8::Isolate* isolate, kj::Exception&& exception);
+
+constexpr kj::Exception::DetailTypeId TUNNELED_EXCEPTION_DETAIL_ID = 0xe8027292171b1646ull;
+
+// Add a serialized copy of the exception value to the KJ exception, as a "detail".
+void addExceptionDetail(Lock& js, kj::Exception& exception, v8::Local<v8::Value> handle);
 
 struct TypeErrorContext {
   enum Kind: uint8_t {


### PR DESCRIPTION
A new property, `stack`, contains the stack trace.

To support this in the case of async exceptions (which have already been converted to KJ), exception tunneling now adds a serialized copy of the V8 error to the exception itself, as a "detail". For now, this is _only_ used by `logUncaughtException()`. In the future, though, when the exception propagates back into JavaScript, we could de-tunnel it by deserializing this detail, rather than based on the description string. However, there are several complexities that need to be solved first, so I have not tried to do that in this PR.

Depends on: https://github.com/capnproto/capnproto/pull/1978