### PR TITLE
Move CommonJS module impl out of jsg and into api

### DIFF
--- a/src/workerd/api/commonjs.h
+++ b/src/workerd/api/commonjs.h
@@ -4,7 +4,7 @@
 
 #include <kj/filesystem.h>
 
-namespace workerd::jsg {
+namespace workerd::api {
 
 class CommonJsModuleObject final: public jsg::Object {
  public:
@@ -19,7 +19,7 @@ class CommonJsModuleObject final: public jsg::Object {
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(path, getPath);
   }
 
-  void visitForMemoryInfo(MemoryTracker& tracker) const;
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
  private:
   jsg::Value exports;
@@ -50,10 +50,29 @@ class CommonJsModuleContext final: public jsg::Object {
 
   jsg::Ref<CommonJsModuleObject> module;
 
-  void visitForMemoryInfo(MemoryTracker& tracker) const;
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
  private:
   kj::Path path;
   jsg::Value exports;
 };
-}  // namespace workerd::jsg
+
+// Used with the original module registry implementation.
+template <typename LockType>
+struct CommonJsImpl: public jsg::ModuleRegistry::CommonJsModuleInfo::CommonJsModuleProvider {
+  jsg::Ref<api::CommonJsModuleContext> context;
+  CommonJsImpl(jsg::Lock& js, kj::Path path)
+      : context(js.alloc<api::CommonJsModuleContext>(js, kj::mv(path))) {}
+  KJ_DISALLOW_COPY_AND_MOVE(CommonJsImpl);
+  jsg::JsObject getContext(jsg::Lock& js) override {
+    auto& lock = kj::downcast<LockType>(js);
+    return jsg::JsObject(lock.wrap(js.v8Context(), context.addRef()));
+  }
+  jsg::JsValue getExports(jsg::Lock& js) override {
+    return jsg::JsValue(context->getModule(js)->getExports(js));
+  }
+};
+
+#define EW_CJS_ISOLATE_TYPES api::CommonJsModuleObject, api::CommonJsModuleContext
+
+}  // namespace workerd::api

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1001,7 +1001,6 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
     lock->v8Isolate->SetData(jsg::SET_DATA_ISOLATE, this);
 
     lock->setCaptureThrowsAsRejections(features.getCaptureThrowsAsRejections());
-    lock->setCommonJsExportDefault(features.getExportCommonJsDefaultNamespace());
     if (features.getSetToStringTag()) {
       lock->setToStringTag();
     }

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -78,7 +78,6 @@ wd_cc_library(
     srcs = [
         "async-context.c++",
         "buffersource.c++",
-        "commonjs.c++",
         "dom-exception.c++",
         "jsg.c++",
         "jsvalue.c++",
@@ -95,7 +94,6 @@ wd_cc_library(
     hdrs = [
         "async-context.h",
         "buffersource.h",
-        "commonjs.h",
         "dom-exception.h",
         "function.h",
         "jsg.h",

--- a/src/workerd/jsg/commonjs.h
+++ b/src/workerd/jsg/commonjs.h
@@ -56,5 +56,4 @@ class CommonJsModuleContext final: public jsg::Object {
   kj::Path path;
   jsg::Value exports;
 };
-
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -211,10 +211,6 @@ void Lock::setToStringTag() {
   IsolateBase::from(v8Isolate).enableSetToStringTag();
 }
 
-void Lock::setCommonJsExportDefault(bool exportDefault) {
-  IsolateBase::from(v8Isolate).setCommonJsExportDefault({}, exportDefault);
-}
-
 void Lock::setLoggerCallback(kj::Function<Logger>&& logger) {
   IsolateBase::from(v8Isolate).setLoggerCallback({}, kj::mv(logger));
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2648,7 +2648,6 @@ class Lock {
   void installJspi();
 
   void setCaptureThrowsAsRejections(bool capture);
-  void setCommonJsExportDefault(bool exportDefault);
 
   void setNodeJsCompatEnabled();
   void setToStringTag();

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-#include "commonjs.h"
 #include "jsg.h"
 #include "setup.h"
 

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -158,44 +158,32 @@ v8::MaybeLocal<v8::Value> evaluateSyntheticModuleCallback(
         }
       }
       KJ_CASE_ONEOF(info, ModuleRegistry::CommonJsModuleInfo) {
-        bool ok = true;
         v8::TryCatch catcher(js.v8Isolate);
         // const_cast is safe here because we're protected by the isolate js.
         auto& commonjs = const_cast<ModuleRegistry::CommonJsModuleInfo&>(info);
         try {
           commonjs.evalFunc(js);
-        } catch (const JsExceptionThrown&) {
-          if (catcher.CanContinue()) catcher.ReThrow();
-          // leave `result` empty to propagate the JS exception
-          ok = false;
-        }
-
-        if (ok) {
-          // Handle the named exports...
-          auto exports = commonjs.moduleContext->module->getExports(js);
-          if (!module->SetSyntheticModuleExport(js.v8Isolate, defaultStr, exports).IsJust()) {
-            ok = false;
-          }
-
-          if (ok && exports->IsObject()) {
-            JsObject obj = JsObject(exports.As<v8::Object>());
-            KJ_IF_SOME(exports, ref.module.maybeNamedExports) {
-              for (auto& name: exports) {
-                // Ignore default... just in case someone was silly enough to include it.
-                if (name == "default"_kj) continue;
-                auto val = obj.get(js, name);
-                if (!module->SetSyntheticModuleExport(js.v8Isolate, js.strIntern(name), val)
-                         .IsJust()) {
-                  ok = false;
-                  break;
+          auto exports = commonjs.getExports(js);
+          if (module->SetSyntheticModuleExport(js.v8Isolate, defaultStr, exports).IsJust()) {
+            KJ_IF_SOME(obj, exports.tryCast<JsObject>()) {
+              KJ_IF_SOME(exports, ref.module.maybeNamedExports) {
+                for (auto& name: exports) {
+                  // Ignore default... just in case someone was silly enough to include it.
+                  if (name == "default"_kj) continue;
+                  auto val = obj.get(js, name);
+                  if (!module->SetSyntheticModuleExport(js.v8Isolate, js.strIntern(name), val)
+                           .IsJust()) {
+                    break;
+                  }
                 }
               }
             }
+            result = makeResolvedPromise();
           }
+        } catch (const JsExceptionThrown&) {
+          if (catcher.CanContinue()) catcher.ReThrow();
+          // leave `result` empty to propagate the JS exception
         }
-
-        if (ok) result = makeResolvedPromise();
-        // If ok is false, we leave result empty to propagate the JS exception
       }
       KJ_CASE_ONEOF(info, ModuleRegistry::TextModuleInfo) {
         if (module->SetSyntheticModuleExport(js.v8Isolate, defaultStr, info.value.getHandle(js))
@@ -399,9 +387,8 @@ ModuleRegistry::ModuleInfo::ModuleInfo(jsg::Lock& js,
   }
 }
 
-Ref<CommonJsModuleContext> ModuleRegistry::CommonJsModuleInfo::initModuleContext(
-    jsg::Lock& js, kj::StringPtr name) {
-  return js.alloc<jsg::CommonJsModuleContext>(js, kj::Path::parse(name));
+jsg::JsValue ModuleRegistry::CommonJsModuleInfo::getExports(jsg::Lock& js) {
+  return provider->getExports(js);
 }
 
 ModuleRegistry::CapnpModuleInfo::CapnpModuleInfo(
@@ -447,7 +434,7 @@ JsValue ModuleRegistry::requireImpl(Lock& js, ModuleInfo& info, RequireImplOptio
       module->GetStatus() == v8::Module::Status::kInstantiating) {
     KJ_IF_SOME(synth, info.maybeSynthetic) {
       KJ_IF_SOME(cjs, synth.tryGet<ModuleRegistry::CommonJsModuleInfo>()) {
-        return JsValue(cjs.moduleContext->getExports(js));
+        return cjs.getExports(js);
       }
     }
   }

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <workerd/jsg/commonjs.h>
 #include <workerd/jsg/function.h>
 #include <workerd/jsg/modules.capnp.h>
 #include <workerd/jsg/observer.h>
@@ -97,7 +96,7 @@ class ModuleRegistry {
         kj::StringPtr content,
         kj::Own<CommonJsModuleProvider> provider)
         : provider(kj::mv(provider)),
-          evalFunc(initEvalFunc(lock, *provider, name, content)) {}
+          evalFunc(initEvalFunc(lock, *this->provider, name, content)) {}
 
     CommonJsModuleInfo(CommonJsModuleInfo&&) = default;
     CommonJsModuleInfo& operator=(CommonJsModuleInfo&&) = default;

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -132,9 +132,6 @@ class IsolateBase {
   inline void setCaptureThrowsAsRejections(kj::Badge<Lock>, bool capture) {
     captureThrowsAsRejections = capture;
   }
-  inline void setCommonJsExportDefault(kj::Badge<Lock>, bool exportDefault) {
-    exportCommonJsDefault = exportDefault;
-  }
 
   inline void setNodeJsCompatEnabled(kj::Badge<Lock>, bool enabled) {
     nodeJsCompatEnabled = enabled;
@@ -274,7 +271,6 @@ class IsolateBase {
   // and there are a number of async APIs that currently throw. When the captureThrowsAsRejections
   // flag is set, that old behavior is changed to be correct.
   bool captureThrowsAsRejections = false;
-  bool exportCommonJsDefault = false;
   bool asyncContextTrackingEnabled = false;
   bool nodeJsCompatEnabled = false;
   bool setToStringTag = false;
@@ -345,10 +341,6 @@ class IsolateBase {
     return captureThrowsAsRejections;
   }
 
-  bool getCommonJsExportDefault() const {
-    return exportCommonJsDefault;
-  }
-
   // Add an item to the deferred destruction queue. Safe to call from any thread at any time.
   void deferDestruction(Item item);
 
@@ -378,7 +370,6 @@ class IsolateBase {
   friend class ExternalMemoryTarget;
 
   friend bool getCaptureThrowsAsRejections(v8::Isolate* isolate);
-  friend bool getCommonJsExportDefault(v8::Isolate* isolate);
   friend kj::Maybe<kj::StringPtr> getJsStackTrace(void* ucontext, kj::ArrayPtr<char> scratch);
 
   friend kj::Exception createTunneledException(

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -25,11 +25,6 @@ bool getCaptureThrowsAsRejections(v8::Isolate* isolate) {
   return jsgIsolate.getCaptureThrowsAsRejections();
 }
 
-bool getCommonJsExportDefault(v8::Isolate* isolate) {
-  auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
-  return jsgIsolate.getCommonJsExportDefault();
-}
-
 bool getShouldSetToStringTag(v8::Isolate* isolate) {
   auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
   return jsgIsolate.shouldSetToStringTag();

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -48,7 +48,6 @@ class JsExceptionThrown: public std::exception {
 };
 
 bool getCaptureThrowsAsRejections(v8::Isolate* isolate);
-bool getCommonJsExportDefault(v8::Isolate* isolate);
 bool getShouldSetToStringTag(v8::Isolate* isolate);
 
 kj::String fullyQualifiedTypeName(const std::type_info& type);

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -10,6 +10,7 @@
 #include <workerd/api/actor.h>
 #include <workerd/api/analytics-engine.h>
 #include <workerd/api/cache.h>
+#include <workerd/api/commonjs.h>
 #include <workerd/api/container.h>
 #include <workerd/api/crypto/impl.h>
 #include <workerd/api/encoding.h>
@@ -82,6 +83,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
     EW_BLOB_ISOLATE_TYPES,
     EW_CACHE_ISOLATE_TYPES,
     EW_CONTAINER_ISOLATE_TYPES,
+    EW_CJS_ISOLATE_TYPES,
     EW_CRYPTO_ISOLATE_TYPES,
     EW_ENCODING_ISOLATE_TYPES,
     EW_EVENTS_ISOLATE_TYPES,
@@ -114,9 +116,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
 
     jsg::TypeWrapperExtension<PromiseWrapper>,
     jsg::InjectConfiguration<CompatibilityFlags::Reader>,
-    Worker::Api::ErrorInterface,
-    jsg::CommonJsModuleObject,
-    jsg::CommonJsModuleContext);
+    Worker::Api::ErrorInterface);
 
 static const PythonConfig defaultConfig{
   .packageDiskCacheRoot = kj::none,
@@ -611,25 +611,12 @@ kj::Maybe<jsg::ModuleRegistry::ModuleInfo> WorkerdApi::tryCompileModule(jsg::Loc
         named = compileNamedExports(module.getNamedExports());
       }
 
-      struct CommonJsImpl: public jsg::ModuleRegistry::CommonJsModuleInfo::CommonJsModuleProvider {
-        jsg::Ref<jsg::CommonJsModuleContext> context;
-        CommonJsImpl(jsg::Lock& js, kj::Path path)
-            : context(js.alloc<jsg::CommonJsModuleContext>(js, kj::mv(path))) {}
-        KJ_DISALLOW_COPY_AND_MOVE(CommonJsImpl);
-        jsg::JsObject getContext(jsg::Lock& js) override {
-          auto& lock = kj::downcast<JsgWorkerdIsolate::Lock>(js);
-          return jsg::JsObject(lock.wrap(js.v8Context(), context.addRef()));
-        }
-        jsg::JsValue getExports(jsg::Lock& js) override {
-          return jsg::JsValue(context->getModule(js)->getExports(js));
-        }
-      };
-
       return jsg::ModuleRegistry::ModuleInfo(lock, module.getName(),
           named.map([](kj::Array<kj::StringPtr>& named) { return named.asPtr(); }),
           jsg::ModuleRegistry::CommonJsModuleInfo(lock, module.getName(),
               module.getCommonJsModule(),
-              kj::heap<CommonJsImpl>(lock, kj::Path::parse(module.getName()))));
+              kj::heap<api::CommonJsImpl<JsgWorkerdIsolate::Lock>>(
+                  lock, kj::Path::parse(module.getName()))));
     }
     case config::Worker::Module::PYTHON_MODULE: {
       // Nothing to do. Handled in compileModules.


### PR DESCRIPTION
As part of the new module registry work, move the `CommonJsModuleContext` and `CommonJsModuleObject` implementation out of jsg and into api.