### PR TITLE
Make the D1 Sessions API default allowed for everyone

### DIFF
--- a/src/cloudflare/internal/d1-api.ts
+++ b/src/cloudflare/internal/d1-api.ts
@@ -2,8 +2,6 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import flags from 'workerd:compatibility-flags';
-
 interface Fetcher {
   fetch: typeof fetch;
 }
@@ -570,8 +568,5 @@ async function toJson<T = unknown>(response: Response): Promise<T> {
 }
 
 export default function makeBinding(env: { fetcher: Fetcher }): D1Database {
-  if (flags.enableD1WithSessionsAPI) {
-    return new D1DatabaseWithSessionAPI(env.fetcher);
-  }
-  return new D1Database(env.fetcher);
+  return new D1DatabaseWithSessionAPI(env.fetcher);
 }

--- a/src/cloudflare/internal/test/d1/d1-api-test-with-sessions.wd-test
+++ b/src/cloudflare/internal/test/d1/d1-api-test-with-sessions.wd-test
@@ -12,7 +12,7 @@ const unitTests :Workerd.Config = (
         compatibilityDate = "2023-01-15",
 
         # NOTE: We provide the extra compatibility flag to enable the Sessions API.
-        compatibilityFlags = ["nodejs_compat", "enable_d1_with_sessions_api"],
+        compatibilityFlags = ["nodejs_compat"],
 
         bindings = [
         (

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -605,12 +605,11 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Enables routing to a replica on the client-side.
   # Doesn't mean requests *will* be routed to a replica, only that they can be.
 
-  enableD1WithSessionsAPI @61 :Bool
+  obsolete61 @61 :Bool
       $compatEnableFlag("enable_d1_with_sessions_api")
       $experimental;
-  # Enables the withSessions(commitTokenOrConstraint) method that allows users
-  # to use read-replication for D1.
-  # Experimental since this is not yet ready and is only meant for internal testing during development.
+  # Was used to enable the withSession(bookmarkOrConstraint) method that allows users
+  # to use read-replication Sessions API for D1. This is now enabled for everyone.
 
   handleCrossRequestPromiseResolution @62 :Bool
       $compatEnableFlag("handle_cross_request_promise_resolution")


### PR DESCRIPTION
We no longer need the `enable_d1_with_sessions_api` experimental compatibility flag since the `withSession()` method should be exposed to everyone.

Internally: CFSQL-1220

## Tests

```
bazel run //src/cloudflare/internal/test/d1:d1-api-test-with-sessions
bazel run //src/cloudflare/internal/test/d1:d1-api-test
```