### PR TITLE
move compile_cache to jsg/compile_cache

### DIFF
--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -11,6 +11,7 @@ wd_cc_library(
     srcs = [
         "async-context.c++",
         "buffersource.c++",
+        "compile-cache.c++",
         "dom-exception.c++",
         "inspector.c++",
         "iterator.c++",
@@ -29,6 +30,7 @@ wd_cc_library(
     hdrs = [
         "async-context.h",
         "buffersource.h",
+        "compile-cache.h",
         "dom-exception.h",
         "function.h",
         "inspector.h",

--- a/src/workerd/jsg/compile-cache.c++
+++ b/src/workerd/jsg/compile-cache.c++
@@ -1,0 +1,31 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+#include "compile-cache.h"
+
+namespace workerd::jsg {
+
+// CompileCache::Data
+
+std::unique_ptr<v8::ScriptCompiler::CachedData> CompileCache::Data::AsCachedData() {
+  return std::make_unique<v8::ScriptCompiler::CachedData>(
+      data, length, v8::ScriptCompiler::CachedData::BufferNotOwned);
+}
+
+// CompileCache
+
+void CompileCache::add(
+    kj::StringPtr key, std::shared_ptr<v8::ScriptCompiler::CachedData> cached) const {
+  cache.lockExclusive()->upsert(kj::str(key), Data(kj::mv(cached)), [](auto&, auto&&) {});
+}
+
+kj::Maybe<CompileCache::Data&> CompileCache::find(kj::StringPtr key) const {
+  KJ_IF_SOME(value, cache.lockExclusive()->find(key)) {
+    if (value.data != nullptr) {
+      return value;
+    }
+  }
+  return kj::none;
+}
+
+}  // namespace workerd::jsg

--- a/src/workerd/jsg/compile-cache.h
+++ b/src/workerd/jsg/compile-cache.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+#pragma once
+
+#include "jsg.h"
+#include "setup.h"
+
+#include <v8.h>
+
+#include <kj/string.h>
+
+namespace workerd::jsg {
+
+// The CompileCache is used to hold cached compilation data for built-in JavaScript modules.
+//
+// Importantly, this is a process-lifetime in-memory cache that is only appropriate for
+// built-in modules.
+//
+// The memory-safety of this cache depends on the assumption that entries are never removed
+// or replaced. If things are ever changed such that entries are removed/replaced, then
+// we'd likely need to have find return an atomic refcount or something similar.
+class CompileCache {
+public:
+  class Data {
+  public:
+    Data(): data(nullptr), length(0), owningPtr(nullptr) {};
+    explicit Data(std::shared_ptr<v8::ScriptCompiler::CachedData> cached_data)
+        : data(cached_data->data),
+          length(cached_data->length),
+          owningPtr(cached_data) {};
+
+    // Returns a v8::ScriptCompiler::CachedData corresponding to this
+    // CompileCache::Data. The lifetime of the returned
+    // v8::ScriptCompiler::CachedData must not outlive that of the data.
+    std::unique_ptr<v8::ScriptCompiler::CachedData> AsCachedData();
+
+    const uint8_t* data;
+    size_t length;
+
+  private:
+    std::shared_ptr<void> owningPtr;
+  };
+
+  void add(kj::StringPtr key, std::shared_ptr<v8::ScriptCompiler::CachedData> cached) const;
+  kj::Maybe<Data&> find(kj::StringPtr key) const;
+
+  static const CompileCache& get() {
+    static const CompileCache instance;
+    return instance;
+  }
+
+private:
+  // The key is the address of the static global that was compiled to produce the CachedData.
+  kj::MutexGuarded<kj::HashMap<kj::String, Data>> cache;
+};
+
+}  // namespace workerd::jsg

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -2,8 +2,8 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+#include "compile-cache.h"
 #include "jsg.h"
-#include "promise.h"
 #include "setup.h"
 
 #include <kj/mutex.h>
@@ -12,62 +12,6 @@
 
 namespace workerd::jsg {
 namespace {
-
-// The CompileCache is used to hold cached compilation data for built-in JavaScript modules.
-//
-// Importantly, this is a process-lifetime in-memory cache that is only appropriate for
-// built-in modules.
-//
-// The memory-safety of this cache depends on the assumption that entries are never removed
-// or replaced. If things are ever changed such that entries are removed/replaced, then
-// we'd likely need to have find return an atomic refcount or something similar.
-class CompileCache {
-public:
-  class Data {
-  public:
-    Data(): data(nullptr), length(0), owningPtr(nullptr) {};
-    explicit Data(std::shared_ptr<v8::ScriptCompiler::CachedData> cached_data)
-        : data(cached_data->data),
-          length(cached_data->length),
-          owningPtr(cached_data) {};
-
-    // Returns a v8::ScriptCompiler::CachedData corresponding to this
-    // CompileCache::Data. The lifetime of the returned
-    // v8::ScriptCompiler::CachedData must not outlive that of the data.
-    std::unique_ptr<v8::ScriptCompiler::CachedData> AsCachedData() {
-      return std::make_unique<v8::ScriptCompiler::CachedData>(
-          data, length, v8::ScriptCompiler::CachedData::BufferNotOwned);
-    }
-
-    const uint8_t* data;
-    size_t length;
-
-  private:
-    std::shared_ptr<void> owningPtr;
-  };
-
-  void add(kj::StringPtr key, std::shared_ptr<v8::ScriptCompiler::CachedData> cached) const {
-    cache.lockExclusive()->upsert(kj::str(key), Data(kj::mv(cached)), [](auto&, auto&&) {});
-  }
-
-  kj::Maybe<Data&> find(kj::StringPtr key) const {
-    KJ_IF_SOME(value, cache.lockExclusive()->find(key)) {
-      if (value.data != nullptr) {
-        return value;
-      }
-    }
-    return kj::none;
-  }
-
-  static const CompileCache& get() {
-    static const CompileCache instance;
-    return instance;
-  }
-
-private:
-  // The key is the address of the static global that was compiled to produce the CachedData.
-  kj::MutexGuarded<kj::HashMap<kj::String, Data>> cache;
-};
 
 // Implementation of `v8::Module::ResolveCallback`.
 v8::MaybeLocal<v8::Module> resolveCallback(v8::Local<v8::Context> context,


### PR DESCRIPTION
Moves compile cache to it's own file to prepare for precompiling node internals.