### PR TITLE
Improve new IoOwn logging

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -956,7 +956,7 @@ void IoContext::requireCurrent() {
   KJ_REQUIRE(threadLocalRequest == this, "request is not current in this thread");
 }
 
-void IoContext::checkFarGet(const DeleteQueue* expectedQueue, kj::StringPtr type) {
+void IoContext::checkFarGet(const DeleteQueue* expectedQueue, const std::type_info& type) {
   KJ_ASSERT(expectedQueue);
   requireCurrent();
 
@@ -1273,9 +1273,9 @@ void IoContext::requireCurrentOrThrowJs(WeakRef& weak) {
   throwNotCurrentJsError();
 }
 
-void IoContext::throwNotCurrentJsError(kj::Maybe<kj::StringPtr> maybeType) {
-  auto type = maybeType.map([](kj::StringPtr type) {
-    return kj::str(" (I/O type: ", type, ")");
+void IoContext::throwNotCurrentJsError(kj::Maybe<const std::type_info&> maybeType) {
+  auto type = maybeType.map([](const std::type_info& type) {
+    return kj::str(" (I/O type: ", jsg::typeName(type), ")");
   }).orDefault(kj::String());
 
   if (threadLocalRequest != nullptr && threadLocalRequest->actor != kj::none) {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -370,7 +370,8 @@ public:
   static void requireCurrentOrThrowJs(WeakRef& weak);
 
   // Just throw the error that requireCurrentOrThrowJs() would throw on failure.
-  [[noreturn]] static void throwNotCurrentJsError(kj::Maybe<kj::StringPtr> maybeType = kj::none);
+  [[noreturn]] static void throwNotCurrentJsError(
+      kj::Maybe<const std::type_info&> maybeType = kj::none);
 
   // -----------------------------------------------------------------
   // Task scheduling and object storage
@@ -811,7 +812,7 @@ private:
 
   void taskFailed(kj::Exception&& exception) override;
   void requireCurrent();
-  void checkFarGet(const DeleteQueue* expectedQueue, kj::StringPtr type);
+  void checkFarGet(const DeleteQueue* expectedQueue, const std::type_info& type);
 
   kj::Maybe<jsg::JsRef<jsg::JsObject>> promiseContextTag;
 

--- a/src/workerd/io/io-own.c++
+++ b/src/workerd/io/io-own.c++
@@ -32,7 +32,7 @@ void DeleteQueue::scheduleDeletion(OwnedObject* object) const {
   }
 }
 
-void DeleteQueue::checkFarGet(const DeleteQueue* deleteQueue, kj::StringPtr type) {
+void DeleteQueue::checkFarGet(const DeleteQueue* deleteQueue, const std::type_info& type) {
   IoContext::current().checkFarGet(deleteQueue, type);
 }
 

--- a/src/workerd/io/io-own.h
+++ b/src/workerd/io/io-own.h
@@ -120,7 +120,7 @@ public:
   // Implements the corresponding methods of IoContext and ActorContext.
   template <typename T> IoOwn<T> addObject(kj::Own<T> obj, OwnedObjectList& ownedObjects);
 
-  static void checkFarGet(const DeleteQueue* deleteQueue, kj::StringPtr type);
+  static void checkFarGet(const DeleteQueue* deleteQueue, const std::type_info& type);
 };
 
 template <typename T>
@@ -288,15 +288,13 @@ IoPtr<T>& IoPtr<T>::operator=(decltype(nullptr)) {
 
 template <typename T>
 inline T* IoOwn<T>::operator->() {
-  auto type = jsg::typeName(typeid(T));
-  DeleteQueue::checkFarGet(deleteQueue, type);
+  DeleteQueue::checkFarGet(deleteQueue, typeid(T));
   return item->ptr;
 }
 
 template <typename T>
 inline IoOwn<T>::operator kj::Own<T>() && {
-  auto type = jsg::typeName(typeid(T));
-  DeleteQueue::checkFarGet(deleteQueue, type);
+  DeleteQueue::checkFarGet(deleteQueue, typeid(T));
   auto result = kj::mv(item->ptr);
   OwnedObjectList::unlink(*item);
   item = nullptr;
@@ -306,8 +304,7 @@ inline IoOwn<T>::operator kj::Own<T>() && {
 
 template <typename T>
 inline T* IoPtr<T>::operator->() {
-  auto type = jsg::typeName(typeid(T));
-  DeleteQueue::checkFarGet(deleteQueue, type);
+  DeleteQueue::checkFarGet(deleteQueue, typeid(T));
   return ptr;
 }
 


### PR DESCRIPTION
Avoid allocating the new string on every dereference. The previous iteration was done pretty quickly just to get something we can test with. I imagine we'll keep it so let's make it more performant.