### PR TITLE
fix: properly expose `WorkflowEntrypoint` constructor in TS types

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -254,6 +254,8 @@ declare module "cloudflare:workers" {
     protected ctx: ExecutionContext;
     protected env: Env;
 
+    constructor(ctx: ExecutionContext, env: Env);
+
     run(event: Readonly<WorkflowEvent<T>>, step: WorkflowStep): Promise<unknown>;
   }
 }

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -5373,6 +5373,7 @@ declare module "cloudflare:workers" {
     [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
     protected ctx: ExecutionContext;
     protected env: Env;
+    constructor(ctx: ExecutionContext, env: Env);
     run(
       event: Readonly<WorkflowEvent<T>>,
       step: WorkflowStep,

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -5399,6 +5399,7 @@ declare module "cloudflare:workers" {
     [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
     protected ctx: ExecutionContext;
     protected env: Env;
+    constructor(ctx: ExecutionContext, env: Env);
     run(
       event: Readonly<WorkflowEvent<T>>,
       step: WorkflowStep,

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -5424,6 +5424,7 @@ declare module "cloudflare:workers" {
     [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
     protected ctx: ExecutionContext;
     protected env: Env;
+    constructor(ctx: ExecutionContext, env: Env);
     run(
       event: Readonly<WorkflowEvent<T>>,
       step: WorkflowStep,

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -5425,6 +5425,7 @@ declare module "cloudflare:workers" {
     [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
     protected ctx: ExecutionContext;
     protected env: Env;
+    constructor(ctx: ExecutionContext, env: Env);
     run(
       event: Readonly<WorkflowEvent<T>>,
       step: WorkflowStep,

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -5428,6 +5428,7 @@ declare module "cloudflare:workers" {
     [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
     protected ctx: ExecutionContext;
     protected env: Env;
+    constructor(ctx: ExecutionContext, env: Env);
     run(
       event: Readonly<WorkflowEvent<T>>,
       step: WorkflowStep,

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -5433,6 +5433,7 @@ declare module "cloudflare:workers" {
     [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
     protected ctx: ExecutionContext;
     protected env: Env;
+    constructor(ctx: ExecutionContext, env: Env);
     run(
       event: Readonly<WorkflowEvent<T>>,
       step: WorkflowStep,

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -5435,6 +5435,7 @@ declare module "cloudflare:workers" {
     [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
     protected ctx: ExecutionContext;
     protected env: Env;
+    constructor(ctx: ExecutionContext, env: Env);
     run(
       event: Readonly<WorkflowEvent<T>>,
       step: WorkflowStep,

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -5435,6 +5435,7 @@ declare module "cloudflare:workers" {
     [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
     protected ctx: ExecutionContext;
     protected env: Env;
+    constructor(ctx: ExecutionContext, env: Env);
     run(
       event: Readonly<WorkflowEvent<T>>,
       step: WorkflowStep,

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -5501,6 +5501,7 @@ declare module "cloudflare:workers" {
     [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
     protected ctx: ExecutionContext;
     protected env: Env;
+    constructor(ctx: ExecutionContext, env: Env);
     run(
       event: Readonly<WorkflowEvent<T>>,
       step: WorkflowStep,

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -5373,6 +5373,7 @@ declare module "cloudflare:workers" {
     [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
     protected ctx: ExecutionContext;
     protected env: Env;
+    constructor(ctx: ExecutionContext, env: Env);
     run(
       event: Readonly<WorkflowEvent<T>>,
       step: WorkflowStep,


### PR DESCRIPTION
Previously we didn't export the constructor for `WorkflowEntrypoint` in TS types (we always had one in the workerd implementation itself) even though other classes like `DurableObject` or `WorkerEntrypoint` also do it. This makes constructor types in `WorkflowEntrypoint` on par with those two. 