### PR TITLE
Implement new bytes() method for Blob and Body objects

### DIFF
--- a/src/workerd/api/blob.c++
+++ b/src/workerd/api/blob.c++
@@ -195,6 +195,11 @@ jsg::Promise<kj::Array<kj::byte>> Blob::arrayBuffer(jsg::Lock& js) {
   // TODO(perf): Find a way to avoid the copy.
   return js.resolvedPromise(kj::heapArray<byte>(data));
 }
+
+jsg::Promise<jsg::BufferSource> Blob::bytes(jsg::Lock& js) {
+  return js.resolvedPromise(js.bytes(kj::heapArray<byte>(data)));
+}
+
 jsg::Promise<kj::String> Blob::text(jsg::Lock& js) {
   return js.resolvedPromise(kj::str(data.asChars()));
 }

--- a/src/workerd/api/blob.h
+++ b/src/workerd/api/blob.h
@@ -41,6 +41,7 @@ public:
                         jsg::Optional<kj::String> type);
 
   jsg::Promise<kj::Array<kj::byte>> arrayBuffer(jsg::Lock& js);
+  jsg::Promise<jsg::BufferSource> bytes(jsg::Lock& js);
   jsg::Promise<kj::String> text(jsg::Lock& js);
   jsg::Ref<ReadableStream> stream();
 
@@ -55,8 +56,13 @@ public:
 
     JSG_METHOD(slice);
     JSG_METHOD(arrayBuffer);
+    JSG_METHOD(bytes);
     JSG_METHOD(text);
     JSG_METHOD(stream);
+
+    JSG_TS_OVERRIDE({
+      bytes(): Promise<Uint8Array>;
+    });
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -782,6 +782,13 @@ jsg::Promise<kj::Array<byte>> Body::arrayBuffer(jsg::Lock& js) {
   // See https://fetch.spec.whatwg.org/#concept-body-consume-body
   return js.resolvedPromise(kj::Array<byte>());
 }
+
+jsg::Promise<jsg::BufferSource> Body::bytes(jsg::Lock& js) {
+  return arrayBuffer(js).then(js, [](jsg::Lock& js, kj::Array<kj::byte> data) {
+    return js.bytes(kj::mv(data));
+  });
+}
+
 jsg::Promise<kj::String> Body::text(jsg::Lock& js) {
   KJ_IF_SOME(i, impl) {
     return js.evalNow([&] {

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -361,6 +361,7 @@ public:
   kj::Maybe<jsg::Ref<ReadableStream>> getBody();
   bool getBodyUsed();
   jsg::Promise<kj::Array<byte>> arrayBuffer(jsg::Lock& js);
+  jsg::Promise<jsg::BufferSource> bytes(jsg::Lock& js);
   jsg::Promise<kj::String> text(jsg::Lock& js);
   jsg::Promise<jsg::Ref<FormData>> formData(jsg::Lock& js);
   jsg::Promise<jsg::Value> json(jsg::Lock& js);
@@ -375,6 +376,7 @@ public:
       JSG_READONLY_INSTANCE_PROPERTY(bodyUsed, getBodyUsed);
     }
     JSG_METHOD(arrayBuffer);
+    JSG_METHOD(bytes);
     JSG_METHOD(text);
     JSG_METHOD(json);
     JSG_METHOD(formData);
@@ -383,7 +385,10 @@ public:
     JSG_TS_DEFINE(type BodyInit = ReadableStream<Uint8Array> | string | ArrayBuffer | ArrayBufferView | Blob | URLSearchParams | FormData);
     // All type aliases get inlined when exporting RTTI, but this type alias is included by
     // the official TypeScript types, so users might be depending on it.
-    JSG_TS_OVERRIDE({ json<T>(): Promise<T>; });
+    JSG_TS_OVERRIDE({
+      json<T>(): Promise<T>;
+      bytes(): Promise<Uint8Array>;
+    });
     // Allow JSON body type to be specified
   }
 

--- a/src/workerd/api/tests/blob2-test.js
+++ b/src/workerd/api/tests/blob2-test.js
@@ -2,8 +2,11 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { strictEqual } from 'node:assert';
-import { inspect } from 'node:util';
+import {
+  ok,
+  strictEqual,
+  deepStrictEqual,
+} from 'node:assert';
 
 export const test = {
   async test() {
@@ -20,5 +23,20 @@ export const test = {
 
     strictEqual(await blob.text(), 'test');
     strictEqual(blob.type, 'text/html');
+  }
+};
+
+export const bytes = {
+  async test() {
+    const check = new Uint8Array([116, 101, 115, 116]);
+    const blob = new Blob(['test']);
+    const u8 = await blob.bytes();
+    deepStrictEqual(u8, check);
+    ok(u8 instanceof Uint8Array);
+
+    const res = new Response('test');
+    const u8_2 = await res.bytes();
+    deepStrictEqual(u8_2, check);
+    ok(u8_2 instanceof Uint8Array);
   }
 };


### PR DESCRIPTION
Refs: https://fetch.spec.whatwg.org/#body-mixin
Refs: https://w3c.github.io/FileAPI/#dfn-Blob

The `bytes()` method was recently added to `Blob` and the `Body` mixin.