### PR TITLE
[nfc] 08/10/24 Build/Docs cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To build `workerd`, you need:
   * LLD 15+ (e.g. package `lld-15`). The build may still succeed if a recent version of GNU gold or the system linker is installed, but lld is highly recommended for link performance.
   * `python3`, `python3-distutils`, and `tcl8.6`
 * On macOS:
-  * Xcode 15 installation (available on macOS 13 and higher)
+  * Xcode 15 installation (available on macOS 13 and higher). Full Xcode is required, the Xcode command line tools alone are not sufficient for building.
   * Homebrew installed `tcl-tk` package (provides Tcl 8.6)
 * On Windows:
   * Install [App Installer](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget)

--- a/src/workerd/api/encoding.h
+++ b/src/workerd/api/encoding.h
@@ -76,7 +76,7 @@ public:
 };
 
 // Decoder implementation that provides a fast-track for US-ASCII.
-class AsciiDecoder: public Decoder {
+class AsciiDecoder final: public Decoder {
 public:
   AsciiDecoder() = default;
   AsciiDecoder(AsciiDecoder&&) = default;
@@ -94,7 +94,7 @@ public:
 // Decoder implementation that uses ICU's built-in conversion APIs.
 // ICU's decoder is fairly comprehensive, covering the full range
 // of encodings required by the Encoding specification.
-class IcuDecoder: public Decoder {
+class IcuDecoder final: public Decoder {
 public:
   IcuDecoder(Encoding encoding, UConverter* converter, bool ignoreBom)
       : encoding(encoding), inner(converter), ignoreBom(ignoreBom), bomSeen(false) {}
@@ -126,7 +126,7 @@ private:
 
 // Implements the TextDecoder interface as prescribed by:
 // https://encoding.spec.whatwg.org/#interface-textdecoder
-class TextDecoder: public jsg::Object {
+class TextDecoder final: public jsg::Object {
 public:
   using DecoderImpl = kj::OneOf<AsciiDecoder, IcuDecoder>;
 
@@ -191,7 +191,7 @@ private:
 
 // Implements the TextEncoder interface as prescribed by:
 // https://encoding.spec.whatwg.org/#interface-textencoder
-class TextEncoder: public jsg::Object {
+class TextEncoder final: public jsg::Object {
 public:
   struct EncodeIntoResult {
     int read;

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -25,7 +25,7 @@ namespace workerd::api {
 
 struct QueueResponse;
 
-class Headers: public jsg::Object {
+class Headers final: public jsg::Object {
 private:
   template <typename T>
   struct IteratorState {
@@ -760,7 +760,7 @@ struct RequestInitializerDict {
   });
 };
 
-class Request: public Body {
+class Request final: public Body {
 public:
   enum class Redirect {
     FOLLOW,
@@ -985,7 +985,7 @@ private:
   }
 };
 
-class Response: public Body {
+class Response final: public Body {
 public:
   enum class BodyEncoding {
     AUTO,
@@ -1200,7 +1200,7 @@ private:
   }
 };
 
-class FetchEvent: public ExtendableEvent {
+class FetchEvent final: public ExtendableEvent {
 public:
   FetchEvent(jsg::Ref<Request> request)
       : ExtendableEvent("fetch"), request(kj::mv(request)),

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -7,7 +7,6 @@ wd_cc_library(
     srcs = glob(["**/*.c++"], exclude = ["**/*-test.c++"]),
     hdrs = glob(["**/*.h"]),
     implementation_deps = [
-        "//src/workerd/util:perfetto",
         "@capnp-cpp//src/kj/compat:kj-gzip",
         "@simdutf",
         "@nbytes",

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -48,7 +48,7 @@ kj::Promise<void> pumpTo(ReadableStreamSource& input, WritableStreamSink& output
 }
 
 // Modified from AllReader in kj/async-io.c++.
-class AllReader {
+class AllReader final {
 public:
   explicit AllReader(ReadableStreamSource& input, uint64_t limit)
       : input(input), limit(limit) {

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -12,7 +12,7 @@ namespace workerd::api {
 class ReadableStreamDefaultReader;
 class ReadableStreamBYOBReader;
 
-class ReaderImpl {
+class ReaderImpl final {
 public:
   ReaderImpl(ReadableStreamController::Reader& reader);
 

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -15,8 +15,10 @@ namespace workerd::api {
 using DefaultController = jsg::Ref<ReadableStreamDefaultController>;
 using ByobController = jsg::Ref<ReadableByteStreamController>;
 
+namespace {
 struct ValueReadable;
 struct ByteReadable;
+}
 
 // =======================================================================================
 // The Unlocked, Locked, ReaderLocked, and WriterLocked structs
@@ -80,7 +82,7 @@ public:
   }
 
 private:
-  class PipeLocked: public PipeController {
+  class PipeLocked final: public PipeController {
   public:
     explicit PipeLocked(Controller& inner, jsg::Ref<WritableStream> ref)
         : inner(inner), writableStreamRef(kj::mv(ref)) {}
@@ -652,7 +654,7 @@ jsg::Promise<ReadResult> deferControllerStateChange(
 // jsg::Ref<ReadableStreamDefaultController> or jsg::Ref<ReadableByteStreamController>.
 // These are the objects that are actually passed on to the user-code's Underlying Source
 // implementation.
-class ReadableStreamJsController: public ReadableStreamController {
+class ReadableStreamJsController final: public ReadableStreamController {
 public:
   using ReadableLockImpl = ReadableLockImpl<ReadableStreamJsController>;
 
@@ -791,7 +793,7 @@ private:
 // The WritableStreamJsController provides the implementation of custom
 // WritableStream's backed by a user-code provided Underlying Sink. The implementation
 // is fairly complicated and defined entirely by the streams specification.
-class WritableStreamJsController: public WritableStreamController {
+class WritableStreamJsController final: public WritableStreamController {
 public:
   using WritableLockImpl = WritableLockImpl<WritableStreamJsController>;
 
@@ -1680,7 +1682,6 @@ struct ReadableState {
     return ReadableState(controller.addRef(), consumer->clone(js, listener), owner);
   }
 };
-}  // namespace
 
 struct ValueReadable final: private api::ValueQueue::ConsumerImpl::StateListener {
 
@@ -1952,6 +1953,7 @@ struct ByteReadable final: private api::ByteQueue::ConsumerImpl::StateListener {
     return state.map([](State& state) { return state.controller.addRef(); });
   }
 };
+}  // namespace
 
 // =======================================================================================
 

--- a/src/workerd/api/tests/encoding-test.js
+++ b/src/workerd/api/tests/encoding-test.js
@@ -5,8 +5,8 @@ import {
   ok,
 } from 'node:assert';
 
-// Test for the Event and EventTarget standard Web API implementations.
-// The implementation for these are in api/basics.{h|c++}
+// Test for the Encoding standard Web API implementation.
+// The implementation for these are in api/encoding.{h|c++}
 
 function decodeStreaming(decoder, input) {
   // Test truncation behavior while streaming by feeding the decoder a single byte at a time.

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -95,7 +95,7 @@ private:
 // heuristic approximation, we attribute each subrequest (and all other forms of resource
 // usage) to the "current" incoming request, which is defined as the newest request that hasn't
 // already completed.
-class IoContext_IncomingRequest {
+class IoContext_IncomingRequest final {
 public:
   IoContext_IncomingRequest(kj::Own<IoContext> context,
                             kj::Own<IoChannelFactory> ioChannelFactory,

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -56,6 +56,7 @@ namespace workerd::server {
 
 using api::pyodide::PythonConfig;
 
+namespace {
 JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
   // Declares the listing of host object types and structs that the jsg
   // automatic type mapping will understand. Each of the various
@@ -124,8 +125,9 @@ static PythonConfig defaultConfig {
   .createSnapshot = false,
   .createBaselineSnapshot = false,
 };
+}
 
-struct WorkerdApi::Impl {
+struct WorkerdApi::Impl final {
   kj::Own<CompatibilityFlags::Reader> features;
   kj::Maybe<kj::Own<jsg::modules::ModuleRegistry>> maybeOwnedModuleRegistry;
   JsgWorkerdIsolate jsgIsolate;
@@ -436,6 +438,7 @@ kj::Maybe<jsg::ModuleRegistry::ModuleInfo> WorkerdApi::tryCompileModule(
   KJ_UNREACHABLE;
 }
 
+namespace {
 kj::Path getPyodideBundleFileName(kj::StringPtr version) {
   return kj::Path(kj::str("pyodide-", version, ".capnp.bin"));
 }
@@ -521,6 +524,7 @@ bool fetchPyodideBundle(const api::pyodide::PythonConfig& pyConfig, kj::StringPt
 
   return true;
 
+}
 }
 
 void WorkerdApi::compileModules(

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -65,6 +65,7 @@
 #include <workerd/util/use-perfetto-categories.h>
 
 namespace workerd::server {
+namespace {
 
 static kj::StringPtr getVersionString() {
   static const kj::String result = kj::str("workerd ", SUPPORTED_COMPATIBILITY_DATE);
@@ -609,7 +610,7 @@ private:
 
 // =======================================================================================
 
-class CliMain: public SchemaFileImpl::ErrorReporter {
+class CliMain final: public SchemaFileImpl::ErrorReporter {
 public:
   CliMain(kj::ProcessContext& context, char** argv)
       : context(context), argv(argv),
@@ -1513,6 +1514,7 @@ private:
 #endif
 };
 
+} // namespace
 }  // namespace workerd::server
 
 int main(int argc, char* argv[]) {

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -1,9 +1,6 @@
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//:build/cc_ast_dump.bzl", "cc_ast_dump")
-load("//:build/run_binary_target.bzl", "run_binary_target")
-load("//:build/wd_cc_binary.bzl", "wd_cc_binary")
-load("//:build/wd_cc_library.bzl", "wd_cc_library")
 
 # ========================================================================================
 # Parameter Name Extractor
@@ -21,9 +18,9 @@ cc_ast_dump(
     }),
     deps = [
         "//src/workerd/api:html-rewriter",
+        "//src/workerd/api/node",
         "//src/workerd/io",
         "//src/workerd/jsg",
-        "//src/workerd/api/node:node",
         "@capnp-cpp//src/capnp",
     ],
 )

--- a/tools/windows/install-deps.bat
+++ b/tools/windows/install-deps.bat
@@ -73,11 +73,9 @@ call :AddToUserPathInEnvironment C:\msys64\usr\bin
 
 echo.
 echo.* Step 7: Install LLVM compiler toolchain.
-@rem workerd is tied to 16.0.6 for the time being (https://github.com/cloudflare/workerd/pull/1092).
-winget install "LLVM" --version 16.0.6
-@rem Work around for clang / bazel not agreeing on install location, will be fixed by
-@rem https://github.com/bazelbuild/bazel/pull/1939.
-move "C:\Program Files\LLVM\lib\clang\16" "C:\Program Files\LLVM\lib\clang\16.0.6"
+@rem The MSVC build frequently breaks in some ways when the LLVM version is updated, we may have to
+@rem manually install a different version again soon.
+@rem winget install "LLVM" --version 18.1.8
 
 echo.
 echo.* Step 8: Install bazelisk as %LOCALAPPDATA%\Programs\bazelisk\bazel.exe.


### PR DESCRIPTION
Cleaning out a number of smaller changes I had stashed for a while.

- Emphasize that building on macOS requires Xcode.
- Clean up Windows dependency script, the workaround is no longer needed.
- Fix cargo-culted comment in encoding-test.js
- Drop unused perfetto dependency for node target
- Mark a few classes as final, expand anonymous namespace usage.