### PR TITLE
Update streams readAllBytes impl to use BufferSource

### DIFF
--- a/src/workerd/api/blob.c++
+++ b/src/workerd/api/blob.c++
@@ -142,6 +142,11 @@ Blob::Blob(kj::Array<byte> data, kj::String type)
       data(ownData.get<kj::Array<kj::byte>>()),
       type(kj::mv(type)) {}
 
+Blob::Blob(jsg::Lock& js, jsg::BufferSource data, kj::String type)
+    : ownData(kj::mv(data)),
+      data(getPtr(ownData.get<jsg::BufferSource>())),
+      type(kj::mv(type)) {}
+
 Blob::Blob(jsg::Lock& js, kj::Array<byte> data, kj::String type)
     : ownData(wrap(js, kj::mv(data))),
       data(getPtr(ownData.get<jsg::BufferSource>())),

--- a/src/workerd/api/blob.h
+++ b/src/workerd/api/blob.h
@@ -14,6 +14,7 @@ class ReadableStream;
 // An implementation of the Web Platform Standard Blob API
 class Blob: public jsg::Object {
 public:
+  Blob(jsg::Lock& js, jsg::BufferSource data, kj::String type);
   Blob(jsg::Lock& js, kj::Array<byte> data, kj::String type);
   Blob(jsg::Ref<Blob> parent, kj::ArrayPtr<const byte> data, kj::String type);
 

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -356,7 +356,7 @@ public:
 
   kj::Maybe<jsg::Ref<ReadableStream>> getBody();
   bool getBodyUsed();
-  jsg::Promise<kj::Array<byte>> arrayBuffer(jsg::Lock& js);
+  jsg::Promise<jsg::BufferSource> arrayBuffer(jsg::Lock& js);
   jsg::Promise<jsg::BufferSource> bytes(jsg::Lock& js);
   jsg::Promise<kj::String> text(jsg::Lock& js);
   jsg::Promise<jsg::Ref<FormData>> formData(jsg::Lock& js);
@@ -501,7 +501,7 @@ public:
       jsg::Lock& js, kj::OneOf<jsg::Ref<Request>, kj::String> requestOrUrl,
       jsg::Optional<kj::OneOf<RequestInitializerDict, jsg::Ref<Request>>> requestInit);
 
-  using GetResult = kj::OneOf<jsg::Ref<ReadableStream>, kj::Array<byte>, kj::String, jsg::Value>;
+  using GetResult = kj::OneOf<jsg::Ref<ReadableStream>, jsg::BufferSource, kj::String, jsg::Value>;
 
   jsg::Promise<GetResult> get(jsg::Lock& js, kj::String url, jsg::Optional<kj::String> type);
 

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -1054,7 +1054,7 @@ void R2Bucket::HeadResult::writeHttpMetadata(jsg::Lock& js, Headers& headers) {
   }
 }
 
