### PR TITLE
adding loadShed outcome

### DIFF
--- a/src/workerd/io/outcome.capnp
+++ b/src/workerd/io/outcome.capnp
@@ -25,5 +25,5 @@ enum EventOutcome {
   scriptNotFound @6;
   canceled @7;
   exceededMemory @8;
-  unavailable @9;
+  loadShed @9;
 }

--- a/src/workerd/io/outcome.capnp
+++ b/src/workerd/io/outcome.capnp
@@ -25,4 +25,5 @@ enum EventOutcome {
   scriptNotFound @6;
   canceled @7;
   exceededMemory @8;
+  unavailable @9;
 }


### PR DESCRIPTION
loadShed means the server didn't start processing the request. It could happen when server is overloaded or in some other not-very-healthy state.

Not used anywhere yet, the plan is to use for load-shedding experiments. There's downstream change open updating the master copy.