### PR TITLE
Move `URL` out of `RequestInfo` to match DOM types

### DIFF
--- a/src/workerd/api/cache.h
+++ b/src/workerd/api/cache.h
@@ -72,11 +72,10 @@ public:
     JSG_METHOD(keys);
 
     JSG_TS_OVERRIDE({
-      delete(request: RequestInfo, options?: CacheQueryOptions): Promise<boolean>;
-      match(request: RequestInfo, options?: CacheQueryOptions): Promise<Response | undefined>;
-      put(request: RequestInfo, response: Response): Promise<void>;
+      delete(request: RequestInfo | URL, options?: CacheQueryOptions): Promise<boolean>;
+      match(request: RequestInfo | URL, options?: CacheQueryOptions): Promise<Response | undefined>;
+      put(request: RequestInfo | URL, response: Response): Promise<void>;
     });
-    // Use RequestInfo type alias to allow `URL`s as cache keys
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -827,7 +827,7 @@ public:
 
       structuredClone<T>(value: T, options?: StructuredSerializeOptions): T;
 
-      fetch(input: RequestInfo, init?: RequestInit<RequestInitCfProperties>): Promise<Response>;
+      fetch(input: RequestInfo | URL, init?: RequestInit<RequestInitCfProperties>): Promise<Response>;
     });
   }
 

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -598,7 +598,7 @@ public:
           ? Rpc.Provider<T, Reserved | "fetch" | "connect" | "queue" | "scheduled">
           : unknown
       ) & {
-        fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+        fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
         connect(address: SocketAddress | string, options?: SocketOptions): Socket;
         queue(queueName: string, messages: ServiceBindingQueueMessage[]): Promise<FetcherQueueResult>;
         scheduled(options?: FetcherScheduledOptions): Promise<FetcherScheduledResult>;
@@ -612,7 +612,7 @@ public:
           ? Rpc.Provider<T, Reserved | "fetch" | "connect">
           : unknown
       ) & {
-        fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+        fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
         connect(address: SocketAddress | string, options?: SocketOptions): Socket;
       });
     }
@@ -904,7 +904,7 @@ public:
 
     JSG_METHOD(clone);
 
-    JSG_TS_DEFINE(type RequestInfo<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> = Request<CfHostMetadata, Cf> | string | URL);
+    JSG_TS_DEFINE(type RequestInfo<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> = Request<CfHostMetadata, Cf> | string);
     // All type aliases get inlined when exporting RTTI, but this type alias is included by
     // the official TypeScript types, so users might be depending on it.
 
@@ -927,14 +927,14 @@ public:
       if(flags.getCacheOptionEnabled()) {
         JSG_READONLY_PROTOTYPE_PROPERTY(cache, getCache);
         JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
-          constructor(input: RequestInfo<CfProperties>, init?: RequestInit<Cf>);
+          constructor(input: RequestInfo<CfProperties> | URL, init?: RequestInit<Cf>);
           clone(): Request<CfHostMetadata, Cf>;
           cache?: "no-store";
           get cf(): Cf | undefined;
         });
       } else {
         JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
-          constructor(input: RequestInfo<CfProperties>, init?: RequestInit<Cf>);
+          constructor(input: RequestInfo<CfProperties> | URL, init?: RequestInit<Cf>);
           clone(): Request<CfHostMetadata, Cf>;
           get cf(): Cf | undefined;
         });
@@ -961,7 +961,7 @@ public:
       JSG_READONLY_INSTANCE_PROPERTY(keepalive, getKeepalive);
 
       JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
