### PR TITLE
[build] TS cleanup

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,14 +23,6 @@ npm_link_package(
     package = "@workerd/jsg",
 )
 
-# The @workerd/test package provides a small library to manage workerd subprocesses in js_test()
-# targets.
-npm_link_package(
-    name = "node_modules/@workerd/test",
-    src = "//src/workerd/server/tests:test_js",
-    package = "@workerd/test",
-)
-
 capnpc_ts_bin.capnpc_ts_binary(
     name = "capnpc_ts",
     visibility = ["//visibility:public"],

--- a/build/deps/gen/dep_aspect_rules_ts.bzl
+++ b/build/deps/gen/dep_aspect_rules_ts.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "v3.3.1"
-URL = "https://github.com/aspect-build/rules_ts/releases/download/v3.3.1/rules_ts-v3.3.1.tar.gz"
-STRIP_PREFIX = "rules_ts-3.3.1"
-SHA256 = "9acd128abe77397505148eaa6895faed57839560dbf2177dd6285e51235e2724"
+TAG_NAME = "v3.3.2"
+URL = "https://github.com/aspect-build/rules_ts/releases/download/v3.3.2/rules_ts-v3.3.2.tar.gz"
+STRIP_PREFIX = "rules_ts-3.3.2"
+SHA256 = "cff3137b043ff6bf1a2542fd9691dc762432370cd39eb4bb0756d288de52067d"
 TYPE = "tgz"
 
 def dep_aspect_rules_ts():

--- a/build/wd_ts_project.bzl
+++ b/build/wd_ts_project.bzl
@@ -12,8 +12,4 @@ def wd_ts_project(name, srcs, deps, testonly = False):
         composite = True,
         source_map = True,
         testonly = testonly,
-        # Disable workers to avoid issue with multiple targets
-        # (https://github.com/aspect-build/rules_ts/issues/128)
-        # TODO: try re-enable these on next aspect_rules_ts update
-        supports_workers = 0,
     )

--- a/src/workerd/server/tests/BUILD.bazel
+++ b/src/workerd/server/tests/BUILD.bazel
@@ -1,14 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 
 js_library(
     name = "server-harness_js_lib",
     srcs = ["server-harness.mjs"],
-)
-
-npm_package(
-    name = "test_js",
-    srcs = [":server-harness_js_lib"],
-    publishable = False,
     visibility = ["//visibility:public"],
 )

--- a/src/workerd/server/tests/inspector/BUILD.bazel
+++ b/src/workerd/server/tests/inspector/BUILD.bazel
@@ -6,9 +6,9 @@ js_test(
     data = [
         ":config.capnp",
         ":index.mjs",
-        "//:node_modules/@workerd/test",
         "//:node_modules/chrome-remote-interface",
         "//src/workerd/server:workerd",
+        "//src/workerd/server/tests:server-harness_js_lib",
     ],
     entry_point = "driver.mjs",
     env = {

--- a/src/workerd/server/tests/inspector/driver.mjs
+++ b/src/workerd/server/tests/inspector/driver.mjs
@@ -2,7 +2,7 @@ import { env } from 'node:process';
 import { beforeEach, afterEach, test } from 'node:test';
 import assert from 'node:assert';
 import CDP from 'chrome-remote-interface';
-import { WorkerdServerHarness } from '@workerd/test/server-harness.mjs';
+import { WorkerdServerHarness } from '../server-harness.mjs';
 
 // Global that is reset for each test.
 let workerd;


### PR DESCRIPTION
- Update rules_ts
- Remove TODO to enable Bazel worker protocol for transpiling. This is no longer supported with TS 5.x.
- Elide npm_package for server tests, this should only be used for actual NPM packages. One instance (for type-related tests) remains, but that's more difficult to remove cleanly.