### PR TITLE
Throw error if the python package disk cache dir is missing.

### DIFF
--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -995,7 +995,8 @@ public:
     kj::Path path = fs->getCurrentPath().eval(pathStr);
     kj::Maybe<kj::Own<const kj::Directory>> dir =
         fs->getRoot().tryOpenSubdir(path, kj::WriteMode::MODIFY);
-    server->setPackageDiskCacheRoot(kj::mv(dir));
+    server->setPackageDiskCacheRoot(
+        kj::mv(KJ_UNWRAP_OR(dir, CLI_ERROR("package disk cache dir must exist"))));
   }
 
   void setPyodideDiskCacheDir(kj::StringPtr pathStr) {


### PR DESCRIPTION
I ran into this when regenerating snapshots, should be loud here so we aren't accidentally not using the disk cache when we're supposed to. Unless there are cases where we rely on this silently failing?