### PR TITLE
Request that sqlite-backed DO alarms get rescheduled when out-of-sync

### DIFF
--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -143,6 +143,7 @@ wd_cc_library(
         ":actor-storage_capnp",
         ":io-gate",
         "//src/workerd/jsg:exception",
+        "//src/workerd/util:autogate",
         "//src/workerd/util:duration-exceeded-logger",
         "//src/workerd/util:sqlite",
         "@capnp-cpp//src/capnp:capnp-rpc",

--- a/src/workerd/io/actor-sqlite-test.c++
+++ b/src/workerd/io/actor-sqlite-test.c++
@@ -5,6 +5,7 @@
 #include "actor-sqlite.h"
 #include "io-gate.h"
 
+#include <workerd/util/autogate.h>
 #include <workerd/util/capnp-mock.h>
 #include <workerd/util/test.h>
 
@@ -413,8 +414,10 @@ KJ_TEST("tells alarm handler to cancel when committed alarm is empty") {
 
 KJ_TEST("tells alarm handler to cancel when handler alarm is later than committed alarm") {
   ActorSqliteTest test;
+  util::Autogate::initAutogateNamesForTest({});
+  KJ_DEFER(util::Autogate::deinitAutogate());
 
-  // Initialize alarm state to 2ms.
+  // Initialize alarm state to 1ms.
   test.setAlarm(oneMs);
   test.pollAndExpectCalls({"scheduleRun(1ms)"})[0]->fulfill();
   test.pollAndExpectCalls({"commit"})[0]->fulfill();
@@ -427,6 +430,32 @@ KJ_TEST("tells alarm handler to cancel when handler alarm is later than committe
   auto cancelResult = kj::mv(armResult.get<ActorSqlite::CancelAlarmHandler>());
   KJ_ASSERT(cancelResult.waitBeforeCancel.poll(test.ws));
   cancelResult.waitBeforeCancel.wait(test.ws);
+}
+
+KJ_TEST("tells alarm handler to reschedule when handler alarm is later than committed alarm") {
+  ActorSqliteTest test;
+  util::Autogate::initAutogateNamesForTest({"reschedule-desynced-sqlite-alarms"_kj});
+  KJ_DEFER(util::Autogate::deinitAutogate());
+
+  // Initialize alarm state to 1ms.
+  test.setAlarm(oneMs);
+  test.pollAndExpectCalls({"scheduleRun(1ms)"})[0]->fulfill();
+  test.pollAndExpectCalls({"commit"})[0]->fulfill();
+  test.pollAndExpectCalls({});
+  KJ_ASSERT(expectSync(test.getAlarm()) == oneMs);
+
+  // Request handler run at 2ms.  Expect cancellation with rescheduling.
+  auto armResult = test.actor.armAlarmHandler(twoMs, false);
+  KJ_ASSERT(armResult.is<ActorSqlite::CancelAlarmHandler>());
+  auto cancelResult = kj::mv(armResult.get<ActorSqlite::CancelAlarmHandler>());
+
+  // Expect rescheduling was requested and that returned promise resolves after fulfillment.
+  auto waitBeforeCancel = kj::mv(cancelResult.waitBeforeCancel);
+  auto rescheduleFulfiller = kj::mv(test.pollAndExpectCalls({"scheduleRun(1ms)"})[0]);
+  KJ_ASSERT(!waitBeforeCancel.poll(test.ws));
+  rescheduleFulfiller->fulfill();
+  KJ_ASSERT(waitBeforeCancel.poll(test.ws));
+  waitBeforeCancel.wait(test.ws);
 }
 
 KJ_TEST("tells alarm handler to reschedule when handler alarm is earlier than committed alarm") {

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -17,6 +17,8 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
   switch (key) {
     case AutogateKey::TEST_WORKERD:
       return "test-workerd"_kj;
+    case AutogateKey::RESCHEDULE_DESYNCED_SQLITE_ALARMS:
+      return "reschedule-desynced-sqlite-alarms"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -14,6 +14,7 @@ namespace workerd::util {
 // Workerd-specific list of autogate keys (can also be used in internal repo).
 enum class AutogateKey {
   TEST_WORKERD,
+  RESCHEDULE_DESYNCED_SQLITE_ALARMS,
   NumOfKeys  // Reserved for iteration.
 };
 


### PR DESCRIPTION
Behind a 'reschedule-desynced-sqlite-alarms' autogate.