### PR TITLE
reduce encoding serialization cost

### DIFF
--- a/src/node/internal/buffer.d.ts
+++ b/src/node/internal/buffer.d.ts
@@ -9,32 +9,42 @@ interface CompareOptions {
 
 type BufferSource = ArrayBufferView | ArrayBuffer;
 
+export type Encoding = number;
+
 export function byteLength(value: string): number;
 export function compare(a: Uint8Array, b: Uint8Array, options?: CompareOptions): number;
 export function concat(list: Uint8Array[], length: number): ArrayBuffer;
-export function decodeString(value: string, encoding: string): ArrayBuffer;
+export function decodeString(value: string, encoding: Encoding): ArrayBuffer;
 export function fillImpl(buffer: Uint8Array,
                          value: string | BufferSource,
                          start: number,
                          end: number,
-                         encoding?: string): void;
+                         encoding?: Encoding): void;
 export function indexOf(buffer: Uint8Array,
                         value: string | Uint8Array,
                         byteOffset?: number,
-                        encoding?: string,
+                        encoding?: Encoding,
                         findLast?: boolean): number | undefined;
 export function swap(buffer: Uint8Array, size: 16|32|64): void;
 export function toString(buffer: Uint8Array,
                          start: number,
                          end: number,
-                         encoding: string): string;
+                         encoding: Encoding): string;
 export function write(buffer: Uint8Array,
                       value: string,
                       offset: number,
                       length: number,
-                      encoding: string): void;
+                      encoding: Encoding): void;
 export function decode(buffer: Uint8Array, state: Uint8Array): string;
 export function flush(state: Uint8Array): string;
 export function isAscii(value: ArrayBufferView): boolean;
 export function isUtf8(value: ArrayBufferView): boolean;
-export function transcode(source: ArrayBufferView, fromEncoding: string, toEncoding: string): ArrayBuffer;
+export function transcode(source: ArrayBufferView, fromEncoding: Encoding, toEncoding: Encoding): ArrayBuffer;
+
+export const ASCII: Encoding;
+export const LATIN1: Encoding;
+export const UTF8: Encoding;
+export const UTF16LE: Encoding;
+export const BASE64: Encoding;
+export const BASE64URL: Encoding;
+export const HEX: Encoding;

--- a/src/node/internal/crypto_hash.ts
+++ b/src/node/internal/crypto_hash.ts
@@ -49,14 +49,9 @@ import {
 } from 'node-internal:internal_errors';
 
 import {
-  validateEncoding,
   validateString,
   validateUint32,
 } from 'node-internal:validators';
