### PR TITLE
Implement node:crypto sign and verify APIs

### DIFF
--- a/src/node/crypto.ts
+++ b/src/node/crypto.ts
@@ -47,6 +47,15 @@ import {
   Hmac,
 } from 'node-internal:crypto_hash';
 
+import {
+  createSign,
+  createVerify,
+  sign,
+  verify,
+  Sign,
+  Verify,
+} from 'node-internal:crypto_sign';
+
 import { hkdf, hkdfSync } from 'node-internal:crypto_hkdf';
 
 import { pbkdf2, pbkdf2Sync, ArrayLike } from 'node-internal:crypto_pbkdf2';
@@ -125,6 +134,13 @@ export {
   Certificate,
   // X509
   X509Certificate,
+  // Sign/Verify
+  createSign,
+  createVerify,
+  sign,
+  verify,
+  Sign,
+  Verify,
 };
 
 export function getCiphers(): string[] {
@@ -245,6 +261,13 @@ export default {
   Certificate,
   // X509
   X509Certificate,
+  // Sign/Verify
+  createSign,
+  createVerify,
+  sign,
+  verify,
+  Sign,
+  Verify,
 };
 
 // Classes
@@ -256,9 +279,9 @@ export default {
 //   * [ ] crypto.ECDH
 //   * [x] crypto.Hash
 //   * [x] crypto.Hmac
-//   * [ ] crypto.KeyObject
-//   * [ ] crypto.Sign
-//   * [ ] crypto.Verify
+//   * [x] crypto.KeyObject
+//   * [x] crypto.Sign
+//   * [x] crypto.Verify
 //   * [x] crypto.X509Certificate
 //   * [ ] crypto.constants
 //   * [ ] crypto.DEFAULT_ENCODING
@@ -288,18 +311,18 @@ export default {
 //   * [x] crypto.createHmac(algorithm, key[, options])
 //   * [x] crypto.getHashes()
 // * Keys, not implemented yet. Calling the following APIs will throw a ERR_METHOD_NOT_IMPLEMENTED
-//   * [.] crypto.createPrivateKey(key)
-//   * [.] crypto.createPublicKey(key)
-//   * [.] crypto.createSecretKey(key[, encoding])
-//   * [.] crypto.generateKey(type, options, callback)
-//   * [.] crypto.generateKeyPair(type, options, callback)
-//   * [.] crypto.generateKeyPairSync(type, options)
-//   * [.] crypto.generateKeySync(type, options)
+//   * [x] crypto.createPrivateKey(key)
+//   * [x] crypto.createPublicKey(key)
+//   * [x] crypto.createSecretKey(key[, encoding])
+//   * [x] crypto.generateKey(type, options, callback)
+//   * [x] crypto.generateKeyPair(type, options, callback)
+//   * [x] crypto.generateKeyPairSync(type, options)
+//   * [x] crypto.generateKeySync(type, options)
 // * Sign/Verify
-//   * [ ] crypto.createSign(algorithm[, options])
-//   * [ ] crypto.createVerify(algorithm[, options])
-//   * [ ] crypto.sign(algorithm, data, key[, callback])
-//   * [ ] crypto.verify(algorithm, data, key, signature[, callback])
+//   * [x] crypto.createSign(algorithm[, options])
+//   * [x] crypto.createVerify(algorithm[, options])
+//   * [x] crypto.sign(algorithm, data, key[, callback])
+//   * [x] crypto.verify(algorithm, data, key, signature[, callback])
 // * Misc
 //   * [ ] crypto.getCipherInfo(nameOrNid[, options])
 //   * [x] crypto.getCiphers()

--- a/src/node/internal/crypto.d.ts
+++ b/src/node/internal/crypto.d.ts
@@ -65,6 +65,47 @@ export class HashHandle {
   public copy(xofLen: number): HashHandle;
 }
 
+export class SignHandle {
+  public constructor(algorithm: string);
+  public update(data: Buffer | ArrayBufferView): void;
+  public sign(
+    key: CryptoKey,
+    rsaPadding?: number,
+    pssSaltLength?: number,
+    dsaSigEnc?: number
+  ): ArrayBuffer;
+}
+
+export class VerifyHandle {
+  public constructor(algorithm: string);
+  public update(data: Buffer | ArrayBufferView): void;
+  public verify(
+    key: CryptoKey,
+    signature: ArrayBufferView,
+    rsaPadding?: number,
+    pssSaltLength?: number,
+    dsaSigEnc?: number
+  ): boolean;
+}
+
+export function signOneShot(
+  key: CryptoKey,
+  algorithm: string | undefined,
+  data: ArrayBufferView,
+  rsaPadding?: number,
+  pssSaltLength?: number,
+  dsaSigEnc?: number
+): ArrayBuffer;
+export function verifyOneShot(
+  key: CryptoKey,
+  algorithm: string | undefined,
+  data: ArrayBufferView,
+  signature: ArrayBufferView,
+  rsaPadding?: number,
+  pssSaltLength?: number,
+  dsaSigEnc?: number
+): boolean;
+
 export type ArrayLike = ArrayBuffer | string | Buffer | ArrayBufferView;
 
 export class HmacHandle {

--- a/src/node/internal/crypto_keys.ts
+++ b/src/node/internal/crypto_keys.ts
@@ -85,7 +85,7 @@ const kCustomPromisifyArgsSymbol = Symbol.for(
 );
 
 // Key input contexts.
-enum KeyContext {
+export enum KeyContext {
   kConsumePublic = 'kConsumePublic',
   kConsumePrivate = 'kConsumePrivate',
   kCreatePublic = 'kCreatePublic',
@@ -386,7 +386,7 @@ export function createSecretKey(
   return KeyObject.from(cryptoImpl.createSecretKey(key)) as SecretKeyObject;
 }
 
-function prepareAsymmetricKey(
+export function prepareAsymmetricKey(
   key: CreateAsymmetricKeyOptions | null | undefined,
   ctx: KeyContext
 ): InnerCreateAsymmetricKeyOptions {

--- a/src/node/internal/crypto_sign.ts
+++ b/src/node/internal/crypto_sign.ts
@@ -1,0 +1,440 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* TODO: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import {
+  default as cryptoImpl,
+  type SignHandle,
+  type VerifyHandle,
+  type CreateAsymmetricKeyOptions,
+} from 'node-internal:crypto';
+
+import { validateString } from 'node-internal:validators';
+
+import { Buffer } from 'node-internal:internal_buffer';
+
+import {
+  KeyObject,
+  isKeyObject,
+  getKeyObjectHandle,
+  createPrivateKey,
+  createPublicKey,
+} from 'node-internal:crypto_keys';
+
+import {
+  ERR_CRYPTO_SIGN_KEY_REQUIRED,
+  ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE,
+  ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_ARG_VALUE,
+} from 'node-internal:internal_errors';
+
+import { Writable } from 'node-internal:streams_writable';
+import { isArrayBufferView } from 'node-internal:internal_types';
+
+export interface SignOptions {}
+
+export interface Sign extends Writable {
+  [kHandle]: SignHandle;
+  update(data: any): void;
+  sign(privateKey: any): any;
+}
+export interface Verify extends Writable {
+  [kHandle]: VerifyHandle;
+  update(data: any): void;
+  verify(publicKey: any, signature: any): any;
+}
+
+const kHandle = Symbol('kHandle');
+
+// Uses old-style class syntax for Node.js compatibility
+export const Sign = function (this: Sign, algorithm: string, options: any) {
+  if (!(this instanceof Sign)) return new Sign(algorithm, options);
+  validateString(algorithm, 'algorithm');
+  this[kHandle] = new cryptoImpl.SignHandle(algorithm);
+  Writable.call(this, options);
+  return this;
+} as any as {
+  new (algorithm: string, options?: SignOptions): Sign;
+};
+Object.setPrototypeOf(Sign.prototype, Writable.prototype);
+Object.setPrototypeOf(Sign, Writable);
+
+Sign.prototype._write = function _write(
+  chunk: string | ArrayBufferView,
+  encoding: string | undefined | null,
+  callback: (err?: any) => void
+) {
+  this.update(chunk, encoding);
+  callback();
+};
+
+Sign.prototype.update = function (
+  this: Sign,
+  data: string | ArrayBufferView,
+  encoding?: string
+) {
+  if (typeof data === 'string') {
+    data = Buffer.from(data, encoding);
+  }
+  if (!isArrayBufferView(data)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'data',
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      data
+    );
+  }
+  this[kHandle].update(data);
+  return this;
+};
+
+function getIntOption(name: string, options: any): number | undefined {
+  const value = options[name];
+  if (value !== undefined) {
+    if (value === value >> 0) {
+      return value;
+    }
+    throw new ERR_INVALID_ARG_VALUE(`options.${name}`, value);
+  }
+  return undefined;
+}
+
+function getDSASignatureEncoding(options: any): number {
+  if (typeof options === 'object') {
+    const { dsaEncoding = 'der' } = options;
+    if (dsaEncoding === 'der')
+      return 0; // kSigEncDER;
+    else if (dsaEncoding === 'ieee-p1363') return 1; // kSigEncP1363
+    throw new ERR_INVALID_ARG_VALUE('options.dsaEncoding', dsaEncoding);
+  }
+
+  return 0;
+}
+
+function getPrivateKey(options: any): CryptoKey {
+  if (options instanceof CryptoKey) {
+    return options as CryptoKey;
+  } else if (isKeyObject(options)) {
+    const keyObject = options as KeyObject;
+    if (keyObject.type === 'secret') {
+      throw new ERR_INVALID_ARG_TYPE(
+        'options',
+        ['PublicKeyObject', 'PrivateKeyObject', 'CryptoKey', 'object'],
+        keyObject.type
+      );
+    }
+    if (keyObject.type === 'public') {
+      throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE('public', 'private');
+    }
+    return getKeyObjectHandle(keyObject);
+  } else {
+    return getKeyObjectHandle(
+      createPrivateKey(options as CreateAsymmetricKeyOptions)
+    );
+  }
+}
+
+Sign.prototype.sign = function (
+  this: Sign,
+  options: any,
+  encoding?: string
+): Buffer | string {
+  if (!options) {
+    throw new ERR_CRYPTO_SIGN_KEY_REQUIRED();
+  }
+
+  const key = getPrivateKey(options);
+
+  // Options specific to RSA
+  const rsaPadding = getIntOption('padding', options);
+  const pssSaltLength = getIntOption('saltLength', options);
+
+  // Options specific to (EC)DSA
+  const dsaSigEnc = getDSASignatureEncoding(options);
+
+  const res = Buffer.from(
+    this[kHandle].sign(key, rsaPadding, pssSaltLength, dsaSigEnc)
+  );
+
+  if (encoding && encoding !== 'buffer') {
+    return res.toString(encoding);
+  }
+
+  return res;
+};
+
+// Uses old-style class syntax for Node.js compatibility
+export const Verify = function (this: Verify, algorithm: string, options: any) {
+  if (!(this instanceof Verify)) return new Verify(algorithm, options);
+  validateString(algorithm, 'algorithm');
+  this[kHandle] = new cryptoImpl.VerifyHandle(algorithm);
+  Writable.call(this, options);
+  return this;
+} as any as {
+  new (algorithm: string, options?: SignOptions): Verify;
+};
+Object.setPrototypeOf(Verify.prototype, Writable.prototype);
+Object.setPrototypeOf(Verify, Writable);
+
+Verify.prototype._write = function _write(
+  chunk: string | ArrayBufferView,
+  encoding: string | undefined | null,
+  callback: (err?: unknown) => void
+) {
+  this.update(chunk, encoding);
+  callback();
+};
+
+Verify.prototype.update = function (
+  this: Verify,
+  data: string | ArrayBufferView,
+  encoding?: string
+) {
+  if (typeof data === 'string') {
+    data = Buffer.from(data, encoding);
+  }
+  if (!isArrayBufferView(data)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'data',
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      data
+    );
+  }
+  this[kHandle].update(data);
+  return this;
+};
+
+Verify.prototype.verify = function (
+  this: Verify,
+  options: any,
+  signature: ArrayBufferView | string,
+  encoding: string = 'utf8'
+) {
+  if (!options) {
+    throw new ERR_CRYPTO_SIGN_KEY_REQUIRED();
+  }
+
+  let key: CryptoKey;
+  if (options instanceof CryptoKey) {
+    key = options as CryptoKey;
+  } else if (isKeyObject(options)) {
+    key = getKeyObjectHandle(options as KeyObject);
+  } else {
+    key = getKeyObjectHandle(
+      createPublicKey(options as CreateAsymmetricKeyOptions)
+    );
+  }
+  if (!(key instanceof CryptoKey)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options',
+      ['KeyObject', 'CryptoKey', 'object'],
+      key
+    );
+  }
+
+  // Options specific to RSA
+  const rsaPadding = getIntOption('padding', options);
+  const pssSaltLength = getIntOption('saltLength', options);
+
+  // Options specific to (EC)DSA
+  const dsaSigEnc = getDSASignatureEncoding(options);
+
+  if (typeof signature === 'string') {
+    signature = Buffer.from(signature, encoding);
+  }
+
+  return this[kHandle].verify(
+    key,
+    signature,
+    rsaPadding,
+    pssSaltLength,
+    dsaSigEnc
+  );
+};
+
+export function createSign(algorithm: string, options: any) {
+  return new Sign(algorithm, options);
+}
+
+export function createVerify(algorithm: string, options: any) {
+  return new Verify(algorithm, options);
+}
+
+type SignCallback = (err: any, signature?: Buffer) => void;
+type VerifyCallback = (err: any, valid?: boolean) => void;
+
+export function sign(
+  algorithm: string | null | undefined,
+  data: BufferSource,
+  options: any,
+  callback?: SignCallback
+): Buffer | void {
+  if (algorithm != null) {
+    validateString(algorithm, 'algorithm');
+  } else {
+    algorithm = undefined;
+  }
+  if (!isArrayBufferView(data)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'data',
+      ['Buffer', 'TypedArray', 'DataView'],
+      data
+    );
+  }
+
+  if (!options) {
+    throw new ERR_CRYPTO_SIGN_KEY_REQUIRED();
+  }
+
+  const key = getPrivateKey(options);
+
+  // Options specific to RSA
+  const rsaPadding = getIntOption('padding', options);
+  const pssSaltLength = getIntOption('saltLength', options);
+
+  // Options specific to (EC)DSA
+  const dsaSigEnc = getDSASignatureEncoding(options);
+
+  if (callback === undefined) {
+    return Buffer.from(
+      cryptoImpl.signOneShot(
+        key,
+        algorithm,
+        data,
+        rsaPadding,
+        pssSaltLength,
+        dsaSigEnc
+      )
+    );
+  }
+
+  try {
+    const signature = Buffer.from(
+      cryptoImpl.signOneShot(
+        key,
+        algorithm,
+        data,
+        rsaPadding,
+        pssSaltLength,
+        dsaSigEnc
+      )
+    );
+    queueMicrotask(() => callback(null, signature));
+  } catch (err) {
+    queueMicrotask(() => callback(err));
+  }
+}
+
+export function verify(
+  algorithm: string | null | undefined,
+  data: BufferSource,
+  options: any,
+  signature: BufferSource,
+  callback?: VerifyCallback
+): boolean | undefined {
+  // Node.js allows the algorithm to be either undefined or null, in which
+  // case we just normalize it to undefined.
+  if (algorithm != null) {
+    validateString(algorithm, 'algorithm');
+  } else {
+    algorithm = undefined;
+  }
+
+  if (!isArrayBufferView(data)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'data',
+      ['Buffer', 'TypedArray', 'DataView'],
+      data
+    );
+  }
+
+  if (!isArrayBufferView(signature)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'signature',
+      ['Buffer', 'TypedArray', 'DataView'],
+      signature
+    );
+  }
+
+  if (!options) {
+    throw new ERR_CRYPTO_SIGN_KEY_REQUIRED();
+  }
+
+  let key: CryptoKey;
+  if (options instanceof CryptoKey) {
+    key = options;
+  } else if (isKeyObject(options)) {
+    key = getKeyObjectHandle(options as KeyObject);
+  } else {
+    key = getKeyObjectHandle(
+      createPublicKey(options as CreateAsymmetricKeyOptions)
+    );
+  }
+  if (!(key instanceof CryptoKey)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options',
+      ['KeyObject', 'CryptoKey', 'object'],
+      key
+    );
+  }
+
+  // Options specific to RSA
+  const rsaPadding = getIntOption('padding', options);
+  const pssSaltLength = getIntOption('saltLength', options);
+
+  // Options specific to (EC)DSA
+  const dsaSigEnc = getDSASignatureEncoding(options);
+
+  if (callback === undefined) {
+    return cryptoImpl.verifyOneShot(
+      key,
+      algorithm,
+      data,
+      signature,
+      rsaPadding,
+      pssSaltLength,
+      dsaSigEnc
+    );
+  }
+
+  try {
+    callback(
+      null,
+      cryptoImpl.verifyOneShot(
+        key,
+        algorithm,
+        data,
+        signature,
+        rsaPadding,
+        pssSaltLength,
+        dsaSigEnc
+      )
+    );
+  } catch (err) {
+    queueMicrotask(() => callback(err));
+  }
+  return; // explicit return is necessary to squelch typescript warning.
+}

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -697,6 +697,12 @@ export class ERR_UNSUPPORTED_OPERATION extends NodeError {
   }
 }
 
