### PR TITLE
Add cloudflare internal symbol to resourcetypes

### DIFF
--- a/src/workerd/api/tests/global-scope-test.js
+++ b/src/workerd/api/tests/global-scope-test.js
@@ -738,5 +738,9 @@ export const toStringTag = {
       toString.call(new URLSearchParams()),
       '[object URLSearchParams]'
     );
+
+    const internalFlag = Symbol.for('cloudflare:internal-class');
+    strictEqual(Headers.prototype[internalFlag], internalFlag);
+    strictEqual(new Headers()[internalFlag], internalFlag);
   },
 };


### PR DESCRIPTION
Miniflare has been using the lack of `Symbol.toStringTag` to detect internal API objects. This is brittle and problematic because for compliance with standard web platform APIs we're supposed to be adding the Symbol.toStringTag to standard types and there are modules in the ecosystem that depend on it. We recently landed a change that adds the Symbol.toStringTag to types but that broke miniflare. This PR adds an alternative symbol to jsg::Objects that can identify themselves as internal.