### PR TITLE
[build] Clean up pyodide target deps and headers, resolving workerd.capnp dependency

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -18,6 +18,7 @@ filegroup(
             "hyperdrive.c++",
             "pyodide/pyodide.c++",
             "pyodide/setup-emscripten.c++",
+            "pyodide/requirements.c++",
             "memory-cache.c++",
             "modules.c++",
             "r2*.c++",
@@ -45,6 +46,7 @@ filegroup(
             "memory-cache.h",
             "pyodide/pyodide.h",
             "pyodide/setup-emscripten.h",
+            "pyodide/requirements.h",
             "modules.h",
             "r2*.h",
             "rtti.h",
@@ -94,22 +96,22 @@ wd_cc_library(
     hdrs = [
         "modules.h",
         "rtti.h",
-        "//src/pyodide:generated/pyodide_extra.capnp.h",
+    ],
+    implementation_deps = [
+        ":pyodide",
+        "//src/workerd/jsg:rtti",
     ],
     visibility = ["//visibility:public"],
     deps = [
         ":html-rewriter",
         ":hyperdrive",
         ":memory-cache",
-        ":pyodide",
         ":r2",
         "//src/cloudflare",
         "//src/node",
         "//src/pyodide",
-        "//src/pyodide:pyodide_extra_capnp",
         "//src/workerd/api/node",
         "//src/workerd/io",
-        "//src/workerd/jsg:rtti",
     ],
 )
 
@@ -149,21 +151,18 @@ wd_cc_library(
         "pyodide/setup-emscripten.h",
         "//src/pyodide:generated/pyodide_extra.capnp.h",
     ],
-    implementation_deps = ["//src/workerd/util:string-buffer"],
+    implementation_deps = ["//src/workerd/io"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/pyodide:pyodide_extra_capnp",
-        "//src/workerd/io",
+        "//src/workerd/io:compatibility-date_capnp",
         "//src/workerd/jsg",
-        "//src/workerd/server:workerd_capnp",
     ],
 )
 
 kj_test(
     src = "pyodide/pyodide-test.c++",
-    deps = [
-        ":pyodide",
-    ],
+    deps = [":pyodide"],
 )
 
 wd_cc_library(

--- a/src/workerd/api/modules.c++
+++ b/src/workerd/api/modules.c++
@@ -1,5 +1,6 @@
 #include "modules.h"
 
+#include <workerd/io/features.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/setup.h>
 

--- a/src/workerd/api/modules.h
+++ b/src/workerd/api/modules.h
@@ -5,13 +5,10 @@
 #pragma once
 
 #include <workerd/api/node/node.h>
-#include <workerd/api/pyodide/pyodide.h>
 #include <workerd/api/rtti.h>
 #include <workerd/api/sockets.h>
 #include <workerd/api/unsafe.h>
 #include <workerd/api/worker-rpc.h>
-#include <workerd/io/features.h>
-#include <workerd/io/worker.h>
 #include <workerd/jsg/modules-new.h>
 
 #include <cloudflare/cloudflare.capnp.h>

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -3,15 +3,9 @@
 //     https://opensource.org/licenses/Apache-2.0
 #pragma once
 
-#include "workerd/util/wait-list.h"
-
 #include <workerd/api/pyodide/setup-emscripten.h>
-#include <workerd/io/io-context.h>
+#include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/jsg/jsg.h>
-#include <workerd/jsg/modules-new.h>
-#include <workerd/jsg/url.h>
-#include <workerd/server/workerd.capnp.h>
-#include <workerd/util/autogate.h>
 
 #include <capnp/serialize.h>
 #include <kj/array.h>
@@ -457,14 +451,6 @@ class SetupEmscripten: public jsg::Object {
 };
 
 kj::Maybe<kj::String> getPyodideLock(PythonSnapshotRelease::Reader pythonSnapshotRelease);
-
-using Worker = server::config::Worker;
-
-jsg::Ref<PyodideMetadataReader> makePyodideMetadataReader(Worker::Reader conf,
-    const PythonConfig& pythonConfig,
-    PythonSnapshotRelease::Reader pythonRelease);
-
-bool hasPythonModules(capnp::List<server::config::Worker::Module>::Reader modules);
 
 #define EW_PYODIDE_ISOLATE_TYPES                                                                   \
   api::pyodide::ReadOnlyBuffer, api::pyodide::PyodideMetadataReader,                               \

--- a/src/workerd/api/pyodide/requirements.c++
+++ b/src/workerd/api/pyodide/requirements.c++
@@ -3,6 +3,9 @@
 //     https://opensource.org/licenses/Apache-2.0
 #include "requirements.h"
 
+#include <capnp/compat/json.h>
+#include <capnp/message.h>
+
 #include <cctype>
 
 namespace workerd::api::pyodide {

--- a/src/workerd/api/pyodide/requirements.h
+++ b/src/workerd/api/pyodide/requirements.h
@@ -3,8 +3,8 @@
 //     https://opensource.org/licenses/Apache-2.0
 #pragma once
 
-#include <capnp/compat/json.h>
-#include <capnp/message.h>
+#include <capnp/compat/json.capnp.h>
+#include <capnp/list.h>
 #include <kj/common.h>
 #include <kj/map.h>
 

--- a/src/workerd/api/pyodide/setup-emscripten.c++
+++ b/src/workerd/api/pyodide/setup-emscripten.c++
@@ -1,6 +1,5 @@
 #include "setup-emscripten.h"
 
-#include <workerd/io/trace.h>
 #include <workerd/io/worker.h>
 
 namespace workerd::api::pyodide {

--- a/src/workerd/api/pyodide/setup-emscripten.h
+++ b/src/workerd/api/pyodide/setup-emscripten.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/jsg/jsg.h>
 
 namespace workerd::api::pyodide {

--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -19,6 +19,7 @@
 #include <workerd/api/memory-cache.h>
 #include <workerd/api/modules.h>
 #include <workerd/api/node/node.h>
+#include <workerd/api/pyodide/pyodide.h>
 #include <workerd/api/queue.h>
 #include <workerd/api/r2-admin.h>
 #include <workerd/api/r2.h>
@@ -35,11 +36,9 @@
 #include <workerd/api/worker-rpc.h>
 #include <workerd/io/compatibility-date.h>
 #include <workerd/jsg/modules.capnp.h>
+#include <workerd/jsg/rtti.h>
 
-#include <cloudflare/cloudflare.capnp.h>
-
-#include <capnp/serialize-packed.h>
-#include <kj/map.h>
+#include <kj/vector.h>
 
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
 #include <workerd/api/gpu/gpu.h>

--- a/src/workerd/api/rtti.h
+++ b/src/workerd/api/rtti.h
@@ -6,7 +6,6 @@
 
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/modules-new.h>
-#include <workerd/jsg/rtti.h>
 #include <workerd/jsg/url.h>
 
 #include <kj/array.h>

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -150,8 +150,6 @@ wd_capnp_library(
     src = "workerd.capnp",
     # Limit visibility to avoid accidental usage – there should be no need to use this outside of
     # test-fixture and the workerd binary.
-    # TODO(cleanup): Resolve exception for api/pyodide by moving affected pyodide code into server
-    # target. This will allow downstream to not depend on workerd.capnp.
     visibility = [
         ":__pkg__",
         "//src/workerd/api:__pkg__",

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -22,6 +22,7 @@
 #include <workerd/io/worker-entrypoint.h>
 #include <workerd/io/worker-interface.h>
 #include <workerd/io/worker.h>
+#include <workerd/util/autogate.h>
 #include <workerd/util/http-util.h>
 #include <workerd/util/mimetype.h>
 #include <workerd/util/use-perfetto-categories.h>


### PR DESCRIPTION
Spiritual successor to #2811. Resolves downstream's dependency on workerd.capnp.h by moving workerd-only python code into server target.

=================
Decided to do some cleanup to kill time on a flight. This will eliminate workerd.capnp as a superfluous linker input upstream. We also manage to no longer compile requirements.c++ twice.