### PR TITLE
Return row counts for SQL ingestion (storage.sql.ingest()).

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -105,10 +105,10 @@ async function test(storage) {
     const inputBytes = new TextEncoder().encode(INSERT_36_ROWS)
     const decoder = new TextDecoder()
 
-
     // Use a chunk size 1, 3, 9, 27, 81, ... bytes
     for (let length = 1; length < inputBytes.length; length = length * 3) {
       let totalRowsWritten = 0;
+      let totalSqlStatements = 0;
       let buffer = ''
       for (let offset = 0; offset < inputBytes.length; offset += length) {
         // Simulate a single "chunk" arriving
@@ -121,6 +121,7 @@ async function test(storage) {
         let result = sql.ingest(buffer);
         buffer = result.remainder;
         totalRowsWritten += result.rowsWritten;
+        totalSqlStatements += result.statementCount;
 
         // Simulate awaiting next chunk
         await scheduler.wait(1)
@@ -146,6 +147,7 @@ async function test(storage) {
 
       // Verify that all 36 rows we inserted were accounted for.
       assert.equal(totalRowsWritten, 36);
+      assert.equal(totalSqlStatements, 6);
 
       sql.exec(`DELETE FROM streaming`)
       await scheduler.wait(1)

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -22,7 +22,7 @@ jsg::Ref<SqlStorage::Cursor> SqlStorage::exec(jsg::Lock& js, kj::String querySql
 jsg::Ref<SqlStorage::IngestResult> SqlStorage::ingest(jsg::Lock& js, kj::String querySql) {
   SqliteDatabase::Regulator& regulator = *this;
   auto result = sqlite->ingestSql(regulator, querySql);
-  return jsg::alloc<IngestResult>(kj::str(result.remainder), result.rowsRead, result.rowsWritten);
+  return jsg::alloc<IngestResult>(kj::str(result.remainder), result.rowsRead, result.rowsWritten, result.statementCount);
 }
 
 jsg::Ref<SqlStorage::Statement> SqlStorage::prepare(jsg::Lock& js, kj::String query) {
@@ -296,7 +296,8 @@ void SqlStorage::visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
   }
 }
 
-SqlStorage::IngestResult::IngestResult(kj::String remainder, uint64_t rowsRead, uint64_t rowsWritten) : remainder(kj::mv(remainder)), rowsRead(rowsRead), rowsWritten(rowsWritten) {}
+SqlStorage::IngestResult::IngestResult(kj::String remainder, uint64_t rowsRead, uint64_t rowsWritten, uint64_t statementCount) :
+  remainder(kj::mv(remainder)), rowsRead(rowsRead), rowsWritten(rowsWritten), statementCount(statementCount) {}
 
 kj::StringPtr SqlStorage::IngestResult::getRemainder() { return remainder; }
 
@@ -304,5 +305,6 @@ double SqlStorage::IngestResult::getRowsRead() { return rowsRead; }
 
 double SqlStorage::IngestResult::getRowsWritten() { return rowsWritten; }
 
+double SqlStorage::IngestResult::getStatementCount() { return statementCount; }
 
 }  // namespace workerd::api

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -19,10 +19,10 @@ jsg::Ref<SqlStorage::Cursor> SqlStorage::exec(jsg::Lock& js, kj::String querySql
   return jsg::alloc<Cursor>(*sqlite, regulator, querySql, kj::mv(bindings));
 }
 
-jsg::Ref<SqlStorage::IngestResult> SqlStorage::ingest(jsg::Lock& js, kj::String querySql) {
+SqlStorage::IngestResult SqlStorage::ingest(jsg::Lock& js, kj::String querySql) {
   SqliteDatabase::Regulator& regulator = *this;
   auto result = sqlite->ingestSql(regulator, querySql);
-  return jsg::alloc<IngestResult>(kj::str(result.remainder), result.rowsRead, result.rowsWritten, result.statementCount);
+  return IngestResult(kj::str(result.remainder), result.rowsRead, result.rowsWritten, result.statementCount);
 }
 
 jsg::Ref<SqlStorage::Statement> SqlStorage::prepare(jsg::Lock& js, kj::String query) {
@@ -295,16 +295,5 @@ void SqlStorage::visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
         sizeof(IoPtr<SqliteDatabase::Statement>));
   }
 }
-
-SqlStorage::IngestResult::IngestResult(kj::String remainder, uint64_t rowsRead, uint64_t rowsWritten, uint64_t statementCount) :
-  remainder(kj::mv(remainder)), rowsRead(rowsRead), rowsWritten(rowsWritten), statementCount(statementCount) {}
-
-kj::StringPtr SqlStorage::IngestResult::getRemainder() { return remainder; }
-
-double SqlStorage::IngestResult::getRowsRead() { return rowsRead; }
-
-double SqlStorage::IngestResult::getRowsWritten() { return rowsWritten; }
-
-double SqlStorage::IngestResult::getStatementCount() { return statementCount; }
 
 }  // namespace workerd::api

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -22,9 +22,10 @@ public:
 
   class Cursor;
   class Statement;
+  class IngestResult;
 
   jsg::Ref<Cursor> exec(jsg::Lock& js, kj::String query, jsg::Arguments<BindingValue> bindings);
-  kj::String ingest(jsg::Lock& js, kj::String query);
+  jsg::Ref<IngestResult> ingest(jsg::Lock& js, kj::String query);
 
   jsg::Ref<Statement> prepare(jsg::Lock& js, kj::String query);
 
@@ -249,10 +250,35 @@ private:
   friend class Cursor;
 };
 
+
+
+class SqlStorage::IngestResult final : public jsg::Object {
+public:
+
+  IngestResult(kj::String remainder, uint64_t rowsRead, uint64_t rowsWritten);
+
+  JSG_RESOURCE_TYPE(IngestResult) {
+    JSG_READONLY_PROTOTYPE_PROPERTY(rowsRead, getRowsRead);
+    JSG_READONLY_PROTOTYPE_PROPERTY(rowsWritten, getRowsWritten);
+    JSG_READONLY_PROTOTYPE_PROPERTY(remainder, getRemainder);
+  }
+
+  kj::StringPtr getRemainder();
+  double getRowsRead();
+  double getRowsWritten();
+
+private:
+  kj::String remainder;
+  uint64_t rowsRead;
+  uint64_t rowsWritten;
+};
+
+
 #define EW_SQL_ISOLATE_TYPES                    \
   api::SqlStorage,                              \
   api::SqlStorage::Statement,                   \
   api::SqlStorage::Cursor,                      \
+  api::SqlStorage::IngestResult,                \
   api::SqlStorage::Cursor::RowIterator,         \
   api::SqlStorage::Cursor::RowIterator::Next,   \
   api::SqlStorage::Cursor::RawIterator,         \

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -255,15 +255,17 @@ private:
 class SqlStorage::IngestResult final : public jsg::Object {
 public:
 
-  IngestResult(kj::String remainder, uint64_t rowsRead, uint64_t rowsWritten);
+  IngestResult(kj::String remainder, uint64_t rowsRead, uint64_t rowsWritten, uint64_t statementCount);
 
   JSG_RESOURCE_TYPE(IngestResult) {
+    JSG_READONLY_PROTOTYPE_PROPERTY(statementCount, getStatementCount);
     JSG_READONLY_PROTOTYPE_PROPERTY(rowsRead, getRowsRead);
     JSG_READONLY_PROTOTYPE_PROPERTY(rowsWritten, getRowsWritten);
     JSG_READONLY_PROTOTYPE_PROPERTY(remainder, getRemainder);
   }
 
   kj::StringPtr getRemainder();
+  double getStatementCount();
   double getRowsRead();
   double getRowsWritten();
 
@@ -271,6 +273,7 @@ private:
   kj::String remainder;
   uint64_t rowsRead;
   uint64_t rowsWritten;
+  uint64_t statementCount;
 };
 
 

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -22,10 +22,10 @@ public:
 
   class Cursor;
   class Statement;
-  class IngestResult;
+  struct IngestResult;
 
   jsg::Ref<Cursor> exec(jsg::Lock& js, kj::String query, jsg::Arguments<BindingValue> bindings);
-  jsg::Ref<IngestResult> ingest(jsg::Lock& js, kj::String query);
+  IngestResult ingest(jsg::Lock& js, kj::String query);
 
   jsg::Ref<Statement> prepare(jsg::Lock& js, kj::String query);
 
@@ -250,30 +250,17 @@ private:
   friend class Cursor;
 };
 
