### PR TITLE
[o11y] Implement Cache API span tags

### DIFF
--- a/src/workerd/api/cache.h
+++ b/src/workerd/api/cache.h
@@ -85,8 +85,11 @@ class Cache: public jsg::Object {
  private:
   kj::Maybe<kj::String> cacheName;
 
-  kj::Own<kj::HttpClient> getHttpClient(
-      IoContext& context, kj::Maybe<kj::String> cfBlobJson, kj::LiteralStringConst operationName);
+  kj::Own<kj::HttpClient> getHttpClient(IoContext& context,
+      kj::Maybe<kj::String> cfBlobJson,
+      kj::LiteralStringConst operationName,
+      kj::StringPtr url,
+      kj::Maybe<jsg::ByteString> cacheControl = kj::none);
 };
 
 // =======================================================================================


### PR DESCRIPTION
Adds support for url.full tag, scaffolding is added to support for cache_control tags but this is not yet complete.

Also see the downstream PR.