### PR TITLE
Upper case all http methods in fetch API with compat flag

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -556,3 +556,9 @@ wd_test(
     args = ["--experimental"],
     data = ["tests/no-to-string-tag-test.js"],
 )
+
+wd_test(
+    src = "tests/fetch-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/fetch-test.js"],
+)

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1004,9 +1004,14 @@ jsg::Ref<Request> Request::constructor(
         KJ_IF_SOME(m, initDict.method) {
           KJ_IF_SOME(code, tryParseHttpMethod(m)) {
             method = code;
-          } else {
-            KJ_IF_SOME(code, kj::tryParseHttpMethod(toUpper(m))) {
-              method = code;
+          } else KJ_IF_SOME(code, kj::tryParseHttpMethod(toUpper(m))) {
+            method = code;
+            if (!FeatureFlags::get(js).getUpperCaseAllHttpMethods()) {
+              // This is actually the spec defined behavior. We're expected to only
+              // upper case get, post, put, delete, head, and options per the spec.
+              // Other methods, even if they would be recognized if they were uppercased,
+              // are supposed to be rejected.
+              // Refs: https://fetch.spec.whatwg.org/#methods
               switch (method) {
                 case kj::HttpMethod::GET:
                 case kj::HttpMethod::POST:
@@ -1018,9 +1023,9 @@ jsg::Ref<Request> Request::constructor(
                 default:
                   JSG_FAIL_REQUIRE(TypeError, kj::str("Invalid HTTP method string: ", m));
               }
-            } else {
-              JSG_FAIL_REQUIRE(TypeError, kj::str("Invalid HTTP method string: ", m));
             }
+          } else {
+            JSG_FAIL_REQUIRE(TypeError, kj::str("Invalid HTTP method string: ", m));
           }
         }
 

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1002,11 +1002,10 @@ jsg::Ref<Request> Request::constructor(
         }
 
         KJ_IF_SOME(m, initDict.method) {
-          auto originalMethod = kj::str(m);
           KJ_IF_SOME(code, tryParseHttpMethod(m)) {
             method = code;
           } else {
-            KJ_IF_SOME(code, kj::tryParseHttpMethod(toUpper(kj::mv(m)))) {
+            KJ_IF_SOME(code, kj::tryParseHttpMethod(toUpper(m))) {
               method = code;
               switch (method) {
                 case kj::HttpMethod::GET:
@@ -1017,11 +1016,10 @@ jsg::Ref<Request> Request::constructor(
                 case kj::HttpMethod::OPTIONS:
                   break;
                 default:
-                  JSG_FAIL_REQUIRE(
-                      TypeError, kj::str("Invalid HTTP method string: ", originalMethod));
+                  JSG_FAIL_REQUIRE(TypeError, kj::str("Invalid HTTP method string: ", m));
               }
             } else {
-              JSG_FAIL_REQUIRE(TypeError, kj::str("Invalid HTTP method string: ", originalMethod));
+              JSG_FAIL_REQUIRE(TypeError, kj::str("Invalid HTTP method string: ", m));
             }
           }
         }

--- a/src/workerd/api/tests/fetch-test.js
+++ b/src/workerd/api/tests/fetch-test.js
@@ -1,0 +1,24 @@
+import { strictEqual, throws } from 'assert';
+
+// Test depends on the setting of the upper_case_all_http_methods compatibility flag.
+strictEqual(
+  globalThis.Cloudflare.compatibilityFlags['upper_case_all_http_methods'],
+  true
+);
+
+export const test = {
+  test() {
+    // Verify that lower-cased method names are converted to upper-case.
+    // even though the Fetch API doesn't do this in general for all methods.
+    // Note that the upper_case_all_http_methods compat flag is intentionally
+    // diverging from the Fetch API here.
+    const req = new Request('https://example.com', { method: 'patch' });
+    strictEqual(req.method, 'PATCH');
+
+    // Unrecognized methods error as expected, with the error message
+    // showing the original-cased method name.
+    throws(() => new Request('http://example.org', { method: 'patchy' }), {
+      message: /^Invalid HTTP method string: patchy$/,
+    });
+  },
+};

--- a/src/workerd/api/tests/fetch-test.wd-test
+++ b/src/workerd/api/tests/fetch-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "fetch-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "fetch-test.js")
+        ],
+        compatibilityDate = "2024-10-01",
+        compatibilityFlags = ["nodejs_compat", "upper_case_all_http_methods"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -639,4 +639,16 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # fix several spec compliance bugs. Unfortunately it turns out that was more breaking
   # than expected. This flag restores the original behavior for compat dates before
   # 2024-09-26
+
+  upperCaseAllHttpMethods @65 :Bool
+      $compatEnableFlag("upper_case_all_http_methods")
+      $compatDisableFlag("no_upper_case_all_http_methods")
+      $compatEnableDate("2024-10-14");
+  # HTTP methods are expected to be upper-cased. Per the fetch spec, if the methods
+  # is specified as `get`, `post`, `put`, `delete`, `head`, or `options`, implementations
+  # are expected to uppercase the method. All other method names would generally be
+  # expected to throw as unrecognized (e.g. `patch` would be an error while `PATCH` is
+  # accepted). This is a bit restrictive, even if it is in the spec. This flag modifies
+  # the behavior to uppercase all methods prior to parsing to that the method is always
+  # recognized if it is a known method.
 }

--- a/src/workerd/util/strings.c++
+++ b/src/workerd/util/strings.c++
@@ -63,6 +63,10 @@ kj::String toLower(kj::ArrayPtr<const char> ptr) {
   return toLower(kj::str(ptr));
 }
 
+kj::String toUpper(kj::ArrayPtr<const char> ptr) {
+  return toUpper(kj::str(ptr));
+}
+
 kj::ArrayPtr<const char> trimLeadingAndTrailingWhitespace(kj::ArrayPtr<const char> ptr) {
   size_t start = 0;
   auto end = ptr.size();

--- a/src/workerd/util/strings.h
+++ b/src/workerd/util/strings.h
@@ -84,6 +84,7 @@ kj::String toUpper(kj::String&& str);
 
 // Copy the input and convert ASCII alpha characters in the given string to lowercase.
 kj::String toLower(kj::ArrayPtr<const char> ptr);
+kj::String toUpper(kj::ArrayPtr<const char> ptr);
 
 kj::ArrayPtr<const char> trimLeadingAndTrailingWhitespace(kj::ArrayPtr<const char> ptr);
 kj::ArrayPtr<const char> trimTailingWhitespace(kj::ArrayPtr<const char> ptr);


### PR DESCRIPTION
This introduces a non-standard behavior that would become the default. Please review carefully. See the original bug report for context (linked below).

Fixes: https://github.com/cloudflare/workerd/issues/2516