### PR TITLE
Add returnRawResponse to AI binding options

### DIFF
--- a/src/cloudflare/internal/ai-api.ts
+++ b/src/cloudflare/internal/ai-api.ts
@@ -23,7 +23,8 @@ export type SessionOptions = {
 
 export type AiOptions = {
   gateway?: GatewayOptions;
-
+  /** If true it will return a Response object */
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
   /*
@@ -141,6 +142,10 @@ export class Ai {
     this.lastRequestId = res.headers.get('cf-ai-req-id');
     this.aiGatewayLogId = res.headers.get('cf-aig-log-id');
     this.lastRequestHttpStatusCode = res.status;
+
+    if (this.options.returnRawResponse) {
+      return res;
+    }
 
     if (!res.ok) {
       throw await this._parseError(res);

--- a/src/cloudflare/internal/test/ai/ai-api-test.js
+++ b/src/cloudflare/internal/test/ai/ai-api-test.js
@@ -196,5 +196,16 @@ export const tests = {
         },
       ]);
     }
+
+    {
+      // Test `returnRawResponse` option is returning a Response object
+      const resp = await env.ai.run(
+        'rawInputs',
+        { prompt: 'test' },
+        { returnRawResponse: true }
+      );
+
+      assert.ok(resp instanceof Response);
+    }
   },
 };

--- a/types/defines/ai.d.ts
+++ b/types/defines/ai.d.ts
@@ -686,6 +686,7 @@ export interface AiModels {
 }
 export type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -720,10 +721,14 @@ export type AiModelListType = Record<string, any>;
 export declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options
+  ): Promise<
+    Options extends { returnRawResponse: true }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -4097,6 +4097,7 @@ interface AiModels {
 }
 type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4131,11 +4132,17 @@ type AiModelListType = Record<string, any>;
 declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 type GatewayOptions = {

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -4109,6 +4109,7 @@ export interface AiModels {
 }
 export type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4145,11 +4146,17 @@ export declare abstract class Ai<
 > {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 export type GatewayOptions = {

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -4123,6 +4123,7 @@ interface AiModels {
 }
 type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4157,11 +4158,17 @@ type AiModelListType = Record<string, any>;
 declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 type GatewayOptions = {

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -4135,6 +4135,7 @@ export interface AiModels {
 }
 export type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4171,11 +4172,17 @@ export declare abstract class Ai<
 > {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 export type GatewayOptions = {

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -4148,6 +4148,7 @@ interface AiModels {
 }
 type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4182,11 +4183,17 @@ type AiModelListType = Record<string, any>;
 declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 type GatewayOptions = {

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -4160,6 +4160,7 @@ export interface AiModels {
 }
 export type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4196,11 +4197,17 @@ export declare abstract class Ai<
 > {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 export type GatewayOptions = {

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -4149,6 +4149,7 @@ interface AiModels {
 }
 type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4183,11 +4184,17 @@ type AiModelListType = Record<string, any>;
 declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 type GatewayOptions = {

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -4161,6 +4161,7 @@ export interface AiModels {
 }
 export type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4197,11 +4198,17 @@ export declare abstract class Ai<
 > {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 export type GatewayOptions = {

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -4152,6 +4152,7 @@ interface AiModels {
 }
 type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4186,11 +4187,17 @@ type AiModelListType = Record<string, any>;
 declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 type GatewayOptions = {

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -4164,6 +4164,7 @@ export interface AiModels {
 }
 export type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4200,11 +4201,17 @@ export declare abstract class Ai<
 > {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 export type GatewayOptions = {

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -4157,6 +4157,7 @@ interface AiModels {
 }
 type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4191,11 +4192,17 @@ type AiModelListType = Record<string, any>;
 declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 type GatewayOptions = {

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -4169,6 +4169,7 @@ export interface AiModels {
 }
 export type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4205,11 +4206,17 @@ export declare abstract class Ai<
 > {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 export type GatewayOptions = {

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -4159,6 +4159,7 @@ interface AiModels {
 }
 type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4193,11 +4194,17 @@ type AiModelListType = Record<string, any>;
 declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 type GatewayOptions = {

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -4171,6 +4171,7 @@ export interface AiModels {
 }
 export type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4207,11 +4208,17 @@ export declare abstract class Ai<
 > {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 export type GatewayOptions = {

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -4159,6 +4159,7 @@ interface AiModels {
 }
 type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4193,11 +4194,17 @@ type AiModelListType = Record<string, any>;
 declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 type GatewayOptions = {

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -4171,6 +4171,7 @@ export interface AiModels {
 }
 export type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4207,11 +4208,17 @@ export declare abstract class Ai<
 > {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 export type GatewayOptions = {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4238,6 +4238,7 @@ interface AiModels {
 }
 type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4272,11 +4273,17 @@ type AiModelListType = Record<string, any>;
 declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 type GatewayOptions = {

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4250,6 +4250,7 @@ export interface AiModels {
 }
 export type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4286,11 +4287,17 @@ export declare abstract class Ai<
 > {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 export type GatewayOptions = {

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -4097,6 +4097,7 @@ interface AiModels {
 }
 type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4131,11 +4132,17 @@ type AiModelListType = Record<string, any>;
 declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 type GatewayOptions = {

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -4109,6 +4109,7 @@ export interface AiModels {
 }
 export type AiOptions = {
   gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
   prefix?: string;
   extraHeaders?: object;
 };
@@ -4145,11 +4146,17 @@ export declare abstract class Ai<
 > {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
-  run<Name extends keyof AiModelList>(
+  run<Name extends keyof AiModelList, Options extends AiOptions>(
     model: Name,
     inputs: AiModelList[Name]["inputs"],
-    options?: AiOptions,
-  ): Promise<AiModelList[Name]["postProcessedOutputs"]>;
+    options?: Options,
+  ): Promise<
+    Options extends {
+      returnRawResponse: true;
+    }
+      ? Response
+      : AiModelList[Name]["postProcessedOutputs"]
+  >;
   public models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
 }
 export type GatewayOptions = {


### PR DESCRIPTION
Add new option to the AI binding
- `returnRawResponse` aims to enable users to have a more granular control over the response coming from the AI binding