### PR TITLE
Deprecate getLogs method from Ai binding

### DIFF
--- a/src/cloudflare/internal/ai-api.ts
+++ b/src/cloudflare/internal/ai-api.ts
@@ -31,7 +31,6 @@ export class Ai {
   private readonly fetcher: Fetcher
 
   private options: AiOptions = {};
-  private logs: Array<string> = [];
   public lastRequestId: string | null = null;
 
   public constructor(fetcher: Fetcher) {
@@ -80,22 +79,8 @@ export class Ai {
       }
 
       return res.body;
+
     } else {
-      // load logs
-      if (this.options.debug) {
-        let parsedLogs: string[] = [];
-        try {
-          const logHeader = res.headers.get("cf-ai-logs")
-          if (logHeader) {
-            parsedLogs = (JSON.parse(atob(logHeader)) as string[]);
-          }
-        } catch {
-          /* empty */
-        }
-
-        this.logs = parsedLogs;
-      }
-
       if (!res.ok || !res.body) {
         throw new InferenceUpstreamError(await res.text());
       }
@@ -110,9 +95,12 @@ export class Ai {
     }
   }
 
-  public getLogs(): Array<string> {
-    return this.logs;
-  }
+    /*
+     * @deprecated this method is deprecated, do not use this
+     */
+    public getLogs(): Array<string> {
+      return []
+    }
 }
 
 export default function makeBinding(env: { fetcher: Fetcher }): Ai {

--- a/src/cloudflare/internal/test/ai/ai-api-test.js
+++ b/src/cloudflare/internal/test/ai/ai-api-test.js
@@ -11,9 +11,6 @@ export const tests = {
             const resp = await env.ai.run('testModel', {prompt: 'test'})
             assert.deepStrictEqual(resp, { response: 'model response' });
 
-            // Test logs is empty
-            assert.deepStrictEqual(env.ai.getLogs(), []);
-
             // Test request id is present
             assert.deepStrictEqual(env.ai.lastRequestId, '3a1983d7-1ddd-453a-ab75-c4358c91b582');
         }
@@ -22,12 +19,6 @@ export const tests = {
             // Test ai blob model run response is a blob/stream
             const resp = await env.ai.run('blobResponseModel', {prompt: 'test'})
             assert.deepStrictEqual(resp instanceof ReadableStream, true);
-        }
-
-        {
-            // Test logs
-            await env.ai.run('testModel', {prompt: 'test'}, {debug: true})
-            assert.deepStrictEqual(env.ai.getLogs(),  [ 'Model started', 'Model run successfully' ]);
         }
 
         {

--- a/src/cloudflare/internal/test/ai/ai-api-test.py
+++ b/src/cloudflare/internal/test/ai/ai-api-test.py
@@ -1,13 +1,10 @@
-# Copyright (c) 2023 Cloudflare, Inc.
+# Copyright (c) 2024 Cloudflare, Inc.
 # Licensed under the Apache 2.0 license found in the LICENSE file or at:
 #     https://opensource.org/licenses/Apache-2.0
 
 async def test(context, env):
   resp = await env.ai.run('testModel', {"prompt": 'test'})
   assert resp.response == "model response"
-
-  # Test logs is empty
-  assert len(env.ai.getLogs()) == 0
 
   # Test request id is present
   assert env.ai.lastRequestId == '3a1983d7-1ddd-453a-ab75-c4358c91b582'

--- a/src/cloudflare/internal/test/ai/ai-mock.js
+++ b/src/cloudflare/internal/test/ai/ai-mock.js
@@ -10,7 +10,6 @@ export default {
 
         const respHeaders = {
             'cf-ai-req-id': '3a1983d7-1ddd-453a-ab75-c4358c91b582',
-            'cf-ai-logs': (data.options.debug) ? btoa(JSON.stringify(["Model started", "Model run successfully"])) : null
         }
 
         if (modelName === 'blobResponseModel') {


### PR DESCRIPTION
This was a testing method added to debug the Ai binding, and is now being deprecated.
It no longer returns any data from the server