### PR TITLE
Clear WritableStreamSink queue on abort with compat flag

### DIFF
--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -168,17 +168,23 @@ private:
 
 class WritableStreamInternalController: public WritableStreamController {
 public:
-  using Writable = IoOwn<WritableStreamSink>;
+  struct Writable {
+    kj::Own<WritableStreamSink> sink;
+    kj::Canceler canceler;
+    Writable(kj::Own<WritableStreamSink> sink) : sink(kj::mv(sink)) {}
+    void abort(kj::Exception&& ex);
+  };
 
   explicit WritableStreamInternalController(StreamStates::Closed closed)
       : state(closed) {}
   explicit WritableStreamInternalController(StreamStates::Errored errored)
       : state(kj::mv(errored)) {}
-  explicit WritableStreamInternalController(Writable writable,
+  explicit WritableStreamInternalController(kj::Own<WritableStreamSink> writable,
       kj::Maybe<uint64_t> maybeHighWaterMark = kj::none,
-      kj::Maybe<jsg::Promise<void>> maybeClosureWaitable = kj::none) : state(kj::mv(writable)),
-          maybeHighWaterMark(maybeHighWaterMark),
-          maybeClosureWaitable(kj::mv(maybeClosureWaitable)) {
+      kj::Maybe<jsg::Promise<void>> maybeClosureWaitable = kj::none)
+      : state(IoContext::current().addObject(kj::heap<Writable>(kj::mv(writable)))),
+        maybeHighWaterMark(maybeHighWaterMark),
+        maybeClosureWaitable(kj::mv(maybeClosureWaitable)) {
 }
 
   WritableStreamInternalController(WritableStreamInternalController&& other) = default;
@@ -269,7 +275,7 @@ private:
   };
 
   kj::Maybe<WritableStream&> owner;
-  kj::OneOf<StreamStates::Closed, StreamStates::Errored, Writable> state;
+  kj::OneOf<StreamStates::Closed, StreamStates::Errored, IoOwn<Writable>> state;
   kj::OneOf<Unlocked, Locked, PipeLocked, WriterLocked> writeState = Unlocked();
 
   kj::Maybe<PendingAbort> maybePendingAbort;

--- a/src/workerd/api/tests/abort-internal-streams-test.js
+++ b/src/workerd/api/tests/abort-internal-streams-test.js
@@ -1,0 +1,23 @@
+import { strictEqual } from 'assert';
+
+export const abortInternalStreamsTest = {
+  async test() {
+    const { writable } = new IdentityTransformStream();
+
+    const writer = writable.getWriter();
+
+    const promise = writer.write(new Uint8Array(10));
+
+    await writer.abort();
+
+    // The write promise should abort proactively without waiting for a read,
+    // indicating that the queue was drained proactively when the abort was
+    // called.
+    try {
+      await promise;
+      throw new Error('The promise should have been rejected');
+    } catch (err) {
+      strictEqual(err, undefined);
+    }
+  }
+};

--- a/src/workerd/api/tests/abort-internal-streams-test.wd-test
+++ b/src/workerd/api/tests/abort-internal-streams-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "abort-internal-streams-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "abort-internal-streams-test.js")
+        ],
+        compatibilityDate = "2024-07-01",
+        compatibilityFlags = ["nodejs_compat_v2", "internal_writable_stream_abort_clears_queue"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/compatibility-date-test.c++
+++ b/src/workerd/io/compatibility-date-test.c++
@@ -235,7 +235,8 @@ KJ_TEST("compatibility flag parsing") {
       " fetchStandardUrl = true,"
       " nodeJsCompatV2 = true,"
       " globalFetchStrictlyPublic = false,"
-      " newModuleRegistry = false)", {},
+      " newModuleRegistry = false,"
+      " internalWritableStreamAbortClearsQueue = true)", {},
       CompatibilityDateValidation::FUTURE_FOR_TEST, false, false);
   expectCompileCompatibilityFlags("2024-09-01", {"nodejs_compat"},
       "(formDataParserSupportsFiles = true,"

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -562,4 +562,13 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # For local development purposes only, increase the message size limit to 128MB.
   # This is not expected ever to be made available in production, as large messages are inefficient.
 
+  internalWritableStreamAbortClearsQueue @57 :Bool
+      $compatEnableFlag("internal_writable_stream_abort_clears_queue")
+      $compatDisableFlag("internal_writable_stream_abort_does_not_clear_queue")
+      $compatEnableDate("2024-09-02");
+  # When using the original WritableStream implementation ("internal" streams), the
+  # abort() operation would be handled lazily, meaning that the queue of pending writes
+  # would not be cleared until the next time the queue was processed. This behavior leads
+  # to a situtation where the stream can hang if the consumer stops consuming. When set,
+  # this flag changes the behavior to clear the queue immediately upon abort.
 }


### PR DESCRIPTION
The motivation here is to address an issue with `WritableStream` instances wrapping a `WritableStreamSink` implementation not processing `abort()` calls proactively. Without the flag the `abort()` will be handled lazily, meaning that a consumer must be actively consuming the data written to the stream in order to trigger the abort and close the stream. This is problematic if the consumer has dropped or otherwise stopped reading from the writable's internal buffer ... the pending abort will never be processed and resolved. This means that pending writes and the pending abort itself will never be resolved in those cases. With the flag, the queue of pending writes is drained immediately when `abort()` is called and the stream is transitioned to an error state immediately. This should cause the underlying `WritableStreamSink` to be aborted and dropped immediately and the pending write and abort promises should all get settled.

internal ticket: EW-8607