### PR TITLE
Update types for Cloudflare Images

### DIFF
--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -30,8 +30,10 @@ interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -45,12 +47,13 @@ interface BasicImageTransformations {
    * source image.
    */
   gravity?:
-    | "left"
-    | "right"
-    | "top"
-    | "bottom"
-    | "center"
-    | "auto"
+    | 'left'
+    | 'right'
+    | 'top'
+    | 'bottom'
+    | 'center'
+    | 'auto'
+    | 'entropy'
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -66,8 +69,9 @@ interface BasicImageTransformations {
 }
 
 interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: 'remainder' | 'box-center';
 }
 
 /**
@@ -176,23 +180,41 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
+  trim?: "border" | {
     top?: number;
-    right?: number;
     bottom?: number;
+    left?: number;
+    right?: number;
+    width?: number;
+    height?: number;
+    border?:
+      | boolean
+      | {
+          color?: string;
+          tolerance?: number;
+          keep?: number;
+        };
   };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -204,7 +226,7 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?: "avif" | "webp" | "json" | "jpeg" | "png" | "baseline-jpeg" | "png-force" | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -284,6 +306,21 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: 'h' | 'v' | 'hv',
+
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and

--- a/types/defines/images.d.ts
+++ b/types/defines/images.d.ts
@@ -12,7 +12,26 @@ type ImageInfoResponse =
     };
 
 type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: 'scale-down' | 'contain' | 'pad' | 'squeeze' | 'cover' | 'crop';
+  flip?: 'h' | 'v' | 'hv';
+  gamma?: number;
   gravity?:
     | 'left'
     | 'right'
@@ -21,13 +40,15 @@ type ImageTransform = {
     | 'center'
     | 'auto'
     | 'entropy'
-    | 'face'
     | {
         x?: number;
         y?: number;
         mode: 'remainder' | 'box-center';
       };
-  trim?: {
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
+  sharpen?: number;
+  trim?: "border" | {
     top?: number;
     bottom?: number;
     left?: number;
@@ -42,24 +63,6 @@ type ImageTransform = {
           keep?: number;
         };
   };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
-  sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
 };
 
 type ImageDrawOptions = {

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -4532,8 +4532,10 @@ export interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4553,6 +4555,7 @@ export interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4567,8 +4570,9 @@ export interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 export interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4676,23 +4680,43 @@ export interface RequestInitCfPropertiesImage
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4704,7 +4728,15 @@ export interface RequestInitCfPropertiesImage
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4784,6 +4816,18 @@ export interface RequestInitCfPropertiesImage
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5700,7 +5744,26 @@ export type ImageInfoResponse =
       height: number;
     };
 export type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5709,45 +5772,31 @@ export type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 export type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -4544,8 +4544,10 @@ interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4565,6 +4567,7 @@ interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4579,8 +4582,9 @@ interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4686,23 +4690,43 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4714,7 +4738,15 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4794,6 +4826,18 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5707,7 +5751,26 @@ type ImageInfoResponse =
       height: number;
     };
 type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5716,45 +5779,31 @@ type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -4558,8 +4558,10 @@ export interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4579,6 +4581,7 @@ export interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4593,8 +4596,9 @@ export interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 export interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4702,23 +4706,43 @@ export interface RequestInitCfPropertiesImage
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4730,7 +4754,15 @@ export interface RequestInitCfPropertiesImage
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4810,6 +4842,18 @@ export interface RequestInitCfPropertiesImage
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5726,7 +5770,26 @@ export type ImageInfoResponse =
       height: number;
     };
 export type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5735,45 +5798,31 @@ export type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 export type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -4569,8 +4569,10 @@ interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4590,6 +4592,7 @@ interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4604,8 +4607,9 @@ interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4711,23 +4715,43 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4739,7 +4763,15 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4819,6 +4851,18 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5732,7 +5776,26 @@ type ImageInfoResponse =
       height: number;
     };
 type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5741,45 +5804,31 @@ type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -4583,8 +4583,10 @@ export interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4604,6 +4606,7 @@ export interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4618,8 +4621,9 @@ export interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 export interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4727,23 +4731,43 @@ export interface RequestInitCfPropertiesImage
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4755,7 +4779,15 @@ export interface RequestInitCfPropertiesImage
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4835,6 +4867,18 @@ export interface RequestInitCfPropertiesImage
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5751,7 +5795,26 @@ export type ImageInfoResponse =
       height: number;
     };
 export type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5760,45 +5823,31 @@ export type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 export type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -4570,8 +4570,10 @@ interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4591,6 +4593,7 @@ interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4605,8 +4608,9 @@ interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4712,23 +4716,43 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4740,7 +4764,15 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4820,6 +4852,18 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5733,7 +5777,26 @@ type ImageInfoResponse =
       height: number;
     };
 type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5742,45 +5805,31 @@ type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -4584,8 +4584,10 @@ export interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4605,6 +4607,7 @@ export interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4619,8 +4622,9 @@ export interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 export interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4728,23 +4732,43 @@ export interface RequestInitCfPropertiesImage
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4756,7 +4780,15 @@ export interface RequestInitCfPropertiesImage
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4836,6 +4868,18 @@ export interface RequestInitCfPropertiesImage
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5752,7 +5796,26 @@ export type ImageInfoResponse =
       height: number;
     };
 export type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5761,45 +5824,31 @@ export type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 export type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -4574,8 +4574,10 @@ interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4595,6 +4597,7 @@ interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4609,8 +4612,9 @@ interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4716,23 +4720,43 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4744,7 +4768,15 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4824,6 +4856,18 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5737,7 +5781,26 @@ type ImageInfoResponse =
       height: number;
     };
 type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5746,45 +5809,31 @@ type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -4588,8 +4588,10 @@ export interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4609,6 +4611,7 @@ export interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4623,8 +4626,9 @@ export interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 export interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4732,23 +4736,43 @@ export interface RequestInitCfPropertiesImage
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4760,7 +4784,15 @@ export interface RequestInitCfPropertiesImage
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4840,6 +4872,18 @@ export interface RequestInitCfPropertiesImage
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5756,7 +5800,26 @@ export type ImageInfoResponse =
       height: number;
     };
 export type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5765,45 +5828,31 @@ export type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 export type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -4579,8 +4579,10 @@ interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4600,6 +4602,7 @@ interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4614,8 +4617,9 @@ interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4721,23 +4725,43 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4749,7 +4773,15 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4829,6 +4861,18 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5742,7 +5786,26 @@ type ImageInfoResponse =
       height: number;
     };
 type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5751,45 +5814,31 @@ type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -4593,8 +4593,10 @@ export interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4614,6 +4616,7 @@ export interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4628,8 +4631,9 @@ export interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 export interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4737,23 +4741,43 @@ export interface RequestInitCfPropertiesImage
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4765,7 +4789,15 @@ export interface RequestInitCfPropertiesImage
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4845,6 +4877,18 @@ export interface RequestInitCfPropertiesImage
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5761,7 +5805,26 @@ export type ImageInfoResponse =
       height: number;
     };
 export type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5770,45 +5833,31 @@ export type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 export type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -4581,8 +4581,10 @@ interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4602,6 +4604,7 @@ interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4616,8 +4619,9 @@ interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4723,23 +4727,43 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4751,7 +4775,15 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4831,6 +4863,18 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5744,7 +5788,26 @@ type ImageInfoResponse =
       height: number;
     };
 type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5753,45 +5816,31 @@ type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -4595,8 +4595,10 @@ export interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4616,6 +4618,7 @@ export interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4630,8 +4633,9 @@ export interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 export interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4739,23 +4743,43 @@ export interface RequestInitCfPropertiesImage
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4767,7 +4791,15 @@ export interface RequestInitCfPropertiesImage
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4847,6 +4879,18 @@ export interface RequestInitCfPropertiesImage
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5763,7 +5807,26 @@ export type ImageInfoResponse =
       height: number;
     };
 export type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5772,45 +5835,31 @@ export type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 export type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -4581,8 +4581,10 @@ interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4602,6 +4604,7 @@ interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4616,8 +4619,9 @@ interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4723,23 +4727,43 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4751,7 +4775,15 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4831,6 +4863,18 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5744,7 +5788,26 @@ type ImageInfoResponse =
       height: number;
     };
 type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5753,45 +5816,31 @@ type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -4595,8 +4595,10 @@ export interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4616,6 +4618,7 @@ export interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4630,8 +4633,9 @@ export interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 export interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4739,23 +4743,43 @@ export interface RequestInitCfPropertiesImage
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4767,7 +4791,15 @@ export interface RequestInitCfPropertiesImage
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4847,6 +4879,18 @@ export interface RequestInitCfPropertiesImage
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5763,7 +5807,26 @@ export type ImageInfoResponse =
       height: number;
     };
 export type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5772,45 +5835,31 @@ export type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 export type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4662,8 +4662,10 @@ interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4683,6 +4685,7 @@ interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4697,8 +4700,9 @@ interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4804,23 +4808,43 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4832,7 +4856,15 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4912,6 +4944,18 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5825,7 +5869,26 @@ type ImageInfoResponse =
       height: number;
     };
 type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5834,45 +5897,31 @@ type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4676,8 +4676,10 @@ export interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4697,6 +4699,7 @@ export interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4711,8 +4714,9 @@ export interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 export interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4820,23 +4824,43 @@ export interface RequestInitCfPropertiesImage
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4848,7 +4872,15 @@ export interface RequestInitCfPropertiesImage
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4928,6 +4960,18 @@ export interface RequestInitCfPropertiesImage
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5844,7 +5888,26 @@ export type ImageInfoResponse =
       height: number;
     };
 export type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5853,45 +5916,31 @@ export type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 export type ImageDrawOptions = {
   opacity?: number;

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -4532,8 +4532,10 @@ export interface BasicImageTransformations {
    *    (white by default). Use of this mode is not recommended, as the same
    *    effect can be more efficiently achieved with the contain mode and the
    *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
   /**
    * When cropping with fit: "cover", this defines the side or point that should
    * be left uncropped. The value is either a string
@@ -4553,6 +4555,7 @@ export interface BasicImageTransformations {
     | "bottom"
     | "center"
     | "auto"
+    | "entropy"
     | BasicImageTransformationsGravityCoordinates;
   /**
    * Background color to add underneath the image. Applies only to images with
@@ -4567,8 +4570,9 @@ export interface BasicImageTransformations {
   rotate?: 0 | 90 | 180 | 270 | 360;
 }
 export interface BasicImageTransformationsGravityCoordinates {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -4676,23 +4680,43 @@ export interface RequestInitCfPropertiesImage
    */
   dpr?: number;
   /**
-   * An object with four properties {left, top, right, bottom} that specify
-   * a number of pixels to cut off on each side. Allows removal of borders
-   * or cutting out a specific fragment of an image. Trimming is performed
-   * before resizing or rotation. Takes dpr into account.
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
    */
