### PR TITLE
[CI] Reduce set of build dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@ FROM mcr.microsoft.com/devcontainers/base:jammy
 # will also install lldb and clangd alongside dependencies.
 ARG LLVM_VERSION=15
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install software-properties-common python3 python3-distutils tclsh \
+    && apt-get -y install --no-install-recommends software-properties-common python3 python3-distutils tclsh \
     && curl -fSsL -o /tmp/llvm.sh https://apt.llvm.org/llvm.sh && chmod +x /tmp/llvm.sh && bash /tmp/llvm.sh ${LLVM_VERSION} \
     && apt-get -y install --no-install-recommends libunwind-${LLVM_VERSION} libc++abi1-${LLVM_VERSION} libc++1-${LLVM_VERSION} libc++-${LLVM_VERSION}-dev libclang-rt-${LLVM_VERSION}-dev -o DPkg::options::="--force-overwrite"
 ENV PATH /usr/lib/llvm-${LLVM_VERSION}/bin:$PATH

--- a/.github/workflows/npm-types.yml
+++ b/.github/workflows/npm-types.yml
@@ -48,9 +48,10 @@ jobs:
         run: |
             export DEBIAN_FRONTEND=noninteractive
             wget https://apt.llvm.org/llvm.sh
+            sed -i '/apt-get install/d' llvm.sh
             chmod +x llvm.sh
             sudo ./llvm.sh 15
-            sudo apt-get install -y libunwind-15 libc++abi1-15 libc++1-15 libc++-15-dev
+            sudo apt-get install -y --no-install-recommends clang-15 lld-15 libunwind-15 libc++abi1-15 libc++1-15 libc++-15-dev
             echo "build:linux --action_env=CC=/usr/lib/llvm-15/bin/clang --action_env=CXX=/usr/lib/llvm-15/bin/clang++" >> .bazelrc
             echo "build:linux --host_action_env=CC=/usr/lib/llvm-15/bin/clang --host_action_env=CXX=/usr/lib/llvm-15/bin/clang++" >> .bazelrc
       - name: build types

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,9 +86,10 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           wget https://apt.llvm.org/llvm.sh
+          sed -i '/apt-get install/d' llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 15
-          sudo apt-get install -y libunwind-15 libc++abi1-15 libc++1-15 libc++-15-dev
+          sudo apt-get install -y --no-install-recommends clang-15 lld-15 libunwind-15 libc++abi1-15 libc++1-15 libc++-15-dev
           echo "build:linux --action_env=CC=/usr/lib/llvm-15/bin/clang --action_env=CXX=/usr/lib/llvm-15/bin/clang++" >> .bazelrc
           echo "build:linux --host_action_env=CC=/usr/lib/llvm-15/bin/clang --host_action_env=CXX=/usr/lib/llvm-15/bin/clang++" >> .bazelrc
       - name: Setup macOS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,10 +62,8 @@ jobs:
           # resulting in a snowballing cache size and cache download/upload times.
       - name: Setup Linux
         if: matrix.os.name == 'linux'
-        # Install dependencies, including clang via through LLVM APT repository. Note that this
-        # will also install lldb and clangd alongside dependencies, which can be removed with
-        # `sudo apt-get remove -y lldb-15 clangd-15; sudo apt-get autoremove -y` if space is
-        # limited.
+        # Install dependencies, including clang through the LLVM APT repository. We drop the
+        # install step so we can install just the packages we need.
         # libunwind, libc++abi1 and libc++1 should be automatically installed as dependencies of
         # libc++, but this appears to cause errors so they are also being explicitly installed.
         # Since the GitHub runner image comes with a number of preinstalled packages, we don't need
@@ -75,9 +73,10 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           wget https://apt.llvm.org/llvm.sh
+          sed -i '/apt-get install/d' llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 15
-          sudo apt-get install -y libunwind-15 libc++abi1-15 libc++1-15 libc++-15-dev libclang-rt-15-dev
+          sudo apt-get install -y --no-install-recommends clang-15 lld-15 libunwind-15 libc++abi1-15 libc++1-15 libc++-15-dev libclang-rt-15-dev
           echo "build:linux --action_env=CC=/usr/lib/llvm-15/bin/clang --action_env=CXX=/usr/lib/llvm-15/bin/clang++" >> .bazelrc
           echo "build:linux --host_action_env=CC=/usr/lib/llvm-15/bin/clang --host_action_env=CXX=/usr/lib/llvm-15/bin/clang++" >> .bazelrc
           sed -i -e "s%llvm-symbolizer%/usr/lib/llvm-15/bin/llvm-symbolizer%" .bazelrc

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -5,12 +5,16 @@ FROM node:bullseye AS builder
 
 WORKDIR /workerd
 
+# Replacing build-essential with dpkg-dev here, no need to install gcc.
 RUN apt-get update
-RUN apt-get install -y curl build-essential git lsb-release wget software-properties-common gnupg
+RUN apt-get install -y --no-install-recommends curl dpkg-dev git lsb-release wget software-properties-common gnupg tcl
 
 RUN wget https://apt.llvm.org/llvm.sh
+# Drop the install step here so we can install just the packages we need.
+RUN sed -i '/apt-get install/d' llvm.sh
 RUN chmod +x llvm.sh
-RUN ./llvm.sh 15 all
+RUN ./llvm.sh 15
+RUN apt-get install -y --no-install-recommends clang-15 lld-15 libunwind-15 libc++abi1-15 libc++1-15 libc++-15-dev libclang-rt-15-dev
 COPY . .
 
 RUN echo "build:linux --action_env=CC=/usr/lib/llvm-15/bin/clang --action_env=CXX=/usr/lib/llvm-15/bin/clang++" >> .bazelrc


### PR DESCRIPTION
Be more intentional about what dependencies we use. This should make CI run a bit faster.

===========

Was inspired to do this while debugging an internal CI issue. We have long resolved our CI space constraints by not building everything twice and using shared linkage, but this should still speed up the build process slightly.