### PR TITLE
Update npm dependencies

### DIFF
--- a/build/wd_test.bzl
+++ b/build/wd_test.bzl
@@ -31,7 +31,10 @@ def wd_test(
 
     if len(ts_srcs) != 0:
         # Generated declarations are currently not being used, but required based on https://github.com/aspect-build/rules_ts/issues/719
-        # TODO When TypeScript 5.6 comes out use noCheck so the test fails throwing a type error.
+        # TODO(build perf): Consider adopting isolated_typecheck to avoid bottlebecks in TS
+        # compilation, see https://github.com/aspect-build/rules_ts/blob/f1b7b83/docs/performance.md#isolated-typecheck.
+        # This will require extensive refactoring and we may only want to enable it for some
+        # targets, but might be useful if we end up transpiling more code later on.
         ts_project(
             name = name + "@ts_project",
             srcs = ts_srcs,

--- a/package.json
+++ b/package.json
@@ -7,20 +7,20 @@
   },
   "dependencies": {
     "capnp-ts": "^0.7.0",
-    "prettier": "^3.5.0",
-    "typescript": "5.5.4"
+    "prettier": "^3.5.1",
+    "typescript": "5.6.2"
   },
   "devDependencies": {
-    "@eslint/js": "^9.19.0",
+    "@eslint/js": "^9.20.0",
     "@types/debug": "^4.1.12",
-    "@types/node": "^20.16.5",
+    "@types/node": "^22.7.5",
     "capnpc-ts": "^0.7.0",
-    "chrome-remote-interface": "^0.33.2",
+    "chrome-remote-interface": "^0.33.3",
     "esbuild": "^0.25.0",
-    "eslint": "^9.19.0",
+    "eslint": "^9.20.1",
     "eslint-plugin-import": "^2.31.0",
     "expect-type": "^1.1.0",
-    "typescript-eslint": "^8.22.0"
+    "typescript-eslint": "^8.23.0"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,42 +15,42 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0
       prettier:
-        specifier: ^3.5.0
-        version: 3.5.0
+        specifier: ^3.5.1
+        version: 3.5.1
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.2
+        version: 5.6.2
     devDependencies:
       '@eslint/js':
-        specifier: ^9.19.0
-        version: 9.19.0
+        specifier: ^9.20.0
+        version: 9.20.0
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
       '@types/node':
-        specifier: ^20.16.5
-        version: 20.16.5
+        specifier: ^22.7.5
+        version: 22.7.5
       capnpc-ts:
         specifier: ^0.7.0
         version: 0.7.0
       chrome-remote-interface:
-        specifier: ^0.33.2
-        version: 0.33.2
+        specifier: ^0.33.3
+        version: 0.33.3
       esbuild:
         specifier: ^0.25.0
         version: 0.25.0
       eslint:
-        specifier: ^9.19.0
-        version: 9.19.0
+        specifier: ^9.20.1
+        version: 9.20.1
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.22.0(eslint@9.19.0)(typescript@5.5.4))(eslint@9.19.0)
+        version: 2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.20.1)(typescript@5.6.2))(eslint@9.20.1)
       expect-type:
         specifier: ^1.1.0
         version: 1.1.0
       typescript-eslint:
-        specifier: ^8.22.0
-        version: 8.22.0(eslint@9.19.0)(typescript@5.5.4)
+        specifier: ^8.23.0
+        version: 8.23.0(eslint@9.20.1)(typescript@5.6.2)
 
 packages:
 
