### PR TITLE
[build] fix lld linker path^3

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -320,7 +320,7 @@ build:release_macos --linkopt="-Wl,-no_function_starts"
 # significantly decreases binary sizes. We could use Xcode 16's -Wl,-deduplicate option instead, but
 # LLD's ICF appears to be superior. We also want to enable ICF for Linux, but there it causes
 # warnings when dynamically linking with libc++.
-build:macos_lld --linkopt=-fuse-ld=lld --linkopt=--ld-path=ld64.lld
+build:macos_lld --linkopt=-fuse-ld=lld --linkopt=--ld-path=/usr/local/bin/ld64.lld
 build:macos_lld_icf --config=macos_lld
 build:macos_lld_icf --linkopt="-Wl,--icf=safe"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,9 +96,10 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           sudo xcode-select -s "/Applications/Xcode_15.1.app"
-          # Install lld and link it to /usr/local/bin.
+          # Install lld and link it to /usr/local/bin. We overwrite any existing link, which may
+          # exist from an older pre-installed LLVM version on the runner image.
           brew install lld
-          sudo ln -s $HOMEBREW_PREFIX/bin/ld64.lld /usr/local/bin/ld64.lld
+          sudo ln -s -f $(brew --prefix lld)/bin/ld64.lld /usr/local/bin/ld64.lld
           # Enable lld identical code folding to significantly reduce binary size.
           echo "build:macos --config=macos_lld_icf" >> .bazelrc
       - name: Setup Windows


### PR DESCRIPTION
Trying to get bazel to use LLD is turning into groundhog day, I'm not yet ready to give up though.

- This should work – tested the new approach on c9f1b4ac136c3373d7afe1f9674a1dc5978f4c16 by emulating the steps needed for release in the test job and matching the image used for release (macos-13), CI completed successfully.