### PR TITLE
[CI][build] Improve CI configuration to mitigate resource constraints

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -176,6 +176,14 @@ build:macos --macos_minimum_os=11.5 --host_macos_minimum_os=11.5
 # information on the flag.
 build:macos --copt='-femit-dwarf-unwind=no-compact-unwind'
 
+# Bazel doesn't allow setting flags only for a specific build mode like fastbuild, but somehow has
+# a flag that does this for ObjC to set "-O0 -DDEBUG=1". Worse yet, options set by this flag cannot
+# be overwritten on the command line, which confusingly makes enabling optimization there not have
+# an effect. On macOS we build some ObjC as part of Dawn, set this flag to an empty string so we
+# can set the right configuration flags.
+# TODO(soon): File a bazel issue for the flag so we can drop this.
+build:macos --experimental_objc_fastbuild_options=''
+
 # Unfortunately experimental_objc_fastbuild_options does not respect options set before and
 # overwrites them. This causes mysterious binary size bloat for fastbuild-based configurations on
 # macOS when enabling some optimizations. Turn it in into a no-op.
@@ -226,10 +234,10 @@ build:windows --extra_execution_platforms=//:x64_windows-clang-cl
 # workaround.
 
 build:windows_no_dbg -c opt
-build:windows_no_dbg --copt='-O0' --host_copt='-O0'
-build:windows_no_dbg --copt='/Od' --host_copt='/Od'
-build:windows_no_dbg --linkopt='/INCREMENTAL:NO' --host_linkopt='/INCREMENTAL:NO'
-build:windows_no_dbg --features=-smaller_binary --features=-disable_assertions_feature
+build:windows_no_dbg --copt='-O0'
+build:windows_no_dbg --copt='/Od'
+build:windows_no_dbg --linkopt='/INCREMENTAL:NO'
+build:windows_no_dbg --features=-smaller_binary
 
 # Mitigate the large size impact of Windows debug binaries somewhat by applying string merging and
 # linker garbage collection.

--- a/.bazelrc
+++ b/.bazelrc
@@ -202,7 +202,7 @@ build:linux --force_pic
 
 # On Linux, garbage collection sections and optimize binary size. These do not apply to the macOS
 # toolchain.
-build:linux --linkopt="-Wl,--gc-sections" --linkopt="-Wl,-O2"
+build:linux --linkopt="-Wl,--gc-sections"
 build:linux --copt="-ffunction-sections" --host_copt="-ffunction-sections"
 build:linux --copt="-fdata-sections" --host_copt="-fdata-sections"
 
@@ -260,7 +260,9 @@ build:release --@rules_rust//:extra_rustc_flag=-Ccodegen-units=1
 # performance, but -O3 should generally be expected to be faster for at least parts of the workerd API.
 build:release_unix --copt='-O3'
 build:release_unix --config=release
+
 build:release_linux --config=release_unix
+build:release_linux --linkopt="-Wl,-O2"
 
 build:release_macos --config=release_unix
 # Disable generating LC_DATA_IN_CODE and LC_FUNCTION_STARTS binary sections, two rarely used types

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,10 @@ jobs:
             config: { suffix: '', bazel-args: '' }
           - os:     { name : windows, image : windows-2022 }
             config: { suffix: -debug, bazel-args: --config=debug }
+          # due to resource constraints, exclude the macOS-debug runner for now. linux-debug and
+          # linux-asan should provide sufficient coverage for building in the debug configuration.
+          - os:     { name : macOS, image : macos-13 }
+            config: { suffix: -debug, bazel-args: --config=debug }
       fail-fast: false
     runs-on: ${{ matrix.os.image }}
     name: test (${{ matrix.os.name }}${{ matrix.config.suffix }})
@@ -128,6 +132,16 @@ jobs:
           build:limit-storage --config=rust-debug
           build:asan --config=limit-storage
           build:debug --config=limit-storage
+          EOF
+      - name: Fix macOS fastbuild configuration
+        # Unlike the bazel Unix toolchain the macOS toolchain sets "-O0 -DDEBUG" for fastbuild by
+        # default. This is unhelpful for compile speeds and test performance, remove the DEBUG
+        # define.
+        if: ${{ !(contains(matrix.config.suffix, 'debug') || contains(matrix.config.suffix, 'asan')) }}
+        shell: bash
+        run: |
+          cat <<EOF >> .bazelrc
+          build:macos --copt=-UDEBUG
           EOF
       - name: Configure git hooks
         # Configure git to quell an irrelevant warning for runners (they never commit / push).


### PR DESCRIPTION
- Disable the macOS-debug runner for now to avoid macOS build queueing unless we have a proper way to approach this.
- For macOS fastbuild, don't define DEBUG to match Linux configuration
- Drop the nonsensical experimental_objc_fastbuild_options flag.
- Don't try to re-enable assertions for Windows fastbuild – this never took effect as the feature was spelled wrong (needs to be just "disable_assertions"), actually using assertions would likely make the Windows build slower (it is already slower than the macOS/Linux jobs).
- Drop flags to disable optimization in the host configuration for Windows fastbuild. Host tools (e.g. capnpc for generating .capnp.h files) use 'opt' mode by default and we want them to run quickly.

Only apply -Wl,-O2 under release configuration
We turned on linker string tail merging as enabled by lld's -O2 flag by default after experiencing binary size constraints on CI, but this can slow down linking. Only enable it for release builds.