### PR TITLE
add matchesGlob placeholder to node:path

### DIFF
--- a/src/node/internal/internal_path.ts
+++ b/src/node/internal/internal_path.ts
@@ -182,6 +182,10 @@ const win32 = {
     throw new Error('path.win32.parse() is not implemented.');
   },
 
+  matchesGlob(_path: string, _pattern: string): boolean {
+    throw new Error('path.win32.matchesGlob() is not implemented.');
+  },
+
   sep: '\\',
   delimiter: ';',
   win32: null as Object|null,
@@ -625,6 +629,10 @@ const posix = {
       ret.dir = '/';
 
     return ret;
+  },
+
+  matchesGlob(_path: string, _pattern: string): boolean {
+    throw new Error('path.posix.matchesGlob() is not implemented.');
   },
 
   sep: '/',

--- a/src/node/path.ts
+++ b/src/node/path.ts
@@ -24,6 +24,7 @@ const {
   parse,
   sep,
   delimiter,
+  matchesGlob,
 } = posix;
 
 export {
@@ -42,6 +43,7 @@ export {
   delimiter,
   posix,
   win32,
+  matchesGlob,
 };
 
 export { default } from 'node-internal:internal_path';


### PR DESCRIPTION
Adds a placeholder for `matchesGlob` which didn't get released on a Node.js release line, yet. 

Documentation is available at: https://github.com/nodejs/node/blob/ce2faef3a70ae1b8336b2628b7f01b07d5402fbc/doc/api/path.md?plain=1#L282
PR is available at: https://github.com/nodejs/node/pull/52881