### PR TITLE
Break actor on errors that rollback transactions

### DIFF
--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -1420,6 +1420,51 @@ export class DurableObjectExample extends DurableObject {
     }
     return bookmark;
   }
+
+  async createTableForTestingAutoRollBackOnCriticalError() {
+    this.state.storage.sql.exec(
+      'CREATE TABLE IF NOT EXISTS test_full (id INTEGER PRIMARY KEY, data BLOB)'
+    );
+  }
+
+  async createCriticalErrorThatLeadsToAutoRollback() {
+    // Limit size of db so we can trigger a SQLITE_FULL error
+    this.state.storage.sql.setMaxPageCountForTest(10);
+
+    try {
+      // Create large data to fill the database quickly
+      const largeData = new Uint8Array(1000000).fill(42);
+      this.state.storage.sql.exec(
+        'INSERT INTO test_full VALUES (?, ?)',
+        2,
+        largeData
+      );
+      throw new Error(
+        'should have thrown SQLITE_FULL exception before we reach here'
+      );
+    } catch (err) {
+      if (err.message !== 'database or disk is full: SQLITE_FULL') {
+        throw err;
+      }
+    }
+
+    const smallData = new Uint8Array(10).fill(1);
+    this.state.storage.sql.exec(
+      'INSERT INTO test_full VALUES (?, ?)',
+      1,
+      smallData
+    );
+  }
+
+  async verifyAutoRollbackAfterCriticalError() {
+    if (
+      [...this.state.storage.sql.exec('SELECT * FROM test_full')].length != 0
+    ) {
+      throw new Error(
+        'found data that was committed when a critical error happened'
+      );
+    }
+  }
 }
 
 export default {
@@ -1529,5 +1574,26 @@ export let testSessionsAPIBookmark = {
     for (let i = 0; i < 20; ++i) {
       bookmark = await stub.testSessionsAPIBookmark(bookmark);
     }
+  },
+};
+
+export let testAutoRollBackOnCriticalError = {
+  async test(ctrl, env, ctx) {
+    let id = env.ns.idFromName('auto-rollback-on-critical-error-test');
+    let stub = env.ns.get(id);
+    await stub.createTableForTestingAutoRollBackOnCriticalError();
+    try {
+      await stub.createCriticalErrorThatLeadsToAutoRollback();
+      throw new Error(
+        'should have thrown SQLITE_FULL exception before we reach here'
+      );
+    } catch (err) {
+      if (!err.message.startsWith('internal error; reference =')) {
+        throw err;
+      }
+    }
+    // Get a new stub since the old stub is broken due to critical error
+    stub = env.ns.get(id);
+    await stub.verifyAutoRollbackAfterCriticalError();
   },
 };

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -78,6 +78,11 @@ SqlStorage::IngestResult SqlStorage::ingest(jsg::Lock& js, kj::String querySql) 
       kj::str(result.remainder), result.rowsRead, result.rowsWritten, result.statementCount);
 }
 
+void SqlStorage::setMaxPageCountForTest(jsg::Lock& js, int count) {
+  auto& db = getDb(js);
+  db.run(SqliteDatabase::TRUSTED, kj::str("PRAGMA max_page_count = ", count));
+}
+
 jsg::Ref<SqlStorage::Statement> SqlStorage::prepare(jsg::Lock& js, jsg::JsString query) {
   return js.alloc<Statement>(js, JSG_THIS, query);
 }

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -31,6 +31,7 @@ class SqlStorage final: public jsg::Object, private SqliteDatabase::Regulator {
 
   jsg::Ref<Cursor> exec(jsg::Lock& js, jsg::JsString query, jsg::Arguments<BindingValue> bindings);
   IngestResult ingest(jsg::Lock& js, kj::String query);
+  void setMaxPageCountForTest(jsg::Lock& js, int count);
 
   jsg::Ref<Statement> prepare(jsg::Lock& js, jsg::JsString query);
 
@@ -46,6 +47,8 @@ class SqlStorage final: public jsg::Object, private SqliteDatabase::Regulator {
 
       // 'ingest' functionality is still experimental-only
       JSG_METHOD(ingest);
+
+      JSG_METHOD(setMaxPageCountForTest);
     }
 
     JSG_READONLY_PROTOTYPE_PROPERTY(databaseSize, getDatabaseSize);

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -213,6 +213,8 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
 
   void onWrite();
 
+  void onCriticalError(kj::Exception exception);
+
   // Issues a request to the alarm scheduler for the given time, returning a promise that resolves
   // when the request is confirmed.
   kj::Promise<void> requestScheduledAlarm(kj::Maybe<kj::Date> requestedTime);

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -262,6 +262,8 @@ kj_test(
     src = "sqlite-test.c++",
     deps = [
         ":sqlite",
+        "//src/workerd/io:io-gate",
+        "@sqlite3",
     ],
 )
 

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -2965,6 +2965,7 @@ interface SqlStorage {
   ): SqlStorageCursor<T>;
   prepare(query: string): SqlStorageStatement;
   ingest(query: string): SqlStorageIngestResult;
+  setMaxPageCountForTest(count: number): void;
   get databaseSize(): number;
   Cursor: typeof SqlStorageCursor;
   Statement: typeof SqlStorageStatement;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -2977,6 +2977,7 @@ export interface SqlStorage {
   ): SqlStorageCursor<T>;
   prepare(query: string): SqlStorageStatement;
   ingest(query: string): SqlStorageIngestResult;
+  setMaxPageCountForTest(count: number): void;
   get databaseSize(): number;
   Cursor: typeof SqlStorageCursor;
   Statement: typeof SqlStorageStatement;


### PR DESCRIPTION
We should break output gates and reset actors in the event that we catch the following exceptions because they implicitly roll back any transaction:

[SQLITE_FULL](https://www.sqlite.org/rescode.html#full): database or disk full
[SQLITE_IOERR](https://www.sqlite.org/rescode.html#ioerr): disk I/O error
[SQLITE_BUSY](https://www.sqlite.org/rescode.html#busy): database in use by another process
[SQLITE_NOMEM](https://www.sqlite.org/rescode.html#nomem): out of memory
https://www.sqlite.org/lang_transaction.html#response_to_errors_within_a_transaction