### PR TITLE
fix node:zlib flush tests

### DIFF
--- a/src/node/internal/internal_zlib_base.ts
+++ b/src/node/internal/internal_zlib_base.ts
@@ -157,8 +157,8 @@ function processCallback(this: ZlibHandleType): void {
           handle.availInBefore, // in_len
           self._outBuffer, // out
           self._outOffset, // out_off
-          self._chunkSize
-        ); // out_len
+          self._chunkSize // out_len
+        );
         self._read(n);
       };
     }
@@ -470,9 +470,9 @@ export class ZlibBase extends Transform {
     kind?: number | (() => void),
     callback: (() => void) | undefined = undefined
   ): void {
-    if (typeof kind === 'function' || (kind == null && !callback)) {
+    if (typeof kind === 'function' || (kind === undefined && !callback)) {
       callback = kind as (() => void) | undefined;
-      kind = this._defaultFlushFlag;
+      kind = this._defaultFullFlushFlag;
     }
 
     if (this.writableFinished) {
@@ -650,7 +650,6 @@ export class Zlib extends ZlibBase {
       dictionary
     );
     super(options ?? {}, mode, handle);
-    handle[owner_symbol] = this;
     this._level = level;
     this._strategy = strategy;
     this._handle = handle;
@@ -678,7 +677,7 @@ export class Zlib extends ZlibBase {
       );
     } else {
       /* eslint-disable-next-line @typescript-eslint/no-unsafe-call */
-      queueMicrotask(() => callback());
+      queueMicrotask(callback);
     }
   }
 

--- a/src/workerd/api/node/tests/zlib-nodejs-test.js
+++ b/src/workerd/api/node/tests/zlib-nodejs-test.js
@@ -1521,40 +1521,39 @@ export const zlibEmptyBuffer = {
 
 // Test taken from:
 // https://github.com/nodejs/node/blob/d75e253c506310ea6728329981beb3284fa431b5/test/parallel/test-zlib-flush.js
-// TODO(soon): Enable this test once the bug is fixed
-// export const zlibFlush = {
-//   async test() {
-//     const opts = { level: 0 };
-//     const deflater = zlib.createDeflate(opts);
+export const zlibFlush = {
+  async test() {
+    const opts = { level: 0 };
+    const deflater = zlib.createDeflate(opts);
 
-//     const chunk = Buffer.from('/9j/4AAQSkZJRgABAQEASA==', 'base64');
-//     const expectedNone = Buffer.from([0x78, 0x01]);
-//     const blkhdr = Buffer.from([0x00, 0x10, 0x00, 0xef, 0xff]);
-//     const adler32 = Buffer.from([0x00, 0x00, 0x00, 0xff, 0xff]);
-//     const expectedFull = Buffer.concat([blkhdr, chunk, adler32]);
-//     let actualNone;
-//     let actualFull;
+    const chunk = Buffer.from('/9j/4AAQSkZJRgABAQEASA==', 'base64');
+    const expectedNone = Buffer.from([0x78, 0x01]);
+    const blkhdr = Buffer.from([0x00, 0x10, 0x00, 0xef, 0xff]);
+    const adler32 = Buffer.from([0x00, 0x00, 0x00, 0xff, 0xff]);
+    const expectedFull = Buffer.concat([blkhdr, chunk, adler32]);
+    let actualNone;
+    let actualFull;
 
-//     const { promise, resolve } = Promise.withResolvers();
-//     deflater.write(chunk, function () {
-//       deflater.flush(zlib.constants.Z_NO_FLUSH, function () {
-//         actualNone = deflater.read();
-//         deflater.flush(function () {
-//           const bufs = [];
-//           let buf;
-//           while ((buf = deflater.read()) !== null) bufs.push(buf);
-//           actualFull = Buffer.concat(bufs);
+    const { promise, resolve } = Promise.withResolvers();
+    deflater.write(chunk, function () {
+      deflater.flush(zlib.constants.Z_NO_FLUSH, function () {
+        actualNone = deflater.read();
+        deflater.flush(function () {
+          const bufs = [];
+          let buf;
+          while ((buf = deflater.read()) !== null) bufs.push(buf);
+          actualFull = Buffer.concat(bufs);
 
-//           resolve();
-//         });
-//       });
-//     });
+          resolve();
+        });
+      });
+    });
 
-//     await promise;
-//     assert.deepStrictEqual(actualNone, expectedNone);
-//     assert.deepStrictEqual(actualFull, expectedFull);
-//   },
-// };
+    await promise;
+    assert.deepStrictEqual(actualNone, expectedNone);
+    assert.deepStrictEqual(actualFull, expectedFull);
+  },
+};
 
 // Test taken from:
 // https://github.com/nodejs/node/blob/9bdf2ee1d184e7ec5c690319e068894ed324b595/test/parallel/test-zlib-dictionary.js


### PR DESCRIPTION
Fixes a bug on `node:zlib` due to using `defaultFlushFlag` instead of `defaultFullFlushFlag`