### PR TITLE
Implement Request.signal to detect client disconnects

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -666,3 +666,9 @@ wd_test(
     args = ["--experimental"],
     data = ["tests/disable-importable-env-test.js"],
 )
+
+wd_test(
+    src = "tests/request-client-disconnect.wd-test",
+    args = ["--experimental"],
+    data = ["tests/request-client-disconnect.js"],
+)

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -511,7 +511,7 @@ class EventTarget: public jsg::Object {
 // An implementation of the Web Platform Standard AbortSignal API
 class AbortSignal final: public EventTarget {
  public:
-  enum class Flag { NONE, NEVER_ABORTS };
+  enum class Flag { NONE, NEVER_ABORTS, IGNORE_FOR_SUBREQUESTS };
 
   AbortSignal(kj::Maybe<kj::Exception> exception = kj::none,
       jsg::Optional<jsg::JsRef<jsg::JsValue>> maybeReason = kj::none,
@@ -602,9 +602,14 @@ class AbortSignal final: public EventTarget {
     tracker.trackField("reason", reason);
   }
 
+  bool isIgnoredForSubrequests() const {
+    return flag == Flag::IGNORE_FOR_SUBREQUESTS;
+  }
+
  private:
   IoOwn<RefcountedCanceler> canceler;
   Flag flag;
+
   kj::Maybe<jsg::JsRef<jsg::JsValue>> reason;
   kj::Maybe<jsg::JsRef<jsg::JsValue>> onAbortHandler;
 
@@ -616,7 +621,9 @@ class AbortSignal final: public EventTarget {
 // An implementation of the Web Platform Standard AbortController API
 class AbortController final: public jsg::Object {
  public:
-  explicit AbortController(): signal(jsg::alloc<AbortSignal>()) {}
+  explicit AbortController(AbortSignal::Flag abortSignalFlag = AbortSignal::Flag::NONE)
+      : signal(jsg::alloc<AbortSignal>(
+            kj::none /* exception */, kj::none /* maybeReason */, abortSignalFlag)) {}
 
   static jsg::Ref<AbortController> constructor() {
     return jsg::alloc<AbortController>();

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -458,7 +458,8 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
       kj::HttpService::Response& response,
       kj::Maybe<kj::StringPtr> cfBlobJson,
       Worker::Lock& lock,
-      kj::Maybe<ExportedHandler&> exportedHandler);
+      kj::Maybe<ExportedHandler&> exportedHandler,
+      kj::Maybe<jsg::Ref<AbortSignal>> abortSignal);
   // TODO(cleanup): Factor out the shared code used between old-style event listeners vs. module
   //   exports and move that code somewhere more appropriate.
 

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1051,6 +1051,7 @@ jsg::Ref<Request> Request::constructor(
           // explicitly say `signal: null`, they must want to drop the signal that was on the
           // original request.
           signal = kj::mv(s);
+          initDict.signal = kj::none;
         }
 
         KJ_IF_SOME(newCf, initDict.cf) {

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -995,7 +995,7 @@ jsg::Ref<Request> Request::constructor(
       cacheMode = oldRequest->getCacheMode();
       redirect = oldRequest->getRedirectEnum();
       fetcher = oldRequest->getFetcher();
-      signal = oldRequest->getSignal();
+      signal = oldRequest->getThisSignal();
     }
   }
 
@@ -1093,7 +1093,7 @@ jsg::Ref<Request> Request::constructor(
         redirect = otherRequest->redirect;
         cacheMode = otherRequest->cacheMode;
         fetcher = otherRequest->getFetcher();
-        signal = otherRequest->getSignal();
+        signal = otherRequest->getThisSignal();
         headers = jsg::alloc<Headers>(*otherRequest->headers);
         cf = otherRequest->cf.deepClone(js);
         KJ_IF_SOME(b, otherRequest->getBody()) {
@@ -1112,7 +1112,8 @@ jsg::Ref<Request> Request::constructor(
 
   // TODO(conform): If `init` has a keepalive flag, pass it to the Body constructor.
   return jsg::alloc<Request>(method, url, redirect, KJ_ASSERT_NONNULL(kj::mv(headers)),
-      kj::mv(fetcher), kj::mv(signal), kj::mv(cf), kj::mv(body), cacheMode);
+      kj::mv(fetcher), kj::mv(signal), kj::mv(cf), kj::mv(body), /* thisSignal */ kj::none,
+      cacheMode);
 }
 
 jsg::Ref<Request> Request::clone(jsg::Lock& js) {
@@ -1121,8 +1122,13 @@ jsg::Ref<Request> Request::clone(jsg::Lock& js) {
   auto cfClone = cf.deepClone(js);
   auto bodyClone = Body::clone(js);
 
-  return jsg::alloc<Request>(method, url, redirect, kj::mv(headersClone), getFetcher(), getSignal(),
-      kj::mv(cfClone), kj::mv(bodyClone));
+  return jsg::alloc<Request>(method, url, redirect, kj::mv(headersClone), getFetcher(),
+      /* signal */ getThisSignal(), kj::mv(cfClone), kj::mv(bodyClone), /* thisSignal */ kj::none);
+
+  // signal
+  //-------
+  // The fetch spec states: "Let clonedSignal be the result of creating a dependent abort signal
+  // from « this’s signal », using AbortSignal and this’s relevant realm."
 }
 
 kj::StringPtr Request::getMethod() {
@@ -1166,7 +1172,7 @@ jsg::Optional<jsg::JsObject> Request::getCf(jsg::Lock& js) {
 // that's a bit silly and unnecessary.
 // The name "thisSignal" is derived from the fetch spec, which draws a
 // distinction between the "signal" and "this' signal".
-jsg::Ref<AbortSignal> Request::getThisSignal(jsg::Lock& js) {
+jsg::Ref<AbortSignal> Request::getThisSignal() {
   KJ_IF_SOME(s, signal) {
     return s.addRef();
   }
@@ -1176,6 +1182,14 @@ jsg::Ref<AbortSignal> Request::getThisSignal(jsg::Lock& js) {
   auto newSignal = jsg::alloc<AbortSignal>(kj::none, kj::none, AbortSignal::Flag::NEVER_ABORTS);
   thisSignal = newSignal.addRef();
   return newSignal;
+}
+
+void Request::clearSignalIfIgnoredForSubrequest() {
+  KJ_IF_SOME(s, signal) {
+    if (s->isIgnoredForSubrequests()) {
+      signal = kj::none;
+    }
+  }
 }
 
 kj::Maybe<Request::Redirect> Request::tryParseRedirect(kj::StringPtr redirect) {
@@ -2218,6 +2232,11 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(jsg::Lock& js,
     // We could emulate these behaviors with various hacks, but just reconstructing the request up
     // front is robust, and won't add significant overhead compared to the rest of fetch().
     auto jsRequest = Request::constructor(js, kj::mv(requestOrUrl), kj::mv(requestInit));
+
+    // Clear the request's signal if the 'ignoreForSubrequests' flag is set. This happens when
+    // a request from an incoming fetch is passed-through to another fetch. We want to avoid
+    // aborting the subrequest in that case.
+    jsRequest->clearSignalIfIgnoredForSubrequest();
 
     // This URL list keeps track of redirections and becomes a source for Response's URL list. The
     // first URL in the list is the Request's URL (visible to JS via Request::getUrl()). The last URL

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -777,7 +777,8 @@ public:
   Request(kj::HttpMethod method, kj::StringPtr url, Redirect redirect,
           jsg::Ref<Headers> headers, kj::Maybe<jsg::Ref<Fetcher>> fetcher,
           kj::Maybe<jsg::Ref<AbortSignal>> signal, CfProperty&& cf,
-          kj::Maybe<Body::ExtractedBody> body, CacheMode cacheMode = CacheMode::NONE)
+          kj::Maybe<Body::ExtractedBody> body, kj::Maybe<jsg::Ref<AbortSignal>> thisSignal,
+          CacheMode cacheMode = CacheMode::NONE)
     : Body(kj::mv(body), *headers), method(method), url(kj::str(url)),
       redirect(redirect), headers(kj::mv(headers)), fetcher(kj::mv(fetcher)),
       cacheMode(cacheMode), cf(kj::mv(cf)) {
@@ -790,6 +791,10 @@ public:
       } else {
         this->signal = kj::mv(s);
       }
+    }
+
+    KJ_IF_SOME(s, thisSignal) {
+      this->thisSignal = kj::mv(s);
     }
   }
   // TODO(conform): Technically, the request's URL should be parsed immediately upon Request
@@ -842,8 +847,12 @@ public:
   // request.signal to always return an AbortSignal even if one is not actively
   // used on this request.
   kj::Maybe<jsg::Ref<AbortSignal>> getSignal();
+  jsg::Ref<AbortSignal> getThisSignal();
 
-  jsg::Ref<AbortSignal> getThisSignal(jsg::Lock& js);
+  // Clear the request's signal if the 'ignoreForSubrequests' flag is set. This happens when
+  // a request from an incoming fetch is passed-through to another fetch. We want to avoid
+  // aborting the subrequest in that case.
+  void clearSignalIfIgnoredForSubrequest();
 
   // Returns the `cf` field containing Cloudflare feature flags.
   jsg::Optional<jsg::JsObject> getCf(jsg::Lock& js);

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -787,14 +787,14 @@ public:
       // that the cancel machinery is not used but the request.signal accessor will still
       // do the right thing.
       if (s->getNeverAborts()) {
-        this->thisSignal = kj::mv(s);
+        this->thisSignal = s.addRef();
       } else {
-        this->signal = kj::mv(s);
+        this->signal = s.addRef();
       }
     }
 
     KJ_IF_SOME(s, thisSignal) {
-      this->thisSignal = kj::mv(s);
+      this->thisSignal = s.addRef();
     }
   }
   // TODO(conform): Technically, the request's URL should be parsed immediately upon Request

--- a/src/workerd/api/tests/request-client-disconnect.js
+++ b/src/workerd/api/tests/request-client-disconnect.js
@@ -1,0 +1,187 @@
+import { DurableObject, WorkerEntrypoint } from 'cloudflare:workers';
+import assert from 'node:assert';
+
+export class AbortTracker extends DurableObject {
+  async getAborted(key) {
+    return this.ctx.storage.get(key);
+  }
+  async setAborted(key, value) {
+    await this.ctx.storage.put(key, value);
+  }
+}
+export class OtherServer extends WorkerEntrypoint {
+  async fetch() {
+    await scheduler.wait(300);
+    return new Response('completed');
+  }
+}
+
+export class Server extends WorkerEntrypoint {
+  async fetch(req) {
+    const key = new URL(req.url).pathname.slice(1);
+    let abortTracker = this.env.AbortTracker.get(
+      this.env.AbortTracker.idFromName('AbortTracker')
+    );
+    await abortTracker.setAborted(key, false);
+
+    req.signal.onabort = () => {
+      this.ctx.waitUntil(abortTracker.setAborted(key, true));
+    };
+
+    return this[key](req);
+  }
+
+  async valid() {
+    return new Response('hello world');
+  }
+
+  async error() {
+    throw new Error('boom');
+  }
+
+  async hang() {
+    for (;;) {
+      await scheduler.wait(86400);
+    }
+  }
+
+  async hangAfterSendingSomeData() {
+    const { readable, writable } = new IdentityTransformStream();
+    this.ctx.waitUntil(this.sendSomeData(writable));
+
+    return new Response(readable);
+  }
+
+  async sendSomeData(writable) {
+    const writer = writable.getWriter();
+    const enc = new TextEncoder();
+    await writer.write(enc.encode('hello world'));
+    await this.hang();
+  }
+
+  async triggerSubrequest(req) {
+    this.ctx.waitUntil(this.callOtherServer(req));
+    await this.hang();
+  }
+
+  async callOtherServer(req) {
+    const key = 'subrequest';
+
+    let abortTracker = this.env.AbortTracker.get(
+      this.env.AbortTracker.idFromName('AbortTracker')
+    );
+
+    const passedThroughReq = new Request(req);
+    passedThroughReq.onabort = () => {
+      this.ctx.waitUntil(abortTracker.setAborted(key, true));
+    };
+
+    const res = await this.env.OtherServer.fetch(passedThroughReq);
+    const text = await res.text();
+
+    if (text == 'completed') {
+      await abortTracker.setAborted(key, false);
+    }
+  }
+}
+
+export const noAbortOnSimpleResponse = {
+  async test(ctrl, env, ctx) {
+    let abortTracker = env.AbortTracker.get(
+      env.AbortTracker.idFromName('AbortTracker')
+    );
+
+    const req = env.Server.fetch('http://example.com/valid');
+
+    const res = await req;
+    assert.strictEqual(await res.text(), 'hello world');
+    assert.strictEqual(await abortTracker.getAborted('valid'), false);
+  },
+};
+
+export const noAbortIfServerThrows = {
+  async test(ctrl, env, ctx) {
+    let abortTracker = env.AbortTracker.get(
+      env.AbortTracker.idFromName('AbortTracker')
+    );
+
+    const req = env.Server.fetch('http://example.com/error');
+
+    await assert.rejects(() => req, { name: 'Error', message: 'boom' });
+    assert.strictEqual(await abortTracker.getAborted('error'), false);
+  },
+};
+
+export const abortIfClientAbandonsRequest = {
+  async test(ctrl, env, ctx) {
+    let abortTracker = env.AbortTracker.get(
+      env.AbortTracker.idFromName('AbortTracker')
+    );
+
+    // This endpoint never generates a response, so we can timeout after an arbitrary time.
+    const req = env.Server.fetch('http://example.com/hang', {
+      signal: AbortSignal.timeout(500),
+    });
+
+    await assert.rejects(() => req, {
+      name: 'TimeoutError',
+      message: 'The operation was aborted due to timeout',
+    });
+    assert.strictEqual(await abortTracker.getAborted('hang'), true);
+  },
+};
+
+export const abortIfClientCancelsReadingResponse = {
+  async test(ctrl, env, ctx) {
+    let abortTracker = env.AbortTracker.get(
+      env.AbortTracker.idFromName('AbortTracker')
+    );
+
+    // This endpoint begins generating a response but then hangs
+    const req = env.Server.fetch('http://example.com/hangAfterSendingSomeData');
+    const res = await req;
+    const reader = res.body.getReader();
+
+    const { value, done } = await reader.read();
+    assert.strictEqual(new TextDecoder().decode(value), 'hello world');
+    assert.ok(!done);
+
+    // Give up reading
+    await reader.cancel();
+
+    // Waste a bit of time so the server cleans up
+    await scheduler.wait(0);
+
+    assert.strictEqual(
+      await abortTracker.getAborted('hangAfterSendingSomeData'),
+      true
+    );
+  },
+};
+
+export const abortedRequestDoesNotAbortSubrequest = {
+  async test(ctrl, env, ctx) {
+    let abortTracker = env.AbortTracker.get(
+      env.AbortTracker.idFromName('AbortTracker')
+    );
+
+    // This endpoint calls another endpoint that eventually completes after wasting 300 ms
+    // So, we abort the initial request quickly...
+    const req = env.Server.fetch('http://example.com/triggerSubrequest', {
+      signal: AbortSignal.timeout(100),
+    });
+
+    await assert.rejects(() => req, {
+      name: 'TimeoutError',
+      message: 'The operation was aborted due to timeout',
+    });
+    assert.strictEqual(
+      await abortTracker.getAborted('triggerSubrequest'),
+      true
+    );
+
+    // Then make sure that the subrequest wasn't also aborted
+    await scheduler.wait(500);
+    assert.strictEqual(await abortTracker.getAborted('subrequest'), false);
+  },
+};

--- a/src/workerd/api/tests/request-client-disconnect.wd-test
+++ b/src/workerd/api/tests/request-client-disconnect.wd-test
@@ -1,0 +1,26 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "request-client-disconnect",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "request-client-disconnect.js" )
+        ],
+        compatibilityDate = "2025-01-01",
+        compatibilityFlags = ["nodejs_compat", "experimental"],
+        durableObjectNamespaces = [
+          (className = "AbortTracker", uniqueKey = "badbeef"),
+        ],
+        durableObjectStorage = (inMemory = void),
+        bindings = [
+          (name = "AbortTracker", durableObjectNamespace = "AbortTracker"),
+          (name = "OtherServer", service = (name = "request-client-disconnect", entrypoint = "OtherServer")),
+          (name = "Server", service = (name = "request-client-disconnect", entrypoint = "Server")),
+          (name = "defaultExport", service = "request-client-disconnect"),
+        ]
+      )
+    )
+  ]
+);
+

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -4,6 +4,7 @@
 
 #include "worker-entrypoint.h"
 
+#include <workerd/api/basics.h>
 #include <workerd/api/global-scope.h>
 #include <workerd/api/util.h>
 #include <workerd/io/io-context.h>
@@ -92,6 +93,7 @@ class WorkerEntrypoint final: public WorkerInterface {
   kj::Maybe<kj::Promise<void>> proxyTask;
   kj::Maybe<kj::Own<WorkerInterface>> failOpenService;
   bool loggedExceptionEarlier = false;
+  kj::Maybe<jsg::Ref<api::AbortController>> abortController;
 
   void init(kj::Own<const Worker> worker,
       kj::Maybe<kj::Own<Worker::Actor>> actor,
@@ -324,10 +326,14 @@ kj::Promise<void> WorkerEntrypoint::request(kj::HttpMethod method,
     TRACE_EVENT_END("workerd", PERFETTO_TRACK_FROM_POINTER(&context));
     TRACE_EVENT("workerd", "WorkerEntrypoint::request() run", PERFETTO_FLOW_FROM_POINTER(this));
     jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+    jsg::Ref<api::AbortSignal> signal = abortController
+                                            .emplace(jsg::alloc<api::AbortController>(
+                                                api::AbortSignal::Flag::IGNORE_FOR_SUBREQUESTS))
+                                            ->getSignal();
 
     return lock.getGlobalScope().request(method, url, headers, requestBody, wrappedResponse,
         cfBlobJson, lock,
-        lock.getExportedHandler(entrypointName, kj::mv(props), context.getActor()));
+        lock.getExportedHandler(entrypointName, kj::mv(props), context.getActor()), kj::mv(signal));
   })
       .then([this](api::DeferredProxy<void> deferredProxy) {
     TRACE_EVENT("workerd", "WorkerEntrypoint::request() deferred proxy step",
@@ -365,6 +371,23 @@ kj::Promise<void> WorkerEntrypoint::request(kj::HttpMethod method,
       failOpenService = context.getSubrequestChannelNoChecks(
           IoContext::NEXT_CLIENT_CHANNEL, false, kj::mv(cfBlobJson));
     }
+
+    if (proxyTask == kj::none && !loggedExceptionEarlier) {
+      // When the client disconnects, trigger an abort on request.signal, unless the request has
+      // already completed normally, or failed with an exception.
+
+      // TODO(perf): Don't add a task to trigger the abort unless we know it has at least one
+      // listener.
+      KJ_IF_SOME(ctrl, abortController) {
+        context.addWaitUntil(context.run(
+            [ctrl = kj::mv(ctrl)](Worker::Lock& lock) mutable { ctrl->abort(lock, kj::none); }));
+      }
+    }
+
+    // Release reference to the AbortController.
+    // Either the waitUntilTask holds a reference to it, or it will never be triggered at all.
+    abortController = kj::none;
+
     auto promise =
         incomingRequest->drain().attach(kj::mv(incomingRequest).attach(kj::mv(outcomeObserver)));
     waitUntilTasks.add(maybeAddGcPassForTest(context, kj::mv(promise)));

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -380,7 +380,7 @@ kj::Promise<void> WorkerEntrypoint::request(kj::HttpMethod method,
       // listener.
       KJ_IF_SOME(ctrl, abortController) {
         context.addWaitUntil(context.run(
-            [ctrl = kj::mv(ctrl)](Worker::Lock& lock) mutable { ctrl->abort(lock, kj::none); }));
+            [ctrl = ctrl.addRef()](Worker::Lock& lock) mutable { ctrl->abort(lock, kj::none); }));
       }
     }
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1929,6 +1929,9 @@ class Server::WorkerService final: public Service,
   }
 
   void unlink() override {
+    // Need to remove all waited until tasks before destroying `ioChannels`
+    waitUntilTasks.clear();
+
     // Need to tear down all actors before tearing down `ioChannels.actorStorage`.
     actorNamespaces.clear();
 

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -427,7 +427,7 @@ TestFixture::Response TestFixture::runRequest(
   runInIoContext([&](const TestFixture::Environment& env) {
     auto& globalScope = env.lock.getGlobalScope();
     return globalScope.request(method, url, requestHeaders, *requestBody, response, "{}"_kj,
-        env.lock, env.lock.getExportedHandler(kj::none, {}, kj::none));
+        env.lock, env.lock.getExportedHandler(kj::none, {}, kj::none), /* abortSignal */ kj::none);
   });
 
   return {.statusCode = response.statusCode, .body = response.body->str()};


### PR DESCRIPTION
How it works:
- An AbortController is added as a member of WorkerEntrypoint. 
- Its AbortSignal is passed through via ServiceWorkerGlobalScope and Request through to JS, so it can be accessed via `Request.signal`.
- If the client disconnects, and we've both not produced a response or thrown an exception, the AbortSignal is triggered.