-        constructor(input: RequestInfo<CfProperties>, init?: RequestInit<Cf>);
+        constructor(input: RequestInfo<CfProperties> | URL, init?: RequestInit<Cf>);
         clone(): Request<CfHostMetadata, Cf>;
         readonly cf?: Cf;
       });

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -14,10 +14,13 @@ type TestType = {
   fieldString: string;
   fieldCallback: (p: string) => number;
   fieldBasicMap: Map<string, number>;
-  fieldComplexMap: Map<string, {
-    fieldString: string;
-    fieldCallback: (p: string) => number;
-  }>;
+  fieldComplexMap: Map<
+    string,
+    {
+      fieldString: string;
+      fieldCallback: (p: string) => number;
+    }
+  >;
   fieldSet: Set<string>;
   fieldSubLevel: {
     fieldString: string;
@@ -28,7 +31,7 @@ type TestType = {
 interface ABasicInterface {
   fieldString: string;
   fieldCallback: (p: string) => number;
-};
+}
 
 interface TestInterface extends ABasicInterface {
   fieldBasicMap: Map<string, number>;
@@ -39,11 +42,11 @@ interface TestInterface extends ABasicInterface {
     fieldCallback: (p: string) => number;
   };
   fieldSubLevelInterface: ABasicInterface;
-};
+}
 
 interface NonSerializableInterface {
   field: ReadableStream<string>;
-};
+}
 
 class TestCounter extends RpcTarget {
   constructor(private val = 0) {
@@ -220,10 +223,15 @@ class TestEntrypoint extends WorkerEntrypoint<Env> {
       fieldString: "a",
       fieldCallback: (p: string) => 1,
       fieldBasicMap: new Map([["b", 2]]),
-      fieldComplexMap: new Map([["c", {
-        fieldString: "d",
-        fieldCallback: (p: string) => 3,
-      }]]),
+      fieldComplexMap: new Map([
+        [
+          "c",
+          {
+            fieldString: "d",
+            fieldCallback: (p: string) => 3,
+          },
+        ],
+      ]),
       fieldSet: new Set(["e"]),
       fieldSubLevel: {
         fieldString: "f",
@@ -236,10 +244,15 @@ class TestEntrypoint extends WorkerEntrypoint<Env> {
       fieldString: "a",
       fieldCallback: (p: string) => 1,
       fieldBasicMap: new Map([["b", 2]]),
-      fieldComplexMap: new Map([["c", {
-        fieldString: "d",
-        fieldCallback: (p: string) => 3,
-      }]]),
+      fieldComplexMap: new Map([
+        [
+          "c",
+          {
+            fieldString: "d",
+            fieldCallback: (p: string) => 3,
+          },
+        ],
+      ]),
       fieldSet: new Set(["e"]),
       fieldSubLevelInline: {
         fieldString: "f",
@@ -374,7 +387,7 @@ export default <ExportedHandler<Env>>{
     // `toEqualTypeOf(...)` will fail if the function signature doesn't match *exactly*)
     {
       expectTypeOf(env.RPC_SERVICE.fetch).toEqualTypeOf<
-        (input: RequestInfo, init?: RequestInit) => Promise<Response>
+        (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
       >();
       expectTypeOf(env.RPC_SERVICE.connect).toEqualTypeOf<
         (address: SocketAddress | string, options?: SocketOptions) => Socket
@@ -391,7 +404,7 @@ export default <ExportedHandler<Env>>{
 
       const stub = env.RPC_OBJECT.get(env.RPC_OBJECT.newUniqueId());
       expectTypeOf(stub.fetch).toEqualTypeOf<
-        (input: RequestInfo, init?: RequestInit) => Promise<Response>
+        (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
       >();
       expectTypeOf(stub.connect).toEqualTypeOf<
         (address: SocketAddress | string, options?: SocketOptions) => Socket
@@ -520,10 +533,15 @@ export default <ExportedHandler<Env>>{
         RpcStub<(p: string) => number>
       >(); // stubified
       expectTypeOf(oType.fieldBasicMap).toEqualTypeOf<Map<string, number>>();
-      expectTypeOf(oType.fieldComplexMap).toEqualTypeOf<Map<string, {
-        fieldString: string;
-        fieldCallback: RpcStub<(p: string) => number>; // stubified
-      }>>();
+      expectTypeOf(oType.fieldComplexMap).toEqualTypeOf<
+        Map<
+          string,
+          {
+            fieldString: string;
+            fieldCallback: RpcStub<(p: string) => number>; // stubified
+          }
+        >
+      >();
       expectTypeOf(oType.fieldSet).toEqualTypeOf<Set<string>>();
       expectTypeOf(oType.fieldSubLevel.fieldString).toEqualTypeOf<string>();
       expectTypeOf(oType.fieldSubLevel.fieldCallback).toEqualTypeOf<
@@ -537,20 +555,31 @@ export default <ExportedHandler<Env>>{
       expectTypeOf(oInterface.fieldCallback).toEqualTypeOf<
         RpcStub<(p: string) => number>
       >(); // stubified
-      expectTypeOf(oInterface.fieldBasicMap).toEqualTypeOf<Map<string, number>>();
-      expectTypeOf(oInterface.fieldComplexMap).toEqualTypeOf<Map<string, {
-        fieldString: string;
-        fieldCallback: RpcStub<(p: string) => number>; // stubified
-      }>>();
+      expectTypeOf(oInterface.fieldBasicMap).toEqualTypeOf<
+        Map<string, number>
+      >();
+      expectTypeOf(oInterface.fieldComplexMap).toEqualTypeOf<
+        Map<
+          string,
+          {
+            fieldString: string;
+            fieldCallback: RpcStub<(p: string) => number>; // stubified
+          }
+        >
+      >();
       expectTypeOf(oInterface.fieldSet).toEqualTypeOf<Set<string>>();
-      expectTypeOf(oInterface.fieldSubLevelInline.fieldString).toEqualTypeOf<string>();
+      expectTypeOf(
+        oInterface.fieldSubLevelInline.fieldString
+      ).toEqualTypeOf<string>();
       expectTypeOf(oInterface.fieldSubLevelInline.fieldCallback).toEqualTypeOf<
         RpcStub<(p: string) => number>
       >(); // stubified
-      expectTypeOf(oInterface.fieldSubLevelInterface.fieldString).toEqualTypeOf<string>();
-      expectTypeOf(oInterface.fieldSubLevelInterface.fieldCallback).toEqualTypeOf<
-        RpcStub<(p: string) => number>
-      >(); // stubified
+      expectTypeOf(
+        oInterface.fieldSubLevelInterface.fieldString
+      ).toEqualTypeOf<string>();
+      expectTypeOf(
+        oInterface.fieldSubLevelInterface.fieldCallback
+      ).toEqualTypeOf<RpcStub<(p: string) => number>>(); // stubified
 
       expectTypeOf(s.nonSerializable1).returns.toBeNever();
       // Note: Since one of the object's members is non-serializable,


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workerd/issues/3090

To improve the typing situation when loading dom types in the same environment as workers-types, this PR moves the `URL` type out of `RequestInfo`, in favour of e.g. `fetch()` referencing `fetch(req: RequestInfo | URL)` directly. This matches how dom types are defined.

There should be no user-observable behaviour change for users using just workers-types, but this should improve the situation if e.g. the fetch definition comes from workers-types but the `RequestInfo` definition comes from dom types.