### PR TITLE
fix create-internal-pr for linux users

### DIFF
--- a/tools/unix/create-internal-pr.sh
+++ b/tools/unix/create-internal-pr.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-if [ -z "$EDGEWORKER_HOME" ]; then
+if [ -z "${EDGEWORKER_HOME+x}" ]; then
 	EDGEWORKER_HOME="$(git rev-parse --show-toplevel)/../edgeworker"
 fi
 


### PR DESCRIPTION
Fixes the script if EDGEWORKER_HOME is not available.