### PR TITLE
fix: Unknown encoding when undefined is used

### DIFF
--- a/src/node/internal/internal_buffer.ts
+++ b/src/node/internal/internal_buffer.ts
@@ -28,7 +28,10 @@ import {
   isUint8Array,
 } from 'node-internal:internal_types';
 
-import { normalizeEncoding } from 'node-internal:internal_utils';
+import {
+  normalizeEncoding,
+  getEncodingOps,
+} from 'node-internal:internal_utils';
 
 import { validateString } from 'node-internal:validators';
 
@@ -648,7 +651,7 @@ Buffer.prototype.toString = function toString(
     return '';
   }
 
-  const normalizedEncoding = normalizeEncoding(encoding?.toString());
+  const normalizedEncoding = getEncodingOps(encoding);
   if (normalizedEncoding === undefined) {
     throw new ERR_UNKNOWN_ENCODING(`${encoding}`);
   }

--- a/src/node/internal/internal_buffer.ts
+++ b/src/node/internal/internal_buffer.ts
@@ -12,15 +12,15 @@
 
 import {
   ERR_BUFFER_OUT_OF_BOUNDS,
-  ERR_OUT_OF_RANGE,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_BUFFER_SIZE,
+  ERR_OUT_OF_RANGE,
   ERR_UNKNOWN_ENCODING,
 } from 'node-internal:internal_errors';
 
-import { default as bufferUtil } from 'node-internal:buffer';
 import type { Encoding } from 'node-internal:buffer';
