### PR TITLE
fix(vectorize): add missing metadata filter operations

### DIFF
--- a/src/cloudflare/internal/vectorize.d.ts
+++ b/src/cloudflare/internal/vectorize.d.ts
@@ -36,6 +36,8 @@ interface VectorizeError {
 type VectorizeVectorMetadataFilterOp =
   | '$eq'
   | '$ne'
+  | '$in'
+  | '$nin'
   | '$lt'
   | '$lte'
   | '$gt'

--- a/types/defines/vectorize.d.ts
+++ b/types/defines/vectorize.d.ts
@@ -25,7 +25,13 @@ interface VectorizeError {
  *
  * This list is expected to grow as support for more operations are released.
  */
-type VectorizeVectorMetadataFilterOp = "$eq" | "$ne";
+type VectorizeVectorMetadataFilterOp =
+  | '$eq'
+  | '$ne'
+  | '$lt'
+  | '$lte'
+  | '$gt'
+  | '$gte';
 
 /**
  * Filter criteria for vector metadata used to limit the retrieved query result set.

--- a/types/defines/vectorize.d.ts
+++ b/types/defines/vectorize.d.ts
@@ -28,6 +28,8 @@ interface VectorizeError {
 type VectorizeVectorMetadataFilterOp =
   | '$eq'
   | '$ne'
+  | '$in'
+  | '$nin'
   | '$lt'
   | '$lte'
   | '$gt'


### PR DESCRIPTION
Adds the missing Vectorize metadata filter operations, as documented here: https://developers.cloudflare.com/vectorize/reference/metadata-filtering/#supported-operations