### PR TITLE
Fix types to correctly suggest NonRetryableError is exported in cloudflare:workflows

### DIFF
--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -2,12 +2,14 @@
  * NonRetryableError allows for a user to throw a fatal error
  * that makes a Workflow instance fail immediately without triggering a retry
  */
-declare abstract class NonRetryableError extends Error {
-  /**
-   * `__brand` is used to differentiate between `NonRetryableError` and `Error`
-   * and is omitted from the constructor because users should not set it
-   */
-  public constructor(message: string, name?: string);
+declare module "cloudflare:workflows" {
+  export abstract class NonRetryableError extends Error {
+    /**
+     * `__brand` is used to differentiate between `NonRetryableError` and `Error`
+     * and is omitted from the constructor because users should not set it
+     */
+    public constructor(message: string, name?: string);
+  }
 }
 
 declare abstract class Workflow {


### PR DESCRIPTION
The types currently suggest that it is in global scope and it is not