### PR TITLE
add process.platform

### DIFF
--- a/src/node/internal/process.ts
+++ b/src/node/internal/process.ts
@@ -92,9 +92,12 @@ export function exit(code: number) {
   utilImpl.processExitImpl(code);
 }
 
+export const platform = utilImpl.processPlatform;
+
 export default {
   nextTick,
   env,
   exit,
   getBuiltinModule,
+  platform,
 };

--- a/src/node/internal/util.d.ts
+++ b/src/node/internal/util.d.ts
@@ -123,3 +123,4 @@ export function isBoxedPrimitive(
 export function getBuiltinModule(id: string): any;
 export function getCallSite(frames: number): Record<string, string>[];
 export function processExitImpl(code: number): void;
+export const processPlatform: string;

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -214,3 +214,9 @@ wd_test(
     args = ["--experimental"],
     data = ["tests/process-exit-test.js"],
 )
+
+wd_test(
+    src = "tests/process-nodejs-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/process-nodejs-test.js"],
+)

--- a/src/workerd/api/node/tests/process-nodejs-test.js
+++ b/src/workerd/api/node/tests/process-nodejs-test.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+
+export const processPlatform = {
+  test() {
+    assert.strictEqual(typeof process.platform, 'string');
+    assert.ok(['darwin', 'win32', 'linux'].includes(process.platform));
+  },
+};

--- a/src/workerd/api/node/tests/process-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/process-nodejs-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "nodejs-process-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "process-nodejs-test.js")
+        ],
+        compatibilityDate = "2024-10-11",
+        compatibilityFlags = ["nodejs_compat"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/node/util.h
+++ b/src/workerd/api/node/util.h
@@ -161,6 +161,16 @@ public:
 
   jsg::Name getResourceTypeInspect(jsg::Lock& js);
 
+#ifdef _WIN32
+  static constexpr kj::StringPtr processPlatform = "win32"_kj;
+#elif defined(__linux__)
+  static constexpr kj::StringPtr processPlatform = "linux"_kj;
+#elif defined(__APPLE__)
+  static constexpr kj::StringPtr processPlatform = "darwin"_kj;
+#else
+  static constexpr kj::StringPtr processPlatform = "unsupported-platform"_kj;
+#endif
+
   // `getOwnNonIndexProperties()` `filter`s
   static constexpr int ALL_PROPERTIES = jsg::PropertyFilter::ALL_PROPERTIES;
   static constexpr int ONLY_ENUMERABLE = jsg::PropertyFilter::ONLY_ENUMERABLE;
@@ -223,6 +233,12 @@ public:
   // then it becomes a non-op.
   void processExitImpl(jsg::Lock& js, int code);
 
+  // IMPORTANT: This function will always return "linux" on production.
+  // This is only added for Node.js compatibility and running OS specific tests
+  kj::StringPtr getProcessPlatform() const {
+    return processPlatform;
+  }
+
   JSG_RESOURCE_TYPE(UtilModule) {
     JSG_NESTED_TYPE(MIMEType);
     JSG_NESTED_TYPE(MIMEParams);
@@ -251,6 +267,7 @@ public:
 
     JSG_METHOD(getBuiltinModule);
     JSG_METHOD(processExitImpl);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(processPlatform, getProcessPlatform);
   }
 };
 


### PR DESCRIPTION
Adds process.platform. This can help us test OS specific code. For example: `node:url`