### PR TITLE
Refactor type generation scripts

### DIFF
--- a/types/src/generator/index.ts
+++ b/types/src/generator/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import assert from "assert";
+import assert from "node:assert";
 import {
   FunctionType,
   Member,
@@ -13,13 +13,13 @@ import {
   Type,
   Type_Which,
 } from "@workerd/jsg/rtti.capnp.js";
-import ts from "typescript";
+import ts, { factory as f } from "typescript";
 import { createStructureNode } from "./structure";
+import { getTypeName } from "./type";
 
 export { getTypeName } from "./type";
-export { parseApiAstDump } from "./parameter-names";
 
-type StructureMap = Map<string, Structure>;
+export type StructureMap = Map<string, Structure>;
 // Builds a lookup table mapping type names to structures
 function collectStructureMap(root: StructureGroups): StructureMap {
   const map = new Map<string, Structure>();
@@ -40,7 +40,7 @@ function collectStructureMap(root: StructureGroups): StructureMap {
 // when certain compatibility flags are enabled (e.g. `Navigator`,
 // standards-compliant `URL`). However, these types are always included in
 // the `*_TYPES` macros.
-function collectIncluded(map: StructureMap): Set<string> {
+function collectIncluded(map: StructureMap, root?: string): Set<string> {
   const included = new Set<string>();
 
   function visitType(type: Type): void {
@@ -101,9 +101,17 @@ function collectIncluded(map: StructureMap): Set<string> {
     }
   }
 
-  // Visit all structures with `JSG_(STRUCT_)TS_ROOT` macros
-  for (const structure of map.values()) {
-    if (structure.getTsRoot()) visitStructure(structure);
+  if (root === undefined) {
+    // If no root was specified, visit all structures with
+    // `JSG_(STRUCT_)TS_ROOT` macros
+    for (const structure of map.values()) {
+      if (structure.getTsRoot()) visitStructure(structure);
+    }
+  } else {
+    // Otherwise, visit just that root
+    const structure = map.get(root);
+    assert(structure !== undefined, `Unknown root: ${root}`);
+    visitStructure(structure);
   }
 
   return included;
@@ -144,39 +152,167 @@ function collectClasses(map: StructureMap): Set<string> {
   return classes;
 }
 
-export function generateDefinitions(root: StructureGroups): ts.Node[] {
-  const map = collectStructureMap(root);
-  const included = collectIncluded(map);
-  const classes = collectClasses(map);
+// Builds a map mapping structure names that are top-level nested types of
+// module structures to the names of those modules. Essentially, a map of which
+// modules export which types (e.g. "workerd::api::node::AsyncLocalStorage" =>
+// "node-internal:async_hooks"). We use this to make sure we don't include
+// duplicate definitions if an internal module references a type from another
+// internal module. In this case, we'll include the definition in the one that
+// exported it.
+function collectModuleTypeExports(
+  root: StructureGroups,
+  map: StructureMap
+): Map</* structureName */ string, /* moduleSpecifier */ string> {
+  const typeExports = new Map<string, string>();
+  root.getModules().forEach((module) => {
+    if (!module.isStructureName()) return;
 
-  // Record a list of ignored structures to make sure we haven't missed any
-  // `JSG_TS_ROOT()` macros
-  const ignored: string[] = [];
+    // Get module root type
+    const specifier = module.getSpecifier();
+    const moduleRootName = module.getStructureName();
+    const moduleRoot = map.get(moduleRootName);
+    assert(moduleRoot !== undefined);
+
+    // Add all nested types in module root
+    moduleRoot.getMembers().forEach((member) => {
+      if (!member.isNested()) return;
+      const nested = member.getNested();
+      typeExports.set(nested.getStructure().getFullyQualifiedName(), specifier);
+    });
+  });
+
+  return typeExports;
+}
+
+export function generateDefinitions(root: StructureGroups): {
+  nodes: ts.Statement[];
+  structureMap: StructureMap;
+} {
+  const structureMap = collectStructureMap(root);
+  const globalIncluded = collectIncluded(structureMap);
+  const classes = collectClasses(structureMap);
+
   // Can't use `flatMap()` here as `getGroups()` returns a `capnp.List`
   const nodes = root.getGroups().map((group) => {
-    const structureNodes: ts.Node[] = [];
+    const structureNodes: ts.Statement[] = [];
     group.getStructures().forEach((structure) => {
       const name = structure.getFullyQualifiedName();
-
-      if (included.has(name)) {
+      if (globalIncluded.has(name)) {
         const asClass = classes.has(name);
-        structureNodes.push(createStructureNode(structure, asClass));
-      } else {
-        ignored.push(name);
+        structureNodes.push(createStructureNode(structure, { asClass }));
+      }
+    });
+    return structureNodes;
+  });
+  const flatNodes = nodes.flat();
+
+  const typeExports = collectModuleTypeExports(root, structureMap);
+  root.getModules().forEach((module) => {
+    if (!module.isStructureName()) return;
+
+    // Get module root type
+    const specifier = module.getSpecifier();
+    const moduleRootName = module.getStructureName();
+    const moduleRoot = structureMap.get(moduleRootName);
+    assert(moduleRoot !== undefined);
+
+    // Build a set of nested types exported by this module. These will always
+    // be included in the module, even if they're referenced globally.
+    const nestedTypeNames = new Set<string>();
+    moduleRoot.getMembers().forEach((member) => {
+      if (member.isNested()) {
+        const nested = member.getNested();
+        nestedTypeNames.add(nested.getStructure().getFullyQualifiedName());
       }
     });
 
-    return structureNodes;
+    // Add all types required by this module, but not the top level or another
+    // internal module.
+    const moduleIncluded = collectIncluded(structureMap, moduleRootName);
+    const statements: ts.Statement[] = [];
+
+    let nextImportId = 1;
+    for (const name of moduleIncluded) {
+      // If this structure was already included globally, ignore it,
+      // unless it's explicitly declared a nested type of this module
+      if (globalIncluded.has(name) && !nestedTypeNames.has(name)) continue;
+
+      // If this structure was exported by another module, import it. Note we
+      // don't need to check whether we've already imported the type as
+      // `moduleIncluded` is a `Set`.
+      const maybeOwningModule = typeExports.get(name);
+      if (maybeOwningModule !== undefined && maybeOwningModule !== specifier) {
+        // Internal modules only have default exports, so we generate something
+        // that looks like this:
+        // ```
+        // import _internal1 from "node-internal:async_hooks";
+        // import AsyncLocalStorage = _internal1.AsyncLocalStorage; // (type & value alias)
+        // ```
+        const identifier = f.createIdentifier(`_internal${nextImportId++}`);
+        const importClause = f.createImportClause(
+          false,
+          /* name */ identifier,
+          /* namedBindings */ undefined
+        );
+        const importDeclaration = f.createImportDeclaration(
+          /* modifiers */ undefined,
+          importClause,
+          f.createStringLiteral(maybeOwningModule)
+        );
+        const typeName = getTypeName(name);
+        const importEqualsDeclaration = f.createImportEqualsDeclaration(
+          /* modifiers */ undefined,
+          /* isTypeOnly */ false,
+          typeName,
+          f.createQualifiedName(identifier, typeName)
+        );
+        statements.unshift(importDeclaration, importEqualsDeclaration);
+
+        continue;
+      }
+
+      // Otherwise, just include the structure in the module
+      const structure = structureMap.get(name);
+      assert(structure !== undefined);
+      const asClass = classes.has(name);
+      const statement = createStructureNode(structure, {
+        asClass,
+        ambientContext: true,
+        // nameOverride: nestedNameOverrides.get(name), // TODO: remove
+      });
+      statements.push(statement);
+    }
+
+    const moduleBody = f.createModuleBlock(statements);
+    const moduleDeclaration = f.createModuleDeclaration(
+      [f.createToken(ts.SyntaxKind.DeclareKeyword)],
+      f.createStringLiteral(specifier),
+      moduleBody
+    );
+    flatNodes.push(moduleDeclaration);
   });
 
-  // Log ignored types to make sure we didn't forget anything
-  if (ignored.length > 0) {
-    console.warn(
-      "WARNING: The following types were not referenced from any `JSG_TS_ROOT()`ed type and have been omitted from the output. " +
-        "This could be because of disabled compatibility flags."
-    );
-    for (const name of ignored) console.warn(`- ${name}`);
-  }
+  return { nodes: flatNodes, structureMap };
+}
 
-  return nodes.flat();
+export function collectTypeScriptModules(root: StructureGroups): string {
+  let result = "";
+
+  root.getModules().forEach((module) => {
+    if (!module.isTsDeclarations()) return;
+    const declarations = module
+      .getTsDeclarations()
+      .replaceAll(/^\/\/\/.+$/gm, (match) => {
+        assert.strictEqual(
+          match,
+          '/// <reference types="@workerd/types-internal" />',
+          `Unexpected triple-slash directive, got ${match}`
+        );
+        return "";
+      });
+
+    result += `declare module "${module.getSpecifier()}" {\n${declarations}\n}\n`;
+  });
+
+  return result;
 }

--- a/types/src/generator/index.ts
+++ b/types/src/generator/index.ts
@@ -302,6 +302,8 @@ export function collectTypeScriptModules(root: StructureGroups): string {
     if (!module.isTsDeclarations()) return;
     const declarations = module
       .getTsDeclarations()
+      // Looks for any lines starting with `///`, which indicates a TypeScript
+      // Triple-Slash Directive (https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html)
       .replaceAll(/^\/\/\/.+$/gm, (match) => {
         assert.strictEqual(
           match,

--- a/types/src/generator/parameter-names.ts
+++ b/types/src/generator/parameter-names.ts
@@ -2,76 +2,27 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import fs from "node:fs";
+export type ParameterNamesData = Record<
+  /* fullyQualifiedParentName */ string,
+  Record</* functionName */ string, string[] | undefined> | undefined
+>;
 
-let paramNameData: Map<string, Parameter> = new Map();
-
-interface Parameter {
-  fullyQualifiedParentName: string;
-  methodName: string;
-  parameterIndex: number;
-  name: string;
+let data: ParameterNamesData | undefined;
+export function installParameterNames(newData: ParameterNamesData) {
+  data = newData;
 }
 
-// Support methods defined in parent classes
-const additionalClassNames: Record<string, string[]> = {
-  DurableObjectStorageOperations: [
-    "DurableObjectStorage",
-    "DurableObjectTransaction",
-  ],
-};
+const reservedKeywords = ["function", "number", "string"];
+
 export function getParameterName(
   fullyQualifiedParentName: string,
-  methodName: string,
-  parameterIndex: number
+  functionName: string,
+  index: number
 ): string {
-  const path = `${fullyQualifiedParentName}.${methodName}[${parameterIndex}]`;
-
-  const name = paramNameData.get(path)?.name;
-  // Some parameter names are reserved TypeScript words, which break later down the pipeline
-  if (name === "function" || name === "number" || name === "string") {
-    return `$${name}`;
-  }
-  if (name && name !== "undefined") {
-    return name;
-  }
-  return `param${parameterIndex}`;
-}
-
-export function parseApiAstDump(astDumpPath: string) {
-  paramNameData = new Map(
-    JSON.parse(fs.readFileSync(astDumpPath, { encoding: "utf-8" }))
-      .flatMap((p: any) => {
-        const shouldRename = p.fully_qualified_parent_name.find(
-          (n: string) => !!additionalClassNames[n]
-        );
-        const renameOptions = additionalClassNames[shouldRename] ?? [];
-        const methodName = p.function_like_name.endsWith("_")
-          ? p.function_like_name.slice(0, -1)
-          : p.function_like_name;
-        return [
-          ...renameOptions.map((r) => ({
-            fullyQualifiedParentName: p.fully_qualified_parent_name
-              .filter((n: any) => !!n)
-              .map((n: string) => (n === shouldRename ? r : n))
-              .join("::"),
-            methodName,
-            parameterIndex: p.index,
-            name: p.name,
-          })),
-          {
-            fullyQualifiedParentName: p.fully_qualified_parent_name
-              .filter((n: any) => !!n)
-              .join("::"),
-            methodName,
-            parameterIndex: p.index,
-            name: p.name,
-          },
-        ];
-      })
-      .map((p: Parameter) => [
-        `${p.fullyQualifiedParentName}.${p.methodName}[${p.parameterIndex}]`,
-        p,
-      ]) as [string, Parameter][]
-  );
+  // `constructor` is a reserved property name
+  if (functionName === "constructor") functionName = `$${functionName}`;
+  const name = data?.[fullyQualifiedParentName]?.[functionName]?.[index];
+  if (name === undefined) return `arg${index}`;
+  if (reservedKeywords.includes(name)) return `$${name}`;
+  return name;
 }

--- a/types/src/generator/parameter-names.ts
+++ b/types/src/generator/parameter-names.ts
@@ -2,27 +2,76 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-export type ParameterNamesData = Record<
-  /* fullyQualifiedParentName */ string,
-  Record</* functionName */ string, string[] | undefined> | undefined
->;
+import fs from "node:fs";
 
-let data: ParameterNamesData | undefined;
-export function installParameterNames(newData: ParameterNamesData) {
-  data = newData;
+let paramNameData: Map<string, Parameter> = new Map();
+
+interface Parameter {
+  fullyQualifiedParentName: string;
+  methodName: string;
+  parameterIndex: number;
+  name: string;
 }
 
-const reservedKeywords = ["function", "number", "string"];
-
+// Support methods defined in parent classes
+const additionalClassNames: Record<string, string[]> = {
+  DurableObjectStorageOperations: [
+    "DurableObjectStorage",
+    "DurableObjectTransaction",
+  ],
+};
 export function getParameterName(
   fullyQualifiedParentName: string,
-  functionName: string,
-  index: number
+  methodName: string,
+  parameterIndex: number
 ): string {
-  // `constructor` is a reserved property name
-  if (functionName === "constructor") functionName = `$${functionName}`;
-  const name = data?.[fullyQualifiedParentName]?.[functionName]?.[index];
-  if (name === undefined) return `arg${index}`;
-  if (reservedKeywords.includes(name)) return `$${name}`;
-  return name;
+  const path = `${fullyQualifiedParentName}.${methodName}[${parameterIndex}]`;
+
+  const name = paramNameData.get(path)?.name;
+  // Some parameter names are reserved TypeScript words, which break later down the pipeline
+  if (name === "function" || name === "number" || name === "string") {
+    return `$${name}`;
+  }
+  if (name && name !== "undefined") {
+    return name;
+  }
+  return `param${parameterIndex}`;
+}
+
+export function parseApiAstDump(astDumpPath: string) {
+  paramNameData = new Map(
+    JSON.parse(fs.readFileSync(astDumpPath, { encoding: "utf-8" }))
+      .flatMap((p: any) => {
+        const shouldRename = p.fully_qualified_parent_name.find(
+          (n: string) => !!additionalClassNames[n]
+        );
+        const renameOptions = additionalClassNames[shouldRename] ?? [];
+        const methodName = p.function_like_name.endsWith("_")
+          ? p.function_like_name.slice(0, -1)
+          : p.function_like_name;
+        return [
+          ...renameOptions.map((r) => ({
+            fullyQualifiedParentName: p.fully_qualified_parent_name
+              .filter((n: any) => !!n)
+              .map((n: string) => (n === shouldRename ? r : n))
+              .join("::"),
+            methodName,
+            parameterIndex: p.index,
+            name: p.name,
+          })),
+          {
+            fullyQualifiedParentName: p.fully_qualified_parent_name
+              .filter((n: any) => !!n)
+              .join("::"),
+            methodName,
+            parameterIndex: p.index,
+            name: p.name,
+          },
+        ];
+      })
+      .map((p: Parameter) => [
+        `${p.fullyQualifiedParentName}.${p.methodName}[${p.parameterIndex}]`,
+        p,
+      ]) as [string, Parameter][]
+  );
 }

--- a/types/src/generator/type.ts
+++ b/types/src/generator/type.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import assert from "assert";
+import assert from "node:assert";
 import {
   ArrayType,
   BuiltinType_Type,
@@ -103,11 +103,22 @@ export function isUnsatisfiable(typeNode: ts.TypeNode) {
 
 // Strings to replace in fully-qualified structure names with nothing
 const replaceEmpty =
-  /^workerd::api::public_beta::|^workerd::api::|^workerd::jsg::|::|[ >]/g;
+  /^workerd::api::public_beta::|^workerd::api::node::|^workerd::api::gpu::|^workerd::api::|^workerd::jsg::|::|[ >]/g;
 // Strings to replace in fully-qualified structure names with an underscore
 const replaceUnderscore = /[<,]/g;
-export function getTypeName(structure: Structure | StructureType): string {
-  let name = structure.getFullyQualifiedName();
+export function getTypeName(
+  structure: Structure | StructureType | /* fullyQualifiedName */ string
+): string {
+  let name: string;
+  if (typeof structure === "string") {
+    assert(
+      structure.includes("::"),
+      `Expected fully-qualified structure name, got "${structure}"`
+    );
+    name = structure;
+  } else {
+    name = structure.getFullyQualifiedName();
+  }
   name = name.replace(replaceEmpty, "");
   name = name.replace(replaceUnderscore, "_");
   return name;
@@ -167,13 +178,9 @@ export function createParamDeclarationNodes(
           `Expected "T[]", got "${printNode(typeNode)}"`
         );
         dotDotDotToken = f.createToken(ts.SyntaxKind.DotDotDotToken);
-      } else {
+      } else if (isUnsatisfiable(typeNode)) {
         // If this is an internal implementation type, omit it, and skip to
         // the next arg
-        assert(
-          isUnsatisfiable(typeNode),
-          `Expected "never", got "${printNode(typeNode)}"`
-        );
         continue;
       }
     }
@@ -204,8 +211,9 @@ export function createTypeNode(
     `"allowMethodParameterCoercion" requires "allowCoercion"`
   );
 
+  const which = type.which();
   // noinspection FallThroughInSwitchStatementJS
-  switch (type.which()) {
+  switch (which) {
     case Type_Which.UNKNOWN:
       return f.createTypeReferenceNode("any");
     case Type_Which.VOIDT:
@@ -323,7 +331,7 @@ export function createTypeNode(
         case BuiltinType_Type.V8FUNCTION:
           return f.createTypeReferenceNode("Function");
         default:
-          assert.fail(`Unknown builtin type: ${builtin}`);
+          assert.fail(`Unknown builtin type: ${builtin satisfies never}`);
       }
     case Type_Which.INTRINSIC:
       const intrinsic = type.getIntrinsic().getName();
@@ -375,9 +383,14 @@ export function createTypeNode(
         case JsgImplType_Type.JSG_NAME:
           return f.createTypeReferenceNode("PropertyKey");
         default:
-          assert.fail(`Unknown JSG implementation type: ${impl}`);
+          assert.fail(
+            `Unknown JSG implementation type: ${impl satisfies never}`
+          );
       }
+    case Type_Which.JS_BUILTIN:
+      // TODO(soon): implement
+      assert.fail("`JS_BUILTIN`s are not yet supported");
     default:
-      assert.fail(`Unknown type: ${type.which()}`);
+      assert.fail(`Unknown type: ${which satisfies never}`);
   }
 }

--- a/types/src/generator/type.ts
+++ b/types/src/generator/type.ts
@@ -102,6 +102,14 @@ export function isUnsatisfiable(typeNode: ts.TypeNode) {
 }
 
 // Strings to replace in fully-qualified structure names with nothing
+// `workerd` references APIs by fully qualified names such as `workerd::api::gpu::GPUFragmentState`
+// This wouldn't be all that user-friendly as a type, and so this regex captures all the
+// parts of an API name that should be removed when turning an API into a TS type
+// For instance, this turns `workerd::api::gpu::GPUFragmentState` into `GPUFragmentState`
+// If any new namespaced APIs are added, they should be added to this regex.
+// If they're _not_ added to this regex, a sane-ish fallback will be used.
+// For instance, a new hypothetical API called `workerd::api::magic::MakeASpell` would be
+// `magicMakeASpell`.
 const replaceEmpty =
   /^workerd::api::public_beta::|^workerd::api::node::|^workerd::api::gpu::|^workerd::api::|^workerd::jsg::|::|[ >]/g;
 // Strings to replace in fully-qualified structure names with an underscore

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-import { readFileSync, readdirSync } from "fs";
-import { mkdir, readFile, readdir, writeFile } from "fs/promises";
 import assert from "node:assert";
-import path from "path";
-import util from "util";
+import { readFileSync, readdirSync } from "node:fs";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import util from "node:util";
 import { StructureGroups } from "@workerd/jsg/rtti.capnp.js";
 import { Message } from "capnp-ts";
 import prettier from "prettier";
@@ -168,7 +168,6 @@ function printDefinitions(
     createCommentsTransformer(standards),
   ]);
 
-  console.error(collectTypeScriptModules(root));
   source += collectTypeScriptModules(root) + extraDefinitions;
 
   // We need the type checker to respect our updated definitions after applying

--- a/types/src/program.ts
+++ b/types/src/program.ts
@@ -15,10 +15,13 @@ const defaultCompilerOpts = ts.getDefaultCompilerOptions();
 export function createMemoryProgram(
   sources: SourcesMap,
   host?: ts.CompilerHost,
-  compilerOpts = defaultCompilerOpts
+  compilerOpts = defaultCompilerOpts,
+  // Provide additional lib files to TypeScript. These should all be prefixed with
+  // `/node_modules/typescript/lib` (e.g. `/node_modules/typescript/lib/lib.esnext.d.ts`)
+  lib?: SourcesMap
 ): ts.Program {
   const sourceFiles = new Map<string, ts.SourceFile>();
-  for (const [sourcePath, source] of sources) {
+  for (const [sourcePath, source] of [...sources, ...(lib ?? [])]) {
     const sourceFile = ts.createSourceFile(
       sourcePath,
       source,
@@ -39,17 +42,20 @@ export function createMemoryProgram(
     getDefaultLibFileName(_options: ts.CompilerOptions): string {
       return "";
     },
+    getDefaultLibLocation() {
+      return "/node_modules/typescript/lib";
+    },
     getNewLine(): string {
       return "\n";
     },
     useCaseSensitiveFileNames(): boolean {
       return true;
     },
-    fileExists(_fileName: string): boolean {
-      return true;
+    fileExists(fileName: string): boolean {
+      return sourceFiles.has(fileName);
     },
     readFile(_path: string): string | undefined {
-      return undefined;
+      assert.fail("readFile() not implemented");
     },
     writeFile(
       _path: string,

--- a/types/src/transforms/comments.ts
+++ b/types/src/transforms/comments.ts
@@ -1,122 +1,79 @@
-// Copyright (c) 2022-2023 Cloudflare, Inc.
-// Licensed under the Apache 2.0 license found in the LICENSE file or at:
-//     https://opensource.org/licenses/Apache-2.0
-
-import assert from "assert";
 import ts from "typescript";
-import { ParsedTypeDefinition } from "../standards";
 import { hasModifier } from "./helpers";
 
-function attachComments(
-  from: ts.Node,
-  to: ts.Node,
-  sourceFile: ts.SourceFile
-): void {
-  const text = sourceFile.getFullText();
-  const extractCommentText = (comment: ts.CommentRange) =>
-    comment.kind === ts.SyntaxKind.MultiLineCommentTrivia
-      ? text.slice(comment.pos + 2, comment.end - 2)
-      : text.slice(comment.pos + 2, comment.end);
-  const leadingComments: string[] =
-    ts
-      .getLeadingCommentRanges(text, from.getFullStart())
-      ?.map(extractCommentText) ?? [];
+// Refer to `collateStandardComments()` in `src/cli/index.ts` for construction
+export type CommentsData = Record<
+  /* globalName */ string,
+  | Record</* root */ "$" | /* memberName */ string, string | undefined>
+  | undefined
+>;
 
-  leadingComments.map((c) =>
-    ts.addSyntheticLeadingComment(
-      to,
-      ts.SyntaxKind.MultiLineCommentTrivia,
-      c,
-      true
-    )
-  );
+let installedData: CommentsData | undefined;
+export function installComments(newData: CommentsData) {
+  installedData = newData;
 }
 
-// Copy comments from a parsed standards TS program. It relies on the shape of lib.dom or lib.webworker
-// Specifically, classes must be defined as a global var with the static properties, and an interface with the instance properties
-export function createCommentsTransformer(
-  standards: ParsedTypeDefinition
-): ts.TransformerFactory<ts.SourceFile> {
+export function createCommentsTransformer(): ts.TransformerFactory<ts.SourceFile> {
   return (ctx) => {
     return (node) => {
-      const visitor = createVisitor(standards);
+      if (installedData === undefined) return node;
+      const visitor = createVisitor(installedData);
       return ts.visitEachChild(node, visitor, ctx);
     };
   };
 }
 
-function createVisitor(standards: ParsedTypeDefinition) {
-  return (node: ts.Node) => {
-    if (ts.isClassDeclaration(node)) {
-      const name = node.name?.getText();
-      assert(name !== undefined);
-      const standardsVersion = standards.parsed.vars.get(name);
-      if (standardsVersion) {
-        const type = standardsVersion.type;
-        assert(
-          type !== undefined && ts.isTypeLiteralNode(type),
-          `Non type literal found for "${name}"`
-        );
-        attachComments(standardsVersion, node, standards.source);
-        const standardsInterface = standards.parsed.interfaces.get(name);
-        assert(standardsInterface !== undefined);
-        node.members.forEach((member) => {
-          const n = member.name?.getText();
-          if (!n && ts.isConstructorDeclaration(member)) return;
+function maybeAddComment(node: ts.Node, comment?: string) {
+  if (comment === undefined) return;
+  ts.addSyntheticLeadingComment(
+    node,
+    ts.SyntaxKind.MultiLineCommentTrivia,
+    comment,
+    /* hasTrailingNewLine */ true
+  );
+}
 
-          assert(n !== undefined, `No name for child of ${name}`);
+function createVisitor(data: CommentsData) {
+  return (node: ts.Node) => {
+    if (
+      (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) &&
+      node.name !== undefined &&
+      ts.isIdentifier(node.name)
+    ) {
+      const comments = data[node.name.text];
+      maybeAddComment(node, comments?.["$"]);
+      for (const member of node.members) {
+        if (member.name !== undefined && ts.isIdentifier(member.name)) {
+          let key = member.name.text;
 
           const isStatic =
             ts.canHaveModifiers(member) &&
             hasModifier(ts.getModifiers(member), ts.SyntaxKind.StaticKeyword);
-          const target = isStatic ? type : standardsInterface;
-          const standardsEquivalent = target.members.find(
-            (member) => member.name?.getText() === n
-          );
+          if (isStatic) key = `static:${key}`;
 
-          if (standardsEquivalent)
-            attachComments(standardsEquivalent, member, standards.source);
-        });
+          maybeAddComment(member, comments?.[key]);
+        }
       }
-    } else if (ts.isFunctionDeclaration(node)) {
-      assert(node.name !== undefined);
-      const name = node.name.text;
-      const standardsVersion = standards.parsed.functions.get(name);
-      if (standardsVersion) {
-        attachComments(standardsVersion, node, standards.source);
-      }
-    } else if (ts.isInterfaceDeclaration(node)) {
-      assert(node.name !== undefined);
-      const name = node.name.text;
-      const standardsVersion = standards.parsed.interfaces.get(name);
-      if (standardsVersion) {
-        attachComments(standardsVersion, node, standards.source);
-        node.members.forEach((member) => {
-          const n = member.name?.getText();
-          assert(n !== undefined);
-          const standardsEquivalent = standardsVersion.members.find(
-            (m) => m.name?.getText() === n
-          );
-          if (standardsEquivalent)
-            attachComments(standardsEquivalent, member, standards.source);
-        });
-      }
-    } else if (ts.isTypeAliasDeclaration(node)) {
-      assert(node.name !== undefined);
-      const name = node.name.text;
-      const standardsVersion = standards.parsed.types.get(name);
-      if (standardsVersion) {
-        attachComments(standardsVersion, node, standards.source);
-      }
-    } else if (ts.isVariableStatement(node)) {
-      // These contain comments that are misleading in the context of a Worker
-      const ignoreForComments = new Set(["self", "navigator", "caches"]);
-      assert(node.declarationList.declarations.length === 1);
-      assert(node.declarationList.declarations[0].name !== undefined);
-      const name = node.declarationList.declarations[0].name.getText();
-      const standardsVersion = standards.parsed.vars.get(name);
-      if (standardsVersion && !ignoreForComments.has(name)) {
-        attachComments(standardsVersion, node, standards.source);
+    }
+
+    if (
+      ts.isFunctionDeclaration(node) &&
+      node.name !== undefined &&
+      ts.isIdentifier(node.name)
+    ) {
+      const comments = data[node.name.text];
+      maybeAddComment(node, comments?.["$"]);
+    }
+
+    if (
+      ts.isVariableStatement(node) &&
+      node.declarationList.declarations.length === 1
+    ) {
+      const declaration = node.declarationList.declarations[0];
+      const name = declaration.name;
+      if (ts.isIdentifier(name)) {
+        const comments = data[name.text];
+        maybeAddComment(node, comments?.["$"]);
       }
     }
 

--- a/types/src/transforms/comments.ts
+++ b/types/src/transforms/comments.ts
@@ -1,79 +1,124 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import assert from "node:assert";
 import ts from "typescript";
+import { ParsedTypeDefinition } from "../standards";
 import { hasModifier } from "./helpers";
 
-// Refer to `collateStandardComments()` in `src/cli/index.ts` for construction
-export type CommentsData = Record<
-  /* globalName */ string,
-  | Record</* root */ "$" | /* memberName */ string, string | undefined>
-  | undefined
->;
+function attachComments(
+  from: ts.Node,
+  to: ts.Node,
+  sourceFile: ts.SourceFile
+): void {
+  const text = sourceFile.getFullText();
+  const extractCommentText = (comment: ts.CommentRange) =>
+    comment.kind === ts.SyntaxKind.MultiLineCommentTrivia
+      ? text.slice(comment.pos + 2, comment.end - 2)
+      : text.slice(comment.pos + 2, comment.end);
+  const leadingComments: string[] =
+    ts
+      .getLeadingCommentRanges(text, from.getFullStart())
+      ?.map(extractCommentText) ?? [];
 
-let installedData: CommentsData | undefined;
-export function installComments(newData: CommentsData) {
-  installedData = newData;
+  leadingComments.map((c) =>
+    ts.addSyntheticLeadingComment(
+      to,
+      ts.SyntaxKind.MultiLineCommentTrivia,
+      c,
+      true
+    )
+  );
 }
 
-export function createCommentsTransformer(): ts.TransformerFactory<ts.SourceFile> {
+// Copy comments from a parsed standards TS program. It relies on the shape of lib.dom or lib.webworker
+// Specifically, classes must be defined as a global var with the static properties, and an interface with the instance properties
+export function createCommentsTransformer(
+  standards: ParsedTypeDefinition
+): ts.TransformerFactory<ts.SourceFile> {
   return (ctx) => {
     return (node) => {
-      if (installedData === undefined) return node;
-      const visitor = createVisitor(installedData);
+      const visitor = createVisitor(standards);
       return ts.visitEachChild(node, visitor, ctx);
     };
   };
 }
 
-function maybeAddComment(node: ts.Node, comment?: string) {
-  if (comment === undefined) return;
-  ts.addSyntheticLeadingComment(
-    node,
-    ts.SyntaxKind.MultiLineCommentTrivia,
-    comment,
-    /* hasTrailingNewLine */ true
-  );
-}
-
-function createVisitor(data: CommentsData) {
+function createVisitor(standards: ParsedTypeDefinition) {
   return (node: ts.Node) => {
-    if (
-      (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) &&
-      node.name !== undefined &&
-      ts.isIdentifier(node.name)
-    ) {
-      const comments = data[node.name.text];
-      maybeAddComment(node, comments?.["$"]);
-      for (const member of node.members) {
-        if (member.name !== undefined && ts.isIdentifier(member.name)) {
-          let key = member.name.text;
+    if (ts.isClassDeclaration(node)) {
+      const name = node.name?.getText();
+      assert(name !== undefined);
+      const standardsVersion = standards.parsed.vars.get(name);
+      if (standardsVersion) {
+        const type = standardsVersion.type;
+        assert(
+          type !== undefined && ts.isTypeLiteralNode(type),
+          `Non type literal found for "${name}"`
+        );
+        attachComments(standardsVersion, node, standards.source);
+        const standardsInterface = standards.parsed.interfaces.get(name);
+        assert(standardsInterface !== undefined);
+        node.members.forEach((member) => {
+          const n = member.name?.getText();
+          if (!n && ts.isConstructorDeclaration(member)) return;
+
+          assert(n !== undefined, `No name for child of ${name}`);
 
           const isStatic =
             ts.canHaveModifiers(member) &&
             hasModifier(ts.getModifiers(member), ts.SyntaxKind.StaticKeyword);
-          if (isStatic) key = `static:${key}`;
+          const target = isStatic ? type : standardsInterface;
+          const standardsEquivalent = target.members.find(
+            (member) => member.name?.getText() === n
+          );
 
-          maybeAddComment(member, comments?.[key]);
-        }
+          if (standardsEquivalent)
+            attachComments(standardsEquivalent, member, standards.source);
+        });
       }
-    }
-
-    if (
-      ts.isFunctionDeclaration(node) &&
-      node.name !== undefined &&
-      ts.isIdentifier(node.name)
-    ) {
-      const comments = data[node.name.text];
-      maybeAddComment(node, comments?.["$"]);
-    }
-
-    if (
-      ts.isVariableStatement(node) &&
-      node.declarationList.declarations.length === 1
-    ) {
-      const declaration = node.declarationList.declarations[0];
-      const name = declaration.name;
-      if (ts.isIdentifier(name)) {
-        const comments = data[name.text];
-        maybeAddComment(node, comments?.["$"]);
+    } else if (ts.isFunctionDeclaration(node)) {
+      assert(node.name !== undefined);
+      const name = node.name.text;
+      const standardsVersion = standards.parsed.functions.get(name);
+      if (standardsVersion) {
+        attachComments(standardsVersion, node, standards.source);
+      }
+    } else if (ts.isInterfaceDeclaration(node)) {
+      assert(node.name !== undefined);
+      const name = node.name.text;
+      const standardsVersion = standards.parsed.interfaces.get(name);
+      if (standardsVersion) {
+        attachComments(standardsVersion, node, standards.source);
+        node.members.forEach((member) => {
+          try {
+            const n = member.name?.getText();
+            assert(n !== undefined);
+            const standardsEquivalent = standardsVersion.members.find(
+              (m) => m.name?.getText() === n
+            );
+            if (standardsEquivalent)
+              attachComments(standardsEquivalent, member, standards.source);
+          } catch {}
+        });
+      }
+    } else if (ts.isTypeAliasDeclaration(node)) {
+      assert(node.name !== undefined);
+      const name = node.name.text;
+      const standardsVersion = standards.parsed.types.get(name);
+      if (standardsVersion) {
+        attachComments(standardsVersion, node, standards.source);
+      }
+    } else if (ts.isVariableStatement(node)) {
+      // These contain comments that are misleading in the context of a Worker
+      const ignoreForComments = new Set(["self", "navigator", "caches"]);
+      assert(node.declarationList.declarations.length === 1);
+      assert(node.declarationList.declarations[0].name !== undefined);
+      const name = node.declarationList.declarations[0].name.getText();
+      const standardsVersion = standards.parsed.vars.get(name);
+      if (standardsVersion && !ignoreForComments.has(name)) {
+        attachComments(standardsVersion, node, standards.source);
       }
     }
 

--- a/types/src/transforms/import-resolve.ts
+++ b/types/src/transforms/import-resolve.ts
@@ -1,0 +1,153 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import assert from "node:assert";
+import ts from "typescript";
+
+// Adapted from https://github.com/cloudflare/workerd/blob/2182afdd8ca9ac35fb18b76205308fabd5000d01/src/node/tsconfig.json#L27-L32.
+// Maps import specifier patterns to target path pattern. Sorted by target path
+// specificity (highest to lowest). When un-resolving target paths to import
+// specifiers, the most specific will be checked first. Note all target paths
+// must be absolute (i.e. start with "/").
+const TSCONFIG_PATHS: Record<string, string> = {
+  "node-internal:*": "/internal/*",
+  "node:*": "/*",
+};
+
+// Resolves all relative imports in `declare module` blocks constructed from
+// `*.d.ts` file contents, using `TSCONFIG_PATHS` to convert between specifiers
+// and on-disk paths:
+//
+// ```ts
+// declare module "node:crypto" {
+//   const _default: {
+//     DiffieHellman: new (key: import("./internal/crypto").ArrayLike, ...) => ...;
+//     Hmac: new (..., options?: import("./internal/streams_transform").TransformOptions) => ...;
+//   };
+//   ...
+// }
+// declare module "node-internal:events" {
+//   export namespace EventEmitter {
+//     var on: typeof import("./events").on;
+//   }
+// }
+// ```
+//
+// --- transforms to --->
+//
+// ```ts
+// declare module "node:crypto" {
+//   const _default: {
+//     DiffieHellman: new (key: import("node-internal:crypto").ArrayLike, ...) => ...;
+//     Hmac: new (..., options?: import("node-internal:streams_transform").TransformOptions) => ...;
+//   };
+//   ...
+// }
+// declare module "node-internal:events" {
+//   export namespace EventEmitter {
+//     var on: typeof import("node-internal:events").on;
+//   }
+// }
+// ```
+export function createImportResolveTransformer(): ts.TransformerFactory<ts.SourceFile> {
+  return (ctx) => {
+    return (node) => {
+      const visitor = createImportResolveVisitor(ctx);
+      return ts.visitEachChild(node, visitor, ctx);
+    };
+  };
+}
+
+// `RegExp` in wildcard rule may optionally contain single capturing group
+type WildcardRule = [/* from */ RegExp, /* to */ string];
+function entryWildcardRule([from, to]: [string, string]): WildcardRule {
+  return [new RegExp(`^${from.replace("*", "(.+)")}$`), to];
+}
+function maybeApplyWildcardRule(rules: WildcardRule[], text: string) {
+  for (const [from, to] of rules) {
+    const match = from.exec(text);
+    if (match === null) continue;
+    return match[1] === undefined ? to : to.replace("*", match[1]);
+  }
+}
+
+const pathEntries = Object.entries(TSCONFIG_PATHS);
+const pathResolveRules = pathEntries.map(entryWildcardRule);
+const pathUnresolveRules = pathEntries.map(([from, to]) =>
+  entryWildcardRule([to, from])
+);
+
+function createImportResolveVisitor(ctx: ts.TransformationContext) {
+  const visitor: ts.Visitor = (node) => {
+    // Visit all `declare module "<specifier>"` nodes
+    if (
+      ts.isModuleDeclaration(node) &&
+      (node.flags & ts.NodeFlags.Namespace) === 0 &&
+      ts.isStringLiteral(node.name)
+    ) {
+      const specifier = node.name.text;
+      const maybePath = maybeApplyWildcardRule(pathResolveRules, specifier);
+      // If we don't know the path of this module, we won't be able to do any
+      // resolving, so return it as is
+      if (maybePath === undefined) return node;
+      const moduleVisitor = createModuleImportResolveVisitor(ctx, maybePath);
+      return ts.visitEachChild(node, moduleVisitor, ctx);
+    }
+
+    return node;
+  };
+  return visitor;
+}
+
+function createModuleImportResolveVisitor(
+  ctx: ts.TransformationContext,
+  referencingPath: string
+) {
+  assert(referencingPath.startsWith("/"), "Expected absolute referencing path");
+  // `file:` protocol isn't important here, just need something for a valid URL
+  const referencingURL = new URL(referencingPath, "file:");
+
+  const visitor: ts.Visitor = (node) => {
+    if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteral(node.argument.literal)
+    ) {
+      const relativeSpecifier = node.argument.literal.text;
+      // If import isn't relative, no need to resolve it, so leave it as is
+      if (!relativeSpecifier.startsWith(".")) return node;
+      // Resolve specifier relative to referencing module
+      const resolvedURL = new URL(relativeSpecifier, referencingURL);
+      const resolvedPath = resolvedURL.pathname;
+      // Convert resolved path back to specifier
+      const specifier = maybeApplyWildcardRule(
+        pathUnresolveRules,
+        resolvedPath
+      );
+      assert(
+        specifier !== undefined,
+        `Unable to find matching specifier rule for path: "${resolvedPath}"`
+      );
+
+      // Update import with new specifier
+      const argument = ctx.factory.updateLiteralTypeNode(
+        node.argument,
+        ctx.factory.createStringLiteral(specifier)
+      );
+      return ctx.factory.updateImportTypeNode(
+        node,
+        argument,
+        node.attributes,
+        node.qualifier,
+        node.typeArguments,
+        node.isTypeOf
+      );
+    }
+
+    // Recursively visit all nodes (don't need to do this first as visitor never
+    // creates any new import type nodes)
+    return ts.visitEachChild(node, visitor, ctx);
+  };
+  return visitor;
+}

--- a/types/src/transforms/index.ts
+++ b/types/src/transforms/index.ts
@@ -2,7 +2,11 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+export * from "./ambient";
+export * from "./comments";
 export * from "./globals";
+export * from "./import-resolve";
+export * from "./importable";
+export * from "./internal-namespace";
 export * from "./iterators";
 export * from "./overrides";
-export * from "./comments";

--- a/types/src/transforms/internal-namespace.ts
+++ b/types/src/transforms/internal-namespace.ts
@@ -1,0 +1,210 @@
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import assert from "node:assert";
+import { Structure, StructureGroups } from "@workerd/jsg/rtti.capnp.js";
+import ts from "typescript";
+import { StructureMap, getTypeName } from "../generator";
+import { maybeExtractGlobalNode } from "./globals";
+import { ensureStatementModifiers } from "./helpers";
+import { createRenameVisitor } from "./overrides";
+
+// Moves all members (excluding imports) of internal `declare module` blocks
+// into namespaces that are then `export default`ed:
+//
+// ```ts
+// declare module "node-internal:diagnostics_channel" {
+//   import _internal1 from "node-internal:async_hooks";
+//   import AsyncLocalStorage = _internal1.AsyncLocalStorage;
+//   interface DiagnosticsChannelModule {
+//     readonly property: boolean;
+//     channel<T>(key: PropertyKey): Channel<T>;
+//     bindStore(store: AsyncLocalStorage, ...): void;
+//     Channel: typeof Channel;
+//   }
+//   abstract class Channel<T> {
+//     ...
+//   }
+// }
+// ```
+//
+// --- transforms to --->
+//
+// ```ts
+// declare module "node-internal:diagnostics_channel" {
+//   import _internal1 from "node-internal:async_hooks";
+//   import AsyncLocalStorage = _internal1.AsyncLocalStorage;
+//   namespace _default {
+//     const property: boolean;
+//     function channel<T>(key: PropertyKey): Channel<T>;
+//     function bindStore(store: AsyncLocalStorage, ...): void;
+//     abstract class Channel<T> {
+//       ...
+//     }
+//   }
+//   export default _default;
+// }
+// ```
+//
+// Note we can't just generate the `namespace _default { ... }` when initially
+// building the AST from RTTI, as the overrides/defines transformer only
+// operates on `interface`/ `class`es, not bare `const`/`function`s.
+//
+// An alternative to exporting a `namespace` would be to export an instance of
+// the root module type:
+//
+// ```
+// declare module "node-internal:diagnostics_channel" {
+//   ...
+//   const _default: DiagnosticsChannelModule;
+//   export default _default;
+// }
+// ```
+//
+// Whilst this correctly exports *values*, it doesn't export *types*.
+// Importantly, it erases type parameters from generic types (i.e. `Channel<T>`
+// becomes `Channel`, with `T`s becoming `unknown`).
+export function createInternalNamespaceTransformer(
+  root: StructureGroups,
+  structureMap: StructureMap
+): ts.TransformerFactory<ts.SourceFile> {
+  return (ctx) => {
+    return (node) => {
+      const moduleStructures = collectInternalModuleStructures(
+        root,
+        structureMap
+      );
+      const visitor = createInternalNamespaceVisitor(moduleStructures, ctx);
+      return ts.visitEachChild(node, visitor, ctx);
+    };
+  };
+}
+
+function collectInternalModuleStructures(
+  root: StructureGroups,
+  structureMap: StructureMap
+) {
+  const moduleRoots = new Map</* specifier */ string, Structure>(); // TODO: add members here as well?
+  root.getModules().forEach((module) => {
+    if (!module.isStructureName()) return;
+    const structure = structureMap.get(module.getStructureName());
+    assert(structure !== undefined);
+    const specifier = module.getSpecifier();
+    // const rootName = getTypeName(module.getStructureName());
+    moduleRoots.set(specifier, structure);
+  });
+  return moduleRoots;
+}
+
+function createInternalNamespaceVisitor(
+  moduleRoots: ReturnType<typeof collectInternalModuleStructures>,
+  ctx: ts.TransformationContext
+) {
+  const visitor: ts.Visitor = (node) => {
+    if (
+      ts.isModuleDeclaration(node) &&
+      (node.flags & ts.NodeFlags.Namespace) === 0 &&
+      ts.isStringLiteral(node.name) &&
+      node.body !== undefined &&
+      ts.isModuleBlock(node.body)
+    ) {
+      // This transformer should only be called on types generated from C++.
+      // Therefore, all `declare modules` represent internal modules.
+      const moduleRoot = moduleRoots.get(node.name.text);
+      assert(
+        moduleRoot !== undefined,
+        `Expected "${node.name.text}" to be an internal module`
+      );
+      const moduleRootName = getTypeName(moduleRoot);
+
+      // Ensure all nested types have the correct name. We do this after
+      // overrides as some module members would otherwise have the same name as
+      // global types (e.g. `cloudflare:workers` `DurableObjectBase` and
+      // `DurableObject`)
+      const renames = new Map</* from */ string, /* to */ string>();
+      moduleRoot.getMembers().forEach((member) => {
+        if (member.isNested()) {
+          const nested = member.getNested();
+          const generatedName = getTypeName(nested.getStructure());
+          const actualName = nested.getName();
+          if (generatedName !== actualName) {
+            renames.set(generatedName, actualName);
+          }
+        }
+      });
+
+      // Filter array of statements to keep at the top-level of the module, and
+      // build array of statements to include in default namespace export
+      const namespaceStatements: ts.Statement[] = [];
+      const moduleStatements = node.body.statements.filter((statement) => {
+        if (
+          ts.isImportDeclaration(statement) ||
+          ts.isImportEqualsDeclaration(statement)
+        ) {
+          // Keep import statements at top-level of module
+          return true;
+        } else if (
+          ts.isInterfaceDeclaration(statement) &&
+          statement.name.text === moduleRootName
+        ) {
+          // Extract out properties and functions from the internal module root
+          // type. Note internal module root types never have constructors, so
+          // should always be interfaces. Internal module root types should
+          // never have type parameters too, so we don't need to worry about
+          // inlining type arguments, unlike the global scope visitor.
+          for (const member of statement.members) {
+            const maybeNode = maybeExtractGlobalNode(ctx, member);
+            if (maybeNode !== undefined) namespaceStatements.push(maybeNode);
+          }
+          // Remove the root type from the module top-level
+          return false;
+        } else {
+          // Assume all other class/interface definitions are nested types that
+          // should be included in the default namespace export...
+          namespaceStatements.push(
+            ensureStatementModifiers(ctx, statement, { declare: false })
+          );
+          // ...and removed from the module top-level
+          return false;
+        }
+      });
+
+      // Add default namespace export to top-level statements
+      const defaultIdentifier = ctx.factory.createIdentifier("_default");
+      const namespaceBody = ctx.factory.createModuleBlock(namespaceStatements);
+      const namespaceDeclaration = ctx.factory.createModuleDeclaration(
+        /* modifiers */ undefined,
+        defaultIdentifier,
+        namespaceBody,
+        ts.NodeFlags.Namespace
+      );
+      const exportStatement = ctx.factory.createExportAssignment(
+        /* modifiers */ undefined,
+        /* isExportEquals */ undefined,
+        defaultIdentifier
+      );
+      moduleStatements.push(namespaceDeclaration, exportStatement);
+
+      // Return updated module declaration with new top-level statements
+      let body = ctx.factory.updateModuleBlock(node.body, moduleStatements);
+      if (renames.size > 0) {
+        const renameVisitor = createRenameVisitor(
+          ctx,
+          renames,
+          /* renameClassesInterfaces */ true
+        );
+        body = ts.visitEachChild(body, renameVisitor, ctx);
+      }
+      return ctx.factory.updateModuleDeclaration(
+        node,
+        node.modifiers,
+        node.name,
+        body
+      );
+    }
+
+    return node;
+  };
+  return visitor;
+}

--- a/types/src/transforms/internal-namespace.ts
+++ b/types/src/transforms/internal-namespace.ts
@@ -91,7 +91,6 @@ function collectInternalModuleStructures(
     const structure = structureMap.get(module.getStructureName());
     assert(structure !== undefined);
     const specifier = module.getSpecifier();
-    // const rootName = getTypeName(module.getStructureName());
     moduleRoots.set(specifier, structure);
   });
   return moduleRoots;

--- a/types/src/transforms/overrides/compiler.ts
+++ b/types/src/transforms/overrides/compiler.ts
@@ -2,11 +2,12 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import assert from "assert";
-import path from "path";
+import assert from "node:assert";
+import path from "node:path";
 import { StructureGroups } from "@workerd/jsg/rtti.capnp.js";
 import ts from "typescript";
 import { getTypeName } from "../../generator";
+import { SourcesMap } from "../../program";
 
 // If an override matches this RegExp, it will replace the existing definition
 const keywordReplace =
@@ -58,15 +59,15 @@ function compileOverride(
   return [override, false];
 }
 
-const overridesPath = path.resolve(__dirname, "overrides");
-const definesPath = path.resolve(__dirname, "defines");
+const overridesPath = "/$virtual/overrides";
+const definesPath = "/$virtual/defines";
 
 // Converts and collects all overrides and defines as TypeScript source files.
 // Also returns a set of definitions that should be replaced by their override.
 export function compileOverridesDefines(
   root: StructureGroups
-): [sources: Map<string, string>, replacements: Set<string>] {
-  const sources = new Map<string, string>();
+): [sources: SourcesMap, replacements: Set<string>] {
+  const sources = new SourcesMap();
   // Types that need their definition completely replaced by their override
   const replacements = new Set<string>();
 

--- a/types/test/generator/index.spec.ts
+++ b/types/test/generator/index.spec.ts
@@ -144,15 +144,15 @@ test("generateDefinitions: only includes referenced types from roots", () => {
   initAsReferencedType(20, prop.initType());
 
   const referencedInterfaces = Array.from(Array(19))
-    .map((_, i) => `export interface Thing${i} {\n}`)
+    .map((_, i) => `interface Thing${i} {\n}`)
     .join("\n");
-  const nodes = generateDefinitions(root);
+  const { nodes } = generateDefinitions(root);
   assert.strictEqual(
     printNodeList(nodes),
     `${referencedInterfaces}
-export declare abstract class Thing19 {
+declare abstract class Thing19 {
 }
-export interface Root1 {
+interface Root1 {
     promise: Promise<Thing0>;
     structure: Thing1;
     array: Thing2[];
@@ -161,10 +161,10 @@ export interface Root1 {
     variants: Thing6 | Thing7 | Thing8;
     function: (param0: Thing9) => Thing10;
 }
-export declare abstract class Nested {
+declare abstract class Nested {
     nestedProp: Thing11;
 }
-export declare class Root2 extends Thing19 {
+declare class Root2 extends Thing19 {
     constructor(param0: Thing14);
     method(param0: Thing12): Thing13;
     Nested: typeof Nested;
@@ -229,23 +229,23 @@ test("generateDefinitions: only generates classes if required", () => {
   // Thing1 should be a class as its inherited
   initAsReferencedType(1, root4.initExtends());
 
-  const nodes = generateDefinitions(root);
+  const { nodes } = generateDefinitions(root);
   assert.strictEqual(
     printNodeList(nodes),
-    `export declare abstract class Thing0 {
+    `declare abstract class Thing0 {
 }
-export declare abstract class Thing1 {
+declare abstract class Thing1 {
 }
-export interface Root1 {
+interface Root1 {
     Thing0: typeof Thing0;
 }
-export declare class Root2 {
+declare class Root2 {
     constructor();
 }
-export declare abstract class Root3 {
+declare abstract class Root3 {
     static method(): void;
 }
-export interface Root4 extends Thing1 {
+interface Root4 extends Thing1 {
 }
 `
   );

--- a/types/test/generator/structure.spec.ts
+++ b/types/test/generator/structure.spec.ts
@@ -45,8 +45,8 @@ test("createStructureNode: method members", () => {
 
   // Note method with unimplemented return is omitted
   assert.strictEqual(
-    printNode(createStructureNode(structure, false)),
-    `export interface Methods {
+    printNode(createStructureNode(structure, { asClass: false })),
+    `interface Methods {
     one(param0: boolean, param1: Promise<any>, param2?: number): void;
     three(...param0: any[]): boolean;
 }`
@@ -54,8 +54,8 @@ test("createStructureNode: method members", () => {
 
   method.setStatic(true);
   assert.strictEqual(
-    printNode(createStructureNode(structure, true)),
-    `export declare abstract class Methods {
+    printNode(createStructureNode(structure, { asClass: true })),
+    `declare abstract class Methods {
     one(param0: boolean, param1: Promise<any>, param2?: number): void;
     static three(...param0: any[]): boolean;
 }`
@@ -121,8 +121,8 @@ test("createStructureNode: property members", () => {
 
   // Note unimplemented properties omitted
   assert.strictEqual(
-    printNode(createStructureNode(structure, false)),
-    `export interface Properties {
+    printNode(createStructureNode(structure, { asClass: false })),
+    `interface Properties {
     one: boolean;
     readonly two: number;
     readonly three?: boolean;
@@ -133,8 +133,8 @@ test("createStructureNode: property members", () => {
 }`
   );
   assert.strictEqual(
-    printNode(createStructureNode(structure, true)),
-    `export declare abstract class Properties {
+    printNode(createStructureNode(structure, { asClass: true })),
+    `declare abstract class Properties {
     one: boolean;
     readonly two: number;
     readonly three?: boolean;
@@ -165,15 +165,15 @@ test("createStructureNode: nested type members", () => {
   nested.setName("RenamedThing");
 
   assert.strictEqual(
-    printNode(createStructureNode(structure, false)),
-    `export interface Nested {
+    printNode(createStructureNode(structure, { asClass: false })),
+    `interface Nested {
     Thing: typeof Thing;
     RenamedThing: typeof OtherThing;
 }`
   );
   assert.strictEqual(
-    printNode(createStructureNode(structure, true)),
-    `export declare abstract class Nested {
+    printNode(createStructureNode(structure, { asClass: true })),
+    `declare abstract class Nested {
     Thing: typeof Thing;
     RenamedThing: typeof OtherThing;
 }`
@@ -192,8 +192,8 @@ test("createStructureNode: constant members", () => {
   constant.setValue(Int64.fromNumber(42));
 
   assert.strictEqual(
-    printNode(createStructureNode(structure, true)),
-    `export declare abstract class Constants {
+    printNode(createStructureNode(structure, { asClass: true })),
+    `declare abstract class Constants {
     static readonly THING: number;
 }`
   );
@@ -233,15 +233,15 @@ test("createStructureNode: iterator members", () => {
   returnStructure.setFullyQualifiedName("workerd::api::AsyncThingIterator");
 
   assert.strictEqual(
-    printNode(createStructureNode(structure, false)),
-    `export interface Iterators {
+    printNode(createStructureNode(structure, { asClass: false })),
+    `interface Iterators {
     [Symbol.iterator](param0?: ThingOptions): ThingIterator;
     [Symbol.asyncIterator](param0?: AsyncThingOptions): AsyncThingIterator;
 }`
   );
   assert.strictEqual(
-    printNode(createStructureNode(structure, true)),
-    `export declare abstract class Iterators {
+    printNode(createStructureNode(structure, { asClass: true })),
+    `declare abstract class Iterators {
     [Symbol.iterator](param0?: ThingOptions): ThingIterator;
     [Symbol.asyncIterator](param0?: AsyncThingOptions): AsyncThingIterator;
 }`
@@ -269,8 +269,8 @@ test("createStructureNode: constructors", () => {
   }
 
   assert.strictEqual(
-    printNode(createStructureNode(structure, true)),
-    `export declare class Constructor {
+    printNode(createStructureNode(structure, { asClass: true })),
+    `declare class Constructor {
     constructor(param0: boolean | undefined, param1: string, param2: Promise<any>, param3?: number);
 }`
   );
@@ -286,8 +286,8 @@ test("createStructureNode: extends", () => {
   extendsStructure.setFullyQualifiedName("workerd::api::Base");
 
   assert.strictEqual(
-    printNode(createStructureNode(structure, true)),
-    `export declare abstract class Extends extends Base {
+    printNode(createStructureNode(structure, { asClass: true })),
+    `declare abstract class Extends extends Base {
 }`
   );
 });

--- a/types/test/index.spec.ts
+++ b/types/test/index.spec.ts
@@ -143,7 +143,7 @@ and limitations under the License.
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event)
  */
-declare interface Event {
+interface Event {
 }
 declare class EventTarget<EventMap extends Record<string, Event> = Record<string, Event>> {
     constructor();
@@ -166,7 +166,7 @@ declare class EventTarget<EventMap extends Record<string, Event> = Record<string
          */
     addEventListener<Type extends keyof EventMap>(type: Type, handler: (event: EventMap[Type]) => void): void;
 }
-declare type WorkerGlobalScopeEventMap = {
+type WorkerGlobalScopeEventMap = {
     fetch: Event;
     scheduled: Event;
 };
@@ -177,7 +177,7 @@ declare abstract class WorkerGlobalScope extends EventTarget<WorkerGlobalScopeEv
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope)
  */
-declare interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
+interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
     things(param0: boolean): IterableIterator<string>;
     get prop(): Promise<number>;
 }
@@ -213,7 +213,7 @@ and limitations under the License.
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event)
  */
-declare interface Event {}
+interface Event {}
 declare class EventTarget<
   EventMap extends Record<string, Event> = Record<string, Event>,
 > {
@@ -240,7 +240,7 @@ declare class EventTarget<
     handler: (event: EventMap[Type]) => void,
   ): void;
 }
-declare type WorkerGlobalScopeEventMap = {
+type WorkerGlobalScopeEventMap = {
   fetch: Event;
   scheduled: Event;
 };
@@ -250,7 +250,7 @@ declare abstract class WorkerGlobalScope extends EventTarget<WorkerGlobalScopeEv
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope)
  */
-declare interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
+interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
   things(param0: boolean): IterableIterator<string>;
   get prop(): Promise<number>;
 }

--- a/types/test/transforms/globals.spec.ts
+++ b/types/test/transforms/globals.spec.ts
@@ -11,29 +11,29 @@ import { createMemoryProgram } from "../../src/program";
 import { createGlobalScopeTransformer } from "../../src/transforms";
 
 test("createGlobalScopeTransformer: extracts global scope", () => {
-  const source = `export type WorkerGlobalScopeEventMap = {
+  const source = `type WorkerGlobalScopeEventMap = {
     fetch: Event;
     scheduled: Event;
 };
-export declare class EventTarget<EventMap extends Record<string, Event> = Record<string, Event>> {
+declare class EventTarget<EventMap extends Record<string, Event> = Record<string, Event>> {
     constructor();
     addEventListener<Type extends keyof EventMap>(type: Type, handler: (event: EventMap[Type]) => void): void; // MethodDeclaration
     removeEventListener<Type extends keyof EventMap>(type: Type, handler: (event: EventMap[Type]) => void): void; // MethodDeclaration
     dispatchEvent(event: EventMap[keyof EventMap]): void; // MethodDeclaration
 }
-export declare class WorkerGlobalScope extends EventTarget<WorkerGlobalScopeEventMap> {
+declare class WorkerGlobalScope extends EventTarget<WorkerGlobalScopeEventMap> {
     thing: string; // PropertyDeclaration
     static readonly CONSTANT: 42; // PropertyDeclaration
     get property(): number; // GetAccessorDeclaration
     set property(value: number); // GetAccessorDeclaration
 }
-export declare class DOMException {
+declare class DOMException {
 }
-export declare abstract class Crypto {
+declare abstract class Crypto {
 }
-export declare abstract class Console {
+declare abstract class Console {
 }
-export interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
+interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
     DOMException: typeof DOMException; // PropertySignature
     btoa(value: string): string; // MethodSignature
     crypto: Crypto; // PropertySignature
@@ -58,26 +58,26 @@ export interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
     output,
     // Extracted global nodes inserted after ServiceWorkerGlobalScope
     source +
-      `export declare function addEventListener<Type extends keyof WorkerGlobalScopeEventMap>(type: Type, handler: (event: WorkerGlobalScopeEventMap[Type]) => void): void;
-export declare function removeEventListener<Type extends keyof WorkerGlobalScopeEventMap>(type: Type, handler: (event: WorkerGlobalScopeEventMap[Type]) => void): void;
-export declare function dispatchEvent(event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap]): void;
-export declare const thing: string;
-export declare const CONSTANT: 42;
-export declare const property: number;
-export declare function btoa(value: string): string;
-export declare const crypto: Crypto;
-export declare const console: Console;
+      `declare function addEventListener<Type extends keyof WorkerGlobalScopeEventMap>(type: Type, handler: (event: WorkerGlobalScopeEventMap[Type]) => void): void;
+declare function removeEventListener<Type extends keyof WorkerGlobalScopeEventMap>(type: Type, handler: (event: WorkerGlobalScopeEventMap[Type]) => void): void;
+declare function dispatchEvent(event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap]): void;
+declare const thing: string;
+declare const CONSTANT: 42;
+declare const property: number;
+declare function btoa(value: string): string;
+declare const crypto: Crypto;
+declare const console: Console;
 `
   );
 });
 
 test("createGlobalScopeTransformer: inlining type parameters in heritage", () => {
-  const source = `export declare class A<T> {
+  const source = `declare class A<T> {
     thing: T;
 }
-export declare class B<T> extends A<T> {
+declare class B<T> extends A<T> {
 }
-export declare class ServiceWorkerGlobalScope extends B<string> {
+declare class ServiceWorkerGlobalScope extends B<string> {
 }
 `;
 
@@ -97,7 +97,7 @@ export declare class ServiceWorkerGlobalScope extends B<string> {
   assert.strictEqual(
     output,
     source +
-      `export declare const thing: string;
+      `declare const thing: string;
 `
   );
 });

--- a/types/test/transforms/overrides/index.spec.ts
+++ b/types/test/transforms/overrides/index.spec.ts
@@ -21,7 +21,7 @@ import {
 } from "../../../src/transforms";
 
 function printDefinitionsWithOverrides(root: StructureGroups): string {
-  const nodes = generateDefinitions(root);
+  const { nodes } = generateDefinitions(root);
 
   const [sources, replacements] = compileOverridesDefines(root);
   const sourcePath = path.resolve(__dirname, "source.ts");
@@ -81,9 +81,9 @@ test("createOverrideDefineTransformer: applies type renames", () => {
 
   assert.strictEqual(
     printDefinitionsWithOverrides(root),
-    `export declare abstract class RenamedThing {
+    `declare abstract class RenamedThing {
 }
-export interface Root1 {
+interface Root1 {
     prop: RenamedThing;
     method(param0: RenamedThing): RenamedThing;
     Thing: typeof RenamedThing;
@@ -150,7 +150,7 @@ test("createOverrideDefineTransformer: applies property overrides", () => {
 
   assert.strictEqual(
     printDefinitionsWithOverrides(root),
-    `export interface Root1 {
+    `interface Root1 {
     prop1?: "thing";
     readonly prop2: true;
     get prop3(): false;
@@ -228,13 +228,13 @@ test("createOverrideDefineTransformer: applies method overrides", () => {
     get(key: string, type: "arrayBuffer"): Promise<ArrayBuffer | null>;
 
     deleteAll: never;
-    
+
     get<T>(key: string, type: "json"): Promise<T | null>;
   }`);
 
   assert.strictEqual(
     printDefinitionsWithOverrides(root),
-    `export declare abstract class Root1 {
+    `declare abstract class Root1 {
     one(): number;
     static one(): 1;
     two(): 2;
@@ -289,10 +289,10 @@ test("createOverrideDefineTransformer: applies type parameter overrides", () => 
 
   assert.strictEqual(
     printDefinitionsWithOverrides(root),
-    `export interface RenamedStruct<Type extends string = string> {
+    `interface RenamedStruct<Type extends string = string> {
     type: Type;
 }
-export interface Root1<R> {
+interface Root1<R> {
     get(): RenamedStruct;
     read(): Promise<R>;
 }
@@ -349,13 +349,13 @@ test("createOverrideDefineTransformer: applies heritage overrides", () => {
 
   assert.strictEqual(
     printDefinitionsWithOverrides(root),
-    `export declare abstract class Superclass<T, U = unknown> {
+    `declare abstract class Superclass<T, U = unknown> {
 }
-export interface Root1 extends Superclass<ArrayBuffer | ArrayBufferView, Uint8Array> {
+interface Root1 extends Superclass<ArrayBuffer | ArrayBufferView, Uint8Array> {
 }
-export interface Root2<T> implements Superclass<T> {
+interface Root2<T> implements Superclass<T> {
 }
-export interface Root3 extends Superclass<boolean> {
+interface Root3 extends Superclass<boolean> {
     prop: 1 | 2 | 3;
 }
 `
@@ -398,18 +398,18 @@ test("createOverrideDefineTransformer: applies full type replacements", () => {
 
   assert.strictEqual(
     printDefinitionsWithOverrides(root),
-    `export declare const Root1 = {
+    `declare const Root1 = {
     new(): {
         0: Root2;
         1: RenamedRoot3;
     };
 };
-export declare enum Root2 {
+declare enum Root2 {
     ONE,
     TWO,
     THREE
 }
-export type RenamedRoot3<T = any> = {
+type RenamedRoot3<T = any> = {
     done: false;
     value: T;
 } | {
@@ -439,7 +439,7 @@ test("createOverrideDefineTransformer: applies overrides with literals", () => {
 
   assert.strictEqual(
     printDefinitionsWithOverrides(root),
-    `export interface Root1 {
+    `interface Root1 {
     literalString: "hello";
     literalNumber: 42;
     literalArray: [
@@ -476,12 +476,12 @@ test("createOverrideDefineTransformer: inserts extra defines", () => {
   // Check defines inserted before structure
   assert.strictEqual(
     printDefinitionsWithOverrides(root),
-    `export interface Root1 {
+    `interface Root1 {
 }
-export interface Root2Extra<Type> {
+interface Root2Extra<Type> {
     prop: Type;
 }
-export interface RenamedRoot2 {
+interface RenamedRoot2 {
 }
 `
   );


### PR DESCRIPTION
This is the first part of landing [Types as a Service](https://github.com/cloudflare/workerd/pull/1959).

This is a relatively large PR, but it's pretty low risk. It mostly contains some refactoring of the type generation code (e.g. files like [types/src/transforms/overrides/compiler.ts](https://github.com/cloudflare/workerd/pull/2379/files#diff-b3672e23392be040c988f7f7a2dac703816fd138336e12d98ab1614cbe169354) which have not changed in functionality). In large part this refactoring is to make it easier for a future PR (another part of #1959) to run this code in a Worker (for instance, changing `import ... from "assert"` to `import ... from "node:assert"` is in support of this goal, as well as the enhancing of the [memory-based compiler host we use for running TypeScript](https://github.com/cloudflare/workerd/pull/2379/files#diff-526655eb36a1321787a081b4d485e11a22d99ded40afdd565a8bc06d8543255a)).

This PR changes the output of the generated `index.d.ts` files to no longer `declare` things for which that's not necessary. This is semantically the same thing, and should have no impact on the usage of these types. We probably should've done it like this all along:

```diff
- declare interface SomeInterface {}
+ interface SomeInterface {}

- declare type SomeType =  {}
+ type SomeType = {}
```
However, this has resulted in some test changes—the behaviour is otherwise unchanged, and the output after this PR should be the same as the output before.

This PR _doesn't_ cover:
- Generating types from internal modules. This means that e.g. `cloudflare:sockets` is still defined by hand, although this PR _does_ add some additional mechanics to make this possible in future.
- The changes made in #1959 to [collation of comments from standards](https://github.com/cloudflare/workerd/pull/1959/files#diff-e4608382ec0590ba5b6b14735401d1fa68bc5c6f30ac856b64f6257af8356b23). This will come in a standalone followup.
- Typechecking internal modules with generated types
- Implementing a worker to generate types
- _Using_ that worker when generating the `@cloudflare/workers-types` package in CI

To aid reviewing, [this link shows the diff](https://github.com/penalosa/workers-types-diff/pull/1/files) between `@cloudflare/workers-types@4.20240701.0` and the output of the type generation scripts run from this branch.
