### PR TITLE
Make NonRetryableError non-abstract in types

### DIFF
--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -3,13 +3,6 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 export class NonRetryableError extends Error {
-  // `__brand` is how engine validates that the user returned a `NonRetryableError`
-  // imported from "cloudflare:workflows"
-  // This enables them to extend NonRetryableError for their own Errors
-  // as well by overriding name
-  // Private fields are not serialized over RPC
-  public readonly __brand: string = 'NonRetryableError';
-
   public constructor(message: string, name = 'NonRetryableError') {
     super(message);
     this.name = name;

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -1,13 +1,9 @@
-/**
- * NonRetryableError allows for a user to throw a fatal error
- * that makes a Workflow instance fail immediately without triggering a retry
- */
 declare module "cloudflare:workflows" {
-  export abstract class NonRetryableError extends Error {
-    /**
-     * `__brand` is used to differentiate between `NonRetryableError` and `Error`
-     * and is omitted from the constructor because users should not set it
-     */
+  /**
+   * NonRetryableError allows for a user to throw a fatal error
+   * that makes a Workflow instance fail immediately without triggering a retry
+   */
+  export class NonRetryableError extends Error {
     public constructor(message: string, name?: string);
   }
 }


### PR DESCRIPTION
Basically, we won't get NonRetryableError serialization done properly because we would have to implement our own Error Serializer for this which might not be worth it, at least for launch. Even if we fix this later, it's okay to let users throw a raw NonRetryableError anyway.