### PR TITLE
remove authorization properties from url in websocket constructor

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1841,25 +1841,6 @@ namespace {
 // Fetch spec requires (suggests?) 20: https://fetch.spec.whatwg.org/#http-redirect-fetch
 constexpr auto MAX_REDIRECT_COUNT = 20;
 
-// URI-encode control characters and spaces.
-kj::String uriEncodeControlChars(kj::ArrayPtr<const byte> bytes) {
-  // TODO(cleanup): Once this is deployed, update open-source KJ HTTP to do this automatically.
-  const char HEX_DIGITS_URI[] = "0123456789ABCDEF";
-
-  kj::Vector<char> result(bytes.size() + 1);
-  for (byte b: bytes) {
-    if (b > 0x20) {
-      result.add(b);
-    } else {
-      result.add('%');
-      result.add(HEX_DIGITS_URI[b / 16]);
-      result.add(HEX_DIGITS_URI[b % 16]);
-    }
-  }
-  result.add('\0');
-  return kj::String(result.releaseAsArray());
-}
-
 jsg::Promise<jsg::Ref<Response>> handleHttpResponse(jsg::Lock& js,
     jsg::Ref<Fetcher> fetcher,
     jsg::Ref<Request> jsRequest,

--- a/src/workerd/api/tests/global-scope-test.js
+++ b/src/workerd/api/tests/global-scope-test.js
@@ -751,3 +751,16 @@ export const validateGlobalThis = {
     util.inspect(globalThis);
   },
 };
+
+export const webSocketUrlValidation = {
+  async test() {
+    // Username and password should have been set in Authorization header
+    // but we silently ignore it to match the fetch() implementation.
+    doesNotThrow(() => new WebSocket('ws://username@domain.com'));
+    // Empty values should be rejected.
+    throws(() => new WebSocket(''), {
+      name: 'SyntaxError',
+      message: /invalid/,
+    });
+  },
+};

--- a/src/workerd/api/util.c++
+++ b/src/workerd/api/util.c++
@@ -238,4 +238,23 @@ kj::Array<char16_t> fastEncodeUtf16(kj::ArrayPtr<const char> bytes) {
   return output.first(actual_length).attach(kj::mv(output));
 }
 
+// URI-encode control characters and spaces.
+kj::String uriEncodeControlChars(kj::ArrayPtr<const byte> bytes) {
+  // TODO(cleanup): Once this is deployed, update open-source KJ HTTP to do this automatically.
+  const char HEX_DIGITS_URI[] = "0123456789ABCDEF";
+
+  kj::Vector<char> result(bytes.size() + 1);
+  for (byte b: bytes) {
+    if (b > 0x20) {
+      result.add(b);
+    } else {
+      result.add('%');
+      result.add(HEX_DIGITS_URI[b / 16]);
+      result.add(HEX_DIGITS_URI[b % 16]);
+    }
+  }
+  result.add('\0');
+  return kj::String(result.releaseAsArray());
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/util.h
+++ b/src/workerd/api/util.h
@@ -87,4 +87,6 @@ void maybeWarnIfNotText(jsg::Lock& js, kj::StringPtr str);
 kj::String fastEncodeBase64Url(kj::ArrayPtr<const byte> bytes);
 kj::Array<char16_t> fastEncodeUtf16(kj::ArrayPtr<const char> bytes);
 
+kj::String uriEncodeControlChars(kj::ArrayPtr<const byte> bytes);
+
 }  // namespace workerd::api


### PR DESCRIPTION
This is not a breaking change since we already disallow it but rather throw an Internal Error whenever a user passes a URL with username/password state.

After this change, we now throw a JSG error which will be propagated to the end-user in a clear way.