### PR TITLE
Improves error messages when fetch fails due to TLS errors.

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1962,10 +1962,11 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(jsg::Lock& js,
     return ioContext.awaitIo(js,
         AbortSignal::maybeCancelWrap(signal, kj::mv(KJ_ASSERT_NONNULL(nativeRequest).response))
             .catch_([](kj::Exception&& exception) -> kj::Promise<kj::HttpClient::Response> {
-      if (exception.getDescription().startsWith("invalid Content-Length header value")) {
-        return JSG_KJ_EXCEPTION(FAILED, Error, exception.getDescription());
-      } else if (exception.getDescription().contains("NOSENTRY script not found")) {
+      if (exception.getDescription().contains("NOSENTRY script not found")) {
         return JSG_KJ_EXCEPTION(FAILED, Error, "Worker not found.");
+      } else if (kj::str(exception.getFile()).startsWith("kj/")) {
+        return JSG_KJ_EXCEPTION(FAILED, Error,
+            kj::str("Internal error processing fetch: ", exception.getDescription()));
       }
       return kj::mv(exception);
     }),

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -507,12 +507,18 @@ kj::Maybe<jsg::Bundle::Reader> fetchPyodideBundle(
 
       auto req = client->request(kj::HttpMethod::GET, url.asPtr(), headers);
 
-      auto res = req.response.wait(io.waitScope);
-      auto body = res.body->readAllBytes().wait(io.waitScope);
+      try {
+        auto res = req.response.wait(io.waitScope);
+        auto body = res.body->readAllBytes().wait(io.waitScope);
 
-      writePyodideBundleFileToDisk(pyConfig.pyodideDiskCacheRoot, version, body);
+        writePyodideBundleFileToDisk(pyConfig.pyodideDiskCacheRoot, version, body);
 
-      pyConfig.pyodideBundleManager.setPyodideBundleData(kj::str(version), kj::mv(body));
+        pyConfig.pyodideBundleManager.setPyodideBundleData(kj::str(version), kj::mv(body));
+      } catch (kj::Exception exc) {
+        // Without this the user would just see "internal error" with no additional info about
+        // what went wrong. Explicitly raising here gives the user a friendlier error message.
+        JSG_FAIL_REQUIRE(Error, kj::str("Failed to fetch Pyodide bundle: ", exc.getDescription()));
+      }
     });
   }
 


### PR DESCRIPTION
When running `wrangler dev` (or running workerd locally directly), it is possible for `fetch` to fail with an "internal error". This can likely happen for many reasons, but in my case it was because I was using WARP and had misconfigured TLS certs. The error I was running into was this one: https://github.com/capnproto/capnproto/blob/6e071e34d88a8fc489638535899cd9d02e55bf76/c%2B%2B/src/kj/compat/tls.c%2B%2B#L221.

I noticed that we already have some custom logic to catch certain exceptions raised from kj and report them back to the user in a more friendly manner. What I'm curious about is why we don't simply report all errors. I think that matching on strings here is fragile, so I went for a bit of a compromise and changed the code to report any error that occurred in kj. But perhaps that will expose far more than we want.


### Test Plan

* Added a KJ_FAIL_REQUIRE to tls.c++ that always fails
* Ran workerd via `LLVM_SYMBOLIZER=llvm-symbolizer-14 bazel run --config=release @workerd//src/workerd/server:workerd --     serve $PWD/deps/workerd/samples/pyodide/config.capnp --experimental`
* Modified pyodide sample to remove python_external_bundle compat flag and to fetch inside the worker instead
* Re-ran workerd