### PR TITLE
Use python packages date from compat date.

### DIFF
--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -400,8 +400,9 @@ kj::Array<kj::StringPtr> ArtifactBundler::getSnapshotImports() {
   return result.releaseAsArray();
 }
 
-jsg::Ref<PyodideMetadataReader> makePyodideMetadataReader(
-    Worker::Reader conf, const PythonConfig& pythonConfig) {
+jsg::Ref<PyodideMetadataReader> makePyodideMetadataReader(Worker::Reader conf,
+    const PythonConfig& pythonConfig,
+    PythonSnapshotRelease::Reader pythonRelease) {
   auto modules = conf.getModules();
   auto mainModule = kj::str(modules.begin()->getName());
   int numFiles = 0;
@@ -451,13 +452,14 @@ jsg::Ref<PyodideMetadataReader> makePyodideMetadataReader(
   bool createSnapshot = pythonConfig.createSnapshot;
   bool createBaselineSnapshot = pythonConfig.createBaselineSnapshot;
   bool snapshotToDisk = createSnapshot || createBaselineSnapshot;
+
   // clang-format off
   return jsg::alloc<PyodideMetadataReader>(
     kj::mv(mainModule),
     names.finish(),
     contents.finish(),
     requirements.finish(),
-    kj::str("20240829.4"), // TODO: hardcoded version
+    kj::str(pythonRelease.getPackages()),
     true      /* isWorkerd */,
     false     /* isTracing */,
     snapshotToDisk,

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -420,8 +420,9 @@ class SetupEmscripten: public jsg::Object {
 
 using Worker = server::config::Worker;
 
-jsg::Ref<PyodideMetadataReader> makePyodideMetadataReader(
-    Worker::Reader conf, const PythonConfig& pythonConfig);
+jsg::Ref<PyodideMetadataReader> makePyodideMetadataReader(Worker::Reader conf,
+    const PythonConfig& pythonConfig,
+    PythonSnapshotRelease::Reader pythonRelease);
 
 bool hasPythonModules(capnp::List<server::config::Worker::Module>::Reader modules);
 

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -430,7 +430,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   pythonWorkers @43 :Bool
       $compatEnableFlag("python_workers")
       $pythonSnapshotRelease(pyodide = "0.26.0a2", pyodideRevision = "2024-03-01",
-          packages = "2024-03-01", backport = 13,
+          packages = "20240829.4", backport = 13,
           baselineSnapshotHash = "d13ce2f4a0ade2e09047b469874dacf4d071ed3558fec4c26f8d0b99d95f77b5")
       $impliedByAfterDate(name = "pythonWorkersDevPyodide", date = "2000-01-01");
   # Enables Python Workers. Access to this flag is not restricted, instead bundles containing
@@ -583,7 +583,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   pythonWorkersDevPyodide @58 :Bool
     $compatEnableFlag("python_workers_development")
     $pythonSnapshotRelease(pyodide = "dev", pyodideRevision = "dev",
-          packages = "2024-03-01", backport = 0,
+          packages = "20240829.4", backport = 0,
           baselineSnapshotHash = "92859211804cd350f9e14010afad86e584bdd017dc7acfd94709a87f3220afae")
     $experimental;
   # Enables Python Workers and uses the bundle from the Pyodide source directory directly. For testing only.


### PR DESCRIPTION
Changes necessary to avoid hardcoding the package bundle date.