### PR TITLE
add node:http, _http_common and _http_outgoing modules

### DIFF
--- a/src/node/_http_common.ts
+++ b/src/node/_http_common.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+// Copyright Joyent and Node contributors. All rights reserved. MIT license.
+
+import {
+  _checkIsHttpToken,
+  _checkInvalidHeaderChar,
+} from 'node-internal:internal_http';
+
+export { _checkIsHttpToken, _checkInvalidHeaderChar };
+export const chunkExpression = /(?:^|\W)chunked(?:$|\W)/i;
+export const continueExpression = /(?:^|\W)100-continue(?:$|\W)/i;
+
+export default {
+  _checkIsHttpToken,
+  _checkInvalidHeaderChar,
+  chunkExpression,
+  continueExpression,
+};

--- a/src/node/_http_outgoing.ts
+++ b/src/node/_http_outgoing.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+// Copyright Joyent and Node contributors. All rights reserved. MIT license.
+
+import {
+  validateHeaderName,
+  validateHeaderValue,
+} from 'node-internal:internal_http';
+
+export { validateHeaderName, validateHeaderValue };
+export default {
+  validateHeaderName,
+  validateHeaderValue,
+};

--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+// Copyright Joyent and Node contributors. All rights reserved. MIT license.
+
+import {
+  validateHeaderName,
+  validateHeaderValue,
+} from 'node-internal:internal_http';
+
+export { validateHeaderName, validateHeaderValue };
+export default {
+  validateHeaderName,
+  validateHeaderValue,
+};

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -778,3 +778,31 @@ export function aggregateTwoErrors(innerError: any, outerError: any) {
   }
   return innerError || outerError;
 }
+
+export class ERR_INVALID_HTTP_TOKEN extends NodeTypeError {
+  constructor(label: string, name: string | undefined) {
+    super(
+      'ERR_INVALID_HTTP_TOKEN',
+      `${label} must be a valid HTTP token ["${name}"]`
+    );
+  }
+}
+
+export class ERR_HTTP_INVALID_HEADER_VALUE extends NodeTypeError {
+  constructor(value: string | undefined, header: string | undefined) {
+    super(
+      'ERR_HTTP_INVALID_HEADER_VALUE',
+      `Invalid value "${value}" for header "${header}"`
+    );
+  }
+}
+
+export class ERR_INVALID_CHAR extends NodeTypeError {
+  constructor(name: string, field?: string) {
+    let msg = `Invalid character in ${name}`;
+    if (field !== undefined) {
+      msg += ` ["${field}"]`;
+    }
+    super('ERR_INVALID_CHAR', msg);
+  }
+}

--- a/src/node/internal/internal_http.ts
+++ b/src/node/internal/internal_http.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+import {
+  ERR_INVALID_HTTP_TOKEN,
+  ERR_INVALID_CHAR,
+  ERR_HTTP_INVALID_HEADER_VALUE,
+} from 'node-internal:internal_errors';
+
+const tokenRegExp = /^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/;
+/**
+ * Verifies that the given val is a valid HTTP token
+ * per the rules defined in RFC 7230
+ * See https://tools.ietf.org/html/rfc7230#section-3.2.6
+ */
+export function _checkIsHttpToken(val: string): boolean {
+  return tokenRegExp.test(val);
+}
+
+const headerCharRegex = /[^\t\x20-\x7e\x80-\xff]/;
+/**
+ * True if val contains an invalid field-vchar
+ *  field-value    = *( field-content / obs-fold )
+ *  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+ *  field-vchar    = VCHAR / obs-text
+ */
+export function _checkInvalidHeaderChar(val: string): boolean {
+  return headerCharRegex.test(val);
+}
+
+export function validateHeaderName(name: string, label: string): void {
+  if (typeof name !== 'string' || !name || !_checkIsHttpToken(name)) {
+    throw new ERR_INVALID_HTTP_TOKEN(label || 'Header name', name);
+  }
+}
+
+export function validateHeaderValue(name: string, value?: string): void {
+  if (value === undefined) {
+    throw new ERR_HTTP_INVALID_HEADER_VALUE(value, name);
+  }
+  if (_checkInvalidHeaderChar(value)) {
+    throw new ERR_INVALID_CHAR('header content', name);
+  }
+}

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -383,3 +383,9 @@ wd_test(
         "//conditions:default": [],
     }),
 )
+
+wd_test(
+    src = "tests/http-nodejs-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/http-nodejs-test.js"],
+)

