### PR TITLE
Put Request.signal ignoreForSubrequests behaviour behind a compat flag

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -732,4 +732,12 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatDisableFlag("allow_importable_env");
   # When allowed, `import { env } from 'cloudflare:workers'` will provide access
   # to the per-request environment/bindings.
+
+  requestSignalPassthrough @79 :Bool
+      $compatEnableFlag("request_signal_passthrough")
+      $compatDisableFlag("no_request_signal_passthrough")
+      $compatEnableDate("2025-04-14");
+    # When enabled, the AbortSignal of the incoming request is not passed through to subrequests.
+    # As a result, outgoing subrequests will not be cancelled when the incoming request is.
+
 }


### PR DESCRIPTION
When I implemented Request.signal (#3488), we wanted to avoid introducing any surprising new behaviour. As a result, any subrequests created from the incoming request have an `ignoreForSubrequests` flag applied to them. This flag makes it so these outgoing subrequests won't be cancelled even if the incoming request is cancelled. But this is, itself, peculiar behaviour, so this PR adds a compat flag to prevent this behaviour.

- Enable: `abort_signal_not_ignored_for_subrequests`
- Disable/default: `abort_signal_ignored_for_subrequests`

There's a whole lot of negation in this one, so a sanity check on the code would be kindly appreciated.
