### PR TITLE
feat: add remaining workflow instance status types

### DIFF
--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -41,12 +41,14 @@ declare abstract class Workflow {
 
 type InstanceStatus = {
   status:
-    | 'queued'
+    | 'queued' // means that instance is waiting to be started (see concurrency limits)
     | 'running'
     | 'paused'
     | 'errored'
-    | 'terminated'
+    | 'terminated' // user terminated the instance while it was running
     | 'complete'
+    | 'waiting' // instance is hibernating and waiting for sleep or event to finish
+    | 'waitingForPause' // instance is finishing the current work to pause
     | 'unknown';
   error?: string;
   output?: object;

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -27,12 +27,14 @@ declare abstract class Workflow {
 
 type InstanceStatus = {
   status:
-    | "queued"
+    | "queued" // means that instance is waiting to be started (see concurrency limits)
     | "running"
     | "paused"
     | "errored"
-    | "terminated"
+    | "terminated" // user terminated the instance while it was running
     | "complete"
+    | "waiting" // instance is hibernating and waiting for sleep or event to finish
+    | "waitingForPause" // instance is finishing the current work to pause
     | "unknown";
   error?: string;
   output?: object;


### PR DESCRIPTION
Adds `waiting` and `waitingForPause` status to `InstanceStatus` to match UI/Wrangler