### PR TITLE
[build] Roll Rust deps, Rust version 1.77 => 1.81

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -320,9 +320,9 @@ http_file(
 http_file(
     name = "cargo_bazel_macos_arm64",
     executable = True,
-    sha256 = "30b01033e7b534c6e1927d9225f52a239a41bad402aac12fb6410683a3daa8b1",
+    integrity = "sha256-RJ6t4W3oO4jdtMjea+3SF3OplpGuBY8/TGxTNiHDn0w=",
     urls = [
-        "https://github.com/bazelbuild/rules_rust/releases/download/0.46.0/cargo-bazel-aarch64-apple-darwin",
+        "https://github.com/bazelbuild/rules_rust/releases/download/0.50.0/cargo-bazel-aarch64-apple-darwin",
     ],
 )
 
@@ -341,9 +341,9 @@ http_file(
 # since cargo_bazel is only used to generate build files.
 http_archive(
     name = "rules_rust",
-    integrity = "sha256-F8U7+AC5MvMtPKGdLLnorVM84cDXKfDRgwd7/dq3rUY=",
+    integrity = "sha256-NE2PXqlFFVnUDR4msCyI3kZtv1y1Io2MCsrlVxsdqI4=",
     urls = [
-        "https://github.com/bazelbuild/rules_rust/releases/download/0.46.0/rules_rust-v0.46.0.tar.gz",
+        "https://github.com/bazelbuild/rules_rust/releases/download/0.50.0/rules_rust-v0.50.0.tar.gz",
     ],
 )
 
@@ -355,7 +355,7 @@ rust_register_toolchains(
     edition = "2021",
     # Rust registers wasm targets by default which we don't need, workerd is only built for its native platform.
     extra_target_triples = [],
-    versions = ["1.77.0"],  # LLVM 17
+    versions = ["1.81.0"],  # LLVM 18
 )
 
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")

--- a/rust-deps/crates/BUILD.adler2-2.0.0.bazel
+++ b/rust-deps/crates/BUILD.adler2-2.0.0.bazel
@@ -11,10 +11,10 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "quote",
+    name = "adler2",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -28,24 +28,17 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "default",
-        "proc-macro",
-    ],
     crate_root = "src/lib.rs",
-    edition = "2018",
+    edition = "2021",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=quote",
+        "crate-name=adler2",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.36",
-    deps = [
-        "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
-    ],
+    version = "2.0.0",
 )

--- a/rust-deps/crates/BUILD.ahash-0.8.11.bazel
+++ b/rust-deps/crates/BUILD.ahash-0.8.11.bazel
@@ -15,7 +15,7 @@ rust_library(
     name = "ahash",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -70,7 +70,7 @@ cargo_build_script(
     name = "_bs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
@@ -101,7 +101,7 @@ cargo_build_script(
     version = "0.8.11",
     visibility = ["//visibility:private"],
     deps = [
-        "@crates_vendor__version_check-0.9.4//:version_check",
+        "@crates_vendor__version_check-0.9.5//:version_check",
     ],
 )
 

--- a/rust-deps/crates/BUILD.anyhow-1.0.87.bazel
+++ b/rust-deps/crates/BUILD.anyhow-1.0.87.bazel
@@ -12,10 +12,10 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "serde",
+    name = "anyhow",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -31,28 +31,23 @@ rust_library(
     ),
     crate_features = [
         "default",
-        "derive",
-        "serde_derive",
         "std",
     ],
     crate_root = "src/lib.rs",
     edition = "2018",
-    proc_macro_deps = [
-        "@crates_vendor__serde_derive-1.0.204//:serde_derive",
-    ],
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=serde",
+        "crate-name=anyhow",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.204",
+    version = "1.0.87",
     deps = [
-        "@crates_vendor__serde-1.0.204//:build_script_build",
+        "@crates_vendor__anyhow-1.0.87//:build_script_build",
     ],
 )
 
@@ -60,12 +55,10 @@ cargo_build_script(
     name = "_bs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     crate_features = [
         "default",
-        "derive",
-        "serde_derive",
         "std",
     ],
     crate_name = "build_script_build",
@@ -83,18 +76,18 @@ cargo_build_script(
         ],
     ),
     edition = "2018",
-    pkg_name = "serde",
+    pkg_name = "anyhow",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=serde",
+        "crate-name=anyhow",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.204",
+    version = "1.0.87",
     visibility = ["//visibility:private"],
 )
 

