### PR TITLE
WPT dom/abort: Fix missing target on events

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -168,6 +168,10 @@ jsg::Optional<jsg::Ref<EventTarget>> Event::getCurrentTarget() {
   return target.map([&](jsg::Ref<EventTarget>& t) { return t.addRef(); });
 }
 
+jsg::Optional<jsg::Ref<EventTarget>> Event::getTarget() {
+  return getCurrentTarget();
+}
+
 kj::Array<jsg::Ref<EventTarget>> Event::composedPath() {
   if (isBeingDispatched) {
     // When isBeingDispatched is true, target should always be non-null.

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -131,6 +131,10 @@ class Event: public jsg::Object {
   // successfully and will remain set after dispatching is completed.
   jsg::Optional<jsg::Ref<EventTarget>> getCurrentTarget();
 
+  // Because we don't support hierarchical EventTargets, this function
+  // will always return the same value as getCurrentTarget().
+  jsg::Optional<jsg::Ref<EventTarget>> getTarget();
+
   // For our implementation, since we do not support hierarchical EventTargets,
   // the composedPath is always either an empty array if the Event is currently
   // not being dispatched, or an array containing only the currentTarget if
@@ -151,6 +155,7 @@ class Event: public jsg::Object {
       JSG_READONLY_PROTOTYPE_PROPERTY(defaultPrevented, getDefaultPrevented);
       JSG_READONLY_PROTOTYPE_PROPERTY(returnValue, getReturnValue);
       JSG_READONLY_PROTOTYPE_PROPERTY(currentTarget, getCurrentTarget);
+      JSG_READONLY_PROTOTYPE_PROPERTY(target, getTarget);
       JSG_READONLY_PROTOTYPE_PROPERTY(srcElement, getCurrentTarget);
       JSG_READONLY_PROTOTYPE_PROPERTY(timeStamp, getTimestamp);
       JSG_READONLY_PROTOTYPE_PROPERTY(isTrusted, getIsTrusted);
@@ -165,6 +170,7 @@ class Event: public jsg::Object {
       JSG_READONLY_INSTANCE_PROPERTY(defaultPrevented, getDefaultPrevented);
       JSG_READONLY_INSTANCE_PROPERTY(returnValue, getReturnValue);
       JSG_READONLY_INSTANCE_PROPERTY(currentTarget, getCurrentTarget);
+      JSG_READONLY_INSTANCE_PROPERTY(target, getTarget);
       JSG_READONLY_INSTANCE_PROPERTY(srcElement, getCurrentTarget);
       JSG_READONLY_INSTANCE_PROPERTY(timeStamp, getTimestamp);
       JSG_READONLY_INSTANCE_PROPERTY(isTrusted, getIsTrusted);

--- a/src/workerd/api/http-test.js
+++ b/src/workerd/api/http-test.js
@@ -234,6 +234,7 @@ export const inspect = {
   defaultPrevented: false,
   returnValue: true,
   currentTarget: WebSocket { readyState: 1, url: null, protocol: '', extensions: '' },
+  target: WebSocket { readyState: 1, url: null, protocol: '', extensions: '' },
   srcElement: WebSocket { readyState: 1, url: null, protocol: '', extensions: '' },
   timeStamp: 0,
   isTrusted: true,

--- a/src/wpt/dom/abort-test.ts
+++ b/src/wpt/dom/abort-test.ts
@@ -7,18 +7,12 @@ import { type TestRunnerConfig } from 'harness/harness';
 export default {
   'AbortSignal.any.js': {},
   'abort-signal-any.any.js': {
-    comment:
-      '(1, 2) Target should be set to signal. (3) Should be investigated.',
+    comment: 'Order of event firing should be investigated.',
     expectedFailures: [
-      'AbortSignal.any() follows a single signal (using AbortController)',
-      'AbortSignal.any() follows multiple signals (using AbortController)',
       'Abort events for AbortSignal.any() signals fire in the right order (using AbortController)',
     ],
   },
-  'event.any.js': {
-    comment: 'Target should be set to signal',
-    expectedFailures: ['the abort event should have the right properties'],
-  },
+  'event.any.js': {},
   'timeout-shadowrealm.any.js': {
     comment: 'Enable when ShadowRealm is implemented',
     skipAllTests: true,

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -716,6 +716,12 @@ declare class Event {
    */
   readonly currentTarget?: EventTarget;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  readonly target?: EventTarget;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -721,6 +721,12 @@ export declare class Event {
    */
   readonly currentTarget?: EventTarget;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  readonly target?: EventTarget;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -716,6 +716,12 @@ declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -721,6 +721,12 @@ export declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -734,6 +734,12 @@ declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -739,6 +739,12 @@ export declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -734,6 +734,12 @@ declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -739,6 +739,12 @@ export declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -734,6 +734,12 @@ declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -739,6 +739,12 @@ export declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -739,6 +739,12 @@ declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -744,6 +744,12 @@ export declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -739,6 +739,12 @@ declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -744,6 +744,12 @@ export declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -739,6 +739,12 @@ declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -744,6 +744,12 @@ export declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -749,6 +749,12 @@ declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -754,6 +754,12 @@ export declare class Event {
    */
   get currentTarget(): EventTarget | undefined;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -716,6 +716,12 @@ declare class Event {
    */
   readonly currentTarget?: EventTarget;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  readonly target?: EventTarget;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -721,6 +721,12 @@ export declare class Event {
    */
   readonly currentTarget?: EventTarget;
   /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  readonly target?: EventTarget;
+  /**
    * @deprecated
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)


### PR DESCRIPTION
This fix is so simple I'm worried I'm missing something. 
It looks like we just... forgot to implement `Event.target` at all. 
Given that we don't support hierarchical events, we can use exactly the same logic we use for `Event.currentTarget`.
Fixes three WPT tests for AbortSignal.