### PR TITLE
[CI] Fix Windows build by disabling BwoB there

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,12 +7,14 @@ test --test_tag_filters=-off-by-default,-slow
 common --noenable_bzlmod
 
 # bazel7 enables Build without the Bytes (BwoB) by default. This significantly speeds up builds
-# using the remote cache since less data needs to be fetched. Enable it explicitly here and set
-# remote_cache_eviction_retries just in case there are cache evictions during the build.
+# using the remote cache since less data needs to be fetched. Set remote_cache_eviction_retries
+# just in case there are cache evictions during the build.
 # TODO(soon): If this proves stable also try --remote_download_minimal for test builds.
 # https://github.com/bazelbuild/bazel/issues/20576 may need to be addressed beforehand.
-build --remote_download_toplevel
 build --experimental_remote_cache_eviction_retries=3
+# Windows build is failing on some runs due to FileAccessException errors, appears to be
+# https://github.com/bazelbuild/bazel/issues/15010 happening again. Disable BwoB for now.
+build:windows --remote_download_all
 
 # Enable webgpu
 build --//src/workerd/io:enable_experimental_webgpu=True


### PR DESCRIPTION
The Windows build has the most to gain from BwoB, but I guess it's still broken there...