### PR TITLE
[CI] Don't generate python tests if they will not be built

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,17 @@ jobs:
             # Strip comment in front of WORKERS_MIRROR_URL, then substitute secret to use it.
             sed -e '/WORKERS_MIRROR_URL/ { s@# *@@; s@WORKERS_MIRROR_URL@${{ secrets.WORKERS_MIRROR_URL }}@; }' -i.bak WORKSPACE
           fi
+      - name: Disable slow tests if applicable
+        # Some tests (like Python import tests) take a long time to run and don't benefit much
+        # from multi-platform testing. For that reason, we only run them in a single configuration
+        # to minimize effect on CI pipeline runtime.
+        if: matrix.os.name != 'linux' || matrix.config.suffix != ''
+        shell: bash
+        run: |
+          cat <<EOF >> .bazelrc
+          build --build_tag_filters=-off-by-default,-slow
+          test --test_tag_filters=-off-by-default,-slow
+          EOF
       - name: Generate list of excluded Bazel targets
         # Exclude large benchmarking binaries created in debug and asan configurations to avoid
         # running out of disk space on the runner (nominally 14GB). We typically have two copies
@@ -121,22 +132,12 @@ jobs:
         shell: bash
         run: |
           cat <<EOF >> .bazelrc
-          build:limit-storage --build_tag_filters=-off-by-default,-benchmark
+          build:limit-storage --build_tag_filters=-off-by-default,-slow,-benchmark
           build:limit-storage --copt="-g1"
           build:limit-storage --copt="-fno-standalone-debug"
           build:limit-storage --config=rust-debug
           build:asan --config=limit-storage
           build:debug --config=limit-storage
-          EOF
-      - name: Disable slow tests if applicable
-        # Some tests (like Python import tests) take a long time to run and don't benefit much
-        # from multi-platform testing. For that reason, we only run them in a single configuration
-        # to minimize effect on CI pipeline runtime.
-        if: matrix.os.name != 'linux' || matrix.config.suffix != ''
-        shell: bash
-        run: |
-          cat <<EOF >> .bazelrc
-          test --test_tag_filters=-slow,-off-by-default
           EOF
       - name: Configure git hooks
         # Configure git to quell an irrelevant warning for runners (they never commit / push).

--- a/src/workerd/server/tests/python/import_tests.bzl
+++ b/src/workerd/server/tests/python/import_tests.bzl
@@ -33,16 +33,22 @@ def gen_import_tests(to_test):
   for lib in to_test.keys():
     worker_py_fname = "import/{}/worker.py".format(lib)
     wd_test_fname = "import/{}/import.wd-test".format(lib)
-    write_file(worker_py_fname + "@rule",
-      worker_py_fname,
-      [generate_import_py_file(to_test[lib])])
-    write_file(wd_test_fname + "@rule",
-      wd_test_fname,
-      [generate_wd_test_file(lib)])
+    write_file(
+      name = worker_py_fname + "@rule",
+      out = worker_py_fname,
+      content = [generate_import_py_file(to_test[lib])],
+      tags = ["slow"],
+    )
+    write_file(
+      name = wd_test_fname + "@rule",
+      out = wd_test_fname,
+      content = [generate_wd_test_file(lib)],
+      tags = ["slow"],
+    )
 
     wd_test(
-      src = "import/{}/import.wd-test".format(lib),
+      src = wd_test_fname,
       args = ["--experimental", "--disk-cache-dir", "../all_pyodide_wheels"],
       data = [worker_py_fname, "@all_pyodide_wheels//:whls"],
-      tags = ["slow"]
+      tags = ["slow"],
     )


### PR DESCRIPTION
- Generating the test files is likely much less expensive than building them, but still cuts down the number of superfluous build actions.

===========

This eliminates ~140 build targets out of ~8000 total depending on build platform. Keeping that number under control makes it easier to reason about bazel caching and build performance.