### PR TITLE
Reset row counters when creating Query using templates

### DIFF
--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -509,7 +509,9 @@ KJ_TEST("SQLite read row counters (basic)") {
   constexpr int dbRowCount = 1000;
   auto insertStmt = db.prepare("INSERT INTO things (id, unindexed_int, value) VALUES (?, ?, ?)");
   for (int i = 0; i < dbRowCount; i++) {
-    insertStmt.run(i, i * 1000, kj::str("value", i));
+    auto query = insertStmt.run(i, i * 1000, kj::str("value", i));
+    KJ_EXPECT(query.getRowsRead() == 1);
+    KJ_EXPECT(query.getRowsWritten() == 1);
   }
 
   // Sanity check that the inserts worked.

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -405,6 +405,7 @@ private:
       : ResetListener(db),
         regulator(regulator),
         maybeStatement(statement) {
+    resetRowCounters();
     bindAll(std::index_sequence_for<Params...>(), kj::fwd<Params>(bindings)...);
   }
   template <typename... Params>


### PR DESCRIPTION
Reset the row counters when we create Query, so we calculate rowsRead and rowsWritten correctly.