### PR TITLE
EventTarget: Recheck handler map on each handler iteration

### DIFF
--- a/src/workerd/api/basics-test.c++
+++ b/src/workerd/api/basics-test.c++
@@ -22,7 +22,7 @@ jsg::V8System v8System;
 
 struct BasicsContext: public jsg::Object, public jsg::ContextGlobal {
 
-  bool test(jsg::Lock& js) {
+  bool testNativeListenersWork(jsg::Lock& js) {
 
     auto target = js.alloc<api::EventTarget>();
 
@@ -49,8 +49,36 @@ struct BasicsContext: public jsg::Object, public jsg::ContextGlobal {
     return called == 3;
   }
 
+  bool testCanAddHandlersInHandlers(jsg::Lock& js) {
+    // Exercises a use case that triggered asan failures in earlier implementations.
+    auto target = js.alloc<api::EventTarget>();
+    int toplevelCalls = 0;
+    int otherCalls = 0;
+    kj::Vector<kj::Own<void>> handlers;
+
+    handlers.add(target->newNativeHandler(
+        js, kj::str("foo"), [&](jsg::Lock& js, jsg::Ref<api::Event> event) {
+      toplevelCalls++;
+
+      for (int i = 0; i < 16; ++i) {
+        handlers.add(target->newNativeHandler(js, kj::str("foo", i),
+            [&](jsg::Lock& js, jsg::Ref<api::Event> event) { otherCalls++; }, false));
+      }
+    }, false));
+
+    handlers.add(target->newNativeHandler(js, kj::str("foo"),
+        [&](jsg::Lock& js, jsg::Ref<api::Event> event) { toplevelCalls++; }, false));
+
+    KJ_ASSERT(target->dispatchEventImpl(js, js.alloc<api::Event>(kj::str("foo"))));
+
+    KJ_ASSERT(toplevelCalls == 2);
+    KJ_ASSERT(otherCalls == 0);
+    return true;
+  }
+
   JSG_RESOURCE_TYPE(BasicsContext) {
-    JSG_METHOD(test);
+    JSG_METHOD(testNativeListenersWork);
+    JSG_METHOD(testCanAddHandlersInHandlers);
   }
 };
 JSG_DECLARE_ISOLATE_TYPE(BasicsIsolate,
@@ -60,7 +88,12 @@ JSG_DECLARE_ISOLATE_TYPE(BasicsIsolate,
 
 KJ_TEST("EventTarget native listeners work") {
   jsg::test::Evaluator<BasicsContext, BasicsIsolate, CompatibilityFlags::Reader> e(v8System);
-  e.expectEval("test()", "boolean", "true");
+  e.expectEval("testNativeListenersWork()", "boolean", "true");
+}
+
+KJ_TEST("EventTarget can add handlers in handlers") {
+  jsg::test::Evaluator<BasicsContext, BasicsIsolate, CompatibilityFlags::Reader> e(v8System);
+  e.expectEval("testCanAddHandlersInHandlers()", "boolean", "true");
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes potential use-after-free, if the underlying kj::HashMap grows enough during iteration to trigger reallocation.