### PR TITLE
[CI] Fix macOS release configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,19 +57,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-15, windows-2022]
+        target-arch: [ X64 ]
         include:
           - os-name: linux
             os: ubuntu-20.04
             bazel-config: release_linux
-            target-arch: X64
           # Based on runner availability, we build both Apple Silicon and (cross-compiled) x86
           # release binaries on the macos-15 runner.
-          - os-name: macOS
+          - os-name: macOS-x64
             # This configuration is used for cross-compiling – macos-15 is Apple Silicon-based but
             # we use it to compile the x64 release.
             os: macos-15
             bazel-config: release_macos
-            target-arch: X64
           - os-name: macOS-arm64
             os: macos-15
             bazel-config: release_macos
@@ -77,7 +76,6 @@ jobs:
           - os-name: windows
             os: windows-2022
             bazel-config: release_windows
-            target-arch: X64
     runs-on: ${{ matrix.os }}
     name: build (${{ matrix.os-name }})
     steps:
@@ -113,7 +111,7 @@ jobs:
           # Enable lld identical code folding to significantly reduce binary size.
           echo "build:macos --config=macos_lld_icf" >> .bazelrc
       - name: Setup macOS (cross)
-        if: ${{ matrix.os-name }} == 'macOS'
+        if: ${{ matrix.os-name }} == 'macOS-x64'
         run: |
           # Cross-compile so that we can use the latest Xcode version for the Intel Mac binary
           echo "build:macos --config=macos-cross-x86_64" >> .bazelrc


### PR DESCRIPTION
The macOS-ARM64 configuration would overwrite the macOS-X64 definition based on how matrix includes work since target-arch is not part of the original matrix configuration. This way we now have macOS-ARM64, but are suddenly missing macOS-X64. Fix this by adding target-arch to the default matrix configuration so that a new configuration is created with the `target-arch: ARM64` directive.

=================

See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#expanding-or-adding-matrix-configurations for documentation/an example on how the include rules work