### PR TITLE
Implement Response.error()

### DIFF
--- a/src/workerd/api/cache.c++
+++ b/src/workerd/api/cache.c++
@@ -154,6 +154,9 @@ jsg::Promise<void> Cache::put(jsg::Lock& js,
     jsg::Ref<Response> jsResponse,
     CompatibilityFlags::Reader flags) {
 
+  JSG_REQUIRE(
+      jsResponse->getType() != "error"_kj, TypeError, "Cache is unble to store an error response");
+
   // Fake kj::HttpService::Response implementation that allows us to reuse jsResponse->send() to
   // serialize the response (headers + body) in the format needed to serve as the payload of
   // our cache PUT request.

--- a/src/workerd/api/eventsource.c++
+++ b/src/workerd/api/eventsource.c++
@@ -448,6 +448,11 @@ void EventSource::run(jsg::Lock& js,
     kj::Maybe<jsg::Ref<Fetcher>> fetcher) {
   notifyOpen(js);
 
+  KJ_IF_SOME(resp, response) {
+    JSG_REQUIRE(resp->getType() != "error"_kj, TypeError,
+        "Error responses are unsupported with EventSource");
+  }
+
   auto onSuccess =
       JSG_VISITABLE_LAMBDA((self = JSG_THIS, readable = readable.addRef(), withReconnection,
                                response = addRef(response), fetcher = addRef(fetcher)),

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -267,6 +267,9 @@ kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::request(kj::HttpMetho
                         canceled = kj::addRef(*canceled), &headers, span = kj::mv(span)](
                         jsg::Lock& js, jsg::Ref<Response> innerResponse) mutable
                     -> IoOwn<kj::Promise<DeferredProxy<void>>> {
+      JSG_REQUIRE(innerResponse->getType() != "error"_kj, TypeError,
+          "Return value from serve handler must not be an error response (like Response.error())");
+
       auto& context = IoContext::current();
       // Drop our fetch_handler span now that the promise has resolved.
       span = kj::none;

--- a/src/workerd/api/html-rewriter.c++
+++ b/src/workerd/api/html-rewriter.c++
@@ -1216,6 +1216,10 @@ jsg::Ref<HTMLRewriter> HTMLRewriter::onDocument(DocumentContentHandlers&& handle
 }
 
 jsg::Ref<Response> HTMLRewriter::transform(jsg::Lock& js, jsg::Ref<Response> response) {
+
+  JSG_REQUIRE(response->getType() != "error"_kj, TypeError,
+      "HTMLRewriter cannot transform an error response");
+
   auto maybeInput = response->getBody();
 
   if (maybeInput == kj::none) {

--- a/src/workerd/api/http-standard-test.wd-test
+++ b/src/workerd/api/http-standard-test.wd-test
@@ -10,8 +10,8 @@ const unitTests :Workerd.Config = (
         bindings = [
           ( name = "SERVICE", service = "http-standard-test" )
         ],
-        compatibilityDate = "2023-08-01",
-        compatibilityFlags = ["nodejs_compat", "fetch_standard_url"],
+        compatibilityDate = "2025-02-01",
+        compatibilityFlags = ["nodejs_compat"],
       )
     ),
   ],

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -1097,13 +1097,7 @@ public:
   //
   // A network error is a response whose status is always 0, status message is always the empty
   // byte sequence, header list is always empty, body is always null, and trailer is always empty.
-  static jsg::Unimplemented error() { return {}; };
-  // TODO(conform): implementation is missing; two approaches where tested:
-  //  - returning a HTTP 5xx response but that doesn't match the spec and we didn't
-  //    find it useful.
-  //  - throwing/propagating a DISCONNECTED kj::Exception to actually disconnect the
-  //    client. However, we were concerned about possible side-effects and incorrect
-  //    error reporting.
+  static jsg::Ref<Response> error(jsg::Lock& js);
 
   jsg::Ref<Response> clone(jsg::Lock& js);
 
@@ -1139,7 +1133,10 @@ public:
   // determined that only the `'default'` and `'error'` properties should be implemented.
   // We currently due not implement Response.error() so "default" is the only value we
   // currently support.
-  kj::StringPtr getType() { return "default"_kj; }
+  kj::StringPtr getType() {
+    if (statusCode == 0) return "error"_kj;
+    return "default"_kj;
+  }
 
   JSG_RESOURCE_TYPE(Response, CompatibilityFlags::Reader flags) {
     JSG_INHERIT(Body);

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -1566,6 +1566,7 @@ declare abstract class Body {
 declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -1571,6 +1571,7 @@ export declare abstract class Body {
 export declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -1572,6 +1572,7 @@ declare abstract class Body {
 declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -1577,6 +1577,7 @@ export declare abstract class Body {
 export declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -1590,6 +1590,7 @@ declare abstract class Body {
 declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -1595,6 +1595,7 @@ export declare abstract class Body {
 export declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -1590,6 +1590,7 @@ declare abstract class Body {
 declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -1595,6 +1595,7 @@ export declare abstract class Body {
 export declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -1590,6 +1590,7 @@ declare abstract class Body {
 declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -1595,6 +1595,7 @@ export declare abstract class Body {
 export declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -1595,6 +1595,7 @@ declare abstract class Body {
 declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -1600,6 +1600,7 @@ export declare abstract class Body {
 export declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -1597,6 +1597,7 @@ declare abstract class Body {
 declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -1602,6 +1602,7 @@ export declare abstract class Body {
 export declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -1597,6 +1597,7 @@ declare abstract class Body {
 declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -1602,6 +1602,7 @@ export declare abstract class Body {
 export declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -1607,6 +1607,7 @@ declare abstract class Body {
 declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -1612,6 +1612,7 @@ export declare abstract class Body {
 export declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -1566,6 +1566,7 @@ declare abstract class Body {
 declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -1571,6 +1571,7 @@ export declare abstract class Body {
 export declare var Response: {
   prototype: Response;
   new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
   redirect(url: string, status?: number): Response;
   json(any: any, maybeInit?: ResponseInit | Response): Response;
 };


### PR DESCRIPTION
Builds on https://github.com/cloudflare/workerd/pull/3590 to implement `Response.error()`.

WinterTC will be including `Response.error()` is the fetch subset that compliant runtimes should implement, and `Response.error()` is necessary for nodejs_compat. 

Fixes: https://github.com/cloudflare/workerd/issues/3591