### PR TITLE
Have nodejs_zlib implied by nodejs_compat_v2

### DIFF
--- a/src/workerd/api/node/tests/zlib-nodejs-test.js
+++ b/src/workerd/api/node/tests/zlib-nodejs-test.js
@@ -2603,3 +2603,22 @@ const PSS_VECTORS_JSON = `{
     ]
   }
 }`;
+
+export const compatFlagTest = {
+  async test(_, env) {
+    const waitForIt = async (test) => {
+      const res = await env[test].fetch('http://example.org');
+      return await res.text();
+    };
+    const results = await Promise.allSettled([
+      waitForIt('compat'),
+      waitForIt('compatv2'),
+      waitForIt('compatNoV2'),
+    ]);
+    assert.deepStrictEqual(results, [
+      { status: 'fulfilled', value: 'true' },
+      { status: 'fulfilled', value: 'true' },
+      { status: 'fulfilled', value: 'true' },
+    ]);
+  },
+};

--- a/src/workerd/api/node/tests/zlib-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/zlib-nodejs-test.wd-test
@@ -9,7 +9,43 @@ const unitTests :Workerd.Config = (
         ],
         compatibilityDate = "2023-01-15",
         compatibilityFlags = ["experimental", "nodejs_compat", "nodejs_zlib"],
+        bindings = [
+          ( name = "compat", service = "compat" ),
+          ( name = "compatv2", service = "compatv2" ),
+          ( name = "compatNoV2", service = "compatNoV2" ),
+        ],
       )
     ),
+    (
+      name = "compat",
+      worker = (
+        modules = [
+          (name = "worker", esModule = "export default {fetch() {return new Response(`${JSON.stringify(globalThis.Cloudflare.compatibilityFlags.nodejs_zlib)}`);}}")
+        ],
+        compatibilityDate = "2024-09-23",
+        compatibilityFlags = ["nodejs_compat"],
+      )
+    ),
+    (
+      name = "compatv2",
+      worker = (
+        modules = [
+          (name = "worker", esModule = "export default {fetch() {return new Response(`${JSON.stringify(globalThis.Cloudflare.compatibilityFlags.nodejs_zlib)}`);}}")
+        ],
+        compatibilityDate = "2024-09-23",
+        compatibilityFlags = ["nodejs_compat_v2"],
+      )
+    ),
+    (
+      name = "compatNoV2",
+      worker = (
+        modules = [
+          (name = "worker", esModule = "export default {fetch() {return new Response(`${JSON.stringify(globalThis.Cloudflare.compatibilityFlags.nodejs_zlib)}`);}}")
+        ],
+        compatibilityDate = "2024-09-23",
+        compatibilityFlags = ["nodejs_compat", "no_nodejs_compat_v2"],
+      )
+    )
   ],
 );
+

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -10,8 +10,11 @@ $Cxx.allowCancellation;
 
 struct ImpliedByAfterDate @0x8f8c1b68151b6cff {
   # Annotates a compatibility flag to indicate that it is implied by the enablement
-  # of the named flag after the specified date.
-  name @0 :Text;
+  # of the named flag(s) after the specified date.
+  union {
+    name @0 :Text;
+    names @2 :List(Text);
+  }
   date @1 :Text;
 }
 
@@ -584,10 +587,10 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   nodeJsZlib @59 :Bool
       $compatEnableFlag("nodejs_zlib")
       $compatDisableFlag("no_nodejs_zlib")
-      $impliedByAfterDate(name = "nodeJsCompat", date = "2024-09-23");
+      $impliedByAfterDate(names = ["nodeJsCompat", "nodeJsCompatV2"], date = "2024-09-23");
   # Enables node:zlib implementation while it is in-development.
   # Once the node:zlib implementation is complete, this will be automatically enabled when
-  # nodejs_compat is enabled.
+  # nodejs_compat or nodejs_compat_v2 are enabled.
 
   replicaRouting @60 :Bool
       $compatEnableFlag("replica_routing")


### PR DESCRIPTION
Ensures that if either nodejs_compat or nodejs_compat_v2 are enabled, then nodejs_zlib will be enabled also

There was a limitation in the original definition of the implied by annotation in that it would only allow specifying a single field. The effect was that `nodejs_zlib` would be implied by `nodejs_compat` but not `noejs_compat_v2`. If I updated it to be implied by `nodejs_compat_v2` then it would transitively work for both `nodejs_compat` and `nodejs_compat_v2` but *wouldn't* do the right thing if the worker had `nodejs_compat, no_nodejs_compat_v2`... Confusing.

This PR modifies the implied by annotation to allow multiple flags to be specified so that it works correct in any combination.