### PR TITLE
Implement built-in node:net impl

### DIFF
--- a/samples/nodejs-compat-net/README.md
+++ b/samples/nodejs-compat-net/README.md
@@ -1,0 +1,28 @@
+# Node.js Compat 'node:net' Example
+
+To run the example on http://localhost:8080
+
+```sh
+$ ./workerd serve config.capnp
+```
+
+To run using bazel
+
+```sh
+$ bazel run //src/workerd/server:workerd -- serve ~/cloudflare/workerd/samples/nodejs-compat/config.capnp
+```
+
+To create a standalone binary that can be run:
+
+```sh
+$ ./workerd compile config.capnp > nodejs-compat
+
+$ ./nodejs-compat
+```
+
+To test:
+
+```sh
+% curl http://localhost:8080
+Hello World
+```

--- a/samples/nodejs-compat-net/config.capnp
+++ b/samples/nodejs-compat-net/config.capnp
@@ -1,0 +1,25 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const nodeNetExample :Workerd.Config = (
+
+  services = [
+    (name = "main", worker = .worker),
+    (name = "internet", network = (
+      allow = ["private"]
+    ))
+  ],
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ]
+);
+
+const worker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js")
+  ],
+  compatibilityDate = "2024-05-31",
+  compatibilityFlags = [
+    "nodejs_compat_v2",
+    # The nodejs_compat_net flag explicitly enables the node:net module.
+    # The nodejs_compat or nodejs_compat_v2 flags must also be set.
+    "nodejs_compat_net",
+    "experimental"]
+);

--- a/samples/nodejs-compat-net/server.mjs
+++ b/samples/nodejs-compat-net/server.mjs
@@ -1,0 +1,21 @@
+import { createServer } from 'node:net';
+
+const server = createServer((socket) => {
+  console.log('Connected...');
+  socket.setEncoding('utf8');
+  socket.on('data', console.log);
+  const i = setInterval(() => {
+    socket.write('ping');
+  }, 1000);
+  socket.once('close', () => {
+    console.log('Disconnected...');
+    clearInterval(i);
+  });
+  socket.on('error', (err) => {
+    console.log('socket errored', err);
+  });
+});
+
+server.listen(8888, () => {
+  console.log('Listening...');
+});

--- a/samples/nodejs-compat-net/worker.js
+++ b/samples/nodejs-compat-net/worker.js
@@ -34,8 +34,6 @@ export default {
 
     console.log(s.bytesRead, s.bytesWritten);
 
-    s.connect({ host: '::1', port: 8888 });
-
     return new Response("ok");
   }
 };

--- a/samples/nodejs-compat-net/worker.js
+++ b/samples/nodejs-compat-net/worker.js
@@ -1,0 +1,41 @@
+import * as net from 'node:net';
+
+export default {
+  async fetch(request) {
+    const s = net.connect({
+      host: '::1',
+      port: 8888,
+    }, () => {
+      console.log('connected to server', s.remoteAddress, s.remotePort, s.remoteFamily);
+    });
+
+    s.setEncoding('utf8');
+
+    s.write('pong1', (err) => console.log('written 1', err));
+    s.write('pong2', (err) => console.log('written 2', err));
+    s.write('pong3', (err) => console.log('written 3', err));
+    s.write('pong4', (err) => console.log('written 4', err));
+    s.write('pong5', (err) => console.log('written 5', err));
+    s.write('pong6', (err) => console.log('written 6', err));
+    s.write('pong7', (err) => console.log('written 7', err));
+    s.write('pong8', (err) => console.log('written 8', err));
+
+    s.on('data', console.log);
+
+    s.once('ready', () => console.log('connection ready'));
+    s.once('close', (hadError) => console.log('connection closed', hadError));
+    s.once('error', (err) => console.log('connection error', err));
+
+    await scheduler.wait(3 * 1000);
+
+    console.log('ending connection');
+    s.end();
+    await scheduler.wait(3 * 1000);
+
+    console.log(s.bytesRead, s.bytesWritten);
+
+    s.connect({ host: '::1', port: 8888 });
+
+    return new Response("ok");
+  }
+};

--- a/samples/tcp-ingress/config.capnp
+++ b/samples/tcp-ingress/config.capnp
@@ -1,0 +1,19 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const tcpIngressExample :Workerd.Config = (
+  services = [
+    (name = "main", worker = .worker),
+  ],
+
+  sockets = [
+    ( name = "http", address = "*:8080", http = (), service = "main" ),
+    ( name = "tcp", address = "*:8081", tcp = (), service = "main" )
+  ]
+);
+
+const worker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js")
+  ],
+  compatibilityDate = "2023-02-28",
+);

--- a/samples/tcp-ingress/worker.js
+++ b/samples/tcp-ingress/worker.js
@@ -1,0 +1,11 @@
+
+export default {
+  async fetch(req) {
+    return new Response("ok");
+  },
+
+  connect({inbound, cf}) {
+    console.log(cf);
+    return inbound.pipeThrough(new IdentityTransformStream());
+  }
+};

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -464,6 +464,14 @@ export class ERR_METHOD_NOT_IMPLEMENTED extends NodeError {
   }
 }
 
