### PR TITLE
add extra logging for makeTimeoutPromise

### DIFF
--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -310,7 +310,7 @@ private:
       auto p = reinterpret_cast<ActorCache*>(pointer);
       KJ_IF_SOME(d, p->currentAlarmTime.tryGet<DeferredAlarmDelete>()) {
         d.status = DeferredAlarmDelete::Status::READY;
-        p->ensureFlushScheduled(WriteOptions { .noCache = d.noCache });
+        p->ensureFlushScheduled(WriteOptions { .noCache = d.noCache }, "alarm disposer"_kjc);
       }
     }
   };
@@ -702,7 +702,7 @@ private:
   kj::Promise<kj::Maybe<Value>> getImpl(kj::Own<Entry> entry, ReadOptions options);
 
   // Ensure that we will flush dirty entries soon.
-  void ensureFlushScheduled(const WriteOptions& options);
+  void ensureFlushScheduled(const WriteOptions& options, kj::LiteralStringConst operationInfo);
 
   // Schedule a read RPC. The given function will be invoked and provided with an
   // ActorStorage::Operations::Client on which the read operation should be performed. The function

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -107,7 +107,7 @@ kj::Maybe<kj::Promise<void>> ActorSqlite::ExplicitTxn::commit() {
     // We committed the root transaction, so it's time to signal any replication layer and lock
     // the output gate in the meantime.
     actorSqlite.commitTasks.add(
-        actorSqlite.outputGate.lockWhile(actorSqlite.commitCallback()));
+        actorSqlite.outputGate.lockWhile(actorSqlite.commitCallback(), "explicit txn commit"_kjc));
   }
 
   // No backpressure for SQLite.
@@ -158,7 +158,7 @@ void ActorSqlite::onWrite() {
       { auto drop = kj::mv(txn); }
 
       return commitCallback();
-    })));
+    }), "committing write"_kjc));
   }
 }
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2951,12 +2951,13 @@ struct Worker::Actor::Impl {
     void inputGateWaiterRemoved() override { metrics.inputGateWaiterRemoved(); }
     // Implements InputGate::Hooks.
 
-    kj::Promise<void> makeTimeoutPromise() override {
+    kj::Promise<void> makeTimeoutPromise(kj::LiteralStringConst operationInfo) override {
       // This really only protects against total hangs. Lowering the timeout drastically is risky,
       // since low timeouts can spuriously fire when under heavy CPU load, failing requests that
       // would otherwise succeed.
       auto timeout = 30 * kj::SECONDS;
       co_await timerChannel.afterLimitTimeout(timeout);
+      KJ_LOG(ERROR, "Durable Object storage operation exceeded timeout", operationInfo);
       kj::throwFatalException(KJ_EXCEPTION(FAILED,
             "broken.outputGateBroken; jsg.Error: Durable Object storage operation exceeded "
             "timeout which caused object to be reset."));


### PR DESCRIPTION
This log adds context on what the output gate was locked on.