### PR TITLE
Implement just enough to make D1’s Sessions API work in local dev

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -1394,6 +1394,17 @@ export class DurableObjectExample extends DurableObject {
 
     assert.deepEqual([...cursor], [{ i: 123 }]);
   }
+
+  async testSessionsAPIBookmark(previousBookmark) {
+    if (previousBookmark) {
+      await this.state.storage.waitForBookmark(previousBookmark);
+    }
+    let bookmark = await this.state.storage.getCurrentBookmark();
+    if (previousBookmark) {
+      assert.ok(previousBookmark < bookmark, "new bookmark didn't advance!");
+    }
+    return bookmark;
+  }
 }
 
 export default {
@@ -1495,3 +1506,13 @@ const INSERT_36_ROWS = ['a', 'b', 'c', 'd', 'e', 'f']
         .join(',')};`
   )
   .join(' ');
+
+export let testSessionsAPIBookmark = {
+  async test(ctrl, env, ctx) {
+    let stub = env.ns.get(env.ns.idFromName('sessions-api-bookmark-test'));
+    let bookmark = undefined;
+    for (let i = 0; i < 20; ++i) {
+      bookmark = await stub.testSessionsAPIBookmark(bookmark);
+    }
+  },
+};

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -80,6 +80,8 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
       kj::Date scheduledTime, bool noCache = false) override;
   void cancelDeferredAlarmDeletion() override;
   kj::Maybe<kj::Promise<void>> onNoPendingFlush() override;
+  kj::Promise<kj::String> getCurrentBookmark() override;
+  kj::Promise<void> waitForBookmark(kj::StringPtr bookmark) override;
   // See ActorCacheInterface
 
  private:

--- a/src/workerd/util/sqlite-metadata.c++
+++ b/src/workerd/util/sqlite-metadata.c++
@@ -54,6 +54,22 @@ void SqliteMetadata::setAlarmUncached(kj::Maybe<kj::Date> currentTime) {
   }
 }
 
+kj::Maybe<uint64_t> SqliteMetadata::getLocalDevelopmentBookmark() {
+  auto query = ensureInitialized().stmtGetLocalDevelopmentBookmark.run();
+  if (query.isDone() || query.isNull(0)) {
+    return kj::none;
+  } else {
+    auto bookmark = query.getInt64(0);
+    KJ_REQUIRE(bookmark >= 0);
+    return bookmark;
+  }
+}
+
+void SqliteMetadata::setLocalDevelopmentBookmark(uint64_t bookmark) {
+  KJ_REQUIRE(bookmark <= static_cast<int64_t>(kj::maxValue));
+  ensureInitialized().stmtSetLocalDevelopmentBookmark.run(static_cast<int64_t>(bookmark));
+}
+
 SqliteMetadata::Initialized& SqliteMetadata::ensureInitialized() {
   if (!tableCreated) {
     db.run(R"(


### PR DESCRIPTION
D1’s Sessions API for read replicas relies on the `getCurrentBookmark` and `waitForBookmark` methods doing something reasonable rather than throwing an exception.