### PR TITLE
Fixes Python pkg import processing.

### DIFF
--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -259,7 +259,7 @@ function memorySnapshotDoImports(Module: Module): string[] {
   // grab them and put them into a set for fast filtering.
   const importedModules: string[] =
     ArtifactBundler.constructor.filterPythonScriptImportsJs(
-      MetadataReader.getNames(),
+      MetadataReader.getNames('py'),
       ArtifactBundler.constructor.parsePythonScriptImports(
         MetadataReader.getWorkerFiles('py')
       )

--- a/src/pyodide/types/runtime-generated/metadata.d.ts
+++ b/src/pyodide/types/runtime-generated/metadata.d.ts
@@ -6,7 +6,7 @@ declare namespace MetadataReader {
   const getRequirements: () => string[];
   const getMainModule: () => string;
   const hasMemorySnapshot: () => boolean;
-  const getNames: () => string[];
+  const getNames: (maybeExtFilter?: string) => string[];
   const getWorkerFiles: (ext: string) => string[];
   const getSizes: () => number[];
   const readMemorySnapshot: (

--- a/src/workerd/api/pyodide/pyodide-test.c++
+++ b/src/workerd/api/pyodide/pyodide-test.c++
@@ -248,5 +248,13 @@ KJ_TEST("Filter worker module/__init__.py") {
   KJ_REQUIRE(result.size() == 1);
   KJ_REQUIRE(result[0] == "c");
 }
+
+KJ_TEST("Filters out subdir/submodule") {
+  auto workerModules = strArray("subdir/submodule.py");
+  auto imports = strArray("subdir.submodule");
+  auto result =
+      ArtifactBundler::filterPythonScriptImportsJs(kj::mv(workerModules), kj::mv(imports));
+  KJ_REQUIRE(result.size() == 0);
+}
 }  // namespace
 }  // namespace workerd::api

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -133,7 +133,10 @@ class PyodideMetadataReader: public jsg::Object {
     return kj::str(this->mainModule);
   }
 
-  kj::Array<jsg::JsRef<jsg::JsString>> getNames(jsg::Lock& js);
+  // Returns the filenames of the files inside of the WorkerBundle that end with the specified
+  // file extension.
+  kj::Array<jsg::JsRef<jsg::JsString>> getNames(
+      jsg::Lock& js, jsg::Optional<kj::String> maybeExtFilter);
 
   // Returns files inside the WorkerBundle that end with the specified file extension.
   // Usually called to get all the Python source files with a `py` extension.


### PR DESCRIPTION
* Fixes a regression which caused breakage in validator-upload test.
* Fixes another bug: only .py filenames are considered in pkg imports now in JS (this was inconsistent with the validator)

@hoodmane it's possible I missed something here, but I think we need the `importToModuleFilename` check so I brought it back.