+export class ERR_OPTION_NOT_IMPLEMENTED extends NodeError {
+  constructor(name: string|symbol) {
+    if (typeof name === 'symbol') {
+      name = (name as symbol).description!;
+    }
+    super("ERR_OPTION_NOT_IMPLEMENTED", `The ${name} option is not implemented`);
+  }
+}
 export class ERR_STREAM_CANNOT_PIPE extends NodeError {
   constructor() {
     super("ERR_STREAM_CANNOT_PIPE", "Cannot pipe, not readable");
@@ -505,6 +513,38 @@ export class ERR_STREAM_PUSH_AFTER_EOF extends NodeError {
 export class ERR_STREAM_UNSHIFT_AFTER_END_EVENT extends NodeError {
   constructor() {
     super("ERR_STREAM_UNSHIFT_AFTER_END_EVENT", "stream.unshift() after end event");
+  }
+}
+
+export class ERR_SOCKET_BAD_PORT extends NodeError {
+  constructor(name: string, port: any, allowZero: boolean) {
+    const operator = allowZero ? '>=' : '>';
+    super("ERR_SOCKET_BAD_PORT",
+        `${name} should be ${operator} 0 and < 65536. Received ${typeof port}.`);
+  }
+}
+
+export class EPIPE extends NodeError {
+  constructor() {
+    super("EPIPE", "This socket has been ended by the other party");
+  }
+}
+
+export class ERR_SOCKET_CLOSED_BEFORE_CONNECTION extends NodeError {
+  constructor() {
+    super("ERR_SOCKET_CLOSED_BEFORE_CONNETION", "Socket closed before connection established");
+  }
+}
+
+export class ERR_SOCKET_CLOSED extends NodeError {
+  constructor() {
+    super("ERR_SOCKET_CLOSED", "Socket is closed");
+  }
+}
+
+export class ERR_SOCKET_CONNECTING extends NodeError {
+  constructor() {
+    super("ERR_SOCKET_CONNECTING", "Socket is already connecting");
   }
 }
 

--- a/src/node/internal/internal_utils.ts
+++ b/src/node/internal/internal_utils.ts
@@ -208,4 +208,3 @@ export function createDeferredPromise() {
     reject,
   };
 }
-

--- a/src/node/internal/validators.ts
+++ b/src/node/internal/validators.ts
@@ -34,10 +34,11 @@ import { normalizeEncoding } from "node-internal:internal_utils";
 import {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
+  ERR_SOCKET_BAD_PORT,
   ERR_OUT_OF_RANGE,
 } from "node-internal:internal_errors";
 
-// TODO(someday): Not current implementing parseFileMode, validatePort
+// TODO(someday): Not current implementing parseFileMode
 
 export const isInt32 = (value: any) => value === (value | 0);
 export const isUint32 = (value: any) => value === (value >>> 0);
@@ -202,6 +203,17 @@ export function validateArray(value: unknown, name: string, minLength = 0) {
   }
 }
 
+export function validatePort(port: unknown, name = 'Port', allowZero = true) {
+  if ((typeof port !== 'number' && typeof port !== 'string') ||
+      (typeof port === 'string' && port.trim().length === 0) ||
+      +port !== (+port >>> 0) ||
+      +port > 0xFFFF ||
+      (port === 0 && !allowZero)) {
+    throw new ERR_SOCKET_BAD_PORT(name, port, allowZero);
+  }
+  return +port | 0;
+};
+
 export default {
   isInt32,
   isUint32,
@@ -217,4 +229,5 @@ export default {
   validateOneOf,
   validateString,
   validateUint32,
+  validatePort,
 };

--- a/src/node/net.js
+++ b/src/node/net.js
@@ -1,0 +1,1109 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is mostly adopted code, enabling linting one day */
+/* eslint-disable */
+import { Duplex } from 'node-internal:streams_duplex';
+
+import inner from 'cloudflare-internal:sockets';
+
+import { default as compatFlags } from 'workerd:compatibility-flags';
+if (!compatFlags.nodeJsCompatNet || !compatFlags.workerdExperimental) {
+  throw new Error(
+      "To use the node:net built-in module, set the nodejs_compat_net flag");
+}
+
+import {
+  ERR_INVALID_ARG_VALUE,
+  ERR_INVALID_ARG_TYPE,
+  ERR_MISSING_ARGS,
+  ERR_OUT_OF_RANGE,
+  ERR_OPTION_NOT_IMPLEMENTED,
+  ERR_SOCKET_CLOSED,
+  ERR_SOCKET_CLOSED_BEFORE_CONNECTION,
+  ERR_SOCKET_CONNECTING,
+  EPIPE,
+} from 'node-internal:internal_errors';
+
+import {
+  validateAbortSignal,
+  validateFunction,
+  validateInt32,
+  validateNumber,
+  validatePort,
+} from 'node-internal:validators';
+
+import {
+  isUint8Array,
+  isArrayBufferView,
+} from 'node-internal:internal_types';
+
+import { Buffer } from 'node-internal:internal_buffer';
+
+const kLastWriteQueueSize = Symbol('kLastWriteQueueSize');
+const kTimeout = Symbol('kTimeout');
+const kBuffer = Symbol('kBuffer');
+const kBufferCb = Symbol('kBufferCb');
+const kBufferGen = Symbol('kBufferGen');
+const kBytesRead = Symbol('kBytesRead');
+const kBytesWritten = Symbol('kBytesWritten');
+const kUpdateTimer = Symbol('kUpdateTimer');
+const normalizedArgsSymbol = Symbol('normalizedArgs');
+
+// Once the socket has been opened, the socket info provided by the
+// socket.opened promise will be stored here.
+const kSocketInfo = Symbol('kSocketInfo');
+
+// IPv4 Segment
+const v4Seg = '(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])';
+const v4Str = `(?:${v4Seg}\\.){3}${v4Seg}`;
+const IPv4Reg = new RegExp(`^${v4Str}$`);
+
+// IPv6 Segment
+const v6Seg = '(?:[0-9a-fA-F]{1,4})';
+const IPv6Reg = new RegExp('^(?:' +
+  `(?:${v6Seg}:){7}(?:${v6Seg}|:)|` +
+  `(?:${v6Seg}:){6}(?:${v4Str}|:${v6Seg}|:)|` +
+  `(?:${v6Seg}:){5}(?::${v4Str}|(?::${v6Seg}){1,2}|:)|` +
+  `(?:${v6Seg}:){4}(?:(?::${v6Seg}){0,1}:${v4Str}|(?::${v6Seg}){1,3}|:)|` +
+  `(?:${v6Seg}:){3}(?:(?::${v6Seg}){0,2}:${v4Str}|(?::${v6Seg}){1,4}|:)|` +
+  `(?:${v6Seg}:){2}(?:(?::${v6Seg}){0,3}:${v4Str}|(?::${v6Seg}){1,5}|:)|` +
+  `(?:${v6Seg}:){1}(?:(?::${v6Seg}){0,4}:${v4Str}|(?::${v6Seg}){1,6}|:)|` +
+  `(?::(?:(?::${v6Seg}){0,5}:${v4Str}|(?::${v6Seg}){1,7}|:))` +
+')(?:%[0-9a-zA-Z-.:]{1,})?$');
+
+const TIMEOUT_MAX = 2 ** 31 - 1;
+
+// ======================================================================================
+
+export function Socket(options) {
+  if (!(this instanceof Socket)) return new Socket(options);
+
+  if (options?.objectMode) {
+    throw new ERR_INVALID_ARG_VALUE(
+      'options.objectMode',
+      options.objectMode,
+      'is not supported');
+  } else if (options?.readableObjectMode || options?.writableObjectMode) {
+    throw new ERR_INVALID_ARG_VALUE(
+      `options.${
+        options.readableObjectMode ? 'readableObjectMode' : 'writableObjectMode'
+      }`,
+      options.readableObjectMode || options.writableObjectMode,
+      'is not supported',
+    );
+  }
+  if (typeof options?.keepAliveInitialDelay !== 'undefined') {
+    validateNumber(options?.keepAliveInitialDelay, 'options.keepAliveInitialDelay');
+
+    if (options.keepAliveInitialDelay < 0) {
+      options.keepAliveInitialDelay = 0;
+    }
+  }
+
+  if (typeof options === 'number') {
+    options = { fd: options };
+  } else {
+    options = { ...options };
+  }
+
+  if (options.handle) {
+    // We are not supporting the options.handle option for now. This is the
+    // option that allows users to pass in a handle to an existing socket.
+    throw new ERR_OPTION_NOT_IMPLEMENTED('options.handle');
+  } else if (options.fd !== undefined) {
+    // We are not supporting the options.fd option for now. This is the option
+    // that allows users to pass in a file descriptor to an existing socket.
+    // Workers doesn't have file descriptors and does not use them in any way.
+    throw new ERR_OPTION_NOT_IMPLEMENTED('options.fd');
+  }
+
+  if (Boolean(options.noDelay)) {
+    throw new ERR_OPTION_NOT_IMPLEMENTED('truthy options.noDelay');
+  }
+  if (Boolean(options.keepAlive)) {
+    throw new ERR_OPTION_NOT_IMPLEMENTED('truthy options.keepAlive');
+  }
+
+  options.allowHalfOpen = Boolean(options.allowHalfOpen);
+  // TODO(now): Match behavior with Node.js
+  // In Node.js, emitClose and autoDestroy are false by default so that
+  // the socket must handle those itself, including emitting the close
+  // event with the hadError argument. We should match that behavior.
+  options.emitClose = false;
+  options.autoDestroy = true;
+  options.decodeStrings = false;
+
+  // In Node.js, these are meaningful when the options.fd is used.
+  // We do not support options.fd so we just ignore whatever value
+  // is given and always pass true.
+  options.readable = true;
+  options.writable = true;
+
+  this.connecting = false;
+  this._hadError = false;
+  this._parent = null;
+  this._host = null;
+  this[kLastWriteQueueSize] = 0;
+  this[kTimeout] = null;
+  this[kBuffer] = null;
+  this[kBufferCb] = null;
+  this[kBufferGen] = null;
+  this[kSocketInfo] = null;
+  this[kBytesRead] = 0;
+  this[kBytesWritten] = 0;
+  this._closeAfterHandlingError = false;
+  this.autoSelectFamilyAttemptedAddresses = [];
+
+  Duplex.call(this, options);
+
+  this.once('end', onReadableStreamEnd);
+
+  if (options.signal) {
+    addClientAbortSignalOption(this, options);
+  }
+
+  const onread = options.onread;
+  if (onread !== null &&
+      typeof onread === 'object' &&
+      // The onread.buffer can either be a Uint8Array or a function that returns
+      // a Uint8Array.
+      (isUint8Array(onread.buffer) || typeof onread.buffer === 'function') &&
+      // The onread.callback is the function used to deliver the read buffer to
+      // the application.
+      typeof onread.callback === 'function') {
+    if (typeof onread.buffer === 'function') {
+      this[kBuffer] = true;
+      this[kBufferGen] = onread.buffer;
+    } else {
+      this[kBuffer] = onread.buffer;
+      this[kBufferGen] = () => this[kBuffer];
+    }
+    this[kBufferCb] = onread.callback;
+  } else {
+    this[kBuffer] = true;
+    this[kBufferGen] = () => new Uint8Array(4096);
+    this[kBufferCb] = undefined;
+  }
+};
+Object.setPrototypeOf(Socket.prototype, Duplex.prototype);
+Object.setPrototypeOf(Socket, Duplex);
+
+Socket.prototype._unrefTimer = function _unrefTimer() {
+  for (let s = this; s != null; s = s._parent) {
+    if (s[kTimeout] != null) {
+      clearTimeout(s[kTimeout]);
+      s[kTimeout] = this.setTimeout(s.timeout, s._onTimeout.bind(s));
+    }
+  }
+};
+
+Socket.prototype.setTimeout = function(msecs, callback) {
+  if (this.destroyed) return this;
+
+  this.timeout = msecs;
+
+  msecs = getTimerDuration(msecs, 'msecs');
+
+  clearTimeout(this[kTimeout]);
+
+  if (msecs === 0) {
+    if (callback !== undefined) {
+      validateFunction(callback, 'callback');
+      this.removeListener('timeout', callback);
+    }
+  } else {
+    this[kTimeout] = setTimeout(this._onTimeout.bind(this), msecs);
+    if (callback !== undefined) {
+      validateFunction(callback, 'callback');
+      this.once('timeout', callback);
+    }
+  }
+  return this;
+};
+
+Socket.prototype._onTimeout = function () {
+  const handle = this._handle;
+  const lastWriteQueueSize = this[kLastWriteQueueSize];
+  if (lastWriteQueueSize > 0 && handle) {
+    // `lastWriteQueueSize !== writeQueueSize` means there is
+    // an active write in progress, so we suppress the timeout.
+    const { writeQueueSize } = handle;
+    if (lastWriteQueueSize !== writeQueueSize) {
+      this[kLastWriteQueueSize] = writeQueueSize;
+      this._unrefTimer();
+      return;
+    }
+  }
+  this.emit('timeout');
+};
+
+Socket.prototype._getpeername = function() {
+  if (this._handle == null) {
+    return {};
+  } else {
+    this[kSocketInfo] ??= {};
+    return { ...this[kSocketInfo].remoteAddress };
+  }
+};
+
+Socket.prototype._getsockname = function() {
+  if (this._handle == null) {
+    return {};
+  }
+  this._sockname ??= {
+    address: '0.0.0.0',
+    port: 0,
+    family: 'IPv4',
+  };
+  return this._sockname;
+};
+
+Socket.prototype.address = function() {
+  if (this.destroyed) return undefined;
+  return this._getsockname();
+};
+
+// ======================================================================================
+// Writable side ...
+
+Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
+  // If we are still connecting, buffer this for later.
+  // The writable logic will buffer up any more writes while
+  // waiting for this one to be done.
+  try {
+    if (this.connecting) {
+      function onClose() {
+        cb(new ERR_SOCKET_CLOSED_BEFORE_CONNECTION());
+      }
+      this.once('connect', function () {
+        this.off('close', onClose);
+        this._writeGeneric(writev, data, encoding, cb);
+      });
+      this.once('close', onClose);
+      return;
+    }
+
+    if (this._handle?.writer === undefined) {
+      cb(new ERR_SOCKET_CLOSED());
+      return false;
+    }
+
+    this._unrefTimer();
+
+    let lastWriteSize = 0;
+    if (writev) {
+      // data is an array of strings or ArrayBufferViews. We're going to concat
+      // them all together into a single buffer so we can write all at once. This
+      // trades higher memory use by copying the input buffers for fewer round trips
+      // through the write loop in the stream. Since the write loops involve bouncing
+      // back and forth across the kj event loop boundary and requires reacquiring the
+      // isolate lock after each write, this should be more efficient in the long run.
+      const buffers = [];
+      for (const d of data) {
+        if (typeof d.chunk === 'string') {
+          const buf = Buffer.from(d.chunk, d.encoding);
+          buffers.push(buf);
+          lastWriteSize += buf.byteLength;
+        } else if (isArrayBufferView(d.chunk)) {
+          buffers.push(new Uint8Array(d.chunk.buffer, d.chunk.byteOffset, d.chunk.byteLength));
+          lastWriteSize += d.chunk.byteLength;
+        } else {
+          throw new ERR_INVALID_ARG_TYPE('chunk', ['string', 'ArrayBufferView'], d.chunk);
+        }
+      }
+      this._unrefTimer();
+
+      this._handle.writer.write(Buffer.concat(buffers)).then(
+        () => {
+          if (this._handle != null) {
+            this._handle.bytesWritten += this[kLastWriteQueueSize];
+          } else {
+            this[kBytesWritten] += this[kLastWriteQueueSize];
+          }
+          this[kLastWriteQueueSize] = 0;
+          this._unrefTimer();
+          cb();
+        },
+        (err) => {
+          this[kLastWriteQueueSize] = 0;
+          this._unrefTimer();
+          cb(err);
+        }
+      );
+    } else {
+      if (typeof data === 'string') {
+        data = Buffer.from(data, encoding);
+      }
+      this._handle.writer.write(data).then(
+        () => {
+          if (this._handle != null) {
+            this._handle.bytesWritten += this[kLastWriteQueueSize];
+          } else {
+            this[kBytesWritten] += this[kLastWriteQueueSize];
+          }
+          this[kLastWriteQueueSize] = 0;
+          this._unrefTimer();
+          cb();
+        },
+        (err) => {
+          this[kLastWriteQueueSize] = 0;
+          this._unrefTimer();
+          cb(err);
+        });
+      lastWriteSize = data.byteLength;
+    }
+    this[kLastWriteQueueSize] = lastWriteSize;
+  } catch (err) {
+    this.destroy(err);
+  }
+};
+
+Socket.prototype._writev = function(chunks, cb) {
+  this._writeGeneric(true, chunks, '', cb);
+};
+
+Socket.prototype._write = function(data, encoding, cb) {
+  this._writeGeneric(false, data, encoding, cb);
+};
+
+Socket.prototype._final = function(cb) {
+  if (this.connecting) {
+    this.once('connect', () => this._final(cb));
+    return;
+  }
+
+  // If there is no writer, then there's really nothing left to do here.
+  if (this._handle?.writer === undefined) {
+    cb();
+    return;
+  }
+
+  this._handle.writer.close().then(() => cb(), (err) => cb(err));
+};
+
+Socket.prototype.end = function(data, encoding, cb) {
+  Duplex.prototype.end.call(this, data, encoding, cb);
+  return this;
+};
+
+// ======================================================================================
+// Readable side
+
+Socket.prototype.pause = function() {
+  if (this.destroyed) return;
+  // If the read loop is already running, setting reading to false
+  // will interrupt it after the current read completes (if any)
+  if (this._handle) this._handle.reading = false;
+  return Duplex.prototype.pause.call(this);
+};
+
+Socket.prototype.resume = function() {
+  if (this.destroyed) return;
+  maybeStartReading(this);
+  return Duplex.prototype.resume.call(this);
+};
+
+Socket.prototype.read = function(n) {
+  if (this.destroyed) return;
+  maybeStartReading(this);
+  return Duplex.prototype.read.call(this, n);
+};
+
+Socket.prototype._read = function(n) {
+  if (this.connecting || !this._handle) {
+    this.once('connect', () => this._read(n));
+  } else if (!this._handle.reading) {
+    maybeStartReading(this);
+  }
+};
+
+// ======================================================================================
+// Destroy and reset
+
+Socket.prototype._reset = function() {
+  return this.destroy();
+};
+
+Socket.prototype.resetAndDestroy = function() {
+  // In Node.js, the resetAndDestroy method is used to "[close] the TCP connection by
+  // sending an RST packet and destroy the stream. If this TCP socket is in connecting
+  // status, it will send an RST packet and destroy this TCP socket once it is connected.
+  // Otherwise, it will call socket.destroy with an ERR_SOCKET_CLOSED Error. If this is
+  // not a TCP socket (for example, a pipe), calling this method will immediately throw
+  // an ERR_INVALID_HANDLE_TYPE Error." In our implementatin we really don't have a way
+  // of ensuring whether or not an RST packet is actually sent so this is largely an
+  // alias for the existing destroy. If the socket is still connecting, it will be
+  // destroyed immediately after the connection is established.
+  if (this.destroyed) return this;
+  if (this._handle) {
+    if (this.connecting) {
+      this.once('connect', () => this._reset());
+    } else {
+      this._reset();
+    }
+  } else {
+    this.destroy(new ERR_SOCKET_CLOSED());
+  }
+  return this;
+};
+
+Socket.prototype.destroySoon = function() {
+  if (this.destroyed) return;
+  if (this.writable) {
+    this.end();
+  }
+
+  if (this.writableFinished) {
+    this.destroy();
+  } else {
+    this.once('finish', this.destroy);
+  }
+};
+
+Socket.prototype._destroy = function(exception, cb) {
+  if (this[kTimeout]) {
+    clearTimeout(this[kTimeout]);
+    this[kTimeout] = undefined;
+  }
+
+  if (this._handle) {
+    this._handle.socket.close().then(
+        () => cleanupAfterDestroy(this, cb, exception),
+        (err) => cleanupAfterDestroy(this, cb, err || exception));
+  } else {
+    cleanupAfterDestroy(this, cb, exception);
+  }
+};
+
+// ======================================================================================
+// Connection
+
+Socket.prototype.connect = function(...args) {
+  if (this.connecting) {
+    throw new ERR_SOCKET_CONNECTING();
+  }
+  // TODO(later): In Node.js a Socket instance can be reset so that it can be reused.
+  // We haven't yet implemented that here. We can consider doing so but it's not an
+  // immediate priority. Implementing it correctly requires making sure the internal
+  // state of the socket is correctly reset.
+  if (this.destroyed) {
+    throw new ERR_SOCKET_CLOSED();
+  }
+  let normalized;
+  if (Array.isArray(args[0]) && args[0][normalizedArgsSymbol]) {
+    normalized = args[0];
+  } else {
+    normalized = normalizeArgs(args);
+  }
+  const options = normalized[0];
+  const cb = normalized[1];
+
+  if (cb !== null) {
+    this.once('connect', cb);
+  }
+
+  if (this._parent && this._parent.connecting) {
+    return this;
+  }
+
+  if (options.port === undefined && options.path == null) {
+    throw new ERR_MISSING_ARGS(['options', 'port', 'path']);
+  }
+
+  if (this.write !== Socket.prototype.write) {
+    this.write = Socket.prototype.write;
+  }
+
+  if (this.destroyed) {
+    this._handle = null;
+    this._peername = null;
+    this._sockname = null;
+  }
+
+  const { path } = options;
+  if (!!path) {
+    throw new ERR_INVALID_ARG_VALUE('path', path, 'is not supported');
+  }
+
+  this[kBytesRead] = 0;
+  this[kBytesWritten] = 0;
+
+  initializeConnection(this, options);
+
+  return this;
+};
+
+// ======================================================================================
+// Socket methods that are not no-ops or nominal impls
+
+Socket.prototype.setNoDelay = function(enable) {
+  if (!enable) return;
+  throw new ERR_INVALID_ARG_VALUE('enable', enable, 'is not supported');
+};
+
+Socket.prototype.setKeepAlive = function(enable, initialDelay) {
+  if (!enable) return;
+  throw new ERR_INVALID_ARG_VALUE('enable', enable, 'is not supported');
+};
+
+Socket.prototype.ref = function() {
+  // Intentional no-op
+};
+
+Socket.prototype.unref = function() {
+  // Intentional no-op
+};
+
+Object.defineProperties(Socket.prototype, {
+  _connecting: {
+    __proto__: null,
+    get() { return this.connecting; },
+  },
+  pending: {
+    __proto__: null,
+    get() { return !this._handle || this.connecting; },
+    configurable: true,
+  },
+  readyState: {
+    __proto__: null,
+    get() {
+      if (this.connecting) {
+        return 'opening';
+      } else if (this.readable && this.writable) {
+        return 'open';
+      } else if (this.readable && !this.writable) {
+        return 'readOnly';
+      } else if (!this.readable && this.writable) {
+        return 'writeOnly';
+      }
+      return 'closed';
+    },
+  },
+  writableLength: {
+    __proto__: null,
+    configurable: false,
+    enumerable: true,
+    get() { return this._writableState.length; }
+  },
+  bufferSize: {
+    __proto__: null,
+    get() {
+      if (this._handle) {
+        return this.writableLength;
+      }
+    },
+  },
+  [kUpdateTimer]: {
+    __proto__: null,
+    get() {
+      return this._unrefTimer;
+    },
+  },
+  bytesRead: {
+    __proto__: null,
+    configurable: false,
+    enumerable: true,
+    get() {
+      return this._handle ? this._handle.bytesRead : this[kBytesRead];
+    }
+  },
+  bytesWritten: {
+    __proto__: null,
+    configurable: false,
+    enumerable: true,
+    get() {
+      const flushed = this._handle != null ? this._handle.bytesWritten : this[kBytesWritten];
+      const pending = this._writableState != null ? this._writableState.length : 0;
+      return flushed + pending;
+    }
+  },
+  remoteAddress: {
+    __proto__: null,
+    configurable: false,
+    enumerable: true,
+    get() {
+      return this._getpeername().address;
+    }
+  },
+  remoteFamily: {
+    __proto__: null,
+    configurable: false,
+    enumerable: true,
+    get() {
+      return this._getpeername().family;
+    }
+  },
+  remotePort: {
+    __proto__: null,
+    configurable: false,
+    enumerable: true,
+    get() {
+      return this._getpeername().port;
+    }
+  },
+  localAddress: {
+    __proto__: null,
+    configurable: false,
+    enumerable: true,
+    get() { return '0.0.0.0'; }
+  },
+  localPort: {
+    __proto__: null,
+    configurable: false,
+    enumerable: true,
+    get() { return 0; }
+  },
+  localFamily: {
+    __proto__: null,
+    configurable: false,
+    enumerable: true,
+    get() { return 'IPv4'; }
+  },
+});
+
+// ======================================================================================
+// Helper/utility methods
+
+function cleanupAfterDestroy(socket, cb, error) {
+  if (socket._handle != null) {
+    socket[kBytesRead] = socket.bytesRead;
+    socket[kBytesWritten] = socket.bytesWritten;
+  }
+  socket._handle = null;
+  socket[kLastWriteQueueSize] = 0;
+  socket[kBuffer] = null;
+  socket[kBufferCb] = null;
+  socket[kBufferGen] = null;
+  socket[kSocketInfo] = null;
+  cb(error);
+  queueMicrotask(() => socket.emit('close', error != null));
+}
+
+function initializeConnection(socket, options) {
+  // options.localAddress, options.localPort, and options.family are ignored.
+  let {
+    host = 'localhost',
+    port = 0,
+    family,
+    hints,
+    autoSelectFamily,
+    lookup,
+  } = options;
+
+  if (!!autoSelectFamily) {
+    // We don't support this option. If the value is falsy, we can safely ignore it.
+    // If the value is truthy, we'll throw an error.
+    throw new ERR_INVALID_ARG_VALUE('options.autoSelectFamily',
+                                    autoSelectFamily,
+                                    'is not supported');
+  }
+
+  if (typeof port !== 'number' && typeof port !== 'string') {
+    throw new ERR_INVALID_ARG_TYPE('options.port', ['number', 'string'], port);
+  }
+  port = validatePort(+port);
+
+  socket.connecting = true;
+
+  const continueConnection = (host, port, family) => {
+    socket._unrefTimer();
+    socket[kSocketInfo] = {
+      remoteAddress: {
+        address: host,
+        port,
+        family: family === 4 ? 'IPv4' : family === 6 ? 'IPv6' : undefined,
+      },
+    };
+
+    if (family === 6) {
+      // The host is an IPv6 address. We need to wrap it in square brackets.
+      host = `[${host}]`;
+    }
+
+    socket.autoSelectFamilyAttemptedAddresses = [`${host}:${port}`];
+
+    socket.emit('connectionAttempt', host, port, addressType);
+
+    socket._host = `${host}`;
+
+    try {
+      const handle = inner.connect(`${host}:${port}`, {
+        allowHalfOpen: socket.allowHalfOpen,
+        // A Node.js socket is always capable of being upgraded to the TLS socket.
+        secureTransport: 'starttls',
+        // We are not going to pass the high water mark here. The outer Node.js
+        // stream will implement the appropriate backpressure for us.
+      });
+
+      // Our version of the socket._handle is necessarily different than Node.js'.
+      // It serves the same purpose but any code that may exist that is depending
+      // on `_handle` being a particular type (which it shouldn't be) will fail.
+      socket._handle = {
+        socket: handle,
+        writer: handle.writable.getWriter(),
+        reader: handle.readable.getReader({ mode: 'byob' }),
+        bytesRead: 0,
+        bytesWritten: 0,
+      };
+
+      handle.opened.then(
+        onConnectionOpened.bind(socket),
+        (err) => {
+          socket.emit('connectionAttemptFailed', host, port, addressType, err);
+          socket.destroy(err);
+      });
+
+      handle.closed.then(
+        onConnectionClosed.bind(socket),
+        socket.destroy.bind(socket));
+    } catch (err) {
+      socket.destroy(err);
+    }
+  };
+
+  const addressType = isIP(host);
+
+  if (addressType === 0) {
+    // The host is not an IP address. That's allowed in our implementation, but let's
+    // see if the user provided a lookup function. If not, we'll skip.
+    if (typeof lookup !== 'undefined') {
+      validateFunction(lookup, 'options.lookup');
+      // Looks like we have a lookup function! Let's call it. The expectation is that
+      // the lookup function will produce a good IP address from the non-IP address
+      // that is given. How that is done is left entirely up to the application code.
+      // The connection attempt will continue once the lookup function invokes the
+      // given callback.
+      lookup(host, { family: family || addressType, hints }, (err, address, family) => {
+        socket.emit('lookup', err, address, family, host);
+        if (err) {
+          socket.destroy(err);
+          return;
+        }
+        if (isIP(address) === 0) {
+          throw new ERR_INVALID_ARG_VALUE('address', address, 'must be an IPv4 or IPv6 address');
+        }
+        if (family !== 4 && family !== 6 && family !== 'IPv4' && family !== 'IPv6') {
+          throw new ERR_INVALID_ARG_VALUE('family', family, 'must be 4 or 6');
+        }
+        continueConnection(address, port, family);
+      });
+      return;
+    }
+  }
+
+  continueConnection(host, port, addressType);
+}
+
+function onConnectionOpened() {
+  try {
+    // The info.remoteAddress property is going to give the
+    // address in the form of a string like `${host}:{port}`. We can choose
+    // to pull that out here but it's not critical at this point.
+    this.connecting = false;
+    this._unrefTimer();
+
+    this.emit('connect');
+    this.emit('ready');
+
+    if (!this.isPaused()) {
+      maybeStartReading(this);
+    }
+  } catch (err) {
+    this.destroy(err);
+  }
+}
+
+function onConnectionClosed() {
+  if (this[kTimeout] != null) clearTimeout(this[kTimeout]);
+  // TODO(now): What else should we do here? Anything?
+}
+
+async function startRead(socket) {
+  const reader = socket._handle.reader;
+  try {
+    while (socket._handle.reading === true) {
+      // The [kBufferGen] function should always be a function that returns
+      // a Uint8Array we can read into.
+      const { value, done } = await reader.read(socket[kBufferGen]());
+
+      // Make sure the socket was not destroyed while we were waiting.
+      // If it was, we're going to throw away the chunk of data we just
+      // read.
+      if (socket.destroyed) {
+        // Doh! Well, this is awkward. Let's just stop reading and return.
+        // There's really nothing else we should try to do here.
+        break;
+      }
+
+      // Reset the timeout timer since we received data.
+      socket._unrefTimer();
+
+      if (done) {
+        // All done! If allowHalfOpen is true, then this will just end the
+        // readable side of the socket. If allowHalfOpen is false, then this
+        // should allow the current write queue to drain but not allow any
+        // further writes to be queued.
+        socket.push(null);
+        break;
+      }
+
+      // If the byteLength is zero, skip the push.
+      if (value.byteLength === 0) {
+        continue;
+      }
+      socket._handle.bytesRead += value.byteLength;
+
+      // The socket API is expected to produce Buffer instances, not Uint8Arrays
+      const buffer = Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+
+      if (typeof socket[kBufferCb] === 'function') {
+        if (socket[kBufferCb](buffer.byteLength, buffer) === false) {
+          // If the callback returns explicitly false (not falsy) then
+          // we're being asked to stop reading for now.
+          break;
+        }
+        continue;
+      }
+
+      // Because we're pushing the buffer onto the stream we can't use the shared
+      // buffer here or the next read will overwrite it! We need to copy. For the
+      // more efficient version, use onread.
+      if (!socket.push(Buffer.from(buffer))) {
+        // If push returns false, we've hit the high water mark and should stop
+        // reading until the stream requests to start reading again.
+        break;
+      }
+    }
+  } finally {
+    if (socket._handle != null) {
+      socket._handle.reading = false;
+    }
+  }
+}
+
+function maybeStartReading(socket) {
+  if (socket[kBuffer] && !socket.connecting && socket._handle && !socket._handle.reading) {
+    socket._handle.reading = true;
+    startRead(socket).catch((err) => socket.destroy(err));
+  }
+}
+
+function writeAfterFIN(chunk, encoding, cb) {
+  if (!this.writableEnded) {
+    return Duplex.prototype.write.call(this, chunk, encoding, cb);
+  }
+
+  if (typeof encoding === 'function') {
+    cb = encoding;
+    encoding = null;
+  }
+
+  const er = new EPIPE();
+
+  queueMicrotask(() => cb(er));
+  this.destroy(er);
+
+  return false;
+}
+
+function onReadableStreamEnd() {
+  if (!this.allowHalfOpen) {
+    this.write = writeAfterFIN;
+  }
+}
+
+function getTimerDuration(msecs, name) {
+  validateNumber(msecs, name);
+  if (msecs < 0 || !Number.isFinite(msecs)) {
+    throw new ERR_OUT_OF_RANGE(name, 'a non-negative finite number', msecs);
+  }
+
+  // Ensure that msecs fits into signed int32
+  if (msecs > TIMEOUT_MAX) {
+    return TIMEOUT_MAX;
+  }
+
+  return msecs;
+}
+
+function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }
+
+function isPipeName(s) {
+  return typeof s === 'string' && toNumber(s) === false;
+}
+
+function normalizeArgs(args) {
+  let arr;
+
+  if (args.length === 0) {
+    arr = [{}, null];
+    arr[normalizedArgsSymbol] = true;
+    return arr;
+  }
+
+  const arg0 = args[0];
+  let options = {};
+  if (typeof arg0 === 'object' && arg0 !== null) {
+    // (options[...][, cb])
+    options = arg0;
+  } else if (isPipeName(arg0)) {
+    // (path[...][, cb])
+    options.path = arg0;
+  } else {
+    // ([port][, host][...][, cb])
+    options.port = arg0;
+    if (args.length > 1 && typeof args[1] === 'string') {
+      options.host = args[1];
+    }
+  }
+
+  const cb = args[args.length - 1];
+  if (typeof cb !== 'function')
+    arr = [options, null];
+  else
+    arr = [options, cb];
+
+  arr[normalizedArgsSymbol] = true;
+  return arr;
+}
+
+function addClientAbortSignalOption(self, options) {
+  validateAbortSignal(options.signal, 'options.signal');
+  const { signal } = options;
+  let disposable;
+
+  function onAbort() {
+    disposable?.[Symbol.dispose]();
+    self._aborted = true;
+    // TODO(now): What else should be do here? Anything?
+  }
+
+  if (signal.aborted) {
+    queueMicrotask(onAbort);
+  } else {
+    queueMicrotask(() => {
+      disposable = addAbortListener(signal, onAbort);
+    });
+  }
+}
+
+function addAbortListener(signal, listener) {
+  if (signal === undefined) {
+    throw new ERR_INVALID_ARG_TYPE('signal', 'AbortSignal', signal);
+  }
+  validateAbortSignal(signal, 'signal');
+  validateFunction(listener, 'listener');
+
+  let removeEventListener;
+  if (signal.aborted) {
+    queueMicrotask(() => listener());
+  } else {
+    signal.addEventListener('abort', listener, { once: true });
+    removeEventListener = () => {
+      signal.removeEventListener('abort', listener);
+    };
+  }
+  return {
+    __proto__: null,
+    [Symbol.dispose]() {
+      removeEventListener?.();
+    },
+  };
+}
+
+// ======================================================================================
+// The rest of the exports
+
+export function connect(...args) {
+  const normalized = normalizeArgs(args);
+  const options = normalized[0];
+  const socket = new Socket(options);
+  if (options.timeout) {
+    socket.setTimeout(options.timeout);
+  }
+  if (socket.destroyed) {
+    return socket;
+  }
+  return socket.connect(normalized);
+}
+
+export const createConnection = connect;
+
+export function getDefaultAutoSelectFamily() {
+  // This is the only value we support.
+  return false;
+};
+
+export function setDefaultAutoSelectFamily(val) {
+  if (!val) return;
+  throw new ERR_INVALID_ARG_VALUE('val', val);
+};
+
+// We don't actually make use of this. It's here only for compatibility.
+// The value is not used anywhere.
+let autoSelectFamilyAttemptTimeout = 10;
+
+export function getDefaultAutoSelectFamilyAttemptTimeout() {
+  return autoSelectFamilyAttemptTimeout;
+}
+
+export function setDefaultAutoSelectFamilyAttemptTimeout(val) {
+  validateInt32(val, 'val', 1);
+  if (val < 10) val = 10;
+  autoSelectFamilyAttemptTimeout = value;
+}
+
+export function isIP(input) {
+  input = `${input}`;
+  if (isIPv4(input)) return 4;
+  if (isIPv6(input)) return 6;
+  return 0;
+}
+
+export function isIPv4(input) {
+  input = typeof input !== 'string' ? `${input}` : input;
+  return IPv4Reg.test(input);
+}
+
+export function isIPv6(input) {
+  input = typeof input !== 'string' ? `${input}` : input;
+  return IPv6Reg.test(input);
+}
+
+export default {
+  Stream: Socket,
+  Socket,
+  connect,
+  createConnection,
+  getDefaultAutoSelectFamily,
+  setDefaultAutoSelectFamily,
+  getDefaultAutoSelectFamilyAttemptTimeout,
+  setDefaultAutoSelectFamilyAttemptTimeout,
+  isIP,
+  isIPv4,
+  isIPv6,
+  _normalizeArgs: normalizeArgs,
+};

