### PR TITLE
Remove websocket locality

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -849,13 +849,9 @@ void DurableObjectState::acceptWebSocket(
     jsg::Optional<kj::Array<kj::String>> tags) {
   JSG_ASSERT(!ws->isAccepted(), Error,
       "Cannot call `acceptWebSocket()` if the WebSocket was already accepted via `accept()`");
-  JSG_ASSERT(ws->pairIsAwaitingCoupling(), Error,
+  JSG_ASSERT(ws->peerIsAwaitingCoupling(), Error,
       "Cannot call `acceptWebSocket()` on this WebSocket because its pair has already been "\
       "accepted or used in a Response.");
-  // WebSocket::couple() will keep the IoContext around if the websocket we return in the Response
-  // is `LOCAL`, so we have to set it to remote. Note that `setRemoteOnPair()` will throw if
-  // `ws` is not an end of a WebSocketPair.
-  ws->setRemoteOnPair();
 
   // We need to get a HibernationManager to give the websocket to.
   auto& a = KJ_REQUIRE_NONNULL(IoContext::current().getActor());

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1808,7 +1808,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(
               jsRequest->getMethodEnum(), kj::mv(urlList),
               response.statusCode, response.statusText, *response.headers,
               newNullInputStream(),
-              jsg::alloc<WebSocket>(kj::mv(webSocket), WebSocket::REMOTE),
+              jsg::alloc<WebSocket>(kj::mv(webSocket)),
               Response::BodyEncoding::AUTO,
               kj::mv(signal)));
         }


### PR DESCRIPTION
Refactor workerd::api::WebSocket such that it no longer needs callers to indicate "locality" to decide whether to register pending events.

Whether to register pending events (and whether to tie the lifetime of the websocket connection to the IoContext) can be determined purely based on existing internal state.

I've reasoned through each case and this should be a non-functional change. I'm somewhat relying on test coverage to back that up, though.

This change was prompted by me trying to figure out when the server side of a websocket terminated in a worker or not (so I could add some appropriate logic) and this was obfuscated by the `setRemoteOnPair` hack.