### PR TITLE
Add substring (alias of substr) into ALLOWED_SQLITE_FUNCTIONS

### DIFF
--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -225,6 +225,7 @@ static constexpr kj::StringPtr ALLOWED_SQLITE_FUNCTIONS[] = {
   // "sqlite_source_id"_kj,
   // "sqlite_version"_kj,
   "substr"_kj,
+  "substring"_kj,
   "total_changes"_kj,
   "trim"_kj,
   "typeof"_kj,


### PR DESCRIPTION
Adds `substring` as an allowed function, which just aliases to `substr`. I ran into this when testing some SQLite queries locally and then porting them to D1.

> "substring()" is an alias for "substr()" beginning with SQLite version 3.34.
https://www.sqlite.org/lang_corefunc.html#substr