### PR TITLE
Fix new queue waitUntil drain() logic

### DIFF
--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -532,7 +532,6 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEventImpl::run(
     kj::TaskSet& waitUntilTasks) {
   incomingRequest->delivered();
   auto& context = incomingRequest->getContext();
-  KJ_DEFER({ waitUntilTasks.add(incomingRequest->drain().attach(kj::mv(incomingRequest))); });
 
   kj::String queueName;
   uint32_t batchSize;
@@ -624,6 +623,12 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEventImpl::run(
       auto result = co_await incomingRequest->finishScheduled();
       bool completed = result == IoContext_IncomingRequest::FinishScheduledResult::COMPLETED;
       outcome = completed ? context.waitUntilStatus() : EventOutcome::EXCEEDED_CPU;
+    } else {
+      // If we aren't going to wait on the waitUntil tasks via a call to
+      // incomingRequest->finishScheduled(), we're responsible for calling draing() on the
+      // incomingRequest to ensure that waitUntil tasks are run in the backgound.
+      waitUntilTasks.add(incomingRequest->drain().attach(
+          kj::mv(incomingRequest), kj::addRef(*queueEventHolder), kj::addRef(*this)));
     }
 
     KJ_IF_SOME(status, context.getLimitEnforcer().getLimitsExceeded()) {


### PR DESCRIPTION
I thought that deferring the drain() in all cases could potentially be useful (e.g. what if an exception gets thrown from somewhere in this method without getting caught?), but that was dumb. This change (A) moves it to only the code path where we aren't already calling finishScheduled (which waits on waitUntilTasks), and (B) properly attaches references to the necessary state that can be accessed from JS.

Follow-up to #3596