### PR TITLE
plumb specific internal request type into limit enforcer newSubrequest

### DIFF
--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -38,7 +38,7 @@ class LocalActorOutgoingFactory final: public Fetcher::OutgoingFactory {
       return KJ_REQUIRE_NONNULL(actorChannel)
           ->startRequest({.cfBlobJson = kj::mv(cfStr), .tracing = tracing});
     },
-        {.inHouse = true,
+        {.internalSubrequestType = InternalSubrequestType{DOSubrequest{}},
           .wrapMetrics = true,
           .operationName = kj::ConstString("durable_object_subrequest"_kjc)}));
   }
@@ -80,7 +80,7 @@ class GlobalActorOutgoingFactory final: public Fetcher::OutgoingFactory {
       return KJ_REQUIRE_NONNULL(actorChannel)
           ->startRequest({.cfBlobJson = kj::mv(cfStr), .tracing = tracing});
     },
-        {.inHouse = true,
+        {.internalSubrequestType = InternalSubrequestType{DOSubrequest{}},
           .wrapMetrics = true,
           .operationName = kj::ConstString("durable_object_subrequest"_kjc)}));
   }
@@ -108,7 +108,7 @@ kj::Own<WorkerInterface> ReplicaActorOutgoingFactory::newSingleUseClient(
     // already open prior to this DO starting up.
     return actorChannel->startRequest({.cfBlobJson = kj::mv(cfStr), .tracing = tracing});
   },
-      {.inHouse = true,
+      {.internalSubrequestType = InternalSubrequestType{DOSubrequest{}},
         .wrapMetrics = true,
         .operationName = kj::ConstString("durable_object_subrequest"_kjc)}));
 }
@@ -123,9 +123,8 @@ jsg::Ref<Fetcher> ColoLocalActorNamespace::get(kj::String actorId) {
       kj::heap<LocalActorOutgoingFactory>(channel, kj::mv(actorId));
   auto outgoingFactory = context.addObject(kj::mv(factory));
 
-  bool isInHouse = true;
-  return jsg::alloc<Fetcher>(
-      kj::mv(outgoingFactory), Fetcher::RequiresHostAndProtocol::YES, isInHouse);
+  return jsg::alloc<Fetcher>(kj::mv(outgoingFactory), Fetcher::RequiresHostAndProtocol::YES,
+      InternalSubrequestType{DOSubrequest{}});
 }
 
 // =======================================================================================

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -12,6 +12,7 @@
 #include <workerd/api/http.h>
 #include <workerd/api/worker-rpc.h>
 #include <workerd/io/actor-id.h>
+#include <workerd/io/internal-subrequest-type.h>
 #include <workerd/jsg/jsg.h>
 
 #include <capnp/compat/byte-stream.h>
