### PR TITLE
Re-merge Request.signal PR

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -708,3 +708,9 @@ wd_test(
     args = ["--experimental"],
     data = ["tests/disable-importable-env-test.js"],
 )
+
+wd_test(
+    src = "tests/request-client-disconnect.wd-test",
+    args = ["--experimental"],
+    data = ["tests/request-client-disconnect.js"],
+)

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -521,7 +521,7 @@ class AbortTriggerRpcClient;
 
 class AbortSignal final: public EventTarget {
  public:
-  enum class Flag { NONE, NEVER_ABORTS };
+  enum class Flag { NONE, NEVER_ABORTS, IGNORE_FOR_SUBREQUESTS };
 
   AbortSignal(kj::Maybe<kj::Exception> exception = kj::none,
       jsg::Optional<jsg::JsRef<jsg::JsValue>> maybeReason = kj::none,
@@ -634,9 +634,18 @@ class AbortSignal final: public EventTarget {
 
   JSG_SERIALIZABLE(rpc::SerializationTag::ABORT_SIGNAL);
 
+  // True if this is a signal on the request of an incoming fetch. When the compat flag
+  // `requestSignalPassthrough` is set, this flag has no effect. But to ensure backwards
+  // compatibility, when this flag is not set, this signal will not be passed through to
+  // subrequests derived from the incoming request.
+  bool isIgnoredForSubrequests() const {
+    return flag == Flag::IGNORE_FOR_SUBREQUESTS;
+  }
+
  private:
   IoOwn<RefcountedCanceler> canceler;
   Flag flag;
+
   kj::Maybe<jsg::JsRef<jsg::JsValue>> reason;
   kj::Maybe<jsg::JsRef<jsg::JsValue>> onAbortHandler;
 
@@ -681,7 +690,10 @@ class AbortSignal final: public EventTarget {
 // An implementation of the Web Platform Standard AbortController API
 class AbortController final: public jsg::Object {
  public:
-  explicit AbortController(jsg::Lock& js): signal(js.alloc<AbortSignal>()) {}
+  explicit AbortController(
+      jsg::Lock& js, AbortSignal::Flag abortSignalFlag = AbortSignal::Flag::NONE)
+      : signal(js.alloc<AbortSignal>(
+            kj::none /* exception */, kj::none /* maybeReason */, abortSignalFlag)) {}
 
   static jsg::Ref<AbortController> constructor(jsg::Lock& js) {
     return js.alloc<AbortController>(js);

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -145,7 +145,8 @@ kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::request(kj::HttpMetho
     kj::HttpService::Response& response,
     kj::Maybe<kj::StringPtr> cfBlobJson,
     Worker::Lock& lock,
-    kj::Maybe<ExportedHandler&> exportedHandler) {
+    kj::Maybe<ExportedHandler&> exportedHandler,
+    kj::Maybe<jsg::Ref<AbortSignal>> abortSignal) {
   TRACE_EVENT("workerd", "ServiceWorkerGlobalScope::request()");
   // To construct a ReadableStream object, we're supposed to pass in an Own<AsyncInputStream>, so
   // that it can drop the reference whenever it gets GC'ed. But in this case the stream's lifetime
@@ -215,8 +216,18 @@ kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::request(kj::HttpMetho
   }
 
   auto jsRequest = js.alloc<Request>(js, method, url, Request::Redirect::MANUAL, kj::mv(jsHeaders),
-      js.alloc<Fetcher>(IoContext::NEXT_CLIENT_CHANNEL, Fetcher::RequiresHostAndProtocol::YES),
-      kj::none /** AbortSignal **/, kj::mv(cf), kj::mv(body));
+      jsg::alloc<Fetcher>(IoContext::NEXT_CLIENT_CHANNEL, Fetcher::RequiresHostAndProtocol::YES),
+      /* signal */ kj::none, kj::mv(cf), kj::mv(body),
+      /* thisSignal */ kj::mv(abortSignal), Request::CacheMode::NONE);
+
+  // signal vs thisSignal
+  // --------------------
+  // The fetch spec definition of Request has a distinction between the
+  // "signal" (which is an optional AbortSignal passed in with the options), and "this' signal",
+  // which is an AbortSignal that is always available via the request.signal accessor.
+  //
+  // redirect
+  // --------
   // I set the redirect mode to manual here, so that by default scripts that just pass requests
   // through to a fetch() call will behave the same as scripts which don't call .respondWith(): if
   // the request results in a redirect, the visitor will see that redirect.

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -460,7 +460,8 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
       kj::HttpService::Response& response,
       kj::Maybe<kj::StringPtr> cfBlobJson,
       Worker::Lock& lock,
-      kj::Maybe<ExportedHandler&> exportedHandler);
+      kj::Maybe<ExportedHandler&> exportedHandler,
+      kj::Maybe<jsg::Ref<AbortSignal>> abortSignal);
   // TODO(cleanup): Factor out the shared code used between old-style event listeners vs. module
   //   exports and move that code somewhere more appropriate.
 

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1004,7 +1004,7 @@ jsg::Ref<Request> Request::constructor(
       cacheMode = oldRequest->getCacheMode();
       redirect = oldRequest->getRedirectEnum();
       fetcher = oldRequest->getFetcher();
-      signal = oldRequest->getSignal();
+      signal = oldRequest->getThisSignal(js);
     }
   }
 
@@ -1060,6 +1060,7 @@ jsg::Ref<Request> Request::constructor(
           // explicitly say `signal: null`, they must want to drop the signal that was on the
           // original request.
           signal = kj::mv(s);
+          initDict.signal = kj::none;
         }
 
         KJ_IF_SOME(newCf, initDict.cf) {
@@ -1113,7 +1114,7 @@ jsg::Ref<Request> Request::constructor(
         cacheMode = otherRequest->cacheMode;
         responseBodyEncoding = otherRequest->responseBodyEncoding;
         fetcher = otherRequest->getFetcher();
-        signal = otherRequest->getSignal();
+        signal = otherRequest->getThisSignal(js);
         headers = js.alloc<Headers>(js, *otherRequest->headers);
         cf = otherRequest->cf.deepClone(js);
         KJ_IF_SOME(b, otherRequest->getBody()) {
@@ -1132,7 +1133,8 @@ jsg::Ref<Request> Request::constructor(
 
   // TODO(conform): If `init` has a keepalive flag, pass it to the Body constructor.
   return js.alloc<Request>(js, method, url, redirect, KJ_ASSERT_NONNULL(kj::mv(headers)),
-      kj::mv(fetcher), kj::mv(signal), kj::mv(cf), kj::mv(body), cacheMode, responseBodyEncoding);
+      kj::mv(fetcher), kj::mv(signal), kj::mv(cf), kj::mv(body), /* thisSignal */ kj::none,
+      cacheMode, responseBodyEncoding);
 }
 
 jsg::Ref<Request> Request::clone(jsg::Lock& js) {
@@ -1142,8 +1144,8 @@ jsg::Ref<Request> Request::clone(jsg::Lock& js) {
   auto bodyClone = Body::clone(js);
 
   return js.alloc<Request>(js, method, url, redirect, kj::mv(headersClone), getFetcher(),
-      /* signal */ getThisSignal(js), kj::mv(cfClone), kj::mv(bodyClone), cacheMode,
-      responseBodyEncoding);
+      /* signal */ getThisSignal(js), kj::mv(cfClone), kj::mv(bodyClone), /* thisSignal */ kj::none,
+      cacheMode, responseBodyEncoding);
 
   // signal
   //-------
@@ -1202,6 +1204,14 @@ jsg::Ref<AbortSignal> Request::getThisSignal(jsg::Lock& js) {
   auto newSignal = js.alloc<AbortSignal>(kj::none, kj::none, AbortSignal::Flag::NEVER_ABORTS);
   thisSignal = newSignal.addRef();
   return newSignal;
+}
+
+void Request::clearSignalIfIgnoredForSubrequest() {
+  KJ_IF_SOME(s, signal) {
+    if (s->isIgnoredForSubrequests()) {
+      signal = kj::none;
+    }
+  }
 }
 
 kj::Maybe<Request::Redirect> Request::tryParseRedirect(kj::StringPtr redirect) {
@@ -2236,6 +2246,11 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(jsg::Lock& js,
     // We could emulate these behaviors with various hacks, but just reconstructing the request up
     // front is robust, and won't add significant overhead compared to the rest of fetch().
     auto jsRequest = Request::constructor(js, kj::mv(requestOrUrl), kj::mv(requestInit));
+
+    // Clear the request's signal if the 'ignoreForSubrequests' flag is set. This happens when
+    // a request from an incoming fetch is passed-through to another fetch. We want to avoid
+    // aborting the subrequest in that case.
+    jsRequest->clearSignalIfIgnoredForSubrequest();
 
     // This URL list keeps track of redirections and becomes a source for Response's URL list. The
     // first URL in the list is the Request's URL (visible to JS via Request::getUrl()). The last URL

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -793,7 +793,7 @@ public:
   Request(jsg::Lock& js, kj::HttpMethod method, kj::StringPtr url, Redirect redirect,
           jsg::Ref<Headers> headers, kj::Maybe<jsg::Ref<Fetcher>> fetcher,
           kj::Maybe<jsg::Ref<AbortSignal>> signal, CfProperty&& cf,
-          kj::Maybe<Body::ExtractedBody> body,
+          kj::Maybe<Body::ExtractedBody> body, kj::Maybe<jsg::Ref<AbortSignal>> thisSignal,
           CacheMode cacheMode = CacheMode::NONE,
           Response_BodyEncoding responseBodyEncoding = Response_BodyEncoding::AUTO)
     : Body(js, kj::mv(body), *headers), method(method), url(kj::str(url)),
@@ -804,10 +804,14 @@ public:
       // that the cancel machinery is not used but the request.signal accessor will still
       // do the right thing.
       if (s->getNeverAborts()) {
-        this->thisSignal = kj::mv(s);
+        this->thisSignal = s.addRef();
       } else {
-        this->signal = kj::mv(s);
+        this->signal = s.addRef();
       }
+    }
+
+    KJ_IF_SOME(s, thisSignal) {
+      this->thisSignal = s.addRef();
     }
   }
   // TODO(conform): Technically, the request's URL should be parsed immediately upon Request
@@ -860,8 +864,12 @@ public:
   // request.signal to always return an AbortSignal even if one is not actively
   // used on this request.
   kj::Maybe<jsg::Ref<AbortSignal>> getSignal();
-
   jsg::Ref<AbortSignal> getThisSignal(jsg::Lock& js);
+
+  // Clear the request's signal if the 'ignoreForSubrequests' flag is set. This happens when
+  // a request from an incoming fetch is passed-through to another fetch. We want to avoid
+  // aborting the subrequest in that case.
+  void clearSignalIfIgnoredForSubrequest();
 
   // Returns the `cf` field containing Cloudflare feature flags.
   jsg::Optional<jsg::JsObject> getCf(jsg::Lock& js);

--- a/src/workerd/api/tests/request-client-disconnect.js
+++ b/src/workerd/api/tests/request-client-disconnect.js
@@ -1,0 +1,187 @@
+import { DurableObject, WorkerEntrypoint } from 'cloudflare:workers';
+import assert from 'node:assert';
+
+export class AbortTracker extends DurableObject {
+  async getAborted(key) {
+    return this.ctx.storage.get(key);
+  }
+  async setAborted(key, value) {
+    await this.ctx.storage.put(key, value);
+  }
+}
+export class OtherServer extends WorkerEntrypoint {
+  async fetch() {
+    await scheduler.wait(300);
+    return new Response('completed');
+  }
+}
+
+export class Server extends WorkerEntrypoint {
+  async fetch(req) {
+    const key = new URL(req.url).pathname.slice(1);
+    let abortTracker = this.env.AbortTracker.get(
+      this.env.AbortTracker.idFromName('AbortTracker')
+    );
+    await abortTracker.setAborted(key, false);
+
+    req.signal.onabort = () => {
+      this.ctx.waitUntil(abortTracker.setAborted(key, true));
+    };
+
+    return this[key](req);
+  }
+
+  async valid() {
+    return new Response('hello world');
+  }
+
+  async error() {
+    throw new Error('boom');
+  }
+
+  async hang() {
+    for (;;) {
+      await scheduler.wait(86400);
+    }
+  }
+
+  async hangAfterSendingSomeData() {
+    const { readable, writable } = new IdentityTransformStream();
+    this.ctx.waitUntil(this.sendSomeData(writable));
+
+    return new Response(readable);
+  }
+
+  async sendSomeData(writable) {
+    const writer = writable.getWriter();
+    const enc = new TextEncoder();
+    await writer.write(enc.encode('hello world'));
+    await this.hang();
+  }
+
+  async triggerSubrequest(req) {
+    this.ctx.waitUntil(this.callOtherServer(req));
+    await this.hang();
+  }
+
+  async callOtherServer(req) {
+    const key = 'subrequest';
+
+    let abortTracker = this.env.AbortTracker.get(
+      this.env.AbortTracker.idFromName('AbortTracker')
+    );
+
+    const passedThroughReq = new Request(req);
+    passedThroughReq.onabort = () => {
+      this.ctx.waitUntil(abortTracker.setAborted(key, true));
+    };
+
+    const res = await this.env.OtherServer.fetch(passedThroughReq);
+    const text = await res.text();
+
+    if (text == 'completed') {
+      await abortTracker.setAborted(key, false);
+    }
+  }
+}
+
+export const noAbortOnSimpleResponse = {
+  async test(ctrl, env, ctx) {
+    let abortTracker = env.AbortTracker.get(
+      env.AbortTracker.idFromName('AbortTracker')
+    );
+
+    const req = env.Server.fetch('http://example.com/valid');
+
+    const res = await req;
+    assert.strictEqual(await res.text(), 'hello world');
+    assert.strictEqual(await abortTracker.getAborted('valid'), false);
+  },
+};
+
+export const noAbortIfServerThrows = {
+  async test(ctrl, env, ctx) {
+    let abortTracker = env.AbortTracker.get(
+      env.AbortTracker.idFromName('AbortTracker')
+    );
+
+    const req = env.Server.fetch('http://example.com/error');
+
+    await assert.rejects(() => req, { name: 'Error', message: 'boom' });
+    assert.strictEqual(await abortTracker.getAborted('error'), false);
+  },
+};
+
+export const abortIfClientAbandonsRequest = {
+  async test(ctrl, env, ctx) {
+    let abortTracker = env.AbortTracker.get(
+      env.AbortTracker.idFromName('AbortTracker')
+    );
+
+    // This endpoint never generates a response, so we can timeout after an arbitrary time.
+    const req = env.Server.fetch('http://example.com/hang', {
+      signal: AbortSignal.timeout(500),
+    });
+
+    await assert.rejects(() => req, {
+      name: 'TimeoutError',
+      message: 'The operation was aborted due to timeout',
+    });
+    assert.strictEqual(await abortTracker.getAborted('hang'), true);
+  },
+};
+
+export const abortIfClientCancelsReadingResponse = {
+  async test(ctrl, env, ctx) {
+    let abortTracker = env.AbortTracker.get(
+      env.AbortTracker.idFromName('AbortTracker')
+    );
+
+    // This endpoint begins generating a response but then hangs
+    const req = env.Server.fetch('http://example.com/hangAfterSendingSomeData');
+    const res = await req;
+    const reader = res.body.getReader();
+
+    const { value, done } = await reader.read();
+    assert.strictEqual(new TextDecoder().decode(value), 'hello world');
+    assert.ok(!done);
+
+    // Give up reading
+    await reader.cancel();
+
+    // Waste a bit of time so the server cleans up
+    await scheduler.wait(0);
+
+    assert.strictEqual(
+      await abortTracker.getAborted('hangAfterSendingSomeData'),
+      true
+    );
+  },
+};
+
+export const abortedRequestDoesNotAbortSubrequest = {
+  async test(ctrl, env, ctx) {
+    let abortTracker = env.AbortTracker.get(
+      env.AbortTracker.idFromName('AbortTracker')
+    );
+
+    // This endpoint calls another endpoint that eventually completes after wasting 300 ms
+    // So, we abort the initial request quickly...
+    const req = env.Server.fetch('http://example.com/triggerSubrequest', {
+      signal: AbortSignal.timeout(100),
+    });
+
+    await assert.rejects(() => req, {
+      name: 'TimeoutError',
+      message: 'The operation was aborted due to timeout',
+    });
+    assert.strictEqual(
+      await abortTracker.getAborted('triggerSubrequest'),
+      true
+    );
+
+    // Then make sure that the subrequest wasn't also aborted
+    await scheduler.wait(500);
+    assert.strictEqual(await abortTracker.getAborted('subrequest'), false);
+  },
+};

--- a/src/workerd/api/tests/request-client-disconnect.wd-test
+++ b/src/workerd/api/tests/request-client-disconnect.wd-test
@@ -1,0 +1,26 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "request-client-disconnect",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "request-client-disconnect.js" )
+        ],
+        compatibilityDate = "2025-01-01",
+        compatibilityFlags = ["nodejs_compat", "experimental"],
+        durableObjectNamespaces = [
+          (className = "AbortTracker", uniqueKey = "badbeef"),
+        ],
+        durableObjectStorage = (inMemory = void),
+        bindings = [
+          (name = "AbortTracker", durableObjectNamespace = "AbortTracker"),
+          (name = "OtherServer", service = (name = "request-client-disconnect", entrypoint = "OtherServer")),
+          (name = "Server", service = (name = "request-client-disconnect", entrypoint = "Server")),
+          (name = "defaultExport", service = "request-client-disconnect"),
+        ]
+      )
+    )
+  ]
+);
+

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -737,4 +737,11 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatDisableFlag("disable_weak_ref");
   # Enables WeakRefs and FinalizationRegistry API.
   # WebAssembly based projects often rely on this API for wasm memory cleanup
