### PR TITLE
EventSource: avoid rethrowing moved-from exception

### DIFF
--- a/src/workerd/api/eventsource.c++
+++ b/src/workerd/api/eventsource.c++
@@ -225,7 +225,7 @@ kj::Promise<void> processBody(IoContext& context, kj::Promise<DeferredProxy<void
       co_return;
     }
     // Propagate the exception up.
-    throw;
+    kj::throwFatalException(kj::mv(ex));
   }
 }
 }  // namespace


### PR DESCRIPTION
`kj::getCaughtExceptionAsKj()` can move data out of the caught exception, so rethrowing it can result in exceptions with missing data.

Caught via code audit of a similar problem; don't know if it can manifest as visible behavior, but would presumably appear as JS exceptions becoming opaque internal errors, or as empty error descriptions in logs.