### PR TITLE
Migrate from deprecated v8::Write interfaces

### DIFF
--- a/src/workerd/api/encoding.c++
+++ b/src/workerd/api/encoding.c++
@@ -467,11 +467,10 @@ namespace {
 TextEncoder::EncodeIntoResult encodeIntoImpl(
     jsg::Lock& js, jsg::JsString input, jsg::BufferSource& buffer) {
   auto result = input.writeInto(js, buffer.asArrayPtr().asChars(),
-      static_cast<jsg::JsString::WriteOptions>(
-          jsg::JsString::NO_NULL_TERMINATION | jsg::JsString::REPLACE_INVALID_UTF8));
+      jsg::JsString::WriteOptions::REPLACE_INVALID_UTF8);
   return TextEncoder::EncodeIntoResult{
-    .read = result.read,
-    .written = result.written,
+    .read = static_cast<int>(result.read),
+    .written = static_cast<int>(result.written),
   };
 }
 }  // namespace

--- a/src/workerd/api/node/buffer.c++
+++ b/src/workerd/api/node/buffer.c++
@@ -83,8 +83,7 @@ uint32_t writeInto(jsg::Lock& js,
     return 0;
   }
 
-  static constexpr jsg::JsString::WriteOptions flags = static_cast<jsg::JsString::WriteOptions>(
-      jsg::JsString::NO_NULL_TERMINATION | jsg::JsString::REPLACE_INVALID_UTF8);
+  static constexpr jsg::JsString::WriteOptions flags = jsg::JsString::WriteOptions::REPLACE_INVALID_UTF8;
 
   switch (encoding) {
     case Encoding::ASCII:
@@ -120,10 +119,7 @@ uint32_t writeInto(jsg::Lock& js,
     }
     case Encoding::HEX: {
       KJ_STACK_ARRAY(kj::byte, buf, string.length(js), 1024, 536870888);
-      static constexpr jsg::JsString::WriteOptions options =
-          static_cast<jsg::JsString::WriteOptions>(
-              jsg::JsString::NO_NULL_TERMINATION | jsg::JsString::REPLACE_INVALID_UTF8);
-      string.writeInto(js, buf, options);
+      string.writeInto(js, buf, flags);
       auto backing = decodeHexTruncated(js, buf, false);
       auto bytes = backing.asArrayPtr();
       auto amountToCopy = kj::min(bytes.size(), dest.size());
@@ -140,8 +136,7 @@ jsg::BackingStore decodeStringImpl(
   auto length = string.length(js);
   if (length == 0) return jsg::BackingStore::alloc<v8::Uint8Array>(js, 0);
 
-  static constexpr jsg::JsString::WriteOptions options = static_cast<jsg::JsString::WriteOptions>(
-      jsg::JsString::NO_NULL_TERMINATION | jsg::JsString::REPLACE_INVALID_UTF8);
+  static constexpr jsg::JsString::WriteOptions options = jsg::JsString::REPLACE_INVALID_UTF8;
 
   switch (encoding) {
     case Encoding::ASCII:

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -291,8 +291,7 @@ JsString::WriteIntoStatus JsString::writeInto(
     Lock& js, kj::ArrayPtr<char> buffer, WriteOptions options) const {
   WriteIntoStatus result = {0, 0};
   if (buffer.size() > 0) {
-    result.written =
-        inner->WriteUtf8(js.v8Isolate, buffer.begin(), buffer.size(), &result.read, options);
+    result.written = inner->WriteUtf8V2(js.v8Isolate, buffer.begin(), buffer.size(), options, &result.read);
   }
   return result;
 }
@@ -301,7 +300,9 @@ JsString::WriteIntoStatus JsString::writeInto(
     Lock& js, kj::ArrayPtr<uint16_t> buffer, WriteOptions options) const {
   WriteIntoStatus result = {0, 0};
   if (buffer.size() > 0) {
-    result.written = inner->Write(js.v8Isolate, buffer.begin(), 0, buffer.size(), options);
+    result.written = kj::min(buffer.size(), length(js));
+    inner->WriteV2(js.v8Isolate, 0, result.written, buffer.begin(), options);
+    result.read = length(js);
   }
   return result;
 }
@@ -310,7 +311,9 @@ JsString::WriteIntoStatus JsString::writeInto(
     Lock& js, kj::ArrayPtr<kj::byte> buffer, WriteOptions options) const {
   WriteIntoStatus result = {0, 0};
   if (buffer.size() > 0) {
-    result.written = inner->WriteOneByte(js.v8Isolate, buffer.begin(), 0, buffer.size(), options);
+    result.written = kj::min(buffer.size(), length(js));
+    inner->WriteOneByteV2(js.v8Isolate, 0, kj::min(length(js), buffer.size()), buffer.begin(), options);
+    result.read = length(js);
   }
   return result;
 }

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -250,10 +250,9 @@ class JsString final: public JsBase<v8::String, JsString> {
   static JsString concat(Lock& js, const JsString& one, const JsString& two) KJ_WARN_UNUSED_RESULT;
 
   enum WriteOptions {
-    NONE = v8::String::NO_OPTIONS,
-    NO_NULL_TERMINATION = v8::String::NO_NULL_TERMINATION,
-    PRESERVE_ONE_BYTE_NULL = v8::String::PRESERVE_ONE_BYTE_NULL,
-    REPLACE_INVALID_UTF8 = v8::String::REPLACE_INVALID_UTF8,
+    NONE = v8::String::WriteFlags::kNone,
+    NULL_TERMINATION = v8::String::WriteFlags::kNullTerminate,
+    REPLACE_INVALID_UTF8 = v8::String::WriteFlags::kReplaceInvalidUtf8,
   };
 
   template <typename T>
@@ -262,9 +261,9 @@ class JsString final: public JsBase<v8::String, JsString> {
 
   struct WriteIntoStatus {
     // The number of elements (e.g. char, byte, uint16_t) read from this string.
-    int read;
+    size_t read;
     // The number of elements (e.g. char, byte, uint16_t) written to the buffer.
-    int written;
+    size_t written;
   };
   WriteIntoStatus writeInto(
       Lock& js, kj::ArrayPtr<char> buffer, WriteOptions options = WriteOptions::NONE) const;


### PR DESCRIPTION
We need this v8 patch to be merged for this to work: https://chromium-review.googlesource.com/c/v8/v8/+/6369297