### PR TITLE
disabling all precommit hooks that depend on external binaries

### DIFF
--- a/tools/cross/format.py
+++ b/tools/cross/format.py
@@ -186,21 +186,21 @@ class FormatConfig:
 
 
 FORMATTERS = [
-    FormatConfig(
-        directory="src/workerd", globs=("*.c++", "*.h"), formatter=clang_format
-    ),
-    FormatConfig(
-        directory="src",
-        globs=("*.js", "*.ts", "*.cjs", "*.ejs", "*.mjs"),
-        formatter=prettier,
-    ),
-    FormatConfig(directory="src", globs=("*.json",), formatter=prettier),
-    FormatConfig(directory=".", globs=("*.py",), formatter=ruff),
-    FormatConfig(
-        directory=".",
-        globs=("*.bzl", "WORKSPACE", "BUILD", "BUILD.*"),
-        formatter=buildifier,
-    ),
+    # FormatConfig(
+    #     directory="src/workerd", globs=("*.c++", "*.h"), formatter=clang_format
+    # ),
+    # FormatConfig(
+    #     directory="src",
+    #     globs=("*.js", "*.ts", "*.cjs", "*.ejs", "*.mjs"),
+    #     formatter=prettier,
+    # ),
+    # FormatConfig(directory="src", globs=("*.json",), formatter=prettier),
+    # FormatConfig(directory=".", globs=("*.py",), formatter=ruff),
+    # FormatConfig(
+    #     directory=".",
+    #     globs=("*.bzl", "WORKSPACE", "BUILD", "BUILD.*"),
+    #     formatter=buildifier,
+    # ),
 ]
 
 


### PR DESCRIPTION
This got out of hand and many developers report problems. All third-party dependencies need to be fetched by bazel if they are a requirement for workerd development.

Feel free to uncomment particular formatters once dependency management is fixed.

This is not a reflection on linters/formatters at all: they are super useful and we should continue increasing the coverage.