### PR TITLE
add missing translatePeerCertificate function

### DIFF
--- a/src/node/_tls_common.ts
+++ b/src/node/_tls_common.ts
@@ -26,7 +26,8 @@
 import {
   createSecureContext,
   SecureContext,
+  translatePeerCertificate,
 } from 'node-internal:internal_tls_common';
 
-export { createSecureContext, SecureContext };
-export default { createSecureContext, SecureContext };
+export { createSecureContext, SecureContext, translatePeerCertificate };
+export default { createSecureContext, SecureContext, translatePeerCertificate };


### PR DESCRIPTION
This is the last remaining function provided in "_tls_common" module. We can now remove the polyfill from it.

cc @vicb would you mind updating the polyfill for `_tls_common`?