### PR TITLE
Add crc32 algorithm to DigestStream

### DIFF
--- a/src/workerd/api/crypto/crc-impl.c++
+++ b/src/workerd/api/crypto/crc-impl.c++
@@ -1,0 +1,85 @@
+// Copyright (c) 2017-2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "crc-impl.h"
+
+#include <array>
+#include <type_traits>
+
+namespace {
+constexpr auto crcTableSize = 256;
+
+template <typename T>
+concept Uint64OrUint32 = std::unsigned_integral<T> && (sizeof(T) == 8 || sizeof(T) == 4);
+
+template <Uint64OrUint32 T>
+constexpr T reverse(T value) {
+  if constexpr (sizeof(T) == 4) {
+    value = ((value & 0xaaaaaaaa) >> 1) | ((value & 0x55555555) << 1);
+    value = ((value & 0xcccccccc) >> 2) | ((value & 0x33333333) << 2);
+    value = ((value & 0xf0f0f0f0) >> 4) | ((value & 0x0f0f0f0f) << 4);
+    value = ((value & 0xff00ff00) >> 8) | ((value & 0x00ff00ff) << 8);
+    value = (value >> 16) | (value << 16);
+    return value;
+  } else {
+    value = ((value & 0xaaaaaaaaaaaaaaaa) >> 1) | ((value & 0x5555555555555555) << 1);
+    value = ((value & 0xcccccccccccccccc) >> 2) | ((value & 0x3333333333333333) << 2);
+    value = ((value & 0xf0f0f0f0f0f0f0f0) >> 4) | ((value & 0x0f0f0f0f0f0f0f0f) << 4);
+    value = ((value & 0xff00ff00ff00ff00) >> 8) | ((value & 0x00ff00ff00ff00ff) << 8);
+    value = ((value & 0xffff0000ffff0000) >> 16) | ((value & 0x0000ffff0000ffff) << 16);
+    value = (value >> 32) | (value << 32);
+    return value;
+  }
+}
+
+template <Uint64OrUint32 T>
+constexpr std::array<T, crcTableSize> gen_crc_table(T polynomial, bool reflectIn, bool reflectOut) {
+  constexpr auto numIterations = sizeof(polynomial) * 8;  // number of bits in polynomial
+  auto crcTable = std::array<T, crcTableSize>{};
+
+  for (T byte = 0u; byte < crcTableSize; ++byte) {
+    T crc = (reflectIn ? (reverse(T(byte)) >> (numIterations - 8)) : byte);
+
+    for (int i = 0; i < numIterations; ++i) {
+      if (crc & (static_cast<T>(1) << (numIterations - 1))) {
+        crc = (crc << 1) ^ polynomial;
+      } else {
+        crc <<= 1;
+      }
+    }
+
+    crcTable[byte] = (reflectOut ? reverse(crc) : crc);
+  }
+
+  return crcTable;
+}
+
+// https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-32-iscsi
+constexpr auto crc32c_table = gen_crc_table(static_cast<uint32_t>(0x1edc6f41), true, true);
+// https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-64-nvme
+constexpr auto crc64nvme_table =
+    gen_crc_table(static_cast<uint64_t>(0xad93d23594c93659), true, true);
+}  // namespace
+
+uint32_t crc32c(uint32_t crc, const uint8_t *data, unsigned int length) {
+  if (data == nullptr) {
+    return 0;
+  }
+  crc ^= 0xffffffff;
+  while (length--) {
+    crc = crc32c_table[(crc ^ *data++) & 0xffL] ^ (crc >> 8);
+  }
+  return crc ^ 0xffffffff;
+}
+
+uint64_t crc64nvme(uint64_t crc, const uint8_t *data, unsigned int length) {
+  if (data == nullptr) {
+    return 0;
+  }
+  crc ^= 0xffffffffffffffff;
+  while (length--) {
+    crc = crc64nvme_table[(crc ^ *data++) & 0xffL] ^ (crc >> 8);
+  }
+  return crc ^ 0xffffffffffffffff;
+}

--- a/src/workerd/api/crypto/crc-impl.h
+++ b/src/workerd/api/crypto/crc-impl.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2017-2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+#include <stdint.h>
+
+// crc32-c implementation according to the spec:
+// https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-32-iscsi
+uint32_t crc32c(uint32_t crc, const uint8_t *data, unsigned int length);
+
+// crc64-nvme implementation according to the spec:
+// https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-64-nvme
+uint64_t crc64nvme(uint64_t crc, const uint8_t *data, unsigned int length);

