### PR TITLE
Revert the revert of `fastEncodeBase64Url` method

### DIFF
--- a/src/workerd/api/crypto/aes.c++
+++ b/src/workerd/api/crypto/aes.c++
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "impl.h"
+#include "util.h"
 
 #include <workerd/io/io-context.h>
 
@@ -166,7 +167,7 @@ private:
 
       SubtleCrypto::JsonWebKey jwk;
       jwk.kty = kj::str("oct");
-      jwk.k = kj::encodeBase64Url(keyData);
+      jwk.k = fastEncodeBase64Url(keyData);
       jwk.alg = kj::str("A", lengthInBytes * 8, aesMode);
       jwk.key_ops = getUsages().map([](auto usage) { return kj::str(usage.name()); });
       // I don't know why the spec says:

--- a/src/workerd/api/crypto/digest.c++
+++ b/src/workerd/api/crypto/digest.c++
@@ -5,6 +5,7 @@
 #include "digest.h"
 
 #include "impl.h"
+#include "util.h"
 
 #include <workerd/api/crypto/crypto.h>
 #include <workerd/io/io-context.h>
@@ -77,7 +78,7 @@ private:
 
       SubtleCrypto::JsonWebKey jwk;
       jwk.kty = kj::str("oct");
-      jwk.k = kj::encodeBase64Url(keyData);
+      jwk.k = fastEncodeBase64Url(keyData);
       jwk.alg = kj::str("HS", keyAlgorithm.hash.name.slice(4));
       jwk.key_ops = getUsages().map([](auto usage) { return kj::str(usage.name()); });
       // I don't know why the spec says:

--- a/src/workerd/api/crypto/ec.c++
+++ b/src/workerd/api/crypto/ec.c++
@@ -70,8 +70,8 @@ SubtleCrypto::JsonWebKey Ec::toJwk(KeyType keyType, kj::StringPtr curveName) con
   auto xa = handleBn(*x, groupDegreeInBytes);
   auto ya = handleBn(*y, groupDegreeInBytes);
 
-  jwk.x = kj::encodeBase64Url(xa);
-  jwk.y = kj::encodeBase64Url(ya);
+  jwk.x = fastEncodeBase64Url(xa);
+  jwk.y = fastEncodeBase64Url(ya);
 
   if (keyType == KeyType::PRIVATE) {
     const auto privateKey = getPrivateKey();
@@ -79,7 +79,7 @@ SubtleCrypto::JsonWebKey Ec::toJwk(KeyType keyType, kj::StringPtr curveName) con
         "Error getting private key material for JSON Web Key export",
         internalDescribeOpensslErrors());
     auto pk = handleBn(*privateKey, groupDegreeInBytes);
-    jwk.d = kj::encodeBase64Url(pk);
+    jwk.d = fastEncodeBase64Url(pk);
   }
   return jwk;
 }
@@ -993,7 +993,7 @@ private:
     SubtleCrypto::JsonWebKey jwk;
     jwk.kty = kj::str("OKP");
     jwk.crv = kj::str(getAlgorithmName() == "X25519"_kj ? "X25519"_kj : "Ed25519"_kj);
-    jwk.x = kj::encodeBase64Url(kj::arrayPtr(rawPublicKey, publicKeyLen));
+    jwk.x = fastEncodeBase64Url(kj::arrayPtr(rawPublicKey, publicKeyLen));
     if (getAlgorithmName() == "Ed25519"_kj) {
       jwk.alg = kj::str("EdDSA");
     }
@@ -1011,7 +1011,7 @@ private:
 
       KJ_ASSERT(privateKeyLen == 32, privateKeyLen);
 
-      jwk.d = kj::encodeBase64Url(kj::arrayPtr(rawPrivateKey, privateKeyLen));
+      jwk.d = fastEncodeBase64Url(kj::arrayPtr(rawPrivateKey, privateKeyLen));
     }
 
     return jwk;

--- a/src/workerd/api/crypto/rsa.c++
+++ b/src/workerd/api/crypto/rsa.c++
@@ -3,6 +3,7 @@
 #include "impl.h"
 #include "keys.h"
 #include "simdutf.h"
+#include "util.h"
 
 #include <openssl/bn.h>
 #include <openssl/crypto.h>
@@ -235,20 +236,20 @@ SubtleCrypto::JsonWebKey Rsa::toJwk(
     jwk.alg = kj::mv(name);
   }
 
