### PR TITLE
Make AbortSignal cloneable

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -852,7 +852,7 @@ jsg::Ref<AbortSignal> AbortSignal::deserialize(
     jsg::Lock& js, rpc::SerializationTag tag, jsg::Deserializer& deserializer) {
   auto& handler = KJ_REQUIRE_NONNULL(
       deserializer.getExternalHandler(), "got AbortSignal on non-RPC serialized object?");
-  auto externalHandler = dynamic_cast<RpcDeserializerExternalHander*>(&handler);
+  auto externalHandler = dynamic_cast<RpcDeserializerExternalHandler*>(&handler);
   KJ_REQUIRE(externalHandler != nullptr, "got AbortSignal on non-RPC serialized object?");
 
   auto isCanceled = static_cast<bool>(deserializer.readRawUint32());

--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -9,6 +9,7 @@
 
 #include <workerd/io/io-context.h>
 
+#include <capnp/message.h>
 #include <kj/async.h>
 #include <kj/vector.h>
 
@@ -265,7 +266,7 @@ void EventTarget::addEventListener(jsg::Lock& js,
       KJ_IF_SOME(signal, maybeSignal) {
         // If the AbortSignal has already been triggered, then we need to stop here.
         // Return without adding the event listener.
-        if (signal->getAborted()) {
+        if (signal->getAborted(js)) {
           return;
         }
       }
@@ -521,6 +522,45 @@ bool EventTarget::dispatchEvent(jsg::Lock& js, jsg::Ref<Event> event) {
   return dispatchEventImpl(js, kj::mv(event));
 }
 
+class AbortTriggerRpcClient final {
+ public:
+  AbortTriggerRpcClient(rpc::AbortTrigger::Client&& client): client(kj::mv(client)) {}
+
+  kj::Promise<void> abort(kj::ArrayPtr<kj::byte> reason) {
+    auto req = client.abortRequest(capnp::MessageSize{reason.size() / sizeof(capnp::word) + 8, 0});
+    auto field = req.initReason();
+    field.setV8Serialized(reason);
+    return req.send().ignoreResult();
+  }
+
+ private:
+  rpc::AbortTrigger::Client client;
+};
+
+namespace {
+// The jsrpc handler that receives aborts from the remote and triggers them locally
+class AbortTriggerRpcServer final: public rpc::AbortTrigger::Server {
+ public:
+  AbortTriggerRpcServer(kj::Own<kj::PromiseFulfiller<void>> fulfiller,
+      kj::Own<AbortSignal::PendingReason>&& pendingReason)
+      : fulfiller(kj::mv(fulfiller)),
+        pendingReason(kj::mv(pendingReason)) {}
+
+  kj::Promise<void> abort(AbortContext abortCtx) override {
+    auto params = abortCtx.getParams();
+    auto reason = params.getReason().getV8Serialized();
+
+    pendingReason->getWrapped() = kj::heapArray(reason.asBytes());
+    fulfiller->fulfill();
+    return kj::READY_NOW;
+  }
+
+ private:
+  kj::Own<kj::PromiseFulfiller<void>> fulfiller;
+  kj::Own<AbortSignal::PendingReason> pendingReason;
+};
+}  // namespace
+
 AbortSignal::AbortSignal(kj::Maybe<kj::Exception> exception,
     jsg::Optional<jsg::JsRef<jsg::JsValue>> maybeReason,
     Flag flag)
@@ -540,16 +580,34 @@ void AbortSignal::setOnAbort(jsg::Lock& js, jsg::Optional<jsg::JsValue> handler)
   KJ_IF_SOME(h, handler) {
     if (h.isFunction() || h.isObject()) {
       onAbortHandler = jsg::JsRef(js, h);
+      subscribeToRpcAbort(js);
       return;
     }
   }
   onAbortHandler = kj::none;
 }
 
+void AbortSignal::addEventListener(jsg::Lock& js,
+    kj::String type,
+    jsg::Identified<Handler> handler,
+    jsg::Optional<AddEventListenerOpts> maybeOptions) {
+  EventTarget::addEventListener(js, kj::mv(type), kj::mv(handler), kj::mv(maybeOptions));
+  subscribeToRpcAbort(js);
+}
+
+bool AbortSignal::getAborted(jsg::Lock& js) {
+  return canceler->isCanceled() || hasPendingReason();
+}
+
 jsg::JsValue AbortSignal::getReason(jsg::Lock& js) {
   KJ_IF_SOME(r, reason) {
     return r.getHandle(js);
   }
+
+  KJ_IF_SOME(r, deserializePendingReason(js)) {
+    return r;
+  }
+
   return js.undefined();
 }
 
@@ -582,8 +640,12 @@ void AbortSignal::throwIfAborted(jsg::Lock& js) {
     KJ_IF_SOME(r, reason) {
       js.throwException(r.getHandle(js));
     } else {
-      js.throwException(abortException(js));
+      js.throwException(abortException(js, kj::none));
     }
+  }
+
+  KJ_IF_SOME(r, deserializePendingReason(js)) {
+    js.throwException(r);
   }
 }
 
@@ -619,7 +681,7 @@ jsg::Ref<AbortSignal> AbortSignal::any(jsg::Lock& js,
   // Let's check to see if any of the signals are already aborted. If it is, we can
   // optimize here by skipping the event handler registration.
   for (auto& sig: signals) {
-    if (sig->getAborted()) {
+    if (sig->getAborted(js)) {
       return AbortSignal::abort(js, sig->getReason(js));
     }
   }
@@ -681,9 +743,24 @@ void AbortSignal::triggerAbort(
       }
     }
   } else {
-    reason = js.exceptionToJsValue(kj::mv(exception));
+    reason = js.exceptionToJsValue(kj::cp(exception));
   }
-  canceler->cancel(kj::cp(exception));
+
+  canceler->cancel(kj::mv(exception));
+
+  // 1. Dispatch to RPC clients
+  if (!rpcClients.empty()) {
+    IoContext& ioContext = IoContext::current();
+    jsg::Serializer ser(js);
+    KJ_IF_SOME(r, reason) {
+      ser.write(js, r.getHandle(js));
+    }
+
+    auto released = ser.release();
+    ioContext.addTask(sendToRpc(kj::mv(released.data)));
+  }
+
+  // 2. Dispatch to local listeners
 
   // This is questionable only because it goes against the spec but it does help prevent
   // memory leaks. Once the abort signal has been triggered, there's really nothing else
@@ -694,6 +771,137 @@ void AbortSignal::triggerAbort(
   KJ_DEFER(removeAllHandlers());
 
   dispatchEventImpl(js, js.alloc<Event>(kj::str("abort")));
+}
+
+void AbortSignal::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
+  auto& handler = JSG_REQUIRE_NONNULL(serializer.getExternalHandler(), DOMDataCloneError,
+      "AbortSignal can only be serialized for RPC.");
+  auto externalHandler = dynamic_cast<RpcSerializerExternalHandler*>(&handler);
+  JSG_REQUIRE(
+      externalHandler != nullptr, DOMDataCloneError, "AbortSignal can only be serialized for RPC.");
+
+  serializer.writeRawUint32(static_cast<uint>(canceler->isCanceled()));
+  serializer.writeRawUint32(static_cast<uint>(flag));
+  KJ_IF_SOME(r, reason) {
+    serializer.write(js, r.getHandle(js));
+  } else {
+    serializer.write(js, js.undefined());
+  }
+
+  if (getAborted(js) || getNeverAborts()) {
+    // This AbortSignal cannot be triggered in the future. No stream is needed.
+    return;
+  }
+
+  auto streamCap = externalHandler
+                       ->writeStream([&](rpc::JsValue::External::Builder builder) mutable {
+    builder.setAbortTrigger();
+  }).castAs<rpc::AbortTrigger>();
+
+  auto& ioContext = IoContext::current();
+  // Keep track of every AbortSignal cloned from this one.
+  // If this->triggerAbort(...) is called, each rpcClient will be informed.
+  rpcClients.add(ioContext.addObject(kj::heap<AbortTriggerRpcClient>(kj::mv(streamCap))));
+}
+
+jsg::Ref<AbortSignal> AbortSignal::deserialize(
+    jsg::Lock& js, rpc::SerializationTag tag, jsg::Deserializer& deserializer) {
+  auto& handler = KJ_REQUIRE_NONNULL(
+      deserializer.getExternalHandler(), "got AbortSignal on non-RPC serialized object?");
+  auto externalHandler = dynamic_cast<RpcDeserializerExternalHander*>(&handler);
+  KJ_REQUIRE(externalHandler != nullptr, "got AbortSignal on non-RPC serialized object?");
+
+  auto isCanceled = static_cast<bool>(deserializer.readRawUint32());
+  auto flag = static_cast<Flag>(deserializer.readRawUint32());
+  auto reason = deserializer.readValue(js);
+
+  if (isCanceled) {
+    // The signal is already aborted and cannot be triggered again. We don't need to set up RPC.
+    return abort(js, reason);
+  }
+
+  if (flag == Flag::NEVER_ABORTS) {
+    // The signal can't be aborted. We don't need to setup RPC
+    return js.alloc<AbortSignal>(/* exception */ kj::none, /* maybeReason */ kj::none, flag);
+  }
+
+  auto reader = externalHandler->read();
+  KJ_REQUIRE(reader.isAbortTrigger(), "external table slot type does't match serialization tag");
+
+  // The AbortSignalImpl will receive any remote triggerAbort requests and fulfill the promise with the reason for abort
+
+  auto signal = js.alloc<AbortSignal>(/* exception */ kj::none, /* maybeReason */ kj::none, flag);
+
+  auto paf = kj::newPromiseAndFulfiller<void>();
+  auto pendingReason = IoContext::current().addObject(kj::refcounted<PendingReason>());
+
+  externalHandler->setLastStream(
+      kj::heap<AbortTriggerRpcServer>(kj::mv(paf.fulfiller), kj::addRef(*pendingReason)));
+  signal->rpcAbortPromise = IoContext::current().addObject(kj::heap(kj::mv(paf.promise)));
+  signal->pendingReason = kj::mv(pendingReason);
+
+  return signal;
+}
+
+kj::Promise<void> AbortSignal::sendToRpc(kj::Array<kj::byte>&& reason) {
+  auto& ioContext = IoContext::current();
+
+  KJ_IF_SOME(outputLocks, ioContext.waitForOutputLocksIfNecessary()) {
+    co_await outputLocks;
+  }
+
+  kj::Vector<kj::Promise<void>> promises;
+  for (auto& cap: rpcClients) {
+    promises.add(cap->abort(reason));
+  }
+
+  co_await kj::joinPromises(promises.releaseAsArray());
+}
+
+bool AbortSignal::hasPendingReason() {
+  KJ_IF_SOME(pr, pendingReason) {
+    return pr->getWrapped() != nullptr;
+  }
+
+  return false;
+}
+
+kj::Maybe<jsg::JsValue> AbortSignal::deserializePendingReason(jsg::Lock& js) {
+  KJ_IF_SOME(pr, pendingReason) {
+    if (pr->getWrapped() == nullptr) {
+      // pendingReason not initialized. This means abort wasn't yet triggered
+      return kj::none;
+    }
+
+    KJ_SWITCH_ONEOF(pr->getWrapped()) {
+      KJ_CASE_ONEOF(v8Serialized, kj::Array<kj::byte>) {
+        jsg::Deserializer des(js, v8Serialized);
+        return kj::some(des.readValue(js));
+      }
+
+      KJ_CASE_ONEOF(exception, kj::Exception) {
+        return kj::some(js.exceptionToJsValue(kj::cp(exception)).getHandle(js));
+      }
+    }
+  }
+
+  return kj::none;
+}
+
+void AbortSignal::subscribeToRpcAbort(jsg::Lock& js) {
+  // For an AbortSignal received over RPC, the first time someone registers an event on the signal,
+  // we want to arrange to awaitIo() for the underlying RPC signal. If no one is actually listening,
+  // though, we don't want to awaitIo() since it blocks hibernation in actors.
+
+  KJ_IF_SOME(promise, rpcAbortPromise) {
+    IoContext::current().awaitIo(js, kj::mv(*promise), [this](jsg::Lock& js) {
+      KJ_IF_SOME(r, deserializePendingReason(js)) {
+        triggerAbort(js, r);
+      }
+    });
+
+    rpcAbortPromise = kj::none;
+  }
 }
 
 void AbortController::abort(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
@@ -737,7 +945,7 @@ kj::Promise<void> Scheduler::wait(
     jsg::Lock& js, double delay, jsg::Optional<WaitOptions> maybeOptions) {
   KJ_IF_SOME(options, maybeOptions) {
     KJ_IF_SOME(s, options.signal) {
-      if (s->getAborted()) {
+      if (s->getAborted(js)) {
         return js.exceptionToKj(s->getReason(js));
       }
     }
@@ -759,7 +967,7 @@ kj::Promise<void> Scheduler::wait(
 
   KJ_IF_SOME(options, maybeOptions) {
     KJ_IF_SOME(s, options.signal) {
-      promise = s->wrap(kj::mv(promise));
+      promise = s->wrap(js, kj::mv(promise));
     }
   }
 

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -588,6 +588,11 @@ class AbortSignal final: public EventTarget {
     }
     JSG_PROTOTYPE_PROPERTY(onabort, getOnAbort, setOnAbort);
     JSG_METHOD(throwIfAborted);
+
+    if (flags.getWorkerdExperimental()) {
+      JSG_METHOD(skipReleaseForTest);
+      JSG_TS_OVERRIDE({ skipReleaseForTest: never });
+    }
   }
 
   // Allows this AbortSignal to also serve as a kj::Canceler
@@ -619,6 +624,10 @@ class AbortSignal final: public EventTarget {
   }
 
   void serialize(jsg::Lock& js, jsg::Serializer& serializer);
+
+  // To test what happens if a capability is dropped before invoking release on the cloned abort
+  // signal, this method will tell every rpcClient to skip this step before destruction.
+  void skipReleaseForTest();
 
   static jsg::Ref<AbortSignal> deserialize(
       jsg::Lock& js, rpc::SerializationTag tag, jsg::Deserializer& deserializer);

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -9,6 +9,7 @@
 
 #include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/io/io-own.h>
+#include <workerd/io/worker-interface.capnp.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/util/canceler.h>
 
@@ -516,6 +517,8 @@ class EventTarget: public jsg::Object {
 };
 
 // An implementation of the Web Platform Standard AbortSignal API
+class AbortTriggerRpcClient;
+
 class AbortSignal final: public EventTarget {
  public:
   enum class Flag { NONE, NEVER_ABORTS };
@@ -524,13 +527,15 @@ class AbortSignal final: public EventTarget {
       jsg::Optional<jsg::JsRef<jsg::JsValue>> maybeReason = kj::none,
       Flag flag = Flag::NONE);
 
+  using PendingReason = kj::RefcountedWrapper<
+      kj::OneOf<kj::Array<kj::byte> /* v8Serialized */, kj::Exception /* if capability is dropped */
+          >>;
+
   // The AbortSignal explicitly does not expose a constructor(). It is
   // illegal for user code to create an AbortSignal directly.
   static jsg::Ref<AbortSignal> constructor() = delete;
 
-  bool getAborted() {
-    return canceler->isCanceled();
-  }
+  bool getAborted(jsg::Lock& js);
 
   jsg::JsValue getReason(jsg::Lock& js);
 
@@ -564,6 +569,11 @@ class AbortSignal final: public EventTarget {
   kj::Maybe<jsg::JsValue> getOnAbort(jsg::Lock& js);
   void setOnAbort(jsg::Lock& js, jsg::Optional<jsg::JsValue> handler);
 
+  void addEventListener(jsg::Lock& js,
+      kj::String type,
+      jsg::Identified<Handler> handler,
+      jsg::Optional<AddEventListenerOpts> maybeOptions);
+
   JSG_RESOURCE_TYPE(AbortSignal, CompatibilityFlags::Reader flags) {
     JSG_INHERIT(EventTarget);
     JSG_STATIC_METHOD(abort);
@@ -582,23 +592,22 @@ class AbortSignal final: public EventTarget {
 
   // Allows this AbortSignal to also serve as a kj::Canceler
   template <typename T>
-  kj::Promise<T> wrap(kj::Promise<T> promise) {
+  kj::Promise<T> wrap(jsg::Lock& js, kj::Promise<T> promise) {
+    subscribeToRpcAbort(js);
+
     JSG_REQUIRE(!canceler->isCanceled(), TypeError, "The AbortSignal has already been triggered");
     return canceler->wrap(kj::mv(promise));
   }
 
   template <typename T>
   static kj::Promise<T> maybeCancelWrap(
-      kj::Maybe<jsg::Ref<AbortSignal>>& signal, kj::Promise<T> promise) {
+      jsg::Lock& js, kj::Maybe<jsg::Ref<AbortSignal>>& signal, kj::Promise<T> promise) {
     KJ_IF_SOME(s, signal) {
-      return s->wrap(kj::mv(promise));
+      return s->wrap(js, kj::mv(promise));
     } else {
       return kj::mv(promise);
     }
   }
-
-  static kj::Exception abortException(
-      jsg::Lock& js, jsg::Optional<kj::OneOf<kj::Exception, jsg::JsValue>> reason = kj::none);
 
   RefcountedCanceler& getCanceler();
 
@@ -609,15 +618,55 @@ class AbortSignal final: public EventTarget {
     tracker.trackField("reason", reason);
   }
 
+  void serialize(jsg::Lock& js, jsg::Serializer& serializer);
+
+  static jsg::Ref<AbortSignal> deserialize(
+      jsg::Lock& js, rpc::SerializationTag tag, jsg::Deserializer& deserializer);
+
+  JSG_SERIALIZABLE(rpc::SerializationTag::ABORT_SIGNAL);
+
  private:
   IoOwn<RefcountedCanceler> canceler;
   Flag flag;
   kj::Maybe<jsg::JsRef<jsg::JsValue>> reason;
   kj::Maybe<jsg::JsRef<jsg::JsValue>> onAbortHandler;
 
+  static kj::Exception abortException(
+      jsg::Lock& js, jsg::Optional<kj::OneOf<kj::Exception, jsg::JsValue>> reason);
+
   void visitForGc(jsg::GcVisitor& visitor);
 
   friend class AbortController;
+
+  // -------------------------------------------------------------
+  // RPC client functionality. Used if this signal was serialized.
+
+  // A collection of rpcClients, which will be notified if this signal is triggered and when this
+  // signal is destroyed.
+  kj::Vector<IoOwn<AbortTriggerRpcClient>> rpcClients;
+
+  // Trigger an abort on all associated clients
+  kj::Promise<void> sendToRpc(kj::Array<kj::byte>&& reason);
+
+  // ---------------------------------------------------------------
+  // RPC server functionality. Used if this signal was deserialized.
+
+  // A promise that is fulfilled if an abort() message is received over RPC.
+  kj::Maybe<IoOwn<kj::Promise<void>>> rpcAbortPromise;
+
+  // A refcounted object used to receive a serialized abort reason
+  // The abort reason is required in asynchronous event handlers as well as synchronous methods
+  // like getReason(). As a result, we can't pass the abort reason in the above promise, and both
+  // sync and async methods will need to check this value.
+  kj::Maybe<IoOwn<PendingReason>> pendingReason;
+
+  // Synchronously check if an abort reason was sent over RPC
+  bool hasPendingReason();
+  kj::Maybe<jsg::JsValue> deserializePendingReason(jsg::Lock& js);
+
+  // Wait for abort over RPC.
+  // We invoke this once at least one event handler is attached to the AbortSignal
+  void subscribeToRpcAbort(jsg::Lock& js);
 };
 
 // An implementation of the Web Platform Standard AbortController API

--- a/src/workerd/api/eventsource.c++
+++ b/src/workerd/api/eventsource.c++
@@ -322,7 +322,7 @@ void EventSource::reconnect(jsg::Lock& js) {
   readyState = State::CONNECTING;
   abortController = js.alloc<AbortController>(js);
   auto signal = abortController->getSignal();
-  context.awaitIo(js, signal->wrap(context.afterLimitTimeout(reconnectionTime)))
+  context.awaitIo(js, signal->wrap(js, context.afterLimitTimeout(reconnectionTime)))
       .then(js,
           JSG_VISITABLE_LAMBDA(
               (self = JSG_THIS), (self), (jsg::Lock & js) mutable { self->start(js); }),

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -1209,7 +1209,7 @@ kj::Maybe<jsg::Promise<void>> WritableStreamInternalController::tryPipeFrom(
   // If a signal is provided, we need to check that it is not already triggered. If it
   // is, we return a rejected promise using the signal's reason.
   KJ_IF_SOME(signal, options.signal) {
-    if ((signal)->getAborted()) {
+    if (signal->getAborted(js)) {
       return rejectedMaybeHandledPromise<void>(js, signal->getReason(js), pipeThrough);
     }
   }
@@ -1758,7 +1758,7 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
         return handlePromise(js,
             ioContext.awaitIo(js,
                 writable->canceler.wrap(
-                    AbortSignal::maybeCancelWrap(request.maybeSignal, kj::mv(promise)))));
+                    AbortSignal::maybeCancelWrap(js, request.maybeSignal, kj::mv(promise)))));
       }
 
       // The ReadableStream is JavaScript-backed. We can still pipe the data but it's going to be
@@ -1813,7 +1813,7 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
 
 bool WritableStreamInternalController::Pipe::checkSignal(jsg::Lock& js) {
   KJ_IF_SOME(signal, maybeSignal) {
-    if ((signal)->getAborted()) {
+    if (signal->getAborted(js)) {
       auto reason = signal->getReason(js);
 
       // abort process might call parent.drain which will delete this,

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -699,7 +699,7 @@ jsg::Ref<ReadableStream> ReadableStream::deserialize(
     jsg::Lock& js, rpc::SerializationTag tag, jsg::Deserializer& deserializer) {
   auto& handler = KJ_REQUIRE_NONNULL(
       deserializer.getExternalHandler(), "got ReadableStream on non-RPC serialized object?");
-  auto externalHandler = dynamic_cast<RpcDeserializerExternalHander*>(&handler);
+  auto externalHandler = dynamic_cast<RpcDeserializerExternalHandler*>(&handler);
   KJ_REQUIRE(externalHandler != nullptr, "got ReadableStream on non-RPC serialized object?");
 
   auto reader = externalHandler->read();

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -479,7 +479,7 @@ template <typename Controller>
 kj::Maybe<jsg::Promise<void>> WritableLockImpl<Controller>::PipeLocked::checkSignal(
     jsg::Lock& js, Controller& self) {
   KJ_IF_SOME(signal, maybeSignal) {
-    if ((signal)->getAborted()) {
+    if (signal->getAborted(js)) {
       auto reason = signal->getReason(js);
       if (!preventCancel) {
         source.release(js, v8::Local<v8::Value>(reason));

--- a/src/workerd/api/streams/writable.c++
+++ b/src/workerd/api/streams/writable.c++
@@ -598,7 +598,7 @@ jsg::Ref<WritableStream> WritableStream::deserialize(
     jsg::Lock& js, rpc::SerializationTag tag, jsg::Deserializer& deserializer) {
   auto& handler = KJ_REQUIRE_NONNULL(
       deserializer.getExternalHandler(), "got WritableStream on non-RPC serialized object?");
-  auto externalHandler = dynamic_cast<RpcDeserializerExternalHander*>(&handler);
+  auto externalHandler = dynamic_cast<RpcDeserializerExternalHandler*>(&handler);
   KJ_REQUIRE(externalHandler != nullptr, "got WritableStream on non-RPC serialized object?");
 
   auto reader = externalHandler->read();

--- a/src/workerd/api/tests/abortsignal-test.js
+++ b/src/workerd/api/tests/abortsignal-test.js
@@ -1,7 +1,89 @@
-import { strictEqual, ok, throws } from 'node:assert';
+import { strictEqual, ok, throws, rejects } from 'node:assert';
+import { WorkerEntrypoint, RpcTarget } from 'cloudflare:workers';
 
 // Test for the AbortSignal and AbortController standard Web API implementations.
 // The implementation for these are in api/basics.{h|c++}
+
+class WrappedAbortSignal extends RpcTarget {
+  constructor() {
+    super();
+    this.ac = new AbortController();
+  }
+
+  forget() {
+    this.ac.signal.skipReleaseForTest();
+  }
+
+  getSignal() {
+    return this.ac.signal;
+  }
+}
+
+let globalAbortController;
+export class RpcRemoteEnd extends WorkerEntrypoint {
+  async echo(signal) {
+    return signal;
+  }
+
+  async countToInfinity(signal) {
+    let onAbortWasFired = false;
+
+    signal.onabort = () => {
+      onAbortWasFired = true;
+    };
+
+    for (let i = 0; ; i++) {
+      await scheduler.wait(50);
+      if (signal.aborted) {
+        return { counter: i, reason: signal.reason, onAbortWasFired };
+      }
+    }
+  }
+
+  async countToInfinityWithRequest(req) {
+    return this.countToInfinity(req.signal);
+  }
+
+  async countToInfinityWithTimeout(remoteSignal) {
+    let timeout = AbortSignal.timeout(1000);
+    let signal = AbortSignal.any([timeout, remoteSignal]);
+    return this.countToInfinity(signal);
+  }
+
+  async ignoreSignal(signal) {
+    let i = 0;
+
+    for (i = 0; i < 10; i++) {
+      await scheduler.wait(50);
+    }
+
+    return { counter: i, reason: signal.reason };
+  }
+
+  async chainReaction(signal) {
+    let onAbortWasFired = false;
+
+    signal.onabort = () => {
+      onAbortWasFired = true;
+    };
+
+    const inner = await this.env.RpcRemoteEnd.countToInfinity(signal);
+    return { inner, reason: signal.reason, onAbortWasFired };
+  }
+
+  async tryUsingGlobalAbortController() {
+    if (globalAbortController === undefined) {
+      globalAbortController = new AbortController();
+      await this.env.RpcRemoteEnd.echo(globalAbortController.signal); // send the signal over
+    } else {
+      globalAbortController.abort(new Error('boom?'));
+    }
+  }
+
+  async getWrappedSignal() {
+    return new WrappedAbortSignal();
+  }
+}
 
 export const abortcontroller = {
   test() {
@@ -210,5 +292,301 @@ export const onabortPrototypeProperty = {
     const handler = {};
     ac.signal.onabort = handler;
     strictEqual(ac.signal.onabort, handler);
+  },
+};
+
+export const rpcUnusedSignal = {
+  async test(ctrl, env, ctx) {
+    const ac = new AbortController();
+    const responseSignal = await env.RpcRemoteEnd.echo(ac.signal);
+
+    ok(responseSignal instanceof AbortSignal);
+    strictEqual(responseSignal.aborted, false);
+    strictEqual(responseSignal.reason, undefined);
+  },
+};
+
+export const rpcNeverAbortsSignal = {
+  async test(ctrl, env, ctx) {
+    const otherRequest = new Request('http://example.com');
+
+    const responseSignal = await env.RpcRemoteEnd.echo(otherRequest.signal);
+    ok(responseSignal instanceof AbortSignal);
+    strictEqual(responseSignal.aborted, false);
+    strictEqual(responseSignal.reason, undefined);
+  },
+};
+
+export const rpcAbortSignalTimeout = {
+  async test(ctrl, env, ctx) {
+    const signal = AbortSignal.timeout(200);
+    const res = await env.RpcRemoteEnd.countToInfinity(signal);
+
+    // We don't care the exact value it got to, but at least 1 iteration should have happened
+    ok(res.counter >= 1);
+
+    // Make sure the reason was passed without being garbled
+    ok(res.reason instanceof DOMException);
+    strictEqual(res.reason.message, 'The operation was aborted due to timeout');
+
+    // Make sure an event was dispatched on the remote side
+    ok(res.onAbortWasFired);
+  },
+};
+
+export const rpcAbortSignalAbort = {
+  async test(ctrl, env, ctx) {
+    // NB: AbortSignal.abort returns an abort signal that is already aborted
+    const expectedReason = "just didn't feel like it";
+    const signal = AbortSignal.abort(expectedReason);
+    const res = await env.RpcRemoteEnd.countToInfinity(signal);
+
+    // No iterations should have happened
+    strictEqual(res.counter, 0);
+
+    // Make sure the reason was passed without being garbled
+    strictEqual(res.reason, "just didn't feel like it");
+
+    // No event is dispatched on an already aborted signal
+    ok(!res.onAbortWasFired);
+  },
+};
+
+export const rpcAbortControllerSignal = {
+  async test(ctrl, env, ctx) {
+    const ac = new AbortController();
+    const resPromise = env.RpcRemoteEnd.countToInfinity(ac.signal);
+
+    // Wait an arbitrary amount of time, then use the AbortController to abort the remote end.
+    await scheduler.wait(200);
+    const expectedReason = 'changed my mind';
+    ac.abort(expectedReason);
+
+    const res = await resPromise;
+
+    // We don't care the exact value it got to, but at least 1 iteration should have happened
+    ok(res.counter >= 1);
+
+    // Make sure the reason was passed without being garbled
+    strictEqual(res.reason, expectedReason);
+
+    // Make sure an event was dispatched on the remote side
+    ok(res.onAbortWasFired);
+  },
+};
+
+export const rpcAbortControllerSignalNoReasonProvided = {
+  async test(ctrl, env, ctx) {
+    const ac = new AbortController();
+    const resPromise = env.RpcRemoteEnd.countToInfinity(ac.signal);
+
+    // Wait an arbitrary amount of time, then use the AbortController to abort the remote end.
+    await scheduler.wait(200);
+    ac.abort();
+
+    const res = await resPromise;
+
+    // We don't care the exact value it got to, but at least 1 iteration should have happened
+    ok(res.counter >= 1);
+
+    // Make sure the reason was passed without being garbled
+    ok(res.reason instanceof DOMException);
+    strictEqual(res.reason.message, 'The operation was aborted');
+
+    // Make sure an event was dispatched on the remote side
+    ok(res.onAbortWasFired);
+  },
+};
+
+export const rpcAbortSignalFurtherCloned = {
+  async test(ctrl, env, ctx) {
+    const ac = new AbortController();
+    const resPromise = env.RpcRemoteEnd.chainReaction(ac.signal);
+
+    // Wait an arbitrary amount of time, then use the AbortController to abort the remote end.
+    await scheduler.wait(200);
+    const expectedReason = 'changed my mind';
+    ac.abort(expectedReason);
+
+    const res = await resPromise;
+
+    // We don't care the exact value it got to, but at least 1 iteration should have happened
+    ok(res.inner.counter >= 1);
+
+    // Make sure the reason was passed without being garbled
+    strictEqual(res.reason, expectedReason);
+    strictEqual(res.inner.reason, expectedReason);
+
+    // Make sure an event was dispatched on the remote side
+    ok(res.onAbortWasFired);
+    ok(res.inner.onAbortWasFired);
+  },
+};
+
+export const rpcAbortSignalManyClients = {
+  async test(ctrl, env, ctx) {
+    const signal = AbortSignal.timeout(200);
+
+    const responses = await Promise.all(
+      Array(5).fill(env.RpcRemoteEnd.countToInfinity(signal))
+    );
+    strictEqual(responses.length, 5);
+
+    for (const res of responses) {
+      // We don't care the exact value it got to, but at least 1 iteration should have happened
+      ok(res.counter >= 1);
+
+      // Make sure the reason was passed without being garbled
+      ok(res.reason instanceof DOMException);
+      strictEqual(
+        res.reason.message,
+        'The operation was aborted due to timeout'
+      );
+
+      // Make sure an event was dispatched on the remote side
+      ok(res.onAbortWasFired);
+    }
+  },
+};
+
+export const rpcAbortSignalAny = {
+  async test(ctrl, env, ctx) {
+    const unusedAc = new AbortController();
+    const signal = AbortSignal.any([AbortSignal.timeout(200), unusedAc.signal]);
+    const res = await env.RpcRemoteEnd.countToInfinity(signal);
+
+    // We don't care the exact value it got to, but at least 1 iteration should have happened
+    ok(res.counter >= 1);
+
+    // Make sure the reason was passed without being garbled
+    ok(res.reason instanceof DOMException);
+    strictEqual(res.reason.message, 'The operation was aborted due to timeout');
+
+    // Make sure an event was dispatched on the remote side
+    ok(res.onAbortWasFired);
+  },
+};
+
+export const rpcAbortSignalAnyOnRemoteEnd = {
+  async test(ctrl, env, ctx) {
+    const ac = new AbortController();
+    const resPromise = env.RpcRemoteEnd.countToInfinityWithTimeout(ac.signal);
+
+    // Wait an arbitrary amount of time, then use the AbortController to abort the remote end.
+    await scheduler.wait(200);
+    const expectedReason =
+      'our timeout triggered before the 1000ms timeout on the other side';
+    ac.abort(expectedReason);
+
+    const res = await resPromise;
+
+    // We don't care the exact value it got to, but at least 1 iteration should have happened
+    ok(res.counter >= 1);
+
+    // Make sure the reason was passed without being garbled
+    strictEqual(res.reason, expectedReason);
+
+    // Make sure an event was dispatched on the remote side
+    ok(res.onAbortWasFired);
+  },
+};
+
+export const rpcRequestSignal = {
+  async test(ctrl, env, ctx) {
+    // Construct a request holding an AbortSignal, and then send this request to the other side
+    const req = new Request('http://example.com', {
+      signal: AbortSignal.timeout(200),
+    });
+
+    const res = await env.RpcRemoteEnd.countToInfinityWithRequest(req);
+
+    // We don't care the exact value it got to, but at least 1 iteration should have happened
+    ok(res.counter >= 1);
+
+    // Make sure the reason was passed without being garbled
+    ok(res.reason instanceof DOMException);
+    strictEqual(res.reason.message, 'The operation was aborted due to timeout');
+
+    // Make sure an event was dispatched on the remote side
+    ok(res.onAbortWasFired);
+  },
+};
+
+export const rpcCrossRequestSignal = {
+  async test(ctrl, env, ctx) {
+    // Save an AbortController in the global scope
+    await env.RpcRemoteEnd.tryUsingGlobalAbortController();
+
+    // Try to use it again
+    await rejects(
+      async () => env.RpcRemoteEnd.tryUsingGlobalAbortController(),
+      {
+        name: 'Error',
+        message:
+          "Cannot perform I/O on behalf of a different request. I/O objects (such as streams, request/response bodies, and others) created in the context of one request handler cannot be accessed from a different request's handler. This is a limitation of Cloudflare Workers which allows us to improve overall performance. (I/O type: RefcountedCanceler)",
+      }
+    );
+  },
+};
+
+export const rpcRemoteCanIgnoreSignal = {
+  async test(ctrl, env, ctx) {
+    const ac = new AbortController();
+    const resPromise = env.RpcRemoteEnd.ignoreSignal(ac.signal);
+
+    // Wait an arbitrary amount of time, then use the AbortController to abort the remote end.
+    await scheduler.wait(200);
+    const expectedReason = 'changed my mind';
+    ac.abort(expectedReason);
+
+    const res = await resPromise;
+
+    // Every iteration completes, the remote is not reacting to the abort
+    strictEqual(res.counter, 10);
+
+    // Make sure the reason was passed without being garbled
+    strictEqual(res.reason, expectedReason);
+  },
+};
+
+export const rpcDestroySignalUnclean = {
+  async test(ctrl, env, ctx) {
+    // wrapper is a RPCTarget that just holds an AbortSignal
+    const wrapper = await env.RpcRemoteEnd.getWrappedSignal();
+
+    // Get our clone of the signal
+    const signal = await wrapper.getSignal();
+
+    // Tell the AbortSignal not to send a release message on disposal
+    await wrapper.forget();
+
+    // Destroy the wrapper
+    wrapper[Symbol.dispose]();
+
+    // No release message was sent, our clone will provide a message explaining the other side is
+    // gone.
+    ok(signal.aborted);
+    strictEqual(
+      signal.reason.message,
+      'An AbortSignal received over RPC was implicitly aborted because the connection back to its ' +
+        'trigger was lost.'
+    );
+  },
+};
+
+export const rpcDestroySignalClean = {
+  async test(ctrl, env, ctx) {
+    // wrapper is a RPCTarget that just holds an AbortSignal
+    const wrapper = await env.RpcRemoteEnd.getWrappedSignal();
+
+    // Get our clone of the signal
+    const signal = await wrapper.getSignal();
+
+    // Destroy the wrapper
+    wrapper[Symbol.dispose]();
+
+    // A release message was sent, the signal will remain in an unaborted state
+    ok(!signal.aborted);
+    strictEqual(signal.reason, undefined);
   },
 };

--- a/src/workerd/api/tests/abortsignal-test.wd-test
+++ b/src/workerd/api/tests/abortsignal-test.wd-test
@@ -7,10 +7,13 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker", esModule = embed "abortsignal-test.js")
         ],
-        compatibilityDate = "2023-01-15",
-        compatibilityFlags = ["nodejs_compat"]
+        compatibilityDate = "2025-01-01",
+        compatibilityFlags = ["nodejs_compat", "experimental"],
+        bindings = [
+          (name = "RpcRemoteEnd", service = (name = "abortsignal-test", entrypoint = "RpcRemoteEnd")),
+        ]
       )
     ),
   ],
-  v8Flags = [ "--expose-gc" ],
+  v8Flags = ["--expose-gc"]
 );

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -1525,19 +1525,13 @@ export let serializeHttpTypes = {
       });
     }
 
-    // Check that a Request with an AbortSignal can't be sent. (We should fix this someday, by
-    // making AbortSignal itself RPC-compatible.)
-    await assert.rejects(
-      env.MyService.roundTrip(
+    {
+      let req = await env.MyService.roundTrip(
         new Request('http://foo', { signal: AbortSignal.timeout(100) })
-      ),
-      {
-        name: 'DataCloneError',
-        message:
-          'Could not serialize object of type "AbortSignal". This type does not support ' +
-          'serialization.',
-      }
-    );
+      );
+      assert.strictEqual(req.url, 'http://foo');
+      assert.ok(req.signal instanceof AbortSignal);
+    }
 
     {
       let req = await env.MyService.returnResponse();

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -128,18 +128,18 @@ capnp::Orphan<capnp::List<rpc::JsValue::External>> RpcSerializerExternalHandler:
   return result;
 }
 
-RpcDeserializerExternalHander::~RpcDeserializerExternalHander() noexcept(false) {
+RpcDeserializerExternalHandler::~RpcDeserializerExternalHandler() noexcept(false) {
   if (!unwindDetector.isUnwinding()) {
     KJ_ASSERT(i == externals.size(), "deserialization did not consume all of the externals");
   }
 }
 
-rpc::JsValue::External::Reader RpcDeserializerExternalHander::read() {
+rpc::JsValue::External::Reader RpcDeserializerExternalHandler::read() {
   KJ_ASSERT(i < externals.size());
   return externals[i++];
 }
 
-void RpcDeserializerExternalHander::setLastStream(capnp::Capability::Client stream) {
+void RpcDeserializerExternalHandler::setLastStream(capnp::Capability::Client stream) {
   KJ_IF_SOME(ss, streamSink) {
     ss.setSlot(i - 1, kj::mv(stream));
   } else {
@@ -205,7 +205,7 @@ DeserializeResult deserializeJsValue(
     jsg::Lock& js, rpc::JsValue::Reader reader, kj::Maybe<StreamSinkImpl&> streamSink = kj::none) {
   auto disposalGroup = kj::heap<RpcStubDisposalGroup>();
 
-  RpcDeserializerExternalHander externalHandler(reader.getExternals(), *disposalGroup, streamSink);
+  RpcDeserializerExternalHandler externalHandler(reader.getExternals(), *disposalGroup, streamSink);
 
   jsg::Deserializer deserializer(js, reader.getV8Serialized(), kj::none, kj::none,
       jsg::Deserializer::Options{
@@ -902,7 +902,7 @@ jsg::Ref<JsRpcStub> JsRpcStub::deserialize(
     jsg::Lock& js, rpc::SerializationTag tag, jsg::Deserializer& deserializer) {
   auto& handler = KJ_REQUIRE_NONNULL(
       deserializer.getExternalHandler(), "got JsRpcStub on non-RPC serialized object?");
-  auto externalHandler = dynamic_cast<RpcDeserializerExternalHander*>(&handler);
+  auto externalHandler = dynamic_cast<RpcDeserializerExternalHandler*>(&handler);
   KJ_REQUIRE(externalHandler != nullptr, "got JsRpcStub on non-RPC serialized object?");
 
   auto reader = externalHandler->read();

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -102,17 +102,17 @@ class StreamSinkImpl;
 
 // ExternalHandler used when deserializing RPC messages. Deserialization functions with which to
 // handle RPC specially should use this.
-class RpcDeserializerExternalHander final: public jsg::Deserializer::ExternalHandler {
+class RpcDeserializerExternalHandler final: public jsg::Deserializer::ExternalHandler {
  public:
   // The `streamSink` parameter should be provided if a StreamSink already exists, e.g. when
   // deserializing results. If omitted, it will be constructed on-demand.
-  RpcDeserializerExternalHander(capnp::List<rpc::JsValue::External>::Reader externals,
+  RpcDeserializerExternalHandler(capnp::List<rpc::JsValue::External>::Reader externals,
       RpcStubDisposalGroup& disposalGroup,
       kj::Maybe<StreamSinkImpl&> streamSink)
       : externals(externals),
         disposalGroup(disposalGroup),
         streamSink(streamSink) {}
-  ~RpcDeserializerExternalHander() noexcept(false);
+  ~RpcDeserializerExternalHandler() noexcept(false);
 
   // Read and return the next external.
   rpc::JsValue::External::Reader read();


### PR DESCRIPTION
Step right up folks, that's right, we've got abort signals that you can pass over RPC.

Now you can create an abort controller, then pass the signal to a function over RPC so you can tell it to abort later.

```js

export class VeryUseful extends WorkerEntrypoint {
  async countToInfinity(signal) {
    for (let i = 0; ; i++) {
      if (signal.aborted) {
        return i;
    }
  }

const ac = new AbortController();
const promise = env.VeryUseful.countToInfinity(ac.signal);
while (Math.random() <= .9)
  ;

ac.abort();
console.log("We got to", await promise);
```


Please let me know if you can think of any more tests this PR is missing.