### PR TITLE
py_ew_test: Add skip_flags argument

### DIFF
--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -20,8 +20,7 @@ py_wd_test("env-param")
 
 py_wd_test(
     "asgi",
-    # TODO: update bundle to include asgi fix and test on 0.26.0a2
-    python_flags = ["development"],
+    skip_python_flags = ["0.27.1"],
 )
 
 py_wd_test("random")
@@ -39,22 +38,18 @@ py_wd_test(
 gen_import_tests(
     PYODIDE_IMPORTS_TO_TEST,
     # TODO: Micropip version mismatch for 0.27.0
-    pkg_python_versions = {
+    pkg_skip_versions = {
         "micropip": [
-            "0.26.0a2",
-            "development",
+            "0.27.1",
         ],
         "langchain-core": [
-            "0.26.0a2",
-            "development",
+            "0.27.1",
         ],
         "langchain_openai": [
-            "0.26.0a2",
-            "development",
+            "0.27.1",
         ],
         "langsmith": [
-            "0.26.0a2",
-            "development",
+            "0.27.1",
         ],
     },
 )

--- a/src/workerd/server/tests/python/import_tests.bzl
+++ b/src/workerd/server/tests/python/import_tests.bzl
@@ -32,7 +32,7 @@ def generate_wd_test_file(requirement):
     return WD_FILE_TEMPLATE.format(requirement, requirement)
 
 # to_test is a dictionary from library name to list of imports
-def gen_import_tests(to_test, pkg_python_versions = {}):
+def gen_import_tests(to_test, pkg_skip_versions = {}):
     for lib in to_test.keys():
         prefix = "import/" + lib
         worker_py_fname = prefix + "/worker.py"
@@ -52,7 +52,7 @@ def gen_import_tests(to_test, pkg_python_versions = {}):
             name = prefix,
             directory = lib,
             src = wd_test_fname,
-            python_flags = pkg_python_versions.get(lib, "all"),
+            skip_python_flags = pkg_skip_versions.get(lib, []),
             args = ["--experimental", "--pyodide-package-disk-cache-dir", "../all_pyodide_wheels"],
             data = [worker_py_fname, "@all_pyodide_wheels//:whls"],
             size = "enormous",

--- a/src/workerd/server/tests/python/py_wd_test.bzl
+++ b/src/workerd/server/tests/python/py_wd_test.bzl
@@ -13,12 +13,14 @@ def py_wd_test(
         data = None,
         name = None,
         python_flags = "all",
+        skip_python_flags = [],
         args = [],
         size = "enormous",
         tags = [],
         **kwargs):
     if python_flags == "all":
         python_flags = FEATURE_FLAGS.keys()
+    python_flags = [flag for flag in python_flags if flag not in skip_python_flags]
     if data == None and directory != None:
         data = native.glob(
             [


### PR DESCRIPTION
This allows us to say which combinations don't work, which is more explicit than saying which ones do work.

Release note: None