### PR TITLE
Fix CppGc leak.

### DIFF
--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -187,6 +187,7 @@ private:
   using Item = kj::OneOf<v8::Global<v8::Data>, RefToDelete>;
 
   const V8System& system;
+  std::unique_ptr<class v8::CppHeap> cppHeap;
   v8::Isolate* ptr;
   kj::Maybe<kj::String> uuid;
   bool evalAllowed = false;


### PR DESCRIPTION
V8 does not dispose of the v8::CppHeap we pass to it on isolate construction, so we now do that ourselves.