### PR TITLE
use llvm 18

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:dev-bookworm
 
 # Install dependencies, including clang via through LLVM APT repository. Note that this
 # will also install lldb and clangd alongside dependencies.
-ARG LLVM_VERSION=16
+ARG LLVM_VERSION=18
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install software-properties-common python3 python3-distutils tclsh nodejs npm \
     && curl -fSsL -o /tmp/llvm.sh https://apt.llvm.org/llvm.sh && chmod +x /tmp/llvm.sh && bash /tmp/llvm.sh ${LLVM_VERSION} \

--- a/.github/workflows/_bazel.yml
+++ b/.github/workflows/_bazel.yml
@@ -57,10 +57,10 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           sed -i '/apt-get install/d' llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 16
+          sudo ./llvm.sh 18
           # keep in sync with build/ci.bazelrc
-          sudo apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev libclang-rt-16-dev llvm-16
-          sed -i -e "s%llvm-symbolizer%/usr/lib/llvm-16/bin/llvm-symbolizer%" .bazelrc
+          sudo apt-get install -y --no-install-recommends clang-18 lld-18 libunwind-18 libc++abi1-18 libc++1-18 libc++-18-dev libclang-rt-18-dev llvm-18
+          sed -i -e "s%llvm-symbolizer%/usr/lib/llvm-18/bin/llvm-symbolizer%" .bazelrc
       - name: Setup Windows
         if: inputs.os_name == 'windows'
         # Set a custom output root directory to avoid long file name issues.

--- a/.github/workflows/release-python-runtime.yml
+++ b/.github/workflows/release-python-runtime.yml
@@ -25,10 +25,10 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           sed -i '/apt-get install/d' llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 16
-          sudo apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev
-          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
-          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
+          sudo ./llvm.sh 18
+          sudo apt-get install -y --no-install-recommends clang-18 lld-18 libunwind-18 libc++abi1-18 libc++1-18 libc++-18-dev
+          echo "build:linux --action_env=CC=/usr/lib/llvm-18/bin/clang" >> .bazelrc
+          echo "build:linux --host_action_env=CC=/usr/lib/llvm-18/bin/clang" >> .bazelrc
       - name: Configure download mirrors
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,10 +115,10 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           sed -i '/apt-get install/d' llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 16
-          sudo apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev
-          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
-          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
+          sudo ./llvm.sh 18
+          sudo apt-get install -y --no-install-recommends clang-18 lld-18 libunwind-18 libc++abi1-18 libc++1-18 libc++-18-dev
+          echo "build:linux --action_env=CC=/usr/lib/llvm-18/bin/clang" >> .bazelrc
+          echo "build:linux --host_action_env=CC=/usr/lib/llvm-18/bin/clang" >> .bazelrc
       - name: Setup macOS
         if: runner.os == 'macOS'
         run: |
@@ -294,10 +294,10 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           sed -i '/apt-get install/d' llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 16
-          sudo apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev
-          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
-          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
+          sudo ./llvm.sh 18
+          sudo apt-get install -y --no-install-recommends clang-18 lld-18 libunwind-18 libc++abi1-18 libc++1-18 libc++-18-dev
+          echo "build:linux --action_env=CC=/usr/lib/llvm-18/bin/clang" >> .bazelrc
+          echo "build:linux --host_action_env=CC=/usr/lib/llvm-18/bin/clang" >> .bazelrc
       - name: Build type generating Worker
         run: |
           bazel build --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types:types_worker
@@ -355,10 +355,10 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           sed -i '/apt-get install/d' llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 16
-          sudo apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev
-          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
-          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
+          sudo ./llvm.sh 18
+          sudo apt-get install -y --no-install-recommends clang-18 lld-18 libunwind-18 libc++abi1-18 libc++1-18 libc++-18-dev
+          echo "build:linux --action_env=CC=/usr/lib/llvm-18/bin/clang" >> .bazelrc
+          echo "build:linux --host_action_env=CC=/usr/lib/llvm-18/bin/clang" >> .bazelrc
       - name: build types
         run: |
             bazel build --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types:types

--- a/.github/workflows/type-snapshot.yml
+++ b/.github/workflows/type-snapshot.yml
@@ -40,10 +40,10 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           sed -i '/apt-get install/d' llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 16
-          sudo apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev
-          echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
-          echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
+          sudo ./llvm.sh 18
+          sudo apt-get install -y --no-install-recommends clang-18 lld-18 libunwind-18 libc++abi1-18 libc++1-18 libc++-18-dev
+          echo "build:linux --action_env=CC=/usr/lib/llvm-18/bin/clang" >> .bazelrc
+          echo "build:linux --host_action_env=CC=/usr/lib/llvm-18/bin/clang" >> .bazelrc
       - name: build types
         run: |
           bazel build --disk_cache=~/bazel-disk-cache --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types:types

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,5 +1,3 @@
-# TODO(later): llvm-toolchain-16 has been backported to Bullseye with the 11.9 point release –
-# switch to using the regular packages instead of LLVM's APT repo here.
 FROM node:bullseye AS builder
 
 WORKDIR /workerd
@@ -12,12 +10,12 @@ RUN wget https://apt.llvm.org/llvm.sh
 # Drop the install step here so we can install just the packages we need.
 RUN sed -i '/apt-get install/d' llvm.sh
 RUN chmod +x llvm.sh
