### PR TITLE
[build] Bump minimum macOS version to 10.13

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -201,10 +201,9 @@ build:unix --cxxopt='-Wno-ignored-qualifiers' --host_cxxopt='-Wno-ignored-qualif
 build:linux --config=unix
 build:macos --config=unix
 
-# Support macOS 11 as the minimum version. There should be at least a warning when backward
+# Support macOS 13 as the minimum version. There should be at least a warning when backward
 # compatibility is broken as -Wunguarded-availability-new is enabled by default.
-# TODO (cleanup): macOS 11.X is now EOL, bump this to macOS 12.5 soon.
-build:macos --macos_minimum_os=11.5 --host_macos_minimum_os=11.5
+build:macos --macos_minimum_os=13.5 --host_macos_minimum_os=13.5
 
 # Avoid emitting duplicate unwind info where compact unwind info can be used. This reduces the
 # object size by ~5% on average, improving disk space usage and link times. The final binary size

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Prebuilt binaries are distributed via `npm`. Run `npx workerd ...` to use these.
 * On Linux:
   * glibc 2.31 or higher (already included on e.g. Ubuntu 20.04, Debian Bullseye)
 * On macOS:
-  * macOS 11.5 or higher
+  * macOS 13.5 or higher
   * The Xcode command line tools, which can be installed with `xcode-select --install`
 * x86_64 CPU with at least SSE4.2 and CLMUL ISA extensions, or arm64 CPU with CRC extension (enabled by default under armv8.1-a). These extensions are supported by all recent x86 and arm64 CPUs.
 


### PR DESCRIPTION
macOS 12 (released 2021) is now EOL, and Mac developers generally update to the latest OS version quickly.
As a side effect, this implicitly enables the chained fixups linker feature, which improves binary launch times and reduces workerd release binary size by ~65 KB (See https://www.emergetools.com/blog/posts/iOS15LaunchTime for more information).