### PR TITLE
Fixes to load dynlib on newer Python versions correctly.

### DIFF
--- a/src/pyodide/BUILD.bazel
+++ b/src/pyodide/BUILD.bazel
@@ -121,6 +121,14 @@ if (typeof FinalizationRegistry === "undefined") {
         unregister(){}
     };
 }
+
+function patchDynlibLookup(Module, libName) {
+    try {
+        return Module.FS.readFile("/usr/lib/" + libName);
+    } catch(e) {
+        console.error("Failed to read ", libName, e);
+    }
+}
 """
 
 REPLACEMENTS = [
@@ -168,6 +176,10 @@ REPLACEMENTS = [
     [
         "eval(UTF8ToString(ptr))",
         "(() => {throw new Error('Internal Emscripten code tried to eval, this should not happen, please file a bug report with your requirements.txt file\\'s contents')})()",
+    ],
+    [
+        "!libData&&flags.fs",
+        "!(libData ??= patchDynlibLookup(Module, libName))&&flags.fs",
     ],
 ]
 

--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -1,6 +1,6 @@
 import { enterJaegerSpan } from 'pyodide-internal:jaeger';
 import {
-  SITE_PACKAGES,
+  VIRTUALIZED_DIR,
   TRANSITIVE_REQUIREMENTS,
   adjustSysPath,
   mountSitePackages,
@@ -80,10 +80,10 @@ export async function loadPyodide(
   Module.setUnsafeEval(UnsafeEval);
   Module.setGetRandomValues(getRandomValues);
 
-  mountSitePackages(Module, SITE_PACKAGES.rootInfo);
+  mountSitePackages(Module, VIRTUALIZED_DIR);
   entropyMountFiles(Module);
   await enterJaegerSpan('load_packages', () =>
-    // NB. loadPackages adds the packages to the `SITE_PACKAGES` global which then gets used in
+    // NB. loadPackages adds the packages to the `VIRTUALIZED_DIR` global which then gets used in
     // preloadDynamicLibs.
     loadPackages(Module, TRANSITIVE_REQUIREMENTS)
   );

--- a/src/pyodide/types/pyodide-lock.d.ts
+++ b/src/pyodide/types/pyodide-lock.d.ts
@@ -1,8 +1,9 @@
+type InstallDir = 'site' | 'stdlib' | 'dynlib';
 interface PackageDeclaration {
   depends: string[];
   file_name: string;
   imports: string[];
-  install_dir: 'site' | 'stdlib';
+  install_dir: InstallDir;
   name: string;
   package_type: string;
   sha256: string;


### PR DESCRIPTION
While working on https://github.com/cloudflare/workerd/pull/3451 I ran into issues with the newer Python version and package bundle. libssl is now expecting libcrypto and other dynlibs to be present in /usr/lib/ so we need to overlay the openssl tarball in that directory, this is what this PR implements.