### PR TITLE
ignore certain values for nodejs redis and mssql client

### DIFF
--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -269,7 +269,8 @@ export function Socket(this: Socket, options?: SocketOptions): Socket {
     throw new ERR_OPTION_NOT_IMPLEMENTED('options.fd');
   }
 
-  // TODO(soon): Support both of these options.
+  // We do not support the noDelay and keepAlive options at this
+  // time and will just ignore them if they are passed.
   //
   // We shouldn't throw an error for the following validations,
   // because it breaks packages such as redis.

--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -245,7 +245,7 @@ export function Socket(this: Socket, options?: SocketOptions): Socket {
       'is not supported'
     );
   }
-  if (typeof options?.keepAliveInitialDelay !== 'undefined') {
+  if (options?.keepAliveInitialDelay !== undefined) {
     validateNumber(
       options.keepAliveInitialDelay,
       'options.keepAliveInitialDelay'
@@ -269,12 +269,18 @@ export function Socket(this: Socket, options?: SocketOptions): Socket {
     throw new ERR_OPTION_NOT_IMPLEMENTED('options.fd');
   }
 
-  if (options.noDelay) {
-    throw new ERR_OPTION_NOT_IMPLEMENTED('truthy options.noDelay');
-  }
-  if (options.keepAlive) {
-    throw new ERR_OPTION_NOT_IMPLEMENTED('truthy options.keepAlive');
-  }
+  // TODO(soon): Support both of these options.
+  //
+  // We shouldn't throw an error for the following validations,
+  // because it breaks packages such as redis.
+  //
+  // if (options.noDelay) {
+  //   throw new ERR_OPTION_NOT_IMPLEMENTED('truthy options.noDelay');
+  // }
+  //
+  // if (options.keepAlive) {
+  //   throw new ERR_OPTION_NOT_IMPLEMENTED('truthy options.keepAlive');
+  // }
 
   options.allowHalfOpen = Boolean(options.allowHalfOpen);
   // TODO(now): Match behavior with Node.js

--- a/src/node/internal/internal_tls_common.ts
+++ b/src/node/internal/internal_tls_common.ts
@@ -24,7 +24,6 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import type tls from 'node:tls';
-import { ERR_OPTION_NOT_IMPLEMENTED } from 'node-internal:internal_errors';
 import { validateInteger } from 'node-internal:validators';
 
 // @ts-expect-error TS2323 Redeclare error.
@@ -56,12 +55,16 @@ export function SecureContext(
       maxVersion
     );
   }
-  if (minVersion !== undefined) {
-    throw new ERR_OPTION_NOT_IMPLEMENTED('minVersion');
-  }
-  if (maxVersion !== undefined) {
-    throw new ERR_OPTION_NOT_IMPLEMENTED('maxVersion');
-  }
+  // We do not support the minVersion and maxVersion options at this
+  // time and will just ignore them if they are passed.
+  // We have to omit these errors in order to support mssql.
+  //
+  // if (minVersion !== undefined) {
+  //   throw new ERR_OPTION_NOT_IMPLEMENTED('minVersion');
+  // }
+  // if (maxVersion !== undefined) {
+  //   throw new ERR_OPTION_NOT_IMPLEMENTED('maxVersion');
+  // }
   if (secureOptions) {
     validateInteger(secureOptions, 'secureOptions');
   }
@@ -73,12 +76,6 @@ export function SecureContext(
 export function createSecureContext(
   options: tls.SecureContextOptions = {}
 ): SecureContext {
-  const nonNullEntry = Object.entries(options).find(
-    ([_key, value]) => value != null
-  );
-  if (nonNullEntry) {
-    throw new ERR_OPTION_NOT_IMPLEMENTED(`options.${nonNullEntry[0]}`);
-  }
   return new SecureContext(
     options.secureProtocol,
     options.secureOptions,

--- a/src/node/internal/internal_tls_wrap.ts
+++ b/src/node/internal/internal_tls_wrap.ts
@@ -253,6 +253,7 @@ export function TLSSocket(
     if (socket instanceof Socket) {
       wrap = socket;
     } else {
+      // TODO(soon): Support passing DuplexSocket to here to unblock mssql.
       // Cloudflare Workers does not support any other socket type.
       throw new ERR_OPTION_NOT_IMPLEMENTED('options.socket');
     }

--- a/src/workerd/api/node/tests/net-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-nodejs-test.js
@@ -457,8 +457,8 @@ export const testNetConnectImmediateFinish = {
 // something different than the original Node.js test
 export const testNetConnectKeepAlive = {
   async test() {
-    // Test that setKeepAlive call does not throw.
-    throws(() => new net.Socket({ keepAlive: true }));
+    // We are not throwing on truthy keepAlive value for mysql/redis clients.
+    // throws(() => new net.Socket({ keepAlive: true }));
     const c = new net.Socket();
     c.setKeepAlive(false);
     c.setKeepAlive(true);


### PR DESCRIPTION
These options break Redis and mssql client. 

Redis reproduction:

```typescript
import { createClient } from 'redis';

export default {
  async fetch(request, env, ctx): Promise<Response> {
    const client = createClient({})

    await client.connect()

    await client.hSet('user-session:123', {
        name: 'John',
        surname: 'Smith',
        company: 'Redis',
        age: 29
    })

    const rows = await client.hGetAll('user-session:123');
    // Return the result as JSON
    const resp = new Response(JSON.stringify(rows), {
      headers: { "Content-Type": "application/json" },
    });

    return resp;
  },
} satisfies ExportedHandler<Env>;
```

Mssql reproduction:

```typescript
import sql from 'mssql';

export default {
  async fetch(request, env, ctx): Promise<Response> {
	  const config = {}
		const conn = await sql.connect(config);

		const rows = await conn.request().query('select * from SYSOBJECTS')

    // Return the result as JSON
    const resp = new Response(JSON.stringify(rows), {
      headers: { "Content-Type": "application/json" },
    });

    return resp;
  },
} satisfies ExportedHandler<Env>;
```