### PR TITLE
Log complete alarm errors in global-scope

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -473,7 +473,9 @@ kj::Promise<WorkerInterface::AlarmResult> ServiceWorkerGlobalScope::runAlarm(
           && context.isOutputGateBroken()) {
         LOG_NOSENTRY(ERROR, "output lock broke during alarm execution", actorId, e);
       } else if (context.isOutputGateBroken()) {
-        LOG_NOSENTRY(ERROR, "output lock broke during alarm execution without an erro description", actorId);
+        // We don't usually log these messages, but it's useful to know the real reason we failed
+        // to correctly investigate stuck alarms.
+        LOG_NOSENTRY(ERROR, "output lock broke during alarm execution without an interesting error description", actorId, e);
       }
       return WorkerInterface::AlarmResult {
         .retry = true,
@@ -503,7 +505,9 @@ kj::Promise<WorkerInterface::AlarmResult> ServiceWorkerGlobalScope::runAlarm(
             LOG_NOSENTRY(ERROR, "output lock broke after executing alarm", actorId, e);
           }
         } else {
-          LOG_NOSENTRY(ERROR, "output lock broke after executing alarm without an error description", actorId);
+        // We don't usually log these messages, but it's useful to know the real reason we failed
+        // to correctly investigate stuck alarms.
+          LOG_NOSENTRY(ERROR, "output lock broke after executing alarm without an interesting error description", actorId, e);
         }
         return WorkerInterface::AlarmResult {
           .retry = true,


### PR DESCRIPTION
Even if we usually don't feel like it's worth logging this message, let's log it temporarily to help investigate alarm failures