### PR TITLE
AI: remove redundant return statement

### DIFF
--- a/src/cloudflare/internal/ai-api.ts
+++ b/src/cloudflare/internal/ai-api.ts
@@ -151,10 +151,6 @@ export class Ai {
       throw await this._parseError(res);
     }
 
-    if (inputs['stream']) {
-      return res.body;
-    }
-
     if (!res.body) {
       throw await this._parseError(res);
     }


### PR DESCRIPTION
Explicitly returning the response body on `input.stream` is redundant as we already do that in the final return statement.