### PR TITLE
Allow fts5vocab module (#1540)

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -356,7 +356,7 @@ async function test(storage) {
   assert.throws(() => sql.exec('SAVEPOINT foo'), /not authorized/)
 
   // Virtual tables
-  // Only fts5 module is allowed
+  // Only fts5 and fts5vocab modules are allowed
   assert.throws(
     () => sql.exec(`CREATE VIRTUAL TABLE test_fts USING fts5abcd(id);`),
     /not authorized/
@@ -371,9 +371,18 @@ async function test(storage) {
     );
   `)
 
-  // Module name is case-insensitive
+  // Module names are case-insensitive
   sql.exec(`
     CREATE VIRTUAL TABLE documents_fts USING FtS5(id, title, content, tokenize = porter);
+  `)
+  sql.exec(`
+    CREATE VIRTUAL TABLE documents_fts_v_col USING fTs5VoCaB(documents_fts, col);
+  `)
+  sql.exec(`
+    CREATE VIRTUAL TABLE documents_fts_v_row USING FtS5vOcAb(documents_fts, row);
+  `)
+  sql.exec(`
+    CREATE VIRTUAL TABLE documents_fts_v_instance USING fTs5VoCaB(documents_fts, instance);
   `)
 
   sql.exec(`
@@ -498,10 +507,10 @@ async function test(storage) {
         )
       )[0].data
     )
-    assert.equal(jsonResult.length, 8)
+    assert.equal(jsonResult.length, 11)
     assert.equal(
       jsonResult.map((r) => r.name).join(','),
-      'myTable,documents,documents_fts,documents_fts_data,documents_fts_idx,documents_fts_content,documents_fts_docsize,documents_fts_config'
+      'myTable,documents,documents_fts,documents_fts_data,documents_fts_idx,documents_fts_content,documents_fts_docsize,documents_fts_config,documents_fts_v_col,documents_fts_v_row,documents_fts_v_instance'
     )
     assert.equal(jsonResult[0].columns.foo, 'TEXT')
     assert.equal(jsonResult[0].columns.bar, 'INTEGER')

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -686,10 +686,12 @@ bool SqliteDatabase::isAuthorized(int actionCode,
 
     case SQLITE_CREATE_VTABLE      :   /* Table Name      Module Name     */
     case SQLITE_DROP_VTABLE        :   /* Table Name      Module Name     */
-      // Virtual tables are tables backed by some native-code callbacks. We don't support these except for FTS5 (Full Text Search) https://www.sqlite.org/fts5.html
+      // Virtual tables are tables backed by some native-code callbacks.
+      // We don't support these except for FTS5 (Full Text Search) https://www.sqlite.org/fts5.html
+      // (Which also includes fts5vocab: "[fts5vocab] is available whenever FTS5 is")
       {
         KJ_IF_SOME (moduleName, param2) {
-          if (strcasecmp(moduleName.begin(), "fts5") == 0) {
+          if (strcasecmp(moduleName.begin(), "fts5") == 0 || strcasecmp(moduleName.begin(), "fts5vocab") == 0) {
             return true;
           }
         }


### PR DESCRIPTION
This module was inadvertently missed in the original allow list – it's a standard part of of FTS5. As per the docs:

> The fts5vocab module is a part of FTS5 - it is available whenever FTS5 is.

https://www.sqlite.org/fts5.html#the_fts5vocab_virtual_table_module