### PR TITLE
Fix shutdown timing in inspector protocol.

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2622,6 +2622,10 @@ private:
           }
           KJ_CASE_ONEOF(close, kj::WebSocket::Close) {
             shutdown();
+            // Pause here to give transmitLoop() the chance to finish and send a reply close.
+            // When `transmitLoop()` ends, `messagePump()` as a whole will end, canceling
+            // `receiveLoop()`.
+            co_await kj::Promise<void>(kj::NEVER_DONE);
           }
         }
       }


### PR DESCRIPTION
`messagePump()` is defined as:

```
return receiveLoop().exclusiveJoin(dispatchLoop()).exclusiveJoin(transmitLoop());
```

`receiveLoop()` is responsible for receiving the final close message, and `transmitLoop()` is responsible for replying to it. This creates a race where `receiveLoop()` might receive the close message and exit before `transmitLoop()` can reply.

We can fix this by having `receiveLoop()` pause after receiving a close message. `transmitLoop()` will reply to it and then return, at which point `receiveLoop()` will be canceled anyway.