### PR TITLE
Python: Put tag and lockfile hash in info section in package bzl file

### DIFF
--- a/build/python/packages_20240829_4.bzl
+++ b/build/python/packages_20240829_4.bzl
@@ -2,167 +2,173 @@
 # (https://github.com/cloudflare/pyodide-build-scripts) and should not be manually modified.
 
 PACKAGES_20240829_4 = {
-    "aiohttp": [
-        "aiohttp",
-    ],
-    "aiosignal": [
-        "aiosignal",
-    ],
-    "annotated-types": [
-        "annotated_types",
-    ],
-    "anyio": [
-        "anyio",
-    ],
-    "async-timeout": [
-        "async_timeout",
-    ],
-    "attrs": [
-        "attr",
-        "attrs",
-    ],
-    "certifi": [
-        "certifi",
-    ],
-    "charset-normalizer": [
-        "charset_normalizer",
-    ],
-    "distro": [
-        "distro",
-    ],
-    "fastapi": [
-        "fastapi",
-    ],
-    "frozenlist": [
-        "frozenlist",
-    ],
-    "h11": [
-        "h11",
-    ],
-    "hashlib": [
-        "_hashlib",
-    ],
-    "httpcore": [
-        "httpcore",
-    ],
-    "httpx": [
-        "httpx",
-    ],
-    "idna": [
-        "idna",
-    ],
-    "jsonpatch": [
-        "jsonpatch",
-    ],
-    "jsonpointer": [
-        "jsonpointer",
-    ],
-    "langchain": [
-        "langchain",
-    ],
-    "langchain-core": [
-        "langchain_core",
-        "langchain_core.callbacks",
-        "langchain_core.language_models.llms",
-        "langchain_core.output_parsers",
-        "langchain_core.prompts",
-    ],
-    "langchain_openai": [
-        "langchain_openai",
-        "langchain_openai.chat_models.base",
-    ],
-    "langsmith": [
-        "langsmith",
-        "langsmith.client",
-    ],
-    "lzma": [
-        "_lzma",
-        "lzma",
-    ],
-    "micropip": [
-        "micropip",
-    ],
-    "multidict": [
-        "multidict",
-    ],
-    "numpy": [
-        "numpy",
-    ],
-    "openai": [
-        "openai",
-    ],
-    "packaging": [
-        "packaging",
-    ],
-    "pydantic": [
-        "pydantic",
-    ],
-    "pydantic_core": [
-        "pydantic_core",
-    ],
-    "pydecimal": [
-        "_pydecimal",
-    ],
-    "pydoc_data": [
-        "pydoc_data",
-    ],
-    "pyyaml": [
-        "_yaml",
-        "yaml",
-    ],
-    "regex": [
-        "regex",
-    ],
-    "requests": [
-        "requests",
-    ],
-    "six": [
-        "six",
-    ],
-    "sniffio": [
-        "sniffio",
-    ],
-    "sqlite3": [
-        "_sqlite3",
-        "sqlite3",
-    ],
-    "ssl": [
-        "_ssl",
-        "ssl",
-    ],
-    "starlette": [
-        "starlette",
-        "starlette.applications",
-        "starlette.authentication",
-        "starlette.background",
-        "starlette.concurrency",
-        "starlette.config",
-        "starlette.convertors",
-        "starlette.datastructures",
-        "starlette.endpoints",
-        "starlette.exceptions",
-        "starlette.formparsers",
-        "starlette.middleware",
-        "starlette.middleware.base",
-        "starlette.requests",
-        "starlette.responses",
-        "starlette.routing",
-        "starlette.schemas",
-    ],
-    "tenacity": [
-        "tenacity",
-    ],
-    "tiktoken": [
-        "tiktoken",
-        "tiktoken_ext",
-    ],
-    "typing-extensions": [
-        "typing_extensions",
-    ],
-    "urllib3": [
-        "urllib3",
-    ],
-    "yarl": [
-        "yarl",
-    ],
+    "info": {
+        "tag": "20240829.4",
+        "lockfile_hash": "c2d9c67ea55a672b95a3beb8d66bfbe7df736edb4bb657383b263151e7e85ef4",
+    },
+    "import_tests": {
+        "aiohttp": [
+            "aiohttp",
+        ],
+        "aiosignal": [
+            "aiosignal",
+        ],
+        "annotated-types": [
+            "annotated_types",
+        ],
+        "anyio": [
+            "anyio",
+        ],
+        "async-timeout": [
+            "async_timeout",
+        ],
+        "attrs": [
+            "attr",
+            "attrs",
+        ],
+        "certifi": [
+            "certifi",
+        ],
+        "charset-normalizer": [
+            "charset_normalizer",
+        ],
+        "distro": [
+            "distro",
+        ],
+        "fastapi": [
+            "fastapi",
+        ],
+        "frozenlist": [
+            "frozenlist",
+        ],
+        "h11": [
+            "h11",
+        ],
+        "hashlib": [
+            "_hashlib",
+        ],
+        "httpcore": [
+            "httpcore",
+        ],
+        "httpx": [
+            "httpx",
+        ],
+        "idna": [
+            "idna",
+        ],
+        "jsonpatch": [
+            "jsonpatch",
+        ],
+        "jsonpointer": [
+            "jsonpointer",
+        ],
+        "langchain": [
+            "langchain",
+        ],
+        "langchain-core": [
+            "langchain_core",
+            "langchain_core.callbacks",
+            "langchain_core.language_models.llms",
+            "langchain_core.output_parsers",
+            "langchain_core.prompts",
+        ],
+        "langchain_openai": [
+            "langchain_openai",
+            "langchain_openai.chat_models.base",
+        ],
+        "langsmith": [
+            "langsmith",
+            "langsmith.client",
+        ],
+        "lzma": [
+            "_lzma",
+            "lzma",
+        ],
+        "micropip": [
+            "micropip",
+        ],
+        "multidict": [
+            "multidict",
+        ],
+        "numpy": [
+            "numpy",
+        ],
+        "openai": [
+            "openai",
+        ],
+        "packaging": [
+            "packaging",
+        ],
+        "pydantic": [
+            "pydantic",
+        ],
+        "pydantic_core": [
+            "pydantic_core",
+        ],
+        "pydecimal": [
+            "_pydecimal",
+        ],
+        "pydoc_data": [
+            "pydoc_data",
+        ],
+        "pyyaml": [
+            "_yaml",
+            "yaml",
+        ],
+        "regex": [
+            "regex",
+        ],
+        "requests": [
+            "requests",
+        ],
+        "six": [
+            "six",
+        ],
+        "sniffio": [
+            "sniffio",
+        ],
+        "sqlite3": [
+            "_sqlite3",
+            "sqlite3",
+        ],
+        "ssl": [
+            "_ssl",
+            "ssl",
+        ],
+        "starlette": [
+            "starlette",
+            "starlette.applications",
+            "starlette.authentication",
+            "starlette.background",
+            "starlette.concurrency",
+            "starlette.config",
+            "starlette.convertors",
+            "starlette.datastructures",
+            "starlette.endpoints",
+            "starlette.exceptions",
+            "starlette.formparsers",
+            "starlette.middleware",
+            "starlette.middleware.base",
+            "starlette.requests",
+            "starlette.responses",
+            "starlette.routing",
+            "starlette.schemas",
+        ],
+        "tenacity": [
+            "tenacity",
+        ],
+        "tiktoken": [
+            "tiktoken",
+            "tiktoken_ext",
+        ],
+        "typing-extensions": [
+            "typing_extensions",
+        ],
+        "urllib3": [
+            "urllib3",
+        ],
+        "yarl": [
+            "yarl",
+        ],
+    },
 }

