### PR TITLE
Support ndjson-format for insert & upsert ops in vectorize api

### DIFF
--- a/src/cloudflare/internal/vectorize-api.ts
+++ b/src/cloudflare/internal/vectorize-api.ts
@@ -18,7 +18,7 @@ enum Operation {
 
 type VectorizeVersion = 'v1' | 'v2';
 
-function toNdJson(arr: object[]) {
+function toNdJson(arr: object[]): string {
   return arr.reduce((acc, o) => acc + JSON.stringify(o) + '\n', '').trim();
 }
 
@@ -33,7 +33,7 @@ class VectorizeIndexImpl implements Vectorize {
     private readonly indexId: string,
     private readonly indexVersion: VectorizeVersion,
     private readonly useNdJson: boolean
-  ) { }
+  ) {}
 
   public async describe(): Promise<VectorizeIndexInfo> {
     const endpoint =
@@ -121,7 +121,7 @@ class VectorizeIndexImpl implements Vectorize {
       this.indexVersion === 'v2'
         ? `insert`
         : `binding/indexes/${this.indexId}/insert`;
-    let bodyVecArr = vectors.map((vec) => ({
+    const bodyVecArr = vectors.map((vec) => ({
       ...vec,
       values: Array.isArray(vec.values) ? vec.values : Array.from(vec.values),
     }));
@@ -235,9 +235,10 @@ class VectorizeIndexImpl implements Vectorize {
       try {
         const errResponse = (await res.json()) as VectorizeError;
         err = new Error(
-          `${Operation[operation]}_ERROR${typeof errResponse.code === 'number'
-            ? ` (code = ${errResponse.code})`
-            : ''
+          `${Operation[operation]}_ERROR${
+            typeof errResponse.code === 'number'
+              ? ` (code = ${errResponse.code})`
+              : ''
           }: ${errResponse.error}`,
           {
             cause: new Error(errResponse.error),
@@ -277,9 +278,10 @@ async function toJson<T = unknown>(response: Response): Promise<T> {
     return JSON.parse(body) as T;
   } catch {
     throw new Error(
-      `Failed to parse body as JSON, got: ${body.length > maxBodyLogChars
-        ? `${body.slice(0, maxBodyLogChars)}…`
-        : body
+      `Failed to parse body as JSON, got: ${
+        body.length > maxBodyLogChars
+          ? `${body.slice(0, maxBodyLogChars)}…`
+          : body
       }`
     );
   }

--- a/src/cloudflare/internal/vectorize-api.ts
+++ b/src/cloudflare/internal/vectorize-api.ts
@@ -18,6 +18,10 @@ enum Operation {
 
 type VectorizeVersion = 'v1' | 'v2';
 
+function toNdJson(arr: object[]) {
+  return arr.map((o) => JSON.stringify(o)).join('\n');
+}
+
 /*
  * The Vectorize beta VectorizeIndex shares the same methods, so to keep things simple, they share one implementation.
  * The types here are specific to Vectorize GA, but the types here don't actually matter as they are stripped away
@@ -27,7 +31,8 @@ class VectorizeIndexImpl implements Vectorize {
   public constructor(
     private readonly fetcher: Fetcher,
     private readonly indexId: string,
-    private readonly indexVersion: VectorizeVersion
+    private readonly indexVersion: VectorizeVersion,
+    private readonly useNdJson: boolean
   ) {}
 
   public async describe(): Promise<VectorizeIndexInfo> {
@@ -116,18 +121,24 @@ class VectorizeIndexImpl implements Vectorize {
       this.indexVersion === 'v2'
         ? `insert`
         : `binding/indexes/${this.indexId}/insert`;
+    let bodyVecArr = vectors.map((vec) => ({
+      ...vec,
+      values: Array.isArray(vec.values) ? vec.values : Array.from(vec.values),
+    }));
+
+    const body = this.useNdJson
+      ? toNdJson(bodyVecArr)
+      : JSON.stringify({ vectors: bodyVecArr });
+
+    const contentType = this.useNdJson
+      ? 'application/x-ndjson'
+      : 'application/json';
+
     const res = await this._send(Operation.VECTOR_INSERT, endpoint, {
       method: 'POST',
-      body: JSON.stringify({
-        vectors: vectors.map((vec) => ({
-          ...vec,
-          values: Array.isArray(vec.values)
-            ? vec.values
-            : Array.from(vec.values),
-        })),
-      }),
+      body,
       headers: {
-        'content-type': 'application/json',
+        'content-type': contentType,
         'cf-vector-search-dim-width': String(
           vectors.length ? vectors[0]?.values?.length : 0
         ),
@@ -146,18 +157,24 @@ class VectorizeIndexImpl implements Vectorize {
       this.indexVersion === 'v2'
         ? `upsert`
         : `binding/indexes/${this.indexId}/upsert`;
+    const bodyVecArr = vectors.map((vec) => ({
+      ...vec,
+      values: Array.isArray(vec.values) ? vec.values : Array.from(vec.values),
+    }));
+
+    const body = this.useNdJson
+      ? toNdJson(bodyVecArr)
+      : JSON.stringify({ vectors: bodyVecArr });
+
+    const contentType = this.useNdJson
+      ? 'application/x-ndjson'
+      : 'application/json';
+
     const res = await this._send(Operation.VECTOR_UPSERT, endpoint, {
       method: 'POST',
-      body: JSON.stringify({
-        vectors: vectors.map((vec) => ({
-          ...vec,
-          values: Array.isArray(vec.values)
-            ? vec.values
-            : Array.from(vec.values),
-        })),
-      }),
+      body,
       headers: {
-        'content-type': 'application/json',
+        'content-type': contentType,
         'cf-vector-search-dim-width': String(
           vectors.length ? vectors[0]?.values?.length : 0
         ),
@@ -274,11 +291,13 @@ export function makeBinding(env: {
   fetcher: Fetcher;
   indexId: string;
   indexVersion?: VectorizeVersion;
+  useNdJson?: boolean;
 }): Vectorize {
   return new VectorizeIndexImpl(
     env.fetcher,
     env.indexId,
-    env.indexVersion ?? 'v1'
+    env.indexVersion ?? 'v1',
+    env.useNdJson ?? false
   );
 }
 

--- a/src/cloudflare/internal/vectorize-api.ts
+++ b/src/cloudflare/internal/vectorize-api.ts
@@ -19,7 +19,7 @@ enum Operation {
 type VectorizeVersion = 'v1' | 'v2';
 
 function toNdJson(arr: object[]) {
-  return arr.map((o) => JSON.stringify(o)).join('\n');
+  return arr.reduce((acc, o) => acc + JSON.stringify(o) + '\n', '').trim();
 }
 
 /*
@@ -33,7 +33,7 @@ class VectorizeIndexImpl implements Vectorize {
     private readonly indexId: string,
     private readonly indexVersion: VectorizeVersion,
     private readonly useNdJson: boolean
-  ) {}
+  ) { }
 
   public async describe(): Promise<VectorizeIndexInfo> {
     const endpoint =
@@ -235,10 +235,9 @@ class VectorizeIndexImpl implements Vectorize {
       try {
         const errResponse = (await res.json()) as VectorizeError;
         err = new Error(
-          `${Operation[operation]}_ERROR${
-            typeof errResponse.code === 'number'
-              ? ` (code = ${errResponse.code})`
-              : ''
+          `${Operation[operation]}_ERROR${typeof errResponse.code === 'number'
+            ? ` (code = ${errResponse.code})`
+            : ''
           }: ${errResponse.error}`,
           {
             cause: new Error(errResponse.error),
@@ -278,10 +277,9 @@ async function toJson<T = unknown>(response: Response): Promise<T> {
     return JSON.parse(body) as T;
   } catch {
     throw new Error(
-      `Failed to parse body as JSON, got: ${
-        body.length > maxBodyLogChars
-          ? `${body.slice(0, maxBodyLogChars)}…`
-          : body
+      `Failed to parse body as JSON, got: ${body.length > maxBodyLogChars
+        ? `${body.slice(0, maxBodyLogChars)}…`
+        : body
       }`
     );
   }


### PR DESCRIPTION
In order to support local bindings in miniflare, we have to send requests through the core Vectorize service. This service requires input for `/insert` and `/upsert` operations to be in ndjson format. This PR adds an initialization option that optionally tells the binding to put the input to these operations in ndjson. Existing behavior should be identical. 