### PR TITLE
Convert websocket exceptions to JS exceptions.

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("//:build/kj_test.bzl", "kj_test")
 load("//:build/wd_capnp_library.bzl", "wd_capnp_library")
 load("//:build/wd_cc_library.bzl", "wd_cc_library")
@@ -633,6 +634,23 @@ wd_test(
     src = "tests/websocket-hibernation.wd-test",
     args = ["--experimental"],
     data = ["tests/websocket-hibernation.js"],
+)
+
+js_binary(
+    name = "websocket-client-error-sidecar",
+    entry_point = "tests/websocket-client-error-sidecar.js",
+)
+
+wd_test(
+    src = "tests/websocket-client-error-test.wd-test",
+    args = ["--experimental"],
+    data = [
+        "tests/websocket-client-error-test.js",
+    ],
+    sidecar = "websocket-client-error-sidecar",
+    sidecar_port_bindings = [
+        "BIG_MESSAGE_SERVER_PORT",
+    ],
 )
 
 wd_test(

--- a/src/workerd/api/tests/websocket-client-error-sidecar.js
+++ b/src/workerd/api/tests/websocket-client-error-sidecar.js
@@ -1,0 +1,91 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+const http = require('http');
+const crypto = require('crypto');
+
+// Handle upgrade requests to switch from HTTP to WebSocket protocol
+function upgradeToWebSocketConnection(req, socket, head) {
+  // Check if it's a WebSocket upgrade request
+  if (req.headers['upgrade'] !== 'websocket') {
+    socket.end('HTTP/1.1 400 Bad Request');
+    return;
+  }
+
+  // Get the WebSocket key from the client
+  const webSocketKey = req.headers['sec-websocket-key'];
+  const GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'; // WebSocket protocol GUID
+
+  // Create the accept key by concatenating the key and GUID, then hashing
+  const acceptKey = crypto
+    .createHash('sha1')
+    .update(webSocketKey + GUID)
+    .digest('base64');
+
+  // Write WebSocket handshake response headers
+  socket.write(
+    'HTTP/1.1 101 Switching Protocols\r\n' +
+      'Upgrade: websocket\r\n' +
+      'Connection: Upgrade\r\n' +
+      `Sec-WebSocket-Accept: ${acceptKey}\r\n` +
+      '\r\n'
+  );
+
+  // Socket is now a WebSocket connection
+  handleWebSocketConnection(socket);
+}
+
+// Function to send a message to the client
+function sendMessage(socket, message) {
+  const payload = Buffer.from(message);
+  const payloadLength = payload.length;
+
+  // Create frame header
+  let header;
+
+  if (payloadLength <= 125) {
+    header = Buffer.alloc(2);
+    header[1] = payloadLength;
+  } else if (payloadLength <= 65535) {
+    header = Buffer.alloc(4);
+    header[1] = 126;
+    header.writeUInt16BE(payloadLength, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[1] = 127;
+    // Write length as 64-bit integer (simplified here)
+    header.writeBigUInt64BE(BigInt(payloadLength), 2);
+  }
+
+  // Set the first byte: FIN bit (0x80) + opcode 0x01 for text data
+  header[0] = 0x81;
+
+  // Combine header and payload
+  const frame = Buffer.concat([header, payload]);
+
+  // Send the frame
+  socket.write(frame);
+}
+
+// Get the port from environment variable
+const port = process.env.BIG_MESSAGE_SERVER_PORT || 9000;
+
+// Create HTTP server to handle the WebSocket handshake
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('WebSocket server is running');
+});
+server.on('upgrade', upgradeToWebSocketConnection);
+server.on('error', (event) => {
+  console.log(event);
+  console.log(event.message);
+});
+// Start the server on port 8080
+server.listen(port);
+
+// Function to handle WebSocket connections
+function handleWebSocketConnection(socket) {
+  // Send a welcome message
+  sendMessage(socket, new Uint8Array(2 * 1024 * 1024));
+}

