### PR TITLE
Check HTTP status code when fetching Py pkg/bundle.

### DIFF
--- a/src/pyodide/internal/loadPackage.ts
+++ b/src/pyodide/internal/loadPackage.ts
@@ -58,6 +58,14 @@ async function loadBundleFromR2(requirement: string): Promise<Reader> {
     // we didn't find it in the disk cache, continue with original fetch
     const url = new URL(WORKERD_INDEX_URL + filename);
     const response = await fetch(url);
+    if (response.status != 200) {
+      throw new Error(
+        'Could not fetch package at url ' +
+          url +
+          ' received status ' +
+          response.status
+      );
+    }
 
     original = await response.arrayBuffer();
     DiskCache.put(filename, original);


### PR DESCRIPTION
We've seen some flaky test failures which seem to be caused by a failure to fetch these. Let's add better errors to see what status codes are actually returned.

If we see 429s we'll implement retry logic in a separate PR.