### PR TITLE
CACHE-11937: enable cache rules request cf overrides compat flag

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -688,7 +688,8 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
 
   requestCfOverridesCacheRules @72 :Bool
       $compatEnableFlag("request_cf_overrides_cache_rules")
-      $experimental
+      $compatDisableFlag("no_request_cf_overrides_cache_rules")
+      $compatEnableDate("2025-04-02")
       $neededByFl;
   # Enables cache settings specified request in fetch api cf object to override cache rules. (only for user owned or grey-clouded sites)
 


### PR DESCRIPTION
This PR enables the compat flag which had been experimental and tested in FL for overriding cache rules when cache settings specified in the request cf object.