### PR TITLE
Make `ctx.props` optional in workers-types

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -238,6 +238,8 @@ class ExecutionContext: public jsg::Object {
     }
     JSG_LAZY_INSTANCE_PROPERTY(props, getProps);
 
+    JSG_TS_OVERRIDE({ props?: Cloudflare.Props })
+
     if (flags.getWorkerdExperimental()) {
       // TODO(soon): Before making this generally available we need to:
       // * Consider whether to use TerminateExecution() instead of throwing.

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -240,19 +240,19 @@ class ExecutionContext: public jsg::Object {
 
     JSG_TS_OVERRIDE({ props?: Cloudflare.Props })
 
-    if (flags.getWorkerdExperimental()) {
-      // TODO(soon): Before making this generally available we need to:
-      // * Consider whether to use TerminateExecution() instead of throwing.
-      // * Make sure it's really not possible for more code to run in the context after abort().
-      //   Currently, abort() triggers in a partially async way so there's an opportunity for some
-      //   other event in the event queue to squeeze in.
-      // * Try to ensure that the provided error is actually the one that propagates out of event
-      //   handlers. Currently this is not consistently true.
-      // * Make sure all event handlers actually honor onAbort().
-      // * Enable the Durable Object version at the same time -- and make sure they're suitably
-      //   consistent with each other.
-      JSG_METHOD(abort);
-    }
+        if (flags.getWorkerdExperimental()) {
+          // TODO(soon): Before making this generally available we need to:
+          // * Consider whether to use TerminateExecution() instead of throwing.
+          // * Make sure it's really not possible for more code to run in the context after abort().
+          //   Currently, abort() triggers in a partially async way so there's an opportunity for some
+          //   other event in the event queue to squeeze in.
+          // * Try to ensure that the provided error is actually the one that propagates out of event
+          //   handlers. Currently this is not consistently true.
+          // * Make sure all event handlers actually honor onAbort().
+          // * Enable the Durable Object version at the same time -- and make sure they're suitably
+          //   consistent with each other.
+          JSG_METHOD(abort);
+        }
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -238,21 +238,21 @@ class ExecutionContext: public jsg::Object {
     }
     JSG_LAZY_INSTANCE_PROPERTY(props, getProps);
 
-    JSG_TS_OVERRIDE({ props?: Cloudflare.Props })
+    JSG_TS_OVERRIDE({ props?: Cloudflare.Props });
 
-        if (flags.getWorkerdExperimental()) {
-          // TODO(soon): Before making this generally available we need to:
-          // * Consider whether to use TerminateExecution() instead of throwing.
-          // * Make sure it's really not possible for more code to run in the context after abort().
-          //   Currently, abort() triggers in a partially async way so there's an opportunity for some
-          //   other event in the event queue to squeeze in.
-          // * Try to ensure that the provided error is actually the one that propagates out of event
-          //   handlers. Currently this is not consistently true.
-          // * Make sure all event handlers actually honor onAbort().
-          // * Enable the Durable Object version at the same time -- and make sure they're suitably
-          //   consistent with each other.
-          JSG_METHOD(abort);
-        }
+    if (flags.getWorkerdExperimental()) {
+      // TODO(soon): Before making this generally available we need to:
+      // * Consider whether to use TerminateExecution() instead of throwing.
+      // * Make sure it's really not possible for more code to run in the context after abort().
+      //   Currently, abort() triggers in a partially async way so there's an opportunity for some
+      //   other event in the event queue to squeeze in.
+      // * Try to ensure that the provided error is actually the one that propagates out of event
+      //   handlers. Currently this is not consistently true.
+      // * Make sure all event handlers actually honor onAbort().
+      // * Enable the Durable Object version at the same time -- and make sure they're suitably
+      //   consistent with each other.
+      JSG_METHOD(abort);
+    }
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -158,6 +158,7 @@ declare namespace Rpc {
 
 declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 
 declare module 'cloudflare:workers' {

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -382,7 +382,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,
@@ -6073,6 +6073,7 @@ declare namespace Rpc {
 }
 declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -384,7 +384,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -6056,6 +6056,7 @@ export declare namespace Rpc {
 }
 export declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -382,7 +382,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,
@@ -6099,6 +6099,7 @@ declare namespace Rpc {
 }
 declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -384,7 +384,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -6082,6 +6082,7 @@ export declare namespace Rpc {
 }
 export declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -385,7 +385,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,
@@ -6117,6 +6117,7 @@ declare namespace Rpc {
 }
 declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -387,7 +387,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -6100,6 +6100,7 @@ export declare namespace Rpc {
 }
 export declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -385,7 +385,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,
@@ -6118,6 +6118,7 @@ declare namespace Rpc {
 }
 declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -387,7 +387,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -6101,6 +6101,7 @@ export declare namespace Rpc {
 }
 export declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -385,7 +385,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,
@@ -6122,6 +6122,7 @@ declare namespace Rpc {
 }
 declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -387,7 +387,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -6105,6 +6105,7 @@ export declare namespace Rpc {
 }
 export declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -390,7 +390,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,
@@ -6127,6 +6127,7 @@ declare namespace Rpc {
 }
 declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -392,7 +392,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -6110,6 +6110,7 @@ export declare namespace Rpc {
 }
 export declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -390,7 +390,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,
@@ -6129,6 +6129,7 @@ declare namespace Rpc {
 }
 declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -392,7 +392,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -6112,6 +6112,7 @@ export declare namespace Rpc {
 }
 export declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -390,7 +390,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,
@@ -6129,6 +6129,7 @@ declare namespace Rpc {
 }
 declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -392,7 +392,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -6112,6 +6112,7 @@ export declare namespace Rpc {
 }
 export declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -391,7 +391,7 @@ interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
   exports: any;
-  props: any;
+  props?: Cloudflare.Props;
   abort(reason?: any): void;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
@@ -6213,6 +6213,7 @@ declare namespace Rpc {
 }
 declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -393,7 +393,7 @@ export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
   exports: any;
-  props: any;
+  props?: Cloudflare.Props;
   abort(reason?: any): void;
 }
 export type ExportedHandlerFetchHandler<
@@ -6196,6 +6196,7 @@ export declare namespace Rpc {
 }
 export declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -382,7 +382,7 @@ interface TestController {}
 interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,
@@ -6073,6 +6073,7 @@ declare namespace Rpc {
 }
 declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 declare module "cloudflare:workers" {
   export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -384,7 +384,7 @@ export interface TestController {}
 export interface ExecutionContext {
   waitUntil(promise: Promise<any>): void;
   passThroughOnException(): void;
-  props: any;
+  props?: Cloudflare.Props;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -6056,6 +6056,7 @@ export declare namespace Rpc {
 }
 export declare namespace Cloudflare {
   interface Env {}
+  interface Props {}
 }
 export interface SecretsStoreSecret {
   /**


### PR DESCRIPTION
Make `ctx.props` optional in workers-types, and allow users to extend it by defining `Cloudflare.Props`