### PR TITLE
Fix issues loading stdlib packages on newer Python versions.

### DIFF
--- a/src/pyodide/internal/loadPackage.ts
+++ b/src/pyodide/internal/loadPackage.ts
@@ -15,6 +15,7 @@ import {
   LOAD_WHEELS_FROM_R2,
   LOAD_WHEELS_FROM_ARTIFACT_BUNDLER,
   PACKAGES_VERSION,
+  USING_OLDEST_PACKAGES_VERSION,
 } from 'pyodide-internal:metadata';
 import {
   SITE_PACKAGES,
@@ -140,8 +141,19 @@ async function loadPackagesImpl(
   Module.FS.mount(tarFS, { info }, path);
 }
 
+/**
+ * Downloads the requirements specified and loads them into Pyodide. Note that this does not
+ * do any dependency resolution, it just installs the requirements that are specified. See
+ * `getTransitiveRequirements` for the code that deals with this.
+ */
 export async function loadPackages(Module: Module, requirements: Set<string>) {
-  const pkgsToLoad = requirements.union(new Set(STDLIB_PACKAGES));
+  let pkgsToLoad = requirements;
+  // TODO: Package snapshot created with '20240829.4' needs the stdlib packages to be added here.
+  // We should remove this check once the next Python and packages versions are rolled
+  // out.
+  if (USING_OLDEST_PACKAGES_VERSION) {
+    pkgsToLoad = pkgsToLoad.union(new Set(STDLIB_PACKAGES));
+  }
   if (LOAD_WHEELS_FROM_R2) {
     await loadPackagesImpl(Module, pkgsToLoad, loadBundleFromR2);
   } else if (LOAD_WHEELS_FROM_ARTIFACT_BUNDLER) {

--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -10,15 +10,15 @@ export const LOAD_WHEELS_FROM_R2: boolean = IS_WORKERD;
 export const LOAD_WHEELS_FROM_ARTIFACT_BUNDLER =
   MetadataReader.shouldUsePackagesInArtifactBundler();
 export const PACKAGES_VERSION = MetadataReader.getPackagesVersion();
+export const USING_OLDEST_PACKAGES_VERSION = PACKAGES_VERSION === '20240829.4';
 // TODO: pyodide-packages.runtime-playground.workers.dev points at a worker which redirects requests
 // to the public R2 bucket URL at pub-45d734c4145d4285b343833ee450ef38.r2.dev. We should remove
 // this worker and point at our prod bucket.
-export const WORKERD_INDEX_URL =
-  PACKAGES_VERSION == '20240829.4'
-    ? 'https://pyodide-packages.runtime-playground.workers.dev/' +
-      PACKAGES_VERSION +
-      '/'
-    : 'https://python-packages.edgeworker.net/' + PACKAGES_VERSION + '/';
+export const WORKERD_INDEX_URL = USING_OLDEST_PACKAGES_VERSION
+  ? 'https://pyodide-packages.runtime-playground.workers.dev/' +
+    PACKAGES_VERSION +
+    '/'
+  : 'https://python-packages.edgeworker.net/' + PACKAGES_VERSION + '/';
 // The package lock is embedded in the binary. See `getPyodideLock` and `packageLocks`.
 export const LOCKFILE: PackageLock = JSON.parse(
   MetadataReader.getPackagesLock()


### PR DESCRIPTION
This fixes two problems:

* the `install_dir` no longer being the source of truth of where a package belongs, now using `package_type`
* dependencies of stdlib packages not being loaded properly