### PR TITLE
Update Workflow class type definition to accept a single event

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -246,6 +246,6 @@ declare module "cloudflare:workers" {
     protected ctx: ExecutionContext;
     protected env: Env;
 
-    run(events: Array<WorkflowEvent<T>>, step: WorkflowStep): Promise<unknown>;
+    run(event: WorkflowEvent<T>, step: WorkflowStep): Promise<unknown>;
   }
 }


### PR DESCRIPTION
We previously passed in an Array of events but have since decided to switch to a single event per Workflow instance. This updates the types. 