### PR TITLE
Extend SQL API to make it "compatible" with D1 API. 

### DIFF
--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -29,6 +29,43 @@ jsg::Ref<SqlStorage::Statement> SqlStorage::prepare(jsg::Lock& js, kj::String qu
   return jsg::alloc<Statement>(getDb(js).prepare(*this, query));
 }
 
+jsg::JsArray SqlStorage::batch(jsg::Lock& js,
+    kj::Array<kj::OneOf<jsg::Ref<SqlStorage::Statement>, jsg::Ref<SqlStorage::BoundStatement>>>
+        statements) {
+  // Batch needs to be run as a transaction, but we can't use `BEGIN TRANSACTION` because we may
+  // already be in a transaction (especially an implicit transaction). That's OK, we can use
+  // savepoints.
+  auto& db = getDb(js);
+  execMemoized(db, beginBatch, "SAVEPOINT _cf_batch");
+  bool success = false;
+  KJ_DEFER({
+    if (!success) {
+      execMemoized(db, rollbackBatch, "ROLLBACK TO _cf_batch");
+    }
+  });
+
+  v8::LocalVector<v8::Value> results(js.v8Isolate);
+
+  for (auto& statement: statements) {
+    KJ_SWITCH_ONEOF(statement) {
+      KJ_CASE_ONEOF(unbound, jsg::Ref<SqlStorage::Statement>) {
+        // If the user put an unbound statement in the batch, assume that the statement simply
+        // doesn't have any arguments.
+        results.push_back(unbound->run(kj::Array<BindingValue>(nullptr))
+            ->getResults(js));
+      }
+      KJ_CASE_ONEOF(bound, jsg::Ref<SqlStorage::BoundStatement>) {
+        results.push_back(bound->run()->getResults(js));
+      }
+    }
+  };
+
+  execMemoized(db, commitBatch, "RELEASE _cf_batch");
+  success = true;
+
+  return jsg::JsArray(v8::Array::New(js.v8Isolate, results.data(), results.size()));
+}
+
 double SqlStorage::getDatabaseSize(jsg::Lock& js) {
   auto& db = getDb(js);
   int64_t pages = execMemoized(db, pragmaPageCount,
@@ -58,6 +95,45 @@ bool SqlStorage::allowTransactions() const {
         "Durable Objects' automatic atomic write coalescing.");
   }
   return false;
+}
+
+jsg::JsValue SqlStorage::wrapSqlValue(jsg::Lock& js, SqlValue value) {
+  KJ_IF_SOME(v, value) {
+    KJ_SWITCH_ONEOF(v) {
+      KJ_CASE_ONEOF(bytes, kj::Array<byte>) {
+        return jsg::JsValue(js.wrapBytes(kj::mv(bytes)));
+      }
+      KJ_CASE_ONEOF(text, kj::StringPtr) {
+        return js.str(text);
+      }
+      KJ_CASE_ONEOF(number, double) {
+        return js.num(number);
+      }
+    }
+    KJ_UNREACHABLE;
+  } else {
+    return js.null();
+  }
+}
+
+jsg::JsObject SqlStorage::wrapSqlRow(jsg::Lock& js, SqlRow row) {
+  return jsg::JsObject(js.withinHandleScope([&]() -> v8::Local<v8::Object> {
+    jsg::JsObject result = js.obj();
+    for (auto& field: row.fields) {
+      result.set(js, field.name, wrapSqlValue(js, kj::mv(field.value)));
+    }
+    return result;
+  }));
+}
+
+jsg::JsArray SqlStorage::wrapSqlRowRaw(jsg::Lock& js, kj::Array<SqlValue> row) {
+  return jsg::JsArray(js.withinHandleScope([&]() -> v8::Local<v8::Array> {
+    v8::LocalVector<v8::Value> values(js.v8Isolate);
+    for (auto& field: row) {
+      values.push_back(wrapSqlValue(js, kj::mv(field)));
+    }
+    return v8::Array::New(js.v8Isolate, values.data(), values.size());
+  }));
 }
 
 SqlStorage::Cursor::State::State(kj::RefcountedWrapper<SqliteDatabase::Statement>& statement,
@@ -113,6 +189,31 @@ double SqlStorage::Cursor::getRowsWritten() {
   }
 }
 
