### PR TITLE
HTMLRewriter: no more write promise chaining

### DIFF
--- a/src/workerd/api/tests/htmlrewriter-test.js
+++ b/src/workerd/api/tests/htmlrewriter-test.js
@@ -968,12 +968,7 @@ export const svgNamespace = {
   },
 };
 
-// This test is commented out because it will cause a stack overflow in workerd if enabled.
-// It is included for reference.
-
-/*
-export const stackOverflow1 = {
-  // One big handler
+export const handlerPerformingManySmallWrites = {
   async test() {
     const promiseDepth = 128 * 100;
     const numReads = 2;
@@ -995,9 +990,9 @@ export const stackOverflow1 = {
       await reader.read();
     }
   },
-};*/
+};
 
-export const stackOverflow2 = {
+export const hugeNumberOfHandlersForAnElement = {
   // Many small handlers
   async test() {
     const promiseDepth = 128 * 100;


### PR DESCRIPTION
This PR follows up on #3758 to provide a more solid fix. 

The chained `writePromise` is no longer used. Instead, every time lol_html generates output, we store it in `outputBuffer` (just a `kj::Vector`). `outputBuffer` is flushed to the output sink after each handler thunk. If more than 128 MB accumulates in `outputBuffer`, we poison the `Rewriter`, preventing users from causing arbitrary memory usage.

As a result of this PR, the test `stackOverflow1` now passes (lots of output from one handler), and `stackOverflow2` continues to pass.