### PR TITLE
Implements support for external package loading in validator.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,7 @@ common --enable_platform_specific_config
 build --verbose_failures
 build --build_tag_filters=-off-by-default
 test --test_tag_filters=-off-by-default
+test:asan --test_tag_filters=-off-by-default,-no-asan
 # exclude enormous tests by default
 build --test_size_filters=-enormous
 

--- a/src/cloudflare/internal/test/ai/BUILD.bazel
+++ b/src/cloudflare/internal/test/ai/BUILD.bazel
@@ -15,4 +15,8 @@ py_wd_test(
         "*.js",
         "*.py",
     ]),
+    tags = [
+        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
+        "no-asan",
+    ],
 )

--- a/src/cloudflare/internal/test/d1/BUILD.bazel
+++ b/src/cloudflare/internal/test/d1/BUILD.bazel
@@ -24,4 +24,8 @@ py_wd_test(
         "*.py",
         "*.js",
     ]),
+    tags = [
+        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
+        "no-asan",
+    ],
 )

--- a/src/cloudflare/internal/test/vectorize/BUILD.bazel
+++ b/src/cloudflare/internal/test/vectorize/BUILD.bazel
@@ -13,4 +13,8 @@ py_wd_test(
         "*.py",
         "*.js",
     ]),
+    tags = [
+        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
+        "no-asan",
+    ],
 )

--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -5,7 +5,7 @@ import {
   SITE_PACKAGES,
   getSitePackagesPath,
 } from 'pyodide-internal:setupPackages';
-import { default as TarReader } from 'pyodide-internal:packages_tar_reader';
+import { default as EmbeddedPackagesTarReader } from 'pyodide-internal:packages_tar_reader';
 import {
   SHOULD_SNAPSHOT_TO_DISK,
   IS_CREATING_BASELINE_SNAPSHOT,
@@ -136,7 +136,10 @@ export function preloadDynamicLibs(Module: Module): void {
         throw Error('contentsOffset not defined for ' + soFile);
       }
       const wasmModuleData = new Uint8Array(size);
-      TarReader.read(contentsOffset, wasmModuleData);
+      (node.reader ?? EmbeddedPackagesTarReader).read(
+        contentsOffset,
+        wasmModuleData
+      );
       const path = sitePackages + '/' + soFile.join('/');
       PRELOADED_SO_FILES.push(path);
       loadDynlib(Module, path, wasmModuleData);

--- a/src/pyodide/internal/tar.ts
+++ b/src/pyodide/internal/tar.ts
@@ -1,5 +1,3 @@
-import { default as TarReader } from 'pyodide-internal:packages_tar_reader';
-
 // This is based on the info about the tar file format on wikipedia
 // And some trial and error with real tar files.
 // https://en.wikipedia.org/wiki/Tar_(computing)#File_format
@@ -44,7 +42,7 @@ function decodeHeader(buf: Uint8Array, reader: Reader): TarFSInfo {
   };
 }
 
-export function parseTarInfo(reader = TarReader): [TarFSInfo, string[]] {
+export function parseTarInfo(reader: Reader): [TarFSInfo, string[]] {
   const directories: TarFSInfo[] = [];
   const soFiles = [];
   const root: TarFSInfo = {

--- a/src/pyodide/types/FS.d.ts
+++ b/src/pyodide/types/FS.d.ts
@@ -12,7 +12,7 @@ interface TarFSInfo {
   name: string;
   parts: string[];
   contentsOffset?: number;
-  reader?: Reader;
+  reader: Reader | null;
 }
 
 declare type MetadataDirInfo = Map<string, MetadataDirInfo>;

--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -35,10 +35,9 @@ void PyodideBundleManager::setPyodideBundleData(
       kj::mv(version), {.messageReader = kj::mv(messageReader), .bundle = bundle});
 }
 
-const kj::Maybe<kj::ArrayPtr<const unsigned char>> PyodidePackageManager::getPyodidePackage(
+const kj::Maybe<const kj::Array<unsigned char>&> PyodidePackageManager::getPyodidePackage(
     kj::StringPtr id) const {
-  return packages.lockShared()->find(id).map(
-      [](const kj::Array<unsigned char>& t) { return t.asPtr(); });
+  return packages.lockShared()->find(id);
 }
 
 void PyodidePackageManager::setPyodidePackageData(

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -38,7 +38,7 @@ class PyodideBundleManager {
 class PyodidePackageManager {
  public:
   void setPyodidePackageData(kj::String id, kj::Array<unsigned char> data) const;
-  const kj::Maybe<kj::ArrayPtr<const unsigned char>> getPyodidePackage(kj::StringPtr id) const;
+  const kj::Maybe<const kj::Array<unsigned char>&> getPyodidePackage(kj::StringPtr id) const;
 
  private:
   const kj::MutexGuarded<kj::HashMap<kj::String, kj::Array<unsigned char>>> packages;

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -558,6 +558,7 @@ void WorkerdApi::compileModules(jsg::Lock& lockParam,
           makePyodideMetadataReader(conf, impl->pythonConfig), jsg::ModuleRegistry::Type::INTERNAL);
 
       // Inject packages tar file
+      // TODO(later): This shouldn't exist once featureFlags.getPythonExternalPackages() is true.
       modules->addBuiltinModule("pyodide-internal:packages_tar_reader",
           jsg::alloc<ReadOnlyBuffer>(PYODIDE_PACKAGES_TAR.get()),
           workerd::jsg::ModuleRegistry::Type::INTERNAL);


### PR DESCRIPTION
Moves package loading to `prepareWasmLinearMemory` so that `preloadDynamicLibs` can use the loaded packages instead of the embedded ones.

Also fixes a stack-use-after-scope error in `getPyodidePackage`

### Test Plan

```
$ bazel test @workerd//src/cloudflare/internal/test/... --config=asan
```