--- a/src/workerd/api/tests/websocket-client-error-test.js
+++ b/src/workerd/api/tests/websocket-client-error-test.js
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// This test verifies that WebSocket protocol errors are properly converted to JavaScript errors
+// using the JsgifyWebSocketErrors handler.
+
+export default {
+  async test(controller, env) {
+    const ws = new WebSocket(`ws://localhost:${env.BIG_MESSAGE_SERVER_PORT}/`);
+    let receivedError = false;
+
+    // Set up a promise to wait for errors
+    const errorPromise = new Promise((resolve, reject) => {
+      // Set a timeout
+      const timeoutId = setTimeout(() => {
+        reject({
+          source: 'timeout',
+          message: 'No error received within timeout',
+        });
+      }, 5000);
+
+      // Handle errors
+      ws.addEventListener('error', (event) => {
+        clearTimeout(timeoutId);
+        receivedError = true;
+
+        if (
+          event.message ===
+          'Uncaught Error: WebSocket protocol error; protocolError.statusCode = 1009; protocolError.description = Message is too large: 2097152 > 1048576'
+        ) {
+          resolve({
+            source: 'client-error',
+            message: event.message,
+          });
+        } else {
+          reject({
+            source: 'client-error-malformed',
+            message: event.message,
+          });
+        }
+      });
+
+      ws.addEventListener('open', () => {});
+      // Handle close
+      ws.addEventListener('close', (event) => {
+        if (!(receivedError && event.code === 1009)) {
+          clearTimeout(timeoutId);
+          reject({
+            source: 'client-close',
+            code: event.code,
+            reason: event.reason,
+          });
+        }
+      });
+    });
+
+    // Wait for an error or timeout
+    await errorPromise;
+  },
+};

--- a/src/workerd/api/tests/websocket-client-error-test.wd-test
+++ b/src/workerd/api/tests/websocket-client-error-test.wd-test
@@ -1,0 +1,18 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (name = "main", worker = .mainWorker),
+    (name = "internet", network = (allow = ["private"])),
+  ],
+);
+
+const mainWorker :Workerd.Worker = (
+  compatibilityDate = "2025-04-11",
+  modules = [
+    (name = "worker", esModule = embed "websocket-client-error-test.js"),
+  ],
+  bindings = [
+    (name = "BIG_MESSAGE_SERVER_PORT", fromEnvironment = "BIG_MESSAGE_SERVER_PORT"),
+  ]
+);

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -124,6 +124,7 @@ wd_cc_library(
         "//src/workerd/io:worker-entrypoint",
         "//src/workerd/jsg",
         "//src/workerd/util:perfetto",
+        "//src/workerd/util:websocket-error-handler",
         "@capnp-cpp//src/kj/compat:kj-tls",
     ],
 )

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -217,6 +217,17 @@ wd_cc_library(
     deps = ["@capnp-cpp//src/kj"],
 )
 
+wd_cc_library(
+    name = "websocket-error-handler",
+    srcs = ["websocket-error-handler.c++"],
+    hdrs = ["websocket-error-handler.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/workerd/jsg:exception",
+        "@capnp-cpp//src/kj/compat:kj-http",
+    ],
+)
+
 exports_files(["autogate.h"])
 
 [

--- a/src/workerd/util/websocket-error-handler.c++
+++ b/src/workerd/util/websocket-error-handler.c++
@@ -1,0 +1,20 @@
+#include "websocket-error-handler.h"
+
+#include <workerd/jsg/exception.h>
+
+#include <kj/common.h>
+#include <kj/exception.h>
+#include <kj/string.h>
+
+namespace workerd {
+
+kj::Exception JsgifyWebSocketErrors::handleWebSocketProtocolError(
+    kj::WebSocket::ProtocolError protocolError) {
+  kj::Exception baseExc =
+      kj::WebSocketErrorHandler::handleWebSocketProtocolError(kj::mv(protocolError));
+  auto newDescription = kj::str(JSG_EXCEPTION(Error), ": ", baseExc.getDescription());
+  return kj::Exception(
+      baseExc.getType(), baseExc.getFile(), baseExc.getLine(), kj::mv(newDescription));
+}
+
+}  // namespace workerd

--- a/src/workerd/util/websocket-error-handler.h
+++ b/src/workerd/util/websocket-error-handler.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <kj/compat/http.h>
+#include <kj/exception.h>
+
+namespace workerd {
+class JsgifyWebSocketErrors final: public kj::WebSocketErrorHandler {
+ public:
+  // Does what kj::WebSocketErrorHandler does, but formatted as a JSG exception.
+  kj::Exception handleWebSocketProtocolError(kj::WebSocket::ProtocolError protocolError) override;
+};
+
+}  // namespace workerd


### PR DESCRIPTION
This already works in production and is tested internally.
This commit ports the solution to workerd so that it works in local
development as well.
Websockets can be used with Workers in two main ways:
1. Eyeball connecting to a Worker acting as a websocket server
2. Worker connecting to an origin websocket server
This commit adds test for both of these cases.