### PR TITLE
make sure href setter throws if invalid

### DIFF
--- a/src/workerd/api/url-standard.c++
+++ b/src/workerd/api/url-standard.c++
@@ -79,8 +79,12 @@ kj::ArrayPtr<const char> URL::getHref() {
   return inner.getHref();
 }
 
-void URL::setHref(kj::String value) {
-  inner.setHref(value);
+void URL::setHref(jsg::Lock& js, kj::String value) {
+  // Href setter is the only place in URL parser that is allowed to throw except the constructor.
+  if (!inner.setHref(value)) {
+    auto context = jsg::TypeErrorContext::setterArgument(typeid(URL), "href");
+    jsg::throwTypeError(js.v8Isolate, context, "valid URL string");
+  }
   KJ_IF_SOME(searchParams, maybeSearchParams) {
     searchParams->reset();
   }

--- a/src/workerd/api/url-standard.h
+++ b/src/workerd/api/url-standard.h
@@ -162,7 +162,7 @@ public:
   }
 
   kj::ArrayPtr<const char> getHref();
-  void setHref(kj::String value);
+  void setHref(jsg::Lock& js, kj::String value);
 
   kj::Array<const char> getOrigin();
 

--- a/src/workerd/api/wpt/url-test.js
+++ b/src/workerd/api/wpt/url-test.js
@@ -8,7 +8,6 @@ export const idnaTestV2Window = run('IdnaTestV2.window.js');
 export const historical = run('historical.any.js', {
   expectedFailures: [
     'Constructor only takes strings',
-    "Setting URL's href attribute and base URLs",
     'URL: no structured serialize/deserialize support',
     'URLSearchParams: no structured serialize/deserialize support',
   ],


### PR DESCRIPTION
We were not following the spec in this particular example. Setting a href should throw an error if the input is not a valid URL. The corresponding WPT is now passing.