### PR TITLE
add createSecureContext and checkServerIdentity to node:tls

### DIFF
--- a/src/node/_tls_common.ts
+++ b/src/node/_tls_common.ts
@@ -1,3 +1,28 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 import { createSecureContext } from 'node-internal:internal_tls_common';
 
 export { createSecureContext };

--- a/src/node/_tls_common.ts
+++ b/src/node/_tls_common.ts
@@ -23,7 +23,10 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import { createSecureContext } from 'node-internal:internal_tls_common';
+import {
+  createSecureContext,
+  SecureContext,
+} from 'node-internal:internal_tls_common';
 
-export { createSecureContext };
-export default { createSecureContext };
+export { createSecureContext, SecureContext };
+export default { createSecureContext, SecureContext };

--- a/src/node/_tls_common.ts
+++ b/src/node/_tls_common.ts
@@ -1,0 +1,4 @@
+import { createSecureContext } from 'node-internal:internal_tls_common';
+
+export { createSecureContext };
+export default { createSecureContext };

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -732,9 +732,9 @@ export class ERR_TLS_INVALID_CONTEXT extends NodeTypeError {
 export class ERR_TLS_CERT_ALTNAME_INVALID extends NodeError {
   reason: string;
   host: string;
-  cert: PeerCertificate;
+  cert?: Partial<PeerCertificate> | undefined;
 
-  constructor(reason: string, host: string, cert: PeerCertificate) {
+  constructor(reason: string, host: string, cert?: Partial<PeerCertificate>) {
     super('ERR_TLS_CERT_ALTNAME_INVALID', reason);
     this.reason = reason;
     this.host = host;

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -709,6 +709,12 @@ export class ERR_TLS_HANDSHAKE_TIMEOUT extends NodeError {
   }
 }
 
+export class ERR_TLS_INVALID_CONTEXT extends NodeTypeError {
+  constructor(field: string) {
+    super('ERR_TLS_INVALID_CONTEXT', `${field} must be a SecureContext`);
+  }
+}
+
 export class ConnResetException extends NodeError {
   path?: string | undefined;
   host?: string | undefined;

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -30,6 +30,7 @@
 // TODO(soon): Fill in more of the internal/errors implementation
 
 import { inspect } from 'node-internal:internal_inspect';
+import type { PeerCertificate } from 'node:tls';
 
 const classRegExp = /^([A-Z][a-z0-9]*)+$/;
 
@@ -83,6 +84,19 @@ export class NodeTypeError extends NodeErrorAbstraction implements TypeError {
   constructor(code: string, message: string) {
     super(TypeError.prototype.name, code, message);
     Object.setPrototypeOf(this, TypeError.prototype);
+    this.toString = function () {
+      return `${this.name} [${this.code}]: ${this.message}`;
+    };
+  }
+}
+
+export class NodeSyntaxError
+  extends NodeErrorAbstraction
+  implements SyntaxError
+{
+  constructor(code: string, message: string) {
+    super(SyntaxError.prototype.name, code, message);
+    Object.setPrototypeOf(this, SyntaxError.prototype);
     this.toString = function () {
       return `${this.name} [${this.code}]: ${this.message}`;
     };
@@ -712,6 +726,28 @@ export class ERR_TLS_HANDSHAKE_TIMEOUT extends NodeError {
 export class ERR_TLS_INVALID_CONTEXT extends NodeTypeError {
   constructor(field: string) {
     super('ERR_TLS_INVALID_CONTEXT', `${field} must be a SecureContext`);
+  }
+}
+
+export class ERR_TLS_CERT_ALTNAME_INVALID extends NodeError {
+  reason: string;
+  host: string;
+  cert: PeerCertificate;
+
+  constructor(reason: string, host: string, cert: PeerCertificate) {
+    super('ERR_TLS_CERT_ALTNAME_INVALID', reason);
+    this.reason = reason;
+    this.host = host;
+    this.cert = cert;
+  }
+}
+
+export class ERR_TLS_CERT_ALTNAME_FORMAT extends NodeSyntaxError {
+  constructor() {
+    super(
+      'ERR_TLS_CERT_ALTNAME_FORMAT',
+      'Invalid subject alternative name string'
+    );
   }
 }
 

--- a/src/node/internal/internal_tls.ts
+++ b/src/node/internal/internal_tls.ts
@@ -1,5 +1,31 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 import type { PeerCertificate } from 'node:tls';
 import { isIP } from 'node:internal/internal_net';
+import { default as urlUtil } from 'node-internal:url';
 import {
   ERR_TLS_CERT_ALTNAME_INVALID,
   ERR_TLS_CERT_ALTNAME_FORMAT,
@@ -9,10 +35,6 @@ import {
 // a conservative version that only lowercases A-Z.
 function toLowerCase(c: string): string {
   return String.fromCharCode(32 + c.charCodeAt(0));
-}
-
-function canonicalizeIP(_ip: string): string {
-  throw new Error('Not implemented');
 }
 
 function unfqdn(host: string): string {
@@ -136,7 +158,7 @@ export function checkServerIdentity(
       if (name.startsWith('DNS:')) {
         dnsNames.push(name.slice(4));
       } else if (name.startsWith('IP Address:')) {
-        ips.push(canonicalizeIP(name.slice(11)));
+        ips.push(urlUtil.canonicalizeIp(name.slice(11)));
       }
     });
   }
@@ -147,7 +169,7 @@ export function checkServerIdentity(
   hostname = unfqdn(hostname); // Remove trailing dot for error messages.
 
   if (isIP(hostname)) {
-    valid = ips.includes(canonicalizeIP(hostname));
+    valid = ips.includes(urlUtil.canonicalizeIp(hostname));
     if (!valid)
       reason = `IP: ${hostname} is not in the cert's list: ` + ips.join(', ');
   } else if (dnsNames.length > 0 || subject?.CN) {

--- a/src/node/internal/internal_tls.ts
+++ b/src/node/internal/internal_tls.ts
@@ -1,0 +1,178 @@
+import type { PeerCertificate } from 'node:tls';
+import { isIP } from 'node:internal/internal_net';
+import {
+  ERR_TLS_CERT_ALTNAME_INVALID,
+  ERR_TLS_CERT_ALTNAME_FORMAT,
+} from 'node:internal/internal_errors';
+
+// String#toLowerCase() is locale-sensitive so we use
+// a conservative version that only lowercases A-Z.
+function toLowerCase(c: string): string {
+  return String.fromCharCode(32 + c.charCodeAt(0));
+}
+
+function canonicalizeIP(_ip: string): string {
+  throw new Error('Not implemented');
+}
+
+function unfqdn(host: string): string {
+  return host.replace(/[.]$/, '');
+}
+
+function splitHost(host: string): string[] {
+  return unfqdn(host).replace(/[A-Z]/g, toLowerCase).split('.');
+}
+
+function check(
+  hostParts: string[],
+  pattern: string | undefined | null,
+  wildcards: boolean
+): boolean {
+  // Empty strings, null, undefined, etc. never match.
+  if (!pattern) return false;
+
+  const patternParts = splitHost(pattern);
+
+  if (hostParts.length !== patternParts.length) return false;
+
+  // Pattern has empty components, e.g. "bad..example.com".
+  if (patternParts.includes('')) return false;
+
+  // RFC 6125 allows IDNA U-labels (Unicode) in names but we have no
+  // good way to detect their encoding or normalize them so we simply
+  // reject them.  Control characters and blanks are rejected as well
+  // because nothing good can come from accepting them.
+  const isBad = (s: string): boolean => /[^\u0021-\u007F]/u.test(s);
+  if (patternParts.some(isBad)) return false;
+
+  // Check host parts from right to left first.
+  for (let i = hostParts.length - 1; i > 0; i -= 1) {
+    if (hostParts[i] !== patternParts[i]) return false;
+  }
+
+  const hostSubdomain = hostParts[0] as string;
+  const patternSubdomain = patternParts[0] as string;
+  const patternSubdomainParts = patternSubdomain.split('*', 3) ?? [];
+
+  // Short-circuit when the subdomain does not contain a wildcard.
+  // RFC 6125 does not allow wildcard substitution for components
+  // containing IDNA A-labels (Punycode) so match those verbatim.
+  if (patternSubdomainParts.length === 1 || patternSubdomain.includes('xn--'))
+    return hostSubdomain === patternSubdomain;
+
+  if (!wildcards) return false;
+
+  // More than one wildcard is always wrong.
+  if (patternSubdomainParts.length > 2) return false;
+
+  // *.tld wildcards are not allowed.
+  if (patternParts.length <= 2) return false;
+
+  const { 0: prefix, 1: suffix } = patternSubdomainParts as [string, string];
+
+  if (prefix.length + suffix.length > hostSubdomain.length) return false;
+
+  if (!hostSubdomain.startsWith(prefix)) return false;
+
+  if (!hostSubdomain.endsWith(suffix)) return false;
+
+  return true;
+}
+
+// This pattern is used to determine the length of escaped sequences within
+// the subject alt names string. It allows any valid JSON string literal.
+// This MUST match the JSON specification (ECMA-404 / RFC8259) exactly.
+const jsonStringPattern =
+  // eslint-disable-next-line no-control-regex
+  /^"(?:[^"\\\u0000-\u001f]|\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4}))*"/;
+
+function splitEscapedAltNames(altNames: string): string[] {
+  const result = [];
+  let currentToken = '';
+  let offset = 0;
+  while (offset !== altNames.length) {
+    const nextSep = altNames.indexOf(',', offset);
+    const nextQuote = altNames.indexOf('"', offset);
+    if (nextQuote !== -1 && (nextSep === -1 || nextQuote < nextSep)) {
+      // There is a quote character and there is no separator before the quote.
+      currentToken += altNames.substring(offset, nextQuote);
+      const match = jsonStringPattern.exec(altNames.substring(nextQuote));
+      if (!match) {
+        throw new ERR_TLS_CERT_ALTNAME_FORMAT();
+      }
+      currentToken += JSON.parse(match[0]);
+      offset = nextQuote + match[0].length;
+    } else if (nextSep !== -1) {
+      // There is a separator and no quote before it.
+      currentToken += altNames.substring(offset, nextSep);
+      result.push(currentToken);
+      currentToken = '';
+      offset = nextSep + 2;
+    } else {
+      currentToken += altNames.substring(offset);
+      offset = altNames.length;
+    }
+  }
+  result.push(currentToken);
+  return result;
+}
+
+export function checkServerIdentity(
+  hostname: string,
+  cert: PeerCertificate
+): void {
+  const subject = cert.subject;
+  const altNames = cert.subjectaltname;
+  const dnsNames: string[] = [];
+  const ips: string[] = [];
+
+  hostname = '' + hostname;
+
+  if (altNames) {
+    const splitAltNames = altNames.includes('"')
+      ? splitEscapedAltNames(altNames)
+      : altNames.split(', ');
+    splitAltNames.forEach((name) => {
+      if (name.startsWith('DNS:')) {
+        dnsNames.push(name.slice(4));
+      } else if (name.startsWith('IP Address:')) {
+        ips.push(canonicalizeIP(name.slice(11)));
+      }
+    });
+  }
+
+  let valid = false;
+  let reason = 'Unknown reason';
+
+  hostname = unfqdn(hostname); // Remove trailing dot for error messages.
+
+  if (isIP(hostname)) {
+    valid = ips.includes(canonicalizeIP(hostname));
+    if (!valid)
+      reason = `IP: ${hostname} is not in the cert's list: ` + ips.join(', ');
+  } else if (dnsNames.length > 0 || subject?.CN) {
+    const hostParts = splitHost(hostname);
+    const wildcard = (pattern: string): boolean =>
+      check(hostParts, pattern, true);
+
+    if (dnsNames.length > 0) {
+      valid = dnsNames.some(wildcard);
+      if (!valid)
+        reason = `Host: ${hostname}. is not in the cert's altnames: ${altNames}`;
+    } else {
+      // Match against Common Name only if no supported identifiers exist.
+      const cn = subject.CN;
+
+      if (Array.isArray(cn)) valid = cn.some(wildcard);
+      else if (cn) valid = wildcard(cn);
+
+      if (!valid) reason = `Host: ${hostname}. is not cert's CN: ${cn}`;
+    }
+  } else {
+    reason = 'Cert does not contain a DNS name';
+  }
+
+  if (!valid) {
+    new ERR_TLS_CERT_ALTNAME_INVALID(reason, hostname, cert);
+  }
+}

--- a/src/node/internal/internal_tls_common.ts
+++ b/src/node/internal/internal_tls_common.ts
@@ -1,0 +1,40 @@
+import type tls from 'node:tls';
+import { ERR_OPTION_NOT_IMPLEMENTED } from 'node-internal:internal_errors';
+import { validateInteger } from 'node-internal:validators';
+
+export class SecureContext {
+  public context: unknown = undefined;
+  public constructor(
+    _secureProtocol?: string,
+    secureOptions?: number,
+    minVersion?: string,
+    maxVersion?: string
+  ) {
+    if (minVersion !== undefined) {
+      throw new ERR_OPTION_NOT_IMPLEMENTED('minVersion');
+    }
+    if (maxVersion !== undefined) {
+      throw new ERR_OPTION_NOT_IMPLEMENTED('maxVersion');
+    }
+    if (secureOptions) {
+      validateInteger(secureOptions, 'secureOptions');
+    }
+  }
+}
+
+export function createSecureContext(
+  options: tls.SecureContextOptions = {}
+): SecureContext {
+  const nonNullEntry = Object.entries(options).find(
+    ([_key, value]) => value != null
+  );
+  if (nonNullEntry) {
+    throw new ERR_OPTION_NOT_IMPLEMENTED(`options.${nonNullEntry[0]}`);
+  }
+  return new SecureContext(
+    options.secureProtocol,
+    options.secureOptions,
+    options.minVersion,
+    options.maxVersion
+  );
+}

--- a/src/node/internal/internal_tls_common.ts
+++ b/src/node/internal/internal_tls_common.ts
@@ -1,3 +1,28 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 import type tls from 'node:tls';
 import { ERR_OPTION_NOT_IMPLEMENTED } from 'node-internal:internal_errors';
 import { validateInteger } from 'node-internal:validators';

--- a/src/node/internal/internal_tls_common.ts
+++ b/src/node/internal/internal_tls_common.ts
@@ -27,24 +27,47 @@ import type tls from 'node:tls';
 import { ERR_OPTION_NOT_IMPLEMENTED } from 'node-internal:internal_errors';
 import { validateInteger } from 'node-internal:validators';
 
-export class SecureContext {
-  public context: unknown = undefined;
+// @ts-expect-error TS2323 Redeclare error.
+export declare class SecureContext {
+  public context: unknown;
   public constructor(
     _secureProtocol?: string,
     secureOptions?: number,
     minVersion?: string,
     maxVersion?: string
-  ) {
-    if (minVersion !== undefined) {
-      throw new ERR_OPTION_NOT_IMPLEMENTED('minVersion');
-    }
-    if (maxVersion !== undefined) {
-      throw new ERR_OPTION_NOT_IMPLEMENTED('maxVersion');
-    }
-    if (secureOptions) {
-      validateInteger(secureOptions, 'secureOptions');
-    }
+  );
+}
+
+// This is intentionally not fully compatible with Node.js implementation
+// since creating and customizing an actually equivalent SecureContext is not supported.
+// @ts-expect-error TS2323 Redeclare error.
+export function SecureContext(
+  this: SecureContext,
+  secureProtocol?: string,
+  secureOptions?: number,
+  minVersion?: string,
+  maxVersion?: string
+): SecureContext {
+  if (!(this instanceof SecureContext)) {
+    return new SecureContext(
+      secureProtocol,
+      secureOptions,
+      minVersion,
+      maxVersion
+    );
   }
+  if (minVersion !== undefined) {
+    throw new ERR_OPTION_NOT_IMPLEMENTED('minVersion');
+  }
+  if (maxVersion !== undefined) {
+    throw new ERR_OPTION_NOT_IMPLEMENTED('maxVersion');
+  }
+  if (secureOptions) {
+    validateInteger(secureOptions, 'secureOptions');
+  }
+
+  this.context = undefined;
+  return this;
 }
 
 export function createSecureContext(

--- a/src/node/internal/internal_tls_wrap.ts
+++ b/src/node/internal/internal_tls_wrap.ts
@@ -48,7 +48,9 @@ import {
   ConnResetException,
   ERR_TLS_HANDSHAKE_TIMEOUT,
   ERR_OPTION_NOT_IMPLEMENTED,
+  ERR_TLS_INVALID_CONTEXT,
 } from 'node-internal:internal_errors';
+import { SecureContext } from 'node-internal:internal_tls_common';
 
 const kConnectOptions = Symbol('connect-options');
 const kErrorEmitted = Symbol('error-emitted');
@@ -207,9 +209,11 @@ export function TLSSocket(
     throw new ERR_OPTION_NOT_IMPLEMENTED('options.requestOCSP');
   }
 
-  if (tlsOptions.secureContext !== undefined) {
-    // TODO(soon): Investigate supporting this.
-    throw new ERR_OPTION_NOT_IMPLEMENTED('options.secureContext');
+  if (
+    tlsOptions.secureContext !== undefined &&
+    !(tlsOptions.secureContext instanceof SecureContext)
+  ) {
+    throw new ERR_TLS_INVALID_CONTEXT('context');
   }
 
   if (tlsOptions.pskCallback !== undefined) {
@@ -606,6 +610,7 @@ export function connect(...args: unknown[]): TLSSocket {
     ALPNProtocols: options.ALPNProtocols,
     enableTrace: options.enableTrace,
     highWaterMark: options.highWaterMark,
+    secureContext: options.secureContext,
     // @ts-expect-error TS2412 Type inconsistencies between types/node
     onread: options.onread,
     signal: options.signal,

--- a/src/node/internal/url.d.ts
+++ b/src/node/internal/url.d.ts
@@ -11,3 +11,4 @@ export function format(
   auth: boolean
 ): string;
 export function toASCII(input: string): string;
+export function canonicalizeIp(input: string): string;

--- a/src/node/tls.ts
+++ b/src/node/tls.ts
@@ -23,9 +23,11 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import { createSecureContext } from 'node-internal:internal_tls_common';
 import { TLSSocket, connect } from 'node-internal:internal_tls_wrap';
-export { TLSSocket, connect };
+export { TLSSocket, connect, createSecureContext };
 export default {
   TLSSocket,
   connect,
+  createSecureContext,
 };

--- a/src/node/tls.ts
+++ b/src/node/tls.ts
@@ -23,11 +23,13 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import { checkServerIdentity } from 'node-internal:internal_tls';
 import { createSecureContext } from 'node-internal:internal_tls_common';
 import { TLSSocket, connect } from 'node-internal:internal_tls_wrap';
-export { TLSSocket, connect, createSecureContext };
+export { TLSSocket, connect, createSecureContext, checkServerIdentity };
 export default {
   TLSSocket,
   connect,
   createSecureContext,
+  checkServerIdentity,
 };

--- a/src/node/tls.ts
+++ b/src/node/tls.ts
@@ -24,10 +24,14 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import { checkServerIdentity } from 'node-internal:internal_tls';
-import { createSecureContext } from 'node-internal:internal_tls_common';
+import {
+  createSecureContext,
+  SecureContext,
+} from 'node-internal:internal_tls_common';
 import { TLSSocket, connect } from 'node-internal:internal_tls_wrap';
 export { TLSSocket, connect, createSecureContext, checkServerIdentity };
 export default {
+  SecureContext,
   TLSSocket,
   connect,
   createSecureContext,

--- a/src/rust/net/BUILD.bazel
+++ b/src/rust/net/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//:build/wd_rust_crate.bzl", "wd_rust_crate")
+
+wd_rust_crate(
+    name = "net",
+    cxx_bridge_deps = [],
+    cxx_bridge_src = "lib.rs",
+    test_deps = [],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/rust/cxx-integration",
+    ],
+)

--- a/src/rust/net/lib.rs
+++ b/src/rust/net/lib.rs
@@ -1,0 +1,16 @@
+use std::net::IpAddr;
+use std::str::FromStr;
+
+#[cxx::bridge(namespace = "workerd::rust::net")]
+mod ffi {
+    extern "Rust" {
+        fn canonicalize_ip(input: &str) -> String;
+    }
+}
+
+#[must_use]
+pub fn canonicalize_ip(input: &str) -> String {
+    IpAddr::from_str(input)
+        .map(|ip| ip.to_string())
+        .unwrap_or(input.to_owned())
+}

--- a/src/rust/net/lib.rs
+++ b/src/rust/net/lib.rs
@@ -12,5 +12,5 @@ mod ffi {
 pub fn canonicalize_ip(input: &str) -> String {
     IpAddr::from_str(input)
         .map(|ip| ip.to_string())
-        .unwrap_or(input.to_owned())
+        .unwrap_or(String::new())
 }

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -63,6 +63,8 @@ wd_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/rust/cxx-integration",
+        "//src/rust/net",
         "//src/workerd/io",
         "//src/workerd/io:compatibility-date_capnp",
         "//src/workerd/jsg",

--- a/src/workerd/api/node/tests/net-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-nodejs-test.js
@@ -1108,20 +1108,3 @@ export const testNetRemoteAddress = {
     await promise;
   },
 };
-
-export default {
-  connect({ inbound }) {
-    inbound.cancel();
-    return new ReadableStream({
-      start(c) {
-        c.close();
-      },
-    });
-  },
-};
-
-export const echoServer = {
-  connect({ inbound }) {
-    return inbound.pipeThrough(new IdentityTransformStream());
-  },
-};

--- a/src/workerd/api/node/tests/tls-nodejs-test.js
+++ b/src/workerd/api/node/tests/tls-nodejs-test.js
@@ -23,7 +23,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 import tls from 'node:tls';
-import { strictEqual, ok, rejects, throws } from 'node:assert';
+import { strictEqual, ok, rejects, throws, doesNotThrow } from 'node:assert';
 import { once } from 'node:events';
 import net from 'node:net';
 
@@ -280,5 +280,18 @@ export const tlsConnectGivenSocket = {
     }
 
     await Promise.all(promises);
+  },
+};
+
+export const testSecureContext = {
+  async test() {
+    throws(() => tls.connect({ port: 42, secureContext: {} }), {
+      code: 'ERR_TLS_INVALID_CONTEXT',
+    });
+
+    doesNotThrow(() => {
+      const secureContext = tls.createSecureContext({});
+      tls.connect({ port: 42, secureContext });
+    });
   },
 };

--- a/src/workerd/api/node/tests/tls-nodejs-test.js
+++ b/src/workerd/api/node/tests/tls-nodejs-test.js
@@ -25,6 +25,7 @@
 import tls from 'node:tls';
 import { strictEqual, ok, rejects, throws, doesNotThrow } from 'node:assert';
 import { once } from 'node:events';
+import { inspect } from 'node:util';
 import net from 'node:net';
 
 // Tests are taken from
@@ -292,6 +293,346 @@ export const testSecureContext = {
     doesNotThrow(() => {
       const secureContext = tls.createSecureContext({});
       tls.connect({ port: 42, secureContext });
+    });
+  },
+};
+
+// Tests are taken from
+// https://github.com/nodejs/node/blob/98513884684bccf944d7834f4820b061af41fb36/test/parallel/test-tls-check-server-identity.js
+export const testCheckServerIdentity = {
+  async test() {
+    const tests = [
+      // False-y values.
+      {
+        host: false,
+        cert: { subject: { CN: 'a.com' } },
+        error: "Host: false. is not cert's CN: a.com",
+      },
+      {
+        host: null,
+        cert: { subject: { CN: 'a.com' } },
+        error: "Host: null. is not cert's CN: a.com",
+      },
+      {
+        host: undefined,
+        cert: { subject: { CN: 'a.com' } },
+        error: "Host: undefined. is not cert's CN: a.com",
+      },
+
+      // Basic CN handling
+      { host: 'a.com', cert: { subject: { CN: 'a.com' } } },
+      { host: 'a.com', cert: { subject: { CN: 'A.COM' } } },
+      {
+        host: 'a.com',
+        cert: { subject: { CN: 'b.com' } },
+        error: "Host: a.com. is not cert's CN: b.com",
+      },
+      { host: 'a.com', cert: { subject: { CN: 'a.com.' } } },
+      {
+        host: 'a.com',
+        cert: { subject: { CN: '.a.com' } },
+        error: "Host: a.com. is not cert's CN: .a.com",
+      },
+
+      // IP address in CN. Technically allowed but so rare that we reject
+      // it anyway. If we ever do start allowing them, we should take care
+      // to only allow public (non-internal, non-reserved) IP addresses,
+      // because that's what the spec mandates.
+      {
+        host: '8.8.8.8',
+        cert: { subject: { CN: '8.8.8.8' } },
+        error: "IP: 8.8.8.8 is not in the cert's list: ",
+      },
+
+      // The spec suggests that a "DNS:" Subject Alternative Name containing an
+      // IP address is valid but it seems so suspect that we currently reject it.
+      {
+        host: '8.8.8.8',
+        cert: { subject: { CN: '8.8.8.8' }, subjectaltname: 'DNS:8.8.8.8' },
+        error: "IP: 8.8.8.8 is not in the cert's list: ",
+      },
+
+      // Likewise for "URI:" Subject Alternative Names.
+      // See also https://github.com/nodejs/node/issues/8108.
+      {
+        host: '8.8.8.8',
+        cert: {
+          subject: { CN: '8.8.8.8' },
+          subjectaltname: 'URI:http://8.8.8.8/',
+        },
+        error: "IP: 8.8.8.8 is not in the cert's list: ",
+      },
+
+      // An "IP Address:" Subject Alternative Name however is acceptable.
+      {
+        host: '8.8.8.8',
+        cert: {
+          subject: { CN: '8.8.8.8' },
+          subjectaltname: 'IP Address:8.8.8.8',
+        },
+      },
+
+      // But not when it's a CIDR.
+      {
+        host: '8.8.8.8',
+        cert: {
+          subject: { CN: '8.8.8.8' },
+          subjectaltname: 'IP Address:8.8.8.0/24',
+        },
+        error: "IP: 8.8.8.8 is not in the cert's list: ",
+      },
+
+      // Wildcards in CN
+      { host: 'b.a.com', cert: { subject: { CN: '*.a.com' } } },
+      {
+        host: 'ba.com',
+        cert: { subject: { CN: '*.a.com' } },
+        error: "Host: ba.com. is not cert's CN: *.a.com",
+      },
+      {
+        host: '\n.b.com',
+        cert: { subject: { CN: '*n.b.com' } },
+        error: "Host: \n.b.com. is not cert's CN: *n.b.com",
+      },
+      {
+        host: 'b.a.com',
+        cert: {
+          subjectaltname: 'DNS:omg.com',
+          subject: { CN: '*.a.com' },
+        },
+        error: "Host: b.a.com. is not in the cert's altnames: " + 'DNS:omg.com',
+      },
+      {
+        host: 'b.a.com',
+        cert: { subject: { CN: 'b*b.a.com' } },
+        error: "Host: b.a.com. is not cert's CN: b*b.a.com",
+      },
+
+      // Empty Cert
+      {
+        host: 'a.com',
+        cert: {},
+        error: 'Cert does not contain a DNS name',
+      },
+
+      // Empty Subject w/DNS name
+      {
+        host: 'a.com',
+        cert: {
+          subjectaltname: 'DNS:a.com',
+        },
+      },
+
+      // Empty Subject w/URI name
+      {
+        host: 'a.b.a.com',
+        cert: {
+          subjectaltname: 'URI:http://a.b.a.com/',
+        },
+        error: 'Cert does not contain a DNS name',
+      },
+
+      // Multiple CN fields
+      {
+        host: 'foo.com',
+        cert: {
+          subject: { CN: ['foo.com', 'bar.com'] }, // CN=foo.com; CN=bar.com;
+        },
+      },
+
+      // DNS names and CN
+      {
+        host: 'a.com',
+        cert: {
+          subjectaltname: 'DNS:*',
+          subject: { CN: 'b.com' },
+        },
+        error: "Host: a.com. is not in the cert's altnames: " + 'DNS:*',
+      },
+      {
+        host: 'a.com',
+        cert: {
+          subjectaltname: 'DNS:*.com',
+          subject: { CN: 'b.com' },
+        },
+        error: "Host: a.com. is not in the cert's altnames: " + 'DNS:*.com',
+      },
+      {
+        host: 'a.co.uk',
+        cert: {
+          subjectaltname: 'DNS:*.co.uk',
+          subject: { CN: 'b.com' },
+        },
+      },
+      {
+        host: 'a.com',
+        cert: {
+          subjectaltname: 'DNS:*.a.com',
+          subject: { CN: 'a.com' },
+        },
+        error: "Host: a.com. is not in the cert's altnames: " + 'DNS:*.a.com',
+      },
+      {
+        host: 'a.com',
+        cert: {
+          subjectaltname: 'DNS:*.a.com',
+          subject: { CN: 'b.com' },
+        },
+        error: "Host: a.com. is not in the cert's altnames: " + 'DNS:*.a.com',
+      },
+      {
+        host: 'a.com',
+        cert: {
+          subjectaltname: 'DNS:a.com',
+          subject: { CN: 'b.com' },
+        },
+      },
+      {
+        host: 'a.com',
+        cert: {
+          subjectaltname: 'DNS:A.COM',
+          subject: { CN: 'b.com' },
+        },
+      },
+
+      // DNS names
+      {
+        host: 'a.com',
+        cert: {
+          subjectaltname: 'DNS:*.a.com',
+          subject: {},
+        },
+        error: "Host: a.com. is not in the cert's altnames: " + 'DNS:*.a.com',
+      },
+      {
+        host: 'b.a.com',
+        cert: {
+          subjectaltname: 'DNS:*.a.com',
+          subject: {},
+        },
+      },
+      {
+        host: 'c.b.a.com',
+        cert: {
+          subjectaltname: 'DNS:*.a.com',
+          subject: {},
+        },
+        error:
+          "Host: c.b.a.com. is not in the cert's altnames: " + 'DNS:*.a.com',
+      },
+      {
+        host: 'b.a.com',
+        cert: {
+          subjectaltname: 'DNS:*b.a.com',
+          subject: {},
+        },
+      },
+      {
+        host: 'a-cb.a.com',
+        cert: {
+          subjectaltname: 'DNS:*b.a.com',
+          subject: {},
+        },
+      },
+      {
+        host: 'a.b.a.com',
+        cert: {
+          subjectaltname: 'DNS:*b.a.com',
+          subject: {},
+        },
+        error:
+          "Host: a.b.a.com. is not in the cert's altnames: " + 'DNS:*b.a.com',
+      },
+      // Multiple DNS names
+      {
+        host: 'a.b.a.com',
+        cert: {
+          subjectaltname: 'DNS:*b.a.com, DNS:a.b.a.com',
+          subject: {},
+        },
+      },
+      // URI names
+      {
+        host: 'a.b.a.com',
+        cert: {
+          subjectaltname: 'URI:http://a.b.a.com/',
+          subject: {},
+        },
+        error: 'Cert does not contain a DNS name',
+      },
+      {
+        host: 'a.b.a.com',
+        cert: {
+          subjectaltname: 'URI:http://*.b.a.com/',
+          subject: {},
+        },
+        error: 'Cert does not contain a DNS name',
+      },
+      // IP addresses
+      {
+        host: 'a.b.a.com',
+        cert: {
+          subjectaltname: 'IP Address:127.0.0.1',
+          subject: {},
+        },
+        error: 'Cert does not contain a DNS name',
+      },
+      {
+        host: '127.0.0.1',
+        cert: {
+          subjectaltname: 'IP Address:127.0.0.1',
+          subject: {},
+        },
+      },
+      {
+        host: '127.0.0.2',
+        cert: {
+          subjectaltname: 'IP Address:127.0.0.1',
+          subject: {},
+        },
+        error: "IP: 127.0.0.2 is not in the cert's list: " + '127.0.0.1',
+      },
+      {
+        host: '127.0.0.1',
+        cert: {
+          subjectaltname: 'DNS:a.com',
+          subject: {},
+        },
+        error: "IP: 127.0.0.1 is not in the cert's list: ",
+      },
+      {
+        host: 'localhost',
+        cert: {
+          subjectaltname: 'DNS:a.com',
+          subject: { CN: 'localhost' },
+        },
+        error: "Host: localhost. is not in the cert's altnames: " + 'DNS:a.com',
+      },
+      // IDNA
+      {
+        host: 'xn--bcher-kva.example.com',
+        cert: { subject: { CN: '*.example.com' } },
+      },
+      // RFC 6125, section 6.4.3: "[...] the client SHOULD NOT attempt to match
+      // a presented identifier where the wildcard character is embedded within
+      // an A-label [...]"
+      {
+        host: 'xn--bcher-kva.example.com',
+        cert: { subject: { CN: 'xn--*.example.com' } },
+        error:
+          "Host: xn--bcher-kva.example.com. is not cert's CN: " +
+          'xn--*.example.com',
+      },
+    ];
+
+    tests.forEach(function (test, i) {
+      const err = tls.checkServerIdentity(test.host, test.cert);
+      strictEqual(
+        err?.reason,
+        test.error,
+        `Test# ${i} failed: ${inspect(test)} \n` +
+          `${test.error} != ${err?.reason}`
+      );
     });
   },
 };

--- a/src/workerd/api/node/tests/tls-nodejs-test.js
+++ b/src/workerd/api/node/tests/tls-nodejs-test.js
@@ -294,6 +294,11 @@ export const testSecureContext = {
       const secureContext = tls.createSecureContext({});
       tls.connect({ port: 42, secureContext });
     });
+
+    doesNotThrow(() => {
+      const secureContext = tls.SecureContext();
+      tls.connect({ port: 42, secureContext });
+    });
   },
 };
 

--- a/src/workerd/api/node/url.c++
+++ b/src/workerd/api/node/url.c++
@@ -84,7 +84,7 @@ jsg::JsString UrlUtil::format(
 
 jsg::JsString UrlUtil::canonicalizeIp(jsg::Lock& js, kj::String input) {
   auto out = rust::net::canonicalize_ip({input.begin(), input.size()});
-  return js.str(kj::StringPtr(out.data(), out.size()));
+  return js.str(kj::StringPtr(out.c_str(), out.size()));
 }
 
 }  // namespace workerd::api::node

--- a/src/workerd/api/node/url.c++
+++ b/src/workerd/api/node/url.c++
@@ -5,6 +5,9 @@
 
 #include "ada.h"
 
+#include <workerd/rust/cxx-integration/cxx-bridge.h>
+#include <workerd/rust/net/lib.rs.h>
+
 namespace workerd::api::node {
 
 namespace {
@@ -77,6 +80,11 @@ jsg::JsString UrlUtil::format(
 
   auto href = out->get_href();
   return js.str(kj::StringPtr(href.data(), href.size()));
+}
+
+jsg::JsString UrlUtil::canonicalizeIp(jsg::Lock& js, kj::String input) {
+  auto out = rust::net::canonicalize_ip({input.begin(), input.size()});
+  return js.str(kj::StringPtr(out.data(), out.size()));
 }
 
 }  // namespace workerd::api::node

--- a/src/workerd/api/node/url.c++
+++ b/src/workerd/api/node/url.c++
@@ -82,6 +82,7 @@ jsg::JsString UrlUtil::format(
   return js.str(kj::StringPtr(href.data(), href.size()));
 }
 
+// We return empty string if the input is not a valid IP address.
 jsg::JsString UrlUtil::canonicalizeIp(jsg::Lock& js, kj::String input) {
   auto out = rust::net::canonicalize_ip({input.begin(), input.size()});
   return js.str(kj::StringPtr(out.c_str(), out.size()));

--- a/src/workerd/api/node/url.h
+++ b/src/workerd/api/node/url.h
@@ -19,10 +19,12 @@ class UrlUtil final: public jsg::Object {
   jsg::JsString format(
       jsg::Lock& js, kj::String href, bool hash, bool unicode, bool search, bool auth);
   jsg::JsString toASCII(jsg::Lock& js, kj::String url);
+  jsg::JsString canonicalizeIp(jsg::Lock& js, kj::String input);
 
   JSG_RESOURCE_TYPE(UrlUtil) {
     JSG_METHOD(domainToUnicode);
     JSG_METHOD(domainToASCII);
+    JSG_METHOD(canonicalizeIp);
 
     // Legacy APIs
     JSG_METHOD(format);


### PR DESCRIPTION
The following pull-request:

- Adds createSecureContext() function but only supports options with no values. this is done to unblock mysql2 from working in cloudflare workers where no custom ssl options are passed.
- Adds checkServerIdentity() for validating a PeerCertificate according to the host.