### PR TITLE
[build] Split up more bazel targets, compile_flags.txt fixes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -138,7 +138,7 @@ build --cxxopt="-fbracket-depth=512" --host_cxxopt="-fbracket-depth=512"
 # Additional Rust flags (see https://doc.rust-lang.org/rustc/codegen-options/index.html)
 # Need to disable debug-assertions for fastbuild, should be off automatically for opt. As long as
 # rust-level LTO is not enabled, LLVM bitcode is not needed so -C embed-bitcode=n provides a free
-# improvement to build speed and rust-deps code size.
+# improvement to build speed and Rust code size.
 # Using extra_rustc_flag for non-exec flags so they can be overwritten selectively.
 build --@rules_rust//:extra_rustc_flag=-Cembed-bitcode=n
 build --@rules_rust//:extra_rustc_flag=-Cpanic=abort

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,6 @@
 
 /*.code-workspace
 
-/rust-deps/target
-/rust-deps/Cargo.toml
-
 node_modules
 /npm/*/bin
 /npm/workerd/install.js

--- a/build/deps/build_deps.jsonc
+++ b/build/deps/build_deps.jsonc
@@ -23,7 +23,7 @@
       "file_regex": "\\.tar\\.gz$"
     },
     {
-      // Needed for objc_library starting with bazel 7
+      // Needed for objc_library starting with bazel 7, used to build dawn on macOS
       "name": "build_bazel_apple_support",
       "type": "github_release",
       "owner": "bazelbuild",

--- a/build/deps/deps.jsonc
+++ b/build/deps/deps.jsonc
@@ -15,7 +15,9 @@
       "owner": "google",
       "repo": "boringssl",
       "branch": "master-with-bazel",
-      // todo: head requires a trivial fix
+      // from main-with-bazel branch. Later boringssl versions have bazel support on the main
+      // branch, so using the custom branch with a different directory structure will no longer be
+      // needed in the future.
       "freeze_commit": "c08ccc9ed166a82b92edd70ab215ae1f2501e838"
     },
     // webgpu deps

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -21,10 +21,9 @@
 -isystem/usr/include/x86_64-linux-gnu
 -isystem/usr/include
 -isystem/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1
+-isystem/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/16/include
 -isystem/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
 -isystem/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Versions/Current/Headers
--isystemC:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.35.32215\include
--isystemc:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt
 -isystembazel-bin/_virtual_includes/icudata-embed
 -isystembazel-bin/external/capnp-cpp/src
 -isystembazel-bin/external/capnp-cpp/src/capnp/_virtual_includes/capnp
@@ -123,3 +122,4 @@
 -Wunused-lambda-capture
 -Wunused-variable
 -no-canonical-prefixes
