### PR TITLE
Re-enable WPT fetch tests

### DIFF
--- a/src/wpt/BUILD.bazel
+++ b/src/wpt/BUILD.bazel
@@ -27,8 +27,6 @@ wpt_test(
     wpt_directory = "@wpt//:dom/abort@module",
 )
 
-"""
-# Temporarily disabled because it cannot run concurrently.
 wpt_test(
     name = "fetch/api",
     size = "large",
@@ -42,7 +40,6 @@ wpt_test(
     }),
     wpt_directory = "@wpt//:fetch/api@module",
 )
-"""
 
 srcs = glob(
     [


### PR DESCRIPTION
Although I was testing the sidecar changes locally with WPT fetch API tests, it turns out I didn't push my local changes. This PR _actually_ re-enables the WPT fetch tests. Sorry for the brainfart.