### PR TITLE
Always use LLD on Linux

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -249,6 +249,9 @@ build:linux --linkopt="-Wl,--gc-sections"
 build:linux --copt="-ffunction-sections" --host_copt="-ffunction-sections"
 build:linux --copt="-fdata-sections" --host_copt="-fdata-sections"
 
+# On Linux, use clang lld.
+build:linux --linkopt="-fuse-ld=lld"
+
 #
 # Windows
 #

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ To build `workerd`, you need:
 * On Linux:
   * We use the clang/LLVM toolchain to build workerd and support version 16 and higher. Earlier versions of clang may still work, but are not officially supported.
   * Clang 16+ (e.g. package `clang-16` on Debian Bookworm). If clang is installed as `clang-<version>` please create a symlink to it in your PATH named `clang`, or use `--action_env=CC=clang-<version>` on `bazel` command lines to specify the compiler name.
-  
+
   * libc++ 16+ (e.g. packages `libc++-16-dev` and `libc++abi-16-dev`)
-  * LLD 16+ (e.g. package `lld-16`). The build may still succeed if a recent version of GNU gold or the system linker is installed, but lld is highly recommended for link performance.
+  * LLD 16+ (e.g. package `lld-16`).
   * `python3`, `python3-distutils`, and `tcl8.6`
 * On macOS:
   * Xcode 15 installation (available on macOS 13 and higher). **Full Xcode is required**, the Xcode command line tools alone are **not sufficient** for building.


### PR DESCRIPTION
Currently, we strongly recommend clang's lld but suggest it "may" be possible to use GNU ld. GNU ld worked in the past but was slow. It currently doesn't work at all due to some errors relating to missing symbols in chromium zlib.

This PR simplifies things by requiring clang lld, and explicitly using it for builds. If a user can install clang, it's simpler to just install lld as well, instead of mixing things. 