### PR TITLE
Put waitForBookmark behind experimental flag

### DIFF
--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -253,7 +253,10 @@ public:
     JSG_METHOD(getCurrentBookmark);
     JSG_METHOD(getBookmarkForTime);
     JSG_METHOD(onNextSessionRestoreBookmark);
-    JSG_METHOD(waitForBookmark);
+
+    if (flags.getWorkerdExperimental()) {
+      JSG_METHOD(waitForBookmark);
+    }
 
     JSG_TS_OVERRIDE({
       get<T = unknown>(key: string, options?: DurableObjectGetOptions): Promise<T | undefined>;


### PR DESCRIPTION
`waitForBookmark` will be part of the public API of read replication, but given that we’re still implementing read replication, this should be behind a flag.

I should have done this in #2923.