### PR TITLE
[build] Add missing no-asan tag

### DIFF
--- a/src/cloudflare/internal/test/aig/BUILD.bazel
+++ b/src/cloudflare/internal/test/aig/BUILD.bazel
@@ -15,4 +15,8 @@ py_wd_test(
         "*.js",
         "*.py",
     ]),
+    tags = [
+        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
+        "no-asan",
+    ],
 )


### PR DESCRIPTION
This is needed following #3140, #3166 adds a new python test which also needs the tag.