### PR TITLE
Make BUILD.wpt path absolute

### DIFF
--- a/build/BUILD.wpt
+++ b/build/BUILD.wpt
@@ -2,7 +2,7 @@
 # Licensed under the Apache 2.0 license found in the LICENSE file or at:
 #     https://opensource.org/licenses/Apache-2.0
 
-load("@workerd//:build/wpt_test.bzl", "wpt_get_directories")
+load("@workerd//:build/wpt_get_directories.bzl", "wpt_get_directories")
 
 [filegroup(
     name = dir,

--- a/build/deps/gen/dep_wpt.bzl
+++ b/build/deps/gen/dep_wpt.bzl
@@ -15,5 +15,5 @@ def dep_wpt():
         strip_prefix = STRIP_PREFIX,
         type = TYPE,
         sha256 = SHA256,
-        build_file = "//:build/BUILD.wpt",
+        build_file = "@workerd//:build/BUILD.wpt",
     )

--- a/build/deps/shared_deps.jsonc
+++ b/build/deps/shared_deps.jsonc
@@ -74,7 +74,7 @@
       "owner": "cloudflare",
       "repo": "workerd-tools",
       "file_regex": "wpt-.*.tar.gz",
-      "build_file": "//:build/BUILD.wpt",
+      "build_file": "@workerd//:build/BUILD.wpt",
       "freeze_version": "wpt-afa16aa1d"
     }
   ]

--- a/build/wpt_get_directories.bzl
+++ b/build/wpt_get_directories.bzl
@@ -1,0 +1,16 @@
+def wpt_get_directories(root, excludes = []):
+    """
+    Globs for files within a WPT directory structure, starting from root.
+    In addition to an explicitly provided excludes argument, hidden directories
+    and top-level files are also excluded as they don't contain test content.
+    """
+
+    root_pattern = "{}/*".format(root) if root else "*"
+    return native.glob(
+        [root_pattern],
+        exclude = native.glob(
+            [root_pattern],
+            exclude_directories = 1,
+        ) + [".*"] + excludes,
+        exclude_directories = 0,
+    )

--- a/build/wpt_test.bzl
+++ b/build/wpt_test.bzl
@@ -54,23 +54,6 @@ def wpt_test(name, wpt_directory, config, autogates = []):
         ],
     )
 
-def wpt_get_directories(root, excludes = []):
-    """
-    Globs for files within a WPT directory structure, starting from root.
-    In addition to an explicitly provided excludes argument, hidden directories
-    and top-level files are also excluded as they don't contain test content.
-    """
-
-    root_pattern = "{}/*".format(root) if root else "*"
-    return native.glob(
-        [root_pattern],
-        exclude = native.glob(
-            [root_pattern],
-            exclude_directories = 1,
-        ) + [".*"] + excludes,
-        exclude_directories = 0,
-    )
-
 def _wpt_js_test_gen_impl(ctx):
     """
     Generates a workerd test suite in JS. This contains the logic to run


### PR DESCRIPTION
This is a follow up for #3777. When a dependency is shared, we can't assume the name of the repo we're in -- it has to be absolute.