### PR TITLE
[rust] publishing cxx bridge includes with workerd/ prefix

### DIFF
--- a/build/wd_rust_binary.bzl
+++ b/build/wd_rust_binary.bzl
@@ -32,7 +32,7 @@ def wd_rust_binary(
             name = name + "@cxx",
             src = cxx_bridge_src,
             hdrs = hdrs,
-            include_prefix = "rust/" + name,
+            include_prefix = "workerd/rust/" + name,
             strip_include_prefix = "",
             # Not applying visibility here – if you import the cxxbridge header, you will likely
             # also need the rust library itself to avoid linker errors.

--- a/build/wd_rust_crate.bzl
+++ b/build/wd_rust_crate.bzl
@@ -83,7 +83,7 @@ def wd_rust_crate(
             name = name + "@cxx",
             src = cxx_bridge_src,
             hdrs = hdrs,
-            include_prefix = "rust/" + name,
+            include_prefix = "workerd/rust/" + name,
             strip_include_prefix = "",
             # Not applying visibility here – if you import the cxxbridge header, you will likely
             # also need the rust library itself to avoid linker errors.

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -48,6 +48,8 @@
 -isystemexternal/zlib
 -isystemexternal/sqlite3
 -isystemexternal/perfetto-sdk/sdk
+-isystembazel-bin/src/rust/cxx-integration/_virtual_includes/cxx-integration@cxx
+-isystembazel-bin/src/rust/cxx-integration-test/_virtual_includes/cxx-integration-test@cxx
 -D_FORTIFY_SOURCE=1
 -D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES
 -DCAPNP_VERSION=11000

--- a/src/rust/cxx-integration-test/cxx-rust-integration-test.c++
+++ b/src/rust/cxx-integration-test/cxx-rust-integration-test.c++
@@ -1,7 +1,7 @@
-#include <rust/cxx-integration-test/lib.rs.h>
-#include <rust/cxx-integration/lib.rs.h>
-#include <rust/cxx.h>
+#include <workerd/rust/cxx-integration-test/lib.rs.h>
+#include <workerd/rust/cxx-integration/lib.rs.h>
 
+#include <rust/cxx.h>
 #include <signal.h>
 
 #include <kj/async.h>
@@ -21,7 +21,9 @@ KJ_TEST("panic results in abort") {
   KJ_EXPECT_SIGNAL(SIGABRT, rust::cxx_integration::trigger_panic("foobar"));
 }
 
-KJ_TEST("ok Result") { KJ_EXPECT(42 == rust::test::result_ok()); }
+KJ_TEST("ok Result") {
+  KJ_EXPECT(42 == rust::test::result_ok());
+}
 
 KJ_TEST("err Result") {
   // if fn returns an error, it is translated into ::rust::Error exception.
@@ -240,4 +242,4 @@ KJ_TEST("array/slice convertions") {
   }
 }
 
-}  // namespace edgeworker::tests
+}  // namespace workerd::rust

--- a/src/rust/cxx-integration-test/lib.rs
+++ b/src/rust/cxx-integration-test/lib.rs
@@ -24,7 +24,7 @@ mod ffi {
 
         // Include the header with the actual callback type definition.
         // This will be included into cxx generated files.
-        include!("rust/cxx-integration-test/cxx-rust-integration-test.h");
+        include!("workerd/rust/cxx-integration-test/cxx-rust-integration-test.h");
     }
 
     // Structures defined without any extern specifier are visible both to Rust and c++.

--- a/src/rust/cxx-integration/lib.rs
+++ b/src/rust/cxx-integration/lib.rs
@@ -9,7 +9,7 @@ mod ffi {
     }
 
     unsafe extern "C++" {
-        include!("rust/cxx-integration/cxx-bridge.h");
+        include!("workerd/rust/cxx-integration/cxx-bridge.h");
     }
 }
 

--- a/src/rust/gen-compile-cache/cxx-bridge.c++
+++ b/src/rust/gen-compile-cache/cxx-bridge.c++
@@ -3,7 +3,7 @@
 #include <workerd/jsg/compile-cache.h>
 #include <workerd/jsg/setup.h>
 
-#include <rust/cxx-integration/lib.rs.h>
+#include <workerd/rust/cxx-integration/lib.rs.h>
 
 #include <capnp/serialize.h>
 

--- a/src/rust/gen-compile-cache/main.rs
+++ b/src/rust/gen-compile-cache/main.rs
@@ -30,7 +30,7 @@ fn main() {
 #[cxx::bridge(namespace = "workerd::rust::gen_compile_cache")]
 mod ffi {
     unsafe extern "C++" {
-        include!("rust/gen-compile-cache/cxx-bridge.h");
+        include!("workerd/rust/gen-compile-cache/cxx-bridge.h");
 
         fn compile(path: &str, source_code: &str) -> Vec<u8>;
     }

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -7,6 +7,7 @@
 #include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/io/supported-compatibility-date.capnp.h>
 #include <workerd/jsg/setup.h>
+#include <workerd/rust/cxx-integration/lib.rs.h>
 #include <workerd/server/v8-platform-impl.h>
 #include <workerd/server/workerd-meta.capnp.h>
 #include <workerd/server/workerd.capnp.h>
@@ -15,7 +16,6 @@
 #include <fcntl.h>
 #include <openssl/rand.h>
 #include <pyodide/generated/pyodide_extra.capnp.h>
-#include <rust/cxx-integration/lib.rs.h>
 #include <sys/stat.h>
 
 #include <capnp/dynamic.h>


### PR DESCRIPTION
This will allow us to have same crate names (cxx-integration) and not to confuse compiler regarding which one is used.