### PR TITLE
Remove superflous throw from web-socket handling

### DIFF
--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -529,7 +529,6 @@ void WebSocket::startReadLoop(jsg::Lock& js, kj::Maybe<kj::Own<InputGate::Critic
       } else {
         native.closedIncoming = true;
         reportError(js, kj::cp(e));
-        kj::throwFatalException(kj::mv(e));
       }
     }
   })));


### PR DESCRIPTION
See internal PR 10195 for reasoning 😅 