### PR TITLE
Lazily initialize _cf_KV sqlite table.

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -264,6 +264,7 @@ async function test(state) {
     () => sql.exec('CREATE TABLE _cf_invalid (name TEXT)'),
     /not authorized/
   )
+  storage.put("blah", 123);  // force creation of _cf_KV table
   assert.throws(
     () => sql.exec('SELECT * FROM _cf_KV'),
     /access to _cf_KV.key is prohibited/

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1862,6 +1862,10 @@ public:
                 auto db = kj::heap<SqliteDatabase>(*as,
                     kj::Path({d.uniqueKey, kj::str(idPtr, ".sqlite")}),
                     kj::WriteMode::CREATE | kj::WriteMode::MODIFY | kj::WriteMode::CREATE_PARENT);
+
+                // Before we do anything, make sure the database is in WAL mode.
+                db->run("PRAGMA journal_mode=WAL;");
+
                 return kj::heap<ActorSqlite>(kj::mv(db), outputGate,
                     []() -> kj::Promise<void> { return kj::READY_NOW; },
                     *sqliteHooks).attach(kj::mv(sqliteHooks));

--- a/src/workerd/util/sqlite-kv.c++
+++ b/src/workerd/util/sqlite-kv.c++
@@ -6,30 +6,50 @@
 
 namespace workerd {
 
-SqliteKv::SqliteKv(SqliteDatabase& db, bool): db(db) {}
+SqliteKv::SqliteKv(SqliteDatabase& db) {
+  if (db.run("SELECT name FROM sqlite_master WHERE type='table' AND name='_cf_KV'").isDone()) {
+    // The _cf_KV table doesn't exist. Defer initialization.
+    state = Uninitialized { db };
+  } else {
+    // The KV table was initialized in the past. We can go ahead and prepare our statements.
+    // (We don't call ensureInitialized() here because the `CREATE TABLE IF NOT EXISTS` query it
+    // executes would be redundant.)
+    state = Initialized(db);
+  }
+}
 
-SqliteDatabase& SqliteKv::ensureInitialized(SqliteDatabase& db) {
-  db.run(R"(
-    CREATE TABLE IF NOT EXISTS _cf_KV (
-      key TEXT PRIMARY KEY,
-      value BLOB
-    ) WITHOUT ROWID;
-  )");
+SqliteKv::Initialized& SqliteKv::ensureInitialized() {
+  KJ_SWITCH_ONEOF(state) {
+    KJ_CASE_ONEOF(uninitialized, Uninitialized) {
+      auto& db = uninitialized.db;
 
-  return db;
+      db.run(R"(
+        CREATE TABLE IF NOT EXISTS _cf_KV (
+          key TEXT PRIMARY KEY,
+          value BLOB
+        ) WITHOUT ROWID;
+      )");
+
+      return state.init<Initialized>(db);
+    }
+    KJ_CASE_ONEOF(initialized, Initialized) {
+      return initialized;
+    }
+  }
+  KJ_UNREACHABLE;
 }
 
 void SqliteKv::put(KeyPtr key, ValuePtr value) {
-  stmtPut.run(key, value);
+  ensureInitialized().stmtPut.run(key, value);
 }
 
 bool SqliteKv::delete_(KeyPtr key) {
-  auto query = stmtDelete.run(key);
+  auto query = ensureInitialized().stmtDelete.run(key);
   return query.changeCount() > 0;
 }
 
 uint SqliteKv::deleteAll() {
-  auto query = stmtDeleteAll.run();
+  auto query = ensureInitialized().stmtDeleteAll.run();
   return query.changeCount();
 }
 

--- a/src/workerd/util/sqlite-kv.c++
+++ b/src/workerd/util/sqlite-kv.c++
@@ -9,9 +9,6 @@ namespace workerd {
 SqliteKv::SqliteKv(SqliteDatabase& db, bool): db(db) {}
 
 SqliteDatabase& SqliteKv::ensureInitialized(SqliteDatabase& db) {
-  // TODO(sqlite): Do this automatically at a lower layer?
-  db.run("PRAGMA journal_mode=WAL;");
-
   db.run(R"(
     CREATE TABLE IF NOT EXISTS _cf_KV (
       key TEXT PRIMARY KEY,


### PR DESCRIPTION
This way, if a Durable Object never actually uses the KV storage interface -- only uses SQL -- we'll never create the table and can skip preparing statements for it.

This will also make it easier for the edge runtime to clean up actors that never had data.