### PR TITLE
Increment Python bundle to new backport number (11).

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -430,7 +430,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   pythonWorkers @43 :Bool
       $compatEnableFlag("python_workers")
       $pythonSnapshotRelease(pyodide = "0.26.0a2", pyodideRevision = "2024-03-01",
-          packages = "2024-03-01", backport = 10,
+          packages = "2024-03-01", backport = 11,
           baselineSnapshotHash = "d13ce2f4a0ade2e09047b469874dacf4d071ed3558fec4c26f8d0b99d95f77b5")
       $impliedByAfterDate(name = "pythonWorkersDevPyodide", date = "2000-01-01");
   # Enables Python Workers. Access to this flag is not restricted, instead bundles containing


### PR DESCRIPTION
New bundle built here: https://github.com/cloudflare/workerd/actions/runs/12635968076/job/35207008586

Used this workflow: https://github.com/cloudflare/workerd/actions/workflows/release-python-runtime.yml