### PR TITLE
remove unnecessary initialization of buffer

### DIFF
--- a/src/node/internal/crypto_hash.ts
+++ b/src/node/internal/crypto_hash.ts
@@ -241,8 +241,7 @@ Hmac.prototype.update = Hash.prototype.update;
 Hmac.prototype.digest = function(this: Hmac, outputEncoding?: string): Buffer | string {
   const state = this[kState];
   if (state[kFinalized]) {
-    const buf = Buffer.from('');
-    return outputEncoding === 'buffer' ? buf : buf.toString(outputEncoding);
+    return !outputEncoding || outputEncoding === 'buffer' ? Buffer.from('') : '';
   }
 
   // Explicit conversion for backward compatibility.


### PR DESCRIPTION
It seems unnecessary to initialize a Buffer for non-buffer output encodings and call toString() on an empty string. If I'm not mistaken, any encoding of an empty string, returns an empty string.

The original implementation also has the same exact issue: https://github.com/nodejs/node/blob/82cf0f2f3c9e4c6f9c28cd130e91287d93200373/lib/internal/crypto/hash.js#L161

Node.js fix: https://github.com/nodejs/node/pull/54046