### PR TITLE
Fix Python Workers when nodejs_compat_v2 is enabled.

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -875,7 +875,6 @@ void ServiceWorkerGlobalScope::reportError(jsg::Lock& js, jsg::JsValue error) {
 }
 
 jsg::JsValue ServiceWorkerGlobalScope::getBuffer(jsg::Lock& js) {
-  KJ_ASSERT(FeatureFlags::get(js).getNodeJsCompatV2());
   constexpr auto kSpecifier = "node:buffer"_kj;
   KJ_IF_SOME(module, js.resolveModule(kSpecifier)) {
     auto def = module.get(js, "default"_kj);
@@ -892,7 +891,6 @@ jsg::JsValue ServiceWorkerGlobalScope::getBuffer(jsg::Lock& js) {
 }
 
 jsg::JsValue ServiceWorkerGlobalScope::getProcess(jsg::Lock& js) {
-  KJ_ASSERT(FeatureFlags::get(js).getNodeJsCompatV2());
   constexpr auto kSpecifier = "node:process"_kj;
   KJ_IF_SOME(module, js.resolveModule(kSpecifier)) {
     auto def = module.get(js, "default"_kj);


### PR DESCRIPTION
For Python Workers the global scope is instantiated before a Worker::Isolate is created and with just a plain jsg::Lock rather than a Worker::Isolate::Lock. That means FeatureFlags::get(js) will fail.

Having this KJ_REQUIRE here does not serve any purpose as these APIs are already behind a compat flag in the JSG_RESOURCE definition.

There's something to be said about whether FeatureFlags::get(js) should even rely on Worker::Isolate::Lock but that does not need to be resolved in this PR. This PR is meant to provide an immediate fix to allow Python Workers to set nodejs_compat_v2.