### PR TITLE
Add compat flag for queue consumers to not block on waitUntil'ed work

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -712,4 +712,6 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # prevents a slow waitUntil'ed promise from slowing down consumption of messages from a queue,
   # which has been a recurring problem for the prior behavior (which did wait for all waitUntil'ed
   # tasks to complete.
+  # This intentionally doesn't have a compatEnableDate yet until so we can let some users opt-in to
+  # try it before enabling it for all new scripts, but will eventually need one.
 }

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -703,4 +703,13 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatDisableFlag("nonclass_entrypoint_reuses_ctx_across_invocations")
       $compatEnableDate("2025-03-10");
   # Creates a unique ExportedHandler for each call to `export default` thus allowing a unique ctx per invocation
+
+  queueConsumerNoWaitForWaitUntil @75 :Bool
+      $compatEnableFlag("queue_consumer_no_wait_for_wait_until")
+      $compatDisableFlag("queue_consumer_wait_for_wait_until");
+  # If enabled, does not require all waitUntil'ed promises to resolve successfully before reporting
+  # succeeded/failed messages/batches back from a queue consumer to the Queues service. This
+  # prevents a slow waitUntil'ed promise from slowing down consumption of messages from a queue,
+  # which has been a recurring problem for the prior behavior (which did wait for all waitUntil'ed
+  # tasks to complete.
 }


### PR DESCRIPTION
The intent is that the event can be considered done when the
queue() handler's returned promise resolves, allowing acked/nacked
message info to be returned back to the queues infrastructure sooner,
rather than requiring all waitUntil'ed work to finish first. This has
two important benefits:

1. This will keep consumer invocations from getting slowed down by
   slow/hung waitUntil'ed tasks.
1. This will keep consumer invocations from failing due to failing
   waitUntil tasks.

This notably makes queue() handlers behave more like fetch() handlers, which should make them more intuitive for most users.