### PR TITLE
[ci] Revert release build to windows-2025 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-15, windows-2025]
+        os: [ubuntu-22.04, macos-15, windows-2022]
         target-arch: [ X64 ]
         include:
           - os-name: linux
@@ -74,7 +74,7 @@ jobs:
             bazel-config: release_macos
             target-arch: ARM64
           - os-name: windows
-            os: windows-2025
+            os: windows-2022
             bazel-config: release_windows
     runs-on: ${{ matrix.os }}
     name: build (${{ matrix.os-name }})


### PR DESCRIPTION
We're seeing build failures with the latest MSVC version when optimization is enabled.


Hopefully we can use the 2025 version again once the image is more mature.