### PR TITLE
[build] Fix disabling exceptions on v8 and friends on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -93,17 +93,28 @@ build:v8-codegen-opt --per_file_copt=external/com_google_absl@-O2
 
 # In Google projects, exceptions are not used as a rule. Disabling them is more consistent with the
 # canonical V8 build and improves code size.
-build --per_file_copt=external/com_google_absl@-fno-exceptions
-build --per_file_copt=external/com_google_protobuf@-fno-exceptions
-build --per_file_copt=external/com_google_tcmalloc@-fno-exceptions
-build --per_file_copt=external/com_googlesource_chromium_icu@-fno-exceptions
-build --per_file_copt=external/perfetto@-fno-exceptions
-build --per_file_copt=external/ssl@-fno-exceptions
-build --per_file_copt=external/v8@-fno-exceptions
-build --per_file_copt=external/ada-url@-fno-exceptions
-build --per_file_copt=external/simdutf@-fno-exceptions
+build:unix --per_file_copt=external/com_google_absl@-fno-exceptions
+build:unix --per_file_copt=external/com_google_protobuf@-fno-exceptions
+build:unix --per_file_copt=external/com_google_tcmalloc@-fno-exceptions
+build:unix --per_file_copt=external/com_googlesource_chromium_icu@-fno-exceptions
+build:unix --per_file_copt=external/perfetto@-fno-exceptions
+build:unix --per_file_copt=external/ssl@-fno-exceptions
+build:unix --per_file_copt=external/v8@-fno-exceptions
+build:unix --per_file_copt=external/ada-url@-fno-exceptions
+build:unix --per_file_copt=external/simdutf@-fno-exceptions
+build:windows --per_file_copt=external/com_google_absl@/GX-
+build:windows --per_file_copt=external/com_google_protobuf@/GX-
+build:windows --per_file_copt=external/com_google_tcmalloc@/GX-
+build:windows --per_file_copt=external/com_googlesource_chromium_icu@/GX-
+build:windows --per_file_copt=external/perfetto@/GX-
+build:windows --per_file_copt=external/ssl@/GX-
+build:windows --per_file_copt=external/v8@/GX-
+build:windows --per_file_copt=external/ada-url@/GX-
+build:windows --per_file_copt=external/simdutf@/GX-
+
 # V8 torque is an exception from this policy, see v8 BUILD.gn.
-build --per_file_copt=external/v8/src/torque@-fexceptions
+build:unix --per_file_copt=external/v8/src/torque@-fexceptions
+build:windows --per_file_copt=external/v8/src/torque@/GX
 
 # Disable relaxing all jumps during LLVM codegen under -O0, which previously led to build
 # performance improvements but makes code size worse. This will be the default in LLVM19.

--- a/build/BUILD.dawn
+++ b/build/BUILD.dawn
@@ -6,12 +6,16 @@ COPTS_UNIX = [
     "-fno-exceptions",
 ]
 
-# TODO(debloat): Disable exceptions and RTTI for dawn, this greatly improves binary size. Note that
-# these flags are not supported by clang-cl and cause warnings there – explore enabling the
-# corresponding flags '/GX-', '/GR-' on Windows after confirming they are safe.
+COPTS_WINDOWS = [
+    "/GR-",
+    "/GX-",
+]
+
+# Disable exceptions and RTTI for dawn, this greatly improves binary size.
 COPTS = select({
     "@platforms//os:osx": COPTS_UNIX,
     "@platforms//os:linux": COPTS_UNIX,
+    "@platforms//os:windows": COPTS_WINDOWS,
     "//conditions:default": [],
 })
 


### PR DESCRIPTION
-fno-exceptions is not available with clang-cl, which causes lots of warnings on CI. Use the equivalent /GX- flag instead.