### PR TITLE
[nfc] Disentangle and Modularize JSG

### DIFF
--- a/build/kj_test.bzl
+++ b/build/kj_test.bzl
@@ -3,7 +3,8 @@ def kj_test(
         data = [],
         deps = [],
         tags = [],
-        size = "medium"):
+        size = "medium",
+        **kwargs):
     test_name = src.removesuffix(".c++")
     native.cc_test(
         name = test_name,
@@ -18,4 +19,5 @@ def kj_test(
         data = data,
         tags = tags,
         size = size,
+        **kwargs
     )

--- a/src/rust/gen-compile-cache/BUILD.bazel
+++ b/src/rust/gen-compile-cache/BUILD.bazel
@@ -23,6 +23,7 @@ wd_cc_library(
     deps = [
         "//src/rust/cxx-integration",
         "//src/workerd/jsg",
+        "//src/workerd/jsg:compile-cache",
         "@capnp-cpp//src/kj",
     ],
 )

--- a/src/rust/gen-compile-cache/cxx-bridge.c++
+++ b/src/rust/gen-compile-cache/cxx-bridge.c++
@@ -1,6 +1,7 @@
 #include "cxx-bridge.h"
 
 #include <workerd/jsg/compile-cache.h>
+#include <workerd/jsg/type-wrapper.h>
 #include <workerd/jsg/setup.h>
 
 #include <workerd/rust/cxx-integration/lib.rs.h>

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -124,6 +124,8 @@ wd_cc_library(
         "//src/workerd/api:url",
         "//src/workerd/api:urlpattern",
         "//src/workerd/jsg",
+        "//src/workerd/jsg:inspector",
+        "//src/workerd/jsg:script",
         "//src/workerd/util:autogate",
         "//src/workerd/util:completion-membrane",
         "//src/workerd/util:exception",

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -9,20 +9,85 @@ exports_files(["modules.capnp"])
 wd_cc_library(
     name = "jsg",
     srcs = [
+        "modules-new.c++",
+    ],
+    hdrs = [
+        "jsg-test.h",
+        "modules-new.h",
+        "type-wrapper.h",
+    ],
+    local_defines = ["JSG_IMPLEMENTATION"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":exception",
+        ":iterator",
+        ":jsg-core",
+        ":memory-tracker",
+        ":url",
+        "//src/workerd/util",
+        "//src/workerd/util:sentry",
+        "//src/workerd/util:thread-scopes",
+        "@capnp-cpp//src/kj",
+        "@workerd-v8//:v8",
+    ],
+)
+
+wd_cc_library(
+    name = "iterator",
+    srcs = [
+        "iterator.c++",
+    ],
+    hdrs = [
+        "iterator.h",
+        "struct.h",
+        "value.h",
+        "web-idl.h",
+    ],
+    local_defines = ["JSG_IMPLEMENTATION"],
+    deps = [
+        ":exception",
+        ":jsg-core",
+        ":memory-tracker",
+        "//src/workerd/util",
+        "//src/workerd/util:sentry",
+        "//src/workerd/util:thread-scopes",
+        "@capnp-cpp//src/kj",
+        "@simdutf",
+        "@workerd-v8//:v8",
+    ],
+)
+
+wd_cc_library(
+    name = "script",
+    srcs = ["script.c++"],
+    hdrs = ["script.h"],
+    local_defines = ["JSG_IMPLEMENTATION"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":jsg-core",
+        "@capnp-cpp//src/kj",
+        "@workerd-v8//:v8",
+    ],
+)
+
+# Subset of JSG that includes core JSG interfaces, but does not depend on type-wrapper API.
+# Factoring this out reduces the need for circular includes and will make future refactoring of JSG
+# much easier.
+# This is only visible in this package for now – to avoid extensive include changes in code using
+# the JSG type wrapper, the main JSG target should be used instead for now.
+# Avoid adding dependencies or new files to this when possible.
+wd_cc_library(
+    name = "jsg-core",
+    srcs = [
         "async-context.c++",
         "buffersource.c++",
         "commonjs.c++",
-        "compile-cache.c++",
         "dom-exception.c++",
-        "inspector.c++",
-        "iterator.c++",
         "jsg.c++",
         "jsvalue.c++",
         "modules.c++",
-        "modules-new.c++",
         "promise.c++",
         "resource.c++",
-        "script.c++",
         "ser.c++",
         "setup.c++",
         "util.c++",
@@ -33,48 +98,71 @@ wd_cc_library(
         "async-context.h",
         "buffersource.h",
         "commonjs.h",
-        "compile-cache.h",
         "dom-exception.h",
         "function.h",
-        "inspector.h",
-        "iterator.h",
         "jsg.h",
-        "jsg-test.h",
         "jsvalue.h",
-        "macro-meta.h",
-        "meta.h",
         "modules.h",
-        "modules-new.h",
         "promise.h",
         "resource.h",
-        "script.h",
         "ser.h",
         "setup.h",
-        "struct.h",
-        "type-wrapper.h",
         "util.h",
         "v8-platform-wrapper.h",
-        "value.h",
-        "web-idl.h",
         "wrappable.h",
     ],
     # Some JSG headers can't be compiled on their own
     features = ["-parse_headers"],
-    visibility = ["//visibility:public"],
+    local_defines = ["JSG_IMPLEMENTATION"],
     deps = [
         ":exception",
+        ":macro-meta",
         ":memory-tracker",
+        ":meta",
         ":modules_capnp",
         ":observer",
-        ":url",
         "//src/workerd/util",
         "//src/workerd/util:autogate",
         "//src/workerd/util:sentry",
         "//src/workerd/util:thread-scopes",
         "//src/workerd/util:uuid",
         "@capnp-cpp//src/kj",
-        "@simdutf",
         "@ssl",
+        "@workerd-v8//:v8",
+    ],
+)
+
+wd_cc_library(
+    name = "compile-cache",
+    srcs = [
+        "compile-cache.c++",
+    ],
+    hdrs = [
+        "compile-cache.h",
+    ],
+    local_defines = ["JSG_IMPLEMENTATION"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj",
+        "@workerd-v8//:v8",
+    ],
+)
+
+wd_cc_library(
+    name = "inspector",
+    srcs = [
+        "inspector.c++",
+    ],
+    hdrs = [
+        "inspector.h",
+    ],
+    local_defines = ["JSG_IMPLEMENTATION"],
+    # Some JSG headers can't be compiled on their own
+    visibility = ["//visibility:public"],
+    deps = [
+        ":jsg-core",
+        "@capnp-cpp//src/kj",
+        "@simdutf",
         "@workerd-v8//:v8",
     ],
 )
@@ -83,6 +171,16 @@ wd_cc_library(
     name = "memory-tracker",
     srcs = ["memory.c++"],
     hdrs = ["memory.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj",
+        "@workerd-v8//:v8",
+    ],
+)
+
+wd_cc_library(
+    name = "meta",
+    hdrs = ["meta.h"],
     visibility = ["//visibility:public"],
     deps = [
         "@capnp-cpp//src/kj",
@@ -176,6 +274,7 @@ wd_cc_library(
 
 [kj_test(
     src = f,
+    local_defines = ["JSG_IMPLEMENTATION"],
     deps = [
         ":jsg",
         "//src/workerd/util:autogate",
@@ -243,7 +342,7 @@ kj_test(
 kj_test(
     src = "multiple-typewrappers-test.c++",
     deps = [
-        "//src/workerd/io",
+        "//src/workerd/io:compatibility-date_capnp",
         "//src/workerd/jsg",
     ],
 )

--- a/src/workerd/jsg/buffersource.h
+++ b/src/workerd/jsg/buffersource.h
@@ -6,6 +6,8 @@
 
 #include "jsg.h"
 
+#include <v8-typed-array.h>
+
 namespace workerd::jsg {
 
 #define JSG_ARRAY_BUFFER_VIEW_TYPES(V)                                                             \

--- a/src/workerd/jsg/commonjs.c++
+++ b/src/workerd/jsg/commonjs.c++
@@ -1,6 +1,8 @@
 #include "commonjs.h"
 
+#include "jsvalue.h"
 #include "modules.h"
+#include "resource.h"
 
 namespace workerd::jsg {
 

--- a/src/workerd/jsg/compile-cache.h
+++ b/src/workerd/jsg/compile-cache.h
@@ -3,11 +3,10 @@
 //     https://opensource.org/licenses/Apache-2.0
 #pragma once
 
-#include "jsg.h"
-#include "setup.h"
+#include <v8-script.h>
 
-#include <v8.h>
-
+#include <kj/map.h>
+#include <kj/mutex.h>
 #include <kj/string.h>
 
 namespace workerd::jsg {

--- a/src/workerd/jsg/dom-exception.c++
+++ b/src/workerd/jsg/dom-exception.c++
@@ -4,6 +4,7 @@
 
 #include "dom-exception.h"
 
+#include "jsvalue.h"
 #include "ser.h"
 
 #include <workerd/jsg/memory.h>

--- a/src/workerd/jsg/dom-exception.h
+++ b/src/workerd/jsg/dom-exception.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "jsg.h"
-#include "ser.h"
 
 #define JSG_DOM_EXCEPTION_FOR_EACH_ERROR_NAME(f)                                                   \
   f(INDEX_SIZE_ERR, 1, "IndexSizeError") f(DOMSTRING_SIZE_ERR, 2, "DOMStringSizeError")            \
@@ -28,6 +27,8 @@
                                                   f(DATA_CLONE_ERR, 25, "DataCloneError")
 
 namespace workerd::jsg {
+class Serializer;
+class Deserializer;
 
 // JSG allows DOMExceptions to be tunneled through kj::Exceptions (see makeInternalError() for
 // details). While this feature is activated conditionally at run-time, and thus does not depend

--- a/src/workerd/jsg/function.h
+++ b/src/workerd/jsg/function.h
@@ -8,8 +8,12 @@
 // Handles wrapping a C++ function so that it can be called from JavaScript, and vice versa.
 
 #include "jsg.h"
-#include "meta.h"
 #include "wrappable.h"
+
+#include <workerd/jsg/meta.h>
+
+#include <v8-context.h>
+#include <v8-function.h>
 
 #include <kj/function.h>
 

--- a/src/workerd/jsg/inspector.c++
+++ b/src/workerd/jsg/inspector.c++
@@ -1,6 +1,7 @@
 #include "inspector.h"
 
 #include "jsg.h"
+#include "jsvalue.h"
 #include "simdutf.h"
 #include "util.h"
 

--- a/src/workerd/jsg/iterator.h
+++ b/src/workerd/jsg/iterator.h
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#include "jsg.h"
-#include "struct.h"
-
+#include <workerd/jsg/jsg.h>
 #include <workerd/jsg/memory.h>
+#include <workerd/jsg/struct.h>
 
 #include <concepts>
 #include <deque>

--- a/src/workerd/jsg/jsg-test.h
+++ b/src/workerd/jsg/jsg-test.h
@@ -5,8 +5,10 @@
 #pragma once
 // Common JSG testing infrastructure
 
-#include "jsg.h"
-#include "setup.h"
+#include <workerd/jsg/jsg.h>
+#include <workerd/jsg/resource.h>
+#include <workerd/jsg/setup.h>
+#include <workerd/jsg/type-wrapper.h>
 
 #include <kj/test.h>
 

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -3,6 +3,11 @@
 #include "buffersource.h"
 #include "ser.h"
 
+#include <v8.h>
+
+#include <kj/string-tree.h>
+#include <kj/string.h>
+
 namespace workerd::jsg {
 
 JsValue::JsValue(v8::Local<v8::Value> inner): inner(inner) {

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -2,7 +2,8 @@
 
 #include "jsg.h"
 
-#include <v8.h>
+#include <v8-container.h>
+#include <v8-external.h>
 
 namespace workerd::jsg {
 

--- a/src/workerd/jsg/memory-test.c++
+++ b/src/workerd/jsg/memory-test.c++
@@ -4,6 +4,7 @@
 
 #include <workerd/jsg/memory.h>
 #include <workerd/jsg/setup.h>
+#include <workerd/jsg/type-wrapper.h>
 
 #include <v8-profiler.h>
 

--- a/src/workerd/jsg/memory.c++
+++ b/src/workerd/jsg/memory.c++
@@ -1,5 +1,7 @@
 #include "memory.h"
 
+#include <v8-array-buffer.h>
+
 #include <kj/one-of.h>
 
 namespace workerd::jsg {
@@ -208,6 +210,11 @@ int HeapSnapshotWriter::GetChunkSize() {
 v8::OutputStream::WriteResult HeapSnapshotWriter::WriteAsciiChunk(char* data, int size) {
   return callback(kj::ArrayPtr<char>(data, size)) ? v8::OutputStream::WriteResult::kContinue
                                                   : v8::OutputStream::WriteResult::kAbort;
+}
+
+void MemoryTracker::trackField(
+    kj::StringPtr edgeName, const v8::BackingStore* value, kj::Maybe<kj::StringPtr> nodeName) {
+  trackFieldWithSize(edgeName, value->ByteLength(), "BackingStore"_kjc);
 }
 
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/memory.h
+++ b/src/workerd/jsg/memory.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <v8-array-buffer.h>
 #include <v8-profiler.h>
 
 #include <kj/common.h>
@@ -21,6 +20,10 @@
 
 #include <stack>
 #include <string>
+
+namespace v8 {
+class BackingStore;
+}
 
 namespace workerd::jsg {
 
@@ -341,11 +344,6 @@ void MemoryTracker::trackFieldWithSize(
 void MemoryTracker::trackInlineFieldWithSize(
     kj::StringPtr edgeName, size_t size, kj::Maybe<kj::StringPtr> nodeName) {
   if (size > 0) addNode(nodeName.orDefault(edgeName), size, edgeName);
-}
-
-void MemoryTracker::trackField(
-    kj::StringPtr edgeName, const v8::BackingStore* value, kj::Maybe<kj::StringPtr> nodeName) {
-  trackFieldWithSize(edgeName, value->ByteLength(), "BackingStore"_kjc);
 }
 
 void MemoryTracker::trackField(

--- a/src/workerd/jsg/modules-new-test.c++
+++ b/src/workerd/jsg/modules-new-test.c++
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "observer.h"
+#include "type-wrapper.h"
 #include "url.h"
 
 #include <workerd/jsg/modules-new.h>

--- a/src/workerd/jsg/modules-new.h
+++ b/src/workerd/jsg/modules-new.h
@@ -5,8 +5,11 @@
 #pragma once
 
 #include <workerd/jsg/jsg.h>
+#include <workerd/jsg/jsvalue.h>
 #include <workerd/jsg/modules.capnp.h>
+#include <workerd/jsg/modules.h>
 #include <workerd/jsg/observer.h>
+#include <workerd/jsg/setup.h>
 #include <workerd/jsg/url.h>
 #include <workerd/jsg/util.h>
 

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -3,9 +3,10 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include "commonjs.h"
-#include "compile-cache.h"
 #include "jsg.h"
 #include "setup.h"
+
+#include <v8-wasm.h>
 
 #include <kj/mutex.h>
 

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -9,7 +9,10 @@
 #include <workerd/jsg/modules.capnp.h>
 #include <workerd/jsg/observer.h>
 #include <workerd/jsg/promise.h>
+#include <workerd/util/sentry.h>
 #include <workerd/util/thread-scopes.h>
+
+#include <v8-json.h>
 
 #include <kj/filesystem.h>
 #include <kj/map.h>

--- a/src/workerd/jsg/multiple-typewrappers-test.c++
+++ b/src/workerd/jsg/multiple-typewrappers-test.c++
@@ -1,7 +1,7 @@
-#include <workerd/io/compatibility-date.h>
-#include <workerd/io/observer.h>
+#include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/setup.h>
+#include <workerd/jsg/type-wrapper.h>
 
 #include <capnp/message.h>
 #include <kj/test.h>

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -8,6 +8,8 @@
 #include "util.h"
 #include "wrappable.h"
 
+#include <v8-promise.h>
+
 #include <kj/async.h>
 #include <kj/table.h>
 

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -10,12 +10,15 @@
 // can call back to the class's methods. This differs from, say, a struct type, which will be deeply
 // converted into a JS object when passed into JS.
 
-#include "meta.h"
+#include "ser.h"
 #include "util.h"
 #include "wrappable.h"
 
 #include <workerd/jsg/memory.h>
+#include <workerd/jsg/meta.h>
 #include <workerd/jsg/modules.capnp.h>
+
+#include <v8-template.h>
 
 #include <kj/debug.h>
 #include <kj/map.h>

--- a/src/workerd/jsg/rtti-test.c++
+++ b/src/workerd/jsg/rtti-test.c++
@@ -5,6 +5,7 @@
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/rtti-test.capnp.h>
 #include <workerd/jsg/rtti.h>
+#include <workerd/jsg/type-wrapper.h>
 
 #include <capnp/message.h>
 #include <capnp/serialize-text.h>

--- a/src/workerd/jsg/script.c++
+++ b/src/workerd/jsg/script.c++
@@ -1,5 +1,7 @@
 #include "script.h"
 
+#include <workerd/jsg/jsvalue.h>
+
 namespace workerd::jsg {
 
 jsg::JsValue NonModuleScript::runAndReturn(jsg::Lock& js) const {

--- a/src/workerd/jsg/ser.c++
+++ b/src/workerd/jsg/ser.c++
@@ -4,7 +4,10 @@
 
 #include "ser.h"
 
+#include "dom-exception.h"
 #include "setup.h"
+
+#include <v8-proxy.h>
 
 namespace workerd::jsg {
 

--- a/src/workerd/jsg/ser.h
+++ b/src/workerd/jsg/ser.h
@@ -6,6 +6,8 @@
 
 #include <workerd/jsg/jsg.h>
 
+#include <v8-value-serializer.h>
+
 #include <kj/vector.h>
 
 namespace workerd::jsg {

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -14,6 +14,7 @@
 #include <workerd/util/uuid.h>
 
 #include <v8-cppgc.h>
+#include <v8-initialization.h>
 
 #if !_WIN32
 #include <cxxabi.h>

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -7,7 +7,6 @@
 
 #include "async-context.h"
 #include "jsg.h"
-#include "type-wrapper.h"
 #include "v8-platform-wrapper.h"
 
 #include <workerd/jsg/observer.h>
@@ -19,7 +18,12 @@
 #include <kj/mutex.h>
 #include <kj/vector.h>
 
+#include <typeindex>
+
 namespace workerd::jsg {
+
+class Deserializer;
+class Serializer;
 
 // Construct a default V8 platform, with the given background thread pool size.
 //
@@ -763,25 +767,5 @@ class Isolate: public IsolateBase {
   // GetAlignedPointerFromEmbedderData and just return wrappers[0].
   bool hasExtraWrappers = false;
 };
-
-// This macro helps cut down on template spam in error messages. Instead of instantiating Isolate
-// directly, do:
-//
-//     JSG_DECLARE_ISOLATE_TYPE(MyIsolate, SomeApiType, AnotherApiType, ...);
-//
-// `MyIsolate` becomes your custom Isolate type, which will support wrapping all of the listed
-// API types.
-#define JSG_DECLARE_ISOLATE_TYPE(Type, ...)                                                        \
-  class Type##_TypeWrapper;                                                                        \
-  typedef ::workerd::jsg::TypeWrapper<Type##_TypeWrapper, jsg::DOMException, ##__VA_ARGS__>        \
-      Type##_TypeWrapperBase;                                                                      \
-  class Type##_TypeWrapper final: public Type##_TypeWrapperBase {                                  \
-   public:                                                                                         \
-    using Type##_TypeWrapperBase::TypeWrapper;                                                     \
-  };                                                                                               \
-  class Type final: public ::workerd::jsg::Isolate<Type##_TypeWrapper> {                           \
-   public:                                                                                         \
-    using ::workerd::jsg::Isolate<Type##_TypeWrapper>::Isolate;                                    \
-  }
 
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/struct.h
+++ b/src/workerd/jsg/struct.h
@@ -8,9 +8,9 @@
 // Translates between C++ struct types and JavaScript objects. This translation is by value: the
 // struct is translated to/from a native JS object with the same field names.
 
-#include "util.h"
-#include "value.h"
-#include "web-idl.h"
+#include <workerd/jsg/util.h>
+#include <workerd/jsg/value.h>
+#include <workerd/jsg/web-idl.h>
 
 namespace workerd::jsg {
 

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+#include "dom-exception.h"
 #include "jsg.h"  // can't include util.h directly due to weird cyclic dependency...
 #include "ser.h"
 #include "setup.h"
@@ -18,7 +19,6 @@
 #endif
 
 #include <workerd/util/autogate.h>
-#include <workerd/util/sentry.h>
 
 namespace workerd::jsg {
 

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -7,9 +7,10 @@
 //
 // This file contains misc utility functions used elsewhere.
 
-#include <workerd/util/sentry.h>
-
-#include <v8.h>
+#include <v8-array-buffer.h>
+#include <v8-exception.h>
+#include <v8-primitive.h>
+#include <v8-promise.h>
 
 #include <kj/debug.h>
 #include <kj/exception.h>
@@ -17,6 +18,9 @@
 
 #include <typeinfo>
 
+namespace v8 {
+class Isolate;
+}
 namespace workerd::jsg {
 
 class Lock;

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -9,9 +9,13 @@
 // arrays, buffers, dicts.
 
 #include "simdutf.h"
-#include "util.h"
-#include "web-idl.h"
-#include "wrappable.h"
+
+#include <workerd/jsg/util.h>
+#include <workerd/jsg/web-idl.h>
+#include <workerd/jsg/wrappable.h>
+
+#include <v8-container.h>
+#include <v8-date.h>
 
 #include <kj/debug.h>
 #include <kj/one-of.h>

--- a/src/workerd/jsg/web-idl.h
+++ b/src/workerd/jsg/web-idl.h
@@ -7,7 +7,7 @@
 //
 // Type traits to help us map between C++ and Web IDL types/concepts.
 
-#include "jsg.h"
+#include <workerd/jsg/jsg.h>
 
 #include <kj/array.h>
 #include <kj/common.h>

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -10,7 +10,6 @@
 
 #include <v8-context.h>
 #include <v8-object.h>
-#include <v8-version.h>
 
 #include <kj/common.h>
 #include <kj/debug.h>


### PR DESCRIPTION
- Factor several files out of the main JSG target
- Significantly reduce header interdependencies/cycles
- Start splitting up uses of <v8.h> into constituent headers.

This will make future refactoring of JSG easier.