### PR TITLE
add support for v8 fast api

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ test-asan *args="//...":
 
 # e.g. just stream-test //src/cloudflare:cloudflare.capnp@eslint
 stream-test *args:
-  bazel test {{args}} --test_output=streamed --cache_test_results=no
+  bazel test {{args}} --test_output=streamed --cache_test_results=no --config=debug
 
 # e.g. just node-test zlib
 node-test test_name *args:
@@ -77,7 +77,7 @@ rustfmt:
 
 # example: just bench mimetype
 bench path:
-  bazel run //src/workerd/tests:bench-{{path}}
+  bazel run //src/workerd/tests:bench-{{path}} --config=benchmark
 
 # example: just clippy dns
 clippy package="...":

--- a/src/workerd/api/actor-state-test.c++
+++ b/src/workerd/api/actor-state-test.c++
@@ -29,6 +29,7 @@ struct ActorStateContext: public jsg::Object, public jsg::ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(ActorStateIsolate, ActorStateContext);
 
 KJ_TEST("v8 serialization version tag hasn't changed") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   jsg::test::Evaluator<ActorStateContext, ActorStateIsolate> e(v8System);
   e.getIsolate().runInLockScope([&](ActorStateIsolate::Lock& isolateLock) {
     JSG_WITHIN_CONTEXT_SCOPE(isolateLock,

--- a/src/workerd/api/basics-test.c++
+++ b/src/workerd/api/basics-test.c++
@@ -14,6 +14,7 @@
 #include <workerd/io/promise-wrapper.h>
 #include <workerd/jsg/jsg-test.h>
 #include <workerd/jsg/jsg.h>
+#include <workerd/util/autogate.h>
 
 namespace workerd::api {
 namespace {
@@ -23,7 +24,6 @@ jsg::V8System v8System;
 struct BasicsContext: public jsg::Object, public jsg::ContextGlobal {
 
   bool testNativeListenersWork(jsg::Lock& js) {
-
     auto target = js.alloc<api::EventTarget>();
 
     int called = 0;
@@ -87,6 +87,7 @@ JSG_DECLARE_ISOLATE_TYPE(BasicsIsolate,
     jsg::TypeWrapperExtension<PromiseWrapper>);
 
 KJ_TEST("EventTarget native listeners work") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   jsg::test::Evaluator<BasicsContext, BasicsIsolate, CompatibilityFlags::Reader> e(v8System);
   e.expectEval("testNativeListenersWork()", "boolean", "true");
 }

--- a/src/workerd/api/crypto/aes-test.c++
+++ b/src/workerd/api/crypto/aes-test.c++
@@ -25,6 +25,7 @@ struct CryptoContext: public jsg::Object, public jsg::ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(CryptoIsolate, CryptoContext);
 
 KJ_TEST("AES-KW key wrap") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   // Basic test that I wrote when I was seeing heap corruption. Found it easier to iterate on with
   // ASAN/valgrind than using our conformance tests with test-runner.
   jsg::test::Evaluator<CryptoContext, CryptoIsolate> e(v8System);

--- a/src/workerd/api/form-data-memory-test.c++
+++ b/src/workerd/api/form-data-memory-test.c++
@@ -91,6 +91,7 @@ JSG_DECLARE_ISOLATE_TYPE(HeadersIsolate,
     workerd::api::File::Options);
 
 KJ_TEST("FormData memory is accounted for") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   jsg::test::Evaluator<HeadersContext, HeadersIsolate, CompatibilityFlags::Reader> e(v8System);
   e.expectEval("test()", "boolean", "true");
 }

--- a/src/workerd/api/headers-test.c++
+++ b/src/workerd/api/headers-test.c++
@@ -96,6 +96,7 @@ JSG_DECLARE_ISOLATE_TYPE(HeadersIsolate,
     jsg::TypeWrapperExtension<PromiseWrapper>);
 
 KJ_TEST("Header memory is accounted for") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   jsg::test::Evaluator<HeadersContext, HeadersIsolate, CompatibilityFlags::Reader> e(v8System);
   e.expectEval("test()", "boolean", "true");
 }

--- a/src/workerd/api/streams/queue-test.c++
+++ b/src/workerd/api/streams/queue-test.c++
@@ -106,6 +106,7 @@ auto getEntry(jsg::Lock& js, auto size) {
 #pragma region ValueQueue Tests
 
 KJ_TEST("ValueQueue basics work") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   preamble([](jsg::Lock& js) {
     ValueQueue queue(2);
 

--- a/src/workerd/api/streams/standard-test.c++
+++ b/src/workerd/api/streams/standard-test.c++
@@ -41,6 +41,7 @@ jsg::BufferSource toBufferSource(jsg::Lock& js, kj::Array<kj::byte> bytes) {
 // Happy Cases
 
 KJ_TEST("ReadableStream read all text (value readable)") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());

--- a/src/workerd/io/frankenvalue-test.c++
+++ b/src/workerd/io/frankenvalue-test.c++
@@ -18,6 +18,7 @@ struct TestContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(TestIsolate, TestContext);
 
 KJ_TEST("Frankenvalue") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   jsg::test::Evaluator<TestContext, TestIsolate> e(v8System);
 
   e.run([&](jsg::Lock& js) {

--- a/src/workerd/io/promise-wrapper-test.c++
+++ b/src/workerd/io/promise-wrapper-test.c++
@@ -84,6 +84,7 @@ JSG_DECLARE_ISOLATE_TYPE(
     CaptureThrowIsolate, CaptureThrowContext, jsg::TypeWrapperExtension<workerd::PromiseWrapper>);
 
 KJ_TEST("Async functions capture sync errors with flag") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<CaptureThrowContext, CaptureThrowIsolate> e(v8System);
   e.setCaptureThrowsAsRejections(true);
   e.expectEval("test1()", "object", "[object Promise]");

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -38,7 +38,6 @@ wd_cc_library(
         "iterator.h",
         "struct.h",
         "value.h",
-        "web-idl.h",
     ],
     local_defines = ["JSG_IMPLEMENTATION"],
     deps = [
@@ -95,6 +94,7 @@ wd_cc_library(
         "async-context.h",
         "buffersource.h",
         "dom-exception.h",
+        "fast-api.h",
         "function.h",
         "jsg.h",
         "jsvalue.h",
@@ -106,6 +106,7 @@ wd_cc_library(
         "setup.h",
         "util.h",
         "v8-platform-wrapper.h",
+        "web-idl.h",
         "wrappable.h",
     ],
     # Some JSG headers can't be compiled on their own
@@ -120,6 +121,7 @@ wd_cc_library(
         ":observer",
         ":url",
         "//src/workerd/util",
+        "//src/workerd/util:autogate",
         "//src/workerd/util:sentry",
         "//src/workerd/util:thread-scopes",
         "//src/workerd/util:uuid",
@@ -280,6 +282,7 @@ wd_cc_library(
     local_defines = ["JSG_IMPLEMENTATION"],
     deps = [
         ":jsg",
+        "//src/workerd/util:autogate",
     ],
 ) for f in glob(
     ["*-test.c++"],

--- a/src/workerd/jsg/README.md
+++ b/src/workerd/jsg/README.md
@@ -10,6 +10,36 @@ the same interface on top of different JavaScript engines. However, as of today,
 quite the case. At present application code will still need to use V8 APIs directly in some
 cases. We would like to improve this in the future.
 
+## V8 Fast API
+
+V8 Fast API allows V8 to compile JavaScript code that calls native functions in a way that directly jumps to the C++ implementation without going through the usual JavaScript-to-C++ binding layers. This is accomplished by having V8 generate specialized machine code that knows how to call the C++ function directly, skipping the overhead of value conversion and JavaScript calling conventions.
+
+### Requirements for Fast API compatibility
+
+For a method to be compatible with Fast API, it must adhere to several constraints due to v8 itself, and may change as the fast api mechanism continues to evolve:
+
+1. **Return Type**: Must be one of these primitive types: `void`, `bool`, `int32_t`, `uint32_t`, `float`, or `double`.
+
+2. **Parameter Types**: Can be the primitive types listed above, or V8 handle types like `v8::Local<v8::Value>` or `v8::Local<v8::Object>`, or types that can be unwrapped from a V8 value using the TypeWrapper.
+
+3. **Method Structure**: Can be a regular instance method, a const instance method, or a method that takes `jsg::Lock&` as its first parameter.
+
+### Using Fast API in workerd
+
+By default, any `JSG_METHOD(name)` will execute fast path if the method signature is compatible with Fast API requirements. To explicitly force the function to use v8 Fast API in workerd, you can use `JSG_ASSERT_FASTAPI`.
+
+### How it works
+
+When a method is registered with the v8 fast api, workerd automatically:
+
+1. Checks if the method signature is compatible with Fast API requirements
+2. Registers both a regular (slow path) method handler and a Fast API handler
+3. Let's V8 optimize calls to this method when possible
+
+V8 determines at runtime whether to use the fast or slow path:
+- The fast path is used when the method is called from optimized code
+- The slow path is used when called from unoptimized code or when handling complex cases
+
 ## The Basics
 
 If you haven't done so already, I recommend reading through both the ["KJ Style Guide"][]
@@ -1430,11 +1460,11 @@ the following rules are applied:
    modifier will be added if it's not already present. In the special case that the override is a
    `type`-alias to `never`, the generated definition will be deleted.
 
-2. Otherwise, the override will be converted to a TypeScript class as follows: (where `<name>` is the
+2. Otherwise, the override will be converted to a TypeScript class as follows: (where `<n>` is the
    unqualified C++ type name of this resource type)
 
-   1. If an override starts with `extends `, `implements ` or `{`: `class <name> ` will be prepended
-   2. If an override starts with `<`: `class <name>` will be prepended
+   1. If an override starts with `extends `, `implements ` or `{`: `class <n> ` will be prepended
+   2. If an override starts with `<`: `class <n>` will be prepended
    3. Otherwise, `class ` will be prepended
 
    After this, if the override doesn't end with `}`, ` {}` will be appended.

--- a/src/workerd/jsg/buffersource-test.c++
+++ b/src/workerd/jsg/buffersource-test.c++
@@ -65,6 +65,7 @@ struct BufferSourceContext: public jsg::Object, public jsg::ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(BufferSourceIsolate, BufferSourceContext);
 
 KJ_TEST("BufferSource works") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<BufferSourceContext, BufferSourceIsolate> e(v8System);
 
   // By default, a BufferSource handle is created as a DataView

--- a/src/workerd/jsg/dom-exception-test.c++
+++ b/src/workerd/jsg/dom-exception-test.c++
@@ -18,6 +18,7 @@ struct DOMExceptionContext: public Object, public ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(DOMExceptionIsolate, DOMExceptionContext);
 
 KJ_TEST("DOMException's prototype is ErrorPrototype") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<DOMExceptionContext, DOMExceptionIsolate> e(v8System);
   e.expectEval(
       "Object.getPrototypeOf(DOMException.prototype) === Error.prototype", "boolean", "true");

--- a/src/workerd/jsg/exception.h
+++ b/src/workerd/jsg/exception.h
@@ -39,6 +39,11 @@ namespace workerd::jsg {
 #define JSG_ASSERT(cond, jsErrorType, ...)                                                         \
   KJ_ASSERT(cond, kj::str(JSG_EXCEPTION(jsErrorType) ": ", ##__VA_ARGS__))
 
+// Asserts if the method is compatible with v8 fast api
+#define JSG_ASSERT_FASTAPI(TypeWrapper, Method, jsErrorType, ...)                                  \
+  KJ_ASSERT(isFastMethodCompatible<TypeWrapper, Method>,                                           \
+      kj::str(JSG_EXCEPTION(jsErrorType) ": ", ##__VA_ARGS__));
+
 #define JSG_REQUIRE(cond, jsErrorType, ...)                                                        \
   KJ_REQUIRE(cond, kj::str(JSG_EXCEPTION(jsErrorType) ": ", ##__VA_ARGS__))
 // Unlike KJ_REQUIRE, JSG_REQUIRE passes all message arguments through kj::str which makes it

--- a/src/workerd/jsg/fast-api-test.c++
+++ b/src/workerd/jsg/fast-api-test.c++
@@ -1,0 +1,409 @@
+#include "jsg-test.h"
+
+#include <workerd/util/autogate.h>
+
+namespace workerd::jsg::test {
+namespace {
+
+using jsg::CallCounter;
+
+struct WrappedInt {
+  int32_t i;
+
+  JSG_STRUCT(i);
+};
+
+class StaticMethodContainer: public jsg::Object {
+ public:
+  StaticMethodContainer() = default;
+
+  static int32_t staticMethod() {
+    return 42;
+  }
+
+  uint32_t getValue() const {
+    return value;
+  }
+
+  void setValue(uint32_t value_) {
+    value = value_;
+  }
+
+  JSG_RESOURCE_TYPE(StaticMethodContainer) {
+    JSG_STATIC_METHOD(staticMethod);
+    JSG_PROTOTYPE_PROPERTY(value, getValue, setValue);
+  }
+
+ private:
+  uint32_t value = 42;
+};
+
+class FastMethodContext: public jsg::Object, public jsg::ContextGlobal {
+ public:
+  int32_t add(int32_t a, int32_t b) {
+    return a + b;
+  }
+
+  int32_t processValue(v8::Local<v8::Value> value) {
+    KJ_ASSERT(value->IsNumber(), "Value must be a number");
+    return value.As<v8::Int32>()->Value();
+  }
+
+  // When arbitrary type unwrapping is supported, keep this test as it is.
+  int32_t processObject(v8::Local<v8::Object> obj) {
+    auto isolate = v8::Isolate::GetCurrent();
+    auto context = isolate->GetCurrentContext();
+    auto testKey = v8::String::NewFromUtf8(isolate, "test").ToLocalChecked();
+    v8::Local<v8::Value> value;
+    if (obj->Get(context, testKey).ToLocal(&value)) {
+      v8::String::Utf8Value type(isolate, value->TypeOf(isolate));
+      KJ_ASSERT(value->IsInt32(), "Received ", *type);
+      return value.As<v8::Int32>()->Value();
+    }
+    return 0;
+  }
+
+  void voidMethod(uint32_t a, uint32_t b) {
+    // Do nothing. This is testing void return type.
+  }
+
+  int32_t throwError(int32_t code) {
+    if (code > 0) {
+      JSG_FAIL_REQUIRE(TypeError, "Test error with code ", code);
+    }
+    return 0;
+  }
+
+  int32_t addWithLock(jsg::Lock& js, int32_t a, v8::Local<v8::Value> b) {
+    KJ_ASSERT(b->IsNumber(), "Second parameter must be a number");
+    int32_t bValue = b.As<v8::Int32>()->Value();
+    return a + bValue;
+  }
+
+  int32_t constAdd(int32_t a, int32_t b) {
+    return a + b;
+  }
+
+  int32_t constAddWithLock(jsg::Lock& js, int32_t a, int32_t b) {
+    return a + b;
+  }
+
+  int32_t unwrapStruct(jsg::Lock& js, WrappedInt w) {
+    return w.i;
+  }
+
+  int32_t unwrapUint(jsg::Lock& js, kj::uint u) {
+    return u;
+  }
+
+  int32_t unwrapString(jsg::Lock& js, kj::String str) {
+    return str.size();
+  }
+
+  int32_t unwrapBufferSource(jsg::Lock& js, jsg::BufferSource source) {
+    return source.size();
+  }
+
+  int32_t unwrapMaybe(jsg::Lock& js, kj::Maybe<kj::String> str) {
+    KJ_IF_SOME(s, str) {
+      return s.size();
+    } else {
+      return -1;
+    }
+  }
+
+  int32_t unwrapOptional(jsg::Lock& js, jsg::Optional<kj::String> str) {
+    KJ_IF_SOME(s, str) {
+      return s.size();
+    } else {
+      return -1;
+    }
+  }
+
+  int32_t unwrapLenientOptional(jsg::Lock& js, jsg::LenientOptional<kj::String> str) {
+    KJ_IF_SOME(s, str) {
+      return s.size();
+    } else {
+      return -1;
+    }
+  }
+
+  jsg::Ref<StaticMethodContainer> newContainer() {
+    return jsg::alloc<StaticMethodContainer>();
+  }
+
+  JSG_RESOURCE_TYPE(FastMethodContext) {
+    JSG_NESTED_TYPE(StaticMethodContainer);
+
+    JSG_METHOD(add);
+    JSG_METHOD(processValue);
+    JSG_METHOD(processObject);
+    JSG_METHOD(voidMethod);
+    JSG_METHOD(throwError);
+    JSG_METHOD(addWithLock);
+    JSG_METHOD(constAdd);
+    JSG_METHOD(constAddWithLock);
+    JSG_METHOD(unwrapStruct);
+    JSG_METHOD(unwrapUint);
+    JSG_METHOD(unwrapString);
+    JSG_METHOD(unwrapBufferSource);
+    JSG_METHOD(unwrapMaybe);
+    JSG_METHOD(unwrapOptional);
+    JSG_METHOD(unwrapLenientOptional);
+
+    JSG_METHOD(newContainer);
+  }
+};
+
+JSG_DECLARE_DEBUG_ISOLATE_TYPE(
+    FastMethodIsolate, FastMethodContext, WrappedInt, StaticMethodContainer);
+
+jsg::V8System v8System({"--allow-natives-syntax"});
+
+struct Test {
+  kj::LiteralStringConst expr;
+  kj::LiteralStringConst expectedReturnType;
+  kj::LiteralStringConst expectedReturnValue;
+  kj::LiteralStringConst target = ""_kjc;
+  kj::uint expectedSlowCount = 1;
+};
+
+CallCounter runTest(Test test) {
+  jsg::callCounter.reset();
+  jsg::test::Evaluator<FastMethodContext, FastMethodIsolate> e(v8System);
+
+  auto target = test.target == ""_kjc ? kj::str(test.expr) : kj::str(test.target, ".", test.expr);
+  e.expectEval(target, test.expectedReturnType, test.expectedReturnValue);
+  KJ_ASSERT(jsg::callCounter == CallCounter(test.expectedSlowCount, 0));
+
+  e.expectEval(kj::str("const fastCall = () => { return ", target,
+                   "; }; "
+                   "%PrepareFunctionForOptimization(fastCall); "
+                   "fastCall(); "
+                   "%OptimizeFunctionOnNextCall(fastCall); "
+                   "fastCall()"),
+      test.expectedReturnType, test.expectedReturnValue);
+  return jsg::callCounter;
+}
+
+KJ_TEST("v8::Local<v8::Value> and v8::Local<v8::Object> as fast method parameters") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
+  KJ_ASSERT(runTest({"processValue(42)"_kjc, "number"_kjc, "42"_kjc}) == CallCounter(2, 1));
+  KJ_ASSERT(
+      runTest({"processObject({test: 123})"_kjc, "number"_kjc, "123"_kjc}) == CallCounter(2, 1));
+}
+
+KJ_TEST("Lock& as the first parameter in fast method calls") {
+  KJ_ASSERT(runTest({"addWithLock(3, 4)"_kjc, "number"_kjc, "7"_kjc}) == CallCounter(2, 1));
+}
+
+KJ_TEST("Const methods in fast method calls") {
+  KJ_ASSERT(runTest({"constAdd(3, 4)"_kjc, "number"_kjc, "7"_kjc}) == CallCounter(2, 1));
+}
+
+KJ_TEST("Const methods with Lock& in fast method calls") {
+  KJ_ASSERT(runTest({"constAddWithLock(3, 4)"_kjc, "number"_kjc, "7"_kjc}) == CallCounter(2, 1));
+}
+
+KJ_TEST("type unwrapping arguments") {
+  KJ_ASSERT(runTest({"unwrapUint(4)"_kjc, "number"_kjc, "4"_kjc}) == CallCounter(2, 1));
+  KJ_ASSERT(runTest({"unwrapStruct({i: 3})"_kjc, "number"_kjc, "3"_kjc}) == CallCounter(2, 1));
+  KJ_ASSERT(runTest({"unwrapString('0123')"_kjc, "number"_kjc, "4"_kjc}) == CallCounter(2, 1));
+  KJ_ASSERT(runTest({"unwrapBufferSource(new Uint8Array(256))"_kjc, "number"_kjc, "256"_kjc}) ==
+      CallCounter(2, 1));
+  KJ_ASSERT(runTest({"unwrapMaybe(undefined)"_kjc, "number"_kjc, "-1"_kjc}) == CallCounter(2, 1));
+  KJ_ASSERT(runTest({"unwrapMaybe('foo')"_kjc, "number"_kjc, "3"_kjc}) == CallCounter(2, 1));
+  KJ_ASSERT(
+      runTest({"unwrapOptional(undefined)"_kjc, "number"_kjc, "-1"_kjc}) == CallCounter(2, 1));
+  KJ_ASSERT(runTest({"unwrapOptional('foo')"_kjc, "number"_kjc, "3"_kjc}) == CallCounter(2, 1));
+  KJ_ASSERT(runTest({"unwrapLenientOptional(undefined)"_kjc, "number"_kjc, "-1"_kjc}) ==
+      CallCounter(2, 1));
+  KJ_ASSERT(
+      runTest({"unwrapLenientOptional('foo')"_kjc, "number"_kjc, "3"_kjc}) == CallCounter(2, 1));
+
+  KJ_ASSERT(runTest({"StaticMethodContainer.staticMethod()"_kjc, "number"_kjc, "42"_kjc}) ==
+      CallCounter(2, 1));
+}
+
+KJ_TEST("Fast methods should work with getters/setters") {
+  KJ_ASSERT(
+      runTest({"value"_kjc, "number"_kjc, "42"_kjc, "newContainer()"_kjc, 2}) == CallCounter(5, 1));
+  KJ_ASSERT(runTest({"value = 12"_kjc, "number"_kjc, "12"_kjc, "newContainer()"_kjc, 2}) ==
+      CallCounter(5, 1));
+}
+
+KJ_TEST("Fast methods properly catch JSG_FAIL_REQUIRE errors") {
+  jsg::callCounter.reset();
+  jsg::test::Evaluator<FastMethodContext, FastMethodIsolate> e(v8System);
+
+  // Test that directly calling the method results in an error
+  e.expectEval("throwError(42)", "throws", "TypeError: Test error with code 42");
+  KJ_ASSERT(jsg::callCounter == CallCounter(1, 0));
+
+  // First run a non-throwing call to allow optimization
+  e.expectEval("throwError(0)", "number", "0");
+  KJ_ASSERT(jsg::callCounter == CallCounter(2, 0));
+
+  e.expectEval("function fastThrow(code) { return throwError(code); }; "
+               "%PrepareFunctionForOptimization(fastThrow); "
+               "fastThrow(0); "
+               "%OptimizeFunctionOnNextCall(fastThrow); "
+               "fastThrow(42)",
+      "throws", "TypeError: Test error with code 42");
+
+  // The counts should now include both the slow path and fast path calls
+  // 3 slow path calls (original direct call + non-throwing call + the initial optimization call that didn't throw)
+  // 1 fast path call (the optimized call that threw an error)
+  KJ_ASSERT(jsg::callCounter == CallCounter(3, 1));
+}
+
+KJ_TEST("isFastMethodCompatible Detection") {
+  static_assert(
+      FastApiWrappedObject<FastMethodIsolate_TypeWrapper, kj::String>, "should be compatible");
+
+  static_assert(FastApiParam<FastMethodIsolate_TypeWrapper, WrappedInt>, "should be compatible");
+
+  static_assert(FastApiParam<FastMethodIsolate_TypeWrapper, kj::OneOf<kj::String, WrappedInt>>,
+      "should be compatible");
+
+  static_assert(!FastApiParam<FastMethodIsolate_TypeWrapper, WrappedInt&>, "should be compatible");
+
+  struct Foo {};
+
+  static_assert(!FastApiWrappedObject<FastMethodIsolate_TypeWrapper, Foo>, "foo is not a jsg type");
+
+  static_assert(!FastApiWrappedObject<FastMethodIsolate_TypeWrapper, jsg::Lock&>,
+      "lock is not a wrapped type");
+
+  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper,
+                    void (FastMethodContext::*)(bool, jsg::Lock&)>,
+      "lock is accepted only as first argument");
+
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper,
+                    void (FastMethodContext::*)(jsg::Lock&, bool)>,
+      "lock is accepted only as first argument");
+
+  // Method type declarations
+  // -----------------------
+
+  // Compatible basic types
+  using VoidMethod = void (FastMethodContext::*)();
+  using IntMethod = int32_t (FastMethodContext::*)(int32_t);
+  using BoolMethod = bool (FastMethodContext::*)(double, bool);
+  using FloatMethod = float (FastMethodContext::*)(int32_t, float);
+
+  // V8 Local types as parameters - should be compatible
+  using V8ValueParamMethod = int32_t (FastMethodContext::*)(v8::Local<v8::Value>);
+  using V8ObjectParamMethod = int32_t (FastMethodContext::*)(v8::Local<v8::Object>);
+
+  // Const method variants - should be compatible
+  using ConstIntMethod = int32_t (FastMethodContext::*)(int32_t) const;
+  using ConstFloatMethod = float (FastMethodContext::*)(float) const;
+
+  // Methods with Lock& as first parameter - should be compatible
+  using LockFirstMethod = int32_t (FastMethodContext::*)(jsg::Lock&, int32_t);
+  using LockFirstVoidMethod = void (FastMethodContext::*)(jsg::Lock&, bool);
+  using LockFirstWithV8Local = int32_t (FastMethodContext::*)(jsg::Lock&, v8::Local<v8::Value>);
+  using ConstLockFirstMethod = int32_t (FastMethodContext::*)(jsg::Lock&, int32_t) const;
+
+  // ---- Non-compatible method types ----
+
+  // Pointer types - not compatible
+  using PointerParamMethod = void* (FastMethodContext::*)(void*);
+  using PointerReturnMethod = void* (FastMethodContext::*)();
+
+  // V8 Local as return type - not compatible
+  using V8ReturnMethod = v8::Local<v8::Value> (FastMethodContext::*)(int32_t);
+
+  // Non-primitive types - not compatible
+  using StringMethod = kj::String (FastMethodContext::*)(kj::String);
+  using ComplexMethod = Ref<FastMethodContext> (FastMethodContext::*)(jsg::Lock&);
+  using KjArrayMethod = kj::Array<int> (FastMethodContext::*)(int32_t);
+  using PromiseMethod = jsg::Promise<int> (FastMethodContext::*)(int32_t);
+  using MaybeVoidMethod = kj::Maybe<void> (FastMethodContext::*)();
+  using PointerMethod = void(v8::Isolate*);
+  using ReferenceMethod = void(v8::Isolate&);
+  using StaticMethodContainerReferenceMethod = void(StaticMethodContainer&);
+  using StaticMethodContainerMethod = void(StaticMethodContainer);
+
+  // Static assertions for compatible method types
+  // --------------------------------------------
+
+  // Basic primitives
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, VoidMethod>,
+      "Void methods should be fast-method compatible");
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, IntMethod>,
+      "Integer methods should be fast-method compatible");
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, BoolMethod>,
+      "Boolean methods should be fast-method compatible");
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, FloatMethod>,
+      "Float methods should be fast-method compatible");
+
+  // V8 Local parameters
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, V8ValueParamMethod>,
+      "Methods with v8::Local<v8::Value> parameters should be fast-method compatible");
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, V8ObjectParamMethod>,
+      "Methods with v8::Local<v8::Object> parameters should be fast-method compatible");
+
+  // Const methods
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, ConstIntMethod>,
+      "Const methods should be fast-method compatible");
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, ConstFloatMethod>,
+      "Const methods with float should be fast-method compatible");
+
+  // Lock& as first parameter
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, LockFirstMethod>,
+      "Methods with Lock& as first parameter should be fast-method compatible");
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, LockFirstVoidMethod>,
+      "Void methods with Lock& as first parameter should be fast-method compatible");
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, LockFirstWithV8Local>,
+      "Methods with Lock& and v8::Local params should be fast-method compatible");
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, ConstLockFirstMethod>,
+      "Const methods with Lock& as first parameter should be fast-method compatible");
+
+  // Complex methods
+  static_assert(FastApiParam<FastMethodIsolate_TypeWrapper, WrappedInt>,
+      "JSG_STRUCT as a parameter is supported");
+
+  // Static assertions for incompatible method types
+  // ----------------------------------------------
+
+  // Pointer types
+  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper, PointerParamMethod>,
+      "Methods with pointer parameters should not be fast-method compatible");
+  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper, PointerReturnMethod>,
+      "Methods returning pointers should not be fast-method compatible");
+
+  // V8 Local return type
+  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper, V8ReturnMethod>,
+      "Methods returning v8::Local<v8::Value> should not be fast-method compatible");
+
+  // Complex types
+  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper, StringMethod>,
+      "Methods with kj::String parameters should not be fast-method compatible");
+  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper, ComplexMethod>,
+      "Methods with Ref return types should not be fast-method compatible");
+  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper, KjArrayMethod>,
+      "Methods returning kj::Array should not be fast-method compatible");
+  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper, PromiseMethod>,
+      "Methods returning Promise should not be fast-method compatible");
+  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper, MaybeVoidMethod>,
+      "Methods returning Maybe<void> should not be fast-method compatible");
+  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper, PointerMethod>,
+      "Methods that have a parameter of v8::Isolate* should not be fast-method compatible");
+  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper, ReferenceMethod>,
+      "Methods that have a parameter of a reference should not be fast-method compatible");
+  static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, StaticMethodContainerMethod>,
+      "This should be compatible");
+  static_assert(
+      !isFastMethodCompatible<FastMethodIsolate_TypeWrapper, StaticMethodContainerReferenceMethod>,
+      "Methods that have a parameter of a reference should not be fast-method compatible");
+
+  // jsg::test::Evaluator<FastMethodContext, FastMethodIsolate> e(v8System);
+  // auto& wrapper = FastMethodIsolate_TypeWrapper::from(e.getIsolate().ptr);
+  // Foo foo = wrapper.unwrap<Foo>(
+  //     v8::Local<v8::Context>(), v8::Local<v8::Value>(), TypeErrorContext::arrayElement(1));
+}
+
+}  // namespace
+}  // namespace workerd::jsg::test