+export class ERR_CRYPTO_SIGN_KEY_REQUIRED extends NodeError {
+  constructor() {
+    super('ERR_CRYPTO_SIGN_KEY_REQUIRED', 'No key provided to sign');
+  }
+}
+
 export function aggregateTwoErrors(innerError: any, outerError: any) {
   if (innerError && outerError && innerError !== outerError) {
     if (Array.isArray(outerError.errors)) {

--- a/src/node/internal/streams_writable.d.ts
+++ b/src/node/internal/streams_writable.d.ts
@@ -1,0 +1,164 @@
+/* This project is licensed under the MIT license.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. */
+
+// Derived from DefinitelyTyped https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/stream.d.ts#L1060
+
+/* TODO: the following is adopted code, enabling linting one day */
+/* eslint-disable */
+
+import { EventEmitter } from 'node:events';
+
+interface WritableOptions {
+  highWaterMark?: number | undefined;
+  decodeStrings?: boolean | undefined;
+  defaultEncoding?: BufferEncoding | undefined;
+  objectMode?: boolean | undefined;
+  emitClose?: boolean | undefined;
+  write?(
+    this: Writable,
+    chunk: any,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void
+  ): void;
+  writev?(
+    this: Writable,
+    chunks: Array<{ chunk: any; encoding: BufferEncoding }>,
+    callback: (error?: Error | null) => void
+  ): void;
+  destroy?(
+    this: Writable,
+    error: Error | null,
+    callback: (error: Error | null) => void
+  ): void;
+  final?(this: Writable, callback: (error?: Error | null) => void): void;
+  autoDestroy?: boolean | undefined;
+}
+
+export class internal extends EventEmitter {
+  pipe<T extends NodeJS.WritableStream>(
+    destination: T,
+    options?: { end?: boolean | undefined }
+  ): T;
+}
+
+export class Stream extends internal {
+  constructor(opts?: any);
+}
+
+export class Writable extends Stream implements NodeJS.WritableStream {
+  readonly writable: boolean;
+  readonly writableEnded: boolean;
+  readonly writableFinished: boolean;
+  readonly writableHighWaterMark: number;
+  readonly writableLength: number;
+  readonly writableObjectMode: boolean;
+  readonly writableCorked: number;
+  destroyed: boolean;
+  constructor(opts?: WritableOptions);
+  _write(
+    chunk: any,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void
+  ): void;
+  _writev?(
+    chunks: Array<{ chunk: any; encoding: BufferEncoding }>,
+    callback: (error?: Error | null) => void
+  ): void;
+  _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
+  _final(callback: (error?: Error | null) => void): void;
+  write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
+  write(
+    chunk: any,
+    encoding: BufferEncoding,
+    cb?: (error: Error | null | undefined) => void
+  ): boolean;
+  setDefaultEncoding(encoding: BufferEncoding): this;
+  end(cb?: () => void): this;
+  end(chunk: any, cb?: () => void): this;
+  end(chunk: any, encoding: BufferEncoding, cb?: () => void): this;
+  cork(): void;
+  uncork(): void;
+  destroy(error?: Error): this;
+
+  addListener(event: 'close', listener: () => void): this;
+  addListener(event: 'drain', listener: () => void): this;
+  addListener(event: 'error', listener: (err: Error) => void): this;
+  addListener(event: 'finish', listener: () => void): this;
+  addListener(event: 'pipe', listener: (src: any) => void): this;
+  addListener(event: 'unpipe', listener: (src: any) => void): this;
+  addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  emit(event: 'close'): boolean;
+  emit(event: 'drain'): boolean;
+  emit(event: 'error', err: Error): boolean;
+  emit(event: 'finish'): boolean;
+  emit(event: 'pipe', src: any): boolean;
+  emit(event: 'unpipe', src: any): boolean;
+  emit(event: string | symbol, ...args: any[]): boolean;
+
+  on(event: 'close', listener: () => void): this;
+  on(event: 'drain', listener: () => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'finish', listener: () => void): this;
+  on(event: 'pipe', listener: (src: any) => void): this;
+  on(event: 'unpipe', listener: (src: any) => void): this;
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  once(event: 'close', listener: () => void): this;
+  once(event: 'drain', listener: () => void): this;
+  once(event: 'error', listener: (err: Error) => void): this;
+  once(event: 'finish', listener: () => void): this;
+  once(event: 'pipe', listener: (src: any) => void): this;
+  once(event: 'unpipe', listener: (src: any) => void): this;
+  once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  prependListener(event: 'close', listener: () => void): this;
+  prependListener(event: 'drain', listener: () => void): this;
+  prependListener(event: 'error', listener: (err: Error) => void): this;
+  prependListener(event: 'finish', listener: () => void): this;
+  prependListener(event: 'pipe', listener: (src: any) => void): this;
+  prependListener(event: 'unpipe', listener: (src: any) => void): this;
+  prependListener(
+    event: string | symbol,
+    listener: (...args: any[]) => void
+  ): this;
+
+  prependOnceListener(event: 'close', listener: () => void): this;
+  prependOnceListener(event: 'drain', listener: () => void): this;
+  prependOnceListener(event: 'error', listener: (err: Error) => void): this;
+  prependOnceListener(event: 'finish', listener: () => void): this;
+  prependOnceListener(event: 'pipe', listener: (src: any) => void): this;
+  prependOnceListener(event: 'unpipe', listener: (src: any) => void): this;
+  prependOnceListener(
+    event: string | symbol,
+    listener: (...args: any[]) => void
+  ): this;
+
+  removeListener(event: 'close', listener: () => void): this;
+  removeListener(event: 'drain', listener: () => void): this;
+  removeListener(event: 'error', listener: (err: Error) => void): this;
+  removeListener(event: 'finish', listener: () => void): this;
+  removeListener(event: 'pipe', listener: (src: any) => void): this;
+  removeListener(event: 'unpipe', listener: (src: any) => void): this;
+  removeListener(
+    event: string | symbol,
+    listener: (...args: any[]) => void
+  ): this;
+}

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -334,3 +334,17 @@ wd_test(
     args = ["--experimental"],
     data = ["tests/async_hooks-nodejs-test.js"],
 )
+
+wd_test(
+    src = "tests/crypto_sign-test.wd-test",
+    args = ["--experimental"],
+    data = [
+        "tests/crypto_sign-test.js",
+        "tests/fixtures/dsa_private.pem",
+        "tests/fixtures/dsa_public.pem",
+        "tests/fixtures/ed25519_private.pem",
+        "tests/fixtures/ed25519_public.pem",
+        "tests/fixtures/rsa_private.pem",
+        "tests/fixtures/rsa_public.pem",
+    ],
+)

--- a/src/workerd/api/node/crypto-keys.c++
+++ b/src/workerd/api/node/crypto-keys.c++
@@ -824,4 +824,12 @@ jsg::BufferSource CryptoImpl::statelessDH(
   JSG_FAIL_REQUIRE(Error, "Unsupported keys for stateless diffie-hellman");
 }
 
+kj::Maybe<const ncrypto::EVPKeyPointer&> CryptoImpl::tryGetKey(jsg::Ref<CryptoKey>& key) {
+  KJ_IF_SOME(key, kj::dynamicDowncastIfAvailable<AsymmetricKey>(*key->impl)) {
+    const ncrypto::EVPKeyPointer& evp = key;
+    return evp;
+  }
+  return kj::none;
+}
+
 }  // namespace workerd::api::node

--- a/src/workerd/api/node/crypto.c++
+++ b/src/workerd/api/node/crypto.c++
@@ -257,4 +257,351 @@ int CryptoImpl::DiffieHellmanHandle::getVerifyError() {
 }
 #pragma endregion  // DiffieHellman
 
+// ======================================================================================
+#pragma region SignVerify
+
+namespace {
+jsg::BackingStore signFinal(jsg::Lock& js,
+    ncrypto::EVPMDCtxPointer&& mdctx,
+    const ncrypto::EVPKeyPointer& pkey,
+    int padding,
+    jsg::Optional<int> pss_salt_len) {
+
+  // The version of BoringSSL we use does not support DSA keys with EVP
+  // When signing/verification. This may change in the future.
+  JSG_REQUIRE(pkey.id() != EVP_PKEY_DSA, Error, "Signing with DSA keys is not currently supported");
+
+  auto data = mdctx.digestFinal(mdctx.getExpectedSize());
+  JSG_REQUIRE(data, Error, "Failed to generate digest");
+
+  auto sig = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, pkey.size());
+  ncrypto::Buffer<kj::byte> sig_buf{
+    .data = sig.asArrayPtr().begin(),
+    .len = sig.size(),
+  };
+
+  ncrypto::EVPKeyCtxPointer pkctx = pkey.newCtx();
+  JSG_REQUIRE(pkctx.initForSign(), Error, "Failed to initialize signing context");
+
+  if (pkey.isRsaVariant()) {
+    std::optional<int> maybeSaltLen = std::nullopt;
+    KJ_IF_SOME(len, pss_salt_len) {
+      maybeSaltLen = len;
+    }
+    JSG_REQUIRE(ncrypto::EVPKeyCtxPointer::setRsaPadding(pkctx.get(), padding, maybeSaltLen), Error,
+        "Failed to set RSA parameters for signature");
+  }
+
+  JSG_REQUIRE(pkctx.setSignatureMd(mdctx), Error, "Failed to set signature digest");
+  JSG_REQUIRE(pkctx.signInto(data, &sig_buf), Error, "Failed to generate signature");
+
+  return kj::mv(sig);
+}
+
+bool verifyFinal(jsg::Lock& js,
+    ncrypto::EVPMDCtxPointer&& mdctx,
+    const ncrypto::EVPKeyPointer& pkey,
+    const jsg::BufferSource& signature,
+    int padding,
+    jsg::Optional<int> pss_salt_len) {
+
+  // The version of BoringSSL we use does not support DSA keys with EVP
+  // When signing/verification. This may change in the future.
+  JSG_REQUIRE(
+      pkey.id() != EVP_PKEY_DSA, Error, "Verifying with DSA keys is not currently supported");
+
+  auto data = mdctx.digestFinal(mdctx.getExpectedSize());
+  JSG_REQUIRE(data, Error, "Failed to finalize signature verification");
+
+  ncrypto::EVPKeyCtxPointer pkctx = pkey.newCtx();
+  JSG_REQUIRE(pkctx, Error, "Failed to initialize key for verification");
+
+  const int init_ret = pkctx.initForVerify();
+  JSG_REQUIRE(init_ret != -2, Error, "Failed to initialize key for verification");
+
+  if (pkey.isRsaVariant()) {
+    std::optional<int> maybeSaltLen = std::nullopt;
+    KJ_IF_SOME(len, pss_salt_len) {
+      maybeSaltLen = len;
+    }
+    JSG_REQUIRE(ncrypto::EVPKeyCtxPointer::setRsaPadding(pkctx.get(), padding, maybeSaltLen), Error,
+        "Failed to set RSA parameters for signature");
+  }
+
+  JSG_REQUIRE(pkctx.setSignatureMd(mdctx), Error,
+      "Failed to set digest context for signature verification");
+
+  ncrypto::Buffer<const kj::byte> sig{
+    .data = signature.asArrayPtr().begin(),
+    .len = signature.size(),
+  };
+
+  return pkctx.verify(sig, data);
+}
+
+jsg::BackingStore convertSignatureToP1363(
+    jsg::Lock& js, const ncrypto::EVPKeyPointer& pkey, jsg::BackingStore&& signature) {
+  auto maybeRs = pkey.getBytesOfRS();
+  if (!maybeRs.has_value()) return kj::mv(signature);
+  unsigned int n = maybeRs.value();
+
+  auto ret = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, 2 * n);
+
+  ncrypto::Buffer<const unsigned char> sig_buffer{
+    .data = signature.asArrayPtr().begin(),
+    .len = signature.size(),
+  };
+
+  if (!ncrypto::extractP1363(sig_buffer, ret.asArrayPtr().begin(), n)) {
+    return kj::mv(signature);
+  }
+
+  return kj::mv(ret);
+}
+
+jsg::BackingStore convertSignatureToDER(
+    jsg::Lock& js, const ncrypto::EVPKeyPointer& pkey, jsg::BackingStore&& backing) {
+  auto maybeRs = pkey.getBytesOfRS();
+  if (!maybeRs.has_value()) return kj::mv(backing);
+  unsigned int n = maybeRs.value();
+
+  if (backing.size() != 2 * n) {
+    return jsg::BackingStore::alloc<v8::ArrayBuffer>(js, 0);
+  }
+
+  const kj::byte* sig_data = backing.asArrayPtr().begin();
+
+  auto asn1_sig = ncrypto::ECDSASigPointer::New();
+  JSG_REQUIRE(asn1_sig, Error, "Internal error generating signature");
+  ncrypto::BignumPointer r(sig_data, n);
+  JSG_REQUIRE(r, Error, "Internal error generating signature");
+  ncrypto::BignumPointer s(sig_data + n, n);
+  JSG_REQUIRE(s, Error, "Internal error generating signature");
+  JSG_REQUIRE(asn1_sig.setParams(kj::mv(r), kj::mv(s)), Error,
+      "Internal error setting signature parameters");
+
+  auto buf = asn1_sig.encode();
+  if (buf.len <= 0) [[unlikely]] {
+    return jsg::BackingStore::alloc<v8::ArrayBuffer>(js, 0);
+  }
+
+  auto ret = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, buf.len);
+  ret.asArrayPtr().copyFrom(kj::ArrayPtr<kj::byte>(buf.data, buf.len));
+  return kj::mv(ret);
+}
+
+const EVP_MD* maybeGetDigest(jsg::Optional<kj::String>& maybeAlgorithm) {
+  KJ_IF_SOME(alg, maybeAlgorithm) {
+    auto md = ncrypto::getDigestByName(std::string_view(alg.begin(), alg.size()));
+    JSG_REQUIRE(md != nullptr, Error, kj::str("Unknown digest: ", alg));
+    return md;
+  }
+  return nullptr;
+}
+}  // namespace
+
+CryptoImpl::SignHandle::SignHandle(ncrypto::EVPMDCtxPointer ctx)
+    : ctx(ncrypto::EVPMDCtxPointer(ctx.release())) {}
+
+jsg::Ref<CryptoImpl::SignHandle> CryptoImpl::SignHandle::constructor(kj::String algorithm) {
+  ncrypto::ClearErrorOnReturn clear_error_on_return;
+  auto md = ncrypto::getDigestByName(std::string_view(algorithm.begin(), algorithm.size()));
+  JSG_REQUIRE(md != nullptr, Error, kj::str("Unknown digest: ", algorithm));
+
+  auto mdctx = ncrypto::EVPMDCtxPointer::New();
+  JSG_REQUIRE(mdctx, Error, "Failed to create signing context");
+  JSG_REQUIRE(mdctx.digestInit(md), Error, "Failed to initialize signing context");
+  return jsg::alloc<SignHandle>(kj::mv(mdctx));
+}
+
+void CryptoImpl::SignHandle::update(jsg::Lock& js, jsg::BufferSource data) {
+  ncrypto::ClearErrorOnReturn clear_error_on_return;
+  JSG_REQUIRE(ctx, Error, "Signing context has already been finalized");
+  auto ptr = data.asArrayPtr();
+  ncrypto::Buffer<const void> buf{
+    .data = ptr.begin(),
+    .len = ptr.size(),
+  };
+  JSG_REQUIRE(ctx.digestUpdate(buf), Error, "Failed to update signing context");
+}
+
+jsg::BufferSource CryptoImpl::SignHandle::sign(jsg::Lock& js,
+    jsg::Ref<CryptoKey> key,
+    jsg::Optional<int> rsaPadding,
+    jsg::Optional<int> pssSaltLength,
+    jsg::Optional<int> dsaSigEnc) {
+  ncrypto::ClearErrorOnReturn clear_error_on_return;
+  JSG_REQUIRE(ctx, Error, "Signing context has already been finalized");
+
+  const auto& pkey = JSG_REQUIRE_NONNULL(tryGetKey(key), Error, "Invalid key for sign operation");
+  JSG_REQUIRE(pkey.validateDsaParameters(), Error, "Invalid DSA parameters");
+
+  // There's a bug in ncrypto that doesn't clear the EVPMDCtxPointer when
+  // moved with kj::mv so instead we release and wrap again.
+  auto backing = signFinal(js, ncrypto::EVPMDCtxPointer(ctx.release()), pkey,
+      rsaPadding.orDefault(pkey.getDefaultSignPadding()), pssSaltLength);
+
+  KJ_IF_SOME(enc, dsaSigEnc) {
+    static constexpr unsigned kP1363 = 1;
+    JSG_REQUIRE(enc <= kP1363 && enc >= 0, Error, "Invalid DSA signature encoding");
+    if (enc == kP1363) {
+      backing = convertSignatureToP1363(js, pkey, kj::mv(backing));
+    }
+  }
+
+  return jsg::BufferSource(js, kj::mv(backing));
+}
+
+CryptoImpl::VerifyHandle::VerifyHandle(ncrypto::EVPMDCtxPointer ctx)
+    : ctx(ncrypto::EVPMDCtxPointer(ctx.release())) {}
+
+jsg::Ref<CryptoImpl::VerifyHandle> CryptoImpl::VerifyHandle::constructor(kj::String algorithm) {
+  ncrypto::ClearErrorOnReturn clear_error_on_return;
+  auto md = ncrypto::getDigestByName(std::string_view(algorithm.begin(), algorithm.size()));
+  JSG_REQUIRE(md != nullptr, Error, kj::str("Unknown digest: ", algorithm));
+
+  auto mdctx = ncrypto::EVPMDCtxPointer::New();
+  JSG_REQUIRE(mdctx, Error, "Failed to create verification context");
+  JSG_REQUIRE(mdctx.digestInit(md), Error, "Failed to initialize verification context");
+
+  return jsg::alloc<VerifyHandle>(kj::mv(mdctx));
+}
+
+void CryptoImpl::VerifyHandle::update(jsg::Lock& js, jsg::BufferSource data) {
+  ncrypto::ClearErrorOnReturn clear_error_on_return;
+  JSG_REQUIRE(ctx, Error, "Verification context has already been finalized");
+  auto ptr = data.asArrayPtr();
+  ncrypto::Buffer<const void> buf{
+    .data = ptr.begin(),
+    .len = ptr.size(),
+  };
+  JSG_REQUIRE(ctx.digestUpdate(buf), Error, "Failed to update verification context");
+}
+
+bool CryptoImpl::VerifyHandle::verify(jsg::Lock& js,
+    jsg::Ref<CryptoKey> key,
+    jsg::BufferSource signature,
+    jsg::Optional<int> rsaPadding,
+    jsg::Optional<int> maybeSaltLen,
+    jsg::Optional<int> dsaSigEnc) {
+  ncrypto::ClearErrorOnReturn clear_error_on_return;
+
+  JSG_REQUIRE(ctx, Error, "Verification context has already been finalized");
+
+  const auto& pkey = JSG_REQUIRE_NONNULL(tryGetKey(key), Error, "Invalid key for verify operation");
+
+  JSG_REQUIRE(!pkey.isOneShotVariant(), Error, "Unsupported operation for this key");
+
+  auto clonedSignature = signature.clone(js);
+  KJ_IF_SOME(enc, dsaSigEnc) {
+    static constexpr unsigned kP1363 = 1;
+    JSG_REQUIRE(enc <= kP1363 && enc >= 0, Error, "Invalid DSA signature encoding");
+    if (enc == kP1363) {
+      clonedSignature =
+          jsg::BufferSource(js, convertSignatureToDER(js, pkey, clonedSignature.detach(js)));
+    }
+  }
+
+  return verifyFinal(js, ncrypto::EVPMDCtxPointer(ctx.release()), pkey, clonedSignature,
+      rsaPadding.orDefault(pkey.getDefaultSignPadding()), maybeSaltLen);
+}
+
+jsg::BufferSource CryptoImpl::signOneShot(jsg::Lock& js,
+    jsg::Ref<CryptoKey> key,
+    jsg::Optional<kj::String> algorithm,
+    jsg::BufferSource data,
+    jsg::Optional<int> rsaPadding,
+    jsg::Optional<int> pssSaltLength,
+    jsg::Optional<int> dsaSigEnc) {
+  ncrypto::ClearErrorOnReturn clear_error_on_return;
+
+  auto mdctx = ncrypto::EVPMDCtxPointer::New();
+  JSG_REQUIRE(mdctx, Error, "Failed to create signing context");
+
+  const auto& pkey = JSG_REQUIRE_NONNULL(tryGetKey(key), Error, "Invalid key for sign operation");
+
+  // The version of BoringSSL we use does not support DSA keys with EVP
+  // When signing/verification. This may change in the future.
+  JSG_REQUIRE(pkey.id() != EVP_PKEY_DSA, Error, "Signing with DSA keys is not currently supported");
+  // TODO(later): When DSA keys are supported, uncomment to validate DSA params.
+  // JSG_REQUIRE(pkey.validateDsaParameters(), Error, "Invalid DSA parameters");
+
+  auto md = maybeGetDigest(algorithm);
+
+  JSG_REQUIRE(mdctx.signInit(pkey, md).has_value(), Error, "Failed to initialize signing context");
+
+  ncrypto::Buffer<const kj::byte> buf{
+    .data = data.asArrayPtr().begin(),
+    .len = data.size(),
+  };
+
+  ncrypto::DataPointer sig = mdctx.signOneShot(buf);
+  kj::ArrayPtr<kj::byte> sigPtr(sig.get<kj::byte>(), sig.size());
+  auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, sig.size());
+  backing.asArrayPtr().copyFrom(sigPtr);
+
+  KJ_IF_SOME(enc, dsaSigEnc) {
+    static constexpr unsigned kP1363 = 1;
+    JSG_REQUIRE(enc <= kP1363 && enc >= 0, Error, "Invalid DSA signature encoding");
+    if (enc == kP1363) {
+      backing = convertSignatureToP1363(js, pkey, kj::mv(backing));
+    }
+  }
+
+  return jsg::BufferSource(js, kj::mv(backing));
+}
+
+bool CryptoImpl::verifyOneShot(jsg::Lock& js,
+    jsg::Ref<CryptoKey> key,
+    jsg::Optional<kj::String> algorithm,
+    jsg::BufferSource data,
+    jsg::BufferSource signature,
+    jsg::Optional<int> rsaPadding,
+    jsg::Optional<int> pssSaltLength,
+    jsg::Optional<int> dsaSigEnc) {
+  ncrypto::ClearErrorOnReturn clear_error_on_return;
+
+  auto mdctx = ncrypto::EVPMDCtxPointer::New();
+  JSG_REQUIRE(mdctx, Error, "Failed to create verification context");
+
+  const auto& pkey =
+      JSG_REQUIRE_NONNULL(tryGetKey(key), Error, "Invalid key for verification operation");
+
+  // The version of BoringSSL we use does not support DSA keys with EVP
+  // When signing/verification. This may change in the future.
+  JSG_REQUIRE(
+      pkey.id() != EVP_PKEY_DSA, Error, "Verifying with DSA keys is not currently supported");
+  // TODO(later): When DSA keys are supported, uncomment to validate DSA params.
+  // JSG_REQUIRE(pkey.validateDsaParameters(), Error, "Invalid DSA parameters");
+
+  auto md = maybeGetDigest(algorithm);
+
+  JSG_REQUIRE(
+      mdctx.verifyInit(pkey, md).has_value(), Error, "Failed to initialize verification context");
+
+  auto clonedSignature = signature.clone(js);
+  KJ_IF_SOME(enc, dsaSigEnc) {
+    static constexpr unsigned kP1363 = 1;
+    JSG_REQUIRE(enc <= kP1363 && enc >= 0, Error, "Invalid DSA signature encoding");
+    if (enc == kP1363) {
+      clonedSignature =
+          jsg::BufferSource(js, convertSignatureToDER(js, pkey, clonedSignature.detach(js)));
+    }
+  }
+
+  ncrypto::Buffer<const kj::byte> buf{
+    .data = data.asArrayPtr().begin(),
+    .len = data.size(),
+  };
+
+  ncrypto::Buffer<const kj::byte> sig{
+    .data = clonedSignature.asArrayPtr().begin(),
+    .len = clonedSignature.size(),
+  };
+
+  return mdctx.verify(buf, sig);
+}
+
+#pragma endregion  // SignVerify
+
 }  // namespace workerd::api::node

