### PR TITLE
Make spanId a random 64-bit rather than using a counter

### DIFF
--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -22,7 +22,7 @@ struct InvocationSpanContext {
   }
   traceId @0 :TraceId;
   invocationId @1 :TraceId;
-  spanId @2 :UInt32;
+  spanId @2 :UInt64;
 }
 
 struct Trace @0x8e8d911203762d34 {


### PR DESCRIPTION
In the streaming tail worker design discussion it was decided that span IDs will follow the otel pattern and will be random 64-bit rather than monotonically increasing counter.