### PR TITLE
Add fetch_standard_url compat flag

### DIFF
--- a/src/workerd/api/http-standard-test.js
+++ b/src/workerd/api/http-standard-test.js
@@ -1,0 +1,27 @@
+import { strictEqual } from 'node:assert';
+
+export default {
+  async fetch(req) {
+    if (req.url.endsWith('/')) {
+      return new Response(null, {
+        status: 302,
+        headers: {
+          location: ' /\t2  '
+        }
+      });
+    } else if (req.url.endsWith('/2')) {
+      return new Response("ok");
+    }
+  }
+};
+
+export const test = {
+  async test(ctrl, env) {
+
+    const resp = await env.SERVICE.fetch(' http://p\tl\na\tc\ne\th\no\tl\nd\te\nr\t/ ');
+
+    console.log(resp.url);
+
+    strictEqual(await resp.text(), "ok");
+  }
+};

--- a/src/workerd/api/http-standard-test.wd-test
+++ b/src/workerd/api/http-standard-test.wd-test
@@ -1,0 +1,18 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "http-standard-test",
+      worker = (
+        modules = [
+          ( name = "worker", esModule = embed "http-standard-test.js" )
+        ],
+        bindings = [
+          ( name = "SERVICE", service = "http-standard-test" )
+        ],
+        compatibilityDate = "2023-08-01",
+        compatibilityFlags = ["nodejs_compat", "fetch_standard_url"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -435,4 +435,10 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # from the Request or Response body is not compliant with the standard. Unfortunately,
   # making it compliant is a breaking change. This flag controls the availability of the
   # new spec-compliant Blob mime type normalization.
+
+  fetchStandardUrl @49 :Bool
+    $compatEnableFlag("fetch_standard_url")
+    $compatDisableFlag("fetch_legacy_url")
+    $compatEnableDate("2024-06-03");
+  # Ensures that WHATWG standard URL parsing is used in the fetch API implementation.
 }


### PR DESCRIPTION
Adds a compat flag that makes it so that the fetch('...') method variant that takes a URL string, the `Request` object constructor, and redirects will use the standard URL parser.

This is not really how I would prefer to address this since, unfortunately, this introduces a double parsing and serialization of the URL in order to minimize changes to the existing implementation. It would be nicer (and very possible) to refactor things to avoid the double parsing at some point.

Fixes: https://github.com/cloudflare/workerd/issues/1957