### PR TITLE
Node.js Compat: Implement the nodejs_compat_v2 compat flag

### DIFF
--- a/src/node/internal/process.ts
+++ b/src/node/internal/process.ts
@@ -16,6 +16,8 @@ import {
   ERR_INVALID_ARG_VALUE,
 } from 'node-internal:internal_errors'
 
+import { default as utilImpl } from 'node-internal:util';
+
 export function nextTick(cb: Function, ...args: unknown[]) {
   queueMicrotask(() => { cb(...args); });
 };
@@ -62,7 +64,12 @@ export const env = new Proxy({}, {
   }
 });
 
+export function getBuiltinModule(id: string) : any {
+  return utilImpl.getBuiltinModule(id);
+}
+
 export default {
   nextTick,
   env,
+  getBuiltinModule,
 };

--- a/src/node/internal/util.d.ts
+++ b/src/node/internal/util.d.ts
@@ -107,3 +107,5 @@ export function isWeakMap(value: unknown): value is WeakMap<any, unknown>;
 export function isWeakSet(value: unknown): value is WeakSet<any>;
 export function isAnyArrayBuffer(value: unknown): value is ArrayBuffer | SharedArrayBuffer;
 export function isBoxedPrimitive(value: unknown): value is Number | String | Boolean | BigInt | Symbol;
+
+export function getBuiltinModule(id: string): any;

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -454,6 +454,12 @@ public:
 
   void reportError(jsg::Lock& js, jsg::JsValue error);
 
+  // When the nodejs_compat_v2 compatibility flag is enabled, we expose the Node.js
+  // compat Buffer and process at the global scope in all modules as lazy instance
+  // properties.
+  jsg::JsValue getBuffer(jsg::Lock& js);
+  jsg::JsValue getProcess(jsg::Lock& js);
+
   JSG_RESOURCE_TYPE(ServiceWorkerGlobalScope, CompatibilityFlags::Reader flags) {
     JSG_INHERIT(WorkerGlobalScope);
 
@@ -525,6 +531,12 @@ public:
       JSG_NESTED_TYPE(ReadableByteStreamController);
       JSG_NESTED_TYPE(WritableStreamDefaultController);
       JSG_NESTED_TYPE(TransformStreamDefaultController);
+    }
+
+    if (flags.getNodeJsCompatV2()) {
+      JSG_LAZY_INSTANCE_PROPERTY(Buffer, getBuffer);
+      JSG_LAZY_INSTANCE_PROPERTY(process, getProcess);
+      JSG_LAZY_INSTANCE_PROPERTY(global, getSelf);
     }
 
     JSG_NESTED_TYPE(CompressionStream);

--- a/src/workerd/api/node/node-compat-v2-test.js
+++ b/src/workerd/api/node/node-compat-v2-test.js
@@ -1,0 +1,64 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+
+// Imports of Node.js built-ins should work both with and without
+// the 'node:' prefix.
+import { default as assert } from 'node:assert';
+import { default as assert2 } from 'assert';
+const assert3 = (await import('node:assert')).default;
+const assert4 = (await import('assert')).default;
+
+assert.strictEqual(assert, assert2);
+assert.strictEqual(assert, assert3);
+assert.strictEqual(assert, assert4);
+
+export const nodeJsExpectedGlobals = {
+  async test() {
+    // Expected Node.js globals Buffer, process, and global should be present.
+    const { Buffer } = await import('node:buffer');
+    assert.strictEqual(Buffer, globalThis.Buffer);
+
+    const { default: process } = await import('node:process');
+    assert.strictEqual(process, globalThis.process);
+
+    assert.strictEqual(global, globalThis);
+  }
+};
+
+export const nodeJsGetBuiltins = {
+  async test() {
+    // node:* modules in the worker bundle should override the built-in modules...
+    const { default: fs } = await import('node:fs');
+    const { default: path } = await import('node:path');
+
+    await import ('node:path');
+
+    // But process.getBuiltinModule should always return the built-in module.
+    const builtInPath = process.getBuiltinModule('node:path');
+    const builtInFs = process.getBuiltinModule('node:fs');
+
+    // These are from the worker bundle....
+    assert.strictEqual(fs, 1);
+    assert.strictEqual(path, 2);
+
+    // But these are from the built-ins...
+    // node:fs is not implemented currently so it should be undefined here.
+    assert.strictEqual(builtInFs, undefined);
+
+    // node:path is implemented tho...
+    assert.notStrictEqual(path, builtInPath);
+    assert.strictEqual(typeof builtInPath, 'object');
+    assert.strictEqual(typeof builtInPath.join, 'function');
+
+    // While process.getBuiltinModule(...) in Node.js only returns Node.js
+    // built-ins, our impl will return cloudflare: and workerd: built-ins
+    // also, for completeness. A key difference, however, is that for non-Node.js
+    // built-ins, the return value is the module namespace rather than the default
+    // export.
+
+    const socket = await import('cloudflare:sockets');
+    assert.strictEqual(process.getBuiltinModule('cloudflare:sockets'), socket);
+  }
+};

