### PR TITLE
Set SQLITE_LIMIT_FUNCTION_ARG to SQLite's normal default.

### DIFF
--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -809,7 +809,9 @@ void SqliteDatabase::setupSecurity() {
   // https://www.sqlite.org/limits.html#max_compound_select
   sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 5);
   sqlite3_limit(db, SQLITE_LIMIT_VDBE_OP, 25000);
-  sqlite3_limit(db, SQLITE_LIMIT_FUNCTION_ARG, 32);
+  // For SQLITE_LIMIT_FUNCTION_ARG we use the default instead of the "security" recommendation
+  // because there are too many valid use cases for large argument lists, especially json_object.
+  sqlite3_limit(db, SQLITE_LIMIT_FUNCTION_ARG, 127);
   sqlite3_limit(db, SQLITE_LIMIT_ATTACHED, 0);
   sqlite3_limit(db, SQLITE_LIMIT_LIKE_PATTERN_LENGTH, 50);
   sqlite3_limit(db, SQLITE_LIMIT_VARIABLE_NUMBER, 100);


### PR DESCRIPTION
People keep legitimately running up against this limit. It's not really clear what value it is providing, so let's just match the default.

Fixes #2412