### PR TITLE
Remove external package loading autogate/compat flag and make default.

### DIFF
--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -75,7 +75,7 @@ BUNDLE_VERSION_INFO = make_bundle_version_info([
     {
         "name": "development",
         "id": "dev",
-        "feature_flags": ["pythonWorkersDevPyodide", "pythonExternalPackages"],
+        "feature_flags": ["pythonWorkersDevPyodide"],
         "emscripten_version": "3.1.52",
         "python_version": "3.12.1",
         "packages": "20240829.4",

--- a/src/pyodide/pyodide_extra.capnp
+++ b/src/pyodide/pyodide_extra.capnp
@@ -1,7 +1,6 @@
 @0x96c290dbf479ac0c;
 
 const pythonEntrypoint :Text = embed "python-entrypoint.js";
-const pyodidePackagesTar :Data = embed "pyodide_packages.tar";
 struct PackageLock {
   packageDate @0 :Text;
   lock @1 :Text;

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -645,12 +645,8 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # the behavior to uppercase all methods prior to parsing to that the method is always
   # recognized if it is a known method.
 
-  pythonExternalPackages @66 :Bool
+  obsolete66 @66 :Bool
       $compatEnableFlag("python_external_packages");
-  # Temporary flag to load Python packages from external bundle loaded at runtime.
-  #
-  # This is a compat flag so that we can opt in our test workers into it before rolling out to
-  # everyone.
 
   noTopLevelAwaitInRequire @67 :Bool
       $compatEnableFlag("disable_top_level_await_in_require")

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -568,15 +568,8 @@ void WorkerdApi::compileModules(jsg::Lock& lockParam,
           jsg::ModuleRegistry::Type::INTERNAL);
 
       // Inject packages tar file
-      if (featureFlags.getPythonExternalPackages() ||
-          util::Autogate::isEnabled(util::AutogateKey::PYTHON_FETCH_INDIVIDUAL_PACKAGES)) {
-        modules->addBuiltinModule("pyodide-internal:packages_tar_reader", "export default { }"_kj,
-            workerd::jsg::ModuleRegistry::Type::INTERNAL, {});
-      } else {
-        modules->addBuiltinModule("pyodide-internal:packages_tar_reader",
-            jsg::alloc<ReadOnlyBuffer>(PYODIDE_PACKAGES_TAR.get()),
-            workerd::jsg::ModuleRegistry::Type::INTERNAL);
-      }
+      modules->addBuiltinModule("pyodide-internal:packages_tar_reader", "export default { }"_kj,
+          workerd::jsg::ModuleRegistry::Type::INTERNAL, {});
 
       // Inject artifact bundler.
       modules->addBuiltinModule("pyodide-internal:artifacts",

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -19,8 +19,6 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "test-workerd"_kj;
     case AutogateKey::STREAMING_TAIL_WORKERS:
       return "streaming-tail-workers"_kj;
-    case AutogateKey::PYTHON_FETCH_INDIVIDUAL_PACKAGES:
-      return "python-fetch-individual-packages";
     case AutogateKey::URLPATTERN:
       return "urlpattern";
     case AutogateKey::NumOfKeys:

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -15,9 +15,6 @@ namespace workerd::util {
 enum class AutogateKey {
   TEST_WORKERD,
   STREAMING_TAIL_WORKERS,
-  // Fetches Python packages as individual bundles from GCS instead of using a single big bundle
-  // embedded in the binary
-  PYTHON_FETCH_INDIVIDUAL_PACKAGES,
   URLPATTERN,
   NumOfKeys  // Reserved for iteration.
 };


### PR DESCRIPTION
This has been out to RoW for a while now, so let's make it default.