### PR TITLE
[build] 03-05-25 Bazel cleanup

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -116,10 +116,6 @@ build:windows --host_copt='-Wno-macro-redefined'
 build:windows --per_file_copt='external/dawn@-Wno-unknown-argument'
 build:windows --host_per_file_copt='external/dawn@-Wno-unknown-argument'
 
-# V8 now requires Windows 10, Bazel fails to set this properly.
-build:windows --per_file_copt=external/v8/src/base/platform/platform-win32.cc@-D_WIN32_WINNT=0x0A00
-build:windows --host_per_file_copt=external/v8/src/base/platform/platform-win32.cc@-D_WIN32_WINNT=0x0A00
-
 # typescript configuration
 # do more correct type checking
 common --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
@@ -206,9 +202,9 @@ build:unix --workspace_status_command=./tools/unix/workspace-status.sh
 build:unix --cxxopt='-std=c++20' --host_cxxopt='-std=c++20'
 build:unix --@capnp-cpp//src/kj:libdl=True
 
+# Bazel uses CC to compile C and C++ actions, no need to define CXX.
 build:unix --action_env=BAZEL_COMPILER=clang
 build:unix --action_env=CC=clang
-build:unix --action_env=CXX=clang++
 
 build:unix --test_env=LLVM_SYMBOLIZER=llvm-symbolizer
 
@@ -301,8 +297,8 @@ build:windows --enable_runfiles
 # `#pragma once` when using symlinked virtual includes, `__atomic_*` functions,
 # a standards-compliant preprocessor, support for GNU statement expressions
 # used by some KJ macros, and understands the `.c++` extension by default.
-# As of bazel 7, incompatible_enable_cc_toolchain_resolution is enabled by default, so we need to
-# define a platform for the clang-cl build.
+# As of bazel 7, toolchain resolution is enabled by default, so we need to define a platform for
+# the clang-cl build.
 build:windows --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl
 build:windows --extra_execution_platforms=//:x64_windows-clang-cl
 

--- a/.github/workflows/release-python-runtime.yml
+++ b/.github/workflows/release-python-runtime.yml
@@ -27,8 +27,8 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 16
           sudo apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev
-          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang --action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
-          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang --host_action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
+          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
+          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
       - name: Configure download mirrors
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ on:
         description: 'Is Prerelease'
         type: boolean
         default: false
-        
 
 jobs:
   version:
@@ -118,8 +117,8 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 16
           sudo apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev
-          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang --action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
-          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang --host_action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
+          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
+          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
       - name: Setup macOS
         if: runner.os == 'macOS'
         run: |
@@ -297,8 +296,8 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 16
           sudo apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev
-          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang --action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
-          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang --host_action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
+          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
+          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
       - name: Build type generating Worker
         run: |
           bazel build --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types:types_worker
@@ -358,8 +357,8 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 16
           sudo apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev
-          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang --action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
-          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang --host_action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
+          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
+          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
       - name: build types
         run: |
             bazel build --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types:types

--- a/.github/workflows/type-snapshot.yml
+++ b/.github/workflows/type-snapshot.yml
@@ -42,8 +42,8 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 16
           sudo apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev
-          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang --action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
-          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang --host_action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
+          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
+          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
       - name: build types
         run: |
           bazel build --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types:types

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -16,8 +16,8 @@ RUN ./llvm.sh 16
 RUN apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev libclang-rt-16-dev
 COPY . .
 
-RUN echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang --action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
-RUN echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang --host_action_env=CXX=/usr/lib/llvm-16/bin/clang++" >> .bazelrc
+RUN echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
+RUN echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
 COPY .bazel-cache /bazel-disk-cache
 # pnpm version will be different depending on the value of `packageManager` field in package.json
 RUN npm install -g pnpm@latest

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -147,20 +147,20 @@ git_repository(
             include_prefix = "third_party/fast_float/src",
         )""",
     commit = "cb1d42aaa1e14b09e1452cfdef373d051b8c02a4",
-    remote = "https://chromium.googlesource.com/external/github.com/fastfloat/fast_float.git",
+    remote = "https://github.com/fastfloat/fast_float.git",
 )
 
 git_repository(
     name = "fp16",
     build_file_content = "exports_files(glob([\"**\"]))",
     commit = "0a92994d729ff76a58f692d3028ca1b64b145d91",
-    remote = "https://chromium.googlesource.com/external/github.com/Maratyszcza/FP16.git",
+    remote = "https://github.com/Maratyszcza/FP16.git",
 )
 
 git_repository(
     name = "highway",
     commit = "00fe003dac355b979f36157f9407c7c46448958e",
-    remote = "https://chromium.googlesource.com/external/github.com/google/highway.git",
+    remote = "https://github.com/google/highway.git",
 )
 
 # OK, now we can bring in tcmalloc itself.
@@ -337,7 +337,6 @@ new_local_repository(
         deps = [ "@v8//:v8_icu", "@workerd//:icudata-embed" ],
         visibility = ["//visibility:public"])""",
     path = "empty",
-    repo_mapping = {"@abseil-cpp": "@com_google_absl"},
 )
 
 # rust-based lolhtml dependency, including the API header.

--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -50,8 +50,8 @@ build:ci-linux-common --copt='-Werror'
 build:ci-linux-common --copt='-Wno-error=#warnings'
 build:ci-linux-common --copt='-Wno-error=deprecated-declarations'
 # keep in sync with .github/workflows/test.yml
-build:ci-linux-common --action_env=CC=/usr/lib/llvm-16/bin/clang --action_env=CXX=/usr/lib/llvm-16/bin/clang++
-build:ci-linux-common --host_action_env=CC=/usr/lib/llvm-16/bin/clang --host_action_env=CXX=/usr/lib/llvm-16/bin/clang++
+build:ci-linux-common --action_env=CC=/usr/lib/llvm-16/bin/clang
+build:ci-linux-common --host_action_env=CC=/usr/lib/llvm-16/bin/clang
 
 build:ci-linux --config=ci-linux-common
 build:ci-linux-arm --config=ci-linux --remote_download_regex=".*src/workerd/server/workerd.*"

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -33,8 +33,8 @@ class Event: public jsg::Object {
   };
 
   inline explicit Event(kj::String ownType, Init init = Init(), bool trusted = true)
-      : type(ownType),
-        ownType(kj::mv(ownType)),
+      : ownType(kj::mv(ownType)),
+        type(this->ownType),
         init(init),
         trusted(trusted) {}
 
@@ -195,8 +195,9 @@ class Event: public jsg::Object {
   }
 
  private:
-  kj::StringPtr type;
+  // listing ownType first so type can be initialized with it in constructor
   kj::String ownType;
+  kj::StringPtr type;
   Init init;
   bool trusted = true;
   bool stopped = false;


### PR DESCRIPTION
[build] 03-05-25 Bazel cleanup
- It turns out that Bazel never uses the CXX env variable – when we need to specify the right path to clang, providing CC is sufficient
- For some V8 dependencies, replace googlesource mirror with the GitHub repository itself
- Drop superfluous repo_mapping and Windows overrides that are no longer needed for V8

[nfc] Fix -Wdangling-field warning
- LLVM 20 produces a warning since the type ptr is initialized with a constructor
argument that will go out of scope. Initializing it with the ownType class
variable instead resolves the warning.