### PR TITLE
Add `highWaterMark` option to `Socket` for backpressure signaling

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -65,6 +65,13 @@ bool getAllowHalfOpen(jsg::Optional<SocketOptions>& opts) {
   return false;
 }
 
+kj::Maybe<uint64_t> getWritableHighWaterMark(jsg::Optional<SocketOptions>& opts) {
+  KJ_IF_SOME(o, opts) {
+    return o.highWaterMark;
+  }
+  return kj::none;
+}
+
 } // namespace
 
 jsg::Ref<Socket> setupSocket(
@@ -146,7 +153,9 @@ jsg::Ref<Socket> setupSocket(
   auto openedPrPair = js.newPromiseAndResolver<SocketInfo>();
   openedPrPair.promise.markAsHandled(js);
   auto writable = jsg::alloc<WritableStream>(
-      ioContext, kj::mv(sysStreams.writable), kj::none, openedPrPair.promise.whenResolved(js));
+      ioContext, kj::mv(sysStreams.writable),
+      getWritableHighWaterMark(options),
+      openedPrPair.promise.whenResolved(js));
 
   auto result = jsg::alloc<Socket>(
       js, ioContext,

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -38,7 +38,8 @@ typedef kj::OneOf<SocketAddress, kj::String> AnySocketAddress;
 struct SocketOptions {
   jsg::Optional<kj::String> secureTransport;
   bool allowHalfOpen = false;
-  JSG_STRUCT(secureTransport, allowHalfOpen);
+  jsg::Optional<uint64_t> highWaterMark;
+  JSG_STRUCT(secureTransport, allowHalfOpen, highWaterMark);
   JSG_MEMORY_INFO(SocketOptions) {
     tracker.trackField("secureTransport", secureTransport);
   }


### PR DESCRIPTION
Adds a `highWaterMark` to `SocketOptions` that is used to configure the high water mark for the socket `WritableStream`. When the size of the internal pending write queue reaches this value, the stream will signal backpressure to the user.