### PR TITLE
Temporarily disable string memory accounting

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -275,8 +275,9 @@ wd_cc_library(
         "basics-test.c++",
         "crypto/aes-test.c++",
         "crypto/impl-test.c++",
-        "headers-test.c++",
-        "form-data-memory-test.c++",
+        # TODO(soon): Re-enable once External Memory Adjustment is updated
+        # "headers-test.c++",
+        # "form-data-memory-test.c++",
         "streams/queue-test.c++",
         "streams/standard-test.c++",
         "util-test.c++",

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -390,23 +390,31 @@ kj::Own<ExternalMemoryTarget> Lock::getExternalMemoryTarget() {
 }
 
 kj::String Lock::accountedKjString(kj::Array<char>&& str) {
-  size_t size = str.size();
-  return kj::String(str.attach(getExternalMemoryAdjustment(size)));
+  // TODO(soon): Temporarily disable while EMA is being looked at.
+  // size_t size = str.size();
+  // return kj::String(str.attach(getExternalMemoryAdjustment(size)));
+  return kj::String(kj::mv(str));
 }
 
 ByteString Lock::accountedByteString(kj::Array<char>&& str) {
-  size_t size = str.size();
-  return ByteString(str.attach(getExternalMemoryAdjustment(size)));
+  // TODO(soon): Temporarily disable while EMA is being looked at.
+  // size_t size = str.size();
+  // return ByteString(str.attach(getExternalMemoryAdjustment(size)));
+  return ByteString(kj::mv(str));
 }
 
 DOMString Lock::accountedDOMString(kj::Array<char>&& str) {
-  size_t size = str.size();
-  return DOMString(str.attach(getExternalMemoryAdjustment(size)));
+  // TODO(soon): Temporarily disable while EMA is being looked at.
+  // size_t size = str.size();
+  // return DOMString(str.attach(getExternalMemoryAdjustment(size)));
+  return DOMString(kj::mv(str));
 }
 
 USVString Lock::accountedUSVString(kj::Array<char>&& str) {
-  size_t size = str.size();
-  return USVString(str.attach(getExternalMemoryAdjustment(size)));
+  // TODO(soon): Temporarily disable while EMA is being looked at.
+  // size_t size = str.size();
+  // return USVString(str.attach(getExternalMemoryAdjustment(size)));
+  return USVString(kj::mv(str));
 }
 
 void ExternalMemoryAdjustment::maybeDeferAdjustment(ssize_t amount) {


### PR DESCRIPTION
Impl of the external memory accounting is being looked at again, temporarily disable use.