### PR TITLE
Add truncated flag for tail worker events

### DIFF
--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -201,7 +201,8 @@ TraceItem::TraceItem(jsg::Lock& js, const Trace& trace)
       scriptTags(getTraceScriptTags(trace)),
       outcome(getTraceOutcome(trace)),
       cpuTime(trace.cpuTime / kj::MILLISECONDS),
-      wallTime(trace.wallTime / kj::MILLISECONDS) {}
+      wallTime(trace.wallTime / kj::MILLISECONDS),
+      truncated(trace.truncated) {}
 
 kj::Maybe<TraceItem::EventInfo> TraceItem::getEvent(jsg::Lock& js) {
   return eventInfo.map([](auto& info) -> TraceItem::EventInfo {
@@ -259,6 +260,8 @@ jsg::Optional<kj::Array<kj::StringPtr>> TraceItem::getScriptTags() {
 }
 
 kj::StringPtr TraceItem::getOutcome() { return outcome; }
+
+bool TraceItem::getTruncated() { return truncated; }
 
 uint TraceItem::getCpuTime() { return cpuTime; }
 

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -102,6 +102,7 @@ public:
 
   uint getCpuTime();
   uint getWallTime();
+  bool getTruncated();
 
   JSG_RESOURCE_TYPE(TraceItem) {
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(event, getEvent);
@@ -115,6 +116,7 @@ public:
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(dispatchNamespace, getDispatchNamespace);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptTags, getScriptTags);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(outcome, getOutcome);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(truncated, getTruncated);
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
@@ -133,6 +135,7 @@ private:
   kj::String outcome;
   uint cpuTime;
   uint wallTime;
+  bool truncated;
 };
 
 // When adding a new TraceItem eventInfo type, it is important not to

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -292,6 +292,7 @@ public:
   kj::Duration cpuTime;
   kj::Duration wallTime;
 
+  bool truncated = false;
   bool exceededLogLimit = false;
   bool exceededExceptionLimit = false;
   bool exceededDiagnosticChannelEventLimit = false;

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -135,6 +135,9 @@ struct Trace @0x8e8d911203762d34 {
     channel @1 :Text;
     message @2 :Data;
   }
+
+  truncated @24 :Bool;
+  # Indicates that the trace was truncated due to reaching the maximum size limit.
 }
 
 struct ScheduledRun @0xd98fc1ae5c8095d0 {


### PR DESCRIPTION
When set, indicates that the tail worker event was truncated due to the event buffer being full.