### PR TITLE
VS-197: Add new type for Vectorize v2 insert response

### DIFF
--- a/src/cloudflare/internal/vectorize.d.ts
+++ b/src/cloudflare/internal/vectorize.d.ts
@@ -134,6 +134,17 @@ interface VectorizeVectorMutation {
   count: number;
 }
 
+/**
+* Results of an operation that performed a mutation on a set of vectors
+* with the v2 version of Vectorize.
+* Here, `mutationId` is the identifier for the last mutation processed by Vectorize.
+*/
+interface VectorizeVectorMutationV2 {
+  /* The identifier for the last mutation processed by Vectorize. */
+  mutationId: string;
+}
+
+
 declare abstract class VectorizeIndex {
   /**
    * Get information about the currently bound index.

--- a/types/defines/vectorize.d.ts
+++ b/types/defines/vectorize.d.ts
@@ -126,6 +126,16 @@ interface VectorizeVectorMutation {
   count: number;
 }
 
+/**
+* Results of an operation that performed a mutation on a set of vectors
+* with the v2 version of Vectorize.
+* Here, `mutationId` is the identifier for the last mutation processed by Vectorize.
+*/
+interface VectorizeVectorMutationV2 {
+  /* The identifier for the last mutation processed by Vectorize. */
+  mutationId: string;
+}
+
 declare abstract class VectorizeIndex {
   /**
    * Get information about the currently bound index.


### PR DESCRIPTION
Add the new type definition for Vectorize v2 insert/upsert response. This would be used to enable v2 operations in wrangler by making the new type available in workers-sdk.