### PR TITLE
Add isFloat16Array APIs for nodejs_compat

### DIFF
--- a/src/node/internal/internal_comparisons.ts
+++ b/src/node/internal/internal_comparisons.ts
@@ -42,6 +42,7 @@ import {
   isBooleanObject,
   isBigIntObject,
   isSymbolObject,
+  isFloat16Array,
   isFloat32Array,
   isFloat64Array,
 } from 'node-internal:internal_types';
@@ -234,7 +235,10 @@ function innerDeepEqual(
     ) {
       return false;
     }
-    if (!strict && (isFloat32Array(val1) || isFloat64Array(val1))) {
+    if (
+      !strict &&
+      (isFloat16Array(val1) || isFloat32Array(val1) || isFloat64Array(val1))
+    ) {
       if (!areSimilarFloatArrays(val1 as FloatArray, val2 as FloatArray)) {
         return false;
       }

--- a/src/node/internal/internal_types.ts
+++ b/src/node/internal/internal_types.ts
@@ -25,13 +25,14 @@
 
 import internal from 'node-internal:util';
 
+import { kHandle } from 'node-internal:crypto_util';
+
 export function isCryptoKey(value: unknown): boolean {
   return value instanceof CryptoKey;
 }
 
 export function isKeyObject(_value: unknown): boolean {
-  // TODO(nodecompat): We currently do not implement KeyObject
-  return false;
+  return _value != null && typeof _value === 'object' && kHandle in _value;
 }
 
 export const isAsyncFunction = internal.isAsyncFunction.bind(internal);
@@ -65,6 +66,7 @@ export const isBigIntObject = internal.isBigIntObject.bind(internal);
 export const isArrayBufferView = internal.isArrayBufferView.bind(internal);
 export const isBigInt64Array = internal.isBigInt64Array.bind(internal);
 export const isBigUint64Array = internal.isBigUint64Array.bind(internal);
+export const isFloat16Array = internal.isFloat16Array.bind(internal);
 export const isFloat32Array = internal.isFloat32Array.bind(internal);
 export const isFloat64Array = internal.isFloat64Array.bind(internal);
 export const isInt8Array = internal.isInt8Array.bind(internal);
@@ -109,6 +111,7 @@ export default {
   isArrayBufferView,
   isBigInt64Array,
   isBigUint64Array,
+  isFloat16Array,
   isFloat32Array,
   isFloat64Array,
   isInt8Array,

--- a/src/node/internal/util.d.ts
+++ b/src/node/internal/util.d.ts
@@ -82,6 +82,7 @@ export function isBooleanObject(value: unknown): value is boolean;
 export function isDataView(value: unknown): value is DataView;
 export function isDate(value: unknown): value is Date;
 export function isExternal(value: unknown): boolean;
+export function isFloat16Array(value: unknown): boolean; // TODO: change to value is Float16Array
 export function isFloat32Array(value: unknown): value is Float32Array;
 export function isFloat64Array(value: unknown): value is Float64Array;
 export function isGeneratorFunction(value: unknown): value is GeneratorFunction;

--- a/src/node/util/types.ts
+++ b/src/node/util/types.ts
@@ -57,6 +57,7 @@ export {
   isArrayBufferView,
   isBigInt64Array,
   isBigUint64Array,
+  isFloat16Array,
   isFloat32Array,
   isFloat64Array,
   isInt8Array,

--- a/src/workerd/api/node/tests/util-nodejs-test.js
+++ b/src/workerd/api/node/tests/util-nodejs-test.js
@@ -4385,3 +4385,300 @@ export const makeSureUtilTypesIsExported = {
     assert.ok(types.default.isTypedArray);
   },
 };
+
+export const testTypes = {
+  async test() {
+    const {
+      isCryptoKey,
+      isKeyObject,
+      isAsyncFunction,
+      isGeneratorFunction,
+      isGeneratorObject,
+      isAnyArrayBuffer,
+      isArrayBuffer,
+      isArgumentsObject,
+      isBoxedPrimitive,
+      isDataView,
+      isMap,
+      isMapIterator,
+      isModuleNamespaceObject,
+      isNativeError,
+      isPromise,
+      isProxy,
+      isSet,
+      isSetIterator,
+      isSharedArrayBuffer,
+      isWeakMap,
+      isWeakSet,
+      isRegExp,
+      isDate,
+      isStringObject,
+      isSymbolObject,
+      isNumberObject,
+      isBooleanObject,
+      isBigIntObject,
+      isArrayBufferView,
+      isBigInt64Array,
+      isBigUint64Array,
+      isFloat16Array,
+      isFloat32Array,
+      isFloat64Array,
+      isInt8Array,
+      isInt16Array,
+      isInt32Array,
+      isTypedArray,
+      isUint8Array,
+      isUint8ClampedArray,
+      isUint16Array,
+      isUint32Array,
+      isExternal,
+    } = await import('node:util/types');
+
+    {
+      const key = await crypto.subtle.importKey(
+        'raw',
+        new Uint8Array(3),
+        {
+          name: 'HMAC',
+          hash: 'SHA-256',
+        },
+        false,
+        ['sign']
+      );
+      assert.ok(isCryptoKey(key));
+      assert.ok(!isCryptoKey(1));
+    }
+
+    {
+      const { createSecretKey } = await import('node:crypto');
+      const key = createSecretKey('hello', 'utf8');
+      assert.ok(isKeyObject(key));
+      assert.ok(!isKeyObject(1));
+    }
+
+    {
+      const foo = async () => {};
+      assert.ok(isAsyncFunction(foo));
+      assert.ok(!isAsyncFunction(1));
+    }
+
+    {
+      function* foo() {}
+      assert.ok(isGeneratorFunction(foo));
+      assert.ok(!isGeneratorFunction(1));
+    }
+
+    {
+      function* foo() {}
+      const gen = foo();
+      assert.ok(isGeneratorObject(gen));
+      assert.ok(!isGeneratorObject(1));
+    }
+
+    {
+      assert.ok(isAnyArrayBuffer(new ArrayBuffer(0)));
+      assert.ok(isAnyArrayBuffer(new SharedArrayBuffer(0)));
+      assert.ok(!isAnyArrayBuffer(1));
+    }
+
+    {
+      assert.ok(isArrayBuffer(new ArrayBuffer(0)));
+      assert.ok(!isArrayBuffer(new SharedArrayBuffer(0)));
+      assert.ok(!isArrayBuffer(1));
+    }
+
+    {
+      (function () {
+        assert.ok(isArgumentsObject(arguments));
+        assert.ok(!isArgumentsObject(1));
+      })();
+    }
+
+    {
+      assert.ok(isBoxedPrimitive(new String('')));
+      assert.ok(!isBoxedPrimitive(1));
+    }
+
+    {
+      assert.ok(isDataView(new DataView(new ArrayBuffer(1))));
+      assert.ok(!isDataView(1));
+    }
+
+    {
+      assert.ok(isMap(new Map()));
+      assert.ok(!isMap(1));
+    }
+
+    {
+      const map = new Map();
+      assert.ok(isMapIterator(map.values()));
+      assert.ok(!isMapIterator(1));
+    }
+
+    {
+      const mod = await import('node:net');
+      assert.ok(isModuleNamespaceObject(mod));
+      assert.ok(!isModuleNamespaceObject(1));
+    }
+
+    {
+      assert.ok(isNativeError(new Error()));
+      assert.ok(!isNativeError(1));
+    }
+
+    {
+      assert.ok(isPromise(Promise.resolve()));
+      assert.ok(!isPromise(1));
+    }
+
+    {
+      assert.ok(isProxy(new Proxy({}, {})));
+      assert.ok(!isProxy(1));
+    }
+
+    {
+      assert.ok(isSet(new Set()));
+      assert.ok(!isSet(1));
+    }
+
+    {
+      const set = new Set();
+      assert.ok(isSetIterator(set.values()));
+      assert.ok(!isSetIterator(1));
+    }
+
+    {
+      assert.ok(isSharedArrayBuffer(new SharedArrayBuffer(0)));
+      assert.ok(!isSharedArrayBuffer(new ArrayBuffer(0)));
+      assert.ok(!isSharedArrayBuffer(1));
+    }
+
+    {
+      assert.ok(isWeakMap(new WeakMap()));
+      assert.ok(!isWeakMap(1));
+    }
+
+    {
+      assert.ok(isWeakSet(new WeakSet()));
+      assert.ok(!isWeakSet(1));
+    }
+
+    {
+      assert.ok(isRegExp(/abc/));
+      assert.ok(!isRegExp(1));
+    }
+
+    {
+      assert.ok(isDate(new Date()));
+      assert.ok(!isDate(1));
+    }
+
+    {
+      assert.ok(isStringObject(new String('')));
+      assert.ok(!isStringObject(''));
+    }
+
+    {
+      assert.ok(isSymbolObject(Object(Symbol('test'))));
+      assert.ok(!isSymbolObject(1));
+    }
+
+    {
+      assert.ok(isNumberObject(new Number(1)));
+      assert.ok(!isNumberObject(1));
+    }
+
+    {
+      assert.ok(isBooleanObject(new Boolean()));
+      assert.ok(!isBooleanObject(1));
+    }
+
+    {
+      assert.ok(isBigIntObject(Object(1n)));
+      assert.ok(!isBigIntObject(1));
+    }
+
+    {
+      assert.ok(isArrayBufferView(new Uint8Array(0)));
+      assert.ok(isArrayBufferView(new DataView(new ArrayBuffer(0))));
+      assert.ok(!isArrayBufferView(1));
+    }
+
+    {
+      assert.ok(isBigInt64Array(new BigInt64Array(0)));
+      assert.ok(!isBigInt64Array(1));
+    }
+
+    {
+      assert.ok(isBigUint64Array(new BigUint64Array(0)));
+      assert.ok(!isBigUint64Array(1));
+    }
+
+    {
+      assert.ok(isFloat32Array(new Float32Array(0)));
+      assert.ok(!isFloat32Array(1));
+    }
+
+    {
+      assert.ok(isFloat64Array(new Float64Array(0)));
+      assert.ok(!isFloat64Array(1));
+    }
+
+    {
+      assert.ok(isInt8Array(new Int8Array(0)));
+      assert.ok(!isInt8Array(1));
+    }
+
+    {
+      assert.ok(isInt16Array(new Int16Array(0)));
+      assert.ok(!isInt16Array(1));
+    }
+
+    {
+      assert.ok(isInt32Array(new Int32Array(0)));
+      assert.ok(!isInt32Array(1));
+    }
+
+    {
+      assert.ok(isTypedArray(new Uint8Array(0)));
+      assert.ok(!isTypedArray(new DataView(new ArrayBuffer(0))));
+      assert.ok(!isTypedArray(1));
+    }
+
+    {
+      assert.ok(isUint8Array(new Uint8Array(0)));
+      assert.ok(!isUint8Array(1));
+    }
+
+    {
+      assert.ok(isUint8ClampedArray(new Uint8ClampedArray(0)));
+      assert.ok(!isUint8ClampedArray(new Uint8Array(0)));
+      assert.ok(!isUint8ClampedArray(1));
+    }
+
+    {
+      assert.ok(isUint16Array(new Uint16Array(0)));
+      assert.ok(!isUint16Array(1));
+    }
+
+    {
+      assert.ok(isUint32Array(new Uint32Array(0)));
+      assert.ok(!isUint32Array(1));
+    }
+
+    {
+      // We don't really expose any externals in any existing APIS
+      // where this would be useful, but hey, let's test it anyway.
+      assert.ok(!isExternal({}));
+    }
+
+    // TODO(soon): Remove this when Float16Array is available unflagged.
+    // The proposal is stage 4 and the v8 C++ APIs are available, but the
+    // flag is still currently required to use it in JavaScript. We aren't
+    // setting that flag but we can still prepare for it to be available.
+    if (globalThis.Float16Array !== undefined) {
+      assert.ok(isFloat16Array(new Float16Array(0)));
+      assert.ok(!isFloat16Array(1));
+    }
+  },
+};

--- a/src/workerd/api/node/tests/util-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/util-nodejs-test.wd-test
@@ -7,7 +7,7 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker", esModule = embed "util-nodejs-test.js")
         ],
-        compatibilityDate = "2023-10-01",
+        compatibilityDate = "2025-04-01",
         compatibilityFlags = ["nodejs_compat"],
       )
     ),

--- a/src/workerd/api/node/util.h
+++ b/src/workerd/api/node/util.h
@@ -126,6 +126,7 @@ class MIMEType final: public jsg::Object {
   V(DataView)                                                                                      \
   V(Date)                                                                                          \
   V(External)                                                                                      \
+  V(Float16Array)                                                                                  \
   V(Float32Array)                                                                                  \
   V(Float64Array)                                                                                  \
   V(GeneratorFunction)                                                                             \

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -52,6 +52,7 @@ inline void requireOnStack(void* self) {
   V(Int16Array)                                                                                    \
   V(Uint32Array)                                                                                   \
   V(Int32Array)                                                                                    \
+  V(Float16Array)                                                                                  \
   V(Float32Array)                                                                                  \
   V(Float64Array)                                                                                  \
   V(BigInt64Array)                                                                                 \


### PR DESCRIPTION
`Float16Array` has reached stage 4 in TC-39 and v8 is nearly done with the implementation. While it is still behind a flag, the C++ APIs are available and Node.js is about to add the `util.types.isFloat16Array` API. This commit adds the API under `nodejs_compat` so that we can prepare for it to be enabled by default in the very near future.

This also expands the testing and completes the implementation of `isKeyObject(...)` since that was still pending.