### PR TITLE
Split ActorIdFactoryImpl into a separate library for testing purposes

### DIFF
--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -78,6 +78,21 @@ wd_cc_library(
 )
 
 wd_cc_library(
+    name = "actor-id-impl",
+    srcs = [
+        "actor-id-impl.c++",
+    ],
+    hdrs = [
+        "actor-id-impl.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/workerd/io",
+        "@capnp-cpp//src/kj:kj",
+    ],
+)
+
+wd_cc_library(
     name = "server",
     srcs = [
         "server.c++",
@@ -96,6 +111,7 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":alarm-scheduler",
+        ":actor-id-impl",
         ":workerd_capnp",
         "//src/workerd/api:html-rewriter",
         "//src/workerd/api:pyodide",

--- a/src/workerd/server/actor-id-impl-test.c++
+++ b/src/workerd/server/actor-id-impl-test.c++
@@ -1,0 +1,100 @@
+// Copyright (c) 2024-2029 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include <workerd/server/actor-id-impl.h>
+#include <kj/test.h>
+#include <kj/debug.h>
+#include <kj/encoding.h>
+#include <kj/compat/gtest.h>
+#include <workerd/jsg/jsg.h>
+#include <openssl/hmac.h>
+
+
+constexpr kj::byte zero32[SHA256_DIGEST_LENGTH] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+KJ_TEST("ActorIdImpl equals test") {
+  using ActorIdImpl = workerd::server::ActorIdFactoryImpl::ActorIdImpl;
+  struct ActorEqualsTest {
+    ActorIdImpl actorLeft= {zero32, kj::none};
+    ActorIdImpl actorRight = {zero32, kj::none};
+    bool expectedResult;
+    ActorEqualsTest(kj::byte leftFill,
+      const char* leftString,
+      kj::byte rightFill,
+      const char* rightString, bool expectedResult) : expectedResult(expectedResult) {
+      kj::byte idParamCopier[SHA256_DIGEST_LENGTH];
+      memset(idParamCopier, leftFill, SHA256_DIGEST_LENGTH);
+      if(leftString == nullptr) {
+        actorLeft = ActorIdImpl(idParamCopier, kj::none);
+      } else {
+        actorLeft = ActorIdImpl(idParamCopier,
+          kj::heapString(leftString));
+      }
+      memset(idParamCopier, rightFill, SHA256_DIGEST_LENGTH);
+      if(rightString == nullptr) {
+        actorRight = ActorIdImpl(idParamCopier, kj::none);
+      } else {
+        actorRight = ActorIdImpl(idParamCopier,
+          kj::heapString(rightString));
+      }
+    }
+  };
+  using Test = ActorEqualsTest;
+  Test testCases[] = {
+    {0, nullptr, 0, nullptr, true},
+    {0, nullptr, 1, nullptr, false},
+    {0, "hello", 0, "goodbye", true},
+    {0, "hello", 1, "goodbye", false},
+    {0, "hello", 0, nullptr, true},
+    {0, "hello", 1, nullptr, false},
+  };
+  for(const auto& testCase : testCases) {
+    KJ_EXPECT(testCase.actorLeft.equals(testCase.actorRight) == testCase.expectedResult);
+  }
+}
+
+constexpr size_t BASE_LENGTH = SHA256_DIGEST_LENGTH / 2;
+kj::String computeProperTestMac(const char * strId, const char* strKey) {
+  auto id = kj::decodeHex(kj::heapString(strId));
+  KJ_ASSERT(!id.hadErrors);
+  KJ_ASSERT(id.size() == SHA256_DIGEST_LENGTH);
+  kj::byte key[SHA256_DIGEST_LENGTH];
+  auto stringPtrKey = kj::StringPtr(strKey);
+  SHA256(stringPtrKey.asBytes().begin(), stringPtrKey.size(), key);
+  kj::byte hmacOut[SHA256_DIGEST_LENGTH];
+  unsigned int len = SHA256_DIGEST_LENGTH;
+  HMAC(EVP_sha256(), key, sizeof(key), id.begin(), BASE_LENGTH, hmacOut, &len);
+  KJ_ASSERT(len == SHA256_DIGEST_LENGTH);
+  auto ret = kj::heapArray<kj::byte>(SHA256_DIGEST_LENGTH);
+  memcpy(ret.begin(), id.begin(), BASE_LENGTH);
+  memcpy(ret.begin() + BASE_LENGTH, hmacOut, SHA256_DIGEST_LENGTH - BASE_LENGTH);
+  return kj::encodeHex(ret);
+}
+
+constexpr const char deadbeef64[] = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+KJ_TEST("ActorIdImplFactory idFromString test") {
+  using ActorIdFactoryImpl = workerd::server::ActorIdFactoryImpl;
+  struct ActorFactoryFromStringTest {
+    ActorIdFactoryImpl actor;
+    kj::String string;
+    bool isFatal;
+    ActorFactoryFromStringTest(const char* actorString, const char* string, bool isFatal):
+      actor(actorString), string(kj::heapString(string)), isFatal(isFatal) {}
+    ActorFactoryFromStringTest(const char* actorString, kj::String string, bool isFatal) :
+      actor(actorString), string(kj::mv(string)), isFatal(isFatal) {}
+  };
+  using Test = ActorFactoryFromStringTest;
+  Test testCases[] = {
+    {"hello", "goodbye", true}, // a random string of the wrong length
+    {"hello", deadbeef64, true}, //Gets past the first assert
+    {deadbeef64, computeProperTestMac(deadbeef64, deadbeef64), false}, //Gets past the second assert
+  };
+  for(auto& testCase : testCases) {
+    if(testCase.isFatal) {
+      KJ_EXPECT_THROW(FAILED, testCase.actor.idFromString(kj::heapString(testCase.string)));
+    } else {
+      auto result = testCase.actor.idFromString(kj::heapString(testCase.string));
+      KJ_EXPECT(result->getName() == kj::none);
+    }
+  }
+}

--- a/src/workerd/server/actor-id-impl.c++
+++ b/src/workerd/server/actor-id-impl.c++
@@ -1,0 +1,109 @@
+#include <workerd/server/actor-id-impl.h>
+#include <workerd/jsg/jsg.h>
+#include <openssl/rand.h>
+#include <openssl/hmac.h>
+#include <kj/encoding.h>
+#include <kj/memory.h>
+
+namespace workerd::server {
+
+ActorIdFactoryImpl::ActorIdImpl::ActorIdImpl(const kj::byte idParam[SHA256_DIGEST_LENGTH], kj::Maybe<kj::String> name)
+  : name(kj::mv(name)) {
+  memcpy(id, idParam, sizeof(id));
+}
+
+kj::String ActorIdFactoryImpl::ActorIdImpl::toString() const {
+  return kj::encodeHex(kj::ArrayPtr<const kj::byte>(id));
+}
+
+kj::Maybe<kj::StringPtr> ActorIdFactoryImpl::ActorIdImpl::getName() const {
+  return name;
+}
+
+bool ActorIdFactoryImpl::ActorIdImpl::equals(const ActorId& other) const {
+  return memcmp(id, kj::downcast<const ActorIdImpl>(other).id, sizeof(id)) == 0;
+}
+
+kj::Own<ActorIdFactory::ActorId> ActorIdFactoryImpl::ActorIdImpl::clone() const {
+  return kj::heap<ActorIdImpl>(id, name.map([](kj::StringPtr str) { return kj::str(str); }));
+}
+
+ActorIdFactoryImpl::ActorIdFactoryImpl(kj::StringPtr uniqueKey) {
+  KJ_ASSERT(SHA256(uniqueKey.asBytes().begin(), uniqueKey.size(), key) == key);
+}
+
+kj::Own<ActorIdFactory::ActorId> ActorIdFactoryImpl::newUniqueId(kj::Maybe<kj::StringPtr> jurisdiction) {
+  JSG_REQUIRE(jurisdiction == kj::none, Error,
+      "Jurisdiction restrictions are not implemented in workerd.");
+
+  // We want to randomly-generate the first 16 bytes, then HMAC those to produce the latter
+  // 16 bytes. But the HMAC will produce 32 bytes, so we're only taking a prefix of it. We'll
+  // allocate a single array big enough to output the HMAC as a suffix, which will then get
+  // truncated.
+  kj::byte id[BASE_LENGTH + SHA256_DIGEST_LENGTH]{};
+
+  if (isPredictableModeForTest()) {
+    memcpy(id, &counter, sizeof(counter));
+    kj::arrayPtr(id).slice(counter).fill(0);
+    ++counter;
+  } else {
+    KJ_ASSERT(RAND_bytes(id, BASE_LENGTH) == 1);
+  }
+
+  computeMac(id);
+  return kj::heap<ActorIdImpl>(id, kj::none);
+}
+
+kj::Own<ActorIdFactory::ActorId> ActorIdFactoryImpl::idFromName(kj::String name) {
+  kj::byte id[BASE_LENGTH + SHA256_DIGEST_LENGTH]{};
+
+  // Compute the first half of the ID by HMACing the name itself. We're using HMAC as a keyed
+  // hash here, not actually for authentication, but it works.
+  uint len = SHA256_DIGEST_LENGTH;
+  KJ_ASSERT(HMAC(EVP_sha256(), key, sizeof(key), name.asBytes().begin(), name.size(), id, &len)
+                  == id);
+  KJ_ASSERT(len == SHA256_DIGEST_LENGTH);
+
+  computeMac(id);
+  return kj::heap<ActorIdImpl>(id, kj::mv(name));
+}
+
+kj::Own<ActorIdFactory::ActorId> ActorIdFactoryImpl::idFromString(kj::String str) {
+  auto decoded = kj::decodeHex(str);
+  JSG_REQUIRE(str.size() == SHA256_DIGEST_LENGTH * 2 && !decoded.hadErrors &&
+              decoded.size() == SHA256_DIGEST_LENGTH,
+              TypeError, "Invalid Durable Object ID: must be 64 hex digits");
+
+  kj::byte id[BASE_LENGTH + SHA256_DIGEST_LENGTH]{};
+  memcpy(id, decoded.begin(), BASE_LENGTH);
+  computeMac(id);
+
+  // Verify that the computed mac matches the input.
+  JSG_REQUIRE(memcmp(id + BASE_LENGTH, decoded.begin() + BASE_LENGTH,
+              decoded.size() - BASE_LENGTH) == 0,
+              TypeError, "Durable Object ID is not valid for this namespace.");
+
+  return kj::heap<ActorIdImpl>(id, kj::none);
+}
+
+kj::Own<ActorIdFactory> ActorIdFactoryImpl::cloneWithJurisdiction(kj::StringPtr jurisdiction) {
+  JSG_FAIL_REQUIRE(Error, "Jurisdiction restrictions are not implemented in workerd.");
+}
+
+bool ActorIdFactoryImpl::matchesJurisdiction(const ActorId& id) {
+  return true;
+}
+
+void ActorIdFactoryImpl::computeMac(kj::byte id[BASE_LENGTH + SHA256_DIGEST_LENGTH]) {
+  // Given that the first `BASE_LENGTH` bytes of `id` are filled in, compute the second half
+  // of the ID by HMACing the first half. The id must be in a buffer large enough to store the
+  // first half of the ID plus a full HMAC, even though only a prefix of the HMAC becomes part
+  // of the final ID.
+
+  kj::byte* hmacOut = id + BASE_LENGTH;
+  uint len = SHA256_DIGEST_LENGTH;
+  KJ_ASSERT(HMAC(EVP_sha256(), key, sizeof(key), id, BASE_LENGTH, hmacOut, &len) == hmacOut);
+  KJ_ASSERT(len == SHA256_DIGEST_LENGTH);
+}
+
+} //namespace workerd::server

--- a/src/workerd/server/actor-id-impl.h
+++ b/src/workerd/server/actor-id-impl.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <openssl/sha.h>
+#include <workerd/io/actor-id.h>
+
+namespace workerd::server {
+class ActorIdFactoryImpl final: public ActorIdFactory {
+public:
+  ActorIdFactoryImpl(kj::StringPtr uniqueKey);
+  class ActorIdImpl final: public ActorId {
+  public:
+    ActorIdImpl(const kj::byte idParam[SHA256_DIGEST_LENGTH], kj::Maybe<kj::String> name);
+
+    kj::String toString() const override;
+    kj::Maybe<kj::StringPtr> getName() const override;
+    bool equals(const ActorId& other) const override;
+    kj::Own<ActorId> clone() const override;
+  private:
+    kj::byte id[SHA256_DIGEST_LENGTH];
+    kj::Maybe<kj::String> name;
+  };
+
+  kj::Own<ActorId> newUniqueId(kj::Maybe<kj::StringPtr> jurisdiction) override;
+  kj::Own<ActorId> idFromName(kj::String name) override;
+  kj::Own<ActorId> idFromString(kj::String str) override;
+  kj::Own<ActorIdFactory> cloneWithJurisdiction(kj::StringPtr jurisdiction) override;
+  bool matchesJurisdiction(const ActorId& id) override;
+private:
+  kj::byte key[SHA256_DIGEST_LENGTH];
+
+  uint64_t counter = 0;   // only used in predictable mode
+
+  static constexpr size_t BASE_LENGTH = SHA256_DIGEST_LENGTH / 2;
+  void computeMac(kj::byte id[BASE_LENGTH + SHA256_DIGEST_LENGTH]);
+};
+
+} // namespace workerd::server

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -36,6 +36,7 @@
 #include <workerd/io/promise-wrapper.h>
 #include <workerd/util/thread-scopes.h>
 #include <workerd/util/use-perfetto-categories.h>
+#include <workerd/server/actor-id-impl.h>
 #include <openssl/sha.h>
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
@@ -542,118 +543,6 @@ void WorkerdApi::compileModules(
     }
   });
 }
