### PR TITLE
Log outputGate broken shouldRetryCountsAgainstLimits for alarms

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -471,16 +471,17 @@ kj::Promise<WorkerInterface::AlarmResult> ServiceWorkerGlobalScope::runAlarm(kj:
             !jsg::isDoNotLogException(desc) && context.isOutputGateBroken()) {
           LOG_NOSENTRY(ERROR, "output lock broke during alarm execution", actorId, e);
         } else if (context.isOutputGateBroken()) {
-          // We don't usually log these messages, but it's useful to know the real reason we failed
-          // to correctly investigate stuck alarms.
-          LOG_NOSENTRY(ERROR,
-              "output lock broke during alarm execution without an interesting error description",
-              actorId, e);
           if (e.getDetail(jsg::EXCEPTION_IS_USER_ERROR) != kj::none) {
             // The handler failed because the user overloaded the object. It's their fault, we'll not
             // retry forever.
             shouldRetryCountsAgainstLimits = true;
           }
+
+          // We don't usually log these messages, but it's useful to know the real reason we failed
+          // to correctly investigate stuck alarms.
+          LOG_NOSENTRY(ERROR,
+              "output lock broke during alarm execution without an interesting error description",
+              actorId, e, shouldRetryCountsAgainstLimits);
         }
         return WorkerInterface::AlarmResult{.retry = true,
           .retryCountsAgainstLimit = shouldRetryCountsAgainstLimits,
@@ -511,16 +512,16 @@ kj::Promise<WorkerInterface::AlarmResult> ServiceWorkerGlobalScope::runAlarm(kj:
               LOG_NOSENTRY(ERROR, "output lock broke after executing alarm", actorId, e);
             }
           } else {
-            // We don't usually log these messages, but it's useful to know the real reason we failed
-            // to correctly investigate stuck alarms.
-            LOG_NOSENTRY(ERROR,
-                "output lock broke after executing alarm without an interesting error description",
-                actorId, e);
             if (e.getDetail(jsg::EXCEPTION_IS_USER_ERROR) != kj::none) {
               // The handler failed because the user overloaded the object. It's their fault, we'll not
               // retry forever.
               shouldRetryCountsAgainstLimits = true;
             }
+            // We don't usually log these messages, but it's useful to know the real reason we failed
+            // to correctly investigate stuck alarms.
+            LOG_NOSENTRY(ERROR,
+                "output lock broke after executing alarm without an interesting error description",
+                actorId, e, shouldRetryCountsAgainstLimits);
           }
           return WorkerInterface::AlarmResult{.retry = true,
             .retryCountsAgainstLimit = shouldRetryCountsAgainstLimits,


### PR DESCRIPTION
We have some overloaded exceptions that are set as `EXCEPTION_IS_USER_ERROR`. These errors should be reported back to the alarm-manager as user errors, but some are being reported as internal errors.

This PR adds additional logging and does a hackish check to enforce that `broken.exceededMemory` errors during the alarm execution are treated as user errors.