### PR TITLE
Remove unused waitUntilTasks fields

### DIFF
--- a/src/workerd/api/hibernatable-web-socket.c++
+++ b/src/workerd/api/hibernatable-web-socket.c++
@@ -213,13 +213,13 @@ HibernatableWebSocketCustomEventImpl::HibernatableWebSocketCustomEventImpl(
     kj::TaskSet& waitUntilTasks,
     kj::Own<HibernationReader> params,
     kj::Maybe<Worker::Actor::HibernationManager&> manager)
-  : typeId(typeId), waitUntilTasks(waitUntilTasks), params(kj::mv(params)) {}
+  : typeId(typeId), params(kj::mv(params)) {}
 HibernatableWebSocketCustomEventImpl::HibernatableWebSocketCustomEventImpl(
     uint16_t typeId,
     kj::TaskSet& waitUntilTasks,
     HibernatableSocketParams params,
     Worker::Actor::HibernationManager& manager)
-  : typeId(typeId), waitUntilTasks(waitUntilTasks), params(kj::mv(params)), manager(manager) {}
+  : typeId(typeId), params(kj::mv(params)), manager(manager) {}
 
 HibernatableSocketParams HibernatableWebSocketCustomEventImpl::consumeParams() {
   KJ_IF_SOME(p, params.tryGet<kj::Own<HibernationReader>>()) {

--- a/src/workerd/api/hibernatable-web-socket.h
+++ b/src/workerd/api/hibernatable-web-socket.h
@@ -90,7 +90,6 @@ private:
   HibernatableSocketParams consumeParams();
 
   uint16_t typeId;
-  kj::TaskSet& waitUntilTasks;
   kj::OneOf<HibernatableSocketParams, kj::Own<HibernationReader>> params;
   kj::Maybe<uint32_t> timeoutMs;
   kj::Maybe<Worker::Actor::HibernationManager&> manager;

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -589,7 +589,7 @@ class TraceCustomEventImpl final: public WorkerInterface::CustomEvent {
 public:
   TraceCustomEventImpl(
       uint16_t typeId, kj::TaskSet& waitUntilTasks, kj::Array<kj::Own<Trace>> traces)
-    : typeId(typeId), waitUntilTasks(waitUntilTasks), traces(kj::mv(traces)) {}
+    : typeId(typeId), traces(kj::mv(traces)) {}
 
   kj::Promise<Result> run(
       kj::Own<IoContext::IncomingRequest> incomingRequest,
@@ -608,7 +608,6 @@ public:
 
 private:
   uint16_t typeId;
-  kj::TaskSet& waitUntilTasks;
   kj::Array<kj::Own<workerd::Trace>> traces;
 };
 


### PR DESCRIPTION
Should resolve unused field warnings.

---

Apparently unused since the `waitUntilTasks` method parameters were added in d1275703d.  More work could be done to clean up the now-unused constructor parameters, but this at least resolves the build warnings.