### PR TITLE
Enable clang-format AllowShortBlocksOnASingleLine

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,6 +32,7 @@ IncludeCategories:
 
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Empty
 
 IndentWidth: 2
 IndentCaseBlocks: false

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -16,3 +16,6 @@ f457f19039b82536b35659c1f9cb898a198e6cd1
 # Use clang-format to sort includes.
 faabf00af72bbce956221b40624f8a3d57f82b7c
 b9e9fb144f44494017e77fbe959355e92f10ae69
+
+# Add `AllowShortBlocksOnASingleLine: Empty` to clang-format
+fa2c488219a5e96792e61f3d51838595e2907c8d

--- a/src/workerd/api/blob.h
+++ b/src/workerd/api/blob.h
@@ -104,8 +104,7 @@ private:
       KJ_CASE_ONEOF(b, jsg::Ref<Blob>) {
         visitor.visit(b);
       }
-      KJ_CASE_ONEOF(b, kj::Array<kj::byte>) {
-      }
+      KJ_CASE_ONEOF(b, kj::Array<kj::byte>) {}
     }
   }
 

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -2483,8 +2483,7 @@ size_t WritableStreamInternalController::jsgGetMemorySelfSize() const {
 }
 void WritableStreamInternalController::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-    }
+    KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
     KJ_CASE_ONEOF(errored, StreamStates::Errored) {
       tracker.trackField("error", errored);
     }
@@ -2528,8 +2527,7 @@ size_t ReadableStreamInternalController::jsgGetMemorySelfSize() const {
 
 void ReadableStreamInternalController::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-    }
+    KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
     KJ_CASE_ONEOF(error, StreamStates::Errored) {
       tracker.trackField("error", error);
     }
