### PR TITLE
Rename Workflow to WorkflowEntrypoint

### DIFF
--- a/src/cloudflare/internal/workers.d.ts
+++ b/src/cloudflare/internal/workers.d.ts
@@ -12,7 +12,7 @@ export class WorkerEntrypoint {
   public env: unknown;
 }
 
-export class Workflow {
+export class WorkflowEntrypoint {
   public constructor(ctx: unknown, env: unknown);
 
   public ctx: unknown;

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -11,4 +11,4 @@ export const WorkerEntrypoint = entrypoints.WorkerEntrypoint;
 export const DurableObject = entrypoints.DurableObject;
 export const RpcStub = entrypoints.RpcStub;
 export const RpcTarget = entrypoints.RpcTarget;
-export const Workflow = entrypoints.Workflow;
+export const WorkflowEntrypoint = entrypoints.WorkflowEntrypoint;

--- a/src/node/internal/workers.d.ts
+++ b/src/node/internal/workers.d.ts
@@ -1,6 +1,6 @@
 declare namespace _default {
   class WorkerEntrypoint {}
-  class Workflow {}
+  class WorkflowEntrypoint {}
   class DurableObject {}
   class RpcPromise {}
   class RpcProperty {}

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -1829,7 +1829,8 @@ jsg::Ref<DurableObjectBase> DurableObjectBase::constructor(
   return jsg::alloc<DurableObjectBase>();
 }
 
-jsg::Ref<Workflow> Workflow::constructor(const v8::FunctionCallbackInfo<v8::Value>& args,
+jsg::Ref<WorkflowEntrypoint> WorkflowEntrypoint::constructor(
+    const v8::FunctionCallbackInfo<v8::Value>& args,
     jsg::Ref<ExecutionContext> ctx,
     jsg::JsObject env) {
   // HACK: We take `FunctionCallbackInfo` mostly so that we can set properties directly on
@@ -1840,7 +1841,7 @@ jsg::Ref<Workflow> Workflow::constructor(const v8::FunctionCallbackInfo<v8::Valu
   jsg::JsObject self(args.This());
   self.set(js, "ctx", jsg::JsValue(args[0]));
   self.set(js, "env", jsg::JsValue(args[1]));
-  return jsg::alloc<Workflow>();
+  return jsg::alloc<WorkflowEntrypoint>();
 }
 
 };  // namespace workerd::api

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -497,23 +497,23 @@ public:
 // When the worker's top-level module exports a class that extends this class, it means that it
 // is a Workflow.
 //
-//     import {Workflow} from "cloudflare:workers";
-//     export class MyWorkflow extends Workflow {
+//     import { WorkflowEntrypoint } from "cloudflare:workers";
+//     export class MyWorkflow extends WorkflowEntrypoint {
 //       async run(batch, fns) { ... }
 //     }
 //
 // `env` and `ctx` are automatically available as `this.env` and `this.ctx`, without the need to
 // define a constructor.
-class Workflow: public jsg::Object {
+class WorkflowEntrypoint: public jsg::Object {
 public:
-  static jsg::Ref<Workflow> constructor(const v8::FunctionCallbackInfo<v8::Value>& args,
+  static jsg::Ref<WorkflowEntrypoint> constructor(const v8::FunctionCallbackInfo<v8::Value>& args,
       jsg::Ref<ExecutionContext> ctx,
       jsg::JsObject env);
 
-  JSG_RESOURCE_TYPE(Workflow) {}
+  JSG_RESOURCE_TYPE(WorkflowEntrypoint) {}
 };
 
-// The "cloudflare:workers" module, which exposes the WorkerEntrypoint and DurableObject types
+// The "cloudflare:workers" module, which exposes the WorkerEntrypoint, WorkflowEntrypoint and DurableObject types
 // for extending.
 class EntrypointsModule: public jsg::Object {
 public:
@@ -522,7 +522,7 @@ public:
 
   JSG_RESOURCE_TYPE(EntrypointsModule) {
     JSG_NESTED_TYPE(WorkerEntrypoint);
-    JSG_NESTED_TYPE(Workflow);
+    JSG_NESTED_TYPE(WorkflowEntrypoint);
     JSG_NESTED_TYPE_NAMED(DurableObjectBase, DurableObject);
     JSG_NESTED_TYPE_NAMED(JsRpcPromise, RpcPromise);
     JSG_NESTED_TYPE_NAMED(JsRpcProperty, RpcProperty);
@@ -533,7 +533,7 @@ public:
 
 #define EW_WORKER_RPC_ISOLATE_TYPES                                                                \
   api::JsRpcPromise, api::JsRpcProperty, api::JsRpcStub, api::JsRpcTarget, api::WorkerEntrypoint,  \
-      api::Workflow, api::DurableObjectBase, api::EntrypointsModule
+      api::WorkflowEntrypoint, api::DurableObjectBase, api::EntrypointsModule
 
 template <class Registry>
 void registerRpcModules(Registry& registry, CompatibilityFlags::Reader flags) {

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1681,7 +1681,7 @@ Worker::Worker(kj::Own<const Script> scriptParam,
                             } else if (handle == entrypointClasses.workerEntrypoint) {
                               impl->statelessClasses.insert(kj::mv(handler.name), kj::mv(cls));
                               return;
-                            } else if (handle == entrypointClasses.workflow) {
+                            } else if (handle == entrypointClasses.workflowEntrypoint) {
                               if (features.getWorkerdExperimental()) {
                                 impl->statelessClasses.insert(kj::mv(handler.name), kj::mv(cls));
                               }

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -483,8 +483,8 @@ public:
     // Class constructor for DurableObject (aka api::DurableObjectBase).
     jsg::JsObject durableObject;
 
-    // Class constructor for Workflow.
-    jsg::JsObject workflow;
+    // Class constructor for WorkflowEntrypoint
+    jsg::JsObject workflowEntrypoint;
   };
 
   // Get the constructors for classes from which entrypoint classes may inherit.

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -247,7 +247,7 @@ WorkerdApi::EntrypointClasses WorkerdApi::getEntrypointClasses(jsg::Lock& lock) 
   return {
     .workerEntrypoint = typedLock.getConstructor<api::WorkerEntrypoint>(lock.v8Context()),
     .durableObject = typedLock.getConstructor<api::DurableObjectBase>(lock.v8Context()),
-    .workflow = typedLock.getConstructor<api::Workflow>(lock.v8Context()),
+    .workflowEntrypoint = typedLock.getConstructor<api::WorkflowEntrypoint>(lock.v8Context()),
   };
 }
 const jsg::TypeHandler<Worker::Api::ErrorInterface>& WorkerdApi::getErrorInterfaceTypeHandler(

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -10,7 +10,7 @@ declare namespace Rpc {
   export const __RPC_TARGET_BRAND: "__RPC_TARGET_BRAND";
   export const __WORKER_ENTRYPOINT_BRAND: "__WORKER_ENTRYPOINT_BRAND";
   export const __DURABLE_OBJECT_BRAND: "__DURABLE_OBJECT_BRAND";
-  export const __WORKFLOW_BRAND: "__WORKFLOW_BRAND";
+  export const __WORKFLOW_ENTRYPOINT_BRAND: "__WORKFLOW_ENTRYPOINT_BRAND";
   export interface RpcTargetBranded {
     [__RPC_TARGET_BRAND]: never;
   }
@@ -20,13 +20,13 @@ declare namespace Rpc {
   export interface DurableObjectBranded {
     [__DURABLE_OBJECT_BRAND]: never;
   }
-  export interface WorkflowBranded {
-    [__WORKFLOW_BRAND]: never;
+  export interface WorkflowEntrypointBranded {
+    [__WORKFLOW_ENTRYPOINT_BRAND]: never;
   }
   export type EntrypointBranded =
     | WorkerEntrypointBranded
     | DurableObjectBranded
-    | WorkflowBranded;
+    | WorkflowEntrypointBranded;
 
   // Types that can be used through `Stub`s
   export type Stubable = RpcTargetBranded | ((...args: any[]) => any);
@@ -233,12 +233,12 @@ declare module "cloudflare:workers" {
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
   };
 
-  export abstract class Workflow<
+  export abstract class WorkflowEntrypoint<
     Env = unknown,
     T extends Rpc.Serializable | unknown = unknown,
-  > implements Rpc.WorkflowBranded
+  > implements Rpc.WorkflowEntrypointBranded
   {
-    [Rpc.__WORKFLOW_BRAND]: never;
+    [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
 
     protected ctx: ExecutionContext;
     protected env: Env;


### PR DESCRIPTION
`Workflow` conflicts with the binding class which is also called `Workflow`

Since we have `WorkerEntrypoint`, `WorkflowEntrypoint` feels like a much more appropriate and descriptive name of the base class

This is of course a breaking change, but these are all scoped under `experimental` for now so that is okay