### PR TITLE
Implements more methods on Python Response API and adds FormData API.

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -27,6 +27,7 @@ ignore = [
   "PLR2004", # Magic value used in comparison
   "TRY003", # Avoid specifying long messages outside the exception class
   "UP038",  # Use X | Y in isinstance check instead of (X, Y)
+  "PLR0911", # too many return statements
 ]
 
 [lint.per-file-ignores]

--- a/src/pyodide/internal/workers.py
+++ b/src/pyodide/internal/workers.py
@@ -1,19 +1,21 @@
 # This module defines a Workers API for Python. It is similar to the API provided by
 # JS Workers, but with changes and additions to be more idiomatic to the Python
 # programming language.
+from collections.abc import Generator, MutableMapping
 from http import HTTPMethod, HTTPStatus
 from typing import TypedDict, Unpack
 
 import js
 
 import pyodide.http
+from pyodide.ffi import JsException, to_js
 from pyodide.http import pyfetch
 
 JSBody = (
     "js.Blob | js.ArrayBuffer | js.TypedArray | js.DataView | js.FormData |"
     "js.ReadableStream | js.URLSearchParams"
 )
-Body = "str | JSBody"
+Body = "str | FormData | JSBody"
 Headers = dict[str, str] | list[tuple[str, str]]
 
 
@@ -23,16 +25,37 @@ class FetchKwargs(TypedDict, total=False):
     method: HTTPMethod = HTTPMethod.GET
 
 
-# TODO: This is just here to make the `body` field available as many Workers
-# examples which rewrite responses make use of it. It's something we should
-# likely upstream to Pyodide.
 class FetchResponse(pyodide.http.FetchResponse):
+    # TODO: Consider upstreaming the `body` attribute
     @property
     def body(self) -> Body:
         """
         Returns the body from the JavaScript Response instance.
         """
