### PR TITLE
Implement JSG_DETACHED_METHOD and JSG_DETACHED_METHOD_NAMED

### DIFF
--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -422,6 +422,53 @@ KJ_TEST("jsg::Lock getUuid") {
   KJ_ASSERT(called);
 }
 
+// ========================================================================================
+struct DetachedMethodContext: public ContextGlobalObject {
+
+  struct FooObject: public jsg::Object {
+    static bool foo() { return true; }
+
+    // TODO(simplify): The baz() method here shows what is currently the only way to
+    // extract the `this` object that a detached or static method may have been bound
+    // to (using either bind(...) in JS or the .call(...) or .apply(...) methods).
+    // We could potentially simplify this by introducing a new `jsg::Self<T>` type of
+    // special placeholder argument that would be automatically filled in with the
+    // bound `this`, if any.
+    static bool baz(const v8::FunctionCallbackInfo<v8::Value>& info,
+                    const TypeHandler<Ref<FooObject>>& handler) {
+      auto& js = jsg::Lock::from(info.GetIsolate());
+      KJ_IF_SOME(self, handler.tryUnwrap(js, info.This())) {
+        return self->abc();
+      }
+      return false;
+    }
+
+    bool abc() { return true; }
+
+    static jsg::Ref<FooObject> constructor() { return jsg::alloc<FooObject>(); }
+    JSG_RESOURCE_TYPE(FooObject) {
+      JSG_DETACHED_METHOD(foo);
+      JSG_DETACHED_METHOD_NAMED(bar, foo);
+      JSG_DETACHED_METHOD(baz);
+    }
+  };
+
+  JSG_RESOURCE_TYPE(DetachedMethodContext) {
+    JSG_NESTED_TYPE(FooObject);
+  }
+};
+JSG_DECLARE_ISOLATE_TYPE(DetachedMethodIsolate,
+                         DetachedMethodContext,
+                         DetachedMethodContext::FooObject);
+
+KJ_TEST("detached method") {
+  Evaluator<DetachedMethodContext, DetachedMethodIsolate> e(v8System);
+  e.expectEval("const {foo} = new FooObject(); foo()", "boolean", "true");
+  e.expectEval("const {bar} = new FooObject(); bar()", "boolean", "true");
+  e.expectEval("const obj = new FooObject(); const {baz} = obj; baz.call(obj)", "boolean", "true");
+  e.expectEval("const obj = new FooObject(); const {baz} = obj; baz.call(123)", "boolean", "false");
+}
+
 }  // namespace
 
 }  // namespace workerd::jsg::test

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -428,16 +428,8 @@ struct DetachedMethodContext: public ContextGlobalObject {
   struct FooObject: public jsg::Object {
     static bool foo() { return true; }
 
-    // TODO(simplify): The baz() method here shows what is currently the only way to
-    // extract the `this` object that a detached or static method may have been bound
-    // to (using either bind(...) in JS or the .call(...) or .apply(...) methods).
-    // We could potentially simplify this by introducing a new `jsg::Self<T>` type of
-    // special placeholder argument that would be automatically filled in with the
-    // bound `this`, if any.
-    static bool baz(const v8::FunctionCallbackInfo<v8::Value>& info,
-                    const TypeHandler<Ref<FooObject>>& handler) {
-      auto& js = jsg::Lock::from(info.GetIsolate());
-      KJ_IF_SOME(self, handler.tryUnwrap(js, info.This())) {
+    static bool baz(This<jsg::Ref<FooObject>> self) {
+      KJ_IF_SOME(self, self.value) {
         return self->abc();
       }
       return false;

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -202,7 +202,7 @@ namespace workerd::jsg {
   } while (false)
 
 // Like JSG_METHOD, except that the JS method is expected to be detachable from the object
-// (using destructuring syntax). Unlike JSG_METHOD, these methods must be defined as static
+// (e.g. using destructuring syntax). Unlike JSG_METHOD, these methods must be defined as static
 // methods on the underlying C++ type.
 #define JSG_DETACHED_METHOD(name) \
   do { \
@@ -1305,6 +1305,25 @@ Ref<T> _jsgThis(T* obj) {
 }
 
 #define JSG_THIS (::workerd::jsg::_jsgThis(this))
+
+// A helper placeholder type for extracting the `this` object from a method call. Use this in
+// cases where a function is being called that is not attached to a base object but still may
+// need to access the `this`. If the this cannot be successfully unwrapped to the given type,
+// then value will be kj::none. Typically this is only useful for static or detached methods.
+template <typename T>
+struct This {
+  kj::Maybe<T> value;
+};
+
+// Is `T` some specialization of `This<U>`?
+template <typename T> struct IsThis_ { static constexpr bool value = false; };
+
+// Is `T` some specialization of `This<U>`?
+template <typename T> struct IsThis_<This<T>> { static constexpr bool value = true; };
+
+// Is `T` some specialization of `This<U>`?
+template <typename T>
+constexpr bool isThis() { return IsThis_<T>::value; }
 
 // Holds a value of type `T` and allows it to be passed to JavaScript multiple times, resulting
 // in exactly the same JavaScript object each time (will compare equal using `===`). You may

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -201,6 +201,21 @@ namespace workerd::jsg {
     registry.template registerMethod<NAME, decltype(&Self::method), &Self::method>(); \
   } while (false)
 
+// Like JSG_METHOD, except that the JS method is expected to be detachable from the object
+// (using destructuring syntax). Unlike JSG_METHOD, these methods must be defined as static
+// methods on the underlying C++ type.
+#define JSG_DETACHED_METHOD(name) \
+  do { \
+    static const char NAME[] = #name; \
+    registry.template registerDetachedMethod<NAME, decltype(Self::name), &Self::name>(); \
+  } while (false)
+
+#define JSG_DETACHED_METHOD_NAMED(name, method) \
+  do { \
+    static const char NAME[] = #name; \
+    registry.template registerDetachedMethod<NAME, decltype(Self::method), &Self::method>(); \
+  } while (false)
+
 // Use inside a JSG_RESOURCE_TYPE block to declare that the given method should be callable from
 // JavaScript on the resource type's constructor.
 #define JSG_STATIC_METHOD(name) \

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -846,6 +846,16 @@ struct ResourceTypeBuilder {
   }
 
   template<const char* name, typename Method, Method method>
+  inline void registerDetachedMethod() {
+    auto functionTemplate = v8::FunctionTemplate::New(isolate,
+        &StaticMethodCallback<TypeWrapper, name, Self, Method, method,
+                              ArgumentIndexes<Method>>::callback,
+        v8::Local<v8::Value>(), v8::Local<v8::Signature>(), 0, v8::ConstructorBehavior::kThrow);
+    functionTemplate->RemovePrototype();
+    prototype->Set(v8StrIntern(isolate, name), functionTemplate);
+  }
+
+  template<const char* name, typename Method, Method method>
   inline void registerStaticMethod() {
     // Notably, we specify an empty signature because a static method invocation will have no holder
     // object.
@@ -1121,6 +1131,9 @@ struct JsSetup {
 
   template<const char* name, typename Method, Method method>
   inline void registerMethod() { }
+
+  template <const char* name, typename Method, Method method>
+  inline void registerDetachedMethod() { }
 
   template<const char* name, typename Method, Method method>
   inline void registerStaticMethod() { }

--- a/src/workerd/jsg/rtti.capnp
+++ b/src/workerd/jsg/rtti.capnp
@@ -182,6 +182,8 @@ struct JsgImplType {
     v8PropertyCallbackInfo @8;
 
     jsgName @9;
+
+    jsgThisPlaceholder @10;
   }
 
   type @0 :Type;

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -553,6 +553,9 @@ struct MemberCounter {
   template<const char* name, typename Method, Method method>
   inline void registerMethod() { ++members; }
 
+  template<const char* name, typename Method, Method method>
+  inline void registerDetachedMethod() { ++members; }
+
   template<typename Method, Method method>
   inline void registerCallable() { /* not a member */ }
 
@@ -744,6 +747,17 @@ struct MembersBuilder {
 
   template<const char* name, typename Method, Method>
   inline void registerMethod() {
+    auto method = members[memberIndex++].initMethod();
+
+    method.setName(name);
+    using Traits = FunctionTraits<Method>;
+    BuildRtti<Configuration, typename Traits::ReturnType>::build(method.initReturnType(), rtti);
+    using Args = typename Traits::ArgsTuple;
+    TupleRttiBuilder<Configuration, Args>::build(method.initArgs(std::tuple_size_v<Args>), rtti);
+  }
+
+  template<const char* name, typename Method, Method>
+  inline void registerDetachedMethod() {
     auto method = members[memberIndex++].initMethod();
 
     method.setName(name);

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -499,6 +499,12 @@ struct BuildRtti<Configuration, jsg::TypeHandler<T>> {
   }
 };
 
+template<typename Configuration, typename T>
+struct BuildRtti<Configuration, jsg::This<T>> {
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) {
+    builder.initJsgImpl().setType(JsgImplType::Type::JSG_THIS_PLACEHOLDER);
+  }
+};
 
 // Functions
 

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -391,6 +391,7 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
                    public NonCoercibleWrapper<Self>,
                    public MemoizedIdentityWrapper<Self>,
                    public IdentifiedWrapper<Self>,
+                   public ThisWrapper<Self>,
                    public SelfRefWrapper<Self>,
                    public ExceptionWrapper<Self>,
                    public ObjectWrapper<Self>,
@@ -448,6 +449,7 @@ public:
   USING_WRAPPER(NonCoercibleWrapper<Self>);
   USING_WRAPPER(MemoizedIdentityWrapper<Self>);
   USING_WRAPPER(IdentifiedWrapper<Self>);
+  USING_WRAPPER(ThisWrapper<Self>);
   USING_WRAPPER(SelfRefWrapper<Self>);
   USING_WRAPPER(ExceptionWrapper<Self>);
   USING_WRAPPER(ObjectWrapper<Self>);
@@ -500,6 +502,8 @@ public:
 
     if constexpr(kj::isSameType<V, Varargs>()) {
       return Varargs(parameterIndex, args);
+    } else if constexpr(isThis<V>()) {
+      return KJ_ASSERT_NONNULL(this->tryUnwrap(context, args.This(), (V*)nullptr, kj::none));
     } else if constexpr(isArguments<V>()) {
       using E = typename V::ElementType;
       size_t size = args.Length() >= parameterIndex ? args.Length() - parameterIndex : 0;

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -901,7 +901,7 @@ public:
       return  v8::ArrayBuffer::New(isolate, 0);
     }
     byte* begin = value.begin();
-    
+
     auto ownerPtr = new kj::Array<byte>(kj::mv(value));
 
     std::unique_ptr<v8::BackingStore> backing =
@@ -1183,6 +1183,33 @@ public:
                                            v8::Local<v8::Value> handle,
                                            MemoizedIdentity<T>*,
                                            kj::Maybe<v8::Local<v8::Object>> parentObject) = delete;
+};
+
+// =======================================================================================
+template <typename TypeWrapper>
+class ThisWrapper {
+public:
+  template <typename T>
+  static auto getName(This<T>*) {
+    return TypeWrapper::getName((T*)nullptr);
+  }
+
+  template <typename T>
+  v8::Local<v8::Value> wrap(
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      This<T>& value) = delete;
+
+  template <typename T>
+  kj::Maybe<This<T>> tryUnwrap(v8::Local<v8::Context> context,
+                               v8::Local<v8::Value> handle,
+                               This<T>*,
+                               kj::Maybe<v8::Local<v8::Object>> parentObject) {
+    auto& wrapper = static_cast<TypeWrapper&>(*this);
+    return This<T> {
+      .value = wrapper.tryUnwrap(context, handle, (T*)nullptr, parentObject),
+    };
+  }
 };
 
 // =======================================================================================


### PR DESCRIPTION
These new macros allow defining instance methods on JSG objects that can be detached from the object using destructuring assignment, etc. They fill an existing gap between JSG_METHOD and JSG_STATIC_METHOD.

```cpp
struct Foo : public jsg::Object {
  static void foo() {};
  void bar() {}
  static void baz() {}

  JSG_RESOURCE_TYPE(Foo) {
    JSG_DETACHED_METHOD(foo);
    JSG_METHOD(bar);
    JSG_STATIC_METHOD(baz);
  }
};
```

```js
const obj = new Foo();

// The bar method can only be called attached or bound to the Foo
obj.bar();  // Ok!

const { bar } = obj;

bar.call(obj); // Ok!
bar.apply(obj); // Ok!
bar.bind(obj)(); // Ok!
bar(); // Error: illegal invocation!

// The baz method is only defined statically on the Foo class
Foo.baz();  // Ok!
obj.baz(); // Error! baz is not a function

// Since foo is defined as a detached method, it can be called
// with or without the object as the receiver

obj.foo(); // Ok!
const { foo } = obj;
foo(); // Ok!

foo.call(obj); // Ok!
foo.call(null); // Ok!
foo.apply(obj); // Ok!
foo.apply(null); // Ok!
```

~~There is a bit of complexity if the implementation of `foo()` does in fact need to know if there is a `this` bound to it. In that case the current only solution is to define the method signature of `foo()` as accepting a `const v8::FunctionCallBackInfo<v8::Value>&` as the first argument, which allows the implementation to check and unwrap the `this` object if it is bound. We can potentially simplify that a bit. See the included jsg-test for an example of how to do this and some discussion around how to simplify.~~ added a commit that simplifies this bit