### PR TITLE
[types] Add missing `reply` fn to `ForwardableEmailMessage`

### DIFF
--- a/types/defines/email.d.ts
+++ b/types/defines/email.d.ts
@@ -41,6 +41,12 @@ interface ForwardableEmailMessage extends EmailMessage {
    * @returns A promise that resolves when the email message is forwarded.
    */
   forward(rcptTo: string, headers?: Headers): Promise<void>;
+  /**
+   * Reply to the sender of this email message with a new EmailMessage object.
+   * @param message The reply message.
+   * @returns A promise that resolves when the email message is replied.
+   */
+  reply(message: EmailMessage): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
The `ForwardableEmailMessage` interface should expose a `reply` function, but it currently doesn't.This commit adds the missing function to the interface definition.

Please refer to https://developers.cloudflare.com/email-routing/email-workers/runtime-api/#emailmessage-definition

Fixes #2283