### PR TITLE
Make sure we don't import pyodide into memory snapshot.

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -22,6 +22,7 @@ select = [
 ]
 ignore = [
   "E402",  # module import not at top of file
+  "E501", # line too long
   "PLR0912", # too many branches
   "PLR0915", # too many statements
   "PLR2004", # Magic value used in comparison

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -66,3 +66,12 @@ py_wd_test(
         "0.27.1",
     ],
 )
+
+py_wd_test(
+    "dont-snapshot-pyodide",
+    # TODO: Requires a new bundle deploy
+    skip_python_flags = [
+        "0.26.0a2",
+        "0.27.1",
+    ],
+)

--- a/src/workerd/server/tests/python/dont-snapshot-pyodide/dont-snapshot-pyodide.wd-test
+++ b/src/workerd/server/tests/python/dont-snapshot-pyodide/dont-snapshot-pyodide.wd-test
@@ -1,0 +1,16 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "dont-snapshot-pyodide",
+      worker = (
+        modules = [
+          (name = "worker.py", pythonModule = embed "worker.py"),
+          (name = "numpy", pythonRequirement = "")
+        ],
+        compatibilityDate = "2024-01-15",
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+      )
+    ),
+  ],
+);

--- a/src/workerd/server/tests/python/dont-snapshot-pyodide/worker.py
+++ b/src/workerd/server/tests/python/dont-snapshot-pyodide/worker.py
@@ -1,0 +1,22 @@
+"""
+To trigger the bug we need to do two things:
+1. import `pyodide` at top level
+2. ensure that there is some package requirement in wd-test
+3. make test() async
+
+Importing numpy isn't really necessary but we need to include it as a requirement in the wd-test
+file so that we consider making a package snapshot. In the buggy code, importing pyodide at top
+level then makes the package snapshot import pyodide while making the snapshot. Importing pyodide
+before calling finalizeBootstrap messes up the runtime state and causes various weird and malign
+symptoms.
+"""
+
+import numpy
+
+import pyodide
+
+
+async def test():
+    # Mention imports so that ruff won't remove them
+    pyodide  # noqa: B018
+    numpy  # noqa: B018


### PR DESCRIPTION
Importing pyodide before `finalizeBootstrap()` is called causes mayhem.