### PR TITLE
Fixes to external package loading: use external lock and load stdlib.

### DIFF
--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -1,5 +1,7 @@
 import { default as MetadataReader } from 'pyodide-internal:runtime-generated/metadata';
 import { default as PYODIDE_BUCKET } from 'pyodide-internal:generated/pyodide-bucket.json';
+// The pyodide-lock.json is read from the Python bundle (pyodide-capnp-bin).
+import { default as PYODIDE_LOCK } from 'pyodide-internal:generated/pyodide-lock.json';
 import { default as ArtifactBundler } from 'pyodide-internal:artifacts';
 
 export const IS_WORKERD = MetadataReader.isWorkerd();
@@ -12,9 +14,7 @@ export const LOAD_WHEELS_FROM_R2: boolean = IS_WORKERD;
 export const LOAD_WHEELS_FROM_ARTIFACT_BUNDLER =
   MetadataReader.shouldUsePackagesInArtifactBundler();
 export const PACKAGES_VERSION = MetadataReader.getPackagesVersion();
-export const LOCKFILE: PackageLock = JSON.parse(
-  MetadataReader.getPackagesLock()
-);
+export const LOCKFILE: PackageLock = PYODIDE_LOCK;
 export const REQUIREMENTS = MetadataReader.getRequirements();
 export const MAIN_MODULE_NAME = MetadataReader.getMainModule();
 export const MEMORY_SNAPSHOT_READER = MetadataReader.hasMemorySnapshot()

--- a/src/pyodide/internal/setupPackages.ts
+++ b/src/pyodide/internal/setupPackages.ts
@@ -23,9 +23,13 @@ function canonicalizePackageName(name: string): string {
 }
 
 // The "name" field in the lockfile is not canonicalized
-const STDLIB_PACKAGES: string[] = Object.values(LOCKFILE.packages)
+export const STDLIB_PACKAGES: string[] = Object.values(LOCKFILE.packages)
   .filter(({ install_dir }) => install_dir === 'stdlib')
   .map(({ name }) => canonicalizePackageName(name));
+
+// Each item in the list is an element of the file path, for example
+// `folder/file.txt` -> `["folder", "file.txt"]
+export type FilePath = string[];
 
 /**
  * SitePackagesDir keeps track of the virtualized view of the site-packages
@@ -33,7 +37,7 @@ const STDLIB_PACKAGES: string[] = Object.values(LOCKFILE.packages)
  */
 class SitePackagesDir {
   public rootInfo: TarFSInfo;
-  public soFiles: string[][];
+  public soFiles: FilePath[];
   public loadedRequirements: Set<string>;
   constructor() {
     this.rootInfo = {
@@ -133,6 +137,7 @@ class SitePackagesDir {
 export function buildSitePackages(requirements: Set<string>): SitePackagesDir {
   if (EmbeddedPackagesTarReader.read === undefined) {
     // Package retrieval is enabled, so the embedded tar reader isn't initialised.
+    // All packages, including STDLIB_PACKAGES, are loaded in `loadPackages`.
     return new SitePackagesDir();
   }
 

--- a/src/pyodide/types/pyodide-lock.d.ts
+++ b/src/pyodide/types/pyodide-lock.d.ts
@@ -16,3 +16,8 @@ interface PackageLock {
     [id: string]: PackageDeclaration;
   };
 }
+
+declare module 'pyodide-internal:generated/pyodide-lock.json' {
+  const lock: PackageLock;
+  export default lock;
+}

--- a/src/pyodide/types/runtime-generated/metadata.d.ts
+++ b/src/pyodide/types/runtime-generated/metadata.d.ts
@@ -17,7 +17,6 @@ declare namespace MetadataReader {
   const disposeMemorySnapshot: () => void;
   const shouldUsePackagesInArtifactBundler: () => boolean;
   const getPackagesVersion: () => string;
-  const getPackagesLock: () => string;
   const read: (index: number, position: number, buffer: Uint8Array) => number;
 }
 

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -27,6 +27,7 @@ class PyodideBundleManager {
  public:
   void setPyodideBundleData(kj::String version, kj::Array<unsigned char> data) const;
   const kj::Maybe<jsg::Bundle::Reader> getPyodideBundle(kj::StringPtr version) const;
+  kj::Maybe<kj::String> getPyodideLock(PythonSnapshotRelease::Reader pythonSnapshotRelease) const;
 
  private:
   struct MessageBundlePair {
@@ -80,7 +81,6 @@ class PyodideMetadataReader: public jsg::Object {
   kj::Array<kj::Array<kj::byte>> contents;
   kj::Array<kj::String> requirements;
   kj::String packagesVersion;
-  kj::String packagesLock;
   bool isWorkerdFlag;
   bool isTracingFlag;
   bool snapshotToDisk;
@@ -94,7 +94,6 @@ class PyodideMetadataReader: public jsg::Object {
       kj::Array<kj::Array<kj::byte>> contents,
       kj::Array<kj::String> requirements,
       kj::String packagesVersion,
-      kj::String packagesLock,
       bool isWorkerd,
       bool isTracing,
       bool snapshotToDisk,
@@ -106,7 +105,6 @@ class PyodideMetadataReader: public jsg::Object {
         contents(kj::mv(contents)),
         requirements(kj::mv(requirements)),
         packagesVersion(kj::mv(packagesVersion)),
-        packagesLock(kj::mv(packagesLock)),
         isWorkerdFlag(isWorkerd),
         isTracingFlag(isTracing),
         snapshotToDisk(snapshotToDisk),
@@ -169,10 +167,6 @@ class PyodideMetadataReader: public jsg::Object {
     return kj::str(packagesVersion);
   }
 
-  kj::String getPackagesLock() {
-    return kj::str(packagesLock);
-  }
-
   JSG_RESOURCE_TYPE(PyodideMetadataReader) {
     JSG_METHOD(isWorkerd);
     JSG_METHOD(isTracing);
@@ -189,7 +183,6 @@ class PyodideMetadataReader: public jsg::Object {
     JSG_METHOD(shouldSnapshotToDisk);
     JSG_METHOD(shouldUsePackagesInArtifactBundler);
     JSG_METHOD(getPackagesVersion);
-    JSG_METHOD(getPackagesLock);
     JSG_METHOD(isCreatingBaselineSnapshot);
   }
 

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -430,7 +430,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   pythonWorkers @43 :Bool
       $compatEnableFlag("python_workers")
       $pythonSnapshotRelease(pyodide = "0.26.0a2", pyodideRevision = "2024-03-01",
-          packages = "2024-03-01", backport = 12,
+          packages = "2024-03-01", backport = 13,
           baselineSnapshotHash = "d13ce2f4a0ade2e09047b469874dacf4d071ed3558fec4c26f8d0b99d95f77b5")
       $impliedByAfterDate(name = "pythonWorkersDevPyodide", date = "2000-01-01");
   # Enables Python Workers. Access to this flag is not restricted, instead bundles containing


### PR DESCRIPTION
Ready for review. Still needs a new bundle generated which I will do after review.

----

Implements changes to use the external package lock (rather than the built-in one) and to fix how we load the stdlib when external package loading is enabled.