### PR TITLE
Add UrlWrapper/UrlList abstractions

### DIFF
--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -41,6 +41,7 @@ wd_cc_library(
             "sentry.h",
             "autogate.h",
             "perfetto-tracing.h",
+            "url-wrapper.h",
             "use-perfetto-categories.h",
         ],
     ),
@@ -48,6 +49,18 @@ wd_cc_library(
     deps = [
         "@capnp-cpp//src/kj/compat:kj-http",
         "@capnp-cpp//src/kj/compat:kj-tls",
+    ],
+)
+
+wd_cc_library(
+    name = "url-wrapper",
+    srcs = ["url-wrapper.c++"],
+    hdrs = ["url-wrapper.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj/compat:kj-http",
+        "//src/workerd/jsg:url",
+        "//src/workerd/jsg:jsg",
     ],
 )
 
@@ -143,7 +156,7 @@ exports_files(["autogate.h"])
     ],
 ) for f in glob(
     ["*-test.c++"],
-    exclude = ["sqlite-*.c++"],
+    exclude = ["sqlite-*.c++","url-wrapper-*.c++"],
 )]
 
 kj_test(
@@ -157,5 +170,12 @@ kj_test(
     src = "sqlite-kv-test.c++",
     deps = [
         ":sqlite",
+    ],
+)
+
+kj_test(
+    src = "url-wrapper-test.c++",
+    deps = [
+        ":url-wrapper",
     ],
 )

--- a/src/workerd/util/url-wrapper-test.c++
+++ b/src/workerd/util/url-wrapper-test.c++
@@ -1,0 +1,56 @@
+#include <kj/test.h>
+#include "url-wrapper.h"
+
+KJ_TEST("Legacy Basics") {
+  auto url = workerd::UrlWrapper::legacy("http://example.com/a?1#foo");
+  KJ_ASSERT(url.toString() == "http://example.com/a?1#foo");
+  auto cloned = url.clone();
+  KJ_ASSERT(url.toString() == cloned.toString());
+
+  KJ_ASSERT(url.toString(workerd::UrlWrapper::ToStringOptions {
+    .includeFragments = false
+  }) == "http://example.com/a?1");
+
+  KJ_ASSERT(url.toString(workerd::UrlWrapper::ToStringOptions {
+    .context = kj::Url::Context::HTTP_PROXY_REQUEST
+  }) == "http://example.com/a?1");
+
+  KJ_ASSERT(url.toString(workerd::UrlWrapper::ToStringOptions {
+    .context = kj::Url::Context::HTTP_REQUEST
+  }) == "/a?1");
+
+  KJ_ASSERT(workerd::UrlWrapper::kLegacyFake.resolve("/foo/bar").toString() ==
+            "https://fake-host/foo/bar");
+}
+
+KJ_TEST("Standard Basics") {
+  auto url = workerd::UrlWrapper::standard(" http://example.\t\ncom/a?1#foo ");
+  KJ_ASSERT(url.toString() == "http://example.com/a?1#foo");
+  auto cloned = url.clone();
+  KJ_ASSERT(url.toString() == cloned.toString());
+
+  KJ_ASSERT(url.toString(workerd::UrlWrapper::ToStringOptions {
+    .includeFragments = false
+  }) == "http://example.com/a?1");
+
+  KJ_ASSERT(url.toString(workerd::UrlWrapper::ToStringOptions {
+    .context = kj::Url::Context::HTTP_PROXY_REQUEST
+  }) == "http://example.com/a?1" );
+
+  KJ_ASSERT(url.toString(workerd::UrlWrapper::ToStringOptions {
+    .context = kj::Url::Context::HTTP_REQUEST
+  }) == "/a?1" );
+
+  KJ_ASSERT(workerd::UrlWrapper::kStandardFake.resolve("  /foo\t/bar  ").toString() ==
+            "https://fake-host/foo/bar");
+}
+
+KJ_TEST("URLList") {
+  workerd::UrlList list;
+  KJ_ASSERT(list.size() == 0);
+  list.add(workerd::UrlWrapper::standard("https://example.com/1"));
+  list.add(workerd::UrlWrapper::standard("https://example.com/2"));
+  KJ_ASSERT(list.size() == 2);
+  auto& back = KJ_ASSERT_NONNULL(list.back());
+  KJ_ASSERT(back.toString() == "https://example.com/2");
+}

--- a/src/workerd/util/url-wrapper.c++
+++ b/src/workerd/util/url-wrapper.c++
@@ -1,0 +1,139 @@
+#include <workerd/util/url-wrapper.h>
+#include <workerd/jsg/jsg.h>
+
+namespace workerd {
+
+namespace {
+kj::OneOf<kj::String, kj::Url, jsg::Url> initialize(UrlWrapper::Mode mode, kj::StringPtr input) {
+  switch (mode) {
+    case UrlWrapper::Mode::LEGACY: {
+      return kj::str(input);
+    }
+    case UrlWrapper::Mode::STANDARD: {
+      return JSG_REQUIRE_NONNULL(jsg::Url::tryParse(input), TypeError, "Invalid URL");
+    }
+  }
+  KJ_UNREACHABLE;
+}
+}  // namespace
+
+UrlWrapper UrlWrapper::kLegacyFake = UrlWrapper::legacy("https://fake-host/");
+UrlWrapper UrlWrapper::kStandardFake = UrlWrapper::standard("https://fake-host/");
+
+UrlWrapper::UrlWrapper(Mode mode, kj::StringPtr input)
+   : inner(initialize(mode, input)) {}
+
+UrlWrapper::UrlWrapper(kj::OneOf<kj::Url, jsg::Url> inner)
+    : inner(kj::mv(inner)) {}
+
+void UrlWrapper::ensureParsed() {
+  KJ_SWITCH_ONEOF(inner) {
+    KJ_CASE_ONEOF(url, jsg::Url) {
+      // Parsed!
+    }
+    KJ_CASE_ONEOF(url, kj::Url) {
+      // Parsed!
+    }
+    KJ_CASE_ONEOF(str, kj::String) {
+      inner = JSG_REQUIRE_NONNULL(kj::Url::tryParse(str), TypeError, "Invalid URL");
+    }
+  }
+}
+
+UrlWrapper UrlWrapper::resolve(kj::StringPtr other) {
+  ensureParsed();
+  KJ_SWITCH_ONEOF(inner) {
+    KJ_CASE_ONEOF(url, jsg::Url) {
+      auto resolved = JSG_REQUIRE_NONNULL(url.resolve(other), TypeError, "Invalid URL");
+      return UrlWrapper(kj::mv(resolved));
+    }
+    KJ_CASE_ONEOF(url, kj::Url) {
+      auto resolved = JSG_REQUIRE_NONNULL(url.tryParseRelative(other), TypeError, "Invalid URL");
+      return UrlWrapper(kj::mv(resolved));
+    }
+    KJ_CASE_ONEOF(str, kj::String) {
+      // The call to ensureParsed above should have already parsed the URL.
+      KJ_UNREACHABLE;
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+kj::String UrlWrapper::toString(kj::Maybe<ToStringOptions> maybeOptions) {
+  auto options = maybeOptions.orDefault({});
+  ensureParsed();
+  auto context = options.context.orDefault(kj::Url::Context::REMOTE_HREF);
+  KJ_SWITCH_ONEOF(inner) {
+    KJ_CASE_ONEOF(url, jsg::Url) {
+      switch (context) {
+        case kj::Url::Context::REMOTE_HREF: {
+          if (options.includeFragments) {
+            return kj::str(url.getHref());
+          } else {
+            auto cloned = url.clone(jsg::Url::EquivalenceOption::IGNORE_FRAGMENTS);
+            return kj::str(cloned.getHref());
+          }
+        }
+        case kj::Url::Context::HTTP_PROXY_REQUEST: {
+          return kj::str(url.getOrigin(), url.getPathname(), url.getSearch());
+        }
+        case kj::Url::Context::HTTP_REQUEST: {
+          return kj::str(url.getPathname(), url.getSearch());
+        }
+      }
+    }
+    KJ_CASE_ONEOF(url, kj::Url) {
+      if (options.includeFragments) {
+        return url.toString(context);
+      } else {
+        auto cloned = url.clone();
+        cloned.fragment = kj::none;
+        return cloned.toString(context);
+      }
+    }
+    KJ_CASE_ONEOF(str, kj::String) {
+      // The call to ensureParsed above should have already parsed the URL.
+      KJ_UNREACHABLE;
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+UrlWrapper UrlWrapper::clone() {
+  KJ_SWITCH_ONEOF(inner) {
+    KJ_CASE_ONEOF(url, jsg::Url) {
+      return UrlWrapper(url.clone());
+    }
+    KJ_CASE_ONEOF(url, kj::Url) {
+      return UrlWrapper(url.clone());
+    }
+    KJ_CASE_ONEOF(str, kj::String) {
+      // The only reason this would be a string is if we're in LEGACY mode.
+      return UrlWrapper(Mode::LEGACY, str);
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+UrlWrapper UrlWrapper::legacy(kj::StringPtr input) {
+  return UrlWrapper(Mode::LEGACY, input);
+}
+
+UrlWrapper UrlWrapper::standard(kj::StringPtr input) {
+  return UrlWrapper(Mode::STANDARD, input);
+}
+
+size_t UrlList::size() const {
+  return urls.size();
+}
+
+void UrlList::add(UrlWrapper&& url) {
+  urls.add(kj::mv(url));
+}
+
+kj::Maybe<UrlWrapper&> UrlList::back() {
+  if (urls.size() == 0) return kj::none;
+  return urls.back();
+}
+
+}  // namespace workerd

--- a/src/workerd/util/url-wrapper.h
+++ b/src/workerd/util/url-wrapper.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <workerd/jsg/url.h>
+#include <kj/compat/url.h>
+#include <kj/one-of.h>
+#include <kj/vector.h>
+
+namespace workerd {
+
+class UrlWrapper final {
+public:
+  // Determines the mode under which the UrlWrapper should operate.
+  enum class Mode {
+    // Legacy mode indicates that UrlWrapper will use the kj::Url implementation.
+    // This includes lazy parsing and a few other quirks.
+    LEGACY,
+    // Standard mode indicates that UrlWrapper will use the jsg::Url implementation.
+    STANDARD,
+  };
+
+  UrlWrapper(Mode mode, kj::StringPtr input);
+  UrlWrapper(UrlWrapper&&) = default;
+  UrlWrapper& operator=(UrlWrapper&&) = default;
+  KJ_DISALLOW_COPY(UrlWrapper);
+
+  static UrlWrapper legacy(kj::StringPtr input);
+  static UrlWrapper standard(kj::StringPtr input);
+
+  void ensureParsed();
+
+  UrlWrapper resolve(kj::StringPtr other);
+
+  struct ToStringOptions {
+    kj::Maybe<kj::Url::Context> context = kj::none;
+    bool includeFragments = true;
+  };
+
+  // When running in STANDARD mode, the context argument is ignored.
+  kj::String toString(kj::Maybe<ToStringOptions> options = kj::none);
+
+  UrlWrapper clone();
+
+  // Returns a legacy mode UrlWrapper that represents the "https://fake-host/" URL.
+  static UrlWrapper kLegacyFake;
+
+  // Returns a standard mode UrlWrapper that represents the "https://fake-host/" URL.
+  static UrlWrapper kStandardFake;
+
+private:
+  kj::OneOf<kj::String, kj::Url, jsg::Url> inner;
+
+  UrlWrapper(kj::OneOf<kj::Url, jsg::Url> inner);
+};
+
+class UrlList final {
+public:
+  UrlList() = default;
+  UrlList(UrlList&&) = default;
+  UrlList& operator=(UrlList&&) = default;
+  KJ_DISALLOW_COPY(UrlList);
+
+  size_t size() const;
+  void add(UrlWrapper&& url);
+  kj::Maybe<UrlWrapper&> back();
+
+private:
+  kj::Vector<UrlWrapper> urls;
+};
+
+}  // namespace workerd

--- a/src/workerd/util/url-wrapper.h
+++ b/src/workerd/util/url-wrapper.h
@@ -47,6 +47,12 @@ public:
   static UrlWrapper kStandardFake;
 
 private:
+  // The UrlWrapper is either a kj::Url or a jsg::Url. When the UrlWrapper is
+  // created initially, and the url is going to be a kj::Url, then the inner will
+  // initially be a kj::String that is lazily parsed into the kj::Url. This is to
+  // preserve an existing pattern we've had that defers parsing of the url
+  // until it is used. When the url is going to a jsg::Url, then it is parsed when
+  // the UrlWrapper is created.
   kj::OneOf<kj::String, kj::Url, jsg::Url> inner;
 
   UrlWrapper(kj::OneOf<kj::Url, jsg::Url> inner);


### PR DESCRIPTION
In preparation for introducing a compatibility flag to change the handling of URLs in the fetch implementation to conform to standards, we need an abstraction over both kj::Url and jsg::Url. This adds that abstraction. It does not change anything to use it yet, but it provides the basics. The next step (in a follow up PR) will be to update all of the fetch API code to use it without with the compatibility flag, then finally add the flag and that switches things over to use jsg::Url

This is part of a refactor meant to improve standards compliance and works towards fixing a bug.

Refs: https://github.com/cloudflare/workerd/issues/1957