### PR TITLE
Wait for PendingEvents to clear when draining actors

### DIFF
--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -341,9 +341,11 @@ kj::Promise<DeferredProxy<void>> WebSocket::couple(
     return false;
   };
   KJ_IF_SOME(p, tryGetPeer()) {
-    // We're terminating the WebSocket in this worker, so the upstream promise (which pumps
-    // messages from the client to this worker) counts as something the request is waiting for.
-    upstream = upstream.attach(context.registerPendingEvent());
+    if (!isHibernatable(p)) {
+      // We're terminating the WebSocket in this worker, so the upstream promise (which pumps
+      // messages from the client to this worker) counts as something the request is waiting for.
+      upstream = upstream.attach(context.registerPendingEvent());
+    }
 
     // We can observe websocket traffic in both directions by attaching an observer to the peer
     // websocket which terminates in the worker.

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -865,7 +865,15 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   class PendingEvent;
 
   kj::Maybe<PendingEvent&> pendingEvent;
-  kj::Maybe<kj::Promise<void>> runFinalizersTask;
+  kj::Maybe<kj::Promise<void>> finalizePendingEventsTask;
+  kj::Maybe<kj::Own<kj::PromiseFulfiller<void>>> finishedPendingEventsFulfiller;
+
+  // Returns a promise that fulfills the next time all pending events are finished.
+  // Only one such promise can exist at a time.
+  kj::Promise<void> drainPendingEvents();
+
+  // Drain both events and waitUntilTasks until both run out.
+  kj::Promise<void> drainEventsAndTasks();
 
   WarningAggregator::Map warningAggregatorMap;
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -4319,6 +4319,9 @@ kj::Promise<bool> Server::test(jsg::V8System& v8System,
       ++failCount;
     }
     KJ_LOG(DBG, kj::str(result ? "[ PASS ] "_kj : "[ FAIL ] "_kj, name));
+
+    // Wait until everything on this thread is wrapped up.
+    co_await kj::yieldUntilWouldSleep();
   };
 
   for (auto& service: services) {


### PR DESCRIPTION
With JS RPC we've noticed tasks getting scheduled after all incoming requests have been dropped and tried draining waitUntilTasks. This happens because often times JS RPC sessions get canceled prematurely and don't end normally.

In a normal request, we wait until the request, or "session", is "done". When a request is "done", all capabilities between the caller and callee have been dropped. In that case, each capability linked to a stub would have been deconstructed and scheduled any stub disposal tasks already through waitUntilTasks. In a canceled request, we immediately try to drain the current set of waitUntilTasks. However, at this point, there might not be any tasks to run, but there will be tasks in the future. Once the drain process is finished, the IncomingRequest is dropped. But as the stubs from the request are released by the RPC system, as the whole request unwinds, the stubs will try to schedule disposal tasks. But there is no IncomingRequest at this point! So the task fails.

With this, actors now create PendingEvents but they still don't get finalized like a normal stateless request. This also updates the PendingEvent system to support exporting a Promise that resolves when there are no more PendingEvents, much like `TaskSet::onEmpty()`. This is used when draining actor requests through a new function, `drainEventsAndTasks()`. This runs on a loop to wait until there are no more PendingEvents and waitUntilTasks.

This on its own breaks WebSocket hibernation, since a PendingEvent is unconditionally attached to the "upstream" promise made by coupling a WebSocket by returning it in a Response. So this changes it to only register a pending event if it's not a hibernatable WebSocket.