### PR TITLE
Refactor constructor for PyodideMetadataReader and other cleanups

### DIFF
--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2509,6 +2509,14 @@ class Lock {
     return errorHandler(kj::mv(error));
   }
 
+  // Like tryCatch() but returns a Promise<T> that resolves to the result of func() or
+  // rejects with the result of errorHandler() if an exception is thrown.
+  template <typename T, typename Func>
+  Promise<T> tryOrReject(Func&& func) {
+    return tryCatch([&]() -> Promise<T> { return toPromise(func()); },
+        [&](Value&& error) -> Promise<T> { return rejectedPromise<T>(kj::mv(error)); });
+  }
+
   // ---------------------------------------------------------------------------
   // Promise-related stuff
 


### PR DESCRIPTION
Refactor to have PyodideMetadataReader instances to be created under isolate lock.

Also, avoid a handful of unnecessary string copies and improve some code style in new module registry stuff.

Replace a couple more `jsg::alloc<T>` uses with `js.alloc<T>`