### PR TITLE
Prevent exception when passing directory instead of file

### DIFF
--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -1094,6 +1094,14 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
     } else {
       // Read file from disk.
       auto path = fs->getCurrentPath().evalNative(pathStr);
+
+      // make sure the path represents a file
+      KJ_IF_SOME(fsMetadata, fs->getRoot().tryLstat(path)) {
+        if (fsMetadata.type != kj::FsNode::Type::FILE) {
+          CLI_ERROR("Path is not a file.");
+        }
+      }
+
       auto file = KJ_UNWRAP_OR(fs->getRoot().tryOpenFile(path), CLI_ERROR("No such file."));
 
       if (binaryConfig) {


### PR DESCRIPTION
If you accidentally pass a directory path instead of a capnp config file to `workerd serve $path` you get an uncaught exception:

```
*** Uncaught exception ***
kj/filesystem-disk-unix.c++:365: failed: mmap: Invalid argument
```

This change adds an assertion that the provided path is a file type. Invoking `workerd serve` with a directory now results in the following error:

```
> workerd serve samples/tail-workers/
workerd serve: samples/tail-workers/: Config path is not a file.
workerd serve --help' for more information.
```