### PR TITLE
Fail cc_ast_dump when AST dump encounters errors, add missing dependencies to API AST dump

### DIFF
--- a/build/cc_ast_dump.bzl
+++ b/build/cc_ast_dump.bzl
@@ -37,7 +37,9 @@ def _cc_ast_dump_impl(ctx):
     inputs = depset(direct = [ctx.file.src], transitive = [cc_toolchain.all_files] + [cc_info.compilation_context.headers])
     env = cc_common.get_environment_variables(feature_configuration = feature_configuration, action_name = CPP_COMPILE_ACTION_NAME, variables = variables)
 
-    command = " ".join([executable] + arguments + ["|", "gzip", "-3", "-", ">", ctx.outputs.out.path])
+    # Enable pipefail so that the action fails when there are e.g. missing include errors, otherwise
+    # we'd just continue despite the error and end up with an incomplete AST.
+    command = " ".join(["set -euo pipefail;"] + [executable] + arguments + ["|", "gzip", "-3", "-", ">", ctx.outputs.out.path])
 
     # run_shell until https://github.com/bazelbuild/bazel/issues/5511 is fixed
     ctx.actions.run_shell(

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -20,6 +20,8 @@ cc_ast_dump(
     deps = [
         "//src/workerd/api:html-rewriter",
         "//src/workerd/api:hyperdrive",
+        "//src/workerd/api:memory-cache",
+        "//src/workerd/api:r2",
         "//src/workerd/api/node",
         "//src/workerd/io",
         "//src/workerd/jsg",


### PR DESCRIPTION
PR #2991 introduced a regression where the API AST dump did not have access to all the required includes. However, an incomplete AST was still being generated despite the missing include error. Add the missing dependencies so that the correct types are generated and enable pipefail for the ast dump/gzip shell commands so that the cc_ast_dump action fails if there are any errors being reported.