### PR TITLE
Expose cpu and wall time in TraceItem

### DIFF
--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -174,6 +174,8 @@ class TraceItem final: public jsg::Object {
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(outcome, getOutcome);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(executionModel, getExecutionModel);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(truncated, getTruncated);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(cpuTime, getCpuTime);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(wallTime, getWallTime);
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -2437,6 +2437,8 @@ interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -2449,6 +2449,8 @@ export interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 export interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -2443,6 +2443,8 @@ interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -2455,6 +2455,8 @@ export interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 export interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -2461,6 +2461,8 @@ interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -2473,6 +2473,8 @@ export interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 export interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -2462,6 +2462,8 @@ interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -2474,6 +2474,8 @@ export interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 export interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -2462,6 +2462,8 @@ interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -2474,6 +2474,8 @@ export interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 export interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -2467,6 +2467,8 @@ interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -2479,6 +2479,8 @@ export interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 export interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -2469,6 +2469,8 @@ interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -2481,6 +2481,8 @@ export interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 export interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -2469,6 +2469,8 @@ interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -2481,6 +2481,8 @@ export interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 export interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -2529,6 +2529,8 @@ interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -2541,6 +2541,8 @@ export interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 export interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -2437,6 +2437,8 @@ interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -2449,6 +2449,8 @@ export interface TraceItem {
   readonly outcome: string;
   readonly executionModel: string;
   readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 export interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;


### PR DESCRIPTION
Internal PR: #9943

Exposes CPU/Wall time in the trace workers api instead of hiding it behind the UnsafeTraceMetrics binding now that we have the confidence we can safely expose this without any spectre issues.