### PR TITLE
Make `PyodideMetadataReader::getWorkerFiles` not fail when it filters files

### DIFF
--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -77,13 +77,13 @@ kj::Array<jsg::JsRef<jsg::JsString>> PyodideMetadataReader::getNames(jsg::Lock& 
 
 kj::Array<jsg::JsRef<jsg::JsString>> PyodideMetadataReader::getWorkerFiles(
     jsg::Lock& js, kj::String ext) {
-  auto builder = kj::heapArrayBuilder<jsg::JsRef<jsg::JsString>>(this->names.size());
-  for (auto i: kj::zeroTo(builder.capacity())) {
+  auto builder = kj::Vector<jsg::JsRef<jsg::JsString>>(this->names.size());
+  for (auto i: kj::zeroTo(this->names.size())) {
     if (this->names[i].endsWith(ext)) {
       builder.add(js, js.str(this->contents[i]));
     }
   }
-  return builder.finish();
+  return builder.releaseAsArray();
 }
 
 kj::Array<jsg::JsRef<jsg::JsString>> PyodideMetadataReader::getRequirements(jsg::Lock& js) {

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -68,3 +68,5 @@ py_wd_test(
 )
 
 py_wd_test("dont-snapshot-pyodide")
+
+py_wd_test("filter-non-py-files")

--- a/src/workerd/server/tests/python/filter-non-py-files/filter-files.wd-test
+++ b/src/workerd/server/tests/python/filter-non-py-files/filter-files.wd-test
@@ -1,0 +1,22 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+# This is a really slow way to test that PyodideMetadataReader::getWorkerFiles works.
+# TODO: replace with a unit test?
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "dont-snapshot-pyodide",
+      worker = (
+        modules = [
+          (name = "worker.py", pythonModule = embed "worker.py"),
+          # a file with no `.py` extension to get filtered out
+          (name = "fake_shared_library.so", data = "This isn't really a shared library..."),
+          # We need a package dependency to trigger the package snapshot logic which we're trying to
+          # test.
+          (name = "numpy", pythonRequirement = "")
+        ],
+        compatibilityDate = "2024-01-15",
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+      )
+    ),
+  ],
+);

--- a/src/workerd/server/tests/python/filter-non-py-files/worker.py
+++ b/src/workerd/server/tests/python/filter-non-py-files/worker.py
@@ -1,0 +1,2 @@
+def test():
+    pass


### PR DESCRIPTION
ArrayBuilder assumes the array we are constructing has the exact size given. For constructing variable size arrays, we need a `kj::Vector`.

- [x] Add a test