### PR TITLE
Save HibernatableWebSocketEventInfo events by value

### DIFF
--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -520,15 +520,15 @@ TraceItem::CustomEventInfo::CustomEventInfo(
     : eventInfo(eventInfo) {}
 
 TraceItem::HibernatableWebSocketEventInfo::HibernatableWebSocketEventInfo(
-    const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Message& eventInfo)
+    const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Message eventInfo)
     : eventType(jsg::alloc<TraceItem::HibernatableWebSocketEventInfo::Message>(trace, eventInfo)) {}
 
 TraceItem::HibernatableWebSocketEventInfo::HibernatableWebSocketEventInfo(
-    const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Close& eventInfo)
+    const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Close eventInfo)
     : eventType(jsg::alloc<TraceItem::HibernatableWebSocketEventInfo::Close>(trace, eventInfo)) {}
 
 TraceItem::HibernatableWebSocketEventInfo::HibernatableWebSocketEventInfo(
-    const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Error& eventInfo)
+    const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Error eventInfo)
     : eventType(jsg::alloc<TraceItem::HibernatableWebSocketEventInfo::Error>(trace, eventInfo)) {}
 
 TraceItem::HibernatableWebSocketEventInfo::Type TraceItem::HibernatableWebSocketEventInfo::

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -455,11 +455,11 @@ class TraceItem::HibernatableWebSocketEventInfo final: public jsg::Object {
   class Error;
 
   explicit HibernatableWebSocketEventInfo(
-      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Message& eventInfo);
+      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Message eventInfo);
   explicit HibernatableWebSocketEventInfo(
-      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Close& eventInfo);
+      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Close eventInfo);
   explicit HibernatableWebSocketEventInfo(
-      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Error& eventInfo);
+      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Error eventInfo);
 
   using Type = kj::OneOf<jsg::Ref<Message>, jsg::Ref<Close>, jsg::Ref<Error>>;
 
@@ -478,7 +478,7 @@ class TraceItem::HibernatableWebSocketEventInfo final: public jsg::Object {
 class TraceItem::HibernatableWebSocketEventInfo::Message final: public jsg::Object {
  public:
   explicit Message(
-      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Message& eventInfo)
+      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Message eventInfo)
       : eventInfo(eventInfo) {}
 
   static constexpr kj::StringPtr webSocketEventType = "message"_kj;
@@ -491,13 +491,12 @@ class TraceItem::HibernatableWebSocketEventInfo::Message final: public jsg::Obje
   }
 
  private:
-  const tracing::HibernatableWebSocketEventInfo::Message& eventInfo;
+  const tracing::HibernatableWebSocketEventInfo::Message eventInfo;
 };
 
 class TraceItem::HibernatableWebSocketEventInfo::Close final: public jsg::Object {
  public:
-  explicit Close(
-      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Close& eventInfo)
+  explicit Close(const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Close eventInfo)
       : eventInfo(eventInfo) {}
 
   static constexpr kj::StringPtr webSocketEventType = "close"_kj;
@@ -515,13 +514,12 @@ class TraceItem::HibernatableWebSocketEventInfo::Close final: public jsg::Object
   }
 
  private:
-  const tracing::HibernatableWebSocketEventInfo::Close& eventInfo;
+  const tracing::HibernatableWebSocketEventInfo::Close eventInfo;
 };
 
 class TraceItem::HibernatableWebSocketEventInfo::Error final: public jsg::Object {
  public:
-  explicit Error(
-      const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Error& eventInfo)
+  explicit Error(const Trace& trace, const tracing::HibernatableWebSocketEventInfo::Error eventInfo)
       : eventInfo(eventInfo) {}
 
   static constexpr kj::StringPtr webSocketEventType = "error"_kj;
@@ -534,7 +532,7 @@ class TraceItem::HibernatableWebSocketEventInfo::Error final: public jsg::Object
   }
 
  private:
-  const tracing::HibernatableWebSocketEventInfo::Error& eventInfo;
+  const tracing::HibernatableWebSocketEventInfo::Error eventInfo;
 };
 
 class TraceItem::CustomEventInfo final: public jsg::Object {


### PR DESCRIPTION
These events are so small...
```C++
  struct Message final {};
  struct Close final {
    uint16_t code;
    bool wasClean;
  };
  struct Error final {};
```
That there shouldn't even be any performance penalty to saving them by value rather than by reference.
The nice thing about it is we don't need to save bare references that can easily cause UB or worse (such as a bug we're trying hopelessly to debug atm).