### PR TITLE
Fix content type determination for blob from fetch

### DIFF
--- a/src/workerd/api/tests/blob2-test.js
+++ b/src/workerd/api/tests/blob2-test.js
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { strictEqual } from 'node:assert';
+import { inspect } from 'node:util';
+
+export const test = {
+  async test() {
+    const res = new Response('test', {
+      headers: {
+        'content-type': 'text/plain, x/y, text/html',
+      }
+    });
+
+    const blob = await res.blob();
+
+    // Without the blob_standard_mime_type compat flag, the blob.type would be
+    // the incorrect 'text/plain, x/y, text/html'
+
+    strictEqual(await blob.text(), 'test');
+    strictEqual(blob.type, 'text/html');
+  }
+};

--- a/src/workerd/api/tests/blob2-test.wd-test
+++ b/src/workerd/api/tests/blob2-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "blob2-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "blob2-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat", "blob_standard_mime_type"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -426,4 +426,13 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # is the same as the one passed to the read method. Our original implementation returned
   # undefined instead. This flag changes the behavior to match the spec and to match the behavior
   # implemented by the JS-backed ReadableStream implementation.
+
+  blobStandardMimeType @48 :Bool
+      $compatEnableFlag("blob_standard_mime_type")
+      $compatDisableFlag("blob_legacy_mime_type")
+      $compatEnableDate("2024-06-03");
+  # The original implementation of the Blob mime type normalization when extracting a blob
+  # from the Request or Response body is not compliant with the standard. Unfortunately,
+  # making it compliant is a breaking change. This flag controls the availability of the
+  # new spec-compliant Blob mime type normalization.
 }

--- a/src/workerd/util/mimetype.h
+++ b/src/workerd/util/mimetype.h
@@ -92,9 +92,15 @@ public:
   static const MimeType MANIFEST_JSON;
   static const MimeType VTT;
   static const MimeType EVENT_STREAM;
+  static const MimeType WILDCARD;
 
   // exposed directly for performance reasons
   static const kj::StringPtr PLAINTEXT_STRING;
+
+  // Extracts a mime type from a concatenated list of content-type values
+  // per the algorithm defined in the fetch spec:
+  // https://fetch.spec.whatwg.org/#concept-header-extract-mime-type
+  static kj::Maybe<MimeType> extract(kj::StringPtr input);
 
 private:
   kj::String type_;
@@ -105,6 +111,9 @@ private:
   // 128 bytes will keep all reasonable mimetypes on the stack.
 
   void paramsToString(ToStringBuffer& buffer) const;
+
+  static kj::Maybe<MimeType> tryParseImpl(kj::ArrayPtr<const char> input,
+                                          ParseOptions options = ParseOptions::DEFAULT);
 };
 
 kj::String KJ_STRINGIFY(const MimeType& state);


### PR DESCRIPTION
Using a compatibility flag, selects the correct content type for a blob from the fetch-provided content-type header(s) as defined by the fetch spec: https://fetch.spec.whatwg.org/#concept-header-extract-mime-type

Sadly it's potentially breaking change so the compat flag is needed.

Fixes: https://github.com/cloudflare/workerd/issues/2099

Goal: Web standards compliance, bug fix