### PR TITLE
R2-2317 add support for SSE-C via `workerd` bindings

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -299,6 +299,12 @@ wd_test(
 )
 
 wd_test(
+    src = "r2-test.wd-test",
+    args = ["--experimental"],
+    data = ["r2-test.js"],
+)
+
+wd_test(
     src = "rtti-test.wd-test",
     args = ["--experimental"],
     data = ["rtti-test.js"],

--- a/src/workerd/api/r2-api.capnp
+++ b/src/workerd/api/r2-api.capnp
@@ -60,6 +60,10 @@ struct R2Conditional {
   # timestamp.
 }
 
+struct R2SSECOptions {
+  key @0 :Text;
+}
+
 struct R2Checksums {
   # The JSON name of these fields must comform to the representation of the ChecksumAlgorithm in
   # the R2 gateway worker.
@@ -93,6 +97,7 @@ struct R2GetRequest {
   range @1 :R2Range;
   rangeHeader @3 :Text;
   onlyIf @2 :R2Conditional;
+  ssec @4 :R2SSECOptions;
 }
 
 struct R2PutRequest {
@@ -106,6 +111,7 @@ struct R2PutRequest {
   sha384 @7 :Data $Json.hex;
   sha512 @8 :Data $Json.hex;
   storageClass @9 :Text;
+  ssec @10 :R2SSECOptions;
 }
 
 struct R2CreateMultipartUploadRequest {
@@ -113,12 +119,14 @@ struct R2CreateMultipartUploadRequest {
   customFields @1 :List(Record);
   httpFields @2 :R2HttpFields;
   storageClass @3 :Text;
+  ssec @4 :R2SSECOptions;
 }
 
 struct R2UploadPartRequest {
   object @0 :Text;
   uploadId @1 :Text;
   partNumber @2 :UInt32;
+  ssec @3 :R2SSECOptions;
 }
 
 struct R2CompleteMultipartUploadRequest {
@@ -187,6 +195,11 @@ struct R2ErrorResponse {
   message @2 :Text;
 }
 
+struct R2SSECResponse {
+  algorithm @0 :Text;
+  keyMd5 @1 :Text;
+}
+
 struct R2HeadResponse {
   name @0 :Text;
   # The name of the object.
@@ -220,6 +233,9 @@ struct R2HeadResponse {
   storageClass @9 :Text;
   # The storage class of the object. Standard or Infrequent Access.
   # Provided on object creation to specify which storage tier R2 should use for this object.
+
+  ssec @10 :R2SSECResponse;
+  # The algorithm/key hash used for encryption(if the user used SSE-C)
 }
 
 using R2GetResponse = R2HeadResponse;
@@ -230,6 +246,8 @@ struct R2CreateMultipartUploadResponse {
   uploadId @0 :Text;
   # The unique identifier of this object, required for subsequent operations on
   # this multipart upload.
+  ssec @1 :R2SSECResponse;
+  # The algorithm/key hash used for encryption(if the user used SSE-C)
 }
 
 struct R2UploadPartResponse {

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -78,8 +78,9 @@ public:
   struct GetOptions {
     jsg::Optional<kj::OneOf<Conditional, jsg::Ref<Headers>>> onlyIf;
     jsg::Optional<kj::OneOf<Range, jsg::Ref<Headers>>> range;
+    jsg::Optional<kj::OneOf<kj::Array<byte>, kj::String>> ssecKey;
 
-    JSG_STRUCT(onlyIf, range);
+    JSG_STRUCT(onlyIf, range, ssecKey);
     JSG_STRUCT_TS_OVERRIDE(R2GetOptions);
   };
 
@@ -189,9 +190,18 @@ public:
     jsg::Optional<kj::OneOf<kj::Array<kj::byte>, jsg::NonCoercible<kj::String>>> sha384;
     jsg::Optional<kj::OneOf<kj::Array<kj::byte>, jsg::NonCoercible<kj::String>>> sha512;
     jsg::Optional<kj::String> storageClass;
+    jsg::Optional<kj::OneOf<kj::Array<byte>, kj::String>> ssecKey;
 
-    JSG_STRUCT(
-        onlyIf, httpMetadata, customMetadata, md5, sha1, sha256, sha384, sha512, storageClass);
+    JSG_STRUCT(onlyIf,
+        httpMetadata,
+        customMetadata,
+        md5,
+        sha1,
+        sha256,
+        sha384,
+        sha512,
+        storageClass,
+        ssecKey);
     JSG_STRUCT_TS_OVERRIDE(R2PutOptions);
   };
 
@@ -199,8 +209,9 @@ public:
     jsg::Optional<kj::OneOf<HttpMetadata, jsg::Ref<Headers>>> httpMetadata;
     jsg::Optional<jsg::Dict<kj::String>> customMetadata;
     jsg::Optional<kj::String> storageClass;
+    jsg::Optional<kj::OneOf<kj::Array<byte>, kj::String>> ssecKey;
 
-    JSG_STRUCT(httpMetadata, customMetadata, storageClass);
+    JSG_STRUCT(httpMetadata, customMetadata, storageClass, ssecKey);
     JSG_STRUCT_TS_OVERRIDE(R2MultipartOptions);
   };
 
@@ -215,7 +226,8 @@ public:
         jsg::Optional<HttpMetadata> httpMetadata,
         jsg::Optional<jsg::Dict<kj::String>> customMetadata,
         jsg::Optional<Range> range,
-        kj::String storageClass)
+        kj::String storageClass,
+        jsg::Optional<kj::String> ssecKeyMd5)
         : name(kj::mv(name)),
           version(kj::mv(version)),
           size(size),
@@ -225,7 +237,8 @@ public:
           httpMetadata(kj::mv(httpMetadata)),
           customMetadata(kj::mv(customMetadata)),
           range(kj::mv(range)),
-          storageClass(kj::mv(storageClass)) {}
+          storageClass(kj::mv(storageClass)),
+          ssecKeyMd5(kj::mv(ssecKeyMd5)) {}
 
     kj::String getName() const {
       return kj::str(name);
@@ -250,6 +263,9 @@ public:
     }
     kj::StringPtr getStorageClass() const {
       return storageClass;
+    }
+    jsg::Optional<kj::StringPtr> getSSECKeyMd5() const {
+      return ssecKeyMd5;
     }
 
     jsg::Optional<HttpMetadata> getHttpMetadata() const {
@@ -285,6 +301,7 @@ public:
       JSG_LAZY_READONLY_INSTANCE_PROPERTY(customMetadata, getCustomMetadata);
       JSG_LAZY_READONLY_INSTANCE_PROPERTY(range, getRange);
       JSG_LAZY_READONLY_INSTANCE_PROPERTY(storageClass, getStorageClass);
+      JSG_LAZY_READONLY_INSTANCE_PROPERTY(ssecKeyMd5, getSSECKeyMd5);
       JSG_METHOD(writeHttpMetadata);
       JSG_TS_OVERRIDE(R2Object);
     }
@@ -296,6 +313,7 @@ public:
       tracker.trackField("checksums", checksums);
       tracker.trackField("httpMetadata", httpMetadata);
       tracker.trackField("customMetadata", customMetadata);
+      tracker.trackField("ssecKeyMd5", ssecKeyMd5);
     }
 
   protected:
@@ -310,6 +328,7 @@ public:
 
     jsg::Optional<Range> range;
     kj::String storageClass;
+    jsg::Optional<kj::String> ssecKeyMd5;
     friend class R2Bucket;
   };
 
@@ -325,6 +344,7 @@ public:
         jsg::Optional<jsg::Dict<kj::String>> customMetadata,
         jsg::Optional<Range> range,
         kj::String storageClass,
+        jsg::Optional<kj::String> ssecKeyMd5,
         jsg::Ref<ReadableStream> body)
         : HeadResult(kj::mv(name),
               kj::mv(version),
@@ -335,7 +355,8 @@ public:
               kj::mv(KJ_ASSERT_NONNULL(httpMetadata)),
               kj::mv(KJ_ASSERT_NONNULL(customMetadata)),
               range,
-              kj::mv(storageClass)),
+              kj::mv(storageClass),
+              kj::mv(ssecKeyMd5)),
           body(kj::mv(body)) {}
 
     jsg::Ref<ReadableStream> getBody() {

--- a/src/workerd/api/r2-multipart.h
+++ b/src/workerd/api/r2-multipart.h
@@ -19,6 +19,12 @@ public:
     JSG_STRUCT(partNumber, etag);
     JSG_STRUCT_TS_OVERRIDE(R2UploadedPart);
   };
