### PR TITLE
01-15-25 Roll deps

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -156,13 +156,10 @@ build --cxxopt="-fbracket-depth=512" --host_cxxopt="-fbracket-depth=512"
 build --@capnp-cpp//src/capnp:gen_rust=True
 
 # Additional Rust flags (see https://doc.rust-lang.org/rustc/codegen-options/index.html)
-# Need to disable debug-assertions for fastbuild, should be off automatically for opt. As long as
-# rust-level LTO is not enabled, LLVM bitcode is not needed so -C embed-bitcode=n provides a free
-# improvement to build speed and Rust code size.
+# Need to disable debug-assertions for fastbuild, should be off automatically for opt.
 # Using extra_rustc_flag for non-exec flags so they can be overwritten selectively.
-build --@rules_rust//:extra_rustc_flag=-Cembed-bitcode=n
 build --@rules_rust//:extra_rustc_flag=-Cdebug-assertions=n
-build --@rules_rust//:extra_exec_rustc_flags=-C,debug-assertions=n,-C,embed-bitcode=n
+build --@rules_rust//:extra_exec_rustc_flags=-Cdebug-assertions=n
 
 # We default to not enabling debug assertions and unwinding for Rust. For debug builds this is not
 # the right setting, but unfortunately we can't set that directly.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -191,7 +191,7 @@ rust_register_toolchains(
         # Add support for macOS rosetta
         "aarch64-unknown-linux-gnu",
     ],
-    versions = ["1.82.0"],  # LLVM 19
+    versions = ["1.83.0"],  # LLVM 19
 )
 
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")

--- a/build/deps/build_deps.jsonc
+++ b/build/deps/build_deps.jsonc
@@ -116,11 +116,7 @@
       "type": "github_release",
       "owner": "aspect-build",
       "repo": "rules_js",
