### PR TITLE
add node:fs base classes

### DIFF
--- a/src/node/internal/filesystem.d.ts
+++ b/src/node/internal/filesystem.d.ts
@@ -1,0 +1,27 @@
+export enum NodeType {
+  FILE = 0,
+  DIRECTORY = 1,
+}
+
+export class FileHandle {
+  public close(): void;
+}
+
+export class Node {
+  public getStat(): {
+    path: string;
+    name: string;
+    createdAt: number;
+    modifiedAt: number;
+    type: NodeType;
+  };
+
+  public getFd(): FileHandle | undefined;
+
+  public readonly readable: boolean;
+  public readonly writable: boolean;
+  public readonly asyncOnly: boolean;
+  public readonly syncOnly: boolean;
+}
+
+export function open(pathLike: string | URL | Buffer): Node | undefined;

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -28,6 +28,7 @@ filegroup(
             "urlpattern.c++",
             "urlpattern-standard.c++",
             "util.c++",
+            "filesystem.c++",
         ],
     ),
     visibility = ["//visibility:public"],
@@ -55,6 +56,7 @@ filegroup(
             "urlpattern.h",
             "urlpattern-standard.h",
             "util.h",
+            "filesystem.h",
         ],
     ),
     visibility = ["//visibility:public"],
@@ -89,6 +91,18 @@ wd_cc_library(
 )
 
 wd_cc_library(
+    name = "filesystem",
+    srcs = ["filesystem.c++"],
+    hdrs = ["filesystem.h"],
+    implementation_deps = [],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/workerd/jsg",
+        "//src/workerd/jsg:url",
+    ],
+)
+
+wd_cc_library(
     name = "rtti",
     srcs = [
         "modules.c++",
@@ -104,6 +118,7 @@ wd_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":filesystem",
         ":html-rewriter",
         ":hyperdrive",
         ":memory-cache",

--- a/src/workerd/api/filesystem.c++
+++ b/src/workerd/api/filesystem.c++
@@ -1,0 +1,30 @@
+// Copyright (c) 2017-2024 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "filesystem.h"
+
+#include <kj/filesystem.h>
+#include <kj/string.h>
+
+#include <cstdint>
+
+namespace workerd::api::filesystem {
+
+void Handle::close() {
+  // Implement this.
+}
+
+Node::Stat Node::getStat() {
+  uint64_t modifiedAt_ = static_cast<uint64_t>((modifiedAt - kj::UNIX_EPOCH) / kj::MILLISECONDS);
+  uint64_t createdAt_ = static_cast<uint64_t>((createdAt - kj::UNIX_EPOCH) / kj::MILLISECONDS);
+  return Stat{
+    .name = name,
+    .path = path.toString(),
+    .modifiedAt = modifiedAt_,
+    .createdAt = createdAt_,
+    .type = static_cast<kj::uint>(type),
+  };
+}
+
+}  // namespace workerd::api::filesystem

--- a/src/workerd/api/filesystem.h
+++ b/src/workerd/api/filesystem.h
@@ -1,0 +1,96 @@
+// Copyright (c) 2017-2024 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <workerd/jsg/jsg.h>
+#include <workerd/jsg/memory.h>
+#include <workerd/jsg/url.h>
+
+#include <kj/filesystem.h>
+#include <kj/string.h>
+
+namespace workerd::api::filesystem {
+
+enum class NodeType : kj::uint { FILE, DIRECTORY };
+
+class Handle: public jsg::Object {
+ public:
+  Handle(kj::Path path): path(kj::mv(path)) {}
+
+  void close();
+
+  JSG_RESOURCE_TYPE(Handle) {
+    JSG_METHOD(close);
+  }
+
+ private:
+  kj::Path path;
+};
+
+class Node: public jsg::Object {
+ public:
+  Node(kj::String name, kj::Path path, kj::Date modifiedAt, kj::Date createdAt, NodeType type)
+      : name(kj::mv(name)),
+        path(kj::mv(path)),
+        modifiedAt(kj::mv(modifiedAt)),
+        createdAt(kj::mv(createdAt)),
+        type(type) {};
+
+  virtual bool isReadable() const {
+    return false;
+  }
+  virtual bool isWritable() const {
+    return false;
+  }
+  virtual bool isAsyncOnly() const {
+    return false;
+  }
+  virtual bool isSyncOnly() const {
+    return false;
+  }
+
+  virtual kj::Maybe<jsg::Ref<Handle>> getFd() {
+    return kj::none;
+  }
+
+  struct Stat {
+    kj::StringPtr name;
+    kj::StringPtr path;
+    uint64_t modifiedAt;
+    uint64_t createdAt;
+    kj::uint type;
+
+    JSG_STRUCT(name, path, modifiedAt, createdAt, type);
+  };
+
+  Stat getStat();
+
+  void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
+    tracker.trackFieldWithSize("name", name.size());
+    tracker.trackFieldWithSize("path", path.size());
+  }
+
+  JSG_RESOURCE_TYPE(Node) {
+    JSG_READONLY_PROTOTYPE_PROPERTY(readable, isReadable);
+    JSG_READONLY_PROTOTYPE_PROPERTY(writable, isWritable);
+    JSG_READONLY_PROTOTYPE_PROPERTY(asyncOnly, isAsyncOnly);
+    JSG_READONLY_PROTOTYPE_PROPERTY(syncOnly, isSyncOnly);
+
+    JSG_METHOD(getStat);
+    JSG_METHOD(getFd);
+  }
+
+ private:
+  kj::String name;
+  kj::Path path;
+  kj::Date modifiedAt;
+  kj::Date createdAt;
+  NodeType type;
+};
+
+}  // namespace workerd::api::filesystem
+
+#define EW_FILESYSTEM_ISOLATE_TYPES                                                                \
+  api::filesystem::Node, api::filesystem::Node::Stat, api::filesystem::Handle

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -9,6 +9,7 @@ wd_cc_library(
         "crypto.c++",
         "crypto-keys.c++",
         "diagnostics-channel.c++",
+        "filesystem.c++",
         "module.c++",
         "timers.c++",
         "util.c++",
@@ -17,6 +18,7 @@ wd_cc_library(
     hdrs = [
         "crypto.h",
         "diagnostics-channel.h",
+        "filesystem.h",
         "module.h",
         "node.h",
         "timers.h",
@@ -30,6 +32,7 @@ wd_cc_library(
     deps = [
         ":node-core",
         "//src/node",
+        "//src/workerd/api:filesystem",
         "//src/workerd/io",
         "@capnp-cpp//src/kj/compat:kj-brotli",
         "@ncrypto",

--- a/src/workerd/api/node/filesystem.c++
+++ b/src/workerd/api/node/filesystem.c++
@@ -1,0 +1,19 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+#include "filesystem.h"
+
+#include <workerd/api/filesystem.h>
+#include <workerd/jsg/jsg.h>
+
+#include <kj/string.h>
+
+using workerd::api::filesystem::Node;
+
+namespace workerd::api::node {
+
+kj::Maybe<jsg::Ref<Node>> FilesystemUtil::open(jsg::Lock& js, kj::String path) {
+  return kj::none;
+}
+
+}  // namespace workerd::api::node

--- a/src/workerd/api/node/filesystem.h
+++ b/src/workerd/api/node/filesystem.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+// Copyright Joyent and Node contributors. All rights reserved. MIT license.
+#pragma once
+
+#include <workerd/api/filesystem.h>
+#include <workerd/jsg/buffersource.h>
+#include <workerd/jsg/jsg.h>
+#include <workerd/jsg/jsvalue.h>
+#include <workerd/jsg/memory.h>
+#include <workerd/jsg/url.h>
+
+#include <kj/string.h>
+
+using workerd::api::filesystem::Handle;
+using workerd::api::filesystem::Node;
+
+namespace workerd::api::node {
+
+class FilesystemUtil final: public jsg::Object {
+ public:
+  FilesystemUtil() = default;
+  FilesystemUtil(jsg::Lock&, const jsg::Url&) {}
+
+  class BundleNode final: public Node {
+   public:
+    BundleNode(kj::String name,
+        kj::Path path,
+        kj::Date modifiedAt,
+        kj::Date createdAt,
+        filesystem::NodeType type)
+        : Node(kj::mv(name), kj::mv(path), modifiedAt, createdAt, type) {}
+
+    bool isReadable() const override {
+      return true;
+    }
+    bool isWritable() const override {
+      return false;
+    }
+    bool isAsyncOnly() const override {
+      return false;
+    }
+    bool isSyncOnly() const override {
+      return false;
+    }
+
+    kj::Maybe<jsg::Ref<Handle>> getFd() override {
+      return kj::none;
+    }
+
+    JSG_RESOURCE_TYPE(BundleNode) {
+      JSG_INHERIT(Node);
+    }
+  };
+
+  kj::Maybe<jsg::Ref<Node>> open(jsg::Lock&, kj::String path);
+
+  JSG_RESOURCE_TYPE(FilesystemUtil) {
+    JSG_METHOD(open);
+  }
+};
+
+#define EW_NODE_FILESYSTEM_ISOLATE_TYPES                                                           \
+  api::node::FilesystemUtil, api::node::FilesystemUtil::BundleNode
+
+}  // namespace workerd::api::node

--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -7,6 +7,7 @@
 #include <workerd/api/node/async-hooks.h>
 #include <workerd/api/node/buffer.h>
 #include <workerd/api/node/dns.h>
+#include <workerd/api/node/filesystem.h>
 #include <workerd/api/node/module.h>
 #include <workerd/api/node/timers.h>
 #include <workerd/api/node/url.h>
@@ -54,7 +55,8 @@ class CompatibilityFlags: public jsg::Object {
   V(ZlibUtil, "node-internal:zlib")                                                                \
   V(UrlUtil, "node-internal:url")                                                                  \
   V(DnsUtil, "node-internal:dns")                                                                  \
-  V(TimersUtil, "node-internal:timers")
+  V(TimersUtil, "node-internal:timers")                                                            \
+  V(FilesystemUtil, "node-internal:filesystem")
 
 // Add to the NODEJS_MODULES_EXPERIMENTAL list any currently in-development
 // node.js compat C++ modules that should be guarded by the experimental compat
@@ -146,4 +148,5 @@ kj::Own<jsg::modules::ModuleBundle> getExternalNodeJsCompatModuleBundle(auto fea
   api::node::CompatibilityFlags, EW_NODE_BUFFER_ISOLATE_TYPES, EW_NODE_CRYPTO_ISOLATE_TYPES,       \
       EW_NODE_DIAGNOSTICCHANNEL_ISOLATE_TYPES, EW_NODE_ASYNCHOOKS_ISOLATE_TYPES,                   \
       EW_NODE_UTIL_ISOLATE_TYPES, EW_NODE_ZLIB_ISOLATE_TYPES, EW_NODE_URL_ISOLATE_TYPES,           \
-      EW_NODE_MODULE_ISOLATE_TYPES, EW_NODE_DNS_ISOLATE_TYPES, EW_NODE_TIMERS_ISOLATE_TYPES\
+      EW_NODE_MODULE_ISOLATE_TYPES, EW_NODE_DNS_ISOLATE_TYPES, EW_NODE_TIMERS_ISOLATE_TYPES,       \
+      EW_NODE_FILESYSTEM_ISOLATE_TYPES

--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -12,6 +12,7 @@
 #include <workerd/api/encoding.h>
 #include <workerd/api/events.h>
 #include <workerd/api/eventsource.h>
+#include <workerd/api/filesystem.h>
 #include <workerd/api/global-scope.h>
 #include <workerd/api/html-rewriter.h>
 #include <workerd/api/hyperdrive.h>
@@ -77,7 +78,8 @@
   F("node", EW_NODE_ISOLATE_TYPES)                                                                 \
   F("rtti", EW_RTTI_ISOLATE_TYPES)                                                                 \
   F("eventsource", EW_EVENTSOURCE_ISOLATE_TYPES)                                                   \
-  F("container", EW_CONTAINER_ISOLATE_TYPES)
+  F("container", EW_CONTAINER_ISOLATE_TYPES)                                                       \
+  F("filesystem", EW_FILESYSTEM_ISOLATE_TYPES)
 
 namespace workerd::api {
 

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -102,6 +102,7 @@ wd_cc_library(
         "//src/workerd/api:data-url",
         "//src/workerd/api:deferred-proxy",
         "//src/workerd/api:encoding",
+        "//src/workerd/api:filesystem",
         "//src/workerd/api:url",
         "//src/workerd/api:urlpattern",
         "//src/workerd/api:urlpattern-standard",

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -16,6 +16,7 @@
 #include <workerd/api/encoding.h>
 #include <workerd/api/events.h>
 #include <workerd/api/eventsource.h>
+#include <workerd/api/filesystem.h>
 #include <workerd/api/global-scope.h>
 #include <workerd/api/html-rewriter.h>
 #include <workerd/api/hyperdrive.h>
@@ -108,6 +109,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
     EW_URLPATTERN_STANDARD_ISOLATE_TYPES,
     EW_WEBSOCKET_ISOLATE_TYPES,
     EW_SQL_ISOLATE_TYPES,
+    EW_FILESYSTEM_ISOLATE_TYPES,
     EW_NODE_ISOLATE_TYPES,
     EW_RTTI_ISOLATE_TYPES,
     EW_HYPERDRIVE_ISOLATE_TYPES,


### PR DESCRIPTION
> Work in progress.


Example usage internal usage:

- fs.getResource() will return different classes that extend from "Node" class depending on the root path of the file.

```typescript
import { default as fs } from 'node-internal:filesystem';

const resource = fs.get('/bundle/hello.jpeg');
resource.getStat() // Returns: { name, ... }
resource.asyncOnly;
resource.syncOnly;
resource.readable;
resource.writable;

const fd = resource.getFd();
fd.close();
``