### PR TITLE
Ask Claude to implement `encodeResponseBody: "manual"` option.

### DIFF
--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -1683,6 +1683,7 @@ interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 type Service<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> =
   Fetcher<T>;

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -1691,6 +1691,7 @@ export interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 export type Service<
   T extends Rpc.WorkerEntrypointBranded | undefined = undefined,

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -1689,6 +1689,7 @@ interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 type Service<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> =
   Fetcher<T>;

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -1697,6 +1697,7 @@ export interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 export type Service<
   T extends Rpc.WorkerEntrypointBranded | undefined = undefined,

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -1707,6 +1707,7 @@ interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 type Service<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> =
   Fetcher<T>;

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -1715,6 +1715,7 @@ export interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 export type Service<
   T extends Rpc.WorkerEntrypointBranded | undefined = undefined,

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -1707,6 +1707,7 @@ interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 type Service<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> =
   Fetcher<T>;

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -1715,6 +1715,7 @@ export interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 export type Service<
   T extends Rpc.WorkerEntrypointBranded | undefined = undefined,

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -1707,6 +1707,7 @@ interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 type Service<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> =
   Fetcher<T>;

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -1715,6 +1715,7 @@ export interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 export type Service<
   T extends Rpc.WorkerEntrypointBranded | undefined = undefined,

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -1712,6 +1712,7 @@ interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 type Service<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> =
   Fetcher<T>;

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -1720,6 +1720,7 @@ export interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 export type Service<
   T extends Rpc.WorkerEntrypointBranded | undefined = undefined,

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -1714,6 +1714,7 @@ interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 type Service<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> =
   Fetcher<T>;

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -1722,6 +1722,7 @@ export interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 export type Service<
   T extends Rpc.WorkerEntrypointBranded | undefined = undefined,

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -1714,6 +1714,7 @@ interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 type Service<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> =
   Fetcher<T>;

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -1722,6 +1722,7 @@ export interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 export type Service<
   T extends Rpc.WorkerEntrypointBranded | undefined = undefined,

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -1732,6 +1732,7 @@ interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 type Service<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> =
   Fetcher<T>;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -1740,6 +1740,7 @@ export interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 export type Service<
   T extends Rpc.WorkerEntrypointBranded | undefined = undefined,

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -1683,6 +1683,7 @@ interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 type Service<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> =
   Fetcher<T>;

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -1691,6 +1691,7 @@ export interface RequestInit<Cf = CfProperties> {
   integrity?: string;
   /* An AbortSignal to set request's signal. */
   signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
 export type Service<
   T extends Rpc.WorkerEntrypointBranded | undefined = undefined,


### PR DESCRIPTION
The `Response` encoder has long had a non-standard option `encodeBody: "manual"` which says: "Do not automatically compress the body according to content-encoding; assume the bytes I provide are already compressed."

However, this only allowed you to construct a `Response` to return with manual encoding. If you made at outgoing HTTP request, and the response was compressed, there was no way to stop the runtime from automatically decompressing it. This commit adds such a way: setting `encodeResponseBody: "manual"` as an option to `fetch()`.

(Of course, `encodeResponseBody` is a non-standard option, but `encodeBody` is as well.)

🚨🚨 THIS PR WAS WRITTEN BY CLAUDE.AI 🚨🚨
(with a lot of prompting by me -- [see trascript](https://claude-workerd-transcript.pages.dev/))

This was an experiment to see how well Claude Code could handle the `workerd` codebase. Final stats:

```
Total cost:            $9.77
Total duration (API):  17m 15.5s
Total duration (wall): 1h 38m 26.7s
Context used:          73%
```

These numbers are... quite a bit larger than what I've seen when working with Claude Code on smaller, simpler projects.

I am... not really sure I saved much time on the implementation itself, vs. writing it manually. But I am impressed that Claude figured it out! And I especially appreciated it writing the unit test because I hate writing tests.