@@ -2542,10 +2540,8 @@ void ReadableStreamInternalController::jsgGetMemoryInfo(jsg::MemoryTracker& trac
     }
   }
   KJ_SWITCH_ONEOF(readState) {
-    KJ_CASE_ONEOF(unlocked, Unlocked) {
-    }
-    KJ_CASE_ONEOF(locked, Locked) {
-    }
+    KJ_CASE_ONEOF(unlocked, Unlocked) {}
+    KJ_CASE_ONEOF(locked, Locked) {}
     KJ_CASE_ONEOF(pipeLocked, PipeLocked) {
       tracker.trackField("pipeLocked", pipeLocked);
     }

--- a/src/workerd/api/streams/queue.h
+++ b/src/workerd/api/streams/queue.h
@@ -352,10 +352,8 @@ public:
 
   void cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
     KJ_SWITCH_ONEOF(state) {
-      KJ_CASE_ONEOF(closed, Closed) {
-      }
-      KJ_CASE_ONEOF(errored, Errored) {
-      }
+      KJ_CASE_ONEOF(closed, Closed) {}
+      KJ_CASE_ONEOF(errored, Errored) {}
       KJ_CASE_ONEOF(ready, Ready) {
         for (auto& request: ready.readRequests) {
           request.resolveAsDone(js);
@@ -505,10 +503,8 @@ public:
 
   void cancelPendingReads(jsg::Lock& js, jsg::JsValue reason) {
     KJ_SWITCH_ONEOF(state) {
-      KJ_CASE_ONEOF(closed, Closed) {
-      }
-      KJ_CASE_ONEOF(errored, Errored) {
-      }
+      KJ_CASE_ONEOF(closed, Closed) {}
+      KJ_CASE_ONEOF(errored, Errored) {}
       KJ_CASE_ONEOF(ready, Ready) {
         for (auto& request: ready.readRequests) {
           request.resolver.reject(js, reason);
@@ -520,8 +516,7 @@ public:
 
   void visitForGc(jsg::GcVisitor& visitor) {
     KJ_SWITCH_ONEOF(state) {
-      KJ_CASE_ONEOF(closed, Closed) {
-      }
+      KJ_CASE_ONEOF(closed, Closed) {}
       KJ_CASE_ONEOF(errored, Errored) {
         // Technically we shouldn't really have to gc visit the stored error here but there
         // should not be any harm in doing so.
@@ -1016,10 +1011,8 @@ size_t QueueImpl<Self>::jsgGetMemorySelfSize() const {
 template <typename Self>
 void QueueImpl<Self>::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(ready, Ready) {
-    }
-    KJ_CASE_ONEOF(closed, Closed) {
-    }
+    KJ_CASE_ONEOF(ready, Ready) {}
+    KJ_CASE_ONEOF(closed, Closed) {}
     KJ_CASE_ONEOF(errored, Errored) {
       tracker.trackField("error", errored);
     }
@@ -1039,8 +1032,7 @@ size_t ConsumerImpl<Self>::jsgGetMemorySelfSize() const {
 template <typename Self>
 void ConsumerImpl<Self>::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(close, Closed) {
-    }
+    KJ_CASE_ONEOF(close, Closed) {}
     KJ_CASE_ONEOF(error, Errored) {
       tracker.trackField("error", error);
     }

--- a/src/workerd/api/streams/standard-test.c++
+++ b/src/workerd/api/streams/standard-test.c++
@@ -62,8 +62,7 @@ KJ_TEST("ReadableStream read all text (value readable)") {
           c->close(js);
           return js.resolvedPromise();
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
-        }
+        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
       }
       KJ_UNREACHABLE;
     }
@@ -120,8 +119,7 @@ KJ_TEST("ReadableStream read all text, rs ref held (value readable)") {
           c->close(js);
           return js.resolvedPromise();
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
-        }
+        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
       }
       KJ_UNREACHABLE;
     }
@@ -175,8 +173,7 @@ KJ_TEST("ReadableStream read all text (byte readable)") {
           c->close(js);
           return js.resolvedPromise();
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
-        }
+        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
       }
       KJ_UNREACHABLE;
     }
@@ -233,8 +230,7 @@ KJ_TEST("ReadableStream read all bytes (value readable)") {
           c->close(js);
           return js.resolvedPromise();
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
-        }
+        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
       }
       KJ_UNREACHABLE;
     }
@@ -292,8 +288,7 @@ KJ_TEST("ReadableStream read all bytes (byte readable)") {
           c->close(js);
           return js.resolvedPromise();
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
-        }
+        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
       }
       KJ_UNREACHABLE;
     }
@@ -356,8 +351,7 @@ KJ_TEST("ReadableStream read all bytes (value readable, more reads)") {
 
           return js.resolvedPromise();
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
-        }
+        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
       }
       KJ_UNREACHABLE;
     }
@@ -421,8 +415,7 @@ KJ_TEST("ReadableStream read all bytes (byte readable, more reads)") {
 
           return js.resolvedPromise();
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
-        }
+        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
       }
       KJ_UNREACHABLE;
     }
@@ -489,8 +482,7 @@ KJ_TEST("ReadableStream read all bytes (byte readable, large data)") {
 
           return js.resolvedPromise();
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
-        }
+        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
       }
       KJ_UNREACHABLE;
     }
@@ -554,8 +546,7 @@ KJ_TEST("ReadableStream read all bytes (value readable, wrong type)") {
           checked++;
           return js.resolvedPromise();
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
-        }
+        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
       }
       KJ_UNREACHABLE;
     },
@@ -616,8 +607,7 @@ KJ_TEST("ReadableStream read all bytes (value readable, to many bytes)") {
           checked++;
           return js.resolvedPromise();
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
-        }
+        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
       }
       KJ_UNREACHABLE;
     }
