### PR TITLE
Test filterPythonScriptImports and fix some problems

### DIFF
--- a/src/workerd/api/pyodide/pyodide-test.c++
+++ b/src/workerd/api/pyodide/pyodide-test.c++
@@ -196,5 +196,57 @@ w["h
   KJ_REQUIRE(result.size() == 0);
 }
 
+using pyodide::ArtifactBundler;
+
+template <typename... Params>
+kj::Array<kj::String> strArray(Params&&... params) {
+  return kj::arr(kj::str(params)...);
+}
+
+KJ_TEST("Simple pass through") {
+  auto imports = strArray("b", "c");
+  auto result = ArtifactBundler::filterPythonScriptImportsJs({}, kj::mv(imports));
+  KJ_REQUIRE(result.size() == 2);
+  KJ_REQUIRE(result[0] == "b");
+  KJ_REQUIRE(result[1] == "c");
+}
+
+KJ_TEST("pyodide and submodules") {
+  auto imports = strArray("pyodide", "pyodide.ffi");
+  auto result = ArtifactBundler::filterPythonScriptImportsJs({}, kj::mv(imports));
+  KJ_REQUIRE(result.size() == 0);
+}
+
+KJ_TEST("js and submodules") {
+  auto imports = strArray("js", "js.crypto");
+  auto result = ArtifactBundler::filterPythonScriptImportsJs({}, kj::mv(imports));
+  KJ_REQUIRE(result.size() == 0);
+}
+
+KJ_TEST("importlib and submodules") {
+  // importlib and importlib.metadata are imported into the baseline snapshot, but importlib.resources is not.
+  auto imports = strArray("importlib", "importlib.metadata", "importlib.resources");
+  auto result = ArtifactBundler::filterPythonScriptImportsJs({}, kj::mv(imports));
+  KJ_REQUIRE(result.size() == 1);
+  KJ_REQUIRE(result[0] == "importlib.resources");
+}
+
+KJ_TEST("Filter worker .py files") {
+  auto workerModules = strArray("b.py", "c.py");
+  auto imports = strArray("b", "c", "d");
+  auto result =
+      ArtifactBundler::filterPythonScriptImportsJs(kj::mv(workerModules), kj::mv(imports));
+  KJ_REQUIRE(result.size() == 1);
+  KJ_REQUIRE(result[0] == "d");
+}
+
+KJ_TEST("Filter worker module/__init__.py") {
+  auto workerModules = strArray("a/__init__.py", "b/__init__.py", "c/a.py");
+  auto imports = strArray("a", "b", "c");
+  auto result =
+      ArtifactBundler::filterPythonScriptImportsJs(kj::mv(workerModules), kj::mv(imports));
+  KJ_REQUIRE(result.size() == 1);
+  KJ_REQUIRE(result[0] == "c");
+}
 }  // namespace
 }  // namespace workerd::api

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -303,9 +303,9 @@ class ArtifactBundler: public jsg::Object {
   // Takes in a list of imported modules and filters them in such a way to avoid local imports and
   // redundant imports in the package snapshot list.
   static kj::Array<kj::String> filterPythonScriptImports(
-      kj::HashSet<kj::String> locals, kj::Array<kj::String> imports);
+      kj::HashSet<kj::String> workerModules, kj::ArrayPtr<kj::String> imports);
   static kj::Array<kj::String> filterPythonScriptImportsJs(
-      kj::Array<kj::String> locals, kj::Array<kj::String> imports);
+      kj::Array<kj::String> workerModules, kj::Array<kj::String> imports);
   static kj::Array<kj::StringPtr> getSnapshotImports();
 
   JSG_RESOURCE_TYPE(ArtifactBundler) {


### PR DESCRIPTION
For most of these checks, we should only be comparing on the first component of a dotted import name. We also need to handle folders with `__init__.py` which are also modules.

This fixes the test failure in #3505.

We could consider removing the `dont-snapshot-pyodide` test, since this gives us unit testing coverage of that logic. Or perhaps we should just combine `filter-non-py-files` and `dont-snapshot-pyodide` into a single integration test covering this file.