### PR TITLE
Cancel previous builds within the same PR on push

### DIFF
--- a/.github/workflows/fixup.yml
+++ b/.github/workflows/fixup.yml
@@ -1,7 +1,6 @@
 name: "Just say no to fixup commits"
 on:
-  pull_request:
-    types: [synchronize, opened, reopened]
+  workflow_call:
 
 jobs:
   block-fixup:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,8 +1,9 @@
 # Based on https://www.neilmacy.co.uk/blog/github-action-to-block-merging
 name: "Internal PR Required"
 on:
+  workflow_call:
   pull_request:
-    types: [synchronize, opened, reopened, labeled, unlabeled]
+    types: [labeled, unlabeled]
 
 jobs:
   InternalPRRequired:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,12 @@ on:
     branches:
     - main
 
+concurrency:
+  # Cancel existing builds for the same PR.
+  # Otherwise, all other builds will be allowed to run through.
+  group: lint.yml-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,18 @@ on:
     branches:
     - main
 
+concurrency:
+  # Cancel existing builds for the same PR.
+  # Otherwise, all other builds will be allowed to run through.
+  group: test.yml-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+
 jobs:
+  fixup:
+    uses: ./.github/workflows/fixup.yml
+  labels:
+   uses: ./.github/workflows/labels.yml 
   test:
     strategy:
       matrix:


### PR DESCRIPTION
What this does:
- Makes the test workflow responsible for triggering fixup, labels and lint. 
- Cancels the entire workflow if another commit is pushed to the same PR
- Allows all other builds to run through.

This should cut down on the number of runners in use, and lead to less wait time for builds.