@@ -673,8 +663,7 @@ KJ_TEST("ReadableStream read all bytes (byte readable, to many bytes)") {
           checked++;
           return js.resolvedPromise();
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
-        }
+        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
       }
       KJ_UNREACHABLE;
     }

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -73,10 +73,8 @@ public:
   }
   void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
     KJ_SWITCH_ONEOF(state) {
-      KJ_CASE_ONEOF(locked, Locked) {
-      }
-      KJ_CASE_ONEOF(unlocked, Unlocked) {
-      }
+      KJ_CASE_ONEOF(locked, Locked) {}
+      KJ_CASE_ONEOF(unlocked, Unlocked) {}
       KJ_CASE_ONEOF(pipeLocked, PipeLocked) {
         tracker.trackField("pipeLocked", pipeLocked);
       }
@@ -168,10 +166,8 @@ public:
 
   JSG_MEMORY_INFO(WritableLockImpl) {
     KJ_SWITCH_ONEOF(state) {
-      KJ_CASE_ONEOF(unlocked, Unlocked) {
-      }
-      KJ_CASE_ONEOF(locked, Locked) {
-      }
+      KJ_CASE_ONEOF(unlocked, Unlocked) {}
+      KJ_CASE_ONEOF(locked, Locked) {}
       KJ_CASE_ONEOF(writerLocked, WriterLocked) {
         tracker.trackField("writerLocked", writerLocked);
       }
@@ -253,10 +249,8 @@ void ReadableLockImpl<Controller>::releaseReader(
     KJ_IF_SOME(js, maybeJs) {
       auto reason = js.typeError("This ReadableStream reader has been released."_kj);
       KJ_SWITCH_ONEOF(self.state) {
-        KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-        }
-        KJ_CASE_ONEOF(errored, StreamStates::Errored) {
-        }
+        KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
+        KJ_CASE_ONEOF(errored, StreamStates::Errored) {}
         KJ_CASE_ONEOF(consumer, kj::Own<ValueReadable>) {
           consumer->cancelPendingReads(js, reason);
         }
@@ -296,10 +290,8 @@ kj::Maybe<ReadableStreamController::PipeController&> ReadableLockImpl<Controller
 template <typename Controller>
 void ReadableLockImpl<Controller>::visitForGc(jsg::GcVisitor& visitor) {
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(locked, Locked) {
-    }
-    KJ_CASE_ONEOF(locked, Unlocked) {
-    }
+    KJ_CASE_ONEOF(locked, Locked) {}
+    KJ_CASE_ONEOF(locked, Unlocked) {}
     KJ_CASE_ONEOF(locked, PipeLocked) {
       visitor.visit(locked);
     }
@@ -326,10 +318,8 @@ void ReadableLockImpl<Controller>::onClose(jsg::Lock& js) {
     KJ_CASE_ONEOF(locked, ReadableLockImpl::PipeLocked) {
       state.template init<Unlocked>();
     }
-    KJ_CASE_ONEOF(locked, Locked) {
-    }
-    KJ_CASE_ONEOF(locked, Unlocked) {
-    }
+    KJ_CASE_ONEOF(locked, Locked) {}
+    KJ_CASE_ONEOF(locked, Unlocked) {}
   }
 }
 
@@ -350,10 +340,8 @@ void ReadableLockImpl<Controller>::onError(jsg::Lock& js, v8::Local<v8::Value> r
     KJ_CASE_ONEOF(locked, ReadableLockImpl::PipeLocked) {
       state.template init<Unlocked>();
     }
-    KJ_CASE_ONEOF(locked, Locked) {
-    }
-    KJ_CASE_ONEOF(locked, Unlocked) {
-    }
+    KJ_CASE_ONEOF(locked, Locked) {}
+    KJ_CASE_ONEOF(locked, Unlocked) {}
   }
 }
 
@@ -418,10 +406,8 @@ void WritableLockImpl<Controller>::releaseWriter(
   KJ_ASSERT(&locked.getWriter() == &writer);
   KJ_IF_SOME(js, maybeJs) {
     KJ_SWITCH_ONEOF(self.state) {
-      KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-      }
-      KJ_CASE_ONEOF(errored, StreamStates::Errored) {
-      }
+      KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
+      KJ_CASE_ONEOF(errored, StreamStates::Errored) {}
       KJ_CASE_ONEOF(controller, jsg::Ref<WritableStreamDefaultController>) {
         controller->cancelPendingWrites(
             js, js.typeError("This WritableStream writer has been released."_kjc));
@@ -474,10 +460,8 @@ void WritableLockImpl<Controller>::releasePipeLock() {
 template <typename Controller>
 void WritableLockImpl<Controller>::visitForGc(jsg::GcVisitor& visitor) {
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(locked, Unlocked) {
-    }
-    KJ_CASE_ONEOF(locked, Locked) {
-    }
+    KJ_CASE_ONEOF(locked, Unlocked) {}
+    KJ_CASE_ONEOF(locked, Locked) {}
     KJ_CASE_ONEOF(locked, WriterLocked) {
       visitor.visit(locked);
     }
@@ -1127,8 +1111,7 @@ void ReadableImpl<Self>::pullIfNeeded(jsg::Lock& js, jsg::Ref<Self> self) {
 template <typename Self>
 void ReadableImpl<Self>::visitForGc(jsg::GcVisitor& visitor) {
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-    }
+    KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
     KJ_CASE_ONEOF(errored, StreamStates::Errored) {
       visitor.visit(errored);
     }
@@ -1578,10 +1561,8 @@ jsg::Promise<void> WritableImpl<Self>::write(
 template <typename Self>
 void WritableImpl<Self>::visitForGc(jsg::GcVisitor& visitor) {
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-    }
-    KJ_CASE_ONEOF(writable, Writable) {
-    }
+    KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
+    KJ_CASE_ONEOF(writable, Writable) {}
     KJ_CASE_ONEOF(error, StreamStates::Errored) {
       visitor.visit(error);
     }
@@ -2542,8 +2523,7 @@ kj::Maybe<ReadableStreamController::PipeController&> ReadableStreamJsController:
 void ReadableStreamJsController::visitForGc(jsg::GcVisitor& visitor) {
   KJ_IF_SOME(pendingState, maybePendingState) {
     KJ_SWITCH_ONEOF(pendingState) {
-      KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-      }
+      KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
       KJ_CASE_ONEOF(error, StreamStates::Errored) {
         visitor.visit(error);
       }
@@ -2551,8 +2531,7 @@ void ReadableStreamJsController::visitForGc(jsg::GcVisitor& visitor) {
   }
 
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-    }
+    KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
     KJ_CASE_ONEOF(error, StreamStates::Errored) {
       visitor.visit(error);
     }
@@ -2683,8 +2662,7 @@ public:
 
   void visitForGc(jsg::GcVisitor& visitor) {
     KJ_SWITCH_ONEOF(state) {
-      KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-      }
+      KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
       KJ_CASE_ONEOF(errored, StreamStates::Errored) {
         visitor.visit(errored);
       }
@@ -3614,8 +3592,7 @@ jsg::Promise<void> WritableStreamJsController::write(
 
 void WritableStreamJsController::visitForGc(jsg::GcVisitor& visitor) {
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-    }
+    KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
     KJ_CASE_ONEOF(error, StreamStates::Errored) {
       visitor.visit(error);
     }
@@ -3922,16 +3899,14 @@ void WritableImpl<Self>::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
   tracker.trackField("signal", signal);
 
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-    }
+    KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
     KJ_CASE_ONEOF(error, StreamStates::Errored) {
       tracker.trackField("error", error);
     }
     KJ_CASE_ONEOF(erroring, StreamStates::Erroring) {
       tracker.trackField("erroring", erroring.reason);
     }
-    KJ_CASE_ONEOF(writable, Writable) {
-    }
+    KJ_CASE_ONEOF(writable, Writable) {}
   }
 
   tracker.trackField("abortAlgorithm", algorithms.abort);
@@ -3959,8 +3934,7 @@ size_t WritableStreamJsController::jsgGetMemorySelfSize() const {
 
 void WritableStreamJsController::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-    }
+    KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
     KJ_CASE_ONEOF(error, StreamStates::Errored) {
       tracker.trackField("error", error);
     }
@@ -3986,8 +3960,7 @@ size_t ReadableStreamJsController::jsgGetMemorySelfSize() const {
 
 void ReadableStreamJsController::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-    }
+    KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
     KJ_CASE_ONEOF(error, StreamStates::Errored) {
       tracker.trackField("error", error);
     }
@@ -4003,8 +3976,7 @@ void ReadableStreamJsController::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) c
 
   KJ_IF_SOME(pendingState, maybePendingState) {
     KJ_SWITCH_ONEOF(pendingState) {
-      KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-      }
+      KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
       KJ_CASE_ONEOF(error, StreamStates::Errored) {
         tracker.trackField("pendingError", error);
       }
@@ -4025,8 +3997,7 @@ size_t ReadableImpl<Self>::jsgGetMemorySelfSize() const {
 template <class Self>
 void ReadableImpl<Self>::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
   KJ_SWITCH_ONEOF(state) {
-    KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-    }
+    KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
     KJ_CASE_ONEOF(error, StreamStates::Errored) {
       tracker.trackField("error", error);
     }

--- a/src/workerd/api/system-streams.c++
+++ b/src/workerd/api/system-streams.c++
@@ -255,8 +255,7 @@ kj::Maybe<kj::Promise<DeferredProxy<void>>> EncodedAsyncOutputStream::tryPumpFro
         KJ_CASE_ONEOF(br, kj::Own<kj::BrotliAsyncOutputStream>) {
           promise = promise.then([&br = br]() { return br->end(); });
         }
-        KJ_CASE_ONEOF(e, Ended) {
-        }
+        KJ_CASE_ONEOF(e, Ended) {}
       }
     }
 
@@ -296,8 +295,7 @@ kj::Promise<void> EncodedAsyncOutputStream::end() {
     KJ_CASE_ONEOF(br, kj::Own<kj::BrotliAsyncOutputStream>) {
       promise = br->end().attach(kj::mv(br));
     }
-    KJ_CASE_ONEOF(e, Ended) {
-    }
+    KJ_CASE_ONEOF(e, Ended) {}
   }
 
   inner.init<Ended>();

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -244,13 +244,11 @@ private:
   void visitForGc(jsg::GcVisitor& visitor) {
     visitor.visit(inner);
     KJ_SWITCH_ONEOF(state) {
-      KJ_CASE_ONEOF(pending, Pending) {
-      }
+      KJ_CASE_ONEOF(pending, Pending) {}
       KJ_CASE_ONEOF(resolved, Resolved) {
         visitor.visit(resolved.result);
       }
-      KJ_CASE_ONEOF(disposed, Disposed) {
-      }
+      KJ_CASE_ONEOF(disposed, Disposed) {}
     }
   }
 };

--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -2179,8 +2179,7 @@ void ActorCache::ensureFlushScheduled(const WriteOptions& options) {
           hooks.updateAlarmInMemory(kj::none);
         }
       }
-      KJ_CASE_ONEOF(_, UnknownAlarmTime) {
-      }
+      KJ_CASE_ONEOF(_, UnknownAlarmTime) {}
     }
 
     return;
@@ -2450,8 +2449,7 @@ kj::Promise<void> ActorCache::startFlushTransaction() {
         maybeAlarmChange = DirtyAlarm{kj::none};
       }
     }
-    KJ_CASE_ONEOF(_, UnknownAlarmTime) {
-    }
+    KJ_CASE_ONEOF(_, UnknownAlarmTime) {}
   }
 
   // We have to remember _before_ waiting for the flush whether or not it was a pre-deleteAll()
@@ -2568,8 +2566,7 @@ kj::Promise<void> ActorCache::flushImpl(uint retryCount) {
           }
         }
       }
-      KJ_CASE_ONEOF(_, ActorCache::UnknownAlarmTime) {
-      }
+      KJ_CASE_ONEOF(_, ActorCache::UnknownAlarmTime) {}
     }
     if (flushingBeforeDeleteAll) {
       // The writes we flushed were writes that had occurred before a deleteAll. Now that they are
@@ -2960,8 +2957,7 @@ kj::Promise<void> ActorCache::flushImplUsingTxn(PutFlush putFlush,
         }
       }
     }
-    KJ_CASE_ONEOF(_, CleanAlarm) {
-    }
+    KJ_CASE_ONEOF(_, CleanAlarm) {}
   }
 
   // We have to wait on the transaction promise so we don't cancel the catch_ branch that triggers

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -67,8 +67,7 @@ void ActorSqlite::ImplicitTxn::rollback() {
 
 ActorSqlite::ExplicitTxn::ExplicitTxn(ActorSqlite& actorSqlite): actorSqlite(actorSqlite) {
   KJ_SWITCH_ONEOF(actorSqlite.currentTxn) {
-    KJ_CASE_ONEOF(_, NoTxn) {
-    }
+    KJ_CASE_ONEOF(_, NoTxn) {}
     KJ_CASE_ONEOF(implicit, ImplicitTxn*) {
       // An implicit transaction is open, commit it now because it would be weird if writes
       // performed before the explicit transaction started were postponed until the transaction

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -749,22 +749,14 @@ void WorkerTracer::setEventInfo(kj::Date timestamp, Trace::EventInfo&& info) {
         return;
       }
     }
-    KJ_CASE_ONEOF(_, Trace::JsRpcEventInfo) {
-    }
-    KJ_CASE_ONEOF(_, Trace::ScheduledEventInfo) {
-    }
-    KJ_CASE_ONEOF(_, Trace::AlarmEventInfo) {
-    }
-    KJ_CASE_ONEOF(_, Trace::QueueEventInfo) {
-    }
-    KJ_CASE_ONEOF(_, Trace::EmailEventInfo) {
-    }
-    KJ_CASE_ONEOF(_, Trace::TraceEventInfo) {
-    }
-    KJ_CASE_ONEOF(_, Trace::HibernatableWebSocketEventInfo) {
-    }
-    KJ_CASE_ONEOF(_, Trace::CustomEventInfo) {
-    }
+    KJ_CASE_ONEOF(_, Trace::JsRpcEventInfo) {}
+    KJ_CASE_ONEOF(_, Trace::ScheduledEventInfo) {}
+    KJ_CASE_ONEOF(_, Trace::AlarmEventInfo) {}
+    KJ_CASE_ONEOF(_, Trace::QueueEventInfo) {}
+    KJ_CASE_ONEOF(_, Trace::EmailEventInfo) {}
+    KJ_CASE_ONEOF(_, Trace::TraceEventInfo) {}
+    KJ_CASE_ONEOF(_, Trace::HibernatableWebSocketEventInfo) {}
+    KJ_CASE_ONEOF(_, Trace::CustomEventInfo) {}
   }
   trace->bytesUsed = newSize;
   trace->eventInfo = kj::mv(info);

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1691,8 +1691,7 @@ Worker::Worker(kj::Own<const Script> scriptParam,
                 KJ_CASE_ONEOF(startupTimeElapsed, kj::Duration) {
                   s = startupTimeElapsed;
                 }
-                KJ_CASE_ONEOF(limitError, kj::Exception) {
-                }
+                KJ_CASE_ONEOF(limitError, kj::Exception) {}
               }
             } else {
             }
@@ -2574,8 +2573,7 @@ public:
           inspector.contextDestroyed(dummyContext);
         });
       }
