### PR TITLE
[ci] Make wrangler team code owners of types/, src/cloudflare/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,8 @@ build-releases.sh @cloudflare/wrangler @cloudflare/workers-runtime-1
 RELEASE.md @cloudflare/wrangler @cloudflare/workers-runtime-1
 package.json @cloudflare/wrangler @cloudflare/workers-runtime-1
 pnpm-lock.yaml @cloudflare/wrangler @cloudflare/workers-runtime-1
-types/ @cloudflare/wrangler @cloudflare/workers-runtime-1
+types/ @cloudflare/wrangler
+src/cloudflare/ @cloudflare/wrangler
 src/workerd/tools/ @cloudflare/wrangler @cloudflare/workers-runtime-1 @cloudflare/workers-durable-objects
 src/workerd/io/supported-compatibility-date.txt @cloudflare/wrangler @cloudflare/workers-runtime-1
 src/node/ @cloudflare/workers-runtime-1 @cloudflare/workers-durable-objects @cloudflare/workers-frameworks


### PR DESCRIPTION
As discussed with @danlapid. The runtime team often has limited context on changes to various bindings resulting in changes to src/cloudflare or type definitions, these directories should be owned by the wrangler team.
Let me know if you have any concerns/further suggestions here.

CC @penalosa