### PR TITLE
Extend D1 binding tests with extra fields added soon

### DIFF
--- a/src/cloudflare/internal/test/d1/d1-api-test-common.js
+++ b/src/cloudflare/internal/test/d1/d1-api-test-common.js
@@ -47,6 +47,9 @@ export const itShould = async (description, ...assertions) => {
 const meta = (values) => ({
   duration: anything,
   served_by: anything,
+  served_by_primary: anything,
+  served_by_region: anything,
+  timings: anything,
   changes: anything,
   last_row_id: anything,
   changed_db: anything,


### PR DESCRIPTION
New fields added to the D1 query responses, so adjust the tests to not fail because of the extra fields since we are using `assert.deepEqual` from `node:assert`.

Since we are running these tests in our internal CI, we don't want them to fail with the new fields.