### PR TITLE
Add daily release automation

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -1,0 +1,50 @@
+name: Daily Release
+
+on:
+  schedule:
+    # Run at 00:30 UTC every day
+    - cron: '30 0 * * *'
+  # Allow manual triggering for testing
+  workflow_dispatch:
+
+jobs:
+  update-compatibility-date:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        
+      - name: Update compatibility date
+        run: |
+          echo "${{ steps.date.outputs.date }}" > src/workerd/io/supported-compatibility-date.txt
+          
+      - name: Check for changes
+        id: git-check
+        run: |
+          if [[ $(git status --porcelain src/workerd/io/supported-compatibility-date.txt) ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+          
+      - name: Set up Git identity
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+      - name: Commit and push changes
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git add src/workerd/io/supported-compatibility-date.txt
+          git commit -m "Release ${{ steps.date.outputs.date }}"
+          git push


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically updates the \ file daily at 00:30 UTC
- This update triggers the existing release workflow, creating daily releases
- The workflow includes a manual trigger option for testing and only pushes when the date has actually changed

## Test plan
- Manually trigger the workflow to verify it correctly updates the compatibility date file
- Verify the workflow runs automatically at the scheduled time

🤖 Generated with [Claude Code](https://claude.ai/code)