### PR TITLE
add node:path win32 implementations

### DIFF
--- a/src/node/internal/internal_path.ts
+++ b/src/node/internal/internal_path.ts
@@ -19,15 +19,33 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-/* todo: the following is adopted code, enabling linting one day */
-/* eslint-disable */
-
-import { CHAR_DOT, CHAR_FORWARD_SLASH } from 'node-internal:constants';
+import {
+  CHAR_DOT,
+  CHAR_FORWARD_SLASH,
+  CHAR_COLON,
+  CHAR_UPPERCASE_A,
+  CHAR_UPPERCASE_Z,
+  CHAR_LOWERCASE_A,
+  CHAR_LOWERCASE_Z,
+  CHAR_BACKWARD_SLASH,
+  CHAR_QUESTION_MARK,
+} from 'node-internal:constants';
 
 import { validateObject, validateString } from 'node-internal:validators';
 
-function isPosixPathSeparator(code: number) {
+function isPathSeparator(code: number): boolean {
+  return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
+}
+
+function isPosixPathSeparator(code: number): boolean {
   return code === CHAR_FORWARD_SLASH;
+}
+
+function isWindowsDeviceRoot(code: number): boolean {
+  return (
+    (code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) ||
+    (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z)
+  );
 }
 
 // Resolves . and .. elements in a path with directory names
@@ -36,7 +54,7 @@ function normalizeString(
   allowAboveRoot: boolean,
   separator: string,
   isPathSeparator: (code: number) => boolean
-) {
+): string {
   let res = '';
   let lastSegmentLength = 0;
   let lastSlash = -1;
@@ -98,7 +116,7 @@ function normalizeString(
   return res;
 }
 
-function formatExt(ext: string) {
+function formatExt(ext: string): string {
   return ext ? `${ext[0] === '.' ? '' : '.'}${ext}` : '';
 }
 
@@ -122,61 +140,916 @@ type PathObject = {
   ext?: string;
 };
 
-function _format(sep: string, pathObject: PathObject) {
+function _format(sep: string, pathObject: PathObject): string {
   validateObject(pathObject, 'pathObject', {});
   const dir = pathObject.dir || pathObject.root;
   const base =
-    pathObject.base || `${pathObject.name || ''}${formatExt(pathObject.ext!)}`;
+    pathObject.base ||
+    `${pathObject.name || ''}${formatExt(pathObject.ext as string)}`;
   if (!dir) {
     return base;
   }
   return dir === pathObject.root ? `${dir}${base}` : `${dir}${sep}${base}`;
 }
 
-// We currently do not implement the path.win32 subset.
 const win32 = {
-  resolve(..._: [string[], string]) {
-    throw new Error('path.win32.resolve() is not implemented.');
+  resolve(...args: string[]): string {
+    let resolvedDevice = '';
+    let resolvedTail = '';
+    let resolvedAbsolute = false;
+    let slashCheck = false;
+
+    for (let i = args.length - 1; i >= -1; i--) {
+      let path: string;
+      if (i >= 0) {
+        path = args[i] as string;
+        validateString(path, `paths[${i}]`);
+
+        // Skip empty entries
+        if (path.length === 0) {
+          continue;
+        }
+      } else if (resolvedDevice.length === 0) {
+        path = '/';
+      } else {
+        // Windows has the concept of drive-specific current working
+        // directories. If we've resolved a drive letter but not yet an
+        // absolute path, get cwd for that drive, or the process cwd if
+        // the drive cwd is not available. We're sure the device is not
+        // a UNC path at this points, because UNC paths are always absolute.
+        path = '/';
+
+        // Verify that a cwd was found and that it actually points
+        // to our drive. If not, default to the drive's root.
+        if (
+          path.slice(0, 2).toLowerCase() !== resolvedDevice.toLowerCase() &&
+          path.charCodeAt(2) === CHAR_BACKWARD_SLASH
+        ) {
+          path = `${resolvedDevice}\\`;
+        }
+      }
+
+      if (
+        i === args.length - 1 &&
+        isPathSeparator(path.charCodeAt(path.length - 1))
+      ) {
+        slashCheck = true;
+      }
+      const len = path.length;
+      let rootEnd = 0;
+      let device = '';
+      let isAbsolute = false;
+      const code = path.charCodeAt(0);
+
+      // Try to match a root
+      if (len === 1) {
+        if (isPathSeparator(code)) {
+          // `path` contains just a path separator
+          rootEnd = 1;
+          isAbsolute = true;
+        }
+      } else if (isPathSeparator(code)) {
+        // Possible UNC root
+
+        // If we started with a separator, we know we at least have an
+        // absolute path of some kind (UNC or otherwise)
+        isAbsolute = true;
+
+        if (isPathSeparator(path.charCodeAt(1))) {
+          // Matched double path separator at beginning
+          let j = 2;
+          let last = j;
+          // Match 1 or more non-path separators
+          while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+            j++;
+          }
+          if (j < len && j !== last) {
+            const firstPart = path.slice(last, j);
+            // Matched!
+            last = j;
+            // Match 1 or more path separators
+            while (j < len && isPathSeparator(path.charCodeAt(j))) {
+              j++;
+            }
+            if (j < len && j !== last) {
+              // Matched!
+              last = j;
+              // Match 1 or more non-path separators
+              while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+                j++;
+              }
+              if (j === len || j !== last) {
+                if (firstPart !== '.' && firstPart !== '?') {
+                  // We matched a UNC root
+                  device = `\\\\${firstPart}\\${path.slice(last, j)}`;
+                  rootEnd = j;
+                } else {
+                  // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
+                  device = `\\\\${firstPart}`;
+                  rootEnd = 4;
+                }
+              }
+            }
+          }
+        } else {
+          rootEnd = 1;
+        }
+      } else if (
+        isWindowsDeviceRoot(code) &&
+        path.charCodeAt(1) === CHAR_COLON
+      ) {
+        // Possible device root
+        device = path.slice(0, 2);
+        rootEnd = 2;
+        if (len > 2 && isPathSeparator(path.charCodeAt(2))) {
+          // Treat separator following drive name as an absolute path
+          // indicator
+          isAbsolute = true;
+          rootEnd = 3;
+        }
+      }
+
+      if (device.length > 0) {
+        if (resolvedDevice.length > 0) {
+          if (device.toLowerCase() !== resolvedDevice.toLowerCase())
+            // This path points to another device so it is not applicable
+            continue;
+        } else {
+          resolvedDevice = device;
+        }
+      }
+
+      if (resolvedAbsolute) {
+        if (resolvedDevice.length > 0) break;
+      } else {
+        resolvedTail = `${path.slice(rootEnd)}\\${resolvedTail}`;
+        resolvedAbsolute = isAbsolute;
+        if (isAbsolute && resolvedDevice.length > 0) {
+          break;
+        }
+      }
+    }
+
+    // At this point the path should be resolved to a full absolute path,
+    // but handle relative paths to be safe (might happen when process.cwd()
+    // fails)
+
+    // Normalize the tail path
+    resolvedTail = normalizeString(
+      resolvedTail,
+      !resolvedAbsolute,
+      '\\',
+      isPathSeparator
+    );
+
+    if (!resolvedAbsolute) {
+      return `${resolvedDevice}${resolvedTail}` || '.';
+    }
+
+    if (resolvedTail.length === 0) {
+      return slashCheck ? `${resolvedDevice}\\` : resolvedDevice;
+    }
+
+    if (slashCheck) {
+      return resolvedTail === '\\'
+        ? `${resolvedDevice}\\`
+        : `${resolvedDevice}\\${resolvedTail}\\`;
+    }
+
+    return `${resolvedDevice}\\${resolvedTail}`;
   },
 
-  normalize(_: string) {
-    throw new Error('path.win32.normalize() is not implemented.');
+  normalize(path: string): string {
+    validateString(path, 'path');
+    const len = path.length;
+    if (len === 0) return '.';
+    let rootEnd = 0;
+    let device;
+    let isAbsolute = false;
+    const code = path.charCodeAt(0);
+
+    // Try to match a root
+    if (len === 1) {
+      // `path` contains just a single char, exit early to avoid
+      // unnecessary work
+      return isPosixPathSeparator(code) ? '\\' : path;
+    }
+    if (isPathSeparator(code)) {
+      // Possible UNC root
+
+      // If we started with a separator, we know we at least have an absolute
+      // path of some kind (UNC or otherwise)
+      isAbsolute = true;
+
+      if (isPathSeparator(path.charCodeAt(1))) {
+        // Matched double path separator at beginning
+        let j = 2;
+        let last = j;
+        // Match 1 or more non-path separators
+        while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+          j++;
+        }
+        if (j < len && j !== last) {
+          const firstPart = path.slice(last, j);
+          // Matched!
+          last = j;
+          // Match 1 or more path separators
+          while (j < len && isPathSeparator(path.charCodeAt(j))) {
+            j++;
+          }
+          if (j < len && j !== last) {
+            // Matched!
+            last = j;
+            // Match 1 or more non-path separators
+            while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+              j++;
+            }
+            if (j === len || j !== last) {
+              if (firstPart === '.' || firstPart === '?') {
+                // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
+                device = `\\\\${firstPart}`;
+                rootEnd = 4;
+              } else if (j === len) {
+                // We matched a UNC root only
+                // Return the normalized version of the UNC root since there
+                // is nothing left to process
+                return `\\\\${firstPart}\\${path.slice(last)}\\`;
+              } else {
+                // We matched a UNC root with leftovers
+                device = `\\\\${firstPart}\\${path.slice(last, j)}`;
+                rootEnd = j;
+              }
+            }
+          }
+        }
+      } else {
+        rootEnd = 1;
+      }
+    } else if (isWindowsDeviceRoot(code) && path.charCodeAt(1) === CHAR_COLON) {
+      // Possible device root
+      device = path.slice(0, 2);
+      rootEnd = 2;
+      if (len > 2 && isPathSeparator(path.charCodeAt(2))) {
+        // Treat separator following drive name as an absolute path
+        // indicator
+        isAbsolute = true;
+        rootEnd = 3;
+      }
+    }
+
+    let tail =
+      rootEnd < len
+        ? normalizeString(
+            path.slice(rootEnd),
+            !isAbsolute,
+            '\\',
+            isPathSeparator
+          )
+        : '';
+    if (tail.length === 0 && !isAbsolute) tail = '.';
+    if (tail.length > 0 && isPathSeparator(path.charCodeAt(len - 1)))
+      tail += '\\';
+    if (device === undefined) {
+      return isAbsolute ? `\\${tail}` : tail;
+    }
+    return isAbsolute ? `${device}\\${tail}` : `${device}${tail}`;
   },
 
-  isAbsolute(_: string) {
-    throw new Error('path.win32.isAbsolute() is not implemented.');
+  isAbsolute(path: string): boolean {
+    validateString(path, 'path');
+    const len = path.length;
+    if (len === 0) return false;
+
+    const code = path.charCodeAt(0);
+    return (
+      isPathSeparator(code) ||
+      // Possible device root
+      (len > 2 &&
+        isWindowsDeviceRoot(code) &&
+        path.charCodeAt(1) === CHAR_COLON &&
+        isPathSeparator(path.charCodeAt(2)))
+    );
   },
 
-  join(..._: string[]) {
-    throw new Error('path.win32.join() is not implemented.');
+  join(...args: string[]): string {
+    if (args.length === 0) return '.';
+
+    let joined: string | undefined;
+    let firstPart: string | undefined;
+    for (let i = 0; i < args.length; ++i) {
+      const arg = args[i];
+      validateString(arg, 'path');
+      if (arg.length > 0) {
+        if (joined === undefined) {
+          joined = arg;
+          firstPart = arg;
+        } else joined += `\\${arg}`;
+      }
+    }
+
+    if (joined === undefined || firstPart === undefined) return '.';
+
+    // Make sure that the joined path doesn't start with two slashes, because
+    // normalize() will mistake it for a UNC path then.
+    //
+    // This step is skipped when it is very clear that the user actually
+    // intended to point at a UNC path. This is assumed when the first
+    // non-empty string arguments starts with exactly two slashes followed by
+    // at least one more non-slash character.
+    //
+    // Note that for normalize() to treat a path as a UNC path it needs to
+    // have at least 2 components, so we don't filter for that here.
+    // This means that the user can use join to construct UNC paths from
+    // a server name and a share name; for example:
+    //   path.join('//server', 'share') -> '\\\\server\\share\\')
+    let needsReplace = true;
+    let slashCount = 0;
+    if (isPathSeparator(firstPart.charCodeAt(0))) {
+      ++slashCount;
+      const firstLen = firstPart.length;
+      if (firstLen > 1 && isPathSeparator(firstPart.charCodeAt(1))) {
+        ++slashCount;
+        if (firstLen > 2) {
+          if (isPathSeparator(firstPart.charCodeAt(2))) ++slashCount;
+          else {
+            // We matched a UNC path in the first part
+            needsReplace = false;
+          }
+        }
+      }
+    }
+    if (needsReplace) {
+      // Find any more consecutive slashes we need to replace
+      while (
+        slashCount < joined.length &&
+        isPathSeparator(joined.charCodeAt(slashCount))
+      ) {
+        slashCount++;
+      }
+
+      // Replace the slashes if needed
+      if (slashCount >= 2) joined = `\\${joined.slice(slashCount)}`;
+    }
+
+    return win32.normalize(joined);
   },
 
-  relative(_0: string, _1: string) {
-    throw new Error('path.win32.relative() is not implemented.');
+  relative(from: string, to: string): string {
+    validateString(from, 'from');
+    validateString(to, 'to');
+
+    if (from === to) return '';
+
+    const fromOrig = win32.resolve(from);
+    const toOrig = win32.resolve(to);
+
+    if (fromOrig === toOrig) return '';
+
+    from = fromOrig.toLowerCase();
+    to = toOrig.toLowerCase();
+
+    if (from === to) return '';
+
+    if (fromOrig.length !== from.length || toOrig.length !== to.length) {
+      const fromSplit = fromOrig.split('\\');
+      const toSplit = toOrig.split('\\');
+      if (fromSplit[fromSplit.length - 1] === '') {
+        fromSplit.pop();
+      }
+      if (toSplit[toSplit.length - 1] === '') {
+        toSplit.pop();
+      }
+
+      const fromLen = fromSplit.length;
+      const toLen = toSplit.length;
+      const length = fromLen < toLen ? fromLen : toLen;
+
+      let i;
+      for (i = 0; i < length; i++) {
+        if (fromSplit[i]?.toLowerCase() !== toSplit[i]?.toLowerCase()) {
+          break;
+        }
+      }
+
+      if (i === 0) {
+        return toOrig;
+      } else if (i === length) {
+        if (toLen > length) {
+          return toSplit.slice(i).join('\\');
+        }
+        if (fromLen > length) {
+          return '..\\'.repeat(fromLen - 1 - i) + '..';
+        }
+        return '';
+      }
+
+      return '..\\'.repeat(fromLen - i) + toSplit.slice(i).join('\\');
+    }
+
+    // Trim any leading backslashes
+    let fromStart = 0;
+    while (
+      fromStart < from.length &&
+      from.charCodeAt(fromStart) === CHAR_BACKWARD_SLASH
+    ) {
+      fromStart++;
+    }
+    // Trim trailing backslashes (applicable to UNC paths only)
+    let fromEnd = from.length;
+    while (
+      fromEnd - 1 > fromStart &&
+      from.charCodeAt(fromEnd - 1) === CHAR_BACKWARD_SLASH
+    ) {
+      fromEnd--;
+    }
+    const fromLen = fromEnd - fromStart;
+
+    // Trim any leading backslashes
+    let toStart = 0;
+    while (
+      toStart < to.length &&
+      to.charCodeAt(toStart) === CHAR_BACKWARD_SLASH
+    ) {
+      toStart++;
+    }
+    // Trim trailing backslashes (applicable to UNC paths only)
+    let toEnd = to.length;
+    while (
+      toEnd - 1 > toStart &&
+      to.charCodeAt(toEnd - 1) === CHAR_BACKWARD_SLASH
+    ) {
+      toEnd--;
+    }
+    const toLen = toEnd - toStart;
+
+    // Compare paths to find the longest common path from root
+    const length = fromLen < toLen ? fromLen : toLen;
+    let lastCommonSep = -1;
+    let i = 0;
+    for (; i < length; i++) {
+      const fromCode = from.charCodeAt(fromStart + i);
+      if (fromCode !== to.charCodeAt(toStart + i)) break;
+      else if (fromCode === CHAR_BACKWARD_SLASH) lastCommonSep = i;
+    }
+
+    // We found a mismatch before the first common path separator was seen, so
+    // return the original `to`.
+    if (i !== length) {
+      if (lastCommonSep === -1) return toOrig;
+    } else {
+      if (toLen > length) {
+        if (to.charCodeAt(toStart + i) === CHAR_BACKWARD_SLASH) {
+          // We get here if `from` is the exact base path for `to`.
+          // For example: from='C:\\foo\\bar'; to='C:\\foo\\bar\\baz'
+          return toOrig.slice(toStart + i + 1);
+        }
+        if (i === 2) {
+          // We get here if `from` is the device root.
+          // For example: from='C:\\'; to='C:\\foo'
+          return toOrig.slice(toStart + i);
+        }
+      }
+      if (fromLen > length) {
+        if (from.charCodeAt(fromStart + i) === CHAR_BACKWARD_SLASH) {
+          // We get here if `to` is the exact base path for `from`.
+          // For example: from='C:\\foo\\bar'; to='C:\\foo'
+          lastCommonSep = i;
+        } else if (i === 2) {
+          // We get here if `to` is the device root.
+          // For example: from='C:\\foo\\bar'; to='C:\\'
+          lastCommonSep = 3;
+        }
+      }
+      if (lastCommonSep === -1) lastCommonSep = 0;
+    }
+
+    let out = '';
+    // Generate the relative path based on the path difference between `to` and
+    // `from`
+    for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i) {
+      if (i === fromEnd || from.charCodeAt(i) === CHAR_BACKWARD_SLASH) {
+        out += out.length === 0 ? '..' : '\\..';
+      }
+    }
+
+    toStart += lastCommonSep;
+
+    // Lastly, append the rest of the destination (`to`) path that comes after
+    // the common path parts
+    if (out.length > 0) return `${out}${toOrig.slice(toStart, toEnd)}`;
+
+    if (toOrig.charCodeAt(toStart) === CHAR_BACKWARD_SLASH) ++toStart;
+    return toOrig.slice(toStart, toEnd);
   },
 
-  toNamespacedPath(_: string) {
-    throw new Error('path.win32.toNamedspacedPath() is not implemented.');
+  toNamespacedPath(path: string): string {
+    // Note: this will *probably* throw somewhere.
+    if (typeof path !== 'string' || path.length === 0) return path;
+
+    const resolvedPath = win32.resolve(path);
+
+    if (resolvedPath.length <= 2) return path;
+
+    if (resolvedPath.charCodeAt(0) === CHAR_BACKWARD_SLASH) {
+      // Possible UNC root
+      if (resolvedPath.charCodeAt(1) === CHAR_BACKWARD_SLASH) {
+        const code = resolvedPath.charCodeAt(2);
+        if (code !== CHAR_QUESTION_MARK && code !== CHAR_DOT) {
+          // Matched non-long UNC root, convert the path to a long UNC path
+          return `\\\\?\\UNC\\${resolvedPath.slice(2)}`;
+        }
+      }
+    } else if (
+      isWindowsDeviceRoot(resolvedPath.charCodeAt(0)) &&
+      resolvedPath.charCodeAt(1) === CHAR_COLON &&
+      resolvedPath.charCodeAt(2) === CHAR_BACKWARD_SLASH
+    ) {
+      // Matched device root, convert the path to a long UNC path
+      return `\\\\?\\${resolvedPath}`;
+    }
+
+    return resolvedPath;
   },
 
-  dirname(_: string) {
-    throw new Error('path.win32.dirname() is not implemented.');
+  dirname(path: string): string {
+    validateString(path, 'path');
+    const len = path.length;
+    if (len === 0) return '.';
+    let rootEnd = -1;
+    let offset = 0;
+    const code = path.charCodeAt(0);
+
+    if (len === 1) {
+      // `path` contains just a path separator, exit early to avoid
+      // unnecessary work or a dot.
+      return isPathSeparator(code) ? path : '.';
+    }
+
+    // Try to match a root
+    if (isPathSeparator(code)) {
+      // Possible UNC root
+
+      rootEnd = offset = 1;
+
+      if (isPathSeparator(path.charCodeAt(1))) {
+        // Matched double path separator at beginning
+        let j = 2;
+        let last = j;
+        // Match 1 or more non-path separators
+        while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+          j++;
+        }
+        if (j < len && j !== last) {
+          // Matched!
+          last = j;
+          // Match 1 or more path separators
+          while (j < len && isPathSeparator(path.charCodeAt(j))) {
+            j++;
+          }
+          if (j < len && j !== last) {
+            // Matched!
+            last = j;
+            // Match 1 or more non-path separators
+            while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+              j++;
+            }
+            if (j === len) {
+              // We matched a UNC root only
+              return path;
+            }
+            if (j !== last) {
+              // We matched a UNC root with leftovers
+
+              // Offset by 1 to include the separator after the UNC root to
+              // treat it as a "normal root" on top of a (UNC) root
+              rootEnd = offset = j + 1;
+            }
+          }
+        }
+      }
+      // Possible device root
+    } else if (isWindowsDeviceRoot(code) && path.charCodeAt(1) === CHAR_COLON) {
+      rootEnd = len > 2 && isPathSeparator(path.charCodeAt(2)) ? 3 : 2;
+      offset = rootEnd;
+    }
+
+    let end = -1;
+    let matchedSlash = true;
+    for (let i = len - 1; i >= offset; --i) {
+      if (isPathSeparator(path.charCodeAt(i))) {
+        if (!matchedSlash) {
+          end = i;
+          break;
+        }
+      } else {
+        // We saw the first non-path separator
+        matchedSlash = false;
+      }
+    }
+
+    if (end === -1) {
+      if (rootEnd === -1) return '.';
+
+      end = rootEnd;
+    }
+    return path.slice(0, end);
   },
 
-  basename(_0: string, _1?: string) {
-    throw new Error('path.win32.basename() is not implemented.');
+  basename(path: string, suffix?: string): string {
+    if (suffix !== undefined) validateString(suffix, 'suffix');
+    validateString(path, 'path');
+    let start = 0;
+    let end = -1;
+    let matchedSlash = true;
+
+    // Check for a drive letter prefix so as not to mistake the following
+    // path separator as an extra separator at the end of the path that can be
+    // disregarded
+    if (
+      path.length >= 2 &&
+      isWindowsDeviceRoot(path.charCodeAt(0)) &&
+      path.charCodeAt(1) === CHAR_COLON
+    ) {
+      start = 2;
+    }
+
+    if (
+      suffix !== undefined &&
+      suffix.length > 0 &&
+      suffix.length <= path.length
+    ) {
+      if (suffix === path) return '';
+      let extIdx = suffix.length - 1;
+      let firstNonSlashEnd = -1;
+      for (let i = path.length - 1; i >= start; --i) {
+        const code = path.charCodeAt(i);
+        if (isPathSeparator(code)) {
+          // If we reached a path separator that was not part of a set of path
+          // separators at the end of the string, stop now
+          if (!matchedSlash) {
+            start = i + 1;
+            break;
+          }
+        } else {
+          if (firstNonSlashEnd === -1) {
+            // We saw the first non-path separator, remember this index in case
+            // we need it if the extension ends up not matching
+            matchedSlash = false;
+            firstNonSlashEnd = i + 1;
+          }
+          if (extIdx >= 0) {
+            // Try to match the explicit extension
+            if (code === suffix.charCodeAt(extIdx)) {
+              if (--extIdx === -1) {
+                // We matched the extension, so mark this as the end of our path
+                // component
+                end = i;
+              }
+            } else {
+              // Extension does not match, so our result is the entire path
+              // component
+              extIdx = -1;
+              end = firstNonSlashEnd;
+            }
+          }
+        }
+      }
+
+      if (start === end) end = firstNonSlashEnd;
+      else if (end === -1) end = path.length;
+      return path.slice(start, end);
+    }
+    for (let i = path.length - 1; i >= start; --i) {
+      if (isPathSeparator(path.charCodeAt(i))) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          start = i + 1;
+          break;
+        }
+      } else if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // path component
+        matchedSlash = false;
+        end = i + 1;
+      }
+    }
+
+    if (end === -1) return '';
+    return path.slice(start, end);
   },
 
-  extname(_: string) {
-    throw new Error('path.win32.extname() is not implemented.');
+  extname(path: string): string {
+    validateString(path, 'path');
+    let start = 0;
+    let startDot = -1;
+    let startPart = 0;
+    let end = -1;
+    let matchedSlash = true;
+    // Track the state of characters (if any) we see before our first dot and
+    // after any path separator we find
+    let preDotState = 0;
+
+    // Check for a drive letter prefix so as not to mistake the following
+    // path separator as an extra separator at the end of the path that can be
+    // disregarded
+
+    if (
+      path.length >= 2 &&
+      path.charCodeAt(1) === CHAR_COLON &&
+      isWindowsDeviceRoot(path.charCodeAt(0))
+    ) {
+      start = startPart = 2;
+    }
+
+    for (let i = path.length - 1; i >= start; --i) {
+      const code = path.charCodeAt(i);
+      if (isPathSeparator(code)) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          startPart = i + 1;
+          break;
+        }
+        continue;
+      }
+      if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // extension
+        matchedSlash = false;
+        end = i + 1;
+      }
+      if (code === CHAR_DOT) {
+        // If this is our first dot, mark it as the start of our extension
+        if (startDot === -1) startDot = i;
+        else if (preDotState !== 1) preDotState = 1;
+      } else if (startDot !== -1) {
+        // We saw a non-dot and non-path separator before our dot, so we should
+        // have a good chance at having a non-empty extension
+        preDotState = -1;
+      }
+    }
+
+    if (
+      startDot === -1 ||
+      end === -1 ||
+      // We saw a non-dot character immediately before the dot
+      preDotState === 0 ||
+      // The (right-most) trimmed path component is exactly '..'
+      (preDotState === 1 && startDot === end - 1 && startDot === startPart + 1)
+    ) {
+      return '';
+    }
+    return path.slice(startDot, end);
   },
 
-  format(_: PathObject) {
-    throw new Error('path.win32.format() is not implemented.');
+  format(path: PathObject): string {
+    return _format('\\', path);
   },
 
-  parse(_: string) {
-    throw new Error('path.win32.parse() is not implemented.');
+  parse(path: string): PathObject {
+    validateString(path, 'path');
+
+    const ret = { root: '', dir: '', base: '', ext: '', name: '' };
+    if (path.length === 0) return ret;
+
+    const len = path.length;
+    let rootEnd = 0;
+    let code = path.charCodeAt(0);
+
+    if (len === 1) {
+      if (isPathSeparator(code)) {
+        // `path` contains just a path separator, exit early to avoid
+        // unnecessary work
+        ret.root = ret.dir = path;
+        return ret;
+      }
+      ret.base = ret.name = path;
+      return ret;
+    }
+    // Try to match a root
+    if (isPathSeparator(code)) {
+      // Possible UNC root
+
+      rootEnd = 1;
+      if (isPathSeparator(path.charCodeAt(1))) {
+        // Matched double path separator at beginning
+        let j = 2;
+        let last = j;
+        // Match 1 or more non-path separators
+        while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+          j++;
+        }
+        if (j < len && j !== last) {
+          // Matched!
+          last = j;
+          // Match 1 or more path separators
+          while (j < len && isPathSeparator(path.charCodeAt(j))) {
+            j++;
+          }
+          if (j < len && j !== last) {
+            // Matched!
+            last = j;
+            // Match 1 or more non-path separators
+            while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+              j++;
+            }
+            if (j === len) {
+              // We matched a UNC root only
+              rootEnd = j;
+            } else if (j !== last) {
+              // We matched a UNC root with leftovers
+              rootEnd = j + 1;
+            }
+          }
+        }
+      }
+    } else if (isWindowsDeviceRoot(code) && path.charCodeAt(1) === CHAR_COLON) {
+      // Possible device root
+      if (len <= 2) {
+        // `path` contains just a drive root, exit early to avoid
+        // unnecessary work
+        ret.root = ret.dir = path;
+        return ret;
+      }
+      rootEnd = 2;
+      if (isPathSeparator(path.charCodeAt(2))) {
+        if (len === 3) {
+          // `path` contains just a drive root, exit early to avoid
+          // unnecessary work
+          ret.root = ret.dir = path;
+          return ret;
+        }
+        rootEnd = 3;
+      }
+    }
+    if (rootEnd > 0) ret.root = path.slice(0, rootEnd);
+
+    let startDot = -1;
+    let startPart = rootEnd;
+    let end = -1;
+    let matchedSlash = true;
+    let i = path.length - 1;
+
+    // Track the state of characters (if any) we see before our first dot and
+    // after any path separator we find
+    let preDotState = 0;
+
+    // Get non-dir info
+    for (; i >= rootEnd; --i) {
+      code = path.charCodeAt(i);
+      if (isPathSeparator(code)) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          startPart = i + 1;
+          break;
+        }
+        continue;
+      }
+      if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // extension
+        matchedSlash = false;
+        end = i + 1;
+      }
+      if (code === CHAR_DOT) {
+        // If this is our first dot, mark it as the start of our extension
+        if (startDot === -1) startDot = i;
+        else if (preDotState !== 1) preDotState = 1;
+      } else if (startDot !== -1) {
+        // We saw a non-dot and non-path separator before our dot, so we should
+        // have a good chance at having a non-empty extension
+        preDotState = -1;
+      }
+    }
+
+    if (end !== -1) {
+      if (
+        startDot === -1 ||
+        // We saw a non-dot character immediately before the dot
+        preDotState === 0 ||
+        // The (right-most) trimmed path component is exactly '..'
+        (preDotState === 1 &&
+          startDot === end - 1 &&
+          startDot === startPart + 1)
+      ) {
+        ret.base = ret.name = path.slice(startPart, end);
+      } else {
+        ret.name = path.slice(startPart, startDot);
+        ret.base = path.slice(startPart, end);
+        ret.ext = path.slice(startDot, end);
+      }
+    }
+
+    // If the directory is the root, use the entire root as the `dir` including
+    // the trailing slash if any (`C:\abc` -> `C:\`). Otherwise, strip out the
+    // trailing slash (`C:\abc\def` -> `C:\abc`).
+    if (startPart > 0 && startPart !== rootEnd)
+      ret.dir = path.slice(0, startPart - 1);
+    else ret.dir = ret.root;
+
+    return ret;
   },
 
   matchesGlob(_path: string, _pattern: string): boolean {
@@ -185,8 +1058,8 @@ const win32 = {
 
   sep: '\\',
   delimiter: ';',
-  win32: null as Object | null,
-  posix: null as Object | null,
+  win32: null as object | null,
+  posix: null as object | null,
 };
 
 const posix = {
@@ -195,7 +1068,7 @@ const posix = {
    * @param {...string} args
    * @returns {string}
    */
-  resolve(...args: string[]) {
+  resolve(...args: string[]): string {
     let resolvedPath = '';
     let resolvedAbsolute = false;
 
@@ -205,12 +1078,12 @@ const posix = {
       validateString(path, 'path');
 
       // Skip empty entries
-      if (path!.length === 0) {
+      if (path.length === 0) {
         continue;
       }
 
       resolvedPath = `${path}/${resolvedPath}`;
-      resolvedAbsolute = path!.charCodeAt(0) === CHAR_FORWARD_SLASH;
+      resolvedAbsolute = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
     }
 
     // At this point the path should be resolved to a full absolute path, but
@@ -234,7 +1107,7 @@ const posix = {
    * @param {string} path
    * @returns {string}
    */
-  normalize(path: string) {
+  normalize(path: string): string {
     validateString(path, 'path');
 
     if (path.length === 0) return '.';
@@ -259,7 +1132,7 @@ const posix = {
    * @param {string} path
    * @returns {boolean}
    */
-  isAbsolute(path: string) {
+  isAbsolute(path: string): boolean {
     validateString(path, 'path');
     return path.length > 0 && path.charCodeAt(0) === CHAR_FORWARD_SLASH;
   },
@@ -268,13 +1141,13 @@ const posix = {
    * @param {...string} args
    * @returns {string}
    */
-  join(...args: string[]) {
+  join(...args: string[]): string {
     if (args.length === 0) return '.';
     let joined;
     for (let i = 0; i < args.length; ++i) {
       const arg = args[i];
       validateString(arg, 'path');
-      if (arg!.length > 0) {
+      if (arg.length > 0) {
         if (joined === undefined) joined = arg;
         else joined += `/${arg}`;
       }
@@ -288,7 +1161,7 @@ const posix = {
    * @param {string} to
    * @returns {string}
    */
-  relative(from: string, to: string) {
+  relative(from: string, to: string): string {
     validateString(from, 'from');
     validateString(to, 'to');
 
@@ -358,7 +1231,7 @@ const posix = {
    * @param {string} path
    * @returns {string}
    */
-  toNamespacedPath(path: string) {
+  toNamespacedPath(path: string): string {
     // Non-op on posix systems
     return path;
   },
@@ -367,7 +1240,7 @@ const posix = {
    * @param {string} path
    * @returns {string}
    */
-  dirname(path: string) {
+  dirname(path: string): string {
     validateString(path, 'path');
     if (path.length === 0) return '.';
     const hasRoot = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
@@ -395,7 +1268,7 @@ const posix = {
    * @param {string} [suffix]
    * @returns {string}
    */
-  basename(path: string, suffix?: string) {
+  basename(path: string, suffix?: string): string {
     if (suffix !== undefined) validateString(suffix, 'ext');
     validateString(path, 'path');
 
@@ -473,7 +1346,7 @@ const posix = {
    * @param {string} path
    * @returns {string}
    */
-  extname(path: string) {
+  extname(path: string): string {
     validateString(path, 'path');
     let startDot = -1;
     let startPart = 0;
@@ -618,12 +1491,14 @@ const posix = {
 
   sep: '/',
   delimiter: ':',
-  win32: null as Object | null,
-  posix: null as Object | null,
+  win32: null as object | null,
+  posix: null as object | null,
 };
 
 posix.win32 = win32.win32 = win32;
 posix.posix = win32.posix = posix;
 
+// TODO(soon): Maybe we should export depending on the host operating system
+// Ref: https://github.com/nodejs/node/blob/10addb0a208c0356a0358cfd2a7b80a0932cd108/lib/path.js#L1696
 export default posix;
 export { posix, win32 };


### PR DESCRIPTION
Implement win32 implementations of `node:path` and enables linter.