### PR TITLE
SQLite: Don't bill for internal queries.

### DIFF
--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -111,6 +111,11 @@ bool SqlStorage::allowTransactions() const {
       "write coalescing.");
 }
 
+bool SqlStorage::shouldAddQueryStats() const {
+  // Bill for queries executed from JavaScript.
+  return true;
+}
+
 SqlStorage::StatementCache::~StatementCache() noexcept(false) {
   for (auto& entry: lru) {
     lru.remove(entry);

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -69,6 +69,7 @@ class SqlStorage final: public jsg::Object, private SqliteDatabase::Regulator {
   bool isAllowedTrigger(kj::StringPtr name) const override;
   void onError(kj::Maybe<int> sqliteErrorCode, kj::StringPtr message) const override;
   bool allowTransactions() const override;
+  bool shouldAddQueryStats() const override;
 
   SqliteDatabase& getDb(jsg::Lock& js) {
     return storage->getSqliteDb(js);

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -1291,8 +1291,10 @@ SqliteDatabase::Query::~Query() noexcept(false) {
 }
 
 void SqliteDatabase::Query::destroy() {
-  //Update the db stats that we have collected for the query
-  db.sqliteObserver.addQueryStats(rowsRead, rowsWritten);
+  if (regulator.shouldAddQueryStats()) {
+    //Update the db stats that we have collected for the query
+    db.sqliteObserver.addQueryStats(rowsRead, rowsWritten);
+  }
 
   // We only need to reset the statement if we don't own it. If we own it, it's about to be
   // destroyed anyway.

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -118,6 +118,14 @@ class SqliteDatabase {
     virtual bool allowTransactions() const {
       return true;
     }
+
+    // Whether or not this query's rows read and written should be recorded to the SqliteObserver
+    // when the query is done. (In other words, determines whether this query is billed.)
+    //
+    // We don't bill for TRUSTED queries since they are used internally by the system.
+    virtual bool shouldAddQueryStats() const {
+      return false;
+    }
   };
 
   // Use as the `Regulator&` for queries that are fully trusted. As a general rule, this should


### PR DESCRIPTION
We bill for:
- SQL queries issued via the JavaScript SQL API.
- DO old-style key/value storage operations.

Anything else, we assume is an internal query, and not billed.