+  struct UploadPartOptions {
+    jsg::Optional<kj::OneOf<kj::Array<byte>, kj::String>> ssecKey;
+
+    JSG_STRUCT(ssecKey);
+    JSG_STRUCT_TS_OVERRIDE(R2UploadPartOptions);
+  };
 
   R2MultipartUpload(kj::String key, kj::String uploadId, jsg::Ref<R2Bucket> bucket)
       : key(kj::mv(key)),
@@ -35,6 +41,7 @@ public:
   jsg::Promise<UploadedPart> uploadPart(jsg::Lock& js,
       int partNumber,
       R2PutValue value,
+      jsg::Optional<UploadPartOptions> options,
       const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType);
   jsg::Promise<void> abort(jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType);
   jsg::Promise<jsg::Ref<R2Bucket::HeadResult>> complete(jsg::Lock& js,

--- a/src/workerd/api/r2-test.js
+++ b/src/workerd/api/r2-test.js
@@ -4,95 +4,245 @@
 
 import assert from 'node:assert';
 
+const bufferKey = new Uint8Array([
+  185, 255, 145, 154, 120, 76, 122, 72, 191, 42, 8, 64, 86, 189, 185, 75, 105,
+  37, 155, 123, 165, 158, 4, 42, 222, 13, 135, 52, 87, 154, 181, 227,
+]);
+const hexKey =
+  'b9ff919a784c7a48bf2a084056bdb94b69259b7ba59e042ade0d8734579ab5e3';
+const keyMd5 = 'WGR5pEm07DroP3hYRAh8Yw==';
+
+const objResponse = {
+  name: 'objectKey',
+  version: 'objectVersion',
+  size: '123',
+  etag: 'objectEtag',
+  uploaded: '1724767257918',
+  storageClass: 'Standard',
+};
+
 export default {
   // Handler for HTTP request binding makes to R2
   async fetch(request, env, ctx) {
     // We only expect PUT/Get
     assert(['GET', 'PUT'].includes(request.method));
 
-    // Each request should have a metadata size header indicating how much
-    // we should read to understand what type of request this is
-    const metadataSizeString = request.headers.get('cf-r2-metadata-size');
-    assert.notStrictEqual(metadataSizeString, null);
+    switch (request.method) {
+      case 'PUT': {
+        // Each request should have a metadata size header indicating how much
+        // we should read to understand what type of request this is
+        const metadataSizeString = request.headers.get('cf-r2-metadata-size');
+        assert.notStrictEqual(metadataSizeString, null);
 
-    const metadataSize = parseInt(metadataSizeString);
-    assert(!Number.isNaN(metadataSize));
+        const metadataSize = parseInt(metadataSizeString);
+        assert(!Number.isNaN(metadataSize));
 
-    const reader = request.body.getReader({ mode: 'byob' });
-    const jsonArray = new Uint8Array(metadataSize);
-    const { value } = await reader.readAtLeast(metadataSize, jsonArray);
-    reader.releaseLock();
+        const reader = request.body.getReader({ mode: 'byob' });
+        const jsonArray = new Uint8Array(metadataSize);
+        const { value } = await reader.readAtLeast(metadataSize, jsonArray);
+        reader.releaseLock();
 
-    const jsonRequest = JSON.parse(new TextDecoder().decode(value));
+        const jsonRequest = JSON.parse(new TextDecoder().decode(value));
 
-    // Currently not using the body in these test so I'm going to just discard
-    for await (const _ of request.body) {
-    }
+        // Currently not using the body in these test so I'm going to just discard
+        for await (const _ of request.body) {
+        }
 
-    // Assert it's the correct version
-    assert((jsonRequest.version = 1));
+        // Assert it's the correct version
+        assert((jsonRequest.version = 1));
+        assert(
+          [
+            'put',
+            'createMultipartUpload',
+            'uploadPart',
+            'completeMultipartUpload',
+          ].includes(jsonRequest.method)
+        );
 
-    if (request.method === 'PUT') {
-      assert(jsonRequest.method === 'put');
-
-      if (jsonRequest.object === 'onlyIfStrongEtag') {
-        assert.deepStrictEqual(jsonRequest.onlyIf, {
-          etagMatches: [
-            {
-              value: 'strongEtag',
-              type: 'strong',
-            },
-          ],
-          etagDoesNotMatch: [
-            {
-              value: 'strongEtag',
-              type: 'strong',
-            },
-          ],
-        });
+        switch (jsonRequest.object) {
+          case 'onlyIfStrongEtag': {
+            assert.deepStrictEqual(jsonRequest.onlyIf, {
+              etagMatches: [
+                {
+                  value: 'strongEtag',
+                  type: 'strong',
+                },
+              ],
+              etagDoesNotMatch: [
+                {
+                  value: 'strongEtag',
+                  type: 'strong',
+                },
+              ],
+            });
+            break;
+          }
+          case 'onlyIfWildcard': {
+            assert.deepStrictEqual(jsonRequest.onlyIf, {
+              etagMatches: [
+                {
+                  type: 'wildcard',
+                },
+              ],
+              etagDoesNotMatch: [
+                {
+                  type: 'wildcard',
+                },
+              ],
+            });
+            break;
+          }
+          case 'ssec': {
+            assert.deepStrictEqual(jsonRequest.ssec, {
+              key: hexKey,
+            });
+            return Response.json({
+              ...objResponse,
+              ssec: {
+                algorithm: 'aes256',
+                keyMd5,
+              },
+            });
+          }
+          case 'ssec-mu': {
+            if (jsonRequest.method === 'createMultipartUpload') {
+              assert.deepStrictEqual(jsonRequest.ssec, {
+                key: hexKey,
+              });
+              return Response.json({
+                uploadId: 'definitelyARealId',
+              });
+            }
+            if (jsonRequest.method === 'uploadPart') {
+              assert.deepStrictEqual(jsonRequest.ssec, {
+                key: hexKey,
+              });
+              return Response.json({
+                etag: 'definitelyAValidEtag',
+                ssec: {
+                  algorithm: 'aes256',
+                  keyMd5,
+                },
+              });
+            }
+            if (jsonRequest.method === 'completeMultipartUpload') {
+              return Response.json({
+                ...objResponse,
+                ssec: {
+                  algorithm: 'aes256',
+                  keyMd5,
+                },
+              });
+            }
+          }
+        }
+        return Response.json(objResponse);
       }
-
-      if (jsonRequest.object === 'onlyIfWildcard') {
-        assert.deepStrictEqual(jsonRequest.onlyIf, {
-          etagMatches: [
-            {
-              type: 'wildcard',
+      case 'GET': {
+        const rawHeader = request.headers.get('cf-r2-request');
+        const jsonRequest = JSON.parse(rawHeader);
+        assert((jsonRequest.version = 1));
+        assert(['get', 'head'].includes(jsonRequest.method));
+        if (jsonRequest.object === 'ssec') {
+          const encoder = new TextEncoder();
+          const metadata = encoder.encode(
+            JSON.stringify({
+              ...objResponse,
+              ssec: {
+                algorithm: 'aes256',
+                keyMd5,
+              },
+            })
+          );
+          const body =
+            jsonRequest.method === 'get'
+              ? new ReadableStream({
+                  start(controller) {
+                    controller.enqueue(metadata);
+                    controller.enqueue(encoder.encode('Bonk'));
+                    controller.close();
+                  },
+                })
+              : metadata;
+          return new Response(body, {
+            headers: {
+              'cf-r2-metadata-size': metadata.length.toString(),
+              'content-length': metadata.length.toString(),
             },
-          ],
-          etagDoesNotMatch: [
-            {
-              type: 'wildcard',
-            },
-          ],
-        });
+          });
+        }
       }
-
-      return Response.json({
-        name: 'objectKey',
-        version: 'objectVersion',
-        size: '123',
-        etag: 'objectEtag',
-        uploaded: '1724767257918',
-        storageClass: 'Standard',
-      });
     }
-
     throw new Error('unexpected');
   },
 
   async test(ctrl, env, ctx) {
-    await env.BUCKET.put('basic', 'content');
-    await env.BUCKET.put('onlyIfStrongEtag', 'content', {
-      onlyIf: {
-        etagMatches: 'strongEtag',
-        etagDoesNotMatch: 'strongEtag',
-      },
-    });
-    await env.BUCKET.put('onlyIfWildcard', 'content', {
-      onlyIf: {
-        etagMatches: '*',
-        etagDoesNotMatch: '*',
-      },
-    });
+    {
+      // Conditionals
+      await env.BUCKET.put('basic', 'content');
+      await env.BUCKET.put('onlyIfStrongEtag', 'content', {
+        onlyIf: {
+          etagMatches: 'strongEtag',
+          etagDoesNotMatch: 'strongEtag',
+        },
+      });
+      await env.BUCKET.put('onlyIfWildcard', 'content', {
+        onlyIf: {
+          etagMatches: '*',
+          etagDoesNotMatch: '*',
+        },
+      });
+    }
+
+    {
+      // SSEC
+      for (const ssecKey of [bufferKey, hexKey]) {
+        {
+          const { ssecKeyMd5 } = await env.BUCKET.put('ssec', 'content', {
+            ssecKey,
+          });
+          assert.strictEqual(ssecKeyMd5, keyMd5);
+        }
+        {
+          const { ssecKeyMd5 } = await env.BUCKET.get('ssec', {
+            ssecKey,
+          });
+          assert.strictEqual(ssecKeyMd5, keyMd5);
+        }
+        {
+          const { ssecKeyMd5 } = await env.BUCKET.head('ssec', {
+            ssecKey,
+          });
+          assert.strictEqual(ssecKeyMd5, keyMd5);
+        }
+        {
+          const multi = await env.BUCKET.createMultipartUpload('ssec-mu', {
+            ssecKey,
+          });
+          assert.equal(multi.uploadId, 'definitelyARealId');
+        }
+        {
+          const multi = await env.BUCKET.createMultipartUpload('ssec-mu', {
+            ssecKey,
+          });
+          const part = await multi.uploadPart(1, 'hey', {
+            ssecKey,
+          });
+          assert.equal(part.etag, 'definitelyAValidEtag');
+        }
+        {
+          const multi = await env.BUCKET.createMultipartUpload('ssec-mu', {
+            ssecKey,
+          });
+          const { ssecKeyMd5 } = await multi.complete([
+            {
+              partNumber: 1,
+              etag: 'definitelyAValidEtag',
+            },
+          ]);
+          assert.strictEqual(ssecKeyMd5, keyMd5);
+        }
+      }
+    }
   },
 };

--- a/src/workerd/api/r2.h
+++ b/src/workerd/api/r2.h
@@ -16,6 +16,7 @@ namespace workerd::api::public_beta {
       api::public_beta::R2Bucket::PutOptions, api::public_beta::R2Bucket::MultipartOptions,        \
       api::public_beta::R2Bucket::Checksums, api::public_beta::R2Bucket::StringChecksums,          \
       api::public_beta::R2Bucket::HttpMetadata, api::public_beta::R2Bucket::ListOptions,           \
-      api::public_beta::R2Bucket::ListResult
+      api::public_beta::R2Bucket::ListResult,                                                      \
+      api::public_beta::R2MultipartUpload::UploadPartOptions
 // The list of r2 types that are added to worker.c++'s JSG_DECLARE_ISOLATE_TYPE
 }  // namespace workerd::api::public_beta


### PR DESCRIPTION
Give R2 Bindings support for creating/interacting with *SSE-C* encrypted objects.

Tests run on branch `mikkel/R2-2317`. Please merge once feature lands