### PR TITLE
Python: Adjust API for Pyodide bundle to support multiple versions

### DIFF
--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -16,10 +16,10 @@
 
 namespace workerd::api::pyodide {
 
-// singleton that owns bundle
-extern kj::Maybe<jsg::Bundle::Reader> pyodideBundleGlobal;
+bool hasPyodideBundle(kj::StringPtr version);
 
-void setPyodideBundleData(kj::Array<unsigned char> data);
+void setPyodideBundleData(kj::String version, kj::Array<unsigned char> data);
+jsg::Bundle::Reader getPyodideBundle(kj::StringPtr version);
 
 
 struct PythonConfig {


### PR DESCRIPTION
A relatively minor change that cleans up the bundle code in pyodide.c++/pyodide.h and adds a TreeMap to handle multiple bundle versions.