### PR TITLE
Disable top-level await in require with a compat flag

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -849,15 +849,8 @@ jsg::JsValue resolveFromRegistry(jsg::Lock& js, kj::StringPtr specifier) {
   auto& info = JSG_REQUIRE_NONNULL(
       moduleRegistry->resolve(js, spec), Error, kj::str("No such module: ", specifier));
   auto module = info.module.getHandle(js);
-  jsg::instantiateModule(js, module);
 
-  auto handle = jsg::check(module->Evaluate(js.v8Context()));
-  KJ_ASSERT(handle->IsPromise());
-  auto prom = handle.As<v8::Promise>();
-  KJ_ASSERT(prom->State() != v8::Promise::PromiseState::kPending);
-  if (module->GetStatus() == v8::Module::kErrored) {
-    jsg::throwTunneledException(js.v8Isolate, module->GetException());
-  }
+  jsg::instantiateModule(js, module);
   return jsg::JsValue(js.v8Get(module->GetModuleNamespace().As<v8::Object>(), "default"_kj));
 }
 }  // namespace

--- a/src/workerd/api/node/tests/module-create-require-test.js
+++ b/src/workerd/api/node/tests/module-create-require-test.js
@@ -24,7 +24,14 @@ export const doTheTest = {
     strictEqual(assert, required);
 
     throws(() => require('invalid'), {
-      message: 'Module evaluation did not complete synchronously.',
+      message: 'Top-level await in module is not permitted at this time.',
+    });
+    // Trying to require the module again should throw the same error.
+    throws(() => require('invalid'), {
+      message: 'Top-level await in module is not permitted at this time.',
+    });
+    throws(() => require('invalid2'), {
+      message: 'Top-level await in module is not permitted at this time.',
     });
 
     throws(() => require('does not exist'));

--- a/src/workerd/api/node/tests/module-create-require-test.wd-test
+++ b/src/workerd/api/node/tests/module-create-require-test.wd-test
@@ -10,10 +10,12 @@ const unitTests :Workerd.Config = (
           (name = "bar", esModule = "export default 2; export const __cjsUnwrapDefault = true;"),
           (name = "baz", commonJsModule = "module.exports = 3;"),
           (name = "worker/qux", text = "4"),
-          (name = "invalid", esModule = "const p = new Promise(() => {}); await p;"),
+          (name = "invalid", esModule = "await new Promise(() => {});"),
+          (name = "invalid2", commonJsModule = "require('invalid3');"),
+          (name = "invalid3", esModule = "await new Promise(() => {});"),
         ],
         compatibilityDate = "2024-08-01",
-        compatibilityFlags = ["nodejs_compat_v2"]
+        compatibilityFlags = ["disable_top_level_await_in_require", "nodejs_compat_v2"]
       )
     ),
   ],

