### PR TITLE
Update queueMicrotask to use jsg::Function

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -521,7 +521,7 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
   jsg::JsString btoa(jsg::Lock& js, jsg::JsString data);
   jsg::JsString atob(jsg::Lock& js, kj::String data);
 
-  void queueMicrotask(jsg::Lock& js, v8::Local<v8::Function> task);
+  void queueMicrotask(jsg::Lock& js, jsg::Function<void()> task);
 
   struct StructuredCloneOptions {
     jsg::Optional<kj::Array<jsg::JsRef<jsg::JsValue>>> transfer;
@@ -857,6 +857,7 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
       setInterval<Args extends any[]>(callback: (...args: Args) => void, msDelay?: number, ...args: Args): number;
 
       structuredClone<T>(value: T, options?: StructuredSerializeOptions): T;
+      queueMicrotask(task: Function): void;
 
       fetch(input: RequestInfo | URL, init?: RequestInit<RequestInitCfProperties>): Promise<Response>;
     });

--- a/src/workerd/api/tests/global-scope-test.js
+++ b/src/workerd/api/tests/global-scope-test.js
@@ -134,7 +134,7 @@ export const queueMicrotask = {
       throws(() => globalThis.queueMicrotask(i), {
         message:
           "Failed to execute 'queueMicrotask' on 'ServiceWorkerGlobalScope': " +
-          "parameter 1 is not of type 'Function'.",
+          "parameter 1 is not of type 'function'.",
       });
     });
     let resolve;


### PR DESCRIPTION
Working on incrementally adopting more use of the jsg abstractions where appropriate.

In this case, queueMicrotask really has no reason to use v8::Function directly, and the work to compile the args list was unnecessary since we know the function will be called with no arguments.