### PR TITLE
Return kj::HashSet from Python's getTransitiveRequirements.

### DIFF
--- a/src/pyodide/internal/setupPackages.ts
+++ b/src/pyodide/internal/setupPackages.ts
@@ -312,7 +312,6 @@ function addPackageToLoad(
 }
 
 export { REQUIREMENTS };
-export const TRANSITIVE_REQUIREMENTS = new Set(
-  MetadataReader.getTransitiveRequirements()
-);
+export const TRANSITIVE_REQUIREMENTS =
+  MetadataReader.getTransitiveRequirements();
 export const VIRTUALIZED_DIR = buildVirtualizedDir(TRANSITIVE_REQUIREMENTS);

--- a/src/pyodide/types/runtime-generated/metadata.d.ts
+++ b/src/pyodide/types/runtime-generated/metadata.d.ts
@@ -20,7 +20,7 @@ declare namespace MetadataReader {
   const getPackagesVersion: () => string;
   const getPackagesLock: () => string;
   const read: (index: number, position: number, buffer: Uint8Array) => number;
-  const getTransitiveRequirements: () => string[];
+  const getTransitiveRequirements: () => Set<string>;
 }
 
 export default MetadataReader;

--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -162,16 +162,11 @@ int PyodideMetadataReader::readMemorySnapshot(int offset, kj::Array<kj::byte> bu
   return readToTarget(KJ_REQUIRE_NONNULL(memorySnapshot), offset, buf);
 }
 
-kj::Array<kj::String> PyodideMetadataReader::getTransitiveRequirements() {
+kj::HashSet<kj::String> PyodideMetadataReader::getTransitiveRequirements() {
   auto packages = parseLockFile(packagesLock);
   auto depMap = getDepMapFromPackagesLock(*packages);
 
-  auto allRequirements = getPythonPackageNames(*packages, depMap, requirements, packagesVersion);
-  auto result = kj::heapArrayBuilder<kj::String>(allRequirements.size());
-  for (const auto& r: allRequirements) {
-    result.add(kj::str(r));
-  }
-  return result.finish();
+  return getPythonPackageNames(*packages, depMap, requirements, packagesVersion);
 }
 
 int ArtifactBundler::readMemorySnapshot(int offset, kj::Array<kj::byte> buf) {

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -210,7 +210,7 @@ class PyodideMetadataReader: public jsg::Object {
     return kj::str(packagesLock);
   }
 
-  kj::Array<kj::String> getTransitiveRequirements();
+  kj::HashSet<kj::String> getTransitiveRequirements();
 
   JSG_RESOURCE_TYPE(PyodideMetadataReader) {
     JSG_METHOD(isWorkerd);


### PR DESCRIPTION
Little clean up and follow up to https://github.com/cloudflare/workerd/pull/3538