### PR TITLE
[nfc] Clean up JSG build

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -108,7 +108,6 @@ wd_cc_library(
         "//src/workerd/io",
         "//src/workerd/jsg",
         "//src/workerd/server:workerd_capnp",
-        "//src/workerd/util:autogate",
     ],
 )
 

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -8,7 +8,6 @@
 #include <pyodide/pyodide.capnp.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/server/workerd.capnp.h>
-#include <workerd/util/autogate.h>
 #include <workerd/io/io-context.h>
 
 namespace workerd::api::pyodide {

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -5,7 +5,6 @@
 #include "sockets.h"
 #include "system-streams.h"
 #include <workerd/io/worker-interface.h>
-#include <workerd/util/autogate.h>
 
 #include <workerd/jsg/url.h>
 

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -30,8 +30,8 @@ wd_cc_library(
         "function.h",
         "inspector.h",
         "iterator.h",
-        "jsg-test.h",
         "jsg.h",
+        "jsg-test.h",
         "jsvalue.h",
         "macro-meta.h",
         "meta.h",
@@ -47,9 +47,6 @@ wd_cc_library(
         "value.h",
         "web-idl.h",
         "wrappable.h",
-    ] + [
-        # todo: why is autogate a part of JSG api???
-        "//src/workerd/util:autogate.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -59,7 +56,6 @@ wd_cc_library(
         ":observer",
         ":url",
         "//src/workerd/util",
-        "//src/workerd/util:autogate",
         "//src/workerd/util:sentry",
         "//src/workerd/util:thread-scopes",
         "@capnp-cpp//src/kj",
@@ -84,13 +80,13 @@ wd_cc_library(
     hdrs = [
         "url.h",
     ],
+    implementation_deps = [
+        "@ada-url",
+    ],
     visibility = ["//visibility:public"],
     deps = [
-        ":exception",
         ":memory-tracker",
-        "@ada-url",
         "@capnp-cpp//src/kj",
-        "@workerd-v8//:v8",
     ],
 )
 
@@ -156,6 +152,7 @@ wd_cc_library(
     hdrs = ["observer.h"],
     visibility = ["//visibility:public"],
     deps = [
+        ":url",
         "@capnp-cpp//src/kj",
     ],
 )

--- a/src/workerd/jsg/memory-test.c++
+++ b/src/workerd/jsg/memory-test.c++
@@ -2,10 +2,11 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-#include "jsg-test.h"
 #include <workerd/jsg/memory.h>
+#include <workerd/jsg/setup.h>
 #include <v8-profiler.h>
 #include <kj/map.h>
+#include <kj/test.h>
 
 namespace workerd::jsg::test {
 namespace {

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -6,7 +6,6 @@
 
 #include <kj/filesystem.h>
 #include <kj/map.h>
-#include <workerd/util/autogate.h>
 #include <workerd/util/thread-scopes.h>
 #include <workerd/jsg/function.h>
 #include <workerd/jsg/modules.capnp.h>

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -21,12 +21,6 @@
 #include <workerd/jsg/memory.h>
 #include <workerd/jsg/modules.capnp.h>
 
-// The signature of SetAccessor changes in v8 12.1 to drop the v8::AccessControl
-// parameter.
-#if (V8_MAJOR_VERSION < 12) || ((V8_MAJOR_VERSION == 12) && (V8_MINOR_VERSION < 1))
-#define V8_PASS_ACCESS_CONTROL
-#endif
-
 namespace std {
   inline auto KJ_HASHCODE(const std::type_index& idx) {
     // Make std::type_index (which points to std::type_info) usable as a kj::HashMap key.
@@ -832,9 +826,6 @@ struct ResourceTypeBuilder {
         Gcb::callback,
         &SetterCallback<TypeWrapper, name, Setter, setter, isContext>::callback,
         v8::Local<v8::Value>(),
-#ifdef V8_PASS_ACCESS_CONTROL
-        v8::AccessControl::DEFAULT,
-#endif
         Gcb::enumerable ? v8::PropertyAttribute::None : v8::PropertyAttribute::DontEnum);
   }
 
@@ -876,9 +867,6 @@ struct ResourceTypeBuilder {
         &Gcb::callback,
         nullptr,
         v8::Local<v8::Value>(),
-#ifdef V8_PASS_ACCESS_CONTROL
-        v8::AccessControl::DEFAULT,
-#endif
         Gcb::enumerable ? v8::PropertyAttribute::ReadOnly
                         : static_cast<v8::PropertyAttribute>(
                             v8::PropertyAttribute::ReadOnly | v8::PropertyAttribute::DontEnum));
@@ -923,9 +911,6 @@ struct ResourceTypeBuilder {
         &Gcb::callback,
         nullptr,
         v8::Local<v8::Value>(),
-#ifdef V8_PASS_ACCESS_CONTROL
-        v8::AccessControl::DEFAULT,
-#endif
         static_cast<v8::PropertyAttribute>(
           v8::PropertyAttribute::ReadOnly | v8::PropertyAttribute::DontEnum));
   }

--- a/src/workerd/jsg/url-test.c++
+++ b/src/workerd/jsg/url-test.c++
@@ -2,9 +2,9 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-#include "jsg-test.h"
 #include "url.h"
 #include <kj/table.h>
+#include <kj/test.h>
 #include <regex>
 #include <openssl/rand.h>
 

--- a/src/workerd/jsg/url.c++
+++ b/src/workerd/jsg/url.c++
@@ -1,5 +1,4 @@
 #include "url.h"
-#include "exception.h"
 #include <kj/hash.h>
 
 extern "C" {

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -21,6 +21,7 @@ wd_cc_library(
         "//src/workerd/io",
         "//src/workerd/jsg",
         "//src/workerd/server",
+        "//src/workerd/util:autogate",
     ],
 )
 

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -15,6 +15,7 @@
 #include <workerd/jsg/modules.h>
 #include <workerd/server/server.h>
 #include <workerd/server/workerd-api.h>
+#include <workerd/util/autogate.h>
 #include <workerd/util/stream-utils.h>
 
 #include "test-fixture.h"

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -5,12 +5,11 @@
 #pragma once
 
 #include <kj/function.h>
+#include <kj/test.h>
 
 #include <workerd/jsg/jsg.h>
-#include <workerd/jsg/setup.h>
 #include <workerd/io/io-context.h>
 #include <workerd/io/worker.h>
-#include <workerd/jsg/jsg-test.h>
 #include <workerd/server/workerd.capnp.h>
 #include <workerd/api/memory-cache.h>
 


### PR DESCRIPTION
Spiritual successor to #2012. Also see the downstream PR.

- [build][nfc] Clean up JSG build file in accordance with IWYU
- [nfc] Drop support for old V8 version
  This was only needed around the time of the switch from 12.0 to 12.1.