### PR TITLE
enforce isolate lock and track allocations on v8

### DIFF
--- a/src/workerd/api/node/zlib-util.h
+++ b/src/workerd/api/node/zlib-util.h
@@ -293,7 +293,6 @@ public:
   class CompressionStream: public jsg::Object {
   public:
     explicit CompressionStream(ZlibMode _mode): context_(_mode) {}
-    CompressionStream() = default;
     // TODO(soon): Find a way to add noexcept(false) to this destructor.
     ~CompressionStream();
     KJ_DISALLOW_COPY_AND_MOVE(CompressionStream);

--- a/src/workerd/api/streams/compression.h
+++ b/src/workerd/api/streams/compression.h
@@ -18,7 +18,6 @@ namespace workerd::api {
 // isolate pointer and use that to get the external memory adjustment.
 class CompressionAllocator final {
 public:
-  CompressionAllocator() = default;
   void configure(z_stream* stream);
 
   static void* AllocForZlib(void* data, uInt items, uInt size);
@@ -26,20 +25,18 @@ public:
   static void FreeForZlib(void* data, void* pointer);
 
 private:
-  // TODO(soon): Use this instead of array<byte> after fixing edgeworker.
-  // struct Allocation {
-  //   kj::Array<kj::byte> data;
-  //   kj::Maybe<jsg::ExternalMemoryAdjustment> memoryAdjustment;
-  // };
-
-  kj::HashMap<void*, kj::Array<kj::byte>> allocations;
+  struct Allocation {
+    kj::Array<kj::byte> data;
+    jsg::ExternalMemoryAdjustment memoryAdjustment;
+  };
+  kj::HashMap<void*, Allocation> allocations;
 };
 
 class CompressionStream: public TransformStream {
 public:
   using TransformStream::TransformStream;
 
-  static jsg::Ref<CompressionStream> constructor(jsg::Lock& js, kj::String format);
+  static jsg::Ref<CompressionStream> constructor(kj::String format);
 
   JSG_RESOURCE_TYPE(CompressionStream) {
     JSG_INHERIT(TransformStream);

--- a/src/workerd/api/streams/compression.h
+++ b/src/workerd/api/streams/compression.h
@@ -27,7 +27,7 @@ public:
 private:
   struct Allocation {
     kj::Array<kj::byte> data;
-    jsg::ExternalMemoryAdjustment memoryAdjustment;
+    kj::Maybe<jsg::ExternalMemoryAdjustment> memoryAdjustment = kj::none;
   };
   kj::HashMap<void*, Allocation> allocations;
 };


### PR DESCRIPTION
Enforce lock exists on all compression operations.