### PR TITLE
Don't rollback ExplicitTxn if broken.

### DIFF
--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -128,7 +128,7 @@ ActorSqlite::ExplicitTxn::~ExplicitTxn() noexcept(false) {
     }
   }();
 
-  if (!committed) {
+  if (!committed && actorSqlite.broken == kj::none) {
     // Assume rollback if not committed.
     rollbackImpl();
   }


### PR DESCRIPTION
If the database is broken, this will just throw another exception. ImplicitTxn's destructor already has the same check, it was just missing here.