### PR TITLE
[CI] Cross-compile Intel Mac release binary

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -211,8 +211,9 @@ build:linux --config=unix
 build:macos --config=unix
 
 # Support macOS 13 as the minimum version. There should be at least a warning when backward
-# compatibility is broken as -Wunguarded-availability-new is enabled by default.
-build:macos --macos_minimum_os=13.5 --host_macos_minimum_os=13.5
+# compatibility is broken as -Wunguarded-availability-new is enabled by default. Only enable for
+# target configuration as host configuration tools are only used during the build process.
+build:macos --macos_minimum_os=13.5
 
 # Avoid emitting duplicate unwind info where compact unwind info can be used. This reduces the
 # object size by ~5% on average, improving disk space usage and link times. The final binary size

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,13 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-13, windows-2022]
+        os: [ubuntu-20.04, macos-15, windows-2022]
         include:
           - os-name: linux
             os: ubuntu-20.04
             bazel-config: release_linux
           - os-name: macOS
-            os: macos-13
+            os: macos-15
             bazel-config: release_macos
           - os-name: windows
             os: windows-2022
@@ -95,11 +95,12 @@ jobs:
       - name: Setup macOS
         if: runner.os == 'macOS'
         run: |
-          sudo xcode-select -s "/Applications/Xcode_15.1.app"
           # Install lld and link it to /usr/local/bin. We overwrite any existing link, which may
           # exist from an older pre-installed LLVM version on the runner image.
           brew install lld
           sudo ln -s -f $(brew --prefix lld)/bin/ld64.lld /usr/local/bin/ld64.lld
+          # Cross-compile so that we can use the latest Xcode version for the Intel Mac binary
+          echo "build:macos --config=macos-cross-x86_64" >> .bazelrc
           # Enable lld identical code folding to significantly reduce binary size.
           echo "build:macos --config=macos_lld_icf" >> .bazelrc
       - name: Setup Windows


### PR DESCRIPTION
Follow-up to #2958, where we added and tested cross-compilation support. This allows us to use Xcode 16 to compile the Intel Mac binary (macos-15 is Apple Silicon-based, macos-13 only has Xcode 15 available) and take advantage of the faster M1-based runners.

- Don't set minimum macOS version for host configuration, host tools are only needed during the build and do not need to be distributed beyond that. This fixes a misleading warning.

==============

Should save some precious macOS runner time. In a follow-up, we will also compile the macOS arm64 binary on GitHub CI, and eventually the Linux arm64 binary. Then all release binaries will be compiled here and we'll be able to automate the NPM publish and NPM types jobs so that releases are fully automated.