### PR TITLE
Export setupContext publically to be used by additional contexts.

### DIFF
--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -153,6 +153,9 @@ public:
   void setConnectOverride(kj::String networkAddress, ConnectFn connectFn);
   kj::Maybe<ConnectFn&> getConnectOverride(kj::StringPtr networkAddress);
 
+  static void setupContext(
+      jsg::Lock& lock, v8::Local<v8::Context> context, Worker::ConsoleMode consoleMode);
+
 private:
   kj::Own<const Script> script;
 


### PR DESCRIPTION
Currently Worker::Isolate::Impl does the setup of the context. Namely setting up the console and WebAssembly.Module@@HasInstance. This functionality is useful in general to any context we might create even before we have a Worker::Isolate.
This commit moves this functionality to a publicly facing api.

Another part split from #2936 