### PR TITLE
Move tracing info types out of Trace class

### DIFF
--- a/src/workerd/api/hibernatable-web-socket.c++
+++ b/src/workerd/api/hibernatable-web-socket.c++
@@ -75,27 +75,27 @@ kj::Promise<WorkerInterface::CustomEvent::Result> HibernatableWebSocketCustomEve
   auto eventParameters = consumeParams();
 
   KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
-    Trace::HibernatableWebSocketEventInfo::Type type =
-        [&]() -> Trace::HibernatableWebSocketEventInfo::Type {
+    tracing::HibernatableWebSocketEventInfo::Type type =
+        [&]() -> tracing::HibernatableWebSocketEventInfo::Type {
       KJ_SWITCH_ONEOF(eventParameters.eventType) {
         KJ_CASE_ONEOF(_, HibernatableSocketParams::Text) {
-          return Trace::HibernatableWebSocketEventInfo::Message{};
+          return tracing::HibernatableWebSocketEventInfo::Message{};
         }
         KJ_CASE_ONEOF(data, HibernatableSocketParams::Data) {
-          return Trace::HibernatableWebSocketEventInfo::Message{};
+          return tracing::HibernatableWebSocketEventInfo::Message{};
         }
         KJ_CASE_ONEOF(close, HibernatableSocketParams::Close) {
-          return Trace::HibernatableWebSocketEventInfo::Close{
+          return tracing::HibernatableWebSocketEventInfo::Close{
             .code = close.code, .wasClean = close.wasClean};
         }
         KJ_CASE_ONEOF(_, HibernatableSocketParams::Error) {
-          return Trace::HibernatableWebSocketEventInfo::Error{};
+          return tracing::HibernatableWebSocketEventInfo::Error{};
         }
       }
       KJ_UNREACHABLE;
     }();
 
-    t.setEventInfo(context.now(), Trace::HibernatableWebSocketEventInfo(kj::mv(type)));
+    t.setEventInfo(context.now(), tracing::HibernatableWebSocketEventInfo(kj::mv(type)));
   }
 
   try {

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -531,7 +531,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEventImpl::run(
   }
 
   KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
-    t.setEventInfo(context.now(), Trace::QueueEventInfo(kj::mv(queueName), batchSize));
+    t.setEventInfo(context.now(), tracing::QueueEventInfo(kj::mv(queueName), batchSize));
   }
 
   // Create a custom refcounted type for holding the queueEvent so that we can pass it to the

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -145,7 +145,7 @@ class TraceItem final: public jsg::Object {
 };
 
 // When adding a new TraceItem eventInfo type, it is important not to
-// try keeping a reference to the Trace and Trace::*EventInfo inputs.
+// try keeping a reference to the Trace and tracing::*EventInfo inputs.
 // They are kj heap objects that have a lifespan that is managed independently
 // of the TraceItem object. Each of the implementations here extract the
 // necessary detail on creation and use LAZY instance properties to minimize
@@ -168,8 +168,8 @@ class TraceItem::FetchEventInfo final: public jsg::Object {
 
   explicit FetchEventInfo(jsg::Lock& js,
       const Trace& trace,
-      const Trace::FetchEventInfo& eventInfo,
-      kj::Maybe<const Trace::FetchResponseInfo&> responseInfo);
+      const tracing::FetchEventInfo& eventInfo,
+      kj::Maybe<const tracing::FetchResponseInfo&> responseInfo);
 
   jsg::Ref<Request> getRequest();
   jsg::Optional<jsg::Ref<Response>> getResponse();
@@ -191,12 +191,12 @@ class TraceItem::FetchEventInfo::Request final: public jsg::Object {
  public:
   struct Detail: public kj::Refcounted {
     jsg::Optional<jsg::V8Ref<v8::Object>> cf;
-    kj::Array<Trace::FetchEventInfo::Header> headers;
+    kj::Array<tracing::FetchEventInfo::Header> headers;
     kj::String method;
     kj::String url;
 
     Detail(jsg::Optional<jsg::V8Ref<v8::Object>> cf,
-        kj::Array<Trace::FetchEventInfo::Header> headers,
+        kj::Array<tracing::FetchEventInfo::Header> headers,
         kj::String method,
         kj::String url);
 
@@ -210,7 +210,7 @@ class TraceItem::FetchEventInfo::Request final: public jsg::Object {
     }
   };
 
-  explicit Request(jsg::Lock& js, const Trace& trace, const Trace::FetchEventInfo& eventInfo);
+  explicit Request(jsg::Lock& js, const Trace& trace, const tracing::FetchEventInfo& eventInfo);
 
   // Creates a possibly unredacted instance that shared a ref of the Detail
   explicit Request(Detail& detail, bool redacted = true);
@@ -242,7 +242,7 @@ class TraceItem::FetchEventInfo::Request final: public jsg::Object {
 
 class TraceItem::FetchEventInfo::Response final: public jsg::Object {
  public:
-  explicit Response(const Trace& trace, const Trace::FetchResponseInfo& responseInfo);
+  explicit Response(const Trace& trace, const tracing::FetchResponseInfo& responseInfo);
 
   uint16_t getStatus();
 
@@ -256,7 +256,7 @@ class TraceItem::FetchEventInfo::Response final: public jsg::Object {
 
 class TraceItem::JsRpcEventInfo final: public jsg::Object {
  public:
-  explicit JsRpcEventInfo(const Trace& trace, const Trace::JsRpcEventInfo& eventInfo);
+  explicit JsRpcEventInfo(const Trace& trace, const tracing::JsRpcEventInfo& eventInfo);
 
   // We call this `rpcMethod` to make clear this is an RPC event, since some tail workers rely
   // on duck-typing EventInfo based on the properties present. (`methodName` might be ambiguous
@@ -279,7 +279,7 @@ class TraceItem::JsRpcEventInfo final: public jsg::Object {
 
 class TraceItem::ScheduledEventInfo final: public jsg::Object {
  public:
-  explicit ScheduledEventInfo(const Trace& trace, const Trace::ScheduledEventInfo& eventInfo);
+  explicit ScheduledEventInfo(const Trace& trace, const tracing::ScheduledEventInfo& eventInfo);
 
   double getScheduledTime();
   kj::StringPtr getCron();
@@ -300,7 +300,7 @@ class TraceItem::ScheduledEventInfo final: public jsg::Object {
 
 class TraceItem::AlarmEventInfo final: public jsg::Object {
  public:
-  explicit AlarmEventInfo(const Trace& trace, const Trace::AlarmEventInfo& eventInfo);
+  explicit AlarmEventInfo(const Trace& trace, const tracing::AlarmEventInfo& eventInfo);
 
   kj::Date getScheduledTime();
 
@@ -314,7 +314,7 @@ class TraceItem::AlarmEventInfo final: public jsg::Object {
 
 class TraceItem::QueueEventInfo final: public jsg::Object {
  public:
-  explicit QueueEventInfo(const Trace& trace, const Trace::QueueEventInfo& eventInfo);
+  explicit QueueEventInfo(const Trace& trace, const tracing::QueueEventInfo& eventInfo);
 
   kj::StringPtr getQueueName();
   uint32_t getBatchSize();
@@ -336,7 +336,7 @@ class TraceItem::QueueEventInfo final: public jsg::Object {
 
 class TraceItem::EmailEventInfo final: public jsg::Object {
  public:
-  explicit EmailEventInfo(const Trace& trace, const Trace::EmailEventInfo& eventInfo);
+  explicit EmailEventInfo(const Trace& trace, const tracing::EmailEventInfo& eventInfo);
 
   kj::StringPtr getMailFrom();
   kj::StringPtr getRcptTo();
@@ -363,7 +363,7 @@ class TraceItem::TailEventInfo final: public jsg::Object {
  public:
   class TailItem;
 
-  explicit TailEventInfo(const Trace& trace, const Trace::TraceEventInfo& eventInfo);
+  explicit TailEventInfo(const Trace& trace, const tracing::TraceEventInfo& eventInfo);
 
   kj::Array<jsg::Ref<TailItem>> getConsumedEvents();
 
@@ -379,7 +379,7 @@ class TraceItem::TailEventInfo final: public jsg::Object {
 
 class TraceItem::TailEventInfo::TailItem final: public jsg::Object {
  public:
-  explicit TailItem(const Trace::TraceEventInfo::TraceItem& traceItem);
+  explicit TailItem(const tracing::TraceEventInfo::TraceItem& traceItem);
 
   kj::Maybe<kj::StringPtr> getScriptName();
 
@@ -402,11 +402,11 @@ class TraceItem::HibernatableWebSocketEventInfo final: public jsg::Object {
   class Error;
 
   explicit HibernatableWebSocketEventInfo(
-      const Trace& trace, const Trace::HibernatableWebSocketEventInfo::Message& eventInfo);
+      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Message& eventInfo);
   explicit HibernatableWebSocketEventInfo(
-      const Trace& trace, const Trace::HibernatableWebSocketEventInfo::Close& eventInfo);
+      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Close& eventInfo);
   explicit HibernatableWebSocketEventInfo(
-      const Trace& trace, const Trace::HibernatableWebSocketEventInfo::Error& eventInfo);
+      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Error& eventInfo);
 
   using Type = kj::OneOf<jsg::Ref<Message>, jsg::Ref<Close>, jsg::Ref<Error>>;
 
@@ -425,7 +425,7 @@ class TraceItem::HibernatableWebSocketEventInfo final: public jsg::Object {
 class TraceItem::HibernatableWebSocketEventInfo::Message final: public jsg::Object {
  public:
   explicit Message(
-      const Trace& trace, const Trace::HibernatableWebSocketEventInfo::Message& eventInfo)
+      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Message& eventInfo)
       : eventInfo(eventInfo) {}
 
   static constexpr kj::StringPtr webSocketEventType = "message"_kj;
@@ -438,12 +438,13 @@ class TraceItem::HibernatableWebSocketEventInfo::Message final: public jsg::Obje
   }
 
  private:
-  const Trace::HibernatableWebSocketEventInfo::Message& eventInfo;
+  const tracing::HibernatableWebSocketEventInfo::Message& eventInfo;
 };
 
 class TraceItem::HibernatableWebSocketEventInfo::Close final: public jsg::Object {
  public:
-  explicit Close(const Trace& trace, const Trace::HibernatableWebSocketEventInfo::Close& eventInfo)
+  explicit Close(
+      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Close& eventInfo)
       : eventInfo(eventInfo) {}
 
   static constexpr kj::StringPtr webSocketEventType = "close"_kj;
@@ -461,12 +462,13 @@ class TraceItem::HibernatableWebSocketEventInfo::Close final: public jsg::Object
   }
 
  private:
-  const Trace::HibernatableWebSocketEventInfo::Close& eventInfo;
+  const tracing::HibernatableWebSocketEventInfo::Close& eventInfo;
 };
 
 class TraceItem::HibernatableWebSocketEventInfo::Error final: public jsg::Object {
  public:
-  explicit Error(const Trace& trace, const Trace::HibernatableWebSocketEventInfo::Error& eventInfo)
+  explicit Error(
+      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Error& eventInfo)
       : eventInfo(eventInfo) {}
 
   static constexpr kj::StringPtr webSocketEventType = "error"_kj;
@@ -479,23 +481,23 @@ class TraceItem::HibernatableWebSocketEventInfo::Error final: public jsg::Object
   }
 
  private:
-  const Trace::HibernatableWebSocketEventInfo::Error& eventInfo;
+  const tracing::HibernatableWebSocketEventInfo::Error& eventInfo;
 };
 
 class TraceItem::CustomEventInfo final: public jsg::Object {
  public:
-  explicit CustomEventInfo(const Trace& trace, const Trace::CustomEventInfo& eventInfo);
+  explicit CustomEventInfo(const Trace& trace, const tracing::CustomEventInfo& eventInfo);
 
   JSG_RESOURCE_TYPE(CustomEventInfo) {}
 
  private:
-  const Trace::CustomEventInfo& eventInfo;
+  const tracing::CustomEventInfo& eventInfo;
 };
 
 class TraceDiagnosticChannelEvent final: public jsg::Object {
  public:
   explicit TraceDiagnosticChannelEvent(
-      const Trace& trace, const Trace::DiagnosticChannelEvent& eventInfo);
+      const Trace& trace, const tracing::DiagnosticChannelEvent& eventInfo);
 
   double getTimestamp();
   kj::StringPtr getChannel();
@@ -520,7 +522,7 @@ class TraceDiagnosticChannelEvent final: public jsg::Object {
 
 class TraceLog final: public jsg::Object {
  public:
-  TraceLog(jsg::Lock& js, const Trace& trace, const Trace::Log& log);
+  TraceLog(jsg::Lock& js, const Trace& trace, const tracing::Log& log);
 
   double getTimestamp();
   kj::StringPtr getLevel();
@@ -545,7 +547,7 @@ class TraceLog final: public jsg::Object {
 
 class TraceException final: public jsg::Object {
  public:
-  TraceException(const Trace& trace, const Trace::Exception& exception);
+  TraceException(const Trace& trace, const tracing::Exception& exception);
 
   double getTimestamp();
   kj::StringPtr getName();

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -1673,7 +1673,7 @@ class EntrypointJsRpcTarget final: public JsRpcTargetBase {
 
   void addTrace(jsg::Lock& js, IoContext& ioctx, kj::StringPtr methodName) override {
     KJ_IF_SOME(t, tracer) {
-      t->setEventInfo(ioctx.now(), Trace::JsRpcEventInfo(kj::str(methodName)));
+      t->setEventInfo(ioctx.now(), tracing::JsRpcEventInfo(kj::str(methodName)));
     }
   }
 };

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -242,14 +242,14 @@ static kj::HttpMethod validateMethod(capnp::HttpMethod method) {
 
 }  // namespace
 
-Trace::FetchEventInfo::FetchEventInfo(
+tracing::FetchEventInfo::FetchEventInfo(
     kj::HttpMethod method, kj::String url, kj::String cfJson, kj::Array<Header> headers)
     : method(method),
       url(kj::mv(url)),
       cfJson(kj::mv(cfJson)),
       headers(kj::mv(headers)) {}
 
-Trace::FetchEventInfo::FetchEventInfo(rpc::Trace::FetchEventInfo::Reader reader)
+tracing::FetchEventInfo::FetchEventInfo(rpc::Trace::FetchEventInfo::Reader reader)
     : method(validateMethod(reader.getMethod())),
       url(kj::str(reader.getUrl())),
       cfJson(kj::str(reader.getCfJson())) {
@@ -258,7 +258,7 @@ Trace::FetchEventInfo::FetchEventInfo(rpc::Trace::FetchEventInfo::Reader reader)
   headers = v.releaseAsArray();
 }
 
-void Trace::FetchEventInfo::copyTo(rpc::Trace::FetchEventInfo::Builder builder) {
+void tracing::FetchEventInfo::copyTo(rpc::Trace::FetchEventInfo::Builder builder) {
   builder.setMethod(static_cast<capnp::HttpMethod>(method));
   builder.setUrl(url);
   builder.setCfJson(cfJson);
@@ -269,145 +269,145 @@ void Trace::FetchEventInfo::copyTo(rpc::Trace::FetchEventInfo::Builder builder) 
   }
 }
 
-Trace::FetchEventInfo::Header::Header(kj::String name, kj::String value)
+tracing::FetchEventInfo::Header::Header(kj::String name, kj::String value)
     : name(kj::mv(name)),
       value(kj::mv(value)) {}
 
-Trace::FetchEventInfo::Header::Header(rpc::Trace::FetchEventInfo::Header::Reader reader)
+tracing::FetchEventInfo::Header::Header(rpc::Trace::FetchEventInfo::Header::Reader reader)
     : name(kj::str(reader.getName())),
       value(kj::str(reader.getValue())) {}
 
-void Trace::FetchEventInfo::Header::copyTo(rpc::Trace::FetchEventInfo::Header::Builder builder) {
+void tracing::FetchEventInfo::Header::copyTo(rpc::Trace::FetchEventInfo::Header::Builder builder) {
   builder.setName(name);
   builder.setValue(value);
 }
 
-Trace::JsRpcEventInfo::JsRpcEventInfo(kj::String methodName): methodName(kj::mv(methodName)) {}
+tracing::JsRpcEventInfo::JsRpcEventInfo(kj::String methodName): methodName(kj::mv(methodName)) {}
 
-Trace::JsRpcEventInfo::JsRpcEventInfo(rpc::Trace::JsRpcEventInfo::Reader reader)
+tracing::JsRpcEventInfo::JsRpcEventInfo(rpc::Trace::JsRpcEventInfo::Reader reader)
     : methodName(kj::str(reader.getMethodName())) {}
 
-void Trace::JsRpcEventInfo::copyTo(rpc::Trace::JsRpcEventInfo::Builder builder) {
+void tracing::JsRpcEventInfo::copyTo(rpc::Trace::JsRpcEventInfo::Builder builder) {
   builder.setMethodName(methodName);
 }
 
-Trace::ScheduledEventInfo::ScheduledEventInfo(double scheduledTime, kj::String cron)
+tracing::ScheduledEventInfo::ScheduledEventInfo(double scheduledTime, kj::String cron)
     : scheduledTime(scheduledTime),
       cron(kj::mv(cron)) {}
 
-Trace::ScheduledEventInfo::ScheduledEventInfo(rpc::Trace::ScheduledEventInfo::Reader reader)
+tracing::ScheduledEventInfo::ScheduledEventInfo(rpc::Trace::ScheduledEventInfo::Reader reader)
     : scheduledTime(reader.getScheduledTime()),
       cron(kj::str(reader.getCron())) {}
 
-void Trace::ScheduledEventInfo::copyTo(rpc::Trace::ScheduledEventInfo::Builder builder) {
+void tracing::ScheduledEventInfo::copyTo(rpc::Trace::ScheduledEventInfo::Builder builder) {
   builder.setScheduledTime(scheduledTime);
   builder.setCron(cron);
 }
 
-Trace::AlarmEventInfo::AlarmEventInfo(kj::Date scheduledTime): scheduledTime(scheduledTime) {}
+tracing::AlarmEventInfo::AlarmEventInfo(kj::Date scheduledTime): scheduledTime(scheduledTime) {}
 
-Trace::AlarmEventInfo::AlarmEventInfo(rpc::Trace::AlarmEventInfo::Reader reader)
+tracing::AlarmEventInfo::AlarmEventInfo(rpc::Trace::AlarmEventInfo::Reader reader)
     : scheduledTime(reader.getScheduledTimeMs() * kj::MILLISECONDS + kj::UNIX_EPOCH) {}
 
-void Trace::AlarmEventInfo::copyTo(rpc::Trace::AlarmEventInfo::Builder builder) {
+void tracing::AlarmEventInfo::copyTo(rpc::Trace::AlarmEventInfo::Builder builder) {
   builder.setScheduledTimeMs((scheduledTime - kj::UNIX_EPOCH) / kj::MILLISECONDS);
 }
 
-Trace::QueueEventInfo::QueueEventInfo(kj::String queueName, uint32_t batchSize)
+tracing::QueueEventInfo::QueueEventInfo(kj::String queueName, uint32_t batchSize)
     : queueName(kj::mv(queueName)),
       batchSize(batchSize) {}
 
-Trace::QueueEventInfo::QueueEventInfo(rpc::Trace::QueueEventInfo::Reader reader)
+tracing::QueueEventInfo::QueueEventInfo(rpc::Trace::QueueEventInfo::Reader reader)
     : queueName(kj::heapString(reader.getQueueName())),
       batchSize(reader.getBatchSize()) {}
 
-void Trace::QueueEventInfo::copyTo(rpc::Trace::QueueEventInfo::Builder builder) {
+void tracing::QueueEventInfo::copyTo(rpc::Trace::QueueEventInfo::Builder builder) {
   builder.setQueueName(queueName);
   builder.setBatchSize(batchSize);
 }
 
-Trace::EmailEventInfo::EmailEventInfo(kj::String mailFrom, kj::String rcptTo, uint32_t rawSize)
+tracing::EmailEventInfo::EmailEventInfo(kj::String mailFrom, kj::String rcptTo, uint32_t rawSize)
     : mailFrom(kj::mv(mailFrom)),
       rcptTo(kj::mv(rcptTo)),
       rawSize(rawSize) {}
 
-Trace::EmailEventInfo::EmailEventInfo(rpc::Trace::EmailEventInfo::Reader reader)
+tracing::EmailEventInfo::EmailEventInfo(rpc::Trace::EmailEventInfo::Reader reader)
     : mailFrom(kj::heapString(reader.getMailFrom())),
       rcptTo(kj::heapString(reader.getRcptTo())),
       rawSize(reader.getRawSize()) {}
 
-void Trace::EmailEventInfo::copyTo(rpc::Trace::EmailEventInfo::Builder builder) {
+void tracing::EmailEventInfo::copyTo(rpc::Trace::EmailEventInfo::Builder builder) {
   builder.setMailFrom(mailFrom);
   builder.setRcptTo(rcptTo);
   builder.setRawSize(rawSize);
 }
 
-kj::Vector<Trace::TraceEventInfo::TraceItem> getTraceItemsFromTraces(
+kj::Vector<tracing::TraceEventInfo::TraceItem> getTraceItemsFromTraces(
     kj::ArrayPtr<kj::Own<Trace>> traces) {
-  return KJ_MAP(t, traces) -> Trace::TraceEventInfo::TraceItem {
-    return Trace::TraceEventInfo::TraceItem(
+  return KJ_MAP(t, traces) -> tracing::TraceEventInfo::TraceItem {
+    return tracing::TraceEventInfo::TraceItem(
         t->scriptName.map([](auto& scriptName) { return kj::str(scriptName); }));
   };
 }
 
-Trace::TraceEventInfo::TraceEventInfo(kj::ArrayPtr<kj::Own<Trace>> traces)
+tracing::TraceEventInfo::TraceEventInfo(kj::ArrayPtr<kj::Own<Trace>> traces)
     : traces(getTraceItemsFromTraces(traces)) {}
 
-kj::Vector<Trace::TraceEventInfo::TraceItem> getTraceItemsFromReader(
+kj::Vector<tracing::TraceEventInfo::TraceItem> getTraceItemsFromReader(
     rpc::Trace::TraceEventInfo::Reader reader) {
-  return KJ_MAP(r, reader.getTraces()) -> Trace::TraceEventInfo::TraceItem {
-    return Trace::TraceEventInfo::TraceItem(r);
+  return KJ_MAP(r, reader.getTraces()) -> tracing::TraceEventInfo::TraceItem {
+    return tracing::TraceEventInfo::TraceItem(r);
   };
 }
 
-Trace::TraceEventInfo::TraceEventInfo(rpc::Trace::TraceEventInfo::Reader reader)
+tracing::TraceEventInfo::TraceEventInfo(rpc::Trace::TraceEventInfo::Reader reader)
     : traces(getTraceItemsFromReader(reader)) {}
 
-void Trace::TraceEventInfo::copyTo(rpc::Trace::TraceEventInfo::Builder builder) {
+void tracing::TraceEventInfo::copyTo(rpc::Trace::TraceEventInfo::Builder builder) {
   auto list = builder.initTraces(traces.size());
   for (auto i: kj::indices(traces)) {
     traces[i].copyTo(list[i]);
   }
 }
 
-Trace::TraceEventInfo::TraceItem::TraceItem(kj::Maybe<kj::String> scriptName)
+tracing::TraceEventInfo::TraceItem::TraceItem(kj::Maybe<kj::String> scriptName)
     : scriptName(kj::mv(scriptName)) {}
 
-Trace::TraceEventInfo::TraceItem::TraceItem(rpc::Trace::TraceEventInfo::TraceItem::Reader reader)
+tracing::TraceEventInfo::TraceItem::TraceItem(rpc::Trace::TraceEventInfo::TraceItem::Reader reader)
     : scriptName(kj::str(reader.getScriptName())) {}
 
-void Trace::TraceEventInfo::TraceItem::copyTo(
+void tracing::TraceEventInfo::TraceItem::copyTo(
     rpc::Trace::TraceEventInfo::TraceItem::Builder builder) {
   KJ_IF_SOME(name, scriptName) {
     builder.setScriptName(name);
   }
 }
 
-Trace::DiagnosticChannelEvent::DiagnosticChannelEvent(
+tracing::DiagnosticChannelEvent::DiagnosticChannelEvent(
     kj::Date timestamp, kj::String channel, kj::Array<kj::byte> message)
     : timestamp(timestamp),
       channel(kj::mv(channel)),
       message(kj::mv(message)) {}
 
-Trace::DiagnosticChannelEvent::DiagnosticChannelEvent(
+tracing::DiagnosticChannelEvent::DiagnosticChannelEvent(
     rpc::Trace::DiagnosticChannelEvent::Reader reader)
     : timestamp(kj::UNIX_EPOCH + reader.getTimestampNs() * kj::NANOSECONDS),
       channel(kj::heapString(reader.getChannel())),
       message(kj::heapArray<kj::byte>(reader.getMessage())) {}
 
-void Trace::DiagnosticChannelEvent::copyTo(rpc::Trace::DiagnosticChannelEvent::Builder builder) {
+void tracing::DiagnosticChannelEvent::copyTo(rpc::Trace::DiagnosticChannelEvent::Builder builder) {
   builder.setTimestampNs((timestamp - kj::UNIX_EPOCH) / kj::NANOSECONDS);
   builder.setChannel(channel);
   builder.setMessage(message);
 }
 
-Trace::HibernatableWebSocketEventInfo::HibernatableWebSocketEventInfo(Type type): type(type) {}
+tracing::HibernatableWebSocketEventInfo::HibernatableWebSocketEventInfo(Type type): type(type) {}
 
-Trace::HibernatableWebSocketEventInfo::HibernatableWebSocketEventInfo(
+tracing::HibernatableWebSocketEventInfo::HibernatableWebSocketEventInfo(
     rpc::Trace::HibernatableWebSocketEventInfo::Reader reader)
     : type(readFrom(reader)) {}
 
-void Trace::HibernatableWebSocketEventInfo::copyTo(
+void tracing::HibernatableWebSocketEventInfo::copyTo(
     rpc::Trace::HibernatableWebSocketEventInfo::Builder builder) {
   auto typeBuilder = builder.initType();
   KJ_SWITCH_ONEOF(type) {
@@ -425,7 +425,7 @@ void Trace::HibernatableWebSocketEventInfo::copyTo(
   }
 }
 
-Trace::HibernatableWebSocketEventInfo::Type Trace::HibernatableWebSocketEventInfo::readFrom(
+tracing::HibernatableWebSocketEventInfo::Type tracing::HibernatableWebSocketEventInfo::readFrom(
     rpc::Trace::HibernatableWebSocketEventInfo::Reader reader) {
   auto type = reader.getType();
   switch (type.which()) {
@@ -445,21 +445,21 @@ Trace::HibernatableWebSocketEventInfo::Type Trace::HibernatableWebSocketEventInf
   }
 }
 
-Trace::FetchResponseInfo::FetchResponseInfo(uint16_t statusCode): statusCode(statusCode) {}
+tracing::FetchResponseInfo::FetchResponseInfo(uint16_t statusCode): statusCode(statusCode) {}
 
-Trace::FetchResponseInfo::FetchResponseInfo(rpc::Trace::FetchResponseInfo::Reader reader)
+tracing::FetchResponseInfo::FetchResponseInfo(rpc::Trace::FetchResponseInfo::Reader reader)
     : statusCode(reader.getStatusCode()) {}
 
-void Trace::FetchResponseInfo::copyTo(rpc::Trace::FetchResponseInfo::Builder builder) {
+void tracing::FetchResponseInfo::copyTo(rpc::Trace::FetchResponseInfo::Builder builder) {
   builder.setStatusCode(statusCode);
 }
 
-Trace::Log::Log(kj::Date timestamp, LogLevel logLevel, kj::String message)
+tracing::Log::Log(kj::Date timestamp, LogLevel logLevel, kj::String message)
     : timestamp(timestamp),
       logLevel(logLevel),
       message(kj::mv(message)) {}
 
-Trace::Exception::Exception(
+tracing::Exception::Exception(
     kj::Date timestamp, kj::String name, kj::String message, kj::Maybe<kj::String> stack)
     : timestamp(timestamp),
       name(kj::mv(name)),
@@ -541,39 +541,39 @@ void Trace::copyTo(rpc::Trace::Builder builder) {
   auto eventInfoBuilder = builder.initEventInfo();
   KJ_IF_SOME(e, eventInfo) {
     KJ_SWITCH_ONEOF(e) {
-      KJ_CASE_ONEOF(fetch, FetchEventInfo) {
+      KJ_CASE_ONEOF(fetch, tracing::FetchEventInfo) {
         auto fetchBuilder = eventInfoBuilder.initFetch();
         fetch.copyTo(fetchBuilder);
       }
-      KJ_CASE_ONEOF(jsRpc, JsRpcEventInfo) {
+      KJ_CASE_ONEOF(jsRpc, tracing::JsRpcEventInfo) {
         auto jsRpcBuilder = eventInfoBuilder.initJsRpc();
         jsRpc.copyTo(jsRpcBuilder);
       }
-      KJ_CASE_ONEOF(scheduled, ScheduledEventInfo) {
+      KJ_CASE_ONEOF(scheduled, tracing::ScheduledEventInfo) {
         auto scheduledBuilder = eventInfoBuilder.initScheduled();
         scheduled.copyTo(scheduledBuilder);
       }
-      KJ_CASE_ONEOF(alarm, AlarmEventInfo) {
+      KJ_CASE_ONEOF(alarm, tracing::AlarmEventInfo) {
         auto alarmBuilder = eventInfoBuilder.initAlarm();
         alarm.copyTo(alarmBuilder);
       }
-      KJ_CASE_ONEOF(queue, QueueEventInfo) {
+      KJ_CASE_ONEOF(queue, tracing::QueueEventInfo) {
         auto queueBuilder = eventInfoBuilder.initQueue();
         queue.copyTo(queueBuilder);
       }
-      KJ_CASE_ONEOF(email, EmailEventInfo) {
+      KJ_CASE_ONEOF(email, tracing::EmailEventInfo) {
         auto emailBuilder = eventInfoBuilder.initEmail();
         email.copyTo(emailBuilder);
       }
-      KJ_CASE_ONEOF(trace, TraceEventInfo) {
+      KJ_CASE_ONEOF(trace, tracing::TraceEventInfo) {
         auto traceBuilder = eventInfoBuilder.initTrace();
         trace.copyTo(traceBuilder);
       }
-      KJ_CASE_ONEOF(hibWs, HibernatableWebSocketEventInfo) {
+      KJ_CASE_ONEOF(hibWs, tracing::HibernatableWebSocketEventInfo) {
         auto hibWsBuilder = eventInfoBuilder.initHibernatableWebSocket();
         hibWs.copyTo(hibWsBuilder);
       }
-      KJ_CASE_ONEOF(custom, CustomEventInfo) {
+      KJ_CASE_ONEOF(custom, tracing::CustomEventInfo) {
         eventInfoBuilder.initCustom();
       }
     }
@@ -594,13 +594,13 @@ void Trace::copyTo(rpc::Trace::Builder builder) {
   }
 }
 
-void Trace::Log::copyTo(rpc::Trace::Log::Builder builder) {
+void tracing::Log::copyTo(rpc::Trace::Log::Builder builder) {
   builder.setTimestampNs((timestamp - kj::UNIX_EPOCH) / kj::NANOSECONDS);
   builder.setLogLevel(logLevel);
   builder.setMessage(message);
 }
 
-void Trace::Exception::copyTo(rpc::Trace::Exception::Builder builder) {
+void tracing::Exception::copyTo(rpc::Trace::Exception::Builder builder) {
   builder.setTimestampNs((timestamp - kj::UNIX_EPOCH) / kj::NANOSECONDS);
   builder.setName(name);
   builder.setMessage(message);
@@ -661,31 +661,31 @@ void Trace::mergeFrom(rpc::Trace::Reader reader, PipelineLogLevel pipelineLogLev
     auto e = reader.getEventInfo();
     switch (e.which()) {
       case rpc::Trace::EventInfo::Which::FETCH:
-        eventInfo = FetchEventInfo(e.getFetch());
+        eventInfo = tracing::FetchEventInfo(e.getFetch());
         break;
       case rpc::Trace::EventInfo::Which::JS_RPC:
-        eventInfo = JsRpcEventInfo(e.getJsRpc());
+        eventInfo = tracing::JsRpcEventInfo(e.getJsRpc());
         break;
       case rpc::Trace::EventInfo::Which::SCHEDULED:
-        eventInfo = ScheduledEventInfo(e.getScheduled());
+        eventInfo = tracing::ScheduledEventInfo(e.getScheduled());
         break;
       case rpc::Trace::EventInfo::Which::ALARM:
-        eventInfo = AlarmEventInfo(e.getAlarm());
+        eventInfo = tracing::AlarmEventInfo(e.getAlarm());
         break;
       case rpc::Trace::EventInfo::Which::QUEUE:
-        eventInfo = QueueEventInfo(e.getQueue());
+        eventInfo = tracing::QueueEventInfo(e.getQueue());
         break;
       case rpc::Trace::EventInfo::Which::EMAIL:
-        eventInfo = EmailEventInfo(e.getEmail());
+        eventInfo = tracing::EmailEventInfo(e.getEmail());
         break;
       case rpc::Trace::EventInfo::Which::TRACE:
-        eventInfo = TraceEventInfo(e.getTrace());
+        eventInfo = tracing::TraceEventInfo(e.getTrace());
         break;
       case rpc::Trace::EventInfo::Which::HIBERNATABLE_WEB_SOCKET:
-        eventInfo = HibernatableWebSocketEventInfo(e.getHibernatableWebSocket());
+        eventInfo = tracing::HibernatableWebSocketEventInfo(e.getHibernatableWebSocket());
         break;
       case rpc::Trace::EventInfo::Which::CUSTOM:
-        eventInfo = CustomEventInfo(e.getCustom());
+        eventInfo = tracing::CustomEventInfo(e.getCustom());
         break;
       case rpc::Trace::EventInfo::Which::NONE:
         eventInfo = kj::none;
@@ -694,15 +694,15 @@ void Trace::mergeFrom(rpc::Trace::Reader reader, PipelineLogLevel pipelineLogLev
   }
 
   if (reader.hasResponse()) {
-    fetchResponseInfo = FetchResponseInfo(reader.getResponse());
+    fetchResponseInfo = tracing::FetchResponseInfo(reader.getResponse());
   }
 }
 
-Trace::Log::Log(rpc::Trace::Log::Reader reader)
+tracing::Log::Log(rpc::Trace::Log::Reader reader)
     : timestamp(kj::UNIX_EPOCH + reader.getTimestampNs() * kj::NANOSECONDS),
       logLevel(reader.getLogLevel()),
       message(kj::str(reader.getMessage())) {}
-Trace::Exception::Exception(rpc::Trace::Exception::Reader reader)
+tracing::Exception::Exception(rpc::Trace::Exception::Reader reader)
     : timestamp(kj::UNIX_EPOCH + reader.getTimestampNs() * kj::NANOSECONDS),
       name(kj::str(reader.getName())),
       message(kj::str(reader.getMessage())) {
@@ -827,7 +827,7 @@ void WorkerTracer::log(kj::Date timestamp, LogLevel logLevel, kj::String message
   if (pipelineLogLevel == PipelineLogLevel::NONE) {
     return;
   }
-  size_t newSize = trace->bytesUsed + sizeof(Trace::Log) + message.size();
+  size_t newSize = trace->bytesUsed + sizeof(tracing::Log) + message.size();
   if (newSize > MAX_TRACE_BYTES) {
     trace->exceededLogLimit = true;
     trace->truncated = true;
@@ -900,7 +900,7 @@ void WorkerTracer::addException(
   if (pipelineLogLevel == PipelineLogLevel::NONE) {
     return;
   }
-  size_t newSize = trace->bytesUsed + sizeof(Trace::Exception) + name.size() + message.size();
+  size_t newSize = trace->bytesUsed + sizeof(tracing::Exception) + name.size() + message.size();
   KJ_IF_SOME(s, stack) {
     newSize += s.size();
   }
@@ -924,7 +924,7 @@ void WorkerTracer::addDiagnosticChannelEvent(
     return;
   }
   size_t newSize =
-      trace->bytesUsed + sizeof(Trace::DiagnosticChannelEvent) + channel.size() + message.size();
+      trace->bytesUsed + sizeof(tracing::DiagnosticChannelEvent) + channel.size() + message.size();
   if (newSize > MAX_TRACE_BYTES) {
     trace->exceededDiagnosticChannelEventLimit = true;
     trace->truncated = true;
@@ -936,7 +936,7 @@ void WorkerTracer::addDiagnosticChannelEvent(
   trace->diagnosticChannelEvents.add(timestamp, kj::mv(channel), kj::mv(message));
 }
 
-void WorkerTracer::setEventInfo(kj::Date timestamp, Trace::EventInfo&& info) {
+void WorkerTracer::setEventInfo(kj::Date timestamp, tracing::EventInfo&& info) {
   KJ_ASSERT(trace->eventInfo == kj::none, "tracer can only be used for a single event");
 
   // TODO(someday): For now, we're using logLevel == none as a hint to avoid doing anything
@@ -952,7 +952,7 @@ void WorkerTracer::setEventInfo(kj::Date timestamp, Trace::EventInfo&& info) {
 
   size_t newSize = trace->bytesUsed;
   KJ_SWITCH_ONEOF(info) {
-    KJ_CASE_ONEOF(fetch, Trace::FetchEventInfo) {
+    KJ_CASE_ONEOF(fetch, tracing::FetchEventInfo) {
       newSize += fetch.url.size();
       for (const auto& header: fetch.headers) {
         newSize += header.name.size() + header.value.size();
@@ -962,18 +962,11 @@ void WorkerTracer::setEventInfo(kj::Date timestamp, Trace::EventInfo&& info) {
         trace->truncated = true;
         trace->logs.add(timestamp, LogLevel::WARN,
             kj::str("[\"Trace resource limit exceeded; could not capture event info.\"]"));
-        trace->eventInfo = Trace::FetchEventInfo(fetch.method, {}, {}, {});
+        trace->eventInfo = tracing::FetchEventInfo(fetch.method, {}, {}, {});
         return;
       }
     }
-    KJ_CASE_ONEOF(_, Trace::JsRpcEventInfo) {}
-    KJ_CASE_ONEOF(_, Trace::ScheduledEventInfo) {}
-    KJ_CASE_ONEOF(_, Trace::AlarmEventInfo) {}
-    KJ_CASE_ONEOF(_, Trace::QueueEventInfo) {}
-    KJ_CASE_ONEOF(_, Trace::EmailEventInfo) {}
-    KJ_CASE_ONEOF(_, Trace::TraceEventInfo) {}
-    KJ_CASE_ONEOF(_, Trace::HibernatableWebSocketEventInfo) {}
-    KJ_CASE_ONEOF(_, Trace::CustomEventInfo) {}
+    KJ_CASE_ONEOF_DEFAULT {}
   }
   trace->bytesUsed = newSize;
   trace->eventInfo = kj::mv(info);
@@ -991,7 +984,7 @@ void WorkerTracer::setWallTime(kj::Duration wallTime) {
   trace->wallTime = wallTime;
 }
 
-void WorkerTracer::setFetchResponseInfo(Trace::FetchResponseInfo&& info) {
+void WorkerTracer::setFetchResponseInfo(tracing::FetchResponseInfo&& info) {
   // Match the behavior of setEventInfo(). Any resolution of the TODO comments
   // in setEventInfo() that are related to this check while probably also affect
   // this function.
@@ -999,7 +992,7 @@ void WorkerTracer::setFetchResponseInfo(Trace::FetchResponseInfo&& info) {
     return;
   }
 
-  KJ_REQUIRE(KJ_REQUIRE_NONNULL(trace->eventInfo).is<Trace::FetchEventInfo>());
+  KJ_REQUIRE(KJ_REQUIRE_NONNULL(trace->eventInfo).is<tracing::FetchEventInfo>());
   KJ_ASSERT(trace->fetchResponseInfo == kj::none, "setFetchResponseInfo can only be called once");
   trace->fetchResponseInfo = kj::mv(info);
 }

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -254,11 +254,11 @@ kj::Promise<void> WorkerEntrypoint::request(kj::HttpMethod method,
       slot.add(value);
     });
     auto traceHeadersArray = KJ_MAP(entry, traceHeaders) {
-      return Trace::FetchEventInfo::Header(kj::mv(entry.key), kj::strArray(entry.value, ", "));
+      return tracing::FetchEventInfo::Header(kj::mv(entry.key), kj::strArray(entry.value, ", "));
     };
 
     t.setEventInfo(timestamp,
-        Trace::FetchEventInfo(method, kj::str(url), kj::mv(cfJson), kj::mv(traceHeadersArray)));
+        tracing::FetchEventInfo(method, kj::str(url), kj::mv(cfJson), kj::mv(traceHeadersArray)));
   }
 
   auto metricsForCatch = kj::addRef(incomingRequest->getMetrics());
@@ -478,7 +478,7 @@ kj::Promise<WorkerInterface::ScheduledResult> WorkerEntrypoint::runScheduled(
 
   KJ_IF_SOME(t, context.getWorkerTracer()) {
     double eventTime = (scheduledTime - kj::UNIX_EPOCH) / kj::MILLISECONDS;
-    t.setEventInfo(context.now(), Trace::ScheduledEventInfo(eventTime, kj::str(cron)));
+    t.setEventInfo(context.now(), tracing::ScheduledEventInfo(eventTime, kj::str(cron)));
   }
 
   // Scheduled handlers run entirely in waitUntil() tasks.
@@ -536,7 +536,7 @@ kj::Promise<WorkerInterface::AlarmResult> WorkerEntrypoint::runAlarmImpl(
   incomingRequest->delivered();
 
   KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
-    t.setEventInfo(context.now(), Trace::AlarmEventInfo(scheduledTime));
+    t.setEventInfo(context.now(), tracing::AlarmEventInfo(scheduledTime));
   }
 
   auto scheduleAlarmResult = co_await actor.scheduleAlarm(scheduledTime);

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1453,7 +1453,7 @@ class RequestObserverWithTracer final: public RequestObserver, public WorkerInte
   ~RequestObserverWithTracer() noexcept(false) {
     KJ_IF_SOME(t, tracer) {
       if (fetchStatus != 0) {
-        t->setFetchResponseInfo(Trace::FetchResponseInfo(fetchStatus));
+        t->setFetchResponseInfo(tracing::FetchResponseInfo(fetchStatus));
       }
       t->setCPUTime(0 * kj::MILLISECONDS);
       t->setWallTime(0 * kj::MILLISECONDS);


### PR DESCRIPTION
These will be reused by the streaming Trace implementation that does not use the Trace class. Separate them out.

No functional changes here beyond marking the class as final and deprecating the aliases.