### PR TITLE
Implements the start of an SDK for Python Workers.

### DIFF
--- a/src/pyodide/internal/workers.py
+++ b/src/pyodide/internal/workers.py
@@ -1,0 +1,78 @@
+# This module defines a Workers API for Python. It is similar to the API provided by
+# JS Workers, but with changes and additions to be more idiomatic to the Python
+# programming language.
+from http import HTTPMethod, HTTPStatus
+from typing import TypedDict, Unpack
+
+import js
+
+import pyodide.http
+from pyodide.http import pyfetch
+
+JSBody = (
+    "js.Blob | js.ArrayBuffer | js.TypedArray | js.DataView | js.FormData |"
+    "js.ReadableStream | js.URLSearchParams"
+)
+Body = "str | JSBody"
+Headers = dict[str, str] | list[tuple[str, str]]
+
+
+class FetchKwargs(TypedDict, total=False):
+    headers: Headers | None
+    body: "Body | None"
+    method: HTTPMethod = HTTPMethod.GET
+
+
+# TODO: This is just here to make the `body` field available as many Workers
+# examples which rewrite responses make use of it. It's something we should
+# likely upstream to Pyodide.
+class FetchResponse(pyodide.http.FetchResponse):
+    @property
+    def body(self) -> Body:
+        """
+        Returns the body from the JavaScript Response instance.
+        """
+        return self.js_response.body
+
+
+async def fetch(
+    resource: str,
+    **other_options: Unpack[FetchKwargs],
+) -> FetchResponse:
+    if "method" in other_options and isinstance(other_options["method"], HTTPMethod):
+        other_options["method"] = other_options["method"].value
+    resp = await pyfetch(resource, **other_options)
+    return FetchResponse(resp.url, resp.js_response)
+
+
+class Response:
+    def __init__(
+        self,
+        body: Body,
+        status: HTTPStatus | int = HTTPStatus.OK,
+        statusText="",
+        headers: Headers = None,
+    ):
+        """
+        Represents the response to a request.
+
+        Based on the JS API of the same name:
+        https://developer.mozilla.org/en-US/docs/Web/API/Response/Response.
+        """
+        options = {
+            "status": status.value if isinstance(status, HTTPStatus) else status,
+        }
+        if len(statusText) > 0:
+            options["statusText"] = statusText
+        if headers:
+            if isinstance(headers, list):
+                # We should have a list[tuple[str, str]]
+                options["headers"] = js.Headers.new(headers)
+            elif isinstance(headers, dict):
+                options["headers"] = js.Headers.new(headers.items())
+            else:
+                raise TypeError(
+                    "Response() received unexpected type for headers argument"
+                )
+
+        self.js_response = js.Response.new(body, **options)

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -26,6 +26,17 @@ py_wd_test(
 )
 
 py_wd_test(
+    src = "sdk/sdk.wd-test",
+    args = ["--experimental"],
+    data = glob(
+        [
+            "sdk/*",
+        ],
+        exclude = ["**/*.wd-test"],
+    ),
+)
+
+py_wd_test(
     src = "env-param/env.wd-test",
     args = ["--experimental"],
     data = glob(

--- a/src/workerd/server/tests/python/sdk/mock.py
+++ b/src/workerd/server/tests/python/sdk/mock.py
@@ -1,0 +1,17 @@
+from cloudflare.workers import Response
+
+
+async def on_fetch(request):
+    if request.url.endswith("/sub"):
+        return Response("Hi there!")
+    elif request.url.endswith("/sub_headers"):
+        assert request.headers.get("Custom-Req-Header") == "123"
+        return Response(
+            "Hi there!", headers={"Custom-Header-That-Should-Passthrough": True}
+        )
+    else:
+        raise ValueError("Unexpected path " + request.url)
+
+
+def test():
+    pass

--- a/src/workerd/server/tests/python/sdk/sdk.wd-test
+++ b/src/workerd/server/tests/python/sdk/sdk.wd-test
@@ -1,0 +1,31 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const python :Workerd.Worker = (
+  modules = [
+    (name = "worker.py", pythonModule = embed "worker.py")
+  ],
+  bindings = [
+    ( name = "SELF", service = "python-sdk" ),
+  ],
+  compatibilityDate = "2024-10-01",
+  compatibilityFlags = ["python_workers_development", "python_external_bundle"],
+);
+
+const mock :Workerd.Worker = (
+  modules = [
+    (name = "mock.py", pythonModule = embed "mock.py")
+  ],
+  compatibilityDate = "2024-10-01",
+  compatibilityFlags = ["python_workers_development", "python_external_bundle"],
+);
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "python-sdk",
+      worker = .python
+    ),
+    ( name = "internet",
+      worker = .mock
+    )
+  ],
+);

