### PR TITLE
Fix connect() SocketOptions type

### DIFF
--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -51,6 +51,9 @@ struct SocketOptions {
   JSG_MEMORY_INFO(SocketOptions) {
     tracker.trackField("secureTransport", secureTransport);
   }
+  JSG_STRUCT_TS_OVERRIDE({
+    secureTransport?: "off" | "on" | "starttls";
+  });
 };
 
 struct TlsOptions {


### PR DESCRIPTION
Hi :wave:,

I noticed that while the internal sockets type definitions https://github.com/cloudflare/workerd/blob/main/src/cloudflare/internal/sockets.d.ts and docs https://developers.cloudflare.com/workers/runtime-apis/tcp-sockets/#socketoptions
both type `secureTransport` as a proper enum, and say `allowHalfOpen` is optional, the generated types don't reflect this: https://workers-types.pages.dev/4.20240605.0/#SocketOptions

This PR is my attempt to fix this, although unlike my previous types fixes, this one was one bit more complicated so if it's using the wrong macro or missing a semicolon, apologies, I'll happily fix - compiling didn't work locally so my only source of confidence is the GH Action run on my fork.

Additionally, I found that somehow the copyright and license comment from only `vectorize.d.ts` is included: see just below https://workers-types.pages.dev/4.20240605.0/#webSocketError.connect, and while this is by no means important, it's annoying me that I couldn't yet find the reason.