### PR TITLE
VS-284: Add Bindings support for Vectorize queryById operation

### DIFF
--- a/src/cloudflare/internal/test/vectorize/vectorize-api-test.js
+++ b/src/cloudflare/internal/test/vectorize/vectorize-api-test.js
@@ -58,6 +58,45 @@ export const test_vector_search_vector_query = {
     }
 
     {
+      // with returnValues = true, returnMetadata = "indexed"
+      const results = await IDX.queryById('some-vector-id', {
+        topK: 3,
+        returnValues: true,
+        returnMetadata: 'indexed',
+      });
+      assert.equal(true, results.count > 0);
+      /** @type {VectorizeMatches}  */
+      const expected = {
+        matches: [
+          {
+            id: 'b0daca4a-ffd8-4865-926b-e24800af2a2d',
+            values: [0.2331, 1.0125, 0.6131, 0.9421, 0.9661, 0.8121],
+            metadata: { text: 'She sells seashells by the seashore' },
+            score: 0.71151,
+          },
+          {
+            id: 'a44706aa-a366-48bc-8cc1-3feffd87d548',
+            values: [0.2321, 0.8121, 0.6315, 0.6151, 0.4121, 0.1512],
+            metadata: {
+              text: 'Peter Piper picked a peck of pickled peppers',
+            },
+            score: 0.68913,
+          },
+          {
+            id: '43cfcb31-07e2-411f-8bf9-f82a95ba8b96',
+            values: [0.0515, 0.7512, 0.8612, 0.2153, 0.15121, 0.6812],
+            metadata: {
+              text: 'You know New York, you need New York, you know you need unique New York',
+            },
+            score: 0.94812,
+          },
+        ],
+        count: 3,
+      };
+      assert.deepStrictEqual(results, expected);
+    }
+
+    {
       // with returnValues = unset (false), returnMetadata = false ("none")
       const results = await IDX.query(new Float32Array(new Array(5).fill(0)), {
         topK: 3,

--- a/src/cloudflare/internal/test/vectorize/vectorize-mock.js
+++ b/src/cloudflare/internal/test/vectorize/vectorize-mock.js
@@ -97,7 +97,7 @@ export default {
       ) {
         return Response.json({});
       } else if (request.method === 'POST' && pathname.endsWith('/query')) {
-        /** @type {VectorizeQueryOptions & {vector: number[]}} */
+        /** @type {VectorizeQueryOptions & ({vector: number[]} | {vectorId: string})} */
         const body = await request.json();
         let returnSet = structuredClone(exampleVectorMatches);
         if (

--- a/src/cloudflare/internal/vectorize.d.ts
+++ b/src/cloudflare/internal/vectorize.d.ts
@@ -244,6 +244,16 @@ declare abstract class Vectorize {
     options?: VectorizeQueryOptions
   ): Promise<VectorizeMatches>;
   /**
+   * Use the provided vector-id to perform a similarity search across the index.
+   * @param vectorId Id for a vector in the index against which the index should be queried.
+   * @param options Configuration options to massage the returned data.
+   * @returns A promise that resolves with matched and scored vectors.
+   */
+  public queryById(
+    vectorId: string,
+    options?: VectorizeQueryOptions
+  ): Promise<VectorizeMatches>;
+  /**
    * Insert a list of vectors into the index dataset. If a provided id exists, an error will be thrown.
    * @param vectors List of vectors that will be inserted.
    * @returns A promise that resolves with a unique identifier of a mutation containing the insert changeset.

--- a/types/defines/vectorize.d.ts
+++ b/types/defines/vectorize.d.ts
@@ -236,6 +236,16 @@ declare abstract class Vectorize {
     options?: VectorizeQueryOptions
   ): Promise<VectorizeMatches>;
   /**
+   * Use the provided vector-id to perform a similarity search across the index.
+   * @param vectorId Id for a vector in the index against which the index should be queried.
+   * @param options Configuration options to massage the returned data.
+   * @returns A promise that resolves with matched and scored vectors.
+   */
+  public queryById(
+    vectorId: string,
+    options?: VectorizeQueryOptions
+  ): Promise<VectorizeMatches>;
+  /**
    * Insert a list of vectors into the index dataset. If a provided id exists, an error will be thrown.
    * @param vectors List of vectors that will be inserted.
    * @returns A promise that resolves with a unique identifier of a mutation containing the insert changeset.


### PR DESCRIPTION
Add a new Vectorize operation for Bindings: `queryById()` that allows users to query their index using a vector already present in the index.