### PR TITLE
Allow SQL interface to be enabled without "experimental" compat flag.

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -16,6 +16,7 @@
 #include "sql.h"
 #include <workerd/api/web-socket.h>
 #include <workerd/io/hibernation-manager.h>
+#include <workerd/io/features.h>
 
 namespace workerd::api {
 
@@ -700,35 +701,49 @@ jsg::Promise<void> DurableObjectStorage::sync(jsg::Lock& js) {
   }
 }
 
-jsg::Optional<jsg::Ref<SqlStorage>> DurableObjectStorage::getSql(
-    jsg::Lock& js, CompatibilityFlags::Reader flags) {
+SqliteDatabase& DurableObjectStorage::getSqliteDb(jsg::Lock& js) {
   KJ_IF_SOME(db, cache->getSqliteDatabase()) {
     // Actor is SQLite-backed but let's make sure SQL is configured to be enabled.
-    if (!enableSql) {
+    if (enableSql) {
+      return db;
+    } else if (FeatureFlags::get(js).getWorkerdExperimental()) {
       // For backwards-compatibility, if the `experimental` compat flag is on, enable SQL. This is
       // deprecated, though, so warn in this case.
-      if (flags.getWorkerdExperimental()) {
-        // TODO(soon): Uncomment this warning after the D1 simulator has been updated to use
-        //   `enableSql`. Otherwise, people doing local dev against D1 may see the warning
-        //   spuriously.
 
-        // IoContext::current().logWarningOnce(
-        //     "Enabling SQL API based on the 'experimental' flag, but this will stop working soon. "
-        //     "Instead, please set `enableSql = true` in your workerd config for the DO namespace. "
-        //     "If using wrangler, under `[[migrations]]` in wrangler.toml, change `new_classes` to "
-        //     "`new_sqlite_classes`.");
-      } else {
-        // SQL is not enabled at all.
-        return kj::none;
-      }
+      // TODO(soon): Uncomment this warning after the D1 simulator has been updated to use
+      //   `enableSql`. Otherwise, people doing local dev against D1 may see the warning
+      //   spuriously.
+
+      // IoContext::current().logWarningOnce(
+      //     "Enabling SQL API based on the 'experimental' flag, but this will stop working soon. "
+      //     "Instead, please set `enableSql = true` in your workerd config for the DO namespace. "
+      //     "If using wrangler, under `[[migrations]]` in wrangler.toml, change `new_classes` to "
+      //     "`new_sqlite_classes`.");
+
+      return db;
+    } else {
+      // We're presumably running local workerd, which always uses SQLite for DO storage, but we're
+      // trying to simulate a non-SQLite DO namespace for testing purposes.
+      JSG_FAIL_REQUIRE(Error,
+          "SQL is not enabled for this Durable Object class. To enable it, set "
+          "`enableSql = true` in your workerd config for the class. If using wrangler, "
+          "under `[[migrations]]` in wrangler.toml, change `new_classes` to "
+          "`new_sqlite_classes`. Note that this change cannot be made after the class is "
+          "already deployed to production.");
     }
-
-    return jsg::alloc<SqlStorage>(db, JSG_THIS);
   } else {
-    // Not SQLite-backed.
-    KJ_REQUIRE(!enableSql, "Durable Object is not backed by SQL but enableSql was true?");
-    return kj::none;
+    // We're in production (not local workerd) and this DO namespace is not backed by SQLite.
+    JSG_FAIL_REQUIRE(Error,
+        "This Durable Object is not backed by SQLite storage, so the SQL API is not available. "
+        "SQL can be enabled on a new Durable Object class by using the `new_sqlite_classes` "
+        "instead of `new_classes` under `[[migrations]]` in your wrangler.toml, but an "
+        "already-deployed class cannot be converted to SQLite (except by deleting the existing "
+        "data).");
   }
+}
+
+jsg::Ref<SqlStorage> DurableObjectStorage::getSql(jsg::Lock& js) {
+  return jsg::alloc<SqlStorage>(JSG_THIS);
 }
 
 kj::Promise<kj::String> DurableObjectStorage::getCurrentBookmark() {

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -238,11 +238,9 @@ public:
     JSG_LAZY_INSTANCE_PROPERTY(sql, getSql);
     JSG_METHOD(transactionSync);
 
-    if (flags.getWorkerdExperimental()) {
-      JSG_METHOD(getCurrentBookmark);
-      JSG_METHOD(getBookmarkForTime);
-      JSG_METHOD(onNextSessionRestoreBookmark);
-    }
+    JSG_METHOD(getCurrentBookmark);
+    JSG_METHOD(getBookmarkForTime);
+    JSG_METHOD(onNextSessionRestoreBookmark);
 
     JSG_TS_OVERRIDE({
       get<T = unknown>(key: string, options?: DurableObjectGetOptions): Promise<T | undefined>;
@@ -504,12 +502,7 @@ public:
     JSG_METHOD(getHibernatableWebSocketEventTimeout);
     JSG_METHOD(getTags);
 
-    if (flags.getWorkerdExperimental()) {
-      // TODO(someday): This currently exists for testing purposes only but maybe it could be
-      //   useful to apps in actual production? It's a convenient way to bail out when you discover
-      //   your state is inconsistent.
-      JSG_METHOD(abort);
-    }
+    JSG_METHOD(abort);
 
     JSG_TS_ROOT();
     JSG_TS_OVERRIDE({

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -180,6 +180,9 @@ public:
     return *cache;
   }
 
+  // Throws if not SQLite-backed.
+  SqliteDatabase& getSqliteDb(jsg::Lock& js);
+
   struct TransactionOptions {
     jsg::Optional<kj::Date> asOfTime;
     jsg::Optional<bool> lowPriority;
@@ -201,7 +204,7 @@ public:
 
   jsg::Promise<void> sync(jsg::Lock& js);
 
-  jsg::Optional<jsg::Ref<SqlStorage>> getSql(jsg::Lock& js, CompatibilityFlags::Reader flags);
+  jsg::Ref<SqlStorage> getSql(jsg::Lock& js);
 
   // Get a bookmark for the current state of the database. Note that since this is async, the
   // bookmark will include any writes in the current atomic batch, including writes that are

--- a/src/workerd/api/sql-test.wd-test
+++ b/src/workerd/api/sql-test.wd-test
@@ -11,6 +11,8 @@ const config :Workerd.Config = (
 
 const mainWorker :Workerd.Worker = (
   compatibilityDate = "2024-03-04",
+
+  # "experimental" flag is needed to test `sql.ingest()`
   compatibilityFlags = ["experimental", "nodejs_compat"],
 
   modules = [
@@ -18,7 +20,9 @@ const mainWorker :Workerd.Worker = (
   ],
 
   durableObjectNamespaces = [
-    (className = "DurableObjectExample", uniqueKey = "210bd0cbd803ef7883a1ee9d86cce06e"),
+    ( className = "DurableObjectExample",
+      uniqueKey = "210bd0cbd803ef7883a1ee9d86cce06e",
+      enableSql = true ),
   ],
 
   durableObjectStorage = (localDisk = "TEST_TMPDIR"),

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -97,9 +97,11 @@ public:
   struct Durable {
     kj::String uniqueKey;
     bool isEvictable;
+    bool enableSql;
   };
   struct Ephemeral {
     bool isEvictable;
+    bool enableSql;
   };
   using ActorConfig = kj::OneOf<Durable, Ephemeral>;
 

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -579,6 +579,14 @@ struct Worker {
     # pinned to memory forever, so we provide this flag to change the default behavior.
     #
     # Note that this is only supported in Workerd; production Durable Objects cannot toggle eviction.
+
+    enableSql @4 :Bool;
+    # Whether or not Durable Objects in this namespace can use the `storage.sql` API to execute SQL
+    # queries.
+    #
+    # workerd uses SQLite to back all Durable Objects, but the SQL API is hidden by default to
+    # emulate behavior of traditional DO namespaces on Cloudflare that aren't SQLite-backed. This
+    # flag should be enabled when testing code that will run on a SQLite-backed namespace.
   }
 
   durableObjectUniqueKeyModifier @8 :Text;

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -364,7 +364,8 @@ TestFixture::TestFixture(SetupParams&& params)
       auto makeStorage =
           [](jsg::Lock& js, const Worker::Api& api,
               ActorCacheInterface& actorCache) -> jsg::Ref<api::DurableObjectStorage> {
-        return jsg::alloc<api::DurableObjectStorage>(IoContext::current().addObject(actorCache));
+        return jsg::alloc<api::DurableObjectStorage>(
+            IoContext::current().addObject(actorCache), /*enableSql=*/false);
       };
       actor = kj::refcounted<Worker::Actor>(*worker, /*tracker=*/kj::none, kj::mv(id),
           /*hasTransient=*/false, makeActorCache,


### PR DESCRIPTION
Instead, it can be enabled in the workerd config.

In production, it'll be enabled implicitly if the new SQLite-based storage engine is in use. But `workerd` running locally always uses SQLite, even when testing code intended to run against non-SQLite namespaces in production, so we need a config option for workerd.

**Also enable PITR and abort() APIs without "experimental".**

Point-in-time recovery is only supported for SQLite-backed DOs in production; PITR methods will throw for non-SQLite namespaces.

abort() will work for all DOs. I think we've generally agreed this should be made public, but it's especially needed with the PITR APIs since you need a way to restart the object immediately after calling `onNextSessionRestoreBookmark()`.