### PR TITLE
[CI] Use Ubuntu 24.04 for npm-types build

### DIFF
--- a/.github/workflows/npm-types.yml
+++ b/.github/workflows/npm-types.yml
@@ -19,7 +19,7 @@ jobs:
       version: ${{ steps.echo.outputs.version }}
       date: ${{ steps.echo.outputs.date }}
       release_version: ${{ steps.echo.outputs.release_version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - id: echo
@@ -28,7 +28,7 @@ jobs:
           echo "version=${{ inputs.prerelease == false && '4' || '0'}}.$(cat src/workerd/io/supported-compatibility-date.txt | tr -d '-').${{ inputs.patch }}" >> $GITHUB_OUTPUT;
           echo "release_version=1.$(cat src/workerd/io/supported-compatibility-date.txt | tr -d '-').0" >> $GITHUB_OUTPUT;
   build-and-publish-types:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: version
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -19,7 +19,7 @@ jobs:
       version: ${{ steps.echo.outputs.version }}
       date: ${{ steps.echo.outputs.date }}
       release_version: ${{ steps.echo.outputs.release_version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - id: echo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
   version:
     outputs:
       version: ${{ steps.echo.outputs.version }}
-    # version job uses ubuntu 22.04, this way we don't have to install the updated clang while
+    # version job uses ubuntu 24.04, this way we don't have to install the updated clang while
     # the build job uses 20.04 for libc compatibility.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - id: echo


### PR DESCRIPTION
This should fix the compatibility issues causing the npm-types build to fail by implicitly updating the LLVM version – note that ubuntu-latest still resolves to 22.04 at this time. Also updates the version CI jobs to use 24.04 since they build code without creating binaries to be published.