-        return self.js_response.body
+        b = self.js_response.body
+        if b.constructor.name == "FormData":
+            return FormData(b)
+        else:
+            return b
+
+    """
+    Instance methods defined below.
+
+    Some methods are implemented by `FetchResponse`, these include `buffer`
+    (replacing JavaScript's `arrayBuffer`), `bytes`, `json`, and `text`.
+
+    Some methods are intentionally not implemented, these include `blob`.
+
+    There are also some additional methods implemented by `FetchResponse`.
+    See https://pyodide.org/en/stable/usage/api/python-api/http.html#pyodide.http.FetchResponse
+    for details.
+    """
+
+    async def formData(self) -> "FormData":
+        try:
+            return FormData(await self.js_response.formData())
+        except JsException as exc:
+            raise _to_python_exception(exc) from exc
 
 
 async def fetch(
@@ -45,7 +68,16 @@ async def fetch(
     return FetchResponse(resp.url, resp.js_response)
 
 
-class Response:
+def _to_python_exception(exc: JsException) -> Exception:
+    if exc.name == "RangeError":
+        return ValueError(exc.message)
+    elif exc.name == "TypeError":
+        return TypeError(exc.message)
+    else:
+        return exc
+
+
+class Response(FetchResponse):
     def __init__(
         self,
         body: Body,
@@ -59,6 +91,19 @@ class Response:
         Based on the JS API of the same name:
         https://developer.mozilla.org/en-US/docs/Web/API/Response/Response.
         """
+        options = self._create_options(status, statusText, headers)
+
+        # Initialise via the FetchResponse super-class which gives us access to
+        # methods that we would ordinarily have to redeclare.
+        js_resp = js.Response.new(
+            body.js_form_data if isinstance(body, FormData) else body, **options
+        )
+        super().__init__(js_resp.url, js_resp)
+
+    @staticmethod
+    def _create_options(
+        status: HTTPStatus | int = HTTPStatus.OK, statusText="", headers: Headers = None
+    ):
         options = {
             "status": status.value if isinstance(status, HTTPStatus) else status,
         }
@@ -71,8 +116,87 @@ class Response:
             elif isinstance(headers, dict):
                 options["headers"] = js.Headers.new(headers.items())
             else:
-                raise TypeError(
-                    "Response() received unexpected type for headers argument"
-                )
+                raise TypeError("Received unexpected type for headers argument")
 
-        self.js_response = js.Response.new(body, **options)
+        return options
+
+    """
+    Static methods defined below. The `error` static method is not implemented as
+    it is not useful for the Workers use case.
+    """
+
+    @staticmethod
+    def redirect(url: str, status: HTTPStatus | int = HTTPStatus.FOUND):
+        code = status.value if isinstance(status, HTTPStatus) else status
+        try:
+            return js.Response.redirect(url, code)
+        except JsException as exc:
+            raise _to_python_exception(exc) from exc
+
+    @staticmethod
+    def json(
+        data: str | dict[str, str],
+        status: HTTPStatus | int = HTTPStatus.OK,
+        statusText="",
+        headers: Headers = None,
+    ):
+        options = Response._create_options(status, statusText, headers)
+        try:
+            return js.Response.json(
+                to_js(data, dict_converter=js.Object.fromEntries), **options
+            )
+        except JsException as exc:
+            raise _to_python_exception(exc) from exc
+
+
+# TODO: Implement pythonic blob API
+FormDataValue = "str | js.Blob"
+
+
+class FormData(MutableMapping[str, FormDataValue]):
+    def __init__(self, form_data: "js.FormData | None | dict[str, FormDataValue]"):
+        if form_data:
+            if isinstance(form_data, dict):
+                self.js_form_data = js.FormData.new()
+                for item in form_data.items():
+                    self.js_form_data.append(item[0], item[1])
+            else:
+                self.js_form_data = form_data
+        else:
+            self.js_form_data = js.FormData.new()
+
+    def __getitem__(self, key: str) -> list[FormDataValue]:
+        return list(self.js_form_data.getAll(key))
+
+    def __setitem__(self, key: str, value: list[FormDataValue]):
+        self.js_form_data.delete(key)
+        for item in value:
+            self.js_form_data.append(key, item)
+
+    def append(self, key: str, value: FormDataValue):
+        self.js_form_data.append(key, value)
+
+    def delete(self, key: str):
+        self.js_form_data.delete(key)
+
+    def __contains__(self, key: str) -> bool:
+        return self.js_form_data.has(key)
+
+    def values(self) -> Generator[FormDataValue, None, None]:
+        yield from self.js_form_data.values()
+
+    def keys(self) -> Generator[str, None, None]:
+        yield from self.js_form_data.keys()
+
+    def __iter__(self):
+        yield from self.keys()
+
+    def items(self) -> Generator[tuple[str, FormDataValue], None, None]:
+        for item in self.js_form_data.entries():
+            yield (item[0], item[1])
+
+    def __delitem__(self, key: str):
+        self.delete(key)
+
+    def __len__(self):
+        return len(self.keys())

--- a/src/workerd/server/tests/python/sdk/sdk.wd-test
+++ b/src/workerd/server/tests/python/sdk/sdk.wd-test
@@ -11,9 +11,9 @@ const python :Workerd.Worker = (
   compatibilityFlags = ["python_workers_development", "python_external_bundle"],
 );
 
-const mock :Workerd.Worker = (
+const server :Workerd.Worker = (
   modules = [
-    (name = "mock.py", pythonModule = embed "mock.py")
+    (name = "server.py", pythonModule = embed "server.py")
   ],
   compatibilityDate = "2024-10-01",
   compatibilityFlags = ["python_workers_development", "python_external_bundle"],
@@ -25,7 +25,7 @@ const unitTests :Workerd.Config = (
       worker = .python
     ),
     ( name = "internet",
-      worker = .mock
+      worker = .server
     )
   ],
 );

--- a/src/workerd/server/tests/python/sdk/server.py
+++ b/src/workerd/server/tests/python/sdk/server.py
@@ -1,4 +1,4 @@
-from cloudflare.workers import Response
+from cloudflare.workers import FormData, Response
 
 
 async def on_fetch(request):
@@ -9,6 +9,11 @@ async def on_fetch(request):
         return Response(
             "Hi there!", headers={"Custom-Header-That-Should-Passthrough": True}
         )
+    elif request.url.endswith("/redirect"):
+        return Response.redirect("https://example.com/sub", status=301)
+    elif request.url.endswith("/formdata"):
+        data = FormData({"field": "value"})
+        return Response(data)
     else:
         raise ValueError("Unexpected path " + request.url)
 

--- a/src/workerd/server/tests/python/sdk/worker.py
+++ b/src/workerd/server/tests/python/sdk/worker.py
@@ -1,8 +1,12 @@
-from http import HTTPMethod
+from http import HTTPMethod, HTTPStatus
 
-from cloudflare.workers import Response, fetch
+import js
+
+from cloudflare.workers import FormData, Response, fetch
 
 
+# Each path in this handler is its own test. The URLs that are being fetched
+# here are defined in server.py.
 async def on_fetch(request):
     if request.url.endswith("/modify"):
         resp = await fetch("https://example.com/sub")
@@ -28,6 +32,52 @@ async def on_fetch(request):
             headers={"Custom-Req-Header": 123},
         )
         return resp
+    elif request.url.endswith("/jsism"):
+        # Headers should be specified via a keyword argument, but it's done
+        # differently in JS. So we test what happens when someone does it
+        # that way accidentally to make sure we give them a reasonable error
+        # message.
+        try:
+            resp = await fetch(
+                "https://example.com/sub",
+                {"headers": {"Custom-Req-Header": 123}},
+            )
+        except TypeError as exc:
+            if str(exc) == "fetch() takes 1 positional argument but 2 were given":
+                return Response("success")
+
+        return Response("fail")
+    elif request.url.endswith("/undefined_opts"):
+        # This tests two things:
+        #   * `Response.redirect` static method
+        #   * that other options can be passed into `fetch`
+        resp = await fetch("https://example.com/redirect", redirect="manual")
+        return resp
+    elif request.url.endswith("/response_inherited"):
+        expected = "test123"
+        resp = Response(expected)
+        text = await resp.text()
+        if text == expected:
+            return Response("success")
+        else:
+            return Response("invalid")
+    elif request.url.endswith("/redirect_invalid_input"):
+        try:
+            return Response.redirect("", HTTPStatus.BAD_GATEWAY)
+        except ValueError:
+            return Response("success")
+        return Response("invalid")
+    elif request.url.endswith("/response_json"):
+        return Response.json({"obj": {"field": 123}}, status=HTTPStatus.NOT_FOUND)
+    elif request.url.endswith("/formdata"):
+        # server.py creates a new FormData and verifies that it can be passed
+        # to Response.
+        resp = await fetch("https://example.com/formdata")
+        data = await resp.formData()
+        if data["field"] == ["value"]:
+            return Response("success")
+        else:
+            return Response("fail")
     else:
         resp = await fetch("https://example.com/sub")
         return resp
@@ -77,8 +127,101 @@ async def can_use_fetch_opts(env):
     assert response.headers.get("Custom-Header-That-Should-Passthrough") == "true"
 
 
+async def gets_nice_error_on_jsism(env):
+    response = await env.SELF.fetch(
+        "http://example.com/jsism",
+    )
+    text = await response.text()
+    assert text == "success"
+
+
+async def can_use_undefined_options_and_redirect(env):
+    response = await env.SELF.fetch(
+        "http://example.com/undefined_opts", redirect="manual"
+    )
+    # The above path in this worker hits server's /redirect path,
+    # which returns a 301 to /sub. The code uses a fetch option which
+    # instructs it to not follow redirects, so we expect to get
+    # a 301 here.
+    assert response.status == 301
+
+
+async def can_use_inherited_response_methods(env):
+    response = await env.SELF.fetch(
+        "http://example.com/response_inherited",
+    )
+    text = await response.text()
+    assert text == "success"
+
+
+async def errors_on_invalid_input_to_redirect(env):
+    response = await env.SELF.fetch(
+        "http://example.com/redirect_invalid_input",
+    )
+    text = await response.text()
+    assert text == "success"
+
+
+async def can_use_response_json(env):
+    response = await env.SELF.fetch(
+        "http://example.com/response_json",
+    )
+    text = await response.text()
+    assert text == '{"obj":{"field":123}}'
+
+
+async def can_request_form_data(env):
+    response = await env.SELF.fetch(
+        "http://example.com/formdata",
+    )
+    text = await response.text()
+    print(text)
+    assert text == "success"
+
+
+async def form_data_unit_tests(env):
+    # Verify that existing JS formdata is loaded correctly.
+    js_data = js.FormData.new()
+    js_data.append("foobar", 123)
+    js_data.append("key", "lorem ipsum")
+    js_data.append("key", "dolor sit amet")
+    data = FormData(js_data)
+    assert data["foobar"] == ["123"]
+    assert data["key"] == ["lorem ipsum", "dolor sit amet"]
+    assert "unknown key" not in data
+    assert "key" in data
+
+    # Verify that dictionary can instantiate form data.
+    data = FormData({"key": "foobar"})
+    assert data["key"] == ["foobar"]
+    assert "key" in data
+
+    # Test iterators
+    data.append("key", "another")
+    data.append("key2", "foobar2")
+    data_items = set(data.items())
+    assert ("key", "foobar") in data_items
+    assert ("key", "another") in data_items
+    assert ("key2", "foobar2") in data_items
+    data_keys = set(data.keys())
+    assert len(list(data.keys())) == 3
+    assert "key" in data_keys
+    assert "key2" in data_keys
+    data_values = set(data.values())
+    assert "foobar" in data_values
+    assert "another" in data_values
+    assert "foobar2" in data_values
+
+
 async def test(ctrl, env):
     await can_return_custom_fetch_response(env)
     await can_modify_response(env)
     await can_use_duplicate_headers(env)
     await can_use_fetch_opts(env)
+    await gets_nice_error_on_jsism(env)
+    await can_use_undefined_options_and_redirect(env)
+    await can_use_inherited_response_methods(env)
+    await errors_on_invalid_input_to_redirect(env)
+    await can_use_response_json(env)
+    await can_request_form_data(env)
+    await form_data_unit_tests(env)


### PR DESCRIPTION
The FormData API does not have a native Python equivalent, but it is a very useful API in Workers. This PR implements it and ties it into the Response API implementation.