### PR TITLE
Add SqliteDatabase::executeWithRegulator

### DIFF
--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -465,6 +465,17 @@ kj::StringPtr SqliteDatabase::ingestSql(Regulator& regulator, kj::StringPtr sqlC
   return sqlCode;
 }
 
+void SqliteDatabase::executeWithRegulator(Regulator& regulator, kj::FunctionParam<void()> func) {
+  // currentRegulator would only be set if we're running this method while running something else
+  // with a regulator.  I'm not sure what the ramifications are, so for now, we'll just assume that
+  // we can only call executeWithRegulator when no regulator is currently set.
+  KJ_REQUIRE(currentRegulator == kj::none);
+
+  currentRegulator = regulator;
+  KJ_DEFER(currentRegulator = kj::none);
+  func();
+}
+
 bool SqliteDatabase::isAuthorized(int actionCode,
     kj::Maybe<kj::StringPtr> param1, kj::Maybe<kj::StringPtr> param2,
     kj::Maybe<kj::StringPtr> dbName, kj::Maybe<kj::StringPtr> triggerName) {

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -94,6 +94,9 @@ public:
   // that was not processed. This is used for streaming SQL ingestion.
   kj::StringPtr ingestSql(Regulator& regulator, kj::StringPtr sqlCode);
 
+  // Execute a function with the given regulator.
+  void executeWithRegulator(Regulator& regulator, kj::FunctionParam<void()> func);
+
 private:
   sqlite3* db;
 


### PR DESCRIPTION
There are `sqlite3` API functions that may prepare and execute their own internal statements.  We need to call those functions with a regulator or we’ll summarily reject them.  Adding a method to do this seemed like a clean way of handling these cases.