### PR TITLE
Fix JsRpcPromise::Resolved context checking.

### DIFF
--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -883,7 +883,8 @@ export let crossContextSharingDoesntWork = {
           "Cannot perform I/O on behalf of a different request. I/O objects (such as streams, " +
           "request/response bodies, and others) created in the context of one request handler " +
           "cannot be accessed from a different request's handler. This is a limitation of " +
-          "Cloudflare Workers which allows us to improve overall performance."
+          "Cloudflare Workers which allows us to improve overall performance. " +
+          "(I/O type: JsRpcPromise)"
     });
 
     // Now let's try accessing a JsRpcProperty, where the property is NOT a direct property of a
@@ -907,7 +908,8 @@ export let crossContextSharingDoesntWork = {
           "Cannot perform I/O on behalf of a different request. I/O objects (such as streams, " +
           "request/response bodies, and others) created in the context of one request handler " +
           "cannot be accessed from a different request's handler. This is a limitation of " +
-          "Cloudflare Workers which allows us to improve overall performance."
+          "Cloudflare Workers which allows us to improve overall performance. " +
+          "(I/O type: JsRpcPromise)"
     });
   },
 }

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -213,8 +213,11 @@ private:
   struct Resolved {
     jsg::Value result;
 
-    // We only use this to prohibit use from the wrong context.
-    kj::Own<IoContext::WeakRef> ioCtx;
+    // Dummy IoPtr to self, used only to verify that we're running in the correct context.
+    // (Dereferencing from the wrong context would throw an exception.)
+    // Note: Can't use IoContext::WeakRef here because it's not thread-safe (it's only intended to
+    //   be helf from KJ I/O objects, but this is a JSG object).
+    IoPtr<JsRpcPromise> ctxCheck;
   };
   struct Disposed {};
 


### PR DESCRIPTION
`IoContext::WeakRef` is a KJ I/O object, so `kj::Own<IoContext::WeakRef>` is not safe to hold from a JSG object. Instead, it would need to be `kj::IoOwn<IoContext::WeakRef>`. But, at that point we don't even need the `WeakRef` anymore because dereferencing the `IoOwn` itself will do exactly the check that we were using the `WeakRef` to do.

Actually, all we really need here is an `IoPtr<T>` (the type of `T` is irrelevant) which we can attempt to dereference in order to effect the context check we want.