-      KJ_CASE_ONEOF(startupTimeElapsed, kj::Duration) {
-      }
+      KJ_CASE_ONEOF(startupTimeElapsed, kj::Duration) {}
     }
 
     if (recordedLock.checkInWithLimitEnforcer(isolate)) {

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -355,8 +355,7 @@ kj::OneOf<kj::StringPtr, v8::Local<v8::Symbol>> Name::getUnwrapped(v8::Isolate* 
 
 void Name::visitForGc(GcVisitor& visitor) {
   KJ_SWITCH_ONEOF(inner) {
-    KJ_CASE_ONEOF(string, kj::String) {
-    }
+    KJ_CASE_ONEOF(string, kj::String) {}
     KJ_CASE_ONEOF(symbol, V8Ref<v8::Symbol>) {
       visitor.visit(symbol);
     }

--- a/src/workerd/jsg/url-test.c++
+++ b/src/workerd/jsg/url-test.c++
@@ -1929,26 +1929,20 @@ KJ_TEST("URLPattern - simple fuzzing") {
                       .search = kj::str(bufs.slice(n * 6, n * 7)),
                       .hash = kj::str(bufs.slice(n * 7, n * 8)),
                       .baseUrl = kj::str(bufs.slice(n * 8, n * 9))})) {
-      KJ_CASE_ONEOF(str, kj::String) {
-      }
-      KJ_CASE_ONEOF(pattern, UrlPattern) {
-      }
+      KJ_CASE_ONEOF(str, kj::String) {}
+      KJ_CASE_ONEOF(pattern, UrlPattern) {}
     }
 
     auto input = kj::str(bufs);
     KJ_SWITCH_ONEOF(UrlPattern::tryCompile(input.asPtr())) {
-      KJ_CASE_ONEOF(str, kj::String) {
-      }
-      KJ_CASE_ONEOF(pattern, UrlPattern) {
-      }
+      KJ_CASE_ONEOF(str, kj::String) {}
+      KJ_CASE_ONEOF(pattern, UrlPattern) {}
     }
 
     KJ_SWITCH_ONEOF(UrlPattern::tryCompile(
                         input.asPtr(), UrlPattern::CompileOptions{.baseUrl = input.asPtr()})) {
-      KJ_CASE_ONEOF(str, kj::String) {
-      }
-      KJ_CASE_ONEOF(pattern, UrlPattern) {
-      }
+      KJ_CASE_ONEOF(str, kj::String) {}
+      KJ_CASE_ONEOF(pattern, UrlPattern) {}
     }
   }
 }