--- a/src/workerd/api/node/tests/http-nodejs-test.js
+++ b/src/workerd/api/node/tests/http-nodejs-test.js
@@ -1,0 +1,147 @@
+import { throws, ok, strictEqual } from 'node:assert';
+import { validateHeaderName, validateHeaderValue } from 'node:http';
+import { _checkIsHttpToken, _checkInvalidHeaderChar } from 'node:_http_common';
+import { inspect } from 'node:util';
+
+// Tests are taken from
+// https://github.com/nodejs/node/blob/c514e8f781b2acedb6a2b42208d8f8f4d8392f09/test/parallel/test-http-header-validators.js
+export const testHttpHeaderValidators = {
+  async test() {
+    // Expected static methods
+    isFunc(validateHeaderName, 'validateHeaderName');
+    isFunc(validateHeaderValue, 'validateHeaderValue');
+
+    // - when used with valid header names - should not throw
+    ['user-agent', 'USER-AGENT', 'User-Agent', 'x-forwarded-for'].forEach(
+      (name) => {
+        validateHeaderName(name);
+      }
+    );
+
+    // - when used with invalid header names:
+    ['איקס-פורוורד-פור', 'x-forwarded-fםr'].forEach((name) => {
+      throws(() => validateHeaderName(name), {
+        code: 'ERR_INVALID_HTTP_TOKEN',
+      });
+    });
+
+    // - when used with valid header values - should not throw
+    [
+      ['x-valid', 1],
+      ['x-valid', '1'],
+      ['x-valid', 'string'],
+    ].forEach(([name, value]) => {
+      validateHeaderValue(name, value);
+    });
+
+    // - when used with invalid header values:
+    [
+      // [header, value, expectedCode]
+      ['x-undefined', undefined, 'ERR_HTTP_INVALID_HEADER_VALUE'],
+      ['x-bad-char', 'לא תקין', 'ERR_INVALID_CHAR'],
+    ].forEach(([name, value, code]) => {
+      throws(() => validateHeaderValue(name, value), { code });
+    });
+
+    // Misc.
+    function isFunc(v, ttl) {
+      ok(v.constructor === Function, `${ttl} is expected to be a function`);
+    }
+  },
+};
+
+// Tests are taken from
+// https://github.com/nodejs/node/blob/c514e8f781b2acedb6a2b42208d8f8f4d8392f09/test/parallel/test-http-invalidheaderfield2.js
+export const testInvalidHeaderField2 = {
+  async test() {
+    // Good header field names
+    [
+      'TCN',
+      'ETag',
+      'date',
+      'alt-svc',
+      'Content-Type',
+      '0',
+      'Set-Cookie2',
+      'Set_Cookie',
+      'foo`bar^',
+      'foo|bar',
+      '~foobar',
+      'FooBar!',
+      '#Foo',
+      '$et-Cookie',
+      '%%Test%%',
+      'Test&123',
+      "It's_fun",
+      '2*3',
+      '4+2',
+      '3.14159265359',
+    ].forEach(function (str) {
+      strictEqual(
+        _checkIsHttpToken(str),
+        true,
+        `_checkIsHttpToken(${inspect(str)}) unexpectedly failed`
+      );
+    });
+    // Bad header field names
+    [
+      ':',
+      '@@',
+      '中文呢', // unicode
+      '((((())))',
+      ':alternate-protocol',
+      'alternate-protocol:',
+      'foo\nbar',
+      'foo\rbar',
+      'foo\r\nbar',
+      'foo\x00bar',
+      '\x7FMe!',
+      '{Start',
+      '(Start',
+      '[Start',
+      'End}',
+      'End)',
+      'End]',
+      '"Quote"',
+      'This,That',
+    ].forEach(function (str) {
+      strictEqual(
+        _checkIsHttpToken(str),
+        false,
+        `_checkIsHttpToken(${inspect(str)}) unexpectedly succeeded`
+      );
+    });
+
+    // Good header field values
+    [
+      'foo bar',
+      'foo\tbar',
+      '0123456789ABCdef',
+      '!@#$%^&*()-_=+\\;\':"[]{}<>,./?|~`',
+    ].forEach(function (str) {
+      strictEqual(
+        _checkInvalidHeaderChar(str),
+        false,
+        `_checkInvalidHeaderChar(${inspect(str)}) unexpectedly failed`
+      );
+    });
+
+    // Bad header field values
+    [
+      'foo\rbar',
+      'foo\nbar',
+      'foo\r\nbar',
+      '中文呢', // unicode
+      '\x7FMe!',
+      'Testing 123\x00',
+      'foo\vbar',
+      'Ding!\x07',
+    ].forEach(function (str) {
+      strictEqual(
+        _checkInvalidHeaderChar(str),
+        true,
+        `_checkInvalidHeaderChar(${inspect(str)}) unexpectedly succeeded`
+      );
+    });
+  },
+};

--- a/src/workerd/api/node/tests/http-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/http-nodejs-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "http-nodejs-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "http-nodejs-test.js")
+        ],
+        compatibilityDate = "2025-01-15",
+        compatibilityFlags = ["nodejs_compat"]
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
This makes the initial pull-request for the path to implementing node:http and it's friends. This pull-request adds **some** methods to `node:http`, `_http_common` and `_http_outgoing` modules exposed by node.js