--- a/src/workerd/jsg/fast-api.h
+++ b/src/workerd/jsg/fast-api.h
@@ -1,0 +1,98 @@
+#pragma once
+
+// Fast API implementation for workerd
+//
+// This file provides utilities to support V8 Fast API Calls, which allow optimized
+// method calls from JavaScript to C++ without going through the V8 API. Fast API
+// Calls perform type checks in the compiler instead of on the embedder side and
+// are subject to strict limitations - they cannot allocate on the JS heap or
+// trigger JS execution.
+//
+// The implementation provides concepts and helpers to determine which types and methods
+// are compatible with Fast API, handling both primitive types that can be passed directly
+// and wrapped objects that require conversion between JavaScript and C++.
+
+#include <workerd/jsg/web-idl.h>
+
+#include <v8-fast-api-calls.h>
+#include <v8-local-handle.h>
+#include <v8-value.h>
+
+#include <kj/common.h>
+
+namespace workerd::jsg {
+
+// These types are passed by fast api as is and do not require wrapping/unwrapping.
+template <typename T>
+concept FastApiPrimitive = kj::isSameType<T, void>() || kj::isSameType<T, bool>() ||
+    kj::isSameType<T, int32_t>() || kj::isSameType<T, int64_t>() || kj::isSameType<T, uint32_t>() ||
+    kj::isSameType<T, uint64_t>() || kj::isSameType<T, float>() || kj::isSameType<T, double>();
+
+// These types can be wrapped/unwrapped from v8::Value using given TypeWrapper
+template <typename TypeWrapper, typename T>
+concept WrappedType = requires(
+    TypeWrapper wrapper, v8::Local<v8::Context> context, v8::Local<v8::Value> value, T* ptr) {
+  wrapper.tryUnwrap(context, value, ptr, kj::none);
+};
+
+// these types are passed by fast api as v8::Value and require unwrapping
+template <typename TypeWrapper, typename T>
+concept FastApiWrappedObject = WrappedType<TypeWrapper, T> && !FastApiPrimitive<T>;
+
+// Helper to determine if a type can be used as a parameter in V8 Fast API
+template <typename TypeWrapper, typename T>
+concept FastApiParam = FastApiPrimitive<T> || FastApiWrappedObject<TypeWrapper, T>;
+
+// Helper to determine if a type can be used as a return value in a V8 Fast API
+template <typename T>
+concept FastApiReturnParam = FastApiPrimitive<T>;
+
+// Helper to determine if a method can be used with V8 fast API
+template <typename TypeWrapper, typename Ret, typename... Args>
+concept FastApiMethod = FastApiReturnParam<Ret> && (FastApiParam<TypeWrapper, Args> && ...);
+
+// Helper to determine if a method pointer type is compatible with Fast API
+template <typename TypeWrapper, typename Method>
+constexpr bool isFastMethodCompatible = false;
+
+// Specialization for non-static member functions
+template <typename TypeWrapper, typename Class, typename Ret, typename... Args>
+constexpr bool isFastMethodCompatible<TypeWrapper, Ret (Class::*)(Args...)> =
+    FastApiMethod<TypeWrapper, Ret, Args...>;
+
+// Specialization for const non-static member functions
+template <typename TypeWrapper, typename Class, typename Ret, typename... Args>
+constexpr bool isFastMethodCompatible<TypeWrapper, Ret (Class::*)(Args...) const> =
+    FastApiMethod<TypeWrapper, Ret, Args...>;
+
+template <typename TypeWrapper, typename Class, typename Ret, typename... Args>
+constexpr bool isFastMethodCompatible<TypeWrapper, Ret (Class::*)(jsg::Lock&, Args...)> =
+    FastApiMethod<TypeWrapper, Ret, Args...>;
+
+template <typename TypeWrapper, typename Class, typename Ret, typename... Args>
+constexpr bool isFastMethodCompatible<TypeWrapper, Ret (Class::*)(jsg::Lock&, Args...) const> =
+    FastApiMethod<TypeWrapper, Ret, Args...>;
+
+// Specialization for static functions
+template <typename TypeWrapper, typename Ret, typename... Args>
+constexpr bool isFastMethodCompatible<TypeWrapper, Ret(Args...)> =
+    FastApiMethod<TypeWrapper, Ret, Args...>;
+
+template <typename TypeWrapper, typename Ret, typename... Args>
+constexpr bool isFastMethodCompatible<TypeWrapper, Ret(jsg::Lock&, Args...)> =
+    FastApiMethod<TypeWrapper, Ret, Args...>;
+
+template <typename TypeWrapper, typename T>
+struct FastApiJSGToV8 {
+  // We allow every type to be passed into v8 fast api using v8::Local<v8::Value>
+  // conversion.
+  using value = v8::Local<v8::Value>;
+};
+
+template <typename TypeWrapper, typename T>
+  requires FastApiPrimitive<T>
+struct FastApiJSGToV8<TypeWrapper, T> {
+  using value = T;
+};
+
+}  // namespace workerd::jsg

