### PR TITLE
fix timeout issues on linux-debug

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -378,6 +378,7 @@ wd_test(
 )
 
 wd_test(
+    size = "large",
     src = "tests/global-scope-test.wd-test",
     args = ["--experimental"],
     data = ["tests/global-scope-test.js"],


### PR DESCRIPTION
We have a constant timeout on linux-debug on `global-scope-test`.