### PR TITLE
refactor zlib to simplify our implementation

### DIFF
--- a/src/workerd/api/node/zlib-util.c++
+++ b/src/workerd/api/node/zlib-util.c++
@@ -499,11 +499,11 @@ void ZlibUtil::CompressionStream<CompressionContext>::writeStream(jsg::Lock& js,
 
   writing = true;
 
-  context().setBuffers(input, inputLength, output, outputLength);
-  context().setFlush(flush);
+  context.setBuffers(input, inputLength, output, outputLength);
+  context.setFlush(flush);
 
   if constexpr (!async) {
-    context().work();
+    context.work();
     if (checkError(js)) {
       updateWriteResult();
       writing = false;
@@ -513,7 +513,7 @@ void ZlibUtil::CompressionStream<CompressionContext>::writeStream(jsg::Lock& js,
 
   // On Node.js, this is called as a result of `ScheduleWork()` call.
   // Since, we implement the whole thing as sync, we're going to ahead and call the whole thing here.
-  context().work();
+  context.work();
 
   // This is implemented slightly differently in Node.js
   // Node.js calls AfterThreadPoolWork().
@@ -543,7 +543,7 @@ void ZlibUtil::CompressionStream<CompressionContext>::close() {
 
 template <typename CompressionContext>
 bool ZlibUtil::CompressionStream<CompressionContext>::checkError(jsg::Lock& js) {
-  KJ_IF_SOME(error, context().getError()) {
+  KJ_IF_SOME(error, context.getError()) {
     emitError(js, kj::mv(error));
     return false;
   }
@@ -562,7 +562,7 @@ template <typename CompressionContext>
 void ZlibUtil::CompressionStream<CompressionContext>::updateWriteResult() {
   KJ_IF_SOME(wr, writeResult) {
     auto ptr = wr.template asArrayPtr<uint32_t>();
-    context().getAfterWriteResult(&ptr[1], &ptr[0]);
+    context.getAfterWriteResult(&ptr[1], &ptr[0]);
   }
 }
 
@@ -600,7 +600,7 @@ void ZlibUtil::CompressionStream<CompressionContext>::write(jsg::Lock& js,
 
 template <typename CompressionContext>
 void ZlibUtil::CompressionStream<CompressionContext>::reset(jsg::Lock& js) {
-  KJ_IF_SOME(error, context().resetStream()) {
+  KJ_IF_SOME(error, context.resetStream()) {
     emitError(js, kj::mv(error));
   }
 }
@@ -617,13 +617,13 @@ void ZlibUtil::ZlibStream::initialize(int windowBits,
     jsg::Function<void()> writeCallback,
     jsg::Optional<kj::Array<kj::byte>> dictionary) {
   initializeStream(kj::mv(writeState), kj::mv(writeCallback));
-  context().setAllocationFunctions(AllocForZlib, FreeForZlib, this);
-  context().initialize(level, windowBits, memLevel, strategy, kj::mv(dictionary));
+  context.setAllocationFunctions(AllocForZlib, FreeForZlib, this);
+  context.initialize(level, windowBits, memLevel, strategy, kj::mv(dictionary));
 }
 
 void ZlibUtil::ZlibStream::params(jsg::Lock& js, int _level, int _strategy) {
-  context().setParams(_level, _strategy);
-  KJ_IF_SOME(err, context().getError()) {
+  context.setParams(_level, _strategy);
+  KJ_IF_SOME(err, context.getError()) {
     emitError(js, kj::mv(err));
   }
 }

--- a/src/workerd/api/node/zlib-util.h
+++ b/src/workerd/api/node/zlib-util.h
@@ -341,7 +341,7 @@ public:
     CompressionContext context;
 
     CompressionContext& getContext() {
-      return *&context;
+      return context;
     }
 
     void initializeStream(jsg::BufferSource _write_result, jsg::Function<void()> writeCallback);

--- a/src/workerd/api/node/zlib-util.h
+++ b/src/workerd/api/node/zlib-util.h
@@ -294,7 +294,7 @@ public:
   template <class CompressionContext>
   class CompressionStream: public jsg::Object {
   public:
-    explicit CompressionStream(ZlibMode _mode): context_(_mode) {}
+    explicit CompressionStream(ZlibMode _mode): context(_mode) {}
     CompressionStream() = default;
     // TODO(soon): Find a way to add noexcept(false) to this destructor.
     ~CompressionStream();
@@ -338,8 +338,10 @@ public:
     }
 
   protected:
-    CompressionContext& context() {
-      return *&context_;
+    CompressionContext context;
+
+    CompressionContext& getContext() {
+      return *&context;
     }
 
     void initializeStream(jsg::BufferSource _write_result, jsg::Function<void()> writeCallback);
@@ -357,7 +359,6 @@ public:
     // context to avoid `heap-use-after-free` ASan error.
     kj::HashMap<uint8_t*, kj::Array<uint8_t>> allocations;
 
-    CompressionContext context_;
     bool initialized = false;
     bool writing = false;
     bool pending_close = false;
@@ -421,7 +422,7 @@ public:
     }
 
     CompressionContext& context() {
-      return this->CompressionStream<CompressionContext>::context();
+      return this->CompressionStream<CompressionContext>::getContext();
     }
   };
 

--- a/src/workerd/api/node/zlib-util.h
+++ b/src/workerd/api/node/zlib-util.h
@@ -338,8 +338,8 @@ public:
     }
 
   protected:
-    CompressionContext* context() {
-      return &context_;
+    CompressionContext& context() {
+      return *&context_;
     }
 
     void initializeStream(jsg::BufferSource _write_result, jsg::Function<void()> writeCallback);
@@ -420,7 +420,7 @@ public:
       JSG_METHOD(params);
     }
 
-    CompressionContext* context() {
+    CompressionContext& context() {
       return this->CompressionStream<CompressionContext>::context();
     }
   };


### PR DESCRIPTION
A little bit late to the party but, I'm following up to @jasnell's comment on `context()`