### PR TITLE
Have internal streams return empty Uint8Array on end of byob stream

### DIFF
--- a/src/workerd/api/tests/streams-test.js
+++ b/src/workerd/api/tests/streams-test.js
@@ -427,6 +427,27 @@ export const abortWriterAfterGc = {
   }
 };
 
+export const finalReadOnInternalStreamReturnsBuffer = {
+  async test() {
+    const { readable, writable } = new IdentityTransformStream();
+    const writer = writable.getWriter();
+    await writer.close();
+
+    const reader = readable.getReader({ mode: 'byob' });
+    let result = await reader.read(new Uint8Array(10));
+    strictEqual(result.done, true);
+    ok(result.value instanceof Uint8Array);
+    strictEqual(result.value.byteLength, 0);
+    strictEqual(result.value.buffer.byteLength, 10);
+
+    result = await reader.read(new Uint8Array(10));
+    strictEqual(result.done, true);
+    ok(result.value instanceof Uint8Array);
+    strictEqual(result.value.byteLength, 0);
+    strictEqual(result.value.buffer.byteLength, 10);
+  }
+};
+
 export default {
   async fetch(request, env) {
     strictEqual(request.headers.get('content-length'), '10');

--- a/src/workerd/api/tests/streams-test.wd-test
+++ b/src/workerd/api/tests/streams-test.wd-test
@@ -9,7 +9,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "streams-test.js")
         ],
         compatibilityDate = "2023-01-15",
-        compatibilityFlags = ["nodejs_compat"],
+        compatibilityFlags = ["nodejs_compat", "internal_stream_byob_return_view"],
         bindings = [
           (name = "subrequest", service = "streams-test")
         ]

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -415,4 +415,15 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # type of Durable Object stubs -- support RPC. If so, this type will have a wildcard method, so
   # it will appear that all possible property names are present on any fetcher instance. This could
   # break code that tries to infer types based on the presence or absence of methods.
+
+  internalStreamByobReturn @47 :Bool
+      $compatEnableFlag("internal_stream_byob_return_view")
+      $compatDisableFlag("internal_stream_byob_return_undefined")
+      $compatEnableDate("2024-05-13");
+  # Sadly, the original implementation of ReadableStream (now called "internal" streams), did not
+  # properly implement the result of ReadableStreamBYOBReader's read method. When done = true,
+  # per the spec, the result `value` must be an empty ArrayBufferView whose underlying ArrayBuffer
+  # is the same as the one passed to the read method. Our original implementation returned
+  # undefined instead. This flag changes the behavior to match the spec and to match the behavior
+  # implemented by the JS-backed ReadableStream implementation.
 }


### PR DESCRIPTION
Per the spec, a BYOB read is supposed to return an empty ArrayBufferView when the stream is closed (done = true) in order to allow the code reading to retake ownership of the underlying buffer. This change makes the internal streams implementation return an empty Uint8Array in this case, matching the behavior of the JS-backed standard streams impl.

~~It's unlikely but this may be considered a breaking change if anyone has code that depends on the fact that `value` would be `undefined` if `done === true` when using the old streams implementation. We need to decide if this case needs a compat flag or not. I'd prefer not to have to introduce Yet Another One.~~ Updated to add the compat flag :-(