### PR TITLE
Temporarily comment out log warning about bad ServiceDesignators.

### DIFF
--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -1538,11 +1538,14 @@ KJ_TEST("Server: referencing DO class as entrypoint is not an error") {
 
   // We see a log warning at config time, but config otherwise completes successfully.
   {
-    KJ_EXPECT_LOG(WARNING,
-        "A ServiceDesignator in the config referenced the entrypoint \"SomeActor\", but this "
-        "class does not extend 'WorkerEntrypoint'. Attempts to call this entrypoint will "
-        "fail at runtime, but historically this was not a startup-time error. Future "
-        "versions of workerd may make this a startup-time error.");
+    // TODO(soon): Restore this warning once miniflare no longer generates config that causes
+    //   it to log spuriously.
+    //
+    // KJ_EXPECT_LOG(WARNING,
+    //     "A ServiceDesignator in the config referenced the entrypoint \"SomeActor\", but this "
+    //     "class does not extend 'WorkerEntrypoint'. Attempts to call this entrypoint will "
+    //     "fail at runtime, but historically this was not a startup-time error. Future "
+    //     "versions of workerd may make this a startup-time error.");
     test.start();
   }
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1833,11 +1833,14 @@ class Server::WorkerService final: public Service,
         name = entry.key;  // replace with more-permanent string
         handlers = &entry.value;
       } else KJ_IF_SOME(className, actorClassEntrypoints.find(n)) {
-        KJ_LOG(WARNING,
-            kj::str("A ServiceDesignator in the config referenced the entrypoint \"", n,
-                "\", but this class does not extend 'WorkerEntrypoint'. Attempts to call this "
-                "entrypoint will fail at runtime, but historically this was not a startup-time "
-                "error. Future versions of workerd may make this a startup-time error."));
+        // TODO(soon): Restore this warning once miniflare no longer generates config that causes
+        //   it to log spuriously.
+        //
+        // KJ_LOG(WARNING,
+        //     kj::str("A ServiceDesignator in the config referenced the entrypoint \"", n,
+        //         "\", but this class does not extend 'WorkerEntrypoint'. Attempts to call this "
+        //         "entrypoint will fail at runtime, but historically this was not a startup-time "
+        //         "error. Future versions of workerd may make this a startup-time error."));
 
         const kj::HashSet<kj::String> EMPTY_HANDLERS;
         name = className;  // replace with more-permanent string


### PR DESCRIPTION
It turns out miniflare intentionally generates configs that define a socket for every export, regardless of whether the export is a valid stateless entrypoint. Miniflare currently has no way to tell which entrypoints are valid. As a result, this warning prints spuriously any time someone runs `wrangler dev` with Durable Objects defined.

We should find a better fix for this, but for now, let's remove the warning.