### PR TITLE
fix devcontainer setup on aarch64 macos

### DIFF
--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -20,6 +20,7 @@
 -isystem/usr/lib/llvm-16/include/c++/v1
 -isystem/usr/lib/llvm-16/lib/clang/16/include
 -isystem/usr/include/x86_64-linux-gnu
+-isystem/usr/include/aarch64-linux-gnu
 -isystem/usr/include
 -isystem/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1
 -isystem/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/16/include


### PR DESCRIPTION
Without this patch, if I open the project in a devcontainer from macos, I get the following error from clangd, and broken go-to-definition etc:

```
In included file: 'bits/wordsize.h' file not foundclang(pp_file_not_found)
features-time64.h(20, 10): Error occurred here
sqlite.h
/workspaces/workerd/src/workerd/util/sqlite.h
```

The problem is that `FROM mcr.microsoft.com/vscode/devcontainers/base:dev-bookworm` brings in an aarch64 ("arm64") debian base image by default on arm macos. This provides `/usr/include/aarch64-linux-gnu` instead of `/usr/include/x86_64-linux-gnu`.

I have put aarch64 lower down on the include path than x86_64, just in case someone on desktop linux has some crazy multiarch/cross compilation setup going on. I have no idea whether this will work, or cause other problems. Seems feasible though, right?

It might be that this isn't the correct way to solve this, and we should instead force everyone onto an x86_64 base image or something. Feel free to close, and I can have another stab with a different approach.