### PR TITLE
webgpu: new callback mode

### DIFF
--- a/src/workerd/api/gpu/gpu-adapter-info.c++
+++ b/src/workerd/api/gpu/gpu-adapter-info.c++
@@ -3,12 +3,11 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "gpu-adapter-info.h"
-#include "workerd/jsg/exception.h"
 
 namespace workerd::api::gpu {
 
-GPUAdapterInfo::GPUAdapterInfo(WGPUAdapterProperties properties)
-    : vendor_(kj::str(properties.vendorName)), architecture_(kj::str(properties.architecture)),
-      device_(kj::str(properties.name)), description_(kj::str(properties.driverDescription)) {}
+GPUAdapterInfo::GPUAdapterInfo(wgpu::AdapterInfo info)
+    : vendor_(kj::str(info.vendor)), architecture_(kj::str(info.architecture)),
+      device_(kj::str(info.device)), description_(kj::str(info.description)) {}
 
 } // namespace workerd::api::gpu

--- a/src/workerd/api/gpu/gpu-adapter-info.h
+++ b/src/workerd/api/gpu/gpu-adapter-info.h
@@ -11,7 +11,7 @@ namespace workerd::api::gpu {
 
 class GPUAdapterInfo : public jsg::Object {
 public:
-  explicit GPUAdapterInfo(WGPUAdapterProperties);
+  explicit GPUAdapterInfo(wgpu::AdapterInfo);
   JSG_RESOURCE_TYPE(GPUAdapterInfo) {
     JSG_READONLY_PROTOTYPE_PROPERTY(vendor, getVendor);
     JSG_READONLY_PROTOTYPE_PROPERTY(architecture, getArchitecture);

--- a/src/workerd/api/gpu/gpu-device.h
+++ b/src/workerd/api/gpu/gpu-device.h
@@ -28,16 +28,10 @@
 
 namespace workerd::api::gpu {
 
-struct GPUDeviceLostContext {
-  GPUDeviceLostContext(jsg::Lock& js);
-  kj::Own<kj::PromiseFulfiller<jsg::Ref<GPUDeviceLostInfo>>> lost_promise_fulfiller_;
-  jsg::MemoizedIdentity<jsg::Promise<jsg::Ref<GPUDeviceLostInfo>>> lost_promise_;
-};
-
 class GPUDevice : public EventTarget {
 public:
   explicit GPUDevice(jsg::Lock& js, wgpu::Device d, kj::Own<AsyncRunner> async,
-                     kj::Own<GPUDeviceLostContext> dlc);
+                     kj::Own<AsyncContext<jsg::Ref<GPUDeviceLostInfo>>> deviceLostCtx);
   ~GPUDevice();
   JSG_RESOURCE_TYPE(GPUDevice) {
     JSG_INHERIT(EventTarget);
@@ -67,7 +61,8 @@ public:
 
 private:
   wgpu::Device device_;
-  kj::Own<GPUDeviceLostContext> dlc_;
+  kj::Own<AsyncContext<jsg::Ref<GPUDeviceLostInfo>>> dlc_;
+  jsg::MemoizedIdentity<jsg::Promise<jsg::Ref<GPUDeviceLostInfo>>> lost_promise_;
   kj::Own<AsyncRunner> async_;
   bool destroyed_ = false;
   jsg::Ref<GPUBuffer> createBuffer(jsg::Lock&, GPUBufferDescriptor);

--- a/src/workerd/api/gpu/gpu-shader-module.c++
+++ b/src/workerd/api/gpu/gpu-shader-module.c++
@@ -9,33 +9,27 @@ namespace workerd::api::gpu {
 
 jsg::Promise<jsg::Ref<GPUCompilationInfo>> GPUShaderModule::getCompilationInfo(jsg::Lock& js) {
 
-  struct Context {
-    kj::Own<kj::PromiseFulfiller<jsg::Ref<GPUCompilationInfo>>> fulfiller;
-    AsyncTask task;
-  };
-  auto paf = kj::newPromiseAndFulfiller<jsg::Ref<GPUCompilationInfo>>();
   // This context object will hold information for the callback, including the
-  // fullfiller to signal the caller with the result, and an async task that
+  // fulfiller to signal the caller with the result, and an async task that
   // will ensure the device's Tick() function is called periodically. It will be
   // deallocated at the end of the callback function.
-  auto ctx = new Context{kj::mv(paf.fulfiller), AsyncTask(kj::addRef(*async_))};
+  using MapAsyncContext = AsyncContext<jsg::Ref<GPUCompilationInfo>>;
+  auto ctx = kj::heap<MapAsyncContext>(js, kj::addRef(*async_));
+  auto promise = kj::mv(ctx->promise_);
   shader_.GetCompilationInfo(
-      [](WGPUCompilationInfoRequestStatus status, WGPUCompilationInfo const* compilationInfo,
-         void* userdata) {
-        auto c = std::unique_ptr<Context>(static_cast<Context*>(userdata));
-
+      wgpu::CallbackMode::AllowProcessEvents,
+      [ctx = kj::mv(ctx)](wgpu::CompilationInfoRequestStatus status,
+                          wgpu::CompilationInfo const* compilationInfo) mutable {
         kj::Vector<jsg::Ref<GPUCompilationMessage>> messages(compilationInfo->messageCount);
         for (uint32_t i = 0; i < compilationInfo->messageCount; i++) {
           auto& msg = compilationInfo->messages[i];
           messages.add(jsg::alloc<GPUCompilationMessage>(msg));
         }
 
-        c->fulfiller->fulfill(jsg::alloc<GPUCompilationInfo>(kj::mv(messages)));
-      },
-      ctx);
+        ctx->fulfiller_->fulfill(jsg::alloc<GPUCompilationInfo>(kj::mv(messages)));
+      });
 
-  auto& context = IoContext::current();
-  return context.awaitIo(js, kj::mv(paf.promise));
+  return promise;
 }
 
 } // namespace workerd::api::gpu


### PR DESCRIPTION
Use the new C++ callback mode of dawn. Replace deprecated getProperties() call with getInfo().