### PR TITLE
Add AI Gateway universal run method

### DIFF
--- a/src/cloudflare/ai.ts
+++ b/src/cloudflare/ai.ts
@@ -6,7 +6,10 @@ export {
   AiOptions,
   InferenceUpstreamError,
   Ai,
+} from 'cloudflare-internal:ai-api';
+
+export {
   AiGateway,
   AiGatewayInternalError,
   AiGatewayLogNotFound,
-} from 'cloudflare-internal:ai-api';
+} from 'cloudflare-internal:aig-api';

--- a/src/cloudflare/internal/ai-api.ts
+++ b/src/cloudflare/internal/ai-api.ts
@@ -2,6 +2,8 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+import { AiGateway, type GatewayOptions } from 'cloudflare-internal:aig-api';
+
 interface Fetcher {
   fetch: typeof fetch;
 }
@@ -16,15 +18,6 @@ interface AiError {
 export type SessionOptions = {
   // Deprecated, do not use this
   extraHeaders?: object;
-};
-
-export type GatewayOptions = {
-  id: string;
-  cacheKey?: string;
-  cacheTtl?: number;
-  skipCache?: boolean;
-  metadata?: Record<string, number | string | boolean | null | bigint>;
-  collectLog?: boolean;
 };
 
 export type AiOptions = {
@@ -153,135 +146,6 @@ export class Ai {
 
   public gateway(gatewayId: string): AiGateway {
     return new AiGateway(this.fetcher, gatewayId);
-  }
-}
-
-//
-// Ai Gateway
-//
-
-export type AiGatewayPatchLog = {
-  score?: number | null;
-  feedback?: -1 | 1 | '-1' | '1' | null;
-  metadata?: Record<string, number | string | boolean | null | bigint> | null;
-};
-
-export type AiGatewayLog = {
-  id: string;
-  provider: string;
-  model: string;
-  model_type?: string;
-  path: string;
-  duration: number;
-  request_type?: string;
-  request_content_type?: string;
-  status_code: number;
-  response_content_type?: string;
-  success: boolean;
-  cached: boolean;
-  tokens_in?: number;
-  tokens_out?: number;
-  metadata?: Record<string, number | string | boolean | null | bigint>;
-  step?: number;
-  cost?: number;
-  custom_cost?: boolean;
-  request_size: number;
-  request_head?: string;
-  request_head_complete: boolean;
-  response_size: number;
-  response_head?: string;
-  response_head_complete: boolean;
-  created_at: Date;
-};
-
-export class AiGatewayInternalError extends Error {
-  public constructor(message: string) {
-    super(message);
-    this.name = 'AiGatewayInternalError';
-  }
-}
-
-export class AiGatewayLogNotFound extends Error {
-  public constructor(message: string) {
-    super(message);
-    this.name = 'AiGatewayLogNotFound';
-  }
-}
-
-export class AiGateway {
-  private readonly fetcher: Fetcher;
-  private readonly gatewayId: string;
-
-  public constructor(fetcher: Fetcher, gatewayId: string) {
-    this.fetcher = fetcher;
-    this.gatewayId = gatewayId;
-  }
-
-  public async getLog(logId: string): Promise<AiGatewayLog> {
-    const res = await this.fetcher.fetch(
-      `https://workers-binding.ai/ai-gateway/gateways/${this.gatewayId}/logs/${logId}`,
-      {
-        method: 'GET',
-      }
-    );
-
-    switch (res.status) {
-      case 200: {
-        const data = (await res.json()) as { result: AiGatewayLog };
-
-        return {
-          ...data.result,
-          created_at: new Date(data.result.created_at),
-        };
-      }
-      case 404: {
-        const data = (await res.json()) as { errors: { message: string }[] };
-
-        throw new AiGatewayLogNotFound(
-          data.errors[0]?.message || 'Log Not Found'
-        );
-      }
-      default: {
-        const data = (await res.json()) as { errors: { message: string }[] };
-
-        throw new AiGatewayInternalError(
-          data.errors[0]?.message || 'Internal Error'
-        );
-      }
-    }
-  }
-
-  public async patchLog(logId: string, data: AiGatewayPatchLog): Promise<void> {
-    const res = await this.fetcher.fetch(
-      `https://workers-binding.ai/ai-gateway/gateways/${this.gatewayId}/logs/${logId}`,
-      {
-        method: 'PATCH',
-        body: JSON.stringify(data),
-        headers: {
-          'content-type': 'application/json',
-        },
-      }
-    );
-
-    switch (res.status) {
-      case 200: {
-        return;
-      }
-      case 404: {
-        const data = (await res.json()) as { errors: { message: string }[] };
-
-        throw new AiGatewayLogNotFound(
-          data.errors[0]?.message || 'Log Not Found'
-        );
-      }
-      default: {
-        const data = (await res.json()) as { errors: { message: string }[] };
-
-        throw new AiGatewayInternalError(
-          data.errors[0]?.message || 'Internal Error'
-        );
-      }
-    }
   }
 }
 

--- a/src/cloudflare/internal/aig-api.ts
+++ b/src/cloudflare/internal/aig-api.ts
@@ -1,0 +1,211 @@
+// Copyright (c) 2024 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+interface Fetcher {
+  fetch: typeof fetch;
+}
+
+export type GatewayOptions = {
+  id: string;
+  cacheKey?: string;
+  cacheTtl?: number;
+  skipCache?: boolean;
+  metadata?: Record<string, number | string | boolean | null | bigint>;
+  collectLog?: boolean;
+};
+
+export type AiGatewayPatchLog = {
+  score?: number | null;
+  feedback?: -1 | 1 | null;
+  metadata?: Record<string, number | string | boolean | null | bigint> | null;
+};
+
+export type AiGatewayLog = {
+  id: string;
+  provider: string;
+  model: string;
+  model_type?: string;
+  path: string;
+  duration: number;
+  request_type?: string;
+  request_content_type?: string;
+  status_code: number;
+  response_content_type?: string;
+  success: boolean;
+  cached: boolean;
+  tokens_in?: number;
+  tokens_out?: number;
+  metadata?: Record<string, number | string | boolean | null | bigint>;
+  step?: number;
+  cost?: number;
+  custom_cost?: boolean;
+  request_size: number;
+  request_head?: string;
+  request_head_complete: boolean;
+  response_size: number;
+  response_head?: string;
+  response_head_complete: boolean;
+  created_at: Date;
+};
+
+export type AIGatewayProviders =
+  | 'workers-ai'
+  | 'anthropic'
+  | 'aws-bedrock'
+  | 'azure-openai'
+  | 'google-vertex-ai'
+  | 'huggingface'
+  | 'openai'
+  | 'perplexity-ai'
+  | 'replicate'
+  | 'groq'
+  | 'cohere'
+  | 'google-ai-studio'
+  | 'mistral'
+  | 'grok'
+  | 'openrouter';
+
+export type AIGatewayHeaders = {
+  'cf-aig-metadata':
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  'cf-aig-custom-cost':
+    | { per_token_in?: number; per_token_out?: number }
+    | { total_cost?: number }
+    | string;
+  'cf-aig-cache-ttl': number | string;
+  'cf-aig-skip-cache': boolean | string;
+  'cf-aig-cache-key': string;
+  'cf-aig-collect-log': boolean | string;
+  Authorization: string;
+  'Content-Type': string;
+  [key: string]: string | number | boolean | object;
+};
+
+export type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
+
+export class AiGatewayInternalError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'AiGatewayInternalError';
+  }
+}
+
+export class AiGatewayLogNotFound extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'AiGatewayLogNotFound';
+  }
+}
+
+export class AiGateway {
+  readonly #fetcher: Fetcher;
+  readonly #gatewayId: string;
+
+  public constructor(fetcher: Fetcher, gatewayId: string) {
+    this.#fetcher = fetcher;
+    this.#gatewayId = gatewayId;
+  }
+
+  public async getLog(logId: string): Promise<AiGatewayLog> {
+    const res = await this.#fetcher.fetch(
+      `https://workers-binding.ai/ai-gateway/gateways/${this.#gatewayId}/logs/${logId}`,
+      {
+        method: 'GET',
+      }
+    );
+
+    switch (res.status) {
+      case 200: {
+        const data = (await res.json()) as { result: AiGatewayLog };
+
+        return {
+          ...data.result,
+          created_at: new Date(data.result.created_at),
+        };
+      }
+      case 404: {
+        const data = (await res.json()) as { errors: { message: string }[] };
+
+        throw new AiGatewayLogNotFound(
+          data.errors[0]?.message || 'Log Not Found'
+        );
+      }
+      default: {
+        const data = (await res.json()) as { errors: { message: string }[] };
+
+        throw new AiGatewayInternalError(
+          data.errors[0]?.message || 'Internal Error'
+        );
+      }
+    }
+  }
+
+  public async patchLog(logId: string, data: AiGatewayPatchLog): Promise<void> {
+    const res = await this.#fetcher.fetch(
+      `https://workers-binding.ai/ai-gateway/gateways/${this.#gatewayId}/logs/${logId}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+        headers: {
+          'content-type': 'application/json',
+        },
+      }
+    );
+
+    switch (res.status) {
+      case 200: {
+        return;
+      }
+      case 404: {
+        const data = (await res.json()) as { errors: { message: string }[] };
+
+        throw new AiGatewayLogNotFound(
+          data.errors[0]?.message || 'Log Not Found'
+        );
+      }
+      default: {
+        const data = (await res.json()) as { errors: { message: string }[] };
+
+        throw new AiGatewayInternalError(
+          data.errors[0]?.message || 'Internal Error'
+        );
+      }
+    }
+  }
+
+  public run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[]
+  ): Promise<Response> {
+    const input = Array.isArray(data) ? data : [data];
+
+    // Convert header values to string
+    for (const req of input) {
+      for (const [k, v] of Object.entries(req.headers)) {
+        if (typeof v === 'number' || typeof v === 'boolean') {
+          req.headers[k] = v.toString();
+          // eslint-disable-next-line
+        } else if (typeof v === 'object' && v != null) {
+          req.headers[k] = JSON.stringify(v);
+        }
+      }
+    }
+
+    return this.#fetcher.fetch(
+      `https://workers-binding.ai/ai-gateway/universal/run/${this.#gatewayId}`,
+      {
+        method: 'POST',
+        body: JSON.stringify(input),
+        headers: {
+          'content-type': 'application/json',
+        },
+      }
+    );
+  }
+}

