### PR TITLE
use correct constructor for URLPattern

### DIFF
--- a/src/workerd/api/urlpattern.h
+++ b/src/workerd/api/urlpattern.h
@@ -83,7 +83,7 @@ class URLPattern final: public jsg::Object {
 
   static jsg::Ref<URLPattern> constructor(jsg::Lock& js,
       jsg::Optional<URLPatternInput> input,
-      jsg::Optional<kj::String> baseURL,
+      jsg::Optional<kj::OneOf<kj::String, URLPatternOptions>> baseURL,
       jsg::Optional<URLPatternOptions> patternOptions);
 
   kj::Maybe<URLPatternResult> exec(

--- a/src/workerd/api/wpt/urlpattern-test.ts
+++ b/src/workerd/api/wpt/urlpattern-test.ts
@@ -175,7 +175,6 @@ export default {
       'Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}]',
       'Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}]',
       'Pattern: [{"pathname":"/:foo\\\\bar"}] Inputs: [{"pathname":"/bazbar"}]',
-      'Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]',
       'Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]',
       'Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]',
       'Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]',

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -2625,7 +2625,7 @@ declare class URLSearchParams {
 declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -2637,7 +2637,7 @@ export declare class URLSearchParams {
 export declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -2651,7 +2651,7 @@ declare class URLSearchParams {
 declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -2663,7 +2663,7 @@ export declare class URLSearchParams {
 export declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -2669,7 +2669,7 @@ declare class URLSearchParams {
 declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -2681,7 +2681,7 @@ export declare class URLSearchParams {
 export declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -2670,7 +2670,7 @@ declare class URLSearchParams {
 declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -2682,7 +2682,7 @@ export declare class URLSearchParams {
 export declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -2673,7 +2673,7 @@ declare class URLSearchParams {
 declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -2685,7 +2685,7 @@ export declare class URLSearchParams {
 export declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -2678,7 +2678,7 @@ declare class URLSearchParams {
 declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -2690,7 +2690,7 @@ export declare class URLSearchParams {
 export declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -2680,7 +2680,7 @@ declare class URLSearchParams {
 declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -2692,7 +2692,7 @@ export declare class URLSearchParams {
 export declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -2680,7 +2680,7 @@ declare class URLSearchParams {
 declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -2692,7 +2692,7 @@ export declare class URLSearchParams {
 export declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -2752,7 +2752,7 @@ declare class URLSearchParams {
 declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -2764,7 +2764,7 @@ export declare class URLSearchParams {
 export declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -2625,7 +2625,7 @@ declare class URLSearchParams {
 declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -2637,7 +2637,7 @@ export declare class URLSearchParams {
 export declare class URLPattern {
   constructor(
     input?: string | URLPatternURLPatternInit,
-    baseURL?: string,
+    baseURL?: string | URLPatternURLPatternOptions,
     patternOptions?: URLPatternURLPatternOptions,
   );
   get protocol(): string;


### PR DESCRIPTION
Ada fixes this already but I don't want to expose 2 different API surface while putting it behind an autogate.

Splitting https://github.com/cloudflare/workerd/pull/3529 into multiple PRs