### PR TITLE
add navigator.hardwareConcurrency

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -586,6 +586,12 @@ wd_test(
 )
 
 wd_test(
+    src = "tests/navigator-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/navigator-test.js"],
+)
+
+wd_test(
     src = "tests/reporterror-test.wd-test",
     args = ["--experimental"],
     data = ["tests/reporterror-test.js"],

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -84,12 +84,21 @@ class Navigator: public jsg::Object {
 
   bool sendBeacon(jsg::Lock& js, kj::String url, jsg::Optional<Body::Initializer> body);
 
+  kj::uint getHardwareConcurrency() {
+    // Workers does not expose hardware concurrency to users.
+    // From the user code perspective there's only one core.
+    return 1;
+  }
+
   JSG_RESOURCE_TYPE(Navigator) {
     JSG_METHOD(sendBeacon);
     JSG_READONLY_INSTANCE_PROPERTY(userAgent, getUserAgent);
+    JSG_READONLY_INSTANCE_PROPERTY(hardwareConcurrency, getHardwareConcurrency);
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
     JSG_READONLY_INSTANCE_PROPERTY(gpu, getGPU);
 #endif
+
+    JSG_TS_OVERRIDE({ readonly hardwareConcurrency: number; });
   }
 };
 

--- a/src/workerd/api/tests/navigator-test.js
+++ b/src/workerd/api/tests/navigator-test.js
@@ -1,0 +1,13 @@
+import { strictEqual } from 'node:assert';
+
+export const testHardwareConcurrency = {
+  async test() {
+    strictEqual(navigator.hardwareConcurrency, 1);
+  },
+};
+
+export const testUserAgent = {
+  async test() {
+    strictEqual(navigator.userAgent, 'Cloudflare-Workers');
+  },
+};

--- a/src/workerd/api/tests/navigator-test.wd-test
+++ b/src/workerd/api/tests/navigator-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "navigator-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "navigator-test.js")
+        ],
+        compatibilityDate = "2025-01-15",
+        compatibilityFlags = ["nodejs_compat"],
+      ),
+    ),
+  ],
+);

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -469,6 +469,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -474,6 +474,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -469,6 +469,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -474,6 +474,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -469,6 +469,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -474,6 +474,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -474,6 +474,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -479,6 +479,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -474,6 +474,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -479,6 +479,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -474,6 +474,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -479,6 +479,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -476,6 +476,7 @@ declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -481,6 +481,7 @@ export declare abstract class Navigator {
       | URLSearchParams,
   ): boolean;
   readonly userAgent: string;
+  readonly hardwareConcurrency: number;
   readonly gpu?: GPU;
 }
 /**


### PR DESCRIPTION
Adding navigator.hardwareConcurrency because it also exists on Node.js. There are libraries that depend on this to run tests etc.