### PR TITLE
[o11y] Consolidate adding trace events for legacy and streaming tail workers

### DIFF
--- a/src/workerd/api/hibernatable-web-socket.c++
+++ b/src/workerd/api/hibernatable-web-socket.c++
@@ -94,15 +94,11 @@ kj::Promise<WorkerInterface::CustomEvent::Result> HibernatableWebSocketCustomEve
     KJ_UNREACHABLE;
   };
 
-  KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
-    t.setEventInfo(context.now(), tracing::HibernatableWebSocketEventInfo(getType()));
-  }
-
   // TODO(streaming-tail-workers): Support Hibernate and Resume events properly.
-  context.getMetrics().reportTailEvent(context.getInvocationSpanContext(), [&] {
-    return tracing::Onset(
-        tracing::HibernatableWebSocketEventInfo(getType()), tracing::Onset::WorkerInfo{}, kj::none);
-  });
+  KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
+    t.setEventInfo(incomingRequest->getContext().getInvocationSpanContext(), context.now(),
+        tracing::HibernatableWebSocketEventInfo(getType()));
+  }
 
   auto outcomeObserver = kj::rc<OutcomeObserver>(
       kj::addRef(incomingRequest->getMetrics()), context.getInvocationSpanContext());

--- a/src/workerd/api/node/diagnostics-channel.c++
+++ b/src/workerd/api/node/diagnostics-channel.c++
@@ -37,7 +37,8 @@ void Channel::publish(jsg::Lock& js, jsg::Value message) {
         Error,
         "Diagnostic events cannot be published with SharedArrayBuffer or "
         "transferred ArrayBuffer instances");
-    tracer.addDiagnosticChannelEvent(context.now(), name.toString(js), kj::mv(tmp.data));
+    tracer.addDiagnosticChannelEvent(
+        context.getInvocationSpanContext(), context.now(), name.toString(js), kj::mv(tmp.data));
   }
 }
 

--- a/src/workerd/api/node/util.c++
+++ b/src/workerd/api/node/util.c++
@@ -274,8 +274,9 @@ namespace {
     // JSG_KJ_EXCEPTION would not give us that, and we only want to incur the cost
     // of creating and capturing the stack when we actually need it.
     auto ex = KJ_ASSERT_NONNULL(js.error(message).tryCast<jsg::JsObject>());
-    tracer.addException(ioContext.now(), ex.get(js, "name"_kj).toString(js),
-        ex.get(js, "message"_kj).toString(js), ex.get(js, "stack"_kj).toString(js));
+    tracer.addException(ioContext.getInvocationSpanContext(), ioContext.now(),
+        ex.get(js, "name"_kj).toString(js), ex.get(js, "message"_kj).toString(js),
+        ex.get(js, "stack"_kj).toString(js));
     ioContext.abort(js.exceptionToKj(ex));
   } else {
     ioContext.abort(JSG_KJ_EXCEPTION(FAILED, Error, kj::mv(message)));

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -556,13 +556,9 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEventImpl::run(
   }
 
   KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
-    t.setEventInfo(context.now(), tracing::QueueEventInfo(kj::str(queueName), batchSize));
+    t.setEventInfo(context.getInvocationSpanContext(), context.now(),
+        tracing::QueueEventInfo(kj::str(queueName), batchSize));
   }
-
-  context.getMetrics().reportTailEvent(context.getInvocationSpanContext(), [&] {
-    return tracing::Onset(tracing::QueueEventInfo(kj::mv(queueName), batchSize),
-        tracing::Onset::WorkerInfo{}, kj::none);
-  });
 
   auto outcomeObserver = kj::rc<OutcomeObserver>(
       kj::addRef(incomingRequest->getMetrics()), context.getInvocationSpanContext());

