### PR TITLE
update node:net to enable mongodb and mysql usage

### DIFF
--- a/src/node/net.ts
+++ b/src/node/net.ts
@@ -757,11 +757,13 @@ Socket.prototype.setNoDelay = function (
 
 Socket.prototype.setKeepAlive = function (
   this: SocketClass,
-  enable?: boolean,
+  _enable?: boolean,
   _initialDelay?: number
 ): SocketClass {
-  if (!enable) return this;
-  throw new ERR_INVALID_ARG_VALUE('enable', enable, 'is not supported');
+  // Ignore this for now.
+  // This is used by services like mySQL.
+  // TODO(soon): Investigate supporting this.
+  return this;
 };
 
 // @ts-expect-error TS2322 Intentionally no-op
@@ -948,13 +950,9 @@ function initializeConnection(
   let { port = 0 } = options;
 
   if (autoSelectFamily != null) {
-    // We don't support this option. If the value is falsy, we can safely ignore it.
-    // If the value is truthy, we'll throw an error.
-    throw new ERR_INVALID_ARG_VALUE(
-      'options.autoSelectFamily',
-      autoSelectFamily,
-      'is not supported'
-    );
+    // We don't support this option.
+    // We shouldn't throw this because services like mongodb depends on it.
+    // TODO(soon): Investigate supporting this.
   }
 
   if (typeof port !== 'number' && typeof port !== 'string') {

--- a/src/workerd/api/node/tests/net-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-nodejs-test.js
@@ -443,10 +443,12 @@ export const testNetConnectImmediateFinish = {
 // something different than the original Node.js test
 export const testNetConnectKeepAlive = {
   async test() {
+    // Test that setKeepAlive call does not throw.
     throws(() => new net.Socket({ keepAlive: true }));
     const c = new net.Socket();
     c.setKeepAlive(false);
-    throws(() => c.setKeepAlive(true));
+    c.setKeepAlive(true);
+    // throws(() => c.setKeepAlive(true));
   },
 };
 


### PR DESCRIPTION
> Co-authored-by: @vicb 

This enables the usage of mongodb and mysql in workerd. mysql package is still not supported but this unblocks several errors.


```
[wrangler:inf] GET / 200 OK (436ms)
before mongo
listDocuments
Connected to MongoDB
Documents:
{
  _id: new ObjectId('6787f5abdbedb3f0a155db7d'),
  name: 'Alice',
  age: 30
}
{ _id: new ObjectId('6787f5abdbedb3f0a155db7e'), name: 'Bob', age: 25 }
{
  _id: new ObjectId('6787f5abdbedb3f0a155db7f'),
  name: 'Charlie',
  age: 35
}
finally
after mongo
[wrangler:inf] GET /favicon.ico 200 OK (87ms)
```