### PR TITLE
Patch v8 to support promise cross-context resolution

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -465,6 +465,7 @@ http_archive(
         "//:patches/v8/0016-Revert-TracedReference-deref-API-removal.patch",
         "//:patches/v8/0017-Revert-heap-Add-masm-specific-unwinding-annotations-.patch",
         "//:patches/v8/0018-Update-illegal-invocation-error-message-in-v8.patch",
+        "//:patches/v8/0019-Implement-cross-request-context-promise-resolve-hand.patch",
     ],
     strip_prefix = "v8-12.9.202.13",
     url = "https://github.com/v8/v8/archive/refs/tags/12.9.202.13.tar.gz",

--- a/patches/v8/0019-Implement-cross-request-context-promise-resolve-hand.patch
+++ b/patches/v8/0019-Implement-cross-request-context-promise-resolve-hand.patch
@@ -1,0 +1,471 @@
+From 8cf4fe0f72fbaf25028ebd152559bd363da6599e Mon Sep 17 00:00:00 2001
+From: James M Snell <jasnell@gmail.com>
+Date: Mon, 16 Sep 2024 09:56:04 -0700
+Subject: [PATCH] Implement cross-request context promise resolve handling
+
+---
+ include/v8-callbacks.h                      | 21 ++++++++++
+ include/v8-isolate.h                        |  2 +
+ src/api/api.cc                              |  7 +++-
+ src/builtins/promise-abstract-operations.tq |  6 ++-
+ src/builtins/promise-resolve.tq             |  4 +-
+ src/execution/isolate-inl.h                 | 21 +++++++---
+ src/execution/isolate.cc                    | 24 +++++++++++-
+ src/execution/isolate.h                     | 19 +++++++--
+ src/heap/factory.cc                         | 11 +++---
+ src/objects/js-promise.h                    |  5 +++
+ src/objects/objects.cc                      | 43 +++++++++++++++++++++
+ src/roots/roots.h                           |  3 +-
+ src/runtime/runtime-promise.cc              | 30 +++++++++++---
+ src/runtime/runtime.h                       |  3 +-
+ 14 files changed, 171 insertions(+), 28 deletions(-)
+
+diff --git a/include/v8-callbacks.h b/include/v8-callbacks.h
+index 25f0c8189e5..f7fbae861a5 100644
+--- a/include/v8-callbacks.h
++++ b/include/v8-callbacks.h
+@@ -471,6 +471,27 @@ using PromiseCrossContextCallback = MaybeLocal<Promise> (*)(Local<Context> conte
+                                                             Local<Promise> promise,
+                                                             Local<Object> tag);
+ 
++/**
++ * PromiseCrossContextResolveCallback is called when resolving or rejecting a
++ * pending promise whose context tag is not strictly equal to the isolate's
++ * current promise context tag. The callback is called with the promise to be
++ * resolved, it's context tag, and a function that when called, causes the
++ * reactions to the resolved promise to be enqueued. The idea is that the
++ * embedder sets this callback in the case it needs to defer the actual
++ * scheduling of the reactions to the given promise to a later time.
++ * Importantly, when this callback is invoked, the state of the promise
++ * should have already been updated. We're simply possibly deferring the
++ * enqueue of the reactions to the promise.
++ */
++using PromiseCrossContextResolveCallback = Maybe<void> (*)(
++    v8::Isolate* isolate,
++    Local<Value> tag,
++    Local<Data> reactions,
++    Local<Value> argument,
++    std::function<void(v8::Isolate* isolate,
++                       Local<Data> reactions,
++                       Local<Value> argument)> callback);
++
+ }  // namespace v8
+ 
+ #endif  // INCLUDE_V8_ISOLATE_CALLBACKS_H_
+diff --git a/include/v8-isolate.h b/include/v8-isolate.h
+index 8112231319b..9fe57f7bde4 100644
+--- a/include/v8-isolate.h
++++ b/include/v8-isolate.h
+@@ -1732,6 +1732,8 @@ class V8_EXPORT Isolate {
+ 
+   class PromiseContextScope;
+   void SetPromiseCrossContextCallback(PromiseCrossContextCallback callback);
++  void SetPromiseCrossContextResolveCallback(
++      PromiseCrossContextResolveCallback callback);
+ 
+   Isolate() = delete;
+   ~Isolate() = delete;
+diff --git a/src/api/api.cc b/src/api/api.cc
+index d3fc6d77ea3..248a78ad24c 100644
+--- a/src/api/api.cc
++++ b/src/api/api.cc
+@@ -12246,12 +12246,17 @@ void Isolate::SetPromiseCrossContextCallback(PromiseCrossContextCallback callbac
+   isolate->set_promise_cross_context_callback(callback);
+ }
+ 
++void Isolate::SetPromiseCrossContextResolveCallback(PromiseCrossContextResolveCallback callback) {
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(this);
++  isolate->set_promise_cross_context_resolve_callback(callback);
++}
++
+ Isolate::PromiseContextScope::PromiseContextScope(Isolate* isolate, v8::Local<v8::Object> tag)
+     : isolate_(reinterpret_cast<i::Isolate*>(isolate)) {
+   DCHECK(!isolate_->has_promise_context_tag());
+   DCHECK(!tag.IsEmpty());
+   i::Handle<i::Object> handle = Utils::OpenHandle(*tag);
+-  isolate_->set_promise_context_tag(*handle);
++  isolate_->set_promise_context_tag(handle);
+ }
+ 
+ Isolate::PromiseContextScope::~PromiseContextScope() {
+diff --git a/src/builtins/promise-abstract-operations.tq b/src/builtins/promise-abstract-operations.tq
+index fdec3d268e4..456d051d3c0 100644
+--- a/src/builtins/promise-abstract-operations.tq
++++ b/src/builtins/promise-abstract-operations.tq
+@@ -23,6 +23,9 @@ extern transitioning runtime PromiseRejectEventFromStack(
+ 
+ extern transitioning runtime PromiseContextCheck(
+     implicit context: Context)(JSPromise): JSPromise;
++
++extern transitioning runtime PromiseResolveContextCheck(
++    implicit context: Context)(JSPromise): JSAny;
+ }
+ 
+ // https://tc39.es/ecma262/#sec-promise-abstract-operations
+@@ -239,7 +242,8 @@ transitioning builtin RejectPromise(
+   // the runtime handle this operation, which greatly reduces
+   // the complexity here and also avoids a couple of back and
+   // forth between JavaScript and C++ land.
+-  if (IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(
++  if (ToBoolean(runtime::PromiseResolveContextCheck(promise)) ||
++      IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(
+           promiseHookFlags) ||
+       !promise.HasHandler()) {
+     // 7. If promise.[[PromiseIsHandled]] is false, perform
+diff --git a/src/builtins/promise-resolve.tq b/src/builtins/promise-resolve.tq
+index 202180adbba..c93ac5905d7 100644
+--- a/src/builtins/promise-resolve.tq
++++ b/src/builtins/promise-resolve.tq
+@@ -96,7 +96,9 @@ transitioning builtin ResolvePromise(
+   // We also let the runtime handle it if promise == resolution.
+   // We can use pointer comparison here, since the {promise} is guaranteed
+   // to be a JSPromise inside this function and thus is reference comparable.
+-  if (IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() ||
++
++  if (ToBoolean(runtime::PromiseResolveContextCheck(promise)) ||
++      IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() ||
+       TaggedEqual(promise, resolution))
+     deferred {
+       return runtime::ResolvePromise(promise, resolution);
+diff --git a/src/execution/isolate-inl.h b/src/execution/isolate-inl.h
+index 9e0969460fd..aa2b1cea6b7 100644
+--- a/src/execution/isolate-inl.h
++++ b/src/execution/isolate-inl.h
+@@ -134,26 +134,35 @@ bool Isolate::is_execution_terminating() {
+          i::ReadOnlyRoots(this).termination_exception();
+ }
+ 
+-Tagged<Object> Isolate::promise_context_tag() {
+-  return promise_context_tag_;
++Handle<Object> Isolate::promise_context_tag() {
++  return root_handle(RootIndex::kPromiseContextTag);
+ }
+ 
+ bool Isolate::has_promise_context_tag() {
+-  return promise_context_tag_ != ReadOnlyRoots(this).the_hole_value();
++  return heap()->promise_context_tag() != ReadOnlyRoots(this).the_hole_value();
+ }
+ 
+ void Isolate::clear_promise_context_tag() {
+-  set_promise_context_tag(ReadOnlyRoots(this).the_hole_value());
++  heap()->set_promise_context_tag(ReadOnlyRoots(this).the_hole_value());
+ }
+ 
+-void Isolate::set_promise_context_tag(Tagged<Object> tag) {
+-  promise_context_tag_ = tag;
++void Isolate::set_promise_context_tag(Handle<Object> tag) {
++  heap()->set_promise_context_tag(*tag);
+ }
+ 
+ void Isolate::set_promise_cross_context_callback(PromiseCrossContextCallback callback) {
+   promise_cross_context_callback_ = callback;
+ }
+ 
++void Isolate::set_promise_cross_context_resolve_callback(
++    PromiseCrossContextResolveCallback callback) {
++  promise_cross_context_resolve_callback_ = callback;
++}
++
++bool Isolate::has_promise_context_resolve_callback() {
++  return promise_cross_context_resolve_callback_ != nullptr;
++}
++
+ #ifdef DEBUG
+ Tagged<Object> Isolate::VerifyBuiltinsResult(Tagged<Object> result) {
+   if (is_execution_terminating() && !v8_flags.strict_termination_checks) {
+diff --git a/src/execution/isolate.cc b/src/execution/isolate.cc
+index 94194d59bae..19e01f57240 100644
+--- a/src/execution/isolate.cc
++++ b/src/execution/isolate.cc
+@@ -593,8 +593,6 @@ void Isolate::Iterate(RootVisitor* v, ThreadLocalTop* thread) {
+                       FullObjectSlot(&thread->pending_message_));
+   v->VisitRootPointer(Root::kStackRoots, nullptr,
+                       FullObjectSlot(&thread->context_));
+-  v->VisitRootPointer(Root::kStackRoots, nullptr,
+-                      FullObjectSlot(&promise_context_tag_));
+ 
+   for (v8::TryCatch* block = thread->try_catch_handler_; block != nullptr;
+        block = block->next_) {
+@@ -7459,5 +7457,27 @@ MaybeHandle<JSPromise> Isolate::RunPromiseCrossContextCallback(Handle<NativeCont
+   return v8::Utils::OpenHandle(*result);
+ }
+ 
++Maybe<void> Isolate::RunPromiseCrossContextResolveCallback(v8::Isolate* isolate,
++                                                           Handle<JSObject> tag,
++                                                           Handle<Object> reactions,
++                                                           Handle<Object> argument,
++                                                           PromiseReaction::Type type) {
++  CHECK(promise_cross_context_resolve_callback_ != nullptr);
++  return promise_cross_context_resolve_callback_(
++      isolate,
++      v8::Utils::ToLocal(tag),
++      v8::Utils::ToLocal(reactions),
++      v8::Utils::ToLocal(argument),
++      [type](v8::Isolate* isolate,
++             v8::Local<v8::Data> reactions,
++             v8::Local<v8::Value> argument) {
++    JSPromise::ContinueTriggerPromiseReactions(
++        reinterpret_cast<Isolate*>(isolate),
++        Utils::OpenHandle(*reactions),
++        Utils::OpenHandle(*argument),
++        type);
++  });
++}
++
+ }  // namespace internal
+ }  // namespace v8
+diff --git a/src/execution/isolate.h b/src/execution/isolate.h
+index 59926e68e97..1bd5193b054 100644
+--- a/src/execution/isolate.h
++++ b/src/execution/isolate.h
+@@ -42,6 +42,7 @@
+ #include "src/objects/contexts.h"
+ #include "src/objects/debug-objects.h"
+ #include "src/objects/js-objects.h"
++#include "src/objects/promise.h"
+ #include "src/objects/tagged.h"
+ #include "src/runtime/runtime.h"
+ #include "src/sandbox/code-pointer-table.h"
+@@ -2244,13 +2245,22 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
+                                        v8::ExceptionContext callback_kind);
+   void SetExceptionPropagationCallback(ExceptionPropagationCallback callback);
+ 
+-  inline Tagged<Object> promise_context_tag();
++  inline Handle<Object> promise_context_tag();
+   inline bool has_promise_context_tag();
+   inline void clear_promise_context_tag();
+-  inline void set_promise_context_tag(Tagged<Object> tag);
++  inline void set_promise_context_tag(Handle<Object> tag);
+   inline void set_promise_cross_context_callback(PromiseCrossContextCallback callback);
++  inline void set_promise_cross_context_resolve_callback(
++      PromiseCrossContextResolveCallback callback);
+   MaybeHandle<JSPromise> RunPromiseCrossContextCallback(Handle<NativeContext> context,
+                                                         Handle<JSPromise> promise);
++  Maybe<void> RunPromiseCrossContextResolveCallback(v8::Isolate* isolate,
++                                                    Handle<JSObject> tag,
++                                                    Handle<Object> reactions,
++                                                    Handle<Object> argument,
++                                                    PromiseReaction::Type type);
++
++  inline bool has_promise_context_resolve_callback();
+ 
+ #ifdef V8_ENABLE_WASM_SIMD256_REVEC
+   void set_wasm_revec_verifier_for_test(
+@@ -2763,9 +2773,10 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
+   int current_thread_counter_ = 0;
+ #endif
+ 
+-  Tagged<Object> promise_context_tag_;
+-  PromiseCrossContextCallback promise_cross_context_callback_;
++  PromiseCrossContextCallback promise_cross_context_callback_ = nullptr;
++  PromiseCrossContextResolveCallback promise_cross_context_resolve_callback_ = nullptr;
+   bool in_promise_cross_context_callback_ = false;
++  bool in_promise_cross_context_resolve_callback_ = false;
+ 
+   class PromiseCrossContextCallbackScope;
+ 
+diff --git a/src/heap/factory.cc b/src/heap/factory.cc
+index c0c46447c2f..47ef01bae12 100644
+--- a/src/heap/factory.cc
++++ b/src/heap/factory.cc
+@@ -4413,18 +4413,17 @@ Handle<JSPromise> Factory::NewJSPromiseWithoutHook() {
+   Handle<JSPromise> promise =
+       Cast<JSPromise>(NewJSObject(isolate()->promise_function()));
+   DisallowGarbageCollection no_gc;
+-  Tagged<JSPromise> raw = *promise;
+-  raw->set_reactions_or_result(Smi::zero(), SKIP_WRITE_BARRIER);
++  promise->set_reactions_or_result(Smi::zero(), SKIP_WRITE_BARRIER);
+   if (!isolate()->has_promise_context_tag()) {
+-    raw->set_context_tag(Smi::zero(), SKIP_WRITE_BARRIER);
++    promise->set_context_tag(Smi::zero(), SKIP_WRITE_BARRIER);
+   } else {
+-    raw->set_context_tag(isolate()->promise_context_tag());
++    promise->set_context_tag(*isolate()->promise_context_tag());
+   }
+ 
+-  raw->set_flags(0);
++  promise->set_flags(0);
+   // TODO(v8) remove once embedder data slots are always zero-initialized.
+   InitEmbedderFields(*promise, Smi::zero());
+-  DCHECK_EQ(raw->GetEmbedderFieldCount(), v8::Promise::kEmbedderFieldCount);
++  DCHECK_EQ(promise->GetEmbedderFieldCount(), v8::Promise::kEmbedderFieldCount);
+   return promise;
+ }
+ 
+diff --git a/src/objects/js-promise.h b/src/objects/js-promise.h
+index e4c1e42c63e..87bebb70d0d 100644
+--- a/src/objects/js-promise.h
++++ b/src/objects/js-promise.h
+@@ -75,6 +75,11 @@ class JSPromise
+   static_assert(v8::Promise::kFulfilled == 1);
+   static_assert(v8::Promise::kRejected == 2);
+ 
++  static void ContinueTriggerPromiseReactions(Isolate* isolate,
++                                              DirectHandle<Object> reactions,
++                                              DirectHandle<Object> argument,
++                                              PromiseReaction::Type type);
++
+  private:
+   // ES section #sec-triggerpromisereactions
+   static Handle<Object> TriggerPromiseReactions(Isolate* isolate,
+diff --git a/src/objects/objects.cc b/src/objects/objects.cc
+index 76e284e19a2..b5cde09038e 100644
+--- a/src/objects/objects.cc
++++ b/src/objects/objects.cc
+@@ -4878,6 +4878,23 @@ Handle<Object> JSPromise::Fulfill(DirectHandle<JSPromise> promise,
+   // 6. Set promise.[[PromiseState]] to "fulfilled".
+   promise->set_status(Promise::kFulfilled);
+ 
++  Handle<Object> obj(promise->context_tag(), isolate);
++  bool needs_promise_context_switch =
++      !(*obj == Smi::zero() ||
++        obj.is_identical_to(isolate->promise_context_tag()) ||
++        !isolate->has_promise_context_resolve_callback());
++  if (needs_promise_context_switch) {
++    if (isolate->RunPromiseCrossContextResolveCallback(
++        reinterpret_cast<v8::Isolate*>(isolate),
++        Cast<JSObject>(obj),
++        reactions,
++        value,
++        PromiseReaction::kFulfill).IsNothing()) {
++      return {};
++    }
++    return isolate->factory()->undefined_value();
++  }
++
+   // 7. Return TriggerPromiseReactions(reactions, value).
+   return TriggerPromiseReactions(isolate, reactions, value,
+                                  PromiseReaction::kFulfill);
+@@ -4933,6 +4950,23 @@ Handle<Object> JSPromise::Reject(Handle<JSPromise> promise,
+     isolate->ReportPromiseReject(promise, reason, kPromiseRejectWithNoHandler);
+   }
+ 
++  Handle<Object> obj(promise->context_tag(), isolate);
++  bool needs_promise_context_switch =
++      !(*obj == Smi::zero() ||
++        obj.is_identical_to(isolate->promise_context_tag()) ||
++        !isolate->has_promise_context_resolve_callback());
++  if (needs_promise_context_switch) {
++    if (isolate->RunPromiseCrossContextResolveCallback(
++        reinterpret_cast<v8::Isolate*>(isolate),
++        Cast<JSObject>(obj),
++        reactions,
++        reason,
++        PromiseReaction::kReject).IsNothing()) {
++      return {};
++    }
++    return isolate->factory()->undefined_value();
++  }
++
+   // 8. Return TriggerPromiseReactions(reactions, reason).
+   return TriggerPromiseReactions(isolate, reactions, reason,
+                                  PromiseReaction::kReject);
+@@ -5035,6 +5069,15 @@ MaybeHandle<Object> JSPromise::Resolve(Handle<JSPromise> promise,
+ }
+ 
+ // static
++
++void JSPromise::ContinueTriggerPromiseReactions(
++    Isolate* isolate,
++    DirectHandle<Object> reactions,
++    DirectHandle<Object> argument,
++    PromiseReaction::Type type) {
++  TriggerPromiseReactions(isolate, reactions, argument, type);
++}
++
+ Handle<Object> JSPromise::TriggerPromiseReactions(
+     Isolate* isolate, DirectHandle<Object> reactions,
+     DirectHandle<Object> argument, PromiseReaction::Type type) {
+diff --git a/src/roots/roots.h b/src/roots/roots.h
+index 288dee65e04..51af59f2efa 100644
+--- a/src/roots/roots.h
++++ b/src/roots/roots.h
+@@ -405,7 +405,8 @@ class RootVisitor;
+   V(FunctionTemplateInfo, error_stack_getter_fun_template,                  \
+     ErrorStackGetterSharedFun)                                              \
+   V(FunctionTemplateInfo, error_stack_setter_fun_template,                  \
+-    ErrorStackSetterSharedFun)
++    ErrorStackSetterSharedFun)                                              \
++  V(Object, promise_context_tag, PromiseContextTag)
+ 
+ // Entries in this list are limited to Smis and are not visited during GC.
+ #define SMI_ROOT_LIST(V)                                                       \
+diff --git a/src/runtime/runtime-promise.cc b/src/runtime/runtime-promise.cc
+index 4fbdf90319c..f58e6ce6173 100644
+--- a/src/runtime/runtime-promise.cc
++++ b/src/runtime/runtime-promise.cc
+@@ -133,8 +133,10 @@ RUNTIME_FUNCTION(Runtime_RejectPromise) {
+   Handle<JSPromise> promise = args.at<JSPromise>(0);
+   Handle<Object> reason = args.at(1);
+   DirectHandle<Boolean> debug_event = args.at<Boolean>(2);
+-  return *JSPromise::Reject(promise, reason,
++  Handle<Object> result = JSPromise::Reject(promise, reason,
+                             Object::BooleanValue(*debug_event, isolate));
++  RETURN_FAILURE_IF_EXCEPTION(isolate);
++  return *result;
+ }
+ 
+ RUNTIME_FUNCTION(Runtime_ResolvePromise) {
+@@ -222,8 +224,8 @@ RUNTIME_FUNCTION(Runtime_PromiseContextInit) {
+   if (!isolate->has_promise_context_tag()) {
+     args.at<JSPromise>(0)->set_context_tag(Smi::zero());
+   } else {
+-    CHECK(!IsUndefined(isolate->promise_context_tag()));
+-    args.at<JSPromise>(0)->set_context_tag(isolate->promise_context_tag());
++    CHECK(!IsUndefined(*isolate->promise_context_tag()));
++    args.at<JSPromise>(0)->set_context_tag(*isolate->promise_context_tag());
+   }
+   return ReadOnlyRoots(isolate).undefined_value();
+ }
+@@ -237,8 +239,8 @@ RUNTIME_FUNCTION(Runtime_PromiseContextCheck) {
+   // If promise.context_tag() is strict equal to isolate.promise_context_tag(),
+   // or if the promise being checked does not have a context tag, we'll just return
+   // promise directly.
+-  Tagged<Object> obj = promise->context_tag();
+-  if (obj == Smi::zero() || obj == isolate->promise_context_tag()) {
++  Handle<Object> obj(promise->context_tag(), isolate);
++  if (*obj == Smi::zero() || obj.is_identical_to(isolate->promise_context_tag())) {
+     return *promise;
+   }
+ 
+@@ -251,5 +253,23 @@ RUNTIME_FUNCTION(Runtime_PromiseContextCheck) {
+   return *result;
+ }
+ 
++RUNTIME_FUNCTION(Runtime_PromiseResolveContextCheck) {
++  HandleScope scope(isolate);
++  DCHECK_EQ(1, args.length());
++  Handle<JSPromise> promise = args.at<JSPromise>(0);
++  // If promise.context_tag() is strict equal to isolate.promise_context_tag(),
++  // or if the promise being checked does not have a context tag, or if the
++  // resolve callback has not been set, we'll just return false here to indicate
++  // that the default handling should be used.
++  Handle<Object> obj(promise->context_tag(), isolate);
++  if (*obj == Smi::zero() ||
++      obj.is_identical_to(isolate->promise_context_tag()) ||
++      !isolate->has_promise_context_resolve_callback()) {
++    return isolate->heap()->ToBoolean(false);
++  }
++
++  return isolate->heap()->ToBoolean(true);
++}
++
+ }  // namespace internal
+ }  // namespace v8
+diff --git a/src/runtime/runtime.h b/src/runtime/runtime.h
+index 9399509f690..bfca9182be0 100644
+--- a/src/runtime/runtime.h
++++ b/src/runtime/runtime.h
+@@ -403,7 +403,8 @@ namespace internal {
+   F(ConstructAggregateErrorHelper, 4, 1) \
+   F(ConstructInternalAggregateErrorHelper, -1 /* <= 5*/, 1) \
+   F(PromiseContextInit, 1, 1)            \
+-  F(PromiseContextCheck, 1, 1)
++  F(PromiseContextCheck, 1, 1)           \
++  F(PromiseResolveContextCheck, 1, 1)
+ 
+ #define FOR_EACH_INTRINSIC_PROXY(F, I) \
+   F(CheckProxyGetSetTrapResult, 2, 1)  \
+-- 
+2.34.1
+

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -548,3 +548,9 @@ wd_test(
     args = ["--experimental"],
     data = ["tests/new-module-registry-test.js"],
 )
+
+wd_test(
+    src = "tests/cross-context-promise-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/cross-context-promise-test.js"],
+)

--- a/src/workerd/api/tests/cross-context-promise-test.js
+++ b/src/workerd/api/tests/cross-context-promise-test.js
@@ -1,0 +1,452 @@
+import { match, rejects, strictEqual, throws } from 'assert';
+import { AsyncLocalStorage } from 'async_hooks';
+import { inspect } from 'util';
+import { mock } from 'node:test';
+
+export const crossContextResolveWorks = {
+  async test(_, env) {
+    // We're going to send two simultaneous requests to the same endpoint.
+    const results = await Promise.allSettled([
+      env.subrequest.fetch('http://example.org/resolve'),
+      env.subrequest.fetch('http://example.org/resolve'),
+    ]);
+    strictEqual(results[0].status, 'fulfilled');
+    strictEqual(results[1].status, 'fulfilled');
+    strictEqual(results[0].value.status, 200);
+    strictEqual(results[1].value.status, 200);
+    strictEqual(await results[0].value.text(), 'ok');
+    strictEqual(await results[1].value.text(), 'ok');
+  },
+};
+
+export const crossContextRejectWorks = {
+  async test(_, env) {
+    // We're going to send two simultaneous requests to the same endpoint.
+    const results = await Promise.allSettled([
+      env.subrequest.fetch('http://example.org/reject'),
+      env.subrequest.fetch('http://example.org/reject'),
+    ]);
+    strictEqual(results[0].status, 'fulfilled');
+    strictEqual(results[1].status, 'fulfilled');
+    strictEqual(results[0].value.status, 200);
+    strictEqual(results[1].value.status, 200);
+    strictEqual(await results[0].value.text(), 'ok');
+    strictEqual(await results[1].value.text(), 'ok');
+  },
+};
+
+export const crossContextStreamWorks = {
+  async test(_, env) {
+    // We're going to send two simultaneous requests to the same endpoint.
+    const results = await Promise.allSettled([
+      env.subrequest.fetch('http://example.org/stream'),
+      env.subrequest.fetch('http://example.org/stream'),
+    ]);
+    strictEqual(results[0].status, 'fulfilled');
+    strictEqual(results[1].status, 'fulfilled');
+    strictEqual(results[0].value.status, 200);
+    strictEqual(results[1].value.status, 200);
+    strictEqual(await results[0].value.text(), 'ok');
+    strictEqual(await results[1].value.text(), 'ok');
+  },
+};
+
+export const customThenableWorks = {
+  async test(_, env) {
+    // We're going to send two simultaneous requests to the same endpoint.
+    const results = await Promise.allSettled([
+      env.subrequest.fetch('http://example.org/thenable'),
+      env.subrequest.fetch('http://example.org/thenable'),
+    ]);
+    strictEqual(results[0].status, 'fulfilled');
+    strictEqual(results[1].status, 'fulfilled');
+    strictEqual(results[0].value.status, 200);
+    strictEqual(results[1].value.status, 200);
+    strictEqual(await results[0].value.text(), 'ok');
+    strictEqual(await results[1].value.text(), 'ok');
+  },
+};
+
+export const unhandledRejectionWorks = {
+  async test(_, env) {
+    // We're going to send two simultaneous requests to the same endpoint.
+    const results = await Promise.allSettled([
+      env.subrequest.fetch('http://example.org/unhandled'),
+      env.subrequest.fetch('http://example.org/unhandled'),
+    ]);
+    strictEqual(results[0].status, 'fulfilled');
+    strictEqual(results[1].status, 'fulfilled');
+    strictEqual(results[0].value.status, 200);
+    strictEqual(results[1].value.status, 200);
+    strictEqual(await results[0].value.text(), 'ok');
+    strictEqual(await results[1].value.text(), 'ok');
+  },
+};
+
+export const expiredContextWorks = {
+  async test(_, env) {
+    // We're going to send two simultaneous requests to the same endpoint.
+    const results = await Promise.allSettled([
+      env.subrequest.fetch('http://example.org/expired'),
+      env.subrequest.fetch('http://example.org/expired'),
+    ]);
+    strictEqual(results[0].status, 'rejected');
+    strictEqual(results[1].status, 'fulfilled');
+    strictEqual(
+      results[0].reason.message,
+      'The script will never generate a response.'
+    );
+    strictEqual(results[1].value.status, 200);
+    strictEqual(await results[1].value.text(), 'ok');
+    // Wait a tick for things to settle out before checking the global.
+    // We're just making sure here that the promise in the first request
+    // was canceled correctly.
+    await scheduler.wait(100);
+    strictEqual(globalThis.expiredRan, undefined);
+  },
+};
+
+export const asyncIterWorks = {
+  async test(_, env) {
+    // We're going to send two simultaneous requests to the same endpoint.
+    const results = await Promise.allSettled([
+      env.subrequest.fetch('http://example.org/asynciter'),
+      env.subrequest.fetch('http://example.org/asynciter'),
+    ]);
+    strictEqual(results[0].status, 'fulfilled');
+    strictEqual(results[1].status, 'fulfilled');
+    strictEqual(results[0].value.status, 200);
+    strictEqual(results[1].value.status, 200);
+    strictEqual(await results[0].value.text(), 'ok');
+    strictEqual(await results[1].value.text(), 'ok');
+  },
+};
+
+export const cyclicAwaitsWorks = {
+  async test(_, env) {
+    // We're going to send two simultaneous requests to the same endpoint.
+    const results = await Promise.allSettled([
+      env.subrequest.fetch('http://example.org/cyclic'),
+      env.subrequest.fetch('http://example.org/cyclic'),
+    ]);
+    strictEqual(results[0].status, 'rejected');
+    strictEqual(results[1].status, 'fulfilled');
+  },
+};
+
+export default {
+  async fetch(req, env, ctx) {
+    if (req.url.endsWith('/resolve')) {
+      return resolveTest(req, env, ctx);
+    } else if (req.url.endsWith('/reject')) {
+      return rejectTest(req, env, ctx);
+    } else if (req.url.endsWith('/stream')) {
+      return crossRequestStream(req, env, ctx);
+    } else if (req.url.endsWith('/thenable')) {
+      return customThenable(req, env, ctx);
+    } else if (req.url.endsWith('/unhandled')) {
+      return unhandledRejection(req, env, ctx);
+    } else if (req.url.endsWith('/expired')) {
+      return expiredContext(req, env, ctx);
+    } else if (req.url.endsWith('/asynciter')) {
+      return asyncIterator(req, env, ctx);
+    } else if (req.url.endsWith('/cyclic')) {
+      return cyclicPromise(req, env, ctx);
+    }
+    throw new Error('Invalid URL');
+  },
+};
+
+function setupWaiter(ctx) {
+  const { promise, resolve } = Promise.withResolvers();
+  setTimeout(resolve, 1000);
+  ctx.waitUntil(promise);
+}
+
+async function resolveTest(req, env, ctx) {
+  const als = new AsyncLocalStorage();
+  // This will be called twice. The first time in one request where we will
+  // create the promise and resolver. The second time for the second request
+  // where the promise will be resolved.
+  if (globalThis.request1 === undefined) {
+    setupWaiter(ctx);
+    const { promise, resolve } = Promise.withResolvers();
+    globalThis.request1 = { promise, resolve };
+    const ab = AbortSignal.abort();
+    strictEqual(ab.aborted, true);
+    await als.run(123, async () => {
+      await promise;
+      strictEqual(als.getStore(), 123);
+    });
+    // This part is the main test. It will not run until after the promise
+    // is resolved in the second request.
+    // We use an AbortSignal because it is bound to the IoContext and will
+    // throw an error if ab.aborted is checked from the wrong IoContext.
+    // If this line runes, it is proof that the promise continuation is
+    // running in the correct IoContext.
+    strictEqual(ab.aborted, true);
+    return new Response('ok');
+  }
+
+  // This is our second request. Here, all we do is resolve the promise.
+
+  // While we are deferring the continuations from the promise, the promise state
+  // change should happen immediately. Before calling resolve, the state should
+  // be pending. After calling resolve, the state should be resolved showing
+  // an undefined value. Updating the state of the promise immediately and
+  // synchronously is required by the language specification.
+  // See: https://tc39.es/ecma262/#sec-promise-resolve-functions
+  strictEqual(inspect(globalThis.request1.promise), 'Promise { <pending> }');
+  als.run('abc', () => globalThis.request1.resolve());
+  strictEqual(inspect(globalThis.request1.promise), 'Promise { undefined }');
+
+  const p = globalThis.request1.promise;
+
+  globalThis.request1 = undefined;
+
+  // We ought to be able to do a cross-request wait on the promise still.
+  await p;
+
+  return new Response('ok');
+}
+
+const reason = new Error('boom');
+
+async function rejectTest(req, env, ctx) {
+  if (globalThis.request2 === undefined) {
+    setupWaiter(ctx);
+    const { promise, reject } = Promise.withResolvers();
+    globalThis.request2 = { reject };
+    const ab = AbortSignal.abort();
+    strictEqual(ab.aborted, true);
+    try {
+      // The promise will be rejected from the other request.
+      await promise;
+      throw new Error('should not get here');
+    } catch (err) {
+      // The reason provided by the other request should be carried
+      // through here. If the ab.aborted check throws, then the continuation
+      // is running in the wrong IoContext, which is the main thing we are
+      // testing for here.
+      strictEqual(err, reason);
+      strictEqual(ab.aborted, true);
+    }
+    return new Response('ok');
+  }
+
+  // This is our second request. Here, all we do is reject the promise.
+  globalThis.request2.reject(reason);
+  globalThis.request2 = undefined;
+  return new Response('ok');
+}
+
+async function crossRequestStream(req, env, ctx) {
+  // Here, we are going to create a stream that will be used across
+  // requests. The first request will create the stream and queue up
+  // a pending read. The second request will fulfull the read by providing
+  // data to the stream.
+  if (globalThis.stream === undefined) {
+    setupWaiter(ctx);
+    let controller;
+    const readable = new ReadableStream({
+      start(c) {
+        controller = c;
+      },
+    });
+    globalThis.stream = { controller };
+    const reader = readable.getReader();
+    const ab = AbortSignal.abort();
+    strictEqual(ab.aborted, true);
+    const read = await reader.read();
+    strictEqual(ab.aborted, true);
+    return new Response('ok');
+  }
+
+  // This is our second request. Here, all we do is provide data to the stream.
+  // This will cause our pending read to be fulfilled.
+  const enc = new TextEncoder();
+  globalThis.stream.controller.enqueue(enc.encode('hello'));
+  globalThis.stream = undefined;
+  return new Response('ok');
+}
+
+async function customThenable(req, env, ctx) {
+  // This will be called twice. The first time in one request where we will
+  // create the promise and resolver. The second time for the second request
+  // where the promise will be resolved.
+  if (globalThis.thenable === undefined) {
+    setupWaiter(ctx);
+    const { promise, resolve } = Promise.withResolvers();
+    globalThis.thenable = { resolve };
+    const ab = AbortSignal.abort();
+    strictEqual(ab.aborted, true);
+
+    // We check to make sure the value provided by the custom thenable is
+    // property passed through to the promise resolution.
+
+    strictEqual(await promise, 1);
+    // This part is the main test. It will not run until after the promise
+    // is resolved in the second request.
+    // We use an AbortSignal because it is bound to the IoContext and will
+    // throw an error if ab.aborted is checked from the wrong IoContext.
+    // If this line runes, it is proof that the promise continuation is
+    // running in the correct IoContext.
+    strictEqual(ab.aborted, true);
+    return new Response('ok');
+  }
+
+  // This is our second request. Here, all we do is resolve the promise.
+  const ab = AbortSignal.abort();
+  strictEqual(ab.aborted, true);
+
+  const then = mock.fn((resolve) => {
+    // The thenable should be invoked in the second request's IoContext.
+    // If it is not, then the ab.aborted check below will fail.
+    strictEqual(ab.aborted, true);
+    resolve(1);
+  });
+
+  globalThis.thenable.resolve({ then });
+  globalThis.thenable = undefined;
+
+  // Confirm that the thenable was called exactly once in this request.
+  await Promise.resolve();
+  strictEqual(then.mock.calls.length, 1);
+
+  return new Response('ok');
+}
+
+async function unhandledRejection(req, env, ctx) {
+  // This will be called twice. The first time in one request where we will
+  // create the promise and resolver. The second time for the second request
+  // where the promise will be rejected.
+  if (globalThis.unhandled === undefined) {
+    setupWaiter(ctx);
+    const { promise, reject } = Promise.withResolvers();
+    globalThis.unhandled = { reject };
+    const ab = AbortSignal.abort();
+    strictEqual(ab.aborted, true);
+
+    const rejectPromise = Promise.withResolvers();
+    globalThis.addEventListener(
+      'unhandledrejection',
+      (event) => {
+        // Here we have a gotcha! The unhandledrejection event is dispatched
+        // synchronously when the promise is rejected. It does not get deferred.
+        // so the IoContext here will be the second request's IoContext! This
+        // means that our ab.aborted check will fail!
+        throws(() => ab.aborted, {
+          message: /I\/O type: RefcountedCanceler/,
+        });
+        strictEqual(event.reason, reason);
+        rejectPromise.resolve();
+      },
+      { once: true }
+    );
+    await rejectPromise.promise;
+
+    return new Response('ok');
+  }
+
+  // This is our second request. Here, all we do is reject the promise.
+  globalThis.unhandled.reject(reason);
+  globalThis.unhandled = undefined;
+  return new Response('ok');
+}
+
+async function expiredContext(req, env, ctx) {
+  if (globalThis.expired === undefined) {
+    // We do not arrange for a waiter here. We want the request context
+    // to be canceled before the promise is resolved. In the error log
+    // (which we unfortunately cannot check here) we should see a message
+    // about the hanging promise being canceled and another message about
+    // a promise resolved across request contexts but the target request
+    // is not longer active. On the calling side, the first request
+    // should reject and the second request should resolve.
+    const { promise, resolve } = Promise.withResolvers();
+    globalThis.expired = { resolve };
+    promise.then(() => {
+      // This should never run...
+      globalThis.expiredRan = true;
+    });
+    await new Promise(() => {});
+    return new Response('ok');
+  }
+
+  // This is our second request. Here, all we do is resolve the promise.
+  // Let's wait a bit to make sure the other request has had time to
+  // be canceled and destroyed.
+  await scheduler.wait(100);
+  globalThis.expired.resolve();
+  globalThis.expired = undefined;
+  return new Response('ok');
+}
+
+async function* gen(ab) {
+  let c = 0;
+  for (;;) {
+    await scheduler.wait(10);
+    strictEqual(ab.aborted, true);
+    yield c++;
+  }
+}
+
+async function asyncIterator(req, env, ctx) {
+  if (globalThis.asynciter === undefined) {
+    const ab = AbortSignal.abort();
+    globalThis.asynciter = gen(ab);
+    globalThis.asyncIter2 = gen(ab);
+    return new Response('ok');
+  }
+
+  // Advancing the iterator should throw an I/O error because the generator
+  // is bound to the wrong IoContext here. This test just confirms that our
+  // promise context patch does not change the expected behavior of the async
+  // generator and async iterators. Those should still throw I/O errors when
+  // the generator is bound to the wrong IoContext via something that it captures.
+  await rejects(globalThis.asynciter.next(), {
+    message: /Cannot perform I\/O/,
+  });
+
+  const foo = {
+    [Symbol.asyncIterator]() {
+      return globalThis.asyncIter2;
+    },
+  };
+
+  try {
+    for await (const _ of foo) {
+    }
+    throw new Error('should not get here');
+  } catch (err) {
+    match(err.message, /Cannot perform I\/O/);
+  }
+
+  return new Response('ok');
+}
+
+async function cyclicPromise(req, env, ctx) {
+  if (globalThis.cyclic === undefined) {
+    setupWaiter(ctx);
+    const { promise, resolve } = Promise.withResolvers();
+    globalThis.cyclic = { promise, resolve };
+    const ab = AbortSignal.abort();
+    strictEqual(ab.aborted, true);
+    await promise;
+    throw new Error('should never get here');
+  }
+
+  async function foo() {
+    await globalThis.cyclic.promise;
+    throw new Error('shnould never get here');
+  }
+
+  // The first request will hang because the promise is resolved
+  // with a promise that waits on the first, creating a hang
+  // condition that we can detect. The test log will contain
+  // a message about a hanging promise being canceled.
+  globalThis.cyclic.resolve(foo());
+  globalThis.cyclic = undefined;
+
+  return new Response('ok');
+}

--- a/src/workerd/api/tests/cross-context-promise-test.wd-test
+++ b/src/workerd/api/tests/cross-context-promise-test.wd-test
@@ -1,0 +1,21 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "cross-context-promise-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "cross-context-promise-test.js")
+        ],
+        compatibilityDate = "2024-07-01",
+        compatibilityFlags = [
+          "nodejs_compat_v2",
+          "handle_cross_request_promise_resolution",
+        ],
+        bindings = [
+          (name = "subrequest", service = "cross-context-promise-test")
+        ]
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -601,4 +601,15 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Enables the withSessions(commitTokenOrConstraint) method that allows users
   # to use read-replication for D1.
   # Experimental since this is not yet ready and is only meant for internal testing during development.
+
+  handleCrossRequestPromiseResolution @62 :Bool
+      $compatEnableFlag("handle_cross_request_promise_resolution")
+      $compatDisableFlag("no_handle_cross_request_promise_resolution")
+      $compatEnableDate("2024-10-14");
+  # Historically, it has been possible to resolve a promise from an incorrect request
+  # IoContext. This leads to issues with promise continuations being scheduled to run
+  # in the wrong IoContext leading to errors and difficult to diagnose bugs. With this
+  # compatibility flag we arrange to have such promise continuations scheduled to run
+  # in the correct IoContext if it is still alive, or dropped on the floor with a warning
+  # if the correct IoContext is not still alive.
 }

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -945,6 +945,9 @@ private:
       kj::Maybe<InputGate::Lock> inputLock,
       kj::Function<void(Worker::Lock&)> func);
 
+  kj::Promise<void> deleteQueueSignalTask;
+  static kj::Promise<void> startDeleteQueueSignalTask(IoContext* context);
+
   friend class Finalizeable;
   friend class DeleteQueue;
   template <typename T>

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2591,6 +2591,11 @@ public:
   JsDate date(kj::Date date) KJ_WARN_UNUSED_RESULT;
   JsDate date(kj::StringPtr date) KJ_WARN_UNUSED_RESULT;
 
+  // Returns a JsObject that is backed internally by a v8::External object that
+  // takes ownership over the inner.
+  template <typename T>
+  JsObject opaque(T&& inner) KJ_WARN_UNUSED_RESULT;
+
   // Returns a jsg::BufferSource whose underlying JavaScript handle is a Uint8Array.
   BufferSource bytes(kj::Array<kj::byte> data) KJ_WARN_UNUSED_RESULT;
 

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -453,6 +453,14 @@ inline JsSet Lock::set(const Args&... args) {
   return JsSet(set);
 }
 
+template <typename T>
+inline JsObject Lock::opaque(T&& inner) {
+  auto wrapped = wrapOpaque(v8Context(), kj::mv(inner));
+  KJ_ASSERT(!wrapped.IsEmpty());
+  KJ_ASSERT(wrapped->IsObject());
+  return JsObject(wrapped.template As<v8::Object>());
+}
+
 // A persistent handle for a Js* type suitable for storage and gc visitable.
 //
 // For example,


### PR DESCRIPTION
Draft for now until I add tests tests and more tests

```
export default {
  async fetch(req, env, ctx) {
    if (globalThis.resolve === undefined) {

      {
        const { promise, resolve } = Promise.withResolvers();
        setTimeout(resolve, 1000);
        ctx.waitUntil(promise);
      }

      // This is our first request. We will create a new promise and resolver
      // pair and store it in a global. This request will then wait for the
      // promise to be resolved before continuing.
      const { promise, resolve } = Promise.withResolvers();
      globalThis.resolve = resolve;
      globalThis.promise = promise;
      const ab = AbortSignal.abort();
      console.log(ab.aborted);
      promise.then(() => {
        // This will be run within the correct IoContext now...
        try {
          console.log('test1', ab.aborted);
        } catch (err) {
          // We would get here if the IoContext was incorrect because
          // of the call to ab.aborted
          console.log(err.message);
        }
      });
    } else {
      // This is our second request. We will resolve the promise created in the
      // first request.
      console.log('....');
      globalThis.resolve();
      globalThis.resolve = undefined;
      console.log('test2');
    }

    return new Response("Hello World\n");
  }
};

```

Some details on how this works:

* Per the original fixup, every IoContext has an associated opaque JS object called the "promise tag"
* Originally, this promise tag was just a simple, ordinary JS object. With this PR it becomes an opaque wrapper around an `kj::Own<IoContext::WeakRef>`
* When an `IoContext` becomes current/locked, that `IoContext`s promise tag is associated with the `v8::Isolate` as the "current promise tag"
* Per the original fixup, whenever a `Promise` is created, the Isolate's "current promise tag" is associated with the Promise in an internal field.
* In the original fixup, when a `Promise` is followed (.then(...), .catch(...), etc), we check to see if the current promise tag matches the promises context tag. If they are not the same, then the promise is a "cross-context promise" and we arrange for proper cross-context signaling.
* This PR *adds* that when the `resolve(...)` or `reject(...)` methods are called, and we determine that the promise is a cross-context promise, scheduling of the promise continuations will be deferred until after we re-enter the promise's original `IoContext`.
* If the promise's original `IoContext` has been destroyed, we drop the continuations on the floor and emit a warning.