-      "file_regex": "^rules_js-",
-      // TODO(cleanup): On latest version, Windows build fails with `tar.exe: Error opening archive:
-      // Can't initialize filter; unable to run program "gzip -d"`, likely due to
-      // https://github.com/aspect-build/rules_js/pull/1905/files. Develop a workaround.
-      "freeze_version": "v2.0.1"
+      "file_regex": "^rules_js-"
     },
     {
       "name": "aspect_rules_ts",

--- a/build/deps/gen/dep_aspect_bazel_lib.bzl
+++ b/build/deps/gen/dep_aspect_bazel_lib.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "v2.9.4"
-URL = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.4/bazel-lib-v2.9.4.tar.gz"
-STRIP_PREFIX = "bazel-lib-2.9.4"
-SHA256 = "349aabd3c2b96caeda6181eb0ae1f14f2a1d9f3cd3c8b05d57f709ceb12e9fb3"
+TAG_NAME = "v2.11.0"
+URL = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.11.0/bazel-lib-v2.11.0.tar.gz"
+STRIP_PREFIX = "bazel-lib-2.11.0"
+SHA256 = "c96db69dd2714a37f3298338a1a42b27e3a2696c3b36dd4441b9bf7a1a12bee0"
 TYPE = "tgz"
 
 def dep_aspect_bazel_lib():

--- a/build/deps/gen/dep_aspect_rules_js.bzl
+++ b/build/deps/gen/dep_aspect_rules_js.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "v2.0.1"
-URL = "https://github.com/aspect-build/rules_js/releases/download/v2.0.1/rules_js-v2.0.1.tar.gz"
-STRIP_PREFIX = "rules_js-2.0.1"
-SHA256 = "4cab6898f0ff8048e32640cce06a47aa4b92b2fb330d055940f95f24c8ebb868"
+TAG_NAME = "v2.1.2"
+URL = "https://github.com/aspect-build/rules_js/releases/download/v2.1.2/rules_js-v2.1.2.tar.gz"
+STRIP_PREFIX = "rules_js-2.1.2"
+SHA256 = "fbc34d815a0cc52183a1a26732fc0329e26774a51abbe0f26fc9fd2dab6133b4"
 TYPE = "tgz"
 
 def dep_aspect_rules_js():

--- a/build/deps/gen/dep_aspect_rules_ts.bzl
+++ b/build/deps/gen/dep_aspect_rules_ts.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "v3.3.2"
-URL = "https://github.com/aspect-build/rules_ts/releases/download/v3.3.2/rules_ts-v3.3.2.tar.gz"
-STRIP_PREFIX = "rules_ts-3.3.2"
-SHA256 = "cff3137b043ff6bf1a2542fd9691dc762432370cd39eb4bb0756d288de52067d"
+TAG_NAME = "v3.4.0"
+URL = "https://github.com/aspect-build/rules_ts/releases/download/v3.4.0/rules_ts-v3.4.0.tar.gz"
+STRIP_PREFIX = "rules_ts-3.4.0"
+SHA256 = "013a10b2b457add73b081780e604778eb50a141709f9194298f97761acdcc169"
 TYPE = "tgz"
 
 def dep_aspect_rules_ts():

--- a/build/deps/gen/dep_buildifier_darwin_amd64.bzl
+++ b/build/deps/gen/dep_buildifier_darwin_amd64.bzl
@@ -2,9 +2,9 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "v7.3.1"
-URL = "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-darwin-amd64"
-SHA256 = "375f823103d01620aaec20a0c29c6cbca99f4fd0725ae30b93655c6704f44d71"
+TAG_NAME = "v8.0.1"
+URL = "https://github.com/bazelbuild/buildtools/releases/download/v8.0.1/buildifier-darwin-amd64"
+SHA256 = "802b013211dbcf91e3c0658ba33ecb3932ef5a6f6764a0b13efcec4e2df04c83"
 
 def dep_buildifier_darwin_amd64():
     http_file(

--- a/build/deps/gen/dep_buildifier_darwin_arm64.bzl
+++ b/build/deps/gen/dep_buildifier_darwin_arm64.bzl
@@ -2,9 +2,9 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "v7.3.1"
-URL = "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-darwin-arm64"
-SHA256 = "5a6afc6ac7a09f5455ba0b89bd99d5ae23b4174dc5dc9d6c0ed5ce8caac3f813"
+TAG_NAME = "v8.0.1"
+URL = "https://github.com/bazelbuild/buildtools/releases/download/v8.0.1/buildifier-darwin-arm64"
+SHA256 = "833e2afc331b9ad8f6b038ad3d69ceeaf97651900bf2a3a45f54f42cafe0bfd3"
 
 def dep_buildifier_darwin_arm64():
     http_file(

--- a/build/deps/gen/dep_buildifier_linux_amd64.bzl
+++ b/build/deps/gen/dep_buildifier_linux_amd64.bzl
@@ -2,9 +2,9 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "v7.3.1"
-URL = "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-amd64"
-SHA256 = "5474cc5128a74e806783d54081f581662c4be8ae65022f557e9281ed5dc88009"
+TAG_NAME = "v8.0.1"
+URL = "https://github.com/bazelbuild/buildtools/releases/download/v8.0.1/buildifier-linux-amd64"
+SHA256 = "1976053ed4decd6dd93170885b4387eddc76ec70dc2697b2e91a9af83269418a"
 
 def dep_buildifier_linux_amd64():
     http_file(

--- a/build/deps/gen/dep_buildifier_linux_arm64.bzl
+++ b/build/deps/gen/dep_buildifier_linux_arm64.bzl
@@ -2,9 +2,9 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "v7.3.1"
-URL = "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-arm64"
-SHA256 = "0bf86c4bfffaf4f08eed77bde5b2082e4ae5039a11e2e8b03984c173c34a561c"
+TAG_NAME = "v8.0.1"
+URL = "https://github.com/bazelbuild/buildtools/releases/download/v8.0.1/buildifier-linux-arm64"
+SHA256 = "93078c57763493bdc2914ed340544500b8f3497341a62e90f00e9e184c4d9c2c"
 
 def dep_buildifier_linux_arm64():
     http_file(

--- a/build/deps/gen/dep_buildifier_windows_amd64.bzl
+++ b/build/deps/gen/dep_buildifier_windows_amd64.bzl
@@ -2,9 +2,9 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "v7.3.1"
-URL = "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-windows-amd64.exe"
-SHA256 = "370cd576075ad29930a82f5de132f1a1de4084c784a82514bd4da80c85acf4a8"
+TAG_NAME = "v8.0.1"
+URL = "https://github.com/bazelbuild/buildtools/releases/download/v8.0.1/buildifier-windows-amd64.exe"
+SHA256 = "6edc9247e6d42d27fb67b9509bb795d159a12468faa89e9f290dcadc26571c31"
 
 def dep_buildifier_windows_amd64():
     http_file(

--- a/build/deps/gen/dep_capnp_cpp.bzl
+++ b/build/deps/gen/dep_capnp_cpp.bzl
@@ -2,11 +2,11 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-URL = "https://github.com/capnproto/capnproto/tarball/1c676b2df7f97220607591a38c28ce7e4a968ad4"
-STRIP_PREFIX = "capnproto-capnproto-1c676b2/c++"
-SHA256 = "9281b860a778c9427c55be647d1247d9f8373ab9023e671505881bf2172eba04"
+URL = "https://github.com/capnproto/capnproto/tarball/f600d249496c55289fa07fd6a21cadeeb340edb9"
+STRIP_PREFIX = "capnproto-capnproto-f600d24/c++"
+SHA256 = "1d96cd31ad93eaf8194ba51d4a009a4f08332ad643740c4b49c081a515a27a60"
 TYPE = "tgz"
-COMMIT = "1c676b2df7f97220607591a38c28ce7e4a968ad4"
+COMMIT = "f600d249496c55289fa07fd6a21cadeeb340edb9"
 
 def dep_capnp_cpp():
     http_archive(

--- a/build/deps/gen/dep_cargo_bazel_linux_arm64.bzl
+++ b/build/deps/gen/dep_cargo_bazel_linux_arm64.bzl
@@ -2,9 +2,9 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "0.54.1"
-URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.54.1/cargo-bazel-aarch64-unknown-linux-gnu"
-SHA256 = "3792feb084bd43b9a7a9cd75be86ee9910b46db59360d6b29c9cca2f8889a0aa"
+TAG_NAME = "0.56.0"
+URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.56.0/cargo-bazel-aarch64-unknown-linux-gnu"
+SHA256 = "f3a35b137221d4627ba0ed62f775c4d3cbb45b6db839ae47f2ebfd48abe44a91"
 
 def dep_cargo_bazel_linux_arm64():
     http_file(

--- a/build/deps/gen/dep_cargo_bazel_linux_x64.bzl
+++ b/build/deps/gen/dep_cargo_bazel_linux_x64.bzl
@@ -2,9 +2,9 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "0.54.1"
-URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.54.1/cargo-bazel-x86_64-unknown-linux-gnu"
-SHA256 = "2b9d07f34694f63f0cc704989ad6ec148ff8d126579832f4f4d88edea75875b2"
+TAG_NAME = "0.56.0"
+URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.56.0/cargo-bazel-x86_64-unknown-linux-gnu"
+SHA256 = "53418ae5457040e84009f7c69b070e1f12f10a9a3a3ef4f5d0829c66e5438ba1"
 
 def dep_cargo_bazel_linux_x64():
     http_file(

--- a/build/deps/gen/dep_cargo_bazel_macos_arm64.bzl
+++ b/build/deps/gen/dep_cargo_bazel_macos_arm64.bzl
@@ -2,9 +2,9 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "0.54.1"
-URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.54.1/cargo-bazel-aarch64-apple-darwin"
-SHA256 = "8204746334a17823bd6a54ce2c3821b0bdca96576700d568e2ca2bd8224dc0ea"
+TAG_NAME = "0.56.0"
+URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.56.0/cargo-bazel-aarch64-apple-darwin"
+SHA256 = "5143e347ec45e0fcc249f1de44f0dce227062579ad364a0b269b39f0ce49f1d8"
 
 def dep_cargo_bazel_macos_arm64():
     http_file(

--- a/build/deps/gen/dep_cargo_bazel_macos_x64.bzl
+++ b/build/deps/gen/dep_cargo_bazel_macos_x64.bzl
@@ -2,9 +2,9 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "0.54.1"
-URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.54.1/cargo-bazel-x86_64-apple-darwin"
-SHA256 = "2ee14b230d32c05415852b7a388b76e700c87c506459e5b31ced19d6c131b6d0"
+TAG_NAME = "0.56.0"
+URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.56.0/cargo-bazel-x86_64-apple-darwin"
+SHA256 = "9e8a92674771982f68031d0cc516ba08b34dd736c4f818d51349547f2136d012"
 
 def dep_cargo_bazel_macos_x64():
     http_file(

--- a/build/deps/gen/dep_cargo_bazel_win_x64.bzl
+++ b/build/deps/gen/dep_cargo_bazel_win_x64.bzl
@@ -2,9 +2,9 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "0.54.1"
-URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.54.1/cargo-bazel-x86_64-pc-windows-msvc.exe"
-SHA256 = "609e894dc52576407afd5edf3b293eab2774e4fffc25ae212ab138556ff7306d"
+TAG_NAME = "0.56.0"
+URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.56.0/cargo-bazel-x86_64-pc-windows-msvc.exe"
+SHA256 = "5c62a1c42b71af6c2765dc5f9518eba22ed28276a65f7accf5a2bca0c5cfaf74"
 
 def dep_cargo_bazel_win_x64():
     http_file(

--- a/build/deps/gen/dep_cxxbridge_cmd.bzl
+++ b/build/deps/gen/dep_cxxbridge_cmd.bzl
@@ -2,11 +2,11 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-URL = "https://crates.io/api/v1/crates/cxxbridge-cmd/1.0.131/download"
-STRIP_PREFIX = "cxxbridge-cmd-1.0.131"
-SHA256 = "5b12e3f7b0477bd2e469107b778d333171cae561a555e96157e67bbd9f42e54f"
+URL = "https://crates.io/api/v1/crates/cxxbridge-cmd/1.0.136/download"
+STRIP_PREFIX = "cxxbridge-cmd-1.0.136"
+SHA256 = "6c33fd49f5d956a1b7ee5f7a9768d58580c6752838d92e39d0d56439efdedc35"
 TYPE = "tgz"
-VERSION = "1.0.131"
+VERSION = "1.0.136"
 
 def dep_cxxbridge_cmd():
     http_archive(

--- a/build/deps/gen/dep_rules_rust.bzl
+++ b/build/deps/gen/dep_rules_rust.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "0.54.1"
-URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.54.1/rules_rust-v0.54.1.tar.gz"
+TAG_NAME = "0.56.0"
+URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.56.0/rules_rust-0.56.0.tar.gz"
 STRIP_PREFIX = ""
-SHA256 = "af4f56caae50a99a68bfce39b141b509dd68548c8204b98ab7a1cafc94d5bb02"
+SHA256 = "f1306aac0b258b790df01ad9abc6abb0df0b65416c74b4ef27f4aab298780a64"
 TYPE = "tgz"
 
 def dep_rules_rust():

--- a/build/deps/gen/dep_simdutf.bzl
+++ b/build/deps/gen/dep_simdutf.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "v5.6.3"
-URL = "https://github.com/simdutf/simdutf/releases/download/v5.6.3/singleheader.zip"
+TAG_NAME = "v6.0.3"
+URL = "https://github.com/simdutf/simdutf/releases/download/v6.0.3/singleheader.zip"
 STRIP_PREFIX = ""
-SHA256 = "33e2968e0f14a72c970c4838e08e502438f37c0a856a9238d69d9161727ba4c2"
+SHA256 = "0e5ba4bc981633bb024ee066833f733b7d3422bc6250f6a6b5bbc09121b782af"
 TYPE = "zip"
 
 def dep_simdutf():

--- a/deps/rust/BUILD.cxxbridge-cmd
+++ b/deps/rust/BUILD.cxxbridge-cmd
@@ -5,7 +5,7 @@ load("@rules_rust//rust:defs.bzl", "rust_binary")
 rust_binary(
     name = "cxxbridge-cmd",
     srcs = glob(["src/**/*.rs"]),
-    data = ["src/gen/include/cxx.h"],
+    compile_data = ["src/gen/include/cxx.h"],
     edition = "2021",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
- With latest rules_rust, -Cembed-bitcode=n is set automatically if LTO is
  disabled, no need to add it manually
- Rust crate data is no longer passed at compile time, so use compile_data
  in cxxbridge-cmd build file