### PR TITLE
CFSQL-1220: Rename the D1 binding class to the previous name to fix vitest tests

### DIFF
--- a/src/cloudflare/internal/d1-api.ts
+++ b/src/cloudflare/internal/d1-api.ts
@@ -94,19 +94,6 @@ class D1Database {
     return this.alwaysPrimarySession.exec(query);
   }
 
-  /**
-   * @deprecated
-   */
-  public async dump(): Promise<ArrayBuffer> {
-    return this.alwaysPrimarySession.dump();
-  }
-}
-
-class D1DatabaseWithSessionAPI extends D1Database {
-  public constructor(fetcher: Fetcher) {
-    super(fetcher);
-  }
-
   public withSession(
     constraintOrBookmark?: D1SessionBookmarkOrConstraint
   ): D1DatabaseSession {
@@ -115,6 +102,13 @@ class D1DatabaseWithSessionAPI extends D1Database {
       constraintOrBookmark = D1_SESSION_CONSTRAINT_FIRST_UNCONSTRAINED;
     }
     return new D1DatabaseSession(this.fetcher, constraintOrBookmark);
+  }
+
+  /**
+   * @deprecated
+   */
+  public async dump(): Promise<ArrayBuffer> {
+    return this.alwaysPrimarySession.dump();
   }
 }
 
@@ -573,5 +567,5 @@ async function toJson<T = unknown>(response: Response): Promise<T> {
 }
 
 export default function makeBinding(env: { fetcher: Fetcher }): D1Database {
-  return new D1DatabaseWithSessionAPI(env.fetcher);
+  return new D1Database(env.fetcher);
 }


### PR DESCRIPTION
The recent changes to make `D1DatabaseWithSessionAPI` the default class returned for the D1 binding (see https://github.com/cloudflare/workerd/pull/3700) broke some vitest pool tests that use the returned class name and were expecting `D1Database`.

This PR just merges `D1DatabaseWithSessionAPI` with its parent class `D1Database` since now we will roll out the `withSession()` method to everyone, and returns the `D1Database` class.