### PR TITLE
webgpu: move GPU access to external process

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -15,6 +15,8 @@ filegroup(
                 "**/*test*.c++",
                 "pyodide.c++",
                 "pyodide/pyodide.c++",
+                "gpu/voodoo/*.c++",
+                "gpu/gpu-wire-container.c++",
             ],
         ),
         "//conditions:default": glob(
@@ -26,9 +28,13 @@ filegroup(
                 "**/*test*.c++",
                 "pyodide.c++",
                 "pyodide/pyodide.c++",
+                "gpu/voodoo/*.c++",
                 "gpu/*.c++",
             ],
         ),
+    }) + select({
+        "//src/workerd/io:set_enable_experimental_webgpu_remote": ["gpu/gpu-wire-container.c++"],
+        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
 )
@@ -40,6 +46,8 @@ api_header_exclusions = [
     "modules.h",
     "rtti.h",
     "**/*test*.h",
+    "gpu/voodoo/*.h",
+    "gpu/gpu-wire-container.h",
 ]
 
 filegroup(
@@ -53,8 +61,31 @@ filegroup(
             ["**/*.h"],
             exclude = api_header_exclusions + ["gpu/*.h"],
         ),
+    }) + select({
+        "//src/workerd/io:set_enable_experimental_webgpu_remote": ["gpu/gpu-wire-container.h"],
+        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
+)
+
+wd_cc_library(
+    name = "voodoo",
+    srcs = glob(
+        ["gpu/voodoo/*.c++"],
+    ),
+    hdrs = glob(
+        ["gpu/voodoo/*.h"],
+    ),
+    target_compatible_with = select({
+        "//src/workerd/io:set_enable_experimental_webgpu": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj:kj-async",
+        "@dawn",
+        "@dawn//:dawn_wire",
+    ],
 )
 
 wd_cc_library(
@@ -145,19 +176,21 @@ wd_cc_capnp_library(
     visibility = ["//visibility:public"],
 )
 
-[kj_test(
-    src = f,
-    deps = [
-        "//src/workerd/io",
-    ],
-) for f in [
-    "actor-state-test.c++",
-    "basics-test.c++",
-    "crypto/aes-test.c++",
-    "crypto/impl-test.c++",
-    "streams/queue-test.c++",
-    "streams/standard-test.c++",
-    "util-test.c++",
+[
+    kj_test(
+        src = f,
+        deps = [
+            "//src/workerd/io",
+        ],
+    )
+    for f in [
+        "actor-state-test.c++",
+        "basics-test.c++",
+        "crypto/aes-test.c++",
+        "crypto/impl-test.c++",
+        "streams/queue-test.c++",
+        "streams/standard-test.c++",
+        "util-test.c++",
     ]
 ]
 
@@ -223,7 +256,10 @@ kj_test(
 
 wd_test(
     src = "tests/js-rpc-socket-test.wd-test",
-    args = ["--experimental", "--no-verbose"],
+    args = [
+        "--experimental",
+        "--no-verbose",
+    ],
     data = ["tests/js-rpc-test.js"],
 )
 

--- a/src/workerd/api/gpu/gpu-adapter.h
+++ b/src/workerd/api/gpu/gpu-adapter.h
@@ -9,7 +9,6 @@
 #include "gpu-supported-features.h"
 #include "gpu-supported-limits.h"
 #include "gpu-utils.h"
-#include <dawn/native/DawnNative.h>
 #include <webgpu/webgpu_cpp.h>
 #include <workerd/jsg/jsg.h>
 
@@ -17,7 +16,7 @@ namespace workerd::api::gpu {
 
 class GPUAdapter : public jsg::Object {
 public:
-  explicit GPUAdapter(dawn::native::Adapter a, kj::Own<AsyncRunner> async)
+  explicit GPUAdapter(wgpu::Adapter a, kj::Own<AsyncRunner> async)
       : adapter_(a), async_(kj::mv(async)){};
   JSG_RESOURCE_TYPE(GPUAdapter) {
     JSG_METHOD(requestDevice);
@@ -28,7 +27,7 @@ public:
 
 private:
   jsg::Promise<jsg::Ref<GPUDevice>> requestDevice(jsg::Lock&, jsg::Optional<GPUDeviceDescriptor>);
-  dawn::native::Adapter adapter_;
+  wgpu::Adapter adapter_;
   kj::Own<AsyncRunner> async_;
   jsg::Promise<jsg::Ref<GPUAdapterInfo>>
   requestAdapterInfo(jsg::Lock& js, jsg::Optional<kj::Array<kj::String>> unmaskHints);

--- a/src/workerd/api/gpu/gpu-async-runner.c++
+++ b/src/workerd/api/gpu/gpu-async-runner.c++
@@ -23,6 +23,12 @@ void AsyncRunner::End() {
   count_--;
 }
 
+void AsyncRunner::MaybeFlush() {
+  KJ_IF_SOME(flusher, flusher) {
+    flusher.Flush();
+  }
+}
+
 void AsyncRunner::QueueTick() {
   if (tick_queued_) {
     return;

--- a/src/workerd/api/gpu/gpu-buffer.c++
+++ b/src/workerd/api/gpu/gpu-buffer.c++
@@ -149,6 +149,7 @@ jsg::Promise<void> GPUBuffer::mapAsync(jsg::Lock& js, GPUFlagsConstant mode,
                      }
                    });
 
+  async_->MaybeFlush();
   return promise;
 }
 

--- a/src/workerd/api/gpu/gpu-container.h
+++ b/src/workerd/api/gpu/gpu-container.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include "gpu-async-runner.h"
+#include <webgpu/webgpu_cpp.h>
+
+namespace workerd::api::gpu {
+
+// This class will own the needed dawn objects
+// for a specific implementation and will also
+// be used to flush dawn commands.
+class DawnContainer : public Flusher {
+public:
+  virtual wgpu::Instance getInstance() = 0;
+  virtual ~DawnContainer() = default;
+};
+
+
+} // namespace workerd::api::gpu

--- a/src/workerd/api/gpu/gpu-device.h
+++ b/src/workerd/api/gpu/gpu-device.h
@@ -29,12 +29,14 @@
 namespace workerd::api::gpu {
 
 struct UncapturedErrorContext {
+  UncapturedErrorContext(IoContext& context) : context(context), target(kj::none) {};
+  IoContext& context;
   kj::Maybe<EventTarget*> target;
 };
 
 class GPUDevice : public EventTarget {
 public:
-  explicit GPUDevice(jsg::Lock& js, wgpu::Device d, kj::Own<AsyncRunner> async,
+  explicit GPUDevice(wgpu::Device d, kj::Own<AsyncRunner> async,
                      kj::Own<AsyncContext<jsg::Ref<GPUDeviceLostInfo>>> deviceLostCtx,
                      kj::Own<UncapturedErrorContext> uErrorCtx);
   ~GPUDevice();

--- a/src/workerd/api/gpu/gpu-native-container.c++
+++ b/src/workerd/api/gpu/gpu-native-container.c++
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "gpu-native-container.h"
+
+namespace workerd::api::gpu {
+
+DawnNativeContainer::DawnNativeContainer() {}
+
+wgpu::Instance DawnNativeContainer::getInstance() {
+  return instance_.Get();
+}
+
+void DawnNativeContainer::Flush() {}
+
+} // namespace workerd::api::gpu

--- a/src/workerd/api/gpu/gpu-native-container.h
+++ b/src/workerd/api/gpu/gpu-native-container.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include "gpu-container.h"
+#include <dawn/native/DawnNative.h>
+
+namespace workerd::api::gpu {
+
+class DawnNativeContainer : public DawnContainer {
+public:
+  wgpu::Instance getInstance() override;
+  void Flush() override;
+  DawnNativeContainer();
+  ~DawnNativeContainer() noexcept override {}
+
+private:
+  dawn::native::Instance instance_;
+};
+
+} // namespace workerd::api::gpu

--- a/src/workerd/api/gpu/gpu-shader-module.c++
+++ b/src/workerd/api/gpu/gpu-shader-module.c++
@@ -29,6 +29,7 @@ jsg::Promise<jsg::Ref<GPUCompilationInfo>> GPUShaderModule::getCompilationInfo(j
         ctx->fulfiller_->fulfill(jsg::alloc<GPUCompilationInfo>(kj::mv(messages)));
       });
 
+  async_->MaybeFlush();
   return promise;
 }
 

--- a/src/workerd/api/gpu/gpu-wire-container.c++
+++ b/src/workerd/api/gpu/gpu-wire-container.c++
@@ -1,0 +1,45 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "gpu-wire-container.h"
+
+namespace workerd::api::gpu {
+
+DawnWireContainer::DawnWireContainer() {
+  // serializer is configured here, optional memory transfer service
+  // is not configured at this time
+  auto& io = IoContext::current();
+  stream_ = io.getIoChannelFactory().getGPUConnection();
+  serializer_ = kj::heap<voodoo::DawnRemoteSerializer>(io.getWaitUntilTasks(), stream_);
+
+  // spawn task to handle incoming commands on stream
+  io.addTask(serializer_->handleIncomingCommands());
+
+  // create dawn wire client
+  dawn::wire::WireClientDescriptor clientDesc = {};
+  clientDesc.serializer = serializer_;
+  wireClient_ = kj::heap<dawn::wire::WireClient>(clientDesc);
+
+  serializer_->onDawnBuffer = [&](const char* data, size_t len) {
+    KJ_ASSERT(data != nullptr);
+    if (wireClient_->HandleCommands(data, len) == nullptr) {
+      KJ_LOG(ERROR, "onDawnBuffer: wireClient_->HandleCommands failed");
+    }
+    if (!serializer_->Flush()) {
+      KJ_LOG(ERROR, "serializer->Flush() failed");
+    }
+  };
+
+  instanceReservation_ = wireClient_->ReserveInstance();
+}
+
+wgpu::Instance DawnWireContainer::getInstance() {
+  return wgpu::Instance::Acquire(instanceReservation_.instance);
+}
+
+void DawnWireContainer::Flush() {
+  serializer_->Flush();
+}
+
+} // namespace workerd::api::gpu

--- a/src/workerd/api/gpu/gpu-wire-container.h
+++ b/src/workerd/api/gpu/gpu-wire-container.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include "gpu-container.h"
+#include <dawn/wire/WireClient.h>
+#include <workerd/api/gpu/voodoo/voodoo-protocol.h>
+
+namespace workerd::api::gpu {
+
+class DawnWireContainer : public DawnContainer {
+public:
+  wgpu::Instance getInstance() override;
+  void Flush() override;
+  DawnWireContainer();
+  ~DawnWireContainer() noexcept override {}
+
+private:
+  kj::Own<kj::AsyncIoStream> stream_;
+  kj::Own<voodoo::DawnRemoteSerializer> serializer_;
+  kj::Own<dawn::wire::WireClient> wireClient_;
+  dawn::wire::ReservedInstance instanceReservation_;
+};
+
+} // namespace workerd::api::gpu

--- a/src/workerd/api/gpu/gpu.h
+++ b/src/workerd/api/gpu/gpu.h
@@ -6,12 +6,14 @@
 
 #include "gpu-adapter-info.h"
 #include "gpu-adapter.h"
+#include "gpu-async-runner.h"
 #include "gpu-bindgroup-layout.h"
 #include "gpu-bindgroup.h"
 #include "gpu-command-buffer.h"
 #include "gpu-command-encoder.h"
 #include "gpu-compute-pass-encoder.h"
 #include "gpu-compute-pipeline.h"
+#include "gpu-container.h"
 #include "gpu-device.h"
 #include "gpu-errors.h"
 #include "gpu-pipeline-layout.h"
@@ -26,7 +28,6 @@
 #include "gpu-texture-view.h"
 #include "gpu-texture.h"
 #include "gpu-utils.h"
-#include <dawn/native/DawnNative.h>
 #include <webgpu/webgpu_cpp.h>
 #include <workerd/jsg/jsg.h>
 
@@ -51,7 +52,8 @@ public:
 private:
   jsg::Promise<kj::Maybe<jsg::Ref<GPUAdapter>>>
   requestAdapter(jsg::Lock&, jsg::Optional<GPURequestAdapterOptions>);
-  dawn::native::Instance instance_;
+  kj::Own<DawnContainer> dawnContainer_;
+  wgpu::Instance instance_;
   kj::Own<AsyncRunner> async_;
 };
 

--- a/src/workerd/api/gpu/voodoo/voodoo-pipe.h
+++ b/src/workerd/api/gpu/voodoo/voodoo-pipe.h
@@ -1,0 +1,193 @@
+#pragma once
+
+// based on https://github.com/rsms/dawn-wire-example/blob/main/pipe.hh
+
+#include <algorithm>
+#include <cstring>
+#include <kj/async-io.h>
+#include <kj/debug.h>
+#include <limits>
+#include <vector>
+#ifdef _WIN32
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#else
+#include <sys/types.h>
+#endif
+
+
+namespace workerd::api::gpu::voodoo {
+
+// Pipe is a circular read-write buffer.
+// It works like this:
+//
+// initial:       storage: 0 1 2 3 4 5 6 7
+// len: 0                  |
+//                        w r
+//
+// write 5 bytes: storage: 0 1 2 3 4 5 6 7
+// len: 5                  |         |
+//                         r         w
+//
+// read 2 bytes:  storage: 0 1 2 3 4 5 6 7
+// len: 3                      |     |
+//                             r     w
+//
+// write 4 bytes: storage: 0 1 2 3 4 5 6 7
+// len: 7                    | |
+//                           w r
+//
+template <size_t Size> struct Pipe {
+  // the len function assumes Size < MAX_SIZE_T/2
+  static_assert(Size < std::numeric_limits<size_t>::max() / 2, "Size < MAX_SIZE_T/2");
+
+  char _storage[Size];
+  size_t _w = 0; // storage write offset
+  size_t _r = 0; // storage read offset
+
+  constexpr size_t cap() const {
+    return Size - 1;
+  }
+  size_t len() const {
+    return (Size - _r + _w) % Size;
+  }
+  size_t avail() const {
+    return (Size - 1 - _w + _r) % Size;
+  }
+
+  // add data to the beginning of the pipe
+  size_t write(const char* src, size_t nbyte); // copy <=nbyte of dst into the pipe
+  size_t writec(char c);                       // add c to the pipe
+  kj::Promise<ssize_t> readFromStream(kj::Own<kj::AsyncIoStream>& stream,
+                                      size_t nbyte); // read <=nbyte from stream (-1 on error)
+
+  // take data out of the end of the pipe
+  size_t read(char* dst, size_t nbyte); // copy <=nbyte of data to dst
+  size_t discard(size_t nbyte);         // read & discard
+  kj::Promise<ssize_t> writeToStream(kj::Own<kj::AsyncIoStream>& stream,
+                                     size_t nbyte); // write <=nbyte to file (-1 on error)
+
+  // takeRef removes nbyte and returns a pointer to the removed bytes,
+  // if and only if the next nbytes are contiguous, i.e. does not span across the
+  // underlying ring buffer's head & tail. Returns nullptr on failure.
+  // The returned memory is only valid until the next call to write() or clear().
+  const char* takeRef(size_t nbyte);
+
+  inline char at(size_t index) const {
+    return _storage[_r + index];
+  }
+
+  // clear drains the pipe by discarding any data waiting to be read
+  void clear() {
+    _w = 0;
+    _r = 0;
+  }
+};
+
+template <size_t Size> size_t Pipe<Size>::write(const char* data, size_t nbyte) {
+  nbyte = std::min(nbyte, avail());
+  size_t chunkend = std::min(nbyte, Size - _w);
+  memcpy(_storage + _w, data, chunkend);
+  memcpy(_storage, data + chunkend, nbyte - chunkend);
+  _w = (_w + nbyte) % Size;
+  return nbyte;
+}
+
+template <size_t Size> size_t Pipe<Size>::writec(char c) {
+  if (avail() == 0) {
+    return 0;
+  }
+  _storage[_w] = c;
+  _w = (_w + 1) % Size;
+  return 1;
+}
+
+size_t writec(char c);
+
+template <size_t Size>
+kj::Promise<ssize_t> Pipe<Size>::readFromStream(kj::Own<kj::AsyncIoStream>& stream, size_t nbyte) {
+  nbyte = std::min(nbyte, avail());
+  size_t chunkend = std::min(nbyte, Size - _w);
+  ssize_t total = 0;
+  if (chunkend > 0) {
+    KJ_LOG(INFO, "will read", _w, chunkend);
+    total = co_await stream->read(_storage + _w, 0, chunkend);
+    KJ_LOG(INFO, "read", total);
+    if (total < (ssize_t)chunkend) {
+      // short read
+      if (total > -1) {
+        goto end;
+      }
+      co_return total;
+    }
+  }
+  if (nbyte > chunkend) {
+    ssize_t n = co_await stream->read(_storage, 0, nbyte - chunkend);
+    if (n < 0) {
+      co_return n;
+    }
+    total += n;
+  }
+end:
+  _w = (_w + (size_t)total) % Size;
+  co_return total;
+}
+
+template <size_t Size>
+kj::Promise<ssize_t> Pipe<Size>::writeToStream(kj::Own<kj::AsyncIoStream>& stream, size_t nbyte) {
+  nbyte = std::min(nbyte, len());
+  size_t chunkend = std::min(nbyte, Size - _r);
+  ssize_t total = 0;
+  const kj::byte* ptr = reinterpret_cast<const kj::byte*>(_storage);
+  if (chunkend > 0) {
+    KJ_LOG(INFO, "will write", _storage, _r, chunkend, stream);
+    co_await stream->write(kj::arrayPtr<const kj::byte>(ptr + _r, chunkend));
+    total = chunkend;
+    KJ_LOG(INFO, "wrote", total);
+  }
+  if (nbyte > chunkend) {
+    auto left = nbyte - chunkend;
+    co_await stream->write(kj::arrayPtr<const kj::byte>(ptr, left));
+    total += left;
+  }
+
+  _r = (_r + nbyte) % Size;
+  co_return total;
+}
+
+template <size_t Size> size_t Pipe<Size>::read(char* data, size_t nbyte) {
+  nbyte = std::min(nbyte, len());
+  size_t chunkend = std::min(nbyte, Size - _r);
+  memcpy(data, _storage + _r, chunkend);
+  memcpy(data + chunkend, _storage, nbyte - chunkend);
+  _r = (_r + nbyte) % Size;
+  return nbyte;
+}
+
+template <size_t Size> size_t Pipe<Size>::discard(size_t nbyte) {
+  nbyte = std::min(nbyte, len());
+  _r = (_r + nbyte) % Size;
+  return nbyte;
+}
+
+template <size_t Size> const char* Pipe<Size>::takeRef(size_t nbyte) {
+  // Either w is ahead of e in memory ...
+  //   0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+  //      W2   |        R1        |    W1      R=read-from, W=write-to
+  //           r                  w
+  // ... or r is ahead of w in memory ...
+  //   0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+  //      R2   |        W1        |    R1
+  //           w                  r
+  // In either case we can only return a reference to R1.
+  nbyte = std::min(nbyte, len());
+  size_t chunkend = std::min(nbyte, Size - _r);
+  const char* p = nullptr;
+  if (chunkend >= nbyte) {
+    p = _storage + _r;
+    _r = (_r + nbyte) % Size;
+  }
+  return p;
+}
+
+} // namespace workerd::api::gpu::voodoo

--- a/src/workerd/api/gpu/voodoo/voodoo-protocol.c++
+++ b/src/workerd/api/gpu/voodoo/voodoo-protocol.c++
@@ -1,0 +1,170 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+#include "voodoo-protocol.h"
+
+namespace workerd::api::gpu::voodoo {
+
+static void decodeDawnCmdHeader(const char* src, uint32_t* dawncmdlen) {
+  KJ_ASSERT(src[0] == MSGT_DAWNCMD);
+  *dawncmdlen = ntohl(*((uint32_t*)&src[1]));
+}
+
+// encodeDawnCmdHeader writes a MSGT_DAWNCMD header of DAWNCMD_MSG_HEADER_SIZE bytes to dst.
+static void encodeDawnCmdHeader(char* dst, uint32_t dawncmdlen) {
+  dst[0] = MSGT_DAWNCMD;
+  *((uint32_t*)&dst[1]) = htonl(dawncmdlen);
+}
+
+kj::Promise<void> DawnRemoteSerializer::handleIncomingCommands() {
+  for (;;) {
+    ssize_t n = co_await _rbuf.readFromStream(stream, _rbuf.cap());
+    if (n == 0) {
+      KJ_LOG(INFO, "EOF received while reading from stream");
+      co_return;
+    }
+
+    KJ_LOG(INFO, "read bytes from stream", n, _rbuf.len());
+    if (_dawnCmdRLen > 0) {
+      maybeReadIncomingDawnCmd();
+    } else {
+      if (!readMsg()) {
+        co_return;
+      }
+    }
+  }
+}
+
+kj::Promise<void> DawnRemoteSerializer::actualFlush() {
+  // if we are flushing Dawn command data, do that before draining _wbuf
+  if (_dawnout.flushlen != 0) {
+    KJ_ASSERT(_dawnout.flushlen > _dawnout.flushoffs);
+    uint32_t len = _dawnout.flushlen - _dawnout.flushoffs;
+    KJ_LOG(INFO, "_dawnout flush", _dawnout.flushoffs, len);
+    const kj::byte* ptr = reinterpret_cast<const kj::byte*>(&_dawnout.flushbuf[_dawnout.flushoffs]);
+    co_await stream->write(kj::arrayPtr<const kj::byte>(ptr, len));
+
+    _dawnout.flushoffs += len;
+    _dawnout.flushlen = 0;
+  }
+
+  // drain _wbuf
+  size_t nbyte = _wbuf.len();
+  if (nbyte > 0) {
+    co_await _wbuf.writeToStream(stream, nbyte);
+  }
+
+  if (needsFlush) {
+    needsFlush = false;
+    Flush();
+  }
+}
+
+// readMsg reads a protocol message from the read buffer (_rbuf)
+bool DawnRemoteSerializer::readMsg() {
+  char tmp[DAWNCMD_MSG_HEADER_SIZE + 1];
+  while (_rbuf.len() > 0) {
+    switch (_rbuf.at(0)) {
+
+    case MSGT_DAWNCMD:
+      KJ_LOG(INFO, "MSGT_DAWNCMD", _rbuf.len(), _rbuf.at(0));
+      if (_rbuf.len() >= DAWNCMD_MSG_HEADER_SIZE) {
+        _rbuf.read(tmp, DAWNCMD_MSG_HEADER_SIZE);
+        decodeDawnCmdHeader(tmp, &_dawnCmdRLen);
+
+        KJ_LOG(INFO, "will start reading dawn command buffer", _dawnCmdRLen);
+        if (!maybeReadIncomingDawnCmd()) {
+          // read was succesful but dawn command is still incomplete
+          return true;
+        };
+      }
+      break;
+
+    default:
+      // unexpected/corrupt message data
+      char c = _rbuf.at(0);
+      KJ_LOG(ERROR, "unexpected message received", c, _rbuf.len());
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool DawnRemoteSerializer::maybeReadIncomingDawnCmd() {
+  KJ_REQUIRE(_dawnCmdRLen > 0, "no data to read as dawn command");
+  KJ_REQUIRE(_dawnCmdRLen <= DAWNCMD_MAX, "length of data to read as dawn command is too high");
+
+  if (_rbuf.len() < _dawnCmdRLen) {
+    KJ_LOG(INFO, "dawn command is still incomplete", _rbuf.len(), _dawnCmdRLen);
+    return false;
+  }
+
+  // onDawnBuffer expects a contiguous memory segment; attempt to simply reference
+  // the data in rbuf. takeRef returns null if the data is not available as a contiguous
+  // segement, in which case we resort to copying it into a temporary buffer.
+  const char* buf = _rbuf.takeRef(_dawnCmdRLen);
+  if (buf == nullptr) {
+    // copy into temporary buffer
+    KJ_LOG(INFO, "data is not contiguous, will copy to temporary buffer _dawntmp");
+    _rbuf.read(_dawntmp, _dawnCmdRLen);
+    buf = _dawntmp;
+  }
+  onDawnBuffer(buf, _dawnCmdRLen);
+  _dawnCmdRLen = 0;
+  return true;
+}
+
+void* DawnRemoteSerializer::GetCmdSpace(size_t size) {
+  KJ_LOG(INFO, "GetCmdSpace() was called", size);
+  KJ_ASSERT(size <= DAWNCMD_MAX);
+  if (DAWNCMD_BUFSIZE - _dawnout.writelen < size) {
+    KJ_LOG(ERROR,
+           "GetCmdSpace() could not allocate enough space for the dawn command and message header",
+           size, _dawnout.writelen);
+    return nullptr;
+  }
+  char* result = &_dawnout.writebuf[_dawnout.writelen];
+  _dawnout.writelen += size;
+  return result;
+}
+
+bool DawnRemoteSerializer::Flush() {
+  KJ_LOG(INFO, "Flush() was called", _dawnout.writelen, _dawnout.flushlen);
+
+  if (_dawnout.flushlen != 0) {
+    /* not done flushing previous buffer */
+    needsFlush = true;
+    return false;
+  }
+
+  if (_dawnout.writelen > DAWNCMD_MSG_HEADER_SIZE) {
+    // write header (preallocated at writebuf[0..DAWNCMD_MSG_HEADER_SIZE])
+    encodeDawnCmdHeader(_dawnout.writebuf, _dawnout.writelen - DAWNCMD_MSG_HEADER_SIZE);
+
+    // swap buffers
+    char* buf1 = _dawnout.flushbuf;
+    _dawnout.flushbuf = _dawnout.writebuf;
+    _dawnout.writebuf = buf1;
+
+    // setup flush state
+    _dawnout.flushlen = _dawnout.writelen;
+    _dawnout.flushoffs = 0;
+    taskset.add(actualFlush());
+
+    // reset write
+    _dawnout.writelen = DAWNCMD_MSG_HEADER_SIZE;
+  } else {
+    KJ_ASSERT(_dawnout.writelen == DAWNCMD_MSG_HEADER_SIZE);
+  }
+  return true;
+};
+
+} // namespace workerd::api::gpu::voodoo

--- a/src/workerd/api/gpu/voodoo/voodoo-protocol.h
+++ b/src/workerd/api/gpu/voodoo/voodoo-protocol.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// This server interacts directly with the GPU, and listens on a UNIX socket for clients
+// of the Dawn Wire protocol.
+
+#pragma once
+
+#include "voodoo-pipe.h"
+#include <dawn/wire/WireServer.h>
+#include <functional>
+#include <kj/async-io.h>
+#include <kj/debug.h>
+#include <kj/exception.h>
+
+// dawn buffer sizes
+#define DAWNCMD_MSG_HEADER_SIZE 9 /* "D" <HEXBYTE>{8} */
+#define DAWNCMD_MAX (4096 * 128)
+#define DAWNCMD_BUFSIZE (DAWNCMD_MAX + DAWNCMD_MSG_HEADER_SIZE)
+
+// protocol messages
+//
+// message        = dawncmdMsg
+// dawncmdMsg     = "D" size
+// size           = <uint32 in big-endian order>
+//
+#define MSGT_DAWNCMD 'D' /* Dawn command buffer */
+
+namespace workerd::api::gpu::voodoo {
+
+class DawnRemoteErrorHandler : public kj::TaskSet::ErrorHandler {
+  kj::Own<kj::AsyncIoStream>& stream;
+
+public:
+  DawnRemoteErrorHandler(kj::Own<kj::AsyncIoStream>& s) : stream(s) {}
+  void taskFailed(kj::Exception&& exception) override {
+    KJ_LOG(ERROR, "task failed in dawn remote handler", exception);
+    stream->shutdownWrite();
+    stream->abortRead();
+  }
+};
+
+struct DawnRemoteSerializer : public dawn::wire::CommandSerializer {
+  DawnRemoteSerializer(kj::TaskSet& ts, kj::Own<kj::AsyncIoStream>& s) : taskset(ts), stream(s) {}
+  kj::TaskSet& taskset;
+  kj::Own<kj::AsyncIoStream>& stream;
+
+  Pipe<DAWNCMD_BUFSIZE + 8> _rbuf; // incoming data (extra space for pipe impl)
+  Pipe<4096> _wbuf;                // outgoing data (in addition to _dawnout)
+
+  uint32_t _dawnCmdRLen = 0; // reamining nbytes to read as dawn command buffer
+
+  // when we attempt to flush but we're still not done with the previous
+  // flush operation we will signal for another flush to happen in the
+  // future.
+  bool needsFlush = false;
+
+  // _dawnout is the dawn command buffer for outgoing Dawn command data
+  struct {
+    char bufs[2][DAWNCMD_BUFSIZE];
+    char* writebuf = bufs[0];                    // buffer used for GetCmdSpace
+    uint32_t writelen = DAWNCMD_MSG_HEADER_SIZE; // length of writebuf
+    char* flushbuf = bufs[1];                    // buffer being written to stream
+    uint32_t flushlen = 0;                       // length of flushbuf (>0 when flushing)
+    uint32_t flushoffs = 0;                      // start offset of flushbuf
+  } _dawnout;
+
+  // _dawntmp is used for temporary storage of incoming dawn command buffers
+  // in the case that they span across Pipe boundaries.
+  char _dawntmp[DAWNCMD_MAX];
+
+  // callbacks, client and server
+  std::function<void(const char* data, size_t len)> onDawnBuffer;
+
+  // main protocol method for handling incoming client commands
+  kj::Promise<void> handleIncomingCommands();
+
+  // internal methods
+  bool maybeReadIncomingDawnCmd();
+  bool readMsg();
+  kj::Promise<void> actualFlush();
+
+  // dawn::wire::CommandSerializer
+  void* GetCmdSpace(size_t size) override;
+  bool Flush() override;
+  size_t GetMaximumAllocationSize() const override {
+    KJ_LOG(INFO, "GetMaximumAllocationSize() was called");
+    return DAWNCMD_MAX;
+  };
+};
+
+} // namespace workerd::api::gpu::voodoo

--- a/src/workerd/api/gpu/voodoo/voodoo-server.c++
+++ b/src/workerd/api/gpu/voodoo/voodoo-server.c++
@@ -1,0 +1,106 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// This server interacts directly with the GPU, and listens on a UNIX socket for clients
+// of the Dawn Wire protocol.
+
+#ifdef _WIN32
+#include <io.h>
+#define unlink _unlink
+#else
+#include <unistd.h>
+#endif
+
+#include <dawn/dawn_proc.h>
+#include <dawn/native/DawnNative.h>
+#include <dawn/webgpu_cpp.h>
+#include <dawn/wire/WireServer.h>
+#include <filesystem>
+#include <kj/async-io.h>
+#include <kj/debug.h>
+#include <thread>
+#include <workerd/api/gpu/voodoo/voodoo-pipe.h>
+#include <workerd/api/gpu/voodoo/voodoo-protocol.h>
+#include <workerd/api/gpu/voodoo/voodoo-server.h>
+
+namespace workerd::api::gpu::voodoo {
+
+void VoodooServer::startServer() {
+  KJ_LOG(INFO, listenPath, "will start listening server");
+
+  // initialize dawn
+  dawnProcSetProcs(&nativeProcs);
+  auto adapters = instance.EnumerateAdapters();
+  KJ_REQUIRE(!adapters.empty(), "no GPU adapters found");
+
+  // initialize event loop
+  kj::AsyncIoContext io = kj::setupAsyncIo();
+
+  // create listening socket
+  unlink(listenPath.cStr());
+  auto addr =
+      io.provider->getNetwork().parseAddress(kj::str("unix:", listenPath)).wait(io.waitScope);
+
+  auto listener = addr->listen();
+
+  // process requests
+  auto promise = acceptLoop(kj::mv(listener));
+  promise.wait(io.waitScope);
+  return;
+}
+
+kj::Promise<void> VoodooServer::acceptLoop(kj::Own<kj::ConnectionReceiver>&& listener) {
+  kj::TaskSet tasks(*this);
+
+  for (;;) {
+    auto connection = co_await listener->accept();
+    tasks.add(handleConnection(kj::mv(connection)));
+  }
+}
+
+kj::Promise<void> VoodooServer::flushAfterEvents(DawnRemoteSerializer& serializer) {
+  WGPUInstance wgpuInstance = instance.Get();
+
+  while (dawn::native::InstanceProcessEvents(wgpuInstance)) {
+    // TODO(soon): how to sleep here without blocking the thread?
+    // I don't have an IoContext to use setTimeout.
+    // This is currently a busy-loop. :(
+  }
+  if (!serializer.Flush()) {
+    KJ_LOG(ERROR, "serializer->Flush() failed");
+  }
+  co_return;
+}
+
+kj::Promise<void> VoodooServer::handleConnection(kj::Own<kj::AsyncIoStream> stream) {
+  KJ_LOG(INFO, "handling connection");
+
+  // setup wire
+  DawnRemoteErrorHandler dawnErrorHandler(stream);
+  kj::TaskSet tasks(dawnErrorHandler);
+  auto serializer = kj::heap<DawnRemoteSerializer>(tasks, stream);
+  dawn::wire::WireServerDescriptor wDesc{
+      .procs = &nativeProcs,
+      .serializer = serializer,
+  };
+
+  auto wireServer = kj::heap<dawn::wire::WireServer>(wDesc);
+  wireServer->InjectInstance(instance.Get(), {1, 0});
+
+  serializer->onDawnBuffer = [&](const char* data, size_t len) {
+    KJ_ASSERT(data != nullptr);
+    if (wireServer->HandleCommands(data, len) == nullptr) {
+      KJ_LOG(ERROR, "onDawnBuffer: wireServer->HandleCommands failed");
+    }
+    tasks.add(flushAfterEvents(*serializer));
+  };
+
+  // process commands
+  co_await serializer->handleIncomingCommands();
+
+  KJ_LOG(INFO, "connection is done");
+  co_return;
+}
+
+} // namespace workerd::api::gpu::voodoo

--- a/src/workerd/api/gpu/voodoo/voodoo-server.h
+++ b/src/workerd/api/gpu/voodoo/voodoo-server.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// This server interacts directly with the GPU, and listens on a UNIX socket for clients
+// of the Dawn Wire protocol.
+
+#pragma once
+
+#include <dawn/dawn_proc.h>
+#include <dawn/native/DawnNative.h>
+#include <dawn/webgpu_cpp.h>
+#include <dawn/wire/WireServer.h>
+#include <filesystem>
+#include <kj/async-io.h>
+#include <kj/debug.h>
+#include <kj/exception.h>
+#include <workerd/api/gpu/voodoo/voodoo-pipe.h>
+#include <workerd/api/gpu/voodoo/voodoo-protocol.h>
+
+namespace workerd::api::gpu::voodoo {
+
+class VoodooServer : public kj::TaskSet::ErrorHandler {
+public:
+  VoodooServer(kj::StringPtr path) : listenPath(path), nativeProcs(dawn::native::GetProcs()) {}
+
+  void taskFailed(kj::Exception&& exception) override {
+    KJ_LOG(ERROR, "task failed handling connection", exception);
+  }
+
+  void startServer();
+
+private:
+  kj::Promise<void> acceptLoop(kj::Own<kj::ConnectionReceiver>&& listener);
+  kj::Promise<void> handleConnection(kj::Own<kj::AsyncIoStream> stream);
+  kj::Promise<void> flushAfterEvents(DawnRemoteSerializer& serializer);
+
+  kj::StringPtr listenPath;
+  DawnProcTable nativeProcs;
+  dawn::native::Instance instance;
+};
+
+} // namespace workerd::api::gpu::voodoo

--- a/src/workerd/api/gpu/webgpu-errors-test.js
+++ b/src/workerd/api/gpu/webgpu-errors-test.js
@@ -24,7 +24,7 @@ export class DurableObjectExample {
 
     device.createBuffer({
       mappedAtCreation: true,
-      size: Number.MAX_SAFE_INTEGER,
+      size: 1,
       usage: GPUBufferUsage.STORAGE,
     });
 
@@ -32,7 +32,7 @@ export class DurableObjectExample {
 
     device.createBuffer({
       mappedAtCreation: true,
-      size: Number.MAX_SAFE_INTEGER,
+      size: 1,
       usage: GPUBufferUsage.STORAGE,
     });
 

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -10,9 +10,20 @@ bool_flag(
     build_setting_default = False,
 )
 
+# Flag to enable remote WebGPU support via the Dawn wire protocol
+bool_flag(
+    name = "enable_experimental_webgpu_remote",
+    build_setting_default = False,
+)
+
 config_setting(
     name = "set_enable_experimental_webgpu",
     flag_values = {"enable_experimental_webgpu": "True"},
+)
+
+config_setting(
+    name = "set_enable_experimental_webgpu_remote",
+    flag_values = {"enable_experimental_webgpu_remote": "True"},
 )
 
 wd_cc_library(
@@ -53,6 +64,9 @@ wd_cc_library(
     defines = select({
         ":set_enable_experimental_webgpu": ["WORKERD_EXPERIMENTAL_ENABLE_WEBGPU"],
         "//conditions:default": [],
+    }) + select({
+        ":set_enable_experimental_webgpu_remote": ["WORKERD_EXPERIMENTAL_ENABLE_WEBGPU_REMOTE"],
+        "//conditions:default": [],
     }),
     implementation_deps = [
         "//src/workerd/util:perfetto",
@@ -87,7 +101,14 @@ wd_cc_library(
         "@capnp-cpp//src/kj:kj-async",
         "@ssl",
     ] + select({
-        ":set_enable_experimental_webgpu": ["@dawn"],
+        ":set_enable_experimental_webgpu": [
+            "@dawn",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        ":set_enable_experimental_webgpu_remote": [
+            "//src/workerd/api:voodoo",
+        ],
         "//conditions:default": [],
     }),
 )

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -104,6 +104,12 @@ public:
 
   virtual kj::Own<WorkerInterface> startSubrequest(uint channel, SubrequestMetadata metadata) = 0;
 
+  // Get a connection to a Dawn server
+  //
+  // This Dawn server implementation will talk directly to the GPU which is
+  // not possible if the worker process is running inside some sandbox.
+  virtual kj::Own<kj::AsyncIoStream> getGPUConnection() = 0;
+
   // Get a Cap'n Proto RPC capability. Various binding types are backed by capabilities.
   //
   // Note that some other channel types, like actor channels, may actually be wrappers around

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -60,6 +60,21 @@ wd_cc_binary(
     }),
 )
 
+wd_cc_binary(
+    name = "voodoo",
+    srcs = [
+        "voodoo.c++",
+    ],
+    target_compatible_with = select({
+        "//src/workerd/io:set_enable_experimental_webgpu": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/workerd/api:voodoo",
+    ],
+)
+
 wd_cc_library(
     name = "alarm-scheduler",
     srcs = [

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1387,12 +1387,15 @@ public:
   using AbortActorsCallback = kj::Function<void()>;
 
   WorkerService(ThreadContext& threadContext, kj::Own<const Worker> worker,
+                kj::Network& network,
+                config::Config::WebgpuBackend::Reader webgpuBackend,
                 kj::Maybe<kj::HashSet<kj::String>> defaultEntrypointHandlers,
                 kj::HashMap<kj::String, kj::HashSet<kj::String>> namedEntrypointsParam,
                 const kj::HashMap<kj::String, ActorConfig>& actorClasses,
                 LinkCallback linkCallback, AbortActorsCallback abortActorsCallback)
       : threadContext(threadContext),
         ioChannels(kj::mv(linkCallback)),
+        network(network), webgpuBackend(webgpuBackend),
         worker(kj::mv(worker)),
         defaultEntrypointHandlers(kj::mv(defaultEntrypointHandlers)),
         waitUntilTasks(*this), abortActorsCallback(kj::mv(abortActorsCallback)) {
@@ -1408,6 +1411,15 @@ public:
       auto ns = kj::heap<ActorNamespace>(*this, entry.key, entry.value, threadContext.getUnsafeTimer());
       actorNamespaces.insert(entry.key, kj::mv(ns));
     }
+  }
+
+  kj::Own<kj::AsyncIoStream> getGPUConnection() override {
+    KJ_ASSERT(webgpuBackend.isLocalUnixSocket());
+
+    auto listenPath = webgpuBackend.getLocalUnixSocket();
+    auto addr = network.parseAddress(kj::str("unix:", listenPath))
+                    .then([](kj::Own<kj::NetworkAddress> address) { return address->connect(); });
+    return kj::newPromisedStream(kj::mv(addr));
   }
 
   kj::Maybe<Service&> getEntrypoint(kj::StringPtr name) {
@@ -1970,7 +1982,8 @@ private:
 
   // LinkedIoChannels owns the SqliteDatabase::Vfs, so make sure it is destroyed last.
   kj::OneOf<LinkCallback, LinkedIoChannels> ioChannels;
-
+  kj::Network& network;
+  config::Config::WebgpuBackend::Reader webgpuBackend;
   kj::Own<const Worker> worker;
   kj::Maybe<kj::HashSet<kj::String>> defaultEntrypointHandlers;
   kj::HashMap<kj::String, EntrypointService> namedEntrypoints;
@@ -2566,7 +2579,7 @@ void Server::abortAllActors() {
 }
 
 kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::Reader conf,
-    capnp::List<config::Extension>::Reader extensions) {
+    capnp::List<config::Extension>::Reader extensions, config::Config::WebgpuBackend::Reader webgpuBackend) {
   TRACE_EVENT("workerd", "Server::makeWorker()", "name", name.cStr());
   auto& localActorConfigs = KJ_ASSERT_NONNULL(actorConfigs.find(name));
 
@@ -3013,6 +3026,7 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
   };
 
   return kj::heap<WorkerService>(globalContext->threadContext, kj::mv(worker),
+                                 network, webgpuBackend,
                                  kj::mv(errorReporter.defaultEntrypoint),
                                  kj::mv(errorReporter.namedEntrypoints), localActorConfigs,
                                  kj::mv(linkCallback), KJ_BIND_METHOD(*this, abortAllActors));
@@ -3023,7 +3037,8 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name, config::Worker::
 kj::Own<Server::Service> Server::makeService(
     config::Service::Reader conf,
     kj::HttpHeaderTable::Builder& headerTableBuilder,
-    capnp::List<config::Extension>::Reader extensions) {
+    capnp::List<config::Extension>::Reader extensions,
+    config::Config::WebgpuBackend::Reader webgpuBackend) {
   kj::StringPtr name = conf.getName();
 
   switch (conf.which()) {
@@ -3039,7 +3054,7 @@ kj::Own<Server::Service> Server::makeService(
       return makeNetworkService(conf.getNetwork());
 
     case config::Service::WORKER:
-      return makeWorker(name, conf.getWorker(), extensions);
+      return makeWorker(name, conf.getWorker(), extensions, webgpuBackend);
 
     case config::Service::DISK:
       return makeDiskDirectoryService(name, conf.getDisk(), headerTableBuilder);
@@ -3562,7 +3577,7 @@ void Server::startServices(jsg::V8System& v8System, config::Config::Reader confi
   // Second pass: Build services.
   for (auto serviceConf: config.getServices()) {
     kj::StringPtr name = serviceConf.getName();
-    auto service = makeService(serviceConf, headerTableBuilder, config.getExtensions());
+    auto service = makeService(serviceConf, headerTableBuilder, config.getExtensions(), config.getWebgpuBackend());
 
     services.upsert(kj::str(name), kj::mv(service), [&](auto&&...) {
       reportConfigError(kj::str("Config defines multiple services named \"", name, "\"."));

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -192,11 +192,13 @@ private:
       kj::StringPtr name, config::DiskDirectory::Reader conf,
       kj::HttpHeaderTable::Builder& headerTableBuilder);
   kj::Own<Service> makeWorker(kj::StringPtr name, config::Worker::Reader conf,
-      capnp::List<config::Extension>::Reader extensions);
+      capnp::List<config::Extension>::Reader extensions,
+      config::Config::WebgpuBackend::Reader webgpuBackend);
   kj::Own<Service> makeService(
       config::Service::Reader conf,
       kj::HttpHeaderTable::Builder& headerTableBuilder,
-      capnp::List<config::Extension>::Reader extensions);
+      capnp::List<config::Extension>::Reader extensions,
+      config::Config::WebgpuBackend::Reader webgpuBackend);
 
   // Aborts all actors in this server except those in namespaces marked with `preventEviction`.
   void abortAllActors();

--- a/src/workerd/server/voodoo.c++
+++ b/src/workerd/server/voodoo.c++
@@ -1,0 +1,45 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// This server interacts directly with the GPU, and listens on a UNIX socket for clients
+// of the Dawn Wire protocol.
+
+#include "workerd/api/gpu/voodoo/voodoo-server.h"
+#include <kj/debug.h>
+#include <kj/main.h>
+
+class VoodooMain : public kj::TaskSet::ErrorHandler {
+public:
+  VoodooMain(kj::ProcessContext& context) : context(context) {}
+
+  void taskFailed(kj::Exception&& exception) override {
+    KJ_LOG(ERROR, "task failed handling connection", exception);
+  }
+
+  kj::MainBuilder::Validity setListenPath(kj::StringPtr path) {
+    listenPath = path;
+    return true;
+  }
+
+  kj::MainBuilder::Validity startServer() {
+    workerd::api::gpu::voodoo::VoodooServer server(listenPath);
+    server.startServer();
+    return true;
+  }
+
+  kj::MainFunc getMain() {
+    return kj::MainBuilder(context, "Voodoo GPU handler V0.0",
+                           "Exposes a Dawn Wire endpoint on a UNIX socket for dawn clients that "
+                           "want to interact with a GPU")
+        .expectArg("<listen_path>", KJ_BIND_METHOD(*this, setListenPath))
+        .callAfterParsing(KJ_BIND_METHOD(*this, startServer))
+        .build();
+  }
+
+private:
+  kj::StringPtr listenPath;
+  kj::ProcessContext& context;
+};
+
+KJ_MAIN(VoodooMain)

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -84,6 +84,19 @@ struct Config {
   # A list of gates which are enabled.
   # These are used to gate features/changes in workerd and in our internal repo. See the equivalent
   # config definition in our internal repo for more details.
+
+  webgpuBackend :union {
+    # Specifies what webgpu backend to use.
+
+    native @5 :Void;
+    # Default. Uses the Vulkan API to access a local GPU directly.
+
+    localUnixSocket @6 :Text;
+    # We will connect to local UNIX socket and expect that a server is listening which implements
+    # our serialization for the Dawn wire protocol. This will allow us to talk to a GPU via a
+    # separate process, which is needed if the main process is prevented from accessing a GPU
+    # directly.
+  }
 }
 
 # ========================================================================================

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -67,6 +67,10 @@ struct DummyIoChannelFactory final: public IoChannelFactory {
     KJ_FAIL_ASSERT("no subrequests");
   }
 
+  kj::Own<kj::AsyncIoStream> getGPUConnection() override {
+    KJ_FAIL_ASSERT("no remote gpu");
+  }
+
   capnp::Capability::Client getCapability(uint channel) override {
     KJ_FAIL_ASSERT("no capabilities");
   }


### PR DESCRIPTION
Support having a separate process that talks to the GPU, and to which workerd can talk to using the dawn wire procotol. There are now two implementations of `DawnContainer`, one that relies on a remote connection via the wire protocol, and another that attempts to access the GPU directly via Dawn native, which is the default.

To use the remote protocol workerd needs to be built with the enable_experimental_webgpu_remote flag and the `webgpuBackend` config needs to be set with the correct path for the unix socket on which the server is listening on.

A server can be launched via the //src/workerd/server:voodoo module passing as a parameter the unix socket path where it will be listening on.