### PR TITLE
Convert DigestStream into JS-backed stream

### DIFF
--- a/src/workerd/api/tests/crypto-streams-test.js
+++ b/src/workerd/api/tests/crypto-streams-test.js
@@ -22,6 +22,7 @@ export const digeststream = {
 
       const digest = new Uint8Array(await stream.digest);
 
+      strictEqual(stream.bytesWritten, 10n);
       deepStrictEqual(digest, check);
     }
 
@@ -69,6 +70,58 @@ export const digeststream = {
       deepStrictEqual(digest, check);
     }
 
+    {
+      const check =
+        new Uint8Array([93, 65, 64, 42, 188, 75, 42, 118, 185, 113, 157, 145, 16, 23, 197, 146]);
+      const digestStream = new crypto.DigestStream('md5');
+      const writer = digestStream.getWriter();
+      await writer.write('hello');
+      await writer.close();
+      const digest = new Uint8Array(await digestStream.digest);
+      deepStrictEqual(digest, check);
+    }
+
+    {
+      const check = new Uint8Array([70,
+        54, 153, 61, 62, 29, 164, 233, 214, 184, 248, 123, 121, 232, 247, 198, 208, 24,
+        88, 13, 82, 102, 25, 80, 234, 188, 56, 69, 197, 137, 122, 77,
+      ]);
+      const digestStream = new crypto.DigestStream('SHA-256');
+      const writer = digestStream.getWriter();
+      await writer.write(new Uint32Array([1,2,3]));
+      await writer.close();
+      const digest = new Uint8Array(await digestStream.digest);
+      deepStrictEqual(digest, check);
+    }
+
+    {
+      const check = new Uint8Array([70,
+        54, 153, 61, 62, 29, 164, 233, 214, 184, 248, 123, 121, 232, 247, 198, 208, 24,
+        88, 13, 82, 102, 25, 80, 234, 188, 56, 69, 197, 137, 122, 77,
+      ]);
+      const digestStream = new crypto.DigestStream('SHA-256');
+      const writer = digestStream.getWriter();
+      // Ensures that byteOffset is correctly handled.
+      await writer.write(new Uint32Array([0,1,2,3]).subarray(1));
+      await writer.close();
+      const digest = new Uint8Array(await digestStream.digest);
+      deepStrictEqual(digest, check);
+    }
+
+    {
+      const digestStream = new crypto.DigestStream('md5');
+      const writer = digestStream.getWriter();
+
+      try {
+        await writer.write(123);
+        throw new Error('should have failed');
+      } catch (err) {
+        strictEqual(err.message,
+              'DigestStream is a byte stream but received an object ' +
+              'of non-ArrayBuffer/ArrayBufferView/string type on its writable side.');
+      }
+    }
+
     // Creating and not using a digest stream doesn't crash
     new crypto.DigestStream('SHA-1');
   }
@@ -82,6 +135,26 @@ export const digestStreamNoEnd = {
 
     writer.write(enc.encode('hello'));
     writer.write(enc.encode('there'));
-    // stream never ends, should not crash when IoContext is torn down.
+    // stream never ends, should not crash.
+  }
+};
+
+export const digestStreamDisposable = {
+  async test() {
+    const enc = new TextEncoder();
+    const stream = new crypto.DigestStream('md5');
+    stream[Symbol.dispose]();
+
+    const writer = stream.getWriter();
+
+    try {
+      await writer.write(enc.encode('hello'));
+      throw new Error('should have failed');
+    } catch (err) {
+      strictEqual(err.message, 'The DigestStream was disposed.');
+    }
+
+    // Calling dispose again should have no impact
+    stream[Symbol.dispose]();
   }
 };


### PR DESCRIPTION
This is one of a series of PRs intended to simplify and improve the implementation/safety/performance/design of various streams bits in the runtime. This one starts with refactoring `DigestStream`.
 
The original implementation of `DigestStream` used a `WritableStreamSink` and the old "internal" streams implementation. This is unnecessary and makes the implementation less efficient than it otherwise could be due to the operations having to bounce between the kj event loop and the JS isolate lock. There's just nothing in the implementation of `DigestStream` that requires the bound through the kj event loop and the original implementation was more an artifact of what was possible at the time it was written.

This PR converts `DigestStream` into a JS-backed stream where the operations occur within the isolate lock. Also avoids the need for IoContext addObject / IoOwn dereferencing. Implementation should be generally safer and more efficient.

Also...

* allow `DigestStream` to accept string inputs. If a string is written to a `DigestStream`, it will be converted to UTF-8 bytes and included in the digest.
* allow `DigestStream` to support `Symbol.dispose`.
* adds a new `bytesWritten` property to `DigestStream` to allow for checking to make sure the digest received the expected number of bytes.
* Improves tests a bit

Internal CI is green.