### PR TITLE
Add type definition of Rate Limit bindings

### DIFF
--- a/types/defines/ratelimit.d.ts
+++ b/types/defines/ratelimit.d.ts
@@ -1,0 +1,16 @@
+interface RateLimitOptions {
+  key: string
+}
+
+interface RateLimitOutcome {
+  success: boolean
+}
+
+interface RateLimit {
+  /**
+   * Rate limit a request based on the provided options.
+   * @see https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/
+   * @returns A promise that resolves with the outcome of the rate limit.
+   */
+  limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
+}


### PR DESCRIPTION
Hi :wave:,

This PR adds a simple type definition for Rate Limit bindings.

As it is in beta, I expect this will evolve over time, so I didn't copy most of the documentation into jsdoc.

Happy to take suggestions for the names of the interfaces and anything else, my other idea was `RateLimitBinding`, but not entirely sure if it would fit in with other bindings.

cc @elithrar