### PR TITLE
Fix SEEK_END for Python metadatafs

### DIFF
--- a/src/pyodide/internal/readOnlyFS.ts
+++ b/src/pyodide/internal/readOnlyFS.ts
@@ -63,10 +63,10 @@ export function createReadonlyFS<Info>(
         } else if (whence === 2) {
           // SEEK_END
           if (FS.isFile(stream.node.mode)) {
-            if ((stream.node.info as any).size == undefined) {
+            if (stream.node.usedBytes == undefined) {
               throw new Error('File size is undefined');
             }
-            position += (stream.node.info as any).size;
+            position += stream.node.usedBytes;
           }
         }
         return position;

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -430,7 +430,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   pythonWorkers @43 :Bool
       $compatEnableFlag("python_workers")
       $pythonSnapshotRelease(pyodide = "0.26.0a2", pyodideRevision = "2024-03-01",
-          packages = "20240829.4", backport = 13,
+          packages = "20240829.4", backport = 14,
           baselineSnapshotHash = "d13ce2f4a0ade2e09047b469874dacf4d071ed3558fec4c26f8d0b99d95f77b5")
       $impliedByAfterDate(name = "pythonWorkersDevPyodide", date = "2000-01-01");
   # Enables Python Workers. Access to this flag is not restricted, instead bundles containing
@@ -684,7 +684,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatEnableFlag("python_workers_20250116")
       $experimental
       $pythonSnapshotRelease(pyodide = "0.27.1", pyodideRevision = "2025-01-16",
-          packages = "20241218", backport = 0,
+          packages = "20241218", backport = 2,
           baselineSnapshotHash = "TODO");
 
   requestCfOverridesCacheRules @72 :Bool

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -35,6 +35,8 @@ py_wd_test(
     ],
 )
 
+py_wd_test("seek-metadatafs")
+
 gen_import_tests(
     PYODIDE_IMPORTS_TO_TEST,
     # TODO: Micropip version mismatch for 0.27.0

--- a/src/workerd/server/tests/python/seek-metadatafs/a.py
+++ b/src/workerd/server/tests/python/seek-metadatafs/a.py
@@ -1,0 +1,8 @@
+import os
+from pathlib import Path
+
+
+def test():
+    fh = Path(__file__).open()
+    print(fh.fileno())
+    print(f"This file is {os.lseek(fh.fileno(), 0, os.SEEK_END)} characters long")

--- a/src/workerd/server/tests/python/seek-metadatafs/seek-metadatafs.wd-test
+++ b/src/workerd/server/tests/python/seek-metadatafs/seek-metadatafs.wd-test
@@ -1,0 +1,16 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "main",
+      worker = (
+        modules = [
+          (name = "a.py", pythonModule = embed "./a.py"),
+        ],
+        compatibilityDate = "2023-12-18",
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+      )
+    ),
+  ],
+);
+


### PR DESCRIPTION
We calculated the total size of the file in readOnlyFS in a way that only worked for tarfs and not for metadatafs.