### PR TITLE
add memory tracking to workerd::mimetype

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -98,6 +98,7 @@ wd_cc_library(
         "pyodide/pyodide.h",
         "//src/pyodide:generated/pyodide_extra.capnp.h",
     ],
+    implementation_deps = ["//src/workerd/util:string-buffer"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/pyodide",
@@ -125,6 +126,7 @@ wd_cc_library(
     deps = [
         "//src/workerd/jsg",
         "//src/workerd/util",
+        "//src/workerd/util:mimetype",
         "@capnp-cpp//src/kj",
     ],
 )
@@ -154,6 +156,7 @@ wd_cc_library(
     deps = [
         "//src/workerd/jsg:url",
         "//src/workerd/util",
+        "//src/workerd/util:mimetype",
         "@capnp-cpp//src/kj",
     ],
 )

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -56,6 +56,7 @@ wd_cc_library(
     deps = [
         "//src/workerd/io:compatibility-date_capnp",
         "//src/workerd/jsg",
+        "//src/workerd/util:mimetype",
     ],
 )
 

--- a/src/workerd/api/node/util.h
+++ b/src/workerd/api/node/util.h
@@ -88,7 +88,7 @@ private:
 
 class MIMEType final: public jsg::Object {
 public:
-  MIMEType(MimeType inner);
+  explicit MIMEType(MimeType inner);
   ~MIMEType() noexcept(false);
   static jsg::Ref<MIMEType> constructor(kj::String input);
 
@@ -107,12 +107,6 @@ public:
     JSG_READONLY_PROTOTYPE_PROPERTY(params, getParams);
     JSG_METHOD(toString);
     JSG_METHOD_NAMED(toJSON, toString);
-  }
-
-  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
-    // TODO(cleanup): Better to have jsg::MimeType be a MemoryRetainer directly
-    tracker.trackFieldWithSize("mimeType", inner.toString().size());
-    tracker.trackField("params", params);
   }
 
 private:

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -74,6 +74,7 @@ wd_cc_library(
     }),
     implementation_deps = [
         "//src/workerd/util:perfetto",
+        "//src/workerd/util:string-buffer",
         "@capnp-cpp//src/kj/compat:kj-brotli",
         "@capnp-cpp//src/kj/compat:kj-gzip",
         "@nbytes",

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -44,7 +44,7 @@ wd_cc_benchmark(
     name = "bench-mimetype",
     srcs = ["bench-mimetype.c++"],
     deps = [
-        "//src/workerd/util",
+        "//src/workerd/util:mimetype",
     ],
 )
 

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -29,7 +29,6 @@ wd_cc_library(
 wd_cc_library(
     name = "util",
     srcs = [
-        "mimetype.c++",
         "stream-utils.c++",
         "wait-list.c++",
     ],
@@ -43,10 +42,7 @@ wd_cc_library(
         "color-util.h",
         "duration-exceeded-logger.h",
         "http-util.h",
-        "mimetype.h",
         "stream-utils.h",
-        "string-buffer.h",
-        "strings.h",
         "uncaught-exception-source.h",
         "wait-list.h",
         "weak-refs.h",
@@ -57,6 +53,36 @@ wd_cc_library(
         "@capnp-cpp//src/kj",
         "@capnp-cpp//src/kj:kj-async",
     ],
+)
+
+wd_cc_library(
+    name = "mimetype",
+    srcs = ["mimetype.c++"],
+    hdrs = ["mimetype.h"],
+    implementation_deps = [
+        ":string-buffer",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/workerd/jsg:memory-tracker",
+        "@capnp-cpp//src/kj",
+        "@capnp-cpp//src/kj:kj-async",
+    ],
+)
+
+wd_cc_library(
+    name = "strings",
+    srcs = [],
+    hdrs = ["strings.h"],
+    visibility = ["//visibility:public"],
+    deps = [],
+)
+
+wd_cc_library(
+    name = "string-buffer",
+    hdrs = ["string-buffer.h"],
+    visibility = ["//visibility:public"],
+    deps = [":strings"],
 )
 
 wd_cc_library(
@@ -184,12 +210,24 @@ exports_files(["autogate.h"])
     )
     for f in [
         "batch-queue-test.c++",
-        "mimetype-test.c++",
         "wait-list-test.c++",
         "duration-exceeded-logger-test.c++",
-        "string-buffer-test.c++",
     ]
 ]
+
+kj_test(
+    src = "string-buffer-test.c++",
+    deps = [
+        ":string-buffer",
+    ],
+)
+
+kj_test(
+    src = "mimetype-test.c++",
+    deps = [
+        ":mimetype",
+    ],
+)
 
 kj_test(
     src = "sqlite-test.c++",

--- a/src/workerd/util/mimetype.h
+++ b/src/workerd/util/mimetype.h
@@ -3,6 +3,8 @@
 //     https://opensource.org/licenses/Apache-2.0
 #pragma once
 
+#include <workerd/jsg/memory.h>
+
 #include <kj/common.h>
 #include <kj/exception.h>
 #include <kj/map.h>
@@ -101,6 +103,12 @@ public:
   // per the algorithm defined in the fetch spec:
   // https://fetch.spec.whatwg.org/#concept-header-extract-mime-type
   static kj::Maybe<MimeType> extract(kj::StringPtr input);
+
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackFieldWithSize("type", type_.size());
+    tracker.trackFieldWithSize("subtype", subtype_.size());
+    tracker.trackFieldWithSize("params", params_.size());
+  }
 
 private:
   kj::String type_;


### PR DESCRIPTION
Adds memory tracking to mimetype and separates several cc libraries to improve build (which is required)