--- a/src/cloudflare/internal/test/aig/aig-api-test.js
+++ b/src/cloudflare/internal/test/aig/aig-api-test.js
@@ -107,5 +107,45 @@ export const tests = {
         );
       }
     }
+
+    // Universal Run
+    {
+      const resp = await env.ai.gateway('my-gateway').run({
+        provider: 'workers-ai',
+        endpoint: '@cf/meta/llama-3.1-8b-instruct',
+        headers: {
+          Authorization: 'Bearer abcde',
+          'Content-Type': 'application/json',
+          'cf-aig-metadata': { user: 123 },
+          'cf-aig-custom-cost': { total_cost: 1.22 },
+          'cf-aig-skip-cache': false,
+          'cf-aig-cache-ttl': 123,
+        },
+        query: {
+          prompt: 'What is Cloudflare?',
+        },
+      });
+
+      const body = await resp.json();
+
+      assert.deepEqual(body, {
+        result: [
+          {
+            endpoint: '@cf/meta/llama-3.1-8b-instruct',
+            headers: {
+              'Content-Type': 'application/json',
+              'cf-aig-cache-ttl': '123',
+              'cf-aig-custom-cost': '{"total_cost":1.22}',
+              'cf-aig-metadata': '{"user":123}',
+              'cf-aig-skip-cache': 'false',
+              Authorization: 'Bearer abcde',
+            },
+            provider: 'workers-ai',
+            query: { prompt: 'What is Cloudflare?' },
+          },
+        ],
+        success: true,
+      });
+    }
   },
 };

