### PR TITLE
[CI] Fix architecture for macOS releases

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -343,6 +343,10 @@ build:release_macos --config=release_unix
 build:release_macos --linkopt="-Wl,-no_data_in_code_info"
 build:release_macos --linkopt="-Wl,-no_function_starts"
 
+# Cross-compiled release build for x86_64.
+build:release_macos_cross_x86_64 --config=release_macos
+build:release_macos_cross_x86_64 --config=macos-cross-x86_64
+
 # On macOS, optionally compile using LLD (19 or higher is compatible with the default flags added by
 # apple_support). Requires Homebrew's lld package to be installed and symlinked into /usr/local/bin.
 # This is less CPU intensive than the system linker, but also slightly slower in terms of wall time

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
             # This configuration is used for cross-compiling – macos-15 is Apple Silicon-based but
             # we use it to compile the x64 release.
             os: macos-15
-            bazel-config: release_macos
+            bazel-config: release_macos_cross_x86_64
           - os-name: macOS-arm64
             os: macos-15
             bazel-config: release_macos
@@ -110,11 +110,6 @@ jobs:
           sudo ln -s -f $(brew --prefix lld)/bin/ld64.lld /usr/local/bin/ld64.lld
           # Enable lld identical code folding to significantly reduce binary size.
           echo "build:macos --config=macos_lld_icf" >> .bazelrc
-      - name: Setup macOS (cross)
-        if: ${{ matrix.os-name }} == 'macOS-x64'
-        run: |
-          # Cross-compile so that we can use the latest Xcode version for the Intel Mac binary
-          echo "build:macos --config=macos-cross-x86_64" >> .bazelrc
       - name: Setup Windows
         if: runner.os == 'Windows'
         run: |


### PR DESCRIPTION
We now have two separate macOS release builds, but the macOS-cross setup got applied to all release jobs, apparently due to a malformed if condition. Avoid having such a condition entirely.