### PR TITLE
Fixes asgi import at top-level failing.

### DIFF
--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -80,6 +80,9 @@ async function setupPatches(pyodide: Pyodide): Promise<void> {
     pyodide.site_packages = `/lib/python${pymajor}.${pyminor}/site-packages`;
 
     // Inject modules that enable JS features to be used idiomatically from Python.
+    //
+    // NOTE: setupPatches is called after memorySnapshotDoImports, so any modules injected here
+    // shouldn't be part of the snapshot and should filtered out in filterPythonScriptImports.
     if (USING_OLDEST_PYODIDE_VERSION) {
       // Inject at cloudflare.workers for backwards compatibility
       pyodide.FS.mkdir(`${pyodide.site_packages}/cloudflare`);

--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -412,8 +412,10 @@ kj::Array<kj::String> PythonModuleInfo::filterPythonScriptImports(
       continue;
     }
 
-    // don't include js or pyodide.
-    if (firstComponent == "js"_kj.asArray() || firstComponent == "pyodide"_kj.asArray()) {
+    // don't include modules that we provide and that are likely to be imported by most
+    // workers.
+    if (firstComponent == "js"_kj.asArray() || firstComponent == "pyodide"_kj.asArray() ||
+        firstComponent == "asgi"_kj.asArray() || firstComponent == "workers"_kj.asArray()) {
       continue;
     }
 


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/cloudflare/workerd/pull/3505.

I've looked into moving when setupPatches gets called but it depends on pyodide being initialised... whereas the memory snapshot stuff seems to require being called before pyodide initialisation is finalised.

Anyway, I'd love @hoodmane's thoughts on this when he's back.