### PR TITLE
remove autogates for compile cache

### DIFF
--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -62,7 +62,6 @@ wd_cc_library(
         ":observer",
         ":url",
         "//src/workerd/util",
-        "//src/workerd/util:autogate",
         "//src/workerd/util:sentry",
         "//src/workerd/util:thread-scopes",
         "//src/workerd/util:uuid",

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -6,8 +6,6 @@
 #include "jsg.h"
 #include "setup.h"
 
-#include <workerd/util/autogate.h>
-
 #include <kj/mutex.h>
 
 #include <set>
@@ -395,14 +393,12 @@ v8::Local<v8::Module> compileEsmModule(jsg::Lock& js,
     contentStr = jsg::v8Str(js.v8Isolate, content);
   }
 
-  if (util::Autogate::isEnabled(util::AutogateKey::COMPILE_CACHE_FOR_BUILTINS)) {
-    if (compileCache.size() > 0 && compileCache.begin() != nullptr) {
-      auto cached = std::make_unique<v8::ScriptCompiler::CachedData>(
-          compileCache.begin(), compileCache.size());
-      v8::ScriptCompiler::Source source(contentStr, origin, cached.release());
-      return jsg::check(v8::ScriptCompiler::CompileModule(
-          js.v8Isolate, &source, v8::ScriptCompiler::kConsumeCodeCache));
-    }
+  if (compileCache.size() > 0 && compileCache.begin() != nullptr) {
+    auto cached =
+        std::make_unique<v8::ScriptCompiler::CachedData>(compileCache.begin(), compileCache.size());
+    v8::ScriptCompiler::Source source(contentStr, origin, cached.release());
+    return jsg::check(v8::ScriptCompiler::CompileModule(
+        js.v8Isolate, &source, v8::ScriptCompiler::kConsumeCodeCache));
   }
 
   v8::ScriptCompiler::Source source(contentStr, origin);

--- a/src/workerd/jsg/resource-test.c++
+++ b/src/workerd/jsg/resource-test.c++
@@ -5,7 +5,6 @@
 #include "jsg-test.h"
 
 #include <workerd/jsg/resource-test.capnp.h>
-#include <workerd/util/autogate.h>
 
 namespace workerd::jsg::test {
 namespace {
@@ -591,7 +590,6 @@ struct JsBundleContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(JsBundleIsolate, JsBundleContext);
 
 KJ_TEST("expectEvalModule function works") {
-  util::Autogate::initAutogate({});
   Evaluator<JsBundleContext, JsBundleIsolate, decltype(nullptr), JsBundleIsolate_TypeWrapper> e(
       v8System);
   e.expectEvalModule("export function run() { return 123; }", "number", "123");

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -17,8 +17,6 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
   switch (key) {
     case AutogateKey::TEST_WORKERD:
       return "test-workerd"_kj;
-    case AutogateKey::COMPILE_CACHE_FOR_BUILTINS:
-      return "compile-cache-for-builtins"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -14,7 +14,6 @@ namespace workerd::util {
 // Workerd-specific list of autogate keys (can also be used in internal repo).
 enum class AutogateKey {
   TEST_WORKERD,
-  COMPILE_CACHE_FOR_BUILTINS,
   NumOfKeys  // Reserved for iteration.
 };
 


### PR DESCRIPTION
Since we rolled out the compile cache to RoW, let's remove it from our codebase.