### PR TITLE
Implement importable env

### DIFF
--- a/src/cloudflare/internal/env.d.ts
+++ b/src/cloudflare/internal/env.d.ts
@@ -1,0 +1,3 @@
+// Get the current environment, if any
+export function getCurrent(): Record<string, unknown> | undefined;
+export function withEnv(newEnv: unknown, fn: () => unknown): unknown;

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -6,9 +6,86 @@
 //   wrapper module that simply re-exports the classes from the built-in module.
 
 import entrypoints from 'cloudflare-internal:workers';
+import innerEnv from 'cloudflare-internal:env';
 
 export const WorkerEntrypoint = entrypoints.WorkerEntrypoint;
 export const DurableObject = entrypoints.DurableObject;
 export const RpcStub = entrypoints.RpcStub;
 export const RpcTarget = entrypoints.RpcTarget;
 export const WorkflowEntrypoint = entrypoints.WorkflowEntrypoint;
+
+export function withEnv(newEnv: unknown, fn: () => unknown): unknown {
+  return innerEnv.withEnv(newEnv, fn);
+}
+
+// A proxy for the workers env/bindings. The proxy is io-context
+// aware in that it will only return values when there is an active
+// IoContext. Mutations to the env via this proxy propagate to the
+// underlying env and do not follow the async context.
+export const env = new Proxy(
+  {},
+  {
+    get(_: unknown, prop: string | symbol): unknown {
+      const inner = innerEnv.getCurrent();
+      if (inner) {
+        return Reflect.get(inner, prop);
+      }
+      return undefined;
+    },
+
+    set(_: unknown, prop: string | symbol, newValue: unknown): boolean {
+      const inner = innerEnv.getCurrent();
+      if (inner) {
+        return Reflect.set(inner, prop, newValue);
+      }
+      return true;
+    },
+
+    has(_: unknown, prop: string | symbol): boolean {
+      const inner = innerEnv.getCurrent();
+      if (inner) {
+        return Reflect.has(inner, prop);
+      }
+      return false;
+    },
+
+    ownKeys(_: unknown): ArrayLike<string | symbol> {
+      const inner = innerEnv.getCurrent();
+      if (inner) {
+        return Reflect.ownKeys(inner);
+      }
+      return [];
+    },
+
+    deleteProperty(_: unknown, prop: string | symbol): boolean {
+      const inner = innerEnv.getCurrent();
+      if (inner) {
+        return Reflect.deleteProperty(inner, prop);
+      }
+      return true;
+    },
+
+    defineProperty(
+      _: unknown,
+      prop: string | symbol,
+      attr: PropertyDescriptor
+    ): boolean {
+      const inner = innerEnv.getCurrent();
+      if (inner) {
+        return Reflect.defineProperty(inner, prop, attr);
+      }
+      return true;
+    },
+
+    getOwnPropertyDescriptor(
+      _: unknown,
+      prop: string | symbol
+    ): PropertyDescriptor | undefined {
+      const inner = innerEnv.getCurrent();
+      if (inner) {
+        return Reflect.getOwnPropertyDescriptor(inner, prop);
+      }
+      return undefined;
+    },
+  }
+);

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -19,6 +19,7 @@ filegroup(
             "pyodide/pyodide.c++",
             "pyodide/setup-emscripten.c++",
             "memory-cache.c++",
+            "modules.c++",
             "r2*.c++",
             "rtti.c++",
             "url.c++",
@@ -84,7 +85,10 @@ wd_cc_library(
 
 wd_cc_library(
     name = "rtti",
-    srcs = ["rtti.c++"],
+    srcs = [
+        "modules.c++",
+        "rtti.c++",
+    ],
     hdrs = [
         "modules.h",
         "rtti.h",
@@ -649,4 +653,16 @@ wd_test(
     src = "tests/fetch-test.wd-test",
     args = ["--experimental"],
     data = ["tests/fetch-test.js"],
+)
+
+wd_test(
+    src = "tests/importable-env-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/importable-env-test.js"],
+)
+
+wd_test(
+    src = "tests/disable-importable-env-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/disable-importable-env-test.js"],
 )

--- a/src/workerd/api/modules.c++
+++ b/src/workerd/api/modules.c++
@@ -1,0 +1,40 @@
+#include "modules.h"
+
+#include <workerd/jsg/jsg.h>
+#include <workerd/jsg/setup.h>
+
+namespace workerd::api {
+
+kj::Maybe<jsg::JsObject> EnvModule::getCurrent(jsg::Lock& js) {
+  auto& key = jsg::IsolateBase::from(js.v8Isolate).getEnvAsyncContextKey();
+  KJ_IF_SOME(frame, jsg::AsyncContextFrame::current(js)) {
+    KJ_IF_SOME(value, frame.get(key)) {
+      auto handle = value.getHandle(js);
+      if (handle->IsObject()) {
+        return jsg::JsObject(handle.As<v8::Object>());
+      }
+    }
+  }
+  // If the compat flag is set to disable importable env, then this
+  // will return nothing.
+  if (FeatureFlags::get(js).getDisableImportableEnv()) return kj::none;
+
+  // Otherwise, fallback to provide the stored environment.
+  return js.getWorkerEnv().map([&](const jsg::Value& val) -> jsg::JsObject {
+    auto handle = val.getHandle(js);
+    JSG_REQUIRE(handle->IsObject(), TypeError, "Expected environment to be an object.");
+    return jsg::JsObject(handle.As<v8::Object>());
+  });
+}
+
+jsg::JsRef<jsg::JsValue> EnvModule::withEnv(
+    jsg::Lock& js, jsg::Value newEnv, jsg::Function<jsg::JsRef<jsg::JsValue>()> fn) {
+  auto& key = jsg::IsolateBase::from(js.v8Isolate).getEnvAsyncContextKey();
+  jsg::AsyncContextFrame::StorageScope storage(js, key, kj::mv(newEnv));
+  return js.tryCatch([&]() mutable -> jsg::JsRef<jsg::JsValue> { return fn(js); },
+      [&](jsg::Value&& exception) mutable -> jsg::JsRef<jsg::JsValue> {
+    js.throwException(kj::mv(exception));
+  });
+}
+
+}  // namespace workerd::api

--- a/src/workerd/api/node/util.c++
+++ b/src/workerd/api/node/util.c++
@@ -242,7 +242,7 @@ jsg::JsValue UtilModule::getBuiltinModule(jsg::Lock& js, kj::String specifier) {
 }
 
 jsg::JsObject UtilModule::getEnvObject(jsg::Lock& js) {
-  return js.getEnv(true);
+  return js.getProcessEnv(true);
 }
 
 namespace {

--- a/src/workerd/api/tests/disable-importable-env-test.js
+++ b/src/workerd/api/tests/disable-importable-env-test.js
@@ -1,0 +1,25 @@
+import { env, withEnv } from 'cloudflare:workers';
+
+// This test runs with the disallow-importable-env flag set, meaning that
+// the env imported from cloudflare:workers exists but is not-populated
+// with the primary environment. Using withEnv, however, would still work.
+
+import { strictEqual, notDeepStrictEqual } from 'node:assert';
+
+strictEqual(env.FOO, undefined);
+
+export const test = {
+  async test(_, argEnv) {
+    strictEqual(env.FOO, undefined);
+    notDeepStrictEqual(argEnv, env);
+
+    // withEnv still works as expected tho
+    const { env: otherEnv2 } = await withEnv({ BAZ: 1 }, async () => {
+      await scheduler.wait(0);
+      return import('child');
+    });
+    strictEqual(otherEnv2.FOO, undefined);
+    strictEqual(otherEnv2.BAZ, 1);
+    strictEqual(argEnv.BAZ, undefined);
+  },
+};

--- a/src/workerd/api/tests/disable-importable-env-test.wd-test
+++ b/src/workerd/api/tests/disable-importable-env-test.wd-test
@@ -1,0 +1,22 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "disable-importable-env-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "disable-importable-env-test.js"),
+          (name = "child", esModule = "import {env as live} from 'cloudflare:workers'; export const env = {...live};"),
+        ],
+        compatibilityDate = "2025-02-01",
+        compatibilityFlags = [
+          "nodejs_compat_v2",
+          "disallow_importable_env",
+        ],
+        bindings = [
+          (name = "FOO", text = "BAR"),
+        ],
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/tests/importable-env-test.js
+++ b/src/workerd/api/tests/importable-env-test.js
@@ -1,0 +1,101 @@
+import {
+  strictEqual,
+  deepStrictEqual,
+  notStrictEqual,
+  ok,
+  rejects,
+} from 'node:assert';
+import { env, withEnv } from 'cloudflare:workers';
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+const check = new AsyncLocalStorage();
+
+// The env is populated at the top level scope.
+strictEqual(env.FOO, 'BAR');
+
+// Cache exists and is accessible.
+ok(env.CACHE);
+// But fails when used because we're not in an io-context
+await rejects(
+  env.CACHE.read('hello', async () => {}),
+  {
+    message: /Disallowed operation called within global scope./,
+  }
+);
+
+export const importableEnv = {
+  async test(_, argEnv) {
+    // Accessing the cache initially at the global scope didn't break anything
+    const cached = await argEnv.CACHE.read('hello', async () => {
+      return {
+        value: 123,
+        expiration: Date.now() + 10000,
+      };
+    });
+    strictEqual(cached, 123);
+
+    // They aren't the same objects...
+    notStrictEqual(env, argEnv);
+    // But have all the same stuff...
+    deepStrictEqual(env, argEnv);
+
+    // It is populated inside a request
+    strictEqual(env.FOO, 'BAR');
+
+    // And following async operations.
+    await scheduler.wait(10);
+    strictEqual(env.FOO, 'BAR');
+
+    // Mutations to the env carry through as expected...
+    env.BAR = 123;
+    const { env: otherEnv } = await import('child');
+    strictEqual(otherEnv.FOO, 'BAR');
+    strictEqual(otherEnv.BAR, 123);
+    deepStrictEqual(argEnv, otherEnv);
+
+    // Using withEnv to replace the env...
+    const { env: otherEnv2 } = await withEnv({ BAZ: 1 }, async () => {
+      await scheduler.wait(0);
+      return import('child2');
+    });
+    strictEqual(otherEnv2.FOO, undefined);
+    strictEqual(otherEnv2.BAZ, 1);
+
+    // Original env is unmodified
+    strictEqual(env.BAZ, undefined);
+
+    // Verify that JSRPC calls appropriately see the environment.
+    const remote = await argEnv.RPC.rpcTarget(undefined);
+    await Promise.all([remote.test(), remote.test2()]);
+  },
+
+  get fetch() {
+    // It's a weird edge case, yes, but let's make sure that the env is
+    // available in getters when extracting the default handlers.
+    strictEqual(env.FOO, 'BAR');
+    return async () => {};
+  },
+
+  // Verifies that the environment is available and correctly propagated
+  // in custom events like jsrpc.
+  rpcTarget() {
+    strictEqual(env.FOO, 'BAR');
+    return withEnv({ FOO: 'BAZ' }, () => {
+      // Arguably, returned RPC targets should probably automatically capture
+      // the current async context and propagate that on subsequent calls,
+      // but they currently do not... therefore we have to manually capture
+      // the async context and be sure to enter it ourselves below.
+      const runInAsyncContext = AsyncLocalStorage.snapshot();
+      return {
+        test() {
+          // This one runs with the modified env
+          runInAsyncContext(() => strictEqual(env.FOO, 'BAZ'));
+        },
+        test2() {
+          // This one runs with the original env
+          strictEqual(env.FOO, 'BAR');
+        },
+      };
+    });
+  },
+};

--- a/src/workerd/api/tests/importable-env-test.wd-test
+++ b/src/workerd/api/tests/importable-env-test.wd-test
@@ -1,0 +1,31 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "importable-env-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "importable-env-test.js"),
+          (name = "child", esModule = "import {env as live} from 'cloudflare:workers'; export const env = {...live};"),
+          (name = "child2", esModule = "import {env as live} from 'cloudflare:workers'; export const env = {...live};"),
+        ],
+        compatibilityDate = "2025-02-01",
+        compatibilityFlags = [
+          "nodejs_compat_v2",
+        ],
+        bindings = [
+          (name = "RPC", service = ( name = "importable-env-test", entrypoint="importableEnv")),
+          (name = "FOO", text = "BAR"),
+          (name = "CACHE", memoryCache = (
+            id = "abc123",
+            limits = (
+              maxKeys = 10,
+              maxValueSize = 1024,
+              maxTotalValueSize = 1024,
+            ),
+          ))
+        ],
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -727,4 +727,10 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $experimental
       $neededByFl;
   # Enables cache settings specified request in cache api cf object to override cache rules. (only for user owned or grey-clouded sites)
+
+  disableImportableEnv @78 :Bool
+      $compatEnableFlag("disallow_importable_env")
+      $compatDisableFlag("allow_importable_env");
+  # When allowed, `import { env } from 'cloudflare:workers'` will provide access
+  # to the per-request environment/bindings.
 }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -19,6 +19,7 @@
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/modules-new.h>
 #include <workerd/jsg/script.h>
