### PR TITLE
Fix URL bugs found by fuzzing

### DIFF
--- a/src/workerd/jsg/url.c++
+++ b/src/workerd/jsg/url.c++
@@ -2056,6 +2056,9 @@ UrlPattern::Result<UrlPattern::Init> UrlPattern::processInit(
         chooseStr(kj::mv(init.protocol), options.protocol).map([](kj::String&& str) mutable {
       // It's silly but the URL spec always includes the : suffix in the value,
       // while the URLPattern spec always omits it. Silly specs.
+      if (!str.size()) {
+        return kj::mv(str);
+      }
       return stripSuffixFromProtocol(str.asPtr());
     })) {
       result.protocol = kj::mv(protocol);

--- a/src/workerd/jsg/url.c++
+++ b/src/workerd/jsg/url.c++
@@ -614,8 +614,10 @@ kj::Maybe<kj::String> canonicalizeOpaquePathname(
   // @see https://wicg.github.io/urlpattern/#canonicalize-an-opaque-pathname
   if (pathname.size() == 0) return kj::str();
   auto str = kj::str("fake:", pathname);
-  auto url = KJ_ASSERT_NONNULL(Url::tryParse(str.asPtr()));
-  return kj::str(url.getPathname());
+  KJ_IF_SOME(url, Url::tryParse(str.asPtr())) {
+    return kj::str(url.getPathname());
+  }
+  return kj::none;
 }
 
 kj::Maybe<kj::String> canonicalizeSearch(
@@ -2151,8 +2153,7 @@ UrlPattern::Result<UrlPattern::Init> UrlPattern::processInit(
         auto str = kj::str(protocol, "://fake-url");
         return KJ_ASSERT_NONNULL(Url::tryParse(str.asPtr()));
       } else {
-        auto str = kj::str("fake://fake-url");
-        return KJ_ASSERT_NONNULL(Url::tryParse(str.asPtr()));
+        return KJ_ASSERT_NONNULL(Url::tryParse("fake://fake-url"_kj));
       }
     }
   })();


### PR DESCRIPTION
Fix minor buffer overflow in url.c++
When the protocol string is empty, we should not try to drop a trailing colon. This was found by using a new fuzzer for URL-related APIs.

Fix URL assertion failure found by fuzzing
This aligns canonicalizeOpaquePathname() with the other canonicalize functions.
Also elides a superfluous memory allocation.

Also see the upstream draft PR.