@@ -2353,8 +2347,7 @@ KJ_TEST("URLPattern - WPT compile success") {
 
   for (auto& testCase: TESTS) {
     KJ_SWITCH_ONEOF(UrlPattern::tryCompile(kj::mv(testCase))) {
-      KJ_CASE_ONEOF(pattern, UrlPattern) {
-      }
+      KJ_CASE_ONEOF(pattern, UrlPattern) {}
       KJ_CASE_ONEOF(err, kj::String) {
         KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
       }
@@ -2365,16 +2358,14 @@ KJ_TEST("URLPattern - WPT compile success") {
     KJ_IF_SOME(base, testCase.base) {
       KJ_SWITCH_ONEOF(UrlPattern::tryCompile(
                           testCase.input, UrlPattern::CompileOptions{.baseUrl = base})) {
-        KJ_CASE_ONEOF(pattern, UrlPattern) {
-        }
+        KJ_CASE_ONEOF(pattern, UrlPattern) {}
         KJ_CASE_ONEOF(err, kj::String) {
           KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
         }
       }
     } else {
       KJ_SWITCH_ONEOF(UrlPattern::tryCompile(testCase.input)) {
-        KJ_CASE_ONEOF(pattern, UrlPattern) {
-        }
+        KJ_CASE_ONEOF(pattern, UrlPattern) {}
         KJ_CASE_ONEOF(err, kj::String) {
           KJ_FAIL_ASSERT("Failed to compile URLPattern", err);
         }

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -101,8 +101,7 @@ public:
           next.state.get<Freelisted>().prev = freelisted.prev;
         }
       }
-      KJ_CASE_ONEOF(d, Dead) {
-      }
+      KJ_CASE_ONEOF(d, Dead) {}
     }
   }
 
@@ -116,8 +115,7 @@ public:
         // due to conservative GC or due to incremental marking. Unfortunately the shim won't be
         // collected on this pass but hopefully it can be on the next pass.
       }
-      KJ_CASE_ONEOF(d, Dead) {
-      }
+      KJ_CASE_ONEOF(d, Dead) {}
     }
   }
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -983,8 +983,7 @@ private:
                   KJ_ASSERT(ranges.size() > 0);
                   if (ranges.size() == 1) range = ranges[0];
                 }
