### PR TITLE
Implement support for JS-backed WritableStreams in JSRPC

### DIFF
--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -3487,7 +3487,7 @@ void WritableStreamJsController::releaseWriter(
 }
 
 kj::Maybe<kj::Own<WritableStreamSink>> WritableStreamJsController::removeSink(jsg::Lock& js) {
-  KJ_UNIMPLEMENTED("WritableStreamJsController::removeSink is not implemented");
+  return kj::none;
 }
 void WritableStreamJsController::detach(jsg::Lock& js) {
   KJ_UNIMPLEMENTED("WritableStreamJsController::detach is not implemented");


### PR DESCRIPTION
First pass at implementing support for JS-backed WritableStreams with JSRPC.

Provides an alternative adapter that will acquire the isolate lock on each write/close call, passing the operation off to the JS interface. This is obviously not as efficient as the original adapter used for `WritableStreamSink` but not yet sure if there's a better approach.