### PR TITLE
Add .retryable and .overloaded properties to tunneled exception objects

### DIFF
--- a/src/workerd/api/streams/standard-test.c++
+++ b/src/workerd/api/streams/standard-test.c++
@@ -3,6 +3,7 @@
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/jsg-test.h>
 #include <workerd/jsg/observer.h>
+#include <workerd/util/autogate.h>
 
 namespace workerd::api {
 namespace {
@@ -15,6 +16,7 @@ struct RsContext: public jsg::Object, public jsg::ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(RsIsolate, RsContext, ReadResult);
 
 void preamble(auto callback) {
+  util::Autogate::initEmptyAutogateForTesting();
   RsIsolate isolate(v8System, kj::heap<jsg::IsolateObserver>());
   isolate.runInLockScope([&](RsIsolate::Lock& lock) {
     JSG_WITHIN_CONTEXT_SCOPE(lock,

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -58,6 +58,7 @@ wd_cc_library(
         ":observer",
         ":url",
         "//src/workerd/util",
+        "//src/workerd/util:autogate",
         "//src/workerd/util:sentry",
         "//src/workerd/util:thread-scopes",
         "@capnp-cpp//src/kj",

--- a/src/workerd/jsg/jsg-test.h
+++ b/src/workerd/jsg/jsg-test.h
@@ -8,6 +8,7 @@
 #include "jsg.h"
 #include "setup.h"
 #include <kj/test.h>
+#include <workerd/util/autogate.h>
 
 namespace workerd::jsg::test {
 
@@ -26,7 +27,9 @@ class Evaluator {
   //   in cases that the isolate includes types that require configuration, but currently the
   //   type is always default-constructed. What if you want to specify a test config?
 public:
-  explicit Evaluator(V8System& v8System) : v8System(v8System) {}
+  explicit Evaluator(V8System& v8System) : v8System(v8System) {
+    util::Autogate::initEmptyAutogateForTesting();
+  }
 
   IsolateType& getIsolate() {
     // Slightly more efficient to only instantiate each isolate type once (17s vs. 20s):

--- a/src/workerd/jsg/modules-new-test.c++
+++ b/src/workerd/jsg/modules-new-test.c++
@@ -5,6 +5,7 @@
 #include <workerd/jsg/setup.h>
 #include <workerd/jsg/modules-new.h>
 #include <workerd/jsg/modules.capnp.h>
+#include <workerd/util/autogate.h>
 #include "observer.h"
 #include "url.h"
 #include <kj/async-io.h>
@@ -108,6 +109,7 @@ struct TestContext: public Object, public ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(TestIsolate, TestContext, TestType);
 
 #define PREAMBLE(fn)                                                                     \
+  util::Autogate::initEmptyAutogateForTesting();                                         \
   TestIsolate isolate(v8System, 123, kj::heap<IsolateObserver>());                       \
   runInV8Stack([&](auto& stackScope) {                                                   \
     TestIsolate::Lock lock(isolate, stackScope);                                         \

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -111,6 +111,26 @@ bool setRemoteError(v8::Isolate* isolate, v8::Local<v8::Value>& exception) {
       v8::True(isolate)));
 }
 
+bool setRetryableError(v8::Isolate* isolate, v8::Local<v8::Value>& exception) {
+  KJ_ASSERT(exception->IsObject());
+  auto obj = exception.As<v8::Object>();
+  return jsg::check(
+    obj->Set(
+      isolate->GetCurrentContext(),
+      jsg::v8StrIntern(isolate, "retryable"_kj),
+      v8::True(isolate)));
+}
+
+bool setOverloadedError(v8::Isolate* isolate, v8::Local<v8::Value>& exception) {
+  KJ_ASSERT(exception->IsObject());
+  auto obj = exception.As<v8::Object>();
+  return jsg::check(
+    obj->Set(
+      isolate->GetCurrentContext(),
+      jsg::v8StrIntern(isolate, "overloaded"_kj),
+      v8::True(isolate)));
+}
+
 bool setDurableObjectResetError(v8::Isolate* isolate, v8::Local<v8::Value>& exception) {
   KJ_ASSERT(exception->IsObject());
   auto obj = exception.As<v8::Object>();
@@ -128,7 +148,8 @@ struct DecodedException {
 };
 
 DecodedException decodeTunneledException(v8::Isolate* isolate,
-                                         kj::StringPtr internalMessage) {
+                                         kj::StringPtr internalMessage,
+                                         kj::Exception::Type excType) {
   // We currently support tunneling the following error types:
   //
   // - Error:        While the Web IDL spec claims this is reserved for use by program authors, this
@@ -204,6 +225,14 @@ DecodedException decodeTunneledException(v8::Isolate* isolate,
     setRemoteError(isolate, result.handle);
   }
 
+  if (util::Autogate::isEnabled(util::AutogateKey::ACTOR_EXCEPTION_PROPERTIES)) {
+    if (excType == kj::Exception::Type::DISCONNECTED) {
+      setRetryableError(isolate, result.handle);
+    } else if (excType == kj::Exception::Type::OVERLOADED) {
+      setOverloadedError(isolate, result.handle);
+    }
+  }
+
   if (result.isDurableObjectReset) {
     setDurableObjectResetError(isolate, result.handle);
   }
@@ -222,8 +251,6 @@ kj::StringPtr extractTunneledExceptionDescription(kj::StringPtr message) {
   }
 }
 
-
-
 v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::Exception&& exception) {
   auto desc = exception.getDescription();
 
@@ -235,7 +262,7 @@ v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::Exception&& exc
   //   in order to extract a full stack trace. Once we do it here, we can remove the code from
   //   there.
 
-  auto tunneledException = decodeTunneledException(isolate, desc);
+  auto tunneledException = decodeTunneledException(isolate, desc, exception.getType());
 
   if (tunneledException.isInternal) {
     auto& observer = IsolateBase::from(isolate).getObserver();
@@ -257,6 +284,11 @@ v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::Exception&& exc
       auto exception = v8::Exception::Error(v8StrIntern(isolate, "Network connection lost."_kj));
       if (tunneledException.isFromRemote) {
         setRemoteError(isolate, exception);
+      }
+
+      if (util::Autogate::isEnabled(util::AutogateKey::ACTOR_EXCEPTION_PROPERTIES)) {
+        // DISCONNECTED exceptions are considered retryable
+        setRetryableError(isolate, exception);
       }
 
       if (tunneledException.isDurableObjectReset) {

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -4,6 +4,7 @@
 #include "autogate.h"
 #include <workerd/util/sentry.h>
 #include <kj/common.h>
+#include <capnp/message.h>
 
 namespace workerd::util {
 
@@ -15,6 +16,8 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "test-workerd"_kj;
     case AutogateKey::UPDATED_ACTOR_EXCEPTION_TYPES:
       return "updated-actor-exception-types";
+    case AutogateKey::ACTOR_EXCEPTION_PROPERTIES:
+      return "actor-exception-properties";
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }
@@ -54,6 +57,14 @@ bool Autogate::isEnabled(AutogateKey key) {
 
 void Autogate::initAutogate(capnp::List<capnp::Text>::Reader gates) {
   globalAutogate = Autogate(gates);
+}
+
+void Autogate::initEmptyAutogateForTesting() {
+  capnp::MallocMessageBuilder message;
+  auto orphanage = message.getOrphanage();
+  auto gatesOrphan = orphanage.newOrphan<capnp::List<capnp::Text>>(0);
+  auto gates = gatesOrphan.get();
+  initAutogate(gates.asReader());
 }
 
 void Autogate::deinitAutogate() { globalAutogate = kj::none; }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -14,6 +14,7 @@ namespace workerd::util {
 enum class AutogateKey {
   TEST_WORKERD,
   UPDATED_ACTOR_EXCEPTION_TYPES, // updates exception types to better match retriability
+  ACTOR_EXCEPTION_PROPERTIES, // adds .retryable and .overloaded properties to tunneled exceptions
   NumOfKeys // Reserved for iteration.
 };
 
@@ -40,6 +41,10 @@ public:
   // process before any threads are created.
   static void initAutogate(
       capnp::List<capnp::Text>::Reader autogates);
+
+  // Convenience method for tests to use to invoke initAutogate()
+  static void initEmptyAutogateForTesting();
+
   // Destroys an initialised global Autogate instance. Used only for testing.
   static void deinitAutogate();
 private:


### PR DESCRIPTION
Add .retryable and .overloaded properties to tunneled exception objects based on the `kj::Exception` type.  The intent is to provide hints to the worker about whether a failed Durable Object operation should be retried.

For "disconnected"-type exceptions, we set the `.retryable` property to true to indicate that the operation's failure is likely transient, and could be retried using best practices, like randomized exponential backoff.

For "overloaded"-type exceptions, we set the `.overloaded` property to true to indicate that retrying the operation in the short term will probably fail, and might contribute to further failures.

We otherwise leave the properties undefined.

Implementation is behind an `ACTOR_EXCEPTION_PROPERTIES` autogate.