### PR TITLE
Allow ExternalMemoryAdjustment when isolate lock isn't held

### DIFF
--- a/src/workerd/api/streams/compression.h
+++ b/src/workerd/api/streams/compression.h
@@ -18,6 +18,7 @@ namespace workerd::api {
 // isolate pointer and use that to get the external memory adjustment.
 class CompressionAllocator final {
  public:
+  CompressionAllocator(kj::Own<jsg::ExternalMemoryTarget>&& externalMemoryTarget);
   void configure(z_stream* stream);
 
   static void* AllocForZlib(void* data, uInt items, uInt size);
@@ -29,6 +30,8 @@ class CompressionAllocator final {
     kj::Array<kj::byte> data;
     kj::Maybe<jsg::ExternalMemoryAdjustment> memoryAdjustment = kj::none;
   };
+
+  kj::Own<jsg::ExternalMemoryTarget> externalMemoryTarget;
   kj::HashMap<void*, Allocation> allocations;
 };
 

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -322,6 +322,17 @@ kj::Maybe<JsObject> Lock::resolveModule(kj::StringPtr specifier) {
   return JsObject(module->GetModuleNamespace().As<v8::Object>());
 }
 
+void ExternalMemoryAccounter::Update(v8::Isolate* isolate, int64_t delta) {
+  KJ_ASSERT(isolate == isolate_ || isolate_ == nullptr);
+  amount_of_external_memory_ += delta;
+  v8::ExternalMemoryAccounter::Update(isolate, delta);
+}
+
+void ExternalMemoryAccounter::Reset(v8::Isolate* isolate) {
+  KJ_ASSERT(isolate == isolate_ || isolate_ == nullptr);
+  v8::ExternalMemoryAccounter::Update(isolate, -amount_of_external_memory_);
+}
+
 void ExternalMemoryTarget::maybeDeferAdjustment(ssize_t amount) {
   KJ_IF_SOME(inner, maybeInner) {
     if (v8::Locker::IsLocked(inner.isolate)) {

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -322,68 +322,105 @@ kj::Maybe<JsObject> Lock::resolveModule(kj::StringPtr specifier) {
   return JsObject(module->GetModuleNamespace().As<v8::Object>());
 }
 
-void ExternalMemoryAdjustment::maybeDeferAdjustment(
-    v8::ExternalMemoryAccounter& externalMemoryAccounter, v8::Isolate* isolate, size_t amount) {
-  if (isolate == nullptr) return;
-  if (v8::Locker::IsLocked(isolate)) {
-    externalMemoryAccounter.Decrease(isolate, amount);
-  } else {
-    // Otherwise, if we don't have the isolate locked, defer the adjustment to the next
-    // time that we do.
-    auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
-    jsgIsolate.deferExternalMemoryDecrement(static_cast<int64_t>(amount));
+void ExternalMemoryTarget::maybeDeferAdjustment(ssize_t amount) {
+  KJ_IF_SOME(inner, maybeInner) {
+    if (v8::Locker::IsLocked(inner.isolate)) {
+      inner.externalMemoryAccounter->Update(inner.isolate, amount);
+    } else {
+      // Otherwise, if we don't have the isolate locked, defer the adjustment to the next
+      // time that we do.
+      auto& jsgIsolate =
+          *reinterpret_cast<IsolateBase*>(inner.isolate->GetData(SET_DATA_ISOLATE_BASE));
+      jsgIsolate.deferExternalMemoryUpdate(static_cast<int64_t>(amount));
+    }
   }
 }
 
-ExternalMemoryAdjustment::ExternalMemoryAdjustment(
-    v8::ExternalMemoryAccounter& externalMemoryAccounter, v8::Isolate* isolate, size_t amount)
-    : externalMemoryAccounter(externalMemoryAccounter),
-      isolate(isolate),
-      amount(amount) {
-  KJ_DASSERT(isolate != nullptr);
-  externalMemoryAccounter.Increase(isolate, amount);
+void ExternalMemoryTarget::reset() {
+  maybeInner = kj::none;
 }
 
+kj::Own<ExternalMemoryTarget> ExternalMemoryTarget::addRef() {
+  return kj::addRef(*this);
+}
+
+ExternalMemoryAdjustment ExternalMemoryTarget::getAdjustment(size_t amount) {
+  return ExternalMemoryAdjustment(addRef(), amount);
+}
+
+bool ExternalMemoryTarget::isIsolateAlive() {
+  return maybeInner != kj::none;
+}
+
+int64_t ExternalMemoryTarget::getPendingMemoryUpdate() {
+  KJ_IF_SOME(inner, maybeInner) {
+    auto& jsgIsolate =
+        *reinterpret_cast<IsolateBase*>(inner.isolate->GetData(SET_DATA_ISOLATE_BASE));
+    return jsgIsolate.getPendingExternalMemoryUpdate();
+  }
+
+  return 0;
+}
+
+ExternalMemoryTarget::~ExternalMemoryTarget() {
+  KJ_IF_SOME(inner, maybeInner) {
+    auto& jsgIsolate =
+        *reinterpret_cast<IsolateBase*>(inner.isolate->GetData(SET_DATA_ISOLATE_BASE));
+    jsgIsolate.removeExternalMemoryTarget(this);
+  }
+}
+
+ExternalMemoryAdjustment Lock::getExternalMemoryAdjustment(int64_t amount) {
+  return IsolateBase::from(v8Isolate).getExternalMemoryTarget()->getAdjustment(amount);
+}
+
+kj::Own<ExternalMemoryTarget> Lock::getExternalMemoryTarget() {
+  return IsolateBase::from(v8Isolate).getExternalMemoryTarget();
+}
+
+void ExternalMemoryAdjustment::maybeDeferAdjustment(ssize_t amount) {
+  KJ_ASSERT(amount >= -static_cast<ssize_t>(this->amount),
+      "Memory usage may not be decreased below zero");
+
+  this->amount += amount;
+  externalMemory->maybeDeferAdjustment(amount);
+}
+
+ExternalMemoryAdjustment::ExternalMemoryAdjustment(
+    kj::Own<ExternalMemoryTarget> externalMemory, size_t amount)
+    : externalMemory(kj::mv(externalMemory)) {
+  maybeDeferAdjustment(amount);
+}
 ExternalMemoryAdjustment::ExternalMemoryAdjustment(ExternalMemoryAdjustment&& other)
-    : externalMemoryAccounter(other.externalMemoryAccounter),
-      isolate(other.isolate),
+    : externalMemory(kj::mv(other.externalMemory)),
       amount(other.amount) {
   other.amount = 0;
-  other.isolate = nullptr;
 }
 
 ExternalMemoryAdjustment& ExternalMemoryAdjustment::operator=(ExternalMemoryAdjustment&& other) {
   // If we currently have an amount, adjust it back to zero.
   // In the case we don't have the isolate lock here, the adjustment
   // will be deferred until the next time we do.
-  if (amount > 0) maybeDeferAdjustment(externalMemoryAccounter, isolate, amount);
-  externalMemoryAccounter = kj::mv(other.externalMemoryAccounter);
+
+  if (amount > 0) maybeDeferAdjustment(-amount);
+  externalMemory = kj::mv(other.externalMemory);
   amount = other.amount;
-  isolate = other.isolate;
   other.amount = 0;
-  other.isolate = nullptr;
   return *this;
 }
 
 ExternalMemoryAdjustment::~ExternalMemoryAdjustment() noexcept(false) {
   if (amount != 0) {
-    maybeDeferAdjustment(externalMemoryAccounter, isolate, amount);
+    maybeDeferAdjustment(-amount);
   }
 }
 
-void ExternalMemoryAdjustment::adjust(Lock& js, ssize_t amount) {
-  amount = kj::max(amount, -static_cast<ssize_t>(this->amount));
-  this->amount += amount;
-  externalMemoryAccounter.Update(isolate, amount);
+void ExternalMemoryAdjustment::adjust(ssize_t amount) {
+  maybeDeferAdjustment(amount);
 }
 
-void ExternalMemoryAdjustment::set(Lock& js, size_t amount) {
-  adjust(js, amount - this->amount);
-}
-
-ExternalMemoryAdjustment Lock::getExternalMemoryAdjustment(int64_t amount) {
-  return ExternalMemoryAdjustment(
-      IsolateBase::from(v8Isolate).getExternalMemoryAccounter(), v8Isolate, amount);
+void ExternalMemoryAdjustment::set(size_t amount) {
+  adjust(amount - this->amount);
 }
 
 Name::Name(kj::String string): hash(kj::hashCode(string)), inner(kj::mv(string)) {}

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2246,42 +2246,71 @@ JS_TYPE_CLASSES(V)
 #undef V
 
 class DOMException;
+class ExternalMemoryAdjustment;
+
+// Used to save a reference to an isolate that is responsible for external memory usage.
+// getAdjustment() can be invoked at any time to create a new RAII adjustment object
+// pointing to this isolate
+class ExternalMemoryTarget: public kj::Refcounted {
+  struct Impl;
+
+ public:
+  ExternalMemoryTarget(): maybeInner(kj::none) {}
+
+  ExternalMemoryTarget(v8::Isolate* isolate, v8::ExternalMemoryAccounter* accounter) {
+    maybeInner.emplace(isolate, accounter);
+  }
+
+  bool isIsolateAlive();
+  int64_t getPendingMemoryUpdate();
+  ExternalMemoryAdjustment getAdjustment(size_t amount);
+  ~ExternalMemoryTarget();
+
+ private:
+  kj::Own<ExternalMemoryTarget> addRef();
+  void reset();
+  void maybeDeferAdjustment(ssize_t amount);
+  struct Impl {
+    v8::Isolate* isolate;
+    v8::ExternalMemoryAccounter* externalMemoryAccounter;
+  };
+
+  kj::Maybe<Impl> maybeInner;
+
+  friend class ExternalMemoryAdjustment;
+  friend class IsolateBase;
+};
 
 // RAII class to adjust the amount of external memory attributed to an isolate.
 // The adjustment will be automatically decremented when the object is destroyed.
 // The allocation amount can be adjusted up or down during the lifetime of an object.
 class ExternalMemoryAdjustment final {
  public:
-  ExternalMemoryAdjustment(
-      v8::ExternalMemoryAccounter& externalMemoryAccounter, v8::Isolate* isolate, size_t amount);
-  ExternalMemoryAdjustment(v8::Isolate* isolate, size_t amount);
+  ExternalMemoryAdjustment(kj::Own<ExternalMemoryTarget> externalMemory, size_t amount);
   ExternalMemoryAdjustment(ExternalMemoryAdjustment&& other);
   ExternalMemoryAdjustment& operator=(ExternalMemoryAdjustment&& other);
   KJ_DISALLOW_COPY(ExternalMemoryAdjustment);
   ~ExternalMemoryAdjustment() noexcept(false);
 
   // Adjust the amount of external memory report up or down.
-  void adjust(Lock&, ssize_t amount);
+  void adjust(ssize_t amount);
 
   // Set a specific amount of external memory to be attributed, overriding
   // the previous amount.
-  void set(Lock&, size_t amount);
-
-  inline v8::Isolate* getIsolate() const {
-    return isolate;
-  }
+  void set(size_t amount);
 
   inline size_t getAmount() const {
     return amount;
   }
 
  private:
-  v8::ExternalMemoryAccounter& externalMemoryAccounter;
-  v8::Isolate* isolate = nullptr;
+  kj::Own<ExternalMemoryTarget> externalMemory;
   size_t amount = 0;
 
-  static void maybeDeferAdjustment(
-      v8::ExternalMemoryAccounter& externalMemoryAccounter, v8::Isolate* isolate, size_t amount);
+  // If the isolate is locked, adjust the v8::ExternalMemoryAccounter immediately.
+  // Otherwise, if we don't have the isolate locked, defer the adjustment to the next
+  // time that we do.
+  void maybeDeferAdjustment(ssize_t amount);
 };
 
 // Represents an isolate lock, which allows the current thread to execute JavaScript code within
@@ -2343,7 +2372,12 @@ class Lock {
   // until the next time the lock is held. The ExternalMemoryAdjustment itself can be
   // moved and can be used to increment or decrement the amount of external memory
   // held.
-  ExternalMemoryAdjustment getExternalMemoryAdjustment(int64_t amount);
+  ExternalMemoryAdjustment getExternalMemoryAdjustment(int64_t amount = 0);
+
+  // Used to save a reference to an isolate that is responsible for external memory usage.
+  // getAdjustment() can be invoked at any time to create a new RAII adjustment object
+  // pointing to this isolate
+  kj::Own<ExternalMemoryTarget> getExternalMemoryTarget();
 
   Value parseJson(kj::ArrayPtr<const char> data);
   Value parseJson(v8::Local<v8::String> text);

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -423,6 +423,10 @@ IsolateBase::~IsolateBase() noexcept(false) {
   }
 
   jsg::runInV8Stack([&](jsg::V8StackScope& stackScope) {
+    // V8 doesn't allow destroying a v8::ExternalMemoryAccounter while it is still reporting
+    // non-zero memory usage. Our allocations may outlive the isolate, however, so we bypass this.
+    externalMemoryAccounter.Reset(ptr);
+
     ptr->Dispose();
     // TODO(cleanup): meaningless after V8 13.4 is released.
     cppHeap.reset();

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -206,7 +206,7 @@ class IsolateBase {
     return JsSymbol(symbolAsyncDispose.Get(ptr));
   }
 
-  v8::ExternalMemoryAccounter& getExternalMemoryAccounter() {
+  jsg::ExternalMemoryAccounter& getExternalMemoryAccounter() {
     return externalMemoryAccounter;
   }
 
@@ -295,7 +295,7 @@ class IsolateBase {
 
   /* *** External Memory accounting *** */
   // Used to report external memory usage to V8
-  v8::ExternalMemoryAccounter externalMemoryAccounter;
+  jsg::ExternalMemoryAccounter externalMemoryAccounter;
 
   // A list of objects currently tracking memory that are referring to this isolate.
   // They must be cleared when the isolate is destroyed.

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -210,6 +210,9 @@ class IsolateBase {
     return externalMemoryAccounter;
   }
 
+  // Get an object referencing this isolate that can be used to adjust external memory usage later
+  kj::Own<ExternalMemoryTarget> getExternalMemoryTarget();
+
   AsyncContextFrame::StorageKey& getEnvAsyncContextKey() {
     return *envAsyncContextKey;
   }
@@ -290,8 +293,32 @@ class IsolateBase {
   // Polyfilled Symbol.asyncDispose.
   v8::Global<v8::Symbol> symbolAsyncDispose;
 
-  // Used to account for external memory
+  /* *** External Memory accounting *** */
+  // Used to report external memory usage to V8
   v8::ExternalMemoryAccounter externalMemoryAccounter;
+
+  // A list of objects currently tracking memory that are referring to this isolate.
+  // They must be cleared when the isolate is destroyed.
+  kj::MutexGuarded<kj::HashSet<ExternalMemoryTarget*>> externalMemoryTargets;
+
+  // Remove an ExternalMemoryTarget from the list of pointers we are tracking.
+  // In doing so, its reference back to the Isolate is also cleared, allowing us to dispose the
+  // isolate.
+  void removeExternalMemoryTarget(ExternalMemoryTarget* target);
+
+  // Current value of memory adjustments that have been requested, but have not yet been reported
+  // to V8.
+  std::atomic<int64_t> pendingExternalMemoryUpdate = {0};
+
+  // Adjust the pending external memory update value
+  void deferExternalMemoryUpdate(int64_t size);
+
+  // Get current value of external memory update (for tests)
+  int64_t getPendingExternalMemoryUpdate();
+
+  // Called when isolate lock is acquired. Report pending memory update to V8 and set its value
+  // back to zero.
+  void clearPendingExternalMemoryUpdate();
 
   // A shared async context key for accessing env
   kj::Own<AsyncContextFrame::StorageKey> envAsyncContextKey;
@@ -308,7 +335,6 @@ class IsolateBase {
   // operation) outside of the queue lock.
   const kj::MutexGuarded<BatchQueue<Item>> queue{
     DESTRUCTION_QUEUE_INITIAL_SIZE, DESTRUCTION_QUEUE_MAX_CAPACITY};
-  std::atomic<int64_t> pendingExternalMemoryDecrement = {0};
 
   struct CodeBlockInfo {
     size_t size = 0;
@@ -344,11 +370,9 @@ class IsolateBase {
 
   // Add an item to the deferred destruction queue. Safe to call from any thread at any time.
   void deferDestruction(Item item);
-  void deferExternalMemoryDecrement(int64_t size);
 
   // Destroy everything in the deferred destruction queue. Must be called under the isolate lock.
   void clearDestructionQueue();
-  void clearPendingExternalMemoryDecrement();
 
   static void fatalError(const char* location, const char* message);
   static void oomError(const char* location, const v8::OOMDetails& details);
@@ -369,7 +393,7 @@ class IsolateBase {
   friend class Data;
   friend class Wrappable;
   friend class HeapTracer;
-  friend class ExternalMemoryAdjustment;
+  friend class ExternalMemoryTarget;
 
   friend bool getCaptureThrowsAsRejections(v8::Isolate* isolate);
   friend bool getCommonJsExportDefault(v8::Isolate* isolate);
@@ -522,7 +546,7 @@ class Isolate: public IsolateBase {
         : jsg::Lock(isolate.ptr),
           jsgIsolate(const_cast<Isolate&>(isolate)) {
       jsgIsolate.clearDestructionQueue();
-      jsgIsolate.clearPendingExternalMemoryDecrement();
+      jsgIsolate.clearPendingExternalMemoryUpdate();
     }
     KJ_DISALLOW_COPY_AND_MOVE(Lock);
     KJ_DISALLOW_AS_COROUTINE_PARAM;


### PR DESCRIPTION
The initial implementation of `jsg::ExternalMemoryAdjustment` allowed for some changes in external memory usage to be made without an isolate lock being held. For example, an adjuster could be moved or destroyed at any time. If the isolate is locked, the change is reported immediately to V8. Otherwise, the change can be _deferred_, by storing an atomic value in the jsg Isolate keeping track of pending memory adjustments. The next time the isolate lock is taken, the pending adjustment is reported to V8.

This PR extends this functionality by allowing all memory adjustments, including construction, `adjust()`, and `set()`, to be deferred if needed.

I also created `jsg::ExternalMemoryTarget` which wraps a reference to an isolate, providing a `getAdjustment()` method to construct an `ExternalMemoryAdjustment` on demand. This class isn't strictly needed - you could just store an isolate pointer, but I think it's helpful because it makes intentions clear when it appears in code. I'm not 100% sure about the name though.

Lastly, I updated `compression.c++` and `zlib-util.c++` to use the new functionality.

Future question: what if a very large amount of memory is used while we're not holding the isolate? Should we implement our own maximum memory limits for pending adjustments eventually?