@@ -88,7 +89,7 @@ class DurableObject final: public Fetcher {
   DurableObject(jsg::Ref<DurableObjectId> id,
       IoOwn<OutgoingFactory> outgoingFactory,
       RequiresHostAndProtocol requiresHost)
-      : Fetcher(kj::mv(outgoingFactory), requiresHost, true /* isInHouse */),
+      : Fetcher(kj::mv(outgoingFactory), requiresHost, InternalSubrequestType{DOSubrequest{}}),
         id(kj::mv(id)) {}
 
   jsg::Ref<DurableObjectId> getId() {

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -5,6 +5,7 @@
 #include "container.h"
 
 #include <workerd/api/http.h>
+#include <workerd/io/internal-subrequest-type.h>
 #include <workerd/io/io-context.h>
 
 namespace workerd::api {
@@ -261,8 +262,8 @@ jsg::Ref<Fetcher> Container::getTcpPort(jsg::Lock& js, int port) {
       kj::heap<TcpPortOutgoingFactory>(ioctx.getByteStreamFactory(), ioctx.getEntropySource(),
           ioctx.getHeaderTable(), req.send().getPort());
 
-  return jsg::alloc<Fetcher>(
-      ioctx.addObject(kj::mv(factory)), Fetcher::RequiresHostAndProtocol::YES, true);
+  return jsg::alloc<Fetcher>(ioctx.addObject(kj::mv(factory)),
+      Fetcher::RequiresHostAndProtocol::YES, InternalSubrequestType{GenericInternalSubrequest{}});
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -264,7 +264,8 @@ kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::request(kj::HttpMetho
       return addNoopDeferredProxy(
           response.sendError(500, "Internal Server Error", ioContext.getHeaderTable()));
     } else {
-      auto client = ioContext.getHttpClient(IoContext::NEXT_CLIENT_CHANNEL, false,
+      auto client = ioContext.getHttpClient(IoContext::NEXT_CLIENT_CHANNEL,
+          kj::none /*internalSubrequestType*/,
           cfBlobJson.map([](kj::StringPtr s) { return kj::str(s); }), "fetch_default"_kjc);
       auto adapter = kj::newHttpService(*client);
       auto promise = adapter->request(method, url, headers, requestBody, response);

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -2561,7 +2561,7 @@ kj::Own<WorkerInterface> Fetcher::getClient(
   KJ_SWITCH_ONEOF(channelOrClientFactory) {
     KJ_CASE_ONEOF(channel, uint) {
       return ioContext.getSubrequestChannel(
-          channel, isInHouse, kj::mv(cfStr), kj::mv(operationName));
+          channel, internalSubrequestType, kj::mv(cfStr), kj::mv(operationName));
     }
     KJ_CASE_ONEOF(outgoingFactory, IoOwn<OutgoingFactory>) {
       return outgoingFactory->newSingleUseClient(kj::mv(cfStr));

--- a/src/workerd/api/hyperdrive.c++
+++ b/src/workerd/api/hyperdrive.c++
@@ -6,6 +6,8 @@
 
 #include "sockets.h"
 
+#include <workerd/io/internal-subrequest-type.h>
+
 #include <openssl/rand.h>
 
 #include <kj/compat/http.h>
@@ -85,8 +87,8 @@ kj::String Hyperdrive::getConnectionString() {
 
 kj::Promise<kj::Own<kj::AsyncIoStream>> Hyperdrive::connectToDb() {
   auto& context = IoContext::current();
-  auto service =
-      context.getSubrequestChannel(this->clientIndex, true, kj::none, "hyperdrive_connect"_kjc);
+  auto service = context.getSubrequestChannel(this->clientIndex,
+      InternalSubrequestType{GenericInternalSubrequest{}}, kj::none, "hyperdrive_connect"_kjc);
 
   kj::HttpHeaderTable headerTable;
   kj::HttpHeaders headers(headerTable);

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -146,8 +146,8 @@ kj::Own<kj::HttpClient> KvNamespace::getHttpClient(IoContext& context,
       }
     }
   }
-  auto client = context.getHttpClientWithSpans(
-      subrequestChannel, true, kj::none, operationName, kj::mv(tags));
+  auto client = context.getHttpClientWithSpans(subrequestChannel,
+      InternalSubrequestType{GenericInternalSubrequest{}}, kj::none, operationName, kj::mv(tags));
 
   headers.add(FLPROD_405_HEADER, urlStr);
   for (const auto& header: additionalHeaders) {

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -206,7 +206,8 @@ kj::Promise<void> WorkerQueue::send(
   // queue broker's domain, and the start of the URL path including the account ID and queue ID. All
   // we have to do is provide the end of the path (which is "/message") to send a single message.
 
-  auto client = context.getHttpClient(subrequestChannel, true, kj::none, "queue_send"_kjc);
+  auto client = context.getHttpClient(subrequestChannel,
+      InternalSubrequestType{GenericInternalSubrequest{}}, kj::none, "queue_send"_kjc);
   auto req = client->request(
       kj::HttpMethod::POST, "https://fake-host/message"_kjc, headers, serialized.data.size());
 
@@ -299,7 +300,8 @@ kj::Promise<void> WorkerQueue::sendBatch(jsg::Lock& js,
   kj::String body(bodyBuilder.releaseAsArray());
   KJ_DASSERT(jsg::JsValue::fromJson(js, body).isObject());
 
-  auto client = context.getHttpClient(subrequestChannel, true, kj::none, "queue_send"_kjc);
+  auto client = context.getHttpClient(subrequestChannel,
+      InternalSubrequestType{GenericInternalSubrequest{}}, kj::none, "queue_send"_kjc);
 
   // We add info about the size of the batch to the headers so that the queue implementation can
   // decide whether it's too large.

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -36,7 +36,8 @@ kj::Own<kj::HttpClient> r2GetClient(
     tags.add(tag.key, kj::str(tag.value));
   }
 
-  return context.getHttpClientWithSpans(subrequestChannel, true, kj::none, user.op, kj::mv(tags));
+  return context.getHttpClientWithSpans(subrequestChannel,
+      InternalSubrequestType{GenericInternalSubrequest{}}, kj::none, user.op, kj::mv(tags));
 }
 
 static bool isWholeNumber(double x) {

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -205,7 +205,7 @@ jsg::Ref<WebSocket> WebSocket::constructor(jsg::Lock& js,
       urlRecord.fragment == kj::none, DOMSyntaxError, wsErr, "The url fragment must be empty.");
 
   kj::HttpHeaders headers(context.getHeaderTable());
-  auto client = context.getHttpClient(0, false, kj::none, "websocket_open"_kjc);
+  auto client = context.getHttpClient(0, kj::none, kj::none, "websocket_open"_kjc);
 
   // Set protocols header if necessary.
   KJ_IF_SOME(variant, protocols) {

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -112,6 +112,7 @@ wd_cc_library(
         ":cdp_capnp",
         ":container_capnp",
         ":frankenvalue",
+        ":internal-subrequest-type",
         ":io-gate",
         ":io-helpers",
         ":limit-enforcer",
@@ -238,6 +239,7 @@ wd_cc_library(
     hdrs = ["limit-enforcer.h"],
     visibility = ["//visibility:public"],
     deps = [
+        ":internal-subrequest-type",
         ":observer",
         "//src/workerd/jsg",
     ],
@@ -305,6 +307,15 @@ wd_capnp_library(
         ":script-version_capnp",
         ":trace_capnp",
         "@capnp-cpp//src/capnp/compat:http-over-capnp_capnp",
+    ],
+)
+
+wd_cc_library(
+    name = "internal-subrequest-type",
+    hdrs = ["internal-subrequest-type.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj",
     ],
 )
 

--- a/src/workerd/io/internal-subrequest-type.h
+++ b/src/workerd/io/internal-subrequest-type.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <kj/one-of.h>
+
+struct GenericInternalSubrequest {};
+struct DOSubrequest {};
+typedef kj::OneOf<GenericInternalSubrequest, DOSubrequest> InternalSubrequestType;

--- a/src/workerd/io/limit-enforcer.h
+++ b/src/workerd/io/limit-enforcer.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <workerd/io/internal-subrequest-type.h>
 #include <workerd/io/observer.h>
 #include <workerd/jsg/jsg.h>
 
@@ -106,10 +107,12 @@ class LimitEnforcer {
   // Called before starting a new subrequest. Throws a JSG exception if the limit has been
   // reached.
   //
-  // `isInHouse` is true for types of subrequests which we need to be "in house" (i.e. to another
-  // Cloudflare service, like Workers KV) and thus should not be subject to the same limits as
-  // external subrequests.
-  virtual void newSubrequest(bool isInHouse) = 0;
+  // `internalSubrequestType` is set for types of subrequests which we need to mark as internal
+  // (i.e. to another Cloudflare service, like Workers KV) and thus should not be subject to the
+  // same limits as external subrequests. InternalSubrequestType is a kj::OneOf instead of a
+  // bool to allow to differentiation between internal subrequests, so that they can be limited
+  // in the appropriate manner. (e.g. for various free tiers of Cloudflare products).
+  virtual void newSubrequest(kj::Maybe<InternalSubrequestType> internalSubrequestType) = 0;
 
   enum class KvOpType { GET, GET_WITH, PUT, LIST, DELETE, GET_BULK };
   // Called before starting a KV operation. Throws a JSG exception if the operation should be

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -363,7 +363,7 @@ kj::Promise<void> WorkerEntrypoint::request(kj::HttpMethod method,
       // Fail-open behavior has been chosen, we'd better save an interface that we can use for
       // that purpose later.
       failOpenService = context.getSubrequestChannelNoChecks(
-          IoContext::NEXT_CLIENT_CHANNEL, false, kj::mv(cfBlobJson));
+          IoContext::NEXT_CLIENT_CHANNEL, kj::none, kj::mv(cfBlobJson));
     }
     auto promise =
         incomingRequest->drain().attach(kj::mv(incomingRequest).attach(kj::mv(outcomeObserver)));

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -722,7 +722,7 @@ static v8::Local<v8::Value> createBindingValue(JsgWorkerdIsolate::Lock& lock,
           jsg::alloc<api::Fetcher>(pipeline.channel,
               pipeline.requiresHost ? api::Fetcher::RequiresHostAndProtocol::YES
                                     : api::Fetcher::RequiresHostAndProtocol::NO,
-              pipeline.isInHouse));
+              pipeline.internalSubrequestType));
     }
 
     KJ_CASE_ONEOF(ns, Global::KvNamespace) {

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -78,7 +78,7 @@ class WorkerdApi final: public Worker::Api {
     struct Fetcher {
       uint channel;
       bool requiresHost;
-      bool isInHouse;
+      kj::Maybe<InternalSubrequestType> internalSubrequestType;
 
       Fetcher clone() const {
         return *this;

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -145,7 +145,7 @@ struct MockLimitEnforcer final: public LimitEnforcer {
     return {};
   }
   void topUpActor() override {}
-  void newSubrequest(bool isInHouse) override {}
+  void newSubrequest(kj::Maybe<InternalSubrequestType> internalSubrequestType) override {}
   void newKvRequest(KvOpType op) override {}
   void newAnalyticsEngineRequest() override {}
   kj::Promise<void> limitDrain() override {


### PR DESCRIPTION
I made these changes to enable the limit enforcer to enforce free tier limits for various products. This goes paired with an internal EW PR that actually does the enforcement.