### PR TITLE
Python Workers: always inject asgi module.

### DIFF
--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -102,9 +102,7 @@ async function setupPatches(pyodide: Pyodide): Promise<void> {
     ) {
       await applyPatch(pyodide, 'httpx');
     }
-    if (TRANSITIVE_REQUIREMENTS.has('fastapi')) {
-      await injectSitePackagesModule(pyodide, 'asgi', 'asgi');
-    }
+    await injectSitePackagesModule(pyodide, 'asgi', 'asgi');
   });
 }
 


### PR DESCRIPTION
This will ensure that the asgi module is always present in Python Workers. There is a potential that this is a breaking change, but I _think_ even if a worker defines their own asgi.py module then it will be imported instead of the injected one (local imports have priority over imports from search path in Python), so no breakage here.