### PR TITLE
Removes usage of embedded PYODIDE_LOCK in C++ code.

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -136,7 +136,6 @@ wd_cc_library(
     hdrs = [
         "pyodide/pyodide.h",
         "pyodide/setup-emscripten.h",
-        "//src/pyodide:generated/pyodide_extra.capnp.h",
     ],
     implementation_deps = ["//src/workerd/util:string-buffer"],
     visibility = ["//visibility:public"],

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -13,8 +13,6 @@
 #include <workerd/server/workerd.capnp.h>
 #include <workerd/util/autogate.h>
 
-#include <pyodide/generated/pyodide_extra.capnp.h>
-
 #include <capnp/serialize.h>
 #include <kj/array.h>
 #include <kj/common.h>

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -30,6 +30,7 @@ py_wd_test("subdirectory")
 
 py_wd_test(
     "sdk",
+    # TODO(EW-8976): Disabled in dev due to test getting stuck
     python_flags = ["0.26.0a2"],
     tags = [
         # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -46,6 +46,8 @@
 #include <workerd/util/thread-scopes.h>
 #include <workerd/util/use-perfetto-categories.h>
 
+#include <pyodide/generated/pyodide_extra.capnp.h>
+
 #include <kj/compat/http.h>
 #include <kj/compat/tls.h>
 #include <kj/compat/url.h>
@@ -157,6 +159,7 @@ void writePyodideBundleFileToDisk(const kj::Maybe<kj::Own<const kj::Directory>>&
     replacer->commit();
   }
 }
+}  // namespace
 
 kj::Maybe<jsg::Bundle::Reader> fetchPyodideBundle(
     const api::pyodide::PythonConfig& pyConfig, kj::StringPtr version) {
@@ -213,7 +216,6 @@ kj::Maybe<jsg::Bundle::Reader> fetchPyodideBundle(
   KJ_LOG(INFO, "Loaded Pyodide package from internet");
   return pyConfig.pyodideBundleManager.getPyodideBundle(version);
 }
-}  // namespace
 
 struct WorkerdApi::Impl final {
   kj::Own<CompatibilityFlags::Reader> features;

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -265,4 +265,7 @@ class WorkerdApi final: public Worker::Api {
       capnp::List<config::Extension>::Reader extensions) const;
 };
 
+kj::Maybe<jsg::Bundle::Reader> fetchPyodideBundle(
+    const api::pyodide::PythonConfig& pyConfig, kj::StringPtr version);
+
 }  // namespace workerd::server


### PR DESCRIPTION
Implements download of python bundle when running `workerd pyodide-lock` + some other clean up to remove the use of the embedded PYODIDE_LOCK.

### Test Plan

```
bazel run @workerd//src/workerd/server:workerd -- pyodide-lock
```
 