### PR TITLE
Add new AsyncLocalStorage constructor options

### DIFF
--- a/src/workerd/api/node/async-hooks.c++
+++ b/src/workerd/api/node/async-hooks.c++
@@ -5,8 +5,9 @@
 
 namespace workerd::api::node {
 
-jsg::Ref<AsyncLocalStorage> AsyncLocalStorage::constructor(jsg::Lock& js) {
-  return js.alloc<AsyncLocalStorage>();
+jsg::Ref<AsyncLocalStorage> AsyncLocalStorage::constructor(
+    jsg::Lock& js, jsg::Optional<AsyncLocalStorage::AsyncLocalStorageOptions> options) {
+  return js.alloc<AsyncLocalStorage>(kj::mv(options));
 }
 
 v8::Local<v8::Value> AsyncLocalStorage::run(jsg::Lock& js,
@@ -40,7 +41,17 @@ v8::Local<v8::Value> AsyncLocalStorage::getStore(jsg::Lock& js) {
       return value.getHandle(js);
     }
   }
+  KJ_IF_SOME(value, defaultValue) {
+    return value.getHandle(js);
+  }
   return js.v8Undefined();
+}
+
+kj::StringPtr AsyncLocalStorage::getName() {
+  KJ_IF_SOME(n, name) {
+    return n.asPtr();
+  }
+  return nullptr;
 }
 
 v8::Local<v8::Function> AsyncLocalStorage::bind(jsg::Lock& js, v8::Local<v8::Function> fn) {

--- a/src/workerd/api/node/tests/async_hooks-nodejs-test.js
+++ b/src/workerd/api/node/tests/async_hooks-nodejs-test.js
@@ -1,5 +1,5 @@
 import async_hooks from 'node:async_hooks';
-import { ok, deepStrictEqual } from 'node:assert';
+import { ok, deepStrictEqual, strictEqual } from 'node:assert';
 
 export const testErrorMethodNotImplemented = {
   async test() {
@@ -7,5 +7,21 @@ export const testErrorMethodNotImplemented = {
     deepStrictEqual(async_hooks.triggerAsyncId(), 0);
     deepStrictEqual(async_hooks.executionAsyncResource(), Object.create(null));
     ok(async_hooks.createHook({}));
+  },
+};
+
+export const asyncLocalStorageOptions = {
+  test() {
+    const als = new async_hooks.AsyncLocalStorage({
+      defaultValue: 1,
+      name: 'foo',
+    });
+    strictEqual(als.name, 'foo');
+    strictEqual(als.getStore(), 1);
+    strictEqual(
+      als.run(2, () => als.getStore()),
+      2
+    );
+    strictEqual(als.getStore(), 1);
   },
 };


### PR DESCRIPTION
These were just today added to Node.js implementation. We likely should hold off merging this until the new options go out in a Node.js release. Just opening this now to get ready. I don't plan to merge this until the first Node.js release with the options is cut.