### PR TITLE
[nfc] always download outputs in release builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,13 +67,14 @@ jobs:
       image: ${{ matrix.os.image }}
       os_name: ${{ matrix.os.name }}
       suffix: ${{ matrix.config.suffix }}
+      extra_bazel_args: "--config=ci-test"
     secrets:
       BAZEL_CACHE_KEY: ${{ secrets.BAZEL_CACHE_KEY }}
       WORKERS_MIRROR_URL: ${{ secrets.WORKERS_MIRROR_URL }}
   lint:
     uses: ./.github/workflows/_bazel.yml
     with:
-      extra_bazel_args: "--config=lint"
+      extra_bazel_args: "--config=lint --config=ci-test"
       run_tests: false
     secrets:
       BAZEL_CACHE_KEY: ${{ secrets.BAZEL_CACHE_KEY }}

--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -20,8 +20,11 @@ build:ci --color=yes
 build:ci --terminal_columns=100
 
 build:ci --config=v8-codegen-opt
-build:ci --remote_download_minimal --disk_cache=~/bazel-disk-cache
 test:ci --test_output=errors
+build:ci --disk_cache=~/bazel-disk-cache
+
+# test CI jobs don't need any top-level artifacts and just verify things
+build:ci-test --remote_download_outputs=minimal
 
 # limit storage usage on ci
 # Exclude large benchmarking binaries created in debug and asan configurations to avoid


### PR DESCRIPTION
after ci.bazelrc move minimal downloads started to apply to release builds too, which is not what we want.
Sorry for inconvenience @fhanau 