### PR TITLE
Delete all alarms on `abortAllDurableObjects()`

### DIFF
--- a/src/workerd/server/alarm-scheduler.c++
+++ b/src/workerd/server/alarm-scheduler.c++
@@ -150,6 +150,25 @@ bool AlarmScheduler::deleteAlarm(ActorKey actor) {
   return query.changeCount() > 0;
 }
 
+void AlarmScheduler::deleteAllAlarms() {
+  stmtDeleteAllAlarms.run();
+
+  alarms.eraseAll([this](ActorKey& key, ScheduledAlarm& value) {
+    KJ_IF_SOME(queued, value.queuedAlarm) {
+      if (value.status == AlarmStatus::STARTED) {
+        // If we are currently running an alarm, we want to delete the queued instead of current.
+        value.queuedAlarm = kj::none;
+      } else {
+        alarms.upsert(key, scheduleAlarm(clock.now(), kj::mv(value.actor), queued));
+      }
+      return false;
+    } else {
+      // We can't remove running alarms.
+      return value.status != AlarmStatus::STARTED;
+    }
+  });
+}
+
 kj::Promise<AlarmScheduler::RetryInfo> AlarmScheduler::runAlarm(
     const ActorKey& actor, kj::Date scheduledTime, uint32_t retryCount) {
   KJ_IF_SOME(ns, namespaces.find(actor.uniqueKey)) {

--- a/src/workerd/server/alarm-scheduler.h
+++ b/src/workerd/server/alarm-scheduler.h
@@ -69,6 +69,7 @@ public:
   kj::Maybe<kj::Date> getAlarm(ActorKey actor);
   bool setAlarm(ActorKey actor, kj::Date scheduledTime);
   bool deleteAlarm(ActorKey actor);
+  void deleteAllAlarms();
 
   void registerNamespace(kj::StringPtr uniqueKey, GetActorFn getActor);
 
@@ -128,6 +129,9 @@ private:
   )");
   SqliteDatabase::Statement stmtDeleteAlarm = db->prepare(R"(
     DELETE FROM _cf_ALARM WHERE actor_unique_key = ? AND actor_id = ?
+  )");
+  SqliteDatabase::Statement stmtDeleteAllAlarms = db->prepare(R"(
+    DELETE FROM _cf_ALARM
   )");
 
   void taskFailed(kj::Exception&& exception) override;

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2548,6 +2548,8 @@ void Server::abortAllActors() {
       }
     }
   }
+
+  alarmScheduler->deleteAllAlarms();
 }
 
 kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::Reader conf,

--- a/src/workerd/server/tests/unsafe-module/unsafe-module-test.js
+++ b/src/workerd/server/tests/unsafe-module/unsafe-module-test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import unsafe from "workerd:unsafe";
+import { DurableObject } from "cloudflare:workers";
 
 function createTestObject(type) {
   return class {
@@ -13,6 +14,19 @@ export const TestDurableObject = createTestObject("durable");
 export const TestDurableObjectPreventEviction = createTestObject("durable-prevent-eviction");
 export const TestEphemeralObject = createTestObject("ephemeral");
 export const TestEphemeralObjectPreventEviction = createTestObject("ephemeral-prevent-eviction");
+
+let alarmTriggers = 0;
+export class AlarmObject extends DurableObject {
+  get scheduledTime() {
+    return this.ctx.storage.getAlarm();
+  }
+  async scheduleIn(delay) {
+    await this.ctx.storage.setAlarm(Date.now() + delay);
+  }
+  alarm() {
+    alarmTriggers++;
+  }
+}
 
 export const test_abort_all_durable_objects = {
   async test(ctrl, env, ctx) {
@@ -51,5 +65,27 @@ export const test_abort_all_durable_objects = {
     // Response from objects in namespaces that have prevent eviction set shouldn't change
     assert.strictEqual(durablePreventEvictionRes1, durablePreventEvictionRes2);
     assert.strictEqual(ephemeralPreventEvictionRes1, ephemeralPreventEvictionRes2);
+  }
+}
+
+export const test_abort_all_durable_objects_alarms = {
+  async test(ctrl, env, ctx) {
+    const id = env.ALARM.newUniqueId();
+    const stub = env.ALARM.get(id);
+
+    // Check we can schedule an alarm as usual
+    assert.strictEqual(await stub.scheduledTime, null);
+    await stub.scheduleIn(500);
+    assert.notStrictEqual(await stub.scheduledTime, null);
+    await scheduler.wait(1000);
+    assert.strictEqual(alarmTriggers, 1);
+    assert.strictEqual(await stub.scheduledTime, null);
+
+    // Check `abortAllDurableObjects()` deletes all alarms
+    await stub.scheduleIn(500);
+    await unsafe.abortAllDurableObjects();
+    assert.strictEqual(await stub.scheduledTime, null);
+    await scheduler.wait(1000);
+    assert.strictEqual(alarmTriggers, 1); // (same as before)
   }
 }

--- a/src/workerd/server/tests/unsafe-module/unsafe-module-test.wd-test
+++ b/src/workerd/server/tests/unsafe-module/unsafe-module-test.wd-test
@@ -2,25 +2,28 @@ using Workerd = import "/workerd/workerd.capnp";
 
 const unitTests :Workerd.Config = (
   services = [
+    ( name = "TEST_TMPDIR", disk = (writable = true) ),
     ( name = "unsafe-module-test",
       worker = (
         modules = [
           ( name = "worker", esModule = embed "unsafe-module-test.js" ),
         ],
         compatibilityDate = "2023-12-06",
-        compatibilityFlags = ["nodejs_compat", "unsafe_module"],
+        compatibilityFlags = ["nodejs_compat", "unsafe_module", "rpc"],
         durableObjectNamespaces = [
           ( className = "TestDurableObject", uniqueKey = "durable" ),
           ( className = "TestDurableObjectPreventEviction", uniqueKey = "durable-prevent-eviction", preventEviction = true ),
           ( className = "TestEphemeralObject", ephemeralLocal = void ),
           ( className = "TestEphemeralObjectPreventEviction", ephemeralLocal = void, preventEviction = true ),
+          ( className = "AlarmObject",  uniqueKey = "alarm" ),
         ],
-        durableObjectStorage = (inMemory = void),
+        durableObjectStorage = ( localDisk = "TEST_TMPDIR" ),
         bindings = [
           ( name = "DURABLE", durableObjectNamespace = "TestDurableObject" ),
           ( name = "DURABLE_PREVENT_EVICTION", durableObjectNamespace = "TestDurableObjectPreventEviction" ),
           ( name = "EPHEMERAL", durableObjectNamespace = "TestEphemeralObject" ),
           ( name = "EPHEMERAL_PREVENT_EVICTION", durableObjectNamespace = "TestEphemeralObjectPreventEviction" ),
+          ( name = "ALARM", durableObjectNamespace = "AlarmObject" ),
         ],
      )
     ),


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/5388

In the Workers Vitest integration, we call the `abortAllDurableObjects()` function after each test to abort all Durable Objects  and close all SQLite databases. If the isolated storage option is enabled, we backup/restore `.sqlite` files to automatically undo writes performed in tests. Right now, this doesn't cancel Durable Object alarms. This means that an alarm scheduled in one test might end up firing when another later test is running. This could lead to unexpected test results, and non-determinism in tests.

This PR addresses this issue by automatically deleting all Durable Object alarms when `abortAllDurableObjects()` is called. This is a local-only internal API that's currently only used in the Vitest integration, so making this breaking change is fine. 👍 