### PR TITLE
[nfc] invoke check_clang_format only when clang_format is invoked

### DIFF
--- a/tools/cross/format.py
+++ b/tools/cross/format.py
@@ -101,6 +101,7 @@ def matches_any_glob(globs: tuple[str, ...], file: Path) -> bool:
 
 
 def clang_format(files: list[Path], check: bool = False) -> bool:
+    check_clang_format()
     cmd = [CLANG_FORMAT]
     if check:
         cmd += ["--dry-run", "--Werror"]
@@ -225,7 +226,6 @@ def format(config: FormatConfig, files: list[Path], check: bool) -> tuple[bool, 
 
 def main() -> None:
     options = parse_args()
-    check_clang_format()
     if options.subcommand == "git":
         files = git_get_modified_files(options.target, options.source, options.staged)
     else:


### PR DESCRIPTION
I guess it will go away once clang_format is managed by bazel, but right now it is a nuisanse since we've disable clang_format.