--- a/rust-deps/crates/BUILD.bazel
+++ b/rust-deps/crates/BUILD.bazel
@@ -33,19 +33,19 @@ filegroup(
 # Workspace Member Dependencies
 alias(
     name = "anyhow",
-    actual = "@crates_vendor__anyhow-1.0.86//:anyhow",
+    actual = "@crates_vendor__anyhow-1.0.87//:anyhow",
     tags = ["manual"],
 )
 
 alias(
     name = "clang-ast",
-    actual = "@crates_vendor__clang-ast-0.1.25//:clang_ast",
+    actual = "@crates_vendor__clang-ast-0.1.26//:clang_ast",
     tags = ["manual"],
 )
 
 alias(
     name = "flate2",
-    actual = "@crates_vendor__flate2-1.0.30//:flate2",
+    actual = "@crates_vendor__flate2-1.0.33//:flate2",
     tags = ["manual"],
 )
 
@@ -63,12 +63,12 @@ alias(
 
 alias(
     name = "serde",
-    actual = "@crates_vendor__serde-1.0.204//:serde",
+    actual = "@crates_vendor__serde-1.0.210//:serde",
     tags = ["manual"],
 )
 
 alias(
     name = "serde_json",
-    actual = "@crates_vendor__serde_json-1.0.120//:serde_json",
+    actual = "@crates_vendor__serde_json-1.0.128//:serde_json",
     tags = ["manual"],
 )

--- a/rust-deps/crates/BUILD.bitflags-1.3.2.bazel
+++ b/rust-deps/crates/BUILD.bitflags-1.3.2.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "bitflags",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.bitflags-2.6.0.bazel
+++ b/rust-deps/crates/BUILD.bitflags-2.6.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "bitflags",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.byteorder-1.5.0.bazel
+++ b/rust-deps/crates/BUILD.byteorder-1.5.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "byteorder",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.cc-1.1.18.bazel
+++ b/rust-deps/crates/BUILD.cc-1.1.18.bazel
@@ -11,10 +11,10 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "miniz_oxide",
+    name = "cc",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -28,9 +28,6 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "with-alloc",
-    ],
     crate_root = "src/lib.rs",
     edition = "2018",
     rustc_flags = [
@@ -38,13 +35,13 @@ rust_library(
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=miniz_oxide",
+        "crate-name=cc",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "0.7.4",
+    version = "1.1.18",
     deps = [
-        "@crates_vendor__adler-1.0.2//:adler",
+        "@crates_vendor__shlex-1.3.0//:shlex",
     ],
 )

--- a/rust-deps/crates/BUILD.cfg-if-1.0.0.bazel
+++ b/rust-deps/crates/BUILD.cfg-if-1.0.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "cfg_if",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.clang-ast-0.1.26.bazel
+++ b/rust-deps/crates/BUILD.clang-ast-0.1.26.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "clang_ast",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -40,9 +40,9 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "0.1.25",
+    version = "0.1.26",
     deps = [
         "@crates_vendor__rustc-hash-2.0.0//:rustc_hash",
-        "@crates_vendor__serde-1.0.204//:serde",
+        "@crates_vendor__serde-1.0.210//:serde",
     ],
 )

--- a/rust-deps/crates/BUILD.convert_case-0.4.0.bazel
+++ b/rust-deps/crates/BUILD.convert_case-0.4.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "convert_case",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.crc32fast-1.4.2.bazel
+++ b/rust-deps/crates/BUILD.crc32fast-1.4.2.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "crc32fast",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.cssparser-0.27.2.bazel
+++ b/rust-deps/crates/BUILD.cssparser-0.27.2.bazel
@@ -15,7 +15,7 @@ rust_library(
     name = "cssparser",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -59,7 +59,7 @@ cargo_build_script(
     name = "_bs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
@@ -91,7 +91,7 @@ cargo_build_script(
     visibility = ["//visibility:private"],
     deps = [
         "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
-        "@crates_vendor__quote-1.0.36//:quote",
+        "@crates_vendor__quote-1.0.37//:quote",
         "@crates_vendor__syn-1.0.109//:syn",
     ],
 )

--- a/rust-deps/crates/BUILD.cssparser-macros-0.6.1.bazel
+++ b/rust-deps/crates/BUILD.cssparser-macros-0.6.1.bazel
@@ -14,7 +14,7 @@ rust_proc_macro(
     name = "cssparser_macros",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -42,7 +42,7 @@ rust_proc_macro(
     ],
     version = "0.6.1",
     deps = [
-        "@crates_vendor__quote-1.0.36//:quote",
-        "@crates_vendor__syn-2.0.72//:syn",
+        "@crates_vendor__quote-1.0.37//:quote",
+        "@crates_vendor__syn-2.0.77//:syn",
     ],
 )

--- a/rust-deps/crates/BUILD.derive_more-0.99.18.bazel
+++ b/rust-deps/crates/BUILD.derive_more-0.99.18.bazel
@@ -14,7 +14,7 @@ rust_proc_macro(
     name = "derive_more",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -72,7 +72,7 @@ rust_proc_macro(
     deps = [
         "@crates_vendor__convert_case-0.4.0//:convert_case",
         "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
-        "@crates_vendor__quote-1.0.36//:quote",
-        "@crates_vendor__syn-2.0.72//:syn",
+        "@crates_vendor__quote-1.0.37//:quote",
+        "@crates_vendor__syn-2.0.77//:syn",
     ],
 )

--- a/rust-deps/crates/BUILD.dtoa-1.0.9.bazel
+++ b/rust-deps/crates/BUILD.dtoa-1.0.9.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "dtoa",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.dtoa-short-0.3.5.bazel
+++ b/rust-deps/crates/BUILD.dtoa-short-0.3.5.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "dtoa_short",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.encoding_rs-0.8.34.bazel
+++ b/rust-deps/crates/BUILD.encoding_rs-0.8.34.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "encoding_rs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.flate2-1.0.33.bazel
+++ b/rust-deps/crates/BUILD.flate2-1.0.33.bazel
@@ -11,10 +11,10 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "syn",
+    name = "flate2",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -29,31 +29,26 @@ rust_library(
         ],
     ),
     crate_features = [
-        "clone-impls",
+        "any_impl",
         "default",
-        "derive",
-        "extra-traits",
-        "full",
-        "parsing",
-        "printing",
-        "proc-macro",
+        "miniz_oxide",
+        "rust_backend",
     ],
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=syn",
+        "crate-name=flate2",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "2.0.72",
+    version = "1.0.33",
     deps = [
-        "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
-        "@crates_vendor__quote-1.0.36//:quote",
-        "@crates_vendor__unicode-ident-1.0.12//:unicode_ident",
+        "@crates_vendor__crc32fast-1.4.2//:crc32fast",
+        "@crates_vendor__miniz_oxide-0.8.0//:miniz_oxide",
     ],
 )

--- a/rust-deps/crates/BUILD.fxhash-0.2.1.bazel
+++ b/rust-deps/crates/BUILD.fxhash-0.2.1.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "fxhash",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.getrandom-0.1.16.bazel
+++ b/rust-deps/crates/BUILD.getrandom-0.1.16.bazel
@@ -15,7 +15,7 @@ rust_library(
     name = "getrandom",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -50,16 +50,16 @@ rust_library(
         "@crates_vendor__getrandom-0.1.16//:build_script_build",
     ] + select({
         "@rules_rust//rust/platform:aarch64-apple-darwin": [
-            "@crates_vendor__libc-0.2.155//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.158//:libc",  # cfg(unix)
         ],
         "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": [
-            "@crates_vendor__libc-0.2.155//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.158//:libc",  # cfg(unix)
         ],
         "@rules_rust//rust/platform:x86_64-apple-darwin": [
-            "@crates_vendor__libc-0.2.155//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.158//:libc",  # cfg(unix)
         ],
         "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": [
-            "@crates_vendor__libc-0.2.155//:libc",  # cfg(unix)
+            "@crates_vendor__libc-0.2.158//:libc",  # cfg(unix)
         ],
         "//conditions:default": [],
     }),
@@ -69,7 +69,7 @@ cargo_build_script(
     name = "_bs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     crate_features = [
         "std",

--- a/rust-deps/crates/BUILD.hashbrown-0.13.2.bazel
+++ b/rust-deps/crates/BUILD.hashbrown-0.13.2.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "hashbrown",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.itoa-0.4.8.bazel
+++ b/rust-deps/crates/BUILD.itoa-0.4.8.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "itoa",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.itoa-1.0.11.bazel
+++ b/rust-deps/crates/BUILD.itoa-1.0.11.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "itoa",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.lazy_static-1.5.0.bazel
+++ b/rust-deps/crates/BUILD.lazy_static-1.5.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "lazy_static",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.lazycell-1.3.0.bazel
+++ b/rust-deps/crates/BUILD.lazycell-1.3.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "lazycell",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.libc-0.2.158.bazel
+++ b/rust-deps/crates/BUILD.libc-0.2.158.bazel
@@ -12,10 +12,10 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "anyhow",
+    name = "libc",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -34,20 +34,20 @@ rust_library(
         "std",
     ],
     crate_root = "src/lib.rs",
-    edition = "2018",
+    edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=anyhow",
+        "crate-name=libc",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.86",
+    version = "0.2.158",
     deps = [
-        "@crates_vendor__anyhow-1.0.86//:build_script_build",
+        "@crates_vendor__libc-0.2.158//:build_script_build",
     ],
 )
 
@@ -55,7 +55,7 @@ cargo_build_script(
     name = "_bs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     crate_features = [
         "default",
@@ -75,19 +75,19 @@ cargo_build_script(
             "WORKSPACE.bazel",
         ],
     ),
-    edition = "2018",
-    pkg_name = "anyhow",
+    edition = "2015",
+    pkg_name = "libc",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=anyhow",
+        "crate-name=libc",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.86",
+    version = "0.2.158",
     visibility = ["//visibility:private"],
 )
 

--- a/rust-deps/crates/BUILD.log-0.4.22.bazel
+++ b/rust-deps/crates/BUILD.log-0.4.22.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "log",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.lol_html-1.2.1.bazel
+++ b/rust-deps/crates/BUILD.lol_html-1.2.1.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "lol_html",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.lolhtml-1.1.1.bazel
+++ b/rust-deps/crates/BUILD.lolhtml-1.1.1.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "lolhtml",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -43,7 +43,7 @@ rust_library(
     version = "1.1.1",
     deps = [
         "@crates_vendor__encoding_rs-0.8.34//:encoding_rs",
-        "@crates_vendor__libc-0.2.155//:libc",
+        "@crates_vendor__libc-0.2.158//:libc",
         "@crates_vendor__lol_html-1.2.1//:lol_html",
         "@crates_vendor__thiserror-1.0.63//:thiserror",
     ],

--- a/rust-deps/crates/BUILD.matches-0.1.10.bazel
+++ b/rust-deps/crates/BUILD.matches-0.1.10.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "matches",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.memchr-2.7.4.bazel
+++ b/rust-deps/crates/BUILD.memchr-2.7.4.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "memchr",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.mime-0.3.17.bazel
+++ b/rust-deps/crates/BUILD.mime-0.3.17.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "mime",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.miniz_oxide-0.8.0.bazel
+++ b/rust-deps/crates/BUILD.miniz_oxide-0.8.0.bazel
@@ -6,15 +6,15 @@
 #     bazel run @//rust-deps:crates_vendor
 ###############################################################################
 
-load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
+load("@rules_rust//rust:defs.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_proc_macro(
-    name = "serde_derive",
+rust_library(
+    name = "miniz_oxide",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -29,24 +29,22 @@ rust_proc_macro(
         ],
     ),
     crate_features = [
-        "default",
+        "with-alloc",
     ],
     crate_root = "src/lib.rs",
-    edition = "2015",
+    edition = "2021",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=serde_derive",
+        "crate-name=miniz_oxide",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.204",
+    version = "0.8.0",
     deps = [
-        "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
-        "@crates_vendor__quote-1.0.36//:quote",
-        "@crates_vendor__syn-2.0.72//:syn",
+        "@crates_vendor__adler2-2.0.0//:adler2",
     ],
 )

--- a/rust-deps/crates/BUILD.nodrop-0.1.14.bazel
+++ b/rust-deps/crates/BUILD.nodrop-0.1.14.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "nodrop",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.once_cell-1.19.0.bazel
+++ b/rust-deps/crates/BUILD.once_cell-1.19.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "once_cell",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.phf-0.8.0.bazel
+++ b/rust-deps/crates/BUILD.phf-0.8.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "phf",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.phf_codegen-0.8.0.bazel
+++ b/rust-deps/crates/BUILD.phf_codegen-0.8.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "phf_codegen",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.phf_generator-0.8.0.bazel
+++ b/rust-deps/crates/BUILD.phf_generator-0.8.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "phf_generator",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.phf_macros-0.8.0.bazel
+++ b/rust-deps/crates/BUILD.phf_macros-0.8.0.bazel
@@ -14,7 +14,7 @@ rust_proc_macro(
     name = "phf_macros",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -48,7 +48,7 @@ rust_proc_macro(
         "@crates_vendor__phf_generator-0.8.0//:phf_generator",
         "@crates_vendor__phf_shared-0.8.0//:phf_shared",
         "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
-        "@crates_vendor__quote-1.0.36//:quote",
+        "@crates_vendor__quote-1.0.37//:quote",
         "@crates_vendor__syn-1.0.109//:syn",
     ],
 )

--- a/rust-deps/crates/BUILD.phf_shared-0.8.0.bazel
+++ b/rust-deps/crates/BUILD.phf_shared-0.8.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "phf_shared",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.pico-args-0.5.0.bazel
+++ b/rust-deps/crates/BUILD.pico-args-0.5.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "pico_args",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.ppv-lite86-0.2.20.bazel
+++ b/rust-deps/crates/BUILD.ppv-lite86-0.2.20.bazel
@@ -11,10 +11,10 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "cc",
+    name = "ppv_lite86",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -28,17 +28,24 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
+    crate_features = [
+        "simd",
+        "std",
+    ],
     crate_root = "src/lib.rs",
-    edition = "2018",
+    edition = "2021",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=cc",
+        "crate-name=ppv-lite86",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.1.6",
+    version = "0.2.20",
+    deps = [
+        "@crates_vendor__zerocopy-0.7.35//:zerocopy",
+    ],
 )

--- a/rust-deps/crates/BUILD.proc-macro-hack-0.5.20+deprecated.bazel
+++ b/rust-deps/crates/BUILD.proc-macro-hack-0.5.20+deprecated.bazel
@@ -15,7 +15,7 @@ rust_proc_macro(
     name = "proc_macro_hack",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -51,7 +51,7 @@ cargo_build_script(
     name = "_bs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     crate_name = "build_script_build",
     crate_root = "build.rs",

--- a/rust-deps/crates/BUILD.proc-macro2-1.0.86.bazel
+++ b/rust-deps/crates/BUILD.proc-macro2-1.0.86.bazel
@@ -15,7 +15,7 @@ rust_library(
     name = "proc_macro2",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -56,7 +56,7 @@ cargo_build_script(
     name = "_bs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     crate_features = [
         "default",

--- a/rust-deps/crates/BUILD.quote-1.0.37.bazel
+++ b/rust-deps/crates/BUILD.quote-1.0.37.bazel
@@ -11,10 +11,10 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "adler",
+    name = "quote",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -28,17 +28,24 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
     crate_root = "src/lib.rs",
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=adler",
+        "crate-name=quote",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.2",
+    version = "1.0.37",
+    deps = [
+        "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
+    ],
 )

--- a/rust-deps/crates/BUILD.rand-0.7.3.bazel
+++ b/rust-deps/crates/BUILD.rand-0.7.3.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "rand",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     aliases = {
         "@crates_vendor__getrandom-0.1.16//:getrandom": "getrandom_package",
@@ -56,7 +56,7 @@ rust_library(
     version = "0.7.3",
     deps = [
         "@crates_vendor__getrandom-0.1.16//:getrandom",
-        "@crates_vendor__libc-0.2.155//:libc",
+        "@crates_vendor__libc-0.2.158//:libc",
         "@crates_vendor__rand_core-0.5.1//:rand_core",
         "@crates_vendor__rand_pcg-0.2.1//:rand_pcg",
     ] + select({

--- a/rust-deps/crates/BUILD.rand_chacha-0.2.2.bazel
+++ b/rust-deps/crates/BUILD.rand_chacha-0.2.2.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "rand_chacha",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -45,7 +45,7 @@ rust_library(
     ],
     version = "0.2.2",
     deps = [
-        "@crates_vendor__ppv-lite86-0.2.17//:ppv_lite86",
+        "@crates_vendor__ppv-lite86-0.2.20//:ppv_lite86",
         "@crates_vendor__rand_core-0.5.1//:rand_core",
     ],
 )

--- a/rust-deps/crates/BUILD.rand_core-0.5.1.bazel
+++ b/rust-deps/crates/BUILD.rand_core-0.5.1.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "rand_core",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.rand_hc-0.2.0.bazel
+++ b/rust-deps/crates/BUILD.rand_hc-0.2.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "rand_hc",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.rand_pcg-0.2.1.bazel
+++ b/rust-deps/crates/BUILD.rand_pcg-0.2.1.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "rand_pcg",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.rustc-hash-2.0.0.bazel
+++ b/rust-deps/crates/BUILD.rustc-hash-2.0.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "rustc_hash",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.rustc_version-0.4.1.bazel
+++ b/rust-deps/crates/BUILD.rustc_version-0.4.1.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "rustc_version",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -40,7 +40,7 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "0.4.0",
+    version = "0.4.1",
     deps = [
         "@crates_vendor__semver-1.0.23//:semver",
     ],

--- a/rust-deps/crates/BUILD.ryu-1.0.18.bazel
+++ b/rust-deps/crates/BUILD.ryu-1.0.18.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "ryu",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.selectors-0.22.0.bazel
+++ b/rust-deps/crates/BUILD.selectors-0.22.0.bazel
@@ -15,7 +15,7 @@ rust_library(
     name = "selectors",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -64,7 +64,7 @@ cargo_build_script(
     name = "_bs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     crate_name = "build_script_build",
     crate_root = "build.rs",

--- a/rust-deps/crates/BUILD.semver-1.0.23.bazel
+++ b/rust-deps/crates/BUILD.semver-1.0.23.bazel
@@ -15,7 +15,7 @@ rust_library(
     name = "semver",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -55,7 +55,7 @@ cargo_build_script(
     name = "_bs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     crate_features = [
         "default",

--- a/rust-deps/crates/BUILD.serde-1.0.210.bazel
+++ b/rust-deps/crates/BUILD.serde-1.0.210.bazel
@@ -12,10 +12,10 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "libc",
+    name = "serde",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -31,23 +31,28 @@ rust_library(
     ),
     crate_features = [
         "default",
+        "derive",
+        "serde_derive",
         "std",
     ],
     crate_root = "src/lib.rs",
-    edition = "2015",
+    edition = "2018",
+    proc_macro_deps = [
+        "@crates_vendor__serde_derive-1.0.210//:serde_derive",
+    ],
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=libc",
+        "crate-name=serde",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "0.2.155",
+    version = "1.0.210",
     deps = [
-        "@crates_vendor__libc-0.2.155//:build_script_build",
+        "@crates_vendor__serde-1.0.210//:build_script_build",
     ],
 )
 
@@ -55,10 +60,12 @@ cargo_build_script(
     name = "_bs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     crate_features = [
         "default",
+        "derive",
+        "serde_derive",
         "std",
     ],
     crate_name = "build_script_build",
@@ -75,19 +82,19 @@ cargo_build_script(
             "WORKSPACE.bazel",
         ],
     ),
-    edition = "2015",
-    pkg_name = "libc",
+    edition = "2018",
+    pkg_name = "serde",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=libc",
+        "crate-name=serde",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "0.2.155",
+    version = "1.0.210",
     visibility = ["//visibility:private"],
 )
 

--- a/rust-deps/crates/BUILD.serde_derive-1.0.210.bazel
+++ b/rust-deps/crates/BUILD.serde_derive-1.0.210.bazel
@@ -6,15 +6,15 @@
 #     bazel run @//rust-deps:crates_vendor
 ###############################################################################
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
-    name = "flate2",
+rust_proc_macro(
+    name = "serde_derive",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -29,26 +29,24 @@ rust_library(
         ],
     ),
     crate_features = [
-        "any_impl",
         "default",
-        "miniz_oxide",
-        "rust_backend",
     ],
     crate_root = "src/lib.rs",
-    edition = "2018",
+    edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=flate2",
+        "crate-name=serde_derive",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.30",
+    version = "1.0.210",
     deps = [
-        "@crates_vendor__crc32fast-1.4.2//:crc32fast",
-        "@crates_vendor__miniz_oxide-0.7.4//:miniz_oxide",
+        "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
+        "@crates_vendor__quote-1.0.37//:quote",
+        "@crates_vendor__syn-2.0.77//:syn",
     ],
 )

--- a/rust-deps/crates/BUILD.serde_json-1.0.128.bazel
+++ b/rust-deps/crates/BUILD.serde_json-1.0.128.bazel
@@ -15,7 +15,7 @@ rust_library(
     name = "serde_json",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -45,12 +45,13 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.120",
+    version = "1.0.128",
     deps = [
         "@crates_vendor__itoa-1.0.11//:itoa",
+        "@crates_vendor__memchr-2.7.4//:memchr",
         "@crates_vendor__ryu-1.0.18//:ryu",
-        "@crates_vendor__serde-1.0.204//:serde",
-        "@crates_vendor__serde_json-1.0.120//:build_script_build",
+        "@crates_vendor__serde-1.0.210//:serde",
+        "@crates_vendor__serde_json-1.0.128//:build_script_build",
     ],
 )
 
@@ -58,7 +59,7 @@ cargo_build_script(
     name = "_bs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     crate_features = [
         "default",
@@ -90,7 +91,7 @@ cargo_build_script(
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.120",
+    version = "1.0.128",
     visibility = ["//visibility:private"],
 )
 

--- a/rust-deps/crates/BUILD.servo_arc-0.1.1.bazel
+++ b/rust-deps/crates/BUILD.servo_arc-0.1.1.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "servo_arc",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.shlex-1.3.0.bazel
+++ b/rust-deps/crates/BUILD.shlex-1.3.0.bazel
@@ -11,7 +11,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "precomputed_hash",
+    name = "shlex",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = True,
@@ -28,6 +28,10 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
+    crate_features = [
+        "default",
+        "std",
+    ],
     crate_root = "src/lib.rs",
     edition = "2015",
     rustc_flags = [
@@ -35,10 +39,10 @@ rust_library(
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=precomputed-hash",
+        "crate-name=shlex",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "0.1.1",
+    version = "1.3.0",
 )

--- a/rust-deps/crates/BUILD.siphasher-0.3.11.bazel
+++ b/rust-deps/crates/BUILD.siphasher-0.3.11.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "siphasher",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.smallvec-1.13.2.bazel
+++ b/rust-deps/crates/BUILD.smallvec-1.13.2.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "smallvec",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.stable_deref_trait-1.2.0.bazel
+++ b/rust-deps/crates/BUILD.stable_deref_trait-1.2.0.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "stable_deref_trait",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.syn-1.0.109.bazel
+++ b/rust-deps/crates/BUILD.syn-1.0.109.bazel
@@ -15,7 +15,7 @@ rust_library(
     name = "syn",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -56,7 +56,7 @@ rust_library(
     version = "1.0.109",
     deps = [
         "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
-        "@crates_vendor__quote-1.0.36//:quote",
+        "@crates_vendor__quote-1.0.37//:quote",
         "@crates_vendor__syn-1.0.109//:build_script_build",
         "@crates_vendor__unicode-ident-1.0.12//:unicode_ident",
     ],
@@ -66,7 +66,7 @@ cargo_build_script(
     name = "_bs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     crate_features = [
         "clone-impls",

--- a/rust-deps/crates/BUILD.syn-2.0.77.bazel
+++ b/rust-deps/crates/BUILD.syn-2.0.77.bazel
@@ -11,10 +11,10 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "version_check",
+    name = "syn",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -28,17 +28,32 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
+    crate_features = [
+        "clone-impls",
+        "default",
+        "derive",
+        "extra-traits",
+        "full",
+        "parsing",
+        "printing",
+        "proc-macro",
+    ],
     crate_root = "src/lib.rs",
-    edition = "2015",
+    edition = "2021",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=version_check",
+        "crate-name=syn",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "0.9.4",
+    version = "2.0.77",
+    deps = [
+        "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
+        "@crates_vendor__quote-1.0.37//:quote",
+        "@crates_vendor__unicode-ident-1.0.12//:unicode_ident",
+    ],
 )

--- a/rust-deps/crates/BUILD.thin-slice-0.1.1.bazel
+++ b/rust-deps/crates/BUILD.thin-slice-0.1.1.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "thin_slice",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.thiserror-1.0.63.bazel
+++ b/rust-deps/crates/BUILD.thiserror-1.0.63.bazel
@@ -15,7 +15,7 @@ rust_library(
     name = "thiserror",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -54,7 +54,7 @@ cargo_build_script(
     name = "_bs",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     crate_name = "build_script_build",
     crate_root = "build.rs",

--- a/rust-deps/crates/BUILD.thiserror-impl-1.0.63.bazel
+++ b/rust-deps/crates/BUILD.thiserror-impl-1.0.63.bazel
@@ -14,7 +14,7 @@ rust_proc_macro(
     name = "thiserror_impl",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -43,7 +43,7 @@ rust_proc_macro(
     version = "1.0.63",
     deps = [
         "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
-        "@crates_vendor__quote-1.0.36//:quote",
-        "@crates_vendor__syn-2.0.72//:syn",
+        "@crates_vendor__quote-1.0.37//:quote",
+        "@crates_vendor__syn-2.0.77//:syn",
     ],
 )

--- a/rust-deps/crates/BUILD.unicode-ident-1.0.12.bazel
+++ b/rust-deps/crates/BUILD.unicode-ident-1.0.12.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "unicode_ident",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.version_check-0.9.5.bazel
+++ b/rust-deps/crates/BUILD.version_check-0.9.5.bazel
@@ -11,10 +11,10 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "ppv_lite86",
+    name = "version_check",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -28,21 +28,17 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "simd",
-        "std",
-    ],
     crate_root = "src/lib.rs",
-    edition = "2018",
+    edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-bazel",
-        "crate-name=ppv-lite86",
+        "crate-name=version_check",
         "manual",
         "noclippy",
         "norustfmt",
     ],
-    version = "0.2.17",
+    version = "0.9.5",
 )

--- a/rust-deps/crates/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
+++ b/rust-deps/crates/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "wasi",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],

--- a/rust-deps/crates/BUILD.zerocopy-0.7.35.bazel
+++ b/rust-deps/crates/BUILD.zerocopy-0.7.35.bazel
@@ -14,7 +14,7 @@ rust_library(
     name = "zerocopy",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -29,10 +29,17 @@ rust_library(
         ],
     ),
     crate_features = [
+        "byteorder",
+        "default",
+        "derive",
         "simd",
+        "zerocopy-derive",
     ],
     crate_root = "src/lib.rs",
     edition = "2018",
+    proc_macro_deps = [
+        "@crates_vendor__zerocopy-derive-0.7.35//:zerocopy_derive",
+    ],
     rustc_flags = [
         "--cap-lints=allow",
     ],
@@ -44,4 +51,7 @@ rust_library(
         "norustfmt",
     ],
     version = "0.7.35",
+    deps = [
+        "@crates_vendor__byteorder-1.5.0//:byteorder",
+    ],
 )

--- a/rust-deps/crates/BUILD.zerocopy-derive-0.7.35.bazel
+++ b/rust-deps/crates/BUILD.zerocopy-derive-0.7.35.bazel
@@ -14,7 +14,7 @@ rust_proc_macro(
     name = "zerocopy_derive",
     srcs = glob(
         include = ["**/*.rs"],
-        allow_empty = False,
+        allow_empty = True,
     ),
     compile_data = glob(
         include = ["**"],
@@ -43,7 +43,7 @@ rust_proc_macro(
     version = "0.7.35",
     deps = [
         "@crates_vendor__proc-macro2-1.0.86//:proc_macro2",
-        "@crates_vendor__quote-1.0.36//:quote",
-        "@crates_vendor__syn-2.0.72//:syn",
+        "@crates_vendor__quote-1.0.37//:quote",
+        "@crates_vendor__syn-2.0.77//:syn",
     ],
 )

--- a/rust-deps/crates/defs.bzl
+++ b/rust-deps/crates/defs.bzl
@@ -296,13 +296,13 @@ def aliases(
 _NORMAL_DEPENDENCIES = {
     "": {
         _COMMON_CONDITION: {
-            "anyhow": Label("@crates_vendor__anyhow-1.0.86//:anyhow"),
-            "clang-ast": Label("@crates_vendor__clang-ast-0.1.25//:clang_ast"),
-            "flate2": Label("@crates_vendor__flate2-1.0.30//:flate2"),
+            "anyhow": Label("@crates_vendor__anyhow-1.0.87//:anyhow"),
+            "clang-ast": Label("@crates_vendor__clang-ast-0.1.26//:clang_ast"),
+            "flate2": Label("@crates_vendor__flate2-1.0.33//:flate2"),
             "lolhtml": Label("@crates_vendor__lolhtml-1.1.1//:lolhtml"),
             "pico-args": Label("@crates_vendor__pico-args-0.5.0//:pico_args"),
-            "serde": Label("@crates_vendor__serde-1.0.204//:serde"),
-            "serde_json": Label("@crates_vendor__serde_json-1.0.120//:serde_json"),
+            "serde": Label("@crates_vendor__serde-1.0.210//:serde"),
+            "serde_json": Label("@crates_vendor__serde_json-1.0.128//:serde_json"),
         },
     },
 }
@@ -367,7 +367,6 @@ _BUILD_PROC_MACRO_ALIASES = {
 _CONDITIONS = {
     "aarch64-apple-darwin": ["@rules_rust//rust/platform:aarch64-apple-darwin"],
     "aarch64-unknown-linux-gnu": ["@rules_rust//rust/platform:aarch64-unknown-linux-gnu"],
-    "cfg(any())": [],
     "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": ["@rules_rust//rust/platform:aarch64-apple-darwin", "@rules_rust//rust/platform:aarch64-unknown-linux-gnu", "@rules_rust//rust/platform:x86_64-apple-darwin", "@rules_rust//rust/platform:x86_64-pc-windows-msvc", "@rules_rust//rust/platform:x86_64-unknown-linux-gnu"],
     "cfg(not(target_os = \"emscripten\"))": ["@rules_rust//rust/platform:aarch64-apple-darwin", "@rules_rust//rust/platform:aarch64-unknown-linux-gnu", "@rules_rust//rust/platform:x86_64-apple-darwin", "@rules_rust//rust/platform:x86_64-pc-windows-msvc", "@rules_rust//rust/platform:x86_64-unknown-linux-gnu"],
     "cfg(target_os = \"emscripten\")": [],
@@ -388,12 +387,12 @@ def crate_repositories():
     """
     maybe(
         http_archive,
-        name = "crates_vendor__adler-1.0.2",
-        sha256 = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+        name = "crates_vendor__adler2-2.0.0",
+        sha256 = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/adler/1.0.2/download"],
-        strip_prefix = "adler-1.0.2",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.adler-1.0.2.bazel"),
+        urls = ["https://static.crates.io/crates/adler2/2.0.0/download"],
+        strip_prefix = "adler2-2.0.0",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.adler2-2.0.0.bazel"),
     )
 
     maybe(
@@ -408,12 +407,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__anyhow-1.0.86",
-        sha256 = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da",
+        name = "crates_vendor__anyhow-1.0.87",
+        sha256 = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/anyhow/1.0.86/download"],
-        strip_prefix = "anyhow-1.0.86",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.anyhow-1.0.86.bazel"),
+        urls = ["https://static.crates.io/crates/anyhow/1.0.87/download"],
+        strip_prefix = "anyhow-1.0.87",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.anyhow-1.0.87.bazel"),
     )
 
     maybe(
@@ -448,12 +447,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__cc-1.1.6",
-        sha256 = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f",
+        name = "crates_vendor__cc-1.1.18",
+        sha256 = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/cc/1.1.6/download"],
-        strip_prefix = "cc-1.1.6",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.cc-1.1.6.bazel"),
+        urls = ["https://static.crates.io/crates/cc/1.1.18/download"],
+        strip_prefix = "cc-1.1.18",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.cc-1.1.18.bazel"),
     )
 
     maybe(
@@ -468,12 +467,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__clang-ast-0.1.25",
-        sha256 = "d1c4a15ee0d6a4f79bf67cedd8323d9e97ae93953c7bd56b7a14f09ada04235c",
+        name = "crates_vendor__clang-ast-0.1.26",
+        sha256 = "577457f7ace079a595017e4307c6e480902664ede6e4a0760747c4f498b7c996",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/clang-ast/0.1.25/download"],
-        strip_prefix = "clang-ast-0.1.25",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.clang-ast-0.1.25.bazel"),
+        urls = ["https://static.crates.io/crates/clang-ast/0.1.26/download"],
+        strip_prefix = "clang-ast-0.1.26",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.clang-ast-0.1.26.bazel"),
     )
 
     maybe(
@@ -558,12 +557,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__flate2-1.0.30",
-        sha256 = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae",
+        name = "crates_vendor__flate2-1.0.33",
+        sha256 = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/flate2/1.0.30/download"],
-        strip_prefix = "flate2-1.0.30",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.flate2-1.0.30.bazel"),
+        urls = ["https://static.crates.io/crates/flate2/1.0.33/download"],
+        strip_prefix = "flate2-1.0.33",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.flate2-1.0.33.bazel"),
     )
 
     maybe(
@@ -638,12 +637,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__libc-0.2.155",
-        sha256 = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c",
+        name = "crates_vendor__libc-0.2.158",
+        sha256 = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/libc/0.2.155/download"],
-        strip_prefix = "libc-0.2.155",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.libc-0.2.155.bazel"),
+        urls = ["https://static.crates.io/crates/libc/0.2.158/download"],
+        strip_prefix = "libc-0.2.158",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.libc-0.2.158.bazel"),
     )
 
     maybe(
@@ -659,7 +658,7 @@ def crate_repositories():
     maybe(
         new_git_repository,
         name = "crates_vendor__lol_html-1.2.1",
-        commit = "53469c5acf5bf2955cbf3848544028ec835d38a4",
+        commit = "7db3d8d9fa9f3fee6ffe36c3f68f14e160476e07",
         init_submodules = True,
         remote = "https://github.com/cloudflare/lol-html.git",
         build_file = Label("@workerd//rust-deps/crates:BUILD.lol_html-1.2.1.bazel"),
@@ -668,7 +667,7 @@ def crate_repositories():
     maybe(
         new_git_repository,
         name = "crates_vendor__lolhtml-1.1.1",
-        commit = "53469c5acf5bf2955cbf3848544028ec835d38a4",
+        commit = "7db3d8d9fa9f3fee6ffe36c3f68f14e160476e07",
         init_submodules = True,
         remote = "https://github.com/cloudflare/lol-html.git",
         build_file = Label("@workerd//rust-deps/crates:BUILD.lolhtml-1.1.1.bazel"),
@@ -707,12 +706,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__miniz_oxide-0.7.4",
-        sha256 = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08",
+        name = "crates_vendor__miniz_oxide-0.8.0",
+        sha256 = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/miniz_oxide/0.7.4/download"],
-        strip_prefix = "miniz_oxide-0.7.4",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.miniz_oxide-0.7.4.bazel"),
+        urls = ["https://static.crates.io/crates/miniz_oxide/0.8.0/download"],
+        strip_prefix = "miniz_oxide-0.8.0",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.miniz_oxide-0.8.0.bazel"),
     )
 
     maybe(
@@ -797,12 +796,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__ppv-lite86-0.2.17",
-        sha256 = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de",
+        name = "crates_vendor__ppv-lite86-0.2.20",
+        sha256 = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/ppv-lite86/0.2.17/download"],
-        strip_prefix = "ppv-lite86-0.2.17",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.ppv-lite86-0.2.17.bazel"),
+        urls = ["https://static.crates.io/crates/ppv-lite86/0.2.20/download"],
+        strip_prefix = "ppv-lite86-0.2.20",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.ppv-lite86-0.2.20.bazel"),
     )
 
     maybe(
@@ -837,12 +836,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__quote-1.0.36",
-        sha256 = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7",
+        name = "crates_vendor__quote-1.0.37",
+        sha256 = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/quote/1.0.36/download"],
-        strip_prefix = "quote-1.0.36",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.quote-1.0.36.bazel"),
+        urls = ["https://static.crates.io/crates/quote/1.0.37/download"],
+        strip_prefix = "quote-1.0.37",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.quote-1.0.37.bazel"),
     )
 
     maybe(
@@ -907,12 +906,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__rustc_version-0.4.0",
-        sha256 = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366",
+        name = "crates_vendor__rustc_version-0.4.1",
+        sha256 = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/rustc_version/0.4.0/download"],
-        strip_prefix = "rustc_version-0.4.0",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.rustc_version-0.4.0.bazel"),
+        urls = ["https://static.crates.io/crates/rustc_version/0.4.1/download"],
+        strip_prefix = "rustc_version-0.4.1",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.rustc_version-0.4.1.bazel"),
     )
 
     maybe(
@@ -947,32 +946,32 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__serde-1.0.204",
-        sha256 = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12",
+        name = "crates_vendor__serde-1.0.210",
+        sha256 = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/serde/1.0.204/download"],
-        strip_prefix = "serde-1.0.204",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.serde-1.0.204.bazel"),
+        urls = ["https://static.crates.io/crates/serde/1.0.210/download"],
+        strip_prefix = "serde-1.0.210",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.serde-1.0.210.bazel"),
     )
 
     maybe(
         http_archive,
-        name = "crates_vendor__serde_derive-1.0.204",
-        sha256 = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222",
+        name = "crates_vendor__serde_derive-1.0.210",
+        sha256 = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/serde_derive/1.0.204/download"],
-        strip_prefix = "serde_derive-1.0.204",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.serde_derive-1.0.204.bazel"),
+        urls = ["https://static.crates.io/crates/serde_derive/1.0.210/download"],
+        strip_prefix = "serde_derive-1.0.210",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.serde_derive-1.0.210.bazel"),
     )
 
     maybe(
         http_archive,
-        name = "crates_vendor__serde_json-1.0.120",
-        sha256 = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5",
+        name = "crates_vendor__serde_json-1.0.128",
+        sha256 = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/serde_json/1.0.120/download"],
-        strip_prefix = "serde_json-1.0.120",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.serde_json-1.0.120.bazel"),
+        urls = ["https://static.crates.io/crates/serde_json/1.0.128/download"],
+        strip_prefix = "serde_json-1.0.128",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.serde_json-1.0.128.bazel"),
     )
 
     maybe(
@@ -983,6 +982,16 @@ def crate_repositories():
         urls = ["https://static.crates.io/crates/servo_arc/0.1.1/download"],
         strip_prefix = "servo_arc-0.1.1",
         build_file = Label("@workerd//rust-deps/crates:BUILD.servo_arc-0.1.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "crates_vendor__shlex-1.3.0",
+        sha256 = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
+        type = "tar.gz",
+        urls = ["https://static.crates.io/crates/shlex/1.3.0/download"],
+        strip_prefix = "shlex-1.3.0",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.shlex-1.3.0.bazel"),
     )
 
     maybe(
@@ -1027,12 +1036,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__syn-2.0.72",
-        sha256 = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af",
+        name = "crates_vendor__syn-2.0.77",
+        sha256 = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/syn/2.0.72/download"],
-        strip_prefix = "syn-2.0.72",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.syn-2.0.72.bazel"),
+        urls = ["https://static.crates.io/crates/syn/2.0.77/download"],
+        strip_prefix = "syn-2.0.77",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.syn-2.0.77.bazel"),
     )
 
     maybe(
@@ -1077,12 +1086,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__version_check-0.9.4",
-        sha256 = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
+        name = "crates_vendor__version_check-0.9.5",
+        sha256 = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/version_check/0.9.4/download"],
-        strip_prefix = "version_check-0.9.4",
-        build_file = Label("@workerd//rust-deps/crates:BUILD.version_check-0.9.4.bazel"),
+        urls = ["https://static.crates.io/crates/version_check/0.9.5/download"],
+        strip_prefix = "version_check-0.9.5",
+        build_file = Label("@workerd//rust-deps/crates:BUILD.version_check-0.9.5.bazel"),
     )
 
     maybe(
@@ -1116,11 +1125,11 @@ def crate_repositories():
     )
 
     return [
-        struct(repo = "crates_vendor__anyhow-1.0.86", is_dev_dep = False),
-        struct(repo = "crates_vendor__clang-ast-0.1.25", is_dev_dep = False),
-        struct(repo = "crates_vendor__flate2-1.0.30", is_dev_dep = False),
+        struct(repo = "crates_vendor__anyhow-1.0.87", is_dev_dep = False),
+        struct(repo = "crates_vendor__clang-ast-0.1.26", is_dev_dep = False),
+        struct(repo = "crates_vendor__flate2-1.0.33", is_dev_dep = False),
         struct(repo = "crates_vendor__lolhtml-1.1.1", is_dev_dep = False),
         struct(repo = "crates_vendor__pico-args-0.5.0", is_dev_dep = False),
-        struct(repo = "crates_vendor__serde-1.0.204", is_dev_dep = False),
-        struct(repo = "crates_vendor__serde_json-1.0.120", is_dev_dep = False),
+        struct(repo = "crates_vendor__serde-1.0.210", is_dev_dep = False),
+        struct(repo = "crates_vendor__serde_json-1.0.128", is_dev_dep = False),
     ]

--- a/rust-deps/packages.bzl
+++ b/rust-deps/packages.bzl
@@ -26,6 +26,6 @@ RTTI_PACKAGES = {
 PACKAGES = RTTI_PACKAGES | {
     "lolhtml": crate.spec(
         git = "https://github.com/cloudflare/lol-html.git",
-        rev = "53469c5acf5bf2955cbf3848544028ec835d38a4",
+        rev = "7db3d8d9fa9f3fee6ffe36c3f68f14e160476e07",
     ),
 }


### PR DESCRIPTION
This rolls the Rust LLVM version from 17 to 18, which feels reasonable based on LLVM 19 being released next week and the compiler versions we currently use to build workerd (16 for Linux, 18 for Windows, Apple Clang equivalent to LLVM 16 on macOS (will be LLVM 17 with the upcoming Xcode version)).