### PR TITLE
Improve buffering in Compression Streams API

### DIFF
--- a/src/workerd/api/streams/compression.c++
+++ b/src/workerd/api/streams/compression.c++
@@ -129,7 +129,7 @@ private:
 
   Mode mode;
   z_stream ctx = {};
-  kj::byte buffer[4096];
+  kj::byte buffer[16384];
 
   // For the eponymous compatibility flag
   ContextFlags strictCompression;

--- a/src/workerd/api/streams/compression.c++
+++ b/src/workerd/api/streams/compression.c++
@@ -255,7 +255,7 @@ public:
         // There might still be data in the output buffer remaining to read.
         if (output.empty()) return size_t(0);
         return tryReadInternal(
-            kj::ArrayPtr<kj::byte>(reinterpret_cast<kj::byte*>(buffer), maxBytes),
+            kj::arrayPtr(reinterpret_cast<kj::byte*>(buffer), maxBytes),
             minBytes);
       }
       KJ_CASE_ONEOF(exception, kj::Exception) {
@@ -263,7 +263,7 @@ public:
       }
       KJ_CASE_ONEOF(open, Open) {
         return tryReadInternal(
-            kj::ArrayPtr<kj::byte>(reinterpret_cast<kj::byte*>(buffer), maxBytes),
+            kj::arrayPtr(reinterpret_cast<kj::byte*>(buffer), maxBytes),
             minBytes);
       }
     }


### PR DESCRIPTION
- Eliminate recursion in compression streams writeInternal() 
This avoids having large stack traces when compressing larger chunks of data
and is easier to maintain with the added comments.

- Reduce excessive copying in Compression Streams API 
In the Compression Streams API, introduce a helper class to only shift output
data when this would reduce output vector size significantly. This results in
the leading bytes of the output vector becoming invalid when reading only parts
of it, which requires careful tracking but avoids having to move the output data
with every read from the buffer.

- Increase Compression Streams output buffer size 
Since zlib uses 256KiB of memory per compression stream with default settings, a
size of 16KiB will not increase memory usage by a large proportion. This should
make processing data slightly faster. Ideally we'd want this to be larger than
deflate's 32KiB window size which would allow zlib to avoid some extra copying
during decompression, but that can be done at a later time alongside other
compression optimizations.

- Clean up ArrayPtr casts