### PR TITLE
Compute WORKERD_INDEX_URL instead of embedding from pyodide_bucket.bzl.

### DIFF
--- a/src/pyodide/BUILD.bazel
+++ b/src/pyodide/BUILD.bazel
@@ -5,7 +5,6 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@capnp-cpp//src/capnp:cc_capnp_library.bzl", "cc_capnp_library")
 load("//:build/capnp_embed.bzl", "capnp_embed")
 load("//:build/js_file.bzl", "js_file")
-load("//:build/pyodide_bucket.bzl", "PYODIDE_PACKAGE_BUCKET_URL")
 load("//:build/python_metadata.bzl", "PYTHON_LOCKFILES")
 load("//:build/wd_ts_bundle.bzl", "wd_ts_bundle")
 
@@ -172,16 +171,6 @@ REPLACEMENTS = [
     ],
 ]
 
-PYODIDE_BUCKET_MODULE = json.encode({
-    "PYODIDE_PACKAGE_BUCKET_URL": PYODIDE_PACKAGE_BUCKET_URL,
-})
-
-write_file(
-    name = "pyodide-bucket.json@rule",
-    out = "generated/pyodide-bucket.json",
-    content = [PYODIDE_BUCKET_MODULE],
-)
-
 expand_template(
     name = "pyodide.asm.js@rule",
     out = "generated/pyodide.asm.js",
@@ -255,15 +244,11 @@ wd_ts_bundle(
     eslintrc_json = "eslint.config.mjs",
     import_name = "pyodide",
     internal_data_modules = INTERNAL_DATA_MODULES,
-    internal_json_modules = [
-        "generated/pyodide-bucket.json",
-    ],
     internal_modules = INTERNAL_MODULES,
     js_deps = [
         "generated/emscriptenSetup",
         "pyodide.asm.wasm@rule",
         "python_stdlib.zip@rule",
-        "pyodide-bucket.json@rule",
     ],
     lint = False,
     modules = MODULES,
@@ -298,7 +283,6 @@ genrule(
         ":pyodide-internal_generated_emscriptenSetup.js",
         ":pyodide-internal_generated_pyodide.asm.wasm",
         ":pyodide-internal_generated_python_stdlib.zip",
-        ":pyodide-internal_generated_pyodide-bucket.json",
     ],
     outs = ["pyodide.capnp.bin"],
     cmd = " ".join([

--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -1,5 +1,4 @@
 import { default as MetadataReader } from 'pyodide-internal:runtime-generated/metadata';
-import { default as PYODIDE_BUCKET } from 'pyodide-internal:generated/pyodide-bucket.json';
 import { default as ArtifactBundler } from 'pyodide-internal:artifacts';
 
 export const IS_WORKERD = MetadataReader.isWorkerd();
@@ -7,11 +6,14 @@ export const IS_TRACING = MetadataReader.isTracing();
 export const SHOULD_SNAPSHOT_TO_DISK = MetadataReader.shouldSnapshotToDisk();
 export const IS_CREATING_BASELINE_SNAPSHOT =
   MetadataReader.isCreatingBaselineSnapshot();
-export const WORKERD_INDEX_URL = PYODIDE_BUCKET.PYODIDE_PACKAGE_BUCKET_URL;
+export const PACKAGES_VERSION = MetadataReader.getPackagesVersion();
+export const WORKERD_INDEX_URL =
+  'https://pyodide-packages.runtime-playground.workers.dev/' +
+  PACKAGES_VERSION +
+  '/';
 export const LOAD_WHEELS_FROM_R2: boolean = IS_WORKERD;
 export const LOAD_WHEELS_FROM_ARTIFACT_BUNDLER =
   MetadataReader.shouldUsePackagesInArtifactBundler();
-export const PACKAGES_VERSION = MetadataReader.getPackagesVersion();
 export const LOCKFILE: PackageLock = JSON.parse(
   MetadataReader.getPackagesLock()
 );

--- a/src/pyodide/types/pyodide-bucket.d.ts
+++ b/src/pyodide/types/pyodide-bucket.d.ts
@@ -1,8 +1,0 @@
-interface PYODIDE_BUCKET {
-  PYODIDE_PACKAGE_BUCKET_URL: string;
-}
-
-declare module 'pyodide-internal:generated/pyodide-bucket.json' {
-  const bucket: PYODIDE_BUCKET;
-  export default bucket;
-}


### PR DESCRIPTION
This ensures that we will get the right package versions in workerd. Before these changes it would always get the same compat date, no matter what is specified by the user.