### PR TITLE
Removing the unused bucket colo id property

### DIFF
--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -160,7 +160,6 @@ interface RequestInitCfProperties extends Record<string, unknown> {
   minify?: RequestInitCfPropertiesImageMinify;
   mirage?: boolean;
   polish?: "lossy" | "lossless" | "off";
-  r2?: RequestInitCfPropertiesR2;
   /**
    * Redirects the request to an alternate origin server. You can use this,
    * for example, to implement load balancing across several origins.
@@ -378,13 +377,6 @@ interface RequestInitCfPropertiesImageMinify {
   javascript?: boolean;
   css?: boolean;
   html?: boolean;
-}
-
-interface RequestInitCfPropertiesR2 {
-  /**
-   * Colo id of bucket that an object is stored in
-   */
-  bucketColoId?: number;
 }
 
 /**

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -12232,7 +12232,6 @@ interface RequestInitCfProperties extends Record<string, unknown> {
   minify?: RequestInitCfPropertiesImageMinify;
   mirage?: boolean;
   polish?: "lossy" | "lossless" | "off";
-  r2?: RequestInitCfPropertiesR2;
   /**
    * Redirects the request to an alternate origin server. You can use this,
    * for example, to implement load balancing across several origins.
@@ -12454,12 +12453,6 @@ interface RequestInitCfPropertiesImageMinify {
   javascript?: boolean;
   css?: boolean;
   html?: boolean;
-}
-interface RequestInitCfPropertiesR2 {
-  /**
-   * Colo id of bucket that an object is stored in
-   */
-  bucketColoId?: number;
 }
 /**
  * Request metadata provided by Cloudflare's edge.

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -12244,7 +12244,6 @@ export interface RequestInitCfProperties extends Record<string, unknown> {
   minify?: RequestInitCfPropertiesImageMinify;
   mirage?: boolean;
   polish?: "lossy" | "lossless" | "off";
-  r2?: RequestInitCfPropertiesR2;
   /**
    * Redirects the request to an alternate origin server. You can use this,
    * for example, to implement load balancing across several origins.
@@ -12466,12 +12465,6 @@ export interface RequestInitCfPropertiesImageMinify {
   javascript?: boolean;
   css?: boolean;
   html?: boolean;
-}
-export interface RequestInitCfPropertiesR2 {
-  /**
-   * Colo id of bucket that an object is stored in
-   */
-  bucketColoId?: number;
 }
 /**
  * Request metadata provided by Cloudflare's edge.

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -11572,7 +11572,6 @@ interface RequestInitCfProperties extends Record<string, unknown> {
   minify?: RequestInitCfPropertiesImageMinify;
   mirage?: boolean;
   polish?: "lossy" | "lossless" | "off";
-  r2?: RequestInitCfPropertiesR2;
   /**
    * Redirects the request to an alternate origin server. You can use this,
    * for example, to implement load balancing across several origins.
@@ -11794,12 +11793,6 @@ interface RequestInitCfPropertiesImageMinify {
   javascript?: boolean;
   css?: boolean;
   html?: boolean;
-}
-interface RequestInitCfPropertiesR2 {
-  /**
-   * Colo id of bucket that an object is stored in
-   */
-  bucketColoId?: number;
 }
 /**
  * Request metadata provided by Cloudflare's edge.

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -11584,7 +11584,6 @@ export interface RequestInitCfProperties extends Record<string, unknown> {
   minify?: RequestInitCfPropertiesImageMinify;
   mirage?: boolean;
   polish?: "lossy" | "lossless" | "off";
-  r2?: RequestInitCfPropertiesR2;
   /**
    * Redirects the request to an alternate origin server. You can use this,
    * for example, to implement load balancing across several origins.
@@ -11806,12 +11805,6 @@ export interface RequestInitCfPropertiesImageMinify {
   javascript?: boolean;
   css?: boolean;
   html?: boolean;
-}
-export interface RequestInitCfPropertiesR2 {
-  /**
-   * Colo id of bucket that an object is stored in
-   */
-  bucketColoId?: number;
 }
 /**
  * Request metadata provided by Cloudflare's edge.


### PR DESCRIPTION
Reverting https://github.com/jkoe-cf/workerd/commit/1a99c34134819f3ddca2a0672c613c1a6f7b8f8e because the property is no longer needed (and is not applicable for general workers usage)