### PR TITLE
Optimize r2-bucket Checksums

### DIFF
--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -108,24 +108,29 @@ static jsg::Ref<T> parseObjectMetadata(R2HeadResponse::Reader responseReader,
     };
   }
 
-  jsg::Ref<R2Bucket::Checksums> checksums = jsg::alloc<R2Bucket::Checksums>(kj::none, kj::none, kj::none, kj::none, kj::none);
+  auto checksums = jsg::alloc<R2Bucket::Checksums>();
 
   if (responseReader.hasChecksums()) {
     R2Checksums::Reader checksumsBuilder = responseReader.getChecksums();
     if (checksumsBuilder.hasMd5()) {
-      checksums->md5 = kj::heapArray(checksumsBuilder.getMd5());
+      KJ_ASSERT(checksumsBuilder.getMd5().size() == 16);
+      checksums->md5.emplace().asPtr().copyFrom(checksumsBuilder.getMd5());
     }
     if (checksumsBuilder.hasSha1()) {
-      checksums->sha1 = kj::heapArray(checksumsBuilder.getSha1());
+      KJ_ASSERT(checksumsBuilder.getSha1().size() == 20);
+      checksums->sha1.emplace().asPtr().copyFrom(checksumsBuilder.getSha1());
     }
     if (checksumsBuilder.hasSha256()) {
-      checksums->sha256 = kj::heapArray(checksumsBuilder.getSha256());
+      KJ_ASSERT(checksumsBuilder.getSha256().size() == 32);
+      checksums->sha256.emplace().asPtr().copyFrom(checksumsBuilder.getSha256());
     }
     if (checksumsBuilder.hasSha384()) {
-      checksums->sha384 = kj::heapArray(checksumsBuilder.getSha384());
+      KJ_ASSERT(checksumsBuilder.getSha384().size() == 48);
+      checksums->sha384.emplace().asPtr().copyFrom(checksumsBuilder.getSha384());
     }
     if (checksumsBuilder.hasSha512()) {
-      checksums->sha512 = kj::heapArray(checksumsBuilder.getSha512());
+      KJ_ASSERT(checksumsBuilder.getSha512().size() == 64);
+      checksums->sha512.emplace().asPtr().copyFrom(checksumsBuilder.getSha512());
     }
   }
 
@@ -1063,10 +1068,6 @@ R2Bucket::StringChecksums R2Bucket::Checksums::toJSON() {
     .sha384 = this->sha384.map(kj::encodeHex),
     .sha512 = this->sha512.map(kj::encodeHex),
   };
-}
-
-kj::Array<kj::byte> cloneByteArray(const kj::Array<kj::byte> &arr) {
-  return kj::heapArray(arr.asPtr());
 }
 
 kj::Maybe<jsg::Ref<R2Bucket::HeadResult>> parseHeadResultWrapper(

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -18,7 +18,6 @@ namespace workerd::api {
 
 namespace workerd::api::public_beta {
 
-kj::Array<kj::byte> cloneByteArray(const kj::Array<kj::byte>& arr);
 kj::ArrayPtr<kj::StringPtr> fillR2Path(kj::StringPtr pathStorage[1], const kj::Maybe<kj::String>& bucket);
 
 class R2MultipartUpload;
@@ -91,24 +90,23 @@ public:
 
   class Checksums: public jsg::Object {
   public:
-    Checksums(
-      jsg::Optional<kj::Array<kj::byte>> md5,
-      jsg::Optional<kj::Array<kj::byte>> sha1,
-      jsg::Optional<kj::Array<kj::byte>> sha256,
-      jsg::Optional<kj::Array<kj::byte>> sha384,
-      jsg::Optional<kj::Array<kj::byte>> sha512
-    ):
-      md5(kj::mv(md5)),
-      sha1(kj::mv(sha1)),
-      sha256(kj::mv(sha256)),
-      sha384(kj::mv(sha384)),
-      sha512(kj::mv(sha512)) {}
+    Checksums() = default;
 
-    jsg::Optional<kj::Array<kj::byte>> getMd5() const { return md5.map(cloneByteArray); }
-    jsg::Optional<kj::Array<kj::byte>> getSha1() const { return sha1.map(cloneByteArray); }
-    jsg::Optional<kj::Array<kj::byte>> getSha256() const { return sha256.map(cloneByteArray); }
-    jsg::Optional<kj::Array<kj::byte>> getSha384() const { return sha384.map(cloneByteArray); }
-    jsg::Optional<kj::Array<kj::byte>> getSha512() const { return sha512.map(cloneByteArray); }
+    jsg::Optional<kj::ArrayPtr<kj::byte>> getMd5() {
+      return md5.map([](auto& data) { return data.asPtr(); });
+    }
+    jsg::Optional<kj::ArrayPtr<kj::byte>> getSha1() {
+      return sha1.map([](auto& data) { return data.asPtr(); });
+    }
+    jsg::Optional<kj::ArrayPtr<kj::byte>> getSha256() {
+      return sha256.map([](auto& data) { return data.asPtr(); });
+    }
+    jsg::Optional<kj::ArrayPtr<kj::byte>> getSha384() {
+      return sha384.map([](auto& data) { return data.asPtr(); });
+    }
+    jsg::Optional<kj::ArrayPtr<kj::byte>> getSha512() {
+      return sha512.map([](auto& data) { return data.asPtr(); });
+    }
 
     StringChecksums toJSON();
 
@@ -122,18 +120,21 @@ public:
       JSG_TS_OVERRIDE(R2Checksums);
     }
 
-    jsg::Optional<kj::Array<kj::byte>> md5;
-    jsg::Optional<kj::Array<kj::byte>> sha1;
-    jsg::Optional<kj::Array<kj::byte>> sha256;
-    jsg::Optional<kj::Array<kj::byte>> sha384;
-    jsg::Optional<kj::Array<kj::byte>> sha512;
+    // Using FixedArrays here is a trade off. The Checksums class
+    // ends up being a bit larger but we avoid multiple heap allocations
+    // and copies.
+    jsg::Optional<kj::FixedArray<kj::byte, 16>> md5;
+    jsg::Optional<kj::FixedArray<kj::byte, 20>> sha1;
+    jsg::Optional<kj::FixedArray<kj::byte, 32>> sha256;
+    jsg::Optional<kj::FixedArray<kj::byte, 48>> sha384;
+    jsg::Optional<kj::FixedArray<kj::byte, 64>> sha512;
 
     void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
-      tracker.trackField("md5", md5);
-      tracker.trackField("sha1", sha1);
-      tracker.trackField("sha256", sha256);
-      tracker.trackField("sha384", sha384);
-      tracker.trackField("sha512", sha512);
+      if (md5 != kj::none) tracker.trackFieldWithSize("md5", 16);
+      if (sha1 != kj::none) tracker.trackFieldWithSize("sha1", 20);
+      if (sha256 != kj::none) tracker.trackFieldWithSize("sha256", 32);
+      if (sha384 != kj::none) tracker.trackFieldWithSize("sha384", 48);
+      if (sha512 != kj::none) tracker.trackFieldWithSize("sha512", 64);
     }
   };
 


### PR DESCRIPTION
This is a bit of a random drive-by optimization. I noticed that the R2Bucket `Checksums` class was unnecessarily performing multiple heap allocations and copies when it could be implemented with stack allocation and a single copy. This does end up making instances of `Checksum` slightly larger but reduces the number of small heap allocations and copies.

In reality, the `Checksums` class really could have been a struct given how it is used but that would possibly be a breaking change :-/