### PR TITLE
Implement InvocationSpanContext for user tracing / streaming tail workers

### DIFF
--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -325,5 +325,6 @@ kj_test(
     src = "trace-test.c++",
     deps = [
         ":trace",
+        "//src/workerd/util:thread-scopes",
     ],
 )

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -15,6 +15,16 @@ using import "/capnp/compat/byte-stream.capnp".ByteStream;
 using import "/workerd/io/outcome.capnp".EventOutcome;
 using import "/workerd/io/script-version.capnp".ScriptVersion;
 
+struct InvocationSpanContext {
+  struct TraceId {
+    high @0 :UInt64;
+    low @1 :UInt64;
+  }
+  traceId @0 :TraceId;
+  invocationId @1 :TraceId;
+  spanId @2 :UInt32;
+}
+
 struct Trace @0x8e8d911203762d34 {
   logs @0 :List(Log);
   struct Log {


### PR DESCRIPTION
This implements the `InvocationSpanContext` class. This type holds a tuple of trace ID, invocation ID, and span ID and will be used in support for the updated streaming tail workers implementation. The basic idea is that every top-level request receives a trace ID which is shared across every invocation the occurs within that request. Every individual invocation has a unique invocation ID, and every span within that invocation receives a monotonically increasing span ID.

While this PR does not currently introduce uses of this type, the idea is for all invocations to always have a root `InvocationSpanContext` and for every child user span created to branch off this root. The current user span then would always have a current `InvocationSpanContext` that would be propagated outward for all traceable sub requests (generally any subrequest that is not an public internet fetch). A follow up PR will start to introduce the uses and propagation of the span context. This PR only introduces the class impl an the basic test for it. (I'm intentionally breaking this work into smaller incremental PRs to make it easier to review individual chunks).