-  trim?: {
-    left?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-  };
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
    */
-  quality?: number;
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
   /**
    * Output format to generate. It can be:
    *  - avif: generate images in AVIF format.
@@ -4704,7 +4728,15 @@ export interface RequestInitCfPropertiesImage
    * - jpeg: generate images in JPEG format.
    * - png: generate images in PNG format.
    */
-  format?: "avif" | "webp" | "json" | "jpeg" | "png";
+  format?:
+    | "avif"
+    | "webp"
+    | "json"
+    | "jpeg"
+    | "png"
+    | "baseline-jpeg"
+    | "png-force"
+    | "svg";
   /**
    * Whether to preserve animation frames from input files. Default is true.
    * Setting it to false reduces animations to still images. This setting is
@@ -4784,6 +4816,18 @@ export interface RequestInitCfPropertiesImage
    * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
    */
   gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
@@ -5700,7 +5744,26 @@ export type ImageInfoResponse =
       height: number;
     };
 export type ImageTransform = {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
+        color?: string;
+        width?: number;
+      }
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+      };
+  brightness?: number;
+  contrast?: number;
   fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
   gravity?:
     | "left"
     | "right"
@@ -5709,45 +5772,31 @@ export type ImageTransform = {
     | "center"
     | "auto"
     | "entropy"
-    | "face"
     | {
         x?: number;
         y?: number;
         mode: "remainder" | "box-center";
       };
-  trim?: {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  width?: number;
-  height?: number;
-  background?: string;
-  rotate?: number;
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
   sharpen?: number;
-  blur?: number;
-  contrast?: number;
-  brightness?: number;
-  gamma?: number;
-  border?: {
-    color?: string;
-    width?: number;
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-  };
-  zoom?: number;
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 export type ImageDrawOptions = {
   opacity?: number;


### PR DESCRIPTION
The types for Cloudflare Images are out of date - this updates the types for both RequestInitCfPropertiesImage and the references for images binding.