### PR TITLE
Implement node:crypto cipher/decipher

### DIFF
--- a/src/node/crypto.ts
+++ b/src/node/crypto.ts
@@ -56,6 +56,17 @@ import {
   Verify,
 } from 'node-internal:crypto_sign';
 
+import {
+  Cipheriv,
+  Decipheriv,
+  createCipheriv,
+  createDecipheriv,
+  publicDecrypt,
+  publicEncrypt,
+  privateDecrypt,
+  privateEncrypt,
+} from 'node-internal:crypto_cipher';
+
 import { hkdf, hkdfSync } from 'node-internal:crypto_hkdf';
 
 import { pbkdf2, pbkdf2Sync, ArrayLike } from 'node-internal:crypto_pbkdf2';
@@ -141,6 +152,15 @@ export {
   verify,
   Sign,
   Verify,
+  // Cipher/Decipher
+  Cipheriv,
+  Decipheriv,
+  createCipheriv,
+  createDecipheriv,
+  publicDecrypt,
+  publicEncrypt,
+  privateDecrypt,
+  privateEncrypt,
 };
 
 export function getCiphers(): string[] {
@@ -268,6 +288,15 @@ export default {
   verify,
   Sign,
   Verify,
+  // Cipher/Decipher
+  Cipheriv,
+  Decipheriv,
+  createCipheriv,
+  createDecipheriv,
+  publicDecrypt,
+  publicEncrypt,
+  privateDecrypt,
+  privateEncrypt,
 };
 
 // Classes

--- a/src/node/internal/crypto.d.ts
+++ b/src/node/internal/crypto.d.ts
@@ -106,6 +106,52 @@ export function verifyOneShot(
   dsaSigEnc?: number
 ): boolean;
 
+export class CipherHandle {
+  public constructor(
+    mode: 'cipher' | 'decipher',
+    algorithm: string,
+    key: CryptoKey,
+    iv: ArrayBuffer | ArrayBufferView,
+    authTagLength?: number
+  );
+  public update(data: ArrayBuffer | ArrayBufferView): ArrayBuffer;
+  public final(): ArrayBuffer;
+  public setAAD(
+    data: ArrayBuffer | ArrayBufferView,
+    plaintextLength?: number
+  ): void;
+  public setAutoPadding(autoPadding: boolean): void;
+  public getAuthTag(): ArrayBuffer | undefined;
+  public setAuthTag(tag: ArrayBuffer | ArrayBufferView): void;
+}
+
+export interface PublicPrivateCipherOptions {
+  padding: number;
+  oaepHash: string;
+  oaepLabel: ArrayBuffer | ArrayBufferView | undefined;
+}
+
+export function publicEncrypt(
+  key: CryptoKey,
+  buffer: ArrayBuffer | ArrayBufferView,
+  options: PublicPrivateCipherOptions
+): Buffer;
+export function publicDecrypt(
+  key: CryptoKey,
+  buffer: ArrayBuffer | ArrayBufferView,
+  options: PublicPrivateCipherOptions
+): Buffer;
+export function privateEncrypt(
+  key: CryptoKey,
+  buffer: ArrayBuffer | ArrayBufferView,
+  options: PublicPrivateCipherOptions
+): Buffer;
+export function privateDecrypt(
+  key: CryptoKey,
+  buffer: ArrayBuffer | ArrayBufferView,
+  options: PublicPrivateCipherOptions
+): Buffer;
+
 export type ArrayLike = ArrayBuffer | string | Buffer | ArrayBufferView;
 
 export class HmacHandle {

--- a/src/node/internal/crypto_cipher.ts
+++ b/src/node/internal/crypto_cipher.ts
@@ -1,0 +1,691 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import {
+  default as cryptoImpl,
+  PublicPrivateCipherOptions,
+  type CipherHandle,
+} from 'node-internal:crypto';
+
+import {
+  Transform,
+  TransformOptions,
+  TransformCallback,
+} from 'node-internal:streams_transform';
+
+import {
+  type KeyObject,
+  createSecretKey,
+  createPublicKey,
+  createPrivateKey,
+  isKeyObject,
+  getKeyObjectHandle,
+} from 'node-internal:crypto_keys';
+
+import {
+  validateNumber,
+  validateObject,
+  validateString,
+  validateUint32,
+} from 'node-internal:validators';
+
+import {
+  ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE,
+  ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_ARG_VALUE,
+  ERR_MISSING_ARGS,
+} from 'node-internal:internal_errors';
+
+import {
+  isAnyArrayBuffer,
+  isArrayBufferView,
+} from 'node-internal:internal_types';
+
+import {
+  type KeyData,
+  type CreateAsymmetricKeyOptions,
+} from 'node-internal:crypto';
+
+import { Buffer } from 'node-internal:internal_buffer';
+
+export interface AADOptions {
+  plaintextLength?: number;
+  encoding?: string;
+}
+
+const kHandle = Symbol('kHandle');
+
+export interface Cipheriv extends Transform {
+  [kHandle]: CipherHandle;
+  update(
+    data: string | ArrayBuffer | ArrayBufferView,
+    inputEncoding?: string,
+    outputEncoding?: string
+  ): string | Buffer;
+  final(outputEncoding?: string): string | Buffer;
+  setAAD(
+    buffer: string | ArrayBuffer | ArrayBufferView,
+    options?: AADOptions
+  ): this;
+  setAutoPadding(autoPadding?: boolean): this;
+  getAuthTag(): Buffer | undefined;
+}
+
+export interface Decipheriv extends Transform {
+  [kHandle]: CipherHandle;
+  update(
+    data: string | ArrayBuffer | ArrayBufferView,
+    inputEncoding?: string,
+    outputEncoding?: string
+  ): string | Buffer;
+  final(outputEncoding?: string): string | Buffer;
+  setAAD(
+    buffer: string | ArrayBuffer | ArrayBufferView,
+    options?: AADOptions
+  ): this;
+  setAutoPadding(autoPadding?: boolean): this;
+  setAuthTag(buffer: ArrayBuffer | ArrayBufferView): this;
+  setAuthTag(buffer: string, encoding?: string): this;
+}
+
+export interface CipherOptions extends TransformOptions {
+  authLengthTag?: number;
+}
+
+function getSecretKey(
+  key: string | ArrayBuffer | ArrayBufferView | KeyObject | CryptoKey
+): CryptoKey {
+  if (key instanceof CryptoKey) {
+    if (key.type !== 'secret') {
+      throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(key.type, 'secret');
+    }
+    return key;
+  } else if (isKeyObject(key)) {
+    if (key.type !== 'secret') {
+      throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(key.type, 'secret');
+    }
+    return getKeyObjectHandle(key);
+  } else if (isAnyArrayBuffer(key) || isArrayBufferView(key)) {
+    return getKeyObjectHandle(createSecretKey(key));
+  } else if (typeof key === 'string') {
+    return getKeyObjectHandle(createSecretKey(key, 'utf8'));
+  }
+
+  throw new ERR_INVALID_ARG_TYPE(
+    'key',
+    ['string', 'Buffer', 'TypedArray', 'DataView', 'KeyObject', 'CryptoKey'],
+    key
+  );
+}
+
+function getIv(
+  iv: string | ArrayBuffer | ArrayBufferView | null
+): ArrayBuffer | ArrayBufferView {
+  if (isAnyArrayBuffer(iv) || isArrayBufferView(iv)) {
+    return iv;
+  } else if (typeof iv === 'string') {
+    return Buffer.from(iv, 'utf8');
+  }
+
+  throw new ERR_INVALID_ARG_TYPE(
+    'iv',
+    ['string', 'Buffer', 'TypedArray', 'DataView', 'null'],
+    iv
+  );
+}
+
+export const Cipheriv = function (
+  this: Cipheriv,
+  algorithm: string,
+  key: string | ArrayBuffer | ArrayBufferView | KeyObject | CryptoKey,
+  iv: string | ArrayBuffer | ArrayBufferView | null,
+  options: CipherOptions = {}
+) {
+  validateString(algorithm, 'algorithm');
+  const secretKey = getSecretKey(key);
+  const ivBuf = getIv(iv);
+
+  if (options.authLengthTag !== undefined) {
+    validateUint32(options.authLengthTag, 'options.authLengthTag');
+  }
+
+  this[kHandle] = new cryptoImpl.CipherHandle(
+    'cipher',
+    algorithm,
+    secretKey,
+    ivBuf,
+    options.authLengthTag
+  );
+
+  Transform.call(this, options as TransformOptions);
+} as unknown as {
+  new (
+    algorithm: string,
+    key: string | ArrayBuffer | ArrayBufferView | KeyObject | CryptoKey,
+    iv: string | ArrayBuffer | ArrayBufferView | null,
+    options?: TransformOptions
+  ): Cipheriv;
+};
+Object.setPrototypeOf(Cipheriv.prototype, Transform.prototype);
+Object.setPrototypeOf(Cipheriv, Transform);
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Cipheriv.prototype.update = function (
+  this: Cipheriv,
+  data: string | ArrayBuffer | ArrayBufferView,
+  inputEncoding?: string,
+  outputEncoding?: string
+): string | Buffer {
+  let ret: ArrayBuffer;
+  if (typeof data === 'string') {
+    if (inputEncoding === undefined) {
+      throw new ERR_INVALID_ARG_VALUE(
+        'inputEncoding',
+        inputEncoding,
+        'If inputEncoding is not provided then the data must be a Buffer'
+      );
+    }
+    ret = this[kHandle].update(Buffer.from(data, inputEncoding));
+  } else if (isAnyArrayBuffer(data)) {
+    ret = this[kHandle].update(data);
+  } else if (isArrayBufferView(data)) {
+    ret = this[kHandle].update(data);
+  } else {
+    throw new ERR_INVALID_ARG_TYPE(
+      'data',
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      data
+    );
+  }
+
+  if (outputEncoding === undefined) {
+    return Buffer.from(ret);
+  }
+
+  return Buffer.from(ret).toString(outputEncoding);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Cipheriv.prototype.final = function (
+  this: Cipheriv,
+  outputEncoding?: string
+): string | Buffer {
+  const ret = this[kHandle].final();
+  if (outputEncoding === undefined) {
+    return Buffer.from(ret);
+  }
+  return Buffer.from(ret).toString(outputEncoding);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Cipheriv.prototype.setAAD = function (
+  this: Cipheriv,
+  buffer: string | ArrayBuffer | ArrayBufferView,
+  options: AADOptions = {}
+): Cipheriv {
+  validateObject(options, 'options');
+  const { plaintextLength, encoding } = options;
+  if (plaintextLength !== undefined) {
+    validateUint32(plaintextLength, 'options.plaintextLength');
+  }
+  if (encoding !== undefined) {
+    validateString(encoding, 'options.encoding');
+  }
+
+  if (typeof buffer === 'string') {
+    this[kHandle].setAAD(Buffer.from(buffer, encoding), plaintextLength);
+  } else if (isAnyArrayBuffer(buffer) || isArrayBufferView(buffer)) {
+    this[kHandle].setAAD(buffer, plaintextLength);
+  }
+  return this;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Cipheriv.prototype.setAutoPadding = function (
+  this: Cipheriv,
+  autoPadding?: boolean
+): Cipheriv {
+  this[kHandle].setAutoPadding(autoPadding ? true : false);
+  return this;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Cipheriv.prototype.getAuthTag = function (this: Cipheriv): Buffer | undefined {
+  const ret = this[kHandle].getAuthTag();
+  if (ret === undefined) return undefined;
+  return Buffer.from(ret);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Cipheriv.prototype._transform = function (
+  this: Cipheriv,
+  chunk: string | Buffer | ArrayBufferView,
+  encoding: string,
+  callback: TransformCallback
+): void {
+  if (typeof chunk === 'string') {
+    chunk = Buffer.from(chunk, encoding);
+  }
+  this.push(Buffer.from(this[kHandle].update(chunk)));
+  callback();
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Cipheriv.prototype._flush = function (
+  this: Cipheriv,
+  callback: TransformCallback
+): void {
+  this.push(Buffer.from(this[kHandle].final()));
+  callback();
+};
+
+export const Decipheriv = function (
+  this: Decipheriv,
+  algorithm: string,
+  key: string | ArrayBuffer | ArrayBufferView | KeyObject | CryptoKey,
+  iv: string | ArrayBuffer | ArrayBufferView | null,
+  options: CipherOptions = {}
+) {
+  validateString(algorithm, 'algorithm');
+  const secretKey = getSecretKey(key);
+  const ivBuf = getIv(iv);
+
+  if (options.authLengthTag !== undefined) {
+    validateUint32(options.authLengthTag, 'options.authLengthTag');
+  }
+
+  this[kHandle] = new cryptoImpl.CipherHandle(
+    'decipher',
+    algorithm,
+    secretKey,
+    ivBuf,
+    options.authLengthTag
+  );
+
+  Transform.call(this, options as TransformOptions);
+  return this;
+} as unknown as {
+  new (
+    algorithm: string,
+    key: string | ArrayBuffer | ArrayBufferView | KeyObject | CryptoKey,
+    iv: string | ArrayBuffer | ArrayBufferView | null,
+    options?: TransformOptions
+  ): Decipheriv;
+};
+
+Object.setPrototypeOf(Decipheriv.prototype, Transform.prototype);
+Object.setPrototypeOf(Decipheriv, Transform);
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Decipheriv.prototype.update = function (
+  this: Decipheriv,
+  data: string | ArrayBuffer | ArrayBufferView,
+  inputEncoding?: string,
+  outputEncoding?: string
+): string | Buffer {
+  let ret: ArrayBuffer;
+  if (typeof data === 'string') {
+    if (inputEncoding === undefined) {
+      throw new ERR_INVALID_ARG_VALUE(
+        'inputEncoding',
+        inputEncoding,
+        'If inputEncoding is not provided then the data must be a Buffer'
+      );
+    }
+    ret = this[kHandle].update(Buffer.from(data, inputEncoding));
+  } else if (isAnyArrayBuffer(data)) {
+    ret = this[kHandle].update(data);
+  } else if (isArrayBufferView(data)) {
+    ret = this[kHandle].update(data);
+  } else {
+    throw new ERR_INVALID_ARG_TYPE(
+      'data',
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      data
+    );
+  }
+
+  if (outputEncoding === undefined) {
+    return Buffer.from(ret);
+  }
+
+  return Buffer.from(ret).toString(outputEncoding);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Decipheriv.prototype.final = function (
+  this: Decipheriv,
+  outputEncoding?: string
+): string | Buffer {
+  const ret = this[kHandle].final();
+  if (outputEncoding === undefined) {
+    return Buffer.from(ret);
+  }
+  return Buffer.from(ret).toString(outputEncoding);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Decipheriv.prototype.setAAD = function (
+  this: Decipheriv,
+  buffer: string | ArrayBuffer | ArrayBufferView,
+  options: AADOptions = {}
+): Decipheriv {
+  validateObject(options, 'options');
+  const { plaintextLength, encoding } = options;
+  if (plaintextLength !== undefined) {
+    validateUint32(plaintextLength, 'options.plaintextLength');
+  }
+  if (encoding !== undefined) {
+    validateString(encoding, 'options.encoding');
+  }
+
+  if (typeof buffer === 'string') {
+    this[kHandle].setAAD(Buffer.from(buffer, encoding), plaintextLength);
+  } else if (isAnyArrayBuffer(buffer) || isArrayBufferView(buffer)) {
+    this[kHandle].setAAD(buffer, plaintextLength);
+  }
+  return this;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Decipheriv.prototype.setAutoPadding = function (
+  this: Decipheriv,
+  autoPadding?: boolean
+): Decipheriv {
+  this[kHandle].setAutoPadding(autoPadding ? true : false);
+  return this;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Decipheriv.prototype.setAuthTag = function (
+  this: Decipheriv,
+  buffer: ArrayBuffer | ArrayBufferView
+): Decipheriv {
+  this[kHandle].setAuthTag(buffer);
+  return this;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Decipheriv.prototype._transform = function (
+  this: Decipheriv,
+  chunk: string | Buffer | ArrayBufferView,
+  encoding: string,
+  callback: TransformCallback
+): void {
+  if (typeof chunk === 'string') {
+    chunk = Buffer.from(chunk, encoding);
+  }
+  this.push(Buffer.from(this[kHandle].update(chunk)));
+  callback();
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+Decipheriv.prototype._flush = function (
+  this: Decipheriv,
+  callback: TransformCallback
+): void {
+  this.push(Buffer.from(this[kHandle].final()));
+  callback();
+};
+
+export function createCipheriv(
+  algorithm: string,
+  key: string | ArrayBuffer | ArrayBufferView | KeyObject | CryptoKey,
+  iv: string | ArrayBuffer | ArrayBufferView | null,
+  options: TransformOptions = {}
+): Cipheriv {
+  return new Cipheriv(algorithm, key, iv, options);
+}
+
+export function createDecipheriv(
+  algorithm: string,
+  key: string | ArrayBuffer | ArrayBufferView | KeyObject | CryptoKey,
+  iv: string | ArrayBuffer | ArrayBufferView | null,
+  options: TransformOptions = {}
+): Decipheriv {
+  return new Decipheriv(algorithm, key, iv, options);
+}
+
+// ======================================================================================
+
+interface HashOptions {
+  padding?: number;
+  oaepHash?: string;
+  oaepLabel?: string | ArrayBuffer | ArrayBufferView;
+  encoding?: string;
+}
+
+export const kRsaPkcs1Padding = 1;
+export const kRsaNoPadding = 3;
+export const kRsaPkcs1OaepPadding = 4;
+
+function getPaddingAndHash(options: HashOptions): PublicPrivateCipherOptions {
+  const {
+    padding = kRsaPkcs1Padding,
+    oaepHash = 'sha256',
+    oaepLabel,
+    encoding = 'utf8',
+  } = options;
+
+  validateNumber(padding, 'options.padding');
+  validateString(oaepHash, 'options.oaepHash');
+
+  let label: ArrayBufferView | ArrayBuffer | undefined;
+  if (oaepLabel !== undefined) {
+    if (typeof oaepLabel === 'string') {
+      label = Buffer.from(oaepLabel, encoding);
+    } else if (isAnyArrayBuffer(oaepLabel) || isArrayBufferView(oaepLabel)) {
+      label = oaepLabel;
+    } else {
+      throw new ERR_INVALID_ARG_TYPE(
+        'options.oaepLabel',
+        ['string', 'Buffer', 'TypedArray', 'DataView', 'ArrayBuffer'],
+        oaepLabel
+      );
+    }
+  }
+
+  return { padding, oaepHash, oaepLabel: label };
+}
+
+export function privateEncrypt(
+  privateKey: CreateAsymmetricKeyOptions | KeyData,
+  buffer: string | ArrayBufferView | ArrayBuffer
+): Buffer {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (privateKey === undefined) {
+    throw new ERR_MISSING_ARGS('privateKey');
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (buffer === undefined) {
+    throw new ERR_MISSING_ARGS('buffer');
+  }
+  const key = ((): CryptoKey => {
+    if (privateKey instanceof CryptoKey) {
+      if (privateKey.type !== 'private') {
+        throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(
+          privateKey.type,
+          'private'
+        );
+      }
+      return privateKey;
+    } else if (isKeyObject(privateKey)) {
+      if (privateKey.type !== 'private') {
+        throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(
+          privateKey.type,
+          'private'
+        );
+      }
+      return getKeyObjectHandle(privateKey);
+    } else {
+      const pvtKey = createPrivateKey(privateKey as CreateAsymmetricKeyOptions);
+      return getKeyObjectHandle(pvtKey);
+    }
+  })();
+  if (typeof buffer === 'string') {
+    const { encoding = 'utf8' } = privateKey as { encoding?: string };
+    buffer = Buffer.from(buffer, encoding);
+  }
+
+  return Buffer.from(
+    cryptoImpl.privateEncrypt(
+      key,
+      buffer,
+      getPaddingAndHash(privateKey as HashOptions)
+    )
+  );
+}
+
+export function privateDecrypt(
+  privateKey: CreateAsymmetricKeyOptions | KeyData,
+  buffer: string | ArrayBufferView | ArrayBuffer
+): Buffer {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (privateKey === undefined) {
+    throw new ERR_MISSING_ARGS('privateKey');
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (buffer === undefined) {
+    throw new ERR_MISSING_ARGS('buffer');
+  }
+  const key = ((): CryptoKey => {
+    if (privateKey instanceof CryptoKey) {
+      if (privateKey.type !== 'private') {
+        throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(
+          privateKey.type,
+          'private'
+        );
+      }
+      return privateKey;
+    } else if (isKeyObject(privateKey)) {
+      if (privateKey.type !== 'private') {
+        throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(
+          privateKey.type,
+          'private'
+        );
+      }
+      return getKeyObjectHandle(privateKey);
+    } else {
+      const pvtKey = createPrivateKey(privateKey as CreateAsymmetricKeyOptions);
+      return getKeyObjectHandle(pvtKey);
+    }
+  })();
+  if (typeof buffer === 'string') {
+    const { encoding = 'utf8' } = privateKey as { encoding?: string };
+    buffer = Buffer.from(buffer, encoding);
+  }
+
+  return Buffer.from(
+    cryptoImpl.privateDecrypt(
+      key,
+      buffer,
+      getPaddingAndHash(privateKey as HashOptions)
+    )
+  );
+}
+
+export function publicEncrypt(
+  key: CreateAsymmetricKeyOptions | KeyData,
+  buffer: string | ArrayBufferView | ArrayBuffer
+): Buffer {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (key === undefined) {
+    throw new ERR_MISSING_ARGS('privateKey');
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (buffer === undefined) {
+    throw new ERR_MISSING_ARGS('buffer');
+  }
+  const pkey = ((): CryptoKey => {
+    if (key instanceof CryptoKey) {
+      if (key.type !== 'public') {
+        throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(key.type, 'public');
+      }
+      return key;
+    } else if (isKeyObject(key)) {
+      if (key.type !== 'public') {
+        throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(key.type, 'public');
+      }
+      return getKeyObjectHandle(key);
+    } else {
+      const pubKey = createPublicKey(key as CreateAsymmetricKeyOptions);
+      return getKeyObjectHandle(pubKey);
+    }
+  })();
+  if (typeof buffer === 'string') {
+    const { encoding = 'utf8' } = key as { encoding?: string };
+    buffer = Buffer.from(buffer, encoding);
+  }
+
+  return Buffer.from(
+    cryptoImpl.publicEncrypt(
+      pkey,
+      buffer,
+      getPaddingAndHash(key as HashOptions)
+    )
+  );
+}
+
+export function publicDecrypt(
+  key: CreateAsymmetricKeyOptions | KeyData,
+  buffer: string | ArrayBufferView | ArrayBuffer
+): Buffer {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (key === undefined) {
+    throw new ERR_MISSING_ARGS('privateKey');
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (buffer === undefined) {
+    throw new ERR_MISSING_ARGS('buffer');
+  }
+  const pkey = ((): CryptoKey => {
+    if (key instanceof CryptoKey) {
+      if (key.type !== 'public') {
+        throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(key.type, 'public');
+      }
+      return key;
+    } else if (isKeyObject(key)) {
+      if (key.type !== 'public') {
+        throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(key.type, 'public');
+      }
+      return getKeyObjectHandle(key);
+    } else {
+      const pubKey = createPublicKey(key as CreateAsymmetricKeyOptions);
+      return getKeyObjectHandle(pubKey);
+    }
+  })();
+  if (typeof buffer === 'string') {
+    const { encoding = 'utf8' } = key as { encoding?: string };
+    buffer = Buffer.from(buffer, encoding);
+  }
+
+  return Buffer.from(
+    cryptoImpl.publicDecrypt(
+      pkey,
+      buffer,
+      getPaddingAndHash(key as HashOptions)
+    )
+  );
+}

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -348,3 +348,15 @@ wd_test(
         "tests/fixtures/rsa_public.pem",
     ],
 )
+
+wd_test(
+    src = "tests/crypto_cipher-test.wd-test",
+    args = ["--experimental"],
+    data = [
+        "tests/crypto_cipher-test.js",
+        "tests/fixtures/ed25519_private.pem",
+        "tests/fixtures/ed25519_public.pem",
+        "tests/fixtures/rsa_private.pem",
+        "tests/fixtures/rsa_public.pem",
+    ],
+)

--- a/src/workerd/api/node/crypto-keys.c++
+++ b/src/workerd/api/node/crypto-keys.c++
@@ -99,6 +99,10 @@ class SecretKey final: public CryptoKey::Impl {
     visitor.visit(keyData);
   }
 
+  const kj::ArrayPtr<const kj::byte> rawKeyData() const {
+    return keyData.asArrayPtr().asConst();
+  }
+
  private:
   jsg::BufferSource keyData;
 };
@@ -828,6 +832,13 @@ kj::Maybe<const ncrypto::EVPKeyPointer&> CryptoImpl::tryGetKey(jsg::Ref<CryptoKe
   KJ_IF_SOME(key, kj::dynamicDowncastIfAvailable<AsymmetricKey>(*key->impl)) {
     const ncrypto::EVPKeyPointer& evp = key;
     return evp;
+  }
+  return kj::none;
+}
+
+kj::Maybe<kj::ArrayPtr<const kj::byte>> CryptoImpl::tryGetSecretKeyData(jsg::Ref<CryptoKey>& key) {
+  KJ_IF_SOME(secret, kj::dynamicDowncastIfAvailable<SecretKey>(*key->impl)) {
+    return secret.rawKeyData();
   }
   return kj::none;
 }

--- a/src/workerd/api/node/tests/crypto_cipher-test.js
+++ b/src/workerd/api/node/tests/crypto_cipher-test.js
@@ -1,0 +1,301 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  createSecretKey,
+  publicDecrypt,
+  publicEncrypt,
+  privateDecrypt,
+  privateEncrypt,
+  createPublicKey,
+  createPrivateKey,
+} from 'node:crypto';
+
+import { strictEqual, deepStrictEqual, throws } from 'node:assert';
+
+const tests = [
+  { name: 'aes-128-cbc', size: 16, iv: 16 },
+  { name: 'aes-192-cbc', size: 24, iv: 16 },
+  { name: 'aes-256-cbc', size: 32, iv: 16 },
+  { name: 'aes-128-ctr', size: 16, iv: 16 },
+  { name: 'aes-192-ctr', size: 24, iv: 16 },
+  { name: 'aes-256-ctr', size: 32, iv: 16 },
+  { name: 'aes-128-ecb', size: 16, iv: 0 },
+  { name: 'aes-192-ecb', size: 24, iv: 0 },
+  { name: 'aes-256-ecb', size: 32, iv: 0 },
+  { name: 'aes-128-ofb', size: 16, iv: 16 },
+  { name: 'aes-192-ofb', size: 24, iv: 16 },
+  { name: 'aes-256-ofb', size: 32, iv: 16 },
+];
+
+const authTagTests = [
+  { name: 'aes-128-gcm', size: 16, iv: 16 },
+  { name: 'aes-192-gcm', size: 24, iv: 16 },
+  { name: 'aes-256-gcm', size: 32, iv: 16 },
+];
+
+export const cipheriv = {
+  async test() {
+    tests.forEach((test) => {
+      const key = createSecretKey(Buffer.alloc(test.size));
+      const iv = Buffer.alloc(test.iv);
+
+      const cipher = createCipheriv(test.name, key, iv);
+      const decipher = createDecipheriv(test.name, key, iv);
+
+      let data = '';
+      data += decipher.update(cipher.update('Hello World', 'utf8'));
+      data += decipher.update(cipher.final());
+      data += decipher.final();
+      strictEqual(data, 'Hello World');
+    });
+
+    // Test that the streams API works also
+    await Promise.all(
+      tests.map(async (test) => {
+        const { promise, resolve, reject } = Promise.withResolvers();
+
+        const key = createSecretKey(Buffer.alloc(test.size));
+        const iv = Buffer.alloc(test.iv);
+
+        const cipher = createCipheriv(test.name, key, iv);
+        const decipher = createDecipheriv(test.name, key, iv);
+        decipher.setEncoding('utf8');
+
+        cipher.end('Hello World');
+        cipher.on('data', (chunk) => {
+          decipher.write(chunk);
+        });
+        cipher.on('end', () => {
+          decipher.end();
+        });
+
+        cipher.on('error', reject);
+        decipher.on('error', reject);
+
+        let res = '';
+        decipher.on('data', (chunk) => {
+          res += chunk;
+        });
+        decipher.on('end', resolve);
+
+        await promise;
+        strictEqual(res, 'Hello World', test.name);
+      })
+    );
+
+    authTagTests.forEach((test) => {
+      const key = createSecretKey(Buffer.alloc(test.size));
+      const iv = Buffer.alloc(test.iv);
+
+      const cipher = createCipheriv(test.name, key, iv);
+
+      let data = '';
+      cipher.setAAD(Buffer.from('hello'));
+      data += cipher.update('Hello World', 'utf8', 'hex');
+      data += cipher.final('hex');
+
+      const tag = cipher.getAuthTag();
+
+      const decipher = createDecipheriv(test.name, key, iv);
+      decipher.setAuthTag(tag);
+      decipher.setAAD(Buffer.from('hello'));
+      let res = '';
+      res += decipher.update(data, 'hex');
+      res += decipher.final();
+      strictEqual(res, 'Hello World');
+    });
+  },
+};
+
+export const largeData = {
+  async test() {
+    const { promise, resolve, reject } = Promise.withResolvers();
+
+    const key = createSecretKey(Buffer.alloc(16));
+    const iv = Buffer.alloc(16);
+    const cipher = createCipheriv('aes-128-cbc', key, iv);
+    const chunks = [
+      randomBytes(1024),
+      randomBytes(2048),
+      randomBytes(4096),
+      randomBytes(8192),
+      randomBytes(16304),
+    ];
+    chunks.forEach((chunk) => cipher.write(chunk));
+    cipher.end();
+
+    const decipher = createDecipheriv('aes-128-cbc', key, iv);
+    cipher.pipe(decipher);
+
+    const output = [];
+    decipher.on('data', (chunk) => output.push(chunk));
+
+    decipher.on('end', () => {
+      const inputCombined = Buffer.concat(chunks);
+      const outputCombined = Buffer.concat(output);
+      deepStrictEqual(inputCombined, outputCombined);
+      resolve();
+    });
+
+    decipher.on('error', reject);
+
+    await promise;
+  },
+};
+
+export const publicEncryptPrivateDecrypt = {
+  test(_, env) {
+    const pub = createPublicKey(env['rsa_public.pem']);
+    const pvt = createPrivateKey(env['rsa_private.pem']);
+
+    pub.oaepLabel = 'test';
+    pub.oaepHash = 'sha256';
+    pub.padding = 4;
+    pub.encoding = 'utf8';
+
+    pvt.oaepLabel = 'test';
+    pvt.oaepHash = 'sha256';
+    pvt.padding = 4;
+    pvt.encoding = 'utf8';
+
+    strictEqual(
+      privateDecrypt(pvt, publicEncrypt(pub, 'hello')).toString(),
+      'hello'
+    );
+  },
+};
+
+export const publicEncryptPrivateDecryptDer = {
+  test(_, env) {
+    const pub = createPublicKey(env['rsa_public.pem']);
+    const pvt = createPrivateKey(env['rsa_private.pem']);
+
+    const pubDer = {
+      key: pub.export({ type: 'pkcs1', format: 'der' }),
+      format: 'der',
+      type: 'pkcs1',
+    };
+
+    const pvtDer = {
+      key: pvt.export({ type: 'pkcs8', format: 'der' }),
+      format: 'der',
+      type: 'pkcs8',
+    };
+
+    strictEqual(
+      privateDecrypt(pvtDer, publicEncrypt(pubDer, 'hello')).toString(),
+      'hello'
+    );
+  },
+};
+
+export const publicEncryptPrivateDecryptPem = {
+  test(_, env) {
+    const pub = createPublicKey(env['rsa_public.pem']);
+    const pvt = createPrivateKey(env['rsa_private.pem']);
+
+    const pubPem = {
+      key: pub.export({ type: 'pkcs1', format: 'pem' }),
+      format: 'pem',
+      type: 'pkcs1',
+    };
+
+    const pvtPem = {
+      key: pvt.export({ type: 'pkcs8', format: 'pem' }),
+      format: 'pem',
+      type: 'pkcs8',
+    };
+
+    strictEqual(
+      privateDecrypt(pvtPem, publicEncrypt(pubPem, 'hello')).toString(),
+      'hello'
+    );
+  },
+};
+
+export const publicEncryptPrivateDecryptPem2 = {
+  test(_, env) {
+    const pub = createPublicKey(env['rsa_public.pem']);
+    const pvt = createPrivateKey(env['rsa_private.pem']);
+
+    const pubPem = pub.export({ type: 'pkcs1', format: 'pem' });
+    const pvtPem = pvt.export({ type: 'pkcs8', format: 'pem' });
+
+    strictEqual(
+      privateDecrypt(pvtPem, publicEncrypt(pubPem, 'hello')).toString(),
+      'hello'
+    );
+  },
+};
+
+export const publicEncryptPrivateDecryptPem3 = {
+  test(_, env) {
+    const pub = createPublicKey(env['rsa_public.pem']);
+    const pvt = createPrivateKey(env['rsa_private.pem']);
+
+    const pubPem = pub.export({ type: 'spki', format: 'pem' });
+    const pvtPem = pvt.export({ type: 'pkcs8', format: 'pem' });
+
+    strictEqual(
+      privateDecrypt(pvtPem, publicEncrypt(pubPem, 'hello')).toString(),
+      'hello'
+    );
+  },
+};
+
+export const privateEncryptPublicDecrypt = {
+  test(_, env) {
+    const pub = createPublicKey(env['rsa_public.pem']);
+    const pvt = createPrivateKey(env['rsa_private.pem']);
+
+    pub.oaepLabel = 'test';
+    pub.oaepHash = 'sha256';
+    pub.padding = 3;
+    pub.encoding = 'utf8';
+
+    pvt.oaepLabel = 'test';
+    pvt.oaepHash = 'sha256';
+    pvt.padding = 3;
+    pvt.encoding = 'utf8';
+
+    const input = 'a'.repeat(256);
+    strictEqual(
+      publicDecrypt(pub, privateEncrypt(pvt, input)).toString(),
+      input
+    );
+  },
+};
+
+export const missingArgChecks = {
+  test() {
+    throws(() => publicEncrypt(), {
+      code: 'ERR_MISSING_ARGS',
+    });
+    throws(() => publicDecrypt(), {
+      code: 'ERR_MISSING_ARGS',
+    });
+    throws(() => privateEncrypt(), {
+      code: 'ERR_MISSING_ARGS',
+    });
+    throws(() => privateDecrypt(), {
+      code: 'ERR_MISSING_ARGS',
+    });
+    throws(() => publicEncrypt('key'), {
+      code: 'ERR_MISSING_ARGS',
+    });
+    throws(() => publicDecrypt('key'), {
+      code: 'ERR_MISSING_ARGS',
+    });
+    throws(() => privateEncrypt('key'), {
+      code: 'ERR_MISSING_ARGS',
+    });
+    throws(() => privateDecrypt('key'), {
+      code: 'ERR_MISSING_ARGS',
+    });
+  },
+};

--- a/src/workerd/api/node/tests/crypto_cipher-test.wd-test
+++ b/src/workerd/api/node/tests/crypto_cipher-test.wd-test
@@ -1,0 +1,21 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "crypto_cipher-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "crypto_cipher-test.js")
+        ],
+        compatibilityDate = "2025-02-01",
+        compatibilityFlags = ["nodejs_compat_v2", "experimental"],
+        bindings = [
+          ( name = "rsa_private.pem", text = embed "fixtures/rsa_private.pem" ),
+          ( name = "rsa_public.pem", text = embed "fixtures/rsa_public.pem" ),
+          ( name = "ed25519_private.pem", text = embed "fixtures/ed25519_private.pem" ),
+          ( name = "ed25519_public.pem", text = embed "fixtures/ed25519_public.pem" ),
+        ],
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
Implementing the node:crypto cipher apis. ~Not yet ready for a full code review.~

Working:
* `createCipheriv(...)`
* `createDecipheriv(...)`
* `publicEncrypt()`
* `publicDecrypt()`
* `privateEncrypt()`
* `privateDecrypt()`

TODO: (will come in a separate PR)
* `getCipherInfo()`
