### PR TITLE
[build] Move io-channels.h back into io target

### DIFF
--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -59,6 +59,7 @@ wd_cc_library(
         "compatibility-date.h",
         "features.h",
         "hibernation-manager.h",
+        "io-channels.h",
         "io-context.h",
         "io-own.h",
         "io-util.h",
@@ -86,7 +87,6 @@ wd_cc_library(
         ":actor-id",
         ":actor-storage_capnp",
         ":cdp_capnp",
-        ":io-channels",
         ":io-gate",
         ":io-helpers",
         ":limit-enforcer",
@@ -228,16 +228,7 @@ wd_cc_library(
     name = "actor-id",
     hdrs = ["actor-id.h"],
     visibility = ["//visibility:public"],
-)
-
-wd_cc_library(
-    name = "io-channels",
-    hdrs = ["io-channels.h"],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":actor-id",
-        ":trace",
-    ],
+    deps = ["@capnp-cpp//src/kj"],
 )
 
 genrule(

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("//:build/pyodide_bucket.bzl", "PYODIDE_IMPORTS_TO_TEST")
-load("//:build/wd_test.bzl", "wd_test")
 load("//src/workerd/server/tests/python:import_tests.bzl", "gen_import_tests")
 load("//src/workerd/server/tests/python:py_wd_test.bzl", "py_wd_test")
 

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -40,7 +40,6 @@ wd_cc_library(
         "batch-queue.h",
         "canceler.h",
         "color-util.h",
-        "duration-exceeded-logger.h",
         "http-util.h",
         "stream-utils.h",
         "uncaught-exception-source.h",
@@ -50,6 +49,7 @@ wd_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":duration-exceeded-logger",
         "@capnp-cpp//src/kj",
         "@capnp-cpp//src/kj:kj-async",
     ],
@@ -199,6 +199,7 @@ wd_cc_library(
     name = "duration-exceeded-logger",
     hdrs = ["duration-exceeded-logger.h"],
     visibility = ["//visibility:public"],
+    deps = ["@capnp-cpp//src/kj"],
 )
 
 exports_files(["autogate.h"])


### PR DESCRIPTION
io-channels.h has a circular dependency with io due to its dependency on io-util.h (parsing the header using bazel is expected to fail accordingly). This means any source file depending on it would need to be in a bazel target depending on io to avoid missing header errors, even if the source file doesn't use io itself. Move it back into io in accordance with IWYU.

\- Fix dependencies for io:actor-id, util:duration-exceeded-logger
\- Fix duration-exceeded-logger.h appearing in two targets