### PR TITLE
add remaining node:buffer methods

### DIFF
--- a/src/node/buffer.ts
+++ b/src/node/buffer.ts
@@ -11,6 +11,8 @@ import {
   isAscii,
   isUtf8,
   transcode,
+  INSPECT_MAX_BYTES,
+  resolveObjectURL,
 } from 'node-internal:internal_buffer';
 
 const atob = globalThis.atob;
@@ -31,6 +33,8 @@ export {
   isAscii,
   isUtf8,
   transcode,
+  INSPECT_MAX_BYTES,
+  resolveObjectURL,
 };
 
 export default {
@@ -46,4 +50,6 @@ export default {
   isAscii,
   isUtf8,
   transcode,
+  INSPECT_MAX_BYTES,
+  resolveObjectURL,
 };

--- a/src/node/internal/internal_buffer.ts
+++ b/src/node/internal/internal_buffer.ts
@@ -64,7 +64,9 @@ const customInspectSymbol =
     ? Symbol['for']('nodejs.util.inspect.custom')
     : null;
 
-const INSPECT_MAX_BYTES = 50;
+// One difference between Node.js and workerd is that, workerd
+// doesn't expose a setter for this, whereas Node.js does.
+export const INSPECT_MAX_BYTES = 50;
 
 export const constants = {
   MAX_LENGTH: kMaxLength,
@@ -2691,6 +2693,10 @@ export function transcode(
   );
 }
 
+export function resolveObjectURL(_id: string): unknown {
+  throw new Error('resolveObjectURL is not implemented');
+}
+
 export default {
   Buffer,
   constants,
@@ -2699,4 +2705,7 @@ export default {
   SlowBuffer,
   isAscii,
   isUtf8,
+  INSPECT_MAX_BYTES,
+  transcode,
+  resolveObjectURL,
 };


### PR DESCRIPTION
These changes would stop wrangler adding polyfills for `node:buffer` and remove it as a "hybrid module". This would improve the size of the workerd script.