### PR TITLE
add node:sys to comply with nodejs_compat

### DIFF
--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -190,6 +190,12 @@ wd_test(
 )
 
 wd_test(
+    src = "tests/sys-nodejs-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/sys-nodejs-test.js"],
+)
+
+wd_test(
     size = "large",
     src = "tests/zlib-nodejs-test.wd-test",
     args = ["--experimental"],

--- a/src/workerd/api/node/tests/sys-nodejs-test.js
+++ b/src/workerd/api/node/tests/sys-nodejs-test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert';
+import module from 'node:module';
+
+export const getBuiltinModule = {
+  async test() {
+    assert.deepStrictEqual(
+      process.getBuiltinModule('node:sys'),
+      process.getBuiltinModule('node:util')
+    );
+  },
+};
+
+export const canBeRequired = {
+  async test() {
+    const require = module.createRequire('/hello');
+    assert.deepStrictEqual(require('node:sys'), require('node:util'));
+    assert.deepStrictEqual(require('sys'), require('node:util'));
+  },
+};
+
+export const canBeImported = {
+  async test() {
+    const sys = await import('node:sys');
+    const util = await import('node:util');
+    assert.deepStrictEqual(sys, util);
+  },
+};

--- a/src/workerd/api/node/tests/sys-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/sys-nodejs-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "nodejs-sys-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "sys-nodejs-test.js")
+        ],
+        compatibilityDate = "2024-09-23",
+        compatibilityFlags = ["nodejs_compat"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -708,6 +708,14 @@ static const std::set<kj::StringPtr> NODEJS_BUILTINS{"_http_agent"_kj, "_http_cl
 }  // namespace
 
 kj::Maybe<kj::String> checkNodeSpecifier(kj::StringPtr specifier) {
+  // The sys module was renamed to 'util'. This shim remains to keep old programs
+  // working. `sys` is deprecated and shouldn't be used.
+  // Note to maintainers: Although this module has been deprecated for a while
+  // Node.js do not plan to remove it.
+  // See: https://github.com/nodejs/node/pull/35407#issuecomment-700693439
+  if (specifier == "sys" || specifier == "node:sys") [[unlikely]] {
+    return kj::str("node:util");
+  }
   if (NODEJS_BUILTINS.contains(specifier)) {
     return kj::str("node:", specifier);
   } else if (specifier.startsWith("node:")) {


### PR DESCRIPTION
Even though it is deprecated, there are people depending on `node:sys`. Still...

@IgorMinar as requested on https://github.com/orgs/cloudflare/projects/24/views/1?pane=issue&itemId=65484840