### PR TITLE
create compile caches on compile step

### DIFF
--- a/build/wd_compile_cache.bzl
+++ b/build/wd_compile_cache.bzl
@@ -5,41 +5,48 @@ Bazel rules for generating compilation caches from a list of input files.
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 
 def _gen_compile_cache_impl(ctx):
-    file_list_path = "{}-compile-cache-file-list".format(ctx.label)
-    file_list = ctx.actions.declare_file(file_list_path)
+    file_list = ctx.actions.declare_file("in")
 
     # Get the File objects from the labels
-    input_files = []
+    srcs = []
     for src in ctx.attr.srcs:
-        input_files.extend(src.files.to_list())
+        srcs.extend(src.files.to_list())
 
     ctx.actions.write(
         output = file_list,
-        content = "\n".join([f.short_path for f in input_files]) + "\n",
+        content = "\n".join([f.path for f in srcs]) + "\n",
     )
 
-    output = ctx.actions.declare_file(ctx.attr.output)
+    out = ctx.outputs.out
+
+    args = ctx.actions.args()
+    args.add(out)
+    args.add(file_list)
 
     ctx.actions.run(
-        outputs = [output],
-        inputs = input_files + [file_list],
-        arguments = [file_list.path],
+        outputs = [out],
+        inputs = [file_list] + srcs,
+        arguments = [args],
         executable = ctx.executable._tool,
         tools = [ctx.executable._tool],
     )
+
+    return [
+        DefaultInfo(files = depset([out])),
+    ]
 
 gen_compile_cache = rule(
     implementation = _gen_compile_cache_impl,
     attrs = {
         "srcs": attr.label_list(mandatory = True, allow_files = True),
-        "output": attr.string(mandatory = True),
+        "out": attr.output(mandatory = True),
         "_tool": attr.label(executable = True, allow_single_file = True, cfg = "exec", default = "//src/workerd/tools:create_compile_cache"),
     },
 )
 
 def wd_compile_cache(name, srcs):
     gen_compile_cache(
-        name = name,
+        name = name + "_gen",
         srcs = srcs,
-        output = "{}-compile-cache-output".format(name),
+        out = name,
     )