+jsg::JsArray SqlStorage::Cursor::getResults(jsg::Lock& js) {
+  KJ_IF_SOME(s, state) {
+    cachedColumnNames.ensureInitialized(js, s->query);
+  }
+
+  // Wrap in handle scope mostly for the benefit of `batch()`, whose implementation calls this
+  // many times.
+  return jsg::JsArray(js.withinHandleScope([&]() {
+    v8::LocalVector<v8::Value> results(js.v8Isolate);
+    jsg::Ref<Cursor> self = JSG_THIS;
+    for (;;) {
+      KJ_IF_SOME(result, rowIteratorNext(js, self)) {
+        results.push_back(wrapSqlRow(js, kj::mv(result)));
+      } else {
+        break;
+      }
+    }
+    return v8::Array::New(js.v8Isolate, results.data(), results.size());
+  }));
+}
+
+jsg::Ref<SqlStorage::Cursor::Meta> SqlStorage::Cursor::getMeta() {
+  return jsg::alloc<Meta>(JSG_THIS);
+}
+
 jsg::Ref<SqlStorage::Cursor::RowIterator> SqlStorage::Cursor::rows(jsg::Lock& js) {
   KJ_IF_SOME(s, state) {
     cachedColumnNames.ensureInitialized(js, s->query);
@@ -140,10 +241,14 @@ jsg::Ref<SqlStorage::Cursor::RawIterator> SqlStorage::Cursor::raw(jsg::Lock&) {
 // Returns the set of column names for the current Cursor. An exception will be thrown if the
 // iterator has already been fully consumed. The resulting columns may contain duplicate entries,
 // for instance a `SELECT *` across a join of two tables that share a column name.
-kj::Array<jsg::JsRef<jsg::JsString>> SqlStorage::Cursor::getColumnNames(jsg::Lock& js) {
+jsg::JsArray SqlStorage::Cursor::getColumnNames(jsg::Lock& js) {
   KJ_IF_SOME(s, state) {
     cachedColumnNames.ensureInitialized(js, s->query);
-    return KJ_MAP(name, this->cachedColumnNames.get()) { return name.addRef(js); };
+    v8::LocalVector<v8::Value> results(js.v8Isolate);
+    for (auto& name: cachedColumnNames.get()) {
+      results.push_back(name.getHandle(js));
+    }
+    return jsg::JsArray(v8::Array::New(js.v8Isolate, results.data(), results.size()));
   } else {
     JSG_FAIL_REQUIRE(Error, "Cannot call .getColumnNames after Cursor iterator has been consumed.");
   }
@@ -274,6 +379,116 @@ jsg::Ref<SqlStorage::Cursor> SqlStorage::Statement::run(jsg::Arguments<BindingVa
   return result;
 }
 
+jsg::Ref<SqlStorage::BoundStatement> SqlStorage::Statement::bind(
+    jsg::Arguments<BindingValue> bindings) {
+  return jsg::alloc<BoundStatement>(JSG_THIS, kj::mv(bindings));
+}
+
+jsg::JsArray SqlStorage::Statement::raw(
+    const v8::FunctionCallbackInfo<v8::Value>& args,
+    const jsg::TypeHandler<BindingValue>& bindingTypeHandler,
+    const jsg::TypeHandler<RawOptions>& optionsTypeHandler) {
+  jsg::Lock& js = jsg::Lock::from(args.GetIsolate());
+
+  uint bindingCount = statement->getWrapped().bindingCount();
+
+  uint argc = args.Length();
+
+  RawOptions options;
+  if (argc > bindingCount) {
+    // More args than there are bindings, so assume the arg after the last binding is the options
+    // struct.
+    options = JSG_REQUIRE_NONNULL(optionsTypeHandler.tryUnwrap(js, args[bindingCount]), TypeError,
+        "Failed to execute SQL statement: argument ", bindingCount, " is not a valid options "
+        "object.");
+  }
+
+  uint n = kj::min(bindingCount, argc);
+  auto bindings = kj::heapArrayBuilder<BindingValue>(n);
+  for (uint i: kj::zeroTo(n)) {
+    bindings.add(JSG_REQUIRE_NONNULL(bindingTypeHandler.tryUnwrap(js, args[i]), TypeError,
+        "Failed to execute SQL statement: argument ", i, " is not a valid SQL argument type."));
+  }
+
+  return rawImpl(js, bindings.finish(), kj::mv(options));
+}
+
+jsg::JsArray SqlStorage::Statement::rawImpl(
+    jsg::Lock& js, jsg::Arguments<BindingValue> bindings,
+    const Statement::RawOptions& options) {
+  auto cursor = run(kj::mv(bindings));
+
+  KJ_IF_SOME(s, cursor->state) {
+    cursor->cachedColumnNames.ensureInitialized(js, s->query);
+  }
+
+  v8::LocalVector<v8::Value> results(js.v8Isolate);
+
+  if (options.columnNames) {
+    results.push_back(cursor->getColumnNames(js));
+  }
+
+  for (;;) {
+    KJ_IF_SOME(result, Cursor::rawIteratorNext(js, cursor)) {
+      results.push_back(wrapSqlRowRaw(js, kj::mv(result)));
+    } else {
+      break;
+    }
+  }
+
+  return jsg::JsArray(v8::Array::New(js.v8Isolate, results.data(), results.size()));
+}
+
+jsg::JsValue SqlStorage::Statement::first(
+    const v8::FunctionCallbackInfo<v8::Value>& args,
+    const jsg::TypeHandler<BindingValue>& bindingTypeHandler) {
+  jsg::Lock& js = jsg::Lock::from(args.GetIsolate());
+
+  uint bindingCount = statement->getWrapped().bindingCount();
+
+  uint argc = args.Length();
+
+  kj::Maybe<jsg::JsString> columnName;
+  if (argc > bindingCount) {
+    // More args than there are bindings, so assume the arg after the last binding is the column
+    // name.
+    columnName = jsg::JsValue(args[bindingCount]).toJsString(js);
+  }
+
+  uint n = kj::min(bindingCount, argc);
+  auto bindings = kj::heapArrayBuilder<BindingValue>(n);
+  for (uint i: kj::zeroTo(n)) {
+    bindings.add(JSG_REQUIRE_NONNULL(bindingTypeHandler.tryUnwrap(js, args[i]), TypeError,
+        "Failed to execute SQL statement: argument ", i, " is not a valid SQL argument type."));
+  }
+
+  return firstImpl(js, bindings.finish(), kj::mv(columnName));
+}
+
+jsg::JsValue SqlStorage::Statement::firstImpl(
+    jsg::Lock& js, jsg::Arguments<BindingValue> bindings, jsg::Optional<jsg::JsString> column) {
+  // Note that because the cursor is never returned to JS, it is never subject to GC, and will be
+  // deterministically destroyed when this function returns.
+  auto cursor = run(kj::mv(bindings));
+
+  auto result = KJ_UNWRAP_OR(Cursor::rowIteratorNext(js, cursor), {
+    // No results.
+    return js.null();
+  });
+
+  KJ_IF_SOME(c, column) {
+    for (auto& field: result.fields) {
+      if (field.name == c) {
+        return jsg::JsValue(wrapSqlValue(js, kj::mv(field.value)));
+      }
+    }
+    JSG_FAIL_REQUIRE(TypeError, "SQL query results have no column named \"", c, "\".");
+  } else {
+    // return whole row
+    return jsg::JsValue(wrapSqlRow(js, kj::mv(result)));
+  }
+}
+
 void SqlStorage::visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
   tracker.trackField("storage", storage);
   tracker.trackFieldWithSize("IoPtr<SqliteDatabase>", sizeof(IoPtr<SqliteDatabase>));
@@ -285,6 +500,46 @@ void SqlStorage::visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
     tracker.trackFieldWithSize(
         "IoPtr<SqllitDatabase::Statement>", sizeof(IoPtr<SqliteDatabase::Statement>));
   }
+}
+
+jsg::Ref<SqlStorage::Cursor> SqlStorage::BoundStatement::run() {
+  return statement->run(cloneBindings());
+}
+
+jsg::JsArray SqlStorage::BoundStatement::raw(jsg::Lock& js,
+    jsg::Optional<Statement::RawOptions> options) {
+  return statement->rawImpl(js, cloneBindings(), options.orDefault({}));
+}
+
+jsg::JsValue SqlStorage::BoundStatement::first(
+    jsg::Lock& js, jsg::Optional<jsg::JsString> column) {
+  return statement->firstImpl(js, cloneBindings(), column);
+}
+
+jsg::Arguments<SqlStorage::BindingValue> SqlStorage::BoundStatement::cloneBindings() {
+  // Annoyingly the bound statement could theoretically be executed multiple times and so we need
+  // to clone the bindings each time in order to pass an owned copy to the query while also keeping
+  // a copy for future calls. In theory with some refactoring we could avoid this but this is only
+  // a compatibility shim anyway so we're not optimizing for it.
+
+  return KJ_MAP(binding, bindings) -> BindingValue {
+    KJ_IF_SOME(b, binding) {
+      KJ_SWITCH_ONEOF(b) {
+        KJ_CASE_ONEOF(bytes, kj::Array<const byte>) {
+          return NonNullBindingValue(kj::Array<const byte>(kj::heapArray(bytes.asPtr())));
+        }
+        KJ_CASE_ONEOF(text, kj::String) {
+          return NonNullBindingValue(kj::heapString(text));
+        }
+        KJ_CASE_ONEOF(number, double) {
+          return NonNullBindingValue(number);
+        }
+      }
+      KJ_UNREACHABLE;
+    } else {
+      return kj::none;
+    }
+  };
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -123,7 +123,7 @@ jsg::Ref<SqlStorage::Cursor::RowIterator> SqlStorage::Cursor::rows(jsg::Lock& js
 kj::Maybe<SqlStorage::Cursor::RowDict> SqlStorage::Cursor::rowIteratorNext(
     jsg::Lock& js, jsg::Ref<Cursor>& obj) {
   auto names = obj->cachedColumnNames.get();
-  return iteratorImpl(js, obj, [&](State& state, uint i, Value&& value) {
+  return iteratorImpl(js, obj, [&](State& state, uint i, SqlValue&& value) {
     return RowDict::Field{
       // A little trick here: We know there are no HandleScopes on the stack between JSG and here,
       // so we can return a dict keyed by local handles, which avoids constructing new V8Refs here
@@ -149,16 +149,17 @@ kj::Array<jsg::JsRef<jsg::JsString>> SqlStorage::Cursor::getColumnNames(jsg::Loc
   }
 }
 
-kj::Maybe<kj::Array<SqlStorage::Cursor::Value>> SqlStorage::Cursor::rawIteratorNext(
+kj::Maybe<kj::Array<SqlStorage::SqlValue>> SqlStorage::Cursor::rawIteratorNext(
     jsg::Lock& js, jsg::Ref<Cursor>& obj) {
-  return iteratorImpl(js, obj, [&](State& state, uint i, Value&& value) { return kj::mv(value); });
+  return iteratorImpl(
+      js, obj, [&](State& state, uint i, SqlValue&& value) { return kj::mv(value); });
 }
 
 template <typename Func>
 auto SqlStorage::Cursor::iteratorImpl(jsg::Lock& js, jsg::Ref<Cursor>& obj, Func&& func)
     -> kj::Maybe<
-        kj::Array<decltype(func(kj::instance<State&>(), uint(), kj::instance<Value&&>()))>> {
-  using Element = decltype(func(kj::instance<State&>(), uint(), kj::instance<Value&&>()));
+        kj::Array<decltype(func(kj::instance<State&>(), uint(), kj::instance<SqlValue&&>()))>> {
+  using Element = decltype(func(kj::instance<State&>(), uint(), kj::instance<SqlValue&&>()));
 
   auto& state = *KJ_UNWRAP_OR(obj->state, {
     if (obj->canceled) {
@@ -193,7 +194,7 @@ auto SqlStorage::Cursor::iteratorImpl(jsg::Lock& js, jsg::Ref<Cursor>& obj, Func
 
   auto results = kj::heapArrayBuilder<Element>(query.columnCount());
   for (auto i: kj::zeroTo(results.capacity())) {
-    Value value;
+    SqlValue value;
     KJ_SWITCH_ONEOF(query.getValue(i)) {
       KJ_CASE_ONEOF(data, kj::ArrayPtr<const byte>) {
         value.emplace(kj::heapArray(data));

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -120,17 +120,17 @@ jsg::Ref<SqlStorage::Cursor::RowIterator> SqlStorage::Cursor::rows(jsg::Lock& js
   return jsg::alloc<RowIterator>(JSG_THIS);
 }
 
-kj::Maybe<SqlStorage::Cursor::RowDict> SqlStorage::Cursor::rowIteratorNext(
+kj::Maybe<SqlStorage::SqlRow> SqlStorage::Cursor::rowIteratorNext(
     jsg::Lock& js, jsg::Ref<Cursor>& obj) {
   auto names = obj->cachedColumnNames.get();
   return iteratorImpl(js, obj, [&](State& state, uint i, SqlValue&& value) {
-    return RowDict::Field{
+    return SqlRow::Field{
       // A little trick here: We know there are no HandleScopes on the stack between JSG and here,
       // so we can return a dict keyed by local handles, which avoids constructing new V8Refs here
       // which would be relatively slower.
       .name = names[i].getHandle(js),
       .value = kj::mv(value)};
-  }).map([&](kj::Array<RowDict::Field>&& fields) { return RowDict{.fields = kj::mv(fields)}; });
+  }).map([&](kj::Array<SqlRow::Field>&& fields) { return SqlRow{.fields = kj::mv(fields)}; });
 }
 
 jsg::Ref<SqlStorage::Cursor::RawIterator> SqlStorage::Cursor::raw(jsg::Lock&) {

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -29,6 +29,9 @@ public:
   // JSG, which does not need to make a copy.
   using SqlValue = kj::Maybe<kj::OneOf<kj::Array<byte>, kj::StringPtr, double>>;
 
+  // One row of a SQL query result. This is an Object whose properties correspond to columns.
+  using SqlRow = jsg::Dict<SqlValue, jsg::JsString>;
+
   jsg::Ref<Cursor> exec(jsg::Lock& js, kj::String query, jsg::Arguments<BindingValue> bindings);
   IngestResult ingest(jsg::Lock& js, kj::String query);
 
@@ -128,8 +131,7 @@ public:
     JSG_READONLY_PROTOTYPE_PROPERTY(rowsWritten, getRowsWritten);
   }
 
-  using RowDict = jsg::Dict<SqlValue, jsg::JsString>;
-  JSG_ITERATOR(RowIterator, rows, RowDict, jsg::Ref<Cursor>, rowIteratorNext);
+  JSG_ITERATOR(RowIterator, rows, SqlRow, jsg::Ref<Cursor>, rowIteratorNext);
   JSG_ITERATOR(RawIterator, raw, kj::Array<SqlValue>, jsg::Ref<Cursor>, rawIteratorNext);
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
@@ -217,7 +219,7 @@ private:
   static kj::Array<const SqliteDatabase::Query::ValuePtr> mapBindings(
       kj::ArrayPtr<BindingValue> values);
 
-  static kj::Maybe<RowDict> rowIteratorNext(jsg::Lock& js, jsg::Ref<Cursor>& obj);
+  static kj::Maybe<SqlRow> rowIteratorNext(jsg::Lock& js, jsg::Ref<Cursor>& obj);
   static kj::Maybe<kj::Array<SqlValue>> rawIteratorNext(jsg::Lock& js, jsg::Ref<Cursor>& obj);
   template <typename Func>
   static auto iteratorImpl(jsg::Lock& js, jsg::Ref<Cursor>& obj, Func&& func)

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -23,6 +23,12 @@ public:
   class Statement;
   struct IngestResult;
 
+  // One value returned from SQL. Note that we intentionally return StringPtr instead of String
+  // because we know that the underlying buffer returned by SQLite will be valid long enough to be
+  // converted by JSG into a V8 string. For byte arrays, on the other hand, we pass ownership to
+  // JSG, which does not need to make a copy.
+  using SqlValue = kj::Maybe<kj::OneOf<kj::Array<byte>, kj::StringPtr, double>>;
+
   jsg::Ref<Cursor> exec(jsg::Lock& js, kj::String query, jsg::Arguments<BindingValue> bindings);
   IngestResult ingest(jsg::Lock& js, kj::String query);
 
@@ -122,15 +128,9 @@ public:
     JSG_READONLY_PROTOTYPE_PROPERTY(rowsWritten, getRowsWritten);
   }
 
-  // One value returned from SQL. Note that we intentionally return StringPtr instead of String
-  // because we know that the underlying buffer returned by SQLite will be valid long enough to be
-  // converted by JSG into a V8 string. For byte arrays, on the other hand, we pass ownership to
-  // JSG, which does not need to make a copy.
-  using Value = kj::Maybe<kj::OneOf<kj::Array<byte>, kj::StringPtr, double>>;
-
-  using RowDict = jsg::Dict<Value, jsg::JsString>;
+  using RowDict = jsg::Dict<SqlValue, jsg::JsString>;
   JSG_ITERATOR(RowIterator, rows, RowDict, jsg::Ref<Cursor>, rowIteratorNext);
-  JSG_ITERATOR(RawIterator, raw, kj::Array<Value>, jsg::Ref<Cursor>, rawIteratorNext);
+  JSG_ITERATOR(RawIterator, raw, kj::Array<SqlValue>, jsg::Ref<Cursor>, rawIteratorNext);
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
     if (state != kj::none) {
@@ -218,11 +218,11 @@ private:
       kj::ArrayPtr<BindingValue> values);
 
   static kj::Maybe<RowDict> rowIteratorNext(jsg::Lock& js, jsg::Ref<Cursor>& obj);
-  static kj::Maybe<kj::Array<Value>> rawIteratorNext(jsg::Lock& js, jsg::Ref<Cursor>& obj);
+  static kj::Maybe<kj::Array<SqlValue>> rawIteratorNext(jsg::Lock& js, jsg::Ref<Cursor>& obj);
   template <typename Func>
   static auto iteratorImpl(jsg::Lock& js, jsg::Ref<Cursor>& obj, Func&& func)
       -> kj::Maybe<
-          kj::Array<decltype(func(kj::instance<State&>(), uint(), kj::instance<Value&&>()))>>;
+          kj::Array<decltype(func(kj::instance<State&>(), uint(), kj::instance<SqlValue&&>()))>>;
 
   friend class Statement;
 };

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -175,6 +175,11 @@ public:
       // Unfortunately, D1 named these properties with underscores, so fake it out.
       JSG_READONLY_PROTOTYPE_PROPERTY(rows_read, getRowsRead);
       JSG_READONLY_PROTOTYPE_PROPERTY(rows_written, getRowsWritten);
+
+      JSG_TS_OVERRIDE({
+        rows_read: never;
+        rows_written: never;
+      });
     }
 
     void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
@@ -208,6 +213,14 @@ public:
     JSG_LAZY_INSTANCE_PROPERTY(results, getResults);
 
     JSG_READONLY_PROTOTYPE_PROPERTY(meta, getMeta);
+
+    JSG_TS_DEFINE(type SqlStorageResultValue = ArrayBuffer | string | number | null);
+    JSG_TS_OVERRIDE(<T = Record<string, SqlStorageResultValue>> {
+      get columnNames(): string[];
+      get results(): T[];
+      [Symbol.iterator](): IterableIterator<T>;
+      raw(): IterableIterator<SqlStorageResultValue[]>;
+    });
   }
 
   JSG_ITERATOR(RowIterator, rows, SqlRow, jsg::Ref<Cursor>, rowIteratorNext);
@@ -319,6 +332,7 @@ public:
     bool columnNames = false;
 
     JSG_STRUCT(columnNames);
+    JSG_STRUCT_TS_OVERRIDE(type RawOptions = never);
   };
 
   // D1 compatibility methods: raw() and first(). These get a little hacky because they both take
@@ -349,6 +363,16 @@ public:
     JSG_METHOD(bind);
     JSG_METHOD(raw);
     JSG_METHOD(first);
+
+    JSG_TS_OVERRIDE({
+      bind(...values: unknown[]): SqlStorageBoundStatement;
+      run<T = Record<string, unknown>>(...values: unknown[]): SqlStorageCursor<T>;
+      all<T = Record<string, unknown>>(...values: unknown[]): SqlStorageCursor<T>;
+      raw<T = unknown[]>(options: {columnNames: true}): [string[], ...T[]];
+      raw<T = unknown[]>(options?: {columnNames?: false}): T[];
+      first<T = unknown>(colName: string): T | null;
+      first<T = Record<string, unknown>>(): T | null;
+    });
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
@@ -393,6 +417,15 @@ public:
     JSG_METHOD_NAMED(all, run);
     JSG_METHOD(raw);
     JSG_METHOD(first);
+
+    JSG_TS_OVERRIDE({
+      run<T = Record<string, unknown>>(): SqlStorageCursor<T>;
+      all<T = Record<string, unknown>>(): SqlStorageCursor<T>;
+      raw<T = unknown[]>(options: {columnNames: true}): [string[], ...T[]];
+      raw<T = unknown[]>(options?: {columnNames?: false}): T[];
+      first<T = unknown>(colName: string): T | null;
+      first<T = Record<string, unknown>>(): T | null;
+    });
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -886,6 +886,12 @@ SqliteDatabase::Statement SqliteDatabase::prepare(
       *this, regulator, prepareSql(regulator, sqlCode, SQLITE_PREPARE_PERSISTENT, SINGLE));
 }
 
+uint SqliteDatabase::Statement::bindingCount() {
+  int result = sqlite3_bind_parameter_count(stmt);
+  KJ_ASSERT(result >= 0);
+  return result;
+}
+
 SqliteDatabase::Query::Query(SqliteDatabase& db,
     const Regulator& regulator,
     Statement& statement,

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -214,6 +214,8 @@ public:
   template <typename... Params>
   Query run(Params&&... bindings);
 
+  uint bindingCount();
+
   operator sqlite3_stmt*() {
     return stmt;
   }

--- a/types/defines/d1.d.ts
+++ b/types/defines/d1.d.ts
@@ -32,10 +32,10 @@ declare abstract class D1Database {
 
 declare abstract class D1PreparedStatement {
   bind(...values: unknown[]): D1PreparedStatement;
-  first<T = unknown>(colName: string): Promise<T | null>;
-  first<T = Record<string, unknown>>(): Promise<T | null>;
   run<T = Record<string, unknown>>(): Promise<D1Result<T>>;
   all<T = Record<string, unknown>>(): Promise<D1Result<T>>;
   raw<T = unknown[]>(options: {columnNames: true}): Promise<[string[], ...T[]]>;
   raw<T = unknown[]>(options?: {columnNames?: false}): Promise<T[]>;
+  first<T = unknown>(colName: string): Promise<T | null>;
+  first<T = Record<string, unknown>>(): Promise<T | null>;
 }


### PR DESCRIPTION
With these additions, code written against a D1 binding should "just work" if given `storage.sql`, as long as it uses `await` on results (which becomes a no-op when the functions are synchronous) instead of `.then()`.

- Add statement.bind(), which returns a bound statement.
- Add sql.batch(), which takes an array of bound statements and returns an array of results.
- Add statement.run() and statement.all(), which are both aliases for calling it as a function.
- Add statement.raw(), which returns an array of arrays of values. This has an option to include column names as the first item in the returned array.
- Add statement.first(), which returns only the first result. This has an option to pass a column name.
- Add cursor.results, which is a property that, when accessed, iterates the cursor and builds an array.
- Add cursor.meta, which emulates the metadata returned by D1. `duration` is always zero.

--------

I think that `cursor.results` is actually pretty nice, but the rest of this feels pretty gross TBH. There's now a lot of redundant ways to do the same thing, and the optional arguments passed to `first()` and `raw()` which fundamentally change their return types feel problematic.

I think we definitely don't want to document all this, as all the redundant ways to do the same thing will confuse people. It would also be nice if we can somehow hide them from IDE auto-complete, though I'm not sure if that's possible. I'm half inclined to actually hide stuff behind a compat flag.

@geelen We're going to need some manual TypeScript overrides here, especially for the methods where I had to do some manual conversion of values to JavaScript and thus the methods' C++ type signatures don't actually fully describe their types. Can you help out? I don't know TS very well, and this is also probably a good exercise for you to verify that what I did actually matches D1 by your understanding.