### PR TITLE
Extend SqliteDatabase with a reset() method that recreates the database

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -1177,6 +1177,11 @@ export class DurableObjectExample {
     } else if (req.url.endsWith('/streaming-ingestion')) {
       await testStreamingIngestion(req, this.state.storage);
       return Response.json({ ok: true });
+    } else if (req.url.endsWith('/deleteAll')) {
+      this.state.storage.put('counter', 888); // will be deleted
+      this.state.storage.deleteAll();
+      assert.strictEqual(await this.state.storage.get('counter'), undefined);
+      return Response.json({ ok: true });
     }
 
     throw new Error('unknown url: ' + req.url);
@@ -1251,6 +1256,11 @@ export default {
 
     // Everything's still consistent.
     assert.equal(await doReq('increment'), 3);
+
+    // Delete all: increments start over
+    await doReq('deleteAll');
+    assert.equal(await doReq('increment'), 1);
+    assert.equal(await doReq('increment'), 2);
   },
 };
 

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -101,6 +101,7 @@ private:
     KJ_DISALLOW_COPY_AND_MOVE(ImplicitTxn);
 
     void commit();
+    void rollback();
 
   private:
     ActorSqlite& parent;

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -46,7 +46,7 @@ public:
       Hooks& hooks = const_cast<Hooks&>(Hooks::DEFAULT));
 
   bool isCommitScheduled() {
-    return !currentTxn.is<NoTxn>();
+    return !currentTxn.is<NoTxn>() || deleteAllCommitScheduled;
   }
 
   kj::Maybe<SqliteDatabase&> getSqliteDatabase() override {
@@ -156,6 +156,9 @@ private:
   // When set to `ExplicitTxn*`, an explicit transaction is currently open, so no implicit
   // transactions should be used in the meantime.
   kj::OneOf<NoTxn, ImplicitTxn*, ExplicitTxn*> currentTxn = NoTxn();
+
+  // If true, then a commit is scheduled as a result of deleteAll() having been called.
+  bool deleteAllCommitScheduled = false;
 
   kj::TaskSet commitTasks;
 

--- a/src/workerd/server/alarm-scheduler.c++
+++ b/src/workerd/server/alarm-scheduler.c++
@@ -25,12 +25,12 @@ std::default_random_engine makeSeededRandomEngine() {
 }  // namespace
 
 AlarmScheduler::AlarmScheduler(
-    const kj::Clock& clock, kj::Timer& timer, const SqliteDatabase::Vfs& vfs, kj::PathPtr path)
+    const kj::Clock& clock, kj::Timer& timer, const SqliteDatabase::Vfs& vfs, kj::Path path)
     : clock(clock),
       timer(timer),
       random(makeSeededRandomEngine()),
       db([&] {
-        auto db = kj::heap<SqliteDatabase>(vfs, path,
+        auto db = kj::heap<SqliteDatabase>(vfs, kj::mv(path),
             kj::WriteMode::CREATE | kj::WriteMode::MODIFY | kj::WriteMode::CREATE_PARENT);
         ensureInitialized(*db);
         return kj::mv(db);

--- a/src/workerd/server/alarm-scheduler.h
+++ b/src/workerd/server/alarm-scheduler.h
@@ -62,7 +62,7 @@ public:
   using GetActorFn = kj::Function<kj::Own<WorkerInterface>(kj::String)>;
 
   AlarmScheduler(
-      const kj::Clock& clock, kj::Timer& timer, const SqliteDatabase::Vfs& vfs, kj::PathPtr path);
+      const kj::Clock& clock, kj::Timer& timer, const SqliteDatabase::Vfs& vfs, kj::Path path);
 
   kj::Maybe<kj::Date> getAlarm(ActorKey actor);
   bool setAlarm(ActorKey actor, kj::Date scheduledTime);

--- a/src/workerd/util/sqlite-kv-test.c++
+++ b/src/workerd/util/sqlite-kv-test.c++
@@ -87,8 +87,27 @@ KJ_TEST("SQLite-KV") {
   kv.put("foo", "hello"_kj.asBytes());
   KJ_EXPECT(list(nullptr, kj::none, kj::none, F) == "bar=def, foo=hello, qux=321");
 
-  kv.deleteAll();
+  // deleteAll()
+  KJ_EXPECT(kv.deleteAll() == 3);
   KJ_EXPECT(list(nullptr, kj::none, kj::none, F) == "");
+
+  KJ_EXPECT(!kv.get("bar", [&](kj::ArrayPtr<const byte> value) {
+    KJ_FAIL_EXPECT("should not call callback when no match", value.asChars());
+  }));
+
+  kv.put("bar", "ghi"_kj.asBytes());
+  kv.put("corge", "garply"_kj.asBytes());
+
+  KJ_EXPECT(list(nullptr, kj::none, kj::none, F) == "bar=ghi, corge=garply");
+
+  {
+    bool called = false;
+    KJ_EXPECT(kv.get("bar", [&](kj::ArrayPtr<const byte> value) {
+      KJ_EXPECT(kj::str(value.asChars()) == "ghi");
+      called = true;
+    }));
+    KJ_EXPECT(called);
+  }
 }
 
 }  // namespace

--- a/src/workerd/util/sqlite-kv.c++
+++ b/src/workerd/util/sqlite-kv.c++
@@ -6,30 +6,33 @@
 
 namespace workerd {
 
-SqliteKv::SqliteKv(SqliteDatabase& db) {
+SqliteKv::SqliteKv(SqliteDatabase& db): ResetListener(db) {
   if (db.run("SELECT name FROM sqlite_master WHERE type='table' AND name='_cf_KV'").isDone()) {
     // The _cf_KV table doesn't exist. Defer initialization.
-    state.init<Uninitialized>(Uninitialized {db});
+    state.init<Uninitialized>(Uninitialized{});
   } else {
     // The KV table was initialized in the past. We can go ahead and prepare our statements.
     // (We don't call ensureInitialized() here because the `CREATE TABLE IF NOT EXISTS` query it
     // executes would be redundant.)
+    tableCreated = true;
     state.init<Initialized>(db);
   }
 }
 
 SqliteKv::Initialized& SqliteKv::ensureInitialized() {
+  if (!tableCreated) {
+    db.run(R"(
+      CREATE TABLE IF NOT EXISTS _cf_KV (
+        key TEXT PRIMARY KEY,
+        value BLOB
+      ) WITHOUT ROWID;
+    )");
+
+    tableCreated = true;
+  }
+
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(uninitialized, Uninitialized) {
-      auto& db = uninitialized.db;
-
-      db.run(R"(
-        CREATE TABLE IF NOT EXISTS _cf_KV (
-          key TEXT PRIMARY KEY,
-          value BLOB
-        ) WITHOUT ROWID;
-      )");
-
       return state.init<Initialized>(db);
     }
     KJ_CASE_ONEOF(initialized, Initialized) {
@@ -49,8 +52,17 @@ bool SqliteKv::delete_(KeyPtr key) {
 }
 
 uint SqliteKv::deleteAll() {
-  auto query = ensureInitialized().stmtDeleteAll.run();
-  return query.changeCount();
+  // TODO(perf): Consider introducing a compatibility flag that causes deleteAll() to always return
+  //   1. Apps almost certainly don't care about the return value but historically we returned the
+  //   count of keys deleted, so now we're stuck counting the table size for no good reason.
+  uint count = tableCreated ? ensureInitialized().stmtCountKeys.run().getInt(0) : 0;
+  db.reset();
+  return count;
+}
+
+void SqliteKv::beforeSqliteReset() {
+  // We'll need to recreate the table on the next operation.
+  tableCreated = false;
 }
 
 }  // namespace workerd

--- a/src/workerd/util/sqlite-kv.c++
+++ b/src/workerd/util/sqlite-kv.c++
@@ -9,12 +9,12 @@ namespace workerd {
 SqliteKv::SqliteKv(SqliteDatabase& db) {
   if (db.run("SELECT name FROM sqlite_master WHERE type='table' AND name='_cf_KV'").isDone()) {
     // The _cf_KV table doesn't exist. Defer initialization.
-    state = Uninitialized{db};
+    state.init<Uninitialized>(Uninitialized {db});
   } else {
     // The KV table was initialized in the past. We can go ahead and prepare our statements.
     // (We don't call ensureInitialized() here because the `CREATE TABLE IF NOT EXISTS` query it
     // executes would be redundant.)
-    state = Initialized(db);
+    state.init<Initialized>(db);
   }
 }
 


### PR DESCRIPTION
And use this to implement deleteAll().

Thus, `deleteAll()` will now delete SQL tables as well, instead of just KV data.