### PR TITLE
Add diagnostic logging to determine import assertion use

### DIFF
--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -645,6 +645,21 @@ v8::MaybeLocal<v8::Promise> dynamicImportCallback(v8::Local<v8::Context> context
   auto registry = ModuleRegistry::from(js);
   auto& wrapper = TypeWrapper::from(js.v8Isolate);
 
+  // TODO(new-module-registry): The specification for import assertions strongly
+  // recommends that embedders reject import attributes and types they do not
+  // understand/implement. This is because import attributes can alter the
+  // interpretation of a module and are considered to be part of the unique
+  // key for caching a module.
+  // Throwing an error for things we do not understand is the safest thing to do.
+  // However, historically we have not followed this guideline in the spec and
+  // it's not clear if enforcing that constraint would be breaking so let's
+  // first try to determine if anyone is making use of import assertions.
+  // If we're lucky, we won't receive any hits on this and we can start
+  // enforcing the rule without a compat flag.
+  if (import_assertions->Length() > 0) {
+    LOG_NOSENTRY(WARNING, "Import attributes specified (and ignored) on dynamic import");
+  }
+
   // TODO(cleanup): This could probably be simplified using jsg::Promise
   const auto makeRejected = [&](auto reason) {
     v8::Local<v8::Promise::Resolver> resolver;


### PR DESCRIPTION
The specification for import assertions strongly recommends that embedders reject import attributes and types they do not understand/implement. This is because import attributes can alter the interpretation of a module and are considered to be part of the unique key for caching a module. Throwing an error for things we do not understand is the safest thing to do. However, historically we have not followed this guideline in the spec and it's not clear if enforcing that constraint would be breaking so let's first try to determine if anyone is making use of import assertions. If we're lucky, we won't receive any hits on this and we can start enforcing the rule without a compat flag.