### PR TITLE
Implement named export support for CJS modules

### DIFF
--- a/src/workerd/api/tests/commonjs-module-test.js
+++ b/src/workerd/api/tests/commonjs-module-test.js
@@ -1,0 +1,14 @@
+import { foo, bar, default as baz } from 'foo';
+import * as fooModule from 'foo';
+import { strictEqual } from 'node:assert';
+
+export const test = {
+  test() {
+    strictEqual(fooModule.default, baz);
+    strictEqual(fooModule.foo, foo);
+    strictEqual(fooModule.bar, undefined);
+    strictEqual(foo, 1);
+    strictEqual(bar, undefined);
+    strictEqual(baz.foo, foo);
+  }
+};

--- a/src/workerd/api/tests/commonjs-module-test.wd-test
+++ b/src/workerd/api/tests/commonjs-module-test.wd-test
@@ -1,0 +1,18 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "commonjs-module-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "commonjs-module-test.js"),
+          (name = "foo",
+           commonJsModule = "exports.foo = 1",
+           namedExports = ["foo", "bar"])
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -253,9 +253,11 @@ public:
         jsg::Lock& js,
         kj::StringPtr name);
 
-    static v8::MaybeLocal<v8::Value> evaluate(jsg::Lock& js,
-                                              NodeJsModuleInfo& info,
-                                              v8::Local<v8::Module> module);
+    static v8::MaybeLocal<v8::Value> evaluate(
+        jsg::Lock& js,
+        NodeJsModuleInfo& info,
+        v8::Local<v8::Module> module,
+        const kj::Maybe<kj::Array<kj::String>>& maybeExports);
 
     jsg::Function<void()> initEvalFunc(
         auto& lock,
@@ -336,6 +338,7 @@ public:
                                           ObjectModuleInfo,
                                           NodeJsModuleInfo>;
     kj::Maybe<SyntheticModuleInfo> maybeSynthetic;
+    kj::Maybe<kj::Array<kj::String>> maybeNamedExports;
 
     ModuleInfo(jsg::Lock& js,
                v8::Local<v8::Module> module,

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -272,6 +272,10 @@ struct Worker {
       # Pyodide (https://pyodide.org/en/stable/usage/packages-in-pyodide.html). All packages listed
       # will be installed prior to the execution of the worker.
     }
+
+    namedExports @10 :List(Text);
+    # For commonJsModule and nodeJsCompatModule, this is a list of named exports that the
+    # module expects to be exported once the evaluation is complete.
   }
 
   compatibilityDate @3 :Text;


### PR DESCRIPTION
Adds the ability for a worker module definition to define a list of named exports. So if the CJS module exports something like...

```
exports.foo = 42;
```

Then the worker can import `foo` directly from the module:

```
import { foo } from 'cjs-module';
```

This just enables the exports in workerd, a separate internal PR will be required to enable it's use in production.

The runtime does very little lifting here. It will be up to whomever is constructing the worker module configuration to identify the exports that should be provided. The runtime will not try to automatically detect the exports. if an export is named but not actually defined by the CJS module, then it's value will be `undefined`. Only exports that are defined when the initial evaluation of the module completes will be supported (CJS generally allows exports to be modified dynamically), and the exports will only work if the `module.exports` value is a non-null object.

This feature was requested by the frameworks team.

Fixes: #2189