### PR TITLE
Add WebSocketObserver

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1549,7 +1549,7 @@ kj::Promise<DeferredProxy<void>> Response::send(
     }
 
     auto clientSocket = outer.acceptWebSocket(outHeaders);
-    auto wsPromise = ws->couple(kj::mv(clientSocket));
+    auto wsPromise = ws->couple(kj::mv(clientSocket), context.getMetrics());
 
     KJ_IF_SOME(a, context.getActor()) {
       KJ_IF_SOME(hib, a.getHibernationManager()) {

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -21,11 +21,27 @@ class WorkerInterface;
 class LimitEnforcer;
 class TimerChannel;
 
+class WebSocketObserver: public kj::Refcounted {
+public:
+  // Called when a worker sends a message on this WebSocket (includes close messages).
+  virtual void sentMessage(size_t bytes) { };
+  // Called when a worker receives a message on this WebSocket (includes close messages).
+  virtual void receivedMessage(size_t bytes) { };
+};
+
 // Observes a specific request to a specific worker. Also observes outgoing subrequests.
 //
 // Observing anything is optional. Default implementations of all methods observe nothing.
 class RequestObserver: public kj::Refcounted {
 public:
+  // This is called when the request is converted to a WebSocket connection terminating in a worker.
+  // An optional WebSocket observer may be returned to observe events on the worker's end of the
+  // WebSocket connection.
+  //
+  // This means that, when the returned observer observes a message being sent, the message is being
+  // sent from the worker to the client making the request.
+  virtual kj::Maybe<kj::Own<WebSocketObserver>> tryCreateWebSocketObserver() { return kj::none; };
+
   // Invoked when the request is actually delivered.
   //
   // If, for some reason, this is not invoked before the object is destroyed, this indicate that


### PR DESCRIPTION
This allows observation of traffic on websocket connections terminating within workers.

I'm not 100% satisfied with either the abstraction or the naming (especially `coupledToLocalWebSocket` as a name for a method which creates a `WebSocketObserver` object), but I couldn't think of a clearly better alternative.

Note that this currently won't observe receives on hibernatable websockets. I'll add a TODO for that.