### PR TITLE
Generate package memory snapshot for validator.

### DIFF
--- a/src/pyodide/internal/process_script_imports.py
+++ b/src/pyodide/internal/process_script_imports.py
@@ -1,6 +1,12 @@
+# This script is used to prepare a worker prior to a _package_ memory snapshot being taken.
+# All it does is walk through the imports in each of the worker's modules and attempts to import
+# them. Local imports are not possible because the worker file path is explicitly removed from the
+# module search path.
+CF_LOADED_MODULES=[]
 def _do_it():
     import ast
     from pathlib import Path
+    import sys
 
     def find_imports(source: str) -> list[str]:
         try:
@@ -23,12 +29,20 @@ def _do_it():
         for mod in find_imports(script):
             try:
                 __import__(mod)
+                CF_LOADED_MODULES.append(mod)
             except ImportError:
                 pass
 
     def process_scripts():
-        for script in Path("/session/metadata").glob("**/*.py"):
+        # Currently this script assumes that it is generating a _package_ snapshot- one that
+        # only includes non-vendored packages. Because of this we do not wish to import local
+        # modules, the easiest way to ensure they cannot be imported is to remove
+        # `/session/metadata` from the sys path.
+        worker_files_path = "/session/metadata"
+        sys.path.remove(worker_files_path)
+        for script in Path(worker_files_path).glob("**/*.py"):
             process_script(script.read_text())
+        sys.path.append(worker_files_path)
 
     process_scripts()
 

--- a/src/pyodide/types/artifacts.d.ts
+++ b/src/pyodide/types/artifacts.d.ts
@@ -1,4 +1,9 @@
 declare namespace ArtifactBundler {
+  type MemorySnapshotResult = {
+    snapshot: Uint8Array;
+    importedModulesList: Array<string>;
+  }
+
   const hasMemorySnapshot: () => boolean;
   const isEwValidating: () => boolean;
   const isEnabled: () => boolean;
@@ -9,7 +14,7 @@ declare namespace ArtifactBundler {
   ) => void;
   const getMemorySnapshotSize: () => number;
   const disposeMemorySnapshot: () => void;
-  const storeMemorySnapshot: (snap: Uint8Array) => void;
+  const storeMemorySnapshot: (snap: MemorySnapshotResult) => void;
 }
 
 export default ArtifactBundler;


### PR DESCRIPTION
Modifies memory snapshot generation to generate a _package_ snapshot- one that only includes imports of modules that are not present in the user's worker bundle.

Reuses the existing AST walker to collect the import names and pushes them out to the validator.

Tested upstream.