### PR TITLE
Hold strong refs in certain streams Writer/Reader methods

### DIFF
--- a/src/workerd/api/tests/streams-test.js
+++ b/src/workerd/api/tests/streams-test.js
@@ -414,6 +414,19 @@ export const readableStreamFromNoopAsyncGen = {
   }
 };
 
+export const abortWriterAfterGc = {
+  async test() {
+    function getWriter() {
+      const { writable } = new IdentityTransformStream();
+      return writable.getWriter();
+    }
+
+    const writer = getWriter();
+    gc();
+    await writer.abort();
+  }
+};
+
 export default {
   async fetch(request, env) {
     strictEqual(request.headers.get('content-length'), '10');


### PR DESCRIPTION
In some edge cases, if the Writer/Reader is the only thing remaining holding a strong reference to a WritableStream or ReadableStream, the calls to `close()`, `abort()`, `cancel()`, etc can cause the Writer/Reader to drop it's strong reference in mid operation, leading to issues. Let's defensively hold an additional strong reference while the operations are pending