### PR TITLE
add const & constexpr to dom-exception related functions

### DIFF
--- a/src/workerd/jsg/dom-exception.c++
+++ b/src/workerd/jsg/dom-exception.c++
@@ -40,15 +40,15 @@ Ref<DOMException> DOMException::constructor(const v8::FunctionCallbackInfo<v8::V
       kj::mv(errMessage), kj::mv(name).orDefault([] { return kj::str("Error"); }));
 }
 
-kj::StringPtr DOMException::getName() {
+kj::StringPtr DOMException::getName() const {
   return name;
 }
 
-kj::StringPtr DOMException::getMessage() {
+kj::StringPtr DOMException::getMessage() const {
   return message;
 }
 
-int DOMException::getCode() {
+int DOMException::getCode() const {
   static const std::map<kj::StringPtr, int> legacyCodes{
 #define MAP_ENTRY(name, code, friendlyName) {friendlyName, code},
     JSG_DOM_EXCEPTION_FOR_EACH_ERROR_NAME(MAP_ENTRY)
@@ -101,8 +101,9 @@ jsg::Ref<DOMException> DOMException::deserialize(
           KJ_ASSERT_NONNULL(errorForStack.get(js, "stack").tryCast<JsString>()).toString(js);
       return js.domException(kj::mv(message), kj::mv(name), kj::mv(stack));
     }
+    default:
+      KJ_UNREACHABLE;
   }
-  KJ_UNREACHABLE;
 }
 
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/dom-exception.h
+++ b/src/workerd/jsg/dom-exception.h
@@ -51,9 +51,9 @@ public:
       Optional<kj::String> message,
       Optional<kj::String> name);
 
-  kj::StringPtr getName();
-  kj::StringPtr getMessage();
-  int getCode();
+  kj::StringPtr getName() const;
+  kj::StringPtr getMessage() const;
+  int getCode() const;
 
 #define JSG_DOM_EXCEPTION_CONSTANT_CXX(name, code, friendlyName) static constexpr int name = code;
 #define JSG_DOM_EXCEPTION_CONSTANT_JS(name, code, friendlyName) JSG_STATIC_CONSTANT(name);
@@ -95,8 +95,8 @@ public:
   // depend on directly here because we cannot introduce the dependency into JSG.
   // Therefore we have to set it manually. A better solution long term is to actually
   // move DOMException into workerd/api, but we'll do that separately.
-  static const uint SERIALIZATION_TAG = 7;
-  static const uint SERIALIZATION_TAG_V2 = 8;
+  static constexpr uint SERIALIZATION_TAG = 7;
+  static constexpr uint SERIALIZATION_TAG_V2 = 8;
   JSG_SERIALIZABLE(SERIALIZATION_TAG_V2, SERIALIZATION_TAG);
 
   void serialize(jsg::Lock& js, jsg::Serializer& serializer);


### PR DESCRIPTION
Fixing some clang-tidy recommendatons.