### PR TITLE
add remaining methods/constants for node:tls

### DIFF
--- a/src/node/internal/internal_tls.ts
+++ b/src/node/internal/internal_tls.ts
@@ -254,3 +254,15 @@ export function convertALPNProtocols(
     );
   }
 }
+
+export function createServer(): void {
+  throw new Error('Not implemented');
+}
+
+export function Server(): void {
+  throw new Error('Not implemented');
+}
+
+export function getCiphers(): void {
+  throw new Error('Not implemented');
+}

--- a/src/node/internal/internal_tls_constants.ts
+++ b/src/node/internal/internal_tls_constants.ts
@@ -1,0 +1,11 @@
+// Allow {CLIENT_RENEG_LIMIT} client-initiated session renegotiations
+// every {CLIENT_RENEG_WINDOW} seconds. An error event is emitted if more
+// renegotiations are seen. The settings are applied to all remote client
+// connections.
+export const CLIENT_RENEG_LIMIT = 3;
+export const CLIENT_RENEG_WINDOW = 600;
+export const DEFAULT_CIPHERS = '';
+export const DEFAULT_ECDH_CURVE = 'auto';
+export const DEFAULT_MIN_VERSION = 'TLSv1.2';
+export const DEFAULT_MAX_VERSION = 'TLSv1.3';
+export const rootCertificates = [];

--- a/src/node/tls.ts
+++ b/src/node/tls.ts
@@ -26,25 +26,37 @@
 import {
   checkServerIdentity,
   convertALPNProtocols,
+  createServer,
+  Server,
+  getCiphers,
 } from 'node-internal:internal_tls';
 import {
   createSecureContext,
   SecureContext,
 } from 'node-internal:internal_tls_common';
+import * as constants from 'node-internal:internal_tls_constants';
 import { TLSSocket, connect } from 'node-internal:internal_tls_wrap';
+export * from 'node-internal:internal_tls_constants';
 export {
   TLSSocket,
   connect,
   createSecureContext,
+  createServer,
   checkServerIdentity,
   SecureContext,
+  Server,
   convertALPNProtocols,
+  getCiphers,
 };
 export default {
   SecureContext,
+  Server,
   TLSSocket,
   connect,
   createSecureContext,
+  createServer,
   checkServerIdentity,
   convertALPNProtocols,
+  getCiphers,
+  ...constants,
 };


### PR DESCRIPTION
Adds remaining methods/constants for node:tls so we can make it a fully supported nodejs module.