### PR TITLE
Run Python tests under asan with leak san disabled.

### DIFF
--- a/src/cloudflare/internal/test/ai/BUILD.bazel
+++ b/src/cloudflare/internal/test/ai/BUILD.bazel
@@ -15,8 +15,8 @@ py_wd_test(
         "*.js",
         "*.py",
     ]),
-    tags = [
-        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
-        "no-asan",
-    ],
+    # TODO(someday): Fix leak san failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
+    env = {
+        "ASAN_OPTIONS": "detect_leaks=0",
+    },
 )

--- a/src/cloudflare/internal/test/aig/BUILD.bazel
+++ b/src/cloudflare/internal/test/aig/BUILD.bazel
@@ -15,8 +15,8 @@ py_wd_test(
         "*.js",
         "*.py",
     ]),
-    tags = [
-        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
-        "no-asan",
-    ],
+    # TODO(someday): Fix leak san failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
+    env = {
+        "ASAN_OPTIONS": "detect_leaks=0",
+    },
 )

--- a/src/cloudflare/internal/test/d1/BUILD.bazel
+++ b/src/cloudflare/internal/test/d1/BUILD.bazel
@@ -24,8 +24,8 @@ py_wd_test(
         "*.py",
         "*.js",
     ]),
-    tags = [
-        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
-        "no-asan",
-    ],
+    # TODO(someday): Fix leak san failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
+    env = {
+        "ASAN_OPTIONS": "detect_leaks=0",
+    },
 )

--- a/src/cloudflare/internal/test/vectorize/BUILD.bazel
+++ b/src/cloudflare/internal/test/vectorize/BUILD.bazel
@@ -13,8 +13,8 @@ py_wd_test(
         "*.py",
         "*.js",
     ]),
-    tags = [
-        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
-        "no-asan",
-    ],
+    # TODO(someday): Fix leak san failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
+    env = {
+        "ASAN_OPTIONS": "detect_leaks=0",
+    },
 )

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -30,10 +30,10 @@ py_wd_test("subdirectory")
 
 py_wd_test(
     "sdk",
-    tags = [
-        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
-        "no-asan",
-    ],
+    # TODO(someday): Fix leak san failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
+    env = {
+        "ASAN_OPTIONS": "detect_leaks=0",
+    },
 )
 
 gen_import_tests(PYODIDE_IMPORTS_TO_TEST)


### PR DESCRIPTION
These tests are currently failing on shutdown due to a memory leak. This PR re-enables them on ASAN without the leak sanitizer to get some coverage under ASAN for them.