### PR TITLE
Complete typescript migration for Pyodide glue code

### DIFF
--- a/src/pyodide/internal/loadPackage.ts
+++ b/src/pyodide/internal/loadPackage.ts
@@ -73,7 +73,7 @@ class ArrayBufferReader {
   }
 }
 
-export async function loadPackages(Module: Module, requirements: string[]) {
+export async function loadPackages(Module: Module, requirements: Set<string>) {
   if (!LOAD_WHEELS_FROM_R2) return;
 
   let loadPromises = [];

--- a/src/pyodide/internal/metadatafs.ts
+++ b/src/pyodide/internal/metadatafs.ts
@@ -1,9 +1,7 @@
-// @ts-nocheck
 import { default as MetadataReader } from "pyodide-internal:runtime-generated/metadata";
 import { createReadonlyFS } from "pyodide-internal:readOnlyFS";
 
-declare type TreeNode = Map<string, TreeNode>;
-function createTree(paths: string[]): TreeNode {
+function createTree(paths: string[]): MetadataFSInfo {
   const tree = new Map();
   paths.forEach((elt: string, idx: number) => {
     let subTree = tree;
@@ -27,7 +25,7 @@ export function createMetadataFS(Module: Module): object { // TODO: Make this ty
   const names = MetadataReader.getNames();
   const sizes = MetadataReader.getSizes();
   const rootInfo = createTree(names);
-  const FSOps = {
+  const FSOps: FSOps = {
     getNodeMode(parent, name, info) {
       return {
         permissions: 0o555, // read and execute but not write
@@ -48,13 +46,13 @@ export function createMetadataFS(Module: Module): object { // TODO: Make this ty
       }
     },
     readdir(node) {
-      return Array.from(node.tree.keys());
+      return Array.from(node.tree!.keys());
     },
     lookup(parent, name) {
-      return parent.tree.get(name);
+      return parent.tree!.get(name)!;
     },
     read(stream, position, buffer) {
-      return MetadataReader.read(stream.node.index, position, buffer);
+      return MetadataReader.read(stream.node.index!, position, buffer);
     },
   };
 

--- a/src/pyodide/internal/readOnlyFS.ts
+++ b/src/pyodide/internal/readOnlyFS.ts
@@ -1,10 +1,10 @@
-export function createReadonlyFS(FSOps: FSOps, Module: Module) {
+export function createReadonlyFS<Info>(FSOps: FSOps<Info>, Module: Module): EmscriptenFS<Info> {
   const FS = Module.FS;
-  const ReadOnlyFS: EmscriptenFS = {
+  const ReadOnlyFS: EmscriptenFS<Info> = {
     mount(mount) {
       return ReadOnlyFS.createNode(null, "/", mount.opts.info);
     },
-    createNode(parent, name, info) {
+    createNode(parent, name, info): FSNode<Info> {
       let { permissions: mode, isDir } = FSOps.getNodeMode(parent, name, info);
       if (isDir) {
         mode |= 1 << 14; // set S_IFDIR
@@ -60,7 +60,10 @@ export function createReadonlyFS(FSOps: FSOps, Module: Module) {
         } else if (whence === 2) {
           // SEEK_END
           if (FS.isFile(stream.node.mode)) {
-            position += stream.node.info.size;
+            if ((stream.node.info as any).size == undefined){
+              throw new Error("File size is undefined");
+            }
+            position += (stream.node.info as any).size;
           }
         }
         return position;

--- a/src/pyodide/internal/readOnlyFS.ts
+++ b/src/pyodide/internal/readOnlyFS.ts
@@ -1,7 +1,6 @@
-// @ts-nocheck
-export function createReadonlyFS(FSOps, Module) {
+export function createReadonlyFS(FSOps: FSOps, Module: Module) {
   const FS = Module.FS;
-  const ReadOnlyFS = {
+  const ReadOnlyFS: EmscriptenFS = {
     mount(mount) {
       return ReadOnlyFS.createNode(null, "/", mount.opts.info);
     },

--- a/src/pyodide/internal/setupPackages.ts
+++ b/src/pyodide/internal/setupPackages.ts
@@ -34,7 +34,7 @@ class SitePackagesDir {
     this.rootInfo = {
       children: new Map(),
       mode: 0o777,
-      type: 5,
+      type: "5",
       modtime: 0,
       size: 0,
       path: "",
@@ -147,12 +147,12 @@ export function buildSitePackages(
  *
  * TODO: stop using loadPackage in workerd.
  */
-export function patchLoadPackage(pyodide: { loadPackage: Function }): void {
+export function patchLoadPackage(pyodide: Pyodide): void {
   pyodide.loadPackage = disabledLoadPackage;
   return;
 }
 
-function disabledLoadPackage() {
+function disabledLoadPackage(): never {
   throw new Error(
     "pyodide.loadPackage is disabled because packages are encoded in the binary",
   );

--- a/src/pyodide/internal/setupPackages.ts
+++ b/src/pyodide/internal/setupPackages.ts
@@ -27,7 +27,7 @@ const STDLIB_PACKAGES: string[] = Object.values(LOCKFILE.packages)
  * directory generated for each worker.
  */
 class SitePackagesDir {
-  public rootInfo: FSInfo;
+  public rootInfo: TarFSInfo;
   public soFiles: string[][];
   public loadedRequirements: Set<string>;
   constructor() {
@@ -51,7 +51,7 @@ class SitePackagesDir {
    * If a file or directory already exists, an error is thrown.
    * @param {TarInfo} overlayInfo The directory that is to be "copied" into site-packages
    */
-  mountOverlay(overlayInfo: FSInfo): void {
+  mountOverlay(overlayInfo: TarFSInfo): void {
     overlayInfo.children!.forEach((val, key) => {
       if (this.rootInfo.children!.has(key)) {
         throw new Error(
@@ -70,7 +70,7 @@ class SitePackagesDir {
    * @param {String} requirement The canonicalized package name this small bundle corresponds to
    */
   addSmallBundle(
-    tarInfo: FSInfo,
+    tarInfo: TarFSInfo,
     soFiles: string[],
     requirement: string,
   ): void {
@@ -89,7 +89,7 @@ class SitePackagesDir {
    * @param {List<String>} requirements canonicalized list of packages to pick from the big bundle
    */
   addBigBundle(
-    tarInfo: FSInfo,
+    tarInfo: TarFSInfo,
     soFiles: string[],
     requirements: Set<string>,
   ): void {
@@ -182,7 +182,7 @@ export function getSitePackagesPath(Module: Module): string {
  * details, so even though we want these directories to be on sys.path, we
  * handle that separately in adjustSysPath.
  */
-export function mountLib(Module: Module, info: FSInfo): void {
+export function mountLib(Module: Module, info: TarFSInfo): void {
   const tarFS = createTarFS(Module);
   const mdFS = createMetadataFS(Module);
   const site_packages = getSitePackagesPath(Module);

--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -137,7 +137,7 @@ export function preloadDynamicLibs(Module: Module): void {
   try {
     const sitePackages = getSitePackagesPath(Module);
     for (const soFile of SO_FILES_TO_LOAD) {
-      let node: FSInfo | undefined = SITE_PACKAGES.rootInfo;
+      let node: TarFSInfo | undefined = SITE_PACKAGES.rootInfo;
       for (const part of soFile) {
         node = node?.children?.get(part);
       }

--- a/src/pyodide/internal/tar.ts
+++ b/src/pyodide/internal/tar.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { default as TarReader } from "pyodide-internal:packages_tar_reader";
 
 // This is based on the info about the tar file format on wikipedia
@@ -6,21 +5,21 @@ import { default as TarReader } from "pyodide-internal:packages_tar_reader";
 // https://en.wikipedia.org/wiki/Tar_(computing)#File_format
 
 const decoder = new TextDecoder();
-function decodeString(buf) {
+function decodeString(buf: Uint8Array): string {
   const nullIdx = buf.indexOf(0);
   if (nullIdx >= 0) {
     buf = buf.subarray(0, nullIdx);
   }
   return decoder.decode(buf);
 }
-function decodeField(buf, offset, size) {
+function decodeField(buf: Uint8Array, offset: number, size: number): string {
   return decodeString(buf.subarray(offset, offset + size));
 }
-function decodeNumber(buf, offset, size) {
+function decodeNumber(buf: Uint8Array, offset: number, size: number): number {
   return parseInt(decodeField(buf, offset, size), 8);
 }
 
-function decodeHeader(buf, reader) {
+function decodeHeader(buf: Uint8Array, reader: Reader): FSInfo {
   const nameBase = decodeField(buf, 0, 100);
   const namePrefix = decodeField(buf, 345, 155);
   let path = namePrefix + nameBase;
@@ -46,12 +45,12 @@ function decodeHeader(buf, reader) {
 }
 
 export function parseTarInfo(reader = TarReader): [FSInfo, string[]] {
-  const directories = [];
+  const directories: FSInfo[] = [];
   const soFiles = [];
-  const root = {
+  const root: FSInfo = {
     children: new Map(),
     mode: 0o777,
-    type: 5,
+    type: "5",
     modtime: 0,
     size: 0,
     path: "",
@@ -108,22 +107,22 @@ export function parseTarInfo(reader = TarReader): [FSInfo, string[]] {
 
     // go up to common ancestor
     while (directories.length && !info.name.startsWith(directory.path)) {
-      directory = directories.pop();
+      directory = directories.pop()!;
     }
     // go down to target (in many tar files this second loop body is evaluated 0
     // times)
     const parts = info.path.slice(0, -1).split("/");
     for (let i = directories.length; i < parts.length - 1; i++) {
       directories.push(directory);
-      directory = directory.children.get(parts[i]);
+      directory = directory.children!.get(parts[i])!;
     }
     if (info.type === "5") {
       // a directory
       directories.push(directory);
       info.parts = parts;
-      info.name = info.parts.at(-1);
+      info.name = info.parts.at(-1)!;
       info.children = new Map();
-      directory.children.set(info.name, info);
+      directory.children!.set(info.name, info);
       directory = info;
     } else if (info.type === "0") {
       // a normal file
@@ -132,7 +131,7 @@ export function parseTarInfo(reader = TarReader): [FSInfo, string[]] {
       if (info.name.endsWith(".so")) {
         soFiles.push(info.path);
       }
-      directory.children.set(info.name, info);
+      directory.children!.set(info.name, info);
     } else {
       // fail if we encounter other values of type (e.g., symlink, LongName, etc)
       throw new Error(`Python TarFS error: Unexpected type ${info.type}`);

--- a/src/pyodide/internal/tar.ts
+++ b/src/pyodide/internal/tar.ts
@@ -19,7 +19,7 @@ function decodeNumber(buf: Uint8Array, offset: number, size: number): number {
   return parseInt(decodeField(buf, offset, size), 8);
 }
 
-function decodeHeader(buf: Uint8Array, reader: Reader): FSInfo {
+function decodeHeader(buf: Uint8Array, reader: Reader): TarFSInfo {
   const nameBase = decodeField(buf, 0, 100);
   const namePrefix = decodeField(buf, 345, 155);
   let path = namePrefix + nameBase;
@@ -44,10 +44,10 @@ function decodeHeader(buf: Uint8Array, reader: Reader): FSInfo {
   };
 }
 
-export function parseTarInfo(reader = TarReader): [FSInfo, string[]] {
-  const directories: FSInfo[] = [];
+export function parseTarInfo(reader = TarReader): [TarFSInfo, string[]] {
+  const directories: TarFSInfo[] = [];
   const soFiles = [];
-  const root: FSInfo = {
+  const root: TarFSInfo = {
     children: new Map(),
     mode: 0o777,
     type: "5",

--- a/src/pyodide/internal/tarfs.ts
+++ b/src/pyodide/internal/tarfs.ts
@@ -1,6 +1,6 @@
 import { createReadonlyFS } from "pyodide-internal:readOnlyFS";
 
-const FSOps: FSOps = {
+const FSOps: FSOps<TarFSInfo> = {
   getNodeMode(parent, name, info) {
     return {
       permissions: info.mode,
@@ -17,16 +17,25 @@ const FSOps: FSOps = {
     }
   },
   readdir(node) {
-    return Array.from(node.info.children!.keys());
+    if (!node.info.children) {
+      throw new Error("Trying to readdir from a non-dir node");
+    }
+    return Array.from(node.info.children.keys());
   },
   lookup(parent, name) {
-    return parent.info.children!.get(name)!;
+    if (!parent.info.children) {
+      throw new Error("Trying to lookup from a non-dir node");
+    }
+    return parent.info.children.get(name)!;
   },
   read(stream, position, buffer) {
     if (stream.node.contentsOffset == undefined) {
       throw new Error("contentsOffset is undefined");
     }
-    return stream.node.info.reader!.read(
+    if (!stream.node.info.reader) {
+      throw new Error("reader is undefined");
+    }
+    return stream.node.info.reader.read(
       stream.node.contentsOffset + position,
       buffer,
     );

--- a/src/pyodide/internal/tarfs.ts
+++ b/src/pyodide/internal/tarfs.ts
@@ -1,7 +1,6 @@
-// @ts-nocheck
 import { createReadonlyFS } from "pyodide-internal:readOnlyFS";
 
-const FSOps = {
+const FSOps: FSOps = {
   getNodeMode(parent, name, info) {
     return {
       permissions: info.mode,
@@ -18,19 +17,22 @@ const FSOps = {
     }
   },
   readdir(node) {
-    return Array.from(node.info.children.keys());
+    return Array.from(node.info.children!.keys());
   },
   lookup(parent, name) {
-    return parent.info.children.get(name);
+    return parent.info.children!.get(name)!;
   },
   read(stream, position, buffer) {
-    return stream.node.info.reader.read(
+    if (stream.node.contentsOffset == undefined) {
+      throw new Error("contentsOffset is undefined");
+    }
+    return stream.node.info.reader!.read(
       stream.node.contentsOffset + position,
       buffer,
     );
   },
 };
 
-export function createTarFS(Module) {
+export function createTarFS(Module: Module) {
   return createReadonlyFS(FSOps, Module);
 }

--- a/src/pyodide/types/FS.d.ts
+++ b/src/pyodide/types/FS.d.ts
@@ -1,18 +1,96 @@
+
+interface Reader {
+  read: (offset: number, dest: Uint8Array) => number;
+}
+
 interface FSInfo {
   children: Map<string, FSInfo> | undefined;
   mode: number;
-  type: number;
+  type: string;
   modtime: number;
   size: number;
   path: string;
   name: string;
   parts: string[];
   contentsOffset?: number;
+  reader?: Reader;
 }
+
+declare type MetadataFSInfo = Map<string, MetadataFSInfo>;
 
 interface FS {
   mkdir: (dirname: string) => void;
   mkdirTree: (dirname: string) => void;
   writeFile: (fname: string, contents: Uint8Array, options: object) => void;
   mount: (fs: object, options: { info?: FSInfo }, path: string) => void;
+  createNode: (parent: FSNode | null, name: string, mode: number) => FSNode;
+  isFile: (mode: number) => boolean;
+  genericErrors: Error[];
+}
+
+interface FSOps {
+  getNodeMode: (parent: FSNode | null, name: string, info: any) => {
+    permissions: number;
+    isDir: boolean;
+  };
+  setNodeAttributes: (node: FSNode, info: any, isDir: boolean) => void;
+  readdir: (node: FSNode) => string[];
+  lookup: (parent: FSNode, name: string) => (FSInfo | MetadataFSInfo);
+  read: (stream: FSStream, position: number, buffer: Uint8Array) => number;
+}
+
+interface MountOpts {
+  opts: { info: FSInfo }
+}
+
+interface FSNodeOps {
+  getattr: (node: FSNode) => FSAttr;
+  readdir: (node: FSNode) => string[];
+  lookup: (parent: FSNode, name: string) => FSNode;
+}
+
+interface FSStream {
+  node: FSNode;
+  position: number;
+}
+
+interface FSStreamOps {
+  llseek: (stream: FSStream, offset: number, whence: number) => number;
+  read: (stream: FSStream, buffer: Uint8Array, offset: number, length: number, position: number) => number;
+}
+
+interface FSNode {
+  id: number;
+  usedBytes: number;
+  mode: number;
+  modtime: number;
+  node_ops: FSNodeOps;
+  stream_ops: FSStreamOps;
+  info: FSInfo;
+  contentsOffset?: number;
+  tree?: MetadataFSInfo;
+  index?: number;
+}
+
+interface FSAttr {
+  dev: number;
+  ino: number;
+  mode: number;
+  nlink: number;
+  uid: number;
+  gid: number,
+  rdev: number,
+  size: number,
+  atime: Date,
+  mtime: Date,
+  ctime: Date,
+  blksize: number;
+  blocks: number;
+}
+
+interface EmscriptenFS {
+  mount: (mount: MountOpts) => FSNode;
+  createNode: (parent: FSNode | null, name: string, info: FSInfo | MetadataFSInfo) => FSNode;
+  node_ops: FSNodeOps;
+  stream_ops: FSStreamOps;
 }

--- a/src/pyodide/types/Module.d.ts
+++ b/src/pyodide/types/Module.d.ts
@@ -1,7 +1,3 @@
-interface Pyodide {
-  _module: Module;
-  registerJsModule: (handle: string, mod: object) => void;
-}
 
 interface ENV {
   HOME: string;

--- a/src/pyodide/types/Pyodide.d.ts
+++ b/src/pyodide/types/Pyodide.d.ts
@@ -1,0 +1,16 @@
+declare type Handler = ((...args: any[]) => any);
+
+interface PyModule {
+  [handlerName: string]: {
+    callRelaxed: (...args: any[]) => any
+  };
+}
+
+interface Pyodide {
+  _module: Module;
+  registerJsModule: (handle: string, mod: object) => void;
+  pyimport: (moduleName: string) => PyModule;
+  FS: FS;
+  site_packages: string;
+  loadPackage: (names: string | string[], options: object) => Promise<any[]>;
+}

--- a/src/pyodide/types/limiter.d.ts
+++ b/src/pyodide/types/limiter.d.ts
@@ -1,0 +1,12 @@
+// A typescript declaration file for the internal Limiter JSG class
+// see src/workerd/api/pyodide/pyodide.h (SimplePythonLimiter)
+
+
+interface Limiter {
+  beginStartup: () => void;
+  finishStartup: () => void;
+}
+
+declare const limiter: Limiter;
+
+export default limiter;

--- a/src/pyodide/types/packages_tar_reader.d.ts
+++ b/src/pyodide/types/packages_tar_reader.d.ts
@@ -1,5 +1,4 @@
-declare namespace TarReader {
-  const read: (offset: number, dest: Uint8Array) => void;
-}
+
+declare const TarReader: Reader;
 
 export default TarReader;

--- a/src/pyodide/types/runtime-generated/metadata.d.ts
+++ b/src/pyodide/types/runtime-generated/metadata.d.ts
@@ -14,6 +14,7 @@ declare namespace MetadataReader {
   ) => void;
   const getMemorySnapshotSize: () => number;
   const disposeMemorySnapshot: () => void;
+  const read: (index: number, position: number, buffer: Uint8Array) => number;
 }
 
 export default MetadataReader;


### PR DESCRIPTION
Last batch of types being added to the Pyodide glue code. There's a bit of jankiness around the filesystem (specifically the `info` object which can technically be any type). There was also a spot where the node type for directories was `5` vs `"5"`, but that didn't end up getting used in a critical path. I made them all `"5"` for consistency. 