@@ -204,15 +204,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.4.0':
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+  '@eslint-community/eslint-utils@4.4.1':
+    resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
-  '@eslint-community/regexpp@4.11.1':
-    resolution: {integrity: sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
@@ -226,12 +222,16 @@ packages:
     resolution: {integrity: sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/core@0.11.0':
+    resolution: {integrity: sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/eslintrc@3.2.0':
     resolution: {integrity: sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.19.0':
-    resolution: {integrity: sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==}
+  '@eslint/js@9.20.0':
+    resolution: {integrity: sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.5':
@@ -292,54 +292,54 @@ packages:
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
-  '@types/node@20.16.5':
-    resolution: {integrity: sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==}
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
-  '@typescript-eslint/eslint-plugin@8.22.0':
-    resolution: {integrity: sha512-4Uta6REnz/xEJMvwf72wdUnC3rr4jAQf5jnTkeRQ9b6soxLxhDEbS/pfMPoJLDfFPNVRdryqWUIV/2GZzDJFZw==}
+  '@typescript-eslint/eslint-plugin@8.23.0':
+    resolution: {integrity: sha512-vBz65tJgRrA1Q5gWlRfvoH+w943dq9K1p1yDBY2pc+a1nbBLZp7fB9+Hk8DaALUbzjqlMfgaqlVPT1REJdkt/w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/parser@8.22.0':
-    resolution: {integrity: sha512-MqtmbdNEdoNxTPzpWiWnqNac54h8JDAmkWtJExBVVnSrSmi9z+sZUt0LfKqk9rjqmKOIeRhO4fHHJ1nQIjduIQ==}
+  '@typescript-eslint/parser@8.23.0':
+    resolution: {integrity: sha512-h2lUByouOXFAlMec2mILeELUbME5SZRN/7R9Cw2RD2lRQQY08MWMM+PmVVKKJNK1aIwqTo9t/0CvOxwPbRIE2Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/scope-manager@8.22.0':
-    resolution: {integrity: sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==}
+  '@typescript-eslint/scope-manager@8.23.0':
+    resolution: {integrity: sha512-OGqo7+dXHqI7Hfm+WqkZjKjsiRtFUQHPdGMXzk5mYXhJUedO7e/Y7i8AK3MyLMgZR93TX4bIzYrfyVjLC+0VSw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/type-utils@8.22.0':
-    resolution: {integrity: sha512-NzE3aB62fDEaGjaAYZE4LH7I1MUwHooQ98Byq0G0y3kkibPJQIXVUspzlFOmOfHhiDLwKzMlWxaNv+/qcZurJA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.8.0'
-
-  '@typescript-eslint/types@8.22.0':
-    resolution: {integrity: sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.22.0':
-    resolution: {integrity: sha512-SJX99NAS2ugGOzpyhMza/tX+zDwjvwAtQFLsBo3GQxiGcvaKlqGBkmZ+Y1IdiSi9h4Q0Lr5ey+Cp9CGWNY/F/w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <5.8.0'
-
-  '@typescript-eslint/utils@8.22.0':
-    resolution: {integrity: sha512-T8oc1MbF8L+Bk2msAvCUzjxVB2Z2f+vXYfcucE2wOmYs7ZUwco5Ep0fYZw8quNwOiw9K8GYVL+Kgc2pETNTLOg==}
+  '@typescript-eslint/type-utils@8.23.0':
+    resolution: {integrity: sha512-iIuLdYpQWZKbiH+RkCGc6iu+VwscP5rCtQ1lyQ7TYuKLrcZoeJVpcLiG8DliXVkUxirW/PWlmS+d6yD51L9jvA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/visitor-keys@8.22.0':
-    resolution: {integrity: sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==}
+  '@typescript-eslint/types@8.23.0':
+    resolution: {integrity: sha512-1sK4ILJbCmZOTt9k4vkoulT6/y5CHJ1qUYxqpF1K/DBAd8+ZUL4LlSCxOssuH5m4rUaaN0uS0HlVPvd45zjduQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.23.0':
+    resolution: {integrity: sha512-LcqzfipsB8RTvH8FX24W4UUFk1bl+0yTOf9ZA08XngFwMg4Kj8A+9hwz8Cr/ZS4KwHrmo9PJiLZkOt49vPnuvQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/utils@8.23.0':
+    resolution: {integrity: sha512-uB/+PSo6Exu02b5ZEiVtmY6RVYO7YU5xqgzTIVZwTHvvK3HsL8tZZHFaTLFtRG3CsV4A5mhOv+NZx5BlhXPyIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/visitor-keys@8.23.0':
+    resolution: {integrity: sha512-oWWhcWDLwDfu++BGTZcmXWqpwtkwb5o7fxUIGksMQQDSdPW9prsSnfIOZMlsj4vBOSrcnjIUZMiIjODgGosFhQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   acorn-jsx@5.3.2:
@@ -425,8 +425,8 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  chrome-remote-interface@0.33.2:
-    resolution: {integrity: sha512-wvm9cOeBTrb218EC+6DteGt92iXr2iY0+XJP30f15JVDhqvWvJEVACh9GvUm8b9Yd8bxQivaLSb8k7mgrbyomQ==}
+  chrome-remote-interface@0.33.3:
+    resolution: {integrity: sha512-zNnn0prUL86Teru6UCAZ1yU1XeXljHl3gj7OrfPcarEfU62OUU4IujDPdTDW3dAWwRqN3ZMG/Chhkh2gPL/wiw==}
     hasBin: true
 
   color-convert@2.0.1:
@@ -468,6 +468,15 @@ packages:
 
   debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -572,8 +581,8 @@ packages:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.19.0:
-    resolution: {integrity: sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==}
+  eslint@9.20.1:
+    resolution: {integrity: sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -609,8 +618,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-glob@3.3.2:
-    resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
   fast-json-stable-stringify@2.1.0:
@@ -619,8 +628,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fastq@1.17.1:
-    resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
+  fastq@1.19.0:
+    resolution: {integrity: sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -935,8 +944,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.5.0:
-    resolution: {integrity: sha512-quyMrVt6svPS7CjQ9gKb3GLEX/rl3BCL2oa/QkNcXv4YNVBC9olt3s+H7ukto06q7B1Qz46PbrKLO34PR6vXcA==}
+  prettier@3.5.1:
+    resolution: {integrity: sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -978,8 +987,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.6.3:
-    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1034,8 +1043,8 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  ts-api-utils@2.0.0:
-    resolution: {integrity: sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==}
+  ts-api-utils@2.0.1:
+    resolution: {integrity: sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -1066,8 +1075,8 @@ packages:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
 
-  typescript-eslint@8.22.0:
-    resolution: {integrity: sha512-Y2rj210FW1Wb6TWXzQc5+P+EWI9/zdS57hLEc0gnyuvdzWo8+Y8brKlbj0muejonhMI/xAZCnZZwjbIfv1CkOw==}
+  typescript-eslint@8.23.0:
+    resolution: {integrity: sha512-/LBRo3HrXr5LxmrdYSOCvoAMm7p2jNizNfbIpCgvG4HMsnoprRUOce/+8VJ9BDYWW68rqIENE/haVLWPeFZBVQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1078,8 +1087,8 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  typescript@5.5.4:
-    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+  typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1204,19 +1213,17 @@ snapshots:
   '@esbuild/win32-x64@0.25.0':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@9.19.0)':
+  '@eslint-community/eslint-utils@4.4.1(eslint@9.20.1)':
     dependencies:
-      eslint: 9.19.0
+      eslint: 9.20.1
       eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/regexpp@4.11.1': {}
 
   '@eslint-community/regexpp@4.12.1': {}
 
   '@eslint/config-array@0.19.1':
     dependencies:
       '@eslint/object-schema': 2.1.5
-      debug: 4.3.7
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -1225,10 +1232,14 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/core@0.11.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
   '@eslint/eslintrc@3.2.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7
+      debug: 4.4.0
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -1239,7 +1250,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.19.0': {}
+  '@eslint/js@9.20.0': {}
 
   '@eslint/object-schema@2.1.5': {}
 
@@ -1271,7 +1282,7 @@ snapshots:
   '@nodelib/fs.walk@1.2.8':
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.17.1
+      fastq: 1.19.0
 
   '@rtsao/scc@1.1.0': {}
 
@@ -1287,85 +1298,85 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
-  '@types/node@20.16.5':
+  '@types/node@22.7.5':
     dependencies:
       undici-types: 6.19.8
 
-  '@typescript-eslint/eslint-plugin@8.22.0(@typescript-eslint/parser@8.22.0(eslint@9.19.0)(typescript@5.5.4))(eslint@9.19.0)(typescript@5.5.4)':
+  '@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.20.1)(typescript@5.6.2))(eslint@9.20.1)(typescript@5.6.2)':
     dependencies:
-      '@eslint-community/regexpp': 4.11.1
-      '@typescript-eslint/parser': 8.22.0(eslint@9.19.0)(typescript@5.5.4)
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/type-utils': 8.22.0(eslint@9.19.0)(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.22.0(eslint@9.19.0)(typescript@5.5.4)
-      '@typescript-eslint/visitor-keys': 8.22.0
-      eslint: 9.19.0
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.23.0(eslint@9.20.1)(typescript@5.6.2)
+      '@typescript-eslint/scope-manager': 8.23.0
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.1)(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.1)(typescript@5.6.2)
+      '@typescript-eslint/visitor-keys': 8.23.0
+      eslint: 9.20.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 2.0.0(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 2.0.1(typescript@5.6.2)
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.22.0(eslint@9.19.0)(typescript@5.5.4)':
+  '@typescript-eslint/parser@8.23.0(eslint@9.20.1)(typescript@5.6.2)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/types': 8.22.0
-      '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.5.4)
-      '@typescript-eslint/visitor-keys': 8.22.0
-      debug: 4.3.7
-      eslint: 9.19.0
-      typescript: 5.5.4
+      '@typescript-eslint/scope-manager': 8.23.0
+      '@typescript-eslint/types': 8.23.0
+      '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.6.2)
+      '@typescript-eslint/visitor-keys': 8.23.0
+      debug: 4.4.0
+      eslint: 9.20.1
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.22.0':
+  '@typescript-eslint/scope-manager@8.23.0':
     dependencies:
-      '@typescript-eslint/types': 8.22.0
-      '@typescript-eslint/visitor-keys': 8.22.0
+      '@typescript-eslint/types': 8.23.0
+      '@typescript-eslint/visitor-keys': 8.23.0
 
-  '@typescript-eslint/type-utils@8.22.0(eslint@9.19.0)(typescript@5.5.4)':
+  '@typescript-eslint/type-utils@8.23.0(eslint@9.20.1)(typescript@5.6.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.22.0(eslint@9.19.0)(typescript@5.5.4)
-      debug: 4.3.7
-      eslint: 9.19.0
-      ts-api-utils: 2.0.0(typescript@5.5.4)
-      typescript: 5.5.4
+      '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.1)(typescript@5.6.2)
+      debug: 4.4.0
+      eslint: 9.20.1
+      ts-api-utils: 2.0.1(typescript@5.6.2)
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.22.0': {}
+  '@typescript-eslint/types@8.23.0': {}
 
-  '@typescript-eslint/typescript-estree@8.22.0(typescript@5.5.4)':
+  '@typescript-eslint/typescript-estree@8.23.0(typescript@5.6.2)':
     dependencies:
-      '@typescript-eslint/types': 8.22.0
-      '@typescript-eslint/visitor-keys': 8.22.0
-      debug: 4.3.7
-      fast-glob: 3.3.2
+      '@typescript-eslint/types': 8.23.0
+      '@typescript-eslint/visitor-keys': 8.23.0
+      debug: 4.4.0
+      fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.6.3
-      ts-api-utils: 2.0.0(typescript@5.5.4)
-      typescript: 5.5.4
+      semver: 7.7.1
+      ts-api-utils: 2.0.1(typescript@5.6.2)
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.22.0(eslint@9.19.0)(typescript@5.5.4)':
+  '@typescript-eslint/utils@8.23.0(eslint@9.20.1)(typescript@5.6.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.19.0)
-      '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/types': 8.22.0
-      '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.5.4)
-      eslint: 9.19.0
-      typescript: 5.5.4
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.1)
+      '@typescript-eslint/scope-manager': 8.23.0
+      '@typescript-eslint/types': 8.23.0
+      '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.6.2)
+      eslint: 9.20.1
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.22.0':
+  '@typescript-eslint/visitor-keys@8.23.0':
     dependencies:
-      '@typescript-eslint/types': 8.22.0
+      '@typescript-eslint/types': 8.23.0
       eslint-visitor-keys: 4.2.0
 
   acorn-jsx@5.3.2(acorn@8.14.0):
@@ -1496,7 +1507,7 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chrome-remote-interface@0.33.2:
+  chrome-remote-interface@0.33.3:
     dependencies:
       commander: 2.11.0
       ws: 7.5.10
@@ -1543,6 +1554,10 @@ snapshots:
       ms: 2.1.3
 
   debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.0:
     dependencies:
       ms: 2.1.3
 
@@ -1677,17 +1692,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.22.0(eslint@9.19.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@9.19.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.20.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@9.20.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.22.0(eslint@9.19.0)(typescript@5.5.4)
-      eslint: 9.19.0
+      '@typescript-eslint/parser': 8.23.0(eslint@9.20.1)(typescript@5.6.2)
+      eslint: 9.20.1
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.22.0(eslint@9.19.0)(typescript@5.5.4))(eslint@9.19.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.23.0(eslint@9.20.1)(typescript@5.6.2))(eslint@9.20.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -1696,9 +1711,9 @@ snapshots:
       array.prototype.flatmap: 1.3.2
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.19.0
+      eslint: 9.20.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.22.0(eslint@9.19.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@9.19.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.20.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@9.20.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -1710,7 +1725,7 @@ snapshots:
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.22.0(eslint@9.19.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.23.0(eslint@9.20.1)(typescript@5.6.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -1725,14 +1740,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint@9.19.0:
+  eslint@9.20.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.19.0)
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.1)
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.19.1
-      '@eslint/core': 0.10.0
+      '@eslint/core': 0.11.0
       '@eslint/eslintrc': 3.2.0
-      '@eslint/js': 9.19.0
+      '@eslint/js': 9.20.0
       '@eslint/plugin-kit': 0.2.5
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
@@ -1742,7 +1757,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7
+      debug: 4.4.0
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -1786,7 +1801,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-glob@3.3.2:
+  fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       '@nodelib/fs.walk': 1.2.8
@@ -1798,7 +1813,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fastq@1.17.1:
+  fastq@1.19.0:
     dependencies:
       reusify: 1.0.4
 
@@ -2099,7 +2114,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.5.0: {}
+  prettier@3.5.1: {}
 
   punycode@2.3.1: {}
 
@@ -2141,7 +2156,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.6.3: {}
+  semver@7.7.1: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -2205,9 +2220,9 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  ts-api-utils@2.0.0(typescript@5.5.4):
+  ts-api-utils@2.0.1(typescript@5.6.2):
     dependencies:
-      typescript: 5.5.4
+      typescript: 5.6.2
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -2254,19 +2269,19 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
 
-  typescript-eslint@8.22.0(eslint@9.19.0)(typescript@5.5.4):
+  typescript-eslint@8.23.0(eslint@9.20.1)(typescript@5.6.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.22.0(@typescript-eslint/parser@8.22.0(eslint@9.19.0)(typescript@5.5.4))(eslint@9.19.0)(typescript@5.5.4)
-      '@typescript-eslint/parser': 8.22.0(eslint@9.19.0)(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.22.0(eslint@9.19.0)(typescript@5.5.4)
-      eslint: 9.19.0
-      typescript: 5.5.4
+      '@typescript-eslint/eslint-plugin': 8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.20.1)(typescript@5.6.2))(eslint@9.20.1)(typescript@5.6.2)
+      '@typescript-eslint/parser': 8.23.0(eslint@9.20.1)(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.1)(typescript@5.6.2)
+      eslint: 9.20.1
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
   typescript@4.7.4: {}
 
-  typescript@5.5.4: {}
+  typescript@5.6.2: {}
 
   unbox-primitive@1.0.2:
     dependencies:

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -77,7 +77,7 @@ interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -318,9 +318,9 @@ declare function removeEventListener<
 declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 declare function setTimeout(
@@ -1322,15 +1322,10 @@ interface TextEncoderEncodeIntoResult {
  */
 declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 interface ErrorEventErrorEventInit {
@@ -1661,11 +1656,7 @@ interface Request<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   readonly integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   readonly keepalive: boolean;
 }
 interface RequestInit<Cf = CfProperties> {

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -77,7 +77,7 @@ export interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ export interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ export interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -320,9 +320,9 @@ export declare function removeEventListener<
 export declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 export declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 export declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 export declare function setTimeout(
@@ -1327,15 +1327,10 @@ export interface TextEncoderEncodeIntoResult {
  */
 export declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 export interface ErrorEventErrorEventInit {
@@ -1669,11 +1664,7 @@ export interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   readonly integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   readonly keepalive: boolean;
 }
 export interface RequestInit<Cf = CfProperties> {

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -77,7 +77,7 @@ interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -318,9 +318,9 @@ declare function removeEventListener<
 declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 declare function setTimeout(
@@ -1328,15 +1328,10 @@ interface TextEncoderEncodeIntoResult {
  */
 declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 interface ErrorEventErrorEventInit {
@@ -1667,11 +1662,7 @@ interface Request<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 interface RequestInit<Cf = CfProperties> {

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -77,7 +77,7 @@ export interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ export interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ export interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -320,9 +320,9 @@ export declare function removeEventListener<
 export declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 export declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 export declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 export declare function setTimeout(
@@ -1333,15 +1333,10 @@ export interface TextEncoderEncodeIntoResult {
  */
 export declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 export interface ErrorEventErrorEventInit {
@@ -1675,11 +1670,7 @@ export interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 export interface RequestInit<Cf = CfProperties> {

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -77,7 +77,7 @@ interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -320,9 +320,9 @@ declare function removeEventListener<
 declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 declare function setTimeout(
@@ -1346,15 +1346,10 @@ interface TextEncoderEncodeIntoResult {
  */
 declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 interface ErrorEventErrorEventInit {
@@ -1685,11 +1680,7 @@ interface Request<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 interface RequestInit<Cf = CfProperties> {

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -77,7 +77,7 @@ export interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ export interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ export interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -322,9 +322,9 @@ export declare function removeEventListener<
 export declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 export declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 export declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 export declare function setTimeout(
@@ -1351,15 +1351,10 @@ export interface TextEncoderEncodeIntoResult {
  */
 export declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 export interface ErrorEventErrorEventInit {
@@ -1693,11 +1688,7 @@ export interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 export interface RequestInit<Cf = CfProperties> {

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -77,7 +77,7 @@ interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -320,9 +320,9 @@ declare function removeEventListener<
 declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 declare function setTimeout(
@@ -1346,15 +1346,10 @@ interface TextEncoderEncodeIntoResult {
  */
 declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 interface ErrorEventErrorEventInit {
@@ -1685,11 +1680,7 @@ interface Request<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 interface RequestInit<Cf = CfProperties> {

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -77,7 +77,7 @@ export interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ export interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ export interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -322,9 +322,9 @@ export declare function removeEventListener<
 export declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 export declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 export declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 export declare function setTimeout(
@@ -1351,15 +1351,10 @@ export interface TextEncoderEncodeIntoResult {
  */
 export declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 export interface ErrorEventErrorEventInit {
@@ -1693,11 +1688,7 @@ export interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 export interface RequestInit<Cf = CfProperties> {

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -77,7 +77,7 @@ interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -320,9 +320,9 @@ declare function removeEventListener<
 declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 declare function setTimeout(
@@ -1346,15 +1346,10 @@ interface TextEncoderEncodeIntoResult {
  */
 declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 interface ErrorEventErrorEventInit {
@@ -1685,11 +1680,7 @@ interface Request<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 interface RequestInit<Cf = CfProperties> {
@@ -2600,6 +2591,7 @@ declare class URL {
   toString(): string;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
   static canParse(url: string, base?: string): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
   static parse(url: string, base?: string): URL | null;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
   static createObjectURL(object: File | Blob): string;

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -77,7 +77,7 @@ export interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ export interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ export interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -322,9 +322,9 @@ export declare function removeEventListener<
 export declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 export declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 export declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 export declare function setTimeout(
@@ -1351,15 +1351,10 @@ export interface TextEncoderEncodeIntoResult {
  */
 export declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 export interface ErrorEventErrorEventInit {
@@ -1693,11 +1688,7 @@ export interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 export interface RequestInit<Cf = CfProperties> {
@@ -2612,6 +2603,7 @@ export declare class URL {
   toString(): string;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
   static canParse(url: string, base?: string): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
   static parse(url: string, base?: string): URL | null;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
   static createObjectURL(object: File | Blob): string;

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -77,7 +77,7 @@ interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -325,9 +325,9 @@ declare function removeEventListener<
 declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 declare function setTimeout(
@@ -1351,15 +1351,10 @@ interface TextEncoderEncodeIntoResult {
  */
 declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 interface ErrorEventErrorEventInit {
@@ -1690,11 +1685,7 @@ interface Request<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 interface RequestInit<Cf = CfProperties> {
@@ -2605,6 +2596,7 @@ declare class URL {
   toString(): string;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
   static canParse(url: string, base?: string): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
   static parse(url: string, base?: string): URL | null;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
   static createObjectURL(object: File | Blob): string;

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -77,7 +77,7 @@ export interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ export interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ export interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -327,9 +327,9 @@ export declare function removeEventListener<
 export declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 export declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 export declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 export declare function setTimeout(
@@ -1356,15 +1356,10 @@ export interface TextEncoderEncodeIntoResult {
  */
 export declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 export interface ErrorEventErrorEventInit {
@@ -1698,11 +1693,7 @@ export interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 export interface RequestInit<Cf = CfProperties> {
@@ -2617,6 +2608,7 @@ export declare class URL {
   toString(): string;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
   static canParse(url: string, base?: string): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
   static parse(url: string, base?: string): URL | null;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
   static createObjectURL(object: File | Blob): string;

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -77,7 +77,7 @@ interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -325,9 +325,9 @@ declare function removeEventListener<
 declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 declare function setTimeout(
@@ -1351,15 +1351,10 @@ interface TextEncoderEncodeIntoResult {
  */
 declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 interface ErrorEventErrorEventInit {
@@ -1692,11 +1687,7 @@ interface Request<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 interface RequestInit<Cf = CfProperties> {
@@ -2607,6 +2598,7 @@ declare class URL {
   toString(): string;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
   static canParse(url: string, base?: string): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
   static parse(url: string, base?: string): URL | null;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
   static createObjectURL(object: File | Blob): string;

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -77,7 +77,7 @@ export interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ export interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ export interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -327,9 +327,9 @@ export declare function removeEventListener<
 export declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 export declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 export declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 export declare function setTimeout(
@@ -1356,15 +1356,10 @@ export interface TextEncoderEncodeIntoResult {
  */
 export declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 export interface ErrorEventErrorEventInit {
@@ -1700,11 +1695,7 @@ export interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 export interface RequestInit<Cf = CfProperties> {
@@ -2619,6 +2610,7 @@ export declare class URL {
   toString(): string;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
   static canParse(url: string, base?: string): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
   static parse(url: string, base?: string): URL | null;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
   static createObjectURL(object: File | Blob): string;

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -77,7 +77,7 @@ interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -325,9 +325,9 @@ declare function removeEventListener<
 declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 declare function setTimeout(
@@ -1351,15 +1351,10 @@ interface TextEncoderEncodeIntoResult {
  */
 declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 interface ErrorEventErrorEventInit {
@@ -1692,11 +1687,7 @@ interface Request<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 interface RequestInit<Cf = CfProperties> {
@@ -2607,6 +2598,7 @@ declare class URL {
   toString(): string;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
   static canParse(url: string, base?: string): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
   static parse(url: string, base?: string): URL | null;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
   static createObjectURL(object: File | Blob): string;

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -77,7 +77,7 @@ export interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ export interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ export interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -327,9 +327,9 @@ export declare function removeEventListener<
 export declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 export declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 export declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 export declare function setTimeout(
@@ -1356,15 +1356,10 @@ export interface TextEncoderEncodeIntoResult {
  */
 export declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 export interface ErrorEventErrorEventInit {
@@ -1700,11 +1695,7 @@ export interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
 }
 export interface RequestInit<Cf = CfProperties> {
@@ -2619,6 +2610,7 @@ export declare class URL {
   toString(): string;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
   static canParse(url: string, base?: string): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
   static parse(url: string, base?: string): URL | null;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
   static createObjectURL(object: File | Blob): string;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -77,7 +77,7 @@ interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -325,9 +325,9 @@ declare function removeEventListener<
 declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 declare function setTimeout(
@@ -1361,15 +1361,10 @@ interface TextEncoderEncodeIntoResult {
  */
 declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 interface ErrorEventErrorEventInit {
@@ -1702,11 +1697,7 @@ interface Request<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
   /**
    * Returns the cache mode associated with request, which is a string indicating how the request will interact with the browser's cache when fetching.
@@ -2679,6 +2670,7 @@ declare class URL {
   toString(): string;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
   static canParse(url: string, base?: string): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
   static parse(url: string, base?: string): URL | null;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
   static createObjectURL(object: File | Blob): string;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -77,7 +77,7 @@ export interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ export interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ export interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -327,9 +327,9 @@ export declare function removeEventListener<
 export declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 export declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 export declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 export declare function setTimeout(
@@ -1366,15 +1366,10 @@ export interface TextEncoderEncodeIntoResult {
  */
 export declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 export interface ErrorEventErrorEventInit {
@@ -1710,11 +1705,7 @@ export interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   keepalive: boolean;
   /**
    * Returns the cache mode associated with request, which is a string indicating how the request will interact with the browser's cache when fetching.
@@ -2691,6 +2682,7 @@ export declare class URL {
   toString(): string;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
   static canParse(url: string, base?: string): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
   static parse(url: string, base?: string): URL | null;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
   static createObjectURL(object: File | Blob): string;

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -77,7 +77,7 @@ interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -318,9 +318,9 @@ declare function removeEventListener<
 declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 declare function setTimeout(
@@ -1322,15 +1322,10 @@ interface TextEncoderEncodeIntoResult {
  */
 declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 interface ErrorEventErrorEventInit {
@@ -1661,11 +1656,7 @@ interface Request<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   readonly integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   readonly keepalive: boolean;
 }
 interface RequestInit<Cf = CfProperties> {

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -77,7 +77,7 @@ export interface Console {
   clear(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
   count(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countreset_static) */
   countReset(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
   debug(...data: any[]): void;
@@ -89,9 +89,9 @@ export interface Console {
   error(...data: any[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
   group(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupcollapsed_static) */
   groupCollapsed(...data: any[]): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupend_static) */
   groupEnd(): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
   info(...data: any[]): void;
@@ -101,9 +101,9 @@ export interface Console {
   table(tabularData?: any, properties?: string[]): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
   time(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeend_static) */
   timeEnd(label?: string): void;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timelog_static) */
   timeLog(label?: string, ...data: any[]): void;
   timeStamp(label?: string): void;
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
@@ -320,9 +320,9 @@ export declare function removeEventListener<
 export declare function dispatchEvent(
   event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
 ): boolean;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/btoa) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 export declare function btoa(data: string): string;
-/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/atob) */
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
 export declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/setTimeout) */
 export declare function setTimeout(
@@ -1327,15 +1327,10 @@ export interface TextEncoderEncodeIntoResult {
  */
 export declare class ErrorEvent extends Event {
   constructor(type: string, init?: ErrorEventErrorEventInit);
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
   get filename(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
   get message(): string;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
   get lineno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
   get colno(): number;
-  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
   get error(): any;
 }
 export interface ErrorEventErrorEventInit {
@@ -1669,11 +1664,7 @@ export interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
    */
   readonly integrity: string;
-  /**
-   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-   */
+  /* Returns a boolean indicating whether or not request can outlive the global in which it was created. */
   readonly keepalive: boolean;
 }
 export interface RequestInit<Cf = CfProperties> {


### PR DESCRIPTION
- Notably updates typescript (5.5 -> 5.6) and node types (20 -> 22). typescript-eslint and @types/node were only partially updated based on new errors/lints from imported types.
- Clarify a TODO message about a possible TS configuration improvement – this would be feasible now that we have TS 5.6 but is not a priority for now.

=============

Brings the Nodejs and node types versions back in sync. Also allows us to clean up the dependabot PRs.