### PR TITLE
Use std::list for WritableImpl::writeRequests.

### DIFF
--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -10,6 +10,8 @@
 #include <workerd/jsg/jsg.h>
 #include <workerd/util/weak-refs.h>
 
+#include <list>
+
 namespace workerd::api {
 
 // =======================================================================================
@@ -367,7 +369,9 @@ class WritableImpl {
   bool backpressure = false;
   size_t highWaterMark = 1;
 
-  std::deque<WriteRequest> writeRequests;
+  // `writeRequests` is often going to be empty in common usage patterns, in which case std::list
+  // is more memory efficient than a std::deque, for example.
+  std::list<WriteRequest> writeRequests;
   size_t amountBuffered = 0;
   bool warnAboutExcessiveBackpressure = true;
   size_t excessiveBackpressureWarningCount = 0;


### PR DESCRIPTION
Previously we used std::deque but this has a large memory footprint when empty in practice. Using std::list optimizes memory for the common case of a lot of WritableStreams with empty queues.