--- a/src/workerd/api/node/node-compat-v2-test.wd-test
+++ b/src/workerd/api/node/node-compat-v2-test.wd-test
@@ -1,0 +1,17 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "node-compat-v2-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "node-compat-v2-test.js"),
+          (name = "node:fs", esModule = "export default 1"),
+          (name = "node:path", esModule = "export default 2"),
+        ],
+        compatibilityDate = "2024-05-01",
+        compatibilityFlags = ["nodejs_compat_v2", "experimental"]
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -60,16 +60,19 @@ void registerNodeJsCompatModules(
 #undef V
 #undef NODEJS_MODULES
 
+  bool nodeJsCompatEnabled = featureFlags.getNodeJsCompat() ||
+                             featureFlags.getNodeJsCompatV2();
+
   // If the `nodejs_compat` flag isn't enabled, only register internal modules.
   // We need these for `console.log()`ing when running `workerd` locally.
   kj::Maybe<jsg::ModuleType> maybeFilter;
-  if (!featureFlags.getNodeJsCompat()) maybeFilter = jsg::ModuleType::INTERNAL;
+  if (!nodeJsCompatEnabled) maybeFilter = jsg::ModuleType::INTERNAL;
 
   registry.addBuiltinBundle(NODE_BUNDLE, maybeFilter);
 
   // If the `nodejs_compat` flag is off, but the `nodejs_als` flag is on, we
   // need to register the `node:async_hooks` module from the bundle.
-  if (!featureFlags.getNodeJsCompat() && featureFlags.getNodeJsAls()) {
+  if (!nodeJsCompatEnabled && featureFlags.getNodeJsAls()) {
     jsg::Bundle::Reader reader = NODE_BUNDLE;
     for (auto module : reader.getModules()) {
       auto specifier = module.getName();

--- a/src/workerd/api/node/util.h
+++ b/src/workerd/api/node/util.h
@@ -196,6 +196,8 @@ public:
   bool isAnyArrayBuffer(jsg::JsValue value);
   bool isBoxedPrimitive(jsg::JsValue value);
 
+  jsg::JsValue getBuiltinModule(jsg::Lock& js, kj::String specifier);
+
   JSG_RESOURCE_TYPE(UtilModule) {
     JSG_NESTED_TYPE(MIMEType);
     JSG_NESTED_TYPE(MIMEParams);
@@ -220,6 +222,8 @@ public:
   #undef V
     JSG_METHOD(isAnyArrayBuffer);
     JSG_METHOD(isBoxedPrimitive);
+
+    JSG_METHOD(getBuiltinModule);
   }
 };
 

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -441,4 +441,12 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
     $compatDisableFlag("fetch_legacy_url")
     $compatEnableDate("2024-06-03");
   # Ensures that WHATWG standard URL parsing is used in the fetch API implementation.
+
+  nodeJsCompatV2 @50 :Bool
+      $compatEnableFlag("nodejs_compat_v2")
+      $compatDisableFlag("no_nodejs_compat_v2")
+      $experimental;
+  # Implies nodeJSCompat with the following additional modifications:
+  # * Node.js Compat built-ins may be imported/required with or without the node: prefix
+  # * Node.js Compat the globals Buffer and process are available everywhere
 }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1018,6 +1018,9 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
 
     lock->setCaptureThrowsAsRejections(features.getCaptureThrowsAsRejections());
     lock->setCommonJsExportDefault(features.getExportCommonJsDefaultNamespace());
+    if (features.getNodeJsCompatV2()) {
+      lock->setNodeJsCompatEnabled();
+    }
 
     if (impl->inspector != kj::none || ::kj::_::Debug::shouldLog(::kj::LogSeverity::INFO)) {
       lock->setLoggerCallback([this](jsg::Lock& js, kj::StringPtr message) {

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -192,6 +192,10 @@ void Lock::setCaptureThrowsAsRejections(bool capture) {
   IsolateBase::from(v8Isolate).setCaptureThrowsAsRejections({}, capture);
 }
 
+void Lock::setNodeJsCompatEnabled() {
+  IsolateBase::from(v8Isolate).setNodeJsCompatEnabled({}, true);
+}
+
 void Lock::setCommonJsExportDefault(bool exportDefault) {
   IsolateBase::from(v8Isolate).setCommonJsExportDefault({}, exportDefault);
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2296,6 +2296,8 @@ public:
   void setCaptureThrowsAsRejections(bool capture);
   void setCommonJsExportDefault(bool exportDefault);
 
+  void setNodeJsCompatEnabled();
+
   using Logger = void(Lock&, kj::StringPtr);
   void setLoggerCallback(kj::Function<Logger>&& logger);
 

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -124,8 +124,14 @@ public:
     exportCommonJsDefault = exportDefault;
   }
 
+  inline void setNodeJsCompatEnabled(kj::Badge<Lock>, bool enabled) {
+    nodeJsCompatEnabled = enabled;
+  }
+
   inline bool areWarningsLogged() const { return maybeLogger != kj::none; }
   inline bool areErrorsReported() const { return maybeErrorReporter != kj::none; }
+
+  inline bool isNodeJsCompatEnabled() const { return nodeJsCompatEnabled; }
 
   // The logger will be optionally set by the isolate setup logic if there is anywhere
   // for the log to go (for instance, if debug logging is enabled or the inspector is
@@ -201,6 +207,7 @@ private:
   bool captureThrowsAsRejections = false;
   bool exportCommonJsDefault = false;
   bool asyncContextTrackingEnabled = false;
+  bool nodeJsCompatEnabled = false;
 
   kj::Maybe<kj::Function<Logger>> maybeLogger;
   kj::Maybe<kj::Function<ErrorReporter>> maybeErrorReporter;


### PR DESCRIPTION
The `nodejs_compat_v2` flag supersedes the 'nodejs_compat' flag. When enabled...

1. Node.js built-ins are available for import/require
2. Unlike the original `nodejs_compat` flag, Node.js imports do not require the 'node:' specifier prefix. Internally, the implementation will detect a Node.js raw specifier and convert it into the appropriate prefixed specifier, e.g. 'fs' becomes 'node:fs'
3. The `Buffer`, `process`, and `global` are exposed on the global
4. A user worker bundle can still provide its own implementations of all `node:` modules which will take precedence over the built-ins
5. The new `process.getBuiltinModule(...)` API is implemented. See https://github.com/nodejs/node/pull/52762

A worker can replace the implementation of `node:process` if they choose, which may mean that `getBuiltinModule(...)` is not available.

Refs: https://github.com/cloudflare/workerd/issues/2133