+-fbracket-depth=512

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -13,6 +13,7 @@ filegroup(
             "data-url.c++",
             "encoding.c++",
             "html-rewriter.c++",
+            "hyperdrive.c++",
             "pyodide.c++",
             "pyodide/pyodide.c++",
             "rtti.c++",
@@ -33,6 +34,7 @@ filegroup(
             "deferred-proxy.h",
             "encoding.h",
             "html-rewriter.h",
+            "hyperdrive.h",
             "modules.h",
             "rtti.h",
             "url.h",
@@ -54,6 +56,7 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":html-rewriter",
+        ":hyperdrive",
         "//src/pyodide",
         "//src/pyodide:pyodide_extra_capnp",
         "//src/workerd/api/node",
@@ -70,6 +73,16 @@ wd_cc_library(
     implementation_deps = [
         "@com_cloudflare_lol_html//:lolhtml",
     ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/workerd/io",
+    ],
+)
+
+wd_cc_library(
+    name = "hyperdrive",
+    srcs = ["hyperdrive.c++"],
+    hdrs = ["hyperdrive.h"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/workerd/io",

--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -4,8 +4,6 @@
 
 #include "actor.h"
 
-#include "util.h"
-
 #include <workerd/io/features.h>
 
 #include <capnp/compat/byte-stream.h>

--- a/src/workerd/api/crypto/dh-primes.h
+++ b/src/workerd/api/crypto/dh-primes.h
@@ -50,10 +50,11 @@
  * (eay@cryptsoft.com).  This product includes software written by Tim
  * Hudson (tjh@cryptsoft.com). */
 
+#pragma once
+
+#include <openssl/base.h>
 #include <openssl/bn.h>
 #include <openssl/dh.h>
-#include <openssl/err.h>
-#include <openssl/mem.h>
 
 extern "C" int bn_set_words(BIGNUM *bn, const BN_ULONG *words, size_t num);
 

--- a/src/workerd/api/hyperdrive.c++
+++ b/src/workerd/api/hyperdrive.c++
@@ -4,7 +4,6 @@
 
 #include "hyperdrive.h"
 
-#include "http.h"
 #include "sockets.h"
 
 #include <openssl/rand.h>

--- a/src/workerd/api/hyperdrive.h
+++ b/src/workerd/api/hyperdrive.h
@@ -6,7 +6,9 @@
 
 #include <workerd/jsg/jsg.h>
 
-#include <kj/async-io.h>
+namespace kj {
+class AsyncIoStream;
+}
 
 namespace workerd::api {
 

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -4,21 +4,60 @@ load("//:build/wd_test.bzl", "wd_test")
 
 wd_cc_library(
     name = "node",
-    srcs = glob(
-        ["**/*.c++"],
-        exclude = ["**/*-test.c++"],
-    ),
-    hdrs = glob(["**/*.h"]),
+    srcs = [
+        "crypto.c++",
+        "crypto-keys.c++",
+        "diagnostics-channel.c++",
+        "zlib-util.c++",
+    ],
+    hdrs = [
+        "crypto.h",
+        "diagnostics-channel.h",
+        "node.h",
+        "zlib-util.h",
+    ],
+    implementation_deps = [
+        "@capnp-cpp//src/kj/compat:kj-gzip",
+        "@nbytes",
+        "//src/workerd/io",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":node-core",
+        "@capnp-cpp//src/kj/compat:kj-brotli",
+    ],
+)
+
+# node source files that don't depend on io.
+wd_cc_library(
+    name = "node-core",
+    srcs = [
+        "async-hooks.c++",
+        "buffer.c++",
+        "i18n.c++",
+        "module.c++",
+        "url.c++",
+        "util.c++",
+    ],
+    hdrs = [
+        "async-hooks.h",
+        "buffer.h",
+        "buffer-string-search.h",
+        "i18n.h",
+        "module.h",
+        "url.h",
+        "util.h",
+    ],
     implementation_deps = [
         "//src/workerd/io",
         "@ada-url",
-        "@capnp-cpp//src/kj/compat:kj-gzip",
         "@nbytes",
         "@simdutf",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "@capnp-cpp//src/kj/compat:kj-brotli",
+        "//src/workerd/io:compatibility_date_capnp",
+        "//src/workerd/jsg",
     ],
 )
 

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -17,9 +17,8 @@ wd_cc_library(
         "zlib-util.h",
     ],
     implementation_deps = [
-        "@capnp-cpp//src/kj/compat:kj-gzip",
-        "@nbytes",
         "//src/workerd/io",
+        "@capnp-cpp//src/kj/compat:kj-gzip",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -49,7 +48,6 @@ wd_cc_library(
         "util.h",
     ],
     implementation_deps = [
-        "//src/workerd/io",
         "@ada-url",
         "@nbytes",
         "@simdutf",

--- a/src/workerd/api/node/diagnostics-channel.h
+++ b/src/workerd/api/node/diagnostics-channel.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include "async-hooks.h"
-
+#include <workerd/api/node/async-hooks.h>
 #include <workerd/jsg/jsg.h>
 
 #include <kj/map.h>

--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "async-hooks.h"
-#include "buffer.h"
 #include "crypto.h"
 #include "diagnostics-channel.h"
-#include "module.h"
-#include "url.h"
-#include "util.h"
 #include "zlib-util.h"
 
+#include <workerd/api/node/async-hooks.h>
+#include <workerd/api/node/buffer.h>
+#include <workerd/api/node/module.h>
+#include <workerd/api/node/url.h>
+#include <workerd/api/node/util.h>
 #include <workerd/io/compatibility-date.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/modules-new.h>

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -118,6 +118,7 @@ wd_cc_library(
         ":workerd_capnp",
         "//deps/rust:runtime",
         "//src/workerd/api:html-rewriter",
+        "//src/workerd/api:hyperdrive",
         "//src/workerd/api:pyodide",
         "//src/workerd/api:rtti",
         "//src/workerd/api/node",

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -49,6 +49,7 @@ wd_cc_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":server",
+        ":v8-platform-impl",
         ":workerd-meta_capnp",
         ":workerd_capnp",
         "//src/pyodide:pyodide_extra_capnp",
@@ -100,12 +101,10 @@ wd_cc_library(
     name = "server",
     srcs = [
         "server.c++",
-        "v8-platform-impl.c++",
         "workerd-api.c++",
     ],
     hdrs = [
         "server.h",
-        "v8-platform-impl.h",
         "workerd-api.h",
     ],
     defines = select({
@@ -127,6 +126,20 @@ wd_cc_library(
         "//src/workerd/jsg",
         "//src/workerd/util:perfetto",
         "@capnp-cpp//src/kj/compat:kj-tls",
+    ],
+)
+
+wd_cc_library(
+    name = "v8-platform-impl",
+    srcs = [
+        "v8-platform-impl.c++",
+    ],
+    hdrs = [
+        "v8-platform-impl.h",
+    ],
+    deps = [
+        "//src/workerd/jsg",
+        "@capnp-cpp//src/kj",
     ],
 )
 

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -18,6 +18,7 @@ cc_ast_dump(
     }),
     deps = [
         "//src/workerd/api:html-rewriter",
+        "//src/workerd/api:hyperdrive",
         "//src/workerd/api/node",
         "//src/workerd/io",
         "//src/workerd/jsg",

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -46,8 +46,7 @@ rust_binary(
 # Deliberately not marking this run_binary_target(): The exec configuration compiles with
 # optimization by default, causing it to run markedly faster than the (non-opt) target
 # configuration, where param_extractor would otherwise take several minutes to run. A different
-# approach would be to set `rustc_flags = ["-C", "opt-level=3"],` here, although in this case any
-# dependencies shared with the rust-deps target would still need to be compiled twice.
+# approach would be to set -Copt-level=3 globally, but that's not helpful for debug builds.
 run_binary(
     name = "param_extractor",
     srcs = [


### PR DESCRIPTION
[build] Factor out api:hyperdrive target

[nfc] Assorted build cleanup
- Add back/expand comments after moving dependencies to update-deps system
- Fix compile_flags.txt for Xcode 16 by adding missing path
- Remove Windows include paths from compile_flags.txt – the team does not
  regularly use Windows and the spaces in the file path make using the file to
  build code (e.g. clang++ @compile_flags.txt <file>) fail.
- Add -fbracket-depth=512 to compile_flags.txt so that it can be used to
  compile workerd-api.c++

[build] Split files off of node and server targets
- Fix missing pragma once in dh-primes.h

[nfc] Clean up Rust-related comments, gitignore