### PR TITLE
Log periodically when an alarm handler is canceled

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -418,7 +418,17 @@ kj::Promise<WorkerInterface::AlarmResult> ServiceWorkerGlobalScope::runAlarm(kj:
   auto& actor = KJ_ASSERT_NONNULL(context.getActor());
   auto& persistent = KJ_ASSERT_NONNULL(actor.getPersistent());
 
-  KJ_SWITCH_ONEOF(persistent.armAlarmHandler(scheduledTime)) {
+  kj::String actorId;
+  KJ_SWITCH_ONEOF(actor.getId()) {
+    KJ_CASE_ONEOF(f, kj::Own<ActorIdFactory::ActorId>) {
+      actorId = f->toString();
+    }
+    KJ_CASE_ONEOF(s, kj::String) {
+      actorId = kj::str(s);
+    }
+  }
+
+  KJ_SWITCH_ONEOF(persistent.armAlarmHandler(scheduledTime, false, actorId)) {
     KJ_CASE_ONEOF(armResult, ActorCacheInterface::RunAlarmHandler) {
       auto& handler = KJ_REQUIRE_NONNULL(exportedHandler);
       if (handler.alarm == kj::none) {

--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -164,7 +164,7 @@ kj::Maybe<kj::Promise<void>> ActorCache::evictStale(kj::Date now) {
 }
 
 kj::OneOf<ActorCache::CancelAlarmHandler, ActorCache::RunAlarmHandler> ActorCache::armAlarmHandler(
-    kj::Date scheduledTime, bool noCache) {
+    kj::Date scheduledTime, bool noCache, kj::StringPtr actorId) {
   noCache = noCache || lru.options.noCache;
 
   KJ_ASSERT(!currentAlarmTime.is<DeferredAlarmDelete>());
@@ -174,6 +174,8 @@ kj::OneOf<ActorCache::CancelAlarmHandler, ActorCache::RunAlarmHandler> ActorCach
       if (t.status == KnownAlarmTime::Status::CLEAN) {
         // If there's a clean scheduledTime that is different from ours, this run should be
         // canceled.
+        LOG_WARNING_PERIODICALLY("NOSENTRY CRDB alarm handler canceled.", scheduledTime,
+            t.time.orDefault(kj::UNIX_EPOCH), actorId);
         return CancelAlarmHandler{.waitBeforeCancel = kj::READY_NOW};
       } else {
         // There's a alarm write that hasn't been set yet pending for a time different than ours --

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -228,7 +228,7 @@ class ActorCacheInterface: public ActorCacheOps {
 
   // Call when entering the alarm handler.
   virtual kj::OneOf<CancelAlarmHandler, RunAlarmHandler> armAlarmHandler(
-      kj::Date scheduledTime, bool noCache = false) = 0;
+      kj::Date scheduledTime, bool noCache = false, kj::StringPtr actorId = "") = 0;
 
   virtual void cancelDeferredAlarmDeletion() = 0;
 
@@ -337,7 +337,7 @@ class ActorCache final: public ActorCacheInterface {
   void shutdown(kj::Maybe<const kj::Exception&> maybeException) override;
 
   kj::OneOf<CancelAlarmHandler, RunAlarmHandler> armAlarmHandler(
-      kj::Date scheduledTime, bool noCache = false) override;
+      kj::Date scheduledTime, bool noCache = false, kj::StringPtr actorId = "") override;
   void cancelDeferredAlarmDeletion() override;
   kj::Maybe<kj::Promise<void>> onNoPendingFlush() override;
   // See ActorCacheInterface

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -77,7 +77,7 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
   kj::Maybe<kj::Promise<void>> evictStale(kj::Date now) override;
   void shutdown(kj::Maybe<const kj::Exception&> maybeException) override;
   kj::OneOf<CancelAlarmHandler, RunAlarmHandler> armAlarmHandler(
-      kj::Date scheduledTime, bool noCache = false) override;
+      kj::Date scheduledTime, bool noCache = false, kj::StringPtr actorId = "") override;
   void cancelDeferredAlarmDeletion() override;
   kj::Maybe<kj::Promise<void>> onNoPendingFlush() override;
   kj::Promise<kj::String> getCurrentBookmark() override;


### PR DESCRIPTION
This commit logs periodically when an alarm handler is canceled to debug infinite retries on canceled alarms.