### PR TITLE
add incompatible async_hooks fns for backward compat

### DIFF
--- a/src/node/async_hooks.ts
+++ b/src/node/async_hooks.ts
@@ -13,6 +13,22 @@ class AsyncHook {
   public disable(): this {
     return this;
   }
+
+  // IMPORTANT
+  //
+  // The following methods were defined in unenv while they don't exist in Node.js
+  // async_hooks module. This is a bug with unenv.
+  // Unfortunately, unless we are 100% sure these methods are not used in production,
+  // we can not remove them from workerd.
+  //
+  // More information about the bug is available at https://github.com/unjs/unenv/issues/403
+  //
+  // Ref: https://github.com/unjs/unenv/blob/ada7c4093c69c9729f1b008a8ab7902389941624/src/runtime/node/async_hooks/internal/async-hook.ts#L25
+  public init(): void {}
+  public before(): void {}
+  public after(): void {}
+  public destroy(): void {}
+  public promiseResolve(): void {}
 }
 
 export const { AsyncLocalStorage, AsyncResource } = async_hooks;


### PR DESCRIPTION
The following methods are defined in unenv even though they are not defined in Node.js. This is due to a bug. AsyncHook class doesn't have these functions, but async hook callbacks does. Please take a look into [Node.js documentation for async_hooks](https://nodejs.org/api/async_hooks.html#class-asynchook)

In order to preserve backward compatibility and not introduce a breaking change on applications that depend on this functions (even though they are not doing anything), we have to implement them in workerd as well.

The issue is tracked on https://github.com/unjs/unenv/issues/403 but removing these functions will be a breaking change, and wrangler still needs to provide these methods regardless of it's been removed from unenv or not. (Unless we remove polyfill and depend on async_hooks implementation of workerd, rather than the polyfill)

In a follow up pull-request, I'll add logging for these functions to track the usage over time. It won't be 100% correct, but it will give us an estimation about whether or not this is used in workers.


cc @IgorMinar @irvinebroque @jasnell @danlapid @vicb