### PR TITLE
Use std::list instead of std::deque for all buffers/queues in streams

### DIFF
--- a/src/workerd/api/streams/compression.c++
+++ b/src/workerd/api/streams/compression.c++
@@ -8,8 +8,8 @@
 
 #include <workerd/io/features.h>
 
-#include <deque>
 #include <iterator>
+#include <list>
 #include <vector>
 
 namespace workerd::api {
@@ -489,7 +489,9 @@ class CompressionStreamImpl: public kj::Refcounted,
 
   kj::Canceler canceler;
   LazyBuffer output;
-  std::deque<PendingRead> pendingReads;
+  // We use std::list to keep memory overhead low when there are many streams with no or few pending
+  // reads.
+  std::list<PendingRead> pendingReads;
 };
 }  // namespace
 

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -10,7 +10,7 @@
 #include <workerd/io/io-context.h>
 #include <workerd/io/observer.h>
 
-#include <deque>
+#include <list>
 
 namespace workerd::api {
 
@@ -377,7 +377,9 @@ class WritableStreamInternalController: public WritableStreamController {
     }
   };
 
-  std::deque<WriteEvent> queue;
+  // We use std::list to keep memory overhead low when there are many streams with no or few pending
+  // events.
+  std::list<WriteEvent> queue;
 };
 
 // An implementation of ReadableStreamSource and WritableStreamSink which communicates read and


### PR DESCRIPTION
API implementation objects.

A very common use case is to create one or more stream API objects per request. These streams currently have a high native memory overhead even when they are empty. Switching to std::list (which doesn't pre-allocate space for items) significantly alleviates this problem.

For example, now ReadableStreams tend to have <50% of their original memory footprint.