### PR TITLE
Allow referencing empty-object exports as entrypoints.

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1957,14 +1957,20 @@ void Worker::Lock::validateHandlers(ValidationErrorReporter& errorReporter) {
           //   hence we will see it here. Rather than try to correct this inconsistency between
           //   struct and dict handling (which could have unintended consequences), let's just
           //   work around by ignoring arrays here.
+          errorReporter.addEmptyExport(name);
           return;
         }
 
         auto dict = js.toDict(handle);
+        bool empty = true;
         for (auto& field: dict.fields) {
           if (!ignoredHandlers.contains(field.name)) {
             errorReporter.addHandler(name, field.name);
+            empty = false;
           }
+        }
+        if (empty) {
+          errorReporter.addEmptyExport(name);
         }
       };
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -74,6 +74,10 @@ public:
   public:
     virtual void addError(kj::String error) = 0;
     virtual void addHandler(kj::Maybe<kj::StringPtr> exportName, kj::StringPtr type) = 0;
+
+    // Called when an export is encountered that defines no handlers, thus isn't useful for
+    // anything.
+    virtual void addEmptyExport(kj::Maybe<kj::StringPtr> exportName) {}
   };
 
   class LockType;

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -1346,6 +1346,13 @@ KJ_TEST("Server: named entrypoints") {
                 `    return new Response("hello from bar entrypoint");
                 `  }
                 `}
+                `
+                `// Also exprot some symbols that aren't valid entrypoints, but we should still
+                `// be allowed to point sockets at them. (Sending any actual requests to them
+                `// will still fail.)
+                `export let invalidObj = {};  // no handlers
+                `export let invalidArray = [1, 2];
+                `export let invalidMap = new Map();
             )
           ]
         )
@@ -1354,7 +1361,14 @@ KJ_TEST("Server: named entrypoints") {
     sockets = [
       ( name = "main", address = "test-addr", service = "hello" ),
       ( name = "alt1", address = "foo-addr", service = (name = "hello", entrypoint = "foo")),
-      ( name = "alt2", address = "bar-addr", service = (name = "hello", entrypoint = "bar"))
+      ( name = "alt2", address = "bar-addr", service = (name = "hello", entrypoint = "bar")),
+
+      ( name = "invalid1", address = "invalid1-addr",
+        service = (name = "hello", entrypoint = "invalidObj")),
+      ( name = "invalid2", address = "invalid2-addr",
+        service = (name = "hello", entrypoint = "invalidArray")),
+      ( name = "invalid3", address = "invalid3-addr",
+        service = (name = "hello", entrypoint = "invalidMap")),
     ]
   ))"_kj);
 


### PR DESCRIPTION
This fixes a regression in miniflare around named entrypoints: If a script had a top-level export that was an object with no instance properties, miniflare would treat it as a named entrypoint (configuring a socket for it), but workerd would consider this config invalid because the export didn't appear to actually be able to handle events.

It would be hard to make miniflare be able to detect the types of exports, so instead we make workerd more lenient.