### PR TITLE
JSRPC: Allow wrapping RPC targets in Proxy objects.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -303,6 +303,7 @@ http_archive(
         "//:patches/v8/0018-Return-rejected-promise-from-WebAssembly.compile-if-.patch",
         "//:patches/v8/0019-codegen-Don-t-pass-a-nullptr-in-InitUnwindingRecord-.patch",
         "//:patches/v8/0020-Add-another-slot-in-the-isolate-for-embedder.patch",
+        "//:patches/v8/0021-Add-ValueSerializer-SetTreatProxiesAsHostObjects.patch",
     ],
     strip_prefix = "v8-13.1.201.8",
     url = "https://github.com/v8/v8/archive/refs/tags/13.1.201.8.tar.gz",

--- a/patches/v8/0021-Add-ValueSerializer-SetTreatProxiesAsHostObjects.patch
+++ b/patches/v8/0021-Add-ValueSerializer-SetTreatProxiesAsHostObjects.patch
@@ -1,0 +1,119 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kenton Varda <kenton@cloudflare.com>
+Date: Wed, 4 Dec 2024 22:36:05 -0600
+Subject: Add ValueSerializer::SetTreatProxiesAsHostObjects().
+
+Previously, ValueSerializer would always refuse to serialize Proxy objects. This commit gives the embedder the option to handle them as host objects.
+
+Similar to the previous patch adding `SetTreatFunctionsAsHostObjects()`, this is intended for use in an RPC system, where an arbitrary object can be "serialized" by replacing it with a stub which, when invoked, performs an RPC back to the originating isolate in order to access the original object there.
+
+diff --git a/include/v8-value-serializer.h b/include/v8-value-serializer.h
+index 141f138e08de849e3e02b3b2b346e643b9e40c70..bdcb2831c55e21c6d511f56dfc79a5076871f05a 100644
+--- a/include/v8-value-serializer.h
++++ b/include/v8-value-serializer.h
+@@ -204,6 +204,15 @@ class V8_EXPORT ValueSerializer {
+    */
+   void SetTreatFunctionsAsHostObjects(bool mode);
+ 
++  /**
++   * Indicate whether to treat Proxies as host objects,
++   * i.e. pass them to Delegate::WriteHostObject. This should not be
++   * called when no Delegate was passed.
++   *
++   * The default is not to treat Proxies as host objects.
++   */
++  void SetTreatProxiesAsHostObjects(bool mode);
++
+   /**
+    * Write raw data in various common formats to the buffer.
+    * Note that integer types are written in base-128 varint format, not with a
+diff --git a/src/api/api.cc b/src/api/api.cc
+index 998b6c91a854b24c01ee58495056dca36a145042..53b8af04828bad7a1f4e18c51648add276644ae9 100644
+--- a/src/api/api.cc
++++ b/src/api/api.cc
+@@ -3570,6 +3570,10 @@ void ValueSerializer::SetTreatFunctionsAsHostObjects(bool mode) {
+   private_->serializer.SetTreatFunctionsAsHostObjects(mode);
+ }
+ 
++void ValueSerializer::SetTreatProxiesAsHostObjects(bool mode) {
++  private_->serializer.SetTreatProxiesAsHostObjects(mode);
++}
++
+ Maybe<bool> ValueSerializer::WriteValue(Local<Context> context,
+                                         Local<Value> value) {
+   auto i_isolate = reinterpret_cast<i::Isolate*>(context->GetIsolate());
+diff --git a/src/objects/value-serializer.cc b/src/objects/value-serializer.cc
+index 531331ee18bac95e4c6bd13f3e91fb9015765393..f7a126205649dfc991d812bbd1820219de980b32 100644
+--- a/src/objects/value-serializer.cc
++++ b/src/objects/value-serializer.cc
+@@ -332,6 +332,10 @@ void ValueSerializer::SetTreatFunctionsAsHostObjects(bool mode) {
+   treat_functions_as_host_objects_ = mode;
+ }
+ 
++void ValueSerializer::SetTreatProxiesAsHostObjects(bool mode) {
++  treat_proxies_as_host_objects_ = mode;
++}
++
+ void ValueSerializer::WriteTag(SerializationTag tag) {
+   uint8_t raw_tag = static_cast<uint8_t>(tag);
+   WriteRawBytes(&raw_tag, sizeof(raw_tag));
+@@ -602,7 +606,12 @@ Maybe<bool> ValueSerializer::WriteJSReceiver(Handle<JSReceiver> receiver) {
+   InstanceType instance_type = receiver->map()->instance_type();
+   if (IsCallable(*receiver)) {
+     if (treat_functions_as_host_objects_) {
+-      return WriteHostObject(Cast<JSObject>(receiver));
++      return WriteHostObject(receiver);
++    }
++    return ThrowDataCloneError(MessageTemplate::kDataCloneError, receiver);
++  } else if (instance_type == JS_PROXY_TYPE) {
++    if (treat_proxies_as_host_objects_) {
++      return WriteHostObject(receiver);
+     }
+     return ThrowDataCloneError(MessageTemplate::kDataCloneError, receiver);
+   } else if (IsSpecialReceiverInstanceType(instance_type) &&
+@@ -1207,7 +1216,7 @@ Maybe<bool> ValueSerializer::WriteSharedObject(
+   return ThrowIfOutOfMemory();
+ }
+ 
+-Maybe<bool> ValueSerializer::WriteHostObject(Handle<JSObject> object) {
++Maybe<bool> ValueSerializer::WriteHostObject(Handle<JSReceiver> object) {
+   WriteTag(SerializationTag::kHostObject);
+   if (!delegate_) {
+     isolate_->Throw(*isolate_->factory()->NewError(
+diff --git a/src/objects/value-serializer.h b/src/objects/value-serializer.h
+index a657bb7f6def9d795d6504eb62f49b5b34c46406..31406f1d3f430b501fe49fa207e2b8fee2ea57da 100644
+--- a/src/objects/value-serializer.h
++++ b/src/objects/value-serializer.h
+@@ -111,6 +111,15 @@ class ValueSerializer {
+    */
+   void SetTreatFunctionsAsHostObjects(bool mode);
+ 
++  /*
++   * Indicate whether to treat Proxies as host objects,
++   * i.e. pass them to Delegate::WriteHostObject. This should not be
++   * called when no Delegate was passed.
++   *
++   * The default is not to treat Proxies as host objects.
++   */
++  void SetTreatProxiesAsHostObjects(bool mode);
++
+  private:
+   // Managing allocations of the internal buffer.
+   Maybe<bool> ExpandBuffer(size_t required_capacity);
+@@ -159,7 +168,7 @@ class ValueSerializer {
+ #endif  // V8_ENABLE_WEBASSEMBLY
+   Maybe<bool> WriteSharedObject(DirectHandle<HeapObject> object)
+       V8_WARN_UNUSED_RESULT;
+-  Maybe<bool> WriteHostObject(Handle<JSObject> object) V8_WARN_UNUSED_RESULT;
++  Maybe<bool> WriteHostObject(Handle<JSReceiver> object) V8_WARN_UNUSED_RESULT;
+ 
+   /*
+    * Reads the specified keys from the object and writes key-value pairs to the
+@@ -192,6 +201,7 @@ class ValueSerializer {
+   bool has_custom_host_objects_ = false;
+   bool treat_array_buffer_views_as_host_objects_ = false;
+   bool treat_functions_as_host_objects_ = false;
++  bool treat_proxies_as_host_objects_ = false;
+   bool out_of_memory_ = false;
+   Zone zone_;
+   uint32_t version_;

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -1600,6 +1600,66 @@ void RpcSerializerExternalHander::serializeFunction(
   });
 }
 
+void RpcSerializerExternalHander::serializeProxy(
+    jsg::Lock& js, jsg::Serializer& serializer, v8::Local<v8::Proxy> proxy) {
+  js.withinHandleScope([&]() {
+    auto handle = jsg::JsObject(proxy);
+
+    // Proxies are only allowed to wrap objects that would normally be serialized by writing a
+    // stub, e.g. plain objects and RpcTargets. In such cases, we can write a stub pointing to the
+    // proxy.
+    //
+    // However, note that we don't actually want to test the Proxy's *target* directly, because
+    // it's possible the Proxy is trying to disguise the target as something else. Instead, we must
+    // determine the type by following the prototype chain. That way, if the Proxy overrides
+    // getPrototype(), we will honor that override.
+    //
+    // Note that we don't support functions. This is because our isFunctionForRpc() check is not
+    // prototype-based, and as such it's unclear how exactly we should go about checking for a
+    // function here. Luckily, you really don't need to use a `Proxy` to wrap a function... you
+    // can just use a function.
+
+    // TODO(perf): We should really cache `prototypeOfObject` somewhere so we don't have to create
+    //   an object to get it. (We do this other places in this file, too...)
+    auto prototypeOfObject = KJ_ASSERT_NONNULL(js.obj().getPrototype(js).tryCast<jsg::JsObject>());
+    auto prototypeOfRpcTarget = js.getPrototypeFor<JsRpcTarget>();
+    bool allowInstanceProperties = false;
+    auto proto = handle.getPrototype(js);
+    if (proto == prototypeOfObject) {
+      // A regular object. Allow access to instance properties.
+      allowInstanceProperties = true;
+    } else {
+      // Walk the prototype chain looking for RpcTarget.
+      for (;;) {
+        if (proto == prototypeOfRpcTarget) {
+          // An RpcTarget, don't allow instance properties.
+          allowInstanceProperties = false;
+          break;
+        }
+
+        KJ_IF_SOME(protoObj, proto.tryCast<jsg::JsObject>()) {
+          proto = protoObj.getPrototype(js);
+        } else {
+          // End of prototype chain, and didn't find RpcTarget.
+          JSG_FAIL_REQUIRE(DOMDataCloneError,
+              "Proxy could not be serialized because it is not a valid RPC receiver type. The "
+              "Proxy must emulate either a plain object or an RpcTarget, as indicated by the "
+              "Proxy's prototype chain.");
+        }
+      }
+    }
+
+    // Great, we've concluded we can indeed point a stub at this proxy.
+    serializer.writeRawUint32(static_cast<uint>(rpc::SerializationTag::JS_RPC_STUB));
+
+    rpc::JsRpcTarget::Client cap =
+        kj::heap<TransientJsRpcTarget>(js, IoContext::current(), handle, allowInstanceProperties);
+    write([cap = kj::mv(cap)](rpc::JsValue::External::Builder builder) mutable {
+      builder.setRpcTarget(kj::mv(cap));
+    });
+  });
+}
+
 // JsRpcTarget implementation specific to entrypoints. This is used to deliver the first, top-level
 // call of an RPC session.
 class EntrypointJsRpcTarget final: public JsRpcTargetBase {

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -66,6 +66,10 @@ class RpcSerializerExternalHander final: public jsg::Serializer::ExternalHandler
   void serializeFunction(
       jsg::Lock& js, jsg::Serializer& serializer, v8::Local<v8::Function> func) override;
 
+  // We can serialize a Proxy if it happens to wrap RpcTarget.
+  void serializeProxy(
+      jsg::Lock& js, jsg::Serializer& serializer, v8::Local<v8::Proxy> proxy) override;
+
  private:
   GetStreamSinkFunc getStreamSinkFunc;
 

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2574,6 +2574,13 @@ class Lock {
   virtual Ref<DOMException> domException(
       kj::String name, kj::String message, kj::Maybe<kj::String> stackValue = kj::none) = 0;
 
+  // Get the prototype object for the given C++ type (which must be a JSG_RESOURCE_TYPE).
+  //
+  // WARNING: A malicious script can tamper with this by overwriting the `prototype` property
+  // of the class object.
+  template <typename T>
+  JsObject getPrototypeFor();
+
   // ====================================================================================
   JsObject global() KJ_WARN_UNUSED_RESULT;
   JsValue undefined() KJ_WARN_UNUSED_RESULT;
@@ -2688,6 +2695,7 @@ class Lock {
 
   friend class JsObject;
   virtual kj::Maybe<Object&> getInstance(v8::Local<v8::Object> obj, const std::type_info& type) = 0;
+  virtual v8::Local<v8::Object> getPrototypeFor(const std::type_info& type) = 0;
 };
 
 // Ensures that the given fn is run within both a handlescope and the context scope.

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -390,6 +390,12 @@ class JsObject final: public JsBase<v8::Object, JsObject> {
   JsObject jsonClone(Lock&);
 };
 
+// Defined here because `JsObject` is an incomplete type in `jsg.h`.
+template <typename T>
+inline JsObject Lock::getPrototypeFor() {
+  return JsObject(getPrototypeFor(typeid(T)));
+}
+
 class JsMap final: public JsBase<v8::Map, JsMap> {
  public:
   operator JsObject();

--- a/src/workerd/jsg/ser.h
+++ b/src/workerd/jsg/ser.h
@@ -74,6 +74,19 @@ class Serializer final: v8::ValueSerializer::Delegate {
     // DataCloneError.
     virtual void serializeFunction(
         jsg::Lock& js, jsg::Serializer& serializer, v8::Local<v8::Function> func);
+
+    // Tries to serialize a proxy as an external. The default implementation throws
+    // DataCloneError.
+    //
+    // TODO(cleanup): This is a bit of a hack to support an RpcTarget that is wrapped in a Proxy.
+    //   For RpcTarget specifically, this works because inheriting RpcTarget is just a marker that
+    //   opts into serializing by creating a stub pointing at the object -- we can create a stub
+    //   pointing at the proxy instead. For any other type, serializing a Proxy probably isn't
+    //   possible, since the serialization wouldn't actually capture the Proxy logic? But I'm
+    //   not 100% certain of that. If we find other use cases in the future it may turn out that
+    //   they call for a different design.
+    virtual void serializeProxy(
+        jsg::Lock& js, jsg::Serializer& serializer, v8::Local<v8::Proxy> proxy);
   };
 
   struct Options {


### PR DESCRIPTION
When serializing a value for RPC, if we encounter a `Proxy`, we will check if it claims to be an instance of `RpcTarget` (via the prototype chain) and, if so, treat it as one, wrapping it in a stub with the same semantics as an actual `RpcTarget`.

Additionally, if the `Proxy` claims to be a plain object (the prototype is `Object.prototype`), we will allow this too, wrapping it in a stub that allows access to the object's "own" properties. This is not exactly the same thing as we'd do if it were really a raw object: in that case, we would actually send the object content. However, it is consistent with our access control model, which says that for plain objects, "own" properties are exposed, but for `RpcTarget` instances, only prototype properties are exposed.

A `Proxy` can even be used to cause an object of class type that is _not_ derived from `RpcTarget` behave as if it were, by overriding `getPrototypeOf()` to return `RpcTarget.prototype`. This is a feature, not a bug! The reasons we don't normally support non-RpcTarget classes by default are (1) we want to reserve the right to add by-value serialization to existing API types in the future, without breaking compatibility, and (2) classes not explicitly written for RPC may not have been written with the understanding that their public API is a security boundary. However, if the developer uses a `Proxy` to fake that the object is an `RpcTarget`, then the developer is "opting in" to `RpcTarget` behavior, namely (1) the object is strictly pass-by-stub, and (2) they are comfortable with exposing the class's public interface.

Fixes #3184