### PR TITLE
Fix handling of termination exceptions.

### DIFF
--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2336,7 +2336,7 @@ public:
   //
   // Some kinds of exceptions explicitly will not be caught:
   // - Exceptions where JavaScript execution cannot continue, such as the "uncatchable exception"
-  //   produced by IsolateBase::terminateExecution().
+  //   produced by IsolateBase::TerminateExecution().
   // - C++ exceptions other than `kj::Exception`, e.g. `std::bad_alloc`. These exceptions are
   //   assumed to be serious enough that they cannot be caught as if they were JavaScript errors,
   //   and instead unwind must continue until C++ catches them.
@@ -2354,13 +2354,14 @@ public:
       } catch (JsExceptionThrown&) {
         // If tryCatch.HasCaught() is false, it typically means that JsExceptionThrown
         // was thrown without an exception actually being scheduled on the isolate.
-        // This may happen in particular when the JsExceptionThrows was the result of
-        // TerminateException() but V8 has since cleared the terminate flag because all
+        // This may happen in particular when the JsExceptionThrown was the result of
+        // TerminateExecution() but V8 has since cleared the terminate flag because all
         // JavaScript call frames have been unwound. Hence, we want to treat this the
         // same as if `CanContinue()` returned false.
         // TODO(cleanup): Do more investigation, maybe explicitly check for the termination
         // flag or arrange to maintain our own separate termination flag to avoid confusion.
         if (!tryCatch.CanContinue() || !tryCatch.HasCaught() || tryCatch.Exception().IsEmpty()) {
+          tryCatch.ReThrow();
           throw;
         }
 

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -513,8 +513,8 @@ PromiseForResult<Func, void, false> Lock::evalNow(Func&& func) {
     if (tryCatch.HasCaught() && tryCatch.CanContinue()) {
       return rejectedPromise<Result>(tryCatch.Exception());
     } else {
-      // probably TerminateExecution() called
-      if (tryCatch.CanContinue()) tryCatch.ReThrow();
+      // Probably TerminateExecution() called.
+      tryCatch.ReThrow();
       throw;
     }
   } catch (kj::Exception& e) {


### PR DESCRIPTION
Exceptions caught in `v8::TryCatch` scopes need to be rethrown in order for the next try/catch handler down the stack to be notified of them. In some code paths, we rethrow the native `jsg::JsExceptionThrown` exception but don't rethrow the v8 exception using `v8::TryCatch::ReThrow()`.

This commit fixes one such code path which resulted in `IoContext::runImpl`'s `jsg::JsExceptionThrown`'s catch block finding that the corresponding `v8::TryCatch` object hadn't been notified of the termination (and didn't contain an exception).