### PR TITLE
add stub implementation for node:dns

### DIFF
--- a/src/node/dns.ts
+++ b/src/node/dns.ts
@@ -1,0 +1,47 @@
+import { default as dnsUtil } from 'node-internal:dns';
+
+export const getServers = dnsUtil.getServers.bind(dnsUtil);
+export const lookup = dnsUtil.lookup.bind(dnsUtil);
+export const lookupService = dnsUtil.lookupService.bind(dnsUtil);
+export const resolve = dnsUtil.resolve.bind(dnsUtil);
+export const resolve4 = dnsUtil.resolve4.bind(dnsUtil);
+export const resolve6 = dnsUtil.resolve6.bind(dnsUtil);
+export const resolveAny = dnsUtil.resolveAny.bind(dnsUtil);
+export const resolveCname = dnsUtil.resolveCname.bind(dnsUtil);
+export const resolveCaa = dnsUtil.resolveCaa.bind(dnsUtil);
+export const resolveMx = dnsUtil.resolveMx.bind(dnsUtil);
+export const resolveNaptr = dnsUtil.resolveNaptr.bind(dnsUtil);
+export const resolveNs = dnsUtil.resolveNs.bind(dnsUtil);
+export const resolvePtr = dnsUtil.resolvePtr.bind(dnsUtil);
+export const resolveSoa = dnsUtil.resolveSoa.bind(dnsUtil);
+export const resolveSrv = dnsUtil.resolveSrv.bind(dnsUtil);
+export const resolveTxt = dnsUtil.resolveTxt.bind(dnsUtil);
+export const reverse = dnsUtil.reverse.bind(dnsUtil);
+export const setDefaultResultOrder =
+  dnsUtil.setDefaultResultOrder.bind(dnsUtil);
+export const getDefaultResultOrder =
+  dnsUtil.getDefaultResultOrder.bind(dnsUtil);
+export const setServers = dnsUtil.setServers.bind(dnsUtil);
+
+export default {
+  getServers,
+  lookup,
+  lookupService,
+  resolve,
+  resolve4,
+  resolve6,
+  resolveAny,
+  resolveCname,
+  resolveCaa,
+  resolveMx,
+  resolveNaptr,
+  resolveNs,
+  resolvePtr,
+  resolveSoa,
+  resolveSrv,
+  resolveTxt,
+  reverse,
+  setDefaultResultOrder,
+  getDefaultResultOrder,
+  setServers,
+};

--- a/src/node/internal/dns.d.ts
+++ b/src/node/internal/dns.d.ts
@@ -1,0 +1,60 @@
+export function getServers(): string[];
+
+export type LookupOptions = {
+  family: number | string;
+  hints: number;
+  all: boolean;
+  order: string;
+  verbatim: boolean;
+};
+export function lookup(
+  hostname: string,
+  options: LookupOptions,
+  callback: unknown
+): void;
+
+export function lookupService(
+  address: string,
+  port: number,
+  callback: unknown
+): void;
+
+export function resolve(
+  hostname: string,
+  rrtype: string,
+  callback: unknown
+): void;
+
+export type Resolve4Options = {
+  ttl: boolean;
+};
+export function resolve4(
+  hostname: string,
+  options: Resolve4Options,
+  callback: unknown
+): void;
+
+export type Resolve6Options = {
+  ttl: boolean;
+};
+export function resolve6(
+  hostname: string,
+  options: Resolve6Options,
+  callback: unknown
+): void;
+
+export function resolveAny(hostname: string, callback: unknown): void;
+export function resolveCname(hostname: string, callback: unknown): void;
+export function resolveCaa(hostname: string, callback: unknown): void;
+export function resolveMx(hostname: string, callback: unknown): void;
+export function resolveNaptr(hostname: string, callback: unknown): void;
+export function resolveNs(hostname: string, callback: unknown): void;
+export function resolvePtr(hostname: string, callback: unknown): void;
+export function resolveSoa(hostname: string, callback: unknown): void;
+export function resolveSrv(hostname: string, callback: unknown): void;
+export function resolveTxt(hostname: string, callback: unknown): void;
+export function reverse(ip: string, callback: unknown): void;
+
+export function setDefaultResultOrder(order: string): void;
+export function getDefaultResultOrder(): string;
+export function setServers(servers: string[]): string;

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -9,11 +9,13 @@ wd_cc_library(
         "crypto.c++",
         "crypto-keys.c++",
         "diagnostics-channel.c++",
+        "dns.c++",
         "zlib-util.c++",
     ],
     hdrs = [
         "crypto.h",
         "diagnostics-channel.h",
+        "dns.h",
         "node.h",
         "zlib-util.h",
     ],
@@ -242,4 +244,10 @@ wd_test(
         ":debug_build": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+)
