### PR TITLE
Update Github Actions dependencies

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.4.0
+        uses: contributor-assistant/github-action@v2.5.1
         env:
           # CLA Action uses this in-built GitHub token to make the API calls for interacting with GitHub.
           # It is built into Github Actions and does not need to be manually specified in your secrets store.

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -9,7 +9,7 @@ jobs:
     name: Add issue to GH project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.6.0
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/cloudflare/projects/1
           github-token: ${{ secrets.DEVPROD_PAT }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           WORKERD_VERSION: ${{ needs.version.outputs.version }}
           LATEST_COMPATIBILITY_DATE: ${{ needs.version.outputs.date }}
-      - uses: robinraju/release-downloader@v1.9
+      - uses: robinraju/release-downloader@v1.11
         with:
           tag: v${{ needs.version.outputs.release_version }}
           fileName: workerd-${{ matrix.arch }}.gz

--- a/build/BUILD.dawn
+++ b/build/BUILD.dawn
@@ -1103,9 +1103,9 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/tint/lang/wgsl/features",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
-        "@dawn//src/tint/lang/wgsl/features",
     ],
 )
 
@@ -1144,6 +1144,6 @@ cc_library(
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
-        "@dawn//src/tint/api",
+        "//src/tint/api",
     ],
 )


### PR DESCRIPTION
- This finally fixes warnings about the deprecated node16 being used for CLAssistant.
- Use short-form for dependencies in BUILD.dawn