--- a/build/wd_compile_cache.bzl
+++ b/build/wd_compile_cache.bzl
@@ -2,7 +2,8 @@
 Bazel rules for generating compilation caches from a list of input files.
 """
 
-load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
+def compile_cache_name(file_path):
+    return file_path + "_cache"
 
 def _gen_compile_cache_impl(ctx):
     file_list = ctx.actions.declare_file("in")
@@ -11,7 +12,9 @@ def _gen_compile_cache_impl(ctx):
     srcs = []
     for src in ctx.attr.srcs:
         srcs.extend(src.files.to_list())
-    outs = [ctx.actions.declare_file(src.path + "_cache") for src in srcs]
+
+    outs = [compile_cache_name(src.basename) for src in srcs]
+    outs = [ctx.actions.declare_file(compile_cache_name(src.basename)) for src in srcs]
 
     content = []
     for i in range(0, len(srcs)):
@@ -34,19 +37,25 @@ def _gen_compile_cache_impl(ctx):
     )
 
     return [
-        DefaultInfo(files = depset(outs)),
+        DefaultInfo(files = depset(direct = outs)),
     ]
 
 gen_compile_cache = rule(
     implementation = _gen_compile_cache_impl,
     attrs = {
         "srcs": attr.label_list(mandatory = True, allow_files = True),
-        "_tool": attr.label(executable = True, allow_single_file = True, cfg = "exec", default = "//src/workerd/tools:create_compile_cache"),
+        "_tool": attr.label(
+            executable = True,
+            allow_single_file = True,
+            cfg = "target",
+            default = "//src/workerd/tools:create_compile_cache",
+        ),
     },
 )
 
 def wd_compile_cache(name, srcs):
     gen_compile_cache(
-        name = name + "_gen",
+        name = name,
         srcs = srcs,
+        visibility = ["//visibility:public"],
     )

--- a/build/wd_compile_cache.bzl
+++ b/build/wd_compile_cache.bzl
@@ -1,0 +1,45 @@
+"""
+Bazel rules for generating compilation caches from a list of input files.
+"""
+
+load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
+
+def _gen_compile_cache_impl(ctx):
+    file_list_path = "{}-compile-cache-file-list".format(ctx.label)
+    file_list = ctx.actions.declare_file(file_list_path)
+
+    # Get the File objects from the labels
+    input_files = []
+    for src in ctx.attr.srcs:
+        input_files.extend(src.files.to_list())
+
+    ctx.actions.write(
+        output = file_list,
+        content = "\n".join([f.short_path for f in input_files]) + "\n",
+    )
+
+    output = ctx.actions.declare_file(ctx.attr.output)
+
+    ctx.actions.run(
+        outputs = [output],
+        inputs = input_files + [file_list],
+        arguments = [file_list.path],
+        executable = ctx.executable._tool,
+        tools = [ctx.executable._tool],
+    )
+
+gen_compile_cache = rule(
+    implementation = _gen_compile_cache_impl,
+    attrs = {
+        "srcs": attr.label_list(mandatory = True, allow_files = True),
+        "output": attr.string(mandatory = True),
+        "_tool": attr.label(executable = True, allow_single_file = True, cfg = "exec", default = "//src/workerd/tools:create_compile_cache"),
+    },
+)
+
+def wd_compile_cache(name, srcs):
+    gen_compile_cache(
+        name = name,
+        srcs = srcs,
+        output = "{}-compile-cache-output".format(name),
+    )

--- a/build/wd_compile_cache.bzl
+++ b/build/wd_compile_cache.bzl
@@ -28,11 +28,12 @@ def _gen_compile_cache_impl(ctx):
     args = ctx.actions.args()
     args.add(file_list)
 
-    ctx.actions.run(
+    ctx.actions.run_shell(
         outputs = outs,
         inputs = [file_list] + srcs,
+        command = ctx.executable._tool.path + " $@",
         arguments = [args],
-        executable = ctx.executable._tool,
+        use_default_shell_env = True,
         tools = [ctx.executable._tool],
     )
 

--- a/build/wd_js_bundle.bzl
+++ b/build/wd_js_bundle.bzl
@@ -124,7 +124,8 @@ def wd_js_bundle_capnp(
         internal_data_modules = [],
         internal_json_modules = [],
         declarations = [],
-        deps = []):
+        deps = [],
+        data = []):
     """Generate cc capnp library with js api bundle.
 
     NOTE: Due to capnpc embed limitation all modules must be in the same or sub directory of the
@@ -190,7 +191,7 @@ def wd_js_bundle_capnp(
         declarations,
     )
 
