### PR TITLE
update nodejs and add compile cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,7 +217,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: Modify package.json version
         run: node npm/scripts/bump-version.mjs npm/workerd-${{ matrix.arch }}/package.json
         env:
@@ -245,7 +245,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 22
           cache: "pnpm"
       - name: Install workers-sdk dependencies
         run: pnpm install
@@ -279,7 +279,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Cache
         id: cache

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,7 @@ deps_gen()
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
-NODE_VERSION = "22.11.0"
+NODE_VERSION = "22.13.0"
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/build/deps/gen/dep_aspect_rules_js.bzl
+++ b/build/deps/gen/dep_aspect_rules_js.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "v2.1.2"
-URL = "https://github.com/aspect-build/rules_js/releases/download/v2.1.2/rules_js-v2.1.2.tar.gz"
-STRIP_PREFIX = "rules_js-2.1.2"
-SHA256 = "fbc34d815a0cc52183a1a26732fc0329e26774a51abbe0f26fc9fd2dab6133b4"
+TAG_NAME = "v2.1.3"
+URL = "https://github.com/aspect-build/rules_js/releases/download/v2.1.3/rules_js-v2.1.3.tar.gz"
+STRIP_PREFIX = "rules_js-2.1.3"
+SHA256 = "875b8d01af629dbf626eddc5cf239c9f0da20330f4d99ad956afc961096448dd"
 TYPE = "tgz"
 
 def dep_aspect_rules_js():

--- a/build/deps/gen/dep_rules_nodejs.bzl
+++ b/build/deps/gen/dep_rules_nodejs.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "v6.3.2"
-URL = "https://api.github.com/repos/bazel-contrib/rules_nodejs/tarball/v6.3.2"
-STRIP_PREFIX = "bazel-contrib-rules_nodejs-ea47e8d"
-SHA256 = "990827af9f845b5e7089ce80ca0737f73b7569f0e6011d0d59b4448967a439be"
+TAG_NAME = "v6.3.3"
+URL = "https://api.github.com/repos/bazel-contrib/rules_nodejs/tarball/v6.3.3"
+STRIP_PREFIX = "bazel-contrib-rules_nodejs-398bcf9"
+SHA256 = "057a4add02cfe13da99c2f0c44f8ca94f7ba1dd683592b983c06912c2aa8e9f9"
 TYPE = "tgz"
 
 def dep_rules_nodejs():

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@eslint/js": "^9.19.0",
     "@types/debug": "^4.1.12",
-    "@types/node": "^20.16.5",
+    "@types/node": "^22.11.0",
     "capnpc-ts": "^0.7.0",
     "chrome-remote-interface": "^0.33.2",
     "esbuild": "^0.24.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^4.1.12
         version: 4.1.12
       '@types/node':
-        specifier: ^20.16.5
-        version: 20.16.5
+        specifier: ^22.11.0
+        version: 22.12.0
       capnpc-ts:
         specifier: ^0.7.0
         version: 0.7.0
@@ -292,8 +292,8 @@ packages:
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
-  '@types/node@20.16.5':
-    resolution: {integrity: sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==}
+  '@types/node@22.12.0':
+    resolution: {integrity: sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==}
 
   '@typescript-eslint/eslint-plugin@8.22.0':
     resolution: {integrity: sha512-4Uta6REnz/xEJMvwf72wdUnC3rr4jAQf5jnTkeRQ9b6soxLxhDEbS/pfMPoJLDfFPNVRdryqWUIV/2GZzDJFZw==}
@@ -1086,8 +1086,8 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1287,9 +1287,9 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
-  '@types/node@20.16.5':
+  '@types/node@22.12.0':
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 6.20.0
 
   '@typescript-eslint/eslint-plugin@8.22.0(@typescript-eslint/parser@8.22.0(eslint@9.19.0)(typescript@5.5.4))(eslint@9.19.0)(typescript@5.5.4)':
     dependencies:
@@ -2275,7 +2275,7 @@ snapshots:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
-  undici-types@6.19.8: {}
+  undici-types@6.20.0: {}
 
   uri-js@4.4.1:
     dependencies:

--- a/types/BUILD.bazel
+++ b/types/BUILD.bazel
@@ -28,6 +28,9 @@ js_binary(
         ":types_lib",
     ],
     entry_point = "scripts/build-types.js",
+    env = {
+        "NODE_COMPILE_CACHE": "/tmp/workerd-types-compile-cache",
+    },
 )
 
 js_run_binary(
@@ -38,6 +41,9 @@ js_run_binary(
         "//:node_modules/prettier",
         "//src/workerd/server:workerd",
     ],
+    env = {
+        "NODE_COMPILE_CACHE": "/tmp/workerd-types-compile-cache",
+    },
     out_dirs = ["definitions"],
     silent_on_success = False,  # Always enable logging for debugging
     tool = ":build_types_bin",


### PR DESCRIPTION
Passing NODE_COMPILE_CACHE environment variable enables compile cache on node.js