### PR TITLE
rust-python-parser tidy up

### DIFF
--- a/src/rust/python-parser/BUILD
+++ b/src/rust/python-parser/BUILD
@@ -1,18 +1,35 @@
 load("//:build/kj_test.bzl", "kj_test")
+load("//:build/wd_cc_library.bzl", "wd_cc_library")
 load("//:build/wd_rust_crate.bzl", "rust_cxx_include", "wd_rust_crate")
+
+wd_cc_library(
+    name = "cxx-bridge",
+    srcs = [
+        "cxx-bridge.c++",
+    ],
+    hdrs = [
+        "cxx-bridge.h",
+    ],
+    linkstatic = True,
+    deps = [
+        "//src/rust/cxx-integration",
+        "@capnp-cpp//src/kj",
+    ],
+)
 
 wd_rust_crate(
     name = "python-parser",
     cxx_bridge_src = "lib.rs",
     visibility = ["//visibility:public"],
     deps = [
+        ":cxx-bridge",
         "@crates_vendor//:ruff_python_ast",
         "@crates_vendor//:ruff_python_parser",
     ],
 )
 
 kj_test(
-    src = "import_parsing.c++",
+    src = "import-parsing-test.c++",
     deps = [
         ":python-parser",
         "//deps/rust:runtime",

--- a/src/rust/python-parser/cxx-bridge.c++
+++ b/src/rust/python-parser/cxx-bridge.c++
@@ -1,0 +1,26 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// #include <workerd/rust/python-parser/lib.rs.h>
+#include "workerd/rust/cxx-integration/lib.rs.h"
+
+#include <kj/test.h>
+
+namespace workerd::rust::python_parser {
+  ::rust::Vec<::rust::String> get_imports(::rust::Slice<::rust::Str const> sources);
+}
+
+using ::workerd::rust::python_parser::get_imports;
+
+namespace workerd::api::pyodide {
+  kj::Array<kj::String> parseImports(kj::ArrayPtr<kj::StringPtr> cpp_modules) {
+    auto rust_modules = kj::heapArrayBuilder<::rust::Str const>(cpp_modules.size());
+    for (auto& entry: cpp_modules) {
+      rust_modules.add(entry.cStr());
+    }
+    ::rust::Slice<::rust::Str const> rust_slice(rust_modules.begin(), rust_modules.size());
+    auto rust_result = get_imports(rust_slice);
+    return workerd::fromRust(rust_result);
+  }
+}

--- a/src/rust/python-parser/cxx-bridge.h
+++ b/src/rust/python-parser/cxx-bridge.h
@@ -1,0 +1,5 @@
+#include "kj/string.h"
+
+namespace workerd::api::pyodide {
+  kj::Array<kj::String> parseImports(kj::ArrayPtr<kj::StringPtr> cpp_modules);
+}

--- a/src/rust/python-parser/import-parsing-test.c++
+++ b/src/rust/python-parser/import-parsing-test.c++
@@ -1,25 +1,7 @@
-// Copyright (c) 2017-2022 Cloudflare, Inc.
-// Licensed under the Apache 2.0 license found in the LICENSE file or at:
-//     https://opensource.org/licenses/Apache-2.0
+#include "import_parsing.h"
+#include "kj/test.h"
 
-#include <workerd/rust/python-parser/lib.rs.h>
-#include "workerd/rust/cxx-integration/lib.rs.h"
-
-#include <kj/test.h>
-
-using ::edgeworker::rust::python_parser::get_imports;
-
-kj::Array<kj::String> parseImports(kj::ArrayPtr<kj::StringPtr> cpp_modules) {
-  auto rust_modules = kj::heapArrayBuilder<::rust::Str const>(cpp_modules.size());
-  for (auto& entry: cpp_modules) {
-    rust_modules.add(entry.cStr());
-  }
-  ::rust::Slice<::rust::Str const> rust_slice(rust_modules.begin(), rust_modules.size());
-  auto rust_result = get_imports(rust_slice);
-  return workerd::fromRust(rust_result);
-}
-
-namespace workerd::api {
+namespace workerd::api::pyodide {
 namespace {
 
 KJ_TEST("basic `import` tests") {

--- a/src/rust/python-parser/lib.rs
+++ b/src/rust/python-parser/lib.rs
@@ -3,9 +3,8 @@ use std::collections::HashSet;
 use ruff_python_ast::{Stmt, StmtImportFrom};
 use ruff_python_parser::parse_module;
 
-#[cxx::bridge(namespace = "edgeworker::rust::python_parser")]
+#[cxx::bridge(namespace = "workerd::rust::python_parser")]
 mod ffi {
-
     extern "Rust" {
         fn get_imports(sources: &[&str]) -> Vec<String>;
     }


### PR DESCRIPTION
1. Tests move into a different compilation unit from logic
2. Put the `parseImports` function into the same statib library as the rust objects.