### PR TITLE
Python: Make new C++ function `getPackageSnapshotImports`

### DIFF
--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -257,14 +257,7 @@ function memorySnapshotDoImports(Module: Module): string[] {
   // The `importedModules` list will contain all modules that have been imported, including local
   // modules, the usual `js` and other stdlib modules. We want to filter out local imports, so we
   // grab them and put them into a set for fast filtering.
-  const importedModules: string[] =
-    ArtifactBundler.constructor.filterPythonScriptImportsJs(
-      MetadataReader.getNames('py'),
-      ArtifactBundler.constructor.parsePythonScriptImports(
-        MetadataReader.getWorkerFiles('py')
-      )
-    );
-
+  const importedModules: string[] = MetadataReader.getPackageSnapshotImports();
   const deduplicatedModules = [...new Set(importedModules)];
 
   // Import the modules list so they are included in the snapshot.

--- a/src/pyodide/types/artifacts.d.ts
+++ b/src/pyodide/types/artifacts.d.ts
@@ -1,11 +1,6 @@
 declare namespace ArtifactBundler {
   const constructor: {
     getSnapshotImports(): string[];
-    filterPythonScriptImportsJs(
-      fileNames: string[],
-      imports: string[]
-    ): string[];
-    parsePythonScriptImports(fileNames: string[]): string[];
   };
 
   type MemorySnapshotResult = {

--- a/src/pyodide/types/runtime-generated/metadata.d.ts
+++ b/src/pyodide/types/runtime-generated/metadata.d.ts
@@ -6,8 +6,8 @@ declare namespace MetadataReader {
   const getRequirements: () => string[];
   const getMainModule: () => string;
   const hasMemorySnapshot: () => boolean;
-  const getNames: (maybeExtFilter?: string) => string[];
-  const getWorkerFiles: (ext: string) => string[];
+  const getNames: () => string[];
+  const getPackageSnapshotImports: () => string[];
   const getSizes: () => number[];
   const readMemorySnapshot: (
     offset: number,

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -138,12 +138,17 @@ class PyodideMetadataReader: public jsg::Object {
 
   // Returns the filenames of the files inside of the WorkerBundle that end with the specified
   // file extension.
+  // TODO: Remove this.
   kj::Array<jsg::JsRef<jsg::JsString>> getNames(
       jsg::Lock& js, jsg::Optional<kj::String> maybeExtFilter);
 
   // Returns files inside the WorkerBundle that end with the specified file extension.
   // Usually called to get all the Python source files with a `py` extension.
+  // TODO: Remove this.
   kj::Array<jsg::JsRef<jsg::JsString>> getWorkerFiles(jsg::Lock& js, kj::String ext);
+
+  // Return the list of names to import into a package snapshot.
+  kj::Array<kj::String> getPackageSnapshotImports(jsg::Lock& js);
 
   kj::Array<jsg::JsRef<jsg::JsString>> getRequirements(jsg::Lock& js);
 
@@ -191,6 +196,7 @@ class PyodideMetadataReader: public jsg::Object {
     JSG_METHOD(getRequirements);
     JSG_METHOD(getNames);
     JSG_METHOD(getWorkerFiles);
+    JSG_METHOD(getPackageSnapshotImports);
     JSG_METHOD(getSizes);
     JSG_METHOD(read);
     JSG_METHOD(hasMemorySnapshot);
@@ -316,6 +322,7 @@ class ArtifactBundler: public jsg::Object {
   static kj::Array<kj::String> parsePythonScriptImports(kj::Array<kj::String> files);
   // Takes in a list of imported modules and filters them in such a way to avoid local imports and
   // redundant imports in the package snapshot list.
+  // TODO: Remove this
   static kj::Array<kj::String> filterPythonScriptImports(
       kj::HashSet<kj::String> workerModules, kj::ArrayPtr<kj::String> imports);
   static kj::Array<kj::String> filterPythonScriptImportsJs(


### PR DESCRIPTION
This simplifies our life when we have to adjust the logic for what goes into the package snapshots. For now leave the old functions to make it easier to migrate.