### PR TITLE
Fixes Python SDK tests when external package loading is enabled.

### DIFF
--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -30,8 +30,6 @@ py_wd_test("subdirectory")
 
 py_wd_test(
     "sdk",
-    # TODO(EW-8976): Disabled in dev due to test getting stuck
-    python_flags = ["0.26.0a2"],
     tags = [
         # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
         "no-asan",

--- a/src/workerd/server/tests/python/sdk/proxy.js
+++ b/src/workerd/server/tests/python/sdk/proxy.js
@@ -1,0 +1,12 @@
+export default {
+  async fetch(req, env) {
+    const url = new URL(req.url);
+    if (url.hostname == 'pyodide-packages.runtime-playground.workers.dev') {
+      return env.INTERNET.fetch(req);
+    } else if (url.hostname == 'example.com') {
+      return env.PYTHON.fetch(req);
+    }
+
+    throw new Error('Invalid url: ' + url);
+  },
+};

--- a/src/workerd/server/tests/python/sdk/sdk.wd-test
+++ b/src/workerd/server/tests/python/sdk/sdk.wd-test
@@ -19,13 +19,34 @@ const server :Workerd.Worker = (
   compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
 );
 
+# We need this proxy so that internal requests made to fetch packages for Python Workers are sent
+# out to the open internet and not to the python-server worker.
+const jsChooserProxy :Workerd.Worker = (
+  modules = [
+    (name = "proxy.js", esModule = embed "proxy.js")
+  ],
+  bindings = [
+    ( name = "PYTHON", service = "python-server" ),
+    ( name = "INTERNET", service = "external" ),
+  ],
+  compatibilityDate = "2024-10-01",
+);
+
 const unitTests :Workerd.Config = (
   services = [
+    ( name = "external",
+      network = (
+        tlsOptions = (trustBrowserCas = true)
+      )
+    ),
+    ( name = "internet",
+      worker = .jsChooserProxy
+    ),
+    ( name = "python-server",
+      worker = .server
+    ),
     ( name = "python-sdk",
       worker = .python
     ),
-    ( name = "internet",
-      worker = .server
-    )
   ],
 );


### PR DESCRIPTION
Some explanation of the failure here: The `internet` outbound in workerd is the one that `fetch` targets, so since we fetch packages in workerd and this test points `fetch` at a custom _Python_ server, it goes into an infinite loop due to the Python server attempting to load packages from ... itself.

Solution here is to create a JS proxy that either sends the requests onto the Python server or to the internet.