### PR TITLE
Provide dynamic port assignments for wd_test sidecars

### DIFF
--- a/build/BUILD.wpt
+++ b/build/BUILD.wpt
@@ -2,7 +2,6 @@
 # Licensed under the Apache 2.0 license found in the LICENSE file or at:
 #     https://opensource.org/licenses/Apache-2.0
 
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@workerd//:build/wpt_get_directories.bzl", "wpt_get_directories")
 load("@workerd//:build/wpt_test.bzl", "wpt_module", "wpt_server_entrypoint")
 
@@ -24,20 +23,9 @@ load("@workerd//:build/wpt_test.bzl", "wpt_module", "wpt_server_entrypoint")
     name = dir,
 ) for dir in wpt_get_directories(root = "fetch")]
 
-write_file(
-    name = "gen_config_json",
-    out = "config.json",
-    content = [json.encode({
-        "server_host": "localhost",
-        "check_subdomains": False,
-    })],
-    visibility = ["//visibility:public"],
-)
-
 wpt_server_entrypoint(
     name = "entrypoint",
     srcs = ["wpt"] + glob(["**/*.py"]),
-    config_json = "config.json",
     python = "@python3_13_host//:python",
     visibility = ["//visibility:public"],
 )

--- a/build/wd_test.bzl
+++ b/build/wd_test.bzl
@@ -66,53 +66,35 @@ WINDOWS_TEMPLATE = """
 @echo off
 setlocal EnableDelayedExpansion
 
-REM Start sidecar if specified
-if not "%SIDECAR%" == "" (
-    start /b "" "%SIDECAR%" > nul 2>&1
-    set SIDECAR_PID=!ERRORLEVEL!
-    timeout /t 1 > nul
+REM Run supervisor to start sidecar if specified
+if not "{sidecar}" == "" (
+    REM These environment variables are processed by the supervisor executable
+    set PORTS_TO_ASSIGN={port_bindings}
+    set SIDECAR_COMMAND="{sidecar}"
+    powershell -Command \"{supervisor} {runtest}\"
+) else (
+    {runtest}
 )
 
-REM Run the actual test
-$(RUNTEST)
-
-REM Cleanup sidecar if it was started
-if defined SIDECAR_PID (
-    taskkill /F /PID !SIDECAR_PID! > nul 2>&1
-)
-
+set TEST_EXIT=!ERRORLEVEL!
 exit /b !TEST_EXIT!
 """
 
 SH_TEMPLATE = """#!/bin/sh
 set -e
 
-cleanup() {
-    if [ ! -z "$SIDECAR_PID" ]; then
-        kill $SIDECAR_PID 2>/dev/null || true
-    fi
-}
-
-trap cleanup EXIT
-
-# Start sidecar if specified
-if [ ! -z "$(SIDECAR)" ]; then
-    "$(SIDECAR)" & SIDECAR_PID=$!
-    # Wait until the process is ready
-    sleep 3
+# Run supervisor to start sidecar if specified
+if [ ! -z "{sidecar}" ]; then
+    # These environment variables are processed by the supervisor executable
+    PORTS_TO_ASSIGN={port_bindings} SIDECAR_COMMAND="{sidecar}" {supervisor} {runtest}
+else
+    {runtest}
 fi
-
-$(RUNTEST)
 """
 
-WINDOWS_RUNTEST_NORMAL = """
-powershell -Command \"%*\" `-dTEST_TMPDIR=$ENV:TEST_TMPDIR
-set TEST_EXIT=!ERRORLEVEL!
-"""
+WINDOWS_RUNTEST_NORMAL = """powershell -Command \"%*\" `-dTEST_TMPDIR=$ENV:TEST_TMPDIR"""
 
-SH_RUNTEST_NORMAL = """
-"$@" -dTEST_TMPDIR=$TEST_TMPDIR
-"""
+SH_RUNTEST_NORMAL = """"$@" -dTEST_TMPDIR=$TEST_TMPDIR"""
 
 # We need variants of the RUN_TEST command for Python memory snapshot tests. We have to invoke
 # workerd twice, once with --python-save-snapshot to produce the snapshot and once with
@@ -145,20 +127,30 @@ echo Using Python Snapshot
 def _wd_test_impl(ctx):
     is_windows = ctx.target_platform_has_constraint(ctx.attr._platforms_os_windows[platform_common.ConstraintValueInfo])
 
+    if ctx.file.sidecar and ctx.attr.python_snapshot_test:
+        # TODO(later): Implement support for generating a combined script with these two options
+        # if we have a test that requires it. Not doing it for now due to complexity.
+        return print("sidecar and python_snapshot_test currently cannot be used together")
+
     # Bazel insists that the rule must actually create the executable that it intends to run; it
     # can't just specify some other executable with some args. OK, fine, we'll use a script that
     # just execs its args.
     if is_windows:
         # Batch script executables must end with ".bat"
         executable = ctx.actions.declare_file("%s_wd_test.bat" % ctx.label.name)
