### PR TITLE
Implements Request class in Python SDK.

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -430,7 +430,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   pythonWorkers @43 :Bool
       $compatEnableFlag("python_workers")
       $pythonSnapshotRelease(pyodide = "0.26.0a2", pyodideRevision = "2024-03-01",
-          packages = "20240829.4", backport = 19,
+          packages = "20240829.4", backport = 20,
           baselineSnapshotHash = "d13ce2f4a0ade2e09047b469874dacf4d071ed3558fec4c26f8d0b99d95f77b5")
       $impliedByAfterDate(name = "pythonWorkersDevPyodide", date = "2000-01-01");
   # Enables Python Workers. Access to this flag is not restricted, instead bundles containing
@@ -684,7 +684,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatEnableFlag("python_workers_20250116")
       $experimental
       $pythonSnapshotRelease(pyodide = "0.27.1", pyodideRevision = "2025-01-16",
-          packages = "20241218", backport = 7,
+          packages = "20241218", backport = 8,
           baselineSnapshotHash = "TODO");
 
   requestCfOverridesCacheRules @72 :Bool


### PR DESCRIPTION
Implements a Python native `Request` class based on https://developer.mozilla.org/en-US/docs/Web/API/Request/Request.

The API tries to match the `Response` API as closely as possible.

### Test Plan

```
$ bazel run @workerd//src/workerd/server/tests/python:sdk_development@
```