### PR TITLE
Jphillips/v8 12.5

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -191,7 +191,7 @@ http_archive(
 #   to confusing compiler errors in tcmalloc in the past.
 git_repository(
     name = "com_google_absl",
-    commit = "b3ae305fd5dbc6ad41eed9add26768c29181219f",
+    commit = "a64dd87cec79c80c88190265cfea0cbd4027677f",
     remote = "https://chromium.googlesource.com/chromium/src/third_party/abseil-cpp.git",
 )
 
@@ -468,11 +468,13 @@ http_archive(
         "//:patches/v8/0015-Set-torque-generator-path-to-external-v8.-This-allow.patch",
         "//:patches/v8/0016-Modify-where-to-look-for-fp16-dependency.-This-depen.patch",
         "//:patches/v8/0017-Fixup-RunMicrotask-to-restore-async-context-on-termi.patch",
+        "//:patches/v8/0018-Expose-v8-Symbol-GetDispose.patch",
+        "//:patches/v8/0019-Rename-V8_COMPRESS_POINTERS_IN_ISOLATE_CAGE.patch",
     ],
-    integrity = "sha256-C6bsXXbKgeCxmG1VNO/LScaPq0HVlmofpVHJ5kswoLg=",
-    strip_prefix = "v8-12.4.254.11",
+    integrity = "sha256-61Qzg9XnA/S2Jw1xSDgfGm8VUnrPR483gcsQOqlBNq0=",
+    strip_prefix = "v8-12.5.227.3",
     type = "tgz",
-    url = "https://github.com/v8/v8/archive/refs/tags/12.4.254.11.tar.gz",
+    url = "https://github.com/v8/v8/archive/refs/tags/12.5.227.3.tar.gz",
 )
 
 git_repository(

--- a/docs/v8-updates.md
+++ b/docs/v8-updates.md
@@ -77,7 +77,7 @@ from the V8 directory.
     You can find the commit versions for V8's dependencies under `v8/DEPS` and the ones
     that are carried through to workerd in the `workerd/WORKSPACE` file.
 
-    These currently include `abseil`, `com_google_chromium_icu` and `trace_event_common`.
+    These currently include `abseil`, `com_googlesource_chromium_icu` and `trace_event_common`.
     Typically you'll get a build failure if the projects are out of sync. Copy the
     commit versions from `v8/DEPS` to the `WORKSPACE` file.
 

--- a/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
+++ b/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
@@ -1,4 +1,4 @@
-From 9cd118a8ffa4c2154438f65503e3fdb8c9b1741d Mon Sep 17 00:00:00 2001
+From 5d5e25c278ac0afc8e48386cc61b936e7eac10ed Mon Sep 17 00:00:00 2001
 From: Alex Robinson <arobinson@cloudflare.com>
 Date: Wed, 2 Mar 2022 15:58:04 -0600
 Subject: Allow manually setting ValueDeserializer format version
@@ -35,10 +35,10 @@ index 0cb3e045bc46ec732956318b980e749d1847d06d..40ad805c7970cc9379e69f046205836d
     * Reads raw data in various common formats to the buffer.
     * Note that integer types are read in base-128 varint format, not with a
 diff --git a/src/api/api.cc b/src/api/api.cc
-index a7070c494c211bec5692767e26ab7bd072b2d6fd..b94dd72c64ef345ca6f13c246c93b7b7191d2cf9 100644
+index e99e7d9d1359c4fcd38478412ebfc1586eeda7b3..151d0380c5c8d043f2f9a6d556d463040749167d 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -3645,6 +3645,10 @@ uint32_t ValueDeserializer::GetWireFormatVersion() const {
+@@ -3582,6 +3582,10 @@ uint32_t ValueDeserializer::GetWireFormatVersion() const {
    return private_->deserializer.GetWireFormatVersion();
  }
  

--- a/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
+++ b/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
@@ -1,4 +1,4 @@
-From e235a6aabeddaf28c1214e628c4a41edef552d69 Mon Sep 17 00:00:00 2001
+From 599f2f35811c9afefe99a45724ae89e8c2b169f0 Mon Sep 17 00:00:00 2001
 From: James M Snell <jasnell@gmail.com>
 Date: Wed, 16 Mar 2022 08:59:21 -0700
 Subject: Allow manually setting ValueSerializer format version
@@ -22,10 +22,10 @@ index 40ad805c7970cc9379e69f046205836dbd760373..596be18adeb3a5a81794aaa44b1d347d
     * Writes out a header, which includes the format version.
     */
 diff --git a/src/api/api.cc b/src/api/api.cc
-index b94dd72c64ef345ca6f13c246c93b7b7191d2cf9..b375bfe4d9a82c4dc2ecae1de9349d02c4dd47aa 100644
+index 151d0380c5c8d043f2f9a6d556d463040749167d..9d46870f6bfdfee90d38a7b3cda2d9846196addc 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -3513,6 +3513,10 @@ ValueSerializer::ValueSerializer(Isolate* v8_isolate, Delegate* delegate)
+@@ -3450,6 +3450,10 @@ ValueSerializer::ValueSerializer(Isolate* v8_isolate, Delegate* delegate)
  
  ValueSerializer::~ValueSerializer() { delete private_; }
  
@@ -37,7 +37,7 @@ index b94dd72c64ef345ca6f13c246c93b7b7191d2cf9..b375bfe4d9a82c4dc2ecae1de9349d02
  
  void ValueSerializer::SetTreatArrayBufferViewsAsHostObjects(bool mode) {
 diff --git a/src/objects/value-serializer.cc b/src/objects/value-serializer.cc
-index 50dbe657283d4c22aacef6824eee670281cd164c..f6b3579da294d86b6ad415471e2f29538ed5a629 100644
+index 1c8f2fa9122e46d8813569504c0534f38f8ae53d..bb36e71af9cb2fda605200550a36c0a74e560671 100644
 --- a/src/objects/value-serializer.cc
 +++ b/src/objects/value-serializer.cc
 @@ -291,6 +291,7 @@ ValueSerializer::ValueSerializer(Isolate* isolate,

--- a/patches/v8/0003-Add-ArrayBuffer-MaybeNew.patch
+++ b/patches/v8/0003-Add-ArrayBuffer-MaybeNew.patch
@@ -1,4 +1,4 @@
-From 831deb67e4977c12667462f3b67efababdd3c411 Mon Sep 17 00:00:00 2001
+From 124a4fecfef38f07e8851ad8003db94950c3d2bc Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Fri, 16 Sep 2022 21:41:45 -0500
 Subject: Add `ArrayBuffer::MaybeNew()`.
@@ -8,10 +8,10 @@ In Cloudflare's edge runtime, this is part of a larger patch that allows gracefu
 (We would like to upstream our internal patch, just need to find the time...)
 
 diff --git a/include/v8-array-buffer.h b/include/v8-array-buffer.h
-index ea6f5b5571a476574d3fb0cd495d162f3b333b0f..e0ccd9dadb0c30f1f040a5240d46dae0883f4fb0 100644
+index 5d855441f8ed7bd775332c0a20d7a57411a1baa8..981dda00eede693bff1d3a240ffe2396b5de9f21 100644
 --- a/include/v8-array-buffer.h
 +++ b/include/v8-array-buffer.h
-@@ -210,6 +210,14 @@ class V8_EXPORT ArrayBuffer : public Object {
+@@ -216,6 +216,14 @@ class V8_EXPORT ArrayBuffer : public Object {
     */
    size_t MaxByteLength() const;
  

--- a/patches/v8/0004-Allow-Windows-builds-under-Bazel.patch
+++ b/patches/v8/0004-Allow-Windows-builds-under-Bazel.patch
@@ -1,14 +1,14 @@
-From 41767e80304816d674136ce08ab241596e4494ee Mon Sep 17 00:00:00 2001
+From fa10e15fe7cef2b0b221b231d6ad9f8f3bc04de5 Mon Sep 17 00:00:00 2001
 From: Brendan Coll <bcoll@cloudflare.com>
 Date: Thu, 16 Mar 2023 11:56:10 +0000
 Subject: Allow Windows builds under Bazel
 
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 05b7472165ae858df0a300279c6065c38faf1768..4a914c56851dbd43329829f9b42c9ca500055fc7 100644
+index 453726808be0e2c9b5f7cbdbec148e480b4c7349..026eeebd5a336597e3bc89b9239a919d94feb6a2 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -778,6 +778,7 @@ filegroup(
+@@ -779,6 +779,7 @@ filegroup(
          "src/base/platform/mutex.h",
          "src/base/platform/platform.cc",
          "src/base/platform/platform.h",
@@ -16,7 +16,7 @@ index 05b7472165ae858df0a300279c6065c38faf1768..4a914c56851dbd43329829f9b42c9ca5
          "src/base/platform/semaphore.cc",
          "src/base/platform/semaphore.h",
          "src/base/platform/time.cc",
-@@ -817,7 +818,6 @@ filegroup(
+@@ -820,7 +821,6 @@ filegroup(
      ] + select({
          "@v8//bazel/config:is_posix": [
              "src/base/platform/platform-posix.cc",
@@ -24,7 +24,7 @@ index 05b7472165ae858df0a300279c6065c38faf1768..4a914c56851dbd43329829f9b42c9ca5
              "src/base/platform/platform-posix-time.cc",
              "src/base/platform/platform-posix-time.h",
          ],
-@@ -840,6 +840,7 @@ filegroup(
+@@ -843,6 +843,7 @@ filegroup(
          "@v8//bazel/config:is_windows": [
              "src/base/debug/stack_trace_win.cc",
              "src/base/platform/platform-win32.cc",
@@ -32,7 +32,7 @@ index 05b7472165ae858df0a300279c6065c38faf1768..4a914c56851dbd43329829f9b42c9ca5
              "src/base/win32-headers.h",
          ],
      }),
-@@ -1229,6 +1230,7 @@ filegroup(
+@@ -1233,6 +1234,7 @@ filegroup(
          "include/v8-wasm-trap-handler-posix.h",
          "src/api/api.cc",
          "src/api/api.h",
@@ -40,7 +40,7 @@ index 05b7472165ae858df0a300279c6065c38faf1768..4a914c56851dbd43329829f9b42c9ca5
          "src/api/api-arguments.cc",
          "src/api/api-arguments.h",
          "src/api/api-arguments-inl.h",
-@@ -2672,6 +2674,11 @@ filegroup(
+@@ -2686,6 +2688,11 @@ filegroup(
              "src/trap-handler/handler-inside-posix.cc",
              "src/trap-handler/handler-outside-posix.cc",
          ],
@@ -52,7 +52,7 @@ index 05b7472165ae858df0a300279c6065c38faf1768..4a914c56851dbd43329829f9b42c9ca5
          "//conditions:default": [],
      }) + select({
          "@v8//bazel/config:v8_arm64_simulator": [
-@@ -2679,13 +2686,6 @@ filegroup(
+@@ -2693,13 +2700,6 @@ filegroup(
              "src/trap-handler/trap-handler-simulator.h",
          ],
          "//conditions:default": [],
@@ -66,7 +66,7 @@ index 05b7472165ae858df0a300279c6065c38faf1768..4a914c56851dbd43329829f9b42c9ca5
      }) + select({
          "@v8//bazel/config:is_windows_64bit": [
              "src/diagnostics/unwinding-info-win64.cc",
-@@ -3682,6 +3682,9 @@ filegroup(
+@@ -3693,6 +3693,9 @@ filegroup(
          "@v8//bazel/config:is_msvc_asm_ia32": ["src/heap/base/asm/ia32/push_registers_masm.asm"],
          "@v8//bazel/config:is_msvc_asm_x64": ["src/heap/base/asm/x64/push_registers_masm.asm"],
          "@v8//bazel/config:is_msvc_asm_arm64": ["src/heap/base/asm/arm64/push_registers_masm.S"],
@@ -76,7 +76,7 @@ index 05b7472165ae858df0a300279c6065c38faf1768..4a914c56851dbd43329829f9b42c9ca5
      }),
  )
  
-@@ -4057,9 +4060,11 @@ filegroup(
+@@ -4068,9 +4071,11 @@ filegroup(
          "src/d8/d8-js.cc",
          "src/d8/d8-platforms.cc",
          "src/d8/d8-platforms.h",
@@ -90,7 +90,7 @@ index 05b7472165ae858df0a300279c6065c38faf1768..4a914c56851dbd43329829f9b42c9ca5
  )
  
  genrule(
-@@ -4396,7 +4401,7 @@ py_test(
+@@ -4407,7 +4412,7 @@ py_test(
          ":noicu/d8",
          ":noicu/v8_build_config",
          "//testing/pybase",
@@ -99,7 +99,7 @@ index 05b7472165ae858df0a300279c6065c38faf1768..4a914c56851dbd43329829f9b42c9ca5
      main = "tools/run-tests.py",
      python_version = "PY3",
      tags = [
-@@ -4426,7 +4431,7 @@ py_test(
+@@ -4437,7 +4442,7 @@ py_test(
          ":icu/d8",
          ":icu/v8_build_config",
          "//testing/pybase",
@@ -178,10 +178,10 @@ index 67454fa90eea460e70e286623fb1c99edd22c650..7efff1ab909dc7048a216e511c2e71c7
      name = "is_clang",
      match_any = [
 diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index f23f48ef03ae6adb08e3cfa605bff35d820c865e..fba64a0ca755da3c4a6b24a02d16ca552113a384 100644
+index 2c49fe59ba342491b53dfae762ee6f882cebf075..4fafb2ae40afa499356777f9bbfedf25f808fdd7 100644
 --- a/bazel/defs.bzl
 +++ b/bazel/defs.bzl
-@@ -118,6 +118,24 @@ def _default_args():
+@@ -119,6 +119,24 @@ def _default_args():
                  "-Wno-non-virtual-dtor",
                  "-isystem .",
              ],
@@ -206,7 +206,7 @@ index f23f48ef03ae6adb08e3cfa605bff35d820c865e..fba64a0ca755da3c4a6b24a02d16ca55
              "//conditions:default": [],
          }) + select({
              "@v8//bazel/config:is_clang": [
-@@ -164,13 +182,23 @@ def _default_args():
+@@ -165,13 +183,23 @@ def _default_args():
              ],
              "//conditions:default": [
              ],
@@ -230,7 +230,7 @@ index f23f48ef03ae6adb08e3cfa605bff35d820c865e..fba64a0ca755da3c4a6b24a02d16ca55
              ],
              "@v8//bazel/config:is_macos": ["-pthread"],
              "//conditions:default": ["-Wl,--no-as-needed -ldl -pthread"],
-@@ -492,6 +520,7 @@ def v8_mksnapshot(name, args, suffix = ""):
+@@ -493,6 +521,7 @@ def v8_mksnapshot(name, args, suffix = ""):
          suffix = suffix,
          target_os = select({
              "@v8//bazel/config:is_macos": "mac",
@@ -238,7 +238,7 @@ index f23f48ef03ae6adb08e3cfa605bff35d820c865e..fba64a0ca755da3c4a6b24a02d16ca55
              "//conditions:default": "",
          }),
      )
-@@ -503,6 +532,7 @@ def v8_mksnapshot(name, args, suffix = ""):
+@@ -504,6 +533,7 @@ def v8_mksnapshot(name, args, suffix = ""):
          suffix = suffix,
          target_os = select({
              "@v8//bazel/config:is_macos": "mac",

--- a/patches/v8/0005-Disable-bazel-whole-archive-build.patch
+++ b/patches/v8/0005-Disable-bazel-whole-archive-build.patch
@@ -1,4 +1,4 @@
-From f67a62ae6200e4394bcd885d2c5953098244131a Mon Sep 17 00:00:00 2001
+From 3a50fdac34c69d142ea40df39bc05fa02d0771c7 Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Tue, 11 Apr 2023 14:41:31 -0400
 Subject: Disable bazel whole-archive build

--- a/patches/v8/0006-Make-v8-Locker-automatically-call-isolate-Enter.patch
+++ b/patches/v8/0006-Make-v8-Locker-automatically-call-isolate-Enter.patch
@@ -1,4 +1,4 @@
-From bb0e0093b5b827b32b98655541fb7452062083ba Mon Sep 17 00:00:00 2001
+From e1f71b7b5e1df33c0d05c7e932c6816d20062b33 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Tue, 23 May 2023 09:18:57 -0500
 Subject: Make v8::Locker automatically call isolate->Enter().

--- a/patches/v8/0007-Add-an-API-to-capture-and-restore-the-cage-base-poin.patch
+++ b/patches/v8/0007-Add-an-API-to-capture-and-restore-the-cage-base-poin.patch
@@ -1,4 +1,4 @@
-From 7ffee5a4b6c0cf7b144616a1023a074c71335333 Mon Sep 17 00:00:00 2001
+From 8dab305cca01cf429c15b75b11f59b5917089e9d Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Tue, 23 May 2023 09:24:11 -0500
 Subject: Add an API to capture and restore the cage base pointers.
@@ -56,7 +56,7 @@ index 22b7a8767a83a702a2601bdfd4c0f71206df0ad5..fee48faffe82400595dca17197c5bbee
  
  #endif  // INCLUDE_V8_LOCKER_H_
 diff --git a/src/execution/v8threads.cc b/src/execution/v8threads.cc
-index 91e1a43d305d06fdf07fccdf80eb07e86115619b..dfe5da8f6bdc5a30d65b7f31d0e3a42fbe49d22b 100644
+index 91e1a43d305d06fdf07fccdf80eb07e86115619b..857da6f175e666930a0d768fbf9edb935f04da5e 100644
 --- a/src/execution/v8threads.cc
 +++ b/src/execution/v8threads.cc
 @@ -6,6 +6,7 @@
@@ -74,7 +74,7 @@ index 91e1a43d305d06fdf07fccdf80eb07e86115619b..dfe5da8f6bdc5a30d65b7f31d0e3a42f
 +
 +PointerCageContext PointerCageContext::GetCurrent() {
 +  PointerCageContext result;
-+#ifdef V8_COMPRESS_POINTERS_IN_ISOLATE_CAGE
++#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 +  result.cage = i::V8HeapCompressionScheme::base();
 +#ifdef V8_EXTERNAL_CODE_SPACE
 +  result.code_cage = i::ExternalCodeCompressionScheme::base();
@@ -84,12 +84,12 @@ index 91e1a43d305d06fdf07fccdf80eb07e86115619b..dfe5da8f6bdc5a30d65b7f31d0e3a42f
 +#else
 +  result.cage = 0;
 +  result.code_cage = 0;
-+#endif  // V8_COMPRESS_POINTERS_IN_ISOLATE_CAGE
++#endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 +  return result;
 +}
 +
 +void PointerCageContext::Apply() const {
-+#ifdef V8_COMPRESS_POINTERS_IN_ISOLATE_CAGE
++#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 +  i::V8HeapCompressionScheme::InitBase(cage);
 +#ifdef V8_EXTERNAL_CODE_SPACE
 +  i::ExternalCodeCompressionScheme::InitBase(code_cage);
@@ -99,7 +99,7 @@ index 91e1a43d305d06fdf07fccdf80eb07e86115619b..dfe5da8f6bdc5a30d65b7f31d0e3a42f
 +  // warning with this line.
 +  (void)code_cage;
 +#endif  // V8_EXTERNAL_CODE_SPACE
-+#endif  // V8_COMPRESS_POINTERS_IN_ISOLATE_CAGE
++#endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 +}
 +
  }  // namespace v8

--- a/patches/v8/0008-Speed-up-V8-bazel-build-by-always-using-target-cfg.patch
+++ b/patches/v8/0008-Speed-up-V8-bazel-build-by-always-using-target-cfg.patch
@@ -1,4 +1,4 @@
-From 2d9e350afb0511e2be66fdfc28321ecef79a9f4d Mon Sep 17 00:00:00 2001
+From 44c1b5772d868c1f048c7cdc30c954a501cc4d09 Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Wed, 7 Jun 2023 21:40:54 -0400
 Subject: Speed up V8 bazel build by always using target cfg
@@ -12,7 +12,7 @@ generated files as the output set. While unrelated to the build cfg change,
 this also improves build times.
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 4a914c56851dbd43329829f9b42c9ca500055fc7..11c26187981450ccbb1291217cae2c4fae3db023 100644
+index 026eeebd5a336597e3bc89b9239a919d94feb6a2..35c8ec1656a0874c182d420954c7b1101dd6b1f7 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
 @@ -17,6 +17,7 @@ load(
@@ -23,7 +23,7 @@ index 4a914c56851dbd43329829f9b42c9ca500055fc7..11c26187981450ccbb1291217cae2c4f
  )
  load(":bazel/v8-non-pointer-compression.bzl", "v8_binary_non_pointer_compression")
  
-@@ -4067,22 +4068,20 @@ filegroup(
+@@ -4078,22 +4079,20 @@ filegroup(
      }),
  )
  
@@ -52,7 +52,7 @@ index 4a914c56851dbd43329829f9b42c9ca500055fc7..11c26187981450ccbb1291217cae2c4f
  )
  
  v8_mksnapshot(
-@@ -4283,8 +4282,6 @@ v8_binary(
+@@ -4294,8 +4293,6 @@ v8_binary(
      srcs = [
          "src/regexp/gen-regexp-special-case.cc",
          "src/regexp/special-case.h",
@@ -61,7 +61,7 @@ index 4a914c56851dbd43329829f9b42c9ca500055fc7..11c26187981450ccbb1291217cae2c4f
      ],
      copts = ["-Wno-implicit-fallthrough"],
      defines = [
-@@ -4296,6 +4293,7 @@ v8_binary(
+@@ -4307,6 +4304,7 @@ v8_binary(
      ],
      deps = [
          "//external:absl_optional",
@@ -70,10 +70,10 @@ index 4a914c56851dbd43329829f9b42c9ca500055fc7..11c26187981450ccbb1291217cae2c4f
      ],
  )
 diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index fba64a0ca755da3c4a6b24a02d16ca552113a384..a8552489ae1901e380fe6825def658911ffb9d62 100644
+index 4fafb2ae40afa499356777f9bbfedf25f808fdd7..58c5a0273769e0df997e9e92bd4274f3cb8f2fc6 100644
 --- a/bazel/defs.bzl
 +++ b/bazel/defs.bzl
-@@ -337,6 +337,15 @@ def v8_library(
+@@ -338,6 +338,15 @@ def v8_library(
              **kwargs
          )
  
@@ -89,7 +89,7 @@ index fba64a0ca755da3c4a6b24a02d16ca552113a384..a8552489ae1901e380fe6825def65891
  # Use a single generator target for torque definitions and initializers. We can
  # split the set of outputs by using OutputGroupInfo, that way we do not need to
  # run the torque generator twice.
-@@ -401,7 +410,7 @@ _v8_torque_files = rule(
+@@ -402,7 +411,7 @@ _v8_torque_files = rule(
          "tool": attr.label(
              allow_files = True,
              executable = True,
@@ -98,7 +98,7 @@ index fba64a0ca755da3c4a6b24a02d16ca552113a384..a8552489ae1901e380fe6825def65891
          ),
          "args": attr.string_list(),
      },
-@@ -502,13 +511,16 @@ _v8_mksnapshot = rule(
+@@ -503,13 +512,16 @@ _v8_mksnapshot = rule(
              mandatory = True,
              allow_files = True,
              executable = True,
@@ -117,7 +117,7 @@ index fba64a0ca755da3c4a6b24a02d16ca552113a384..a8552489ae1901e380fe6825def65891
  )
  
  def v8_mksnapshot(name, args, suffix = ""):
-@@ -631,3 +643,34 @@ def v8_build_config(name):
+@@ -632,3 +644,34 @@ def v8_build_config(name):
          outs = ["icu/" + name + ".json"],
          cmd = "echo '" + build_config_content(cpu, "true") + "' > \"$@\"",
      )

--- a/patches/v8/0009-Implement-Promise-Context-Tagging.patch
+++ b/patches/v8/0009-Implement-Promise-Context-Tagging.patch
@@ -1,4 +1,4 @@
-From 94e314608af7a47bec9eee2eeb79f90c0810e2d6 Mon Sep 17 00:00:00 2001
+From 3ce5029ced765f653ec08bc43cdc571566a6b49f Mon Sep 17 00:00:00 2001
 From: James M Snell <jasnell@gmail.com>
 Date: Thu, 22 Jun 2023 15:29:26 -0700
 Subject: Implement Promise Context Tagging
@@ -25,7 +25,7 @@ index 4f5e716f8147a2aafbe6d27ab2507fe98f9e1651..c10b476b23e519bfee6b1c0af7759f1a
  
  #endif  // INCLUDE_V8_ISOLATE_CALLBACKS_H_
 diff --git a/include/v8-isolate.h b/include/v8-isolate.h
-index 585b513fac446a5fd08e6be18117f3bd98c38584..0fee97cd1cd44ff7f448e2d8078c60b56f502260 100644
+index 9e49d77182dfbc88fcb3f2174bd01c05093bf4d4..d62c8753c8cb67a4341a5806a1caae4afbe1ed2a 100644
 --- a/include/v8-isolate.h
 +++ b/include/v8-isolate.h
 @@ -1711,6 +1711,9 @@ class V8_EXPORT Isolate {
@@ -59,10 +59,10 @@ index 585b513fac446a5fd08e6be18117f3bd98c38584..0fee97cd1cd44ff7f448e2d8078c60b5
  
  #endif  // INCLUDE_V8_ISOLATE_H_
 diff --git a/src/api/api.cc b/src/api/api.cc
-index b375bfe4d9a82c4dc2ecae1de9349d02c4dd47aa..dbd42ec0e2bdb37d604bbc4f72e402cf3a153b40 100644
+index 9d46870f6bfdfee90d38a7b3cda2d9846196addc..709665a41d6219c4ef6392afc269c8c41b662d4b 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -11910,6 +11910,23 @@ std::string SourceLocation::ToString() const {
+@@ -11914,6 +11914,23 @@ std::string SourceLocation::ToString() const {
    return std::string(function_) + "@" + file_ + ":" + std::to_string(line_);
  }
  
@@ -204,10 +204,10 @@ index 07b6e2cd02f97fc1aa99f91bd9c166304482f8e7..6826686c07f4a02b856f2d5d5015c857
         offset < JSPromise::kSizeWithEmbedderFields; offset += kTaggedSize) {
      a.Store(AccessBuilder::ForJSObjectOffset(offset),
 diff --git a/src/diagnostics/objects-printer.cc b/src/diagnostics/objects-printer.cc
-index 7677022ce31c1b8ead0cc2eb37fb505b750639be..a53641eeed8d31a0f835e1bb1238a578e3956ba4 100644
+index 76ee1466041901abcbb39a841ca1c34538f21314..2eb353707d88befb3595a39d243831d5821d4b0d 100644
 --- a/src/diagnostics/objects-printer.cc
 +++ b/src/diagnostics/objects-printer.cc
-@@ -739,6 +739,7 @@ void JSPromise::JSPromisePrint(std::ostream& os) {
+@@ -754,6 +754,7 @@ void JSPromise::JSPromisePrint(std::ostream& os) {
    os << "\n - has_handler: " << has_handler();
    os << "\n - handled_hint: " << handled_hint();
    os << "\n - is_silent: " << is_silent();
@@ -247,10 +247,10 @@ index 256db29d140785084190ee7287480698a6498d74..ea09d04f1d09a5ac3b5b0c946d20a7e0
  Tagged<Object> Isolate::VerifyBuiltinsResult(Tagged<Object> result) {
    if (is_execution_terminating() && !v8_flags.strict_termination_checks) {
 diff --git a/src/execution/isolate.cc b/src/execution/isolate.cc
-index c2cc0458bb644ca362e848a50935c458621475fa..8e0292ff0862e92681a3ebf3a63d4f275d1fe102 100644
+index 0126e50b615c032abc2045d9b4b7e5c0f55473a1..b4ba45baa077d6a4e96eef952becb985f07ac358 100644
 --- a/src/execution/isolate.cc
 +++ b/src/execution/isolate.cc
-@@ -581,6 +581,8 @@ void Isolate::Iterate(RootVisitor* v, ThreadLocalTop* thread) {
+@@ -583,6 +583,8 @@ void Isolate::Iterate(RootVisitor* v, ThreadLocalTop* thread) {
                        FullObjectSlot(&thread->pending_message_));
    v->VisitRootPointer(Root::kStackRoots, nullptr,
                        FullObjectSlot(&thread->context_));
@@ -259,7 +259,7 @@ index c2cc0458bb644ca362e848a50935c458621475fa..8e0292ff0862e92681a3ebf3a63d4f27
  
    for (v8::TryCatch* block = thread->try_catch_handler_; block != nullptr;
         block = block->next_) {
-@@ -4843,6 +4845,7 @@ bool Isolate::Init(SnapshotData* startup_snapshot_data,
+@@ -5091,6 +5093,7 @@ bool Isolate::Init(SnapshotData* startup_snapshot_data,
      shared_heap_object_cache_.push_back(ReadOnlyRoots(this).undefined_value());
    }
  
@@ -267,7 +267,7 @@ index c2cc0458bb644ca362e848a50935c458621475fa..8e0292ff0862e92681a3ebf3a63d4f27
    InitializeThreadLocal();
  
    // Profiler has to be created after ThreadLocal is initialized
-@@ -6678,5 +6681,39 @@ void DefaultWasmAsyncResolvePromiseCallback(
+@@ -6942,5 +6945,39 @@ void DefaultWasmAsyncResolvePromiseCallback(
    CHECK(ret.IsJust() ? ret.FromJust() : isolate->IsExecutionTerminating());
  }
  
@@ -308,10 +308,10 @@ index c2cc0458bb644ca362e848a50935c458621475fa..8e0292ff0862e92681a3ebf3a63d4f27
  }  // namespace internal
  }  // namespace v8
 diff --git a/src/execution/isolate.h b/src/execution/isolate.h
-index 8f40fe7e101803ce53ddcfe16d8643a001381399..2db6248ddb29ad8c26cf812131160712cbefc79c 100644
+index 7068d3d0ed160d264a2e84f732a4b4ebf440f87a..f8cf15554dfefdddc976060284e57c8af6a31bb1 100644
 --- a/src/execution/isolate.h
 +++ b/src/execution/isolate.h
-@@ -2219,6 +2219,14 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
+@@ -2230,6 +2230,14 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
      battery_saver_mode_enabled_ = battery_saver_mode_enabled;
    }
  
@@ -324,9 +324,9 @@ index 8f40fe7e101803ce53ddcfe16d8643a001381399..2db6248ddb29ad8c26cf812131160712
 +                                                        Handle<JSPromise> promise);
 +
   private:
-   explicit Isolate(std::unique_ptr<IsolateAllocator> isolate_allocator);
+   explicit Isolate(IsolateGroup* isolate_group);
    ~Isolate();
-@@ -2706,11 +2714,18 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
+@@ -2718,12 +2726,19 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
    int current_thread_counter_ = 0;
  #endif
  
@@ -340,16 +340,17 @@ index 8f40fe7e101803ce53ddcfe16d8643a001381399..2db6248ddb29ad8c26cf812131160712
    friend class GlobalSafepoint;
    friend class TestSerializer;
    friend class SharedHeapNoClientsTest;
+   friend class IsolateForPointerCompression;
    friend class IsolateForSandbox;
 +  friend class PromiseCrossContextCallbackScope;
  };
  
  // The current entered Isolate and its thread data. Do not access these
 diff --git a/src/heap/factory.cc b/src/heap/factory.cc
-index 08a69d99f706f6fa0cbe63af697931fa67a5b468..9568ba8563ba4078c28a5f60e4c5673cbeced156 100644
+index 3be8c75688e9bb54b2b85ae5f0af39a0f435a696..1e85fbd1d2171a4a3c3db6cd9df8a9ab3b64a36b 100644
 --- a/src/heap/factory.cc
 +++ b/src/heap/factory.cc
-@@ -4180,6 +4180,12 @@ Handle<JSPromise> Factory::NewJSPromiseWithoutHook() {
+@@ -4209,6 +4209,12 @@ Handle<JSPromise> Factory::NewJSPromiseWithoutHook() {
    DisallowGarbageCollection no_gc;
    Tagged<JSPromise> raw = *promise;
    raw->set_reactions_or_result(Smi::zero(), SKIP_WRITE_BARRIER);
@@ -375,10 +376,10 @@ index 25c7e1f76c72996eb1d8fb3d93cbfc06f4f41bf3..5afde92d7cdbd7d1b06060a2c047474a
  }
  
 diff --git a/src/profiler/heap-snapshot-generator.cc b/src/profiler/heap-snapshot-generator.cc
-index 38e75f4243dd905c8923b2c41c7f2e1b17d5072d..c525f0fd1c4f637d2b4b59c958572f888edeb6c1 100644
+index 33503ce014ced181230c189de617cadd5b7e43be..c4dd13be8b0480612b1beb8acad4a82e46b5d943 100644
 --- a/src/profiler/heap-snapshot-generator.cc
 +++ b/src/profiler/heap-snapshot-generator.cc
-@@ -1817,6 +1817,9 @@ void V8HeapExplorer::ExtractJSPromiseReferences(HeapEntry* entry,
+@@ -1832,6 +1832,9 @@ void V8HeapExplorer::ExtractJSPromiseReferences(HeapEntry* entry,
    SetInternalReference(entry, "reactions_or_result",
                         promise->reactions_or_result(),
                         JSPromise::kReactionsOrResultOffset);
@@ -434,10 +435,10 @@ index f5ff4a63dc0a3494f96dc557836adcbfee22ed8b..749f4a31597c19abb5b0ab67b5ec4951
  }  // namespace internal
  }  // namespace v8
 diff --git a/src/runtime/runtime.h b/src/runtime/runtime.h
-index a5c6cedd55a47d6db24738c77f04a41c735b739d..6f698bccc9ec8c62a17339eae114ba95d4e0c3b1 100644
+index 24347d46b884bf84de2a7914eec1ffe8b5a1340f..c6203f66cbf192a7339d5d69337febc1d8f17706 100644
 --- a/src/runtime/runtime.h
 +++ b/src/runtime/runtime.h
-@@ -402,7 +402,9 @@ namespace internal {
+@@ -405,7 +405,9 @@ namespace internal {
    F(PromiseRejectAfterResolved, 2, 1)    \
    F(PromiseResolveAfterResolved, 2, 1)   \
    F(ConstructAggregateErrorHelper, 4, 1) \

--- a/patches/v8/0010-Enable-V8-shared-linkage.patch
+++ b/patches/v8/0010-Enable-V8-shared-linkage.patch
@@ -1,14 +1,14 @@
-From 98baf18e19e905b8ecdcec3678f67a27ef0403d1 Mon Sep 17 00:00:00 2001
+From 0260f2e0b910db7342d9eed13e2aa5a80e8fbee1 Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Sun, 9 Jul 2023 18:46:20 -0400
 Subject: Enable V8 shared linkage
 
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 11c26187981450ccbb1291217cae2c4fae3db023..3eac159a78b8ed19e2ff0b04724a1d40b749a38e 100644
+index 35c8ec1656a0874c182d420954c7b1101dd6b1f7..83d0a7de3af130c1b95198bffb798a1f342a8053 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -1496,7 +1496,6 @@ filegroup(
+@@ -1500,7 +1500,6 @@ filegroup(
          "src/execution/futex-emulation.h",
          "src/execution/interrupts-scope.cc",
          "src/execution/interrupts-scope.h",
@@ -16,7 +16,7 @@ index 11c26187981450ccbb1291217cae2c4fae3db023..3eac159a78b8ed19e2ff0b04724a1d40
          "src/execution/isolate.h",
          "src/execution/isolate-data.h",
          "src/execution/isolate-inl.h",
-@@ -3747,6 +3746,10 @@ filegroup(
+@@ -3758,6 +3757,10 @@ filegroup(
          "src/snapshot/snapshot-empty.cc",
          "src/snapshot/static-roots-gen.cc",
          "src/snapshot/static-roots-gen.h",
@@ -27,7 +27,7 @@ index 11c26187981450ccbb1291217cae2c4fae3db023..3eac159a78b8ed19e2ff0b04724a1d40
      ],
  )
  
-@@ -4203,6 +4206,8 @@ v8_library(
+@@ -4214,6 +4217,8 @@ v8_library(
      name = "v8",
      srcs = [
          ":v8_inspector_files",
@@ -37,10 +37,10 @@ index 11c26187981450ccbb1291217cae2c4fae3db023..3eac159a78b8ed19e2ff0b04724a1d40
          ":is_not_v8_enable_turbofan": [
              # With Turbofan disabled, we only include the stubbed-out API.
 diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index a8552489ae1901e380fe6825def658911ffb9d62..e55defede9fed3eea9348bd7bd50d98f688a2a7b 100644
+index 58c5a0273769e0df997e9e92bd4274f3cb8f2fc6..32a36debd591db53f5c7dfcbdae4080e78647fd1 100644
 --- a/bazel/defs.bzl
 +++ b/bazel/defs.bzl
-@@ -294,7 +294,6 @@ def v8_library(
+@@ -295,7 +295,6 @@ def v8_library(
              copts = copts + default.copts,
              linkopts = linkopts + default.linkopts,
              alwayslink = 1,
@@ -48,7 +48,7 @@ index a8552489ae1901e380fe6825def658911ffb9d62..e55defede9fed3eea9348bd7bd50d98f
              **kwargs
          )
  
-@@ -313,7 +312,6 @@ def v8_library(
+@@ -314,7 +313,6 @@ def v8_library(
              copts = copts + default.copts + ENABLE_I18N_SUPPORT_DEFINES,
              linkopts = linkopts + default.linkopts,
              alwayslink = 1,
@@ -56,7 +56,7 @@ index a8552489ae1901e380fe6825def658911ffb9d62..e55defede9fed3eea9348bd7bd50d98f
              **kwargs
          )
  
-@@ -333,7 +331,6 @@ def v8_library(
+@@ -334,7 +332,6 @@ def v8_library(
              copts = copts + default.copts,
              linkopts = linkopts + default.linkopts,
              alwayslink = 1,

--- a/patches/v8/0011-Randomize-the-initial-ExecutionContextId-used-by-the.patch
+++ b/patches/v8/0011-Randomize-the-initial-ExecutionContextId-used-by-the.patch
@@ -1,4 +1,4 @@
-From 4d3628b920eaff1f648628e186371fda4704dbfa Mon Sep 17 00:00:00 2001
+From eab8942d89ba72d620f338fe00949c18ea0f310a Mon Sep 17 00:00:00 2001
 From: Orion Hodson <orion@cloudflare.com>
 Date: Wed, 13 Sep 2023 15:38:15 +0100
 Subject: Randomize the initial ExecutionContextId used by the inspector

--- a/patches/v8/0012-Always-enable-continuation-preserved-data-in-the-bui.patch
+++ b/patches/v8/0012-Always-enable-continuation-preserved-data-in-the-bui.patch
@@ -1,11 +1,11 @@
-From b79d1a994d3bb0b8a774ed6fe03ca7057bacea8a Mon Sep 17 00:00:00 2001
+From d45c01570f9d35750a9b3b179ae26761c3ecd9eb Mon Sep 17 00:00:00 2001
 From: James M Snell <jasnell@gmail.com>
 Date: Thu, 18 Jan 2024 10:19:14 -0800
 Subject: Always enable continuation preserved data in the build
 
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 3eac159a78b8ed19e2ff0b04724a1d40b749a38e..f3e7958b39e5b7e42b06fad83a0bf6f7352ffd3c 100644
+index 83d0a7de3af130c1b95198bffb798a1f342a8053..bb12025ec61e330798f6956daea7e850b6530d1b 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
 @@ -430,6 +430,7 @@ v8_config(

--- a/patches/v8/0013-increase-visibility-of-virtual-method.patch
+++ b/patches/v8/0013-increase-visibility-of-virtual-method.patch
@@ -1,4 +1,4 @@
-From 97e7428b6f68776b53b6ccd774643a53b7f43400 Mon Sep 17 00:00:00 2001
+From 9d3e44cb68db49f361ee5b7d6badfe79cde0e1dd Mon Sep 17 00:00:00 2001
 From: Mike Aizatsky <maizatskyi@cloudflare.com>
 Date: Tue, 6 Feb 2024 12:55:07 -0800
 Subject: increase visibility of virtual method

--- a/patches/v8/0014-Add-ValueSerializer-SetTreatFunctionsAsHostObjects.patch
+++ b/patches/v8/0014-Add-ValueSerializer-SetTreatFunctionsAsHostObjects.patch
@@ -1,4 +1,4 @@
-From 29224a29f67d26df68fddad0fe8fd8698a629d98 Mon Sep 17 00:00:00 2001
+From 75408c3f880f462fe2ab801f9b10fb8bde505a05 Mon Sep 17 00:00:00 2001
 From: Kenton Varda <kenton@cloudflare.com>
 Date: Sat, 2 Mar 2024 09:00:18 -0600
 Subject: Add ValueSerializer::SetTreatFunctionsAsHostObjects().
@@ -28,10 +28,10 @@ index 596be18adeb3a5a81794aaa44b1d347dec6c0c7d..141f138e08de849e3e02b3b2b346e643
     * Write raw data in various common formats to the buffer.
     * Note that integer types are written in base-128 varint format, not with a
 diff --git a/src/api/api.cc b/src/api/api.cc
-index dbd42ec0e2bdb37d604bbc4f72e402cf3a153b40..4ce08df6d8cb1c0d1c36b55ab67830f2f01eb4e1 100644
+index 709665a41d6219c4ef6392afc269c8c41b662d4b..81696ccdd35ec40726d05a8f6e35fffff63a80f6 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -3523,6 +3523,10 @@ void ValueSerializer::SetTreatArrayBufferViewsAsHostObjects(bool mode) {
+@@ -3460,6 +3460,10 @@ void ValueSerializer::SetTreatArrayBufferViewsAsHostObjects(bool mode) {
    private_->serializer.SetTreatArrayBufferViewsAsHostObjects(mode);
  }
  
@@ -43,7 +43,7 @@ index dbd42ec0e2bdb37d604bbc4f72e402cf3a153b40..4ce08df6d8cb1c0d1c36b55ab67830f2
                                          Local<Value> value) {
    auto i_isolate = reinterpret_cast<i::Isolate*>(context->GetIsolate());
 diff --git a/src/objects/value-serializer.cc b/src/objects/value-serializer.cc
-index f6b3579da294d86b6ad415471e2f29538ed5a629..d315739d0d604ed0557f51aca44fe0b41afabd38 100644
+index bb36e71af9cb2fda605200550a36c0a74e560671..fa85a7b462623ad627ecf07272bc95540b007ac6 100644
 --- a/src/objects/value-serializer.cc
 +++ b/src/objects/value-serializer.cc
 @@ -328,6 +328,10 @@ void ValueSerializer::SetTreatArrayBufferViewsAsHostObjects(bool mode) {

--- a/patches/v8/0015-Set-torque-generator-path-to-external-v8.-This-allow.patch
+++ b/patches/v8/0015-Set-torque-generator-path-to-external-v8.-This-allow.patch
@@ -1,4 +1,4 @@
-From 73ad7c7d3b3ff45b835ffba9eb97c6a0ca13deb9 Mon Sep 17 00:00:00 2001
+From 9b7ad1f488606db3429a10209f2b9e24abd9ce56 Mon Sep 17 00:00:00 2001
 From: Garrett Gu <garrett@cloudflare.com>
 Date: Wed, 10 Apr 2024 14:31:33 -0500
 Subject: Set torque generator path to external/v8. This allows bazel to find
@@ -8,10 +8,10 @@ Subject: Set torque generator path to external/v8. This allows bazel to find
 See https://chromium-review.googlesource.com/c/v8/v8/+/5339896
 
 diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index e55defede9fed3eea9348bd7bd50d98f688a2a7b..faeef2b2ed71b4784050451a61a16febbd7455b8 100644
+index 32a36debd591db53f5c7dfcbdae4080e78647fd1..1720e4ba4b610c0e1804184baf8516b7e2a8441c 100644
 --- a/bazel/defs.bzl
 +++ b/bazel/defs.bzl
-@@ -347,7 +347,7 @@ def get_cfg():
+@@ -348,7 +348,7 @@ def get_cfg():
  # split the set of outputs by using OutputGroupInfo, that way we do not need to
  # run the torque generator twice.
  def _torque_files_impl(ctx):

--- a/patches/v8/0016-Modify-where-to-look-for-fp16-dependency.-This-depen.patch
+++ b/patches/v8/0016-Modify-where-to-look-for-fp16-dependency.-This-depen.patch
@@ -1,19 +1,16 @@
-From b8c3575ff696eac20bd8d94f49407b52642087c1 Mon Sep 17 00:00:00 2001
+From b6f555a04117cc019523aafa6fb98de3b629db6a Mon Sep 17 00:00:00 2001
 From: Garrett Gu <garrett@cloudflare.com>
 Date: Mon, 22 Apr 2024 10:10:21 -0500
 Subject: Modify where to look for fp16 dependency. This dependency is normally
  downloaded by gn but we need to fetch it in Bazel. We do so in the workerd
  repo in the WORKSPACE file.
 
----
- BUILD.bazel | 26 ++++++++++++++++----------
- 1 file changed, 16 insertions(+), 10 deletions(-)
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index f3e7958b39e5b7e42b06fad83a0bf6f7352ffd3c..e1fed34c700e88cb7a54450d0f2c7cb34c6c921f 100644
+index bb12025ec61e330798f6956daea7e850b6530d1b..b8387d5aae1f37d2b4180b420e43d72e390fe138 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -3689,16 +3689,22 @@ filegroup(
+@@ -3700,16 +3700,22 @@ filegroup(
      }),
  )
  

--- a/patches/v8/0017-Fixup-RunMicrotask-to-restore-async-context-on-termi.patch
+++ b/patches/v8/0017-Fixup-RunMicrotask-to-restore-async-context-on-termi.patch
@@ -1,14 +1,14 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From e4427f63e1eb3214b868336d02072729a96c49ca Mon Sep 17 00:00:00 2001
 From: James M Snell <jasnell@gmail.com>
 Date: Thu, 18 Apr 2024 13:31:01 -0700
 Subject: Fixup RunMicrotask to restore async context on terminate execution
 
 
 diff --git a/src/execution/microtask-queue.cc b/src/execution/microtask-queue.cc
-index 0dda78af32572981be90e4d86fc789167e97b247..f85be4bcf1641c5d6454c1c90dfd90170027c5a8 100644
+index 983020785ec769138e0149d9f39ea93a0fc0efc9..ecefe54251b481265c169eafe2fa870c4f088741 100644
 --- a/src/execution/microtask-queue.cc
 +++ b/src/execution/microtask-queue.cc
-@@ -188,6 +188,11 @@ int MicrotaskQueue::RunMicrotasks(Isolate* isolate) {
+@@ -190,6 +190,11 @@ int MicrotaskQueue::RunMicrotasks(Isolate* isolate) {
                       processed_microtask_count);
    }
  
@@ -20,7 +20,7 @@ index 0dda78af32572981be90e4d86fc789167e97b247..f85be4bcf1641c5d6454c1c90dfd9017
    if (isolate->is_execution_terminating()) {
      DCHECK(isolate->has_exception());
      DCHECK(maybe_result.is_null());
-@@ -201,11 +206,6 @@ int MicrotaskQueue::RunMicrotasks(Isolate* isolate) {
+@@ -203,11 +208,6 @@ int MicrotaskQueue::RunMicrotasks(Isolate* isolate) {
      return -1;
    }
  

--- a/patches/v8/0018-Expose-v8-Symbol-GetDispose.patch
+++ b/patches/v8/0018-Expose-v8-Symbol-GetDispose.patch
@@ -1,0 +1,35 @@
+From 2a682aab4706d8405481300358e0c3f43c299359 Mon Sep 17 00:00:00 2001
+From: Jon Phillips <jphillips@cloudflare.com>
+Date: Tue, 30 Apr 2024 00:06:33 +0100
+Subject: Expose v8::Symbol::GetDispose().
+
+V8 appears to be in the process of supporting the explicit resource
+management spec. Since `Symbol.dispose` has been exposed to JS we need
+to be able to access the native v8::Symbol too.
+
+diff --git a/include/v8-primitive.h b/include/v8-primitive.h
+index eb0a791cf73946c0955f6ccadbb36f0c4999cbab..0fe1b2cd6ac9ad383f1e178221126d92a446154e 100644
+--- a/include/v8-primitive.h
++++ b/include/v8-primitive.h
+@@ -625,6 +625,7 @@ class V8_EXPORT Symbol : public Name {
+   static Local<Symbol> GetToPrimitive(Isolate* isolate);
+   static Local<Symbol> GetToStringTag(Isolate* isolate);
+   static Local<Symbol> GetUnscopables(Isolate* isolate);
++  static Local<Symbol> GetDispose(Isolate* isolate);
+ 
+   V8_INLINE static Symbol* Cast(Data* data) {
+ #ifdef V8_ENABLE_CHECKS
+diff --git a/src/api/api.cc b/src/api/api.cc
+index 81696ccdd35ec40726d05a8f6e35fffff63a80f6..b8ac160c2ae2adce89bff09f77a63d0732295943 100644
+--- a/src/api/api.cc
++++ b/src/api/api.cc
+@@ -9303,7 +9303,8 @@ Local<Symbol> v8::Symbol::ForApi(Isolate* v8_isolate, Local<String> name) {
+   V(Split, split)                             \
+   V(ToPrimitive, to_primitive)                \
+   V(ToStringTag, to_string_tag)               \
+-  V(Unscopables, unscopables)
++  V(Unscopables, unscopables)                 \
++  V(Dispose, dispose)                         \
+ 
+ #define SYMBOL_GETTER(Name, name)                                      \
+   Local<Symbol> v8::Symbol::Get##Name(Isolate* v8_isolate) {           \

--- a/patches/v8/0019-Rename-V8_COMPRESS_POINTERS_IN_ISOLATE_CAGE.patch
+++ b/patches/v8/0019-Rename-V8_COMPRESS_POINTERS_IN_ISOLATE_CAGE.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jon Phillips <jphillips@cloudflare.com>
+Date: Thu, 9 May 2024 23:36:43 +0100
+Subject: =?UTF-8?q?Rename=20V8=5FCOMPRESS=5FPOINTERS=5FIN=5FISOLATE=5FCAGE?=
+ =?UTF-8?q?=20->=0AV8=5FCOMPRESS=5FPOINTERS=5FIN=5FMULTIPLE=5FCAGES=20in?=
+ =?UTF-8?q?=20BUILD.bazel.?=
+
+This appears to have been missed as part of the v8 patch which applied
+this rename elsewhere:
+https://chromium-review.googlesource.com/c/v8/v8/+/5279595.
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 453726808be0e2c9b5f7cbdbec148e480b4c7349..7928495046052241943bf14a5a7e08e7c2fd128b 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -296,10 +296,10 @@ selects.config_setting_group(
+     ],
+ )
+
+-# Enable isolated cage if v8_enable_pointer_compression and
++# Enable multiple cages if v8_enable_pointer_compression and
+ # NOT v8_enable_pointer_compression_shared_cage.
+ selects.config_setting_group(
+-    name = "enable_pointer_compression_isolated_cage",
++    name = "enable_pointer_compression_multiple_cages",
+     match_all = [
+         ":is_v8_enable_pointer_compression",
+         ":is_not_v8_enable_pointer_compression_shared_cage",
+@@ -492,8 +492,8 @@ v8_config(
+         ":enable_pointer_compression_shared_cage": [
+             "V8_COMPRESS_POINTERS_IN_SHARED_CAGE",
+         ],
+-        ":enable_pointer_compression_isolated_cage": [
+-            "V8_COMPRESS_POINTERS_IN_ISOLATE_CAGE",
++        ":enable_pointer_compression_multiple_cages": [
++            "V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES",
+         ],
+         "//conditions:default": [],
+     }) + select({

--- a/src/workerd/api/node/util-nodejs-test.js
+++ b/src/workerd/api/node/util-nodejs-test.js
@@ -631,19 +631,26 @@ export const utilInspect = {
 
     // Prevent enumerable error properties from being printed.
     {
-      let err = new Error();
+      let err = new Error('foobar');
       err.message = 'foobar';
       let out = util.inspect(err).split('\n');
       assert.strictEqual(out[0], 'Error: foobar');
-      assert(out[out.length - 1].startsWith('    at '));
+      assert(out[1].startsWith('    at '));
       // Reset the error, the stack is otherwise not recreated.
       err = new Error();
       err.message = 'foobar';
+      out = util.inspect(err).split('\n');
+      assert.strictEqual(out[0], 'Error');
+      assert(out[1].startsWith('    at '));
+      assert.strictEqual(out[out.length - 2], "  message: 'foobar'");
+      assert.strictEqual(out[out.length - 1], '}');
+      // Reset the error, the stack is otherwise not recreated.
+      err = new Error('foobar');
       err.name = 'Unique';
       Object.defineProperty(err, 'stack', { value: err.stack, enumerable: true });
       out = util.inspect(err).split('\n');
       assert.strictEqual(out[0], 'Unique: foobar');
-      assert(out[out.length - 1].startsWith('    at '));
+      assert(out[1].startsWith('    at '));
       err.name = 'Baz';
       out = util.inspect(err).split('\n');
       assert.strictEqual(out[0], 'Unique: foobar');

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -268,7 +268,7 @@ Name Lock::newApiSymbol(kj::StringPtr symbol) {
 }
 
 JsSymbol Lock::symbolDispose() {
-  return IsolateBase::from(v8Isolate).getSymbolDispose();
+  return JsSymbol(v8::Symbol::GetDispose(v8Isolate));
 }
 JsSymbol Lock::symbolAsyncDispose() {
   return IsolateBase::from(v8Isolate).getSymbolAsyncDispose();

--- a/src/workerd/jsg/resource.c++
+++ b/src/workerd/jsg/resource.c++
@@ -31,17 +31,18 @@ void polyfillSymbols(jsg::Lock& js, v8::Local<v8::Context> context) {
 
     auto symbol = KJ_ASSERT_NONNULL(obj.get(js, "Symbol").tryCast<JsObject>());
 
-    KJ_DASSERT(!symbol.has(js, "dispose") && !symbol.has(js, "asyncDispose"),
-        "It looks like V8 has been updated to support the explicit resource management spec! "
-        "We should now remove our polyfill and depend on V8's version of these symbols.");
+    // At the time of writing, V8 has exposed the `Symbol.dispose` global symbol but not yet
+    // `asyncDispose`.
+    KJ_DASSERT(!symbol.has(js, "asyncDispose"),
+        "It looks like V8 has been updated to support the asyncDispose global symbol! "
+        "We should now remove our polyfill and depend on V8's version of this symbol.");
 
-    symbol.set(js, "dispose", js.symbolDispose());
     symbol.set(js, "asyncDispose", js.symbolAsyncDispose());
   });
 }
 
 v8::Local<v8::Symbol> getSymbolDispose(v8::Isolate* isolate) {
-  return IsolateBase::from(isolate).getSymbolDispose();
+  return v8::Symbol::GetDispose(isolate);
 }
 v8::Local<v8::Symbol> getSymbolAsyncDispose(v8::Isolate* isolate) {
   return IsolateBase::from(isolate).getSymbolAsyncDispose();

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -372,9 +372,6 @@ IsolateBase::IsolateBase(const V8System& system, v8::Isolate::CreateParams&& cre
       this->opaqueTemplate.Reset(ptr, opaqueTemplate);
 
       // Create Symbol.dispose and Symbol.asyncDispose.
-      symbolDispose.Reset(ptr, v8::Symbol::New(ptr,
-          v8::String::NewFromUtf8(ptr, "dispose",
-              v8::NewStringType::kInternalized).ToLocalChecked()));
       symbolAsyncDispose.Reset(ptr, v8::Symbol::New(ptr,
           v8::String::NewFromUtf8(ptr, "asyncDispose",
               v8::NewStringType::kInternalized).ToLocalChecked()));
@@ -406,7 +403,6 @@ void IsolateBase::dropWrappers(kj::Own<void> typeWrapperInstance) {
 
     // Make sure v8::Globals are destroyed under lock (but not until later).
     KJ_DEFER(symbolAsyncDispose.Reset());
-    KJ_DEFER(symbolDispose.Reset());
     KJ_DEFER(opaqueTemplate.Reset());
 
     // Make sure the TypeWrapper is destroyed under lock by declaring a new copy of the variable
@@ -621,6 +617,7 @@ kj::Maybe<kj::StringPtr> getJsStackTrace(void* ucontext, kj::ArrayPtr<char> scra
     case v8::StateTag::EXTERNAL:          vmState = "external"; break;
     case v8::StateTag::ATOMICS_WAIT:      vmState = "atomics_wait"; break;
     case v8::StateTag::IDLE:              vmState = "idle"; break;
+    case v8::StateTag::LOGGING:           vmState = "logging"; break;
   }
   appendText("js: (", vmState, ")");
 

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -152,9 +152,6 @@ public:
   size_t jsgGetMemorySelfSize() const { return sizeof(IsolateBase); }
   bool jsgGetMemoryInfoIsRootNode() const { return true; }
 
-  JsSymbol getSymbolDispose() {
-    return JsSymbol(symbolDispose.Get(ptr));
-  }
   JsSymbol getSymbolAsyncDispose() {
     return JsSymbol(symbolAsyncDispose.Get(ptr));
   }
@@ -211,8 +208,7 @@ private:
   // object with 2 internal fields.
   v8::Global<v8::FunctionTemplate> opaqueTemplate;
 
-  // Polyfilled Symbol.dispose and Symbol.asyncDispose.
-  v8::Global<v8::Symbol> symbolDispose;
+  // Polyfilled Symbol.asyncDispose.
   v8::Global<v8::Symbol> symbolAsyncDispose;
 
   // We expect queues to remain relatively small -- 8 is the largest size I have observed from local


### PR DESCRIPTION
Non-trivial changes:
* V8 appears to be in the process of supporting the explicit resource management spec. Since `Symbol.dispose` has been exposed to JS I've patched v8 to expose it via a native API so we can now use v8's `Symbol.dispose` for our JS RPC implementation.
* Node’s util.inspect changed behaviour due to the following V8 change: https://chromium-review.googlesource.com/c/v8/v8/+/5378709. I've patched the tests to reflect the new behaviour.