### PR TITLE
Enable python external package loading by default.

### DIFF
--- a/src/pyodide/BUILD.bazel
+++ b/src/pyodide/BUILD.bazel
@@ -20,46 +20,10 @@ capnp_embed(
     deps = ["pyodide_packages_archive"],
 )
 
-copy_file(
-    name = "python_entrypoint_file",
-    src = "python-entrypoint.js",
-    out = "generated/python-entrypoint.js",
-)
-
-capnp_embed(
-    name = "python_entrypoint_file_embed",
-    src = "generated/python-entrypoint.js",
-    deps = ["python_entrypoint_file"],
-)
-
-copy_file(
-    name = "pyodide_extra_capnp_file",
-    src = "pyodide_extra.capnp",
-    out = "generated/pyodide_extra.capnp",
-)
-
-capnp_embed(
-    name = "pyodide_extra_file_embed",
-    src = "generated/pyodide_extra.capnp",
-    deps = ["pyodide_extra_capnp_file"],
-)
-
 capnp_embed(
     name = "pyodide_lock_file_embed",
     src = "generated/pyodide-lock.json",
     deps = ["pyodide-lock.js@rule"],
-)
-
-cc_capnp_library(
-    name = "pyodide_extra_capnp",
-    srcs = ["generated/pyodide_extra.capnp"],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":pyodide_extra_file_embed",
-        ":pyodide_lock_file_embed",
-        ":pyodide_packages_archive_embed",
-        ":python_entrypoint_file_embed",
-    ],
 )
 
 copy_file(

--- a/src/pyodide/pyodide_extra.capnp
+++ b/src/pyodide/pyodide_extra.capnp
@@ -1,5 +1,0 @@
-@0x96c290dbf479ac0c;
-
-const pythonEntrypoint :Text = embed "python-entrypoint.js";
-const pyodidePackagesTar :Data = embed "pyodide_packages.tar";
-const pyodideLock :Text = embed "pyodide-lock.json";

--- a/src/pyodide/python-entrypoint.js
+++ b/src/pyodide/python-entrypoint.js
@@ -1,9 +1,0 @@
-// The entrypoint to a worker has to be an ES6 module (well, ignoring service
-// workers). For Python workers, we use this file as the ES6 entrypoint.
-//
-// This file is treated as part of the user bundle and cannot import internal
-// modules. Any imports from this file must be user-visible. To deal with this,
-// we delegate the implementation to `python-entrypoint-helper` which is a
-// BUILTIN module that can see our INTERNAL modules.
-
-export { default } from 'pyodide:python-entrypoint-helper';

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -85,7 +85,6 @@ wd_cc_library(
     hdrs = [
         "modules.h",
         "rtti.h",
-        "//src/pyodide:generated/pyodide_extra.capnp.h",
         "//src/workerd/server:workerd.capnp.h",
     ],
     visibility = ["//visibility:public"],
@@ -98,7 +97,6 @@ wd_cc_library(
         "//src/cloudflare",
         "//src/node",
         "//src/pyodide",
-        "//src/pyodide:pyodide_extra_capnp",
         "//src/workerd/api/node",
         "//src/workerd/io",
         "//src/workerd/jsg:rtti",
@@ -142,7 +140,6 @@ wd_cc_library(
     implementation_deps = ["//src/workerd/util:string-buffer"],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/pyodide:pyodide_extra_capnp",
         "//src/workerd/io",
         "//src/workerd/jsg",
         "//src/workerd/server:workerd_capnp",

--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -521,4 +521,18 @@ bool hasPythonModules(capnp::List<server::config::Worker::Module>::Reader module
   return false;
 }
 
+kj::StringPtr getPythonEntrypoint() {
+  return R"JS_SCRIPT(
+// The entrypoint to a worker has to be an ES6 module (well, ignoring service
+// workers). For Python workers, we use this file as the ES6 entrypoint.
+//
+// This file is treated as part of the user bundle and cannot import internal
+// modules. Any imports from this file must be user-visible. To deal with this,
+// we delegate the implementation to `python-entrypoint-helper` which is a
+// BUILTIN module that can see our INTERNAL modules.
+
+export { default } from 'pyodide:python-entrypoint-helper';
+  )JS_SCRIPT"_kj;
+}
+
 }  // namespace workerd::api::pyodide

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -424,6 +424,8 @@ jsg::Ref<PyodideMetadataReader> makePyodideMetadataReader(Worker::Reader conf,
 
 bool hasPythonModules(capnp::List<server::config::Worker::Module>::Reader modules);
 
+kj::StringPtr getPythonEntrypoint();
+
 #define EW_PYODIDE_ISOLATE_TYPES                                                                   \
   api::pyodide::ReadOnlyBuffer, api::pyodide::PyodideMetadataReader,                               \
       api::pyodide::ArtifactBundler, api::pyodide::DiskCache,                                      \

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -51,7 +51,6 @@ wd_cc_binary(
         ":v8-platform-impl",
         ":workerd-meta_capnp",
         ":workerd_capnp",
-        "//src/pyodide:pyodide_extra_capnp",
         "//src/rust/cxx-integration",
         "//src/workerd/util:autogate",
         "//src/workerd/util:perfetto",


### PR DESCRIPTION
**Not yet ready to merge**

Removes the pyodide_extra embedded capnp file so nothing from Pyodide is embedded in the binaries anymore.