### PR TITLE
Fix some WPT url tests failing due to invalid surrogates in UTF8

### DIFF
--- a/src/workerd/api/url-standard.h
+++ b/src/workerd/api/url-standard.h
@@ -35,12 +35,12 @@ class URLSearchParams: public jsg::Object {
     }
   };
 public:
-  using StringPair = jsg::Sequence<kj::String>;
+  using StringPair = jsg::Sequence<jsg::USVString>;
   using StringPairs = jsg::Sequence<StringPair>;
 
   using Initializer = kj::OneOf<StringPairs,
-                                jsg::Dict<kj::String, kj::String>,
-                                kj::String>;
+                                jsg::Dict<jsg::USVString, jsg::USVString>,
+                                jsg::USVString>;
 
   // Constructor called by the static constructor method.
   URLSearchParams(Initializer init);
@@ -50,12 +50,12 @@ public:
 
   static jsg::Ref<URLSearchParams> constructor(jsg::Optional<Initializer> init);
 
-  void append(kj::String name, kj::String value);
-  void delete_(jsg::Lock& js, kj::String name, jsg::Optional<kj::String> value);
-  kj::Maybe<kj::ArrayPtr<const char>> get(kj::String name);
-  kj::Array<kj::ArrayPtr<const char>> getAll(kj::String name);
-  bool has(jsg::Lock& js, kj::String name, jsg::Optional<kj::String> value);
-  void set(kj::String name, kj::String value);
+  void append(jsg::USVString name, jsg::USVString value);
+  void delete_(jsg::Lock& js, jsg::USVString name, jsg::Optional<jsg::USVString> value);
+  kj::Maybe<kj::ArrayPtr<const char>> get(jsg::USVString name);
+  kj::Array<kj::ArrayPtr<const char>> getAll(jsg::USVString name);
+  bool has(jsg::Lock& js, jsg::USVString name, jsg::Optional<jsg::USVString> value);
+  void set(jsg::USVString name, jsg::USVString value);
   void sort();
 
   JSG_ITERATOR(EntryIterator, entries,
@@ -162,9 +162,9 @@ public:
   URL(kj::StringPtr url, kj::Maybe<kj::StringPtr> base = kj::none);
   ~URL() noexcept(false) override;
 
-  static jsg::Ref<URL> constructor(kj::String url, jsg::Optional<kj::String> base);
+  static jsg::Ref<URL> constructor(jsg::USVString url, jsg::Optional<jsg::USVString> base);
 
-  static kj::Maybe<jsg::Ref<URL>> parse(jsg::Lock& js, kj::String url, jsg::Optional<kj::String> base) {
+  static kj::Maybe<jsg::Ref<URL>> parse(jsg::Lock& js, jsg::USVString url, jsg::Optional<jsg::USVString> base) {
     // Method should not throw if the parse fails
     return js.tryCatch([&]() -> kj::Maybe<jsg::Ref<URL>> {
       return constructor(kj::mv(url), kj::mv(base));
@@ -172,36 +172,36 @@ public:
   }
 
   kj::ArrayPtr<const char> getHref();
-  void setHref(jsg::Lock& js, kj::String value);
+  void setHref(jsg::Lock& js, jsg::USVString value);
 
   kj::Array<const char> getOrigin();
 
   kj::ArrayPtr<const char> getProtocol();
-  void setProtocol(kj::String value);
+  void setProtocol(jsg::USVString value);
 
   kj::ArrayPtr<const char> getUsername();
-  void setUsername(kj::String value);
+  void setUsername(jsg::USVString value);
 
   kj::ArrayPtr<const char> getPassword();
-  void setPassword(kj::String value);
+  void setPassword(jsg::USVString value);
 
   kj::ArrayPtr<const char> getHost();
-  void setHost(kj::String value);
+  void setHost(jsg::USVString value);
 
   kj::ArrayPtr<const char> getHostname();
-  void setHostname(kj::String value);
+  void setHostname(jsg::USVString value);
 
   kj::ArrayPtr<const char> getPort();
-  void setPort(kj::String value);
+  void setPort(jsg::USVString value);
 
   kj::ArrayPtr<const char> getPathname();
-  void setPathname(kj::String value);
+  void setPathname(jsg::USVString value);
 
   kj::ArrayPtr<const char> getSearch();
-  void setSearch(kj::String value);
+  void setSearch(jsg::USVString value);
 
   kj::ArrayPtr<const char> getHash();
-  void setHash(kj::String value);
+  void setHash(jsg::USVString value);
 
   jsg::Ref<URLSearchParams> getSearchParams();
 
@@ -215,9 +215,9 @@ public:
   //   'not a url'
   // ].filter((test) => URL.canParse(test));
   //
-  static bool canParse(kj::String url, jsg::Optional<kj::String> base = kj::none);
+  static bool canParse(jsg::USVString url, jsg::Optional<jsg::USVString> base = kj::none);
   static jsg::JsString createObjectURL(jsg::Lock& js, kj::OneOf<jsg::Ref<File>, jsg::Ref<Blob>> object);
-  static void revokeObjectURL(jsg::Lock& js, kj::String object_url);
+  static void revokeObjectURL(jsg::Lock& js, jsg::USVString object_url);
 
   JSG_RESOURCE_TYPE(URL) {
     JSG_READONLY_PROTOTYPE_PROPERTY(origin, getOrigin);

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1050,6 +1050,31 @@ class ByteString: public kj::String {
   //   We default the enum to NONE so that ByteString(kj::str(otherHeader)) works as expected.
 };
 
+// A USVString has the exact same representation as a kj::String, but we guarantee that it meets
+// the WHATWG definition of a "scalar value string". Particularly, a USVString will never contain
+// invalid surrogate characters. A USVString should be used when implementing a Web API that
+// requires this behaviour.
+// See <https://infra.spec.whatwg.org/#scalar-value-string>
+class USVString: public kj::String {
+ public:
+  // Inheriting constructors does not inherit copy/move constructors, so we declare a forwarding
+  // constructor instead.
+  template <typename... Params>
+  explicit USVString(Params&&... params): kj::String(kj::fwd<Params>(params)...) {}
+};
+
+// A DOMString has the exact same representation as a kj::String, but may contain WTF-8 encoded
+// data like unpaired surrogate characters, that are not strictly valid in UTF-8. A DOMString
+// should be used when implementing a Web API that requires this behaviour, or when an explicit
+// decision is made to accept potentially invalid strings.
+class DOMString: public kj::String {
+ public:
+  // Inheriting constructors does not inherit copy/move constructors, so we declare a forwarding
+  // constructor instead.
+  template <typename... Params>
+  explicit DOMString(Params&&... params): kj::String(kj::fwd<Params>(params)...) {}
+};
+
 // A Dict<V, K> in C++ corresponds to a JavaScript object that is being used as a string -> value
 // map, where all the values are of type T.
 //
@@ -2006,8 +2031,8 @@ class PropertyReflection {
 };
 
 template <typename T>
-concept CoercibleType =
-    kj::isSameType<kj::String, T>() || kj::isSameType<bool, T>() || kj::isSameType<double, T>();
+concept CoercibleType = kj::isSameType<kj::String, T>() || kj::isSameType<USVString, T>() ||
+    kj::isSameType<DOMString, T>() || kj::isSameType<bool, T>() || kj::isSameType<double, T>();
 // When updating this list, be sure to keep the corresponding checks in the NonCoercibleWrapper
 // class in value.h updated as well.
 
@@ -2019,7 +2044,7 @@ concept CoercibleType =
 //
 // Here, T can be only one of several types that support coercion:
 //
-// * kj::String (value must be a string)
+// * kj::String, jsg::USVString, jsg::DOMString (value must be a string)
 // * bool (value must be a boolean)
 // * double (value must be a number)
 //

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -247,6 +247,8 @@ FOR_EACH_NUMBER_TYPE(DECLARE_NUMBER_TYPE)
   F(kj::StringPtr)                                                                                 \
   F(v8::String)                                                                                    \
   F(ByteString)                                                                                    \
+  F(USVString)                                                                                     \
+  F(DOMString)                                                                                     \
   F(jsg::JsString)
 
 FOR_EACH_STRING_TYPE(DECLARE_STRING_TYPE)

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -412,8 +412,10 @@ class StringWrapper {
   static constexpr const char* getName(kj::String*) {
     return "string";
   }
-  // TODO(someday): This conflates USVStrings, which must have valid code points, with DOMStrings,
-  //   which needn't have valid code points.
+
+  // TODO(someday): The conversion to kj::String doesn't explicitly consider the distinction
+  // between DOMString (~ WTF-8; could contain invalid code points) and USVString (invalid code
+  // points are always replaced with U+FFFD). Code should make an explict choice between the two.
 
   static constexpr const char* getName(kj::ArrayPtr<const char>*) {
     return "string";
@@ -426,6 +428,14 @@ class StringWrapper {
     return "ByteString";
   }
   // TODO(cleanup): Move to a HeaderStringWrapper in the api directory.
+
+  static constexpr const char* getName(USVString*) {
+    return "USVString";
+  }
+
+  static constexpr const char* getName(DOMString*) {
+    return "DOMString";
+  }
 
   v8::Local<v8::String> wrap(v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
@@ -448,6 +458,18 @@ class StringWrapper {
       kj::Maybe<v8::Local<v8::Object>> creator,
       const ByteString& value) {
     // TODO(cleanup): Move to a HeaderStringWrapper in the api directory.
+    return wrap(context, creator, value.asPtr());
+  }
+
+  v8::Local<v8::String> wrap(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      const USVString& value) {
+    return wrap(context, creator, value.asPtr());
+  }
+
+  v8::Local<v8::String> wrap(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      const DOMString& value) {
     return wrap(context, creator, value.asPtr());
   }
 
@@ -486,6 +508,29 @@ class StringWrapper {
     }
 
     return kj::mv(result);
+  }
+
+  kj::Maybe<USVString> tryUnwrap(v8::Local<v8::Context> context,
+      v8::Local<v8::Value> handle,
+      USVString*,
+      kj::Maybe<v8::Local<v8::Object>> parentObject) {
+    v8::Local<v8::String> str = check(handle->ToString(context));
+    v8::Isolate* isolate = context->GetIsolate();
+    auto buf = kj::heapArray<char>(str->Utf8LengthV2(isolate) + 1);
+    str->WriteUtf8V2(isolate, buf.begin(), buf.size(),
+        v8::String::WriteFlags::kNullTerminate | v8::String::WriteFlags::kReplaceInvalidUtf8);
+    return USVString(kj::mv(buf));
+  }
+
+  kj::Maybe<DOMString> tryUnwrap(v8::Local<v8::Context> context,
+      v8::Local<v8::Value> handle,
+      DOMString*,
+      kj::Maybe<v8::Local<v8::Object>> parentObject) {
+    v8::Local<v8::String> str = check(handle->ToString(context));
+    v8::Isolate* isolate = context->GetIsolate();
+    auto buf = kj::heapArray<char>(str->Utf8LengthV2(isolate) + 1);
+    str->WriteUtf8V2(isolate, buf.begin(), buf.size(), v8::String::WriteFlags::kNullTerminate);
+    return DOMString(kj::mv(buf));
   }
 };
 
@@ -1130,7 +1175,8 @@ class NonCoercibleWrapper {
       NonCoercible<T>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
     auto& wrapper = static_cast<TypeWrapper&>(*this);
-    if constexpr (kj::isSameType<kj::String, T>()) {
+    if constexpr (kj::isSameType<kj::String, T>() || kj::isSameType<jsg::USVString, T>() ||
+        kj::isSameType<jsg::DOMString, T>()) {
       if (!handle->IsString()) return kj::none;
       KJ_IF_SOME(value, wrapper.tryUnwrap(context, handle, (T*)nullptr, parentObject)) {
         return NonCoercible<T>{

--- a/src/workerd/jsg/web-idl.h
+++ b/src/workerd/jsg/web-idl.h
@@ -114,8 +114,10 @@ constexpr bool isNumericType =
 
 template <typename T>
 constexpr bool isStringType = kj::isSameType<T, kj::String>() || kj::isSameType<T, ByteString>() ||
+    kj::isSameType<T, USVString>() || kj::isSameType<T, DOMString>() ||
     kj::isSameType<T, v8::Local<v8::String>>() || kj::isSameType<T, jsg::V8Ref<v8::String>>() ||
-    kj::isSameType<T, NonCoercible<kj::String>>() || kj::isSameType<T, jsg::JsString>();
+    kj::isSameType<T, NonCoercible<kj::String>>() || kj::isSameType<T, NonCoercible<USVString>>() ||
+    kj::isSameType<T, NonCoercible<DOMString>>() || kj::isSameType<T, jsg::JsString>();
 
 template <typename T>
 constexpr bool isObjectType =

--- a/src/wpt/url-test.ts
+++ b/src/wpt/url-test.ts
@@ -38,12 +38,7 @@ export default {
     replace: (code): string =>
       code.replace(/\["url", "a", "area"\]/, '[ "url" ]'),
   },
-  'url-constructor.any.js': {
-    comment: 'Fix this eventually',
-    expectedFailures: [
-      'Parsing: <http://example.com/\uD800\uD801\uDFFE\uDFFF\uFDD0\uFDCF\uFDEF\uFDF0\uFFFE\uFFFF?\uD800\uD801\uDFFE\uDFFF\uFDD0\uFDCF\uFDEF\uFDF0\uFFFE\uFFFF> without base',
-    ],
-  },
+  'url-constructor.any.js': {},
   'url-origin.any.js': {},
   'url-searchparams.any.js': {},
   'url-setters-a-area.window.js': {
@@ -135,12 +130,7 @@ export default {
   'urlsearchparams-append.any.js': {},
   'urlsearchparams-constructor.any.js': {
     comment: 'Fix this eventually',
-    expectedFailures: [
-      'URLSearchParams constructor, DOMException as argument',
-      'Construct with 2 unpaired surrogates (no trailing)',
-      'Construct with 3 unpaired surrogates (no leading)',
-      'Construct with object with NULL, non-ASCII, and surrogate keys',
-    ],
+    expectedFailures: ['URLSearchParams constructor, DOMException as argument'],
   },
   'urlsearchparams-delete.any.js': {},
   'urlsearchparams-foreach.any.js': {},


### PR DESCRIPTION
* Adds jsg::USVString, which is guaranteed not to contain invalid characters in UTF8. This type is intended to make it convenient and consistent to implement Web APIs which say they take a USVString without having to deal with this issue every time.
* Updates url-standard to use USVStrings as specified by the WHATWG URL spec.