### PR TITLE
Implement unsettled promise tracker

### DIFF
--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -483,6 +483,12 @@ public:
       kj::Function<ModuleFallbackCallback>&& callback) const {
     // By default does nothing.
   }
+
+  virtual void enableUnsettledPromiseTracker() {
+    // Non-op by default
+  }
+
+  virtual bool isUnsettledPromiseTrackerEnabled() const { return false; }
 };
 
 // A Worker may bounce between threads as it handles multiple requests, but can only actually

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -23,6 +23,7 @@ wd_cc_library(
         "util.c++",
         "v8-platform-wrapper.c++",
         "wrappable.c++",
+        "promise-tracker.c++",
     ],
     hdrs = [
         "async-context.h",
@@ -49,6 +50,7 @@ wd_cc_library(
         "value.h",
         "web-idl.h",
         "wrappable.h",
+        "promise-tracker.h",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/workerd/jsg/promise-tracker-test.c++
+++ b/src/workerd/jsg/promise-tracker-test.c++
@@ -1,0 +1,51 @@
+#include "promise-tracker.h"
+#include "jsg-test.h"
+
+namespace workerd::jsg::test {
+
+V8System v8System;
+
+namespace {
+
+struct PromiseContext: public jsg::Object, public jsg::ContextGlobal {
+  JSG_RESOURCE_TYPE(PromiseContext) {}
+};
+JSG_DECLARE_ISOLATE_TYPE(PromiseIsolate, PromiseContext);
+
+KJ_TEST("Promise Tracker") {
+  Evaluator<PromiseContext, PromiseIsolate> e(v8System);
+  e.getIsolate().enableUnsettledPromiseTracker();
+
+  e.getIsolate().runInLockScope([](PromiseIsolate::Lock& lock) {
+    JSG_WITHIN_CONTEXT_SCOPE(lock,
+      lock.template newContext<PromiseContext>().getHandle(lock.v8Isolate),
+      [](jsg::Lock& js) {
+
+      auto& isolateBase = IsolateBase::from(js.v8Isolate);
+      auto& tracker = KJ_ASSERT_NONNULL(isolateBase.getUnsettledPromiseTracker());
+
+      // Create an unresolved promise.
+      auto p1 = js.newPromiseAndResolver<void>();
+
+      // Create a resolved promise.
+      auto p2 = js.resolvedPromise();
+
+      // Create a rejected promise.
+      auto p3 = js.rejectedPromise<void>(js.str("foo"_kj));
+
+      KJ_ASSERT(tracker.size() == 1);
+      KJ_ASSERT(tracker.report().size() > 0);
+
+      // Now let's resolve the outstanding promise...
+      p1.resolver.resolve(js);
+
+      KJ_ASSERT(tracker.size() == 0);
+      KJ_ASSERT(tracker.report().size() == 0);
+
+      KJ_ASSERT(true);
+    });
+  });
+}
+
+}  // namespace
+}  // namespace workerd::jsg::test

--- a/src/workerd/jsg/promise-tracker.c++
+++ b/src/workerd/jsg/promise-tracker.c++
@@ -1,0 +1,63 @@
+#include "promise-tracker.h"
+#include "setup.h"
+#include <kj/vector.h>
+#include <v8.h>
+
+namespace workerd::jsg {
+
+UnsettledPromiseTracker::UnsettledPromiseTracker(v8::Isolate* isolate) : isolate(isolate) {
+  isolate->SetPromiseHook([](v8::PromiseHookType type,
+                             v8::Local<v8::Promise> promise,
+                             v8::Local<v8::Value> parent) {
+    auto& js = Lock::from(promise->GetIsolate());
+    auto& isolate = IsolateBase::from(promise->GetIsolate());
+    UnsettledPromiseTracker& self = KJ_ASSERT_NONNULL(isolate.getUnsettledPromiseTracker());
+    switch (type) {
+      case v8::PromiseHookType::kInit:
+        {
+          auto obj = js.obj();
+          obj.set(js, "name"_kj, js.str(kj::str("Promise ", promise->GetIdentityHash())));
+
+          auto message = ([&] {
+            if (parent->IsPromise()) {
+              return kj::str("follows ", parent.As<v8::Promise>()->GetIdentityHash());
+            } else {
+              return kj::str("created");
+            }
+          })();
+
+          obj.set(js, "message"_kj, js.str(message));
+          v8::Exception::CaptureStackTrace(js.v8Context(), obj);
+          auto stack = obj.get(js, "stack"_kj);
+          self.promises_.upsert(promise->GetIdentityHash(), stack.toString(js));
+        }
+        break;
+      case v8::PromiseHookType::kResolve: {
+          self.promises_.erase(promise->GetIdentityHash());
+        }
+        break;
+      case v8::PromiseHookType::kBefore: {
+        // Nothing to do in this case
+        break;
+      }
+      case v8::PromiseHookType::kAfter: {
+        // Nothing to do in this case
+        break;
+      }
+    }
+  });
+}
+
+UnsettledPromiseTracker::~UnsettledPromiseTracker() noexcept(false) {
+  isolate->SetPromiseHook(nullptr);
+}
+
+kj::String UnsettledPromiseTracker::report() {
+  kj::Vector<kj::String> lines;
+  for (auto& [id, stack] : promises_) {
+    lines.add(kj::str("Unresolved ", stack));
+  }
+  return kj::str(kj::delimited(lines.releaseAsArray(), "\n"_kj));
+}
+
+}  // namespace workerd::jsg

--- a/src/workerd/jsg/promise-tracker.h
+++ b/src/workerd/jsg/promise-tracker.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <kj/map.h>
+
+namespace v8 {
+  class Isolate;
+}
+
+namespace workerd::jsg {
+
+// The UnsettledPromiseTracker is a local-dev utility that tracks all promises
+// created in an isolate and will generate a report of all promises that are
+// unsettled when `report()` is called. This is useful for debugging cases where
+// promises may be hanging to know exactly where they were created.
+//
+// Note that this uses the v8 Promise Hooks API under the covers. If we add more
+// uses of the promise hooks API, the implementation of this will need to be
+// refactored a bit as the design of that API allows only one set of hooks to
+// be installed on an isolate at a time.
+//
+// Only ONE instance of the UnsettledPromiseTracker should be created at a time
+// for any single isolate.
+class UnsettledPromiseTracker final {
+public:
+  UnsettledPromiseTracker(v8::Isolate* isolate);
+  ~UnsettledPromiseTracker() noexcept(false);
+
+  KJ_DISALLOW_COPY_AND_MOVE(UnsettledPromiseTracker);
+
+  kj::String report();
+
+  inline size_t size() const { return promises_.size(); }
+  inline void reset() { promises_.clear(); }
+
+private:
+  v8::Isolate* isolate;
+
+  // We don't want to maintain strong references to the promises themselves so
+  // here we are going to maintain a table of the promise id hash and the serialized
+  // stack identifying where the promise was created.
+  kj::HashMap<int, kj::String> promises_;
+};
+
+}  // namespace workerd::jsg

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -14,6 +14,7 @@
 #include <kj/map.h>
 #include <kj/mutex.h>
 #include <workerd/jsg/observer.h>
+#include <workerd/jsg/promise-tracker.h>
 
 namespace workerd::jsg {
 
@@ -68,6 +69,8 @@ private:
 class IsolateBase {
 public:
   static IsolateBase& from(v8::Isolate* isolate);
+
+  inline v8::Isolate* getIsolate() { return ptr; }
 
   // Unwraps a JavaScript exception as a kj::Exception.
   virtual kj::Exception unwrapException(v8::Local<v8::Context> context,
@@ -156,6 +159,9 @@ public:
     return JsSymbol(symbolAsyncDispose.Get(ptr));
   }
 
+  void enableUnsettledPromiseTracker();
+  kj::Maybe<UnsettledPromiseTracker&> getUnsettledPromiseTracker();
+
 private:
   template <typename TypeWrapper>
   friend class Isolate;
@@ -204,6 +210,8 @@ private:
   kj::Maybe<kj::Function<Logger>> maybeLogger;
   kj::Maybe<kj::Function<ErrorReporter>> maybeErrorReporter;
   kj::Maybe<kj::Function<ModuleFallbackCallback>> maybeModuleFallbackCallback;
+
+  kj::Maybe<kj::Own<UnsettledPromiseTracker>> unsettledPromiseTracker;
 
   // FunctionTemplate used by Wrappable::attachOpaqueWrapper(). Just a constructor for an empty
   // object with 2 internal fields.

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2682,6 +2682,11 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
                                   *memoryCacheProvider,
                                   pythonConfig
                                   );
+
+  if (traceUnsettledPromises) {
+    api->enableUnsettledPromiseTracker();
+  }
+
   auto inspectorPolicy = Worker::Isolate::InspectorPolicy::DISALLOW;
   if (inspectorOverride != kj::none) {
     // For workerd, if the inspector is enabled, it is always fully trusted.

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -71,6 +71,10 @@ public:
     pythonConfig.createBaselineSnapshot = true;
   }
 
+  void enableTraceUnsettledPromises() {
+    traceUnsettledPromises = true;
+  }
+
   // Runs the server using the given config.
   kj::Promise<void> run(jsg::V8System& v8System, config::Config::Reader conf,
                         kj::Promise<void> drainWhen = kj::NEVER_DONE);
@@ -109,6 +113,7 @@ private:
   };
 
   bool experimental = false;
+  bool traceUnsettledPromises = false;
 
   Worker::ConsoleMode consoleMode;
 

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -879,4 +879,12 @@ const WorkerdApi& WorkerdApi::from(const Worker::Api& api) {
   return kj::downcast<const WorkerdApi>(api);
 }
 
+void WorkerdApi::enableUnsettledPromiseTracker() {
+  impl->jsgIsolate.enableUnsettledPromiseTracker();
+}
+
+bool WorkerdApi::isUnsettledPromiseTrackerEnabled() const {
+  return const_cast<JsgWorkerdIsolate&>(impl->jsgIsolate).getUnsettledPromiseTracker() != kj::none;
+}
+
 }  // namespace workerd::server

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -224,6 +224,9 @@ public:
   void setModuleFallbackCallback(
        kj::Function<ModuleFallbackCallback>&& callback) const override;
 
+  void enableUnsettledPromiseTracker() override;
+  bool isUnsettledPromiseTrackerEnabled() const override;
+
 private:
   struct Impl;
   kj::Own<Impl> impl;

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -736,7 +736,10 @@ public:
         .addOption({"python-save-snapshot"}, [this]() { server.setPythonCreateSnapshot();  return true; },
                   "Save a dedicated snapshot to the disk cache")
         .addOption({"python-save-baseline-snapshot"}, [this]() { server.setPythonCreateBaselineSnapshot();  return true; },
-                  "Save a baseline snapshot to the disk cache");
+                  "Save a baseline snapshot to the disk cache")
+        .addOption({"trace-unsettled-promises"}, [this]() {
+            server.enableTraceUnsettledPromises(); return true;
+        }, "Trace unsettled promises on request completion");
   }
 
   kj::MainFunc addServeOptions(kj::MainBuilder& builder) {


### PR DESCRIPTION
@mikenomitch @kentonv  ...

This provides a prototype of a utility for tracking unsettled-promises using the v8 promise hooks API.

For example, given this example:

```
export default {
  async fetch(req, env) {

    const { promise } = Promise.withResolvers();
    await promise;

    return new Response("Hello World\n");
  }
};
```

...and running workerd with the `--trace-unsettled-promises` CLI flag...

The output would be similar to: 

![image](https://github.com/cloudflare/workerd/assets/439929/705022d1-2d2e-408f-b43d-b29a6b2d51b3)

Notice here that there are few limitations with this approach.

1. While the tracker will attempt to grab the stack trace identifying the location where promises are created, that's not always possible if the promise is created internally by the runtime.
2. While the tracker can know if one promise is following another, we can't always really know *what* promises those actually are. The best we have is the hash id of the promise.
3. Using the promise hooks, we can't know really if the promise is from this IoContext/request or not. We could potentially expand the context tagging mechanism we use to follow cross-request promises but that would be a bit of a larger change. Certainly possible but would require additional floated patches on v8
4. It's difficult for us to determine exactly which promise represents the one that is holding up the request itself.

So while this gives us more useful information than what we had before, it's certainly not perfect.