### PR TITLE
Add TS support for importable env

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -1,3 +1,6 @@
+// Extend this in your apps to properly type Env
+interface Env {}
+
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.
@@ -239,8 +242,15 @@ declare module "cloudflare:workers" {
   };
 
   export abstract class WorkflowStep {
-    do<T extends Rpc.Serializable<T>>(name: string, callback: () => Promise<T>): Promise<T>;
-    do<T extends Rpc.Serializable<T>>(name: string, config: WorkflowStepConfig, callback: () => Promise<T>): Promise<T>;
+    do<T extends Rpc.Serializable<T>>(
+      name: string,
+      callback: () => Promise<T>
+    ): Promise<T>;
+    do<T extends Rpc.Serializable<T>>(
+      name: string,
+      config: WorkflowStepConfig,
+      callback: () => Promise<T>
+    ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;
   }
@@ -257,6 +267,11 @@ declare module "cloudflare:workers" {
 
     constructor(ctx: ExecutionContext, env: Env);
 
-    run(event: Readonly<WorkflowEvent<T>>, step: WorkflowStep): Promise<unknown>;
+    run(
+      event: Readonly<WorkflowEvent<T>>,
+      step: WorkflowStep
+    ): Promise<unknown>;
   }
+
+  export const env: Env;
 }


### PR DESCRIPTION
This adds TypeScript support for importable env:

```ts
import { env } from "cloudflare:workers"
```

It works by typing `env` as the empty interface `Env`. This will then be merged with user `Env` declarations in `worker-configuration.d.ts` files generated by `wrangler types`, resulting in `env` being typed correctly.

As a future augmentation, we should (in `wrangler types`) modify the generated runtime types to respect the user-provided name for the `Env` interface.