### PR TITLE
[build] Define CI-friendly bazel configuration, silence noisy Windows warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,10 @@ build --experimental_remote_cache_eviction_retries=3
 # similar bugs in the past. Disable BwoB for now.
 build:windows --remote_download_all
 
+# Import CI-specific configuration. As the amount of custom configuration settings we use grows,
+# consider moving more flags out to separate files.
+import %workspace%/build/ci.bazelrc
+
 # Enable webgpu
 build --//src/workerd/io:enable_experimental_webgpu=True
 
@@ -84,9 +88,15 @@ https://libcxx.llvm.org/DesignDocs/HeaderRemovalPolicy.html
 build:unix --cxxopt=-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES
 build:unix --host_cxxopt=-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES
 
-# Need to redefine _WIN32_WINNT to build dawn on Windows
-build:windows --per_file_copt='external/dawn@-Wno-macro-redefined'
-build:windows --host_per_file_copt='external/dawn@-Wno-macro-redefined'
+# V8 redefines the _WIN32_WINNT set by bazel, disable warnings for redefined macros. Since V8 uses
+# a global define for this, we need to apply it for everything.
+# TODO(cleanup): Patch upstream V8 to use local_defines for this instead.
+build:windows --copt='-Wno-macro-redefined'
+build:windows --host_copt='-Wno-macro-redefined'
+# Dawn/Tint adds compiler flags that are ignored on Windows
+build:windows --per_file_copt='external/dawn@-Wno-unknown-argument'
+build:windows --host_per_file_copt='external/dawn@-Wno-unknown-argument'
+
 # V8 now requires Windows 10, Bazel fails to set this properly.
 build:windows --per_file_copt=external/v8/src/base/platform/platform-win32.cc@-D_WIN32_WINNT=0x0A00
 build:windows --host_per_file_copt=external/v8/src/base/platform/platform-win32.cc@-D_WIN32_WINNT=0x0A00

--- a/.github/workflows/npm-types.yml
+++ b/.github/workflows/npm-types.yml
@@ -56,7 +56,7 @@ jobs:
             echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang --host_action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
       - name: build types
         run: |
-            bazel build --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=release_linux //types:types
+            bazel build --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types:types
       - name: Build package
         run: node npm/scripts/build-types-package.mjs
         env:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -107,7 +107,7 @@ jobs:
           echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang --host_action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
       - name: Build type generating Worker
         run: |
-          bazel build --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=release_linux //types:types_worker
+          bazel build --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types:types_worker
 
       - name: Modify package.json version
         run: node npm/scripts/bump-version.mjs npm/workerd/package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
         # static libraries, for example the Rust STL. This is equivalent to the -Wl,-S linker
         # option, symbols will not be removed.
         run: |
-          bazelisk build --jobs=32 --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=${{ matrix.bazel-config }} //src/workerd/server:workerd
+          bazel build --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=${{ matrix.bazel-config }} //src/workerd/server:workerd
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,19 +172,13 @@ jobs:
         # Configure git to quell an irrelevant warning for runners (they never commit / push).
         run: git config core.hooksPath githooks
       - name: Bazel build
-        # Use a higher jobs level to effectively fetch from CPU and and use the remote cache at the
-        # same time, see https://github.com/bazelbuild/bazel/issues/6394. 32 is still a fairly
-        # small number here and should work for the small CI runners we use, if we switch to a
-        # bigger runner consider increasing this towards the suggested value of 200.
-        # Note the number of maximum build jobs is controlled by the --local_resources=cpu flag and
-        # still limited to the number of cores by default.
         # timestamps are no longer being added here, the GitHub logs include timestamps (Use
         # 'Show timestamps' on the web interface)
         run: |
-          bazelisk build --remote_download_minimal ${{ matrix.config.bazel-args }} --jobs=32 --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --verbose_failures --config=v8-codegen-opt //...
+          bazel build --remote_download_minimal ${{ matrix.config.bazel-args }} --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=v8-codegen-opt //...
       - name: Bazel test
         run: |
-          bazelisk test --remote_download_minimal ${{ matrix.config.bazel-args }} --jobs=32 --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --keep_going --verbose_failures --test_output=errors --config=v8-codegen-opt //...
+          bazel test --remote_download_minimal ${{ matrix.config.bazel-args }} --disk_cache=~/bazel-disk-cache --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --test_output=errors --config=ci --config=v8-codegen-opt //...
       - name: Report disk usage (in MB)
         if: always()
         shell: bash
@@ -215,4 +209,4 @@ jobs:
           fi
       - name: Bazel shutdown
         # Check that there are no .bazelrc issues that prevent shutdown.
-        run: bazelisk shutdown
+        run: bazel shutdown

--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -1,0 +1,20 @@
+# CI-only configuration. Some of these settings are inspired by bazel-lib https://github.com/bazel-contrib/bazel-lib/blob/v2.9.3/.aspect/bazelrc/ci.bazelrc
+# Not all shared options in the GitHub CI are ported since we use a different remote cache setup for
+# internal CI.
+build:ci --keep_going
+build:ci --verbose_failures
+# Use a higher jobs level to effectively fetch from CPU and and use the remote cache at the same
+# time, see https://github.com/bazelbuild/bazel/issues/6394. 32 is still a fairly small number here
+# and should work for the small CI runners we use, if we switch to a bigger runner consider
+# increasing this closer towards the suggested value of 200. Note the number of maximum build jobs
+# is controlled by the --local_resources=cpu flag and still limited to the number of cores by
+# default.
+build:ci --jobs=32
+# Do not check for changes in external repository files, should speed up bazel invocations after the first one
+build:ci --noexperimental_check_external_repository_files
+# Rate limit progress updates for smaller logs, default is 0.2 which leads to very frequent updates.
+build:ci --show_progress_rate_limit=1
+# Enable color output
+build:ci --color=yes
+# Indicate support for more terminal columns, 100 is the line length recommended by KJ style.
+build:ci --terminal_columns=100


### PR DESCRIPTION
[build] Define CI-friendly bazel configuration
The only material change is to add keep_going for all bazel invocations. So far
we bailed out early during the build step of the test action based on concerns
about runs that rebuild V8 not failing fast, but it feels more useful to keep
going to get all of the error messages since V8 rebuilds are rare.

[build] Silence noisy Windows warnings
This makes the Windows build log much smaller.