### PR TITLE
Fixes Python print()s not showing up in `wrangler dev`.

### DIFF
--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -102,5 +102,14 @@ export async function loadPyodide(
   const pyodide = Module.API.public_api;
 
   finishSnapshotSetup(pyodide);
+
+  // Need to set these here so that the logs go to the right context. If we don't they will go
+  // to SetupEmscripten's context and end up being KJ_LOG'd, which we do not want.
+  Module.API.initializeStreams(
+    null,
+    (msg) => console.log(msg),
+    (msg) => console.error(msg)
+  );
+
   return pyodide;
 }

--- a/src/pyodide/types/Pyodide.d.ts
+++ b/src/pyodide/types/Pyodide.d.ts
@@ -13,4 +13,6 @@ interface Pyodide {
   FS: FS;
   site_packages: string;
   loadPackage: (names: string | string[], options: object) => Promise<any[]>;
+  setStdout: (options?: any) => void;
+  setStderr: (options?: any) => void;
 }

--- a/src/pyodide/types/emscripten.d.ts
+++ b/src/pyodide/types/emscripten.d.ts
@@ -15,6 +15,11 @@ interface API {
   finalizeBootstrap: () => void;
   public_api: Pyodide;
   rawRun: (code: string) => [status: number, err: string];
+  initializeStreams: (
+    stdin?: any,
+    stdout?: (a: string) => void,
+    stderr?: (a: string) => void
+  ) => void;
 }
 
 interface LDSO {

--- a/src/workerd/server/tests/python/hello/worker.py
+++ b/src/workerd/server/tests/python/hello/worker.py
@@ -1,4 +1,5 @@
 def test():
+    from js import console
     from js.WebAssembly import Suspending
 
     Suspending  # noqa: B018
@@ -7,3 +8,4 @@ def test():
     # because we don't test whether we printed anything.
     # TODO: update this to test that something happened
     print("Does this work?")
+    console.log("Does this work?")  # both should print the same output


### PR DESCRIPTION
It's not trivial to test this in workerd, but I will follow up with a test in workers-sdk.

### Test Plan

```
bazel run @workerd//src/workerd/server/tests/python:hello_development@
```

<details><summary>Before</summary>
<p>

```
workerd/server/server.c++:4470: debug: [ TEST ] python-hello
Loading hashlib, lzma, pydecimal, pydoc-data, sqlite3, ssl
Loaded hashlib, lzma, pydecimal, pydoc-data, sqlite3, ssl
workerd/io/worker.c++:1871: info: console.log(); message() = ["Does this work?"]
Does this work?
```

</p>
</details> 

<details><summary>After</summary>
<p>

```
workerd/server/server.c++:4470: debug: [ TEST ] python-hello
Loading hashlib, lzma, pydecimal, pydoc-data, sqlite3, ssl
Loaded hashlib, lzma, pydecimal, pydoc-data, sqlite3, ssl
Does this work?
Does this work?
workerd/server/server.c++:4478: debug: [ PASS ] python-hello
```

</p>
</details> 