### PR TITLE
[o11y] Adjust user span naming

### DIFF
--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -40,7 +40,7 @@ class LocalActorOutgoingFactory final: public Fetcher::OutgoingFactory {
     },
         {.inHouse = true,
           .wrapMetrics = true,
-          .operationName = kj::ConstString("actor_subrequest"_kjc)}));
+          .operationName = kj::ConstString("durable_object_subrequest"_kjc)}));
   }
 
  private:
@@ -82,7 +82,7 @@ class GlobalActorOutgoingFactory final: public Fetcher::OutgoingFactory {
     },
         {.inHouse = true,
           .wrapMetrics = true,
-          .operationName = kj::ConstString("actor_subrequest"_kjc)}));
+          .operationName = kj::ConstString("durable_object_subrequest"_kjc)}));
   }
 
  private:
@@ -110,7 +110,7 @@ kj::Own<WorkerInterface> ReplicaActorOutgoingFactory::newSingleUseClient(
   },
       {.inHouse = true,
         .wrapMetrics = true,
-        .operationName = kj::ConstString("actor_subrequest"_kjc)}));
+        .operationName = kj::ConstString("durable_object_subrequest"_kjc)}));
 }
 
 jsg::Ref<Fetcher> ColoLocalActorNamespace::get(kj::String actorId) {

--- a/src/workerd/api/hyperdrive.c++
+++ b/src/workerd/api/hyperdrive.c++
@@ -86,7 +86,7 @@ kj::String Hyperdrive::getConnectionString() {
 kj::Promise<kj::Own<kj::AsyncIoStream>> Hyperdrive::connectToDb() {
   auto& context = IoContext::current();
   auto service =
-      context.getSubrequestChannel(this->clientIndex, true, kj::none, "hyperdrive_dev"_kjc);
+      context.getSubrequestChannel(this->clientIndex, true, kj::none, "hyperdrive_connect"_kjc);
 
   kj::HttpHeaderTable headerTable;
   kj::HttpHeaders headers(headerTable);

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -205,7 +205,7 @@ jsg::Ref<WebSocket> WebSocket::constructor(jsg::Lock& js,
       urlRecord.fragment == kj::none, DOMSyntaxError, wsErr, "The url fragment must be empty.");
 
   kj::HttpHeaders headers(context.getHeaderTable());
-  auto client = context.getHttpClient(0, false, kj::none, "WebSocket::constructor"_kjc);
+  auto client = context.getHttpClient(0, false, kj::none, "websocket_open"_kjc);
 
   // Set protocols header if necessary.
   KJ_IF_SOME(variant, protocols) {


### PR DESCRIPTION
This is more descriptive:
Websocket::constructor => websocket_open
actor_subrequest => durable_object_subrequest
hyperdrive_dev => hyperdrive_connect to match downstream name

Downstream PR to follow.