### PR TITLE
Extract code formatting config to its own file

### DIFF
--- a/tools/cross/format.json
+++ b/tools/cross/format.json
@@ -1,0 +1,27 @@
+[
+  {
+    "directory": "src/workerd",
+    "globs": ["*.c++", "*.h"],
+    "formatter": "clang-format"
+  },
+  {
+    "directory": "src",
+    "globs": ["*.js", "*.ts", "*.cjs", "*.ejs", "*.mjs"],
+    "formatter": "prettier"
+  },
+  {
+    "directory": "src",
+    "globs": ["*.json"],
+    "formatter": "prettier"
+  },
+  {
+    "directory": ".",
+    "globs": ["*.py"],
+    "formatter": "ruff"
+  },
+  {
+    "directory": ".",
+    "globs": ["*.bzl", "WORKSPACE", "BUILD", "BUILD.*"],
+    "formatter": "buildifier"
+  }
+]


### PR DESCRIPTION
So we can use the same formatting tool in both workerd and our internal repo.