### PR TITLE
Set default getAlarmLimit() value to 15 minutes

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2179,7 +2179,7 @@ private:
   void newAnalyticsEngineRequest() override {}
   kj::Promise<void> limitDrain() override { return kj::NEVER_DONE; }
   kj::Promise<void> limitScheduled() override { return kj::NEVER_DONE; }
-  kj::Duration getAlarmLimit() override { return 0 * kj::MILLISECONDS; }
+  kj::Duration getAlarmLimit() override { return 15 * kj::MINUTES; }
   size_t getBufferingLimit() override { return kj::maxValue; }
   kj::Maybe<EventOutcome> getLimitsExceeded() override { return kj::none; }
   kj::Promise<void> onLimitsExceeded() override { return kj::NEVER_DONE; }

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -132,7 +132,7 @@ struct MockLimitEnforcer final: public LimitEnforcer {
   void newAnalyticsEngineRequest() override {}
   kj::Promise<void> limitDrain() override { return kj::NEVER_DONE; }
   kj::Promise<void> limitScheduled() override { return kj::NEVER_DONE; }
-  kj::Duration getAlarmLimit() override { return 0 * kj::MILLISECONDS; }
+  kj::Duration getAlarmLimit() override { return 15 * kj::MINUTES; }
   size_t getBufferingLimit() override { return kj::maxValue; }
   kj::Maybe<EventOutcome> getLimitsExceeded() override { return kj::none; }
   kj::Promise<void> onLimitsExceeded() override { return kj::NEVER_DONE; }


### PR DESCRIPTION
Set default getAlarmLimit() value to 15 minutes to avoid hitting 'invalid alarm timeout value' warning in workerd.