### PR TITLE
Speed up workers-sdk-test.

### DIFF
--- a/.github/workflows/_bazel.yml
+++ b/.github/workflows/_bazel.yml
@@ -22,6 +22,10 @@ on:
         type: string
         required: false
         default: ''
+      upload_binary:
+        type: boolean
+        required: false
+        default: false
     secrets:
       BAZEL_CACHE_KEY:
         required: true
@@ -102,11 +106,12 @@ jobs:
           du -ms -t 1 $GITHUB_WORKSPACE
 
       - name: Upload binary
-        if: inputs.os_name == 'linux-arm' && inputs.suffix == ''
+        if: inputs.upload_binary
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.os_name }}-${{ runner.arch }}${{ inputs.suffix }}-binary
-          path: bazel-bin/src/workerd/server/workerd
+          path: bazel-bin/src/workerd/server/workerd${{ runner.os == 'Windows' && '.exe' || '' }}
+          if-no-files-found: error
 
       - name: Drop large Bazel cache files
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,9 @@ jobs:
             config: { suffix: -debug }
           - os: { name: linux, image: ubuntu-22.04 }
             config: { suffix: -debug }
+            # linux release is handled by separate test-linux job
+          - os: { name: linux, image: ubuntu-22.04 }
+            config: { suffix: '' }
       fail-fast: false
     uses: ./.github/workflows/_bazel.yml
     with:
@@ -72,6 +75,20 @@ jobs:
     secrets:
       BAZEL_CACHE_KEY: ${{ secrets.BAZEL_CACHE_KEY }}
       WORKERS_MIRROR_URL: ${{ secrets.WORKERS_MIRROR_URL }}
+
+  # Handled separately from `test` to speed up execution of workers-sdk-test which depends on it.
+  test-linux:
+    uses: ./.github/workflows/_bazel.yml
+    with:
+      image: ubuntu-22.04
+      os_name: linux
+      suffix: ''
+      extra_bazel_args: '--config=ci-test'
+      upload_binary: true
+    secrets:
+      BAZEL_CACHE_KEY: ${{ secrets.BAZEL_CACHE_KEY }}
+      WORKERS_MIRROR_URL: ${{ secrets.WORKERS_MIRROR_URL }}
+
   lint:
     uses: ./.github/workflows/_bazel.yml
     with:
@@ -149,9 +166,9 @@ jobs:
             The generated output of `@cloudflare/workers-types` matches the snapshot in `types/generated-snapshot` :tada:
 
   workers-sdk-test:
-    needs: [test, check-snapshot]
+    needs: [test-linux, check-snapshot]
     name: Run workers-sdk tests
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout workers-sdk
         uses: actions/checkout@v4
@@ -172,7 +189,7 @@ jobs:
       - name: Download workerd binary
         uses: actions/download-artifact@v4
         with:
-          name: linux-arm-ARM64-binary
+          name: linux-X64-binary
           path: /tmp
 
       - name: Make workerd binary executable

--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -57,8 +57,8 @@ build:ci-linux-common --copt='-Wno-error=deprecated-declarations'
 build:ci-linux-common --action_env=CC=/usr/lib/llvm-18/bin/clang
 build:ci-linux-common --host_action_env=CC=/usr/lib/llvm-18/bin/clang
 
-build:ci-linux --config=ci-linux-common
-build:ci-linux-arm --config=ci-linux --remote_download_regex=".*src/workerd/server/workerd.*"
+build:ci-linux --config=ci-linux-common --remote_download_regex=".*src/workerd/server/workerd.*"
+build:ci-linux-arm --config=ci-linux-common
 
 build:ci-linux-debug --config=ci-linux-common --config=ci-limit-storage
 build:ci-linux-debug --config=debug --config=rust-debug


### PR DESCRIPTION
The check "workers-sdk-test" is a required check that depends on "test". 
That means it depends on the entire matrix to succeed. 
In reality it only actually depends on test linux-arm. 
Currently all of "test" is a required check because of it.
Another problem is that it currently only runs once all of "test" succeeds instead of right after it's actual dependencies succeed.

This commit changes that so workers-sdk-test depends only on test-linux. 
A new check that only runs the test on the linux with empty suffix configuration.
This should restore our ability to choose which test jobs are required and which aren't.