### PR TITLE
Fetch pedantry: do not set statusText unless spec explicitly says to

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1461,7 +1461,10 @@ jsg::Ref<Response> Response::constructor(jsg::Lock& js,
       }
     }
   } else {
-    statusText = kj::str(defaultStatusText(statusCode));
+    // A response has an associated status message. Unless stated otherwise it is the empty byte sequence.
+    // https://fetch.spec.whatwg.org/#concept-response-status-message
+
+    statusText.emplace(kj::str(""));
   }
 
   KJ_IF_SOME(bi, bodyInit) {
@@ -1537,10 +1540,8 @@ jsg::Ref<Response> Response::redirect(jsg::Lock& js, kj::String url, jsg::Option
   kjHeaders.set(kj::HttpHeaderId::LOCATION, kj::mv(parsedUrl));
   auto headers = js.alloc<Headers>(js, kjHeaders, Headers::Guard::IMMUTABLE);
 
-  auto statusText = defaultStatusText(statusCode);
-
-  return js.alloc<Response>(
-      js, statusCode, kj::str(statusText), kj::mv(headers), nullptr, kj::none);
+  return js.alloc<Response>(js, statusCode, kj::str("") /* statusText is not specified to be set */,
+      kj::mv(headers), nullptr, kj::none);
 }
 
 jsg::Ref<Response> Response::json_(

--- a/src/wpt/fetch/api-test.ts
+++ b/src/wpt/fetch/api-test.ts
@@ -784,10 +784,7 @@ export default {
     comment: 'Likely just missing validation',
     expectedFailures: ['Ensure response headers are immutable'],
   },
-  'response/response-init-001.any.js': {
-    comment: 'statusText should be inited to OK',
-    expectedFailures: ['Check default value for statusText attribute'],
-  },
+  'response/response-init-001.any.js': {},
   'response/response-init-002.any.js': {},
   'response/response-init-contenttype.any.js': {
     comment:
@@ -802,28 +799,10 @@ export default {
     ],
   },
   'response/response-static-json.any.js': {
-    comment: 'statusText does not match the status code',
-    expectedFailures: [
-      // For this test specifically: failed to throw on non-encodable data
-      'Check static json() throws when data is not encodable',
-      'Check response returned by static json() with init undefined',
-      'Check response returned by static json() with init {"status":400}',
-      'Check response returned by static json() with init {"headers":{}}',
-      'Check response returned by static json() with init {"headers":{"content-type":"foo/bar"}}',
-      'Check response returned by static json() with init {"headers":{"x-foo":"bar"}}',
-    ],
+    comment: 'Failed to throw on non-encodable data',
+    expectedFailures: ['Check static json() throws when data is not encodable'],
   },
-  'response/response-static-redirect.any.js': {
-    comment: 'statusText does not match the status code',
-    expectedFailures: [
-      'Check default redirect response',
-      'Check response returned by static method redirect(), status = 301',
-      'Check response returned by static method redirect(), status = 302',
-      'Check response returned by static method redirect(), status = 303',
-      'Check response returned by static method redirect(), status = 307',
-      'Check response returned by static method redirect(), status = 308',
-    ],
-  },
+  'response/response-static-redirect.any.js': {},
   'response/response-stream-bad-chunk.any.js': {
     comment:
       'Several issues. Firstly, we require the type field to always be passed to ReadableStream',


### PR DESCRIPTION
Fetch spec:

> A [response](https://fetch.spec.whatwg.org/#concept-response) has an associated status message. Unless stated otherwise it is the empty byte sequence.

https://fetch.spec.whatwg.org/#concept-response-status-message

So actually it turns out we're not supposed to helpfully set a default status message to match the code in most cases. The exception when we're supposed to do so are when  `about`, `blob` and `data` URLs are fetched.

