### PR TITLE
[types] Refactor doc comment injection

### DIFF
--- a/types/src/cloudflare.ts
+++ b/types/src/cloudflare.ts
@@ -1,0 +1,80 @@
+// This file extends `standards.ts` with specific comments overrides for Cloudflare Workers APIs
+// that aren't adequately described by a standard .d.ts file
+
+import { CommentsData } from "./transforms";
+export default {
+  caches: {
+    $: `*
+* The Cache API allows fine grained control of reading and writing from the Cloudflare global network cache.
+*
+* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/)
+`,
+  },
+  CacheStorage: {
+    $: `*
+* The Cache API allows fine grained control of reading and writing from the Cloudflare global network cache.
+*
+* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/)
+`,
+  },
+  Cache: {
+    $: `*
+* The Cache API allows fine grained control of reading and writing from the Cloudflare global network cache.
+*
+* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/)
+`,
+    delete: ` [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/#delete) `,
+    match: ` [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/#match) `,
+    put: ` [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/#put) `,
+  },
+  crypto: {
+    $: `*
+* The Web Crypto API provides a set of low-level functions for common cryptographic tasks.
+* The Workers runtime implements the full surface of this API, but with some differences in
+* the [supported algorithms](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/#supported-algorithms)
+* compared to those implemented in most browsers.
+*
+* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/)
+`,
+  },
+  Crypto: {
+    $: `*
+* The Web Crypto API provides a set of low-level functions for common cryptographic tasks.
+* The Workers runtime implements the full surface of this API, but with some differences in
+* the [supported algorithms](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/#supported-algorithms)
+* compared to those implemented in most browsers.
+*
+* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/)
+`,
+  },
+  performance: {
+    $: `*
+* The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
+* as well as timing of subrequests and other operations.
+*
+* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
+`,
+  },
+  Performance: {
+    $: `*
+* The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
+* as well as timing of subrequests and other operations.
+*
+* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
+`,
+    timeOrigin: ` [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancetimeorigin) `,
+    now: ` [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancenow) `,
+  },
+  self: {
+    $: undefined,
+  },
+  navigator: {
+    $: undefined,
+  },
+  origin: {
+    $: undefined,
+  },
+  WorkerGlobalScope: {
+    $: undefined,
+  },
+} satisfies CommentsData;

--- a/types/src/standards.ts
+++ b/types/src/standards.ts
@@ -1,68 +1,117 @@
-import { assert } from "console";
-import { readFile } from "fs/promises";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
 import * as ts from "typescript";
 import { createMemoryProgram } from "./program";
-export interface ParsedTypeDefinition {
-  program: ts.Program;
-  source: ts.SourceFile;
-  checker: ts.TypeChecker;
-  parsed: {
-    functions: Map<string, ts.FunctionDeclaration>;
-    interfaces: Map<string, ts.InterfaceDeclaration>;
-    vars: Map<string, ts.VariableDeclaration>;
-    types: Map<string, ts.TypeAliasDeclaration>;
-    classes: Map<string, ts.ClassDeclaration>;
-  };
-}
+import { CommentsData } from "./transforms";
 
