### PR TITLE
POC of different destinations for rpc and fetch

### DIFF
--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -663,6 +663,8 @@ struct ExternalServer {
   # `HttpOptions`.
 
   address @0 :Text;
+
+  addressFetch @7 :Text;
   # Address/port of the server. Optional; if not specified, then you will be required to specify
   # the address on the command line with with `--external-addr <name>=<addr>`.
   #


### PR DESCRIPTION
**TLDR:** This is a quick POC of a way to point RPC calls and HTTP requests to different network addresses.

## The problem

Wrangler/Miniflare uses a `workerd` `ExternalServer` to represent service bindings between Workers in local development. This is because each Worker runs in a different `workerd` process configured by `wrangler dev` (ignoring the experimental multiworker support we've been landing recently). The caller will configure:

```
external: {
	address: address,
	http: {
		style: HttpOptions_Style.PROXY,
	},
},
```

as the service binding, where `address` is a direct address to a `capnpConnectHost` configured `Socket` from the callee.

This means that all communication over that service binding will go to the service linked to the `capnpConnectHost` `Socket` on the callee `workerd`.

However, for Workers Assets this presents a problem. Communication over service bindings needs to go to a different Worker depending on whether it's RPC or HTTP (to the user worker and router worker respectively). We need a way to connect to different addresses (Miniflare exposes a `Socket` for every configured worker) based on the type of communication. 

## The proposed solution

This PR implements (with bugs, caveats, and build failures) a proposed solution which adds an additional config property to `ExternalServer`, `addressFetch`. When workerd is making a connection to an `ExternalServer`, it should use the address specified in `addressFetch` for HTTP communication and the address specified in `address` for RPC communication. If `addressFetch` is _not_ specified it should use `address` for both RPC and HTTP communication.

Wrangler/Miniflare can then leverage this by pointing `address` at the user worker's `Socket`, and `addressFetch` at the router worker's `Socket`