### PR TITLE
CACHE-11937: add compat flag to support cache rules overrides

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -679,4 +679,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatDisableFlag("cache_no_cache_disabled")
       $experimental;
   # Enables the use of cache: no-cache in the fetch api.
+
+  requestCfOverridesCacheRules @71 :Bool
+      $compatEnableFlag("request_cf_overrides_cache_rules")
+      $experimental;
+  # Enables cache settings specified request in fetch api cf object to override cache rules. (only for user owned or grey-clouded sites)
 }


### PR DESCRIPTION
Adding a new flag to support overriding cache rules via request.cf object. Currently, if a resource is fetched via the fetch API and have cache settings such as cacheEverything: true specified in the 'cf' object, while there is also cache rules defined against that resource, the cache settings in request cf object isn't respected. Cache team is working on fixing this behavior to give precedence over to request cf object first and then to cache rules, however, we are hiding this behavior behind a compatibility flag until we're confident the change works as intended for everyone.