### PR TITLE
Fix AI binding get logs encoding

### DIFF
--- a/src/cloudflare/internal/ai-api.ts
+++ b/src/cloudflare/internal/ai-api.ts
@@ -87,7 +87,7 @@ export class Ai {
         try {
           const logHeader = res.headers.get("cf-ai-logs")
           if (logHeader) {
-            parsedLogs = (JSON.parse(atob(logHeader)) as string[]);
+            parsedLogs = (JSON.parse(decodeURIComponent(atob(logHeader))) as string[]);
           }
         } catch {
           /* empty */

--- a/src/cloudflare/internal/test/ai/ai-mock.js
+++ b/src/cloudflare/internal/test/ai/ai-mock.js
@@ -10,7 +10,7 @@ export default {
 
         const respHeaders = {
             'cf-ai-req-id': '3a1983d7-1ddd-453a-ab75-c4358c91b582',
-            'cf-ai-logs': (data.options.debug) ? btoa(JSON.stringify(["Model started", "Model run successfully"])) : null
+            'cf-ai-logs': (data.options.debug) ? btoa(encodeURIComponent(JSON.stringify(["Model started", "Model run successfully"]))) : null
         }
 
         if (modelName === 'blobResponseModel') {


### PR DESCRIPTION
The logs returned in AI binding are also `encodeURIComponent` from the server, and the reverse `decodeURIComponent` was missing