### PR TITLE
[CI] Use GitHub Actions-based binary for Apple Silicon releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,16 +143,17 @@ jobs:
     strategy:
       matrix:
         arch: [linux-64, darwin-64, windows-64]
+        # This variable itself is unused, but allows us to set up two macOS builds. arm64 builds for
+        # other platforms will be supported later, then we'll list both architectures here.
+        cpu: [ X64 ]
         include:
           - arch: linux-64
             name: Linux-X64
           - arch: darwin-64
             name: macOS-X64
-          # TODO(soon): After verifying that Apple Silicon artifacts are being built and uploaded
-          # properly, decommission the internal build and add them to the tagged release instead of
-          # using the internal build.
-          # - arch: darwin-arm64
-          #   name: macOS-ARM64
+          - arch: darwin-arm64
+            name: macOS-ARM64
+            cpu: ARM64
           - arch: windows-64
             name: Windows-X64
     steps:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To build `workerd`, you need:
   * LLD 16+ (e.g. package `lld-16`).
   * `python3`, `python3-distutils`, and `tcl8.6`
 * On macOS:
-  * Xcode 15 installation (available on macOS 13 and higher). **Full Xcode is required**, the Xcode command line tools alone are **not sufficient** for building.
+  * Xcode 16 installation (available on macOS 14 and higher). **Full Xcode is required**, the Xcode command line tools alone are **not sufficient** for building.
   * Homebrew installed `tcl-tk` package (provides Tcl 8.6)
 * On Windows:
   * Install [App Installer](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget)


### PR DESCRIPTION
With #3135 Apple Silicon release artifacts are being created properly, add them to tagged releases too.
Xcode 16 appears to be required to build V8 starting with the 13.1 release, update the README to reflect this.