### PR TITLE
Enable cache: no-cache compat flag and enum

### DIFF
--- a/src/workerd/api/http-test-ts.ts-wd-test
+++ b/src/workerd/api/http-test-ts.ts-wd-test
@@ -10,6 +10,7 @@ const unitTests :Workerd.Config = (
         bindings = [
           ( name = "SERVICE", service = "http-test" ),
           ( name = "CACHE_ENABLED", json = "false" ),
+          ( name = "NO_CACHE_ENABLED", json = "false" ),
         ],
         compatibilityDate = "2023-08-01",
         compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "cache_option_disabled"],
@@ -23,9 +24,24 @@ const unitTests :Workerd.Config = (
         bindings = [
           ( name = "SERVICE", service = "http-test-cache-option-enabled" ),
           ( name = "CACHE_ENABLED", json = "true" ),
+          ( name = "NO_CACHE_ENABLED", json = "false" ),
         ],
-        compatibilityDate = "2023-08-01",
-        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "cache_option_enabled"],
+        compatibilityDate = "2024-11-11",
+        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers"],
+      )
+    ),
+    ( name = "http-test-cache-no-cache",
+      worker = (
+        modules = [
+          ( name = "worker-cache-no-cache", esModule = embed "http-test-ts.js" )
+        ],
+        bindings = [
+          ( name = "SERVICE", service = "http-test-cache-no-cache" ),
+          ( name = "CACHE_ENABLED", json = "true" ),
+          ( name = "NO_CACHE_ENABLED", json = "true" ),
+        ],
+        compatibilityDate = "2024-11-11",
+        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "cache_no_cache_enabled"],
       )
     ),
   ],

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1214,7 +1214,7 @@ kj::Maybe<kj::String> Request::serializeCfBlobJson(jsg::Lock& js) {
       break;
     case CacheMode::NOCACHE:
       ttl = 0;
-      KJ_FALLTHROUGH;
+      break;
     case CacheMode::NONE:
       KJ_UNREACHABLE;
   }
@@ -1239,8 +1239,11 @@ void RequestInitializerDict::validate(jsg::Lock& js) {
 
     // Validate that the cache type is valid
     auto cacheMode = getCacheModeFromName(c);
-    JSG_REQUIRE(cacheMode != Request::CacheMode::NOCACHE, TypeError,
-        kj::str("Unsupported cache mode: ", c));
+
+    if (!FeatureFlags::get(js).getCacheNoCache()) {
+      JSG_REQUIRE(cacheMode != Request::CacheMode::NOCACHE, TypeError,
+          kj::str("Unsupported cache mode: ", c));
+    }
   }
 }
 

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -755,12 +755,21 @@ struct RequestInitializerDict {
              referrer, referrerPolicy, integrity, signal);
   JSG_STRUCT_TS_OVERRIDE_DYNAMIC(CompatibilityFlags::Reader flags) {
     if(flags.getCacheOptionEnabled()) {
-      JSG_TS_OVERRIDE(RequestInit<Cf = CfProperties> {
-        headers?: HeadersInit;
-        body?: BodyInit | null;
-        cache?: 'no-store';
-        cf?: Cf;
-      });
+      if(flags.getCacheNoCache()) {
+        JSG_TS_OVERRIDE(RequestInit<Cf = CfProperties> {
+          headers?: HeadersInit;
+          body?: BodyInit | null;
+          cache?: 'no-store' | 'no-cache';
+          cf?: Cf;
+        });
+      } else {
+        JSG_TS_OVERRIDE(RequestInit<Cf = CfProperties> {
+          headers?: HeadersInit;
+          body?: BodyInit | null;
+          cache?: 'no-store';
+          cf?: Cf;
+        });
+      }
     } else {
       JSG_TS_OVERRIDE(RequestInit<Cf = CfProperties> {
         headers?: HeadersInit;
@@ -929,12 +938,21 @@ public:
       JSG_READONLY_PROTOTYPE_PROPERTY(keepalive, getKeepalive);
       if(flags.getCacheOptionEnabled()) {
         JSG_READONLY_PROTOTYPE_PROPERTY(cache, getCache);
-        JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
-          constructor(input: RequestInfo<CfProperties> | URL, init?: RequestInit<Cf>);
-          clone(): Request<CfHostMetadata, Cf>;
-          cache?: "no-store";
-          get cf(): Cf | undefined;
-        });
+        if(flags.getCacheNoCache()) {
+          JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
+            constructor(input: RequestInfo<CfProperties> | URL, init?: RequestInit<Cf>);
+            clone(): Request<CfHostMetadata, Cf>;
+            cache?: "no-store" | "no-cache";
+            get cf(): Cf | undefined;
+          });
+        } else {
+          JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
+            constructor(input: RequestInfo<CfProperties> | URL, init?: RequestInit<Cf>);
+            clone(): Request<CfHostMetadata, Cf>;
+            cache?: "no-store";
+            get cf(): Cf | undefined;
+          });
+        }
       } else {
         JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
           constructor(input: RequestInfo<CfProperties> | URL, init?: RequestInit<Cf>);

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -673,4 +673,10 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   tailWorkerUserSpans @69 :Bool
       $compatEnableFlag("tail_worker_user_spans")
       $experimental;
+
+  cacheNoCache @70 :Bool
+      $compatEnableFlag("cache_no_cache_enabled")
+      $compatDisableFlag("cache_no_cache_disabled")
+      $experimental;
+  # Enables the use of cache: no-cache in the fetch api.
 }


### PR DESCRIPTION
First part of `cache: no-cache` implementation:
- Work-shopping the test infrastructure in workerd.
- Allow no-cache construction
- Update typescript information

Note that the actual implementation is incompelete.