### PR TITLE
Update python 0.27.1 bundle

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -684,6 +684,6 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatEnableFlag("python_workers_20250116")
       $experimental
       $pythonSnapshotRelease(pyodide = "0.27.1", pyodideRevision = "2025-01-16",
-          packages = "2024-12-18", backport = 0,
+          packages = "2024-12-18", backport = 1,
           baselineSnapshotHash = "TODO");
 }


### PR DESCRIPTION
The new version includes #3349 which fixes the baseline snapshot production.