--- a/src/node/net.js
+++ b/src/node/net.js
@@ -299,6 +299,7 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
         cb(new ERR_SOCKET_CLOSED_BEFORE_CONNECTION());
       }
       this.once('connect', function () {
+        // Note that off is a Node.js equivalent to removeEventListener
         this.off('close', onClose);
         this._writeGeneric(writev, data, encoding, cb);
       });
@@ -838,7 +839,7 @@ function onConnectionOpened() {
 
 function onConnectionClosed() {
   if (this[kTimeout] != null) clearTimeout(this[kTimeout]);
-  // TODO(now): What else should we do here? Anything?
+  // TODO(later): What else should we do here? Anything?
 }
 
 async function startRead(socket) {

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -115,6 +115,86 @@ void ServiceWorkerGlobalScope::clear() {
   unhandledRejections.clear();
 }
 
+kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::connect(
+    kj::AsyncIoStream& connection,
+    kj::HttpService::ConnectResponse& response,
+    kj::Maybe<kj::StringPtr> cfBlobJson,
+    Worker::Lock& lock,
+    kj::Maybe<ExportedHandler&> exportedHandler) {
+  ExportedHandler& eh = JSG_REQUIRE_NONNULL(exportedHandler, Error,
+      "Connect ingress is not currently supported with Service Workers syntax.");
+
+  kj::HttpHeaderTable table;
+  kj::HttpHeaders headers(table);
+
+  KJ_IF_SOME(handler, eh.connect) {
+    // Has a connect handler!
+    response.accept(200, "OK", headers);
+
+    auto ownConnection = newNeuterableIoStream(connection);
+    auto deferredNeuter = kj::defer([ownConnection = kj::addRef(*ownConnection)]() mutable {
+      ownConnection->neuter(makeNeuterException(NeuterReason::CLIENT_DISCONNECTED));
+    });
+    KJ_ON_SCOPE_FAILURE(ownConnection->neuter(makeNeuterException(NeuterReason::THREW_EXCEPTION)));
+    auto conn2 = kj::addRef(*ownConnection);
+
+    auto& ioContext = IoContext::current();
+    jsg::Lock& js = lock;
+
+    CfProperty cf(cfBlobJson);
+
+    auto conn = newSystemMultiStream(kj::addRef(*ownConnection), ioContext);
+    auto jsInbound = jsg::alloc<ReadableStream>(ioContext, kj::mv(conn.readable));
+
+    kj::Maybe<SpanBuilder> span = ioContext.makeTraceSpan("connect_handler"_kjc);
+    auto event = jsg::alloc<ConnectEvent>(kj::mv(jsInbound), kj::mv(cf));
+    auto promise = handler(js, kj::mv(event), eh.env.addRef(js), eh.getCtx());
+
+    struct RefcountedBool: public kj::Refcounted {
+      bool value;
+      RefcountedBool(bool value): value(value) {}
+    };
+    auto canceled = kj::refcounted<RefcountedBool>(false);
+
+    return ioContext.awaitJs(js, promise.then(js, ioContext.addFunctor(
+        [canceled = kj::addRef(*canceled),
+         outbound = kj::mv(conn.writable),
+         span = kj::mv(span)]
+        (jsg::Lock& js, jsg::Ref<ReadableStream> jsOutbound) mutable
+            -> IoOwn<kj::Promise<DeferredProxy<void>>> {
+      auto& context = IoContext::current();
+      span = kj::none;
+      if (canceled->value) {
+        // The client disconnected before the response was ready. The outbound
+        // is a dangling reference, let's not use it.
+        return context.addObject(kj::heap(addNoopDeferredProxy(kj::READY_NOW)));
+      } else {
+        return context.addObject(kj::heap(jsOutbound->pumpTo(js, kj::mv(outbound), true)));
+      }
+    }))).attach(kj::defer([canceled = kj::mv(canceled)]() mutable { canceled->value = true; }))
+        .then([ownConnection = kj::mv(ownConnection), deferredNeuter = kj::mv(deferredNeuter)]
+              (DeferredProxy<void> deferredProxy) mutable {
+      deferredProxy.proxyTask = deferredProxy.proxyTask
+          .then([connection = kj::addRef(*ownConnection)]() mutable {
+        connection->neuter(makeNeuterException(NeuterReason::SENT_RESPONSE));
+      }, [connection = kj::addRef(*ownConnection)](kj::Exception&& e) mutable {
+        connection->neuter(makeNeuterException(NeuterReason::THREW_EXCEPTION));
+        kj::throwFatalException(kj::mv(e));
+      }).attach(kj::mv(deferredNeuter));
+
+      return deferredProxy;
+    }, [connection = kj::mv(conn2)](kj::Exception&& e) mutable -> DeferredProxy<void> {
+      // HACK: We depend on the fact that the success-case lambda above hasn't been destroyed yet
+      //   so `deferredNeuter` hasn't been destroyed yet.
+      connection->neuter(makeNeuterException(NeuterReason::THREW_EXCEPTION));
+      kj::throwFatalException(kj::mv(e));
+    });
+  }
+  lock.logWarningOnce("Received a connect event but we lack a handler. "
+      "Did you remember to export a connect() function?");
+  JSG_FAIL_REQUIRE(Error, "Handler does not export a connect() function.");
+}
+
 kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::request(
     kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
     kj::AsyncInputStream& requestBody, kj::HttpService::Response& response,

--- a/src/workerd/api/node/net-test.js
+++ b/src/workerd/api/node/net-test.js
@@ -1,0 +1,1189 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT ORs
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* todo: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import {
+  fail,
+  ok,
+  strictEqual,
+  throws,
+} from 'node:assert';
+
+import { mock } from 'node:test';
+
+import { once } from 'node:events';
+
+import * as net from 'node:net';
+
+const enc = new TextEncoder();
+
+// test/parallel/test-net-access-byteswritten.js
+export const testNetAccessBytesWritten = {
+  test() {
+    // Check that the bytesWritten getter doesn't crash if object isn't
+    // constructed. Also check bytesRead...
+
+    // TODO(now): Should be undefined
+    strictEqual(net.Socket.prototype.bytesWritten, NaN);
+    strictEqual(net.Socket.prototype.bytesRead, undefined);
+  }
+};
+
+// test/parallel/test-net-after-close.js
+export const testNetAfterClose = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9999, 'localhost');
+    c.resume();
+    c.on('close', () => resolve());
+    await promise;
+
+    // Calling functions / accessing properties of a closed socket should not throw
+    c.setNoDelay();
+    c.setKeepAlive();
+    c.bufferSize;
+    c.pause();
+    c.resume();
+    c.address();
+    c.remoteAddress;
+    c.remotePort;
+  }
+};
+
+// test/parallel/test-net-allow-half-open.js
+export const testNetAllowHalfOpen = {
+  async test() {
+
+    // Verify that the socket closes propertly when the other end closes
+    // and allowHalfOpen is false.
+
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9999, 'localhost');
+    strictEqual(c.allowHalfOpen, false);
+    c.resume();
+
+    const endFn = mock.fn(() => {
+      queueMicrotask(() => {
+        ok(!c.destroyed);
+      });
+    });
+    const finishFn = mock.fn(() => {
+      ok(!c.destroyed);
+    });
+    const closeFn = mock.fn(() => {
+      resolve();
+    });
+    c.on('end', endFn);
+
+    // Even tho we're not writing anything, since the socket receives a
+    // EOS and allowHalfOpen is false, the socket should close both the
+    // readable and writable sides, meaning we should definitely get a
+    // finish event.
+    c.on('finish', finishFn);
+    c.on('close', closeFn);
+    await promise;
+    strictEqual(endFn.mock.callCount(), 1);
+    strictEqual(finishFn.mock.callCount(), 1);
+    strictEqual(closeFn.mock.callCount(), 1);
+  }
+};
+
+// test/parallel/test-net-better-error-messages-port-hostname.js
+export const testNetBetterErrorMessagesPortHostname = {
+  async test() {
+    // This is intentionally not a completely faithful reproduction of the
+    // original test, as we don't have the ability to mock DNS lookups.
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(0, 'invalid address');
+    c.on('connect', () => {
+      throw new Error('should not connect');
+    });
+    const errorFn = mock.fn((error) => {
+      // TODO(review): Currently our errors do not match the errors that
+      // Node.js produces. Do we need them to? Specifically, in a case like
+      // this, Node.js' error would have a meaningful `code` property along
+      // with `hostname` and `syscall` properties. We, instead, are passing
+      // along the underlying error returned from the internal Socket API.
+      try {
+        strictEqual(error.message, 'Specified address could not be parsed.');
+      } catch (err) {
+        console.log(err.message);
+      }
+      resolve();
+    });
+    c.on('error', errorFn);
+    await promise;
+    strictEqual(errorFn.mock.callCount(), 1);
+  }
+};
+
+// test/parallel/test-net-binary.js
+export const testNetBinary = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+
+    // Connect to the echo server
+    const c = net.connect(9998, 'localhost');
+    c.setEncoding('latin1');
+    let result = '';
+    c.on('data', (chunk) => {
+      result += chunk;
+    });
+
+    let binaryString = '';
+    for (let i = 255; i >= 0; i--) {
+      c.write(String.fromCharCode(i), 'latin1');
+      binaryString += String.fromCharCode(i);
+    }
+    c.end();
+    c.on('close', () => {
+      resolve();
+    });
+    await promise;
+    strictEqual(result, binaryString);
+  }
+};
+
+// test/parallel/test-net-buffersize.js
+export const testNetBuffersize = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9999, 'localhost');
+    const finishFn = mock.fn(() => {
+      strictEqual(c.bufferSize, 0);
+      resolve();
+    });
+    c.on('finish', finishFn);
+
+    strictEqual(c.bufferSize, 0);
+    c.write('a');
+    c.end();
+    strictEqual(c.bufferSize, 1);
+    await promise;
+    strictEqual(finishFn.mock.callCount(), 1);
+  }
+};
+
+// test/parallel/test-net-bytes-read.js
+export const testNetBytesRead = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    // Connect to the echo server
+    const c = net.connect(9998, 'localhost');
+    c.resume();
+    c.write('hello');
+    c.end();
+    const endFn = mock.fn(() => {
+      strictEqual(c.bytesRead, 5);
+      resolve();
+    });
+    c.on('end', endFn);
+
+    await promise;
+
+    strictEqual(endFn.mock.callCount(), 1);
+  }
+};
+
+// test/parallel/test-net-bytes-stats.js
+export const testNetBytesStats = {
+  async test() {
+    // This is intentionally not a completely faithful reproduction of the
+    // original test which checks the bytesRead on the server side.
+
+    // Connect to the echo server
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9998, 'localhost');
+    let bytesDelivered = 0;
+    c.on('data', (chunk) => bytesDelivered += chunk.byteLength);
+    c.write('hello');
+    c.end();
+    const endFn = mock.fn(() => {
+      strictEqual(c.bytesWritten, 5);
+      strictEqual(bytesDelivered, 5);
+      strictEqual(c.bytesRead, 5);
+      resolve();
+    });
+    c.on('end', endFn);
+
+    await promise;
+    strictEqual(endFn.mock.callCount(), 1);
+  }
+};
+
+// test/parallel/test-net-bytes-written-large.js
+const N = 10000000;
+export const testNetBytesWrittenLargeVariant1 = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9998, 'localhost');
+    c.resume();
+
+    const writeFn = mock.fn(() => {
+      strictEqual(c.bytesWritten, N);
+      resolve();
+    });
+
+    c.end(Buffer.alloc(N), writeFn);
+
+    await promise;
+  }
+};
+
+export const testNetBytesWrittenLargeVariant2 = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9998, 'localhost');
+    c.resume();
+
+    const writeFn = mock.fn(() => {
+      strictEqual(c.bytesWritten, N);
+      resolve();
+    });
+
+    c.end('a'.repeat(N), writeFn);
+
+    await promise;
+  }
+};
+
+export const testNetBytesWrittenLargeVariant3 = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9998, 'localhost');
+    c.resume();
+
+    const writeFn = mock.fn(() => {
+      strictEqual(c.bytesWritten, 2 * N);
+      resolve();
+    });
+
+    c.cork();
+    c.write('a'.repeat(N));
+    strictEqual(c.bytesWritten, N);
+    c.write(Buffer.alloc(N));
+    strictEqual(c.bytesWritten, 2 * N);
+    c.end('', writeFn);
+    c.uncork();
+
+    await promise;
+  }
+};
+
+// test/parallel/test-net-can-reset-timeout.js
+export const testNetCanResetTimeout = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9998, 'localhost');
+    c.setTimeout(100);
+
+    const timeoutFn = mock.fn(() => {
+      c.write('WHAT.');
+    });
+    c.on('timeout', timeoutFn);
+
+    const dataFn = mock.fn(() => {
+      resolve();
+    });
+    c.on('data', dataFn);
+
+    await promise;
+
+    strictEqual(timeoutFn.mock.callCount(), 1);
+    strictEqual(dataFn.mock.callCount(), 1);
+  }
+};
+
+async function assertAbort(socket, testName) {
+  try {
+    await once(socket, 'close');
+    fail(`close ${testName} should have thrown`);
+  } catch (err) {
+    strictEqual(err.name, 'AbortError');
+  }
+};
+
+// test/parallel/test-net-connect-abort-controller.js
+export const testNetConnectAbortControllerPostAbort = {
+  async test() {
+    const ac = new AbortController();
+    const { signal } = ac;
+    const socket = net.connect({ port: 9999, signal });
+    ac.abort();
+    await assertAbort(socket, 'postAbort');
+  }
+};
+
+export const testNetConnectAbortControllerPreAbort = {
+  async test() {
+    const ac = new AbortController();
+    const { signal } = ac;
+    ac.abort();
+    const socket = net.connect({ port: 9999, signal });
+    await assertAbort(socket, 'preAbort');
+  }
+};
+
+export const testNetConnectAbortControllerTickAbort = {
+  async test() {
+    const ac = new AbortController();
+    const { signal } = ac;
+    queueMicrotask(() => ac.abort());
+    const socket = net.connect({ port: 9999, signal });
+    await assertAbort(socket, 'tickAbort');
+  }
+};
+
+export const testNetConnectAbortControllerConstructor = {
+  async test() {
+    const ac = new AbortController();
+    const { signal } = ac;
+    ac.abort();
+    const socket = new net.Socket({ signal });
+    await assertAbort(socket, 'testConstructor');
+  }
+};
+
+export const testNetConnectAbortControllerConstructorPost = {
+  async test() {
+    const ac = new AbortController();
+    const { signal } = ac;
+    const socket = new net.Socket({ signal });
+    ac.abort();
+    await assertAbort(socket, 'testConstructorPost');
+  }
+};
+
+export const testNetConnectAbortControllerConstructorPostTick = {
+  async test() {
+    const ac = new AbortController();
+    const { signal } = ac;
+    queueMicrotask(() => ac.abort());
+    const socket = new net.Socket({ signal });
+    await assertAbort(socket, 'testConstructorPostTick');
+  }
+};
+
+// test/parallel/test-net-connect-after-destroy.js
+export const testNetConnectAfterDestroy = {
+  async test() {
+    // Connect to something that we need to lookup, then delay
+    // the lookup so that the connect attempt happens after the
+    // destroy
+    const lookup = mock.fn((host, options, callback) => {
+      setTimeout(() => callback(null, 'localhost'), 100);
+    });
+    const c = net.connect({
+      port: 80,
+      host: 'example.org',
+      lookup,
+    });
+    c.on('connect', () => {
+      throw new Error('should not connect');
+    });
+    c.destroy();
+    strictEqual(c.destroyed, true);
+    strictEqual(lookup.mock.callCount(), 1);
+  }
+};
+
+// test/parallel/test-net-connect-buffer.js
+export const testNetConnectBuffer = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect({
+      port: 9998,
+      host: 'localhost',
+      highWaterMark: 0,
+    });
+
+    strictEqual(c.pending, true);
+    strictEqual(c.connecting, true);
+    strictEqual(c.readyState, 'opening');
+    strictEqual(c.bytesWritten, 0);
+
+    // Write a string that contains a multi-byte character sequence to test that
+    // `bytesWritten` is incremented with the # of bytes, not # of characters.
+    const a = "L'État, c'est ";
+    const b = 'moi';
+
+    let result = '';
+    c.setEncoding('utf8');
+    c.on('data', (chunk) => {
+      result += chunk;
+    });
+    const endFn = mock.fn(() => {
+      strictEqual(result, a + b);
+    });
+    c.on('end', endFn);
+
+    const writeFn = mock.fn(() => {
+      strictEqual(c.pending, false);
+      strictEqual(c.connecting, false);
+      strictEqual(c.readyState, 'readOnly');
+      strictEqual(c.bytesWritten, Buffer.from(a + b).length);
+    });
+    c.write(a, writeFn);
+
+    const closeFn = mock.fn(() => {
+      resolve();
+    });
+    c.on('close', closeFn);
+
+    c.end(b);
+
+    await promise;
+    strictEqual(closeFn.mock.callCount(), 1);
+    strictEqual(writeFn.mock.callCount(), 1);
+    strictEqual(endFn.mock.callCount(), 1);
+  }
+};
+
+// test/parallel/test-net-connect-destroy.js
+export const testNetConnectDestroy = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9999, 'localhost');
+    c.on('close', () => resolve());
+    c.destroy();
+    await promise;
+  }
+};
+
+// test/parallel/test-net-connect-immediate-destroy.js
+export const testNetConnectImmediateDestroy = {
+  async test() {
+    const connectFn = mock.fn();
+    const socket = net.connect(9999, 'localhost', connectFn);
+    socket.destroy();
+    await Promise.resolve();
+    strictEqual(connectFn.mock.callCount(), 0);
+  }
+};
+
+// test/parallel/test-net-connect-immediate-finish.js
+export const testNetConnectImmediateFinish = {
+  async text() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9999, 'localhost');
+    c.end();
+    c.on('finish', () => resolve());
+    await promise;
+  }
+};
+
+// test/parallel/test-net-connect-keepalive.js
+// test/parallel/test-net-keepalive.js
+// We don't actually support keep alive so this test does
+// something different than the original Node.js test
+export const testNetConnectKeepAlive = {
+  async test() {
+    throws(() => new net.Socket({ keepAlive: true }));
+    const c = new net.Socket();
+    c.setKeepAlive(false);
+    throws(() => c.setKeepAlive(true));
+  }
+};
+
+// test/parallel/test-net-connect-memleak.js
+export const testNetConnectMemleak = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const connectFn = mock.fn(() => resolve());
+    const c = net.connect(9999, 'localhost', connectFn);
+    c.emit('connect');
+    await promise;
+    strictEqual(connectFn.mock.callCount(), 1);
+  }
+};
+
+// test/parallel/test-net-connect-no-arg.js
+export const testNetConnectNoArg = {
+  test() {
+    throws(() => net.connect(), {
+      code: 'ERR_MISSING_ARGS',
+      message: 'The "options" or "port" or "path" argument must be specified',
+    });
+    throws(() => new net.Socket().connect(), {
+      code: 'ERR_MISSING_ARGS',
+      message: 'The "options" or "port" or "path" argument must be specified',
+    });
+    throws(() => net.connect({}), {
+      code: 'ERR_MISSING_ARGS',
+      message: 'The "options" or "port" or "path" argument must be specified',
+    });
+    throws(() => new net.Socket().connect({}), {
+      code: 'ERR_MISSING_ARGS',
+      message: 'The "options" or "port" or "path" argument must be specified',
+    });
+  }
+};
+
+// test/parallel/test-net-connect-nodelay.js
+// We do not support the nodelay option so this test does something different
+// than the original Node.js test
+export const testNetConnectNoDelay = {
+  async test() {
+    throws(() => new net.Socket({ noDelay: true }));
+    const c = new net.Socket();
+    c.setNoDelay(false);
+    throws(() => c.setNoDelay(true));
+  }
+};
+
+// test/parallel/test-net-connect-options-allowhalfopen.js
+// Simplified version of the equivalent Node.js test
+export const testNetConnectOptionsAllowHalfOpen = {
+  async test() {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const c = net.connect({ port: 9999, allowHalfOpen: true });
+    c.resume();
+    const writeFn = mock.fn(() => {
+      c.write('hello', (err) => {
+        if (err) reject(err);
+        resolve();
+      });
+    });
+    const endFn = mock.fn(() => {
+      strictEqual(c.readable, false);
+      strictEqual(c.writable, true);
+      queueMicrotask(writeFn);
+    });
+    c.on('end', endFn);
+    await promise;
+  }
+};
+
+// test/parallel/test-net-connect-options-fd.js
+// We do not support the fd option so this test does something different
+// than the original Node.js test
+export const testNetConnectOptionsFd = {
+  async test() {
+    throws(() => new net.Socket({ fd: 42 }));
+  }
+};
+
+// test/parallel/test-net-connect-options-invalid.js
+export const testNetConnectOptionsInvalid = {
+  test() {
+    [
+      'objectMode',
+      'readableObjectMode',
+      'writableObjectMode',
+    ].forEach((invalidKey) => {
+      const option = {
+        port: 8080,
+        [invalidKey]: true,
+      };
+      const message = `The property 'options.${invalidKey}' is not supported. Received true`;
+
+      throws(() => net.connect(option), {
+        code: 'ERR_INVALID_ARG_VALUE',
+        name: 'TypeError',
+        message: new RegExp(message),
+      });
+    });
+  }
+};
+
+// test/parallel/test-net-connect-options-ipv6.js
+export const testNetConnectOptionsIpv6 = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect({ host: '::1', port: 9999 });
+    c.on('connect', () => resolve());
+    await promise;
+  }
+};
+
+// test/parallel/test-net-connect-options-path.js
+// We do not support the path option so this test does something different
+// than the original Node.js test
+export const testNetConnectOptionsPath = {
+  async test() {
+    throws(() => net.connect({ path: '/tmp/sock' }));
+  }
+}
+
+// test/parallel/test-net-connect-options-port.js
+export const testNetConnectOptionsPort = {
+  async test() {
+    [true, false].forEach((port) => {
+      throws(() => net.connect(port), {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError',
+      });
+    });
+    [-1, 65537].forEach((port) => {
+      throws(() => net.connect(port), {
+        code: 'ERR_SOCKET_BAD_PORT',
+      });
+    });
+  }
+};
+
+// test/parallel/test-net-connect-paused-connection.js
+// The original test is a bit different given that it uses unref to avoid
+// the paused connection from keeping the process alive. We don't have unref
+// so let's just make sure things clean up okay when the IoContext is destroyed.
+export const testNetConnectPausedConnection = {
+  test() {
+    net.connect(9999, 'localhost').pause();
+  }
+};
+
+// test/parallel/test-net-dns-custom-lookup.js
+// test/parallel/test-net-dns-lookup.js
+export const testNetDnsCustomLookup = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const lookup = mock.fn((host, options, callback) => {
+      strictEqual(host, 'localhost');
+      strictEqual(options.family, 0);
+      queueMicrotask(() => callback(null, '127.0.0.1', 4));
+    });
+    const c = net.connect({
+      port: 9999,
+      host: 'localhost',
+      lookup,
+    });
+    c.on('lookup', (err, ip, type) => {
+      strictEqual(err, null);
+      strictEqual(ip, '127.0.0.1');
+      strictEqual(type, 4);
+      resolve();
+    });
+    await promise;
+    strictEqual(lookup.mock.callCount(), 1);
+  }
+};
+
+// test/parallel/test-net-dns-lookup-skip.js
+export const testNetDnsLookupSkip = {
+  async test() {
+    const lookup = mock.fn();
+    ['127.0.0.1', '::1'].forEach((host) => {
+      net.connect({ host, port: 9999, lookup }).destroy();
+    });
+    strictEqual(lookup.mock.callCount(), 0);
+  }
+};
+
+// test/parallel/test-net-during-close.js
+export const testNetDuringClose = {
+  test() {
+    const c = net.connect(9999, 'localhost');
+    c.destroy();
+    c.remoteAddress;
+    c.remoteFamily;
+    c.remotePort;
+  }
+};
+
+// test/parallel/test-net-end-destroyed.js
+export const testNetEndDestroyed = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9999, 'localhost');
+    c.resume();
+
+    const endFn = mock.fn(() => {
+      strictEqual(c.destroyed, false);
+      resolve();
+    });
+    c.on('end', endFn);
+    await promise;
+  }
+};
+
+// test/parallel/test-net-end-without-connect.js
+export const testNetEndWithoutConnect = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = new net.Socket();
+    const endFn = mock.fn(() => {
+      strictEqual(c.writable, false);
+      resolve();
+    });
+    c.end(endFn);
+    await promise;
+  }
+};
+
+// test/parallel/test-net-isip.js
+export const testNetIsIp = {
+  test() {
+    strictEqual(net.isIP('127.0.0.1'), 4);
+    strictEqual(net.isIP('x127.0.0.1'), 0);
+    strictEqual(net.isIP('example.com'), 0);
+    strictEqual(net.isIP('0000:0000:0000:0000:0000:0000:0000:0000'), 6);
+    strictEqual(net.isIP('0000:0000:0000:0000:0000:0000:0000:0000::0000'), 0);
+    strictEqual(net.isIP('1050:0:0:0:5:600:300c:326b'), 6);
+    strictEqual(net.isIP('2001:252:0:1::2008:6'), 6);
+    strictEqual(net.isIP('2001:dead:beef:1::2008:6'), 6);
+    strictEqual(net.isIP('2001::'), 6);
+    strictEqual(net.isIP('2001:dead::'), 6);
+    strictEqual(net.isIP('2001:dead:beef::'), 6);
+    strictEqual(net.isIP('2001:dead:beef:1::'), 6);
+    strictEqual(net.isIP('ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff'), 6);
+    strictEqual(net.isIP(':2001:252:0:1::2008:6:'), 0);
+    strictEqual(net.isIP(':2001:252:0:1::2008:6'), 0);
+    strictEqual(net.isIP('2001:252:0:1::2008:6:'), 0);
+    strictEqual(net.isIP('2001:252::1::2008:6'), 0);
+    strictEqual(net.isIP('::2001:252:1:2008:6'), 6);
+    strictEqual(net.isIP('::2001:252:1:1.1.1.1'), 6);
+    strictEqual(net.isIP('::2001:252:1:255.255.255.255'), 6);
+    strictEqual(net.isIP('::2001:252:1:255.255.255.255.76'), 0);
+    strictEqual(net.isIP('fe80::2008%eth0'), 6);
+    strictEqual(net.isIP('fe80::2008%eth0.0'), 6);
+    strictEqual(net.isIP('fe80::2008%eth0@1'), 0);
+    strictEqual(net.isIP('::anything'), 0);
+    strictEqual(net.isIP('::1'), 6);
+    strictEqual(net.isIP('::'), 6);
+    strictEqual(net.isIP('0000:0000:0000:0000:0000:0000:12345:0000'), 0);
+    strictEqual(net.isIP('0'), 0);
+    strictEqual(net.isIP(), 0);
+    strictEqual(net.isIP(''), 0);
+    strictEqual(net.isIP(null), 0);
+    strictEqual(net.isIP(123), 0);
+    strictEqual(net.isIP(true), 0);
+    strictEqual(net.isIP({}), 0);
+    strictEqual(net.isIP({ toString: () => '::2001:252:1:255.255.255.255' }), 6);
+    strictEqual(net.isIP({ toString: () => '127.0.0.1' }), 4);
+    strictEqual(net.isIP({ toString: () => 'bla' }), 0);
+
+    strictEqual(net.isIPv4('127.0.0.1'), true);
+    strictEqual(net.isIPv4('example.com'), false);
+    strictEqual(net.isIPv4('2001:252:0:1::2008:6'), false);
+    strictEqual(net.isIPv4(), false);
+    strictEqual(net.isIPv4(''), false);
+    strictEqual(net.isIPv4(null), false);
+    strictEqual(net.isIPv4(123), false);
+    strictEqual(net.isIPv4(true), false);
+    strictEqual(net.isIPv4({}), false);
+    strictEqual(net.isIPv4({ toString: () => '::2001:252:1:255.255.255.255' }), false);
+    strictEqual(net.isIPv4({ toString: () => '127.0.0.1' }), true);
+    strictEqual(net.isIPv4({ toString: () => 'bla' }), false);
+
+    strictEqual(net.isIPv6('127.0.0.1'), false);
+    strictEqual(net.isIPv6('example.com'), false);
+    strictEqual(net.isIPv6('2001:252:0:1::2008:6'), true);
+    strictEqual(net.isIPv6(), false);
+    strictEqual(net.isIPv6(''), false);
+    strictEqual(net.isIPv6(null), false);
+    strictEqual(net.isIPv6(123), false);
+    strictEqual(net.isIPv6(true), false);
+    strictEqual(net.isIPv6({}), false);
+    strictEqual(net.isIPv6({ toString: () => '::2001:252:1:255.255.255.255' }), true);
+    strictEqual(net.isIPv6({ toString: () => '127.0.0.1' }), false);
+    strictEqual(net.isIPv6({ toString: () => 'bla' }), false);
+  }
+};
+
+// test/parallel/test-net-isipv4.js
+export const testNetIsIpv4 = {
+  test() {
+    const v4 = [
+      '0.0.0.0',
+      '8.8.8.8',
+      '127.0.0.1',
+      '100.100.100.100',
+      '192.168.0.1',
+      '18.101.25.153',
+      '123.23.34.2',
+      '172.26.168.134',
+      '212.58.241.131',
+      '128.0.0.0',
+      '23.71.254.72',
+      '223.255.255.255',
+      '192.0.2.235',
+      '99.198.122.146',
+      '46.51.197.88',
+      '173.194.34.134',
+    ];
+
+    const v4not = [
+      '.100.100.100.100',
+      '100..100.100.100.',
+      '100.100.100.100.',
+      '999.999.999.999',
+      '256.256.256.256',
+      '256.100.100.100.100',
+      '123.123.123',
+      'http://123.123.123',
+      '1000.2.3.4',
+      '999.2.3.4',
+      '0000000192.168.0.200',
+      '192.168.0.2000000000',
+    ];
+
+    for (const ip of v4) {
+      strictEqual(net.isIPv4(ip), true);
+    }
+
+    for (const ip of v4not) {
+      strictEqual(net.isIPv4(ip), false);
+    }
+  }
+};
+
+// test/parallel/test-net-isipv6.js
+export const testNetIsIpv6 = {
+  test() {
+    const v6 = [
+      '::',
+      '1::',
+      '::1',
+      '1::8',
+      '1::7:8',
+      '1:2:3:4:5:6:7:8',
+      '1:2:3:4:5:6::8',
+      '1:2:3:4:5:6:7::',
+      '1:2:3:4:5::7:8',
+      '1:2:3:4:5::8',
+      '1:2:3::8',
+      '1::4:5:6:7:8',
+      '1::6:7:8',
+      '1::3:4:5:6:7:8',
+      '1:2:3:4::6:7:8',
+      '1:2::4:5:6:7:8',
+      '::2:3:4:5:6:7:8',
+      '1:2::8',
+      '2001:0000:1234:0000:0000:C1C0:ABCD:0876',
+      '3ffe:0b00:0000:0000:0001:0000:0000:000a',
+      'FF02:0000:0000:0000:0000:0000:0000:0001',
+      '0000:0000:0000:0000:0000:0000:0000:0001',
+      '0000:0000:0000:0000:0000:0000:0000:0000',
+      '::ffff:192.168.1.26',
+      '2::10',
+      'ff02::1',
+      'fe80::',
+      '2002::',
+      '2001:db8::',
+      '2001:0db8:1234::',
+      '::ffff:0:0',
+      '::ffff:192.168.1.1',
+      '1:2:3:4::8',
+      '1::2:3:4:5:6:7',
+      '1::2:3:4:5:6',
+      '1::2:3:4:5',
+      '1::2:3:4',
+      '1::2:3',
+      '::2:3:4:5:6:7',
+      '::2:3:4:5:6',
+      '::2:3:4:5',
+      '::2:3:4',
+      '::2:3',
+      '::8',
+      '1:2:3:4:5:6::',
+      '1:2:3:4:5::',
+      '1:2:3:4::',
+      '1:2:3::',
+      '1:2::',
+      '1:2:3:4::7:8',
+      '1:2:3::7:8',
+      '1:2::7:8',
+      '1:2:3:4:5:6:1.2.3.4',
+      '1:2:3:4:5::1.2.3.4',
+      '1:2:3:4::1.2.3.4',
+      '1:2:3::1.2.3.4',
+      '1:2::1.2.3.4',
+      '1::1.2.3.4',
+      '1:2:3:4::5:1.2.3.4',
+      '1:2:3::5:1.2.3.4',
+      '1:2::5:1.2.3.4',
+      '1::5:1.2.3.4',
+      '1::5:11.22.33.44',
+      'fe80::217:f2ff:254.7.237.98',
+      'fe80::217:f2ff:fe07:ed62',
+      '2001:DB8:0:0:8:800:200C:417A',
+      'FF01:0:0:0:0:0:0:101',
+      '0:0:0:0:0:0:0:1',
+      '0:0:0:0:0:0:0:0',
+      '2001:DB8::8:800:200C:417A',
+      'FF01::101',
+      '0:0:0:0:0:0:13.1.68.3',
+      '0:0:0:0:0:FFFF:129.144.52.38',
+      '::13.1.68.3',
+      '::FFFF:129.144.52.38',
+      'fe80:0000:0000:0000:0204:61ff:fe9d:f156',
+      'fe80:0:0:0:204:61ff:fe9d:f156',
+      'fe80::204:61ff:fe9d:f156',
+      'fe80:0:0:0:204:61ff:254.157.241.86',
+      'fe80::204:61ff:254.157.241.86',
+      'fe80::1',
+      '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+      '2001:db8:85a3:0:0:8a2e:370:7334',
+      '2001:db8:85a3::8a2e:370:7334',
+      '2001:0db8:0000:0000:0000:0000:1428:57ab',
+      '2001:0db8:0000:0000:0000::1428:57ab',
+      '2001:0db8:0:0:0:0:1428:57ab',
+      '2001:0db8:0:0::1428:57ab',
+      '2001:0db8::1428:57ab',
+      '2001:db8::1428:57ab',
+      '::ffff:12.34.56.78',
+      '::ffff:0c22:384e',
+      '2001:0db8:1234:0000:0000:0000:0000:0000',
+      '2001:0db8:1234:ffff:ffff:ffff:ffff:ffff',
+      '2001:db8:a::123',
+      '::ffff:192.0.2.128',
+      '::ffff:c000:280',
+      'a:b:c:d:e:f:f1:f2',
+      'a:b:c::d:e:f:f1',
+      'a:b:c::d:e:f',
+      'a:b:c::d:e',
+      'a:b:c::d',
+      '::a',
+      '::a:b:c',
+      '::a:b:c:d:e:f:f1',
+      'a::',
+      'a:b:c::',
+      'a:b:c:d:e:f:f1::',
+      'a:bb:ccc:dddd:000e:00f:0f::',
+      '0:a:0:a:0:0:0:a',
+      '0:a:0:0:a:0:0:a',
+      '2001:db8:1:1:1:1:0:0',
+      '2001:db8:1:1:1:0:0:0',
+      '2001:db8:1:1:0:0:0:0',
+      '2001:db8:1:0:0:0:0:0',
+      '2001:db8:0:0:0:0:0:0',
+      '2001:0:0:0:0:0:0:0',
+      'A:BB:CCC:DDDD:000E:00F:0F::',
+      '0:0:0:0:0:0:0:a',
+      '0:0:0:0:a:0:0:0',
+      '0:0:0:a:0:0:0:0',
+      'a:0:0:a:0:0:a:a',
+      'a:0:0:a:0:0:0:a',
+      'a:0:0:0:a:0:0:a',
+      'a:0:0:0:a:0:0:0',
+      'a:0:0:0:0:0:0:0',
+      'fe80::7:8%eth0',
+      'fe80::7:8%1',
+    ];
+
+    const v6not = [
+      '',
+      '1:',
+      ':1',
+      '11:36:12',
+      '02001:0000:1234:0000:0000:C1C0:ABCD:0876',
+      '2001:0000:1234:0000:00001:C1C0:ABCD:0876',
+      '2001:0000:1234: 0000:0000:C1C0:ABCD:0876',
+      '2001:1:1:1:1:1:255Z255X255Y255',
+      '3ffe:0b00:0000:0001:0000:0000:000a',
+      'FF02:0000:0000:0000:0000:0000:0000:0000:0001',
+      '3ffe:b00::1::a',
+      '::1111:2222:3333:4444:5555:6666::',
+      '1:2:3::4:5::7:8',
+      '12345::6:7:8',
+      '1::5:400.2.3.4',
+      '1::5:260.2.3.4',
+      '1::5:256.2.3.4',
+      '1::5:1.256.3.4',
+      '1::5:1.2.256.4',
+      '1::5:1.2.3.256',
+      '1::5:300.2.3.4',
+      '1::5:1.300.3.4',
+      '1::5:1.2.300.4',
+      '1::5:1.2.3.300',
+      '1::5:900.2.3.4',
+      '1::5:1.900.3.4',
+      '1::5:1.2.900.4',
+      '1::5:1.2.3.900',
+      '1::5:300.300.300.300',
+      '1::5:3000.30.30.30',
+      '1::400.2.3.4',
+      '1::260.2.3.4',
+      '1::256.2.3.4',
+      '1::1.256.3.4',
+      '1::1.2.256.4',
+      '1::1.2.3.256',
+      '1::300.2.3.4',
+      '1::1.300.3.4',
+      '1::1.2.300.4',
+      '1::1.2.3.300',
+      '1::900.2.3.4',
+      '1::1.900.3.4',
+      '1::1.2.900.4',
+      '1::1.2.3.900',
+      '1::300.300.300.300',
+      '1::3000.30.30.30',
+      '::400.2.3.4',
+      '::260.2.3.4',
+      '::256.2.3.4',
+      '::1.256.3.4',
+      '::1.2.256.4',
+      '::1.2.3.256',
+      '::300.2.3.4',
+      '::1.300.3.4',
+      '::1.2.300.4',
+      '::1.2.3.300',
+      '::900.2.3.4',
+      '::1.900.3.4',
+      '::1.2.900.4',
+      '::1.2.3.900',
+      '::300.300.300.300',
+      '::3000.30.30.30',
+      '2001:DB8:0:0:8:800:200C:417A:221',
+      'FF01::101::2',
+      '1111:2222:3333:4444::5555:',
+      '1111:2222:3333::5555:',
+      '1111:2222::5555:',
+      '1111::5555:',
+      '::5555:',
+      ':::',
+      '1111:',
+      ':',
+      ':1111:2222:3333:4444::5555',
+      ':1111:2222:3333::5555',
+      ':1111:2222::5555',
+      ':1111::5555',
+      ':::5555',
+      '1.2.3.4:1111:2222:3333:4444::5555',
+      '1.2.3.4:1111:2222:3333::5555',
+      '1.2.3.4:1111:2222::5555',
+      '1.2.3.4:1111::5555',
+      '1.2.3.4::5555',
+      '1.2.3.4::',
+      'fe80:0000:0000:0000:0204:61ff:254.157.241.086',
+      '123',
+      'ldkfj',
+      '2001::FFD3::57ab',
+      '2001:db8:85a3::8a2e:37023:7334',
+      '2001:db8:85a3::8a2e:370k:7334',
+      '1:2:3:4:5:6:7:8:9',
+      '1::2::3',
+      '1:::3:4:5',
+      '1:2:3::4:5:6:7:8:9',
+      '::ffff:2.3.4',
+      '::ffff:257.1.2.3',
+      '::ffff:12345678901234567890.1.26',
+      '2001:0000:1234:0000:0000:C1C0:ABCD:0876 0',
+      '02001:0000:1234:0000:0000:C1C0:ABCD:0876',
+    ];
+
+    for (const ip of v6) {
+      strictEqual(net.isIPv6(ip), true);
+    }
+
+    for (const ip of v6not) {
+      strictEqual(net.isIPv6(ip), false);
+    }
+  }
+};
+
+// test/parallel/test-net-large-string.js
+export const testNetLargeString = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9998, 'localhost');
+    let response = '';
+    const size = 40 * 1024;
+    const data = 'あ'.repeat(size);
+    c.setEncoding('utf8');
+    c.on('data', (data) => response += data);
+    c.end(data);
+    c.on('close', resolve);
+    await promise;
+    strictEqual(response.length, size);
+    strictEqual(response, data);
+  }
+};
+
+// test/parallel/test-net-local-address-port.js
+// The localAddress information is a non-op in our implementation
+export const testNetLocalAddressPort = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9999, 'localhost');
+    c.on('connect', () => {
+      strictEqual(c.localAddress, '0.0.0.0');
+      strictEqual(c.localPort, 0);
+      resolve();
+    });
+    await promise;
+  }
+};
+
+// test/parallel/test-net-onread-static-buffer.js
+export const testNetOnReadStaticBuffer = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const buffer = Buffer.alloc(1024);
+    const fn = mock.fn((nread, buf) => {
+      strictEqual(nread, 5);
+      strictEqual(buf.buffer.byteLength, 1024);
+      resolve();
+    });
+    const c = net.connect({
+      port: 9998,
+      host: 'localhost',
+      onread: {
+        buffer,
+        callback: fn,
+      }
+    });
+    c.on('data', () => {
+      throw new Error('Should not have failed');
+    });
+    c.write('hello');
+    await promise;
+    strictEqual(fn.mock.callCount(), 1);
+  }
+};
+
+// test/parallel/test-net-remote-address-port.js
+// test/parallel/test-net-remote-address.js
+export const testNetRemoteAddress = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const c = net.connect(9999, 'localhost');
+    c.on('connect', () => {
+      strictEqual(c.remoteAddress, 'localhost');
+      strictEqual(c.remotePort, 9999);
+      resolve();
+    });
+    await promise;
+  }
+};
+
+export default {
+  connect({inbound}) {
+    inbound.cancel();
+    return new ReadableStream({
+      start(c) {
+        c.close();
+      }
+    });
+  }
+};
+
+export const echoServer = {
+  connect({inbound}) {
+    return inbound.pipeThrough(new IdentityTransformStream());
+  }
+}

