### PR TITLE
[build] Simplify V8 build configuration, minor build updates

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -61,11 +61,6 @@ build:v8-codegen-opt --per_file_copt=v8/src/objects@-O2
 build:v8-codegen-opt --per_file_copt=v8/src/wasm@-O2
 build:v8-codegen-opt --per_file_copt=v8/src/base@-O2
 
-# Enable C++20 to support std::unordered_map::contains(). Not sure why this is needed here, V8
-# is supposed to work with C++14.
-build:unix --per_file_copt='external/v8/src/compiler/graph-visualizer.cc@-std=c++20'
-build:windows --per_file_copt='external/v8/src/compiler/graph-visualizer.cc@/std:c++20'
-
 # Need to redefine _WIN32_WINNT to build dawn on Windows
 build:windows --per_file_copt='external/dawn@-Wno-macro-redefined'
 build:windows --host_per_file_copt='external/dawn@-Wno-macro-redefined'

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,8 +23,8 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "build_bazel_apple_support",
-    sha256 = "c4bb2b7367c484382300aee75be598b92f847896fb31bbd22f3a2346adf66a80",
-    url = "https://github.com/bazelbuild/apple_support/releases/download/1.15.1/apple_support.1.15.1.tar.gz",
+    sha256 = "c31ce8e531b50ef1338392ee29dd3db3689668701ec3237b9c61e26a1937ab07",
+    url = "https://github.com/bazelbuild/apple_support/releases/download/1.16.0/apple_support.1.16.0.tar.gz",
 )
 
 load(
@@ -33,6 +33,11 @@ load(
 )
 
 apple_support_dependencies()
+
+# apple_support now requires bazel_features, pull in its dependencies too.
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
 
 # ========================================================================================
 # Simple dependencies
@@ -253,10 +258,10 @@ rules_fuzzing_init()
 # OK, now we can bring in tcmalloc itself.
 http_archive(
     name = "com_google_tcmalloc",
-    sha256 = "1003d34b60c337e2d4168a55da6b3658e74b944e5ace46136fd7ba5e32c4d544",
-    strip_prefix = "google-tcmalloc-d67d394",
+    sha256 = "81f285cb337f445276f37c308cb90120f8ba4311d1be9daf3b93dccf4bfdba7d",
+    strip_prefix = "google-tcmalloc-69c409c",
     type = "tgz",
-    url = "https://github.com/google/tcmalloc/tarball/d67d3949c45ae9b4017db8b1c61fdf37a3b0d645",
+    url = "https://github.com/google/tcmalloc/tarball/69c409c344bdf894fc7aab83e2d9e280b009b2f3",
 )
 
 # ========================================================================================

--- a/rust-deps/crates/BUILD.cc-1.1.6.bazel
+++ b/rust-deps/crates/BUILD.cc-1.1.6.bazel
@@ -6,12 +6,12 @@
 #     bazel run @//rust-deps:crates_vendor
 ###############################################################################
 
-load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
+load("@rules_rust//rust:defs.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_proc_macro(
-    name = "thiserror_impl",
+rust_library(
+    name = "cc",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -29,21 +29,16 @@ rust_proc_macro(
         ],
     ),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=thiserror-impl",
+        "crate-name=cc",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.62",
-    deps = [
-        "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
-        "@crates_vendor__quote-1.0.36//:quote",
-        "@crates_vendor__syn-2.0.71//:syn",
-    ],
+    version = "1.1.6",
 )

--- a/rust-deps/crates/BUILD.cssparser-macros-0.6.1.bazel
+++ b/rust-deps/crates/BUILD.cssparser-macros-0.6.1.bazel
@@ -43,6 +43,6 @@ rust_proc_macro(
     version = "0.6.1",
     deps = [
         "@crates_vendor__quote-1.0.36//:quote",
-        "@crates_vendor__syn-2.0.71//:syn",
+        "@crates_vendor__syn-2.0.72//:syn",
     ],
 )

--- a/rust-deps/crates/BUILD.derive_more-0.99.18.bazel
+++ b/rust-deps/crates/BUILD.derive_more-0.99.18.bazel
@@ -73,6 +73,6 @@ rust_proc_macro(
         "@crates_vendor__convert_case-0.4.0//:convert_case",
         "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
         "@crates_vendor__quote-1.0.36//:quote",
-        "@crates_vendor__syn-2.0.71//:syn",
+        "@crates_vendor__syn-2.0.72//:syn",
     ],
 )

