### PR TITLE
simplify clangcl usage on windows builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -287,10 +287,7 @@ build:windows --enable_runfiles
 # `#pragma once` when using symlinked virtual includes, `__atomic_*` functions,
 # a standards-compliant preprocessor, support for GNU statement expressions
 # used by some KJ macros, and understands the `.c++` extension by default.
-# As of bazel 7, incompatible_enable_cc_toolchain_resolution is enabled by default, so we need to
-# define a platform for the clang-cl build.
-build:windows --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl
-build:windows --extra_execution_platforms=//:x64_windows-clang-cl
+build:windows --compiler=clang-cl
 
 # The Windows fastbuild bazel configuration is broken in that it necessarily generates PDB debug
 # information while the Linux and macOS toolchains only compile with debug information in the dbg

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -28,16 +28,6 @@ capnpc_ts_bin.capnpc_ts_binary(
     visibility = ["//visibility:public"],
 )
 
-# Platform definition for using clang-cl on Windows
-platform(
-    name = "x64_windows-clang-cl",
-    constraint_values = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:windows",
-        "@bazel_tools//tools/cpp:clang-cl",
-    ],
-)
-
 # Used for cross-compilation
 platform(
     name = "macOS_x86",


### PR DESCRIPTION
It seems we have a simpler way of using clang-cl compiler now. 