-RUN ./llvm.sh 16
-RUN apt-get install -y --no-install-recommends clang-16 lld-16 libunwind-16 libc++abi1-16 libc++1-16 libc++-16-dev libclang-rt-16-dev
+RUN ./llvm.sh 18
+RUN apt-get install -y --no-install-recommends clang-18 lld-18 libunwind-18 libc++abi1-18 libc++1-18 libc++-18-dev libclang-rt-18-dev
 COPY . .
 
-RUN echo "build:linux --action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
-RUN echo "build:linux --host_action_env=CC=/usr/lib/llvm-16/bin/clang" >> .bazelrc
+RUN echo "build:linux --action_env=CC=/usr/lib/llvm-18/bin/clang" >> .bazelrc
+RUN echo "build:linux --host_action_env=CC=/usr/lib/llvm-18/bin/clang" >> .bazelrc
 COPY .bazel-cache /bazel-disk-cache
 # pnpm version will be different depending on the value of `packageManager` field in package.json
 RUN npm install -g pnpm@latest

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ To build `workerd`, you need:
 * Bazel
   * If you use [Bazelisk](https://github.com/bazelbuild/bazelisk) (recommended), it will automatically download and use the right version of Bazel for building workerd.
 * On Linux:
-  * We use the clang/LLVM toolchain to build workerd and support version 16 and higher. Earlier versions of clang may still work, but are not officially supported.
-  * Clang 16+ (e.g. package `clang-16` on Debian Bookworm). If clang is installed as `clang-<version>` please create a symlink to it in your PATH named `clang`, or use `--action_env=CC=clang-<version>` on `bazel` command lines to specify the compiler name.
+  * We use the clang/LLVM toolchain to build workerd and support version 18 and higher. Earlier versions of clang may still work, but are not officially supported.
+  * Clang 18+ (e.g. package `clang-18` on Debian Bookworm). If clang is installed as `clang-<version>` please create a symlink to it in your PATH named `clang`, or use `--action_env=CC=clang-<version>` on `bazel` command lines to specify the compiler name.
 
-  * libc++ 16+ (e.g. packages `libc++-16-dev` and `libc++abi-16-dev`)
-  * LLD 16+ (e.g. package `lld-16`).
+  * libc++ 18+ (e.g. packages `libc++-18-dev` and `libc++abi-18-dev`)
+  * LLD 18+ (e.g. package `lld-18`).
   * `python3`, `python3-distutils`, and `tcl8.6`
 * On macOS:
   * Xcode 16 installation (available on macOS 14 and higher). Building with just the Xcode Command Line Tools is not being tested, but should work too.

--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -54,8 +54,8 @@ build:ci-linux-common --copt='-Werror'
 build:ci-linux-common --copt='-Wno-error=#warnings'
 build:ci-linux-common --copt='-Wno-error=deprecated-declarations'
 # keep in sync with .github/workflows/test.yml
-build:ci-linux-common --action_env=CC=/usr/lib/llvm-16/bin/clang
-build:ci-linux-common --host_action_env=CC=/usr/lib/llvm-16/bin/clang
+build:ci-linux-common --action_env=CC=/usr/lib/llvm-18/bin/clang
+build:ci-linux-common --host_action_env=CC=/usr/lib/llvm-18/bin/clang
 
 build:ci-linux --config=ci-linux-common
 build:ci-linux-arm --config=ci-linux --remote_download_regex=".*src/workerd/server/workerd.*"

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -18,8 +18,8 @@
 -Iexternal/ncrypto/include
 -isystembazel-bin/external/sqlite3
 -Isrc
--isystem/usr/lib/llvm-16/include/c++/v1
--isystem/usr/lib/llvm-16/lib/clang/16/include
+-isystem/usr/lib/llvm-18/include/c++/v1
+-isystem/usr/lib/llvm-18/lib/clang/18/include
 -isystem/usr/include/x86_64-linux-gnu
 -isystem/usr/include/aarch64-linux-gnu
 -isystem/usr/include

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,7 +26,7 @@ just compile-commands
 
 workerd code is automatically formatted by clang-format. Run `python ./tools/cross/format.py` to reformat the code
 or use the appropriate IDE extension.
-While building workerd currently requires LLVM 16 or above, formatting requires clang-format 18.1.8 as different
+While building workerd currently requires LLVM 18 or above, formatting requires clang-format 18.1.8 as different
 versions result in different format suggestions. This is automatically fetched using Bazel and does not need to be
 installed manually.
 

--- a/doxyfile
+++ b/doxyfile
@@ -1222,8 +1222,8 @@ CLANG_OPTIONS          = -std=c++20     \
                          -I/usr/include/c++/11/bits \
                          -I/usr/include/x86_64-linux-gnu \
                          -I/usr/include/x86_64-linux-gnu/c++/11 \
-                         -I/usr/lib/llvm-16/include/c++/v1 \
-                         -I/usr/lib/llvm-16/lib/clang/16/include
+                         -I/usr/lib/llvm-18/include/c++/v1 \
+                         -I/usr/lib/llvm-18/lib/clang/18/include
 
 # If clang assisted parsing is enabled you can provide the clang parser with the
 # path to the directory containing a file called compile_commands.json. This


### PR DESCRIPTION
I hit https://github.com/llvm/llvm-project/issues/67449 similar to https://github.com/dtolnay/cxx/issues/1436 in #3822 

This was fixed in llvm-18: https://github.com/llvm/llvm-project/commit/078651b6de4b767b91e3e6a51e5df11a06d7bc4f

clang-18 is available since Debian stable (bookworm) and Ubuntu LTS (24.04)