### PR TITLE
Use v8::LocalVector in multiple places

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -690,14 +690,14 @@ void ServiceWorkerGlobalScope::queueMicrotask(jsg::Lock& js, v8::Local<v8::Funct
           (jsg::Lock & js, const v8::FunctionCallbackInfo<v8::Value>& args)->v8::Local<v8::Value> {
             return js.tryCatch([&]() -> v8::Local<v8::Value> {
               auto function = fn.getHandle(js);
-              auto context = js.v8Context();
 
-              kj::Vector<v8::Local<v8::Value>> argv(args.Length());
+              v8::LocalVector<v8::Value> argv(js.v8Isolate, args.Length());
               for (int n = 0; n < args.Length(); n++) {
-              argv.add(args[n]);
+              argv[n] = args[n];
               }
 
-              return jsg::check(function->Call(context, js.v8Null(), args.Length(), argv.begin()));
+              return jsg::check(
+                  function->Call(js.v8Context(), js.v8Null(), argv.size(), argv.data()));
             }, [&](jsg::Value exception) {
               reportError(js, jsg::JsValue(exception.getHandle(js)));
               return js.v8Undefined();

--- a/src/workerd/jsg/iterator.h
+++ b/src/workerd/jsg/iterator.h
@@ -688,11 +688,11 @@ public:
       jsg::Sequence<U> sequence) {
     v8::Isolate* isolate = context->GetIsolate();
     v8::EscapableHandleScope handleScope(isolate);
-    KJ_STACK_ARRAY(v8::Local<v8::Value>, items, sequence.size(), MAX_STACK, MAX_STACK);
+    v8::LocalVector<v8::Value> items(isolate, sequence.size());
     for (auto i: kj::indices(sequence)) {
       items[i] = static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(sequence[i]));
     }
-    return handleScope.Escape(v8::Array::New(isolate, items.begin(), items.size()));
+    return handleScope.Escape(v8::Array::New(isolate, items.data(), items.size()));
   }
 
   template <typename U>
@@ -701,11 +701,11 @@ public:
       jsg::Sequence<U>& sequence) {
     v8::Isolate* isolate = context->GetIsolate();
     v8::EscapableHandleScope handleScope(isolate);
-    KJ_STACK_ARRAY(v8::Local<v8::Value>, items, sequence.size(), MAX_STACK, MAX_STACK);
+    v8::LocalVector<v8::Value> items(isolate, sequence.size());
     for (auto i: kj::indices(sequence)) {
       items[i] = static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(sequence[i]));
     }
-    return handleScope.Escape(v8::Array::New(isolate, items.begin(), items.size()));
+    return handleScope.Escape(v8::Array::New(isolate, items.data(), items.size()));
   }
 
   template <typename U>

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -458,8 +458,11 @@ JsSymbol Lock::symbolInternal(kj::StringPtr str) {
 }
 
 JsArray Lock::arr(kj::ArrayPtr<JsValue> values) {
-  auto items = KJ_MAP(i, values) { return v8::Local<v8::Value>(i); };
-  return JsArray(v8::Array::New(v8Isolate, items.begin(), items.size()));
+  v8::LocalVector<v8::Value> items(v8Isolate, values.size());
+  for (size_t n = 0; n < values.size(); n++) {
+    items[n] = values[n];
+  }
+  return JsArray(v8::Array::New(v8Isolate, items.data(), items.size()));
 }
 
 #define V(Name)                                                                                    \

