### PR TITLE
Implements decorator for Python event handlers.

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -430,7 +430,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   pythonWorkers @43 :Bool
       $compatEnableFlag("python_workers")
       $pythonSnapshotRelease(pyodide = "0.26.0a2", pyodideRevision = "2024-03-01",
-          packages = "20240829.4", backport = 20,
+          packages = "20240829.4", backport = 21,
           baselineSnapshotHash = "d13ce2f4a0ade2e09047b469874dacf4d071ed3558fec4c26f8d0b99d95f77b5")
       $impliedByAfterDate(name = "pythonWorkersDevPyodide", date = "2000-01-01");
   # Enables Python Workers. Access to this flag is not restricted, instead bundles containing
@@ -683,7 +683,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatEnableFlag("python_workers_20250116")
       $experimental
       $pythonSnapshotRelease(pyodide = "0.27.1", pyodideRevision = "2025-01-16",
-          packages = "20241218", backport = 8,
+          packages = "20241218", backport = 9,
           baselineSnapshotHash = "TODO");
 
   requestCfOverridesCacheRules @72 :Bool


### PR DESCRIPTION
For now a simple decorator that transforms any `request` argument to the Python `Request` class. In the future we will make it do more things like transform the `env` argument for bindings.

Happy to bikeshed the name, I chose `event` because that's what the Rust workers use.

### Test Plan

```
$ bazel run @workerd//src/workerd/server/tests/python:sdk_development@
```