### PR TITLE
Revert "Temporarily disable string memory accounting (#3928)"

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -275,9 +275,8 @@ wd_cc_library(
         "basics-test.c++",
         "crypto/aes-test.c++",
         "crypto/impl-test.c++",
-        # TODO(soon): Re-enable once External Memory Adjustment is updated
-        # "headers-test.c++",
-        # "form-data-memory-test.c++",
+        "headers-test.c++",
+        "form-data-memory-test.c++",
         "streams/queue-test.c++",
         "streams/standard-test.c++",
         "util-test.c++",

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -382,31 +382,23 @@ kj::Own<const ExternalMemoryTarget> Lock::getExternalMemoryTarget() {
 }
 
 kj::String Lock::accountedKjString(kj::Array<char>&& str) {
-  // TODO(soon): Temporarily disable while EMA is being looked at.
-  // size_t size = str.size();
-  // return kj::String(str.attach(getExternalMemoryAdjustment(size)));
-  return kj::String(kj::mv(str));
+  size_t size = str.size();
+  return kj::String(str.attach(getExternalMemoryAdjustment(size)));
 }
 
 ByteString Lock::accountedByteString(kj::Array<char>&& str) {
-  // TODO(soon): Temporarily disable while EMA is being looked at.
-  // size_t size = str.size();
-  // return ByteString(str.attach(getExternalMemoryAdjustment(size)));
-  return ByteString(kj::mv(str));
+  size_t size = str.size();
+  return ByteString(str.attach(getExternalMemoryAdjustment(size)));
 }
 
 DOMString Lock::accountedDOMString(kj::Array<char>&& str) {
-  // TODO(soon): Temporarily disable while EMA is being looked at.
-  // size_t size = str.size();
-  // return DOMString(str.attach(getExternalMemoryAdjustment(size)));
-  return DOMString(kj::mv(str));
+  size_t size = str.size();
+  return DOMString(str.attach(getExternalMemoryAdjustment(size)));
 }
 
 USVString Lock::accountedUSVString(kj::Array<char>&& str) {
-  // TODO(soon): Temporarily disable while EMA is being looked at.
-  // size_t size = str.size();
-  // return USVString(str.attach(getExternalMemoryAdjustment(size)));
-  return USVString(kj::mv(str));
+  size_t size = str.size();
+  return USVString(str.attach(getExternalMemoryAdjustment(size)));
 }
 
 void ExternalMemoryAdjustment::maybeDeferAdjustment(ssize_t amount) {


### PR DESCRIPTION
This reverts commit d5076b98fe64b019c080059116c7030a076b6ba9.