### PR TITLE
Fixes "promise will never complete" when exceeding memory.

### DIFF
--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -125,6 +125,7 @@ wd_cc_library(
         "//src/workerd/jsg",
         "//src/workerd/util:autogate",
         "//src/workerd/util:completion-membrane",
+        "//src/workerd/util:exception",
         "//src/workerd/util:sqlite",
         "//src/workerd/util:thread-scopes",
         "//src/workerd/util:uuid",

--- a/src/workerd/io/limit-enforcer.h
+++ b/src/workerd/io/limit-enforcer.h
@@ -83,6 +83,8 @@ class IsolateLimitEnforcer: public kj::Refcounted {
   virtual size_t getBlobSizeLimit() const {
     return 128 * 1024 * 1024;  // 128 MB
   }
+
+  virtual bool hasExcessivelyExceededHeapLimit() const = 0;
 };
 
 // Abstract interface that enforces resource limits on a IoContext.

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3199,6 +3199,10 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name,
       // No limit on the number of iterations in workerd
       return kj::none;
     }
+
+    bool hasExcessivelyExceededHeapLimit() const override {
+      return false;
+    }
   };
 
   auto jsgobserver = kj::atomicRefcounted<JsgIsolateObserver>();

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -212,6 +212,9 @@ struct MockIsolateLimitEnforcer final: public IsolateLimitEnforcer {
   kj::Maybe<size_t> checkPbkdfIterations(jsg::Lock& lock, size_t iterations) const override {
     return kj::none;
   }
+  bool hasExcessivelyExceededHeapLimit() const override {
+    return false;
+  }
 };
 
 struct MockErrorReporter final: public Worker::ValidationErrorReporter {

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -210,6 +210,13 @@ wd_cc_library(
     deps = ["@capnp-cpp//src/capnp"],
 )
 
+wd_cc_library(
+    name = "exception",
+    hdrs = ["exception.h"],
+    visibility = ["//visibility:public"],
+    deps = ["@capnp-cpp//src/kj"],
+)
+
 exports_files(["autogate.h"])
 
 [

--- a/src/workerd/util/exception.h
+++ b/src/workerd/util/exception.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <kj/exception.h>
+
+namespace workerd {
+
+// If an exception is thrown for exceeding memory limits, it will contain this detail.
+constexpr kj::Exception::DetailTypeId MEMORY_LIMIT_DETAIL_ID = 0xbaf76dd7ce5bd8cfull;
+
+}  // namespace workerd


### PR DESCRIPTION
When we grow WebAssembly memory in a specific way, we can get into a situation where the isolate gets terminated and the termination waiter signal doesn't reach the isolate. This resulted in a promise being rejected with a "Promise will never complete" exception. This PR fixes this so that a more descriptive exception is used.