### PR TITLE
Streaming Trace, Part 3: Add toObject(js) methods to trace structs

### DIFF
--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -188,6 +188,10 @@ kj::Maybe<TraceItem::EventInfo> getTraceEvent(jsg::Lock& js, const Trace& trace)
       KJ_CASE_ONEOF(custom, trace::CustomEventInfo) {
         return kj::Maybe(jsg::alloc<TraceItem::CustomEventInfo>(trace, custom));
       }
+      KJ_CASE_ONEOF(custome, trace::Tags) {
+        // The legacy trace format does not support trace::Tags in the Trace.
+        return kj::Maybe(jsg::alloc<TraceItem::CustomEventInfo>(trace, trace::CustomEventInfo{}));
+      }
     }
   }
   return kj::none;

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -162,6 +162,7 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":worker-interface_capnp",
+        "//src/workerd/jsg",
         "//src/workerd/jsg:memory-tracker",
         "//src/workerd/util",
         "//src/workerd/util:own-util",

--- a/src/workerd/io/trace-legacy.c++
+++ b/src/workerd/io/trace-legacy.c++
@@ -116,6 +116,10 @@ void Trace::copyTo(rpc::Trace::Builder builder) {
       KJ_CASE_ONEOF(custom, trace::CustomEventInfo) {
         eventInfoBuilder.initCustom();
       }
+      KJ_CASE_ONEOF(custom, trace::Tags) {
+        // The legacy trace format does not support tags in the Trace.
+        eventInfoBuilder.initCustom();
+      }
     }
   } else {
     eventInfoBuilder.setNone();
@@ -251,6 +255,7 @@ void Trace::setEventInfo(kj::Date timestamp, trace::EventInfo&& info) {
     KJ_CASE_ONEOF(_, trace::TraceEventInfo) {}
     KJ_CASE_ONEOF(_, trace::HibernatableWebSocketEventInfo) {}
     KJ_CASE_ONEOF(_, trace::CustomEventInfo) {}
+    KJ_CASE_ONEOF(_, trace::Tags) {}
   }
   bytesUsed = newSize;
   onsetInfo.info = kj::mv(info);

--- a/src/workerd/io/trace-streaming.h
+++ b/src/workerd/io/trace-streaming.h
@@ -74,6 +74,7 @@ struct StreamEvent final {
 
   void copyTo(rpc::Trace::StreamEvent::Builder builder) const;
   StreamEvent clone() const;
+  jsg::JsObject toObject(jsg::Lock&, trace::NameProvider) const;
 };
 
 // ======================================================================================
@@ -114,7 +115,7 @@ public:
     // random UUIDs. This should generally only be used in local development
     // or standalone uses of workerd.
     static kj::Own<IdFactory> newUuidIdFactory();
-    static kj::Own<const IdFactory::Id> newIdFromString(kj::StringPtr str);
+    static kj::Own<IdFactory::Id> newIdFromString(kj::StringPtr str);
   };
 
   // The delegate is the piece that actually handles the output of the stream events

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -266,6 +266,7 @@ struct Trace @0x8e8d911203762d34 {
       none @1 :Void;
       fetch @2 :FetchEventInfo;
       jsRpc @3 :JsRpcEventInfo;
+      custom @4 :List(Tag);
     }
   }
 


### PR DESCRIPTION
These don't really need to be represented as JSG_STRUCT because we do not need bidirectional conversion.