--- a/src/workerd/api/node/tests/crypto_sign-test.js
+++ b/src/workerd/api/node/tests/crypto_sign-test.js
@@ -1,0 +1,146 @@
+import {
+  createSign,
+  createVerify,
+  createPrivateKey,
+  createPublicKey,
+  sign,
+  verify,
+} from 'node:crypto';
+
+import { strictEqual, throws } from 'node:assert';
+
+const rsaSig =
+  '26bb4d9641ecec048b791322c6427f62f3f4e21f7198e9e7544c8a56af40' +
+  '27bcfe1b306291188f97ced0e3ceaa5ded1ae1406ec30e46a18434e55dc6' +
+  'c9f237e26b124bf7ec77e54483d7782b805aa9a74bbe0f4aa8658d7620e4' +
+  'd3a305777b5dc8262c675bf23c8dc5acfe8c4fa1ca8acdd956cdcbdf1fb2' +
+  'f879b37dc0ed8ec51815ff02b98eefde44ac79f886902ea69e5ed2561e9e' +
+  'eb2a74ec1de677b285f8108f25e9f34cc826fbbd1ad091d231dc73eaf28a' +
+  'e02f09ad84ec9a38d8a7e28bea26fb7d4db20eecd075b5b261ca7320af94' +
+  'cd58ba4b26d895df4fd6f68bd4d82acdcb35557012e2f69739ce8cf4a66e' +
+  'bf4550ee50f6c9cec642d66fef71495a';
+
+export const rsaSignVerifyObjects = {
+  test(_, env) {
+    const key = createPrivateKey(env['rsa_private.pem']);
+
+    throws(() => createSign(), {
+      message:
+        'The "algorithm" argument must be of type string. Received undefined',
+    });
+
+    const signer = createSign('sha256');
+    signer.update('hello world');
+
+    throws(() => signer.update(1), {
+      message: /argument must be of type string/,
+    });
+
+    throws(() => signer.sign(), {
+      message: 'No key provided to sign',
+    });
+
+    throws(() => signer.sign(env['rsa_public.pem']), {
+      message: 'Failed to parse private key',
+    });
+
+    const pub = createPublicKey(env['rsa_public.pem']);
+    throws(() => signer.sign(pub), {
+      code: 'ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE',
+    });
+
+    const signature = signer.sign(key, 'hex');
+
+    throws(() => signer.sign(key, 'hex'), {
+      message: 'Signing context has already been finalized',
+    });
+
+    strictEqual(signature, rsaSig);
+
+    const verify = createVerify('sha256');
+
+    throws(() => createVerify(), {
+      message:
+        'The "algorithm" argument must be of type string. Received undefined',
+    });
+
+    verify.update('hello world');
+
+    throws(() => verify.update(1), {
+      message: /argument must be of type string/,
+    });
+
+    throws(() => verify.verify(), {
+      message: 'No key provided to sign',
+    });
+
+    strictEqual(verify.verify(env['rsa_public.pem'], signature, 'hex'), true);
+
+    throws(() => verify.verify(env['rsa_public.pem'], signature, 'hex'), {
+      message: 'Verification context has already been finalized',
+    });
+  },
+};
+
+export const rsaSignVerifyOneshot = {
+  test(_, env) {
+    const key = createPrivateKey(env['rsa_private.pem']);
+    const sig = sign('sha256', Buffer.from('hello world'), key);
+    strictEqual(sig.toString('hex'), rsaSig);
+    strictEqual(
+      verify('sha256', Buffer.from('hello world'), env['rsa_public.pem'], sig),
+      true
+    );
+  },
+};
+
+export const ed25519SignVerifyObjects = {
+  test(_, env) {
+    // Sign object is not allowed with ed25519
+    throws(
+      () => {
+        const key = createPrivateKey(env['ed25519_private.pem']);
+        const signer = createSign('sha256');
+        signer.update('hello world');
+        const signature = signer.sign(key, 'hex');
+      },
+      {
+        message: 'Failed to set signature digest',
+      }
+    );
+  },
+};
+
+export const ed25519SignVerifyOneshot = {
+  test(_, env) {
+    const key = createPrivateKey(env['ed25519_private.pem']);
+    const sig = sign(null, Buffer.from('hello world'), key);
+    strictEqual(
+      verify(null, Buffer.from('hello world'), env['ed25519_public.pem'], sig),
+      true
+    );
+  },
+};
+
+export const dsaSignVerifyObjects = {
+  test(_, env) {
+    const pvt = createPrivateKey(env['dsa_private.pem']);
+    const pub = createPublicKey(env['dsa_public.pem']);
+    const signer = createSign('sha256');
+    const verifier = createVerify('sha256');
+    signer.update('');
+    verifier.update('');
+    throws(() => signer.sign(pvt), {
+      message: 'Signing with DSA keys is not currently supported',
+    });
+    throws(() => verifier.verify(pub, Buffer.alloc(0)), {
+      message: 'Verifying with DSA keys is not currently supported',
+    });
+    throws(() => sign('sha256', Buffer.alloc(0), pvt), {
+      message: 'Signing with DSA keys is not currently supported',
+    });
+    throws(() => verify('sha256', Buffer.alloc(0), pub, Buffer.alloc(0)), {
+      message: 'Verifying with DSA keys is not currently supported',
+    });
+  },
+};

