### PR TITLE
Refactor: Make ValidationErrorReporter interface better.

### DIFF
--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -78,11 +78,14 @@ class Worker: public kj::AtomicRefcounted {
   class ValidationErrorReporter {
    public:
     virtual void addError(kj::String error) = 0;
-    virtual void addHandler(kj::Maybe<kj::StringPtr> exportName, kj::StringPtr type) = 0;
 
-    // Called when an export is encountered that defines no handlers, thus isn't useful for
-    // anything.
-    virtual void addEmptyExport(kj::Maybe<kj::StringPtr> exportName) {}
+    // Report that the Worker implements a stateless entrypoint (e.g. WorkerEntrypoint or plain
+    // object export) with the given export name and methods.
+    virtual void addEntrypoint(
+        kj::Maybe<kj::StringPtr> exportName, kj::Array<kj::String> methods) = 0;
+
+    // Report that the Worker exports a Durable Object class with the given name.
+    virtual void addActorClass(kj::StringPtr exportName) = 0;
   };
 
   class LockType;
@@ -884,7 +887,10 @@ struct SimpleWorkerErrorReporter final: public Worker::ValidationErrorReporter {
   void addError(kj::String error) override {
     errors.add(kj::mv(error));
   }
-  void addHandler(kj::Maybe<kj::StringPtr> exportName, kj::StringPtr type) override {
+  void addEntrypoint(kj::Maybe<kj::StringPtr> exportName, kj::Array<kj::String> methods) override {
+    KJ_UNREACHABLE;
+  }
+  void addActorClass(kj::StringPtr exportName) override {
     KJ_UNREACHABLE;
   }
 

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -1503,6 +1503,185 @@ KJ_TEST("Server: referencing non-extant default entrypoint is not an error") {
     wat)"_blockquote);
 }
 
+KJ_TEST("Server: referencing DO class as entrypoint is not an error") {
+  // For historical reasons, it's not a config error to refer to an actor class as a stateless
+  // entrypoint.
+  TestServer test(R"((
+    services = [
+      ( name = "hello",
+        worker = (
+          compatibilityDate = "2022-08-17",
+          modules = [
+            ( name = "main.js",
+              esModule =
+                `import { DurableObject } from "cloudflare:workers"
+                `
+                `export class SomeActor extends DurableObject {}
+                `
+                `export default {
+                `  async fetch(request, env) {
+                `    return new Response("OK");
+                `  }
+                `}
+            )
+          ],
+        )
+      ),
+    ],
+    sockets = [
+      ( name = "main",
+        address = "test-addr",
+        service = (name = "hello", entrypoint = "SomeActor")
+      ),
+    ]
+  ))"_kj);
+
+  // We see no error at config time -- this completes successfully.
+  test.start();
+
+  // However, a request will still fail at runtime.
+  KJ_EXPECT_LOG(ERROR, "worker is not an actor but class name was requested");
+  KJ_EXPECT_LOG(INFO, "Unable to get exported handler");
+  KJ_EXPECT_LOG(ERROR, "Unable to get exported handler");
+
+  auto conn = test.connect("test-addr");
+  conn.sendHttpGet("/");
+  conn.recv(R"(
+    HTTP/1.1 500 Internal Server Error
+    Connection: close
+    Content-Length: 21
+
+    Internal Server Error)"_blockquote);
+}
+
+KJ_TEST("Server: exporting a DO class as the default export is not an error") {
+  // For historical reasons, it's not a config error to export a DO class as the default
+  // entrypoint. It doesn't work at runtime, but it's not a config error.
+  TestServer test(R"((
+    services = [
+      ( name = "hello",
+        worker = (
+          compatibilityDate = "2022-08-17",
+          modules = [
+            ( name = "main.js",
+              esModule =
+                `import { DurableObject } from "cloudflare:workers"
+                `
+                `export default class extends DurableObject {
+                `  async fetch(request) {
+                `    return new Response("this should not be called");
+                `  }
+                `}
+            )
+          ],
+        )
+      ),
+    ],
+    sockets = [
+      ( name = "main",
+        address = "test-addr",
+        service = "hello"
+      ),
+    ]
+  ))"_kj);
+
+  // We see no error at config time -- this completes successfully.
+  test.start();
+
+  // Note that there is no way to actually configure the default export as a DO class since
+  // `className` is non-optional in both `DurableObjectNamespace` and
+  // `DurableObjectNamespaceDesignator`.
+  //
+  // We can, however, try to send a stateless request to the default entrypoint and see what
+  // happens!
+  //
+  // Since the runtime does not believe there is any (stateless) entrypoint exported as the
+  // default entrypoint, if you try to send a request to it, it behaves the same as if there were
+  // no `export default` at all.
+  //
+  // The behavior of this is quite strange. See the comment in the earlier test:
+  //
+  //   KJ_TEST("Server: referencing non-extant default entrypoint is not an error")
+  auto conn = test.connect("test-addr");
+  conn.sendHttpGet("/");
+
+  {
+    auto subreq = test.receiveSubrequest("foo", {"public"});
+    subreq.recv(R"(
+      GET / HTTP/1.1
+      Host: foo
+
+    )"_blockquote);
+    subreq.send(R"(
+      HTTP/1.1 200 OK
+      Content-Length: 3
+
+      wat)"_blockquote);
+  }
+
+  conn.recv(R"(
+    HTTP/1.1 200 OK
+    Content-Length: 3
+
+    wat)"_blockquote);
+}
+
+KJ_TEST("Server: configuring a DO namespace with no class export is not an error") {
+  // For historical reasons, it's not a config error to configure a DO namespace when there is
+  // no corresponding class export.
+  TestServer test(R"((
+    services = [
+      ( name = "hello",
+        worker = (
+          compatibilityDate = "2022-08-17",
+          modules = [
+            ( name = "main.js",
+              esModule =
+                `export default {
+                `  async fetch(request, env) {
+                `    return env.ns.get(env.ns.newUniqueId()).fetch(request);
+                `    //return new Response("OK");
+                `  }
+                `}
+            )
+          ],
+          bindings = [(name = "ns", durableObjectNamespace = "MyActorClass")],
+          durableObjectNamespaces = [
+            ( className = "MyActorClass",
+              uniqueKey = "mykey",
+            )
+          ],
+          durableObjectStorage = (inMemory = void)
+        )
+      ),
+    ],
+    sockets = [
+      ( name = "main",
+        address = "test-addr",
+        service = "hello"
+      ),
+    ]
+  ))"_kj);
+
+  // We see no error at config time -- this completes successfully.
+  test.start();
+
+  // However, a request will still fail at runtime.
+  KJ_EXPECT_LOG(ERROR, "no such actor class");
+  KJ_EXPECT_LOG(INFO, "internal error");
+  KJ_EXPECT_LOG(INFO, "internal error");
+  KJ_EXPECT_LOG(ERROR, "internal error");
+
+  auto conn = test.connect("test-addr");
+  conn.sendHttpGet("/");
+  conn.recv(R"(
+    HTTP/1.1 500 Internal Server Error
+    Connection: close
+    Content-Length: 21
+
+    Internal Server Error)"_blockquote);
+}
+
 KJ_TEST("Server: call queue handler on service binding") {
   TestServer test(R"((
     services = [

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -1536,8 +1536,15 @@ KJ_TEST("Server: referencing DO class as entrypoint is not an error") {
     ]
   ))"_kj);
 
-  // We see no error at config time -- this completes successfully.
-  test.start();
+  // We see a log warning at config time, but config otherwise completes successfully.
+  {
+    KJ_EXPECT_LOG(WARNING,
+        "A ServiceDesignator in the config referenced the entrypoint \"SomeActor\", but this "
+        "class does not extend 'WorkerEntrypoint'. Attempts to call this entrypoint will "
+        "fail at runtime, but historically this was not a startup-time error. Future "
+        "versions of workerd may make this a startup-time error.");
+    test.start();
+  }
 
   // However, a request will still fail at runtime.
   KJ_EXPECT_LOG(ERROR, "worker is not an actor but class name was requested");
@@ -1585,8 +1592,13 @@ KJ_TEST("Server: exporting a DO class as the default export is not an error") {
     ]
   ))"_kj);
 
