### PR TITLE
Switch to std::list from std::dequeue in web socket

### DIFF
--- a/src/workerd/api/memory-cache.h
+++ b/src/workerd/api/memory-cache.h
@@ -10,6 +10,7 @@
 #include <kj/table.h>
 #include <kj/timer.h>
 
+#include <list>
 #include <set>
 
 namespace workerd {
@@ -232,7 +233,7 @@ class SharedMemoryCache: public kj::AtomicRefcounted {
     struct Waiter {
       kj::Own<kj::CrossThreadPromiseFulfiller<Use::GetWithFallbackOutcome>> fulfiller;
     };
-    std::deque<Waiter> waiting;
+    std::list<Waiter> waiting;
 
     InProgress(kj::String&& key): key(kj::mv(key)) {}
 

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -14,6 +14,7 @@
 #include <kj/compat/http.h>
 
 #include <cstdlib>
+#include <list>
 
 namespace workerd {
 class ActorObserver;
@@ -629,7 +630,7 @@ class WebSocket: public EventTarget {
   // between regular websocket messages, and auto-responses.
   struct AutoResponse {
     kj::Promise<void> ongoingAutoResponse = kj::READY_NOW;
-    std::deque<kj::String> pendingAutoResponseDeque;
+    std::list<kj::String> pendingAutoResponseDeque;
     size_t queuedAutoResponses = 0;
     bool isPumping = false;
     bool isClosed = false;

--- a/src/workerd/jsg/iterator.h
+++ b/src/workerd/jsg/iterator.h
@@ -9,7 +9,7 @@
 #include <workerd/jsg/struct.h>
 
 #include <concepts>
-#include <deque>
+#include <list>
 
 namespace workerd::jsg {
 
@@ -791,7 +791,7 @@ class AsyncIteratorImpl {
   }
 
  private:
-  std::deque<Promise<void>> pendingStack;
+  std::list<Promise<void>> pendingStack;
 };
 
 // Provides the base implementation of JSG_ASYNC_ITERATOR types. See the documentation


### PR DESCRIPTION
These will end up being very minor impact but worth doing. Trades the less memory-efficient std::deque for the slightly less performant but more memory-efficient std::list in a couple of cases.