### PR TITLE
enable spec-compliant URLPattern under compat flag

### DIFF
--- a/src/workerd/api/api-rtti-test.c++
+++ b/src/workerd/api/api-rtti-test.c++
@@ -24,9 +24,6 @@
 #include <workerd/io/compatibility-date.h>
 #include <workerd/jsg/rtti.h>
 
-// TODO(soon): Remove this once URLPattern autogate has been removed.
-#include <workerd/util/autogate.h>
-
 #include <kj/test.h>
 
 // Test building rtti for various APIs.
@@ -35,7 +32,6 @@ namespace workerd::api {
 namespace {
 
 KJ_TEST("WorkerGlobalScope") {
-  util::Autogate::initAutogate({});
   jsg::rtti::Builder builder((CompatibilityFlags::Reader()));
   builder.structure<WorkerGlobalScope>();
   KJ_EXPECT(builder.structure("workerd::api::Event"_kj) != kj::none);
@@ -43,7 +39,6 @@ KJ_TEST("WorkerGlobalScope") {
 }
 
 KJ_TEST("ServiceWorkerGlobalScope") {
-  util::Autogate::initAutogate({});
   jsg::rtti::Builder builder((CompatibilityFlags::Reader()));
   builder.structure<ServiceWorkerGlobalScope>();
   KJ_EXPECT(builder.structure("workerd::api::DurableObjectId"_kj) != kj::none);

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -10,7 +10,6 @@
 
 #include <workerd/io/io-timers.h>
 #include <workerd/jsg/jsg.h>
-#include <workerd/util/autogate.h>
 
 namespace workerd::jsg {
 class DOMException;
@@ -710,8 +709,7 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
       JSG_NESTED_TYPE(URLSearchParams);
     }
 
-    // We conditionally enable a more spec compliant URLPattern to avoid any breakages.
-    if (util::Autogate::isEnabled(util::AutogateKey::URLPATTERN)) {
+    if (flags.getSpecCompliantUrlpattern()) {
       JSG_NESTED_TYPE_NAMED(urlpattern::URLPattern, URLPattern);
     } else {
       JSG_NESTED_TYPE(URLPattern);

--- a/src/workerd/api/urlpattern-standard.h
+++ b/src/workerd/api/urlpattern-standard.h
@@ -60,6 +60,7 @@ class URLPattern final: public jsg::Object {
     jsg::Optional<kj::String> baseURL;
 
     JSG_STRUCT(protocol, username, password, hostname, port, pathname, search, hash, baseURL);
+    JSG_STRUCT_TS_OVERRIDE(URLPatternInit);
 
     ada::url_pattern_init toAdaType() const;
   };
@@ -74,7 +75,7 @@ class URLPattern final: public jsg::Object {
     jsg::JsObject groups;
 
     JSG_STRUCT(input, groups);
-    JSG_STRUCT_TS_OVERRIDE({
+    JSG_STRUCT_TS_OVERRIDE(URLPatternComponentResult {
                   input: string;
                   groups: Record<string, string>;
                 });
@@ -90,12 +91,14 @@ class URLPattern final: public jsg::Object {
 #undef V
 
     JSG_STRUCT(inputs, protocol, username, password, hostname, port, pathname, search, hash);
+    JSG_STRUCT_TS_OVERRIDE(URLPatternResult);
   };
 
   struct URLPatternOptions final {
     jsg::Optional<bool> ignoreCase;
 
     JSG_STRUCT(ignoreCase);
+    JSG_STRUCT_TS_OVERRIDE(URLPatternOptions);
 
     ada::url_pattern_options toAdaType() const;
   };

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -743,15 +743,24 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatEnableFlag("cache_api_compat_flags")
       $compatDisableFlag("no_cache_api_compat_flags")
       $compatEnableDate("2025-04-19");
-    # when enabled, exports compability flags for FL to Cache API requests.
+  # when enabled, exports compability flags for FL to Cache API requests.
 
   pythonWorkersDurableObjects @81 :Bool
       $compatEnableFlag("python_workers_durable_objects")
       $experimental;
-    # when enabled, enables Durable Object support for Python Workers.
+  # when enabled, enables Durable Object support for Python Workers.
 
-  # Experimental support for streaming tail worker.
   streamingTailWorker @82 :Bool
       $compatEnableFlag("streaming_tail_worker")
       $experimental;
+  # Experimental support for streaming tail worker.
+
+  specCompliantUrlpattern @83 :Bool
+    $compatEnableFlag("urlpattern_standard")
+    $compatEnableDate("2025-05-01")
+    $compatDisableFlag("urlpattern_original");
+  # The original URLPattern implementation is not compliant with the
+  # WHATWG URLPattern Standard, leading to a number of issues reported by users. Unfortunately,
+  # making it spec compliant is a breaking change. This flag controls the availability
+  # of the new spec-compliant URLPattern implementation.
 }

--- a/src/workerd/tools/param-names-ast.c++
+++ b/src/workerd/tools/param-names-ast.c++
@@ -30,6 +30,7 @@
 #include <workerd/api/trace.h>
 #include <workerd/api/unsafe.h>
 #include <workerd/api/url-standard.h>
+#include <workerd/api/urlpattern-standard.h>
 #include <workerd/api/urlpattern.h>
 #include <workerd/api/worker-rpc.h>
 #include <workerd/io/compatibility-date.h>

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -19,8 +19,6 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "test-workerd"_kj;
     case AutogateKey::STREAMING_TAIL_WORKERS:
       return "streaming-tail-workers"_kj;
-    case AutogateKey::URLPATTERN:
-      return "urlpattern";
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -15,7 +15,6 @@ namespace workerd::util {
 enum class AutogateKey {
   TEST_WORKERD,
   STREAMING_TAIL_WORKERS,
-  URLPATTERN,
   NumOfKeys  // Reserved for iteration.
 };
 

--- a/src/wpt/BUILD.bazel
+++ b/src/wpt/BUILD.bazel
@@ -10,13 +10,16 @@ wpt_test(
 
 wpt_test(
     name = "urlpattern",
+    # We use a fixed compat date because new URLPattern implementation
+    # will be the default one on a later date.
+    compat_date = "2025-04-09",
     config = "urlpattern-test.ts",
     wpt_directory = "@wpt//:urlpattern@module",
 )
 
 wpt_test(
     name = "urlpattern-standard",
-    autogates = ["workerd-autogate-urlpattern"],
+    compat_flags = ["urlpattern_standard"],
     config = "urlpattern-standard-test.ts",
     wpt_directory = "@wpt//:urlpattern@module",
 )

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -2658,9 +2658,9 @@ declare class URLSearchParams {
 }
 declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2670,13 +2670,13 @@ declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-interface URLPatternURLPatternInit {
+interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2687,22 +2687,22 @@ interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-interface URLPatternURLPatternComponentResult {
+interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-interface URLPatternURLPatternOptions {
+interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -2670,9 +2670,9 @@ export declare class URLSearchParams {
 }
 export declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2682,13 +2682,13 @@ export declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-export interface URLPatternURLPatternInit {
+export interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2699,22 +2699,22 @@ export interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-export interface URLPatternURLPatternComponentResult {
+export interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-export interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+export interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-export interface URLPatternURLPatternOptions {
+export interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -2684,9 +2684,9 @@ declare class URLSearchParams {
 }
 declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2696,13 +2696,13 @@ declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-interface URLPatternURLPatternInit {
+interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2713,22 +2713,22 @@ interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-interface URLPatternURLPatternComponentResult {
+interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-interface URLPatternURLPatternOptions {
+interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -2696,9 +2696,9 @@ export declare class URLSearchParams {
 }
 export declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2708,13 +2708,13 @@ export declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-export interface URLPatternURLPatternInit {
+export interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2725,22 +2725,22 @@ export interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-export interface URLPatternURLPatternComponentResult {
+export interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-export interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+export interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-export interface URLPatternURLPatternOptions {
+export interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -2702,9 +2702,9 @@ declare class URLSearchParams {
 }
 declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2714,13 +2714,13 @@ declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-interface URLPatternURLPatternInit {
+interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2731,22 +2731,22 @@ interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-interface URLPatternURLPatternComponentResult {
+interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-interface URLPatternURLPatternOptions {
+interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -2714,9 +2714,9 @@ export declare class URLSearchParams {
 }
 export declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2726,13 +2726,13 @@ export declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-export interface URLPatternURLPatternInit {
+export interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2743,22 +2743,22 @@ export interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-export interface URLPatternURLPatternComponentResult {
+export interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-export interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+export interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-export interface URLPatternURLPatternOptions {
+export interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -2703,9 +2703,9 @@ declare class URLSearchParams {
 }
 declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2715,13 +2715,13 @@ declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-interface URLPatternURLPatternInit {
+interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2732,22 +2732,22 @@ interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-interface URLPatternURLPatternComponentResult {
+interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-interface URLPatternURLPatternOptions {
+interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -2715,9 +2715,9 @@ export declare class URLSearchParams {
 }
 export declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2727,13 +2727,13 @@ export declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-export interface URLPatternURLPatternInit {
+export interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2744,22 +2744,22 @@ export interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-export interface URLPatternURLPatternComponentResult {
+export interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-export interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+export interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-export interface URLPatternURLPatternOptions {
+export interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -2707,9 +2707,9 @@ declare class URLSearchParams {
 }
 declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2719,13 +2719,13 @@ declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-interface URLPatternURLPatternInit {
+interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2736,22 +2736,22 @@ interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-interface URLPatternURLPatternComponentResult {
+interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-interface URLPatternURLPatternOptions {
+interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -2719,9 +2719,9 @@ export declare class URLSearchParams {
 }
 export declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2731,13 +2731,13 @@ export declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-export interface URLPatternURLPatternInit {
+export interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2748,22 +2748,22 @@ export interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-export interface URLPatternURLPatternComponentResult {
+export interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-export interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+export interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-export interface URLPatternURLPatternOptions {
+export interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -2712,9 +2712,9 @@ declare class URLSearchParams {
 }
 declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2724,13 +2724,13 @@ declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-interface URLPatternURLPatternInit {
+interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2741,22 +2741,22 @@ interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-interface URLPatternURLPatternComponentResult {
+interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-interface URLPatternURLPatternOptions {
+interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -2724,9 +2724,9 @@ export declare class URLSearchParams {
 }
 export declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2736,13 +2736,13 @@ export declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-export interface URLPatternURLPatternInit {
+export interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2753,22 +2753,22 @@ export interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-export interface URLPatternURLPatternComponentResult {
+export interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-export interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+export interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-export interface URLPatternURLPatternOptions {
+export interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -2714,9 +2714,9 @@ declare class URLSearchParams {
 }
 declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2726,13 +2726,13 @@ declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-interface URLPatternURLPatternInit {
+interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2743,22 +2743,22 @@ interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-interface URLPatternURLPatternComponentResult {
+interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-interface URLPatternURLPatternOptions {
+interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -2726,9 +2726,9 @@ export declare class URLSearchParams {
 }
 export declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2738,13 +2738,13 @@ export declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-export interface URLPatternURLPatternInit {
+export interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2755,22 +2755,22 @@ export interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-export interface URLPatternURLPatternComponentResult {
+export interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-export interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+export interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-export interface URLPatternURLPatternOptions {
+export interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -2714,9 +2714,9 @@ declare class URLSearchParams {
 }
 declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2726,13 +2726,13 @@ declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-interface URLPatternURLPatternInit {
+interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2743,22 +2743,22 @@ interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-interface URLPatternURLPatternComponentResult {
+interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-interface URLPatternURLPatternOptions {
+interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -2726,9 +2726,9 @@ export declare class URLSearchParams {
 }
 export declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2738,13 +2738,13 @@ export declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-export interface URLPatternURLPatternInit {
+export interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2755,22 +2755,22 @@ export interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-export interface URLPatternURLPatternComponentResult {
+export interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-export interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+export interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-export interface URLPatternURLPatternOptions {
+export interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -2787,9 +2787,9 @@ declare class URLSearchParams {
 }
 declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2799,13 +2799,14 @@ declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  get hasRegExpGroups(): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-interface URLPatternURLPatternInit {
+interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2816,22 +2817,22 @@ interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-interface URLPatternURLPatternComponentResult {
+interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-interface URLPatternURLPatternOptions {
+interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -2799,9 +2799,9 @@ export declare class URLSearchParams {
 }
 export declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2811,13 +2811,14 @@ export declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  get hasRegExpGroups(): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-export interface URLPatternURLPatternInit {
+export interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2828,22 +2829,22 @@ export interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-export interface URLPatternURLPatternComponentResult {
+export interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-export interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+export interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-export interface URLPatternURLPatternOptions {
+export interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -2658,9 +2658,9 @@ declare class URLSearchParams {
 }
 declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2670,13 +2670,13 @@ declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-interface URLPatternURLPatternInit {
+interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2687,22 +2687,22 @@ interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-interface URLPatternURLPatternComponentResult {
+interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-interface URLPatternURLPatternOptions {
+interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -2670,9 +2670,9 @@ export declare class URLSearchParams {
 }
 export declare class URLPattern {
   constructor(
-    input?: string | URLPatternURLPatternInit,
-    baseURL?: string | URLPatternURLPatternOptions,
-    patternOptions?: URLPatternURLPatternOptions,
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
   );
   get protocol(): string;
   get username(): string;
@@ -2682,13 +2682,13 @@ export declare class URLPattern {
   get pathname(): string;
   get search(): string;
   get hash(): string;
-  test(input?: string | URLPatternURLPatternInit, baseURL?: string): boolean;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
   exec(
-    input?: string | URLPatternURLPatternInit,
+    input?: string | URLPatternInit,
     baseURL?: string,
-  ): URLPatternURLPatternResult | null;
+  ): URLPatternResult | null;
 }
-export interface URLPatternURLPatternInit {
+export interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;
@@ -2699,22 +2699,22 @@ export interface URLPatternURLPatternInit {
   hash?: string;
   baseURL?: string;
 }
-export interface URLPatternURLPatternComponentResult {
+export interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
-export interface URLPatternURLPatternResult {
-  inputs: (string | URLPatternURLPatternInit)[];
-  protocol: URLPatternURLPatternComponentResult;
-  username: URLPatternURLPatternComponentResult;
-  password: URLPatternURLPatternComponentResult;
-  hostname: URLPatternURLPatternComponentResult;
-  port: URLPatternURLPatternComponentResult;
-  pathname: URLPatternURLPatternComponentResult;
-  search: URLPatternURLPatternComponentResult;
-  hash: URLPatternURLPatternComponentResult;
+export interface URLPatternResult {
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
-export interface URLPatternURLPatternOptions {
+export interface URLPatternOptions {
   ignoreCase?: boolean;
 }
 /**

--- a/types/src/generator/type.ts
+++ b/types/src/generator/type.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import assert from "node:assert";
+import assert from 'node:assert';
 import {
   ArrayType,
   BuiltinType_Type,
@@ -13,10 +13,10 @@ import {
   StructureType,
   Type,
   Type_Which,
-} from "@workerd/jsg/rtti.capnp.js";
-import ts, { factory as f } from "typescript";
-import { printNode } from "../print";
-import { getParameterName } from "./parameter-names";
+} from '@workerd/jsg/rtti.capnp.js';
+import ts, { factory as f } from 'typescript';
+import { printNode } from '../print';
+import { getParameterName } from './parameter-names';
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex
 export function findLastIndex<T>(
@@ -40,7 +40,7 @@ export function maybeUnwrapOptional(
     ts.isTypeReferenceNode(typeNode.types[1]) &&
     ts.isIdentifier(typeNode.types[1].typeName) &&
     // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-    typeNode.types[1].typeName.escapedText === "undefined"
+    typeNode.types[1].typeName.escapedText === 'undefined'
   ) {
     return typeNode.types[0];
   }
@@ -49,21 +49,21 @@ export function maybeUnwrapOptional(
 // Returns `true` iff this maybe type represents `T | null`, not `T | undefined`
 function isNullMaybe(maybe: MaybeType): boolean {
   // https://github.com/cloudflare/workerd/blob/33e692f2216704b7226c8c59b1455eefedf79068/src/workerd/jsg/jsg.h#L220-L221
-  return maybe.getName() === "kj::Maybe";
+  return maybe.getName() === 'kj::Maybe';
 }
 
 // Returns `true` iff this number type represents a character
 function isCharNumber(number: NumberType): boolean {
   // https://github.com/cloudflare/workerd/blob/33e692f2216704b7226c8c59b1455eefedf79068/src/workerd/jsg/rtti.h#L158
   const name = number.getName();
-  return name === "char";
+  return name === 'char';
 }
 
 // Returns `true` iff this number type represents a byte
 function isByteNumber(number: NumberType): boolean {
   // https://github.com/cloudflare/workerd/blob/33e692f2216704b7226c8c59b1455eefedf79068/src/workerd/jsg/rtti.h#L160
   const name = number.getName();
-  return name === "unsigned char";
+  return name === 'unsigned char';
 }
 
 // Returns `true` iff this number type represents `number | bigint`
@@ -72,23 +72,23 @@ function isBigNumber(number: NumberType): boolean {
   // https://github.com/cloudflare/workerd/blob/33e692f2216704b7226c8c59b1455eefedf79068/src/workerd/jsg/rtti.h#L157-L167
   const name = number.getName();
   return (
-    name === "long" ||
-    name === "unsigned long" ||
-    name === "long long" ||
-    name === "unsigned long long" ||
-    name === "jsg::JsBigInt"
+    name === 'long' ||
+    name === 'unsigned long' ||
+    name === 'long long' ||
+    name === 'unsigned long long' ||
+    name === 'jsg::JsBigInt'
   );
 }
 
 // Returns `true` iff this array type represents a pointer to an array
 function isArrayPointer(array: ArrayType): boolean {
-  return array.getName() === "kj::ArrayPtr";
+  return array.getName() === 'kj::ArrayPtr';
 }
 
 // Returns `true` iff this array type represents an iterable
 function isIterable(array: ArrayType): boolean {
   // https://github.com/cloudflare/workerd/blob/33e692f2216704b7226c8c59b1455eefedf79068/src/workerd/jsg/README.md?plain=1#L185-L186
-  return array.getName() === "jsg::Sequence";
+  return array.getName() === 'jsg::Sequence';
 }
 
 // Returns `true` iff `typeNode` is `never`
@@ -96,7 +96,7 @@ export function isUnsatisfiable(typeNode: ts.TypeNode): boolean {
   const isNeverTypeReference =
     ts.isTypeReferenceNode(typeNode) &&
     ts.isIdentifier(typeNode.typeName) &&
-    typeNode.typeName.text === "never";
+    typeNode.typeName.text === 'never';
   const isNeverKeyword =
     ts.isToken(typeNode) && typeNode.kind == ts.SyntaxKind.NeverKeyword;
   return isNeverTypeReference || isNeverKeyword;
@@ -112,24 +112,24 @@ export function isUnsatisfiable(typeNode: ts.TypeNode): boolean {
 // For instance, a new hypothetical API called `workerd::api::magic::MakeASpell` would be
 // `magicMakeASpell`.
 const replaceEmpty =
-  /^workerd::api::public_beta::|^workerd::api::node::|^workerd::api::|^workerd::jsg::|::|[ >]/g;
+  /^workerd::api::public_beta::|^workerd::api::urlpattern::|^workerd::api::node::|^workerd::api::|^workerd::jsg::|::|[ >]/g;
 // Strings to replace in fully-qualified structure names with an underscore
 const replaceUnderscore = /[<,]/g;
 export function getTypeName(
   structure: Structure | StructureType | /* fullyQualifiedName */ string
 ): string {
   let name: string;
-  if (typeof structure === "string") {
+  if (typeof structure === 'string') {
     assert(
-      structure.includes("::"),
+      structure.includes('::'),
       `Expected fully-qualified structure name, got "${structure}"`
     );
     name = structure;
   } else {
     name = structure.getFullyQualifiedName();
   }
-  name = name.replace(replaceEmpty, "");
-  name = name.replace(replaceUnderscore, "_");
+  name = name.replace(replaceEmpty, '');
+  name = name.replace(replaceUnderscore, '_');
   return name;
 }
 
@@ -224,20 +224,20 @@ export function createTypeNode(
   // noinspection FallThroughInSwitchStatementJS
   switch (which) {
     case Type_Which.UNKNOWN:
-      return f.createTypeReferenceNode("any");
+      return f.createTypeReferenceNode('any');
     case Type_Which.VOIDT:
-      return f.createTypeReferenceNode("void");
+      return f.createTypeReferenceNode('void');
     case Type_Which.BOOLT:
-      return f.createTypeReferenceNode("boolean");
+      return f.createTypeReferenceNode('boolean');
     case Type_Which.NUMBER: {
       const number = type.getNumber();
       if (isBigNumber(number)) {
         return f.createUnionTypeNode([
-          f.createTypeReferenceNode("number"),
-          f.createTypeReferenceNode("bigint"),
+          f.createTypeReferenceNode('number'),
+          f.createTypeReferenceNode('bigint'),
         ]);
       } else {
-        return f.createTypeReferenceNode("number");
+        return f.createTypeReferenceNode('number');
       }
     }
     case Type_Which.PROMISE: {
@@ -248,13 +248,13 @@ export function createTypeNode(
         // We don't use `allowCoercion` here, as we want stream callback return
         // types to be `Promise<void>` so they match official TypeScript types:
         // https://github.com/microsoft/TypeScript/blob/f1288c33a1594046dcb4bad2ecdda80a1b035bb7/lib/lib.webworker.d.ts#L5987-L6025
-        return f.createTypeReferenceNode("Promise", [
-          f.createTypeReferenceNode("any"),
+        return f.createTypeReferenceNode('Promise', [
+          f.createTypeReferenceNode('any'),
         ]);
       }
 
       const valueType = createTypeNode(value, allowCoercion);
-      const promiseType = f.createTypeReferenceNode("Promise", [valueType]);
+      const promiseType = f.createTypeReferenceNode('Promise', [valueType]);
       if (allowCoercion) {
         return f.createUnionTypeNode([valueType, promiseType]);
       } else {
@@ -264,33 +264,33 @@ export function createTypeNode(
     case Type_Which.STRUCTURE:
       return f.createTypeReferenceNode(getTypeName(type.getStructure()));
     case Type_Which.STRING:
-      return f.createTypeReferenceNode("string");
+      return f.createTypeReferenceNode('string');
     case Type_Which.OBJECT:
-      return f.createTypeReferenceNode("any");
+      return f.createTypeReferenceNode('any');
     case Type_Which.ARRAY: {
       const array = type.getArray();
       const element = array.getElement();
       if (element.isNumber() && isCharNumber(element.getNumber())) {
-        return f.createTypeReferenceNode("string");
+        return f.createTypeReferenceNode('string');
       } else if (element.isNumber() && isByteNumber(element.getNumber())) {
         // If the array element is a `byte`...
         if (allowCoercion) {
           // When coercion is enabled (e.g. method param), `kj::Array<byte>` and
           // `kj::ArrayPtr<byte>` both mean `ArrayBuffer | ArrayBufferView`
           return f.createUnionTypeNode([
-            f.createTypeReferenceNode("ArrayBuffer"),
-            f.createTypeReferenceNode("ArrayBufferView"),
+            f.createTypeReferenceNode('ArrayBuffer'),
+            f.createTypeReferenceNode('ArrayBufferView'),
           ]);
         } else {
           // When coercion is disabled, `kj::ArrayPtr<byte>` corresponds to
           // `ArrayBufferView`, whereas `kj::Array<byte>` is `ArrayBuffer`
           return f.createTypeReferenceNode(
-            isArrayPointer(array) ? "ArrayBufferView" : "ArrayBuffer"
+            isArrayPointer(array) ? 'ArrayBufferView' : 'ArrayBuffer'
           );
         }
       } else if (isIterable(array) && allowCoercion) {
         // If this is a `jsg::Sequence` parameter, it should accept any iterable
-        return f.createTypeReferenceNode("Iterable", [
+        return f.createTypeReferenceNode('Iterable', [
           createTypeNode(element, allowCoercion),
         ]);
       } else {
@@ -300,7 +300,7 @@ export function createTypeNode(
     }
     case Type_Which.MAYBE: {
       const maybe = type.getMaybe();
-      const alternative = isNullMaybe(maybe) ? "null" : "undefined";
+      const alternative = isNullMaybe(maybe) ? 'null' : 'undefined';
       return f.createUnionTypeNode([
         createTypeNode(maybe.getValue(), allowCoercion),
         f.createTypeReferenceNode(alternative),
@@ -308,7 +308,7 @@ export function createTypeNode(
     }
     case Type_Which.DICT: {
       const dict = type.getDict();
-      return f.createTypeReferenceNode("Record", [
+      return f.createTypeReferenceNode('Record', [
         createTypeNode(dict.getKey(), allowCoercion),
         createTypeNode(dict.getValue(), allowCoercion),
       ]);
@@ -324,27 +324,27 @@ export function createTypeNode(
       const builtin = type.getBuiltin().getType();
       switch (builtin) {
         case BuiltinType_Type.V8UINT8ARRAY:
-          return f.createTypeReferenceNode("Uint8Array");
+          return f.createTypeReferenceNode('Uint8Array');
         case BuiltinType_Type.V8ARRAY_BUFFER_VIEW:
-          return f.createTypeReferenceNode("ArrayBufferView");
+          return f.createTypeReferenceNode('ArrayBufferView');
         case BuiltinType_Type.V8ARRAY_BUFFER:
-          return f.createTypeReferenceNode("ArrayBuffer");
+          return f.createTypeReferenceNode('ArrayBuffer');
         case BuiltinType_Type.JSG_BUFFER_SOURCE:
           return f.createUnionTypeNode([
-            f.createTypeReferenceNode("ArrayBuffer"),
-            f.createTypeReferenceNode("ArrayBufferView"),
+            f.createTypeReferenceNode('ArrayBuffer'),
+            f.createTypeReferenceNode('ArrayBufferView'),
           ]);
         case BuiltinType_Type.KJ_DATE:
           if (allowCoercion) {
             return f.createUnionTypeNode([
-              f.createTypeReferenceNode("number"),
-              f.createTypeReferenceNode("Date"),
+              f.createTypeReferenceNode('number'),
+              f.createTypeReferenceNode('Date'),
             ]);
           } else {
-            return f.createTypeReferenceNode("Date");
+            return f.createTypeReferenceNode('Date');
           }
         case BuiltinType_Type.V8FUNCTION:
-          return f.createTypeReferenceNode("Function");
+          return f.createTypeReferenceNode('Function');
         default:
           assert.fail(`Unknown builtin type: ${builtin satisfies never}`);
       }
@@ -353,15 +353,15 @@ export function createTypeNode(
     case Type_Which.INTRINSIC: {
       const intrinsic = type.getIntrinsic().getName();
       switch (intrinsic) {
-        case "v8::kErrorPrototype":
-          return f.createTypeReferenceNode("Error");
-        case "v8::kIteratorPrototype":
-          return f.createTypeReferenceNode("Iterator", [
-            f.createTypeReferenceNode("unknown"),
+        case 'v8::kErrorPrototype':
+          return f.createTypeReferenceNode('Error');
+        case 'v8::kIteratorPrototype':
+          return f.createTypeReferenceNode('Iterator', [
+            f.createTypeReferenceNode('unknown'),
           ]);
-        case "v8::kAsyncIteratorPrototype":
-          return f.createTypeReferenceNode("AsyncIterator", [
-            f.createTypeReferenceNode("unknown"),
+        case 'v8::kAsyncIteratorPrototype':
+          return f.createTypeReferenceNode('AsyncIterator', [
+            f.createTypeReferenceNode('unknown'),
           ]);
         default:
           assert.fail(`Unknown intrinsic type: ${intrinsic}`);
@@ -371,8 +371,8 @@ export function createTypeNode(
     case Type_Which.FUNCTION: {
       const func = type.getFunction();
       const params = createParamDeclarationNodes(
-        "FUNCTION_TODO",
-        "FUNCTION_TODO",
+        'FUNCTION_TODO',
+        'FUNCTION_TODO',
         func.getArgs().toArray()
       );
       const result = createTypeNode(
@@ -397,11 +397,11 @@ export function createTypeNode(
         case JsgImplType_Type.V8FUNCTION_CALLBACK_INFO:
         case JsgImplType_Type.V8PROPERTY_CALLBACK_INFO:
           // All these types should be omitted from function parameters
-          return f.createTypeReferenceNode("never");
+          return f.createTypeReferenceNode('never');
         case JsgImplType_Type.JSG_VARARGS:
-          return f.createArrayTypeNode(f.createTypeReferenceNode("any"));
+          return f.createArrayTypeNode(f.createTypeReferenceNode('any'));
         case JsgImplType_Type.JSG_NAME:
-          return f.createTypeReferenceNode("PropertyKey");
+          return f.createTypeReferenceNode('PropertyKey');
         default:
           assert.fail(
             `Unknown JSG implementation type: ${impl satisfies never}`
@@ -411,7 +411,7 @@ export function createTypeNode(
     }
     case Type_Which.JS_BUILTIN: {
       // TODO(soon): implement
-      assert.fail("`JS_BUILTIN`s are not yet supported");
+      assert.fail('`JS_BUILTIN`s are not yet supported');
       break;
     }
     default: {


### PR DESCRIPTION
This PR adds a new compat flag named `urlpattern_standard` which replaces the URLPattern implementation with Ada backed one. It will be automatically enabled on May 1st, 2025.

Fixes https://github.com/cloudflare/workerd/issues/3533
Fixes https://github.com/cloudflare/workerd/issues/327
