### PR TITLE
[build] Add support for Bazel header parsing

### DIFF
--- a/src/workerd/api/node/buffer-string-search.h
+++ b/src/workerd/api/node/buffer-string-search.h
@@ -28,8 +28,11 @@
 // found in the LICENSE file.
 #pragma once
 
-#include <algorithm>
-#include <cstring>
+#include <kj/common.h>
+
+#include <cstdint>
+
+using kj::uint;
 
 namespace workerd::api::node {
 namespace stringsearch {
@@ -201,7 +204,7 @@ inline T AlignDown(T value, U alignment) {
 }
 
 inline uint8_t GetHighestValueByte(uint16_t character) {
-  return std::max(static_cast<uint8_t>(character & 0xFF), static_cast<uint8_t>(character >> 8));
+  return kj::max(static_cast<uint8_t>(character & 0xFF), static_cast<uint8_t>(character >> 8));
 }
 
 inline uint8_t GetHighestValueByte(uint8_t character) {

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -54,6 +54,8 @@ wd_cc_library(
         "web-idl.h",
         "wrappable.h",
     ],
+    # Some JSG headers can't be compiled on their own
+    features = ["-parse_headers"],
     visibility = ["//visibility:public"],
     deps = [
         ":exception",

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -63,6 +63,8 @@ wd_cc_library(
         ":duration-exceeded-logger",
         "@capnp-cpp//src/kj",
         "@capnp-cpp//src/kj:kj-async",
+        # TODO(cleanup): Only for abortable.h, factor out
+        "@capnp-cpp//src/kj/compat:kj-http",
     ],
 )
 
@@ -165,6 +167,9 @@ wd_cc_library(
     name = "sentry",
     hdrs = ["sentry.h"],
     visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj",
+    ],
 )
 
 wd_cc_library(


### PR DESCRIPTION
capnp PR: https://github.com/capnproto/capnproto/pull/2207

Header parsing will be part of the downstream lint checks, I hope to add it to the workerd lint job in a follow-up PR too.