-
-import {
-  normalizeEncoding
-} from 'node-internal:internal_utils';
 
 import {
   isArrayBufferView,
@@ -129,9 +124,6 @@ Hash.prototype.copy = function(this: Hash, options?: HashOptions): Hash {
 Hash.prototype._transform = function(this: Hash | Hmac, chunk: string | Buffer | ArrayBufferView,
                                      encoding: string, callback: TransformCallback): void {
   if (typeof chunk === 'string') {
-    encoding ??= 'utf-8';
-    validateEncoding(chunk, encoding);
-    encoding = normalizeEncoding(encoding)!;
     chunk = Buffer.from(chunk, encoding);
   }
   this[kHandle].update(chunk);
@@ -155,8 +147,6 @@ Hash.prototype.update = function(this: Hash | Hmac, data: string | Buffer | Arra
     throw new ERR_CRYPTO_HASH_FINALIZED();
 
   if (typeof data === 'string') {
-    validateEncoding(data, encoding!);
-    encoding = normalizeEncoding(encoding);
     data = Buffer.from(data, encoding);
   } else if (!isArrayBufferView(data)) {
     throw new ERR_INVALID_ARG_TYPE(

--- a/src/node/internal/internal_stringdecoder.ts
+++ b/src/node/internal/internal_stringdecoder.ts
@@ -26,7 +26,7 @@
 /* todo: the following is adopted code, enabling linting one day */
 /* eslint-disable */
 
-import { Buffer, isEncoding } from 'node-internal:internal_buffer';
+import { Buffer } from 'node-internal:internal_buffer';
 import { normalizeEncoding } from 'node-internal:internal_utils';
 import {
   ERR_INVALID_ARG_TYPE,
@@ -43,15 +43,18 @@ const kBufferedBytes = 5;
 const kEncoding = 6;
 const kSize = 7;
 
-const encodings : Record<string,number> = {
-  ascii: 0,
-  latin1: 1,
-  utf8: 2,
-  utf16le: 3,
-  base64: 4,
-  base64url: 5,
-  hex: 6,
-};
+// The order of this array should be in sync with i18n.h
+// Encoding enum. Index of this array defines the uint8_t
+// value of an encoding.
+const encodings = [
+  'ascii',
+  'latin1',
+  'utf8',
+  'utf16le',
+  'base64',
+  'base64url',
+  'hex',
+];
 
 const kNativeDecoder = Symbol('kNativeDecoder');
 
@@ -73,12 +76,12 @@ interface InternalDecoder extends StringDecoder {
 
 export function StringDecoder(this: StringDecoder, encoding: string = 'utf8') {
   const normalizedEncoding = normalizeEncoding(encoding);
-  if (!isEncoding(normalizedEncoding)) {
+  if (normalizedEncoding === undefined) {
     throw new ERR_UNKNOWN_ENCODING(encoding);
   }
   (this as InternalDecoder)[kNativeDecoder] = Buffer.alloc(kSize);
-  (this as InternalDecoder)[kNativeDecoder][kEncoding] = encodings[normalizedEncoding!]!;
-  this.encoding = normalizedEncoding!;
+  (this as InternalDecoder)[kNativeDecoder][kEncoding] = normalizedEncoding;
+  this.encoding = encodings[normalizedEncoding]!;
 }
 
 function write(this: StringDecoder, buf: ArrayBufferView|DataView|string): string {

--- a/src/node/internal/internal_utils.ts
+++ b/src/node/internal/internal_utils.ts
@@ -27,59 +27,63 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 /* eslint-disable */
+import { default as bufferUtil } from 'node-internal:buffer';
+import type { Encoding } from 'node-internal:buffer';
 
-export function normalizeEncoding(enc?: string) : string | undefined {
+const { UTF8, UTF16LE, HEX, ASCII, BASE64, BASE64URL, LATIN1 } = bufferUtil;
+
+export function normalizeEncoding(enc?: string) : Encoding | undefined {
   if (enc == null ||
       enc === "utf8" ||
       enc === "utf-8" ||
       enc === "UTF8" ||
-      enc === "UTF-8") return "utf8";
+      enc === "UTF-8") return UTF8;
   return slowCases(enc);
 }
 
-export function slowCases(enc: string) : string | undefined {
+export function slowCases(enc: string) : Encoding | undefined {
   switch (enc.length) {
     case 4:
-      if (enc === "UTF8") return "utf8";
-      if (enc === "ucs2" || enc === "UCS2") return "utf16le";
+      if (enc === "UTF8") return UTF8;
+      if (enc === "ucs2" || enc === "UCS2") return UTF16LE;
       enc = `${enc}`.toLowerCase();
-      if (enc === "utf8") return "utf8";
-      if (enc === "ucs2") return "utf16le";
+      if (enc === "utf8") return UTF8;
+      if (enc === "ucs2") return UTF16LE;
       break;
     case 3:
       if (
         enc === "hex" || enc === "HEX" ||
         `${enc}`.toLowerCase() === "hex"
       ) {
-        return "hex";
+        return HEX;
       }
       break;
     case 5:
-      if (enc === "ascii") return "ascii";
-      if (enc === "ucs-2") return "utf16le";
-      if (enc === "UTF-8") return "utf8";
-      if (enc === "ASCII") return "ascii";
-      if (enc === "UCS-2") return "utf16le";
+      if (enc === "ascii") return ASCII;
+      if (enc === "ucs-2") return UTF16LE;
+      if (enc === "UTF-8") return UTF8;
+      if (enc === "ASCII") return ASCII;
+      if (enc === "UCS-2") return UTF16LE;
       enc = `${enc}`.toLowerCase();
-      if (enc === "utf-8") return "utf8";
-      if (enc === "ascii") return "ascii";
-      if (enc === "ucs-2") return "utf16le";
+      if (enc === "utf-8") return UTF8;
+      if (enc === "ascii") return ASCII;
+      if (enc === "ucs-2") return UTF16LE;
       break;
     case 6:
-      if (enc === "base64") return "base64";
-      if (enc === "latin1" || enc === "binary") return "latin1";
-      if (enc === "BASE64") return "base64";
-      if (enc === "LATIN1" || enc === "BINARY") return "latin1";
+      if (enc === "base64") return BASE64;
+      if (enc === "latin1" || enc === "binary") return LATIN1;
+      if (enc === "BASE64") return BASE64;
+      if (enc === "LATIN1" || enc === "BINARY") return LATIN1;
       enc = `${enc}`.toLowerCase();
-      if (enc === "base64") return "base64";
-      if (enc === "latin1" || enc === "binary") return "latin1";
+      if (enc === "base64") return BASE64;
+      if (enc === "latin1" || enc === "binary") return LATIN1;
       break;
     case 7:
       if (
         enc === "utf16le" || enc === "UTF16LE" ||
         `${enc}`.toLowerCase() === "utf16le"
       ) {
-        return "utf16le";
+        return UTF16LE;
       }
       break;
     case 8:
@@ -87,7 +91,7 @@ export function slowCases(enc: string) : string | undefined {
         enc === "utf-16le" || enc === "UTF-16LE" ||
         `${enc}`.toLowerCase() === "utf-16le"
       ) {
-        return "utf16le";
+        return UTF16LE;
       }
       break;
     case 9:
@@ -95,11 +99,11 @@ export function slowCases(enc: string) : string | undefined {
         enc === "base64url" || enc === "BASE64URL" ||
         `${enc}`.toLowerCase() === "base64url"
       ) {
-        return "base64url";
+        return BASE64URL;
       }
       break;
     default:
-      if (enc === "") return "utf8";
+      if (enc === "") return UTF8;
   }
   return undefined;
 }

--- a/src/node/internal/validators.ts
+++ b/src/node/internal/validators.ts
@@ -36,6 +36,7 @@ import {
   ERR_INVALID_ARG_VALUE,
   ERR_OUT_OF_RANGE,
 } from "node-internal:internal_errors";
+import { default as bufferUtil } from 'node-internal:buffer';
 
 // TODO(someday): Not current implementing parseFileMode, validatePort
 
@@ -166,7 +167,7 @@ export function validateEncoding(data: unknown, encoding: string): void {
   const normalizedEncoding = normalizeEncoding(encoding);
   const length = (data as any).length;
 
-  if (normalizedEncoding === "hex" && length % 2 !== 0) {
+  if (normalizedEncoding === bufferUtil.HEX && length % 2 !== 0) {
     throw new ERR_INVALID_ARG_VALUE(
       "encoding",
       encoding,

--- a/src/workerd/api/node/buffer.h
+++ b/src/workerd/api/node/buffer.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <workerd/jsg/jsg.h>
+#include "i18n.h"
 
 namespace workerd::api::node {
 
@@ -35,20 +36,20 @@ public:
 
   kj::Array<kj::byte> decodeString(jsg::Lock& js,
                                    jsg::JsString string,
-                                   kj::String encoding);
+                                   EncodingValue encoding);
 
   void fillImpl(jsg::Lock& js,
                 kj::Array<kj::byte> buffer,
                 kj::OneOf<jsg::JsString, jsg::BufferSource> value,
                 uint32_t start,
                 uint32_t end,
-                jsg::Optional<kj::String> encoding);
+                jsg::Optional<EncodingValue> encoding);
 
   jsg::Optional<uint32_t> indexOf(jsg::Lock& js,
                                   kj::Array<kj::byte> buffer,
                                   kj::OneOf<jsg::JsString, jsg::BufferSource> value,
                                   int32_t byteOffset,
-                                  kj::String encoding,
+                                  EncodingValue encoding,
                                   bool isForward);
 
   void swap(jsg::Lock& js, kj::Array<kj::byte> buffer, int size);
@@ -57,14 +58,14 @@ public:
                          kj::Array<kj::byte> bytes,
                          uint32_t start,
                          uint32_t end,
-                         kj::String encoding);
+                         EncodingValue encoding);
 
   uint32_t write(jsg::Lock& js,
                  kj::Array<kj::byte> buffer,
                  jsg::JsString string,
                  uint32_t offset,
                  uint32_t length,
-                 kj::String encoding);
+                 EncodingValue encoding);
 
   enum NativeDecoderFields {
     kIncompleteCharactersStart = 0,
@@ -82,8 +83,8 @@ public:
   bool isAscii(kj::Array<kj::byte> bytes);
   bool isUtf8(kj::Array<kj::byte> bytes);
   kj::Array<kj::byte> transcode(kj::Array<kj::byte> source,
-                                kj::String rawFromEncoding,
-                                kj::String rawToEncoding);
+                                EncodingValue rawFromEncoding,
+                                EncodingValue rawToEncoding);
 
   JSG_RESOURCE_TYPE(BufferUtil) {
     JSG_METHOD(byteLength);
@@ -102,6 +103,14 @@ public:
     // For StringDecoder
     JSG_METHOD(decode);
     JSG_METHOD(flush);
+
+    JSG_STATIC_CONSTANT_NAMED(ASCII, static_cast<EncodingValue>(Encoding::ASCII));
+    JSG_STATIC_CONSTANT_NAMED(LATIN1, static_cast<EncodingValue>(Encoding::LATIN1));
+    JSG_STATIC_CONSTANT_NAMED(UTF8, static_cast<EncodingValue>(Encoding::UTF8));
+    JSG_STATIC_CONSTANT_NAMED(UTF16LE, static_cast<EncodingValue>(Encoding::UTF16LE));
+    JSG_STATIC_CONSTANT_NAMED(BASE64, static_cast<EncodingValue>(Encoding::BASE64));
+    JSG_STATIC_CONSTANT_NAMED(BASE64URL, static_cast<EncodingValue>(Encoding::BASE64URL));
+    JSG_STATIC_CONSTANT_NAMED(HEX, static_cast<EncodingValue>(Encoding::HEX));
   }
 };
 

--- a/src/workerd/api/node/i18n.h
+++ b/src/workerd/api/node/i18n.h
@@ -1,24 +1,29 @@
 // Copyright (c) 2017-2022 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
+#pragma once
 
 #include <kj/common.h>
 #include <kj/debug.h>
 #include <kj/one-of.h>
 #include <kj/string.h>
 
+#include <stdint.h>
+
 struct UConverter;
 
 namespace workerd::api::node {
 
-enum class Encoding {
-  ASCII,
-  LATIN1,
-  UTF8,
-  UTF16LE,
-  BASE64,
-  BASE64URL,
-  HEX,
+using EncodingValue = uint8_t;
+
+enum Encoding : EncodingValue {
+  ASCII = 0,
+  LATIN1 = 1,
+  UTF8 = 2,
+  UTF16LE = 3,
+  BASE64 = 4,
+  BASE64URL = 5,
+  HEX = 6,
 };
 
 namespace i18n {


### PR DESCRIPTION
Reduces encoding variable serialization cost between javascript and c++. by converting it to uint8_t we can reduce the "initial" cost we pay by calling almost all buffer functions.