### PR TITLE
fix: add Symbol.toStringTag to KeyObject instances

### DIFF
--- a/src/node/internal/crypto_keys.ts
+++ b/src/node/internal/crypto_keys.ts
@@ -158,6 +158,10 @@ export abstract class KeyObject {
   }
 
   abstract get type() : KeyObjectType;
+
+  get [Symbol.toStringTag]() {
+    return "KeyObject"
+  }
 }
 
 abstract class AsymmetricKeyObject extends KeyObject {


### PR DESCRIPTION
As per https://github.com/nodejs/node/pull/46043, this adds Symbol.toStringTag getter to KeyObject.