### PR TITLE
Avoid unnecessary allocations in HTMLRewriter

### DIFF
--- a/src/workerd/api/streams/transform.h
+++ b/src/workerd/api/streams/transform.h
@@ -119,4 +119,11 @@ public:
   }
 };
 
+struct OneWayPipe {
+  kj::Own<ReadableStreamSource> in;
+  kj::Own<WritableStreamSink> out;
+};
+
+OneWayPipe newIdentityPipe(kj::Maybe<uint64_t> expectedLength = kj::none);
+
 }  // namespace workerd::api


### PR DESCRIPTION
The original code was allocating an `IdentityTransformStream` and `WritableStream` just to end up throwing both away immediately after. This simplifies things by making it possible to create a the identity pipeline that underlies `IdentityTransformStream` directly, simplifying things a bit by avoiding the unnecessary additional allocations and removing an unnecessary use of the `removeSink()` API.

Internal CI is green.