### PR TITLE
Check exception type to set retryCountsAgainstLimit for alarms

### DIFF
--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -243,6 +243,9 @@ void ActorCache::evictOrOomIfNeeded(Lock& lock) {
     // Add trace info sufficient to tell us which operation caused the failure.
     exception.addTraceHere();
     exception.addTrace(__builtin_return_address(0));
+    // We know this exeption happens due to user error. Let's add an exception detail so we can
+    // parse it later.
+    exception.setDetail(jsg::EXCEPTION_IS_USER_ERROR, kj::heapArray<byte>(0));
 
     if (maybeTerminalException == kj::none) {
       maybeTerminalException.emplace(kj::cp(exception));

--- a/src/workerd/jsg/exception.h
+++ b/src/workerd/jsg/exception.h
@@ -146,4 +146,6 @@ TunneledErrorType tunneledErrorType(kj::StringPtr internalMessage);
 // Annotate an internal message with the corresponding brokenness reason.
 kj::String annotateBroken(kj::StringPtr internalMessage, kj::StringPtr brokennessReason);
 
+constexpr kj::Exception::DetailTypeId EXCEPTION_IS_USER_ERROR = 0x82aff7d637c30e47ull;
+
 }  // namespace workerd::jsg


### PR DESCRIPTION
If an exception is of type OVERLOADED we set `retryCountsAgainstLimites = true` for alarms. 