### PR TITLE
Gate prototypes behind compatability flag for cache: no-store

### DIFF
--- a/src/workerd/api/http-test.wd-test
+++ b/src/workerd/api/http-test.wd-test
@@ -8,11 +8,24 @@ const unitTests :Workerd.Config = (
           ( name = "worker", esModule = embed "http-test.js" )
         ],
         bindings = [
-          ( name = "SERVICE", service = "http-test" )
+          ( name = "SERVICE", service = "http-test" ),
+          ( name = "cacheEnabled", text = "false" ),
+        ],
+        compatibilityDate = "2023-08-01",
+        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "cache_option_disabled"],
+      )
+    ),
+    ( name = "http-test-cache-option-enabled",
+      worker = (
+        modules = [
+          ( name = "worker-cache-enabled", esModule = embed "http-test.js" )
+        ],
+        bindings = [
+          ( name = "SERVICE", service = "http-test-cache-option-enabled" ),
+          ( name = "cacheEnabled", text = "true" ),
         ],
         compatibilityDate = "2023-08-01",
         compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "cache_option_enabled"],
-      )
-    ),
+    ))
   ],
 );

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1076,9 +1076,10 @@ jsg::Ref<Request> Request::constructor(
         }
 
         KJ_IF_SOME(c, initDict.cache) {
+          const bool flagsHelp = (c == "no-store" || c == "no-cache");
           JSG_REQUIRE(FeatureFlags::get(js).getCacheOptionEnabled(), TypeError, kj::str(
             "Unsupported cache mode: ", c,
-            "\nYou may need to enable the cache_option_enabled compatability flag."));
+            flagsHelp ? "\nYou may need to enable the cache_option_enabled compatibility flag." : ""));
           cacheMode = getCacheModeFromName(c);
         }
 

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -912,7 +912,9 @@ public:
       // JSG_READONLY_PROTOTYPE_PROPERTY(credentials, getCredentials);
       JSG_READONLY_PROTOTYPE_PROPERTY(integrity, getIntegrity);
       JSG_READONLY_PROTOTYPE_PROPERTY(keepalive, getKeepalive);
-      JSG_READONLY_PROTOTYPE_PROPERTY(cache, getCache);
+      if(flags.getCacheOptionEnabled()) {
+        JSG_READONLY_PROTOTYPE_PROPERTY(cache, getCache);
+      }
 
       JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
         constructor(input: RequestInfo<CfProperties>, init?: RequestInit<Cf>);


### PR DESCRIPTION
Small bug fix, where prototype for `cache` was not gated behind the compatibility flag in #2409.