### PR TITLE
Fixes Python import parser bug in multi-line string literals.

### DIFF
--- a/src/workerd/api/pyodide/pyodide-test.c++
+++ b/src/workerd/api/pyodide/pyodide-test.c++
@@ -187,5 +187,14 @@ import openai)SCRIPT"));
   KJ_REQUIRE(result[2] == "openai");
 }
 
+KJ_TEST("quote in multiline string") {
+  auto files = kj::heapArrayBuilder<kj::String>(1);
+  files.add(kj::str(R"SCRIPT(temp = """
+w["h
+""")SCRIPT"));
+  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  KJ_REQUIRE(result.size() == 0);
+}
+
 }  // namespace
 }  // namespace workerd::api

--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -268,6 +268,9 @@ kj::Array<kj::String> ArtifactBundler::parsePythonScriptImports(kj::Array<kj::St
             i += 3;  // skip start quotes.
             // skip until terminating quotes.
             while (i + 2 < file.size() && file[i + 1] != quote && file[i + 2] != quote) {
+              if (file[i] == quote) {
+                i++;
+              }
               i += skipUntil(file, {quote}, i);
             }
             i += 3;  // skip terminating quotes.
@@ -277,6 +280,9 @@ kj::Array<kj::String> ArtifactBundler::parsePythonScriptImports(kj::Array<kj::St
             i += 3;  // skip `"\<NL>`
             // skip until quote, but ignore `\"`.
             while (file[i] != quote && file[i - 1] != '\\') {
+              if (file[i] == quote) {
+                i++;
+              }
               i += skipUntil(file, {quote}, i);
             }
             i += 1;  // skip quote.


### PR DESCRIPTION
We're switching to Ruff, but in the meantime the fix was simple so let's get it deployed.

### Test Plan

```
$ 
```

Also ran the parser on some real Python code (which I should have done in my previous changes), specifically:

* My cold start worker code
* The .py files in https://github.com/pyodide/pyodide/tree/main/src/py/pyodide 
* Some of the .py files in https://github.com/pyodide/pyodide/tree/main/src/tests