### PR TITLE
Reset kj::Maybes with `kj::none` instead of `{}`

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -399,7 +399,7 @@ public:
 
   void resetChannel() {
     auto lockedState = state.lockExclusive();
-    lockedState->channel = {};
+    lockedState->channel = kj::none;
   }
 
   // This method is called by v8 when a breakpoint or debugger statement is hit. This method
@@ -2521,7 +2521,7 @@ private:
     }
 
     void disconnect() {
-      channel = {};
+      channel = kj::none;
       shutdown();
     }
 
@@ -2837,7 +2837,7 @@ void Worker::Isolate::disconnectInspector() {
   // reference on the script, so that the script can be deleted.
   KJ_IF_SOME(current, currentInspectorSession) {
     current.disconnect();
-    currentInspectorSession = {};
+    currentInspectorSession = kj::none;
   }
   impl->inspectorClient.resetChannel();
 }


### PR DESCRIPTION
The capnproto pull request
https://github.com/capnproto/capnproto/pull/2014 adds another assignment operator for Maybes.  With a version of capnproto including that PR, we get compilation errors of the form:

```
external/workerd/src/workerd/io/worker.c++:2524:15: error: use of overloaded operator '=' is ambiguous (with operand types 'kj::Maybe<InspectorChannelImpl &>' and 'void')
      channel = {};
      ~~~~~~~ ^ ~~
bazel-out/k8-dbg/bin/external/capnp-cpp/src/kj/_virtual_includes/kj/kj/common.h:1679:17: note: candidate function
  inline Maybe& operator=(decltype(nullptr)) { ptr = nullptr; return *this; }
                ^
bazel-out/k8-dbg/bin/external/capnp-cpp/src/kj/_virtual_includes/kj/kj/common.h:1682:17: note: candidate function
  inline Maybe& operator=(T* other) { ptr = other; return *this; }
                ^
```

The Maybes that I fixed in this PR are all reference types (`Maybe<T&>`), so I’m not sure what assigning `{}` would do, since if it’s assigning a temporary, the reference will be garbage.

However, in the three cases here, we seem to be resetting the objects, so assigning `kj::none` is correct.