### PR TITLE
add placeholders for createObjectURL()

### DIFF
--- a/src/workerd/api/url-standard.c++
+++ b/src/workerd/api/url-standard.c++
@@ -53,6 +53,16 @@ bool URL::canParse(kj::String url, jsg::Optional<kj::String> maybeBase) {
   return jsg::Url::canParse(url, maybeBase.map([](kj::String& str) { return str.asPtr(); }));
 }
 
+jsg::JsString URL::createObjectURL(jsg::Lock& js, kj::OneOf<File, Blob> object) {
+  // TODO(soon): Implement this
+  JSG_FAIL_REQUIRE(Error, "URL.createObjectURL() is not implemented"_kj);
+}
+
+void URL::revokeObjectURL(jsg::Lock& js, kj::String object_url) {
+  // TODO(soon): Implement this
+  JSG_FAIL_REQUIRE(Error, "URL.revokeObjectURL() is not implemented"_kj);
+}
+
 jsg::Ref<URLSearchParams> URL::getSearchParams() {
   KJ_IF_SOME(searchParams, maybeSearchParams) {
     return searchParams.addRef();

--- a/src/workerd/api/url-standard.c++
+++ b/src/workerd/api/url-standard.c++
@@ -53,7 +53,8 @@ bool URL::canParse(kj::String url, jsg::Optional<kj::String> maybeBase) {
   return jsg::Url::canParse(url, maybeBase.map([](kj::String& str) { return str.asPtr(); }));
 }
 
-jsg::JsString URL::createObjectURL(jsg::Lock& js, kj::OneOf<File, Blob> object) {
+jsg::JsString URL::createObjectURL(
+    jsg::Lock& js, kj::OneOf<jsg::Ref<File>, jsg::Ref<Blob>> object) {
   // TODO(soon): Implement this
   JSG_FAIL_REQUIRE(Error, "URL.createObjectURL() is not implemented"_kj);
 }

--- a/src/workerd/api/url-standard.h
+++ b/src/workerd/api/url-standard.h
@@ -206,7 +206,7 @@ public:
   // ].filter((test) => URL.canParse(test));
   //
   static bool canParse(kj::String url, jsg::Optional<kj::String> base = kj::none);
-  static jsg::JsString createObjectURL(jsg::Lock& js, kj::OneOf<workerd::api::File, workerd::api::Blob> object);
+  static jsg::JsString createObjectURL(jsg::Lock& js, kj::OneOf<jsg::Ref<File>, jsg::Ref<Blob>> object);
   static void revokeObjectURL(jsg::Lock& js, kj::String object_url);
 
   JSG_RESOURCE_TYPE(URL) {

--- a/src/workerd/api/url-standard.h
+++ b/src/workerd/api/url-standard.h
@@ -6,6 +6,7 @@
 
 #include <kj/hash.h>
 #include "form-data.h"
+#include <workerd/api/blob.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/url.h>
 #include <workerd/io/compatibility-date.capnp.h>
@@ -205,6 +206,8 @@ public:
   // ].filter((test) => URL.canParse(test));
   //
   static bool canParse(kj::String url, jsg::Optional<kj::String> base = kj::none);
+  static jsg::JsString createObjectURL(jsg::Lock& js, kj::OneOf<workerd::api::File, workerd::api::Blob> object);
+  static void revokeObjectURL(jsg::Lock& js, kj::String object_url);
 
   JSG_RESOURCE_TYPE(URL) {
     JSG_READONLY_PROTOTYPE_PROPERTY(origin, getOrigin);
@@ -223,6 +226,8 @@ public:
     JSG_METHOD_NAMED(toString, getHref);
     JSG_STATIC_METHOD(canParse);
     JSG_STATIC_METHOD(parse);
+    JSG_STATIC_METHOD(createObjectURL);
+    JSG_STATIC_METHOD(revokeObjectURL);
 
     JSG_TS_OVERRIDE(URL {
       constructor(url: string | URL, base?: string | URL);


### PR DESCRIPTION
Add placeholders for `URL.createObjectURL()` and `URL.revokeObjectURL()`

Ref: https://github.com/cloudflare/workerd/issues/2969