### PR TITLE
Be able to pass environment variables in containers start()

### DIFF
--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -26,10 +26,11 @@ class Container: public jsg::Object {
   struct StartupOptions {
     jsg::Optional<kj::Array<kj::String>> entrypoint;
     bool enableInternet = false;
+    jsg::Optional<jsg::Dict<kj::String>> env;
 
     // TODO(containers): Allow intercepting stdin/stdout/stderr by specifying streams here.
 
-    JSG_STRUCT(entrypoint, enableInternet);
+    JSG_STRUCT(entrypoint, enableInternet, env);
   };
 
   bool getRunning() {

--- a/src/workerd/io/container.capnp
+++ b/src/workerd/io/container.capnp
@@ -27,6 +27,13 @@ interface Container @0x9aaceefc06523bca {
     # Set true to enable the container to talk directly to the public internet. Otherwise, the
     # public internet will not be accessible -- but it's still possible to intercept connection
     # attempts and handle them in the DO, using the "listen" methods below.
+
+    environmentVariables @2 :List(Text);
+    # Specifies the environment variables of the container.
+    # It will spread over the existing defined environment variables of the container image.
+    # If null, the container will start with the environment variables defined in its image.
+    # The format is defined as a list of `NAME=VALUE`.
+    # The container runtime should validate the environment variables input.
   }
 
   monitor @2 ();

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -3413,6 +3413,7 @@ interface Container {
 interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -3425,6 +3425,7 @@ export interface Container {
 export interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -3439,6 +3439,7 @@ interface Container {
 interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -3451,6 +3451,7 @@ export interface Container {
 export interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -3464,6 +3464,7 @@ interface Container {
 interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -3476,6 +3476,7 @@ export interface Container {
 export interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -3465,6 +3465,7 @@ interface Container {
 interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -3477,6 +3477,7 @@ export interface Container {
 export interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -3469,6 +3469,7 @@ interface Container {
 interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -3481,6 +3481,7 @@ export interface Container {
 export interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -3474,6 +3474,7 @@ interface Container {
 interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -3486,6 +3486,7 @@ export interface Container {
 export interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -3476,6 +3476,7 @@ interface Container {
 interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -3488,6 +3488,7 @@ export interface Container {
 export interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -3476,6 +3476,7 @@ interface Container {
 interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -3488,6 +3488,7 @@ export interface Container {
 export interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3557,6 +3557,7 @@ interface Container {
 interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3569,6 +3569,7 @@ export interface Container {
 export interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -3413,6 +3413,7 @@ interface Container {
 interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -3425,6 +3425,7 @@ export interface Container {
 export interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
+  env?: Record<string, string>;
 }
 export type AiImageClassificationInput = {
   image: number[];


### PR DESCRIPTION
We are just defining in the container capnp schema the `environmentVariables` property, and the `env` property in the start options. 
The user will be able to pass environment variables like this:
```
this.ctx.container.start({ 
  env: {
    A: "C",
    C: "A",
  },
});
```

If the container image is already configured to have `A=C`, it will override it and set `A` to `B`. New environment variables are just appended. It's up to the container runtime to implement this behaviour correctly.