### PR TITLE
fix(types/defines/ai.d.ts): correct the type of the `segments` property to be an array

### DIFF
--- a/types/defines/ai.d.ts
+++ b/types/defines/ai.d.ts
@@ -430,7 +430,7 @@ export interface Ai_Cf_Openai_Whisper_Large_V3_Turbo_Output {
        */
       end?: number;
     }[];
-  };
+  }[];
   /**
    * The transcription in WebVTT format, which includes timing and text information for use in subtitles.
    */


### PR DESCRIPTION
Correct the incorrect type of Output in “@cf/openai/whisper-large-v3-turbo”.
I think segments is array.