### PR TITLE
Change process.env implementation to be based on importable env.

### DIFF
--- a/src/node/internal/process.ts
+++ b/src/node/internal/process.ts
@@ -20,13 +20,105 @@ export function nextTick(cb: Function, ...args: unknown[]) {
   });
 }
 
-// Note that there is no process-level environment in workers so the process.env
-// object is initially empty. This is different from Node.js where process.env
-// picks up values from the operating system environment. The configured bindings
-// for the worker are accessible from the env argument passed into the fetch
-// handler and have no impact here.
+// Decide if a value can round-trip to JSON without losing any information.
+function isJsonSerializable(
+  value: any,
+  seen: Set<Object> = new Set()
+): boolean {
+  switch (typeof value) {
+    case 'boolean':
+    case 'number':
+    case 'string':
+      return true;
 
-export const env = new Proxy(utilImpl.getEnvObject(), {
+    case 'object': {
+      if (value === null) {
+        return true;
+      }
+
+      if (seen.has(value)) {
+        // Don't allow cycles or aliases. (Non-cyclic aliases technically could be OK, but a
+        // round trip to JSON would lose the fact that they are aliases.)
+        return false;
+      }
+      seen.add(value);
+
+      if (typeof value.toJSON === 'function') {
+        // This type is explicitly designed to be JSON-serialized so we'll accept it.
+        return true;
+      }
+
+      // We only consider objects to be serializable if they are plain objects or plain arrays.
+      // Technically, JSON can serialize any subclass of Object (as well as objects with null
+      // prototypes), but the round trip would lose information about the original type. Hence,
+      // we assume that any env var containing such things is not intended to be appear as JSON
+      // in process.env. For example, we wouldn't want a KV namespace to show up in process.env as
+      // "{}" -- this would be weird.
+      switch (Object.getPrototypeOf(value)) {
+        case Object.prototype:
+          // Note that Object.values() only returns string-keyed values, not symbol-keyed.
+          return Object.values(value).every((prop) =>
+            isJsonSerializable(prop, seen)
+          );
+        case Array.prototype:
+          return (<Array<unknown>>value).every((elem) =>
+            isJsonSerializable(elem, seen)
+          );
+        default:
+          return false;
+      }
+    }
+
+    default:
+      return false;
+  }
+}
+
+function getInitialEnv() {
+  let env: Record<string, string> = {};
+  for (let [key, value] of Object.entries(utilImpl.getEnvObject())) {
+    // Workers environment variables can have a variety of types, but process.env vars are
+    // strictly strings. We want to convert our workers env into process.env, but allowing
+    // process.env to contain non-strings would probably break Node apps.
+    //
+    // As a compromise, we say:
+    // - Workers env vars that are plain strings are unchanged in process.env.
+    // - Workers env vars that can be represented as JSON will be JSON-stringified in process.env.
+    // - Anything else will be omitted.
+    //
+    // Note that you might argue that, at the config layer, it's possible to differentiate between
+    // plain strings and JSON values that evaluated to strings. Wouldn't it be nice if we could
+    // check which way the binding was originally configured in order to decide whether to
+    // represent it plain or as JSON here. However, there is no way to tell just by looking at
+    // the `env` object inside a Worker whether a particular var was originally configured as
+    // plain text, or as JSON that evaluated to a string. Either way, you just get a string. And
+    // indeed, the Workers Runtime itself does not necessarily know this. In many cases it does
+    // know, but in general the abstraction the Runtime intends to provide is that `env` is just
+    // a JavaScript object, and how exactly the contents were originally represented is not
+    // intended to be conveyed. This is important because, for example, we could extend dynamic
+    // dispatch bindings in the future such that the caller can specify `env` directly, and in
+    // that case the caller would simply specify a JS object, without JSON or any other
+    // serialization involved. In this case, there would be no way to know if a string var was
+    // "supposed to be" raw text vs. JSON.
+    //
+    // So, we have to do the best we can given just what we know -- the JavaScript object that is
+    // `env`.
+    //
+    // As a consolation, this is consistent with how variables are defined in wrangler.toml: you
+    // do not explicitly specify whether a variable is text or JSON. If you define a variable with
+    // a simple string value, it gets configured as a text var. If you specify an object, then it's
+    // configured as JSON.
+
+    if (typeof value === 'string') {
+      env[key] = value;
+    } else if (isJsonSerializable(value)) {
+      env[key] = JSON.stringify(value);
+    }
+  }
+  return env;
+}
+
+export const env = new Proxy(getInitialEnv(), {
   // Per Node.js rules. process.env values must be coerced to strings.
   // When defined using defineProperty, the property descriptor must be writable,
   // configurable, and enumerable using just a falsy check. Getters and setters

--- a/src/workerd/api/modules.c++
+++ b/src/workerd/api/modules.c++
@@ -20,10 +20,8 @@ kj::Maybe<jsg::JsObject> EnvModule::getCurrent(jsg::Lock& js) {
   if (FeatureFlags::get(js).getDisableImportableEnv()) return kj::none;
 
   // Otherwise, fallback to provide the stored environment.
-  return js.getWorkerEnv().map([&](const jsg::Value& val) -> jsg::JsObject {
-    auto handle = val.getHandle(js);
-    JSG_REQUIRE(handle->IsObject(), TypeError, "Expected environment to be an object.");
-    return jsg::JsObject(handle.As<v8::Object>());
+  return js.getWorkerEnv().map([&](const jsg::V8Ref<v8::Object>& val) -> jsg::JsObject {
+    return jsg::JsObject(val.getHandle(js));
   });
 }
 

--- a/src/workerd/api/node/util.c++
+++ b/src/workerd/api/node/util.c++
@@ -250,7 +250,17 @@ jsg::JsValue UtilModule::getBuiltinModule(jsg::Lock& js, kj::String specifier) {
 }
 
 jsg::JsObject UtilModule::getEnvObject(jsg::Lock& js) {
-  return js.getProcessEnv(true);
+  if (FeatureFlags::get(js).getPopulateProcessEnv()) {
+    KJ_IF_SOME(env, js.getWorkerEnv()) {
+      jsg::JsValue val(env.getHandle(js));
+      KJ_IF_SOME(obj, val.tryCast<jsg::JsObject>()) {
+        return obj;
+      }
+    }
+  }
+
+  // Default to empty object.
+  return js.obj();
 }
 
 namespace {

--- a/src/workerd/api/node/util.c++
+++ b/src/workerd/api/node/util.c++
@@ -252,10 +252,7 @@ jsg::JsValue UtilModule::getBuiltinModule(jsg::Lock& js, kj::String specifier) {
 jsg::JsObject UtilModule::getEnvObject(jsg::Lock& js) {
   if (FeatureFlags::get(js).getPopulateProcessEnv()) {
     KJ_IF_SOME(env, js.getWorkerEnv()) {
-      jsg::JsValue val(env.getHandle(js));
-      KJ_IF_SOME(obj, val.tryCast<jsg::JsObject>()) {
-        return obj;
-      }
+      return jsg::JsObject(env.getHandle(js));
     }
   }
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1618,7 +1618,7 @@ Worker::Worker(kj::Own<const Script> scriptParam,
               // Use `env` variable.
               bindingsScope = v8::Object::New(lock.v8Isolate);
               if (!FeatureFlags::get(js).getDisableImportableEnv()) {
-                lock.setWorkerEnv(lock.v8Ref(bindingsScope.As<v8::Value>()));
+                lock.setWorkerEnv(lock.v8Ref(bindingsScope));
               }
             } else {
               // Use global-scope bindings.

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2705,13 +2705,6 @@ class Lock {
   // the inspector (if attached), or to KJ_LOG(Info).
   virtual void reportError(const JsValue& value) = 0;
 
-  // Sets an env value that will be expressed on the process.env
-  // if/when nodejs-compat mode is used.
-  virtual void setProcessEnvField(const JsValue& name, const JsValue& value) = 0;
-
-  // Returns the process.env base object.
-  virtual JsObject getProcessEnv(bool release = false) = 0;
-
   // Store the worker environment.
   virtual void setWorkerEnv(Value value) = 0;
 

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2706,10 +2706,10 @@ class Lock {
   virtual void reportError(const JsValue& value) = 0;
 
   // Store the worker environment.
-  virtual void setWorkerEnv(Value value) = 0;
+  virtual void setWorkerEnv(V8Ref<v8::Object> value) = 0;
 
   // Retrieve the worker environment.
-  virtual kj::Maybe<Value> getWorkerEnv() = 0;
+  virtual kj::Maybe<V8Ref<v8::Object>> getWorkerEnv() = 0;
 
   // Resolve an internal module namespace from the given specifier.
   // This variation can be used only for internal built-ins.

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -428,7 +428,6 @@ void IsolateBase::dropWrappers(kj::FunctionParam<void()> drop) {
     // Make sure v8::Globals are destroyed under lock (but not until later).
     KJ_DEFER(symbolAsyncDispose.Reset());
     KJ_DEFER(opaqueTemplate.Reset());
-    KJ_DEFER(envObj.Reset());
     KJ_DEFER(workerEnvObj.Reset());
 
     // Make sure the TypeWrapper is destroyed under lock by declaring a new copy of the variable

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -284,9 +284,6 @@ class IsolateBase {
   // object with 2 internal fields.
   v8::Global<v8::FunctionTemplate> opaqueTemplate;
 
-  // Object that is used as the underlying target of process.env when nodejs-compat mode is used.
-  v8::Global<v8::Object> envObj;
-
   // Object used as the underlying storage for a workers environment.
   v8::Global<v8::Object> workerEnvObj;
 
@@ -698,24 +695,6 @@ class Isolate: public IsolateBase {
         jsgIsolate.reportError(
             *this, value.toString(*this), value, JsMessage::create(*this, value));
       }
-    }
-
-    // Sets an env value that will be expressed on the process.env
-    // if/when nodejs-compat mode is used.
-    void setProcessEnvField(const JsValue& name, const JsValue& value) override {
-      getProcessEnv().set(*this, name, value);
-    }
-
-    // Returns the env base object.
-    JsObject getProcessEnv(bool release = false) override {
-      KJ_DEFER({
-        if (release) jsgIsolate.envObj.Reset();
-      });
-      if (jsgIsolate.envObj.IsEmpty()) {
-        v8::Local<v8::Object> env = obj();
-        jsgIsolate.envObj.Reset(v8Isolate, env);
-      }
-      return JsObject(jsgIsolate.envObj.Get(v8Isolate));
     }
 
     void setWorkerEnv(Value value) override {

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -697,15 +697,13 @@ class Isolate: public IsolateBase {
       }
     }
 
-    void setWorkerEnv(Value value) override {
-      auto handle = value.getHandle(*this);
-      KJ_ASSERT(handle->IsObject());
-      jsgIsolate.workerEnvObj.Reset(v8Isolate, handle.template As<v8::Object>());
+    void setWorkerEnv(V8Ref<v8::Object> value) override {
+      jsgIsolate.workerEnvObj.Reset(v8Isolate, value.getHandle(*this));
     }
 
-    kj::Maybe<Value> getWorkerEnv() override {
+    kj::Maybe<V8Ref<v8::Object>> getWorkerEnv() override {
       if (jsgIsolate.workerEnvObj.IsEmpty()) return kj::none;
-      return v8Ref<v8::Value>(jsgIsolate.workerEnvObj.Get(v8Isolate));
+      return v8Ref<v8::Object>(jsgIsolate.workerEnvObj.Get(v8Isolate));
     }
 
    private:

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -654,67 +654,6 @@ static v8::Local<v8::Value> createBindingValue(JsgWorkerdIsolate::Lock& lock,
   KJ_SWITCH_ONEOF(global.value) {
     KJ_CASE_ONEOF(json, Global::Json) {
       value = jsg::check(v8::JSON::Parse(context, lock.str(json.text)));
-      if (featureFlags.getPopulateProcessEnv() && featureFlags.getNodeJsCompat()) {
-        // Generally speaking, process.env has the TEXT and JSON bindings from env.
-        // TEXT bindings are simple enough and env.{name} will strictly equal
-        // process.env.{name}. With JSON bindings it a bit trickier due to architectural
-        // quirks and history in our runtime.
-        // If you set the JSON environment variable to a value that parses to a string
-        // then it will be exposed on process.env and env as that parsed string such
-        // that env.{name} will strictly equal process.env{name} like with TEXT bindings.
-        // If, however, the value parses to any type other than a string, the
-        // process.env.{name} will instead be the raw parseable JSON string and will
-        // *not* strictly equal env.{name}.
-        //
-        // So, for example, given the bindings:
-        //
-        //    (name = "FOO", json = "{}"),
-        //    (name = "BAR", json = "\"abc\""),
-        //    (name = "BAZ", json = "\"\\\"abc\\\"\"")
-        //
-        // In the worker:
-        //
-        //    env.FOO === process.env.FOO;                      // false
-        //    console.log(typeof env.FOO);                      // 'object'
-        //    console.log(typeof process.env.FOO);              // 'string'
-        //    console.log(env.FOO);                             // [object Object]
-        //    console.log(process.env.FOO);                     // '{}'
-        //    console.log(typeof JSON.parse(process.env.FOO));  // 'object'
-        //
-        //    env.BAR === process.env.BAR;                      // true
-        //    console.log(typeof env.BAR);                      // 'string'
-        //    console.log(typeof process.env.BAR);              // 'string'
-        //    console.log(env.BAR);                             // 'abc'
-        //    console.log(process.env.BAR);                     // 'abc'
-        //    console.log(typeof JSON.parse(process.env.BAR));  // throws!!
-        //
-        //    env.BAZ === process.env.BAZ;                      // true
-        //    console.log(typeof enf.BAZ);                      // 'string'
-        //    console.log(typeof process.env.BAZ);              // 'string'
-        //    console.log(env.BAZ);                             // '"abc"'
-        //    console.log(process.env.BAZ);                     // '"abc"
-        //    console.log(typeof JSON.parse(process.env.BAZ));  // 'string'
-        //
-        // JSON.parse(process.env.FOO) works because the value is a parseable
-        // JSON string. JSON.parse(process.env.BAR) throws an error because
-        // the value is not a parseable JSON string, even tho the binding uses
-        // type JSON. JSON.parse(process.env.BAZ)` works because the original
-        // JSON-encoded value was double-escaped and the result of the above
-        // v8::JSON::Parse is itself a parseable JSON string.
-        //
-        // Practically speaking this means that developers can never really
-        // count on environment variables accessed via `env` always being
-        // strictly equal to the same environment variable accessed via
-        // process.env because, despite being defined as JSON bindings,
-        // the resulting value may or may not be JSON parseable or may be
-        // parsed in one context (env) and unparsed in another (process.env).
-
-        if (value->IsString()) {
-          lock.setProcessEnvField(lock.str(global.name), jsg::JsValue(value));
-        } else {
-          lock.setProcessEnvField(lock.str(global.name), lock.str(json.text));
-        }
-      }
     }
 
     KJ_CASE_ONEOF(pipeline, Global::Fetcher) {
@@ -800,9 +739,6 @@ static v8::Local<v8::Value> createBindingValue(JsgWorkerdIsolate::Lock& lock,
 
     KJ_CASE_ONEOF(text, kj::String) {
       value = lock.wrap(context, kj::mv(text));
-      if (featureFlags.getPopulateProcessEnv() && featureFlags.getNodeJsCompat()) {
-        lock.setProcessEnvField(lock.str(global.name), jsg::JsValue(value));
-      }
     }
 
     KJ_CASE_ONEOF(data, kj::Array<byte>) {


### PR DESCRIPTION
This means that `disallow_importable_env` will disable both importable env and `process.env`, which is likely what anyone using this flag wants. (Source: Me, the only known person who even wants `disallow_importable_env`.)

This also allows us to delete a lot of code.

Although this is techincally a breaking change since these fetaures have already shipped, it seems highly unlikely that someone has managed to deploy code which both sets `disallow_importable_env` and also `nodejs_compat_populate_process_env` and depends on `process.env`. This will get harder once `nodejs_compat_populate_process_env` becomes the default on `2025-04-01`.