### PR TITLE
SQLite: Make foreign key errors on txn commit visible to app.

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -1379,7 +1379,7 @@ export default {
     // Test defer_foreign_keys (explodes the DO)
     await assert.rejects(async () => {
       await doReq('sql-test-foreign-keys');
-    }, /Error: internal error/);
+    }, /constraints were violated: FOREIGN KEY constraint failed: SQLITE_CONSTRAINT/);
 
     // Some increments.
     assert.equal(await doReq('increment'), 1);

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -130,6 +130,9 @@ wd_cc_library(
         "actor-sqlite.h",
         "actor-storage.h",
     ],
+    implementation_deps = [
+        "@sqlite3",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":actor-storage_capnp",

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -90,8 +90,16 @@ private:
   SqliteKv kv;
   SqliteMetadata metadata;
 
+  // Define a SqliteDatabase::Regulator that is similar to TRUSTED but turns certain SQLite errors
+  // into application errors as appropriate when committing an implicit transaction.
+  class TxnCommitRegulator: public SqliteDatabase::Regulator {
+  public:
+    void onError(kj::Maybe<int> sqliteErrorCode, kj::StringPtr message) const;
+  };
+  static constexpr TxnCommitRegulator TRUSTED_TXN_COMMIT;
+
   SqliteDatabase::Statement beginTxn = db->prepare("BEGIN TRANSACTION");
-  SqliteDatabase::Statement commitTxn = db->prepare("COMMIT TRANSACTION");
+  SqliteDatabase::Statement commitTxn = db->prepare(TRUSTED_TXN_COMMIT, "COMMIT TRANSACTION");
 
   kj::Maybe<kj::Exception> broken;
 


### PR DESCRIPTION
I noticed the test was testing for an "internal error", which is always a bug, and implies that in prod an error would have been logged to Sentry. We can make this throw an application-visible error instead. This also makes the test output look less bad.