### PR TITLE
Introducing better Workers AI types

### DIFF
--- a/types/defines/ai.d.ts
+++ b/types/defines/ai.d.ts
@@ -50,10 +50,10 @@ export declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-export type AiSpeechRecognitionInput = {
+export type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-export type AiSpeechRecognitionOutput = {
+export type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -62,9 +62,9 @@ export type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-export declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+export declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 export type AiSummarizationInput = {
   input_text: string;
@@ -100,16 +100,31 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+export type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 export type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -120,9 +135,14 @@ export type AiTextGenerationToolInput = {
     };
   };
 };
+export type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -133,7 +153,8 @@ export type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 export type AiTextGenerationOutput =
   | {
@@ -148,15 +169,33 @@ export declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+export type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+export type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+export declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 export type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-export type AiTextToImageOutput = ReadableStream<Uint8Array>;
+export type AiTextToImageOutput = Uint8Array;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -178,117 +217,71 @@ export type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-export type BaseAiTextClassificationModels =
-  "@cf/huggingface/distilbert-sst-2-int8";
-export type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-export type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-export type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-export type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-export type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-export type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-export type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-export type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-export type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-export declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+export type ModelType<Name extends keyof AiModels> = AiModels[Name];
+export interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+export type ModelListType = Record<string, any>;
+export declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }

--- a/types/defines/ai.d.ts
+++ b/types/defines/ai.d.ts
@@ -100,7 +100,12 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -108,7 +113,7 @@ export type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -119,12 +124,12 @@ export type AiTextGenerationToolLegacyInput = {
   };
 };
 export type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -142,7 +147,6 @@ export type AiTextGenerationFunctionsInput = {
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -195,7 +199,7 @@ export type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-export type AiTextToImageOutput = Uint8Array;
+export type AiTextToImageOutput = ReadableStream<Uint8Array>;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -3464,7 +3464,12 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3472,7 +3477,7 @@ type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3483,12 +3488,12 @@ type AiTextGenerationToolLegacyInput = {
   };
 };
 type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3506,7 +3511,6 @@ type AiTextGenerationFunctionsInput = {
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3559,7 +3563,7 @@ type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-type AiTextToImageOutput = Uint8Array;
+type AiTextToImageOutput = ReadableStream<Uint8Array>;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -3414,10 +3414,10 @@ declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-type AiSpeechRecognitionInput = {
+type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-type AiSpeechRecognitionOutput = {
+type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3426,9 +3426,9 @@ type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 type AiSummarizationInput = {
   input_text: string;
@@ -3464,16 +3464,31 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3484,9 +3499,14 @@ type AiTextGenerationToolInput = {
     };
   };
 };
+type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3497,7 +3517,8 @@ type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 type AiTextGenerationOutput =
   | {
@@ -3512,15 +3533,33 @@ declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-type AiTextToImageOutput = ReadableStream<Uint8Array>;
+type AiTextToImageOutput = Uint8Array;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3542,118 +3581,73 @@ type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-type BaseAiTextClassificationModels = "@cf/huggingface/distilbert-sst-2-int8";
-type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+type ModelType<Name extends keyof AiModels> = AiModels[Name];
+interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+type ModelListType = Record<string, any>;
+declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -3476,7 +3476,12 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3484,7 +3489,7 @@ export type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3495,12 +3500,12 @@ export type AiTextGenerationToolLegacyInput = {
   };
 };
 export type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3518,7 +3523,6 @@ export type AiTextGenerationFunctionsInput = {
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3571,7 +3575,7 @@ export type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-export type AiTextToImageOutput = Uint8Array;
+export type AiTextToImageOutput = ReadableStream<Uint8Array>;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -3426,10 +3426,10 @@ export declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-export type AiSpeechRecognitionInput = {
+export type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-export type AiSpeechRecognitionOutput = {
+export type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3438,9 +3438,9 @@ export type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-export declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+export declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 export type AiSummarizationInput = {
   input_text: string;
@@ -3476,16 +3476,31 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+export type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 export type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3496,9 +3511,14 @@ export type AiTextGenerationToolInput = {
     };
   };
 };
+export type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3509,7 +3529,8 @@ export type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 export type AiTextGenerationOutput =
   | {
@@ -3524,15 +3545,33 @@ export declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+export type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+export type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+export declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 export type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-export type AiTextToImageOutput = ReadableStream<Uint8Array>;
+export type AiTextToImageOutput = Uint8Array;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3554,119 +3593,73 @@ export type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-export type BaseAiTextClassificationModels =
-  "@cf/huggingface/distilbert-sst-2-int8";
-export type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-export type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-export type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-export type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-export type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-export type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-export type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-export type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-export type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-export declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+export type ModelType<Name extends keyof AiModels> = AiModels[Name];
+export interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+export type ModelListType = Record<string, any>;
+export declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 export type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -3490,7 +3490,12 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3498,7 +3503,7 @@ type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3509,12 +3514,12 @@ type AiTextGenerationToolLegacyInput = {
   };
 };
 type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3532,7 +3537,6 @@ type AiTextGenerationFunctionsInput = {
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3585,7 +3589,7 @@ type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-type AiTextToImageOutput = Uint8Array;
+type AiTextToImageOutput = ReadableStream<Uint8Array>;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -3440,10 +3440,10 @@ declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-type AiSpeechRecognitionInput = {
+type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-type AiSpeechRecognitionOutput = {
+type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3452,9 +3452,9 @@ type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 type AiSummarizationInput = {
   input_text: string;
@@ -3490,16 +3490,31 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3510,9 +3525,14 @@ type AiTextGenerationToolInput = {
     };
   };
 };
+type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3523,7 +3543,8 @@ type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 type AiTextGenerationOutput =
   | {
@@ -3538,15 +3559,33 @@ declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-type AiTextToImageOutput = ReadableStream<Uint8Array>;
+type AiTextToImageOutput = Uint8Array;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3568,118 +3607,73 @@ type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-type BaseAiTextClassificationModels = "@cf/huggingface/distilbert-sst-2-int8";
-type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+type ModelType<Name extends keyof AiModels> = AiModels[Name];
+interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+type ModelListType = Record<string, any>;
+declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -3502,7 +3502,12 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3510,7 +3515,7 @@ export type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3521,12 +3526,12 @@ export type AiTextGenerationToolLegacyInput = {
   };
 };
 export type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3544,7 +3549,6 @@ export type AiTextGenerationFunctionsInput = {
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3597,7 +3601,7 @@ export type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-export type AiTextToImageOutput = Uint8Array;
+export type AiTextToImageOutput = ReadableStream<Uint8Array>;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -3452,10 +3452,10 @@ export declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-export type AiSpeechRecognitionInput = {
+export type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-export type AiSpeechRecognitionOutput = {
+export type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3464,9 +3464,9 @@ export type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-export declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+export declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 export type AiSummarizationInput = {
   input_text: string;
@@ -3502,16 +3502,31 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+export type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 export type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3522,9 +3537,14 @@ export type AiTextGenerationToolInput = {
     };
   };
 };
+export type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3535,7 +3555,8 @@ export type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 export type AiTextGenerationOutput =
   | {
@@ -3550,15 +3571,33 @@ export declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+export type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+export type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+export declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 export type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-export type AiTextToImageOutput = ReadableStream<Uint8Array>;
+export type AiTextToImageOutput = Uint8Array;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3580,119 +3619,73 @@ export type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-export type BaseAiTextClassificationModels =
-  "@cf/huggingface/distilbert-sst-2-int8";
-export type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-export type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-export type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-export type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-export type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-export type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-export type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-export type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-export type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-export declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+export type ModelType<Name extends keyof AiModels> = AiModels[Name];
+export interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+export type ModelListType = Record<string, any>;
+export declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 export type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -3465,10 +3465,10 @@ declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-type AiSpeechRecognitionInput = {
+type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-type AiSpeechRecognitionOutput = {
+type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3477,9 +3477,9 @@ type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 type AiSummarizationInput = {
   input_text: string;
@@ -3515,16 +3515,31 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3535,9 +3550,14 @@ type AiTextGenerationToolInput = {
     };
   };
 };
+type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3548,7 +3568,8 @@ type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 type AiTextGenerationOutput =
   | {
@@ -3563,15 +3584,33 @@ declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-type AiTextToImageOutput = ReadableStream<Uint8Array>;
+type AiTextToImageOutput = Uint8Array;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3593,118 +3632,73 @@ type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-type BaseAiTextClassificationModels = "@cf/huggingface/distilbert-sst-2-int8";
-type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+type ModelType<Name extends keyof AiModels> = AiModels[Name];
+interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+type ModelListType = Record<string, any>;
+declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -3515,7 +3515,12 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3523,7 +3528,7 @@ type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3534,12 +3539,12 @@ type AiTextGenerationToolLegacyInput = {
   };
 };
 type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3557,7 +3562,6 @@ type AiTextGenerationFunctionsInput = {
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3610,7 +3614,7 @@ type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-type AiTextToImageOutput = Uint8Array;
+type AiTextToImageOutput = ReadableStream<Uint8Array>;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -3527,7 +3527,12 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3535,7 +3540,7 @@ export type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3546,12 +3551,12 @@ export type AiTextGenerationToolLegacyInput = {
   };
 };
 export type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3569,7 +3574,6 @@ export type AiTextGenerationFunctionsInput = {
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3622,7 +3626,7 @@ export type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-export type AiTextToImageOutput = Uint8Array;
+export type AiTextToImageOutput = ReadableStream<Uint8Array>;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -3477,10 +3477,10 @@ export declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-export type AiSpeechRecognitionInput = {
+export type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-export type AiSpeechRecognitionOutput = {
+export type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3489,9 +3489,9 @@ export type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-export declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+export declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 export type AiSummarizationInput = {
   input_text: string;
@@ -3527,16 +3527,31 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+export type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 export type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3547,9 +3562,14 @@ export type AiTextGenerationToolInput = {
     };
   };
 };
+export type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3560,7 +3580,8 @@ export type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 export type AiTextGenerationOutput =
   | {
@@ -3575,15 +3596,33 @@ export declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+export type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+export type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+export declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 export type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-export type AiTextToImageOutput = ReadableStream<Uint8Array>;
+export type AiTextToImageOutput = Uint8Array;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3605,119 +3644,73 @@ export type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-export type BaseAiTextClassificationModels =
-  "@cf/huggingface/distilbert-sst-2-int8";
-export type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-export type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-export type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-export type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-export type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-export type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-export type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-export type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-export type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-export declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+export type ModelType<Name extends keyof AiModels> = AiModels[Name];
+export interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+export type ModelListType = Record<string, any>;
+export declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 export type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -3516,7 +3516,12 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3524,7 +3529,7 @@ type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3535,12 +3540,12 @@ type AiTextGenerationToolLegacyInput = {
   };
 };
 type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3558,7 +3563,6 @@ type AiTextGenerationFunctionsInput = {
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3611,7 +3615,7 @@ type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-type AiTextToImageOutput = Uint8Array;
+type AiTextToImageOutput = ReadableStream<Uint8Array>;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -3466,10 +3466,10 @@ declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-type AiSpeechRecognitionInput = {
+type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-type AiSpeechRecognitionOutput = {
+type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3478,9 +3478,9 @@ type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 type AiSummarizationInput = {
   input_text: string;
@@ -3516,16 +3516,31 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3536,9 +3551,14 @@ type AiTextGenerationToolInput = {
     };
   };
 };
+type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3549,7 +3569,8 @@ type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 type AiTextGenerationOutput =
   | {
@@ -3564,15 +3585,33 @@ declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-type AiTextToImageOutput = ReadableStream<Uint8Array>;
+type AiTextToImageOutput = Uint8Array;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3594,118 +3633,73 @@ type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-type BaseAiTextClassificationModels = "@cf/huggingface/distilbert-sst-2-int8";
-type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+type ModelType<Name extends keyof AiModels> = AiModels[Name];
+interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+type ModelListType = Record<string, any>;
+declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -3528,7 +3528,12 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3536,7 +3541,7 @@ export type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3547,12 +3552,12 @@ export type AiTextGenerationToolLegacyInput = {
   };
 };
 export type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3570,7 +3575,6 @@ export type AiTextGenerationFunctionsInput = {
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3623,7 +3627,7 @@ export type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-export type AiTextToImageOutput = Uint8Array;
+export type AiTextToImageOutput = ReadableStream<Uint8Array>;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -3478,10 +3478,10 @@ export declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-export type AiSpeechRecognitionInput = {
+export type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-export type AiSpeechRecognitionOutput = {
+export type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3490,9 +3490,9 @@ export type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-export declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+export declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 export type AiSummarizationInput = {
   input_text: string;
@@ -3528,16 +3528,31 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+export type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 export type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3548,9 +3563,14 @@ export type AiTextGenerationToolInput = {
     };
   };
 };
+export type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3561,7 +3581,8 @@ export type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 export type AiTextGenerationOutput =
   | {
@@ -3576,15 +3597,33 @@ export declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+export type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+export type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+export declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 export type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-export type AiTextToImageOutput = ReadableStream<Uint8Array>;
+export type AiTextToImageOutput = Uint8Array;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3606,119 +3645,73 @@ export type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-export type BaseAiTextClassificationModels =
-  "@cf/huggingface/distilbert-sst-2-int8";
-export type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-export type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-export type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-export type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-export type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-export type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-export type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-export type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-export type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-export declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+export type ModelType<Name extends keyof AiModels> = AiModels[Name];
+export interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+export type ModelListType = Record<string, any>;
+export declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 export type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -3519,7 +3519,12 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3527,7 +3532,7 @@ type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3538,12 +3543,12 @@ type AiTextGenerationToolLegacyInput = {
   };
 };
 type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3561,7 +3566,6 @@ type AiTextGenerationFunctionsInput = {
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3614,7 +3618,7 @@ type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-type AiTextToImageOutput = Uint8Array;
+type AiTextToImageOutput = ReadableStream<Uint8Array>;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -3469,10 +3469,10 @@ declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-type AiSpeechRecognitionInput = {
+type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-type AiSpeechRecognitionOutput = {
+type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3481,9 +3481,9 @@ type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 type AiSummarizationInput = {
   input_text: string;
@@ -3519,16 +3519,31 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3539,9 +3554,14 @@ type AiTextGenerationToolInput = {
     };
   };
 };
+type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3552,7 +3572,8 @@ type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 type AiTextGenerationOutput =
   | {
@@ -3567,15 +3588,33 @@ declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-type AiTextToImageOutput = ReadableStream<Uint8Array>;
+type AiTextToImageOutput = Uint8Array;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3597,118 +3636,73 @@ type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-type BaseAiTextClassificationModels = "@cf/huggingface/distilbert-sst-2-int8";
-type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+type ModelType<Name extends keyof AiModels> = AiModels[Name];
+interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+type ModelListType = Record<string, any>;
+declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -3531,7 +3531,12 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3539,7 +3544,7 @@ export type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3550,12 +3555,12 @@ export type AiTextGenerationToolLegacyInput = {
   };
 };
 export type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3573,7 +3578,6 @@ export type AiTextGenerationFunctionsInput = {
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3626,7 +3630,7 @@ export type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-export type AiTextToImageOutput = Uint8Array;
+export type AiTextToImageOutput = ReadableStream<Uint8Array>;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -3481,10 +3481,10 @@ export declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-export type AiSpeechRecognitionInput = {
+export type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-export type AiSpeechRecognitionOutput = {
+export type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3493,9 +3493,9 @@ export type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-export declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+export declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 export type AiSummarizationInput = {
   input_text: string;
@@ -3531,16 +3531,31 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+export type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 export type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3551,9 +3566,14 @@ export type AiTextGenerationToolInput = {
     };
   };
 };
+export type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3564,7 +3584,8 @@ export type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 export type AiTextGenerationOutput =
   | {
@@ -3579,15 +3600,33 @@ export declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+export type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+export type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+export declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 export type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-export type AiTextToImageOutput = ReadableStream<Uint8Array>;
+export type AiTextToImageOutput = Uint8Array;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3609,119 +3648,73 @@ export type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-export type BaseAiTextClassificationModels =
-  "@cf/huggingface/distilbert-sst-2-int8";
-export type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-export type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-export type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-export type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-export type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-export type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-export type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-export type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-export type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-export declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+export type ModelType<Name extends keyof AiModels> = AiModels[Name];
+export interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+export type ModelListType = Record<string, any>;
+export declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 export type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -3474,10 +3474,10 @@ declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-type AiSpeechRecognitionInput = {
+type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-type AiSpeechRecognitionOutput = {
+type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3486,9 +3486,9 @@ type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 type AiSummarizationInput = {
   input_text: string;
@@ -3524,16 +3524,31 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3544,9 +3559,14 @@ type AiTextGenerationToolInput = {
     };
   };
 };
+type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3557,7 +3577,8 @@ type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 type AiTextGenerationOutput =
   | {
@@ -3572,15 +3593,33 @@ declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-type AiTextToImageOutput = ReadableStream<Uint8Array>;
+type AiTextToImageOutput = Uint8Array;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3602,118 +3641,73 @@ type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-type BaseAiTextClassificationModels = "@cf/huggingface/distilbert-sst-2-int8";
-type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+type ModelType<Name extends keyof AiModels> = AiModels[Name];
+interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+type ModelListType = Record<string, any>;
+declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -3524,7 +3524,12 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3532,7 +3537,7 @@ type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3543,12 +3548,12 @@ type AiTextGenerationToolLegacyInput = {
   };
 };
 type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3566,7 +3571,6 @@ type AiTextGenerationFunctionsInput = {
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3619,7 +3623,7 @@ type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-type AiTextToImageOutput = Uint8Array;
+type AiTextToImageOutput = ReadableStream<Uint8Array>;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -3486,10 +3486,10 @@ export declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-export type AiSpeechRecognitionInput = {
+export type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-export type AiSpeechRecognitionOutput = {
+export type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3498,9 +3498,9 @@ export type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-export declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+export declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 export type AiSummarizationInput = {
   input_text: string;
@@ -3536,16 +3536,31 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+export type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 export type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3556,9 +3571,14 @@ export type AiTextGenerationToolInput = {
     };
   };
 };
+export type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3569,7 +3589,8 @@ export type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 export type AiTextGenerationOutput =
   | {
@@ -3584,15 +3605,33 @@ export declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+export type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+export type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+export declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 export type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-export type AiTextToImageOutput = ReadableStream<Uint8Array>;
+export type AiTextToImageOutput = Uint8Array;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3614,119 +3653,73 @@ export type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-export type BaseAiTextClassificationModels =
-  "@cf/huggingface/distilbert-sst-2-int8";
-export type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-export type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-export type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-export type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-export type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-export type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-export type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-export type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-export type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-export declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+export type ModelType<Name extends keyof AiModels> = AiModels[Name];
+export interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+export type ModelListType = Record<string, any>;
+export declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 export type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -3536,7 +3536,12 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3544,7 +3549,7 @@ export type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3555,12 +3560,12 @@ export type AiTextGenerationToolLegacyInput = {
   };
 };
 export type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3578,7 +3583,6 @@ export type AiTextGenerationFunctionsInput = {
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3631,7 +3635,7 @@ export type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-export type AiTextToImageOutput = Uint8Array;
+export type AiTextToImageOutput = ReadableStream<Uint8Array>;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -3476,10 +3476,10 @@ declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-type AiSpeechRecognitionInput = {
+type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-type AiSpeechRecognitionOutput = {
+type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3488,9 +3488,9 @@ type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 type AiSummarizationInput = {
   input_text: string;
@@ -3526,16 +3526,31 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3546,9 +3561,14 @@ type AiTextGenerationToolInput = {
     };
   };
 };
+type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3559,7 +3579,8 @@ type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 type AiTextGenerationOutput =
   | {
@@ -3574,15 +3595,33 @@ declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-type AiTextToImageOutput = ReadableStream<Uint8Array>;
+type AiTextToImageOutput = Uint8Array;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3604,118 +3643,73 @@ type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-type BaseAiTextClassificationModels = "@cf/huggingface/distilbert-sst-2-int8";
-type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+type ModelType<Name extends keyof AiModels> = AiModels[Name];
+interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+type ModelListType = Record<string, any>;
+declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -3526,7 +3526,12 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3534,7 +3539,7 @@ type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3545,12 +3550,12 @@ type AiTextGenerationToolLegacyInput = {
   };
 };
 type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3568,7 +3573,6 @@ type AiTextGenerationFunctionsInput = {
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3621,7 +3625,7 @@ type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-type AiTextToImageOutput = Uint8Array;
+type AiTextToImageOutput = ReadableStream<Uint8Array>;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -3488,10 +3488,10 @@ export declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-export type AiSpeechRecognitionInput = {
+export type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-export type AiSpeechRecognitionOutput = {
+export type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3500,9 +3500,9 @@ export type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-export declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+export declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 export type AiSummarizationInput = {
   input_text: string;
@@ -3538,16 +3538,31 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+export type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 export type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3558,9 +3573,14 @@ export type AiTextGenerationToolInput = {
     };
   };
 };
+export type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3571,7 +3591,8 @@ export type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 export type AiTextGenerationOutput =
   | {
@@ -3586,15 +3607,33 @@ export declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+export type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+export type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+export declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 export type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-export type AiTextToImageOutput = ReadableStream<Uint8Array>;
+export type AiTextToImageOutput = Uint8Array;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3616,119 +3655,73 @@ export type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-export type BaseAiTextClassificationModels =
-  "@cf/huggingface/distilbert-sst-2-int8";
-export type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-export type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-export type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-export type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-export type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-export type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-export type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-export type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-export type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-export declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+export type ModelType<Name extends keyof AiModels> = AiModels[Name];
+export interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+export type ModelListType = Record<string, any>;
+export declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 export type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -3538,7 +3538,12 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3546,7 +3551,7 @@ export type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3557,12 +3562,12 @@ export type AiTextGenerationToolLegacyInput = {
   };
 };
 export type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3580,7 +3585,6 @@ export type AiTextGenerationFunctionsInput = {
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3633,7 +3637,7 @@ export type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-export type AiTextToImageOutput = Uint8Array;
+export type AiTextToImageOutput = ReadableStream<Uint8Array>;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -3476,10 +3476,10 @@ declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-type AiSpeechRecognitionInput = {
+type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-type AiSpeechRecognitionOutput = {
+type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3488,9 +3488,9 @@ type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 type AiSummarizationInput = {
   input_text: string;
@@ -3526,16 +3526,31 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3546,9 +3561,14 @@ type AiTextGenerationToolInput = {
     };
   };
 };
+type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3559,7 +3579,8 @@ type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 type AiTextGenerationOutput =
   | {
@@ -3574,15 +3595,33 @@ declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-type AiTextToImageOutput = ReadableStream<Uint8Array>;
+type AiTextToImageOutput = Uint8Array;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3604,118 +3643,73 @@ type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-type BaseAiTextClassificationModels = "@cf/huggingface/distilbert-sst-2-int8";
-type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+type ModelType<Name extends keyof AiModels> = AiModels[Name];
+interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+type ModelListType = Record<string, any>;
+declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -3526,7 +3526,12 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3534,7 +3539,7 @@ type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3545,12 +3550,12 @@ type AiTextGenerationToolLegacyInput = {
   };
 };
 type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3568,7 +3573,6 @@ type AiTextGenerationFunctionsInput = {
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3621,7 +3625,7 @@ type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-type AiTextToImageOutput = Uint8Array;
+type AiTextToImageOutput = ReadableStream<Uint8Array>;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -3488,10 +3488,10 @@ export declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-export type AiSpeechRecognitionInput = {
+export type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-export type AiSpeechRecognitionOutput = {
+export type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3500,9 +3500,9 @@ export type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-export declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+export declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 export type AiSummarizationInput = {
   input_text: string;
@@ -3538,16 +3538,31 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+export type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 export type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3558,9 +3573,14 @@ export type AiTextGenerationToolInput = {
     };
   };
 };
+export type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3571,7 +3591,8 @@ export type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 export type AiTextGenerationOutput =
   | {
@@ -3586,15 +3607,33 @@ export declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+export type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+export type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+export declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 export type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-export type AiTextToImageOutput = ReadableStream<Uint8Array>;
+export type AiTextToImageOutput = Uint8Array;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3616,119 +3655,73 @@ export type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-export type BaseAiTextClassificationModels =
-  "@cf/huggingface/distilbert-sst-2-int8";
-export type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-export type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-export type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-export type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-export type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-export type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-export type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-export type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-export type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-export declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+export type ModelType<Name extends keyof AiModels> = AiModels[Name];
+export interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+export type ModelListType = Record<string, any>;
+export declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 export type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -3538,7 +3538,12 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3546,7 +3551,7 @@ export type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3557,12 +3562,12 @@ export type AiTextGenerationToolLegacyInput = {
   };
 };
 export type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3580,7 +3585,6 @@ export type AiTextGenerationFunctionsInput = {
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3633,7 +3637,7 @@ export type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-export type AiTextToImageOutput = Uint8Array;
+export type AiTextToImageOutput = ReadableStream<Uint8Array>;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3542,10 +3542,10 @@ declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-type AiSpeechRecognitionInput = {
+type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-type AiSpeechRecognitionOutput = {
+type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3554,9 +3554,9 @@ type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 type AiSummarizationInput = {
   input_text: string;
@@ -3592,16 +3592,31 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3612,9 +3627,14 @@ type AiTextGenerationToolInput = {
     };
   };
 };
+type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3625,7 +3645,8 @@ type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 type AiTextGenerationOutput =
   | {
@@ -3640,15 +3661,33 @@ declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-type AiTextToImageOutput = ReadableStream<Uint8Array>;
+type AiTextToImageOutput = Uint8Array;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3670,118 +3709,73 @@ type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-type BaseAiTextClassificationModels = "@cf/huggingface/distilbert-sst-2-int8";
-type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+type ModelType<Name extends keyof AiModels> = AiModels[Name];
+interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+type ModelListType = Record<string, any>;
+declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3592,7 +3592,12 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3600,7 +3605,7 @@ type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3611,12 +3616,12 @@ type AiTextGenerationToolLegacyInput = {
   };
 };
 type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3634,7 +3639,6 @@ type AiTextGenerationFunctionsInput = {
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3687,7 +3691,7 @@ type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-type AiTextToImageOutput = Uint8Array;
+type AiTextToImageOutput = ReadableStream<Uint8Array>;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3554,10 +3554,10 @@ export declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-export type AiSpeechRecognitionInput = {
+export type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-export type AiSpeechRecognitionOutput = {
+export type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3566,9 +3566,9 @@ export type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-export declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+export declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 export type AiSummarizationInput = {
   input_text: string;
@@ -3604,16 +3604,31 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+export type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 export type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3624,9 +3639,14 @@ export type AiTextGenerationToolInput = {
     };
   };
 };
+export type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3637,7 +3657,8 @@ export type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 export type AiTextGenerationOutput =
   | {
@@ -3652,15 +3673,33 @@ export declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+export type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+export type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+export declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 export type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-export type AiTextToImageOutput = ReadableStream<Uint8Array>;
+export type AiTextToImageOutput = Uint8Array;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3682,119 +3721,73 @@ export type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-export type BaseAiTextClassificationModels =
-  "@cf/huggingface/distilbert-sst-2-int8";
-export type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-export type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-export type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-export type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-export type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-export type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-export type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-export type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-export type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-export declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+export type ModelType<Name extends keyof AiModels> = AiModels[Name];
+export interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+export type ModelListType = Record<string, any>;
+export declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 export type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3604,7 +3604,12 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3612,7 +3617,7 @@ export type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3623,12 +3628,12 @@ export type AiTextGenerationToolLegacyInput = {
   };
 };
 export type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3646,7 +3651,6 @@ export type AiTextGenerationFunctionsInput = {
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3699,7 +3703,7 @@ export type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-export type AiTextToImageOutput = Uint8Array;
+export type AiTextToImageOutput = ReadableStream<Uint8Array>;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -3464,7 +3464,12 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3472,7 +3477,7 @@ type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3483,12 +3488,12 @@ type AiTextGenerationToolLegacyInput = {
   };
 };
 type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3506,7 +3511,6 @@ type AiTextGenerationFunctionsInput = {
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3559,7 +3563,7 @@ type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-type AiTextToImageOutput = Uint8Array;
+type AiTextToImageOutput = ReadableStream<Uint8Array>;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -3414,10 +3414,10 @@ declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-type AiSpeechRecognitionInput = {
+type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-type AiSpeechRecognitionOutput = {
+type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3426,9 +3426,9 @@ type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 type AiSummarizationInput = {
   input_text: string;
@@ -3464,16 +3464,31 @@ declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3484,9 +3499,14 @@ type AiTextGenerationToolInput = {
     };
   };
 };
+type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3497,7 +3517,8 @@ type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 type AiTextGenerationOutput =
   | {
@@ -3512,15 +3533,33 @@ declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-type AiTextToImageOutput = ReadableStream<Uint8Array>;
+type AiTextToImageOutput = Uint8Array;
 declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3542,118 +3581,73 @@ type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-type BaseAiTextClassificationModels = "@cf/huggingface/distilbert-sst-2-int8";
-type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+type ModelType<Name extends keyof AiModels> = AiModels[Name];
+interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+type ModelListType = Record<string, any>;
+declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 type GatewayOptions = {
   id: string;

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -3476,7 +3476,12 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool" | string;
+  role:
+    | "user"
+    | "assistant"
+    | "system"
+    | "tool"
+    | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -3484,7 +3489,7 @@ export type AiTextGenerationToolLegacyInput = {
   name: string;
   description: string;
   parameters?: {
-    type: "object" | string;
+    type: "object" | (string & NonNullable<unknown>);
     properties: {
       [key: string]: {
         type: string;
@@ -3495,12 +3500,12 @@ export type AiTextGenerationToolLegacyInput = {
   };
 };
 export type AiTextGenerationToolInput = {
-  type: "function" | string;
+  type: "function" | (string & NonNullable<unknown>);
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object" | string;
+      type: "object" | (string & NonNullable<unknown>);
       properties: {
         [key: string]: {
           type: string;
@@ -3518,7 +3523,6 @@ export type AiTextGenerationFunctionsInput = {
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
-  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3571,7 +3575,7 @@ export type AiTextToImageInput = {
   guidance?: number;
   seed?: number;
 };
-export type AiTextToImageOutput = Uint8Array;
+export type AiTextToImageOutput = ReadableStream<Uint8Array>;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -3426,10 +3426,10 @@ export declare abstract class BaseAiSentenceSimilarity {
   inputs: AiSentenceSimilarityInput;
   postProcessedOutputs: AiSentenceSimilarityOutput;
 }
-export type AiSpeechRecognitionInput = {
+export type AiAutomaticSpeechRecognitionInput = {
   audio: number[];
 };
-export type AiSpeechRecognitionOutput = {
+export type AiAutomaticSpeechRecognitionOutput = {
   text?: string;
   words?: {
     word: string;
@@ -3438,9 +3438,9 @@ export type AiSpeechRecognitionOutput = {
   }[];
   vtt?: string;
 };
-export declare abstract class BaseAiSpeechRecognition {
-  inputs: AiSpeechRecognitionInput;
-  postProcessedOutputs: AiSpeechRecognitionOutput;
+export declare abstract class BaseAiAutomaticSpeechRecognition {
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 export type AiSummarizationInput = {
   input_text: string;
@@ -3476,16 +3476,31 @@ export declare abstract class BaseAiTextEmbeddings {
   postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 export type RoleScopedChatInput = {
-  role: "user" | "assistant" | "system" | "tool";
+  role: "user" | "assistant" | "system" | "tool" | string;
   content: string;
+  name?: string;
+};
+export type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | string;
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
 };
 export type AiTextGenerationToolInput = {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;
     parameters?: {
-      type: "object";
+      type: "object" | string;
       properties: {
         [key: string]: {
           type: string;
@@ -3496,9 +3511,14 @@ export type AiTextGenerationToolInput = {
     };
   };
 };
+export type AiTextGenerationFunctionsInput = {
+  name: string;
+  code: string;
+};
 export type AiTextGenerationInput = {
   prompt?: string;
   raw?: boolean;
+  image?: number[];
   stream?: boolean;
   max_tokens?: number;
   temperature?: number;
@@ -3509,7 +3529,8 @@ export type AiTextGenerationInput = {
   frequency_penalty?: number;
   presence_penalty?: number;
   messages?: RoleScopedChatInput[];
-  tools?: AiTextGenerationToolInput[];
+  tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[];
+  functions?: AiTextGenerationFunctionsInput[];
 };
 export type AiTextGenerationOutput =
   | {
@@ -3524,15 +3545,33 @@ export declare abstract class BaseAiTextGeneration {
   inputs: AiTextGenerationInput;
   postProcessedOutputs: AiTextGenerationOutput;
 }
+export type AiTextToSpeechInput = {
+  prompt: string;
+  lang?: string;
+};
+export type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
+export declare abstract class BaseAiTextToSpeech {
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
+}
 export type AiTextToImageInput = {
   prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
   image?: number[];
+  image_b64?: string;
   mask?: number[];
   num_steps?: number;
   strength?: number;
   guidance?: number;
+  seed?: number;
 };
-export type AiTextToImageOutput = ReadableStream<Uint8Array>;
+export type AiTextToImageOutput = Uint8Array;
 export declare abstract class BaseAiTextToImage {
   inputs: AiTextToImageInput;
   postProcessedOutputs: AiTextToImageOutput;
@@ -3554,119 +3593,73 @@ export type AiOptions = {
   prefix?: string;
   extraHeaders?: object;
 };
-export type BaseAiTextClassificationModels =
-  "@cf/huggingface/distilbert-sst-2-int8";
-export type BaseAiTextToImageModels =
-  | "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-  | "@cf/runwayml/stable-diffusion-v1-5-inpainting"
-  | "@cf/runwayml/stable-diffusion-v1-5-img2img"
-  | "@cf/lykon/dreamshaper-8-lcm"
-  | "@cf/bytedance/stable-diffusion-xl-lightning";
-export type BaseAiTextEmbeddingsModels =
-  | "@cf/baai/bge-small-en-v1.5"
-  | "@cf/baai/bge-base-en-v1.5"
-  | "@cf/baai/bge-large-en-v1.5";
-export type BaseAiSpeechRecognitionModels =
-  | "@cf/openai/whisper"
-  | "@cf/openai/whisper-tiny-en"
-  | "@cf/openai/whisper-sherpa";
-export type BaseAiImageClassificationModels = "@cf/microsoft/resnet-50";
-export type BaseAiObjectDetectionModels = "@cf/facebook/detr-resnet-50";
-export type BaseAiTextGenerationModels =
-  | "@cf/meta/llama-3.1-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct"
-  | "@cf/meta/llama-3-8b-instruct-awq"
-  | "@cf/meta/llama-2-7b-chat-int8"
-  | "@cf/mistral/mistral-7b-instruct-v0.1"
-  | "@cf/mistral/mistral-7b-instruct-v0.2-lora"
-  | "@cf/meta/llama-2-7b-chat-fp16"
-  | "@hf/thebloke/llama-2-13b-chat-awq"
-  | "@hf/thebloke/zephyr-7b-beta-awq"
-  | "@hf/thebloke/mistral-7b-instruct-v0.1-awq"
-  | "@hf/thebloke/codellama-7b-instruct-awq"
-  | "@hf/thebloke/openhermes-2.5-mistral-7b-awq"
-  | "@hf/thebloke/neural-chat-7b-v3-1-awq"
-  | "@hf/thebloke/llamaguard-7b-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-base-awq"
-  | "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
-  | "@hf/nousresearch/hermes-2-pro-mistral-7b"
-  | "@hf/mistral/mistral-7b-instruct-v0.2"
-  | "@hf/google/gemma-7b-it"
-  | "@hf/nexusflow/starling-lm-7b-beta"
-  | "@cf/deepseek-ai/deepseek-math-7b-instruct"
-  | "@cf/defog/sqlcoder-7b-2"
-  | "@cf/openchat/openchat-3.5-0106"
-  | "@cf/tiiuae/falcon-7b-instruct"
-  | "@cf/thebloke/discolm-german-7b-v1-awq"
-  | "@cf/qwen/qwen1.5-0.5b-chat"
-  | "@cf/qwen/qwen1.5-1.8b-chat"
-  | "@cf/qwen/qwen1.5-7b-chat-awq"
-  | "@cf/qwen/qwen1.5-14b-chat-awq"
-  | "@cf/tinyllama/tinyllama-1.1b-chat-v1.0"
-  | "@cf/microsoft/phi-2"
-  | "@cf/google/gemma-2b-it-lora"
-  | "@cf/google/gemma-7b-it-lora"
-  | "@cf/meta-llama/llama-2-7b-chat-hf-lora"
-  | "@cf/fblgit/una-cybertron-7b-v2-bf16"
-  | "@cf/fblgit/una-cybertron-7b-v2-awq";
-export type BaseAiTranslationModels = "@cf/meta/m2m100-1.2b";
-export type BaseAiSummarizationModels = "@cf/facebook/bart-large-cnn";
-export type BaseAiImageToTextModels =
-  | "@cf/unum/uform-gen2-qwen-500m"
-  | "@cf/llava-hf/llava-1.5-7b-hf";
-export declare abstract class Ai {
-  public aiGatewayLogId: string | null;
-  public gateway(gatewayId: string): AiGateway;
-  run(
-    model: BaseAiTextClassificationModels,
-    inputs: BaseAiTextClassification["inputs"],
+export type ModelType<Name extends keyof AiModels> = AiModels[Name];
+export interface AiModels {
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/baai/bge-base-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-small-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/baai/bge-large-en-v1.5": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/facebook/detr-resnet-50": BaseAiObjectDetection;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": BaseAiTextGeneration;
+  "@cf/meta/m2m100-1.2b": BaseAiTranslation;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/unum/uform-gen2-qwen-500m": BaseAiImageToText;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+}
+export type ModelListType = Record<string, any>;
+export declare abstract class Ai<ModelList extends ModelListType = AiModels> {
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  run<Name extends keyof ModelList>(
+    model: Name,
+    inputs: ModelList[Name]["inputs"],
     options?: AiOptions,
-  ): Promise<BaseAiTextClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextToImageModels,
-    inputs: BaseAiTextToImage["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextToImage["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextEmbeddingsModels,
-    inputs: BaseAiTextEmbeddings["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextEmbeddings["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSpeechRecognitionModels,
-    inputs: BaseAiSpeechRecognition["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSpeechRecognition["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageClassificationModels,
-    inputs: BaseAiImageClassification["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageClassification["postProcessedOutputs"]>;
-  run(
-    model: BaseAiObjectDetectionModels,
-    inputs: BaseAiObjectDetection["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiObjectDetection["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTextGenerationModels,
-    inputs: BaseAiTextGeneration["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTextGeneration["postProcessedOutputs"]>;
-  run(
-    model: BaseAiTranslationModels,
-    inputs: BaseAiTranslation["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiTranslation["postProcessedOutputs"]>;
-  run(
-    model: BaseAiSummarizationModels,
-    inputs: BaseAiSummarization["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiSummarization["postProcessedOutputs"]>;
-  run(
-    model: BaseAiImageToTextModels,
-    inputs: BaseAiImageToText["inputs"],
-    options?: AiOptions,
-  ): Promise<BaseAiImageToText["postProcessedOutputs"]>;
+  ): Promise<ModelList[Name]["postProcessedOutputs"]>;
 }
 export type GatewayOptions = {
   id: string;


### PR DESCRIPTION
With growing a growing list of supported models and their capabilities, we are making it simpler to infer input/output types from model names.

From users perspective, they will still be able to call `AI.run("<model-name>", {<inputs>}, {<options>})`, but we are modifying the type definitions to make it easier for future updates.