-  jwk.n = kj::encodeBase64Url(KJ_REQUIRE_NONNULL(bignumToArray(KJ_REQUIRE_NONNULL(n))));
-  jwk.e = kj::encodeBase64Url(KJ_REQUIRE_NONNULL(bignumToArray(KJ_REQUIRE_NONNULL(e))));
+  jwk.n = fastEncodeBase64Url(KJ_REQUIRE_NONNULL(bignumToArray(KJ_REQUIRE_NONNULL(n))));
+  jwk.e = fastEncodeBase64Url(KJ_REQUIRE_NONNULL(bignumToArray(KJ_REQUIRE_NONNULL(e))));
 
   if (keyType == KeyType::PRIVATE) {
-    jwk.d = kj::encodeBase64Url(KJ_REQUIRE_NONNULL(bignumToArray(KJ_REQUIRE_NONNULL(d))));
+    jwk.d = fastEncodeBase64Url(KJ_REQUIRE_NONNULL(bignumToArray(KJ_REQUIRE_NONNULL(d))));
     jwk.p =
-        kj::encodeBase64Url(KJ_REQUIRE_NONNULL(bignumToArray(KJ_REQUIRE_NONNULL(RSA_get0_p(rsa)))));
+        fastEncodeBase64Url(KJ_REQUIRE_NONNULL(bignumToArray(KJ_REQUIRE_NONNULL(RSA_get0_p(rsa)))));
     jwk.q =
-        kj::encodeBase64Url(KJ_REQUIRE_NONNULL(bignumToArray(KJ_REQUIRE_NONNULL(RSA_get0_q(rsa)))));
-    jwk.dp = kj::encodeBase64Url(
+        fastEncodeBase64Url(KJ_REQUIRE_NONNULL(bignumToArray(KJ_REQUIRE_NONNULL(RSA_get0_q(rsa)))));
+    jwk.dp = fastEncodeBase64Url(
         KJ_REQUIRE_NONNULL(bignumToArray(KJ_REQUIRE_NONNULL(RSA_get0_dmp1(rsa)))));
-    jwk.dq = kj::encodeBase64Url(
+    jwk.dq = fastEncodeBase64Url(
         KJ_REQUIRE_NONNULL(bignumToArray(KJ_REQUIRE_NONNULL(RSA_get0_dmq1(rsa)))));
-    jwk.qi = kj::encodeBase64Url(
+    jwk.qi = fastEncodeBase64Url(
         KJ_REQUIRE_NONNULL(bignumToArray(KJ_REQUIRE_NONNULL(RSA_get0_iqmp(rsa)))));
   }
 

--- a/src/workerd/api/node/crypto-keys.c++
+++ b/src/workerd/api/node/crypto-keys.c++
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 #include "crypto.h"
+#include "util.h"
 
 #include <workerd/api/crypto/impl.h>
 
@@ -46,7 +47,7 @@ public:
     if (format == "jwk") {
       SubtleCrypto::JsonWebKey jwk;
       jwk.kty = kj::str("oct");
-      jwk.k = kj::encodeBase64Url(keyData);
+      jwk.k = fastEncodeBase64Url(keyData);
       jwk.ext = true;
       return jwk;
     }

--- a/src/workerd/api/util.c++
+++ b/src/workerd/api/util.c++
@@ -292,11 +292,14 @@ void maybeWarnIfNotText(jsg::Lock& js, kj::StringPtr str) {
 }
 
 kj::String fastEncodeBase64Url(kj::ArrayPtr<const byte> bytes) {
+  if (KJ_UNLIKELY(bytes.size() == 0)) {
+    return {};
+  }
   auto expected_length = simdutf::base64_length_from_binary(bytes.size(), simdutf::base64_url);
-  auto output = kj::heapArray<char>(expected_length);
+  auto output = kj::heapArray<char>(expected_length + 1);
   auto actual_length = simdutf::binary_to_base64(
       bytes.asChars().begin(), bytes.size(), output.asChars().begin(), simdutf::base64_url);
-  KJ_ASSERT(expected_length == actual_length);
+  output[actual_length] = '\0';
   return kj::String(kj::mv(output));
 }
 

--- a/src/workerd/api/util.c++
+++ b/src/workerd/api/util.c++
@@ -4,6 +4,8 @@
 
 #include "util.h"
 
+#include "simdutf.h"
+
 #include <workerd/io/io-context.h>
 #include <workerd/util/mimetype.h>
 #include <workerd/util/thread-scopes.h>
@@ -288,4 +290,14 @@ void maybeWarnIfNotText(jsg::Lock& js, kj::StringPtr str) {
           "\". The result will probably be corrupted. Consider "
           "checking the Content-Type header before interpreting entities as text."));
 }
+
+kj::String fastEncodeBase64Url(kj::ArrayPtr<const byte> bytes) {
+  auto expected_length = simdutf::base64_length_from_binary(bytes.size(), simdutf::base64_url);
+  auto output = kj::heapArray<char>(expected_length);
+  auto actual_length = simdutf::binary_to_base64(
+      bytes.asChars().begin(), bytes.size(), output.asChars().begin(), simdutf::base64_url);
+  KJ_ASSERT(expected_length == actual_length);
+  return kj::String(kj::mv(output));
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/util.h
+++ b/src/workerd/api/util.h
@@ -102,4 +102,6 @@ double dateNow();
 
 void maybeWarnIfNotText(jsg::Lock& js, kj::StringPtr str);
 
+kj::String fastEncodeBase64Url(kj::ArrayPtr<const byte> bytes);
+
 }  // namespace workerd::api


### PR DESCRIPTION
Applying the suggestion of adding a null terminator before passing the input to `kj::String`

Reverts https://github.com/cloudflare/workerd/pull/2776