### PR TITLE
Create and assign an InvocationSpanContext for every invocation

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -201,11 +201,13 @@ IoContext::IoContext(ThreadContext& thread,
 IoContext::IncomingRequest::IoContext_IncomingRequest(kj::Own<IoContext> contextParam,
     kj::Own<IoChannelFactory> ioChannelFactoryParam,
     kj::Own<RequestObserver> metricsParam,
-    kj::Maybe<kj::Own<WorkerTracer>> workerTracer)
+    kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
+    kj::Rc<tracing::InvocationSpanContext> invocationSpanContext)
     : context(kj::mv(contextParam)),
       metrics(kj::mv(metricsParam)),
       workerTracer(kj::mv(workerTracer)),
-      ioChannelFactory(kj::mv(ioChannelFactoryParam)) {}
+      ioChannelFactory(kj::mv(ioChannelFactoryParam)),
+      invocationSpanContext(kj::mv(invocationSpanContext)) {}
 
 // A call to delivered() implies a promise to call drain() later (or one of the other methods
 // that sets waitedForWaitUntil). So, we can now safely add the request to

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -110,7 +110,8 @@ class IoContext_IncomingRequest final {
   IoContext_IncomingRequest(kj::Own<IoContext> context,
       kj::Own<IoChannelFactory> ioChannelFactory,
       kj::Own<RequestObserver> metrics,
-      kj::Maybe<kj::Own<WorkerTracer>> workerTracer);
+      kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
+      kj::Rc<tracing::InvocationSpanContext> invocationSpanContext);
   KJ_DISALLOW_COPY_AND_MOVE(IoContext_IncomingRequest);
   ~IoContext_IncomingRequest() noexcept(false);
 
@@ -160,11 +161,22 @@ class IoContext_IncomingRequest final {
     return workerTracer;
   }
 
+  // The invocation span context is a unique identifier for a specific
+  // worker invocation.
+  kj::Rc<tracing::InvocationSpanContext>& getInvocationSpanContext() {
+    return invocationSpanContext;
+  }
+
  private:
   kj::Own<IoContext> context;
   kj::Own<RequestObserver> metrics;
   kj::Maybe<kj::Own<WorkerTracer>> workerTracer;
   kj::Own<IoChannelFactory> ioChannelFactory;
+
+  // The invocation span context identifies the trace id, invocation id, and root
+  // span for the current request. Every invocation of a worker function always
+  // has a root span, even if it is not explicitly traced.
+  kj::Rc<tracing::InvocationSpanContext> invocationSpanContext;
 
   bool wasDelivered = false;
 

--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -15,6 +15,10 @@ class ThreadContext;
 class WorkerInterface;
 class WorkerTracer;
 
+namespace tracing {
+class InvocationSpanContext;
+};
+
 // Create and return a wrapper around a Worker that handles receiving a new event
 // from the outside. In particular,
 // this handles:
@@ -34,6 +38,11 @@ kj::Own<WorkerInterface> newWorkerEntrypoint(ThreadContext& threadContext,
     kj::TaskSet& waitUntilTasks,
     bool tunnelExceptions,
     kj::Maybe<kj::Own<WorkerTracer>> workerTracer,
-    kj::Maybe<kj::String> cfBlobJson);
+    kj::Maybe<kj::String> cfBlobJson,
+    // The trigger invocation span may be propagated from other request. If it is provided,
+    // the implication is that this worker entrypoint is being created as a subrequest or
+    // subtask of another request. If it is kj::none, then this invocation is a top-level
+    // invocation.
+    kj::Maybe<kj::Rc<tracing::InvocationSpanContext>> maybeTriggerInvocationSpan = kj::none);
 
 }  // namespace workerd

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -405,8 +405,10 @@ void TestFixture::runInIoContext(kj::Function<kj::Promise<void>(const Environmen
 kj::Own<IoContext::IncomingRequest> TestFixture::createIncomingRequest() {
   auto context = kj::refcounted<IoContext>(
       threadContext, kj::atomicAddRef(*worker), actor, kj::heap<MockLimitEnforcer>());
+  auto invocationSpanContext = tracing::InvocationSpanContext::newForInvocation(kj::none, kj::none);
   auto incomingRequest = kj::heap<IoContext::IncomingRequest>(kj::addRef(*context),
-      kj::heap<DummyIoChannelFactory>(*timerChannel), kj::refcounted<RequestObserver>(), nullptr);
+      kj::heap<DummyIoChannelFactory>(*timerChannel), kj::refcounted<RequestObserver>(), nullptr,
+      kj::mv(invocationSpanContext));
   incomingRequest->delivered();
   return incomingRequest;
 }


### PR DESCRIPTION
@fhanau ... please consider this one carefully. What I'm not sure about is whether the `InvocationSpanContext` should be held by the `IncomingRequest` or something internal to the `RequestObserver`.

Eventually I'd like to abstract out the `WorkerTracer` here and actually hide that inside the `RequestObserver` and put it entirely behind `SpanBuilder` but that'll come later. Accordingly, however, I don't want to put `InvocationSpanContext` inside the `WorkerTracer`.

The other thing to keep in mind is that we'll need to be able to propagate the `InvocationSpanContext` across subrequests of various kinds so we'll need easy access to it to place it into things like the control header.

How is this expected to be used? Good question! When streaming tail workers is fully operational, the invocation span context will be recorded with each mark event. Every child span created during the invocation of a worker will become a child off this root and should have its own `kj::Rc<InvocationSpanContext>` and there should always be a "current invocation span context" at any given time during an invocation that is propagated via the async context just like the current SpanParent. The fact that the user SpanBuilder would need to have access to this suggests to me that *maybe* the root `InvocationSpanContext` should be owned by the `RequestObserver` but I'm not entirely sure.