-        content = WINDOWS_TEMPLATE.replace("$(SIDECAR)", ctx.file.sidecar.path if ctx.file.sidecar else "")
+        template = WINDOWS_TEMPLATE
         runtest = WINDOWS_RUNTEST_SNAPSHOT if ctx.attr.python_snapshot_test else WINDOWS_RUNTEST_NORMAL
-        content = content.replace("$(RUNTEST)", runtest)
     else:
         executable = ctx.outputs.executable
-        content = SH_TEMPLATE.replace("$(SIDECAR)", ctx.file.sidecar.short_path if ctx.file.sidecar else "")
+        template = SH_TEMPLATE
         runtest = SH_RUNTEST_SNAPSHOT if ctx.attr.python_snapshot_test else SH_RUNTEST_NORMAL
-        content = content.replace("$(RUNTEST)", runtest)
+
+    content = template.format(
+        sidecar = ctx.file.sidecar.short_path if ctx.file.sidecar else "",
+        runtest = runtest,
+        supervisor = ctx.file.sidecar_supervisor.short_path if ctx.file.sidecar_supervisor else "",
+        port_bindings = ",".join(ctx.attr.sidecar_port_bindings),
+    )
 
     ctx.actions.write(
         output = executable,
@@ -175,6 +167,13 @@ def _wd_test_impl(ctx):
         if default_runfiles:
             runfiles = runfiles.merge(default_runfiles)
 
+        runfiles = runfiles.merge(ctx.runfiles(files = [ctx.file.sidecar_supervisor]))
+
+        # Also merge the supervisor's own runfiles if it has any
+        default_runfiles = ctx.attr.sidecar_supervisor[DefaultInfo].default_runfiles
+        if default_runfiles:
+            runfiles = runfiles.merge(default_runfiles)
+
     return [
         DefaultInfo(
             executable = executable,
@@ -186,20 +185,42 @@ _wd_test = rule(
     implementation = _wd_test_impl,
     test = True,
     attrs = {
+        # The workerd executable is used to run all tests
         "workerd": attr.label(
             allow_single_file = True,
             executable = True,
             cfg = "exec",
             default = "//src/workerd/server:workerd",
         ),
-        "flags": attr.string_list(),
+        # A list of files that this test requires to be present in order to run.
         "data": attr.label_list(allow_files = True),
+        # If set, an executable that is run in parallel with the test, and provides some functionality
+        # needed for the test. This is usually a backend server, with workerd serving as the client.
+        # The sidecar will be killed once the test completes.
         "sidecar": attr.label(
             allow_single_file = True,
             executable = True,
             cfg = "exec",
         ),
+        # A list of binding names which will be filled in with random port numbers that the sidecar
+        # and test can use for communication. The test will only begin once the sidecar is
+        # listening to these ports.
+        #
+        # In the sidecar, access these bindings as environment variables. In the wd-test file, add
+        # fromEnvironment bindings to expose them to the test.
+        #
+        # Reminder: you'll also need to add a network = ( allow = ["private"] ) service as well.
+        "sidecar_port_bindings": attr.string_list(),
+        # An executable that is used to manage port assignments and child process creation when a
+        # sidecar is specified.
+        "sidecar_supervisor": attr.label(
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+            default = "//src/workerd/api/node:sidecar-supervisor",
+        ),
         "python_snapshot_test": attr.bool(),
+        # A reference to the Windows platform label, needed for the implementation of wd_test
         "_platforms_os_windows": attr.label(default = "@platforms//os:windows"),
     },
 )

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -383,3 +383,9 @@ wd_test(
         "//conditions:default": [],
     }),
 )
+
+js_binary(
+    name = "sidecar-supervisor",
+    entry_point = "tests/sidecar-supervisor.mjs",
+    visibility = ["//visibility:public"],
+)

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -318,11 +318,11 @@ wd_test(
     args = ["--experimental"],
     data = ["tests/net-nodejs-test.js"],
     sidecar = "net-nodejs-tcp-server",
-    target_compatible_with = select({
-        # TODO(soon): Investigate why this test timeout on Windows.
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
+    sidecar_port_bindings = [
+        "SERVER_PORT",
+        "ECHO_SERVER_PORT",
+        "TIMEOUT_SERVER_PORT",
+    ],
 )
 
 wd_test(
@@ -377,11 +377,10 @@ wd_test(
         "tests/tls-nodejs-test.js",
     ],
     sidecar = "tls-nodejs-tcp-server",
-    target_compatible_with = select({
-        # TODO(soon): Investigate why this test timeout on Windows.
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
+    sidecar_port_bindings = [
+        "ECHO_SERVER_PORT",
+        "HELLO_SERVER_PORT",
+    ],
 )
 
 js_binary(

--- a/src/workerd/api/node/tests/net-nodejs-tcp-server.js
+++ b/src/workerd/api/node/tests/net-nodejs-tcp-server.js
@@ -7,13 +7,17 @@
 // We execute this command using Node.js, which makes net.createServer available.
 const net = require('node:net');
 
+function reportPort(server) {
+  console.info(`Listening on port ${server.address().port}`);
+}
+
 const server = net.createServer((s) => {
   s.on('error', () => {
     // Do nothing
   });
   s.end();
 });
-server.listen(9999, () => console.info('Listening on port 9999'));
+server.listen(process.env.SERVER_PORT, () => reportPort(server));
 
 const echoServer = net.createServer((s) => {
   s.setTimeout(100);
@@ -22,7 +26,7 @@ const echoServer = net.createServer((s) => {
   });
   s.pipe(s);
 });
-echoServer.listen(9998, () => console.info('Listening on port 9998'));
+echoServer.listen(process.env.ECHO_SERVER_PORT, () => reportPort(echoServer));
 
 const timeoutServer = net.createServer((s) => {
   s.setTimeout(100);
@@ -39,4 +43,6 @@ const timeoutServer = net.createServer((s) => {
     // Do nothing
   });
 });
-timeoutServer.listen(9997, () => console.info('Listening on port 9997'));
+timeoutServer.listen(process.env.TIMEOUT_SERVER_PORT, () =>
+  reportPort(timeoutServer)
+);

--- a/src/workerd/api/node/tests/net-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-nodejs-test.js
@@ -30,6 +30,14 @@ import * as net from 'node:net';
 
 const enc = new TextEncoder();
 
+export const checkPortsSetCorrectly = {
+  test(ctrl, env, ctx) {
+    ok(env.SERVER_PORT);
+    ok(env.ECHO_SERVER_PORT);
+    ok(env.TIMEOUT_SERVER_PORT);
+  },
+};
+
 // test/parallel/test-net-access-byteswritten.js
 export const testNetAccessBytesWritten = {
   test() {
@@ -44,9 +52,9 @@ export const testNetAccessBytesWritten = {
 
 // test/parallel/test-net-after-close.js
 export const testNetAfterClose = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
-    const c = net.connect(9999, 'localhost');
+    const c = net.connect(env.SERVER_PORT, 'localhost');
     c.resume();
     c.on('close', () => resolve());
     await promise;
@@ -65,12 +73,12 @@ export const testNetAfterClose = {
 
 // test/parallel/test-net-allow-half-open.js
 export const testNetAllowHalfOpen = {
-  async test() {
+  async test(ctrl, env, ctx) {
     // Verify that the socket closes properly when the other end closes
     // and allowHalfOpen is false.
 
     const { promise, resolve } = Promise.withResolvers();
-    const c = net.connect(9999, 'localhost');
+    const c = net.connect(env.SERVER_PORT, 'localhost');
     strictEqual(c.allowHalfOpen, false);
     c.resume();
 
@@ -131,11 +139,11 @@ export const testNetBetterErrorMessagesPortHostname = {
 
 // test/parallel/test-net-binary.js
 export const testNetBinary = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
 
     // Connect to the echo server
-    const c = net.connect(9998, 'localhost');
+    const c = net.connect(env.ECHO_SERVER_PORT, 'localhost');
     c.setEncoding('latin1');
     let result = '';
     c.on('data', (chunk) => {
@@ -158,9 +166,9 @@ export const testNetBinary = {
 
 // test/parallel/test-net-buffersize.js
 export const testNetBuffersize = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
-    const c = net.connect(9999, 'localhost');
+    const c = net.connect(env.SERVER_PORT, 'localhost');
     const finishFn = mock.fn(() => {
       strictEqual(c.bufferSize, 0);
       resolve();
@@ -178,10 +186,10 @@ export const testNetBuffersize = {
 
 // test/parallel/test-net-bytes-read.js
 export const testNetBytesRead = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
     // Connect to the echo server
-    const c = net.connect(9998, 'localhost');
+    const c = net.connect(env.ECHO_SERVER_PORT, 'localhost');
     c.resume();
     c.write('hello');
     c.end();
@@ -199,13 +207,13 @@ export const testNetBytesRead = {
 
 // test/parallel/test-net-bytes-stats.js
 // export const testNetBytesStats = {
-//   async test() {
+//   async test(ctrl, env, ctx) {
 //     // This is intentionally not a completely faithful reproduction of the
 //     // original test which checks the bytesRead on the server side.
 //
 //     // Connect to the echo server
 //     const { promise, resolve } = Promise.withResolvers();
-//     const c = net.connect(9998, 'localhost');
+//     const c = net.connect(env.ECHO_SERVER_PORT, 'localhost');
 //     let bytesDelivered = 0;
 //     c.on('data', (chunk) => (bytesDelivered += chunk.byteLength));
 //     c.write('hello');
@@ -226,9 +234,9 @@ export const testNetBytesRead = {
 // test/parallel/test-net-bytes-written-large.js
 const N = 10000000;
 export const testNetBytesWrittenLargeVariant1 = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
-    const c = net.connect(9998, 'localhost');
+    const c = net.connect(env.ECHO_SERVER_PORT, 'localhost');
     c.resume();
 
     const writeFn = mock.fn(() => {
@@ -244,9 +252,9 @@ export const testNetBytesWrittenLargeVariant1 = {
 
 // test/parallel/test-net-can-reset-timeout.js
 export const testNetCanResetTimeout = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
-    const c = net.connect(9997, 'localhost');
+    const c = net.connect(env.TIMEOUT_SERVER_PORT, 'localhost');
     const dataFn = mock.fn(() => {
       c.end();
     });
@@ -270,31 +278,31 @@ async function assertAbort(socket, testName) {
 
 // test/parallel/test-net-connect-abort-controller.js
 export const testNetConnectAbortControllerPostAbort = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const ac = new AbortController();
     const { signal } = ac;
-    const socket = net.connect({ port: 9999, signal });
+    const socket = net.connect({ port: env.SERVER_PORT, signal });
     ac.abort();
     await assertAbort(socket, 'postAbort');
   },
 };
 
 export const testNetConnectAbortControllerPreAbort = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const ac = new AbortController();
     const { signal } = ac;
     ac.abort();
-    const socket = net.connect({ port: 9999, signal });
+    const socket = net.connect({ port: env.SERVER_PORT, signal });
     await assertAbort(socket, 'preAbort');
   },
 };
 
 export const testNetConnectAbortControllerTickAbort = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const ac = new AbortController();
     const { signal } = ac;
     queueMicrotask(() => ac.abort());
-    const socket = net.connect({ port: 9999, signal });
+    const socket = net.connect({ port: env.SERVER_PORT, signal });
     await assertAbort(socket, 'tickAbort');
   },
 };
@@ -354,10 +362,10 @@ export const testNetConnectAfterDestroy = {
 
 // test/parallel/test-net-connect-buffer.js
 export const testNetConnectBuffer = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
     const c = net.connect({
-      port: 9998,
+      port: env.ECHO_SERVER_PORT,
       host: 'localhost',
       highWaterMark: 0,
     });
@@ -406,9 +414,9 @@ export const testNetConnectBuffer = {
 
 // test/parallel/test-net-connect-destroy.js
 export const testNetConnectDestroy = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
-    const c = net.connect(9999, 'localhost');
+    const c = net.connect(env.SERVER_PORT, 'localhost');
     c.on('close', () => resolve());
     c.destroy();
     await promise;
@@ -417,9 +425,9 @@ export const testNetConnectDestroy = {
 
 // test/parallel/test-net-connect-immediate-destroy.js
 export const testNetConnectImmediateDestroy = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const connectFn = mock.fn();
-    const socket = net.connect(9999, 'localhost', connectFn);
+    const socket = net.connect(env.SERVER_PORT, 'localhost', connectFn);
     socket.destroy();
     await Promise.resolve();
     strictEqual(connectFn.mock.callCount(), 0);
@@ -428,9 +436,9 @@ export const testNetConnectImmediateDestroy = {
 
 // test/parallel/test-net-connect-immediate-finish.js
 export const testNetConnectImmediateFinish = {
-  async text() {
+  async text(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
-    const c = net.connect(9999, 'localhost');
+    const c = net.connect(env.SERVER_PORT, 'localhost');
     c.end();
     c.on('finish', () => resolve());
     await promise;
@@ -454,10 +462,10 @@ export const testNetConnectKeepAlive = {
 
 // test/parallel/test-net-connect-memleak.js
 export const testNetConnectMemleak = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
     const connectFn = mock.fn(() => resolve());
-    const c = net.connect(9999, 'localhost', connectFn);
+    const c = net.connect(env.SERVER_PORT, 'localhost', connectFn);
     c.emit('connect');
     await promise;
     strictEqual(connectFn.mock.callCount(), 1);
@@ -489,9 +497,9 @@ export const testNetConnectNoArg = {
 // test/parallel/test-net-connect-options-allowhalfopen.js
 // Simplified version of the equivalent Node.js test
 export const testNetConnectOptionsAllowHalfOpen = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve, reject } = Promise.withResolvers();
-    const c = net.connect({ port: 9999, allowHalfOpen: true });
+    const c = net.connect({ port: env.SERVER_PORT, allowHalfOpen: true });
     c.resume();
     const writeFn = mock.fn(() => {
       c.write('hello', (err) => {
@@ -541,9 +549,9 @@ export const testNetConnectOptionsInvalid = {
 
 // test/parallel/test-net-connect-options-ipv6.js
 export const testNetConnectOptionsIpv6 = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
-    const c = net.connect({ host: '::1', port: 9999 });
+    const c = net.connect({ host: '::1', port: env.SERVER_PORT });
     c.on('connect', () => resolve());
     await promise;
   },
@@ -580,15 +588,15 @@ export const testNetConnectOptionsPort = {
 // the paused connection from keeping the process alive. We don't have unref
 // so let's just make sure things clean up okay when the IoContext is destroyed.
 export const testNetConnectPausedConnection = {
-  test() {
-    net.connect(9999, 'localhost').pause();
+  test(ctrl, env, ctx) {
+    net.connect(env.SERVER_PORT, 'localhost').pause();
   },
 };
 
 // test/parallel/test-net-dns-custom-lookup.js
 // test/parallel/test-net-dns-lookup.js
 export const testNetDnsCustomLookup = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
     const lookup = mock.fn((host, options, callback) => {
       strictEqual(host, 'localhost');
@@ -596,7 +604,7 @@ export const testNetDnsCustomLookup = {
       queueMicrotask(() => callback(null, '127.0.0.1', 4));
     });
     const c = net.connect({
-      port: 9999,
+      port: env.SERVER_PORT,
       host: 'localhost',
       lookup,
     });
@@ -613,10 +621,10 @@ export const testNetDnsCustomLookup = {
 
 // test/parallel/test-net-dns-lookup-skip.js
 export const testNetDnsLookupSkip = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const lookup = mock.fn();
     ['127.0.0.1', '::1'].forEach((host) => {
-      net.connect({ host, port: 9999, lookup }).destroy();
+      net.connect({ host, port: env.SERVER_PORT, lookup }).destroy();
     });
     strictEqual(lookup.mock.callCount(), 0);
   },
@@ -624,8 +632,8 @@ export const testNetDnsLookupSkip = {
 
 // test/parallel/test-net-during-close.js
 export const testNetDuringClose = {
-  test() {
-    const c = net.connect(9999, 'localhost');
+  test(ctrl, env, ctx) {
+    const c = net.connect(env.SERVER_PORT, 'localhost');
     c.destroy();
     c.remoteAddress;
     c.remoteFamily;
@@ -635,9 +643,9 @@ export const testNetDuringClose = {
 
 // test/parallel/test-net-end-destroyed.js
 export const testNetEndDestroyed = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
-    const c = net.connect(9999, 'localhost');
+    const c = net.connect(env.SERVER_PORT, 'localhost');
     c.resume();
 
     const endFn = mock.fn(() => {
@@ -1036,9 +1044,9 @@ export const testNetIsIpv6 = {
 
 // test/parallel/test-net-large-string.js
 export const testNetLargeString = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
-    const c = net.connect(9998, 'localhost');
+    const c = net.connect(env.ECHO_SERVER_PORT, 'localhost');
     let response = '';
     const size = 40 * 1024;
     const data = 'あ'.repeat(size);
@@ -1055,9 +1063,9 @@ export const testNetLargeString = {
 // test/parallel/test-net-local-address-port.js
 // The localAddress information is a non-op in our implementation
 export const testNetLocalAddressPort = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
-    const c = net.connect(9999, 'localhost');
+    const c = net.connect(env.SERVER_PORT, 'localhost');
     c.on('connect', () => {
       strictEqual(c.localAddress, '0.0.0.0');
       strictEqual(c.localPort, 0);
@@ -1069,7 +1077,7 @@ export const testNetLocalAddressPort = {
 
 // test/parallel/test-net-onread-static-buffer.js
 export const testNetOnReadStaticBuffer = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
     const buffer = Buffer.alloc(1024);
     const fn = mock.fn((nread, buf) => {
@@ -1078,7 +1086,7 @@ export const testNetOnReadStaticBuffer = {
       resolve();
     });
     const c = net.connect({
-      port: 9998,
+      port: env.ECHO_SERVER_PORT,
       host: 'localhost',
       onread: {
         buffer,
@@ -1097,12 +1105,12 @@ export const testNetOnReadStaticBuffer = {
 // test/parallel/test-net-remote-address-port.js
 // test/parallel/test-net-remote-address.js
 export const testNetRemoteAddress = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
-    const c = net.connect(9999, 'localhost');
+    const c = net.connect(env.SERVER_PORT, 'localhost');
     c.on('connect', () => {
       strictEqual(c.remoteAddress, 'localhost');
-      strictEqual(c.remotePort, 9999);
+      strictEqual(c.remotePort, parseInt(env.SERVER_PORT));
       resolve();
     });
     await promise;

--- a/src/workerd/api/node/tests/net-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/net-nodejs-test.wd-test
@@ -9,6 +9,11 @@ const unitTests :Workerd.Config = (
         ],
         compatibilityDate = "2025-01-09",
         compatibilityFlags = ["nodejs_compat"],
+        bindings = [
+          (name = "SERVER_PORT", fromEnvironment = "SERVER_PORT"),
+          (name = "ECHO_SERVER_PORT", fromEnvironment = "ECHO_SERVER_PORT"),
+          (name = "TIMEOUT_SERVER_PORT", fromEnvironment = "TIMEOUT_SERVER_PORT"),
+        ]
       )
     ),
     ( name = "internet", network = ( allow = ["private"] ) ),

--- a/src/workerd/api/node/tests/sidecar-supervisor.mjs
+++ b/src/workerd/api/node/tests/sidecar-supervisor.mjs
@@ -1,0 +1,84 @@
+// Copyright (c) 2017-2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import net from 'node:net';
+import child_process from 'node:child_process';
+import { scheduler } from 'node:timers/promises';
+
+const ANY_PORT = 0;
+const CONNECT_POLL_INTERVAL_MS = 500;
+const CONNECT_POLL_MAX_ATTEMPTS = 10;
+
+function getListeningServer() {
+  const { promise, resolve } = Promise.withResolvers();
+  const server = net.createServer();
+  server.listen(ANY_PORT).once('listening', () => resolve(server));
+  return promise;
+}
+
+function closeServer(server) {
+  const { promise, resolve } = Promise.withResolvers();
+  server.close(resolve);
+  return promise;
+}
+
+async function reservePorts(envVarNames) {
+  const servers = await Promise.all(envVarNames.map(getListeningServer));
+  const ports = Object.fromEntries(
+    envVarNames.map((envVar, i) => [envVar, servers[i].address().port])
+  );
+  Object.assign(process.env, ports);
+
+  // TODO(soon): We need to close the ports we found so sidecarCommand can bind to them.
+  // During this time, another unrelated process could end up taking the ports we're using.
+  // SO_REUSEPORT is safer but the sidecarCommand must know to use it.
+  await Promise.all(servers.map(closeServer));
+
+  return ports;
+}
+
+function waitForListening(port) {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  let attempts = 0;
+  const interval = setInterval(() => {
+    attempts++;
+
+    const conn = net
+      .connect(port, () => {
+        conn.destroy();
+        clearInterval(interval);
+        resolve();
+      })
+      .once('error', (err) => console.log('waiting for sidecar...', err.code));
+
+    if (attempts > CONNECT_POLL_MAX_ATTEMPTS) {
+      reject(
+        `Sidecar failed to listen to port ${port} after ${attempts} attempts.`
+      );
+    }
+  }, CONNECT_POLL_INTERVAL_MS);
+  return promise;
+}
+
+function runSidecar(cmd) {
+  const { promise, resolve } = Promise.withResolvers();
+  const proc = child_process.spawn(cmd, { shell: true, stdio: 'inherit' });
+  proc.once('exit', resolve);
+  return { promise, proc };
+}
+
+const portsToAssign = process.env.PORTS_TO_ASSIGN.split(',');
+const sidecarCommand = process.env.SIDECAR_COMMAND;
+const testArgv = process.argv.slice(2); // Shift off the stuff Node puts in argv
+
+const ports = await reservePorts(portsToAssign);
+const sidecar = runSidecar(sidecarCommand);
+await Promise.all(Object.values(ports).map(waitForListening));
+
+process.exitCode = child_process.spawnSync(testArgv[0], testArgv.slice(1), {
+  stdio: 'inherit',
+}).status;
+
+sidecar.proc.kill();
+await sidecar.promise;

--- a/src/workerd/api/node/tests/tls-nodejs-tcp-server.js
+++ b/src/workerd/api/node/tests/tls-nodejs-tcp-server.js
@@ -5,6 +5,10 @@
 // This file is used as a sidecar for the tls-nodejs-test tests.
 const tls = require('node:tls');
 
+function reportPort(server) {
+  console.info(`Listening on port ${server.address().port}`);
+}
+
 // Taken from https://github.com/nodejs/node/blob/304743655d5236c2edc39094336ee2667600b684/test/fixtures/keys/agent1-key.pem
 const AGENT1_KEY_PEM = `-----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCn5Ieb/G+/y5iD
@@ -71,10 +75,12 @@ const echoServer = tls.createServer(options, (s) => {
   });
   s.pipe(s);
 });
-echoServer.listen(8888, () => console.info('Listening on port 8888'));
+echoServer.listen(process.env.ECHO_SERVER_PORT, () => reportPort(echoServer));
 
 // Taken from test-tls-connect-given-socket.js
 const helloServer = tls.createServer(options, (socket) => {
   socket.end('Hello');
 });
-helloServer.listen(8887, () => console.info('Listening on port 8887'));
+helloServer.listen(process.env.HELLO_SERVER_PORT, () =>
+  reportPort(helloServer)
+);

--- a/src/workerd/api/node/tests/tls-nodejs-test.js
+++ b/src/workerd/api/node/tests/tls-nodejs-test.js
@@ -36,14 +36,21 @@ import { inspect } from 'node:util';
 import net from 'node:net';
 import { translatePeerCertificate } from '_tls_common';
 
+export const checkPortsSetCorrectly = {
+  test(ctrl, env, ctx) {
+    ok(env.ECHO_SERVER_PORT);
+    ok(env.HELLO_SERVER_PORT);
+  },
+};
+
 // Tests are taken from
 // https://github.com/nodejs/node/blob/304743655d5236c2edc39094336ee2667600b684/test/parallel/test-tls-connect-abort-controller.js
 export const tlsConnectAbortController = {
-  async test() {
+  async test(ctrl, env, ctx) {
     // Our tests differ from Node.js
     // We don't check for abortSignal listener count because it's not supported.
     const connectOptions = (signal) => ({
-      port: 8888,
+      port: env.ECHO_SERVER_PORT,
       host: 'localhost',
       signal,
     });
@@ -118,7 +125,7 @@ export const tlsConnectAbortController = {
 // Tests are taken from
 // https://github.com/nodejs/node/blob/304743655d5236c2edc39094336ee2667600b684/test/parallel/test-tls-connect-allow-half-open-option.js
 export const connectAllowHalfOpenOption = {
-  async test() {
+  async test(ctrl, env, ctx) {
     {
       const socket = tls.connect({ port: 42, lookup() {} });
       strictEqual(socket.allowHalfOpen, false);
@@ -137,7 +144,7 @@ export const connectAllowHalfOpenOption = {
       const { promise, resolve } = Promise.withResolvers();
       const socket = tls.connect(
         {
-          port: 8888,
+          port: env.ECHO_SERVER_PORT,
           allowHalfOpen: true,
         },
         () => {
@@ -167,10 +174,10 @@ export const connectAllowHalfOpenOption = {
 // Tests are taken from
 // https://github.com/nodejs/node/blob/755e4603fd1679de72d250514ea5096b272ae8d6/test/parallel/test-tls-connect-simple.js
 export const tlsConnectSimple = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const promise1 = Promise.withResolvers();
     const promise2 = Promise.withResolvers();
-    const options = { port: 8888 };
+    const options = { port: env.ECHO_SERVER_PORT };
     const client1 = tls.connect(options, function () {
       client1.end();
       promise1.resolve();
@@ -187,9 +194,9 @@ export const tlsConnectSimple = {
 // Tests are taken from
 // https://github.com/nodejs/node/blob/755e4603fd1679de72d250514ea5096b272ae8d6/test/parallel/test-tls-connect-timeout-option.js
 export const tlsConnectTimeoutOption = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const socket = tls.connect({
-      port: 8888,
+      port: env.ECHO_SERVER_PORT,
       lookup: () => {},
       timeout: 1000,
     });
@@ -201,11 +208,11 @@ export const tlsConnectTimeoutOption = {
 // Tests are taken from
 // https://github.com/nodejs/node/blob/755e4603fd1679de72d250514ea5096b272ae8d6/test/parallel/test-tls-connect-no-host.js
 export const tlsConnectNoHost = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const { promise, resolve } = Promise.withResolvers();
     const socket = tls.connect(
       {
-        port: 8888,
+        port: env.ECHO_SERVER_PORT,
         // No host set here. 'localhost' is the default,
         // but tls.checkServerIdentity() breaks before the fix with:
         // Error: Hostname/IP doesn't match certificate's altnames:
@@ -223,7 +230,7 @@ export const tlsConnectNoHost = {
 // Tests are taken from
 // https://github.com/nodejs/node/blob/755e4603fd1679de72d250514ea5096b272ae8d6/test/parallel/test-tls-connect-given-socket.js
 export const tlsConnectGivenSocket = {
-  async test() {
+  async test(ctrl, env, ctx) {
     const promises = [];
     let waiting = 2;
     function establish(socket, shouldNotCallCallback = false) {
@@ -259,7 +266,7 @@ export const tlsConnectGivenSocket = {
       return client;
     }
 
-    const port = 8887;
+    const port = env.HELLO_SERVER_PORT;
     // Immediate death socket
     const immediateDeath = net.connect(port);
     establish(immediateDeath, true).destroy();

--- a/src/workerd/api/node/tests/tls-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/tls-nodejs-test.wd-test
@@ -9,6 +9,10 @@ const unitTests :Workerd.Config = (
         ],
         compatibilityDate = "2025-01-09",
         compatibilityFlags = ["nodejs_compat"],
+        bindings = [
+          (name = "ECHO_SERVER_PORT", fromEnvironment = "ECHO_SERVER_PORT"),
+          (name = "HELLO_SERVER_PORT", fromEnvironment = "HELLO_SERVER_PORT"),
+        ]
       ),
     ),
     ( name = "internet",

--- a/src/wpt/BUILD.bazel
+++ b/src/wpt/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
 load("//:build/eslint_test.bzl", "eslint_test")
 load("//:build/wpt_test.bzl", "wpt_test")
 
@@ -34,11 +33,10 @@ wpt_test(
     name = "fetch/api",
     size = "large",
     config = "fetch/api-test.ts",
-    # TODO(soon): Only a single test can have start_server=True
-    # Solution: Upgrade sidecar to allow dynamic port assignment
     start_server = True,
     target_compatible_with = select({
-        # TODO(soon): Improve sidecar compatibility with Windows
+        # TODO(later): Provide a Windows version of the sidecar script we wrote to invoke wptserve.
+        # Currently we only have a Unix shell script.
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),

--- a/src/wpt/harness/harness.ts
+++ b/src/wpt/harness/harness.ts
@@ -77,6 +77,8 @@ export type TestRunnerConfig = {
 
 type Env = {
   unsafe: { eval: (code: string) => void };
+  HTTP_PORT: string | null;
+  HTTPS_PORT: string | null;
   [key: string]: unknown;
 };
 
@@ -975,7 +977,10 @@ globalThis.get_host_info = (): HostInfo => {
 
   const httpsUrl = new URL(httpUrl);
   httpsUrl.protocol = 'https';
-  httpsUrl.port = '8443';
+
+  // If the environment variable HTTPS_PORT is set, the wpt server is running as a sidecar.
+  // Update the URL's port so we can connect to it
+  httpsUrl.port = globalThis.state.env.HTTPS_PORT ?? '';
 
   return {
     REMOTE_HOST: httpUrl.hostname,
@@ -1227,8 +1232,12 @@ export function createRunner(
 
         const testUrl = new URL(
           path.join(moduleBase, file),
-          'http://localhost:8000'
+          'http://localhost'
         );
+
+        // If the environment variable HTTP_PORT is set, the wpt server is running as a sidecar.
+        // Update the URL's port so we can connect to it
+        testUrl.port = env.HTTP_PORT ?? '';
 
         globalThis.state = new RunnerState(testUrl, file, env, options);
         const meta = parseWptMetadata(String(env[file]));


### PR DESCRIPTION
wd_tests can have an optional _sidecar_, which is a script that runs in parallel to the test and exits once the test terminates. This option is so far used to run a backend server so we can test how workerd works as a client. We do this for node:net, node:tls and WPT tests.

Currently, all of these sidecars use hardcoded ports. This is inconvenient in cases where another process is already using that port, and especially in cases where Bazel runs several copies of a test in parallel.

This PR addresses this issue by providing a `num_ports=n` option, which assigns `n` ports to both the sidecar and the test. The assigned ports are passed through environment variables like `PORT_1`, `PORT_2`, etc.  Ports are selected by a NodeJS script (the supervisor) that binds to port 0, checks the assigned port, and then releases it. 

## Alternative options considered

* Unix domain sockets: Easier to work with for this application, but would require patching WPT to support Unix domain sockets.
* Using a regex to grep for "Listening to port xxxx" messages from the sidecar: Seems brittle

## Further improvements

* There is an opportunity for a race condition to occur when the supervisor releases the ports and when the sidecar binds to them. Another process could end up being assigned those ports and the test would fail. With a little bit of cooperation from the sidecar processes, the supervisor could bind with SO_REUSEPORT and so could the sidecar, so that the port won't ever be released back to the OS until the test is done.