### PR TITLE
Different fix for reportUndefinedSymbolsNoOp bug

### DIFF
--- a/src/pyodide/BUILD.bazel
+++ b/src/pyodide/BUILD.bazel
@@ -125,10 +125,6 @@ REPLACEMENTS = [
         "reportUndefinedSymbols()",
         "reportUndefinedSymbolsNoOp()"
     ],
-    [
-        "Module.reportUndefinedSymbolsNoOp()",
-        "Module.reportUndefinedSymbols()"
-    ]
 ]
 
 load("//:build/pyodide_bucket.bzl", "PYODIDE_PACKAGE_BUCKET_URL")

--- a/src/pyodide/internal/python.js
+++ b/src/pyodide/internal/python.js
@@ -248,6 +248,7 @@ function getEmscriptenSettings(lockfile, indexURL) {
     // important because the file system lives outside of linear memory.
     preRun: [prepareFileSystem, setEnv, preloadDynamicLibs],
     instantiateWasm,
+    reportUndefinedSymbolsNoOp() {},
     // if SNAPSHOT_SIZE is defined, start with the linear memory big enough to
     // fit the snapshot. If it's not defined, this falls back to the default.
     INITIAL_MEMORY: SNAPSHOT_SIZE,


### PR DESCRIPTION
See #1919 

Instead of keeping Modules.reportUndefinedSymbols, this PR actually defines Modules.reportUndefinedSymbolsNoOp and performs the substitution as before.