### PR TITLE
Improve tail worker support

### DIFF
--- a/samples/tail-workers/config.capnp
+++ b/samples/tail-workers/config.capnp
@@ -13,7 +13,7 @@ const helloWorld :Workerd.Worker = (
     (name = "worker", esModule = embed "worker.js")
   ],
   compatibilityDate = "2024-10-14",
-  logging = ( toService = "log" ),
+  tails = ["log"],
 );
 
 const logWorker :Workerd.Worker = (

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -2310,9 +2310,7 @@ KJ_TEST("Server: tail workers") {
                 `}
             )
           ],
-          logging = (
-            toServices = ["tail", "tail2"]
-          ),
+          tails = ["tail", "tail2"],
         )
       ),
       ( name = "tail",

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1578,7 +1578,7 @@ public:
     kj::Maybe<Service&> cache;
     kj::Maybe<kj::Own<SqliteDatabase::Vfs>> actorStorage;
     AlarmScheduler& alarmScheduler;
-    kj::Array<Service*> loggingServices;
+    kj::Array<Service*> tails;
   };
   using LinkCallback = kj::Function<LinkedIoChannels(WorkerService&)>;
   using AbortActorsCallback = kj::Function<void()>;
@@ -1665,7 +1665,7 @@ public:
 
     auto& channels = KJ_ASSERT_NONNULL(ioChannels.tryGet<LinkedIoChannels>());
 
-    auto tailWorkers = KJ_MAP(service, channels.loggingServices) -> kj::Own<WorkerInterface> {
+    auto tailWorkers = KJ_MAP(service, channels.tails) -> kj::Own<WorkerInterface> {
       KJ_ASSERT(service != this, "A worker currently cannot log to itself");
       // Caution here... if the tail worker ends up have a cirular dependency
       // on the worker we'll end up with an infinite loop trying to initialize.
@@ -3228,7 +3228,7 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name,
       }
     }
 
-    result.loggingServices = KJ_MAP(tail, conf.getTails()) {
+    result.tails = KJ_MAP(tail, conf.getTails()) {
       return &lookupService(tail, kj::str("Worker \"", name, "\"'s tails"));
     };
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1578,11 +1578,10 @@ public:
     kj::Maybe<Service&> cache;
     kj::Maybe<kj::Own<SqliteDatabase::Vfs>> actorStorage;
     AlarmScheduler& alarmScheduler;
+    kj::Array<Service*> loggingServices;
   };
   using LinkCallback = kj::Function<LinkedIoChannels(WorkerService&)>;
   using AbortActorsCallback = kj::Function<void()>;
-  using LookupServiceCallback =
-      kj::Function<Service&(config::ServiceDesignator::Reader, kj::StringPtr)>;
 
   WorkerService(ThreadContext& threadContext,
       kj::Own<const Worker> worker,
@@ -1590,17 +1589,13 @@ public:
       kj::HashMap<kj::String, kj::HashSet<kj::String>> namedEntrypointsParam,
       const kj::HashMap<kj::String, ActorConfig>& actorClasses,
       LinkCallback linkCallback,
-      AbortActorsCallback abortActorsCallback,
-      kj::Array<kj::Own<config::ServiceDesignator::Reader>> loggingServices,
-      LookupServiceCallback lookupService)
+      AbortActorsCallback abortActorsCallback)
       : threadContext(threadContext),
         ioChannels(kj::mv(linkCallback)),
         worker(kj::mv(worker)),
         defaultEntrypointHandlers(kj::mv(defaultEntrypointHandlers)),
         waitUntilTasks(*this),
-        abortActorsCallback(kj::mv(abortActorsCallback)),
-        loggingServices(kj::mv(loggingServices)),
-        lookupService(kj::mv(lookupService)) {
+        abortActorsCallback(kj::mv(abortActorsCallback)) {
 
     namedEntrypoints.reserve(namedEntrypointsParam.size());
     for (auto& ep: namedEntrypointsParam) {
@@ -1668,15 +1663,16 @@ public:
             kj::none /* stableId */, kj::none /* scriptName */, kj::none /* scriptVersion */,
             kj::none /* dispatchNamespace */, nullptr /* scriptTags */, kj::none /* entrypoint */);
 
-    auto tailWorkers = KJ_MAP(svc, loggingServices) -> kj::Own<WorkerInterface> {
-      auto& service = lookupService(*svc, "looking logging service");
-      KJ_ASSERT(&service != this, "A worker currently cannot log to itself");
+    auto& channels = KJ_ASSERT_NONNULL(ioChannels.tryGet<LinkedIoChannels>());
+
+    auto tailWorkers = KJ_MAP(service, channels.loggingServices) -> kj::Own<WorkerInterface> {
+      KJ_ASSERT(service != this, "A worker currently cannot log to itself");
       // Caution here... if the tail worker ends up have a cirular dependency
       // on the worker we'll end up with an infinite loop trying to initialize.
       // We can test this directly but it's more difficult to test indirect
       // loops (dependency of dependency, etc). Here we're just going to keep
       // it simple and just check the direct dependency.
-      return service.startRequest({});
+      return service->startRequest({});
     };
 
     // When the tracer is complete, deliver the traces to both the parent
@@ -2231,8 +2227,6 @@ private:
   kj::HashMap<kj::StringPtr, kj::Own<ActorNamespace>> actorNamespaces;
   kj::TaskSet waitUntilTasks;
   AbortActorsCallback abortActorsCallback;
-  kj::Array<kj::Own<config::ServiceDesignator::Reader>> loggingServices;
-  LookupServiceCallback lookupService;
 
   class ActorChannelImpl final: public IoChannelFactory::ActorChannel {
   public:
@@ -3234,34 +3228,33 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name,
       }
     }
 
+    auto logging = conf.getLogging();
+    switch (logging.which()) {
+      case config::Worker::Logging::Which::NONE: {
+        break;
+      }
+      case config::Worker::Logging::Which::TO_SERVICE: {
+        result.loggingServices = kj::arr(&lookupService(logging.getToService(),
+            kj::str("Worker \"", name, "\"'s logging")));
+        break;
+      }
+      case config::Worker::Logging::Which::TO_SERVICES: {
+        auto list = logging.getToServices();
+        auto builder = kj::heapArrayBuilder<Service*>(list.size());
+        for (auto svc: list) {
+          builder.add(&lookupService(svc, kj::str("Worker \"", name, "\"'s logging")));
+        }
+        result.loggingServices = builder.finish();
+        break;
+      }
+    }
+
     return result;
   };
 
-  kj::Vector<kj::Own<config::ServiceDesignator::Reader>> loggingServices;
-  auto logging = conf.getLogging();
-  switch (logging.which()) {
-    case config::Worker::Logging::Which::NONE: {
-      break;
-    }
-    case config::Worker::Logging::Which::TO_SERVICE: {
-      loggingServices.add(capnp::clone(logging.getToService()));
-      break;
-    }
-    case config::Worker::Logging::Which::TO_SERVICES: {
-      for (auto svc: logging.getToServices()) {
-        loggingServices.add(capnp::clone(svc));
-      }
-      break;
-    }
-  }
-
   return kj::heap<WorkerService>(globalContext->threadContext, kj::mv(worker),
       kj::mv(errorReporter.defaultEntrypoint), kj::mv(errorReporter.namedEntrypoints),
-      localActorConfigs, kj::mv(linkCallback), KJ_BIND_METHOD(*this, abortAllActors),
-      loggingServices.releaseAsArray(),
-      [this](const config::ServiceDesignator::Reader& service, kj::StringPtr context) -> Service& {
-    return lookupService(service, kj::str(context));
-  });
+      localActorConfigs, kj::mv(linkCallback), KJ_BIND_METHOD(*this, abortAllActors));
 }
 
 // =======================================================================================

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3232,35 +3232,6 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name,
       return &lookupService(tail, kj::str("Worker \"", name, "\"'s tails"));
     };
 
-    // Also check deprecated `logging` field.
-    if (conf.hasTails()) {
-      if (!conf.getLogging().isNone()) {
-        reportConfigError(kj::str("service ", name,
-            ": Config specifies both `logging` and `tails`. Please use only `tails`."));
-      }
-    } else {
-      auto logging = conf.getLogging();
-      switch (logging.which()) {
-        case config::Worker::Logging::Which::NONE: {
-          break;
-        }
-        case config::Worker::Logging::Which::TO_SERVICE: {
-          result.loggingServices = kj::arr(
-              &lookupService(logging.getToService(), kj::str("Worker \"", name, "\"'s logging")));
-          break;
-        }
-        case config::Worker::Logging::Which::TO_SERVICES: {
-          auto list = logging.getToServices();
-          auto builder = kj::heapArrayBuilder<Service*>(list.size());
-          for (auto svc: list) {
-            builder.add(&lookupService(svc, kj::str("Worker \"", name, "\"'s logging")));
-          }
-          result.loggingServices = builder.finish();
-          break;
-        }
-      }
-    }
-
     return result;
   };
 

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -630,16 +630,9 @@ struct Worker {
 
   moduleFallback @13 :Text;
 
-  tails @17 :List(ServiceDesignator);
+  tails @14 :List(ServiceDesignator);
   # List of tail worker services that should receive tail events for this worker.
   # See: https://developers.cloudflare.com/workers/observability/logs/tail-workers/
-
-  logging :union {
-    # DEPRECATED: Use `tails` instead. `logging` does exactly the same thing.
-    none @14 :Void;
-    toService @15 :ServiceDesignator;
-    toServices @16 :List(ServiceDesignator);
-  }
 }
 
 struct ExternalServer {

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -630,8 +630,12 @@ struct Worker {
 
   moduleFallback @13 :Text;
 
-  # Tail worker configuration
+  tails @17 :List(ServiceDesignator);
+  # List of tail worker services that should receive tail events for this worker.
+  # See: https://developers.cloudflare.com/workers/observability/logs/tail-workers/
+
   logging :union {
+    # DEPRECATED: Use `tails` instead. `logging` does exactly the same thing.
     none @14 :Void;
     toService @15 :ServiceDesignator;
     toServices @16 :List(ServiceDesignator);


### PR DESCRIPTION
This fixes some issues from #3021, which I noticed while working on something unrelated.

The third commit is more of a suggestion. Do we think anyone is using `logging` yet? If so, maybe I should drop this commit. If not, maybe I should change the commit to actually remove `logging` in favor of the simpler flat array which I've named `tails`... let me know.