### PR TITLE
add upgraded attribute to socket class

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -329,6 +329,10 @@ jsg::Ref<Socket> Socket::startTls(jsg::Lock& js, jsg::Optional<TlsOptions> tlsOp
               tlsStarter = kj::mv(tlsStarter)](jsg::Lock& js) mutable {
     writable->detach(js);
     readable = readable->detach(js, true);
+
+    // We should set this before closedResolver.resolve() in order to give the user
+    // the option to check if the closed promise is resolved due to upgrade or not.
+    upgraded = true;
     closedResolver.resolve(js);
 
     auto acceptedHostname = domain.asPtr();

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -102,6 +102,10 @@ class Socket: public jsg::Object {
     return openedPromise;
   }
 
+  bool getUpgraded() const {
+    return upgraded;
+  }
+
   // Closes the socket connection.
   //
   // The closure is only performed after the socket connection is properly
@@ -134,6 +138,7 @@ class Socket: public jsg::Object {
     JSG_READONLY_PROTOTYPE_PROPERTY(writable, getWritable);
     JSG_READONLY_PROTOTYPE_PROPERTY(closed, getClosed);
     JSG_READONLY_PROTOTYPE_PROPERTY(opened, getOpened);
+    JSG_READONLY_PROTOTYPE_PROPERTY(upgraded, getUpgraded);
     JSG_METHOD(close);
     JSG_METHOD(startTls);
   }
@@ -176,6 +181,8 @@ class Socket: public jsg::Object {
   // Set to true on sockets created with `useSecureTransport` set to true or a socket returned by
   // `startTls`.
   bool isSecureSocket;
+  // Set to true when the socket is upgraded to a secure one.
+  bool upgraded = false;
   // The domain/ip this socket is connected to. Used for startTls.
   kj::String domain;
   // Whether the port this socket connected to is 80/443. Used for nicer errors.

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -2864,6 +2864,7 @@ interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -2876,6 +2876,7 @@ export interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -2890,6 +2890,7 @@ interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -2902,6 +2902,7 @@ export interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -2908,6 +2908,7 @@ interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -2920,6 +2920,7 @@ export interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -2909,6 +2909,7 @@ interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -2921,6 +2921,7 @@ export interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -2913,6 +2913,7 @@ interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -2925,6 +2925,7 @@ export interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -2918,6 +2918,7 @@ interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -2930,6 +2930,7 @@ export interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -2920,6 +2920,7 @@ interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -2932,6 +2932,7 @@ export interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -2920,6 +2920,7 @@ interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -2932,6 +2932,7 @@ export interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3003,6 +3003,7 @@ interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3015,6 +3015,7 @@ export interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -2864,6 +2864,7 @@ interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -2876,6 +2876,7 @@ export interface Socket {
   get writable(): WritableStream;
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }


### PR DESCRIPTION
This enables developers to understand why their closed promise is resolving if they call socket.starttls()