--- a/src/workerd/api/node/util.c++
+++ b/src/workerd/api/node/util.c++
@@ -217,13 +217,6 @@ jsg::JsValue UtilModule::getBuiltinModule(jsg::Lock& js, kj::String specifier) {
           jsg::ModuleRegistry::ResolveMethod::IMPORT, rawSpecifier.asPtr())) {
     auto module = info.module.getHandle(js);
     jsg::instantiateModule(js, module);
-    auto handle = jsg::check(module->Evaluate(js.v8Context()));
-    KJ_ASSERT(handle->IsPromise());
-    auto prom = handle.As<v8::Promise>();
-    KJ_ASSERT(prom->State() != v8::Promise::PromiseState::kPending);
-    if (module->GetStatus() == v8::Module::kErrored) {
-      jsg::throwTunneledException(js.v8Isolate, module->GetException());
-    }
 
     // For Node.js modules, we want to grab the default export and return that.
     // For other built-ins, we'll return the module namespace instead. Can be

--- a/src/workerd/api/tests/new-module-registry-test.js
+++ b/src/workerd/api/tests/new-module-registry-test.js
@@ -8,7 +8,7 @@ import {
 import { foo, default as def } from 'foo';
 import { default as fs } from 'node:fs';
 import { Buffer } from 'buffer';
-const { foo: foo2, default: def2 } = await import('bar');
+import { foo as foo2, default as def2 } from 'bar';
 
 // Verify that import.meta.url is correct here.
 strictEqual(import.meta.url, 'file:///worker');

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -657,4 +657,12 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   #
   # This is a compat flag so that we can opt in our test workers into it before rolling out to
   # everyone.
+
+  noTopLevelAwaitInRequire @67 :Bool
+      $compatEnableFlag("disable_top_level_await_in_require")
+      $compatDisableFlag("enable_top_level_await_in_require")
+      $compatEnableDate("2024-12-02");
+  # When enabled, use of top-level await syntax in require() calls will be disallowed.
+  # The ecosystem and runtimes are moving to a state where top level await in modules
+  # is being strongly discouraged.
 }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -999,6 +999,9 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
     if (features.getNodeJsCompatV2()) {
       lock->setNodeJsCompatEnabled();
     }
+    if (features.getNoTopLevelAwaitInRequire()) {
+      lock->disableTopLevelAwait();
+    }
 
     if (impl->inspector != kj::none || ::kj::_::Debug::shouldLog(::kj::LogSeverity::INFO)) {
       lock->setLoggerCallback([this](jsg::Lock& js, kj::StringPtr message) {

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -195,6 +195,10 @@ void Lock::setNodeJsCompatEnabled() {
   IsolateBase::from(v8Isolate).setNodeJsCompatEnabled({}, true);
 }
 
+void Lock::disableTopLevelAwait() {
+  IsolateBase::from(v8Isolate).disableTopLevelAwait();
+}
+
 void Lock::setToStringTag() {
   IsolateBase::from(v8Isolate).enableSetToStringTag();
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2516,6 +2516,7 @@ public:
 
   void setNodeJsCompatEnabled();
   void setToStringTag();
+  void disableTopLevelAwait();
 
   using Logger = void(Lock&, kj::StringPtr);
   void setLoggerCallback(kj::Function<Logger>&& logger);

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -191,7 +191,14 @@ private:
   v8::Global<v8::UnboundScript> unboundScript;
 };
 
-void instantiateModule(jsg::Lock& js, v8::Local<v8::Module>& module);
+enum class InstantiateModuleOptions {
+  DEFAULT,
+  NO_TOP_LEVEL_AWAIT,
+};
+
+void instantiateModule(jsg::Lock& js,
+    v8::Local<v8::Module>& module,
+    InstantiateModuleOptions options = InstantiateModuleOptions::DEFAULT);
 
 enum class ModuleInfoCompileOption {
   // The BUNDLE options tells the compile operation to treat the content as coming

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -194,7 +194,10 @@ private:
 };
 
 enum class InstantiateModuleOptions {
+  // Allows pending top-level await in the module when evaluated. Will cause
+  // the microtask queue to be drained once in an attempt to resolve those.
   DEFAULT,
+  // Throws if the module evaluation results in a pending promise.
   NO_TOP_LEVEL_AWAIT,
 };
 
@@ -403,6 +406,16 @@ public:
   using DynamicImportCallback = Promise<Value>(jsg::Lock& js, kj::Function<Value()> handler);
 
   virtual void setDynamicImportCallback(kj::Function<DynamicImportCallback> func) = 0;
+
+  enum class RequireImplOptions {
+    // Require returns the module namespace.
+    DEFAULT,
+    // Require returns the default export.
+    EXPORT_DEFAULT,
+  };
+
+  static JsValue requireImpl(
+      Lock& js, ModuleInfo& info, RequireImplOptions options = RequireImplOptions::DEFAULT);
 };
 
 template <typename TypeWrapper>

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -88,6 +88,8 @@ private:
 // expected within the global scope of a Node.js compatible module (such as
 // Buffer and process).
 
+// TODO(cleanup): There's a fair amount of duplicated code between the CommonJsModule
+// and NodeJsModule types... should be deduplicated.
 class NodeJsModuleObject: public jsg::Object {
 public:
   NodeJsModuleObject(jsg::Lock& js, kj::String path);
@@ -252,7 +254,7 @@ public:
   };
 
   struct NodeJsModuleInfo {
-    jsg::Ref<jsg::Object> moduleContext;
+    jsg::Ref<NodeJsModuleContext> moduleContext;
     jsg::Function<void()> evalFunc;
 
     NodeJsModuleInfo(auto& lock, kj::StringPtr name, kj::StringPtr content)
@@ -262,7 +264,7 @@ public:
     NodeJsModuleInfo(NodeJsModuleInfo&&) = default;
     NodeJsModuleInfo& operator=(NodeJsModuleInfo&&) = default;
 
-    static jsg::Ref<jsg::Object> initModuleContext(jsg::Lock& js, kj::StringPtr name);
+    static jsg::Ref<NodeJsModuleContext> initModuleContext(jsg::Lock& js, kj::StringPtr name);
 
     static v8::MaybeLocal<v8::Value> evaluate(jsg::Lock& js,
         NodeJsModuleInfo& info,
@@ -270,7 +272,7 @@ public:
         const kj::Maybe<kj::Array<kj::String>>& maybeExports);
 
     jsg::Function<void()> initEvalFunc(auto& lock,
-        jsg::Ref<jsg::Object>& moduleContext,
+        jsg::Ref<jsg::NodeJsModuleContext>& moduleContext,
         kj::StringPtr name,
         kj::StringPtr content) {
       v8::ScriptOrigin origin(v8StrIntern(lock.v8Isolate, name));

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -151,6 +151,14 @@ public:
     setToStringTag = true;
   }
 
+  inline void disableTopLevelAwait() {
+    allowTopLevelAwait = false;
+  }
+
+  inline bool isTopLevelAwaitEnabled() const {
+    return allowTopLevelAwait;
+  }
+
   // The logger will be optionally set by the isolate setup logic if there is anywhere
   // for the log to go (for instance, if debug logging is enabled or the inspector is
   // being used).
@@ -238,6 +246,7 @@ private:
   bool asyncContextTrackingEnabled = false;
   bool nodeJsCompatEnabled = false;
   bool setToStringTag = false;
+  bool allowTopLevelAwait = true;
 
   kj::Maybe<kj::Function<Logger>> maybeLogger;
   kj::Maybe<kj::Function<ErrorReporter>> maybeErrorReporter;


### PR DESCRIPTION
~~Currently, the top level scope of a Worker script and modules that are imported may use top level await. However, because we restrict the use of i/o in the top level scope, the only thing that can be awaited at the top level scope is a dynamic import, which we require to be resolved synchronously. It is a bit nonsensical to support synchronously resolved dynamic imports at the top level when we can just use static imports more effectively. Additionally, the ecosystem and runtimes are moving to a state where top level await in modules is being strongly discouraged. This compat flag. This compatibility flag will make it impossible to use top level await.~~

(made the change with lots of distractions so keeping as a draft until I can do a second pass to make sure nothing was missed)

*Update*: Updated to apply the compat flag only to `require()` calls, along with a few other relevant cleanups. Still keeping as a draft because this will need some extensive testing.