### PR TITLE
Fix `console.log(globalThis)` crash #3175

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -880,16 +880,19 @@ double Performance::now() {
 }
 
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
-jsg::Ref<api::gpu::GPU> Navigator::getGPU(CompatibilityFlags::Reader flags) {
+jsg::Optional<jsg::Ref<api::gpu::GPU>> Navigator::getGPU(CompatibilityFlags::Reader flags) {
   // is this a durable object?
   KJ_IF_SOME(actor, IoContext::current().getActor()) {
-    JSG_REQUIRE(actor.getPersistent() != kj::none, TypeError,
-        "webgpu api is only available in Durable Objects (no storage)");
+    if (actor.getPersistent() == kj::none) {
+      return kj::none;
+    }
   } else {
-    JSG_FAIL_REQUIRE(TypeError, "webgpu api is only available in Durable Objects");
+    return kj::none;
   };
 
-  JSG_REQUIRE(flags.getWebgpu(), TypeError, "webgpu needs the webgpu compatibility flag set");
+  if (!flags.getWebgpu()) {
+    return kj::none;
+  }
 
   return jsg::alloc<api::gpu::GPU>();
 }

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -74,7 +74,7 @@ class Navigator: public jsg::Object {
     return "Cloudflare-Workers"_kj;
   }
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
-  jsg::Ref<api::gpu::GPU> getGPU(CompatibilityFlags::Reader flags);
+  jsg::Optional<jsg::Ref<api::gpu::GPU>> getGPU(CompatibilityFlags::Reader flags);
 #endif
 
   bool sendBeacon(jsg::Lock& js, kj::String url, jsg::Optional<Body::Initializer> body);

--- a/src/workerd/api/tests/global-scope-test.js
+++ b/src/workerd/api/tests/global-scope-test.js
@@ -2,11 +2,13 @@ import {
   deepStrictEqual,
   strictEqual,
   throws,
+  doesNotThrow,
   notStrictEqual,
   ok,
 } from 'node:assert';
 
 import { AsyncLocalStorage } from 'node:async_hooks';
+import util from 'node:util';
 
 export const navigatorUserAgent = {
   async test() {
@@ -742,5 +744,10 @@ export const toStringTag = {
     const internalFlag = Symbol.for('cloudflare:internal-class');
     strictEqual(Headers.prototype[internalFlag], internalFlag);
     strictEqual(new Headers()[internalFlag], internalFlag);
+  },
+};
+export const validateGlobalThis = {
+  test() {
+    util.inspect(globalThis);
   },
 };

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -469,7 +469,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -474,7 +474,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -469,7 +469,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -474,7 +474,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -469,7 +469,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -474,7 +474,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -474,7 +474,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -479,7 +479,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -474,7 +474,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -479,7 +479,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -474,7 +474,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -479,7 +479,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -476,7 +476,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -481,7 +481,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
-  readonly gpu: GPU;
+  readonly gpu?: GPU;
 }
 /**
  * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,


### PR DESCRIPTION
The bug in https://github.com/cloudflare/workerd/issues/3175 is caused by the fact that the function `getGPU` in `global_scope.c++` is set to only work in a `DurableObject`, and that is not the case in local development.

The fix is simple: Instead of setting the wgpu flag to be always on, enable it only in CI.
As long as `wgpu` is meant to be only accessible in `DureableObjects`, this fix should suffice.

I hope I didn't miss anything, and I'm happy to iterate on it otherwise.

Output of the `Bazel run all tests (dbg)` task:
![image](https://github.com/user-attachments/assets/a0e67bbe-a6ce-476f-9684-2aeab5e6194a)

Output of `bazel test --config=cli -c dbg --cache_test_results=no //...`:
![image](https://github.com/user-attachments/assets/392b9a92-c5e8-44c5-b95f-d900010753fe)