+
+wd_test(
+    src = "tests/dns-nodejs-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/dns-nodejs-test.js"],
 )

--- a/src/workerd/api/node/dns.c++
+++ b/src/workerd/api/node/dns.c++
@@ -1,0 +1,94 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+#include "dns.h"
+
+namespace workerd::api::node {
+kj::Array<kj::String> DnsUtil::getServers(jsg::Lock& js) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::lookup(jsg::Lock& js,
+    kj::String hostname,
+    jsg::Optional<LookupOptions> options,
+    LookupCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::lookupService(
+    jsg::Lock& js, kj::String address, kj::uint port, LookupServiceCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::resolve(
+    jsg::Lock& js, kj::String hostname, kj::String rrtype, ResolveCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::resolve4(
+    jsg::Lock& js, kj::String hostname, Resolve4Options options, Resolve6Callback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::resolve6(
+    jsg::Lock& js, kj::String hostname, Resolve6Options options, Resolve6Callback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::resolveAny(jsg::Lock& js, kj::String hostname, ResolveAnyCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::resolveCname(jsg::Lock& js, kj::String hostname, ResolveCnameCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::resolveCaa(jsg::Lock& js, kj::String hostname, ResolveCaaCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::resolveMx(jsg::Lock& js, kj::String hostname, ResolveMxCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::resolveNaptr(jsg::Lock& js, kj::String hostname, ResolveNaptrCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::resolveNs(jsg::Lock& js, kj::String hostname, ResolveNsCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::resolvePtr(jsg::Lock& js, kj::String hostname, ResolvePtrCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::resolveSoa(jsg::Lock& js, kj::String hostname, ResolveSoaCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::resolveSrv(jsg::Lock& js, kj::String hostname, ResolveSrvCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::resolveTxt(jsg::Lock& js, kj::String hostname, ResolveTxtCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::reverse(jsg::Lock& js, kj::String ip, ReverseCallback callback) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::setDefaultResultOrder(jsg::Lock& js, kj::String order) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+kj::StringPtr DnsUtil::getDefaultResultOrder(jsg::Lock& js) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+void DnsUtil::setServers(kj::Array<kj::String> servers) {
+  JSG_FAIL_REQUIRE(Error, "Not implemented"_kj);
+}
+
+}  // namespace workerd::api::node

--- a/src/workerd/api/node/dns.h
+++ b/src/workerd/api/node/dns.h
@@ -1,0 +1,127 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+#pragma once
+
+#include <workerd/jsg/jsg.h>
+
+#include <kj/string.h>
+
+namespace workerd::api::node {
+
+class DnsUtil final: public jsg::Object {
+ public:
+  DnsUtil() = default;
+  DnsUtil(jsg::Lock&, const jsg::Url&) {}
+
+  kj::Array<kj::String> getServers(jsg::Lock& js);
+
+  struct LookupOptions {
+    kj::OneOf<kj::String, kj::uint> family = static_cast<kj::uint>(0);
+    kj::uint hints;
+    bool all = false;
+    jsg::Optional<kj::String> order;
+    bool verbatim = true;
+
+    JSG_STRUCT(family, hints, all, order, verbatim);
+  };
+  using LookupCallback = jsg::Function<void(void)>;
+  void lookup(jsg::Lock& js,
+      kj::String hostname,
+      jsg::Optional<LookupOptions> options,
+      LookupCallback callback);
+
+  using LookupServiceCallback = jsg::Function<void(void)>;
+  void lookupService(
+      jsg::Lock& js, kj::String address, kj::uint port, LookupServiceCallback callback);
+
+  using ResolveCallback = jsg::Function<void(void)>;
+  void resolve(jsg::Lock& js, kj::String hostname, kj::String rrtype, ResolveCallback callback);
+
+  struct Resolve4Options {
+    bool ttl;
+
+    JSG_STRUCT(Resolve4Options);
+  };
+  using Resolve4Callback = jsg::Function<void(void)>;
+  void resolve4(
+      jsg::Lock& js, kj::String hostname, Resolve4Options options, Resolve4Callback callback);
+
+  struct Resolve6Options {
+    bool ttl;
+
+    JSG_STRUCT(ttl);
+  };
+  using Resolve6Callback = jsg::Function<void(void)>;
+  void resolve6(
+      jsg::Lock& js, kj::String hostname, Resolve6Options options, Resolve6Callback callback);
+
+  using ResolveAnyCallback = jsg::Function<void(void)>;
+  void resolveAny(jsg::Lock& js, kj::String hostname, ResolveAnyCallback callback);
+
+  using ResolveCnameCallback = jsg::Function<void(void)>;
+  void resolveCname(jsg::Lock& js, kj::String hostname, ResolveCnameCallback callback);
+
+  using ResolveCaaCallback = jsg::Function<void(void)>;
+  void resolveCaa(jsg::Lock& js, kj::String hostname, ResolveCaaCallback callback);
+
+  using ResolveMxCallback = jsg::Function<void(void)>;
+  void resolveMx(jsg::Lock& js, kj::String hostname, ResolveMxCallback callback);
+
+  using ResolveNaptrCallback = jsg::Function<void(void)>;
+  void resolveNaptr(jsg::Lock& js, kj::String hostname, ResolveNaptrCallback callback);
+
+  using ResolveNsCallback = jsg::Function<void(void)>;
+  void resolveNs(jsg::Lock& js, kj::String hostname, ResolveNsCallback callback);
+
+  using ResolvePtrCallback = jsg::Function<void(void)>;
+  void resolvePtr(jsg::Lock& js, kj::String hostname, ResolvePtrCallback callback);
+
+  using ResolveSoaCallback = jsg::Function<void(void)>;
+  void resolveSoa(jsg::Lock& js, kj::String hostname, ResolveSoaCallback callback);
+
+  using ResolveSrvCallback = jsg::Function<void(void)>;
+  void resolveSrv(jsg::Lock& js, kj::String hostname, ResolveSrvCallback callback);
+
+  using ResolveTxtCallback = jsg::Function<void(void)>;
+  void resolveTxt(jsg::Lock& js, kj::String hostname, ResolveTxtCallback callback);
+
+  using ReverseCallback = jsg::Function<void(void)>;
+  void reverse(jsg::Lock& js, kj::String ip, ReverseCallback callback);
+
+  void setDefaultResultOrder(jsg::Lock& js, kj::String order);
+  kj::StringPtr getDefaultResultOrder(jsg::Lock& js);
+  void setServers(kj::Array<kj::String> servers);
+
+  JSG_RESOURCE_TYPE(DnsUtil) {
+    // Callback implementations
+    JSG_METHOD(getServers);
+    JSG_METHOD(lookup);
+    JSG_METHOD(lookupService);
+    JSG_METHOD(resolve);
+    JSG_METHOD(resolve4);
+    JSG_METHOD(resolve6);
+    JSG_METHOD(resolveAny);
+    JSG_METHOD(resolveCname);
+    JSG_METHOD(resolveCaa);
+    JSG_METHOD(resolveMx);
+    JSG_METHOD(resolveNaptr);
+    JSG_METHOD(resolveNs);
+    JSG_METHOD(resolvePtr);
+    JSG_METHOD(resolveSoa);
+    JSG_METHOD(resolveSrv);
+    JSG_METHOD(resolveTxt);
+    JSG_METHOD(reverse);
+
+    // Getter, setters
+    JSG_METHOD(setDefaultResultOrder);
+    JSG_METHOD(getDefaultResultOrder);
+    JSG_METHOD(setServers);
+  }
+};
+
+#define EW_NODE_DNS_ISOLATE_TYPES                                                                  \
+  api::node::DnsUtil, api::node::DnsUtil::LookupOptions, api::node::DnsUtil::Resolve4Options,      \
+      api::node::DnsUtil::Resolve6Options
+
+}  // namespace workerd::api::node

--- a/src/workerd/api/node/dns.h
+++ b/src/workerd/api/node/dns.h
@@ -41,7 +41,7 @@ class DnsUtil final: public jsg::Object {
   struct Resolve4Options {
     bool ttl;
 
-    JSG_STRUCT(Resolve4Options);
+    JSG_STRUCT(ttl);
   };
   using Resolve4Callback = jsg::Function<void(void)>;
   void resolve4(

--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -6,6 +6,7 @@
 
 #include <workerd/api/node/async-hooks.h>
 #include <workerd/api/node/buffer.h>
+#include <workerd/api/node/dns.h>
 #include <workerd/api/node/module.h>
 #include <workerd/api/node/url.h>
 #include <workerd/api/node/util.h>
@@ -50,7 +51,8 @@ class CompatibilityFlags: public jsg::Object {
   V(UtilModule, "node-internal:util")                                                              \
   V(DiagnosticsChannelModule, "node-internal:diagnostics_channel")                                 \
   V(ZlibUtil, "node-internal:zlib")                                                                \
-  V(UrlUtil, "node-internal:url")
+  V(UrlUtil, "node-internal:url")                                                                  \
+  V(DnsUtil, "node-internal:dns")
 
 // Add to the NODEJS_MODULES_EXPERIMENTAL list any currently in-development
 // node.js compat C++ modules that should be guarded by the experimental compat
@@ -142,4 +144,4 @@ kj::Own<jsg::modules::ModuleBundle> getExternalNodeJsCompatModuleBundle(auto fea
   api::node::CompatibilityFlags, EW_NODE_BUFFER_ISOLATE_TYPES, EW_NODE_CRYPTO_ISOLATE_TYPES,       \
       EW_NODE_DIAGNOSTICCHANNEL_ISOLATE_TYPES, EW_NODE_ASYNCHOOKS_ISOLATE_TYPES,                   \
       EW_NODE_UTIL_ISOLATE_TYPES, EW_NODE_ZLIB_ISOLATE_TYPES, EW_NODE_URL_ISOLATE_TYPES,           \
-      EW_NODE_MODULE_ISOLATE_TYPES\
+      EW_NODE_MODULE_ISOLATE_TYPES, EW_NODE_DNS_ISOLATE_TYPES\

--- a/src/workerd/api/node/tests/dns-nodejs-test.js
+++ b/src/workerd/api/node/tests/dns-nodejs-test.js
@@ -3,24 +3,29 @@ import { strictEqual } from 'node:assert';
 
 export const functionsExist = {
   async test() {
-    strictEqual(typeof dns.lookup, 'function');
-    strictEqual(typeof dns.lookupService, 'function');
-    strictEqual(typeof dns.resolve, 'function');
-    strictEqual(typeof dns.resolve4, 'function');
-    strictEqual(typeof dns.resolve6, 'function');
-    strictEqual(typeof dns.resolveAny, 'function');
-    strictEqual(typeof dns.resolveCname, 'function');
-    strictEqual(typeof dns.resolveCaa, 'function');
-    strictEqual(typeof dns.resolveMx, 'function');
-    strictEqual(typeof dns.resolveNaptr, 'function');
-    strictEqual(typeof dns.resolveNs, 'function');
-    strictEqual(typeof dns.resolvePtr, 'function');
-    strictEqual(typeof dns.resolveSoa, 'function');
-    strictEqual(typeof dns.resolveSrv, 'function');
-    strictEqual(typeof dns.resolveTxt, 'function');
-    strictEqual(typeof dns.reverse, 'function');
-    strictEqual(typeof dns.setDefaultResultOrder, 'function');
-    strictEqual(typeof dns.getDefaultResultOrder, 'function');
-    strictEqual(typeof dns.setServers, 'function');
+    const syncFns = [
+      'lookup',
+      'lookupService',
+      'resolve',
+      'resolve4',
+      'resolve6',
+      'resolveAny',
+      'resolveCname',
+      'resolveCaa',
+      'resolveMx',
+      'resolveNaptr',
+      'resolveNs',
+      'resolvePtr',
+      'resolveSoa',
+      'resolveSrv',
+      'reverse',
+      'setDefaultResultOrder',
+      'getDefaultResultOrder',
+      'setServers',
+    ];
+
+    for (const fn of syncFns) {
+      strictEqual(typeof dns[fn], 'function');
+    }
   },
 };

--- a/src/workerd/api/node/tests/dns-nodejs-test.js
+++ b/src/workerd/api/node/tests/dns-nodejs-test.js
@@ -1,0 +1,26 @@
+import dns from 'node:dns';
+import { strictEqual } from 'node:assert';
+
+export const functionsExist = {
+  async test() {
+    strictEqual(typeof dns.lookup, 'function');
+    strictEqual(typeof dns.lookupService, 'function');
+    strictEqual(typeof dns.resolve, 'function');
+    strictEqual(typeof dns.resolve4, 'function');
+    strictEqual(typeof dns.resolve6, 'function');
+    strictEqual(typeof dns.resolveAny, 'function');
+    strictEqual(typeof dns.resolveCname, 'function');
+    strictEqual(typeof dns.resolveCaa, 'function');
+    strictEqual(typeof dns.resolveMx, 'function');
+    strictEqual(typeof dns.resolveNaptr, 'function');
+    strictEqual(typeof dns.resolveNs, 'function');
+    strictEqual(typeof dns.resolvePtr, 'function');
+    strictEqual(typeof dns.resolveSoa, 'function');
+    strictEqual(typeof dns.resolveSrv, 'function');
+    strictEqual(typeof dns.resolveTxt, 'function');
+    strictEqual(typeof dns.reverse, 'function');
+    strictEqual(typeof dns.setDefaultResultOrder, 'function');
+    strictEqual(typeof dns.getDefaultResultOrder, 'function');
+    strictEqual(typeof dns.setServers, 'function');
+  },
+};

--- a/src/workerd/api/node/tests/dns-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/dns-nodejs-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "nodejs-dns-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "dns-nodejs-test.js")
+        ],
+        compatibilityDate = "2024-10-11",
+        compatibilityFlags = ["nodejs_compat"],
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
Implements a stub implementation for `node:dns`. Remember that there is still `node:dns/promises` that needs to be stubbed. 

Small note: I'm in the process of investigating fully implementing node:dns in the short term.