### PR TITLE
Python: Fix header conversion to byte-pair on scope building

### DIFF
--- a/src/pyodide/internal/asgi.py
+++ b/src/pyodide/internal/asgi.py
@@ -24,8 +24,10 @@ def acquire_js_buffer(pybuffer):
 
 def request_to_scope(req, env, ws=False):
     from js import URL
-
-    headers = [tuple(x) for x in req.headers]
+    # @app.get("/example")
+    # async def example(request: Request):
+    #     request.headers.get("content-type") # this will error if header is not "bytes" as in ASGI spec.
+    headers = [(k.lower().encode(), v.encode()) for k, v in req.headers]
     url = URL.new(req.url)
     assert url.protocol[-1] == ":"
     scheme = url.protocol[:-1]
@@ -111,7 +113,8 @@ async def process_request(app, req, env):
         nonlocal headers
         if got["type"] == "http.response.start":
             status = got["status"]
-            headers = got["headers"]
+            # Like above, we need to convert byte-pairs into string explicitly.
+            headers = [(k.decode(), v.decode()) for k, v in got["headers"]]
         if got["type"] == "http.response.body":
             # intentionally leak body to avoid a copy
             #

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -33,6 +33,17 @@ wd_test(
     ),
 )
 
+wd_test(
+    src = "asgi/asgi.wd-test",
+    args = ["--experimental"],
+    data = glob(
+        [
+            "asgi/*",
+        ],
+        exclude = ["**/*.wd-test"],
+    ),
+)
+
 # langchain test: disabled for now because it's flaky
 # TODO: reenable this?
 #

--- a/src/workerd/server/tests/python/asgi/asgi.wd-test
+++ b/src/workerd/server/tests/python/asgi/asgi.wd-test
@@ -1,0 +1,19 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "python-asgi",
+      worker = (
+        modules = [
+          (name = "worker.py", pythonModule = embed "worker.py"),
+          (name = "fastapi", pythonRequirement = ""),
+        ],
+        bindings = [
+          ( name = "SELF", service = "python-asgi" ),
+        ],
+        compatibilityDate = "2024-10-01",
+        compatibilityFlags = ["python_workers"],
+      )
+    )
+  ],
+);

--- a/src/workerd/server/tests/python/asgi/worker.py
+++ b/src/workerd/server/tests/python/asgi/worker.py
@@ -1,0 +1,71 @@
+from pyodide.ffi import to_js
+
+
+def check_encoding(byte_str, encoding="utf-8"):
+    try:
+        byte_str.decode(encoding)
+        return True
+    except UnicodeDecodeError:
+        return False
+
+
+class Server:
+    def __init__(self):
+        pass
+
+    async def __call__(self, scope, receive, send) -> None:
+        scope["app"] = self
+
+        assert scope["type"] in ("http", "websocket", "lifespan")
+
+        if scope["type"] == "lifespan":
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            return
+
+        elif scope["type"] == "http":
+            headers = scope["headers"]
+            for header in headers:
+                assert isinstance(header[0], bytes) and isinstance(header[1], bytes)
+                assert check_encoding(header[0]) and check_encoding(header[1])
+
+            await receive()
+            # Send response and return
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": headers,
+                }
+            )
+
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b"Hello, World",
+                }
+            )
+
+
+async def on_fetch(request, env):
+    import asgi
+
+    return await asgi.fetch(app, request, env)
+
+
+app = Server()
+
+
+async def header_test(env):
+    example_hdr = {"Header1": "Value1", "Header2": "Value2"}
+    response = await env.SELF.fetch("http://example.com/", headers=to_js(example_hdr))
+    for header in response.headers:
+        assert isinstance(header[0], str) and isinstance(header[1], str)
+        expected_hdr = {k.lower(): v.lower() for k, v in example_hdr.items()}
+        assert header[0] in expected_hdr.keys()
+        assert expected_hdr[header[0]] == header[1].lower()
+
+
+async def test(ctrl, env):
+    await header_test(env)


### PR DESCRIPTION
> headers: These are byte strings of the exact byte sequences sent by the client/to be sent by the server. While modern HTTP standards say that headers should be ASCII, older ones did not and allowed a wider range of characters. Frameworks/applications should decode headers as they deem appropriate.
(https://asgi.readthedocs.io/en/latest/specs/www.html#wsgi-compatibility)

Workerd uses Pyodide JSProxy object when passing `fetch(request, env)` to Python, but JSProxy objects translates into string, not byte-string.

In order to match ASGI specification, it needs to be translated into byte-pair when building scopes.