### PR TITLE
Constructing a `WorkerEntrypoint` from userland

### DIFF
--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -1731,3 +1731,19 @@ export let proxiedRpcTarget = {
     }
   },
 };
+
+// Test that we can construct a WorkerEntrypoint
+export class MyEntrypoint extends WorkerEntrypoint {
+  rpcFunc() {
+    return 'hello from entrypoint';
+  }
+}
+function constructEntrypoint(cls, env) {
+  return new cls({ waitUntil: () => {} }, env);
+}
+export let testConstructEntrypoint = {
+  async test(controller, env, ctx) {
+    const constructed = constructEntrypoint(MyEntrypoint, env);
+    assert.strictEqual(await constructed.rpcFunc(), 'hello from entrypoint');
+  },
+};

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -1967,9 +1967,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result> JsRpcSessionCustomEventImpl::s
 // =======================================================================================
 
 jsg::Ref<WorkerEntrypoint> WorkerEntrypoint::constructor(
-    const v8::FunctionCallbackInfo<v8::Value>& args,
-    jsg::Ref<ExecutionContext> ctx,
-    jsg::JsObject env) {
+    const v8::FunctionCallbackInfo<v8::Value>& args, jsg::JsObject ctx, jsg::JsObject env) {
   // HACK: We take `FunctionCallbackInfo` mostly so that we can set properties directly on
   //   `This()`. There ought to be a better way to get access to `this` in a constructor.
   //   We *also* declare `ctx` and `env` params more explicitly just for the sake of type checking.

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -492,9 +492,8 @@ class JsRpcSessionCustomEventImpl final: public WorkerInterface::CustomEvent {
 // define a constructor.
 class WorkerEntrypoint: public jsg::Object {
  public:
-  static jsg::Ref<WorkerEntrypoint> constructor(const v8::FunctionCallbackInfo<v8::Value>& args,
-      jsg::Ref<ExecutionContext> ctx,
-      jsg::JsObject env);
+  static jsg::Ref<WorkerEntrypoint> constructor(
+      const v8::FunctionCallbackInfo<v8::Value>& args, jsg::JsObject ctx, jsg::JsObject env);
 
   JSG_RESOURCE_TYPE(WorkerEntrypoint) {}
 };


### PR DESCRIPTION
This PR adds a sample that demonstrates that it's not possible to construct a `WorkerEntrypoint` in userland with a user-provided `ctx` object. Instead, this error appears:

```
workerd/server/server.c++:3880: error: Uncaught exception: workerd/jsg/_virtual_includes/iterator/workerd/jsg/value.h:1473: failed: remote.jsg.TypeError: Failed to construct 'WorkerEntrypoint': constructor parameter 1 is not of type 'ExecutionContext'.
```

This is important for the Vitest integration because we need to be able to (within a single "real" execution context):
- Construct a WorkerEntrypoint with a custom execution context
- wait for all `waitUntil`s in the custom execution context to be settled
- Do some assertions

This works with default export-style workers, because the `fetch()` method can just be called directly with the custom execution context, but that's not possible with `WorkerEntrypoint`-style workers.

---

Or at least that _was_ the case! Thanks to the changes now in this PR, the above is possible—and `WorkerEntrypoint` can be constructed with any object, allowing for custom execution contexts.