### PR TITLE
Implements cloudflare:workers compatFlags API

### DIFF
--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -11,3 +11,9 @@ export const WorkerEntrypoint = entrypoints.WorkerEntrypoint;
 export const DurableObject = entrypoints.DurableObject;
 export const RpcStub = entrypoints.RpcStub;
 export const RpcTarget = entrypoints.RpcTarget;
+
+/* eslint-disable */
+import { default as flags } from 'workerd:compatibility-flags';
+export const compatFlags = (flags as any).compatFlags;
+Object.freeze(compatFlags);
+/* eslint-enable */

--- a/src/workerd/api/tests/compat-flags-test.js
+++ b/src/workerd/api/tests/compat-flags-test.js
@@ -1,0 +1,23 @@
+import {
+  ok,
+  throws,
+} from 'node:assert';
+
+import { compatFlags } from 'cloudflare:workers';
+
+export const compatFlagsTest = {
+  test() {
+    throws(() => compatFlags.no_nodejs_compat_v2 = true);
+    throws(() => compatFlags.not_a_real_compat_flag = true);
+    ok(compatFlags['nodejs_compat_v2']);
+    ok(!compatFlags['no_nodejs_compat_v2']);
+    ok(compatFlags['url_standard']);
+    ok(!compatFlags['url_original']);
+    ok(!compatFlags['not-a-real-compat-flag']);
+    const keys = Object.keys(compatFlags);
+    ok(keys.includes('nodejs_compat_v2'));
+    ok(keys.includes('url_standard'));
+    ok(keys.includes('url_original'));
+    ok(!keys.includes('not-a-real-compat-flag'));
+  }
+}

--- a/src/workerd/api/tests/compat-flags-test.wd-test
+++ b/src/workerd/api/tests/compat-flags-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "compat-flags-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "compat-flags-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat_v2"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -58,6 +58,11 @@ void JsObject::set(Lock& js, kj::StringPtr name, const JsValue& value) {
   set(js, js.strIntern(name), value);
 }
 
+void JsObject::setReadOnly(Lock& js, kj::StringPtr name, const JsValue& value) {
+  v8::Local<v8::String> nameStr = js.strIntern(name);
+  check(inner->DefineOwnProperty(js.v8Context(), nameStr, value, v8::ReadOnly));
+}
+
 JsValue JsObject::get(Lock& js, const JsValue& name) {
   return JsValue(check(inner->Get(js.v8Context(), name.inner)));
 }

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -329,6 +329,7 @@ public:
 
   void set(Lock& js, const JsValue& name, const JsValue& value);
   void set(Lock& js, kj::StringPtr name, const JsValue& value);
+  void setReadOnly(Lock& js, kj::StringPtr name, const JsValue& value);
   JsValue get(Lock& js, const JsValue& name) KJ_WARN_UNUSED_RESULT;
   JsValue get(Lock& js, kj::StringPtr name) KJ_WARN_UNUSED_RESULT;
 


### PR DESCRIPTION
A simple built-in module and API for determining if a given compat flag is set.

```
import { compatFlags } from 'cloudflare:workers'

// Any of the enable/disable flag names can be passed here.
// Invalid values come out as `undefined`.
console.log(compatFlags['url_standard']);
console.log(compatFlags['url_original']);
```

Having an API for this is something we've discussed a few times.

Note that this only works with ESM syntax workers given that it requires the module registry.