### PR TITLE
Python pools: Remove lockfile and indexURL arguments from getEmscriptenSettings

### DIFF
--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -78,17 +78,17 @@ async function prepareWasmLinearMemory(Module: Module): Promise<void> {
 }
 
 export async function loadPyodide(
+  isWorkerd: boolean,
   lockfile: PackageLock,
   indexURL: string
 ): Promise<Pyodide> {
   const Module = await enterJaegerSpan('instantiate_emscripten', () =>
-    instantiateEmscriptenModule(
-      lockfile,
-      indexURL,
-      pythonStdlib,
-      pyodideWasmModule
-    )
+    instantiateEmscriptenModule(isWorkerd, pythonStdlib, pyodideWasmModule)
   );
+  if (isWorkerd) {
+    Module.API.config.indexURL = indexURL;
+    Module.API.config.resolveLockFilePromise!(lockfile);
+  }
   setUnsafeEval(UnsafeEval);
   setGetRandomValues(getRandomValues);
   await enterJaegerSpan('prepare_wasm_linear_memory', () =>

--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -37,7 +37,7 @@ function getPyodide(): Promise<Pyodide> {
     if (pyodidePromise) {
       return pyodidePromise;
     }
-    pyodidePromise = loadPyodide(LOCKFILE, WORKERD_INDEX_URL);
+    pyodidePromise = loadPyodide(IS_WORKERD, LOCKFILE, WORKERD_INDEX_URL);
     return pyodidePromise;
   });
 }

--- a/src/pyodide/types/emscripten.d.ts
+++ b/src/pyodide/types/emscripten.d.ts
@@ -1,11 +1,17 @@
 interface ENV {
   HOME: string;
+  [k: string]: string;
+}
+
+interface PyodideConfig {
+  env: ENV;
+  jsglobals: any;
+  resolveLockFilePromise?: (lockfile: PackageLock) => void;
+  indexURL?: string;
 }
 
 interface API {
-  config: {
-    env: ENV;
-  };
+  config: PyodideConfig;
   finalizeBootstrap: () => void;
   public_api: Pyodide;
   rawRun: (code: string) => [status: number, err: string];


### PR DESCRIPTION
Instead, just pass `isWorkerd` and then set up lockfile and indexURL in python.ts