### PR TITLE
format.py: Use bazel build, support excludes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -434,7 +434,8 @@ http_file(
 
 FILE_GROUP = """filegroup(
 	name="file",
-	srcs=["**/*"])"""
+	srcs=glob(["**"])
+)"""
 
 http_archive(
     name = "ruff-darwin-arm64",


### PR DESCRIPTION
Adds a few features to format.py that improve compatibility with the internal repo:
- Adds `excludes` to the config, listing directories that should not be formatted
- Uses `bazel build` instead of `bazel fetch`, so that bazel creates some symlinks the internal repo expects to exist.
- Fixes a mistake in the filegroup config for formatters distributed as a `http_archive`