### PR TITLE
add runtime team to types/generated-snapshot code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@ build-releases.sh @cloudflare/wrangler @cloudflare/workers-runtime-1
 RELEASE.md @cloudflare/wrangler @cloudflare/workers-runtime-1
 package.json @cloudflare/wrangler @cloudflare/workers-runtime-1
 pnpm-lock.yaml @cloudflare/wrangler @cloudflare/workers-runtime-1
+/types/generated-snapshot @cloudflare/wrangler @cloudflare/workers-runtime-1
 /types/ @cloudflare/wrangler
 /src/cloudflare/ @cloudflare/wrangler
 src/workerd/tools/ @cloudflare/wrangler @cloudflare/workers-runtime-1 @cloudflare/workers-durable-objects


### PR DESCRIPTION
When generated-snapshots are changed (either through updating a type in a C++ file, or through adding a new function) we require Wrangler team input, but it is often not needed.

An example: https://github.com/cloudflare/workerd/pull/3945