### PR TITLE
Create and use snapshot by default in all `wd_py_test`s

### DIFF
--- a/src/cloudflare/internal/test/ai/BUILD.bazel
+++ b/src/cloudflare/internal/test/ai/BUILD.bazel
@@ -15,6 +15,8 @@ py_wd_test(
         "*.js",
         "*.py",
     ]),
+    # Works but times out frequently
+    make_snapshot = False,
     tags = [
         # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
         "no-asan",

--- a/src/cloudflare/internal/test/aig/BUILD.bazel
+++ b/src/cloudflare/internal/test/aig/BUILD.bazel
@@ -15,6 +15,8 @@ py_wd_test(
         "*.js",
         "*.py",
     ]),
+    # Works but times out
+    make_snapshot = False,
     tags = [
         # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
         "no-asan",

--- a/src/cloudflare/internal/test/br/BUILD.bazel
+++ b/src/cloudflare/internal/test/br/BUILD.bazel
@@ -15,6 +15,8 @@ py_wd_test(
         "*.js",
         "*.py",
     ]),
+    # Works but times out
+    make_snapshot = False,
     tags = [
         # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
         "no-asan",

--- a/src/cloudflare/internal/test/d1/BUILD.bazel
+++ b/src/cloudflare/internal/test/d1/BUILD.bazel
@@ -24,6 +24,7 @@ py_wd_test(
         "*.py",
         "*.js",
     ]),
+    make_snapshot = False,
     tags = [
         # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
         "no-asan",

--- a/src/cloudflare/internal/test/vectorize/BUILD.bazel
+++ b/src/cloudflare/internal/test/vectorize/BUILD.bazel
@@ -13,6 +13,8 @@ py_wd_test(
         "*.py",
         "*.js",
     ]),
+    # Works but times out
+    make_snapshot = False,
     tags = [
         # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
         "no-asan",

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -49,6 +49,7 @@ struct PythonConfig {
   const PyodideBundleManager pyodideBundleManager;
   bool createSnapshot;
   bool createBaselineSnapshot;
+  bool loadSnapshotFromDisk;
 };
 
 // A function to read a segment of the tar file into a buffer

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -79,6 +79,9 @@ class Server final: private kj::TaskSet::ErrorHandler {
   void setPythonCreateBaselineSnapshot() {
     pythonConfig.createBaselineSnapshot = true;
   }
+  void setPythonLoadSnapshot() {
+    pythonConfig.loadSnapshotFromDisk = true;
+  }
 
   // Runs the server using the given config.
   kj::Promise<void> run(jsg::V8System& v8System,
@@ -118,7 +121,8 @@ class Server final: private kj::TaskSet::ErrorHandler {
   PythonConfig pythonConfig = PythonConfig{.packageDiskCacheRoot = kj::none,
     .pyodideDiskCacheRoot = kj::none,
     .createSnapshot = false,
-    .createBaselineSnapshot = false};
+    .createBaselineSnapshot = false,
+    .loadSnapshotFromDisk = false};
 
   bool experimental = false;
 

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -20,6 +20,8 @@ py_wd_test("env-param")
 
 py_wd_test(
     "asgi",
+    # TODO: investigate failure!
+    make_snapshot = False,
     skip_python_flags = ["0.27.1"],
 )
 

--- a/src/workerd/server/tests/python/import_tests.bzl
+++ b/src/workerd/server/tests/python/import_tests.bzl
@@ -53,6 +53,7 @@ def gen_import_tests(to_test, pkg_skip_versions = {}):
             directory = lib,
             src = wd_test_fname,
             skip_python_flags = pkg_skip_versions.get(lib, []),
+            make_snapshot = False,
             args = ["--experimental", "--pyodide-package-disk-cache-dir", "../all_pyodide_wheels"],
             data = [worker_py_fname, "@all_pyodide_wheels//:whls"],
             size = "enormous",

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -779,10 +779,15 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
       server->setPythonCreateSnapshot();
       return true;
     }, "Save a dedicated snapshot to the disk cache")
-        .addOption({"python-save-baseline-snapshot"}, [this]() {
+        .addOption({"python-save-baseline-snapshot"},
+            [this]() {
       server->setPythonCreateBaselineSnapshot();
       return true;
-    }, "Save a baseline snapshot to the disk cache");
+    }, "Save a baseline snapshot to the disk cache")
+        .addOption({"python-load-snapshot"}, [this]() {
+      server->setPythonLoadSnapshot();
+      return true;
+    }, "Load a snapshot from the package disk cache");
   }
 
   kj::MainFunc addServeOptions(kj::MainBuilder& builder) {


### PR DESCRIPTION
This isn't as good as having actual validator coverage but it should help catch a lot of the problems we're having at validation time.

On top of #3476.