### PR TITLE
SQLite: Cache prepared statements behind `sql.exec()`.

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -831,15 +831,18 @@ async function test(state) {
     assert.deepEqual(rawResults[2], [4, 5, 6, 7, 8, 9]);
     assert.deepEqual(rawResults[3], [4, 5, 6, 1, 2, 3]);
 
-    // Once an iterator is consumed, it can no longer access the columnNames.
-    assert.throws(() => {
-      iterator.columnNames;
-    }, 'Error: Cannot call .getColumnNames after Cursor iterator has been consumed.');
+    // After an iterator is consumed, columnNames can still be accessed.
+    assert.deepEqual(iterator.columnNames, ['a', 'b', 'c', 'c', 'd', 'e']);
 
     // Also works with cursors returned from .exec
     const execIterator = sql.exec(`SELECT * FROM abc, cde`);
     assert.deepEqual(execIterator.columnNames, ['a', 'b', 'c', 'c', 'd', 'e']);
     assert.equal(Array.from(execIterator.raw())[0].length, 6);
+
+    // Execute some sort of statement that returns no results, check that we can read the column
+    // names (which is empty).
+    const oneIterator = sql.exec(`UPDATE abc SET a = 1 WHERE b = 123542`);
+    assert.deepEqual(oneIterator.columnNames, []);
   }
 
   await scheduler.wait(1);

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -294,14 +294,12 @@ async function test(state) {
   assert.equal(resultPrepared.length, 1);
   assert.equal(resultPrepared[0]['789'], 789);
 
-  // Running the same query twice invalidates the previous cursor.
+  // Running the same query twice, overlapping, works just fine.
   let result1 = prepared();
   let result2 = prepared();
+  // Iterate result2 before result1.
   assert.equal([...result2][0]['789'], 789);
-  assert.throws(
-    () => [...result1],
-    'SQL cursor was closed because the same statement was executed again.'
-  );
+  assert.equal([...result1][0]['789'], 789);
 
   // That said if a cursor was already done before the statement was re-run, it's not considered
   // canceled.
@@ -331,9 +329,7 @@ async function test(state) {
   }
 
   // Prepared statement with multiple statements
-  assert.throws(() => {
-    sql.prepare('SELECT 1; SELECT 2;');
-  }, /A prepared SQL statement must contain only one statement./);
+  assert.deepEqual([...sql.prepare('SELECT 1; SELECT 2;')()], [{ 2: 2 }]);
 
   // Accessing a hidden _cf_ table
   assert.throws(

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -19,6 +19,10 @@ async function test(state) {
   assert.equal(resultNumberRaw[0].length, 1);
   assert.equal(resultNumberRaw[0][0], 123);
 
+  sql.exec('SELECT 123');
+  sql.exec('SELECT 123');
+  sql.exec('SELECT 123');
+
   // Test string results
   const resultStr = [...sql.exec("SELECT 'hello'")];
   assert.equal(resultStr.length, 1);

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -1070,9 +1070,12 @@ async function testIoStats(storage) {
     while (true) {
       const result = resultsIterator.next();
       if (result.done) {
+        assert.equal(10, cursor.rowsRead);
         break;
       }
-      assert.equal(++rowsSeen, cursor.rowsRead);
+      // + 1 because the cursor is always one result ahead of what has been returned -- but there
+      // are only 10 rows total.
+      assert.equal(Math.min(++rowsSeen + 1, 10), cursor.rowsRead);
     }
   }
 

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -117,7 +117,7 @@ SqlStorage::Cursor::~Cursor() noexcept(false) {
   }
 }
 
-void SqlStorage::Cursor::CachedColumnNames::ensureInitialized(
+void SqlStorage::CachedColumnNames::ensureInitialized(
     jsg::Lock& js, SqliteDatabase::Query& source) {
   if (names == kj::none) {
     js.withinHandleScope([&] {

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -123,7 +123,7 @@ public:
   static constexpr Regulator TRUSTED;
 
   // Prepares the given SQL code as a persistent statement that can be used across several queries.
-  // Don't use this for one-off queries; pass the code to the Query constructor.
+  // Don't use this for one-off queries; use run() instead.
   Statement prepare(const Regulator& regulator, kj::StringPtr sqlCode);
 
   // Convenience method to start a query. This is equivalent to `prepare(sqlCode).run(bindings...)`

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -126,6 +126,18 @@ public:
   // Don't use this for one-off queries; use run() instead.
   Statement prepare(const Regulator& regulator, kj::StringPtr sqlCode);
 
+  // Prepares a statement that may acutally be multiple statements (separated by semicolons).
+  // In this case, the code is not actually parsed until first executed (this implies
+  // `prepareMulti()` will never throw since it doesn't actually do anything). This lazy-parsing
+  // behavior is necessary in the case that later statements depend on the effects of earlier ones.
+  // For example, the first statement might create a table, and the next statement insert into that
+  // table. SQLite will refuse to parse the insertion statement until the table has been created,
+  // so each statement must be executed before the next can be parsed.
+  //
+  // As with exec(), the result of executing a batch of multiple statements is always the result
+  // of the last statement. The results of all other statements are discarded.
+  Statement prepareMulti(const Regulator& regulator, kj::String sqlCode);
+
   // Convenience method to start a query. This is equivalent to `prepare(sqlCode).run(bindings...)`
   // except:
   // - It may be more efficient for one-off use caes.
@@ -321,8 +333,14 @@ private:
   //
   // In MULTI mode, if `sqlCode` contains multiple statements, each statement before the last one
   // is executed immediately. The returned object represents the last statement.
-  StatementAndEffect prepareSql(
-      const Regulator& regulator, kj::StringPtr sqlCode, uint prepFlags, Multi multi);
+  //
+  // If `prelude` is provided, then, in MULTI mode, all statements which are executed immediately
+  // are also appended to `prelude`.
+  StatementAndEffect prepareSql(const Regulator& regulator,
+      kj::StringPtr sqlCode,
+      uint prepFlags,
+      Multi multi,
+      kj::Maybe<kj::Vector<Statement>&> prelude = kj::none);
 
   // Implements SQLite authorizer callback, see sqlite3_set_authorizer().
   bool isAuthorized(int actionCode,
@@ -367,23 +385,30 @@ public:
   template <typename... Params>
   Query run(Params&&... bindings);
 
-  // Convert to sqlite3_stmt, creating it on-demand if needed.
-  operator sqlite3_stmt*() {
-    return getStatementAndEffect().statement;
-  }
-
 private:
   const Regulator& regulator;
   kj::OneOf<kj::String, StatementAndEffect> stmt;
+
+  // List of statements to execute before this one. Only non-empty if this Statement was created
+  // by prepareMulti().
+  kj::Vector<Statement> prelude;
 
   Statement(SqliteDatabase& db, const Regulator& regulator, StatementAndEffect stmt)
       : ResetListener(db),
         regulator(regulator),
         stmt(kj::mv(stmt)) {}
 
+  // Lazily-parsed statement -- used by `prepareMulti()`.
+  Statement(SqliteDatabase& db, const Regulator& regulator, kj::String sqlCode)
+      : ResetListener(db),
+        regulator(regulator),
+        stmt(kj::mv(sqlCode)) {}
+
   void beforeSqliteReset() override;
 
-  StatementAndEffect& getStatementAndEffect();
+  // Get the underlying StatementAndEffect, which the caller will then execute. If `prelude` is
+  // non-empty, prepareForExecution() actually executes the prelude.
+  StatementAndEffect& prepareForExecution();
 
   friend class SqliteDatabase;
 };
@@ -513,7 +538,7 @@ private:
   Query(SqliteDatabase& db, const Regulator& regulator, Statement& statement, Params&&... bindings)
       : ResetListener(db),
         regulator(regulator),
-        maybeStatement(statement.getStatementAndEffect()) {
+        maybeStatement(statement.prepareForExecution()) {
     // If we throw from the constructor, the destructor won't run. Need to call destroy()
     // explicitly.
     KJ_ON_SCOPE_FAILURE(destroy());
@@ -834,6 +859,11 @@ template <size_t size>
 SqliteDatabase::Statement SqliteDatabase::prepare(
     const Regulator& regulator, const char (&sqlCode)[size]) {
   return prepare(regulator, kj::StringPtr(sqlCode, size - 1));
+}
+
+inline SqliteDatabase::Statement SqliteDatabase::prepareMulti(
+    const Regulator& regulator, kj::String sqlCode) {
+  return Statement(*this, regulator, kj::mv(sqlCode));
 }
 
 }  // namespace workerd


### PR DESCRIPTION
`sql.exec()` currently parses the query every time it is invoked. This change makes it so that we retain some number of prepared statements in a cache and reuse them, keyed by the query text. Since query strings are likely commonly internalized strings, cache lookups should be O(1) most of the time, as internalized strings compare equal by identity without the need to compare content.