### PR TITLE
rename the new compatFlags API to compatibilityFlags

### DIFF
--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -14,6 +14,6 @@ export const RpcTarget = entrypoints.RpcTarget;
 
 /* eslint-disable */
 import { default as flags } from 'workerd:compatibility-flags';
-export const compatFlags = (flags as any).compatFlags;
-Object.freeze(compatFlags);
+export const compatibilityFlags = (flags as any).compatFlags;
+Object.freeze(compatibilityFlags);
 /* eslint-enable */

--- a/src/workerd/api/tests/compat-flags-test.js
+++ b/src/workerd/api/tests/compat-flags-test.js
@@ -3,18 +3,18 @@ import {
   throws,
 } from 'node:assert';
 
-import { compatFlags } from 'cloudflare:workers';
+import { compatibilityFlags } from 'cloudflare:workers';
 
 export const compatFlagsTest = {
   test() {
-    throws(() => compatFlags.no_nodejs_compat_v2 = true);
-    throws(() => compatFlags.not_a_real_compat_flag = true);
-    ok(compatFlags['nodejs_compat_v2']);
-    ok(!compatFlags['no_nodejs_compat_v2']);
-    ok(compatFlags['url_standard']);
-    ok(!compatFlags['url_original']);
-    ok(!compatFlags['not-a-real-compat-flag']);
-    const keys = Object.keys(compatFlags);
+    throws(() => compatibilityFlags.no_nodejs_compat_v2 = true);
+    throws(() => compatibilityFlags.not_a_real_compat_flag = true);
+    ok(compatibilityFlags['nodejs_compat_v2']);
+    ok(!compatibilityFlags['no_nodejs_compat_v2']);
+    ok(compatibilityFlags['url_standard']);
+    ok(!compatibilityFlags['url_original']);
+    ok(!compatibilityFlags['not-a-real-compat-flag']);
+    const keys = Object.keys(compatibilityFlags);
     ok(keys.includes('nodejs_compat_v2'));
     ok(keys.includes('url_standard'));
     ok(keys.includes('url_original'));


### PR DESCRIPTION
Had an additional review comment come in just after merging. Let's get this one in now before I pull the change into the internal repo