### PR TITLE
Adds APIs to jsg::Lock to perform manual external memory accounting.

### DIFF
--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2085,6 +2085,20 @@ public:
     return *reinterpret_cast<Lock*>(v8Isolate->GetData(2));
   }
 
+  // Manually make adjustments to the amount of external memory reported to V8.
+  // This is useful when we have a large amount of external memory allocated that
+  // typically would not be visible to v8's memory tracking. In the future we hope
+  // to make most memory accounting automatic, making most direct uses of this
+  // API unnecessary but there will always be times when manual adjustments are
+  // necessary.
+  void adjustExternalMemory(ssize_t amount);
+
+  // Reports amount of external memory to be manually attributed to the isolate.
+  // When the returned kj::Own<void> is dropped, the amount will be subtracted
+  // from the isolate's external memory accounting. It is important that these
+  // be held onto only during the lifetime of the isolate.
+  kj::Own<void> getExternalMemoryAdjuster(size_t amount);
+
   Value parseJson(kj::ArrayPtr<const char> data);
   Value parseJson(v8::Local<v8::String> text);
   template <typename T>


### PR DESCRIPTION
While ultimately we want to explore more automatic memory accounting for jsg objects, there's still a need for manual adjustments. This PR adds two new APIs to `jsg::Lock` for manual external memory adjustments.

Why is this needed? Let's say you have a `jsg::Object` that holds onto an internal `kj::Array<kj::byte>` that is never wrapped in a `v8::ArrayBuffer` ... v8 won't never know about that memory allocation for that `kj::Array` unless we manually inform it.

```
class Foo: public jsg::Object {
public:
  Foo(jsg::Lock& js) : foo(kj::heapArray<int>(1024).attach(js.getExternalMemoryAdjuster(1024))) {}
private:
  kj::Array<kj::byte> foo;
}
```

Manual adjustment is imperfect and should only be used when the need is clear. We want to work on making the adjustments largely automatic when possible to do so, but for now this gives us a path forward to having better external memory tracking.

Note that when a `kj::Array<kj::byte>` is wrapped by a `v8::ArrayBuffer`, the `v8::ArrayBuffer` itself will handle reporting for us, so we don't need to manually adjust in those cases.