### PR TITLE
call synctime when receiving new websocket messages

### DIFF
--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -962,6 +962,9 @@ kj::Promise<kj::Maybe<kj::Exception>> WebSocket::readLoop(
         a.getMetrics().receivedWebSocketMessage(size);
       }
 
+      // This should count as a new IO event, so we should call syncTime
+      context.getIoChannelFactory().getTimer().syncTime();
+
       // Re-enter the context with context.run(). This is arguably a bit unusual compared to other
       // I/O which is delivered by return from context.awaitIo(), but the difference here is that we
       // have a long stream of events over time. It makes sense to use context.run() each time a new


### PR DESCRIPTION
This seems safe to me since I don't really see a fundamental difference between websocket messages and fetch requests, and I think the hibernatable path already ends up calling synctime because I think it calls into IoContext::IncomingRequest::delivered() through HibernatableWebSocketCustomEventImpl::run(). (I'm not sure whether that run method gets ran for every new ws message though)

I think you may be able to get more accurate timestamps by sending messages to a websocket pair that you just hold in a worker internally, but I think you may already be able to do that with hibernatable websockets?