### PR TITLE
[build] Do not have //src/workerd/io depend on src/cloudflare, src/node

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -95,6 +95,8 @@ wd_cc_library(
         ":memory-cache",
         ":pyodide",
         ":r2",
+        "//src/cloudflare",
+        "//src/node",
         "//src/pyodide",
         "//src/pyodide:pyodide_extra_capnp",
         "//src/workerd/api/node",

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
-load("@bazel_skylib//lib:selects.bzl", "selects")
 load("//:build/kj_test.bzl", "kj_test")
 load("//:build/wd_cc_library.bzl", "wd_cc_library")
 load("//:build/wd_test.bzl", "wd_test")
@@ -29,6 +28,7 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":node-core",
+        "//src/node",
         "@capnp-cpp//src/kj/compat:kj-brotli",
     ],
 )

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -106,8 +106,6 @@ wd_cc_library(
         ":supported-compatibility-date_capnp",
         ":trace",
         ":worker-interface",
-        "//src/cloudflare",
-        "//src/node",
         "//src/workerd/api:analytics-engine_capnp",
         "//src/workerd/api:data-url",
         "//src/workerd/api:deferred-proxy",

--- a/src/workerd/jsg/url.c++
+++ b/src/workerd/jsg/url.c++
@@ -2301,6 +2301,6 @@ UrlPattern::UrlPattern(kj::Array<Component> components, bool ignoreCase)
 
 }  // namespace workerd::jsg
 
-const workerd::jsg::Url operator"" _url(const char* str, size_t size) {
+const workerd::jsg::Url operator""_url(const char* str, size_t size) {
   return KJ_ASSERT_NONNULL(workerd::jsg::Url::tryParse(kj::ArrayPtr<const char>(str, size)));
 }

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -114,6 +114,8 @@ wd_cc_library(
         ":alarm-scheduler",
         ":workerd_capnp",
         "//deps/rust:runtime",
+        "//src/cloudflare",
+        "//src/node",
         "//src/workerd/api:html-rewriter",
         "//src/workerd/api:hyperdrive",
         "//src/workerd/api:memory-cache",

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -51,7 +51,7 @@ kj::Own<config::Config::Reader> parseConfig(kj::StringPtr text, kj::SourceLocati
 // This is intended to allow multi-line raw text to be specified conveniently using C++11
 // `R"(blah)"` literal syntax, without the need to mess up indentation relative to the
 // surrounding code.
-kj::String operator"" _blockquote(const char* str, size_t n) {
+kj::String operator""_blockquote(const char* str, size_t n) {
   kj::StringPtr text(str, n);
 
   // Ignore a leading newline so that `R"(` can be placed on the line before the initial indent.

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -18,6 +18,8 @@ cc_ast_dump(
         "//conditions:default": [],
     }),
     deps = [
+        "//src/cloudflare",
+        "//src/node",
         "//src/workerd/api:html-rewriter",
         "//src/workerd/api:hyperdrive",
         "//src/workerd/api:memory-cache",


### PR DESCRIPTION
This was making io depend on the `gen-compile-cache` binary, which created a bottleneck and delayed building source files in io and its dependents.

Drive-by: Fix LLVM 20 operator warnings

I have confirmed that downstream CI passes with this change.