### PR TITLE
Rename GetPrototype() uses to GetPrototypeV2()

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1802,8 +1802,8 @@ void Worker::handleLog(jsg::Lock& js,
 
           // Determine whether `obj` is constructed using `{}` or `new Object()`. This ensures
           // we don't serialise values like Promises to JSON.
-          if (obj->GetPrototype()->SameValue(freshObj->GetPrototype()) ||
-              obj->GetPrototype()->IsNull()) {
+          if (obj->GetPrototypeV2()->SameValue(freshObj->GetPrototypeV2()) ||
+              obj->GetPrototypeV2()->IsNull()) {
             shouldSerialiseToJson = true;
           }
 

--- a/src/workerd/jsg/ser.c++
+++ b/src/workerd/jsg/ser.c++
@@ -95,7 +95,7 @@ v8::Maybe<bool> Serializer::IsHostObject(v8::Isolate* isolate, v8::Local<v8::Obj
   // to be serialized normally. Otherwise, it is a class instance, which we should treat as a host
   // object. Inside `WriteHostObject()` we will throw DataCloneError due to the object not having
   // internal fields.
-  return v8::Just(object->GetPrototype() != prototypeOfObject);
+  return v8::Just(object->GetPrototypeV2() != prototypeOfObject);
 }
 
 v8::Maybe<bool> Serializer::WriteHostObject(v8::Isolate* isolate, v8::Local<v8::Object> object) {


### PR DESCRIPTION
This is expected to be relatively temporary. V8 is in the process of deprecating and removing the original `GetPrototype()` implementation. Once that original impl is removed, I believe the plan is to rename `GetPrototypeV2()` back to `GetPrototype()`, at which point we'll likely need to change these back. That's ok, we want to make sure there's no issue with updating to the new behavior well in advance of that.