### PR TITLE
VS-257: Fix Vectorize query options

### DIFF
--- a/src/cloudflare/internal/test/vectorize/vectorize-api-test.js
+++ b/src/cloudflare/internal/test/vectorize/vectorize-api-test.js
@@ -19,7 +19,7 @@ export const test_vector_search_vector_query = {
   async test(_, env) {
     const IDX = env["vector-search"];
     {
-      // with returnValues = true, returnMetadata = true
+      // with returnValues = true, returnMetadata = "indexed"
       const results = await IDX.query(new Float32Array(new Array(5).fill(0)), {
         topK: 3,
         returnValues: true,
@@ -58,7 +58,7 @@ export const test_vector_search_vector_query = {
     }
 
     {
-      // with returnValues = unset (false), returnMetadata = unset (false)
+      // with returnValues = unset (false), returnMetadata = unset (none)
       const results = await IDX.query(new Float32Array(new Array(5).fill(0)), {
         topK: 3,
       });
@@ -85,7 +85,7 @@ export const test_vector_search_vector_query = {
     }
 
     {
-      // with returnValues = unset (false), returnMetadata = unset (false), filter = "Peter Piper picked a peck of pickled peppers"
+      // with returnValues = unset (false), returnMetadata = unset (none), filter = "Peter Piper picked a peck of pickled peppers"
       const results = await IDX.query(new Float32Array(new Array(5).fill(0)), {
         topK: 1,
         filter: {

--- a/src/cloudflare/internal/test/vectorize/vectorize-mock.js
+++ b/src/cloudflare/internal/test/vectorize/vectorize-mock.js
@@ -97,7 +97,7 @@ export default {
       ) {
         return Response.json({});
       } else if (request.method === "POST" && pathname.endsWith("/query")) {
-        /** @type {VectorizeQueryOptions<VectorizeMetadataRetrievalLevel> & {vector: number[]}} */
+        /** @type {VectorizeQueryOptions & {vector: number[]}} */
         const body = await request.json();
         let returnSet = structuredClone(exampleVectorMatches);
         if (
@@ -114,7 +114,7 @@ export default {
           returnSet.forEach((v) => {
             delete v.values;
           });
-        if (!body?.returnMetadata)
+        if (!body?.returnMetadata || body?.returnMetadata === "none")
           returnSet.forEach((v) => {
             delete v.metadata;
           });

--- a/src/cloudflare/internal/vectorize.d.ts
+++ b/src/cloudflare/internal/vectorize.d.ts
@@ -67,13 +67,11 @@ type VectorizeDistanceMetric = "euclidean" | "cosine" | "dot-product";
  */
 type VectorizeMetadataRetrievalLevel = "all" | "indexed" | "none";
 
-interface VectorizeQueryOptions<
-  MetadataReturn extends boolean | VectorizeMetadataRetrievalLevel = boolean,
-> {
+interface VectorizeQueryOptions{
   topK?: number;
   namespace?: string;
   returnValues?: boolean;
-  returnMetadata?: MetadataReturn;
+  returnMetadata?: boolean | VectorizeMetadataRetrievalLevel;
   filter?: VectorizeVectorMetadataFilter;
 }
 
@@ -196,7 +194,7 @@ declare abstract class VectorizeIndex {
    */
   public query(
     vector: VectorFloatArray | number[],
-    options: VectorizeQueryOptions
+    options?: VectorizeQueryOptions
   ): Promise<VectorizeMatches>;
   /**
    * Insert a list of vectors into the index dataset. If a provided id exists, an error will be thrown.
@@ -243,7 +241,7 @@ declare abstract class Vectorize {
    */
   public query(
     vector: VectorFloatArray | number[],
-    options: VectorizeQueryOptions<VectorizeMetadataRetrievalLevel>
+    options?: VectorizeQueryOptions
   ): Promise<VectorizeMatches>;
   /**
    * Insert a list of vectors into the index dataset. If a provided id exists, an error will be thrown.

--- a/types/defines/vectorize.d.ts
+++ b/types/defines/vectorize.d.ts
@@ -59,13 +59,11 @@ type VectorizeDistanceMetric = "euclidean" | "cosine" | "dot-product";
  */
 type VectorizeMetadataRetrievalLevel = "all" | "indexed" | "none";
 
-interface VectorizeQueryOptions<
-  MetadataReturn extends boolean | VectorizeMetadataRetrievalLevel = boolean,
-> {
+interface VectorizeQueryOptions{
   topK?: number;
   namespace?: string;
   returnValues?: boolean;
-  returnMetadata?: MetadataReturn;
+  returnMetadata?: boolean | VectorizeMetadataRetrievalLevel;
   filter?: VectorizeVectorMetadataFilter;
 }
 
@@ -188,7 +186,7 @@ declare abstract class VectorizeIndex {
    */
   public query(
     vector: VectorFloatArray | number[],
-    options: VectorizeQueryOptions
+    options?: VectorizeQueryOptions
   ): Promise<VectorizeMatches>;
   /**
    * Insert a list of vectors into the index dataset. If a provided id exists, an error will be thrown.
@@ -235,7 +233,7 @@ declare abstract class Vectorize {
    */
   public query(
     vector: VectorFloatArray | number[],
-    options: VectorizeQueryOptions<VectorizeMetadataRetrievalLevel>
+    options?: VectorizeQueryOptions
   ): Promise<VectorizeMatches>;
   /**
    * Insert a list of vectors into the index dataset. If a provided id exists, an error will be thrown.


### PR DESCRIPTION
This change fixes 2 aspects of Vectorize query options.

1. Options itself should be an optional field.

2. Options.returnMetadata should be of type boolean for Vectorize V1 and of type `VectorizeMetadataRetrievalLevel` for Vectorize V2. The existing type relied on a generic to assign type appropriately for the operation, but did not work as expected for Vectorize V2. It continued to expect a boolean field for V2 as well instead of `VectorizeMetadataRetrievalLevel`.

Follows: https://github.com/cloudflare/workerd/pull/2443