### PR TITLE
Move the default implied on date for nodejs-compat-v2

### DIFF
--- a/src/workerd/io/compatibility-date-test.c++
+++ b/src/workerd/io/compatibility-date-test.c++
@@ -178,8 +178,8 @@ KJ_TEST("compatibility flag parsing") {
   expectCompileCompatibilityFlags("2021-05-17", {"r2_internal_beta_bindings"}, "()", {},
       CompatibilityDateValidation::FUTURE_FOR_TEST, true, false);
 
-  // nodejs_compat implies nodejs_compat_v2 on or after 2024-08-05
-  expectCompileCompatibilityFlags("2024-09-02", {"nodejs_compat"},
+  // nodejs_compat implies nodejs_compat_v2 on or after 2024-09-23
+  expectCompileCompatibilityFlags("2024-09-23", {"nodejs_compat"},
       "(formDataParserSupportsFiles = true,"
       " fetchRefusesUnknownProtocols = true,"
       " esiIncludeIsVoidTag = false,"
@@ -236,7 +236,7 @@ KJ_TEST("compatibility flag parsing") {
       " allowCustomPorts = true,"
       " internalWritableStreamAbortClearsQueue = true)",
       {}, CompatibilityDateValidation::FUTURE_FOR_TEST, false, false);
-  expectCompileCompatibilityFlags("2024-09-01", {"nodejs_compat"},
+  expectCompileCompatibilityFlags("2024-09-22", {"nodejs_compat"},
       "(formDataParserSupportsFiles = true,"
       " fetchRefusesUnknownProtocols = true,"
       " esiIncludeIsVoidTag = false,"
@@ -289,7 +289,14 @@ KJ_TEST("compatibility flag parsing") {
       " fetchStandardUrl = true,"
       " nodeJsCompatV2 = false,"
       " globalFetchStrictlyPublic = false,"
-      " newModuleRegistry = false)",
+      " newModuleRegistry = false,"
+      " cacheOptionEnabled = false,"
+      " kvDirectBinding = false,"
+      " allowCustomPorts = true,"
+      " increaseWebsocketMessageSize = false,"
+      " internalWritableStreamAbortClearsQueue = true,"
+      " pythonWorkersDevPyodide = false,"
+      " nodeJsZlib = false)",
       {}, CompatibilityDateValidation::FUTURE_FOR_TEST, false, false);
 }
 

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -486,7 +486,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   nodeJsCompatV2 @50 :Bool
       $compatEnableFlag("nodejs_compat_v2")
       $compatDisableFlag("no_nodejs_compat_v2")
-      $impliedByAfterDate(name = "nodeJsCompat", date = "2024-09-02");
+      $impliedByAfterDate(name = "nodeJsCompat", date = "2024-09-23");
   # Implies nodeJSCompat with the following additional modifications:
   # * Node.js Compat built-ins may be imported/required with or without the node: prefix
   # * Node.js Compat the globals Buffer and process are available everywhere


### PR DESCRIPTION
Push back the date where nodejs-compat implies nodejs-compat-v2

@dom96 @vickykont ... this would need to go out into a release this week.