### PR TITLE
Create an isolate group per isolate

### DIFF
--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -310,7 +310,12 @@ static v8::Isolate* newIsolate(v8::Isolate::CreateParams&& params, v8::CppHeap* 
       params.array_buffer_allocator_shared = std::shared_ptr<v8::ArrayBuffer::Allocator>(
           v8::ArrayBuffer::Allocator::NewDefaultAllocator());
     }
+#if (V8_MAJOR_VERSION == 13 && V8_MINOR_VERSION > 2) || V8_MAJOR_VERSION > 13
+    v8::IsolateGroup group = v8::IsolateGroup::Create();
+    return v8::Isolate::New(group, params);
+#else
     return v8::Isolate::New(params);
+#endif
   });
 }
 }  // namespace


### PR DESCRIPTION
Starting with 13.3 we need to put each Isolate in its own IsolateGroup, otherwise they share a pointer cage, which causes out-of-memory or overflow of code space.

Felix: As I recall you already tried this patch with success - see chat.