### PR TITLE
enable linter for module.ts

### DIFF
--- a/src/node/buffer.ts
+++ b/src/node/buffer.ts
@@ -2,8 +2,6 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-
 import {
   constants,
   kMaxLength,

--- a/src/node/internal/crypto.d.ts
+++ b/src/node/internal/crypto.d.ts
@@ -166,13 +166,6 @@ export type KeyAlgorithm =
   | HmacKeyAlgorithm
   | AesKeyAlgorithm;
 
-export interface CryptoKey {
-  algorithm: KeyAlgorithm;
-  extractable: boolean;
-  type: KeyObjectType;
-  usages: string[];
-}
-
 export interface RsaOtherPrimesInfo {
   d?: string;
   r?: string;

--- a/src/node/internal/crypto_hash.ts
+++ b/src/node/internal/crypto_hash.ts
@@ -199,7 +199,7 @@ export function createHmac(
 let Hmac = function (
   this: Hmac,
   hmac: string,
-  key: ArrayLike | KeyObject | cryptoImpl.CryptoKey,
+  key: CryptoKey,
   options?: TransformOptions
 ): Hmac {
   if (!(this instanceof Hmac)) {
@@ -214,11 +214,8 @@ let Hmac = function (
     }
     this[kHandle] = new cryptoImpl.HmacHandle(hmac, key[kHandle]);
   } else if (isCryptoKey(key)) {
-    if ((key as cryptoImpl.CryptoKey).type !== 'secret') {
-      throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(
-        (key as cryptoImpl.CryptoKey).type,
-        'secret'
-      );
+    if (key.type !== 'secret') {
+      throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(key.type, 'secret');
     }
     this[kHandle] = new cryptoImpl.HmacHandle(hmac, key);
   } else if (
@@ -241,7 +238,7 @@ let Hmac = function (
   } else {
     this[kHandle] = new cryptoImpl.HmacHandle(
       hmac,
-      getArrayBufferOrView(key as ArrayLike, 'key', encoding)
+      getArrayBufferOrView(key, 'key', encoding)
     );
   }
 

--- a/src/node/internal/crypto_keys.ts
+++ b/src/node/internal/crypto_keys.ts
@@ -29,7 +29,6 @@
 import { Buffer } from 'node-internal:internal_buffer';
 
 import {
-  CryptoKey,
   KeyData,
   KeyObjectType,
   KeyExportResult,

--- a/src/node/internal/crypto_util.ts
+++ b/src/node/internal/crypto_util.ts
@@ -90,7 +90,7 @@ export const numberToHexCharCode = (number: number): number =>
  */
 export function arrayBufferToUnsignedBigInt(buf: ArrayBuffer): bigint {
   const length = buf.byteLength;
-  const chars = Array<number>(length * 2);
+  const chars = new Array<number>(length * 2);
   const view = new DataView(buf);
 
   for (let i = 0; i < length; i++) {

--- a/src/node/internal/internal_zlib.ts
+++ b/src/node/internal/internal_zlib.ts
@@ -104,7 +104,6 @@ function wrapCallback(
   callback: CompressCallback<Error, Buffer>
 ): CompressCallback<string, ArrayBuffer> {
   return (error: string | null, result: ArrayBuffer | undefined) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     queueMicrotask(() => {
       if (error) {
         callback(new Error(error));

--- a/src/node/internal/internal_zlib_base.ts
+++ b/src/node/internal/internal_zlib_base.ts
@@ -477,7 +477,6 @@ export class ZlibBase extends Transform {
 
     if (this.writableFinished) {
       if (callback) {
-        /* eslint-disable-next-line @typescript-eslint/no-unsafe-call */
         queueMicrotask(callback);
       }
     } else if (this.writableEnded) {
@@ -538,7 +537,6 @@ export class ZlibBase extends Transform {
 
   #processChunk(chunk: Buffer, flushFlag: number, cb: () => void): void {
     if (!this._handle) {
-      /* eslint-disable-next-line @typescript-eslint/no-unsafe-call */
       queueMicrotask(cb);
       return;
     }
@@ -644,7 +642,6 @@ export class Zlib extends ZlibBase {
       writeState,
 
       () => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         queueMicrotask(processCallback.bind(handle));
       },
       dictionary
@@ -676,7 +673,6 @@ export class Zlib extends ZlibBase {
         this.#paramsAfterFlushCallback.bind(this, level, strategy, callback)
       );
     } else {
-      /* eslint-disable-next-line @typescript-eslint/no-unsafe-call */
       queueMicrotask(callback);
     }
   }

--- a/src/node/internal/web_crypto.d.ts
+++ b/src/node/internal/web_crypto.d.ts
@@ -1,9 +1,0 @@
-// Just enough of web crypto api to write the code in node-compat
-type SubtleCrypto = unknown;
-
-type CryptoKey = unknown;
-
-declare const CryptoKey: {
-  prototype: CryptoKey;
-  new (): CryptoKey;
-};

--- a/src/node/module.ts
+++ b/src/node/module.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2017-2022 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-/* eslint-disable */
 
 import { default as moduleUtil } from 'node-internal:module';
 import { ERR_INVALID_ARG_VALUE } from 'node-internal:internal_errors';
@@ -11,22 +10,18 @@ export function createRequire(
 ): (specifier: string) => unknown {
   // Note that per Node.js' requirements, path must be one of either
   // an absolute file path or a file URL. We do not currently handle
-  // module specifiers as URLs yet but we'll try to get close.
+  // module specifiers as URLs yet, but we'll try to get close.
 
-  path = `${path}`;
-  if (
-    !(path as string).startsWith('/') &&
-    !(path as string).startsWith('file:')
-  ) {
+  const normalizedPath = `${path}`;
+  if (!normalizedPath.startsWith('/') && !normalizedPath.startsWith('file:')) {
     throw new ERR_INVALID_ARG_VALUE(
       'path',
-      path,
-      'The argument must be a file URL object, ' +
-        'a file URL string, or an absolute path string.'
+      normalizedPath,
+      'The argument must be a file URL object, a file URL string, or an absolute path string.'
     );
   }
 
-  return moduleUtil.createRequire(path as string);
+  return moduleUtil.createRequire(normalizedPath);
 }
 
 // Indicates only that the given specifier is known to be a

--- a/src/node/tsconfig.json
+++ b/src/node/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "dom"],
     "alwaysStrict": true,
     "strict": true,
     "allowJs": true,

--- a/src/node/url.ts
+++ b/src/node/url.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2017-2022 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { default as urlUtil } from 'node-internal:url';
 import { ERR_MISSING_ARGS } from 'node-internal:internal_errors';
 

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -153,6 +153,7 @@ wd_test(
 )
 
 wd_test(
+    size = "large",
     src = "tests/zlib-nodejs-test.wd-test",
     args = ["--experimental"],
     data = ["tests/zlib-nodejs-test.js"],


### PR DESCRIPTION
We no longer need to disable linters for files that use URL or queueMicrotask()