### PR TITLE
[o11y] Expand and refactor STW support

### DIFF
--- a/src/workerd/api/hibernatable-web-socket.c++
+++ b/src/workerd/api/hibernatable-web-socket.c++
@@ -6,6 +6,7 @@
 
 #include <workerd/api/global-scope.h>
 #include <workerd/io/hibernation-manager.h>
+#include <workerd/io/tracer.h>
 #include <workerd/jsg/ser.h>
 
 namespace workerd::api {

--- a/src/workerd/api/node/diagnostics-channel.c++
+++ b/src/workerd/api/node/diagnostics-channel.c++
@@ -2,6 +2,7 @@
 
 #include <workerd/io/io-context.h>
 #include <workerd/io/trace.h>
+#include <workerd/io/tracer.h>
 #include <workerd/jsg/ser.h>
 
 namespace workerd::api::node {

--- a/src/workerd/api/node/util.c++
+++ b/src/workerd/api/node/util.c++
@@ -5,6 +5,7 @@
 
 #include <workerd/io/features.h>
 #include <workerd/io/io-context.h>
+#include <workerd/io/tracer.h>
 #include <workerd/jsg/jsg.h>
 
 #include <kj/vector.h>

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -8,6 +8,7 @@
 
 #include <workerd/api/global-scope.h>
 #include <workerd/io/features.h>
+#include <workerd/io/tracer.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/ser.h>
 #include <workerd/util/mimetype.h>

--- a/src/workerd/api/tail-worker-test.js
+++ b/src/workerd/api/tail-worker-test.js
@@ -30,38 +30,38 @@ export const test = {
 
     let expected = [
       // http-test.js: fetch and scheduled events get reported correctly.
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"http://placeholder/body-length","cfJson":"","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"http://placeholder/body-length","cfJson":"","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"scheduled","scheduledTime":"1970-01-01T00:00:00.000Z","cron":""}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"scheduled","scheduledTime":"1970-01-01T00:00:00.000Z","cron":"* * * * 30"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://placeholder/not-found","cfJson":"","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://placeholder/web-socket","cfJson":"","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"exception","name":"Error","message":"The script will never generate a response."}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"http://placeholder/body-length","cfJson":"","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"http://placeholder/body-length","cfJson":"","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"scheduled","scheduledTime":"1970-01-01T00:00:00.000Z","cron":""}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"scheduled","scheduledTime":"1970-01-01T00:00:00.000Z","cron":"* * * * 30"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://placeholder/not-found","cfJson":"","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://placeholder/web-socket","cfJson":"","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"exception","name":"Error","message":"The script will never generate a response."}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // queue-test.js: queue events
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-delay-secs","value":"2"},{"name":"x-msg-fmt","value":"text"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"bytes"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"json"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"v8"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"POST","url":"https://fake-host/batch","cfJson":"","headers":[{"name":"cf-queue-batch-bytes","value":"31"},{"name":"cf-queue-batch-count","value":"4"},{"name":"cf-queue-largest-msg","value":"13"},{"name":"content-type","value":"application/json"},{"name":"x-msg-delay-secs","value":"2"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"queue","queueName":"test-queue","batchSize":5}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-delay-secs","value":"2"},{"name":"x-msg-fmt","value":"text"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"bytes"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"json"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/message","cfJson":"","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"v8"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/batch","cfJson":"","headers":[{"name":"cf-queue-batch-bytes","value":"31"},{"name":"cf-queue-batch-count","value":"4"},{"name":"cf-queue-largest-msg","value":"13"},{"name":"content-type","value":"application/json"},{"name":"x-msg-delay-secs","value":"2"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"queue","queueName":"test-queue","batchSize":5}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // actor-alarms-test.js: alarm events
-      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://foo/test","cfJson":"","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"alarm","scheduledTime":"1970-01-01T00:00:00.000Z"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://foo/test","cfJson":"","headers":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"alarm","scheduledTime":"1970-01-01T00:00:00.000Z"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // legacy tail worker, triggered via alarm test. It would appear that these being recorded
       // after the onsets above is not guaranteed, but since the streaming tail worker is invoked
       // when the main invocation starts whereas the legacy tail worker is only invoked when it ends
       // this should be fine in practice.
-      '{"type":"onset","info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // tests/websocket-hibernation.js: hibernatableWebSocket events
-      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://example.com/","cfJson":"","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"fetch","method":"GET","url":"http://example.com/hibernation","cfJson":"","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"hibernatableWebSocket","info":{"type":"message"}}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","info":{"type":"hibernatableWebSocket","info":{"type":"close","code":1000,"wasClean":true}}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://example.com/","cfJson":"","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://example.com/hibernation","cfJson":"","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"hibernatableWebSocket","info":{"type":"message"}}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","scriptTags":[],"info":{"type":"hibernatableWebSocket","info":{"type":"close","code":1000,"wasClean":true}}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
     ];
 
     assert.deepStrictEqual(response, expected);

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -8,6 +8,7 @@
 #include <workerd/api/http.h>
 #include <workerd/api/util.h>
 #include <workerd/io/io-context.h>
+#include <workerd/io/tracer.h>
 #include <workerd/jsg/ser.h>
 #include <workerd/util/own-util.h>
 #include <workerd/util/thread-scopes.h>

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -6,6 +6,7 @@
 #include <workerd/api/global-scope.h>
 #include <workerd/api/worker-rpc.h>
 #include <workerd/io/features.h>
+#include <workerd/io/tracer.h>
 #include <workerd/jsg/ser.h>
 
 #include <capnp/membrane.h>

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -5,6 +5,7 @@
 #include "io-context.h"
 
 #include <workerd/io/io-gate.h>
+#include <workerd/io/tracer.h>
 #include <workerd/io/worker.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/util/sentry.h>

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -14,7 +14,6 @@
 #include <workerd/io/io-thread-context.h>
 #include <workerd/io/io-timers.h>
 #include <workerd/io/trace.h>
-#include <workerd/io/tracer.h>
 #include <workerd/jsg/async-context.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/util/exception.h>
@@ -27,7 +26,9 @@
 #include <kj/function.h>
 #include <kj/mutex.h>
 
-#include <initializer_list>
+namespace workerd {
+class WorkerTracer;
+}
 
 namespace workerd {
 class LimitEnforcer;

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -1510,7 +1510,7 @@ void tracing::TailEvent::copyTo(rpc::Trace::TailEvent::Builder builder) {
         KJ_CASE_ONEOF(link, Link) {
           link.copyTo(eventBuilder.initLink());
         }
-        KJ_CASE_ONEOF(attrs, kj::Array<Attribute>) {
+        KJ_CASE_ONEOF(attrs, CustomInfo) {
           // Mark is a collection of attributes.
           auto attrBuilder = eventBuilder.initAttribute(attrs.size());
           for (size_t n = 0; n < attrs.size(); n++) {

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -632,7 +632,7 @@ struct Link final {
   Link clone() const;
 };
 
-using Mark = kj::OneOf<DiagnosticChannelEvent, Exception, Log, Return, Link, kj::Array<Attribute>>;
+using Mark = kj::OneOf<DiagnosticChannelEvent, Exception, Log, Return, Link, CustomInfo>;
 
 // Marks the opening of a child span within the streaming tail session.
 struct SpanOpen final {

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -349,10 +349,14 @@ void WorkerTracer::setFetchResponseInfo(tracing::FetchResponseInfo&& info) {
 
   KJ_REQUIRE(KJ_REQUIRE_NONNULL(trace->eventInfo).is<tracing::FetchEventInfo>());
   KJ_ASSERT(trace->fetchResponseInfo == kj::none, "setFetchResponseInfo can only be called once");
-  KJ_IF_SOME(writer, maybeTailStreamWriter) {
-    writer->report(KJ_ASSERT_NONNULL(topLevelInvocationSpanContext),
-        tracing::Return(tracing::Return::Info(info.clone())));
-  }
+  // TODO(streaming-tail): The fetch response info is currently being reported when terminating the
+  // request observer. This results in it being reported after the outcome event, which we need to
+  // avoid.
+  // KJ_IF_SOME(writer, maybeTailStreamWriter) {
+  //   KJ_LOG(WARNING, "setFetchResponseInfo");
+  //   writer->report(KJ_ASSERT_NONNULL(topLevelInvocationSpanContext),
+  //       tracing::Return(tracing::Return::Info(info.clone())));
+  // }
   trace->fetchResponseInfo = kj::mv(info);
 }
 

--- a/src/workerd/io/tracer.h
+++ b/src/workerd/io/tracer.h
@@ -91,7 +91,8 @@ class PipelineTracer final: public kj::Refcounted, public kj::EnableAddRefToThis
   friend class WorkerTracer;
 
  public:
-  kj::Maybe<kj::Own<tracing::TailStreamWriter>> maybeTailStreamWriter;
+  // tail stream writers for worker stages in the given pipeline.
+  kj::Vector<kj::Own<tracing::TailStreamWriter>> tailStreamWriters;
 };
 
 // An abstract class that defines shares functionality for tracers
@@ -185,6 +186,11 @@ class WorkerTracer final: public kj::Refcounted, public BaseTracer {
  private:
   PipelineLogLevel pipelineLogLevel;
   kj::Own<Trace> trace;
+
+  // TODO(streaming-tail): Top-level invocation span context, used to add a placeholder span context
+  // for trace events. This should no longer be needed after merging the existing span ID and
+  // InvocationSpanContext interfaces.
+  kj::Maybe<tracing::InvocationSpanContext> topLevelInvocationSpanContext;
 
   // own an instance of the pipeline to make sure it doesn't get destroyed
   // before we're finished tracing

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -365,7 +365,7 @@ kj::Promise<void> WorkerEntrypoint::request(kj::HttpMethod method,
     waitUntilTasks.add(maybeAddGcPassForTest(context, kj::mv(promise)));
   }))
       .then([this, metrics = kj::mv(metricsForProxyTask),
-                outcomeObserver = kj::mv(outcomeObserver)]() mutable -> kj::Promise<void> {
+                outcomeObserver = outcomeObserver.addRef()]() mutable -> kj::Promise<void> {
     TRACE_EVENT("workerd", "WorkerEntrypoint::request() finish proxying",
         PERFETTO_TERMINATING_FLOW_FROM_POINTER(this));
     // Now that the IoContext is dropped (unless it had waitUntil()s), we can finish proxying
@@ -384,7 +384,8 @@ kj::Promise<void> WorkerEntrypoint::request(kj::HttpMethod method,
     proxyTask = kj::none;
   }))
       .catch_([this, wrappedResponse = kj::mv(wrappedResponse), isActor, method, url, &headers,
-                  &requestBody, metrics = kj::mv(metricsForCatch)](
+                  &requestBody, metrics = kj::mv(metricsForCatch),
+                  outcomeObserver = kj::mv(outcomeObserver)](
                   kj::Exception&& exception) mutable -> kj::Promise<void> {
     // Don't return errors to end user.
     TRACE_EVENT("workerd", "WorkerEntrypoint::request() exception",

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -7,6 +7,7 @@
 #include <workerd/api/global-scope.h>
 #include <workerd/api/util.h>
 #include <workerd/io/io-context.h>
+#include <workerd/io/tracer.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/util/autogate.h>
 #include <workerd/util/sentry.h>

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -13,6 +13,7 @@
 #include <workerd/io/features.h>
 #include <workerd/io/frankenvalue.h>
 #include <workerd/io/promise-wrapper.h>
+#include <workerd/io/tracer.h>
 #include <workerd/io/worker.h>
 #include <workerd/jsg/async-context.h>
 #include <workerd/jsg/inspector.h>

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1478,9 +1478,7 @@ void Server::InspectorServiceIsolateRegistrar::registerIsolate(
 namespace {
 class RequestObserverWithTracer final: public RequestObserver, public WorkerInterface {
  public:
-  RequestObserverWithTracer(kj::Maybe<kj::Own<WorkerTracer>> tracer,
-      kj::Array<kj::Own<WorkerInterface>> streamingTailWorkers,
-      kj::TaskSet& waitUntilTasks)
+  RequestObserverWithTracer(kj::Maybe<kj::Own<WorkerTracer>> tracer, kj::TaskSet& waitUntilTasks)
       : tracer(kj::mv(tracer)) {}
 
   ~RequestObserverWithTracer() noexcept(false) {
@@ -1912,8 +1910,7 @@ class Server::WorkerService final: public Service,
       })));
     }
 
-    observer = kj::refcounted<RequestObserverWithTracer>(
-        mapAddRef(workerTracer), kj::mv(streamingTailWorkers), waitUntilTasks);
+    observer = kj::refcounted<RequestObserverWithTracer>(mapAddRef(workerTracer), waitUntilTasks);
 
     return newWorkerEntrypoint(threadContext, kj::atomicAddRef(*worker), entrypointName,
         kj::mv(props), kj::mv(actor), kj::Own<LimitEnforcer>(this, kj::NullDisposer::instance),

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -12,6 +12,7 @@
 #include <workerd/io/io-channels.h>
 #include <workerd/io/limit-enforcer.h>
 #include <workerd/io/observer.h>
+#include <workerd/io/tracer.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/setup.h>
 #include <workerd/server/server.h>

--- a/src/workerd/util/own-util.h
+++ b/src/workerd/util/own-util.h
@@ -6,6 +6,7 @@
 
 #include <kj/array.h>
 #include <kj/refcount.h>
+#include <kj/string.h>
 
 namespace workerd {
 
@@ -37,6 +38,10 @@ inline auto mapAddRef(kj::ArrayPtr<kj::Own<T>>& array) -> kj::Array<kj::Own<T>> 
 template <typename T>
 inline auto mapAddRef(kj::Array<kj::Own<T>>& array) -> kj::Array<kj::Own<T>> {
   return KJ_MAP(t, array) { return kj::addRef(*t); };
+}
+
+inline auto mapCopyString(kj::Maybe<kj::String>& string) -> kj::Maybe<kj::String> {
+  return string.map([](kj::String& s) { return kj::str(s); });
 }
 
 }  // namespace workerd


### PR DESCRIPTION
- Add rudimentary user tracing support
- Add support for fetch response info, ancillary fields like script tags
- Extend lifetime of outcome event for fetch handler so that exception outcome can be reported correctly.

Upstream PR to follow.