### PR TITLE
Add AbortSignal test that fails under asan

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -276,7 +276,10 @@ void EventTarget::addEventListener(jsg::Lock& js,
                 removeEventListener(js, kj::mv(type), kj::mv(handler), kj::none);
               });
 
-      return signal->newNativeHandler(js, kj::str("abort"), kj::mv(func), true);
+      // TODO(now): Attaching a strong reference to signal probably isn't correct; it fixes the
+      // memory error in AbortSignal::any(), but probably by creating a leaked cycle?
+      return signal->newNativeHandler(js, kj::str("abort"), kj::mv(func), true)
+          .attach(signal.addRef());
     });
 
     auto eventHandler = kj::heap<EventHandler>(

--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -244,6 +244,7 @@ void EventTarget::addEventListener(jsg::Lock& js,
 
     bool once = false;
     kj::Maybe<jsg::Ref<AbortSignal>> maybeSignal;
+    kj::Maybe<jsg::Ref<AbortSignal>> maybeFollowingSignal;
     KJ_IF_SOME(value, maybeOptions) {
       KJ_SWITCH_ONEOF(value) {
         KJ_CASE_ONEOF(b, bool) {
@@ -256,6 +257,7 @@ void EventTarget::addEventListener(jsg::Lock& js,
               "addEventListener(): options.passive must be false.");
           once = opts.once.orDefault(false);
           maybeSignal = kj::mv(opts.signal);
+          maybeFollowingSignal = kj::mv(opts.followingSignal);
         }
       }
     }
@@ -276,8 +278,16 @@ void EventTarget::addEventListener(jsg::Lock& js,
                 removeEventListener(js, kj::mv(type), kj::mv(handler), kj::none);
               });
 
-      // TODO(now): Attaching a strong reference to signal probably isn't correct; it fixes the
-      // memory error in AbortSignal::any(), but probably by creating a leaked cycle?
+      // The returned native handler captures a bare reference to signal and
+      // will be held by this EventTarget. The signal is the only thing that
+      // triggers it. If signal is gc'd the native handler created here could
+      // still be alive which means *technically* it will be holding a bare
+      // reference for something that is already destroyed. However, there's
+      // nothing else that would trigger it so it's generally safe-ish. That
+      // said, it's still a potential UAF so let's guard against it by attaching
+      // a strong reference to the signal to the event handler. This will mean
+      // likely keeping the signal in memory longer if it can otherwise be
+      // gc'd but that's ok, the impact should be minimal.
       return signal->newNativeHandler(js, kj::str("abort"), kj::mv(func), true)
           .attach(signal.addRef());
     });
@@ -289,6 +299,15 @@ void EventTarget::addEventListener(jsg::Lock& js,
           .abortHandler = kj::mv(maybeAbortHandler),
         },
         once);
+
+    // If maybeFollowingSignal is set, we need to attach it to the event handler
+    // in order to keep it alive. This is used only for AbortSignal.any() where
+    // the followed signal (this) is being followed by another signal. We need
+    // to make sure the following signal stays alive until either the followed
+    // signal is triggered or destroyed.
+    KJ_IF_SOME(following, maybeFollowingSignal) {
+      eventHandler = eventHandler.attach(kj::mv(following));
+    }
 
     set.handlers.upsert(kj::mv(eventHandler), [&](auto&&...) {});
   });
@@ -626,8 +645,9 @@ jsg::Ref<AbortSignal> AbortSignal::any(jsg::Lock& js,
     sig->addEventListener(js, kj::str("abort"), kj::mv(identified),
         AddEventListenerOptions{// Once the abort is triggered, this handler should remove itself.
           .once = true,
-          // When the signal is triggered, we'll use it to cancel the other registered signals.
-          .signal = signal.addRef()});
+          // Each of the followed signals will maintain a strong reference to this new
+          // one that's been created.
+          .followingSignal = signal.addRef()});
   }
   return signal;
 }

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -308,6 +308,12 @@ class EventTarget: public jsg::Object {
     jsg::Optional<jsg::Ref<AbortSignal>> signal;
 
     JSG_STRUCT(capture, passive, once, signal);
+
+    // A following signal is used when the EventTarget is an AbortSignal
+    // that is being followed by another AbortSignal via the AbortSignal.any.
+    // This is used to keep the following signal alive until either the
+    // signal is triggered or this AbortSignal is destroyed.
+    jsg::Optional<jsg::Ref<AbortSignal>> followingSignal;
   };
 
   using AddEventListenerOpts = kj::OneOf<AddEventListenerOptions, bool>;

--- a/src/workerd/api/tests/abortsignal-test.wd-test
+++ b/src/workerd/api/tests/abortsignal-test.wd-test
@@ -12,4 +12,5 @@ const unitTests :Workerd.Config = (
       )
     ),
   ],
+  v8Flags = [ "--expose-gc" ],
 );


### PR DESCRIPTION
Add AbortSignal test that fails under asan, and also a (possibly incorrect) fix.

It looks like `AbortSignal::any(signals)`:
- creates a new "any" AbortSignal
- for each `sig` in`signals`, adds an "abort" event listener lambda that extracts the abort reason from "sig" and calls `triggerAbort()` on the "any" AbortSignal

The lambda seems to intentionally avoid directly capturing strong references to either "sig" or the "any" AbortSignal.  The rationale for the latter is that `sig.addEventListener(..., {signal})` will itself capture a strong reference to `signal`, but it does not...  It uses `signal` to create an `abortHandler` via `signal->newNativeHandler()`, but `newNativeHandler()` seems to also intentionally avoid capturing strong references to signal.

So if a GC occurs after the last JS reference to the "any" AbortSignal is dropped but before one of its signals aborts and runs the lambda, it will trigger a memory error.  I've found that `attach()`ing a reference to the signal will keep it alive and avoid the error, but this probably works by creating a cyclic reference and leaking the memory.

The right solution might be to either capture a strong reference to `signal` somewhere or to use some sort of weakref to avoid firing the abort handler after the "any" signal is freed?  But the code makes it seem like it's working around subtleties in ownership that I don't fully understand.