### PR TITLE
zlib: Add support for info: true option

### DIFF
--- a/src/node/internal/internal_zlib_base.ts
+++ b/src/node/internal/internal_zlib_base.ts
@@ -529,6 +529,16 @@ export class ZlibBase extends Transform {
   public _processChunk(
     chunk: Buffer,
     flushFlag: number,
+    cb?: undefined
+  ): Buffer;
+  public _processChunk(
+    chunk: Buffer,
+    flushFlag: number,
+    cb: () => void
+  ): undefined;
+  public _processChunk(
+    chunk: Buffer,
+    flushFlag: number,
     cb?: () => void
   ): Buffer | Uint8Array | undefined {
     if (cb != null && typeof cb === 'function') {

--- a/src/node/internal/zlib.d.ts
+++ b/src/node/internal/zlib.d.ts
@@ -1,14 +1,9 @@
 import { owner_symbol, type Zlib } from 'node-internal:internal_zlib_base';
 
-export function crc32(data: ArrayBufferView, value: number): number;
-
-export type CompressCallback = (
-  err: Error | null,
-  buffer?: ArrayBuffer
-) => void;
-export type InternalCompressCallback = (res: Error | ArrayBuffer) => void;
+type InternalCompressCallback = (res: Error | ArrayBuffer) => void;
 
 export function crc32(data: ArrayBufferView | string, value: number): number;
+
 export function zlibSync(
   data: ArrayBufferView | string,
   options: ZlibOptions,
@@ -178,6 +173,8 @@ export interface BrotliOptions {
       }
     | undefined;
   maxOutputLength?: number | undefined;
+  // Not specified in NodeJS docs but the tests expect it
+  info?: boolean | undefined;
 }
 
 type ErrorHandler = (errno: number, code: string, message: string) => void;

--- a/src/workerd/api/node/tests/zlib-nodejs-test.js
+++ b/src/workerd/api/node/tests/zlib-nodejs-test.js
@@ -2005,26 +2005,25 @@ export const convenienceMethods = {
           await promise;
         }
 
-        // TODO(soon): Enable this test
-        // {
-        //   const { promise, resolve } = Promise.withResolvers();
-        //   zlib[method[0]](expect, optsInfo, (err, result) => {
-        //     assert.ifError(err);
-        //
-        //     const compressed = result.buffer;
-        //     zlib[method[1]](compressed, optsInfo, (err, result) => {
-        //       assert.ifError(err);
-        //       assert.strictEqual(
-        //         result.buffer.toString(),
-        //         expectStr,
-        //         `Should get original string after ${method[0]}/` +
-        //           `${method[1]} ${type} with info option.`
-        //       );
-        //       resolve();
-        //     });
-        //   });
-        //   await promise;
-        // }
+        {
+          const { promise, resolve } = Promise.withResolvers();
+          zlib[method[0]](expect, optsInfo, (err, result) => {
+            assert.ifError(err);
+
+            const compressed = result.buffer;
+            zlib[method[1]](compressed, optsInfo, (err, result) => {
+              assert.ifError(err);
+              assert.strictEqual(
+                result.buffer.toString(),
+                expectStr,
+                `Should get original string after ${method[0]}/` +
+                  `${method[1]} ${type} with info option.`
+              );
+              resolve();
+            });
+          });
+          await promise;
+        }
 
         {
           const compressed = zlib[`${method[0]}Sync`](expect, opts);
@@ -2048,25 +2047,24 @@ export const convenienceMethods = {
           );
         }
 
-        // TODO(soon): Enable this test
-        // {
-        //   const compressed = zlib[`${method[0]}Sync`](expect, optsInfo);
-        //   const decompressed = zlib[`${method[1]}Sync`](
-        //     compressed.buffer,
-        //     optsInfo
-        //   );
-        //   assert.strictEqual(
-        //     decompressed.buffer.toString(),
-        //     expectStr,
-        //     `Should get original string after ${method[0]}Sync/` +
-        //       `${method[1]}Sync ${type} without options.`
-        //   );
-        //   assert.ok(
-        //     decompressed.engine instanceof zlib[method[3]],
-        //     `Should get engine ${method[3]} after ${method[0]} ` +
-        //       `${type} with info option.`
-        //   );
-        // }
+        {
+          const compressed = zlib[`${method[0]}Sync`](expect, optsInfo);
+          const decompressed = zlib[`${method[1]}Sync`](
+            compressed.buffer,
+            optsInfo
+          );
+          assert.strictEqual(
+            decompressed.buffer.toString(),
+            expectStr,
+            `Should get original string after ${method[0]}Sync/` +
+              `${method[1]}Sync ${type} without options.`
+          );
+          assert.ok(
+            decompressed.engine instanceof zlib[method[3]],
+            `Should get engine ${method[3]} after ${method[0]} ` +
+              `${type} with info option.`
+          );
+        }
       }
     }
 


### PR DESCRIPTION
This PR implements the `{info: true}` option for zlib. It's not documented for brotli, but the unit tests expect it there too. We return an engine, and the buffer. 

~However, the engine we're returning isn't really legit - we just create it on the fly to return it. Should we fall back to the streaming path when `info: true`, for more fidelity with NodeJS or is this close enough?~ Now going whole-hog and falling back to the streaming implementation when `info: true`