### PR TITLE
improve utf8 to utf16 conversion performance

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -44,7 +44,7 @@ void warnIfBadHeaderString(const jsg::ByteString& byteString) {
         // the wrong thing by UTF-8-encoding their bytes. To help the author understand the issue,
         // we can show the string that they would be putting in the header if we implemented the
         // spec correctly, and the string that is actually going get serialized onto the wire.
-        auto rawHex = kj::strArray(KJ_MAP(b, kj::encodeUtf16(byteString)) {
+        auto rawHex = kj::strArray(KJ_MAP(b, fastEncodeUtf16(byteString.asArray())) {
           KJ_ASSERT(b < 256);  // Guaranteed by StringWrapper having set CONTAINS_EXTENDED_ASCII.
           return kj::str("\\x", kj::hex(kj::byte(b)));
         }, "");

--- a/src/workerd/api/url.c++
+++ b/src/workerd/api/url.c++
@@ -599,8 +599,8 @@ void URLSearchParams::sort() {
   //   🌈  f0 9f 8c 88 |  d83c df08
 
   std::stable_sort(url->query.begin(), url->query.end(), [](const auto& left, const auto& right) {
-    auto leftUtf16 = kj::encodeUtf16(left.name.asArray());
-    auto rightUtf16 = kj::encodeUtf16(right.name.asArray());
+    auto leftUtf16 = fastEncodeUtf16(left.name.asArray());
+    auto rightUtf16 = fastEncodeUtf16(right.name.asArray());
     return std::lexicographical_compare(
         leftUtf16.begin(), leftUtf16.end(), rightUtf16.begin(), rightUtf16.end());
   });

--- a/src/workerd/api/util.c++
+++ b/src/workerd/api/util.c++
@@ -303,4 +303,15 @@ kj::String fastEncodeBase64Url(kj::ArrayPtr<const byte> bytes) {
   return kj::String(kj::mv(output));
 }
 
+kj::Array<char16_t> fastEncodeUtf16(kj::ArrayPtr<const char> bytes) {
+  if (KJ_UNLIKELY(bytes.size() == 0)) {
+    return {};
+  }
+  auto expected_length = simdutf::utf16_length_from_utf8(bytes.asChars().begin(), bytes.size());
+  auto output = kj::heapArray<char16_t>(expected_length);
+  auto actual_length =
+      simdutf::convert_utf8_to_utf16(bytes.asChars().begin(), bytes.size(), output.begin());
+  return output.slice(0, actual_length).attach(kj::mv(output));
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/util.h
+++ b/src/workerd/api/util.h
@@ -103,5 +103,6 @@ double dateNow();
 void maybeWarnIfNotText(jsg::Lock& js, kj::StringPtr str);
 
 kj::String fastEncodeBase64Url(kj::ArrayPtr<const byte> bytes);
+kj::Array<char16_t> fastEncodeUtf16(kj::ArrayPtr<const char> bytes);
 
 }  // namespace workerd::api

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -64,6 +64,7 @@ wd_cc_library(
         "//src/workerd/util:thread-scopes",
         "//src/workerd/util:uuid",
         "@capnp-cpp//src/kj",
+        "@simdutf",
         "@workerd-v8//:v8",
     ],
 )

--- a/src/workerd/jsg/inspector.c++
+++ b/src/workerd/jsg/inspector.c++
@@ -1,6 +1,8 @@
 #include "inspector.h"
 
 #include "jsg.h"
+#include "simdutf.h"
+#include "util.h"
 
 #include <v8-inspector.h>
 
@@ -45,13 +47,7 @@ private:
 }  // namespace
 
 v8_inspector::StringView toInspectorStringView(kj::StringPtr text) {
-  bool isAscii = true;
-  for (char c: text) {
-    if (c & 0x80) {
-      isAscii = false;
-      break;
-    }
-  }
+  bool isAscii = simdutf::validate_ascii(text.begin(), text.size());
 
   if (isAscii) {
     return StringViewWithScratch(


### PR DESCRIPTION
Introduces `fastEncodeUtf16` function that uses simdutf under the hood to convert utf8 inputs to utf16. The changeset also includes the usage of `simdutf::validate_ascii` to check if an input is a valid ascii.