### PR TITLE
fix pnpm-setup workflow on release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,10 +175,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          # This version will be different depending on the value of `packageManager` field
-          # in package.json file with the setting in `.npmrc` file.
-          version: latest
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
It seems `version` field is not required whenever there is a `packageManager` field in `package.json`. Shout out to @npaun for finding the bug. Ref: https://github.com/pnpm/action-setup?tab=readme-ov-file#version