### PR TITLE
Use name instead of id for instances in Workflows binding

### DIFF
--- a/src/cloudflare/internal/test/workflows/workflows-api-test.js
+++ b/src/cloudflare/internal/test/workflows/workflows-api-test.js
@@ -9,13 +9,13 @@ export const tests = {
     {
       // Test create instance
       const instance = await env.workflow.create('foo', { bar: 'baz' });
-      assert.deepStrictEqual(instance.id, 'foo');
+      assert.deepStrictEqual(instance.name, 'foo');
     }
 
     {
       // Test get instance
       const instance = await env.workflow.get('bar');
-      assert.deepStrictEqual(instance.id, 'bar');
+      assert.deepStrictEqual(instance.name, 'bar');
     }
   },
 };

--- a/src/cloudflare/internal/test/workflows/workflows-mock.js
+++ b/src/cloudflare/internal/test/workflows/workflows-mock.js
@@ -10,7 +10,8 @@ export default {
       return Response.json(
         {
           result: {
-            instanceId: data.id,
+            instanceId: 'id',
+            instanceName: data.name,
           },
         },
         {
@@ -26,7 +27,8 @@ export default {
       return Response.json(
         {
           result: {
-            instanceId: data.id,
+            instanceId: 'id',
+            instanceName: data.name,
           },
         },
         {

--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -49,9 +49,11 @@ async function callFetcher<T>(
 class InstanceImpl implements Instance {
   private readonly fetcher: Fetcher;
   public readonly id: string;
+  public readonly name: string;
 
-  public constructor(id: string, fetcher: Fetcher) {
+  public constructor(id: string, name: string, fetcher: Fetcher) {
     this.id = id;
+    this.name = name;
     this.fetcher = fetcher;
   }
 
@@ -93,24 +95,30 @@ class WorkflowImpl {
     this.fetcher = fetcher;
   }
 
-  public async get(id: string): Promise<Instance> {
-    const result = await callFetcher<{ instanceId: string }>(
-      this.fetcher,
-      '/get',
-      { id }
-    );
+  public async get(name: string): Promise<Instance> {
+    const result = await callFetcher<{
+      instanceId: string;
+      instanceName: string;
+    }>(this.fetcher, '/get', { name });
 
-    return new InstanceImpl(result.instanceId, this.fetcher);
+    return new InstanceImpl(
+      result.instanceId,
+      result.instanceName,
+      this.fetcher
+    );
   }
 
-  public async create(id: string, params: object): Promise<Instance> {
-    const result = await callFetcher<{ instanceId: string }>(
-      this.fetcher,
-      '/create',
-      { id, params }
-    );
+  public async create(name: string, params: object): Promise<Instance> {
+    const result = await callFetcher<{
+      instanceId: string;
+      instanceName: string;
+    }>(this.fetcher, '/create', { name, params });
 
-    return new InstanceImpl(result.instanceId, this.fetcher);
+    return new InstanceImpl(
+      result.instanceId,
+      result.instanceName,
+      this.fetcher
+    );
   }
 }
 

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -15,18 +15,18 @@ declare module "cloudflare:workflows" {
 declare abstract class Workflow {
   /**
    * Get a handle to an existing instance of the Workflow.
-   * @param id Id for the instance of this Workflow
+   * @param name Name of the instance of this Workflow
    * @returns A promise that resolves with a handle for the Instance
    */
-  public get(id: string): Promise<Instance>;
+  public get(name: string): Promise<Instance>;
 
   /**
-   * Create a new instance and return a handle to it. If a provided id exists, an error will be thrown.
-   * @param id Id to create the instance of this Workflow with
+   * Create a new instance and return a handle to it. If a provided instance name exists, an error will be thrown.
+   * @param name Name to create the instance of this Workflow with
    * @param params The payload to send over to this instance
    * @returns A promise that resolves with a handle for the Instance
    */
-  public create(id: string, params: object): Promise<Instance>;
+  public create(name: string, params: object): Promise<Instance>;
 }
 
 type InstanceStatus = {
@@ -49,6 +49,7 @@ interface WorkflowError {
 
 declare abstract class Instance {
   public id: string;
+  public name: string;
 
   /**
    * Pause the instance.


### PR DESCRIPTION
This is a breaking chance but the binding is currently experimental so that is okay 

The Workflow binding currently accepts an `id` for its create and get functions. We now allow users to pass in a user defined "instance name". This can be used to lookup instances that were previously created. 