### PR TITLE
Fix type for Workflows sleep

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -230,10 +230,7 @@ declare module "cloudflare:workers" {
       callback: () => Promise<T>,
       config?: WorkflowStepConfig
     ) => Promise<T>;
-    sleep: (
-      name: string,
-      duration: WorkflowSleepDuration
-    ) => void | Promise<void>;
+    sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
   };
 
   export abstract class Workflow<


### PR DESCRIPTION
It is currently `Promise<void> | void` which is incorrect because it _always_ returns a thenable