### PR TITLE
Update SQLite to version 3.47

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,9 +44,9 @@ http_archive(
         "//:patches/sqlite/0002-macOS-missing-PATH-fix.patch",
         "//:patches/sqlite/0003-sqlite-complete-early-exit.patch",
     ],
-    sha256 = "ab9aae38a11b931f35d8d1c6d62826d215579892e6ffbf89f20bdce106a9c8c5",
-    strip_prefix = "sqlite-src-3440000",
-    url = "https://sqlite.org/2023/sqlite-src-3440000.zip",
+    sha256 = "f59c349bedb470203586a6b6d10adb35f2afefa49f91e55a672a36a09a8fedf7",
+    strip_prefix = "sqlite-src-3470000",
+    url = "https://sqlite.org/2024/sqlite-src-3470000.zip",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")

--- a/patches/sqlite/0001-row-counts-plain.patch
+++ b/patches/sqlite/0001-row-counts-plain.patch
@@ -1,26 +1,26 @@
-diff -u5 -r sqlite-src-3440000.pristine/src/shell.c.in sqlite-src-3440000/src/shell.c.in
---- sqlite-src-3440000.pristine/src/shell.c.in	2023-11-01 04:31:37.000000000 -0700
-+++ sqlite-src-3440000/src/shell.c.in	2023-11-03 15:06:27.994222697 -0700
-@@ -3381,10 +3381,15 @@
-     raw_printf(pArg->out, "Reprepare operations:                %d\n", iCur);
-     iCur = sqlite3_stmt_status(pArg->pStmt, SQLITE_STMTSTATUS_RUN, bReset);
-     raw_printf(pArg->out, "Number of times run:                 %d\n", iCur);
+diff -u5 -r sqlite-src-pristine/src/shell.c.in sqlite-src-modified/src/shell.c.in
+--- sqlite-src-pristine/src/shell.c.in	2024-10-21 11:47:53
++++ sqlite-src-modified/src/shell.c.in	2024-11-05 08:16:15
+@@ -3411,10 +3411,15 @@
+     sqlite3_fprintf(out,
+            "Number of times run:                 %d\n", iCur);
      iCur = sqlite3_stmt_status(pArg->pStmt, SQLITE_STMTSTATUS_MEMUSED, bReset);
-     raw_printf(pArg->out, "Memory used by prepared stmt:        %d\n", iCur);
+     sqlite3_fprintf(out,
+            "Memory used by prepared stmt:        %d\n", iCur);
 +
 +    iCur = sqlite3_stmt_status(pArg->pStmt, LIBSQL_STMTSTATUS_ROWS_READ, bReset);
-+    raw_printf(pArg->out, "Rows read:                           %d\n", iCur);
++    sqlite3_fprintf(pArg->out, "Rows read:                           %d\n", iCur);
 +    iCur = sqlite3_stmt_status(pArg->pStmt, LIBSQL_STMTSTATUS_ROWS_WRITTEN, bReset);
-+    raw_printf(pArg->out, "Rows written:                        %d\n", iCur);
++    sqlite3_fprintf(pArg->out, "Rows written:                        %d\n", iCur);
    }
  
  #ifdef __linux__
    displayLinuxIoStats(pArg->out);
  #endif
-diff -u5 -r sqlite-src-3440000.pristine/src/sqlite.h.in sqlite-src-3440000/src/sqlite.h.in
---- sqlite-src-3440000.pristine/src/sqlite.h.in	2023-11-01 04:31:37.000000000 -0700
-+++ sqlite-src-3440000/src/sqlite.h.in	2023-11-03 15:06:27.994222697 -0700
-@@ -8815,10 +8815,18 @@
+diff -u5 -r sqlite-src-pristine/src/sqlite.h.in sqlite-src-modified/src/sqlite.h.in
+--- sqlite-src-pristine/src/sqlite.h.in	2024-10-21 11:47:53
++++ sqlite-src-modified/src/sqlite.h.in	2024-11-05 08:13:50
+@@ -8907,20 +8907,32 @@
  ** used to store the prepared statement.  ^This value is not actually
  ** a counter, and so the resetFlg parameter to sqlite3_stmt_status()
  ** is ignored when the opcode is SQLITE_STMTSTATUS_MEMUSED.
