### PR TITLE
Add Response.prototype.type property

### DIFF
--- a/src/workerd/api/http-standard-test.js
+++ b/src/workerd/api/http-standard-test.js
@@ -26,3 +26,10 @@ export const test = {
     strictEqual(await resp.text(), 'ok');
   },
 };
+
+export const typeTest = {
+  test() {
+    const resp = new Response('ok');
+    strictEqual(resp.type, 'default');
+  },
+};

--- a/src/workerd/api/http-test-ts.ts
+++ b/src/workerd/api/http-test-ts.ts
@@ -112,6 +112,7 @@ export const cacheMode = {
   url: 'http://placeholder/not-found',
   webSocket: null,
   cf: undefined,
+  type: 'default',
   body: ReadableStream {
     locked: false,
     [state]: 'readable',

--- a/src/workerd/api/http-test.js
+++ b/src/workerd/api/http-test.js
@@ -201,6 +201,7 @@ export const inspect = {
   url: 'http://placeholder/not-found',
   webSocket: null,
   cf: undefined,
+  type: 'default',
   body: ReadableStream {
     locked: false,
     [state]: 'readable',
@@ -329,6 +330,7 @@ export const cacheMode = {
   url: 'http://placeholder/not-found',
   webSocket: null,
   cf: undefined,
+  type: 'default',
   body: ReadableStream {
     locked: false,
     [state]: 'readable',

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -1136,9 +1136,10 @@ public:
 
   // This relates to CORS, which doesn't apply on the edge -- see Request::Initializer::mode.
   // In discussing with other runtime implementations that do not implement CORS, it was
-  // determined that just have this property as undefined is the best option.
-  // jsg::JsValue getType(jsg::Lock& js) { return js.v8Undefined(); }
-  // TODO(conform): Won't implement?
+  // determined that only the `'default'` and `'error'` properties should be implemented.
+  // We currently due not implement Response.error() so "default" is the only value we
+  // currently support.
+  kj::StringPtr getType() { return "default"_kj; }
 
   JSG_RESOURCE_TYPE(Response, CompatibilityFlags::Reader flags) {
     JSG_INHERIT(Body);
@@ -1161,9 +1162,7 @@ public:
 
       JSG_READONLY_PROTOTYPE_PROPERTY(cf, getCf);
 
-      // TODO(conform): This is a standard properties that we do not implement (see description
-      // above).
-      // JSG_READONLY_PROTOTYPE_PROPERTY(type, getType);
+      JSG_READONLY_PROTOTYPE_PROPERTY(type, getType);
     } else {
       JSG_READONLY_INSTANCE_PROPERTY(status, getStatus);
       JSG_READONLY_INSTANCE_PROPERTY(statusText, getStatusText);
@@ -1177,12 +1176,13 @@ public:
 
       JSG_READONLY_INSTANCE_PROPERTY(cf, getCf);
 
-      // TODO(conform): This is a standard properties that we do not implement (see description
-      // above).
-      // JSG_READONLY_INSTANCE_PROPERTY(type, getType);
+      JSG_READONLY_INSTANCE_PROPERTY(type, getType);
     }
 
-    JSG_TS_OVERRIDE({ constructor(body?: BodyInit | null, init?: ResponseInit); });
+    JSG_TS_OVERRIDE({
+      constructor(body?: BodyInit | null, init?: ResponseInit);
+      type: 'default' | 'error';
+    });
     // Use `BodyInit` and `ResponseInit` type aliases in constructor instead of inlining
   }
 

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -1591,6 +1591,8 @@ interface Response extends Body {
   readonly url: string;
   readonly webSocket: WebSocket | null;
   readonly cf?: any;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 interface ResponseInit {
   status?: number;

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -1596,6 +1596,8 @@ export interface Response extends Body {
   readonly url: string;
   readonly webSocket: WebSocket | null;
   readonly cf?: any;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 export interface ResponseInit {
   status?: number;
@@ -5633,6 +5635,18 @@ export type PagesPluginFunction<
 > = (
   context: EventPluginContext<Env, Params, Data, PluginArgs>,
 ) => Response | Promise<Response>;
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export declare abstract class PipelineTransform {
+  /**
+   * transformJson recieves an array of javascript objects which can be
+   * mutated and returned to the pipeline
+   * @param data The data to be mutated
+   * @returns A promise containing the mutated data
+   */
+  public transformJson(data: object[]): Promise<object[]>;
+}
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -5638,18 +5638,6 @@ export type PagesPluginFunction<
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-export declare abstract class PipelineTransform {
-  /**
-   * transformJson recieves an array of javascript objects which can be
-   * mutated and returned to the pipeline
-   * @param data The data to be mutated
-   * @returns A promise containing the mutated data
-   */
-  public transformJson(data: object[]): Promise<object[]>;
-}
-// Copyright (c) 2022-2023 Cloudflare, Inc.
-// Licensed under the Apache 2.0 license found in the LICENSE file or at:
-//     https://opensource.org/licenses/Apache-2.0
 export type PipelineRecord = Record<string, unknown>;
 export type PipelineBatchMetadata = {
   pipelineId: string;

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -1597,6 +1597,8 @@ interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 interface ResponseInit {
   status?: number;

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -1602,6 +1602,8 @@ export interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 export interface ResponseInit {
   status?: number;
@@ -5659,6 +5661,18 @@ export type PagesPluginFunction<
 > = (
   context: EventPluginContext<Env, Params, Data, PluginArgs>,
 ) => Response | Promise<Response>;
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export declare abstract class PipelineTransform {
+  /**
+   * transformJson recieves an array of javascript objects which can be
+   * mutated and returned to the pipeline
+   * @param data The data to be mutated
+   * @returns A promise containing the mutated data
+   */
+  public transformJson(data: object[]): Promise<object[]>;
+}
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -5664,18 +5664,6 @@ export type PagesPluginFunction<
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-export declare abstract class PipelineTransform {
-  /**
-   * transformJson recieves an array of javascript objects which can be
-   * mutated and returned to the pipeline
-   * @param data The data to be mutated
-   * @returns A promise containing the mutated data
-   */
-  public transformJson(data: object[]): Promise<object[]>;
-}
-// Copyright (c) 2022-2023 Cloudflare, Inc.
-// Licensed under the Apache 2.0 license found in the LICENSE file or at:
-//     https://opensource.org/licenses/Apache-2.0
 export type PipelineRecord = Record<string, unknown>;
 export type PipelineBatchMetadata = {
   pipelineId: string;

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -1615,6 +1615,8 @@ interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 interface ResponseInit {
   status?: number;

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -1620,6 +1620,8 @@ export interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 export interface ResponseInit {
   status?: number;
@@ -5684,6 +5686,18 @@ export type PagesPluginFunction<
 > = (
   context: EventPluginContext<Env, Params, Data, PluginArgs>,
 ) => Response | Promise<Response>;
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export declare abstract class PipelineTransform {
+  /**
+   * transformJson recieves an array of javascript objects which can be
+   * mutated and returned to the pipeline
+   * @param data The data to be mutated
+   * @returns A promise containing the mutated data
+   */
+  public transformJson(data: object[]): Promise<object[]>;
+}
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -5689,18 +5689,6 @@ export type PagesPluginFunction<
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-export declare abstract class PipelineTransform {
-  /**
-   * transformJson recieves an array of javascript objects which can be
-   * mutated and returned to the pipeline
-   * @param data The data to be mutated
-   * @returns A promise containing the mutated data
-   */
-  public transformJson(data: object[]): Promise<object[]>;
-}
-// Copyright (c) 2022-2023 Cloudflare, Inc.
-// Licensed under the Apache 2.0 license found in the LICENSE file or at:
-//     https://opensource.org/licenses/Apache-2.0
 export type PipelineRecord = Record<string, unknown>;
 export type PipelineBatchMetadata = {
   pipelineId: string;

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -1615,6 +1615,8 @@ interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 interface ResponseInit {
   status?: number;

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -1620,6 +1620,8 @@ export interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 export interface ResponseInit {
   status?: number;
@@ -5685,6 +5687,18 @@ export type PagesPluginFunction<
 > = (
   context: EventPluginContext<Env, Params, Data, PluginArgs>,
 ) => Response | Promise<Response>;
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export declare abstract class PipelineTransform {
+  /**
+   * transformJson recieves an array of javascript objects which can be
+   * mutated and returned to the pipeline
+   * @param data The data to be mutated
+   * @returns A promise containing the mutated data
+   */
+  public transformJson(data: object[]): Promise<object[]>;
+}
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -5690,18 +5690,6 @@ export type PagesPluginFunction<
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-export declare abstract class PipelineTransform {
-  /**
-   * transformJson recieves an array of javascript objects which can be
-   * mutated and returned to the pipeline
-   * @param data The data to be mutated
-   * @returns A promise containing the mutated data
-   */
-  public transformJson(data: object[]): Promise<object[]>;
-}
-// Copyright (c) 2022-2023 Cloudflare, Inc.
-// Licensed under the Apache 2.0 license found in the LICENSE file or at:
-//     https://opensource.org/licenses/Apache-2.0
 export type PipelineRecord = Record<string, unknown>;
 export type PipelineBatchMetadata = {
   pipelineId: string;

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -1615,6 +1615,8 @@ interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 interface ResponseInit {
   status?: number;

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -5694,18 +5694,6 @@ export type PagesPluginFunction<
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-export declare abstract class PipelineTransform {
-  /**
-   * transformJson recieves an array of javascript objects which can be
-   * mutated and returned to the pipeline
-   * @param data The data to be mutated
-   * @returns A promise containing the mutated data
-   */
-  public transformJson(data: object[]): Promise<object[]>;
-}
-// Copyright (c) 2022-2023 Cloudflare, Inc.
-// Licensed under the Apache 2.0 license found in the LICENSE file or at:
-//     https://opensource.org/licenses/Apache-2.0
 export type PipelineRecord = Record<string, unknown>;
 export type PipelineBatchMetadata = {
   pipelineId: string;

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -1620,6 +1620,8 @@ export interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 export interface ResponseInit {
   status?: number;
@@ -5689,6 +5691,18 @@ export type PagesPluginFunction<
 > = (
   context: EventPluginContext<Env, Params, Data, PluginArgs>,
 ) => Response | Promise<Response>;
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export declare abstract class PipelineTransform {
+  /**
+   * transformJson recieves an array of javascript objects which can be
+   * mutated and returned to the pipeline
+   * @param data The data to be mutated
+   * @returns A promise containing the mutated data
+   */
+  public transformJson(data: object[]): Promise<object[]>;
+}
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -1620,6 +1620,8 @@ interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 interface ResponseInit {
   status?: number;

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -1625,6 +1625,8 @@ export interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 export interface ResponseInit {
   status?: number;
@@ -5694,6 +5696,18 @@ export type PagesPluginFunction<
 > = (
   context: EventPluginContext<Env, Params, Data, PluginArgs>,
 ) => Response | Promise<Response>;
+// Copyright (c) 2022-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export declare abstract class PipelineTransform {
+  /**
+   * transformJson recieves an array of javascript objects which can be
+   * mutated and returned to the pipeline
+   * @param data The data to be mutated
+   * @returns A promise containing the mutated data
+   */
+  public transformJson(data: object[]): Promise<object[]>;
+}
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -5699,18 +5699,6 @@ export type PagesPluginFunction<
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-export declare abstract class PipelineTransform {
-  /**
-   * transformJson recieves an array of javascript objects which can be
-   * mutated and returned to the pipeline
-   * @param data The data to be mutated
-   * @returns A promise containing the mutated data
-   */
-  public transformJson(data: object[]): Promise<object[]>;
-}
-// Copyright (c) 2022-2023 Cloudflare, Inc.
-// Licensed under the Apache 2.0 license found in the LICENSE file or at:
-//     https://opensource.org/licenses/Apache-2.0
 export type PipelineRecord = Record<string, unknown>;
 export type PipelineBatchMetadata = {
   pipelineId: string;

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -1622,6 +1622,8 @@ interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 interface ResponseInit {
   status?: number;

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -1627,6 +1627,8 @@ export interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 export interface ResponseInit {
   status?: number;

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -1622,6 +1622,8 @@ interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 interface ResponseInit {
   status?: number;

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -1627,6 +1627,8 @@ export interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 export interface ResponseInit {
   status?: number;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -1632,6 +1632,8 @@ interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 interface ResponseInit {
   status?: number;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -1637,6 +1637,8 @@ export interface Response extends Body {
   url: string;
   webSocket: WebSocket | null;
   cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 export interface ResponseInit {
   status?: number;

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -1591,6 +1591,8 @@ interface Response extends Body {
   readonly url: string;
   readonly webSocket: WebSocket | null;
   readonly cf?: any;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 interface ResponseInit {
   status?: number;

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -1596,6 +1596,8 @@ export interface Response extends Body {
   readonly url: string;
   readonly webSocket: WebSocket | null;
   readonly cf?: any;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 export interface ResponseInit {
   status?: number;


### PR DESCRIPTION
WinterTC recently agreed that conformant implementations should, at the very least, support the `'default'` value for `Response.prototype.type` property and, if the runtime implements `Response.error()`, the `'error'` value -- even if the implementation otherwise does not implement CORS.