### PR TITLE
[nfc] 08-23-24 build cleanup

### DIFF
--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -50,6 +50,7 @@
 -isystemexternal/sqlite3
 -isystemexternal/perfetto-sdk/sdk
 -D_FORTIFY_SOURCE=1
+-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES
 -DCAPNP_VERSION=11000
 -DDEBUG
 -DGOOGLE3

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -8,8 +8,10 @@
 // See actor.h for APIs used by other Workers to talk to Actors.
 
 #include <workerd/jsg/jsg.h>
-#include <workerd/io/io-context.h>
-#include <workerd/io/actor-storage.capnp.h>
+#include <workerd/io/actor-id.h>
+#include <workerd/io/compatibility-date.capnp.h>
+#include <workerd/io/io-own.h>
+#include <workerd/io/worker.h>
 #include <kj/async.h>
 #include <workerd/io/actor-cache.h>
 

--- a/src/workerd/api/api-rtti-test.c++
+++ b/src/workerd/api/api-rtti-test.c++
@@ -8,16 +8,21 @@
 #include <workerd/api/cache.h>
 #include <workerd/api/crypto/crypto.h>
 #include <workerd/api/encoding.h>
+#include <workerd/api/events.h>
+#include <workerd/api/eventsource.h>
 #include <workerd/api/global-scope.h>
 #include <workerd/api/html-rewriter.h>
 #include <workerd/api/queue.h>
 #include <workerd/api/scheduled.h>
+#include <workerd/api/streams.h>
 #include <workerd/api/sockets.h>
 #include <workerd/api/sql.h>
 #include <workerd/api/streams/standard.h>
 #include <workerd/api/trace.h>
+#include <workerd/api/url-standard.h>
 #include <workerd/api/urlpattern.h>
 #include <workerd/jsg/rtti.h>
+#include <workerd/io/compatibility-date.h>
 
 // Test building rtti for various APIs.
 

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -8,7 +8,7 @@
 // TODO(cleanp): Rename to events.h?
 
 #include <workerd/jsg/jsg.h>
-#include <workerd/io/io-context.h>
+#include <workerd/io/io-own.h>
 #include <workerd/util/canceler.h>
 #include <kj/function.h>
 #include <kj/map.h>

--- a/src/workerd/api/blob.c++
+++ b/src/workerd/api/blob.c++
@@ -3,8 +3,8 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "blob.h"
-#include "streams.h"
 #include "util.h"
+#include <workerd/api/streams/readable.h>
 #include <workerd/io/observer.h>
 #include <workerd/util/mimetype.h>
 

--- a/src/workerd/api/crypto/aes.c++
+++ b/src/workerd/api/crypto/aes.c++
@@ -6,9 +6,10 @@
 #include <algorithm>
 #include <cstdint>
 #include <openssl/aes.h>
+#include <openssl/base.h>
 #include <openssl/bn.h>
