### PR TITLE
Un-ship SQL prepared statements.

### DIFF
--- a/src/workerd/api/sql-test.wd-test
+++ b/src/workerd/api/sql-test.wd-test
@@ -12,7 +12,7 @@ const config :Workerd.Config = (
 const mainWorker :Workerd.Worker = (
   compatibilityDate = "2024-03-04",
 
-  # "experimental" flag is needed to test `sql.ingest()`
+  # "experimental" flag is needed to test `sql.ingest()` and `sql.prepare()`.
   compatibilityFlags = ["experimental", "nodejs_compat"],
 
   modules = [

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -32,7 +32,12 @@ public:
 
   JSG_RESOURCE_TYPE(SqlStorage, CompatibilityFlags::Reader flags) {
     JSG_METHOD(exec);
-    JSG_METHOD(prepare);
+
+    // Prepared statement API is experimental-only and deprecated. exec() will automatically
+    // handle caching prepared statements, so apps don't need to worry about it.
+    if (flags.getWorkerdExperimental()) {
+      JSG_METHOD(prepare);
+    }
 
     // Make sure that the 'ingest' function is still experimental-only if and when
     // the SQL API becomes publicly available.


### PR DESCRIPTION
We intend to make `exec()` automatically memoize prepared statements such that no application should ever be preparing statements manually. So, let's not even ship the API.

It's not yet possible to enable the SQL API in prod without the experimental flag so it's still safe to put `prepare()` back behind that flag.