### PR TITLE
Enable use_plus_in_repo_names for common options

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,6 +13,10 @@ build --test_timeout=1,15,60,240
 # Not using bzlmod for dependencies yet
 common --noenable_bzlmod
 
+# Use plus in repo names for Bazel 7 as long as it's used to address some resolution issues
+# Bazel 8 brings this behavior by default and this line can be removed after Bazel upgrade.
+common --incompatible_use_plus_in_repo_names
+
 # bazel7 enables Build without the Bytes (BwoB) by default. This significantly speeds up builds
 # using the remote cache since less data needs to be fetched. Set remote_cache_eviction_retries
 # which is required to fully support a "dumb" cache. Bazel 8 already sets this value by default.


### PR DESCRIPTION
Bazel 7 uses ~ in external repo names and it leads to various issues like bazelbuild/bazel#23127 or some tools consider such paths as ignored because tilde could mean a backup copy of the file. Bazel 8 addresses these issues with use of + by default, but Bazel 7 must be supplied with an incompatible argument to enable this behavior