### PR TITLE
convert jsg::dict to use hashmap instead of array

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -549,9 +549,9 @@ jsg::Promise<void> DurableObjectStorageOperations::putMultiple(
 
     kj::Array<byte> buffer = serializeV8Value(js, field.value);
 
-    units += billingUnits(field.name.size() + buffer.size());
+    units += billingUnits(field.key.size() + buffer.size());
 
-    kvs.add(ActorCacheOps::KeyValuePair{kj::mv(field.name), kj::mv(buffer)});
+    kvs.add(ActorCacheOps::KeyValuePair{kj::mv(field.key), kj::mv(buffer)});
   }
 
   jsg::Promise<void> maybeBackpressure =

--- a/src/workerd/api/gpu/gpu-adapter.c++
+++ b/src/workerd/api/gpu/gpu-adapter.c++
@@ -101,7 +101,7 @@ jsg::Promise<jsg::Ref<GPUDevice>> GPUAdapter::requestDevice(
 
     KJ_IF_SOME(requiredLimits, d.requiredLimits) {
       for (auto& f: requiredLimits.fields) {
-        setLimit(limits, f.name, f.value);
+        setLimit(limits, f.key, f.value);
       }
       desc.requiredLimits = &limits;
     }

--- a/src/workerd/api/gpu/gpu-device.c++
+++ b/src/workerd/api/gpu/gpu-device.c++
@@ -308,9 +308,10 @@ ParsedRenderPipelineDescriptor parseRenderPipelineDescriptor(
     kj::Vector<wgpu::ConstantEntry> constants;
 
     for (auto& f: cDict.fields) {
-      wgpu::ConstantEntry e;
-      e.key = f.name.cStr();
-      e.value = f.value;
+      wgpu::ConstantEntry e{
+        .key = f.key.cStr(),
+        .value = f.value,
+      };
       constants.add(kj::mv(e));
     }
     auto constantsArray = constants.releaseAsArray();
@@ -432,9 +433,10 @@ ParsedRenderPipelineDescriptor parseRenderPipelineDescriptor(
       kj::Vector<wgpu::ConstantEntry> constants;
 
       for (auto& f: cDict.fields) {
-        wgpu::ConstantEntry e;
-        e.key = f.name.cStr();
-        e.value = f.value;
+        wgpu::ConstantEntry e{
+          .key = f.key.cStr(),
+          .value = f.value,
+        };
         constants.add(kj::mv(e));
       }
       auto constantsArray = constants.releaseAsArray();
@@ -549,9 +551,10 @@ wgpu::ComputePipelineDescriptor parseComputePipelineDescriptor(
   kj::Vector<wgpu::ConstantEntry> constants;
   KJ_IF_SOME(cDict, descriptor.compute.constants) {
     for (auto& f: cDict.fields) {
-      wgpu::ConstantEntry e;
-      e.key = f.name.cStr();
-      e.value = f.value;
+      wgpu::ConstantEntry e{
+        .key = f.key.cStr(),
+        .value = f.value,
+      };
       constants.add(kj::mv(e));
     }
   }

--- a/src/workerd/api/node/zlib-util.c++
+++ b/src/workerd/api/node/zlib-util.c++
@@ -882,7 +882,7 @@ kj::Array<kj::byte> ZlibUtil::brotliSync(InputSource data, BrotliContext::Option
 
   KJ_IF_SOME(params, opts.params) {
     for (const auto& field: params.fields) {
-      KJ_IF_SOME(err, ctx.setParams(field.name.parseAs<int>(), field.value)) {
+      KJ_IF_SOME(err, ctx.setParams(field.key.parseAs<int>(), field.value)) {
         JSG_FAIL_REQUIRE(Error, err.message);
       }
     }

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -257,13 +257,13 @@ public:
     }
 
     const jsg::Optional<jsg::Dict<kj::String>> getCustomMetadata() const {
-      return customMetadata.map([](const jsg::Dict<kj::String>& m) {
-        return jsg::Dict<kj::String>{
-          .fields =
-              KJ_MAP(f, m.fields) {
-          return jsg::Dict<kj::String>::Field{.name = kj::str(f.name), .value = kj::str(f.value)};
-        },
-        };
+      return customMetadata.map([](const jsg::Dict<kj::String>& cm) {
+        auto res = jsg::Dict<kj::String>{};
+        res.fields.reserve(cm.fields.size());
+        for (auto& m: cm.fields) {
+          res.fields.insert(kj::str(m.key), kj::str(m.value));
+        }
+        return kj::mv(res);
       });
     }
 

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -344,16 +344,15 @@ jsg::Dict<jsg::ByteString, jsg::ByteString> TraceItem::FetchEventInfo::Request::
         name.contains("token"_kjc));
   };
 
-  using HeaderDict = jsg::Dict<jsg::ByteString, jsg::ByteString>;
-  auto builder = kj::heapArrayBuilder<HeaderDict::Field>(detail->headers.size());
+  jsg::Dict<jsg::ByteString, jsg::ByteString> dict{};
+  dict.fields.reserve(detail->headers.size());
   for (const auto& header: detail->headers) {
     auto v = (redacted && shouldRedact(header.name)) ? "REDACTED"_kj : header.value;
-    builder.add(
-        HeaderDict::Field{jsg::ByteString(kj::str(header.name)), jsg::ByteString(kj::str(v))});
+    dict.fields.insert(jsg::ByteString(kj::str(header.name)), jsg::ByteString(kj::str(v)));
   }
 
   // TODO(conform): Better to return a frozen JS Object?
-  return HeaderDict{builder.finish()};
+  return dict;
 }
 
 kj::StringPtr TraceItem::FetchEventInfo::Request::getMethod() {

--- a/src/workerd/api/url-standard.c++
+++ b/src/workerd/api/url-standard.c++
@@ -169,7 +169,7 @@ jsg::UrlSearchParams initSearchParams(const URLSearchParams::Initializer& init) 
     KJ_CASE_ONEOF(dict, jsg::Dict<kj::String, kj::String>) {
       jsg::UrlSearchParams params;
       for (auto& item: dict.fields) {
-        params.append(item.name, item.value);
+        params.append(item.key, item.value);
       }
       return kj::mv(params);
     }

--- a/src/workerd/api/url.c++
+++ b/src/workerd/api/url.c++
@@ -520,7 +520,7 @@ jsg::Ref<URLSearchParams> URLSearchParams::constructor(
       }
       KJ_CASE_ONEOF(dict, jsg::Dict<kj::String>) {
         searchParams->url->query = KJ_MAP(entry, dict.fields) {
-          return kj::Url::QueryParam{kj::mv(entry.name), kj::mv(entry.value)};
+          return kj::Url::QueryParam{kj::mv(entry.key), kj::mv(entry.value)};
         };
       }
       KJ_CASE_ONEOF(arrayOfArrays, kj::Array<kj::Array<kj::String>>) {

--- a/src/workerd/api/urlpattern.c++
+++ b/src/workerd/api/urlpattern.c++
@@ -44,27 +44,23 @@ kj::Maybe<URLPattern::URLPatternComponentResult> execRegex(jsg::Lock& js,
     jsg::JsRef<jsg::JsRegExp>& regex,
     kj::ArrayPtr<const kj::String> nameList,
     kj::StringPtr input) {
-  using Groups = jsg::Dict<kj::String, kj::String>;
-
   KJ_IF_SOME(array, regex.getHandle(js)(js, input)) {
     // Starting at 1 here looks a bit odd but it is intentional. The result of the regex
     // is an array and we're skipping the first element.
     uint32_t index = 1;
     uint32_t length = array.size();
-    kj::Vector<Groups::Field> fields(length - 1);
-
+    jsg::Dict<kj::String> dict{};
+    dict.fields.reserve(length - 1);
     while (index < length) {
       auto value = array.get(js, index);
-      fields.add(Groups::Field{
-        .name = kj::str(nameList[index - 1]),
-        .value = value.isUndefined() ? kj::str() : kj::str(value),
-      });
+      dict.fields.insert(
+          kj::str(nameList[index - 1]), value.isUndefined() ? kj::String() : kj::str(value));
       index++;
     }
 
     return URLPattern::URLPatternComponentResult{
       .input = kj::str(input),
-      .groups = Groups{.fields = fields.releaseAsArray()},
+      .groups = kj::mv(dict),
     };
   }
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1636,7 +1636,7 @@ Worker::Worker(kj::Own<const Script> scriptParam,
                         obj.env = lock.v8Ref(bindingsScope.As<v8::Value>());
                         obj.ctx = jsg::alloc<api::ExecutionContext>();
 
-                        impl->namedHandlers.insert(kj::mv(handler.name), kj::mv(obj));
+                        impl->namedHandlers.insert(kj::mv(handler.key), kj::mv(obj));
                       }
                       KJ_CASE_ONEOF(cls, EntrypointClass) {
                         js.withinHandleScope([&]() {
@@ -1644,18 +1644,18 @@ Worker::Worker(kj::Own<const Script> scriptParam,
 
                           for (;;) {
                             if (handle == entrypointClasses.durableObject) {
-                              impl->actorClasses.insert(kj::mv(handler.name),
+                              impl->actorClasses.insert(kj::mv(handler.key),
                                   Impl::ActorClassInfo{
                                     .cls = kj::mv(cls),
                                     .missingSuperclass = false,
                                   });
                               return;
                             } else if (handle == entrypointClasses.workerEntrypoint) {
-                              impl->statelessClasses.insert(kj::mv(handler.name), kj::mv(cls));
+                              impl->statelessClasses.insert(kj::mv(handler.key), kj::mv(cls));
                               return;
                             } else if (handle == entrypointClasses.workflow) {
                               if (features.getWorkerdExperimental()) {
-                                impl->statelessClasses.insert(kj::mv(handler.name), kj::mv(cls));
+                                impl->statelessClasses.insert(kj::mv(handler.key), kj::mv(cls));
                               }
                               return;
                             }
@@ -1667,7 +1667,7 @@ Worker::Worker(kj::Own<const Script> scriptParam,
                               // class if it doesn't inherit anything.
                               // TODO(someday): Log a warning suggesting extending DurableObject.
                               // TODO(someday): Introduce a compat flag that makes this required.
-                              impl->actorClasses.insert(kj::mv(handler.name),
+                              impl->actorClasses.insert(kj::mv(handler.key),
                                   Impl::ActorClassInfo{
                                     .cls = kj::mv(cls),
                                     .missingSuperclass = true,
@@ -2125,8 +2125,8 @@ void Worker::Lock::validateHandlers(ValidationErrorReporter& errorReporter) {
         auto dict = js.toDict(handle);
         bool empty = true;
         for (auto& field: dict.fields) {
-          if (!ignoredHandlers.contains(field.name)) {
-            errorReporter.addHandler(name, field.name);
+          if (!ignoredHandlers.contains(field.key)) {
+            errorReporter.addHandler(name, field.key);
             empty = false;
           }
         }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1038,24 +1038,11 @@ public:
 // Note: A Dict<V, K> corresponds to a record<K, V> in the Web IDL language.
 template <typename Value, typename Key = kj::String>
 struct Dict {
-  // TODO(someday): Maybe make this a map and not an array? Current use case doesn't care, though.
-
-  // Field of an object.
-  struct Field {
-    Key name;
-    Value value;
-
-    JSG_MEMORY_INFO(Field) {
-      tracker.trackField("name", name);
-      tracker.trackField("value", value);
-    }
-  };
-
-  kj::Array<Field> fields;
+  kj::HashMap<Key, Value> fields;
 
   JSG_MEMORY_INFO(Dict) {
     for (const auto& field: fields) {
-      tracker.trackField(nullptr, field);
+      tracker.trackField(field.key, field.value);
     }
   }
 };

--- a/src/workerd/jsg/value-test.c++
+++ b/src/workerd/jsg/value-test.c++
@@ -348,18 +348,19 @@ KJ_TEST("OneOf") {
 struct DictContext: public ContextGlobalObject {
   kj::String takeDict(Dict<Ref<NumberBox>> dict) {
     return kj::strArray(
-        KJ_MAP(f, dict.fields) { return kj::str(f.name, ": ", f.value->value); }, ", ");
+        KJ_MAP(f, dict.fields) { return kj::str(f.key, ": ", f.value->value); }, ", ");
   }
   kj::String takeDictOfFunctions(Lock& js, Dict<Function<int()>> dict) {
     return kj::strArray(
-        KJ_MAP(f, dict.fields) { return kj::str(f.name, ": ", f.value(js)); }, ", ");
+        KJ_MAP(f, dict.fields) { return kj::str(f.key, ": ", f.value(js)); }, ", ");
   }
   Dict<Ref<NumberBox>> returnDict() {
-    auto builder = kj::heapArrayBuilder<Dict<Ref<NumberBox>>::Field>(3);
-    builder.add(Dict<Ref<NumberBox>>::Field{kj::str("foo"), jsg::alloc<NumberBox>(123)});
-    builder.add(Dict<Ref<NumberBox>>::Field{kj::str("bar"), jsg::alloc<NumberBox>(456)});
-    builder.add(Dict<Ref<NumberBox>>::Field{kj::str("baz"), jsg::alloc<NumberBox>(789)});
-    return {builder.finish()};
+    auto dict = Dict<Ref<NumberBox>>();
+    dict.fields.reserve(3);
+    dict.fields.insert(kj::str("foo"), jsg::alloc<NumberBox>(123));
+    dict.fields.insert(kj::str("bar"), jsg::alloc<NumberBox>(456));
+    dict.fields.insert(kj::str("baz"), jsg::alloc<NumberBox>(789));
+    return dict;
   }
 
   JSG_RESOURCE_TYPE(DictContext) {


### PR DESCRIPTION
Replaces jsg::dict internals to use kj::HashMap instead of kj::Array.