### PR TITLE
feat: add GET_BULK operation to KvOpType enum

### DIFF
--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -91,6 +91,8 @@ kj::Own<kj::HttpClient> KvNamespace::getHttpClient(IoContext& context,
             return "kv_list"_kjc;
           case LimitEnforcer::KvOpType::DELETE:
             return "kv_delete"_kjc;
+          case LimitEnforcer::KvOpType::GET_BULK:
+            return "kv_get_bulk"_kjc;
         }
       }
     }

--- a/src/workerd/io/limit-enforcer.h
+++ b/src/workerd/io/limit-enforcer.h
@@ -111,7 +111,7 @@ class LimitEnforcer {
   // external subrequests.
   virtual void newSubrequest(bool isInHouse) = 0;
 
-  enum class KvOpType { GET, GET_WITH, PUT, LIST, DELETE };
+  enum class KvOpType { GET, GET_WITH, PUT, LIST, DELETE, GET_BULK };
   // Called before starting a KV operation. Throws a JSG exception if the operation should be
   // blocked due to exceeding limits, such as the free tier daily operation limit.
   virtual void newKvRequest(KvOpType op) = 0;


### PR DESCRIPTION
We are trying to merge this one: 
https://github.com/cloudflare/workerd/pull/3744

that needs a fix in an internal repo that needs this enum to be defined first.
This very simple pr just updates that enum to fix this circular dependency.