### PR TITLE
Only ask for nodejs_als in the async-context sample

### DIFF
--- a/samples/async-context/config.capnp
+++ b/samples/async-context/config.capnp
@@ -31,5 +31,8 @@ const helloWorld :Workerd.Worker = (
     (name = "worker", esModule = embed "worker.js")
   ],
   compatibilityDate = "2023-02-28",
-  compatibilityFlags = ["nodejs_compat"]
+  # Only ask for workerd's implementation of `node:async_hooks`'s AsyncLocalStorage, 
+  # instead of all of the node compatibility APIs, provided by `nodejs_compat`. See:
+  # https://developers.cloudflare.com/workers/configuration/compatibility-dates/#nodejs-compatibility-flag
+  compatibilityFlags = ["nodejs_als"]
 );


### PR DESCRIPTION
I think it's best to encourage people to use this narrower flag instead of making the entirety of the emulated nodejs API available, as the documentation explains.

I don't think there's any build interactions with samples/ at all, so I manually ran this sample with my changes and confirmed it works.