-                KJ_CASE_ONEOF(_, kj::HttpEverythingRange) {
-                }
+                KJ_CASE_ONEOF(_, kj::HttpEverythingRange) {}
                 KJ_CASE_ONEOF(_, kj::HttpUnsatisfiableRange) {
                   kj::HttpHeaders headers(headerTable);
                   headers.set(kj::HttpHeaderId::CONTENT_RANGE, kj::str("bytes */", meta.size));

--- a/src/workerd/util/mimetype.c++
+++ b/src/workerd/util/mimetype.c++
@@ -430,8 +430,7 @@ kj::Maybe<MimeType> MimeType::extract(kj::StringPtr input) {
     for (size_t i = 0; i < input.size(); ++i) {
       if (input[i] == '"' && (i == 0 || input[i - 1] != '\\')) {
         // Skip to the end of the quoted section
-        while (++i < input.size() && (input[i] != '"' || input[i - 1] == '\\')) {
-        }
+        while (++i < input.size() && (input[i] != '"' || input[i - 1] == '\\')) {}
       } else if (input[i] == ',' && (i == 0 || input[i - 1] != '\\')) {
         return i;
       }


### PR DESCRIPTION
This looks much cleaner and readable IMHO. There is also an "Always" option for this, but its output feels less readable to me.

=============

See https://clang.llvm.org/docs/ClangFormatStyleOptions.html#allowshortblocksonasingleline. I don't remember how I found this but it might have been improved/fixed in LLVM 18/19.