### PR TITLE
Move class impl out of server.h

### DIFF
--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -248,61 +248,6 @@ private:
 
 // An ActorStorage implementation which will always respond to reads as if the state is empty,
 // and will fail any writes.
-class EmptyReadOnlyActorStorageImpl final: public rpc::ActorStorage::Stage::Server {
-public:
-  kj::Promise<void> get(GetContext context) override {
-    return kj::READY_NOW;
-  }
-  kj::Promise<void> getMultiple(GetMultipleContext context) override {
-    return context.getParams()
-        .getStream()
-        .endRequest(capnp::MessageSize{2, 0})
-        .send()
-        .ignoreResult();
-  }
-  kj::Promise<void> list(ListContext context) override {
-    return context.getParams()
-        .getStream()
-        .endRequest(capnp::MessageSize{2, 0})
-        .send()
-        .ignoreResult();
-  }
-  kj::Promise<void> getAlarm(GetAlarmContext context) override {
-    return kj::READY_NOW;
-  }
-  kj::Promise<void> txn(TxnContext context) override {
-    auto results = context.getResults(capnp::MessageSize{2, 1});
-    results.setTransaction(kj::heap<TransactionImpl>());
-    return kj::READY_NOW;
-  }
-
-private:
-  class TransactionImpl final: public rpc::ActorStorage::Stage::Transaction::Server {
-  protected:
-    kj::Promise<void> get(GetContext context) override {
-      return kj::READY_NOW;
-    }
-    kj::Promise<void> getMultiple(GetMultipleContext context) override {
-      return context.getParams()
-          .getStream()
-          .endRequest(capnp::MessageSize{2, 0})
-          .send()
-          .ignoreResult();
-    }
-    kj::Promise<void> list(ListContext context) override {
-      return context.getParams()
-          .getStream()
-          .endRequest(capnp::MessageSize{2, 0})
-          .send()
-          .ignoreResult();
-    }
-    kj::Promise<void> getAlarm(GetAlarmContext context) override {
-      return kj::READY_NOW;
-    }
-    kj::Promise<void> commit(CommitContext context) override {
-      return kj::READY_NOW;
-    }
-  };
-};
+kj::Own<rpc::ActorStorage::Stage::Server> newEmptyReadOnlyActorStorage();
 
 }  // namespace workerd::server

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -359,7 +359,7 @@ TestFixture::TestFixture(SetupParams&& params)
       auto makeActorCache = [](const ActorCache::SharedLru& sharedLru, OutputGate& outputGate,
                                 ActorCache::Hooks& hooks, SqliteObserver& sqliteObserver) {
         return kj::heap<ActorCache>(
-            kj::heap<server::EmptyReadOnlyActorStorageImpl>(), sharedLru, outputGate, hooks);
+            server::newEmptyReadOnlyActorStorage(), sharedLru, outputGate, hooks);
       };
       auto makeStorage =
           [](jsg::Lock& js, const Worker::Api& api,


### PR DESCRIPTION
There's no need to have the class implementation in the header file.