### PR TITLE
Refactor: split ArtifactBundler into three separate classes

### DIFF
--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -1,7 +1,7 @@
 import { default as MetadataReader } from "pyodide-internal:runtime-generated/metadata";
 export { default as LOCKFILE } from "pyodide-internal:generated/pyodide-lock.json";
 import { default as PYODIDE_BUCKET } from "pyodide-internal:generated/pyodide-bucket.json";
-import { default as ArtifactBundler } from "pyodide-internal:artifacts";
+import { default as Artifacts } from "pyodide-internal:artifacts";
 
 export const IS_WORKERD = MetadataReader.isWorkerd();
 export const IS_TRACING = MetadataReader.isTracing();
@@ -11,8 +11,4 @@ export const IS_CREATING_BASELINE_SNAPSHOT =
 export const WORKERD_INDEX_URL = PYODIDE_BUCKET.PYODIDE_PACKAGE_BUCKET_URL;
 export const REQUIREMENTS = MetadataReader.getRequirements();
 export const MAIN_MODULE_NAME = MetadataReader.getMainModule();
-export const MEMORY_SNAPSHOT_READER = MetadataReader.hasMemorySnapshot()
-  ? MetadataReader
-  : ArtifactBundler.hasMemorySnapshot()
-    ? ArtifactBundler
-    : undefined;
+export const MEMORY_SNAPSHOT_READER = MetadataReader.hasMemorySnapshot()  ? MetadataReader : Artifacts.snapshotDownloader;

