### PR TITLE
Support case-insensitive encoding in TextDecoder API (Fixes #2300)

### DIFF
--- a/src/workerd/api/encoding.c++
+++ b/src/workerd/api/encoding.c++
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "encoding.h"
+#include "util.h"
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/buffersource.h>
 #include <unicode/ucnv.h>
@@ -256,6 +257,7 @@ kj::StringPtr getEncodingId(Encoding encoding) {
 }
 
 Encoding getEncodingForLabel(kj::StringPtr label) {
+  kj::String labelInsensitive = toLower(label);
   const auto trim = [](kj::StringPtr label) {
     const auto isAsciiWhitespace = [](auto c) {
       return c == 0x09 /* tab */ ||
@@ -271,7 +273,7 @@ Encoding getEncodingForLabel(kj::StringPtr label) {
     return label.slice(start, end).asChars();
   };
 
-  auto trimmed = trim(label);
+  auto trimmed = trim(labelInsensitive);
 #define V(label, key) if (trimmed == label##_kj) return Encoding::key;
   EW_ENCODING_LABELS(V)
 #undef V

--- a/src/workerd/api/tests/encoding-test.js
+++ b/src/workerd/api/tests/encoding-test.js
@@ -577,6 +577,9 @@ export const allTheDecoders = {
       ["utf-16", "utf-16le"],
       ["utf-16le", "utf-16le"],
       ["x-user-defined", undefined],
+      // Test that match is case-insensitive
+      ["UTF-8", "utf-8"],
+      ["UtF-8", "utf-8"],
     ].forEach((pair) => {
       const [label, key] = pair;
       if (key === undefined) {


### PR DESCRIPTION
The Encoding [spec](https://encoding.spec.whatwg.org/#names-and-labels) requires that case-insensitive labels are supported.