### PR TITLE
[Vectorize] Fix field name for Vectorize describe operation

### DIFF
--- a/src/cloudflare/internal/vectorize.d.ts
+++ b/src/cloudflare/internal/vectorize.d.ts
@@ -111,7 +111,7 @@ interface VectorizeIndexDetails {
  */
 interface VectorizeIndexInfo {
   /** The number of records containing vectors within the index. */
-  vectorsCount: number;
+  vectorCount: number;
   /** Number of dimensions the index has been configured for. */
   dimensions: number;
   /** ISO 8601 datetime of the last processed mutation on in the index. All changes before this mutation will be reflected in the index state. */

--- a/types/defines/vectorize.d.ts
+++ b/types/defines/vectorize.d.ts
@@ -103,7 +103,7 @@ interface VectorizeIndexDetails {
  */
 interface VectorizeIndexInfo {
   /** The number of records containing vectors within the index. */
-  vectorsCount: number;
+  vectorCount: number;
   /** Number of dimensions the index has been configured for. */
   dimensions: number;
   /** ISO 8601 datetime of the last processed mutation on in the index. All changes before this mutation will be reflected in the index state. */


### PR DESCRIPTION
Fix the typo in the field `vectorsCount`, and replace it with `vectorCount` in the Vectorize V2 Describe response type.