### PR TITLE
[nfc] wd_capnp_library: support dependency on json.capnp

### DIFF
--- a/build/wd_capnp_library.bzl
+++ b/build/wd_capnp_library.bzl
@@ -15,10 +15,13 @@ def wd_capnp_library(
     """
     base_name = src.removesuffix(".capnp")
 
+    # json.capnp is available implicitly for c++ targets
+    cc_deps = [dep for dep in deps if dep != "@capnp-cpp//src/capnp/compat:json_capnp"]
+
     wd_cc_capnp_library(
         name = base_name + "_capnp",
         visibility = visibility,
-        deps = deps,
+        deps = cc_deps,
         srcs = [src],
         tags = ["manual"] + tags,
         target_compatible_with = target_compatible_with,


### PR DESCRIPTION
It is special and its c++ version is not built but checked into the vcs. It is implicitly available to c++ targets, but needs be built for rust.