### PR TITLE
Python: Remove version info from devPyodide compat flag

### DIFF
--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -4,6 +4,7 @@
 #include "pyodide.h"
 
 #include "requirements.h"
+#include "workerd/io/compatibility-date.h"
 
 #include <workerd/api/pyodide/setup-emscripten.h>
 #include <workerd/util/strings.h>
@@ -438,7 +439,7 @@ kj::Array<kj::String> PythonModuleInfo::filterPythonScriptImports(
   return filteredImportsBuilder.finish();
 }
 
-kj::Maybe<kj::String> getPyodideLock(PythonSnapshotRelease::Reader pythonSnapshotRelease) {
+kj::Maybe<kj::String> getPyodideLock(PythonRelease& pythonSnapshotRelease) {
   for (auto pkgLock: *PACKAGE_LOCKS) {
     if (pkgLock.getPackageDate() == pythonSnapshotRelease.getPackages()) {
       return kj::str(pkgLock.getLock());

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <workerd/api/pyodide/setup-emscripten.h>
-#include <workerd/io/compatibility-date.capnp.h>
+#include <workerd/io/compatibility-date.h>
 #include <workerd/jsg/jsg.h>
 
 #include <capnp/serialize.h>
@@ -461,7 +461,7 @@ class SetupEmscripten: public jsg::Object {
   void visitForGc(jsg::GcVisitor& visitor);
 };
 
-kj::Maybe<kj::String> getPyodideLock(PythonSnapshotRelease::Reader pythonSnapshotRelease);
+kj::Maybe<kj::String> getPyodideLock(PythonRelease& pythonSnapshotRelease);
 
 #define EW_PYODIDE_ISOLATE_TYPES                                                                   \
   api::pyodide::ReadOnlyBuffer, api::pyodide::PyodideMetadataReader,                               \

--- a/src/workerd/io/compatibility-date.c++
+++ b/src/workerd/io/compatibility-date.c++
@@ -336,8 +336,7 @@ kj::Array<const PythonSnapshotParsedField> makePythonSnapshotFieldTable(
   return table.releaseAsArray();
 }
 
-kj::Maybe<PythonSnapshotRelease::Reader> getPythonSnapshotRelease(
-    CompatibilityFlags::Reader featureFlags) {
+kj::Maybe<PythonRelease> getPythonSnapshotRelease(CompatibilityFlags::Reader featureFlags) {
   uint latestFieldOrdinal = 0;
   kj::Maybe<PythonSnapshotRelease::Reader> result;
 
@@ -362,12 +361,12 @@ kj::Maybe<PythonSnapshotRelease::Reader> getPythonSnapshotRelease(
       result = field.pythonSnapshotRelease;
     }
   }
-
-  return result;
+  auto dev = featureFlags.getPythonWorkersDevPyodide();
+  return result.map([dev](auto x) { return PythonRelease(x, dev); });
 }
 
-kj::String getPythonBundleName(PythonSnapshotRelease::Reader pyodideRelease) {
-  if (pyodideRelease.getPyodide() == "dev") {
+kj::String getPythonBundleName(PythonRelease& pyodideRelease) {
+  if (pyodideRelease.isDevelopment) {
     return kj::str("dev");
   }
   return kj::str(pyodideRelease.getPyodide(), "_", pyodideRelease.getPyodideRevision(), "_",

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -583,9 +583,6 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
 
   pythonWorkersDevPyodide @58 :Bool
     $compatEnableFlag("python_workers_development")
-    $pythonSnapshotRelease(pyodide = "dev", pyodideRevision = "dev",
-          packages = "20240829.4", backport = 0,
-          baselineSnapshotHash = "92859211804cd350f9e14010afad86e584bdd017dc7acfd94709a87f3220afae")
     $experimental;
   # Enables Python Workers and uses the bundle from the Pyodide source directory directly. For testing only.
   #

--- a/src/workerd/io/compatibility-date.h
+++ b/src/workerd/io/compatibility-date.h
@@ -51,9 +51,33 @@ kj::Maybe<kj::String> normalizeCompatDate(kj::StringPtr date);
 // Returns the current date as a string formatted by CompatDate.
 kj::String currentDateStr();
 
-kj::Maybe<PythonSnapshotRelease::Reader> getPythonSnapshotRelease(
-    CompatibilityFlags::Reader featureFlags);
-kj::String getPythonBundleName(PythonSnapshotRelease::Reader pyodideRelease);
+class PythonRelease {
+ public:
+  PythonSnapshotRelease::Reader capnpRelease;
+  bool isDevelopment;
+  PythonRelease(PythonSnapshotRelease::Reader capnpRelease, bool isDevelopment)
+      : capnpRelease(capnpRelease),
+        isDevelopment(isDevelopment) {}
+
+  kj::StringPtr getPyodide() {
+    return capnpRelease.getPyodide();
+  }
+  kj::StringPtr getPyodideRevision() {
+    return capnpRelease.getPyodideRevision();
+  }
+  kj::StringPtr getPackages() {
+    return capnpRelease.getPackages();
+  }
+  kj::StringPtr getBaselineSnapshotHash() {
+    return capnpRelease.getBaselineSnapshotHash();
+  };
+  int64_t getBackport() {
+    return capnpRelease.getBackport();
+  }
+};
+
+kj::Maybe<PythonRelease> getPythonSnapshotRelease(CompatibilityFlags::Reader featureFlags);
+kj::String getPythonBundleName(PythonRelease& pyodideRelease);
 
 // These values come from src/workerd/io/compatibility-date.capnp
 static constexpr uint64_t COMPAT_ENABLE_FLAG_ANNOTATION_ID = 0xb6dabbc87cd1b03eull;

--- a/src/workerd/server/tests/python/py_wd_test.bzl
+++ b/src/workerd/server/tests/python/py_wd_test.bzl
@@ -4,7 +4,7 @@ load("//:build/wd_test.bzl", "wd_test")
 FEATURE_FLAGS = {
     "0.26.0a2": [],
     "0.27.5": ["python_workers_20250116"],
-    "development": ["python_workers_development", "python_external_packages"],
+    "development": ["python_workers_development"],
 }
 
 def _py_wd_test_helper(

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -153,9 +153,8 @@ void writePyodideBundleFileToDisk(const kj::Maybe<kj::Own<const kj::Directory>>&
   }
 }
 
-jsg::Ref<api::pyodide::PyodideMetadataReader> makePyodideMetadataReader(config::Worker::Reader conf,
-    const PythonConfig& pythonConfig,
-    PythonSnapshotRelease::Reader pythonRelease) {
+jsg::Ref<api::pyodide::PyodideMetadataReader> makePyodideMetadataReader(
+    config::Worker::Reader conf, const PythonConfig& pythonConfig, PythonRelease& pythonRelease) {
   using Worker = config::Worker;
   auto modules = conf.getModules();
   auto mainModule = kj::str(modules.begin()->getName());


### PR DESCRIPTION
Instead, pass around a class with a pair of the SnapshotRelease::Reader and an `isDev` boolean. This should make it easier to run development tests against multiple versions of Python in local development.