+struct SqlStorage::IngestResult {
+  IngestResult(kj::String remainder, double rowsRead, double rowsWritten, double statementCount)
+    : remainder(kj::mv(remainder)), rowsRead(rowsRead), rowsWritten(rowsWritten),
+      statementCount(statementCount) {}
 
-
-class SqlStorage::IngestResult final : public jsg::Object {
-public:
-
-  IngestResult(kj::String remainder, uint64_t rowsRead, uint64_t rowsWritten, uint64_t statementCount);
-
-  JSG_RESOURCE_TYPE(IngestResult) {
-    JSG_READONLY_PROTOTYPE_PROPERTY(statementCount, getStatementCount);
-    JSG_READONLY_PROTOTYPE_PROPERTY(rowsRead, getRowsRead);
-    JSG_READONLY_PROTOTYPE_PROPERTY(rowsWritten, getRowsWritten);
-    JSG_READONLY_PROTOTYPE_PROPERTY(remainder, getRemainder);
-  }
-
-  kj::StringPtr getRemainder();
-  double getStatementCount();
-  double getRowsRead();
-  double getRowsWritten();
-
-private:
   kj::String remainder;
-  uint64_t rowsRead;
-  uint64_t rowsWritten;
-  uint64_t statementCount;
+  double rowsRead;
+  double rowsWritten;
+  double statementCount;
+
+  JSG_STRUCT(remainder, rowsRead, rowsWritten, statementCount);
 };
 
 

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -450,6 +450,7 @@ kj::Own<sqlite3_stmt> SqliteDatabase::prepareSql(
 SqliteDatabase::IngestResult SqliteDatabase::ingestSql(Regulator& regulator, kj::StringPtr sqlCode) {
   uint64_t rowsRead = 0;
   uint64_t rowsWritten = 0;
+  uint64_t statementCount = 0;
 
   // While there's still some input SQL to process
   while (sqlCode.begin() != sqlCode.end()) {
@@ -464,11 +465,12 @@ SqliteDatabase::IngestResult SqliteDatabase::ingestSql(Regulator& regulator, kj:
 
     rowsRead += q.getRowsRead();
     rowsWritten += q.getRowsWritten();
+    statementCount++;
     sqlCode = sqlCode.slice(statementLength);
   }
 
   // Return the leftover buffer
-  return {.remainder = sqlCode, .rowsRead = rowsRead, .rowsWritten = rowsWritten};
+  return {.remainder = sqlCode, .rowsRead = rowsRead, .rowsWritten = rowsWritten, .statementCount = statementCount};
 }
 
 void SqliteDatabase::executeWithRegulator(Regulator& regulator, kj::FunctionParam<void()> func) {

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -36,6 +36,12 @@ public:
   class Regulator;
   struct VfsOptions;
 
+  struct IngestResult {
+    kj::StringPtr remainder;
+    uint64_t rowsRead;
+    uint64_t rowsWritten;
+  };
+
   SqliteDatabase(const Vfs& vfs, kj::PathPtr path, kj::Maybe<kj::WriteMode> maybeMode = kj::none);
   ~SqliteDatabase() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(SqliteDatabase);
@@ -92,7 +98,7 @@ public:
   // Helper to execute a chunk of SQL that may not be complete.
   // Executes every valid statement provided, and returns the remaining portion of the input
   // that was not processed. This is used for streaming SQL ingestion.
-  kj::StringPtr ingestSql(Regulator& regulator, kj::StringPtr sqlCode);
+  IngestResult ingestSql(Regulator& regulator, kj::StringPtr sqlCode);
 
   // Execute a function with the given regulator.
   void executeWithRegulator(Regulator& regulator, kj::FunctionParam<void()> func);

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -40,6 +40,7 @@ public:
     kj::StringPtr remainder;
     uint64_t rowsRead;
     uint64_t rowsWritten;
+    uint64_t statementCount;
   };
 
   SqliteDatabase(const Vfs& vfs, kj::PathPtr path, kj::Maybe<kj::WriteMode> maybeMode = kj::none);


### PR DESCRIPTION
D1 bills based on rows read and written, but sql.ingest() didn't return those. Now it does.

This required changing the return type of sql.ingest(), but it's an experimental API so that should be okay.

  let sqlCode = "INSERT INTO tbl (col) VALUES (123); INSERT I";
  let result = sql.ingest(sqlCode);

Old:

  result == " INSERT I"

New:

  result.remainder == " INSERT I"
  result.meta.rowsRead == 0
  result.meta.rowsWritten == 1

This "meta" attribute also gives us a convenient spot to stick additional information. For example, if we wanted to count how many SQL statements ingest() executed, we could easily add "result.meta.statementsExecuted" without breaking any existing users.

Implementation-wise, there might be an optimization opportunity around SqlStorage::IngestResult::getMeta(). Right now, it allocates a new Meta every time it's called, so if you do the obvious thing like so:

  totalRead += result.meta.rowsRead
  totalWritten += result.meta.rowsWritten
  totalRedFish += result.meta.redFish  // and so on

then that might end up allocating and discarding multiple Meta objects, and some caching could fix that. On the other hand, I'm not very familiar[1] with JSG internals, so maybe that's already happening somehow. I have no idea.

[1] This is a terrible understatement.