### PR TITLE
[nfc] Fix spelling of Cloudflare, other typos found by codespell

### DIFF
--- a/docs/api-updates.md
+++ b/docs/api-updates.md
@@ -10,9 +10,9 @@ update the documentation at the same time as the flag.
 Compatibility flags and dates for use within Workerd are defined in [compatibility-date.capnp](src/workerd/io/compatibility-date.capnp).
 
 When you create a Workerd pull request that contains new compatibility definitions, please
-create a pull request to update CloudFlare docs at the same time.
+create a pull request to update Cloudflare docs at the same time.
 
-## Compatibility documentation in CloudFlare docs
+## Compatibility documentation in Cloudflare docs
 
 Compatibility flags and dates should be added to the [Cloudflare Workers Compatibility Dates](https://developers.cloudflare.com/workers/platform/compatibility-dates) documentation.
 

--- a/src/node/internal/crypto_keys.ts
+++ b/src/node/internal/crypto_keys.ts
@@ -79,7 +79,7 @@ import {
 // In Node.js, the definition of KeyObject is a bit complicated because
 // KeyObject instances in Node.js can be transferred via postMessage() and
 // structuredClone(), etc, allowing instances to be shared across multiple
-// worker threads. We do not implement that model so we're esssentially
+// worker threads. We do not implement that model so we're essentially
 // re-implementing the Node.js API here instead of just taking their code.
 // Also in Node.js, CryptoKey is layered on top of KeyObject since KeyObject
 // existed first. We're, however, going to layer our KeyObject on top of

--- a/src/pyodide/internal/asgi.py
+++ b/src/pyodide/internal/asgi.py
@@ -164,7 +164,7 @@ async def process_websocket(app, req):
             s = got.get("text", None)
             if b:
                 with acquire_js_buffer(b) as jsbytes:
-                    # Unlike the `Reponse` constructor,  server.send seems to
+                    # Unlike the `Response` constructor,  server.send seems to
                     # eagerly copy the source buffer
                     server.send(jsbytes)
             if s:

--- a/src/pyodide/internal/builtin_wrappers.js
+++ b/src/pyodide/internal/builtin_wrappers.js
@@ -47,7 +47,7 @@ export function monotonicDateNow() {
  *    passes this check.
  * 3. In normal Python code, this will only be called a fixed number of times
  *    every time we load a .so file. If we ever get to the position where
- *    `checkCallee` is a performance bottleneck, that would be a great successs.
+ *    `checkCallee` is a performance bottleneck, that would be a great success.
  *    Using ctypes, one can arrange to call a lot more times by repeatedly
  *    allocating and discarding closures. But:
  *      - ctypes is quite slow even by Python's standards

--- a/src/pyodide/internal/python.js
+++ b/src/pyodide/internal/python.js
@@ -90,7 +90,7 @@ function instantiateWasm(wasmImports, successCallback) {
  * We also make an empty home directory and an empty global site-packages
  * directory `/lib/pythonv.vv/site-packages`.
  *
- * This is a simpified version of the `prepareFileSystem` function here:
+ * This is a simplified version of the `prepareFileSystem` function here:
  * https://github.com/pyodide/pyodide/blob/main/src/js/module.ts
  */
 function prepareFileSystem(Module) {

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -2864,7 +2864,7 @@ public:
         // by kj write promise. If the outer kj Promise is dropped, the PumpToReader attached
         // to it is dropped. When that happens, there's a chance the JS continuation will still
         // be scheduled to run. The IoOwn ensures that the PumpToReader, and the sink it owns,
-        // are always accessed from the right IoContext. Thw WeakRef ensures that if the
+        // are always accessed from the right IoContext. The WeakRef ensures that if the
         // PumpToReader is freed while the JS continuation is pending, there won't be a dangling
         // reference.
         return ioContext.awaitJs(js,

--- a/src/workerd/io/actor-cache-test.c++
+++ b/src/workerd/io/actor-cache-test.c++
@@ -1349,7 +1349,7 @@ KJ_TEST("ActorCache flush hard failure") {
 
   KJ_EXPECT_THROW_MESSAGE("broken.outputGateBroken; jsg.Error: flush failed hard", promise.wait(ws));
 
-  // Futher writes won't even try to start any new transactions because the failure killed them all.
+  // Further writes won't even try to start any new transactions because the failure killed them all.
   test.put("bar", "456");
 }
 
@@ -1376,7 +1376,7 @@ KJ_TEST("ActorCache flush hard failure with output gate bypass") {
   KJ_EXPECT_THROW_MESSAGE("flush failed hard", promise.wait(ws));
   KJ_EXPECT_THROW_MESSAGE("flush failed hard", test.gate.wait().wait(ws));
 
-  // Futher writes won't even try to start any new transactions because the failure killed them all.
+  // Further writes won't even try to start any new transactions because the failure killed them all.
   test.put("bar", "456");
 }
 
@@ -3605,7 +3605,7 @@ KJ_TEST("ActorCache LRU purge larger") {
   test.put("corge", kilobyte);
 
   // Dropped from cache, because the puts are in-flight and so cannot be dropped. This read gets
-  // sent off before the puts above becase the event loop hasn't been yielded yet.
+  // sent off before the puts above because the event loop hasn't been yielded yet.
   // TODO(cleanup): We hold onto the promise here (even though in theory it'd be fine to drop)
   // because the capnp-mock framework doesn't handle dropped client promises well (capnp destructs
   // the ReceivedCall before waitForEvent resolves and hands control back to expectCall, leaving
@@ -5228,7 +5228,7 @@ KJ_TEST("ActorCache can wait for flush") {
     }, {
       // We can't test the second operation because deleteAll immediately follows up with any puts
       // that happened while it was in flight. This means that we invoke the mock twice in the same
-      // promise chain without being able to set up expections in time.
+      // promise chain without being able to set up exceptions in time.
       .skipSecondOperation = true,
     });
   }

--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -335,7 +335,7 @@ void ActorCache::evictEntry(Lock& lock, Entry& entry) {
   //
   // TODO(perf): Maybe we should instead replace the evicted entry with an UNKNOWN entry in this
   //   case? The problem is, when the app accesses a key in the gap, the LRU time of the previous
-  //   entry gets bumped, but the _next_ entry does not get bumped. Hence these acccesses won't
+  //   entry gets bumped, but the _next_ entry does not get bumped. Hence these accesses won't
   //   prevent the next entry from being evicted, and when it is, the gap effectively gets evicted
   //   too, leading to a cache miss on a key that had been recently accessed. This is a pretty
   //   obscure scenario, though, and after one cache miss the key would then be in cache again.
@@ -1778,7 +1778,7 @@ kj::PromiseForResult<Func, rpc::ActorStorage::Operations::Client> ActorCache::sc
     Func&& function) {
   // This is basically kj::retryOnDisconnect() except that we make the first call synchronously.
   // For our use case, this is safe, and I wanted to make sure reads get sent concurrently with
-  // futher JavaScript execution if possible.
+  // further JavaScript execution if possible.
   auto promise = kj::evalNow([&]() mutable {
     return function(storage).attach(recordStorageRead(hooks, clock));
   });
@@ -2212,7 +2212,7 @@ kj::Maybe<kj::Promise<void>> ActorCache::onNoPendingFlush() {
   }
 
   // There are no scheduled or in-flight flushes (and there may never have been any), we can return
-  // a false maybee.
+  // a false Maybe.
   return kj::none;
 }
 
@@ -2617,7 +2617,7 @@ kj::Promise<void> ActorCache::flushImpl(uint retryCount) {
                jsg::isDoNotLogException(e.getDescription())) {
       // Before passing along the exception, give it the proper brokenness reason.
       // We were overriding any exception that came through here by ioGateBroken (now outputGateBroken).
-      // without checking for previous brokeness reasons we would be unable to throw
+      // without checking for previous brokenness reasons we would be unable to throw
       // exceededConcurrentStorageOps at all.
       auto msg = jsg::stripRemoteExceptionPrefix(e.getDescription());
       if (!(msg.startsWith("broken."))) {

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -156,7 +156,7 @@ public:
       kj::Array<Key> keys, WriteOptions options) = 0;
 };
 
-// Abstract interface that is implemneted by ActorCache as well as ActorSqlite.
+// Abstract interface that is implemented by ActorCache as well as ActorSqlite.
 //
 // This extends ActorCacheOps and adds some methods that don't make sense as part of
 // ActorCache::Transaction.
@@ -304,7 +304,7 @@ private:
   class DeferredAlarmDeleter: public kj::Disposer {
   public:
     // The `Own<void>` returned by `armAlarmHandler()` is actually set up to point to the
-    // `ActorCache` itself, but with an alterante disposer that deletes the alarm rather than
+    // `ActorCache` itself, but with an alternate disposer that deletes the alarm rather than
     // the whole object.
     void disposeImpl(void* pointer) const {
       auto p = reinterpret_cast<ActorCache*>(pointer);
@@ -427,7 +427,7 @@ private:
 
     // Avoid using setClean() and setDirty() directly. If you want to set the status to CLEAN or
     // DIRTY, consider using the addToCleanList() and addToDirtyList() methods. This helps us keep
-    // the state transitions managable.
+    // the state transitions manageable.
     void setClean() {
       syncStatus = EntrySyncStatus::CLEAN;
     }

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -64,7 +64,7 @@ public:
 // a unique subrequest channel number, and calling `binding.fetch()` sends the request to the
 // given channel.
 //
-// While most channels are SubrequestChannels, other channel types exit to handle I/O that is
+// While most channels are SubrequestChannels, other channel types exist to handle I/O that is
 // not subrequest-shaped. For example, a Workers Analytics Engine binding uses a logging channel.
 //
 // Note that each type of channel has its own number space. That is, subrequest channel 5 and

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -408,7 +408,7 @@ public:
   // Historically, we solved this with something called `capctx`. You would write something like:
   // `awaitIo(promise.then(capctx(func)))`. This provided both properties: `func()` ran both in
   // the KJ event loop and with the isolate lock held. However, this had the problem that it
-  // required returning to the KJ event loop between running func() and runnning whatever
+  // required returning to the KJ event loop between running func() and running whatever
   // JavaScript code was waiting on it. This implies releasing the isolate lock just to
   // immediately acquire it again, which was wasteful. Passing `func` as a parameter to `awaitIo()`
   // allows it to run under the same isolate lock that then runs the awaiting JavaScript.
@@ -523,7 +523,7 @@ public:
   }
 
   // Like awaitIo(), but handles the specific case of Promise<DeferredProxy>. This is special
-  // becaues the convention is that the outer promise is NOT treated as a pending I/O event; it
+  // because the convention is that the outer promise is NOT treated as a pending I/O event; it
   // may actually be waiting for something to happen in JavaScript land. Once the outer promise
   // resolves, the inner promise (the DeferredProxy<T>) is treated as external I/O.
   template <typename T>
@@ -870,7 +870,7 @@ private:
     return incomingRequests.front();
   }
 
-  // Run the given callback within the scope of this IoContext. This encapsultes the
+  // Run the given callback within the scope of this IoContext. This encapsulates the
   // setup of a number of scopes that must be entered prior to running within the
   // context, including entering the V8StackScope and acquiring the Worker::Lock.
   void runInContextScope(Worker::LockType lockType,
@@ -1061,7 +1061,7 @@ jsg::PromiseForResult<Func, T, true> IoContext::awaitIoImpl(
           // We don't use `resolver.reject()` here because if we convert the kj::Exception into
           // a JS Error here, it won't have a useful stack trace. V8 can generate a good stack
           // trace as long as we construct the Error inside of a promise continuation, so we use
-          // a `.then()` below that acutally extracts the kj::Exception and turn it into a JS
+          // a `.then()` below that actually extracts the kj::Exception and turn it into a JS
           // Error.
           resolver.resolve(js, kj::mv(e));
         } else {
@@ -1292,7 +1292,7 @@ jsg::PromiseForResult<Func, void, true> IoContext::blockConcurrencyWhile(
     // Annotate as broken for periodic metrics.
     auto msg = e.getDescription();
     if (!msg.startsWith("broken."_kj) && !msg.startsWith("remote.broken."_kj)) {
-      // If we already set up a brokeness reason, we shouldn't override it.
+      // If we already set up a brokenness reason, we shouldn't override it.
 
       auto description = jsg::annotateBroken(msg, "broken.inputGateBroken");
       e.setDescription(kj::mv(description));

--- a/src/workerd/io/io-thread-context.h
+++ b/src/workerd/io/io-thread-context.h
@@ -31,7 +31,7 @@ public:
       HeaderIdBundle headerIds, capnp::HttpOverCapnpFactory& httpOverCapnpFactory,
           capnp::ByteStreamFactory& byteStreamFactory, bool isFiddle);
 
-  // This should only be used to costruct TimerChannel. Everything else should use TimerChannel.
+  // This should only be used to construct TimerChannel. Everything else should use TimerChannel.
   inline kj::Timer& getUnsafeTimer() const { return timer; }
   inline kj::EntropySource& getEntropySource() const { return entropySource; }
   inline const kj::HttpHeaderTable& getHeaderTable() const { return headerIds.table; }

--- a/src/workerd/io/limit-enforcer.h
+++ b/src/workerd/io/limit-enforcer.h
@@ -136,7 +136,7 @@ public:
   // are exceeded.
   virtual kj::Maybe<EventOutcome> getLimitsExceeded() = 0;
 
-  // Reutrns a promise that will reject if and when a limit is exceeded that prevents further
+  // Returns a promise that will reject if and when a limit is exceeded that prevents further
   // JavaScript execution, such as the CPU or memory limit.
   virtual kj::Promise<void> onLimitsExceeded() = 0;
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3187,7 +3187,7 @@ void Worker::Actor::ensureConstructed(IoContext& context) {
       auto msg = e.getDescription();
 
       if (!msg.startsWith("broken."_kj) && !msg.startsWith("remote.broken."_kj)) {
-        // If we already set up a brokeness reason, we shouldn't override it.
+        // If we already set up a brokenness reason, we shouldn't override it.
 
         auto description = jsg::annotateBroken(msg, "broken.constructorFailed");
         e.setDescription(kj::mv(description));

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -764,7 +764,7 @@ public:
 
   // Wait for `Date.now()` to be greater than or equal to `scheduledTime`. If the promise resolves
   // to an `AlarmFulfiller`, then the caller is responsible for invoking `fulfill()`, `reject()`, or
-  // `cancel()`. Otherwise, the scheduled alarm was overriden by another call to `scheduleAlarm()`
+  // `cancel()`. Otherwise, the scheduled alarm was overridden by another call to `scheduleAlarm()`
   // and thus was cancelled. Note that callers likely want to invoke `getAlarm()` first to see if
   // there is an existing alarm at `scheduledTime` for which they want to wait (instead of
   // cancelling it).

--- a/src/workerd/jsg/README.md
+++ b/src/workerd/jsg/README.md
@@ -342,7 +342,7 @@ mappings for these structures.
 One choice is to map to and from a `kj::Array<kj::byte>`.
 
 When receiving a `kj::Array<kj::byte>` in C++ *from* a JavaScript `TypedArray` or `ArrayBuffer`,
-it is important to understand that the underlying data is not copied or transfered. Instead, the
+it is important to understand that the underlying data is not copied or transferred. Instead, the
 `kj::Array<kj::byte>` provides a *view* over the same underlying `v8::BackingStore` as the
 `TypedArray` or `ArrayBuffer`.
 
@@ -1686,7 +1686,7 @@ This code is only ever called when a heap snapshot is being generated so
 typically it should have very little cost. Heap snapshots are generally
 fairly expensive to create, however, so care should be taken not to make
 things too complicated. Ideally, none of the implementation methods in a
-type should allocate. There is some allocation occuring internally while
+type should allocate. There is some allocation occurring internally while
 building the graph, of course, but the methods for visitation (in particular
 the `jsgGetMemoryInfo(...)` method) should not perform any allocations if it
 can be avoided.

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1461,7 +1461,7 @@ class Constructor;
 //
 // If the type T is GC visitable (i.e. it is a type that you could pass to GcVisitor::visit()),
 // then the system will arrange to correctly visit it when the T is wrapped in a Promise.
-// Additionally, if a continuation function passed to `.then()` is GC-visitable, it will similary
+// Additionally, if a continuation function passed to `.then()` is GC-visitable, it will similarly
 // be visited. JSG_VISITABLE_LAMBDA is a useful in conjunction with `.then()` (see jsg::Function,
 // above).
 //

--- a/src/workerd/jsg/memory.h
+++ b/src/workerd/jsg/memory.h
@@ -104,7 +104,7 @@ namespace workerd::jsg {
 // typically it should have very little cost. Heap snapshots are generally
 // fairly expensive to create, however, so care should be taken not to make
 // things too complicated. Ideally, none of the implementation methods in a
-// type should allocate. There is some allocation occuring internally while
+// type should allocate. There is some allocation occurring internally while
 // building the graph, of course, but the methods for visitation (in particular
 // the jsgGetMemoryInfo(...) method) should not perform any allocations if it
 // can be avoided.

--- a/src/workerd/jsg/resource-test.c++
+++ b/src/workerd/jsg/resource-test.c++
@@ -681,7 +681,7 @@ KJ_TEST("lazy js global class works") {
   e.expectEval("new BootstrapClass().run()", "string", "THIS_IS_BOOTSTRAP_CLASS");
 }
 
-KJ_TEST("lazy js readonly property can not be overriden") {
+KJ_TEST("lazy js readonly property can not be overridden") {
   Evaluator<JsLazyReadonlyPropertyContext, JsLazyReadonlyPropertyIsolate> e(v8System);
   e.expectEval("globalThis.bootstrapFunction = function(){'boo'}; bootstrapFunction()", "string", "THIS_IS_BOOTSTRAP_FUNCTION");
   e.expectEval("bootstrapFunction = function(){'boo'}; bootstrapFunction()", "string", "THIS_IS_BOOTSTRAP_FUNCTION");
@@ -720,7 +720,7 @@ KJ_TEST("lazy js global class works") {
   e.expectEval("new BootstrapClass().run()", "string", "THIS_IS_BOOTSTRAP_CLASS");
 }
 
-KJ_TEST("lazy js property can be overriden") {
+KJ_TEST("lazy js property can be overridden") {
   Evaluator<JsLazyPropertyContext, JsLazyPropertyIsolate, decltype(nullptr), JsLazyPropertyIsolate_TypeWrapper> e(v8System);
   // for module syntax
   e.expectEvalModule(R"(

--- a/src/workerd/jsg/ser-test.c++
+++ b/src/workerd/jsg/ser-test.c++
@@ -265,7 +265,7 @@ KJ_TEST("serialization") {
   // Also try round-tripping the new version. It now accepts arbitrary values, not just strings.
   e2.expectEval("roundTrip(new Bar(123)).val", "number", "123");
 
-  // Note that cycles through host objects are correcty serialized!
+  // Note that cycles through host objects are correctly serialized!
   //
   // V8 BUG ALERT: The below works if we use `obj` as the root of serialization, but NOT if we
   //   use `bar` as the root. The reason is a flaw in the design of V8's callbacks for parsing

--- a/src/workerd/jsg/url-test.c++
+++ b/src/workerd/jsg/url-test.c++
@@ -1462,7 +1462,7 @@ KJ_TEST("URLPattern - MDN example 3 - pathname: '/books/:id(\\d+)' with base") {
   }
 }
 
-KJ_TEST("URLPattern - MDN example 4 - pathame: '/:type(foo|bar)'") {
+KJ_TEST("URLPattern - MDN example 4 - pathname: '/:type(foo|bar)'") {
   KJ_SWITCH_ONEOF(UrlPattern::tryCompile({
     .pathname = kj::str("/:type(foo|bar)")
   })) {

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -314,7 +314,7 @@ void throwInternalError(v8::Isolate* isolate, kj::Exception&& exception) {
 void addExceptionDetail(Lock& js, kj::Exception& exception, v8::Local<v8::Value> handle) {
   js.tryCatch([&]() {
     Serializer ser(js, {
-      // Make sure we don't break compatibility if V8 introduces a new version. This vaule can
+      // Make sure we don't break compatibility if V8 introduces a new version. This value can
       // be bumped to match the new version once all of production is updated to understand it.
       .version = 15,
     });

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -25,7 +25,7 @@ static thread_local bool inCppgcShimDestructor = false;
 bool HeapTracer::isInCppgcDestructor() { return inCppgcShimDestructor; }
 
 void HeapTracer::clearWrappers() {
-  // When clearing wrappers (at isolate shutdown), we may be destroying objects that were recenly
+  // When clearing wrappers (at isolate shutdown), we may be destroying objects that were recently
   // determined to be unreachable, but the CppgcShim destructors haven't been run yet. We need to
   // treat this case as if we are running CppgcShim destructors, that is, assume any
   // TracedReferences we destroy have already been collected so cannot be touched.
@@ -44,7 +44,7 @@ void HeapTracer::clearWrappers() {
 // V8's GC integrates with cppgc, aka "oilpan", a garbage collector for C++ objects. We want to
 // integrate with the GC in order to receive GC visitation callbacks, so that the GC is able to
 // trace through our C++ objects to find what is reachable through them. The only way for us to
-// supprot this is by integrating with cppgc.
+// support this is by integrating with cppgc.
 //
 // However, workerd was written using KJ idioms long before cppgc existed. Rewriting all our code
 // to use cppgc allocation instead would be a highly invasive change. Maybe we'll do it someday,

--- a/src/workerd/server/alarm-scheduler.c++
+++ b/src/workerd/server/alarm-scheduler.c++
@@ -58,7 +58,7 @@ void AlarmScheduler::loadAlarmsFromDb() {
   auto now = clock.now();
 
   // TODO(someday): don't maintain the entire alarm set in memory -- right now for the usecase of
-  // local development, doing so is sufficent.
+  // local development, doing so is sufficient.
   auto query = db->run(R"(
     SELECT actor_unique_key, actor_id, scheduled_time FROM _cf_ALARM;
   )");
@@ -230,7 +230,7 @@ kj::Promise<void> AlarmScheduler::makeAlarmTask(kj::Duration delay,
       co_return;
     }
 
-    // When we reach this block of code and alarm has either successed or failed and may (or may
+    // When we reach this block of code and alarm has either succeeded or failed and may (or may
     // not) retry. Setting the status of an alarm as FINISHED here, will allow deletion of alarms
     // between retries. If there's a retry, `makeAlarmTask` is called, setting status as RUNNING
     // again.

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -415,7 +415,7 @@ private:
   kj::UnwindDetector unwindDetector;
 
   // ---------------------------------------------------------------------------
-  // implements Filesytem
+  // implements Filesystem
 
   const kj::Directory& getRoot() const override {
     return *root;
@@ -1350,7 +1350,7 @@ KJ_TEST("Server: named entrypoints") {
                 `  }
                 `}
                 `
-                `// Also exprot some symbols that aren't valid entrypoints, but we should still
+                `// Also export some symbols that aren't valid entrypoints, but we should still
                 `// be allowed to point sockets at them. (Sending any actual requests to them
                 `// will still fail.)
                 `export let invalidObj = {};  // no handlers

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -944,7 +944,7 @@ private:
           // (especially with HEAD requests) is quite useful.
           // TODO(cleanup): Arguably the implementation of `fetch()` should be adjusted so that
           //   if no `Content-Length` header is returned, but the body size is known via the KJ
-          //   HTTP API, then the header shoud be filled in automatically. Unclear if this is safe
+          //   HTTP API, then the header should be filled in automatically. Unclear if this is safe
           //   to change without a compat flag.
 
           if (method == kj::HttpMethod::HEAD) {
@@ -1128,7 +1128,7 @@ kj::Own<Server::Service> Server::makeDiskDirectoryService(
 // This class provides a small thread-safe interface to the InspectorService so <name>:<isolate>
 // mappings can be added after the InspectorService has started.
 //
-// The CloudFlare devtools only show the first service in workerd configuration. This service
+// The Cloudflare devtools only show the first service in workerd configuration. This service
 // is always contains a users code. However, in packaging user code wrangler may add
 // additional services that also have code. If using Chrome devtools to inspect a workerd,
 // instance all services are visible and can be debugged.
@@ -1617,7 +1617,7 @@ public:
           a->shutdown(0, KJ_EXCEPTION(DISCONNECTED,
               "broken.dropped; Actor freed due to inactivity"));
         }
-        // Destory the last strong Worker::Actor reference.
+        // Destroy the last strong Worker::Actor reference.
         actor = kj::none;
       }
 
@@ -2600,7 +2600,7 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
       // any actual requests are sent to an empty handler, they will fail at runtime.
       //
       // The reason we want the config to be considered valid even if it refers to empty
-      // entrypoints is so that it's safe to auto-generate a config that binds every exprot to
+      // entrypoints is so that it's safe to auto-generate a config that binds every export to
       // a socket, without checking the types of all the exports. Miniflare does this.
       KJ_IF_SOME(e, exportName) {
         namedEntrypoints.findOrCreate(e,
@@ -3179,7 +3179,7 @@ private:
       // TODO(someday): Use cfBlobJson from the connection if there is one, or from RPC params
       //   if we add that? (Note that if a connection-level cf blob exists, it should take
       //   priority; we should only accept a cf blob from the client if we have a cfBlobHeader
-      //   configrued, which hints that this service trusts the client to provide the cf blob.)
+      //   configured, which hints that this service trusts the client to provide the cf blob.)
 
       context.initResults(capnp::MessageSize {4, 1}).setDispatcher(
           kj::heap<EventDispatcherImpl>(parent, parent.service.startRequest({})));

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -202,7 +202,7 @@ private:
 // Class which uses inotify to watch a set of files and alert when they change.
 //
 // This version uses kqueue to watch for changes in files. kqueue typically doesn't scale well
-// to watching whole directory trees, since it must keep a file descriptor opne for each watched
+// to watching whole directory trees, since it must keep a file descriptor open for each watched
 // file. However, for our use case, we don't really want to watch a directory tree anyway, we
 // want to watch the specific set of files which were opened while parsing the config. This is
 // not so bad, probably.
@@ -220,7 +220,7 @@ public:
   void watch(kj::PathPtr path, kj::Maybe<const kj::ReadableFile&> file) {
     KJ_IF_SOME(f, file) {
       KJ_IF_SOME(fd, f.getFd()) {
-        // We need to duplicate the FD becasue the original will probably be closed later and
+        // We need to duplicate the FD because the original will probably be closed later and
         // closing the FD unregisters it from kqueue.
         int duped;
         KJ_SYSCALL(duped = dup(fd));
@@ -808,7 +808,7 @@ public:
           "    }\n");
     return addServeOrTestOptions(addConfigParsingOptionsNoConstName(builder))
         .addOption({"no-verbose"}, [this]() { noVerbose = true; return true; },
-            "Disable INFO-level logging for this test. Otherwise, INFO logging is enalbed by "
+            "Disable INFO-level logging for this test. Otherwise, INFO logging is enabled by "
             "default for tests in order to show uncaught exceptions, but it can be noisey.")
         .expectOptionalArg("<filter>", CLI_METHOD(setTestFilter))
         .callAfterParsing(CLI_METHOD(test))
@@ -1085,7 +1085,7 @@ public:
 
   void compile() {
     if (hadErrors) {
-      // Errors were already reported with context.error(), so contex.exit() will exit with a
+      // Errors were already reported with context.error(), so context.exit() will exit with a
       // non-zero code.
       context.exit();
     }
@@ -1434,7 +1434,7 @@ private:
           return cnst.getShortDisplayName();
         };
         // TODO: this error message says "you must specify which one to use".
-        // This is not actaully possible? Either fix the error message to say
+        // This is not actually possible? Either fix the error message to say
         // **how** to specify which config object to use or tell user to define
         // exactly one top level Config constant.
         context.exitError(kj::str(

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -25,7 +25,7 @@
 # to see and restrict what each Worker can access. Instead, the default is that a Worker has
 # access to no privileged resources at all, and you must explicitly declare "bindings" to give
 # it access to specific resources. A binding gives the Worker a JavaScript API object that points
-# to a specific resource. This means that by changing config alone, you can fully controll which
+# to a specific resource. This means that by changing config alone, you can fully control which
 # resources an Worker connects to. (You can even disallow access to the public internet, although
 # public internet access is granted by default.)
 #
@@ -207,7 +207,7 @@ struct Worker {
     # event handlers.
     #
     # The value of this field is the raw source code. When using Cap'n Proto text format, use the
-    # `embed` directive to read the code from an exnternal file:
+    # `embed` directive to read the code from an external file:
     #
     #     serviceWorkerScript = embed "worker.js"
 
@@ -346,7 +346,7 @@ struct Worker {
 
       kvNamespace @11 :ServiceDesignator;
       # A KV namespace, implemented by the named service. The Worker sees a KvNamespace-typed
-      # binding. Requests to the namespace will be converted into HTTP requests targetting the
+      # binding. Requests to the namespace will be converted into HTTP requests targeting the
       # given service name.
 
       r2Bucket @12 :ServiceDesignator;
@@ -359,7 +359,7 @@ struct Worker {
 
       queue @15 :ServiceDesignator;
       # A Queue binding, implemented by the named service. Requests to the
-      # namespace will be converted into HTTP requests targetting the given
+      # namespace will be converted into HTTP requests targeting the given
       # service name.
 
       fromEnvironment @16 :Text;
@@ -556,10 +556,10 @@ struct Worker {
       # Instances of this class are ephemeral -- they have no durable storage at all. The
       # `state.storage` API will not be present. Additionally, this namespace will allow arbitrary
       # strings as IDs. There are no `idFromName()` nor `newUniqueId()` methods; `get()` takes any
-      # string as a paremeter.
+      # string as a parameter.
       #
       # Ephemeral objects are NOT globally unique, only "locally" unique, for some definition of
-      # "local". For exmaple, on Cloudflare's network, these objects are unique per-colo.
+      # "local". For example, on Cloudflare's network, these objects are unique per-colo.
       #
       # WARNING: Cloudflare Workers currently limits this feature to Cloudflare-internal users
       #   only, because using them correctly requires deep understanding of Cloudflare network
@@ -731,7 +731,7 @@ struct DiskDirectory {
   # particular, no attempt is made to guess the `Content-Type` header. You normally would wrap
   # this in a Worker that fills in the metadata in the way you want.
   #
-  # A GET request targetting a directory (rather than a file) will return a basic JSAN directory
+  # A GET request targeting a directory (rather than a file) will return a basic JSAN directory
   # listing like:
   #
   #     [{"name":"foo","type":"file"},{"name":"bar","type":"directory"}]

--- a/src/workerd/tools/api-encoder.c++
+++ b/src/workerd/tools/api-encoder.c++
@@ -202,7 +202,7 @@ struct ApiEncoderMain {
 #undef EW_TYPE_GROUP_COUNT
 #undef EW_TYPE_GROUP_WRITE
 
-    // Write structure groups to a file or stdout if none specifed
+    // Write structure groups to a file or stdout if none specified
     KJ_IF_SOME (value, output) {
       auto fs = kj::newDiskFilesystem();
       auto path = kj::Path::parse(value);

--- a/src/workerd/util/duration-exceeded-logger-test.c++
+++ b/src/workerd/util/duration-exceeded-logger-test.c++
@@ -14,7 +14,7 @@ KJ_TEST("Duration alert triggers when time is exceeded") {
 
     KJ_EXPECT_LOG(WARNING, "durationAlert Test Message; warningDuration = 10s; actualDuration = ");
     // we don't check the actual duration emitted to avoid making the test flaky.
-    // this is okay because KJ_EXPECT_LOG just checks for substring occurences
+    // this is okay because KJ_EXPECT_LOG just checks for substring occurrences
     {
         DurationExceededLogger duration(timer, 10*kj::SECONDS, "durationAlert Test Message");
         timer.advanceTo(timer.now() + 100*kj::SECONDS);

--- a/src/workerd/util/sqlite-kv.h
+++ b/src/workerd/util/sqlite-kv.h
@@ -123,7 +123,7 @@ private:
 // =======================================================================================
 // inline implementation details
 //
-// We define these two methods as templates rather than ues kj::Function since they're not too
+// We define these two methods as templates rather than use kj::Function since they're not too
 // complicated and avoiding the virtual call is nice. Plus in list()'s case, the actual call sites
 // pass constants for `order` so the `order ==` branch can be eliminated.
 

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -1030,7 +1030,7 @@ static thread_local int currentVfsRoot = AT_FDCWD;
 // We will tell SQLite to use alternate implementations of path-oriented syscalls which use the
 // `*at()` versions of the calls with `currentVfsRoot` as the directory descriptor. When the
 // descriptor is `AT_FDCWD`, this will naturally reproduce the behavior of the non-`at()` versions.
-// We temporarily swap this for a real desriptor when our custom VFS wrapper is being invoked.
+// We temporarily swap this for a real descriptor when our custom VFS wrapper is being invoked.
 
 static int replaced_open(const char* path, int flags, int mode) {
   return openat(currentVfsRoot, path, flags, mode);
@@ -1278,7 +1278,7 @@ struct SqliteDatabase::Vfs::FileImpl: public sqlite3_file {
   kj::Maybe<kj::Own<Lock>> lock;
   // Rather complicatedly, SQLite doesn't consider the -shm file to be a separate file that it
   // opens via the VFS, but rather a facet of the database file itself. We implement it using an
-  // entirely different interface anyawy.
+  // entirely different interface anyway.
   //
   // We leave this null if the file is not the main database file.
 

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -63,7 +63,7 @@ public:
   // except:
   // - It may be more efficient for one-off use caes.
   // - The code can include multiple statements, separated by semicolons. The bindings and returned
-  //   `Query` object are both associated with the last statement. This is particulary convenient
+  //   `Query` object are both associated with the last statement. This is particularly convenient
   //   for doing database initialization such as creating several tables at once.
   template <typename... Params>
   Query run(Regulator& regulator, kj::StringPtr sqlCode, Params&&... bindings);
@@ -483,7 +483,7 @@ public:
 //
 // When using a Vfs based on a regular disk directory, this class isn't used; instead, SQLite's
 // native implementation kicks in, which is based on advisory file locks at the OS level, as well
-// as mmaped shared memory from a file next to the database with suffix `-shm`.
+// as mmapped shared memory from a file next to the database with suffix `-shm`.
 class SqliteDatabase::Lock {
 public:
   // The main database can be locked at one of these levels.

--- a/src/workerd/util/thread-scopes.h
+++ b/src/workerd/util/thread-scopes.h
@@ -4,7 +4,7 @@
 
 #pragma once
 // This file contains several horrible hacks involving setting a thread-local value within some
-// scope in the call stack, and then being able to check the vaule from deeper in the stack,
+// scope in the call stack, and then being able to check the value from deeper in the stack,
 // without passing down an object. We use this pattern to signal hints across modules that do not
 // directly call each other, where it would be excessively inconvenient to pass the value down the
 // stack, perhaps because there is code in between that we do not control (e.g., V8).

--- a/src/workerd/util/uuid.h
+++ b/src/workerd/util/uuid.h
@@ -18,7 +18,7 @@ kj::String randomUUID(kj::Maybe<kj::EntropySource&> optionalEntropySource);
 // A 128-bit universally unique identifier (UUID).
 //
 // A UUID can be created from and converted between between two formats:
-// 1. Upper/lower format: an "upper" field representing the most signficant bits and "lower" field
+// 1. Upper/lower format: an "upper" field representing the most significant bits and "lower" field
 //    representings the least significant bits.
 // 2. Stringified 8-4-4-4-12 hex format.
 //


### PR DESCRIPTION
This cleans up codespell issues excluding false positives in all of workerd except for the src/workerd/api folder, which can be addressed in a followup PR.