### PR TITLE
bazelrc: Add incompatible_strict_action_env to prevent  bazel cache invalidation when switching terminals

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,6 +26,9 @@ build --nolegacy_external_runfiles
 # Flip this early to avoid breaking compatibility once it becomes the default.
 build --incompatible_disallow_empty_glob
 
+# Prevents bazel cache invalidation when switching terminals
+build --incompatible_strict_action_env
+
 # Dawn tint build flags
 build --@dawn//src/tint:tint_build_glsl_writer=False
 build --@dawn//src/tint:tint_build_glsl_validator=False


### PR DESCRIPTION
This change was already applied to the internal repo.  Adding it here will make it more convenient to work on worked, as well.