### PR TITLE
Invalidate Python caches earlier so packages are picked up.

### DIFF
--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -19,6 +19,7 @@ import {
   getRandomValues,
 } from 'pyodide-internal:topLevelEntropy/lib';
 import { default as UnsafeEval } from 'internal:unsafe-eval';
+import { simpleRunPython } from 'pyodide-internal:util';
 
 /**
  * This file is a simplified version of the Pyodide loader:
@@ -65,6 +66,12 @@ async function prepareWasmLinearMemory(Module: Module): Promise<void> {
   Module.removeRunDependency('dynlibs');
   if (SHOULD_RESTORE_SNAPSHOT) {
     restoreSnapshot(Module);
+    // Invalidate caches if we have a snapshot because the contents of site-packages
+    // may have changed.
+    simpleRunPython(
+      Module,
+      'from importlib import invalidate_caches as f; f(); del f'
+    );
   }
   // entropyAfterRuntimeInit adjusts JS state ==> always needs to be called.
   entropyAfterRuntimeInit(Module);

--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -404,14 +404,6 @@ let TEST_SNAPSHOT: Uint8Array | undefined = undefined;
 })();
 
 export function finishSnapshotSetup(pyodide: Pyodide): void {
-  if (LOADED_SNAPSHOT_VERSION !== undefined) {
-    // Invalidate caches if we have a snapshot because the contents of site-packages may have changed.
-    simpleRunPython(
-      pyodide._module,
-      'from importlib import invalidate_caches as f; f(); del f'
-    );
-  }
-
   // This is just here for our test suite. Ugly but just about the only way to test this.
   if (TEST_SNAPSHOT) {
     const snapshotString = new TextDecoder().decode(TEST_SNAPSHOT);


### PR DESCRIPTION
Right now the validator fails to validate a Python Worker that imports packages when the validator is using the baseline snapshot. This should fix it.