### PR TITLE
feat: better define step retry delay and step timeout types

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -217,15 +217,19 @@ declare module "cloudflare:workers" {
     | `${number} ${WorkflowDurationLabel}${"s" | ""}`
     | number;
 
+  export type WorkflowDelayDuration = WorkflowSleepDuration;
+
+  export type WorkflowTimeoutDuration = WorkflowSleepDuration;
+
   export type WorkflowBackoff = "constant" | "linear" | "exponential";
 
   export type WorkflowStepConfig = {
     retries?: {
       limit: number;
-      delay: string | number;
+      delay: WorkflowDelayDuration | number;
       backoff?: WorkflowBackoff;
     };
-    timeout?: string | number;
+    timeout?: WorkflowTimeoutDuration | number;
   };
 
   export type WorkflowEvent<T> = {


### PR DESCRIPTION
Previously, both types were specified as a string, which is not intended behavior. We only allow for a specific formatted string - same as `WorkflowSleepDuration`.

I've added `WorkflowTimeoutDuration` and `WorkflowDelayDuration` for better DX in the types by reducing confusion (otherwise you would see a `WorkflowSleepDuration` in a timeout field) - also gives us flexibility if we need to separate them later.

While this could be a breaking change in the types, we already validate it at runtime, so there are no worries here.