--- a/src/workerd/api/crypto/crypto.h
+++ b/src/workerd/api/crypto/crypto.h
@@ -666,9 +666,16 @@ class SubtleCrypto: public jsg::Object {
 // DigestStream is a non-standard extension that provides a way of generating
 // a hash digest from streaming data. It combines Web Crypto concepts into a
 // WritableStream and is compatible with both APIs.
+class DigestContext {
+ public:
+  virtual ~DigestContext() noexcept = default;
+  virtual void write(kj::ArrayPtr<kj::byte> buffer) = 0;
+  virtual kj::Array<kj::byte> close() = 0;
+};
+
 class DigestStream: public WritableStream {
  public:
-  using DigestContextPtr = kj::Own<EVP_MD_CTX>;
+  using DigestContextPtr = kj::Own<DigestContext>;
   using Algorithm = kj::OneOf<kj::String, SubtleCrypto::HashAlgorithm>;
 
   explicit DigestStream(kj::Own<WritableStreamController> controller,

--- a/src/workerd/api/crypto/endianness.c++
+++ b/src/workerd/api/crypto/endianness.c++
@@ -1,0 +1,186 @@
+// Copyright (c) 2017-2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "endianness.h"
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+#define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+
+#include <endian.h>
+
+#elif defined(__APPLE__)
+
+#include <libkern/OSByteOrder.h>
+
+uint16_t htobe16(uint16_t x) {
+  return OSSwapHostToBigInt16(x);
+}
+uint16_t htole16(uint16_t x) {
+  return OSSwapHostToLittleInt16(x);
+}
+uint16_t be16toh(uint16_t x) {
+  return OSSwapBigToHostInt16(x);
+}
+uint16_t le16toh(uint16_t x) {
+  return OSSwapLittleToHostInt16(x);
+}
+
+uint32_t htobe32(uint32_t x) {
+  return OSSwapHostToBigInt32(x);
+}
+uint32_t htole32(uint32_t x) {
+  return OSSwapHostToLittleInt32(x);
+}
+uint32_t be32toh(uint32_t x) {
+  return OSSwapBigToHostInt32(x);
+}
+uint32_t le32toh(uint32_t x) {
+  return OSSwapLittleToHostInt32(x);
+}
+
+uint64_t htobe64(uint64_t x) {
+  return OSSwapHostToBigInt64(x);
+}
+uint64_t htole64(uint64_t x) {
+  return OSSwapHostToLittleInt64(x);
+}
+uint64_t be64toh(uint64_t x) {
+  return OSSwapBigToHostInt64(x);
+}
+uint64_t le64toh(uint64_t x) {
+  return OSSwapLittleToHostInt64(x);
+}
+
+#elif defined(__OpenBSD__)
+
+#include <sys/endian.h>
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
+#include <sys/endian.h>
+
+uint16_t be16toh(uint16_t x) {
+  return betoh16(x);
+}
+uint16_t le16toh(uint16_t x) {
+  return letoh16(x);
+}
+
+uint32_t be32toh(uint32_t x) {
+  return betoh32(x);
+}
+uint32_t le32toh(uint32_t x) {
+  return letoh32(x);
+}
+
+uint64_t be64toh(uint64_t x) {
+  return betoh64(x);
+}
+uint64_t le64toh(uint64_t x) {
+  return letoh64(x);
+}
+
+#elif defined(__WINDOWS__)
+
+#include <winsock2.h>
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+
+uint16_t htobe16(uint16_t x) {
+  return htons(x);
+}
+uint16_t htole16(uint16_t x) {
+  return x;
+}
+uint16_t be16toh(uint16_t x) {
+  return ntohs(x);
+}
+uint16_t le16toh(uint16_t x) {
+  return x;
+}
+
+uint32_t htobe32(uint32_t x) {
+  return htonl(x);
+}
+uint32_t htole32(uint32_t x) {
+  return x;
+}
+uint32_t be32toh(uint32_t x) {
+  return ntohl(x);
+}
+uint32_t le32toh(uint32_t x) {
+  return x;
+}
+
+uint64_t htobe64(uint64_t x) {
+  return htonll(x);
+}
+uint64_t htole64(uint64_t x) {
+  return x;
+}
+uint64_t be64toh(uint64_t x) {
+  return ntohll(x);
+}
+uint64_t le64toh(uint64_t x) {
+  return x;
+}
+
+#elif BYTE_ORDER == BIG_ENDIAN
+
+/* that would be xbox 360 */
+uint16_t htobe16(uint16_t x) {
+  return x;
+}
+uint16_t htole16(uint16_t x) {
+  return __builtin_bswap16(x);
+}
+uint16_t be16toh(uint16_t x) {
+  return x;
+}
+uint16_t le16toh(uint16_t x) {
+  return __builtin_bswap16(x);
+}
+
+uint32_t htobe32(uint32_t x) {
+  return x;
+}
+uint32_t htole32(uint32_t x) {
+  return __builtin_bswap32(x);
+}
+uint32_t be32toh(uint32_t x) {
+  return x;
+}
+uint32_t le32toh(uint32_t x) {
+  return __builtin_bswap32(x);
+}
+
+uint64_t htobe64(uint64_t x) {
+  return x;
+}
+uint64_t htole64(uint64_t x) {
+  return __builtin_bswap64(x);
+}
+uint64_t be64toh(uint64_t x) {
+  return x;
+}
+uint64_t le64toh(uint64_t x) {
+  return __builtin_bswap64(x);
+}
+
+#else
+
+#error byte order not supported
+
+#endif
+
+#else
+
+#error platform not supported
+
+#endif

--- a/src/workerd/api/crypto/endianness.h
+++ b/src/workerd/api/crypto/endianness.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2017-2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+#include <stdint.h>
+
+// This file provides cross platform support for endianness conversions.
+// It is intended to hide away the poluting includes of system headers to provide the functions
+// without poluting the global namespace.
+
+uint16_t htobe16(uint16_t x);
+uint16_t htole16(uint16_t x);
+uint16_t be16toh(uint16_t x);
+uint16_t le16toh(uint16_t x);
+
+uint32_t htobe32(uint32_t x);
+uint32_t htole32(uint32_t x);
+uint32_t be32toh(uint32_t x);
+uint32_t le32toh(uint32_t x);
+
+uint64_t htobe64(uint64_t x);
+uint64_t htole64(uint64_t x);
+uint64_t be64toh(uint64_t x);
+uint64_t le64toh(uint64_t x);


### PR DESCRIPTION
Since openssl does not support crc32 as a digest algorithm I extended our support through a new self implemented class and took the initial implementation out to it's own class.

Solves internal ticket #8999