### PR TITLE
Use IoContext::abort more consistently

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1205,8 +1205,7 @@ void IoContext::runFinalizers(Worker::AsyncLock& asyncLock) {
     // Don't bother fulfilling `abortFulfiller` if limits were exceeded because in that case the
     // abort promise will be fulfilled shortly anyway.
     if (limitEnforcer->getLimitsExceeded() == kj::none) {
-      abortFulfiller->reject(
-          JSG_KJ_EXCEPTION(FAILED, Error, "The script will never generate a response."));
+      abort(JSG_KJ_EXCEPTION(FAILED, Error, "The script will never generate a response."));
     }
   }
 

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -337,6 +337,9 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
 
   // Force context abort now.
   void abort(kj::Exception&& e) {
+    if (abortException != kj::none) {
+      return;
+    }
     abortException = kj::cp(e);
     abortFulfiller->reject(kj::mv(e));
   }


### PR DESCRIPTION
Also ignore future aborts if abort has already been called once. This was originally implied by the behavior of fulfiller since calling reject more than once will ignore future calls.