### PR TITLE
Improve Blob memory accounting

### DIFF
--- a/src/workerd/api/form-data.h
+++ b/src/workerd/api/form-data.h
@@ -49,8 +49,12 @@ public:
   // `convertFilesToStrings` is for backwards-compatibility. The first implementation of this
   // class in Workers incorrectly represented files as strings (of their content). Changing this
   // could break deployed code, so this has to be controlled by a compatibility flag.
-  void parse(kj::ArrayPtr<const char> rawText, kj::StringPtr contentType,
-             bool convertFilesToStrings);
+  //
+  // Parsing may or may not pass a jsg::Lock. If a lock is passed, any File objects created will
+  // track their internal allocated memory in the associated isolate. If a lock is not passed,
+  // the internal allocated memory will not be tracked.
+  void parse(kj::Maybe<jsg::Lock&> js, kj::ArrayPtr<const char> rawText,
+             kj::StringPtr contentType, bool convertFilesToStrings);
 
   struct Entry {
     kj::String name;
@@ -79,7 +83,8 @@ public:
   // message they receive too pretty: they won't get farther than `document.getElementById()`.
   static jsg::Ref<FormData> constructor();
 
-  void append(kj::String name, kj::OneOf<jsg::Ref<File>, jsg::Ref<Blob>, kj::String> value,
+  void append(jsg::Lock& js, kj::String name,
+              kj::OneOf<jsg::Ref<File>, jsg::Ref<Blob>, kj::String> value,
               jsg::Optional<kj::String> filename);
 
   void delete_(kj::String name);
@@ -90,7 +95,8 @@ public:
 
   bool has(kj::String name);
 
-  void set(kj::String name, kj::OneOf<jsg::Ref<File>, jsg::Ref<Blob>, kj::String> value,
+  void set(jsg::Lock& js, kj::String name,
+           kj::OneOf<jsg::Ref<File>, jsg::Ref<Blob>, kj::String> value,
            jsg::Optional<kj::String> filename);
 
   JSG_ITERATOR(EntryIterator, entries,

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -825,7 +825,7 @@ jsg::Promise<jsg::Ref<FormData>> Body::formData(jsg::Lock& js) {
           context.getLimitEnforcer().getBufferingLimit()).then(js,
           [contentType = kj::mv(contentType), formData = kj::mv(formData)]
           (auto& js, kj::String rawText) mutable {
-        formData->parse(kj::mv(rawText), contentType,
+        formData->parse(js, kj::mv(rawText), contentType,
             !FeatureFlags::get(js).getFormDataParserSupportsFiles());
         return kj::mv(formData);
       });
@@ -834,7 +834,7 @@ jsg::Promise<jsg::Ref<FormData>> Body::formData(jsg::Lock& js) {
     // Theoretically, we already know if this will throw: the empty string is a valid
     // application/x-www-form-urlencoded body, but not multipart/form-data. However, best to let
     // FormData::parse() make the decision, to keep the logic in one place.
-    formData->parse(kj::String(), contentType,
+    formData->parse(js, kj::String(), contentType,
         !FeatureFlags::get(js).getFormDataParserSupportsFiles());
     return js.resolvedPromise(kj::mv(formData));
   });
@@ -860,7 +860,7 @@ jsg::Promise<jsg::Ref<Blob>> Body::blob(jsg::Lock& js) {
           }).orDefault(nullptr);
     }
 
-    return jsg::alloc<Blob>(kj::mv(buffer), kj::mv(contentType));
+    return jsg::alloc<Blob>(js, kj::mv(buffer), kj::mv(contentType));
   });
 }
 

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -1056,7 +1056,7 @@ jsg::Promise<jsg::Ref<Blob>> R2Bucket::GetResult::blob(jsg::Lock& js) {
     kj::String contentType = KJ_REQUIRE_NONNULL(httpMetadata).contentType
         .map([](const auto& str) { return kj::str(str); })
         .orDefault(nullptr);
-    return jsg::alloc<Blob>(kj::mv(buffer), kj::mv(contentType));
+    return jsg::alloc<Blob>(js, kj::mv(buffer), kj::mv(contentType));
   });
 }
 

--- a/src/workerd/api/tests/blob-test.js
+++ b/src/workerd/api/tests/blob-test.js
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { strictEqual } from 'node:assert';
+import { strictEqual, throws } from 'node:assert';
 import { inspect } from 'node:util';
 
 export const test1 = {
@@ -126,5 +126,25 @@ export const testInspect = {
 
     const file = new File(["1"], "file.txt", { type: "text/plain", lastModified: 1000 });
     strictEqual(inspect(file), "File { lastModified: 1000, name: 'file.txt', type: 'text/plain', size: 1 }");
+  }
+};
+
+export const overLarge = {
+  test() {
+    const blob1 = new Blob([new ArrayBuffer(128 * 1024 * 1024)]);
+
+    throws(() => {
+      new Blob([new ArrayBuffer((128 * 1024 * 1024) + 1)]);
+    }, {
+      message: 'Blob size 134217729 exceeds limit 134217728',
+      name: 'RangeError',
+    });
+
+    throws(() => {
+      new Blob([' ', blob1]);
+    }, {
+      message: 'Blob size 134217729 exceeds limit 134217728',
+      name: 'RangeError',
+    });
   }
 };

--- a/src/workerd/io/limit-enforcer.h
+++ b/src/workerd/io/limit-enforcer.h
@@ -78,6 +78,11 @@ public:
     if (iterations > DEFAULT_MAX_PBKDF2_ITERATIONS) return DEFAULT_MAX_PBKDF2_ITERATIONS;
     return kj::none;
   }
+
+  // Called when a Blob is being created to determine the maximum allowed size of the Blob.
+  virtual size_t getBlobSizeLimit() const {
+    return 128 * 1024 * 1024;  // 128 MB
+  }
 };
 
 // Abstract interface that enforces resource limits on a IoContext.


### PR DESCRIPTION
Updates the `Blob` storage (`ownData`) to use a `jsg::BufferSource` rather than a raw `kj::Array<byte>` to allow the isolate to better track the external memory allocation.

While in here, also updates the `concat(...)` method to use the new safer `copyFrom(...)` API in kj replacing the less safe `memcpy` and manual pointer arithmetic.

We also avoid an extraneous copy when creating a File from a Blob