### PR TITLE
types: Fix D1 run() type

### DIFF
--- a/types/defines/d1.d.ts
+++ b/types/defines/d1.d.ts
@@ -34,7 +34,7 @@ declare abstract class D1PreparedStatement {
   bind(...values: unknown[]): D1PreparedStatement;
   first<T = unknown>(colName: string): Promise<T | null>;
   first<T = Record<string, unknown>>(): Promise<T | null>;
-  run(): Promise<D1Response>;
+  run<T = Record<string, unknown>>(): Promise<D1Result<T>>;
   all<T = Record<string, unknown>>(): Promise<D1Result<T>>;
   raw<T = unknown[]>(options: {columnNames: true}): Promise<[string[], ...T[]]>;
   raw<T = unknown[]>(options?: {columnNames?: false}): Promise<T[]>;

--- a/types/test/types/d1.ts
+++ b/types/test/types/d1.ts
@@ -16,7 +16,7 @@ export const handler: ExportedHandler<{ DB: D1Database }> = {
       expectType<{
         meta: Record<string, unknown>;
         success: boolean;
-        results?: never;
+        results?: any;
       }>(response);
     }
 


### PR DESCRIPTION
This is out of sync with prod, which is does accept a type parameter and returns a `D1Result`

cc @vy-ton @geelen 