### PR TITLE
Remove noisy alarm debug logs

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -518,11 +518,6 @@ kj::Promise<WorkerInterface::AlarmResult> ServiceWorkerGlobalScope::runAlarm(kj:
               // retry forever.
               shouldRetryCountsAgainstLimits = true;
             }
-            // We don't usually log these messages, but it's useful to know the real reason we failed
-            // to correctly investigate stuck alarms.
-            LOG_NOSENTRY(ERROR,
-                "output lock broke after executing alarm without an interesting error description",
-                actorId, e, shouldRetryCountsAgainstLimits);
           }
           return WorkerInterface::AlarmResult{.retry = true,
             .retryCountsAgainstLimit = shouldRetryCountsAgainstLimits,


### PR DESCRIPTION
These logs can became noisy and don't add much at this point. 
This PR removes them