### PR TITLE
Roll boringssl

### DIFF
--- a/build/deps/deps.jsonc
+++ b/build/deps/deps.jsonc
@@ -14,11 +14,12 @@
       "type": "github_tarball",
       "owner": "google",
       "repo": "boringssl",
-      "branch": "master-with-bazel",
-      // from main-with-bazel branch. Later boringssl versions have bazel support on the main
-      // branch, so using the custom branch with a different directory structure will no longer be
-      // needed in the future.
-      "freeze_commit": "c08ccc9ed166a82b92edd70ab215ae1f2501e838"
+      "branch": "master",
+      // boringssl may subtly break backwards compatibility and behave differently than the latest
+      // FIPS version, often by rejecting key values that it considers invalid/unsafe even though
+      // they are still accepted by boringssl. Update with caution and only after confirming this
+      // is compatible with the downstream build.
+      "freeze_commit": "6abe18402eb2a5e9b00158c6459646a948c53060"
     },
     {
       "name": "ada-url",

--- a/build/deps/gen/dep_ssl.bzl
+++ b/build/deps/gen/dep_ssl.bzl
@@ -2,11 +2,11 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-URL = "https://github.com/google/boringssl/tarball/c08ccc9ed166a82b92edd70ab215ae1f2501e838"
-STRIP_PREFIX = "google-boringssl-c08ccc9"
-SHA256 = "7c0822ba820a2d3c11d1cc2b533ea0c220224b11ac50ab56d97ce0b5fb57b303"
+URL = "https://github.com/google/boringssl/tarball/6abe18402eb2a5e9b00158c6459646a948c53060"
+STRIP_PREFIX = "google-boringssl-6abe184"
+SHA256 = "76962c003a298f405d1a5d273a74a94f58b69f65d64b8574a82d4c21c5e407be"
 TYPE = "tgz"
-COMMIT = "c08ccc9ed166a82b92edd70ab215ae1f2501e838"
+COMMIT = "6abe18402eb2a5e9b00158c6459646a948c53060"
 
 def dep_ssl():
     http_archive(

--- a/src/workerd/api/crypto/dh.c++
+++ b/src/workerd/api/crypto/dh.c++
@@ -104,11 +104,8 @@ kj::Own<DH> initDh(kj::OneOf<kj::Array<kj::byte>, int>& sizeOrKey,
             return 1;
           };
           // Operations on an "egregiously large" prime will throw with recent boringssl.
-          // TODO(soon): Convert this and the other invalid parameter warning to user errors if
-          // possible.
-          if (size > OPENSSL_DH_MAX_MODULUS_BITS) {
-            KJ_LOG(WARNING, "DiffieHellman init: requested prime size too large");
-          }
+          JSG_REQUIRE(size <= OPENSSL_DH_MAX_MODULUS_BITS, RangeError,
+              "DiffieHellman init failed: requested prime size too large");
           if (!DH_generate_parameters_ex(dh.get(), size, gen, &cb)) {
             KJ_IF_SOME(outcome, status.status) {
               if (outcome == EventOutcome::EXCEEDED_CPU) {
@@ -121,11 +118,10 @@ kj::Own<DH> initDh(kj::OneOf<kj::Array<kj::byte>, int>& sizeOrKey,
             }
             JSG_FAIL_REQUIRE(Error, "DiffieHellman init failed: could not generate parameters");
           }
-          // Boringssl throws on DH with g >= p or g | 2 since g can't be an element of p's
+          // Boringssl throws on DH with g >= p or p | 2 since g can't be an element of p's
           // multiplicative group in that case.
-          if (!BN_is_odd(DH_get0_p(dh)) || BN_ucmp(DH_get0_g(dh), DH_get0_p(dh)) >= 0) {
-            KJ_LOG(WARNING, "DiffieHellman init: Invalid generated DH prime");
-          }
+          JSG_REQUIRE(BN_is_odd(DH_get0_p(dh)) && BN_ucmp(DH_get0_g(dh), DH_get0_p(dh)) < 0, Error,
+              "DiffieHellman init failed: Invalid DH prime generated");
           return kj::mv(dh);
         }
         KJ_CASE_ONEOF(gen, kj::Array<kj::byte>) {
@@ -136,13 +132,10 @@ kj::Own<DH> initDh(kj::OneOf<kj::Array<kj::byte>, int>& sizeOrKey,
       }
     }
     KJ_CASE_ONEOF(key, kj::Array<kj::byte>) {
-      JSG_REQUIRE(
-          key.size() <= INT32_MAX, RangeError, "DiffieHellman init failed: key is too large");
-      JSG_REQUIRE(key.size() > 0, Error, "DiffieHellman init failed: invalid key");
       // Operations on an "egregiously large" prime will throw with boringssl.
-      if (key.size() > OPENSSL_DH_MAX_MODULUS_BITS / CHAR_BIT) {
-        KJ_LOG(WARNING, "DiffieHellman init: prime too large");
-      }
+      JSG_REQUIRE(key.size() <= OPENSSL_DH_MAX_MODULUS_BITS / CHAR_BIT, RangeError,
+          "DiffieHellman init failed: key is too large");
+      JSG_REQUIRE(key.size() > 0, Error, "DiffieHellman init failed: invalid key");
       auto dh = OSSL_NEW(DH);
 
       // We use a std::unique_ptr here instead of a kj::Own because DH_set0_pqg takes ownership
@@ -173,11 +166,10 @@ kj::Own<DH> initDh(kj::OneOf<kj::Array<kj::byte>, int>& sizeOrKey,
       UniqueBignum bn_p(toBignumUnowned(key), &BN_clear_free);
       JSG_REQUIRE(bn_p != nullptr, Error,
           "DiffieHellman init failed: could not convert key representation");
-      // Boringssl throws on DH with g >= p or g | 2 since g can't be an element of p's
+      // Boringssl throws on DH with g >= p or p | 2 since g can't be an element of p's
       // multiplicative group in that case.
-      if (!BN_is_odd(bn_p.get()) || BN_ucmp(bn_g.get(), bn_p.get()) >= 0) {
-        KJ_LOG(WARNING, "DiffieHellman init: Invalid DH prime generated");
-      }
+      JSG_REQUIRE(BN_is_odd(bn_p.get()) && BN_ucmp(bn_g.get(), bn_p.get()) < 0, Error,
+          "DiffieHellman init failed: Invalid DH prime generated");
       JSG_REQUIRE(DH_set0_pqg(dh, bn_p.get(), nullptr, bn_g.get()), Error,
           "DiffieHellman init failed: could not set keys");
       bn_g.release();


### PR DESCRIPTION
Follow-up to #2745. After confirming that the few cases where DH inputs that are now rejected by boringssl are not being actively used in production, we can return a proper error for them and update the boringssl version for workerd. With the new version, we're moving 13 months forward. Even if the version used internally is out-of-sync for now, the added checks here ensure that the behavior is the same.
Test cases are updated based on the new behavior.