### PR TITLE
Simplify PipelineTracer

### DIFF
--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -591,7 +591,7 @@ kj::Rc<WorkerTracer> PipelineTracer::makeWorkerTracer(PipelineLogLevel pipelineL
       kj::mv(dispatchNamespace), kj::mv(scriptId), kj::mv(scriptTags), kj::mv(entrypoint),
       executionModel);
   traces.add(kj::addRef(*trace));
-  return kj::rc<WorkerTracer>(kj::addRef(*this), kj::mv(trace), pipelineLogLevel);
+  return kj::rc<WorkerTracer>(addRefToThis(), kj::mv(trace), pipelineLogLevel);
 }
 
 void PipelineTracer::addTrace(rpc::Trace::Reader reader) {
@@ -599,7 +599,7 @@ void PipelineTracer::addTrace(rpc::Trace::Reader reader) {
 }
 
 WorkerTracer::WorkerTracer(
-    kj::Own<PipelineTracer> parentPipeline, kj::Own<Trace> trace, PipelineLogLevel pipelineLogLevel)
+    kj::Rc<PipelineTracer> parentPipeline, kj::Own<Trace> trace, PipelineLogLevel pipelineLogLevel)
     : pipelineLogLevel(pipelineLogLevel),
       trace(kj::mv(trace)),
       parentPipeline(kj::mv(parentPipeline)),

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -559,13 +559,14 @@ void SpanBuilder::addLog(kj::Date timestamp, kj::ConstString key, TagValue value
 }
 
 PipelineTracer::~PipelineTracer() noexcept(false) {
-  KJ_IF_SOME(p, parentTracer) {
-    for (auto& t: traces) {
-      p->traces.add(kj::addRef(*t));
-    }
-  }
   KJ_IF_SOME(f, completeFulfiller) {
     f.get()->fulfill(traces.releaseAsArray());
+  }
+}
+
+void PipelineTracer::addTracesFromChild(kj::ArrayPtr<kj::Own<Trace>> traces) {
+  for (auto& t: traces) {
+    this->traces.add(kj::addRef(*t));
   }
 }
 

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -335,7 +335,7 @@ class WorkerTracer;
 // A tracer which records traces for a set of stages. All traces for a pipeline's stages and
 // possible subpipeline stages are recorded here, where they can be used to call a pipeline's
 // trace worker.
-class PipelineTracer final: public kj::Refcounted {
+class PipelineTracer final: public kj::Refcounted, public kj::EnableAddRefToThis<PipelineTracer> {
 public:
   // Creates a pipeline tracer (with a possible parent).
   explicit PipelineTracer() = default;
@@ -376,7 +376,7 @@ private:
 // via extractTrace.
 class WorkerTracer final: public kj::Refcounted {
 public:
-  explicit WorkerTracer(kj::Own<PipelineTracer> parentPipeline,
+  explicit WorkerTracer(kj::Rc<PipelineTracer> parentPipeline,
       kj::Own<Trace> trace,
       PipelineLogLevel pipelineLogLevel);
   explicit WorkerTracer(PipelineLogLevel pipelineLogLevel, ExecutionModel executionModel);
@@ -432,7 +432,7 @@ private:
 
   // own an instance of the pipeline to make sure it doesn't get destroyed
   // before we're finished tracing
-  kj::Maybe<kj::Own<PipelineTracer>> parentPipeline;
+  kj::Maybe<kj::Rc<PipelineTracer>> parentPipeline;
   // A weak reference for the internal span submitter. We use this so that the span submitter can
   // add spans while the tracer exists, but does not artifically prolong the lifetime of the tracer
   // which would interfere with span submission (traces get submitted when the worker returns its

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -338,20 +338,13 @@ class WorkerTracer;
 class PipelineTracer final: public kj::Refcounted {
 public:
   // Creates a pipeline tracer (with a possible parent).
-  explicit PipelineTracer(kj::Maybe<kj::Own<PipelineTracer>> parentPipeline = kj::none)
-      : parentTracer(kj::mv(parentPipeline)) {}
-
+  explicit PipelineTracer() = default;
   ~PipelineTracer() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(PipelineTracer);
 
   // Returns a promise that fulfills when traces are complete.  Only one such promise can
   // exist at a time.
   kj::Promise<kj::Array<kj::Own<Trace>>> onComplete();
-
-  // Makes a tracer for a subpipeline.
-  kj::Own<PipelineTracer> makePipelineSubtracer() {
-    return kj::refcounted<PipelineTracer>(kj::addRef(*this));
-  }
 
   // Makes a tracer for a worker stage.
   kj::Rc<WorkerTracer> makeWorkerTracer(PipelineLogLevel pipelineLogLevel,
@@ -368,11 +361,11 @@ public:
   // to the host where tracing was initiated.
   void addTrace(rpc::Trace::Reader reader);
 
+  void addTracesFromChild(kj::ArrayPtr<kj::Own<Trace>> traces);
+
 private:
   kj::Vector<kj::Own<Trace>> traces;
   kj::Maybe<kj::Own<kj::PromiseFulfiller<kj::Array<kj::Own<Trace>>>>> completeFulfiller;
-
-  kj::Maybe<kj::Own<PipelineTracer>> parentTracer;
 
   friend class WorkerTracer;
 };

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -361,6 +361,8 @@ public:
   // to the host where tracing was initiated.
   void addTrace(rpc::Trace::Reader reader);
 
+  // When collecting traces from multiple stages in a pipeline, this is called by the
+  // tracer for a subordinate stage to add its collected traces to the parent pipeline.
   void addTracesFromChild(kj::ArrayPtr<kj::Own<Trace>> traces);
 
 private:


### PR DESCRIPTION
Eliminate internal nesting of PipelineTracers. Use the resolved on complete promise to propagate traces up to the parent.

This was originally done as part of the larger PR to introduce streaming traces but makes sense to pull out separately here.