### PR TITLE
Local dev: allow tailing the same worker

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -360,6 +360,14 @@ wd_test(
     ],
 )
 
+# Test for a worker that can log to itself using the isTracer parameter
+wd_test(
+    src = "self-logger-test.wd-test",
+    data = [
+        "self-logger-test.js",
+    ],
+)
+
 wd_test(
     src = "analytics-engine-test.wd-test",
     args = ["--experimental"],

--- a/src/workerd/api/self-logger-test.js
+++ b/src/workerd/api/self-logger-test.js
@@ -1,0 +1,61 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+import * as assert from 'node:assert';
+
+// Track if we've received logs in the tail handler
+let receivedLogsInTail = false;
+
+export default {
+  async fetch(request, env) {
+    // Log some messages that should be captured by the tail handler
+    console.log('Self-logger test: Message 1');
+    console.log('Self-logger test: Message 2');
+    console.error(new Error('Self-logger test: Error message'));
+
+    return new Response('Self-logger test completed');
+  },
+
+  // Tail handler in the same worker that generates logs
+  async tail(events) {
+    console.log(`Self-logger received ${events.length} events`);
+
+    // Check that we have the logs we expect
+    const logs = [];
+    for (const event of events) {
+      if (event.logs) {
+        for (const log of event.logs) {
+          logs.push(log.message[0]);
+        }
+      }
+    }
+
+    // Verify we're seeing the logs from our fetch handler
+    const foundMessage1 = logs.some((log) => log.includes('Message 1'));
+    const foundMessage2 = logs.some((log) => log.includes('Message 2'));
+    const foundError = logs.some((log) => log.includes('Error message'));
+
+    // Assert that we found our logs (this will throw if the test fails)
+    assert.ok(foundMessage1, 'Should have received "Message 1" in logs');
+    assert.ok(foundMessage2, 'Should have received "Message 2" in logs');
+    assert.ok(foundError, 'Should have received "Error message" in logs');
+    // If we get here, it means the self-logging functionality is working
+    receivedLogsInTail = true;
+  },
+};
+
+export const test = {
+  async test(ctrl, env, ctx) {
+    // This test simply verifies that the self-logger worked
+    // If the tail handler was called, receivedLogsInTail will be true
+    const response = await env.SERVICE.fetch('http://example.com/');
+    const body = await response.text();
+    assert.strictEqual(body, 'Self-logger test completed');
+    await scheduler.wait(100);
+    assert.strictEqual(
+      receivedLogsInTail,
+      true,
+      'Tail handler should have been called'
+    );
+  },
+};

--- a/src/workerd/api/self-logger-test.wd-test
+++ b/src/workerd/api/self-logger-test.wd-test
@@ -1,0 +1,19 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    (name = "self-logger", worker = .selfLoggerWorker),
+  ],
+);
+
+const selfLoggerWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "self-logger-test.js")
+  ],
+  bindings = [
+    ( name = "SERVICE", service = "self-logger" ),
+  ],
+  compatibilityDate = "2024-10-14",
+  compatibilityFlags = ["nodejs_compat"],
+  tails = ["self-logger"],
+);


### PR DESCRIPTION
This gets around the current limitation by allowing exactly one extra layer of depth. 
This should be enough for any real use case. 
Tail workers can now tail the same worker but they will not tail themselves. 
I believe this is what users would expect and is similar to what they get in prod.