### PR TITLE
[do not merge] Load Pyodide runtime through HTTP

### DIFF
--- a/src/workerd/api/modules.h
+++ b/src/workerd/api/modules.h
@@ -20,7 +20,9 @@ namespace workerd::api {
 template <class Registry>
 void registerModules(Registry& registry, auto featureFlags) {
   node::registerNodeJsCompatModules(registry, featureFlags);
-  pyodide::registerPyodideModules(registry, featureFlags);
+  if (featureFlags.getPythonWorkers()) {
+    pyodide::registerPyodideModules(registry, featureFlags);
+  }
   registerUnsafeModules(registry, featureFlags);
   if (featureFlags.getRttiApi()) {
     registerRTTIModule(registry);
@@ -43,11 +45,6 @@ void registerBuiltinModules(jsg::modules::ModuleRegistry::Builder& builder, auto
   builder.add(getInternalUnsafeModuleBundle<TypeWrapper>(featureFlags));
   if (featureFlags.getUnsafeModule()) {
     builder.add(getExternalUnsafeModuleBundle<TypeWrapper>(featureFlags));
-  }
-
-  if (featureFlags.getPythonWorkers()) {
-    builder.add(pyodide::getExternalPyodideModuleBundle(featureFlags));
-    builder.add(pyodide::getInternalPyodideModuleBundle(featureFlags));
   }
 
   if (featureFlags.getRttiApi()) {

--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -7,6 +7,17 @@
 
 namespace workerd::api::pyodide {
 
+kj::Maybe<kj::Array<unsigned char>> pyodideBundleDataGlobal = kj::none;
+kj::Maybe<kj::Own<capnp::FlatArrayMessageReader>> pyodideBundleReaderGlobal = kj::none;
+kj::Maybe<jsg::Bundle::Reader> pyodideBundleGlobal = kj::none;
+
+void setPyodideBundleData(kj::Array<unsigned char> data) {
+  pyodideBundleReaderGlobal = kj::heap<capnp::FlatArrayMessageReader>(kj::arrayPtr(
+        reinterpret_cast<const capnp::word*>(data.begin()), data.size() / sizeof(capnp::word)));
+  pyodideBundleGlobal = KJ_REQUIRE_NONNULL(pyodideBundleReaderGlobal)->getRoot<jsg::Bundle>();
+  pyodideBundleDataGlobal = kj::mv(data);
+}
+
 static int readToTarget(kj::ArrayPtr<const kj::byte> source, int offset, kj::ArrayPtr<kj::byte> buf) {
   int size = source.size();
   if (offset >= size || offset < 0) {

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -11,8 +11,15 @@
 #include <workerd/jsg/url.h>
 #include <workerd/server/workerd.capnp.h>
 #include <workerd/io/io-context.h>
+#include "capnp/serialize.h"
 
 namespace workerd::api::pyodide {
+
+// singleton that owns bundle
+extern kj::Maybe<jsg::Bundle::Reader> pyodideBundleGlobal;
+
+void setPyodideBundleData(kj::Array<unsigned char> data);
+
 
 struct PythonConfig {
   kj::Maybe<kj::Own<const kj::Directory>> diskCacheRoot;
@@ -344,26 +351,7 @@ bool hasPythonModules(capnp::List<server::config::Worker::Module>::Reader module
   api::pyodide::SimplePythonLimiter
 
 template <class Registry> void registerPyodideModules(Registry& registry, auto featureFlags) {
-  if (featureFlags.getPythonWorkers()) {
-    // We add `pyodide:` packages here including python-entrypoint-helper.js.
-    registry.addBuiltinBundle(PYODIDE_BUNDLE, kj::none);
-    registry.template addBuiltinModule<PackagesTarReader>(
-        "pyodide-internal:packages_tar_reader", workerd::jsg::ModuleRegistry::Type::INTERNAL);
-  }
+  registry.template addBuiltinModule<PackagesTarReader>(
+      "pyodide-internal:packages_tar_reader", workerd::jsg::ModuleRegistry::Type::INTERNAL);
 }
-
-kj::Own<jsg::modules::ModuleBundle> getInternalPyodideModuleBundle(auto featureFlags) {
-  jsg::modules::ModuleBundle::BuiltinBuilder builder(
-      jsg::modules::ModuleBundle::BuiltinBuilder::Type::BUILTIN_ONLY);
-  jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(builder, PYODIDE_BUNDLE);
-  return builder.finish();
-}
-
-kj::Own<jsg::modules::ModuleBundle> getExternalPyodideModuleBundle(auto featureFlags) {
-  jsg::modules::ModuleBundle::BuiltinBuilder builder(
-      jsg::modules::ModuleBundle::BuiltinBuilder::Type::BUILTIN);
-  jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(builder, PYODIDE_BUNDLE);
-  return builder.finish();
-}
-
 } // namespace workerd::api::pyodide

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -33,6 +33,7 @@
 #include <workerd/util/use-perfetto-categories.h>
 #include <workerd/api/worker-rpc.h>
 #include "workerd-api.h"
+#include "workerd/api/pyodide/pyodide.h"
 #include "workerd/io/hibernation-manager.h"
 #include <stdlib.h>
 
@@ -2565,6 +2566,36 @@ void Server::abortAllActors() {
   }
 }
 
+void Server::fetchPyodideBundle() {
+  {
+    kj::Thread([] () {
+      kj::AsyncIoContext io = kj::setupAsyncIo();
+      kj::HttpHeaderTable table;
+
+      kj::TlsContext::Options options;
+      options.useSystemTrustStore = true;
+
+      kj::Own<kj::TlsContext> tls = kj::heap<kj::TlsContext>(kj::mv(options));
+      auto &network = io.provider->getNetwork();
+      auto tlsNetwork = tls->wrapNetwork(network);
+      auto &timer = io.provider->getTimer();
+
+      auto client = kj::newHttpClient(timer, table, network, *tlsNetwork);
+
+      kj::HttpHeaders headers(table);
+
+      auto req = client->request(kj::HttpMethod::GET, "https://storage.googleapis.com/cloudflare-edgeworker-python-packages/python-runtime-capnp-bin/pyodide-1.capnp.bin", headers);
+
+      auto res = req.response.wait(io.waitScope);
+      auto body = res.body->readAllBytes().wait(io.waitScope);
+
+      api::pyodide::setPyodideBundleData(kj::mv(body));
+
+    });
+  }
+
+}
+
 kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::Reader conf,
     capnp::List<config::Extension>::Reader extensions) {
   TRACE_EVENT("workerd", "Server::makeWorker()", "name", name.cStr());
@@ -2687,6 +2718,10 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
     newModuleRegistry = WorkerdApi::initializeBundleModuleRegistry(
         *observer, conf, featureFlags.asReader(), pythonConfig);
   }
+
+  // Get the pyodide bundle and register it in memory.
+  // After this, the pyodide bundle is accessible at pyodideBundleGlobal
+  fetchPyodideBundle();
 
   auto api = kj::heap<WorkerdApi>(globalContext->v8System,
                                   featureFlags.asReader(),

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -227,6 +227,8 @@ private:
                                     kj::HttpHeaderTable::Builder& headerTableBuilder,
                                     kj::ForkedPromise<void>& forkedDrainWhen,
                                     bool forTest = false);
+
+  void fetchPyodideBundle();
 };
 
 // An ActorStorage implementation which will always respond to reads as if the state is empty,

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -446,7 +446,9 @@ void WorkerdApi::compileModules(
     if (hasPythonModules(confModules)) {
       KJ_REQUIRE(featureFlags.getPythonWorkers(),
           "The python_workers compatibility flag is required to use Python.");
-      // Inject pyodide bootstrap module.
+      // Inject Pyodide bundle
+      modules->addBuiltinBundle(PYODIDE_BUNDLE, kj::none);
+      // Inject pyodide bootstrap module (TODO: load this from the capnproto bundle?)
       {
         auto mainModule = confModules.begin();
         capnp::MallocMessageBuilder message;

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -43,6 +43,7 @@
 #include <openssl/sha.h>
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
+#include <kj/compat/http.h>
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
 #include <workerd/api/gpu/gpu.h>
 #else
@@ -447,7 +448,7 @@ void WorkerdApi::compileModules(
       KJ_REQUIRE(featureFlags.getPythonWorkers(),
           "The python_workers compatibility flag is required to use Python.");
       // Inject Pyodide bundle
-      modules->addBuiltinBundle(PYODIDE_BUNDLE, kj::none);
+      modules->addBuiltinBundle(KJ_ASSERT_NONNULL(pyodideBundleGlobal), kj::none);
       // Inject pyodide bootstrap module (TODO: load this from the capnproto bundle?)
       {
         auto mainModule = confModules.begin();


### PR DESCRIPTION
This loads the Pyodide bundle through HTTP. It does this in a synchronous way, by creating a new kj::Thread and immediately disowning it, causing the current thread to be blocked on the completion of the new thread. 

Do not merge this yet. It takes up to 15s to load the Pyodide bundle, and this is not acceptable to run in CI. To do that, we need to:
1. Configure Bazel to populate the disk cache with a Pyodide bundle
2. Add code to fetchPyodideBundle() to use the disk cache, preventing the fetch in most cases. 