### PR TITLE
Initial implementation of DO-attached containers API

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -825,10 +825,13 @@ kj::OneOf<jsg::Ref<DurableObjectId>, kj::StringPtr> ActorState::getId() {
   KJ_UNREACHABLE;
 }
 
-DurableObjectState::DurableObjectState(
-    Worker::Actor::Id actorId, kj::Maybe<jsg::Ref<DurableObjectStorage>> storage)
+DurableObjectState::DurableObjectState(Worker::Actor::Id actorId,
+    kj::Maybe<jsg::Ref<DurableObjectStorage>> storage,
+    kj::Maybe<rpc::Container::Client> container)
     : id(kj::mv(actorId)),
-      storage(kj::mv(storage)) {}
+      storage(kj::mv(storage)),
+      container(container.map(
+          [&](rpc::Container::Client& cap) { return jsg::alloc<Container>(kj::mv(cap)); })) {}
 
 void DurableObjectState::waitUntil(kj::Promise<void> promise) {
   IoContext::current().addWaitUntil(kj::mv(promise));

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -8,6 +8,7 @@
 // See actor.h for APIs used by other Workers to talk to Actors.
 
 #include <workerd/api/actor.h>
+#include <workerd/api/container.h>
 #include <workerd/io/actor-cache.h>
 #include <workerd/io/actor-id.h>
 #include <workerd/io/compatibility-date.capnp.h>
@@ -462,7 +463,9 @@ class WebSocketRequestResponsePair: public jsg::Object {
 // The type passed as the first parameter to durable object class's constructor.
 class DurableObjectState: public jsg::Object {
  public:
-  DurableObjectState(Worker::Actor::Id actorId, kj::Maybe<jsg::Ref<DurableObjectStorage>> storage);
+  DurableObjectState(Worker::Actor::Id actorId,
+      kj::Maybe<jsg::Ref<DurableObjectStorage>> storage,
+      kj::Maybe<rpc::Container::Client> container);
 
   void waitUntil(kj::Promise<void> promise);
 
@@ -470,6 +473,10 @@ class DurableObjectState: public jsg::Object {
 
   jsg::Optional<jsg::Ref<DurableObjectStorage>> getStorage() {
     return storage.map([&](jsg::Ref<DurableObjectStorage>& p) { return p.addRef(); });
+  }
+
+  jsg::Optional<jsg::Ref<Container>> getContainer() {
+    return container.map([](jsg::Ref<Container>& c) { return c.addRef(); });
   }
 
   jsg::Promise<jsg::JsRef<jsg::JsValue>> blockConcurrencyWhile(
@@ -536,6 +543,7 @@ class DurableObjectState: public jsg::Object {
     JSG_METHOD(waitUntil);
     JSG_READONLY_INSTANCE_PROPERTY(id, getId);
     JSG_READONLY_INSTANCE_PROPERTY(storage, getStorage);
+    JSG_READONLY_INSTANCE_PROPERTY(container, getContainer);
     JSG_METHOD(blockConcurrencyWhile);
     JSG_METHOD(acceptWebSocket);
     JSG_METHOD(getWebSockets);
@@ -574,6 +582,7 @@ class DurableObjectState: public jsg::Object {
  private:
   Worker::Actor::Id id;
   kj::Maybe<jsg::Ref<DurableObjectStorage>> storage;
+  kj::Maybe<jsg::Ref<Container>> container;
 
   // Limits for Hibernatable WebSocket tags.
 

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -541,9 +541,9 @@ class DurableObjectState: public jsg::Object {
 
   JSG_RESOURCE_TYPE(DurableObjectState, CompatibilityFlags::Reader flags) {
     JSG_METHOD(waitUntil);
-    JSG_READONLY_INSTANCE_PROPERTY(id, getId);
-    JSG_READONLY_INSTANCE_PROPERTY(storage, getStorage);
-    JSG_READONLY_INSTANCE_PROPERTY(container, getContainer);
+    JSG_LAZY_INSTANCE_PROPERTY(id, getId);
+    JSG_LAZY_INSTANCE_PROPERTY(storage, getStorage);
+    JSG_LAZY_INSTANCE_PROPERTY(container, getContainer);
     JSG_METHOD(blockConcurrencyWhile);
     JSG_METHOD(acceptWebSocket);
     JSG_METHOD(getWebSockets);

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "container.h"
+
+#include <workerd/io/io-context.h>
+
+namespace workerd::api {
+
+Container::Container(rpc::Container::Client rpcClient)
+    : rpcClient(IoContext::current().addObject(kj::heap(kj::mv(rpcClient)))) {}
+
+}  // namespace workerd::api

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -4,11 +4,239 @@
 
 #include "container.h"
 
+#include <workerd/api/http.h>
 #include <workerd/io/io-context.h>
 
 namespace workerd::api {
 
+// =======================================================================================
+// Basic lifecycle methods
+
 Container::Container(rpc::Container::Client rpcClient)
     : rpcClient(IoContext::current().addObject(kj::heap(kj::mv(rpcClient)))) {}
+
+void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions) {
+  JSG_REQUIRE(!running, Error, "start() cannot be called on a container that is already running.");
+
+  StartupOptions options = kj::mv(maybeOptions).orDefault({});
+
+  auto req = rpcClient->startRequest();
+  KJ_IF_SOME(entrypoint, options.entrypoint) {
+    auto list = req.initEntrypoint(entrypoint.size());
+    for (auto i: kj::indices(entrypoint)) {
+      list.set(i, entrypoint[i]);
+    }
+  }
+  req.setEnableInternet(options.enableInternet);
+
+  IoContext::current().addTask(req.send().ignoreResult());
+
+  running = true;
+}
+
+jsg::Promise<void> Container::monitor(jsg::Lock& js) {
+  JSG_REQUIRE(running, Error, "monitor() cannot be called on a container that is not running.");
+
+  return IoContext::current()
+      .awaitIo(js, rpcClient->monitorRequest(capnp::MessageSize{4, 0}).send().ignoreResult())
+      .then(js, [this](jsg::Lock& js) {
+    running = false;
+    KJ_IF_SOME(d, destroyReason) {
+      jsg::Value error = kj::mv(d);
+      destroyReason = kj::none;
+      js.throwException(kj::mv(error));
+    }
+  }, [this](jsg::Lock& js, jsg::Value&& error) {
+    running = false;
+    destroyReason = kj::none;
+    js.throwException(kj::mv(error));
+  });
+}
+
+jsg::Promise<void> Container::destroy(jsg::Lock& js, jsg::Optional<jsg::Value> error) {
+  if (!running) return js.resolvedPromise();
+
+  if (destroyReason == kj::none) {
+    destroyReason = kj::mv(error);
+  }
+
+  return IoContext::current().awaitIo(
+      js, rpcClient->destroyRequest(capnp::MessageSize{4, 0}).send().ignoreResult());
+}
+
+void Container::signal(jsg::Lock& js, int signo) {
+  JSG_REQUIRE(signo > 0 && signo <= 64, RangeError, "Invalid signal number.");
+  JSG_REQUIRE(running, Error, "signal() cannot be called on a container that is not running.");
+
+  auto req = rpcClient->signalRequest(capnp::MessageSize{4, 0});
+  req.setSigno(signo);
+  IoContext::current().addTask(req.send().ignoreResult());
+}
+
+// =======================================================================================
+// getTcpPort()
+
+// `getTcpPort()` returns a `Fetcher`, on which `fetch()` and `connect()` can be called. `Fetcher`
+// is a JavaScript wrapper around `WorkerInterface`, so we need to implement that.
+class Container::TcpPortWorkerInterface final: public WorkerInterface {
+ public:
+  TcpPortWorkerInterface(capnp::ByteStreamFactory& byteStreamFactory,
+      const kj::HttpHeaderTable& headerTable,
+      rpc::Container::Port::Client port)
+      : byteStreamFactory(byteStreamFactory),
+        headerTable(headerTable),
+        port(kj::mv(port)) {}
+
+  // Implements fetch(), i.e., HTTP requests. We form a TCP connection, then run HTTP over it
+  // (as opposed to, say, speaking http-over-capnp to the container service).
+  kj::Promise<void> request(kj::HttpMethod method,
+      kj::StringPtr url,
+      const kj::HttpHeaders& headers,
+      kj::AsyncInputStream& requestBody,
+      kj::HttpService::Response& response) override {
+    // URLs should have been validated earlier in the stack, so parsing the URL should succeed.
+    auto parsedUrl = KJ_REQUIRE_NONNULL(kj::Url::tryParse(url, kj::Url::Context::HTTP_PROXY_REQUEST,
+                                            {.percentDecode = false, .allowEmpty = true}),
+        "invalid url?", url);
+
+    // We don't support TLS.
+    JSG_REQUIRE(parsedUrl.scheme != "https", Error,
+        "Connencting to a container using HTTPS is not currently supported; use HTTP instead. "
+        "TLS is unnecessary anyway, as the connection is already secure by default.");
+
+    // Schemes other than http: and https: should have been rejected earlier, but let's verify.
+    KJ_REQUIRE(parsedUrl.scheme == "http");
+
+    // We need to convert the URL from proxy format (full URL in request line) to host format
+    // (path in request line, hostname in Host header).
+    auto newHeaders = headers.cloneShallow();
+    newHeaders.set(kj::HttpHeaderId::HOST, parsedUrl.host);
+    auto noHostUrl = parsedUrl.toString(kj::Url::Context::HTTP_REQUEST);
+
+    // Make a TCP connection...
+    auto pipe = kj::newTwoWayPipe();
+    auto connectionPromise =
+        connectImpl(*pipe.ends[1]).then([]() -> kj::Promise<void> { return kj::NEVER_DONE; });
+
+    // ... and then stack an HttpClient on it ...
+    auto client = kj::newHttpClient(headerTable, *pipe.ends[0]);
+
+    // ... and then adapt that to an HttpService ...
+    auto service = kj::newHttpService(*client);
+
+    // ... and now we can just forward our call to that.
+    co_await connectionPromise.exclusiveJoin(
+        service->request(method, noHostUrl, newHeaders, requestBody, response));
+  }
+
+  // Implements connect(), i.e., forms a raw socket.
+  kj::Promise<void> connect(kj::StringPtr host,
+      const kj::HttpHeaders& headers,
+      kj::AsyncIoStream& connection,
+      ConnectResponse& response,
+      kj::HttpConnectSettings settings) override {
+    JSG_REQUIRE(!settings.useTls, Error,
+        "Connencting to a container using TLS is not currently supported. It is unnecessary "
+        "anyway, as the connection is already secure by default.");
+
+    auto promise = connectImpl(connection);
+
+    kj::HttpHeaders responseHeaders(headerTable);
+    response.accept(200, "OK", responseHeaders);
+
+    return promise;
+  }
+
+  // The only `CustomEvent` that can happen through `Fetcher` is a JSRPC call. Maybe we will
+  // support this someday? But not today.
+  kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override {
+    return event->notSupported();
+  }
+
+  // There's no way to invoke the remaining event types via `Fetcher`.
+  kj::Promise<void> prewarm(kj::StringPtr url) override {
+    KJ_UNREACHABLE;
+  }
+  kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override {
+    KJ_UNREACHABLE;
+  }
+  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime, uint32_t retryCount) override {
+    KJ_UNREACHABLE;
+  }
+
+ private:
+  capnp::ByteStreamFactory& byteStreamFactory;
+  const kj::HttpHeaderTable& headerTable;
+  rpc::Container::Port::Client port;
+
+  // Connect to the port and pump bytes to/from `connection`. Used by both request() and
+  // connect().
+  kj::Promise<void> connectImpl(kj::AsyncIoStream& connection) {
+    // A lot of the following is copied from
+    // capnp::HttpOverCapnpFactory::KjToCapnpHttpServiceAdapter::connect().
+    auto req = port.connectRequest(capnp::MessageSize{4, 1});
+    auto downPipe = kj::newOneWayPipe();
+    req.setDown(byteStreamFactory.kjToCapnp(kj::mv(downPipe.out)));
+    auto pipeline = req.send();
+
+    // Make sure the request message isn't pinned into memory through the co_await below.
+    { auto drop = kj::mv(req); }
+
+    auto downPumpTask =
+        downPipe.in->pumpTo(connection)
+            .then([&connection, down = kj::mv(downPipe.in)](uint64_t) -> kj::Promise<void> {
+      connection.shutdownWrite();
+      return kj::NEVER_DONE;
+    });
+    auto up = pipeline.getUp();
+
+    auto upStream = byteStreamFactory.capnpToKjExplicitEnd(up);
+    auto upPumpTask = connection.pumpTo(*upStream)
+                          .then([&upStream = *upStream](uint64_t) mutable {
+      return upStream.end();
+    }).then([up = kj::mv(up), upStream = kj::mv(upStream)]() mutable -> kj::Promise<void> {
+      return kj::NEVER_DONE;
+    });
+
+    co_await pipeline.ignoreResult();
+  }
+};
+
+// `Fetcher` actually wants us to give it a factory that creates a new `WorkerInterface` for each
+// request, so this is that.
+class Container::TcpPortOutgoingFactory final: public Fetcher::OutgoingFactory {
+ public:
+  TcpPortOutgoingFactory(capnp::ByteStreamFactory& byteStreamFactory,
+      const kj::HttpHeaderTable& headerTable,
+      rpc::Container::Port::Client port)
+      : byteStreamFactory(byteStreamFactory),
+        headerTable(headerTable),
+        port(kj::mv(port)) {}
+
+  kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) override {
+    // At present we have no use for `cfStr`.
+    return kj::heap<TcpPortWorkerInterface>(byteStreamFactory, headerTable, port);
+  }
+
+ private:
+  capnp::ByteStreamFactory& byteStreamFactory;
+  const kj::HttpHeaderTable& headerTable;
+  rpc::Container::Port::Client port;
+};
+
+jsg::Ref<Fetcher> Container::getTcpPort(jsg::Lock& js, int port) {
+  JSG_REQUIRE(port > 0 && port < 65536, TypeError, "Invalid port number: ", port);
+
+  auto req = rpcClient->getTcpPortRequest(capnp::MessageSize{4, 0});
+  req.setPort(port);
+
+  auto& ioctx = IoContext::current();
+
+  kj::Own<Fetcher::OutgoingFactory> factory = kj::heap<TcpPortOutgoingFactory>(
+      ioctx.getByteStreamFactory(), ioctx.getHeaderTable(), req.send().getPort());
+
+  return jsg::alloc<Fetcher>(
+      ioctx.addObject(kj::mv(factory)), Fetcher::RequiresHostAndProtocol::YES, true);
+}
 
 }  // namespace workerd::api

--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+// APIs that an Actor (Durable Object) uses to access its own state.
+//
+// See actor.h for APIs used by other Workers to talk to Actors.
+
+#include <workerd/io/container.capnp.h>
+#include <workerd/io/io-own.h>
+#include <workerd/jsg/jsg.h>
+
+namespace workerd::api {
+
+class Fetcher;
+
+// Implements the `ctx.container` API for durable-object-attached containers. This API allows
+// the DO to supervise the attached container (lightweight virtual machine), including starting,
+// stopping, monitoring, making requests to the container, intercepting outgoing network requests,
+// etc.
+class Container: public jsg::Object {
+ public:
+  Container(rpc::Container::Client rpcClient);
+
+  JSG_RESOURCE_TYPE(Container) {
+    // TODO(now): Implement the API.
+  }
+
+ private:
+  IoOwn<rpc::Container::Client> rpcClient;
+};
+
+#define EW_CONTAINER_ISOLATE_TYPES api::Container
+
+}  // namespace workerd::api

--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -82,7 +82,8 @@
   F("node", EW_NODE_ISOLATE_TYPES)                                                                 \
   F("rtti", EW_RTTI_ISOLATE_TYPES)                                                                 \
   F("webgpu", EW_WEBGPU_ISOLATE_TYPES)                                                             \
-  F("eventsource", EW_EVENTSOURCE_ISOLATE_TYPES)
+  F("eventsource", EW_EVENTSOURCE_ISOLATE_TYPES)                                                   \
+  F("container", EW_CONTAINER_ISOLATE_TYPES)
 
 namespace workerd::api {
 

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -98,6 +98,7 @@ wd_cc_library(
         ":actor-id",
         ":actor-storage_capnp",
         ":cdp_capnp",
+        ":container_capnp",
         ":frankenvalue",
         ":io-gate",
         ":io-helpers",

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -303,6 +303,13 @@ wd_capnp_library(src = "features.capnp")
 
 wd_capnp_library(src = "frankenvalue.capnp")
 
+wd_capnp_library(
+    src = "container.capnp",
+    deps = [
+        "@capnp-cpp//src/capnp/compat:byte-stream_capnp",
+    ],
+)
+
 kj_test(
     src = "io-gate-test.c++",
     deps = [

--- a/src/workerd/io/container.capnp
+++ b/src/workerd/io/container.capnp
@@ -1,0 +1,89 @@
+@0xcb7be0e1be835084;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("workerd::rpc");
+$Cxx.allowCancellation;
+
+using import "/capnp/compat/byte-stream.capnp".ByteStream;
+
+interface Container @0x9aaceefc06523bca {
+  # RPC interface to talk to a container, for containers attached to Durable Objects.
+  #
+  # When the actor shuts down, workerd will drop the `Container` capability, at which point
+  # the container engine should implicitly destroy the container.
+
+  status @0 () -> (running :Bool);
+  # Returns the container's current status. The runtime will always call this at DO startup.
+
+  start @1 StartParams -> ();
+  # Start the container. It's an error to call this if the container is already running.
+
+  struct StartParams {
+    entrypoint @0 :List(Text);
+    # Specifies the command to run as the root process of the container. If null, the container
+    # image's default command is used.
+
+    enableInternet @1 :Bool = false;
+    # Set true to enable the container to talk directly to the public internet. Otherwise, the
+    # public internet will not be accessible -- but it's still possible to intercept connection
+    # attempts and handle them in the DO, using the "listen" methods below.
+  }
+
+  monitor @2 ();
+  # Waits for the container to shut down.
+  #
+  # If the container shuts down because the root process exited with a success status, or because
+  # the client invoked `destroy()`, then `monitor()` completes without an error. If it shuts down
+  # for any other reason, `monitor()` throws an exception describing what happened. (This exception
+  # may or may not be a JSG exception depending on whether it is an application error or a system
+  # error.)
+
+  destroy @3 ();
+  # Immediately and abruptly stops the container and tears it down. The application is not given
+  # any warning, it simply stops immediately. Upon successful return from destroy(), the container
+  # is no longer running. If a call to `monitor()` is waiting when `destroy()` is invoked,
+  # `monitor()` will also return (with no error). If the container is not running when `destroy()`
+  # is invoked, `destroy()` silently returns with no error.
+
+  signal @4 (signo :UInt32);
+  # Sends the given Linux signal number to the root process.
+
+  getTcpPort @5 (port :UInt16) -> (port :Port);
+  # Obtains an object which can be used to connect to the application inside the container on the
+  # given TCP port (the application must be listening on this port).
+
+  interface Port {
+    # Represents a port to which connections can be made.
+
+    connect @0 (down :ByteStream) -> (up :ByteStream);
+    # Forms a raw socket connection to the port.
+    #
+    # Note that when the Durable Object application uses the HTTP-oriented APIs, workerd will
+    # take care of speaking the HTTP protocol on top of the raw socket. So, the container engine
+    # need only implement raw connections.
+  }
+
+  listenTcp @6 (filter :IpFilter, handler :TcpHandler) -> (handle :Capability);
+  # Arranges to intercept outgoing TCP connections from the container and redirect them to the
+  # given `handler`.
+
+  struct IpFilter {
+    # Specifies a range of IP addresses and/or port numbers which should be intercepted when the
+    # application in the container tries to connect to them.
+
+    addr @0 :Text;
+    # null = all addresses
+    # TODO(someday): Support CIDR? (e.g. "192.168.0.0/16")
+
+    port @1 :UInt16 = 0;
+    # 0 = all ports
+  }
+
+  interface TcpHandler {
+    # Interface which intercepts outgoing connections from a container.
+
+    connect @0 (addr :Text, port :UInt16, down :ByteStream) -> (up :ByteStream);
+    # Like Port.connect() but also receives the address and port number to which the container was
+    # attempting to connect.
+  }
+}

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -8,6 +8,7 @@
 #include <workerd/io/actor-cache.h>  // because we can't forward-declare ActorCache::SharedLru.
 #include <workerd/io/actor-id.h>
 #include <workerd/io/compatibility-date.capnp.h>
+#include <workerd/io/container.capnp.h>
 #include <workerd/io/frankenvalue.h>
 #include <workerd/io/io-channels.h>
 #include <workerd/io/limit-enforcer.h>
@@ -762,7 +763,8 @@ class Worker::Actor final: public kj::Refcounted {
       TimerChannel& timerChannel,
       kj::Own<ActorObserver> metrics,
       kj::Maybe<kj::Own<HibernationManager>> manager,
-      kj::Maybe<uint16_t> hibernationEventType);
+      kj::Maybe<uint16_t> hibernationEventType,
+      kj::Maybe<rpc::Container::Client> container = kj::none);
 
   ~Actor() noexcept(false);
 

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -10,6 +10,7 @@
 #include <workerd/api/actor.h>
 #include <workerd/api/analytics-engine.h>
 #include <workerd/api/cache.h>
+#include <workerd/api/container.h>
 #include <workerd/api/crypto/impl.h>
 #include <workerd/api/encoding.h>
 #include <workerd/api/events.h>
@@ -85,6 +86,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
     EW_BASICS_ISOLATE_TYPES,
     EW_BLOB_ISOLATE_TYPES,
     EW_CACHE_ISOLATE_TYPES,
+    EW_CONTAINER_ISOLATE_TYPES,
     EW_CRYPTO_ISOLATE_TYPES,
     EW_ENCODING_ISOLATE_TYPES,
     EW_EVENTS_ISOLATE_TYPES,

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -538,6 +538,7 @@ interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3400,6 +3401,18 @@ declare class EventSource extends EventTarget {
 interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -543,6 +543,7 @@ export interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3412,6 +3413,18 @@ export declare class EventSource extends EventTarget {
 export interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+export interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+export interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -538,6 +538,7 @@ interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3426,6 +3427,18 @@ declare class EventSource extends EventTarget {
 interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -543,6 +543,7 @@ export interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3438,6 +3439,18 @@ export declare class EventSource extends EventTarget {
 export interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+export interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+export interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -556,6 +556,7 @@ interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3451,6 +3452,18 @@ declare class EventSource extends EventTarget {
 interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -561,6 +561,7 @@ export interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3463,6 +3464,18 @@ export declare class EventSource extends EventTarget {
 export interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+export interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+export interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -556,6 +556,7 @@ interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3452,6 +3453,18 @@ declare class EventSource extends EventTarget {
 interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -561,6 +561,7 @@ export interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3464,6 +3465,18 @@ export declare class EventSource extends EventTarget {
 export interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+export interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+export interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -556,6 +556,7 @@ interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3455,6 +3456,18 @@ declare class EventSource extends EventTarget {
 interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -561,6 +561,7 @@ export interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3467,6 +3468,18 @@ export declare class EventSource extends EventTarget {
 export interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+export interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+export interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -561,6 +561,7 @@ interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3460,6 +3461,18 @@ declare class EventSource extends EventTarget {
 interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -566,6 +566,7 @@ export interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3472,6 +3473,18 @@ export declare class EventSource extends EventTarget {
 export interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+export interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+export interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -561,6 +561,7 @@ interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3462,6 +3463,18 @@ declare class EventSource extends EventTarget {
 interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -566,6 +566,7 @@ export interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3474,6 +3475,18 @@ export declare class EventSource extends EventTarget {
 export interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+export interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+export interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -561,6 +561,7 @@ interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3462,6 +3463,18 @@ declare class EventSource extends EventTarget {
 interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -566,6 +566,7 @@ export interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3474,6 +3475,18 @@ export declare class EventSource extends EventTarget {
 export interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+export interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+export interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -566,6 +566,7 @@ interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3541,6 +3542,18 @@ declare class EventSource extends EventTarget {
 interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -571,6 +571,7 @@ export interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3553,6 +3554,18 @@ export declare class EventSource extends EventTarget {
 export interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+export interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+export interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -538,6 +538,7 @@ interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3400,6 +3401,18 @@ declare class EventSource extends EventTarget {
 interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -543,6 +543,7 @@ export interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
+  container?: Container;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -3412,6 +3413,18 @@ export declare class EventSource extends EventTarget {
 export interface EventSourceEventSourceInit {
   withCredentials?: boolean;
   fetcher?: Fetcher;
+}
+export interface Container {
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
+}
+export interface ContainerStartupOptions {
+  entrypoint?: string[];
+  enableInternet: boolean;
 }
 export type AiImageClassificationInput = {
   image: number[];


### PR DESCRIPTION
Implemented here:
- Basic lifecycle (start/monitor/destroy/signal)
- Connecting to a TCP port in the container, either as a raw socket or HTTP.

Not implemented yet:
- Intercepting outgoing connections from container (`listenTcp()`).
- Starting the DO with an already-running container.
- Hibernating while container is running.
- vsocks
- stdio interception
- Any sort of local testing with workerd (only the production runtime is fully wired up for now).