### PR TITLE
Add timestamp field to version metadata type

### DIFF
--- a/types/defines/versions.d.ts
+++ b/types/defines/versions.d.ts
@@ -7,4 +7,6 @@ export type WorkerVersionMetadata = {
   id: string;
   /** The tag of the Worker Version using this binding */
   tag: string;
+  /** The timestamp of when the Worker Version was uploaded */
+  timestamp: string;
 }


### PR DESCRIPTION
Hi :wave: ,

This PR adds a `timestamp` field to the type definitions of Version Metadata bindings. Based on my testing, this field is already present on bindings today, and Walshy told me it's fine to add it to types.

cc @WalshyDev