-jsg::Promise<kj::Array<kj::byte>> R2Bucket::GetResult::arrayBuffer(jsg::Lock& js) {
+jsg::Promise<jsg::BufferSource> R2Bucket::GetResult::arrayBuffer(jsg::Lock& js) {
   return js.evalNow([&] {
     JSG_REQUIRE(!body->isDisturbed(), TypeError,
         "Body has already been used. "
@@ -1094,7 +1094,7 @@ jsg::Promise<jsg::Value> R2Bucket::GetResult::json(jsg::Lock& js) {
 
 jsg::Promise<jsg::Ref<Blob>> R2Bucket::GetResult::blob(jsg::Lock& js) {
   // Copy-pasted from http.c++
-  return arrayBuffer(js).then(js, [this](jsg::Lock& js, kj::Array<byte> buffer) {
+  return arrayBuffer(js).then(js, [this](jsg::Lock& js, jsg::BufferSource buffer) {
     // httpMetadata can't be null because GetResult always populates it.
     kj::String contentType = KJ_REQUIRE_NONNULL(httpMetadata)
                                  .contentType.map([](const auto& str) {

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -346,7 +346,7 @@ public:
       return body->isDisturbed();
     }
 
-    jsg::Promise<kj::Array<kj::byte>> arrayBuffer(jsg::Lock& js);
+    jsg::Promise<jsg::BufferSource> arrayBuffer(jsg::Lock& js);
     jsg::Promise<kj::String> text(jsg::Lock& js);
     jsg::Promise<jsg::Value> json(jsg::Lock& js);
     jsg::Promise<jsg::Ref<Blob>> blob(jsg::Lock& js);

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -510,7 +510,7 @@ public:
   //
   // limit specifies an upper maximum bound on the number of bytes permitted to be read.
   // The promise will reject if the read will produce more bytes than the limit.
-  virtual jsg::Promise<kj::Array<byte>> readAllBytes(jsg::Lock& js, uint64_t limit) = 0;
+  virtual jsg::Promise<jsg::BufferSource> readAllBytes(jsg::Lock& js, uint64_t limit) = 0;
 
   // Fully consumes the ReadableStream. If the stream is already locked to a reader or
   // errored, the returned JS promise will reject. If the stream is already closed, the

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -96,7 +96,7 @@ public:
 
   void visitForGc(jsg::GcVisitor& visitor) override;
 
-  jsg::Promise<kj::Array<byte>> readAllBytes(jsg::Lock& js, uint64_t limit) override;
+  jsg::Promise<jsg::BufferSource> readAllBytes(jsg::Lock& js, uint64_t limit) override;
   jsg::Promise<kj::String> readAllText(jsg::Lock& js, uint64_t limit) override;
 
   kj::Maybe<uint64_t> tryGetLength(StreamEncoding encoding) override;

--- a/src/workerd/api/streams/standard-test.c++
+++ b/src/workerd/api/streams/standard-test.c++
@@ -242,8 +242,8 @@ KJ_TEST("ReadableStream read all bytes (value readable)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(
-        js, [&](jsg::Lock& js, kj::Array<kj::byte>&& text) {
-      KJ_ASSERT(text == "Hello, world!"_kjc.asBytes());
+        js, [&](jsg::Lock& js, jsg::BufferSource&& text) {
+      KJ_ASSERT(text.asArrayPtr() == "Hello, world!"_kjb);
       checked++;
     });
 
@@ -300,8 +300,8 @@ KJ_TEST("ReadableStream read all bytes (byte readable)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(
-        js, [&](jsg::Lock& js, kj::Array<kj::byte>&& text) {
-      KJ_ASSERT(text == "Hello, world!"_kjc.asBytes());
+        js, [&](jsg::Lock& js, jsg::BufferSource&& text) {
+      KJ_ASSERT(text.asArrayPtr() == "Hello, world!"_kjb);
       checked++;
     });
 
@@ -363,8 +363,8 @@ KJ_TEST("ReadableStream read all bytes (value readable, more reads)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(
-        js, [&](jsg::Lock& js, kj::Array<kj::byte>&& text) {
-      KJ_ASSERT(text == "Hello, world!"_kjc.asBytes());
+        js, [&](jsg::Lock& js, jsg::BufferSource&& text) {
+      KJ_ASSERT(text.asArrayPtr() == "Hello, world!"_kjb);
       checked++;
     });
 
@@ -427,8 +427,8 @@ KJ_TEST("ReadableStream read all bytes (byte readable, more reads)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(
-        js, [&](jsg::Lock& js, kj::Array<kj::byte>&& text) {
-      KJ_ASSERT(text == "Hello, world!"_kjc.asBytes());
+        js, [&](jsg::Lock& js, jsg::BufferSource&& text) {
+      KJ_ASSERT(text.asArrayPtr() == "Hello, world!"_kjb);
       checked++;
     });
 
@@ -495,13 +495,13 @@ KJ_TEST("ReadableStream read all bytes (byte readable, large data)") {
     // Starts a read loop of javascript promises.
     auto promise = rs->getController()
                        .readAllBytes(js, (BASE * 7) + 1)
-                       .then(js, [&](jsg::Lock& js, kj::Array<kj::byte>&& text) {
+                       .then(js, [&](jsg::Lock& js, jsg::BufferSource&& text) {
       kj::byte check[BASE * 7]{};
       kj::arrayPtr(check).first(BASE).fill('A');
       kj::arrayPtr(check).slice(BASE).first(BASE * 2).fill('B');
       kj::arrayPtr(check).slice(BASE * 3).fill('C');
       KJ_ASSERT(text.size() == BASE * 7);
-      KJ_ASSERT(check == text);
+      KJ_ASSERT(text.asArrayPtr() == check);
       checked++;
     });
 
@@ -563,7 +563,7 @@ KJ_TEST("ReadableStream read all bytes (value readable, wrong type)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, kj::Array<kj::byte>&& text) { KJ_UNREACHABLE; },
+        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
         [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) ==
           "TypeError: This ReadableStream did not return bytes.");
@@ -619,7 +619,7 @@ KJ_TEST("ReadableStream read all bytes (value readable, to many bytes)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, kj::Array<kj::byte>&& text) { KJ_UNREACHABLE; },
+        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
         [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) == "TypeError: Memory limit exceeded before EOF.");
       checked++;
@@ -675,7 +675,7 @@ KJ_TEST("ReadableStream read all bytes (byte readable, to many bytes)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, kj::Array<kj::byte>&& text) { KJ_UNREACHABLE; },
+        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
         [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) == "TypeError: Memory limit exceeded before EOF.");
       checked++;
@@ -718,7 +718,7 @@ KJ_TEST("ReadableStream read all bytes (byte readable, failed read)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, kj::Array<kj::byte>&& text) { KJ_UNREACHABLE; },
+        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
         [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) == "Error: boom");
       checked++;
@@ -760,7 +760,7 @@ KJ_TEST("ReadableStream read all bytes (value readable, failed read)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, kj::Array<kj::byte>&& text) { KJ_UNREACHABLE; },
+        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
         [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) == "Error: boom");
       checked++;
@@ -803,7 +803,7 @@ KJ_TEST("ReadableStream read all bytes (byte readable, failed start)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, kj::Array<kj::byte>&& text) { KJ_UNREACHABLE; },
+        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
         [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) == "Error: boom");
       checked++;
@@ -846,7 +846,7 @@ KJ_TEST("ReadableStream read all bytes (byte readable, failed start 2)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, kj::Array<kj::byte>&& text) { KJ_UNREACHABLE; },
+        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
         [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) == "Error: boom");
       checked++;

--- a/src/workerd/jsg/buffersource.h
+++ b/src/workerd/jsg/buffersource.h
@@ -384,6 +384,11 @@ public:
     return BufferSource(js, KJ_ASSERT_NONNULL(maybeBackingStore).getTypedViewSlice<T>(start, end));
   }
 
+  template <BufferSourceType T = v8::Uint8Array>
+  BufferSource getTypedView(jsg::Lock& js) {
+    return BufferSource(js, KJ_ASSERT_NONNULL(maybeBackingStore).getTypedView<T>());
+  }
+
   JSG_MEMORY_INFO(BufferSource) {
     tracker.trackField("handle", handle);
     KJ_IF_SOME(backing, maybeBackingStore) {


### PR DESCRIPTION
Have the streams `readAllBytes(...)` API use `jsg::BufferSource` instead of the `kj::Array<kj::byte>` type binding.