### PR TITLE
add complete node:url implementation

### DIFF
--- a/src/node/internal/internal_querystring.ts
+++ b/src/node/internal/internal_querystring.ts
@@ -9,7 +9,7 @@ import { ERR_INVALID_URI } from 'node-internal:internal_errors';
 type EncodeFunction = (value: string) => string;
 type DecodeFunction = (value: string) => string;
 
-const hexTable = new Array(256) as string[];
+export const hexTable = new Array(256) as string[];
 for (let i = 0; i < 256; ++i) {
   hexTable[i] = '%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase();
 }
@@ -35,7 +35,7 @@ const isHexTable = new Int8Array([
 ]);
 
 /* eslint-disable */
-function encodeStr(
+export function encodeStr(
   str: string,
   noEscapeTable: Int8Array,
   hexTable: string[]
@@ -339,8 +339,8 @@ function addKeyVal(
 
 export function parse(
   qs: string,
-  sep: string,
-  eq: string,
+  sep?: string,
+  eq?: string,
   options?: {
     maxKeys?: number;
     decodeURIComponent?: DecodeFunction;

--- a/src/node/internal/internal_url.ts
+++ b/src/node/internal/internal_url.ts
@@ -258,3 +258,54 @@ export function toPathIfFileURL(fileURLOrPath: URL | string): string {
   if (!isURL(fileURLOrPath)) return fileURLOrPath;
   return fileURLToPath(fileURLOrPath);
 }
+
+/**
+ * Utility function that converts a URL object into an ordinary options object
+ * as expected by the `http.request` and `https.request` APIs.
+ * @param {URL} url
+ * @returns {Record<string, unknown>}
+ */
+export function urlToHttpOptions(url: URL): Record<string, unknown> {
+  const { hostname, pathname, port, username, password, search } = url;
+  const options: Record<string, unknown> = {
+    __proto__: null,
+    ...url, // In case the url object was extended by the user.
+    protocol: url.protocol,
+    hostname:
+      hostname && hostname[0] === '[' ? hostname.slice(1, -1) : hostname,
+    hash: url.hash,
+    search: search,
+    pathname: pathname,
+    path: `${pathname || ''}${search || ''}`,
+    href: url.href,
+  };
+  if (port !== '') {
+    options.port = Number(port);
+  }
+  if (username || password) {
+    options.auth = `${decodeURIComponent(username)}:${decodeURIComponent(password)}`;
+  }
+  return options;
+}
+
+// Protocols that can allow "unsafe" and "unwise" chars.
+export const unsafeProtocol = new Set<string>(['javascript', 'javascript:']);
+// Protocols that never have a hostname.
+export const hostlessProtocol = new Set<string>(['javascript', 'javascript:']);
+// Protocols that always contain a // bit.
+export const slashedProtocol = new Set<string>([
+  'http',
+  'http:',
+  'https',
+  'https:',
+  'ftp',
+  'ftp:',
+  'gopher',
+  'gopher:',
+  'file',
+  'file:',
+  'ws',
+  'ws:',
+  'wss',
+  'wss:',
+]);

--- a/src/node/internal/legacy_url.ts
+++ b/src/node/internal/legacy_url.ts
@@ -1,0 +1,1018 @@
+import { validateString, validateObject } from 'node-internal:validators';
+import {
+  CHAR_SPACE,
+  CHAR_TAB,
+  CHAR_CARRIAGE_RETURN,
+  CHAR_LINE_FEED,
+  CHAR_NO_BREAK_SPACE,
+  CHAR_ZERO_WIDTH_NOBREAK_SPACE,
+  CHAR_HASH,
+  CHAR_FORWARD_SLASH,
+  CHAR_LEFT_SQUARE_BRACKET,
+  CHAR_RIGHT_SQUARE_BRACKET,
+  CHAR_LEFT_ANGLE_BRACKET,
+  CHAR_RIGHT_ANGLE_BRACKET,
+  CHAR_LEFT_CURLY_BRACKET,
+  CHAR_RIGHT_CURLY_BRACKET,
+  CHAR_QUESTION_MARK,
+  CHAR_DOUBLE_QUOTE,
+  CHAR_SINGLE_QUOTE,
+  CHAR_PERCENT,
+  CHAR_SEMICOLON,
+  CHAR_BACKWARD_SLASH,
+  CHAR_CIRCUMFLEX_ACCENT,
+  CHAR_GRAVE_ACCENT,
+  CHAR_VERTICAL_LINE,
+  CHAR_AT,
+  CHAR_COLON,
+} from 'node-internal:constants';
+import {
+  parse as querystringParse,
+  stringify as querystringStringify,
+  encodeStr,
+  hexTable,
+} from 'node-internal:internal_querystring';
+import {
+  slashedProtocol,
+  hostlessProtocol,
+  unsafeProtocol,
+} from 'node-internal:internal_url';
+import {
+  ERR_INVALID_URL,
+  ERR_INVALID_ARG_TYPE,
+} from 'node-internal:internal_errors';
+import { default as urlUtil } from 'node-internal:url';
+import { spliceOne } from 'node-internal:internal_utils';
+
+// Reference: RFC 3986, RFC 1808, RFC 2396
+
+// define these here so at least they only have to be
+// compiled once on the first module load.
+const protocolPattern = /^[a-z0-9.+-]+:/i;
+const portPattern = /:[0-9]*$/;
+const hostPattern = /^\/\/[^@/]+@[^@/]+/;
+
+// Special case for a simple path URL
+const simplePathPattern = /^(\/\/?(?!\/)[^?\s]*)(\?[^\s]*)?$/;
+
+const hostnameMaxLen = 255;
+
+// This prevents some common spoofing bugs due to our use of IDNA toASCII. For
+// compatibility, the set of characters we use here is the *intersection* of
+// "forbidden host code point" in the WHATWG URL Standard [1] and the
+// characters in the host parsing loop in Url.prototype.parse, with the
+// following additions:
+//
+// - ':' since this could cause a "protocol spoofing" bug
+// - '@' since this could cause parts of the hostname to be confused with auth
+// - '[' and ']' since this could cause a non-IPv6 hostname to be interpreted
+//   as IPv6 by isIpv6Hostname above
+//
+// [1]: https://url.spec.whatwg.org/#forbidden-host-code-point
+const forbiddenHostChars = /[\0\t\n\r #%/:<>?@[\\\]^|]/;
+// For IPv6, permit '[', ']', and ':'.
+const forbiddenHostCharsIpv6 = /[\0\t\n\r #%/<>?@\\^|]/;
+
+function getHostname(self: typeof Url, rest: string, hostname: string): string {
+  for (let i = 0; i < hostname.length; ++i) {
+    const code = hostname.charCodeAt(i);
+    const isValid =
+      code !== CHAR_FORWARD_SLASH &&
+      code !== CHAR_BACKWARD_SLASH &&
+      code !== CHAR_HASH &&
+      code !== CHAR_QUESTION_MARK &&
+      code !== CHAR_COLON;
+
+    if (!isValid) {
+      self.hostname = hostname.slice(0, i);
+      return `/${hostname.slice(i)}${rest}`;
+    }
+  }
+  return rest;
+}
+
+function isIpv6Hostname(hostname: string): boolean {
+  return (
+    hostname.charCodeAt(0) === CHAR_LEFT_SQUARE_BRACKET &&
+    hostname.charCodeAt(hostname.length - 1) === CHAR_RIGHT_SQUARE_BRACKET
+  );
+}
+
+// Escaped characters. Use empty strings to fill up unused entries.
+// Using Array is faster than Object/Map
+// prettier-ignore
+const escapedCodes = [
+  /* 0 - 9 */ '', '', '', '', '', '', '', '', '', '%09',
+  /* 10 - 19 */ '%0A', '', '', '%0D', '', '', '', '', '', '',
+  /* 20 - 29 */ '', '', '', '', '', '', '', '', '', '',
+  /* 30 - 39 */ '', '', '%20', '', '%22', '', '', '', '', '%27',
+  /* 40 - 49 */ '', '', '', '', '', '', '', '', '', '',
+  /* 50 - 59 */ '', '', '', '', '', '', '', '', '', '',
+  /* 60 - 69 */ '%3C', '', '%3E', '', '', '', '', '', '', '',
+  /* 70 - 79 */ '', '', '', '', '', '', '', '', '', '',
+  /* 80 - 89 */ '', '', '', '', '', '', '', '', '', '',
+  /* 90 - 99 */ '', '', '%5C', '', '%5E', '', '%60', '', '', '',
+  /* 100 - 109 */ '', '', '', '', '', '', '', '', '', '',
+  /* 110 - 119 */ '', '', '', '', '', '', '', '', '', '',
+  /* 120 - 125 */ '', '', '', '%7B', '%7C', '%7D',
+];
+
+// Automatically escape all delimiters and unwise characters from RFC 2396.
+// Also escape single quotes in case of an XSS attack.
+// Return the escaped string.
+function autoEscapeStr(rest: string): string {
+  let escaped = '';
+  let lastEscapedPos = 0;
+  for (let i = 0; i < rest.length; ++i) {
+    // `escaped` contains substring up to the last escaped character.
+    const escapedChar = escapedCodes[rest.charCodeAt(i)];
+    if (escapedChar) {
+      // Concat if there are ordinary characters in the middle.
+      if (i > lastEscapedPos) escaped += rest.slice(lastEscapedPos, i);
+      escaped += escapedChar;
+      lastEscapedPos = i + 1;
+    }
+  }
+  if (lastEscapedPos === 0)
+    // Nothing has been escaped.
+    return rest;
+
+  // There are ordinary characters at the end.
+  if (lastEscapedPos < rest.length) escaped += rest.slice(lastEscapedPos);
+
+  return escaped;
+}
+
+export const Url = function Url(this: Record<string, null>) {
+  this.protocol = null;
+  this.slashes = null;
+  this.auth = null;
+  this.host = null;
+  this.port = null;
+  this.hostname = null;
+  this.hash = null;
+  this.search = null;
+  this.query = null;
+  this.pathname = null;
+  this.path = null;
+  this.href = null;
+} as unknown as {
+  protocol?: string | null | undefined;
+  slashes?: boolean | null | undefined;
+  auth?: string | null | undefined;
+  host?: string | null | undefined;
+  port?: string | null | undefined;
+  hostname?: string | null | undefined;
+  hash?: string | null | undefined;
+  search?: string | null | undefined;
+  query?: Record<string, unknown> | string | null | undefined;
+  pathname?: string | null | undefined;
+  path?: string | null | undefined;
+  href?: string | null | undefined;
+
+  new (): typeof Url;
+  prototype: typeof Url;
+
+  parse(
+    url: string | typeof Url,
+    parseQueryString?: boolean,
+    slashesDenoteHost?: boolean
+  ): typeof Url;
+  parseHost(): void;
+  format(): string;
+  resolve(from: string): string;
+  resolveObject(input: string | typeof Url): typeof Url;
+  parseHost(): void;
+};
+
+Url.prototype.parse = function parse(
+  this: typeof Url,
+  url: string | typeof Url,
+  parseQueryString?: boolean,
+  slashesDenoteHost?: boolean
+): typeof Url {
+  validateString(url, 'url');
+
+  // Copy chrome, IE, opera backslash-handling behavior.
+  // Backslashes before the query string get converted to forward slashes
+  // See: https://code.google.com/p/chromium/issues/detail?id=25916
+  let hasHash = false;
+  let hasAt = false;
+  let start = -1;
+  let end = -1;
+  let rest = '';
+  let lastPos = 0;
+  for (let i = 0, inWs = false, split = false; i < url.length; ++i) {
+    const code = url.charCodeAt(i);
+
+    // Find first and last non-whitespace characters for trimming
+    const isWs =
+      code < 33 ||
+      code === CHAR_NO_BREAK_SPACE ||
+      code === CHAR_ZERO_WIDTH_NOBREAK_SPACE;
+    if (start === -1) {
+      if (isWs) continue;
+      lastPos = start = i;
+    } else if (inWs) {
+      if (!isWs) {
+        end = -1;
+        inWs = false;
+      }
+    } else if (isWs) {
+      end = i;
+      inWs = true;
+    }
+
+    // Only convert backslashes while we haven't seen a split character
+    if (!split) {
+      switch (code) {
+        case CHAR_AT:
+          hasAt = true;
+          break;
+        case CHAR_HASH:
+          hasHash = true;
+          split = true;
+          break;
+        case CHAR_QUESTION_MARK:
+          split = true;
+          break;
+        case CHAR_BACKWARD_SLASH:
+          if (i - lastPos > 0) rest += url.slice(lastPos, i);
+          rest += '/';
+          lastPos = i + 1;
+          break;
+      }
+    } else if (!hasHash && code === CHAR_HASH) {
+      hasHash = true;
+    }
+  }
+
+  // Check if string was non-empty (including strings with only whitespace)
+  if (start !== -1) {
+    if (lastPos === start) {
+      // We didn't convert any backslashes
+
+      if (end === -1) {
+        if (start === 0) rest = url;
+        else rest = url.slice(start);
+      } else {
+        rest = url.slice(start, end);
+      }
+    } else if (end === -1 && lastPos < url.length) {
+      // We converted some backslashes and have only part of the entire string
+      rest += url.slice(lastPos);
+    } else if (end !== -1 && lastPos < end) {
+      // We converted some backslashes and have only part of the entire string
+      rest += url.slice(lastPos, end);
+    }
+  }
+
+  if (!slashesDenoteHost && !hasHash && !hasAt) {
+    // Try fast path regexp
+    const simplePath = simplePathPattern.exec(rest);
+    if (simplePath) {
+      this.path = rest;
+      this.href = rest;
+      this.pathname = simplePath[1];
+      if (simplePath[2]) {
+        this.search = simplePath[2];
+        if (parseQueryString) {
+          this.query = querystringParse(this.search.slice(1));
+        } else {
+          this.query = this.search.slice(1);
+        }
+      } else if (parseQueryString) {
+        this.search = null;
+        this.query = { __proto__: null };
+      }
+      return this;
+    }
+  }
+
+  let proto: string | RegExpExecArray | null = protocolPattern.exec(rest);
+  let lowerProto;
+  if (proto) {
+    proto = proto[0];
+    lowerProto = proto.toLowerCase();
+    this.protocol = lowerProto;
+    rest = rest.slice(proto.length);
+  }
+
+  // Figure out if it's got a host
+  // user@server is *always* interpreted as a hostname, and url
+  // resolution will treat //foo/bar as host=foo,path=bar because that's
+  // how the browser resolves relative URLs.
+  let slashes;
+  if (slashesDenoteHost || proto || hostPattern.test(rest)) {
+    slashes =
+      rest.charCodeAt(0) === CHAR_FORWARD_SLASH &&
+      rest.charCodeAt(1) === CHAR_FORWARD_SLASH;
+    if (slashes && !(proto && hostlessProtocol.has(lowerProto as string))) {
+      rest = rest.slice(2);
+      this.slashes = true;
+    }
+  }
+
+  if (
+    !hostlessProtocol.has(lowerProto as string) &&
+    (slashes || (proto && !slashedProtocol.has(proto)))
+  ) {
+    // there's a hostname.
+    // the first instance of /, ?, ;, or # ends the host.
+    //
+    // If there is an @ in the hostname, then non-host chars *are* allowed
+    // to the left of the last @ sign, unless some host-ending character
+    // comes *before* the @-sign.
+    // URLs are obnoxious.
+    //
+    // ex:
+    // http://a@b@c/ => user:a@b host:c
+    // http://a@b?@c => user:a host:b path:/?@c
+
+    let hostEnd = -1;
+    let atSign = -1;
+    let nonHost = -1;
+    for (let i = 0; i < rest.length; ++i) {
+      switch (rest.charCodeAt(i)) {
+        case CHAR_TAB:
+        case CHAR_LINE_FEED:
+        case CHAR_CARRIAGE_RETURN:
+          // WHATWG URL removes tabs, newlines, and carriage returns. Let's do that too.
+          rest = rest.slice(0, i) + rest.slice(i + 1);
+          i -= 1;
+          break;
+        case CHAR_SPACE:
+        case CHAR_DOUBLE_QUOTE:
+        case CHAR_PERCENT:
+        case CHAR_SINGLE_QUOTE:
+        case CHAR_SEMICOLON:
+        case CHAR_LEFT_ANGLE_BRACKET:
+        case CHAR_RIGHT_ANGLE_BRACKET:
+        case CHAR_BACKWARD_SLASH:
+        case CHAR_CIRCUMFLEX_ACCENT:
+        case CHAR_GRAVE_ACCENT:
+        case CHAR_LEFT_CURLY_BRACKET:
+        case CHAR_VERTICAL_LINE:
+        case CHAR_RIGHT_CURLY_BRACKET:
+          // Characters that are never ever allowed in a hostname from RFC 2396
+          if (nonHost === -1) nonHost = i;
+          break;
+        case CHAR_HASH:
+        case CHAR_FORWARD_SLASH:
+        case CHAR_QUESTION_MARK:
+          // Find the first instance of any host-ending characters
+          if (nonHost === -1) nonHost = i;
+          hostEnd = i;
+          break;
+        case CHAR_AT:
+          // At this point, either we have an explicit point where the
+          // auth portion cannot go past, or the last @ char is the decider.
+          atSign = i;
+          nonHost = -1;
+          break;
+      }
+      if (hostEnd !== -1) break;
+    }
+    start = 0;
+    if (atSign !== -1) {
+      this.auth = decodeURIComponent(rest.slice(0, atSign));
+      start = atSign + 1;
+    }
+    if (nonHost === -1) {
+      this.host = rest.slice(start);
+      rest = '';
+    } else {
+      this.host = rest.slice(start, nonHost);
+      rest = rest.slice(nonHost);
+    }
+
+    // pull out port.
+    this.parseHost();
+
+    // We've indicated that there is a hostname,
+    // so even if it's empty, it has to be present.
+    if (typeof this.hostname !== 'string') this.hostname = '';
+
+    const hostname = this.hostname;
+
+    // If hostname begins with [ and ends with ]
+    // assume that it's an IPv6 address.
+    const ipv6Hostname = isIpv6Hostname(hostname);
+
+    // validate a little.
+    if (!ipv6Hostname) {
+      rest = getHostname(this, rest, hostname);
+    }
+
+    if (this.hostname.length > hostnameMaxLen) {
+      this.hostname = '';
+    } else {
+      // Hostnames are always lower case.
+      this.hostname = this.hostname.toLowerCase();
+    }
+
+    if (this.hostname !== '') {
+      if (ipv6Hostname) {
+        if (forbiddenHostCharsIpv6.test(this.hostname)) {
+          throw new ERR_INVALID_URL(url);
+        }
+      } else {
+        // IDNA Support: Returns a punycoded representation of "domain".
+        // It only converts parts of the domain name that
+        // have non-ASCII characters, i.e. it doesn't matter if
+        // you call it with a domain that already is ASCII-only.
+        this.hostname = urlUtil.toASCII(this.hostname);
+
+        // Prevent two potential routes of hostname spoofing.
+        // 1. If this.hostname is empty, it must have become empty due to toASCII
+        //    since we checked this.hostname above.
+        // 2. If any of forbiddenHostChars appears in this.hostname, it must have
+        //    also gotten in due to toASCII. This is since getHostname would have
+        //    filtered them out otherwise.
+        // Rather than trying to correct this by moving the non-host part into
+        // the pathname as we've done in getHostname, throw an exception to
+        // convey the severity of this issue.
+        if (this.hostname === '' || forbiddenHostChars.test(this.hostname)) {
+          throw new ERR_INVALID_URL(url);
+        }
+      }
+    }
+
+    const p = this.port ? ':' + this.port : '';
+    const h = this.hostname || '';
+    this.host = h + p;
+
+    // strip [ and ] from the hostname
+    // the host field still retains them, though
+    if (ipv6Hostname) {
+      this.hostname = this.hostname.slice(1, -1);
+      if (rest[0] !== '/') {
+        rest = '/' + rest;
+      }
+    }
+  }
+
+  // Now rest is set to the post-host stuff.
+  // Chop off any delim chars.
+  if (!unsafeProtocol.has(lowerProto as string)) {
+    // First, make 100% sure that any "autoEscape" chars get
+    // escaped, even if encodeURIComponent doesn't think they
+    // need to be.
+    rest = autoEscapeStr(rest);
+  }
+
+  let questionIdx = -1;
+  let hashIdx = -1;
+  for (let i = 0; i < rest.length; ++i) {
+    const code = rest.charCodeAt(i);
+    if (code === CHAR_HASH) {
+      this.hash = rest.slice(i);
+      hashIdx = i;
+      break;
+    } else if (code === CHAR_QUESTION_MARK && questionIdx === -1) {
+      questionIdx = i;
+    }
+  }
+
+  if (questionIdx !== -1) {
+    if (hashIdx === -1) {
+      this.search = rest.slice(questionIdx);
+      this.query = rest.slice(questionIdx + 1);
+    } else {
+      this.search = rest.slice(questionIdx, hashIdx);
+      this.query = rest.slice(questionIdx + 1, hashIdx);
+    }
+    if (parseQueryString) {
+      this.query = querystringParse(this.query);
+    }
+  } else if (parseQueryString) {
+    // No query string, but parseQueryString still requested
+    this.search = null;
+    this.query = { __proto__: null };
+  }
+
+  const useQuestionIdx =
+    questionIdx !== -1 && (hashIdx === -1 || questionIdx < hashIdx);
+  const firstIdx = useQuestionIdx ? questionIdx : hashIdx;
+  if (firstIdx === -1) {
+    if (rest.length > 0) this.pathname = rest;
+  } else if (firstIdx > 0) {
+    this.pathname = rest.slice(0, firstIdx);
+  }
+  if (
+    slashedProtocol.has(lowerProto as string) &&
+    this.hostname &&
+    !this.pathname
+  ) {
+    this.pathname = '/';
+  }
+
+  // To support http.request
+  if (this.pathname || this.search) {
+    const p = this.pathname || '';
+    const s = this.search || '';
+    this.path = p + s;
+  }
+
+  // Finally, reconstruct the href based on what has been validated.
+  this.href = this.format();
+  return this;
+};
+
+// These characters do not need escaping:
+// ! - . _ ~
+// ' ( ) * :
+// digits
+// alpha (uppercase)
+// alpha (lowercase)
+// prettier-ignore
+const noEscapeAuth = new Int8Array([
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x00 - 0x0F
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x10 - 0x1F
+  0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, // 0x20 - 0x2F
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, // 0x30 - 0x3F
+  0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x40 - 0x4F
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, // 0x50 - 0x5F
+  0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x60 - 0x6F
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0, // 0x70 - 0x7F
+]);
+
+Url.prototype.format = function format(this: typeof Url): string {
+  let auth = this.auth || '';
+  if (auth) {
+    auth = encodeStr(auth, noEscapeAuth, hexTable);
+    auth += '@';
+  }
+
+  let protocol = this.protocol || '';
+  let pathname = this.pathname || '';
+  let hash = this.hash || '';
+  let host = '';
+  let query = '';
+
+  if (this.host) {
+    host = auth + this.host;
+  } else if (this.hostname) {
+    host =
+      auth +
+      (this.hostname.includes(':') && !isIpv6Hostname(this.hostname)
+        ? '[' + this.hostname + ']'
+        : this.hostname);
+    if (this.port) {
+      host += ':' + this.port;
+    }
+  }
+
+  if (this.query !== null && typeof this.query === 'object') {
+    query = querystringStringify(this.query);
+  }
+
+  let search = this.search || (query && '?' + query) || '';
+
+  if (protocol && protocol.charCodeAt(protocol.length - 1) !== 58 /* : */)
+    protocol += ':';
+
+  let newPathname = '';
+  let lastPos = 0;
+  for (let i = 0; i < pathname.length; ++i) {
+    switch (pathname.charCodeAt(i)) {
+      case CHAR_HASH:
+        if (i - lastPos > 0) newPathname += pathname.slice(lastPos, i);
+        newPathname += '%23';
+        lastPos = i + 1;
+        break;
+      case CHAR_QUESTION_MARK:
+        if (i - lastPos > 0) newPathname += pathname.slice(lastPos, i);
+        newPathname += '%3F';
+        lastPos = i + 1;
+        break;
+    }
+  }
+  if (lastPos > 0) {
+    if (lastPos !== pathname.length)
+      pathname = newPathname + pathname.slice(lastPos);
+    else pathname = newPathname;
+  }
+
+  // Only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
+  // unless they had them to begin with.
+  if (this.slashes || slashedProtocol.has(protocol)) {
+    if (this.slashes || host) {
+      if (pathname && pathname.charCodeAt(0) !== CHAR_FORWARD_SLASH)
+        pathname = '/' + pathname;
+      host = '//' + host;
+    } else if (
+      protocol.length >= 4 &&
+      protocol.charCodeAt(0) === 102 /* f */ &&
+      protocol.charCodeAt(1) === 105 /* i */ &&
+      protocol.charCodeAt(2) === 108 /* l */ &&
+      protocol.charCodeAt(3) === 101 /* e */
+    ) {
+      host = '//';
+    }
+  }
+
+  search = search.replace(/#/g, '%23');
+
+  if (hash && hash.charCodeAt(0) !== CHAR_HASH) hash = '#' + hash;
+  if (search && search.charCodeAt(0) !== CHAR_QUESTION_MARK)
+    search = '?' + search;
+
+  return protocol + host + pathname + search + hash;
+};
+
+export function resolve(source: typeof Url | string, relative: string): string {
+  return parse(source, false, true).resolve(relative);
+}
+
+Url.prototype.resolveObject = function resolveObject(
+  relative: string | typeof Url
+): typeof Url {
+  if (typeof relative === 'string') {
+    const rel = new Url();
+    rel.parse(relative, false, true);
+    relative = rel;
+  }
+
+  const result = new Url();
+  Object.assign(result, this);
+
+  // Hash is always overridden, no matter what.
+  // even href="" will remove it.
+  result.hash = relative.hash;
+
+  // If the relative url is empty, then there's nothing left to do here.
+  if (relative.href === '') {
+    result.href = result.format();
+    return result;
+  }
+
+  // Hrefs like //foo/bar always cut to the protocol.
+  if (relative.slashes && !relative.protocol) {
+    // Take everything except the protocol from relative
+    const relativeWithoutProtocol = Object.keys(relative).reduce((acc, key) => {
+      if (key !== 'protocol') {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        acc[key] = relative[key];
+      }
+      return acc;
+    }, {});
+    Object.assign(result, relativeWithoutProtocol);
+
+    // urlParse appends trailing / to urls like http://www.example.com
+    if (
+      slashedProtocol.has(result.protocol as string) &&
+      result.hostname &&
+      !result.pathname
+    ) {
+      result.path = result.pathname = '/';
+    }
+
+    result.href = result.format();
+    return result;
+  }
+
+  if (relative.protocol && relative.protocol !== result.protocol) {
+    // If it's a known url protocol, then changing
+    // the protocol does weird things
+    // first, if it's not file:, then we MUST have a host,
+    // and if there was a path
+    // to begin with, then we MUST have a path.
+    // if it is file:, then the host is dropped,
+    // because that's known to be hostless.
+    // anything else is assumed to be absolute.
+    if (!slashedProtocol.has(relative.protocol)) {
+      Object.assign(result, relative);
+      result.href = result.format();
+      return result;
+    }
+
+    result.protocol = relative.protocol;
+    if (
+      !relative.host &&
+      !/^file:?$/.test(relative.protocol) &&
+      !hostlessProtocol.has(relative.protocol)
+    ) {
+      const relPath = (relative.pathname || '').split('/');
+      while (relPath.length && !(relative.host = relPath.shift())) {
+        // keep this empty.
+      }
+      relative.host ||= '';
+      relative.hostname ||= '';
+      if (relPath[0] !== '') relPath.unshift('');
+      if (relPath.length < 2) relPath.unshift('');
+      result.pathname = relPath.join('/');
+    } else {
+      result.pathname = relative.pathname;
+    }
+    result.search = relative.search;
+    result.query = relative.query;
+    result.host = relative.host || '';
+    result.auth = relative.auth;
+    result.hostname = relative.hostname || relative.host;
+    result.port = relative.port;
+    // To support http.request
+    if (result.pathname || result.search) {
+      const p = result.pathname || '';
+      const s = result.search || '';
+      result.path = p + s;
+    }
+    result.slashes ||= relative.slashes;
+    result.href = result.format();
+    return result;
+  }
+
+  const isSourceAbs = result.pathname && result.pathname.charAt(0) === '/';
+  const isRelAbs =
+    relative.host || (relative.pathname && relative.pathname.charAt(0) === '/');
+  let mustEndAbs =
+    !!isRelAbs ||
+    !!isSourceAbs ||
+    (!!result.host && !!relative.pathname) ||
+    false;
+  const removeAllDots = mustEndAbs;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  let srcPath = (result.pathname && result.pathname.split('/')) || [];
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const relPath = (relative.pathname && relative.pathname.split('/')) || [];
+  const noLeadingSlashes =
+    result.protocol && !slashedProtocol.has(result.protocol);
+
+  // If the url is a non-slashed url, then relative
+  // links like ../.. should be able
+  // to crawl up to the hostname, as well.  This is strange.
+  // result.protocol has already been set by now.
+  // Later on, put the first path part into the host field.
+  if (noLeadingSlashes) {
+    result.hostname = '';
+    result.port = null;
+    if (result.host) {
+      if (srcPath[0] === '') srcPath[0] = result.host;
+      else srcPath.unshift(result.host);
+    }
+    result.host = '';
+    if (relative.protocol) {
+      relative.hostname = null;
+      relative.port = null;
+      result.auth = null;
+      if (relative.host) {
+        if (relPath[0] === '') relPath[0] = relative.host;
+        else relPath.unshift(relative.host);
+      }
+      relative.host = null;
+    }
+    mustEndAbs &&= relPath[0] === '' || srcPath[0] === '';
+  }
+
+  if (isRelAbs) {
+    // it's absolute.
+    if (relative.host || relative.host === '') {
+      if (result.host !== relative.host) result.auth = null;
+      result.host = relative.host;
+      result.port = relative.port;
+    }
+    if (relative.hostname || relative.hostname === '') {
+      if (result.hostname !== relative.hostname) result.auth = null;
+      result.hostname = relative.hostname;
+    }
+    result.search = relative.search;
+    result.query = relative.query;
+    srcPath = relPath;
+    // Fall through to the dot-handling below.
+  } else if (relPath.length) {
+    // it's relative
+    // throw away the existing file, and take the new path instead.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    srcPath ||= [];
+    srcPath.pop();
+    srcPath = srcPath.concat(relPath);
+    result.search = relative.search;
+    result.query = relative.query;
+  } else if (relative.search !== null && relative.search !== undefined) {
+    // Just pull out the search.
+    // like href='?foo'.
+    // Put this after the other two cases because it simplifies the booleans
+    if (noLeadingSlashes) {
+      result.hostname = result.host = srcPath.shift();
+      // Occasionally the auth can get stuck only in host.
+      // This especially happens in cases like
+      // url.resolveObject('mailto:local1@domain1', 'local2@domain2')
+      const authInHost =
+        result.host && result.host.indexOf('@') > 0 && result.host.split('@');
+      if (authInHost) {
+        result.auth = authInHost.shift();
+        result.host = result.hostname = authInHost.shift();
+      }
+    }
+    result.search = relative.search;
+    result.query = relative.query;
+    // To support http.request
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (result.pathname !== null || result.search !== null) {
+      result.path =
+        (result.pathname ? result.pathname : '') +
+        (result.search ? result.search : '');
+    }
+    result.href = result.format();
+    return result;
+  }
+
+  if (!srcPath.length) {
+    // No path at all. All other things were already handled above.
+    result.pathname = null;
+    // To support http.request
+    if (result.search) {
+      result.path = '/' + result.search;
+    } else {
+      result.path = null;
+    }
+    result.href = result.format();
+    return result;
+  }
+
+  // If a url ENDs in . or .., then it must get a trailing slash.
+  // however, if it ends in anything else non-slashy,
+  // then it must NOT get a trailing slash.
+  let last = srcPath.slice(-1)[0];
+  const hasTrailingSlash =
+    ((result.host || relative.host || srcPath.length > 1) &&
+      (last === '.' || last === '..')) ||
+    last === '';
+
+  // Strip single dots, resolve double dots to parent dir
+  // if the path tries to go above the root, `up` ends up > 0
+  let up = 0;
+  for (let i = srcPath.length - 1; i >= 0; i--) {
+    last = srcPath[i];
+    if (last === '.') {
+      spliceOne(srcPath, i);
+    } else if (last === '..') {
+      spliceOne(srcPath, i);
+      up++;
+    } else if (up) {
+      spliceOne(srcPath, i);
+      up--;
+    }
+  }
+
+  // If the path is allowed to go above the root, restore leading ..s
+  if (!mustEndAbs && !removeAllDots) {
+    while (up--) {
+      srcPath.unshift('..');
+    }
+  }
+
+  if (
+    mustEndAbs &&
+    srcPath[0] !== '' &&
+    (!srcPath[0] || srcPath[0].charAt(0) !== '/')
+  ) {
+    srcPath.unshift('');
+  }
+
+  if (hasTrailingSlash && srcPath.join('/').slice(-1) !== '/') {
+    srcPath.push('');
+  }
+
+  const isAbsolute =
+    srcPath[0] === '' || (srcPath[0] && srcPath[0].charAt(0) === '/');
+
+  // put the host back
+  if (noLeadingSlashes) {
+    result.hostname = result.host = isAbsolute
+      ? ''
+      : srcPath.length
+        ? srcPath.shift()
+        : '';
+    // Occasionally the auth can get stuck only in host.
+    // This especially happens in cases like
+    // url.resolveObject('mailto:local1@domain1', 'local2@domain2')
+    const authInHost =
+      result.host && result.host.indexOf('@') > 0
+        ? result.host.split('@')
+        : false;
+    if (authInHost) {
+      result.auth = authInHost.shift();
+      result.host = result.hostname = authInHost.shift();
+    }
+  }
+
+  mustEndAbs ||= Boolean(result.host && srcPath.length);
+
+  if (mustEndAbs && !isAbsolute) {
+    srcPath.unshift('');
+  }
+
+  if (!srcPath.length) {
+    result.pathname = null;
+    result.path = null;
+  } else {
+    result.pathname = srcPath.join('/');
+  }
+
+  // To support request.http
+  if (result.pathname !== null || result.search !== null) {
+    result.path =
+      (result.pathname ? result.pathname : '') +
+      (result.search ? result.search : '');
+  }
+  result.auth = relative.auth || result.auth;
+  result.slashes ||= relative.slashes;
+  result.href = result.format();
+  return result;
+};
+
+Url.prototype.resolve = function resolve(
+  this: typeof Url,
+  relative: string
+): string {
+  return this.resolveObject(parse(relative, false, true)).format();
+};
+
+Url.prototype.parseHost = function parseHost(this: typeof Url): void {
+  let host = this.host as string;
+  let port: RegExpExecArray | string | null = portPattern.exec(host);
+  if (port) {
+    port = port[0];
+    if (port !== ':') {
+      this.port = port.slice(1);
+    }
+    host = host.slice(0, host.length - port.length);
+  }
+  if (host) this.hostname = host;
+};
+
+export function parse(
+  url: typeof Url | string,
+  parseQueryString?: boolean,
+  slashesDenoteHost?: boolean
+): typeof Url {
+  if (url instanceof Url) return url;
+
+  const urlObject = new Url();
+  urlObject.parse(url, parseQueryString, slashesDenoteHost);
+  return urlObject;
+}
+
+// Format a parsed object into a url string
+export function format(
+  urlObject: typeof Url | URL | string | null,
+  options: unknown
+): string {
+  // Ensure it's an object, and not a string url.
+  // If it's an object, this is a no-op.
+  // this way, you can call urlParse() on strings
+  // to clean up potentially wonky urls.
+  if (typeof urlObject === 'string') {
+    urlObject = parse(urlObject);
+  } else if (typeof urlObject !== 'object' || urlObject === null) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'urlObject',
+      ['Object', 'string'],
+      urlObject
+    );
+  } else if (urlObject instanceof URL) {
+    let fragment = true;
+    let unicode = false;
+    let search = true;
+    let auth = true;
+
+    if (options) {
+      validateObject(options, 'options');
+
+      if (options.fragment != null) {
+        fragment = Boolean(options.fragment);
+      }
+
+      if (options.unicode != null) {
+        unicode = Boolean(options.unicode);
+      }
+
+      if (options.search != null) {
+        search = Boolean(options.search);
+      }
+
+      if (options.auth != null) {
+        auth = Boolean(options.auth);
+      }
+    }
+
+    return urlUtil.format(urlObject.href, fragment, unicode, search, auth);
+  }
+
+  return Url.prototype.format.call(urlObject);
+}
+
+export function resolveObject(
+  source: string | typeof Url,
+  relative: string | typeof Url
+): typeof Url | string {
+  if (!source) {
+    return relative;
+  }
+  return parse(source, false, true).resolveObject(relative);
+}

--- a/src/node/internal/url.d.ts
+++ b/src/node/internal/url.d.ts
@@ -3,3 +3,11 @@
 //     https://opensource.org/licenses/Apache-2.0
 export function domainToASCII(domain: string): string;
 export function domainToUnicode(domain: string): string;
+export function format(
+  href: string,
+  hash: boolean,
+  unicode: boolean,
+  search: boolean,
+  auth: boolean
+): string;
+export function toASCII(input: string): string;

--- a/src/node/url.ts
+++ b/src/node/url.ts
@@ -7,7 +7,15 @@ import {
   fileURLToPath,
   pathToFileURL,
   toPathIfFileURL,
+  urlToHttpOptions,
 } from 'node-internal:internal_url';
+import {
+  format,
+  parse,
+  resolve,
+  resolveObject,
+  Url,
+} from 'node-internal:legacy_url';
 
 const { URL, URLSearchParams } = globalThis;
 
@@ -31,7 +39,15 @@ export {
   fileURLToPath,
   pathToFileURL,
   toPathIfFileURL,
+  urlToHttpOptions,
 } from 'node-internal:internal_url';
+export {
+  format,
+  parse,
+  resolve,
+  resolveObject,
+  Url,
+} from 'node-internal:legacy_url';
 export { URL, URLSearchParams };
 
 export default {
@@ -42,4 +58,11 @@ export default {
   fileURLToPath,
   pathToFileURL,
   toPathIfFileURL,
+  urlToHttpOptions,
+  // Legacy APIs
+  format,
+  parse,
+  resolve,
+  resolveObject,
+  Url,
 };

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("//:build/kj_test.bzl", "kj_test")
 load("//:build/wd_cc_library.bzl", "wd_cc_library")
 load("//:build/wd_test.bzl", "wd_test")
@@ -225,4 +226,20 @@ wd_test(
     src = "tests/querystring-nodejs-test.wd-test",
     args = ["--experimental"],
     data = ["tests/querystring-nodejs-test.js"],
+)
+
+config_setting(
+    name = "debug_build",
+    values = {"compilation_mode": "dbg"},
+)
+
+wd_test(
+    size = "large",
+    src = "tests/legacy_url-nodejs-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/legacy_url-nodejs-test.js"],
+    target_compatible_with = select({
+        ":debug_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )

--- a/src/workerd/api/node/tests/legacy_url-nodejs-test.js
+++ b/src/workerd/api/node/tests/legacy_url-nodejs-test.js
@@ -1,0 +1,2254 @@
+import url from 'node:url';
+import assert from 'node:assert';
+import { inspect } from 'node:util';
+
+// Ref: https://github.com/nodejs/node/blob/e92446536ed4e268c9eef6ae6f911e384c98eecf/test/parallel/test-url-format.js
+export const format = {
+  async test() {
+    const formatTests = {
+      'http://example.com?': {
+        href: 'http://example.com/?',
+        protocol: 'http:',
+        slashes: true,
+        host: 'example.com',
+        hostname: 'example.com',
+        search: '?',
+        query: {},
+        pathname: '/',
+      },
+      'http://example.com?foo=bar#frag': {
+        href: 'http://example.com/?foo=bar#frag',
+        protocol: 'http:',
+        host: 'example.com',
+        hostname: 'example.com',
+        hash: '#frag',
+        search: '?foo=bar',
+        query: 'foo=bar',
+        pathname: '/',
+      },
+      'http://example.com?foo=@bar#frag': {
+        href: 'http://example.com/?foo=@bar#frag',
+        protocol: 'http:',
+        host: 'example.com',
+        hostname: 'example.com',
+        hash: '#frag',
+        search: '?foo=@bar',
+        query: 'foo=@bar',
+        pathname: '/',
+      },
+      'http://example.com?foo=/bar/#frag': {
+        href: 'http://example.com/?foo=/bar/#frag',
+        protocol: 'http:',
+        host: 'example.com',
+        hostname: 'example.com',
+        hash: '#frag',
+        search: '?foo=/bar/',
+        query: 'foo=/bar/',
+        pathname: '/',
+      },
+      'http://example.com?foo=?bar/#frag': {
+        href: 'http://example.com/?foo=?bar/#frag',
+        protocol: 'http:',
+        host: 'example.com',
+        hostname: 'example.com',
+        hash: '#frag',
+        search: '?foo=?bar/',
+        query: 'foo=?bar/',
+        pathname: '/',
+      },
+      'http://example.com#frag=?bar/#frag': {
+        href: 'http://example.com/#frag=?bar/#frag',
+        protocol: 'http:',
+        host: 'example.com',
+        hostname: 'example.com',
+        hash: '#frag=?bar/#frag',
+        pathname: '/',
+      },
+      'http://google.com" onload="alert(42)/': {
+        href: 'http://google.com/%22%20onload=%22alert(42)/',
+        protocol: 'http:',
+        host: 'google.com',
+        pathname: '/%22%20onload=%22alert(42)/',
+      },
+      'http://a.com/a/b/c?s#h': {
+        href: 'http://a.com/a/b/c?s#h',
+        protocol: 'http',
+        host: 'a.com',
+        pathname: 'a/b/c',
+        hash: 'h',
+        search: 's',
+      },
+      'xmpp:isaacschlueter@jabber.org': {
+        href: 'xmpp:isaacschlueter@jabber.org',
+        protocol: 'xmpp:',
+        host: 'jabber.org',
+        auth: 'isaacschlueter',
+        hostname: 'jabber.org',
+      },
+      'http://atpass:foo%40bar@127.0.0.1/': {
+        href: 'http://atpass:foo%40bar@127.0.0.1/',
+        auth: 'atpass:foo@bar',
+        hostname: '127.0.0.1',
+        protocol: 'http:',
+        pathname: '/',
+      },
+      'http://atslash%2F%40:%2F%40@foo/': {
+        href: 'http://atslash%2F%40:%2F%40@foo/',
+        auth: 'atslash/@:/@',
+        hostname: 'foo',
+        protocol: 'http:',
+        pathname: '/',
+      },
+      'svn+ssh://foo/bar': {
+        href: 'svn+ssh://foo/bar',
+        hostname: 'foo',
+        protocol: 'svn+ssh:',
+        pathname: '/bar',
+        slashes: true,
+      },
+      'dash-test://foo/bar': {
+        href: 'dash-test://foo/bar',
+        hostname: 'foo',
+        protocol: 'dash-test:',
+        pathname: '/bar',
+        slashes: true,
+      },
+      'dash-test:foo/bar': {
+        href: 'dash-test:foo/bar',
+        hostname: 'foo',
+        protocol: 'dash-test:',
+        pathname: '/bar',
+      },
+      'dot.test://foo/bar': {
+        href: 'dot.test://foo/bar',
+        hostname: 'foo',
+        protocol: 'dot.test:',
+        pathname: '/bar',
+        slashes: true,
+      },
+      'dot.test:foo/bar': {
+        href: 'dot.test:foo/bar',
+        hostname: 'foo',
+        protocol: 'dot.test:',
+        pathname: '/bar',
+      },
+      // IPv6 support
+      'coap:u:p@[::1]:61616/.well-known/r?n=Temperature': {
+        href: 'coap:u:p@[::1]:61616/.well-known/r?n=Temperature',
+        protocol: 'coap:',
+        auth: 'u:p',
+        hostname: '::1',
+        port: '61616',
+        pathname: '/.well-known/r',
+        search: 'n=Temperature',
+      },
+      'coap:[fedc:ba98:7654:3210:fedc:ba98:7654:3210]:61616/s/stopButton': {
+        href: 'coap:[fedc:ba98:7654:3210:fedc:ba98:7654:3210]:61616/s/stopButton',
+        protocol: 'coap',
+        host: '[fedc:ba98:7654:3210:fedc:ba98:7654:3210]:61616',
+        pathname: '/s/stopButton',
+      },
+      'http://[::]/': {
+        href: 'http://[::]/',
+        protocol: 'http:',
+        hostname: '[::]',
+        pathname: '/',
+      },
+
+      // Encode context-specific delimiters in path and query, but do not touch
+      // other non-delimiter chars like `%`.
+      // <https://github.com/nodejs/node-v0.x-archive/issues/4082>
+
+      // `#`,`?` in path
+      '/path/to/%%23%3F+=&.txt?foo=theA1#bar': {
+        href: '/path/to/%%23%3F+=&.txt?foo=theA1#bar',
+        pathname: '/path/to/%#?+=&.txt',
+        query: {
+          foo: 'theA1',
+        },
+        hash: '#bar',
+      },
+
+      // `#`,`?` in path + `#` in query
+      '/path/to/%%23%3F+=&.txt?foo=the%231#bar': {
+        href: '/path/to/%%23%3F+=&.txt?foo=the%231#bar',
+        pathname: '/path/to/%#?+=&.txt',
+        query: {
+          foo: 'the#1',
+        },
+        hash: '#bar',
+      },
+
+      // `#` in path end + `#` in query
+      '/path/to/%%23?foo=the%231#bar': {
+        href: '/path/to/%%23?foo=the%231#bar',
+        pathname: '/path/to/%#',
+        query: {
+          foo: 'the#1',
+        },
+        hash: '#bar',
+      },
+
+      // `?` and `#` in path and search
+      'http://ex.com/foo%3F100%m%23r?abc=the%231?&foo=bar#frag': {
+        href: 'http://ex.com/foo%3F100%m%23r?abc=the%231?&foo=bar#frag',
+        protocol: 'http:',
+        hostname: 'ex.com',
+        hash: '#frag',
+        search: '?abc=the#1?&foo=bar',
+        pathname: '/foo?100%m#r',
+      },
+
+      // `?` and `#` in search only
+      'http://ex.com/fooA100%mBr?abc=the%231?&foo=bar#frag': {
+        href: 'http://ex.com/fooA100%mBr?abc=the%231?&foo=bar#frag',
+        protocol: 'http:',
+        hostname: 'ex.com',
+        hash: '#frag',
+        search: '?abc=the#1?&foo=bar',
+        pathname: '/fooA100%mBr',
+      },
+
+      // Multiple `#` in search
+      'http://example.com/?foo=bar%231%232%233&abc=%234%23%235#frag': {
+        href: 'http://example.com/?foo=bar%231%232%233&abc=%234%23%235#frag',
+        protocol: 'http:',
+        slashes: true,
+        host: 'example.com',
+        hostname: 'example.com',
+        hash: '#frag',
+        search: '?foo=bar#1#2#3&abc=#4##5',
+        query: {},
+        pathname: '/',
+      },
+
+      // More than 255 characters in hostname which exceeds the limit
+      [`http://${'a'.repeat(255)}.com/node`]: {
+        href: 'http:///node',
+        protocol: 'http:',
+        slashes: true,
+        host: '',
+        hostname: '',
+        pathname: '/node',
+        path: '/node',
+      },
+
+      // Greater than or equal to 63 characters after `.` in hostname
+      [`http://www.${'z'.repeat(63)}example.com/node`]: {
+        href: `http://www.${'z'.repeat(63)}example.com/node`,
+        protocol: 'http:',
+        slashes: true,
+        host: `www.${'z'.repeat(63)}example.com`,
+        hostname: `www.${'z'.repeat(63)}example.com`,
+        pathname: '/node',
+        path: '/node',
+      },
+
+      // https://github.com/nodejs/node/issues/3361
+      'file:///home/user': {
+        href: 'file:///home/user',
+        protocol: 'file',
+        pathname: '/home/user',
+        path: '/home/user',
+      },
+
+      // surrogate in auth
+      'http://%F0%9F%98%80@www.example.com/': {
+        href: 'http://%F0%9F%98%80@www.example.com/',
+        protocol: 'http:',
+        auth: '\uD83D\uDE00',
+        hostname: 'www.example.com',
+        pathname: '/',
+      },
+    };
+
+    for (const u in formatTests) {
+      const expect = formatTests[u].href;
+      delete formatTests[u].href;
+      const actual = url.format(u);
+      const actualObj = url.format(formatTests[u]);
+      assert.strictEqual(
+        actual,
+        expect,
+        `wonky format(${u}) == ${expect}\nactual:${actual}`
+      );
+      assert.strictEqual(
+        actualObj,
+        expect,
+        `wonky format(${JSON.stringify(formatTests[u])}) == ${
+          expect
+        }\nactual: ${actualObj}`
+      );
+    }
+  },
+};
+
+// Ref: https://github.com/nodejs/node/blob/e92446536ed4e268c9eef6ae6f911e384c98eecf/test/parallel/test-url-relative.js
+export const relative = {
+  async test() {
+    // When source is false
+    assert.strictEqual(url.resolveObject('', 'foo'), 'foo');
+
+    // [from, path, expected]
+    const relativeTests = [
+      ['/foo/bar/baz', 'quux', '/foo/bar/quux'],
+      ['/foo/bar/baz', 'quux/asdf', '/foo/bar/quux/asdf'],
+      ['/foo/bar/baz', 'quux/baz', '/foo/bar/quux/baz'],
+      ['/foo/bar/baz', '../quux/baz', '/foo/quux/baz'],
+      ['/foo/bar/baz', '/bar', '/bar'],
+      ['/foo/bar/baz/', 'quux', '/foo/bar/baz/quux'],
+      ['/foo/bar/baz/', 'quux/baz', '/foo/bar/baz/quux/baz'],
+      ['/foo/bar/baz', '../../../../../../../../quux/baz', '/quux/baz'],
+      ['/foo/bar/baz', '../../../../../../../quux/baz', '/quux/baz'],
+      ['/foo', '.', '/'],
+      ['/foo', '..', '/'],
+      ['/foo/', '.', '/foo/'],
+      ['/foo/', '..', '/'],
+      ['/foo/bar', '.', '/foo/'],
+      ['/foo/bar', '..', '/'],
+      ['/foo/bar/', '.', '/foo/bar/'],
+      ['/foo/bar/', '..', '/foo/'],
+      ['foo/bar', '../../../baz', '../../baz'],
+      ['foo/bar/', '../../../baz', '../baz'],
+      [
+        'http://example.com/b//c//d;p?q#blarg',
+        'https:#hash2',
+        'https:///#hash2',
+      ],
+      [
+        'http://example.com/b//c//d;p?q#blarg',
+        'https:/p/a/t/h?s#hash2',
+        'https://p/a/t/h?s#hash2',
+      ],
+      [
+        'http://example.com/b//c//d;p?q#blarg',
+        'https://u:p@h.com/p/a/t/h?s#hash2',
+        'https://u:p@h.com/p/a/t/h?s#hash2',
+      ],
+      [
+        'http://example.com/b//c//d;p?q#blarg',
+        'https:/a/b/c/d',
+        'https://a/b/c/d',
+      ],
+      [
+        'http://example.com/b//c//d;p?q#blarg',
+        'http:#hash2',
+        'http://example.com/b//c//d;p?q#hash2',
+      ],
+      [
+        'http://example.com/b//c//d;p?q#blarg',
+        'http:/p/a/t/h?s#hash2',
+        'http://example.com/p/a/t/h?s#hash2',
+      ],
+      [
+        'http://example.com/b//c//d;p?q#blarg',
+        'http://u:p@h.com/p/a/t/h?s#hash2',
+        'http://u:p@h.com/p/a/t/h?s#hash2',
+      ],
+      [
+        'http://example.com/b//c//d;p?q#blarg',
+        'http:/a/b/c/d',
+        'http://example.com/a/b/c/d',
+      ],
+      ['/foo/bar/baz', '/../etc/passwd', '/etc/passwd'],
+      ['http://localhost', 'file:///Users/foo', 'file:///Users/foo'],
+      ['http://localhost', 'file://foo/Users', 'file://foo/Users'],
+      [
+        'https://registry.npmjs.org',
+        '@foo/bar',
+        'https://registry.npmjs.org/@foo/bar',
+      ],
+    ];
+    for (let i = 0; i < relativeTests.length; i++) {
+      const relativeTest = relativeTests[i];
+
+      const a = url.resolve(relativeTest[0], relativeTest[1]);
+      const e = relativeTest[2];
+      assert.strictEqual(
+        a,
+        e,
+        `resolve(${relativeTest[0]}, ${relativeTest[1]})` +
+          ` == ${e}\n  actual=${a}`
+      );
+    }
+
+    //
+    // Tests below taken from Chiron
+    // http://code.google.com/p/chironjs/source/browse/trunk/src/test/http/url.js
+    //
+    // Copyright (c) 2002-2008 Kris Kowal <http://cixar.com/~kris.kowal>
+    // used with permission under MIT License
+    //
+    // Changes marked with @isaacs
+
+    const bases = [
+      'http://a/b/c/d;p?q',
+      'http://a/b/c/d;p?q=1/2',
+      'http://a/b/c/d;p=1/2?q',
+      'fred:///s//a/b/c',
+      'http:///s//a/b/c',
+    ];
+
+    // [to, from, result]
+    const relativeTests2 = [
+      // http://lists.w3.org/Archives/Public/uri/2004Feb/0114.html
+      ['../c', 'foo:a/b', 'foo:c'],
+      ['foo:.', 'foo:a', 'foo:'],
+      ['/foo/../../../bar', 'zz:abc', 'zz:/bar'],
+      ['/foo/../bar', 'zz:abc', 'zz:/bar'],
+      // @isaacs Disagree. Not how web browsers resolve this.
+      ['foo/../../../bar', 'zz:abc', 'zz:bar'],
+      // ['foo/../../../bar',  'zz:abc', 'zz:../../bar'], // @isaacs Added
+      ['foo/../bar', 'zz:abc', 'zz:bar'],
+      ['zz:.', 'zz:abc', 'zz:'],
+      ['/.', bases[0], 'http://a/'],
+      ['/.foo', bases[0], 'http://a/.foo'],
+      ['.foo', bases[0], 'http://a/b/c/.foo'],
+
+      // http://gbiv.com/protocols/uri/test/rel_examples1.html
+      // examples from RFC 2396
+      ['g:h', bases[0], 'g:h'],
+      ['g', bases[0], 'http://a/b/c/g'],
+      ['./g', bases[0], 'http://a/b/c/g'],
+      ['g/', bases[0], 'http://a/b/c/g/'],
+      ['/g', bases[0], 'http://a/g'],
+      ['//g', bases[0], 'http://g/'],
+      // Changed with RFC 2396bis
+      // ('?y', bases[0], 'http://a/b/c/d;p?y'],
+      ['?y', bases[0], 'http://a/b/c/d;p?y'],
+      ['g?y', bases[0], 'http://a/b/c/g?y'],
+      // Changed with RFC 2396bis
+      // ('#s', bases[0], CURRENT_DOC_URI + '#s'],
+      ['#s', bases[0], 'http://a/b/c/d;p?q#s'],
+      ['g#s', bases[0], 'http://a/b/c/g#s'],
+      ['g?y#s', bases[0], 'http://a/b/c/g?y#s'],
+      [';x', bases[0], 'http://a/b/c/;x'],
+      ['g;x', bases[0], 'http://a/b/c/g;x'],
+      ['g;x?y#s', bases[0], 'http://a/b/c/g;x?y#s'],
+      // Changed with RFC 2396bis
+      // ('', bases[0], CURRENT_DOC_URI],
+      ['', bases[0], 'http://a/b/c/d;p?q'],
+      ['.', bases[0], 'http://a/b/c/'],
+      ['./', bases[0], 'http://a/b/c/'],
+      ['..', bases[0], 'http://a/b/'],
+      ['../', bases[0], 'http://a/b/'],
+      ['../g', bases[0], 'http://a/b/g'],
+      ['../..', bases[0], 'http://a/'],
+      ['../../', bases[0], 'http://a/'],
+      ['../../g', bases[0], 'http://a/g'],
+      ['../../../g', bases[0], ('http://a/../g', 'http://a/g')],
+      ['../../../../g', bases[0], ('http://a/../../g', 'http://a/g')],
+      // Changed with RFC 2396bis
+      // ('/./g', bases[0], 'http://a/./g'],
+      ['/./g', bases[0], 'http://a/g'],
+      // Changed with RFC 2396bis
+      // ('/../g', bases[0], 'http://a/../g'],
+      ['/../g', bases[0], 'http://a/g'],
+      ['g.', bases[0], 'http://a/b/c/g.'],
+      ['.g', bases[0], 'http://a/b/c/.g'],
+      ['g..', bases[0], 'http://a/b/c/g..'],
+      ['..g', bases[0], 'http://a/b/c/..g'],
+      ['./../g', bases[0], 'http://a/b/g'],
+      ['./g/.', bases[0], 'http://a/b/c/g/'],
+      ['g/./h', bases[0], 'http://a/b/c/g/h'],
+      ['g/../h', bases[0], 'http://a/b/c/h'],
+      ['g;x=1/./y', bases[0], 'http://a/b/c/g;x=1/y'],
+      ['g;x=1/../y', bases[0], 'http://a/b/c/y'],
+      ['g?y/./x', bases[0], 'http://a/b/c/g?y/./x'],
+      ['g?y/../x', bases[0], 'http://a/b/c/g?y/../x'],
+      ['g#s/./x', bases[0], 'http://a/b/c/g#s/./x'],
+      ['g#s/../x', bases[0], 'http://a/b/c/g#s/../x'],
+      ['http:g', bases[0], ('http:g', 'http://a/b/c/g')],
+      ['http:', bases[0], ('http:', bases[0])],
+      // Not sure where this one originated
+      ['/a/b/c/./../../g', bases[0], 'http://a/a/g'],
+
+      // http://gbiv.com/protocols/uri/test/rel_examples2.html
+      // slashes in base URI's query args
+      ['g', bases[1], 'http://a/b/c/g'],
+      ['./g', bases[1], 'http://a/b/c/g'],
+      ['g/', bases[1], 'http://a/b/c/g/'],
+      ['/g', bases[1], 'http://a/g'],
+      ['//g', bases[1], 'http://g/'],
+      // Changed in RFC 2396bis
+      // ('?y', bases[1], 'http://a/b/c/?y'],
+      ['?y', bases[1], 'http://a/b/c/d;p?y'],
+      ['g?y', bases[1], 'http://a/b/c/g?y'],
+      ['g?y/./x', bases[1], 'http://a/b/c/g?y/./x'],
+      ['g?y/../x', bases[1], 'http://a/b/c/g?y/../x'],
+      ['g#s', bases[1], 'http://a/b/c/g#s'],
+      ['g#s/./x', bases[1], 'http://a/b/c/g#s/./x'],
+      ['g#s/../x', bases[1], 'http://a/b/c/g#s/../x'],
+      ['./', bases[1], 'http://a/b/c/'],
+      ['../', bases[1], 'http://a/b/'],
+      ['../g', bases[1], 'http://a/b/g'],
+      ['../../', bases[1], 'http://a/'],
+      ['../../g', bases[1], 'http://a/g'],
+
+      // http://gbiv.com/protocols/uri/test/rel_examples3.html
+      // slashes in path params
+      // all of these changed in RFC 2396bis
+      ['g', bases[2], 'http://a/b/c/d;p=1/g'],
+      ['./g', bases[2], 'http://a/b/c/d;p=1/g'],
+      ['g/', bases[2], 'http://a/b/c/d;p=1/g/'],
+      ['g?y', bases[2], 'http://a/b/c/d;p=1/g?y'],
+      [';x', bases[2], 'http://a/b/c/d;p=1/;x'],
+      ['g;x', bases[2], 'http://a/b/c/d;p=1/g;x'],
+      ['g;x=1/./y', bases[2], 'http://a/b/c/d;p=1/g;x=1/y'],
+      ['g;x=1/../y', bases[2], 'http://a/b/c/d;p=1/y'],
+      ['./', bases[2], 'http://a/b/c/d;p=1/'],
+      ['../', bases[2], 'http://a/b/c/'],
+      ['../g', bases[2], 'http://a/b/c/g'],
+      ['../../', bases[2], 'http://a/b/'],
+      ['../../g', bases[2], 'http://a/b/g'],
+
+      // http://gbiv.com/protocols/uri/test/rel_examples4.html
+      // double and triple slash, unknown scheme
+      ['g:h', bases[3], 'g:h'],
+      ['g', bases[3], 'fred:///s//a/b/g'],
+      ['./g', bases[3], 'fred:///s//a/b/g'],
+      ['g/', bases[3], 'fred:///s//a/b/g/'],
+      ['/g', bases[3], 'fred:///g'], // May change to fred:///s//a/g
+      ['//g', bases[3], 'fred://g'], // May change to fred:///s//g
+      ['//g/x', bases[3], 'fred://g/x'], // May change to fred:///s//g/x
+      ['///g', bases[3], 'fred:///g'],
+      ['./', bases[3], 'fred:///s//a/b/'],
+      ['../', bases[3], 'fred:///s//a/'],
+      ['../g', bases[3], 'fred:///s//a/g'],
+
+      ['../../', bases[3], 'fred:///s//'],
+      ['../../g', bases[3], 'fred:///s//g'],
+      ['../../../g', bases[3], 'fred:///s/g'],
+      // May change to fred:///s//a/../../../g
+      ['../../../../g', bases[3], 'fred:///g'],
+
+      // http://gbiv.com/protocols/uri/test/rel_examples5.html
+      // double and triple slash, well-known scheme
+      ['g:h', bases[4], 'g:h'],
+      ['g', bases[4], 'http:///s//a/b/g'],
+      ['./g', bases[4], 'http:///s//a/b/g'],
+      ['g/', bases[4], 'http:///s//a/b/g/'],
+      ['/g', bases[4], 'http:///g'], // May change to http:///s//a/g
+      ['//g', bases[4], 'http://g/'], // May change to http:///s//g
+      ['//g/x', bases[4], 'http://g/x'], // May change to http:///s//g/x
+      ['///g', bases[4], 'http:///g'],
+      ['./', bases[4], 'http:///s//a/b/'],
+      ['../', bases[4], 'http:///s//a/'],
+      ['../g', bases[4], 'http:///s//a/g'],
+      ['../../', bases[4], 'http:///s//'],
+      ['../../g', bases[4], 'http:///s//g'],
+      // May change to http:///s//a/../../g
+      ['../../../g', bases[4], 'http:///s/g'],
+      // May change to http:///s//a/../../../g
+      ['../../../../g', bases[4], 'http:///g'],
+
+      // From Dan Connelly's tests in http://www.w3.org/2000/10/swap/uripath.py
+      ['bar:abc', 'foo:xyz', 'bar:abc'],
+      ['../abc', 'http://example/x/y/z', 'http://example/x/abc'],
+      ['http://example/x/abc', 'http://example2/x/y/z', 'http://example/x/abc'],
+      ['../r', 'http://ex/x/y/z', 'http://ex/x/r'],
+      ['q/r', 'http://ex/x/y', 'http://ex/x/q/r'],
+      ['q/r#s', 'http://ex/x/y', 'http://ex/x/q/r#s'],
+      ['q/r#s/t', 'http://ex/x/y', 'http://ex/x/q/r#s/t'],
+      ['ftp://ex/x/q/r', 'http://ex/x/y', 'ftp://ex/x/q/r'],
+      ['', 'http://ex/x/y', 'http://ex/x/y'],
+      ['', 'http://ex/x/y/', 'http://ex/x/y/'],
+      ['', 'http://ex/x/y/pdq', 'http://ex/x/y/pdq'],
+      ['z/', 'http://ex/x/y/', 'http://ex/x/y/z/'],
+      [
+        '#Animal',
+        'file:/swap/test/animal.rdf',
+        'file:/swap/test/animal.rdf#Animal',
+      ],
+      ['../abc', 'file:/e/x/y/z', 'file:/e/x/abc'],
+      ['/example/x/abc', 'file:/example2/x/y/z', 'file:/example/x/abc'],
+      ['../r', 'file:/ex/x/y/z', 'file:/ex/x/r'],
+      ['/r', 'file:/ex/x/y/z', 'file:/r'],
+      ['q/r', 'file:/ex/x/y', 'file:/ex/x/q/r'],
+      ['q/r#s', 'file:/ex/x/y', 'file:/ex/x/q/r#s'],
+      ['q/r#', 'file:/ex/x/y', 'file:/ex/x/q/r#'],
+      ['q/r#s/t', 'file:/ex/x/y', 'file:/ex/x/q/r#s/t'],
+      ['ftp://ex/x/q/r', 'file:/ex/x/y', 'ftp://ex/x/q/r'],
+      ['', 'file:/ex/x/y', 'file:/ex/x/y'],
+      ['', 'file:/ex/x/y/', 'file:/ex/x/y/'],
+      ['', 'file:/ex/x/y/pdq', 'file:/ex/x/y/pdq'],
+      ['z/', 'file:/ex/x/y/', 'file:/ex/x/y/z/'],
+      [
+        'file://meetings.example.com/cal#m1',
+        'file:/devel/WWW/2000/10/swap/test/reluri-1.n3',
+        'file://meetings.example.com/cal#m1',
+      ],
+      [
+        'file://meetings.example.com/cal#m1',
+        'file:/home/connolly/w3ccvs/WWW/2000/10/swap/test/reluri-1.n3',
+        'file://meetings.example.com/cal#m1',
+      ],
+      ['./#blort', 'file:/some/dir/foo', 'file:/some/dir/#blort'],
+      ['./#', 'file:/some/dir/foo', 'file:/some/dir/#'],
+      // Ryan Lee
+      ['./', 'http://example/x/abc.efg', 'http://example/x/'],
+
+      // Graham Klyne's tests
+      // http://www.ninebynine.org/Software/HaskellUtils/Network/UriTest.xls
+      // 01-31 are from Connelly's cases
+
+      // 32-49
+      ['./q:r', 'http://ex/x/y', 'http://ex/x/q:r'],
+      ['./p=q:r', 'http://ex/x/y', 'http://ex/x/p=q:r'],
+      ['?pp/rr', 'http://ex/x/y?pp/qq', 'http://ex/x/y?pp/rr'],
+      ['y/z', 'http://ex/x/y?pp/qq', 'http://ex/x/y/z'],
+      [
+        'local/qual@domain.org#frag',
+        'mailto:local',
+        'mailto:local/qual@domain.org#frag',
+      ],
+      [
+        'more/qual2@domain2.org#frag',
+        'mailto:local/qual1@domain1.org',
+        'mailto:local/more/qual2@domain2.org#frag',
+      ],
+      ['y?q', 'http://ex/x/y?q', 'http://ex/x/y?q'],
+      ['/x/y?q', 'http://ex?p', 'http://ex/x/y?q'],
+      ['c/d', 'foo:a/b', 'foo:a/c/d'],
+      ['/c/d', 'foo:a/b', 'foo:/c/d'],
+      ['', 'foo:a/b?c#d', 'foo:a/b?c'],
+      ['b/c', 'foo:a', 'foo:b/c'],
+      ['../b/c', 'foo:/a/y/z', 'foo:/a/b/c'],
+      ['./b/c', 'foo:a', 'foo:b/c'],
+      ['/./b/c', 'foo:a', 'foo:/b/c'],
+      ['../../d', 'foo://a//b/c', 'foo://a/d'],
+      ['.', 'foo:a', 'foo:'],
+      ['..', 'foo:a', 'foo:'],
+
+      // 50-57[cf. TimBL comments --
+      //  http://lists.w3.org/Archives/Public/uri/2003Feb/0028.html,
+      //  http://lists.w3.org/Archives/Public/uri/2003Jan/0008.html)
+      ['abc', 'http://example/x/y%2Fz', 'http://example/x/abc'],
+      ['../../x%2Fabc', 'http://example/a/x/y/z', 'http://example/a/x%2Fabc'],
+      ['../x%2Fabc', 'http://example/a/x/y%2Fz', 'http://example/a/x%2Fabc'],
+      ['abc', 'http://example/x%2Fy/z', 'http://example/x%2Fy/abc'],
+      ['q%3Ar', 'http://ex/x/y', 'http://ex/x/q%3Ar'],
+      ['/x%2Fabc', 'http://example/x/y%2Fz', 'http://example/x%2Fabc'],
+      ['/x%2Fabc', 'http://example/x/y/z', 'http://example/x%2Fabc'],
+      ['/x%2Fabc', 'http://example/x/y%2Fz', 'http://example/x%2Fabc'],
+
+      // 70-77
+      [
+        'local2@domain2',
+        'mailto:local1@domain1?query1',
+        'mailto:local2@domain2',
+      ],
+      [
+        'local2@domain2?query2',
+        'mailto:local1@domain1',
+        'mailto:local2@domain2?query2',
+      ],
+      [
+        'local2@domain2?query2',
+        'mailto:local1@domain1?query1',
+        'mailto:local2@domain2?query2',
+      ],
+      ['?query2', 'mailto:local@domain?query1', 'mailto:local@domain?query2'],
+      ['local@domain?query2', 'mailto:?query1', 'mailto:local@domain?query2'],
+      ['?query2', 'mailto:local@domain?query1', 'mailto:local@domain?query2'],
+      ['http://example/a/b?c/../d', 'foo:bar', 'http://example/a/b?c/../d'],
+      ['http://example/a/b#c/../d', 'foo:bar', 'http://example/a/b#c/../d'],
+
+      // 82-88
+      // @isaacs Disagree. Not how browsers do it.
+      // ['http:this', 'http://example.org/base/uri', 'http:this'],
+      // @isaacs Added
+      [
+        'http:this',
+        'http://example.org/base/uri',
+        'http://example.org/base/this',
+      ],
+      ['http:this', 'http:base', 'http:this'],
+      ['.//g', 'f:/a', 'f://g'],
+      ['b/c//d/e', 'f://example.org/base/a', 'f://example.org/base/b/c//d/e'],
+      [
+        'm2@example.ord/c2@example.org',
+        'mid:m@example.ord/c@example.org',
+        'mid:m@example.ord/m2@example.ord/c2@example.org',
+      ],
+      [
+        'mini1.xml',
+        'file:///C:/DEV/Haskell/lib/HXmlToolbox-3.01/examples/',
+        'file:///C:/DEV/Haskell/lib/HXmlToolbox-3.01/examples/mini1.xml',
+      ],
+      ['../b/c', 'foo:a/y/z', 'foo:a/b/c'],
+
+      // changing auth
+      [
+        'http://diff:auth@www.example.com',
+        'http://asdf:qwer@www.example.com',
+        'http://diff:auth@www.example.com/',
+      ],
+
+      // changing port
+      [
+        'https://example.com:81/',
+        'https://example.com:82/',
+        'https://example.com:81/',
+      ],
+
+      // https://github.com/nodejs/node/issues/1435
+      [
+        'https://another.host.com/',
+        'https://user:password@example.org/',
+        'https://another.host.com/',
+      ],
+      [
+        '//another.host.com/',
+        'https://user:password@example.org/',
+        'https://another.host.com/',
+      ],
+      [
+        'http://another.host.com/',
+        'https://user:password@example.org/',
+        'http://another.host.com/',
+      ],
+      [
+        'mailto:another.host.com',
+        'mailto:user@example.org',
+        'mailto:another.host.com',
+      ],
+      [
+        'https://example.com/foo',
+        'https://user:password@example.com',
+        'https://user:password@example.com/foo',
+      ],
+
+      // No path at all
+      ['#hash1', '#hash2', '#hash1'],
+    ];
+    for (let i = 0; i < relativeTests2.length; i++) {
+      const relativeTest = relativeTests2[i];
+
+      const a = url.resolve(relativeTest[1], relativeTest[0]);
+      const e = url.format(relativeTest[2]);
+      assert.strictEqual(
+        a,
+        e,
+        `resolve(${relativeTest[0]}, ${relativeTest[1]})` +
+          ` == ${e}\n  actual=${a}`
+      );
+    }
+
+    // If format and parse are inverse operations then
+    // resolveObject(parse(x), y) == parse(resolve(x, y))
+
+    // format: [from, path, expected]
+    for (let i = 0; i < relativeTests.length; i++) {
+      const relativeTest = relativeTests[i];
+
+      let actual = url.resolveObject(
+        url.parse(relativeTest[0]),
+        relativeTest[1]
+      );
+      let expected = url.parse(relativeTest[2]);
+
+      assert.deepStrictEqual(actual, expected);
+
+      expected = relativeTest[2];
+      actual = url.format(actual);
+
+      assert.strictEqual(
+        actual,
+        expected,
+        `format(${actual}) == ${expected}\n` + `actual: ${actual}`
+      );
+    }
+
+    // format: [to, from, result]
+    // the test: ['.//g', 'f:/a', 'f://g'] is a fundamental problem
+    // url.parse('f:/a') does not have a host
+    // url.resolve('f:/a', './/g') does not have a host because you have moved
+    // down to the g directory.  i.e. f:     //g, however when this url is parsed
+    // f:// will indicate that the host is g which is not the case.
+    // it is unclear to me how to keep this information from being lost
+    // it may be that a pathname of ////g should collapse to /g but this seems
+    // to be a lot of work for an edge case.  Right now I remove the test
+    if (
+      relativeTests2[181][0] === './/g' &&
+      relativeTests2[181][1] === 'f:/a' &&
+      relativeTests2[181][2] === 'f://g'
+    ) {
+      relativeTests2.splice(181, 1);
+    }
+    for (let i = 0; i < relativeTests2.length; i++) {
+      const relativeTest = relativeTests2[i];
+
+      let actual = url.resolveObject(
+        url.parse(relativeTest[1]),
+        relativeTest[0]
+      );
+      let expected = url.parse(relativeTest[2]);
+
+      assert.deepStrictEqual(
+        actual,
+        expected,
+        `expected ${inspect(expected)} but got ${inspect(actual)}`
+      );
+
+      expected = url.format(relativeTest[2]);
+      actual = url.format(actual);
+
+      assert.strictEqual(
+        actual,
+        expected,
+        `format(${relativeTest[1]}) == ${expected}\n` + `actual: ${actual}`
+      );
+    }
+  },
+};
+
+// Ref: https://github.com/nodejs/node/blob/e92446536ed4e268c9eef6ae6f911e384c98eecf/test/parallel/test-url-urltooptions.js
+export const urlToHttpOptions = {
+  async test() {
+    // Test urlToHttpOptions
+    const urlObj = new URL('http://user:pass@foo.bar.com:21/aaa/zzz?l=24#test');
+    const opts = url.urlToHttpOptions(urlObj);
+    assert.strictEqual(opts instanceof URL, false);
+    assert.strictEqual(opts.protocol, 'http:');
+    assert.strictEqual(opts.auth, 'user:pass');
+    assert.strictEqual(opts.hostname, 'foo.bar.com');
+    assert.strictEqual(opts.port, 21);
+    assert.strictEqual(opts.path, '/aaa/zzz?l=24');
+    assert.strictEqual(opts.pathname, '/aaa/zzz');
+    assert.strictEqual(opts.search, '?l=24');
+    assert.strictEqual(opts.hash, '#test');
+
+    const { hostname } = url.urlToHttpOptions(new URL('http://[::1]:21'));
+    assert.strictEqual(hostname, '::1');
+
+    // If a WHATWG URL object is copied, it is possible that the resulting copy
+    // contains the Symbols that Node uses for brand checking, but not the data
+    // properties, which are getters. Verify that urlToHttpOptions() can handle
+    // such a case.
+    const copiedUrlObj = { ...urlObj };
+    const copiedOpts = url.urlToHttpOptions(copiedUrlObj);
+    assert.strictEqual(copiedOpts instanceof URL, false);
+    assert.strictEqual(copiedOpts.protocol, undefined);
+    assert.strictEqual(copiedOpts.auth, undefined);
+    assert.strictEqual(copiedOpts.hostname, undefined);
+    assert.strictEqual(copiedOpts.port, NaN);
+    assert.strictEqual(copiedOpts.path, '');
+    assert.strictEqual(copiedOpts.pathname, undefined);
+    assert.strictEqual(copiedOpts.search, undefined);
+    assert.strictEqual(copiedOpts.hash, undefined);
+    assert.strictEqual(copiedOpts.href, undefined);
+  },
+};
+
+// Ref: https://github.com/nodejs/node/blob/e92446536ed4e268c9eef6ae6f911e384c98eecf/test/parallel/test-url-format-whatwg.js
+export const formatWhatwg = {
+  async test() {
+    const myURL = new URL(
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    // should format
+    assert.strictEqual(
+      url.format(myURL),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, {}),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    // handle invalid arguments
+    for (const value of [true, 1, 'test', Infinity]) {
+      assert.throws(() => url.format(myURL, value), {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError',
+      });
+    }
+
+    // any falsy value other than undefined will be treated as false
+    assert.strictEqual(
+      url.format(myURL, { auth: false }),
+      'http://xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { auth: '' }),
+      'http://xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { auth: 0 }),
+      'http://xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { auth: 1 }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { auth: {} }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { fragment: false }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { fragment: '' }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { fragment: 0 }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { fragment: 1 }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { fragment: {} }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { search: false }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { search: '' }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { search: 0 }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { search: 1 }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { search: {} }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { unicode: true }),
+      'http://user:pass@理容ナカムラ.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { unicode: 1 }),
+      'http://user:pass@理容ナカムラ.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { unicode: {} }),
+      'http://user:pass@理容ナカムラ.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { unicode: false }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    assert.strictEqual(
+      url.format(myURL, { unicode: 0 }),
+      'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c'
+    );
+
+    // should format with unicode: true
+    assert.strictEqual(
+      url.format(new URL('http://user:pass@xn--0zwm56d.com:8080/path'), {
+        unicode: true,
+      }),
+      'http://user:pass@测试.com:8080/path'
+    );
+
+    // should format tel: prefix
+    assert.strictEqual(
+      url.format(new URL('tel:123')),
+      url.format(new URL('tel:123'), { unicode: true })
+    );
+  },
+};
+
+// Ref: https://github.com/nodejs/node/blob/e92446536ed4e268c9eef6ae6f911e384c98eecf/test/parallel/test-url-parse-query.js
+export const urlParseQuery = {
+  async test() {
+    function createWithNoPrototype(properties = []) {
+      const noProto = { __proto__: null };
+      properties.forEach((property) => {
+        noProto[property.key] = property.value;
+      });
+      return noProto;
+    }
+
+    function check(actual, expected) {
+      assert.notStrictEqual(Object.getPrototypeOf(actual), Object.prototype);
+      assert.deepStrictEqual(
+        Object.keys(actual).sort(),
+        Object.keys(expected).sort()
+      );
+      Object.keys(expected).forEach(function (key) {
+        assert.deepStrictEqual(actual[key], expected[key]);
+      });
+    }
+
+    const parseTestsWithQueryString = {
+      '/foo/bar?baz=quux#frag': {
+        href: '/foo/bar?baz=quux#frag',
+        hash: '#frag',
+        search: '?baz=quux',
+        query: createWithNoPrototype([{ key: 'baz', value: 'quux' }]),
+        pathname: '/foo/bar',
+        path: '/foo/bar?baz=quux',
+      },
+      'http://example.com': {
+        href: 'http://example.com/',
+        protocol: 'http:',
+        slashes: true,
+        host: 'example.com',
+        hostname: 'example.com',
+        query: createWithNoPrototype(),
+        search: null,
+        pathname: '/',
+        path: '/',
+      },
+      '/example': {
+        protocol: null,
+        slashes: null,
+        auth: undefined,
+        host: null,
+        port: null,
+        hostname: null,
+        hash: null,
+        search: null,
+        query: createWithNoPrototype(),
+        pathname: '/example',
+        path: '/example',
+        href: '/example',
+      },
+      '/example?query=value': {
+        protocol: null,
+        slashes: null,
+        auth: undefined,
+        host: null,
+        port: null,
+        hostname: null,
+        hash: null,
+        search: '?query=value',
+        query: createWithNoPrototype([{ key: 'query', value: 'value' }]),
+        pathname: '/example',
+        path: '/example?query=value',
+        href: '/example?query=value',
+      },
+    };
+    for (const u in parseTestsWithQueryString) {
+      const actual = url.parse(u, true);
+      const expected = Object.assign(
+        new url.Url(),
+        parseTestsWithQueryString[u]
+      );
+      for (const i in actual) {
+        if (actual[i] === null && expected[i] === undefined) {
+          expected[i] = null;
+        }
+      }
+
+      const properties = Object.keys(actual).sort();
+      assert.deepStrictEqual(properties, Object.keys(expected).sort());
+      properties.forEach((property) => {
+        if (property === 'query') {
+          check(actual[property], expected[property]);
+        } else {
+          assert.deepStrictEqual(actual[property], expected[property]);
+        }
+      });
+    }
+  },
+};
+
+// Ref: https://github.com/nodejs/node/blob/e92446536ed4e268c9eef6ae6f911e384c98eecf/test/parallel/test-url-parse-format.js
+export const urlParseFormat = {
+  async test() {
+    // URLs to parse, and expected data
+    // { url : parsed }
+    const parseTests = {
+      '//some_path': {
+        href: '//some_path',
+        pathname: '//some_path',
+        path: '//some_path',
+      },
+
+      'http:\\\\evil-phisher\\foo.html#h\\a\\s\\h': {
+        protocol: 'http:',
+        slashes: true,
+        host: 'evil-phisher',
+        hostname: 'evil-phisher',
+        pathname: '/foo.html',
+        path: '/foo.html',
+        hash: '#h%5Ca%5Cs%5Ch',
+        href: 'http://evil-phisher/foo.html#h%5Ca%5Cs%5Ch',
+      },
+
+      'http:\\\\evil-phisher\\foo.html?json="\\"foo\\""#h\\a\\s\\h': {
+        protocol: 'http:',
+        slashes: true,
+        host: 'evil-phisher',
+        hostname: 'evil-phisher',
+        pathname: '/foo.html',
+        search: '?json=%22%5C%22foo%5C%22%22',
+        query: 'json=%22%5C%22foo%5C%22%22',
+        path: '/foo.html?json=%22%5C%22foo%5C%22%22',
+        hash: '#h%5Ca%5Cs%5Ch',
+        href: 'http://evil-phisher/foo.html?json=%22%5C%22foo%5C%22%22#h%5Ca%5Cs%5Ch',
+      },
+
+      'http:\\\\evil-phisher\\foo.html#h\\a\\s\\h?blarg': {
+        protocol: 'http:',
+        slashes: true,
+        host: 'evil-phisher',
+        hostname: 'evil-phisher',
+        pathname: '/foo.html',
+        path: '/foo.html',
+        hash: '#h%5Ca%5Cs%5Ch?blarg',
+        href: 'http://evil-phisher/foo.html#h%5Ca%5Cs%5Ch?blarg',
+      },
+
+      'http:\\\\evil-phisher\\foo.html': {
+        protocol: 'http:',
+        slashes: true,
+        host: 'evil-phisher',
+        hostname: 'evil-phisher',
+        pathname: '/foo.html',
+        path: '/foo.html',
+        href: 'http://evil-phisher/foo.html',
+      },
+
+      'HTTP://www.example.com/': {
+        href: 'http://www.example.com/',
+        protocol: 'http:',
+        slashes: true,
+        host: 'www.example.com',
+        hostname: 'www.example.com',
+        pathname: '/',
+        path: '/',
+      },
+
+      'HTTP://www.example.com': {
+        href: 'http://www.example.com/',
+        protocol: 'http:',
+        slashes: true,
+        host: 'www.example.com',
+        hostname: 'www.example.com',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://www.ExAmPlE.com/': {
+        href: 'http://www.example.com/',
+        protocol: 'http:',
+        slashes: true,
+        host: 'www.example.com',
+        hostname: 'www.example.com',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://user:pw@www.ExAmPlE.com/': {
+        href: 'http://user:pw@www.example.com/',
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user:pw',
+        host: 'www.example.com',
+        hostname: 'www.example.com',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://USER:PW@www.ExAmPlE.com/': {
+        href: 'http://USER:PW@www.example.com/',
+        protocol: 'http:',
+        slashes: true,
+        auth: 'USER:PW',
+        host: 'www.example.com',
+        hostname: 'www.example.com',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://user@www.example.com/': {
+        href: 'http://user@www.example.com/',
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user',
+        host: 'www.example.com',
+        hostname: 'www.example.com',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://user%3Apw@www.example.com/': {
+        href: 'http://user:pw@www.example.com/',
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user:pw',
+        host: 'www.example.com',
+        hostname: 'www.example.com',
+        pathname: '/',
+        path: '/',
+      },
+
+      "http://x.com/path?that's#all, folks": {
+        href: 'http://x.com/path?that%27s#all,%20folks',
+        protocol: 'http:',
+        slashes: true,
+        host: 'x.com',
+        hostname: 'x.com',
+        search: '?that%27s',
+        query: 'that%27s',
+        pathname: '/path',
+        hash: '#all,%20folks',
+        path: '/path?that%27s',
+      },
+
+      'HTTP://X.COM/Y': {
+        href: 'http://x.com/Y',
+        protocol: 'http:',
+        slashes: true,
+        host: 'x.com',
+        hostname: 'x.com',
+        pathname: '/Y',
+        path: '/Y',
+      },
+
+      // Whitespace in the front
+      ' http://www.example.com/': {
+        href: 'http://www.example.com/',
+        protocol: 'http:',
+        slashes: true,
+        host: 'www.example.com',
+        hostname: 'www.example.com',
+        pathname: '/',
+        path: '/',
+      },
+
+      // + not an invalid host character
+      // per https://url.spec.whatwg.org/#host-parsing
+      'http://x.y.com+a/b/c': {
+        href: 'http://x.y.com+a/b/c',
+        protocol: 'http:',
+        slashes: true,
+        host: 'x.y.com+a',
+        hostname: 'x.y.com+a',
+        pathname: '/b/c',
+        path: '/b/c',
+      },
+
+      // An unexpected invalid char in the hostname.
+      'HtTp://x.y.cOm;a/b/c?d=e#f g<h>i': {
+        href: 'http://x.y.com/;a/b/c?d=e#f%20g%3Ch%3Ei',
+        protocol: 'http:',
+        slashes: true,
+        host: 'x.y.com',
+        hostname: 'x.y.com',
+        pathname: ';a/b/c',
+        search: '?d=e',
+        query: 'd=e',
+        hash: '#f%20g%3Ch%3Ei',
+        path: ';a/b/c?d=e',
+      },
+
+      // Make sure that we don't accidentally lcast the path parts.
+      'HtTp://x.y.cOm;A/b/c?d=e#f g<h>i': {
+        href: 'http://x.y.com/;A/b/c?d=e#f%20g%3Ch%3Ei',
+        protocol: 'http:',
+        slashes: true,
+        host: 'x.y.com',
+        hostname: 'x.y.com',
+        pathname: ';A/b/c',
+        search: '?d=e',
+        query: 'd=e',
+        hash: '#f%20g%3Ch%3Ei',
+        path: ';A/b/c?d=e',
+      },
+
+      'http://x...y...#p': {
+        href: 'http://x...y.../#p',
+        protocol: 'http:',
+        slashes: true,
+        host: 'x...y...',
+        hostname: 'x...y...',
+        hash: '#p',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://x/p/"quoted"': {
+        href: 'http://x/p/%22quoted%22',
+        protocol: 'http:',
+        slashes: true,
+        host: 'x',
+        hostname: 'x',
+        pathname: '/p/%22quoted%22',
+        path: '/p/%22quoted%22',
+      },
+
+      '<http://goo.corn/bread> Is a URL!': {
+        href: '%3Chttp://goo.corn/bread%3E%20Is%20a%20URL!',
+        pathname: '%3Chttp://goo.corn/bread%3E%20Is%20a%20URL!',
+        path: '%3Chttp://goo.corn/bread%3E%20Is%20a%20URL!',
+      },
+
+      'http://www.narwhaljs.org/blog/categories?id=news': {
+        href: 'http://www.narwhaljs.org/blog/categories?id=news',
+        protocol: 'http:',
+        slashes: true,
+        host: 'www.narwhaljs.org',
+        hostname: 'www.narwhaljs.org',
+        search: '?id=news',
+        query: 'id=news',
+        pathname: '/blog/categories',
+        path: '/blog/categories?id=news',
+      },
+
+      'http://mt0.google.com/vt/lyrs=m@114&hl=en&src=api&x=2&y=2&z=3&s=': {
+        href: 'http://mt0.google.com/vt/lyrs=m@114&hl=en&src=api&x=2&y=2&z=3&s=',
+        protocol: 'http:',
+        slashes: true,
+        host: 'mt0.google.com',
+        hostname: 'mt0.google.com',
+        pathname: '/vt/lyrs=m@114&hl=en&src=api&x=2&y=2&z=3&s=',
+        path: '/vt/lyrs=m@114&hl=en&src=api&x=2&y=2&z=3&s=',
+      },
+
+      'http://mt0.google.com/vt/lyrs=m@114???&hl=en&src=api&x=2&y=2&z=3&s=': {
+        href:
+          'http://mt0.google.com/vt/lyrs=m@114???&hl=en&src=api' +
+          '&x=2&y=2&z=3&s=',
+        protocol: 'http:',
+        slashes: true,
+        host: 'mt0.google.com',
+        hostname: 'mt0.google.com',
+        search: '???&hl=en&src=api&x=2&y=2&z=3&s=',
+        query: '??&hl=en&src=api&x=2&y=2&z=3&s=',
+        pathname: '/vt/lyrs=m@114',
+        path: '/vt/lyrs=m@114???&hl=en&src=api&x=2&y=2&z=3&s=',
+      },
+
+      'http://user:pass@mt0.google.com/vt/lyrs=m@114???&hl=en&src=api&x=2&y=2&z=3&s=':
+        {
+          href: 'http://user:pass@mt0.google.com/vt/lyrs=m@114???&hl=en&src=api&x=2&y=2&z=3&s=',
+          protocol: 'http:',
+          slashes: true,
+          host: 'mt0.google.com',
+          auth: 'user:pass',
+          hostname: 'mt0.google.com',
+          search: '???&hl=en&src=api&x=2&y=2&z=3&s=',
+          query: '??&hl=en&src=api&x=2&y=2&z=3&s=',
+          pathname: '/vt/lyrs=m@114',
+          path: '/vt/lyrs=m@114???&hl=en&src=api&x=2&y=2&z=3&s=',
+        },
+
+      'file:///etc/passwd': {
+        href: 'file:///etc/passwd',
+        slashes: true,
+        protocol: 'file:',
+        pathname: '/etc/passwd',
+        hostname: '',
+        host: '',
+        path: '/etc/passwd',
+      },
+
+      'file://localhost/etc/passwd': {
+        href: 'file://localhost/etc/passwd',
+        protocol: 'file:',
+        slashes: true,
+        pathname: '/etc/passwd',
+        hostname: 'localhost',
+        host: 'localhost',
+        path: '/etc/passwd',
+      },
+
+      'file://foo/etc/passwd': {
+        href: 'file://foo/etc/passwd',
+        protocol: 'file:',
+        slashes: true,
+        pathname: '/etc/passwd',
+        hostname: 'foo',
+        host: 'foo',
+        path: '/etc/passwd',
+      },
+
+      'file:///etc/node/': {
+        href: 'file:///etc/node/',
+        slashes: true,
+        protocol: 'file:',
+        pathname: '/etc/node/',
+        hostname: '',
+        host: '',
+        path: '/etc/node/',
+      },
+
+      'file://localhost/etc/node/': {
+        href: 'file://localhost/etc/node/',
+        protocol: 'file:',
+        slashes: true,
+        pathname: '/etc/node/',
+        hostname: 'localhost',
+        host: 'localhost',
+        path: '/etc/node/',
+      },
+
+      'file://foo/etc/node/': {
+        href: 'file://foo/etc/node/',
+        protocol: 'file:',
+        slashes: true,
+        pathname: '/etc/node/',
+        hostname: 'foo',
+        host: 'foo',
+        path: '/etc/node/',
+      },
+
+      'http:/baz/../foo/bar': {
+        href: 'http:/baz/../foo/bar',
+        protocol: 'http:',
+        pathname: '/baz/../foo/bar',
+        path: '/baz/../foo/bar',
+      },
+
+      'http://user:pass@example.com:8000/foo/bar?baz=quux#frag': {
+        href: 'http://user:pass@example.com:8000/foo/bar?baz=quux#frag',
+        protocol: 'http:',
+        slashes: true,
+        host: 'example.com:8000',
+        auth: 'user:pass',
+        port: '8000',
+        hostname: 'example.com',
+        hash: '#frag',
+        search: '?baz=quux',
+        query: 'baz=quux',
+        pathname: '/foo/bar',
+        path: '/foo/bar?baz=quux',
+      },
+
+      '//user:pass@example.com:8000/foo/bar?baz=quux#frag': {
+        href: '//user:pass@example.com:8000/foo/bar?baz=quux#frag',
+        slashes: true,
+        host: 'example.com:8000',
+        auth: 'user:pass',
+        port: '8000',
+        hostname: 'example.com',
+        hash: '#frag',
+        search: '?baz=quux',
+        query: 'baz=quux',
+        pathname: '/foo/bar',
+        path: '/foo/bar?baz=quux',
+      },
+
+      '/foo/bar?baz=quux#frag': {
+        href: '/foo/bar?baz=quux#frag',
+        hash: '#frag',
+        search: '?baz=quux',
+        query: 'baz=quux',
+        pathname: '/foo/bar',
+        path: '/foo/bar?baz=quux',
+      },
+
+      'http:/foo/bar?baz=quux#frag': {
+        href: 'http:/foo/bar?baz=quux#frag',
+        protocol: 'http:',
+        hash: '#frag',
+        search: '?baz=quux',
+        query: 'baz=quux',
+        pathname: '/foo/bar',
+        path: '/foo/bar?baz=quux',
+      },
+
+      'mailto:foo@bar.com?subject=hello': {
+        href: 'mailto:foo@bar.com?subject=hello',
+        protocol: 'mailto:',
+        host: 'bar.com',
+        auth: 'foo',
+        hostname: 'bar.com',
+        search: '?subject=hello',
+        query: 'subject=hello',
+        path: '?subject=hello',
+      },
+
+      "javascript:alert('hello');": {
+        href: "javascript:alert('hello');",
+        protocol: 'javascript:',
+        pathname: "alert('hello');",
+        path: "alert('hello');",
+      },
+
+      'xmpp:isaacschlueter@jabber.org': {
+        href: 'xmpp:isaacschlueter@jabber.org',
+        protocol: 'xmpp:',
+        host: 'jabber.org',
+        auth: 'isaacschlueter',
+        hostname: 'jabber.org',
+      },
+
+      'http://atpass:foo%40bar@127.0.0.1:8080/path?search=foo#bar': {
+        href: 'http://atpass:foo%40bar@127.0.0.1:8080/path?search=foo#bar',
+        protocol: 'http:',
+        slashes: true,
+        host: '127.0.0.1:8080',
+        auth: 'atpass:foo@bar',
+        hostname: '127.0.0.1',
+        port: '8080',
+        pathname: '/path',
+        search: '?search=foo',
+        query: 'search=foo',
+        hash: '#bar',
+        path: '/path?search=foo',
+      },
+
+      'svn+ssh://foo/bar': {
+        href: 'svn+ssh://foo/bar',
+        host: 'foo',
+        hostname: 'foo',
+        protocol: 'svn+ssh:',
+        pathname: '/bar',
+        path: '/bar',
+        slashes: true,
+      },
+
+      'dash-test://foo/bar': {
+        href: 'dash-test://foo/bar',
+        host: 'foo',
+        hostname: 'foo',
+        protocol: 'dash-test:',
+        pathname: '/bar',
+        path: '/bar',
+        slashes: true,
+      },
+
+      'dash-test:foo/bar': {
+        href: 'dash-test:foo/bar',
+        host: 'foo',
+        hostname: 'foo',
+        protocol: 'dash-test:',
+        pathname: '/bar',
+        path: '/bar',
+      },
+
+      'dot.test://foo/bar': {
+        href: 'dot.test://foo/bar',
+        host: 'foo',
+        hostname: 'foo',
+        protocol: 'dot.test:',
+        pathname: '/bar',
+        path: '/bar',
+        slashes: true,
+      },
+
+      'dot.test:foo/bar': {
+        href: 'dot.test:foo/bar',
+        host: 'foo',
+        hostname: 'foo',
+        protocol: 'dot.test:',
+        pathname: '/bar',
+        path: '/bar',
+      },
+
+      // IDNA tests
+      'http://www.日本語.com/': {
+        href: 'http://www.xn--wgv71a119e.com/',
+        protocol: 'http:',
+        slashes: true,
+        host: 'www.xn--wgv71a119e.com',
+        hostname: 'www.xn--wgv71a119e.com',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://example.Bücher.com/': {
+        href: 'http://example.xn--bcher-kva.com/',
+        protocol: 'http:',
+        slashes: true,
+        host: 'example.xn--bcher-kva.com',
+        hostname: 'example.xn--bcher-kva.com',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://www.Äffchen.com/': {
+        href: 'http://www.xn--ffchen-9ta.com/',
+        protocol: 'http:',
+        slashes: true,
+        host: 'www.xn--ffchen-9ta.com',
+        hostname: 'www.xn--ffchen-9ta.com',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://www.Äffchen.cOm;A/b/c?d=e#f g<h>i': {
+        href: 'http://www.xn--ffchen-9ta.com/;A/b/c?d=e#f%20g%3Ch%3Ei',
+        protocol: 'http:',
+        slashes: true,
+        host: 'www.xn--ffchen-9ta.com',
+        hostname: 'www.xn--ffchen-9ta.com',
+        pathname: ';A/b/c',
+        search: '?d=e',
+        query: 'd=e',
+        hash: '#f%20g%3Ch%3Ei',
+        path: ';A/b/c?d=e',
+      },
+
+      'http://SÉLIER.COM/': {
+        href: 'http://xn--slier-bsa.com/',
+        protocol: 'http:',
+        slashes: true,
+        host: 'xn--slier-bsa.com',
+        hostname: 'xn--slier-bsa.com',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://ليهمابتكلموشعربي؟.ي؟/': {
+        href: 'http://xn--egbpdaj6bu4bxfgehfvwxn.xn--egb9f/',
+        protocol: 'http:',
+        slashes: true,
+        host: 'xn--egbpdaj6bu4bxfgehfvwxn.xn--egb9f',
+        hostname: 'xn--egbpdaj6bu4bxfgehfvwxn.xn--egb9f',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://➡.ws/➡': {
+        href: 'http://xn--hgi.ws/➡',
+        protocol: 'http:',
+        slashes: true,
+        host: 'xn--hgi.ws',
+        hostname: 'xn--hgi.ws',
+        pathname: '/➡',
+        path: '/➡',
+      },
+
+      'http://bucket_name.s3.amazonaws.com/image.jpg': {
+        protocol: 'http:',
+        slashes: true,
+        host: 'bucket_name.s3.amazonaws.com',
+        hostname: 'bucket_name.s3.amazonaws.com',
+        pathname: '/image.jpg',
+        href: 'http://bucket_name.s3.amazonaws.com/image.jpg',
+        path: '/image.jpg',
+      },
+
+      'git+http://github.com/joyent/node.git': {
+        protocol: 'git+http:',
+        slashes: true,
+        host: 'github.com',
+        hostname: 'github.com',
+        pathname: '/joyent/node.git',
+        path: '/joyent/node.git',
+        href: 'git+http://github.com/joyent/node.git',
+      },
+
+      // If local1@domain1 is uses as a relative URL it may
+      // be parse into auth@hostname, but here there is no
+      // way to make it work in url.parse, I add the test to be explicit
+      'local1@domain1': {
+        pathname: 'local1@domain1',
+        path: 'local1@domain1',
+        href: 'local1@domain1',
+      },
+
+      // While this may seem counter-intuitive, a browser will parse
+      // <a href='www.google.com'> as a path.
+      'www.example.com': {
+        href: 'www.example.com',
+        pathname: 'www.example.com',
+        path: 'www.example.com',
+      },
+
+      // ipv6 support
+      '[fe80::1]': {
+        href: '[fe80::1]',
+        pathname: '[fe80::1]',
+        path: '[fe80::1]',
+      },
+
+      'coap://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]': {
+        protocol: 'coap:',
+        slashes: true,
+        host: '[fedc:ba98:7654:3210:fedc:ba98:7654:3210]',
+        hostname: 'fedc:ba98:7654:3210:fedc:ba98:7654:3210',
+        href: 'coap://[fedc:ba98:7654:3210:fedc:ba98:7654:3210]/',
+        pathname: '/',
+        path: '/',
+      },
+
+      'coap://[1080:0:0:0:8:800:200C:417A]:61616/': {
+        protocol: 'coap:',
+        slashes: true,
+        host: '[1080:0:0:0:8:800:200c:417a]:61616',
+        port: '61616',
+        hostname: '1080:0:0:0:8:800:200c:417a',
+        href: 'coap://[1080:0:0:0:8:800:200c:417a]:61616/',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://user:password@[3ffe:2a00:100:7031::1]:8080': {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user:password',
+        host: '[3ffe:2a00:100:7031::1]:8080',
+        port: '8080',
+        hostname: '3ffe:2a00:100:7031::1',
+        href: 'http://user:password@[3ffe:2a00:100:7031::1]:8080/',
+        pathname: '/',
+        path: '/',
+      },
+
+      'coap://u:p@[::192.9.5.5]:61616/.well-known/r?n=Temperature': {
+        protocol: 'coap:',
+        slashes: true,
+        auth: 'u:p',
+        host: '[::192.9.5.5]:61616',
+        port: '61616',
+        hostname: '::192.9.5.5',
+        href: 'coap://u:p@[::192.9.5.5]:61616/.well-known/r?n=Temperature',
+        search: '?n=Temperature',
+        query: 'n=Temperature',
+        pathname: '/.well-known/r',
+        path: '/.well-known/r?n=Temperature',
+      },
+
+      // empty port
+      'http://example.com:': {
+        protocol: 'http:',
+        slashes: true,
+        host: 'example.com',
+        hostname: 'example.com',
+        href: 'http://example.com/',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://example.com:/a/b.html': {
+        protocol: 'http:',
+        slashes: true,
+        host: 'example.com',
+        hostname: 'example.com',
+        href: 'http://example.com/a/b.html',
+        pathname: '/a/b.html',
+        path: '/a/b.html',
+      },
+
+      'http://example.com:?a=b': {
+        protocol: 'http:',
+        slashes: true,
+        host: 'example.com',
+        hostname: 'example.com',
+        href: 'http://example.com/?a=b',
+        search: '?a=b',
+        query: 'a=b',
+        pathname: '/',
+        path: '/?a=b',
+      },
+
+      'http://example.com:#abc': {
+        protocol: 'http:',
+        slashes: true,
+        host: 'example.com',
+        hostname: 'example.com',
+        href: 'http://example.com/#abc',
+        hash: '#abc',
+        pathname: '/',
+        path: '/',
+      },
+
+      'http://[fe80::1]:/a/b?a=b#abc': {
+        protocol: 'http:',
+        slashes: true,
+        host: '[fe80::1]',
+        hostname: 'fe80::1',
+        href: 'http://[fe80::1]/a/b?a=b#abc',
+        search: '?a=b',
+        query: 'a=b',
+        hash: '#abc',
+        pathname: '/a/b',
+        path: '/a/b?a=b',
+      },
+
+      'http://-lovemonsterz.tumblr.com/rss': {
+        protocol: 'http:',
+        slashes: true,
+        host: '-lovemonsterz.tumblr.com',
+        hostname: '-lovemonsterz.tumblr.com',
+        href: 'http://-lovemonsterz.tumblr.com/rss',
+        pathname: '/rss',
+        path: '/rss',
+      },
+
+      'http://-lovemonsterz.tumblr.com:80/rss': {
+        protocol: 'http:',
+        slashes: true,
+        port: '80',
+        host: '-lovemonsterz.tumblr.com:80',
+        hostname: '-lovemonsterz.tumblr.com',
+        href: 'http://-lovemonsterz.tumblr.com:80/rss',
+        pathname: '/rss',
+        path: '/rss',
+      },
+
+      'http://user:pass@-lovemonsterz.tumblr.com/rss': {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user:pass',
+        host: '-lovemonsterz.tumblr.com',
+        hostname: '-lovemonsterz.tumblr.com',
+        href: 'http://user:pass@-lovemonsterz.tumblr.com/rss',
+        pathname: '/rss',
+        path: '/rss',
+      },
+
+      'http://user:pass@-lovemonsterz.tumblr.com:80/rss': {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user:pass',
+        port: '80',
+        host: '-lovemonsterz.tumblr.com:80',
+        hostname: '-lovemonsterz.tumblr.com',
+        href: 'http://user:pass@-lovemonsterz.tumblr.com:80/rss',
+        pathname: '/rss',
+        path: '/rss',
+      },
+
+      'http://_jabber._tcp.google.com/test': {
+        protocol: 'http:',
+        slashes: true,
+        host: '_jabber._tcp.google.com',
+        hostname: '_jabber._tcp.google.com',
+        href: 'http://_jabber._tcp.google.com/test',
+        pathname: '/test',
+        path: '/test',
+      },
+
+      'http://user:pass@_jabber._tcp.google.com/test': {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user:pass',
+        host: '_jabber._tcp.google.com',
+        hostname: '_jabber._tcp.google.com',
+        href: 'http://user:pass@_jabber._tcp.google.com/test',
+        pathname: '/test',
+        path: '/test',
+      },
+
+      'http://_jabber._tcp.google.com:80/test': {
+        protocol: 'http:',
+        slashes: true,
+        port: '80',
+        host: '_jabber._tcp.google.com:80',
+        hostname: '_jabber._tcp.google.com',
+        href: 'http://_jabber._tcp.google.com:80/test',
+        pathname: '/test',
+        path: '/test',
+      },
+
+      'http://user:pass@_jabber._tcp.google.com:80/test': {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user:pass',
+        port: '80',
+        host: '_jabber._tcp.google.com:80',
+        hostname: '_jabber._tcp.google.com',
+        href: 'http://user:pass@_jabber._tcp.google.com:80/test',
+        pathname: '/test',
+        path: '/test',
+      },
+
+      'http://x:1/\' <>"`/{}|\\^~`/': {
+        protocol: 'http:',
+        slashes: true,
+        host: 'x:1',
+        port: '1',
+        hostname: 'x',
+        pathname: '/%27%20%3C%3E%22%60/%7B%7D%7C/%5E~%60/',
+        path: '/%27%20%3C%3E%22%60/%7B%7D%7C/%5E~%60/',
+        href: 'http://x:1/%27%20%3C%3E%22%60/%7B%7D%7C/%5E~%60/',
+      },
+
+      'http://a@b@c/': {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'a@b',
+        host: 'c',
+        hostname: 'c',
+        href: 'http://a%40b@c/',
+        path: '/',
+        pathname: '/',
+      },
+
+      'http://a@b?@c': {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'a',
+        host: 'b',
+        hostname: 'b',
+        href: 'http://a@b/?@c',
+        path: '/?@c',
+        pathname: '/',
+        search: '?@c',
+        query: '@c',
+      },
+
+      'http://a.b/\tbc\ndr\ref g"hq\'j<kl>?mn\\op^q=r`99{st|uv}wz': {
+        protocol: 'http:',
+        slashes: true,
+        host: 'a.b',
+        port: null,
+        hostname: 'a.b',
+        hash: null,
+        pathname: '/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E',
+        path: '/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
+        search: '?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
+        query: 'mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
+        href: 'http://a.b/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
+      },
+
+      'http://a\r" \t\n<\'b:b@c\r\nd/e?f': {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'a" <\'b:b',
+        host: 'cd',
+        port: null,
+        hostname: 'cd',
+        hash: null,
+        search: '?f',
+        query: 'f',
+        pathname: '/e',
+        path: '/e?f',
+        href: "http://a%22%20%3C'b:b@cd/e?f",
+      },
+
+      // Git urls used by npm
+      'git+ssh://git@github.com:npm/npm': {
+        protocol: 'git+ssh:',
+        slashes: true,
+        auth: 'git',
+        host: 'github.com',
+        port: null,
+        hostname: 'github.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/:npm/npm',
+        path: '/:npm/npm',
+        href: 'git+ssh://git@github.com/:npm/npm',
+      },
+
+      'https://*': {
+        protocol: 'https:',
+        slashes: true,
+        auth: null,
+        host: '*',
+        port: null,
+        hostname: '*',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'https://*/',
+      },
+
+      // The following two URLs are the same, but they differ for a capital A.
+      // Verify that the protocol is checked in a case-insensitive manner.
+      'javascript:alert(1);a=\x27@white-listed.com\x27': {
+        protocol: 'javascript:',
+        slashes: null,
+        auth: null,
+        host: null,
+        port: null,
+        hostname: null,
+        hash: null,
+        search: null,
+        query: null,
+        pathname: "alert(1);a='@white-listed.com'",
+        path: "alert(1);a='@white-listed.com'",
+        href: "javascript:alert(1);a='@white-listed.com'",
+      },
+
+      'javAscript:alert(1);a=\x27@white-listed.com\x27': {
+        protocol: 'javascript:',
+        slashes: null,
+        auth: null,
+        host: null,
+        port: null,
+        hostname: null,
+        hash: null,
+        search: null,
+        query: null,
+        pathname: "alert(1);a='@white-listed.com'",
+        path: "alert(1);a='@white-listed.com'",
+        href: "javascript:alert(1);a='@white-listed.com'",
+      },
+
+      'ws://www.example.com': {
+        protocol: 'ws:',
+        slashes: true,
+        hostname: 'www.example.com',
+        host: 'www.example.com',
+        pathname: '/',
+        path: '/',
+        href: 'ws://www.example.com/',
+      },
+
+      'wss://www.example.com': {
+        protocol: 'wss:',
+        slashes: true,
+        hostname: 'www.example.com',
+        host: 'www.example.com',
+        pathname: '/',
+        path: '/',
+        href: 'wss://www.example.com/',
+      },
+
+      '//fhqwhgads@example.com/everybody-to-the-limit': {
+        protocol: null,
+        slashes: true,
+        auth: 'fhqwhgads',
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/everybody-to-the-limit',
+        path: '/everybody-to-the-limit',
+        href: '//fhqwhgads@example.com/everybody-to-the-limit',
+      },
+
+      '//fhqwhgads@example.com/everybody#to-the-limit': {
+        protocol: null,
+        slashes: true,
+        auth: 'fhqwhgads',
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: '#to-the-limit',
+        search: null,
+        query: null,
+        pathname: '/everybody',
+        path: '/everybody',
+        href: '//fhqwhgads@example.com/everybody#to-the-limit',
+      },
+
+      '\bhttp://example.com/\b': {
+        protocol: 'http:',
+        slashes: true,
+        auth: null,
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'http://example.com/',
+      },
+
+      'https://evil.com$.example.com': {
+        protocol: 'https:',
+        slashes: true,
+        auth: null,
+        host: 'evil.com$.example.com',
+        port: null,
+        hostname: 'evil.com$.example.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'https://evil.com$.example.com/',
+      },
+
+      // Validate the output of hostname with commas.
+      'x://0.0,1.1/': {
+        protocol: 'x:',
+        slashes: true,
+        auth: null,
+        host: '0.0,1.1',
+        port: null,
+        hostname: '0.0,1.1',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'x://0.0,1.1/',
+      },
+    };
+
+    // should parse and format
+    {
+      for (const u in parseTests) {
+        let actual = url.parse(u);
+        const spaced = url.parse(`     \t  ${u}\n\t`);
+        let expected = Object.assign(new url.Url(), parseTests[u]);
+
+        Object.keys(actual).forEach(function (i) {
+          if (expected[i] === undefined && actual[i] === null) {
+            expected[i] = null;
+          }
+        });
+
+        assert.deepStrictEqual(
+          actual,
+          expected,
+          `parsing ${u} and expected ${inspect(expected)} but got ${inspect(actual)}`
+        );
+        assert.deepStrictEqual(
+          spaced,
+          expected,
+          `expected ${inspect(expected)}, got ${inspect(spaced)}`
+        );
+
+        expected = parseTests[u].href;
+        actual = url.format(parseTests[u]);
+
+        assert.strictEqual(
+          actual,
+          expected,
+          `format(${u}) == ${u}\nactual:${actual}`
+        );
+      }
+    }
+
+    // parse result should equal new url.Url()
+    {
+      const parsed = url
+        .parse('http://nodejs.org/')
+        .resolveObject('jAvascript:alert(1);a=\x27@white-listed.com\x27');
+
+      const expected = Object.assign(new url.Url(), {
+        protocol: 'javascript:',
+        slashes: null,
+        auth: null,
+        host: null,
+        port: null,
+        hostname: null,
+        hash: null,
+        search: null,
+        query: null,
+        pathname: "alert(1);a='@white-listed.com'",
+        path: "alert(1);a='@white-listed.com'",
+        href: "javascript:alert(1);a='@white-listed.com'",
+      });
+
+      assert.deepStrictEqual(parsed, expected);
+    }
+  },
+};
+
+// Ref: https://github.com/nodejs/node/blob/e92446536ed4e268c9eef6ae6f911e384c98eecf/test/parallel/test-url-parse-invalid-input.js
+export const urlParseInvalidInput = {
+  async test() {
+    // https://github.com/joyent/node/issues/568
+    [
+      [undefined, 'undefined'],
+      [null, 'object'],
+      [true, 'boolean'],
+      [false, 'boolean'],
+      [0.0, 'number'],
+      [0, 'number'],
+      [[], 'object'],
+      [{}, 'object'],
+      [() => {}, 'function'],
+      [Symbol('foo'), 'symbol'],
+    ].forEach(([val, type]) => {
+      assert.throws(
+        () => {
+          url.parse(val);
+        },
+        {
+          code: 'ERR_INVALID_ARG_TYPE',
+          name: 'TypeError',
+        }
+      );
+    });
+
+    assert.throws(
+      () => {
+        url.parse('http://%E0%A4%A@fail');
+      },
+      (e) => {
+        // The error should be a URIError.
+        if (!(e instanceof URIError)) return false;
+
+        // The error should be from the JS engine and not from Node.js.
+        // JS engine errors do not have the `code` property.
+        return e.code === undefined;
+      }
+    );
+
+    assert.throws(
+      () => {
+        url.parse('http://[127.0.0.1\x00c8763]:8000/');
+      },
+      { code: 'ERR_INVALID_URL', input: 'http://[127.0.0.1\x00c8763]:8000/' }
+    );
+
+    {
+      // An array of Unicode code points whose Unicode NFKD contains a "bad
+      // character".
+      const badIDNA = (() => {
+        const BAD_CHARS = '#%/:?@[\\]^|';
+        const out = [];
+        for (let i = 0x80; i < 0x110000; i++) {
+          const cp = String.fromCodePoint(i);
+          for (const badChar of BAD_CHARS) {
+            if (cp.normalize('NFKD').includes(badChar)) {
+              out.push(cp);
+            }
+          }
+        }
+        return out;
+      })();
+
+      // The generation logic above should at a minimum produce these two
+      // characters.
+      assert(badIDNA.includes('℀'));
+      assert(badIDNA.includes('＠'));
+
+      for (const badCodePoint of badIDNA) {
+        const badURL = `http://fail${badCodePoint}fail.com/`;
+        assert.throws(
+          () => {
+            url.parse(badURL);
+          },
+          (e) => e.code === 'ERR_INVALID_URL',
+          `parsing ${badURL}`
+        );
+      }
+
+      assert.throws(
+        () => {
+          url.parse('http://\u00AD/bad.com/');
+        },
+        (e) => e.code === 'ERR_INVALID_URL',
+        'parsing http://\u00AD/bad.com/'
+      );
+    }
+  },
+};

--- a/src/workerd/api/node/tests/legacy_url-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/legacy_url-nodejs-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "legacy_url-nodejs-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "legacy_url-nodejs-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat"]
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/node/url.h
+++ b/src/workerd/api/node/url.h
@@ -16,10 +16,17 @@ public:
 
   jsg::JsString domainToUnicode(jsg::Lock& js, kj::String domain);
   jsg::JsString domainToASCII(jsg::Lock& js, kj::String domain);
+  jsg::JsString format(
+      jsg::Lock& js, kj::String href, bool hash, bool unicode, bool search, bool auth);
+  jsg::JsString toASCII(jsg::Lock& js, kj::String url);
 
   JSG_RESOURCE_TYPE(UrlUtil) {
     JSG_METHOD(domainToUnicode);
     JSG_METHOD(domainToASCII);
+
+    // Legacy APIs
+    JSG_METHOD(format);
+    JSG_METHOD(toASCII);
   }
 };
 


### PR DESCRIPTION
Adds all remaining functionality for removing the requirement of the polyfill from wrangler for `node:url` module. (We can remove the hybrid polyfill). It is important to add the remaining modules because `node:url` is one of the most used modules in the ecosystem.

Here's the functionality implemented:

- Legacy `new Url()` class
- `url.urlToHttpOptions`
- `url.format()`
- `url.parse()`
- `url.resolve()`
- `url.resolveObject()`