@@ -39,25 +39,186 @@ diff -u5 -r sqlite-src-3440000.pristine/src/sqlite.h.in sqlite-src-3440000/src/s
  #define SQLITE_STMTSTATUS_SORT              2
  #define SQLITE_STMTSTATUS_AUTOINDEX         3
  #define SQLITE_STMTSTATUS_VM_STEP           4
-@@ -8826,10 +8834,14 @@
+ #define SQLITE_STMTSTATUS_REPREPARE         5
  #define SQLITE_STMTSTATUS_RUN               6
  #define SQLITE_STMTSTATUS_FILTER_MISS       7
  #define SQLITE_STMTSTATUS_FILTER_HIT        8
  #define SQLITE_STMTSTATUS_MEMUSED           99
- 
++
 +#define LIBSQL_STMTSTATUS_BASE              1024
 +#define LIBSQL_STMTSTATUS_ROWS_READ         LIBSQL_STMTSTATUS_BASE + 1
 +#define LIBSQL_STMTSTATUS_ROWS_WRITTEN      LIBSQL_STMTSTATUS_BASE + 2
-+
+ 
  /*
  ** CAPI3REF: Custom Page Cache Object
  **
  ** The sqlite3_pcache type is opaque.  It is implemented by
- ** the pluggable module.  The SQLite core has no knowledge of
-diff -u5 -r sqlite-src-3440000.pristine/src/vdbeapi.c sqlite-src-3440000/src/vdbeapi.c
---- sqlite-src-3440000.pristine/src/vdbeapi.c	2023-11-01 04:31:37.000000000 -0700
-+++ sqlite-src-3440000/src/vdbeapi.c	2023-11-03 15:23:46.669473054 -0700
-@@ -2036,11 +2036,11 @@
+diff -u5 -r sqlite-src-pristine/src/vdbe.c sqlite-src-modified/src/vdbe.c
+--- sqlite-src-pristine/src/vdbe.c	2024-10-21 11:47:53
++++ sqlite-src-modified/src/vdbe.c	2024-11-05 08:13:50
+@@ -3737,10 +3737,11 @@
+   if( pOp->p3 ){
+     nEntry = sqlite3BtreeRowCountEst(pCrsr);
+   }else{
+     nEntry = 0;  /* Not needed.  Only used to silence a warning. */
+     rc = sqlite3BtreeCount(db, pCrsr, &nEntry);
++    p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE] += nEntry;
+     if( rc ) goto abort_due_to_error;
+   }
+   pOut = out2Prerelease(p, pOp);
+   pOut->u.i = nEntry;
+   goto check_for_interrupt;
+@@ -4900,10 +4901,11 @@
+     if( eqOnly && r.eqSeen==0 ){
+       assert( res!=0 );
+       goto seek_not_found;
+     }
+   }
++  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
+ #ifdef SQLITE_TEST
+   sqlite3_search_count++;
+ #endif
+   if( oc>=OP_SeekGE ){  assert( oc==OP_SeekGE || oc==OP_SeekGT );
+     if( res<0 || (res==0 && oc==OP_SeekGT) ){
+@@ -5470,10 +5472,11 @@
+   pC->nullRow = 0;
+   pC->cacheStatus = CACHE_STALE;
+   pC->deferredMoveto = 0;
+   VdbeBranchTaken(res!=0,2);
+   pC->seekResult = res;
++  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
+   if( res!=0 ){
+     assert( rc==SQLITE_OK );
+     if( pOp->p2==0 ){
+       rc = SQLITE_CORRUPT_BKPT;
+     }else{
+@@ -5727,10 +5730,11 @@
+   }
+   if( pOp->p5 & OPFLAG_ISNOOP ) break;
+ #endif
+ 
+   assert( (pOp->p5 & OPFLAG_LASTROWID)==0 || (pOp->p5 & OPFLAG_NCHANGE)!=0 );
++  if (!pC->isEphemeral) p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
+   if( pOp->p5 & OPFLAG_NCHANGE ){
+     p->nChange++;
+     if( pOp->p5 & OPFLAG_LASTROWID ) db->lastRowid = x.nKey;
+   }
+   assert( (pData->flags & (MEM_Blob|MEM_Str))!=0 || pData->n==0 );
+@@ -5920,10 +5924,11 @@
+   pC->seekResult = 0;
+   if( rc ) goto abort_due_to_error;
+ 
+   /* Invoke the update-hook if required. */
+   if( opflags & OPFLAG_NCHANGE ){
++    if (!pC->isEphemeral) p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
+     p->nChange++;
+     if( db->xUpdateCallback && ALWAYS(pTab!=0) && HasRowid(pTab) ){
+       db->xUpdateCallback(db->pUpdateArg, SQLITE_DELETE, zDb, pTab->zName,
+           pC->movetoTarget);
+       assert( pC->iDb>=0 );
+@@ -6207,10 +6212,11 @@
+   rc = sqlite3BtreeLast(pCrsr, &res);
+   pC->nullRow = (u8)res;
+   pC->deferredMoveto = 0;
+   pC->cacheStatus = CACHE_STALE;
+   if( rc ) goto abort_due_to_error;
++  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
+   if( pOp->p2>0 ){
+     VdbeBranchTaken(res!=0,2);
+     if( res ) goto jump_to_p2;
+   }
+   break;
+@@ -6326,10 +6332,11 @@
+     pC->deferredMoveto = 0;
+     pC->cacheStatus = CACHE_STALE;
+   }
+   if( rc ) goto abort_due_to_error;
+   pC->nullRow = (u8)res;
++  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
+   if( pOp->p2>0 ){
+     VdbeBranchTaken(res!=0,2);
+     if( res ) goto jump_to_p2;
+   }
+   break;
+@@ -6431,10 +6438,11 @@
+   pC->cacheStatus = CACHE_STALE;
+   VdbeBranchTaken(rc==SQLITE_OK,2);
+   if( rc==SQLITE_OK ){
+     pC->nullRow = 0;
+     p->aCounter[pOp->p5]++;
++    p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
+ #ifdef SQLITE_TEST
+     sqlite3_search_count++;
+ #endif
+     goto jump_to_p2_and_check_for_interrupt;
+   }
+@@ -6482,10 +6490,11 @@
+   assert( pC!=0 );
+   assert( !isSorter(pC) );
+   pIn2 = &aMem[pOp->p2];
+   assert( (pIn2->flags & MEM_Blob) || (pOp->p5 & OPFLAG_PREFORMAT) );
+   if( pOp->p5 & OPFLAG_NCHANGE ) p->nChange++;
++  if (!pC->isEphemeral) p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
+   assert( pC->eCurType==CURTYPE_BTREE );
+   assert( pC->isTable==0 );
+   rc = ExpandBlob(pIn2);
+   if( rc ) goto abort_due_to_error;
+   x.nKey = pIn2->n;
+@@ -6882,10 +6891,11 @@
+   assert( p->readOnly==0 );
+   assert( DbMaskTest(p->btreeMask, pOp->p2) );
+   rc = sqlite3BtreeClearTable(db->aDb[pOp->p2].pBt, (u32)pOp->p1, &nChange);
+   if( pOp->p3 ){
+     p->nChange += nChange;
++    p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE] += nChange;
+     if( pOp->p3>0 ){
+       assert( memIsValid(&aMem[pOp->p3]) );
+       memAboutToChange(p, &aMem[pOp->p3]);
+       aMem[pOp->p3].u.i += nChange;
+     }
+@@ -8466,10 +8476,11 @@
+   ** some other method is next invoked on the save virtual table cursor.
+   */
+   rc = pModule->xNext(pCur->uc.pVCur);
+   sqlite3VtabImportErrmsg(p, pVtab);
+   if( rc ) goto abort_due_to_error;
++  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
+   res = pModule->xEof(pCur->uc.pVCur);
+   VdbeBranchTaken(!res,2);
+   if( !res ){
+     /* If there is data, jump to P2 */
+     goto jump_to_p2_and_check_for_interrupt;
+@@ -8587,10 +8598,11 @@
+         rc = SQLITE_OK;
+       }else{
+         p->errorAction = ((pOp->p5==OE_Replace) ? OE_Abort : pOp->p5);
+       }
+     }else{
++      p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
+       p->nChange++;
+     }
+     if( rc ) goto abort_due_to_error;
+   }
+   break;
+diff -u5 -r sqlite-src-pristine/src/vdbeInt.h sqlite-src-modified/src/vdbeInt.h
+--- sqlite-src-pristine/src/vdbeInt.h	2024-10-21 11:47:53
++++ sqlite-src-modified/src/vdbeInt.h	2024-11-05 08:13:50
+@@ -496,10 +496,11 @@
+   bft bIsReader:1;        /* True for statements that read */
+   bft haveEqpOps:1;       /* Bytecode supports EXPLAIN QUERY PLAN */
+   yDbMask btreeMask;      /* Bitmask of db->aDb[] entries referenced */
+   yDbMask lockMask;       /* Subset of btreeMask that requires a lock */
+   u32 aCounter[9];        /* Counters used by sqlite3_stmt_status() */
++  u32 aLibsqlCounter[3];  /* libSQL extension: Counters used by sqlite3_stmt_status()*/
+   char *zSql;             /* Text of the SQL statement that generated this */
+ #ifdef SQLITE_ENABLE_NORMALIZE
+   char *zNormSql;         /* Normalization of the associated SQL statement */
+   DblquoteStr *pDblStr;   /* List of double-quoted string literals */
+ #endif
+diff -u5 -r sqlite-src-pristine/src/vdbeapi.c sqlite-src-modified/src/vdbeapi.c
+--- sqlite-src-pristine/src/vdbeapi.c	2024-10-21 11:47:53
++++ sqlite-src-modified/src/vdbeapi.c	2024-11-05 08:13:50
+@@ -2072,11 +2072,11 @@
  int sqlite3_stmt_status(sqlite3_stmt *pStmt, int op, int resetFlag){
    Vdbe *pVdbe = (Vdbe*)pStmt;
    u32 v;
@@ -70,7 +231,7 @@ diff -u5 -r sqlite-src-3440000.pristine/src/vdbeapi.c sqlite-src-3440000/src/vdb
      return 0;
    }
  #endif
-@@ -2053,10 +2053,13 @@
+@@ -2089,10 +2089,13 @@
      db->lookaside.pEnd = db->lookaside.pStart;
      sqlite3VdbeDelete(pVdbe);
      db->pnBytesFreed = 0;
@@ -84,165 +245,3 @@ diff -u5 -r sqlite-src-3440000.pristine/src/vdbeapi.c sqlite-src-3440000/src/vdb
      if( resetFlag ) pVdbe->aCounter[op] = 0;
    }
    return (int)v;
-diff -u5 -r sqlite-src-3440000.pristine/src/vdbe.c sqlite-src-3440000/src/vdbe.c
---- sqlite-src-3440000.pristine/src/vdbe.c	2023-11-01 04:31:37.000000000 -0700
-+++ sqlite-src-3440000/src/vdbe.c	2024-01-30 10:49:55.735518937 -0800
-@@ -3708,10 +3708,11 @@
-   if( pOp->p3 ){
-     nEntry = sqlite3BtreeRowCountEst(pCrsr);
-   }else{
-     nEntry = 0;  /* Not needed.  Only used to silence a warning. */
-     rc = sqlite3BtreeCount(db, pCrsr, &nEntry);
-+    p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE] += nEntry;
-     if( rc ) goto abort_due_to_error;
-   }
-   pOut = out2Prerelease(p, pOp);
-   pOut->u.i = nEntry;
-   goto check_for_interrupt;
-@@ -4867,10 +4868,11 @@
-     if( eqOnly && r.eqSeen==0 ){
-       assert( res!=0 );
-       goto seek_not_found;
-     }
-   }
-+  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
- #ifdef SQLITE_TEST
-   sqlite3_search_count++;
- #endif
-   if( oc>=OP_SeekGE ){  assert( oc==OP_SeekGE || oc==OP_SeekGT );
-     if( res<0 || (res==0 && oc==OP_SeekGT) ){
-@@ -5436,10 +5438,11 @@
-   pC->nullRow = 0;
-   pC->cacheStatus = CACHE_STALE;
-   pC->deferredMoveto = 0;
-   VdbeBranchTaken(res!=0,2);
-   pC->seekResult = res;
-+  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
-   if( res!=0 ){
-     assert( rc==SQLITE_OK );
-     if( pOp->p2==0 ){
-       rc = SQLITE_CORRUPT_BKPT;
-     }else{
-@@ -5693,10 +5696,11 @@
-   }
-   if( pOp->p5 & OPFLAG_ISNOOP ) break;
- #endif
- 
-   assert( (pOp->p5 & OPFLAG_LASTROWID)==0 || (pOp->p5 & OPFLAG_NCHANGE)!=0 );
-+  if (!pC->isEphemeral) p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
-   if( pOp->p5 & OPFLAG_NCHANGE ){
-     p->nChange++;
-     if( pOp->p5 & OPFLAG_LASTROWID ) db->lastRowid = x.nKey;
-   }
-   assert( (pData->flags & (MEM_Blob|MEM_Str))!=0 || pData->n==0 );
-@@ -5886,10 +5890,11 @@
-   pC->seekResult = 0;
-   if( rc ) goto abort_due_to_error;
- 
-   /* Invoke the update-hook if required. */
-   if( opflags & OPFLAG_NCHANGE ){
-+    if (!pC->isEphemeral) p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
-     p->nChange++;
-     if( db->xUpdateCallback && ALWAYS(pTab!=0) && HasRowid(pTab) ){
-       db->xUpdateCallback(db->pUpdateArg, SQLITE_DELETE, zDb, pTab->zName,
-           pC->movetoTarget);
-       assert( pC->iDb>=0 );
-@@ -6173,10 +6178,11 @@
-   rc = sqlite3BtreeLast(pCrsr, &res);
-   pC->nullRow = (u8)res;
-   pC->deferredMoveto = 0;
-   pC->cacheStatus = CACHE_STALE;
-   if( rc ) goto abort_due_to_error;
-+  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
-   if( pOp->p2>0 ){
-     VdbeBranchTaken(res!=0,2);
-     if( res ) goto jump_to_p2;
-   }
-   break;
-@@ -6282,10 +6288,11 @@
-     pC->deferredMoveto = 0;
-     pC->cacheStatus = CACHE_STALE;
-   }
-   if( rc ) goto abort_due_to_error;
-   pC->nullRow = (u8)res;
-+  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
-   if( pOp->p2>0 ){
-     VdbeBranchTaken(res!=0,2);
-     if( res ) goto jump_to_p2;
-   }
-   break;
-@@ -6387,10 +6394,11 @@
-   pC->cacheStatus = CACHE_STALE;
-   VdbeBranchTaken(rc==SQLITE_OK,2);
-   if( rc==SQLITE_OK ){
-     pC->nullRow = 0;
-     p->aCounter[pOp->p5]++;
-+    p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
- #ifdef SQLITE_TEST
-     sqlite3_search_count++;
- #endif
-     goto jump_to_p2_and_check_for_interrupt;
-   }
-@@ -6438,10 +6446,11 @@
-   assert( pC!=0 );
-   assert( !isSorter(pC) );
-   pIn2 = &aMem[pOp->p2];
-   assert( (pIn2->flags & MEM_Blob) || (pOp->p5 & OPFLAG_PREFORMAT) );
-   if( pOp->p5 & OPFLAG_NCHANGE ) p->nChange++;
-+  if (!pC->isEphemeral) p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
-   assert( pC->eCurType==CURTYPE_BTREE );
-   assert( pC->isTable==0 );
-   rc = ExpandBlob(pIn2);
-   if( rc ) goto abort_due_to_error;
-   x.nKey = pIn2->n;
-@@ -6838,10 +6847,11 @@
-   assert( p->readOnly==0 );
-   assert( DbMaskTest(p->btreeMask, pOp->p2) );
-   rc = sqlite3BtreeClearTable(db->aDb[pOp->p2].pBt, (u32)pOp->p1, &nChange);
-   if( pOp->p3 ){
-     p->nChange += nChange;
-+    p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE] += nChange;
-     if( pOp->p3>0 ){
-       assert( memIsValid(&aMem[pOp->p3]) );
-       memAboutToChange(p, &aMem[pOp->p3]);
-       aMem[pOp->p3].u.i += nChange;
-     }
-@@ -8391,10 +8401,11 @@
-   ** some other method is next invoked on the save virtual table cursor.
-   */
-   rc = pModule->xNext(pCur->uc.pVCur);
-   sqlite3VtabImportErrmsg(p, pVtab);
-   if( rc ) goto abort_due_to_error;
-+  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
-   res = pModule->xEof(pCur->uc.pVCur);
-   VdbeBranchTaken(!res,2);
-   if( !res ){
-     /* If there is data, jump to P2 */
-     goto jump_to_p2_and_check_for_interrupt;
-@@ -8512,10 +8523,11 @@
-         rc = SQLITE_OK;
-       }else{
-         p->errorAction = ((pOp->p5==OE_Replace) ? OE_Abort : pOp->p5);
-       }
-     }else{
-+      p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
-       p->nChange++;
-     }
-     if( rc ) goto abort_due_to_error;
-   }
-   break;
-diff -u5 -r sqlite-src-3440000.pristine/src/vdbeInt.h sqlite-src-3440000/src/vdbeInt.h
---- sqlite-src-3440000.pristine/src/vdbeInt.h	2023-11-01 04:31:37.000000000 -0700
-+++ sqlite-src-3440000/src/vdbeInt.h	2023-11-03 15:06:27.998222610 -0700
-@@ -496,10 +496,11 @@
-   bft bIsReader:1;        /* True for statements that read */
-   bft haveEqpOps:1;       /* Bytecode supports EXPLAIN QUERY PLAN */
-   yDbMask btreeMask;      /* Bitmask of db->aDb[] entries referenced */
-   yDbMask lockMask;       /* Subset of btreeMask that requires a lock */
-   u32 aCounter[9];        /* Counters used by sqlite3_stmt_status() */
-+  u32 aLibsqlCounter[3];  /* libSQL extension: Counters used by sqlite3_stmt_status()*/
-   char *zSql;             /* Text of the SQL statement that generated this */
- #ifdef SQLITE_ENABLE_NORMALIZE
-   char *zNormSql;         /* Normalization of the associated SQL statement */
-   DblquoteStr *pDblStr;   /* List of double-quoted string literals */
- #endif

--- a/patches/sqlite/README.md
+++ b/patches/sqlite/README.md
@@ -1,5 +1,6 @@
-The patches for SQLite are applied against the plain source, not the
-amalgamated source.
+# Patching SQLite
+
+The patches for SQLite are applied against the plain source, not the amalgamated source.
 
 SQLite comes in two forms. First, there's the "plain" form. It looks a
 lot like a typical open-source C project: there's a bunch of .c and .h
@@ -17,21 +18,28 @@ any patches that needed modification with their fixed versions.
 Example, assuming the new SQLite has been downloaded into the current
 directory:
 
-$ unzip sqlite-src-$VERSION.zip
-$ mv sqlite-src-$VERSION sqlite-src-pristine
-$ unzip sqlite-src-$VERSION.zip  # yes, again
-$ mv sqlite-src-$VERSION sqlite-src-modified
+```bash
+export VERSION=3470000
+unzip sqlite-src-$VERSION.zip
+mv sqlite-src-$VERSION sqlite-src-pristine
+unzip sqlite-src-$VERSION.zip  # yes, again
+mv sqlite-src-$VERSION sqlite-src-modified
+```
 
 Now patch:
 
-$ cd sqlite-src-modified
-$ patch -p1 < /path/to/workerd/patches/sqlite/0001-row-counts-plain.patch
-$ ./configure && make test
+```bash
+cd sqlite-src-modified
+patch -p1 < /path/to/workerd/patches/sqlite/0001-row-counts-plain.patch
+./configure && make test
+```
 
 Make sure the tests pass. If the patch needed any modification, regenerate it:
 
-$ diff -u5 -r sqlite-src-pristine sqlite-src-modified \
+```bash
+diff -u5 -r sqlite-src-pristine sqlite-src-modified \
     | grep -v "Only in sqlite-src-modified" \
     > /path/to/workerd/patches/sqlite/0001-row-counts-plain.patch
+```
 
 Repeat for each patch.


### PR DESCRIPTION
For the checksum, HTTP archive uses SHA2-256 whereas the SQLite downloads page uses SHA3-256. I manually verified the checksum: 
```
openssl dgst -sha3-256 sqlite-src-3470000.zip
SHA3-256(sqlite-src-3470000.zip)= 91d37d50fc6f6dba05dc4f595368f00da922f0c0859f5efc86d45bdc709690e3

openssl dgst -sha256 sqlite-src-3470000.zip
SHA2-256(sqlite-src-3470000.zip)= f59c349bedb470203586a6b6d10adb35f2afefa49f91e55a672a36a09a8fedf7
```