### PR TITLE
[nfc] Clean up JSG and perfetto includes, pull in capnproto include cleanup

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,10 +39,10 @@ apple_support_dependencies()
 
 http_archive(
     name = "capnp-cpp",
-    integrity = "sha256-6bAIGw5ciWkS16cgJC6vxd2LmE31+p1XkhnfPsiklDQ=",
-    strip_prefix = "capnproto-capnproto-3765f4c/c++",
+    integrity = "sha256-CVO8cb5nAjJJi7MUqpaLn1MJ8HZVtikpwV3p+a7PJLo=",
+    strip_prefix = "capnproto-capnproto-b09f083/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/3765f4c0c8839398ea59831c13b3bf19035aa69f"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/b09f083e32cb20c7e759c0d15bc8302b34bafe41"],
 )
 
 http_archive(

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -6,11 +6,14 @@
 -Ibazel-bin/external/ada-url/_virtual_includes/ada-url/
 -Ibazek-bin/external/simdutf/virtual_includes/simdutf/
 -Ibazel-bin/external/com_cloudflare_lol_html/_virtual_includes/lolhtml
+-Ibazel-bin/external/perfetto/
 -Iexternal/perfetto-sdk/sdk/
 -Iexternal/ada-url/
 -Iexternal/simdutf/
 -Iexternal/com_google_benchmark/include/
 -Iexternal/dawn/include
+-Iexternal/perfetto/include/
+-Iexternal/perfetto/include/perfetto/base/build_configs/bazel/
 -Iexternal/ssl/src/include
 -Isrc
 -isystem/usr/lib/llvm-15/include/c++/v1

--- a/src/workerd/api/r2-admin.c++
+++ b/src/workerd/api/r2-admin.c++
@@ -5,6 +5,7 @@
 #include "r2-admin.h"
 #include "r2-rpc.h"
 #include <kj/compat/http.h>
+#include <capnp/message.h>
 #include <capnp/compat/json.h>
 #include <workerd/util/http-util.h>
 #include <workerd/api/r2-api.capnp.h>

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -13,6 +13,7 @@
 #include <workerd/util/mimetype.h>
 #include <kj/encoding.h>
 #include <kj/compat/http.h>
+#include <capnp/message.h>
 #include <capnp/compat/json.h>
 #include <workerd/util/http-util.h>
 #include <workerd/api/r2-api.capnp.h>

--- a/src/workerd/api/r2-multipart.c++
+++ b/src/workerd/api/r2-multipart.c++
@@ -8,6 +8,7 @@
 #include <array>
 #include <math.h>
 #include <kj/compat/http.h>
+#include <capnp/message.h>
 #include <capnp/compat/json.h>
 #include <workerd/util/http-util.h>
 #include <workerd/api/r2-api.capnp.h>

--- a/src/workerd/api/r2-rpc.c++
+++ b/src/workerd/api/r2-rpc.c++
@@ -10,6 +10,7 @@
 // This is imported for the error type and that's shared between internal and public beta.
 
 #include <kj/compat/http.h>
+#include <capnp/message.h>
 #include <capnp/compat/json.h>
 
 namespace workerd::api {

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -58,6 +58,7 @@ wd_cc_library(
         "//conditions:default": [],
     }),
     implementation_deps = [
+        "//src/workerd/util:perfetto",
         "@capnp-cpp//src/kj/compat:kj-brotli",
         "@capnp-cpp//src/kj/compat:kj-gzip",
         "@simdutf",
@@ -82,6 +83,7 @@ wd_cc_library(
         "@capnp-cpp//src/capnp:capnp-rpc",
         "@capnp-cpp//src/capnp/compat:http-over-capnp",
         "@capnp-cpp//src/kj:kj-async",
+        "@ssl",
     ] + select({
         ":set_enable_experimental_webgpu": ["@dawn"],
         "//conditions:default": [],
@@ -98,7 +100,6 @@ wd_cc_library(
         ":worker-interface_capnp",
         "//src/workerd/jsg:memory-tracker",
         "//src/workerd/util:own-util",
-        "//src/workerd/util:perfetto",
         "//src/workerd/util:thread-scopes",
         "@capnp-cpp//src/kj:kj-async",
         "@capnp-cpp//src/kj/compat:kj-http",

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <kj/debug.h>
 #include <kj/async.h>
 #include <workerd/io/actor-storage.h>
 #include <kj/one-of.h>

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -24,7 +24,6 @@
 #include <workerd/util/weak-refs.h>
 #include <workerd/io/limit-enforcer.h>
 #include <workerd/io/io-channels.h>
-#include <workerd/util/perfetto-tracing.h>
 #include <workerd/util/uncaught-exception-source.h>
 
 namespace capnp { class HttpOverCapnpFactory; }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -23,6 +23,7 @@
 #include <workerd/jsg/util.h>
 #include <workerd/io/cdp.capnp.h>
 #include <workerd/io/compatibility-date.h>
+#include <capnp/message.h>
 #include <capnp/compat/json.h>
 #include <kj/compat/gzip.h>
 #include <kj/compat/brotli.h>

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -14,8 +14,8 @@ wd_cc_library(
         "iterator.c++",
         "jsg.c++",
         "jsvalue.c++",
-        "modules-new.c++",
         "modules.c++",
+        "modules-new.c++",
         "promise.c++",
         "resource.c++",
         "ser.c++",
@@ -155,7 +155,6 @@ wd_cc_library(
     hdrs = ["observer.h"],
     visibility = ["//visibility:public"],
     deps = [
-        ":url",
         "@capnp-cpp//src/kj",
     ],
 )
@@ -201,6 +200,7 @@ kj_test(
     src = "url-test.c++",
     deps = [
         ":jsg",
+        "@ssl",
     ],
 )
 

--- a/src/workerd/jsg/async-context.c++
+++ b/src/workerd/jsg/async-context.c++
@@ -3,7 +3,6 @@
 //     https://opensource.org/licenses/Apache-2.0
 #include "async-context.h"
 #include "jsg.h"
-#include "setup.h"
 #include <workerd/jsg/memory.h>
 #include <v8.h>
 

--- a/src/workerd/jsg/inspector.h
+++ b/src/workerd/jsg/inspector.h
@@ -1,7 +1,14 @@
 #pragma once
 
-#include <kj/string.h>
-#include <v8-inspector.h>
+namespace kj {
+  class String;
+  class StringPtr;
+}
+
+namespace v8_inspector {
+class V8Inspector;
+class StringView;
+}
 
 namespace workerd::jsg {
 

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2577,4 +2577,3 @@ inline v8::Local<v8::Context> JsContext<T>::getHandle(Lock& js) {
 #include "function.h"
 #include "iterator.h"
 #include "jsvalue.h"
-#include <workerd/jsg/url.h>

--- a/src/workerd/jsg/memory.h
+++ b/src/workerd/jsg/memory.h
@@ -16,7 +16,7 @@
 #include <kj/table.h>
 #include <kj/string.h>
 #include <v8-profiler.h>
-#include <v8.h>
+#include <v8-array-buffer.h>
 #include <stack>
 #include <string>
 

--- a/src/workerd/jsg/observer.h
+++ b/src/workerd/jsg/observer.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <workerd/jsg/url.h>
 #include <kj/common.h>
 #include <kj/string.h>
 #include <kj/exception.h>
@@ -16,6 +15,8 @@ namespace v8 {
 }
 
 namespace workerd::jsg {
+
+class Url;
 
 struct ResolveObserver {
   virtual ~ResolveObserver() noexcept(false) { }

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -13,7 +13,6 @@
 #include <capnp/message.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/rtti.capnp.h>
-#include <kj/map.h>
 
 namespace workerd::jsg::rtti {
 

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -13,12 +13,14 @@
 #include <kj/refcount.h>
 #include <kj/vector.h>
 #include <kj/list.h>
-#include <v8.h>
-#include <workerd/jsg/memory.h>
+#include <v8-context.h>
+#include <v8-object.h>
 
 namespace cppgc { class Visitor; }
 
 namespace workerd::jsg {
+
+class MemoryTracker;
 
 using kj::uint;
 

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -50,10 +50,10 @@ wd_cc_binary(
         ":server",
         ":workerd-meta_capnp",
         ":workerd_capnp",
+        "//src/pyodide:pyodide_extra_capnp",
         "//src/workerd/util:autogate",
         "//src/workerd/util:perfetto",
         "@capnp-cpp//src/capnp:capnpc",
-        "//src/pyodide:pyodide_extra_capnp",
     ] + select({
         "@platforms//os:windows": [],
         "//conditions:default": ["@workerd//src/workerd/util:symbolizer"],
@@ -103,6 +103,7 @@ wd_cc_library(
         "//src/workerd/io",
         "//src/workerd/jsg",
         "//src/workerd/util:perfetto",
+        "@capnp-cpp//src/kj/compat:kj-tls",
     ],
 )
 

--- a/src/workerd/tests/bench-json.c++
+++ b/src/workerd/tests/bench-json.c++
@@ -5,6 +5,7 @@
 #include <benchmark/benchmark.h>
 #include <workerd/tests/bench-tools.h>
 #include <workerd/api/r2-api.capnp.h>
+#include <capnp/message.h>
 #include "capnp/compat/json.h"
 #include <kj/string.h>
 #include <kj/test.h>

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -6,6 +6,7 @@
 
 #include <kj/function.h>
 #include <kj/test.h>
+#include <capnp/message.h>
 
 #include <workerd/jsg/jsg.h>
 #include <workerd/io/io-context.h>

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -8,7 +8,7 @@ wd_cc_library(
     hdrs = ["perfetto-tracing.h", "use-perfetto-categories.h"],
     visibility = ["//visibility:public"],
     deps = [
-        "@capnp-cpp//src/kj"
+        "@capnp-cpp//src/kj",
     ] + select({
         "@platforms//os:windows": [],
         "//conditions:default": ["@perfetto//:libperfetto_client_experimental"],
@@ -44,10 +44,10 @@ wd_cc_library(
             "use-perfetto-categories.h",
         ],
     ),
+    implementation_deps = ["@ssl"],
     visibility = ["//visibility:public"],
     deps = [
         "@capnp-cpp//src/kj/compat:kj-http",
-        "@capnp-cpp//src/kj/compat:kj-tls",
     ],
 )
 
@@ -66,7 +66,7 @@ wd_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/workerd/util:sentry",
+        ":sentry",
         "@capnp-cpp//src/kj:kj-async",
     ],
 )
@@ -86,8 +86,8 @@ wd_cc_library(
     srcs = ["symbolizer.c++"],
     visibility = ["//visibility:public"],
     deps = [
-        "@capnp-cpp//src/kj",
         ":sentry",
+        "@capnp-cpp//src/kj",
     ],
     alwayslink = 1,
     target_compatible_with = select({
@@ -100,6 +100,7 @@ wd_cc_library(
     name = "own-util",
     hdrs = ["own-util.h"],
     visibility = ["//visibility:public"],
+    deps = ["@capnp-cpp//src/kj"],
 )
 
 wd_cc_library(

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -5,6 +5,7 @@
 #include <workerd/util/sentry.h>
 #include <capnp/message.h>
 #include <kj/common.h>
+#include "kj/debug.h"
 
 namespace workerd::util {
 

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -3,9 +3,8 @@
 //     https://opensource.org/licenses/Apache-2.0
 #pragma once
 
-#include "kj/debug.h"
-#include <kj/map.h>
-#include <capnp/common.h>
+#include "kj/string.h"
+#include <capnp/blob.h>
 #include <capnp/list.h>
 #include <initializer_list>
 

--- a/src/workerd/util/canceler.h
+++ b/src/workerd/util/canceler.h
@@ -3,9 +3,10 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #pragma once
-#include <kj/async-io.h>
+#include <kj/async.h>
 #include <kj/common.h>
 #include <kj/debug.h>
+#include <kj/function.h>
 #include <kj/refcount.h>
 #include <kj/list.h>
 

--- a/src/workerd/util/capnp-mock.h
+++ b/src/workerd/util/capnp-mock.h
@@ -5,13 +5,14 @@
 
 #pragma once
 
-#include <kj/test.h>
 #include <kj/debug.h>
-#include <capnp/dynamic.h>
-#include <capnp/serialize-text.h>
 #include <kj/list.h>
 #include <kj/map.h>
+#include <kj/refcount.h>
 #include <kj/source-location.h>
+#include <capnp/dynamic.h>
+#include <capnp/message.h>
+#include <capnp/serialize-text.h>
 
 namespace workerd {
 

--- a/src/workerd/util/perfetto-tracing.h
+++ b/src/workerd/util/perfetto-tracing.h
@@ -2,13 +2,19 @@
 
 #if defined(WORKERD_USE_PERFETTO)
 #include <kj/memory.h>
-#include <kj/string.h>
 #define PERFETTO_ENABLE_LEGACY_TRACE_EVENTS 1
-#include "perfetto/tracing.h"
+// Only include a smaller header here to keep include size under control. This approach is
+// recommended in the full perfetto header (perfetto/tracing.h).
+#include "perfetto/tracing/track_event.h"
 
 PERFETTO_DEFINE_CATEGORIES_IN_NAMESPACE(
     workerd::traces,
     perfetto::Category("workerd"));
+
+namespace kj {
+  class StringPtr;
+  class String;
+}
 
 namespace workerd {
 


### PR DESCRIPTION
This brings us significantly closer to IWYU. Total include size improves significantly by reducing exposure to perfetto and improvements in the underlying capnproto change.
Includes slight buildifer cleanup.

capnproto PR [#2039](https://github.com/capnproto/capnproto/pull/2039)
\- This will require some downstream changes, but the changes here should be ready for review.