### PR TITLE
Split Workflow get into getById and getByName

### DIFF
--- a/src/cloudflare/internal/test/workflows/workflows-api-test.js
+++ b/src/cloudflare/internal/test/workflows/workflows-api-test.js
@@ -17,7 +17,7 @@ export const tests = {
 
     {
       // Test get instance
-      const instance = await env.workflow.get('bar');
+      const instance = await env.workflow.getById('bar');
       assert.deepStrictEqual(instance.id, 'bar');
     }
   },

--- a/src/cloudflare/internal/test/workflows/workflows-mock.js
+++ b/src/cloudflare/internal/test/workflows/workflows-mock.js
@@ -6,7 +6,7 @@ export default {
   async fetch(request, env, ctx) {
     const data = await request.json();
 
-    if (request.url.includes('/get') && request.method === 'POST') {
+    if (request.url.includes('/getById') && request.method === 'POST') {
       return Response.json(
         {
           result: {

--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -39,7 +39,7 @@ async function callFetcher<T>(
   }
 }
 
-class InstanceImpl implements Instance {
+class InstanceImpl implements WorkflowInstance {
   private readonly fetcher: Fetcher;
   public readonly id: string;
 
@@ -86,7 +86,7 @@ class WorkflowImpl {
     this.fetcher = fetcher;
   }
 
-  public async getById(id: string): Promise<Instance> {
+  public async getById(id: string): Promise<WorkflowInstance> {
     const result = await callFetcher<{
       instanceId: string;
       instanceName: string;
@@ -95,7 +95,7 @@ class WorkflowImpl {
     return new InstanceImpl(result.instanceId, this.fetcher);
   }
 
-  public async getByName(name: string): Promise<Instance> {
+  public async getByName(name: string): Promise<WorkflowInstance> {
     const result = await callFetcher<{
       instanceId: string;
       instanceName: string;
@@ -106,7 +106,7 @@ class WorkflowImpl {
 
   public async create(
     options?: WorkflowInstanceCreateOptions
-  ): Promise<Instance> {
+  ): Promise<WorkflowInstance> {
     const result = await callFetcher<{
       instanceId: string;
       instanceName: string;

--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -86,12 +86,20 @@ class WorkflowImpl {
     this.fetcher = fetcher;
   }
 
-  public async get(id: string): Promise<Instance> {
-    const result = await callFetcher<{ instanceId: string }>(
-      this.fetcher,
-      '/get',
-      { id }
-    );
+  public async getById(id: string): Promise<Instance> {
+    const result = await callFetcher<{
+      instanceId: string;
+      instanceName: string;
+    }>(this.fetcher, '/getById', { id });
+
+    return new InstanceImpl(result.instanceId, this.fetcher);
+  }
+
+  public async getByName(name: string): Promise<Instance> {
+    const result = await callFetcher<{
+      instanceId: string;
+      instanceName: string;
+    }>(this.fetcher, '/getByName', { name });
 
     return new InstanceImpl(result.instanceId, this.fetcher);
   }
@@ -99,11 +107,10 @@ class WorkflowImpl {
   public async create(
     options?: WorkflowInstanceCreateOptions
   ): Promise<Instance> {
-    const result = await callFetcher<{ instanceId: string }>(
-      this.fetcher,
-      '/create',
-      options ?? {}
-    );
+    const result = await callFetcher<{
+      instanceId: string;
+      instanceName: string;
+    }>(this.fetcher, '/create', options ?? {});
 
     return new InstanceImpl(result.instanceId, this.fetcher);
   }

--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -28,11 +28,18 @@ declare abstract class Workflow {
    * @param id Id for the instance of this Workflow
    * @returns A promise that resolves with a handle for the Instance
    */
-  public get(id: string): Promise<Instance>;
+  public getById(id: string): Promise<Instance>;
+
+  /**
+   * Get a handle to an existing instance of the Workflow.
+   * @param name Name for the instance of this Workflow
+   * @returns A promise that resolves with a handle for the Instance
+   */
+  public getByName(name: string): Promise<Instance>;
 
   /**
    * Create a new instance and return a handle to it. If a provided id exists, an error will be thrown.
-   * @param options optional fields to customize the instance creation
+   * @param options Options when creating an instance including name and params
    * @returns A promise that resolves with a handle for the Instance
    */
   public create(options?: WorkflowInstanceCreateOptions): Promise<Instance>;
@@ -40,11 +47,11 @@ declare abstract class Workflow {
 
 interface WorkflowInstanceCreateOptions {
   /**
-   * Name to create the instance of this Workflow with - it should always be unique
+   * A name for your Workflow instance. Must be unique within the Workflow.
    */
   name?: string;
   /**
-   * The payload to send over to this instance, this is optional since you might need to pass params into the instance
+   * The event payload the Workflow instance is triggered with
    */
   params?: unknown;
 }

--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -28,21 +28,23 @@ declare abstract class Workflow {
    * @param id Id for the instance of this Workflow
    * @returns A promise that resolves with a handle for the Instance
    */
-  public getById(id: string): Promise<Instance>;
+  public getById(id: string): Promise<WorkflowInstance>;
 
   /**
    * Get a handle to an existing instance of the Workflow.
    * @param name Name for the instance of this Workflow
    * @returns A promise that resolves with a handle for the Instance
    */
-  public getByName(name: string): Promise<Instance>;
+  public getByName(name: string): Promise<WorkflowInstance>;
 
   /**
    * Create a new instance and return a handle to it. If a provided id exists, an error will be thrown.
    * @param options Options when creating an instance including name and params
    * @returns A promise that resolves with a handle for the Instance
    */
-  public create(options?: WorkflowInstanceCreateOptions): Promise<Instance>;
+  public create(
+    options?: WorkflowInstanceCreateOptions
+  ): Promise<WorkflowInstance>;
 }
 
 interface WorkflowInstanceCreateOptions {
@@ -76,7 +78,7 @@ interface WorkflowError {
   message: string;
 }
 
-declare abstract class Instance {
+declare abstract class WorkflowInstance {
   public id: string;
 
   /**

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -14,21 +14,23 @@ declare abstract class Workflow {
    * @param id Id for the instance of this Workflow
    * @returns A promise that resolves with a handle for the Instance
    */
-  public getById(id: string): Promise<Instance>;
+  public getById(id: string): Promise<WorkflowInstance>;
 
   /**
    * Get a handle to an existing instance of the Workflow.
    * @param name Name for the instance of this Workflow
    * @returns A promise that resolves with a handle for the Instance
    */
-  public getByName(name: string): Promise<Instance>;
+  public getByName(name: string): Promise<WorkflowInstance>;
 
   /**
    * Create a new instance and return a handle to it. If a provided id exists, an error will be thrown.
    * @param options Options when creating an instance including name and params
    * @returns A promise that resolves with a handle for the Instance
    */
-  public create(options?: WorkflowInstanceCreateOptions): Promise<Instance>;
+  public create(
+    options?: WorkflowInstanceCreateOptions
+  ): Promise<WorkflowInstance>;
 }
 
 interface WorkflowInstanceCreateOptions {
@@ -62,7 +64,7 @@ interface WorkflowError {
   message: string;
 }
 
-declare abstract class Instance {
+declare abstract class WorkflowInstance {
   public id: string;
 
   /**

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -14,11 +14,18 @@ declare abstract class Workflow {
    * @param id Id for the instance of this Workflow
    * @returns A promise that resolves with a handle for the Instance
    */
-  public get(id: string): Promise<Instance>;
+  public getById(id: string): Promise<Instance>;
+
+  /**
+   * Get a handle to an existing instance of the Workflow.
+   * @param name Name for the instance of this Workflow
+   * @returns A promise that resolves with a handle for the Instance
+   */
+  public getByName(name: string): Promise<Instance>;
 
   /**
    * Create a new instance and return a handle to it. If a provided id exists, an error will be thrown.
-   * @param options optional fields to customize the instance creation
+   * @param options Options when creating an instance including name and params
    * @returns A promise that resolves with a handle for the Instance
    */
   public create(options?: WorkflowInstanceCreateOptions): Promise<Instance>;
@@ -26,11 +33,11 @@ declare abstract class Workflow {
 
 interface WorkflowInstanceCreateOptions {
   /**
-   * Name to create the instance of this Workflow with - it should always be unique
+   * A name for your Workflow instance. Must be unique within the Workflow.
    */
   name?: string;
   /**
-   * The payload to send over to this instance, this is optional since you might need to pass params into the instance
+   * The event payload the Workflow instance is triggered with
    */
   params?: unknown;
 }
@@ -69,9 +76,9 @@ declare abstract class Instance {
   public resume(): Promise<void>;
 
   /**
-   * Abort the instance. If it is errored, terminated or complete, an error will be thrown.
+   * Terminate the instance. If it is errored, terminated or complete, an error will be thrown.
    */
-  public abort(): Promise<void>;
+  public terminate(): Promise<void>;
 
   /**
    * Restart the instance.


### PR DESCRIPTION
We're moving `get` to `getById` and `getByName` for instances in Workflow binding