### PR TITLE
[CI] Make Windows build work with updated GitHub Actions image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
           # Set a custom output root directory to avoid long file name issues.
           [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
           [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'build:windows --copt=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR --host_copt=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR')
-          choco upgrade llvm --version=17.0.6
+          choco upgrade llvm --allow-downgrade --version=17.0.6
       - name: Configure download mirrors
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,9 +99,10 @@ jobs:
         # Set a custom output root directory to avoid long file name issues.
         run: |
           [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
-          # Work around https://github.com/actions/runner-images/issues/10004
+          # TODO(cleanup): Work around https://github.com/actions/runner-images/issues/10004. Drop
+          # this after the updated image has been fully rolled out.
           [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'build:windows --copt=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR --host_copt=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR')
-          choco upgrade llvm --version=17.0.6
+          choco upgrade llvm --allow-downgrade --version=17.0.6
       - name: Configure download mirrors
         shell: bash
         run: |


### PR DESCRIPTION
Follow-up to #2248. The upgraded image uses a higher LLVM version by default, causing the upgrade action to be rejected. We don't actually need to downgrade in that case, but this allows us to support both the old and the new image.