### PR TITLE
Return abort exception error through promise in IoContext::run()

### DIFF
--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -1035,7 +1035,7 @@ kj::PromiseForResult<Func, Worker::Lock&> IoContext::run(
   // Before we try running anything, let's make sure our IoContext hasn't been aborted. If it has
   // been aborted, there's likely not an active request so later operations will fail anyway.
   KJ_IF_SOME(ex, abortException) {
-    kj::throwFatalException(kj::cp(ex));
+    return kj::cp(ex);
   }
 
   kj::Promise<Worker::AsyncLock> asyncLockPromise = nullptr;


### PR DESCRIPTION
In WorkerEntrypoint::request, we set up draining as part of the returned promise. But if an exception is thrown by IoContext::run separately from the returned promise, the IncomingRequest is dropped during unwinding without draining! So with this we just wrap context.run in evalNow to make sure any thrown exceptions are caught.