### PR TITLE
Half-indent public: and private:

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -40,6 +40,11 @@ IndentCaseLabels: true
 PointerAlignment: Left
 DerivePointerAlignment: true
 
+# Move public and private in by a half-indentation.  This makes
+# diffs and Github code reviews more readable by letting you
+# see which class the diff snippet is part of.
+AccessModifierOffset: -1
+
 # Really "Attach" but empty braces aren't split.
 BreakBeforeBraces: Custom
 BraceWrapping:

--- a/src/workerd/api/actor-state-iocontext-test.c++
+++ b/src/workerd/api/actor-state-iocontext-test.c++
@@ -22,7 +22,7 @@ bool contains(kj::StringPtr haystack, kj::StringPtr needle) {
 }
 
 class MockActorId: public ActorIdFactory::ActorId {
-public:
+ public:
   MockActorId(kj::String id): id(kj::mv(id)) {}
   kj::String toString() const override {
     return kj::str("MockActorId<", id, ">");
@@ -42,7 +42,7 @@ public:
 
   virtual ~MockActorId() {};
 
-private:
+ private:
   kj::String id;
 };
 

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -31,7 +31,7 @@ jsg::JsValue deserializeV8Value(
 // Common implementation of DurableObjectStorage and DurableObjectTransaction. This class is
 // designed to be used as a mixin.
 class DurableObjectStorageOperations {
-public:
+ public:
   struct GetOptions {
     jsg::Optional<bool> allowConcurrency;
     jsg::Optional<bool> noCache;
@@ -121,7 +121,7 @@ public:
       jsg::Lock& js, kj::Date scheduledTime, jsg::Optional<SetAlarmOptions> options);
   jsg::Promise<void> deleteAlarm(jsg::Lock& js, jsg::Optional<SetAlarmOptions> options);
 
-protected:
+ protected:
   typedef kj::StringPtr OpName;
   static constexpr OpName OP_GET = "get()"_kj;
   static constexpr OpName OP_GET_ALARM = "getAlarm()"_kj;
@@ -153,7 +153,7 @@ protected:
     return kj::mv(options);
   }
 
-private:
+ private:
   jsg::Promise<jsg::JsRef<jsg::JsValue>> getOne(
       jsg::Lock& js, kj::String key, const GetOptions& options);
   jsg::Promise<jsg::JsRef<jsg::JsValue>> getMultiple(
@@ -172,7 +172,7 @@ private:
 class DurableObjectTransaction;
 
 class DurableObjectStorage: public jsg::Object, public DurableObjectStorageOperations {
-public:
+ public:
   DurableObjectStorage(IoPtr<ActorCacheInterface> cache, bool enableSql)
       : cache(kj::mv(cache)),
         enableSql(enableSql) {}
@@ -285,21 +285,21 @@ public:
     });
   }
 
-protected:
+ protected:
   ActorCacheOps& getCache(kj::StringPtr op) override;
 
   bool useDirectIo() override {
     return false;
   }
 
-private:
+ private:
   IoPtr<ActorCacheInterface> cache;
   bool enableSql;
   uint transactionSyncDepth = 0;
 };
 
 class DurableObjectTransaction final: public jsg::Object, public DurableObjectStorageOperations {
-public:
+ public:
   DurableObjectTransaction(IoOwn<ActorCacheInterface::Transaction> cacheTxn)
       : cacheTxn(kj::mv(cacheTxn)) {}
 
@@ -343,14 +343,14 @@ public:
     });
   }
 
-protected:
+ protected:
   ActorCacheOps& getCache(kj::StringPtr op) override;
 
   bool useDirectIo() override {
     return false;
   }
 
-private:
+ private:
   // Becomes null when committed or rolled back.
   kj::Maybe<IoOwn<ActorCacheInterface::Transaction>> cacheTxn;
 
@@ -364,7 +364,7 @@ private:
 // used for colo-local namespaces.
 class ActorState: public jsg::Object {
   // TODO(cleanup): Remove getPersistent method that isn't supported for colo-local actors anymore.
-public:
+ public:
   ActorState(Worker::Actor::Id actorId,
       kj::Maybe<jsg::JsRef<jsg::JsValue>> transient,
       kj::Maybe<jsg::Ref<DurableObjectStorage>> persistent);
@@ -402,14 +402,14 @@ public:
     tracker.trackField("persistent", persistent);
   }
 
-private:
+ private:
   Worker::Actor::Id id;
   kj::Maybe<jsg::JsRef<jsg::JsValue>> transient;
   kj::Maybe<jsg::Ref<DurableObjectStorage>> persistent;
 };
 
 class WebSocketRequestResponsePair: public jsg::Object {
-public:
+ public:
   WebSocketRequestResponsePair(kj::String request, kj::String response)
       : request(kj::mv(request)),
         response(kj::mv(response)) {};
@@ -436,14 +436,14 @@ public:
     tracker.trackField("response", response);
   }
 
-private:
+ private:
   kj::String request;
   kj::String response;
 };
 
 // The type passed as the first parameter to durable object class's constructor.
 class DurableObjectState: public jsg::Object {
-public:
+ public:
   DurableObjectState(Worker::Actor::Id actorId, kj::Maybe<jsg::Ref<DurableObjectStorage>> storage);
 
   void waitUntil(kj::Promise<void> promise);
@@ -553,7 +553,7 @@ public:
     tracker.trackField("storage", storage);
   }
 
-private:
+ private:
   Worker::Actor::Id id;
   kj::Maybe<jsg::Ref<DurableObjectStorage>> storage;
 

--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -16,7 +16,7 @@
 namespace workerd::api {
 
 class LocalActorOutgoingFactory final: public Fetcher::OutgoingFactory {
-public:
+ public:
   LocalActorOutgoingFactory(uint channelId, kj::String actorId)
       : channelId(channelId),
         actorId(kj::mv(actorId)) {}
@@ -43,14 +43,14 @@ public:
           .operationName = kj::ConstString("actor_subrequest"_kjc)}));
   }
 
-private:
+ private:
   uint channelId;
   kj::String actorId;
   kj::Maybe<kj::Own<IoChannelFactory::ActorChannel>> actorChannel;
 };
 
 class GlobalActorOutgoingFactory final: public Fetcher::OutgoingFactory {
-public:
+ public:
   GlobalActorOutgoingFactory(uint channelId,
       jsg::Ref<DurableObjectId> id,
       kj::Maybe<kj::String> locationHint,
@@ -85,7 +85,7 @@ public:
           .operationName = kj::ConstString("actor_subrequest"_kjc)}));
   }
 
-private:
+ private:
   uint channelId;
   jsg::Ref<DurableObjectId> id;
   kj::Maybe<kj::String> locationHint;

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -26,7 +26,7 @@ namespace workerd::api {
 
 // A capability to an ephemeral Actor namespace.
 class ColoLocalActorNamespace: public jsg::Object {
-public:
+ public:
   ColoLocalActorNamespace(uint channel): channel(channel) {}
 
   jsg::Ref<Fetcher> get(kj::String actorId);
@@ -35,7 +35,7 @@ public:
     JSG_METHOD(get);
   }
 
-private:
+ private:
   uint channel;
 };
 
@@ -43,7 +43,7 @@ class DurableObjectNamespace;
 
 // DurableObjectId type seen by JavaScript.
 class DurableObjectId: public jsg::Object {
-public:
+ public:
   DurableObjectId(kj::Own<ActorIdFactory::ActorId> id): id(kj::mv(id)) {}
 
   const ActorIdFactory::ActorId& getInner() {
@@ -75,7 +75,7 @@ public:
     tracker.trackFieldWithSize("id", sizeof(ActorIdFactory::ActorId));
   }
 
-private:
+ private:
   kj::Own<ActorIdFactory::ActorId> id;
 
   friend class DurableObjectNamespace;
@@ -84,7 +84,7 @@ private:
 // Stub object used to send messages to a remote durable object.
 class DurableObject final: public Fetcher {
 
-public:
+ public:
   DurableObject(jsg::Ref<DurableObjectId> id,
       IoOwn<OutgoingFactory> outgoingFactory,
       RequiresHostAndProtocol requiresHost)
@@ -127,7 +127,7 @@ public:
     tracker.trackField("id", id);
   }
 
-private:
+ private:
   jsg::Ref<DurableObjectId> id;
 
   void visitForGc(jsg::GcVisitor& visitor) {
@@ -138,7 +138,7 @@ private:
 // Global durable object class binding type.
 class DurableObjectNamespace: public jsg::Object {
 
-public:
+ public:
   DurableObjectNamespace(uint channel, kj::Own<ActorIdFactory> idFactory)
       : channel(channel),
         idFactory(kj::mv(idFactory)) {}
@@ -219,7 +219,7 @@ public:
     }
   }
 
-private:
+ private:
   uint channel;
   kj::Own<ActorIdFactory> idFactory;
 

--- a/src/workerd/api/analytics-engine.h
+++ b/src/workerd/api/analytics-engine.h
@@ -26,7 +26,7 @@ namespace workerd::api {
 //
 // https://blog.cloudflare.com/workers-analytics-engine/
 class AnalyticsEngine: public jsg::Object {
-public:
+ public:
   explicit AnalyticsEngine(
       uint logfwdrChannel, kj::String dataset, int64_t version, uint32_t ownerId)
       : logfwdrChannel(logfwdrChannel),
@@ -66,7 +66,7 @@ public:
     tracker.trackField("dataset", dataset);
   }
 
-private:
+ private:
   double millisToNanos(double m) {
     return m * 1000000;
   }

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -24,7 +24,7 @@ class ActorState;
 
 // An implementation of the Web Platform Standard Event API
 class Event: public jsg::Object {
-public:
+ public:
   struct Init final {
     jsg::Optional<bool> bubbles;
     jsg::Optional<bool> cancelable;
@@ -188,7 +188,7 @@ public:
     tracker.trackField("target", target);
   }
 
-private:
+ private:
   kj::StringPtr type;
   kj::String ownType;
   Init init;
@@ -205,7 +205,7 @@ private:
 };
 
 class ExtendableEvent: public Event {
-public:
+ public:
   using Event::Event;
 
   // While ExtendableEvent is defined by the spec to be constructable, there's really not a
@@ -232,7 +232,7 @@ public:
 
 // An implementation of the Web Platform Standard CustomEvent API
 class CustomEvent: public Event {
-public:
+ public:
   struct CustomEventInit final {
     jsg::Optional<bool> bubbles;
     jsg::Optional<bool> cancelable;
@@ -262,13 +262,13 @@ public:
     tracker.trackField("detail", detail);
   }
 
-private:
+ private:
   jsg::Optional<jsg::JsRef<jsg::JsValue>> detail;
 };
 
 // An implementation of the Web Platform Standard EventTarget API
 class EventTarget: public jsg::Object {
-public:
+ public:
   ~EventTarget() noexcept(false);
 
   size_t getHandlerCount(kj::StringPtr type) const;
@@ -362,10 +362,10 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   // RAII-style listener that can be attached to an EventTarget.
   class NativeHandler {
-  public:
+   public:
     using Signature = void(jsg::Ref<Event>);
     NativeHandler(jsg::Lock& js,
         EventTarget& target,
@@ -381,7 +381,7 @@ private:
 
     void visitForGc(jsg::GcVisitor& visitor);
 
-  private:
+   private:
     void detach();
 
     kj::String type;
@@ -504,7 +504,7 @@ private:
 
 // An implementation of the Web Platform Standard AbortSignal API
 class AbortSignal final: public EventTarget {
-public:
+ public:
   enum class Flag { NONE, NEVER_ABORTS };
 
   AbortSignal(kj::Maybe<kj::Exception> exception = kj::none,
@@ -596,7 +596,7 @@ public:
     tracker.trackField("reason", reason);
   }
 
-private:
+ private:
   IoOwn<RefcountedCanceler> canceler;
   Flag flag;
   kj::Maybe<jsg::JsRef<jsg::JsValue>> reason;
@@ -609,7 +609,7 @@ private:
 
 // An implementation of the Web Platform Standard AbortController API
 class AbortController final: public jsg::Object {
-public:
+ public:
   explicit AbortController(): signal(jsg::alloc<AbortSignal>()) {}
 
   static jsg::Ref<AbortController> constructor() {
@@ -635,7 +635,7 @@ public:
     tracker.trackField("signal", signal);
   }
 
-private:
+ private:
   jsg::Ref<AbortSignal> signal;
 
   void visitForGc(jsg::GcVisitor& visitor) {
@@ -649,7 +649,7 @@ private:
 // to be global and provides task scheduling APIs. We currently only implement
 // a subset of the API that is being defined.
 class Scheduler final: public jsg::Object {
-public:
+ public:
   struct WaitOptions {
     jsg::Optional<jsg::Ref<AbortSignal>> signal;
     JSG_STRUCT(signal);
@@ -664,7 +664,7 @@ public:
     JSG_METHOD(wait);
   }
 
-private:
+ private:
 };
 
 #define EW_BASICS_ISOLATE_TYPES                                                                    \

--- a/src/workerd/api/blob.c++
+++ b/src/workerd/api/blob.c++
@@ -230,7 +230,7 @@ jsg::Promise<kj::String> Blob::text(jsg::Lock& js) {
 }
 
 class Blob::BlobInputStream final: public ReadableStreamSource {
-public:
+ public:
   BlobInputStream(jsg::Ref<Blob> blob): unread(blob->data), blob(kj::mv(blob)) {}
 
   // Attempt to read a maximum of maxBytes from the remaining unread content of the blob
@@ -277,7 +277,7 @@ public:
     co_return;
   }
 
-private:
+ private:
   kj::ArrayPtr<const byte> unread;
   jsg::Ref<Blob> blob;
 };

--- a/src/workerd/api/blob.h
+++ b/src/workerd/api/blob.h
@@ -13,7 +13,7 @@ class ReadableStream;
 
 // An implementation of the Web Platform Standard Blob API
 class Blob: public jsg::Object {
-public:
+ public:
   Blob(jsg::Lock& js, jsg::BufferSource data, kj::String type);
   Blob(jsg::Lock& js, kj::Array<byte> data, kj::String type);
   Blob(jsg::Ref<Blob> parent, kj::ArrayPtr<const byte> data, kj::String type);
@@ -85,7 +85,7 @@ public:
     tracker.trackField("type", type);
   }
 
-private:
+ private:
   Blob(kj::Array<byte> data, kj::String type);
 
   // Using a jsg::BufferSource to store the ownData allows the associated isolate
@@ -115,7 +115,7 @@ private:
 
 // An implementation of the Web Platform Standard File API
 class File: public Blob {
-public:
+ public:
   // This constructor variation is used when a File is created outside of the isolate
   // lock. This is currently only the case when parsing FormData outside of running
   // JavaScript (such as in the internal fiddle service).
@@ -160,7 +160,7 @@ public:
     tracker.trackField("name", name);
   }
 
-private:
+ private:
   kj::String name;
   double lastModified;
 };

--- a/src/workerd/api/cache.c++
+++ b/src/workerd/api/cache.c++
@@ -157,7 +157,7 @@ jsg::Promise<void> Cache::put(jsg::Lock& js,
   // serialize the response (headers + body) in the format needed to serve as the payload of
   // our cache PUT request.
   class ResponseSerializer final: public kj::HttpService::Response {
-  public:
+   public:
     struct Payload {
       // The serialized form of the response to be cached. This stream itself contains a full
       // HTTP response, with headers and body, representing the content of jsResponse to be written
@@ -175,7 +175,7 @@ jsg::Promise<void> Cache::put(jsg::Lock& js,
       return KJ_ASSERT_NONNULL(kj::mv(payload));
     }
 
-  private:
+   private:
     kj::Own<kj::AsyncOutputStream> send(uint statusCode,
         kj::StringPtr statusText,
         const kj::HttpHeaders& headers,

--- a/src/workerd/api/cache.h
+++ b/src/workerd/api/cache.h
@@ -35,7 +35,7 @@ struct CacheQueryOptions {
 };
 
 class Cache: public jsg::Object {
-public:
+ public:
   explicit Cache(kj::Maybe<kj::String> cacheName);
 
   jsg::Unimplemented add(Request::Info request);
@@ -82,7 +82,7 @@ public:
     tracker.trackField("cacheName", cacheName);
   }
 
-private:
+ private:
   kj::Maybe<kj::String> cacheName;
 
   kj::Own<kj::HttpClient> getHttpClient(
@@ -93,7 +93,7 @@ private:
 // CacheStorage
 
 class CacheStorage: public jsg::Object {
-public:
+ public:
   CacheStorage();
 
   jsg::Promise<jsg::Ref<Cache>> open(jsg::Lock& js, kj::String cacheName);
@@ -131,7 +131,7 @@ public:
     tracker.trackField("default", default_);
   }
 
-private:
+ private:
   jsg::Ref<Cache> default_;
 };
 

--- a/src/workerd/api/cf-property.h
+++ b/src/workerd/api/cf-property.h
@@ -14,7 +14,7 @@ namespace workerd::api {
 // The string header is parsed on demand and the parsed value cached.
 class CfProperty {
 
-public:
+ public:
   KJ_DISALLOW_COPY(CfProperty);
 
   explicit CfProperty() {}
@@ -55,7 +55,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::Maybe<kj::OneOf<kj::String, jsg::JsRef<jsg::JsObject>>> value;
 };
 

--- a/src/workerd/api/crypto/aes.c++
+++ b/src/workerd/api/crypto/aes.c++
@@ -108,7 +108,7 @@ int decryptFinalHelper(kj::StringPtr algorithm,
 // The base key is used to avoid repeating the JWK export logic. It also happens to simplify the
 // concrete implementations to only define encrypt/decrypt.
 class AesKeyBase: public CryptoKey::Impl {
-public:
+ public:
   explicit AesKeyBase(kj::Array<kj::byte> keyData,
       CryptoKey::AesKeyAlgorithm keyAlgorithm,
       bool extractable,
@@ -117,7 +117,7 @@ public:
         keyData(kj::mv(keyData)),
         keyAlgorithm(kj::mv(keyAlgorithm)) {}
 
-protected:
+ protected:
   kj::StringPtr getAlgorithmName() const override final {
     // AesKeyAlgorithm is constructed from normalizedName which points into the static constant
     // defined in crypto.c++ for lookup.
@@ -144,7 +144,7 @@ protected:
     tracker.trackField("keyAlgorithm", keyAlgorithm);
   }
 
-private:
+ private:
   CryptoKey::AlgorithmVariant getAlgorithm(jsg::Lock& js) const override final {
     return keyAlgorithm;
   }
@@ -187,20 +187,20 @@ private:
     return kj::heapArray(keyData.asPtr());
   }
 
-protected:
+ protected:
   ZeroOnFree keyData;
   CryptoKey::AesKeyAlgorithm keyAlgorithm;
 };
 
 class AesGcmKey final: public AesKeyBase {
-public:
+ public:
   explicit AesGcmKey(kj::Array<kj::byte> keyData,
       CryptoKey::AesKeyAlgorithm keyAlgorithm,
       bool extractable,
       CryptoKeyUsageSet usages)
       : AesKeyBase(kj::mv(keyData), kj::mv(keyAlgorithm), extractable, usages) {}
 
-private:
+ private:
   kj::Array<kj::byte> encrypt(SubtleCrypto::EncryptAlgorithm&& algorithm,
       kj::ArrayPtr<const kj::byte> plainText) const override {
     kj::ArrayPtr<kj::byte> iv =
@@ -330,14 +330,14 @@ private:
 };
 
 class AesCbcKey final: public AesKeyBase {
-public:
+ public:
   explicit AesCbcKey(kj::Array<kj::byte> keyData,
       CryptoKey::AesKeyAlgorithm keyAlgorithm,
       bool extractable,
       CryptoKeyUsageSet usages)
       : AesKeyBase(kj::mv(keyData), kj::mv(keyAlgorithm), extractable, usages) {}
 
-private:
+ private:
   kj::Array<kj::byte> encrypt(SubtleCrypto::EncryptAlgorithm&& algorithm,
       kj::ArrayPtr<const kj::byte> plainText) const override {
     kj::ArrayPtr<kj::byte> iv =
@@ -415,7 +415,7 @@ private:
 class AesCtrKey final: public AesKeyBase {
   static constexpr size_t expectedCounterByteSize = 16;
 
-public:
+ public:
   explicit AesCtrKey(kj::Array<kj::byte> keyData,
       CryptoKey::AesKeyAlgorithm keyAlgorithm,
       bool extractable,
@@ -432,7 +432,7 @@ public:
     return encryptOrDecrypt(kj::mv(algorithm), cipherText);
   }
 
-protected:
+ protected:
   static const EVP_CIPHER& lookupAesType(size_t keyLengthBytes) {
     switch (keyLengthBytes) {
       case 16:
@@ -533,7 +533,7 @@ protected:
     return result.releaseAsArray();
   }
 
-private:
+ private:
   kj::Own<BIGNUM> getCounter(
       kj::ArrayPtr<kj::byte> counterBlock, const unsigned counterBitLength) const {
     // See GetCounter from https://chromium.googlesource.com/chromium/src/+/refs/tags/91.0.4458.2/components/webcrypto/algorithms/aes_ctr.cc#86
@@ -613,7 +613,7 @@ private:
 };
 
 class AesKwKey final: public AesKeyBase {
-public:
+ public:
   explicit AesKwKey(kj::Array<kj::byte> keyData,
       CryptoKey::AesKeyAlgorithm keyAlgorithm,
       bool extractable,

--- a/src/workerd/api/crypto/crypto.h
+++ b/src/workerd/api/crypto/crypto.h
@@ -26,7 +26,7 @@ class EllipticKey;
 //
 // https://w3c.github.io/webcrypto/#dfn-RecognizedKeyUsage
 class CryptoKeyUsageSet {
-public:
+ public:
   static constexpr CryptoKeyUsageSet encrypt() {
     return 1 << 0;
   }
@@ -125,7 +125,7 @@ public:
     return strings.finish();
   }
 
-private:
+ private:
   constexpr CryptoKeyUsageSet(uint8_t set): set(set) {}
   uint8_t set;
 };
@@ -137,7 +137,7 @@ private:
 // `importKey()`, `generateKey()`, or `deriveKey()` methods. The user can then use the object by
 // passing it as a parameter to other SubtleCrypto methods.
 class CryptoKey: public jsg::Object {
-public:
+ public:
   // KeyAlgorithm dictionaries
   //
   // These dictionaries implement CryptoKey's `algorithm` property. They allow user code to inspect
@@ -322,7 +322,7 @@ public:
   bool verifyX509Public(const X509* x509) const;
   bool verifyX509Private(const X509* x509) const;
 
-private:
+ private:
   kj::Own<Impl> impl;
 
   friend class SubtleCrypto;
@@ -339,7 +339,7 @@ struct CryptoKeyPair {
 };
 
 class SubtleCrypto: public jsg::Object {
-public:
+ public:
   // Algorithm dictionaries
   //
   // Every method of SubtleCrypto except `exportKey()` takes an `algorithm` parameter, usually as the
@@ -630,7 +630,7 @@ public:
 // a hash digest from streaming data. It combines Web Crypto concepts into a
 // WritableStream and is compatible with both APIs.
 class DigestStream: public WritableStream {
-public:
+ public:
   using DigestContextPtr = kj::Own<EVP_MD_CTX>;
   using Algorithm = kj::OneOf<kj::String, SubtleCrypto::HashAlgorithm>;
 
@@ -664,7 +664,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   static DigestContextPtr initContext(SubtleCrypto::HashAlgorithm& algorithm);
 
   struct Ready {
@@ -694,7 +694,7 @@ private:
 // Implements the Crypto interface as prescribed by:
 // https://www.w3.org/TR/WebCryptoAPI/#crypto-interface
 class Crypto: public jsg::Object {
-public:
+ public:
   jsg::BufferSource getRandomValues(jsg::BufferSource buffer);
 
   kj::String randomUUID();
@@ -737,7 +737,7 @@ public:
     tracker.trackField("subtle", subtle);
   }
 
-private:
+ private:
   jsg::Ref<SubtleCrypto> subtle = jsg::alloc<SubtleCrypto>();
 };
 

--- a/src/workerd/api/crypto/dh.h
+++ b/src/workerd/api/crypto/dh.h
@@ -11,7 +11,7 @@
 namespace workerd::api {
 
 class DiffieHellman final {
-public:
+ public:
   DiffieHellman(kj::StringPtr group);
   DiffieHellman(kj::OneOf<kj::Array<kj::byte>, int>& sizeOrKey,
       kj::OneOf<kj::Array<kj::byte>, int>& generator);
@@ -31,7 +31,7 @@ public:
 
   kj::Maybe<int> check() KJ_WARN_UNUSED_RESULT;
 
-private:
+ private:
   kj::Own<DH> dh;
 };
 

--- a/src/workerd/api/crypto/digest.c++
+++ b/src/workerd/api/crypto/digest.c++
@@ -17,7 +17,7 @@ namespace workerd::api {
 namespace {
 
 class HmacKey final: public CryptoKey::Impl {
-public:
+ public:
   explicit HmacKey(kj::Array<kj::byte> keyData,
       CryptoKey::HmacKeyAlgorithm keyAlgorithm,
       bool extractable,
@@ -37,7 +37,7 @@ public:
     tracker.trackField("keyAlgorithm", keyAlgorithm);
   }
 
-private:
+ private:
   kj::Array<kj::byte> sign(
       SubtleCrypto::SignAlgorithm&& algorithm, kj::ArrayPtr<const kj::byte> data) const override {
     return computeHmac(kj::mv(algorithm), data);

--- a/src/workerd/api/crypto/digest.h
+++ b/src/workerd/api/crypto/digest.h
@@ -8,7 +8,7 @@ KJ_DECLARE_NON_POLYMORPHIC(HMAC_CTX)
 
 namespace workerd::api {
 class HmacContext final {
-public:
+ public:
   using KeyData = kj::OneOf<kj::ArrayPtr<kj::byte>, CryptoKey::Impl*>;
 
   HmacContext(kj::StringPtr algorithm, KeyData key);
@@ -21,14 +21,14 @@ public:
 
   size_t size() const;
 
-private:
+ private:
   // Will be kj::Own<HMAC_CTX> while the hmac data is being updated,
   // and kj::Array<kj::byte> after the digest() has been called.
   kj::OneOf<kj::Own<HMAC_CTX>, jsg::BufferSource> state;
 };
 
 class HashContext final {
-public:
+ public:
   HashContext(kj::StringPtr algorithm, kj::Maybe<uint32_t> maybeXof);
   HashContext(HashContext&&) = default;
   HashContext& operator=(HashContext&&) = default;
@@ -40,7 +40,7 @@ public:
 
   size_t size() const;
 
-private:
+ private:
   HashContext(kj::OneOf<kj::Own<EVP_MD_CTX>, jsg::BufferSource>, kj::Maybe<uint32_t> maybeXof);
 
   // Will be kj::Own<EVP_MD_CTX> while the hash data is being updated,

--- a/src/workerd/api/crypto/ec.c++
+++ b/src/workerd/api/crypto/ec.c++
@@ -131,7 +131,7 @@ kj::Maybe<Ec> Ec::tryGetEc(const EVP_PKEY* key) {
 namespace {
 
 class EllipticKey final: public AsymmetricKeyCryptoKeyImpl {
-public:
+ public:
   explicit EllipticKey(AsymmetricKeyData keyData,
       CryptoKey::EllipticKeyAlgorithm keyAlgorithm,
       uint rsSize,
@@ -397,7 +397,7 @@ public:
     tracker.trackField("keyAlgorithm", keyAlgorithm);
   }
 
-private:
+ private:
   SubtleCrypto::JsonWebKey exportJwk() const override final {
     auto ec = JSG_REQUIRE_NONNULL(Ec::tryGetEc(getEvpPkey()), DOMOperationError,
         "No elliptic curve data backing key", tryDescribeOpensslErrors());
@@ -792,7 +792,7 @@ namespace {
 // namedCurve field whereas the algorithms in the Secure Curves spec do not. We handle this by
 // keeping track of the algorithm identifier and returning an algorithm struct based on that.
 class EdDsaKey final: public AsymmetricKeyCryptoKeyImpl {
-public:
+ public:
   explicit EdDsaKey(AsymmetricKeyData keyData, kj::StringPtr keyAlgorithm, bool extractable)
       : AsymmetricKeyCryptoKeyImpl(kj::mv(keyData), extractable),
         keyAlgorithm(kj::mv(keyAlgorithm)) {}
@@ -975,7 +975,7 @@ public:
     AsymmetricKeyCryptoKeyImpl::jsgGetMemoryInfo(tracker);
   }
 
-private:
+ private:
   kj::StringPtr keyAlgorithm;
 
   SubtleCrypto::JsonWebKey exportJwk() const override final {

--- a/src/workerd/api/crypto/ec.h
+++ b/src/workerd/api/crypto/ec.h
@@ -10,7 +10,7 @@
 namespace workerd::api {
 
 class Ec final {
-public:
+ public:
   static kj::Maybe<Ec> tryGetEc(const EVP_PKEY* key);
   Ec(EC_KEY* key);
 
@@ -40,7 +40,7 @@ public:
 
   CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail() const;
 
-private:
+ private:
   EC_KEY* key;
   const EC_GROUP* group = nullptr;
   kj::Own<BIGNUM> x;

--- a/src/workerd/api/crypto/hkdf.c++
+++ b/src/workerd/api/crypto/hkdf.c++
@@ -12,7 +12,7 @@ namespace workerd::api {
 namespace {
 
 class HkdfKey final: public CryptoKey::Impl {
-public:
+ public:
   explicit HkdfKey(kj::Array<kj::byte> keyData,
       CryptoKey::KeyAlgorithm keyAlgorithm,
       bool extractable,
@@ -32,7 +32,7 @@ public:
     tracker.trackField("keyAlgorithm", keyAlgorithm);
   }
 
-private:
+ private:
   kj::Array<kj::byte> deriveBits(jsg::Lock& js,
       SubtleCrypto::DeriveKeyAlgorithm&& algorithm,
       kj::Maybe<uint32_t> maybeLength) const override {

--- a/src/workerd/api/crypto/impl.h
+++ b/src/workerd/api/crypto/impl.h
@@ -100,7 +100,7 @@ kj::StringPtr getAlgorithmName(const kj::OneOf<kj::String, T>& param) {
 }
 
 class CryptoKey::Impl {
-public:
+ public:
   // C++ API
 
   using ImportFunc = kj::Own<Impl>(jsg::Lock& js,
@@ -244,7 +244,7 @@ public:
     return false;
   }
 
-private:
+ private:
   const bool extractable;
   const CryptoKeyUsageSet usages;
 };
@@ -279,7 +279,7 @@ struct CryptoAlgorithm {
 };
 
 class SslArrayDisposer: public kj::ArrayDisposer {
-public:
+ public:
   static const SslArrayDisposer INSTANCE;
 
   void disposeImpl(void* firstElement,
@@ -291,10 +291,10 @@ public:
 
 template <typename T, void (*sslFree)(T*)>
 class SslDisposer: public kj::Disposer {
-public:
+ public:
   static const SslDisposer INSTANCE;
 
-protected:
+ protected:
   void disposeImpl(void* pointer) const override {
     sslFree(reinterpret_cast<T*>(pointer));
   }
@@ -377,7 +377,7 @@ static inline T integerCeilDivision(T a, T b) {
 // A wrapper for kj::Array<kj::byte> that will ensure the memory is overwritten
 // with zeroes when destroyed.
 class ZeroOnFree {
-public:
+ public:
   inline ZeroOnFree(kj::Array<kj::byte>&& inner): inner(kj::mv(inner)) {}
   ~ZeroOnFree() noexcept(false);
 
@@ -400,7 +400,7 @@ public:
     return inner.asPtr();
   }
 
-private:
+ private:
   kj::Array<kj::byte> inner;
 };
 

--- a/src/workerd/api/crypto/keys.h
+++ b/src/workerd/api/crypto/keys.h
@@ -46,7 +46,7 @@ struct AsymmetricKeyData {
 };
 
 class AsymmetricKeyCryptoKeyImpl: public CryptoKey::Impl {
-public:
+ public:
   explicit AsymmetricKeyCryptoKeyImpl(AsymmetricKeyData&& key, bool extractable);
 
   // ---------------------------------------------------------------------------
@@ -113,7 +113,7 @@ public:
   bool verifyX509Public(const X509* cert) const override;
   bool verifyX509Private(const X509* cert) const override;
 
-private:
+ private:
   virtual SubtleCrypto::JsonWebKey exportJwk() const = 0;
   virtual kj::Array<kj::byte> exportRaw() const = 0;
 

--- a/src/workerd/api/crypto/pbkdf2.c++
+++ b/src/workerd/api/crypto/pbkdf2.c++
@@ -13,7 +13,7 @@ namespace workerd::api {
 namespace {
 
 class Pbkdf2Key final: public CryptoKey::Impl {
-public:
+ public:
   explicit Pbkdf2Key(kj::Array<kj::byte> keyData,
       CryptoKey::KeyAlgorithm keyAlgorithm,
       bool extractable,
@@ -33,7 +33,7 @@ public:
     tracker.trackField("keyAlgorithm", keyAlgorithm);
   }
 
-private:
+ private:
   kj::Array<kj::byte> deriveBits(jsg::Lock& js,
       SubtleCrypto::DeriveKeyAlgorithm&& algorithm,
       kj::Maybe<uint32_t> maybeLength) const override {

--- a/src/workerd/api/crypto/rsa.c++
+++ b/src/workerd/api/crypto/rsa.c++
@@ -647,6 +647,7 @@ class RsaOaepKey final: public RsaBase {
  private:
   jsg::BufferSource commonEncryptDecrypt(jsg::Lock& js,
       SubtleCrypto::EncryptAlgorithm&& algorithm,
+      kj::ArrayPtr<const kj::byte> data,
       InitFunction init,
       EncryptDecryptFunction encryptDecrypt) const {
     auto pkey = getEvpPkey();

--- a/src/workerd/api/crypto/rsa.c++
+++ b/src/workerd/api/crypto/rsa.c++
@@ -488,7 +488,7 @@ bool Rsa::isRSAPrivateKey(kj::ArrayPtr<const kj::byte> keyData) {
 
 namespace {
 class RsaBase: public AsymmetricKeyCryptoKeyImpl {
-public:
+ public:
   explicit RsaBase(
       AsymmetricKeyData keyData, CryptoKey::RsaKeyAlgorithm keyAlgorithm, bool extractable)
       : AsymmetricKeyCryptoKeyImpl(kj::mv(keyData), extractable),
@@ -505,10 +505,10 @@ public:
     tracker.trackField("keyAlgorithm", keyAlgorithm);
   }
 
-protected:
+ protected:
   CryptoKey::RsaKeyAlgorithm keyAlgorithm;
 
-private:
+ private:
   SubtleCrypto::JsonWebKey exportJwk() const override final {
     auto rsa = JSG_REQUIRE_NONNULL(Rsa::tryGetRsa(getEvpPkey()), DOMDataError,
         "No RSA data backing key", tryDescribeOpensslErrors());
@@ -528,7 +528,7 @@ private:
 };
 
 class RsassaPkcs1V15Key final: public RsaBase {
-public:
+ public:
   explicit RsassaPkcs1V15Key(
       AsymmetricKeyData keyData, CryptoKey::RsaKeyAlgorithm keyAlgorithm, bool extractable)
       : RsaBase(kj::mv(keyData), kj::mv(keyAlgorithm), extractable) {}
@@ -547,7 +547,7 @@ public:
     return KJ_REQUIRE_NONNULL(keyAlgorithm.hash).name;
   }
 
-private:
+ private:
   kj::String jwkHashAlgorithmName() const override {
     const auto& hashName = KJ_REQUIRE_NONNULL(keyAlgorithm.hash).name;
     JSG_REQUIRE(hashName.startsWith("SHA"), DOMNotSupportedError,
@@ -557,7 +557,7 @@ private:
 };
 
 class RsaPssKey final: public RsaBase {
-public:
+ public:
   explicit RsaPssKey(
       AsymmetricKeyData keyData, CryptoKey::RsaKeyAlgorithm keyAlgorithm, bool extractable)
       : RsaBase(kj::mv(keyData), kj::mv(keyAlgorithm), extractable) {}
@@ -585,7 +585,7 @@ public:
     OSSLCALL(EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx, salt));
   }
 
-private:
+ private:
   kj::String jwkHashAlgorithmName() const override {
     const auto& hashName = KJ_REQUIRE_NONNULL(keyAlgorithm.hash).name;
     JSG_REQUIRE(hashName.startsWith("SHA"), DOMNotSupportedError,
@@ -598,7 +598,7 @@ class RsaOaepKey final: public RsaBase {
   using InitFunction = decltype(EVP_PKEY_encrypt_init);
   using EncryptDecryptFunction = decltype(EVP_PKEY_encrypt);
 
-public:
+ public:
   explicit RsaOaepKey(
       AsymmetricKeyData keyData, CryptoKey::RsaKeyAlgorithm keyAlgorithm, bool extractable)
       : RsaBase(kj::mv(keyData), kj::mv(keyAlgorithm), extractable) {}
@@ -635,7 +635,7 @@ public:
         kj::mv(algorithm), cipherText, EVP_PKEY_decrypt_init, EVP_PKEY_decrypt);
   }
 
-private:
+ private:
   kj::Array<kj::byte> commonEncryptDecrypt(SubtleCrypto::EncryptAlgorithm&& algorithm,
       kj::ArrayPtr<const kj::byte> data,
       InitFunction init,
@@ -661,7 +661,7 @@ private:
 };
 
 class RsaRawKey final: public RsaBase {
-public:
+ public:
   explicit RsaRawKey(
       AsymmetricKeyData keyData, CryptoKey::RsaKeyAlgorithm keyAlgorithm, bool extractable)
       : RsaBase(kj::mv(keyData), kj::mv(keyAlgorithm), extractable) {}
@@ -692,7 +692,7 @@ public:
     KJ_UNIMPLEMENTED("this should not be called since we overrode sign() and verify()");
   }
 
-private:
+ private:
   kj::String jwkHashAlgorithmName() const override {
     const auto& hashName = KJ_REQUIRE_NONNULL(keyAlgorithm.hash).name;
     JSG_REQUIRE(hashName.startsWith("SHA"), DOMNotSupportedError,

--- a/src/workerd/api/crypto/rsa.h
+++ b/src/workerd/api/crypto/rsa.h
@@ -11,7 +11,7 @@
 namespace workerd::api {
 
 class Rsa final {
-public:
+ public:
   static kj::Maybe<Rsa> tryGetRsa(const EVP_PKEY* key);
   Rsa(RSA* rsa);
 
@@ -71,7 +71,7 @@ public:
 
   static bool isRSAPrivateKey(kj::ArrayPtr<const kj::byte> keyData) KJ_WARN_UNUSED_RESULT;
 
-private:
+ private:
   RSA* rsa;
   const BIGNUM* n = nullptr;
   const BIGNUM* e = nullptr;

--- a/src/workerd/api/crypto/x509.h
+++ b/src/workerd/api/crypto/x509.h
@@ -9,7 +9,7 @@ namespace workerd::api {
 class CryptoKey;
 
 class X509Certificate: public jsg::Object {
-public:
+ public:
   X509Certificate(X509* cert): cert_(kj::disposeWith<X509_free>(cert)) {}
 
   static kj::Maybe<jsg::Ref<X509Certificate>> parse(kj::Array<const kj::byte> raw);
@@ -80,7 +80,7 @@ public:
     JSG_METHOD(toLegacyObject);
   }
 
-private:
+ private:
   kj::Own<X509> cert_;
   kj::Maybe<jsg::Ref<X509Certificate>> issuerCert_;
 };

--- a/src/workerd/api/data-url.h
+++ b/src/workerd/api/data-url.h
@@ -8,7 +8,7 @@
 namespace workerd::api {
 
 class DataUrl final {
-public:
+ public:
   static kj::Maybe<DataUrl> tryParse(kj::StringPtr url);
   static kj::Maybe<DataUrl> from(const jsg::Url& url);
 
@@ -27,7 +27,7 @@ public:
     return data.releaseAsBytes();
   }
 
-private:
+ private:
   DataUrl(MimeType mimeType, kj::Array<kj::byte> data)
       : mimeType(kj::mv(mimeType)),
         data(kj::mv(data)) {}

--- a/src/workerd/api/deferred-proxy.h
+++ b/src/workerd/api/deferred-proxy.h
@@ -119,7 +119,7 @@ class DeferredProxyCoroutine: public kj::_::PromiseNode,
   using InnerCoroutineAdapter =
       typename kj::_::stdcoro::coroutine_traits<kj::Promise<T>, Args...>::promise_type;
 
-public:
+ public:
   using Handle = kj::_::stdcoro::coroutine_handle<DeferredProxyCoroutine>;
 
   DeferredProxyCoroutine(kj::SourceLocation location = {})
@@ -191,7 +191,7 @@ public:
   }
   // Required by Awaiter<T>::await_suspend() to support awaiting Promises.
 
-private:
+ private:
   void fulfillOuterPromise() {
     // Fulfill the outer promise if it hasn't already settled.
 

--- a/src/workerd/api/encoding.h
+++ b/src/workerd/api/encoding.h
@@ -65,7 +65,7 @@ enum class Encoding {
 
 // A Decoder provides the underlying implementation of a TextDecoder.
 class Decoder {
-public:
+ public:
   virtual ~Decoder() noexcept(true) {}
   virtual Encoding getEncoding() = 0;
   virtual kj::Maybe<jsg::JsString> decode(
@@ -76,7 +76,7 @@ public:
 
 // Decoder implementation that provides a fast-track for US-ASCII.
 class AsciiDecoder final: public Decoder {
-public:
+ public:
   AsciiDecoder() = default;
   AsciiDecoder(AsciiDecoder&&) = default;
   AsciiDecoder& operator=(AsciiDecoder&&) = default;
@@ -94,7 +94,7 @@ public:
 // ICU's decoder is fairly comprehensive, covering the full range
 // of encodings required by the Encoding specification.
 class IcuDecoder final: public Decoder {
-public:
+ public:
   IcuDecoder(Encoding encoding, UConverter* converter, bool ignoreBom)
       : encoding(encoding),
         inner(converter),
@@ -114,7 +114,7 @@ public:
 
   void reset() override;
 
-private:
+ private:
   struct ConverterDeleter {
     void operator()(UConverter* pointer) const {
       ucnv_close(pointer);
@@ -131,7 +131,7 @@ private:
 // Implements the TextDecoder interface as prescribed by:
 // https://encoding.spec.whatwg.org/#interface-textdecoder
 class TextDecoder final: public jsg::Object {
-public:
+ public:
   using DecoderImpl = kj::OneOf<AsciiDecoder, IcuDecoder>;
 
   struct ConstructorOptions {
@@ -185,7 +185,7 @@ public:
   kj::Maybe<jsg::JsString> decodePtr(
       jsg::Lock& js, kj::ArrayPtr<const kj::byte> buffer, bool flush);
 
-private:
+ private:
   Decoder& getImpl();
 
   DecoderImpl decoder;
@@ -199,7 +199,7 @@ private:
 // Implements the TextEncoder interface as prescribed by:
 // https://encoding.spec.whatwg.org/#interface-textencoder
 class TextEncoder final: public jsg::Object {
-public:
+ public:
   struct EncodeIntoResult {
     int read;
     int written;

--- a/src/workerd/api/events.h
+++ b/src/workerd/api/events.h
@@ -7,7 +7,7 @@
 namespace workerd::api {
 
 class ErrorEvent: public Event {
-public:
+ public:
   struct ErrorEventInit {
     jsg::Optional<kj::String> message;
     jsg::Optional<kj::String> filename;
@@ -42,7 +42,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   ErrorEventInit init;
 
   void visitForGc(jsg::GcVisitor& visitor);

--- a/src/workerd/api/eventsource.c++
+++ b/src/workerd/api/eventsource.c++
@@ -15,7 +15,7 @@ namespace workerd::api {
 
 namespace {
 class EventSourceSink final: public WritableStreamSink {
-public:
+ public:
   EventSourceSink(EventSource& eventSource): eventSource(eventSource) {}
 
   kj::Promise<void> write(kj::ArrayPtr<const kj::byte> buffer) override {
@@ -83,7 +83,7 @@ public:
     clear();
   }
 
-private:
+ private:
   kj::Maybe<EventSource&> eventSource;
 
   // Retained bytes to be processed in the next write.

--- a/src/workerd/api/eventsource.h
+++ b/src/workerd/api/eventsource.h
@@ -18,9 +18,9 @@ class Response;
 // Implements the web standard EventSource API
 // https://developer.mozilla.org/en-US/docs/Web/API/EventSource
 class EventSource: public EventTarget {
-public:
+ public:
   class ErrorEvent final: public Event {
-  public:
+   public:
     ErrorEvent(jsg::Lock& js, const jsg::JsValue& error)
         : Event(kj::str("error")),
           error(js, error) {}
@@ -31,7 +31,7 @@ public:
       JSG_LAZY_READONLY_INSTANCE_PROPERTY(error, getError);
     }
 
-  private:
+   private:
     jsg::JsRef<jsg::JsValue> error;
 
     jsg::JsValue getError(jsg::Lock& js) {
@@ -40,7 +40,7 @@ public:
   };
 
   class OpenEvent final: public Event {
-  public:
+   public:
     OpenEvent(): Event(kj::str("open")) {}
     static jsg::Ref<OpenEvent> constructor() = delete;
     JSG_RESOURCE_TYPE(OpenEvent) {
@@ -49,7 +49,7 @@ public:
   };
 
   class MessageEvent final: public Event {
-  public:
+   public:
     explicit MessageEvent(kj::Maybe<kj::String> type,
         kj::String data,
         kj::String lastEventId,
@@ -67,7 +67,7 @@ public:
       JSG_LAZY_READONLY_INSTANCE_PROPERTY(lastEventId, getLastEventId);
     }
 
-  private:
+   private:
     kj::String data;
     kj::String lastEventId;
     kj::Maybe<kj::Array<const char>> origin;
@@ -208,7 +208,7 @@ public:
   void visitForGc(jsg::GcVisitor& visitor);
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   IoContext& context;
   struct FetchImpl {
     jsg::Url url;

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -69,7 +69,7 @@ using DOMException = jsg::DOMException;
 
 // A subset of the standard Navigator API.
 class Navigator: public jsg::Object {
-public:
+ public:
   kj::StringPtr getUserAgent() {
     return "Cloudflare-Workers"_kj;
   }
@@ -89,7 +89,7 @@ public:
 };
 
 class Performance: public jsg::Object {
-public:
+ public:
   // We always return a time origin of 0, making performance.now() equivalent to Date.now(). There
   // is no other appropriate time origin to use given that the Worker platform is intended to be
   // treated like one big computer rather than many individual instances. In particular, if and
@@ -118,7 +118,7 @@ public:
 // configuration details. This is not a standard API and great care should
 // be taken when deciding to expose new properties or methods here.
 class Cloudflare: public jsg::Object {
-public:
+ public:
   // Return an object containing the state of all compatibility flags known to the runtime.
   jsg::JsObject getCompatibilityFlags(jsg::Lock& js);
 
@@ -131,7 +131,7 @@ public:
 };
 
 class PromiseRejectionEvent: public Event {
-public:
+ public:
   PromiseRejectionEvent(
       v8::PromiseRejectEvent type, jsg::V8Ref<v8::Promise> promise, jsg::Value reason);
 
@@ -155,7 +155,7 @@ public:
     tracker.trackField("reason", reason);
   }
 
-private:
+ private:
   jsg::V8Ref<v8::Promise> promise;
   jsg::Value reason;
 
@@ -163,7 +163,7 @@ private:
 };
 
 class WorkerGlobalScope: public EventTarget, public jsg::ContextGlobal {
-public:
+ public:
   jsg::Unimplemented importScripts(kj::String s) {
     return {};
   };
@@ -198,12 +198,12 @@ public:
 // At present, this has no methods. It is defined for consistency with other handlers and on the
 // assumption that we'll probably want to put something here someday.
 class TestController: public jsg::Object {
-public:
+ public:
   JSG_RESOURCE_TYPE(TestController) {}
 };
 
 class ExecutionContext: public jsg::Object {
-public:
+ public:
   void waitUntil(kj::Promise<void> promise);
   void passThroughOnException();
 
@@ -233,7 +233,7 @@ public:
 
 // AlarmEventInfo is a jsg::Object used to pass alarm invocation info to an alarm handler.
 class AlarmInvocationInfo: public jsg::Object {
-public:
+ public:
   AlarmInvocationInfo(uint32_t retry): retryCount(retry) {}
 
   bool getIsRetry() {
@@ -248,7 +248,7 @@ public:
     JSG_READONLY_INSTANCE_PROPERTY(retryCount, getRetryCount);
   }
 
-private:
+ private:
   uint32_t retryCount = 0;
 };
 
@@ -361,7 +361,7 @@ struct ExportedHandler {
 // An approximation of Node.js setImmediate `Immediate` object.
 // This is used only when the `nodejs_compat_v2` compatibility flag is enabled.
 class Immediate final: public jsg::Object {
-public:
+ public:
   Immediate(IoContext& context, TimeoutId timeoutId);
 
   // In Node.js, the "ref" mechanism refers to whether or not an i/o object
@@ -384,7 +384,7 @@ public:
     JSG_DISPOSE(dispose);
   }
 
-private:
+ private:
   // On the off chance user code holds onto to the Ref<Immediate> longer than
   // the IoContext remains alive, let's maintain just a weak reference to the
   // IoContext here to avoid problems. This reference is used only for handling
@@ -396,7 +396,7 @@ private:
 
 // Global object API exposed to JavaScript.
 class ServiceWorkerGlobalScope: public WorkerGlobalScope {
-public:
+ public:
   ServiceWorkerGlobalScope(v8::Isolate* isolate);
 
   // Drop all references to JavaScript objects so that the context can be garbage-collected. Call
@@ -838,7 +838,7 @@ public:
     tracker.trackField("unhandledRejections", unhandledRejections);
   }
 
-private:
+ private:
   jsg::UnhandledRejectionHandler unhandledRejections;
 
   // Global properties such as scheduler, crypto, caches, self, and origin should

--- a/src/workerd/api/gpu/gpu-adapter-info.h
+++ b/src/workerd/api/gpu/gpu-adapter-info.h
@@ -11,7 +11,7 @@
 namespace workerd::api::gpu {
 
 class GPUAdapterInfo: public jsg::Object {
-public:
+ public:
   explicit GPUAdapterInfo(wgpu::AdapterInfo);
   JSG_RESOURCE_TYPE(GPUAdapterInfo) {
     JSG_READONLY_PROTOTYPE_PROPERTY(vendor, getVendor);
@@ -27,7 +27,7 @@ public:
     tracker.trackField("description", description_);
   }
 
-private:
+ private:
   kj::String vendor_;
   kj::String architecture_;
   kj::String device_;

--- a/src/workerd/api/gpu/gpu-adapter.h
+++ b/src/workerd/api/gpu/gpu-adapter.h
@@ -18,7 +18,7 @@
 namespace workerd::api::gpu {
 
 class GPUAdapter: public jsg::Object {
-public:
+ public:
   explicit GPUAdapter(dawn::native::Adapter a, kj::Own<AsyncRunner> async)
       : adapter_(a),
         async_(kj::mv(async)) {};
@@ -29,7 +29,7 @@ public:
     JSG_READONLY_PROTOTYPE_PROPERTY(limits, getLimits);
   }
 
-private:
+ private:
   jsg::Promise<jsg::Ref<GPUDevice>> requestDevice(jsg::Lock&, jsg::Optional<GPUDeviceDescriptor>);
   dawn::native::Adapter adapter_;
   kj::Own<AsyncRunner> async_;

--- a/src/workerd/api/gpu/gpu-async-runner.h
+++ b/src/workerd/api/gpu/gpu-async-runner.h
@@ -17,7 +17,7 @@ namespace workerd::api::gpu {
 // AsyncRunner is used to poll a wgpu::Instance with calls to ProcessEvents() while there
 // are asynchronous tasks in flight.
 class AsyncRunner: public kj::Refcounted {
-public:
+ public:
   AsyncRunner(wgpu::Instance instance): instance_(instance) {};
 
   // Begin() should be called when a new asynchronous task is started.
@@ -31,7 +31,7 @@ public:
   // Every call to Begin() should eventually result in a call to End().
   void End();
 
-private:
+ private:
   void QueueTick();
   wgpu::Instance const instance_;
   uint64_t count_ = 0;
@@ -44,7 +44,7 @@ private:
 // associated with any async task.
 template <typename T>
 class AsyncContext: public kj::Refcounted {
-public:
+ public:
   inline AsyncContext(AsyncContext&&) = default;
 
   // Constructor.
@@ -69,7 +69,7 @@ public:
   kj::Own<kj::PromiseFulfiller<T>> fulfiller_;
   jsg::Promise<T> promise_;
 
-private:
+ private:
   KJ_DISALLOW_COPY(AsyncContext);
   kj::Own<AsyncRunner> runner_;
 };

--- a/src/workerd/api/gpu/gpu-bindgroup-layout.h
+++ b/src/workerd/api/gpu/gpu-bindgroup-layout.h
@@ -13,7 +13,7 @@
 namespace workerd::api::gpu {
 
 class GPUBindGroupLayout: public jsg::Object {
-public:
+ public:
   explicit GPUBindGroupLayout(wgpu::BindGroupLayout l): layout_(kj::mv(l)) {};
 
   // Implicit cast operator to Dawn GPU object
@@ -23,7 +23,7 @@ public:
 
   JSG_RESOURCE_TYPE(GPUBindGroupLayout) {}
 
-private:
+ private:
   wgpu::BindGroupLayout layout_;
 };
 

--- a/src/workerd/api/gpu/gpu-bindgroup.h
+++ b/src/workerd/api/gpu/gpu-bindgroup.h
@@ -16,7 +16,7 @@
 namespace workerd::api::gpu {
 
 class GPUBindGroup: public jsg::Object {
-public:
+ public:
   // Implicit cast operator to Dawn GPU object
   inline operator const wgpu::BindGroup&() const {
     return group_;
@@ -24,7 +24,7 @@ public:
   explicit GPUBindGroup(wgpu::BindGroup g): group_(kj::mv(g)) {};
   JSG_RESOURCE_TYPE(GPUBindGroup) {}
 
-private:
+ private:
   wgpu::BindGroup group_;
 };
 

--- a/src/workerd/api/gpu/gpu-buffer.h
+++ b/src/workerd/api/gpu/gpu-buffer.h
@@ -12,7 +12,7 @@
 namespace workerd::api::gpu {
 
 class GPUBuffer: public jsg::Object {
-public:
+ public:
   // Implicit cast operator to Dawn GPU object
   inline operator const wgpu::Buffer&() const {
     return buffer_;
@@ -37,7 +37,7 @@ public:
     tracker.trackField("detachKey", detachKey_);
   }
 
-private:
+ private:
   // https://www.w3.org/TR/webgpu/#buffer-interface
   enum class State {
     Unmapped,

--- a/src/workerd/api/gpu/gpu-command-buffer.h
+++ b/src/workerd/api/gpu/gpu-command-buffer.h
@@ -11,7 +11,7 @@
 namespace workerd::api::gpu {
 
 class GPUCommandBuffer: public jsg::Object {
-public:
+ public:
   // Implicit cast operator to Dawn GPU object
   inline operator const wgpu::CommandBuffer&() const {
     return cmd_buf_;
@@ -19,7 +19,7 @@ public:
   explicit GPUCommandBuffer(wgpu::CommandBuffer b): cmd_buf_(kj::mv(b)) {};
   JSG_RESOURCE_TYPE(GPUCommandBuffer) {}
 
-private:
+ private:
   wgpu::CommandBuffer cmd_buf_;
 };
 

--- a/src/workerd/api/gpu/gpu-command-encoder.h
+++ b/src/workerd/api/gpu/gpu-command-encoder.h
@@ -40,7 +40,7 @@ struct GPUImageCopyBuffer {
 };
 
 class GPUCommandEncoder: public jsg::Object {
-public:
+ public:
   explicit GPUCommandEncoder(wgpu::CommandEncoder e, kj::String label)
       : encoder_(kj::mv(e)),
         label_(kj::mv(label)) {};
@@ -60,7 +60,7 @@ public:
     tracker.trackField("label", label_);
   }
 
-private:
+ private:
   wgpu::CommandEncoder encoder_;
   kj::String label_;
   kj::StringPtr getLabel() {

--- a/src/workerd/api/gpu/gpu-compute-pass-encoder.h
+++ b/src/workerd/api/gpu/gpu-compute-pass-encoder.h
@@ -16,7 +16,7 @@
 namespace workerd::api::gpu {
 
 class GPUComputePassEncoder: public jsg::Object {
-public:
+ public:
   explicit GPUComputePassEncoder(wgpu::ComputePassEncoder e): encoder_(kj::mv(e)) {};
   JSG_RESOURCE_TYPE(GPUComputePassEncoder) {
     JSG_METHOD(setPipeline);
@@ -25,7 +25,7 @@ public:
     JSG_METHOD(end);
   }
 
-private:
+ private:
   wgpu::ComputePassEncoder encoder_;
   void setPipeline(jsg::Ref<GPUComputePipeline> pipeline);
   void dispatchWorkgroups(GPUSize32 workgroupCountX,

--- a/src/workerd/api/gpu/gpu-compute-pipeline.h
+++ b/src/workerd/api/gpu/gpu-compute-pipeline.h
@@ -14,7 +14,7 @@
 namespace workerd::api::gpu {
 
 class GPUComputePipeline: public jsg::Object {
-public:
+ public:
   // Implicit cast operator to Dawn GPU object
   inline operator const wgpu::ComputePipeline&() const {
     return pipeline_;
@@ -24,7 +24,7 @@ public:
     JSG_METHOD(getBindGroupLayout);
   }
 
-private:
+ private:
   wgpu::ComputePipeline pipeline_;
   jsg::Ref<GPUBindGroupLayout> getBindGroupLayout(uint32_t index);
 };

--- a/src/workerd/api/gpu/gpu-device.h
+++ b/src/workerd/api/gpu/gpu-device.h
@@ -34,7 +34,7 @@ struct UncapturedErrorContext {
 };
 
 class GPUDevice: public EventTarget {
-public:
+ public:
   explicit GPUDevice(jsg::Lock& js,
       wgpu::Device d,
       kj::Own<AsyncRunner> async,
@@ -67,7 +67,7 @@ public:
   // illegal for user code to create an GPUDevice directly.
   static jsg::Ref<GPUDevice> constructor() = delete;
 
-private:
+ private:
   wgpu::Device device_;
   kj::Own<AsyncContext<jsg::Ref<GPUDeviceLostInfo>>> dlc_;
   jsg::MemoizedIdentity<jsg::Promise<jsg::Ref<GPUDeviceLostInfo>>> lost_promise_;
@@ -118,7 +118,7 @@ struct GPUUncapturedErrorEventInit {
 };
 
 class GPUUncapturedErrorEvent: public Event {
-public:
+ public:
   GPUUncapturedErrorEvent(
       kj::StringPtr type, GPUUncapturedErrorEventInit gpuUncapturedErrorEventInitDict)
       : Event(kj::mv(type)),
@@ -135,7 +135,7 @@ public:
     tracker.trackField("error", error_);
   }
 
-private:
+ private:
   jsg::Ref<GPUError> error_;
 
   jsg::Ref<GPUError> getError() {

--- a/src/workerd/api/gpu/gpu-errors.h
+++ b/src/workerd/api/gpu/gpu-errors.h
@@ -13,7 +13,7 @@
 namespace workerd::api::gpu {
 
 class GPUError: public jsg::Object {
-public:
+ public:
   explicit GPUError(kj::String m): message_(kj::mv(m)) {};
   JSG_RESOURCE_TYPE(GPUError) {
     JSG_READONLY_PROTOTYPE_PROPERTY(message, getMessage);
@@ -27,12 +27,12 @@ public:
     tracker.trackField("message", message_);
   }
 
-private:
+ private:
   kj::String message_;
 };
 
 class GPUOutOfMemoryError: public GPUError {
-public:
+ public:
   using GPUError::GPUError;
   JSG_RESOURCE_TYPE(GPUOutOfMemoryError) {
     JSG_INHERIT(GPUError);
@@ -40,7 +40,7 @@ public:
 };
 
 class GPUValidationError: public GPUError {
-public:
+ public:
   using GPUError::GPUError;
   JSG_RESOURCE_TYPE(GPUValidationError) {
     JSG_INHERIT(GPUError);
@@ -48,7 +48,7 @@ public:
 };
 
 class GPUInternalError: public GPUError {
-public:
+ public:
   using GPUError::GPUError;
   JSG_RESOURCE_TYPE(GPUInternalError) {
     JSG_INHERIT(GPUError);
@@ -56,7 +56,7 @@ public:
 };
 
 class GPUDeviceLostInfo: public jsg::Object {
-public:
+ public:
   explicit GPUDeviceLostInfo(GPUDeviceLostReason r, kj::String m)
       : reason_(kj::mv(r)),
         message_(kj::mv(m)) {};
@@ -70,7 +70,7 @@ public:
     tracker.trackField("reason", reason_);
   }
 
-private:
+ private:
   GPUDeviceLostReason reason_;
   kj::String message_;
   kj::StringPtr getMessage() {

--- a/src/workerd/api/gpu/gpu-pipeline-layout.h
+++ b/src/workerd/api/gpu/gpu-pipeline-layout.h
@@ -13,7 +13,7 @@
 namespace workerd::api::gpu {
 
 class GPUPipelineLayout: public jsg::Object {
-public:
+ public:
   // Implicit cast operator to Dawn GPU object
   inline operator const wgpu::PipelineLayout&() const {
     return layout_;
@@ -21,7 +21,7 @@ public:
   explicit GPUPipelineLayout(wgpu::PipelineLayout l): layout_(kj::mv(l)) {};
   JSG_RESOURCE_TYPE(GPUPipelineLayout) {}
 
-private:
+ private:
   wgpu::PipelineLayout layout_;
 };
 

--- a/src/workerd/api/gpu/gpu-query-set.h
+++ b/src/workerd/api/gpu/gpu-query-set.h
@@ -13,7 +13,7 @@
 namespace workerd::api::gpu {
 
 class GPUQuerySet: public jsg::Object {
-public:
+ public:
   // Implicit cast operator to Dawn GPU object
   inline operator const wgpu::QuerySet&() const {
     return querySet_;
@@ -21,7 +21,7 @@ public:
   explicit GPUQuerySet(wgpu::QuerySet q): querySet_(kj::mv(q)) {};
   JSG_RESOURCE_TYPE(GPUQuerySet) {}
 
-private:
+ private:
   wgpu::QuerySet querySet_;
 };
 

--- a/src/workerd/api/gpu/gpu-queue.h
+++ b/src/workerd/api/gpu/gpu-queue.h
@@ -14,7 +14,7 @@
 namespace workerd::api::gpu {
 
 class GPUQueue: public jsg::Object {
-public:
+ public:
   // Implicit cast operator to Dawn GPU object
   inline operator const wgpu::Queue&() const {
     return queue_;
@@ -25,7 +25,7 @@ public:
     JSG_METHOD(writeBuffer);
   }
 
-private:
+ private:
   wgpu::Queue queue_;
   void submit(kj::Array<jsg::Ref<GPUCommandBuffer>> commandBuffers);
   void writeBuffer(jsg::Ref<GPUBuffer> buffer,

--- a/src/workerd/api/gpu/gpu-render-pass-encoder.h
+++ b/src/workerd/api/gpu/gpu-render-pass-encoder.h
@@ -16,7 +16,7 @@
 namespace workerd::api::gpu {
 
 class GPURenderPassEncoder: public jsg::Object {
-public:
+ public:
   explicit GPURenderPassEncoder(wgpu::RenderPassEncoder e): encoder_(kj::mv(e)) {};
   JSG_RESOURCE_TYPE(GPURenderPassEncoder) {
     JSG_METHOD(setPipeline);
@@ -24,7 +24,7 @@ public:
     JSG_METHOD(end);
   }
 
-private:
+ private:
   wgpu::RenderPassEncoder encoder_;
   void setPipeline(jsg::Ref<GPURenderPipeline> pipeline);
   void draw(GPUSize32 vertexCount,

--- a/src/workerd/api/gpu/gpu-render-pipeline.h
+++ b/src/workerd/api/gpu/gpu-render-pipeline.h
@@ -14,7 +14,7 @@
 namespace workerd::api::gpu {
 
 class GPURenderPipeline: public jsg::Object {
-public:
+ public:
   // Implicit cast operator to Dawn GPU object
   inline operator const wgpu::RenderPipeline&() const {
     return pipeline_;
@@ -22,7 +22,7 @@ public:
   explicit GPURenderPipeline(wgpu::RenderPipeline p): pipeline_(kj::mv(p)) {};
   JSG_RESOURCE_TYPE(GPURenderPipeline) {}
 
-private:
+ private:
   wgpu::RenderPipeline pipeline_;
 };
 

--- a/src/workerd/api/gpu/gpu-sampler.h
+++ b/src/workerd/api/gpu/gpu-sampler.h
@@ -13,7 +13,7 @@
 namespace workerd::api::gpu {
 
 class GPUSampler: public jsg::Object {
-public:
+ public:
   // Implicit cast operator to Dawn GPU object
   inline operator const wgpu::Sampler&() const {
     return sampler_;
@@ -22,7 +22,7 @@ public:
   explicit GPUSampler(wgpu::Sampler s): sampler_(kj::mv(s)) {};
   JSG_RESOURCE_TYPE(GPUSampler) {}
 
-private:
+ private:
   wgpu::Sampler sampler_;
 };
 

--- a/src/workerd/api/gpu/gpu-shader-module.h
+++ b/src/workerd/api/gpu/gpu-shader-module.h
@@ -14,7 +14,7 @@
 namespace workerd::api::gpu {
 
 class GPUCompilationMessage: public jsg::Object {
-public:
+ public:
   explicit GPUCompilationMessage(const WGPUCompilationMessage& m): message(m) {}
 
   JSG_RESOURCE_TYPE(GPUCompilationMessage) {
@@ -26,7 +26,7 @@ public:
     JSG_READONLY_PROTOTYPE_PROPERTY(length, getLength);
   }
 
-private:
+ private:
   WGPUCompilationMessage message;
 
   kj::StringPtr getMessage() {
@@ -59,7 +59,7 @@ private:
 };
 
 class GPUCompilationInfo: public jsg::Object {
-public:
+ public:
   explicit GPUCompilationInfo(kj::Vector<jsg::Ref<GPUCompilationMessage>> messages)
       : messages_(kj::mv(messages)) {};
   JSG_RESOURCE_TYPE(GPUCompilationInfo) {
@@ -72,7 +72,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::Vector<jsg::Ref<GPUCompilationMessage>> messages_;
   kj::ArrayPtr<jsg::Ref<GPUCompilationMessage>> getMessages() {
     return messages_.asPtr();
@@ -83,7 +83,7 @@ private:
 };
 
 class GPUShaderModule: public jsg::Object {
-public:
+ public:
   // Implicit cast operator to Dawn GPU object
   inline operator const wgpu::ShaderModule&() const {
     return shader_;
@@ -95,7 +95,7 @@ public:
     JSG_METHOD(getCompilationInfo);
   }
 
-private:
+ private:
   wgpu::ShaderModule shader_;
   kj::Own<AsyncRunner> async_;
   jsg::Promise<jsg::Ref<GPUCompilationInfo>> getCompilationInfo(jsg::Lock& js);

--- a/src/workerd/api/gpu/gpu-supported-features.h
+++ b/src/workerd/api/gpu/gpu-supported-features.h
@@ -13,7 +13,7 @@
 namespace workerd::api::gpu {
 
 class GPUSupportedFeatures: public jsg::Object {
-public:
+ public:
   explicit GPUSupportedFeatures(kj::Array<wgpu::FeatureName> features);
   JSG_RESOURCE_TYPE(GPUSupportedFeatures) {
     JSG_METHOD(has);
@@ -26,7 +26,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::HashSet<GPUFeatureName> enabled_;
   bool has(kj::String name);
   kj::Array<kj::StringPtr> keys();

--- a/src/workerd/api/gpu/gpu-supported-limits.h
+++ b/src/workerd/api/gpu/gpu-supported-limits.h
@@ -13,7 +13,7 @@
 namespace workerd::api::gpu {
 
 class GPUSupportedLimits: public jsg::Object {
-public:
+ public:
   explicit GPUSupportedLimits(wgpu::SupportedLimits limits): limits_(kj::mv(limits)) {};
   JSG_RESOURCE_TYPE(GPUSupportedLimits) {
     JSG_READONLY_PROTOTYPE_PROPERTY(maxTextureDimension1D, getMaxTextureDimension1D);
@@ -62,7 +62,7 @@ public:
         maxComputeWorkgroupsPerDimension, getMaxComputeWorkgroupsPerDimension);
   }
 
-private:
+ private:
   wgpu::SupportedLimits limits_;
   uint32_t getMaxTextureDimension1D() {
     return limits_.limits.maxTextureDimension1D;

--- a/src/workerd/api/gpu/gpu-texture-view.h
+++ b/src/workerd/api/gpu/gpu-texture-view.h
@@ -13,7 +13,7 @@
 namespace workerd::api::gpu {
 
 class GPUTextureView: public jsg::Object {
-public:
+ public:
   // Implicit cast operator to Dawn GPU object
   inline operator const wgpu::TextureView&() const {
     return textureView_;
@@ -21,7 +21,7 @@ public:
   explicit GPUTextureView(wgpu::TextureView t): textureView_(kj::mv(t)) {};
   JSG_RESOURCE_TYPE(GPUTextureView) {}
 
-private:
+ private:
   wgpu::TextureView textureView_;
 };
 

--- a/src/workerd/api/gpu/gpu-texture.h
+++ b/src/workerd/api/gpu/gpu-texture.h
@@ -14,7 +14,7 @@
 namespace workerd::api::gpu {
 
 class GPUTexture: public jsg::Object {
-public:
+ public:
   // Implicit cast operator to Dawn GPU object
   inline operator const wgpu::Texture&() const {
     return texture_;
@@ -32,7 +32,7 @@ public:
     JSG_READONLY_PROTOTYPE_PROPERTY(usage, getUsage);
   }
 
-private:
+ private:
   wgpu::Texture texture_;
 
   jsg::Ref<GPUTextureView> createView(jsg::Optional<GPUTextureViewDescriptor> descriptor);

--- a/src/workerd/api/gpu/gpu.h
+++ b/src/workerd/api/gpu/gpu.h
@@ -44,13 +44,13 @@ struct GPURequestAdapterOptions {
 };
 
 class GPU: public jsg::Object {
-public:
+ public:
   explicit GPU();
   JSG_RESOURCE_TYPE(GPU) {
     JSG_METHOD(requestAdapter);
   }
 
-private:
+ private:
   jsg::Promise<kj::Maybe<jsg::Ref<GPUAdapter>>> requestAdapter(
       jsg::Lock&, jsg::Optional<GPURequestAdapterOptions>);
   dawn::native::Instance instance_;

--- a/src/workerd/api/hibernatable-web-socket.h
+++ b/src/workerd/api/hibernatable-web-socket.h
@@ -19,7 +19,7 @@ namespace workerd::api {
 using HibernationReader =
     rpc::HibernatableWebSocketEventDispatcher::HibernatableWebSocketEventParams::Reader;
 class HibernatableWebSocketEvent final: public ExtendableEvent {
-public:
+ public:
   explicit HibernatableWebSocketEvent();
 
   static jsg::Ref<HibernatableWebSocketEvent> constructor(kj::String type) = delete;
@@ -51,13 +51,13 @@ public:
     JSG_INHERIT(ExtendableEvent);
   }
 
-private:
+ private:
   Worker::Actor::HibernationManager& getHibernationManager(jsg::Lock& lock);
 };
 
 class HibernatableWebSocketCustomEventImpl final: public WorkerInterface::CustomEvent,
                                                   public kj::Refcounted {
-public:
+ public:
   HibernatableWebSocketCustomEventImpl(uint16_t typeId,
       kj::Own<HibernationReader> params,
       kj::Maybe<Worker::Actor::HibernationManager&> manager = kj::none);
@@ -80,7 +80,7 @@ public:
     KJ_UNIMPLEMENTED("hibernatable web socket event not supported");
   }
 
-private:
+ private:
   // Returns `params`, but if we have a HibernationReader we convert it to a
   // HibernatableSocketParams first.
   HibernatableSocketParams consumeParams();

--- a/src/workerd/api/html-rewriter.c++
+++ b/src/workerd/api/html-rewriter.c++
@@ -29,10 +29,10 @@ namespace {
 // functions.
 template <typename T, void (*lolhtmlFree)(T*)>
 class LolHtmlDisposer: public kj::Disposer {
-public:
+ public:
   static const LolHtmlDisposer INSTANCE;
 
-protected:
+ protected:
   void disposeImpl(void* pointer) const override {
     lolhtmlFree(reinterpret_cast<T*>(pointer));
   }
@@ -55,7 +55,7 @@ const LolHtmlDisposer<T, lolhtmlFree> LolHtmlDisposer<T, lolhtmlFree>::INSTANCE;
 //
 // Use `kj::str(LolString.asChars())` to allocate your own copy of a LolString.
 class LolString {
-public:
+ public:
   explicit LolString(lol_html_str_t s): chars(s.data, s.len) {}
   ~LolString() noexcept(false) {
     lol_html_str_free({chars.begin(), chars.size()});
@@ -83,7 +83,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::ArrayPtr<const char> chars;
 };
 
@@ -145,7 +145,7 @@ decltype(auto) checkToken(kj::Maybe<T>& impl) {
 // HTMLRewriter::TokenScope
 
 class HTMLRewriter::TokenScope {
-public:
+ public:
   template <typename T>
   explicit TokenScope(jsg::Ref<T>& value): contentToken(value.addRef()) {}
   ~TokenScope() noexcept(false) {
@@ -158,7 +158,7 @@ public:
   }
   KJ_DISALLOW_COPY(TokenScope);
 
-private:
+ private:
   kj::Maybe<jsg::Ref<HTMLRewriter::Token>> contentToken;
 };
 
@@ -218,7 +218,7 @@ using UnregisteredElementOrDocumentHandlers =
 
 // Wrapper around an actual rewriter (streaming parser).
 class Rewriter final: public WritableStreamSink {
-public:
+ public:
   explicit Rewriter(jsg::Lock& js,
       kj::ArrayPtr<UnregisteredElementOrDocumentHandlers> unregisteredHandlers,
       kj::ArrayPtr<const char> encoding,
@@ -234,7 +234,7 @@ public:
   // Implementation for `Element::onEndTag` to avoid exposing private details of Rewriter.
   void onEndTag(lol_html_element_t* element, ElementCallbackFunction&& callback);
 
-private:
+ private:
   // Wait for the write promise (if any) produced by our `output()` callback, then, if there is a
   // stored exception, abort the wrapped WritableStreamSink with it, then return the exception.
   // Otherwise, just return.

--- a/src/workerd/api/html-rewriter.h
+++ b/src/workerd/api/html-rewriter.h
@@ -36,7 +36,7 @@ class DocumentEnd;
 // HTMLRewriter
 
 class HTMLRewriter: public jsg::Object {
-public:
+ public:
   class Token;
   class TokenScope;
 
@@ -111,7 +111,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   void visitForGc(jsg::GcVisitor& visitor);
 
   struct Impl;
@@ -138,7 +138,7 @@ private:
 // collecting definitions.
 
 class HTMLRewriter::Token: public jsg::Object {
-public:
+ public:
   virtual void htmlContentScopeEnd() = 0;
 };
 
@@ -158,7 +158,7 @@ struct ContentOptions {
 class Rewriter;
 
 class Element final: public HTMLRewriter::Token {
-public:
+ public:
   using CType = lol_html_Element;
 
   explicit Element(CType& element, Rewriter& wrapper);
@@ -227,7 +227,7 @@ public:
     // callback function
   }
 
-private:
+ private:
   struct Impl {
     Impl(CType& element, Rewriter&);
     KJ_DISALLOW_COPY_AND_MOVE(Impl);
@@ -244,7 +244,7 @@ private:
 };
 
 class Element::AttributesIterator final: public HTMLRewriter::Token {
-public:
+ public:
   using CType = lol_html_AttributesIterator;
 
   // lol_html_AttributesIterator has the distinction of being valid only during a content handler
@@ -268,14 +268,14 @@ public:
     JSG_ITERABLE(self);
   }
 
-private:
+ private:
   kj::Maybe<kj::Own<CType>> impl;
 
   void htmlContentScopeEnd() override;
 };
 
 class EndTag final: public HTMLRewriter::Token {
-public:
+ public:
   using CType = lol_html_EndTag;
 
   explicit EndTag(CType& tag, Rewriter&);
@@ -302,14 +302,14 @@ public:
     // Require content to be a string
   }
 
-private:
+ private:
   kj::Maybe<CType&> impl;
 
   void htmlContentScopeEnd() override;
 };
 
 class Comment final: public HTMLRewriter::Token {
-public:
+ public:
   using CType = lol_html_Comment;
 
   explicit Comment(CType& comment, Rewriter&);
@@ -342,14 +342,14 @@ public:
     // Require content to be a string
   }
 
-private:
+ private:
   kj::Maybe<CType&> impl;
 
   void htmlContentScopeEnd() override;
 };
 
 class Text final: public HTMLRewriter::Token {
-public:
+ public:
   using CType = lol_html_TextChunk;
 
   explicit Text(CType& text, Rewriter&);
@@ -384,14 +384,14 @@ public:
     // Require content to be a string
   }
 
-private:
+ private:
   kj::Maybe<CType&> impl;
 
   void htmlContentScopeEnd() override;
 };
 
 class Doctype final: public HTMLRewriter::Token {
-public:
+ public:
   using CType = lol_html_Doctype;
 
   explicit Doctype(CType& doctype, Rewriter&);
@@ -408,14 +408,14 @@ public:
     JSG_TS_ROOT();
   }
 
-private:
+ private:
   kj::Maybe<CType&> impl;
 
   void htmlContentScopeEnd() override;
 };
 
 class DocumentEnd final: public HTMLRewriter::Token {
-public:
+ public:
   using CType = lol_html_DocumentEnd;
 
   explicit DocumentEnd(CType& documentEnd, Rewriter&);
@@ -432,7 +432,7 @@ public:
     // Require content to be a string
   }
 
-private:
+ private:
   kj::Maybe<CType&> impl;
 
   void htmlContentScopeEnd() override;

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -586,7 +586,7 @@ jsg::Ref<Headers> Headers::deserialize(
 namespace {
 
 class BodyBufferInputStream final: public ReadableStreamSource {
-public:
+ public:
   BodyBufferInputStream(Body::Buffer buffer)
       : unread(buffer.view),
         ownBytes(kj::mv(buffer.ownBytes)) {}
@@ -618,7 +618,7 @@ public:
     co_return;
   }
 
-private:
+ private:
   kj::ArrayPtr<const byte> unread;
   kj::OneOf<kj::Own<Body::RefcountedBytes>, jsg::Ref<Blob>> ownBytes;
 };

--- a/src/workerd/api/hyperdrive.h
+++ b/src/workerd/api/hyperdrive.h
@@ -19,7 +19,7 @@ class Socket;
 // Provides the same interface as Hyperdrive while sending connection
 // traffic directly to postgres
 class Hyperdrive: public jsg::Object {
-public:
+ public:
   // `clientIndex` is what to pass to IoContext::getHttpClient() to get an HttpClient
   // representing this namespace.
   explicit Hyperdrive(uint clientIndex,
@@ -57,7 +57,7 @@ public:
     tracker.trackField("scheme", scheme);
   }
 
-private:
+ private:
   uint clientIndex;
   kj::String randomHost;
   kj::String database;

--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -19,7 +19,7 @@ namespace workerd::api {
 
 // A capability to a KV namespace.
 class KvNamespace: public jsg::Object {
-public:
+ public:
   struct AdditionalHeader {
     kj::String name;
     kj::String value;
@@ -164,7 +164,7 @@ public:
     tracker.trackField("additionalHeaders", additionalHeaders.asPtr());
   }
 
-protected:
+ protected:
   // Do the boilerplate work of constructing an HTTP client to KV. Setting a KvOptType causes
   // the limiter for that op type to be checked. If a string is used, that's used as the operation
   // name for the HttpClient without any limiter enforcement.
@@ -175,7 +175,7 @@ protected:
       kj::OneOf<LimitEnforcer::KvOpType, kj::LiteralStringConst> opTypeOrName,
       kj::StringPtr urlStr);
 
-private:
+ private:
   kj::Array<AdditionalHeader> additionalHeaders;
   uint subrequestChannel;
 };

--- a/src/workerd/api/memory-cache.h
+++ b/src/workerd/api/memory-cache.h
@@ -92,10 +92,10 @@ class MemoryCacheProvider;
 // fairly different from this implementation so quite a few of the details here
 // are expected to change.
 class SharedMemoryCache: public kj::AtomicRefcounted {
-private:
+ private:
   struct InProgress;
 
-public:
+ public:
   struct ThreadUnsafeData;
 
   struct Limits {
@@ -169,11 +169,11 @@ public:
       kj::Maybe<AdditionalResizeMemoryLimitHandler&> additionalResizeMemoryLimitHandler,
       const kj::MonotonicClock& timer);
 
-public:
+ public:
   // RAII class that attaches itself to a cache, suggests cache limits to the
   // cache it is attached to, and allows interacting with the cache.
   class Use {
-  public:
+   public:
     KJ_DISALLOW_COPY(Use);
 
     Use(kj::Own<const SharedMemoryCache> cache, const Limits& limits);
@@ -201,7 +201,7 @@ public:
     kj::OneOf<kj::Own<CacheValue>, kj::Promise<GetWithFallbackOutcome>> getWithFallback(
         const kj::String& key, SpanBuilder& span) const;
 
-  private:
+   private:
     // Creates a new FallbackDoneCallback associated with the given
     // InProgress struct. This is called whenever getWithFallback() wants to
     // invoke a fallback but it does not call the fallback directly. The caller
@@ -222,7 +222,7 @@ public:
     Limits limits;
   };
 
-private:
+ private:
   struct InProgress {
     const kj::String key;
 
@@ -236,7 +236,7 @@ private:
     // Callbacks for a HashIndex that allow locating an InProgress struct
     // based on the cache key.
     class KeyCallbacks {
-    public:
+     public:
       inline const kj::String& keyForRow(const kj::Own<InProgress>& entry) const {
         return entry->key;
       }
@@ -297,7 +297,7 @@ private:
   // cache key, which is a string. This is used for all key-based cache
   // operations.
   class KeyCallbacks {
-  public:
+   public:
     inline const kj::String& keyForRow(const MemoryCacheEntry& entry) const {
       return entry.key;
     }
@@ -316,7 +316,7 @@ private:
   // Callbacks for a TreeIndex that allow sorting cache entries by their
   // liveliness. This is used to evict the least recently used entry.
   class LivelinessCallbacks {
-  public:
+   public:
     inline const uint64_t& keyForRow(const MemoryCacheEntry& entry) const {
       return entry.liveliness;
     }
@@ -338,7 +338,7 @@ private:
   // the largest cache values when the maximum value size is reduced, e.g.,
   // when a new version of a worker is deployed.
   class ValueSizeCallbacks {
-  public:
+   public:
     inline const MemoryCacheEntry& keyForRow(const MemoryCacheEntry& entry) const {
       return entry;
     }
@@ -361,7 +361,7 @@ private:
   // they are not least recently used. Values with no expiration timestamp are
   // at the very end, ordered by their cache keys.
   class ExpirationCallbacks {
-  public:
+   public:
     inline const MemoryCacheEntry& keyForRow(const MemoryCacheEntry& entry) const {
       return entry;
     }
@@ -378,7 +378,7 @@ private:
       return e.key < key.key;
     }
 
-  private:
+   private:
     inline bool isBefore(const kj::Maybe<double>& a, const kj::Maybe<double>& b) const {
       KJ_IF_SOME(da, a) {
         KJ_IF_SOME(db, b) {
@@ -393,7 +393,7 @@ private:
     }
   };
 
-public:
+ public:
   struct ThreadUnsafeData {
     KJ_DISALLOW_COPY_AND_MOVE(ThreadUnsafeData);
 
@@ -441,7 +441,7 @@ public:
     kj::Table<kj::Own<InProgress>, kj::HashIndex<InProgress::KeyCallbacks>> inProgress;
   };
 
-private:
+ private:
   // To ensure thread-safety, all mutable data is guarded by a mutex. Each cache
   // operation requires an exclusive lock. Even read-only operations need to
   // update the liveliness of cache entries, which currently requires a lock.
@@ -471,7 +471,7 @@ private:
 // all calls from JavaScript are essentially forwarded to that object, which
 // manages interaction with the shared cache in a thread-safe manner.
 class MemoryCache: public jsg::Object {
-public:
+ public:
   MemoryCache(SharedMemoryCache::Use&& use): cacheUse(kj::mv(use)) {}
 
   using FallbackFunction = jsg::Function<jsg::Promise<CacheValueProduceResult>(kj::String)>;
@@ -486,7 +486,7 @@ public:
     JSG_METHOD(read);
   }
 
-private:
+ private:
   SharedMemoryCache::Use cacheUse;
 };
 
@@ -498,7 +498,7 @@ private:
 // that can be passed along to the individual cache instances so we can monitor just how much
 // the in memory cache is being used.
 class MemoryCacheProvider {
-public:
+ public:
   MemoryCacheProvider(const kj::MonotonicClock& timer,
       kj::Maybe<SharedMemoryCache::AdditionalResizeMemoryLimitHandler>
           additionalResizeMemoryLimitHandler = kj::none);
@@ -509,7 +509,7 @@ public:
 
   void removeInstance(const SharedMemoryCache& instance) const;
 
-private:
+ private:
   kj::Maybe<SharedMemoryCache::AdditionalResizeMemoryLimitHandler>
       additionalResizeMemoryLimitHandler;
 

--- a/src/workerd/api/node/async-hooks.h
+++ b/src/workerd/api/node/async-hooks.h
@@ -28,7 +28,7 @@ namespace workerd::api::node {
 //   });
 //   console.log(als.getStore());  // undefined
 class AsyncLocalStorage final: public jsg::Object {
-public:
+ public:
   AsyncLocalStorage(): key(kj::refcounted<jsg::AsyncContextFrame::StorageKey>()) {}
   ~AsyncLocalStorage() noexcept(false) {
     key->reset();
@@ -86,7 +86,7 @@ public:
 
   kj::Own<jsg::AsyncContextFrame::StorageKey> getKey();
 
-private:
+ private:
   kj::Own<jsg::AsyncContextFrame::StorageKey> key;
 };
 
@@ -126,7 +126,7 @@ private:
 //   target.addEventListener('abc', handler);
 //   target.addEventListener('xyz', handler);
 class AsyncResource final: public jsg::Object {
-public:
+ public:
   struct Options {
     // Node.js' API allows user code to create AsyncResource instances within an
     // explicitly specified parent execution context (what we call an "Async Context
@@ -204,7 +204,7 @@ public:
     tracker.trackField("frame", frame);
   }
 
-private:
+ private:
   kj::Maybe<jsg::Ref<jsg::AsyncContextFrame>> frame;
 
   inline void visitForGc(jsg::GcVisitor& visitor) {
@@ -216,7 +216,7 @@ private:
 // We provide this because AsyncLocalStorage is exposed via async_hooks in
 // Node.js.
 class AsyncHooksModule final: public jsg::Object {
-public:
+ public:
   AsyncHooksModule() = default;
   AsyncHooksModule(jsg::Lock&, const jsg::Url&) {}
 

--- a/src/workerd/api/node/buffer-string-search.h
+++ b/src/workerd/api/node/buffer-string-search.h
@@ -36,7 +36,7 @@ namespace stringsearch {
 
 template <typename T>
 class Vector {
-public:
+ public:
   Vector(T* data, size_t length, bool isForward)
       : start_(data),
         length_(length),
@@ -64,7 +64,7 @@ public:
     return start_[is_forward_ ? index : (length_ - index - 1)];
   }
 
-private:
+ private:
   T* start_;
   size_t length_;
   bool is_forward_;
@@ -77,7 +77,7 @@ private:
 // Class holding constants and methods that apply to all string search variants,
 // independently of subject and pattern char size.
 class StringSearchBase {
-protected:
+ protected:
   // Cap on the maximal shift in the Boyer-Moore implementation. By setting a
   // limit, we can fix the size of tables. For a needle longer than this limit,
   // search will not be optimal, since we only build tables for a suffix
@@ -110,7 +110,7 @@ protected:
 
 template <typename Char>
 class StringSearch: private StringSearchBase {
-public:
+ public:
   typedef stringsearch::Vector<const Char> Vector;
 
   explicit StringSearch(Vector pattern): pattern_(pattern), start_(0) {
@@ -159,7 +159,7 @@ public:
         "sizeof(Char) == sizeof(uint16_t) || sizeof(uint8_t)");
   }
 
-private:
+ private:
   typedef size_t (StringSearch::*SearchFunction)(Vector, size_t);
   size_t SingleCharSearch(Vector subject, size_t start_index);
   size_t LinearSearch(Vector subject, size_t start_index);

--- a/src/workerd/api/node/buffer.h
+++ b/src/workerd/api/node/buffer.h
@@ -11,7 +11,7 @@ namespace workerd::api::node {
 
 // Implements utilities in support of the Node.js Buffer
 class BufferUtil final: public jsg::Object {
-public:
+ public:
   BufferUtil() = default;
   BufferUtil(jsg::Lock&, const jsg::Url&) {}
 

--- a/src/workerd/api/node/crypto-keys.c++
+++ b/src/workerd/api/node/crypto-keys.c++
@@ -19,7 +19,7 @@ namespace {
 // single secret key can be used for both AES and HMAC, where as
 // Web Crypto requires a separate key for each algorithm.
 class SecretKey final: public CryptoKey::Impl {
-public:
+ public:
   explicit SecretKey(kj::Array<kj::byte> keyData)
       : Impl(true, CryptoKeyUsageSet::privateKeyMask() | CryptoKeyUsageSet::publicKeyMask()),
         keyData(kj::mv(keyData)) {}
@@ -65,7 +65,7 @@ public:
     tracker.trackFieldWithSize("keyData", keyData.size());
   }
 
-private:
+ private:
   ZeroOnFree keyData;
 };
 }  // namespace

--- a/src/workerd/api/node/crypto.h
+++ b/src/workerd/api/node/crypto.h
@@ -12,10 +12,10 @@
 namespace workerd::api::node {
 
 class CryptoImpl final: public jsg::Object {
-public:
+ public:
   // DH
   class DiffieHellmanHandle final: public jsg::Object {
-  public:
+   public:
     DiffieHellmanHandle(DiffieHellman dh);
 
     static jsg::Ref<DiffieHellmanHandle> constructor(jsg::Lock& js,
@@ -44,7 +44,7 @@ public:
       JSG_METHOD(getVerifyError);
     };
 
-  private:
+   private:
     DiffieHellman dh;
     int verifyError;
   };
@@ -61,7 +61,7 @@ public:
 
   // Hash
   class HashHandle final: public jsg::Object {
-  public:
+   public:
     HashHandle(HashContext ctx): ctx(kj::mv(ctx)) {}
 
     static jsg::Ref<HashHandle> constructor(kj::String algorithm, kj::Maybe<uint32_t> xofLen);
@@ -81,13 +81,13 @@ public:
 
     void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-  private:
+   private:
     HashContext ctx;
   };
 
   // Hmac
   class HmacHandle final: public jsg::Object {
-  public:
+   public:
     using KeyParam = kj::OneOf<kj::Array<kj::byte>, jsg::Ref<CryptoKey>>;
 
     HmacHandle(HmacContext ctx): ctx(kj::mv(ctx)) {};
@@ -110,7 +110,7 @@ public:
 
     void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-  private:
+   private:
     HmacContext ctx;
   };
 

--- a/src/workerd/api/node/diagnostics-channel.h
+++ b/src/workerd/api/node/diagnostics-channel.h
@@ -9,7 +9,7 @@
 namespace workerd::api::node {
 
 class Channel: public jsg::Object {
-public:
+ public:
   using MessageCallback = jsg::Function<void(jsg::Value, jsg::Name)>;
   using TransformCallback = jsg::Function<jsg::Value(jsg::Value)>;
 
@@ -45,7 +45,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   struct StoreEntry {
     kj::Own<jsg::AsyncContextFrame::StorageKey> key;
     TransformCallback transform;
@@ -76,7 +76,7 @@ private:
 };
 
 class DiagnosticsChannelModule: public jsg::Object {
-public:
+ public:
   DiagnosticsChannelModule() = default;
   DiagnosticsChannelModule(jsg::Lock&, const jsg::Url&) {}
 
@@ -99,7 +99,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   kj::HashMap<kj::String, jsg::Ref<Channel>> channels;
 
   void visitForGc(jsg::GcVisitor& visitor);

--- a/src/workerd/api/node/i18n.h
+++ b/src/workerd/api/node/i18n.h
@@ -42,7 +42,7 @@ constexpr bool canBeTranscoded(Encoding encoding) noexcept {
 }
 
 class Converter final {
-public:
+ public:
   explicit Converter(Encoding encoding, kj::StringPtr substitude = ""_kj);
   KJ_DISALLOW_COPY_AND_MOVE(Converter);
 
@@ -52,7 +52,7 @@ public:
   void reset();
   void setSubstituteChars(kj::StringPtr sub);
 
-private:
+ private:
   kj::Own<UConverter> conv_;
 };
 

--- a/src/workerd/api/node/module.h
+++ b/src/workerd/api/node/module.h
@@ -8,7 +8,7 @@
 namespace workerd::api::node {
 
 class ModuleUtil final: public jsg::Object {
-public:
+ public:
   ModuleUtil() = default;
   ModuleUtil(jsg::Lock&, const jsg::Url&) {}
 

--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -24,7 +24,7 @@ namespace workerd::api::node {
 // TODO(later): Consider moving out of node.h when needed for other
 // built-ins
 class CompatibilityFlags: public jsg::Object {
-public:
+ public:
   CompatibilityFlags() = default;
   CompatibilityFlags(jsg::Lock&, const jsg::Url&) {}
 

--- a/src/workerd/api/node/url.h
+++ b/src/workerd/api/node/url.h
@@ -10,7 +10,7 @@
 namespace workerd::api::node {
 
 class UrlUtil final: public jsg::Object {
-public:
+ public:
   UrlUtil() = default;
   UrlUtil(jsg::Lock&, const jsg::Url&) {}
 

--- a/src/workerd/api/node/util.h
+++ b/src/workerd/api/node/util.h
@@ -26,14 +26,14 @@ static constexpr bool IsWithinBounds(size_t off, size_t len, size_t max) noexcep
 class MIMEType;
 
 class MIMEParams final: public jsg::Object {
-private:
+ private:
   template <typename T>
   struct IteratorState final {
     kj::Array<T> values;
     uint index = 0;
   };
 
-public:
+ public:
   MIMEParams(kj::Maybe<MimeType&> mimeType = kj::none);
 
   static jsg::Ref<MIMEParams> constructor();
@@ -66,7 +66,7 @@ public:
     JSG_ITERABLE(entries);
   }
 
-private:
+ private:
   template <typename T>
   static kj::Maybe<T> iteratorNext(jsg::Lock& js, IteratorState<T>& state) {
     if (state.index >= state.values.size()) {
@@ -87,7 +87,7 @@ private:
 };
 
 class MIMEType final: public jsg::Object {
-public:
+ public:
   explicit MIMEType(MimeType inner);
   ~MIMEType() noexcept(false);
   static jsg::Ref<MIMEType> constructor(kj::String input);
@@ -109,7 +109,7 @@ public:
     JSG_METHOD_NAMED(toJSON, toString);
   }
 
-private:
+ private:
   workerd::MimeType inner;
   jsg::Ref<MIMEParams> params;
 };
@@ -155,7 +155,7 @@ private:
   V(WeakSet)
 
 class UtilModule final: public jsg::Object {
-public:
+ public:
   UtilModule() = default;
   UtilModule(jsg::Lock&, const jsg::Url&) {}
 

--- a/src/workerd/api/node/zlib-util.c++
+++ b/src/workerd/api/node/zlib-util.c++
@@ -38,7 +38,7 @@ namespace {
 class GrowableBuffer final {
   // A copy of kj::Vector with some additional methods for use as a growable buffer with a maximum
   // size
-public:
+ public:
   inline explicit GrowableBuffer(size_t _chunkSize, size_t _maxCapacity) {
     auto maxChunkSize = kj::min(_chunkSize, _maxCapacity);
     builder = kj::heapArrayBuilder<kj::byte>(maxChunkSize);
@@ -93,7 +93,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::ArrayBuilder<kj::byte> builder;
   size_t chunkSize;
   size_t maxCapacity;

--- a/src/workerd/api/node/zlib-util.h
+++ b/src/workerd/api/node/zlib-util.h
@@ -91,7 +91,7 @@ struct CompressionError {
 };
 
 class ZlibContext final {
-public:
+ public:
   explicit ZlibContext(ZlibMode _mode): mode(_mode) {}
   ZlibContext() = default;
   ~ZlibContext() noexcept(false);
@@ -176,7 +176,7 @@ public:
         maxOutputLength);
   };
 
-private:
+ private:
   bool initializeZlib();
   kj::Maybe<CompressionError> setDictionary();
 
@@ -203,7 +203,7 @@ private:
 using CompressionStreamErrorHandler = jsg::Function<void(int, kj::StringPtr, kj::StringPtr)>;
 
 class BrotliContext {
-public:
+ public:
   explicit BrotliContext(ZlibMode _mode): mode(_mode) {}
   KJ_DISALLOW_COPY(BrotliContext);
   void setBuffers(kj::ArrayPtr<kj::byte> input, kj::ArrayPtr<kj::byte> output);
@@ -225,7 +225,7 @@ public:
     JSG_STRUCT(flush, finishFlush, chunkSize, params, maxOutputLength);
   };
 
-protected:
+ protected:
   ZlibMode mode;
   const uint8_t* nextIn = nullptr;
   uint8_t* nextOut = nullptr;
@@ -242,7 +242,7 @@ protected:
 };
 
 class BrotliEncoderContext final: public BrotliContext {
-public:
+ public:
   static const ZlibMode Mode = ZlibMode::BROTLI_ENCODE;
   explicit BrotliEncoderContext(ZlibMode _mode);
 
@@ -256,13 +256,13 @@ public:
   kj::Maybe<CompressionError> setParams(int key, uint32_t value);
   kj::Maybe<CompressionError> getError() const;
 
-private:
+ private:
   bool lastResult = false;
   kj::Own<BrotliEncoderStateStruct> state;
 };
 
 class BrotliDecoderContext final: public BrotliContext {
-public:
+ public:
   static const ZlibMode Mode = ZlibMode::BROTLI_DECODE;
   explicit BrotliDecoderContext(ZlibMode _mode);
 
@@ -276,7 +276,7 @@ public:
   kj::Maybe<CompressionError> setParams(int key, uint32_t value);
   kj::Maybe<CompressionError> getError() const;
 
-private:
+ private:
   BrotliDecoderResult lastResult = BROTLI_DECODER_RESULT_SUCCESS;
   BrotliDecoderErrorCode error = BROTLI_DECODER_NO_ERROR;
   kj::String errorString;
@@ -285,13 +285,13 @@ private:
 
 // Implements utilities in support of the Node.js Zlib
 class ZlibUtil final: public jsg::Object {
-public:
+ public:
   ZlibUtil() = default;
   ZlibUtil(jsg::Lock&, const jsg::Url&) {}
 
   template <class CompressionContext>
   class CompressionStream: public jsg::Object {
-  public:
+   public:
     explicit CompressionStream(ZlibMode _mode): context_(_mode) {}
     // TODO(soon): Find a way to add noexcept(false) to this destructor.
     ~CompressionStream();
@@ -330,7 +330,7 @@ public:
       JSG_METHOD(setErrorHandler);
     }
 
-  protected:
+   protected:
     CompressionContext* context() {
       return &context_;
     }
@@ -342,7 +342,7 @@ public:
     // context to avoid `heap-use-after-free` ASan error.
     CompressionAllocator allocator;
 
-  private:
+   private:
     CompressionContext context_;
     bool initialized = false;
     bool writing = false;
@@ -356,7 +356,7 @@ public:
   };
 
   class ZlibStream final: public CompressionStream<ZlibContext> {
-  public:
+   public:
     explicit ZlibStream(ZlibMode mode): CompressionStream(mode) {}
     KJ_DISALLOW_COPY_AND_MOVE(ZlibStream);
     static jsg::Ref<ZlibStream> constructor(ZlibModeValue mode);
@@ -381,7 +381,7 @@ public:
 
   template <typename CompressionContext>
   class BrotliCompressionStream: public CompressionStream<CompressionContext> {
-  public:
+   public:
     explicit BrotliCompressionStream(ZlibMode _mode)
         : CompressionStream<CompressionContext>(_mode) {}
     KJ_DISALLOW_COPY_AND_MOVE(BrotliCompressionStream);

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -23,11 +23,11 @@
 namespace workerd::api::pyodide {
 
 class PyodideBundleManager {
-public:
+ public:
   void setPyodideBundleData(kj::String version, kj::Array<unsigned char> data) const;
   const kj::Maybe<jsg::Bundle::Reader> getPyodideBundle(kj::StringPtr version) const;
 
-private:
+ private:
   struct MessageBundlePair {
     kj::Own<capnp::FlatArrayMessageReader> messageReader;
     jsg::Bundle::Reader bundle;
@@ -36,11 +36,11 @@ private:
 };
 
 class PyodidePackageManager {
-public:
+ public:
   void setPyodidePackageData(kj::String id, kj::Array<unsigned char> data) const;
   const kj::Maybe<kj::ArrayPtr<const unsigned char>> getPyodidePackage(kj::StringPtr id) const;
 
-private:
+ private:
   const kj::MutexGuarded<kj::HashMap<kj::String, kj::Array<unsigned char>>> packages;
 };
 
@@ -57,7 +57,7 @@ struct PythonConfig {
 class PackagesTarReader: public jsg::Object {
   kj::ArrayPtr<const kj::byte> source;
 
-public:
+ public:
   PackagesTarReader(kj::ArrayPtr<const kj::byte> src = PYODIDE_PACKAGES_TAR.get()): source(src) {};
 
   int read(jsg::Lock& js, int offset, kj::Array<kj::byte> buf);
@@ -73,7 +73,7 @@ public:
 // This is done this way to avoid copying files as much as possible. We set up a Metadata File
 // System which reads the contents as they are needed.
 class PyodideMetadataReader: public jsg::Object {
-private:
+ private:
   kj::String mainModule;
   kj::Array<kj::String> names;
   kj::Array<kj::Array<kj::byte>> contents;
@@ -87,7 +87,7 @@ private:
   bool usePackagesInArtifactBundler;
   kj::Maybe<kj::Array<kj::byte>> memorySnapshot;
 
-public:
+ public:
   PyodideMetadataReader(kj::String mainModule,
       kj::Array<kj::String> names,
       kj::Array<kj::Array<kj::byte>> contents,
@@ -215,7 +215,7 @@ struct MemorySnapshotResult {
 // A loaded bundle of artifacts for a particular script id. It can also contain V8 version and
 // CPU architecture-specific artifacts. The logic for loading these is in getArtifacts.
 class ArtifactBundler: public jsg::Object {
-public:
+ public:
   kj::Maybe<const PyodidePackageManager&> packageManager;
   // ^ lifetime should be contained by lifetime of ArtifactBundler since there is normally one worker set for the whole process. see worker-set.h
   // In other words:
@@ -322,7 +322,7 @@ public:
     JSG_STATIC_METHOD(getSnapshotImports);
   }
 
-private:
+ private:
   // A memory snapshot of the state of the Python interpreter after initialisation. Used to speed
   // up cold starts.
   kj::Maybe<kj::Array<const kj::byte>> existingSnapshot;
@@ -330,7 +330,7 @@ private:
 };
 
 class DisabledInternalJaeger: public jsg::Object {
-public:
+ public:
   static jsg::Ref<DisabledInternalJaeger> create() {
     return jsg::alloc<DisabledInternalJaeger>();
   }
@@ -339,12 +339,12 @@ public:
 
 // This cache is used by Pyodide to store wheels fetched over the internet across workerd restarts in local dev only
 class DiskCache: public jsg::Object {
-private:
+ private:
   static const kj::Maybe<kj::Own<const kj::Directory>> NULL_CACHE_ROOT;  // always set to kj::none
 
   const kj::Maybe<kj::Own<const kj::Directory>>& cacheRoot;
 
-public:
+ public:
   DiskCache(): cacheRoot(NULL_CACHE_ROOT) {};  // Disabled disk cache
   DiskCache(const kj::Maybe<kj::Own<const kj::Directory>>& cacheRoot): cacheRoot(cacheRoot) {};
 
@@ -367,13 +367,13 @@ public:
 //
 // TODO(later): stop execution as soon limit is reached, instead of doing so after the fact.
 class SimplePythonLimiter: public jsg::Object {
-private:
+ private:
   int startupLimitMs;
   kj::Maybe<kj::Function<kj::TimePoint()>> getTimeCb;
 
   kj::Maybe<kj::TimePoint> startTime;
 
-public:
+ public:
   SimplePythonLimiter(): startupLimitMs(0), getTimeCb(kj::none) {}
 
   SimplePythonLimiter(int startupLimitMs, kj::Function<kj::TimePoint()> getTimeCb)

--- a/src/workerd/api/queue.h
+++ b/src/workerd/api/queue.h
@@ -20,7 +20,7 @@ class ExecutionContext;
 
 // A capability to a Worker Queue.
 class WorkerQueue: public jsg::Object {
-public:
+ public:
   // `subrequestChannel` is what to pass to IoContext::getHttpClient() to get an HttpClient
   // representing this queue.
   WorkerQueue(uint subrequestChannel): subrequestChannel(subrequestChannel) {}
@@ -85,7 +85,7 @@ public:
     JSG_TS_DEFINE(type QueueContentType = "text" | "bytes" | "json" | "v8");
   }
 
-private:
+ private:
   uint subrequestChannel;
 };
 
@@ -152,7 +152,7 @@ struct QueueRetryOptions {
 };
 
 class QueueMessage final: public jsg::Object {
-public:
+ public:
   QueueMessage(jsg::Lock& js, rpc::QueueMessage::Reader message, IoPtr<QueueEventResult> result);
   QueueMessage(jsg::Lock& js, IncomingQueueMessage message, IoPtr<QueueEventResult> result);
 
@@ -191,7 +191,7 @@ public:
     tracker.trackFieldWithSize("IoPtr<QueueEventResult>", sizeof(IoPtr<QueueEventResult>));
   }
 
-private:
+ private:
   kj::String id;
   kj::Date timestamp;
   jsg::JsRef<jsg::JsValue> body;
@@ -204,7 +204,7 @@ private:
 };
 
 class QueueEvent final: public ExtendableEvent {
-public:
+ public:
   // TODO(cleanup): Should we get around the need for this alternative param type by just having the
   // service worker caller provide us with capnp-serialized params?
   struct Params {
@@ -267,7 +267,7 @@ public:
     return completionStatus;
   }
 
-private:
+ private:
   // TODO(perf): Should we store these in a v8 array directly rather than this intermediate kj
   // array to avoid one intermediate copy?
   kj::Array<jsg::Ref<QueueMessage>> messages;
@@ -282,7 +282,7 @@ private:
 
 // Type used when calling a module-exported queue event handler.
 class QueueController final: public jsg::Object {
-public:
+ public:
   QueueController(jsg::Ref<QueueEvent> event): event(kj::mv(event)) {}
 
   kj::ArrayPtr<jsg::Ref<QueueMessage>> getMessages() {
@@ -315,7 +315,7 @@ public:
     tracker.trackField("event", event);
   }
 
-private:
+ private:
   jsg::Ref<QueueEvent> event;
 
   void visitForGc(jsg::GcVisitor& visitor) {
@@ -334,7 +334,7 @@ struct QueueExportedHandler {
 };
 
 class QueueCustomEventImpl final: public WorkerInterface::CustomEvent, public kj::Refcounted {
-public:
+ public:
   QueueCustomEventImpl(
       kj::OneOf<QueueEvent::Params, rpc::EventDispatcher::QueueParams::Reader> params)
       : params(kj::mv(params)) {}
@@ -365,7 +365,7 @@ public:
     KJ_UNIMPLEMENTED("queue event not supported");
   }
 
-private:
+ private:
   kj::OneOf<rpc::EventDispatcher::QueueParams::Reader, QueueEvent::Params> params;
   QueueEventResult result;
 };

--- a/src/workerd/api/r2-admin.h
+++ b/src/workerd/api/r2-admin.h
@@ -24,7 +24,7 @@ class R2Admin: public jsg::Object {
     using R2Bucket::FeatureFlags::FeatureFlags;
   };
 
-public:
+ public:
   // `subrequestChannel` is what to pass to IoContext::getHttpClient() to get an HttpClient
   // representing this namespace.
   explicit R2Admin(CompatibilityFlags::Reader featureFlags, uint subrequestChannel)
@@ -46,7 +46,7 @@ public:
   };
 
   class RetrievedBucket: public R2Bucket {
-  public:
+   public:
     RetrievedBucket(R2Bucket::FeatureFlags featureFlags,
         uint subrequestChannel,
         kj::String name,
@@ -67,7 +67,7 @@ public:
       JSG_READONLY_INSTANCE_PROPERTY(created, getCreated);
     }
 
-  private:
+   private:
     kj::Date created;
 
     friend class R2Admin;
@@ -103,7 +103,7 @@ public:
     tracker.trackField("jwt", jwt);
   }
 
-private:
+ private:
   R2Bucket::FeatureFlags featureFlags;
   uint subrequestChannel;
   kj::Maybe<kj::String> jwt;

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -23,7 +23,7 @@ class R2MultipartUpload;
 
 // A capability to an R2 Bucket.
 class R2Bucket: public jsg::Object {
-protected:
+ protected:
   struct friend_tag_t {};
 
   struct FeatureFlags {
@@ -32,7 +32,7 @@ protected:
     bool listHonorsIncludes;
   };
 
-public:
+ public:
   // `clientIndex` is what to pass to IoContext::getHttpClient() to get an HttpClient
   // representing this namespace.
   explicit R2Bucket(CompatibilityFlags::Reader featureFlags, uint clientIndex)
@@ -95,7 +95,7 @@ public:
   };
 
   class Checksums: public jsg::Object {
-  public:
+   public:
     Checksums(jsg::Optional<kj::Array<kj::byte>> md5,
         jsg::Optional<kj::Array<kj::byte>> sha1,
         jsg::Optional<kj::Array<kj::byte>> sha256,
@@ -205,7 +205,7 @@ public:
   };
 
   class HeadResult: public jsg::Object {
-  public:
+   public:
     HeadResult(kj::String name,
         kj::String version,
         double size,
@@ -298,7 +298,7 @@ public:
       tracker.trackField("customMetadata", customMetadata);
     }
 
-  protected:
+   protected:
     kj::String name;
     kj::String version;
     double size;
@@ -314,7 +314,7 @@ public:
   };
 
   class GetResult: public HeadResult {
-  public:
+   public:
     GetResult(kj::String name,
         kj::String version,
         double size,
@@ -368,7 +368,7 @@ public:
       tracker.trackField("body", body);
     }
 
-  private:
+   private:
     jsg::Ref<ReadableStream> body;
   };
 
@@ -505,12 +505,12 @@ public:
     tracker.trackField("jwt", jwt);
   }
 
-protected:
+ protected:
   kj::Maybe<kj::StringPtr> adminBucketName() const {
     return adminBucket;
   }
 
-private:
+ private:
   FeatureFlags featureFlags;
   uint clientIndex;
   kj::Maybe<kj::String> adminBucket;

--- a/src/workerd/api/r2-multipart.h
+++ b/src/workerd/api/r2-multipart.h
@@ -11,7 +11,7 @@
 namespace workerd::api::public_beta {
 
 class R2MultipartUpload: public jsg::Object {
-public:
+ public:
   struct UploadedPart {
     int partNumber;
     kj::String etag;
@@ -55,12 +55,12 @@ public:
     tracker.trackField("bucket", bucket);
   }
 
-protected:
+ protected:
   kj::String key;
   kj::String uploadId;
   jsg::Ref<R2Bucket> bucket;
 
-private:
+ private:
   void visitForGc(jsg::GcVisitor& visitor) {
     visitor.visit(bucket);
   }

--- a/src/workerd/api/r2-rpc.h
+++ b/src/workerd/api/r2-rpc.h
@@ -21,7 +21,7 @@ class ReadableStream;
 // TODO(soon): Switch to structured objects and use jsg::Ref<R2Error> instead of kj::Own<R2Error>
 //   to maintain ownership.
 class R2Error: public jsg::Object {
-public:
+ public:
   R2Error(uint v4Code, kj::String message): v4Code(v4Code), message(kj::mv(message)) {}
 
   constexpr kj::StringPtr getName() const {
@@ -52,7 +52,7 @@ public:
     JSG_TS_ROOT();
   }
 
-private:
+ private:
   uint v4Code;
   kj::String message;
   kj::Maybe<kj::String> action;

--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -189,7 +189,7 @@ CompatibilityFlags::Reader compileAllFlags(capnp::MessageBuilder &message) {
 }
 
 struct TypesEncoder {
-public:
+ public:
   TypesEncoder(): compatFlags(kj::heapArray<kj::String>(0)) {}
   TypesEncoder(kj::String compatDate, kj::Array<kj::String> compatFlags)
       : compatDate(kj::mv(compatDate)),
@@ -246,7 +246,7 @@ public:
     return kj::heapArray(bytes);
   }
 
-private:
+ private:
   template <typename Type>
   void writeStructure(jsg::rtti::Builder<CompatibilityFlags::Reader> &builder,
       capnp::List<jsg::rtti::Structure>::Builder structures) {

--- a/src/workerd/api/rtti.h
+++ b/src/workerd/api/rtti.h
@@ -15,7 +15,7 @@
 namespace workerd::api {
 
 class RTTIModule final: public jsg::Object {
-public:
+ public:
   RTTIModule() = default;
   RTTIModule(jsg::Lock&, const jsg::Url&) {}
 

--- a/src/workerd/api/scheduled.h
+++ b/src/workerd/api/scheduled.h
@@ -11,7 +11,7 @@
 namespace workerd::api {
 
 class ScheduledEvent final: public ExtendableEvent {
-public:
+ public:
   explicit ScheduledEvent(double scheduledTime, kj::StringPtr cron);
 
   static jsg::Ref<ScheduledEvent> constructor(kj::String type) = delete;
@@ -36,14 +36,14 @@ public:
     tracker.trackField("cron", cron);
   }
 
-private:
+ private:
   double scheduledTime;
   kj::String cron;
 };
 
 // Type used when calling a module-exported scheduled event handler.
 class ScheduledController final: public jsg::Object {
-public:
+ public:
   ScheduledController(jsg::Ref<ScheduledEvent> event): event(kj::mv(event)) {}
 
   double getScheduledTime() {
@@ -66,7 +66,7 @@ public:
     tracker.trackField("event", event);
   }
 
-private:
+ private:
   jsg::Ref<ScheduledEvent> event;
 
   void visitForGc(jsg::GcVisitor& visitor) {

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -56,7 +56,7 @@ struct TlsOptions {
 };
 
 class Socket: public jsg::Object {
-public:
+ public:
   Socket(jsg::Lock& js,
       IoContext& context,
       kj::Own<kj::RefcountedWrapper<kj::Own<kj::AsyncIoStream>>> connectionStream,
@@ -155,7 +155,7 @@ public:
     tracker.trackField("openedPromise", openedPromise);
   }
 
-private:
+ private:
   // TODO(cleanup): Combine all the IoOwns here into one, to improve efficiency and make
   //   shutdown order clearer.
 
@@ -235,7 +235,7 @@ jsg::Ref<Socket> connectImpl(jsg::Lock& js,
     jsg::Optional<SocketOptions> options);
 
 class SocketsModule final: public jsg::Object {
-public:
+ public:
   SocketsModule() = default;
   SocketsModule(jsg::Lock&, const jsg::Url&) {}
 

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -13,7 +13,7 @@
 namespace workerd::api {
 
 class SqlStorage final: public jsg::Object, private SqliteDatabase::Regulator {
-public:
+ public:
   SqlStorage(jsg::Ref<DurableObjectStorage> storage);
   ~SqlStorage();
 
@@ -60,7 +60,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   void visitForGc(jsg::GcVisitor& visitor) {
     visitor.visit(storage);
   }
@@ -99,7 +99,7 @@ private:
   };
 
   class StatementCacheCallbacks {
-  public:
+   public:
     inline const jsg::HashableV8Ref<v8::String>& keyForRow(
         const kj::Rc<CachedStatement>& entry) const {
       return entry->query;
@@ -173,7 +173,7 @@ private:
 };
 
 class SqlStorage::Cursor final: public jsg::Object {
-public:
+ public:
   template <typename... Params>
   Cursor(jsg::Lock& js, Params&&... params) {
     auto stateObj = kj::heap<State>(kj::fwd<Params>(params)...);
@@ -234,7 +234,7 @@ public:
     return reusedCachedQuery;
   }
 
-private:
+ private:
   struct State {
     kj::Maybe<kj::Rc<CachedStatement>> cachedStatement;
 
@@ -303,7 +303,7 @@ private:
 // implement automatic prepared statement caching via the simple `exec()` API. Since this is
 // a compatibility shim only, to simplify things, it is acutally just a wrapper around `exec()`.
 class SqlStorage::Statement final: public jsg::Object {
-public:
+ public:
   Statement(jsg::Lock& js, jsg::Ref<SqlStorage> sqlStorage, jsg::JsString query)
       : sqlStorage(kj::mv(sqlStorage)),
         // Internalize the string before constructing the statement so that it doesn't have to
@@ -321,7 +321,7 @@ public:
     tracker.trackField("query", query);
   }
 
-private:
+ private:
   jsg::Ref<SqlStorage> sqlStorage;
   jsg::V8Ref<v8::String> query;
 

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -189,7 +189,7 @@ struct Transformer {
 // a kj stream, you will implement the WritableStreamSink API.
 
 class WritableStreamSink {
-public:
+ public:
   virtual kj::Promise<void> write(kj::ArrayPtr<const byte> buffer) KJ_WARN_UNUSED_RESULT = 0;
   virtual kj::Promise<void> write(
       kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) KJ_WARN_UNUSED_RESULT = 0;
@@ -215,7 +215,7 @@ public:
 };
 
 class ReadableStreamSource {
-public:
+ public:
   virtual kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) = 0;
 
   // The ReadableStreamSource version of pumpTo() has no `amount` parameter, since the Streams spec
@@ -320,13 +320,13 @@ struct Erroring {
 // standard dictates that streams can be canceled/aborted/errored using any arbitrary JavaScript
 // value, not just Errors.
 class ReadableStreamController {
-public:
+ public:
   // The ReadableStreamController::Reader interface is a base for all ReadableStream reader
   // implementations and is used solely as a means of attaching a Reader implementation to
   // the internal state of the controller. See the ReadableStream::*Reader classes for the
   // full Reader API.
   class Reader {
-  public:
+   public:
     // True if the reader is a BYOB reader.
     virtual bool isByteOriented() const = 0;
 
@@ -373,11 +373,11 @@ public:
   // the TeeController to interface with the shared underlying source, and the
   // TeeController ensures that each Branch receives the data that is read.
   class TeeController {
-  public:
+   public:
     // Represents an individual ReadableStreamController tee branch registered with
     // a TeeController. One or more branches is registered with the TeeController.
     class Branch {
-    public:
+     public:
       virtual ~Branch() noexcept(false) {}
 
       virtual void doClose(jsg::Lock& js) = 0;
@@ -386,7 +386,7 @@ public:
     };
 
     class BranchPtr {
-    public:
+     public:
       inline BranchPtr(Branch* branch): inner(branch) {
         KJ_ASSERT(inner != nullptr);
       }
@@ -414,7 +414,7 @@ public:
         return inner == other.inner;
       }
 
-    private:
+     private:
       Branch* inner;
     };
 
@@ -437,7 +437,7 @@ public:
   // and WritableStreamController so that the pipeTo/pipeThrough/tryPipeTo can work
   // without caring about what kind of controller it is working with.
   class PipeController {
-  public:
+   public:
     virtual ~PipeController() noexcept(false) {}
     virtual bool isClosed() = 0;
     virtual kj::Maybe<v8::Local<v8::Value>> tryGetErrored(jsg::Lock& js) = 0;
@@ -580,13 +580,13 @@ kj::Own<ReadableStreamController> newReadableStreamInternalController(
 // standard dictates that streams can be canceled/aborted/errored using any arbitrary JavaScript
 // value, not just Errors.
 class WritableStreamController {
-public:
+ public:
   // The WritableStreamController::Writer interface is a base for all WritableStream writer
   // implementations and is used solely as a means of attaching a Writer implementation to
   // the internal state of the controller. See the WritableStream::*Writer classes for the
   // full Writer API.
   class Writer {
-  public:
+   public:
     // When a Writer is locked to a controller, the controller will attach itself to the writer,
     // passing along the closed and ready promises that will be used to communicate state to the
     // user code.
@@ -737,7 +737,7 @@ struct Locked {};
 // When a reader is locked to a ReadableStream, a ReaderLock instance
 // is used internally to represent the locked state in the ReadableStreamController.
 class ReaderLocked {
-public:
+ public:
   ReaderLocked(ReadableStreamController::Reader& reader,
       jsg::Promise<void>::Resolver closedFulfiller,
       kj::Maybe<IoOwn<kj::Canceler>> canceler = kj::none)
@@ -780,7 +780,7 @@ public:
     tracker.trackFieldWithSize("IoOwn<kj::Canceler>", sizeof(IoOwn<kj::Canceler>));
   }
 
-private:
+ private:
   kj::Maybe<ReadableStreamController::Reader&> reader;
   kj::Maybe<jsg::Promise<void>::Resolver> closedFulfiller;
   kj::Maybe<IoOwn<kj::Canceler>> canceler;
@@ -789,7 +789,7 @@ private:
 // When a writer is locked to a WritableStream, a WriterLock instance
 // is used internally to represent the locked state in the WritableStreamController.
 class WriterLocked {
-public:
+ public:
   WriterLocked(WritableStreamController::Writer& writer,
       jsg::Promise<void>::Resolver closedFulfiller,
       kj::Maybe<jsg::Promise<void>::Resolver> readyFulfiller = kj::none)
@@ -838,7 +838,7 @@ public:
     tracker.trackField("readyFulfiller", readyFulfiller);
   }
 
-private:
+ private:
   kj::Maybe<WritableStreamController::Writer&> writer;
   kj::Maybe<jsg::Promise<void>::Resolver> closedFulfiller;
   kj::Maybe<jsg::Promise<void>::Resolver> readyFulfiller;

--- a/src/workerd/api/streams/compression.c++
+++ b/src/workerd/api/streams/compression.c++
@@ -67,7 +67,7 @@ void CompressionAllocator::FreeForZlib(void* opaque, void* pointer) {
 namespace {
 
 class Context {
-public:
+ public:
   enum class Mode {
     COMPRESS,
     DECOMPRESS,
@@ -160,10 +160,10 @@ public:
     };
   }
 
-protected:
+ protected:
   CompressionAllocator allocator;
 
-private:
+ private:
   static int getWindowBits(kj::StringPtr format) {
     // We use a windowBits value of 15 combined with the magic value
     // for the compression format type. For gzip, the magic value is
@@ -195,7 +195,7 @@ private:
 // excessive copying when reading a larger amount of buffered data in small chunks. valid_size_ is
 // used to track the amount of data that has not been read back yet.
 class LazyBuffer {
-public:
+ public:
   LazyBuffer(): valid_size_(0) {}
 
   // Return a chunk of data and mark it as invalid. The returned chunk remains valid until data is
@@ -240,7 +240,7 @@ public:
     return valid_size_ == 0;
   }
 
-private:
+ private:
   std::vector<kj::byte> output;
   size_t valid_size_;
 };
@@ -250,7 +250,7 @@ template <Context::Mode mode>
 class CompressionStreamImpl: public kj::Refcounted,
                              public ReadableStreamSource,
                              public WritableStreamSink {
-public:
+ public:
   explicit CompressionStreamImpl(kj::String format, Context::ContextFlags flags)
       : context(mode, format, flags) {}
 
@@ -326,7 +326,7 @@ public:
     cancelInternal(kj::mv(reason));
   }
 
-private:
+ private:
   struct PendingRead {
     kj::ArrayPtr<kj::byte> buffer;
     size_t minBytes = 1;

--- a/src/workerd/api/streams/compression.h
+++ b/src/workerd/api/streams/compression.h
@@ -17,14 +17,14 @@ namespace workerd::api {
 // instance. Therefore, we lookup the current jsg::Lock instance from the
 // isolate pointer and use that to get the external memory adjustment.
 class CompressionAllocator final {
-public:
+ public:
   void configure(z_stream* stream);
 
   static void* AllocForZlib(void* data, uInt items, uInt size);
   static void* AllocForBrotli(void* data, size_t size);
   static void FreeForZlib(void* data, void* pointer);
 
-private:
+ private:
   struct Allocation {
     kj::Array<kj::byte> data;
     kj::Maybe<jsg::ExternalMemoryAdjustment> memoryAdjustment = kj::none;
@@ -33,7 +33,7 @@ private:
 };
 
 class CompressionStream: public TransformStream {
-public:
+ public:
   using TransformStream::TransformStream;
 
   static jsg::Ref<CompressionStream> constructor(kj::String format);
@@ -48,7 +48,7 @@ public:
 };
 
 class DecompressionStream: public TransformStream {
-public:
+ public:
   using TransformStream::TransformStream;
 
   static jsg::Ref<DecompressionStream> constructor(jsg::Lock& js, kj::String format);

--- a/src/workerd/api/streams/encoding.c++
+++ b/src/workerd/api/streams/encoding.c++
@@ -13,8 +13,8 @@ namespace workerd::api {
 
 namespace {
 class TextEncoderStreamController: public kj::Refcounted {
-public:
-private:
+ public:
+ private:
   jsg::Ref<TextEncoder> encoder = jsg::alloc<TextEncoder>();
 };
 }  // namespace

--- a/src/workerd/api/streams/encoding.h
+++ b/src/workerd/api/streams/encoding.h
@@ -13,7 +13,7 @@
 namespace workerd::api {
 
 class TextEncoderStream: public TransformStream {
-public:
+ public:
   using TransformStream::TransformStream;
 
   static jsg::Ref<TextEncoderStream> constructor(jsg::Lock& js);
@@ -32,7 +32,7 @@ public:
 };
 
 class TextDecoderStream: public TransformStream {
-public:
+ public:
   struct TextDecoderStreamInit {
     jsg::Optional<bool> fatal;
     jsg::Optional<bool> ignoreBOM;
@@ -62,7 +62,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   jsg::Ref<TextDecoder> decoder;
 
   void visitForGc(jsg::GcVisitor& visitor);

--- a/src/workerd/api/streams/internal-test.c++
+++ b/src/workerd/api/streams/internal-test.c++
@@ -17,7 +17,7 @@ namespace {
 
 template <int size>
 class FooStream: public ReadableStreamSource {
-public:
+ public:
   FooStream(): ptr(&data[0]), remaining_(size) {
     KJ_ASSERT(RAND_bytes(data, size) == 1);
   }
@@ -50,7 +50,7 @@ public:
     return maxMaxBytesSeen_;
   }
 
-private:
+ private:
   uint8_t data[size];
   uint8_t* ptr;
   size_t remaining_;
@@ -60,7 +60,7 @@ private:
 
 template <int size>
 class BarStream: public FooStream<size> {
-public:
+ public:
   kj::Maybe<uint64_t> tryGetLength(StreamEncoding encoding) {
     return size;
   }
@@ -143,7 +143,7 @@ KJ_TEST("zero-length stream") {
   kj::WaitScope waitScope(loop);
 
   class Zero: public ReadableStreamSource {
-  public:
+   public:
     kj::Promise<size_t> tryRead(void*, size_t, size_t) {
       return (size_t)0;
     }
@@ -163,7 +163,7 @@ KJ_TEST("lying stream") {
   kj::WaitScope waitScope(loop);
 
   class Dishonest: public FooStream<10000> {
-  public:
+   public:
     kj::Maybe<uint64_t> tryGetLength(StreamEncoding encoding) {
       return (size_t)10;
     }
@@ -186,7 +186,7 @@ KJ_TEST("honest small stream") {
   kj::WaitScope waitScope(loop);
 
   class HonestSmall: public FooStream<100> {
-  public:
+   public:
     kj::Maybe<uint64_t> tryGetLength(StreamEncoding encoding) {
       return (size_t)100;
     }
@@ -212,7 +212,7 @@ KJ_TEST("WritableStreamInternalController queue size assertion") {
   TestFixture fixture({.featureFlags = flags.asReader()});
 
   class MySink final: public WritableStreamSink {
-  public:
+   public:
     kj::Promise<void> write(kj::ArrayPtr<const byte> buffer) override {
       return kj::READY_NOW;
     }
@@ -285,7 +285,7 @@ KJ_TEST("WritableStreamInternalController observability") {
   TestFixture fixture({.featureFlags = flags.asReader()});
 
   class MySink final: public WritableStreamSink {
-  public:
+   public:
     kj::Promise<void> write(kj::ArrayPtr<const byte> buffer) override {
       ++writeCount;
       return kj::READY_NOW;
@@ -301,12 +301,12 @@ KJ_TEST("WritableStreamInternalController observability") {
       return writeCount;
     }
 
-  private:
+   private:
     uint writeCount = 0;
   };
 
   class MyObserver final: public ByteStreamObserver {
-  public:
+   public:
     virtual void onChunkEnqueued(size_t bytes) {
       ++queueSize;
       queueSizeBytes += bytes;

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -51,7 +51,7 @@ kj::Promise<void> pumpTo(ReadableStreamSource& input, WritableStreamSink& output
 
 // Modified from AllReader in kj/async-io.c++.
 class AllReader final {
-public:
+ public:
   explicit AllReader(ReadableStreamSource& input, uint64_t limit): input(input), limit(limit) {
     JSG_REQUIRE(limit > 0, TypeError, "Memory limit exceeded before EOF.");
     KJ_IF_SOME(length, input.tryGetLength(StreamEncoding::IDENTITY)) {
@@ -70,7 +70,7 @@ public:
     co_return kj::String(kj::mv(data));
   }
 
-private:
+ private:
   ReadableStreamSource& input;
   uint64_t limit;
 
@@ -246,7 +246,7 @@ kj::Exception reasonToException(jsg::Lock& js,
 
 // Adapt ReadableStreamSource to kj::AsyncInputStream's interface for use with `kj::newTee()`.
 class TeeAdapter final: public kj::AsyncInputStream {
-public:
+ public:
   explicit TeeAdapter(kj::Own<ReadableStreamSource> inner): inner(kj::mv(inner)) {}
 
   kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
@@ -257,12 +257,12 @@ public:
     return inner->tryGetLength(StreamEncoding::IDENTITY);
   }
 
-private:
+ private:
   kj::Own<ReadableStreamSource> inner;
 };
 
 class TeeBranch final: public ReadableStreamSource {
-public:
+ public:
   explicit TeeBranch(kj::Own<kj::AsyncInputStream> inner): inner(kj::mv(inner)) {}
 
   kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
@@ -321,12 +321,12 @@ public:
     // TODO(someday): What to do?
   }
 
-private:
+ private:
   // Adapt WritableStreamSink to kj::AsyncOutputStream's interface for use in
   // `TeeBranch::pumpTo()`. If you squint, the write logic looks very similar to TeeAdapter's
   // read logic.
   class PumpAdapter final: public kj::AsyncOutputStream {
-  public:
+   public:
     explicit PumpAdapter(WritableStreamSink& inner): inner(inner) {}
 
     kj::Promise<void> write(kj::ArrayPtr<const byte> buffer) override {
@@ -350,9 +350,9 @@ private:
 static const WarningAggregator::Key unusedStreamBranchKey;
 
 class WarnIfUnusedStream final: public ReadableStreamSource {
-public:
+ public:
   class UnusedStreamWarningContext final: public WarningAggregator::WarningContext {
-  public:
+   public:
     UnusedStreamWarningContext(jsg::Lock& js): exception(jsg::JsRef(js, js.error(""_kjc))) {}
 
     kj::String toString(jsg::Lock& js) override {
@@ -362,7 +362,7 @@ public:
       return obj.get(js, "stack"_kjc).toString(js);
     }
 
-  private:
+   private:
     jsg::JsRef<jsg::JsValue> exception;
   };
 
@@ -442,7 +442,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::Own<WarningAggregator> warningAggregator;
   kj::Own<UnusedStreamWarningContext> warningContext;
   kj::Own<ReadableStreamSource> inner;
@@ -779,7 +779,7 @@ kj::Maybe<kj::Own<ReadableStreamSource>> ReadableStreamInternalController::remov
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {
       class NullSource final: public ReadableStreamSource {
-      public:
+       public:
         kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
           return size_t(0);
         }

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -36,7 +36,7 @@ namespace workerd::api {
 class WritableStreamInternalController;
 
 class ReadableStreamInternalController: public ReadableStreamController {
-public:
+ public:
   using Readable = IoOwn<ReadableStreamSource>;
 
   explicit ReadableStreamInternalController(StreamStates::Closed closed): state(closed) {}
@@ -116,13 +116,13 @@ public:
   size_t jsgGetMemorySelfSize() const override;
   void jsgGetMemoryInfo(jsg::MemoryTracker& info) const override;
 
-private:
+ private:
   void doCancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason);
   void doClose(jsg::Lock& js);
   void doError(jsg::Lock& js, v8::Local<v8::Value> reason);
 
   class PipeLocked: public PipeController {
-  public:
+   public:
     PipeLocked(ReadableStreamInternalController& inner, jsg::Ref<WritableStream> ref)
         : inner(inner),
           ref(kj::mv(ref)) {}
@@ -151,7 +151,7 @@ private:
     size_t jsgGetMemorySelfSize() const;
     void jsgGetMemoryInfo(jsg::MemoryTracker& info) const;
 
-  private:
+   private:
     ReadableStreamInternalController& inner;
     jsg::Ref<WritableStream> ref;
   };
@@ -172,7 +172,7 @@ private:
 };
 
 class WritableStreamInternalController: public WritableStreamController {
-public:
+ public:
   struct Writable {
     kj::Own<WritableStreamSink> sink;
     kj::Canceler canceler;
@@ -254,7 +254,7 @@ public:
   size_t jsgGetMemorySelfSize() const override;
   void jsgGetMemoryInfo(jsg::MemoryTracker& info) const override;
 
-private:
+ private:
   struct AbortOptions {
     bool reject = false;
     bool handled = false;
@@ -390,7 +390,7 @@ class IdentityTransformStreamImpl: public kj::Refcounted,
                                    public WritableStreamSink {
   // TODO(soon): Reimplement this in terms of kj::OneWayPipe, so we can optimize pumpTo().
 
-public:
+ public:
   explicit IdentityTransformStreamImpl(kj::Maybe<uint64_t> limit = kj::none): limit(limit) {}
 
   ~IdentityTransformStreamImpl() noexcept(false) {
@@ -425,7 +425,7 @@ public:
 
   void abort(kj::Exception reason) override;
 
-private:
+ private:
   kj::Promise<size_t> readHelper(kj::ArrayPtr<kj::byte> bytes);
 
   kj::Promise<void> writeHelper(kj::ArrayPtr<const kj::byte> bytes);

--- a/src/workerd/api/streams/queue.h
+++ b/src/workerd/api/streams/queue.h
@@ -147,7 +147,7 @@ class QueueImpl;
 // Provides the underlying implementation shared by ByteQueue and ValueQueue.
 template <typename Self>
 class QueueImpl final {
-public:
+ public:
   using ConsumerImpl = ConsumerImpl<Self>;
   using Entry = typename Self::Entry;
   using State = typename Self::State;
@@ -278,7 +278,7 @@ public:
   inline size_t jsgGetMemorySelfSize() const;
   inline void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   struct Closed {};
   using Errored = jsg::Value;
 
@@ -310,7 +310,7 @@ private:
 // Provides the underlying implementation shared by ByteQueue::Consumer and ValueQueue::Consumer
 template <typename Self>
 class ConsumerImpl final {
-public:
+ public:
   struct StateListener {
     virtual void onConsumerClose(jsg::Lock& js) = 0;
     virtual void onConsumerError(jsg::Lock& js, jsg::Value reason) = 0;
@@ -537,7 +537,7 @@ public:
   inline size_t jsgGetMemorySelfSize() const;
   inline void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   // A sentinel used in the buffer to signal that close() has been called.
   struct Close {};
 
@@ -632,7 +632,7 @@ private:
 // Value queue
 
 class ValueQueue final {
-public:
+ public:
   using ConsumerImpl = ConsumerImpl<ValueQueue>;
   using QueueImpl = QueueImpl<ValueQueue>;
 
@@ -655,7 +655,7 @@ public:
   // A value queue entry consists of an arbitrary JavaScript value and a size that is
   // calculated by the size algorithm function provided in the stream constructor.
   class Entry {
-  public:
+   public:
     explicit Entry(jsg::Value value, size_t size);
     KJ_DISALLOW_COPY_AND_MOVE(Entry);
 
@@ -671,7 +671,7 @@ public:
       tracker.trackField("value", value);
     }
 
-  private:
+   private:
     jsg::Value value;
     size_t size;
   };
@@ -686,7 +686,7 @@ public:
   };
 
   class Consumer final {
-  public:
+   public:
     Consumer(ValueQueue& queue, kj::Maybe<ConsumerImpl::StateListener&> stateListener = kj::none);
     Consumer(QueueImpl& queue, kj::Maybe<ConsumerImpl::StateListener&> stateListener = kj::none);
     Consumer(Consumer&&) = delete;
@@ -722,7 +722,7 @@ public:
     inline size_t jsgGetMemorySelfSize() const;
     inline void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-  private:
+   private:
     ConsumerImpl impl;
 
     friend class ValueQueue;
@@ -754,7 +754,7 @@ public:
   inline size_t jsgGetMemorySelfSize() const;
   inline void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   QueueImpl impl;
 
   static void handlePush(
@@ -774,7 +774,7 @@ private:
 // Byte queue
 
 class ByteQueue final {
-public:
+ public:
   using ConsumerImpl = ConsumerImpl<ByteQueue>;
   using QueueImpl = QueueImpl<ByteQueue>;
 
@@ -822,7 +822,7 @@ public:
   // the BYOB read request. Once either of those are called, or once invalidate() is called,
   // the ByobRequest is no longer usable and should be discarded.
   class ByobRequest final {
-  public:
+   public:
     ByobRequest(ReadRequest& request, ConsumerImpl& consumer, QueueImpl& queue)
         : request(request),
           consumer(consumer),
@@ -856,7 +856,7 @@ public:
 
     JSG_MEMORY_INFO(ByteQueue::ByobRequest) {}
 
-  private:
+   private:
     kj::Maybe<ReadRequest&> request;
     ConsumerImpl& consumer;
     QueueImpl& queue;
@@ -875,7 +875,7 @@ public:
   // A byte queue entry consists of a jsg::BufferSource containing a non-zero-length
   // sequence of bytes. The size is determined by the number of bytes in the entry.
   class Entry {
-  public:
+   public:
     explicit Entry(jsg::BufferSource store);
 
     kj::ArrayPtr<kj::byte> toArrayPtr();
@@ -890,7 +890,7 @@ public:
       tracker.trackField("store", store);
     }
 
-  private:
+   private:
     jsg::BufferSource store;
   };
 
@@ -906,7 +906,7 @@ public:
   };
 
   class Consumer {
-  public:
+   public:
     Consumer(ByteQueue& queue, kj::Maybe<ConsumerImpl::StateListener&> stateListener = kj::none);
     Consumer(QueueImpl& queue, kj::Maybe<ConsumerImpl::StateListener&> stateListener = kj::none);
     Consumer(Consumer&&) = delete;
@@ -941,7 +941,7 @@ public:
     inline size_t jsgGetMemorySelfSize() const;
     inline void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-  private:
+   private:
     ConsumerImpl impl;
   };
 
@@ -981,7 +981,7 @@ public:
   inline size_t jsgGetMemorySelfSize() const;
   inline void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   QueueImpl impl;
 
   static void handlePush(

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -518,7 +518,7 @@ namespace {
 // HACK: We need as async pipe, like kj::newOneWayPipe(), except supporting explicit end(). So we
 //   wrap the two ends of the pipe in special adapters that track whether end() was called.
 class ExplicitEndOutputPipeAdapter final: public capnp::ExplicitEndOutputStream {
-public:
+ public:
   ExplicitEndOutputPipeAdapter(
       kj::Own<kj::AsyncOutputStream> inner, kj::Own<kj::RefcountedWrapper<bool>> ended)
       : inner(kj::mv(inner)),
@@ -547,13 +547,13 @@ public:
     return kj::READY_NOW;
   }
 
-private:
+ private:
   kj::Maybe<kj::Own<kj::AsyncOutputStream>> inner;
   kj::Own<kj::RefcountedWrapper<bool>> ended;
 };
 
 class ExplicitEndInputPipeAdapter final: public kj::AsyncInputStream {
-public:
+ public:
   ExplicitEndInputPipeAdapter(kj::Own<kj::AsyncInputStream> inner,
       kj::Own<kj::RefcountedWrapper<bool>> ended,
       kj::Maybe<uint64_t> expectedLength)
@@ -592,7 +592,7 @@ public:
     return inner->pumpTo(output, amount);
   }
 
-private:
+ private:
   kj::Own<kj::AsyncInputStream> inner;
   kj::Own<kj::RefcountedWrapper<bool>> ended;
   kj::Maybe<uint64_t> expectedLength;
@@ -605,7 +605,7 @@ private:
 // TODO(someday): Devise a better way for RPC streams to extend the lifetime of the RPC session
 //   beyond the destruction of the IoContext, if it is being used for deferred proxying.
 class NoDeferredProxyReadableStream final: public ReadableStreamSource {
-public:
+ public:
   NoDeferredProxyReadableStream(kj::Own<ReadableStreamSource> inner, IoContext& ioctx)
       : inner(kj::mv(inner)),
         ioctx(ioctx) {}
@@ -643,7 +643,7 @@ public:
     });
   }
 
-private:
+ private:
   kj::Own<ReadableStreamSource> inner;
   IoContext& ioctx;
 };

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -43,7 +43,7 @@ namespace {
 // for implementing the reader lock in a consistent way (without duplicating any code).
 template <typename Controller>
 class ReadableLockImpl {
-public:
+ public:
   using PipeController = ReadableStreamController::PipeController;
   using Reader = ReadableStreamController::Reader;
 
@@ -84,9 +84,9 @@ public:
     }
   }
 
-private:
+ private:
   class PipeLocked final: public PipeController {
-  public:
+   public:
     explicit PipeLocked(Controller& inner, jsg::Ref<WritableStream> ref)
         : inner(inner),
           writableStreamRef(kj::mv(ref)) {}
@@ -133,7 +133,7 @@ private:
       tracker.trackField("writableStreamRef", writableStreamRef);
     }
 
-  private:
+   private:
     Controller& inner;
     jsg::Ref<WritableStream> writableStreamRef;
 
@@ -149,7 +149,7 @@ private:
 // eventually allow it to be shared also with WritableStreamInternalController.
 template <typename Controller>
 class WritableLockImpl {
-public:
+ public:
   using Writer = WritableStreamController::Writer;
 
   bool isLockedToWriter() const;
@@ -177,7 +177,7 @@ public:
     }
   }
 
-private:
+ private:
   struct PipeLocked {
     ReadableStreamController::PipeController& source;
     jsg::Ref<ReadableStream> readableStreamRef;
@@ -631,7 +631,7 @@ jsg::Promise<ReadResult> deferControllerStateChange(jsg::Lock& js,
 // These are the objects that are actually passed on to the user-code's Underlying Source
 // implementation.
 class ReadableStreamJsController final: public ReadableStreamController {
-public:
+ public:
   using ReadableLockImpl = ReadableLockImpl<ReadableStreamJsController>;
 
   KJ_DISALLOW_COPY_AND_MOVE(ReadableStreamJsController);
@@ -717,7 +717,7 @@ public:
   size_t jsgGetMemorySelfSize() const override;
   void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const override;
 
-private:
+ private:
   // If the stream was created within the scope of a request, we want to treat it as I/O
   // and make sure it is not advanced from the scope of a different request.
   kj::Maybe<IoContext&> ioContext;
@@ -764,7 +764,7 @@ private:
 // WritableStream's backed by a user-code provided Underlying Sink. The implementation
 // is fairly complicated and defined entirely by the streams specification.
 class WritableStreamJsController final: public WritableStreamController {
-public:
+ public:
   using WritableLockImpl = WritableLockImpl<WritableStreamJsController>;
 
   using Controller = jsg::Ref<WritableStreamDefaultController>;
@@ -848,7 +848,7 @@ public:
   size_t jsgGetMemorySelfSize() const override;
   void jsgGetMemoryInfo(jsg::MemoryTracker& info) const override;
 
-private:
+ private:
   jsg::Promise<void> pipeLoop(jsg::Lock& js);
 
   kj::Maybe<IoContext&> ioContext;
@@ -2637,7 +2637,7 @@ namespace {
 // Consumes all bytes from a stream, buffering in memory, with the purpose
 // of producing either a single concatenated kj::Array<byte> or kj::String.
 class AllReader {
-public:
+ public:
   using PartList = kj::Array<kj::ArrayPtr<byte>>;
 
   AllReader(jsg::Ref<ReadableStream> stream, uint64_t limit): state(kj::mv(stream)), limit(limit) {}
@@ -2672,7 +2672,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::OneOf<StreamStates::Closed, StreamStates::Errored, jsg::Ref<ReadableStream>> state;
   uint64_t limit;
   kj::Vector<jsg::BufferSource> parts;
@@ -2757,7 +2757,7 @@ private:
 };
 
 class PumpToReader {
-public:
+ public:
   PumpToReader(jsg::Ref<ReadableStream> stream, kj::Own<WritableStreamSink> sink, bool end)
       : ioContext(IoContext::current()),
         state(kj::mv(stream)),
@@ -2805,7 +2805,7 @@ public:
     KJ_UNREACHABLE;
   }
 
-private:
+ private:
   struct Pumping {};
   IoContext& ioContext;
   kj::OneOf<Pumping, StreamStates::Closed, kj::Exception, jsg::Ref<ReadableStream>> state;

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -130,7 +130,7 @@ class WritableStreamJsController;
 // ReadableStreamDefaultController and the ReadableByteStreamController.
 template <class Self>
 class ReadableImpl {
-public:
+ public:
   using Consumer = typename Self::QueueType::Consumer;
   using Entry = typename Self::QueueType::Entry;
   using StateListener = typename Self::QueueType::ConsumerImpl::StateListener;
@@ -187,7 +187,7 @@ public:
   size_t jsgGetMemorySelfSize() const;
   void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   struct Algorithms {
     kj::Maybe<jsg::Function<UnderlyingSource::StartAlgorithm>> start;
     kj::Maybe<jsg::Function<UnderlyingSource::PullAlgorithm>> pull;
@@ -246,7 +246,7 @@ private:
 // controllers be introduced.
 template <class Self>
 class WritableImpl {
-public:
+ public:
   using PendingAbort = WritableStreamController::PendingAbort;
 
   struct WriteRequest {
@@ -326,7 +326,7 @@ public:
   size_t jsgGetMemorySelfSize() const;
   void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   struct Algorithms {
     kj::Maybe<jsg::Function<UnderlyingSink::AbortAlgorithm>> abort;
     kj::Maybe<jsg::Function<UnderlyingSink::CloseAlgorithm>> close;
@@ -386,7 +386,7 @@ private:
 // It is capable of streaming any JavaScript value through it, including typed arrays and
 // array buffers, but treats all values as opaque. BYOB reads are not supported.
 class ReadableStreamDefaultController: public jsg::Object {
-public:
+ public:
   using QueueType = ValueQueue;
   using ReadableImpl = ReadableImpl<ReadableStreamDefaultController>;
 
@@ -429,7 +429,7 @@ public:
 
   kj::Maybe<StreamStates::Errored> getMaybeErrorState(jsg::Lock& js);
 
-private:
+ private:
   kj::Maybe<IoContext&> ioContext;
   ReadableImpl impl;
 
@@ -450,7 +450,7 @@ private:
 // dictated by the streams specification since the class name is used as the exported
 // object name.
 class ReadableStreamBYOBRequest: public jsg::Object {
-public:
+ public:
   ReadableStreamBYOBRequest(jsg::Lock& js,
       kj::Own<ByteQueue::ByobRequest> readRequest,
       jsg::Ref<ReadableByteStreamController> controller);
@@ -484,7 +484,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   struct Impl {
     kj::Own<ByteQueue::ByobRequest> readRequest;
     jsg::Ref<ReadableByteStreamController> controller;
@@ -507,7 +507,7 @@ private:
 // It is capable of only streaming byte data through it in the form of typed arrays.
 // BYOB reads are supported.
 class ReadableByteStreamController: public jsg::Object {
-public:
+ public:
   using QueueType = ByteQueue;
   using ReadableImpl = ReadableImpl<ReadableByteStreamController>;
 
@@ -548,7 +548,7 @@ public:
     tracker.trackField("maybeByobRequest", maybeByobRequest);
   }
 
-private:
+ private:
   kj::Maybe<IoContext&> ioContext;
   ReadableImpl impl;
   kj::Maybe<jsg::Ref<ReadableStreamBYOBRequest>> maybeByobRequest;
@@ -566,7 +566,7 @@ private:
 // to determine whether it is capable of handling whatever type of JavaScript object it
 // is given.
 class WritableStreamDefaultController: public jsg::Object {
-public:
+ public:
   using WritableImpl = WritableImpl<WritableStreamDefaultController>;
 
   explicit WritableStreamDefaultController(WritableStream& owner);
@@ -600,7 +600,7 @@ public:
 
   void cancelPendingWrites(jsg::Lock& js, jsg::JsValue reason);
 
-private:
+ private:
   kj::Maybe<IoContext&> ioContext;
   WritableImpl impl;
 
@@ -618,7 +618,7 @@ private:
 // However, user code can do silly things like hold the Transform controller
 // long after both the readable and writable sides have been gc'd.
 class TransformStreamDefaultController: public jsg::Object {
-public:
+ public:
   TransformStreamDefaultController(jsg::Lock& js);
 
   void init(jsg::Lock& js,
@@ -660,7 +660,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   struct Algorithms {
     kj::Maybe<jsg::Function<Transformer::TransformAlgorithm>> transform;
     kj::Maybe<jsg::Function<Transformer::FlushAlgorithm>> flush;

--- a/src/workerd/api/streams/transform.h
+++ b/src/workerd/api/streams/transform.h
@@ -21,7 +21,7 @@ namespace workerd::api {
 // non-standard behavior. With the transformstream_enable_standard_constructor flag set, however,
 // the TransformStream implements standardized behavior.
 class TransformStream: public jsg::Object {
-public:
+ public:
   explicit TransformStream(jsg::Ref<ReadableStream> readable, jsg::Ref<WritableStream> writable)
       : readable(kj::mv(readable)),
         writable(kj::mv(writable)) {}
@@ -65,7 +65,7 @@ public:
     tracker.trackField("writable", writable);
   }
 
-private:
+ private:
   jsg::Ref<ReadableStream> readable;
   jsg::Ref<WritableStream> writable;
 
@@ -79,7 +79,7 @@ private:
 // Unlike standard the TransformStream, the readable side of an IdentityTransformStream
 // supports BYOB reads.
 class IdentityTransformStream: public TransformStream {
-public:
+ public:
   using TransformStream::TransformStream;
 
   struct QueuingStrategy {
@@ -102,7 +102,7 @@ public:
 // We don't currently enforce this limit -- it just convinces the kj-http layer to
 // emit a Content-Length (assuming it doesn't get gzipped or anything).
 class FixedLengthStream: public IdentityTransformStream {
-public:
+ public:
   using IdentityTransformStream::IdentityTransformStream;
 
   static jsg::Ref<FixedLengthStream> constructor(jsg::Lock& js,

--- a/src/workerd/api/streams/writable.c++
+++ b/src/workerd/api/streams/writable.c++
@@ -301,7 +301,7 @@ namespace {
 
 // Wrapper around `WritableStreamSink` that makes it suitable for passing off to capnp RPC.
 class WritableStreamRpcAdapter final: public capnp::ExplicitEndOutputStream {
-public:
+ public:
   WritableStreamRpcAdapter(kj::Own<WritableStreamSink> inner): inner(kj::mv(inner)) {}
   ~WritableStreamRpcAdapter() noexcept(false) {
     weakRef->invalidate();
@@ -346,7 +346,7 @@ public:
     return canceler.wrap(getInner().end());
   }
 
-private:
+ private:
   kj::Maybe<kj::Own<WritableStreamSink>> inner;
   kj::Canceler canceler;
   kj::Own<kj::PromiseFulfiller<void>> doneFulfiller;
@@ -371,7 +371,7 @@ private:
 // directly on the WritableStreamController. Note that this approach is necessarily
 // a lot slower
 class WritableStreamJsRpcAdapter final: public capnp::ExplicitEndOutputStream {
-public:
+ public:
   WritableStreamJsRpcAdapter(IoContext& context, jsg::Ref<WritableStreamDefaultWriter> writer)
       : context(context),
         writer(kj::mv(writer)) {}
@@ -513,7 +513,7 @@ public:
     }));
   }
 
-private:
+ private:
   IoContext& context;
   kj::Maybe<jsg::Ref<WritableStreamDefaultWriter>> writer;
   kj::Canceler canceler;

--- a/src/workerd/api/streams/writable.h
+++ b/src/workerd/api/streams/writable.h
@@ -11,7 +11,7 @@
 namespace workerd::api {
 
 class WritableStreamDefaultWriter: public jsg::Object, public WritableStreamController::Writer {
-public:
+ public:
   explicit WritableStreamDefaultWriter();
 
   ~WritableStreamDefaultWriter() noexcept(false) override;
@@ -76,7 +76,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   struct Initial {};
   // While a Writer is attached to a WritableStream, it holds a strong reference to the
   // WritableStream to prevent it from being GC'd so long as the Writer is available.
@@ -98,7 +98,7 @@ private:
 };
 
 class WritableStream: public jsg::Object {
-public:
+ public:
   explicit WritableStream(IoContext& ioContext,
       kj::Own<WritableStreamSink> sink,
       kj::Maybe<kj::Own<ByteStreamObserver>> observer,
@@ -172,7 +172,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   kj::Maybe<IoContext&> ioContext;
   kj::Own<WritableStreamController> controller;
   kj::Own<WeakRef<WritableStream>> weakRef =

--- a/src/workerd/api/system-streams.c++
+++ b/src/workerd/api/system-streams.c++
@@ -20,7 +20,7 @@ namespace {
 // A wrapper around a native `kj::AsyncInputStream` which knows the underlying encoding of the
 // stream and whether or not it requires pending event registration.
 class EncodedAsyncInputStream final: public ReadableStreamSource {
-public:
+ public:
   explicit EncodedAsyncInputStream(
       kj::Own<kj::AsyncInputStream> inner, StreamEncoding encoding, IoContext& context);
 
@@ -47,7 +47,7 @@ public:
   // brotli streams.
   kj::Maybe<Tee> tryTee(uint64_t limit) override;
 
-private:
+ private:
   friend class EncodedAsyncOutputStream;
 
   void ensureIdentityEncoding();
@@ -147,7 +147,7 @@ void EncodedAsyncInputStream::ensureIdentityEncoding() {
 // probably have a distinct end() method of its own that we can defer to, but until it
 // does, it is important for us to release it as soon as end() or abort() are called.
 class EncodedAsyncOutputStream final: public WritableStreamSink {
-public:
+ public:
   explicit EncodedAsyncOutputStream(
       kj::Own<kj::AsyncOutputStream> inner, StreamEncoding encoding, IoContext& context);
 
@@ -163,7 +163,7 @@ public:
 
   StreamEncoding disownEncodingResponsibility() override;
 
-private:
+ private:
   void ensureIdentityEncoding();
 
   // Unwrap `inner` as a `kj::AsyncOutputStream`.

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -23,7 +23,7 @@ class TraceLog;
 class TraceDiagnosticChannelEvent;
 
 class TailEvent final: public ExtendableEvent {
-public:
+ public:
   explicit TailEvent(jsg::Lock& js, kj::StringPtr type, kj::ArrayPtr<kj::Own<Trace>> events);
 
   static jsg::Ref<TailEvent> constructor(kj::String type) = delete;
@@ -41,7 +41,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   kj::Array<jsg::Ref<TraceItem>> events;
 
   void visitForGc(jsg::GcVisitor& visitor) {
@@ -67,7 +67,7 @@ struct ScriptVersion {
 };
 
 class TraceItem final: public jsg::Object {
-public:
+ public:
   class FetchEventInfo;
   class JsRpcEventInfo;
   class ScheduledEventInfo;
@@ -126,7 +126,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   kj::Maybe<EventInfo> eventInfo;
   kj::Maybe<double> eventTimestamp;
   kj::Array<jsg::Ref<TraceLog>> logs;
@@ -162,7 +162,7 @@ private:
 // only set once the request has finished entirely (along with the outcome,
 // see TraceItem::getOutcome).
 class TraceItem::FetchEventInfo final: public jsg::Object {
-public:
+ public:
   class Request;
   class Response;
 
@@ -182,13 +182,13 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   jsg::Ref<Request> request;
   jsg::Optional<jsg::Ref<Response>> response;
 };
 
 class TraceItem::FetchEventInfo::Request final: public jsg::Object {
-public:
+ public:
   struct Detail: public kj::Refcounted {
     jsg::Optional<jsg::V8Ref<v8::Object>> cf;
     kj::Array<Trace::FetchEventInfo::Header> headers;
@@ -235,13 +235,13 @@ public:
     tracker.trackField("detail", detail);
   }
 
-private:
+ private:
   bool redacted = true;
   kj::Own<Detail> detail;
 };
 
 class TraceItem::FetchEventInfo::Response final: public jsg::Object {
-public:
+ public:
   explicit Response(const Trace& trace, const Trace::FetchResponseInfo& responseInfo);
 
   uint16_t getStatus();
@@ -250,12 +250,12 @@ public:
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(status, getStatus);
   }
 
-private:
+ private:
   uint16_t status;
 };
 
 class TraceItem::JsRpcEventInfo final: public jsg::Object {
-public:
+ public:
   explicit JsRpcEventInfo(const Trace& trace, const Trace::JsRpcEventInfo& eventInfo);
 
   // We call this `rpcMethod` to make clear this is an RPC event, since some tail workers rely
@@ -273,12 +273,12 @@ public:
     tracker.trackField("rpcMethod", rpcMethod);
   }
 
-private:
+ private:
   kj::String rpcMethod;
 };
 
 class TraceItem::ScheduledEventInfo final: public jsg::Object {
-public:
+ public:
   explicit ScheduledEventInfo(const Trace& trace, const Trace::ScheduledEventInfo& eventInfo);
 
   double getScheduledTime();
@@ -293,13 +293,13 @@ public:
     tracker.trackField("cron", cron);
   }
 
-private:
+ private:
   double scheduledTime;
   kj::String cron;
 };
 
 class TraceItem::AlarmEventInfo final: public jsg::Object {
-public:
+ public:
   explicit AlarmEventInfo(const Trace& trace, const Trace::AlarmEventInfo& eventInfo);
 
   kj::Date getScheduledTime();
@@ -308,12 +308,12 @@ public:
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(scheduledTime, getScheduledTime);
   }
 
-private:
+ private:
   kj::Date scheduledTime;
 };
 
 class TraceItem::QueueEventInfo final: public jsg::Object {
-public:
+ public:
   explicit QueueEventInfo(const Trace& trace, const Trace::QueueEventInfo& eventInfo);
 
   kj::StringPtr getQueueName();
@@ -329,13 +329,13 @@ public:
     tracker.trackField("queueName", queueName);
   }
 
-private:
+ private:
   kj::String queueName;
   uint32_t batchSize;
 };
 
 class TraceItem::EmailEventInfo final: public jsg::Object {
-public:
+ public:
   explicit EmailEventInfo(const Trace& trace, const Trace::EmailEventInfo& eventInfo);
 
   kj::StringPtr getMailFrom();
@@ -353,14 +353,14 @@ public:
     tracker.trackField("rcptTo", rcptTo);
   }
 
-private:
+ private:
   kj::String mailFrom;
   kj::String rcptTo;
   uint32_t rawSize;
 };
 
 class TraceItem::TailEventInfo final: public jsg::Object {
-public:
+ public:
   class TailItem;
 
   explicit TailEventInfo(const Trace& trace, const Trace::TraceEventInfo& eventInfo);
@@ -373,12 +373,12 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   kj::Array<jsg::Ref<TailItem>> consumedEvents;
 };
 
 class TraceItem::TailEventInfo::TailItem final: public jsg::Object {
-public:
+ public:
   explicit TailItem(const Trace::TraceEventInfo::TraceItem& traceItem);
 
   kj::Maybe<kj::StringPtr> getScriptName();
@@ -391,12 +391,12 @@ public:
     tracker.trackField("scriptName", scriptName);
   }
 
-private:
+ private:
   kj::Maybe<kj::String> scriptName;
 };
 
 class TraceItem::HibernatableWebSocketEventInfo final: public jsg::Object {
-public:
+ public:
   class Message;
   class Close;
   class Error;
@@ -418,12 +418,12 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   Type eventType;
 };
 
 class TraceItem::HibernatableWebSocketEventInfo::Message final: public jsg::Object {
-public:
+ public:
   explicit Message(
       const Trace& trace, const Trace::HibernatableWebSocketEventInfo::Message& eventInfo)
       : eventInfo(eventInfo) {}
@@ -437,12 +437,12 @@ public:
     JSG_READONLY_INSTANCE_PROPERTY(webSocketEventType, getWebSocketEventType);
   }
 
-private:
+ private:
   const Trace::HibernatableWebSocketEventInfo::Message& eventInfo;
 };
 
 class TraceItem::HibernatableWebSocketEventInfo::Close final: public jsg::Object {
-public:
+ public:
   explicit Close(const Trace& trace, const Trace::HibernatableWebSocketEventInfo::Close& eventInfo)
       : eventInfo(eventInfo) {}
 
@@ -460,12 +460,12 @@ public:
     JSG_READONLY_INSTANCE_PROPERTY(wasClean, getWasClean);
   }
 
-private:
+ private:
   const Trace::HibernatableWebSocketEventInfo::Close& eventInfo;
 };
 
 class TraceItem::HibernatableWebSocketEventInfo::Error final: public jsg::Object {
-public:
+ public:
   explicit Error(const Trace& trace, const Trace::HibernatableWebSocketEventInfo::Error& eventInfo)
       : eventInfo(eventInfo) {}
 
@@ -478,22 +478,22 @@ public:
     JSG_READONLY_INSTANCE_PROPERTY(webSocketEventType, getWebSocketEventType);
   }
 
-private:
+ private:
   const Trace::HibernatableWebSocketEventInfo::Error& eventInfo;
 };
 
 class TraceItem::CustomEventInfo final: public jsg::Object {
-public:
+ public:
   explicit CustomEventInfo(const Trace& trace, const Trace::CustomEventInfo& eventInfo);
 
   JSG_RESOURCE_TYPE(CustomEventInfo) {}
 
-private:
+ private:
   const Trace::CustomEventInfo& eventInfo;
 };
 
 class TraceDiagnosticChannelEvent final: public jsg::Object {
-public:
+ public:
   explicit TraceDiagnosticChannelEvent(
       const Trace& trace, const Trace::DiagnosticChannelEvent& eventInfo);
 
@@ -512,14 +512,14 @@ public:
     tracker.trackFieldWithSize("message", message.size());
   }
 
-private:
+ private:
   double timestamp;
   kj::String channel;
   kj::Array<kj::byte> message;
 };
 
 class TraceLog final: public jsg::Object {
-public:
+ public:
   TraceLog(jsg::Lock& js, const Trace& trace, const Trace::Log& log);
 
   double getTimestamp();
@@ -537,14 +537,14 @@ public:
     tracker.trackField("message", message);
   }
 
-private:
+ private:
   double timestamp;
   kj::String level;
   jsg::V8Ref<v8::Object> message;
 };
 
 class TraceException final: public jsg::Object {
-public:
+ public:
   TraceException(const Trace& trace, const Trace::Exception& exception);
 
   double getTimestamp();
@@ -564,7 +564,7 @@ public:
     tracker.trackField("message", message);
   }
 
-private:
+ private:
   double timestamp;
   kj::String name;
   kj::String message;
@@ -572,7 +572,7 @@ private:
 };
 
 class TraceMetrics final: public jsg::Object {
-public:
+ public:
   explicit TraceMetrics(uint cpuTime, uint wallTime);
 
   uint getCPUTime() {
@@ -589,13 +589,13 @@ public:
     JSG_TS_ROOT();
   }
 
-private:
+ private:
   uint cpuTime;
   uint wallTime;
 };
 
 class UnsafeTraceMetrics final: public jsg::Object {
-public:
+ public:
   jsg::Ref<TraceMetrics> fromTrace(jsg::Ref<TraceItem> item);
 
   JSG_RESOURCE_TYPE(UnsafeTraceMetrics) {
@@ -606,7 +606,7 @@ public:
 };
 
 class TraceCustomEventImpl final: public WorkerInterface::CustomEvent {
-public:
+ public:
   TraceCustomEventImpl(uint16_t typeId, kj::Array<kj::Own<Trace>> traces)
       : typeId(typeId),
         traces(kj::mv(traces)) {}
@@ -629,7 +629,7 @@ public:
 
   static constexpr uint16_t TYPE = 2;
 
-private:
+ private:
   uint16_t typeId;
   kj::Array<kj::Own<workerd::Trace>> traces;
 };

--- a/src/workerd/api/unsafe.h
+++ b/src/workerd/api/unsafe.h
@@ -9,7 +9,7 @@ namespace workerd::api {
 
 // A special binding object that allows for dynamic evaluation.
 class UnsafeEval: public jsg::Object {
-public:
+ public:
   UnsafeEval() = default;
   UnsafeEval(jsg::Lock&, const jsg::Url&) {}
 
@@ -62,7 +62,7 @@ public:
 };
 
 class UnsafeModule: public jsg::Object {
-public:
+ public:
   UnsafeModule() = default;
   UnsafeModule(jsg::Lock&, const jsg::Url&) {}
   jsg::Promise<void> abortAllDurableObjects(jsg::Lock& js);

--- a/src/workerd/api/urlpattern.h
+++ b/src/workerd/api/urlpattern.h
@@ -25,7 +25,7 @@ namespace workerd::api {
 // More information about the URL Pattern syntax can be found at
 // https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API
 class URLPattern final: public jsg::Object {
-public:
+ public:
   // A structure providing matching patterns for individual components
   // of a URL. When a URLPattern is created, or when a URLPattern is
   // used to match or test against a URL, the input can be given as
@@ -107,7 +107,7 @@ public:
     tracker.trackField("inner", inner);
   }
 
-private:
+ private:
   jsg::UrlPattern inner;
 #define V(_, name) jsg::JsRef<jsg::JsRegExp> name##Regex;
   URL_PATTERN_COMPONENTS(V)

--- a/src/workerd/api/util.c++
+++ b/src/workerd/api/util.c++
@@ -93,7 +93,7 @@ auto translateTeeErrors(Func&& f) -> decltype(kj::fwd<Func>(f)()) {
 
 kj::Own<kj::AsyncInputStream> newTeeErrorAdapter(kj::Own<kj::AsyncInputStream> inner) {
   class Adapter final: public kj::AsyncInputStream {
-  public:
+   public:
     explicit Adapter(kj::Own<AsyncInputStream> inner): inner(kj::mv(inner)) {}
 
     kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
@@ -112,7 +112,7 @@ kj::Own<kj::AsyncInputStream> newTeeErrorAdapter(kj::Own<kj::AsyncInputStream> i
       return inner->tryTee(limit);
     }
 
-  private:
+   private:
     kj::Own<AsyncInputStream> inner;
   };
 

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -25,7 +25,7 @@ template <typename T>
 struct DeferredProxy;
 
 class MessageEvent: public Event {
-public:
+ public:
   MessageEvent(jsg::Lock& js, const jsg::JsValue& data)
       : Event("message"),
         data(jsg::JsRef(js, data)) {}
@@ -90,7 +90,7 @@ public:
     tracker.trackField("data", data);
   }
 
-private:
+ private:
   jsg::JsRef<jsg::JsValue> data;
 
   void visitForGc(jsg::GcVisitor& visitor) {
@@ -99,7 +99,7 @@ private:
 };
 
 class CloseEvent: public Event {
-public:
+ public:
   CloseEvent(uint code, kj::String reason, bool clean)
       : Event("close"),
         code(code),
@@ -150,7 +150,7 @@ public:
     tracker.trackField("reason", reason);
   }
 
-private:
+ private:
   int code;
   kj::String reason;
   bool clean;
@@ -161,7 +161,7 @@ private:
 class WebSocket;
 
 class WebSocketPair: public jsg::Object {
-private:
+ private:
   struct IteratorState final {
     jsg::Ref<WebSocketPair> pair;
     size_t index = 0;
@@ -175,7 +175,7 @@ private:
     }
   };
 
-public:
+ public:
   WebSocketPair(jsg::Ref<WebSocket> first, jsg::Ref<WebSocket> second)
       : sockets{kj::mv(first), kj::mv(second)} {}
 
@@ -224,7 +224,7 @@ public:
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
-private:
+ private:
   jsg::Ref<WebSocket> sockets[2];
 
   static kj::Maybe<jsg::Ref<WebSocket>> iteratorNext(jsg::Lock& js, IteratorState& state) {
@@ -241,12 +241,12 @@ private:
 };
 
 class WebSocket: public EventTarget {
-private:
+ private:
   // Forward declarations.
   struct PackedWebSocket;
   struct Native;
 
-public:
+ public:
   // WebSocket ready states.
   static constexpr int READY_STATE_CONNECTING = 0;
   static constexpr int READY_STATE_OPEN = 1;
@@ -459,7 +459,7 @@ public:
     return weakRef->addRef();
   }
 
-private:
+ private:
   kj::Own<WeakRef<WebSocket>> weakRef;
   kj::Maybe<kj::String> url;
   kj::Maybe<kj::String> protocol = kj::String();
@@ -529,7 +529,7 @@ private:
 
     // A simple wrapper to make it easier to access the underlying kj::WebSocket.
     class WrappedWebSocket {
-    public:
+     public:
       explicit WrappedWebSocket(Hibernatable ws);
       explicit WrappedWebSocket(kj::Own<kj::WebSocket> ws);
 
@@ -551,7 +551,7 @@ private:
       bool isAwaitingRelease();
       bool isAwaitingError();
 
-    private:
+     private:
       kj::OneOf<kj::Own<kj::WebSocket>, Hibernatable> inner;
     };
 

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -23,7 +23,7 @@ using StreamSinkFulfiller = kj::Own<kj::PromiseFulfiller<rpc::JsValue::StreamSin
 // provide the appropriate destination capability. This class is designed to allow these two
 // calls to happen in either order for each slot.
 class StreamSinkImpl final: public rpc::JsValue::StreamSink::Server, public kj::Refcounted {
-public:
+ public:
   ~StreamSinkImpl() noexcept(false) {
     for (auto& slot: table) {
       KJ_IF_SOME(f, slot.tryGet<StreamFulfiller>()) {
@@ -80,7 +80,7 @@ public:
     return kj::READY_NOW;
   }
 
-private:
+ private:
   using StreamFulfiller = kj::Own<kj::PromiseFulfiller<capnp::Capability::Client>>;
   struct Consumed {};
 
@@ -261,7 +261,7 @@ jsg::JsValue deserializeRpcReturnValue(
 //
 // TODO(cleanup): This is generally useful, should it be part of capnp?
 class CompletionMembrane final: public capnp::MembranePolicy, public kj::Refcounted {
-public:
+ public:
   explicit CompletionMembrane(kj::Own<kj::PromiseFulfiller<void>> doneFulfiller)
       : doneFulfiller(kj::mv(doneFulfiller)) {}
   ~CompletionMembrane() noexcept(false) {
@@ -282,7 +282,7 @@ public:
     return kj::addRef(*this);
   }
 
-private:
+ private:
   kj::Own<kj::PromiseFulfiller<void>> doneFulfiller;
 };
 
@@ -290,7 +290,7 @@ private:
 //
 // TODO(cleanup): This is generally useful, should it be part of capnp?
 class RevokerMembrane final: public capnp::MembranePolicy, public kj::Refcounted {
-public:
+ public:
   explicit RevokerMembrane(kj::Promise<void> promise): promise(promise.fork()) {}
 
   kj::Maybe<capnp::Capability::Client> inboundCall(
@@ -311,7 +311,7 @@ public:
     return promise.addBranch();
   }
 
-private:
+ private:
   kj::ForkedPromise<void> promise;
 };
 
@@ -924,7 +924,7 @@ static MakeCallPipeline::Result makeCallPipeline(jsg::Lock& js, jsg::JsValue val
 // of a top-level entrypoint vs. a transient object introduced by a previous RPC in the same
 // session.
 class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
-public:
+ public:
   JsRpcTargetBase(IoContext& ctx): weakIoContext(ctx.getWeakRef()) {}
 
   struct EnvCtx {
@@ -1146,10 +1146,10 @@ public:
 
   KJ_DISALLOW_COPY_AND_MOVE(JsRpcTargetBase);
 
-protected:
+ protected:
   kj::Own<IoContext::WeakRef> weakIoContext;
 
-private:
+ private:
   // Returns true if the given name cannot be used as a method on this type.
   virtual bool isReservedName(kj::StringPtr name) = 0;
 
@@ -1403,7 +1403,7 @@ private:
 };
 
 class TransientJsRpcTarget final: public JsRpcTargetBase {
-public:
+ public:
   TransientJsRpcTarget(
       jsg::Lock& js, IoContext& ioCtx, jsg::JsObject object, bool allowInstanceProperties = false)
       : JsRpcTargetBase(ioCtx),
@@ -1451,7 +1451,7 @@ public:
     };
   }
 
-private:
+ private:
   struct Handles {
     jsg::JsRef<jsg::JsObject> object;
     kj::Maybe<jsg::V8Ref<v8::Function>> dispose;
@@ -1603,7 +1603,7 @@ void RpcSerializerExternalHander::serializeFunction(
 // JsRpcTarget implementation specific to entrypoints. This is used to deliver the first, top-level
 // call of an RPC session.
 class EntrypointJsRpcTarget final: public JsRpcTargetBase {
-public:
+ public:
   EntrypointJsRpcTarget(IoContext& ioCtx,
       kj::Maybe<kj::StringPtr> entrypointName,
       kj::Maybe<kj::Own<WorkerTracer>> tracer)
@@ -1647,7 +1647,7 @@ public:
     return targetInfo;
   }
 
-private:
+ private:
   kj::Maybe<kj::String> entrypointName;
   kj::Maybe<kj::Own<WorkerTracer>> tracer;
 
@@ -1687,7 +1687,7 @@ private:
 // would create a cycle.
 class JsRpcSessionCustomEventImpl::ServerTopLevelMembrane final: public capnp::MembranePolicy,
                                                                  public kj::Refcounted {
-public:
+ public:
   explicit ServerTopLevelMembrane(kj::Own<kj::PromiseFulfiller<void>> doneFulfiller)
       : doneFulfiller(kj::mv(doneFulfiller)) {}
   ~ServerTopLevelMembrane() noexcept(false) {
@@ -1714,7 +1714,7 @@ public:
     return kj::addRef(*this);
   }
 
-private:
+ private:
   kj::Maybe<kj::Own<kj::PromiseFulfiller<void>>> doneFulfiller;
 };
 

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -33,7 +33,7 @@ constexpr size_t MAX_JS_RPC_MESSAGE_SIZE = 1u << 20;
 // ExternalHandler used when serializing RPC messages. Serialization functions which whish to
 // handle RPC specially should use this.
 class RpcSerializerExternalHander final: public jsg::Serializer::ExternalHandler {
-public:
+ public:
   using GetStreamSinkFunc = kj::Function<rpc::JsValue::StreamSink::Client()>;
 
   // `getStreamSinkFunc` will be called at most once, the first time a stream is encountered in
@@ -66,7 +66,7 @@ public:
   void serializeFunction(
       jsg::Lock& js, jsg::Serializer& serializer, v8::Local<v8::Function> func) override;
 
-private:
+ private:
   GetStreamSinkFunc getStreamSinkFunc;
 
   kj::Vector<BuilderCallback> externals;
@@ -80,7 +80,7 @@ class StreamSinkImpl;
 // ExternalHandler used when deserializing RPC messages. Deserialization functions which whish to
 // handle RPC specially should use this.
 class RpcDeserializerExternalHander final: public jsg::Deserializer::ExternalHandler {
-public:
+ public:
   // The `streamSink` parameter should be provided if a StreamSink already exists, e.g. when
   // deserializing results. If omitted, it will be constructed on-demand.
   RpcDeserializerExternalHander(capnp::List<rpc::JsValue::External>::Reader externals,
@@ -111,7 +111,7 @@ public:
     return kj::mv(streamSinkCap);
   }
 
-private:
+ private:
   capnp::List<rpc::JsValue::External>::Reader externals;
   uint i = 0;
 
@@ -125,7 +125,7 @@ private:
 // Base class for objects which can be sent over RPC, but doing so actually sends a stub which
 // makes RPCs back to the original object.
 class JsRpcTarget: public jsg::Object {
-public:
+ public:
   static jsg::Ref<JsRpcTarget> constructor() {
     return jsg::alloc<JsRpcTarget>();
   }
@@ -143,7 +143,7 @@ public:
 // This class is NOT part of the JavaScript class heirarchy (it has no JSG_RESOURCE_TYPE block),
 // it's only a C++ class used to abstract how to get a capnp client out of the object.
 class JsRpcClientProvider: public jsg::Object {
-public:
+ public:
   // Get a capnp client that can be used to dispatch one call.
   //
   // If this isn't the root object (i.e. this is a JsRpcProperty), the property path starting from
@@ -157,7 +157,7 @@ class JsRpcProperty;
 // Represents the promise returned by calling an RPC method. We don't use a regular Promise object,
 // but rather our own custom thenable, so that we can support pipelining on it.
 class JsRpcPromise: public JsRpcClientProvider {
-public:
+ public:
   // A weak reference to this JsRpcPromise. Unlike the usual WeakRef pattern, though, this ref is
   // allocated before the promise itself is actually created, and filled in later. This is needed
   // to solve cyclic initialization challenges in `callImpl()`.
@@ -218,7 +218,7 @@ public:
     tracker.trackField("inner", inner);
   }
 
-private:
+ private:
   jsg::JsRef<jsg::JsPromise> inner;
   kj::Own<WeakRef> weakRef;
 
@@ -255,7 +255,7 @@ private:
 
 // Represents a property -- possibly, a method -- of a remote RPC object.
 class JsRpcProperty: public JsRpcClientProvider {
-public:
+ public:
   JsRpcProperty(jsg::Ref<JsRpcClientProvider> parent, kj::String name)
       : parent(kj::mv(parent)),
         name(kj::mv(name)) {}
@@ -301,7 +301,7 @@ public:
     tracker.trackField("name", name);
   }
 
-private:
+ private:
   // The parent object from which this property was obtained.
   jsg::Ref<JsRpcClientProvider> parent;
 
@@ -326,7 +326,7 @@ private:
 // `Fetcher`, which has a `getRpcMethod()` call of its own that mostly delegates to
 // `JsRpcStub::sendJsRpc()`.
 class JsRpcStub: public JsRpcClientProvider {
-public:
+ public:
   JsRpcStub(IoOwn<rpc::JsRpcTarget::Client> capnpClient): capnpClient(kj::mv(capnpClient)) {}
   JsRpcStub(IoOwn<rpc::JsRpcTarget::Client> capnpClient, RpcStubDisposalGroup& disposalGroup);
   ~JsRpcStub() noexcept(false);
@@ -365,7 +365,7 @@ public:
 
   JSG_SERIALIZABLE(rpc::SerializationTag::JS_RPC_STUB);
 
-private:
+ private:
   // Nulled out upon dispose().
   kj::Maybe<IoOwn<rpc::JsRpcTarget::Client>> capnpClient;
 
@@ -376,7 +376,7 @@ private:
 };
 
 class RpcStubDisposalGroup {
-public:
+ public:
   ~RpcStubDisposalGroup() noexcept(false);
 
   // Release all the stubs in the group without disposing them. They will have to be disposed
@@ -397,7 +397,7 @@ public:
     callPipeline = kj::mv(value);
   }
 
-private:
+ private:
   kj::List<JsRpcStub, &JsRpcStub::disposalGroupLink> list;
   kj::Maybe<IoOwn<rpc::JsRpcTarget::Client>> callPipeline;
   friend class JsRpcStub;
@@ -406,7 +406,7 @@ private:
 // `jsRpcSession` returns a capability that provides the client a way to call remote methods
 // over RPC. We drain the IncomingRequest after the capability is used to run the relevant JS.
 class JsRpcSessionCustomEventImpl final: public WorkerInterface::CustomEvent {
-public:
+ public:
   JsRpcSessionCustomEventImpl(uint16_t typeId,
       kj::PromiseFulfillerPair<rpc::JsRpcTarget::Client> paf =
           kj::newPromiseAndFulfiller<rpc::JsRpcTarget::Client>())
@@ -443,7 +443,7 @@ public:
   // type in -- so we hardcode it here.
   static constexpr uint16_t WORKER_RPC_EVENT_TYPE = 9;
 
-private:
+ private:
   kj::Own<kj::PromiseFulfiller<workerd::rpc::JsRpcTarget::Client>> capFulfiller;
 
   // We need to set the client/server capability on the event itself to get around CustomEvent's
@@ -468,7 +468,7 @@ private:
 // `env` and `ctx` are automatically available as `this.env` and `this.ctx`, without the need to
 // define a constructor.
 class WorkerEntrypoint: public jsg::Object {
-public:
+ public:
   static jsg::Ref<WorkerEntrypoint> constructor(const v8::FunctionCallbackInfo<v8::Value>& args,
       jsg::Ref<ExecutionContext> ctx,
       jsg::JsObject env);
@@ -487,7 +487,7 @@ public:
 // there were no other kinds of exported classes so this was fine. Going forward, we encourage
 // everyone to be explicit by inheriting this, and we require it if you want to use RPC.
 class DurableObjectBase: public jsg::Object {
-public:
+ public:
   static jsg::Ref<DurableObjectBase> constructor(const v8::FunctionCallbackInfo<v8::Value>& args,
       jsg::Ref<DurableObjectState> ctx,
       jsg::JsObject env);
@@ -508,7 +508,7 @@ public:
 // `env` and `ctx` are automatically available as `this.env` and `this.ctx`, without the need to
 // define a constructor.
 class WorkflowEntrypoint: public jsg::Object {
-public:
+ public:
   static jsg::Ref<WorkflowEntrypoint> constructor(const v8::FunctionCallbackInfo<v8::Value>& args,
       jsg::Ref<ExecutionContext> ctx,
       jsg::JsObject env);
@@ -519,7 +519,7 @@ public:
 // The "cloudflare:workers" module, which exposes the WorkerEntrypoint, WorkflowEntrypoint and DurableObject types
 // for extending.
 class EntrypointsModule: public jsg::Object {
-public:
+ public:
   EntrypointsModule() = default;
   EntrypointsModule(jsg::Lock&, const jsg::Url&) {}
 

--- a/src/workerd/io/actor-cache-test.c++
+++ b/src/workerd/io/actor-cache-test.c++
@@ -197,7 +197,7 @@ struct ActorCacheConvenienceWrappers {
     return target.delete_(KJ_MAP(k, keys) { return kj::str(k); }, options);
   }
 
-private:
+ private:
   ActorCacheOps& target;
 };
 

--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -439,7 +439,7 @@ auto ActorCache::getImpl(
 }
 
 class ActorCache::GetMultiStreamImpl final: public rpc::ActorStorage::ListStream::Server {
-public:
+ public:
   GetMultiStreamImpl(ActorCache& cache,
       kj::Vector<kj::Own<Entry>> cachedEntries,
       kj::Vector<Key> keysToFetchParam,
@@ -743,7 +743,7 @@ inline auto seekOrEnd(auto& map, kj::Maybe<ActorCache::KeyPtr> key) {
 }  // namespace
 
 class ActorCache::ForwardListStreamImpl final: public rpc::ActorStorage::ListStream::Server {
-public:
+ public:
   ForwardListStreamImpl(ActorCache& cache,
       Key beginKey,
       kj::Maybe<Key> endKey,
@@ -1123,7 +1123,7 @@ kj::OneOf<ActorCache::GetResultList, kj::Promise<ActorCache::GetResultList>> Act
 // -----------------------------------------------------------------------------
 
 class ActorCache::ReverseListStreamImpl final: public rpc::ActorStorage::ListStream::Server {
-public:
+ public:
   ReverseListStreamImpl(ActorCache& cache,
       Key beginKey,
       kj::Maybe<Key> endKey,

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -48,7 +48,7 @@ struct ActorCacheWriteOptions {
 
 // Common interface between ActorCache and ActorCache::Transaction.
 class ActorCacheOps {
-public:
+ public:
   typedef kj::String Key;
   typedef kj::StringPtr KeyPtr;
   // Keys are text for now, but we could also change this to `Array<const byte>`.
@@ -164,12 +164,12 @@ public:
 // This extends ActorCacheOps and adds some methods that don't make sense as part of
 // ActorCache::Transaction.
 class ActorCacheInterface: public ActorCacheOps {
-public:
+ public:
   // If the actor's storage is backed by SQLite, return the underlying database.
   virtual kj::Maybe<SqliteDatabase&> getSqliteDatabase() = 0;
 
   class Transaction: public ActorCacheOps {
-  public:
+   public:
     // Write all changes to the underlying ActorCache.
     //
     // If commit() is not called before the Transaction is destroyed, nothing is written.
@@ -278,13 +278,13 @@ public:
 // accounted across many actors (typically, all actors in the same isolate), so that the cache
 // size limit can be set based on the per-isolate memory limit.
 class ActorCache final: public ActorCacheInterface {
-public:
+ public:
   // Shared LRU for a whole isolate.
   class SharedLru;
 
   // Hooks that can be used to customize ActorCache behavior or report statistics.
   class Hooks {
-  public:
+   public:
     // Called when the alarm time is dirty when neverFlush is set and ensureFlushScheduled is called.
     virtual void updateAlarmInMemory(kj::Maybe<kj::Date> newAlarmTime) {};
 
@@ -342,10 +342,10 @@ public:
   // Check for inconsistencies in the cache, e.g. redundant entries.
   void verifyConsistencyForTest();
 
-private:
+ private:
   // Backs the `kj::Own<void>` returned by `armAlarmHandler()`.
   class DeferredAlarmDeleter: public kj::Disposer {
-  public:
+   public:
     // The `Own<void>` returned by `armAlarmHandler()` is actually set up to point to the
     // `ActorCache` itself, but with an alternate disposer that deletes the alarm rather than
     // the whole object.
@@ -425,7 +425,7 @@ private:
     kj::Maybe<ActorCache&> maybeCache;
     const Key key;
 
-  private:
+   private:
     // The value associated with this key. If our `valueStatus` below is `ABSENT` or `UNKNOWN`, it
     // will have size 0.
     //
@@ -441,7 +441,7 @@ private:
     // This enum indicates how synchronized this entry is with storage.
     EntrySyncStatus syncStatus = EntrySyncStatus::NOT_IN_CACHE;
 
-  public:
+   public:
     EntryValueStatus getValueStatus() const {
       return valueStatus;
     }
@@ -531,7 +531,7 @@ private:
 
   // Callbacks for a kj::TreeIndex for a kj::Table<kj::Own<Entry>>.
   class EntryTableCallbacks {
-  public:
+   public:
     inline KeyPtr keyForRow(const kj::Own<Entry>& row) const {
       return row->key;
     }
@@ -590,7 +590,7 @@ private:
   };
 
   class CountedDeleteWaiter {
-  public:
+   public:
     explicit CountedDeleteWaiter(ActorCache& cache, kj::Own<CountedDelete> state)
         : cache(cache),
           state(kj::mv(state)) {
@@ -613,7 +613,7 @@ private:
       return *state;
     }
 
-  private:
+   private:
     ActorCache& cache;
     kj::Own<CountedDelete> state;
   };
@@ -628,7 +628,7 @@ private:
 
   // Wrapper around kj::List that keeps track of the total size of all elements.
   class DirtyList {
-  public:
+   public:
     void add(Entry& entry) {
       inner.add(entry);
       innerSize += entry.size();
@@ -650,7 +650,7 @@ private:
       return inner.end();
     }
 
-  private:
+   private:
     kj::List<Entry, &Entry::link> inner;
     size_t innerSize = 0;
   };
@@ -869,9 +869,9 @@ private:
 class ActorCacheOps::GetResultList {
   using Entry = ActorCache::Entry;
 
-public:
+ public:
   class Iterator {
-  public:
+   public:
     KeyValuePtrPairWithCache operator*() {
       KJ_IREQUIRE(ptr->get()->getValueStatus() == ActorCache::EntryValueStatus::PRESENT);
       return {ptr->get()->key, ptr->get()->getValuePtr().orDefault({}), *statusPtr};
@@ -891,7 +891,7 @@ public:
       return ptr == other.ptr && statusPtr == other.statusPtr;
     }
 
-  private:
+   private:
     const kj::Own<Entry>* ptr;
     const CacheStatus* statusPtr;
 
@@ -914,7 +914,7 @@ public:
   // Construct a simple GetResultList from key-value pairs.
   explicit GetResultList(kj::Vector<KeyValuePair> contents);
 
-private:
+ private:
   kj::Vector<kj::Own<Entry>> entries;
   kj::Vector<CacheStatus> cacheStatuses;
 
@@ -971,7 +971,7 @@ struct ActorCacheSharedLruOptions {
 };
 
 class ActorCache::SharedLru {
-public:
+ public:
   using Options = ActorCacheSharedLruOptions;
 
   explicit SharedLru(Options options);
@@ -984,7 +984,7 @@ public:
     return size.load(std::memory_order_relaxed);
   }
 
-private:
+ private:
   const Options options;
 
   // List of clean values, across all caches, ordered from least-recently-used to
@@ -1013,7 +1013,7 @@ private:
 // It is up to a higher layer to make sure that only one transaction occurs at a time, perhaps
 // using critical sections.
 class ActorCache::Transaction final: public ActorCacheInterface::Transaction {
-public:
+ public:
   Transaction(ActorCache& cache);
   ~Transaction() noexcept(false);
 
@@ -1042,7 +1042,7 @@ public:
   kj::Promise<void> rollback() override;
   // Implements ActorCacheInterface::Transaction.
 
-private:
+ private:
   ActorCache& cache;
 
   struct Change {
@@ -1052,7 +1052,7 @@ private:
 
   // Callbacks for a kj::TreeIndex for a kj::Table<Change>.
   class ChangeTableCallbacks {
-  public:
+   public:
     inline KeyPtr keyForRow(const Change& row) const {
       return row.entry->key;
     }

--- a/src/workerd/io/actor-id.h
+++ b/src/workerd/io/actor-id.h
@@ -19,7 +19,7 @@ enum class ActorGetMode {
 // This is NOT at I/O type. Each global actor namespace binding holds one instance of this which
 // it may call from any thread.
 class ActorIdFactory {
-public:
+ public:
   // Abstract actor ID.
   //
   // This is NOT an I/O type. An ActorId created in one IoContext can be used in other
@@ -28,7 +28,7 @@ public:
   // worker (by the IoChannelFactory for any IoContext), but will detect if the ID is not valid
   // for the specific namespace.
   class ActorId {
-  public:
+   public:
     // Get the string that could be passed to `idFromString()` to recreate this ID.
     virtual kj::String toString() const = 0;
 

--- a/src/workerd/io/actor-sqlite-test.c++
+++ b/src/workerd/io/actor-sqlite-test.c++
@@ -62,7 +62,7 @@ struct ActorSqliteTest final {
   kj::Vector<Call> calls;
 
   struct ActorSqliteTestHooks final: public ActorSqlite::Hooks {
-  public:
+   public:
     explicit ActorSqliteTestHooks(ActorSqliteTest& parent): parent(parent) {}
 
     kj::Promise<void> scheduleRun(kj::Maybe<kj::Date> newAlarmTime) override {

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -19,11 +19,11 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
   //   However, that probably requires rewriting `DurableObjectStorageOperations`. For now, hooking
   //   here is easier and not too costly.
 
-public:
+ public:
   // Hooks to configure ActorSqlite behavior, right now only used to allow plugging in a backend
   // for alarm operations.
   class Hooks {
-  public:
+   public:
     // Makes a request to the alarm manager to run the alarm handler at the given time, returning
     // a promise that resolves when the scheduling has succeeded.
     virtual kj::Promise<void> scheduleRun(kj::Maybe<kj::Date> newAlarmTime);
@@ -82,7 +82,7 @@ public:
   kj::Maybe<kj::Promise<void>> onNoPendingFlush() override;
   // See ActorCacheInterface
 
-private:
+ private:
   kj::Own<SqliteDatabase> db;
   OutputGate& outputGate;
   kj::Function<kj::Promise<void>()> commitCallback;
@@ -93,7 +93,7 @@ private:
   // Define a SqliteDatabase::Regulator that is similar to TRUSTED but turns certain SQLite errors
   // into application errors as appropriate when committing an implicit transaction.
   class TxnCommitRegulator: public SqliteDatabase::Regulator {
-  public:
+   public:
     void onError(kj::Maybe<int> sqliteErrorCode, kj::StringPtr message) const;
   };
   static constexpr TxnCommitRegulator TRUSTED_TXN_COMMIT;
@@ -106,7 +106,7 @@ private:
   struct NoTxn {};
 
   class ImplicitTxn {
-  public:
+   public:
     explicit ImplicitTxn(ActorSqlite& parent);
     ~ImplicitTxn() noexcept(false);
     KJ_DISALLOW_COPY_AND_MOVE(ImplicitTxn);
@@ -114,14 +114,14 @@ private:
     void commit();
     void rollback();
 
-  private:
+   private:
     ActorSqlite& parent;
 
     bool committed = false;
   };
 
   class ExplicitTxn: public ActorCacheInterface::Transaction, public kj::Refcounted {
-  public:
+   public:
     ExplicitTxn(ActorSqlite& actorSqlite);
     ~ExplicitTxn() noexcept(false);
     KJ_DISALLOW_COPY_AND_MOVE(ExplicitTxn);
@@ -151,7 +151,7 @@ private:
         kj::Maybe<kj::Date> newAlarmTime, WriteOptions options) override;
     // Implements ActorCacheOps. These will all forward to the ActorSqlite instance.
 
-  private:
+   private:
     ActorSqlite& actorSqlite;
     kj::Maybe<kj::Own<ExplicitTxn>> parent;
     uint depth = 0;
@@ -177,7 +177,7 @@ private:
 
   // Backs the `kj::Own<void>` returned by `armAlarmHandler()`.
   class DeferredAlarmDeleter: public kj::Disposer {
-  public:
+   public:
     // The `Own<void>` returned by `armAlarmHandler()` is actually set up to point to the
     // `ActorSqlite` itself, but with an alternate disposer that deletes the alarm rather than
     // the whole object.

--- a/src/workerd/io/actor-storage.h
+++ b/src/workerd/io/actor-storage.h
@@ -10,7 +10,7 @@
 namespace workerd {
 // This class wraps common values and functions for interacting durable object (actor) storage.
 class ActorStorageLimits {
-public:
+ public:
   // We grant some extra cushion on top of the advertised max size in order
   // to avoid penalizing people for pushing right up against the advertised size.
   // The v8 serialization method we use can add a few extra bytes for its type tag

--- a/src/workerd/io/hibernation-manager.h
+++ b/src/workerd/io/hibernation-manager.h
@@ -17,7 +17,7 @@ namespace workerd {
 
 // Implements the HibernationManager class.
 class HibernationManagerImpl final: public Worker::Actor::HibernationManager {
-public:
+ public:
   HibernationManagerImpl(kj::Own<Worker::Actor::Loopback> loopback, uint16_t hibernationEventType);
   ~HibernationManagerImpl() noexcept(false);
 
@@ -51,7 +51,7 @@ public:
   // Gets the event timeout if set.
   kj::Maybe<uint32_t> getEventTimeout() override;
 
-private:
+ private:
   class HibernatableWebSocket;
 
   kj::Promise<void> handleReadLoop(HibernatableWebSocket& refToHibernatable);
@@ -75,7 +75,7 @@ private:
   // such as `attachment`, `url`, `extensions`, etc. These properties are only read/modified
   // when initiating, or waking from hibernation.
   class HibernatableWebSocket {
-  public:
+   public:
     HibernatableWebSocket(jsg::Ref<api::WebSocket> websocket,
         kj::ArrayPtr<kj::String> tags,
         HibernationManagerImpl& manager);
@@ -139,7 +139,7 @@ private:
     friend HibernationManagerImpl;
   };
 
-private:
+ private:
   // Removes a HibernatableWebSocket from the HibernationManager's various collections.
   void dropHibernatableWebSocket(HibernatableWebSocket& hib);
 
@@ -203,7 +203,7 @@ private:
   const size_t ACTIVE_CONNECTION_LIMIT = 1024 * 32;
 
   class DisconnectHandler: public kj::TaskSet::ErrorHandler {
-  public:
+   public:
     // We don't need to do anything here; we already handle disconnects in the callee of readLoop().
     void taskFailed(kj::Exception&& exception) override {};
   };

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -22,7 +22,7 @@ class WorkerInterface;
 // Interface for talking to the Cache API. Needs to be declared here so that IoContext can
 // contain it.
 class CacheClient {
-public:
+ public:
   // Get the default namespace, i.e. the one that fetch() will use for caching.
   //
   // The returned client is intended to be used for one request. `cfBlobJson` and `parentSpan` have
@@ -41,7 +41,7 @@ public:
 // A timer instance, used to back Date.now(), setTimeout(), etc. This object may implement
 // Spectre mitigations.
 class TimerChannel {
-public:
+ public:
   // Call each time control enters the isolate to set up the clock.
   virtual void syncTime() = 0;
 
@@ -81,7 +81,7 @@ public:
 // all methods throw exceptions, then the Worker will be completely unable to communicate with
 // anything in the world except for the client -- this is a useful property for sandboxing!
 class IoChannelFactory {
-public:
+ public:
   // Contains metadata attached to an outgoing subrequest from a worker, independent of the type
   // of request.
   struct SubrequestMetadata {
@@ -133,7 +133,7 @@ public:
   // sent, and they will be delivered in the order they are sent (e-order). This is an I/O type
   // so it is only valid within the `IoContext` where it was created.
   class ActorChannel {
-  public:
+   public:
     // Start a new request to this actor.
     //
     // Note that not all `metadata` properties make sense here, but it didn't seem worth defining

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -26,7 +26,7 @@ static void* getThreadId() {
 }
 
 class IoContext::TimeoutManagerImpl final: public TimeoutManager {
-public:
+ public:
   class TimeoutState;
   using Map = std::map<TimeoutId, TimeoutState>;
   using Iterator = Map::iterator;
@@ -55,7 +55,7 @@ public:
     }
   }
 
-private:
+ private:
   struct IdAndIterator {
     TimeoutId id;
     Iterator it;
@@ -100,7 +100,7 @@ private:
 };
 
 class IoContext::TimeoutManagerImpl::TimeoutState {
-public:
+ public:
   TimeoutState(TimeoutManagerImpl& manager, TimeoutParameters params);
   ~TimeoutState();
 
@@ -476,7 +476,7 @@ kj::Promise<IoContext_IncomingRequest::FinishScheduledResult> IoContext::Incomin
 }
 
 class IoContext::PendingEvent: public kj::Refcounted {
-public:
+ public:
   explicit PendingEvent(IoContext& context): maybeContext(context) {}
   ~PendingEvent() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(PendingEvent);
@@ -1239,7 +1239,7 @@ void IoContext::runFinalizers(Worker::AsyncLock& asyncLock) {
 namespace {
 
 class CacheSerializedInputStream final: public kj::AsyncInputStream {
-public:
+ public:
   CacheSerializedInputStream(
       kj::Own<kj::AsyncInputStream> inner, kj::Own<kj::PromiseFulfiller<void>> fulfiller)
       : inner(kj::mv(inner)),
@@ -1261,7 +1261,7 @@ public:
     return inner->pumpTo(output, amount);
   }
 
-private:
+ private:
   kj::Own<kj::AsyncInputStream> inner;
   kj::Own<kj::PromiseFulfiller<void>> fulfiller;
 };

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -47,10 +47,10 @@ class IoContext;
 // those will be emitted all at once with a single header message followed by contextual
 // information for each individual collected instance.
 class WarningAggregator final: public kj::AtomicRefcounted {
-public:
+ public:
   // The IoContext will maintain a map of WarningAggregators based on an opaque key.
   class Key final {
-  public:
+   public:
     Key(): hash(kj::hashCode(this)) {}
     KJ_DISALLOW_COPY_AND_MOVE(Key);
     inline uint hashCode() const {
@@ -60,13 +60,13 @@ public:
       return this == &other;
     }
 
-  private:
+   private:
     uint hash;
   };
 
   // Captures the contextual information for a specific aggregated warning.
   class WarningContext {
-  public:
+   public:
     virtual ~WarningContext() noexcept(false) = default;
     virtual kj::String toString(jsg::Lock& js) = 0;
   };
@@ -84,7 +84,7 @@ public:
 
   using Map = kj::HashMap<const Key&, kj::Own<WarningAggregator>>;
 
-private:
+ private:
   kj::Own<const Worker> worker;
   kj::Own<RequestObserver> requestMetrics;
   EmitCallback emitter;
@@ -106,7 +106,7 @@ private:
 // usage) to the "current" incoming request, which is defined as the newest request that hasn't
 // already completed.
 class IoContext_IncomingRequest final {
-public:
+ public:
   IoContext_IncomingRequest(kj::Own<IoContext> context,
       kj::Own<IoChannelFactory> ioChannelFactory,
       kj::Own<RequestObserver> metrics,
@@ -160,7 +160,7 @@ public:
     return workerTracer;
   }
 
-private:
+ private:
   kj::Own<IoContext> context;
   kj::Own<RequestObserver> metrics;
   kj::Maybe<kj::Own<WorkerTracer>> workerTracer;
@@ -205,7 +205,7 @@ private:
 // like this. We don't want people leaking heavy objects or allowing simultaneous requests to
 // interfere with each other.
 class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler {
-public:
+ public:
   class TimeoutManagerImpl;
 
   // Construct a new IoContext. Before using it, you must also create an IncomingRequest.
@@ -816,7 +816,7 @@ public:
     return *getCurrentIncomingRequest().ioChannelFactory;
   }
 
-private:
+ private:
   ThreadContext& thread;
 
   kj::Own<WeakRef> selfRef = kj::refcounted<WeakRef>(kj::Badge<IoContext>(), *this);
@@ -905,7 +905,7 @@ private:
   kj::Maybe<jsg::JsRef<jsg::JsObject>> promiseContextTag;
 
   class Runnable {
-  public:
+   public:
     virtual void run(Worker::Lock& lock) = 0;
   };
   void runImpl(Runnable& runnable,
@@ -1262,7 +1262,7 @@ kj::_::ReducePromises<RemoveIoOwn<T>> IoContext::awaitJs(jsg::Lock& js, jsg::Pro
       }
     }
 
-  private:
+   private:
     kj::Maybe<kj::StringPtr> finalize() override {
       if (!isDone) {
         fulfiller->reject(JSG_KJ_EXCEPTION(FAILED, Error, "Promise will never complete."));

--- a/src/workerd/io/io-gate.h
+++ b/src/workerd/io/io-gate.h
@@ -33,7 +33,7 @@ using kj::uint;
 // An InputGate blocks incoming events from being delivered to an actor while the lock is held.
 class InputGate {
 
-public:
+ public:
   // Hooks that can be used to customize InputGate behavior.
   //
   // Technically, everything implemented here could be accomplished by a class that wraps
@@ -43,7 +43,7 @@ public:
   // would kick in when ActorCache tried to use it.
   class Hooks {
 
-  public:
+   public:
     // Optionally track metrics. In practice these are implemented by MetricsCollector::Actor, but
     // we don't want to depend on that class from here.
     virtual void inputGateLocked() {}
@@ -62,7 +62,7 @@ public:
 
   // A lock that blocks all new events from being delivered while it exists.
   class Lock {
-  public:
+   public:
     KJ_DISALLOW_COPY(Lock);
     Lock(Lock&& other): gate(other.gate), cs(kj::mv(other.cs)) {
       other.gate = nullptr;
@@ -95,7 +95,7 @@ public:
       return gate == other.gate;
     }
 
-  private:
+   private:
     // Becomes null on move.
     InputGate* gate;
 
@@ -112,7 +112,7 @@ public:
   // actor should be shut down in this case. This promise never resolves, only rejects.
   kj::Promise<void> onBroken();
 
-private:
+ private:
   Hooks& hooks;
 
   // How many instances of `Lock` currently exist? When this reaches zero, we'll release some
@@ -166,7 +166,7 @@ private:
 // top-level scope. E.g., if a critical section initiates a storage read and a fetch() at the
 // same time, the fetch() is prevented from returning until after the storage read has returned.
 class InputGate::CriticalSection: private InputGate, public kj::Refcounted {
-public:
+ public:
   CriticalSection(InputGate& parent);
   ~CriticalSection() noexcept(false);
 
@@ -188,7 +188,7 @@ public:
   // breaks the InputGate.
   void failed(const kj::Exception& e);
 
-private:
+ private:
   enum State {
     // wait() hasn't been called.
     NOT_STARTED,
@@ -221,7 +221,7 @@ private:
 // An OutputGate blocks outgoing messages from an Actor until writes which they might depend on
 // are confirmed.
 class OutputGate {
-public:
+ public:
   // Hooks that can be used to customize OutputGate behavior.
   //
   // Technically, everything implemented here could be accomplished by a class that wraps
@@ -230,7 +230,7 @@ public:
   // it was more convenient to give Worker::Actor a way to inject behavior into OutputGate which
   // would kick in when ActorCache tried to use it.
   class Hooks {
-  public:
+   public:
     // Optionally make a promise which should be exclusiveJoin()ed with the lock promise to
     // implement a timeout. The returned promise should be something that throws an exception
     // after some timeout has expired.
@@ -271,7 +271,7 @@ public:
 
   bool isBroken();
 
-private:
+ private:
   Hooks& hooks;
 
   kj::ForkedPromise<void> pastLocksPromise;

--- a/src/workerd/io/io-own.h
+++ b/src/workerd/io/io-own.h
@@ -52,7 +52,7 @@ using RemoveIoOwn = typename RemoveIoOwn_<T>::Type;
 // reject() on some Fulfiller object. It can optionally return a warning which should be
 // logged if the inspector is attached.
 class Finalizeable {
-public:
+ public:
   KJ_DISALLOW_COPY_AND_MOVE(Finalizeable);
 
 #ifdef KJ_DEBUG
@@ -66,7 +66,7 @@ public:
   Finalizeable() = default;
 #endif
 
-private:
+ private:
   virtual kj::Maybe<kj::StringPtr> finalize() = 0;
   friend class IoContext;
 
@@ -93,7 +93,7 @@ struct SpecificOwnedObject: public OwnedObject {
 };
 
 class OwnedObjectList {
-public:
+ public:
   OwnedObjectList() = default;
   KJ_DISALLOW_COPY_AND_MOVE(OwnedObjectList);
   ~OwnedObjectList() noexcept(false);
@@ -109,7 +109,7 @@ public:
     return finalizersRan;
   }
 
-private:
+ private:
   kj::Maybe<kj::Own<OwnedObject>> head;
 
   bool finalizersRan = false;
@@ -117,7 +117,7 @@ private:
 
 // Object which receives possibly-cross-thread deletions of owned objects.
 class DeleteQueue: public kj::AtomicRefcounted {
-public:
+ public:
   DeleteQueue(): crossThreadDeleteQueue(State{kj::Vector<OwnedObject*>()}) {}
 
   void scheduleDeletion(OwnedObject* object) const;
@@ -155,7 +155,7 @@ public:
   static void checkFarGet(const DeleteQueue* deleteQueue, const std::type_info& type);
   static void checkWeakGet(workerd::WeakRef<IoContext>& weak);
 
-private:
+ private:
   template <typename T>
   SpecificOwnedObject<T>* addObjectImpl(kj::Own<T> obj, OwnedObjectList& ownedObjects);
 
@@ -169,7 +169,7 @@ private:
 // the DeleteQueue concept that allows us to use the same queue for more than
 // just deletions.
 class IoCrossContextExecutor {
-public:
+ public:
   IoCrossContextExecutor(kj::Own<const DeleteQueue> deleteQueue)
       : deleteQueue(kj::mv(deleteQueue)) {}
 
@@ -177,7 +177,7 @@ public:
   // The target IoContext will be signaled to run the action as soon as it is able.
   void execute(jsg::Lock& js, kj::Function<void(jsg::Lock&)>&& action);
 
-private:
+ private:
   friend class IoContext;
   friend class DeleteQueue;
 
@@ -226,7 +226,7 @@ inline ReverseIoOwn<T> DeleteQueue::addObjectReverse(
 // we can't just do it in IoContext's destructor. As a hack, we customize our pointer
 // to the delete queue to get the tear-down order right.
 class DeleteQueuePtr: public kj::Own<DeleteQueue> {
-public:
+ public:
   DeleteQueuePtr(kj::Own<DeleteQueue> value): kj::Own<DeleteQueue>(kj::mv(value)) {}
   KJ_DISALLOW_COPY_AND_MOVE(DeleteQueuePtr);
   ~DeleteQueuePtr() noexcept(false) {
@@ -251,7 +251,7 @@ public:
 template <typename T>
 class IoOwn {
 
-public:
+ public:
   IoOwn(IoOwn&& other);
   IoOwn(decltype(nullptr)): item(nullptr) {}
   ~IoOwn() noexcept(false);
@@ -279,7 +279,7 @@ public:
   // the one that owns the IoContext.
   void deferGcToContext() &&;
 
-private:
+ private:
   friend class IoContext;
   friend class DeleteQueue;
 
@@ -295,7 +295,7 @@ private:
 // dereferenced unless the isolate is executing on the appropriate event loop thread.
 template <typename T>
 class IoPtr {
-public:
+ public:
   IoPtr(const IoPtr& other): deleteQueue(kj::atomicAddRef(*other.deleteQueue)), ptr(other.ptr) {}
   IoPtr(IoPtr&& other) = default;
 
@@ -305,7 +305,7 @@ public:
   }
   IoPtr& operator=(decltype(nullptr));
 
-private:
+ private:
   friend class IoContext;
   friend class DeleteQueue;
 
@@ -329,7 +329,7 @@ private:
 // using `ReverseIoOwn`.
 template <typename T>
 class ReverseIoOwn {
-public:
+ public:
   ReverseIoOwn(ReverseIoOwn&& other);
   ReverseIoOwn(decltype(nullptr)): item(nullptr) {}
   ~ReverseIoOwn() noexcept(false);
@@ -343,7 +343,7 @@ public:
   ReverseIoOwn& operator=(ReverseIoOwn&& other);
   ReverseIoOwn& operator=(decltype(nullptr));
 
-private:
+ private:
   friend class IoContext;
   friend class DeleteQueue;
 

--- a/src/workerd/io/io-thread-context.h
+++ b/src/workerd/io/io-thread-context.h
@@ -8,7 +8,7 @@ namespace workerd {
 // Thread-level stuff needed to construct a IoContext. One of these is created for each
 // request-handling thread.
 class ThreadContext {
-public:
+ public:
   struct HeaderIdBundle {
     HeaderIdBundle(kj::HttpHeaderTable::Builder& builder);
 
@@ -57,7 +57,7 @@ public:
     return fiddle;
   }
 
-private:
+ private:
   // NOTE: This timer only updates when entering the event loop!
   kj::Timer& timer;
   kj::EntropySource& entropySource;

--- a/src/workerd/io/io-timers.h
+++ b/src/workerd/io/io-timers.h
@@ -15,7 +15,7 @@ class IoContext;
 // However, clearTimeout implementations are expected to only have access to timeouts set via that
 // same implementation.
 class TimeoutId {
-public:
+ public:
   // Use a double so that we can exceed the maximum value for uint32_t.
   using NumberType = double;
 
@@ -43,28 +43,28 @@ public:
     return value < id.value;
   }
 
-private:
+ private:
   constexpr explicit TimeoutId(ValueType value): value(value) {}
 
   ValueType value;
 };
 
 class TimeoutId::Generator {
-public:
+ public:
   Generator() = default;
   KJ_DISALLOW_COPY_AND_MOVE(Generator);
 
   // Get the next TimeoutId for this generator. This function will never return a TimeoutId <= 0.
   TimeoutId getNext();
 
-private:
+ private:
   // We always skip 0 per the spec:
   // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers.
   TimeoutId::ValueType nextId = 1;
 };
 
 class TimeoutManager {
-public:
+ public:
   // Upper bound on the number of timeouts a user can *ever* have active.
   constexpr static auto MAX_TIMEOUTS = 10'000;
 

--- a/src/workerd/io/limit-enforcer.h
+++ b/src/workerd/io/limit-enforcer.h
@@ -18,7 +18,7 @@ static constexpr size_t DEFAULT_MAX_PBKDF2_ITERATIONS = 100'000;
 //
 // See also LimitEnforcer, which enforces on a per-request level.
 class IsolateLimitEnforcer {
-public:
+ public:
   // Get CreateParams to pass when constructing a new isolate.
   virtual v8::Isolate::CreateParams getCreateParams() = 0;
 
@@ -87,7 +87,7 @@ public:
 
 // Abstract interface that enforces resource limits on a IoContext.
 class LimitEnforcer {
-public:
+ public:
   // Called just after taking the isolate lock, before executing JavaScript code, to enforce
   // limits on that code execution, particularly the CPU limit. The returned `Own<void>` should
   // be dropped when JavaScript is done, before unlocking the isolate.

--- a/src/workerd/io/observer.c++
+++ b/src/workerd/io/observer.c++
@@ -12,7 +12,7 @@ namespace {
 kj::Maybe<kj::Own<FeatureObserver>> featureObserver;
 
 class FeatureObserverImpl final: public FeatureObserver {
-public:
+ public:
   void use(Feature feature) const override {
     auto lock = counts.lockExclusive();
     lock->upsert(feature, 1, [](uint64_t& count, uint64_t value) { count += value; });
@@ -25,7 +25,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::MutexGuarded<kj::HashMap<Feature, uint64_t>> counts;
 };
 

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -23,7 +23,7 @@ class LimitEnforcer;
 class TimerChannel;
 
 class WebSocketObserver: public kj::Refcounted {
-public:
+ public:
   virtual ~WebSocketObserver() noexcept(false) = default;
   // Called when a worker sends a message on this WebSocket (includes close messages).
   virtual void sentMessage(size_t bytes) {};
@@ -39,7 +39,7 @@ public:
 // size of the chunks in the internal queue by incrementing and decrementing each metric in
 // enqueue() and dequeue() respectively.
 class ByteStreamObserver {
-public:
+ public:
   virtual ~ByteStreamObserver() noexcept(false) = default;
   // Called when a chunk of size `bytes` is enqueued on the stream.
   virtual void onChunkEnqueued(size_t bytes) {};
@@ -52,7 +52,7 @@ public:
 //
 // Observing anything is optional. Default implementations of all methods observe nothing.
 class RequestObserver: public kj::Refcounted {
-public:
+ public:
   // This is called when the request is converted to a WebSocket connection terminating in a worker.
   // An optional WebSocket observer may be returned to observe events on the worker's end of the
   // WebSocket connection.
@@ -142,7 +142,7 @@ public:
 };
 
 class IsolateObserver: public kj::AtomicRefcounted, public jsg::IsolateObserver {
-public:
+ public:
   virtual ~IsolateObserver() noexcept(false) {}
 
   // Called when Worker::Isolate is created.
@@ -170,7 +170,7 @@ public:
 
   // Created while parsing a script, to record related metrics.
   class Parse {
-  public:
+   public:
     // Marks the ScriptReplica as finished parsing, which starts reporting of isolate metrics.
     virtual void done() {}
   };
@@ -181,7 +181,7 @@ public:
   }
 
   class LockTiming {
-  public:
+   public:
     // Called by `Isolate::takeAsyncLock()` when it is blocked by a different isolate lock on the
     // same thread.
     virtual void waitingForOtherIsolate(kj::StringPtr id) {}
@@ -223,7 +223,7 @@ public:
   // This is a thin wrapper around LockTiming which efficiently handles the case where we don't
   // want to track timing.
   class LockRecord {
-  public:
+   public:
     explicit LockRecord(kj::Maybe<kj::Own<LockTiming>> lockTimingParam)
         : lockTiming(kj::mv(lockTimingParam)) {
       KJ_IF_SOME(l, lockTiming) l.get()->start();
@@ -243,7 +243,7 @@ public:
       KJ_IF_SOME(l, lockTiming) l.get()->gcEpilogue();
     }
 
-  private:
+   private:
     // The presence of `lockTiming` determines whether or not we need to record timing data. If
     // we have no `lockTiming`, then this LockRecord wrapper is just a big nothingburger.
     kj::Maybe<kj::Own<LockTiming>> lockTiming;
@@ -251,10 +251,10 @@ public:
 };
 
 class WorkerObserver: public kj::AtomicRefcounted {
-public:
+ public:
   // Created while executing a script's global scope, to record related metrics.
   class Startup {
-  public:
+   public:
     virtual void done() {}
   };
 
@@ -269,7 +269,7 @@ public:
 };
 
 class ActorObserver: public kj::Refcounted, public SqliteObserver {
-public:
+ public:
   // Allows the observer to run in the background, periodically making observations. Owner must
   // call this and store the promise. `limitEnforcer` is used to collect CPU usage metrics, it
   // must remain valid as long as the loop is running.
@@ -308,14 +308,14 @@ public:
 // RAII object to call `teardownFinished()` on an observer for you.
 template <typename Observer>
 class TeardownFinishedGuard {
-public:
+ public:
   TeardownFinishedGuard(Observer& ref): ref(ref) {}
   ~TeardownFinishedGuard() noexcept(false) {
     ref.teardownFinished();
   }
   KJ_DISALLOW_COPY_AND_MOVE(TeardownFinishedGuard);
 
-private:
+ private:
   Observer& ref;
 };
 
@@ -325,7 +325,7 @@ private:
 //
 // There is exactly one instance of this class per worker process.
 class FeatureObserver {
-public:
+ public:
   static kj::Own<FeatureObserver> createDefault();
   static void init(kj::Own<FeatureObserver> instance);
   static kj::Maybe<FeatureObserver&> get();

--- a/src/workerd/io/promise-wrapper.h
+++ b/src/workerd/io/promise-wrapper.h
@@ -11,7 +11,7 @@ namespace workerd {
 
 template <typename Self>
 class PromiseWrapper {
-public:
+ public:
   template <typename T>
   static constexpr const char* getName(kj::Promise<T>*) {
     return "Promise";

--- a/src/workerd/io/request-tracker.h
+++ b/src/workerd/io/request-tracker.h
@@ -12,16 +12,16 @@ namespace workerd {
 // is carried out once all requests have completed. `activeRequests` is incremented each time a
 // new request is created, and then decremented once it completes.
 class RequestTracker final: public kj::Refcounted {
-public:
+ public:
   class Hooks {
-  public:
+   public:
     virtual void active() = 0;
     virtual void inactive() = 0;
   };
 
   // An object that should be associated with (attached to) a request.
   class ActiveRequest final {
-  public:
+   public:
     // On creation, if the parent RequestTracker has 0 active requests, we call the `active()` hook.
     // On destruction, if the RequestTracker has 0 active requests, we call the `inactive()` hook.
     // Otherwise, we just increment/decrement the count on creation/destruction respectively.
@@ -30,7 +30,7 @@ public:
     KJ_DISALLOW_COPY(ActiveRequest);
     ~ActiveRequest() noexcept(false);
 
-  private:
+   private:
     kj::Maybe<kj::Own<RequestTracker>> maybeParent;
   };
 
@@ -54,7 +54,7 @@ public:
     return kj::addRef(*this);
   }
 
-private:
+ private:
   void requestActive();
   void requestInactive();
 

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -37,7 +37,7 @@ namespace tracing {
 // is used to represent tracing IDs for jaeger traces. For external tracing,
 // this is used for both the trace ID and invocation ID for tail workers.
 class TraceId final {
-public:
+ public:
   // A null trace ID. This is only acceptable for use in tests.
   constexpr TraceId(decltype(nullptr)): low(0), high(0) {}
 
@@ -109,7 +109,7 @@ public:
     return high;
   }
 
-private:
+ private:
   uint64_t low = 0;
   uint64_t high = 0;
 };
@@ -142,7 +142,7 @@ struct Span;
 
 // Collects trace information about the handling of a worker/pipeline fetch event.
 class Trace final: public kj::Refcounted {
-public:
+ public:
   explicit Trace(kj::Maybe<kj::String> stableId,
       kj::Maybe<kj::String> scriptName,
       kj::Maybe<kj::Own<ScriptVersion::Reader>> scriptVersion,
@@ -156,7 +156,7 @@ public:
   KJ_DISALLOW_COPY_AND_MOVE(Trace);
 
   class FetchEventInfo {
-  public:
+   public:
     class Header;
 
     explicit FetchEventInfo(
@@ -164,7 +164,7 @@ public:
     FetchEventInfo(rpc::Trace::FetchEventInfo::Reader reader);
 
     class Header {
-    public:
+     public:
       explicit Header(kj::String name, kj::String value);
       Header(rpc::Trace::FetchEventInfo::Header::Reader reader);
 
@@ -189,7 +189,7 @@ public:
   };
 
   class JsRpcEventInfo {
-  public:
+   public:
     explicit JsRpcEventInfo(kj::String methodName);
     JsRpcEventInfo(rpc::Trace::JsRpcEventInfo::Reader reader);
 
@@ -199,7 +199,7 @@ public:
   };
 
   class ScheduledEventInfo {
-  public:
+   public:
     explicit ScheduledEventInfo(double scheduledTime, kj::String cron);
     ScheduledEventInfo(rpc::Trace::ScheduledEventInfo::Reader reader);
 
@@ -210,7 +210,7 @@ public:
   };
 
   class AlarmEventInfo {
-  public:
+   public:
     explicit AlarmEventInfo(kj::Date scheduledTime);
     AlarmEventInfo(rpc::Trace::AlarmEventInfo::Reader reader);
 
@@ -220,7 +220,7 @@ public:
   };
 
   class QueueEventInfo {
-  public:
+   public:
     explicit QueueEventInfo(kj::String queueName, uint32_t batchSize);
     QueueEventInfo(rpc::Trace::QueueEventInfo::Reader reader);
 
@@ -231,7 +231,7 @@ public:
   };
 
   class EmailEventInfo {
-  public:
+   public:
     explicit EmailEventInfo(kj::String mailFrom, kj::String rcptTo, uint32_t rawSize);
     EmailEventInfo(rpc::Trace::EmailEventInfo::Reader reader);
 
@@ -243,14 +243,14 @@ public:
   };
 
   class TraceEventInfo {
-  public:
+   public:
     class TraceItem;
 
     explicit TraceEventInfo(kj::ArrayPtr<kj::Own<Trace>> traces);
     TraceEventInfo(rpc::Trace::TraceEventInfo::Reader reader);
 
     class TraceItem {
-    public:
+     public:
       explicit TraceItem(kj::Maybe<kj::String> scriptName);
       TraceItem(rpc::Trace::TraceEventInfo::TraceItem::Reader reader);
 
@@ -265,7 +265,7 @@ public:
   };
 
   class HibernatableWebSocketEventInfo {
-  public:
+   public:
     struct Message {};
     struct Close {
       uint16_t code;
@@ -285,13 +285,13 @@ public:
   };
 
   class CustomEventInfo {
-  public:
+   public:
     explicit CustomEventInfo() {};
     CustomEventInfo(rpc::Trace::CustomEventInfo::Reader reader) {};
   };
 
   class FetchResponseInfo {
-  public:
+   public:
     explicit FetchResponseInfo(uint16_t statusCode);
     FetchResponseInfo(rpc::Trace::FetchResponseInfo::Reader reader);
 
@@ -301,7 +301,7 @@ public:
   };
 
   class DiagnosticChannelEvent {
-  public:
+   public:
     explicit DiagnosticChannelEvent(
         kj::Date timestamp, kj::String channel, kj::Array<kj::byte> message);
     DiagnosticChannelEvent(rpc::Trace::DiagnosticChannelEvent::Reader reader);
@@ -316,7 +316,7 @@ public:
   };
 
   class Log {
-  public:
+   public:
     explicit Log(kj::Date timestamp, LogLevel logLevel, kj::String message);
     Log(rpc::Trace::Log::Reader reader);
     Log(Log&&) = default;
@@ -334,7 +334,7 @@ public:
   };
 
   class Exception {
-  public:
+   public:
     explicit Exception(
         kj::Date timestamp, kj::String name, kj::String message, kj::Maybe<kj::String> stack);
     Exception(rpc::Trace::Exception::Reader reader);
@@ -423,7 +423,7 @@ class WorkerTracer;
 // possible subpipeline stages are recorded here, where they can be used to call a pipeline's
 // trace worker.
 class PipelineTracer final: public kj::Refcounted, public kj::EnableAddRefToThis<PipelineTracer> {
-public:
+ public:
   // Creates a pipeline tracer (with a possible parent).
   explicit PipelineTracer() = default;
   ~PipelineTracer() noexcept(false);
@@ -452,7 +452,7 @@ public:
   // tracer for a subordinate stage to add its collected traces to the parent pipeline.
   void addTracesFromChild(kj::ArrayPtr<kj::Own<Trace>> traces);
 
-private:
+ private:
   kj::Vector<kj::Own<Trace>> traces;
   kj::Maybe<kj::Own<kj::PromiseFulfiller<kj::Array<kj::Own<Trace>>>>> completeFulfiller;
 
@@ -464,7 +464,7 @@ private:
 // write to isn't provided (that already exists in a PipelineTracer), the trace must by extracted
 // via extractTrace.
 class WorkerTracer final: public kj::Refcounted {
-public:
+ public:
   explicit WorkerTracer(kj::Rc<PipelineTracer> parentPipeline,
       kj::Own<Trace> trace,
       PipelineLogLevel pipelineLogLevel);
@@ -515,7 +515,7 @@ public:
     return self->addRef();
   }
 
-private:
+ private:
   PipelineLogLevel pipelineLogLevel;
   kj::Own<Trace> trace;
 
@@ -558,7 +558,7 @@ struct Span {
   // Represents a trace span. `Span` objects are delivered to `SpanObserver`s for recording. To
   // create a `Span`, use a `SpanBuilder`.
 
-public:
+ public:
   using TagValue = kj::OneOf<bool, int64_t, double, kj::String>;
   // TODO(someday): Support binary bytes, too.
   using TagMap = kj::HashMap<kj::ConstString, TagValue>;
@@ -595,7 +595,7 @@ public:
 // spans for itself that show up as children of the caller's span, but the caller does not
 // want to give the callee any other ability to modify the parent span.
 class SpanParent {
-public:
+ public:
   SpanParent(SpanBuilder& builder);
 
   // Make a SpanParent that causes children not to be reported anywhere.
@@ -629,7 +629,7 @@ public:
     return observer;
   }
 
-private:
+ private:
   kj::Maybe<kj::Own<SpanObserver>> observer;
 };
 
@@ -642,7 +642,7 @@ private:
 // SpanBuilder is designed to be write-only -- you cannot read back the content. Only the
 // observer (if there is one) receives the content.
 class SpanBuilder {
-public:
+ public:
   // Create a new top-level span that will report to the given observer. If the observer is null,
   // no data is collected.
   //
@@ -708,7 +708,7 @@ public:
   // duplicate keys.
   void addLog(kj::Date timestamp, kj::ConstString key, TagValue value);
 
-private:
+ private:
   kj::Maybe<kj::Own<SpanObserver>> observer;
   // The under-construction span, or null if the span has ended.
   kj::Maybe<Span> span;
@@ -723,7 +723,7 @@ private:
 // A new SpanObserver is created at the start of each Span. The observer is used to report the
 // span data at the end of the span, as well as to construct child observers.
 class SpanObserver: public kj::Refcounted {
-public:
+ public:
   // Allocate a new child span.
   //
   // Note that children can be created long after a span has completed.
@@ -794,13 +794,13 @@ struct TraceParentContext {
 // given request span using a specified tag name. Ideal for automatically tracking and logging
 // execution times within a scoped block.
 class ScopedDurationTagger {
-public:
+ public:
   explicit ScopedDurationTagger(
       SpanBuilder& span, kj::ConstString key, const kj::MonotonicClock& timer);
   ~ScopedDurationTagger() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(ScopedDurationTagger);
 
-private:
+ private:
   SpanBuilder& span;
   kj::ConstString key;
   const kj::MonotonicClock& timer;

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -29,7 +29,7 @@ namespace {
 //   - Or, falling back to proxying if passThroughOnException() was used.
 // - Finish waitUntil() tasks.
 class WorkerEntrypoint final: public WorkerInterface {
-public:
+ public:
   // Call this instead of the constructor. It actually adds a wrapper object around the
   // `WorkerEntrypoint`, but the wrapper still implements `WorkerInterface`.
   //
@@ -71,7 +71,7 @@ public:
   kj::Promise<bool> test() override;
   kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override;
 
-private:
+ private:
   class ResponseSentTracker;
 
   // Members initialized at startup.
@@ -106,7 +106,7 @@ private:
       kj::Date scheduledTime,
       uint32_t retryCount);
 
-public:  // For kj::heap() only; pretend this is private.
+ public:  // For kj::heap() only; pretend this is private.
   WorkerEntrypoint(kj::Badge<WorkerEntrypoint> badge,
       ThreadContext& threadContext,
       kj::TaskSet& waitUntilTasks,
@@ -118,7 +118,7 @@ public:  // For kj::heap() only; pretend this is private.
 // Simple wrapper around `HttpService::Response` to let us know if the response was sent
 // already.
 class WorkerEntrypoint::ResponseSentTracker final: public kj::HttpService::Response {
-public:
+ public:
   ResponseSentTracker(kj::HttpService::Response& inner): inner(inner) {}
   KJ_DISALLOW_COPY_AND_MOVE(ResponseSentTracker);
 
@@ -142,7 +142,7 @@ public:
     return inner.acceptWebSocket(headers);
   }
 
-private:
+ private:
   kj::HttpService::Response& inner;
   bool sent = false;
 };

--- a/src/workerd/io/worker-interface.c++
+++ b/src/workerd/io/worker-interface.c++
@@ -15,7 +15,7 @@ namespace {
 // A WorkerInterface that delays requests until some promise resolves, then forwards them to the
 // interface the promise resolved to.
 class PromisedWorkerInterface final: public WorkerInterface {
-public:
+ public:
   PromisedWorkerInterface(kj::Promise<kj::Own<WorkerInterface>> promise)
       : promise(promise.then([this](kj::Own<WorkerInterface> result) { worker = kj::mv(result); })
                     .fork()) {}
@@ -83,7 +83,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::ForkedPromise<void> promise;
   kj::Maybe<kj::Own<WorkerInterface>> worker;
 };
@@ -101,7 +101,7 @@ kj::Own<kj::HttpClient> asHttpClient(kj::Own<WorkerInterface> workerInterface) {
 namespace {
 // A Revocable WebSocket wrapper, revoked when revokeProm rejects
 class RevocableWebSocket final: public kj::WebSocket {
-public:
+ public:
   RevocableWebSocket(kj::Own<WebSocket> ws, kj::Promise<void> revokeProm)
       : ws(kj::mv(ws)),
         revokeProm(revokeProm
@@ -165,7 +165,7 @@ public:
     return 0;
   }
 
-private:
+ private:
   template <typename T>
   kj::Promise<T> wrap(kj::Promise<T> prom) {
     // just to fix the revocation promise return type, serves no purpose otherwise
@@ -192,7 +192,7 @@ private:
 // A HttpResponse that can revoke long-running websocket connections started as part of the
 // response. Ordinary HTTP requests are not revoked.
 class RevocableWebSocketHttpResponse final: public kj::HttpService::Response {
-public:
+ public:
   RevocableWebSocketHttpResponse(kj::HttpService::Response& inner, kj::Promise<void> revokeProm)
       : inner(inner),
         revokeProm(revokeProm.fork()) {}
@@ -208,7 +208,7 @@ public:
     return kj::heap<RevocableWebSocket>(inner.acceptWebSocket(headers), revokeProm.addBranch());
   }
 
-private:
+ private:
   kj::HttpService::Response& inner;
   kj::ForkedPromise<void> revokeProm;
 };
@@ -216,7 +216,7 @@ private:
 // A WorkerInterface that cancels WebSockets when revokeProm is rejected.
 // Currently only supports cancelling for upgrades.
 class RevocableWebSocketWorkerInterface final: public WorkerInterface {
-public:
+ public:
   RevocableWebSocketWorkerInterface(WorkerInterface& worker, kj::Promise<void> revokeProm);
   kj::Promise<void> request(kj::HttpMethod method,
       kj::StringPtr url,
@@ -233,7 +233,7 @@ public:
   kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime, uint32_t retryCount) override;
   kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override;
 
-private:
+ private:
   WorkerInterface& worker;
   kj::ForkedPromise<void> revokeProm;
 };
@@ -295,7 +295,7 @@ kj::Own<WorkerInterface> newRevocableWebSocketWorkerInterface(
 namespace {
 
 class ErrorWorkerInterface final: public WorkerInterface {
-public:
+ public:
   ErrorWorkerInterface(kj::Exception&& exception): exception(exception) {}
 
   kj::Promise<void> request(kj::HttpMethod method,
@@ -331,7 +331,7 @@ public:
     kj::throwFatalException(kj::mv(exception));
   }
 
-private:
+ private:
   kj::Exception exception;
 };
 

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -17,7 +17,7 @@ class IoContext_IncomingRequest;
 // An interface representing the services made available by a worker/pipeline to handle a
 // request.
 class WorkerInterface: public kj::HttpService {
-public:
+ public:
   // Constructs a WorkerInterface where any method called will throw the given exception.
   static kj::Own<WorkerInterface> fromException(kj::Exception&& e);
 
@@ -60,7 +60,7 @@ public:
   };
 
   class AlarmFulfiller {
-  public:
+   public:
     AlarmFulfiller(kj::Own<kj::PromiseFulfiller<AlarmResult>> fulfiller);
     KJ_DISALLOW_COPY(AlarmFulfiller);
     AlarmFulfiller(AlarmFulfiller&&) = default;
@@ -70,7 +70,7 @@ public:
     void reject(const kj::Exception& e);
     void cancel();
 
-  private:
+   private:
     kj::Maybe<kj::Own<kj::PromiseFulfiller<AlarmResult>>> maybeFulfiller;
     kj::Maybe<kj::PromiseFulfiller<AlarmResult>&> getFulfiller();
   };
@@ -101,7 +101,7 @@ public:
   static constexpr auto ALARM_RETRY_MAX_TRIES = 6;
 
   class CustomEvent {
-  public:
+   public:
     struct Result {
       // Outcome for logging / metrics purposes.
       EventOutcome outcome;
@@ -143,7 +143,7 @@ public:
   [[nodiscard]] virtual kj::Promise<CustomEvent::Result> customEvent(
       kj::Own<CustomEvent> event) = 0;
 
-private:
+ private:
   kj::Maybe<kj::Own<kj::HttpService>> adapterService;
 };
 
@@ -153,7 +153,7 @@ kj::Own<WorkerInterface> newPromisedWorkerInterface(kj::Promise<kj::Own<WorkerIn
 
 template <typename Func>
 class LazyWorkerInterface final: public WorkerInterface {
-public:
+ public:
   LazyWorkerInterface(Func func): func(kj::mv(func)) {}
 
   void ensureResolve() {
@@ -235,7 +235,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::Maybe<Func> func;
   kj::Maybe<kj::ForkedPromise<void>> promise;
   kj::Maybe<kj::Own<WorkerInterface>> worker;
@@ -264,7 +264,7 @@ kj::Own<WorkerInterface> newRevocableWebSocketWorkerInterface(
 // is intended to be single-use, this class is also inherently single-use (i.e. only one event
 // can be delivered).
 class RpcWorkerInterface: public WorkerInterface {
-public:
+ public:
   RpcWorkerInterface(capnp::HttpOverCapnpFactory& httpOverCapnpFactory,
       capnp::ByteStreamFactory& byteStreamFactory,
       rpc::EventDispatcher::Client dispatcher);
@@ -286,7 +286,7 @@ public:
   kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime, uint32_t retryCount) override;
   kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override;
 
-private:
+ private:
   capnp::HttpOverCapnpFactory& httpOverCapnpFactory;
   capnp::ByteStreamFactory& byteStreamFactory;
   rpc::EventDispatcher::Client dispatcher;

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -341,12 +341,12 @@ uint64_t getCurrentThreadId() {
 // Represents a thread's attempt to take an async lock. Each Isolate has a linked list of
 // `AsyncWaiter`s. A particular thread only ever owns one `AsyncWaiter` at a time.
 class Worker::AsyncWaiter: public kj::Refcounted {
-public:
+ public:
   AsyncWaiter(kj::Own<const Isolate> isolate);
   ~AsyncWaiter() noexcept;
   KJ_DISALLOW_COPY_AND_MOVE(AsyncWaiter);
 
-private:
+ private:
   // Executor for this waiter's thread.
   const kj::Executor& executor;
 
@@ -378,7 +378,7 @@ private:
 };
 
 class Worker::InspectorClient: public v8_inspector::V8InspectorClient {
-public:
+ public:
   // Wall time in milliseconds with millisecond precision. console.time() and friends rely on this
   // function to implement timers.
   double currentTimeMS() override {
@@ -443,7 +443,7 @@ public:
     runMessageLoop = false;
   }
 
-private:
+ private:
   static bool dispatchOneMessageDuringPause(Worker::Isolate::InspectorChannelImpl& channel);
 
   struct InspectorTimerInfo {
@@ -531,7 +531,7 @@ struct Worker::Isolate::Impl {
   // Always use this wrapper in code which may face lock contention (that's mostly everywhere).
   class Lock {
 
-  public:
+   public:
     explicit Lock(
         const Worker::Isolate& isolate, Worker::LockType lockType, jsg::V8StackScope& stackScope)
         : impl(*isolate.impl),
@@ -627,7 +627,7 @@ struct Worker::Isolate::Impl {
     // believes it has exclusive access.
     bool checkInWithLimitEnforcer(Worker::Isolate& isolate);
 
-  private:
+   private:
     const Impl& impl;
     IsolateObserver::LockRecord metrics;
     ThreadProgressCounter progressCounter;
@@ -638,7 +638,7 @@ struct Worker::Isolate::Impl {
 
     ConsoleMode consoleMode;
 
-  public:
+   public:
     kj::Own<jsg::Lock> lock;
   };
 
@@ -684,7 +684,7 @@ struct Worker::Isolate::Impl {
 namespace {
 
 class CpuProfilerDisposer final: public kj::Disposer {
-public:
+ public:
   virtual void disposeImpl(void* pointer) const override {
     reinterpret_cast<v8::CpuProfiler*>(pointer)->Dispose();
   }
@@ -2387,7 +2387,7 @@ kj::Promise<void> Worker::AsyncLock::whenThreadIdle() {
 // but we don't want to keep buffering extremely large ones, so just discard buffered data
 // upon hitting a limit and don't return any body to the devtools frontend afterwards.
 class Worker::Isolate::LimitedBodyWrapper: public kj::OutputStream {
-public:
+ public:
   LimitedBodyWrapper(size_t limit = 1 * 1024 * 1024): limit(limit) {
     if (limit > 0) {
       inner.emplace();
@@ -2423,7 +2423,7 @@ public:
     }
   }
 
-private:
+ private:
   size_t size = 0;
   size_t limit = 0;
   kj::Maybe<kj::VectorOutputStream> inner;
@@ -2436,7 +2436,7 @@ struct MessageQueue {
 };
 
 class Worker::Isolate::InspectorChannelImpl final: public v8_inspector::V8Inspector::Channel {
-public:
+ public:
   InspectorChannelImpl(kj::Own<const Worker::Isolate> isolateParam,
       kj::Own<const kj::Executor> isolateThreadExecutor,
       kj::WebSocket& webSocket)
@@ -2681,13 +2681,13 @@ public:
   // debugger statement.
   bool dispatchOneMessageDuringPause();
 
-private:
+ private:
   // Class that manages the I/O for devtools connections. I/O is performed on the
   // thread associated with the InspectorService (the thread that calls attachInspector).
   // Most of the public API is intended for code running on the isolate thread, such as
   // the InspectorChannelImpl and the InspectorClient.
   class WebSocketIoHandler final {
-  public:
+   public:
     WebSocketIoHandler(kj::Own<const kj::Executor> isolateThreadExecutor, kj::WebSocket& webSocket)
         : isolateThreadExecutor(kj::mv(isolateThreadExecutor)),
           webSocket(webSocket) {
@@ -2760,7 +2760,7 @@ private:
       outgoingQueueNotifier->notify();
     }
 
-  private:
+   private:
     static kj::Maybe<kj::String> pollMessage(MessageQueue& messageQueue) {
       if (messageQueue.head < messageQueue.messages.size()) {
         kj::String message = kj::mv(messageQueue.messages[messageQueue.head++]);
@@ -3171,7 +3171,7 @@ struct Worker::Actor::Impl {
       classInstance;
 
   class HooksImpl: public InputGate::Hooks, public OutputGate::Hooks, public ActorCache::Hooks {
-  public:
+   public:
     HooksImpl(kj::Own<Loopback> loopback, TimerChannel& timerChannel, ActorObserver& metrics)
         : loopback(kj::mv(loopback)),
           timerChannel(timerChannel),
@@ -3228,7 +3228,7 @@ struct Worker::Actor::Impl {
       metrics.storageWriteCompleted(latency);
     }
 
-  private:
+   private:
     kj::Own<Loopback> loopback;  // only for updateAlarmInMemory()
     TimerChannel& timerChannel;  // only for afterLimitTimeout() and updateAlarmInMemory()
     ActorObserver& metrics;
@@ -3822,7 +3822,7 @@ double getWallTimeForProcessSandboxOnly() {
 }  // namespace
 
 class Worker::Isolate::ResponseStreamWrapper final: public kj::AsyncOutputStream {
-public:
+ public:
   ResponseStreamWrapper(kj::Own<const Isolate> isolate,
       kj::String requestId,
       kj::Own<kj::AsyncOutputStream> inner,
@@ -3932,7 +3932,7 @@ public:
     return inner->whenWriteDisconnected();
   }
 
-private:
+ private:
   using InspectorLock = InspectorChannelImpl::InspectorLock;
 
   kj::Own<const Isolate> constIsolate;
@@ -3945,7 +3945,7 @@ private:
 };
 
 class Worker::Isolate::SubrequestClient final: public WorkerInterface {
-public:
+ public:
   explicit SubrequestClient(kj::Own<const Isolate> isolate,
       kj::Own<WorkerInterface> inner,
       kj::HttpHeaderId contentEncodingHeaderId,
@@ -3970,7 +3970,7 @@ public:
   kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime, uint32_t retryCount) override;
   kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override;
 
-private:
+ private:
   kj::Own<const Isolate> constIsolate;
   kj::Own<WorkerInterface> inner;
   kj::HttpHeaderId contentEncodingHeaderId;
@@ -4135,7 +4135,7 @@ kj::Promise<void> Worker::Isolate::SubrequestClient::request(kj::HttpMethod meth
   typedef decltype(signalResponse) SignalResponse;
 
   class ResponseWrapper final: public kj::HttpService::Response {
-  public:
+   public:
     ResponseWrapper(
         kj::HttpService::Response& inner, kj::String requestId, SignalResponse signalResponse)
         : inner(inner),
@@ -4158,7 +4158,7 @@ kj::Promise<void> Worker::Isolate::SubrequestClient::request(kj::HttpMethod meth
       return kj::mv(webSocket);
     }
 
-  private:
+   private:
     kj::HttpService::Response& inner;
     kj::String requestId;
     SignalResponse signalResponse;

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -68,13 +68,13 @@ typedef kj::OneOf<EntrypointClass, api::ExportedHandler> NamedExport;
 //   "Worker" is ambiguous. I considered naming the class WorkerInstance, but it feels redundant
 //   for a class name to end in "Instance". ("I have an instance of WorkerInstance...")
 class Worker: public kj::AtomicRefcounted {
-public:
+ public:
   class Script;
   class Isolate;
   class Api;
 
   class ValidationErrorReporter {
-  public:
+   public:
     virtual void addError(kj::String error) = 0;
     virtual void addHandler(kj::Maybe<kj::StringPtr> exportName, kj::StringPtr type) = 0;
 
@@ -156,7 +156,7 @@ public:
   static void setupContext(
       jsg::Lock& lock, v8::Local<v8::Context> context, Worker::ConsoleMode consoleMode);
 
-private:
+ private:
   kj::Own<const Script> script;
 
   kj::Own<WorkerObserver> metrics;
@@ -184,7 +184,7 @@ private:
 // A compiled script within an Isolate, but which hasn't been instantiated into a particular
 // context (Worker).
 class Worker::Script: public kj::AtomicRefcounted {
-public:
+ public:
   ~Script() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(Script);
 
@@ -229,7 +229,7 @@ public:
   bool isPython;
   using Source = kj::OneOf<ScriptSource, ModulesSource>;
 
-private:
+ private:
   kj::Own<const Isolate> isolate;
   kj::String id;
   bool modular;
@@ -239,7 +239,7 @@ private:
 
   friend class Worker;
 
-public:  // pretend this is private (needs to be public because allocated through template)
+ public:  // pretend this is private (needs to be public because allocated through template)
   explicit Script(kj::Own<const Isolate> isolate,
       kj::StringPtr id,
       Source source,
@@ -262,7 +262,7 @@ public:  // pretend this is private (needs to be public because allocated throug
 // ephemeral. So when the last script is destructed, the isolate can be expected to also be
 // destructed soon.
 class Worker::Isolate: public kj::AtomicRefcounted {
-public:
+ public:
   // Determines whether a devtools inspector client can be attached.
   enum class InspectorPolicy {
     DISALLOW,
@@ -398,7 +398,7 @@ public:
 
   kj::Own<const WeakIsolateRef> getWeakRef() const;
 
-private:
+ private:
   kj::Promise<AsyncLock> takeAsyncLockImpl(
       kj::Maybe<kj::Own<IsolateObserver::LockTiming>> lockTiming) const;
 
@@ -468,7 +468,7 @@ private:
 // In contrast, the rest of the classes in `worker.h` are concerned more with lifecycle
 // management.
 class Worker::Api {
-public:
+ public:
   // Get the current `Api` or throw if we're not currently executing JavaScript.
   static const Api& current();
   // TODO(cleanup): This is a hack thrown in quickly because IoContext::current() doesn't work in
@@ -556,19 +556,19 @@ public:
 //
 // A Worker::Lock MUST be allocated on the stack.
 class Worker::Lock {
-public:
+ public:
   // Worker locks should normally be taken asynchronously. The TakeSynchronously type can be used
   // when a synchronous lock is unavoidable. The purpose of this type is to make it easy to find
   // all the places where we take synchronous locks.
   class TakeSynchronously {
-  public:
+   public:
     // We don't provide a default constructor so that call sites need to think about whether they
     // have a Request& available to pass in.
     explicit TakeSynchronously(kj::Maybe<RequestObserver&> request);
 
     kj::Maybe<RequestObserver&> getRequest();
 
-  private:
+   private:
     // Non-null if this lock is being taken on behalf of a request.
     RequestObserver* request = nullptr;
     // HACK: The OneOf<TakeSynchronously, ...> in Worker::LockType doesn't like that
@@ -635,7 +635,7 @@ public:
   // Get the opaque storage key to use for recording trace information in async contexts.
   jsg::AsyncContextFrame::StorageKey& getTraceAsyncContextKey();
 
-private:
+ private:
   explicit Lock(const Worker& worker, LockType lockType, jsg::V8StackScope&);
   struct Impl;
 
@@ -648,11 +648,11 @@ private:
 // Can be initialized either from an `AsyncLock` or a `TakeSynchronously`, to indicate whether an
 // async lock is held and help us grep for places in the code that do not support async locks.
 class Worker::LockType {
-public:
+ public:
   LockType(Lock::TakeSynchronously origin): origin(origin) {}
   LockType(AsyncLock& origin): origin(&origin) {}
 
-private:
+ private:
   kj::OneOf<Lock::TakeSynchronously, AsyncLock*> origin;
   friend class Worker::Isolate;
 };
@@ -673,12 +673,12 @@ auto Worker::runInLockScope(LockType lockType, auto func) const {
 // You must never store an `AsyncLock` long-term. Use it in a continuation and then discard it.
 // To put it another way: An `AsyncLock` instance must never outlive an `evalLast()`.
 class Worker::AsyncLock {
-public:
+ public:
   // Waits until the thread has no async locks, is not waiting on any locks, and has finished all
   // pending events (a la `kj::evalLast()`).
   static kj::Promise<void> whenThreadIdle();
 
-private:
+ private:
   kj::Own<AsyncWaiter> waiter;
   kj::Maybe<kj::Own<IsolateObserver::LockTiming>> lockTiming;
 
@@ -693,7 +693,7 @@ private:
 // Represents actor state within a Worker instance. This object tracks the JavaScript heap
 // objects backing `event.actorState`. Multiple `Actor`s can be created within a single `Worker`.
 class Worker::Actor final: public kj::Refcounted {
-public:
+ public:
   // Callback which constructs the `ActorCacheInterface` instance (if any) for the Actor. This
   // can be used to customize the storage implementation. This will be called synchronously in
   // the constructor.
@@ -715,7 +715,7 @@ public:
   // Class that allows sending requests to this actor, recreating it as needed. It is safe to hold
   // onto this for longer than a Worker::Actor is alive.
   class Loopback {
-  public:
+   public:
     // Send a request to this actor, potentially re-creating it if it is not currently active.
     // The returned kj::Own<WorkerInterface> may be held longer than Loopback, and is assumed
     // to keep the Worker::Actor alive as well.
@@ -728,7 +728,7 @@ public:
   // The manager handles accepting new WebSockets, retrieving existing WebSockets by tag, and
   // removing WebSockets from its collection when they disconnect.
   class HibernationManager: public kj::Refcounted {
-  public:
+   public:
     virtual void acceptWebSocket(jsg::Ref<api::WebSocket> ws, kj::ArrayPtr<kj::String> tags) = 0;
     virtual kj::Vector<jsg::Ref<api::WebSocket>> getWebSockets(
         jsg::Lock& js, kj::Maybe<kj::StringPtr> tag) = 0;
@@ -849,7 +849,7 @@ public:
 
   kj::Own<Worker::Actor> addRef();
 
-private:
+ private:
   kj::Promise<WorkerInterface::ScheduleAlarmResult> handleAlarm(kj::Date scheduledTime);
 
   kj::Own<const Worker> worker;

--- a/src/workerd/jsg/async-context.h
+++ b/src/workerd/jsg/async-context.h
@@ -66,10 +66,10 @@ namespace workerd::jsg {
 // AsyncContextFrame::StorageKey is used to define a storage cell within the storage
 // context.
 class AsyncContextFrame final: public Wrappable {
-public:
+ public:
   // An opaque key that identifies an async-local storage cell within the frame.
   class StorageKey: public kj::Refcounted {
-  public:
+   public:
     StorageKey(): hash(kj::hashCode(this)) {}
     KJ_DISALLOW_COPY_AND_MOVE(StorageKey);
 
@@ -99,7 +99,7 @@ public:
 
     JSG_MEMORY_INFO(StorageKey) {}
 
-  private:
+   private:
     uint hash;
     bool dead = false;
   };
@@ -208,7 +208,7 @@ public:
     tracker.trackField("storage", storage);
   }
 
-private:
+ private:
   struct StorageEntryCallbacks {
     StorageKey& keyForRow(StorageEntry& entry) const {
       return *entry.key;

--- a/src/workerd/jsg/buffersource.h
+++ b/src/workerd/jsg/buffersource.h
@@ -72,7 +72,7 @@ using BufferSourceViewConstructor = v8::Local<v8::Value> (*)(Lock&, BackingStore
 // The BackingStore can be safely used outside of the isolate lock and can even be passed
 // into another isolate if necessary.
 class BackingStore {
-public:
+ public:
   template <BufferSourceType T = v8::Uint8Array>
   static BackingStore from(kj::Array<kj::byte> data) {
     // Creates a new BackingStore that takes over ownership of the given kj::Array.
@@ -212,7 +212,7 @@ public:
     tracker.trackFieldWithSize("buffer", size());
   }
 
-private:
+ private:
   std::shared_ptr<v8::BackingStore> backingStore;
   size_t byteLength;
   size_t byteOffset;
@@ -284,7 +284,7 @@ private:
 //     }
 //   };
 class BufferSource {
-public:
+ public:
   static kj::Maybe<BufferSource> tryAlloc(Lock& js, size_t size);
   static BufferSource wrap(
       Lock& js, void* data, size_t size, BackingStore::Disposer disposer, void* ctx);
@@ -403,7 +403,7 @@ public:
     }
   }
 
-private:
+ private:
   Value handle;
   kj::Maybe<BackingStore> maybeBackingStore;
 
@@ -426,7 +426,7 @@ private:
 // TypeWrapper implementation for the BufferSource type.
 template <typename TypeWrapper>
 class BufferSourceWrapper {
-public:
+ public:
   static constexpr const char* getName(BufferSource*) {
     return "BufferSource";
   }

--- a/src/workerd/jsg/compile-cache.h
+++ b/src/workerd/jsg/compile-cache.h
@@ -21,9 +21,9 @@ namespace workerd::jsg {
 // or replaced. If things are ever changed such that entries are removed/replaced, then
 // we'd likely need to have find return an atomic refcount or something similar.
 class CompileCache {
-public:
+ public:
   class Data {
-  public:
+   public:
     Data(): data(nullptr), length(0), owningPtr(nullptr) {};
     explicit Data(std::shared_ptr<v8::ScriptCompiler::CachedData> cached_data)
         : data(cached_data->data),
@@ -38,7 +38,7 @@ public:
     const uint8_t* data;
     size_t length;
 
-  private:
+   private:
     std::shared_ptr<void> owningPtr;
   };
 
@@ -50,7 +50,7 @@ public:
     return instance;
   }
 
-private:
+ private:
   // The key is the address of the static global that was compiled to produce the CachedData.
   kj::MutexGuarded<kj::HashMap<kj::String, Data>> cache;
 };

--- a/src/workerd/jsg/disable-memoize-test.c++
+++ b/src/workerd/jsg/disable-memoize-test.c++
@@ -94,13 +94,13 @@ struct TestContext: public BaseTestContext {
 JSG_DECLARE_ISOLATE_TYPE(TestIsolate, TestContext, BaseTestContext, TestApi1, TestApi2);
 
 class Configuration {
-public:
+ public:
   Configuration(workerd::CompatibilityFlags::Reader& flags): flags(flags) {}
   operator const workerd::CompatibilityFlags::Reader() const {
     return flags;
   }
 
-private:
+ private:
   workerd::CompatibilityFlags::Reader& flags;
 };
 

--- a/src/workerd/jsg/dom-exception.h
+++ b/src/workerd/jsg/dom-exception.h
@@ -42,7 +42,7 @@ namespace workerd::jsg {
 // the same tunneled exception feature by defining their own globally-accessible type named
 // "DOMException".
 class DOMException: public Object {
-public:
+ public:
   DOMException(kj::String message, kj::String name): message(kj::mv(message)), name(kj::mv(name)) {}
 
   // JS API
@@ -103,7 +103,7 @@ public:
   static jsg::Ref<DOMException> deserialize(
       jsg::Lock& js, uint tag, jsg::Deserializer& deserializer);
 
-private:
+ private:
   kj::String message;
   kj::String name;
   PropertyReflection<kj::String> stack;

--- a/src/workerd/jsg/function.h
+++ b/src/workerd/jsg/function.h
@@ -20,7 +20,7 @@ class WrappableFunction;
 
 template <typename Ret, typename... Args>
 class WrappableFunction<Ret(Args...)>: public Wrappable {
-public:
+ public:
   WrappableFunction(bool needsGcTracing): needsGcTracing(needsGcTracing) {}
   virtual Ret operator()(Lock& js, Args&&... args) = 0;
 
@@ -46,7 +46,7 @@ class WrappableFunctionImpl;
 
 template <typename Ret, typename... Args, typename Impl>
 class WrappableFunctionImpl<Ret(Args...), Impl, false>: public WrappableFunction<Ret(Args...)> {
-public:
+ public:
   WrappableFunctionImpl(Impl&& func)
       : WrappableFunction<Ret(Args...)>(false),
         func(kj::fwd<Impl>(func)) {}
@@ -55,13 +55,13 @@ public:
     return func(js, kj::fwd<Args>(args)...);
   }
 
-private:
+ private:
   Impl func;
 };
 
 template <typename Ret, typename... Args, typename Impl>
 class WrappableFunctionImpl<Ret(Args...), Impl, true>: public WrappableFunction<Ret(Args...)> {
-public:
+ public:
   WrappableFunctionImpl(Impl&& func)
       : WrappableFunction<Ret(Args...)>(true),
         func(kj::fwd<Impl>(func)) {}
@@ -73,7 +73,7 @@ public:
     visitor.visit(func);
   }
 
-private:
+ private:
   Impl func;
 };
 
@@ -137,7 +137,7 @@ template <typename Ret, typename... Args>
 class Function<Ret(Args...)> {
   // (Docs are in jsg.h, the public header.)
 
-public:
+ public:
   using NativeFunction = jsg::WrappableFunction<Ret(Args...)>;
 
   // When holding a JavaScript function, `Wrapper` is a C++ function that will handle converting
@@ -268,7 +268,7 @@ public:
     }
   }
 
-private:
+ private:
   Function(Ref<NativeFunction>&& func): impl(kj::mv(func)) {}
 
   struct JsImpl {
@@ -288,7 +288,7 @@ private:
 
 template <typename T>
 class Constructor: public jsg::Function<T> {
-public:
+ public:
   using jsg::Function<T>::Function;
 };
 
@@ -311,7 +311,7 @@ using MethodSignature = typename MethodSignature_<Method>::Type;
 template <typename TypeWrapper>
 class FunctionWrapper {
 
-public:
+ public:
   template <typename Func, typename = decltype(&kj::Decay<Func>::operator())>
   static constexpr const char* getName(Func*) {
     return "function";
@@ -486,7 +486,7 @@ public:
 
 template <typename Func>
 class VisitableLambda {
-public:
+ public:
   VisitableLambda(Func&& func): func(kj::fwd<Func>(func)) {}
 
   template <typename... Params>
@@ -498,7 +498,7 @@ public:
     func(visitor);
   }
 
-private:
+ private:
   Func func;
 };
 

--- a/src/workerd/jsg/inspector.c++
+++ b/src/workerd/jsg/inspector.c++
@@ -36,12 +36,12 @@ kj::String KJ_STRINGIFY(const v8_inspector::StringView& view) {
 namespace workerd::jsg {
 namespace {
 class StringViewWithScratch: public v8_inspector::StringView {
-public:
+ public:
   StringViewWithScratch(v8_inspector::StringView text, kj::Array<char16_t>&& scratch)
       : v8_inspector::StringView(text),
         scratch(kj::mv(scratch)) {}
 
-private:
+ private:
   kj::Array<char16_t> scratch;
 };
 }  // namespace

--- a/src/workerd/jsg/iterator.h
+++ b/src/workerd/jsg/iterator.h
@@ -33,7 +33,7 @@ struct GeneratorNext {
 template <typename T>
 class GeneratorContext final {
   // See the documentation in jsg.h
-public:
+ public:
   // Signal early return on the generator. The value given will be returned by the
   // generator's forEach once the generator completes returning.
   void return_(Lock& js, kj::Maybe<T> maybeValue = kj::none) {
@@ -56,7 +56,7 @@ public:
     return state.template is<Erroring>();
   }
 
-private:
+ private:
   struct Init {};
   struct Erroring {};
   using Returning = kj::Maybe<T>;
@@ -88,7 +88,7 @@ private:
 // Provides underlying state for Generator and AsyncGenerator instances.
 template <typename Generator>
 class GeneratorImpl {
-public:
+ public:
   using T = typename Generator::Type;
   using NextSignature = typename Generator::NextSignature;
   using ReturnSignature = typename Generator::ReturnSignature;
@@ -120,7 +120,7 @@ public:
     }
   }
 
-private:
+ private:
   struct Finished {};
   struct Active {
     kj::Maybe<NextSignature> maybeNext;
@@ -181,7 +181,7 @@ concept AsyncGeneratorCallback = true;
 template <typename T>
 class Generator final {
   // See the documentation in jsg.h
-public:
+ public:
   Generator(Generator&&) = default;
   Generator& operator=(Generator&&) = default;
 
@@ -279,7 +279,7 @@ public:
     }
   }
 
-private:
+ private:
   using Type = T;
   using Next = GeneratorNext<T>;
   using NextSignature = Function<Next()>;
@@ -302,7 +302,7 @@ private:
 template <typename T>
 class AsyncGenerator final {
   // See the documentation in jsg.h
-public:
+ public:
   AsyncGenerator(AsyncGenerator&&) = default;
   AsyncGenerator& operator=(AsyncGenerator&&) = default;
 
@@ -335,7 +335,7 @@ public:
     }
   }
 
-private:
+ private:
   using Type = T;
   using Next = GeneratorNext<T>;
   using NextSignature = Function<Promise<Next>()>;
@@ -535,7 +535,7 @@ Promise<void> AsyncGenerator<T>::throw_(Lock& js, jsg::Value exception) {
 
 template <typename TypeWrapper>
 class GeneratorWrapper {
-public:
+ public:
   template <typename T>
   static constexpr const char* getName(Generator<T>*) {
     return "Generator";
@@ -674,7 +674,7 @@ template <typename TypeWrapper>
 class SequenceWrapper {
   // TypeWrapper mixin for jsg::Sequences.
 
-public:
+ public:
   static auto constexpr MAX_STACK = 64;
 
   template <typename U>
@@ -733,7 +733,7 @@ template <typename SelfType, typename Type, typename State>
 class IteratorBase: public Object {
   // Provides the base implementation of JSG_ITERATOR types. See the documentation
   // for JSG_ITERATOR for details.
-public:
+ public:
   using NextSignature = kj::Maybe<Type>(Lock&, State&);
   explicit IteratorBase(State state): state(kj::mv(state)) {}
   struct Next {
@@ -760,7 +760,7 @@ public:
     }
   }
 
-private:
+ private:
   State state;
 
   Next nextImpl(Lock& js, NextSignature nextFunc) {
@@ -777,7 +777,7 @@ private:
 };
 
 class AsyncIteratorImpl {
-public:
+ public:
   struct Finished {};
 
   kj::Maybe<Promise<void>&> maybeCurrent();
@@ -801,7 +801,7 @@ public:
     // TODO(soon): Implement memory tracking
   }
 
-private:
+ private:
   std::deque<Promise<void>> pendingStack;
 };
 
@@ -856,7 +856,7 @@ private:
 // return an immediately resolved promise indicating that the iterator is done.
 template <typename SelfType, typename Type, typename State>
 class AsyncIteratorBase: public Object {
-public:
+ public:
   using NextSignature = Promise<kj::Maybe<Type>>(Lock&, State&);
   using ReturnSignature = Promise<void>(Lock&, State&, Optional<Value>);
   using Next = AsyncIteratorImpl::Next<Type>;
@@ -888,7 +888,7 @@ public:
     }
   }
 
-private:
+ private:
   struct InnerState {
     State state;
     AsyncIteratorImpl impl;
@@ -1066,7 +1066,7 @@ private:
 // implementation of the entries(Lock&) member function.
 #define JSG_ITERATOR(Name, Label, Type, State, NextFunc)                                           \
   class Name final: public jsg::IteratorBase<Name, Type, State> {                                  \
-  public:                                                                                          \
+   public:                                                                                         \
     using jsg::IteratorBase<Name, Type, State>::IteratorBase;                                      \
     inline Next next(jsg::Lock& js) {                                                              \
       return nextImpl(js, NextFunc);                                                               \
@@ -1081,7 +1081,7 @@ private:
 
 #define JSG_ASYNC_ITERATOR_TYPE(Name, Type, State, NextFunc, ReturnFunc)                           \
   class Name final: public jsg::AsyncIteratorBase<Name, Type, State> {                             \
-  public:                                                                                          \
+   public:                                                                                         \
     using jsg::AsyncIteratorBase<Name, Type, State>::AsyncIteratorBase;                            \
     inline jsg::Promise<Next> next(jsg::Lock& js) {                                                \
       return nextImpl(js, NextFunc);                                                               \

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -204,7 +204,7 @@ struct ProtoContext: public ContextGlobalObject {
     JSG_INSTANCE_PROPERTY(contextProperty, getContextProperty, setContextProperty);
   }
 
-private:
+ private:
   kj::String contextProperty;
 };
 JSG_DECLARE_ISOLATE_TYPE(ProtoIsolate, ProtoContext, NumberBox, BoxBox, ExtendedNumberBox);
@@ -321,7 +321,7 @@ KJ_TEST("jsg::Lock logWarning") {
 // JSG_CALLABLE Test
 struct CallableContext: public ContextGlobalObject {
   struct MyCallable: public Object {
-  public:
+   public:
     static Ref<MyCallable> constructor() {
       return alloc<MyCallable>();
     }

--- a/src/workerd/jsg/jsg-test.h
+++ b/src/workerd/jsg/jsg-test.h
@@ -27,7 +27,7 @@ class Evaluator {
   // TODO(cleanup): `ConfigurationType` currently can optionally be specified to fix the build
   //   in cases that the isolate includes types that require configuration, but currently the
   //   type is always default-constructed. What if you want to specify a test config?
-public:
+ public:
   explicit Evaluator(V8System& v8System): v8System(v8System) {}
 
   IsolateType& getIsolate() {
@@ -135,7 +135,7 @@ public:
     lock.runMicrotasks();
   }
 
-private:
+ private:
   V8System& v8System;
 };
 
@@ -213,7 +213,7 @@ struct NumberBox: public Object {
 };
 
 class BoxBox: public Object {
-public:
+ public:
   explicit BoxBox(Ref<NumberBox> inner): inner(kj::mv(inner)) {}
 
   Ref<NumberBox> inner;
@@ -230,7 +230,7 @@ public:
     JSG_READONLY_INSTANCE_PROPERTY(inner, getInner);
   }
 
-private:
+ private:
   void visitForGc(GcVisitor& visitor) {
     visitor.visit(inner);
   }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -760,7 +760,7 @@ class Lock;
 // visitation for them. Moving jsg::Data which are reachable via GC visitation is undefined
 // behavior outside of an isolate lock.
 class Data {
-public:
+ public:
   Data(decltype(nullptr)) {}
   ~Data() noexcept(false) {
     destroy();
@@ -813,7 +813,7 @@ public:
     return handle == other;
   }
 
-private:
+ private:
   // The isolate with which the handles below are associated.
   v8::Isolate* isolate = nullptr;
 
@@ -855,7 +855,7 @@ private:
 // jsg::V8Ref<T> when you need the type-safety of holding a handle to a specific V8 type.
 template <typename T>
 class V8Ref: private Data {
-public:
+ public:
   V8Ref(decltype(nullptr)): Data(nullptr) {}
   V8Ref(v8::Isolate* isolate, v8::Local<T> handle): Data(isolate, handle) {}
   V8Ref(V8Ref&& other): Data(kj::mv(other)) {}
@@ -893,7 +893,7 @@ public:
   template <typename U>
   V8Ref<U> cast(jsg::Lock& js);
 
-private:
+ private:
   friend class GcVisitor;
   friend class MemoryTracker;
 };
@@ -905,7 +905,7 @@ using Value = V8Ref<v8::Value>;
 // T must v8::Object or a subclass (or anything that implements GetIdentityHash()).
 template <typename T>
 class HashableV8Ref: public V8Ref<T> {
-public:
+ public:
   HashableV8Ref(decltype(nullptr)): V8Ref<T>(nullptr), identityHash(0) {}
   HashableV8Ref(v8::Isolate* isolate, v8::Local<T> handle)
       // TODO(perf): It's not clear if V8's `GetIdentityHash()` is intended to return uniform
@@ -928,7 +928,7 @@ public:
     return identityHash;
   }
 
-private:
+ private:
   int identityHash;
 
   HashableV8Ref(v8::Isolate* isolate, v8::Local<T> handle, int identityHash)
@@ -975,7 +975,7 @@ void MemoryTracker::trackField(
 //     void foo(Optional<Data> data);
 template <typename T>
 class Optional: public kj::Maybe<T> {
-public:
+ public:
   // Inheriting constructors does not inherit copy/move constructors, so we declare a forwarding
   // constructor instead.
   template <typename... Params>
@@ -986,7 +986,7 @@ public:
 //  error, it just results in an unset LenientOptional.
 template <typename T>
 class LenientOptional: public kj::Maybe<T> {
-public:
+ public:
   // Inheriting constructors does not inherit copy/move constructors, so we declare a forwarding
   // constructor instead.
   template <typename... Params>
@@ -1000,7 +1000,7 @@ public:
 // Another option is to use jsg::Identified<MyStruct>, but sometimes storing the reference
 // into a field of the unwrapped struct is more convenient.
 class SelfRef: public V8Ref<v8::Object> {
-public:
+ public:
   using V8Ref::V8Ref;
 };
 
@@ -1012,7 +1012,7 @@ public:
 //
 //   Move this class to the `api` directory and rename to HeaderString.
 class ByteString: public kj::String {
-public:
+ public:
   // Inheriting constructors does not inherit copy/move constructors, so we declare a forwarding
   // constructor instead.
   template <typename... Params>
@@ -1067,7 +1067,7 @@ class TypeHandler;
 // unwrapping them all as type T.
 template <typename T>
 class Arguments: public kj::Array<T> {
-public:
+ public:
   Arguments(kj::Array<T>&& value): kj::Array<T>(kj::mv(value)) {}
 
   using ElementType = T;
@@ -1094,7 +1094,7 @@ constexpr bool isArguments() {
 // An array of local values placed on the end of a parameter list to capture all trailing values
 class Varargs {
   // TODO(cleanup): Can all use cases of this be replaced with Arguments<Value>?
-public:
+ public:
   Varargs(size_t index, const v8::FunctionCallbackInfo<v8::Value>& args)
       : startIndex(index),
         args(args) {
@@ -1117,7 +1117,7 @@ public:
 
   class Iterator {
     // TODO(cleanup): This is similar to capnp::_::IndexingIterator. Maybe a common utility class should be added to KJ.
-  public:
+   public:
     inline Iterator(size_t index, const v8::FunctionCallbackInfo<v8::Value>& args)
         : index(index),
           args(args) {}
@@ -1140,7 +1140,7 @@ public:
       return index == other.index && &args == &other.args;
     }
 
-  private:
+   private:
     size_t index;
     const v8::FunctionCallbackInfo<v8::Value>& args;
   };
@@ -1152,7 +1152,7 @@ public:
     return Iterator(startIndex + length, args);
   };
 
-private:
+ private:
   size_t startIndex;
   size_t length;
   const v8::FunctionCallbackInfo<v8::Value>& args;
@@ -1165,7 +1165,7 @@ void visitSubclassForGc(T* obj, GcVisitor& visitor);
 
 // All resource types must inherit from this.
 class Object: private Wrappable {
-public:
+ public:
   using jsgThis = Object;
 
   // Objects that extend from jsg::Object should never be copied or moved
@@ -1205,7 +1205,7 @@ public:
   // own tag.
   static constexpr uint jsgSerializeTag = kj::maxValue;
 
-private:
+ private:
   inline void visitForMemoryInfo(MemoryTracker& tracker) const {}
   inline void visitForGc(GcVisitor& visitor) {}
   template <typename>
@@ -1254,7 +1254,7 @@ private:
 // behavior outside of an isolate lock.
 template <typename T>
 class Ref {
-public:
+ public:
   Ref(decltype(nullptr)): strong(false) {}
   Ref(Ref&& other): inner(kj::mv(other.inner)), strong(true) {
     if (other.strong) {
@@ -1342,7 +1342,7 @@ public:
     inner->Wrappable::attachWrapper(isolate, object, resourceNeedsGcTracing<T>());
   }
 
-private:
+ private:
   kj::Own<T> inner;
 
   // If this has ever been traced, the parent object from which the trace originated. This is kept
@@ -1402,7 +1402,7 @@ Ref<T> _jsgThis(T* obj) {
 // JavaScript, including types that are otherwise pass-by-value.
 template <typename T>
 class MemoizedIdentity {
-public:
+ public:
   inline MemoizedIdentity(T value): value(kj::mv(value)) {}
 
   inline MemoizedIdentity& operator=(T value) {
@@ -1427,7 +1427,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::OneOf<T, Value> value;
 
   template <typename TypeWrapper>
@@ -1464,7 +1464,7 @@ struct Identified {
 //
 // Name implements hashCode() so it is suitable for use as a key in kj::HashMap, etc.
 class Name final {
-public:
+ public:
   explicit Name(kj::String string);
   explicit Name(kj::StringPtr string);
   explicit Name(Lock& js, v8::Local<v8::Symbol> symbol);
@@ -1491,7 +1491,7 @@ public:
     }
   }
 
-private:
+ private:
   int hash;
   kj::OneOf<kj::String, V8Ref<v8::Symbol>> inner;
 
@@ -1703,7 +1703,7 @@ class ModuleRegistry;
 // jsg::Object should always be the first inherited class, and jsg::ContextGlobal second.
 // The lifetime of the global object matches the lifetime of the JavaScript context.
 class ContextGlobal {
-public:
+ public:
   ContextGlobal() {}
 
   KJ_DISALLOW_COPY_AND_MOVE(ContextGlobal);
@@ -1712,7 +1712,7 @@ public:
     return *moduleRegistry;
   }
 
-private:
+ private:
   kj::Own<ModuleRegistry> moduleRegistry;
 
   void setModuleRegistry(kj::Own<ModuleRegistry> registry) {
@@ -1728,7 +1728,7 @@ private:
 // which is more than just the global object.
 template <typename T>
 class JsContext {
-public:
+ public:
   static_assert(
       std::is_base_of_v<ContextGlobal, T>, "context global type must extend jsg::ContextGlobal");
 
@@ -1754,7 +1754,7 @@ public:
   }
   v8::Local<v8::Context> getHandle(Lock& js) const;
 
-private:
+ private:
   v8::Global<v8::Context> handle;
   Ref<T> object;
   kj::Maybe<kj::Own<void>> maybeNewRegistryHandle;
@@ -1807,7 +1807,7 @@ constexpr bool hasPublicVisitForGc() {
 // destroy them. To avoid this situation, make sure your C++ objects have clear ownership, so
 // that the reference graph is a DAG, just like you always would in C++.
 class GcVisitor {
-public:
+ public:
   template <typename T>
   void visit(Ref<T>& ref) {
     ref.inner->visitRef(*this, ref.parent, ref.strong);
@@ -1868,7 +1868,7 @@ public:
     }
   }
 
-private:
+ private:
   Wrappable& parent;
   kj::Maybe<cppgc::Visitor&> cppgcVisitor;
 
@@ -1917,7 +1917,7 @@ constexpr bool isGcVisitable() {
 // For resource types, also need to wrap in Ref, i.e. `TypeHandler<jsg::Ref<T>>`.
 template <typename T>
 class TypeHandler {
-public:
+ public:
   // ---------------------------------------------------------------------------
   // Interface for value types (i.e. types not declared using JSG_RESOURCE_TYPE).
   //
@@ -1960,7 +1960,7 @@ public:
 // handler, you can also do `obj.onfoo = func`.
 template <typename T>
 class PropertyReflection {
-public:
+ public:
   // Read the property of this object called `name`, unwrapping it as type `T`.
   kj::Maybe<T> get(Lock& js, kj::StringPtr name);
 
@@ -1977,7 +1977,7 @@ public:
 
   // TODO(someday): Support for reading Symbols and Privates?
 
-private:
+ private:
   kj::Maybe<Wrappable&> self;
 
   typedef kj::Maybe<T> Unwrapper(v8::Isolate*, v8::Local<v8::Object> object, kj::StringPtr name);
@@ -2202,7 +2202,7 @@ class DOMException;
 // The adjustment will be automatically decremented when the object is destroyed.
 // The allocation amount can be adjusted up or down during the lifetime of an object.
 class ExternalMemoryAdjustment final {
-public:
+ public:
   ExternalMemoryAdjustment() = default;
   ExternalMemoryAdjustment(v8::Isolate* isolate, size_t amount);
   ExternalMemoryAdjustment(ExternalMemoryAdjustment&& other);
@@ -2225,7 +2225,7 @@ public:
     return amount;
   }
 
-private:
+ private:
   size_t amount = 0;
   v8::Isolate* isolate = nullptr;
 
@@ -2256,7 +2256,7 @@ private:
 // passed down to everyone else from there. See setup.h for details.
 
 class Lock {
-public:
+ public:
   // The underlying V8 isolate, useful for directly calling V8 APIs. Hopefully, this is rarely
   // needed outside JSG itself.
   v8::Isolate* const v8Isolate;
@@ -2646,7 +2646,7 @@ public:
   // the inspector (if attached), or to KJ_LOG(Info).
   virtual void reportError(const JsValue& value) = 0;
 
-private:
+ private:
   // Mark the jsg::Lock as being disallowed from being passed as a parameter into
   // a kj promise coroutine. Note that this only blocks directly passing the Lock
   // in. Types that have the Lock included as a member field won't be caught and
@@ -2687,10 +2687,10 @@ private:
 // The V8StackScope is used only as a marker to prove that we are running in the V8 stack
 // established by calling runInV8Stack(...)
 class V8StackScope final {
-public:
+ public:
   KJ_DISALLOW_COPY_AND_MOVE(V8StackScope);
 
-private:
+ private:
   V8StackScope() = default;
   KJ_DISALLOW_AS_COROUTINE_PARAM;
 

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -127,7 +127,7 @@ enum PromiseState { PENDING, FULFILLED, REJECTED };
 //   const TypeHandler<MyStruct>& handler = // ...
 //   MyStruct v = KJ_ASSERT_NONNULL(handler.tryUnwrap(js, obj));
 class JsValue final {
-public:
+ public:
   template <typename T>
   kj::Maybe<T> tryCast() const KJ_WARN_UNUSED_RESULT;
 
@@ -161,7 +161,7 @@ public:
 
   explicit JsValue(v8::Local<v8::Value> inner);
 
-private:
+ private:
   v8::Local<v8::Value> inner;
   friend class Lock;
   template <typename TypeWrapper>
@@ -178,7 +178,7 @@ private:
 
 template <typename T, typename Self>
 class JsBase {
-public:
+ public:
   operator v8::Local<v8::Value>() const {
     return inner;
   }
@@ -199,7 +199,7 @@ public:
   }
   JsRef<Self> addRef(Lock& js) KJ_WARN_UNUSED_RESULT;
 
-private:
+ private:
   v8::Local<T> inner;
   friend class Lock;
   friend class JsValue;
@@ -213,14 +213,14 @@ private:
 };
 
 class JsBoolean final: public JsBase<v8::Boolean, JsBoolean> {
-public:
+ public:
   bool value(Lock& js) const KJ_WARN_UNUSED_RESULT;
 
   using JsBase<v8::Boolean, JsBoolean>::JsBase;
 };
 
 class JsArray final: public JsBase<v8::Array, JsArray> {
-public:
+ public:
   operator JsObject() const;
   uint32_t size() const KJ_WARN_UNUSED_RESULT;
   JsValue get(Lock& js, uint32_t i) const KJ_WARN_UNUSED_RESULT;
@@ -230,7 +230,7 @@ public:
 };
 
 class JsString final: public JsBase<v8::String, JsString> {
-public:
+ public:
   int length(Lock& js) const KJ_WARN_UNUSED_RESULT;
   int utf8Length(Lock& js) const KJ_WARN_UNUSED_RESULT;
   kj::String toString(Lock& js) const KJ_WARN_UNUSED_RESULT;
@@ -277,14 +277,14 @@ public:
 };
 
 class JsRegExp final: public JsBase<v8::RegExp, JsRegExp> {
-public:
+ public:
   kj::Maybe<JsArray> operator()(Lock& js, const JsString& input) const KJ_WARN_UNUSED_RESULT;
   kj::Maybe<JsArray> operator()(Lock& js, kj::StringPtr input) const KJ_WARN_UNUSED_RESULT;
   using JsBase<v8::RegExp, JsRegExp>::JsBase;
 };
 
 class JsDate final: public JsBase<v8::Date, JsDate> {
-public:
+ public:
   jsg::ByteString toUTCString(Lock& js) const;
   operator kj::Date() const;
   using JsBase<v8::Date, JsDate>::JsBase;
@@ -302,14 +302,14 @@ public:
 // You'll usually want to use `jsg::Promise<T>`. `jsg::JsPromise` should only be used when you need
 // direct access to the promise state (e.g. the promise state or its fulfilled value).
 class JsPromise final: public JsBase<v8::Promise, JsPromise> {
-public:
+ public:
   PromiseState state();
   JsValue result();
   using JsBase<v8::Promise, JsPromise>::JsBase;
 };
 
 class JsProxy final: public JsBase<v8::Proxy, JsProxy> {
-public:
+ public:
   JsValue target();
   JsValue handler();
   using JsBase<v8::Proxy, JsProxy>::JsBase;
@@ -317,7 +317,7 @@ public:
 
 #define V(Name)                                                                                    \
   class Js##Name final: public JsBase<v8::Name, Js##Name> {                                        \
-  public:                                                                                          \
+   public:                                                                                         \
     using JsBase<v8::Name, Js##Name>::JsBase;                                                      \
   };
 
@@ -331,7 +331,7 @@ V(Set)
 #undef V
 
 class JsObject final: public JsBase<v8::Object, JsObject> {
-public:
+ public:
   template <typename T>
   bool isInstanceOf(Lock& js) {
     return js.getInstance(inner, typeid(T)) != kj::none;
@@ -391,7 +391,7 @@ public:
 };
 
 class JsMap final: public JsBase<v8::Map, JsMap> {
-public:
+ public:
   operator JsObject();
 
   void set(Lock& js, const JsValue& name, const JsValue& value);
@@ -492,7 +492,7 @@ template <typename T>
 class JsRef final {
   static_assert(std::is_assignable_v<JsValue, T>, "JsRef<T>, T must be assignable to type JsValue");
 
-public:
+ public:
   JsRef(): JsRef(nullptr) {}
   JsRef(decltype(nullptr)): value(nullptr) {}
   JsRef(Lock& js, const T& value): value(js.v8Isolate, value.inner) {}
@@ -539,7 +539,7 @@ public:
     tracker.trackField("value", value);
   }
 
-private:
+ private:
   Value value;
   friend class JsValue;
 #define V(Name) friend class Js##Name;
@@ -621,7 +621,7 @@ struct JsValueWrapper {
 };
 
 class JsMessage final {
-public:
+ public:
   static JsMessage create(Lock& js, const JsValue& exception);
   explicit inline JsMessage(): inner(v8::Local<v8::Message>()) {
     requireOnStack(this);
@@ -643,7 +643,7 @@ public:
   // kj::Vector.
   void addJsStackTrace(Lock& js, kj::Vector<kj::String>& lines);
 
-private:
+ private:
   v8::Local<v8::Message> inner;
 };
 

--- a/src/workerd/jsg/memory.c++
+++ b/src/workerd/jsg/memory.c++
@@ -5,7 +5,7 @@
 namespace workerd::jsg {
 
 class MemoryRetainerNode final: public v8::EmbedderGraph::Node {
-public:
+ public:
   static constexpr auto PREFIX = "workerd /";
 
   const char* Name() override {
@@ -43,7 +43,7 @@ public:
   KJ_DISALLOW_COPY_AND_MOVE(MemoryRetainerNode);
   ~MemoryRetainerNode() noexcept(true) {}
 
-private:
+ private:
   static v8::EmbedderGraph::Node::Detachedness fromDetachedState(MemoryInfoDetachedState state) {
     switch (state) {
       case MemoryInfoDetachedState::UNKNOWN:

--- a/src/workerd/jsg/memory.h
+++ b/src/workerd/jsg/memory.h
@@ -165,7 +165,7 @@ concept V8Value = requires(T a) { std::is_assignable_v<v8::Value, T>; };
 // jsg::MemoryTracker is used to construct the embedder graph for v8 heap
 // snapshot construction.
 class MemoryTracker final {
-public:
+ public:
   inline void trackFieldWithSize(
       kj::StringPtr edgeName, size_t size, kj::Maybe<kj::StringPtr> nodeName = kj::none);
 
@@ -296,7 +296,7 @@ public:
 
   KJ_DISALLOW_COPY_AND_MOVE(MemoryTracker);
 
-private:
+ private:
   v8::Isolate* isolate_;
   v8::EmbedderGraph* graph_;
   std::stack<MemoryRetainerNode*> nodeStack_;
@@ -589,7 +589,7 @@ inline void visitSubclassForMemoryInfo(const T* obj, MemoryTracker& tracker) {
 // ======================================================================================
 
 class HeapSnapshotActivity final: public v8::ActivityControl {
-public:
+ public:
   using Callback = kj::Function<bool(uint32_t done, uint32_t total)>;
 
   HeapSnapshotActivity(Callback callback);
@@ -597,12 +597,12 @@ public:
 
   ControlOption ReportProgressValue(uint32_t done, uint32_t total) override;
 
-private:
+ private:
   Callback callback;
 };
 
 class HeapSnapshotWriter final: public v8::OutputStream {
-public:
+ public:
   using Callback = kj::Function<bool(kj::Maybe<kj::ArrayPtr<char>>)>;
 
   HeapSnapshotWriter(Callback callback, size_t chunkSize = 65536);
@@ -614,7 +614,7 @@ public:
 
   v8::OutputStream::WriteResult WriteAsciiChunk(char* data, int size) override;
 
-private:
+ private:
   Callback callback;
   size_t chunkSize;
 };

--- a/src/workerd/jsg/modules-new.c++
+++ b/src/workerd/jsg/modules-new.c++
@@ -50,7 +50,7 @@ ModuleBundle::Type toModuleBuilderType(ModuleBundle::BuiltinBuilder::Type type) 
 }
 
 class EsModule final: public Module {
-public:
+ public:
   explicit EsModule(Url specifier, Type type, Flags flags, kj::Array<const char> source)
       : Module(kj::mv(specifier), type, flags | Flags::ESM | Flags::EVAL),
         source(kj::mv(source)),
@@ -143,7 +143,7 @@ public:
     return module;
   }
 
-private:
+ private:
   v8::MaybeLocal<v8::Value> actuallyEvaluate(
       Lock& js, v8::Local<v8::Module> module, const CompilationObserver& observer) const override {
     return module->Evaluate(js.v8Context());
@@ -178,7 +178,7 @@ private:
 // module namespace (i.e. the exports) and the evaluation steps. This is used for things
 // like CommonJS modules, JSON modules, etc.
 class SyntheticModule final: public Module {
-public:
+ public:
   static constexpr auto DEFAULT = "default"_kjc;
 
   SyntheticModule(Url specifier,
@@ -205,7 +205,7 @@ public:
         evaluationSteps);
   }
 
-private:
+ private:
   static v8::MaybeLocal<v8::Value> evaluationSteps(
       v8::Local<v8::Context> context, v8::Local<v8::Module> module);
 
@@ -256,7 +256,7 @@ private:
 
 // Binds a ModuleRegistry to an Isolate.
 class IsolateModuleRegistry final {
-public:
+ public:
   static IsolateModuleRegistry& from(v8::Isolate* isolate) {
     auto context = isolate->GetCurrentContext();
     void* ptr = context->GetAlignedPointerFromEmbedderData(2);
@@ -446,7 +446,7 @@ public:
         .map([](Entry& entry) -> Entry& { return entry; });
   }
 
-private:
+ private:
   ModuleRegistry& inner;
   const CompilationObserver& observer;
 
@@ -790,7 +790,7 @@ v8::MaybeLocal<v8::Module> resolveCallback(v8::Local<v8::Context> context,
 // The fallback module bundle calls a single resolve callback to resolve all modules
 // it is asked to resolve. Instances must be thread-safe.
 class FallbackModuleBundle final: public ModuleBundle {
-public:
+ public:
   FallbackModuleBundle(Builder::ResolveCallback&& callback)
       : ModuleBundle(Type::FALLBACK),
         callback(kj::mv(callback)) {}
@@ -821,7 +821,7 @@ public:
     return kj::none;
   }
 
-private:
+ private:
   Builder::ResolveCallback callback;
 
   struct Cache final {
@@ -835,7 +835,7 @@ private:
 // The static module bundle maintains an internal table of specifiers to resolve callbacks
 // in memory. Instances must be thread-safe.
 class StaticModuleBundle final: public ModuleBundle {
-public:
+ public:
   StaticModuleBundle(Type type,
       kj::HashMap<Url, ModuleBundle::Builder::ResolveCallback> modules,
       kj::HashMap<Url, Url> aliases)
@@ -874,7 +874,7 @@ public:
     return kj::none;
   }
 
-private:
+ private:
   kj::HashMap<Url, ModuleBundle::Builder::ResolveCallback> modules;
   kj::HashMap<Url, Url> aliases;
   kj::MutexGuarded<kj::HashMap<Url, kj::Own<Module>>> cache;

--- a/src/workerd/jsg/modules-new.h
+++ b/src/workerd/jsg/modules-new.h
@@ -162,7 +162,7 @@ struct ResolveContext final {
 // The Module class itself represents the definition of a module and not
 // it's actual instantiation.
 class Module {
-public:
+ public:
   enum class Type : uint8_t {
     BUNDLE,
     BUILTIN,
@@ -251,7 +251,7 @@ public:
   // A helper interface that is used to make it easier for a synthetic module
   // evaluation callback to set the exports of the module.
   class ModuleNamespace final {
-  public:
+   public:
     explicit ModuleNamespace(
         v8::Local<v8::Module> inner, kj::ArrayPtr<const kj::String> namedExports);
     KJ_DISALLOW_COPY_AND_MOVE(ModuleNamespace);
@@ -263,7 +263,7 @@ public:
     // (should not include the "default")
     kj::ArrayPtr<const kj::StringPtr> getNamedExports() const;
 
-  private:
+   private:
     v8::Local<v8::Module> inner;
     kj::HashSet<kj::StringPtr> namedExports;
   };
@@ -314,13 +314,13 @@ public:
   // EvaluatingScope class makes it possible to guard against that, throwing an
   // error if there's already an active evaluation happening.
   class EvaluatingScope final {
-  public:
+   public:
     EvaluatingScope() = default;
     KJ_DISALLOW_COPY_AND_MOVE(EvaluatingScope);
     ~EvaluatingScope() noexcept(false);
     kj::Own<void> enterEvaluationScope(const Url& specifier) KJ_WARN_UNUSED_RESULT;
 
-  private:
+   private:
     struct Impl;
     KJ_DECLARE_NON_POLYMORPHIC(Impl);
     kj::Maybe<Impl&> maybeEvaluating;
@@ -371,10 +371,10 @@ public:
     };
   }
 
-protected:
+ protected:
   Module(Url specifier, Type type, Flags flags = Flags::NONE);
 
-private:
+ private:
   Url specifier_;
   Type type_;
   Flags flags_;
@@ -393,12 +393,12 @@ constexpr Module::Flags operator|(const Module::Flags& a, const Module::Flags& b
 // any internal caching it may use to optimize resolution. Accesses to the
 // bundle must be thread-safe.
 class ModuleBundle {
-public:
+ public:
   using Type = Module::Type;
 
   // A Builder is used to construct a ModuleBundle.
   class Builder {
-  public:
+   public:
     KJ_DISALLOW_COPY_AND_MOVE(Builder);
 
     using ResolveCallback = kj::Function<kj::Maybe<kj::Own<Module>>(const ResolveContext&)>;
@@ -413,7 +413,7 @@ public:
       return type_;
     }
 
-  protected:
+   protected:
     Builder(Type type);
 
     void ensureIsNotBundleSpecifier(const Url& specifier);
@@ -425,7 +425,7 @@ public:
 
   // Used to build a ModuleBundle representing modules sourced from a worker bundle.
   class BundleBuilder final: public Builder {
-  public:
+   public:
     static const Url BASE;
 
     BundleBuilder();
@@ -446,7 +446,7 @@ public:
 
   // Used to builde a ModuleBundle representing modules sources from the runtime.
   class BuiltinBuilder final: public Builder {
-  public:
+   public:
     enum class Type {
       BUILTIN,
       BUILTIN_ONLY,
@@ -502,10 +502,10 @@ public:
   virtual kj::Maybe<Module&> resolve(
       const ResolveContext& context) KJ_LIFETIMEBOUND KJ_WARN_UNUSED_RESULT = 0;
 
-protected:
+ protected:
   ModuleBundle(Type type);
 
-private:
+ private:
   Type type_;
 };
 
@@ -524,14 +524,14 @@ constexpr ModuleBundle::BuiltInBundleOptions operator&(
 // Importantly, the ModuleRegistry is immutable once created and
 // must be thread-safe.
 class ModuleRegistry final: public ModuleRegistryBase {
-private:
+ private:
   enum BundleIndices { kBundle, kBuiltin, kBuiltinOnly, kFallback, kBundleCount };
 
-public:
+ public:
   using EvalCallback = Module::EvalCallback;
 
   class Builder final {
-  public:
+   public:
     enum class Options {
       NONE = 0,
       // When set, allows the ModuleRegistry to use a fallback ModuleBundle to
@@ -555,7 +555,7 @@ public:
 
     Builder& setEvalCallback(EvalCallback callback) KJ_LIFETIMEBOUND;
 
-  private:
+   private:
     bool allowsFallback() const;
 
     // One slot for each of ModuleBundle::Type
@@ -604,7 +604,7 @@ public:
   ModuleRegistry(ModuleRegistry::Builder* builder);
   KJ_DISALLOW_COPY_AND_MOVE(ModuleRegistry);
 
-private:
+ private:
   const ResolveObserver& observer;
   kj::Maybe<ModuleRegistry&> maybeParent;
   // One slot for each of ModuleBundle::Type

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -18,7 +18,7 @@ namespace workerd::jsg {
 class CommonJsModuleContext;
 
 class CommonJsModuleObject: public jsg::Object {
-public:
+ public:
   CommonJsModuleObject(jsg::Lock& js): exports(js.v8Isolate, v8::Object::New(js.v8Isolate)) {}
 
   v8::Local<v8::Value> getExports(jsg::Lock& js) {
@@ -36,12 +36,12 @@ public:
     tracker.trackField("exports", exports);
   }
 
-private:
+ private:
   jsg::Value exports;
 };
 
 class CommonJsModuleContext: public jsg::Object {
-public:
+ public:
   CommonJsModuleContext(jsg::Lock& js, kj::Path path)
       : module(jsg::alloc<CommonJsModuleObject>(js)),
         path(kj::mv(path)),
@@ -73,7 +73,7 @@ public:
     tracker.trackFieldWithSize("path", path.size());
   }
 
-private:
+ private:
   kj::Path path;
   jsg::Value exports;
 };
@@ -91,7 +91,7 @@ private:
 // TODO(cleanup): There's a fair amount of duplicated code between the CommonJsModule
 // and NodeJsModule types... should be deduplicated.
 class NodeJsModuleObject: public jsg::Object {
-public:
+ public:
   NodeJsModuleObject(jsg::Lock& js, kj::String path);
 
   v8::Local<v8::Value> getExports(jsg::Lock& js);
@@ -119,7 +119,7 @@ public:
     tracker.trackField("path", path);
   }
 
-private:
+ private:
   jsg::Value exports;
   kj::String path;
 };
@@ -132,7 +132,7 @@ private:
 // (b) The common Node.js globals that we implement are exposed. For instance, `process`
 //     and `Buffer` will be found at the global scope.
 class NodeJsModuleContext: public jsg::Object {
-public:
+ public:
   NodeJsModuleContext(jsg::Lock& js, kj::Path path);
 
   v8::Local<v8::Value> require(jsg::Lock& js, kj::String specifier);
@@ -166,14 +166,14 @@ public:
     tracker.trackFieldWithSize("path", path.size());
   }
 
-private:
+ private:
   kj::Path path;
   jsg::Value exports;
 };
 
 // jsg::NonModuleScript wraps a v8::UnboundScript.
 class NonModuleScript {
-public:
+ public:
   NonModuleScript(jsg::Lock& js, v8::Local<v8::UnboundScript> script)
       : unboundScript(js.v8Isolate, script) {}
 
@@ -189,7 +189,7 @@ public:
   static jsg::NonModuleScript compile(
       kj::StringPtr code, jsg::Lock& js, kj::StringPtr name = "worker.js");
 
-private:
+ private:
   v8::Global<v8::UnboundScript> unboundScript;
 };
 
@@ -223,7 +223,7 @@ v8::Local<v8::WasmModuleObject> compileWasmModule(
 // The ModuleRegistry maintains the collection of modules known to a script that can be
 // required or imported.
 class ModuleRegistry {
-public:
+ public:
   KJ_DISALLOW_COPY_AND_MOVE(ModuleRegistry);
 
   ModuleRegistry() {}
@@ -435,7 +435,7 @@ kj::Maybe<kj::OneOf<kj::String, ModuleRegistry::ModuleInfo>> tryResolveFromFallb
 
 template <typename TypeWrapper>
 class ModuleRegistryImpl final: public ModuleRegistry {
-public:
+ public:
   KJ_DISALLOW_COPY_AND_MOVE(ModuleRegistryImpl);
 
   ModuleRegistryImpl(CompilationObserver& observer): observer(observer) {}
@@ -704,7 +704,7 @@ public:
     return observer;
   }
 
-private:
+ private:
   CompilationObserver& observer;
   kj::Maybe<kj::Function<DynamicImportCallback>> dynamicImportHandler;
 

--- a/src/workerd/jsg/observer.h
+++ b/src/workerd/jsg/observer.h
@@ -50,7 +50,7 @@ struct ResolveObserver {
 
   // Used to report the status of a module resolution.
   class ResolveStatus {
-  public:
+   public:
     ResolveStatus() = default;
     KJ_DISALLOW_COPY_AND_MOVE(ResolveStatus);
     virtual ~ResolveStatus() noexcept(false) {}

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -220,7 +220,7 @@ class PromiseWrapper;
 
 template <typename T>
 class Promise {
-public:
+ public:
   static_assert(!kj::canConvert<T*, v8::Data*>(),
       "jsg::Promise<T> expects T to be an instantiable C++ type, not a JS heap type; use "
       "jsg::Promise<jsg::V8Ref<T>> to represent a promise for a JavaScript heap object.");
@@ -317,7 +317,7 @@ public:
   }
 
   class Resolver {
-  public:
+   public:
     Resolver(v8::Isolate* isolate, v8::Local<v8::Promise::Resolver> v8Resolver)
         : v8Resolver(isolate, kj::mv(v8Resolver)) {}
 
@@ -366,7 +366,7 @@ public:
       tracker.trackField("resolver", v8Resolver);
     }
 
-  private:
+   private:
     V8Ref<v8::Promise::Resolver> v8Resolver;
     friend class MemoryTracker;
   };
@@ -381,7 +381,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::Maybe<V8Ref<v8::Promise>> v8Promise;
   bool markedAsHandled = false;
 
@@ -565,7 +565,7 @@ void thenUnwrap(const v8::FunctionCallbackInfo<v8::Value>& args) {
 // TypeWrapper mixin for Promise.
 template <typename TypeWrapper>
 class PromiseWrapper {
-public:
+ public:
   // The constructor here is a bit of a hack. The config is optional and might not be a JsgConfig
   // object (or convertible to a JsgConfig) if is provided. However, because of the way TypeWrapper
   // inherits PromiseWrapper, we always end up passing a config option (which might be
@@ -667,7 +667,7 @@ public:
     }
   }
 
-private:
+ private:
   const JsgConfig config;
 
   static bool isThenable(v8::Local<v8::Context> context, v8::Local<v8::Value> handle) {
@@ -686,7 +686,7 @@ private:
 // weak references to rejected promises that have not been handled and will handle
 // emitting events and console warnings as appropriate.
 class UnhandledRejectionHandler {
-public:
+ public:
   using Handler = void(jsg::Lock& js,
       v8::PromiseRejectEvent event,
       jsg::V8Ref<v8::Promise> promise,
@@ -707,7 +707,7 @@ public:
     tracker.trackField("warnedRejections", warnedRejections);
   }
 
-private:
+ private:
   // Used as part of the book keeping for unhandled rejections. When an
   // unhandled rejection occurs, the unhandledRejections Table will be updated.
   // If the rejection is later handled asynchronously, then the item will be

--- a/src/workerd/jsg/resource-test.c++
+++ b/src/workerd/jsg/resource-test.c++
@@ -149,7 +149,7 @@ struct PropContext: public ContextGlobalObject {
     JSG_NESTED_TYPE(PrototypePropertyObject);
   }
 
-private:
+ private:
   kj::String contextProperty;
 };
 JSG_DECLARE_ISOLATE_TYPE(PropIsolate, PropContext, PrototypePropertyObject);
@@ -237,13 +237,13 @@ KJ_TEST("non-constructible types can't be constructed") {
 
 struct IterableContext: public ContextGlobalObject {
   class Iterable: public Object {
-  public:
+   public:
     static Ref<Iterable> constructor() {
       return jsg::alloc<Iterable>();
     }
 
     class Iterator: public Object {
-    public:
+     public:
       struct NextValue {
         bool done;
         Optional<int> value;
@@ -273,7 +273,7 @@ struct IterableContext: public ContextGlobalObject {
         JSG_ITERABLE(self);
       }
 
-    private:
+     private:
       Ref<Iterable> parent;
       int* cursor;
     };
@@ -287,7 +287,7 @@ struct IterableContext: public ContextGlobalObject {
       JSG_ITERABLE(entries);
     }
 
-  private:
+   private:
     int values[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     // In real code, this data structure could be more complex, and we would need to think about
     // iterator invalidation, which might require storing back-references from the parent iterable

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -813,7 +813,7 @@ v8::Local<v8::Symbol> getSymbolAsyncDispose(v8::Isolate* isolate);
 
 // A configuration type that can be derived from any input type, because it contains nothing.
 class NullConfiguration {
-public:
+ public:
   template <typename T>
   NullConfiguration(T&&) {}
 };
@@ -822,7 +822,7 @@ public:
 // subclasses will then be able to register themselves in the map.
 template <typename TypeWrapper>
 class DynamicResourceTypeMap {
-private:
+ private:
   typedef void ReflectionInitializer(jsg::Object& object, TypeWrapper& wrapper);
   struct DynamicTypeInfo {
     v8::Local<v8::FunctionTemplate> tmpl;
@@ -1211,7 +1211,7 @@ struct ResourceTypeBuilder {
 
   inline void registerJsBundle(Bundle::Reader bundle) { /* handled at the second stage */ }
 
-private:
+ private:
   TypeWrapper& typeWrapper;
   v8::Isolate* isolate;
   v8::Local<v8::FunctionTemplate> constructor;
@@ -1320,13 +1320,13 @@ struct JsSetup {
   template <const char* tsDefine>
   inline void registerTypeScriptDefine() {}
 
-private:
+ private:
   jsg::Lock& js;
   v8::Local<v8::Context> context;
 };
 
 class ModuleRegistryBase {
-public:
+ public:
   virtual ~ModuleRegistryBase() noexcept(false) {}
   virtual kj::Own<void> attachToIsolate(
       Lock& js, const CompilationObserver& observer) KJ_WARN_UNUSED_RESULT = 0;
@@ -1340,7 +1340,7 @@ struct NewContextOptions {
 // JSG_RESOURCE_TYPE block).
 template <typename TypeWrapper, typename T>
 class ResourceWrapper {
-public:
+ public:
   // If the JSG_RESOURCE_TYPE macro declared a configuration parameter, then `Configuration` will
   // be that type, otherwise NullConfiguration which accepts any configuration.
   using Configuration = DetectedOr<NullConfiguration, GetConfiguration, T>;
@@ -1563,7 +1563,7 @@ public:
     }
   }
 
-private:
+ private:
   Configuration configuration;
   v8::Global<v8::FunctionTemplate> memoizedConstructor;
   v8::Global<v8::FunctionTemplate> contextConstructor;
@@ -1646,7 +1646,7 @@ private:
 // Like ResourceWrapper for T = jsg::Object. We need some special-casing for this type.
 template <typename TypeWrapper>
 class ObjectWrapper {
-public:
+ public:
   static constexpr const std::type_info& getName(Object*) {
     return typeid(Object);
   }

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -34,7 +34,7 @@ struct BuildRtti;
 // interpret all types passed through a given builder.
 template <typename MetaConfiguration>
 class Builder {
-public:
+ public:
   const MetaConfiguration config;
 
   Builder(const MetaConfiguration& config): config(config) {}
@@ -66,7 +66,7 @@ public:
     });
   }
 
-private:
+ private:
   capnp::MallocMessageBuilder builder;
   kj::HashMap<kj::String, kj::Own<capnp::MallocMessageBuilder>> symbols;
 };
@@ -112,7 +112,7 @@ struct TupleRttiBuilder {
     build(std::make_integer_sequence<size_t, std::tuple_size_v<Tuple>>{}, builder, rtti);
   }
 
-private:
+ private:
   template <size_t... Indexes>
   static inline void build(std::integer_sequence<size_t, Indexes...> seq,
       capnp::List<Type>::Builder builder,

--- a/src/workerd/jsg/ser.h
+++ b/src/workerd/jsg/ser.h
@@ -56,7 +56,7 @@ namespace workerd::jsg {
 //   corresponding type handler. This is useful if the serializer wants to, say, assemble a
 //   JSG_STRUCT, convert it into an actual JS object, and serialize that.
 class Serializer final: v8::ValueSerializer::Delegate {
-public:
+ public:
   // "Externals" are values which can be serialized, but refer to some external resource, rather
   // than being self-contained. The way externals are supported depends on the serialization
   // context: passing externals over RPC, for example, is completely different from storing them
@@ -69,7 +69,7 @@ public:
   // doesn't implement any supported subclass, then serialization is not possible, and an
   // appropriate exception should be thrown.
   class ExternalHandler {
-  public:
+   public:
     // Tries to serialize a function as an external. The default implementation throws
     // DataCloneError.
     virtual void serializeFunction(
@@ -164,7 +164,7 @@ public:
     writeLengthDelimited(text.asBytes());
   }
 
-private:
+ private:
   // Throw a DataCloneError, complaining that the given object cannot be serialized. (This is
   // similar to ThrowDataCloneError() except that it formats the error message itself, and it
   // is expected to be called from KJ-ish code so it throws JsExceptionThrown rather than
@@ -204,10 +204,10 @@ private:
 // Must be allocated on the stack, and requires that a v8::HandleScope exist in
 // the stack.
 class Deserializer final: v8::ValueDeserializer::Delegate {
-public:
+ public:
   // Exactly like Serializer::ExternalHandler, but for Deserializer.
   class ExternalHandler {
-  public:
+   public:
     virtual ~ExternalHandler() noexcept(false) = 0;
   };
 
@@ -258,7 +258,7 @@ public:
     return deser.GetWireFormatVersion();
   }
 
-private:
+ private:
   void init(Lock& js,
       kj::Maybe<kj::ArrayPtr<std::shared_ptr<v8::BackingStore>>> transferredArrayBuffers = kj::none,
       kj::Maybe<Options> maybeOptions = kj::none);
@@ -276,7 +276,7 @@ private:
 
 // Intended for use with v8::ValueSerializer data released into a kj::Array.
 class SerializedBufferDisposer: public kj::ArrayDisposer {
-protected:
+ protected:
   void disposeImpl(void* firstElement,
       size_t elementSize,
       size_t elementCount,

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -46,7 +46,7 @@ static void v8DcheckError(const char* file, int line, const char* message) {
 }
 
 class PlatformDisposer final: public kj::Disposer {
-public:
+ public:
   virtual void disposeImpl(void* pointer) const override {
     delete static_cast<v8::Platform*>(pointer);
   }

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -36,7 +36,7 @@ kj::Own<v8::Platform> defaultPlatform(uint backgroundThreadCount);
 // construct one of these per process. This performs process-wide initialization of the V8
 // library.
 class V8System {
-public:
+ public:
   // Use the default v8::Platform implementation, as if by:
   //   auto v8Platform = jsg::defaultPlatform();
   //   auto v8System = V8System(*v8Platform);
@@ -58,7 +58,7 @@ public:
   typedef void FatalErrorCallback(kj::StringPtr location, kj::StringPtr message);
   static void setFatalErrorCallback(FatalErrorCallback* callback);
 
-private:
+ private:
   kj::Own<v8::Platform> platformInner;
   V8PlatformWrapper platformWrapper;
   friend class IsolateBase;
@@ -69,7 +69,7 @@ private:
 // Base class of Isolate<T> containing parts that don't need to be templated, to avoid code
 // bloat.
 class IsolateBase {
-public:
+ public:
   static IsolateBase& from(v8::Isolate* isolate);
 
   // Unwraps a JavaScript exception as a kj::Exception.
@@ -198,7 +198,7 @@ public:
     return JsSymbol(symbolAsyncDispose.Get(ptr));
   }
 
-private:
+ private:
   template <typename TypeWrapper>
   friend class Isolate;
 
@@ -206,7 +206,7 @@ private:
 
   // The internals of a jsg::Ref<T> to be deleted.
   class RefToDelete {
-  public:
+   public:
     RefToDelete(bool strong, kj::Own<void> ownWrappable, Wrappable* wrappable)
         : strong(strong),
           ownWrappable(kj::mv(ownWrappable)),
@@ -221,7 +221,7 @@ private:
     // Default move ctor okay because ownWrappable.get() will be null if moved-from.
     KJ_DISALLOW_COPY(RefToDelete);
 
-  private:
+   private:
     bool strong;
     // Keeps the `wrappable` pointer below valid.
     kj::Own<void> ownWrappable;
@@ -391,7 +391,7 @@ kj::Maybe<kj::StringPtr> getJsStackTrace(void* ucontext, kj::ArrayPtr<char> scra
 //
 template <typename TypeWrapper>
 class Isolate: public IsolateBase {
-public:
+ public:
   // Construct an isolate that requires configuration. `configuration` is a value that all
   // individual wrappers' configurations must be able to be constructed from. For example, if all
   // wrappers use the same configuration type, then `MetaConfiguration` should just be that type.
@@ -451,7 +451,7 @@ public:
   // constructing a `Lock` on the stack.
   class Lock final: public jsg::Lock {
 
-  public:
+   public:
     // `V8StackScope` must be provided to prove that one has been created on the stack before
     // taking a lock. Any GC'd pointers stored on the stack must be kept within this scope in
     // order for V8's stack-scanning GC to find them.
@@ -609,7 +609,7 @@ public:
       }
     }
 
-  private:
+   private:
     Isolate& jsgIsolate;
 
     virtual kj::Maybe<Object&> getInstance(
@@ -634,7 +634,7 @@ public:
     });
   }
 
-private:
+ private:
   kj::SpaceFor<TypeWrapper> wrapperSpace;
   kj::Own<TypeWrapper> wrapper;  // Needs to be destroyed under lock...
 };
@@ -651,11 +651,11 @@ private:
   typedef ::workerd::jsg::TypeWrapper<Type##_TypeWrapper, jsg::DOMException, ##__VA_ARGS__>        \
       Type##_TypeWrapperBase;                                                                      \
   class Type##_TypeWrapper final: public Type##_TypeWrapperBase {                                  \
-  public:                                                                                          \
+   public:                                                                                         \
     using Type##_TypeWrapperBase::TypeWrapper;                                                     \
   };                                                                                               \
   class Type final: public ::workerd::jsg::Isolate<Type##_TypeWrapper> {                           \
-  public:                                                                                          \
+   public:                                                                                         \
     using ::workerd::jsg::Isolate<Type##_TypeWrapper>::Isolate;                                    \
   }
 

--- a/src/workerd/jsg/struct.h
+++ b/src/workerd/jsg/struct.h
@@ -23,7 +23,7 @@ template <typename TypeWrapper,
 class FieldWrapper {
   static constexpr inline const char* exportedName = name + namePrefixStripLength;
 
-public:
+ public:
   using Type = T;
 
   explicit FieldWrapper(v8::Isolate* isolate)
@@ -58,7 +58,7 @@ public:
         context, jsValue, TypeErrorContext::structField(typeid(Struct), exportedName), in);
   }
 
-private:
+ private:
   v8::Global<v8::Name> nameHandle;
 };
 
@@ -77,7 +77,7 @@ class StructWrapper;
 // JSG_STRUCT block).
 template <typename Self, typename T, typename... FieldWrappers, size_t... indices>
 class StructWrapper<Self, T, TypeTuple<FieldWrappers...>, kj::_::Indexes<indices...>> {
-public:
+ public:
   static const JsgKind JSG_KIND = JsgKind::STRUCT;
 
   static constexpr const std::type_info& getName(T*) {
@@ -153,7 +153,7 @@ public:
   void newContext() = delete;
   void getTemplate() = delete;
 
-private:
+ private:
   kj::Maybe<kj::Tuple<FieldWrappers...>> lazyFields;
 
   kj::Tuple<FieldWrappers...>& getFields(v8::Isolate* isolate) {

--- a/src/workerd/jsg/tracing-test.c++
+++ b/src/workerd/jsg/tracing-test.c++
@@ -15,7 +15,7 @@ class NumberBoxHolder: public Object {
   // This differs from BoxBox (in jsg-test.h) in that this just holds the exact object you give
   // it, whereas BoxBox likes to create new objects.
 
-public:
+ public:
   explicit NumberBoxHolder(Ref<NumberBox> inner): inner(kj::mv(inner)) {}
 
   Ref<NumberBox> inner;
@@ -32,7 +32,7 @@ public:
     JSG_READONLY_PROTOTYPE_PROPERTY(inner, getInner);
   }
 
-private:
+ private:
   void visitForGc(GcVisitor& visitor) {
     visitor.visit(inner);
   }
@@ -42,7 +42,7 @@ class GcDetector: public jsg::Object {
   // Object which comes in pairs where one member of the pair can detect if the other has been
   // collected.
 
-public:
+ public:
   ~GcDetector() noexcept(false) {
     KJ_IF_SOME(s, sibling) s.sibling = kj::none;
   }
@@ -68,7 +68,7 @@ public:
 class GcDetectorBox: public jsg::Object {
   // Contains a GcDetector. Useful for testing tracing scenarios.
 
-public:
+ public:
   jsg::Ref<GcDetector> inner = jsg::alloc<GcDetector>();
 
   jsg::Ref<GcDetector> getInner() {
@@ -79,7 +79,7 @@ public:
     JSG_READONLY_PROTOTYPE_PROPERTY(inner, getInner);
   }
 
-private:
+ private:
   void visitForGc(GcVisitor& visitor) {
     visitor.visit(inner);
   }
@@ -88,7 +88,7 @@ private:
 class ValueBox: public jsg::Object {
   // Contains an arbitrary value.
 
-public:
+ public:
   ValueBox(jsg::Value inner): inner(kj::mv(inner)) {}
 
   static jsg::Ref<ValueBox> constructor(jsg::Value inner) {
@@ -105,7 +105,7 @@ public:
     JSG_READONLY_PROTOTYPE_PROPERTY(inner, getInner);
   }
 
-private:
+ private:
   void visitForGc(GcVisitor& visitor) {
     visitor.visit(inner);
   }

--- a/src/workerd/jsg/type-wrapper-test.c++
+++ b/src/workerd/jsg/type-wrapper-test.c++
@@ -34,7 +34,7 @@ template <typename Self>
 class TestExtension {
   // Test manually extending the TypeWrapper with wrap/unwrap functions for a custom type.
 
-public:
+ public:
   static constexpr const char* getName(TestExtensionType*) {
     return "TestExtensionTypeName";
   }
@@ -204,14 +204,14 @@ KJ_TEST("v8::Value subclass unwrapping") {
 
 struct UnimplementedContext: public ContextGlobalObject {
   class UnimplementedConstructor: public Object {
-  public:
+   public:
     static Unimplemented constructor() {
       return Unimplemented();
     }
     JSG_RESOURCE_TYPE(UnimplementedConstructor) {}
   };
   class UnimplementedConstructorParam: public Object {
-  public:
+   public:
     UnimplementedConstructorParam(int i): i(i) {}
     static Ref<UnimplementedConstructorParam> constructor(int i, Unimplemented) {
       return jsg::alloc<UnimplementedConstructorParam>(i);
@@ -247,7 +247,7 @@ struct UnimplementedContext: public ContextGlobalObject {
   }
 
   class UnimplementedProperties: public Object {
-  public:
+   public:
     static Ref<UnimplementedProperties> constructor() {
       return jsg::alloc<UnimplementedProperties>();
     }

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -35,7 +35,7 @@ constexpr bool isValueLessParameter<TypeWrapper,
 //
 // This is just a trivial pass-through.
 class V8HandleWrapper {
-public:
+ public:
   template <typename T, typename = kj::EnableIf<kj::canConvert<T, v8::Value>()>>
   static constexpr const std::type_info& getName(v8::Local<T>*) {
     return typeid(T);
@@ -143,7 +143,7 @@ public:
 };
 
 class UnimplementedWrapper {
-public:
+ public:
   static constexpr const std::type_info& getName(Unimplemented*) {
     return typeid(Unimplemented);
   }
@@ -204,7 +204,7 @@ public:
 // works the same way as the second parameter to `JSG_RESOURCE_TYPE`.
 template <template <typename TypeWrapper> typename Extension>
 class TypeWrapperExtension {
-public:
+ public:
   static const JsgKind JSG_KIND = JsgKind::EXTENSION;
 };
 
@@ -217,7 +217,7 @@ public:
 // `Configuration` can be a reference type.
 template <typename Configuration>
 class InjectConfiguration {
-public:
+ public:
   static const JsgKind JSG_KIND = JsgKind::EXTENSION;
 };
 
@@ -229,7 +229,7 @@ class TypeWrapperBase;
 // Specialization of TypeWrapperBase for types that have a JSG_RESOURCE_TYPE block.
 template <typename Self, typename T>
 class TypeWrapperBase<Self, T, JsgKind::RESOURCE>: public ResourceWrapper<Self, T> {
-public:
+ public:
   template <typename MetaConfiguration>
   TypeWrapperBase(MetaConfiguration& config): ResourceWrapper<Self, T>(config) {}
 
@@ -240,7 +240,7 @@ public:
 template <typename Self, typename T>
 class TypeWrapperBase<Self, T, JsgKind::STRUCT>
     : public StructWrapper<Self, T, typename T::template JsgFieldWrappers<Self, T>> {
-public:
+ public:
   template <typename MetaConfiguration>
   TypeWrapperBase(MetaConfiguration& config) {}
 
@@ -262,7 +262,7 @@ class TypeWrapperBase<Self, TypeWrapperExtension<Extension>, JsgKind::EXTENSION>
     return false;  // extension constructor does not take arguments
   }
 
-public:
+ public:
   template <typename MetaConfiguration,
       typename = kj::EnableIf<!sfinae<MetaConfiguration>((Extension<Self>*)nullptr)>>
   TypeWrapperBase(MetaConfiguration& config) {}
@@ -279,7 +279,7 @@ public:
 // Specialization of TypeWrapperBase for InjectConfiguration.
 template <typename Self, typename Configuration>
 class TypeWrapperBase<Self, InjectConfiguration<Configuration>, JsgKind::EXTENSION> {
-public:
+ public:
   template <typename MetaConfiguration>
   TypeWrapperBase(MetaConfiguration& config): configuration(kj::fwd<MetaConfiguration>(config)) {}
 
@@ -298,7 +298,7 @@ public:
 
   inline void initTypeWrapper() {}
 
-private:
+ private:
   Configuration configuration;
 };
 
@@ -397,7 +397,7 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
                    public JsValueWrapper<Self> {
   // TODO(soon): Should the TypeWrapper object be stored on the isolate rather than the context?
 
-public:
+ public:
   template <typename MetaConfiguration>
   TypeWrapper(v8::Isolate* isolate, MetaConfiguration&& configuration)
       : TypeWrapperBase<Self, T>(configuration)...,
@@ -562,7 +562,7 @@ public:
 template <typename Self, typename... Types>
 template <typename T>
 class TypeWrapper<Self, Types...>::TypeHandlerImpl final: public TypeHandler<T> {
-public:
+ public:
   v8::Local<v8::Value> wrap(Lock& js, T value) const override {
     auto isolate = js.v8Isolate;
     auto context = js.v8Context();

--- a/src/workerd/jsg/url.c++
+++ b/src/workerd/jsg/url.c++
@@ -26,10 +26,10 @@ namespace workerd::jsg {
 
 namespace {
 class AdaOwnedStringDisposer: public kj::ArrayDisposer {
-public:
+ public:
   static const AdaOwnedStringDisposer INSTANCE;
 
-protected:
+ protected:
   void disposeImpl(void* firstElement,
       size_t elementSize,
       size_t elementCount,

--- a/src/workerd/jsg/url.h
+++ b/src/workerd/jsg/url.h
@@ -9,7 +9,7 @@ namespace workerd::jsg {
 
 // A WHATWG-compliant URL implementation provided by ada-url.
 class Url final {
-public:
+ public:
   // Keep in sync with ada::scheme:type
   enum class SchemeType {
     HTTP = 0,
@@ -119,7 +119,7 @@ public:
 
   static kj::Array<kj::byte> percentDecode(kj::ArrayPtr<const kj::byte> input);
 
-private:
+ private:
   Url(kj::Own<void> inner);
   kj::Own<void> inner;
 };
@@ -132,29 +132,29 @@ constexpr Url::EquivalenceOption operator&(Url::EquivalenceOption a, Url::Equiva
 }
 
 class UrlSearchParams final {
-public:
+ public:
   class KeyIterator final {
-  public:
+   public:
     bool hasNext() const;
     kj::Maybe<kj::ArrayPtr<const char>> next() const;
 
-  private:
+   private:
     KeyIterator(kj::Own<void> inner);
     kj::Own<void> inner;
     friend class UrlSearchParams;
   };
   class ValueIterator final {
-  public:
+   public:
     bool hasNext() const;
     kj::Maybe<kj::ArrayPtr<const char>> next() const;
 
-  private:
+   private:
     ValueIterator(kj::Own<void> inner);
     kj::Own<void> inner;
     friend class UrlSearchParams;
   };
   class EntryIterator final {
-  public:
+   public:
     struct Entry {
       kj::ArrayPtr<const char> key;
       kj::ArrayPtr<const char> value;
@@ -162,7 +162,7 @@ public:
     bool hasNext() const;
     kj::Maybe<Entry> next() const;
 
-  private:
+   private:
     EntryIterator(kj::Own<void> inner);
     kj::Own<void> inner;
     friend class UrlSearchParams;
@@ -199,7 +199,7 @@ public:
     tracker.trackField("inner", toStr());
   }
 
-private:
+ private:
   UrlSearchParams(kj::Own<void> inner);
   kj::Own<void> inner;
 };
@@ -217,7 +217,7 @@ inline kj::String KJ_STRINGIFY(const UrlSearchParams& searchParams) {
 // Encapsulates a parsed URLPattern.
 // @see https://wicg.github.io/urlpattern
 class UrlPattern final {
-public:
+ public:
   // If the value is T, the operation is successful.
   // If the value is kj::String, that's an Error message.
   template <typename T>
@@ -225,7 +225,7 @@ public:
 
   // An individual, compiled component of a URLPattern.
   class Component final {
-  public:
+   public:
     Component(kj::String pattern, kj::String regex, kj::Array<kj::String> names);
 
     Component(Component&&) = default;
@@ -250,7 +250,7 @@ public:
       }
     }
 
-  private:
+   private:
     // The normalized pattern for this component.
     kj::String pattern = nullptr;
 
@@ -353,7 +353,7 @@ public:
     tracker.trackField("hash", hash);
   }
 
-private:
+ private:
   UrlPattern(kj::Array<Component> components, bool ignoreCase);
 
   Component protocol;

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -621,7 +621,7 @@ class ExternString: public Type {
   // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
   // IN THE SOFTWARE.
 
-public:
+ public:
   inline const Data* data() const override {
     return buf.begin();
   }
@@ -665,7 +665,7 @@ public:
     return str;
   }
 
-private:
+ private:
   v8::Isolate* isolate;
   kj::ArrayPtr<const Data> buf;
 

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -32,12 +32,12 @@ typedef unsigned int uint;
 // case an exception is thrown. Writing code that deals with maybes is cumbersome and error-prone
 // compared to C++ exceptions.
 class JsExceptionThrown: public std::exception {
-public:
+ public:
   JsExceptionThrown();
   ~JsExceptionThrown() noexcept = default;  // We must match `std::exception`'s noexcept.
   const char* what() const noexcept override;
 
-private:
+ private:
   void* trace[16];
   kj::ArrayPtr<void* const> tracePtr;
   mutable kj::String whatBuffer;

--- a/src/workerd/jsg/v8-platform-wrapper.h
+++ b/src/workerd/jsg/v8-platform-wrapper.h
@@ -11,7 +11,7 @@
 namespace workerd::jsg {
 
 class V8PlatformWrapper: public v8::Platform {
-public:
+ public:
   explicit V8PlatformWrapper(v8::Platform& inner): inner(inner) {}
 
   v8::PageAllocator* GetPageAllocator() override {
@@ -71,11 +71,11 @@ public:
     return inner.GetTracingController();
   }
 
-private:
+ private:
   v8::Platform& inner;
 
   class JobTaskWrapper: public v8::JobTask {
-  public:
+   public:
     JobTaskWrapper(std::unique_ptr<v8::JobTask> inner);
 
     void Run(v8::JobDelegate*) override;
@@ -84,7 +84,7 @@ private:
       return inner->GetMaxConcurrency(worker_count);
     }
 
-  private:
+   private:
     std::unique_ptr<v8::JobTask> inner;
   };
 };

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -31,7 +31,7 @@ namespace workerd::jsg {
 // Note that we can't generally change the wrap(context, ...) functions to wrap(isolate, ...)
 // because ResourceWrapper<TW, T>::wrap() needs the context to create new object instances.
 class PrimitiveWrapper {
-public:
+ public:
   static constexpr const char* getName(double*) {
     return "number";
   }
@@ -361,7 +361,7 @@ public:
 // Name
 template <typename TypeWrapper>
 class NameWrapper {
-public:
+ public:
   static constexpr const char* getName(Name*) {
     return "string or Symbol";
   }
@@ -408,7 +408,7 @@ public:
 // This wrapper has an extra wrap() overload that takes an isolate instead of a context, for the
 // same reason discussed in PrimitiveWrapper.
 class StringWrapper {
-public:
+ public:
   static constexpr const char* getName(kj::String*) {
     return "string";
   }
@@ -506,7 +506,7 @@ constexpr bool isUnionType(T*) {
 // TypeWrapper mixin for optionals.
 template <typename TypeWrapper>
 class OptionalWrapper {
-public:
+ public:
   template <typename U>
   static constexpr decltype(auto) getName(Optional<U>*) {
     return TypeWrapper::getName((kj::Decay<U>*)nullptr);
@@ -540,7 +540,7 @@ public:
 // TypeWrapper mixin for lenient optionals.
 template <typename TypeWrapper>
 class LenientOptionalWrapper {
-public:
+ public:
   template <typename U>
   static constexpr decltype(auto) getName(LenientOptional<U>*) {
     return TypeWrapper::getName((kj::Decay<U>*)nullptr);
@@ -580,7 +580,7 @@ public:
 template <typename TypeWrapper>
 class MaybeWrapper {
 
-public:
+ public:
   // The constructor here is a bit of a hack. The config is optional and might not be a JsgConfig
   // object (or convertible to a JsgConfig) if is provided. However, because of the way TypeWrapper
   // inherits MaybeWrapper, we always end up passing a config option (which might be std::nullptr_t)
@@ -622,7 +622,7 @@ public:
     }
   }
 
-private:
+ private:
   const JsgConfig config;
 };
 
@@ -638,7 +638,7 @@ constexpr bool isOneOf<kj::OneOf<T...>> = true;
 // TypeWrapper mixin for variants.
 template <typename TypeWrapper>
 class OneOfWrapper {
-public:
+ public:
   template <typename... U>
   static kj::String getName(kj::OneOf<U...>*) {
     const auto getNameStr = [](auto u) {
@@ -783,7 +783,7 @@ public:
 // TypeWrapper mixin for arrays.
 template <typename TypeWrapper>
 class ArrayWrapper {
-public:
+ public:
   static auto constexpr MAX_STACK = 64;
   template <typename U>
   static constexpr const char* getName(kj::Array<U>*) {
@@ -899,7 +899,7 @@ public:
 // 3. If a method returns an ArrayBuffer, create and return a `kj::Array<kj::byte>`.
 template <typename TypeWrapper>
 class ArrayBufferWrapper {
-public:
+ public:
   static constexpr const char* getName(kj::ArrayPtr<byte>*) {
     return "ArrayBuffer or ArrayBufferView";
   }
@@ -972,7 +972,7 @@ public:
 // TypeWrapper mixin for dictionaries (objects used as string -> value maps).
 template <typename TypeWrapper>
 class DictWrapper {
-public:
+ public:
   template <typename K, typename V>
   static constexpr const char* getName(Dict<V, K>*) {
     return "object";
@@ -1062,7 +1062,7 @@ public:
 
 template <typename TypeWrapper>
 class DateWrapper {
-public:
+ public:
   static constexpr const char* getName(kj::Date*) {
     return "date";
   }
@@ -1087,7 +1087,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::Date toKjDate(double millis) {
     JSG_REQUIRE(isFinite(millis), TypeError,
         "The value cannot be converted because it is not a valid Date.");
@@ -1114,7 +1114,7 @@ private:
 
 template <typename TypeWrapper>
 class NonCoercibleWrapper {
-public:
+ public:
   template <CoercibleType T>
   static auto getName(NonCoercible<T>*) {
     return TypeWrapper::getName((T*)nullptr);
@@ -1178,7 +1178,7 @@ void MemoizedIdentity<T>::visitForGc(GcVisitor& visitor) {
 
 template <typename TypeWrapper>
 class MemoizedIdentityWrapper {
-public:
+ public:
   template <typename T>
   static auto getName(MemoizedIdentity<T>*) {
     return TypeWrapper::getName((T*)nullptr);
@@ -1214,7 +1214,7 @@ public:
 
 template <typename TypeWrapper>
 class IdentifiedWrapper {
-public:
+ public:
   template <typename T>
   static auto getName(Identified<T>*) {
     return TypeWrapper::getName((T*)nullptr);
@@ -1249,7 +1249,7 @@ public:
 
 template <typename TypeWrapper>
 class SelfRefWrapper {
-public:
+ public:
   static auto getName(SelfRef*) {
     return "SelfRef";
   }
@@ -1282,7 +1282,7 @@ class DOMException;
 
 template <typename TypeWrapper>
 class ExceptionWrapper {
-public:
+ public:
   static constexpr const char* getName(kj::Exception*) {
     return "Exception";
   }

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -73,7 +73,7 @@ void HeapTracer::clearWrappers() {
 // major GC occurs, the freelist is cleared, since any unreachable CppgcShim objects are likely
 // condemned after that point and will be deleted shortly thereafter.
 class Wrappable::CppgcShim final: public cppgc::GarbageCollected<CppgcShim> {
-public:
+ public:
   CppgcShim(Wrappable& wrappable): state(Active{kj::addRef(wrappable)}) {
     KJ_DASSERT(wrappable.cppgcShim == kj::none);
     wrappable.cppgcShim = *this;

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -52,7 +52,7 @@ class HeapTracer;
 // For resource types, this wrapper refcount counts the number of Ref<T>s that point to the
 // Wrappable and are not visible to GC tracing.
 class Wrappable: public kj::Refcounted {
-public:
+ public:
   enum InternalFields : int {
     // Field must contain a pointer to `WORKERD_WRAPPABLE_TAG`. This is a workerd-specific
     // tag that helps us to identify a v8 API object as one of our own.
@@ -151,7 +151,7 @@ public:
   // Called by HeapTracer when V8 tells us that it found a reference to this object.
   void traceFromV8(cppgc::Visitor& cppgcVisitor);
 
-private:
+ private:
   class CppgcShim;
 
   // If a JS wrapper is currently allocated, this point to the cppgc shim object.
@@ -193,7 +193,7 @@ private:
 
 // For historical reasons, this is actually implemented in setup.c++.
 class HeapTracer: public v8::EmbedderRootsHandler {
-public:
+ public:
   explicit HeapTracer(v8::Isolate* isolate);
 
   ~HeapTracer() noexcept {
@@ -242,7 +242,7 @@ public:
     return false;
   }
 
-private:
+ private:
   v8::Isolate* isolate;
   kj::Vector<Wrappable*> wrappersToTrace;
 

--- a/src/workerd/server/actor-id-impl.h
+++ b/src/workerd/server/actor-id-impl.h
@@ -6,10 +6,10 @@
 
 namespace workerd::server {
 class ActorIdFactoryImpl final: public ActorIdFactory {
-public:
+ public:
   ActorIdFactoryImpl(kj::StringPtr uniqueKey);
   class ActorIdImpl final: public ActorId {
-  public:
+   public:
     ActorIdImpl(const kj::byte idParam[SHA256_DIGEST_LENGTH], kj::Maybe<kj::String> name);
 
     kj::String toString() const override;
@@ -17,7 +17,7 @@ public:
     bool equals(const ActorId& other) const override;
     kj::Own<ActorId> clone() const override;
 
-  private:
+   private:
     kj::byte id[SHA256_DIGEST_LENGTH];
     kj::Maybe<kj::String> name;
   };
@@ -28,7 +28,7 @@ public:
   kj::Own<ActorIdFactory> cloneWithJurisdiction(kj::StringPtr jurisdiction) override;
   bool matchesJurisdiction(const ActorId& id) override;
 
-private:
+ private:
   kj::byte key[SHA256_DIGEST_LENGTH];
 
   uint64_t counter = 0;  // only used in predictable mode

--- a/src/workerd/server/alarm-scheduler.h
+++ b/src/workerd/server/alarm-scheduler.h
@@ -44,7 +44,7 @@ inline uint KJ_HASHCODE(const ActorKey& k) {
 // Allows scheduling alarm executions at specific times, returning a promise representing
 // the completion of the alarm event.
 class AlarmScheduler final: kj::TaskSet::ErrorHandler {
-public:
+ public:
   static constexpr auto RETRY_START_SECONDS = WorkerInterface::ALARM_RETRY_START_SECONDS;
 
   // Max number of "valid" retry attempts, i.e the worker returned an error
@@ -70,7 +70,7 @@ public:
 
   void registerNamespace(kj::StringPtr uniqueKey, GetActorFn getActor);
 
-private:
+ private:
   enum class AlarmStatus { WAITING, STARTED, FINISHED };
   const kj::Clock& clock;
   kj::Timer& timer;

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -87,7 +87,7 @@ kj::String operator"" _blockquote(const char* str, size_t n) {
 }
 
 class TestStream {
-public:
+ public:
   TestStream(kj::WaitScope& ws, kj::Own<kj::AsyncIoStream> stream)
       : ws(ws),
         stream(kj::mv(stream)) {}
@@ -202,7 +202,7 @@ public:
         {});
   }
 
-private:
+ private:
   kj::WaitScope& ws;
   kj::Own<kj::AsyncIoStream> stream;
 
@@ -308,7 +308,7 @@ private:
 };
 
 class TestServer final: private kj::Filesystem, private kj::EntropySource, private kj::Clock {
-public:
+ public:
   TestServer(kj::StringPtr configText, kj::SourceLocation loc = {})
       : ws(loop),
         config(parseConfig(configText, loc)),
@@ -425,7 +425,7 @@ public:
 
   kj::Date fakeDate;
 
-private:
+ private:
   kj::UnwindDetector unwindDetector;
 
   // ---------------------------------------------------------------------------
@@ -476,7 +476,7 @@ private:
   }
 
   class MockAddress final: public kj::NetworkAddress {
-  public:
+   public:
     MockAddress(TestServer& test, kj::StringPtr peerFilter, kj::String address)
         : test(test),
           peerFilter(peerFilter),
@@ -510,14 +510,14 @@ private:
       KJ_UNIMPLEMENTED("unused");
     }
 
-  private:
+   private:
     TestServer& test;
     kj::StringPtr peerFilter;
     kj::String address;
   };
 
   class MockNetwork final: public kj::Network {
-  public:
+   public:
     MockNetwork(TestServer& test,
         kj::ArrayPtr<const kj::StringPtr> allow,
         kj::ArrayPtr<const kj::StringPtr> deny)
@@ -537,7 +537,7 @@ private:
       return kj::heap<MockNetwork>(test, allow, deny);
     }
 
-  private:
+   private:
     TestServer& test;
     kj::String filter;
   };

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -61,7 +61,7 @@ static kj::Maybe<PemData> decodePem(kj::ArrayPtr<const char> text) {
   KJ_DEFER(BIO_free(bio));
 
   class OpenSslDisposer: public kj::ArrayDisposer {
-  public:
+   public:
     void disposeImpl(void* firstElement,
         size_t elementSize,
         size_t elementCount,
@@ -192,7 +192,7 @@ struct Server::GlobalContext {
 };
 
 class Server::Service {
-public:
+ public:
   // Cross-links this service with other services. Must be called once before `startRequest()`.
   virtual void link() {}
 
@@ -288,7 +288,7 @@ class Server::HttpRewriter {
   // TODO(beta): Do we want to automatically add `Date`, `Server` (to outgoing responses),
   //   `User-Agent` (to outgoing requests), etc.?
 
-public:
+ public:
   HttpRewriter(
       config::HttpOptions::Reader httpOptions, kj::HttpHeaderTable::Builder& headerTableBuilder)
       : style(httpOptions.getStyle()),
@@ -394,14 +394,14 @@ public:
     return capnpConnectHost;
   }
 
-private:
+ private:
   config::HttpOptions::Style style;
   kj::Maybe<kj::HttpHeaderId> forwardedProtoHeader;
   kj::Maybe<kj::HttpHeaderId> cfBlobHeader;
   kj::Maybe<kj::StringPtr> capnpConnectHost;
 
   class HeaderInjector {
-  public:
+   public:
     HeaderInjector(capnp::List<config::HttpOptions::Header>::Reader headers,
         kj::HttpHeaderTable::Builder& headerTableBuilder)
         : injectedHeaders(KJ_MAP(header, headers) {
@@ -427,7 +427,7 @@ private:
       }
     }
 
-  private:
+   private:
     struct InjectedHeader {
       kj::HttpHeaderId id;
       kj::Maybe<kj::String> value;
@@ -443,7 +443,7 @@ private:
 
 // Service used when the service's config is invalid.
 class Server::InvalidConfigService final: public Service {
-public:
+ public:
   kj::Own<WorkerInterface> startRequest(IoChannelFactory::SubrequestMetadata metadata) override {
     JSG_FAIL_REQUIRE(Error, "Service cannot handle requests because its config is invalid.");
   }
@@ -466,7 +466,7 @@ class PromisedNetworkAddress final: public kj::NetworkAddress {
   //   not do DNS lookup immediately, and therefore can return a NetworkAddress synchronously.
   //   In fact, this version should be designed to redo the DNS lookup periodically to see if it
   //   changed, which would be nice for workerd when the remote address may change over time.
-public:
+ public:
   PromisedNetworkAddress(kj::Promise<kj::Own<kj::NetworkAddress>> promise)
       : promise(promise.then([this](kj::Own<kj::NetworkAddress> result) { addr = kj::mv(result); })
                     .fork()) {}
@@ -500,13 +500,13 @@ public:
     KJ_UNIMPLEMENTED("PromisedNetworkAddress::toString() not implemented");
   }
 
-private:
+ private:
   kj::ForkedPromise<void> promise;
   kj::Maybe<kj::Own<kj::NetworkAddress>> addr;
 };
 
 class Server::ExternalTcpService final: public Service, private WorkerInterface {
-public:
+ public:
   ExternalTcpService(kj::Own<kj::NetworkAddress> addrParam): addr(kj::mv(addrParam)) {}
 
   kj::Own<WorkerInterface> startRequest(IoChannelFactory::SubrequestMetadata metadata) override {
@@ -517,7 +517,7 @@ public:
     return handlerName == "fetch"_kj || handlerName == "connect"_kj;
   }
 
-private:
+ private:
   kj::Own<kj::NetworkAddress> addr;
 
   kj::Promise<void> request(kj::HttpMethod method,
@@ -571,7 +571,7 @@ private:
 
 // Service used when the service is configured as external HTTP service.
 class Server::ExternalHttpService final: public Service, private kj::TaskSet::ErrorHandler {
-public:
+ public:
   ExternalHttpService(kj::Own<kj::NetworkAddress> addrParam,
       kj::Own<HttpRewriter> rewriter,
       kj::HttpHeaderTable& headerTable,
@@ -600,7 +600,7 @@ public:
     return handlerName == "fetch"_kj || handlerName == "connect"_kj;
   }
 
-private:
+ private:
   kj::Own<kj::NetworkAddress> addr;
 
   kj::Own<kj::HttpClient> inner;
@@ -659,7 +659,7 @@ private:
   }
 
   class WorkerInterfaceImpl final: public WorkerInterface, private kj::HttpService::Response {
-  public:
+   public:
     WorkerInterfaceImpl(ExternalHttpService& parent, IoChannelFactory::SubrequestMetadata metadata)
         : parent(parent),
           metadata(kj::mv(metadata)) {}
@@ -710,7 +710,7 @@ private:
           .attach(kj::mv(event));
     }
 
-  private:
+   private:
     ExternalHttpService& parent;
     IoChannelFactory::SubrequestMetadata metadata;
     kj::Maybe<kj::HttpService::Response&> wrappedResponse;
@@ -812,7 +812,7 @@ kj::Own<Server::Service> Server::makeExternalService(kj::StringPtr name,
 
 // Service used when the service is configured as network service.
 class Server::NetworkService final: public Service, private WorkerInterface {
-public:
+ public:
   NetworkService(kj::HttpHeaderTable& headerTable,
       kj::Timer& timer,
       kj::EntropySource& entropySource,
@@ -838,7 +838,7 @@ public:
     return handlerName == "fetch"_kj || handlerName == "connect"_kj;
   }
 
-private:
+ private:
   kj::Own<kj::Network> network;
   kj::Maybe<kj::Own<kj::Network>> tlsNetwork;
   kj::Own<kj::HttpClient> inner;
@@ -904,7 +904,7 @@ kj::Own<Server::Service> Server::makeNetworkService(config::Network::Reader conf
 
 // Service used when the service is configured as disk directory service.
 class Server::DiskDirectoryService final: public Service, private WorkerInterface {
-public:
+ public:
   DiskDirectoryService(config::DiskDirectory::Reader conf,
       kj::Own<const kj::Directory> dir,
       kj::HttpHeaderTable::Builder& headerTableBuilder)
@@ -933,7 +933,7 @@ public:
     return handlerName == "fetch"_kj;
   }
 
-private:
+ private:
   kj::Maybe<const kj::Directory&> writable;
   kj::Own<const kj::ReadableDirectory> readable;
   kj::HttpHeaderTable& headerTable;
@@ -1213,7 +1213,7 @@ kj::Own<Server::Service> Server::makeDiskDirectoryService(kj::StringPtr name,
 // additional services that also have code. If using Chrome devtools to inspect a workerd,
 // instance all services are visible and can be debugged.
 class Server::InspectorServiceIsolateRegistrar final {
-public:
+ public:
   InspectorServiceIsolateRegistrar() {}
   ~InspectorServiceIsolateRegistrar() noexcept(true);
 
@@ -1221,7 +1221,7 @@ public:
 
   KJ_DISALLOW_COPY_AND_MOVE(InspectorServiceIsolateRegistrar);
 
-private:
+ private:
   void attach(const Server::InspectorService* anInspectorService) {
     *inspectorService.lockExclusive() = anInspectorService;
   }
@@ -1239,7 +1239,7 @@ private:
 // The InspectorService is created when workerd serve is called using the -i option
 // to define the inspector socket.
 class Server::InspectorService final: public kj::HttpService, public kj::HttpServerErrorHandler {
-public:
+ public:
   InspectorService(kj::Own<const kj::Executor> isolateThreadExecutor,
       kj::Timer& timer,
       kj::HttpHeaderTable::Builder& headerTableBuilder,
@@ -1419,7 +1419,7 @@ public:
     isolates.insert(kj::str(name), isolate->getWeakRef());
   }
 
-private:
+ private:
   kj::Own<const kj::Executor> isolateThreadExecutor;
   kj::Timer& timer;
   kj::HttpHeaderTable& headerTable;
@@ -1448,7 +1448,7 @@ void Server::InspectorServiceIsolateRegistrar::registerIsolate(
 // =======================================================================================
 namespace {
 class RequestObserverWithTracer final: public RequestObserver, public WorkerInterface {
-public:
+ public:
   RequestObserverWithTracer(kj::Maybe<kj::Own<WorkerTracer>> tracer): tracer(kj::mv(tracer)) {}
   ~RequestObserverWithTracer() noexcept(false) {
     KJ_IF_SOME(t, tracer) {
@@ -1555,7 +1555,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::Maybe<kj::Own<WorkerTracer>> tracer;
   kj::Maybe<WorkerInterface&> inner;
   EventOutcome outcome = EventOutcome::OK;
@@ -1568,7 +1568,7 @@ class Server::WorkerService final: public Service,
                                    private IoChannelFactory,
                                    private TimerChannel,
                                    private LimitEnforcer {
-public:
+ public:
   class ActorNamespace;
 
   // I/O channels, delivered when link() is called.
@@ -1714,7 +1714,7 @@ public:
   }
 
   class ActorNamespace final {
-  public:
+   public:
     ActorNamespace(WorkerService& service,
         kj::StringPtr className,
         const ActorConfig& config,
@@ -1766,7 +1766,7 @@ public:
     // initiate the eviction of the Durable Object. If no requests arrive in the next 10 seconds,
     // the DO is evicted, otherwise we cancel the eviction task.
     class ActorContainer final: public RequestTracker::Hooks {
-    public:
+     public:
       ActorContainer(kj::StringPtr key, ActorNamespace& parent, kj::Timer& timer)
           : key(key),
             tracker(kj::refcounted<RequestTracker>(*this)),
@@ -1904,7 +1904,7 @@ public:
       // The actor is constructed after the ActorContainer so it starts off empty.
       kj::Maybe<kj::Own<Worker::Actor>> actor;
 
-    private:
+     private:
       kj::StringPtr key;
       kj::Own<RequestTracker> tracker;
       ActorNamespace& parent;
@@ -1925,7 +1925,7 @@ public:
     // `ActorContainer::hasClients()` starts returning false. After 70 seconds, the cleanupLoop
     // will remove the `ActorContainer` from `actors`.
     class ActorContainerRef: public kj::Refcounted {
-    public:
+     public:
       ActorContainerRef(ActorContainer& container): container(container) {
         // Link this ref to the actual ActorContainer.
         container.containerRef = *this;
@@ -1941,7 +1941,7 @@ public:
         return kj::addRef(*this);
       }
 
-    private:
+     private:
       // This is a maybe because the ActorContainer could be destroyed before ActorContainerRef
       // if the actor is broken.
       kj::Maybe<ActorContainer&> container;
@@ -1952,7 +1952,7 @@ public:
       actors.clear();
     }
 
-  private:
+   private:
     WorkerService& service;
     kj::StringPtr className;
     const ActorConfig& config;
@@ -2016,7 +2016,7 @@ public:
     // Implements actor loopback, which is used by websocket hibernation to deliver events to the
     // actor from the websocket's read loop.
     class Loopback: public Worker::Actor::Loopback, public kj::Refcounted {
-    public:
+     public:
       Loopback(ActorNamespace& ns, kj::String id): ns(ns), id(kj::mv(id)) {}
 
       kj::Own<WorkerInterface> getWorker(IoChannelFactory::SubrequestMetadata metadata) {
@@ -2027,13 +2027,13 @@ public:
         return kj::addRef(*this);
       }
 
-    private:
+     private:
       ActorNamespace& ns;
       kj::String id;
     };
 
     class ActorSqliteHooks final: public ActorSqlite::Hooks {
-    public:
+     public:
       ActorSqliteHooks(AlarmScheduler& alarmScheduler, ActorKey actor)
           : alarmScheduler(alarmScheduler),
             actor(actor) {}
@@ -2047,7 +2047,7 @@ public:
         return kj::READY_NOW;
       }
 
-    private:
+     private:
       AlarmScheduler& alarmScheduler;
       ActorKey actor;
     };
@@ -2197,9 +2197,9 @@ public:
     }
   };
 
-private:
+ private:
   class EntrypointService final: public Service {
-  public:
+   public:
     EntrypointService(
         WorkerService& worker, kj::StringPtr entrypoint, kj::HashSet<kj::String> handlers)
         : worker(worker),
@@ -2214,7 +2214,7 @@ private:
       return handlers.contains(handlerName);
     }
 
-  private:
+   private:
     WorkerService& worker;
     kj::StringPtr entrypoint;
     kj::HashSet<kj::String> handlers;
@@ -2235,14 +2235,14 @@ private:
   LookupServiceCallback lookupService;
 
   class ActorChannelImpl final: public IoChannelFactory::ActorChannel {
-  public:
+   public:
     ActorChannelImpl(ActorNamespace& ns, Worker::Actor::Id id): ns(ns), id(kj::mv(id)) {}
 
     kj::Own<WorkerInterface> startRequest(IoChannelFactory::SubrequestMetadata metadata) override {
       return ns.getActor(Worker::Actor::cloneId(id), kj::mv(metadata));
     }
 
-  private:
+   private:
     ActorNamespace& ns;
     Worker::Actor::Id id;
   };
@@ -2269,7 +2269,7 @@ private:
     KJ_FAIL_REQUIRE("no capability channels");
   }
   class CacheClientImpl final: public CacheClient {
-  public:
+   public:
     CacheClientImpl(Service& cacheService, kj::HttpHeaderId cacheNamespaceHeader)
         : cacheService(cacheService),
           cacheNamespaceHeader(cacheNamespaceHeader) {}
@@ -2288,13 +2288,13 @@ private:
           kj::mv(cfBlobJson), kj::mv(parentSpan));
     }
 
-  private:
+   private:
     Service& cacheService;
     kj::HttpHeaderId cacheNamespaceHeader;
   };
 
   class CacheHttpClientImpl final: public kj::HttpClient {
-  public:
+   public:
     CacheHttpClientImpl(Service& parent,
         kj::HttpHeaderId cacheNamespaceHeader,
         kj::Maybe<kj::String> cacheName,
@@ -2313,7 +2313,7 @@ private:
       return client->request(method, url, addCacheNameHeader(headers, cacheName), expectedBodySize);
     }
 
-  private:
+   private:
     kj::Own<kj::HttpClient> client;
     kj::Maybe<kj::String> cacheName;
     kj::HttpHeaderId cacheNamespaceHeader;
@@ -2880,7 +2880,7 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name,
 
   // IsolateLimitEnforcer that enforces no limits.
   class NullIsolateLimitEnforcer final: public IsolateLimitEnforcer {
-  public:
+   public:
     v8::Isolate::CreateParams getCreateParams() override {
       return {};
     }
@@ -3334,7 +3334,7 @@ Server::Service& Server::lookupService(
 // =======================================================================================
 
 class Server::HttpListener final: public kj::Refcounted {
-public:
+ public:
   HttpListener(Server& owner,
       kj::Own<kj::ConnectionReceiver> listener,
       Service& service,
@@ -3410,7 +3410,7 @@ public:
     }
   }
 
-private:
+ private:
   Server& owner;
   kj::Own<kj::ConnectionReceiver> listener;
   Service& service;
@@ -3433,7 +3433,7 @@ private:
   }
 
   class WorkerdBootstrapImpl final: public rpc::WorkerdBootstrap::Server {
-  public:
+   public:
     WorkerdBootstrapImpl(HttpListener& parent): parent(parent) {}
 
     kj::Promise<void> startEvent(StartEventContext context) {
@@ -3447,12 +3447,12 @@ private:
       return kj::READY_NOW;
     }
 
-  private:
+   private:
     HttpListener& parent;
   };
 
   class EventDispatcherImpl final: public rpc::EventDispatcher::Server {
-  public:
+   public:
     EventDispatcherImpl(HttpListener& parent, kj::Own<WorkerInterface> worker)
         : parent(parent),
           worker(kj::mv(worker)) {}
@@ -3497,7 +3497,7 @@ private:
       return worker->customEvent(kj::mv(customEvent)).ignoreResult().attach(kj::mv(worker));
     }
 
-  private:
+   private:
     HttpListener& parent;
     kj::Maybe<kj::Own<WorkerInterface>> worker;
 
@@ -3529,7 +3529,7 @@ private:
     ListedHttpServer listedHttp;
 
     class ResponseWrapper final: public kj::HttpService::Response {
-    public:
+     public:
       ResponseWrapper(kj::HttpService::Response& inner, HttpRewriter& rewriter)
           : inner(inner),
             rewriter(rewriter) {}
@@ -3551,7 +3551,7 @@ private:
         return inner.acceptWebSocket(rewrite);
       }
 
-    private:
+     private:
       kj::HttpService::Response& inner;
       HttpRewriter& rewriter;
     };
@@ -4090,7 +4090,7 @@ namespace {
 // An ActorStorage implementation which will always respond to reads as if the state is empty,
 // and will fail any writes.
 class EmptyReadOnlyActorStorageImpl final: public rpc::ActorStorage::Stage::Server {
-public:
+ public:
   kj::Promise<void> get(GetContext context) override {
     return kj::READY_NOW;
   }
@@ -4117,9 +4117,9 @@ public:
     return kj::READY_NOW;
   }
 
-private:
+ private:
   class TransactionImpl final: public rpc::ActorStorage::Stage::Transaction::Server {
-  protected:
+   protected:
     kj::Promise<void> get(GetContext context) override {
       return kj::READY_NOW;
     }

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -34,7 +34,7 @@ using api::pyodide::PythonConfig;
 // The purpose of this class is to implement the core logic independently of the CLI itself,
 // in such a way that it can be unit-tested. workerd.c++ implements the CLI wrapper around this.
 class Server final: private kj::TaskSet::ErrorHandler {
-public:
+ public:
   Server(kj::Filesystem& fs,
       kj::Timer& timer,
       kj::Network& network,
@@ -109,7 +109,7 @@ public:
   class InspectorService;
   class InspectorServiceIsolateRegistrar;
 
-private:
+ private:
   kj::Filesystem& fs;
   kj::Timer& timer;
   kj::Network& network;

--- a/src/workerd/server/v8-platform-impl.h
+++ b/src/workerd/server/v8-platform-impl.h
@@ -18,7 +18,7 @@ namespace workerd::server {
 // Everything else gets passed through to the wrapped v8::Platform implementation (presumably
 // from `jsg::defaultPlatform()`).
 class WorkerdPlatform final: public v8::Platform {
-public:
+ public:
   // This takes a reference to its wrapped platform because otherwise we would have to destroy a
   // kj::Own in our noexcept destructor (feasible but ugly).
   explicit WorkerdPlatform(v8::Platform& inner): inner(inner) {}
@@ -75,7 +75,7 @@ public:
     return inner.GetTracingController();
   }
 
-private:
+ private:
   v8::Platform& inner;
 };
 

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -138,7 +138,7 @@ struct WorkerdApi::Impl final {
   const PythonConfig& pythonConfig;
 
   class Configuration {
-  public:
+   public:
     Configuration(Impl& impl)
         : features(*impl.features),
           jsgConfig(jsg::JsgConfig{
@@ -152,7 +152,7 @@ struct WorkerdApi::Impl final {
       return jsgConfig;
     }
 
-  private:
+   private:
     CompatibilityFlags::Reader& features;
     jsg::JsgConfig jsgConfig;
   };

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -31,7 +31,7 @@ using api::pyodide::PythonConfig;
 
 // A Worker::Api implementation with support for all the APIs supported by the OSS runtime.
 class WorkerdApi final: public Worker::Api {
-public:
+ public:
   WorkerdApi(jsg::V8System& v8System,
       CompatibilityFlags::Reader features,
       kj::Own<IsolateLimitEnforcer> limitEnforcer,
@@ -252,7 +252,7 @@ public:
       const CompatibilityFlags::Reader& featureFlags,
       const PythonConfig& pythonConfig);
 
-private:
+ private:
   struct Impl;
   kj::Own<Impl> impl;
 

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -82,7 +82,7 @@ static kj::StringPtr getVersionString() {
 // =======================================================================================
 
 class EntropySourceImpl: public kj::EntropySource {
-public:
+ public:
   void generate(kj::ArrayPtr<kj::byte> buffer) override {
     KJ_ASSERT(RAND_bytes(buffer.begin(), buffer.size()) == 1);
   }
@@ -94,7 +94,7 @@ public:
 // Result<T, E>, it seems like such a slog.
 
 class CliError {
-public:
+ public:
   CliError(kj::String description): description(kj::mv(description)) {}
   kj::String description;
 };
@@ -130,7 +130,7 @@ constexpr capnp::ReaderOptions CONFIG_READER_OPTIONS = {
 
 // Class which uses inotify to watch a set of files and alert when they change.
 class FileWatcher {
-public:
+ public:
   FileWatcher(kj::UnixEventPort& port)
       : inotifyFd(makeInotify()),
         observer(port, inotifyFd, kj::UnixEventPort::FdObserver::OBSERVE_READ) {}
@@ -192,7 +192,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::AutoCloseFd inotifyFd;
   kj::UnixEventPort::FdObserver observer;
 
@@ -219,7 +219,7 @@ private:
 // Apple provides the FSEvents API as an alternative, but it seems way more complicated and I
 // can't tell if it would provide a real advantage. Plus, kqueue works on BSD systems.
 class FileWatcher {
-public:
+ public:
   FileWatcher(kj::UnixEventPort& port)
       : kqueueFd(makeKqueue()),
         observer(port, kqueueFd, kj::UnixEventPort::FdObserver::OBSERVE_READ) {}
@@ -269,7 +269,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::AutoCloseFd kqueueFd;
   kj::UnixEventPort::FdObserver observer;
   kj::Vector<kj::AutoCloseFd> filesWatched;
@@ -299,7 +299,7 @@ private:
 #elif _WIN32
 
 class FileWatcher {
-public:
+ public:
   FileWatcher(kj::Win32EventPort& port) {}
 
   bool isSupported() {
@@ -312,14 +312,14 @@ public:
     return kj::NEVER_DONE;
   }
 
-private:
+ private:
 };
 
 #else
 
 // Dummy FileWatcher implementation for operating systems that aren't supported yet.
 class FileWatcher {
-public:
+ public:
   FileWatcher(kj::UnixEventPort& port) {}
 
   bool isSupported() {
@@ -332,7 +332,7 @@ public:
     return kj::NEVER_DONE;
   }
 
-private:
+ private:
 };
 
 #endif  // #__linux__, #else
@@ -347,9 +347,9 @@ kj::Maybe<kj::Own<capnp::SchemaFile>> tryImportBulitin(kj::StringPtr name);
 // These callbacks also give us more control over error reporting, in particular the ability
 // to not throw an exception on the first error seen.
 class SchemaFileImpl final: public capnp::SchemaFile {
-public:
+ public:
   class ErrorReporter {
-  public:
+   public:
     virtual void reportParsingError(
         kj::StringPtr file, SourcePos start, SourcePos end, kj::StringPtr message) = 0;
   };
@@ -438,7 +438,7 @@ public:
     errorReporter.reportParsingError(displayName, start, end, message);
   }
 
-private:
+ private:
   const kj::Directory& root;
   kj::PathPtr current;
 
@@ -469,7 +469,7 @@ private:
 //   schema nodes rather than re-parse the file from scratch? This is tricky as some information
 //   is lost after compilation which is needed to compile dependents, e.g. aliases are erased.
 class BuiltinSchemaFileImpl final: public capnp::SchemaFile {
-public:
+ public:
   BuiltinSchemaFileImpl(kj::StringPtr name, kj::StringPtr content): name(name), content(content) {}
 
   kj::StringPtr getDisplayName() const override {
@@ -500,7 +500,7 @@ public:
     KJ_FAIL_ASSERT("parse error in built-in schema?", start.line, start.column, message);
   }
 
-private:
+ private:
   kj::StringPtr name;
   kj::StringPtr content;
 };
@@ -525,7 +525,7 @@ kj::Maybe<kj::Own<capnp::SchemaFile>> tryImportBulitin(kj::StringPtr name) {
 // There is no use for loopback sockets in production since direct service bindings are more
 // efficient while solving the same problems.
 class NetworkWithLoopback final: public kj::Network {
-public:
+ public:
   NetworkWithLoopback(kj::Network& inner, kj::AsyncIoProvider& ioProvider)
       : inner(inner),
         ioProvider(ioProvider),
@@ -562,7 +562,7 @@ public:
         inner.restrictPeers(allow, deny), ioProvider, loopbackEnabled);
   }
 
-private:
+ private:
   kj::Network& inner;
   kj::Own<kj::Network> ownInner;
   kj::AsyncIoProvider& ioProvider KJ_UNUSED;
@@ -587,7 +587,7 @@ private:
   static constexpr kj::StringPtr PREFIX = "loopback:"_kj;
 
   class LoopbackAddr final: public kj::NetworkAddress {
-  public:
+   public:
     LoopbackAddr(NetworkWithLoopback& parent, kj::StringPtr name)
         : parent(parent),
           name(kj::str(name)) {}
@@ -616,13 +616,13 @@ private:
       return kj::str(PREFIX, name);
     }
 
-  private:
+   private:
     NetworkWithLoopback& parent;
     kj::String name;
   };
 
   class LoopbackReceiver final: public kj::ConnectionReceiver {
-  public:
+   public:
     LoopbackReceiver(ConnectionQueue& queue): queue(queue) {}
 
     kj::Promise<kj::Own<kj::AsyncIoStream>> accept() override {
@@ -633,7 +633,7 @@ private:
       return 0;
     }
 
-  private:
+   private:
     ConnectionQueue& queue;
   };
 };
@@ -641,7 +641,7 @@ private:
 // =======================================================================================
 
 class CliMain final: public SchemaFileImpl::ErrorReporter {
-public:
+ public:
   CliMain(kj::ProcessContext& context, char** argv)
       : context(context),
         argv(argv),
@@ -1378,7 +1378,7 @@ public:
   }
 #endif
 
-private:
+ private:
   kj::ProcessContext& context;
   char** argv;
 

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -122,7 +122,7 @@ static constexpr kj::StringPtr mainModuleName = "main"_kj;
 static constexpr kj::StringPtr scriptId = "script"_kj;
 
 class MockEntropySource final: public kj::EntropySource {
-public:
+ public:
   ~MockEntropySource() {}
   void generate(kj::ArrayPtr<kj::byte> buffer) override {
     for (kj::byte& b: buffer) {
@@ -137,7 +137,7 @@ public:
     return r;
   }
 
-private:
+ private:
   kj::byte counter = 0;
 };
 
@@ -282,7 +282,7 @@ struct MockResponse final: public kj::HttpService::Response {
 };
 
 class MockActorLoopback: public Worker::Actor::Loopback, public kj::Refcounted {
-public:
+ public:
   virtual kj::Own<WorkerInterface> getWorker(IoChannelFactory::SubrequestMetadata metadata) {
     return kj::Own<WorkerInterface>();
   };

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -88,7 +88,7 @@ struct TestFixture {
   // Performs HTTP request on the default module handler, and waits for full response.
   Response runRequest(kj::HttpMethod method, kj::StringPtr url, kj::StringPtr body);
 
-private:
+ private:
   kj::Maybe<kj::WaitScope&> waitScope;
   capnp::MallocMessageBuilder configArena;
   workerd::server::config::Worker::Reader config;

--- a/src/workerd/util/abortable.h
+++ b/src/workerd/util/abortable.h
@@ -11,7 +11,7 @@ namespace workerd {
 
 template <typename T>
 class AbortableImpl final {
-public:
+ public:
   AbortableImpl(kj::Own<T> inner, RefcountedCanceler& canceler)
       : canceler(kj::addRef(canceler)),
         inner(kj::mv(inner)),
@@ -41,7 +41,7 @@ public:
     return inner;
   }
 
-private:
+ private:
   kj::Own<RefcountedCanceler> canceler;
   kj::Maybe<kj::Own<T>> inner;
   RefcountedCanceler::Listener onCancel;
@@ -56,7 +56,7 @@ private:
 // TODO(later): It would be good to see if both this and NeuterableInputStream
 // could be combined into a single utility.
 class AbortableInputStream final: public kj::AsyncInputStream, public kj::Refcounted {
-public:
+ public:
   AbortableInputStream(kj::Own<kj::AsyncInputStream> inner, RefcountedCanceler& canceler)
       : impl(kj::mv(inner), canceler) {}
 
@@ -76,7 +76,7 @@ public:
     return impl.wrap(&kj::AsyncInputStream::pumpTo, output, amount);
   }
 
-private:
+ private:
   AbortableImpl<kj::AsyncInputStream> impl;
 };
 
@@ -85,7 +85,7 @@ private:
 // is using an AbortSignal. The AbortableWebSocket is created using the AbortSignal's
 // RefcountedCanceler, which will be triggered when the AbortSignal is triggered.
 class AbortableWebSocket final: public kj::WebSocket, public kj::Refcounted {
-public:
+ public:
   AbortableWebSocket(kj::Own<kj::WebSocket> inner, RefcountedCanceler& canceler)
       : impl(kj::mv(inner), canceler) {}
 
@@ -146,7 +146,7 @@ public:
     return impl.getInner().getPreferredExtensions(ctx);
   };
 
-private:
+ private:
   AbortableImpl<kj::WebSocket> impl;
 };
 

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -32,7 +32,7 @@ enum class AutogateKey {
 // When making structural changes here, ensure you align them with autogate.h in the internal repo.
 class Autogate {
 
-public:
+ public:
   static bool isEnabled(AutogateKey key);
 
   // Creates a global Autogate and seeds it with gates that are specified in the config.
@@ -47,7 +47,7 @@ public:
   // Destroys an initialised global Autogate instance. Used only for testing.
   static void deinitAutogate();
 
-private:
+ private:
   bool gates[(unsigned long)AutogateKey::NumOfKeys];
 
   Autogate(capnp::List<capnp::Text>::Reader autogates);

--- a/src/workerd/util/batch-queue.h
+++ b/src/workerd/util/batch-queue.h
@@ -27,7 +27,7 @@ using kj::uint;
 // when wrapped as a `kj::MutexGuarded<BatchQueue<T>>`.
 template <typename T>
 class BatchQueue {
-public:
+ public:
   // `initialCapacity` is the number of elements of type T for which we should allocate space in the
   // initial buffers, and any reconstructed buffers. Buffers will be reconstructed if they are
   // observed to grow beyond `maxCapacity` after a completed pop operation.
@@ -43,7 +43,7 @@ public:
   // A Batch can be converted to an ArrayPtr<T>. When a Batch is destroyed, it clears the pop
   // buffer and resets the pop buffer capacity to `initialCapacity` if necessary.
   class Batch {
-  public:
+   public:
     Batch() = default;
     Batch(Batch&&) = default;
     Batch& operator=(Batch&&) = default;
@@ -60,7 +60,7 @@ public:
       return *this;
     }
 
-  private:
+   private:
     explicit Batch(BatchQueue& batchQueue): batchQueue(batchQueue) {}
     friend BatchQueue;
 
@@ -104,7 +104,7 @@ public:
     return pushBuffer.size();
   }
 
-private:
+ private:
   kj::Vector<T> pushBuffer;
   kj::Vector<T> popBuffer;
   uint initialCapacity;

--- a/src/workerd/util/canceler.h
+++ b/src/workerd/util/canceler.h
@@ -20,9 +20,9 @@ namespace workerd {
 // to various other objects that will use it to wrap their
 // Promises.
 class RefcountedCanceler: public kj::Refcounted {
-public:
+ public:
   class Listener {
-  public:
+   public:
     explicit Listener(RefcountedCanceler& canceler, kj::Function<void()> fn)
         : fn(kj::mv(fn)),
           canceler(canceler) {
@@ -33,7 +33,7 @@ public:
       canceler.removeListener(*this);
     }
 
-  private:
+   private:
     kj::Function<void()> fn;
     RefcountedCanceler& canceler;
     kj::ListLink<Listener> link;
@@ -101,7 +101,7 @@ public:
     listeners.remove(listener);
   }
 
-private:
+ private:
   kj::Canceler canceler;
   kj::Maybe<kj::Exception> reason;
 

--- a/src/workerd/util/capnp-mock.h
+++ b/src/workerd/util/capnp-mock.h
@@ -66,13 +66,13 @@ kj::String canonicalizeCapnpText(
     capnp::StructSchema schema, kj::StringPtr text, kj::Maybe<kj::StringPtr> capName = kj::none);
 
 class MockClient: public capnp::DynamicCapability::Client {
-public:
+ public:
   using capnp::DynamicCapability::Client::Client;
   MockClient(capnp::DynamicCapability::Client&& client)
       : capnp::DynamicCapability::Client(kj::mv(client)) {}
 
   class ExpectedCall {
-  public:
+   public:
     ExpectedCall(capnp::RemotePromise<capnp::DynamicStruct> promise): promise(kj::mv(promise)) {}
 
     void expectReturns(
@@ -98,7 +98,7 @@ public:
       }).wait(ws);
     }
 
-  private:
+   private:
     capnp::RemotePromise<capnp::DynamicStruct> promise;
   };
 
@@ -115,7 +115,7 @@ public:
 class MockServer: public kj::Refcounted {
   struct ReceivedCall;
 
-public:
+ public:
   MockServer(capnp::InterfaceSchema schema): schema(schema) {}
 
   template <typename T>
@@ -132,7 +132,7 @@ public:
   }
 
   class ExpectedCall {
-  public:
+   public:
     ExpectedCall(ReceivedCall& received): maybeReceived(received) {
       received.expectedCall = this;
     }
@@ -231,7 +231,7 @@ public:
       KJ_ASSERT_AT(maybeReceived == kj::none, location, "call has not been canceled");
     }
 
-  private:
+   private:
     kj::Maybe<ReceivedCall&> maybeReceived;
     ReceivedCall& getReceived(kj::SourceLocation location) {
       return KJ_REQUIRE_NONNULL_AT(maybeReceived, location, "call was unexpectedly canceled");
@@ -280,7 +280,7 @@ public:
     }
   }
 
-private:
+ private:
   capnp::InterfaceSchema schema;
   kj::Maybe<kj::Own<kj::PromiseFulfiller<void>>> waiter;
 
@@ -334,7 +334,7 @@ private:
   }
 
   class Server final: public capnp::DynamicCapability::Server {
-  public:
+   public:
     Server(MockServer& mock)
         : capnp::DynamicCapability::Server(mock.schema, {.allowCancellation = true}),
           mock(kj::addRef(mock)) {}
@@ -350,7 +350,7 @@ private:
       return kj::newAdaptedPromise<void, ReceivedCall>(*mock, method, kj::mv(context));
     }
 
-  private:
+   private:
     kj::Own<MockServer> mock;
   };
 };

--- a/src/workerd/util/duration-exceeded-logger.h
+++ b/src/workerd/util/duration-exceeded-logger.h
@@ -16,7 +16,7 @@ namespace workerd::util {
 // thereby timing everything after the initialization of the timer, until the end of the scope where it was
 // instantiated.
 class DurationExceededLogger {
-public:
+ public:
   DurationExceededLogger(
       const kj::MonotonicClock& clock, kj::Duration warningDuration, kj::StringPtr logMessage)
       : warningDuration(warningDuration),
@@ -33,7 +33,7 @@ public:
     }
   }
 
-private:
+ private:
   kj::Duration warningDuration;
   kj::StringPtr logMessage;
   kj::TimePoint start;

--- a/src/workerd/util/http-util.h
+++ b/src/workerd/util/http-util.h
@@ -43,7 +43,7 @@ kj::Promise<kj::HttpClient::WebSocketResponse> attachToWebSocketResponse(
 // A Response kj::HttpService::Response implementation that records the status
 // code on the response.
 class SimpleResponseObserver final: public kj::HttpService::Response {
-public:
+ public:
   SimpleResponseObserver(kj::uint* statusCode, kj::HttpService::Response& response)
       : inner(response),
         statusCode(statusCode) {}
@@ -61,7 +61,7 @@ public:
     return inner.acceptWebSocket(headers);
   }
 
-private:
+ private:
   kj::HttpService::Response& inner;
   kj::uint* statusCode;
 };

--- a/src/workerd/util/mimetype.h
+++ b/src/workerd/util/mimetype.h
@@ -16,7 +16,7 @@ template <size_t>
 class StringBuffer;
 
 class MimeType final {
-public:
+ public:
   using MimeParams = kj::HashMap<kj::String, kj::String>;
 
   enum ParseOptions {
@@ -110,7 +110,7 @@ public:
     tracker.trackFieldWithSize("params", params_.size());
   }
 
-private:
+ private:
   kj::String type_;
   kj::String subtype_;
   MimeParams params_;

--- a/src/workerd/util/perfetto-tracing.h
+++ b/src/workerd/util/perfetto-tracing.h
@@ -20,7 +20,7 @@ namespace workerd {
 // Perfetto subsystem on first initialization and writing events to the given
 // file path.
 class PerfettoSession {
-public:
+ public:
   explicit PerfettoSession(kj::StringPtr path, kj::StringPtr categories);
 
   // Create a PerfettoSession on an existing fd (the constructor will handle
@@ -39,7 +39,7 @@ public:
   // Called by embedders at most once to register the workerd track events.
   static void registerWorkerdTracks();
 
-private:
+ private:
   struct Impl;
   kj::Own<Impl> impl;
 

--- a/src/workerd/util/sqlite-kv.h
+++ b/src/workerd/util/sqlite-kv.h
@@ -25,7 +25,7 @@ class SqliteKvRegulator: public SqliteDatabase::Regulator {
 // (Ideally this class would allow configuring the table name, but this would require a somewhat
 // obnoxious amount of string allocation.)
 class SqliteKv: private SqliteDatabase::ResetListener {
-public:
+ public:
   explicit SqliteKv(SqliteDatabase& db);
 
   typedef kj::StringPtr KeyPtr;
@@ -59,7 +59,7 @@ public:
   //   extension might help here, though it can only support arrays of NUL-terminated strings, not
   //   byte blobs or strings containing NUL bytes.
 
-private:
+ private:
   struct Uninitialized {};
 
   struct Initialized {

--- a/src/workerd/util/sqlite-metadata.h
+++ b/src/workerd/util/sqlite-metadata.h
@@ -15,7 +15,7 @@ namespace workerd {
 // The table is named `_cf_METADATA`. The naming is designed so that if the application is allowed to
 // perform direct SQL queries, we can block it from accessing any table prefixed with `_cf_`.
 class SqliteMetadata final: private SqliteDatabase::ResetListener {
-public:
+ public:
   explicit SqliteMetadata(SqliteDatabase& db);
 
   // Return currently set alarm time, or none.
@@ -24,7 +24,7 @@ public:
   // Sets current alarm time, or none.
   void setAlarm(kj::Maybe<kj::Date> currentTime);
 
-private:
+ private:
   struct Uninitialized {};
   struct Initialized {
     SqliteDatabase& db;

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -137,7 +137,7 @@ KJ_TEST("SQLite backed by in-memory directory") {
 }
 
 class TempDirOnDisk {
-public:
+ public:
   TempDirOnDisk() {}
   ~TempDirOnDisk() noexcept(false) {
     dir = nullptr;
@@ -151,7 +151,7 @@ public:
     return *dir;
   }
 
-private:
+ private:
   kj::Own<kj::Filesystem> disk = kj::newDiskFilesystem();
   kj::Path path = makeTmpPath();
   kj::Own<const kj::Directory> dir = disk->getRoot().openSubdir(path, kj::WriteMode::MODIFY);
@@ -395,7 +395,7 @@ KJ_TEST("SQLite Regulator") {
   SqliteDatabase db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
 
   class RegulatorImpl: public SqliteDatabase::Regulator {
-  public:
+   public:
     RegulatorImpl(kj::StringPtr blocked): blocked(blocked) {}
 
     bool isAllowedName(kj::StringPtr name) const override {
@@ -405,7 +405,7 @@ KJ_TEST("SQLite Regulator") {
 
     bool alwaysFail = false;
 
-  private:
+   private:
     kj::StringPtr blocked;
   };
 
@@ -708,7 +708,7 @@ KJ_TEST("SQLite row counters with triggers") {
   SqliteDatabase db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
 
   class RegulatorImpl: public SqliteDatabase::Regulator {
-  public:
+   public:
     RegulatorImpl() = default;
 
     bool isAllowedTrigger(kj::StringPtr name) const override {
@@ -823,7 +823,7 @@ KJ_TEST("reset database") {
 
 KJ_TEST("SQLite observer addQueryStats") {
   class TestSqliteObserver: public SqliteObserver {
-  public:
+   public:
     void addQueryStats(uint64_t read, uint64_t written) override {
       rowsRead += read;
       rowsWritten += written;
@@ -927,7 +927,7 @@ KJ_TEST("SQLite failed statement reset") {
 }
 
 class MockRollbackCallback {
-public:
+ public:
   kj::Function<void()> create() {
     KJ_ASSERT(!created);
     created = true;
@@ -947,7 +947,7 @@ public:
     return !called && destroyed;
   }
 
-private:
+ private:
   bool created = false;
   bool called = false;
   bool destroyed = false;

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -143,7 +143,7 @@ void disposeSqlite(sqlite3_stmt* stmt) {
 
 template <typename T>
 class SqliteDisposer: public kj::Disposer {
-public:
+ public:
   void disposeImpl(void* pointer) const override {
     disposeSqlite(reinterpret_cast<T*>(pointer));
   }
@@ -2046,12 +2046,12 @@ sqlite3_vfs SqliteDatabase::Vfs::makeKjVfs() {
 // -----------------------------------------------------------------------------
 
 class SqliteDatabase::Vfs::DefaultLockManager final: public SqliteDatabase::LockManager {
-public:
+ public:
   kj::Own<Lock> lock(kj::PathPtr path, const kj::ReadableFile& mainDatabaseFile) const override {
     return kj::heap<LockImpl>(*this, path);
   }
 
-private:
+ private:
   class LockImpl;
   struct LockState;
   using LockMap = kj::HashMap<kj::PathPtr, LockState*>;
@@ -2079,7 +2079,7 @@ private:
   };
 
   class LockImpl final: public Lock {
-  public:
+   public:
     LockImpl(const DefaultLockManager& lockManager, kj::PathPtr path): lockManager(lockManager) {
       auto mlock = lockManager.lockMap.lockExclusive();
       auto& slot = mlock->findOrCreate(path, [&]() {
@@ -2258,7 +2258,7 @@ private:
       }
     }
 
-  private:
+   private:
     const DefaultLockManager& lockManager;
     kj::Own<LockState> state;
     Level currentLevel = UNLOCKED;

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -23,7 +23,7 @@ using kj::uint;
 
 // Used to collect periodic metrics about queries and size of sqlite db
 class SqliteObserver {
-public:
+ public:
   virtual void addQueryStats(uint64_t rowsRead, uint64_t rowsWritten) {}
   // The method is not used by the SqliteDatabase, it is added here for convenience
   virtual void setSqliteStoredBytes(uint64_t sqliteStoredBytes) {}
@@ -39,7 +39,7 @@ public:
 // representing a true disk directory, the real SQLite disk implementation will be used with
 // all of its features.
 class SqliteDatabase {
-public:
+ public:
   class Vfs;
   class Query;
   class Statement;
@@ -72,7 +72,7 @@ public:
   // of returning false. If they do, this exception will pass through to the caller in place of
   // a generic "not authorized" exception.
   class Regulator {
-  public:
+   public:
     // Returns whether the given name (which may be a table, index, view, etc.) is allowed to be
     // accessed. Typically, this is used to deny access to names containing special prefixes
     // indicating that they are privileged, like `_cf_`.
@@ -202,7 +202,7 @@ public:
 
   // Objects that need to be notified when reset() is called may inherit `ResetListener`.
   class ResetListener {
-  public:
+   public:
     ResetListener(SqliteDatabase& db): db(db) {
       db.resetListeners.add(*this);
     }
@@ -218,10 +218,10 @@ public:
     // called before actually resetting the database.
     virtual void beforeSqliteReset() = 0;
 
-  protected:  // so that subclasess don't have to store their own copy of the `db` reference
+   protected:  // so that subclasess don't have to store their own copy of the `db` reference
     SqliteDatabase& db;
 
-  private:
+   private:
     kj::ListLink<ResetListener> link;
 
     friend class SqliteDatabase;
@@ -256,7 +256,7 @@ public:
     }
   }
 
-private:
+ private:
   const Vfs& vfs;
   kj::Path path;
   bool readOnly;
@@ -370,7 +370,7 @@ private:
 
 // Represents a prepared SQL statement, which can be executed many times.
 class SqliteDatabase::Statement final: private ResetListener {
-public:
+ public:
   // Convenience method to start a query. This is equivalent to:
   //
   //     SqliteDatabase::Query(db, statement, bindings...);
@@ -385,7 +385,7 @@ public:
   template <typename... Params>
   Query run(Params&&... bindings);
 
-private:
+ private:
   const Regulator& regulator;
   kj::OneOf<kj::String, StatementAndEffect> stmt;
 
@@ -418,7 +418,7 @@ private:
 // Only one Query can exist at a time, for a given database. It should probably be allocated on
 // the stack.
 class SqliteDatabase::Query final: private ResetListener {
-public:
+ public:
   using ValuePtr =
       kj::OneOf<kj::ArrayPtr<const byte>, kj::StringPtr, int64_t, double, decltype(nullptr)>;
 
@@ -512,7 +512,7 @@ public:
     }
   }
 
-private:
+ private:
   const Regulator& regulator;
   StatementAndEffect ownStatement;                // for one-off queries
   kj::Maybe<StatementAndEffect&> maybeStatement;  // null if database was reset
@@ -633,7 +633,7 @@ struct SqliteDatabase::VfsOptions {
 //
 // An instance of `Vfs` can safely be used across multiple threads.
 class SqliteDatabase::Vfs {
-public:
+ public:
   // Pretend `Options` is declared nested here. Due to a C++ quirk, we cannot actually declare it
   // nested while having default-initialized parameters of this type.
   using Options = VfsOptions;
@@ -675,7 +675,7 @@ public:
 
   KJ_DISALLOW_COPY_AND_MOVE(Vfs);
 
-private:
+ private:
   const kj::Directory& directory;
   kj::Own<LockManager> ownLockManager;
   const LockManager& lockManager;
@@ -720,7 +720,7 @@ private:
 };
 
 class SqliteDatabase::LockManager {
-public:
+ public:
   // Obtain a lock for the given database path. The main database file is also provided in case
   // it is useful. This method only creates the `Lock` object; it's level starts out as UNLOCKED,
   // meaning no actual lock is held yet.
@@ -744,7 +744,7 @@ public:
 // native implementation kicks in, which is based on advisory file locks at the OS level, as well
 // as mmapped shared memory from a file next to the database with suffix `-shm`.
 class SqliteDatabase::Lock {
-public:
+ public:
   // The main database can be locked at one of these levels.
   //
   // See the SQLite documentation for an explanation of lock levels:

--- a/src/workerd/util/stream-utils.c++
+++ b/src/workerd/util/stream-utils.c++
@@ -9,7 +9,7 @@ namespace workerd {
 
 namespace {
 class NullIoStream final: public kj::AsyncIoStream {
-public:
+ public:
   void shutdownWrite() override {}
 
   kj::Promise<void> write(kj::ArrayPtr<const kj::byte> buffer) override {
@@ -36,7 +36,7 @@ public:
 };
 
 class MemoryInputStream final: public kj::AsyncInputStream {
-public:
+ public:
   MemoryInputStream(kj::ArrayPtr<const kj::byte> data): data(data) {}
 
   kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
@@ -46,12 +46,12 @@ public:
     return toRead;
   }
 
-private:
+ private:
   kj::ArrayPtr<const kj::byte> data;
 };
 
 class NeuterableInputStreamImpl final: public NeuterableInputStream {
-public:
+ public:
   NeuterableInputStreamImpl(kj::AsyncInputStream& inner): inner(&inner) {}
 
   void neuter(kj::Exception exception) override {
@@ -76,7 +76,7 @@ public:
     return canceler.wrap(getStream().pumpTo(output, amount));
   }
 
-private:
+ private:
   kj::OneOf<kj::AsyncInputStream*, kj::Exception> inner;
   kj::Canceler canceler;
 
@@ -94,7 +94,7 @@ private:
 };
 
 class NeuterableIoStreamImpl final: public NeuterableIoStream {
-public:
+ public:
   NeuterableIoStreamImpl(kj::AsyncIoStream& inner): inner(&inner) {}
 
   void neuter(kj::Exception reason) override {
@@ -163,7 +163,7 @@ public:
     return getStream().getFd();
   }
 
-private:
+ private:
   kj::OneOf<kj::AsyncIoStream*, kj::Exception> inner;
   kj::Canceler canceler;
 

--- a/src/workerd/util/stream-utils.h
+++ b/src/workerd/util/stream-utils.h
@@ -13,12 +13,12 @@ kj::Own<kj::AsyncInputStream> newMemoryInputStream(kj::StringPtr);
 
 // An InputStream that can be disconnected.
 class NeuterableInputStream: public kj::AsyncInputStream, public kj::Refcounted {
-public:
+ public:
   virtual void neuter(kj::Exception ex) = 0;
 };
 
 class NeuterableIoStream: public kj::AsyncIoStream {
-public:
+ public:
   virtual void neuter(kj::Exception ex) = 0;
 };
 

--- a/src/workerd/util/string-buffer.h
+++ b/src/workerd/util/string-buffer.h
@@ -18,7 +18,7 @@ namespace workerd {
 template <size_t StackSize>
 class StringBuffer {
 
-public:
+ public:
   KJ_DISALLOW_COPY_AND_MOVE(StringBuffer);
 
   explicit StringBuffer(size_t heapChunkSize)
@@ -40,7 +40,7 @@ public:
     return result;
   }
 
-private:
+ private:
   // minimum heap chunk size
   const size_t heapChunkSize;
 

--- a/src/workerd/util/thread-scopes.h
+++ b/src/workerd/util/thread-scopes.h
@@ -24,7 +24,7 @@ namespace workerd {
 //
 // In particular this is used when loading Wasm modules, to properly enable Liftoff and Tier-up.
 class AllowV8BackgroundThreadsScope {
-public:
+ public:
   AllowV8BackgroundThreadsScope();
   ~AllowV8BackgroundThreadsScope() noexcept(false);
 
@@ -69,7 +69,7 @@ void setPredictableModeForTest();
 // changes in a uint64_t. Use this in places where your code cannot call Watchdog::checkIn() and
 // may block for longer than the watchdog timeout, but can still observe forward progress.
 class ThreadProgressCounter {
-public:
+ public:
   // When a ProgressCounter is instantiated, it saves the current value of `counter`. When
   // Watchdog::tryHandleSignal() is called with an active ProgressCounter on the thread, the
   // function compares this saved value with the (possibly updated) current value. If they differ,
@@ -92,7 +92,7 @@ public:
   // the counter is updated.
   static void acknowledgeProgress();
 
-private:
+ private:
   uint64_t savedValue;
   uint64_t& counter;
 
@@ -105,7 +105,7 @@ private:
 // Isolate locks can block for a relatively long time, so we especially try to avoid taking
 // them while any other locks are held.
 class WarnAboutIsolateLockScope {
-public:
+ public:
   WarnAboutIsolateLockScope();
   ~WarnAboutIsolateLockScope() noexcept(false);
   KJ_DISALLOW_COPY(WarnAboutIsolateLockScope);
@@ -114,7 +114,7 @@ public:
 
   static void maybeWarn();
 
-private:
+ private:
   bool released = false;
 };
 }  // namespace workerd

--- a/src/workerd/util/uuid.h
+++ b/src/workerd/util/uuid.h
@@ -29,7 +29,7 @@ kj::String randomUUID(kj::Maybe<kj::EntropySource&> optionalEntropySource);
 //
 // A "null UUID" (a UUID with a value of 0) is considered invalid and is not possible to create.
 class UUID {
-public:
+ public:
   // Create a UUID from upper and lower parts. If the UUID would be null, return kj::none.
   //
   // For example, creating a UUID from upper and lower values of 81985529216486895 and
@@ -63,7 +63,7 @@ public:
     return kj::hashCode(upper, lower);
   }
 
-private:
+ private:
   uint64_t upper;
   uint64_t lower;
 

--- a/src/workerd/util/wait-list.c++
+++ b/src/workerd/util/wait-list.c++
@@ -91,7 +91,7 @@ kj::Promise<void> CrossThreadWaitList::addWaiter() const {
 
 kj::Own<kj::CrossThreadPromiseFulfiller<void>> CrossThreadWaitList::makeSeparateFulfiller() {
   class FulfillerImpl final: public kj::CrossThreadPromiseFulfiller<void> {
-  public:
+   public:
     FulfillerImpl(kj::Own<const State> state): state(kj::mv(state)) {}
     ~FulfillerImpl() noexcept(false) {
       state->lostFulfiller();
@@ -110,7 +110,7 @@ kj::Own<kj::CrossThreadPromiseFulfiller<void>> CrossThreadWaitList::makeSeparate
       return !__atomic_load_n(&state->done, __ATOMIC_ACQUIRE);
     }
 
-  private:
+   private:
     kj::Own<const State> state;
   };
 

--- a/src/workerd/util/wait-list.h
+++ b/src/workerd/util/wait-list.h
@@ -22,7 +22,7 @@ using kj::uint;
 //   turns out to be most convenient. But if you want a separate fulfiller, you can call the
 //   `makeSeparateFulfiller()` method.
 class CrossThreadWaitList {
-public:
+ public:
   struct Options {
     // Enable this if it is common for there to be multiple waiters in the same thread. This avoids
     // sending multiple cross-thread signals in this case, instead sending one signal that all
@@ -68,15 +68,15 @@ public:
   // explicitly.
   kj::Own<kj::CrossThreadPromiseFulfiller<void>> makeSeparateFulfiller();
 
-private:
+ private:
   // Forward declare our private structs so we can name the Map for public use in the source file.
   struct State;
   struct Waiter;
 
-public:
+ public:
   using WaiterMap = kj::HashMap<const CrossThreadWaitList::State*, Waiter*>;
 
-private:
+ private:
   struct Waiter: public kj::Refcounted {
     Waiter(const State& state, kj::Own<kj::CrossThreadPromiseFulfiller<void>> fulfiller);
     ~Waiter() noexcept(false);

--- a/src/workerd/util/weak-refs.h
+++ b/src/workerd/util/weak-refs.h
@@ -16,7 +16,7 @@ namespace workerd {
 // T must itself extend from kj::AtomicRefcounted
 template <typename T>
 class AtomicWeakRef final: public kj::AtomicRefcounted {
-public:
+ public:
   inline static kj::Own<const AtomicWeakRef<T>> wrap(T* this_) {
     return kj::atomicRefcounted<AtomicWeakRef<T>>(this_);
   }
@@ -36,7 +36,7 @@ public:
     return kj::atomicAddRef(*this);
   }
 
-private:
+ private:
   kj::MutexGuarded<const T*> this_;
 
   // This is invoked by the owner destructor to clear the pointer. That means that any racing
@@ -66,7 +66,7 @@ private:
 // kj::WeakOwn<T> type with the same basic characteristics.
 template <typename T>
 class WeakRef final: public kj::Refcounted {
-public:
+ public:
   inline WeakRef(kj::Badge<T>, T& thing): maybeThing(thing) {}
 
   // The use of the kj::Badge<T> in the constructor ensures that the initial instances
@@ -100,7 +100,7 @@ public:
     return maybeThing != kj::none;
   }
 
-private:
+ private:
   friend T;
 
   inline void invalidate() {

--- a/src/workerd/util/xthreadnotifier.h
+++ b/src/workerd/util/xthreadnotifier.h
@@ -18,7 +18,7 @@ class XThreadNotifier final: public kj::AtomicRefcounted {
   //   an executor.executeAsync() promise from an arbitrary thread. Then, if the inspector
   //   session was destroyed in its thread while a cross-thread notification was in-flight, it
   //   could cancel that notification directly.
-public:
+ public:
   static inline kj::Own<XThreadNotifier> create() {
     return kj::atomicRefcounted<XThreadNotifier>();
   }
@@ -38,7 +38,7 @@ public:
     paf.lockExclusive()->fulfiller->fulfill();
   }
 
-private:
+ private:
   kj::MutexGuarded<kj::PromiseCrossThreadFulfillerPair<void>> paf;
 };
 


### PR DESCRIPTION
This improves the readability of unified diffs and Github code reviews.  The diff format tries to tell you the context of the change with a text appended to the @@ line, like so:

@@ -22,7 +22,7 @@ bool contains(kj::StringPtr haystack, kj::StringPtr needle) {

However with our old public/private indentation style we would often not see the class name, but rather just whether we were in the public or private section, like so:

@@ -121,7 +121,7 @@ public: