### PR TITLE
Fix "actor still initializing when getHandler() called" with containers.

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3506,7 +3506,11 @@ kj::Promise<void> Worker::Actor::ensureConstructedImpl(IoContext& context, Actor
       handler.missingSuperclass = info.missingSuperclass;
 
       impl->classInstance = kj::mv(handler);
-    }, kj::mv(inputLock));
+    }, inputLock.addRef());
+    // We addRef() the inputLock above rather than kj::mv() it so that the lock remains held
+    // through the catch block below, if an exception is thrown. This is important since we
+    // MUST update `impl->classInstance` to something other than `Initializing` before we
+    // release the lock.
   } catch (...) {
     // Get the KJ exception
     auto e = kj::getCaughtExceptionAsKj();


### PR DESCRIPTION
We observed this error in production when testing containers.

This change was technically composed by Claude Code. Transcript: https://claude-workerd-transcript.pages.dev/ensure-constructed

Claude was surprisingly quick to narrow down where the problem might be, given just the error message.

However, ultimately it needed hints to figure out the actual problem, and the code it initially proposed as the fix was not very good (though its choice to use `KJ_ON_SCOPE_FAILURE` was interesting!).

The code in this commit may have been written by it, but only after very explicit prompting from me on what to do.

I think I would have found and fixed the problem more quickly without Claude, but its ability to reason about the code is nevertheless impressive.