### PR TITLE
Fixes "inserted row already exists in table" error in Python.

### DIFF
--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -105,15 +105,15 @@ kj::HashSet<kj::String> PythonModuleInfo::getWorkerModuleSet() {
     }
     auto firstSlash = name.findFirst('/');
     KJ_IF_SOME(idx, firstSlash) {
-      result.insert(kj::str(name.slice(0, idx)));
+      result.upsert(kj::str(name.slice(0, idx)), [](auto&&, auto&&) {});
       continue;
     }
     if (name.endsWith(dotPy)) {
-      result.insert(kj::str(name.slice(0, name.size() - dotPy.size())));
+      result.upsert(kj::str(name.slice(0, name.size() - dotPy.size())), [](auto&&, auto&&) {});
       continue;
     }
     if (name.endsWith(dotSo)) {
-      result.insert(kj::str(name.slice(0, name.size() - dotSo.size())));
+      result.upsert(kj::str(name.slice(0, name.size() - dotSo.size())), [](auto&&, auto&&) {});
       continue;
     }
   }
@@ -399,7 +399,7 @@ kj::Array<kj::String> PythonModuleInfo::filterPythonScriptImports(
     kj::HashSet<kj::String> workerModules, kj::ArrayPtr<kj::String> imports) {
   auto baselineSnapshotImportsSet = kj::HashSet<kj::StringPtr>();
   for (auto& pkgImport: snapshotImports) {
-    baselineSnapshotImportsSet.insert(kj::mv(pkgImport));
+    baselineSnapshotImportsSet.upsert(kj::mv(pkgImport), [](auto&&, auto&&) {});
   }
 
   kj::HashSet<kj::String> filteredImportsSet;
@@ -426,7 +426,7 @@ kj::Array<kj::String> PythonModuleInfo::filterPythonScriptImports(
     if (workerModules.contains(firstComponent)) {
       continue;
     }
-    filteredImportsSet.insert(kj::mv(pkgImport));
+    filteredImportsSet.upsert(kj::mv(pkgImport), [](auto&&, auto&&) {});
   }
 
   auto filteredImportsBuilder = kj::heapArrayBuilder<kj::String>(filteredImportsSet.size());

--- a/src/workerd/server/tests/python/vendor_dir/vendor_dir.wd-test
+++ b/src/workerd/server/tests/python/vendor_dir/vendor_dir.wd-test
@@ -7,6 +7,9 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py"),
           (name = "vendor/a.py", pythonModule = embed "vendor/a.py"),
+          # This module below is only here to verify that we don't crash because of
+          # duplicate module names.
+          (name = "vendor/worker.py", pythonModule = embed "vendor/a.py"),
           (name = "numpy", pythonRequirement = "")
         ],
         compatibilityDate = "2024-01-15",


### PR DESCRIPTION
This error was thrown when a worker bundle has multiple modules with the same filename.

I changed a few other `insert`s to `upsert` just in case.

### Test Plan

```
bazel run @workerd//src/workerd/server/tests/python:vendor_dir_development@
```