### PR TITLE
Reproduce HTMLRewriter stack overflow using JS code + quick fix

### DIFF
--- a/src/workerd/api/tests/htmlrewriter-test.js
+++ b/src/workerd/api/tests/htmlrewriter-test.js
@@ -968,6 +968,10 @@ export const svgNamespace = {
   },
 };
 
+// This test is commented out because it will cause a stack overflow in workerd if enabled.
+// It is included for reference.
+
+/*
 export const stackOverflow1 = {
   // One big handler
   async test() {
@@ -991,7 +995,7 @@ export const stackOverflow1 = {
       await reader.read();
     }
   },
-};
+};*/
 
 export const stackOverflow2 = {
   // Many small handlers

--- a/src/workerd/api/tests/htmlrewriter-test.js
+++ b/src/workerd/api/tests/htmlrewriter-test.js
@@ -967,3 +967,52 @@ export const svgNamespace = {
     strictEqual(namespace, 'http://www.w3.org/2000/svg');
   },
 };
+
+export const stackOverflow1 = {
+  // One big handler
+  async test() {
+    const promiseDepth = 128 * 100;
+    const numReads = 2;
+    const input = new Response('<div></div>');
+
+    const output = new HTMLRewriter()
+      .onDocument({
+        end(e) {
+          for (let i = 0; i < promiseDepth; i++) {
+            e.append('<div></div>', { html: true });
+          }
+        },
+      })
+      .transform(input);
+
+    // Begin reading but do not fully consume
+    const reader = output.body.getReader();
+    for (let i = 0; i < numReads; i++) {
+      await reader.read();
+    }
+  },
+};
+
+export const stackOverflow2 = {
+  // Many small handlers
+  async test() {
+    const promiseDepth = 128 * 100;
+    const numReads = promiseDepth;
+
+    const input = new Response('<div></div>'.repeat(promiseDepth));
+
+    const output = new HTMLRewriter()
+      .on('div', {
+        element(e) {
+          e.append('<div></div>', { html: true });
+        },
+      })
+      .transform(input);
+
+    // Begin reading but do not fully consume
+    const reader = output.body.getReader();
+    for (let i = 0; i < numReads; i++) {
+      await reader.read();
+    }
+  },
+};


### PR DESCRIPTION
This PR adds two tests that cause a stack overflow in workerd:
- `stackOverflow1`: A single replacement function generates a lot of output bytes
- `stackOverflow2`: The replacement function runs many times

I've also implemented the idea we came up with to limit the depth of the promise chain: waiting on `writePromise` after every thunk call. As expected, this fixes `stackOverflow2` but not `stackOverflow1`. Therefore I commented out `stackOverflow1` for now.

I'd like to merge this quick fix to see if the sentry errors go away, but it's not a full fix. The next step would be to implement an internal buffer in `Rewriter` and flush that to the `inner` (output sink) after each thunk call.

There's also another potential situation where a ReadableStream is used to provide the replacement. In another PR, we could implement back pressure to avoid too much data from being buffered at once.