### PR TITLE
update prettier and clang-format cli options in format.py

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 alias b := build
 alias t := test
+alias f := format
 
 default:
   @just --list
@@ -26,3 +27,6 @@ test *args="//...":
 
 test-asan *args="//...":
   just test {{args}} --config=asan
+
+format:
+  python3 tools/cross/format.py

--- a/tools/cross/format.py
+++ b/tools/cross/format.py
@@ -85,7 +85,7 @@ def filter_files_by_exts(
 
 
 def clang_format(files: List[str], check: bool = False) -> bool:
-    cmd = [CLANG_FORMAT, "--verbose"]
+    cmd = [CLANG_FORMAT]
     if check:
         cmd += ["--dry-run", "--Werror"]
     else:
@@ -95,7 +95,7 @@ def clang_format(files: List[str], check: bool = False) -> bool:
 
 
 def prettier(files: List[str], check: bool = False) -> bool:
-    cmd = [PRETTIER]
+    cmd = [PRETTIER, "--log-level=warn"]
     if check:
         cmd.append("--check")
     else:
@@ -164,10 +164,9 @@ FORMATTERS = [
     ),
     FormatConfig(
         directory="src",
-        extensions=(".js", ".ts", ".cjs", ".ejs", ".mjs"),
+        extensions=(".js", ".ts", ".cjs", ".ejs", ".mjs", ".json"),
         formatter=prettier,
     ),
-    FormatConfig(directory="src", extensions=(".json",), formatter=prettier),
     FormatConfig(directory=".", extensions=(".py",), formatter=ruff),
     # TODO: lint bazel files
 ]


### PR DESCRIPTION
- Replaced `--check` with `--list-different` to reduce noise (hides the files that does not need formatting) 
- Added `--log-level=warn` on formatting where now it prints only the files that actually changed.