### PR TITLE
Fix the type of the Hyperdrive binding's port field

### DIFF
--- a/types/defines/hyperdrive.d.ts
+++ b/types/defines/hyperdrive.d.ts
@@ -29,7 +29,7 @@ interface Hyperdrive {
   /*
    * The port that must be paired the the host field when connecting.
    */
-  readonly port: string;
+  readonly port: number;
   /*
    * The username to use when authenticating to your database via Hyperdrive.
    * Unlike the host and password, this will be the same every time 


### PR DESCRIPTION
It is returned as a number in the implementation of the binding (both in prod and in local development), not a string. This was purely an error in the types.

Noticed in https://github.com/cloudflare/cloudflare-docs/pull/13763#discussion_r1552262281

---

Confirmed both by checking the return type in our source code (`uint16_t`) and by running `console.log(typeof(env.HYPERDRIVE.port));` within a worker at the edge and getting back `number`.