### PR TITLE
add util.getCallSite implementation

### DIFF
--- a/src/node/internal/util.d.ts
+++ b/src/node/internal/util.d.ts
@@ -121,3 +121,4 @@ export function isBoxedPrimitive(
 ): value is number | string | boolean | bigint | symbol;
 
 export function getBuiltinModule(id: string): any;
+export function getCallSite(frames: number): Record<string, string>[];

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -250,6 +250,10 @@ export function deprecate(
   return fn;
 }
 
+export function getCallSite(frames: number = 10) {
+  return utilImpl.getCallSite(frames);
+}
+
 export default {
   types,
   callbackify,
@@ -278,6 +282,7 @@ export default {
   parseArgs,
   transferableAbortController,
   transferableAbortSignal,
+  getCallSite,
 };
 
 // Node.js util APIs we're currently not supporting

--- a/src/workerd/api/node/tests/util-nodejs-test.js
+++ b/src/workerd/api/node/tests/util-nodejs-test.js
@@ -4342,3 +4342,15 @@ export const debuglog = {
     console.log = original;
   },
 };
+
+export const getCallSiteTest = {
+  test() {
+    const callSites = util.getCallSite();
+    assert.strictEqual(callSites.length, 1);
+    const [stack] = callSites;
+    assert.strictEqual(stack.functionName, 'test');
+    assert.strictEqual(stack.scriptName, 'worker');
+    assert.strictEqual(typeof stack.lineNumber, 'number');
+    assert.strictEqual(typeof stack.column, 'number');
+  },
+};

--- a/src/workerd/api/node/util.h
+++ b/src/workerd/api/node/util.h
@@ -204,6 +204,16 @@ public:
 
   jsg::JsString getConstructorName(jsg::Lock& js, jsg::JsObject value);
 
+  struct CallSiteEntry {
+    kj::String functionName;
+    kj::String scriptName;
+    int lineNumber;
+    int column;
+
+    JSG_STRUCT(functionName, scriptName, lineNumber, column);
+  };
+  kj::Array<CallSiteEntry> getCallSite(jsg::Lock& js, int frames);
+
 #define V(Type) bool is##Type(jsg::JsValue value);
   JS_UTIL_IS_TYPES(V)
 #undef V
@@ -230,6 +240,7 @@ public:
     JSG_METHOD(getProxyDetails);
     JSG_METHOD(previewEntries);
     JSG_METHOD(getConstructorName);
+    JSG_METHOD(getCallSite);
 
 #define V(Type) JSG_METHOD(is##Type);
     JS_UTIL_IS_TYPES(V)
@@ -247,6 +258,6 @@ public:
       api::node::MIMEType, api::node::MIMEParams, api::node::MIMEParams::EntryIterator,            \
       api::node::MIMEParams::ValueIterator, api::node::MIMEParams::KeyIterator,                    \
       api::node::MIMEParams::EntryIterator::Next, api::node::MIMEParams::ValueIterator::Next,      \
-      api::node::MIMEParams::KeyIterator::Next
+      api::node::MIMEParams::KeyIterator::Next, api::node::UtilModule::CallSiteEntry
 
 }  // namespace workerd::api::node


### PR DESCRIPTION
This pull-request adds the one of the newest Node.js API: `util.getCallSite()`