### PR TITLE
Use V8's zlib

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -282,34 +282,12 @@ http_archive(
 # the build process. To update the dependency, update the reference commit in
 # rust-deps/BUILD.bazel and run `bazel run //rust-deps:crates_vendor -- --repin`
 
-# Based on https://github.com/bazelbuild/bazel/blob/master/third_party/zlib/BUILD.
-_zlib_build = """
-cc_library(
+git_repository(
     name = "zlib",
-    srcs = glob(["*.c"]),
-    hdrs = glob(["*.h"]),
-    includes = ["."],
-    # Workaround for zlib warnings and mac compilation. Some issues were resolved in v1.3, but there are still implicit function declarations.
-    copts = [
-        "-w",
-        "-Dverbose=-1",
-    ] + select({
-        "@platforms//os:linux": [ "-Wno-implicit-function-declaration" ],
-        "@platforms//os:macos": [ "-Wno-implicit-function-declaration" ],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-)
-"""
-
-http_archive(
-    name = "zlib",
-    build_file_content = _zlib_build,
-    sha256 = "38ef96b8dfe510d42707d9c781877914792541133e1870841463bfa73f883e32",
-    strip_prefix = "zlib-1.3.1",
-    # Using the .tar.xz artifact from the release page – for many other dependencies we use a
-    # snapshot based on the tag of a release instead.
-    urls = ["https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.xz"],
+    build_file = "//:build/BUILD.zlib",
+    # Must match the version used by v8
+    commit = "c2469fdd73f192383d2d94288da0ff5b9a3869f5",
+    remote = "https://chromium.googlesource.com/chromium/src/third_party/zlib.git",
 )
 
 http_file(

--- a/build/BUILD.zlib
+++ b/build/BUILD.zlib
@@ -1,0 +1,194 @@
+# This config closely follows the original GN build file
+# Ref: https://chromium.googlesource.com/chromium/src/third_party/zlib.git/+/refs/heads/main/BUILD.gn
+# The main difference is that we don't set ZLIB_DLL because it messes things up on Windows
+
+package(default_visibility = ["//visibility:public"])
+
+zlib_warnings = [
+    "-Wno-incompatible-pointer-types",
+    "-Wunused-variable",
+]
+
+cc_library(
+    name = "zlib_common_headers",
+    hdrs = [
+        "chromeconf.h",
+        "deflate.h",
+        "inffast.h",
+        "inffixed.h",
+        "inflate.h",
+        "inftrees.h",
+        "zconf.h",
+        "zlib.h",
+        "zutil.h",
+    ],
+    defines = ["ZLIB_IMPLEMENTATION"],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "x86_defines",
+    defines = select({
+        "@platforms//os:windows": ["X86_WINDOWS"],
+        "//conditions:default": ["X86_NOT_WINDOWS"],
+    }),
+)
+
+cc_library(
+    name = "zlib_adler32_simd",
+    srcs = [
+        "adler32_simd.c",
+        "adler32_simd.h",
+    ],
+    copts = select({
+        "@platforms//cpu:x86_64": ["-mssse3"],
+        "//conditions:default": [],
+    }),
+    defines = select({
+        "@platforms//cpu:x86_64": ["ADLER32_SIMD_SSSE3"],
+        "@platforms//cpu:aarch64": ["ADLER32_SIMD_NEON"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":zlib_common_headers"] + select({
+        "@platforms//cpu:x86_64": [":x86_defines"],
+        "//conditions:default": [],
+    }),
+)
+
+cc_library(
+    name = "zlib_arm_crc32",
+    srcs = [
+        "crc32_simd.c",
+        "crc32_simd.h",
+    ],
+    defines = ["CRC32_ARMV8_CRC32"] + select({
+        "@platforms//os:linux": ["ARMV8_OS_LINUX"],
+        "@platforms//os:macos": ["ARMV8_OS_MACOS"],
+        "@platforms//os:windows": ["ARMV8_OS_WINDOWS"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":zlib_common_headers"],
+)
+
+cc_library(
+    name = "zlib_inflate_chunk_simd",
+    srcs = [
+        "contrib/optimizations/chunkcopy.h",
+        "contrib/optimizations/inffast_chunk.c",
+        "contrib/optimizations/inffast_chunk.h",
+        "contrib/optimizations/inflate.c",
+    ],
+    copts = zlib_warnings,
+    defines = select({
+        "@platforms//cpu:x86_64": [
+            "INFLATE_CHUNK_SIMD_SSE2",
+            "INFLATE_CHUNK_READ_64LE",
+        ],
+        "@platforms//cpu:aarch64": [
+            "INFLATE_CHUNK_SIMD_NEON",
+            "INFLATE_CHUNK_READ_64LE",
+        ],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":zlib_common_headers"],
+)
+
+cc_library(
+    name = "zlib_crc32_simd",
+    srcs = [
+        "crc32_simd.c",
+        "crc32_simd.h",
+        "crc_folding.c",
+    ],
+    copts = [
+        "-msse4.2",
+        "-mpclmul",
+    ],
+    defines = select({
+        "@platforms//cpu:x86_64": ["CRC32_SIMD_SSE42_PCLMUL"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":zlib_common_headers"],
+)
+
+cc_library(
+    name = "zlib_slide_hash_simd",
+    srcs = [
+        "slide_hash_simd.h",
+    ],
+    defines = select({
+        "@platforms//cpu:x86_64": ["DEFLATE_SLIDE_HASH_SSE2"],
+        "@platforms//cpu:aarch64": ["DEFLATE_SLIDE_HASH_NEON"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":zlib_common_headers"],
+)
+
+filegroup(
+    name = "inflate_c",
+    srcs = [
+        "inflate.c",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "zlib_files",
+    srcs = [
+        "adler32.c",
+        "chromeconf.h",
+        "compress.c",
+        "contrib/optimizations/insert_string.h",
+        "cpu_features.c",
+        "cpu_features.h",
+        "crc32.c",
+        "crc32.h",
+        "deflate.c",
+        "deflate.h",
+        "gzclose.c",
+        "gzguts.h",
+        "gzlib.c",
+        "gzread.c",
+        "gzwrite.c",
+        "infback.c",
+        "inffast.c",
+        "inffast.h",
+        "inffixed.h",
+        "inflate.h",
+        "inftrees.c",
+        "inftrees.h",
+        "trees.c",
+        "trees.h",
+        "uncompr.c",
+        "zconf.h",
+        "zlib.h",
+        "zutil.c",
+        "zutil.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "zlib",
+    srcs = [":zlib_files"] + select({
+        "@platforms//cpu:x86_64": [],
+        "@platforms//cpu:aarch64": [],
+        "//conditions:default": [":inflate_c"],
+    }),
+    copts = zlib_warnings,
+    defines = select({
+        "@platforms//cpu:x86_64": [],
+        "@platforms//cpu:aarch64": [],
+        "//conditions:default": ["CPU_NO_SIMD"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":zlib_adler32_simd",
+        ":zlib_inflate_chunk_simd",
+        ":zlib_slide_hash_simd",
+    ] + select({
+        "@platforms//cpu:x86_64": [":zlib_crc32_simd"],
+        "@platforms//cpu:aarch64": [":zlib_arm_crc32"],
+    }),
+)


### PR DESCRIPTION
This PR changes the source of zlib to match what V8 is using, so that we don't have version conflicts between workerd and the internal edgeworker repo.

zlib is built from source. The build config is a translation from the BUILD.gn file into bazel syntax.

Note that this is a bit of a different build process from edgeworker, which uses precompiled binaries from v8 for zlib.
