### PR TITLE
NFC Add bazel rule to generate external pyodide capnproto bundle

### DIFF
--- a/build/wd_js_bundle.bzl
+++ b/build/wd_js_bundle.bzl
@@ -114,7 +114,7 @@ def _copy_modules(modules, declarations):
         result[new_filename] = modules[m]
     return result, declarations_result
 
-def wd_js_bundle(
+def wd_js_bundle_capnp(
         name,
         import_name,
         schema_id,
@@ -146,6 +146,7 @@ def wd_js_bundle(
      internal_json_modules: list of json source files
      declarations: d.ts label set
      deps: dependency list
+    Returns: The set of data dependencies
     """
     builtin_modules_dict = {
         m: "{}:{}".format(import_name, _to_name(m))
@@ -201,7 +202,7 @@ def wd_js_bundle(
 
     gen_api_bundle_capnpn(
         name = name + "@gen",
-        out = name + ".capnp",
+        out = name,
         schema_id = schema_id,
         const_name = import_name + "Bundle",
         builtin_modules = builtin_modules_dict,
@@ -213,7 +214,11 @@ def wd_js_bundle(
         data = data,
         deps = deps,
     )
+    return data
 
+
+def wd_js_bundle(name, import_name, *args, **kwargs):
+    data = wd_js_bundle_capnp(name + ".capnp", import_name, *args, **kwargs)
     cc_capnp_library(
         name = name,
         srcs = [name + ".capnp"],

--- a/src/pyodide/BUILD.bazel
+++ b/src/pyodide/BUILD.bazel
@@ -3,7 +3,7 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@capnp-cpp//src/capnp:cc_capnp_library.bzl", "cc_capnp_library")
 load("//:build/capnp_embed.bzl", "capnp_embed")
-load("//:build/wd_ts_bundle.bzl", "wd_ts_bundle")
+load("//:build/wd_ts_bundle.bzl", "wd_ts_bundle_capnp")
 
 copy_file(
     name = "pyodide_packages_archive",
@@ -146,8 +146,8 @@ expand_template(
     template = "@pyodide//:pyodide/pyodide.asm.js",
 )
 
-wd_ts_bundle(
-    name = "pyodide",
+data = wd_ts_bundle_capnp(
+    name = "pyodide.capnp",
     modules = ["python-entrypoint-helper.ts"],
     import_name = "pyodide",
     internal_data_modules = ["generated/python_stdlib.zip"] + glob([
@@ -178,4 +178,35 @@ wd_ts_bundle(
         "python_stdlib.zip@rule",
         "pyodide-bucket.json@rule",
     ],
+)
+
+cc_capnp_library(
+    name = "pyodide",
+    srcs = ["pyodide.capnp"],
+    strip_include_prefix = "",
+    visibility = ["//visibility:public"],
+    data = data,
+    deps = ["@workerd//src/workerd/jsg:modules_capnp"],
+    include_prefix = "pyodide",
+)
+
+
+genrule(
+    name = "pyodide.capnp.bin@rule",
+    tools = ["@capnp-cpp//src/capnp:capnp_tool"],
+    srcs = ["pyodide.capnp", "//src/workerd/jsg:modules.capnp"] + data,
+    outs = ["pyodide.capnp.bin"],
+    visibility = ["//visibility:public"],
+    cmd = " ".join([
+        # Annoying logic to deal with different paths in workerd vs downstream.
+        # Either need "-I src" in workerd or -I external/workerd/src downstream
+        "INCLUDE=$$(stat src > /dev/null 2>&1 && echo src || echo external/workerd/src);",
+        "$(execpath @capnp-cpp//src/capnp:capnp_tool)",
+        "eval",
+        "$(location :pyodide.capnp)",
+        "pyodideBundle",
+        "-I $$INCLUDE",
+        "-o binary",
+        "> $@",
+    ])
 )

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -4,6 +4,8 @@ load("//:build/kj_test.bzl", "kj_test")
 load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
 load("//:build/wd_cc_library.bzl", "wd_cc_library")
 
+exports_files(["modules.capnp"])
+
 wd_cc_library(
     name = "jsg",
     srcs = [

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("//:build/kj_test.bzl", "kj_test")
 load("//:build/wd_cc_binary.bzl", "wd_cc_binary")
 load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
@@ -179,3 +180,11 @@ kj_test(
         "@ssl",
     ],
 )
+
+
+copy_file(
+    name = "pyodide.capnp.bin@rule",
+    src = "//src/pyodide:pyodide.capnp.bin@rule",
+    out = "pyodide.capnp.bin",
+)
+


### PR DESCRIPTION
Split off from #2288. This doesn't actually use the rule for anything yet, and perhaps we'll want to move this logic into pyodide-build-scripts eventually. But this will enable us to test against the Pyodide setup code in the source tree.