--- a/build/python/packages_20250324_1.bzl
+++ b/build/python/packages_20250324_1.bzl
@@ -2,266 +2,272 @@
 # (https://github.com/cloudflare/pyodide-build-scripts) and should not be manually modified.
 
 PACKAGES_20250324_1 = {
-    "PyJWT": [
-        "jwt",
-    ],
-    "aiohappyeyeballs": [
-        "aiohappyeyeballs",
-    ],
-    "aiohttp": [
-        "aiohttp",
-    ],
-    "aiohttp-tests": [
-        "aiohttp",
-    ],
-    "aiosignal": [
-        "aiosignal",
-    ],
-    "annotated-types": [
-        "annotated_types",
-    ],
-    "annotated-types-tests": [
-        "annotated_types",
-    ],
-    "anyio": [
-        "anyio",
-    ],
-    "async-timeout": [
-        "async_timeout",
-    ],
-    "attrs": [
-        "attr",
-        "attrs",
-    ],
-    "beautifulsoup4": [
-        "bs4",
-    ],
-    "beautifulsoup4-tests": [
-        "bs4",
-    ],
-    "certifi": [
-        "certifi",
-    ],
-    "cffi": [
-        "cffi",
-    ],
-    "charset-normalizer": [
-        "charset_normalizer",
-    ],
-    "cryptography": [
-        "cryptography",
-        "cryptography.fernet",
-        "cryptography.hazmat",
-        "cryptography.utils",
-        "cryptography.x509",
-    ],
-    "distro": [
-        "distro",
-    ],
-    "fastapi": [
-        "fastapi",
-    ],
-    "frozenlist": [
-        "frozenlist",
-    ],
-    "h11": [
-        "h11",
-    ],
-    "h11-tests": [
-        "h11",
-    ],
-    "hashlib": [
-        "_hashlib",
-    ],
-    "httpcore": [
-        "httpcore",
-    ],
-    "httpx": [
-        "httpx",
-    ],
-    "idna": [
-        "idna",
-    ],
-    "jsonpatch": [
-        "jsonpatch",
-    ],
-    "jsonpointer": [
-        "jsonpointer",
-    ],
-    "langchain": [
-        "langchain",
-    ],
-    "langchain-core": [
-        "langchain_core",
-        "langchain_core.callbacks",
-        "langchain_core.language_models.llms",
-        "langchain_core.output_parsers",
-        "langchain_core.prompts",
-    ],
-    "langchain_openai": [
-        "langchain_openai",
-        "langchain_openai.chat_models.base",
-    ],
-    "langsmith": [
-        "langsmith",
-        "langsmith.client",
-    ],
-    "lzma": [
-        "_lzma",
-        "lzma",
-    ],
-    "micropip": [
-        "micropip",
-    ],
-    "multidict": [
-        "multidict",
-    ],
-    "numpy": [
-        "numpy",
-    ],
-    "numpy-tests": [
-        "numpy",
-    ],
-    "openai": [
-        "openai",
-    ],
-    "packaging": [
-        "packaging",
-    ],
-    "propcache": [
-        "propcache",
-    ],
-    "pycparser": [
-        "pycparser",
-    ],
-    "pydantic": [
-        "pydantic",
-        "pydantic.alias_generators",
-        "pydantic.aliases",
-        "pydantic.annotated_handlers",
-        "pydantic.class_validators",
-        "pydantic.color",
-        "pydantic.config",
-        "pydantic.dataclasses",
-        "pydantic.datetime_parse",
-        "pydantic.decorator",
-        "pydantic.deprecated",
-        "pydantic.env_settings",
-        "pydantic.error_wrappers",
-        "pydantic.errors",
-        "pydantic.experimental",
-        "pydantic.fields",
-        "pydantic.functional_serializers",
-        "pydantic.functional_validators",
-        "pydantic.generics",
-        "pydantic.json",
-        "pydantic.json_schema",
-        "pydantic.main",
-        "pydantic.networks",
-        "pydantic.parse",
-        "pydantic.plugin",
-        "pydantic.root_model",
-        "pydantic.schema",
-        "pydantic.tools",
-        "pydantic.type_adapter",
-        "pydantic.types",
-        "pydantic.typing",
-        "pydantic.utils",
-        "pydantic.v1",
-        "pydantic.validate_call_decorator",
-        "pydantic.validators",
-        "pydantic.version",
-        "pydantic.warnings",
-    ],
-    "pydantic_core": [
-        "pydantic_core",
-    ],
-    "pydecimal": [
-        "_pydecimal",
-    ],
-    "pydoc_data": [
-        "pydoc_data",
-    ],
-    "python-multipart": [
-        "multipart",
-        "python_multipart",
-    ],
-    "pyyaml": [
-        "_yaml",
-        "yaml",
-    ],
-    "regex": [
-        "regex",
-    ],
-    "regex-tests": [
-        "regex",
-    ],
-    "requests": [
-        "requests",
-    ],
-    "six": [
-        "six",
-    ],
-    "sniffio": [
-        "sniffio",
-    ],
-    "sniffio-tests": [
-        "sniffio",
-    ],
-    "soupsieve": [
-        "soupsieve",
-    ],
-    "sqlalchemy": [
-        "sqlalchemy",
-    ],
-    "sqlalchemy-tests": [
-        "sqlalchemy",
-    ],
-    "sqlite3": [
-        "_sqlite3",
-        "sqlite3",
-    ],
-    "ssl": [
-        "_ssl",
-        "ssl",
-    ],
-    "starlette": [
-        "starlette",
-        "starlette.applications",
-        "starlette.authentication",
-        "starlette.background",
-        "starlette.concurrency",
-        "starlette.config",
-        "starlette.converters",
-        "starlette.datastructures",
-        "starlette.endpoints",
-        "starlette.exceptions",
-        "starlette.formparsers",
-        "starlette.middleware",
-        "starlette.middleware.base",
-        "starlette.requests",
-        "starlette.responses",
-        "starlette.routing",
-        "starlette.schemas",
-    ],
-    "tblib": [
-        "tblib",
-    ],
-    "tenacity": [
-        "tenacity",
-    ],
-    "tiktoken": [
-        "tiktoken",
-        "tiktoken_ext",
-    ],
-    "typing-extensions": [
-        "typing_extensions",
-    ],
-    "urllib3": [
-        "urllib3",
-        "urllib3.contrib.emscripten",
-    ],
-    "yarl": [
-        "yarl",
-    ],
+    "info": {
+        "tag": "20250324.1",
+        "lockfile_hash": "3e5a9317dc0cfcf63e556034bf0e87b958bd6debcfdccdfffc8ce477cc439626",
+    },
+    "import_tests": {
+        "PyJWT": [
+            "jwt",
+        ],
+        "aiohappyeyeballs": [
+            "aiohappyeyeballs",
+        ],
+        "aiohttp": [
+            "aiohttp",
+        ],
+        "aiohttp-tests": [
+            "aiohttp",
+        ],
+        "aiosignal": [
+            "aiosignal",
+        ],
+        "annotated-types": [
+            "annotated_types",
+        ],
+        "annotated-types-tests": [
+            "annotated_types",
+        ],
+        "anyio": [
+            "anyio",
+        ],
+        "async-timeout": [
+            "async_timeout",
+        ],
+        "attrs": [
+            "attr",
+            "attrs",
+        ],
+        "beautifulsoup4": [
+            "bs4",
+        ],
+        "beautifulsoup4-tests": [
+            "bs4",
+        ],
+        "certifi": [
+            "certifi",
+        ],
+        "cffi": [
+            "cffi",
+        ],
+        "charset-normalizer": [
+            "charset_normalizer",
+        ],
+        "cryptography": [
+            "cryptography",
+            "cryptography.fernet",
+            "cryptography.hazmat",
+            "cryptography.utils",
+            "cryptography.x509",
+        ],
+        "distro": [
+            "distro",
+        ],
+        "fastapi": [
+            "fastapi",
+        ],
+        "frozenlist": [
+            "frozenlist",
+        ],
+        "h11": [
+            "h11",
+        ],
+        "h11-tests": [
+            "h11",
+        ],
+        "hashlib": [
+            "_hashlib",
+        ],
+        "httpcore": [
+            "httpcore",
+        ],
+        "httpx": [
+            "httpx",
+        ],
+        "idna": [
+            "idna",
+        ],
+        "jsonpatch": [
+            "jsonpatch",
+        ],
+        "jsonpointer": [
+            "jsonpointer",
+        ],
+        "langchain": [
+            "langchain",
+        ],
+        "langchain-core": [
+            "langchain_core",
+            "langchain_core.callbacks",
+            "langchain_core.language_models.llms",
+            "langchain_core.output_parsers",
+            "langchain_core.prompts",
+        ],
+        "langchain_openai": [
+            "langchain_openai",
+            "langchain_openai.chat_models.base",
+        ],
+        "langsmith": [
+            "langsmith",
+            "langsmith.client",
+        ],
+        "lzma": [
+            "_lzma",
+            "lzma",
+        ],
+        "micropip": [
+            "micropip",
+        ],
+        "multidict": [
+            "multidict",
+        ],
+        "numpy": [
+            "numpy",
+        ],
+        "numpy-tests": [
+            "numpy",
+        ],
+        "openai": [
+            "openai",
+        ],
+        "packaging": [
+            "packaging",
+        ],
+        "propcache": [
+            "propcache",
+        ],
+        "pycparser": [
+            "pycparser",
+        ],
+        "pydantic": [
+            "pydantic",
+            "pydantic.alias_generators",
+            "pydantic.aliases",
+            "pydantic.annotated_handlers",
+            "pydantic.class_validators",
+            "pydantic.color",
+            "pydantic.config",
+            "pydantic.dataclasses",
+            "pydantic.datetime_parse",
+            "pydantic.decorator",
+            "pydantic.deprecated",
+            "pydantic.env_settings",
+            "pydantic.error_wrappers",
+            "pydantic.errors",
+            "pydantic.experimental",
+            "pydantic.fields",
+            "pydantic.functional_serializers",
+            "pydantic.functional_validators",
+            "pydantic.generics",
+            "pydantic.json",
+            "pydantic.json_schema",
+            "pydantic.main",
+            "pydantic.networks",
+            "pydantic.parse",
+            "pydantic.plugin",
+            "pydantic.root_model",
+            "pydantic.schema",
+            "pydantic.tools",
+            "pydantic.type_adapter",
+            "pydantic.types",
+            "pydantic.typing",
+            "pydantic.utils",
+            "pydantic.v1",
+            "pydantic.validate_call_decorator",
+            "pydantic.validators",
+            "pydantic.version",
+            "pydantic.warnings",
+        ],
+        "pydantic_core": [
+            "pydantic_core",
+        ],
+        "pydecimal": [
+            "_pydecimal",
+        ],
+        "pydoc_data": [
+            "pydoc_data",
+        ],
+        "python-multipart": [
+            "multipart",
+            "python_multipart",
+        ],
+        "pyyaml": [
+            "_yaml",
+            "yaml",
+        ],
+        "regex": [
+            "regex",
+        ],
+        "regex-tests": [
+            "regex",
+        ],
+        "requests": [
+            "requests",
+        ],
+        "six": [
+            "six",
+        ],
+        "sniffio": [
+            "sniffio",
+        ],
+        "sniffio-tests": [
+            "sniffio",
+        ],
+        "soupsieve": [
+            "soupsieve",
+        ],
+        "sqlalchemy": [
+            "sqlalchemy",
+        ],
+        "sqlalchemy-tests": [
+            "sqlalchemy",
+        ],
+        "sqlite3": [
+            "_sqlite3",
+            "sqlite3",
+        ],
+        "ssl": [
+            "_ssl",
+            "ssl",
+        ],
+        "starlette": [
+            "starlette",
+            "starlette.applications",
+            "starlette.authentication",
+            "starlette.background",
+            "starlette.concurrency",
+            "starlette.config",
+            "starlette.converters",
+            "starlette.datastructures",
+            "starlette.endpoints",
+            "starlette.exceptions",
+            "starlette.formparsers",
+            "starlette.middleware",
+            "starlette.middleware.base",
+            "starlette.requests",
+            "starlette.responses",
+            "starlette.routing",
+            "starlette.schemas",
+        ],
+        "tblib": [
+            "tblib",
+        ],
+        "tenacity": [
+            "tenacity",
+        ],
+        "tiktoken": [
+            "tiktoken",
+            "tiktoken_ext",
+        ],
+        "typing-extensions": [
+            "typing_extensions",
+        ],
+        "urllib3": [
+            "urllib3",
+            "urllib3.contrib.emscripten",
+        ],
+        "yarl": [
+            "yarl",
+        ],
+    },
 }


### PR DESCRIPTION
This goes together with:
https://github.com/cloudflare/pyodide-build-scripts/pull/11 
which changes the generated bazel file to match the new expected format.

Use "Hide whitespace" to review.