### PR TITLE
fix(bot): detectionIds default json

### DIFF
--- a/src/workerd/api/cf-property.c++
+++ b/src/workerd/api/cf-property.c++
@@ -13,7 +13,7 @@ static constexpr kj::StringPtr kDefaultBotManagementValue = R"DATA({
   "verifiedBot": false,
   "jsDetection": { "passed": false },
   "staticResource": false,
-  "detectionIds": {},
+  "detectionIds": [],
   "score": 99
 })DATA"_kjc;
 


### PR DESCRIPTION
## What

This aims to resolve a runtime discrepancy in `botManagement.detectionIds`.

## Why

We're observing two different runtime types `{}` and `number[]`, but expect only `number[]` based on [HTTP Requests Docs](https://developers.cloudflare.com/logs/reference/log-fields/zone/http_requests/#botdetectionids) — `array[int]` — as well as the [TypeScript types](https://github.com/cloudflare/workerd/blob/main/types/generated-snapshot/oldest/index.ts#L4810)

---

CloudFlare dashboard logs
| own `cURL` request | non bot traffic  |
|--------|--------|
| ![CleanShot 2025-02-28 at 09 58 22@2x](https://github.com/user-attachments/assets/164b72fd-8519-469c-9635-58ccc31aeaca) | ![](https://github.com/user-attachments/assets/2ba5b6f1-66f4-4345-bad6-8526eaf0eafb) |

