### PR TITLE
Tweaked TS generation of DO SQlite types

### DIFF
--- a/types/test/types/do.ts
+++ b/types/test/types/do.ts
@@ -1,0 +1,37 @@
+import { DurableObject } from "cloudflare:workers";
+import { expectTypeOf } from "expect-type";
+
+// Aliased as SqlStorageValue, but let's assert it includes the raw types we expect
+type Value = ArrayBuffer | string | number | null;
+
+class TestDOSql extends DurableObject {
+  test() {
+    const db = this.ctx.storage.sql;
+
+    expectTypeOf<SqlStorage>(db);
+
+    expectTypeOf<number>(db.databaseSize);
+
+    // Verify default row type of exec
+    for (const row of db.exec("...")) {
+      expectTypeOf<Record<string, Value>>(row);
+    }
+
+    // Verify scoped row type of exec
+    for (const row of db.exec<{ name: string; phone: number }>("...")) {
+      expectTypeOf<{ name: string; phone: number }>(row);
+
+      // @ts-expect-error double-checking our assertions are strict
+      expectTypeOf<{ name: string; phone: string }>(row);
+      // @ts-expect-error double-checking our assertions are strict
+      expectTypeOf<Record<string, number>>(row);
+    }
+
+    const cursor = db.exec("...", 1, "two")
+    expectTypeOf<SqlStorageCursor<Record<string, Value>>>(cursor);
+
+    expectTypeOf<number>(cursor.rowsRead);
+    expectTypeOf<number>(cursor.rowsWritten);
+    expectTypeOf<string[]>(cursor.columnNames);
+  }
+}


### PR DESCRIPTION
After #2722, we now have a final, very minimal SQLite API for durable objects. So I've just tweaked the TS generation to give a few generics to make things easier to work with. These are the changes:

```diff
diff --git a/.local/types-main/2023-07-01/index.ts b/bazel-bin/types/definitions/2023-07-01/index.ts
index 45460a4d..556a55d3 100755
--- a/.local/types-main/2023-07-01/index.ts
+++ b/bazel-bin/types/definitions/2023-07-01/index.ts
@@ -2778,20 +2778,24 @@ export declare const WebSocketPair: {
   };
 };
 export interface SqlStorage {
-  exec(query: string, ...bindings: any[]): SqlStorageCursor;
+  exec<T extends Record<string, SqlStorageValue>>(
+    query: string,
+    ...bindings: any[]
+  ): SqlStorageCursor<T>;
   get databaseSize(): number;
   Cursor: typeof SqlStorageCursor;
   Statement: typeof SqlStorageStatement;
 }
 export declare abstract class SqlStorageStatement {}
-export declare abstract class SqlStorageCursor {
-  raw(): IterableIterator<((ArrayBuffer | string | number) | null)[]>;
+export type SqlStorageValue = ArrayBuffer | string | number | null;
+export declare abstract class SqlStorageCursor<
+  T extends Record<string, SqlStorageValue>,
+> {
+  raw<U extends SqlStorageValue[]>(): IterableIterator<U>;
   get columnNames(): string[];
   get rowsRead(): number;
   get rowsWritten(): number;
-  [Symbol.iterator](): IterableIterator<
-    Record<string, (ArrayBuffer | string | number) | null>
-  >;
+  [Symbol.iterator](): IterableIterator<T>;
 }
 export interface Socket {
   get readable(): ReadableStream;
```

And the relevant diff between `2023-07-01` and `experimental`:

```diff
 export declare abstract class ScheduledEvent extends ExtendableEvent {
   readonly scheduledTime: number;
   readonly cron: string;
@@ -2782,6 +2836,8 @@ export interface SqlStorage {
     query: string,
     ...bindings: any[]
   ): SqlStorageCursor<T>;
+  prepare(query: string): SqlStorageStatement;
+  ingest(query: string): SqlStorageIngestResult;
   get databaseSize(): number;
   Cursor: typeof SqlStorageCursor;
   Statement: typeof SqlStorageStatement;
@@ -2797,6 +2853,12 @@ export declare abstract class SqlStorageCursor<
   get rowsWritten(): number;
   [Symbol.iterator](): IterableIterator<T>;
 }
+export interface SqlStorageIngestResult {
+  remainder: string;
+  rowsRead: number;
+  rowsWritten: number;
+  statementCount: number;
+}
 export interface Socket {
   get readable(): ReadableStream;
   get writable(): WritableStream;
```