### PR TITLE
Fix bug with reportUndefinedSymbols shim

### DIFF
--- a/src/pyodide/BUILD.bazel
+++ b/src/pyodide/BUILD.bazel
@@ -124,6 +124,10 @@ REPLACEMENTS = [
     [
         "reportUndefinedSymbols()",
         "reportUndefinedSymbolsNoOp()"
+    ],
+    [
+        "Module.reportUndefinedSymbolsNoOp()",
+        "Module.reportUndefinedSymbols()"
     ]
 ]
 


### PR DESCRIPTION
Looks like #1868 also replaces a call to Module.reportUndefinedSymbols, which throws an error in local dev because this value is assigned in two other places like so:

```
Module.reportUndefinedSymbols = () => {}
...
Module["reportUndefinedSymbols"] = ...
```

Which are not matched by the rule. This PR simply refuses to replace `Module.reportUndefinedSymbols()` with `Module.reportUndefinedSymbolsNoOp()`. 