### PR TITLE
[CI] Remove Windows CI image workaround

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,6 @@ jobs:
         run: |
           # Set a custom output root directory to avoid long file name issues.
           [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
-          [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'build:windows --copt=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR --host_copt=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR')
-          choco upgrade llvm --allow-downgrade --version=17.0.6
       - name: Configure download mirrors
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,10 +99,6 @@ jobs:
         # Set a custom output root directory to avoid long file name issues.
         run: |
           [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=C:/tmp')
-          # TODO(cleanup): Work around https://github.com/actions/runner-images/issues/10004. Drop
-          # this after the updated image has been fully rolled out.
-          [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'build:windows --copt=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR --host_copt=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR')
-          choco upgrade llvm --allow-downgrade --version=17.0.6
       - name: Configure download mirrors
         shell: bash
         run: |


### PR DESCRIPTION
The issue has been fixed in actions/runner-images#10014, which has been fully deployed since. Since this issue happened the last time LLVM was updated within MSVC, our build might be broken again without warning the next time too.