-    data = (
+    data = data + (
         list(builtin_modules_dict) +
         list(internal_modules_dict) +
         list(internal_wasm_modules_dict) +

--- a/build/wd_ts_bundle.bzl
+++ b/build/wd_ts_bundle.bzl
@@ -24,7 +24,8 @@ def wd_ts_bundle_capnp(
         internal_json_modules = [],
         lint = True,
         deps = [],
-        js_deps = []):
+        js_deps = [],
+        data = []):
     """Compiles typescript modules and generates api bundle with the result.
 
     Args:
@@ -75,6 +76,7 @@ def wd_ts_bundle_capnp(
         declarations = declarations,
         schema_id = schema_id,
         deps = deps + js_deps,
+        data = data,
     )
 
     if lint:
@@ -113,4 +115,3 @@ def wd_ts_bundle(name, import_name, *args, **kwargs):
         deps = ["@workerd//src/workerd/jsg:modules_capnp"],
         include_prefix = import_name,
     )
-    return data

--- a/build/wd_ts_bundle.bzl
+++ b/build/wd_ts_bundle.bzl
@@ -113,3 +113,4 @@ def wd_ts_bundle(name, import_name, *args, **kwargs):
         deps = ["@workerd//src/workerd/jsg:modules_capnp"],
         include_prefix = import_name,
     )
+    return data

--- a/build/wd_ts_bundle.bzl
+++ b/build/wd_ts_bundle.bzl
@@ -27,7 +27,8 @@ def wd_ts_bundle(
         lint = True,
         deps = [],
         js_deps = [],
-        data = []):
+        data = [],
+        gen_compile_cache = False):
     """Compiles typescript modules and generates api bundle with the result.
 
     Args:
@@ -79,6 +80,7 @@ def wd_ts_bundle(
         schema_id = schema_id,
         deps = deps + js_deps,
         data = data,
+        gen_compile_cache = gen_compile_cache,
     )
 
     if lint:

--- a/src/node/BUILD.bazel
+++ b/src/node/BUILD.bazel
@@ -1,9 +1,9 @@
-load("@workerd//:build/wd_compile_cache.bzl", "wd_compile_cache")
 load("@workerd//:build/wd_ts_bundle.bzl", "wd_ts_bundle")
 
 wd_ts_bundle(
     name = "node",
     eslintrc_json = "eslint.config.mjs",
+    gen_compile_cache = True,
     import_name = "node",
     internal_modules = glob([
         "internal/*.ts",
@@ -20,11 +20,4 @@ wd_ts_bundle(
     schema_id = "0xbcc8f57c63814005",
     tsconfig_json = "tsconfig.json",
     deps = ["//:node_modules/@types/node"],
-)
-
-wd_compile_cache(
-    name = "compile_cache",
-    srcs = [
-        ":assert.js",
-    ],
 )

--- a/src/node/BUILD.bazel
+++ b/src/node/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@workerd//:build/wd_compile_cache.bzl", "wd_compile_cache")
 load("@workerd//:build/wd_ts_bundle.bzl", "wd_ts_bundle")
 
-srcs = wd_ts_bundle(
+wd_ts_bundle(
     name = "node",
     eslintrc_json = "eslint.config.mjs",
     import_name = "node",
@@ -23,6 +23,8 @@ srcs = wd_ts_bundle(
 )
 
 wd_compile_cache(
-    name = "node_compile_cache",
-    srcs = srcs,
+    name = "compile_cache",
+    srcs = [
+        ":assert.js",
+    ],
 )

--- a/src/node/BUILD.bazel
+++ b/src/node/BUILD.bazel
@@ -1,6 +1,7 @@
+load("@workerd//:build/wd_compile_cache.bzl", "wd_compile_cache")
 load("@workerd//:build/wd_ts_bundle.bzl", "wd_ts_bundle")
 
-wd_ts_bundle(
+srcs = wd_ts_bundle(
     name = "node",
     eslintrc_json = "eslint.config.mjs",
     import_name = "node",
@@ -19,4 +20,9 @@ wd_ts_bundle(
     schema_id = "0xbcc8f57c63814005",
     tsconfig_json = "tsconfig.json",
     deps = ["//:node_modules/@types/node"],
+)
+
+wd_compile_cache(
+    name = "node_compile_cache",
+    srcs = srcs,
 )

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -61,6 +61,7 @@ wd_cc_library(
         ":modules_capnp",
         ":observer",
         ":url",
+        "//src/workerd/tools:compile_cache_capnp",
         "//src/workerd/util",
         "//src/workerd/util:sentry",
         "//src/workerd/util:thread-scopes",

--- a/src/workerd/jsg/compile-cache.c++
+++ b/src/workerd/jsg/compile-cache.c++
@@ -14,8 +14,9 @@ std::unique_ptr<v8::ScriptCompiler::CachedData> CompileCache::Data::AsCachedData
 
 // CompileCache
 
-void CompileCache::add(
-    kj::StringPtr key, std::shared_ptr<v8::ScriptCompiler::CachedData> cached) const {
+void CompileCache::add(kj::StringPtr key, v8::Local<v8::UnboundModuleScript> script) const {
+  auto cached =
+      std::shared_ptr<v8::ScriptCompiler::CachedData>(v8::ScriptCompiler::CreateCodeCache(script));
   cache.lockExclusive()->upsert(kj::str(key), Data(kj::mv(cached)), [](auto&, auto&&) {});
 }
 

--- a/src/workerd/jsg/compile-cache.h
+++ b/src/workerd/jsg/compile-cache.h
@@ -42,7 +42,7 @@ public:
     std::shared_ptr<void> owningPtr;
   };
 
-  void add(kj::StringPtr key, std::shared_ptr<v8::ScriptCompiler::CachedData> cached) const;
+  void add(kj::StringPtr key, v8::Local<v8::UnboundModuleScript> script) const;
   kj::Maybe<Data&> find(kj::StringPtr key) const;
 
   static const CompileCache& get() {

--- a/src/workerd/jsg/compile-cache.h
+++ b/src/workerd/jsg/compile-cache.h
@@ -8,6 +8,7 @@
 
 #include <v8.h>
 
+#include <capnp/message.h>
 #include <kj/string.h>
 
 namespace workerd::jsg {
@@ -44,6 +45,7 @@ public:
 
   void add(kj::StringPtr key, v8::Local<v8::UnboundModuleScript> script) const;
   kj::Maybe<Data&> find(kj::StringPtr key) const;
+  void serialize(capnp::MessageBuilder& message) const;
 
   static const CompileCache& get() {
     static const CompileCache instance;

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -417,9 +417,7 @@ v8::Local<v8::Module> compileEsmModule(jsg::Lock& js,
       jsg::check(v8::ScriptCompiler::CompileModule(js.v8Isolate, &source, compileOptions));
 
   if (existingCacheData == nullptr) {
-    auto cachedData = std::shared_ptr<v8::ScriptCompiler::CachedData>(
-        v8::ScriptCompiler::CreateCodeCache(module->GetUnboundModuleScript()));
-    compileCache.add(name, kj::mv(cachedData));
+    compileCache.add(name, module->GetUnboundModuleScript());
   }
 
   return module;

--- a/src/workerd/jsg/modules.capnp
+++ b/src/workerd/jsg/modules.capnp
@@ -23,6 +23,9 @@ struct Module {
   tsDeclaration @3 :Text;
 
   type @2 :ModuleType;
+
+  # Optional compile cache to be used to speed up module loading
+  compileCache @3 :Data;
 }
 
 

--- a/src/workerd/jsg/modules.capnp
+++ b/src/workerd/jsg/modules.capnp
@@ -25,7 +25,7 @@ struct Module {
   type @2 :ModuleType;
 
   # Optional compile cache to be used to speed up module loading
-  compileCache @3 :Data;
+  compileCache @7 :Data;
 }
 
 

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -140,6 +140,7 @@ wd_cc_library(
     hdrs = [
         "v8-platform-impl.h",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//src/workerd/jsg",
         "@capnp-cpp//src/kj",

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -71,3 +71,20 @@ run_binary(
     tool = "param_extractor_bin",
     visibility = ["//visibility:public"],
 )
+
+# This binary is used to generate compile cache for workerd.
+# This will later be used by workerd to access compile caches of JS internals.
+# NOTE: We only enable compile cache for linux at the moment.
+cc_binary(
+    name = "create_compile_cache_bin",
+    srcs = ["create-compile-cache.c++"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        "//src/workerd/jsg",
+        "@capnp-cpp//src/kj",
+        "@workerd-v8//:v8",
+    ],
+)

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//:build/cc_ast_dump.bzl", "cc_ast_dump")
+load("//:build/wd_cc_binary.bzl", "wd_cc_binary")
 
 # ========================================================================================
 # Parameter Name Extractor
@@ -75,13 +76,10 @@ run_binary(
 # This binary is used to generate compile cache for workerd.
 # This will later be used by workerd to access compile caches of JS internals.
 # NOTE: We only enable compile cache for linux at the moment.
-cc_binary(
-    name = "create_compile_cache_bin",
+wd_cc_binary(
+    name = "create_compile_cache",
     srcs = ["create-compile-cache.c++"],
-    target_compatible_with = select({
-        "@platforms//os:linux": [],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
+    visibility = ["//visibility:public"],
     deps = [
         "//src/workerd/jsg",
         "@capnp-cpp//src/kj",

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -87,7 +87,6 @@ wd_cc_capnp_library(
 
 # This binary is used to generate compile cache for workerd.
 # This will later be used by workerd to access compile caches of JS internals.
-# NOTE: We only enable compile cache for linux at the moment.
 wd_cc_binary(
     name = "create_compile_cache",
     srcs = ["create-compile-cache.c++"],

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -2,6 +2,7 @@ load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//:build/cc_ast_dump.bzl", "cc_ast_dump")
 load("//:build/wd_cc_binary.bzl", "wd_cc_binary")
+load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
 
 # ========================================================================================
 # Parameter Name Extractor
@@ -27,7 +28,10 @@ cc_ast_dump(
         "//src/workerd/io",
         "//src/workerd/jsg",
         "@capnp-cpp//src/capnp",
-    ],
+    ] + select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["@workerd//src/workerd/util:symbolizer"],
+    }),
 )
 
 rust_binary(
@@ -73,6 +77,14 @@ run_binary(
     visibility = ["//visibility:public"],
 )
 
+wd_cc_capnp_library(
+    name = "compile_cache_capnp",
+    srcs = ["compile-cache.capnp"],
+    data = [],
+    visibility = ["//visibility:public"],
+    deps = [],
+)
+
 # This binary is used to generate compile cache for workerd.
 # This will later be used by workerd to access compile caches of JS internals.
 # NOTE: We only enable compile cache for linux at the moment.
@@ -81,6 +93,7 @@ wd_cc_binary(
     srcs = ["create-compile-cache.c++"],
     visibility = ["//visibility:public"],
     deps = [
+        ":compile_cache_capnp",
         "//src/workerd/jsg",
         "@capnp-cpp//src/kj",
         "@workerd-v8//:v8",

--- a/src/workerd/tools/compile-cache.capnp
+++ b/src/workerd/tools/compile-cache.capnp
@@ -1,0 +1,13 @@
+@0xd36f904ea8f67738;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("workerd::tools");
+
+struct CompileCache {
+  entries @0 :List(CompileCacheEntry);
+
+  struct CompileCacheEntry {
+    path @0 :Text;
+    data @1 :Data;
+  }
+}

--- a/src/workerd/tools/create-compile-cache.c++
+++ b/src/workerd/tools/create-compile-cache.c++
@@ -53,13 +53,11 @@ public:
         end++;
       }
 
-      auto line = fileListContent.slice(start, end);
-
+      auto line = kj::str(fileListContent.slice(start, end).asChars());
       if (line.size() > 0) {
-        auto strLine = kj::StringPtr(line.asChars().begin(), line.size());
-        auto space = KJ_REQUIRE_NONNULL(strLine.findFirst(' '));
-        auto path = kj::str(strLine.first(space).asChars());
-        auto out = kj::str(strLine.slice(space + 1));
+        auto space = KJ_REQUIRE_NONNULL(line.findFirst(' '));
+        auto path = kj::str(line.first(space));
+        auto out = kj::str(line.slice(space + 1));
 
         auto file = dir.openFile(kj::Path::parse(path));
         auto content = file->mmap(0, file->stat().size);

--- a/src/workerd/tools/create-compile-cache.c++
+++ b/src/workerd/tools/create-compile-cache.c++
@@ -1,0 +1,113 @@
+#include "fcntl.h"
+
+#include <workerd/jsg/compile-cache.h>
+#include <workerd/jsg/setup.h>
+
+#include <kj/filesystem.h>
+#include <kj/main.h>
+
+namespace workerd::api {
+namespace {
+JSG_DECLARE_ISOLATE_TYPE(CompileCacheIsolate);
+
+constexpr int resourceLineOffset = 0;
+constexpr int resourceColumnOffset = 0;
+constexpr bool resourceIsSharedCrossOrigin = false;
+constexpr int scriptId = -1;
+constexpr bool resourceIsOpaque = false;
+constexpr bool isWasm = false;
+constexpr bool isModule = true;
+
+// CompileCacheCreator receives an argument of a text file where each line
+// represents the path of the file to create compile caches for.
+class CompileCacheCreator {
+public:
+  explicit CompileCacheCreator(kj::ProcessContext& context)
+      : context(context),
+        ccIsolate(system, kj::heap<jsg::IsolateObserver>(), params) {};
+
+  kj::MainFunc getMain() {
+    return kj::MainBuilder(
+        context, "Process a file list", "This binary processes the specified file list.")
+        .expectArg("<file_path>", KJ_BIND_METHOD(*this, setFilePath))
+        .callAfterParsing(KJ_BIND_METHOD(*this, run))
+        .build();
+  }
+
+  void readFiles() {
+    auto fileListFd = open(filePath.begin(), O_RDONLY);
+    auto fileList = kj::newDiskReadableFile(kj::AutoCloseFd(fileListFd));
+    auto fileListContent = fileList->mmap(0, fileList->stat().size);
+
+    size_t start = 0;
+    size_t end = 0;
+
+    while (end < fileListContent.size()) {
+      while (end < fileListContent.size() && fileListContent[end] != '\n') {
+        end++;
+      }
+
+      auto path = fileListContent.slice(start, end);
+
+      if (path.size() > 0) {
+        auto fd = open(path.asChars().begin(), O_RDONLY);
+        auto file = kj::newDiskReadableFile(kj::AutoCloseFd(fd));
+        auto content = file->mmap(0, file->stat().size);
+
+        auto heap = kj::heapArray<kj::byte>(content.size());
+        std::memcpy(heap.begin(), content.begin(), content.size());
+        file_contents.add(kj::tuple(kj::heapString(path.asChars()), kj::mv(heap)));
+      }
+
+      end++;
+      start = end;
+    }
+  }
+
+  kj::MainBuilder::Validity run() {
+    readFiles();
+
+    const auto& compileCache = jsg::CompileCache::get();
+    auto options = v8::ScriptCompiler::kNoCompileOptions;
+
+    ccIsolate.runInLockScope([&](CompileCacheIsolate::Lock& js) {
+      for (auto& entry: file_contents) {
+        kj::StringPtr name = kj::get<0>(entry);
+        kj::ArrayPtr<kj::byte> content = kj::get<1>(entry);
+
+        v8::ScriptOrigin origin(jsg::v8StrIntern(js.v8Isolate, name), resourceLineOffset,
+            resourceColumnOffset, resourceIsSharedCrossOrigin, scriptId, {}, resourceIsOpaque,
+            isWasm, isModule);
+
+        auto contentStr = jsg::newExternalOneByteString(js, content.asChars());
+        auto source = v8::ScriptCompiler::Source(contentStr, origin, nullptr);
+        auto module = jsg::check(v8::ScriptCompiler::CompileModule(js.v8Isolate, &source, options));
+
+        compileCache.add(name, module->GetUnboundModuleScript());
+      }
+    });
+
+    return true;
+  }
+
+private:
+  kj::ProcessContext& context;
+  kj::StringPtr filePath{};
+
+  jsg::V8System system{};
+  v8::Isolate::CreateParams params{};
+  CompileCacheIsolate ccIsolate;
+
+  kj::MainBuilder::Validity setFilePath(kj::StringPtr path) {
+    filePath = path;
+    return true;
+  }
+
+  // Key is the path of the file, and value is the content.
+  kj::Vector<kj::Tuple<kj::String, kj::Array<kj::byte>>> file_contents{};
+};
+
+}  // namespace
+}  // namespace workerd::api
+
+KJ_MAIN(workerd::api::CompileCacheCreator)

--- a/src/workerd/tools/create-compile-cache.c++
+++ b/src/workerd/tools/create-compile-cache.c++
@@ -34,7 +34,6 @@ public:
   kj::MainFunc getMain() {
     return kj::MainBuilder(
         context, "Process a file list", "This binary processes the specified file list.")
-        .expectArg("<output_path>", KJ_BIND_METHOD(*this, setOutputPath))
         .expectArg("<file_path>", KJ_BIND_METHOD(*this, setFilePath))
         .callAfterParsing(KJ_BIND_METHOD(*this, run))
         .build();
@@ -54,14 +53,22 @@ public:
         end++;
       }
 
-      auto path = fileListContent.slice(start, end);
+      auto line = fileListContent.slice(start, end);
 
-      if (path.size() > 0) {
-        auto file =
-            dir.openFile(kj::Path::parse(kj::StringPtr(path.asChars().begin(), path.size())));
+      if (line.size() > 0) {
+        auto strLine = kj::StringPtr(line.asChars().begin(), line.size());
+        auto space = KJ_REQUIRE_NONNULL(strLine.findFirst(' '));
+        auto path = kj::str(strLine.first(space).asChars());
+        auto out = kj::str(strLine.slice(space + 1));
+
+        auto file = dir.openFile(kj::Path::parse(path));
         auto content = file->mmap(0, file->stat().size);
 
-        file_contents.add(kj::tuple(kj::heapString(path.asChars()), kj::mv(content)));
+        file_contents.add(Target{
+          .sourcePath = kj::mv(path),
+          .sourceContent = kj::str(content),
+          .outputPath = kj::mv(out),
+        });
       }
 
       end++;
@@ -72,43 +79,32 @@ public:
   kj::MainBuilder::Validity run() {
     readFiles();
 
-    const auto& compileCache = jsg::CompileCache::get();
     auto options = v8::ScriptCompiler::kNoCompileOptions;
+    auto fs = kj::newDiskFilesystem();
+    auto& dir = fs->getCurrent();
 
     ccIsolate.runInLockScope([&](CompileCacheIsolate::Lock& isolateLock) {
       JSG_WITHIN_CONTEXT_SCOPE(isolateLock,
           isolateLock.newContext<CompilerCacheContext>().getHandle(isolateLock),
           [&](jsg::Lock& js) {
-        for (auto& entry: file_contents) {
-          kj::StringPtr name = kj::get<0>(entry);
-          kj::ArrayPtr<const kj::byte> content = kj::get<1>(entry);
+        for (auto& target: file_contents) {
+          v8::ScriptOrigin origin(jsg::v8StrIntern(js.v8Isolate, target.sourcePath),
+              resourceLineOffset, resourceColumnOffset, resourceIsSharedCrossOrigin, scriptId, {},
+              resourceIsOpaque, isWasm, isModule);
 
-          v8::ScriptOrigin origin(jsg::v8StrIntern(js.v8Isolate, name), resourceLineOffset,
-              resourceColumnOffset, resourceIsSharedCrossOrigin, scriptId, {}, resourceIsOpaque,
-              isWasm, isModule);
-
-          auto contentStr = jsg::newExternalOneByteString(js, content.asChars());
+          auto contentStr = jsg::newExternalOneByteString(js, target.sourceContent);
           auto source = v8::ScriptCompiler::Source(contentStr, origin, nullptr);
           auto module =
               jsg::check(v8::ScriptCompiler::CompileModule(js.v8Isolate, &source, options));
 
-          compileCache.add(name, module->GetUnboundModuleScript());
+          auto output = dir.openFile(kj::Path::parse(target.outputPath),
+              kj::WriteMode::CREATE | kj::WriteMode::CREATE_PARENT);
+          auto codeCache = v8::ScriptCompiler::CreateCodeCache(module->GetUnboundModuleScript());
+          output->writeAll(kj::arrayPtr(codeCache->data, codeCache->length));
+          delete codeCache;
         }
       });
     });
-
-    auto fs = kj::newDiskFilesystem();
-    auto& dir = fs->getCurrent();
-    auto output = dir.openFile(outputPath, kj::WriteMode::CREATE | kj::WriteMode::CREATE_PARENT);
-
-    capnp::MallocMessageBuilder message;
-    compileCache.serialize(message);
-
-    KJ_IF_SOME(fd, output->getFd()) {
-      capnp::writeMessageToFd(fd, message);
-    } else {
-      KJ_FAIL_ASSERT("Failed to get file descriptor of output file"_kj);
-    }
 
     return true;
   }
@@ -116,7 +112,6 @@ public:
 private:
   kj::ProcessContext& context;
   kj::Path filePath{};
-  kj::Path outputPath{};
 
   jsg::V8System system{};
   v8::Isolate::CreateParams params{};
@@ -127,13 +122,14 @@ private:
     return true;
   }
 
-  kj::MainBuilder::Validity setOutputPath(kj::StringPtr path) {
-    outputPath = kj::Path::parse(path);
-    return true;
-  }
+  struct Target {
+    kj::String sourcePath;
+    kj::String sourceContent;
+    kj::String outputPath;
+  };
 
   // Key is the path of the file, and value is the content.
-  kj::Vector<kj::Tuple<kj::String, kj::Array<const kj::byte>>> file_contents{};
+  kj::Vector<Target> file_contents{};
 };
 
 }  // namespace


### PR DESCRIPTION
> Work in progress. 

The goal of this pull-request is to create an intermediary step between TypeScript compiler and Workerd compilation step to create compile caches. Compile caches will be used by the main binary to improve the startup time of the built-in modules (and only the built-ins).

Technical details:

The newly introduced binary accepts a string to the path of a file list that contains every path to be compile cached. With the current change the build process will slightly change to the following:

1. Workerd runs typescript and compiles TS files.
2. Each node.js built-in will be passed to the newly introduced binary to create a compile cache for the given paths.
3. Workerd will be compiled and it will use the compile cache output from the creator binary if exists.

Limitations:
- Currently, we only enable it for Linux. We can enable it for Windows, but since we're only using Linux on production, I don't think it's beneficial to support Windows.
- We need to handle downstream repository and the isolate creation differences.