### PR TITLE
improve create-internal-pr.sh

### DIFF
--- a/tools/unix/create-internal-pr.sh
+++ b/tools/unix/create-internal-pr.sh
@@ -20,8 +20,7 @@ fi
 if [ $BRANCH_EXISTS -eq 1 ]; then
 	git checkout $SYNC_BRANCH_NAME
 else
-	git checkout master 
-	git checkout -b $SYNC_BRANCH_NAME
+	git checkout -b $SYNC_BRANCH_NAME origin/master
 fi
 
 git -C deps/workerd fetch origin $BRANCH_NAME


### PR DESCRIPTION
I'm not sure how it works right now for others. Every time I try to use `just internal-pr` the newly created branch is not up to date with the origin master, and I manually have to run `git pull --rebase origin master`. 