### PR TITLE
[nfc] Fold up streaming tail worker autogate, use the compat flag instead

### DIFF
--- a/samples/tail-workers/config.capnp
+++ b/samples/tail-workers/config.capnp
@@ -6,9 +6,6 @@ const tailWorkerExample :Workerd.Config = (
     (name = "log", worker = .logWorker),
   ],
   sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ],
-  autogates = [
-    "workerd-autogate-streaming-tail-workers",
-  ],
 );
 
 const helloWorld :Workerd.Worker = (
@@ -16,6 +13,7 @@ const helloWorld :Workerd.Worker = (
     (name = "worker", esModule = embed "worker.js")
   ],
   compatibilityDate = "2024-10-14",
+  compatibilityFlags = ["experimental", "streaming_tail_worker"],
   tails = ["log"],
   streamingTails = ["log"],
 );

--- a/src/workerd/api/tail-worker-test.wd-test
+++ b/src/workerd/api/tail-worker-test.wd-test
@@ -13,7 +13,7 @@ const unitTests :Workerd.Config = (
           ( name = "CACHE_ENABLED", json = "false" ),
         ],
         compatibilityDate = "2023-08-01",
-        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "cache_option_disabled"],
+        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "cache_option_disabled", "streaming_tail_worker"],
         streamingTails = ["log", "log-invalid"],
       ),
     ),
@@ -27,7 +27,7 @@ const unitTests :Workerd.Config = (
           ( name = "SERVICE", service = "queue-test" ),
         ],
         compatibilityDate = "2023-07-24",
-        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers"],
+        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "streaming_tail_worker"],
         streamingTails = ["log"],
       )
     ),
@@ -54,14 +54,11 @@ const unitTests :Workerd.Config = (
     ),
 
   ],
-  autogates = [
-    "workerd-autogate-streaming-tail-workers",
-  ],
 );
 
 const alarmsWorker :Workerd.Worker = (
   compatibilityDate = "2022-09-16",
-  compatibilityFlags = ["experimental", "nodejs_compat"],
+  compatibilityFlags = ["experimental", "nodejs_compat", "streaming_tail_worker"],
 
   modules = [
     (name = "worker", esModule = embed "actor-alarms-test.js"),
@@ -83,7 +80,7 @@ const alarmsWorker :Workerd.Worker = (
 
 const hiberWorker :Workerd.Worker = (
   compatibilityDate = "2023-12-18",
-  compatibilityFlags = ["experimental", "nodejs_compat"],
+  compatibilityFlags = ["experimental", "nodejs_compat", "streaming_tail_worker"],
 
   modules = [
     (name = "worker", esModule = embed "tests/websocket-hibernation.js"),
@@ -123,5 +120,6 @@ const logLegacy :Workerd.Worker = (
     (name = "worker", esModule = embed "tail-worker-test-dummy.js")
   ],
   compatibilityDate = "2024-10-14",
+  compatibilityFlags = ["streaming_tail_worker"],
   streamingTails = ["log"],
 );

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -926,9 +926,6 @@ kj::Promise<WorkerInterface::CustomEvent::Result> TailStreamCustomEventImpl::run
   IoContext& ioContext = incomingRequest->getContext();
   incomingRequest->delivered();
 
-  // TODO(streaming-tail): Support instrementation for streaming tail workers themselves – need to
-  // be careful to avoid infinite recursion in case pipeline stages tail themselves in the
-  // downstream implementation.
   KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
     t.setEventInfo(ioContext.getInvocationSpanContext(), ioContext.now(),
         TraceEventInfo(kj::Array<TraceEventInfo::TraceItem>(nullptr)));

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -392,6 +392,7 @@ tracing::EmailEventInfo tracing::EmailEventInfo::clone() const {
   return EmailEventInfo(kj::str(mailFrom), kj::str(rcptTo), rawSize);
 }
 
+namespace {
 kj::Vector<tracing::TraceEventInfo::TraceItem> getTraceItemsFromTraces(
     kj::ArrayPtr<kj::Own<Trace>> traces) {
   return KJ_MAP(t, traces) -> tracing::TraceEventInfo::TraceItem {
@@ -400,15 +401,16 @@ kj::Vector<tracing::TraceEventInfo::TraceItem> getTraceItemsFromTraces(
   };
 }
 
-tracing::TraceEventInfo::TraceEventInfo(kj::ArrayPtr<kj::Own<Trace>> traces)
-    : traces(getTraceItemsFromTraces(traces)) {}
-
 kj::Vector<tracing::TraceEventInfo::TraceItem> getTraceItemsFromReader(
     rpc::Trace::TraceEventInfo::Reader reader) {
   return KJ_MAP(r, reader.getTraces()) -> tracing::TraceEventInfo::TraceItem {
     return tracing::TraceEventInfo::TraceItem(r);
   };
 }
+}  // namespace
+
+tracing::TraceEventInfo::TraceEventInfo(kj::ArrayPtr<kj::Own<Trace>> traces)
+    : traces(getTraceItemsFromTraces(traces)) {}
 
 tracing::TraceEventInfo::TraceEventInfo(rpc::Trace::TraceEventInfo::Reader reader)
     : traces(getTraceItemsFromReader(reader)) {}

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -150,6 +150,7 @@ void WorkerTracer::addLog(const tracing::InvocationSpanContext& context,
 
 // TODO(cleanup): Needed to convert between span value definitions in LTW/STW. These should be the
 // same really.
+namespace {
 workerd::tracing::Attribute::Value convertSpanTag(const Span::TagValue& tag) {
   KJ_SWITCH_ONEOF(tag) {
     KJ_CASE_ONEOF(str, kj::String) {
@@ -167,6 +168,7 @@ workerd::tracing::Attribute::Value convertSpanTag(const Span::TagValue& tag) {
   }
   KJ_UNREACHABLE;
 }
+}  // namespace
 
 void WorkerTracer::addSpan(CompleteSpan&& span) {
   // This is where we'll actually encode the span.

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1856,7 +1856,7 @@ class Server::WorkerService final: public Service,
       return service->startRequest({});
     };
 
-    if (util::Autogate::isEnabled(util::AutogateKey::STREAMING_TAIL_WORKERS)) {
+    if (worker->getIsolate().getApi().getFeatureFlags().getStreamingTailWorker()) {
       streamingTailWorkers = KJ_MAP(service, channels.streamingTails) -> kj::Own<WorkerInterface> {
         // Caution here... if the tail worker ends up have a circular dependency
         // on the worker we'll end up with an infinite loop trying to initialize.

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -17,8 +17,6 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
   switch (key) {
     case AutogateKey::TEST_WORKERD:
       return "test-workerd"_kj;
-    case AutogateKey::STREAMING_TAIL_WORKERS:
-      return "streaming-tail-workers"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -14,7 +14,6 @@ namespace workerd::util {
 // Workerd-specific list of autogate keys (can also be used in internal repo).
 enum class AutogateKey {
   TEST_WORKERD,
-  STREAMING_TAIL_WORKERS,
   NumOfKeys  // Reserved for iteration.
 };
 


### PR DESCRIPTION
- Drop obsolete TODO – with the refactored implementation, tracing STWs is already supported.