--- a/src/cloudflare/internal/test/aig/aig-mock.js
+++ b/src/cloudflare/internal/test/aig/aig-mock.js
@@ -101,6 +101,12 @@ export default {
       return Response.json({ success: true });
     }
 
+    if (request.method === 'POST') {
+      const body = await request.json();
+
+      return Response.json({ success: true, result: body });
+    }
+
     return Response.json({ success: false }, { status: 500 });
   },
 };

--- a/types/defines/aig.d.ts
+++ b/types/defines/aig.d.ts
@@ -9,7 +9,7 @@ export type GatewayOptions = {
 
 export type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 
@@ -41,10 +41,52 @@ export type AiGatewayLog = {
   created_at: Date;
 };
 
+export type AIGatewayProviders =
+  | 'workers-ai'
+  | 'anthropic'
+  | 'aws-bedrock'
+  | 'azure-openai'
+  | 'google-vertex-ai'
+  | 'huggingface'
+  | 'openai'
+  | 'perplexity-ai'
+  | 'replicate'
+  | 'groq'
+  | 'cohere'
+  | 'google-ai-studio'
+  | 'mistral'
+  | 'grok'
+  | 'openrouter';
+
+export type AIGatewayHeaders = {
+  'cf-aig-metadata':
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  'cf-aig-custom-cost':
+    | { per_token_in?: number; per_token_out?: number }
+    | { total_cost?: number }
+    | string;
+  'cf-aig-cache-ttl': number | string;
+  'cf-aig-skip-cache': boolean | string;
+  'cf-aig-cache-key': string;
+  'cf-aig-collect-log': boolean | string;
+  Authorization: string;
+  'Content-Type': string;
+  [key: string]: string | number | boolean | object;
+};
+
+export type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
+
 export interface AiGatewayInternalError extends Error {}
 export interface AiGatewayLogNotFound extends Error {}
 
 export declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[]): Promise<Response>;
 }

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -3664,7 +3664,7 @@ type GatewayOptions = {
 };
 type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 type AiGatewayLog = {
@@ -3694,11 +3694,57 @@ type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 interface AiGatewayInternalError extends Error {}
 interface AiGatewayLogNotFound extends Error {}
 declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -3677,7 +3677,7 @@ export type GatewayOptions = {
 };
 export type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 export type AiGatewayLog = {
@@ -3707,11 +3707,57 @@ export type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+export type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+export type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+export type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 export interface AiGatewayInternalError extends Error {}
 export interface AiGatewayLogNotFound extends Error {}
 export declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 export interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -3690,7 +3690,7 @@ type GatewayOptions = {
 };
 type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 type AiGatewayLog = {
@@ -3720,11 +3720,57 @@ type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 interface AiGatewayInternalError extends Error {}
 interface AiGatewayLogNotFound extends Error {}
 declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -3703,7 +3703,7 @@ export type GatewayOptions = {
 };
 export type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 export type AiGatewayLog = {
@@ -3733,11 +3733,57 @@ export type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+export type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+export type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+export type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 export interface AiGatewayInternalError extends Error {}
 export interface AiGatewayLogNotFound extends Error {}
 export declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 export interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -3714,7 +3714,7 @@ type GatewayOptions = {
 };
 type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 type AiGatewayLog = {
@@ -3744,11 +3744,57 @@ type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 interface AiGatewayInternalError extends Error {}
 interface AiGatewayLogNotFound extends Error {}
 declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -3727,7 +3727,7 @@ export type GatewayOptions = {
 };
 export type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 export type AiGatewayLog = {
@@ -3757,11 +3757,57 @@ export type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+export type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+export type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+export type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 export interface AiGatewayInternalError extends Error {}
 export interface AiGatewayLogNotFound extends Error {}
 export declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 export interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -3715,7 +3715,7 @@ type GatewayOptions = {
 };
 type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 type AiGatewayLog = {
@@ -3745,11 +3745,57 @@ type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 interface AiGatewayInternalError extends Error {}
 interface AiGatewayLogNotFound extends Error {}
 declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -3728,7 +3728,7 @@ export type GatewayOptions = {
 };
 export type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 export type AiGatewayLog = {
@@ -3758,11 +3758,57 @@ export type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+export type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+export type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+export type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 export interface AiGatewayInternalError extends Error {}
 export interface AiGatewayLogNotFound extends Error {}
 export declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 export interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -3718,7 +3718,7 @@ type GatewayOptions = {
 };
 type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 type AiGatewayLog = {
@@ -3748,11 +3748,57 @@ type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 interface AiGatewayInternalError extends Error {}
 interface AiGatewayLogNotFound extends Error {}
 declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -3731,7 +3731,7 @@ export type GatewayOptions = {
 };
 export type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 export type AiGatewayLog = {
@@ -3761,11 +3761,57 @@ export type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+export type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+export type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+export type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 export interface AiGatewayInternalError extends Error {}
 export interface AiGatewayLogNotFound extends Error {}
 export declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 export interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -3723,7 +3723,7 @@ type GatewayOptions = {
 };
 type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 type AiGatewayLog = {
@@ -3753,11 +3753,57 @@ type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 interface AiGatewayInternalError extends Error {}
 interface AiGatewayLogNotFound extends Error {}
 declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -3736,7 +3736,7 @@ export type GatewayOptions = {
 };
 export type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 export type AiGatewayLog = {
@@ -3766,11 +3766,57 @@ export type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+export type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+export type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+export type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 export interface AiGatewayInternalError extends Error {}
 export interface AiGatewayLogNotFound extends Error {}
 export declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 export interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -3725,7 +3725,7 @@ type GatewayOptions = {
 };
 type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 type AiGatewayLog = {
@@ -3755,11 +3755,57 @@ type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 interface AiGatewayInternalError extends Error {}
 interface AiGatewayLogNotFound extends Error {}
 declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -3738,7 +3738,7 @@ export type GatewayOptions = {
 };
 export type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 export type AiGatewayLog = {
@@ -3768,11 +3768,57 @@ export type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+export type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+export type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+export type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 export interface AiGatewayInternalError extends Error {}
 export interface AiGatewayLogNotFound extends Error {}
 export declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 export interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -3725,7 +3725,7 @@ type GatewayOptions = {
 };
 type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 type AiGatewayLog = {
@@ -3755,11 +3755,57 @@ type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 interface AiGatewayInternalError extends Error {}
 interface AiGatewayLogNotFound extends Error {}
 declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -3738,7 +3738,7 @@ export type GatewayOptions = {
 };
 export type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 export type AiGatewayLog = {
@@ -3768,11 +3768,57 @@ export type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+export type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+export type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+export type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 export interface AiGatewayInternalError extends Error {}
 export interface AiGatewayLogNotFound extends Error {}
 export declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 export interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3790,7 +3790,7 @@ type GatewayOptions = {
 };
 type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 type AiGatewayLog = {
@@ -3820,11 +3820,57 @@ type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 interface AiGatewayInternalError extends Error {}
 interface AiGatewayLogNotFound extends Error {}
 declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3803,7 +3803,7 @@ export type GatewayOptions = {
 };
 export type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 export type AiGatewayLog = {
@@ -3833,11 +3833,57 @@ export type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+export type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+export type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+export type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 export interface AiGatewayInternalError extends Error {}
 export interface AiGatewayLogNotFound extends Error {}
 export declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 export interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -3664,7 +3664,7 @@ type GatewayOptions = {
 };
 type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 type AiGatewayLog = {
@@ -3694,11 +3694,57 @@ type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 interface AiGatewayInternalError extends Error {}
 interface AiGatewayLogNotFound extends Error {}
 declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -3677,7 +3677,7 @@ export type GatewayOptions = {
 };
 export type AiGatewayPatchLog = {
   score?: number | null;
-  feedback?: -1 | 1 | "-1" | "1" | null;
+  feedback?: -1 | 1 | null;
   metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 export type AiGatewayLog = {
@@ -3707,11 +3707,57 @@ export type AiGatewayLog = {
   response_head_complete: boolean;
   created_at: Date;
 };
+export type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter";
+export type AIGatewayHeaders = {
+  "cf-aig-metadata":
+    | Record<string, number | string | boolean | null | bigint>
+    | string;
+  "cf-aig-custom-cost":
+    | {
+        per_token_in?: number;
+        per_token_out?: number;
+      }
+    | {
+        total_cost?: number;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
+};
+export type AIGatewayUniversalRequest = {
+  provider: AIGatewayProviders | string; // eslint-disable-line
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
+};
 export interface AiGatewayInternalError extends Error {}
 export interface AiGatewayLogNotFound extends Error {}
 export declare abstract class AiGateway {
   patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
   getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+  ): Promise<Response>;
 }
 export interface BasicImageTransformations {
   /**


### PR DESCRIPTION
This pr adds a new .run method to ai gateway

Example usage:
```ts
      const resp = await env.AI.gateway('my-gateway').run({
        provider: 'workers-ai',
        endpoint: '@cf/meta/llama-3.1-8b-instruct',
        headers: {
          Authorization: 'Bearer abcde',
          'Content-Type': 'application/json',
          'cf-aig-metadata': { user: 123 },
          'cf-aig-custom-cost': { total_cost: 1.22 },
          'cf-aig-skip-cache': false,
          'cf-aig-cache-ttl': 123,
        },
        query: {
          prompt: 'What is Cloudflare?',
        },
      });
```