### PR TITLE
Add ^ to pnpm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 9.1.3
+          version: ^9.1.3
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Looks like the previous change worked! Let's try this to match the version declared in `workers-sdk/package.json` so we can pick up minor & patch updates at the same time as `workers-sdk`. 