### PR TITLE
EW-9182 Add assertion to detect timeout ID generator mismatches

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -45,6 +45,18 @@ class IoContext::TimeoutManagerImpl final: public TimeoutManager {
 
   TimeoutId setTimeout(
       IoContext& context, TimeoutId::Generator& generator, TimeoutParameters params) override {
+    // Verify the generator is from the correct ServiceWorkerGlobalScope. If we have been passed a
+    // different `timeoutIdGenerator`, then that means this IoContext is active at a time when
+    // JavaScript in a different V8 context is executing. This _should_ be impossible, but we're
+    // occasionally seeing timeout ID collision assertion failures in `addState()`, and one possible
+    // explanation is that an IoContext is somehow current for a different V8 context.
+    //
+    // TODO(cleanup): Find a more general way to assert that the JS API surface is being used under
+    //   the correct IoContext, get rid of this function's `generator` parameter, and instead rely
+    //   on the IoContext to provide the generator.
+    KJ_ASSERT(&generator == &context.getCurrentLock().getTimeoutIdGenerator(),
+        "TimeoutId Generator mismatch - using a generator from wrong ServiceWorkerGlobalScope");
+
     auto [id, it] = addState(generator, kj::mv(params));
     setTimeoutImpl(context, it);
     return id;

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2027,6 +2027,10 @@ api::ServiceWorkerGlobalScope& Worker::Lock::getGlobalScope() {
       getContext()->GetAlignedPointerFromEmbedderData(1));
 }
 
+TimeoutId::Generator& Worker::Lock::getTimeoutIdGenerator() {
+  return getGlobalScope().timeoutIdGenerator;
+}
+
 jsg::AsyncContextFrame::StorageKey& Worker::Lock::getTraceAsyncContextKey() {
   // const_cast OK because we are a lock on this isolate.
   auto& isolate = const_cast<Isolate&>(worker.getIsolate());

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -11,6 +11,7 @@
 #include <workerd/io/container.capnp.h>
 #include <workerd/io/frankenvalue.h>
 #include <workerd/io/io-channels.h>
+#include <workerd/io/io-timers.h>
 #include <workerd/io/limit-enforcer.h>
 #include <workerd/io/outcome.capnp.h>
 #include <workerd/io/request-tracker.h>
@@ -652,6 +653,9 @@ class Worker::Lock {
 
   // Get the C++ object representing the global scope.
   api::ServiceWorkerGlobalScope& getGlobalScope();
+
+  // Get the timeout ID generator from this worker's ServiceWorkerGlobalScope.
+  TimeoutId::Generator& getTimeoutIdGenerator();
 
   // Get the opaque storage key to use for recording trace information in async contexts.
   jsg::AsyncContextFrame::StorageKey& getTraceAsyncContextKey();


### PR DESCRIPTION
Add instrumentation to verify that the TimeoutId::Generator being used belongs to the ServiceWorkerGlobalScope associated with the current IoContext. This will help diagnose potential timeout ID collisions caused by generators being used with the wrong IoContext.

- Add getTimeoutIdGenerator() method to Worker::Lock
- Add assertion in TimeoutManagerImpl::setTimeout to validate generator
- This will fail early with a descriptive error if the invariant is violated

🤖 Generated with Claude, then lightly edited by Harris Hancock.