-  // We see no error at config time -- this completes successfully.
-  test.start();
+  // We see a log error at config time, but config otherwise completes successfully.
+  {
+    KJ_EXPECT_LOG(ERROR,
+        "Exported actor class as default entrypoint. This doesn't work, but historically "
+        "did not produce a startup-time error.");
+    test.start();
+  }
 
   // Note that there is no way to actually configure the default export as a DO class since
   // `className` is non-optional in both `DurableObjectNamespace` and
@@ -1663,8 +1675,17 @@ KJ_TEST("Server: configuring a DO namespace with no class export is not an error
     ]
   ))"_kj);
 
-  // We see no error at config time -- this completes successfully.
-  test.start();
+  // We see a log warning at config time, but config otherwise completes successfully.
+  {
+    KJ_EXPECT_LOG(WARNING,
+        "A DurableObjectNamespace in the config referenced the class \"MyActorClass\", but "
+        "no such Durable Object class is exported from the worker. Please make sure the "
+        "class name matches, it is exported, and the class extends 'DurableObject'. "
+        "Attempts to call to this Durable Object class will fail at runtime, but historically "
+        "this was not a startup-time error. Future versions of workerd may make this a "
+        "startup-time error.");
+    test.start();
+  }
 
   // However, a request will still fail at runtime.
   KJ_EXPECT_LOG(ERROR, "no such actor class");

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1791,6 +1791,7 @@ class Server::WorkerService final: public Service,
       kj::Own<const Worker> worker,
       kj::Maybe<kj::HashSet<kj::String>> defaultEntrypointHandlers,
       kj::HashMap<kj::String, kj::HashSet<kj::String>> namedEntrypoints,
