### PR TITLE
[BUILD] Split up bazel io target

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -10,6 +10,7 @@ filegroup(
             ["**/*.c++"],
             exclude = [
                 "html-rewriter.c++",
+                "data-url.c++",
                 "rtti.c++",
                 "**/*test*.c++",
                 "pyodide.c++",
@@ -20,6 +21,7 @@ filegroup(
             ["**/*.c++"],
             exclude = [
                 "html-rewriter.c++",
+                "data-url.c++",
                 "rtti.c++",
                 "**/*test*.c++",
                 "pyodide.c++",
@@ -31,27 +33,25 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+api_header_exclusions = [
+    "html-rewriter.h",
+    "deferred-proxy.h",
+    "data-url.h",
+    "modules.h",
+    "rtti.h",
+    "**/*test*.h",
+]
+
 filegroup(
     name = "hdrs",
     srcs = select({
         "//src/workerd/io:set_enable_experimental_webgpu": glob(
             ["**/*.h"],
-            exclude = [
-                "html-rewriter.h",
-                "modules.h",
-                "rtti.h",
-                "**/*test*.h",
-            ],
+            exclude = api_header_exclusions,
         ),
         "//conditions:default": glob(
             ["**/*.h"],
-            exclude = [
-                "html-rewriter.h",
-                "modules.h",
-                "rtti.h",
-                "**/*test*.h",
-                "gpu/*.h",
-            ],
+            exclude = api_header_exclusions + ["gpu/*.h"],
         ),
     }),
     visibility = ["//visibility:public"],
@@ -111,6 +111,28 @@ wd_cc_library(
     ],
 )
 
+wd_cc_library(
+    name = "data-url",
+    srcs = ["data-url.c++"],
+    hdrs = ["data-url.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/workerd/jsg:url",
+        "//src/workerd/util",
+        "@capnp-cpp//src/kj",
+    ],
+)
+
+wd_cc_library(
+    name = "deferred-proxy",
+    hdrs = ["deferred-proxy.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj",
+        "@capnp-cpp//src/kj:kj-async",
+    ],
+)
+
 wd_cc_capnp_library(
     name = "r2-api_capnp",
     srcs = ["r2-api.capnp"],
@@ -128,16 +150,30 @@ wd_cc_capnp_library(
     deps = [
         "//src/workerd/io",
     ],
-) for f in glob(
-    ["**/*-test.c++"],
-    exclude = [
-        "api-rtti-test.c++",
-        "actor-state-iocontext-test.c++",
-        "cf-property-test.c++",
-        "node/*-test.c++",
-        "streams/internal-test.c++",
+) for f in [
+    "actor-state-test.c++",
+    "basics-test.c++",
+    "crypto/aes-test.c++",
+    "crypto/impl-test.c++",
+    "streams/queue-test.c++",
+    "streams/standard-test.c++",
+    "util-test.c++",
+    ]
+]
+
+kj_test(
+    src = "data-url-test.c++",
+    deps = [
+        ":data-url",
     ],
-)]
+)
+
+kj_test(
+    src = "deferred-proxy-test.c++",
+    deps = [
+        ":deferred-proxy",
+    ],
+)
 
 kj_test(
     src = "streams/internal-test.c++",

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -20,36 +20,33 @@ wd_cc_library(
     # HACK: Currently, the `io` and `api` packages are interdependent. We fold all the sources
     #   from `api` into `io`. In principle, it should be possible to pull them apart so `api`
     #   depends on `io` but not vice versa.
-    # TODO(cleaunp): Fix this.
+    # TODO(cleanup): Fix this.
     srcs = glob(
         ["*.c++"],
         exclude = [
             "worker-interface.c++",
             "*-test.c++",
             "trace.c++",
+            "io-gate.c++",
+            "observer.c++",
+            "actor-cache.c++",
+            "actor-sqlite.c++",
+            "actor-storage.c++",
+            "worker-entrypoint.c++",
         ],
     ) + ["//src/workerd/api:srcs"],
     hdrs = glob(
         ["*.h"],
-        # `trace.h` should really be excluded here, but doing so causes the build to fail on
-        # Windows with errors like:
-        #
-        # ```
-        # ERROR: C:/.../src/workerd/io/BUILD.bazel: Compiling src/workerd/io/compatibility-date.c++ failed: undeclared inclusion(s) in rule '//src/workerd/io:io':
-        # this rule is missing dependency declarations for the following files included by 'src/workerd/io/compatibility-date.c++':
-        #   'bazel-out/x64_windows-opt/bin/src/workerd/io/_virtual_includes/io/workerd/io/trace.h'
-        # In file included from <built-in>:429:
-        # ```
-        #
-        # This feels like a weird interaction between symlinks on Windows and Bazel.
-        # `trace.h` is `#pragma once`d though, so including it in both `io` and `trace` targets
-        # should be ok.
-        #
-        # TODO(soon): Fix this
         exclude = [
             "actor-id.h",
+            "actor-cache.h",
+            "actor-sqlite.h",
+            "actor-storage.h",
             "io-channels.h",
+            "io-gate.h",
+            "trace.h",
             "observer.h",
+            "worker-entrypoint.h",
             "worker-interface.h",
         ],
     ) + ["//src/workerd/api:hdrs"],
@@ -65,21 +62,26 @@ wd_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":actor",
         ":actor-id",
         ":actor-storage_capnp",
         ":capnp",
         ":io-channels",
+        ":io-gate",
         ":observer",
         ":trace",
         ":worker-interface",
         "//src/cloudflare",
         "//src/node",
         "//src/workerd/api:analytics-engine_capnp",
+        "//src/workerd/api:data-url",
+        "//src/workerd/api:deferred-proxy",
         "//src/workerd/api:r2-api_capnp",
         "//src/workerd/jsg",
         "//src/workerd/util:autogate",
-        "//src/workerd/util:duration-exceeded-logger",
         "//src/workerd/util:sqlite",
+        "//src/workerd/util:thread-scopes",
+        "//src/workerd/util:uuid",
         "@capnp-cpp//src/capnp:capnp-rpc",
         "@capnp-cpp//src/capnp/compat:http-over-capnp",
         "@capnp-cpp//src/kj:kj-async",
@@ -90,29 +92,67 @@ wd_cc_library(
     }),
 )
 
+# TODO(cleanup): Split this up further.
+wd_cc_library(
+    name = "actor",
+    srcs = [
+        "actor-cache.c++",
+        "actor-sqlite.c++",
+        "actor-storage.c++",
+    ],
+    hdrs = [
+        "actor-cache.h",
+        "actor-sqlite.h",
+        "actor-storage.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":actor-storage_capnp",
+        ":io-gate",
+        "//src/workerd/jsg:exception",
+        "//src/workerd/util:duration-exceeded-logger",
+        "//src/workerd/util:sqlite",
+        "@capnp-cpp//src/capnp:capnp-rpc",
+        "@capnp-cpp//src/kj:kj-async",
+    ],
+)
+
 wd_cc_library(
     name = "trace",
     srcs = ["trace.c++"],
     hdrs = ["trace.h"],
     visibility = ["//visibility:public"],
     deps = [
-        ":capnp",
         ":worker-interface_capnp",
         "//src/workerd/jsg:memory-tracker",
         "//src/workerd/util:own-util",
-        "//src/workerd/util:thread-scopes",
+        "@capnp-cpp//src/capnp:capnpc",
+        "@capnp-cpp//src/capnp:capnp-rpc",
         "@capnp-cpp//src/kj:kj-async",
-        "@capnp-cpp//src/kj/compat:kj-http",
     ],
 )
 
 wd_cc_library(
     name = "observer",
+    srcs = ["observer.c++"],
     hdrs = ["observer.h"],
     visibility = ["//visibility:public"],
     deps = [
+        ":features_capnp",
         ":trace",
+        ":worker-interface",
         "//src/workerd/jsg:observer",
+    ],
+)
+
+wd_cc_library(
+    name = "io-gate",
+    srcs = ["io-gate.c++"],
+    hdrs = ["io-gate.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj",
+        "@capnp-cpp//src/kj:kj-async",
     ],
 )
 
@@ -120,6 +160,21 @@ wd_cc_library(
     name = "limit-enforcer",
     hdrs = ["limit-enforcer.h"],
     visibility = ["//visibility:public"],
+    deps = [
+        ":observer",
+        "//src/workerd/jsg",
+    ],
+)
+
+wd_cc_library(
+    name = "worker-entrypoint",
+    srcs = ["worker-entrypoint.c++"],
+    hdrs = ["worker-entrypoint.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":io",
+        "//src/workerd/util:perfetto",
+    ],
 )
 
 wd_cc_library(
@@ -128,7 +183,9 @@ wd_cc_library(
     hdrs = ["worker-interface.h"],
     visibility = ["//visibility:public"],
     deps = [
-        ":trace",
+        ":worker-interface_capnp",
+        "@capnp-cpp//src/capnp:capnpc",
+        "@capnp-cpp//src/capnp:capnp-rpc",
         "@capnp-cpp//src/capnp/compat:http-over-capnp",
     ],
 )
@@ -228,11 +285,40 @@ wd_cc_capnp_library(
     visibility = ["//visibility:public"],
 )
 
-[kj_test(
-    src = f,
+kj_test(
+    src = "io-gate-test.c++",
     deps = [
-        ":io",
-        "//src/workerd/util:autogate",
+        ":io-gate",
+    ],
+)
+
+kj_test(
+    src = "actor-cache-test.c++",
+    deps = [
+        ":actor",
+        ":io-gate",
+        "//src/workerd/util:test",
         "//src/workerd/util:test-util",
     ],
-) for f in glob(["*-test.c++"])]
+)
+
+kj_test(
+    src = "promise-wrapper-test.c++",
+    deps = [":io"],
+)
+
+kj_test(
+    src = "compatibility-date-test.c++",
+    deps = [
+        ":io",
+        "@capnp-cpp//src/capnp:capnpc",
+    ],
+)
+
+kj_test(
+    src = "observer-test.c++",
+    deps = [
+        ":observer",
+        "@capnp-cpp//src/capnp:capnpc",
+    ],
+)

--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -7,7 +7,7 @@
 
 #include <kj/debug.h>
 
-#include <workerd/jsg/jsg.h>
+#include <workerd/jsg/exception.h>
 #include <workerd/io/io-gate.h>
 #include <workerd/util/sentry.h>
 #include <workerd/util/duration-exceeded-logger.h>

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -4,7 +4,7 @@
 
 #include "actor-sqlite.h"
 #include <algorithm>
-#include <workerd/jsg/jsg.h>
+#include <workerd/jsg/exception.h>
 #include "io-gate.h"
 
 namespace workerd {

--- a/src/workerd/io/actor-storage.c++
+++ b/src/workerd/io/actor-storage.c++
@@ -4,7 +4,7 @@
 
 #include "actor-storage.h"
 
-#include <workerd/jsg/jsg.h>
+#include <workerd/jsg/exception.h>
 
 namespace workerd {
 void ActorStorageLimits::checkMaxKeySize(kj::StringPtr key) {

--- a/src/workerd/io/compatibility-date.c++
+++ b/src/workerd/io/compatibility-date.c++
@@ -7,6 +7,7 @@
 #include "time.h"
 #include <capnp/schema.h>
 #include <capnp/dynamic.h>
+#include <kj/debug.h>
 #include <kj/map.h>
 #include <kj/vector.h>
 

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -6,12 +6,12 @@
 
 #include <workerd/io/actor-id.h>
 #include <workerd/io/io-channels.h>
-#include "io-gate.h"
+#include <workerd/io/io-gate.h>
 #include "io-own.h"
 #include "io-timers.h"
 #include "io-thread-context.h"
 #include "limit-enforcer.h"
-#include "trace.h"
+#include <workerd/io/trace.h>
 #include "worker.h"
 #include <workerd/api/deferred-proxy.h>
 #include <workerd/jsg/async-context.h>

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -10,7 +10,6 @@
 #include <kj/refcount.h>
 #include <kj/exception.h>
 #include <kj/time.h>
-#include <kj/compat/http.h>
 #include <workerd/io/trace.h>
 #include <workerd/io/features.capnp.h>
 #include <workerd/jsg/observer.h>

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -5,7 +5,6 @@
 #include <workerd/io/trace.h>
 #include <capnp/message.h>
 #include <capnp/schema.h>
-#include <kj/compat/http.h>
 #include <kj/debug.h>
 #include <cstdlib>
 

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -3,7 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "worker-entrypoint.h"
-#include "io-context.h"
+#include <workerd/io/io-context.h>
 #include <capnp/message.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/api/global-scope.h>

--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "worker.h"
+#include <workerd/io/worker.h>
 
 namespace workerd {
 

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -60,6 +60,7 @@ wd_cc_library(
         "//src/workerd/util",
         "//src/workerd/util:sentry",
         "//src/workerd/util:thread-scopes",
+        "//src/workerd/util:uuid",
         "@capnp-cpp//src/kj",
         "@workerd-v8//:v8",
     ],
@@ -197,7 +198,7 @@ kj_test(
 kj_test(
     src = "url-test.c++",
     deps = [
-        ":jsg",
+        ":url",
         "@ssl",
     ],
 )

--- a/src/workerd/jsg/exception.h
+++ b/src/workerd/jsg/exception.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <kj/string.h>
+#include <kj/debug.h>
 
 namespace workerd::jsg {
 

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -72,7 +72,7 @@ wd_cc_library(
     deps = [
         "//src/workerd/io",
         "//src/workerd/util:sqlite",
-        "@capnp-cpp//src/kj:kj",
+        "@capnp-cpp//src/kj",
         "@capnp-cpp//src/kj:kj-async",
     ],
 )
@@ -87,8 +87,11 @@ wd_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/workerd/io",
+        "//src/workerd/io:actor-id",
+        "//src/workerd/jsg:exception",
+        "//src/workerd/util:thread-scopes",
         "@capnp-cpp//src/kj:kj",
+        "@ssl",
     ],
 )
 
@@ -117,6 +120,7 @@ wd_cc_library(
         "//src/workerd/api:pyodide",
         "//src/workerd/api:rtti",
         "//src/workerd/io",
+        "//src/workerd/io:worker-entrypoint",
         "//src/workerd/jsg",
         "//src/workerd/util:perfetto",
         "@capnp-cpp//src/kj/compat:kj-tls",
@@ -157,10 +161,21 @@ sh_test(
     tags = ["no-qemu"],
 )
 
-[kj_test(
-    src = f,
+kj_test(
+    src = "server-test.c++",
     deps = [
         ":server",
         "//src/workerd/util:test-util",
     ],
-) for f in glob(["*-test.c++"])]
+)
+
+kj_test(
+    src = "actor-id-impl-test.c++",
+    deps = [
+        ":actor-id-impl",
+        "//src/workerd/jsg:exception",
+        "//src/workerd/util:thread-scopes",
+        "@capnp-cpp//src/kj",
+        "@ssl",
+    ],
+)

--- a/src/workerd/server/actor-id-impl-test.c++
+++ b/src/workerd/server/actor-id-impl-test.c++
@@ -6,8 +6,7 @@
 #include <kj/test.h>
 #include <kj/debug.h>
 #include <kj/encoding.h>
-#include <kj/compat/gtest.h>
-#include <workerd/jsg/jsg.h>
+#include <workerd/jsg/exception.h>
 #include <openssl/hmac.h>
 
 

--- a/src/workerd/server/actor-id-impl.c++
+++ b/src/workerd/server/actor-id-impl.c++
@@ -1,5 +1,6 @@
 #include <workerd/server/actor-id-impl.h>
-#include <workerd/jsg/jsg.h>
+#include <workerd/jsg/exception.h>
+#include <workerd/util/thread-scopes.h>
 #include <openssl/rand.h>
 #include <openssl/hmac.h>
 #include <kj/encoding.h>
@@ -59,7 +60,7 @@ kj::Own<ActorIdFactory::ActorId> ActorIdFactoryImpl::idFromName(kj::String name)
 
   // Compute the first half of the ID by HMACing the name itself. We're using HMAC as a keyed
   // hash here, not actually for authentication, but it works.
-  uint len = SHA256_DIGEST_LENGTH;
+  unsigned int len = SHA256_DIGEST_LENGTH;
   KJ_ASSERT(HMAC(EVP_sha256(), key, sizeof(key), name.asBytes().begin(), name.size(), id, &len)
                   == id);
   KJ_ASSERT(len == SHA256_DIGEST_LENGTH);
@@ -100,7 +101,7 @@ void ActorIdFactoryImpl::computeMac(kj::byte id[BASE_LENGTH + SHA256_DIGEST_LENG
   // of the final ID.
 
   kj::byte* hmacOut = id + BASE_LENGTH;
-  uint len = SHA256_DIGEST_LENGTH;
+  unsigned int len = SHA256_DIGEST_LENGTH;
   KJ_ASSERT(HMAC(EVP_sha256(), key, sizeof(key), id, BASE_LENGTH, hmacOut, &len) == hmacOut);
   KJ_ASSERT(len == SHA256_DIGEST_LENGTH);
 }

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -5,17 +5,20 @@ load("//:build/wd_cc_library.bzl", "wd_cc_library")
 wd_cc_library(
     name = "perfetto",
     srcs = ["perfetto-tracing.c++"],
-    hdrs = ["perfetto-tracing.h", "use-perfetto-categories.h"],
+    hdrs = [
+        "perfetto-tracing.h",
+        "use-perfetto-categories.h",
+    ],
+    defines = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["WORKERD_USE_PERFETTO"],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         "@capnp-cpp//src/kj",
     ] + select({
         "@platforms//os:windows": [],
         "//conditions:default": ["@perfetto//:libperfetto_client_experimental"],
-    }),
-    defines = select({
-        "@platforms//os:windows": [],
-        "//conditions:default": ["WORKERD_USE_PERFETTO"],
     }),
 )
 # TODO(later): Currently perfetto support is not enabled on Windows simply because the
@@ -28,26 +31,54 @@ wd_cc_library(
     srcs = [
         "mimetype.c++",
         "stream-utils.c++",
-        "uuid.c++",
         "wait-list.c++",
     ],
-    hdrs = glob(
-        ["*.h"],
-        exclude = [
-            "capnp-mock.h",
-            "sqlite*.h",
-            "own-util.h",
-            "thread-scopes.h",
-            "sentry.h",
-            "autogate.h",
-            "perfetto-tracing.h",
-            "use-perfetto-categories.h",
-        ],
-    ),
-    implementation_deps = ["@ssl"],
+    # This is verbose, but allows us to be intentional about what we include here and e.g. avoid
+    # accidentally including test headers or having targets depend on more than they need to.
+    # TODO (cleanup): Break this up entirely.
+    hdrs = [
+        "abortable.h",
+        "batch-queue.h",
+        "canceler.h",
+        "color-util.h",
+        "duration-exceeded-logger.h",
+        "http-util.h",
+        "mimetype.h",
+        "stream-utils.h",
+        "string-buffer.h",
+        "strings.h",
+        "uncaught-exception-source.h",
+        "wait-list.h",
+        "weak-refs.h",
+        "xthreadnotifier.h",
+    ],
     visibility = ["//visibility:public"],
     deps = [
+        "@capnp-cpp//src/kj",
+        "@capnp-cpp//src/kj:kj-async",
+    ],
+)
+
+wd_cc_library(
+    name = "uuid",
+    srcs = ["uuid.c++"],
+    hdrs = ["uuid.h"],
+    implementation_deps = [
         "@capnp-cpp//src/kj/compat:kj-http",
+        "@ssl",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj",
+    ],
+)
+
+wd_cc_library(
+    name = "test",
+    hdrs = ["test.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj:kj-test",
     ],
 )
 
@@ -84,16 +115,16 @@ wd_cc_library(
 wd_cc_library(
     name = "symbolizer",
     srcs = ["symbolizer.c++"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":sentry",
         "@capnp-cpp//src/kj",
     ],
     alwayslink = 1,
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
 )
 
 wd_cc_library(
@@ -126,7 +157,11 @@ wd_cc_library(
     # Make missing string repr for an autogate into a hard error
     copts = ["-Werror=switch"],
     visibility = ["//visibility:public"],
-    deps = [":sentry", "@capnp-cpp//src/kj", "@capnp-cpp//src/capnp"],
+    deps = [
+        ":sentry",
+        "@capnp-cpp//src/capnp",
+        "@capnp-cpp//src/kj",
+    ],
 )
 
 wd_cc_library(
@@ -142,10 +177,14 @@ exports_files(["autogate.h"])
     deps = [
         ":util",
     ],
-) for f in glob(
-    ["*-test.c++"],
-    exclude = ["sqlite-*.c++"],
-)]
+) for f in [
+    "batch-queue-test.c++",
+    "mimetype-test.c++",
+    "wait-list-test.c++",
+    "duration-exceeded-logger-test.c++",
+    "string-buffer-test.c++",
+    ]
+]
 
 kj_test(
     src = "sqlite-test.c++",
@@ -158,5 +197,19 @@ kj_test(
     src = "sqlite-kv-test.c++",
     deps = [
         ":sqlite",
+    ],
+)
+
+kj_test(
+    src = "test-test.c++",
+    deps = [
+        ":test",
+    ],
+)
+
+kj_test(
+    src = "uuid-test.c++",
+    deps = [
+        ":uuid",
     ],
 )

--- a/src/workerd/util/uuid.c++
+++ b/src/workerd/util/uuid.c++
@@ -4,6 +4,7 @@
 
 #include "uuid.h"
 
+#include <kj/compat/http.h>
 #include <openssl/rand.h>
 #include <cstdlib>
 

--- a/src/workerd/util/uuid.h
+++ b/src/workerd/util/uuid.h
@@ -4,9 +4,13 @@
 
 #pragma once
 
-#include <kj/compat/http.h>
+#include <cstdint>
 #include <kj/string.h>
 #include <kj/hash.h>
+
+namespace kj {
+  class EntropySource;
+}
 
 namespace workerd {
 


### PR DESCRIPTION
This makes it easier to avoid superfluous dependencies, especially in tests.
Making io a smaller target will help us rebuild less code following trivial
changes – any change to a header included in the io target requires all io and
dependent source files to be rebuilt.
Crucially, this also isolates several tests from io/JSG (and by extension V8). Since
we currently make V8 alwayslink, this makes these test binaries much
smaller (~140MB => ~1MB on macOS), improving CI performance as less data
needs to be fetched from cache.