### PR TITLE
Add `replicaRouting` compat flag

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -588,4 +588,10 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Enables node:zlib implementation while it is in-development.
   # Once the node:zlib implementation is complete, this will be automatically enabled when
   # nodejs_compat is enabled.
+
+  replicaRouting @60 :Bool
+      $compatEnableFlag("replica_routing")
+      $experimental;
+  # Enables routing to a replica on the client-side.
+  # Doesn't mean requests *will* be routed to a replica, only that they can be.
 }

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -151,6 +151,7 @@ public:
       const ActorIdFactory::ActorId& id,
       kj::Maybe<kj::String> locationHint,
       ActorGetMode mode,
+      bool enableReplicaRouting,
       SpanParent parentSpan) = 0;
 
   // Get an actor stub from the given namespace for the actor with the given name.

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -721,9 +721,10 @@ public:
       const ActorIdFactory::ActorId& id,
       kj::Maybe<kj::String> locationHint,
       ActorGetMode mode,
+      bool enableReplicaRouting,
       SpanParent parentSpan) {
     return getIoChannelFactory().getGlobalActor(
-        channel, id, kj::mv(locationHint), mode, kj::mv(parentSpan));
+        channel, id, kj::mv(locationHint), mode, enableReplicaRouting, kj::mv(parentSpan));
   }
   kj::Own<IoChannelFactory::ActorChannel> getColoLocalActorChannel(
       uint channel, kj::StringPtr id, SpanParent parentSpan) {

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2205,9 +2205,11 @@ private:
       const ActorIdFactory::ActorId& id,
       kj::Maybe<kj::String> locationHint,
       ActorGetMode mode,
+      bool enableReplicaRouting,
       SpanParent parentSpan) override {
     JSG_REQUIRE(mode == ActorGetMode::GET_OR_CREATE, Error,
         "workerd only supports GET_OR_CREATE mode for getting actor stubs");
+    JSG_REQUIRE(!enableReplicaRouting, Error, "workerd does not support replica routing.");
     auto& channels =
         KJ_REQUIRE_NONNULL(ioChannels.tryGet<LinkedIoChannels>(), "link() has not been called");
 

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -99,6 +99,7 @@ struct DummyIoChannelFactory final: public IoChannelFactory {
       const ActorIdFactory::ActorId& id,
       kj::Maybe<kj::String> locationHint,
       ActorGetMode mode,
+      bool enableReplicaRouting,
       SpanParent parentSpan) override {
     KJ_FAIL_REQUIRE("no actor channels");
   }


### PR DESCRIPTION
This will remain `experimental` for some time.

Note that turning this on in local dev would effectively be a no-op, but rather than allow the flag to be set and continue regular operation, we'll throw an exception.