### PR TITLE
DeferredProxyCoroutine::await_transform() perfectly-forwards result

### DIFF
--- a/src/workerd/api/deferred-proxy.h
+++ b/src/workerd/api/deferred-proxy.h
@@ -181,7 +181,7 @@ class DeferredProxyCoroutine: public kj::_::PromiseNode,
   }
 
   template <typename U>
-  auto await_transform(U&& awaitable) {
+  decltype(auto) await_transform(U&& awaitable) {
     // Trivially forward everything, so we can await anything a kj::Promise<T> can.
     return inner.await_transform(kj::fwd<U>(awaitable));
   }


### PR DESCRIPTION
Our current implementation of await_transform() requires that we return a result by value, by dint of returning `auto`. An upcoming capnproto patch will change await_transform()'s behavior to just be a pass-through, deferring the actual awaiter construction to a new `operator co_await` implementation. By returning `decltype(auto)`, we become compatible with capnproto both before and after that patch.