### PR TITLE
[build] Add -fvisibility-inlines-hidden

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -80,6 +80,10 @@ build:debug -c dbg
 
 # Using simple template names saves around 5% of binary size of workerd.
 build:unix --cxxopt='-gsimple-template-names' --host_cxxopt='-gsimple-template-names'
+# Enable hidden visibility for inline functions. This can cause problems when comparing pointers to
+# inline functions across shared library boundaries, but this is unlikely to be done anywhere
+# within workerd, V8 explicitly supports hidden visibility.
+build:unix --cxxopt='-fvisibility-inlines-hidden' --host_cxxopt='-fvisibility-inlines-hidden'
 
 # Define a config mode which is fastbuild but with basic debug info.
 build:fastdbg -c fastbuild


### PR DESCRIPTION
Mark C++ inline methods as hidden, causing them to not be exported when creating shared libraries.

This significantly reduces binary sizes and possibly link times on Linux, where shared linkage is used for everything except the workerd binary (build folder size shrinks 7011MB => 6954 MB based on CI statistics). There is a smaller binary size improvement for macOS, where shared linkage is not enabled by default.
I want to also enable actual hidden visibility (i.e. `-fvisibility=hidden`) for V8, but that likely requires significant patching as it is only supported in the V8 GN build so far.
See https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-fvisibility-inlines-hidden for background information.