### PR TITLE
[CI] Disable Bazel remote cache Build without the Bytes on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,8 +13,8 @@ build --experimental_remote_cache_eviction_retries=3
 # Note that we use remote_download_minimal for test builds, which avoids fetching build outputs
 # where possible. While several previous BwoB bugs have been fixed, this is slower than it could be
 # due to https://github.com/bazelbuild/bazel/issues/20576.
-# Windows build is failing on some runs due to FileAccessException errors, appears to be
-# https://github.com/bazelbuild/bazel/issues/15010 happening again. Disable BwoB for now.
+# Windows build is failing on some runs due to FileAccessException errors, Bazel has had several
+# similar bugs in the past. Disable BwoB for now.
 build:windows --remote_download_all
 
 # Enable webgpu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,11 @@ jobs:
           - os:     { name: linux, image: ubuntu-20.04 }
             config: { suffix: -asan, bazel-args: --config=asan }
           # Windows has a custom non-debug bazel config.
+          # As of 7.2.1 support for Bazel remote cache BwoB is broken on Windows, likely due to
+          # disk I/O race conditions causing permission denied errors (this also happened in
+          # previous versions). Use remote_download_all for now.
           - os:     { name : windows, image : windows-2022 }
-            config: { suffix: '', bazel-args: --config=windows_no_dbg }
+            config: { suffix: '', bazel-args: "--config=windows_no_dbg --remote_download_all" }
           # TODO (later): The custom Windows-debug configuration consistently runs out of disk
           # space on CI, disable it for now. Once https://github.com/bazelbuild/bazel/issues/21615
           # has been resolved we can likely re-enable it and possibly fold up the custom
@@ -166,10 +169,10 @@ jobs:
         # timestamps are no longer being added here, the GitHub logs include timestamps (Use
         # 'Show timestamps' on the web interface)
         run: |
-          bazelisk build ${{ matrix.config.bazel-args }} --remote_download_minimal --jobs=32 --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --verbose_failures --config=v8-codegen-opt //...
+          bazelisk build --remote_download_minimal ${{ matrix.config.bazel-args }} --jobs=32 --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --verbose_failures --config=v8-codegen-opt //...
       - name: Bazel test
         run: |
-          bazelisk test ${{ matrix.config.bazel-args }} --remote_download_minimal --jobs=32 --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --keep_going --verbose_failures --test_output=errors --config=v8-codegen-opt //...
+          bazelisk test --remote_download_minimal ${{ matrix.config.bazel-args }} --jobs=32 --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --keep_going --verbose_failures --test_output=errors --config=v8-codegen-opt //...
       - name: Report disk usage (in MB)
         if: always()
         shell: bash


### PR DESCRIPTION
The previous commit accidentally enabled it again – turning on remote_download_minimal should be restricted to Linux and macOS.