### PR TITLE
Disable slow tests by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,9 @@
 common --enable_platform_specific_config
 build --verbose_failures
 build --build_tag_filters=-off-by-default
-test --test_tag_filters=-off-by-default
+test --test_tag_filters=-off-by-default,-slow
+
+test:enable-slow-tests --test_tag_filters=-off-by-default
 
 # Not using bzlmod for dependencies yet
 common --noenable_bzlmod

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,15 +128,15 @@ jobs:
           build:asan --config=limit-storage
           build:debug --config=limit-storage
           EOF
-      - name: Disable slow tests if applicable
+      - name: Enable slow tests if applicable
         # Some tests (like Python import tests) take a long time to run and don't benefit much
         # from multi-platform testing. For that reason, we only run them in a single configuration
         # to minimize effect on CI pipeline runtime.
-        if: matrix.os.name != 'linux' || matrix.config.suffix != ''
+        if: matrix.os.name == 'linux' && matrix.config.suffix != ''
         shell: bash
         run: |
           cat <<EOF >> .bazelrc
-          test --test_tag_filters=-slow,-off-by-default
+          test --config=enable-slow-tests
           EOF
       - name: Configure git hooks
         # Configure git to quell an irrelevant warning for runners (they never commit / push).


### PR DESCRIPTION
Test plan:
```
bazel test /src/...
```
Observe that Python import tests are not run.

Furthermore, Python import tests should be run in:
1. Linux nondebug on workerd CI
2. Linux debug on Edgeworker CI