### PR TITLE
[nfc] Use Request::sendIgnoringResult() to elide promise continuations

### DIFF
--- a/build/deps/gen/dep_capnp_cpp.bzl
+++ b/build/deps/gen/dep_capnp_cpp.bzl
@@ -2,11 +2,11 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-URL = "https://github.com/capnproto/capnproto/tarball/ff191c66c2bbff428c10923b5d4032087b592fe0"
-STRIP_PREFIX = "capnproto-capnproto-ff191c6/c++"
-SHA256 = "0d332fb8ce5909fa605b6ed0e5b97705f163a649f11b5d136c27efb4943ebc9f"
+URL = "https://github.com/capnproto/capnproto/tarball/cbdaa00ab5b121c98fc13418f21f81c7cec49367"
+STRIP_PREFIX = "capnproto-capnproto-cbdaa00/c++"
+SHA256 = "ecf00a12f0650cbd23e0bcf0611528a92f94fe99dff6b024d80bea1e8b77664a"
 TYPE = "tgz"
-COMMIT = "ff191c66c2bbff428c10923b5d4032087b592fe0"
+COMMIT = "cbdaa00ab5b121c98fc13418f21f81c7cec49367"
 
 def dep_capnp_cpp():
     http_archive(

--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -532,7 +532,7 @@ class AbortTriggerRpcClient final {
     auto req = client.abortRequest(capnp::MessageSize{reason.size() / sizeof(capnp::word) + 8, 0});
     auto field = req.initReason();
     field.setV8Serialized(reason);
-    return req.send().ignoreResult();
+    return req.sendIgnoringResult();
   }
 
   ~AbortTriggerRpcClient() noexcept(false) {
@@ -542,7 +542,7 @@ class AbortTriggerRpcClient final {
 
     auto req = client.releaseRequest(capnp::MessageSize{4, 0});
     // We call detach() on the resulting promise so that we can perform RPC in a destructor
-    req.send().ignoreResult().detach([](kj::Exception exc) {
+    req.sendIgnoringResult().detach([](kj::Exception exc) {
       if (exc.getType() == kj::Exception::Type::DISCONNECTED) {
         // It's possible we can't send the release message because we're already disconnected.
         return;

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -47,7 +47,7 @@ void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions)
     }
   }
 
-  IoContext::current().addTask(req.send().ignoreResult());
+  IoContext::current().addTask(req.sendIgnoringResult());
 
   running = true;
 }
@@ -56,7 +56,7 @@ jsg::Promise<void> Container::monitor(jsg::Lock& js) {
   JSG_REQUIRE(running, Error, "monitor() cannot be called on a container that is not running.");
 
   return IoContext::current()
-      .awaitIo(js, rpcClient->monitorRequest(capnp::MessageSize{4, 0}).send().ignoreResult())
+      .awaitIo(js, rpcClient->monitorRequest(capnp::MessageSize{4, 0}).sendIgnoringResult())
       .then(js, [this](jsg::Lock& js) {
     running = false;
     KJ_IF_SOME(d, destroyReason) {
@@ -79,7 +79,7 @@ jsg::Promise<void> Container::destroy(jsg::Lock& js, jsg::Optional<jsg::Value> e
   }
 
   return IoContext::current().awaitIo(
-      js, rpcClient->destroyRequest(capnp::MessageSize{4, 0}).send().ignoreResult());
+      js, rpcClient->destroyRequest(capnp::MessageSize{4, 0}).sendIgnoringResult());
 }
 
 void Container::signal(jsg::Lock& js, int signo) {
@@ -88,7 +88,7 @@ void Container::signal(jsg::Lock& js, int signo) {
 
   auto req = rpcClient->signalRequest(capnp::MessageSize{4, 0});
   req.setSigno(signo);
-  IoContext::current().addTask(req.send().ignoreResult());
+  IoContext::current().addTask(req.sendIgnoringResult());
 }
 
 // =======================================================================================

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -689,7 +689,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEventImpl::run(
         // already rejected.
         kj::String abortError;
         co_await ioContext.onAbort()
-            .then([] {}, [&abortError](kj::Exception&& e) {
+            .catch_([&abortError](kj::Exception&& e) {
           abortError = kj::str(e);
         }).exclusiveJoin(ioContext.afterLimitTimeout(1 * kj::MICROSECONDS).then([&abortError]() {
           abortError = kj::str("onAbort() promise has unexpectedly not yet been rejected");

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -4085,7 +4085,7 @@ jsg::Ref<ReadableStream> ReadableStream::from(
         .cancel =
             [generator = kj::addRef(*rcGenerator)](jsg::Lock& js, auto reason) mutable {
     return generator->generator.return_(js, kj::none)
-        .then(js, [genertor = kj::mv(generator)](auto& lock) {});
+        .then(js, [generator = kj::mv(generator)](auto& lock) {});
   },
       },
       StreamQueuingStrategy{

--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -629,7 +629,7 @@ kj::OneOf<ActorCache::GetResultList, kj::Promise<ActorCache::GetResultList>> Act
       list.set(i, keysToFetch[i].asBytes());
     }
     req.setStream(streamClient);
-    return req.send().ignoreResult();
+    return req.sendIgnoringResult();
   });
 
   // Wait on the RPC only until stream.end() is called, then report the results. We prevent
@@ -1102,7 +1102,7 @@ kj::OneOf<ActorCache::GetResultList, kj::Promise<ActorCache::GetResultList>> Act
     }
 
     req.setStream(streamClient);
-    return req.send().ignoreResult();
+    return req.sendIgnoringResult();
   });
 
   // Wait on the RPC only until stream.end() is called, then report the results. We prevent
@@ -1430,7 +1430,7 @@ kj::OneOf<ActorCache::GetResultList, kj::Promise<ActorCache::GetResultList>> Act
       req.setLimit(l - streamServerRef.fetchedEntries.size());
     }
     req.setStream(streamClient);
-    return req.send().ignoreResult();
+    return req.sendIgnoringResult();
   });
 
   // Wait on the RPC only until stream.end() is called, then report the results. We prevent
@@ -2696,7 +2696,7 @@ kj::Promise<void> ActorCache::flushImplUsingSinglePut(PutFlush putFlush) {
     auto writeObserver = recordStorageWrite(hooks, clock);
     util::DurationExceededLogger logger(
         clock, 1 * kj::SECONDS, "storage operation took longer than expected: single put");
-    co_await request.send().ignoreResult();
+    co_await request.sendIgnoringResult();
   }
 }
 
@@ -2723,7 +2723,7 @@ kj::Promise<void> ActorCache::flushImplUsingSingleMutedDelete(MutedDeleteFlush m
     auto writeObserver = recordStorageWrite(hooks, clock);
     util::DurationExceededLogger logger(
         clock, 1 * kj::SECONDS, "storage operation took longer than expected: muted delete");
-    co_await request.send().ignoreResult();
+    co_await request.sendIgnoringResult();
   }
 }
 
@@ -2764,7 +2764,7 @@ kj::Promise<void> ActorCache::flushImplAlarmOnly(DirtyAlarm dirty) {
   KJ_IF_SOME(newTime, dirty.newTime) {
     auto req = storage.setAlarmRequest();
     req.setScheduledTimeMs((newTime - kj::UNIX_EPOCH) / kj::MILLISECONDS);
-    co_await req.send().ignoreResult();
+    co_await req.sendIgnoringResult();
     co_return;
   } else {
     // Alarm deletes are a bit trickier because we have to take DeferredAlarmDeletes into account.
@@ -2917,11 +2917,11 @@ kj::Promise<void> ActorCache::flushImplUsingTxn(PutFlush putFlush,
   }
 
   for (auto& request: rpcMutedDeletes) {
-    promises.add(request.send().ignoreResult());
+    promises.add(request.sendIgnoringResult());
   }
 
   for (auto& request: rpcPuts) {
-    promises.add(request.send().ignoreResult());
+    promises.add(request.sendIgnoringResult());
   }
 
   KJ_SWITCH_ONEOF(maybeAlarmChange) {
@@ -2929,7 +2929,7 @@ kj::Promise<void> ActorCache::flushImplUsingTxn(PutFlush putFlush,
       KJ_IF_SOME(newTime, dirty.newTime) {
         auto req = txn.setAlarmRequest();
         req.setScheduledTimeMs((newTime - kj::UNIX_EPOCH) / kj::MILLISECONDS);
-        promises.add(req.send().ignoreResult());
+        promises.add(req.sendIgnoringResult());
       } else {
         auto req = txn.deleteAlarmRequest();
         KJ_IF_SOME(deferredDelete, currentAlarmTime.tryGet<DeferredAlarmDelete>()) {
@@ -2956,7 +2956,7 @@ kj::Promise<void> ActorCache::flushImplUsingTxn(PutFlush putFlush,
           // and READY is set when the run completes -- only FLUSHING indicates we actually
           // need to send a request.
         } else {
-          promises.add(req.send().ignoreResult());
+          promises.add(req.sendIgnoringResult());
         }
       }
     }
@@ -2973,7 +2973,7 @@ kj::Promise<void> ActorCache::flushImplUsingTxn(PutFlush putFlush,
     auto writeObserver = recordStorageWrite(hooks, clock);
     util::DurationExceededLogger logger(clock, 1 * kj::SECONDS,
         "storage operation took longer than expected: commit flush transaction");
-    promises.add(txn.commitRequest(capnp::MessageSize{4, 0}).send().ignoreResult());
+    promises.add(txn.commitRequest(capnp::MessageSize{4, 0}).sendIgnoringResult());
 
     co_await kj::joinPromises(promises.finish());
     for (auto& rpcCountedDelete: rpcCountedDeletes) {

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -459,7 +459,7 @@ kj::Promise<void> IoContext::IncomingRequest::drain() {
   }
   return context->waitUntilTasks.onEmpty()
       .exclusiveJoin(kj::mv(timeoutPromise))
-      .exclusiveJoin(context->abortPromise.addBranch().then([] {}, [](kj::Exception&& e) {}));
+      .exclusiveJoin(context->abortPromise.addBranch().catch_([](kj::Exception&&) {}));
 }
 
 kj::Promise<IoContext_IncomingRequest::FinishScheduledResult> IoContext::IncomingRequest::

--- a/src/workerd/io/worker-interface.c++
+++ b/src/workerd/io/worker-interface.c++
@@ -373,7 +373,7 @@ kj::Promise<void> RpcWorkerInterface::connect(kj::StringPtr host,
 kj::Promise<void> RpcWorkerInterface::prewarm(kj::StringPtr url) {
   auto req = dispatcher.prewarmRequest(capnp::MessageSize{url.size() / sizeof(capnp::word) + 4, 0});
   req.setUrl(url);
-  return req.send().ignoreResult();
+  return req.sendIgnoringResult();
 }
 
 kj::Promise<WorkerInterface::ScheduledResult> RpcWorkerInterface::runScheduled(

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1850,7 +1850,7 @@ class Server::WorkerService final: public Service,
     kj::Vector<kj::Own<WorkerInterface>> streamingTailWorkers(channels.streamingTails.size());
     auto addWorkerIfNotRecursiveTracer =
         [this, isTracer](kj::Vector<kj::Own<WorkerInterface>>& workers, Service& service) {
-      // Caution here... if the tail worker ends up have a circular dependency
+      // Caution here... if the tail worker ends up having a circular dependency
       // on the worker we'll end up with an infinite loop trying to initialize.
       // We can test this directly but it's more difficult to test indirect
       // loops (dependency of dependency, etc). Here we're just going to keep

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -4384,15 +4384,13 @@ class EmptyReadOnlyActorStorageImpl final: public rpc::ActorStorage::Stage::Serv
     return context.getParams()
         .getStream()
         .endRequest(capnp::MessageSize{2, 0})
-        .send()
-        .ignoreResult();
+        .sendIgnoringResult();
   }
   kj::Promise<void> list(ListContext context) override {
     return context.getParams()
         .getStream()
         .endRequest(capnp::MessageSize{2, 0})
-        .send()
-        .ignoreResult();
+        .sendIgnoringResult();
   }
   kj::Promise<void> getAlarm(GetAlarmContext context) override {
     return kj::READY_NOW;
@@ -4413,15 +4411,13 @@ class EmptyReadOnlyActorStorageImpl final: public rpc::ActorStorage::Stage::Serv
       return context.getParams()
           .getStream()
           .endRequest(capnp::MessageSize{2, 0})
-          .send()
-          .ignoreResult();
+          .sendIgnoringResult();
     }
     kj::Promise<void> list(ListContext context) override {
       return context.getParams()
           .getStream()
           .endRequest(capnp::MessageSize{2, 0})
-          .send()
-          .ignoreResult();
+          .sendIgnoringResult();
     }
     kj::Promise<void> getAlarm(GetAlarmContext context) override {
       return kj::READY_NOW;


### PR DESCRIPTION
This eliminates some memory allocations for promise continuations and improves code size.
See capnp PR for context: https://github.com/capnproto/capnproto/pull/2286