### PR TITLE
[bazel] Improve cc toolchain handling to prepare for further starlarkification

### DIFF
--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -3,7 +3,7 @@ name: Run internal build
 on:
   pull_request:
     paths-ignore:
-      - 'doc/**'
+      - 'docs/**'
       - 'justfile'
       - '.devcontainer'
       - '**/*.md'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'doc/**'
+      - 'docs/**'
       - 'justfile'
       - '.devcontainer'
       - '**/*.md'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   pull_request:
     paths-ignore:
-      - 'doc/**'
+      - 'docs/**'
       - 'justfile'
       - '.devcontainer'
       - '**/*.md'

--- a/.github/workflows/type-snapshot.yml
+++ b/.github/workflows/type-snapshot.yml
@@ -3,7 +3,7 @@ name: Check @cloudflare/workers-types snapshot
 on:
   pull_request:
     paths-ignore:
-      - 'doc/**'
+      - 'docs/**'
       - 'justfile'
       - '.devcontainer'
       - '**/*.md'

--- a/build/cc_ast_dump.bzl
+++ b/build/cc_ast_dump.bzl
@@ -4,8 +4,10 @@ Dump the AST of a given C++ source file
 Based loosely on https://github.com/bazelbuild/rules_cc/blob/main/examples/my_c_compile/my_c_compile.bzl
 """
 
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load("@rules_cc//cc:action_names.bzl", "CPP_COMPILE_ACTION_NAME")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cpp_toolchain", "use_cc_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 
 def _cc_ast_dump_impl(ctx):
     cc_toolchain = find_cpp_toolchain(ctx)
@@ -55,8 +57,7 @@ cc_ast_dump = rule(
         "src": attr.label(mandatory = True, allow_single_file = True),
         "out": attr.output(mandatory = True),
         "deps": attr.label_list(providers = [CcInfo]),
-        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
-    toolchains = use_cpp_toolchain(),  # copybara-use-repo-external-label
+    toolchains = use_cc_toolchain(),  # copybara-use-repo-external-label
     fragments = ["cpp"],
 )


### PR DESCRIPTION
- CcInfo and cc_common will need to be imported in a future Bazel version, and find_cpp_toolchain / use_cpp_toolchain need to be imported from rules_cc based on the starlarkification effort.
- the _cc_toolchain attribute is obsolete with CC toolchain resolution, which is always-on in Bazel 8.

Drive-by: Fix not having to run tests for docs/ changes on CI.