### PR TITLE
ensure clang-format is v18.1.8

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -29,3 +29,19 @@ or use the appropriate IDE extension.
 While workerd generally requires llvm 15, formatting requires clang-format-18.
 
 Code formatting is checked before check-in and during `Linting` CI build.
+
+## Clang-format
+
+Workerd depends on clang-format v18.1.8. In order to install it on Linux, please run the following code:
+
+```bash
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh 18 clang-format
+```
+
+If you didn't do so, please symlink clang-format-18 to clang.
+
+```bash
+sudo ln -s /usr/bin/clang-format-18 /usr/bin/clang-format
+```

--- a/tools/cross/format.py
+++ b/tools/cross/format.py
@@ -76,9 +76,9 @@ def check_clang_format() -> None:
             logging.error("unable to read clang version")
             exit(1)
 
-        major, _, _ = match.groups()
-        if int(major) != 18:
-            logging.error("clang-format version must be 18")
+        major, minor, patch = match.groups()
+        if int(major) != 18 or int(minor) != 1 or int(patch) != 8:
+            logging.error("clang-format version must be 18.1.8")
             exit(1)
     except FileNotFoundError:
         # Clang-format is not in the PATH


### PR DESCRIPTION
Make sure that we are using the same clang-format version. If v18 has a new version, CI will break and we'll have to manually change the validation on `format.py` which will make sure that all the breaking changes will be fixed.