--- a/src/workerd/api/tail-worker-test.js
+++ b/src/workerd/api/tail-worker-test.js
@@ -30,23 +30,23 @@ export const test = {
 
     let expected = [
       // http-test.js: fetch and scheduled events get reported correctly.
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"http://placeholder/body-length","cfJson":"{}","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"http://placeholder/body-length","cfJson":"{}","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"http://placeholder/body-length","cfJson":"","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"http://placeholder/body-length","cfJson":"","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
       '{"type":"onset","info":{"type":"scheduled","scheduledTime":"1970-01-01T00:00:00.000Z","cron":""}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
       '{"type":"onset","info":{"type":"scheduled","scheduledTime":"1970-01-01T00:00:00.000Z","cron":"* * * * 30"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://placeholder/not-found","cfJson":"{}","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://placeholder/web-socket","cfJson":"{}","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://placeholder/not-found","cfJson":"","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://placeholder/web-socket","cfJson":"","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"exception","name":"Error","message":"The script will never generate a response."}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // queue-test.js: queue events
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"{}","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"{}","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"{}","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"{}","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/batch","cfJson":"{}","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-delay-secs","value":"2"},{"name":"x-msg-fmt","value":"text"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"bytes"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"json"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"v8"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/batch","cfJson":"","headers":[{"name":"cf-queue-batch-bytes","value":"31"},{"name":"cf-queue-batch-count","value":"4"},{"name":"cf-queue-largest-msg","value":"13"},{"name":"content-type","value":"application/json"},{"name":"x-msg-delay-secs","value":"2"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
       '{"type":"onset","info":{"type":"queue","queueName":"test-queue","batchSize":5}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // actor-alarms-test.js: alarm events
-      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://foo/test","cfJson":"{}","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://foo/test","cfJson":"","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
       '{"type":"onset","info":{"type":"alarm","scheduledTime":"1970-01-01T00:00:00.000Z"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // legacy tail worker, triggered via alarm test. It would appear that these being recorded
@@ -58,8 +58,8 @@ export const test = {
       '{"type":"onset","info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // tests/websocket-hibernation.js: hibernatableWebSocket events
-      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://example.com/","cfJson":"{}","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://example.com/hibernation","cfJson":"{}","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://example.com/","cfJson":"","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://example.com/hibernation","cfJson":"","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
       '{"type":"onset","info":{"type":"hibernatableWebSocket","info":{"type":"message"}}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
       '{"type":"onset","info":{"type":"hibernatableWebSocket","info":{"type":"close","code":1000,"wasClean":true}}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
     ];

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -653,12 +653,10 @@ kj::Promise<void> sendTracesToExportedHandler(kj::Own<IoContext::IncomingRequest
   auto& metrics = incomingRequest->getMetrics();
 
   KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
-    t.setEventInfo(context.now(), tracing::TraceEventInfo(traces));
+    t.setEventInfo(
+        context.getInvocationSpanContext(), context.now(), tracing::TraceEventInfo(traces));
   }
 
-  metrics.reportTailEvent(context.getInvocationSpanContext(), [&] {
-    return tracing::Onset(tracing::TraceEventInfo(traces), tracing::Onset::WorkerInfo{}, kj::none);
-  });
   auto outcomeObserver = kj::rc<OutcomeObserver>(
       kj::addRef(incomingRequest->getMetrics()), context.getInvocationSpanContext());
 

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -1833,12 +1833,9 @@ class EntrypointJsRpcTarget final: public JsRpcTargetBase {
 
   void addTrace(jsg::Lock& js, IoContext& ioctx, kj::StringPtr methodName) override {
     KJ_IF_SOME(t, tracer) {
-      t->setEventInfo(ioctx.now(), tracing::JsRpcEventInfo(kj::str(methodName)));
+      t->setEventInfo(ioctx.getInvocationSpanContext(), ioctx.now(),
+          tracing::JsRpcEventInfo(kj::str(methodName)));
     }
-    ioctx.getMetrics().reportTailEvent(ioctx.getInvocationSpanContext(), [&] {
-      return tracing::Onset(
-          tracing::JsRpcEventInfo(kj::str(methodName)), tracing::Onset::WorkerInfo{}, kj::none);
-    });
   }
 };
 

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -128,21 +128,6 @@ class RequestObserver: public kj::Refcounted {
     return nullptr;
   }
 
-  // If the worker is configured to support streaming tail workers, reportTailEvent
-  // will forward the given event on to the collection of streaming tail workers
-  // that are configured with this observer. Otherwise, this is a non-op.
-  virtual void reportTailEvent(
-      const tracing::InvocationSpanContext& context, tracing::TailEvent::Event&& event) {
-    reportTailEvent(context, [event = kj::mv(event)]() mutable { return kj::mv(event); });
-  }
-
-  // If the worker is configured to support streaming tail workers, reportTailEvent
-  // will forward the event returned by the callback on to the collection of streaming
-  // fail workers that are configured with this observer. The callback will only be
-  // invoked if there are tail workers.
-  virtual void reportTailEvent(const tracing::InvocationSpanContext& context,
-      kj::FunctionParam<tracing::TailEvent::Event()> fn) {}
-
   // Reports the outcome event to any configured streaming tail workers, signalizing that the
   // request has completed and will not produce any more events.
   virtual void reportOutcome(const tracing::InvocationSpanContext& context) {}

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -289,7 +289,7 @@ void tracing::FetchEventInfo::copyTo(rpc::Trace::FetchEventInfo::Builder builder
   }
 }
 
-tracing::FetchEventInfo tracing::FetchEventInfo::clone() {
+tracing::FetchEventInfo tracing::FetchEventInfo::clone() const {
   return FetchEventInfo(
       method, kj::str(url), kj::str(cfJson), KJ_MAP(h, headers) { return h.clone(); });
 }
@@ -307,7 +307,7 @@ void tracing::FetchEventInfo::Header::copyTo(rpc::Trace::FetchEventInfo::Header:
   builder.setValue(value);
 }
 
-tracing::FetchEventInfo::Header tracing::FetchEventInfo::Header::clone() {
+tracing::FetchEventInfo::Header tracing::FetchEventInfo::Header::clone() const {
   return Header(kj::str(name), kj::str(value));
 }
 
@@ -320,7 +320,7 @@ void tracing::JsRpcEventInfo::copyTo(rpc::Trace::JsRpcEventInfo::Builder builder
   builder.setMethodName(methodName);
 }
 
-tracing::JsRpcEventInfo tracing::JsRpcEventInfo::clone() {
+tracing::JsRpcEventInfo tracing::JsRpcEventInfo::clone() const {
   return JsRpcEventInfo(kj::str(methodName));
 }
 
@@ -337,7 +337,7 @@ void tracing::ScheduledEventInfo::copyTo(rpc::Trace::ScheduledEventInfo::Builder
   builder.setCron(cron);
 }
 
-tracing::ScheduledEventInfo tracing::ScheduledEventInfo::clone() {
+tracing::ScheduledEventInfo tracing::ScheduledEventInfo::clone() const {
   return ScheduledEventInfo(scheduledTime, kj::str(cron));
 }
 
@@ -350,7 +350,7 @@ void tracing::AlarmEventInfo::copyTo(rpc::Trace::AlarmEventInfo::Builder builder
   builder.setScheduledTimeMs((scheduledTime - kj::UNIX_EPOCH) / kj::MILLISECONDS);
 }
 
-tracing::AlarmEventInfo tracing::AlarmEventInfo::clone() {
+tracing::AlarmEventInfo tracing::AlarmEventInfo::clone() const {
   return AlarmEventInfo(scheduledTime);
 }
 
@@ -367,7 +367,7 @@ void tracing::QueueEventInfo::copyTo(rpc::Trace::QueueEventInfo::Builder builder
   builder.setBatchSize(batchSize);
 }
 
-tracing::QueueEventInfo tracing::QueueEventInfo::clone() {
+tracing::QueueEventInfo tracing::QueueEventInfo::clone() const {
   return QueueEventInfo(kj::str(queueName), batchSize);
 }
 
@@ -387,7 +387,7 @@ void tracing::EmailEventInfo::copyTo(rpc::Trace::EmailEventInfo::Builder builder
   builder.setRawSize(rawSize);
 }
 
-tracing::EmailEventInfo tracing::EmailEventInfo::clone() {
+tracing::EmailEventInfo tracing::EmailEventInfo::clone() const {
   return EmailEventInfo(kj::str(mailFrom), kj::str(rcptTo), rawSize);
 }
 
@@ -419,7 +419,7 @@ void tracing::TraceEventInfo::copyTo(rpc::Trace::TraceEventInfo::Builder builder
   }
 }
 
-tracing::TraceEventInfo tracing::TraceEventInfo::clone() {
+tracing::TraceEventInfo tracing::TraceEventInfo::clone() const {
   return TraceEventInfo(KJ_MAP(item, traces) { return item.clone(); });
 }
 
@@ -436,7 +436,7 @@ void tracing::TraceEventInfo::TraceItem::copyTo(
   }
 }
 
-tracing::TraceEventInfo::TraceItem tracing::TraceEventInfo::TraceItem::clone() {
+tracing::TraceEventInfo::TraceItem tracing::TraceEventInfo::TraceItem::clone() const {
   return TraceItem(scriptName.map([](auto& name) { return kj::str(name); }));
 }
 
@@ -458,7 +458,7 @@ void tracing::DiagnosticChannelEvent::copyTo(rpc::Trace::DiagnosticChannelEvent:
   builder.setMessage(message);
 }
 
-tracing::DiagnosticChannelEvent tracing::DiagnosticChannelEvent::clone() {
+tracing::DiagnosticChannelEvent tracing::DiagnosticChannelEvent::clone() const {
   return DiagnosticChannelEvent(timestamp, kj::str(channel), kj::heapArray<kj::byte>(message));
 }
 
@@ -486,7 +486,7 @@ void tracing::HibernatableWebSocketEventInfo::copyTo(
   }
 }
 
-tracing::HibernatableWebSocketEventInfo tracing::HibernatableWebSocketEventInfo::clone() {
+tracing::HibernatableWebSocketEventInfo tracing::HibernatableWebSocketEventInfo::clone() const {
   KJ_SWITCH_ONEOF(type) {
     KJ_CASE_ONEOF(_, Message) {
       return HibernatableWebSocketEventInfo(Message{});
@@ -533,7 +533,7 @@ void tracing::FetchResponseInfo::copyTo(rpc::Trace::FetchResponseInfo::Builder b
   builder.setStatusCode(statusCode);
 }
 
-tracing::FetchResponseInfo tracing::FetchResponseInfo::clone() {
+tracing::FetchResponseInfo tracing::FetchResponseInfo::clone() const {
   return FetchResponseInfo(statusCode);
 }
 
@@ -691,7 +691,7 @@ void tracing::Log::copyTo(rpc::Trace::Log::Builder builder) {
   builder.setMessage(message);
 }
 
-tracing::Log tracing::Log::clone() {
+tracing::Log tracing::Log::clone() const {
   return Log(timestamp, logLevel, kj::str(message));
 }
 
@@ -704,7 +704,7 @@ void tracing::Exception::copyTo(rpc::Trace::Exception::Builder builder) {
   }
 }
 
-tracing::Exception tracing::Exception::clone() {
+tracing::Exception tracing::Exception::clone() const {
   return Exception(timestamp, kj::str(name), kj::str(message),
       stack.map([](auto& stack) { return kj::str(stack); }));
 }
@@ -833,7 +833,7 @@ void tracing::Resume::copyTo(rpc::Trace::Resume::Builder builder) {
   }
 }
 
-tracing::Resume tracing::Resume::clone() {
+tracing::Resume tracing::Resume::clone() const {
   return Resume(attachment.map([](auto& attach) { return kj::heapArray<kj::byte>(attach); }));
 }
 
@@ -843,7 +843,7 @@ tracing::Hibernate::Hibernate(rpc::Trace::Hibernate::Reader reader) {}
 
 void tracing::Hibernate::copyTo(rpc::Trace::Hibernate::Builder builder) {}
 
-tracing::Hibernate tracing::Hibernate::clone() {
+tracing::Hibernate tracing::Hibernate::clone() const {
   return Hibernate();
 }
 
@@ -916,7 +916,7 @@ void tracing::Attribute::copyTo(rpc::Trace::Attribute::Builder builder) {
   }
 }
 
-tracing::Attribute tracing::Attribute::clone() {
+tracing::Attribute tracing::Attribute::clone() const {
   constexpr auto cloneValue = [](const Value& value) -> Value {
     KJ_SWITCH_ONEOF(value) {
       KJ_CASE_ONEOF(str, kj::String) {
@@ -981,7 +981,7 @@ void tracing::Return::copyTo(rpc::Trace::Return::Builder builder) {
   }
 }
 
-tracing::Return tracing::Return::clone() {
+tracing::Return tracing::Return::clone() const {
   KJ_IF_SOME(i, info) {
     KJ_SWITCH_ONEOF(i) {
       KJ_CASE_ONEOF(fetch, tracing::FetchResponseInfo) {
@@ -1057,9 +1057,9 @@ void tracing::SpanOpen::copyTo(rpc::Trace::SpanOpen::Builder builder) {
   }
 }
 
-tracing::SpanOpen tracing::SpanOpen::clone() {
-  constexpr auto cloneInfo = [](kj::Maybe<Info>& info) -> kj::Maybe<tracing::SpanOpen::Info> {
-    return info.map([](Info& info) -> tracing::SpanOpen::Info {
+tracing::SpanOpen tracing::SpanOpen::clone() const {
+  constexpr auto cloneInfo = [](const kj::Maybe<Info>& info) -> kj::Maybe<tracing::SpanOpen::Info> {
+    return info.map([](const Info& info) -> tracing::SpanOpen::Info {
       KJ_SWITCH_ONEOF(info) {
         KJ_CASE_ONEOF(fetch, tracing::FetchEventInfo) {
           return fetch.clone();
@@ -1089,7 +1089,7 @@ void tracing::SpanClose::copyTo(rpc::Trace::SpanClose::Builder builder) {
   builder.setOutcome(outcome);
 }
 
-tracing::SpanClose tracing::SpanClose::clone() {
+tracing::SpanClose tracing::SpanClose::clone() const {
   return SpanClose(outcome);
 }
 
@@ -1141,9 +1141,9 @@ void tracing::Link::copyTo(rpc::Trace::Link::Builder builder) {
   ctx.setSpanId(spanId.getId());
 }
 
-tracing::Link tracing::Link::clone() {
+tracing::Link tracing::Link::clone() const {
   return Link(
-      label.map([](kj::String& str) { return kj::str(str); }), traceId, invocationId, spanId);
+      label.map([](const kj::String& str) { return kj::str(str); }), traceId, invocationId, spanId);
 }
 
 namespace {
@@ -1328,43 +1328,44 @@ tracing::Onset::WorkerInfo tracing::Onset::WorkerInfo::clone() const {
   };
 }
 
-tracing::Onset tracing::Onset::clone() {
-  constexpr auto cloneInfo = [](Info& info) -> tracing::Onset::Info {
-    KJ_SWITCH_ONEOF(info) {
-      KJ_CASE_ONEOF(fetch, FetchEventInfo) {
-        return fetch.clone();
-      }
-      KJ_CASE_ONEOF(jsrpc, JsRpcEventInfo) {
-        return jsrpc.clone();
-      }
-      KJ_CASE_ONEOF(scheduled, ScheduledEventInfo) {
-        return scheduled.clone();
-      }
-      KJ_CASE_ONEOF(alarm, AlarmEventInfo) {
-        return alarm.clone();
-      }
-      KJ_CASE_ONEOF(queue, QueueEventInfo) {
-        return queue.clone();
-      }
-      KJ_CASE_ONEOF(email, EmailEventInfo) {
-        return email.clone();
-      }
-      KJ_CASE_ONEOF(trace, TraceEventInfo) {
-        return trace.clone();
-      }
-      KJ_CASE_ONEOF(hws, HibernatableWebSocketEventInfo) {
-        return hws.clone();
-      }
-      KJ_CASE_ONEOF(resume, Resume) {
-        return resume.clone();
-      }
-      KJ_CASE_ONEOF(custom, CustomEventInfo) {
-        return CustomEventInfo();
-      }
+tracing::EventInfo tracing::cloneEventInfo(const tracing::EventInfo& info) {
+  KJ_SWITCH_ONEOF(info) {
+    KJ_CASE_ONEOF(fetch, FetchEventInfo) {
+      return fetch.clone();
     }
-    KJ_UNREACHABLE;
-  };
-  return Onset(cloneInfo(info), workerInfo.clone(), trigger.map([](TriggerContext& ctx) {
+    KJ_CASE_ONEOF(jsrpc, JsRpcEventInfo) {
+      return jsrpc.clone();
+    }
+    KJ_CASE_ONEOF(scheduled, ScheduledEventInfo) {
+      return scheduled.clone();
+    }
+    KJ_CASE_ONEOF(alarm, AlarmEventInfo) {
+      return alarm.clone();
+    }
+    KJ_CASE_ONEOF(queue, QueueEventInfo) {
+      return queue.clone();
+    }
+    KJ_CASE_ONEOF(email, EmailEventInfo) {
+      return email.clone();
+    }
+    KJ_CASE_ONEOF(trace, TraceEventInfo) {
+      return trace.clone();
+    }
+    KJ_CASE_ONEOF(hws, HibernatableWebSocketEventInfo) {
+      return hws.clone();
+    }
+    KJ_CASE_ONEOF(resume, Resume) {
+      return resume.clone();
+    }
+    KJ_CASE_ONEOF(custom, CustomEventInfo) {
+      return CustomEventInfo();
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+tracing::Onset tracing::Onset::clone() const {
+  return Onset(cloneEventInfo(info), workerInfo.clone(), trigger.map([](const TriggerContext& ctx) {
     return TriggerContext(ctx.traceId, ctx.invocationId, ctx.spanId);
   }));
 }
@@ -1385,7 +1386,7 @@ void tracing::Outcome::copyTo(rpc::Trace::Outcome::Builder builder) {
   builder.setWallTime(wallTime / kj::MILLISECONDS);
 }
 
-tracing::Outcome tracing::Outcome::clone() {
+tracing::Outcome tracing::Outcome::clone() const {
   return Outcome(outcome, cpuTime, wallTime);
 }
 
@@ -1521,8 +1522,8 @@ void tracing::TailEvent::copyTo(rpc::Trace::TailEvent::Builder builder) {
   }
 }
 
-tracing::TailEvent tracing::TailEvent::clone() {
-  constexpr auto cloneEvent = [](Event& event) -> Event {
+tracing::TailEvent tracing::TailEvent::clone() const {
+  constexpr auto cloneEvent = [](const Event& event) -> Event {
     KJ_SWITCH_ONEOF(event) {
       KJ_CASE_ONEOF(onset, Onset) {
         return onset.clone();

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -290,7 +290,7 @@ struct FetchEventInfo final {
     kj::String value;
 
     void copyTo(rpc::Trace::FetchEventInfo::Header::Builder builder);
-    Header clone();
+    Header clone() const;
 
     JSG_MEMORY_INFO(Header) {
       tracker.trackField("name", name);
@@ -305,7 +305,7 @@ struct FetchEventInfo final {
   kj::Array<Header> headers;
 
   void copyTo(rpc::Trace::FetchEventInfo::Builder builder);
-  FetchEventInfo clone();
+  FetchEventInfo clone() const;
 };
 
 // Describes a jsrpc request
@@ -319,7 +319,7 @@ struct JsRpcEventInfo final {
   kj::String methodName;
 
   void copyTo(rpc::Trace::JsRpcEventInfo::Builder builder);
-  JsRpcEventInfo clone();
+  JsRpcEventInfo clone() const;
 };
 
 // Describes a scheduled request
@@ -334,7 +334,7 @@ struct ScheduledEventInfo final {
   kj::String cron;
 
   void copyTo(rpc::Trace::ScheduledEventInfo::Builder builder);
-  ScheduledEventInfo clone();
+  ScheduledEventInfo clone() const;
 };
 
 // Describes a Durable Object alarm request
@@ -348,7 +348,7 @@ struct AlarmEventInfo final {
   kj::Date scheduledTime;
 
   void copyTo(rpc::Trace::AlarmEventInfo::Builder builder);
-  AlarmEventInfo clone();
+  AlarmEventInfo clone() const;
 };
 
 // Describes a queue worker request
@@ -363,7 +363,7 @@ struct QueueEventInfo final {
   uint32_t batchSize;
 
   void copyTo(rpc::Trace::QueueEventInfo::Builder builder);
-  QueueEventInfo clone();
+  QueueEventInfo clone() const;
 };
 
 // Describes an email request
@@ -379,7 +379,7 @@ struct EmailEventInfo final {
   uint32_t rawSize;
 
   void copyTo(rpc::Trace::EmailEventInfo::Builder builder);
-  EmailEventInfo clone();
+  EmailEventInfo clone() const;
 };
 
 // Describes a legacy tail worker request
@@ -403,13 +403,13 @@ struct TraceEventInfo final {
     kj::Maybe<kj::String> scriptName;
 
     void copyTo(rpc::Trace::TraceEventInfo::TraceItem::Builder builder);
-    TraceItem clone();
+    TraceItem clone() const;
   };
 
   kj::Vector<TraceItem> traces;
 
   void copyTo(rpc::Trace::TraceEventInfo::Builder builder);
-  TraceEventInfo clone();
+  TraceEventInfo clone() const;
 };
 
 // Describes a hibernatable web socket event
@@ -432,7 +432,7 @@ struct HibernatableWebSocketEventInfo final {
   Type type;
 
   void copyTo(rpc::Trace::HibernatableWebSocketEventInfo::Builder builder);
-  HibernatableWebSocketEventInfo clone();
+  HibernatableWebSocketEventInfo clone() const;
   static Type readFrom(rpc::Trace::HibernatableWebSocketEventInfo::Reader reader);
 };
 
@@ -453,7 +453,7 @@ struct FetchResponseInfo final {
   uint16_t statusCode;
 
   void copyTo(rpc::Trace::FetchResponseInfo::Builder builder);
-  FetchResponseInfo clone();
+  FetchResponseInfo clone() const;
 };
 
 // Describes an event published using the node:diagnostics_channel API
@@ -469,7 +469,7 @@ struct DiagnosticChannelEvent final {
   kj::Array<kj::byte> message;
 
   void copyTo(rpc::Trace::DiagnosticChannelEvent::Builder builder);
-  DiagnosticChannelEvent clone();
+  DiagnosticChannelEvent clone() const;
 };
 
 // Describes a log event
@@ -488,7 +488,7 @@ struct Log final {
   kj::String message;
 
   void copyTo(rpc::Trace::Log::Builder builder);
-  Log clone();
+  Log clone() const;
 };
 
 // Describes an exception event
@@ -509,7 +509,7 @@ struct Exception final {
   kj::Maybe<kj::String> stack;
 
   void copyTo(rpc::Trace::Exception::Builder builder);
-  Exception clone();
+  Exception clone() const;
 };
 
 // Used to indicate that a previously hibernated tail stream is being resumed.
@@ -523,7 +523,7 @@ struct Resume final {
   kj::Maybe<kj::Array<kj::byte>> attachment;
 
   void copyTo(rpc::Trace::Resume::Builder builder);
-  Resume clone();
+  Resume clone() const;
 };
 
 // Used to indicate that a tail stream is being hibernated.
@@ -535,7 +535,7 @@ struct Hibernate final {
   ~Hibernate() noexcept(false) = default;
 
   void copyTo(rpc::Trace::Hibernate::Builder builder);
-  Hibernate clone();
+  Hibernate clone() const;
 };
 
 // EventInfo types are used to describe the onset of an invocation. The FetchEventInfo
@@ -550,6 +550,8 @@ using EventInfo = kj::OneOf<FetchEventInfo,
     HibernatableWebSocketEventInfo,
     Resume,
     CustomEventInfo>;
+
+EventInfo cloneEventInfo(const EventInfo& info);
 
 template <typename T>
 concept AttributeValue = kj::isSameType<kj::String, T>() || kj::isSameType<bool, T>() ||
@@ -586,7 +588,7 @@ struct Attribute final {
   Values value;
 
   void copyTo(rpc::Trace::Attribute::Builder builder);
-  Attribute clone();
+  Attribute clone() const;
 };
 using CustomInfo = kj::Array<Attribute>;
 
@@ -608,7 +610,7 @@ struct Return final {
   kj::Maybe<Info> info = kj::none;
 
   void copyTo(rpc::Trace::Return::Builder builder);
-  Return clone();
+  Return clone() const;
 };
 
 // A Link mark is used to establish a link from one span to another.
@@ -627,7 +629,7 @@ struct Link final {
   SpanId spanId;
 
   void copyTo(rpc::Trace::Link::Builder builder);
-  Link clone();
+  Link clone() const;
 };
 
 using Mark = kj::OneOf<DiagnosticChannelEvent, Exception, Log, Return, Link, kj::Array<Attribute>>;
@@ -649,7 +651,7 @@ struct SpanOpen final {
   kj::Maybe<Info> info = kj::none;
 
   void copyTo(rpc::Trace::SpanOpen::Builder builder);
-  SpanOpen clone();
+  SpanOpen clone() const;
 };
 
 // Marks the closing of a child span within the streaming tail session.
@@ -665,7 +667,7 @@ struct SpanClose final {
   EventOutcome outcome = EventOutcome::OK;
 
   void copyTo(rpc::Trace::SpanClose::Builder builder);
-  SpanClose clone();
+  SpanClose clone() const;
 };
 
 // The Onset and Outcome event types are special forms of SpanOpen and
@@ -714,7 +716,7 @@ struct Onset final {
   kj::Maybe<TriggerContext> trigger;
 
   void copyTo(rpc::Trace::Onset::Builder builder);
-  Onset clone();
+  Onset clone() const;
 };
 
 struct Outcome final {
@@ -729,7 +731,7 @@ struct Outcome final {
   kj::Duration wallTime;
 
   void copyTo(rpc::Trace::Outcome::Builder builder);
-  Outcome clone();
+  Outcome clone() const;
 };
 
 // A streaming tail worker receives a series of Tail Events. Tail events always
@@ -765,7 +767,7 @@ struct TailEvent final {
   Event event;
 
   void copyTo(rpc::Trace::TailEvent::Builder builder);
-  TailEvent clone();
+  TailEvent clone() const;
 };
 }  // namespace tracing
 


### PR DESCRIPTION
First commit is very simple refactoring to facilitate cloning trace events. Second commit removes reportTailEvent() and instead uses WorkerTracer to report events to the tail stream writer. This means duplication in adding trace events is abstracted away.

- Note that Outcome event reporting is not folded into this class at present.
- Note that this can cause the legacy trace size limit to the Streaming model – this will be cleaned up once we transmit all event data over the stream layer.
- As a side effect, streaming tail worker now supports headers in fetch handler onset events, update tests accordingly
- This will make it easy to support Return and SpanOpen/SpanClose events.