### PR TITLE
[CI] Build using --remote_download_toplevel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,13 +6,13 @@ test --test_tag_filters=-off-by-default,-slow
 # Not using bzlmod for dependencies yet
 common --noenable_bzlmod
 
-# TODO(soon): bazel7 enables Build without the Bytes (BwoB) by default. This could significantly
-# speed up builds using the remote cache since less data needs to be fetched. Unfortunately, it
-# appears to cause build failures due to https://github.com/bazelbuild/bazel/issues/20559 at this
-# time. Use --remote_download_all to disable BwoB for now.
-# When that issue and https://github.com/bazelbuild/bazel/issues/20576 have been addressed, we can
-# also explore --remote_download_minimal.
-build --remote_download_all
+# bazel7 enables Build without the Bytes (BwoB) by default. This significantly speeds up builds
+# using the remote cache since less data needs to be fetched. Enable it explicitly here and set
+# remote_cache_eviction_retries just in case there are cache evictions during the build.
+# TODO(soon): If this proves stable also try --remote_download_minimal for test builds.
+# https://github.com/bazelbuild/bazel/issues/20576 may need to be addressed beforehand.
+build --remote_download_toplevel
+build --experimental_remote_cache_eviction_retries=3
 
 # Enable webgpu
 build --//src/workerd/io:enable_experimental_webgpu=True

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
         # static libraries, for example the Rust STL. This is equivalent to the -Wl,-S linker
         # option, symbols will not be removed.
         run: |
-          bazelisk build --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=${{ matrix.bazel-config }} //src/workerd/server:workerd
+          bazelisk build --jobs=32 --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=${{ matrix.bazel-config }} //src/workerd/server:workerd
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,13 +143,19 @@ jobs:
         # Configure git to quell an irrelevant warning for runners (they never commit / push).
         run: git config core.hooksPath githooks
       - name: Bazel build
+        # Use a higher jobs level to effectively fetch from CPU and and use the remote cache at the
+        # same time, see https://github.com/bazelbuild/bazel/issues/6394. 32 is still a fairly
+        # small number here and should work for the small CI runners we use, if we switch to a
+        # bigger runner consider increasing this towards the suggested value of 200.
+        # Note the number of maximum build jobs is controlled by the --local_resources=cpu flag and
+        # still limited to the number of cores by default.
         # timestamps are no longer being added here, the GitHub logs include timestamps (Use
         # 'Show timestamps' on the web interface)
         run: |
-          bazelisk build ${{ matrix.config.bazel-args }} --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --verbose_failures --config=v8-codegen-opt //...
+          bazelisk build ${{ matrix.config.bazel-args }} --jobs=32 --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --verbose_failures --config=v8-codegen-opt //...
       - name: Bazel test
         run: |
-          bazelisk test ${{ matrix.config.bazel-args }} --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --keep_going --verbose_failures --test_output=errors --config=v8-codegen-opt //...
+          bazelisk test ${{ matrix.config.bazel-args }} --jobs=32 --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --keep_going --verbose_failures --test_output=errors --config=v8-codegen-opt //...
       - name: Report disk usage (in MB)
         if: always()
         shell: bash


### PR DESCRIPTION
bazelbuild/bazel#22785 fixes a bug remote caching bug that prevented us from fetching only top-level targets from cache. Enabling that option should speed up CI runs.
Also increase the number of concurrent Bazel jobs, see bazelbuild/bazel#6394