--- a/src/workerd/server/tests/python/sdk/worker.py
+++ b/src/workerd/server/tests/python/sdk/worker.py
@@ -1,0 +1,84 @@
+from http import HTTPMethod
+
+from cloudflare.workers import Response, fetch
+
+
+async def on_fetch(request):
+    if request.url.endswith("/modify"):
+        resp = await fetch("https://example.com/sub")
+        return Response(
+            resp.body,
+            status=201,
+            headers={"Custom-Header-That-Should-Passthrough": "modified"},
+        )
+    elif request.url.endswith("/modify_tuple"):
+        resp = await fetch("https://example.com/sub")
+        return Response(
+            resp.body,
+            headers=[
+                ("Custom-Header-That-Should-Passthrough", "modified"),
+                ("Custom-Header-That-Should-Passthrough", "another"),
+            ],
+        )
+    elif request.url.endswith("/fetch_opts"):
+        resp = await fetch(
+            "https://example.com/sub_headers",
+            method=HTTPMethod.GET,
+            body=None,
+            headers={"Custom-Req-Header": 123},
+        )
+        return resp
+    else:
+        resp = await fetch("https://example.com/sub")
+        return resp
+
+
+# TODO: Right now the `fetch` that's available on a binding is the JS fetch.
+# We may wish to rewrite it to be the same as the `fetch` defined in
+# `cloudflare.workers`. Doing so will require a feature flag.
+
+
+async def can_return_custom_fetch_response(env):
+    response = await env.SELF.fetch(
+        "http://example.com/",
+    )
+    text = await response.text()
+    assert text == "Hi there!"
+
+
+async def can_modify_response(env):
+    response = await env.SELF.fetch(
+        "http://example.com/modify",
+    )
+    text = await response.text()
+    assert text == "Hi there!"
+    assert response.status == 201
+    assert response.headers.get("Custom-Header-That-Should-Passthrough") == "modified"
+
+
+async def can_use_duplicate_headers(env):
+    response = await env.SELF.fetch(
+        "http://example.com/modify_tuple",
+    )
+    text = await response.text()
+    assert text == "Hi there!"
+    assert (
+        response.headers.get("Custom-Header-That-Should-Passthrough")
+        == "modified, another"
+    )
+
+
+async def can_use_fetch_opts(env):
+    response = await env.SELF.fetch(
+        "http://example.com/fetch_opts",
+    )
+    text = await response.text()
+    assert text == "Hi there!"
+    assert response.headers.get("Custom-Header-That-Should-Passthrough") == "true"
+
+
+async def test(ctrl, env):
+    await can_return_custom_fetch_response(env)
+    await can_modify_response(env)
+    await can_use_duplicate_headers(env)
+    await can_use_fetch_opts(env)


### PR DESCRIPTION
Implements the beginnings of a Python SDK, an API that makes writing Python Workers easier as it avoids dealing with awkward details of the Pyodide JS FFI. This PR implements the following:

* a new `cloudflare.workers` module which contains the API
* a `fetch` function defined in that module which accepts native Python types like HTTPMethod, it calls into Pyodide's `pyfetch` which offers many other niceties
* a `Response` function which creates a new `Response` instance and accepts native Python types like HTTPStatus
* support for returning a Pyodide FetchResponse from the `on_fetch` handler
* a custom `FetchResponse` which makes it possible to access the JS ReadableStream via `body` (this is often used in examples which rewrite a response). This is probably something we want to upstream to Pyodide.

This is just the start and the plan is to add more APIs into this module. For example, I want to make an idiomatic version of `FormData` and I'm sure we'll run into other cases where an idiomatic wrapper around the JS API makes sense.

### Test Plan

```
$ bazel run @workerd//src/workerd/server/tests/python:sdk/sdk
```