--- a/src/workerd/jsg/modules-new.c++
+++ b/src/workerd/jsg/modules-new.c++
@@ -192,14 +192,14 @@ public:
   }
 
   v8::MaybeLocal<v8::Module> getDescriptor(Lock& js, const CompilationObserver&) const override {
-    KJ_STACK_ARRAY(v8::Local<v8::String>, exports, namedExports.size() + 1, 10, 10);
+    v8::LocalVector<v8::String> exports(js.v8Isolate, namedExports.size() + 1);
     int n = 0;
     exports[n++] = js.str(DEFAULT);
     for (const auto& exp: namedExports) {
       exports[n++] = js.str(exp);
     }
     return v8::Module::CreateSyntheticModule(js.v8Isolate, js.str(specifier().getHref()),
-        v8::MemorySpan<const v8::Local<v8::String>>(exports.begin(), exports.size()),
+        v8::MemorySpan<const v8::Local<v8::String>>(exports.data(), exports.size()),
         evaluationSteps);
   }
 

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -486,9 +486,10 @@ v8::Local<v8::Module> compileEsmModule(jsg::Lock& js,
 
 v8::Local<v8::Module> createSyntheticModule(
     jsg::Lock& js, kj::StringPtr name, kj::Maybe<kj::ArrayPtr<kj::StringPtr>> maybeExports) {
-  std::vector<v8::Local<v8::String>> exportNames;
+  v8::LocalVector<v8::String> exportNames(js.v8Isolate);
   exportNames.push_back(v8StrIntern(js.v8Isolate, "default"_kj));
   KJ_IF_SOME(exports, maybeExports) {
+    exportNames.reserve(exports.size());
     for (auto& name: exports) {
       exportNames.push_back(v8StrIntern(js.v8Isolate, name));
     }

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -792,14 +792,13 @@ public:
     v8::Isolate* isolate = context->GetIsolate();
     v8::EscapableHandleScope handleScope(isolate);
 
-    auto len = array.size();
-    KJ_STACK_ARRAY(v8::Local<v8::Value>, items, len, MAX_STACK, MAX_STACK);
-    for (auto n = 0; n < len; n++) {
+    v8::LocalVector<v8::Value> items(isolate, array.size());
+    for (auto n = 0; n < items.size(); n++) {
       items[n] = static_cast<TypeWrapper*>(this)
                      ->wrap(context, creator, kj::mv(array[n]))
                      .template As<v8::Value>();
     }
-    auto out = v8::Array::New(isolate, items.begin(), len);
+    auto out = v8::Array::New(isolate, items.data(), items.size());
 
     return handleScope.Escape(out);
   }
@@ -810,14 +809,13 @@ public:
     v8::Isolate* isolate = context->GetIsolate();
     v8::EscapableHandleScope handleScope(isolate);
 
-    auto len = array.size();
-    KJ_STACK_ARRAY(v8::Local<v8::Value>, items, len, MAX_STACK, MAX_STACK);
-    for (auto n = 0; n < len; n++) {
+    v8::LocalVector<v8::Value> items(isolate, array.size());
+    for (auto n = 0; n < items.size(); n++) {
       items[n] = static_cast<TypeWrapper*>(this)
                      ->wrap(context, creator, kj::mv(array[n]))
                      .template As<v8::Value>();
     }
-    auto out = v8::Array::New(isolate, items.begin(), len);
+    auto out = v8::Array::New(isolate, items.data(), items.size());
 
     return handleScope.Escape(out);
   }

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -763,9 +763,8 @@ static v8::Local<v8::Value> createBindingValue(JsgWorkerdIsolate::Lock& lock,
         KJ_ASSERT(fn->IsFunction(), "Entrypoint is not a function", wrapped.entrypoint);
 
         // invoke the function, its result will be binding value
-        auto args = kj::arr(env.As<v8::Value>());
-        value = jsg::check(
-            v8::Function::Cast(*fn)->Call(context, context->Global(), args.size(), args.begin()));
+        v8::Local<v8::Value> arg = env.As<v8::Value>();
+        value = jsg::check(v8::Function::Cast(*fn)->Call(context, context->Global(), 1, &arg));
       } else {
         KJ_LOG(
             ERROR, "wrapped binding module can't be resolved (internal modules only)", moduleName);


### PR DESCRIPTION
v8 Local handles aren't really supposed to be heap allocated at all. A short while back v8 introduced a new `v8::LocalVector<T>` collection type that more correctly handles the allocation and handling of a collection of locals. Update workerd to use it.