--- a/src/workerd/jsg/function-test.c++
+++ b/src/workerd/jsg/function-test.c++
@@ -44,6 +44,7 @@ struct CallbackContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(CallbackIsolate, CallbackContext, CallbackContext::Frobber, NumberBox);
 
 KJ_TEST("callbacks") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<CallbackContext, CallbackIsolate> e(v8System);
   e.expectEval("callCallback((str, num) => {\n"
                "  return [typeof str, str, typeof num, num.toString(), 'bar'].join(', ');\n"

--- a/src/workerd/jsg/iterator-test.c++
+++ b/src/workerd/jsg/iterator-test.c++
@@ -4,6 +4,8 @@
 
 #include "jsg-test.h"
 
+#include <workerd/util/autogate.h>
+
 namespace workerd::jsg::test {
 namespace {
 
@@ -12,7 +14,6 @@ V8System v8System;
 struct GeneratorContext: public Object, public ContextGlobal {
 
   uint generatorTest(Lock& js, Generator<kj::String> generator) {
-
     KJ_DEFER(generator.forEach(
         js, [](auto& js, auto, auto&) { KJ_FAIL_ASSERT("Should not have been called"); }));
 
@@ -190,6 +191,7 @@ struct GeneratorContext: public Object, public ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(GeneratorIsolate, GeneratorContext, GeneratorContext::Test);
 
 KJ_TEST("Generator works") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<GeneratorContext, GeneratorIsolate> e(v8System);
 
   e.expectEval("generatorTest([undefined,2,3])", "number", "2");

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -43,6 +43,7 @@ struct TestContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(TestIsolate, TestContext);
 
 KJ_TEST("hello world") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<TestContext, TestIsolate> e(v8System);
   e.expectEval("'Hello' + ', World!'", "string", "Hello, World!");
 }

--- a/src/workerd/jsg/jsvalue-test.c++
+++ b/src/workerd/jsg/jsvalue-test.c++
@@ -109,6 +109,7 @@ struct JsValueContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(JsValueIsolate, JsValueContext, JsValueContext::Foo);
 
 KJ_TEST("simple") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<JsValueContext, JsValueIsolate> e(v8System);
   e.expectEval("takeJsValue(false)", "boolean", "false");
   e.expectEval("takeJsString(123)", "string", "123");

--- a/src/workerd/jsg/memory-test.c++
+++ b/src/workerd/jsg/memory-test.c++
@@ -40,7 +40,7 @@ void runTest(auto callback) {
 }
 
 KJ_TEST("MemoryTracker test") {
-
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   // Verifies that workerd details are included in the heapsnapshot.
   // This is not a comprehensive test of the heapsnapshot content,
   // it is designed just to make sure that we are, in fact, publishing

--- a/src/workerd/jsg/modules-new-test.c++
+++ b/src/workerd/jsg/modules-new-test.c++
@@ -123,6 +123,8 @@ JSG_DECLARE_ISOLATE_TYPE(TestIsolate, TestContext, TestType);
 // ======================================================================================
 
 KJ_TEST("An empty registry") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
+
   // We should be able to create an empty registry that returns nothing.
   // Basic resolution of this kind does not require an isolate lock.
 

--- a/src/workerd/jsg/multiple-typewrappers-test.c++
+++ b/src/workerd/jsg/multiple-typewrappers-test.c++
@@ -137,6 +137,7 @@ void expectEval(
 }
 
 KJ_TEST("Create a context with a configuration then create a default context with another") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   capnp::MallocMessageBuilder flagsArena;
   auto flags = flagsArena.initRoot<::workerd::CompatibilityFlags>();
   auto flagsReader = flags.asReader();

--- a/src/workerd/jsg/promise-test.c++
+++ b/src/workerd/jsg/promise-test.c++
@@ -118,6 +118,7 @@ struct PromiseContext: public jsg::Object, public jsg::ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(PromiseIsolate, PromiseContext);
 
 KJ_TEST("jsg::Promise<T>") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<PromiseContext, PromiseIsolate> e(v8System);
 
   e.expectEval("setResult(promise.then(i => i + 1 /* oops, i is a string */));\n"

--- a/src/workerd/jsg/resource-test.c++
+++ b/src/workerd/jsg/resource-test.c++
@@ -21,6 +21,7 @@ struct BoxContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(BoxIsolate, BoxContext, NumberBox, BoxBox);
 
 KJ_TEST("constructors and properties") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<BoxContext, BoxIsolate> e(v8System);
   e.expectEval("new NumberBox(123).value", "number", "123");
   e.expectEval("new NumberBox(123).boxed.value", "number", "123");

--- a/src/workerd/jsg/rtti-test.c++
+++ b/src/workerd/jsg/rtti-test.c++
@@ -215,6 +215,7 @@ struct TestResource: public Base {
 };
 
 KJ_TEST("resource reference") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   KJ_EXPECT(tType<TestResource>() ==
       "(structure = (name = \"TestResource\", fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestResource\"))");
 }

--- a/src/workerd/jsg/ser-test.c++
+++ b/src/workerd/jsg/ser-test.c++
@@ -238,6 +238,7 @@ struct SerTestContextV2: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(SerTestIsolateV2, SerTestContextV2, SerTestContextV2::Bar);
 
 KJ_TEST("serialization") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<SerTestContext, SerTestIsolate> e(v8System);
 
   // Test serializing built-in values.

--- a/src/workerd/jsg/setup-test.c++
+++ b/src/workerd/jsg/setup-test.c++
@@ -15,6 +15,7 @@ struct EvalContext: public Object, public ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(EvalIsolate, EvalContext);
 
 KJ_TEST("eval() is blocked") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<EvalContext, EvalIsolate> e(v8System);
   e.expectEval("eval('123')", "throws",
       "EvalError: Code generation from strings disallowed for this context");

--- a/src/workerd/jsg/struct-test.c++
+++ b/src/workerd/jsg/struct-test.c++
@@ -42,6 +42,7 @@ struct StructContext: public Object, public ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(StructIsolate, StructContext, NumberBox, TestStruct, SelfStruct);
 
 KJ_TEST("structs") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<StructContext, StructIsolate> e(v8System);
   e.expectEval(
       "readTestStruct({str: 'foo', num: 123, box: new NumberBox(456)})", "string", "foo, 123, 456");

--- a/src/workerd/jsg/tracing-test.c++
+++ b/src/workerd/jsg/tracing-test.c++
@@ -165,6 +165,7 @@ JSG_DECLARE_ISOLATE_TYPE(TraceTestIsolate,
     ValueBox);
 
 KJ_TEST("GC collects objects when expected") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<TraceTestContext, TraceTestIsolate> e(v8System);
 
   // Test that a full GC can collect native objects.

--- a/src/workerd/jsg/type-wrapper-test.c++
+++ b/src/workerd/jsg/type-wrapper-test.c++
@@ -61,6 +61,7 @@ class TestExtension {
 JSG_DECLARE_ISOLATE_TYPE(ExtensionIsolate, ExtensionContext, TypeWrapperExtension<TestExtension>);
 
 KJ_TEST("extensions") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<ExtensionContext, ExtensionIsolate> e(v8System);
   e.expectEval("fromExtensionType(toExtensionType(12.3))", "number", "12");
 }

--- a/src/workerd/jsg/util-test.c++
+++ b/src/workerd/jsg/util-test.c++
@@ -23,6 +23,7 @@ struct FreezeContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(FreezeIsolate, FreezeContext);
 
 KJ_TEST("recursive freezing") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<FreezeContext, FreezeIsolate> e(v8System);
   e.expectEval("let obj = { foo: [ { bar: 1 } ] };\n"
                "recursivelyFreeze(obj);\n"

--- a/src/workerd/jsg/value-test.c++
+++ b/src/workerd/jsg/value-test.c++
@@ -21,6 +21,7 @@ struct BoolContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(BoolIsolate, BoolContext);
 
 KJ_TEST("bool") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<BoolContext, BoolIsolate> e(v8System);
   e.expectEval("takeBool(false)", "string", "false");
   e.expectEval("takeBool(true)", "string", "true");

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -78,3 +78,9 @@ wd_cc_benchmark(
         "//src/workerd/util",
     ],
 )
+
+wd_cc_benchmark(
+    name = "bench-fast-api",
+    srcs = ["bench-fast-api.c++"],
+    deps = ["//src/workerd/jsg"],
+)

--- a/src/workerd/tests/bench-fast-api.c++
+++ b/src/workerd/tests/bench-fast-api.c++
@@ -1,0 +1,126 @@
+// Copyright (c) 2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include <workerd/jsg/jsg.h>
+#include <workerd/jsg/setup.h>
+#include <workerd/tests/bench-tools.h>
+
+namespace workerd {
+namespace {
+
+class FastMethodContext: public jsg::Object, public jsg::ContextGlobal {
+ public:
+  int32_t slowAdd(int32_t a, int32_t b) {
+    return a + b;
+  }
+
+  int32_t slowAddWithLock(jsg::Lock& js, int32_t a, v8::Local<v8::Value> b) {
+    int32_t bValue = b.As<v8::Int32>()->Value();
+    return a + bValue;
+  }
+
+  JSG_RESOURCE_TYPE(FastMethodContext) {
+    JSG_METHOD(slowAdd);
+    JSG_METHOD(slowAddWithLock);
+  }
+};
+
+JSG_DECLARE_ISOLATE_TYPE(FastMethodIsolate, FastMethodContext);
+
+jsg::V8System system;
+
+struct FastMethodFixture: public benchmark::Fixture {
+  virtual ~FastMethodFixture() noexcept(true) {}
+
+  void SetUp(benchmark::State& state) noexcept(true) override {}
+
+  void TearDown(benchmark::State& state) noexcept(true) override {}
+};
+
+// Benchmark the slow method
+BENCHMARK_F(FastMethodFixture, SlowAPI)(benchmark::State& state) {
+  FastMethodIsolate isolate(system, kj::heap<jsg::IsolateObserver>(), {});
+  auto code =
+      "var result = 0; for (let i = 0; i < 10000; i++) { result += slowAdd(2, 3); } result"_kj;
+
+  isolate.runInLockScope([&](FastMethodIsolate::Lock& isolateLock) {
+    auto context = isolateLock.newContext<FastMethodContext>();
+
+    return JSG_WITHIN_CONTEXT_SCOPE(
+        isolateLock, context.getHandle(isolateLock), [&](jsg::Lock& js) {
+      v8::Local<v8::String> source = jsg::v8Str(js.v8Isolate, code);
+
+      // Compile the source code.
+      v8::Local<v8::Script> script;
+      KJ_ASSERT(v8::Script::Compile(js.v8Context(), source).ToLocal(&script));
+
+      // Run the script to get the result.
+      for (auto _: state) {
+        v8::Local<v8::Value> result;
+        KJ_ASSERT(script->Run(js.v8Context()).ToLocal(&result));
+        v8::String::Utf8Value value(js.v8Isolate, result);
+        KJ_ASSERT(*value == "50000"_kj, *value);
+      }
+    });
+  });
+}
+
+// Benchmark the slow method with Lock& parameter
+BENCHMARK_F(FastMethodFixture, SlowAPIWithLock)(benchmark::State& state) {
+  FastMethodIsolate isolate(system, kj::heap<jsg::IsolateObserver>(), {});
+  auto code =
+      "var result = 0; for (let i = 0; i < 10000; i++) { result += slowAddWithLock(2, 3); } result"_kj;
+
+  isolate.runInLockScope([&](FastMethodIsolate::Lock& isolateLock) {
+    auto context = isolateLock.newContext<FastMethodContext>();
+
+    return JSG_WITHIN_CONTEXT_SCOPE(
+        isolateLock, context.getHandle(isolateLock), [&](jsg::Lock& js) {
+      v8::Local<v8::String> source = jsg::v8Str(js.v8Isolate, code);
+
+      // Compile the source code.
+      v8::Local<v8::Script> script;
+      KJ_ASSERT(v8::Script::Compile(js.v8Context(), source).ToLocal(&script));
+
+      // Run the script to get the result.
+      for (auto _: state) {
+        v8::Local<v8::Value> result;
+        KJ_ASSERT(script->Run(js.v8Context()).ToLocal(&result));
+        v8::String::Utf8Value value(js.v8Isolate, result);
+        KJ_ASSERT(*value == "50000"_kj, *value);
+      }
+    });
+  });
+}
+
+// Benchmark the fast method with Lock& parameter
+BENCHMARK_F(FastMethodFixture, FastAPIWithLock)(benchmark::State& state) {
+  FastMethodIsolate isolate(system, kj::heap<jsg::IsolateObserver>(), {});
+  auto code =
+      "var result = 0; for (let i = 0; i < 10000; i++) { result += fastAddWithLock(2, 3); } result"_kj;
+
+  isolate.runInLockScope([&](FastMethodIsolate::Lock& isolateLock) {
+    auto context = isolateLock.newContext<FastMethodContext>();
+
+    return JSG_WITHIN_CONTEXT_SCOPE(
+        isolateLock, context.getHandle(isolateLock), [&](jsg::Lock& js) {
+      v8::Local<v8::String> source = jsg::v8Str(js.v8Isolate, code);
+
+      // Compile the source code.
+      v8::Local<v8::Script> script;
+      KJ_ASSERT(v8::Script::Compile(js.v8Context(), source).ToLocal(&script));
+
+      // Run the script to get the result.
+      for (auto _: state) {
+        v8::Local<v8::Value> result;
+        KJ_ASSERT(script->Run(js.v8Context()).ToLocal(&result));
+        v8::String::Utf8Value value(js.v8Isolate, result);
+        KJ_ASSERT(*value == "50000"_kj, *value);
+      }
+    });
+  });
+}
+
+}  // namespace
+}  // namespace workerd

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -19,6 +19,8 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "test-workerd"_kj;
     case AutogateKey::RESCHEDULE_DESYNCED_SQLITE_ALARMS:
       return "reschedule-desynced-sqlite-alarms"_kj;
+    case AutogateKey::V8_FAST_API:
+      return "v8-fast-api"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -15,6 +15,7 @@ namespace workerd::util {
 enum class AutogateKey {
   TEST_WORKERD,
   RESCHEDULE_DESYNCED_SQLITE_ALARMS,
+  V8_FAST_API,
   NumOfKeys  // Reserved for iteration.
 };
 


### PR DESCRIPTION
Adds v8 fast api support to type wrapper and JSG.

TODO:

- [x] Find a way to test this
- [x] Add benchmarks
- [x] Support v8:Local<v8::Value> and v8::Local<v8::Object> as parameters
- [x] Support throwing error
- [x] Support const functions
- [x] Add support for jsg::Lock& in first argument
- [x] Add support for custom JSG structs and objects as parameters
- [x] Add support for all kj types
- [x] Add support for optional types
- [x] Automatically use fast APIs for method signatures that support it.
- [x] Call registerFastMethod() from JSG_STATIC_METHOD, and other possible macros.

BONUS:
- [ ] Add both FastOneByteString and v8::Local<v8::Value> function overload for kj::String (FastOneByteString is faster)
- [ ] Add a cfunction overload if the last parameter of the function is optional.
- [ ] Add function overloads, if there are multiple trailing optional parameters.

---

Used AI here and there to solve certain errors. Please review with caution.