### PR TITLE
Add API to set and get the V8 cage base address

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -302,6 +302,7 @@ http_archive(
         "//:patches/v8/0017-Modify-where-to-look-for-fast_float-dependency.patch",
         "//:patches/v8/0018-Return-rejected-promise-from-WebAssembly.compile-if-.patch",
         "//:patches/v8/0019-codegen-Don-t-pass-a-nullptr-in-InitUnwindingRecord-.patch",
+        "//:patches/v8/0020-Add-another-slot-in-the-isolate-for-embedder.patch",
     ],
     strip_prefix = "v8-13.1.201.8",
     url = "https://github.com/v8/v8/archive/refs/tags/13.1.201.8.tar.gz",

--- a/patches/v8/0020-Add-another-slot-in-the-isolate-for-embedder.patch
+++ b/patches/v8/0020-Add-another-slot-in-the-isolate-for-embedder.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Erik Corry <erikcorry@chromium.org>
+Date: Mon, 2 Dec 2024 14:16:37 +0100
+Subject: Add another slot in the isolate for embedder
+
+
+diff --git a/include/v8-internal.h b/include/v8-internal.h
+index 289ba019329101168038aabd05109caa615e8334..554c64d958f319aa69bade348a6b7d7c41a84961 100644
+--- a/include/v8-internal.h
++++ b/include/v8-internal.h
+@@ -897,7 +897,7 @@ class Internals {
+   static const int kExternalTwoByteRepresentationTag = 0x02;
+   static const int kExternalOneByteRepresentationTag = 0x0a;
+ 
+-  static const uint32_t kNumIsolateDataSlots = 4;
++  static const uint32_t kNumIsolateDataSlots = 5;
+   static const int kStackGuardSize = 8 * kApiSystemPointerSize;
+   static const int kNumberOfBooleanFlags = 6;
+   static const int kErrorMessageParamSize = 1;

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -987,9 +987,9 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
     auto lock = api->lock(stackScope);
     auto features = api->getFeatureFlags();
 
-    KJ_DASSERT(lock->v8Isolate->GetNumberOfDataSlots() >= SET_DATA_SLOTS_IN_USE);
-    KJ_DASSERT(lock->v8Isolate->GetData(SET_DATA_LOCK) == nullptr);
-    lock->v8Isolate->SetData(SET_DATA_LOCK, this);
+    KJ_DASSERT(lock->v8Isolate->GetNumberOfDataSlots() >= jsg::SET_DATA_SLOTS_IN_USE);
+    KJ_DASSERT(lock->v8Isolate->GetData(jsg::SET_DATA_ISOLATE) == nullptr);
+    lock->v8Isolate->SetData(jsg::SET_DATA_ISOLATE, this);
 
     lock->setCaptureThrowsAsRejections(features.getCaptureThrowsAsRejections());
     lock->setCommonJsExportDefault(features.getExportCommonJsDefaultNamespace());
@@ -1412,7 +1412,7 @@ Worker::Script::~Script() noexcept(false) {
 }
 
 const Worker::Isolate& Worker::Isolate::from(jsg::Lock& js) {
-  auto ptr = js.v8Isolate->GetData(SET_DATA_LOCK);
+  auto ptr = js.v8Isolate->GetData(jsg::SET_DATA_ISOLATE);
   KJ_ASSERT(ptr != nullptr);
   return *static_cast<const Worker::Isolate*>(ptr);
 }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -987,9 +987,9 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
     auto lock = api->lock(stackScope);
     auto features = api->getFeatureFlags();
 
-    KJ_DASSERT(lock->v8Isolate->GetNumberOfDataSlots() >= 3);
-    KJ_DASSERT(lock->v8Isolate->GetData(3) == nullptr);
-    lock->v8Isolate->SetData(3, this);
+    KJ_DASSERT(lock->v8Isolate->GetNumberOfDataSlots() >= SET_DATA_SLOTS_IN_USE);
+    KJ_DASSERT(lock->v8Isolate->GetData(SET_DATA_LOCK) == nullptr);
+    lock->v8Isolate->SetData(SET_DATA_LOCK, this);
 
     lock->setCaptureThrowsAsRejections(features.getCaptureThrowsAsRejections());
     lock->setCommonJsExportDefault(features.getExportCommonJsDefaultNamespace());
@@ -1412,7 +1412,7 @@ Worker::Script::~Script() noexcept(false) {
 }
 
 const Worker::Isolate& Worker::Isolate::from(jsg::Lock& js) {
-  auto ptr = js.v8Isolate->GetData(3);
+  auto ptr = js.v8Isolate->GetData(SET_DATA_LOCK);
   KJ_ASSERT(ptr != nullptr);
   return *static_cast<const Worker::Isolate*>(ptr);
 }

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -120,7 +120,7 @@ Lock::Lock(v8::Isolate* v8Isolate)
     : v8Isolate(v8Isolate),
       locker(v8Isolate),
       isolateScope(v8Isolate),
-      previousData(v8Isolate->GetData(SET_DATA_ISOLATE)),
+      previousData(v8Isolate->GetData(SET_DATA_LOCK)),
       warningsLogged(IsolateBase::from(v8Isolate).areWarningsLogged()) {
   if (previousData != nullptr) {
     // Hmm, there's already a current lock. It must be a recursive lock (i.e. a second lock taken
@@ -139,10 +139,10 @@ Lock::Lock(v8::Isolate* v8Isolate)
     KJ_LOG(ERROR, "took recursive isolate lock", kj::getStackTrace());
 #endif
   }
-  v8Isolate->SetData(SET_DATA_ISOLATE, this);
+  v8Isolate->SetData(SET_DATA_LOCK, this);
 }
 Lock::~Lock() noexcept(false) {
-  v8Isolate->SetData(SET_DATA_ISOLATE, previousData);
+  v8Isolate->SetData(SET_DATA_LOCK, previousData);
 }
 
 Value Lock::parseJson(kj::ArrayPtr<const char> data) {

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -72,7 +72,7 @@ void Data::destroy() {
       //
       // Note that only the v8::Global part of `handle` needs to be destroyed under isolate lock.
       // The `tracedRef` part has a trivial destructor so can be destroyed on any thread.
-      auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(0));
+      auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
       jsgIsolate.deferDestruction(v8::Global<v8::Data>(kj::mv(handle)));
     }
     isolate = nullptr;
@@ -120,7 +120,7 @@ Lock::Lock(v8::Isolate* v8Isolate)
     : v8Isolate(v8Isolate),
       locker(v8Isolate),
       isolateScope(v8Isolate),
-      previousData(v8Isolate->GetData(2)),
+      previousData(v8Isolate->GetData(SET_DATA_ISOLATE)),
       warningsLogged(IsolateBase::from(v8Isolate).areWarningsLogged()) {
   if (previousData != nullptr) {
     // Hmm, there's already a current lock. It must be a recursive lock (i.e. a second lock taken
@@ -139,10 +139,10 @@ Lock::Lock(v8::Isolate* v8Isolate)
     KJ_LOG(ERROR, "took recursive isolate lock", kj::getStackTrace());
 #endif
   }
-  v8Isolate->SetData(2, this);
+  v8Isolate->SetData(SET_DATA_ISOLATE, this);
 }
 Lock::~Lock() noexcept(false) {
-  v8Isolate->SetData(2, previousData);
+  v8Isolate->SetData(SET_DATA_ISOLATE, previousData);
 }
 
 Value Lock::parseJson(kj::ArrayPtr<const char> data) {
@@ -290,7 +290,7 @@ void ExternalMemoryAdjustment::maybeDeferAdjustment(v8::Isolate* isolate, size_t
   } else {
     // Otherwise, if we don't have the isolate locked, defer the adjustment to the next
     // time that we do.
-    auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(0));
+    auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
     jsgIsolate.deferExternalMemoryDecrement(static_cast<int64_t>(amount));
   }
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -735,6 +735,15 @@ consteval size_t prefixLengthToStrip(const char (&s)[N]) {
   registry.template registerStructProperty<name##_JSG_NAME_DO_NOT_USE_DIRECTLY,                    \
       decltype(::kj::instance<Self>().name), &Self::name>()
 
+enum SetDataIndex {
+  SET_DATA_ISOLATE_BASE,
+  SET_DATA_TYPE_WRAPPER,
+  SET_DATA_ISOLATE,
+  SET_DATA_LOCK,
+  SET_DATA_CAGE_BASE,
+  SET_DATA_SLOTS_IN_USE,
+};
+
 // =======================================================================================
 // Special types
 //
@@ -2272,7 +2281,7 @@ class Lock {
   // This method is intended to be used in callbacks from V8 that pass an isolate pointer but
   // don't provide any further context. Most code should rely on the caller passing in a `Lock&`.
   static Lock& from(v8::Isolate* v8Isolate) {
-    return *reinterpret_cast<Lock*>(v8Isolate->GetData(2));
+    return *reinterpret_cast<Lock*>(v8Isolate->GetData(SET_DATA_ISOLATE));
   }
 
   // RAII construct that reports amount of external memory to be manually attributed to

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -735,12 +735,20 @@ consteval size_t prefixLengthToStrip(const char (&s)[N]) {
   registry.template registerStructProperty<name##_JSG_NAME_DO_NOT_USE_DIRECTLY,                    \
       decltype(::kj::instance<Self>().name), &Self::name>()
 
+// Indexes for adding API data to V8's Isolate object.
 enum SetDataIndex {
+  // The jsg::IsolateBase for a particular V8 isolate.
   SET_DATA_ISOLATE_BASE,
+  // The TypeWrapper object for a particular V8 isolate.
   SET_DATA_TYPE_WRAPPER,
-  SET_DATA_ISOLATE,
+  // The lock associated with the V8 isolate.
   SET_DATA_LOCK,
+  // The Worker::Isolate associated with the V8 isolate.
+  SET_DATA_ISOLATE,
+  // The address of the base of the 4Gbyte compressed pointer area.
+  // If we are using the sandbox it's also the base of the sandbox.
   SET_DATA_CAGE_BASE,
+  // The number of slots workerd uses in the API data for Isolate objects.
   SET_DATA_SLOTS_IN_USE,
 };
 
@@ -2281,7 +2289,7 @@ class Lock {
   // This method is intended to be used in callbacks from V8 that pass an isolate pointer but
   // don't provide any further context. Most code should rely on the caller passing in a `Lock&`.
   static Lock& from(v8::Isolate* v8Isolate) {
-    return *reinterpret_cast<Lock*>(v8Isolate->GetData(SET_DATA_ISOLATE));
+    return *reinterpret_cast<Lock*>(v8Isolate->GetData(SET_DATA_LOCK));
   }
 
   // RAII construct that reports amount of external memory to be manually attributed to

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -161,7 +161,7 @@ void V8System::setFatalErrorCallback(FatalErrorCallback* callback) {
 }
 
 IsolateBase& IsolateBase::from(v8::Isolate* isolate) {
-  return *static_cast<IsolateBase*>(isolate->GetData(0));
+  return *static_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
 }
 
 void IsolateBase::buildEmbedderGraph(v8::Isolate* isolate, v8::EmbedderGraph* graph, void* data) {
@@ -339,7 +339,7 @@ IsolateBase::IsolateBase(const V8System& system,
     ptr->SetOOMErrorHandler(&oomError);
 
     ptr->SetMicrotasksPolicy(v8::MicrotasksPolicy::kExplicit);
-    ptr->SetData(0, this);
+    ptr->SetData(SET_DATA_ISOLATE_BASE, this);
 
     ptr->SetModifyCodeGenerationFromStringsCallback(&modifyCodeGenCallback);
     ptr->SetAllowWasmCodeGenerationCallback(&allowWasmCallback);
@@ -401,7 +401,8 @@ IsolateBase::~IsolateBase() noexcept(false) {
 }
 
 v8::Local<v8::FunctionTemplate> IsolateBase::getOpaqueTemplate(v8::Isolate* isolate) {
-  return static_cast<IsolateBase*>(isolate->GetData(0))->opaqueTemplate.Get(isolate);
+  return static_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE))
+      ->opaqueTemplate.Get(isolate);
 }
 
 void IsolateBase::dropWrappers(kj::Own<void> typeWrapperInstance) {
@@ -449,13 +450,14 @@ void IsolateBase::oomError(const char* location, const v8::OOMDetails& oom) {
 v8::ModifyCodeGenerationFromStringsResult IsolateBase::modifyCodeGenCallback(
     v8::Local<v8::Context> context, v8::Local<v8::Value> source, bool isCodeLike) {
   v8::Isolate* isolate = context->GetIsolate();
-  IsolateBase* self = static_cast<IsolateBase*>(isolate->GetData(0));
+  IsolateBase* self = static_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
   return {.codegen_allowed = self->evalAllowed, .modified_source = {}};
 }
 
 bool IsolateBase::allowWasmCallback(v8::Local<v8::Context> context, v8::Local<v8::String> source) {
   // Don't allow WASM unless arbitrary eval() is allowed.
-  IsolateBase* self = static_cast<IsolateBase*>(context->GetIsolate()->GetData(0));
+  IsolateBase* self =
+      static_cast<IsolateBase*>(context->GetIsolate()->GetData(SET_DATA_ISOLATE_BASE));
   return self->evalAllowed;
 }
 
@@ -463,7 +465,7 @@ void IsolateBase::jitCodeEvent(const v8::JitCodeEvent* event) noexcept {
   // We register this callback with V8 in order to build a mapping of code addresses to source
   // code locations, which we use when reporting stack traces during crashes.
 
-  IsolateBase* self = static_cast<IsolateBase*>(event->isolate->GetData(0));
+  IsolateBase* self = static_cast<IsolateBase*>(event->isolate->GetData(SET_DATA_ISOLATE_BASE));
   auto& codeMap = self->codeMap;
 
   // Pointer comparison between pointers not from the same array is UB so we'd better operate on
@@ -566,16 +568,15 @@ void* getJsCageBase() {
   if (!v8Initialized) return nullptr;
   v8::Isolate* isolate = v8::Isolate::TryGetCurrent();
   if (isolate == nullptr) return nullptr;
-  // Returns null if we are not using pointer cages.
-  return isolate->GetData(4);
+  // Returns null if setJsCageBase was never called.
+  return isolate->GetData(SET_DATA_CAGE_BASE);
 }
 
-void setJsCageBase(void* base) {
+void setJsCageBase(void* cageBase) {
   if (!v8Initialized) return;
   v8::Isolate* isolate = v8::Isolate::TryGetCurrent();
   if (isolate == nullptr) return;
-  // Returns null if we are not using pointer cages.
-  isolate->SetData(4, base);
+  isolate->SetData(SET_DATA_CAGE_BASE, cageBase);
 }
 
 #if _WIN32
@@ -664,7 +665,7 @@ kj::Maybe<kj::StringPtr> getJsStackTrace(void* ucontext, kj::ArrayPtr<char> scra
   }
   appendText("js: (", vmState, ")");
 
-  auto& codeMap = static_cast<IsolateBase*>(isolate->GetData(0))->codeMap;
+  auto& codeMap = static_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE))->codeMap;
 
   for (auto i: kj::zeroTo(sampleInfo.frames_count)) {
     uintptr_t addr = reinterpret_cast<uintptr_t>(traceSpace[i]);

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -562,6 +562,22 @@ void IsolateBase::jitCodeEvent(const v8::JitCodeEvent* event) noexcept {
   }
 }
 
+void* getJsCageBase() {
+  if (!v8Initialized) return nullptr;
+  v8::Isolate* isolate = v8::Isolate::TryGetCurrent();
+  if (isolate == nullptr) return nullptr;
+  // Returns null if we are not using pointer cages.
+  return isolate->GetData(4);
+}
+
+void setJsCageBase(void* base) {
+  if (!v8Initialized) return;
+  v8::Isolate* isolate = v8::Isolate::TryGetCurrent();
+  if (isolate == nullptr) return;
+  // Returns null if we are not using pointer cages.
+  isolate->SetData(4, base);
+}
+
 #if _WIN32
 kj::Maybe<kj::StringPtr> getJsStackTrace(void* ucontext, kj::ArrayPtr<char> scratch) {
   // This function is only called by the internal build which just targets Linux.

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -355,6 +355,14 @@ class IsolateBase {
 // intended to be invoked from a signal handler.
 kj::Maybe<kj::StringPtr> getJsStackTrace(void* ucontext, kj::ArrayPtr<char> scratch);
 
+// Set the location of the pointer cage base for the current isolate.  This is only
+// used by getJsCageBase().
+void setJsCageBase(void* cage_base);
+
+// Get the location previously set by setJsCageBase() for the current isolate.  Returns
+// a null pointer if there is no current isolate.
+void* getJsCageBase();
+
 // Class representing a JavaScript execution engine, with the ability to wrap some set of API
 // classes which you specify.
 //

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -357,7 +357,7 @@ kj::Maybe<kj::StringPtr> getJsStackTrace(void* ucontext, kj::ArrayPtr<char> scra
 
 // Set the location of the pointer cage base for the current isolate.  This is only
 // used by getJsCageBase().
-void setJsCageBase(void* cage_base);
+void setJsCageBase(void* cageBase);
 
 // Get the location previously set by setJsCageBase() for the current isolate.  Returns
 // a null pointer if there is no current isolate.

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -403,7 +403,7 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
       : TypeWrapperBase<Self, T>(configuration)...,
         MaybeWrapper<Self>(configuration),
         PromiseWrapper<Self>(configuration) {
-    isolate->SetData(1, this);
+    isolate->SetData(SET_DATA_TYPE_WRAPPER, this);
   }
   KJ_DISALLOW_COPY_AND_MOVE(TypeWrapper);
 
@@ -412,7 +412,7 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
   }
 
   static TypeWrapper& from(v8::Isolate* isolate) {
-    return *reinterpret_cast<TypeWrapper*>(isolate->GetData(1));
+    return *reinterpret_cast<TypeWrapper*>(isolate->GetData(SET_DATA_TYPE_WRAPPER));
   }
 
   using TypeWrapperBase<Self, T>::getName...;

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -20,17 +20,17 @@
 namespace workerd::jsg {
 
 bool getCaptureThrowsAsRejections(v8::Isolate* isolate) {
-  auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(0));
+  auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
   return jsgIsolate.getCaptureThrowsAsRejections();
 }
 
 bool getCommonJsExportDefault(v8::Isolate* isolate) {
-  auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(0));
+  auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
   return jsgIsolate.getCommonJsExportDefault();
 }
 
 bool getShouldSetToStringTag(v8::Isolate* isolate) {
-  auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(0));
+  auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
   return jsgIsolate.shouldSetToStringTag();
 }
 
@@ -474,7 +474,7 @@ void throwTunneledException(v8::Isolate* isolate, v8::Local<v8::Value> exception
 }
 
 kj::Exception createTunneledException(v8::Isolate* isolate, v8::Local<v8::Value> exception) {
-  auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(0));
+  auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
   return jsgIsolate.unwrapException(isolate->GetCurrentContext(), exception);
 }
 

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -299,7 +299,7 @@ void Wrappable::maybeDeferDestruction(bool strong, kj::Own<void> ownSelf, Wrappa
     auto drop = kj::mv(item);
   } else {
     // Otherwise, we have a wrapper and we don't have the isolate locked.
-    auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(0));
+    auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
     jsgIsolate.deferDestruction(kj::mv(item));
   }
 }


### PR DESCRIPTION
I want to use this to call madvise just before a crash so the V8 heap
for the crashing isolate is part of the core dump.