--- a/rust-deps/crates/BUILD.lol_html-1.2.1.bazel
+++ b/rust-deps/crates/BUILD.lol_html-1.2.1.bazel
@@ -52,6 +52,6 @@ rust_library(
         "@crates_vendor__memchr-2.7.4//:memchr",
         "@crates_vendor__mime-0.3.17//:mime",
         "@crates_vendor__selectors-0.22.0//:selectors",
-        "@crates_vendor__thiserror-1.0.62//:thiserror",
+        "@crates_vendor__thiserror-1.0.63//:thiserror",
     ],
 )

--- a/rust-deps/crates/BUILD.lolhtml-1.1.1.bazel
+++ b/rust-deps/crates/BUILD.lolhtml-1.1.1.bazel
@@ -45,6 +45,6 @@ rust_library(
         "@crates_vendor__encoding_rs-0.8.34//:encoding_rs",
         "@crates_vendor__libc-0.2.155//:libc",
         "@crates_vendor__lol_html-1.2.1//:lol_html",
-        "@crates_vendor__thiserror-1.0.62//:thiserror",
+        "@crates_vendor__thiserror-1.0.63//:thiserror",
     ],
 )

--- a/rust-deps/crates/BUILD.serde_derive-1.0.204.bazel
+++ b/rust-deps/crates/BUILD.serde_derive-1.0.204.bazel
@@ -47,6 +47,6 @@ rust_proc_macro(
     deps = [
         "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
         "@crates_vendor__quote-1.0.36//:quote",
-        "@crates_vendor__syn-2.0.71//:syn",
+        "@crates_vendor__syn-2.0.72//:syn",
     ],
 )

--- a/rust-deps/crates/BUILD.syn-2.0.72.bazel
+++ b/rust-deps/crates/BUILD.syn-2.0.72.bazel
@@ -11,7 +11,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "cc",
+    name = "syn",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -28,17 +28,32 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
+    crate_features = [
+        "clone-impls",
+        "default",
+        "derive",
+        "extra-traits",
+        "full",
+        "parsing",
+        "printing",
+        "proc-macro",
+    ],
     crate_root = "src/lib.rs",
-    edition = "2018",
+    edition = "2021",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=cc",
+        "crate-name=syn",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.1.3",
+    version = "2.0.72",
+    deps = [
+        "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
+        "@crates_vendor__quote-1.0.36//:quote",
+        "@crates_vendor__unicode-ident-1.0.12//:unicode_ident",
+    ],
 )

