### PR TITLE
Better SQLite error message generation.

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -200,6 +200,11 @@ async function test(storage) {
   assert.throws(() => sql.exec('SELECT ;'), /syntax error at offset 7/)
   assert.throws(() => sql.exec('SELECT -;'), /syntax error at offset 8/)
 
+  // Data type mismatch
+  sql.exec(`CREATE TABLE test_error_codes (name TEXT);`)
+  assert.throws(() => sql.exec(`INSERT INTO test_error_codes(rowid, name) values ('yeah','nah');`), /Error: datatype mismatch: SQLITE_MISMATCH/)
+  sql.exec(`DROP TABLE test_error_codes;`)
+
   // Incorrect number of binding values
   assert.throws(
     () => sql.exec('SELECT ?'),
@@ -277,12 +282,12 @@ async function test(storage) {
   }
 
   // Trying to write to read-only pragmas is not allowed
-  assert.throws(() => sql.exec('PRAGMA data_version = 5'), /not authorized/)
+  assert.throws(() => sql.exec('PRAGMA data_version = 5'), /not authorized: SQLITE_AUTH/)
   assert.throws(
     () => sql.exec('PRAGMA max_page_count = 65536'),
     /not authorized/
   )
-  assert.throws(() => sql.exec('PRAGMA page_size = 8192'), /not authorized/)
+  assert.throws(() => sql.exec('PRAGMA page_size = 8192'), /not authorized: SQLITE_AUTH/)
 
   // PRAGMA table_info and PRAGMA table_xinfo are allowed.
   sql.exec('CREATE TABLE myTable (foo TEXT, bar INTEGER)')


### PR DESCRIPTION
The error messages now have the error code in them, either something like SQLITE_TOOBIG or SQLITE_FORMAT if it's a known code, or SQLITE_UNKNOWN_ERROR_CODE(%d) if it's not known to us.

SQLite doesn't provide any function to do this for us. It has an internal function `sqlite3ErrName` that looks a lot like the giant switch statement in this commit, but (a) it's not exposed to library consumers, and (b) it's only present if compiled with certain flags like SQLITE_DEBUG that also turn on a bunch of other stuff.

I considered patching SQLite to expose `sqlite3ErrName`, but I think it's easier for workerd maintainers to deal with adding the occasional new case to a switch statement we own than it is to maintain yet another SQLite patch.