### PR TITLE
WPT: Run tests with unsafeEval so they can use IOContext

### DIFF
--- a/src/workerd/api/wpt/url-test.ts
+++ b/src/workerd/api/wpt/url-test.ts
@@ -50,11 +50,12 @@ export default {
     ],
   },
   'url-setters-a-area.window.js': {
-    comment: 'Implement promise_test',
+    comment: 'Implement globalThis.document',
     skipAllTests: true,
   },
   'urlencoded-parser.any.js': {
-    comment: 'Implement unsafeRequire',
+    comment:
+      'Requests fail due to HTTP method "LADIDA", responses fail due to shift_jis encoding',
     expectedFailures: [
       'request.formData() with input: test',
       'response.formData() with input: test',


### PR DESCRIPTION
WPT tests are now declared as text bindings and executed with unsafeEval. This way they can do IOContext things. 
This PR also fixes promise_test to store each promise created and await them all before evaluating the test results.