--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -1,4 +1,4 @@
-import { default as ArtifactBundler } from "pyodide-internal:artifacts";
+import { default as Artifacts } from "pyodide-internal:artifacts";
 import { default as UnsafeEval } from "internal:unsafe-eval";
 import { default as DiskCache } from "pyodide-internal:disk_cache";
 import {
@@ -25,9 +25,9 @@ let LOADED_BASELINE_SNAPSHOT: number;
  */
 
 const TOP_LEVEL_SNAPSHOT =
-  ArtifactBundler.isEwValidating() || SHOULD_SNAPSHOT_TO_DISK;
+  !!Artifacts.validatorSnapshotUploader || SHOULD_SNAPSHOT_TO_DISK;
 const SHOULD_UPLOAD_SNAPSHOT =
-  ArtifactBundler.isEnabled() || TOP_LEVEL_SNAPSHOT;
+  !!Artifacts.runtimeSnapshotUploader || TOP_LEVEL_SNAPSHOT;
 
 /**
  * Global variable for the memory snapshot. On the first run we stick a copy of
@@ -306,7 +306,7 @@ function setUploadFunction(toUpload: Uint8Array): void {
   }
   DEFERRED_UPLOAD_FUNCTION = async () => {
     try {
-      const success = await ArtifactBundler.uploadMemorySnapshot(toUpload);
+      const success = await Artifacts.runtimeSnapshotUploader!.uploadMemorySnapshot(toUpload);
       // Free memory
       // @ts-ignore
       toUpload = undefined;
@@ -446,8 +446,8 @@ export function finishSnapshotSetup(pyodide: Pyodide): void {
 }
 
 export function maybeStoreMemorySnapshot() {
-  if (ArtifactBundler.isEwValidating()) {
-    ArtifactBundler.storeMemorySnapshot(getMemoryToUpload());
+  if (Artifacts.validatorSnapshotUploader) {
+    Artifacts.validatorSnapshotUploader.storeMemorySnapshot(getMemoryToUpload());
   } else if (SHOULD_SNAPSHOT_TO_DISK) {
     DiskCache.put("snapshot.bin", getMemoryToUpload());
     console.log("Saved snapshot to disk");

--- a/src/pyodide/types/artifacts.d.ts
+++ b/src/pyodide/types/artifacts.d.ts
@@ -1,15 +1,25 @@
-declare namespace ArtifactBundler {
-  const hasMemorySnapshot: () => boolean;
-  const isEwValidating: () => boolean;
-  const isEnabled: () => boolean;
-  const uploadMemorySnapshot: (toUpload: Uint8Array) => Promise<boolean>;
-  const readMemorySnapshot: (
+type ValidatorSnapshotUploader = {
+  storeMemorySnapshot: (snap: Uint8Array) => void;
+};
+
+type RuntimeSnapshotUploader = {
+  uploadMemorySnapshot: (snap: Uint8Array) => boolean;
+};
+
+type SnapshotDownloader = {
+  getMemorySnapshotSize: () => number;
+  disposeMemorySnapshot: () => void;
+  readMemorySnapshot: (
     offset: number,
     buf: Uint32Array | Uint8Array,
   ) => void;
-  const getMemorySnapshotSize: () => number;
-  const disposeMemorySnapshot: () => void;
-  const storeMemorySnapshot: (snap: Uint8Array) => void;
+};
+
+declare namespace Artifacts {
+  const validatorSnapshotUploader: ValidatorSnapshotUploader | undefined;
+  const runtimeSnapshotUploader: RuntimeSnapshotUploader | undefined;
+  const snapshotDownloader: SnapshotDownloader | undefined;
 }
 
-export default ArtifactBundler;
+export default Artifacts;
+

--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -63,11 +63,11 @@ int PyodideMetadataReader::readMemorySnapshot(int offset, kj::Array<kj::byte> bu
   return readToTarget(KJ_REQUIRE_NONNULL(memorySnapshot), offset, buf);
 }
 
-int ArtifactBundler::readMemorySnapshot(int offset, kj::Array<kj::byte> buf) {
-  if (existingSnapshot == kj::none) {
+int SnapshotDownloader::readMemorySnapshot(int offset, kj::Array<kj::byte> buf) {
+  if (snapshot == kj::none) {
     return 0;
   }
-  return readToTarget(KJ_REQUIRE_NONNULL(existingSnapshot), offset, buf);
+  return readToTarget(KJ_REQUIRE_NONNULL(snapshot), offset, buf);
 }
 
 jsg::Ref<PyodideMetadataReader> makePyodideMetadataReader(Worker::Reader conf, const PythonConfig& pythonConfig) {

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -474,20 +474,20 @@ void WorkerdApi::compileModules(
             jsg::ModuleRegistry::Type::INTERNAL);
       }
       // Inject artifact bundler.
-      {
-        using ModuleInfo = jsg::ModuleRegistry::ModuleInfo;
-        using ObjectModuleInfo = jsg::ModuleRegistry::ObjectModuleInfo;
-        using ResolveMethod = jsg::ModuleRegistry::ResolveMethod;
-        auto specifier = "pyodide-internal:artifacts";
-        modules->addBuiltinModule(specifier,
-            [specifier = kj::str(specifier)](
-                jsg::Lock& js, ResolveMethod, kj::Maybe<const kj::Path&>&) mutable {
-          auto& wrapper = JsgWorkerdIsolate_TypeWrapper::from(js.v8Isolate);
-          auto wrap = wrapper.wrap(js.v8Context(), kj::none, ArtifactBundler::makeDisabledBundler());
-          return kj::Maybe(ModuleInfo(js, specifier, kj::none, ObjectModuleInfo(js, wrap)));
-        },
-            jsg::ModuleRegistry::Type::INTERNAL);
-      }
+      // {
+      //   using ModuleInfo = jsg::ModuleRegistry::ModuleInfo;
+      //   using ObjectModuleInfo = jsg::ModuleRegistry::ObjectModuleInfo;
+      //   using ResolveMethod = jsg::ModuleRegistry::ResolveMethod;
+      //   auto specifier = "pyodide-internal:artifacts";
+      //   modules->addBuiltinModule(specifier,
+      //       [specifier = kj::str(specifier)](
+      //           jsg::Lock& js, ResolveMethod, kj::Maybe<const kj::Path&>&) mutable {
+      //     auto& wrapper = JsgWorkerdIsolate_TypeWrapper::from(js.v8Isolate);
+      //     auto wrap = wrapper.wrap(js.v8Context(), kj::none, Artifacts::disabled());
+      //     return kj::Maybe(ModuleInfo(js, specifier, kj::none, ObjectModuleInfo(js, wrap)));
+      //   },
+      //       jsg::ModuleRegistry::Type::INTERNAL);
+      // }
 
       // Inject jaeger internal tracer in a disabled state (we don't have a use for it in workerd)
       {
@@ -915,13 +915,13 @@ kj::Own<jsg::modules::ModuleRegistry> WorkerdApi::initializeBundleModuleRegistry
       return metadataReader.addRef();
     }));
     // Inject artifact bundler.
-    pyodideBundleBuilder.addSynthetic(artifactsSpecifier,
-        jsg::modules::Module::newJsgObjectModuleHandler<
-            ArtifactBundler,
-            JsgWorkerdIsolate_TypeWrapper>([](jsg::Lock& js) mutable
-                -> jsg::Ref<ArtifactBundler> {
-      return ArtifactBundler::makeDisabledBundler();
-    }));
+    // pyodideBundleBuilder.addSynthetic(artifactsSpecifier,
+    //     jsg::modules::Module::newJsgObjectModuleHandler<
+    //         Artifacts,
+    //         JsgWorkerdIsolate_TypeWrapper>([](jsg::Lock& js) mutable
+    //             -> Artifacts {
+    //   return Artifacts::disabled();
+    // }));
     // Inject jaeger internal tracer in a disabled state (we don't have a use for it in workerd)
     pyodideBundleBuilder.addSynthetic(internalJaegerSpecifier,
         jsg::modules::Module::newJsgObjectModuleHandler<


### PR DESCRIPTION
And put them into a new struct called PyodideArtifacts. This is intended to help with the work toward loading the Python runtime from GCS. But also these three classes have unrelated state.