### PR TITLE
feat: add createBatch API for Workflows binding

### DIFF
--- a/src/cloudflare/internal/test/workflows/workflows-api-test.js
+++ b/src/cloudflare/internal/test/workflows/workflows-api-test.js
@@ -20,5 +20,21 @@ export const tests = {
       const instance = await env.workflow.get('bar');
       assert.deepStrictEqual(instance.id, 'bar');
     }
+
+    {
+      // Test createBatch
+      const instances = await env.workflow.createBatch([
+        {
+          id: 'foo',
+          payload: { bar: 'baz' },
+        },
+        {
+          id: 'bar',
+          payload: { bar: 'baz' },
+        },
+      ]);
+      assert.deepStrictEqual(instances[0].id, 'foo');
+      assert.deepStrictEqual(instances[1].id, 'bar');
+    }
   },
 };

--- a/src/cloudflare/internal/test/workflows/workflows-mock.js
+++ b/src/cloudflare/internal/test/workflows/workflows-mock.js
@@ -5,8 +5,9 @@
 export default {
   async fetch(request, env, ctx) {
     const data = await request.json();
+    const reqUrl = new URL(request.url);
 
-    if (request.url.includes('/get') && request.method === 'POST') {
+    if (reqUrl.pathname === '/get' && request.method === 'POST') {
       return Response.json(
         {
           result: {
@@ -22,12 +23,26 @@ export default {
       );
     }
 
-    if (request.url.includes('/create') && request.method === 'POST') {
+    if (reqUrl.pathname === '/create' && request.method === 'POST') {
       return Response.json(
         {
           result: {
             id: data.id,
           },
+        },
+        {
+          status: 201,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }
+      );
+    }
+
+    if (reqUrl.pathname === '/createBatch' && request.method === 'POST') {
+      return Response.json(
+        {
+          result: data.map((val) => ({ id: val.id })),
         },
         {
           status: 201,

--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -103,6 +103,18 @@ class WorkflowImpl {
 
     return new InstanceImpl(result.id, this.fetcher);
   }
+
+  public async createBatch(
+    options: WorkflowInstanceCreateOptions[]
+  ): Promise<WorkflowInstance[]> {
+    const results = await callFetcher<
+      {
+        id: string;
+      }[]
+    >(this.fetcher, '/createBatch', options);
+
+    return results.map((result) => new InstanceImpl(result.id, this.fetcher));
+  }
 }
 
 export function makeBinding(env: { fetcher: Fetcher }): Workflow {

--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -38,6 +38,16 @@ declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>
   ): Promise<WorkflowInstance>;
+
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[]
+  ): Promise<WorkflowInstance[]>;
 }
 
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -24,6 +24,16 @@ declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>
   ): Promise<WorkflowInstance>;
+
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[]
+  ): Promise<WorkflowInstance[]>;
 }
 
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -6480,6 +6480,15 @@ declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -6381,6 +6381,15 @@ export declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -6506,6 +6506,15 @@ declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -6407,6 +6407,15 @@ export declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -6531,6 +6531,15 @@ declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -6432,6 +6432,15 @@ export declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -6532,6 +6532,15 @@ declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -6433,6 +6433,15 @@ export declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -6536,6 +6536,15 @@ declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -6437,6 +6437,15 @@ export declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -6541,6 +6541,15 @@ declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -6442,6 +6442,15 @@ export declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -6543,6 +6543,15 @@ declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -6444,6 +6444,15 @@ export declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -6543,6 +6543,15 @@ declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -6444,6 +6444,15 @@ export declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -6624,6 +6624,15 @@ declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -6525,6 +6525,15 @@ export declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -6480,6 +6480,15 @@ declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -6381,6 +6381,15 @@ export declare abstract class Workflow<PARAMS = unknown> {
   public create(
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(
+    batch: WorkflowInstanceCreateOptions<PARAMS>[],
+  ): Promise<WorkflowInstance[]>;
 }
 export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**


### PR DESCRIPTION
Closes WOR-496

We want to allow users to batch create instances in the same request - this implies that the RPC limit is shared for the batch.