### PR TITLE
Implement process.exit(...) in the runtime

### DIFF
--- a/src/node/internal/process.ts
+++ b/src/node/internal/process.ts
@@ -88,8 +88,13 @@ export function getBuiltinModule(id: string): any {
   return utilImpl.getBuiltinModule(id);
 }
 
+export function exit(code: number) {
+  utilImpl.processExitImpl(code);
+}
+
 export default {
   nextTick,
   env,
+  exit,
   getBuiltinModule,
 };

--- a/src/node/internal/util.d.ts
+++ b/src/node/internal/util.d.ts
@@ -122,3 +122,4 @@ export function isBoxedPrimitive(
 
 export function getBuiltinModule(id: string): any;
 export function getCallSite(frames: number): Record<string, string>[];
+export function processExitImpl(code: number): void;

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -54,6 +54,7 @@ wd_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/workerd/io",
         "//src/workerd/io:compatibility-date_capnp",
         "//src/workerd/jsg",
         "//src/workerd/util:mimetype",
@@ -206,4 +207,10 @@ wd_test(
     src = "tests/module-create-require-test.wd-test",
     args = ["--experimental"],
     data = ["tests/module-create-require-test.js"],
+)
+
+wd_test(
+    src = "tests/process-exit-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/process-exit-test.js"],
 )

--- a/src/workerd/api/node/tests/process-exit-test.js
+++ b/src/workerd/api/node/tests/process-exit-test.js
@@ -1,0 +1,63 @@
+import { fail, ok, rejects, strictEqual } from 'assert';
+
+let called = false;
+
+process.exit(9999);
+
+export const test = {
+  async test(_, env) {
+    // We don't really have a way to verifying that the correct log messages
+    // we emitted. For now, we need to manually check the log out, and here
+    // we check only that we received an internal error and that no other
+    // lines of code ran after the process.exit call.
+    await rejects(env.subrequest.fetch('http://example.org'), {
+      message: /^The Node.js process.exit/,
+    });
+    ok(!called);
+  },
+};
+
+let fooCreateCount = 0;
+
+export const test2 = {
+  async test(_, env) {
+    // We don't really have a way to verifying that the correct log messages
+    // we emitted. For now, we need to manually check the log out, and here
+    // we check only that we received an internal error and that no other
+    // lines of code ran after the process.exit call.
+    {
+      const obj = env.foo.get(
+        env.foo.idFromName('210bd0cbd803ef7883a1ee9d86cce06f')
+      );
+      await rejects(obj.fetch('http://example.org'), {
+        message: /^The Node.js process.exit/,
+      });
+      await rejects(obj.fetch('http://example.org'), {
+        message: /^The Node.js process.exit/,
+      });
+      // The durable object should have been created twice.
+      strictEqual(fooCreateCount, 2);
+    }
+  },
+};
+
+export default {
+  async fetch() {
+    try {
+      process.exit(123);
+    } finally {
+      called = true;
+    }
+  },
+};
+
+export class Foo {
+  constructor() {
+    fooCreateCount++;
+  }
+
+  fetch() {
+    process.exit(123);
+    fail('Should never get here.');
+  }
+}

--- a/src/workerd/api/node/tests/process-exit-test.wd-test
+++ b/src/workerd/api/node/tests/process-exit-test.wd-test
@@ -1,0 +1,23 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "process-exit-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "process-exit-test.js")
+        ],
+        compatibilityDate = "2024-10-01",
+        compatibilityFlags = ["nodejs_compat"],
+        durableObjectNamespaces = [
+          (className = "Foo", uniqueKey = "210bd0cbd803ef7883a1ee9d86cce06f"),
+        ],
+        durableObjectStorage = (inMemory = void),
+        bindings = [
+          (name = "subrequest", service = "process-exit-test"),
+          (name = "foo", durableObjectNamespace = "Foo"),
+        ]
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/node/util.h
+++ b/src/workerd/api/node/util.h
@@ -216,6 +216,13 @@ public:
 
   jsg::JsValue getBuiltinModule(jsg::Lock& js, kj::String specifier);
 
+  // This is used in the implementation of process.exit(...). Contrary
+  // to what the name suggests, it does not actually exit the process.
+  // Instead, it will cause the IoContext, if any, and will stop javascript
+  // from further executing in that request. If there is no active IoContext,
+  // then it becomes a non-op.
+  void processExitImpl(jsg::Lock& js, int code);
+
   JSG_RESOURCE_TYPE(UtilModule) {
     JSG_NESTED_TYPE(MIMEType);
     JSG_NESTED_TYPE(MIMEParams);
@@ -243,6 +250,7 @@ public:
     JSG_METHOD(isBoxedPrimitive);
 
     JSG_METHOD(getBuiltinModule);
+    JSG_METHOD(processExitImpl);
   }
 };
 

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1089,6 +1089,16 @@ void IoContext::runImpl(Runnable& runnable,
         // Check if we hit a limit.
         limitEnforcer->requireLimitsNotExceeded();
 
+        // If we were terminated because abort() was called, then it's not an unknown
+        // reason...
+        if (!abortFulfiller->isWaiting()) {
+          // Nothing to do here. Do not log anything. The assumption is that we've
+          // terminated because the IoContext was aborted and isolate->TerminateExection()
+          // was called (likely because of someone using process.exit(...) in Node.js
+          // compat mode).
+          return;
+        }
+
         // That should have thrown, so we shouldn't get here.
         KJ_FAIL_ASSERT("script terminated for unknown reasons");
       } else {


### PR DESCRIPTION
An implementation of `process.exit(...)` as part of Node.js compat.

Unlike in Node.js, calling `process.exit(...)` does not actually exit the workerd process, for obvious reasons. Instead, when called within the scope of a request, calling `process.exit(...)` will cause the current IoContext to be aborted and will call `isolate->TerminateExecution()` to prevent further execution of JavaScript while leaving the isolate in a good state to run other requests.

This needs to be evaluated very carefully. The approach is a bit of a hack and there might be a better way of doing this that I'm not seeing. So let's not rush this in.