### PR TITLE
remove unnecessary JSG_TS_OVERRIDE calls

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -694,9 +694,7 @@ void ServiceWorkerGlobalScope::emitPromiseRejection(jsg::Lock& js,
   }
 }
 
-jsg::JsString ServiceWorkerGlobalScope::btoa(jsg::Lock& js, jsg::JsValue data) {
-  auto str = data.toJsString(js);
-
+jsg::JsString ServiceWorkerGlobalScope::btoa(jsg::Lock& js, jsg::JsString str) {
   // We could implement btoa() by accepting a kj::String, but then we'd have to check that it
   // doesn't have any multibyte code points. Easier to perform that test using v8::String's
   // ContainsOnlyOneByte() function.

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -97,8 +97,6 @@ class Navigator: public jsg::Object {
 #ifdef WORKERD_EXPERIMENTAL_ENABLE_WEBGPU
     JSG_READONLY_INSTANCE_PROPERTY(gpu, getGPU);
 #endif
-
-    JSG_TS_OVERRIDE({ readonly hardwareConcurrency: number; });
   }
 };
 
@@ -530,7 +528,7 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
   // ---------------------------------------------------------------------------
   // JS API
 
-  jsg::JsString btoa(jsg::Lock& js, jsg::JsValue data);
+  jsg::JsString btoa(jsg::Lock& js, jsg::JsString data);
   jsg::JsString atob(jsg::Lock& js, kj::String data);
 
   void queueMicrotask(jsg::Lock& js, v8::Local<v8::Function> task);
@@ -879,8 +877,6 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
     // `Module` is also declared `abstract` to disable its `BufferSource` constructor.
 
     JSG_TS_OVERRIDE({
-      btoa(data: string): string;
-
       setTimeout(callback: (...args: any[]) => void, msDelay?: number): number;
       setTimeout<Args extends any[]>(callback: (...args: Args) => void, msDelay?: number, ...args: Args): number;
 

--- a/src/workerd/api/urlpattern-standard.h
+++ b/src/workerd/api/urlpattern-standard.h
@@ -127,10 +127,6 @@ class URLPattern final: public jsg::Object {
     JSG_READONLY_PROTOTYPE_PROPERTY(hasRegExpGroups, getHasRegExpGroups);
     JSG_METHOD(test);
     JSG_METHOD(exec);
-
-    JSG_TS_OVERRIDE({
-                  get hasRegExpGroups(): boolean;
-                });
   }
 
  private:


### PR DESCRIPTION
A small cleanup to get rid of unnecessary jsg_ts_override calls across the repository