### PR TITLE
feat: workflow types support generic params

### DIFF
--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -22,7 +22,7 @@ declare abstract class NonRetryableError extends Error {
   public constructor(message: string, name?: string);
 }
 
-declare abstract class Workflow {
+declare abstract class Workflow<PARAMS = unknown> {
   /**
    * Get a handle to an existing instance of the Workflow.
    * @param id Id for the instance of this Workflow
@@ -36,11 +36,11 @@ declare abstract class Workflow {
    * @returns A promise that resolves with a handle for the Instance
    */
   public create(
-    options?: WorkflowInstanceCreateOptions
+    options?: WorkflowInstanceCreateOptions<PARAMS>
   ): Promise<WorkflowInstance>;
 }
 
-interface WorkflowInstanceCreateOptions {
+interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**
    * An id for your Workflow instance. Must be unique within the Workflow.
    * This is automatically generated if not passed in.
@@ -49,7 +49,7 @@ interface WorkflowInstanceCreateOptions {
   /**
    * The event payload the Workflow instance is triggered with
    */
-  params?: unknown;
+  params?: PARAMS;
 }
 
 type InstanceStatus = {

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -8,7 +8,7 @@ declare module "cloudflare:workflows" {
   }
 }
 
-declare abstract class Workflow {
+declare abstract class Workflow<PARAMS = unknown> {
   /**
    * Get a handle to an existing instance of the Workflow.
    * @param id Id for the instance of this Workflow
@@ -22,11 +22,11 @@ declare abstract class Workflow {
    * @returns A promise that resolves with a handle for the Instance
    */
   public create(
-    options?: WorkflowInstanceCreateOptions
+    options?: WorkflowInstanceCreateOptions<PARAMS>
   ): Promise<WorkflowInstance>;
 }
 
-interface WorkflowInstanceCreateOptions {
+interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**
    * An id for your Workflow instance. Must be unique within the Workflow.
    */
@@ -34,7 +34,7 @@ interface WorkflowInstanceCreateOptions {
   /**
    * The event payload the Workflow instance is triggered with
    */
-  params?: unknown;
+  params?: PARAMS;
 }
 
 type InstanceStatus = {


### PR DESCRIPTION
Improves types usability, instead of writing

```ts
type Env {
   MY_WORKFLOW: Workflow;
}

// ... some logic in other file
env.MY_WORKFLOW.create({
  params: {
     some_param: 1
   } as MyWorkflowParams
 });
```

We could do something like

```ts
type Env {
   MY_WORKFLOW: Workflow<MyWorkflowParams>;
}

// ... some logic in other file
env.MY_WORKFLOW.create({
  params: {
     some_param: 1
   }
});
```