### PR TITLE
Make callback the last arg for Workflow do

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -225,11 +225,22 @@ declare module "cloudflare:workers" {
   };
 
   export type WorkflowStep = {
-    do: <T extends Rpc.Serializable>(
-      name: string,
-      callback: () => Promise<T>,
-      config?: WorkflowStepConfig
-    ) => Promise<T>;
+    do:
+      | (<T extends Rpc.Serializable>(
+          name: string,
+          callback: () => Promise<T>
+        ) => Promise<T>)
+      | (<T extends Rpc.Serializable>(
+          name: string,
+          config: WorkflowStepConfig,
+          callback: () => Promise<T>
+        ) => Promise<T>)
+      | (<T extends Rpc.Serializable>(
+          name: string,
+          config: WorkflowStepConfig | (() => Promise<T>),
+          callback?: () => Promise<T>
+        ) => Promise<T>);
+
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
   };
 


### PR DESCRIPTION
The callback is now always the last argument with an optional `config` as second argument. This allows users to do: 

```
step.do('does not truncate', async () => {
    return event.payload.char.repeat(900);
}),

step.do(
    'does truncate',
    {
        retries: {
            limit: 5,
            backoff: 'constant',
            delay: '1 second',
        },
    },
    async () => {
        return event.payload.char.repeat(2000);
    }
),
```

