### PR TITLE
fix buffer.transcode if both encodings are same

### DIFF
--- a/src/workerd/api/node/i18n.c++
+++ b/src/workerd/api/node/i18n.c++
@@ -215,14 +215,6 @@ void Converter::setSubstituteChars(kj::StringPtr sub) {
 
 kj::Array<kj::byte> transcode(
     kj::ArrayPtr<kj::byte> source, Encoding fromEncoding, Encoding toEncoding) {
-  // Optimization:
-  // If both encodings are same, we just return a copy of the buffer.
-  if (fromEncoding == toEncoding) {
-    auto destbuf = kj::heapArray<kj::byte>(source.size());
-    destbuf.asPtr().copyFrom(source);
-    return destbuf.asBytes().attach(kj::mv(destbuf));
-  }
-
   TranscodeImpl transcode_function = &TranscodeDefault;
   switch (fromEncoding) {
     case Encoding::ASCII:

--- a/src/workerd/api/node/tests/buffer-nodejs-test.js
+++ b/src/workerd/api/node/tests/buffer-nodejs-test.js
@@ -6045,6 +6045,13 @@ export const transcodeTest = {
       ok(copied_value.buffer.detached);
       ok(!original.buffer.detached);
     }
+
+    // Same encoding types should return in a value that replaces
+    // invalid characters with replacement characters.
+    deepStrictEqual(
+      transcode(Buffer.from([0x80]), 'utf8', 'utf8'),
+      Buffer.from([0xef, 0xbf, 0xbd])
+    );
   },
 };
 


### PR DESCRIPTION
This was an invalid optimization. If fromEncoding and toEncoding is same, and if the encoding is invalid (such as invalid utf8), the output should have included a result that replaces invalid characters with replacement characters. 