### PR TITLE
Add ResolveObserver to jsg/observer.h

### DIFF
--- a/src/workerd/jsg/observer.h
+++ b/src/workerd/jsg/observer.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <workerd/jsg/url.h>
 #include <kj/common.h>
 #include <kj/string.h>
 #include <kj/exception.h>
@@ -16,6 +17,77 @@ namespace v8 {
 
 namespace workerd::jsg {
 
+struct ResolveObserver {
+  virtual ~ResolveObserver() noexcept(false) { }
+
+  // Identifies the context in which a module resolution is being performed.
+  enum class Context {
+    // The resolve is being performed in the context of a worker bundle module
+    // (that is, a worker script is calling import or require).
+    BUNDLE,
+    // The resolve is being performed in the context of a builtin module
+    // (that is, one of the modules built into the worker runtime).
+    BUILTIN,
+    // Like builtin, the but it's a module that is *only* resolvable from a builtin
+    // (like the `node-internal:...` modules)
+    BUILTIN_ONLY,
+  };
+
+  enum class Source {
+    // The resolve originated from a static import statement.
+    STATIC_IMPORT,
+    // The resolve originated from a dynamic import statement.
+    DYNAMIC_IMPORT,
+    // The resolve originated from a CommonJS require() call.
+    REQUIRE,
+    // The resolve originated from an internal direct call to
+    // the ModuleRegistry.
+    INTERNAL,
+    // The resolve originated from some other source (to be defined).
+    OTHER,
+  };
+
+  // Used to report the status of a module resolution.
+  class ResolveStatus {
+  public:
+    ResolveStatus() = default;
+    KJ_DISALLOW_COPY_AND_MOVE(ResolveStatus);
+    virtual ~ResolveStatus() noexcept(false) {}
+
+    // Indicates that the module resolution was successful and a
+    // matching module was found in the registry.
+    virtual void found() {}
+
+    // Indicates that the module resolution failed because no matching
+    // module was found in the registry.
+    virtual void notFound() {}
+
+    // Indicates that the module resolution failed because an error
+    // occurred.
+    virtual void exception(kj::Exception&& exception) {}
+  };
+
+  // Called when a module is being resolved. The returned ResolveStatus
+  // object will be used to report the result of the resolution.
+  // It is guaranteed that isolate lock is not held during invocation.
+  virtual kj::Own<ResolveStatus> onResolveModule(const Url& specifier,
+                                                 Context context,
+                                                 Source source) const {
+    static ResolveStatus nonopStatus;
+    return { &nonopStatus, kj::NullDisposer::instance };
+  }
+
+  // Called when a module is being resolved. The returned ResolveStatus
+  // object will be used to report the result of the resolution.
+  // It is guaranteed that isolate lock is not held during invocation.
+  virtual kj::Own<ResolveStatus> onResolveModule(kj::StringPtr specifier,
+                                                 Context context,
+                                                 Source source) const {
+    static ResolveStatus nonopStatus;
+    return { &nonopStatus, kj::NullDisposer::instance };
+  }
+};
+
 struct CompilationObserver {
   virtual ~CompilationObserver() noexcept(false) { }
 
@@ -24,16 +96,38 @@ struct CompilationObserver {
 
   // Monitors behavior of compilation processes.
 
-  // Called at the start of module compilation.
+  // Called at the start of ESM compilation.
   // Returned value will be destroyed when module compilation finishes.
-  // It is guaranteed that isolate lock is held during both invocations.
+  // It is guaranteed that isolate lock is held during invocation.
   virtual kj::Own<void> onEsmCompilationStart(
       v8::Isolate* isolate, kj::StringPtr name, Option option) const { return kj::Own<void>(); }
 
+  // Called at the start of Script (e.g. non-ESM) compilation.
+  // Returned value will be destroyed when module compilation finishes.
+  // It is guaranteed that isolate lock is held during invocation.
+  virtual kj::Own<void> onScriptCompilationStart(
+      v8::Isolate* isolate, kj::Maybe<kj::StringPtr> name = kj::none) const {
+    return kj::Own<void>();
+  }
+
   // Called at the start of wasm compilation.
   // Returned value will be destroyed when module compilation finishes.
-  // It is guaranteed that isolate lock is held during both invocations.
+  // It is guaranteed that isolate lock is held during invocation.
   virtual kj::Own<void> onWasmCompilationStart(v8::Isolate* isolate, size_t codeSize) const {
+    return kj::Own<void>();
+  }
+
+  // Variation that is called at the start of wasm compilation from cache.
+  // Returned value will be destroyed when module compilation finishes.
+  // It is guaranteed that isolate lock is held during invocation.
+  virtual kj::Own<void> onWasmCompilationStart(v8::Isolate* isolate) const {
+    return kj::Own<void>();
+  }
+
+  // Called at the start of json module parsing.
+  // Returned value will be destroyed when parsing completes.
+  // It is guaranteed that isolate lock is held during invocation.
+  virtual kj::Own<void> onJsonCompilationStart(v8::Isolate* isolate, size_t inputSize) const {
     return kj::Own<void>();
   }
 };
@@ -53,7 +147,8 @@ struct Detail {
 };
 
 struct IsolateObserver : public CompilationObserver,
-                         public InternalExceptionObserver {
+                         public InternalExceptionObserver,
+                         public ResolveObserver {
   virtual ~IsolateObserver() noexcept(false) { }
 };
 

--- a/src/workerd/jsg/observer.h
+++ b/src/workerd/jsg/observer.h
@@ -120,7 +120,7 @@ struct CompilationObserver {
   // Variation that is called at the start of wasm compilation from cache.
   // Returned value will be destroyed when module compilation finishes.
   // It is guaranteed that isolate lock is held during invocation.
-  virtual kj::Own<void> onWasmCompilationStart(v8::Isolate* isolate) const {
+  virtual kj::Own<void> onWasmCompilationFromCacheStart(v8::Isolate* isolate) const {
     return kj::Own<void>();
   }
 


### PR DESCRIPTION
This separates out the new ResolveObserver interface from the new module registry PR in order to make it easier to review and further reduce the size of that other PR. This only adds the definition and does not introduce any code that uses it. That'll come with the module registry PR.

The idea is to improve observability of the module resolution process, including tracking the failure cases. For workerd, these observers are non-ops by default but can be set up by embedders to have actual backing implementations.

Refs: https://github.com/cloudflare/workerd/pull/1553