### PR TITLE
Cleanup some stuff accidentally commited in #3499

### DIFF
--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -340,7 +340,6 @@ kj::Array<kj::String> ArtifactBundler::filterPythonScriptImports(
   for (auto& pkgImport: ArtifactBundler::getSnapshotImports()) {
     baselineSnapshotImportsSet.insert(kj::mv(pkgImport));
   }
-  // baselineSnapshotImportsSet.insertAll(kj::mv(ArtifactBundler::getSnapshotImports()));
 
   kj::HashSet<kj::String> filteredImportsSet;
   filteredImportsSet.reserve(imports.size());

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -67,11 +67,4 @@ py_wd_test(
     ],
 )
 
-py_wd_test(
-    "dont-snapshot-pyodide",
-    # TODO: Requires a new bundle deploy
-    skip_python_flags = [
-        "0.26.0a2",
-        "0.27.1",
-    ],
-)
+py_wd_test("dont-snapshot-pyodide")


### PR DESCRIPTION
cc @danlapid. If you want I can turn the ruff "line too long" lint back on, but it is common to disable this because ruff also comes with a formatter that itself wraps long lines and does not always agree with the ruff linter about when a line should be wrapped.