### PR TITLE
Fixes Socket::startTls assert failure when request IoContext ends.

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -339,7 +339,12 @@ jsg::Ref<Socket> Socket::startTls(jsg::Lock& js, jsg::Optional<TlsOptions> tlsOp
       }
     }
 
-    // All non-secure sockets should have a tlsStarter.
+    // All non-secure sockets should have a tlsStarter. Though since tlsStarter is an IoOwn, if
+    // the request's IoContext has ended then `tlsStarter` will be null. This can happen if the
+    // flush operation is taking a particularly long time (EW-8538), so we throw a JSG error if
+    // that's the case.
+    JSG_REQUIRE(*tlsStarter != nullptr, TypeError,
+        "The request has finished before startTls completed.");
     auto secureStream = KJ_ASSERT_NONNULL(*tlsStarter)(acceptedHostname).then(
       [stream = connectionStream->addWrappedRef()]() mutable -> kj::Own<kj::AsyncIoStream> {
         return kj::mv(stream);


### PR DESCRIPTION
The `tlsStarter` is an `IoOwn` which means that it gets deallocated when the request's IoContext ends. In the `startTls` implementation we wait for a `flush` to complete before we use the `tlsStarter`, the `flush` may complete after the lifetime of the IoContext at which point the `tlsStarter` will be null and the `KJ_ASSERT_NONNULL` will fail.

This PR throws a JSG error instead which should (hopefully) fail more gracefully.