### PR TITLE
fix node:dns quotation marks on resolveTxt

### DIFF
--- a/src/node/internal/internal_dns_client.ts
+++ b/src/node/internal/internal_dns_client.ts
@@ -236,7 +236,7 @@ export function normalizeTxt({ data }: Answer): string[] {
   // Each entry has quotation marks as a prefix and suffix.
   // Node.js APIs doesn't have them.
   if (data.startsWith('"') && data.endsWith('"')) {
-    return [data.slice(1, -1)];
+    return [data.replaceAll('"', '')];
   }
   return [data];
 }


### PR DESCRIPTION
I'm not adding tests because I don't want to spam Yahoo on every PR run, but the following test now pass:

```js
    // https://github.com/cloudflare/workerd/issues/3325
    {
      const result = await dnsPromises.resolveTxt('s1024._domainkey.yahoo.com');
      deepStrictEqual(result, [
        [
          'k=rsa;  p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDrEee0Ri4Juz+QfiWYui/E9UGSXau/2P8LjnTD8V4Unn+2FAZVGE3kL23bzeoULYv4PeleB3gfmJiDJOKU3Ns5L4KJAUUHjFwDebt0NP+sBK0VKeTATL2Yr/S3bT/xhy+1xtj4RkdV7fVxTn56Lb4udUnwuxK4V5b5PdOKj/+XcwIDAQAB; n=A 1024 bit key;',
        ],
      ]);
    }
```

Fixes https://github.com/cloudflare/workerd/issues/3325