### PR TITLE
V8 Updates: Migrate to v8::Object::Wrap/Unwrap

### DIFF
--- a/src/workerd/jsg/ser.c++
+++ b/src/workerd/jsg/ser.c++
@@ -103,8 +103,7 @@ v8::Maybe<bool> Serializer::WriteHostObject(v8::Isolate* isolate, v8::Local<v8::
     jsg::Lock& js = jsg::Lock::from(isolate);
 
     if (object->InternalFieldCount() != Wrappable::INTERNAL_FIELD_COUNT ||
-        object->GetAlignedPointerFromInternalField(Wrappable::WRAPPABLE_TAG_FIELD_INDEX) !=
-            &Wrappable::WRAPPABLE_TAG) {
+        !Wrappable::isWorkerdApiObject(object)) {
       KJ_IF_SOME(eh, externalHandler) {
         if (object->IsFunction()) {
           eh.serializeFunction(js, *this, object.As<v8::Function>());

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -278,13 +278,7 @@ bool HeapTracer::TryResetRoot(const v8::TracedReference<v8::Value>& handle) {
 namespace {
   std::unique_ptr<v8::CppHeap> newCppHeap(V8PlatformWrapper* system) {
     return jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
-      v8::CppHeapCreateParams heapParams {
-        {},
-        v8::WrapperDescriptor(
-            Wrappable::WRAPPABLE_TAG_FIELD_INDEX,
-            Wrappable::CPPGC_SHIM_FIELD_INDEX,
-            Wrappable::WRAPPABLE_TAG)
-      };
+      v8::CppHeapCreateParams heapParams {{}};
       heapParams.marking_support = cppgc::Heap::MarkingType::kAtomic;
       heapParams.sweeping_support = cppgc::Heap::SweepingType::kAtomic;
       return v8::CppHeap::Create(system, heapParams);


### PR DESCRIPTION
v8 is simplifying the way embedder apis connect to wrapper JS objects.

This attempts to keep the necessary changes as minimal as possible.

Note that with the move to `v8::Object::Wrap/Unwrap`, we ought to be able to eliminate the special handling of the context global wrapper and simplify things a bit further, but that's bit of a larger change. Will save that for a separate PR.