### PR TITLE
[build] Run tests previously disabled under ASan

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -199,6 +199,8 @@ build:asan --config=sanitizer-common
 build:asan --copt="-fsanitize=address" --linkopt="-fsanitize=address"
 build:asan --test_env=ASAN_OPTIONS=abort_on_error=true
 build:asan --test_env=KJ_CLEAN_SHUTDOWN=1
+# Enable ASan, LSan support in V8
+build:asan --per_file_copt='external/v8@-DADDRESS_SANITIZER,-DLEAK_SANITIZER'
 
 #
 # Linux and macOS

--- a/src/cloudflare/internal/test/ai/BUILD.bazel
+++ b/src/cloudflare/internal/test/ai/BUILD.bazel
@@ -17,8 +17,4 @@ py_wd_test(
     ]),
     # Works but times out frequently
     make_snapshot = False,
-    tags = [
-        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
-        "no-asan",
-    ],
 )

--- a/src/cloudflare/internal/test/aig/BUILD.bazel
+++ b/src/cloudflare/internal/test/aig/BUILD.bazel
@@ -17,8 +17,4 @@ py_wd_test(
     ]),
     # Works but times out
     make_snapshot = False,
-    tags = [
-        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
-        "no-asan",
-    ],
 )

--- a/src/cloudflare/internal/test/autorag/BUILD.bazel
+++ b/src/cloudflare/internal/test/autorag/BUILD.bazel
@@ -17,8 +17,4 @@ py_wd_test(
     ]),
     # Works but times out
     make_snapshot = False,
-    tags = [
-        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
-        "no-asan",
-    ],
 )

--- a/src/cloudflare/internal/test/br/BUILD.bazel
+++ b/src/cloudflare/internal/test/br/BUILD.bazel
@@ -17,8 +17,4 @@ py_wd_test(
     ]),
     # Works but times out
     make_snapshot = False,
-    tags = [
-        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
-        "no-asan",
-    ],
 )

--- a/src/cloudflare/internal/test/d1/BUILD.bazel
+++ b/src/cloudflare/internal/test/d1/BUILD.bazel
@@ -25,8 +25,4 @@ py_wd_test(
         "*.js",
     ]),
     make_snapshot = False,
-    tags = [
-        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
-        "no-asan",
-    ],
 )

--- a/src/cloudflare/internal/test/vectorize/BUILD.bazel
+++ b/src/cloudflare/internal/test/vectorize/BUILD.bazel
@@ -15,8 +15,4 @@ py_wd_test(
     ]),
     # Works but times out
     make_snapshot = False,
-    tags = [
-        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
-        "no-asan",
-    ],
 )

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -31,10 +31,6 @@ py_wd_test("subdirectory")
 
 py_wd_test(
     "sdk",
-    tags = [
-        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
-        "no-asan",
-    ],
 )
 
 py_wd_test("seek-metadatafs")
@@ -70,10 +66,6 @@ py_wd_test("seek-metadatafs")
 
 py_wd_test(
     "undefined-handler",
-    tags = [
-        # TODO(someday): Fix asan failure for this, see https://github.com/cloudflare/workerd/pull/3140#discussion_r1858273318
-        "no-asan",
-    ],
 )
 
 py_wd_test("vendor_dir")

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -78,6 +78,22 @@ static kj::StringPtr getVersionString() {
 
 // =======================================================================================
 
+// For ASan's leak sanitizer, suppress warnings about leaks with stacks that include "unknown
+// modules". This suppression is adopted from the GN build and applies to addresses that LSan can't
+// symbolize or even map to a binary – perhaps JIT or snapshot-generated code in V8's case?
+// TODO(someday): Suppression is needed to get several python tests to pass under LSan. Investigate
+// if this is an actual leak (perhaps a bug in V8 itself since it is suppressed there?) at a later
+// time.
+#if __has_feature(address_sanitizer)
+extern "C" __attribute__((no_sanitize("address"))) __attribute__((visibility("default")))
+__attribute__((used)) const char*
+__lsan_default_suppressions() {
+  return "leak:<unknown module>\n";
+}
+#endif
+
+// =======================================================================================
+
 class EntropySourceImpl: public kj::EntropySource {
  public:
   void generate(kj::ArrayPtr<kj::byte> buffer) override {


### PR DESCRIPTION
We explicitly enable V8's ASan/LSan support here, and add a LSan suppression from the canonical GN build.