### PR TITLE
Fix AiTextToImageOutput type from UInt8Array -> ReadableStream

### DIFF
--- a/types/defines/ai.d.ts
+++ b/types/defines/ai.d.ts
@@ -156,7 +156,7 @@ export type AiTextToImageInput = {
   strength?: number;
   guidance?: number;
 };
-export type AiTextToImageOutput = Uint8Array;
+export type AiTextToImageOutput = ReadableStream<Uint8Array>;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;


### PR DESCRIPTION
As noted in https://github.com/cloudflare/workerd/issues/2470 - the response type from `env.AI.run` with (in my case) `@cf/bytedance/stable-diffusion-xl-lightning`  claims it should return a UInt8Array, but actually returns a ReadableStream.

This is fine when feeding it into a `new Response()` and returning, but is problematic when trying to use the data in other ways.

You can replicate this with the example model usage [here](https://developers.cloudflare.com/workers-ai/models/stable-diffusion-xl-lightning/)

```
[ai]
binding = "AI"
```

```ts
export interface Env {
  AI: Ai;
}

export default {
  async fetch(request, env, ctx): Promise<Response> {
  const inputs = {prompt: "cyberpunk cat"};

  const response = await env.AI.run(
    "@cf/bytedance/stable-diffusion-xl-lightning",
    inputs
  );

  // Expected: Uint8Array. Actual: ReadableStream
  console.log(response);
  return new Response("Don't error");
}
```