--- a/src/workerd/api/node/net-test.wd-test
+++ b/src/workerd/api/node/net-test.wd-test
@@ -1,0 +1,23 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "net-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "net-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat_v2", "nodejs_compat_net", "experimental"],
+      )
+    ),
+    ( name = "internet", network = ( allow = ["private"] ) ),
+  ],
+  sockets = [
+    (name = "tcp", address = "*:9999", tcp = (), service = "net-test"),
+    (name = "echoTcp", address = "*:9998", tcp = (), service = (
+      name = "net-test",
+      entrypoint = "echoServer",
+    )),
+  ],
+);

--- a/src/workerd/api/tests/tcp-ingress-test.js
+++ b/src/workerd/api/tests/tcp-ingress-test.js
@@ -1,0 +1,29 @@
+import { connect } from 'cloudflare:sockets';
+import {
+  ok,
+  strictEqual,
+} from 'assert';
+
+export const newFunction = {
+  async test() {
+    const socket = connect('localhost:8081');
+    await socket.opened;
+    const dec = new TextDecoder();
+    let result = '';
+    for await (const chunk of socket.readable) {
+      result += dec.decode(chunk, { stream: true });
+    }
+    result += dec.decode();
+    strictEqual(result, 'hello');
+    await socket.closed;
+  }
+};
+
+export default {
+  connect({inbound, cf}) {
+    const enc = new TextEncoder();
+    ok(inbound instanceof ReadableStream);
+    strictEqual(typeof cf.clientIp, 'string');
+    return ReadableStream.from([enc.encode('hello')]);
+  },
+};

