### PR TITLE
Fix returning interface types from rpc methods

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -111,6 +111,7 @@ declare namespace Rpc {
   type Result<R> =
     R extends Stubable ? Promise<Stub<R>> & Provider<R>
     : R extends Serializable ? Promise<Stubify<R> & MaybeDisposable<R>> & MaybeProvider<R>
+    : R extends { [K in keyof R]: Serializable } ? Promise<Stubify<R> & MaybeDisposable<R>> & MaybeProvider<R>
     : never;
 
   // Type for method or property on an RPC interface.

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -53,9 +53,7 @@ declare namespace Rpc {
     | ReadonlyArray<Serializable>
     | {
         [K in keyof T]: K extends number | string
-          ? T[K] extends Function
-            ? never
-            : Serializable<T[K]>
+          ? Serializable<T[K]>
           : never;
       }
     // Special types

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -48,13 +48,11 @@ declare namespace Rpc {
     | Error
     | RegExp
     // Structured cloneable composites
-    | Map<Serializable, Serializable>
-    | Set<Serializable>
-    | ReadonlyArray<Serializable>
+    | Map<Serializable<T>, Serializable<T>>
+    | Set<Serializable<T>>
+    | ReadonlyArray<Serializable<T>>
     | {
-        [K in keyof T]: K extends number | string
-          ? Serializable<T[K]>
-          : never;
+        [K in keyof T]: K extends number | string ? Serializable<T[K]> : never;
       }
     // Special types
     | ReadableStream<Uint8Array>

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -10,7 +10,40 @@ import {
 } from "cloudflare:workers";
 import { expectTypeOf } from "expect-type";
 
-class BoringClass {}
+type TestType = {
+  fieldString: string;
+  fieldCallback: (p: string) => number;
+  fieldBasicMap: Map<string, number>;
+  fieldComplexMap: Map<string, {
+    fieldString: string;
+    fieldCallback: (p: string) => number;
+  }>;
+  fieldSet: Set<string>;
+  fieldSubLevel: {
+    fieldString: string;
+    fieldCallback: (p: string) => number;
+  };
+};
+
+interface ABasicInterface {
+  fieldString: string;
+  fieldCallback: (p: string) => number;
+};
+
+interface TestInterface extends ABasicInterface {
+  fieldBasicMap: Map<string, number>;
+  fieldComplexMap: Map<string, ABasicInterface>;
+  fieldSet: Set<string>;
+  fieldSubLevelInline: {
+    fieldString: string;
+    fieldCallback: (p: string) => number;
+  };
+  fieldSubLevelInterface: ABasicInterface;
+};
+
+interface NonSerializableInterface {
+  field: ReadableStream<string>;
+};
 
 class TestCounter extends RpcTarget {
   constructor(private val = 0) {
@@ -181,14 +214,52 @@ class TestEntrypoint extends WorkerEntrypoint<Env> {
       Object: { a: { b: new TestCounter() } },
     };
   }
-  get nonSerializable1() {
-    return new BoringClass();
+
+  methodReturnsTypeObject(): TestType {
+    return {
+      fieldString: "a",
+      fieldCallback: (p: string) => 1,
+      fieldBasicMap: new Map([["b", 2]]),
+      fieldComplexMap: new Map([["c", {
+        fieldString: "d",
+        fieldCallback: (p: string) => 3,
+      }]]),
+      fieldSet: new Set(["e"]),
+      fieldSubLevel: {
+        fieldString: "f",
+        fieldCallback: (p: string) => 4,
+      },
+    };
+  }
+  methodReturnsInterfaceObject(): TestInterface {
+    return {
+      fieldString: "a",
+      fieldCallback: (p: string) => 1,
+      fieldBasicMap: new Map([["b", 2]]),
+      fieldComplexMap: new Map([["c", {
+        fieldString: "d",
+        fieldCallback: (p: string) => 3,
+      }]]),
+      fieldSet: new Set(["e"]),
+      fieldSubLevelInline: {
+        fieldString: "f",
+        fieldCallback: (p: string) => 4,
+      },
+      fieldSubLevelInterface: {
+        fieldString: "e",
+        fieldCallback: (p: string) => 5,
+      },
+    };
+  }
+
+  nonSerializable1() {
+    return new ReadableStream<string>();
   }
   nonSerializable2() {
-    return { a: new BoringClass() };
+    return { field: new ReadableStream<string>() };
   }
-  async nonSerializable3() {
-    return new ReadableStream<string>();
+  nonSerializable3(): NonSerializableInterface {
+    return { field: new ReadableStream<string>() };
   }
 
   [Symbol.dispose]() {
@@ -441,13 +512,50 @@ export default <ExportedHandler<Env>>{
 
       expectTypeOf(s.everySerializable).not.toBeNever();
 
-      // These are _not_ serializable, but will nevertheless not be typed as `never`. This
-      // is because TS can't distinguish between a class instance and an interface. At runtime,
-      // using an RPC method like this will throw:
-      //   "Could not serialize object. This type does not support serialization.""
-      expectTypeOf(s.nonSerializable1).not.toBeNever();
-      expectTypeOf(s.nonSerializable2).returns.not.toBeNever();
+      // Verify serializable composite objects defined with "type" keyword
+      const oType = await s.methodReturnsTypeObject();
+      expectTypeOf(oType).not.toBeNever();
+      expectTypeOf(oType.fieldString).toEqualTypeOf<string>();
+      expectTypeOf(oType.fieldCallback).toEqualTypeOf<
+        RpcStub<(p: string) => number>
+      >(); // stubified
+      expectTypeOf(oType.fieldBasicMap).toEqualTypeOf<Map<string, number>>();
+      expectTypeOf(oType.fieldComplexMap).toEqualTypeOf<Map<string, {
+        fieldString: string;
+        fieldCallback: RpcStub<(p: string) => number>; // stubified
+      }>>();
+      expectTypeOf(oType.fieldSet).toEqualTypeOf<Set<string>>();
+      expectTypeOf(oType.fieldSubLevel.fieldString).toEqualTypeOf<string>();
+      expectTypeOf(oType.fieldSubLevel.fieldCallback).toEqualTypeOf<
+        RpcStub<(p: string) => number>
+      >(); // stubified
 
+      // Verify serializable composite objects defined with "inteface" keyword
+      const oInterface = await s.methodReturnsInterfaceObject();
+      expectTypeOf(oInterface).not.toBeNever();
+      expectTypeOf(oInterface.fieldString).toEqualTypeOf<string>();
+      expectTypeOf(oInterface.fieldCallback).toEqualTypeOf<
+        RpcStub<(p: string) => number>
+      >(); // stubified
+      expectTypeOf(oInterface.fieldBasicMap).toEqualTypeOf<Map<string, number>>();
+      expectTypeOf(oInterface.fieldComplexMap).toEqualTypeOf<Map<string, {
+        fieldString: string;
+        fieldCallback: RpcStub<(p: string) => number>; // stubified
+      }>>();
+      expectTypeOf(oInterface.fieldSet).toEqualTypeOf<Set<string>>();
+      expectTypeOf(oInterface.fieldSubLevelInline.fieldString).toEqualTypeOf<string>();
+      expectTypeOf(oInterface.fieldSubLevelInline.fieldCallback).toEqualTypeOf<
+        RpcStub<(p: string) => number>
+      >(); // stubified
+      expectTypeOf(oInterface.fieldSubLevelInterface.fieldString).toEqualTypeOf<string>();
+      expectTypeOf(oInterface.fieldSubLevelInterface.fieldCallback).toEqualTypeOf<
+        RpcStub<(p: string) => number>
+      >(); // stubified
+
+      expectTypeOf(s.nonSerializable1).returns.toBeNever();
+      // Note: Since one of the object's members is non-serializable,
+      //   the entire object is resolved as 'never'.
+      expectTypeOf(s.nonSerializable2).returns.toBeNever();
       expectTypeOf(s.nonSerializable3).returns.toBeNever();
 
       // Verify serializable objects without any stubs are still disposable

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -440,8 +440,14 @@ export default <ExportedHandler<Env>>{
       expectTypeOf(s.objectProperty.z(false)).toEqualTypeOf<Promise<number>>(); // (pipelining)
 
       expectTypeOf(s.everySerializable).not.toBeNever();
-      expectTypeOf(s.nonSerializable1).toBeNever();
-      expectTypeOf(s.nonSerializable2).returns.toBeNever();
+
+      // These are _not_ serializable, but will nevertheless not be typed as `never`. This
+      // is because TS can't distinguish between a class instance and an interface. At runtime,
+      // using an RPC method like this will throw:
+      //   "Could not serialize object. This type does not support serialization.""
+      expectTypeOf(s.nonSerializable1).not.toBeNever();
+      expectTypeOf(s.nonSerializable2).returns.not.toBeNever();
+
       expectTypeOf(s.nonSerializable3).returns.toBeNever();
 
       // Verify serializable objects without any stubs are still disposable


### PR DESCRIPTION
Fixes #2003

`interface` does not extend `Serializable` but `type` does.
```typescript
interface R1 {
  field: string;
}
type R2 = {
  field: string;
}
```
```R1 extends Serializable``` fails.
```R2 extends Serializable``` ok.

After the patch both `interface` and `type` match `Serializable`.

This fix is a starting point for the issue, there may be a better solution.