### PR TITLE
Support .tar in Python's loadBundleFromR2.

### DIFF
--- a/src/pyodide/types/disk_cache.d.ts
+++ b/src/pyodide/types/disk_cache.d.ts
@@ -1,5 +1,5 @@
 declare namespace DiskCache {
-  const get: (key: String) => ArrayBuffer;
+  const get: (key: String) => ArrayBuffer | null;
   const put: (key: String, val: ArrayBuffer) => void;
 }
 


### PR DESCRIPTION
This PR improves decompressArrayBuffer so that it:

* detects uncompressed tarballs and doesn't attempt to decompress them again
* throws a good error when the filename points to an unsupported format