### PR TITLE
WPT: Add remaining url tests

### DIFF
--- a/build/wpt_test.bzl
+++ b/build/wpt_test.bzl
@@ -89,10 +89,11 @@ def generate_external_modules(files):
 
     for file in files.to_list():
         file_path = wd_relative_path(file)
-        if file.basename.endswith(".js"):
+        if file.extension == "js":
             entry = """(name = "{}", esModule = embed "{}")""".format(file.basename, file_path)
-        elif file.basename.endswith(".json"):
-            entry = """(name = "{}", json = embed "{}")""".format(file.basename, file_path)
+        elif file.extension == "json":
+            # TODO(soon): It's difficult to manipulate paths in Bazel, so we assume that all JSONs are in a resources/ directory for now
+            entry = """(name = "resources/{}", json = embed "{}")""".format(file.basename, file_path)
         else:
             # For other file types, you can add more conditions or skip them
             continue

--- a/src/workerd/api/wpt/url-test.js
+++ b/src/workerd/api/wpt/url-test.js
@@ -2,20 +2,131 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import * as harness from 'harness';
+import { run } from 'harness';
 
-export const urlConstructor = {
-  async test() {
-    harness.prepare();
-    await import('url-constructor.any.js');
-    harness.validate();
-  },
-};
+export const historical = run('historical.any.js', {
+  expectedFailures: ["Setting URL's href attribute and base URLs"],
+});
 
-export const urlOrigin = {
-  async test() {
-    harness.prepare();
-    await import('url-origin.any.js');
-    harness.validate();
-  },
-};
+export const urlConstructor = run('url-constructor.any.js', {
+  expectedFailures: [
+    'Parsing: <http://example.com/\uD800\uD801\uDFFE\uDFFF\uFDD0\uFDCF\uFDEF\uFDF0\uFFFE\uFFFF?\uD800\uD801\uDFFE\uDFFF\uFDD0\uFDCF\uFDEF\uFDF0\uFFFE\uFFFF> without base',
+  ],
+});
+
+export const urlOrigin = run('url-origin.any.js');
+export const urlSearchParams = run('url-searchparams.any.js');
+export const urlSettersStripping = run('url-setters-stripping.any.js');
+export const urlSetters = run('url-setters.any.js');
+export const urlStaticsCanParse = run('url-statics-canparse.any.js');
+export const urlStaticsParse = run('url-statics-parse.any.js');
+export const urlToJson = run('url-tojson.any.js');
+
+export const urlencodedParser = run('urlencoded-parser.any.js', {
+  expectedFailures: [
+    'request.formData() with input: test',
+    'response.formData() with input: test',
+    'request.formData() with input: \uFEFFtest=\uFEFF',
+    'response.formData() with input: \uFEFFtest=\uFEFF',
+    'request.formData() with input: %EF%BB%BFtest=%EF%BB%BF',
+    'response.formData() with input: %EF%BB%BFtest=%EF%BB%BF',
+    'request.formData() with input: %EF%BF%BF=%EF%BF%BF',
+    'response.formData() with input: %EF%BF%BF=%EF%BF%BF',
+    'request.formData() with input: %FE%FF',
+    'response.formData() with input: %FE%FF',
+    'request.formData() with input: %FF%FE',
+    'response.formData() with input: %FF%FE',
+    'request.formData() with input: †&†=x',
+    'response.formData() with input: †&†=x',
+    'request.formData() with input: %C2',
+    'response.formData() with input: %C2',
+    'request.formData() with input: %C2x',
+    'response.formData() with input: %C2x',
+    'request.formData() with input: _charset_=windows-1252&test=%C2x',
+    'response.formData() with input: _charset_=windows-1252&test=%C2x',
+    'request.formData() with input: ',
+    'response.formData() with input: ',
+    'request.formData() with input: a',
+    'response.formData() with input: a',
+    'request.formData() with input: a=b',
+    'response.formData() with input: a=b',
+    'request.formData() with input: a=',
+    'response.formData() with input: a=',
+    'request.formData() with input: =b',
+    'response.formData() with input: =b',
+    'request.formData() with input: &',
+    'response.formData() with input: &',
+    'request.formData() with input: &a',
+    'response.formData() with input: &a',
+    'request.formData() with input: a&',
+    'response.formData() with input: a&',
+    'request.formData() with input: a&a',
+    'response.formData() with input: a&a',
+    'request.formData() with input: a&b&c',
+    'response.formData() with input: a&b&c',
+    'request.formData() with input: a=b&c=d',
+    'response.formData() with input: a=b&c=d',
+    'request.formData() with input: a=b&c=d&',
+    'response.formData() with input: a=b&c=d&',
+    'request.formData() with input: &&&a=b&&&&c=d&',
+    'response.formData() with input: &&&a=b&&&&c=d&',
+    'request.formData() with input: a=a&a=b&a=c',
+    'response.formData() with input: a=a&a=b&a=c',
+    'request.formData() with input: a==a',
+    'response.formData() with input: a==a',
+    'request.formData() with input: a=a+b+c+d',
+    'response.formData() with input: a=a+b+c+d',
+    'request.formData() with input: %=a',
+    'response.formData() with input: %=a',
+    'request.formData() with input: %a=a',
+    'response.formData() with input: %a=a',
+    'request.formData() with input: %a_=a',
+    'response.formData() with input: %a_=a',
+    'request.formData() with input: %61=a',
+    'response.formData() with input: %61=a',
+    'request.formData() with input: %61+%4d%4D=',
+    'response.formData() with input: %61+%4d%4D=',
+    'request.formData() with input: id=0&value=%',
+    'response.formData() with input: id=0&value=%',
+    'request.formData() with input: b=%2sf%2a',
+    'response.formData() with input: b=%2sf%2a',
+    'request.formData() with input: b=%2%2af%2a',
+    'response.formData() with input: b=%2%2af%2a',
+    'request.formData() with input: b=%%2a',
+    'response.formData() with input: b=%%2a',
+  ],
+});
+
+export const urlSearchParamsAppend = run('urlsearchparams-append.any.js');
+
+export const urlSearchParamsConstructor = run(
+  'urlsearchparams-constructor.any.js',
+  {
+    expectedFailures: [
+      'URLSearchParams constructor, DOMException as argument',
+      'Construct with 2 unpaired surrogates (no trailing)',
+      'Construct with 3 unpaired surrogates (no leading)',
+      'Construct with object with NULL, non-ASCII, and surrogate keys',
+    ],
+  }
+);
+
+export const urlSearchParamsDelete = run('urlsearchparams-delete.any.js');
+
+export const urlSearchParamsForEach = run('urlsearchparams-foreach.any.js', {
+  skippedTests: ['For-of Check'],
+});
+
+export const urlSearchParamsGet = run('urlsearchparams-get.any.js');
+export const urlSearchParamsGetAll = run('urlsearchparams-getall.any.js');
+export const urlSearchParamsHas = run('urlsearchparams-has.any.js');
+export const urlSearchParamsSet = run('urlsearchparams-set.any.js');
+export const urlSearchParamsSize = run('urlsearchparams-size.any.js');
+
+export const urlSearchParamsSort = await run('urlsearchparams-sort.any.js', {
+  expectedFailures: ['Parse and sort: ﬃ&🌈', 'URL parse and sort: ﬃ&🌈'],
+});
+
+export const urlSearchParamsStringifier = run(
+  'urlsearchparams-stringifier.any.js'
+);