--- a/src/workerd/api/tests/tcp-ingress-test.wd-test
+++ b/src/workerd/api/tests/tcp-ingress-test.wd-test
@@ -1,0 +1,19 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "tcp-ingress-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "tcp-ingress-test.js"),
+        ],
+        compatibilityDate = "2024-06-03",
+        compatibilityFlags = ["nodejs_compat_v2", "experimental"],
+      )
+    ),
+    ( name = "internet", network = ( allow = ["private"] ) )
+  ],
+  sockets = [
+    (name = "tcp", address = "*:8081", tcp = (), service = "tcp-ingress-test")
+  ]
+);

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -68,6 +68,7 @@ class TraceItem final: public jsg::Object {
 public:
   class FetchEventInfo;
   class JsRpcEventInfo;
+  class ConnectEventInfo;
   class ScheduledEventInfo;
   class AlarmEventInfo;
   class QueueEventInfo;
@@ -80,6 +81,7 @@ public:
 
   typedef kj::OneOf<jsg::Ref<FetchEventInfo>,
                     jsg::Ref<JsRpcEventInfo>,
+                    jsg::Ref<ConnectEventInfo>,
                     jsg::Ref<ScheduledEventInfo>,
                     jsg::Ref<AlarmEventInfo>,
                     jsg::Ref<QueueEventInfo>,
@@ -266,6 +268,21 @@ public:
 
 private:
   kj::String rpcMethod;
+};
+
+class TraceItem::ConnectEventInfo final: public jsg::Object {
+public:
+  explicit ConnectEventInfo(jsg::Lock& js, const Trace& trace,
+                            const Trace::ConnectEventInfo& eventInfo);
+
+  jsg::Optional<jsg::V8Ref<v8::Object>> getCf(jsg::Lock& js);
+
+  JSG_RESOURCE_TYPE(ConnectEventInfo) {
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(cf, getCf);
+  }
+
+private:
+  jsg::Optional<jsg::V8Ref<v8::Object>> cf;
 };
 
 class TraceItem::ScheduledEventInfo final: public jsg::Object {
@@ -616,6 +633,7 @@ private:
   api::TailEvent,                                                 \
   api::TraceItem,                                                 \
   api::TraceItem::AlarmEventInfo,                                 \
+  api::TraceItem::ConnectEventInfo,                               \
   api::TraceItem::CustomEventInfo,                                \
   api::TraceItem::ScheduledEventInfo,                             \
   api::TraceItem::QueueEventInfo,                                 \

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -488,4 +488,12 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # always been configured to accept publicly-routable internet hosts only; hostnames which map
   # to private IP addresses (as defined in e.g. RFC 1918) will be rejected. Thus, workerd has
   # always been SSRF-safe by default.
+
+  nodeJsCompatNet @52 :Bool
+      $compatEnableFlag("nodejs_compat_net")
+      $compatDisableFlag("no_nodejs_compat_net")
+      $compatEnableDate("2024-08-01")
+      $experimental;
+  # When the nodejs_compat or nodejs_compat v2 flags are enabled, the nodejs_compat_net
+  # flag determines if the node:net built-in module is also available.
 }

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -101,6 +101,16 @@ public:
     void copyTo(rpc::Trace::JsRpcEventInfo::Builder builder);
   };
 
