### PR TITLE
[build] Reduce STL header include overhead, O0 code size

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -61,6 +61,17 @@ build:v8-codegen-opt --per_file_copt=v8/src/objects@-O2
 build:v8-codegen-opt --per_file_copt=v8/src/wasm@-O2
 build:v8-codegen-opt --per_file_copt=v8/src/base@-O2
 
+# Disable relaxing all jumps during LLVM codegen under -O0, which previously led to build
+# performance improvements but makes code size worse. This will be the default in LLVM19.
+# https://maskray.me/blog/2024-04-27-clang-o0-output-branch-displacement-and-size-increase
+build:unix --copt="-mno-relax-all" --host_copt="-mno-relax-all"
+
+# Limit transitive header includes within libc++. This improves compliance with IWYU, helps avoid
+# errors with downstream projects that implicitly define this already and reduces total include size.
+https://libcxx.llvm.org/DesignDocs/HeaderRemovalPolicy.html
+build:unix --cxxopt=-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES
+build:unix --host_cxxopt=-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES
+
 # Need to redefine _WIN32_WINNT to build dawn on Windows
 build:windows --per_file_copt='external/dawn@-Wno-macro-redefined'
 build:windows --host_per_file_copt='external/dawn@-Wno-macro-redefined'

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,10 +44,10 @@ bazel_features_deps()
 
 http_archive(
     name = "capnp-cpp",
-    integrity = "sha256-r2LCeW0nWWzS72WLQaFpzbJ+f/F191Mze1PllHWGV6E=",
-    strip_prefix = "capnproto-capnproto-b343a79/c++",
+    integrity = "sha256-u4TajPQnM3yQIcLUghhNnEUslu0o3q0VdY3jRoPq7yM=",
+    strip_prefix = "capnproto-capnproto-6446b72/c++",
     type = "tgz",
-    urls = ["https://github.com/capnproto/capnproto/tarball/b343a799317e6a4b83d2a27bf712498fd5346985"],
+    urls = ["https://github.com/capnproto/capnproto/tarball/6446b721a9860eebccf9d3c73b27610491359b5a"],
 )
 
 http_archive(


### PR DESCRIPTION
- The include and code size optimizations are already enabled in the downstream project.
- Use cleaner syntax when disabling legacy_external_runfiles.