### PR TITLE
[build] Apply more V8 optimizations to improve test performance

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -66,16 +66,26 @@ build --per_file_copt=external/com_google_tcmalloc@-DANNOTATE_MEMORY_IS_INITIALI
 build --per_file_copt=external/com_google_protobuf@-Wno-deprecated-declarations,-Wno-deprecated-pragma,-Wno-deprecated-this-capture
 build --host_per_file_copt=external/com_google_protobuf@-Wno-deprecated-declarations,-Wno-deprecated-pragma,-Wno-deprecated-this-capture
 
-# Increasing the optimization level of some portions of V8 significantly speeds up Python tests
-# in GitHub Actions. This is an optional performance hack and shouly only be used in CI.
-build:v8-codegen-opt --per_file_copt=v8/src/compiler@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/common@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/builtins@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/heap@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/snapshot@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/objects@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/wasm@-O2
+# Increasing the optimization level of some portions of V8 significantly speeds up Python tests in
+# GitHub Actions. This is an optional performance hack intended for CI, although it might also be
+# useful for local development.
+build:v8-codegen-opt --per_file_copt=v8/src/api@-O2
 build:v8-codegen-opt --per_file_copt=v8/src/base@-O2
+build:v8-codegen-opt --per_file_copt=v8/src/builtins@-O2
+build:v8-codegen-opt --per_file_copt=v8/src/codegen@-O2
+build:v8-codegen-opt --per_file_copt=v8/src/common@-O2
+build:v8-codegen-opt --per_file_copt=v8/src/compiler@-O2
+build:v8-codegen-opt --per_file_copt=v8/src/execution@-O2
+build:v8-codegen-opt --per_file_copt=v8/src/heap@-O2
+build:v8-codegen-opt --per_file_copt=v8/src/objects@-O2
+build:v8-codegen-opt --per_file_copt=v8/src/parsing@-O2
+build:v8-codegen-opt --per_file_copt=v8/src/roots@-O2
+build:v8-codegen-opt --per_file_copt=v8/src/runtime@-O2
+build:v8-codegen-opt --per_file_copt=v8/src/parsing@-O2
+build:v8-codegen-opt --per_file_copt=v8/src/snapshot@-O2
+build:v8-codegen-opt --per_file_copt=v8/src/wasm@-O2
+# V8 is heavily using absl for hashing now, optimize it too.
+build:v8-codegen-opt --per_file_copt=external/com_google_absl@-O2
 
 # Disable relaxing all jumps during LLVM codegen under -O0, which previously led to build
 # performance improvements but makes code size worse. This will be the default in LLVM19.

--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -19,12 +19,14 @@ build:ci --color=yes
 # Indicate support for more terminal columns, 100 is the line length recommended by KJ style.
 build:ci --terminal_columns=100
 
-build:ci --config=v8-codegen-opt
 test:ci --test_output=errors
 build:ci --disk_cache=~/bazel-disk-cache
 
 # test CI jobs don't need any top-level artifacts and just verify things
 build:ci-test --remote_download_outputs=minimal
+# Enable v8-codegen-opt for test so that python tests run in an acceptable time frame but not for
+# release builds – this sets -O2 and release should keep -O3.
+build:ci-test --config=v8-codegen-opt
 
 # limit storage usage on ci
 # Exclude large benchmarking binaries created in debug and asan configurations to avoid


### PR DESCRIPTION
This makes python tests run significantly faster on CI.

=============

Turns out that optimizing a larger subset of V8 can further improve python test performance (~~\~2x faster in local testing~~ looks like a smaller speedup on CI, local results were based on DEBUG being enabled). Tests currently take ~9 mins to run on Windows which was <3 mins not too long ago, this change will help mitigate this regression. We could optimize all of V8 to simplify things here, but this subset should work well for now.