### PR TITLE
Add waitForBookmark to DurableObjectStorage

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -735,6 +735,10 @@ kj::Promise<kj::String> DurableObjectStorage::onNextSessionRestoreBookmark(kj::S
   return cache->onNextSessionRestoreBookmark(bookmark);
 }
 
+kj::Promise<void> DurableObjectStorage::waitForBookmark(kj::String bookmark) {
+  return cache->waitForBookmark(bookmark);
+}
+
 ActorCacheOps& DurableObjectTransaction::getCache(OpName op) {
   JSG_REQUIRE(!rolledBack, Error, kj::str("Cannot ", op, " on rolled back transaction"));
   auto& result = *JSG_REQUIRE_NONNULL(cacheTxn, Error,

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -227,6 +227,14 @@ public:
   // by calling state.abort() or by throwing from a blockConcurrencyWhile() callback.
   kj::Promise<kj::String> onNextSessionRestoreBookmark(kj::String bookmark);
 
+  // Wait until the database has been updated to the state represented by `bookmark`.
+  //
+  // `waitForBookmark` is useful synchronizing requests across replicas of the same database.  On
+  // primary databases, `waitForBookmark` will resolve immediately.  On replica databases,
+  // `waitForBookmark` will resolve when the replica has been updated to a point at or after
+  // `bookmark`.
+  kj::Promise<void> waitForBookmark(kj::String bookmark);
+
   JSG_RESOURCE_TYPE(DurableObjectStorage, CompatibilityFlags::Reader flags) {
     JSG_METHOD(get);
     JSG_METHOD(list);
@@ -245,6 +253,7 @@ public:
     JSG_METHOD(getCurrentBookmark);
     JSG_METHOD(getBookmarkForTime);
     JSG_METHOD(onNextSessionRestoreBookmark);
+    JSG_METHOD(waitForBookmark);
 
     JSG_TS_OVERRIDE({
       get<T = unknown>(key: string, options?: DurableObjectGetOptions): Promise<T | undefined>;

--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -3357,4 +3357,9 @@ kj::Promise<kj::String> ActorCacheInterface::onNextSessionRestoreBookmark(kj::St
       Error, "This Durable Object's storage back-end does not implement point-in-time recovery.");
 }
 
+kj::Promise<void> ActorCacheInterface::waitForBookmark(kj::StringPtr bookmark) {
+  JSG_FAIL_REQUIRE(
+      Error, "This Durable Object's storage back-end does not implement point-in-time recovery.");
+}
+
 }  // namespace workerd

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -238,6 +238,7 @@ public:
   virtual kj::Promise<kj::String> getCurrentBookmark();
   virtual kj::Promise<kj::String> getBookmarkForTime(kj::Date timestamp);
   virtual kj::Promise<kj::String> onNextSessionRestoreBookmark(kj::StringPtr bookmark);
+  virtual kj::Promise<void> waitForBookmark(kj::StringPtr bookmark);
 };
 
 // An in-memory caching layer on top of ActorStorage.Stage RPC interface.


### PR DESCRIPTION
This exposes the internal `waitForBookmark` method to JavaScript. We’ll need this in order to implement decent consistency models with SQLite replication.