### PR TITLE
Fix type params

### DIFF
--- a/src/workerd/tools/param-names-ast.c++
+++ b/src/workerd/tools/param-names-ast.c++
@@ -4,6 +4,7 @@
 
 // This file includes all Worker APIs, and is used to generate a Clang AST dump for later
 // lookup of parameter names for inclusion in the TS types (since RTTI doesn't include this information)
+// It must be kept up to date with the APIs exposed in src/workerd/api/rtti.c++
 #include <workerd/api/actor-state.h>
 #include <workerd/api/actor.h>
 #include <workerd/api/analytics-engine.h>
@@ -16,6 +17,7 @@
 #include <workerd/api/html-rewriter.h>
 #include <workerd/api/hyperdrive.h>
 #include <workerd/api/kv.h>
+#include <workerd/api/memory-cache.h>
 #include <workerd/api/node/node.h>
 #include <workerd/api/queue.h>
 #include <workerd/api/r2-admin.h>
@@ -23,6 +25,12 @@
 #include <workerd/api/scheduled.h>
 #include <workerd/api/sockets.h>
 #include <workerd/api/sql.h>
+#include <workerd/api/streams.h>
 #include <workerd/api/streams/standard.h>
 #include <workerd/api/trace.h>
+#include <workerd/api/unsafe.h>
+#include <workerd/api/url-standard.h>
 #include <workerd/api/urlpattern.h>
+#include <workerd/api/worker-rpc.h>
+#include <workerd/io/compatibility-date.h>
+#include <workerd/jsg/modules.capnp.h>


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workerd/issues/2652

A regression introduced in https://github.com/cloudflare/workerd/commit/fc7f91d59e114f697784e9a2caf9b0e3e93f46c2 meant that parameter names for some APIs were no longer being included in the generated types, since `param-names-ast.c++` didn't import them. This PR updates the includes within `param-names-ast.c++` to match `rtti.c++`.