### PR TITLE
Add builtin repl module

### DIFF
--- a/src/cloudflare/repl.ts
+++ b/src/cloudflare/repl.ts
@@ -1,0 +1,23 @@
+//@ts-ignore
+import { default as Stdin } from "workerd:stdin";
+//@ts-ignore
+import { default as UnsafeEval } from "internal:unsafe-eval";
+
+// https://vane.life/2016/04/03/eval-locally-with-persistent-context/
+var __EVAL = (s: string) => UnsafeEval.eval(`void (__EVAL = ${__EVAL.toString()}); ${s}`);
+
+function evaluate(expr: string) {
+    try {
+        const result = __EVAL(expr);
+        console.log(result);
+    } catch(err: any) {
+        console.log(expr, 'ERROR:', err.message);
+    }
+}
+
+export default function repl() {
+  while(true) {
+    const query: string = Stdin.getline();
+    evaluate(query);
+  }
+}


### PR DESCRIPTION
The goal of a REPL is to make experimenting with bindings & workerd APIs easier for developers. 

We envision the system working like:
```
wrangler dev --repl ...
```

When the `--repl` flag is passed in, Wrangler/Miniflare will replace the main worker script with something like:
```
import { default as repl } from "cloudflare:repl";

export default {
  async fetch(req, env) {
    repl();
  }
};
```

The understanding is that the REPL that is launched will have the same bindings & setup as the worker that would have been launched by `wrangler dev`. 

Here's how you can experiment with it right now:
1. Replace `samples/helloworld_esm/worker.js` with the above script
2. `./bazel-bin/src/workerd/server/workerd serve samples/helloworld_esm/config.capnp`
3. In another terminal window, `curl http://localhost:8080`
4. In the first terminal window, there should be an REPL now. 

TODO: 
- This current mechanism would have miniflare to create a fake GET request to trigger the fetch() endpoint. Is there some less clunky way to do this?
- We need to actually implement the wrangler/miniflare side of things
- We need to pass through the `env` parameter to give access to the bindings