### PR TITLE
[build] Roll select dependencies, enable use_plus_in_repo_names

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,6 +13,10 @@ build --test_timeout=1,15,60,240
 # Not using bzlmod for dependencies yet
 common --noenable_bzlmod
 
+# Use plus in repo names for Bazel 7 as long as it's used to address some resolution issues
+# Bazel 8 brings this behavior by default and this line can be removed after Bazel upgrade.
+common --incompatible_use_plus_in_repo_names
+
 # bazel7 enables Build without the Bytes (BwoB) by default. This significantly speeds up builds
 # using the remote cache since less data needs to be fetched. Set remote_cache_eviction_retries
 # which is required to fully support a "dumb" cache. Bazel 8 already sets this value by default.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To build `workerd`, you need:
   * LLD 16+ (e.g. package `lld-16`).
   * `python3`, `python3-distutils`, and `tcl8.6`
 * On macOS:
-  * Xcode 16 installation (available on macOS 14 and higher). **Full Xcode is required**, the Xcode command line tools alone are **not sufficient** for building.
+  * Xcode 16 installation (available on macOS 14 and higher). Building with just the Xcode Command Line Tools is not being tested, but should work too.
   * Homebrew installed `tcl-tk` package (provides Tcl 8.6)
 * On Windows:
   * Install [App Installer](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -212,7 +212,7 @@ rust_register_toolchains(
         # Add support for macOS rosetta
         "aarch64-unknown-linux-gnu",
     ],
-    versions = ["1.83.0"],  # LLVM 19
+    versions = ["1.84.0"],  # LLVM 19
 )
 
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")

--- a/build/deps/gen/dep_ada_url.bzl
+++ b/build/deps/gen/dep_ada_url.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "v3.1.0"
-URL = "https://github.com/ada-url/ada/releases/download/v3.1.0/singleheader.zip"
+TAG_NAME = "v3.1.3"
+URL = "https://github.com/ada-url/ada/releases/download/v3.1.3/singleheader.zip"
 STRIP_PREFIX = ""
-SHA256 = "54de2c093a94ab0b6ffc3c16d01a89ef7cacbd743f08b5fa63fd06b8684efbd6"
+SHA256 = "2a15aa5b032e5dabdf648aa35fd4aa466d2cba0854aff5ffec7496d2d407800a"
 TYPE = "zip"
 
 def dep_ada_url():

--- a/build/deps/gen/dep_aspect_rules_js.bzl
+++ b/build/deps/gen/dep_aspect_rules_js.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "v2.1.3"
-URL = "https://github.com/aspect-build/rules_js/releases/download/v2.1.3/rules_js-v2.1.3.tar.gz"
-STRIP_PREFIX = "rules_js-2.1.3"
-SHA256 = "875b8d01af629dbf626eddc5cf239c9f0da20330f4d99ad956afc961096448dd"
+TAG_NAME = "v2.2.0"
+URL = "https://github.com/aspect-build/rules_js/releases/download/v2.2.0/rules_js-v2.2.0.tar.gz"
+STRIP_PREFIX = "rules_js-2.2.0"
+SHA256 = "d66f8abf914a0454a69181b7b17acaae56d7b0e2784cb26b40cb3273c4d836d1"
 TYPE = "tgz"
 
 def dep_aspect_rules_js():

--- a/build/deps/gen/dep_build_bazel_apple_support.bzl
+++ b/build/deps/gen/dep_build_bazel_apple_support.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "1.17.1"
-URL = "https://api.github.com/repos/bazelbuild/apple_support/tarball/1.17.1"
-STRIP_PREFIX = "bazelbuild-apple_support-8ee7a2d"
-SHA256 = "75112edeece57fedeef88bce87e28e4a30cc29f0892053532f29f57cf62709a1"
+TAG_NAME = "1.19.0"
+URL = "https://api.github.com/repos/bazelbuild/apple_support/tarball/1.19.0"
+STRIP_PREFIX = "bazelbuild-apple_support-92cef2e"
+SHA256 = "fcbb1eae4ffbe32df629e0bba33dc8fa97222974d55c54d8f2d809abba73cb46"
 TYPE = "tgz"
 
 def dep_build_bazel_apple_support():

--- a/build/deps/gen/dep_capnp_cpp.bzl
+++ b/build/deps/gen/dep_capnp_cpp.bzl
@@ -2,11 +2,11 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-URL = "https://github.com/capnproto/capnproto/tarball/3497c484729231105a08a5703b8b7297d090732d"
-STRIP_PREFIX = "capnproto-capnproto-3497c48/c++"
-SHA256 = "7056f4ebf3d3f3d73e56c6f75e7c6da05bc4b220e1997ca4384475ece942f448"
+URL = "https://github.com/capnproto/capnproto/tarball/20af9fe2de10a2e7f621a212351d20860cc32a0d"
+STRIP_PREFIX = "capnproto-capnproto-20af9fe/c++"
+SHA256 = "96cfddf676babe345bf321ccfaabb855dfe7dc127e69c4fdd959abd52de47721"
 TYPE = "tgz"
-COMMIT = "3497c484729231105a08a5703b8b7297d090732d"
+COMMIT = "20af9fe2de10a2e7f621a212351d20860cc32a0d"
 
 def dep_capnp_cpp():
     http_archive(

--- a/build/deps/gen/dep_simdutf.bzl
+++ b/build/deps/gen/dep_simdutf.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "v6.0.3"
-URL = "https://github.com/simdutf/simdutf/releases/download/v6.0.3/singleheader.zip"
+TAG_NAME = "v6.2.0"
+URL = "https://github.com/simdutf/simdutf/releases/download/v6.2.0/singleheader.zip"
 STRIP_PREFIX = ""
-SHA256 = "0e5ba4bc981633bb024ee066833f733b7d3422bc6250f6a6b5bbc09121b782af"
+SHA256 = "66c85f591133e3baa23cc441d6e2400dd2c94c4902820734ddbcd9e04dd3988b"
 TYPE = "zip"
 
 def dep_simdutf():


### PR DESCRIPTION
- With the new apple_support version including https://github.com/bazelbuild/apple_support/pull/354, macOS builds should be able to build with just the Xcode Command Line Tools, although CI uses full Xcode so this is not tested. Numerous folks ran into issues with this, hopefully this will make it easier for people to get started with workerd.
- Enable `use_plus_in_repo_names` for common options, ported from #3492 by @ujohnny where Windows CI was somehow failing perpetually by cherry-picking the commit.