### PR TITLE
Revert "Add TS support for importable env"

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -1,6 +1,3 @@
-// Extend this in your apps to properly type Env
-interface Env {}
-
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.
@@ -242,15 +239,8 @@ declare module "cloudflare:workers" {
   };
 
   export abstract class WorkflowStep {
-    do<T extends Rpc.Serializable<T>>(
-      name: string,
-      callback: () => Promise<T>
-    ): Promise<T>;
-    do<T extends Rpc.Serializable<T>>(
-      name: string,
-      config: WorkflowStepConfig,
-      callback: () => Promise<T>
-    ): Promise<T>;
+    do<T extends Rpc.Serializable<T>>(name: string, callback: () => Promise<T>): Promise<T>;
+    do<T extends Rpc.Serializable<T>>(name: string, config: WorkflowStepConfig, callback: () => Promise<T>): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;
   }
@@ -267,11 +257,6 @@ declare module "cloudflare:workers" {
 
     constructor(ctx: ExecutionContext, env: Env);
 
-    run(
-      event: Readonly<WorkflowEvent<T>>,
-      step: WorkflowStep
-    ): Promise<unknown>;
+    run(event: Readonly<WorkflowEvent<T>>, step: WorkflowStep): Promise<unknown>;
   }
-
-  export const env: Env;
 }

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -5798,8 +5798,6 @@ interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.
@@ -6058,7 +6056,6 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -5814,8 +5814,6 @@ export interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-export interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -5824,8 +5824,6 @@ interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.
@@ -6084,7 +6082,6 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -5840,8 +5840,6 @@ export interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-export interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -5849,8 +5849,6 @@ interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.
@@ -6109,7 +6107,6 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -5865,8 +5865,6 @@ export interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-export interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -5850,8 +5850,6 @@ interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.
@@ -6110,7 +6108,6 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -5866,8 +5866,6 @@ export interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-export interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -5854,8 +5854,6 @@ interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.
@@ -6114,7 +6112,6 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -5870,8 +5870,6 @@ export interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-export interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -5859,8 +5859,6 @@ interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.
@@ -6119,7 +6117,6 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -5875,8 +5875,6 @@ export interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-export interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -5861,8 +5861,6 @@ interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.
@@ -6121,7 +6119,6 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -5877,8 +5877,6 @@ export interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-export interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -5861,8 +5861,6 @@ interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.
@@ -6121,7 +6119,6 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -5877,8 +5877,6 @@ export interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-export interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -5942,8 +5942,6 @@ interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.
@@ -6202,7 +6200,6 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -5958,8 +5958,6 @@ export interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-export interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -5798,8 +5798,6 @@ interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.
@@ -6058,7 +6056,6 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -5814,8 +5814,6 @@ export interface RateLimit {
    */
   limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
-// Extend this in your apps to properly type Env
-export interface Env {}
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.


### PR DESCRIPTION
Reverts cloudflare/workerd#3636 after reports of breakage for users who use type rather than interface to define their env type