### PR TITLE
[ci] Adjust runner configurations to reduce stalls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,6 @@ jobs:
           # Add an Address Sanitizer (ASAN) build on Linux for additional checking.
           - os:     { name: linux, image: ubuntu-22.04 }
             config: { suffix: -asan }
-          # Windows has a custom non-debug bazel config.
-          - os:     { name : windows, image : windows-2025 }
-            config: { suffix: '' }
           # TODO (later): The custom Windows-debug configuration consistently runs out of disk
           # space on CI, disable it for now. Once https://github.com/bazelbuild/bazel/issues/21615
           # has been resolved we can likely re-enable it and possibly fold up the custom
@@ -54,14 +51,14 @@ jobs:
           # - os:     { name : windows, image : windows-2025 }
           #   config: { suffix: -debug, bazel-args: --config=windows_dbg }
         exclude:
-          # Skip the matrix generated Windows non-debug config to use the one added above.
-          - os:     { name : windows, image : windows-2025 }
-            config: { suffix: '' }
           - os:     { name : windows, image : windows-2025 }
             config: { suffix: -debug }
-          # due to resource constraints, exclude the macOS-debug runner for now. linux-debug and
-          # linux-asan should provide sufficient coverage for building in the debug configuration.
+          # due to resource constraints, exclude the macOS and x64 Linux debug runners for now.
+          # linux-asan and arm64 linux-debug should provide sufficient coverage for building in the
+          # debug configuration.
           - os:     { name : macOS, image : macos-15 }
+            config: { suffix: -debug }
+          - os:     { name : linux, image : ubuntu-22.04 }
             config: { suffix: -debug }
       fail-fast: false
     uses: ./.github/workflows/_bazel.yml


### PR DESCRIPTION
We added arm64 runners recently which may have increased CI congestion.
- Disable Linux x64 debug job, we'll rely on the arm64 one
- Since we're here, clean up handling of the Windows runner, which got removed and then added back previously.

I also meant to move the Linux asan job from x64 to arm64 which is somewhat faster, but that would require a change to required CI jobs so not something I want to get into now.