### PR TITLE
EW-8447 Fix CPU profiling again

### DIFF
--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -315,14 +315,32 @@ public:
   uint getLockSuccessCount() const;
 
   // Accepts a connection to the V8 inspector and handles requests until the client disconnects.
+  // Also adds a special JSON value to the header identified by `controlHeaderId`, for compatibility
+  // with internal Cloudflare systems.
+  //
+  // This overload will dispatch all inspector messages on the _calling thread's_ `kj::Executor`.
+  // When linked against vanilla V8, this means that CPU profiling will only profile JavaScript
+  // running on the _calling thread_, which will most likely only be inspector console commands, and
+  // is not typically desired.
+  //
+  // For the above reason , this overload is curently only suitable for use by the internal Workers
+  // Runtime codebase, which patches V8 to profile whichever thread currently holds the `v8::Locker`
+  // for this Isolate.
   kj::Promise<void> attachInspector(kj::Timer& timer,
       kj::Duration timerOffset,
       kj::HttpService::Response& response,
       const kj::HttpHeaderTable& headerTable,
       kj::HttpHeaderId controlHeaderId) const;
 
-  kj::Promise<void> attachInspector(
-      kj::Timer& timer, kj::Duration timerOffset, kj::WebSocket& webSocket) const;
+  // Accepts a connection to the V8 inspector and handles requests until the client disconnects.
+  //
+  // This overload will dispatch all inspector messages on the `kj::Executor` passed in via
+  // `isolateThreadExecutorNotifierPair`. For CPU profiling to work as expected, this `kj::Executor`
+  // must be associated with the same thread which executes the Worker's JavaScript.
+  kj::Promise<void> attachInspector(ExecutorNotifierPair isolateThreadExecutorNotifierPair,
+      kj::Timer& timer,
+      kj::Duration timerOffset,
+      kj::WebSocket& webSocket) const;
 
   // Log a warning to the inspector if attached, and log an INFO severity message.
   void logWarning(kj::StringPtr description, Worker::Lock& lock);

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -335,9 +335,9 @@ public:
   // Accepts a connection to the V8 inspector and handles requests until the client disconnects.
   //
   // This overload will dispatch all inspector messages on the `kj::Executor` passed in via
