### PR TITLE
Redoing "#2073: Update Request to support cache option" with compat flags

### DIFF
--- a/src/workerd/api/http-test.js
+++ b/src/workerd/api/http-test.js
@@ -126,6 +126,7 @@ export const inspect = {
     });
     assert.strictEqual(util.inspect(request),
 `Request {
+  cache: undefined,
   keepalive: false,
   integrity: '',
   cf: undefined,
@@ -203,5 +204,38 @@ export const inspect = {
     webSocket.send("data");
     webSocket.close();
     await messagePromise;
+  }
+};
+
+export const cacheMode = {
+  async test() {
+    {
+      const req = new Request('https://example.org', { });
+      assert.strictEqual(req.cache, undefined);
+    }
+    {
+      const req = new Request('https://example.org', { cache: 'no-store' });
+      assert.strictEqual(req.cache, 'no-store');
+    }
+    {
+      const req = new Request('https://example.org', { cache: 'no-cache' });
+      assert.strictEqual(req.cache, 'no-cache');
+    }
+    assert.throws(() => {
+      new Request('https://example.org', { cache: 'unsupported' });
+    }, {
+      name: 'TypeError',
+      message: 'Unsupported cache mode: unsupported',
+    });
+
+    // Any value other that undefined is currently not supported
+    // TODO(soon): The no-store and no-cache values will be supported
+    // soon, at which time this test will need to be updated.
+    await assert.rejects((async () => {
+      await fetch('http://example.org', { cache: 'no-store' });
+    })(), {
+      name: 'TypeError',
+      message: 'Unsupported cache mode: no-store',
+    });
   }
 };

--- a/src/workerd/api/http-test.js
+++ b/src/workerd/api/http-test.js
@@ -228,7 +228,7 @@ export const cacheMode = {
       message: 'Unsupported cache mode: unsupported',
     });
 
-    // Any value other that undefined is currently not supported
+    // Any value other than undefined is currently not supported
     // TODO(soon): The no-store and no-cache values will be supported
     // soon, at which time this test will need to be updated.
     await assert.rejects((async () => {

--- a/src/workerd/api/http-test.wd-test
+++ b/src/workerd/api/http-test.wd-test
@@ -11,7 +11,7 @@ const unitTests :Workerd.Config = (
           ( name = "SERVICE", service = "http-test" )
         ],
         compatibilityDate = "2023-08-01",
-        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "cache_header_enabled"],
+        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "cache_option_enabled"],
       )
     ),
   ],

--- a/src/workerd/api/http-test.wd-test
+++ b/src/workerd/api/http-test.wd-test
@@ -11,7 +11,7 @@ const unitTests :Workerd.Config = (
           ( name = "SERVICE", service = "http-test" )
         ],
         compatibilityDate = "2023-08-01",
-        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers"],
+        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "cache_header_enabled"],
       )
     ),
   ],

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1076,6 +1076,10 @@ jsg::Ref<Request> Request::constructor(
         }
 
         KJ_IF_SOME(c, initDict.cache) {
+          bool cacheHeaderEnabled = FeatureFlags::get(js).getCacheHeaderEnabled();
+          if(!cacheHeaderEnabled) {
+            JSG_FAIL_REQUIRE(TypeError, kj::str("Unsupported cache mode: ", c, "\nYou may need to enable a compatability flag."));
+          }
           cacheMode = getCacheModeFromName(c);
         }
 

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1076,10 +1076,9 @@ jsg::Ref<Request> Request::constructor(
         }
 
         KJ_IF_SOME(c, initDict.cache) {
-          bool cacheHeaderEnabled = FeatureFlags::get(js).getCacheHeaderEnabled();
-          if(!cacheHeaderEnabled) {
-            JSG_FAIL_REQUIRE(TypeError, kj::str("Unsupported cache mode: ", c, "\nYou may need to enable a compatability flag."));
-          }
+          JSG_REQUIRE(FeatureFlags::get(js).getCacheOptionEnabled(), TypeError, kj::str(
+            "Unsupported cache mode: ", c,
+            "\nYou may need to enable the cache_option_enabled compatability flag."));
           cacheMode = getCacheModeFromName(c);
         }
 

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -113,6 +113,21 @@ void requireValidHeaderValue(kj::StringPtr value) {
   }
 }
 
+Request::CacheMode getCacheModeFromName(kj::StringPtr value) {
+  if (value == "no-store") return Request::CacheMode::NOSTORE;
+  if (value == "no-cache") return Request::CacheMode::NOCACHE;
+  JSG_FAIL_REQUIRE(TypeError, kj::str("Unsupported cache mode: ", value));
+}
+
+jsg::Optional<kj::StringPtr> getCacheModeName(Request::CacheMode mode) {
+  switch (mode) {
+    case (Request::CacheMode::NONE): return kj::none;
+    case (Request::CacheMode::NOCACHE): return "no-cache"_kj;
+    case (Request::CacheMode::NOSTORE): return "no-store"_kj;
+  }
+  KJ_UNREACHABLE;
+}
+
 }  // namespace
 
 Headers::Headers(jsg::Dict<jsg::ByteString, jsg::ByteString> dict)
@@ -898,6 +913,13 @@ jsg::Ref<Request> Request::coerce(
         : Request::constructor(js, kj::mv(input), kj::mv(init));
 }
 
+jsg::Optional<kj::StringPtr> Request::getCache(jsg::Lock& js) {
+  return getCacheModeName(cacheMode);
+}
+Request::CacheMode Request::getCacheMode() {
+  return cacheMode;
+}
+
 jsg::Ref<Request> Request::constructor(
     jsg::Lock& js,
     Request::Info input,
@@ -910,6 +932,7 @@ jsg::Ref<Request> Request::constructor(
   CfProperty cf;
   kj::Maybe<Body::ExtractedBody> body;
   Redirect redirect = Redirect::FOLLOW;
+  CacheMode cacheMode = CacheMode::NONE;
 
   KJ_SWITCH_ONEOF(input) {
     KJ_CASE_ONEOF(u, kj::String) {
@@ -975,6 +998,7 @@ jsg::Ref<Request> Request::constructor(
           body = Body::ExtractedBody((oldJsBody)->detach(js), oldRequest->getBodyBuffer(js));
         }
       }
+      cacheMode = oldRequest->getCacheMode();
       redirect = oldRequest->getRedirectEnum();
       fetcher = oldRequest->getFetcher();
       signal = oldRequest->getSignal();
@@ -1051,6 +1075,10 @@ jsg::Ref<Request> Request::constructor(
               "response status code).");
         }
 
+        KJ_IF_SOME(c, initDict.cache) {
+          cacheMode = getCacheModeFromName(c);
+        }
+
         if (initDict.method != kj::none || initDict.body != kj::none) {
           // We modified at least one of the method or the body. In this case, we enforce the
           // spec rule that GET/HEAD requests cannot have bodies. (On the other hand, if neither
@@ -1065,6 +1093,7 @@ jsg::Ref<Request> Request::constructor(
       KJ_CASE_ONEOF(otherRequest, jsg::Ref<Request>) {
         method = otherRequest->method;
         redirect = otherRequest->redirect;
+        cacheMode = otherRequest->cacheMode;
         fetcher = otherRequest->getFetcher();
         signal = otherRequest->getSignal();
         headers = jsg::alloc<Headers>(*otherRequest->headers);
@@ -1086,7 +1115,7 @@ jsg::Ref<Request> Request::constructor(
   // TODO(conform): If `init` has a keepalive flag, pass it to the Body constructor.
   return jsg::alloc<Request>(method, url, redirect,
                  KJ_ASSERT_NONNULL(kj::mv(headers)), kj::mv(fetcher), kj::mv(signal),
-                 kj::mv(cf), kj::mv(body));
+                 kj::mv(cf), kj::mv(body), cacheMode);
 }
 
 jsg::Ref<Request> Request::clone(jsg::Lock& js) {
@@ -1200,6 +1229,10 @@ void Request::serialize(
     // property should probably go away in any case.
 
     .cf = cf.getRef(js),
+
+    .cache = getCacheModeName(cacheMode).map([](kj::StringPtr name) -> kj::String {
+      return kj::str(name);
+    }),
 
     // .mode is unimplemented
     // .credentials is unimplemented
@@ -1770,6 +1803,15 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(
 
   kj::HttpHeaders headers(ioContext.getHeaderTable());
   jsRequest->shallowCopyHeadersTo(headers);
+
+  // If the jsRequest has a CacheMode, we need to handle that here.
+  // Currently, the ony cache mode we support is undefined, but we will soon support
+  // no-cache and no-store. These additional modes will be hidden behind an autogate.
+  if (jsRequest->getCacheMode() != Request::CacheMode::NONE) {
+    return js.rejectedPromise<jsg::Ref<Response>>(
+        js.typeError(kj::str("Unsupported cache mode: ",
+            KJ_ASSERT_NONNULL(jsRequest->getCache(js)))));
+  }
 
   kj::String url = uriEncodeControlChars(
       urlList.back().toString(kj::Url::HTTP_PROXY_REQUEST).asBytes());

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1805,7 +1805,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(
   jsRequest->shallowCopyHeadersTo(headers);
 
   // If the jsRequest has a CacheMode, we need to handle that here.
-  // Currently, the ony cache mode we support is undefined, but we will soon support
+  // Currently, the only cache mode we support is undefined, but we will soon support
   // no-cache and no-store. These additional modes will be hidden behind an autogate.
   if (jsRequest->getCacheMode() != Request::CacheMode::NONE) {
     return js.rejectedPromise<jsg::Ref<Response>>(

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -912,6 +912,7 @@ public:
       // JSG_READONLY_PROTOTYPE_PROPERTY(credentials, getCredentials);
       JSG_READONLY_PROTOTYPE_PROPERTY(integrity, getIntegrity);
       JSG_READONLY_PROTOTYPE_PROPERTY(keepalive, getKeepalive);
+      JSG_READONLY_PROTOTYPE_PROPERTY(cache, getCache);
 
       JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
         constructor(input: RequestInfo<CfProperties>, init?: RequestInit<Cf>);
@@ -944,7 +945,6 @@ public:
         readonly cf?: Cf;
       });
     }
-    JSG_READONLY_PROTOTYPE_PROPERTY(cache, getCache);
   }
 
   void serialize(

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -694,9 +694,10 @@ struct RequestInitializerDict {
   jsg::WontImplement credentials;
 
   // In browsers this controls the local browser cache. For Cloudflare Workers it could control the
-  // Cloudflare edge cache. Note that this setting is different from using the `Cache-Control`
-  // header since `Cache-Control` would be forwarded to the origin.
-  jsg::Unimplemented cache;
+  // Cloudflare edge cache. While the standard defines a number of values for this property, our
+  // implementation supports only three: undefined (identifying the default caching behavior that
+  // has been implemented by the runtime), "no-store", and "no-cache".
+  jsg::Optional<kj::String> cache;
 
   // These control how the `Referer` and `Origin` headers are initialized by the browser.
   // Browser-side JavaScript is normally not permitted to set these headers, because servers
@@ -769,13 +770,21 @@ public:
   };
   static kj::Maybe<Redirect> tryParseRedirect(kj::StringPtr redirect);
 
+  enum class CacheMode {
+    // CacheMode::NONE is set when cache is undefined. It represents the dafault cache
+    // mode that workers has supported.
+    NONE,
+    NOSTORE,
+    NOCACHE,
+  };
+
   Request(kj::HttpMethod method, kj::StringPtr url, Redirect redirect,
           jsg::Ref<Headers> headers, kj::Maybe<jsg::Ref<Fetcher>> fetcher,
           kj::Maybe<jsg::Ref<AbortSignal>> signal, CfProperty&& cf,
-          kj::Maybe<Body::ExtractedBody> body)
+          kj::Maybe<Body::ExtractedBody> body, CacheMode cacheMode = CacheMode::NONE)
     : Body(kj::mv(body), *headers), method(method), url(kj::str(url)),
       redirect(redirect), headers(kj::mv(headers)), fetcher(kj::mv(fetcher)),
-      cf(kj::mv(cf)) {
+      cacheMode(cacheMode), cf(kj::mv(cf)) {
     KJ_IF_SOME(s, signal) {
       // If the AbortSignal will never abort, assigning it to thisSignal instead ensures
       // that the cancel machinery is not used but the request.signal accessor will still
@@ -870,15 +879,8 @@ public:
   // TODO(conform): Won't implement?
 
   // The cache mode determines how HTTP cache is used with the request.
-  // We currently do not fully implement this. Currently we will explicitly
-  // throw in the Request constructor if the option is set. For the accessor
-  // we want it to always just return undefined while it is not implemented.
-  // The spec does not provide a value to indicate "unimplemented" and all
-  // of the other values would imply semantics we do not follow. In discussion
-  // with other implementers with the same issues, it was decided that
-  // simply returning undefined for these was the best option.
-  // jsg::JsValue getCache(jsg::Lock& js) { return js.v8Undefined(); }
-  // TODO(conform): Won't implement?
+  jsg::Optional<kj::StringPtr> getCache(jsg::Lock& js);
+  CacheMode getCacheMode();
 
   // We do not implement integrity checking at all. However, the spec says that
   // the default value should be an empty string. When the Request object is
@@ -908,7 +910,6 @@ public:
       // JSG_READONLY_PROTOTYPE_PROPERTY(duplex, getDuplex);
       // JSG_READONLY_PROTOTYPE_PROPERTY(mode, getMode);
       // JSG_READONLY_PROTOTYPE_PROPERTY(credentials, getCredentials);
-      // JSG_READONLY_PROTOTYPE_PROPERTY(cache, getCache);
       JSG_READONLY_PROTOTYPE_PROPERTY(integrity, getIntegrity);
       JSG_READONLY_PROTOTYPE_PROPERTY(keepalive, getKeepalive);
 
@@ -934,7 +935,6 @@ public:
       // JSG_READONLY_INSTANCE_PROPERTY(duplex, getDuplex);
       // JSG_READONLY_INSTANCE_PROPERTY(mode, getMode);
       // JSG_READONLY_INSTANCE_PROPERTY(credentials, getCredentials);
-      // JSG_READONLY_INSTANCE_PROPERTY(cache, getCache);
       JSG_READONLY_INSTANCE_PROPERTY(integrity, getIntegrity);
       JSG_READONLY_INSTANCE_PROPERTY(keepalive, getKeepalive);
 
@@ -944,6 +944,7 @@ public:
         readonly cf?: Cf;
       });
     }
+    JSG_READONLY_PROTOTYPE_PROPERTY(cache, getCache);
   }
 
   void serialize(
@@ -971,6 +972,8 @@ private:
   jsg::Ref<Headers> headers;
   kj::Maybe<jsg::Ref<Fetcher>> fetcher;
   kj::Maybe<jsg::Ref<AbortSignal>> signal;
+
+  CacheMode cacheMode = CacheMode::NONE;
 
   // The fetch spec definition of Request has a distinction between the "signal" (which is
   // an optional AbortSignal passed in with the options), and "this' signal", which is an

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -504,4 +504,10 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatDisableFlag("legacy_module_registry")
       $experimental;
   # Enables of the new module registry implementation.
+
+  cacheHeaderEnabled @53 :Bool
+    $compatEnableFlag("cache_header_enabled")
+    $compatDisableFlag("cache_header_disabled")
+    $experimental;
+  # Enables the use of no-cache and no-store headers from requests
 }

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -505,9 +505,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $experimental;
   # Enables of the new module registry implementation.
 
-  cacheHeaderEnabled @53 :Bool
-    $compatEnableFlag("cache_header_enabled")
-    $compatDisableFlag("cache_header_disabled")
+  cacheOptionEnabled @53 :Bool
+    $compatEnableFlag("cache_option_enabled")
+    $compatDisableFlag("cache_option_disabled")
     $experimental;
   # Enables the use of no-cache and no-store headers from requests
 }


### PR DESCRIPTION
RM-18292

Updates the Request object to support specifying a cache mode per the standard. Only undefined, 'no-store' and 'no-cache' may be specified, and the fetch implementation specifically does not implement the semantics for either 'no-store' or 'no-cache' yet. 
Also adds the compatibility flag for `cacheHeaderEnabled`. This just lays the ground work for the additional changes.

The next step is to start adding the support for adding the appropriate header fields in the fetch implementation behind an autogate.