### PR TITLE
README.md: Describe compiler name requirements better

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To build `workerd`, you need:
   * If you use [Bazelisk](https://github.com/bazelbuild/bazelisk) (recommended), it will automatically download and use the right version of Bazel for building workerd.
 * On Linux:
   * We use the clang/LLVM toolchain to build workerd and support version 15 and higher. Earlier versions of clang may still work, but are not officially supported.
-  * Clang 15+ (e.g. package `clang-15` on Debian Bookworm). If clang is installed as `clang-<version>` please create a symlink for just `clang` too or use `--action_env=CC=clang-<version>` to specify the compiler name.
+  * Clang 15+ (e.g. package `clang-15` on Debian Bookworm). If clang is installed as `clang-<version>` please create a symlink to it in your path named `clang`, or use `--action_env=CC=clang-<version>` on `bazel` command lines to specify the compiler name.
   * libc++ 15+ (e.g. packages `libc++-15-dev` and `libc++abi-15-dev`)
   * LLD 15+ (e.g. package `lld-15`). The build may still succeed if a recent version of GNU gold or the system linker is installed, but lld is highly recommended for link performance.
   * `python3`, `python3-distutils`, and `tcl8.6`

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ To build `workerd`, you need:
   * If you use [Bazelisk](https://github.com/bazelbuild/bazelisk) (recommended), it will automatically download and use the right version of Bazel for building workerd.
 * On Linux:
   * We use the clang/LLVM toolchain to build workerd and support version 15 and higher. Earlier versions of clang may still work, but are not officially supported.
-  * Clang 15+ (e.g. package `clang-15` on Debian Bookworm).
+  * Clang 15+ (e.g. package `clang-15` on Debian Bookworm). If clang is installed as `clang-<version>` please create a symlink for just `clang` too or use `--action_env=CC=clang-<version>` to specify the compiler name.
   * libc++ 15+ (e.g. packages `libc++-15-dev` and `libc++abi-15-dev`)
-  * LLD 15+ (e.g. package `lld-15`).
+  * LLD 15+ (e.g. package `lld-15`). The build may still succeed if a recent version of GNU gold or the system linker is installed, but lld is highly recommended for link performance.
   * `python3`, `python3-distutils`, and `tcl8.6`
 * On macOS:
   * Xcode 15 installation (available on macOS 13 and higher)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ To build `workerd`, you need:
   * If you use [Bazelisk](https://github.com/bazelbuild/bazelisk) (recommended), it will automatically download and use the right version of Bazel for building workerd.
 * On Linux:
   * We use the clang/LLVM toolchain to build workerd and support version 15 and higher. Earlier versions of clang may still work, but are not officially supported.
-  * Clang 15+ (e.g. package `clang-15` on Debian Bookworm). If clang is installed as `clang-<version>` please create a symlink to it in your path named `clang`, or use `--action_env=CC=clang-<version>` on `bazel` command lines to specify the compiler name.
+  * Clang 15+ (e.g. package `clang-15` on Debian Bookworm). If clang is installed as `clang-<version>` please create a symlink to it in your PATH named `clang`, or use `--action_env=CC=clang-<version>` on `bazel` command lines to specify the compiler name.
+  
   * libc++ 15+ (e.g. packages `libc++-15-dev` and `libc++abi-15-dev`)
   * LLD 15+ (e.g. package `lld-15`). The build may still succeed if a recent version of GNU gold or the system linker is installed, but lld is highly recommended for link performance.
   * `python3`, `python3-distutils`, and `tcl8.6`


### PR DESCRIPTION
- Add instructions to make the compiler available as just clang, which avoids confusing errors when it is installed as `clang-<version>`.
- Add comment about lld being highly recommended – it turns out that if it is not present Bazel may silently use GNU gold instead, which is able to link workerd correctly but led to much higher link times recently.