### PR TITLE
Speed up reviews for experimental type changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@ RELEASE.md @cloudflare/wrangler @cloudflare/workers-runtime-1
 package.json @cloudflare/wrangler @cloudflare/workers-runtime-1
 pnpm-lock.yaml @cloudflare/wrangler @cloudflare/workers-runtime-1
 /types/ @cloudflare/wrangler
+/types/generated-snapshot/experimental/ @cloudflare/workers-runtime-1 @cloudflare/workers-durable-objects
 /src/cloudflare/ @cloudflare/wrangler
 src/workerd/tools/ @cloudflare/wrangler @cloudflare/workers-runtime-1 @cloudflare/workers-durable-objects
 src/workerd/io/supported-compatibility-date.txt @cloudflare/wrangler @cloudflare/workers-runtime-1


### PR DESCRIPTION
Based on previous discussions, I know we need to ask the Wrangler team to look at generated type changes. 

I'm wondering if it would be ok for us to be able to just change experimental types, though? It seems like we're using this for internal stuff that shouldn't affect users.

Happy to close this if it's not a good idea