### PR TITLE
Use v8::LocalVector where appropriate

### DIFF
--- a/src/workerd/api/crypto/x509.c++
+++ b/src/workerd/api/crypto/x509.c++
@@ -838,8 +838,8 @@ jsg::JsObject X509Certificate::toLegacyObject(jsg::Lock& js) {
     obj.set(js, "fingerprint512", js.str(fingerprint512));
   }
   KJ_IF_SOME(keyUsage, getKeyUsage()) {
-    auto values = KJ_MAP(str, keyUsage) { return jsg::JsValue(js.str(str)); };
-    obj.set(js, "ext_key_usage", js.arr(values));
+    obj.set(js, "ext_key_usage",
+        js.arr(keyUsage.asPtr(), [](jsg::Lock& js, const kj::String& val) { return js.str(val); }));
   }
   KJ_IF_SOME(serialNumber, getSerialNumber()) {
     obj.set(js, "serialNumber", js.str(serialNumber));

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -252,11 +252,9 @@ kj::String KvNamespace::formBulkBodyString(jsg::Lock& js,
   }
   auto object = js.obj();
 
-  auto keysArray = kj::heapArrayBuilder<jsg::JsValue>(names.size());
-  for (auto& n: names) {
-    keysArray.add(js.str(n));
-  }
-  object.set(js, "keys", js.arr(keysArray));
+  auto keysArray =
+      js.arr(names.asPtr(), [](jsg::Lock& js, const kj::String& val) { return js.str(val); });
+  object.set(js, "keys", keysArray);
 
   if (type != kj::str("")) {
     object.set(js, "type", js.str(type));

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2750,6 +2750,12 @@ class Lock {
 
   JsArray arr(kj::ArrayPtr<JsValue> values) KJ_WARN_UNUSED_RESULT;
 
+  // Create a JavaScript array from the given kj::ArrayPtr, passing each
+  // item through the given transformation function to create the appropriate
+  // JsValue.
+  template <typename T, typename Func>
+  JsArray arr(kj::ArrayPtr<T> values, Func fn) KJ_WARN_UNUSED_RESULT;
+
   template <typename... Args>
     requires(std::assignable_from<JsValue&, Args> && ...)
   JsSet set(const Args&... args) KJ_WARN_UNUSED_RESULT;

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -453,13 +453,19 @@ JsObject Lock::obj() {
 
 JsObject Lock::obj(kj::ArrayPtr<kj::StringPtr> keys, kj::ArrayPtr<JsValue> values) {
   KJ_DASSERT(keys.size() == values.size());
-  auto keys_ = KJ_MAP(k, keys) -> v8::Local<v8::Name> {
-    return v8::String::NewFromUtf8(v8Isolate, k.begin(), v8::NewStringType::kNormal, k.size())
-        .ToLocalChecked();
-  };
-  auto values_ = KJ_MAP(v, values) -> v8::Local<v8::Value> { return v; };
+  v8::LocalVector<v8::Name> keys_(v8Isolate);
+  v8::LocalVector<v8::Value> values_(v8Isolate);
+  keys_.reserve(keys.size());
+  values_.reserve(keys.size());
+  for (auto& k: keys) {
+    v8::Local<v8::String> key = str(k);
+    keys_.push_back(key);
+  }
+  for (auto& v: values) {
+    values_.push_back(v);
+  }
   return JsObject(
-      v8::Object::New(v8Isolate, v8::Null(v8Isolate), keys_.begin(), values_.begin(), keys.size()));
+      v8::Object::New(v8Isolate, v8::Null(v8Isolate), keys_.data(), values_.data(), keys.size()));
 }
 
 JsObject Lock::objNoProto() {

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -460,6 +460,16 @@ inline JsArray Lock::arr(const Args&... args) {
   return JsArray(v8::Array::New(v8Isolate, &values[0], sizeof...(Args)));
 }
 
+template <typename T, typename Func>
+inline JsArray Lock::arr(kj::ArrayPtr<T> values, Func fn) {
+  v8::LocalVector<v8::Value> vec(v8Isolate);
+  vec.reserve(values.size());
+  for (const T& val: values) {
+    vec.push_back(fn(*this, val));
+  }
+  return JsArray(v8::Array::New(v8Isolate, vec.data(), vec.size()));
+}
+
 template <typename... Args>
   requires(std::assignable_from<JsValue&, Args> && ...)
 inline JsSet Lock::set(const Args&... args) {


### PR DESCRIPTION
KJ_MAP will allocate the array of v8::Local<T>'s on the heap which is technically not allowed. While most of these places are not necessarily problematic as is, the general pattern is. Let's prefer to use `v8::LocalVector` where appropriate instead.