-#include <openssl/crypto.h>
-#include <openssl/err.h>
+#include <openssl/cipher.h>
+#include <openssl/mem.h>
 #include <workerd/io/io-context.h>
 
 namespace workerd::api {

--- a/src/workerd/api/crypto/crypto.c++
+++ b/src/workerd/api/crypto/crypto.c++
@@ -5,8 +5,8 @@
 #include "crypto.h"
 #include "impl.h"
 #include <workerd/api/streams/standard.h>
-#include <openssl/crypto.h>
-#include <openssl/err.h>
+#include <openssl/digest.h>
+#include <openssl/mem.h>
 #include <workerd/api/util.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/io/io-context.h>

--- a/src/workerd/api/crypto/crypto.h
+++ b/src/workerd/api/crypto/crypto.h
@@ -10,8 +10,8 @@
 #include <workerd/jsg/buffersource.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/buffersource.h>
-#include <openssl/err.h>
-#include "../streams.h"
+#include <workerd/api/streams/writable.h>
+#include <openssl/base.h>  // for EVP_MD_CTX, X509
 
 namespace workerd::api {
 namespace node {

--- a/src/workerd/api/crypto/ec.h
+++ b/src/workerd/api/crypto/ec.h
@@ -2,8 +2,7 @@
 
 #include "impl.h"
 #include "keys.h"
-#include <openssl/bn.h>
-#include <openssl/ec.h>
+#include <openssl/base.h>
 #include <kj/common.h>
 
 namespace workerd::api {

--- a/src/workerd/api/crypto/impl.c++
+++ b/src/workerd/api/crypto/impl.c++
@@ -9,10 +9,11 @@
 #include <openssl/bn.h>
 #include <openssl/err.h>
 #include <openssl/ec.h>
+#include <openssl/evp.h>
 #include <openssl/rsa.h>
 #include <openssl/rand.h>
 #include <openssl/crypto.h>
-#include <workerd/jsg/setup.h>
+#include <workerd/jsg/memory.h>
 
 namespace workerd::api {
 namespace {

--- a/src/workerd/api/crypto/impl.h
+++ b/src/workerd/api/crypto/impl.h
@@ -10,8 +10,9 @@
 #include "crypto.h"
 #include <workerd/api/util.h>
 #include <kj/encoding.h>
-#include <openssl/evp.h>
-#include <openssl/bio.h>
+#include <openssl/base.h>
+#include <openssl/bn.h>
+#include <openssl/err.h>
 
 typedef struct bignum_st BIGNUM;
 

--- a/src/workerd/api/crypto/pbkdf2.c++
+++ b/src/workerd/api/crypto/pbkdf2.c++
@@ -4,7 +4,8 @@
 
 #include "impl.h"
 #include <workerd/api/crypto/kdf.h>
-#include <openssl/crypto.h>
+#include <openssl/evp.h>
+#include <openssl/mem.h>
 
 namespace workerd::api {
 namespace {

--- a/src/workerd/api/crypto/rsa.h
+++ b/src/workerd/api/crypto/rsa.h
@@ -2,7 +2,7 @@
 
 #include "crypto.h"
 #include "keys.h"
-#include <openssl/rsa.h>
+#include <openssl/base.h>
 #include <openssl/evp.h>
 #include <kj/common.h>
 

--- a/src/workerd/api/crypto/scrypt.c++
+++ b/src/workerd/api/crypto/scrypt.c++
@@ -4,7 +4,7 @@
 
 #include "impl.h"
 #include <workerd/api/crypto/kdf.h>
-#include <openssl/crypto.h>
+#include <openssl/evp.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -9,6 +9,7 @@
 #include <workerd/api/cache.h>
 #include <workerd/api/crypto/crypto.h>
 #include <workerd/api/events.h>
+#include <workerd/api/eventsource.h>
 #include <workerd/api/scheduled.h>
 #include <workerd/api/system-streams.h>
 #include <workerd/api/trace.h>

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -6,9 +6,7 @@
 
 #include <workerd/jsg/jsg.h>
 #include "basics.h"
-#include "events.h"
 #include "http.h"
-#include "eventsource.h"
 #include "hibernation-event-params.h"
 #include <workerd/io/io-timers.h>
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
@@ -26,12 +24,17 @@ class Cache;
 class CacheStorage;
 class Crypto;
 class CryptoKey;
+class ErrorEvent;
+class EventSource;
+class FixedLengthStream;
 class SubtleCrypto;
 class TextDecoder;
 class TextEncoder;
 class HTMLRewriter;
+class IdentityTransformStream;
 class Response;
 class TraceItem;
+class TransformStream;
 class ScheduledController;
 class ScheduledEvent;
 class ReadableStream;

--- a/src/workerd/api/hibernatable-web-socket.h
+++ b/src/workerd/api/hibernatable-web-socket.h
@@ -7,6 +7,7 @@
 #include <kj/debug.h>
 #include <kj/time.h>
 
+#include <workerd/io/worker.h>
 #include <workerd/io/worker-interface.capnp.h>
 #include <workerd/io/worker-interface.h>
 #include <workerd/api/basics.h>

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -14,6 +14,7 @@
 #include <kj/memory.h>
 #include <kj/parse/char.h>
 #include <workerd/io/features.h>
+#include <workerd/util/abortable.h>
 #include <workerd/util/http-util.h>
 #include <workerd/util/mimetype.h>
 #include <workerd/util/stream-utils.h>

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -6,24 +6,20 @@
 
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/async-context.h>
-#include <workerd/util/abortable.h>
 #include <kj/compat/http.h>
 #include <map>
 #include "basics.h"
 #include "cf-property.h"
-#include "streams.h"
+#include <workerd/api/streams/readable.h>
 #include "form-data.h"
 #include "web-socket.h"
 #include "url.h"
-#include "url-standard.h"
 #include "blob.h"
 #include <workerd/io/compatibility-date.capnp.h>
 #include "worker-rpc.h"
 #include "queue.h"
 
 namespace workerd::api {
-
-struct QueueResponse;
 
 class Headers final: public jsg::Object {
 private:

--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -4,10 +4,14 @@
 
 #pragma once
 
-#include <workerd/jsg/jsg.h>
-#include "streams.h"
+#include <workerd/api/streams/readable.h>
 #include <workerd/io/limit-enforcer.h>
+#include <workerd/jsg/jsg.h>
 
+namespace kj {
+class HttpClient;
+class HttpHeaders;
+}  // namespace kj
 namespace workerd {
 class IoContext;
 }

--- a/src/workerd/api/modules.h
+++ b/src/workerd/api/modules.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <workerd/api/node/node.h>
-#include <workerd/api/unsafe.h>
 #include <workerd/api/pyodide/pyodide.h>
 #include <workerd/api/rtti.h>
 #include <workerd/api/sockets.h>

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -83,6 +83,7 @@ wd_test(
 )
 
 wd_test(
+    size = "large",
     src = "tests/crypto_scrypt-test.wd-test",
     args = ["--experimental"],
     data = ["tests/crypto_scrypt-test.js"],

--- a/src/workerd/api/node/crypto.h
+++ b/src/workerd/api/node/crypto.h
@@ -8,7 +8,6 @@
 #include <workerd/api/crypto/digest.h>
 #include <workerd/api/crypto/dh.h>
 #include <workerd/api/crypto/x509.h>
-#include <openssl/evp.h>
 
 namespace workerd::api::node {
 

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -7,10 +7,7 @@
 #include "r2-rpc.h"
 
 #include <workerd/jsg/jsg.h>
-#include "streams.h"
-#include <workerd/api/r2-api.capnp.h>
-#include <capnp/compat/json.h>
-#include <workerd/util/http-util.h>
+#include <workerd/api/streams/readable.h>
 
 namespace workerd::api {
 class Headers;

--- a/src/workerd/api/r2-rpc.h
+++ b/src/workerd/api/r2-rpc.h
@@ -4,9 +4,12 @@
 
 #pragma once
 
-#include <workerd/api/basics.h>
 #include <workerd/api/blob.h>
 #include <workerd/jsg/jsg.h>
+
+namespace kj {
+class HttpClient;
+}
 
 namespace workerd::api {
 

--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -24,6 +24,7 @@
 #include <workerd/api/sockets.h>
 #include <workerd/api/scheduled.h>
 #include <workerd/api/sql.h>
+#include <workerd/api/streams.h>
 #include <workerd/api/streams/standard.h>
 #include <workerd/api/trace.h>
 #include <workerd/api/urlpattern.h>
@@ -32,8 +33,10 @@
 #include <workerd/api/hyperdrive.h>
 #include <workerd/api/eventsource.h>
 #include <workerd/api/unsafe.h>
+#include <workerd/api/url-standard.h>
 #include <workerd/api/memory-cache.h>
 #include <workerd/api/worker-rpc.h>
+#include <workerd/io/compatibility-date.h>
 
 #include <cloudflare/cloudflare.capnp.h>
 

--- a/src/workerd/api/rtti.h
+++ b/src/workerd/api/rtti.h
@@ -6,7 +6,7 @@
 
 #include <kj/array.h>
 #include <kj/string.h>
-#include <workerd/io/compatibility-date.h>
+#include <workerd/jsg/jsg.h>
 #include <workerd/jsg/modules.h>
 #include <workerd/jsg/modules-new.h>
 #include <workerd/jsg/url.h>

--- a/src/workerd/api/scheduled.c++
+++ b/src/workerd/api/scheduled.c++
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "scheduled.h"
+#include <workerd/io/io-context.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -460,4 +460,8 @@ jsg::Promise<void> Socket::maybeCloseWriteSide(jsg::Lock& js) {
       }));
 }
 
+jsg::Ref<Socket> SocketsModule::connect(
+    jsg::Lock& js, AnySocketAddress address, jsg::Optional<SocketOptions> options) {
+  return connectImpl(js, kj::none, kj::mv(address), kj::mv(options));
+}
 }  // namespace workerd::api

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -8,7 +8,8 @@
 #include <workerd/jsg/modules.h>
 #include <workerd/jsg/modules-new.h>
 #include <workerd/jsg/url.h>
-#include "streams.h"
+#include <workerd/api/streams/readable.h>
+#include <workerd/api/streams/writable.h>
 
 namespace workerd::api {
 
@@ -240,9 +241,7 @@ public:
   SocketsModule(jsg::Lock&, const jsg::Url&) {}
 
   jsg::Ref<Socket> connect(
-      jsg::Lock& js, AnySocketAddress address, jsg::Optional<SocketOptions> options) {
-    return connectImpl(js, kj::none, kj::mv(address), kj::mv(options));
-  }
+      jsg::Lock& js, AnySocketAddress address, jsg::Optional<SocketOptions> options);
 
   JSG_RESOURCE_TYPE(SocketsModule) {
     JSG_METHOD(connect);

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -8,10 +8,9 @@
 #include <workerd/util/sqlite.h>
 #include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/io/io-context.h>
+#include <workerd/api/actor-state.h>
 
 namespace workerd::api {
-
-class DurableObjectStorage;
 
 class SqlStorage final: public jsg::Object, private SqliteDatabase::Regulator {
 public:

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "common.h"
+#include "writable.h"
 #include <workerd/io/io-context.h>
 #include <deque>
 

--- a/src/workerd/api/system-streams.h
+++ b/src/workerd/api/system-streams.h
@@ -6,7 +6,7 @@
 // Implementations of ReadableStreamSource / WritableStreamSink which wrap system streams (sockets),
 // handle encoding/decoding, and optimize pumping between them when possible.
 
-#include "streams.h"
+#include <workerd/api/streams/common.h>  // for StreamEncoding, ...
 #include "http.h"
 #include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/io/io-context.h>

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -11,6 +11,7 @@
 #include <workerd/api/basics.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/io/trace.h>
+#include <workerd/io/io-context.h>
 #include <kj/async.h>
 
 namespace workerd::api {

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -7,7 +7,8 @@
 #include <workerd/jsg/jsg.h>
 #include <kj/compat/http.h>
 #include "basics.h"
-#include <workerd/io/io-context.h>
+#include <workerd/io/io-gate.h>
+#include <workerd/io/observer.h>
 #include <workerd/util/weak-refs.h>
 #include <cstdlib>
 

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -15,41 +15,51 @@ config_setting(
     flag_values = {"enable_experimental_webgpu": "True"},
 )
 
+# TODO(cleanup): Split up into smaller targets, although this target is already relatively small and
+# not encumbered with many dependencies.
+wd_cc_library(
+    name = "io-helpers",
+    srcs = [
+        "io-thread-context.c++",
+        "io-timers.c++",
+        "request-tracker.c++",
+    ],
+    hdrs = [
+        "io-thread-context.h",
+        "io-timers.h",
+        "request-tracker.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/workerd/jsg",
+        "@capnp-cpp//src/capnp/compat:http-over-capnp",
+    ],
+)
+
 wd_cc_library(
     name = "io",
     # HACK: Currently, the `io` and `api` packages are interdependent. We fold all the sources
     #   from `api` into `io`. In principle, it should be possible to pull them apart so `api`
-    #   depends on `io` but not vice versa.
+    #   depends on `io` but not vice versa. In practice, this appears very difficult due to the
+    # IoContext -> Worker -> ServiceWorkerGlobalScope -> (various api targets) dependency chain.
     # TODO(cleanup): Fix this.
-    srcs = glob(
-        ["*.c++"],
-        exclude = [
-            "worker-interface.c++",
-            "*-test.c++",
-            "trace.c++",
-            "io-gate.c++",
-            "observer.c++",
-            "actor-cache.c++",
-            "actor-sqlite.c++",
-            "actor-storage.c++",
-            "worker-entrypoint.c++",
-        ],
-    ) + ["//src/workerd/api:srcs"],
-    hdrs = glob(
-        ["*.h"],
-        exclude = [
-            "actor-id.h",
-            "actor-cache.h",
-            "actor-sqlite.h",
-            "actor-storage.h",
-            "io-channels.h",
-            "io-gate.h",
-            "trace.h",
-            "observer.h",
-            "worker-entrypoint.h",
-            "worker-interface.h",
-        ],
-    ) + ["//src/workerd/api:hdrs"],
+    srcs = [
+        "compatibility-date.c++",
+        "features.c++",
+        "hibernation-manager.c++",
+        "io-context.c++",
+        "io-own.c++",
+        "worker.c++",
+    ] + ["//src/workerd/api:srcs"],
+    hdrs = [
+        "compatibility-date.h",
+        "features.h",
+        "hibernation-manager.h",
+        "io-context.h",
+        "io-own.h",
+        "promise-wrapper.h",
+        "worker.h",
+    ] + ["//src/workerd/api:hdrs"],
     defines = select({
         ":set_enable_experimental_webgpu": ["WORKERD_EXPERIMENTAL_ENABLE_WEBGPU"],
         "//conditions:default": [],
@@ -68,6 +78,8 @@ wd_cc_library(
         ":capnp",
         ":io-channels",
         ":io-gate",
+        ":io-helpers",
+        ":limit-enforcer",
         ":observer",
         ":trace",
         ":worker-interface",

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -6,7 +6,7 @@
 
 #include <kj/debug.h>
 #include <kj/async.h>
-#include <workerd/io/actor-storage.h>
+#include <workerd/io/actor-storage.capnp.h>
 #include <kj/one-of.h>
 #include <kj/map.h>
 #include <kj/list.h>

--- a/src/workerd/io/actor-storage.c++
+++ b/src/workerd/io/actor-storage.c++
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "actor-storage.h"
+#include <workerd/io/actor-storage.capnp.h>
 
 #include <workerd/jsg/exception.h>
 

--- a/src/workerd/io/actor-storage.h
+++ b/src/workerd/io/actor-storage.h
@@ -7,8 +7,6 @@
 #include <kj/common.h>
 #include <kj/string.h>
 
-#include <workerd/io/actor-storage.capnp.h>
-
 namespace workerd {
 // This class wraps common values and functions for interacting durable object (actor) storage.
 class ActorStorageLimits {

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -376,10 +376,6 @@ void IoContext::logUncaughtExceptionAsync(
   runImpl(runnable, false, Worker::Lock::TakeSynchronously(metrics), kj::none, true);
 }
 
-void IoContext::reportPromiseRejectEvent(v8::PromiseRejectMessage& message) {
-  KJ_REQUIRE_NONNULL(currentLock).reportPromiseRejectEvent(message);
-}
-
 void IoContext::addTask(kj::Promise<void> promise) {
   ++addTaskCounter;
 

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -8,9 +8,8 @@
 #include <workerd/io/io-channels.h>
 #include <workerd/io/io-gate.h>
 #include "io-own.h"
-#include "workerd/io/io-timers.h"
-#include "workerd/io/io-thread-context.h"
-#include "workerd/io/limit-enforcer.h"
+#include <workerd/io/io-timers.h>
+#include <workerd/io/io-thread-context.h>
 #include <workerd/io/trace.h>
 #include "worker.h"
 #include <workerd/api/deferred-proxy.h>
@@ -22,9 +21,12 @@
 #include <kj/function.h>
 #include <capnp/dynamic.h>
 #include <workerd/util/weak-refs.h>
-#include <workerd/io/limit-enforcer.h>
 #include <workerd/io/io-channels.h>
 #include <workerd/util/uncaught-exception-source.h>
+
+namespace workerd {
+class LimitEnforcer;
+}
 
 namespace capnp {
 class HttpOverCapnpFactory;

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -8,9 +8,9 @@
 #include <workerd/io/io-channels.h>
 #include <workerd/io/io-gate.h>
 #include "io-own.h"
-#include "io-timers.h"
-#include "io-thread-context.h"
-#include "limit-enforcer.h"
+#include "workerd/io/io-timers.h"
+#include "workerd/io/io-thread-context.h"
+#include "workerd/io/limit-enforcer.h"
 #include <workerd/io/trace.h>
 #include "worker.h"
 #include <workerd/api/deferred-proxy.h>
@@ -308,8 +308,6 @@ public:
   // Log an uncaught exception from an asynchronous context, i.e. when the IoContext is not
   // "current".
   void logUncaughtExceptionAsync(UncaughtExceptionSource source, kj::Exception&& e);
-
-  void reportPromiseRejectEvent(v8::PromiseRejectMessage& message);
 
   // Returns a promise that will reject with an exception if and when the request should be
   // aborted, e.g. because its CPU time expired. This should be joined with any promises for

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1091,7 +1091,7 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
       // doesn't currently provide an easy way to do this.
       if (IoContext::hasCurrent()) {
         try {
-          IoContext::current().reportPromiseRejectEvent(message);
+          IoContext::current().getCurrentLock().reportPromiseRejectEvent(message);
         } catch (jsg::JsExceptionThrown&) {
           // V8 expects us to just return.
           return;

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -17,7 +17,6 @@
 #include <kj/mutex.h>
 #include <workerd/io/io-channels.h>
 #include <workerd/io/actor-id.h>
-#include <workerd/io/actor-storage.capnp.h>
 #include <workerd/io/request-tracker.h>
 #include <workerd/io/actor-cache.h>  // because we can't forward-declare ActorCache::SharedLru.
 #include <workerd/util/weak-refs.h>

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -19,6 +19,7 @@
 #include <workerd/api/encoding.h>
 #include <workerd/api/events.h>
 #include <workerd/api/eventsource.h>
+#include <workerd/api/url-standard.h>
 #include <workerd/api/global-scope.h>
 #include <workerd/api/html-rewriter.h>
 #include <workerd/api/hyperdrive.h>
@@ -29,6 +30,7 @@
 #include <workerd/api/scheduled.h>
 #include <workerd/api/sockets.h>
 #include <workerd/api/streams/standard.h>
+#include <workerd/api/streams.h>
 #include <workerd/api/sql.h>
 #include <workerd/api/r2.h>
 #include <workerd/api/r2-admin.h>
@@ -37,13 +39,11 @@
 #include <workerd/api/urlpattern.h>
 #include <workerd/api/memory-cache.h>
 #include <workerd/api/node/node.h>
+#include <workerd/io/compatibility-date.h>
 #include <workerd/io/promise-wrapper.h>
 #include <workerd/util/thread-scopes.h>
 #include <workerd/util/use-perfetto-categories.h>
 #include <workerd/server/actor-id-impl.h>
-#include <openssl/sha.h>
-#include <openssl/hmac.h>
-#include <openssl/rand.h>
 #include <kj/compat/http.h>
 #include <kj/compat/tls.h>
 #include <kj/compat/url.h>

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -6,9 +6,20 @@
 
 #include <workerd/io/worker.h>
 #include <workerd/server/workerd.capnp.h>
-#include <workerd/jsg/setup.h>
 #include <workerd/jsg/modules-new.h>
-#include <workerd/api/pyodide/pyodide.h>
+
+namespace workerd {
+namespace api {
+namespace pyodide {
+struct PythonConfig;
+}
+}  // namespace api
+}  // namespace workerd
+namespace workerd {
+namespace jsg {
+class V8System;
+}
+}  // namespace workerd
 
 namespace workerd::api {
 class MemoryCacheProvider;

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -13,6 +13,7 @@
 #include <workerd/io/limit-enforcer.h>
 #include <workerd/io/observer.h>
 #include <workerd/jsg/modules.h>
+#include <workerd/jsg/setup.h>
 #include <workerd/server/server.h>
 #include <workerd/server/workerd-api.h>
 #include <workerd/util/autogate.h>


### PR DESCRIPTION
[build] workerd/io target cleanup, fold up IoContext::reportPromiseRejectEvent()
\- Dissolve glob in io target
\- Isolate more source files into smaller target
\- reportPromiseRejectEvent() does not involve IoContext internals and is only used within Worker, fold it into worker.c++.
This makes io easier to maintain and makes the target a bit smaller.

[nfc] Extended api include cleanup aided by include-what-you-use
\- Add _LIBCPP_REMOVE_TRANSITIVE_INCLUDES to compile_flags.txt so errors for missing headers are available within the editor too


I wanted to divide the io target further and see what impact IWYU has in practice. IWYU made it easier to clean up some headers, but the real-world impact is kinda disappointing (1080MB => 1071MB size of preprocessed workerd source). Still, just having frequently used headers like http.h be smaller should also help with managing include sizes in the downstream project. In some cases I also fixed headers being unable to compile on their own or moved functions from a header to the corresponding cpp file if that allowed removing includes from the header.