--- a/src/workerd/api/node/tests/crypto_sign-test.wd-test
+++ b/src/workerd/api/node/tests/crypto_sign-test.wd-test
@@ -1,0 +1,23 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "crypto_sign-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "crypto_sign-test.js")
+        ],
+        compatibilityDate = "2025-01-15",
+        compatibilityFlags = ["nodejs_compat", "experimental"],
+        bindings = [
+          ( name = "rsa_private.pem", text = embed "fixtures/rsa_private.pem" ),
+          ( name = "rsa_public.pem", text = embed "fixtures/rsa_public.pem" ),
+          ( name = "ed25519_private.pem", text = embed "fixtures/ed25519_private.pem" ),
+          ( name = "ed25519_public.pem", text = embed "fixtures/ed25519_public.pem" ),
+          ( name = "dsa_private.pem", text = embed "fixtures/dsa_private.pem" ),
+          ( name = "dsa_public.pem", text = embed "fixtures/dsa_public.pem" ),
+        ],
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
Implements the `node:crypto` `createSign(...)`/`createVerify(...)`/`crypto.sign(...)`/`crypto.verify(...)` APIs. RSA and ed25519 are currently test to work, other key types aren't verified yet. DSA likely does not work, for instance. Will be working on expanding tests next but this ought to be able to land.

Reviewers: some familiarity with the Node.js implementation is likely necessary to review this for correctness. 