### PR TITLE
SQC-333: Support Hyperdrive with SSL in dev mode

### DIFF
--- a/src/workerd/api/hyperdrive.c++
+++ b/src/workerd/api/hyperdrive.c++
@@ -80,7 +80,7 @@ uint16_t Hyperdrive::getPort() {
 
 kj::String Hyperdrive::getConnectionString() {
   return kj::str(getScheme(), "://", getUser(), ":", getPassword(), "@", getHost(), ":", getPort(),
-      "/", getDatabase(), "?sslmode=disable");
+      "/", getDatabase(), "?sslmode=prefer");
 }
 
 kj::Promise<kj::Own<kj::AsyncIoStream>> Hyperdrive::connectToDb() {


### PR DESCRIPTION
We have historically used sslmode=disable in when running `wrangler dev`, with the intention of not forcing folks to set up SSL on a local test DB.  Unfortunately this causes friction because many hosted databases will have SSL set up and required, and Hyperdrive in production actually requires this. To improve flexibilty, switch to `prefer` mode which will use SSL if available for a close-to-production experience, but will allow unencrypted connections if needed.