### PR TITLE
Fix minor undefined behavior in modules-new-test

### DIFF
--- a/src/workerd/jsg/modules-new-test.c++
+++ b/src/workerd/jsg/modules-new-test.c++
@@ -1588,15 +1588,17 @@ KJ_TEST("Using a registry from multiple threads works") {
   static constexpr auto makeThread = [](ModuleRegistry& registry) {
     auto paf = kj::newPromiseAndCrossThreadFulfiller<void>();
     kj::Thread thread([&registry, fulfiller = kj::mv(paf.fulfiller)] {
-      PREAMBLE([&](Lock& js) {
-        CompilationObserver compilationObserver;
-        auto attached = registry.attachToIsolate(js, compilationObserver);
-        js.tryCatch([&] {
-          auto val = ModuleRegistry::resolve(js, "file:///foo");
-          KJ_ASSERT(val.isNumber());
-        }, [&](Value exception) { js.throwException(kj::mv(exception)); });
-        fulfiller->fulfill();
-      });
+      {
+        PREAMBLE([&](Lock& js) {
+          CompilationObserver compilationObserver;
+          auto attached = registry.attachToIsolate(js, compilationObserver);
+          js.tryCatch([&] {
+            auto val = ModuleRegistry::resolve(js, "file:///foo");
+            KJ_ASSERT(val.isNumber());
+          }, [&](Value exception) { js.throwException(kj::mv(exception)); });
+        });
+      }
+      fulfiller->fulfill();
     });
     thread.detach();
     return kj::mv(paf.promise);


### PR DESCRIPTION
When running under high load, a race condition in modules-new-test.c++ could lead to the V8 isolate being destroyed too late, leading to a member access within null pointer during isolate deallocation.

As suggested by @danlapid