### PR TITLE
Add Browser Rendering JS wrapped binding

### DIFF
--- a/src/cloudflare/br.ts
+++ b/src/cloudflare/br.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// This binding is managed by the browser rendering team (aka brapi)
+// https://developers.cloudflare.com/browser-rendering/
+
+export { BrowserRendering } from 'cloudflare-internal:br-api';

--- a/src/cloudflare/internal/br-api.ts
+++ b/src/cloudflare/internal/br-api.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+interface Fetcher {
+  fetch: typeof fetch;
+}
+
+export class BrowserRendering {
+  private readonly fetcher: Fetcher;
+
+  public constructor(fetcher: Fetcher) {
+    this.fetcher = fetcher;
+  }
+
+  public async fetch(
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ): Promise<Response> {
+    return this.fetcher.fetch(input, init);
+  }
+}
+
+export default function makeBinding(env: {
+  fetcher: Fetcher;
+}): BrowserRendering {
+  return new BrowserRendering(env.fetcher);
+}

--- a/src/cloudflare/internal/test/br/BUILD.bazel
+++ b/src/cloudflare/internal/test/br/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//:build/wd_test.bzl", "wd_test")
+load("//src/workerd/server/tests/python:py_wd_test.bzl", "py_wd_test")
+
+wd_test(
+    src = "br-api-test.wd-test",
+    args = ["--experimental"],
+    data = glob(["*.js"]),
+)
+
+py_wd_test(
+    size = "large",
+    src = "python-br-api-test.wd-test",
+    args = ["--experimental"],
+    data = glob([
+        "*.js",
+        "*.py",
+    ]),
+    tags = [
+        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
+        "no-asan",
+    ],
+)

--- a/src/cloudflare/internal/test/br/br-api-test.js
+++ b/src/cloudflare/internal/test/br/br-api-test.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import * as assert from 'node:assert';
+
+export const tests = {
+  async test(_, env) {
+    {
+      // Test legacy fetch
+      const resp = await env.browser.fetch('http://workers-binding.brapi/run', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          inputs: { test: true },
+        }),
+      });
+      assert.deepStrictEqual(await resp.json(), { success: true });
+    }
+  },
+};

--- a/src/cloudflare/internal/test/br/br-api-test.py
+++ b/src/cloudflare/internal/test/br/br-api-test.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+
+async def test(context, env):
+    resp = await env.browser.fetch("http://workers-binding.brapi/run")
+    data = await resp.json()
+    assert data.success is True

--- a/src/cloudflare/internal/test/br/br-api-test.wd-test
+++ b/src/cloudflare/internal/test/br/br-api-test.wd-test
@@ -1,0 +1,36 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "brapi-api-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "br-api-test.js")
+        ],
+        compatibilityDate = "2024-12-30",
+        compatibilityFlags = ["nodejs_compat"],
+        bindings = [
+        (
+          name = "browser",
+          wrapped = (
+            moduleName = "cloudflare-internal:br-api",
+            innerBindings = [(
+              name = "fetcher",
+              service = "br-mock"
+            )],
+          )
+        )
+        ],
+      )
+    ),
+    ( name = "br-mock",
+      worker = (
+        compatibilityDate = "2024-12-30",
+        compatibilityFlags = ["experimental", "nodejs_compat"],
+        modules = [
+          (name = "worker", esModule = embed "br-mock.js")
+        ],
+      )
+    )
+  ]
+);

--- a/src/cloudflare/internal/test/br/br-mock.js
+++ b/src/cloudflare/internal/test/br/br-mock.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+export default {
+  async fetch(request, env, ctx) {
+    return Response.json(
+      { success: true },
+      {
+        headers: {
+          'content-type': 'application/json',
+        },
+      }
+    );
+  },
+};

--- a/src/cloudflare/internal/test/br/python-br-api-test.wd-test
+++ b/src/cloudflare/internal/test/br/python-br-api-test.wd-test
@@ -1,0 +1,36 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "br-api-test",
+      worker = (
+        modules = [
+          (name = "worker.py", pythonModule = embed "br-api-test.py")
+        ],
+        compatibilityDate = "2024-06-03",
+        compatibilityFlags = ["nodejs_compat", "python_workers_development"],
+        bindings = [
+        (
+          name = "browser",
+          wrapped = (
+            moduleName = "cloudflare-internal:br-api",
+            innerBindings = [(
+              name = "fetcher",
+              service = "br-mock"
+            )],
+          )
+        )
+        ],
+      )
+    ),
+    ( name = "br-mock",
+      worker = (
+        compatibilityDate = "2024-06-03",
+        compatibilityFlags = ["experimental", "nodejs_compat"],
+        modules = [
+          (name = "worker", esModule = embed "br-mock.js")
+        ],
+      )
+    )
+  ]
+);


### PR DESCRIPTION
Browser rendering team is migrating from a simple Fetcher binding into a JS wrapped binding.
This pull requests adds a very simple wrapped binding that only exposes the already existing `.fetch()` method for existing worker.
Follow up pr's will include adding custom methods to this new binding once it starts being used.