+import { default as bufferUtil } from 'node-internal:buffer';
 
 import {
   isAnyArrayBuffer,
@@ -32,11 +32,11 @@ import { normalizeEncoding } from 'node-internal:internal_utils';
 
 import { validateString } from 'node-internal:validators';
 
-import internalUtil from 'node-internal:util';
 import {
   InspectOptionsStylized,
   inspect as utilInspect,
 } from 'node-internal:internal_inspect';
+import internalUtil from 'node-internal:util';
 
 const { ASCII, BASE64, BASE64URL, HEX, LATIN1, UTF16LE, UTF8 } = bufferUtil;
 
@@ -648,7 +648,7 @@ Buffer.prototype.toString = function toString(
     return '';
   }
 
-  const normalizedEncoding = normalizeEncoding(`${encoding}`);
+  const normalizedEncoding = normalizeEncoding(encoding);
   if (normalizedEncoding === undefined) {
     throw new ERR_UNKNOWN_ENCODING(`${encoding}`);
   }

--- a/src/node/internal/internal_buffer.ts
+++ b/src/node/internal/internal_buffer.ts
@@ -12,15 +12,15 @@
 
 import {
   ERR_BUFFER_OUT_OF_BOUNDS,
+  ERR_OUT_OF_RANGE,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_BUFFER_SIZE,
-  ERR_OUT_OF_RANGE,
   ERR_UNKNOWN_ENCODING,
 } from 'node-internal:internal_errors';
 
-import type { Encoding } from 'node-internal:buffer';
 import { default as bufferUtil } from 'node-internal:buffer';
+import type { Encoding } from 'node-internal:buffer';
 
 import {
   isAnyArrayBuffer,
@@ -32,11 +32,11 @@ import { normalizeEncoding } from 'node-internal:internal_utils';
 
 import { validateString } from 'node-internal:validators';
 
+import internalUtil from 'node-internal:util';
 import {
   InspectOptionsStylized,
   inspect as utilInspect,
 } from 'node-internal:internal_inspect';
-import internalUtil from 'node-internal:util';
 
 const { ASCII, BASE64, BASE64URL, HEX, LATIN1, UTF16LE, UTF8 } = bufferUtil;
 
@@ -648,7 +648,7 @@ Buffer.prototype.toString = function toString(
     return '';
   }
 
-  const normalizedEncoding = normalizeEncoding(encoding);
+  const normalizedEncoding = normalizeEncoding(encoding?.toString());
   if (normalizedEncoding === undefined) {
     throw new ERR_UNKNOWN_ENCODING(`${encoding}`);
   }

--- a/src/node/internal/internal_utils.ts
+++ b/src/node/internal/internal_utils.ts
@@ -42,10 +42,12 @@ export function normalizeEncoding(enc?: string): Encoding | undefined {
     enc === 'UTF-8'
   )
     return UTF8;
-  return slowCases(enc);
+  return getEncodingOps(enc);
 }
 
-export function slowCases(enc: unknown): Encoding | undefined {
+export function getEncodingOps(enc: unknown): Encoding | undefined {
+  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+  enc += '';
   // @ts-expect-error TS18046 TS complains about unknown can not have length.
   switch (enc.length) {
     case 4:

--- a/src/node/internal/internal_utils.ts
+++ b/src/node/internal/internal_utils.ts
@@ -36,7 +36,6 @@ const { UTF8, UTF16LE, HEX, ASCII, BASE64, BASE64URL, LATIN1 } = bufferUtil;
 export function normalizeEncoding(enc?: string): Encoding | undefined {
   if (
     enc == null ||
-    enc === undefined ||
     enc === 'utf8' ||
     enc === 'utf-8' ||
     enc === 'UTF8' ||

--- a/src/node/internal/internal_utils.ts
+++ b/src/node/internal/internal_utils.ts
@@ -26,10 +26,10 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import type { Encoding } from 'node-internal:buffer';
 import { default as bufferUtil } from 'node-internal:buffer';
-import { ERR_FALSY_VALUE_REJECTION } from 'node-internal:internal_errors';
+import type { Encoding } from 'node-internal:buffer';
 import { validateFunction } from 'node-internal:validators';
+import { ERR_FALSY_VALUE_REJECTION } from 'node-internal:internal_errors';
 
 const { UTF8, UTF16LE, HEX, ASCII, BASE64, BASE64URL, LATIN1 } = bufferUtil;
 

--- a/src/node/internal/internal_utils.ts
+++ b/src/node/internal/internal_utils.ts
@@ -26,16 +26,17 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import { default as bufferUtil } from 'node-internal:buffer';
 import type { Encoding } from 'node-internal:buffer';
-import { validateFunction } from 'node-internal:validators';
+import { default as bufferUtil } from 'node-internal:buffer';
 import { ERR_FALSY_VALUE_REJECTION } from 'node-internal:internal_errors';
+import { validateFunction } from 'node-internal:validators';
 
 const { UTF8, UTF16LE, HEX, ASCII, BASE64, BASE64URL, LATIN1 } = bufferUtil;
 
 export function normalizeEncoding(enc?: string): Encoding | undefined {
   if (
     enc == null ||
+    enc === undefined ||
     enc === 'utf8' ||
     enc === 'utf-8' ||
     enc === 'UTF8' ||

--- a/src/workerd/api/node/tests/buffer-nodejs-test.js
+++ b/src/workerd/api/node/tests/buffer-nodejs-test.js
@@ -25,9 +25,9 @@
 
 import {
   deepStrictEqual,
-  ok,
   notDeepStrictEqual,
   notStrictEqual,
+  ok,
   strictEqual,
   throws,
 } from 'node:assert';
@@ -35,14 +35,14 @@ import util from 'node:util';
 
 import {
   Buffer,
+  File,
   SlowBuffer,
-  kMaxLength,
-  kStringMaxLength,
   constants,
   isAscii,
   isUtf8,
+  kMaxLength,
+  kStringMaxLength,
   transcode,
-  File,
 } from 'node:buffer';
 
 import * as buffer from 'node:buffer';
@@ -5696,7 +5696,9 @@ export const toString = {
     // default utf-8 if undefined
     strictEqual(Buffer.from('utf-8').toString(), 'utf-8');
 
-    const invalidEncodings = new Array(10).fill(0).map((_, i) => String(i + 1).repeat(i + 1));
+    const invalidEncodings = new Array(10)
+      .fill(0)
+      .map((_, i) => String(i + 1).repeat(i + 1));
     // Invalid encodings
     for (const encoding of [...invalidEncodings, null]) {
       const error = {

--- a/src/workerd/api/node/tests/buffer-nodejs-test.js
+++ b/src/workerd/api/node/tests/buffer-nodejs-test.js
@@ -5815,7 +5815,8 @@ export const toStringRange = {
       },
       {
         name: 'TypeError',
-      }
+      },
+      'toString() with 0 and null as the encoding should have thrown'
     );
 
     throws(
@@ -5824,7 +5825,8 @@ export const toStringRange = {
       },
       {
         name: 'TypeError',
-      }
+      },
+      'toString() with null encoding should have thrown'
     );
   },
 };

--- a/src/workerd/api/node/tests/buffer-nodejs-test.js
+++ b/src/workerd/api/node/tests/buffer-nodejs-test.js
@@ -5693,9 +5693,13 @@ export const toString = {
       strictEqual(Buffer.from('666f6f', encoding).toString(encoding), '666f6f');
     });
 
+    // default utf-8 if undefined
+    strictEqual(Buffer.from('utf-8').toString(), 'utf-8');
+
+
+    const invalidEncodings = new Array(10).fill(0).map((_, i) => String(i + 1).repeat(i + 1));
     // Invalid encodings
-    for (let i = 1; i < 10; i++) {
-      const encoding = String(i).repeat(i);
+    for (const encoding of [...invalidEncodings, null]) {
       const error = {
         code: 'ERR_UNKNOWN_ENCODING',
         name: 'TypeError',

--- a/src/workerd/api/node/tests/buffer-nodejs-test.js
+++ b/src/workerd/api/node/tests/buffer-nodejs-test.js
@@ -5696,7 +5696,6 @@ export const toString = {
     // default utf-8 if undefined
     strictEqual(Buffer.from('utf-8').toString(), 'utf-8');
 
-
     const invalidEncodings = new Array(10).fill(0).map((_, i) => String(i + 1).repeat(i + 1));
     // Invalid encodings
     for (const encoding of [...invalidEncodings, null]) {


### PR DESCRIPTION
The behavior of `buffer.toString(encoding)` is not compliant with nodejs API. it throws an error `UNKNOWN_ENCODING: null` (or undefined) because it's being passed as a string "undefined" or "null"