### PR TITLE
Updated types to seperate models for composability and reusability

### DIFF
--- a/types/defines/ai.d.ts
+++ b/types/defines/ai.d.ts
@@ -14,6 +14,12 @@ export type AiImageToTextInput = {
   prompt?: string;
   max_tokens?: number;
   temperature?: number;
+  top_p?: number;
+  top_k?: number;
+  seed?: number;
+  repetition_penalty?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
   raw?: boolean;
   messages?: RoleScopedChatInput[];
 };
@@ -102,6 +108,13 @@ export type AiTextGenerationInput = {
   raw?: boolean;
   stream?: boolean;
   max_tokens?: number;
+  temperature?: number;
+  top_p?: number;
+  top_k?: number;
+  seed?: number;
+  repetition_penalty?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
   messages?: RoleScopedChatInput[];
 };
 export type AiTextGenerationOutput =
@@ -139,112 +152,143 @@ export declare abstract class BaseAiTranslation {
   postProcessedOutputs: AiTranslationOutput;
 }
 export type AiOptions = {
-  gatewayId?: string;
   prefix?: string;
   extraHeaders?: object;
 };
+export type BaseAiTextClassificationModels =
+  | "@cf/huggingface/distilbert-sst-2-int8"
+  | "@cf/jpmorganchase/roberta-spam"
+  | "@cf/inml/inml-roberta-dga";
+export type BaseAiTextToImageModels =
+  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
+  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
+  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
+  | "@cf/lykon/dreamshaper-8-lcm"
+  | "@cf/bytedance/stable-diffusion-xl-lightning";
+export type BaseAiSentenceSimilarityModels =
+  "@hf/sentence-transformers/all-minilm-l6-v2";
+export type BaseAiTextEmbeddingsModels =
+  | "@cf/baai/bge-small-en-v1.5"
+  | "@cf/baai/bge-base-en-v1.5"
+  | "@cf/baai/bge-large-en-v1.5"
+  | "@hf/baai/bge-m3";
+export type BaseAiSpeechRecognitionModels =
+  | "@cf/openai/whisper"
+  | "@cf/openai/whisper-tiny-en"
+  | "@cf/openai/whisper-sherpa";
+export type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
+export type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
+export type BaseAiTextGenerationModels =
+  | "@cf/meta/llama-3-8b-instruct"
+  | "@cf/meta/llama-3-8b-instruct-wope"
+  | "@cf/meta/llama-3-8b-instruct-awq"
+  | "@cf/meta/llama-2-7b-chat-int8"
+  | "@cf/mistral/mistral-7b-instruct-v0.1"
+  | "@cf/mistral/mistral-7b-instruct-v0.1-vllm"
+  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
+  | "@cf/meta/llama-2-7b-chat-fp16"
+  | "@cf/meta/llama-2-7b-chat-fp16-vllm"
+  | "@cf/meta/llama-2-7b-chat-awq"
+  | "@hf/thebloke/llama-2-13b-chat-awq"
+  | "@hf/thebloke/zephyr-7b-beta-awq"
+  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
+  | "@hf/thebloke/codellama-7b-instruct-awq"
+  | "@hf/thebloke/openchat_3.5-awq"
+  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
+  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
+  | "@hf/thebloke/llamaguard-7b-awq"
+  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
+  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
+  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
+  | "@hf/mistral/mistral-7b-instruct-v0.2"
+  | "@cf/mistral/mixtral-8x7b-instruct-v0.1-awq"
+  | "@hf/google/gemma-7b-it"
+  | "@hf/nexusflow/starling-lm-7b-beta"
+  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
+  | "@cf/defog/sqlcoder-7b-2"
+  | "@cf/openchat/openchat-3.5-0106"
+  | "@cf/tiiuae/falcon-7b-instruct"
+  | "@cf/thebloke/discolm-german-7b-v1-awq"
+  | "@cf/qwen/qwen1.5-0.5b-chat"
+  | "@cf/qwen/qwen1.5-1.8b-chat"
+  | "@cf/qwen/qwen1.5-7b-chat-awq"
+  | "@cf/qwen/qwen1.5-14b-chat-awq"
+  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
+  | "@cf/microsoft/phi-2"
+  | "@cf/microsoft/phi-3-mini-4k-instruct"
+  | "@cf/google/gemma-2b-it-lora"
+  | "@cf/google/gemma-7b-it-lora"
+  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
+  | "@cf/deepseek-ai/deepseek-coder-7b-instruct-v1.5"
+  | "@cf/nexaaidev/octopus-v2"
+  | "@cf/m-a-p/opencodeinterpreter-ds-6.7b"
+  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
+  | "@cf/fblgit/una-cybertron-7b-v2-awq"
+  | "@groq/meta/llama3-8b-8192"
+  | "@groq/meta/llama3-70b-8192"
+  | "@groq/mistralai/mixtral-8x7b-32768";
+export type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
+export type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
+export type BaseAiImageToTextModels =
+  | "@cf/unum/uform-gen2-qwen-500m"
+  | "@cf/shopify/shopify-llava-1.5-7b-hf"
+  | "@cf/shopify/shopify-llava-1.5-7b-hf-awq"
+  | "@cf/llava-hf/llava-1.5-7b-hf"
+  | "@cf/faire/faire-llava-1.5-7b";
 export declare abstract class Ai {
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
   run(
-    model:
-      | "@cf/huggingface/distilbert-sst-2-int8"
-      | "@cf/jpmorganchase/roberta-spam"
-      | "@cf/inml/inml-roberta-dga",
+    model: BaseAiTextClassificationModels,
     inputs: BaseAiTextClassification["inputs"],
     options?: AiOptions
   ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
   run(
-    model:
-      | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-      | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-      | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-      | "@cf/lykon/dreamshaper-8-lcm"
-      | "@cf/bytedance/stable-diffusion-xl-lightning",
+    model: BaseAiTextToImageModels,
     inputs: BaseAiTextToImage["inputs"],
     options?: AiOptions
   ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
   run(
-    model: "@hf/sentence-transformers/all-minilm-l6-v2",
+    model: BaseAiSentenceSimilarityModels,
     inputs: BaseAiSentenceSimilarity["inputs"],
     options?: AiOptions
   ): Promise<BaseAiSentenceSimilarity["postProcessedOutputs"]>;
   run(
-    model:
-      | "@cf/baai/bge-small-en-v1.5"
-      | "@cf/baai/bge-base-en-v1.5"
-      | "@cf/baai/bge-large-en-v1.5",
+    model: BaseAiTextEmbeddingsModels,
     inputs: BaseAiTextEmbeddings["inputs"],
     options?: AiOptions
   ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
   run(
-    model:
-      | "@cf/openai/whisper"
-      | "@cf/openai/whisper-tiny-en"
-      | "@cf/openai/whisper-sherpa",
+    model: BaseAiSpeechRecognitionModels,
     inputs: BaseAiSpeechRecognition["inputs"],
     options?: AiOptions
   ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
   run(
-    model: "@cf/microsoft/resnet-50",
+    model: BaseAiImageClassificationModels,
     inputs: BaseAiImageClassification["inputs"],
     options?: AiOptions
   ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
   run(
-    model: "@cf/facebook/detr-resnet-50",
+    model: BaseAiObjectDetectionModels,
     inputs: BaseAiObjectDetection["inputs"],
     options?: AiOptions
   ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
   run(
-    model:
-      | "@cf/meta/llama-3-8b-instruct"
-      | "@cf/meta/llama-2-7b-chat-int8"
-      | "@cf/mistral/mistral-7b-instruct-v0.1"
-      | "@cf/mistral/mistral-7b-instruct-v0.1-vllm"
-      | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-      | "@cf/meta/llama-2-7b-chat-fp16"
-      | "@hf/thebloke/llama-2-13b-chat-awq"
-      | "@hf/thebloke/zephyr-7b-beta-awq"
-      | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-      | "@hf/thebloke/codellama-7b-instruct-awq"
-      | "@hf/thebloke/openchat_3.5-awq"
-      | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-      | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-      | "@hf/thebloke/llamaguard-7b-awq"
-      | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-      | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-      | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-      | "@hf/mistral/mistral-7b-instruct-v0.2"
-      | "@cf/mistral/mixtral-8x7b-instruct-v0.1-awq"
-      | "@hf/google/gemma-7b-it"
-      | "@hf/nexusflow/starling-lm-7b-beta"
-      | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-      | "@cf/defog/sqlcoder-7b-2"
-      | "@cf/openchat/openchat-3.5-0106"
-      | "@cf/tiiuae/falcon-7b-instruct"
-      | "@cf/thebloke/discolm-german-7b-v1-awq"
-      | "@cf/qwen/qwen1.5-0.5b-chat"
-      | "@cf/qwen/qwen1.5-1.8b-chat"
-      | "@cf/qwen/qwen1.5-7b-chat-awq"
-      | "@cf/qwen/qwen1.5-14b-chat-awq"
-      | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-      | "@cf/microsoft/phi-2"
-      | "@cf/google/gemma-2b-it-lora"
-      | "@cf/google/gemma-7b-it-lora"
-      | "@cf/meta-llama/llama-2-7b-chat-hf-lora",
+    model: BaseAiTextGenerationModels,
     inputs: BaseAiTextGeneration["inputs"],
     options?: AiOptions
   ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
   run(
-    model: "@cf/meta/m2m100-1.2b",
+    model: BaseAiTranslationModels,
     inputs: BaseAiTranslation["inputs"],
     options?: AiOptions
   ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
   run(
-    model: "@cf/facebook/bart-large-cnn",
+    model: BaseAiSummarizationModels,
     inputs: BaseAiSummarization["inputs"],
     options?: AiOptions
   ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
   run(
-    model: "@cf/unum/uform-gen2-qwen-500m" | "@cf/llava-hf/llava-1.5-7b-hf",
+    model: BaseAiImageToTextModels,
     inputs: BaseAiImageToText["inputs"],
     options?: AiOptions
   ): Promise<BaseAiImageToText["postProcessedOutputs"]>;


### PR DESCRIPTION
As discussed in the internal chat, I feel it's better to output types where the models are detached from the Ai class, so I slightly updated the type generator to generate types in this format
```ts
export type BaseAiTextClassificationModels = ...;
  

export declare abstract class Ai {
  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
  run(
    model: BaseAiTextClassificationModels,
    inputs: BaseAiTextClassification["inputs"],
    options?: AiOptions
  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
  ```
  
This will not only expose the types out for the users but also for our new features in workersAI where having TextModel types will be good for the SDK.
I have also created a PR in types generator in AI SDK