### PR TITLE
Undo tightening of rules around default entrypoints in #3193.

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1630,7 +1630,19 @@ class Server::WorkerService final: public Service,
       name = entry.key;  // replace with more-permanent string
       handlers = &entry.value;
     } else {
-      handlers = &KJ_UNWRAP_OR_RETURN(defaultEntrypointHandlers, kj::none);
+      KJ_IF_SOME(d, defaultEntrypointHandlers) {
+        handlers = &d;
+      } else {
+        // It would appear that there is no default export, therefore this refers to an entrypoint
+        // that doesn't exist! However, this was historically allowed. For backwards-compatibility,
+        // we preserve this behavior, by returning a reference to the WorkerService itself, whose
+        // startRequest() will fail.
+        //
+        // What will happen if you invoke this entrypoint? Not what you think. Check out the
+        // test case in server-test.c++ entitled "referencing non-extant default entrypoint is not
+        // an error" for the sordid details.
+        return fakeOwn(*this);
+      }
     }
     return kj::heap<EntrypointService>(*this, name, propsJson, *handlers);
   }


### PR DESCRIPTION
Say you have a module-syntax Worker that has no `export default`. You then refer to that worker from elsewhere in the workerd config, but you do not specify an entrypoint. What should happen?

In the midst of other changes, PR #3193 turned this into an error, becaues it seemed like obviously it should be. This turns out to have broken Miniflare tests, which often use an empty string as a placeholder Worker that is referenced but never invoked.

So, this PR restores the old behavior.

It turns out, incidentally, that the old behavior is crazier than you'd imagine. See the comments in the test case for details.