### PR TITLE
Three more node:zlib tests

### DIFF
--- a/src/workerd/api/node/tests/zlib-nodejs-test.js
+++ b/src/workerd/api/node/tests/zlib-nodejs-test.js
@@ -1521,40 +1521,223 @@ export const zlibEmptyBuffer = {
     }
   },
 };
+
 // Test taken from:
 // https://github.com/nodejs/node/blob/d75e253c506310ea6728329981beb3284fa431b5/test/parallel/test-zlib-flush.js
 // TODO(soon): Enable this test once the bug is fixed
-export const zlibFlush = {
+// export const zlibFlush = {
+//   async test() {
+//     const opts = { level: 0 };
+//     const deflater = zlib.createDeflate(opts);
+
+//     const chunk = Buffer.from('/9j/4AAQSkZJRgABAQEASA==', 'base64');
+//     const expectedNone = Buffer.from([0x78, 0x01]);
+//     const blkhdr = Buffer.from([0x00, 0x10, 0x00, 0xef, 0xff]);
+//     const adler32 = Buffer.from([0x00, 0x00, 0x00, 0xff, 0xff]);
+//     const expectedFull = Buffer.concat([blkhdr, chunk, adler32]);
+//     let actualNone;
+//     let actualFull;
+
+//     const { promise, resolve } = Promise.withResolvers();
+//     deflater.write(chunk, function () {
+//       deflater.flush(zlib.constants.Z_NO_FLUSH, function () {
+//         actualNone = deflater.read();
+//         deflater.flush(function () {
+//           const bufs = [];
+//           let buf;
+//           while ((buf = deflater.read()) !== null) bufs.push(buf);
+//           actualFull = Buffer.concat(bufs);
+
+//           resolve();
+//         });
+//       });
+//     });
+
+//     await promise;
+//     assert.deepStrictEqual(actualNone, expectedNone);
+//     assert.deepStrictEqual(actualFull, expectedFull);
+//   },
+// };
+
+// Test taken from:
+// https://github.com/nodejs/node/blob/9bdf2ee1d184e7ec5c690319e068894ed324b595/test/parallel/test-zlib-dictionary.js
+export const zlibDictionary = {
   async test() {
-    const opts = { level: 0 };
-    const deflater = zlib.createDeflate(opts);
+    const spdyDict = Buffer.from(
+      [
+        'optionsgetheadpostputdeletetraceacceptaccept-charsetaccept-encodingaccept-',
+        'languageauthorizationexpectfromhostif-modified-sinceif-matchif-none-matchi',
+        'f-rangeif-unmodifiedsincemax-forwardsproxy-authorizationrangerefererteuser',
+        '-agent10010120020120220320420520630030130230330430530630740040140240340440',
+        '5406407408409410411412413414415416417500501502503504505accept-rangesageeta',
+        'glocationproxy-authenticatepublicretry-afterservervarywarningwww-authentic',
+        'ateallowcontent-basecontent-encodingcache-controlconnectiondatetrailertran',
+        'sfer-encodingupgradeviawarningcontent-languagecontent-lengthcontent-locati',
+        'oncontent-md5content-rangecontent-typeetagexpireslast-modifiedset-cookieMo',
+        'ndayTuesdayWednesdayThursdayFridaySaturdaySundayJanFebMarAprMayJunJulAugSe',
+        'pOctNovDecchunkedtext/htmlimage/pngimage/jpgimage/gifapplication/xmlapplic',
+        'ation/xhtmltext/plainpublicmax-agecharset=iso-8859-1utf-8gzipdeflateHTTP/1',
+        '.1statusversionurl\0',
+      ].join('')
+    );
 
-    const chunk = Buffer.from('/9j/4AAQSkZJRgABAQEASA==', 'base64');
-    const expectedNone = Buffer.from([0x78, 0x01]);
-    const blkhdr = Buffer.from([0x00, 0x10, 0x00, 0xef, 0xff]);
-    const adler32 = Buffer.from([0x00, 0x00, 0x00, 0xff, 0xff]);
-    const expectedFull = Buffer.concat([blkhdr, chunk, adler32]);
-    let actualNone;
-    let actualFull;
+    const input = [
+      'HTTP/1.1 200 Ok',
+      'Server: node.js',
+      'Content-Length: 0',
+      '',
+    ].join('\r\n');
 
-    const { promise, resolve } = Promise.withResolvers();
-    deflater.write(chunk, function () {
-      deflater.flush(zlib.constants.Z_NO_FLUSH, function () {
-        actualNone = deflater.read();
-        deflater.flush(function () {
-          const bufs = [];
-          let buf;
-          while ((buf = deflater.read()) !== null) bufs.push(buf);
-          actualFull = Buffer.concat(bufs);
+    // basicDictionaryTest
+    {
+      let { promise, resolve, reject } = Promise.withResolvers();
+      let output = '';
+      const deflate = zlib.createDeflate({ dictionary: spdyDict });
+      const inflate = zlib.createInflate({ dictionary: spdyDict });
+      inflate.setEncoding('utf-8');
 
-          resolve();
-        });
+      deflate.on('data', function (chunk) {
+        inflate.write(chunk);
       });
-    });
 
-    await promise;
-    assert.deepStrictEqual(actualNone, expectedNone);
-    assert.deepStrictEqual(actualFull, expectedFull);
+      deflate.on('error', reject);
+
+      inflate.on('data', function (chunk) {
+        output += chunk;
+      });
+
+      inflate.on('error', reject);
+
+      deflate.on('end', function () {
+        inflate.end();
+      });
+
+      inflate.on('end', function () {
+        assert.strictEqual(input, output);
+        resolve();
+      });
+
+      deflate.write(input);
+      deflate.end();
+      await promise;
+    }
+
+    // deflateResetDictionaryTest
+    {
+      let { promise, resolve, reject } = Promise.withResolvers();
+      let doneReset = false;
+      let output = '';
+      const deflate = zlib.createDeflate({ dictionary: spdyDict });
+      const inflate = zlib.createInflate({ dictionary: spdyDict });
+      inflate.setEncoding('utf-8');
+
+      deflate.on('data', function (chunk) {
+        if (doneReset) inflate.write(chunk);
+      });
+
+      deflate.on('error', reject);
+
+      inflate.on('data', function (chunk) {
+        output += chunk;
+      });
+
+      inflate.on('error', reject);
+
+      deflate.on('end', function () {
+        inflate.end();
+      });
+
+      inflate.on('end', function () {
+        assert.strictEqual(input, output);
+        resolve();
+      });
+
+      deflate.write(input);
+      deflate.flush(function () {
+        deflate.reset();
+        doneReset = true;
+        deflate.write(input);
+        deflate.end();
+      });
+
+      await promise;
+    }
+
+    // rawDictionaryTest
+    {
+      let { promise, resolve, reject } = Promise.withResolvers();
+      let output = '';
+      const deflate = zlib.createDeflateRaw({ dictionary: spdyDict });
+      const inflate = zlib.createInflateRaw({ dictionary: spdyDict });
+      inflate.setEncoding('utf-8');
+
+      deflate.on('data', function (chunk) {
+        inflate.write(chunk);
+      });
+
+      deflate.on('error', reject);
+
+      inflate.on('data', function (chunk) {
+        output += chunk;
+      });
+
+      inflate.on('error', reject);
+
+      deflate.on('end', function () {
+        inflate.end();
+      });
+
+      inflate.on('end', function () {
+        assert.strictEqual(input, output);
+        resolve();
+      });
+
+      deflate.write(input);
+      deflate.end();
+
+      await promise;
+    }
+
+    // deflateRawResetDictionaryTest
+    {
+      let { promise, resolve, reject } = Promise.withResolvers();
+      let doneReset = false;
+      let output = '';
+      const deflate = zlib.createDeflateRaw({ dictionary: spdyDict });
+      const inflate = zlib.createInflateRaw({ dictionary: spdyDict });
+      inflate.setEncoding('utf-8');
+
+      deflate.on('data', function (chunk) {
+        if (doneReset) inflate.write(chunk);
+      });
+
+      deflate.on('error', reject);
+
+      inflate.on('data', function (chunk) {
+        output += chunk;
+      });
+
+      inflate.on('error', reject);
+
+      deflate.on('end', function () {
+        inflate.end();
+      });
+
+      inflate.on('end', function () {
+        assert.strictEqual(input, output);
+        resolve();
+      });
+
+      deflate.write(input);
+      deflate.flush(function () {
+        deflate.reset();
+        doneReset = true;
+        deflate.write(input);
+        deflate.end();
+      });
+
+      await promise;
+    }
   },
 };
 
@@ -1577,7 +1760,7 @@ export const zlibFlush = {
 // - [ ] test-zlib-unused-weak.js
 // - [ ] test-zlib-brotli-from-string.js
 // - [x] test-zlib-deflate-constructors.js
-// - [ ] test-zlib-flush.js
+// - [x] test-zlib-flush.js
 // - [ ] test-zlib-maxOutputLength.js
 // - [x] test-zlib-unzip-one-byte-chunks.js
 // - [ ] test-zlib-brotli.js
@@ -1601,7 +1784,7 @@ export const zlibFlush = {
 // - [ ] test-zlib-params.js
 // - [x] test-zlib-zero-byte.js
 // - [ ] test-zlib-close-after-write.js
-// - [ ] test-zlib-dictionary.js
+// - [x] test-zlib-dictionary.js
 // - [x] test-zlib-from-string.js
 // - [ ] test-zlib-premature-end.js
 // - [x] test-zlib-zero-windowBits.js

--- a/src/workerd/api/node/tests/zlib-nodejs-test.js
+++ b/src/workerd/api/node/tests/zlib-nodejs-test.js
@@ -1521,6 +1521,42 @@ export const zlibEmptyBuffer = {
     }
   },
 };
+// Test taken from:
+// https://github.com/nodejs/node/blob/d75e253c506310ea6728329981beb3284fa431b5/test/parallel/test-zlib-flush.js
+// TODO(soon): Enable this test once the bug is fixed
+export const zlibFlush = {
+  async test() {
+    const opts = { level: 0 };
+    const deflater = zlib.createDeflate(opts);
+
+    const chunk = Buffer.from('/9j/4AAQSkZJRgABAQEASA==', 'base64');
+    const expectedNone = Buffer.from([0x78, 0x01]);
+    const blkhdr = Buffer.from([0x00, 0x10, 0x00, 0xef, 0xff]);
+    const adler32 = Buffer.from([0x00, 0x00, 0x00, 0xff, 0xff]);
+    const expectedFull = Buffer.concat([blkhdr, chunk, adler32]);
+    let actualNone;
+    let actualFull;
+
+    const { promise, resolve } = Promise.withResolvers();
+    deflater.write(chunk, function () {
+      deflater.flush(zlib.constants.Z_NO_FLUSH, function () {
+        actualNone = deflater.read();
+        deflater.flush(function () {
+          const bufs = [];
+          let buf;
+          while ((buf = deflater.read()) !== null) bufs.push(buf);
+          actualFull = Buffer.concat(bufs);
+
+          resolve();
+        });
+      });
+    });
+
+    await promise;
+    assert.deepStrictEqual(actualNone, expectedNone);
+    assert.deepStrictEqual(actualFull, expectedFull);
+  },
+};
 
 // Node.js tests relevant to zlib
 //

--- a/src/workerd/api/node/tests/zlib-nodejs-test.js
+++ b/src/workerd/api/node/tests/zlib-nodejs-test.js
@@ -1741,6 +1741,29 @@ export const zlibDictionary = {
   },
 };
 
+// Test taken from
+// https://github.com/nodejs/node/blob/ef6b9ffc8dfc7b2a395c864d2729a0ce1be9ef18/test/parallel/test-zlib-close-after-write.js
+export const closeAfterWrite = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const close = mock.fn();
+
+    zlib.gzip('hello', (err, out) => {
+      assert.ifError(err);
+
+      const unzip = zlib.createGunzip();
+      unzip.write(out);
+      unzip.close(() => {
+        close();
+        resolve();
+      });
+    });
+
+    await promise;
+    assert.strictEqual(close.mock.callCount(), 1);
+  },
+};
+
 // Node.js tests relevant to zlib
 //
 // - [ ] test-zlib-brotli-16GB.js
@@ -1783,7 +1806,7 @@ export const zlibDictionary = {
 // - [x] test-zlib-from-gzip-with-trailing-garbage.js
 // - [ ] test-zlib-params.js
 // - [x] test-zlib-zero-byte.js
-// - [ ] test-zlib-close-after-write.js
+// - [x] test-zlib-close-after-write.js
 // - [x] test-zlib-dictionary.js
 // - [x] test-zlib-from-string.js
 // - [ ] test-zlib-premature-end.js


### PR DESCRIPTION
Nice small PR for EOD Friday. Adds two tests from NodeJS. Actually, we'll throw in a third one at no additional cost.

- test-zlib-flush.js (currently fails)
- test-zlib-dictionary.js (all good!)
- test-zlib-close-after-write (all good!)
