### PR TITLE
fix(node:timers) calling refresh breaks the timers

### DIFF
--- a/src/node/internal/internal_timers.ts
+++ b/src/node/internal/internal_timers.ts
@@ -53,13 +53,11 @@ export class Timeout {
   }
 
   #constructTimer(): number {
-    if (this.#isRepeat) {
-      // @ts-expect-error TS2322 Due to difference between Node.js and globals
-      return globalThis.setInterval(this.#callback, this.#after, ...this.#args);
-    } else {
-      // @ts-expect-error TS2322 Due to difference between Node.js and globals
-      return globalThis.setTimeout(this.#callback, this.#after, ...this.#args);
-    }
+    // @ts-expect-error TS2322 Due to difference between Node.js and globals
+    this.#timer = this.#isRepeat
+      ? globalThis.setInterval(this.#callback, this.#after, ...this.#args)
+      : globalThis.setTimeout(this.#callback, this.#after, ...this.#args);
+    return this.#timer;
   }
 
   #clearTimeout(): void {

--- a/src/workerd/api/node/tests/timers-nodejs-test.js
+++ b/src/workerd/api/node/tests/timers-nodejs-test.js
@@ -136,3 +136,22 @@ export const testSetInterval = {
     }
   },
 };
+
+export const testRefresh = {
+  async test() {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    timers.clearTimeout(
+      timers
+        .setTimeout(() => {
+          reject();
+        }, 1)
+        .refresh()
+    );
+
+    timers.setTimeout(() => {
+      resolve();
+    }, 2);
+
+    await promise;
+  },
+};


### PR DESCRIPTION
Calling `TImeout#refresh` does not update `#timer` making it impossible to cancel
/refresh the timer.