+      kj::HashSet<kj::String> actorClassEntrypoints,
       const kj::HashMap<kj::String, ActorConfig>& actorClasses,
       LinkCallback linkCallback,
       AbortActorsCallback abortActorsCallback)
@@ -1799,6 +1800,7 @@ class Server::WorkerService final: public Service,
         worker(kj::mv(worker)),
         defaultEntrypointHandlers(kj::mv(defaultEntrypointHandlers)),
         namedEntrypoints(kj::mv(namedEntrypoints)),
+        actorClassEntrypoints(kj::mv(actorClassEntrypoints)),
         waitUntilTasks(*this),
         abortActorsCallback(kj::mv(abortActorsCallback)) {
 
@@ -1812,11 +1814,24 @@ class Server::WorkerService final: public Service,
 
   kj::Maybe<kj::Own<Service>> getEntrypoint(
       kj::Maybe<kj::StringPtr> name, kj::Maybe<kj::StringPtr> propsJson) {
-    kj::HashSet<kj::String>* handlers;
+    const kj::HashSet<kj::String>* handlers;
     KJ_IF_SOME(n, name) {
-      auto& entry = KJ_UNWRAP_OR_RETURN(namedEntrypoints.findEntry(n), kj::none);
-      name = entry.key;  // replace with more-permanent string
-      handlers = &entry.value;
+      KJ_IF_SOME(entry, namedEntrypoints.findEntry(n)) {
+        name = entry.key;  // replace with more-permanent string
+        handlers = &entry.value;
+      } else KJ_IF_SOME(className, actorClassEntrypoints.find(n)) {
+        KJ_LOG(WARNING,
+            kj::str("A ServiceDesignator in the config referenced the entrypoint \"", n,
+                "\", but this class does not extend 'WorkerEntrypoint'. Attempts to call this "
+                "entrypoint will fail at runtime, but historically this was not a startup-time "
+                "error. Future versions of workerd may make this a startup-time error."));
+
+        const kj::HashSet<kj::String> EMPTY_HANDLERS;
+        name = className;  // replace with more-permanent string
+        handlers = &EMPTY_HANDLERS;
+      } else {
+        return kj::none;
+      }
     } else {
       KJ_IF_SOME(d, defaultEntrypointHandlers) {
         handlers = &d;
@@ -1974,7 +1989,17 @@ class Server::WorkerService final: public Service,
         : service(service),
           className(className),
           config(config),
-          timer(timer) {}
+          timer(timer) {
+      if (!service.actorClassEntrypoints.contains(className)) {
+        KJ_LOG(WARNING,
+            kj::str("A DurableObjectNamespace in the config referenced the class \"", className,
+                "\", but no such Durable Object class is exported from the worker. Please make "
+                "sure the class name matches, it is exported, and the class extends "
+                "'DurableObject'. Attempts to call to this Durable Object class will fail at "
+                "runtime, but historically this was not a startup-time error. Future versions of "
+                "workerd may make this a startup-time error."));
+      }
+    }
 
     const ActorConfig& getConfig() {
       return config;
@@ -2456,7 +2481,7 @@ class Server::WorkerService final: public Service,
     EntrypointService(WorkerService& worker,
         kj::Maybe<kj::StringPtr> entrypoint,
         kj::Maybe<kj::StringPtr> propsJson,
-        kj::HashSet<kj::String>& handlers)
+        const kj::HashSet<kj::String>& handlers)
         : worker(worker),
           entrypoint(entrypoint),
           handlers(handlers) {
@@ -2476,7 +2501,7 @@ class Server::WorkerService final: public Service,
    private:
     WorkerService& worker;
     kj::Maybe<kj::StringPtr> entrypoint;
-    kj::HashSet<kj::String>& handlers;
+    const kj::HashSet<kj::String>& handlers;
     Frankenvalue props;
   };
 
@@ -2488,6 +2513,7 @@ class Server::WorkerService final: public Service,
   kj::Own<const Worker> worker;
   kj::Maybe<kj::HashSet<kj::String>> defaultEntrypointHandlers;
   kj::HashMap<kj::String, kj::HashSet<kj::String>> namedEntrypoints;
+  kj::HashSet<kj::String> actorClassEntrypoints;
   kj::HashMap<kj::StringPtr, kj::Own<ActorNamespace>> actorNamespaces;
   kj::TaskSet waitUntilTasks;
   AbortActorsCallback abortActorsCallback;
@@ -3085,41 +3111,30 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name,
     Server& server;
     kj::StringPtr name;
 
-    kj::HashMap<kj::String, kj::HashSet<kj::String>> namedEntrypoints;
-
     // The `HashSet`s are the set of exported handlers, like `fetch`, `test`, etc.
+    kj::HashMap<kj::String, kj::HashSet<kj::String>> namedEntrypoints;
     kj::Maybe<kj::HashSet<kj::String>> defaultEntrypoint;
+    kj::HashSet<kj::String> actorClasses;
 
     void addError(kj::String error) override {
       server.reportConfigError(kj::str("service ", name, ": ", error));
     }
 
-    void addHandler(kj::Maybe<kj::StringPtr> exportName, kj::StringPtr type) override {
-      kj::HashSet<kj::String>* set;
-      KJ_IF_SOME(e, exportName) {
-        set = &namedEntrypoints.findOrCreate(
-            e, [&]() -> decltype(namedEntrypoints)::Entry { return {kj::str(e), {}}; });
-      } else {
-        set = &defaultEntrypoint.emplace();
+    void addEntrypoint(
+        kj::Maybe<kj::StringPtr> exportName, kj::Array<kj::String> methods) override {
+      kj::HashSet<kj::String> set;
+      for (auto& method: methods) {
+        set.insert(kj::mv(method));
       }
-      set->insert(kj::str(type));
+      KJ_IF_SOME(e, exportName) {
+        namedEntrypoints.insert(kj::str(e), kj::mv(set));
+      } else {
+        defaultEntrypoint = kj::mv(set);
+      }
     }
 
-    void addEmptyExport(kj::Maybe<kj::StringPtr> exportName) override {
-      // Even though the export has no handlers, we want to add it to the namedEntrypoints map,
-      // so that other parts of the config are allowed to refer to this entrypoint. Otherwise,
-      // if anything in the config refers to it, we'll treat the config as invalid. Of course, if
-      // any actual requests are sent to an empty handler, they will fail at runtime.
-      //
-      // The reason we want the config to be considered valid even if it refers to empty
-      // entrypoints is so that it's safe to auto-generate a config that binds every export to
-      // a socket, without checking the types of all the exports. Miniflare does this.
-      KJ_IF_SOME(e, exportName) {
-        namedEntrypoints.findOrCreate(
-            e, [&]() -> decltype(namedEntrypoints)::Entry { return {kj::str(e), {}}; });
-      } else {
-        defaultEntrypoint.emplace();
-      }
+    void addActorClass(kj::StringPtr exportName) override {
+      actorClasses.insert(kj::str(exportName));
     }
   };
 
@@ -3509,7 +3524,8 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name,
 
   return kj::heap<WorkerService>(globalContext->threadContext, kj::mv(worker),
       kj::mv(errorReporter.defaultEntrypoint), kj::mv(errorReporter.namedEntrypoints),
-      localActorConfigs, kj::mv(linkCallback), KJ_BIND_METHOD(*this, abortAllActors));
+      kj::mv(errorReporter.actorClasses), localActorConfigs, kj::mv(linkCallback),
+      KJ_BIND_METHOD(*this, abortAllActors));
 }
 
 // =======================================================================================

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -219,9 +219,8 @@ struct MockErrorReporter final: public Worker::ValidationErrorReporter {
     KJ_FAIL_REQUIRE("unexpected error", error);
   }
 
-  void addHandler(kj::Maybe<kj::StringPtr> exportName, kj::StringPtr type) override {
-    KJ_FAIL_REQUIRE("addHandler not implemented", exportName.orDefault("<empty>"), type);
-  }
+  void addEntrypoint(kj::Maybe<kj::StringPtr> exportName, kj::Array<kj::String> methods) override {}
+  void addActorClass(kj::StringPtr exportName) override {}
 };
 
 inline server::config::Worker::Reader buildConfig(


### PR DESCRIPTION
This interface evolved from early beginnings where we didn't really know where we were going, and as a result was quite warty in the way that it reported entrypoints:
* It would report each _method_ of stateless entrypoints with a separate call, rather than reporting the whole entrypoint at once. All of the implementations had to group these back into entrypoints using HashMaps.
* It reported a Durable Object class as if it were an entrypoint with a single method called "class". This sort of made sense back when there was a fixed list of handler names, but the introduction of RPC made this very weird.

Evidence of why this was a bad interface can be seen in the first commit of this PR, which introduces tests for three different bugs that I discovered just while refactoring this interface.

In any case, this changes the interface to just make sense.