### PR TITLE
simplify workerd/api/node bazel

### DIFF
--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -10,6 +10,7 @@ wd_cc_library(
     ),
     hdrs = glob(["**/*.h"]),
     implementation_deps = [
+        "//src/workerd/io",
         "@ada-url",
         "@capnp-cpp//src/kj/compat:kj-gzip",
         "@nbytes",
@@ -17,7 +18,6 @@ wd_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/workerd/io",
         "@capnp-cpp//src/kj/compat:kj-brotli",
     ],
 )

--- a/src/workerd/api/node/async-hooks.h
+++ b/src/workerd/api/node/async-hooks.h
@@ -7,8 +7,6 @@
 #include <workerd/jsg/async-context.h>
 #include <workerd/jsg/jsg.h>
 
-#include <kj/table.h>
-
 namespace workerd::api::node {
 
 // Implements a subset of the Node.js AsyncLocalStorage API.

--- a/src/workerd/api/node/i18n.c++
+++ b/src/workerd/api/node/i18n.c++
@@ -9,16 +9,9 @@
 
 #include <workerd/jsg/exception.h>
 
-#include <unicode/putil.h>
-#include <unicode/uchar.h>
-#include <unicode/uclean.h>
 #include <unicode/ucnv.h>
-#include <unicode/udata.h>
 #include <unicode/uidna.h>
 #include <unicode/urename.h>
-#include <unicode/ustring.h>
-#include <unicode/utf16.h>
-#include <unicode/utf8.h>
 #include <unicode/utypes.h>
 #include <unicode/uvernum.h>
 #include <unicode/uversion.h>

--- a/src/workerd/api/node/i18n.h
+++ b/src/workerd/api/node/i18n.h
@@ -4,8 +4,6 @@
 #pragma once
 
 #include <kj/common.h>
-#include <kj/debug.h>
-#include <kj/one-of.h>
 #include <kj/string.h>
 
 #include <cstdint>

--- a/src/workerd/api/node/zlib-util.c++
+++ b/src/workerd/api/node/zlib-util.c++
@@ -5,7 +5,6 @@
 
 #include "zlib-util.h"
 
-#include "nbytes.h"
 #include "util.h"
 
 // The following implementation is adapted from Node.js


### PR DESCRIPTION
Moves `workerd/io` to implementation_deps and removes unused includes.