### PR TITLE
[nfc] mark py_wd_tests as python

### DIFF
--- a/src/workerd/server/tests/python/py_wd_test.bzl
+++ b/src/workerd/server/tests/python/py_wd_test.bzl
@@ -73,7 +73,7 @@ def py_wd_test(
         "--pyodide-package-disk-cache-dir",
         ".",
     ]
-    tags = tags + ["py_wd_test"]
+    tags = tags + ["py_wd_test", "python"]
 
     for python_flag in python_flags:
         _py_wd_test_helper(


### PR DESCRIPTION
"python" is the tag we use downstream