### PR TITLE
[build] Fix profile configuration, assorted build cleanup

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -69,7 +69,8 @@ build:thin-lto --linkopt='-flto=thin'
 # configuration used for performance profiling
 build:profile --config=thin-lto
 build:profile --copt="-fno-omit-frame-pointer" --copt="-mno-omit-leaf-frame-pointer"
-build:profile --copt='-g1' --linkopt='-g1' --strip=never
+build:profile --copt='-g1' --copt="-fdebug-info-for-profiling"
+build:profile --strip=never
 
 # configuration used for performance benchmarking is the same as profiling for consistency
 build:benchmark --config=profile
@@ -83,7 +84,6 @@ build:unix --cxxopt='-gsimple-template-names' --host_cxxopt='-gsimple-template-n
 # Define a config mode which is fastbuild but with basic debug info.
 build:fastdbg -c fastbuild
 build:fastdbg --cxxopt='-g1' --host_cxxopt='-g1'
-build:fastdbg --linkopt='-g1' --host_linkopt='-g1'
 build:fastdbg --strip=never
 build:fastdbg --//:dead_strip=False
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,14 +139,14 @@ jobs:
         if: always()
         shell: bash
         run: |
-          BAZEL_OUTPUT_BASE=$(bazel info --ui_event_filters=-WARNING output_base)
-          BAZEL_REPOSITORY_CACHE=$(bazel info --ui_event_filters=-WARNING repository_cache)
+          BAZEL_OUTPUT_BASE=$(bazel info output_base)
+          BAZEL_REPOSITORY_CACHE=$(bazel info repository_cache)
           echo "Bazel cache usage statistics"
-          du -hs -t 1 ~/bazel-disk-cache/* $BAZEL_REPOSITORY_CACHE
+          du -ms -t 1 ~/bazel-disk-cache/* $BAZEL_REPOSITORY_CACHE
           echo "Bazel output usage statistics"
-          du -hs -t 1 $BAZEL_OUTPUT_BASE
+          du -ms -t 1 $BAZEL_OUTPUT_BASE
           echo "Workspace usage statistics"
-          du -hs -t 1 $GITHUB_WORKSPACE
+          du -ms -t 1 $GITHUB_WORKSPACE
       - name: Drop large Bazel cache files
         if: always()
         # Github has a nominal 10GB of storage for all cached builds associated with a project.
@@ -159,7 +159,7 @@ jobs:
           if [ -d ~/bazel-disk-cache ]; then
             find ~/bazel-disk-cache -size +100M -type f -exec rm {} \;
             echo "Trimmed Bazel cache usage statistics"
-            du -hs -t 1 ~/bazel-disk-cache/*
+            du -ms -t 1 ~/bazel-disk-cache/*
           else
             echo "Disk cache does not exist: ~/bazel-disk-cache"
           fi

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -10,7 +10,7 @@ wd_cc_library(
     deps = [
         "@capnp-cpp//src/kj"
     ] + select({
-        "@platforms//os:windows": ["@workerd-v8//:v8"],
+        "@platforms//os:windows": [],
         "//conditions:default": ["@perfetto//:libperfetto_client_experimental"],
     }),
     defines = select({


### PR DESCRIPTION
- Pass -fdebug-info-for-profiling in the profile configuration. We may also want to add this in some other -g1-based configurations to have better backtraces, but that can be handled separately.
- -g1 is not needed at link time.
- As of bazel 7.1, `bazel info` does no longer produce excessive warnings – drop the warning filter.
- Report CI disk space usage in MB – this makes it easier to gauge the binary size impact of code changes.
- Drop superfluous perfetto-tracing => V8 dependency.