-
-class ActorIdFactoryImpl final: public ActorIdFactory {
-public:
-  ActorIdFactoryImpl(kj::StringPtr uniqueKey) {
-    KJ_ASSERT(SHA256(uniqueKey.asBytes().begin(), uniqueKey.size(), key) == key);
-  }
-
-  class ActorIdImpl final: public ActorId {
-  public:
-    ActorIdImpl(const kj::byte idParam[SHA256_DIGEST_LENGTH], kj::Maybe<kj::String> name)
-        : name(kj::mv(name)) {
-      memcpy(id, idParam, sizeof(id));
-    }
-
-    kj::String toString() const override {
-      return kj::encodeHex(kj::ArrayPtr<const kj::byte>(id));
-    }
-    kj::Maybe<kj::StringPtr> getName() const override {
-      return name;
-    }
-    bool equals(const ActorId& other) const override {
-      return memcmp(id, kj::downcast<const ActorIdImpl>(other).id, sizeof(id)) == 0;
-    }
-    kj::Own<ActorId> clone() const override {
-      return kj::heap<ActorIdImpl>(id, name.map([](kj::StringPtr str) { return kj::str(str); }));
-    }
-
-  private:
-    kj::byte id[SHA256_DIGEST_LENGTH];
-    kj::Maybe<kj::String> name;
-  };
-
-  kj::Own<ActorId> newUniqueId(kj::Maybe<kj::StringPtr> jurisdiction) override {
-    JSG_REQUIRE(jurisdiction == kj::none, Error,
-        "Jurisdiction restrictions are not implemented in workerd.");
-
-    // We want to randomly-generate the first 16 bytes, then HMAC those to produce the latter
-    // 16 bytes. But the HMAC will produce 32 bytes, so we're only taking a prefix of it. We'll
-    // allocate a single array big enough to output the HMAC as a suffix, which will then get
-    // truncated.
-    kj::byte id[BASE_LENGTH + SHA256_DIGEST_LENGTH]{};
-
-    if (isPredictableModeForTest()) {
-      memcpy(id, &counter, sizeof(counter));
-      kj::arrayPtr(id).slice(counter).fill(0);
-      ++counter;
-    } else {
-      KJ_ASSERT(RAND_bytes(id, BASE_LENGTH) == 1);
-    }
-
-    computeMac(id);
-    return kj::heap<ActorIdImpl>(id, kj::none);
-  }
-
-  kj::Own<ActorId> idFromName(kj::String name) override {
-    kj::byte id[BASE_LENGTH + SHA256_DIGEST_LENGTH]{};
-
-    // Compute the first half of the ID by HMACing the name itself. We're using HMAC as a keyed
-    // hash here, not actually for authentication, but it works.
-    uint len = SHA256_DIGEST_LENGTH;
-    KJ_ASSERT(HMAC(EVP_sha256(), key, sizeof(key), name.asBytes().begin(), name.size(), id, &len)
-                   == id);
-    KJ_ASSERT(len == SHA256_DIGEST_LENGTH);
-
-    computeMac(id);
-    return kj::heap<ActorIdImpl>(id, kj::mv(name));
-  }
-
-  kj::Own<ActorId> idFromString(kj::String str) override {
-    auto decoded = kj::decodeHex(str);
-    JSG_REQUIRE(str.size() == SHA256_DIGEST_LENGTH * 2 && !decoded.hadErrors &&
-                decoded.size() == SHA256_DIGEST_LENGTH,
-                TypeError, "Invalid Durable Object ID: must be 64 hex digits");
-
-    kj::byte id[BASE_LENGTH + SHA256_DIGEST_LENGTH]{};
-    memcpy(id, decoded.begin(), BASE_LENGTH);
-    computeMac(id);
-
-    // Verify that the computed mac matches the input.
-    JSG_REQUIRE(memcmp(id + BASE_LENGTH, decoded.begin() + BASE_LENGTH,
-                decoded.size() - BASE_LENGTH) == 0,
-                TypeError, "Durable Object ID is not valid for this namespace.");
-
-    return kj::heap<ActorIdImpl>(id, kj::none);
-  }
-
-  kj::Own<ActorIdFactory> cloneWithJurisdiction(kj::StringPtr jurisdiction) override {
-    JSG_FAIL_REQUIRE(Error, "Jurisdiction restrictions are not implemented in workerd.");
-  }
-
-  bool matchesJurisdiction(const ActorId& id) override {
-    return true;
-  }
-
-private:
-  kj::byte key[SHA256_DIGEST_LENGTH];
-
-  uint64_t counter = 0;   // only used in predictable mode
-
-  static constexpr size_t BASE_LENGTH = SHA256_DIGEST_LENGTH / 2;
-  void computeMac(kj::byte id[BASE_LENGTH + SHA256_DIGEST_LENGTH]) {
-    // Given that the first `BASE_LENGTH` bytes of `id` are filled in, compute the second half
-    // of the ID by HMACing the first half. The id must be in a buffer large enough to store the
-    // first half of the ID plus a full HMAC, even though only a prefix of the HMAC becomes part
-    // of the final ID.
-
-    kj::byte* hmacOut = id + BASE_LENGTH;
-    uint len = SHA256_DIGEST_LENGTH;
-    KJ_ASSERT(HMAC(EVP_sha256(), key, sizeof(key), id, BASE_LENGTH, hmacOut, &len) == hmacOut);
-    KJ_ASSERT(len == SHA256_DIGEST_LENGTH);
-  }
-};
 
 static v8::Local<v8::Value> createBindingValue(
     JsgWorkerdIsolate::Lock& lock,


### PR DESCRIPTION
Enables the instances of `memcmp` inside `ActorIdFactoryImpl` to be tested.