-// Collate standards (to support lib.(dom|webworker).iterable.d.ts being defined separately)
-export async function collateStandards(
+// Collate comments from standards-based .d.ts files (e.g. lib.webworker.d.ts)
+export function collateStandardComments(
   ...standardTypes: string[]
-): Promise<ParsedTypeDefinition> {
-  const STANDARDS_PATH = "/source.ts";
-  const text: string = (
-    await Promise.all(
-      standardTypes.map(
-        async (s) =>
-          // Remove the Microsoft copyright notices from the file, to prevent them being copied in as TS comments
-          (await readFile(s, "utf-8")).split(`/////////////////////////////`)[2]
-      )
+): CommentsData {
+  const combinedLibPath = "/$virtual/standards.d.ts";
+  const combinedLibContents: string = standardTypes
+    .map(
+      (s) =>
+        // Remove the Microsoft copyright notices from the file, to prevent them being copied in as TS comments
+        readFileSync(s, "utf-8").split(`/////////////////////////////`)[2]
     )
-  ).join("\n");
-  const program = createMemoryProgram(new Map([[STANDARDS_PATH, text]]));
-  const source = program.getSourceFile(STANDARDS_PATH)!;
-  const checker = program.getTypeChecker();
-  const parsed = {
-    functions: new Map<string, ts.FunctionDeclaration>(),
-    interfaces: new Map<string, ts.InterfaceDeclaration>(),
-    vars: new Map<string, ts.VariableDeclaration>(),
-    types: new Map<string, ts.TypeAliasDeclaration>(),
-    classes: new Map<string, ts.ClassDeclaration>(),
+    .join("\n");
+
+  const program = createMemoryProgram(
+    new Map([[combinedLibPath, combinedLibContents]])
+  );
+
+  const combinedLibFile = program.getSourceFile(combinedLibPath);
+
+  assert(combinedLibFile !== undefined);
+
+  const result: CommentsData = {};
+  const recordComments = (node: ts.Node, name: string, memberName?: string) => {
+    const ranges = ts.getLeadingCommentRanges(
+      combinedLibContents,
+      node.getFullStart()
+    );
+    if (ranges === undefined) return;
+
+    const nodeResult = (result[name] ??= {});
+    const key = memberName ?? "$";
+    nodeResult[key] ??= "";
+
+    for (const range of ranges) {
+      let text = combinedLibContents.slice(range.pos + 2, range.end);
+      // All lib.*.d.ts file use multiline comment syntax (/** ... */).
+      // For the avoidance of doubt and to make sure the following parsing code is valid,
+      // assert that only multiline comments are included.
+      assert(
+        range.kind === ts.SyntaxKind.MultiLineCommentTrivia,
+        "Unexpected single-line comment in a standards .d.ts file"
+      );
+      text = text
+        // Remove the multiline comment end
+        .slice(0, text.length - 2)
+        // Remove multiline comment prefix lines (e.g. `   * ` -> ` * `)
+        .replaceAll(/^\s+/gm, " ");
+
+      // Let's make sure comments that are actually only 1 line (usually a link to MDN) don't start
+      // with two * characters (e.g. `/** [MDN Reference] ... */` -> `/* [MDN Reference] ... */`)
+      if (!text.includes("\n") && text.startsWith("*")) {
+        text = text.slice(1);
+      }
+
+      // Because we load multiple lib files, some types are included multiple times.
+      // This simple check makes sure that we don't add a doc comment twice
+      if (!nodeResult[key]?.includes?.(text)) {
+        nodeResult[key] += text;
+      }
+    }
   };
-  ts.forEachChild(source, (node) => {
-    let name = "";
-    if (node && ts.isFunctionDeclaration(node)) {
-      name = node.name?.text ?? "";
-      parsed.functions.set(name, node);
+
+  ts.forEachChild(combinedLibFile, (node) => {
+    if (ts.isInterfaceDeclaration(node)) {
+      // Prototype properties/methods exist on interfaces, for example:
+      // ```ts
+      // /** ... */
+      // interface AbortSignal extends EventTarget {
+      //   /** ... */
+      //   readonly aborted: boolean;
+      // }
+      // ```
+      recordComments(node, node.name.text);
+      for (const member of node.members) {
+        if (member.name === undefined) continue;
+        if (!ts.isIdentifier(member.name)) continue;
+        recordComments(member, node.name.text, member.name.text);
+      }
+    } else if (ts.isFunctionDeclaration(node)) {
+      if (node.name !== undefined) recordComments(node, node.name.text);
     } else if (ts.isVariableStatement(node)) {
-      assert(node.declarationList.declarations.length === 1);
-      name = node.declarationList.declarations[0].name.getText(source);
-      parsed.vars.set(name, node.declarationList.declarations[0]);
-    } else if (ts.isInterfaceDeclaration(node)) {
-      name = node.name.text;
-      parsed.interfaces.set(name, node);
-    } else if (ts.isTypeAliasDeclaration(node)) {
-      name = node.name.text;
-      parsed.types.set(name, node);
-    } else if (ts.isClassDeclaration(node)) {
-      name = node.name?.text ?? "";
-      parsed.classes.set(name, node);
+      if (node.declarationList.declarations.length > 1) return;
+      const declaration = node.declarationList.declarations[0];
+      const name = declaration.name;
+      if (!ts.isIdentifier(name)) return;
+      recordComments(node, name.text);
+
+      if (
+        declaration.type !== undefined &&
+        ts.isTypeLiteralNode(declaration.type)
+      ) {
+        // Static properties/methods exist on type literals, for example:
+        // ```ts
+        // declare var AbortSignal: {
+        //   prototype: AbortSignal;
+        //   new(): AbortSignal;
+        //   /** ... */
+        //   abort(reason?: any): AbortSignal;
+        // };
+        // ```
+        for (const member of declaration.type.members) {
+          if (member.name === undefined) continue;
+          if (!ts.isIdentifier(member.name)) continue;
+          recordComments(member, name.text, `static:${member.name.text}`);
+        }
+      }
     }
   });
-  return {
-    program,
-    source,
-    checker,
-    parsed,
-  };
+
+  return result;
 }

--- a/types/src/transforms/comments.ts
+++ b/types/src/transforms/comments.ts
@@ -1,124 +1,78 @@
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-
-import assert from "node:assert";
 import ts from "typescript";
-import { ParsedTypeDefinition } from "../standards";
 import { hasModifier } from "./helpers";
 
-function attachComments(
-  from: ts.Node,
-  to: ts.Node,
-  sourceFile: ts.SourceFile
-): void {
-  const text = sourceFile.getFullText();
-  const extractCommentText = (comment: ts.CommentRange) =>
-    comment.kind === ts.SyntaxKind.MultiLineCommentTrivia
-      ? text.slice(comment.pos + 2, comment.end - 2)
-      : text.slice(comment.pos + 2, comment.end);
-  const leadingComments: string[] =
-    ts
-      .getLeadingCommentRanges(text, from.getFullStart())
-      ?.map(extractCommentText) ?? [];
+// Refer to `collateStandardComments()` in `standards.ts` for construction
+export type CommentsData = Record<
+  /* globalName */ string,
+  | Record</* root */ "$" | /* memberName */ string, string | undefined>
+  | undefined
+>;
 
-  leadingComments.map((c) =>
-    ts.addSyntheticLeadingComment(
-      to,
-      ts.SyntaxKind.MultiLineCommentTrivia,
-      c,
-      true
-    )
-  );
-}
-
-// Copy comments from a parsed standards TS program. It relies on the shape of lib.dom or lib.webworker
-// Specifically, classes must be defined as a global var with the static properties, and an interface with the instance properties
 export function createCommentsTransformer(
-  standards: ParsedTypeDefinition
+  comments: CommentsData
 ): ts.TransformerFactory<ts.SourceFile> {
   return (ctx) => {
     return (node) => {
-      const visitor = createVisitor(standards);
+      const visitor = createVisitor(comments);
       return ts.visitEachChild(node, visitor, ctx);
     };
   };
 }
 
-function createVisitor(standards: ParsedTypeDefinition) {
-  return (node: ts.Node) => {
-    if (ts.isClassDeclaration(node)) {
-      const name = node.name?.getText();
-      assert(name !== undefined);
-      const standardsVersion = standards.parsed.vars.get(name);
-      if (standardsVersion) {
-        const type = standardsVersion.type;
-        assert(
-          type !== undefined && ts.isTypeLiteralNode(type),
-          `Non type literal found for "${name}"`
-        );
-        attachComments(standardsVersion, node, standards.source);
-        const standardsInterface = standards.parsed.interfaces.get(name);
-        assert(standardsInterface !== undefined);
-        node.members.forEach((member) => {
-          const n = member.name?.getText();
-          if (!n && ts.isConstructorDeclaration(member)) return;
+function maybeAddComment(node: ts.Node, comment?: string) {
+  if (comment === undefined) return;
+  ts.addSyntheticLeadingComment(
+    node,
+    ts.SyntaxKind.MultiLineCommentTrivia,
+    comment,
+    /* hasTrailingNewLine */ true
+  );
+}
 
-          assert(n !== undefined, `No name for child of ${name}`);
+function createVisitor(data: CommentsData) {
+  return (node: ts.Node) => {
+    if (
+      (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) &&
+      node.name !== undefined &&
+      ts.isIdentifier(node.name)
+    ) {
+      const comments = data[node.name.text];
+      maybeAddComment(node, comments?.["$"]);
+      for (const member of node.members) {
+        if (member.name !== undefined && ts.isIdentifier(member.name)) {
+          let key = member.name.text;
 
           const isStatic =
             ts.canHaveModifiers(member) &&
             hasModifier(ts.getModifiers(member), ts.SyntaxKind.StaticKeyword);
-          const target = isStatic ? type : standardsInterface;
-          const standardsEquivalent = target.members.find(
-            (member) => member.name?.getText() === n
-          );
+          if (isStatic) key = `static:${key}`;
 
-          if (standardsEquivalent)
-            attachComments(standardsEquivalent, member, standards.source);
-        });
+          maybeAddComment(member, comments?.[key]);
+        }
       }
-    } else if (ts.isFunctionDeclaration(node)) {
-      assert(node.name !== undefined);
-      const name = node.name.text;
-      const standardsVersion = standards.parsed.functions.get(name);
-      if (standardsVersion) {
-        attachComments(standardsVersion, node, standards.source);
-      }
-    } else if (ts.isInterfaceDeclaration(node)) {
-      assert(node.name !== undefined);
-      const name = node.name.text;
-      const standardsVersion = standards.parsed.interfaces.get(name);
-      if (standardsVersion) {
-        attachComments(standardsVersion, node, standards.source);
-        node.members.forEach((member) => {
-          try {
-            const n = member.name?.getText();
-            assert(n !== undefined);
-            const standardsEquivalent = standardsVersion.members.find(
-              (m) => m.name?.getText() === n
-            );
-            if (standardsEquivalent)
-              attachComments(standardsEquivalent, member, standards.source);
-          } catch {}
-        });
-      }
-    } else if (ts.isTypeAliasDeclaration(node)) {
-      assert(node.name !== undefined);
-      const name = node.name.text;
-      const standardsVersion = standards.parsed.types.get(name);
-      if (standardsVersion) {
-        attachComments(standardsVersion, node, standards.source);
-      }
-    } else if (ts.isVariableStatement(node)) {
-      // These contain comments that are misleading in the context of a Worker
-      const ignoreForComments = new Set(["self", "navigator", "caches"]);
-      assert(node.declarationList.declarations.length === 1);
-      assert(node.declarationList.declarations[0].name !== undefined);
-      const name = node.declarationList.declarations[0].name.getText();
-      const standardsVersion = standards.parsed.vars.get(name);
-      if (standardsVersion && !ignoreForComments.has(name)) {
-        attachComments(standardsVersion, node, standards.source);
+    }
+
+    if (
+      ts.isFunctionDeclaration(node) &&
+      node.name !== undefined &&
+      ts.isIdentifier(node.name)
+    ) {
+      const comments = data[node.name.text];
+      maybeAddComment(node, comments?.["$"]);
+    }
+
+    if (
+      ts.isVariableStatement(node) &&
+      node.declarationList.declarations.length === 1
+    ) {
+      const declaration = node.declarationList.declarations[0];
+      const name = declaration.name;
+      if (ts.isIdentifier(name)) {
+        const comments = data[name.text];
+        maybeAddComment(node, comments?.["$"]);
       }
     }
 

--- a/types/test/index.spec.ts
+++ b/types/test/index.spec.ts
@@ -145,25 +145,30 @@ and limitations under the License.
  */
 interface Event {
 }
+/**
+ * EventTarget is a DOM interface implemented by objects that can receive events and may have listeners for them.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget)
+ */
 declare class EventTarget<EventMap extends Record<string, Event> = Record<string, Event>> {
     constructor();
     /**
-         * Appends an event listener for events whose type attribute value is type. The callback argument sets the callback that will be invoked when the event is dispatched.
-         *
-         * The options argument sets listener-specific options. For compatibility this can be a boolean, in which case the method behaves exactly as if the value was specified as options's capture.
-         *
-         * When set to true, options's capture prevents callback from being invoked when the event's eventPhase attribute value is BUBBLING_PHASE. When false (or not present), callback will not be invoked when event's eventPhase attribute value is CAPTURING_PHASE. Either way, callback will be invoked if event's eventPhase attribute value is AT_TARGET.
-         *
-         * When set to true, options's passive indicates that the callback will not cancel the event by invoking preventDefault(). This is used to enable performance optimizations described in § 2.8 Observing event listeners.
-         *
-         * When set to true, options's once indicates that the callback will only be invoked once after which the event listener will be removed.
-         *
-         * If an AbortSignal is passed for options's signal, then the event listener will be removed when signal is aborted.
-         *
-         * The event listener is appended to target's event listener list and is not appended if it has the same type, callback, and capture.
-         *
-         * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
-         */
+     * Appends an event listener for events whose type attribute value is type. The callback argument sets the callback that will be invoked when the event is dispatched.
+     *
+     * The options argument sets listener-specific options. For compatibility this can be a boolean, in which case the method behaves exactly as if the value was specified as options's capture.
+     *
+     * When set to true, options's capture prevents callback from being invoked when the event's eventPhase attribute value is BUBBLING_PHASE. When false (or not present), callback will not be invoked when event's eventPhase attribute value is CAPTURING_PHASE. Either way, callback will be invoked if event's eventPhase attribute value is AT_TARGET.
+     *
+     * When set to true, options's passive indicates that the callback will not cancel the event by invoking preventDefault(). This is used to enable performance optimizations described in § 2.8 Observing event listeners.
+     *
+     * When set to true, options's once indicates that the callback will only be invoked once after which the event listener will be removed.
+     *
+     * If an AbortSignal is passed for options's signal, then the event listener will be removed when signal is aborted.
+     *
+     * The event listener is appended to target's event listener list and is not appended if it has the same type, callback, and capture.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
+     */
     addEventListener<Type extends keyof EventMap>(type: Type, handler: (event: EventMap[Type]) => void): void;
 }
 type WorkerGlobalScopeEventMap = {
@@ -214,6 +219,11 @@ and limitations under the License.
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event)
  */
 interface Event {}
+/**
+ * EventTarget is a DOM interface implemented by objects that can receive events and may have listeners for them.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget)
+ */
 declare class EventTarget<
   EventMap extends Record<string, Event> = Record<string, Event>,
 > {


### PR DESCRIPTION
Follow up to https://github.com/cloudflare/workerd/pull/2379, and part 2 of landing https://github.com/cloudflare/workerd/pull/1959.

For some prior context, when we generate types we copy over doc comments from `lib.webworker.d.ts` to the built runtime types. This means that things like `Request.json()` which are present in both the Workers environment and the web have useful comments when you hover over them in editors. This is really useful! But there are a few problems which this PR addresses.

The main _purpose_ of this PR is to ensure that when we generate types, all of the data passed into the generation function ([`printDefinitions()`](https://github.com/cloudflare/workerd/blob/0e30ac6cd5772ca7b1b9d656f392d3f24c5821bf/types/src/index.ts#L145)) is serialisable, to help move towards a world where type generation happens in a Worker. When type generation happens in a Worker, we want to be able to embed the extracted comments in the Worker itself—with the implementation as it was before this PR, the extracted comments lived in live TypeScript compiler node objects. Now, we have an intermediate format that can be bundled into a future type generation Worker: [`CommentsData`](https://github.com/cloudflare/workerd/blob/0e30ac6cd5772ca7b1b9d656f392d3f24c5821bf/types/src/transforms/comments.ts#L8).

Along with this serialisable intermediate format, this PR also fixes a bug where top-level APIs did not have comments copied over. They now are e.g.

```diff
+/**
+ * This Streams API interface provides a built-in byte length queuing strategy that can be used when constructing streams.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CountQueuingStrategy)
+ */
declare class CountQueuingStrategy implements QueuingStrategy {
  ...
}
```

This PR also introduces a method for injecting additional comments into the generated runtime types (see `types/src/cloudflare.ts`), and kicks things off by including doc-comments for crypto, cache, and performance, all of which have short descriptions and link out to the Cloudflare docs. These comments are not intended to have perfect coverage, they just slightly improve on what's already present. I imagine this file will need to evolve and change over time as we add new APIs. cc @irvinebroque for visibility on this section in particular.

To aid reviewing, [this link shows the diff](https://github.com/penalosa/workers-types-diff/pull/1/files) between @cloudflare/workers-types@4.20240701.0 and the output of the type generation scripts run from this branch.