### PR TITLE
Implement support for macOS Apple Silicon => x86_64 cross compilation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -221,6 +221,19 @@ build:macos --copt='-femit-dwarf-unwind=no-compact-unwind'
 # TODO(soon): File a bazel issue for the flag so we can drop this.
 build:macos --experimental_objc_fastbuild_options=""
 
+# Cross-Compilation
+# Only cross-compiling on macOS from Apple Silicon to x86_64 is supported – using apple_support
+# makes this much easier than on other platforms. We could define a configuration for cross-
+# compiling from Intel Mac too, but it lacks a means to run Apple Silicon binaries. We would have to
+# change V8 mksnapshot to build in the host configuration again (effectively compiling much of V8
+# twice) and couldn't run tests, so it would provide little value.
+#
+# Define the target platform
+build:macos-cross-x86_64 --cpu=darwin_x86_64 --host_cpu=darwin_arm64 --platforms //:macOS_x86
+# Some cross-compiled tests are slower when run over Rosetta, increase the medium test size timeout.
+# Test performance is still very much satisfactory considering that emulation is being used here.
+build:macos-cross-x86_64 --test_timeout=1,30,60,240
+
 # On Linux, always link libc++ statically to avoid compatibility issues with different OS versions.
 # macOS links with dynamic libc++ by default, which has good backwards compatibility.
 # Drop default link flags, which include libstdc++ for Linux

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -46,6 +46,15 @@ platform(
     ],
 )
 
+# Used for cross-compilation
+platform(
+    name = "macOS_x86",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 # bazel enables the --ffunction-sections, --gc-sections flags used to remove dead code by default
 # on Linux opt builds. Enable the equivalent macOS flag -Wl,-dead_strip here to work around bazel
 # idiosyncrasies.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -178,8 +178,11 @@ rules_rust_dependencies()
 
 rust_register_toolchains(
     edition = "2021",
-    # Rust registers wasm targets by default which we don't need, workerd is only built for its native platform.
-    extra_target_triples = [],
+    # Add support macOS cross-compilation, the overhead for this is limited with only a few more
+    # targets being generated for the extra triple as part of the toolchain. Setting this explicitly
+    # also avoids registering support for the wasm32-unknown-unknown and wasm32-wasi targets, which
+    # are otherwise added by default.
+    extra_target_triples = ["x86_64-apple-darwin"],
     versions = ["1.81.0"],  # LLVM 18
 )
 


### PR DESCRIPTION
I hope to use this in CI in the near future to compile x86 release binaries on Apple Silicon to make this process faster and have access to the latest compiler version. That can be discussed in detail on another issue.