### PR TITLE
Python: Followup improvements after #3956

### DIFF
--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -59,7 +59,7 @@ def make_bundle_version_info(versions):
         entry["feature_flags"] = [entry["flag"]]
         result[name] = entry
     dev = result["development"]
-    result["development"] = result[dev["pyodide_version"]] | dev
+    result["development"] = result[dev["real_pyodide_version"]] | dev
     return result
 
 BUNDLE_VERSION_INFO = make_bundle_version_info([
@@ -92,8 +92,10 @@ BUNDLE_VERSION_INFO = make_bundle_version_info([
         "baseline_snapshot_hash": "TODO",
     },
     {
+        "real_pyodide_version": "0.26.0a2",
         "name": "development",
-        "pyodide_version": "0.26.0a2",
+        "pyodide_version": "dev",
+        "pyodide_date": "dev",
         "id": "dev",
         "flag": "pythonWorkersDevPyodide",
         "baseline_snapshot_hash": "92859211804cd350f9e14010afad86e584bdd017dc7acfd94709a87f3220afae",

--- a/src/pyodide/BUILD.bazel
+++ b/src/pyodide/BUILD.bazel
@@ -6,21 +6,23 @@ pyodide_extra()
 
 python_bundles()
 
+DEV_VERSION = BUNDLE_VERSION_INFO["development"]["real_pyodide_version"]
+
 alias(
     name = "pyodide.capnp.bin",
-    actual = "pyodide.capnp.bin@rule@0.26.0a2",
+    actual = "pyodide.capnp.bin@rule@" + DEV_VERSION,
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "pyodide.capnp.bin@rule",
-    actual = "pyodide.capnp.bin@rule@0.26.0a2",
+    actual = "pyodide.capnp.bin@rule@" + DEV_VERSION,
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "pyodide",
-    actual = "pyodide@0.26.0a2",
+    actual = "pyodide@" + DEV_VERSION,
     visibility = ["//visibility:public"],
 )
 

--- a/src/workerd/api/pyodide/pyodide-test.c++
+++ b/src/workerd/api/pyodide/pyodide-test.c++
@@ -29,14 +29,14 @@ KJ_TEST("getPythonSnapshotRelease") {
   featureFlags.setPythonWorkersDevPyodide(true);
   {
     auto res = KJ_ASSERT_NONNULL(getPythonSnapshotRelease(featureFlags));
-    KJ_ASSERT(res.getPyodide() == "0.26.0a2");
+    KJ_ASSERT(res.getPyodide() == "dev");
     KJ_ASSERT(res.getFlagName() == "pythonWorkersDevPyodide");
   }
 
   featureFlags.setPythonWorkers(false);
   {
     auto res = KJ_ASSERT_NONNULL(getPythonSnapshotRelease(featureFlags));
-    KJ_ASSERT(res.getPyodide() == "0.26.0a2");
+    KJ_ASSERT(res.getPyodide() == "dev");
     KJ_ASSERT(res.getFlagName() == "pythonWorkersDevPyodide");
   }
 


### PR DESCRIPTION
* Make development version fully determined from python_metadata.bzl
* Set pyodide_version back to "dev" in development PythonSnapshotRelease data