### PR TITLE
add remaining node:module methods

### DIFF
--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -212,9 +212,9 @@ wd_test(
 )
 
 wd_test(
-    src = "tests/module-create-require-test.wd-test",
+    src = "tests/module-nodejs-test.wd-test",
     args = ["--experimental"],
-    data = ["tests/module-create-require-test.js"],
+    data = ["tests/module-nodejs-test.js"],
 )
 
 wd_test(

--- a/src/workerd/api/node/tests/module-nodejs-test.js
+++ b/src/workerd/api/node/tests/module-nodejs-test.js
@@ -80,3 +80,17 @@ export const isBuiltinTest = {
     });
   },
 };
+
+export const testErrorMethodNotImplemented = {
+  async test() {
+    const m = await import('node:module');
+    const methods = ['findSourceMap', 'register', 'syncBuiltinESMExports'];
+
+    for (const method of methods) {
+      throws(() => m[method](), {
+        name: 'Error',
+        code: 'ERR_METHOD_NOT_IMPLEMENTED',
+      });
+    }
+  },
+};

--- a/src/workerd/api/node/tests/module-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/module-nodejs-test.wd-test
@@ -2,10 +2,10 @@ using Workerd = import "/workerd/workerd.capnp";
 
 const unitTests :Workerd.Config = (
   services = [
-    ( name = "module-create-require-test",
+    ( name = "nodejs-module-test",
       worker = (
         modules = [
-          (name = "worker", esModule = embed "module-create-require-test.js"),
+          (name = "worker", esModule = embed "module-nodejs-test.js"),
           (name = "foo", esModule = "export default 1;"),
           (name = "bar", esModule = "export default 2; export const __cjsUnwrapDefault = true;"),
           (name = "baz", commonJsModule = "module.exports = 3;"),

--- a/src/workerd/api/tsconfig.json
+++ b/src/workerd/api/tsconfig.json
@@ -15,5 +15,5 @@
     "allowJs": true
   },
   "include": ["**/*.ts"],
-  "exclude": []
+  "exclude": ["wpt/**"]
 }


### PR DESCRIPTION
I've purposefully didn't add the undocumented methods (even though unenv adds them), and purposefully didn't add experimental or in active development methods.

After this lands, we can remove the unenv polyfill, but I'm not quite sure what we will do with functions that are undocumented but implemented in the polyfill (even though they throw notImplemented() errors)

cc @irvinebroque @jasnell @danlapid 