### PR TITLE
No need to throw when closing a WritableStream that's already closing

### DIFF
--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -1020,8 +1020,7 @@ void WritableStreamInternalController::setHighWaterMark(uint64_t highWaterMark) 
 
 jsg::Promise<void> WritableStreamInternalController::closeImpl(jsg::Lock& js, bool markAsHandled) {
   if (isClosedOrClosing()) {
-    auto reason = js.v8TypeError("This WritableStream has been closed."_kj);
-    return rejectedMaybeHandledPromise<void>(js, reason, markAsHandled);
+    return js.resolvedPromise();
   }
   if (isPiping()) {
     auto reason = js.v8TypeError("This WritableStream is currently being piped to."_kj);


### PR DESCRIPTION
This should at least handle @mrbbot's original repro here: https://github.com/cloudflare/workerd/issues/992

Need to determine if there are other issues given the other comments in that thread. They appear to be unrelated but the examples given are not clear enough to make a proper repro