### PR TITLE
Start instrumenting for streaming tail workers

### DIFF
--- a/samples/tail-workers/tail.js
+++ b/samples/tail-workers/tail.js
@@ -7,7 +7,10 @@ export default {
   tail(traces) {
     console.log(traces[0].logs);
   },
-  tailStream() {
-    return {};
+  tailStream(...args) {
+    console.log(...args);
+    return (...args) => {
+      console.log(...args);
+    };
   },
 };

--- a/samples/tail-workers/worker.js
+++ b/samples/tail-workers/worker.js
@@ -5,6 +5,8 @@
 export default {
   async fetch(req, env) {
     console.log('hello to the tail worker!');
+    reportError('boom');
+    reportError(new Error('test'));
     return new Response("Hello World\n");
   }
 };

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -532,8 +532,13 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEventImpl::run(
   }
 
   KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
-    t.setEventInfo(context.now(), tracing::QueueEventInfo(kj::mv(queueName), batchSize));
+    t.setEventInfo(context.now(), tracing::QueueEventInfo(kj::str(queueName), batchSize));
   }
+
+  context.getMetrics().reportTailEvent(context, [&] {
+    return tracing::Onset(tracing::QueueEventInfo(kj::mv(queueName), batchSize),
+        tracing::Onset::WorkerInfo{}, kj::none);
+  });
 
   // Create a custom refcounted type for holding the queueEvent so that we can pass it to the
   // waitUntil'ed callback safely without worrying about whether this coroutine gets canceled.

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -656,6 +656,10 @@ kj::Promise<void> sendTracesToExportedHandler(kj::Own<IoContext::IncomingRequest
     t.setEventInfo(context.now(), tracing::TraceEventInfo(traces));
   }
 
+  metrics.reportTailEvent(context, [&] {
+    return tracing::Onset(tracing::TraceEventInfo(traces), tracing::Onset::WorkerInfo{}, kj::none);
+  });
+
   auto nonEmptyTraces = kj::Vector<kj::Own<Trace>>(kj::size(traces));
   for (auto& trace: traces) {
     if (trace->eventInfo != kj::none) {

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -1739,6 +1739,10 @@ class EntrypointJsRpcTarget final: public JsRpcTargetBase {
     KJ_IF_SOME(t, tracer) {
       t->setEventInfo(ioctx.now(), tracing::JsRpcEventInfo(kj::str(methodName)));
     }
+    ioctx.getMetrics().reportTailEvent(ioctx, [&] {
+      return tracing::Onset(
+          tracing::JsRpcEventInfo(kj::str(methodName)), tracing::Onset::WorkerInfo{}, kj::none);
+    });
   }
 };
 

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -738,7 +738,7 @@ class TailStreamHandler final: public TailStreamTargetBase {
     // Take the received set of events and dispatch them to the correct handler.
 
     v8::Local<v8::Value> h = handler.getHandle(js);
-    v8::LocalVector<v8::Value> returnValues(js.v8Isolate, events.size());
+    v8::LocalVector<v8::Value> returnValues(js.v8Isolate);
     StringCache stringCache;
 
     if (h->IsFunction()) {
@@ -836,7 +836,8 @@ class TailStreamEntrypoint final: public TailStreamTargetBase {
 
     return ioContext.awaitJs(js,
         js.toPromise(result).then(js,
-            ioContext.addFunctor([&results, &ioContext](jsg::Lock& js, jsg::Value value) {
+            ioContext.addFunctor(
+                [results = kj::mv(results), &ioContext](jsg::Lock& js, jsg::Value value) mutable {
       // The value here can be one of a function, an object, or undefined.
       // Any value other than these will result in a warning but will otherwise
       // be treated like undefined.


### PR DESCRIPTION
This PR starts to add instrumentation for various parts of the streaming tail workers work. Note that the approach this takes right now is generally a straw man that we need to evaluate. We have to support *both* legacy and streaming tail workers and right now the legacy tail workers instrumentation (using `getWorkerTracer()`) is untouched/unchanged with this approach but it means having to dual-instrument the various places in the code where we publish the event. That's... less than ideal. We can coalesce APIs here with a bit more effort. Consider this PR to be the place to discuss the various API options here. Does this work or should we try for a better/cleaner approach?

@rohinlohe ... just for visibility so you can see things are moving