### PR TITLE
Importable env types, take 2

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -151,6 +151,10 @@ declare namespace Rpc {
   };
 }
 
+declare namespace Cloudflare {
+	interface Env {}
+}
+
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;
   export const RpcStub: {
@@ -259,4 +263,6 @@ declare module "cloudflare:workers" {
 
     run(event: Readonly<WorkflowEvent<T>>, step: WorkflowStep): Promise<unknown>;
   }
+
+  export const env: Cloudflare.Env;
 }

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -5964,6 +5964,9 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+declare namespace Cloudflare {
+  interface Env {}
+}
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;
   export const RpcStub: {
@@ -6062,6 +6065,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
+  export const env: Cloudflare.Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -5980,6 +5980,9 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+export declare namespace Cloudflare {
+  interface Env {}
+}
 export declare namespace TailStream {
   interface Header {
     readonly name: string;

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -5990,6 +5990,9 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+declare namespace Cloudflare {
+  interface Env {}
+}
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;
   export const RpcStub: {
@@ -6088,6 +6091,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
+  export const env: Cloudflare.Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -6006,6 +6006,9 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+export declare namespace Cloudflare {
+  interface Env {}
+}
 export declare namespace TailStream {
   interface Header {
     readonly name: string;

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -6015,6 +6015,9 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+declare namespace Cloudflare {
+  interface Env {}
+}
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;
   export const RpcStub: {
@@ -6113,6 +6116,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
+  export const env: Cloudflare.Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -6031,6 +6031,9 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+export declare namespace Cloudflare {
+  interface Env {}
+}
 export declare namespace TailStream {
   interface Header {
     readonly name: string;

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -6016,6 +6016,9 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+declare namespace Cloudflare {
+  interface Env {}
+}
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;
   export const RpcStub: {
@@ -6114,6 +6117,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
+  export const env: Cloudflare.Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -6032,6 +6032,9 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+export declare namespace Cloudflare {
+  interface Env {}
+}
 export declare namespace TailStream {
   interface Header {
     readonly name: string;

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -6020,6 +6020,9 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+declare namespace Cloudflare {
+  interface Env {}
+}
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;
   export const RpcStub: {
@@ -6118,6 +6121,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
+  export const env: Cloudflare.Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -6036,6 +6036,9 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+export declare namespace Cloudflare {
+  interface Env {}
+}
 export declare namespace TailStream {
   interface Header {
     readonly name: string;

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -6025,6 +6025,9 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+declare namespace Cloudflare {
+  interface Env {}
+}
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;
   export const RpcStub: {
@@ -6123,6 +6126,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
+  export const env: Cloudflare.Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -6041,6 +6041,9 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+export declare namespace Cloudflare {
+  interface Env {}
+}
 export declare namespace TailStream {
   interface Header {
     readonly name: string;

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -6027,6 +6027,9 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+declare namespace Cloudflare {
+  interface Env {}
+}
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;
   export const RpcStub: {
@@ -6125,6 +6128,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
+  export const env: Cloudflare.Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -6043,6 +6043,9 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+export declare namespace Cloudflare {
+  interface Env {}
+}
 export declare namespace TailStream {
   interface Header {
     readonly name: string;

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -6027,6 +6027,9 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+declare namespace Cloudflare {
+  interface Env {}
+}
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;
   export const RpcStub: {
@@ -6125,6 +6128,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
+  export const env: Cloudflare.Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -6043,6 +6043,9 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+export declare namespace Cloudflare {
+  interface Env {}
+}
 export declare namespace TailStream {
   interface Header {
     readonly name: string;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -6108,6 +6108,9 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+declare namespace Cloudflare {
+  interface Env {}
+}
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;
   export const RpcStub: {
@@ -6206,6 +6209,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
+  export const env: Cloudflare.Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -6124,6 +6124,9 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+export declare namespace Cloudflare {
+  interface Env {}
+}
 export declare namespace TailStream {
   interface Header {
     readonly name: string;

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -5964,6 +5964,9 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+declare namespace Cloudflare {
+  interface Env {}
+}
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;
   export const RpcStub: {
@@ -6062,6 +6065,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
+  export const env: Cloudflare.Env;
 }
 declare module "cloudflare:sockets" {
   function _connect(

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -5980,6 +5980,9 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
+export declare namespace Cloudflare {
+  interface Env {}
+}
 export declare namespace TailStream {
   interface Header {
     readonly name: string;


### PR DESCRIPTION
This adds a namespaced type for importable env, `Cloudflare.Env`. This can be provided by a user `.d.ts` file via something like:

```ts
declare namespace Cloudflare {
 	interface Env {
 		string: 'hello world';
 		json: { key: 'value' };
 		SECRET: string;
	}
}
```

This will be generated by `wrangler types` in the near future