-  // `isolateThreadExecutorNotifierPair`. For CPU profiling to work as expected, this `kj::Executor`
-  // must be associated with the same thread which executes the Worker's JavaScript.
-  kj::Promise<void> attachInspector(ExecutorNotifierPair isolateThreadExecutorNotifierPair,
+  // `isolateThreadExecutor`. For CPU profiling to work as expected, this `kj::Executor` must be
+  // associated with the same thread which executes the Worker's JavaScript.
+  kj::Promise<void> attachInspector(kj::Own<const kj::Executor> isolateThreadExecutor,
       kj::Timer& timer,
       kj::Duration timerOffset,
       kj::WebSocket& webSocket) const;

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1230,10 +1230,12 @@ private:
 // to define the inspector socket.
 class Server::InspectorService final: public kj::HttpService, public kj::HttpServerErrorHandler {
 public:
-  InspectorService(kj::Timer& timer,
+  InspectorService(ExecutorNotifierPair isolateThreadExecutorNotifierPair,
+      kj::Timer& timer,
       kj::HttpHeaderTable::Builder& headerTableBuilder,
       InspectorServiceIsolateRegistrar& registrar)
-      : timer(timer),
+      : isolateThreadExecutorNotifierPair(kj::mv(isolateThreadExecutorNotifierPair)),
+        timer(timer),
         headerTable(headerTableBuilder.getFutureTable()),
         server(timer, headerTable, *this, kj::HttpServerSettings{.errorHandler = *this}),
         registrar(registrar) {
@@ -1288,7 +1290,8 @@ public:
             auto webSocket = response.acceptWebSocket(responseHeaders);
             kj::Duration timerOffset = 0 * kj::MILLISECONDS;
             try {
-              co_return co_await ref->attachInspector(timer, timerOffset, *webSocket);
+              co_return co_await ref->attachInspector(
+                  isolateThreadExecutorNotifierPair.clone(), timer, timerOffset, *webSocket);
             } catch (...) {
               auto exception = kj::getCaughtExceptionAsKj();
               if (exception.getType() == kj::Exception::Type::DISCONNECTED) {
@@ -1407,6 +1410,7 @@ public:
   }
 
 private:
+  ExecutorNotifierPair isolateThreadExecutorNotifierPair;
   kj::Timer& timer;
   kj::HttpHeaderTable& headerTable;
   kj::HashMap<kj::String, kj::Own<const Worker::Isolate::WeakIsolateRef>> isolates;
@@ -3481,14 +3485,28 @@ uint startInspector(
   static constexpr uint DEFAULT_PORT = 9229;
   kj::MutexGuarded<uint> inspectorPort(UNASSIGNED_PORT);
 
-  kj::Thread thread([inspectorAddress, &inspectorPort, &registrar]() {
+  // `startInspector()` is called on the Isolate thread. V8 requires CPU profiling to be started and
+  // stopped on the same thread which executes JavaScript -- that is, the Isolate thread -- which
+  // means we need to dispatch inspector messages on this thread. To help make that happen, we
+  // capture this thread's kj::Executor and create an XThreadNotifier tied to this thread here, and
+  // pass it into the InspectorService below. Later, when the InspectorService receives a WebSocket
+  // connection, it calls `Isolate::attachInspector()`, which starts a dispatch loop on the
+  // kj::Executor we create here. The InspectorService reads subsequent WebSocket inspector messages
+  // and feeds them to that dispatch loop via the XThreadNotifier we create here.
+  auto isolateThreadExecutorNotifierPair = ExecutorNotifierPair{};
+
+  // Start the InspectorService thread.
+  kj::Thread thread(
+      [inspectorAddress, &inspectorPort, &registrar,
+          isolateThreadExecutorNotifierPair = kj::mv(isolateThreadExecutorNotifierPair)]() mutable {
     kj::AsyncIoContext io = kj::setupAsyncIo();
 
     kj::HttpHeaderTable::Builder headerTableBuilder;
 
     // Create the special inspector service.
     auto inspectorService(
-        kj::heap<Server::InspectorService>(io.provider->getTimer(), headerTableBuilder, registrar));
+        kj::heap<Server::InspectorService>(kj::mv(isolateThreadExecutorNotifierPair),
+            io.provider->getTimer(), headerTableBuilder, registrar));
     auto ownHeaderTable = headerTableBuilder.build();
 
     // Configure and start the inspector socket.

--- a/src/workerd/server/tests/inspector/driver.mjs
+++ b/src/workerd/server/tests/inspector/driver.mjs
@@ -54,68 +54,71 @@ async function connectInspector(port) {
   });
 }
 
-// TODO(soon): This test reproduces a null pointer dereference in workerd (possibly the same issue
-//   as https://github.com/cloudflare/workerd/issues/2564), but the test doesn't fail. :(
-test('Can repeatedly connect and disconnect to the inspector port', async () => {
-  for (let i = 0; i < 5; ++i) {
+async function profileAndExpectDeriveBitsFrames(inspectorClient) {
+  // Enable and start profiling.
+  await inspectorClient.Profiler.enable();
+  await inspectorClient.Profiler.start();
+
+  // Drive the worker with a test request. A single one is sufficient.
+  let httpPort = await workerd.getListenPort('http');
+  const response = await fetch(`http://localhost:${httpPort}`);
+  await response.arrayBuffer();
+
+  // Stop and disable profiling.
+  const profile = await inspectorClient.Profiler.stop();
+  await inspectorClient.Profiler.disable();
+
+  // Figure out which function name was most frequently sampled.
+  let hitCountMap = new Map();
+
+  for (let node of profile.profile.nodes) {
+    if (hitCountMap.get(node.callFrame.functionName) === undefined) {
+      hitCountMap.set(node.callFrame.functionName, 0);
+    }
+    hitCountMap.set(
+      node.callFrame.functionName,
+      hitCountMap.get(node.callFrame.functionName) + node.hitCount
+    );
+  }
+
+  let max = {
+    name: null,
+    count: 0,
+  };
+
+  for (let [name, count] of hitCountMap) {
+    if (count > max.count) {
+      max.name = name;
+      max.count = count;
+    }
+  }
+
+  // The most CPU-intensive function our test script runs is `deriveBits()`, so we expect that to be
+  // the most frequently sampled function.
+  assert.equal(max.name, 'deriveBits');
+  assert.notEqual(max.count, 0);
+}
+
+// Regression test for https://github.com/cloudflare/workerd/issues/1754.
+//
+// At one time, workerd produced only "(program)" frames.
+test('Profiler mostly sees deriveBits() frames', async () => {
+  let inspectorClient = await connectInspector(
+    await workerd.getListenInspectorPort()
+  );
+  await profileAndExpectDeriveBitsFrames(inspectorClient);
+  await inspectorClient.close();
+});
+
+// Regression test for https://github.com/cloudflare/workerd/issues/2564.
+//
+// At one time, workerd segfaulted on the second inspector connection.
+test('Can repeatedly reconnect the inspector and profiling still works', async () => {
+  for (let i = 0; i < 4; ++i) {
     let inspectorClient = await connectInspector(
       await workerd.getListenInspectorPort()
     );
-
-    // Drive the worker with a test request.
-    let httpPort = await workerd.getListenPort('http');
-    const response = await fetch(`http://localhost:${httpPort}`);
-    let body = await response.arrayBuffer();
-    console.log(body);
-
+    await profileAndExpectDeriveBitsFrames(inspectorClient);
     await inspectorClient.close();
   }
 });
-
-// TODO(soon): Re-enable once https://github.com/cloudflare/workerd/issues/2564 is solved.
-// test("Profiler mostly sees deriveBits() frames", async () => {
-//   let inspectorClient = await connectInspector(await workerd.getListenInspectorPort());
-
-//   // Enable and start profiling.
-//   await inspectorClient.Profiler.enable();
-//   await inspectorClient.Profiler.start();
-
-//   // Drive the worker with a test request. A single one is sufficient.
-//   let httpPort = await workerd.getListenPort("http");
-//   const response = await fetch(`http://localhost:${httpPort}`);
-//   await response.arrayBuffer();
-
-//   // Stop and disable profiling.
-//   const profile = await inspectorClient.Profiler.stop();
-//   await inspectorClient.Profiler.disable();
-
-//   // Figure out which function name was most frequently sampled.
-//   let hitCountMap = new Map();
-
-//   for (let node of profile.profile.nodes) {
-//     if (hitCountMap.get(node.callFrame.functionName) === undefined) {
-//       hitCountMap.set(node.callFrame.functionName, 0);
-//     }
-//     hitCountMap.set(node.callFrame.functionName,
-//         hitCountMap.get(node.callFrame.functionName) + node.hitCount);
-//   }
-
-//   let max = {
-//     name: null,
-//     count: 0,
-//   };
-
-//   for (let [name, count] of hitCountMap) {
-//     if (count > max.count) {
-//       max.name = name;
-//       max.count = count;
-//     }
-//   }
-
-//   // The most CPU-intensive function our test script runs is `deriveBits()`, so we expect that to be
-//   // the most frequently sampled function.
-//   assert.equal(max.name, "deriveBits");
-//   assert.notEqual(max.count, 0);
-
-//   await inspectorClient.close();
-// });

--- a/src/workerd/server/tests/inspector/driver.mjs
+++ b/src/workerd/server/tests/inspector/driver.mjs
@@ -27,6 +27,11 @@ beforeEach(async () => {
   });
 
   await workerd.start();
+
+  // We wait for the worker's HTTP port to come online before starting the test case. If we don't,
+  // and the inspector port comes online first, there's a chance the inspector connection will fail
+  // with 404 because the isolate doesn't exist yet.
+  await workerd.getListenPort('http');
 });
 
 // Stop workerd.

--- a/src/workerd/util/xthreadnotifier.h
+++ b/src/workerd/util/xthreadnotifier.h
@@ -42,18 +42,4 @@ private:
   kj::MutexGuarded<kj::PromiseCrossThreadFulfillerPair<void>> paf;
 };
 
-// Convenience struct for creating and passing around a kj::Executor and XThreadNotifier. The
-// default constructor creates a pair of the objects which are both tied to the current thread.
-struct ExecutorNotifierPair {
-  kj::Own<const kj::Executor> executor = kj::getCurrentThreadExecutor().addRef();
-  kj::Own<XThreadNotifier> notifier = XThreadNotifier::create();
-
-  ExecutorNotifierPair clone() {
-    return {
-      .executor = executor->addRef(),
-      .notifier = kj::atomicAddRef(*notifier),
-    };
-  }
-};
-
 }  // namespace workerd

--- a/src/workerd/util/xthreadnotifier.h
+++ b/src/workerd/util/xthreadnotifier.h
@@ -42,4 +42,18 @@ private:
   kj::MutexGuarded<kj::PromiseCrossThreadFulfillerPair<void>> paf;
 };
 
+// Convenience struct for creating and passing around a kj::Executor and XThreadNotifier. The
+// default constructor creates a pair of the objects which are both tied to the current thread.
+struct ExecutorNotifierPair {
+  kj::Own<const kj::Executor> executor = kj::getCurrentThreadExecutor().addRef();
+  kj::Own<XThreadNotifier> notifier = XThreadNotifier::create();
+
+  ExecutorNotifierPair clone() {
+    return {
+      .executor = executor->addRef(),
+      .notifier = kj::atomicAddRef(*notifier),
+    };
+  }
+};
+
 }  // namespace workerd


### PR DESCRIPTION
My initial attempt at a fix made a subtle behavior change which I did not consider fully: instead of a new `incomingQueueNotifier` XThreadNotifier being constructed for every inspector connection, my fix caused all inspector connections to re-use one long-lived XThreadNotifier. This subsequently ran afoul of the fact that XThreadNotifier::awaitNotification() is not cancel-safe: if it is cancelled while awaiting its stored promise, calling awaitNotification() a second time tries to await a moved-from promise.

This PR restores the previous behavior of creating a new `incomingQueueNotifier` XThreadNotifier for every inspector connection. However, instead of constructing it in the WebSocketIoHandler constructor as before, I moved the construction to the `messageLoop()` function implementation, which also spawns the dispatch loop. This narrows the scope of access to the notifier to only those functions which actually need it, keeps our usage of the dispatch kj::Executor localized in one place, and avoids synchronously blocking the inspector thread, as we would have had to do if we constructed it in the WebSocketIoHandler constructor.