### PR TITLE
add a todo for IsolateBase::getUuid()

### DIFF
--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -731,6 +731,8 @@ kj::Maybe<kj::StringPtr> getJsStackTrace(void* ucontext, kj::ArrayPtr<char> scra
 }
 #endif
 
+// TODO(soon): Replace this with Isolate::GetHashSeed() once current v8 release supports it.
+// Ref: https://chromium-review.googlesource.com/c/v8/v8/+/6286748
 kj::StringPtr IsolateBase::getUuid() {
   // Lazily create a random UUID for this isolate.
   KJ_IF_SOME(u, uuid) {


### PR DESCRIPTION
https://chromium-review.googlesource.com/c/v8/v8/+/6286748 has landed. We can get rid of getUuid() and use GetHashSeed() for uniqueness check.

We go from 128 bits to 64 bits but since this is only used for testing, I think we can get away with collisions.