### PR TITLE
Worker::numRequestsInFlight

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1741,6 +1741,18 @@ Worker::~Worker() noexcept(false) {
   lock->push(kj::mv(impl));
 }
 
+void Worker::onRequestStarted() const {
+  requestsInFlight.fetch_add(1, std::memory_order_relaxed);
+}
+
+void Worker::onRequestFinished() const {
+  requestsInFlight.fetch_sub(1, std::memory_order_relaxed);
+}
+
+uint64_t Worker::numRequestsInFlight() const {
+  return requestsInFlight.load(std::memory_order_relaxed);
+}
+
 void Worker::handleLog(jsg::Lock& js,
     ConsoleMode consoleMode,
     LogLevel level,

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -26,6 +26,8 @@
 #include <kj/compat/http.h>
 #include <kj/mutex.h>
 
+#include <atomic>
+
 namespace v8 {
 class Isolate;
 }
@@ -165,7 +167,15 @@ class Worker: public kj::AtomicRefcounted {
   static void setupContext(
       jsg::Lock& lock, v8::Local<v8::Context> context, Worker::ConsoleMode consoleMode);
 
+  void onRequestStarted() const;
+
+  void onRequestFinished() const;
+
+  uint64_t numRequestsInFlight() const;
+
  private:
+  mutable std::atomic<uint64_t> requestsInFlight;
+
   kj::Own<const Script> script;
 
   kj::Own<WorkerObserver> metrics;


### PR DESCRIPTION
We do scheduling decision based on number requests in flight. We currently use the number of references for that but it is very fiddly and easy to break.

Track the number of requests in flight directly.

I was considering to make on* methods private, but that would require me to move WorkerEntrypoint out of anonymous namespace. LMK if you still prefer me to do that.