### PR TITLE
docs: clarify ExternalServer DNS resolution behavior

### DIFF
--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -652,7 +652,9 @@ struct ExternalServer {
   # - "[1234:5678::abcd]:80": Connect to the given IPv6 address and port.
   # - "unix:/path/to/socket": Connect to the given Unix Domain socket by path.
   # - "unix-abstract:name": On Linux, connect to the given "abstract" Unix socket name.
-  # - "example.com:80": Perform a DNS lookup to determine the address, and then connect to it.
+  # - "example.com:80": Perform a DNS lookup once on startup to determine the address, and then
+  #    connect to it. (If you need to track changes to DNS responses over time, use a Network
+  #    instead.)
   #
   # (These are the formats supported by KJ's parseAddress().)
 


### PR DESCRIPTION
From reading the source code of workerd and KJ, I can see that ExternalServer does DNS resolution only once ever. This was certainly surprising to me, and I suspect it would be a surprise to many, as ExternalServer is the seemingly most natural way to get a binding to a particular networked service, but it is in fact only suitable to look up domain names that are guaranteed to not change over the lifetime of the workerd service on which it is configured, like container sidecars.

So, be more explicit about the behavior in the documentation.