### PR TITLE
Work around actions/runner-images#10004

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,8 @@ jobs:
         run: |
           # Set a custom output root directory to avoid long file name issues.
           [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
+          [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'build:windows --copt=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR --host_copt=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR')
+          choco upgrade llvm --version=17.0.6
       - name: Configure download mirrors
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,9 @@ jobs:
         # Set a custom output root directory to avoid long file name issues.
         run: |
           [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
+          # Work around https://github.com/actions/runner-images/issues/10004
+          [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'build:windows --copt=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR --host_copt=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR')
+          choco upgrade llvm --version=17.0.6
       - name: Configure download mirrors
         shell: bash
         run: |


### PR DESCRIPTION
The updated runner image uses an MSVC version that expects LLVM 17, but the image has LLVM 16 still, leaving it in a broken state. Manually install 17 as a workaround.