### PR TITLE
Add just new-wpt-test to generate initial config

### DIFF
--- a/build/wpt_test.bzl
+++ b/build/wpt_test.bzl
@@ -163,9 +163,11 @@ import {{ createRunner }} from 'harness/harness';
 import config from '{test_config}';
 
 const allTestFiles = {all_test_files};
-const run = createRunner(config, '{test_name}', allTestFiles);
+const {{ run, printResults }} = createRunner(config, '{test_name}', allTestFiles);
 
 {cases}
+
+export const zzz_results = printResults();
 """
 
 def generate_external_cases(base, files):
@@ -270,6 +272,7 @@ const unitTests :Workerd.Config = (
           (name = "unsafe", unsafeEval = void),
           (name = "HTTP_PORT", fromEnvironment = "HTTP_PORT"),
           (name = "HTTPS_PORT", fromEnvironment = "HTTPS_PORT"),
+          (name = "GEN_TEST_CONFIG", fromEnvironment = "GEN_TEST_CONFIG"),
           {bindings}
         ],
         {compat_date}

--- a/justfile
+++ b/justfile
@@ -47,6 +47,17 @@ lldb-wpt-test test_name: build
 asan-wpt-test test_name:
   bazel test //src/workerd/api/wpt:{{test_name}} --config=asan
 
+new-wpt-test test_name:
+  mkdir -p src/wpt/$(dirname {{test_name}})
+  echo "export default {};" > src/wpt/{{test_name}}-test.ts
+  git add src/wpt/{{test_name}}-test.ts
+
+  echo >> src/wpt/BUILD.bazel
+  echo 'wpt_test(name = "{{test_name}}", config = "{{test_name}}-test.ts", wpt_directory = "@wpt//:{{test_name}}@module")' >> src/wpt/BUILD.bazel
+
+  ./tools/cross/format.py
+  bazel test //src/wpt:{{test_name}} --test_env=GEN_TEST_CONFIG=1 --test_output=streamed
+
 format: rustfmt
   python3 tools/cross/format.py
 


### PR DESCRIPTION
## Test templates

* Adds new recipe to justfile, `just new-wpt-test test_name` that automatically writes the needed boilerplate for Bazel/Typescript to get the new test running.
* Adds a new environment variable `GEN_TEST_CONFIG=1`. If specified, the harness will print out an initial test config for the new test suite, at the end of the test output. For example,

```typescript
// Copyright (c) 2017-2022 Cloudflare, Inc.
// Licensed under the Apache 2.0 license found in the LICENSE file or at:
//     https://opensource.org/licenses/Apache-2.0

import { type TestRunnerConfig } from 'harness/harness';

export default {
  "aborting.any.js": {},
  "bad-strategies.any.js": {},
  "bad-underlying-sinks.any.js": {},
  "byte-length-queuing-strategy.any.js": {},
  "close.any.js": {},
  "constructor.any.js": {},
  "count-queuing-strategy.any.js": {},
  "error.any.js": {},
  "floating-point-total-queue-size.any.js": {},
  "garbage-collection.any.js": {},
  "general.any.js": {},
  "properties.any.js": {},
  "reentrant-strategy.any.js": {},
  "start.any.js": {},
  "write.any.js": {}
} satisfies TestRunnerConfig;
```

## `only: true` improvements

- The harness supports setting an `only` flag on a particular test case, which runs only this test, so you can focus on fixing it, not reading through piles of output. This has been improved a bit so that the test cases that aren't running won't produce workerd runner output like  `workerd/server/server.c++:4314: debug: [ TEST ]`  either.

## Future work

* The generated config could automatically suggest `skipAllTests` and `expectedFailures` as needed.
* This mechanism will also be used to print wpt.fyi-formatted test results.