### PR TITLE
Fixup TransformStream backpressure

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -660,4 +660,12 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # When enabled, use of top-level await syntax in require() calls will be disallowed.
   # The ecosystem and runtimes are moving to a state where top level await in modules
   # is being strongly discouraged.
+
+  fixupTransformStreamBackpressure @68 :Bool
+      $compatEnableFlag("fixup-transform-stream-backpressure")
+      $compatDisableFlag("original-transform-stream-backpressure")
+      $compatEnableDate("2024-12-16");
+  # A bug in the original implementation of TransformStream failed to apply backpressure
+  # correctly. The fix, however, can break existing implementations that don't account
+  # for the bug so we need to put the fix behind a compat flag.
 }


### PR DESCRIPTION
The TransformStream would originally start with backpressure enabled as it is supposed to but we failed to reapply backpressure when items were enqueued. This meant that after the first write to the TransformStream, no backpressure signaling would occur. Doh! This fixes it.

Unfortunately a compat flag is necessary because suddenly enforcing backpressure correctly could break existing workers that failed to realize it was broken. I noticed this because making the change broke one of our tests.

```
export default {
  async fetch(req, env, ctx) {

    async function sleep(ns) {
      await new Promise((res) => setTimeout(res, ns));
    }

    const strategy = new ByteLengthQueuingStrategy({ highWaterMark: 2024 });

    const { writable, readable } = new TransformStream(undefined, strategy);

    let writes = 0, reads = 0;

    // Start writing chunks to the stream
    async function write(writable) {
      const writer = writable.getWriter();
      for (let n = 0; n < 10000; n++) {
        console.log('waiting on backpressure', writer.ready, writer.desiredSize);
        // To correctly await on backpressure, wait on the writer.ready promise
        await writer.ready;
        console.log('backpressure cleared. writing a chunk');
        // You can also wait on the write.write but doing so is unnecessary if you're awaiting
        // on the writer.ready and can actually hurt performance by reducing writer throughput
        writer.write(crypto.getRandomValues(new Uint8Array(1024)));
        console.log('chunk written', ++writes, writer.desiredSize);
      }
      await writer.close();
      console.log('done writing');
    }

    async function read(readable) {
      console.log('reading pending...');
      await sleep(5_000);

      console.log('reading....');
      for await (const chunk of readable) {
        console.log(`read ${chunk.length}`, ++reads);
        await sleep(100);
      }
      console.log('done reading');
    }

    await Promise.all([
      write(writable),
      read(readable)
    ]);

    return new Response("Hello World\n");
  }
};
```