### PR TITLE
Implement connection props.

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -204,6 +204,9 @@ class TestController: public jsg::Object {
 
 class ExecutionContext: public jsg::Object {
  public:
+  ExecutionContext(jsg::Lock& js): props(js, js.obj()) {}
+  ExecutionContext(jsg::Lock& js, jsg::JsValue props): props(js, props) {}
+
   void waitUntil(kj::Promise<void> promise);
   void passThroughOnException();
 
@@ -211,9 +214,14 @@ class ExecutionContext: public jsg::Object {
   // and throwing an error at the client.
   void abort(jsg::Lock& js, jsg::Optional<jsg::Value> reason);
 
+  jsg::JsValue getProps(jsg::Lock& js) {
+    return props.getHandle(js);
+  }
+
   JSG_RESOURCE_TYPE(ExecutionContext, CompatibilityFlags::Reader flags) {
     JSG_METHOD(waitUntil);
     JSG_METHOD(passThroughOnException);
+    JSG_LAZY_INSTANCE_PROPERTY(props, getProps);
 
     if (flags.getWorkerdExperimental()) {
       // TODO(soon): Before making this generally available we need to:
@@ -228,6 +236,17 @@ class ExecutionContext: public jsg::Object {
       //   consistent with each other.
       JSG_METHOD(abort);
     }
+  }
+
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackField("props", props);
+  }
+
+ private:
+  jsg::JsRef<jsg::JsValue> props;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(props);
   }
 };
 

--- a/src/workerd/api/hibernatable-web-socket.h
+++ b/src/workerd/api/hibernatable-web-socket.h
@@ -66,6 +66,7 @@ class HibernatableWebSocketCustomEventImpl final: public WorkerInterface::Custom
 
   kj::Promise<Result> run(kj::Own<IoContext_IncomingRequest> incomingRequest,
       kj::Maybe<kj::StringPtr> entrypointName,
+      Frankenvalue props,
       kj::TaskSet& waitUntilTasks) override;
 
   kj::Promise<Result> sendRpc(capnp::HttpOverCapnpFactory& httpOverCapnpFactory,

--- a/src/workerd/api/queue.h
+++ b/src/workerd/api/queue.h
@@ -341,6 +341,7 @@ class QueueCustomEventImpl final: public WorkerInterface::CustomEvent, public kj
 
   kj::Promise<Result> run(kj::Own<IoContext_IncomingRequest> incomingRequest,
       kj::Maybe<kj::StringPtr> entrypointName,
+      Frankenvalue props,
       kj::TaskSet& waitUntilTasks) override;
 
   kj::Promise<Result> sendRpc(capnp::HttpOverCapnpFactory& httpOverCapnpFactory,

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -615,6 +615,7 @@ class TraceCustomEventImpl final: public WorkerInterface::CustomEvent {
 
   kj::Promise<Result> run(kj::Own<IoContext::IncomingRequest> incomingRequest,
       kj::Maybe<kj::StringPtr> entrypointName,
+      Frankenvalue props,
       kj::TaskSet& waitUntilTasks) override;
 
   kj::Promise<Result> sendRpc(capnp::HttpOverCapnpFactory& httpOverCapnpFactory,

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -420,6 +420,7 @@ class JsRpcSessionCustomEventImpl final: public WorkerInterface::CustomEvent {
 
   kj::Promise<Result> run(kj::Own<IoContext::IncomingRequest> incomingRequest,
       kj::Maybe<kj::StringPtr> entrypointName,
+      Frankenvalue props,
       kj::TaskSet& waitUntilTasks) override;
 
   kj::Promise<Result> sendRpc(capnp::HttpOverCapnpFactory& httpOverCapnpFactory,

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -220,6 +220,7 @@ wd_cc_library(
     hdrs = ["worker-interface.h"],
     visibility = ["//visibility:public"],
     deps = [
+        ":frankenvalue_capnp",
         ":worker-interface_capnp",
         "@capnp-cpp//src/capnp:capnp-rpc",
         "@capnp-cpp//src/capnp:capnpc",

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -46,6 +46,7 @@ wd_cc_library(
     srcs = [
         "compatibility-date.c++",
         "features.c++",
+        "frankenvalue.c++",
         "hibernation-manager.c++",
         "io-context.c++",
         "io-own.c++",
@@ -58,6 +59,7 @@ wd_cc_library(
     hdrs = [
         "compatibility-date.h",
         "features.h",
+        "frankenvalue.h",
         "hibernation-manager.h",
         "io-channels.h",
         "io-context.h",
@@ -87,6 +89,7 @@ wd_cc_library(
         ":actor-id",
         ":actor-storage_capnp",
         ":cdp_capnp",
+        ":frankenvalue_capnp",
         ":io-gate",
         ":io-helpers",
         ":limit-enforcer",
@@ -273,6 +276,8 @@ wd_capnp_library(src = "compatibility-date.capnp")
 
 wd_capnp_library(src = "features.capnp")
 
+wd_capnp_library(src = "frankenvalue.capnp")
+
 kj_test(
     src = "io-gate-test.c++",
     deps = [
@@ -326,5 +331,12 @@ kj_test(
     deps = [
         ":trace",
         "//src/workerd/util:thread-scopes",
+    ],
+)
+
+kj_test(
+    src = "frankenvalue-test.c++",
+    deps = [
+        ":io",
     ],
 )

--- a/src/workerd/io/frankenvalue-test.c++
+++ b/src/workerd/io/frankenvalue-test.c++
@@ -1,0 +1,56 @@
+#include "frankenvalue.h"
+
+#include <workerd/jsg/jsg-test.h>
+
+#include <capnp/message.h>
+#include <kj/debug.h>
+#include <kj/test.h>
+
+namespace workerd {
+namespace {
+
+jsg::V8System v8System;
+class ContextGlobalObject: public jsg::Object, public jsg::ContextGlobal {};
+
+struct TestContext: public ContextGlobalObject {
+  JSG_RESOURCE_TYPE(TestContext) {}
+};
+JSG_DECLARE_ISOLATE_TYPE(TestIsolate, TestContext);
+
+KJ_TEST("Frankenvalue") {
+  jsg::test::Evaluator<TestContext, TestIsolate> e(v8System);
+
+  e.run([&](jsg::Lock& js) {
+    // Create a value based on JSON.
+    Frankenvalue value = Frankenvalue::fromJson(kj::str(R"({"baz": 321, "qux": "xyz"})"_kj));
+
+    // prop1 is empty.
+    value.setProperty(kj::str("prop1"), {});
+
+    // prop2 is a V8-serialized value.
+    value.setProperty(kj::str("prop2"), ({
+      auto obj = js.obj();
+      obj.set(js, "foo", js.num(123));
+      obj.set(js, "bar", js.str("abc"_kj));
+      Frankenvalue::fromJs(js, obj);
+    }));
+
+    // Round trip through capnp.
+    {
+      capnp::MallocMessageBuilder message;
+      auto builder = message.initRoot<rpc::Frankenvalue>();
+      value.toCapnp(builder);
+      value = Frankenvalue::fromCapnp(builder.asReader());
+    }
+
+    // Use clone().
+    value = value.clone();
+
+    // Back to JS, then JSON, then check that nothing was lost.
+    KJ_EXPECT(js.serializeJson(value.toJs(js)) ==
+        R"({"baz":321,"qux":"xyz","prop1":{},"prop2":{"foo":123,"bar":"abc"}})"_kj);
+  });
+}
+
+}  // namespace
+}  // namespace workerd

--- a/src/workerd/io/frankenvalue.c++
+++ b/src/workerd/io/frankenvalue.c++
@@ -1,0 +1,148 @@
+#include "frankenvalue.h"
+
+#include <workerd/jsg/ser.h>
+
+namespace workerd {
+
+Frankenvalue Frankenvalue::clone() const {
+  Frankenvalue result;
+
+  KJ_SWITCH_ONEOF(value) {
+    KJ_CASE_ONEOF(_, EmptyObject) {
+      result.value = EmptyObject();
+    }
+    KJ_CASE_ONEOF(json, Json) {
+      result.value = Json{kj::str(json.json)};
+    }
+    KJ_CASE_ONEOF(v8Serialized, V8Serialized) {
+      result.value = V8Serialized{kj::heapArray(v8Serialized.data.asPtr())};
+    }
+  }
+
+  if (properties.size() > 0) {
+    result.properties.reserve(properties.size());
+
+    for (auto& property: properties) {
+      result.properties.add(Property{
+        .name = kj::str(property.name),
+        .value = property.value.clone(),
+      });
+    }
+  }
+
+  return result;
+}
+
+void Frankenvalue::toCapnp(rpc::Frankenvalue::Builder builder) const {
+  KJ_SWITCH_ONEOF(value) {
+    KJ_CASE_ONEOF(_, EmptyObject) {
+      builder.setEmptyObject();
+    }
+    KJ_CASE_ONEOF(json, Json) {
+      builder.setJson(json.json);
+    }
+    KJ_CASE_ONEOF(v8Serialized, V8Serialized) {
+      builder.setV8Serialized(v8Serialized.data);
+    }
+  }
+
+  if (properties.size() > 0) {
+    auto listBuilder = builder.initProperties(properties.size());
+
+    for (auto i: kj::indices(properties)) {
+      auto elemBuilder = listBuilder[i];
+      elemBuilder.setName(properties[i].name);
+      properties[i].value.toCapnp(elemBuilder);
+    }
+  }
+}
+
+Frankenvalue Frankenvalue::fromCapnp(rpc::Frankenvalue::Reader reader) {
+  Frankenvalue result;
+
+  switch (reader.which()) {
+    case rpc::Frankenvalue::EMPTY_OBJECT:
+      result.value = EmptyObject();
+      break;
+    case rpc::Frankenvalue::JSON:
+      result.value = Json{kj::str(reader.getJson())};
+      break;
+    case rpc::Frankenvalue::V8_SERIALIZED:
+      result.value = V8Serialized{kj::heapArray(reader.getV8Serialized())};
+      break;
+  }
+
+  auto properties = reader.getProperties();
+  if (properties.size() > 0) {
+    result.properties.reserve(properties.size());
+
+    for (auto property: properties) {
+      result.properties.add(Property{
+        .name = kj::str(property.getName()),
+        .value = fromCapnp(property),
+      });
+    }
+  }
+
+  return result;
+}
+
+jsg::JsValue Frankenvalue::toJs(jsg::Lock& js) const {
+  // TODO(cleanup): Make `withinHandleScope()` correctly support `jsg::JsValue` and friends.
+  return jsg::JsValue(js.withinHandleScope([&]() -> v8::Local<v8::Value> {
+    jsg::JsValue result = [&]() -> jsg::JsValue {
+      KJ_SWITCH_ONEOF(value) {
+        KJ_CASE_ONEOF(_, EmptyObject) {
+          return js.obj();
+        }
+        KJ_CASE_ONEOF(json, Json) {
+          // TODO(cleanup): Make jsg::Lock::parseJson() not return a persistent handle.
+          return jsg::JsValue(jsg::check(v8::JSON::Parse(js.v8Context(), js.str(json.json))));
+        }
+        KJ_CASE_ONEOF(v8Serialized, V8Serialized) {
+          jsg::Deserializer deser(js, v8Serialized.data);
+          return deser.readValue(js);
+        }
+      }
+      KJ_UNREACHABLE;
+    }();
+
+    if (properties.size() > 0) {
+      jsg::JsObject obj = KJ_REQUIRE_NONNULL(
+          result.tryCast<jsg::JsObject>(), "non-object Frakenvalue can't have properties");
+
+      for (auto& property: properties) {
+        obj.set(js, property.name, property.value.toJs(js));
+      }
+    }
+
+    return result;
+  }));
+}
+
+Frankenvalue Frankenvalue::fromJs(jsg::Lock& js, jsg::JsValue value) {
+  Frankenvalue result;
+
+  js.withinHandleScope([&]() {
+    jsg::Serializer ser(js, {.treatClassInstancesAsPlainObjects = false});
+    ser.write(js, value);
+    result.value = V8Serialized{ser.release().data};
+  });
+
+  return result;
+}
+
+Frankenvalue Frankenvalue::fromJson(kj::String json) {
+  Frankenvalue result;
+  result.value = Json{kj::mv(json)};
+  return result;
+}
+
+void Frankenvalue::setProperty(kj::String name, Frankenvalue value) {
+  properties.add(Property{
+    .name = kj::mv(name),
+    .value = kj::mv(value),
+  });
+}
+
+}  // namespace workerd

--- a/src/workerd/io/frankenvalue.capnp
+++ b/src/workerd/io/frankenvalue.capnp
@@ -1,0 +1,37 @@
+@0xcc3b225cb3101aba;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("workerd::rpc");
+$Cxx.allowCancellation;
+
+struct Frankenvalue {
+  # Represents a JavaScript value that has been stitched together from multiple sources outside of
+  # a JavaScript evaluation context. The Frankevalue can be evaluated down to a JS value as soon
+  # as it has a JS execution environment in which to be evaluated.
+  #
+  # This is used in particular to represent `ctx.props`.
+
+  union {
+    emptyObject @0 :Void;
+    # Just an object with no properties.
+
+    json @1 :Text;
+    # Parse this JSON-formatted text to compute the value.
+
+    v8Serialized @2 :Data;
+    # Parse these V8-serialized bytes to compute the value.
+  }
+
+  properties @3 :List(Frankenvalue);
+  # Additional properties to add to the value. The base value (specified by the union above) must
+  # be an object. Each property in this list must have a `name`. They will be added as properties
+  # of the object.
+  #
+  # If a property in the list conflicts with a property that already exists in the base value,
+  # the property is overwritten with the value from the `properties` list.
+
+  name @4 :Text;
+  # Property name. Used only when this `Frankenvalue` represents a property, that is, it is an
+  # element within the `properties` list of some other `Frankenvalue`. If this is the root value,
+  # then `name` must be null.
+}

--- a/src/workerd/io/frankenvalue.h
+++ b/src/workerd/io/frankenvalue.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2024 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <workerd/io/frankenvalue.capnp.h>
+#include <workerd/jsg/jsg.h>
+
+namespace workerd {
+
+// C++ class mirroring `Frankenvalue` as defined in `frankenvalue.capnp`.
+//
+// Represents a JavaScript value that has been stitched together from multiple sources outside of
+// a JavaScript evaluation context. The Frankevalue can be evaluated down to a JS value as soon
+// as it has a JS execution environment in which to be evaluated.
+//
+// This is used in particular to represent `ctx.props`.
+class Frankenvalue {
+ public:
+  Frankenvalue(): value(EmptyObject()) {}
+
+  bool empty() const {
+    return value.is<EmptyObject>() && properties.empty();
+  }
+
+  Frankenvalue clone() const;
+
+  // Convert to/from capnp format.
+  void toCapnp(rpc::Frankenvalue::Builder builder) const;
+  static Frankenvalue fromCapnp(rpc::Frankenvalue::Reader reader);
+
+  // Convert to/from JavaScript values. Note that round trips here don't produce the exact same
+  // Frankenvalue representation: toJs() puts all the contents together into a single value, and
+  // fromJs() always returns a Frakenvalue containing a single V8-serialized value.
+  jsg::JsValue toJs(jsg::Lock& js) const;
+  static Frankenvalue fromJs(jsg::Lock& js, jsg::JsValue value);
+
+  // Construct a Frakenvalue from JSON.
+  //
+  // (It's not possible to convert a Frakenvalue back to JSON, except by evaluating it in JS and
+  // then JSON-stringifying from there.)
+  static Frankenvalue fromJson(kj::String json);
+
+  // Add a property to the value, represented as another Frankenvalue. This is how you "stitch
+  // together" values!
+  //
+  // This is called `set` because the new property will override any existing property with the
+  // same name, but note that this strictly appends content. The replacement happens only when the
+  // Frankenvalue is finally converted to JS.
+  void setProperty(kj::String name, Frankenvalue value);
+
+ private:
+  struct EmptyObject {};
+  struct Json {
+    kj::String json;
+  };
+  struct V8Serialized {
+    kj::Array<byte> data;
+  };
+  kj::OneOf<EmptyObject, Json, V8Serialized> value;
+
+  struct Property;
+  kj::Vector<Property> properties;
+};
+
+// Can't be defined inline since `Frankenvalue` is still incomplete there.
+struct Frankenvalue::Property {
+  kj::String name;
+  Frankenvalue value;
+};
+
+}  // namespace workerd

--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <workerd/io/frankenvalue.capnp.h>
 #include <workerd/io/worker.h>
 
 namespace workerd {
@@ -30,6 +31,7 @@ class InvocationSpanContext;
 kj::Own<WorkerInterface> newWorkerEntrypoint(ThreadContext& threadContext,
     kj::Own<const Worker> worker,
     kj::Maybe<kj::StringPtr> entrypointName,
+    Frankenvalue props,
     kj::Maybe<kj::Own<Worker::Actor>> actor,
     kj::Own<LimitEnforcer> limitEnforcer,
     kj::Own<void> ioContextDependency,

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -12,6 +12,7 @@
 
 namespace workerd {
 
+class Frankenvalue;
 class IoContext_IncomingRequest;
 
 // An interface representing the services made available by a worker/pipeline to handle a
@@ -111,6 +112,7 @@ class WorkerInterface: public kj::HttpService {
     // for this event.
     virtual kj::Promise<Result> run(kj::Own<IoContext_IncomingRequest> incomingRequest,
         kj::Maybe<kj::StringPtr> entrypointName,
+        Frankenvalue props,
         kj::TaskSet& waitUntilTasks) = 0;
 
     // Forward the event over RPC.

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -8,6 +8,7 @@
 #include <workerd/io/actor-cache.h>  // because we can't forward-declare ActorCache::SharedLru.
 #include <workerd/io/actor-id.h>
 #include <workerd/io/compatibility-date.capnp.h>
+#include <workerd/io/frankenvalue.h>
 #include <workerd/io/io-channels.h>
 #include <workerd/io/limit-enforcer.h>
 #include <workerd/io/outcome.capnp.h>
@@ -627,10 +628,12 @@ class Worker::Lock {
   // default handler. Returns null if this is not a modules-syntax worker (but `entrypointName`
   // must be null in that case).
   //
-  // If running in an actor, the name is ignored and the entrypoint originally used to construct
-  // the actor is returned.
+  // `props` is the value to place in `ctx.props`.
+  //
+  // If running in an actor, the name and props are ignored and the entrypoint originally used to
+  // construct the actor is returned.
   kj::Maybe<kj::Own<api::ExportedHandler>> getExportedHandler(
-      kj::Maybe<kj::StringPtr> entrypointName, kj::Maybe<Worker::Actor&> actor);
+      kj::Maybe<kj::StringPtr> entrypointName, Frankenvalue props, kj::Maybe<Worker::Actor&> actor);
 
   // Get the C++ object representing the global scope.
   api::ServiceWorkerGlobalScope& getGlobalScope();

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -41,7 +41,7 @@ class Server final: private kj::TaskSet::ErrorHandler {
       kj::EntropySource& entropySource,
       Worker::ConsoleMode consoleMode,
       kj::Function<void(kj::String)> reportConfigError);
-  ~Server() noexcept(false);
+  ~Server() noexcept;
 
   // Permit experimental features to be used. These features may break backwards compatibility
   // in the future.
@@ -216,10 +216,13 @@ class Server final: private kj::TaskSet::ErrorHandler {
   void abortAllActors();
 
   // Can only be called in the link stage.
-  Service& lookupService(config::ServiceDesignator::Reader designator, kj::String errorContext);
+  //
+  // May return a new object or may return a fake-own around a long-lived object.
+  kj::Own<Service> lookupService(
+      config::ServiceDesignator::Reader designator, kj::String errorContext);
 
   kj::Promise<void> listenHttp(kj::Own<kj::ConnectionReceiver> listener,
-      Service& service,
+      kj::Own<Service> service,
       kj::StringPtr physicalProtocol,
       kj::Own<HttpRewriter> rewriter);
 

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -192,6 +192,16 @@ struct ServiceDesignator {
   # `entrypoint` is specified here, it names an alternate entrypoint to use on the target worker,
   # otherwise the default is used.
 
+  props :union {
+    # Value to provide in `ctx.props` in the target worker.
+
+    empty @2 :Void;
+    # Empty object. (This is the default.)
+
+    json @3 :Text;
+    # A JSON-encoded value.
+  }
+
   # TODO(someday): Options to specify which event types are allowed.
   # TODO(someday): Allow adding an outgoing middleware stack here (see TODO in Service, above).
 }

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -425,7 +425,7 @@ TestFixture::Response TestFixture::runRequest(
   runInIoContext([&](const TestFixture::Environment& env) {
     auto& globalScope = env.lock.getGlobalScope();
     return globalScope.request(method, url, requestHeaders, *requestBody, response, "{}"_kj,
-        env.lock, env.lock.getExportedHandler(kj::none, kj::none));
+        env.lock, env.lock.getExportedHandler(kj::none, {}, kj::none));
   });
 
   return {.statusCode = response.statusCode, .body = response.body->str()};

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -392,6 +392,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -394,6 +394,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -392,6 +392,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -394,6 +394,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -395,6 +395,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -397,6 +397,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -395,6 +395,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -397,6 +397,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -395,6 +395,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -397,6 +397,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -400,6 +400,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -402,6 +402,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -400,6 +400,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -402,6 +402,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -400,6 +400,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -402,6 +402,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -400,6 +400,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
   abort(reason?: any): void;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -402,6 +402,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
   abort(reason?: any): void;
 }
 export type ExportedHandlerFetchHandler<

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -392,6 +392,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -394,6 +394,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
+  props: any;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,


### PR DESCRIPTION
This adds `ctx.props` to the `ctx` object given to `WorkerEntrypoint`s. The property receives metadata about the particular service binding over which the entrypoint was invoked.

```
class MyEntrypoint extends WorkerEntrypoint {
  foo() {
    console.log("called by: " + this.ctx.props.caller);
  }
}
```

Service binding declarations in the workerd config may specify what metadata to pass:

```
bindings = [
  ( name = "FOO",
    service = (
      name = "my-service",
      entrypoint = "MyEntrypoint",
      props = (
        json = `{"caller": "my-calling-service"}
      )
    )
  )
]
```

Note that "caller" is just an example. The props can contain anything. Use cases include:
* Authentication of the caller's identity.
* Authorization / permissions (independent of caller identity).
* Specifying a particular resource. For example, if the `WorkerEntrypoint` represents a chat room, `props.roomId` could be the ID of the specific chat room to access.

This allows service bindings to implement a deeper capability-based security model, where bindings point to specific resources with specific permissions, instead of general APIs.

On Cloudflare, only users who have permission to modify your worker will have permission to create a binding containing arbitrary metadata. Meanwhile we will be creating a mechanism by which you can grant a service binding to your worker to someone, but where you specify the metadata. Thus, you can use the metadata to authenticate requests, without the need for any cryptography.