### PR TITLE
Add addBuiltinModule from an instance of a template type

### DIFF
--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -541,11 +541,16 @@ public:
 
   template <typename T>
   void addBuiltinModule(kj::StringPtr specifier, Type type = Type::BUILTIN) {
+    addBuiltinModule(specifier, alloc<T>(), type);
+  }
+
+  template <typename T>
+  void addBuiltinModule(kj::StringPtr specifier, Ref<T> object, Type type = Type::BUILTIN) {
     addBuiltinModule(specifier,
-        [specifier = kj::str(specifier)](
-            Lock& js, ResolveMethod, kj::Maybe<const kj::Path&>&) -> kj::Maybe<ModuleInfo> {
+        [specifier = kj::str(specifier), object = kj::mv(object)](
+            Lock& js, ResolveMethod, kj::Maybe<const kj::Path&>&) mutable -> kj::Maybe<ModuleInfo> {
       auto& wrapper = TypeWrapper::from(js.v8Isolate);
-      auto wrap = wrapper.wrap(js.v8Context(), kj::none, alloc<T>());
+      auto wrap = wrapper.wrap(js.v8Context(), kj::none, kj::mv(object));
       return kj::Maybe(ModuleInfo(js, specifier, kj::none, ObjectModuleInfo(js, wrap)));
     },
         type);


### PR DESCRIPTION
We can use `addBuiltinModule<T>(spec, type)` to add a builtin module, but it imposes the restriction that the instance of `T` we want needs to be made with a zero argument constructor. In a lot of use cases, we want to create it with a static method or a constructor that takes args. So this adds a new overload that takes the object we want to use as the builtinModule. The original version is then implemented in terms of the new version.