### PR TITLE
Improve crypto memory accounting 

### DIFF
--- a/src/workerd/api/crypto/crypto.c++
+++ b/src/workerd/api/crypto/crypto.c++
@@ -652,14 +652,14 @@ jsg::Promise<SubtleCrypto::ExportKeyData> SubtleCrypto::exportKey(
   });
 }
 
-bool SubtleCrypto::timingSafeEqual(kj::Array<kj::byte> a, kj::Array<kj::byte> b) {
+bool SubtleCrypto::timingSafeEqual(jsg::BufferSource a, jsg::BufferSource b) {
   JSG_REQUIRE(a.size() == b.size(), TypeError, "Input buffers must have the same byte length.");
 
   // The implementation here depends entirely on the characteristics of the CRYPTO_memcmp
   // implementation. We do not perform any additional verification that the operation is
   // actually timing safe other than checking the input types and lengths.
 
-  return CRYPTO_memcmp(a.begin(), b.begin(), a.size()) == 0;
+  return CRYPTO_memcmp(a.asArrayPtr().begin(), b.asArrayPtr().begin(), a.size()) == 0;
 }
 
 // =======================================================================================

--- a/src/workerd/api/crypto/crypto.c++
+++ b/src/workerd/api/crypto/crypto.c++
@@ -306,8 +306,8 @@ bool CryptoKey::operator==(const CryptoKey& other) const {
   return this == &other || (getType() == other.getType() && impl->equals(*other.impl));
 }
 
-CryptoKey::AsymmetricKeyDetails CryptoKey::getAsymmetricKeyDetails() const {
-  return impl->getAsymmetricKeyDetail();
+CryptoKey::AsymmetricKeyDetails CryptoKey::getAsymmetricKeyDetails(jsg::Lock& js) const {
+  return impl->getAsymmetricKeyDetail(js);
 }
 
 bool CryptoKey::verifyX509Public(const X509* cert) const {

--- a/src/workerd/api/crypto/crypto.h
+++ b/src/workerd/api/crypto/crypto.h
@@ -187,8 +187,6 @@ class CryptoKey: public jsg::Object {
     JSG_MEMORY_INFO(HmacKeyAlgorithm) {}
   };
 
-  using BigInteger = kj::Array<kj::byte>;
-
   struct RsaKeyAlgorithm {
     // "RSASSA-PKCS1-v1_5", "RSA-PSS", "RSA-OAEP"
     kj::StringPtr name;
@@ -197,41 +195,25 @@ class CryptoKey: public jsg::Object {
     uint16_t modulusLength;
 
     // The RSA public exponent (in unsigned big-endian form)
-    kj::OneOf<BigInteger, jsg::BufferSource> publicExponent;
+    jsg::BufferSource publicExponent;
 
     // The hash algorithm that is used with this key.
     jsg::Optional<KeyAlgorithm> hash;
 
     RsaKeyAlgorithm clone(jsg::Lock& js) const {
       auto fixPublicExp = FeatureFlags::get(js).getCryptoPreservePublicExponent();
-      KJ_SWITCH_ONEOF(publicExponent) {
-        KJ_CASE_ONEOF(array, BigInteger) {
-          if (fixPublicExp) {
-            // alloc will, by default create a Uint8Array
-            auto expBack = jsg::BackingStore::alloc(js, array.size());
-            expBack.asArrayPtr().copyFrom(array);
-            return {name, modulusLength, jsg::BufferSource(js, kj::mv(expBack)), hash};
-          } else {
-            auto expBack = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, array.size());
-            expBack.asArrayPtr().copyFrom(array);
-            return {name, modulusLength, jsg::BufferSource(js, kj::mv(expBack)), hash};
-          }
-        }
-        KJ_CASE_ONEOF(source, jsg::BufferSource) {
-          // Should only happen if the flag is enabled and an algorithm field is cloned twice.
-          if (fixPublicExp) {
-            // alloc will, by default create a Uint8Array
-            auto expBack = jsg::BackingStore::alloc(js, source.size());
-            expBack.asArrayPtr().copyFrom(source);
-            return {name, modulusLength, jsg::BufferSource(js, kj::mv(expBack)), hash};
-          } else {
-            auto expBack = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, source.size());
-            expBack.asArrayPtr().copyFrom(source);
-            return {name, modulusLength, jsg::BufferSource(js, kj::mv(expBack)), hash};
-          }
-        }
+
+      // Should only happen if the flag is enabled and an algorithm field is cloned twice.
+      if (fixPublicExp) {
+        // alloc will, by default create a Uint8Array.
+        auto expBack = jsg::BackingStore::alloc(js, publicExponent.size());
+        expBack.asArrayPtr().copyFrom(publicExponent.asArrayPtr());
+        return {name, modulusLength, jsg::BufferSource(js, kj::mv(expBack)), hash};
+      } else {
+        auto expBack = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, publicExponent.size());
+        expBack.asArrayPtr().copyFrom(publicExponent.asArrayPtr());
+        return {name, modulusLength, jsg::BufferSource(js, kj::mv(expBack)), hash};
       }
-      KJ_UNREACHABLE;
     }
 
     JSG_STRUCT(name, modulusLength, publicExponent, hash);
@@ -270,7 +252,7 @@ class CryptoKey: public jsg::Object {
   // by CryptoKey::Impl to provide the actual implementation.
   struct AsymmetricKeyDetails {
     jsg::Optional<uint32_t> modulusLength;
-    jsg::Optional<kj::Array<kj::byte>> publicExponent;
+    jsg::Optional<jsg::BufferSource> publicExponent;
     // TODO(later): BoringSSL does not currently support getting the RSA-PSS
     // details for an RSA key. Once it does, we can update our impl and add
     // these fields.
@@ -287,7 +269,7 @@ class CryptoKey: public jsg::Object {
         divisorLength,
         namedCurve);
   };
-  AsymmetricKeyDetails getAsymmetricKeyDetails() const;
+  AsymmetricKeyDetails getAsymmetricKeyDetails(jsg::Lock& js) const;
 
   ~CryptoKey() noexcept(false);
 
@@ -377,10 +359,10 @@ class SubtleCrypto: public jsg::Object {
     kj::String name;
 
     // For AES: The initialization vector use. May be up to 2^64-1 bytes long.
-    jsg::Optional<kj::Array<kj::byte>> iv;
+    jsg::Optional<jsg::BufferSource> iv;
 
     // The additional authentication data to include.
-    jsg::Optional<kj::Array<kj::byte>> additionalData;
+    jsg::Optional<jsg::BufferSource> additionalData;
 
     // The desired length of the authentication tag. May be 0 - 128.
     // Note: the spec specifies this as a Web IDL byte (== signed char in C++), not an int, but JS
@@ -389,7 +371,7 @@ class SubtleCrypto: public jsg::Object {
 
     // The initial value of the counter block for AES-CTR.
     // https://www.w3.org/TR/WebCryptoAPI/#aes-ctr-params
-    jsg::Optional<kj::Array<kj::byte>> counter;
+    jsg::Optional<jsg::BufferSource> counter;
 
     // The length, in bits, of the rightmost part of the counter block that is incremented.
     // See above why we use int instead of int8_t.
@@ -397,7 +379,7 @@ class SubtleCrypto: public jsg::Object {
     jsg::Optional<int> length;
 
     // The optional label/application data to associate with the message (for RSA-OAEP)
-    jsg::Optional<kj::Array<kj::byte>> label;
+    jsg::Optional<jsg::BufferSource> label;
 
     JSG_STRUCT(name, iv, additionalData, tagLength, counter, length, label);
   };
@@ -435,7 +417,7 @@ class SubtleCrypto: public jsg::Object {
     jsg::Optional<int> modulusLength;
 
     // For RSA algorithms
-    jsg::Optional<kj::Array<kj::byte>> publicExponent;
+    jsg::Optional<jsg::BufferSource> publicExponent;
 
     // For AES algorithms or when name == "HMAC": The length in bits of the key.
     jsg::Optional<int> length;
@@ -477,7 +459,7 @@ class SubtleCrypto: public jsg::Object {
     kj::String name;
 
     // PBKDF2 parameters
-    jsg::Optional<kj::Array<kj::byte>> salt;
+    jsg::Optional<jsg::BufferSource> salt;
     jsg::Optional<int> iterations;
     jsg::Optional<kj::OneOf<kj::String, HashAlgorithm>> hash;
 
@@ -488,7 +470,7 @@ class SubtleCrypto: public jsg::Object {
 
     // Bit string that corresponds to the context and application specific context for the derived
     // keying material
-    jsg::Optional<kj::Array<kj::byte>> info;
+    jsg::Optional<jsg::BufferSource> info;
 
     JSG_STRUCT(name, salt, iterations, hash, $public, info);
   };

--- a/src/workerd/api/crypto/crypto.h
+++ b/src/workerd/api/crypto/crypto.h
@@ -620,7 +620,7 @@ class SubtleCrypto: public jsg::Object {
       const jsg::TypeHandler<JsonWebKey>& jwkHandler);
 
   // This is a non-standard extension based off Node.js' implementation of crypto.timingSafeEqual.
-  bool timingSafeEqual(kj::Array<kj::byte> a, kj::Array<kj::byte> b);
+  bool timingSafeEqual(jsg::BufferSource a, jsg::BufferSource b);
 
   JSG_RESOURCE_TYPE(SubtleCrypto) {
     JSG_METHOD(encrypt);

--- a/src/workerd/api/crypto/crypto.h
+++ b/src/workerd/api/crypto/crypto.h
@@ -657,7 +657,7 @@ class DigestContext {
  public:
   virtual ~DigestContext() noexcept = default;
   virtual void write(kj::ArrayPtr<kj::byte> buffer) = 0;
-  virtual kj::Array<kj::byte> close() = 0;
+  virtual jsg::BufferSource close(jsg::Lock& js) = 0;
 };
 
 class DigestStream: public WritableStream {
@@ -667,12 +667,12 @@ class DigestStream: public WritableStream {
 
   explicit DigestStream(kj::Own<WritableStreamController> controller,
       SubtleCrypto::HashAlgorithm algorithm,
-      jsg::Promise<kj::Array<kj::byte>>::Resolver resolver,
-      jsg::Promise<kj::Array<kj::byte>> promise);
+      jsg::Promise<jsg::BufferSource>::Resolver resolver,
+      jsg::Promise<jsg::BufferSource> promise);
 
   static jsg::Ref<DigestStream> constructor(jsg::Lock& js, Algorithm algorithm);
 
-  jsg::MemoizedIdentity<jsg::Promise<kj::Array<kj::byte>>>& getDigest() {
+  jsg::MemoizedIdentity<jsg::Promise<jsg::BufferSource>>& getDigest() {
     return promise;
   }
   void dispose(jsg::Lock& js);
@@ -700,15 +700,14 @@ class DigestStream: public WritableStream {
 
   struct Ready {
     SubtleCrypto::HashAlgorithm algorithm;
-    jsg::Promise<kj::Array<kj::byte>>::Resolver resolver;
+    jsg::Promise<jsg::BufferSource>::Resolver resolver;
     DigestContextPtr context;
-    Ready(
-        SubtleCrypto::HashAlgorithm algorithm, jsg::Promise<kj::Array<kj::byte>>::Resolver resolver)
+    Ready(SubtleCrypto::HashAlgorithm algorithm, jsg::Promise<jsg::BufferSource>::Resolver resolver)
         : algorithm(kj::mv(algorithm)),
           resolver(kj::mv(resolver)),
           context(initContext(this->algorithm)) {}
   };
-  jsg::MemoizedIdentity<jsg::Promise<kj::Array<kj::byte>>> promise;
+  jsg::MemoizedIdentity<jsg::Promise<jsg::BufferSource>> promise;
   kj::OneOf<Ready, StreamStates::Closed, StreamStates::Errored> state;
   uint64_t bytesWritten = 0;
 

--- a/src/workerd/api/crypto/ec.c++
+++ b/src/workerd/api/crypto/ec.c++
@@ -114,7 +114,7 @@ jsg::BufferSource Ec::getRawPublicKey(jsg::Lock& js) const {
   return jsg::BufferSource(js, kj::mv(backing));
 }
 
-CryptoKey::AsymmetricKeyDetails Ec::getAsymmetricKeyDetail() const {
+CryptoKey::AsymmetricKeyDetails Ec::getAsymmetricKeyDetail(jsg::Lock& js) const {
   // Adapted from Node.js' GetEcKeyDetail
   return CryptoKey::AsymmetricKeyDetails{
     .namedCurve = kj::str(OBJ_nid2sn(EC_GROUP_get_curve_name(group)))};
@@ -418,9 +418,9 @@ class EllipticKey final: public AsymmetricKeyCryptoKeyImpl {
         .getRawPublicKey(js);
   }
 
-  CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail() const override {
+  CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail(jsg::Lock& js) const override {
     // Adapted from Node.js' GetEcKeyDetail
-    return KJ_ASSERT_NONNULL(Ec::tryGetEc(getEvpPkey())).getAsymmetricKeyDetail();
+    return KJ_ASSERT_NONNULL(Ec::tryGetEc(getEvpPkey())).getAsymmetricKeyDetail(js);
   }
 
   CryptoKey::EllipticKeyAlgorithm keyAlgorithm;
@@ -971,7 +971,7 @@ class EdDsaKey final: public AsymmetricKeyCryptoKeyImpl {
     return jsg::BufferSource(js, kj::mv(backing));
   }
 
-  CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail() const override {
+  CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail(jsg::Lock& js) const override {
     // Node.js implementation for EdDsa keys currently does not provide any detail
     return CryptoKey::AsymmetricKeyDetails{};
   }

--- a/src/workerd/api/crypto/ec.h
+++ b/src/workerd/api/crypto/ec.h
@@ -38,7 +38,7 @@ class Ec final {
 
   jsg::BufferSource getRawPublicKey(jsg::Lock& js) const KJ_WARN_UNUSED_RESULT;
 
-  CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail() const;
+  CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail(jsg::Lock& js) const;
 
  private:
   EC_KEY* key;

--- a/src/workerd/api/crypto/hkdf.c++
+++ b/src/workerd/api/crypto/hkdf.c++
@@ -42,9 +42,11 @@ class HkdfKey final: public CryptoKey::Impl {
     const EVP_MD* hashType = lookupDigestAlgorithm(hashName).second;
 
     const auto& salt =
-        JSG_REQUIRE_NONNULL(algorithm.salt, TypeError, "Missing field \"salt\" in \"algorithm\".");
+        JSG_REQUIRE_NONNULL(algorithm.salt, TypeError, "Missing field \"salt\" in \"algorithm\".")
+            .asArrayPtr();
     const auto& info =
-        JSG_REQUIRE_NONNULL(algorithm.info, TypeError, "Missing field \"info\" in \"algorithm\".");
+        JSG_REQUIRE_NONNULL(algorithm.info, TypeError, "Missing field \"info\" in \"algorithm\".")
+            .asArrayPtr();
 
     uint32_t length = JSG_REQUIRE_NONNULL(
         maybeLength, DOMOperationError, "HKDF cannot derive a key with null length.");

--- a/src/workerd/api/crypto/impl.c++
+++ b/src/workerd/api/crypto/impl.c++
@@ -222,10 +222,10 @@ bool CryptoKey::Impl::equals(const jsg::BufferSource& other) const {
   KJ_FAIL_REQUIRE("Unable to compare raw key material for this key");
 }
 
-kj::Own<CryptoKey::Impl> CryptoKey::Impl::from(kj::Own<EVP_PKEY> key) {
+kj::Own<CryptoKey::Impl> CryptoKey::Impl::from(jsg::Lock& js, kj::Own<EVP_PKEY> key) {
   switch (EVP_PKEY_id(key.get())) {
     case EVP_PKEY_RSA:
-      return fromRsaKey(kj::mv(key));
+      return fromRsaKey(js, kj::mv(key));
     case EVP_PKEY_EC:
       return fromEcKey(kj::mv(key));
     case EVP_PKEY_ED25519:

--- a/src/workerd/api/crypto/impl.h
+++ b/src/workerd/api/crypto/impl.h
@@ -137,7 +137,7 @@ class CryptoKey::Impl {
 
   Impl(bool extractable, CryptoKeyUsageSet usages): extractable(extractable), usages(usages) {}
 
-  static kj::Own<CryptoKey::Impl> from(kj::Own<EVP_PKEY> key);
+  static kj::Own<CryptoKey::Impl> from(jsg::Lock& js, kj::Own<EVP_PKEY> key);
 
   bool isExtractable() const {
     return extractable;
@@ -221,7 +221,7 @@ class CryptoKey::Impl {
 
   virtual kj::StringPtr getAlgorithmName() const = 0;
 
-  virtual CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail() const {
+  virtual CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail(jsg::Lock& js) const {
     JSG_FAIL_REQUIRE(DOMNotSupportedError,
         "The getAsymmetricKeyDetail operation is not implemented for \"", getAlgorithmName(),
         "\".");
@@ -430,7 +430,7 @@ void checkPbkdfLimits(jsg::Lock& js, size_t iterations);
 // is properly seeded without consuming entropy.
 bool CSPRNG(kj::ArrayPtr<kj::byte> buffer);
 
-kj::Own<CryptoKey::Impl> fromRsaKey(kj::Own<EVP_PKEY> key);
+kj::Own<CryptoKey::Impl> fromRsaKey(jsg::Lock& js, kj::Own<EVP_PKEY> key);
 kj::Own<CryptoKey::Impl> fromEcKey(kj::Own<EVP_PKEY> key);
 kj::Own<CryptoKey::Impl> fromEd25519Key(kj::Own<EVP_PKEY> key);
 

--- a/src/workerd/api/crypto/pbkdf2.c++
+++ b/src/workerd/api/crypto/pbkdf2.c++
@@ -41,7 +41,8 @@ class Pbkdf2Key final: public CryptoKey::Impl {
         JSG_REQUIRE_NONNULL(algorithm.hash, TypeError, "Missing field \"hash\" in \"algorithm\"."));
     auto hashType = lookupDigestAlgorithm(hashName).second;
     kj::ArrayPtr<kj::byte> salt =
-        JSG_REQUIRE_NONNULL(algorithm.salt, TypeError, "Missing field \"salt\" in \"algorithm\".");
+        JSG_REQUIRE_NONNULL(algorithm.salt, TypeError, "Missing field \"salt\" in \"algorithm\".")
+            .asArrayPtr();
     int iterations = JSG_REQUIRE_NONNULL(
         algorithm.iterations, TypeError, "Missing field \"iterations\" in \"algorithm\".");
 

--- a/src/workerd/api/crypto/rsa.h
+++ b/src/workerd/api/crypto/rsa.h
@@ -30,7 +30,7 @@ class Rsa final {
 
   jsg::BufferSource getPublicExponent(jsg::Lock& js) KJ_WARN_UNUSED_RESULT;
 
-  CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail() const KJ_WARN_UNUSED_RESULT;
+  CryptoKey::AsymmetricKeyDetails getAsymmetricKeyDetail(jsg::Lock& js) const KJ_WARN_UNUSED_RESULT;
 
   jsg::BufferSource sign(
       jsg::Lock& js, const kj::ArrayPtr<const kj::byte> data) const KJ_WARN_UNUSED_RESULT;

--- a/src/workerd/api/crypto/x509.c++
+++ b/src/workerd/api/crypto/x509.c++
@@ -654,12 +654,12 @@ jsg::BufferSource X509Certificate::getRaw(jsg::Lock& js) {
   return jsg::BufferSource(js, kj::mv(buf));
 }
 
-kj::Maybe<jsg::Ref<CryptoKey>> X509Certificate::getPublicKey() {
+kj::Maybe<jsg::Ref<CryptoKey>> X509Certificate::getPublicKey(jsg::Lock& js) {
   ClearErrorOnReturn clear_error_on_return;
   auto ptr = X509_get_pubkey(cert_.get());
   if (ptr == nullptr) return kj::none;
   auto pkey = kj::disposeWith<EVP_PKEY_free>(ptr);
-  return jsg::alloc<CryptoKey>(CryptoKey::Impl::from(kj::mv(pkey)));
+  return jsg::alloc<CryptoKey>(CryptoKey::Impl::from(js, kj::mv(pkey)));
 }
 
 kj::Maybe<kj::String> X509Certificate::getPem() {

--- a/src/workerd/api/crypto/x509.h
+++ b/src/workerd/api/crypto/x509.h
@@ -24,7 +24,7 @@ class X509Certificate: public jsg::Object {
   kj::Maybe<kj::Array<kj::String>> getKeyUsage();
   kj::Maybe<kj::Array<const char>> getSerialNumber();
   jsg::BufferSource getRaw(jsg::Lock& js);
-  kj::Maybe<jsg::Ref<CryptoKey>> getPublicKey();
+  kj::Maybe<jsg::Ref<CryptoKey>> getPublicKey(jsg::Lock& js);
   kj::Maybe<kj::String> getPem();
   kj::Maybe<kj::String> getFingerprint();
   kj::Maybe<kj::String> getFingerprint256();

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -1182,26 +1182,26 @@ interface RsaOtherPrimesInfo {
 }
 interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1236,7 +1236,7 @@ interface CryptoKeyHmacKeyAlgorithm {
 interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 interface CryptoKeyEllipticKeyAlgorithm {
@@ -1253,7 +1253,7 @@ declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  readonly digest: Promise<ArrayBuffer>;
+  readonly digest: Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -1187,26 +1187,26 @@ export interface RsaOtherPrimesInfo {
 }
 export interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1241,7 +1241,7 @@ export interface CryptoKeyHmacKeyAlgorithm {
 export interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 export interface CryptoKeyEllipticKeyAlgorithm {
@@ -1258,7 +1258,7 @@ export declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  readonly digest: Promise<ArrayBuffer>;
+  readonly digest: Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -1188,26 +1188,26 @@ interface RsaOtherPrimesInfo {
 }
 interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1242,7 +1242,7 @@ interface CryptoKeyHmacKeyAlgorithm {
 interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 interface CryptoKeyEllipticKeyAlgorithm {
@@ -1259,7 +1259,7 @@ declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -1193,26 +1193,26 @@ export interface RsaOtherPrimesInfo {
 }
 export interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1247,7 +1247,7 @@ export interface CryptoKeyHmacKeyAlgorithm {
 export interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 export interface CryptoKeyEllipticKeyAlgorithm {
@@ -1264,7 +1264,7 @@ export declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -1206,26 +1206,26 @@ interface RsaOtherPrimesInfo {
 }
 interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1260,7 +1260,7 @@ interface CryptoKeyHmacKeyAlgorithm {
 interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 interface CryptoKeyEllipticKeyAlgorithm {
@@ -1277,7 +1277,7 @@ declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -1211,26 +1211,26 @@ export interface RsaOtherPrimesInfo {
 }
 export interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1265,7 +1265,7 @@ export interface CryptoKeyHmacKeyAlgorithm {
 export interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 export interface CryptoKeyEllipticKeyAlgorithm {
@@ -1282,7 +1282,7 @@ export declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -1206,26 +1206,26 @@ interface RsaOtherPrimesInfo {
 }
 interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1260,7 +1260,7 @@ interface CryptoKeyHmacKeyAlgorithm {
 interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 interface CryptoKeyEllipticKeyAlgorithm {
@@ -1277,7 +1277,7 @@ declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -1211,26 +1211,26 @@ export interface RsaOtherPrimesInfo {
 }
 export interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1265,7 +1265,7 @@ export interface CryptoKeyHmacKeyAlgorithm {
 export interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 export interface CryptoKeyEllipticKeyAlgorithm {
@@ -1282,7 +1282,7 @@ export declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -1206,26 +1206,26 @@ interface RsaOtherPrimesInfo {
 }
 interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1260,7 +1260,7 @@ interface CryptoKeyHmacKeyAlgorithm {
 interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 interface CryptoKeyEllipticKeyAlgorithm {
@@ -1277,7 +1277,7 @@ declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -1211,26 +1211,26 @@ export interface RsaOtherPrimesInfo {
 }
 export interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1265,7 +1265,7 @@ export interface CryptoKeyHmacKeyAlgorithm {
 export interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 export interface CryptoKeyEllipticKeyAlgorithm {
@@ -1282,7 +1282,7 @@ export declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -1211,26 +1211,26 @@ interface RsaOtherPrimesInfo {
 }
 interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1265,7 +1265,7 @@ interface CryptoKeyHmacKeyAlgorithm {
 interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 interface CryptoKeyEllipticKeyAlgorithm {
@@ -1282,7 +1282,7 @@ declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -1216,26 +1216,26 @@ export interface RsaOtherPrimesInfo {
 }
 export interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1270,7 +1270,7 @@ export interface CryptoKeyHmacKeyAlgorithm {
 export interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 export interface CryptoKeyEllipticKeyAlgorithm {
@@ -1287,7 +1287,7 @@ export declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -1211,26 +1211,26 @@ interface RsaOtherPrimesInfo {
 }
 interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1265,7 +1265,7 @@ interface CryptoKeyHmacKeyAlgorithm {
 interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 interface CryptoKeyEllipticKeyAlgorithm {
@@ -1282,7 +1282,7 @@ declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -1216,26 +1216,26 @@ export interface RsaOtherPrimesInfo {
 }
 export interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1270,7 +1270,7 @@ export interface CryptoKeyHmacKeyAlgorithm {
 export interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 export interface CryptoKeyEllipticKeyAlgorithm {
@@ -1287,7 +1287,7 @@ export declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -1211,26 +1211,26 @@ interface RsaOtherPrimesInfo {
 }
 interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1265,7 +1265,7 @@ interface CryptoKeyHmacKeyAlgorithm {
 interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 interface CryptoKeyEllipticKeyAlgorithm {
@@ -1282,7 +1282,7 @@ declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -1216,26 +1216,26 @@ export interface RsaOtherPrimesInfo {
 }
 export interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1270,7 +1270,7 @@ export interface CryptoKeyHmacKeyAlgorithm {
 export interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 export interface CryptoKeyEllipticKeyAlgorithm {
@@ -1287,7 +1287,7 @@ export declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -1221,26 +1221,26 @@ interface RsaOtherPrimesInfo {
 }
 interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1275,7 +1275,7 @@ interface CryptoKeyHmacKeyAlgorithm {
 interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 interface CryptoKeyEllipticKeyAlgorithm {
@@ -1292,7 +1292,7 @@ declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -1226,26 +1226,26 @@ export interface RsaOtherPrimesInfo {
 }
 export interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1280,7 +1280,7 @@ export interface CryptoKeyHmacKeyAlgorithm {
 export interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 export interface CryptoKeyEllipticKeyAlgorithm {
@@ -1297,7 +1297,7 @@ export declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  get digest(): Promise<ArrayBuffer>;
+  get digest(): Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -1182,26 +1182,26 @@ interface RsaOtherPrimesInfo {
 }
 interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1236,7 +1236,7 @@ interface CryptoKeyHmacKeyAlgorithm {
 interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 interface CryptoKeyEllipticKeyAlgorithm {
@@ -1253,7 +1253,7 @@ declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  readonly digest: Promise<ArrayBuffer>;
+  readonly digest: Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -1187,26 +1187,26 @@ export interface RsaOtherPrimesInfo {
 }
 export interface SubtleCryptoDeriveKeyAlgorithm {
   name: string;
-  salt?: ArrayBuffer;
+  salt?: ArrayBuffer | ArrayBufferView;
   iterations?: number;
   hash?: string | SubtleCryptoHashAlgorithm;
   $public?: CryptoKey;
-  info?: ArrayBuffer;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoEncryptAlgorithm {
   name: string;
-  iv?: ArrayBuffer;
-  additionalData?: ArrayBuffer;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
   tagLength?: number;
-  counter?: ArrayBuffer;
+  counter?: ArrayBuffer | ArrayBufferView;
   length?: number;
-  label?: ArrayBuffer;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 export interface SubtleCryptoGenerateKeyAlgorithm {
   name: string;
   hash?: string | SubtleCryptoHashAlgorithm;
   modulusLength?: number;
-  publicExponent?: ArrayBuffer;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
   length?: number;
   namedCurve?: string;
 }
@@ -1241,7 +1241,7 @@ export interface CryptoKeyHmacKeyAlgorithm {
 export interface CryptoKeyRsaKeyAlgorithm {
   name: string;
   modulusLength: number;
-  publicExponent: ArrayBuffer | (ArrayBuffer | ArrayBufferView);
+  publicExponent: ArrayBuffer | ArrayBufferView;
   hash?: CryptoKeyKeyAlgorithm;
 }
 export interface CryptoKeyEllipticKeyAlgorithm {
@@ -1258,7 +1258,7 @@ export declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
   constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-  readonly digest: Promise<ArrayBuffer>;
+  readonly digest: Promise<ArrayBuffer | ArrayBufferView>;
   get bytesWritten(): number | bigint;
 }
 /**


### PR DESCRIPTION
Avoid use of the `kj::Array<kj::byte>` type mapping when not needed. Use jsg::BufferSource instead to better ensure that memory is accounted for.

This does not cover all of crypto but gets a sizeable chunk of it.