### PR TITLE
Refactor pyodide ArtifactBundler for move to js.alloc

### DIFF
--- a/src/workerd/api/crypto/crypto.h
+++ b/src/workerd/api/crypto/crypto.h
@@ -301,7 +301,7 @@ class CryptoKey: public jsg::Object {
   // HACK: Needs to be public so derived classes can inherit from it.
   class Impl;
 
-  // Treat as private -- needs to be public for jsg::alloc<T>()...
+  // Treat as private -- needs to be public for js.alloc<T>()...
   explicit CryptoKey(kj::Own<Impl> impl);
 
   // Compare the contents of this key with the other. Will return false if

--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -168,10 +168,10 @@ kj::HashSet<kj::String> PyodideMetadataReader::getTransitiveRequirements() {
 }
 
 int ArtifactBundler::readMemorySnapshot(int offset, kj::Array<kj::byte> buf) {
-  if (existingSnapshot == kj::none) {
+  if (inner->existingSnapshot == kj::none) {
     return 0;
   }
-  return readToTarget(KJ_REQUIRE_NONNULL(existingSnapshot), offset, buf);
+  return readToTarget(KJ_REQUIRE_NONNULL(inner->existingSnapshot), offset, buf);
 }
 
 kj::Array<kj::String> PythonModuleInfo::parsePythonScriptImports(kj::Array<kj::String> files) {

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -282,61 +282,68 @@ struct MemorySnapshotResult {
 // CPU architecture-specific artifacts. The logic for loading these is in getArtifacts.
 class ArtifactBundler: public jsg::Object {
  public:
-  kj::Maybe<const PyodidePackageManager&> packageManager;
-  // ^ lifetime should be contained by lifetime of ArtifactBundler since there is normally one worker set for the whole process. see worker-set.h
-  // In other words:
-  // WorkerSet lifetime = PackageManager lifetime and Worker lifetime = ArtifactBundler lifetime and WorkerSet owns and will outlive Worker, so PackageManager outlives ArtifactBundler
-  kj::Maybe<MemorySnapshotResult> storedSnapshot;
+  struct State: public kj::Refcounted {
+    kj::Maybe<const PyodidePackageManager&> packageManager;
+    // ^ lifetime should be contained by lifetime of ArtifactBundler since there is normally one worker set for the whole process. see worker-set.h
+    // In other words:
+    // WorkerSet lifetime = PackageManager lifetime and Worker lifetime = ArtifactBundler lifetime and WorkerSet owns and will outlive Worker, so PackageManager outlives ArtifactBundler
+    kj::Maybe<MemorySnapshotResult> storedSnapshot;
 
-  ArtifactBundler(kj::Maybe<const PyodidePackageManager&> packageManager,
-      kj::Maybe<kj::Array<const kj::byte>> existingSnapshot,
-      bool isValidating = false)
-      : packageManager(packageManager),
-        storedSnapshot(kj::none),
-        existingSnapshot(kj::mv(existingSnapshot)),
-        isValidating(isValidating) {};
+    // A memory snapshot of the state of the Python interpreter after initialization. Used to speed
+    // up cold starts.
+    kj::Maybe<kj::Array<const kj::byte>> existingSnapshot;
+    bool isValidating;
+
+    State(kj::Maybe<const PyodidePackageManager&> packageManager,
+        kj::Maybe<kj::Array<const kj::byte>> existingSnapshot,
+        bool isValidating = false)
+        : packageManager(packageManager),
+          storedSnapshot(kj::none),
+          existingSnapshot(kj::mv(existingSnapshot)),
+          isValidating(isValidating) {};
+  };
+
+  ArtifactBundler(kj::Own<State> inner): inner(kj::mv(inner)) {};
 
   void storeMemorySnapshot(jsg::Lock& js, MemorySnapshotResult snapshot) {
-    KJ_REQUIRE(isValidating);
-    storedSnapshot = kj::mv(snapshot);
+    KJ_REQUIRE(inner->isValidating);
+    inner->storedSnapshot = kj::mv(snapshot);
   }
 
   bool hasMemorySnapshot() {
-    return existingSnapshot != kj::none;
+    return inner->existingSnapshot != kj::none;
   }
 
   int getMemorySnapshotSize() {
-    if (existingSnapshot == kj::none) {
+    if (inner->existingSnapshot == kj::none) {
       return 0;
     }
-    return KJ_REQUIRE_NONNULL(existingSnapshot).size();
+    return KJ_REQUIRE_NONNULL(inner->existingSnapshot).size();
   }
 
   int readMemorySnapshot(int offset, kj::Array<kj::byte> buf);
   void disposeMemorySnapshot() {
-    existingSnapshot = kj::none;
+    inner->existingSnapshot = kj::none;
   }
 
   // Determines whether this ArtifactBundler was created inside the validator.
   bool isEwValidating() {
-    return isValidating;
+    return inner->isValidating;
   }
 
-  static jsg::Ref<ArtifactBundler> makeDisabledBundler() {
-    return jsg::alloc<ArtifactBundler>(kj::none, kj::none);
+  static kj::Own<State> makeDisabledBundler() {
+    return kj::refcounted<State>(kj::none, kj::none);
   }
 
   // Creates an ArtifactBundler that only grants access to packages, and not a memory snapshot.
-  static jsg::Ref<ArtifactBundler> makePackagesOnlyBundler(
-      kj::Maybe<const PyodidePackageManager&> manager) {
-    return jsg::alloc<ArtifactBundler>(manager, kj::none);
+  static kj::Own<State> makePackagesOnlyBundler(kj::Maybe<const PyodidePackageManager&> manager) {
+    return kj::refcounted<State>(manager, kj::none);
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
-    if (existingSnapshot == kj::none) {
-      return;
+    KJ_IF_SOME(snap, inner->existingSnapshot) {
+      tracker.trackFieldWithSize("snapshot", snap.size());
     }
-    tracker.trackFieldWithSize("snapshot", KJ_REQUIRE_NONNULL(existingSnapshot).size());
   }
 
   bool isEnabled() {
@@ -344,7 +351,7 @@ class ArtifactBundler: public jsg::Object {
   }
 
   kj::Maybe<jsg::Ref<ReadOnlyBuffer>> getPackage(kj::String path) {
-    KJ_IF_SOME(pacman, packageManager) {
+    KJ_IF_SOME(pacman, inner->packageManager) {
       KJ_IF_SOME(ptr, pacman.getPyodidePackage(path)) {
         return jsg::alloc<ReadOnlyBuffer>(ptr);
       }
@@ -368,10 +375,7 @@ class ArtifactBundler: public jsg::Object {
   }
 
  private:
-  // A memory snapshot of the state of the Python interpreter after initialization. Used to speed
-  // up cold starts.
-  kj::Maybe<kj::Array<const kj::byte>> existingSnapshot;
-  bool isValidating;
+  kj::Own<State> inner;
 };
 
 class DisabledInternalJaeger: public jsg::Object {

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -350,10 +350,10 @@ class ArtifactBundler: public jsg::Object {
     return false;  // TODO(later): Remove this function once we regenerate the bundle.
   }
 
-  kj::Maybe<jsg::Ref<ReadOnlyBuffer>> getPackage(kj::String path) {
+  kj::Maybe<jsg::Ref<ReadOnlyBuffer>> getPackage(jsg::Lock& js, kj::String path) {
     KJ_IF_SOME(pacman, inner->packageManager) {
       KJ_IF_SOME(ptr, pacman.getPyodidePackage(path)) {
-        return jsg::alloc<ReadOnlyBuffer>(ptr);
+        return js.alloc<ReadOnlyBuffer>(ptr);
       }
     }
 
@@ -380,8 +380,8 @@ class ArtifactBundler: public jsg::Object {
 
 class DisabledInternalJaeger: public jsg::Object {
  public:
-  static jsg::Ref<DisabledInternalJaeger> create() {
-    return jsg::alloc<DisabledInternalJaeger>();
+  static jsg::Ref<DisabledInternalJaeger> create(jsg::Lock& js) {
+    return js.alloc<DisabledInternalJaeger>();
   }
   JSG_RESOURCE_TYPE(DisabledInternalJaeger) {}
 };
@@ -396,10 +396,6 @@ class DiskCache: public jsg::Object {
  public:
   DiskCache(): cacheRoot(NULL_CACHE_ROOT) {};  // Disabled disk cache
   DiskCache(const kj::Maybe<kj::Own<const kj::Directory>>& cacheRoot): cacheRoot(cacheRoot) {};
-
-  static jsg::Ref<DiskCache> makeDisabled() {
-    return jsg::alloc<DiskCache>();
-  }
 
   jsg::Optional<kj::Array<kj::byte>> get(jsg::Lock& js, kj::String key);
   void put(jsg::Lock& js, kj::String key, kj::Array<kj::byte> data);
@@ -429,8 +425,8 @@ class SimplePythonLimiter: public jsg::Object {
       : startupLimitMs(startupLimitMs),
         getTimeCb(kj::mv(getTimeCb)) {}
 
-  static jsg::Ref<SimplePythonLimiter> makeDisabled() {
-    return jsg::alloc<SimplePythonLimiter>();
+  static jsg::Ref<SimplePythonLimiter> makeDisabled(jsg::Lock& js) {
+    return js.alloc<SimplePythonLimiter>();
   }
 
   void beginStartup() {

--- a/src/workerd/api/url.h
+++ b/src/workerd/api/url.h
@@ -103,7 +103,7 @@ public:
     // Allow URLs which get coerced to strings in either constructor parameter
   }
 
-  // Treat as private -- needs to be public for jsg::alloc<T>()...
+  // Treat as private -- needs to be public for js.alloc<T>()...
   explicit URL(kj::Url&& u);
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -248,7 +248,7 @@ v8::Local<v8::Object> Wrappable::getHandle(v8::Isolate* isolate) {
 }
 
 void Wrappable::addStrongRef() {
-  // The `isolate == nullptr` check here ensures that `jsg::alloc<T>()` can be used with no
+  // The `isolate == nullptr` check here ensures that `js.alloc<T>()` can be used with no
   // isolate, simply allocating the object as a normal C++ heap object.
   KJ_DREQUIRE(isolate == nullptr || v8::Isolate::TryGetCurrent() != nullptr,
       "referencing wrapper without isolate lock");

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -688,8 +688,8 @@ void WorkerdApi::compileModules(jsg::Lock& lockParam,
           jsg::ModuleRegistry::Type::INTERNAL);
 
       // Inject jaeger internal tracer in a disabled state (we don't have a use for it in workerd)
-      modules->addBuiltinModule("pyodide-internal:internalJaeger", DisabledInternalJaeger::create(),
-          jsg::ModuleRegistry::Type::INTERNAL);
+      modules->addBuiltinModule("pyodide-internal:internalJaeger",
+          DisabledInternalJaeger::create(lockParam), jsg::ModuleRegistry::Type::INTERNAL);
 
       // Inject disk cache module
       modules->addBuiltinModule("pyodide-internal:disk_cache",
@@ -697,8 +697,8 @@ void WorkerdApi::compileModules(jsg::Lock& lockParam,
           jsg::ModuleRegistry::Type::INTERNAL);
 
       // Inject a (disabled) SimplePythonLimiter
-      modules->addBuiltinModule("pyodide-internal:limiter", SimplePythonLimiter::makeDisabled(),
-          jsg::ModuleRegistry::Type::INTERNAL);
+      modules->addBuiltinModule("pyodide-internal:limiter",
+          SimplePythonLimiter::makeDisabled(lockParam), jsg::ModuleRegistry::Type::INTERNAL);
     }
 
     for (auto module: confModules) {
@@ -1118,7 +1118,7 @@ kj::Own<jsg::modules::ModuleRegistry> WorkerdApi::initializeBundleModuleRegistry
         jsg::modules::Module::newJsgObjectModuleHandler<DisabledInternalJaeger,
             JsgWorkerdIsolate_TypeWrapper>(
             [](jsg::Lock& js) mutable -> jsg::Ref<DisabledInternalJaeger> {
-      return DisabledInternalJaeger::create();
+      return DisabledInternalJaeger::create(js);
     }));
     // Inject disk cache module
     pyodideBundleBuilder.addSynthetic(diskCacheSpecifier,
@@ -1130,7 +1130,7 @@ kj::Own<jsg::modules::ModuleRegistry> WorkerdApi::initializeBundleModuleRegistry
         jsg::modules::Module::newJsgObjectModuleHandler<SimplePythonLimiter,
             JsgWorkerdIsolate_TypeWrapper>(
             [](jsg::Lock& js) mutable -> jsg::Ref<SimplePythonLimiter> {
-      return SimplePythonLimiter::makeDisabled();
+      return SimplePythonLimiter::makeDisabled(js);
     }));
 
     builder.add(pyodideBundleBuilder.finish());

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -684,7 +684,8 @@ void WorkerdApi::compileModules(jsg::Lock& lockParam,
 
       // Inject artifact bundler.
       modules->addBuiltinModule("pyodide-internal:artifacts",
-          ArtifactBundler::makeDisabledBundler(), jsg::ModuleRegistry::Type::INTERNAL);
+          lockParam.alloc<ArtifactBundler>(ArtifactBundler::makeDisabledBundler()),
+          jsg::ModuleRegistry::Type::INTERNAL);
 
       // Inject jaeger internal tracer in a disabled state (we don't have a use for it in workerd)
       modules->addBuiltinModule("pyodide-internal:internalJaeger", DisabledInternalJaeger::create(),
@@ -1110,7 +1111,7 @@ kj::Own<jsg::modules::ModuleRegistry> WorkerdApi::initializeBundleModuleRegistry
     pyodideBundleBuilder.addSynthetic(artifactsSpecifier,
         jsg::modules::Module::newJsgObjectModuleHandler<ArtifactBundler,
             JsgWorkerdIsolate_TypeWrapper>([](jsg::Lock& js) mutable -> jsg::Ref<ArtifactBundler> {
-      return ArtifactBundler::makeDisabledBundler();
+      return js.alloc<ArtifactBundler>(ArtifactBundler::makeDisabledBundler());
     }));
     // Inject jaeger internal tracer in a disabled state (we don't have a use for it in workerd)
     pyodideBundleBuilder.addSynthetic(internalJaegerSpecifier,


### PR DESCRIPTION
Update pyodide sources to replace jsg::alloc with js.alloc