### PR TITLE
Check container status before invoking actor constructor.

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -828,12 +828,14 @@ kj::OneOf<jsg::Ref<DurableObjectId>, kj::StringPtr> ActorState::getId() {
 DurableObjectState::DurableObjectState(Worker::Actor::Id actorId,
     jsg::JsRef<jsg::JsValue> exports,
     kj::Maybe<jsg::Ref<DurableObjectStorage>> storage,
-    kj::Maybe<rpc::Container::Client> container)
+    kj::Maybe<rpc::Container::Client> container,
+    bool containerRunning)
     : id(kj::mv(actorId)),
       exports(kj::mv(exports)),
       storage(kj::mv(storage)),
-      container(container.map(
-          [&](rpc::Container::Client& cap) { return jsg::alloc<Container>(kj::mv(cap)); })) {}
+      container(container.map([&](rpc::Container::Client& cap) {
+        return jsg::alloc<Container>(kj::mv(cap), containerRunning);
+      })) {}
 
 void DurableObjectState::waitUntil(kj::Promise<void> promise) {
   IoContext::current().addWaitUntil(kj::mv(promise));

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -466,7 +466,8 @@ class DurableObjectState: public jsg::Object {
   DurableObjectState(Worker::Actor::Id actorId,
       jsg::JsRef<jsg::JsValue> exports,
       kj::Maybe<jsg::Ref<DurableObjectStorage>> storage,
-      kj::Maybe<rpc::Container::Client> container);
+      kj::Maybe<rpc::Container::Client> container,
+      bool containerRunning);
 
   void waitUntil(kj::Promise<void> promise);
 

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -12,8 +12,9 @@ namespace workerd::api {
 // =======================================================================================
 // Basic lifecycle methods
 
-Container::Container(rpc::Container::Client rpcClient)
-    : rpcClient(IoContext::current().addObject(kj::heap(kj::mv(rpcClient)))) {}
+Container::Container(rpc::Container::Client rpcClient, bool running)
+    : rpcClient(IoContext::current().addObject(kj::heap(kj::mv(rpcClient)))),
+      running(running) {}
 
 void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions) {
   JSG_REQUIRE(!running, Error, "start() cannot be called on a container that is already running.");

--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -21,7 +21,7 @@ class Fetcher;
 // etc.
 class Container: public jsg::Object {
  public:
-  Container(rpc::Container::Client rpcClient);
+  Container(rpc::Container::Client rpcClient, bool running);
 
   struct StartupOptions {
     jsg::Optional<kj::Array<kj::String>> entrypoint;
@@ -60,9 +60,7 @@ class Container: public jsg::Object {
 
  private:
   IoOwn<rpc::Container::Client> rpcClient;
-
-  // TODO(containers): Actually check if the container is already running when the DO starts.
-  bool running = false;
+  bool running;
 
   kj::Maybe<jsg::Value> destroyReason;
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -483,11 +483,6 @@ struct Worker::Impl {
   kj::Maybe<jsg::Value> env;
   kj::Maybe<jsg::Value> ctxExports;
 
-  struct ActorClassInfo {
-    EntrypointClass cls;
-    bool missingSuperclass;
-  };
-
   // Note: The default export is given the string name "default", because that's what V8 tells us,
   // and so it's easiest to go with it. I guess that means that you can't actually name an export
   // "default"?
@@ -1687,7 +1682,7 @@ Worker::Worker(kj::Own<const Script> scriptParam,
                           for (;;) {
                             if (handle == entrypointClasses.durableObject) {
                               impl->actorClasses.insert(kj::mv(handler.name),
-                                  Impl::ActorClassInfo{
+                                  ActorClassInfo{
                                     .cls = kj::mv(cls),
                                     .missingSuperclass = false,
                                   });
@@ -1708,7 +1703,7 @@ Worker::Worker(kj::Own<const Script> scriptParam,
                               // TODO(someday): Log a warning suggesting extending DurableObject.
                               // TODO(someday): Introduce a compat flag that makes this required.
                               impl->actorClasses.insert(kj::mv(handler.name),
-                                  Impl::ActorClassInfo{
+                                  ActorClassInfo{
                                     .cls = kj::mv(cls),
                                     .missingSuperclass = true,
                                   });
@@ -3207,11 +3202,11 @@ struct Worker::Actor::Impl {
 
   // If the actor is backed by a class, this field tracks the instance through its stages. The
   // instance is constructed as part of the first request to be delivered.
-  kj::OneOf<NoClass,                  // not class-based
-      Worker::Impl::ActorClassInfo*,  // constructor not run yet
-      Initializing,                   // constructor currently running
-      api::ExportedHandler,           // fully constructed
-      kj::Exception                   // constructor threw
+  kj::OneOf<NoClass,            // not class-based
+      Worker::ActorClassInfo*,  // constructor not run yet
+      Initializing,             // constructor currently running
+      api::ExportedHandler,     // fully constructed
+      kj::Exception             // constructor threw
       >
       classInstance;
 
@@ -3444,7 +3439,7 @@ Worker::Actor::Actor(const Worker& worker,
 }
 
 void Worker::Actor::ensureConstructed(IoContext& context) {
-  KJ_IF_SOME(info, impl->classInstance.tryGet<Worker::Impl::ActorClassInfo*>()) {
+  KJ_IF_SOME(info, impl->classInstance.tryGet<Worker::ActorClassInfo*>()) {
     context.addWaitUntil(context
                              .run([this, &info = *info](Worker::Lock& lock) {
       jsg::Lock& js = lock;
@@ -3606,7 +3601,7 @@ void Worker::Actor::assertCanSetAlarm() {
       JSG_FAIL_REQUIRE(
           TypeError, "Your Durable Object must be class-based in order to call setAlarm()");
     }
-    KJ_CASE_ONEOF(_, Worker::Impl::ActorClassInfo*) {
+    KJ_CASE_ONEOF(_, Worker::ActorClassInfo*) {
       KJ_FAIL_ASSERT("setAlarm() invoked before Durable Object ctor");
     }
     KJ_CASE_ONEOF(_, Impl::Initializing) {
@@ -3750,7 +3745,7 @@ kj::Maybe<api::ExportedHandler&> Worker::Actor::getHandler() {
     KJ_CASE_ONEOF(_, Impl::NoClass) {
       return kj::none;
     }
-    KJ_CASE_ONEOF(_, Worker::Impl::ActorClassInfo*) {
+    KJ_CASE_ONEOF(_, Worker::ActorClassInfo*) {
       KJ_FAIL_ASSERT("ensureConstructed() wasn't called");
     }
     KJ_CASE_ONEOF(_, Impl::Initializing) {

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -879,6 +879,8 @@ class Worker::Actor final: public kj::Refcounted {
 
   kj::Maybe<api::ExportedHandler&> getHandler();
   friend class Worker;
+
+  kj::Promise<void> ensureConstructedImpl(IoContext&, ActorClassInfo& info);
 };
 
 // =======================================================================================

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -179,6 +179,11 @@ class Worker: public kj::AtomicRefcounted {
 
   kj::HashMap<kj::String, ConnectFn> connectOverrides;
 
+  struct ActorClassInfo {
+    EntrypointClass cls;
+    bool missingSuperclass;
+  };
+
   class InspectorClient;
   class AsyncWaiter;
   friend constexpr bool _kj_internal_isPolymorphic(AsyncWaiter*);


### PR DESCRIPTION
This way we can construct the `Container` API object with a correct value for the `.running` property.