### PR TITLE
Python: Fix fetching external packages loadBundle

### DIFF
--- a/src/pyodide/internal/loadPackage.js
+++ b/src/pyodide/internal/loadPackage.js
@@ -33,7 +33,7 @@ async function loadBundle(requirement) {
   const url = new URL(WORKERD_INDEX_URL + filename);
   const response = await fetch(url);
 
-  const compressed = response.body.arrayBuffer();
+  const compressed = await response.arrayBuffer();
   const decompressed = await decompressArrayBuffer(compressed);
 
   DiskCache.put(filename, compressed);


### PR DESCRIPTION
Fix for "Python: Fetch error while loading external packages #2229"

`response.body.arrayBuffer()` to `response.arrayBuffer()`