### PR TITLE
Refactor DOMException

### DIFF
--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -228,6 +228,7 @@ enum SerializationTag {
   response @6;
 
   domException @7;
+  domExceptionV2 @8;
   # Keep this value in sync with the DOMException::SERIALIZATION_TAG in
   # /src/workerd/jsg/dom-exception (but we can't actually change this value
   # without breaking things).

--- a/src/workerd/jsg/dom-exception.c++
+++ b/src/workerd/jsg/dom-exception.c++
@@ -11,14 +11,31 @@
 namespace workerd::jsg {
 
 Ref<DOMException> DOMException::constructor(
-    Lock& js,
+    const v8::FunctionCallbackInfo<v8::Value>& args,
     Optional<kj::String> message,
     Optional<kj::String> name) {
+  Lock& js = Lock::from(args.GetIsolate());
   kj::String errMessage = kj::mv(message).orDefault([&] { return kj::String(); });
+
+  // V8 gives Error objects a non-standard (but widely known) `stack` property, and Web IDL
+  // requires that DOMException get any non-standard properties that Error gets. Chrome honors
+  // this requirement only for runtime-generated DOMExceptions -- script-generated DOMExceptions
+  // don't get `stack`, even though script-generated Errors do. It's more convenient and, IMO,
+  // more conformant to just give all DOMExceptions a `stack` property.
+  jsg::check(v8::Exception::CaptureStackTrace(js.v8Context(), args.This()));
+
+  // This part is a bit of a hack. By default, the various properties on JavaScript errors
+  // are not enumerable. However, our implementation of DOMException has always defined
+  // them as enumerable, which means just setting the stack above would be a breaking change.
+  // To maintain backwards compat we have to define the stack as enumerable here.
+  v8::PropertyDescriptor prop;
+  prop.set_enumerable(true);
+  v8::Local<v8::String> stackName = js.str("stack"_kjc);
+  jsg::check(args.This()->DefineProperty(js.v8Context(), stackName, prop));
+
   return jsg::alloc<DOMException>(
       kj::mv(errMessage),
-      kj::mv(name).orDefault([] { return kj::str("Error"); }),
-      js.v8Ref(v8::Exception::Error(v8Str(js.v8Isolate, errMessage)).As<v8::Object>()));
+      kj::mv(name).orDefault([] { return kj::str("Error"); }));
 }
 
 kj::StringPtr DOMException::getName() {
@@ -42,37 +59,47 @@ int DOMException::getCode() {
   return 0;
 }
 
-v8::Local<v8::Value> DOMException::getStack(Lock& js) {
-  return js.v8Get(errorForStack.getHandle(js), "stack"_kj);
-}
-
-void DOMException::visitForGc(GcVisitor& visitor) {
-  visitor.visit(errorForStack);
-}
-
 void DOMException::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
-  // TODO(cleanup): The `errorForStack` field is a bit unfortunate. It is an extraneous
-  // error object that we have to create currently in order to get the stack field because
-  // v8 currently does not provide a way to attach the stack to the JS wrapper object
-  // from C++. Sadly, the `errorForStack` ends up duplicating both the `name` and `message`
-  // properties. Ideally in the future, however, we can do away with errorForStack and
-  // instead just attach the stack property to the JS wrapper object directly. Doing so,
-  // we may be able to optimize things a bit more but for now, we'll just serialize the
-  // name and errorForStack and pull the message off the deserialized error on the other
-  // side.
   serializer.writeLengthDelimited(name);
-  serializer.write(js, JsValue(errorForStack.getHandle(js)));
+  serializer.writeLengthDelimited(message);
+
+  // It's a bit unfortunate that the stack here ends up also including the name and message
+  // so we end up duplicating some of the information here, but that's ok. It's better to
+  // keep this implementation simple rather than to implement any kind of deduplication.
+  KJ_IF_SOME(stack, this->stack.get(js, "stack")) {
+    serializer.writeLengthDelimited(stack);
+  } else {
+    // This branch shouldn't really be taken in the typical case. It's only here
+    // to handle the case where the stack property could not be unwrapped for some
+    // reason. We don't need to treat it as an error case, just set the stack to
+    // the empty string and move on.
+    serializer.writeLengthDelimited(""_kj);
+  }
 }
 
 jsg::Ref<DOMException> DOMException::deserialize(
     jsg::Lock& js, uint tag, jsg::Deserializer& deserializer) {
-  kj::String name = deserializer.readLengthDelimitedString();
-  auto errorForStack = KJ_ASSERT_NONNULL(deserializer.readValue(js).tryCast<JsObject>());
-  kj::String message = KJ_ASSERT_NONNULL(errorForStack.get(js, "message"_kj)
-      .tryCast<JsString>()).toString(js);
-  return jsg::alloc<DOMException>(kj::mv(message),
-                                  kj::mv(name),
-                                  js.v8Ref<v8::Object>(errorForStack));
+  switch (tag) {
+    case SERIALIZATION_TAG_V2: {
+      kj::String name = deserializer.readLengthDelimitedString();
+      kj::String message = deserializer.readLengthDelimitedString();
+      kj::String stack = deserializer.readLengthDelimitedString();
+      return js.domException(kj::mv(name), kj::mv(message), kj::mv(stack));
+    }
+    case SERIALIZATION_TAG: {
+      // This is the original serialization of DOMException. It was only
+      // used for a very short period of time (a matter of weeks) but there's
+      // still a remote chance that someone might use it in some persisted state
+      // somewhere. So let's go ahead and support it.
+      kj::String name = deserializer.readLengthDelimitedString();
+      auto errorForStack = KJ_ASSERT_NONNULL(deserializer.readValue(js).tryCast<JsObject>());
+      kj::String message = KJ_ASSERT_NONNULL(errorForStack.get(js, "message"_kj)
+          .tryCast<JsString>()).toString(js);
+      kj::String stack = KJ_ASSERT_NONNULL(errorForStack.get(js, "stack")
+          .tryCast<JsString>()).toString(js);
+      return js.domException(kj::mv(message), kj::mv(name), kj::mv(stack));
+    }
+  }
 }
 
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2026,6 +2026,8 @@ class JsMessage;
   JS_TYPE_CLASSES(V)
 #undef V
 
+class DOMException;
+
 // Represents an isolate lock, which allows the current thread to execute JavaScript code within
 // an isolate. A thread must lock an isolate -- obtaining an instance of `Lock` -- before it can
 // manipulate JavaScript objects or execute JavaScript code inside the isolate.
@@ -2329,6 +2331,9 @@ public:
       return fn();
     }
   }
+
+  virtual Ref<DOMException> domException(kj::String name, kj::String message,
+      kj::Maybe<kj::String> stackValue = kj::none) = 0;
 
   // ====================================================================================
   JsObject global() KJ_WARN_UNUSED_RESULT;

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -411,11 +411,6 @@ template <typename Arg> auto getParameterType(void (*)(Arg)) -> Arg;
 // SFINAE-friendly accessor for a resource type's configuration parameter.
 template <typename T> using GetConfiguration = decltype(getParameterType(&T::jsgConfiguration));
 
-v8::Local<v8::Value> makeDOMException(
-    v8::Isolate* isolate,
-    v8::Local<v8::String> message,
-    kj::StringPtr name);
-
 inline bool isFinite(double value) {
   return !(kj::isNaN(value) || value == kj::inf() || value == -kj::inf());
 }


### PR DESCRIPTION
* Eliminate the extra object allocated for the stack using the new v8::Exception::CaptureStackTrace API.
* Avoid having to use the JS constructor to create instances by using the FunctionTemplate directly