### PR TITLE
actor-cache: migrate DO default shutdown exception type from "overloaded" to "disconnected"

### DIFF
--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -75,6 +75,7 @@ wd_cc_library(
         "//src/workerd/api:analytics-engine_capnp",
         "//src/workerd/api:r2-api_capnp",
         "//src/workerd/jsg",
+        "//src/workerd/util:autogate",
         "//src/workerd/util:duration-exceeded-logger",
         "//src/workerd/util:sqlite",
         "@capnp-cpp//src/capnp:capnp-rpc",
@@ -222,6 +223,7 @@ wd_cc_capnp_library(
     src = f,
     deps = [
         ":io",
+        "//src/workerd/util:autogate",
         "//src/workerd/util:test-util",
     ],
 ) for f in glob(["*-test.c++"])]

--- a/src/workerd/io/actor-cache-test.c++
+++ b/src/workerd/io/actor-cache-test.c++
@@ -5277,7 +5277,7 @@ KJ_TEST("ActorCache can shutdown") {
 
     auto error = options.maybeError.map([](const kj::Exception& e) {
       return kj::cp(e);
-    }).orDefault(KJ_EXCEPTION(OVERLOADED, kj::str(ActorCache::SHUTDOWN_ERROR_MESSAGE)));
+    }).orDefault(KJ_EXCEPTION(DISCONNECTED, kj::str(ActorCache::SHUTDOWN_ERROR_MESSAGE)));
 
     if (res.shouldBreakOutputGate) {
       // We expected the output gate to break async after shutdown.

--- a/src/workerd/io/actor-cache-test.c++
+++ b/src/workerd/io/actor-cache-test.c++
@@ -10,6 +10,7 @@
 #include "io-gate.h"
 #include <kj/thread.h>
 #include <kj/source-location.h>
+#include <workerd/util/autogate.h>
 #include <workerd/util/capnp-mock.h>
 
 namespace workerd {
@@ -197,6 +198,7 @@ struct ActorCacheTestOptions {
   size_t maxKeysPerRpc = 128;
   bool noCache = false;
   bool neverFlush = false;
+  bool withUpdatedExceptionTypes = false;
 };
 
 struct ActorCacheTest: public ActorCacheConvenienceWrappers {
@@ -225,7 +227,21 @@ struct ActorCacheTest: public ActorCacheConvenienceWrappers {
         cache(kj::mv(mockPair.client), lru, gate),
         gateBrokenPromise(options.monitorOutputGate
             ? eagerlyReportExceptions(gate.onBroken())
-            : kj::Promise<void>(kj::READY_NOW)) {}
+            : kj::Promise<void>(kj::READY_NOW)) {
+    // Set up autogate
+    capnp::MallocMessageBuilder message;
+    auto orphanage = message.getOrphanage();
+    kj::Vector<kj::StringPtr> strs;
+    if (options.withUpdatedExceptionTypes) {
+      strs.add("workerd-autogate-updated-actor-exception-types"_kj);
+    }
+    auto gatesOrphan = orphanage.newOrphan<capnp::List<capnp::Text>>(strs.size());
+    auto gates = gatesOrphan.get();
+    for (auto i: kj::indices(strs)) {
+      gates.set(i, strs[i]);
+    }
+    util::Autogate::initAutogate(gates.asReader());
+  }
 
   ~ActorCacheTest() noexcept(false) {
     // Make sure if the output gate has been broken, the exception was reported. This is important
@@ -5249,9 +5265,13 @@ KJ_TEST("ActorCache can shutdown") {
 
   struct VerifyOptions {
     kj::Maybe<const kj::Exception&> maybeError;
+    bool withUpdatedExceptionTypes = false;
   };
   auto verifyWithOptions = [&](auto&& beforeShutdown, auto&& afterShutdown, VerifyOptions options) {
-    auto test = ActorCacheTest({.monitorOutputGate = false});
+    auto test = ActorCacheTest({
+      .monitorOutputGate = false,
+      .withUpdatedExceptionTypes = options.withUpdatedExceptionTypes,
+    });
     auto& ws = test.ws;
 
     BeforeShutdownResult res = beforeShutdown(test);
@@ -5275,9 +5295,14 @@ KJ_TEST("ActorCache can shutdown") {
     }                                                                                              \
   } while (false)
 
+    KJ_ASSERT(options.withUpdatedExceptionTypes ==
+        util::Autogate::isEnabled(util::AutogateKey::UPDATED_ACTOR_EXCEPTION_TYPES));
+    auto defaultError = (options.withUpdatedExceptionTypes
+            ? KJ_EXCEPTION(DISCONNECTED, kj::str(ActorCache::SHUTDOWN_ERROR_MESSAGE))
+            : KJ_EXCEPTION(OVERLOADED, kj::str(ActorCache::SHUTDOWN_ERROR_MESSAGE)));
     auto error = options.maybeError.map([](const kj::Exception& e) {
       return kj::cp(e);
-    }).orDefault(KJ_EXCEPTION(DISCONNECTED, kj::str(ActorCache::SHUTDOWN_ERROR_MESSAGE)));
+    }).orDefault(defaultError);
 
     if (res.shouldBreakOutputGate) {
       // We expected the output gate to break async after shutdown.
@@ -5310,8 +5335,14 @@ KJ_TEST("ActorCache can shutdown") {
   };
 
   auto verify = [&](auto&& beforeShutdown, auto&& afterShutdown) {
-    verifyWithOptions(beforeShutdown, afterShutdown, {.maybeError = kj::none});
-    verifyWithOptions(beforeShutdown, afterShutdown, {.maybeError = KJ_EXCEPTION(FAILED, "Nope.")});
+    verifyWithOptions(beforeShutdown, afterShutdown,
+        { .maybeError = kj::none, .withUpdatedExceptionTypes = false });
+    verifyWithOptions(beforeShutdown, afterShutdown,
+        { .maybeError = kj::none, .withUpdatedExceptionTypes = true });
+    verifyWithOptions(beforeShutdown, afterShutdown,
+        { .maybeError = KJ_EXCEPTION(FAILED, "Nope."), .withUpdatedExceptionTypes = false });
+    verifyWithOptions(beforeShutdown, afterShutdown,
+        { .maybeError = KJ_EXCEPTION(FAILED, "Nope."), .withUpdatedExceptionTypes = true });
   };
 
   verify([](ActorCacheTest& test){

--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -2225,7 +2225,7 @@ void ActorCache::shutdown(kj::Maybe<const kj::Exception&> maybeException) {
 
       // Use the direct constructor so that we can reuse the constexpr message variable for testing.
       auto exception = kj::Exception(
-          kj::Exception::Type::OVERLOADED, __FILE__, __LINE__,
+          kj::Exception::Type::DISCONNECTED, __FILE__, __LINE__,
           kj::heapString(SHUTDOWN_ERROR_MESSAGE));
 
       // Add trace info sufficient to tell us which operation caused the failure.

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -315,7 +315,7 @@ void ActorSqlite::shutdown(kj::Maybe<const kj::Exception&> maybeException) {
 
       // Use the direct constructor so that we can reuse the constexpr message variable for testing.
       auto exception = kj::Exception(
-          kj::Exception::Type::OVERLOADED, __FILE__, __LINE__,
+          kj::Exception::Type::DISCONNECTED, __FILE__, __LINE__,
           kj::heapString(ActorCache::SHUTDOWN_ERROR_MESSAGE));
 
       // Add trace info sufficient to tell us which operation caused the failure.

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -5,6 +5,7 @@
 #include "actor-sqlite.h"
 #include <algorithm>
 #include <workerd/jsg/jsg.h>
+#include <workerd/util/autogate.h>
 #include "io-gate.h"
 
 namespace workerd {
@@ -314,9 +315,11 @@ void ActorSqlite::shutdown(kj::Maybe<const kj::Exception&> maybeException) {
       }
 
       // Use the direct constructor so that we can reuse the constexpr message variable for testing.
+      auto excType = (util::Autogate::isEnabled(util::AutogateKey::UPDATED_ACTOR_EXCEPTION_TYPES)
+              ? kj::Exception::Type::DISCONNECTED
+              : kj::Exception::Type::OVERLOADED);
       auto exception = kj::Exception(
-          kj::Exception::Type::DISCONNECTED, __FILE__, __LINE__,
-          kj::heapString(ActorCache::SHUTDOWN_ERROR_MESSAGE));
+          excType, __FILE__, __LINE__, kj::heapString(ActorCache::SHUTDOWN_ERROR_MESSAGE));
 
       // Add trace info sufficient to tell us which operation caused the failure.
       exception.addTraceHere();

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -4,6 +4,7 @@
 
 #include "server.h"
 #include <kj/test.h>
+#include <workerd/util/autogate.h>
 #include <workerd/util/capnp-mock.h>
 #include <workerd/jsg/setup.h>
 #include <kj/async-queue.h>
@@ -36,6 +37,8 @@ kj::Own<config::Config::Reader> parseConfig(kj::StringPtr text, kj::SourceLocati
   })) {
     KJ_FAIL_REQUIRE_AT(loc, exception);
   }
+
+  util::Autogate::initAutogate(root.asReader().getAutogates());
 
   return capnp::clone(root.asReader());
 }

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -13,6 +13,8 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
   switch (key) {
     case AutogateKey::TEST_WORKERD:
       return "test-workerd"_kj;
+    case AutogateKey::UPDATED_ACTOR_EXCEPTION_TYPES:
+      return "updated-actor-exception-types";
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -13,6 +13,7 @@ namespace workerd::util {
 // Workerd-specific list of autogate keys (can also be used in internal repo).
 enum class AutogateKey {
   TEST_WORKERD,
+  UPDATED_ACTOR_EXCEPTION_TYPES, // updates exception types to better match retriability
   NumOfKeys // Reserved for iteration.
 };
 


### PR DESCRIPTION
These "Durable Object storage is no longer accessible" exceptions would occur during actor destruction, if no other explicit exception is provided.  It is unknown if these still occur, but it seems likely that they would occur due to a transient reason -- like the worker getting evicted -- rather than overload, so we'd like to treat them as retryable.
