### PR TITLE
Implements Python RPC + test suite.

### DIFF
--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -240,22 +240,17 @@ function makeEntrypointProxyHandler(
       if (typeof prop !== 'string') {
         return Reflect.get(target, prop, receiver);
       }
+      // Proxy calls to `fetch` to methods named `on_fetch` (and the same for other handlers.)
       const isKnownHandler = SUPPORTED_HANDLER_NAMES.includes(prop);
       if (isKnownHandler) {
         prop = 'on_' + prop;
       }
+
       return async function (...args: any[]): Promise<any> {
+        // Check if the requested method exists and if so, call it.
         const pyInstance = await pyInstancePromise;
         if (typeof pyInstance[prop] === 'function') {
-          const res = await doPyCallHelper(
-            isKnownHandler,
-            pyInstance[prop],
-            args
-          );
-          if (isKnownHandler) {
-            return res?.js_object ?? res;
-          }
-          return res;
+          return await doPyCallHelper(isKnownHandler, pyInstance[prop], args);
         } else {
           throw new TypeError(`Method ${prop} does not exist`);
         }

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -81,3 +81,5 @@ py_wd_test(
 py_wd_test("js-import")
 
 py_wd_test("importable-env")
+
+py_wd_test("python-rpc")

--- a/src/workerd/server/tests/python/python-rpc/python-rpc.wd-test
+++ b/src/workerd/server/tests/python/python-rpc/python-rpc.wd-test
@@ -1,0 +1,38 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (name = "py", worker = .pyWorker),
+    (name = "js", worker = .jsWorker),
+  ],
+);
+
+const pyWorker :Workerd.Worker = (
+  compatibilityDate = "2025-03-04",
+
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+
+  modules = [
+    (name = "worker.py", pythonModule = embed "worker.py"),
+  ],
+
+  bindings = [
+    (name = "PythonRpc", service = (name = "py", entrypoint = "PythonRpcTester")),
+    (name = "JsRpc", service = (name = "js", entrypoint = "JsRpcTester")),
+    (name = "FOO", text = "text binding"),
+  ],
+);
+
+const jsWorker :Workerd.Worker = (
+  compatibilityDate = "2025-03-04",
+
+  compatibilityFlags = ["nodejs_compat"],
+
+  modules = [
+    (name = "worker", esModule = embed "worker.js"),
+  ],
+
+  bindings = [
+    (name = "PythonRpc", service = (name = "py", entrypoint = "PythonRpcTester")),
+  ],
+);

--- a/src/workerd/server/tests/python/python-rpc/worker.js
+++ b/src/workerd/server/tests/python/python-rpc/worker.js
@@ -1,0 +1,61 @@
+import { WorkerEntrypoint } from 'cloudflare:workers';
+
+import * as assert from 'node:assert';
+
+export class JsRpcTester extends WorkerEntrypoint {
+  async noArgs() {
+    return 'hello from js';
+  }
+  async oneArg(a) {
+    return `${a}`;
+  }
+  async identity(x) {
+    return x;
+  }
+  async handleResponse(resp) {
+    // Verify that we receive a JS object here...
+    assert.deepStrictEqual(resp.constructor.name, 'Response');
+    return resp;
+  }
+
+  async handleRequest(req) {
+    assert.deepStrictEqual(req.constructor.name, 'Request');
+    return req;
+  }
+}
+
+export default {
+  async test(ctrl, env, ctx) {
+    // JS types
+    for (const val of [
+      1,
+      'test',
+      [1, 2, 3],
+      new Map([['key', 42]]),
+      42,
+      1.2345,
+      false,
+      true,
+      undefined,
+    ]) {
+      const response = await env.PythonRpc.identity(val);
+      assert.deepStrictEqual(response, val);
+    }
+
+    const null_resp = await env.PythonRpc.identity(null);
+    assert.deepStrictEqual(null_resp, undefined);
+
+    // Web/API Types
+    const py_response = await env.PythonRpc.handle_response(
+      new Response('this is a response')
+    );
+    assert.deepStrictEqual(await py_response.text(), 'this is a response');
+    assert.equal(py_response.constructor.name, 'Response');
+
+    const py_request = await env.PythonRpc.handle_request(
+      new Request('https://test.com', { method: 'POST' })
+    );
+    assert.deepStrictEqual(py_request.method, 'POST');
+    assert.equal(py_request.constructor.name, 'Request');
+  },
+};

--- a/src/workerd/server/tests/python/python-rpc/worker.py
+++ b/src/workerd/server/tests/python/python-rpc/worker.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2023 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+import collections.abc
+import json
+from datetime import datetime
+from http import HTTPMethod
+from unittest import TestCase
+
+import js
+from workers import Blob, Request, Response, WorkerEntrypoint, handler
+
+from pyodide.ffi import JsException, JsProxy, to_js
+
+assertRaises = TestCase().assertRaises
+assertRaisesRegex = TestCase().assertRaisesRegex
+
+
+class PythonRpcTester(WorkerEntrypoint):
+    async def no_args(self):
+        return "hello from python"
+
+    async def one_arg(self, x):
+        return f"{x}"
+
+    async def identity(self, x):
+        assert not isinstance(x, JsProxy)
+        return x
+
+    async def handle_response(self, response):
+        # Verify that we receive a Python object here...
+        assert isinstance(response, Response)
+        return response
+
+    async def handle_request(self, req):
+        assert isinstance(req, Request)
+        return req
+
+
+class CustomType:
+    def __init__(self, x):
+        self.x = 42
+
+
+def assert_equal(a, b, avoid_type_check):
+    # Convert to JSON so that the contents of the values can be easily compared.
+    received = json.dumps(
+        json.loads(js.JSON.stringify(a) if isinstance(a, JsProxy) else json.dumps(a))
+    )
+    expected = json.dumps(
+        json.loads(js.JSON.stringify(b) if isinstance(b, JsProxy) else json.dumps(b))
+    )
+    if received != expected:
+        raise ValueError(
+            f"Assert failed, args contents are not equal. received='{received}' expected='{expected}'"
+        )
+
+    if type(a) is not type(b) and not avoid_type_check:
+        raise ValueError(
+            f"Assert failed, types don't match. received={type(a)} expected={type(b)}"
+        )
+
+
+@handler
+async def test(ctrl, env, ctx):
+    # https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types
+    #
+    # Workers RPC doesn't support all of the above, but does support all the JS Types and
+    # some of the Web API types.
+    #
+    # ReadableStream and WritableStream are also supported.
+    #
+    # We verify that we can send and receive as much of these as possible, including between
+    # Python<->Python, JS<->Python and vice versa. We also ensure that the types we receive are
+    # native Python types, rather than `JsProxy`s.
+
+    # Simple tests.
+    assert await env.PythonRpc.no_args() == "hello from python"
+    assert await env.JsRpc.noArgs() == "hello from js"
+    assert await env.PythonRpc.one_arg(42) == "42"
+    assert await env.JsRpc.oneArg(42) == "42"
+    arr = await env.PythonRpc.identity([1, 2, 3])
+    assert isinstance(arr, collections.abc.Sequence) and not isinstance(arr, str)
+
+    # Verify that text bindings can be accessed.
+    assert env.FOO == "text binding"
+
+    # Python Types
+    for val in ["test", [1, 2, 3], {"key": 42}, 42, 1.2345, False, True, None]:
+        received = await env.PythonRpc.identity(val)
+        assert not isinstance(received, JsProxy), (
+            "Expected the returned value from RPC to be a Python type."
+        )
+        assert_equal(received, val, False)
+        received = await env.JsRpc.identity(val)
+        assert not isinstance(received, JsProxy), (
+            "Expected the returned value from RPC to be a Python type."
+        )
+        assert_equal(received, val, False)
+
+    curr_date = datetime.now()
+    py_date = await env.PythonRpc.identity(curr_date)
+    assert isinstance(py_date, datetime)
+    assert py_date == curr_date
+
+    py_date_list = await env.PythonRpc.identity([datetime.now(), datetime.now()])
+    for d in py_date_list:
+        assert isinstance(d, datetime)
+
+    py_set = await env.PythonRpc.identity({1, 2, 3})
+    assert isinstance(py_set, set)
+    assert 2 in py_set
+    assert 42 not in py_set
+
+    py_binary = await env.PythonRpc.identity(b"binary")
+    assert isinstance(py_binary, memoryview)
+    py_binary = await env.PythonRpc.identity(memoryview(b"abcefg"))
+    assert isinstance(py_binary, memoryview)
+
+    # JS types
+    for val in [
+        to_js([1, 2, 3, 4]),
+        js.Number.new("1234"),
+    ]:
+        received = await env.PythonRpc.identity(val)
+        assert not isinstance(received, JsProxy), (
+            "Expected the returned value from RPC to be a Python type."
+        )
+        assert_equal(received, val.to_py(), True)
+        received = await env.JsRpc.identity(val)
+        assert not isinstance(received, JsProxy), (
+            "Expected the returned value from RPC to be a Python type."
+        )
+        assert_equal(received, val.to_py(), True)
+
+    for val in [
+        js.ArrayBuffer.new(8),
+        js.DataView.new(js.ArrayBuffer.new(16)),
+        js.Int16Array.of("10", "24"),
+    ]:
+        js_binary = await env.PythonRpc.identity(val)
+        assert isinstance(js_binary, memoryview)
+        js_binary = await env.JsRpc.identity(val)
+        assert isinstance(js_binary, memoryview)
+
+    js_map = await env.PythonRpc.identity(
+        js.Map.new(
+            [
+                [1, "one"],
+                [2, "two"],
+                [3, "three"],
+            ]
+        ),
+    )
+    assert isinstance(js_map, dict)
+    assert js_map[1] == "one"
+
+    js_set = await env.PythonRpc.identity(
+        js.Set.new([1, 2, 3, 4]),
+    )
+    assert isinstance(js_set, set)
+    assert 1 in js_set
+    assert 42 not in js_set
+
+    js_undefined = await env.PythonRpc.identity(js.undefined)
+    assert js_undefined is None
+
+    js_date = await env.PythonRpc.identity(js.Date.new())
+    assert isinstance(js_date, datetime)
+
+    js_date_list = await env.PythonRpc.identity([js.Date.new(), js.Date.new()])
+    for d in js_date_list:
+        assert isinstance(d, datetime)
+
+    js_exception = await env.PythonRpc.identity(js.Error.new("message"))
+    assert isinstance(js_exception, Exception)
+
+    js_obj = await env.PythonRpc.identity(
+        to_js({"foo": 42}, dict_converter=js.Object.fromEntries)
+    )
+    assert isinstance(js_obj, dict)
+    assert js_obj["foo"] == 42
+
+    # Web/API Types
+    # - Response
+    py_response = await env.PythonRpc.handle_response(Response("this is a response"))
+    assert isinstance(py_response, Response)
+    assert await py_response.text() == "this is a response"
+    js_response = await env.JsRpc.handleResponse(Response("this is a response"))
+    assert await js_response.text() == "this is a response"
+    assert isinstance(js_response, Response)
+
+    # - Request
+    py_response = await env.PythonRpc.handle_request(
+        Request("https://test.com", method=HTTPMethod.POST)
+    )
+    assert isinstance(py_response, Request)
+    assert py_response.method == "POST"
+    js_response = await env.JsRpc.handleRequest(
+        Request("https://test.com", method=HTTPMethod.POST)
+    )
+    assert js_response.method == "POST"
+    assert isinstance(js_response, Request)
+
+    # - Verify that a JS type can be sent.
+    py_response2 = await env.PythonRpc.handle_response(js.Response.new("a JS response"))
+    assert await py_response2.text() == "a JS response"
+
+    # Verify that sending unsupported types fails.
+    data_clone_regex = "^DataCloneError"
+    with assertRaisesRegex(JsException, data_clone_regex):
+        await env.PythonRpc.one_arg(CustomType(42))
+    with assertRaisesRegex(JsException, data_clone_regex):
+        await env.PythonRpc.one_arg(Blob("print(42)", content_type="text/python"))
+    with assertRaisesRegex(JsException, data_clone_regex):
+        await env.PythonRpc.identity(complex(1.23))
+    with assertRaises(TypeError):
+        await env.PythonRpc.identity((1, 2, 3))
+    with assertRaisesRegex(JsException, data_clone_regex):
+        await env.PythonRpc.identity(range(0, 30, 5))
+    with assertRaises(TypeError):
+        await env.PythonRpc.identity(bytearray.fromhex("2Ef0 F1f2  "))
+    with assertRaises(TypeError):
+        await env.PythonRpc.identity([(1, 2, 3)])
+    # TODO: Support RegExp.
+    with assertRaises(TypeError):
+        await env.PythonRpc.identity(js.RegExp.new("ab+c", "i"))
+    with assertRaises(TypeError):
+        await env.PythonRpc.identity(lambda x: x + x)
+    with assertRaises(TypeError):
+
+        def my_func():
+            pass
+
+        await env.PythonRpc.identity(my_func)
+    with assertRaises(TypeError):
+        await env.PythonRpc.identity({"test": (1, 2, 3)})


### PR DESCRIPTION
Relatively large PR which introduces Workers RPC support for Python. The aim is to make it easy to call functions defined in other Python and JS Workers, to do this all arguments are converted to/from JS where appropriate.

The implementation relies on a number of wrappers as well as conversion functions:

* The binding `env` object is wrapped via the `handler` decorator, it gets wrapped in a class that intercepts calls to `Fetcher` bindings (i.e. `env.ServiceBinding`) and then another class that intercepts calls made on that binding. All arguments passed to these calls are wrapped in a call to `serialize_to_js` and the returned value from the call is wrapped in a call to `serialize_to_python`.
* The `serialize_to_python` and `serialize_to_js` functions convert Python and JS arguments to JS and Python respectively. These mostly use Pyodide's `to_js` and `to_py` but with some improvements and restrictions.
* Arguments received by WorkerEntrypoints also get converted. This is done in the code that manages the entrypoint classes and already intercepts calls.

All of this is supported by a test suite which attempts to send/receive both from and to Python, as well as from and to JS. 

### Test Plan
```
$ bazel run @workerd//src/workerd/server/tests/python:python-rpc_development@
```