### PR TITLE
update description of cacheTags as it's no longer for ENT only

### DIFF
--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -99,8 +99,6 @@ interface RequestInitCfProperties extends Record<string, unknown> {
    * to the origin response without modifications to the origin server.
    * This will allow for greater control over the Purge by Cache Tag feature
    * utilizing changes only in the Workers process.
-   *
-   * Only available for Enterprise customers.
    */
   cacheTags?: string[];
   /**


### PR DESCRIPTION
Note there is a bunch of files like "types/generated-snapshot/2021-11-03/index.d.ts" with the same description. I believe I don't need to update that? 