### PR TITLE
Make Python package vendoring work

### DIFF
--- a/src/workerd/api/pyodide/pyodide-test.c++
+++ b/src/workerd/api/pyodide/pyodide-test.c++
@@ -13,7 +13,7 @@ KJ_TEST("basic `import` tests") {
   auto files = kj::heapArrayBuilder<kj::String>(2);
   files.add(kj::str("import a\nimport z"));
   files.add(kj::str("import b"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 3);
   KJ_REQUIRE(result[0] == "a");
   KJ_REQUIRE(result[1] == "z");
@@ -23,7 +23,7 @@ KJ_TEST("basic `import` tests") {
 KJ_TEST("supports whitespace") {
   auto files = kj::heapArrayBuilder<kj::String>(1);
   files.add(kj::str("import      a\nimport    \n\tz"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 2);
   KJ_REQUIRE(result[0] == "a");
   KJ_REQUIRE(result[1] == "z");
@@ -32,7 +32,7 @@ KJ_TEST("supports whitespace") {
 KJ_TEST("supports windows newlines") {
   auto files = kj::heapArrayBuilder<kj::String>(1);
   files.add(kj::str("import      a\r\nimport    \r\n\tz"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 2);
   KJ_REQUIRE(result[0] == "a");
   KJ_REQUIRE(result[1] == "z");
@@ -41,7 +41,7 @@ KJ_TEST("supports windows newlines") {
 KJ_TEST("basic `from` test") {
   auto files = kj::heapArrayBuilder<kj::String>(1);
   files.add(kj::str("from x import a,b\nfrom z import y"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 2);
   KJ_REQUIRE(result[0] == "x");
   KJ_REQUIRE(result[1] == "z");
@@ -50,7 +50,7 @@ KJ_TEST("basic `from` test") {
 KJ_TEST("ignores indented blocks") {
   auto files = kj::heapArrayBuilder<kj::String>(1);
   files.add(kj::str("import a\nif True:\n  import x\nimport y"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 2);
   KJ_REQUIRE(result[0] == "a");
   KJ_REQUIRE(result[1] == "y");
@@ -59,7 +59,7 @@ KJ_TEST("ignores indented blocks") {
 KJ_TEST("supports nested imports") {
   auto files = kj::heapArrayBuilder<kj::String>(1);
   files.add(kj::str("import a.b\nimport z.x.y.i"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 2);
   KJ_REQUIRE(result[0] == "a.b");
   KJ_REQUIRE(result[1] == "z.x.y.i");
@@ -68,7 +68,7 @@ KJ_TEST("supports nested imports") {
 KJ_TEST("nested `from` test") {
   auto files = kj::heapArrayBuilder<kj::String>(1);
   files.add(kj::str("from x.y.z import a,b\nfrom z import y"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 2);
   KJ_REQUIRE(result[0] == "x.y.z");
   KJ_REQUIRE(result[1] == "z");
@@ -77,7 +77,7 @@ KJ_TEST("nested `from` test") {
 KJ_TEST("ignores trailing period") {
   auto files = kj::heapArrayBuilder<kj::String>(1);
   files.add(kj::str("import a.b.\nimport z.x.y.i."));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 0);
 }
 
@@ -86,14 +86,14 @@ KJ_TEST("ignores relative import") {
   // input below.
   auto files = kj::heapArrayBuilder<kj::String>(1);
   files.add(kj::str("import .a.b\nimport ..z.x\nfrom .y import x"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 0);
 }
 
 KJ_TEST("supports commas") {
   auto files = kj::heapArrayBuilder<kj::String>(1);
   files.add(kj::str("import a,b"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 2);
   KJ_REQUIRE(result[0] == "a");
   KJ_REQUIRE(result[1] == "b");
@@ -105,7 +105,7 @@ KJ_TEST("supports backslash") {
   files.add(kj::str("import\\\n q,w"));
   files.add(kj::str("from \\\nx import y"));
   files.add(kj::str("from \\\n   c import y"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 6);
   KJ_REQUIRE(result[0] == "a");
   KJ_REQUIRE(result[1] == "b");
@@ -135,7 +135,7 @@ import b \
   files.add(kj::str("FOO=\"\"\"  \n", R"SCRIPT(import x
 from y import z
 """)SCRIPT"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 0);
 }
 
@@ -151,7 +151,7 @@ BAR="""
 import e
 """
 from t import u)SCRIPT"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 2);
   KJ_REQUIRE(result[0] == "w");
   KJ_REQUIRE(result[1] == "t");
@@ -161,7 +161,7 @@ KJ_TEST("import after string literal") {
   auto files = kj::heapArrayBuilder<kj::String>(1);
   files.add(kj::str(R"SCRIPT(import a
 "import b)SCRIPT"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 1);
   KJ_REQUIRE(result[0] == "a");
 }
@@ -170,7 +170,7 @@ KJ_TEST("import after `i`") {
   auto files = kj::heapArrayBuilder<kj::String>(1);
   files.add(kj::str(R"SCRIPT(import a
 iimport b)SCRIPT"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 1);
   KJ_REQUIRE(result[0] == "a");
 }
@@ -180,7 +180,7 @@ KJ_TEST("langchain import") {
   files.add(kj::str(R"SCRIPT(from js import Response, console, URL
 from langchain.chat_models import ChatOpenAI
 import openai)SCRIPT"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 3);
   KJ_REQUIRE(result[0] == "js");
   KJ_REQUIRE(result[1] == "langchain.chat_models");
@@ -192,11 +192,12 @@ KJ_TEST("quote in multiline string") {
   files.add(kj::str(R"SCRIPT(temp = """
 w["h
 """)SCRIPT"));
-  auto result = pyodide::ArtifactBundler::parsePythonScriptImports(files.finish());
+  auto result = pyodide::PythonModuleInfo::parsePythonScriptImports(files.finish());
   KJ_REQUIRE(result.size() == 0);
 }
 
 using pyodide::ArtifactBundler;
+using pyodide::PythonModuleInfo;
 
 template <typename... Params>
 kj::Array<kj::String> strArray(Params&&... params) {
@@ -208,9 +209,19 @@ kj::Array<kj::Array<kj::byte>> bytesArray(Params&&... params) {
   return kj::arr(kj::heapArray<kj::byte>(kj::str(params).asBytes())...);
 }
 
+template <typename... Params>
+kj::HashSet<kj::String> strSet(Params&&... params) {
+  auto array = strArray(params...);
+  kj::HashSet<kj::String> set;
+  for (auto& str: array) {
+    set.insert(kj::mv(str));
+  }
+  return set;
+}
+
 KJ_TEST("Simple pass through") {
   auto imports = strArray("b", "c");
-  auto result = ArtifactBundler::filterPythonScriptImportsJs({}, kj::mv(imports));
+  auto result = PythonModuleInfo::filterPythonScriptImports({}, kj::mv(imports));
   KJ_REQUIRE(result.size() == 2);
   KJ_REQUIRE(result[0] == "b");
   KJ_REQUIRE(result[1] == "c");
@@ -218,47 +229,44 @@ KJ_TEST("Simple pass through") {
 
 KJ_TEST("pyodide and submodules") {
   auto imports = strArray("pyodide", "pyodide.ffi");
-  auto result = ArtifactBundler::filterPythonScriptImportsJs({}, kj::mv(imports));
+  auto result = PythonModuleInfo::filterPythonScriptImports({}, kj::mv(imports));
   KJ_REQUIRE(result.size() == 0);
 }
 
 KJ_TEST("js and submodules") {
   auto imports = strArray("js", "js.crypto");
-  auto result = ArtifactBundler::filterPythonScriptImportsJs({}, kj::mv(imports));
+  auto result = PythonModuleInfo::filterPythonScriptImports({}, kj::mv(imports));
   KJ_REQUIRE(result.size() == 0);
 }
 
 KJ_TEST("importlib and submodules") {
   // importlib and importlib.metadata are imported into the baseline snapshot, but importlib.resources is not.
   auto imports = strArray("importlib", "importlib.metadata", "importlib.resources");
-  auto result = ArtifactBundler::filterPythonScriptImportsJs({}, kj::mv(imports));
+  auto result = PythonModuleInfo::filterPythonScriptImports({}, kj::mv(imports));
   KJ_REQUIRE(result.size() == 1);
   KJ_REQUIRE(result[0] == "importlib.resources");
 }
 
 KJ_TEST("Filter worker .py files") {
-  auto workerModules = strArray("b.py", "c.py");
+  auto workerModules = strSet("b.py", "c.py");
   auto imports = strArray("b", "c", "d");
-  auto result =
-      ArtifactBundler::filterPythonScriptImportsJs(kj::mv(workerModules), kj::mv(imports));
+  auto result = PythonModuleInfo::filterPythonScriptImports(kj::mv(workerModules), kj::mv(imports));
   KJ_REQUIRE(result.size() == 1);
   KJ_REQUIRE(result[0] == "d");
 }
 
 KJ_TEST("Filter worker module/__init__.py") {
-  auto workerModules = strArray("a/__init__.py", "b/__init__.py", "c/a.py");
+  auto workerModules = strSet("a/__init__.py", "b/__init__.py", "c/a.py");
   auto imports = strArray("a", "b", "c");
-  auto result =
-      ArtifactBundler::filterPythonScriptImportsJs(kj::mv(workerModules), kj::mv(imports));
+  auto result = PythonModuleInfo::filterPythonScriptImports(kj::mv(workerModules), kj::mv(imports));
   KJ_REQUIRE(result.size() == 1);
   KJ_REQUIRE(result[0] == "c");
 }
 
 KJ_TEST("Filters out subdir/submodule") {
-  auto workerModules = strArray("subdir/submodule.py");
+  auto workerModules = strSet("subdir/submodule.py");
   auto imports = strArray("subdir.submodule");
-  auto result =
-      ArtifactBundler::filterPythonScriptImportsJs(kj::mv(workerModules), kj::mv(imports));
+  auto result = PythonModuleInfo::filterPythonScriptImports(kj::mv(workerModules), kj::mv(imports));
   KJ_REQUIRE(result.size() == 0);
 }
 

--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -93,22 +93,38 @@ kj::Array<kj::String> PythonModuleInfo::getPythonFileContents() {
   return builder.releaseAsArray();
 }
 
-kj::HashSet<kj::String> PythonModuleInfo::getPythonFileNamesSet() {
+kj::HashSet<kj::String> PythonModuleInfo::getWorkerModuleSet() {
   auto result = kj::HashSet<kj::String>();
-  for (auto& name: names) {
-    if (!name.endsWith(".py")) {
+  const auto vendor = "vendor/"_kj;
+  const auto dotPy = ".py"_kj;
+  const auto dotSo = ".so"_kj;
+  for (auto& item: names) {
+    kj::StringPtr name = item;
+    if (name.startsWith(vendor)) {
+      name = name.slice(vendor.size());
+    }
+    auto firstSlash = name.findFirst('/');
+    KJ_IF_SOME(idx, firstSlash) {
+      result.insert(kj::str(name.slice(0, idx)));
       continue;
     }
-    result.insert(kj::str(name));
+    if (name.endsWith(dotPy)) {
+      result.insert(kj::str(name.slice(0, name.size() - dotPy.size())));
+      continue;
+    }
+    if (name.endsWith(dotSo)) {
+      result.insert(kj::str(name.slice(0, name.size() - dotSo.size())));
+      continue;
+    }
   }
   return result;
 }
 
 kj::Array<kj::String> PythonModuleInfo::getPackageSnapshotImports() {
   auto workerFiles = this->getPythonFileContents();
-  auto imports = parsePythonScriptImports(kj::mv(workerFiles));
-  auto names = getPythonFileNamesSet();
-  return PythonModuleInfo::filterPythonScriptImports(kj::mv(names), kj::mv(imports));
+  auto importedNames = parsePythonScriptImports(kj::mv(workerFiles));
+  auto workerModules = getWorkerModuleSet();
+  return PythonModuleInfo::filterPythonScriptImports(kj::mv(workerModules), kj::mv(importedNames));
 }
 
 kj::Array<kj::String> PyodideMetadataReader::getPackageSnapshotImports() {
@@ -384,34 +400,6 @@ kj::Array<kj::StringPtr> ArtifactBundler::getSnapshotImports() {
   return kj::heapArray(snapshotImports.begin(), snapshotImports.size());
 }
 
-// This is equivalent to `pkgImport.replace('.', '/') + ".py"`.
-kj::String importToModuleFilename(kj::StringPtr pkgImport) {
-  auto result = kj::heapString(pkgImport.size() + 3);
-  for (auto i = 0; i < pkgImport.size(); i++) {
-    if (pkgImport[i] == '.') {
-      result[i] = '/';
-    } else {
-      result[i] = pkgImport[i];
-    }
-  }
-
-  result[pkgImport.size()] = '.';
-  result[pkgImport.size() + 1] = 'p';
-  result[pkgImport.size() + 2] = 'y';
-  return result;
-}
-
-bool isWorkerModuleImport(kj::HashSet<kj::String>& workerModules,
-    kj::ArrayPtr<const char> firstComponent,
-    kj::StringPtr pkgImport) {
-  // TODO: handling for:
-  // 1. namespace packages
-  // 2. shared libraries
-  return workerModules.contains(kj::str(firstComponent, ".py")) ||
-      workerModules.contains(kj::str(firstComponent, "/__init__.py")) ||
-      workerModules.contains(importToModuleFilename(pkgImport));
-}
-
 kj::Array<kj::String> PythonModuleInfo::filterPythonScriptImports(
     kj::HashSet<kj::String> workerModules, kj::ArrayPtr<kj::String> imports) {
   auto baselineSnapshotImportsSet = kj::HashSet<kj::StringPtr>();
@@ -440,7 +428,7 @@ kj::Array<kj::String> PythonModuleInfo::filterPythonScriptImports(
     }
 
     // Don't include imports from worker files
-    if (isWorkerModuleImport(workerModules, firstComponent, pkgImport)) {
+    if (workerModules.contains(firstComponent)) {
       continue;
     }
     filteredImportsSet.insert(kj::mv(pkgImport));

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -92,7 +92,7 @@ class PythonModuleInfo {
   //
   // Package relative imports are ignored.
   static kj::Array<kj::String> parsePythonScriptImports(kj::Array<kj::String> files);
-  kj::HashSet<kj::String> getPythonFileNamesSet();
+  kj::HashSet<kj::String> getWorkerModuleSet();
   kj::Array<kj::String> getPythonFileContents();
   static kj::Array<kj::String> filterPythonScriptImports(
       kj::HashSet<kj::String> workerModules, kj::ArrayPtr<kj::String> imports);

--- a/src/workerd/server/tests/python/vendor_dir/vendor_dir.wd-test
+++ b/src/workerd/server/tests/python/vendor_dir/vendor_dir.wd-test
@@ -6,7 +6,8 @@ const unitTests :Workerd.Config = (
       worker = (
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py"),
-          (name = "vendor/a.py", pythonModule = embed "vendor/a.py")
+          (name = "vendor/a.py", pythonModule = embed "vendor/a.py"),
+          (name = "numpy", pythonRequirement = "")
         ],
         compatibilityDate = "2024-01-15",
         compatibilityFlags = [%PYTHON_FEATURE_FLAGS],

--- a/src/workerd/server/tests/python/vendor_dir/worker.py
+++ b/src/workerd/server/tests/python/vendor_dir/worker.py
@@ -1,4 +1,5 @@
-def test():
-    from a import A
+from a import A
 
+
+def test():
     assert A == 77


### PR DESCRIPTION
* Python: Clean up pyodide.h a bit
This removes the no longer used APIs and moves more functions to PythonModuleInfo.

* Python: Update getPackageSnapshotImports() to handle vendor directory
This adds vendor directory handling to `getPackageSnapshotImports()` and so makes package vendoring work correctly.