### PR TITLE
[rust] use experimental_use_cc_common_link everywhere but windows

### DIFF
--- a/build/wd_rust_binary.bzl
+++ b/build/wd_rust_binary.bzl
@@ -54,6 +54,10 @@ def wd_rust_binary(
         visibility = visibility,
         data = data,
         proc_macro_deps = proc_macro_deps,
+        experimental_use_cc_common_link = select({
+            "@platforms//os:windows": 0,
+            "//conditions:default": 1,
+        }),
     )
 
     rust_test(
@@ -66,4 +70,8 @@ def wd_rust_binary(
             # our tests are usually very heavy and do not support concurrent invocation
             "RUST_TEST_THREADS": "1",
         },
+        experimental_use_cc_common_link = select({
+            "@platforms//os:windows": 0,
+            "//conditions:default": 1,
+        }),
     )

--- a/build/wd_rust_crate.bzl
+++ b/build/wd_rust_crate.bzl
@@ -123,4 +123,8 @@ def wd_rust_crate(
         crate_features = crate_features,
         deps = test_deps,
         proc_macro_deps = test_proc_macro_deps,
+        experimental_use_cc_common_link = select({
+            "@platforms//os:windows": 0,
+            "//conditions:default": 1,
+        }),
     )


### PR DESCRIPTION
needed for better ew compatibility. Doesn't seem to work on windows at all.