### PR TITLE
Use new "response stream disconnected" status for disconnections during proxying

### DIFF
--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -56,11 +56,20 @@ public:
   // the prewarm metric will be incremented.
   virtual void setIsPrewarm() {}
 
+  // Describes the source of a failure
+  enum class FailureSource: uint8_t {
+    // Failure occurred during deferred proxying
+    DEFERRED_PROXY,
+
+    // Failure occurred elsewhere
+    OTHER,
+  };
+
   // Report that the request failed with the given exception. This only needs to be called in
   // cases where the wrapper created with wrapWorkerInterface() wouldn't otherwise see the
   // exception, e.g. because it has been replaced with an HTTP error response or because it
   // occurred asynchronously.
-  virtual void reportFailure(const kj::Exception& e) {}
+  virtual void reportFailure(const kj::Exception& e, FailureSource source = FailureSource::OTHER) {}
 
   // Wrap the given WorkerInterface with a version that collects metrics. This method may only be
   // called once, and only one method call may be made to the returned interface.

--- a/src/workerd/io/outcome.capnp
+++ b/src/workerd/io/outcome.capnp
@@ -26,4 +26,5 @@ enum EventOutcome {
   canceled @7;
   exceededMemory @8;
   loadShed @9;
+  responseStreamDisconnected @10;
 }

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -17,6 +17,8 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "test-workerd"_kj;
     case AutogateKey::PYODIDE_LOAD_EXTERNAL:
       return "pyodide-load-external"_kj;
+    case AutogateKey::RESPONSE_STREAM_DISCONNECTED_STATUS:
+      return "response-stream-disconnected-status"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -14,6 +14,8 @@ namespace workerd::util {
 enum class AutogateKey {
   TEST_WORKERD,
   PYODIDE_LOAD_EXTERNAL,
+  // Enables reporting of disconnection during deferred proxying as a new status.
+  RESPONSE_STREAM_DISCONNECTED_STATUS,
   NumOfKeys // Reserved for iteration.
 };
 


### PR DESCRIPTION
Add new responseStreamDisconnected request status, to be used when an exception is thrown due to disconnection during deferred proxying, which is common when the client or server hangs up early, particularly when proxying websockets.  Should allow us to differentiate these cases from those where JS is still running, such that a thrown exception could still be caught and handled by the worker.

Also, add instrumentation to report failure during deferred proxying.
