### PR TITLE
Adds more information to script will never generate a response errors

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1152,6 +1152,12 @@ auto IoContext::tryGetWeakRefForCurrent() -> kj::Maybe<kj::Own<WeakRef>> {
   }
 }
 
+static constexpr auto scriptWillNeverGenerateResponseErr =
+    "The script will never generate a response. Request response relies on "
+    "a Promise that will never be resolved during the Request's lifetime. "
+    "For more information go to "
+    "https://developers.cloudflare.com/workers/errors/script-will-never-generate-a-response";
+
 void IoContext::runFinalizers(Worker::AsyncLock& asyncLock) {
   KJ_ASSERT(actor == kj::none);  // we don't finalize actor requests
 
@@ -1163,8 +1169,7 @@ void IoContext::runFinalizers(Worker::AsyncLock& asyncLock) {
     // Don't bother fulfilling `abortFulfiller` if limits were exceeded because in that case the
     // abort promise will be fulfilled shortly anyway.
     if (limitEnforcer->getLimitsExceeded() == kj::none) {
-      abortFulfiller->reject(JSG_KJ_EXCEPTION(FAILED, Error,
-          "The script will never generate a response."));
+      abortFulfiller->reject(JSG_KJ_EXCEPTION(FAILED, Error, scriptWillNeverGenerateResponseErr));
     }
   }
 


### PR DESCRIPTION
Adds a bit more information to the logs for "script will never generate a response" including a URL to upcoming docs.

This should only be merged after [the docs changes here](https://github.com/cloudflare/cloudflare-docs/pull/15014) get in.