### PR TITLE
Increase PBKDF2 iterations to OWASP recommended value

### DIFF
--- a/src/workerd/io/limit-enforcer.h
+++ b/src/workerd/io/limit-enforcer.h
@@ -12,7 +12,7 @@ namespace workerd {
 struct ActorCacheSharedLruOptions;
 class IoContext;
 
-static constexpr size_t DEFAULT_MAX_PBKDF2_ITERATIONS = 100'000;
+static constexpr size_t DEFAULT_MAX_PBKDF2_ITERATIONS = 600'000;
 
 // Interface for an object that enforces resource limits on an Isolate level.
 //


### PR DESCRIPTION
This PR increases the PBKDF2 iterations to align with the OWASP recommended value for better security. The change is minimal and does not affect other parts of the codebase.

- Updated PBKDF2 iterations to 600'000
- Verified tests pass successfully
- Discussion reference: #1346 

This change follows security best practices as recommended by OWASP. Let me know if any further modifications are needed.