### PR TITLE
Unpin the port for compile-tests using control-fd

### DIFF
--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -146,7 +146,6 @@ sh_test(
     args = [
         "$(location :workerd)",
         "$(location //samples:helloworld/config.capnp)",
-        "10702",
         "$(location tests/compile-tests/compile-helloworld-test.ok)",
     ],
     data = [
@@ -155,6 +154,7 @@ sh_test(
         "//samples:helloworld/config.capnp",
         "//samples:helloworld/worker.js",
     ],
+    tags = ["no-qemu"],
 )
 
 [kj_test(

--- a/src/workerd/server/tests/compile-tests/compile-test.sh
+++ b/src/workerd/server/tests/compile-tests/compile-test.sh
@@ -35,25 +35,33 @@ done
 shift $(expr $OPTIND - 1)
 WORKERD_BINARY=$1
 CAPNP_SOURCE=$2
-PORT=$3
-EXPECTED=$4
+EXPECTED=$3
 
 CAPNP_BINARY=$(mktemp)
+PORT_FILE=$(mktemp)
 
 # Compile the app
 $WORKERD_BINARY compile $CAPNP_SOURCE > $CAPNP_BINARY
 
 # Run the app
-$CAPNP_BINARY -shttp=localhost:$PORT &
+$CAPNP_BINARY -shttp=localhost:0 --control-fd=1 > $PORT_FILE &
 KILL=$!
+
+# Make intermediate files before trying to wait on the bindings
 OUTPUT=$(mktemp)
 FIXED_OUTPUT=$(mktemp)
 FIXED_EXPECTED=$(mktemp)
 
-# Request output - and ensure the system is live
-while ! curl localhost:$PORT -o $OUTPUT; do
+# Wait on the port bindings to occur
+while ! grep \"socket\"\:\"http\" $PORT_FILE; do
   sleep .1
-done;
+done
+
+# Identify the port chosen by the binary
+PORT=`grep \"socket\"\:\"http\" $PORT_FILE | sed 's/^.*\"port\"://g' | sed 's/\}//g' |head -n 1`
+
+# Request output
+curl localhost:$PORT -o $OUTPUT
 
 # Compare the tests to the expected output
 sed -e's/[[:space:]]*$//' $OUTPUT > $FIXED_OUTPUT
@@ -65,6 +73,7 @@ kill -9 $KILL
 
 # Clean up temp files
 rm -f $CAPNP_BINARY
+rm -f $PORT_FILE
 rm -f $OUTPUT
 rm -f $FIXED_OUTPUT
 rm -f $FIXED_EXPECTED


### PR DESCRIPTION
This PR also sets `no-qemu` as this is causing problems downstream.