+  class ConnectEventInfo {
+  public:
+    explicit ConnectEventInfo(kj::String cfJson);
+    explicit ConnectEventInfo(rpc::Trace::ConnectEventInfo::Reader reader);
+
+    kj::String cfJson;
+
+    void copyTo(rpc::Trace::ConnectEventInfo::Builder builder);
+  };
+
   class ScheduledEventInfo {
   public:
     explicit ScheduledEventInfo(double scheduledTime, kj::String cron);
@@ -266,7 +276,7 @@ public:
 
   typedef kj::OneOf<FetchEventInfo, JsRpcEventInfo, ScheduledEventInfo, AlarmEventInfo,
           QueueEventInfo, EmailEventInfo, TraceEventInfo, HibernatableWebSocketEventInfo,
-          CustomEventInfo> EventInfo;
+          CustomEventInfo, ConnectEventInfo> EventInfo;
   kj::Maybe<EventInfo> eventInfo;
   // TODO(someday): Support more event types.
   // TODO(someday): Work out what sort of information we may want to convey about the parent

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -438,7 +438,129 @@ kj::Promise<void> WorkerEntrypoint::request(
 kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host, const kj::HttpHeaders& headers,
     kj::AsyncIoStream& connection, ConnectResponse& response,
     kj::HttpConnectSettings settings) {
-  JSG_FAIL_REQUIRE(TypeError, "Incoming CONNECT on a worker not supported");
+  auto incomingRequest = kj::mv(KJ_REQUIRE_NONNULL(this->incomingRequest,
+                                "connect() can only be called once"));
+  this->incomingRequest = kj::none;
+  incomingRequest->delivered();
+  auto& context = incomingRequest->getContext();
+  bool isActor = context.getActor() != kj::none;
+
+  KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
+    auto timestamp = context.now();
+    kj::String cfJson;
+    KJ_IF_SOME(c, cfBlobJson) {
+      cfJson = kj::str(c);
+    }
+
+    t.setEventInfo(timestamp, Trace::ConnectEventInfo(kj::mv(cfJson)));
+  }
+
+  auto metricsForCatch = kj::addRef(incomingRequest->getMetrics());
+
+  return context.run(
+      [this, &context, &connection, &response, entrypointName = entrypointName]
+      (Worker::Lock& lock) mutable {
+    jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+
+    return lock.getGlobalScope().connect(
+        connection, response, cfBlobJson, lock,
+        lock.getExportedHandler(entrypointName, context.getActor()));
+  }).then([this](api::DeferredProxy<void> deferredProxy) {
+    proxyTask = kj::mv(deferredProxy.proxyTask);
+  }).exclusiveJoin(context.onAbort())
+      .catch_([this,&context](kj::Exception&& exception) mutable -> kj::Promise<void> {
+
+    // Log JS exceptions to the JS console, if fiddle is attached. This also has the effect of
+    // logging internal errors to syslog.
+    loggedExceptionEarlier = true;
+    context.logUncaughtExceptionAsync(UncaughtExceptionSource::REQUEST_HANDLER,
+                                      kj::cp(exception));
+
+    // Do not allow the exception to escape the isolate without waiting for the output gate to
+    // open. Note that in the success path, this is taken care of in `FetchEvent::respondWith()`.
+    return context.waitForOutputLocks()
+        .then([exception = kj::mv(exception)]() mutable
+              -> kj::Promise<void> { return kj::mv(exception); });
+  }).attach(kj::defer([this,incomingRequest = kj::mv(incomingRequest),&context]() mutable {
+    // The request has been canceled, but allow it to continue executing in the background.
+    auto promise = incomingRequest->drain().attach(kj::mv(incomingRequest));
+    waitUntilTasks.add(maybeAddGcPassForTest(context, kj::mv(promise)));
+  })).then([this]() -> kj::Promise<void> {
+    // Now that the IoContext is dropped (unless it had waitUntil()s), we can finish proxying
+    // without pinning it or the isolate into memory.
+    KJ_IF_SOME(p, proxyTask) {
+      return kj::mv(p);
+    } else {
+      return kj::READY_NOW;
+    }
+  }).attach(kj::defer([this]() mutable {
+    // If we're being cancelled, we need to make sure `proxyTask` gets canceled.
+    proxyTask = kj::none;
+  })).catch_([this, isActor, &response, metrics = kj::mv(metricsForCatch)]
+             (kj::Exception&& exception) mutable -> kj::Promise<void> {
+    // Don't return errors to end user.
+
+    auto isInternalException = !jsg::isTunneledException(exception.getDescription())
+        && !jsg::isDoNotLogException(exception.getDescription());
+    if (!loggedExceptionEarlier) {
+      // This exception seems to have originated during the deferred proxy task, so it was not
+      // logged to the IoContext earlier.
+      if (exception.getType() != kj::Exception::Type::DISCONNECTED && isInternalException) {
+        LOG_EXCEPTION("workerEntrypoint", exception);
+      } else {
+        KJ_LOG(INFO, exception);  // Run with --verbose to see exception logs.
+      }
+    }
+
+    auto exceptionToPropagate = [&]() {
+      if (isInternalException) {
+        // We've already logged it here, the only thing that matters to the client is that we failed
+        // due to an internal error. Note that this does not need to be labeled "remote." since jsg
+        // will sanitize it as an internal error. Note that we use `setDescription()` to preserve
+        // the exception type for `cjfs::makeInternalError(...)` downstream.
+        exception.setDescription(kj::str(
+            "worker_do_not_log; Request failed due to internal error"));
+        return kj::mv(exception);
+      } else {
+        // We do not care how many remote capnp servers this went through since we are returning
+        // it to the worker via jsg.
+        // TODO(someday) We also do this stripping when making the tunneled exception for
+        // `jsg::isTunneledException(...)`. It would be lovely if we could simply store some type
+        // instead of `loggedExceptionEarlier`. It would save use some work.
+        auto description = jsg::stripRemoteExceptionPrefix(exception.getDescription());
+        if (!description.startsWith("remote.")) {
+          // If we already were annotated as remote from some other worker entrypoint, no point
+          // adding an additional prefix.
+          exception.setDescription(kj::str("remote.", description));
+        }
+        return kj::mv(exception);
+      }
+
+    };
+
+    if (isActor || tunnelExceptions) {
+      // We want to tunnel exceptions from actors back to the caller.
+      // TODO(cleanup): We'd really like to tunnel exceptions any time a worker is calling another
+      // worker, not just for actors (and W2W below), but getting that right will require cleaning
+      // up error handling more generally.
+      return exceptionToPropagate();
+    } else {
+      // Return error.
+
+      // We're catching the exception and replacing it with 5xx, but metrics should still indicate
+      // an exception.
+      metrics->reportFailure(exception);
+
+      kj::HttpHeaders headers(threadContext.getHeaderTable());
+      if (exception.getType() == kj::Exception::Type::OVERLOADED) {
+        response.reject(503, "Service Unavailable", headers, uint64_t(0));
+      } else {
+        response.reject(500, "Internal Server Error", headers, uint64_t(0));
+      }
+
+      return kj::READY_NOW;
+    }
+  });
 }
 
 void WorkerEntrypoint::prewarm(kj::StringPtr url) {

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -58,6 +58,7 @@ struct Trace @0x8e8d911203762d34 {
     email @16 :EmailEventInfo;
     trace @18 :TraceEventInfo;
     hibernatableWebSocket @20 :HibernatableWebSocketEventInfo;
+    connect @24 :ConnectEventInfo;
   }
   struct FetchEventInfo {
     method @0 :HttpMethod;
@@ -73,6 +74,10 @@ struct Trace @0x8e8d911203762d34 {
 
   struct JsRpcEventInfo {
     methodName @0 :Text;
+  }
+
+  struct ConnectEventInfo {
+    cfJson @0 :Text;
   }
 
   struct ScheduledEventInfo {

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -28,10 +28,10 @@
 #include <workerd/io/request-tracker.h>
 #include <workerd/util/http-util.h>
 #include <workerd/api/actor-state.h>
-#include <workerd/util/mimetype.h>
-#include <workerd/util/uuid.h>
-#include <workerd/util/use-perfetto-categories.h>
 #include <workerd/api/worker-rpc.h>
+#include <workerd/util/mimetype.h>
+#include <workerd/util/use-perfetto-categories.h>
+#include <workerd/util/stream-utils.h>
 #include "workerd-api.h"
 #include "workerd/io/hibernation-manager.h"
 #include <stdlib.h>
@@ -3351,6 +3351,92 @@ private:
   };
 };
 
+class Server::TcpListener final: public kj::Refcounted {
+public:
+  TcpListener(Server& owner, kj::Own<kj::ConnectionReceiver> listener, Service& service,
+              kj::HttpHeaderTable& headerTable, kj::Own<HttpRewriter> rewriter)
+      : owner(owner),
+        listener(kj::mv(listener)),
+        service(service),
+        headerTable(headerTable),
+        rewriter(kj::mv(rewriter)) {}
+
+  kj::Promise<void> run() {
+    for (;;) {
+      kj::AuthenticatedStream stream = co_await listener->acceptAuthenticated();
+
+      kj::Maybe<kj::String> cfBlobJson;
+      if (!rewriter->hasCfBlobHeader()) {
+        // Construct a cf blob describing the client identity.
+
+        kj::PeerIdentity* peerId;
+
+        KJ_IF_SOME(tlsId,
+            kj::dynamicDowncastIfAvailable<kj::TlsPeerIdentity>(*stream.peerIdentity)) {
+          peerId = &tlsId.getNetworkIdentity();
+
+          // TODO(someday): Add client certificate info to the cf blob? At present, KJ only
+          //   supplies the common name, but that doesn't even seem to be one of the fields that
+          //   Cloudflare-hosted Workers receive. We should probably try to match those.
+        } else {
+          peerId = stream.peerIdentity;
+        }
+
+        KJ_IF_SOME(remote,
+            kj::dynamicDowncastIfAvailable<kj::NetworkPeerIdentity>(*peerId)) {
+          cfBlobJson = kj::str("{\"clientIp\": \"", escapeJsonString(remote.toString()), "\"}");
+        } else KJ_IF_SOME(local,
+            kj::dynamicDowncastIfAvailable<kj::LocalPeerIdentity>(*peerId)) {
+          auto creds = local.getCredentials();
+
+          kj::Vector<kj::String> parts;
+          KJ_IF_SOME(p, creds.pid) {
+            parts.add(kj::str("\"clientPid\":", p));
+          }
+          KJ_IF_SOME(u, creds.uid) {
+            parts.add(kj::str("\"clientUid\":", u));
+          }
+
+          cfBlobJson = kj::str("{", kj::strArray(parts, ","), "}");
+        }
+      }
+
+      IoChannelFactory::SubrequestMetadata metadata;
+      metadata.cfBlobJson = cfBlobJson.map([](kj::StringPtr s) { return kj::str(s); });
+      auto req = service.startRequest(kj::mv(metadata));
+      auto response = kj::heap<ResponseWrapper>();
+      kj::HttpHeaders headers(headerTable);
+      // The empty string here is the host parameter that is required by the API
+      // but is not actually used in the implementation at this point.
+      owner.tasks.add(req->connect(""_kj, headers, *stream.stream, *response, {})
+          .attach(kj::mv(stream.stream), kj::mv(response)).attach(kj::mv(req)));
+    }
+  }
+
+private:
+  Server& owner;
+  kj::Own<kj::ConnectionReceiver> listener;
+  Service& service;
+  kj::HttpHeaderTable& headerTable;
+  kj::Own<HttpRewriter> rewriter;
+
+  struct ResponseWrapper final: public kj::HttpService::ConnectResponse {
+    void accept(uint statusCode,
+                kj::StringPtr statusText,
+                const kj::HttpHeaders& headers) override {
+      // Ok.. we're accepting the connection... anything to do?
+    }
+    kj::Own<kj::AsyncOutputStream> reject(
+        uint statusCode,
+        kj::StringPtr statusText,
+        const kj::HttpHeaders& headers,
+        kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+      // Doh... we're rejecting the connection... anything to do?
+      return newNullOutputStream();
+    }
+  };
+};
+
 kj::Promise<void> Server::listenHttp(
     kj::Own<kj::ConnectionReceiver> listener, Service& service,
     kj::StringPtr physicalProtocol, kj::Own<HttpRewriter> rewriter) {
@@ -3358,6 +3444,16 @@ kj::Promise<void> Server::listenHttp(
                                           physicalProtocol, kj::mv(rewriter),
                                           globalContext->headerTable, timer,
                                           globalContext->httpOverCapnpFactory);
+  co_return co_await obj->run();
+}
+
+kj::Promise<void> Server::listenTcp(
+    kj::Own<kj::ConnectionReceiver> listener,
+    Service& service,
+    kj::Own<HttpRewriter> rewriter) {
+  auto obj = kj::refcounted<TcpListener>(*this, kj::mv(listener), service,
+                                         globalContext->headerTable,
+                                         kj::mv(rewriter));
   co_return co_await obj->run();
 }
 
@@ -3624,18 +3720,31 @@ kj::Promise<void> Server::listenOnSockets(config::Config::Reader config,
     config::HttpOptions::Reader httpOptions;
     kj::Maybe<kj::Own<kj::TlsContext>> tls;
     kj::StringPtr physicalProtocol;
+    bool isHttp = false;
     switch (sock.which()) {
       case config::Socket::HTTP:
+        isHttp = true;
         defaultPort = 80;
         httpOptions = sock.getHttp();
         physicalProtocol = "http";
         goto validSocket;
       case config::Socket::HTTPS: {
+        isHttp = true;
         auto https = sock.getHttps();
         defaultPort = 443;
         httpOptions = https.getOptions();
         tls = makeTlsContext(https.getTlsOptions());
         physicalProtocol = "https";
+        goto validSocket;
+      }
+      case config::Socket::TCP: {
+        isHttp = false;
+        auto tcp = sock.getTcp();
+        // No default port
+        // No physical protocol mention here.
+        if (tcp.hasTlsOptions()) {
+          tls = makeTlsContext(tcp.getTlsOptions());
+        }
         goto validSocket;
       }
     }
@@ -3665,27 +3774,47 @@ kj::Promise<void> Server::listenOnSockets(config::Config::Reader config,
       })(kj::mv(listener), kj::mv(t));
     }
 
-    // Need to create rewriter before waiting on anything since `headerTableBuilder` will no longer
-    // be available later.
+    // Need to create rewriter before waiting on anything since `headerTableBuilder` will
+    // no longer be available later.
     auto rewriter = kj::heap<HttpRewriter>(httpOptions, headerTableBuilder);
 
-    auto handle = kj::coCapture(
-        [this, &service, rewriter = kj::mv(rewriter), physicalProtocol, name]
-        (kj::Promise<kj::Own<kj::ConnectionReceiver>> promise)
-            mutable -> kj::Promise<void> {
-      TRACE_EVENT("workerd", "setup listenHttp");
-      auto listener = co_await promise;
-      KJ_IF_SOME(stream, controlOverride) {
-        auto message = kj::str("{\"event\":\"listen\",\"socket\":\"", name, "\",\"port\":", listener->getPort(), "}\n");
-        try {
-          stream->write(message.asBytes());
-        } catch (kj::Exception& e) {
-          KJ_LOG(ERROR, e);
+    if (isHttp) {
+      auto handle = kj::coCapture(
+          [this, &service, rewriter = kj::mv(rewriter), physicalProtocol, name]
+          (kj::Promise<kj::Own<kj::ConnectionReceiver>> promise)
+              mutable -> kj::Promise<void> {
+        TRACE_EVENT("workerd", "setup listenHttp");
+        auto listener = co_await promise;
+        KJ_IF_SOME(stream, controlOverride) {
+          auto message = kj::str("{\"event\":\"listen\",\"socket\":\"", name, "\",\"port\":", listener->getPort(), "}\n");
+          try {
+            stream->write(message.asBytes());
+          } catch (kj::Exception& e) {
+            KJ_LOG(ERROR, e);
+          }
         }
-      }
-      co_await listenHttp(kj::mv(listener), service, physicalProtocol, kj::mv(rewriter));
-    });
-    tasks.add(handle(kj::mv(listener)).exclusiveJoin(forkedDrainWhen.addBranch()));
+        co_await listenHttp(kj::mv(listener), service, physicalProtocol, kj::mv(rewriter));
+      });
+      tasks.add(handle(kj::mv(listener)).exclusiveJoin(forkedDrainWhen.addBranch()));
+    } else {
+      auto handle = kj::coCapture(
+          [this,&service, rewriter = kj::mv(rewriter), name]
+          (kj::Promise<kj::Own<kj::ConnectionReceiver>> promise)
+              mutable -> kj::Promise<void> {
+        TRACE_EVENT("workerd", "setup listenTcp");
+        auto listener = co_await promise;
+        KJ_IF_SOME(stream, controlOverride) {
+          auto message = kj::str("{\"event\":\"listen\",\"socket\":\"", name, "\",\"port\":", listener->getPort(), "}\n");
+          try {
+            stream->write(message.asBytes());
+          } catch (kj::Exception& e) {
+            KJ_LOG(ERROR, e);
+          }
+        }
+        co_await listenTcp(kj::mv(listener), service, kj::mv(rewriter));
+      });
+      tasks.add(handle(kj::mv(listener)).exclusiveJoin(forkedDrainWhen.addBranch()));
+    }
   }
 
   for (auto& unmatched: socketOverrides) {

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -207,6 +207,9 @@ private:
   kj::Promise<void> listenHttp(kj::Own<kj::ConnectionReceiver> listener, Service& service,
                                kj::StringPtr physicalProtocol, kj::Own<HttpRewriter> rewriter);
 
+  kj::Promise<void> listenTcp(kj::Own<kj::ConnectionReceiver> listener, Service& service,
+                              kj::Own<HttpRewriter> rewriter);
+
   class InvalidConfigService;
   class ExternalHttpService;
   class ExternalTcpService;
@@ -215,6 +218,7 @@ private:
   class WorkerService;
   class WorkerEntrypointService;
   class HttpListener;
+  class TcpListener;
 
   void startServices(jsg::V8System& v8System, config::Config::Reader config,
                      kj::HttpHeaderTable::Builder& headerTableBuilder,

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -118,6 +118,9 @@ struct Socket {
       options @3 :HttpOptions;
       tlsOptions @4 :TlsOptions;
     }
+    tcp :group {
+      tlsOptions @6 :TlsOptions;
+    }
 
     # TODO(someday): TCP, TCP proxy, SMTP, Cap'n Proto, ...
   }

--- a/src/workerd/util/stream-utils.c++
+++ b/src/workerd/util/stream-utils.c++
@@ -208,7 +208,7 @@ kj::Own<NeuterableInputStream> newNeuterableInputStream(kj::AsyncInputStream& in
 }
 
 kj::Own<NeuterableIoStream> newNeuterableIoStream(kj::AsyncIoStream& inner) {
-  return kj::heap<NeuterableIoStreamImpl>(inner);
+  return kj::refcounted<NeuterableIoStreamImpl>(inner);
 }
 
 }  // namespace workerd

--- a/src/workerd/util/stream-utils.h
+++ b/src/workerd/util/stream-utils.h
@@ -18,7 +18,8 @@ public:
   virtual void neuter(kj::Exception ex) = 0;
 };
 
