### PR TITLE
Log when deleteAll is called with an alarm still set on the object

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -509,9 +509,24 @@ jsg::Promise<void> DurableObjectStorage::deleteAll(
     jsg::Lock& js, jsg::Optional<PutOptions> maybeOptions) {
   auto options = configureOptions(kj::mv(maybeOptions).orDefault(PutOptions{}));
 
+  auto& context = IoContext::current();
+  {
+    // Log to get a sense of whether users are potentially depending on alarms being kept around
+    // after deleteAll is called.
+    auto getOptions = configureOptions(GetOptions{});
+    context.addTask(context
+                        .awaitJs(js,
+                            transformCacheResult(js, cache->getAlarm(getOptions), getOptions,
+                                [](jsg::Lock&, kj::Maybe<kj::Date> alarmValue) {
+      if (alarmValue != kj::none) {
+        LOG_WARNING_PERIODICALLY("NOSENTRY deleteAll called with an alarm still set");
+      }
+      return alarmValue;
+    })).ignoreResult());
+  }
+
   auto deleteAll = cache->deleteAll(options);
 
-  auto& context = IoContext::current();
   context.addTask(updateStorageDeletes(context, currentActorMetrics(), kj::mv(deleteAll.count)));
 
   return transformMaybeBackpressure(js, options, kj::mv(deleteAll.backpressure));


### PR DESCRIPTION
To get a better sense of the prevalence of this usage pattern.