### PR TITLE
SQC-333: Revert previous changes

### DIFF
--- a/src/workerd/api/hyperdrive.c++
+++ b/src/workerd/api/hyperdrive.c++
@@ -80,7 +80,7 @@ uint16_t Hyperdrive::getPort() {
 
 kj::String Hyperdrive::getConnectionString() {
   return kj::str(getScheme(), "://", getUser(), ":", getPassword(), "@", getHost(), ":", getPort(),
-      "/", getDatabase(), "?sslmode=prefer");
+      "/", getDatabase(), "?sslmode=disable");
 }
 
 kj::Promise<kj::Own<kj::AsyncIoStream>> Hyperdrive::connectToDb() {


### PR DESCRIPTION
This commit reverts 1149737171addcb3705314ce56eaa2196f449710. The sslmode change in the previous commit does not work as expected. Connection attempts time out, presumably getting hung while negotiating SSL upgrade. Revert this change until we have the bandwidth to attempt it again.