### PR TITLE
COMPILED_MAGIC_SUFFIX check from memcmp equals 0 -> arrayPtr equality

### DIFF
--- a/samples/BUILD.bazel
+++ b/samples/BUILD.bazel
@@ -1,0 +1,4 @@
+exports_files([
+    "helloworld/config.capnp",
+    "helloworld/worker.js",
+])

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -110,8 +110,8 @@ wd_cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
-        ":alarm-scheduler",
         ":actor-id-impl",
+        ":alarm-scheduler",
         ":workerd_capnp",
         "//src/workerd/api:html-rewriter",
         "//src/workerd/api:pyodide",
@@ -136,6 +136,24 @@ wd_cc_capnp_library(
     visibility = ["//visibility:public"],
     deps = [
         ":workerd_capnp",
+    ],
+)
+
+sh_test(
+    name = "helloworld_compile_test",
+    size = "small",
+    srcs = ["tests/compile-tests/compile-test.sh"],
+    args = [
+        "$(location :workerd)",
+        "$(location //samples:helloworld/config.capnp)",
+        "8080",
+        "$(location tests/compile-tests/compile-helloworld-test.ok)",
+    ],
+    data = [
+        "tests/compile-tests/compile-helloworld-test.ok",
+        ":workerd",
+        "//samples:helloworld/config.capnp",
+        "//samples:helloworld/worker.js",
     ],
 )
 

--- a/src/workerd/server/tests/compile-tests/compile-helloworld-test.ok
+++ b/src/workerd/server/tests/compile-tests/compile-helloworld-test.ok
@@ -1,0 +1,1 @@
+Hello World

--- a/src/workerd/server/tests/compile-tests/compile-test.sh
+++ b/src/workerd/server/tests/compile-tests/compile-test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# $1 -> workerd binary path
+# $2 -> path to desired file to compile
+# $3 -> port to curl
+# $4 -> desired output
+
+# Help Function
+function show_help() {
+  echo "
+The Compile Test script is designed to aid in testing compiled workerd binaries.
+It works by verifying that the result of a curl command on a running compiled binary matches an expected output.
+usage: compile-test.sh [-d] [-h] <workerd command> <file-to-compile> <port-to-curl> <expected-output-file>
+  options:
+    -d print out where tmp files are created and do not delete them
+    -h this help message
+
+  Note: all flags must occur before arguments
+"
+}
+
+while getopts "h" option; do
+  case ${option} in
+    h)
+      show_help
+      exit
+      ;;
+  esac
+done
+
+shift $(expr $OPTIND - 1)
+WORKERD_BINARY=$1
+CAPNP_SOURCE=$2
+PORT=$3
+EXPECTED=$4
+
+CAPNP_BINARY=$(mktemp)
+
+# Compile the app
+$WORKERD_BINARY compile $CAPNP_SOURCE > $CAPNP_BINARY
+
+# Run the app
+$CAPNP_BINARY &
+KILL=$!
+OUTPUT=$(mktemp)
+FIXED_OUTPUT=$(mktemp)
+FIXED_EXPECTED=$(mktemp)
+
+# Request output - and ensure the system is live
+while ! curl localhost:$PORT -o $OUTPUT; do
+  sleep .1
+done;
+
+# Compare the tests to the expected output
+sed -e's/[[:space:]]*$//' $OUTPUT > $FIXED_OUTPUT
+sed -e's/[[:space:]]*$//' $EXPECTED > $FIXED_EXPECTED
+diff $FIXED_OUTPUT $FIXED_EXPECTED
+
+# Clean up running workerd
+kill -9 $KILL
+
+# Clean up temp files
+rm -f $CAPNP_BINARY
+rm -f $OUTPUT
+rm -f $FIXED_OUTPUT
+rm -f $FIXED_EXPECTED

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -635,7 +635,7 @@ public:
       KJ_ASSERT(size > sizeof(COMPILED_MAGIC_SUFFIX) + sizeof(uint64_t));
       kj::byte magic[sizeof(COMPILED_MAGIC_SUFFIX)]{};
       exe.read(size - sizeof(COMPILED_MAGIC_SUFFIX), magic);
-      if (memcmp(magic, COMPILED_MAGIC_SUFFIX, sizeof(COMPILED_MAGIC_SUFFIX)) == 0) {
+      if (kj::arrayPtr(magic) == kj::arrayPtr(COMPILED_MAGIC_SUFFIX).asBytes()) {
         // Oh! It appears we are running a compiled binary, it has a config appended to the end.
         uint64_t configSize;
         exe.read(size - sizeof(COMPILED_MAGIC_SUFFIX) - sizeof(uint64_t),


### PR DESCRIPTION
This change follows the pattern of other safety changes to use `ArrayPtr` equality rather than `memcmp == 0`, which has bounds checking.

This PR also adds a test that compiled binaries run correctly using `sh_test`.