+
+  requestSignalPassthrough @85 :Bool
+      $compatEnableFlag("request_signal_passthrough")
+      $compatDisableFlag("no_request_signal_passthrough")
+      $compatEnableDate("2025-05-23");
+  # When enabled, the AbortSignal of the incoming request is not passed through to subrequests.
+  # As a result, outgoing subrequests will not be cancelled when the incoming request is.
 }

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1803,6 +1803,9 @@ class Server::WorkerService final: public Service,
   }
 
   void unlink() override {
+    // Need to remove all waited until tasks before destroying `ioChannels`
+    waitUntilTasks.clear();
+
     // Need to tear down all actors before tearing down `ioChannels.actorStorage`.
     actorNamespaces.clear();
 

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -427,7 +427,7 @@ TestFixture::Response TestFixture::runRequest(
   runInIoContext([&](const TestFixture::Environment& env) {
     auto& globalScope = env.lock.getGlobalScope();
     return globalScope.request(method, url, requestHeaders, *requestBody, response, "{}"_kj,
-        env.lock, env.lock.getExportedHandler(kj::none, {}, kj::none));
+        env.lock, env.lock.getExportedHandler(kj::none, {}, kj::none), /* abortSignal */ kj::none);
   });
 
   return {.statusCode = response.statusCode, .body = response.body->str()};


### PR DESCRIPTION
This PR re-enables the support for `Request.signal` on incoming requests that I originally added in #3488 and #3727. These changes were originally reviewed and approved in those PRs.

However, these changes caused a regression in production and had to be reverted in #3735. AbortSignals were never cloneable, and trying to clone any Request with the `signal` property set would fail. But with my PR, the `signal` property was now always set in a very common case, the request received by a worker in its fetch handler.

AbortSignal will now be cloneable once #3922 is merged. The second commit to this PR adds a regression test which now fails but will work once #3922 is merged.