### PR TITLE
Dont log DISCONNECTED application errors

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1289,6 +1289,10 @@ class Server::InspectorService final: public kj::HttpService, public kj::HttpSer
 
   kj::Promise<void> handleApplicationError(
       kj::Exception exception, kj::Maybe<kj::HttpService::Response&> response) override {
+    if (exception.getType() == kj::Exception::Type::DISCONNECTED) {
+      // Don't send a response, just close connection.
+      return kj::READY_NOW;
+    }
     KJ_LOG(ERROR, kj::str("Uncaught exception: ", exception));
     KJ_IF_SOME(r, response) {
       co_return co_await r.sendError(500, "Internal Server Error", headerTable);


### PR DESCRIPTION
This is to fix random `disconnected: worker_do_not_log; Request failed due to internal error` errors seen in https://github.com/opennextjs/opennextjs-cloudflare/actions/runs/13650895966/job/38158955611?pr=436#step:7:54
The added logic matches internal logic