### PR TITLE
Remove unique symbol from RPC types

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -6,10 +6,10 @@ declare namespace Rpc {
   // TypeScript uses *structural* typing meaning anything with the same shape as type `T` is a `T`.
   // For the classes exported by `cloudflare:workers` we want *nominal* typing (i.e. we only want to
   // accept `WorkerEntrypoint` from `cloudflare:workers`, not any other class with the same shape)
-  export const __RPC_STUB_BRAND: unique symbol;
-  export const __RPC_TARGET_BRAND: unique symbol;
-  export const __WORKER_ENTRYPOINT_BRAND: unique symbol;
-  export const __DURABLE_OBJECT_BRAND: unique symbol;
+  export const __RPC_STUB_BRAND: "__RPC_STUB_BRAND";
+  export const __RPC_TARGET_BRAND: "__RPC_TARGET_BRAND";
+  export const __WORKER_ENTRYPOINT_BRAND: "__WORKER_ENTRYPOINT_BRAND";
+  export const __DURABLE_OBJECT_BRAND: "__DURABLE_OBJECT_BRAND";
   export interface RpcTargetBranded {
     [__RPC_TARGET_BRAND]: never;
   }
@@ -68,7 +68,7 @@ declare namespace Rpc {
   // Recursively rewrite all `Stubable` types with `Stub`s
   // prettier-ignore
   type Stubify<T> =
-      T extends Stubable ? Stub<T>
+    T extends Stubable ? Stub<T>
     : T extends Map<infer K, infer V> ? Map<Stubify<K>, Stubify<V>>
     : T extends Set<infer V> ? Set<Stubify<V>>
     : T extends Array<infer V> ? Array<Stubify<V>>
@@ -81,7 +81,7 @@ declare namespace Rpc {
   // `Stub` depends on `Provider`, which depends on `Unstubify`, which would depend on `Stub`.
   // prettier-ignore
   type Unstubify<T> =
-      T extends StubBase<infer V> ? V
+    T extends StubBase<infer V> ? V
     : T extends Map<infer K, infer V> ? Map<Unstubify<K>, Unstubify<V>>
     : T extends Set<infer V> ? Set<Unstubify<V>>
     : T extends Array<infer V> ? Array<Unstubify<V>>
@@ -104,7 +104,7 @@ declare namespace Rpc {
   // Intersecting with `(Maybe)Provider` allows pipelining.
   // prettier-ignore
   type Result<R> =
-      R extends Stubable ? Promise<Stub<R>> & Provider<R>
+    R extends Stubable ? Promise<Stub<R>> & Provider<R>
     : R extends Serializable ? Promise<Stubify<R> & MaybeDisposable<R>> & MaybeProvider<R>
     : never;
 
@@ -150,8 +150,7 @@ declare module "cloudflare:workers" {
   // `protected` fields don't appear in `keyof`s, so can't be accessed over RPC
 
   export abstract class WorkerEntrypoint<Env = unknown>
-    implements Rpc.WorkerEntrypointBranded
-  {
+    implements Rpc.WorkerEntrypointBranded {
     [Rpc.__WORKER_ENTRYPOINT_BRAND]: never;
 
     protected ctx: ExecutionContext;
@@ -167,8 +166,7 @@ declare module "cloudflare:workers" {
   }
 
   export abstract class DurableObject<Env = unknown>
-    implements Rpc.DurableObjectBranded
-  {
+    implements Rpc.DurableObjectBranded {
     [Rpc.__DURABLE_OBJECT_BRAND]: never;
 
     protected ctx: DurableObjectState;


### PR DESCRIPTION
Fixes #1996

Previously, the RPC types used `unique symbol` to enforce nominal typing rather than structural typing for Durable Object and Service binding entrypoints. While this works, it's slightly _too_ strict. It meant that different versions of `DurableObject` and `WorkerEntrypoint` were not compatible (e.g. across workers-types entrypoints, and across ambient and exported types. This PR relaxes that constraint to use a well-known string instead, which will preserve nominal typing unless someone goes out of their way to add a specific property.

cc @Skye-31 