### PR TITLE
NFC Fix comment in bench-tools.h

### DIFF
--- a/src/workerd/tests/bench-tools.h
+++ b/src/workerd/tests/bench-tools.h
@@ -13,15 +13,16 @@
 // enough to not need ns precision.
 #define WD_BENCHMARK(X) BENCHMARK(X)->Unit(benchmark::kMicrosecond)
 
-/* Macro inspired by KJ_TEST() to enable benchmarking without requiring the benchmark::State */                                            \
-/* argument and make it easy to convert tests to benchmarks. */ /* Make sure the linker fails if tests are not in anonymous namespaces. */ \
-#define WD_BENCH(description)                                                                                                              \
-  extern int KJ_CONCAT(YouMustWrapTestsInAnonymousNamespace, __COUNTER__) KJ_UNUSED;                                                       \
-  void KJ_UNIQUE_NAME(Bench)();                                                                                                            \
-  void KJ_UNIQUE_NAME(BenchImpl)(benchmark::State & state) {                                                                               \
-    for (auto _: state) {                                                                                                                  \
-      KJ_UNIQUE_NAME(Bench)();                                                                                                             \
-    }                                                                                                                                      \
-  }                                                                                                                                        \
-  WD_BENCHMARK(KJ_UNIQUE_NAME(BenchImpl))->Name(description);                                                                              \
+// Macro inspired by KJ_TEST() to enable benchmarking without requiring the benchmark::State
+// argument and make it easy to convert tests to benchmarks. Make sure the linker fails if tests are
+// not in anonymous namespaces.
+#define WD_BENCH(description)                                                                      \
+  extern int KJ_CONCAT(YouMustWrapTestsInAnonymousNamespace, __COUNTER__) KJ_UNUSED;               \
+  void KJ_UNIQUE_NAME(Bench)();                                                                    \
+  void KJ_UNIQUE_NAME(BenchImpl)(benchmark::State & state) {                                       \
+    for (auto _: state) {                                                                          \
+      KJ_UNIQUE_NAME(Bench)();                                                                     \
+    }                                                                                              \
+  }                                                                                                \
+  WD_BENCHMARK(KJ_UNIQUE_NAME(BenchImpl))->Name(description);                                      \
   void KJ_UNIQUE_NAME(Bench)()


### PR DESCRIPTION
I don't see any reason to use block comments and line continuations here, line comments are used elsewhere in the file and work fine. Also clang-format seems to not like it