### PR TITLE
Add Pyodide development compat flag

### DIFF
--- a/src/workerd/io/compatibility-date.c++
+++ b/src/workerd/io/compatibility-date.c++
@@ -340,6 +340,10 @@ kj::Maybe<PythonSnapshotRelease::Reader> getPythonSnapshotRelease(
       continue;
     }
 
+    if (field.pythonSnapshotRelease.getPyodide() == "dev"_kj) {
+      return field.pythonSnapshotRelease;
+    }
+
     // We pick the flag with the highest ordinal value that is enabled and has a
     // pythonSnapshotRelease annotation.
     //

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -429,6 +429,12 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Python modules are restricted in EWC.
   #
   # WARNING: Python Workers are still an experimental feature and thus subject to change.
+  pythonWorkersDevPyodide @58 :Bool
+    $compatEnableFlag("python_workers_development")
+    $pythonSnapshotRelease(pyodide = "dev", pyodideRevision = "dev",
+          packages = "2024-03-01", backport = 0)
+    $experimental;
+  # Enables Python Workers and uses the bundle from the Pyodide source directory directly. For testing.
 
   fetcherNoGetPutDelete @44 :Bool
       $compatEnableFlag("fetcher_no_get_put_delete")


### PR DESCRIPTION
Garrett already added the logic to consume this flag in workerd. We will want to test with the flag both on and off. Downstream we also need some additional code to consume the flag.