### PR TITLE
EW-8589 add a compat date to support custom ports for worker subrequests

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -517,4 +517,10 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Enables bypassing FL by translating pipeline tunnel configuration to subpipeline.
   # This flag is used only by the internal repo and not directly by workerd.
 
+  allowCustomPorts @55 :Bool
+      $compatEnableFlag("allow_custom_ports")
+      $experimental;
+  # Enables fetching hosts with a custom port from workers.
+  # For orange clouded sites only standard ports are allowed (https://developers.cloudflare.com/fundamentals/reference/network-ports/#network-ports-compatible-with-cloudflares-proxy).
+  # For grey clouded sites all ports are allowed.
 }


### PR DESCRIPTION
This PR enables worker subrequests to fetch hosts in any port on sites that are grey-clouded or cloudflare proxy standard ports on orange-clouded sites.