### PR TITLE
Moar WritableStream memory optimization

### DIFF
--- a/src/workerd/api/streams/common.c++
+++ b/src/workerd/api/streams/common.c++
@@ -30,8 +30,8 @@ void WritableStreamController::PendingAbort::fail(jsg::Lock& js, v8::Local<v8::V
   maybeRejectPromise<void>(js, resolver, reason);
 }
 
-kj::Maybe<WritableStreamController::PendingAbort> WritableStreamController::PendingAbort::dequeue(
-    kj::Maybe<WritableStreamController::PendingAbort>& maybePendingAbort) {
+kj::Maybe<kj::Own<WritableStreamController::PendingAbort>> WritableStreamController::PendingAbort::
+    dequeue(kj::Maybe<kj::Own<WritableStreamController::PendingAbort>>& maybePendingAbort) {
   return kj::mv(maybePendingAbort);
 }
 

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -639,7 +639,8 @@ class WritableStreamController {
       visitor.visit(resolver, promise, reason);
     }
 
-    static kj::Maybe<PendingAbort> dequeue(kj::Maybe<PendingAbort>& maybePendingAbort);
+    static kj::Maybe<kj::Own<PendingAbort>> dequeue(
+        kj::Maybe<kj::Own<PendingAbort>>& maybePendingAbort);
 
     JSG_MEMORY_INFO(PendingAbort) {
       tracker.trackField("resolver", resolver);

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -284,7 +284,7 @@ class WritableStreamInternalController: public WritableStreamController {
 
   kj::Maybe<kj::Own<ByteStreamObserver>> observer;
 
-  kj::Maybe<PendingAbort> maybePendingAbort;
+  kj::Maybe<kj::Own<PendingAbort>> maybePendingAbort;
 
   uint64_t currentWriteBufferSize = 0;
   bool warnAboutExcessiveBackpressure = true;

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -379,7 +379,7 @@ class WritableImpl {
   kj::Maybe<WriteRequest> inFlightWrite;
   kj::Maybe<jsg::Promise<void>::Resolver> inFlightClose;
   kj::Maybe<jsg::Promise<void>::Resolver> closeRequest;
-  kj::Maybe<PendingAbort> maybePendingAbort;
+  kj::Maybe<kj::Own<PendingAbort>> maybePendingAbort;
 
   friend Self;
 };


### PR DESCRIPTION
Make WritableStream controllers' `maybePendingAbort` members heap-allocated to reduce WritableStream's memory footprint when no abort is pending.

Reduces the footprint by a further ~100 bytes.