### PR TITLE
Break actor on errors that rollback transactions

### DIFF
--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -197,11 +197,11 @@ void ActorSqlite::ExplicitTxn::rollbackImpl() noexcept(false) {
   }
 }
 
-void ActorSqlite::onCriticalError(kj::StringPtr message) {
-  auto exception =
-      kj::Exception(kj::Exception::Type::FAILED, __FILE__, __LINE__, kj::heapString(message));
-  broken.emplace(kj::mv(exception));
-  requireNotBroken();
+void ActorSqlite::onCriticalError(kj::Exception exception) {
+  // If we have already experienced a terminal exception, no need to replace it
+  if (broken == kj::none) {
+    broken.emplace(kj::mv(exception));
+  }
 }
 
 void ActorSqlite::onWrite() {

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -197,19 +197,11 @@ void ActorSqlite::ExplicitTxn::rollbackImpl() noexcept(false) {
   }
 }
 
-void ActorSqlite::onCriticalError(int sqliteErrorCode, kj::StringPtr message) {
-  switch (sqliteErrorCode) {
-    case SQLITE_FULL:
-      JSG_FAIL_REQUIRE(Error, "Database or disk full: ", message);
-    case SQLITE_IOERR:
-      JSG_FAIL_REQUIRE(Error, "Disk I/O error: ", message);
-    case SQLITE_BUSY:
-      JSG_FAIL_REQUIRE(Error, "Database in use by another process: ", message);
-    case SQLITE_NOMEM:
-      JSG_FAIL_REQUIRE(Error, "Out of memory: ", message);
-    case SQLITE_INTERRUPT:
-      JSG_FAIL_REQUIRE(Error, "Out of memory: ", message);
-  }
+void ActorSqlite::onCriticalError(kj::StringPtr message) {
+  auto exception =
+      kj::Exception(kj::Exception::Type::FAILED, __FILE__, __LINE__, kj::heapString(message));
+  broken.emplace(kj::mv(exception));
+  requireNotBroken();
 }
 
 void ActorSqlite::onWrite() {

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -213,7 +213,7 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
 
   void onWrite();
 
-  void onCriticalError(int sqliteErrorCode, kj::StringPtr message);
+  void onCriticalError(kj::StringPtr message);
 
   // Issues a request to the alarm scheduler for the given time, returning a promise that resolves
   // when the request is confirmed.

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -213,7 +213,7 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
 
   void onWrite();
 
-  void onCriticalError(kj::StringPtr message);
+  void onCriticalError(kj::Exception maybeException);
 
   // Issues a request to the alarm scheduler for the given time, returning a promise that resolves
   // when the request is confirmed.

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -213,6 +213,8 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
 
   void onWrite();
 
+  void onCriticalError(int sqliteErrorCode, kj::StringPtr message);
+
   // Issues a request to the alarm scheduler for the given time, returning a promise that resolves
   // when the request is confirmed.
   kj::Promise<void> requestScheduledAlarm(kj::Maybe<kj::Date> requestedTime);

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -213,7 +213,7 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
 
   void onWrite();
 
-  void onCriticalError(kj::Exception maybeException);
+  void onCriticalError(kj::Exception exception);
 
   // Issues a request to the alarm scheduler for the given time, returning a promise that resolves
   // when the request is confirmed.

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -251,6 +251,8 @@ kj_test(
     src = "sqlite-test.c++",
     deps = [
         ":sqlite",
+        "//src/workerd/io:io-gate",
+        "@sqlite3",
     ],
 )
 

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -535,13 +535,13 @@ void SqliteDatabase::notifyWrite() {
 void SqliteDatabase::handleCriticalError(kj::Maybe<int> errorCode, kj::StringPtr errorMessage) {
   KJ_IF_SOME(code, errorCode) {
     if (code == SQLITE_FULL || code == SQLITE_IOERR || code == SQLITE_BUSY ||
-        code == SQLITE_NOMEM || code == SQLITE_INTERRUPT) {
+        code == SQLITE_NOMEM) {
 
       sqlite3* db = &KJ_ASSERT_NONNULL(maybeDb, "previous reset() failed");
       // The transaction was rolledback, re-enabling the auto commit mode, so we should fail
       if (sqlite3_get_autocommit(db) != 0) {
         KJ_IF_SOME(cb, onCriticalErrorCallback) {
-          cb(code, errorMessage);
+          cb(errorMessage);
         }
       }
     }

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -178,9 +178,10 @@ class SqliteDatabase {
     onWriteCallback = kj::mv(callback);
   }
 
-  void handleCriticalError(kj::Maybe<int> errorCode, kj::StringPtr errorMessage);
+  void handleCriticalError(
+      kj::Maybe<int> errorCode, kj::StringPtr errorMessage, kj::Maybe<kj::Exception> exception);
 
-  void onCriticalError(kj::Function<void(kj::StringPtr message)> callback) {
+  void onCriticalError(kj::Function<void(kj::Exception exception)> callback) {
     onCriticalErrorCallback = kj::mv(callback);
   }
 
@@ -294,7 +295,7 @@ class SqliteDatabase {
   kj::Maybe<sqlite3_stmt&> currentStatement;
 
   kj::Maybe<kj::Function<void()>> onWriteCallback;
-  kj::Maybe<kj::Function<void(kj::StringPtr message)>> onCriticalErrorCallback;
+  kj::Maybe<kj::Function<void(kj::Exception)>> onCriticalErrorCallback;
   kj::Maybe<kj::Function<void(SqliteDatabase&)>> afterResetCallback;
 
   kj::List<ResetListener, &ResetListener::link> resetListeners;
@@ -529,8 +530,10 @@ class SqliteDatabase::Query final: private ResetListener {
     }
   }
 
-  void handleCriticalError(kj::Maybe<int> errorCode, kj::StringPtr errorMessage) {
-    return db.handleCriticalError(errorCode, errorMessage);
+  void handleCriticalError(kj::Maybe<int> errorCode,
+      kj::StringPtr errorMessage,
+      kj::Maybe<kj::Exception> maybeException) {
+    return db.handleCriticalError(errorCode, errorMessage, maybeException);
   }
 
  private:

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -180,7 +180,7 @@ class SqliteDatabase {
 
   void handleCriticalError(kj::Maybe<int> errorCode, kj::StringPtr errorMessage);
 
-  void onCriticalError(kj::Function<void(int sqliteErrorCode, kj::StringPtr message)> callback) {
+  void onCriticalError(kj::Function<void(kj::StringPtr message)> callback) {
     onCriticalErrorCallback = kj::mv(callback);
   }
 
@@ -294,7 +294,7 @@ class SqliteDatabase {
   kj::Maybe<sqlite3_stmt&> currentStatement;
 
   kj::Maybe<kj::Function<void()>> onWriteCallback;
-  kj::Maybe<kj::Function<void(int sqliteErrorCode, kj::StringPtr message)>> onCriticalErrorCallback;
+  kj::Maybe<kj::Function<void(kj::StringPtr message)>> onCriticalErrorCallback;
   kj::Maybe<kj::Function<void(SqliteDatabase&)>> afterResetCallback;
 
   kj::List<ResetListener, &ResetListener::link> resetListeners;


### PR DESCRIPTION
We should break output gates and reset actors in the event that we catch the following exceptions because they implicitly roll back any transaction:

[SQLITE_FULL](https://www.sqlite.org/rescode.html#full): database or disk full
[SQLITE_IOERR](https://www.sqlite.org/rescode.html#ioerr): disk I/O error
[SQLITE_BUSY](https://www.sqlite.org/rescode.html#busy): database in use by another process
[SQLITE_NOMEM](https://www.sqlite.org/rescode.html#nomem): out of memory
https://www.sqlite.org/lang_transaction.html#response_to_errors_within_a_transaction