--- a/rust-deps/crates/BUILD.thiserror-1.0.63.bazel
+++ b/rust-deps/crates/BUILD.thiserror-1.0.63.bazel
@@ -32,7 +32,7 @@ rust_library(
     crate_root = "src/lib.rs",
     edition = "2021",
     proc_macro_deps = [
-        "@crates_vendor__thiserror-impl-1.0.62//:thiserror_impl",
+        "@crates_vendor__thiserror-impl-1.0.63//:thiserror_impl",
     ],
     rustc_flags = [
         "--cap-lints=allow",
@@ -44,9 +44,9 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.62",
+    version = "1.0.63",
     deps = [
-        "@crates_vendor__thiserror-1.0.62//:build_script_build",
+        "@crates_vendor__thiserror-1.0.63//:build_script_build",
     ],
 )
 
@@ -82,7 +82,7 @@ cargo_build_script(
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.62",
+    version = "1.0.63",
     visibility = ["//visibility:private"],
 )
 

--- a/rust-deps/crates/BUILD.thiserror-impl-1.0.63.bazel
+++ b/rust-deps/crates/BUILD.thiserror-impl-1.0.63.bazel
@@ -6,12 +6,12 @@
 #     bazel run @//rust-deps:crates_vendor
 ###############################################################################
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
-    name = "syn",
+rust_proc_macro(
+    name = "thiserror_impl",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -28,16 +28,6 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "clone-impls",
-        "default",
-        "derive",
-        "extra-traits",
-        "full",
-        "parsing",
-        "printing",
-        "proc-macro",
-    ],
     crate_root = "src/lib.rs",
     edition = "2021",
     rustc_flags = [
@@ -45,15 +35,15 @@ rust_library(
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=syn",
+        "crate-name=thiserror-impl",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "2.0.71",
+    version = "1.0.63",
     deps = [
         "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
         "@crates_vendor__quote-1.0.36//:quote",
-        "@crates_vendor__unicode-ident-1.0.12//:unicode_ident",
+        "@crates_vendor__syn-2.0.72//:syn",
     ],
 )

--- a/rust-deps/crates/BUILD.zerocopy-derive-0.7.35.bazel
+++ b/rust-deps/crates/BUILD.zerocopy-derive-0.7.35.bazel
@@ -44,6 +44,6 @@ rust_proc_macro(
     deps = [
         "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
         "@crates_vendor__quote-1.0.36//:quote",
-        "@crates_vendor__syn-2.0.71//:syn",
+        "@crates_vendor__syn-2.0.72//:syn",
     ],
 )

--- a/rust-deps/crates/defs.bzl
+++ b/rust-deps/crates/defs.bzl
@@ -448,12 +448,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__cc-1.1.3",
-        sha256 = "18e2d530f35b40a84124146478cd16f34225306a8441998836466a2e2961c950",
+        name = "crates_vendor__cc-1.1.6",
+        sha256 = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/cc/1.1.3/download"],
-        strip_prefix = "cc-1.1.3",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.cc-1.1.3.bazel"),
+        urls = ["https://static.crates.io/crates/cc/1.1.6/download"],
+        strip_prefix = "cc-1.1.6",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.cc-1.1.6.bazel"),
     )
 
     maybe(
@@ -1027,12 +1027,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__syn-2.0.71",
-        sha256 = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462",
+        name = "crates_vendor__syn-2.0.72",
+        sha256 = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/syn/2.0.71/download"],
-        strip_prefix = "syn-2.0.71",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.syn-2.0.71.bazel"),
+        urls = ["https://static.crates.io/crates/syn/2.0.72/download"],
+        strip_prefix = "syn-2.0.72",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.syn-2.0.72.bazel"),
     )
 
     maybe(
@@ -1047,22 +1047,22 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__thiserror-1.0.62",
-        sha256 = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb",
+        name = "crates_vendor__thiserror-1.0.63",
+        sha256 = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/thiserror/1.0.62/download"],
-        strip_prefix = "thiserror-1.0.62",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.thiserror-1.0.62.bazel"),
+        urls = ["https://static.crates.io/crates/thiserror/1.0.63/download"],
+        strip_prefix = "thiserror-1.0.63",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.thiserror-1.0.63.bazel"),
     )
 
     maybe(
         http_archive,
-        name = "crates_vendor__thiserror-impl-1.0.62",
-        sha256 = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c",
+        name = "crates_vendor__thiserror-impl-1.0.63",
+        sha256 = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/thiserror-impl/1.0.62/download"],
-        strip_prefix = "thiserror-impl-1.0.62",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.thiserror-impl-1.0.62.bazel"),
+        urls = ["https://static.crates.io/crates/thiserror-impl/1.0.63/download"],
+        strip_prefix = "thiserror-impl-1.0.63",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.thiserror-impl-1.0.63.bazel"),
     )
 
     maybe(


### PR DESCRIPTION
- V8 defaults to C++20 as of version 12.7, drop the corresponding override.
- With https://github.com/google/tcmalloc/pull/239 being merged, updating tcmalloc has been unblocked.
- Roll rust deps, apple_support