### PR TITLE
fix: remove `Symbol.dispose` references for old TypeScript versions

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -145,8 +145,6 @@ declare module "cloudflare:workers" {
 
   export abstract class RpcTarget implements Rpc.RpcTargetBranded {
     [Rpc.__RPC_TARGET_BRAND]: never;
-
-    [Symbol.dispose]?(): void;
   }
 
   // `protected` fields don't appear in `keyof`s, so can't be accessed over RPC
@@ -159,8 +157,6 @@ declare module "cloudflare:workers" {
     protected ctx: ExecutionContext;
     protected env: Env;
     constructor(ctx: ExecutionContext, env: Env);
-
-    [Symbol.dispose]?(): void;
 
     fetch?(request: Request): Response | Promise<Response>;
     tail?(events: TraceItem[]): void | Promise<void>;
@@ -178,8 +174,6 @@ declare module "cloudflare:workers" {
     protected ctx: DurableObjectState;
     protected env: Env;
     constructor(ctx: DurableObjectState, env: Env);
-
-    [Symbol.dispose]?(): void;
 
     fetch?(request: Request): Response | Promise<Response>;
     alarm?(): void | Promise<void>;


### PR DESCRIPTION
Hey! 👋 This PR removes some references to `Symbol.dispose()` introduced in #1870. As this comment helpfully explains... 

https://github.com/cloudflare/workerd/blob/aa43411321843bfe19709d8e4a9a18d54a049f79/types/defines/disposable.d.ts#L1-L7

...using `Symbol.dispose` will fail type checking with TypeScript versions before 5.2. 🤦‍♂️ 

These uses of `Symbol.dispose` were meant to hint that these classes could be `Disposable`s and `workerd` would handle calling `Symbol.dispose` at an appropriate time. Users can still define `Symbol.dispose()` without these definitions. They were also meant to provide some basic type checking if users did define a `Symbol.dispose`, but since they're `void` return typed, anything could've been returned from them. Removing them shouldn't cause any problems.

Note we can't do something like `implements Disposable` on `RpcTarget`, `WorkerEntrypoint`, and `DurableObject` since `Disposable` requires `Symbol.dispose` to be defined, whereas we'd like it to be optional. We technically could define different versions of the types for different TypeScript versions, but this probably isn't worth it for the reasons above.