### PR TITLE
Run test imports at top level, fix pydantic and numpy imports

### DIFF
--- a/src/workerd/server/tests/python/import_tests.bzl
+++ b/src/workerd/server/tests/python/import_tests.bzl
@@ -2,9 +2,12 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//:build/wd_test.bzl", "wd_test")
 
 def generate_import_py_file(imports):
-  res = "def test():\n"
+  res = ""
   for imp in imports:
-    res += "   import "+imp+"\n"
+    res += "import "+imp+"\n"
+
+  res += "def test():\n"
+  res += "   pass"
   return res
 
 WD_FILE_TEMPLATE = """


### PR DESCRIPTION
Importing stuff within a `test()` function does not invoke the top-level entropy patches we implemented, so this change should make our testing much more complete. 

Should reproduce https://github.com/cloudflare/python-workers-examples/issues/9. 