### PR TITLE
More incremental work on new module registry impl

### DIFF
--- a/src/workerd/jsg/modules-new.c++
+++ b/src/workerd/jsg/modules-new.c++
@@ -392,6 +392,7 @@ public:
       // Evaluate the module and grab the default export from the module namespace.
       auto promise =
           check(entry.module.evaluate(js, module, observer, maybeEvalCallback)).As<v8::Promise>();
+      js.runMicrotasks();
 
       switch (promise->State()) {
         case v8::Promise::kFulfilled: {


### PR DESCRIPTION
Adds in the part about ensuring ESM evaluation occurs outside of the IoContext if there is one.

Some context for newcomers: I've been slowly working on a new implementation of the module registry in workerd. This is a continuation of that work. Here I implement the bits of the code necessary to ensure that the module is evaluated outside of the IoContext if there is one.

This code currently is not used in production.