### PR TITLE
Do not allow code with warnings to pass CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,6 +43,7 @@ build --@dawn//src/tint:tint_build_wgsl_writer=True
 # Our dependencies (ICU, zlib, etc.) produce a lot of these warnings, so we disable them. Depending
 # on the clang version, zlib either produces warnings for -Wdeprecated-non-prototype or does not
 # have that option, so disable -Wunknown-warning-option there too.
+build --per_file_copt='external@-Wno-error'
 build --per_file_copt='external/v8@-Wno-deprecated-declarations'
 build --per_file_copt='external/com_googlesource_chromium_icu@-Wno-ambiguous-reversed-operator,-Wno-deprecated-declarations'
 build --host_per_file_copt='external/com_googlesource_chromium_icu@-Wno-ambiguous-reversed-operator,-Wno-deprecated-declarations'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,9 @@ jobs:
           sudo apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev libclang-rt-16-dev
           echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang --action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
           echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang --host_action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
+          echo "build:linux --copt='-Werror'" >> .bazelrc
+          echo "build:linux --copt='-Wno-error=#warnings'" >> .bazelrc
+          echo "build:linux --copt='-Wno-error=deprecated-declarations'" >> .bazelrc
           sed -i -e "s%llvm-symbolizer%/usr/lib/llvm-16/bin/llvm-symbolizer%" .bazelrc
       - name: Setup macOS
         if: matrix.os.name == 'macOS'

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1602,7 +1602,8 @@ Worker::Worker(kj::Own<const Script> scriptParam,
                 }
                 KJ_CASE_ONEOF(limitError, kj::Exception) { }
               }
-            }
+            } else {} // Added to suppress a compiler warning
+
             startupMetrics->done();
           } catch (const kj::Exception& e) {
             lock.throwException(kj::cp(e));


### PR DESCRIPTION
This PR enables `-Werror`, when building in the CI. As a result, warnings are treated as a fatal error. This ensures that warnings will be addressed, and won't pile up over time in our codebase. Here are some specific details about the configuration.

* Warnings aren't fatal locally. This is for convenience while working on code.
* Warnings aren't fatal in `external/`. This is because these warnings come from our dependencies, and need to be fixed there.
* Deprecation warnings and `#warning` are not fatal. They're just here to give us a heads up that something will need to be fixed eventually.
* Warnings are only fatal on Linux builds. I didn't want to make this a maddening quest of fixing macOS, Windows AND Linux compiler warnings every time we do a PR.
