### PR TITLE
Rename abort to terminate in Workflows binding

### DIFF
--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -66,8 +66,8 @@ class InstanceImpl implements Instance {
     });
   }
 
-  public async abort(): Promise<void> {
-    await callFetcher(this.fetcher, '/abort', {
+  public async terminate(): Promise<void> {
+    await callFetcher(this.fetcher, '/terminate', {
       id: this.id,
     });
   }

--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -71,9 +71,9 @@ declare abstract class Instance {
   public resume(): Promise<void>;
 
   /**
-   * Abort the instance. If it is errored, terminated or complete, an error will be thrown.
+   * Terminate the instance. If it is errored, terminated or complete, an error will be thrown.
    */
-  public abort(): Promise<void>;
+  public terminate(): Promise<void>;
 
   /**
    * Restart the instance.


### PR DESCRIPTION
Terminate is more consistent with the rest of our APIs