### PR TITLE
improve node:net stability and test coverage

### DIFF
--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -53,10 +53,6 @@ export class NodeErrorAbstraction extends Error {
     super(message);
     this.code = code;
     this.name = name;
-    //This number changes depending on the name of this class
-    //20 characters as of now
-    (this as any).stack =
-      this.stack && `${name} [${this.code}]${this.stack.slice(20)}`;
   }
 
   override toString() {
@@ -654,7 +650,7 @@ export class EPIPE extends NodeError {
 export class ERR_SOCKET_CLOSED_BEFORE_CONNECTION extends NodeError {
   constructor() {
     super(
-      'ERR_SOCKET_CLOSED_BEFORE_CONNETION',
+      'ERR_SOCKET_CLOSED_BEFORE_CONNECTION',
       'Socket closed before connection established'
     );
   }
@@ -777,4 +773,10 @@ export function aggregateTwoErrors(innerError: any, outerError: any) {
     return err;
   }
   return innerError || outerError;
+}
+
+export class ERR_INVALID_IP_ADDRESS extends NodeTypeError {
+  constructor(ipAddress: string) {
+    super('ERR_INVALID_IP_ADDRESS', `Invalid IP address: ${ipAddress}`);
+  }
 }

--- a/src/node/internal/streams_duplex.js
+++ b/src/node/internal/streams_duplex.js
@@ -92,6 +92,9 @@ export function Duplex(options) {
     this.allowHalfOpen = true;
   }
 }
+
+Duplex.prototype.destroy = Writable.prototype.destroy;
+
 Object.defineProperties(Duplex.prototype, {
   writable: {
     ...Object.getOwnPropertyDescriptor(Writable.prototype, 'writable'),

--- a/src/node/internal/streams_writable.js
+++ b/src/node/internal/streams_writable.js
@@ -343,7 +343,7 @@ function writeOrBuffer(stream, state, chunk, encoding, callback) {
   state.length += len;
 
   // stream._write resets state.length
-  const ret = state.length < state.highWaterMark;
+  const ret = state.length < state.highWaterMark || state.length === 0;
   // We must ensure that previous needDrain will not be reset to false.
   if (!ret) state.needDrain = true;
   if (state.writing || state.corked || state.errored || !state.constructed) {

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -322,6 +322,8 @@ wd_test(
         "SERVER_PORT",
         "ECHO_SERVER_PORT",
         "TIMEOUT_SERVER_PORT",
+        "END_SERVER_PORT",
+        "SERVER_THAT_DIES_PORT",
     ],
 )
 
@@ -387,4 +389,10 @@ js_binary(
     name = "sidecar-supervisor",
     entry_point = "tests/sidecar-supervisor.mjs",
     visibility = ["//visibility:public"],
+)
+
+wd_test(
+    src = "tests/streams-nodejs-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/streams-nodejs-test.js"],
 )

--- a/src/workerd/api/node/tests/net-nodejs-tcp-server.js
+++ b/src/workerd/api/node/tests/net-nodejs-tcp-server.js
@@ -46,3 +46,16 @@ const timeoutServer = net.createServer((s) => {
 timeoutServer.listen(process.env.TIMEOUT_SERVER_PORT, () =>
   reportPort(timeoutServer)
 );
+
+const endServer = net.createServer((s) => {
+  s.end();
+});
+endServer.listen(process.env.END_SERVER_PORT, () => reportPort(endServer));
+
+const serverThatDies = net.createServer(function (s) {
+  serverThatDies.close();
+  s.end();
+});
+serverThatDies.listen(process.env.SERVER_THAT_DIES_PORT, () =>
+  reportPort(serverThatDies)
+);

--- a/src/workerd/api/node/tests/net-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/net-nodejs-test.wd-test
@@ -13,6 +13,8 @@ const unitTests :Workerd.Config = (
           (name = "SERVER_PORT", fromEnvironment = "SERVER_PORT"),
           (name = "ECHO_SERVER_PORT", fromEnvironment = "ECHO_SERVER_PORT"),
           (name = "TIMEOUT_SERVER_PORT", fromEnvironment = "TIMEOUT_SERVER_PORT"),
+          (name = "END_SERVER_PORT", fromEnvironment = "END_SERVER_PORT"),
+          (name = "SERVER_THAT_DIES_PORT", fromEnvironment = "SERVER_THAT_DIES_PORT"),
         ]
       )
     ),

--- a/src/workerd/api/node/tests/streams-nodejs-test.js
+++ b/src/workerd/api/node/tests/streams-nodejs-test.js
@@ -1,0 +1,53 @@
+import { Duplex, Readable, Writable } from 'node:stream';
+import { strictEqual, deepStrictEqual } from 'node:assert';
+
+export const testStreamDuplexDestroy = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const duplex = new Duplex({
+      read() {},
+      write(chunk, enc, cb) {
+        cb();
+      },
+    });
+
+    duplex.cork();
+    duplex.write('foo', (err) => {
+      strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+      resolve();
+    });
+    duplex.destroy();
+    await promise;
+  },
+};
+
+// Prevents stream unexpected pause when highWaterMark set to 0
+// Ref: https://github.com/nodejs/node/commit/50695e5de14ccd8255537972181bbc9a1f44368e
+export const testStreamsHighwatermark = {
+  async test() {
+    const { promise, resolve } = Promise.withResolvers();
+    const res = [];
+    const r = new Readable({
+      read() {},
+    });
+    const w = new Writable({
+      highWaterMark: 0,
+      write(chunk, encoding, callback) {
+        res.push(chunk.toString());
+        callback();
+      },
+    });
+
+    r.pipe(w);
+    r.push('a');
+    r.push('b');
+    r.push('c');
+    r.push(null);
+
+    r.on('end', () => {
+      deepStrictEqual(res, ['a', 'b', 'c']);
+      resolve();
+    });
+    await promise;
+  },
+};

--- a/src/workerd/api/node/tests/streams-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/streams-nodejs-test.wd-test
@@ -1,0 +1,16 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "streams-nodejs-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "streams-nodejs-test.js")
+        ],
+        compatibilityDate = "2025-01-09",
+        compatibilityFlags = ["nodejs_compat"],
+      )
+    ),
+    ( name = "internet", network = ( allow = ["private"] ) ),
+  ],
+);


### PR DESCRIPTION
- Fixes Duplex.destroy() to use correct method.
- Fixes Writable stream highwaterMark for value 0.
- Fixes `node:net` bytesWritten getter.
- Adds lots and lots of tests.
- Fixes error codes.
- Fixes NodeError messages getting cut