### PR TITLE
Implement rsa toPem, toDer, and fromJwk utilities

### DIFF
--- a/src/workerd/api/crypto/impl.h
+++ b/src/workerd/api/crypto/impl.h
@@ -373,6 +373,8 @@ kj::Own<CryptoKey::Impl> fromRsaKey(kj::Own<EVP_PKEY> key);
 kj::Own<CryptoKey::Impl> fromEcKey(kj::Own<EVP_PKEY> key);
 kj::Own<CryptoKey::Impl> fromEd25519Key(kj::Own<EVP_PKEY> key);
 
+ // If the input bytes are a valid ASN.1 sequence, return them minus the prefix.
+kj::Maybe<kj::ArrayPtr<const kj::byte>> tryGetAsn1Sequence(kj::ArrayPtr<const kj::byte> data);
 }  // namespace workerd::api
 
 KJ_DECLARE_NON_POLYMORPHIC(DH);

--- a/src/workerd/api/crypto/keys.h
+++ b/src/workerd/api/crypto/keys.h
@@ -4,6 +4,29 @@
 
 namespace workerd::api {
 
+enum class KeyEncoding {
+  PKCS1,
+  PKCS8,
+  SPKI,
+  SEC1,
+};
+
+inline kj::StringPtr KJ_STRINGIFY(KeyEncoding encoding) {
+  switch (encoding) {
+    case KeyEncoding::PKCS1: return "pkcs1";
+    case KeyEncoding::PKCS8: return "pkcs8";
+    case KeyEncoding::SPKI: return "spki";
+    case KeyEncoding::SEC1: return "sec1";
+  }
+  KJ_UNREACHABLE;
+}
+
+enum class KeyFormat {
+  PEM,
+  DER,
+  JWK,
+};
+
 enum class KeyType {
   SECRET,
   PUBLIC,

--- a/src/workerd/api/crypto/rsa.c++
+++ b/src/workerd/api/crypto/rsa.c++
@@ -269,7 +269,6 @@ kj::Maybe<AsymmetricKeyData> Rsa::fromJwk(KeyType keyType,
 
   static constexpr auto kInvalidBase64Error = "Invalid RSA key in JSON Web Key; invalid base64."_kj;
 
-  // TODO(now): Use a decodeBase64Url variant
   auto nDecoded = toBignumUnowned(simdutfBase64UrlDecodeChecked(n, kInvalidBase64Error));
   auto eDecoded = toBignumUnowned(simdutfBase64UrlDecodeChecked(e, kInvalidBase64Error));
   JSG_REQUIRE(RSA_set0_key(rsa.get(), nDecoded, eDecoded, nullptr) == 1, Error,
@@ -392,14 +391,14 @@ kj::Array<const kj::byte> Rsa::toDer(KeyEncoding encoding,
       switch (encoding) {
         case KeyEncoding::PKCS1: {
           JSG_REQUIRE(i2d_RSAPublicKey_bio(bio.get(), rsa) == 1, Error,
-              "Failed to write RSA public key to PEM", tryDescribeOpensslErrors());
+              "Failed to write RSA public key to DER", tryDescribeOpensslErrors());
           break;
         }
         case workerd::api::KeyEncoding::SPKI: {
           auto evpPkey = OSSL_NEW(EVP_PKEY);
           EVP_PKEY_set1_RSA(evpPkey.get(), rsa);
           JSG_REQUIRE(i2d_PUBKEY_bio(bio.get(), evpPkey.get()) == 1, Error,
-              "Failed to write RSA public key to PEM", tryDescribeOpensslErrors());
+              "Failed to write RSA public key to SPKI", tryDescribeOpensslErrors());
           break;
         }
         default: {

--- a/src/workerd/api/crypto/rsa.h
+++ b/src/workerd/api/crypto/rsa.h
@@ -22,19 +22,38 @@ public:
 
   kj::Array<kj::byte> getPublicExponent() KJ_WARN_UNUSED_RESULT;
 
-  CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail() const;
+  CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail() const KJ_WARN_UNUSED_RESULT;
 
-  kj::Array<kj::byte> sign(const kj::ArrayPtr<const kj::byte> data) const;
+  kj::Array<kj::byte> sign(const kj::ArrayPtr<const kj::byte> data) const KJ_WARN_UNUSED_RESULT;
+
+  static kj::Maybe<AsymmetricKeyData> fromJwk(
+      KeyType keyType,
+      const SubtleCrypto::JsonWebKey& jwk) KJ_WARN_UNUSED_RESULT;
 
   SubtleCrypto::JsonWebKey toJwk(KeyType keytype,
-                                 kj::Maybe<kj::String> maybeHashAlgorithm) const;
+                                 kj::Maybe<kj::String> maybeHashAlgorithm) const
+                                KJ_WARN_UNUSED_RESULT;
+
+  struct CipherOptions {
+    const EVP_CIPHER* cipher;
+    kj::ArrayPtr<const kj::byte> passphrase;
+  };
+
+  kj::String toPem(KeyEncoding encoding,
+                   KeyType keyType,
+                   kj::Maybe<CipherOptions> options = kj::none) const KJ_WARN_UNUSED_RESULT;
+
+  kj::Array<const kj::byte> toDer(KeyEncoding encoding,
+                                  KeyType keyType,
+                                  kj::Maybe<CipherOptions> options = kj::none) const
+                                  KJ_WARN_UNUSED_RESULT;
 
   using EncryptDecryptFunction = decltype(EVP_PKEY_encrypt);
   kj::Array<kj::byte> cipher(EVP_PKEY_CTX* ctx,
                              SubtleCrypto::EncryptAlgorithm&& algorithm,
                              kj::ArrayPtr<const kj::byte> data,
                              EncryptDecryptFunction encryptDecrypt,
-                             const EVP_MD* cipher) const;
+                             const EVP_MD* cipher) const KJ_WARN_UNUSED_RESULT;
 
   // The W3C standard itself doesn't describe any parameter validation but the conformance tests
   // do test "bad" exponents, likely because everyone uses OpenSSL that suffers from poor behavior
@@ -44,6 +63,8 @@ public:
                                 size_t modulusLength,
                                 kj::ArrayPtr<kj::byte> publicExponent,
                                 bool isImport = false);
+
+  static bool isRSAPrivateKey(kj::ArrayPtr<const kj::byte> keyData) KJ_WARN_UNUSED_RESULT;
 
 private:
   RSA* rsa;

--- a/src/workerd/api/crypto/rsa.h
+++ b/src/workerd/api/crypto/rsa.h
@@ -32,7 +32,7 @@ public:
 
   SubtleCrypto::JsonWebKey toJwk(KeyType keytype,
                                  kj::Maybe<kj::String> maybeHashAlgorithm) const
-                                KJ_WARN_UNUSED_RESULT;
+                                 KJ_WARN_UNUSED_RESULT;
 
   struct CipherOptions {
     const EVP_CIPHER* cipher;


### PR DESCRIPTION
Separating out more of the node.js crypto key handling support. There's a lot to do with all this so I'm piecing it out into separate PRs that individually are easier to review. This adds methods but does not add the stuff that uses it yet. Tests for these individual pieces will also be added separately. A fair amount of this is adapted from https://github.com/nodejs/node/blob/main/src/crypto/crypto_keys.cc