--- a/src/wpt/harness.js
+++ b/src/wpt/harness.js
@@ -3,7 +3,13 @@
 //     https://opensource.org/licenses/Apache-2.0
 // Copyright © web-platform-tests contributors. BSD license
 
-import { strictEqual } from 'node:assert';
+import {
+  strictEqual,
+  notStrictEqual,
+  deepStrictEqual,
+  throws,
+  ok,
+} from 'node:assert';
 
 globalThis.fetch = async (url) => {
   const { default: data } = await import(url);
@@ -14,15 +20,79 @@ globalThis.fetch = async (url) => {
   };
 };
 
-globalThis.promise_test = (callback) => {
-  callback();
+globalThis.GLOBAL = { isWindow: () => false };
+
+globalThis.done = () => undefined;
+
+globalThis.subsetTestByKey = (_key, testType, testCallback, testMessage) => {
+  // This function is designed to allow selecting only certain tests when
+  // running in a browser, by changing the query string. We'll always run
+  // all the tests.
+
+  return testType(testCallback, testMessage);
 };
 
-globalThis.assert_equals = (a, b, c) => {
-  strictEqual(a, b, c);
+globalThis.promise_test = (callback, message) => {
+  if (!shouldRunTest(message)) {
+    return;
+  }
+
+  try {
+    globalThis.promises.push(callback());
+  } catch (err) {
+    globalThis.errors.push(new AggregateError([err], message));
+  }
+};
+
+globalThis.assert_equals = (a, b, message) => {
+  strictEqual(a, b, message);
+};
+
+globalThis.assert_not_equals = (a, b, message) => {
+  notStrictEqual(a, b, message);
+};
+
+globalThis.assert_true = (val, message) => {
+  strictEqual(val, true, message);
+};
+
+globalThis.assert_false = (val, message) => {
+  strictEqual(val, false, message);
+};
+
+globalThis.assert_array_equals = (a, b, message) => {
+  deepStrictEqual(a, b, message);
+};
+
+globalThis.assert_throws_js = (type, fn, message) => {
+  throws(fn, type, message);
+};
+
+globalThis.assert_throws_exactly = (expected, fn, message) => {
+  try {
+    fn();
+  } catch (actual) {
+    deepStrictEqual(actual, expected, message);
+  }
+};
+
+globalThis.assert_throws_dom = (name, fn, message) => {
+  throws(
+    fn,
+    (err) => {
+      ok(err instanceof DOMException, message);
+      deepStrictEqual(err.name, name, message);
+      return true;
+    },
+    message
+  );
 };
 
 globalThis.test = (callback, message) => {
+  if (!shouldRunTest(message)) {
+    return;
+  }
+
   try {
     callback();
   } catch (err) {
@@ -32,15 +102,51 @@ globalThis.test = (callback, message) => {
 
 globalThis.errors = [];
 
-export function prepare() {
-  globalThis.errors = [];
+function shouldRunTest(message) {
+  if ((globalThis.testOptions.skippedTests ?? []).includes(message)) {
+    console.warn('skipped', message);
+    return false;
+  }
+
+  if (globalThis.testOptions.verbose) {
+    console.log('run', message);
+  }
+
+  return true;
 }
 
-export function validate() {
-  if (globalThis.errors.length > 0) {
-    for (const err of globalThis.errors) {
+function prepare(options) {
+  globalThis.errors = [];
+  globalThis.promises = [];
+  globalThis.testOptions = options;
+}
+
+async function validate(options) {
+  await Promise.all(globalThis.promises);
+
+  const expectedFailures = options.expectedFailures ?? [];
+  let failed = false;
+
+  for (const err of globalThis.errors) {
+    if (expectedFailures.includes(err.message)) {
+      console.warn('Expected failure: ', err);
+    } else {
       console.error(err);
+      failed = true;
     }
+  }
+
+  if (failed) {
     throw new Error('Test failed');
   }
+}
+
+export function run(file, options = {}) {
+  return {
+    async test() {
+      prepare(options);
+      await import(file);
+      await validate(options);
+    },
+  };
 }


### PR DESCRIPTION
Adds the following features to the test harness:
- A single `run` entry point
- An `expectedFailures` option to document which tests we know aren't working yet
- A `skippedTests` option for tests that would make workerd crash
- A `verbose` option to print subtests before they are run.

Implements more WPT assertion/test functions:
- subsetTestByKey
- promise_test (probably still needs further improvements)
- assert_not_equals
- assert_true / assert_falwse
- assert_array_equals
- assert_throws_js

Integrates the following WPT tests:
- [X] url-constructor.any.js
    - [ ] Failure: 'Parsing: <http://example.com/\uD800\uD801\uDFFE\uDFFF\uFDD0\uFDCF\uFDEF\uFDF0\uFFFE\uFFFF?\uD800\uD801\uDFFE\uDFFF\uFDD0\uFDCF\uFDEF\uFDF0\uFFFE\uFFFF> without base'
- [X] url-origin.any.js
- [X] url-searchparams.any.js
- [X] url-setters-stripping.any.js
- [X] url-setters.any.js
- [X] url-statics-parse.any.js
- [X] url-tojson.any.js
- [X] urlencoded-parser.any.js
   - [ ] Failure: Request tests fail because WPT is using a bogus method named "LADIDA" and we throw
   - [ ] Failure: Response tests fail because we  need an IO context
- [X] urlsearchparams-append.any.js
   - [ ] Failure: 'URLSearchParams constructor, DOMException as argument'
   - [ ] Failure: 'Construct with 2 unpaired surrogates (no trailing)'
   - [ ] Failure: 'Construct with 3 unpaired surrogates (no leading)'
   - [ ] Failure: 'Construct with object with NULL, non-ASCII, and surrogate keys'
- [X] urlsearchparams-delete.any.js
- [X] urlsearchparams-foreach.any.js
    - [ ] Segfault:  'For-of Check'
- [X] urlsearchparams-get.any.js
- [X] urlsearchparams-getall.any.js
- [X] urlsearchparams-has.any.js
- [X] urlsearchparams-set.any.js
- [X] urlsearchparams-size.any.js
- [X] urlsearchparams-sort.any.js
   - Basically the issue here is sorting between a ligature and an emoji
   - [ ] Failure: Parse and sort: ﬃ&🌈
   - [ ] Failure: URL parse and sort: ﬃ&🌈
- [X] urlsearchparams-stringifier.any.js