### PR TITLE
feat: add Workflows to ValidationErrorReporter

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -947,4 +947,11 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # This flag is intended to be a roll-up flag. That is, as additional APIs
   # reach EOL, new compat flags will be added for those that will have
   # `impliedByAfterDate(name = "removeNodeJsCompatEOL", ...` annotations.
+
+  enableWorkflowScriptValidation @109 :Bool
+      $compatEnableFlag("enable_validate_workflow_entrypoint")
+      $compatDisableFlag("disable_validate_workflow_entrypoint")
+      $compatEnableDate("2025-09-20");
+  # This flag enables additional checks in the control plane to validate that workflows are
+  # defined and used correctly
 }

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -104,6 +104,9 @@ class Worker: public kj::AtomicRefcounted {
 
     // Report that the Worker exports a Durable Object class with the given name.
     virtual void addActorClass(kj::StringPtr exportName) = 0;
+
+    // Report that the Worker exports a Workflow class with the given name.
+    virtual void addWorkflowClass(kj::StringPtr exportName, kj::Array<kj::String> methods) = 0;
   };
 
   class LockType;
@@ -975,6 +978,10 @@ struct SimpleWorkerErrorReporter final: public Worker::ValidationErrorReporter {
     KJ_UNREACHABLE;
   }
   void addActorClass(kj::StringPtr exportName) override {
+    KJ_UNREACHABLE;
+  }
+
+  void addWorkflowClass(kj::StringPtr exportName, kj::Array<kj::String> methods) override {
     KJ_UNREACHABLE;
   }
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1784,6 +1784,17 @@ struct Server::ErrorReporter: public Worker::ValidationErrorReporter {
   void addActorClass(kj::StringPtr exportName) override {
     actorClasses.insert(kj::str(exportName));
   }
+
+  void addWorkflowClass(kj::StringPtr exportName, kj::Array<kj::String> methods) override {
+    // At runtime, we need to add it into the normal namedEntrypoints for Workflows to appear
+    // in `WorkerService`. This is a different method compared to `addEntrypoint` because we need to
+    // check for `WorkflowEntrypoint` inheritance at validation time.
+    kj::HashSet<kj::String> set;
+    for (auto& method: methods) {
+      set.insert(kj::mv(method));
+    }
+    namedEntrypoints.insert(kj::str(exportName), kj::mv(set));
+  }
 };
 
 // Implementation of ErrorReporter specifically for reporting errors in the top-level workerd

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -226,6 +226,7 @@ struct MockErrorReporter final: public Worker::ValidationErrorReporter {
 
   void addEntrypoint(kj::Maybe<kj::StringPtr> exportName, kj::Array<kj::String> methods) override {}
   void addActorClass(kj::StringPtr exportName) override {}
+  void addWorkflowClass(kj::StringPtr exportName, kj::Array<kj::String> methods) override {}
 };
 
 inline server::config::Worker::Reader buildConfig(


### PR DESCRIPTION
In order to have proper validation for Workflows I think we will need a similar setup as DOs: ValidationErrorReporter now has a `addWorkflowClass` that behaves similarily as `addActorClass`. (This will need a internal PR in order to work properly).

This will be useful in cases that a user exports a class but doesn't extend from `WorkflowEntrypoint` (meaning they won't get `ctx` and `env` and see weird errors).