### PR TITLE
Fix explicit template instantiations in zlib-util.c++

### DIFF
--- a/src/workerd/api/node/zlib-util.c++
+++ b/src/workerd/api/node/zlib-util.c++
@@ -927,28 +927,20 @@ void ZlibUtil::brotliWithCallback(
 
 #ifndef CREATE_TEMPLATE
 #define CREATE_TEMPLATE(T)                                                                         \
-  template void ZlibUtil::CompressionStream<T>::reset(jsg::Lock& js);                              \
+  template class ZlibUtil::CompressionStream<T>;                                                   \
   template void ZlibUtil::CompressionStream<T>::write<false>(jsg::Lock & js, int flush,            \
       jsg::Optional<kj::Array<kj::byte>> input, int inputOffset, int inputLength,                  \
       kj::Array<kj::byte> output, int outputOffset, int outputLength);                             \
   template void ZlibUtil::CompressionStream<T>::write<true>(jsg::Lock & js, int flush,             \
       jsg::Optional<kj::Array<kj::byte>> input, int inputOffset, int inputLength,                  \
-      kj::Array<kj::byte> output, int outputOffset, int outputLength);                             \
-  template jsg::Ref<ZlibUtil::CompressionStream<T>> ZlibUtil::CompressionStream<T>::constructor(   \
-      jsg::Lock& js, ZlibModeValue mode);
+      kj::Array<kj::byte> output, int outputOffset, int outputLength);
 
 CREATE_TEMPLATE(ZlibContext)
 CREATE_TEMPLATE(BrotliEncoderContext)
 CREATE_TEMPLATE(BrotliDecoderContext)
 
-template jsg::Ref<ZlibUtil::BrotliCompressionStream<BrotliEncoderContext>> ZlibUtil::
-    BrotliCompressionStream<BrotliEncoderContext>::constructor(jsg::Lock& js, ZlibModeValue mode);
-template jsg::Ref<ZlibUtil::BrotliCompressionStream<BrotliDecoderContext>> ZlibUtil::
-    BrotliCompressionStream<BrotliDecoderContext>::constructor(jsg::Lock& js, ZlibModeValue mode);
-template bool ZlibUtil::BrotliCompressionStream<BrotliEncoderContext>::initialize(
-    jsg::Lock&, jsg::BufferSource, jsg::BufferSource, jsg::Function<void()>);
-template bool ZlibUtil::BrotliCompressionStream<BrotliDecoderContext>::initialize(
-    jsg::Lock&, jsg::BufferSource, jsg::BufferSource, jsg::Function<void()>);
+template class ZlibUtil::BrotliCompressionStream<BrotliEncoderContext>;
+template class ZlibUtil::BrotliCompressionStream<BrotliDecoderContext>;
 
 template kj::Array<kj::byte> ZlibUtil::brotliSync<BrotliEncoderContext>(
     jsg::Lock& js, InputSource data, BrotliContext::Options opts);


### PR DESCRIPTION
Fixes #4022.  

For regular member functions, we can just explicitly instantiate the template for the entire class, instead of listing each function signature. However, if the member function has template arguments of its own, it still needs to be listed separately.

@anonrig Could you please check that this works locally for you as well - I don't want to end up swapping one linker problem for another.