### PR TITLE
avoid leading slashes on .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,31 +2,31 @@
 .DS_Store
 
 # directory for developers to store local resources
-/.local/
+.local/
 
-/*.code-workspace
+*.code-workspace
 
 node_modules
-/npm/*/bin
-/npm/workerd/install.js
-/npm/workerd/lib/
+./npm/*/bin
+./npm/workerd/install.js
+./npm/workerd/lib/
 package-lock.json
 
 # The external link for compile_flags.txt: Differs on Windows vs macOS/Linux, so we can't check it in. The pattern needs to not have a trailing / because it's a symlink on macOS/Linux.
-/external
+external
 # Bazel output symlinks: Same reasoning as /external. You need the * because people can change the name of the directory your repository is cloned into, changing the bazel-<workspace_name> symlink.
-/bazel-*
+bazel-*
 # Compiled output -> don't check in
-/compile_commands.json
-/rust-project.json
+compile_commands.json
+rust-project.json
 # Directory where clangd puts its indexing work
-/.cache/
+.cache
 
-/.bazel-cache
+.bazel-cache
 
-/workerd-*
+workerd-*
 
-/docs/api
+docs/api
 
 *.tsbuildinfo
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,9 @@
 *.code-workspace
 
 node_modules
-./npm/*/bin
-./npm/workerd/install.js
-./npm/workerd/lib/
+npm/*/bin
+npm/workerd/install.js
+npm/workerd/lib/
 package-lock.json
 
 # The external link for compile_flags.txt: Differs on Windows vs macOS/Linux, so we can't check it in. The pattern needs to not have a trailing / because it's a symlink on macOS/Linux.


### PR DESCRIPTION
Editors like Zed doesn't support "/" prefix for the gitignore entries.