### PR TITLE
Don't hardcode python_workers_development in certain Py wd-tests.

### DIFF
--- a/src/cloudflare/internal/test/ai/python-ai-api-test.wd-test
+++ b/src/cloudflare/internal/test/ai/python-ai-api-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker.py", pythonModule = embed "ai-api-test.py")
         ],
         compatibilityDate = "2023-01-15",
-        compatibilityFlags = ["nodejs_compat", "python_workers_development"],
+        compatibilityFlags = ["nodejs_compat", %PYTHON_FEATURE_FLAGS],
         bindings = [
         (
           name = "ai",

--- a/src/cloudflare/internal/test/aig/python-aig-api-test.wd-test
+++ b/src/cloudflare/internal/test/aig/python-aig-api-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker.py", pythonModule = embed "aig-api-test.py")
         ],
         compatibilityDate = "2023-01-15",
-        compatibilityFlags = ["nodejs_compat", "python_workers_development"],
+        compatibilityFlags = ["nodejs_compat", %PYTHON_FEATURE_FLAGS],
         bindings = [
         (
           name = "ai",

--- a/src/cloudflare/internal/test/br/python-br-api-test.wd-test
+++ b/src/cloudflare/internal/test/br/python-br-api-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker.py", pythonModule = embed "br-api-test.py")
         ],
         compatibilityDate = "2024-06-03",
-        compatibilityFlags = ["nodejs_compat", "python_workers_development"],
+        compatibilityFlags = ["nodejs_compat", %PYTHON_FEATURE_FLAGS],
         bindings = [
         (
           name = "browser",

--- a/src/cloudflare/internal/test/d1/python-d1-api-test.wd-test
+++ b/src/cloudflare/internal/test/d1/python-d1-api-test.wd-test
@@ -9,7 +9,7 @@ const unitTests :Workerd.Config = (
           (name = "worker.py", pythonModule = embed "d1-api-test.py")
         ],
         compatibilityDate = "2023-01-15",
-        compatibilityFlags = ["nodejs_compat", "python_workers_development"],
+        compatibilityFlags = ["nodejs_compat", %PYTHON_FEATURE_FLAGS],
         bindings = [
         (
           name = "d1",

--- a/src/cloudflare/internal/test/vectorize/python-vectorize-api-test.wd-test
+++ b/src/cloudflare/internal/test/vectorize/python-vectorize-api-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           ( name = "worker.py", pythonModule = embed "vectorize-api-test.py" )
         ],
         compatibilityDate = "2023-11-21",
-        compatibilityFlags = ["nodejs_compat", "python_workers_development"],
+        compatibilityFlags = ["nodejs_compat", %PYTHON_FEATURE_FLAGS],
         bindings = [
           ( name = "vectorSearch",
             wrapped = (


### PR DESCRIPTION
This is confusing and means these only ever run under one Python version.