### PR TITLE
[DRAFT][o11y] Fix tail stream cancellation warning

### DIFF
--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -8,6 +8,7 @@
 #include <workerd/io/features.h>
 #include <workerd/io/tracer.h>
 #include <workerd/jsg/ser.h>
+#include <workerd/util/completion-membrane.h>
 
 #include <capnp/membrane.h>
 
@@ -254,65 +255,6 @@ jsg::JsValue deserializeRpcReturnValue(
 
   return value;
 }
-
-// A membrane applied which detects when no capabilities are held any longer, at which point it
-// fulfills a fulfiller.
-//
-// TODO(cleanup): This is generally useful, should it be part of capnp?
-class CompletionMembrane final: public capnp::MembranePolicy, public kj::Refcounted {
- public:
-  explicit CompletionMembrane(kj::Own<kj::PromiseFulfiller<void>> doneFulfiller)
-      : doneFulfiller(kj::mv(doneFulfiller)) {}
-  ~CompletionMembrane() noexcept(false) {
-    doneFulfiller->fulfill();
-  }
-
-  kj::Maybe<capnp::Capability::Client> inboundCall(
-      uint64_t interfaceId, uint16_t methodId, capnp::Capability::Client target) override {
-    return kj::none;
-  }
-
-  kj::Maybe<capnp::Capability::Client> outboundCall(
-      uint64_t interfaceId, uint16_t methodId, capnp::Capability::Client target) override {
-    return kj::none;
-  }
-
-  kj::Own<MembranePolicy> addRef() override {
-    return kj::addRef(*this);
-  }
-
- private:
-  kj::Own<kj::PromiseFulfiller<void>> doneFulfiller;
-};
-
-// A membrane which revokes when some Promise is fulfilled.
-//
-// TODO(cleanup): This is generally useful, should it be part of capnp?
-class RevokerMembrane final: public capnp::MembranePolicy, public kj::Refcounted {
- public:
-  explicit RevokerMembrane(kj::Promise<void> promise): promise(promise.fork()) {}
-
-  kj::Maybe<capnp::Capability::Client> inboundCall(
-      uint64_t interfaceId, uint16_t methodId, capnp::Capability::Client target) override {
-    return kj::none;
-  }
-
-  kj::Maybe<capnp::Capability::Client> outboundCall(
-      uint64_t interfaceId, uint16_t methodId, capnp::Capability::Client target) override {
-    return kj::none;
-  }
-
-  kj::Own<MembranePolicy> addRef() override {
-    return kj::addRef(*this);
-  }
-
-  kj::Maybe<kj::Promise<void>> onRevoked() override {
-    return promise.addBranch();
-  }
-
- private:
-  kj::ForkedPromise<void> promise;
-};
 
 // A membrane which attaches some object until it is destroyed.
 //

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -967,22 +967,10 @@ kj::Promise<WorkerInterface::CustomEvent::Result> TailStreamCustomEventImpl::sen
     capnp::HttpOverCapnpFactory& httpOverCapnpFactory,
     capnp::ByteStreamFactory& byteStreamFactory,
     rpc::EventDispatcher::Client dispatcher) {
-  auto revokePaf = kj::newPromiseAndFulfiller<void>();
-
-  // TODO(streaming-tail): Session is currently being reported as canceled when using
-  // TailStreamCustomEventImpl via RPC, investigate.
-  KJ_DEFER({
-    if (revokePaf.fulfiller->isWaiting()) {
-      revokePaf.fulfiller->reject(KJ_EXCEPTION(DISCONNECTED, "Streaming tail session canceled"));
-    }
-  });
-
   auto req = dispatcher.tailStreamSessionRequest();
   auto sent = req.send();
 
   rpc::TailStreamTarget::Client cap = sent.getTopLevel();
-
-  cap = capnp::membrane(kj::mv(cap), kj::refcounted<RevokerMembrane>(kj::mv(revokePaf.promise)));
 
   auto completionPaf = kj::newPromiseAndFulfiller<void>();
   cap = capnp::membrane(
@@ -993,11 +981,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result> TailStreamCustomEventImpl::sen
   try {
     co_await sent.ignoreResult().exclusiveJoin(kj::mv(completionPaf.promise));
   } catch (...) {
-    auto e = kj::getCaughtExceptionAsKj();
-    if (revokePaf.fulfiller->isWaiting()) {
-      revokePaf.fulfiller->reject(kj::cp(e));
-    }
-    kj::throwFatalException(kj::mv(e));
+    kj::throwFatalException(kj::getCaughtExceptionAsKj());
   }
 
   co_return WorkerInterface::CustomEvent::Result{.outcome = EventOutcome::OK};


### PR DESCRIPTION
The revoker membrane was an artifact of trace-stream being proted from JSRPC and should not be needed here.