### PR TITLE
Refactor: ActorCache flush transaction and CountedDeletes

### DIFF
--- a/src/workerd/io/actor-cache-test.c++
+++ b/src/workerd/io/actor-cache-test.c++
@@ -750,7 +750,7 @@ KJ_TEST("ActorCache deleteAll()") {
   {
     auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
     mockTxn->expectCall("delete", ws)
-        .withParams(CAPNP(keys = ["bar", "baz", "grault"]))
+        .withParams(CAPNP(keys = ["bar", "grault", "baz"]))
         .thenReturn(CAPNP(numDeleted = 2));
     mockTxn->expectCall("delete", ws)
         .withParams(CAPNP(keys = ["garply"]))
@@ -862,7 +862,7 @@ KJ_TEST("ActorCache deleteAll() again when previous one isn't done yet") {
   {
     auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
     mockTxn->expectCall("delete", ws)
-        .withParams(CAPNP(keys = ["bar", "baz", "grault"]))
+        .withParams(CAPNP(keys = ["bar", "grault", "baz"]))
         .thenReturn(CAPNP(numDeleted = 2));
     mockTxn->expectCall("delete", ws)
         .withParams(CAPNP(keys = ["garply"]))

--- a/src/workerd/io/actor-cache-test.c++
+++ b/src/workerd/io/actor-cache-test.c++
@@ -750,7 +750,7 @@ KJ_TEST("ActorCache deleteAll()") {
   {
     auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
     mockTxn->expectCall("delete", ws)
-        .withParams(CAPNP(keys = ["bar", "grault", "baz"]))
+        .withParams(CAPNP(keys = ["bar", "baz", "grault"]))
         .thenReturn(CAPNP(numDeleted = 2));
     mockTxn->expectCall("delete", ws)
         .withParams(CAPNP(keys = ["garply"]))
@@ -766,8 +766,6 @@ KJ_TEST("ActorCache deleteAll()") {
     mockTxn->expectDropped(ws);
   }
 
-  KJ_ASSERT(deletePromise.wait(ws) == 2);
-
   mockStorage->expectCall("deleteAll", ws)
       .thenReturn(CAPNP(numDeleted = 2));
 
@@ -781,6 +779,8 @@ KJ_TEST("ActorCache deleteAll()") {
                                      (key = "waldo", value = "99999")]))
         .thenReturn(CAPNP());
   }
+
+  KJ_ASSERT(deletePromise.wait(ws) == 2);
 
   KJ_ASSERT(expectCached(test.get("foo")) == nullptr);
   KJ_ASSERT(expectCached(test.get("baz")) == nullptr);
@@ -862,7 +862,7 @@ KJ_TEST("ActorCache deleteAll() again when previous one isn't done yet") {
   {
     auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
     mockTxn->expectCall("delete", ws)
-        .withParams(CAPNP(keys = ["bar", "grault", "baz"]))
+        .withParams(CAPNP(keys = ["bar", "baz", "grault"]))
         .thenReturn(CAPNP(numDeleted = 2));
     mockTxn->expectCall("delete", ws)
         .withParams(CAPNP(keys = ["garply"]))
@@ -875,8 +875,6 @@ KJ_TEST("ActorCache deleteAll() again when previous one isn't done yet") {
     mockTxn->expectDropped(ws);
   }
 
-  KJ_ASSERT(deletePromise.wait(ws) == 2);
-
   // Do another deleteAll() before the first one is done.
   auto deleteAllB = test.cache.deleteAll({});
 
@@ -886,7 +884,6 @@ KJ_TEST("ActorCache deleteAll() again when previous one isn't done yet") {
   // Now finish it.
   mockStorage->expectCall("deleteAll", ws)
       .thenReturn(CAPNP(numDeleted = 2));
-
   KJ_ASSERT(deleteAllA.count.wait(ws) == 2);
   KJ_ASSERT(deleteAllB.count.wait(ws) == 0);
 
@@ -896,6 +893,7 @@ KJ_TEST("ActorCache deleteAll() again when previous one isn't done yet") {
         .withParams(CAPNP(entries = [(key = "fred", value = "2323")]))
         .thenReturn(CAPNP());
   }
+  KJ_ASSERT(deletePromise.wait(ws) == 2);
 }
 
 KJ_TEST("ActorCache coalescing") {
@@ -950,7 +948,7 @@ KJ_TEST("ActorCache coalescing") {
         .withParams(CAPNP(keys = ["grault"]))
         .thenReturn(CAPNP(numDeleted = 0));
     mockTxn->expectCall("delete", ws)
-        .withParams(CAPNP(keys = ["garply", "fred", "waldo"]))
+        .withParams(CAPNP(keys = ["garply", "waldo", "fred"]))
         .thenReturn(CAPNP(numDeleted = 2));
     mockTxn->expectCall("delete", ws)
         .withParams(CAPNP(keys = ["bar", "foo"]))
@@ -1172,10 +1170,9 @@ KJ_TEST("ActorCache flush retry") {
   KJ_ASSERT(KJ_ASSERT_NONNULL(expectCached(test.get("corge"))) == "555");
   KJ_ASSERT(expectCached(test.get("grault")) == nullptr);
 
-  // Although the transaction didn't complete, the delete did, and so it resolves.
-  KJ_ASSERT(promise1.wait(ws) == 1);
-
-  // The second delete had failed, though, so is still outstanding.
+  // Although the counted delete succeeded, the promise will not resolve until our flush succeeds!
+  KJ_ASSERT(!promise1.poll(ws));
+  // The second delete failed and is also still outstanding until a flush succeeds.
   KJ_ASSERT(!promise2.poll(ws));
 
   // The transaction will be retried, with the updated puts and deletes.
@@ -1188,11 +1185,14 @@ KJ_TEST("ActorCache flush retry") {
     // last time, because it hasn't been further overwritten, and that delete from last time
     // wasn't actually committed.
     mockTxn->expectCall("delete", ws)
-        .withParams(CAPNP(keys = ["grault", "corge"]))
+        .withParams(CAPNP(keys = ["quux"]))
+        .thenReturn(CAPNP());  // count ignored because we got it on the first try!
+    mockTxn->expectCall("delete", ws)
+        .withParams(CAPNP(keys = ["corge", "grault"]))
         .thenReturn(CAPNP(numDeleted = 2));
     mockTxn->expectCall("delete", ws)
-        .withParams(CAPNP(keys = ["quux", "baz"]))
-        .thenReturn(CAPNP(numDeleted = 1234));  // count ignored
+        .withParams(CAPNP(keys = ["baz"]))
+        .thenReturn(CAPNP(numDeleted = 1234)); // count ignored
     mockTxn->expectCall("put", ws)
         .withParams(CAPNP(entries = [(key = "foo", value = "123"),
                                      (key = "bar", value = "654"),
@@ -1214,6 +1214,9 @@ KJ_TEST("ActorCache flush retry") {
 
   // Second delete finished this time.
   KJ_ASSERT(promise2.wait(ws) == 2);
+
+  // Our flush has succeeded and we've obtained our count!
+  KJ_ASSERT(promise1.wait(ws) == 1);
 }
 
 KJ_TEST("ActorCache output gate blocked during flush") {
@@ -3496,7 +3499,7 @@ KJ_TEST("ActorCache listReverse() retry on failure") {
 // =======================================================================================
 // LRU purge
 
-constexpr size_t ENTRY_SIZE = 128;
+constexpr size_t ENTRY_SIZE = 120;
 KJ_TEST("ActorCache LRU purge") {
   ActorCacheTest test({.softLimit = 1 * ENTRY_SIZE});
   auto& ws = test.ws;

--- a/src/workerd/io/actor-cache-test.c++
+++ b/src/workerd/io/actor-cache-test.c++
@@ -1038,10 +1038,8 @@ KJ_TEST("ActorCache get-put ordering") {
   auto mockGet2 = mockStorage->expectCall("getMultiple", ws)
       .withParams(CAPNP(keys = ["baz"]), "stream"_kj);
 
-  // The flush transaction's capability will be created but no writes will be done on it until our
-  // reads finish!
-  auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
-  mockTxn->expectNoActivity(ws);
+  // No writes will be done until our reads finish!
+  mockStorage->expectNoActivity(ws);
 
   // Let's have the second read complete first.
   kj::mv(mockGet2).useCallback("stream", [&](MockClient stream) {
@@ -1059,8 +1057,8 @@ KJ_TEST("ActorCache get-put ordering") {
   KJ_ASSERT(KJ_ASSERT_NONNULL(expectCached(test.get("bar"))) == "456");
   KJ_ASSERT(KJ_ASSERT_NONNULL(expectCached(test.get("baz"))) == "987");
 
-  // The transaction still isn't doing anything because the first read is still outstanding.
-  mockTxn->expectNoActivity(ws);
+  // Still no writes because the first read is still outstanding.
+  mockStorage->expectNoActivity(ws);
 
   // Finally, have the first read complete.
   kj::mv(mockGet1).useCallback("stream", [&](MockClient stream) {
@@ -1080,6 +1078,7 @@ KJ_TEST("ActorCache get-put ordering") {
   KJ_ASSERT(KJ_ASSERT_NONNULL(expectCached(test.get("baz"))) == "987");
 
   // Next up, the flush transaction proceeds.
+  auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
   mockTxn->expectCall("delete", ws)
       .withParams(CAPNP(keys = ["bar"]))
       .thenReturn(CAPNP(numDeleted = 1));
@@ -1374,9 +1373,8 @@ KJ_TEST("ActorCache read retry") {
   auto mockGet = mockStorage->expectCall("get", ws)
       .withParams(CAPNP(key = "foo"));
 
-  // No activity on the transaction yet, because reads are outstanding.
-  auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
-  mockTxn->expectNoActivity(ws);
+  // No activity because reads are outstanding.
+  mockStorage->expectNoActivity(ws);
 
   // Fail out the read with a disconnect.
   kj::mv(mockGet).thenThrow(KJ_EXCEPTION(DISCONNECTED, "read failed"));
@@ -1385,13 +1383,14 @@ KJ_TEST("ActorCache read retry") {
   auto mockGet2 = mockStorage->expectCall("get", ws)
       .withParams(CAPNP(key = "foo"));
 
-  // Still no transaction activity.
-  mockTxn->expectNoActivity(ws);
+  // Still no activity because of the read.
+  mockStorage->expectNoActivity(ws);
 
   // Finish it.
   kj::mv(mockGet2).thenReturn(CAPNP(value = "123"));
 
   // Now the transaction starts actually writing (and completes).
+  auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
   mockTxn->expectCall("delete", ws)
       .withParams(CAPNP(keys = ["baz"]))
       .thenReturn(CAPNP(numDeleted = 0));
@@ -1457,9 +1456,8 @@ KJ_TEST("ActorCache read hard fail") {
   auto mockGet = mockStorage->expectCall("get", ws)
       .withParams(CAPNP(key = "foo"));
 
-  // The transaction won't write anything until the read completes.
-  auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
-  mockTxn->expectNoActivity(ws);
+  // We won't write anything until the read completes.
+  mockStorage->expectNoActivity(ws);
 
   // Fail out the read with non-disconnect.
   kj::mv(mockGet).thenThrow(KJ_EXCEPTION(FAILED, "read failed"));
@@ -1468,6 +1466,7 @@ KJ_TEST("ActorCache read hard fail") {
   KJ_EXPECT_THROW_MESSAGE("read failed", promise.wait(ws));
 
   // The read is NOT retried, so expect the transaction to run now.
+  auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
   mockTxn->expectCall("delete", ws)
       .withParams(CAPNP(keys = ["baz"]))
       .thenReturn(CAPNP(numDeleted = 0));
@@ -1494,15 +1493,15 @@ KJ_TEST("ActorCache read cancel") {
   auto mockGet = mockStorage->expectCall("get", ws)
       .withParams(CAPNP(key = "foo"));
 
-  // The transaction won't write anything until the read completes.
-  auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
-  mockTxn->expectNoActivity(ws);
+  // We won't write anything until the read completes.
+  mockStorage->expectNoActivity(ws);
 
   // Cancel the read.
   promise = nullptr;
   mockGet.expectCanceled();
 
-  // The tansaction proceeds.
+  // The transaction proceeds.
+  auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
   mockTxn->expectCall("delete", ws)
       .withParams(CAPNP(keys = ["baz"]))
       .thenReturn(CAPNP(numDeleted = 0));
@@ -1934,9 +1933,8 @@ KJ_TEST("ActorCache list() with seemingly-redundant dirty entries") {
   auto listCall = mockStorage->expectCall("list", ws)
       .withParams(CAPNP(start = "aaa", end = "fff"), "stream"_kj);
 
-  // The delete transaction won't do any work until the list completes.
-  auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
-  mockTxn->expectNoActivity(ws);
+  // The delete won't do any work until the list completes.
+  mockStorage->expectNoActivity(ws);
 
   // Now write some contradictory values.
   test.put("bbb", "bval");
@@ -1958,6 +1956,7 @@ KJ_TEST("ActorCache list() with seemingly-redundant dirty entries") {
 
   // Now the transaction runs, notably containing only the original writes, not the later writes,
   // despite our flush being delayed by the reads.
+  auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
   mockTxn->expectCall("delete", ws)
       .withParams(CAPNP(keys = ["bbb"]))
       .thenReturn(CAPNP(numDeleted = 1));
@@ -2936,9 +2935,8 @@ KJ_TEST("ActorCache listReverse() with seemingly-redundant dirty entries") {
   auto listCall = mockStorage->expectCall("list", ws)
       .withParams(CAPNP(start = "aaa", end = "fff", reverse = true), "stream"_kj);
 
-  // The transaction will be created but not do any work because the list is outstanding.
-  auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
-  mockTxn->expectNoActivity(ws);
+  // We won't do any work while the list is outstanding.
+  mockStorage->expectNoActivity(ws);
 
   // Now write some contradictory values.
   test.put("bbb", "bval");
@@ -2959,6 +2957,7 @@ KJ_TEST("ActorCache listReverse() with seemingly-redundant dirty entries") {
   KJ_ASSERT(expectCached(test.get("ccc")) == nullptr);
 
   // The transaction completes now.
+  auto mockTxn = mockStorage->expectCall("txn", ws).returnMock("transaction");
   mockTxn->expectCall("delete", ws)
       .withParams(CAPNP(keys = ["bbb"]))
       .thenReturn(CAPNP(numDeleted = 1));

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -716,19 +716,20 @@ private:
     size_t wordCount = 0;
   };
   struct PutFlush {
-    kj::Vector<Entry*> entries;
+    kj::Vector<kj::Own<Entry>> entries;
     kj::Vector<FlushBatch> batches;
   };
   struct MutedDeleteFlush {
-    kj::Vector<Entry*> entries;
+    kj::Vector<kj::Own<Entry>> entries;
     kj::Vector<FlushBatch> batches;
   };
   struct CountedDeleteFlush {
     kj::Own<CountedDelete> countedDelete;
-    kj::Vector<Entry*> entries;
+    kj::Vector<kj::Own<Entry>> entries;
     kj::Vector<FlushBatch> batches;
   };
   using CountedDeleteFlushes = kj::Array<CountedDeleteFlush>;
+  kj::Promise<void> startFlushTransaction();
   kj::Promise<void> flushImplUsingSinglePut(PutFlush putFlush);
   kj::Promise<void> flushImplUsingSingleMutedDelete(MutedDeleteFlush mutedFlush);
   kj::Promise<void> flushImplUsingSingleCountedDelete(CountedDeleteFlush countedFlush);

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -319,22 +319,9 @@ private:
     // The value was set by the app via put() or delete(), and we have not yet initiated a write
     // to disk. The entry is appended to `dirtyList` whenever entering this state.
     //
-    // Next state: FLUSHING (if we begin flushing to disk) or NOT_IN_CACHE (if a new put()/delete()
+    // Next state: CLEAN (if the flush succeeds) or NOT_IN_CACHE (if a new put()/delete()
     // overwrites this entry first).
     DIRTY,
-
-    // The value is dirty but an RPC is in-flight to write this value to disk. If the value is
-    // overwritten in the meantime, or the write fails, then the state needs to change back to
-    // DIRTY. If the write completes successfully and the state is still FLUSHING, then the state
-    // can progress to CLEAN.
-    //
-    // The entry remains in `dirtyList` while in this state. Since newly-dirty entries are always
-    // appended to `dirtyList`, it's guaranteed that all `FLUSHING` entries in `dirtyList` come
-    // before all `DIRTY` entries.
-    //
-    // Next state: CLEAN (if the flush completes) or NOT_IN_CACHE (if a new put()/delete()
-    // overwrites the entry first).
-    FLUSHING,
 
     // The entry matches what is currently on disk. The entry is currently present in the LRU
     // queue.
@@ -434,10 +421,6 @@ private:
       }
     }
 
-    void setFlushing() {
-      syncStatus = EntrySyncStatus::FLUSHING;
-    }
-
     void setNotInCache() {
       syncStatus = EntrySyncStatus::NOT_IN_CACHE;
     }
@@ -455,8 +438,7 @@ private:
 
     bool isDirty() const {
       switch(getSyncStatus()) {
-        case EntrySyncStatus::DIRTY:
-        case EntrySyncStatus::FLUSHING: {
+        case EntrySyncStatus::DIRTY: {
           return true;
         }
         case EntrySyncStatus::CLEAN: {
@@ -469,17 +451,18 @@ private:
     }
 
     bool isStale = false;
+    bool flushStarted = false;
 
     // If true, then a past list() operation covered the space between this entry and the following
     // entry, meaning that we know for sure that there are no other keys on disk between them.
     bool gapIsKnownEmpty = false;
 
     // If true, then this entry should be evicted from cache immediately when it becomes CLEAN.
-    // The entry still needs to reside in cache while DIRTY/FLUSHING since we need to store it
+    // The entry still needs to reside in cache while DIRTY since we need to store it
     // somewhere, and so we might as well serve cache hits based on it in the meantime.
     bool noCache = false;
 
-    // In the DIRTY or FLUSHING state, if this entry was originally created as the result of a
+    // In the DIRTY state, if this entry was originally created as the result of a
     // `delete()` call, and as such the caller needs to receive a count of deletions, then this
     // tracks that need. Note that only one caller could ever be waiting on this, because
     // subsequent delete() calls can be counted based on the cache content. This can be null
@@ -496,7 +479,7 @@ private:
 
     // If CLEAN, the entry will be in the SharedLru's `cleanList`.
     //
-    // If DIRTY or FLUSHING, the entry will be in `dirtyList`.
+    // If DIRTY, the entry will be in `dirtyList`.
     kj::ListLink<Entry> link;
 
     size_t size() const {
@@ -569,8 +552,8 @@ private:
     size_t innerSize = 0;
   };
 
-  // List of entries in DIRTY or FLUSHING state. New dirty entries are added to the end. If any
-  // FLUSHING entries are present, they always appear strictly before DIRTY entries.
+  // List of entries in DIRTY state. New dirty entries are added to the end. If any
+  // flushing entries are present, they always appear strictly before non-flushing entries.
   DirtyList dirtyList;
 
   // Map of current known values for keys. Searchable by key, including ordered iteration.


### PR DESCRIPTION
This is some additional refactoring work that the read coalesce change relies on.

I specifically wanted to separate this so we can think about whether we want to retain the `FLUSHING` state or continue forward with `flushStarted`. It was too difficult to untangle that change when the smaller commits were all over the large single PR, but now that they're all [in front of us](https://github.com/cloudflare/workerd/pull/1914) we should be able to make changes with less effort.