### PR TITLE
Updated 'cloudflare:pipelines' module binding & transformation defaults for generic params

### DIFF
--- a/types/defines/pipelines.d.ts
+++ b/types/defines/pipelines.d.ts
@@ -2,19 +2,18 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 declare module "cloudflare:pipelines" {
-  export abstract class PipelineTransformationEntrypoint<Env = unknown, I extends PipelineRecord = {}, O extends PipelineRecord = {}> {
-    /**
-     * run recieves an array of PipelineRecord which can be
-     * mutated and returned to the pipeline
-     * @param records Incoming records from the pipeline to be transformed
-     * @param metadata Information about the specific pipeline calling the transformation entrypoint
-     * @returns A promise containing the transformed PipelineRecord array
-     */
-
+  export abstract class PipelineTransformationEntrypoint<Env = unknown, I extends PipelineRecord = PipelineRecord, O extends PipelineRecord = PipelineRecord> {
     protected env: Env;
     protected ctx: ExecutionContext;
     constructor(ctx: ExecutionContext, env: Env);
 
+    /**
+     * run recieves an array of PipelineRecord which can be
+     * transformed and returned to the pipeline
+     * @param records Incoming records from the pipeline to be transformed
+     * @param metadata Information about the specific pipeline calling the transformation entrypoint
+     * @returns A promise containing the transformed PipelineRecord array
+     */
     public run(records: I[], metadata: PipelineBatchMetadata): Promise<O[]>;
   }
   export type PipelineRecord = Record<string, unknown>
@@ -22,7 +21,7 @@ declare module "cloudflare:pipelines" {
     pipelineId: string;
     pipelineName: string;
   }
-  export interface Pipeline<T extends PipelineRecord> {
+  export interface Pipeline<T extends PipelineRecord = PipelineRecord> {
     /**
      * The Pipeline interface represents the type of a binding to a Pipeline
      *

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -5818,19 +5818,19 @@ declare module "assets:*" {
 declare module "cloudflare:pipelines" {
   export abstract class PipelineTransformationEntrypoint<
     Env = unknown,
-    I extends PipelineRecord = {},
-    O extends PipelineRecord = {},
+    I extends PipelineRecord = PipelineRecord,
+    O extends PipelineRecord = PipelineRecord,
   > {
+    protected env: Env;
+    protected ctx: ExecutionContext;
+    constructor(ctx: ExecutionContext, env: Env);
     /**
      * run recieves an array of PipelineRecord which can be
-     * mutated and returned to the pipeline
+     * transformed and returned to the pipeline
      * @param records Incoming records from the pipeline to be transformed
      * @param metadata Information about the specific pipeline calling the transformation entrypoint
      * @returns A promise containing the transformed PipelineRecord array
      */
-    protected env: Env;
-    protected ctx: ExecutionContext;
-    constructor(ctx: ExecutionContext, env: Env);
     public run(records: I[], metadata: PipelineBatchMetadata): Promise<O[]>;
   }
   export type PipelineRecord = Record<string, unknown>;
@@ -5838,7 +5838,7 @@ declare module "cloudflare:pipelines" {
     pipelineId: string;
     pipelineName: string;
   };
-  export interface Pipeline<T extends PipelineRecord> {
+  export interface Pipeline<T extends PipelineRecord = PipelineRecord> {
     /**
      * The Pipeline interface represents the type of a binding to a Pipeline
      *

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -5844,19 +5844,19 @@ declare module "assets:*" {
 declare module "cloudflare:pipelines" {
   export abstract class PipelineTransformationEntrypoint<
     Env = unknown,
-    I extends PipelineRecord = {},
-    O extends PipelineRecord = {},
+    I extends PipelineRecord = PipelineRecord,
+    O extends PipelineRecord = PipelineRecord,
   > {
+    protected env: Env;
+    protected ctx: ExecutionContext;
+    constructor(ctx: ExecutionContext, env: Env);
     /**
      * run recieves an array of PipelineRecord which can be
-     * mutated and returned to the pipeline
+     * transformed and returned to the pipeline
      * @param records Incoming records from the pipeline to be transformed
      * @param metadata Information about the specific pipeline calling the transformation entrypoint
      * @returns A promise containing the transformed PipelineRecord array
      */
-    protected env: Env;
-    protected ctx: ExecutionContext;
-    constructor(ctx: ExecutionContext, env: Env);
     public run(records: I[], metadata: PipelineBatchMetadata): Promise<O[]>;
   }
   export type PipelineRecord = Record<string, unknown>;
@@ -5864,7 +5864,7 @@ declare module "cloudflare:pipelines" {
     pipelineId: string;
     pipelineName: string;
   };
-  export interface Pipeline<T extends PipelineRecord> {
+  export interface Pipeline<T extends PipelineRecord = PipelineRecord> {
     /**
      * The Pipeline interface represents the type of a binding to a Pipeline
      *

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -5869,19 +5869,19 @@ declare module "assets:*" {
 declare module "cloudflare:pipelines" {
   export abstract class PipelineTransformationEntrypoint<
     Env = unknown,
-    I extends PipelineRecord = {},
-    O extends PipelineRecord = {},
+    I extends PipelineRecord = PipelineRecord,
+    O extends PipelineRecord = PipelineRecord,
   > {
+    protected env: Env;
+    protected ctx: ExecutionContext;
+    constructor(ctx: ExecutionContext, env: Env);
     /**
      * run recieves an array of PipelineRecord which can be
-     * mutated and returned to the pipeline
+     * transformed and returned to the pipeline
      * @param records Incoming records from the pipeline to be transformed
      * @param metadata Information about the specific pipeline calling the transformation entrypoint
      * @returns A promise containing the transformed PipelineRecord array
      */
-    protected env: Env;
-    protected ctx: ExecutionContext;
-    constructor(ctx: ExecutionContext, env: Env);
     public run(records: I[], metadata: PipelineBatchMetadata): Promise<O[]>;
   }
   export type PipelineRecord = Record<string, unknown>;
@@ -5889,7 +5889,7 @@ declare module "cloudflare:pipelines" {
     pipelineId: string;
     pipelineName: string;
   };
-  export interface Pipeline<T extends PipelineRecord> {
+  export interface Pipeline<T extends PipelineRecord = PipelineRecord> {
     /**
      * The Pipeline interface represents the type of a binding to a Pipeline
      *

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -5870,19 +5870,19 @@ declare module "assets:*" {
 declare module "cloudflare:pipelines" {
   export abstract class PipelineTransformationEntrypoint<
     Env = unknown,
-    I extends PipelineRecord = {},
-    O extends PipelineRecord = {},
+    I extends PipelineRecord = PipelineRecord,
+    O extends PipelineRecord = PipelineRecord,
   > {
+    protected env: Env;
+    protected ctx: ExecutionContext;
+    constructor(ctx: ExecutionContext, env: Env);
     /**
      * run recieves an array of PipelineRecord which can be
-     * mutated and returned to the pipeline
+     * transformed and returned to the pipeline
      * @param records Incoming records from the pipeline to be transformed
      * @param metadata Information about the specific pipeline calling the transformation entrypoint
      * @returns A promise containing the transformed PipelineRecord array
      */
-    protected env: Env;
-    protected ctx: ExecutionContext;
-    constructor(ctx: ExecutionContext, env: Env);
     public run(records: I[], metadata: PipelineBatchMetadata): Promise<O[]>;
   }
   export type PipelineRecord = Record<string, unknown>;
@@ -5890,7 +5890,7 @@ declare module "cloudflare:pipelines" {
     pipelineId: string;
     pipelineName: string;
   };
-  export interface Pipeline<T extends PipelineRecord> {
+  export interface Pipeline<T extends PipelineRecord = PipelineRecord> {
     /**
      * The Pipeline interface represents the type of a binding to a Pipeline
      *

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -5874,19 +5874,19 @@ declare module "assets:*" {
 declare module "cloudflare:pipelines" {
   export abstract class PipelineTransformationEntrypoint<
     Env = unknown,
-    I extends PipelineRecord = {},
-    O extends PipelineRecord = {},
+    I extends PipelineRecord = PipelineRecord,
+    O extends PipelineRecord = PipelineRecord,
   > {
+    protected env: Env;
+    protected ctx: ExecutionContext;
+    constructor(ctx: ExecutionContext, env: Env);
     /**
      * run recieves an array of PipelineRecord which can be
-     * mutated and returned to the pipeline
+     * transformed and returned to the pipeline
      * @param records Incoming records from the pipeline to be transformed
      * @param metadata Information about the specific pipeline calling the transformation entrypoint
      * @returns A promise containing the transformed PipelineRecord array
      */
-    protected env: Env;
-    protected ctx: ExecutionContext;
-    constructor(ctx: ExecutionContext, env: Env);
     public run(records: I[], metadata: PipelineBatchMetadata): Promise<O[]>;
   }
   export type PipelineRecord = Record<string, unknown>;
@@ -5894,7 +5894,7 @@ declare module "cloudflare:pipelines" {
     pipelineId: string;
     pipelineName: string;
   };
-  export interface Pipeline<T extends PipelineRecord> {
+  export interface Pipeline<T extends PipelineRecord = PipelineRecord> {
     /**
      * The Pipeline interface represents the type of a binding to a Pipeline
      *

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -5879,19 +5879,19 @@ declare module "assets:*" {
 declare module "cloudflare:pipelines" {
   export abstract class PipelineTransformationEntrypoint<
     Env = unknown,
-    I extends PipelineRecord = {},
-    O extends PipelineRecord = {},
+    I extends PipelineRecord = PipelineRecord,
+    O extends PipelineRecord = PipelineRecord,
   > {
+    protected env: Env;
+    protected ctx: ExecutionContext;
+    constructor(ctx: ExecutionContext, env: Env);
     /**
      * run recieves an array of PipelineRecord which can be
-     * mutated and returned to the pipeline
+     * transformed and returned to the pipeline
      * @param records Incoming records from the pipeline to be transformed
      * @param metadata Information about the specific pipeline calling the transformation entrypoint
      * @returns A promise containing the transformed PipelineRecord array
      */
-    protected env: Env;
-    protected ctx: ExecutionContext;
-    constructor(ctx: ExecutionContext, env: Env);
     public run(records: I[], metadata: PipelineBatchMetadata): Promise<O[]>;
   }
   export type PipelineRecord = Record<string, unknown>;
@@ -5899,7 +5899,7 @@ declare module "cloudflare:pipelines" {
     pipelineId: string;
     pipelineName: string;
   };
-  export interface Pipeline<T extends PipelineRecord> {
+  export interface Pipeline<T extends PipelineRecord = PipelineRecord> {
     /**
      * The Pipeline interface represents the type of a binding to a Pipeline
      *

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -5881,19 +5881,19 @@ declare module "assets:*" {
 declare module "cloudflare:pipelines" {
   export abstract class PipelineTransformationEntrypoint<
     Env = unknown,
-    I extends PipelineRecord = {},
-    O extends PipelineRecord = {},
+    I extends PipelineRecord = PipelineRecord,
+    O extends PipelineRecord = PipelineRecord,
   > {
+    protected env: Env;
+    protected ctx: ExecutionContext;
+    constructor(ctx: ExecutionContext, env: Env);
     /**
      * run recieves an array of PipelineRecord which can be
-     * mutated and returned to the pipeline
+     * transformed and returned to the pipeline
      * @param records Incoming records from the pipeline to be transformed
      * @param metadata Information about the specific pipeline calling the transformation entrypoint
      * @returns A promise containing the transformed PipelineRecord array
      */
-    protected env: Env;
-    protected ctx: ExecutionContext;
-    constructor(ctx: ExecutionContext, env: Env);
     public run(records: I[], metadata: PipelineBatchMetadata): Promise<O[]>;
   }
   export type PipelineRecord = Record<string, unknown>;
@@ -5901,7 +5901,7 @@ declare module "cloudflare:pipelines" {
     pipelineId: string;
     pipelineName: string;
   };
-  export interface Pipeline<T extends PipelineRecord> {
+  export interface Pipeline<T extends PipelineRecord = PipelineRecord> {
     /**
      * The Pipeline interface represents the type of a binding to a Pipeline
      *

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -5881,19 +5881,19 @@ declare module "assets:*" {
 declare module "cloudflare:pipelines" {
   export abstract class PipelineTransformationEntrypoint<
     Env = unknown,
-    I extends PipelineRecord = {},
-    O extends PipelineRecord = {},
+    I extends PipelineRecord = PipelineRecord,
+    O extends PipelineRecord = PipelineRecord,
   > {
+    protected env: Env;
+    protected ctx: ExecutionContext;
+    constructor(ctx: ExecutionContext, env: Env);
     /**
      * run recieves an array of PipelineRecord which can be
-     * mutated and returned to the pipeline
+     * transformed and returned to the pipeline
      * @param records Incoming records from the pipeline to be transformed
      * @param metadata Information about the specific pipeline calling the transformation entrypoint
      * @returns A promise containing the transformed PipelineRecord array
      */
-    protected env: Env;
-    protected ctx: ExecutionContext;
-    constructor(ctx: ExecutionContext, env: Env);
     public run(records: I[], metadata: PipelineBatchMetadata): Promise<O[]>;
   }
   export type PipelineRecord = Record<string, unknown>;
@@ -5901,7 +5901,7 @@ declare module "cloudflare:pipelines" {
     pipelineId: string;
     pipelineName: string;
   };
-  export interface Pipeline<T extends PipelineRecord> {
+  export interface Pipeline<T extends PipelineRecord = PipelineRecord> {
     /**
      * The Pipeline interface represents the type of a binding to a Pipeline
      *

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -5962,19 +5962,19 @@ declare module "assets:*" {
 declare module "cloudflare:pipelines" {
   export abstract class PipelineTransformationEntrypoint<
     Env = unknown,
-    I extends PipelineRecord = {},
-    O extends PipelineRecord = {},
+    I extends PipelineRecord = PipelineRecord,
+    O extends PipelineRecord = PipelineRecord,
   > {
+    protected env: Env;
+    protected ctx: ExecutionContext;
+    constructor(ctx: ExecutionContext, env: Env);
     /**
      * run recieves an array of PipelineRecord which can be
-     * mutated and returned to the pipeline
+     * transformed and returned to the pipeline
      * @param records Incoming records from the pipeline to be transformed
      * @param metadata Information about the specific pipeline calling the transformation entrypoint
      * @returns A promise containing the transformed PipelineRecord array
      */
-    protected env: Env;
-    protected ctx: ExecutionContext;
-    constructor(ctx: ExecutionContext, env: Env);
     public run(records: I[], metadata: PipelineBatchMetadata): Promise<O[]>;
   }
   export type PipelineRecord = Record<string, unknown>;
@@ -5982,7 +5982,7 @@ declare module "cloudflare:pipelines" {
     pipelineId: string;
     pipelineName: string;
   };
-  export interface Pipeline<T extends PipelineRecord> {
+  export interface Pipeline<T extends PipelineRecord = PipelineRecord> {
     /**
      * The Pipeline interface represents the type of a binding to a Pipeline
      *

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -5818,19 +5818,19 @@ declare module "assets:*" {
 declare module "cloudflare:pipelines" {
   export abstract class PipelineTransformationEntrypoint<
     Env = unknown,
-    I extends PipelineRecord = {},
-    O extends PipelineRecord = {},
+    I extends PipelineRecord = PipelineRecord,
+    O extends PipelineRecord = PipelineRecord,
   > {
+    protected env: Env;
+    protected ctx: ExecutionContext;
+    constructor(ctx: ExecutionContext, env: Env);
     /**
      * run recieves an array of PipelineRecord which can be
-     * mutated and returned to the pipeline
+     * transformed and returned to the pipeline
      * @param records Incoming records from the pipeline to be transformed
      * @param metadata Information about the specific pipeline calling the transformation entrypoint
      * @returns A promise containing the transformed PipelineRecord array
      */
-    protected env: Env;
-    protected ctx: ExecutionContext;
-    constructor(ctx: ExecutionContext, env: Env);
     public run(records: I[], metadata: PipelineBatchMetadata): Promise<O[]>;
   }
   export type PipelineRecord = Record<string, unknown>;
@@ -5838,7 +5838,7 @@ declare module "cloudflare:pipelines" {
     pipelineId: string;
     pipelineName: string;
   };
-  export interface Pipeline<T extends PipelineRecord> {
+  export interface Pipeline<T extends PipelineRecord = PipelineRecord> {
     /**
      * The Pipeline interface represents the type of a binding to a Pipeline
      *


### PR DESCRIPTION
@penalosa pointed out that the type generated is quite complex by wrangler types where there is no default generic param on the pipelines binding. Adding a default here and then making it consistent on PipelineTransformationEntrypoint
https://github.com/cloudflare/workers-sdk/pull/8528#discussion_r2002193772

Also moved the comment about the run method on to the correct line

@oliy @cmackenzie1 