### PR TITLE
Fix setTimeout ID collisions.

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -687,7 +687,6 @@ TimeoutId::NumberType ServiceWorkerGlobalScope::setTimeoutInternal(
     jsg::Function<void()> function,
     double msDelay) {
   auto timeoutId = IoContext::current().setTimeoutImpl(
-      timeoutIdGenerator,
       /** repeats = */ false,
       kj::mv(function),
       msDelay);
@@ -707,7 +706,6 @@ TimeoutId::NumberType ServiceWorkerGlobalScope::setTimeout(
     function(js, kj::mv(args));
   };
   auto timeoutId = IoContext::current().setTimeoutImpl(
-      timeoutIdGenerator,
       /* repeats = */ false,
       [function = kj::mv(fn)](jsg::Lock& js) mutable {
     function(js);
@@ -737,7 +735,6 @@ TimeoutId::NumberType ServiceWorkerGlobalScope::setInterval(
     function(js, jsg::Arguments(kj::mv(argv)));
   };
   auto timeoutId = IoContext::current().setTimeoutImpl(
-      timeoutIdGenerator,
       /* repeats = */ true,
       [function = kj::mv(fn)](jsg::Lock& js) mutable {
     function(js);

--- a/src/workerd/api/gpu/gpu-async-runner.c++
+++ b/src/workerd/api/gpu/gpu-async-runner.c++
@@ -30,7 +30,7 @@ void AsyncRunner::QueueTick() {
   tick_queued_ = true;
 
   IoContext::current().setTimeoutImpl(
-      timeoutIdGenerator, false,
+      false,
       [this](jsg::Lock& js) mutable {
         this->tick_queued_ = false;
         if (this->count_ > 0) {

--- a/src/workerd/api/gpu/gpu-async-runner.h
+++ b/src/workerd/api/gpu/gpu-async-runner.h
@@ -33,7 +33,6 @@ private:
   wgpu::Device const device_;
   uint64_t count_ = 0;
   bool tick_queued_ = false;
-  TimeoutId::Generator timeoutIdGenerator;
 };
 
 // AsyncTask is a RAII helper for calling AsyncRunner::Begin() on construction,

--- a/src/workerd/api/gpu/webgpu-buffer-test.js
+++ b/src/workerd/api/gpu/webgpu-buffer-test.js
@@ -6,6 +6,11 @@ export class DurableObjectExample {
   }
 
   async fetch() {
+    // Some WebGPU APIs use setTimeout under the hood. There used to be a bug whereby webGPU would
+    // try to use a timeout ID that was already in use by a call to a JS timer API (or vice versa).
+    // We set a timeout here as a regression test.
+    setTimeout(() => { console.log("timeout fired"); }, 30000);
+
     ok(navigator.gpu);
     const adapter = await navigator.gpu.requestAdapter();
     ok(adapter);

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -548,7 +548,6 @@ public:
   // Used to implement setTimeout(). We don't expose the timer directly because the
   // promises it returns need to live in this I/O context, anyway.
   TimeoutId setTimeoutImpl(
-    TimeoutId::Generator& generator,
     bool repeat,
     jsg::Function<void()> function,
     double msDelay);

--- a/src/workerd/io/io-timers.h
+++ b/src/workerd/io/io-timers.h
@@ -79,11 +79,10 @@ public:
     kj::Maybe<jsg::Function<void()>> function;
   };
 
-  virtual TimeoutId setTimeout(
-      IoContext& context, TimeoutId::Generator& generator, TimeoutParameters params) = 0;
+  virtual TimeoutId setTimeout(IoContext& context, TimeoutParameters params) = 0;
   virtual void clearTimeout(IoContext& context, TimeoutId id) = 0;
   virtual size_t getTimeoutCount() const = 0;
   virtual kj::Maybe<kj::Date> getNextTimeout() const = 0;
 };
 
-}  // namespace workerd
+} // namespace workerd


### PR DESCRIPTION
`workerd::api::gpu::AsyncRunner` was using a different instance of `TimeoutId::Generator` than is used for `setTimeout` calls from JS.

I fix this by moving ownership of the `TimeoutIdGenerator` into the `TimeoutManagerImpl` itself.

In the case of `gpu::AsyncRunner`, it doesn't look like there's any need to generate an ID for the timeout, so we could alternatively approach this by re-using the timeout logic but not generating an ID in order to avoid silently using up timeout ID values under the hood. Not sure whether it's worth it.