### PR TITLE
Repro of issue with RPC & promise pipelining

### DIFF
--- a/samples/promise-pipelining/config.capnp
+++ b/samples/promise-pipelining/config.capnp
@@ -1,0 +1,39 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const tailWorkerExample :Workerd.Config = (
+  services = [
+    (name = "worker-a", worker = .workerA),
+    (name = "proxy-worker", worker = .proxyWorker),
+    (name = "user-worker", worker = .userWorker),
+  ],
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "worker-a" ) ],
+);
+
+const workerA :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker-a.js")
+  ],
+  compatibilityDate = "2025-01-01",
+  bindings = [
+    (name = "PROXY", service = ( name = "proxy-worker")),
+    (name = "USER", service = ( name = "user-worker"))
+
+  ]
+);
+
+const proxyWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "proxy-worker.js")
+  ],
+  compatibilityDate = "2025-01-01",
+  bindings = [
+    (name = "USER", service = ( name = "user-worker"))
+  ]
+);
+
+const userWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "user-worker.js")
+  ],
+  compatibilityDate = "2025-01-01",
+);

--- a/samples/promise-pipelining/proxy-worker.js
+++ b/samples/promise-pipelining/proxy-worker.js
@@ -1,0 +1,7 @@
+import { WorkerEntrypoint } from 'cloudflare:workers';
+export default class Worker extends WorkerEntrypoint {
+  fetch() {}
+  foo(emoji) {
+    return this.env.USER.foo(emoji);
+  }
+}

--- a/samples/promise-pipelining/user-worker.js
+++ b/samples/promise-pipelining/user-worker.js
@@ -1,0 +1,10 @@
+export default {
+  fetch() {},
+  async foo(emoji) {
+    return {
+      bar: {
+        buzz: () => `You made it! ${emoji}`,
+      },
+    };
+  },
+};

--- a/samples/promise-pipelining/worker-a.js
+++ b/samples/promise-pipelining/worker-a.js
@@ -1,0 +1,7 @@
+export default {
+  async fetch(request, env) {
+    const foo = env.PROXY.foo('🐜');
+    const buzzResult = await foo.bar.buzz();
+    return new Response(buzzResult);
+  },
+};


### PR DESCRIPTION
Reproduces what we think is a bug in the runtime, that is related to promise pipelining.

The sample sets up three Workers that service bind in the following way: `worker-a` -> `proxy-worker` -> `user-worker`. The proxy Worker acts as a "proxy", by forwarding the `foo()` RPC calls to the `user-worker` 

```
foo(emoji) {
    return this.env.USER.foo(emoji);
}
```

Running this sample will result in `worker-a` throwing an error: `RPC stub used after being disposed.`. 