### PR TITLE
Fix: change WorkflowStep into an abstract class

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -224,26 +224,12 @@ declare module "cloudflare:workers" {
     timestamp: Date;
   };
 
-  export type WorkflowStep = {
-    do:
-      | (<T extends Rpc.Serializable>(
-          name: string,
-          callback: () => Promise<T>
-        ) => Promise<T>)
-      | (<T extends Rpc.Serializable>(
-          name: string,
-          config: WorkflowStepConfig,
-          callback: () => Promise<T>
-        ) => Promise<T>)
-      | (<T extends Rpc.Serializable>(
-          name: string,
-          config: WorkflowStepConfig | (() => Promise<T>),
-          callback?: () => Promise<T>
-        ) => Promise<T>);
-
+  export abstract class WorkflowStep {
+    do<T extends Rpc.Serializable>(name: string, callback: () => Promise<T>): Promise<T>;
+    do<T extends Rpc.Serializable>(name: string, config: WorkflowStepConfig, callback: () => Promise<T>): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;
-  };
+  }
 
   export abstract class WorkflowEntrypoint<
     Env = unknown,


### PR DESCRIPTION
For some reason, Typescript resolves types in a different away compared to abstract classes. As a consequence, it would not apply the overloading properly and always treats `WorkflowStep.do` as a 3 argument function