### PR TITLE
[ci] Update Windows runner to Server 2025

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-15, windows-2022]
+        os: [ubuntu-20.04, macos-15, windows-2025]
         target-arch: [ X64 ]
         include:
           - os-name: linux
@@ -74,7 +74,7 @@ jobs:
             bazel-config: release_macos
             target-arch: ARM64
           - os-name: windows
-            os: windows-2022
+            os: windows-2025
             bazel-config: release_windows
     runs-on: ${{ matrix.os }}
     name: build (${{ matrix.os-name }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           [
             { name : linux, image : ubuntu-20.04 },
             { name : macOS, image : macos-15 },
-            { name : windows, image : windows-2022 }
+            { name : windows, image : windows-2025 }
           ]
         config:
           [
@@ -43,19 +43,19 @@ jobs:
           - os:     { name: linux, image: ubuntu-20.04 }
             config: { suffix: -asan }
           # Windows has a custom non-debug bazel config.
-          - os:     { name : windows, image : windows-2022 }
+          - os:     { name : windows, image : windows-2025 }
             config: { suffix: '' }
           # TODO (later): The custom Windows-debug configuration consistently runs out of disk
           # space on CI, disable it for now. Once https://github.com/bazelbuild/bazel/issues/21615
           # has been resolved we can likely re-enable it and possibly fold up the custom
           # configurations, as we can more easily disable PDB file generation.
-          # - os:     { name : windows, image : windows-2022 }
+          # - os:     { name : windows, image : windows-2025 }
           #   config: { suffix: -debug, bazel-args: --config=windows_dbg }
         exclude:
           # Skip the matrix generated Windows non-debug config to use the one added above.
-          - os:     { name : windows, image : windows-2022 }
+          - os:     { name : windows, image : windows-2025 }
             config: { suffix: '' }
-          - os:     { name : windows, image : windows-2022 }
+          - os:     { name : windows, image : windows-2025 }
             config: { suffix: -debug }
           # due to resource constraints, exclude the macOS-debug runner for now. linux-debug and
           # linux-asan should provide sufficient coverage for building in the debug configuration.


### PR DESCRIPTION
Based on limited testing, Bazel starts up and computes the repo mapping much faster on the windows-2025 (perhaps no longer bottlenecked on I/O?), which should speed up I/O as a whole. The new runner is considered "beta" quality (see announcement https://github.com/actions/runner-images/issues/11228), but unfortunately the Windows runner is rather unstable in general so I see little risk of having more instability from this.