-class NeuterableIoStream: public kj::AsyncIoStream {
+class NeuterableIoStream: public kj::AsyncIoStream,
+                          public kj::Refcounted {
 public:
   virtual void neuter(kj::Exception ex) = 0;
 };


### PR DESCRIPTION
Implement a subset of the `node:net` and `node:tls` modules supporting `net.Socket`, `tls.TLSSocket`, `net.BlockList`, and `net.SocketAddress`. The `net.Server` and `tls.TLSServer` types are explicitly unsupported and won't be implemented.

**Update: The key next step on this is implementing tests... Folks should feel free to start performing code review on the main piece. If folks would like a walkthrough to help with the code review, let me know**

Very rough todo list: 

* [x] Get it basically working ... ;-) ... basic implementation of the core functions. Difficult to delineate all the specific tasks involved here.
  * [x] `net.connect(...)` creates the Socket, normalizes the arguments, and forwards the args to `socket.connect(...)`
  * [x] `socket.connect(...)` validates the input arguments, initiates the underlying socket connection 
  * [x] `new Socket([options])` works
    * [x] `options.allowHalfOpen` works and passes through to the underlying `Socket`
    * [x] `options.fd` throws an error if set
    * [x] `options.readable` is ignored since `options.fd` is unsupported
    * [x] `options.writable` is ignored since `options.fd` in unsupported
    * [x] `options.signal` sets an `AbortSignal` that destroys the `net.Socket` when triggered  
    * [x] ~~Setting `options.handle` to an existing standard `Socket` instance should wrap that socket~~ Will implement this separately as it's not critical for immediate compat in the short term
  * [x] Initialize and establish the connection
  * [x] `connect` and `ready` events are emitted when the connection is opened
  * [x] `close` event is emitted when destroy is called
  * [x] `close` event `hadError` argument is true when destroy is called with an error
  * [x] `error` event is emitted when destroy is called with an error
  * [x] destroy is called with an error when attempt to establish a connection fails
  * [x] `connectionAttempt` event is emitted when initializing a connection
  * [x] `connectionAttemptFailed` event is emitted when initializing a connection fails
  * [x] `connectionAttemptTimeout` event will not be emitted since the family autoselection  feature is not implemented
  * [x]  The `addressType` argument in the `connectAttempt` and `connectionAttmptFailed` events is the correct type
  * [x] Writes while connecting are buffered until connection established, then buffered writes are flushed
  * [x] Writev works
  * [x] Writes can be corked/uncorked any time
  * [x] Writes can be encoded strings or TypedArrays, other types throw
  * [x] Individual write callbacks are called. Error argument is set appropriately when write fails
  * [x] Calling `end()` closes the connection
  * [x] The `drain` event is emitted when the write buffer is empty 
  * [x] When `end()` is called, buffered data in the readable side is still avaialble
  * [x] If `options.lookup` is provided and destination address is not an IP address, the `options.lookup` function should be called to "resolve" the address. (optional... we could just as easily choose not to support `options.lookup`)
  * [x] The `lookup` event is emitted after the `options.lookup` is called and returns a result
  * [x] Underlying reader on the socket is a BYOB reader reusing the user provided buffer or our auto allocated buffer
  * [x] An error while reading from the underlying socket causes the `net.Socket` to be destroyed with an error
  * [x] The `net.Socket` can have a `read` event attached putting the stream in flowing mode
  * [x] If the `read` event is attached while the connection is still pending, the `read` will automatically start when the connection is established.
  * [x] The stream can be paused/resumed to stop/restart the flow of data
  * [x] Attempting to connect to a pipe path fails
  * [x] The `data` event is emitted when a chunk of data has been read
  * [x] The `end` event is emitted when the underlying stream readable side is done
  * [x] Reading honors backpressure signaling by pausing
  * [x] Receiving and EOS from the remote should end the readable side of the stream. If `allowHalfOpen` is false, this should close and destroy the socket ONLY once the write buffer is drained. If `allowHalfOpen` is true, it should not.
  * [x] `socket.setTimeout(...)` sets an activity timer on the socket.
  * [x] The socket timeout is reset on writes, reads, and when the connection is established.
  * [x] The `timeout` event is emitted when the activity timeout expires.
  * [x] `socket.address()` returns the local address if the socket is connected, undefined otherwise... we hard code this to `0.0.0.0:0` since we have no notion of a local bound address in workers
  * [x] `socket.autoSelectFamilyAttemptedAddresses` is always an array, when connect is called, it always just contains the one address we're connecting to. This is generally non-op since we do not implement family autoselection
  * [x] `socket.bufferSize` returns the number of bytes buffered
  * [x] `socket.bytesRead` returns the number of bytes read
  * [x] `socket.bytesWritten` returns the number of bytes written
  * [x] `socket.connect(options[, connectListener])` works
    * [x]  Passing an ipv6 address works
    * [x]  `options.autoSelectFamily` only accepts a falsy value. truthy values throw
    * [x] `options.autoSelectFamilyAttemptTimeout` is validated to be a number but is otherwise ignored
    * [x] `options.family` is verified to match the `host` specified
    * [x] `options.hints` is ignored unless `options.lookup` is given, then it is passed to that function when called
    * [x] `options.host` is the address to connect to. Defaults to `localhost`.
    * [x] `options.keepAlive` only falsy values are accepted. Truthy values throw
    * [x] `options.keepAliveInitialDelay` is validated to be a number but is otherwise ignored
    * [x] `options.localAddress` is ignored
    * [x] `options.localPort` is ignored
    * [x] `options.lookup` is used if the `host` is not a valid IP address
    * [x] `options.noDelay` falsy values are accepted. Truthy values throw 
    * [x] `options.port` is validated to be a proper port
    * [x] `options.path` throws
    * [x] `options.onread` is used if specified 
  * [x] `socket.connect(path[, connectListener])` throws
  * [x] `socket.connect(port[, host[, connectListener])` works
  * [x] `socket.connecting` is true while the connection is being established. Is false otherwise
  * [x] `socket.destroy(error)` immediately destroys the stream and closes the connection
    * [x]  All underlying resources are freed
  * [x] ~`socket.connect(...)` can be called again immediately after `socket.destroy(...)`~ Currently not planning to implement this for now. We can do this in a separate PR.
  * [x] `socket.destroyed` is true after calling `socket.destroy()`
  * [x] `socket.destroySoon()` destroys the socket after all data is written. If the `finish` event already emitted, the socket is destroyed immediately. If the socket is still writable, `end()` is called.
  * [x] `socket.end(data[, encoding[, callback]])` writes the given chun and ends the writable size and half-closes the socket
  * [x] `socket.localAddress` always returns `0.0.0.0`
  * [x] `socket.localPort` always returns `0`
  * [x] `socket.localFamily` always returns `0`
  * [x] `socket.pause()` pauses reading of data on the stream. Pauses the underlying read loop
  * [x] `socket.pending` is `true` if the socket is not connected yet at all
  * [x] `socket.ref()` and `socket.unref()` are non-op
  * [x] `socket.remoteAddress` is the remote host
  * [x] `socket.remoteFamily` is the remote host IP type
  * [x] `socket.remotePort` is the remote port
  * [x] `socket.resetAndDestroy()` closes the connection and destroys the stream. 
  * [x] `socket.resume()` resumes reading after a call to pause
  * [x] `socket.setEncoding(...)` sets the text encoding for the readable side of the socket
  * [x] `socket.setKeepAlive()` accepts falsy values, throws on truthy values
  * [x] `socket.setNoDelay()` accepts falsy values, throws on truthy values
  * [x] `socket.readyState` accurately reflects the ready status of the connection
  * [x] The timeout timer is reset after each read from the underlying socket
* [x] Add the compat flag / date that will signal the availability of the net API`
* [x] Tests test and more tests ... The plan is to port as many of the Node.js tests as possible but testing of the `Socket` API within workerd is fairly limited currently
* [ ] Documentation

Future work items (to come in separate follow-up PRs
* `tls.TLSSocket` is implemented
* `net.BlockList` is implemented
* `net.SocketAddress` is implemented
* Socket supports diagnostics channel
* AsyncLocalStorage context is correctly propagated such that it matches Node.js' behavior (will needs tests to verify this)
