### PR TITLE
Containers: wait for up/down streams to finish resolving the connectImpl promise

### DIFF
--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -199,6 +199,7 @@ class Container::TcpPortWorkerInterface final: public WorkerInterface {
     });
 
     co_await pipeline.ignoreResult();
+    co_await kj::joinPromisesFailFast(kj::arr(kj::mv(upPumpTask), kj::mv(downPumpTask)));
   }
 };
 


### PR DESCRIPTION
@kenton suggested adding this line to fix the issues we were finding with the containers integration. Seems to be fixing all of the problems we were finding!