### PR TITLE
[ci] Limit Semgrep, CLA assistant CI actions

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
           # CLA Action uses this in-built GitHub token to make the API calls for interacting with GitHub.

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,11 +1,6 @@
 
 on:
-  pull_request: {}
   workflow_dispatch: {}
-  push: 
-    branches:
-      - main
-      - master
   schedule:
     - cron: '0 0 * * *'
 name: Semgrep config


### PR DESCRIPTION
The semgrep CI action is very slow and produces many false positives. It is currently the 3rd largest consumer of action run time for workerd, worsening the current runner exhaustion issue which leads to massive queueing of CI workflows. This can slow down the entire development cycle – limit the action to a nightly run, which matches the workers-sdk setting.

Since we're here, only run the (much lighter) CLA assistant workflow on PR comments, not on issue comments. This will reduce the total workflow invocation count somewhat.


CC @hrushikeshdeshpande – this matches previous action on https://github.com/cloudflare/workers-sdk/pull/7309 and https://github.com/cloudflare/stpyv8/pull/123.