### PR TITLE
feat: add instanceId to the Workflow event type

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -235,6 +235,7 @@ declare module "cloudflare:workers" {
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
+    instanceId: string;
   };
 
   export abstract class WorkflowStep {

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -5357,6 +5357,7 @@ declare module "cloudflare:workers" {
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
+    instanceId: string;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -5383,6 +5383,7 @@ declare module "cloudflare:workers" {
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
+    instanceId: string;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -5408,6 +5408,7 @@ declare module "cloudflare:workers" {
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
+    instanceId: string;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -5409,6 +5409,7 @@ declare module "cloudflare:workers" {
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
+    instanceId: string;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -5412,6 +5412,7 @@ declare module "cloudflare:workers" {
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
+    instanceId: string;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -5417,6 +5417,7 @@ declare module "cloudflare:workers" {
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
+    instanceId: string;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -5419,6 +5419,7 @@ declare module "cloudflare:workers" {
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
+    instanceId: string;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -5419,6 +5419,7 @@ declare module "cloudflare:workers" {
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
+    instanceId: string;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -5485,6 +5485,7 @@ declare module "cloudflare:workers" {
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
+    instanceId: string;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -5357,6 +5357,7 @@ declare module "cloudflare:workers" {
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
+    instanceId: string;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(


### PR DESCRIPTION
This will allow users to get the instance id directly (without passing it to the event payload itself) - allows users to make instances more observable, allows users to create better globally unique keys (for APIs, or external storage) and so on...