### PR TITLE
Add updateConfiguration function to jsg Isolates

### DIFF
--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -572,6 +572,11 @@ public:
   // std::nullptr_t). The getConfig allows us to handle any case using reasonable defaults.
   PromiseWrapper(const auto& config): config(getConfig(config)) {}
 
+  template <typename MetaConfiguration>
+  void updateConfiguration(MetaConfiguration&& configuration) {
+    config = getConfig(kj::fwd<MetaConfiguration>(configuration));
+  }
+
   template <typename T>
   static constexpr const char* getName(Promise<T>*) {
     return "Promise";
@@ -668,7 +673,7 @@ public:
   }
 
 private:
-  const JsgConfig config;
+  JsgConfig config;
 
   static bool isThenable(v8::Local<v8::Context> context, v8::Local<v8::Value> handle) {
     if (handle->IsObject()) {

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -1349,6 +1349,11 @@ public:
   ResourceWrapper(MetaConfiguration&& configuration)
       : configuration(kj::fwd<MetaConfiguration>(configuration)) {}
 
+  template <typename MetaConfiguration>
+  void updateConfiguration(MetaConfiguration&& config) {
+    configuration = kj::fwd<MetaConfiguration>(config);
+  }
+
   inline void initTypeWrapper() {
     TypeWrapper& wrapper = static_cast<TypeWrapper&>(*this);
     wrapper.resourceTypeMap.insert(typeid(T),

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -409,6 +409,11 @@ public:
     dropWrappers(kj::mv(wrapper));
   }
 
+  template <typename MetaConfiguration>
+  void updateConfiguration(MetaConfiguration&& configuration) {
+    wrapper->updateConfiguration(kj::fwd<MetaConfiguration>(configuration));
+  }
+
   kj::Exception unwrapException(
       v8::Local<v8::Context> context, v8::Local<v8::Value> exception) override {
     return wrapper->template unwrap<kj::Exception>(

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -246,6 +246,9 @@ public:
 
   inline void initTypeWrapper() {}
 
+  template <typename MetaConfiguration>
+  void updateConfiguration(MetaConfiguration&& configuration) {}
+
   void unwrap() = delete;  // StructWrapper only implements tryUnwrap(), not unwrap()
 };
 
@@ -274,6 +277,9 @@ public:
   void unwrap() = delete;  // extensions only implement tryUnwrap(), not unwrap()
 
   inline void initTypeWrapper() {}
+
+  template <typename MetaConfiguration>
+  void updateConfiguration(MetaConfiguration&& configuration) {}
 };
 
 // Specialization of TypeWrapperBase for InjectConfiguration.
@@ -297,6 +303,11 @@ public:
   void getTemplate() = delete;
 
   inline void initTypeWrapper() {}
+
+  template <typename MetaConfiguration>
+  void updateConfiguration(MetaConfiguration&& config) {
+    configuration = kj::fwd<MetaConfiguration>(config);
+  }
 
 private:
   Configuration configuration;
@@ -409,6 +420,13 @@ public:
 
   void initTypeWrapper() {
     (TypeWrapperBase<Self, T>::initTypeWrapper(), ...);
+  }
+
+  template <typename MetaConfiguration>
+  void updateConfiguration(MetaConfiguration&& configuration) {
+    (TypeWrapperBase<Self, T>::updateConfiguration(kj::fwd<MetaConfiguration>(configuration)), ...);
+    MaybeWrapper<Self>::updateConfiguration(kj::fwd<MetaConfiguration>(configuration));
+    PromiseWrapper<Self>::updateConfiguration(kj::fwd<MetaConfiguration>(configuration));
   }
 
   static TypeWrapper& from(v8::Isolate* isolate) {

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -587,6 +587,11 @@ public:
   // The getConfig allows us to handle any case using reasonable defaults.
   MaybeWrapper(const auto& config): config(getConfig(config)) {}
 
+  template <typename MetaConfiguration>
+  void updateConfiguration(MetaConfiguration&& configuration) {
+    config = getConfig(kj::fwd<MetaConfiguration>(configuration));
+  }
+
   template <typename U>
   static constexpr decltype(auto) getName(kj::Maybe<U>*) {
     return TypeWrapper::getName((kj::Decay<U>*)nullptr);
@@ -623,7 +628,7 @@ public:
   }
 
 private:
-  const JsgConfig config;
+  JsgConfig config;
 };
 
 // =======================================================================================


### PR DESCRIPTION
This can be used to update the given configuration at runtime. 
Note that while some jsg structs are lazily using the configuration, others can use it at construction and will have the original configuration value.

This is another step towards Python Isolate Pools and is coming in direct continuation to https://github.com/cloudflare/workerd/pull/2999.
This is another part split from workerd #2936 and internal #9006 for reviewability.