### PR TITLE
EW-8447 Fix CPU profiling

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2307,8 +2307,11 @@ struct MessageQueue {
 
 class Worker::Isolate::InspectorChannelImpl final: public v8_inspector::V8Inspector::Channel {
 public:
-  InspectorChannelImpl(kj::Own<const Worker::Isolate> isolateParam, kj::WebSocket& webSocket)
-      : ioHandler(webSocket), state(kj::heap<State>(this, kj::mv(isolateParam))) {
+  InspectorChannelImpl(kj::Own<const Worker::Isolate> isolateParam,
+      ExecutorNotifierPair isolateThreadExecutorNotifierPair,
+      kj::WebSocket& webSocket)
+      : ioHandler(kj::mv(isolateThreadExecutorNotifierPair), webSocket),
+        state(kj::heap<State>(this, kj::mv(isolateParam))) {
     ioHandler.connect(*this);
   }
 
@@ -2558,11 +2561,12 @@ private:
   // the InspectorChannelImpl and the InspectorClient.
   class WebSocketIoHandler final {
   public:
-    WebSocketIoHandler(kj::WebSocket& webSocket)
-        : webSocket(webSocket) {
+    WebSocketIoHandler(ExecutorNotifierPair isolateThreadExecutorNotifierPair, kj::WebSocket& webSocket)
+        : isolateThreadExecutor(kj::mv(isolateThreadExecutorNotifierPair.executor)),
+          incomingQueueNotifier(kj::mv(isolateThreadExecutorNotifierPair.notifier)),
+          webSocket(webSocket) {
       // Assume we are being instantiated on the InspectorService thread, the thread that will do
       // I/O for CDP messages. Messages are delivered to the InspectorChannelImpl on the Isolate thread.
-      incomingQueueNotifier = XThreadNotifier::create();
       outgoingQueueNotifier = XThreadNotifier::create();
     }
 
@@ -2595,7 +2599,20 @@ private:
     // Message pumping promise that should be evaluated on the InspectorService
     // thread.
     kj::Promise<void> messagePump() {
-      return receiveLoop().exclusiveJoin(dispatchLoop()).exclusiveJoin(transmitLoop());
+      // Although inspector I/O must happen on the InspectorService thread (to make sure breakpoints
+      // don't block inspector I/O), inspector messages must be actually dispatched on the Isolate
+      // thread. So, we run the dispatch loop on the Isolate thread.
+      //
+      // Note that the above comment is only really accurate in vanilla workerd. In the case of the
+      // internal Cloudflare Workers runtime, `isolateThreadExecutor` may actually refer to the
+      // current thread's `kj::Executor`. That's fine; calling `executeAsync()` on the current
+      // thread's executor just posts the task to the event loop, and everything works as expected.
+      auto dispatchLoopPromise = isolateThreadExecutor->executeAsync([this]() {
+        return dispatchLoop();
+      });
+      return receiveLoop()
+          .exclusiveJoin(kj::mv(dispatchLoopPromise))
+          .exclusiveJoin(transmitLoop());
     }
 
     void send(kj::String message) {
@@ -2636,6 +2653,7 @@ private:
       outgoingQueueNotifier->notify();
     }
 
+    // Must be called on the InspectorService thread.
     kj::Promise<void> receiveLoop() {
      for (;;) {
         auto message = co_await webSocket.receive(MAX_MESSAGE_SIZE);
@@ -2658,6 +2676,7 @@ private:
       }
     }
 
+    // Must be called on the Isolate thread.
     kj::Promise<void> dispatchLoop() {
       for (;;) {
         co_await incomingQueueNotifier->awaitNotification();
@@ -2667,6 +2686,7 @@ private:
       }
     }
 
+    // Must be called on the InspectorService thread.
     kj::Promise<void> transmitLoop() {
       for (;;) {
         co_await outgoingQueueNotifier->awaitNotification();
@@ -2693,10 +2713,17 @@ private:
       }
     }
 
+    // We need access to the Isolate thread's kj::Executor to run the inspector dispatch loop. This
+    // doesn't actually have to be an Own, because the Isolate thread will destroy the Isolate
+    // before it exits, but it doesn't hurt.
+    kj::Own<const kj::Executor> isolateThreadExecutor;
+
     kj::MutexGuarded<MessageQueue> incomingQueue;
+    // This XThreadNotifier must be created on the Isolate thread.
     kj::Own<XThreadNotifier> incomingQueueNotifier;
 
     kj::MutexGuarded<MessageQueue> outgoingQueue;
+    // This XThreadNotifier must be created on the InspectorService thread.
     kj::Own<XThreadNotifier> outgoingQueueNotifier;
 
     kj::WebSocket& webSocket;                 // only accessed on the InspectorService thread.
@@ -2846,11 +2873,17 @@ kj::Promise<void> Worker::Isolate::attachInspector(
   headers.set(controlHeaderId, "{\"ewLog\":{\"status\":\"ok\"}}");
   auto webSocket = response.acceptWebSocket(headers);
 
-  return attachInspector(timer, timerOffset, *webSocket)
+  // This `attachInspector()` overload is used by the internal Cloudflare Workers runtime, which has
+  // no concept of a single Isolate thread. Instead, it's okay for all inspector messages to be
+  // dispatched on the calling thread.
+  auto executorNotifierPair = ExecutorNotifierPair{};
+
+  return attachInspector(kj::mv(executorNotifierPair), timer, timerOffset, *webSocket)
       .attach(kj::mv(webSocket));
 }
 
 kj::Promise<void> Worker::Isolate::attachInspector(
+    ExecutorNotifierPair isolateThreadExecutorNotifierPair,
     kj::Timer& timer,
     kj::Duration timerOffset,
     kj::WebSocket& webSocket) const {
@@ -2871,7 +2904,10 @@ kj::Promise<void> Worker::Isolate::attachInspector(
 
     lockedSelf.impl->inspectorClient.setInspectorTimerInfo(timer, timerOffset);
 
-    auto channel = kj::heap<Worker::Isolate::InspectorChannelImpl>(kj::atomicAddRef(*this), webSocket);
+    auto channel = kj::heap<Worker::Isolate::InspectorChannelImpl>(
+        kj::atomicAddRef(*this),
+        kj::mv(isolateThreadExecutorNotifierPair),
+        webSocket);
     lockedSelf.currentInspectorSession = *channel;
     lockedSelf.impl->inspectorClient.setChannel(*channel);
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1164,10 +1164,12 @@ private:
 class Server::InspectorService final: public kj::HttpService, public kj::HttpServerErrorHandler {
 public:
   InspectorService(
+      ExecutorNotifierPair isolateThreadExecutorNotifierPair,
       kj::Timer& timer,
       kj::HttpHeaderTable::Builder& headerTableBuilder,
       InspectorServiceIsolateRegistrar& registrar)
-      : timer(timer),
+      : isolateThreadExecutorNotifierPair(kj::mv(isolateThreadExecutorNotifierPair)),
+        timer(timer),
         headerTable(headerTableBuilder.getFutureTable()),
         server(timer, headerTable, *this, kj::HttpServerSettings {
           .errorHandler = *this
@@ -1225,7 +1227,8 @@ public:
             auto webSocket = response.acceptWebSocket(responseHeaders);
             kj::Duration timerOffset = 0 * kj::MILLISECONDS;
             try {
-              co_return co_await ref->attachInspector(timer, timerOffset, *webSocket);
+              co_return co_await ref->attachInspector(
+                  isolateThreadExecutorNotifierPair.clone(), timer, timerOffset, *webSocket);
             } catch (...) {
               auto exception = kj::getCaughtExceptionAsKj();
               if (exception.getType() == kj::Exception::Type::DISCONNECTED) {
@@ -1343,6 +1346,7 @@ public:
   }
 
 private:
+  ExecutorNotifierPair isolateThreadExecutorNotifierPair;
   kj::Timer& timer;
   kj::HttpHeaderTable& headerTable;
   kj::HashMap<kj::String, kj::Own<const Worker::Isolate::WeakIsolateRef>> isolates;
@@ -3432,14 +3436,30 @@ uint startInspector(kj::StringPtr inspectorAddress,
   static constexpr uint DEFAULT_PORT = 9229;
   kj::MutexGuarded<uint> inspectorPort(UNASSIGNED_PORT);
 
-  kj::Thread thread([inspectorAddress, &inspectorPort, &registrar](){
+  // `startInspector()` is called on the Isolate thread. V8 requires CPU profiling to be started and
+  // stopped on the same thread which executes JavaScript -- that is, the Isolate thread -- which
+  // means we need to dispatch inspector messages on this thread. To help make that happen, we
+  // capture this thread's kj::Executor and create an XThreadNotifier tied to this thread here, and
+  // pass it into the InspectorService below. Later, when the InspectorService receives a WebSocket
+  // connection, it calls `Isolate::attachInspector()`, which starts a dispatch loop on the
+  // kj::Executor we create here. The InspectorService reads subsequent WebSocket inspector messages
+  // and feeds them to that dispatch loop via the XThreadNotifier we create here.
+  auto isolateThreadExecutorNotifierPair = ExecutorNotifierPair{};
+
+  // Start the InspectorService thread.
+  kj::Thread thread([inspectorAddress, &inspectorPort, &registrar,
+      isolateThreadExecutorNotifierPair = kj::mv(isolateThreadExecutorNotifierPair)]() mutable {
     kj::AsyncIoContext io = kj::setupAsyncIo();
 
     kj::HttpHeaderTable::Builder headerTableBuilder;
 
     // Create the special inspector service.
     auto inspectorService(
-        kj::heap<Server::InspectorService>(io.provider->getTimer(), headerTableBuilder, registrar));
+        kj::heap<Server::InspectorService>(
+            kj::mv(isolateThreadExecutorNotifierPair),
+            io.provider->getTimer(),
+            headerTableBuilder,
+            registrar));
     auto ownHeaderTable = headerTableBuilder.build();
 
     // Configure and start the inspector socket.

--- a/src/workerd/util/xthreadnotifier.h
+++ b/src/workerd/util/xthreadnotifier.h
@@ -42,4 +42,19 @@ private:
   kj::MutexGuarded<kj::PromiseCrossThreadFulfillerPair<void>> paf;
 };
 
+
+// Convenience struct for creating and passing around a kj::Executor and XThreadNotifier. The
+// default constructor creates a pair of the objects which are both tied to the current thread.
+struct ExecutorNotifierPair {
+  kj::Own<const kj::Executor> executor = kj::getCurrentThreadExecutor().addRef();
+  kj::Own<XThreadNotifier> notifier = XThreadNotifier::create();
+
+  ExecutorNotifierPair clone() {
+    return {
+      .executor = executor->addRef(),
+      .notifier = kj::atomicAddRef(*notifier),
+    };
+  }
+};
+
 }  // namespace workerd


### PR DESCRIPTION
When breakpoint debugging was introduced, it added a new thread, the InspectorService thread. This thread is necessary in order to continue performing WebSocket I/O while the Isolate is paused at a breakpoint. The feature _also_ moved inspector message dispatching onto this same InspectorService thread. For most inspector messages, this turns out to be benign, but not for CPU profiling start/stop messages: those must be dispatched on the thread which we desire to profile. The end result was that breakpoint debugging caused us to profile JavaScript on the InspectorService thread (e.g., anything executed on the Chrome Devtools console) instead of the Isolate thread, as originally intended.

This turns out to be relatively easy to fix, because breakpoint debugging would already dispatch inspector messages on the Isolate thread in a specific case: when the Isolate was paused at a breakpoint, meaning there are already exists some machinery to pass inspector messages across threads. This commit simply makes it so that all messages are passed to the Isolate thread for dispatching, instead of only when paused at a breakpoint.

We (obviously) do not have any tests for CPU profiling, or else we would have caught this issue much earlier. This commit does not add any such tests. Since we'd like to fix this issue sooner than later, my intent is to land this commit first and add tests later -- we will not close related tickets until such tests are implemented.

I have smoke tested both profiling and breakpoint debugging; both work with the change in this commit.