### PR TITLE
Remove cached column names from the statement cache

### DIFF
--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -165,12 +165,6 @@ void SqlStorage::Cursor::initColumnNames(jsg::Lock& js, State& stateRef) {
   //   `v8::Local`.
   KJ_IF_SOME(cached, stateRef.cachedStatement) {
     reusedCachedQuery = cached->useCount++ > 0;
-
-    KJ_IF_SOME(names, cached->cachedColumnNames) {
-      // Use cached copy.
-      columnNames = names.addRef(js);
-      return;
-    }
   }
 
   js.withinHandleScope([&]() {
@@ -180,11 +174,6 @@ void SqlStorage::Cursor::initColumnNames(jsg::Lock& js, State& stateRef) {
     }
     auto array = jsg::JsArray(v8::Array::New(js.v8Isolate, vec.data(), vec.size()));
     columnNames = jsg::JsRef<jsg::JsArray>(js, array);
-
-    KJ_IF_SOME(cached, stateRef.cachedStatement) {
-      // Cache for the next run.
-      cached->cachedColumnNames = jsg::JsRef<jsg::JsArray>(js, array);
-    }
   });
 }
 

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -85,7 +85,6 @@ private:
     jsg::HashableV8Ref<v8::String> query;
     size_t statementSize;
     SqliteDatabase::Statement statement;
-    kj::Maybe<jsg::JsRef<jsg::JsArray>> cachedColumnNames;  // initialized on first exec
     kj::ListLink<CachedStatement> lruLink;
     uint useCount = 0;
 


### PR DESCRIPTION
In production, we saw the assertion in
SqlStorage::Cursor::rowIteratorNext fail:

```
failed: expected names.size() == values.size() [9 == 10];
```

The assertion fires when the set of values in returned by the next row in the statement (`values`) doesn’t match the set of column names when we first compiled the statement.  This can happen if the tables that the statement refers to have been altered to have a different number of columns after the statement was compiled and cached.

Compiled SQLite statements themselves become invalid when the schema of the tables they reference change.  However, if you use `sqlite3_prepare_v2` or later (and we do because we use `sqlite3_prepare_v3`!), SQLite will automatically recompile the statement against the current schema when SQLite notices the statement is out of date.

It would be better if we could figure out how to detect recompilation and fix the column name cache, but doing so looks like a big change.  Instead, this commit removes the column name cache, which isn’t a huge deal.

(NOTE: there’s still a bug where if someone changes the schema while iterating through the results of a query, we could hit the same error. But… you shouldn’t be doing that.)