### PR TITLE
Implements kj::HashSet support for jsg.

### DIFF
--- a/src/workerd/jsg/README.md
+++ b/src/workerd/jsg/README.md
@@ -170,6 +170,21 @@ void doSomething(kj::Array<kj::String> strings) {
 doSomething(['a', 'b', 'c']);
 ```
 
+### Set type (`kj::HashSet<T>`)
+
+The `kj::HashSet<T>` type maps to JavaScript sets. The `T` can be any value, though there are
+currently some restrictions. For example, you cannot have a `kj::HashSet<CustomStruct>`.
+
+```cpp
+void doSomething(kj::HashSet<kj::String> strings) {
+  KJ_DBG(strings.has("a"));
+}
+```
+
+```js
+doSomething(new Set(['a', 'b', 'c']));
+```
+
 ### Sequence types (`jsg::Sequence<T>`)
 
 A [Sequence][] is any JavaScript object that implements `Symbol.iterator`. These are

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -379,6 +379,7 @@ FOR_EACH_MAYBE_TYPE(DECLARE_MAYBE_TYPE)
 #define FOR_EACH_ARRAY_TYPE(F)                                                                     \
   F(kj::Array)                                                                                     \
   F(kj::ArrayPtr)                                                                                  \
+  F(kj::HashSet)                                                                                   \
   F(jsg::Sequence)                                                                                 \
   F(jsg::AsyncGenerator)
 

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -378,6 +378,7 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
                    public MaybeWrapper<Self>,
                    public OneOfWrapper<Self>,
                    public ArrayWrapper<Self>,
+                   public SetWrapper<Self>,
                    public SequenceWrapper<Self>,
                    public GeneratorWrapper<Self>,
                    public ArrayBufferWrapper<Self>,
@@ -435,6 +436,7 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
   USING_WRAPPER(MaybeWrapper<Self>);
   USING_WRAPPER(OneOfWrapper<Self>);
   USING_WRAPPER(ArrayWrapper<Self>);
+  USING_WRAPPER(SetWrapper<Self>);
   USING_WRAPPER(SequenceWrapper<Self>);
   USING_WRAPPER(GeneratorWrapper<Self>);
   USING_WRAPPER(ArrayBufferWrapper<Self>);

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -852,6 +852,62 @@ class ArrayWrapper {
 };
 
 // =======================================================================================
+// Sets
+
+// TypeWrapper mixin for sets.
+template <typename TypeWrapper>
+class SetWrapper {
+ public:
+  static auto constexpr MAX_STACK = 64;
+  template <typename U>
+  static constexpr const char* getName(kj::HashSet<U>*) {
+    return "Set";
+  }
+
+  template <typename U>
+  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      kj::HashSet<U> set) {
+    v8::Isolate* isolate = context->GetIsolate();
+    v8::EscapableHandleScope handleScope(isolate);
+
+    auto out = v8::Set::New(isolate);
+    for (auto& item: set) {
+      v8::HandleScope scope(isolate);
+      check(
+          out->Add(context, static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(item))));
+    }
+
+    return handleScope.Escape(out);
+  }
+
+  template <typename U>
+  kj::Maybe<kj::HashSet<U>> tryUnwrap(v8::Local<v8::Context> context,
+      v8::Local<v8::Value> handle,
+      kj::HashSet<U>*,
+      kj::Maybe<v8::Local<v8::Object>> parentObject) {
+    if (!handle->IsSet()) {
+      return kj::none;
+    }
+
+    auto set = handle.As<v8::Set>();
+    auto array = set->AsArray();
+    auto length = array->Length();
+    auto builder = kj::HashSet<U>();
+    builder.reserve(length);
+    for (auto i: kj::zeroTo(length)) {
+      v8::Local<v8::Value> element = check(array->Get(context, i));
+      auto value = static_cast<TypeWrapper*>(this)->template unwrap<U>(
+          context, element, TypeErrorContext::other());
+      builder.upsert(kj::mv(value), [&](U& existing, U&& replacement) {
+        JSG_FAIL_REQUIRE(TypeError, "Duplicate values in the set after unwrapping.");
+      });
+    }
+    return kj::mv(builder);
+  }
+};
+
+// =======================================================================================
 // ArrayBuffers / ArrayBufferViews
 //
 // This wrapper implements the following wrapping conversions:


### PR DESCRIPTION
### Test Plan

```
bazel run @workerd//src/workerd/jsg:value-test
```