### PR TITLE
add secureTransport attribute to socket class

### DIFF
--- a/src/workerd/api/hyperdrive.c++
+++ b/src/workerd/api/hyperdrive.c++
@@ -44,7 +44,7 @@ jsg::Ref<Socket> Hyperdrive::connect(jsg::Lock& js) {
   // some users may want it anyway.
   auto nullTlsStarter = kj::heap<kj::TlsStarterCallback>();
   auto sock = setupSocket(js, kj::mv(conn), kj::str(getHost(), ":", getPort()), kj::none,
-      kj::mv(nullTlsStarter), false, kj::str(this->randomHost), false);
+      kj::mv(nullTlsStarter), SecureTransportKind::OFF, kj::str(this->randomHost), false);
   sock->handleProxyStatus(js, kj::mv(paf.promise));
   return sock;
 }

--- a/src/workerd/api/node/tests/tls-nodejs-test.js
+++ b/src/workerd/api/node/tests/tls-nodejs-test.js
@@ -754,11 +754,13 @@ export const testStartTlsBehaviorOnUpgrade = {
     const socket = connect(`localhost:${env.HELLO_SERVER_PORT}`, {
       secureTransport: 'starttls',
     });
+    strictEqual(socket.secureTransport, 'starttls');
     strictEqual(socket.upgraded, false);
     await socket.opened;
     strictEqual(socket.upgraded, false);
     socket.closed
       .then(() => {
+        strictEqual(socket.secureTransport, 'starttls');
         strictEqual(socket.upgraded, true);
         resolve();
       })
@@ -766,6 +768,7 @@ export const testStartTlsBehaviorOnUpgrade = {
     const secureSocket = socket.startTls();
     // The newly created socket instance is not upgraded.
     strictEqual(secureSocket.upgraded, false);
+    strictEqual(secureSocket.secureTransport, 'on');
     await promise;
   },
 };

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -2865,6 +2865,7 @@ interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -2877,6 +2877,7 @@ export interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -2891,6 +2891,7 @@ interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -2903,6 +2903,7 @@ export interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -2909,6 +2909,7 @@ interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -2921,6 +2921,7 @@ export interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -2910,6 +2910,7 @@ interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -2922,6 +2922,7 @@ export interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -2914,6 +2914,7 @@ interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -2926,6 +2926,7 @@ export interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -2919,6 +2919,7 @@ interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -2931,6 +2931,7 @@ export interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -2921,6 +2921,7 @@ interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -2933,6 +2933,7 @@ export interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -2921,6 +2921,7 @@ interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -2933,6 +2933,7 @@ export interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3004,6 +3004,7 @@ interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3016,6 +3016,7 @@ export interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -2865,6 +2865,7 @@ interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -2877,6 +2877,7 @@ export interface Socket {
   get closed(): Promise<void>;
   get opened(): Promise<SocketInfo>;
   get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
 }


### PR DESCRIPTION
Build on top of https://github.com/cloudflare/workerd/pull/3945. Please review the last commit only.

Adds a "secureTransport" property to socket class.