### PR TITLE
03-18-25 assorted build cleanup

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -23,7 +23,7 @@ COPY .bazel-cache /bazel-disk-cache
 RUN npm install -g pnpm@latest
 RUN pnpm install
 
-RUN pnpm exec bazelisk build --disk_cache=/bazel-disk-cache --config=release_linux //src/workerd/server:workerd
+RUN pnpm exec bazel build --disk_cache=/bazel-disk-cache --config=release_linux //src/workerd/server:workerd
 
 FROM scratch as artifact
 COPY --from=builder /workerd/bazel-bin/src/workerd/server/workerd /workerd-linux-arm64

--- a/build-releases.sh
+++ b/build-releases.sh
@@ -15,7 +15,7 @@ TAG_NAME=$(curl -sL https://api.github.com/repos/cloudflare/workerd/releases/lat
 git checkout $TAG_NAME
 
 # Build macOS binary
-pnpm exec bazelisk build --disk_cache=./.bazel-cache --config=release_macos //src/workerd/server:workerd
+pnpm exec bazel build --disk_cache=./.bazel-cache --config=release_macos //src/workerd/server:workerd
 
 cp bazel-bin/src/workerd/server/workerd ./workerd-darwin-arm64
 

--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -12,6 +12,10 @@ build:ci --verbose_failures
 build:ci --jobs=32
 # Do not check for changes in external repository files, should speed up bazel invocations after the first one
 build:ci --noexperimental_check_external_repository_files
+# Only build runfile trees when needed. Runfile trees are useful for directly invoking bazel-built
+# binaries, but not needed otherwise. Building runfile trees is slow on systems with slow disk I/O,
+# so avoid doing so where we can. https://github.com/bazelbuild/bazel/commit/03246077f948f2790a83520e7dccc2625650e6df
+build:ci --nobuild_runfile_links
 # Rate limit progress updates for smaller logs, default is 0.2 which leads to very frequent updates.
 build:ci --show_progress_rate_limit=1
 # Enable color output

--- a/build/wd_rust_crate.bzl
+++ b/build/wd_rust_crate.bzl
@@ -40,7 +40,10 @@ def rust_cxx_bridge(
         hdrs = [src + ".h"] + hdrs,
         strip_include_prefix = strip_include_prefix,
         include_prefix = include_prefix,
-        linkstatic = True,
+        linkstatic = select({
+            "@platforms//os:windows": True,
+            "//conditions:default": False,
+        }),
         deps = deps,
         visibility = visibility,
     )

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -15,6 +15,7 @@
 -Iexternal/perfetto/include/
 -Iexternal/perfetto/include/perfetto/base/build_configs/bazel/
 -Iexternal/ssl/include
+-Iexternal/ncrypto/include
 -isystembazel-bin/external/sqlite3
 -Isrc
 -isystem/usr/lib/llvm-16/include/c++/v1

--- a/src/rust/gen-compile-cache/BUILD.bazel
+++ b/src/rust/gen-compile-cache/BUILD.bazel
@@ -19,7 +19,10 @@ wd_cc_library(
     hdrs = [
         "cxx-bridge.h",
     ],
-    linkstatic = True,
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
     deps = [
         "//src/rust/cxx-integration",
         "//src/workerd/jsg",

--- a/tools/windows/install-deps.bat
+++ b/tools/windows/install-deps.bat
@@ -57,7 +57,7 @@ winget install "Microsoft.VisualStudio.2022.Community" --override "install --con
 echo.
 echo.* Step 4: Install Python 3.
 winget install Python3 -v 3.12.1 --override "/passive PrependPath=1"
-@rem bazel requires a bazel3.exe binary, create a symlink for it.
+@rem bazel requires a python3.exe binary, create a symlink for it.
 mklink "%LOCALAPPDATA%\Programs\Python\Python312\python3.exe" "%LOCALAPPDATA%\Programs\Python\Python312\python.exe"
 
 echo.


### PR DESCRIPTION
- Only force Rust static linkage on Windows, Linux should still use shared link when possible
- Fix typos, prefer bazel name over bazelisk
- Add ncrypto to compile_flags.txt to fix clangd includes
- Port --nobuild_runfile_links bazel option from downstream, reducing CI I/O overhead.