### PR TITLE
Add error message in internal build log

### DIFF
--- a/tools/cross/internal_build.py
+++ b/tools/cross/internal_build.py
@@ -61,6 +61,7 @@ if __name__ == "__main__":
             status = resp.json()["status"]
             if status == "errored":
                 print("Internal build failed.")
+                print(resp.json()["error"]["message"])
                 print(
                     "If you are a Cloudflare employee, please check your internal"
                     " branch and refer this doc for further details:"


### PR DESCRIPTION
Display internal pipelink link in case of failure, or error message in case internal PR is not up-to-date.