+#include <workerd/jsg/setup.h>
 #include <workerd/jsg/util.h>
 #include <workerd/util/batch-queue.h>
 #include <workerd/util/color-util.h>
@@ -1626,6 +1627,9 @@ Worker::Worker(kj::Own<const Script> scriptParam,
             if (script->isModular()) {
               // Use `env` variable.
               bindingsScope = v8::Object::New(lock.v8Isolate);
+              if (!FeatureFlags::get(js).getDisableImportableEnv()) {
+                lock.setWorkerEnv(lock.v8Ref(bindingsScope.As<v8::Value>()));
+              }
             } else {
               // Use global-scope bindings.
               bindingsScope = context->Global();

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2707,10 +2707,16 @@ class Lock {
 
   // Sets an env value that will be expressed on the process.env
   // if/when nodejs-compat mode is used.
-  virtual void setEnvField(const JsValue& name, const JsValue& value) = 0;
+  virtual void setProcessEnvField(const JsValue& name, const JsValue& value) = 0;
 
-  // Returns the env base object.
-  virtual JsObject getEnv(bool release = false) = 0;
+  // Returns the process.env base object.
+  virtual JsObject getProcessEnv(bool release = false) = 0;
+
+  // Store the worker environment.
+  virtual void setWorkerEnv(Value value) = 0;
+
+  // Retrieve the worker environment.
+  virtual kj::Maybe<Value> getWorkerEnv() = 0;
 
  private:
   // Mark the jsg::Lock as being disallowed from being passed as a parameter into

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -338,6 +338,7 @@ IsolateBase::IsolateBase(const V8System& system,
 #else
       ptr(newIsolate(kj::mv(createParams), cppHeap.get())),
 #endif
+      envAsyncContextKey(kj::refcounted<AsyncContextFrame::StorageKey>()),
       heapTracer(ptr),
       observer(kj::mv(observer)) {
   jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
@@ -433,6 +434,7 @@ void IsolateBase::dropWrappers(kj::FunctionParam<void()> drop) {
     KJ_DEFER(symbolAsyncDispose.Reset());
     KJ_DEFER(opaqueTemplate.Reset());
     KJ_DEFER(envObj.Reset());
+    KJ_DEFER(workerEnvObj.Reset());
 
     // Make sure the TypeWrapper is destroyed under lock by declaring a new copy of the variable
     // that is destroyed before the lock is released.

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -116,6 +116,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
     EW_WEBGPU_ISOLATE_TYPES,
 #endif
+    workerd::api::EnvModule,
 
     jsg::TypeWrapperExtension<PromiseWrapper>,
     jsg::InjectConfiguration<CompatibilityFlags::Reader>,
@@ -705,9 +706,9 @@ static v8::Local<v8::Value> createBindingValue(JsgWorkerdIsolate::Lock& lock,
         // parsed in one context (env) and unparsed in another (process.env).
 
         if (value->IsString()) {
-          lock.setEnvField(lock.str(global.name), jsg::JsValue(value));
+          lock.setProcessEnvField(lock.str(global.name), jsg::JsValue(value));
         } else {
-          lock.setEnvField(lock.str(global.name), lock.str(json.text));
+          lock.setProcessEnvField(lock.str(global.name), lock.str(json.text));
         }
       }
     }
@@ -796,7 +797,7 @@ static v8::Local<v8::Value> createBindingValue(JsgWorkerdIsolate::Lock& lock,
     KJ_CASE_ONEOF(text, kj::String) {
       value = lock.wrap(context, kj::mv(text));
       if (featureFlags.getPopulateProcessEnv() && featureFlags.getNodeJsCompat()) {
-        lock.setEnvField(lock.str(global.name), jsg::JsValue(value));
+        lock.setProcessEnvField(lock.str(global.name), jsg::JsValue(value));
       }
     }
 


### PR DESCRIPTION
PR marked as a draft until we're certain this is what we want....

```js
import { env } from 'cloudflare:workers';

console.log(env.FOO);  // Undefined, outside request io context

export default {
  fetch(req) {
    console.log(env.FOO);  // 'BAR', inside request io context
    // ...
  }
}
```

~~Gated by a compat flag that is off by default~~ The flag is now on by default.

  * `allow_importable_env`
  * `disallow_importable_env`

Mutations of the env properties are passed through to the underlying object so will be reflected on the `env` argument passed into the handlers.

Note that this is *not* directly tied to `process.env`... this exposes the regular `env`/`bindings` via the import when accessed within the context of a request. As such, any modules used by your worker can access the bindings without having them explicitly passed down. The `process.env` is populated from the same original source but mutations on `process.env` will not be reflected on the importable `env` and vis versa. At least for the time being.