### PR TITLE
Optimize types/definitions build process

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -98,3 +98,10 @@ js_library(
     srcs = [".prettierrc.json"],
     visibility = ["//visibility:public"],
 )
+
+# Smart types target that only rebuilds when necessary
+alias(
+    name = "types",
+    actual = "//types:build_types_when_needed",
+    visibility = ["//visibility:public"],
+)

--- a/types/BUILD.bazel
+++ b/types/BUILD.bazel
@@ -37,9 +37,11 @@ js_run_binary(
         ":types_worker",
         "//:node_modules/prettier",
         "//src/workerd/server:workerd",
-    ],
+        # Add explicit dependencies on type definition files
+    ] + glob(["defines/**/*.d.ts"]),
     out_dirs = ["definitions"],
     silent_on_success = False,  # Always enable logging for debugging
+    tags = ["manual"],  # Add manual tag so it doesn't build by default
     tool = ":build_types_bin",
     visibility = ["//visibility:public"],
 )
@@ -51,6 +53,20 @@ js_binary(
     ],
     entry_point = "scripts/build-worker.js",
     node_options = ["--enable-source-maps"],
+)
+
+# This is a wrapper target that only rebuilds the types when necessary
+js_run_binary(
+    name = "build_types_when_needed",
+    srcs = [
+        "scripts/config.capnp",
+        ":types_worker",
+        "//:node_modules/prettier",
+        "//src/workerd/server:workerd",
+    ] + glob(["defines/**/*.d.ts"]) + glob(["src/transforms/**/*.ts"]),
+    out_dirs = ["definitions"],
+    tool = ":build_types_bin",
+    visibility = ["//visibility:public"],
 )
 
 js_run_binary(


### PR DESCRIPTION
An attempt to try Claude after getting some confidence from @kentonv. Let's see if this change is worth 0.9$.

```
> /cost
  ⎿  Total cost:            $0.88
     Total duration (API):  9m 0.3s
     Total duration (wall): 14m 7.1s
     Total code changes:    28 lines added, 5 lines removed
```

Improve the build system to only rebuild types when source files change, rather than rebuilding for every build. This is accomplished by:

1. Adding explicit file dependencies to the types target
2. Creating a new build_types_when_needed target that tracks source files
3. Adding a convenient alias in the root BUILD.bazel