### PR TITLE
Bug Fix: Fixup WritableStream backpressure signaling, add warning

### DIFF
--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -275,6 +275,8 @@ private:
   kj::Maybe<PendingAbort> maybePendingAbort;
 
   uint64_t currentWriteBufferSize = 0;
+  bool warnAboutExcessiveBackpressure = true;
+  size_t excessiveBackpressureWarningCount = 0;
 
   // The highWaterMark is the total amount of data currently buffered in
   // the controller waiting to be flushed out to the underlying WritableStreamSink.

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -381,6 +381,8 @@ private:
 
   std::deque<WriteRequest> writeRequests;
   size_t amountBuffered = 0;
+  bool warnAboutExcessiveBackpressure = true;
+  size_t excessiveBackpressureWarningCount = 0;
 
   kj::Maybe<WriteRequest> inFlightWrite;
   kj::Maybe<jsg::Promise<void>::Resolver> inFlightClose;


### PR DESCRIPTION
Fixes a bug in the internal WritableStream impl that would cause it to signal backpressure too often, also add a warning if a WritableStream excessively exceeds the configured highwatermark (if any). "Excessive" here is defined as a multiple of the high water mark.