### PR TITLE
Implements globalThis.Cloudflare.compatibilityFlags API

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -110,6 +110,22 @@ public:
   }
 };
 
+// Exposed as a global to provide access to certain Cloudflare-specific
+// configuration details. This is not a standard API and great care should
+// be taken when deciding to expose new properties or methods here.
+class Cloudflare: public jsg::Object {
+public:
+  // Return an object containing the state of all compatibility flags known to the runtime.
+  jsg::JsObject getCompatibilityFlags(jsg::Lock& js);
+
+  JSG_RESOURCE_TYPE(Cloudflare) {
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(compatibilityFlags, getCompatibilityFlags);
+
+    JSG_TS_OVERRIDE({ readonly compatibilityFlags: Record<string, boolean>;
+    });
+  }
+};
+
 class PromiseRejectionEvent: public Event {
 public:
   PromiseRejectionEvent(
@@ -507,6 +523,10 @@ public:
     return jsg::alloc<Performance>();
   }
 
+  jsg::Ref<Cloudflare> getCloudflare() {
+    return jsg::alloc<Cloudflare>();
+  }
+
   // The origin is unknown, return "null" as described in
   // https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque.
   kj::StringPtr getOrigin() {
@@ -570,6 +590,7 @@ public:
     JSG_LAZY_INSTANCE_PROPERTY(caches, getCaches);
     JSG_LAZY_INSTANCE_PROPERTY(scheduler, getScheduler);
     JSG_LAZY_INSTANCE_PROPERTY(performance, getPerformance);
+    JSG_LAZY_INSTANCE_PROPERTY(Cloudflare, getCloudflare);
     JSG_READONLY_INSTANCE_PROPERTY(origin, getOrigin);
 
     JSG_NESTED_TYPE(Event);
@@ -824,6 +845,6 @@ private:
   api::WorkerGlobalScope, api::ServiceWorkerGlobalScope, api::TestController,                      \
       api::ExecutionContext, api::ExportedHandler,                                                 \
       api::ServiceWorkerGlobalScope::StructuredCloneOptions, api::PromiseRejectionEvent,           \
-      api::Navigator, api::Performance, api::AlarmInvocationInfo, api::Immediate
+      api::Navigator, api::Performance, api::AlarmInvocationInfo, api::Immediate, api::Cloudflare
 // The list of global-scope.h types that are added to worker.c++'s JSG_DECLARE_ISOLATE_TYPE
 }  // namespace workerd::api

--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -12,6 +12,7 @@
 #include <workerd/jsg/modules-new.h>
 #include <capnp/dynamic.h>
 #include <node/node.capnp.h>
+#include <workerd/io/compatibility-date.h>
 
 namespace workerd::api::node {
 

--- a/src/workerd/api/tests/compat-flags-test.js
+++ b/src/workerd/api/tests/compat-flags-test.js
@@ -1,0 +1,58 @@
+import { ok, strictEqual, throws } from 'node:assert';
+
+const { compatibilityFlags } = globalThis.Cloudflare;
+ok(Object.isSealed(compatibilityFlags));
+ok(Object.isFrozen(compatibilityFlags));
+ok(!Object.isExtensible(compatibilityFlags));
+
+// It shuld be possible to shadow the Cloudflare global
+const Cloudflare = 1;
+strictEqual(Cloudflare, 1);
+
+export const compatFlagsTest = {
+  test() {
+    // The compatibility flags object should be sealed, frozen, and not extensible.
+    throws(() => (compatibilityFlags.no_nodejs_compat_v2 = '...'));
+    throws(() => (compatibilityFlags.not_a_real_compat_flag = '...'));
+    throws(() => {
+      delete compatibilityFlags['nodejs_compat_v2'];
+    });
+
+    // The compatibility flags object should have no prototype.
+    strictEqual(Object.getPrototypeOf(compatibilityFlags), null);
+
+    // The compatibility flags object should have the expected properties...
+    // That is... the only keys that should appear on the compatibilityFlags
+    // object are the enable flags.
+    //
+    // If a key does not appear, it can mean one of three things:
+    // 1. It is a disable flag.
+    // 2. It is an experimental flag and the experimental option is not set.
+    // 3. The flag does not exist.
+    //
+    // At this level we make no attempt to differentiate between these cases
+    ok(compatibilityFlags['nodejs_compat_v2']);
+    ok(compatibilityFlags['url_standard']);
+
+    ok(!compatibilityFlags['no_nodejs_compat_v2']);
+    ok(!compatibilityFlags['url_original']);
+    strictEqual(compatibilityFlags['no_nodejs_compat_v2'], undefined);
+    strictEqual(compatibilityFlags['url_original'], undefined);
+
+    // Since we are not specifying the experimental flag, experimental flags should
+    // not be included in the output.
+    strictEqual(compatibilityFlags['durable_object_rename'], undefined);
+    strictEqual('durable_object_rename' in compatibilityFlags, false);
+
+    // If a flag does not exist, the value will be undefined.
+    strictEqual(compatibilityFlags['not-a-real-compat-flag'], undefined);
+    strictEqual('not-a-real-compat-flag' in compatibilityFlags, false);
+
+    // The compatibility flags object should have the expected keys.
+    const keys = Object.keys(compatibilityFlags);
+    ok(keys.includes('nodejs_compat_v2'));
+    ok(keys.includes('url_standard'));
+    ok(!keys.includes('url_original'));
+    ok(!keys.includes('not-a-real-compat-flag'));
+  },
+};

--- a/src/workerd/api/tests/compat-flags-test.wd-test
+++ b/src/workerd/api/tests/compat-flags-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "compat-flags-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "compat-flags-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat_v2"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/features.h
+++ b/src/workerd/io/features.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <workerd/io/compatibility-date.capnp.h>
+#include <workerd/io/compatibility-date.h>
 #include <workerd/jsg/jsg.h>
 
 namespace workerd {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2541,6 +2541,7 @@ public:
   JsSymbol symbolShared(kj::StringPtr) KJ_WARN_UNUSED_RESULT;
   JsSymbol symbolInternal(kj::StringPtr) KJ_WARN_UNUSED_RESULT;
   JsObject obj() KJ_WARN_UNUSED_RESULT;
+  JsObject objNoProto() KJ_WARN_UNUSED_RESULT;
   JsMap map() KJ_WARN_UNUSED_RESULT;
   JsValue external(void*) KJ_WARN_UNUSED_RESULT;
   JsValue error(kj::StringPtr message) KJ_WARN_UNUSED_RESULT;

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -341,6 +341,7 @@ public:
 
   void set(Lock& js, const JsValue& name, const JsValue& value);
   void set(Lock& js, kj::StringPtr name, const JsValue& value);
+  void setReadOnly(Lock& js, kj::StringPtr name, const JsValue& value);
   JsValue get(Lock& js, const JsValue& name) KJ_WARN_UNUSED_RESULT;
   JsValue get(Lock& js, kj::StringPtr name) KJ_WARN_UNUSED_RESULT;
 
@@ -377,6 +378,7 @@ public:
   using JsBase<v8::Object, JsObject>::JsBase;
 
   void recursivelyFreeze(Lock&);
+  void seal(Lock&);
   JsObject jsonClone(Lock&);
 };
 


### PR DESCRIPTION
A simple built-in API for determining if a given compat flag is set.

```
const { compatibilityFlags } = globalThis.Cloudflare || {};

console.log(compatibilityFlags['url_standard']); 
```

Internal discussion wiki: (sorry external folks, you won't be able to see this) https://wiki.cfdata.org/display/~jsnell/Exposing+active+compat+flags+to+workers