### PR TITLE
WPT harness hooks: before, after, replace

### DIFF
--- a/src/wpt/url-test.ts
+++ b/src/wpt/url-test.ts
@@ -33,8 +33,16 @@ export default {
     skipAllTests: true,
   },
   'toascii.window.js': {
-    comment: 'Implement document',
-    skipAllTests: true,
+    comment:
+      'Replacer disables tests involving document.createElement. Expected failures are due to Unicode 15.1',
+    expectedFailures: [
+      // Taken from https://github.com/nodejs/node/blob/5ab7c4c5b01e7579fd436000232f0f0484289d44/test/wpt/status/url.json#L13
+      '\uD87E\uDC68.com (using URL)',
+      '\uD87E\uDC68.com (using URL.host)',
+      '\uD87E\uDC68.com (using URL.hostname)',
+    ],
+    replace: (code): string =>
+      code.replace(/\["url", "a", "area"\]/, '[ "url" ]'),
   },
   'url-constructor.any.js': {
     comment: 'Fix this eventually',


### PR DESCRIPTION
Adds some hooks requested by @anonrig to the WPT harness which can be implemented to modify the test:
- before: run code before the test
- after: run code after the test
- replace: perform an arbitrary modification to the code of the test

The replace hook is used in this PR to enable the test`toascii.window.js` by removing the DOM manipulation stuff from it, just like NodeJS does.