### PR TITLE
disable tseslint on js files

### DIFF
--- a/tools/base.eslint.config.mjs
+++ b/tools/base.eslint.config.mjs
@@ -45,5 +45,9 @@ export function baseConfig({ tsconfigRootDir }) {
       },
     },
     prettierPlugin,
+    {
+      files: ['**/*.js', '**/*.mjs', '**/*.cjs'],
+      ...tseslint.configs.disableTypeChecked,
+    },
   )
 }


### PR DESCRIPTION
This would improve the linter performance by not running type checking on javascript files.