### PR TITLE
deriveBits: Fix incorrect behaviour when outputLen = 0

### DIFF
--- a/src/workerd/api/crypto/ec.c++
+++ b/src/workerd/api/crypto/ec.c++
@@ -274,9 +274,10 @@ class EllipticKey final: public AsymmetricKeyCryptoKeyImpl {
     // The pattern seems pretty clearly ~(2^n - 1) where n is the number of bits to mask off. Let's
     // check the last one though (8 is not a possible boundary condition).
     // (2^7 - 1) = 0x7f => ~0x7f = 0x80 (when truncated to a byte)
-    uint8_t mask = ~((1 << numBitsToMaskOff) - 1);
-
-    sharedSecret.back() &= mask;
+    if (numBitsToMaskOff) {
+      uint8_t mask = ~((1 << numBitsToMaskOff) - 1);
+      sharedSecret.back() &= mask;
+    }
 
     auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, sharedSecret.size());
     backing.asArrayPtr().copyFrom(sharedSecret);
@@ -969,8 +970,11 @@ class EdDsaKey final: public AsymmetricKeyCryptoKeyImpl {
     sharedSecret.truncate(resultByteLength);
     auto numBitsToMaskOff = resultByteLength * 8 - outputBitLength;
     KJ_DASSERT(numBitsToMaskOff < 8, numBitsToMaskOff);
-    uint8_t mask = ~((1 << numBitsToMaskOff) - 1);
-    sharedSecret.back() &= mask;
+
+    if (numBitsToMaskOff) {
+      uint8_t mask = ~((1 << numBitsToMaskOff) - 1);
+      sharedSecret.back() &= mask;
+    }
 
     auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, sharedSecret.size());
     backing.asArrayPtr().copyFrom(sharedSecret);

--- a/src/workerd/api/crypto/hkdf.c++
+++ b/src/workerd/api/crypto/hkdf.c++
@@ -51,9 +51,8 @@ class HkdfKey final: public CryptoKey::Impl {
     uint32_t length = JSG_REQUIRE_NONNULL(
         maybeLength, DOMOperationError, "HKDF cannot derive a key with null length.");
 
-    JSG_REQUIRE(length != 0 && (length % 8) == 0, DOMOperationError,
-        "HKDF requires a derived key length that is a non-zero multiple of eight (requested ",
-        length, ").");
+    JSG_REQUIRE(length % 8 == 0, DOMOperationError,
+        "HKDF requires a derived key length that is a multiple of eight (requested ", length, ").");
 
     auto derivedLengthBytes = length / 8;
 

--- a/src/workerd/api/crypto/pbkdf2.c++
+++ b/src/workerd/api/crypto/pbkdf2.c++
@@ -49,9 +49,9 @@ class Pbkdf2Key final: public CryptoKey::Impl {
     uint32_t length = JSG_REQUIRE_NONNULL(
         maybeLength, DOMOperationError, "PBKDF2 cannot derive a key with null length.");
 
-    JSG_REQUIRE(length != 0 && (length & 0b111) == 0, DOMOperationError,
-        "PBKDF2 requires a derived key length that is a non-zero multiple of eight (requested ",
-        length, ").");
+    JSG_REQUIRE(length % 8 == 0, DOMOperationError,
+        "PBKDF2 requires a derived key length that is a multiple of eight (requested ", length,
+        ").");
 
     JSG_REQUIRE(iterations > 0, DOMOperationError,
         "PBKDF2 requires a positive iteration count (requested ", iterations, ").");

--- a/src/wpt/BUILD.bazel
+++ b/src/wpt/BUILD.bazel
@@ -95,6 +95,7 @@ wpt_test(
 wpt_test(
     name = "WebCryptoAPI",
     size = "large",
+    timeout = "eternal",  # Give 240s to run
     config = "WebCryptoAPI-test.ts",
     target_compatible_with = select({
         # Too slow on Windows

--- a/src/wpt/WebCryptoAPI-test.ts
+++ b/src/wpt/WebCryptoAPI-test.ts
@@ -34,10 +34,7 @@ export default {
   },
   'derive_bits_keys/derive_key_and_encrypt.https.any.js': {},
   'derive_bits_keys/derive_key_and_encrypt.js': {},
-  'derive_bits_keys/derived_bits_length.https.any.js': {
-    comment: 'To be investigated. Triggers Asan error',
-    skipAllTests: true,
-  },
+  'derive_bits_keys/derived_bits_length.https.any.js': {},
   'derive_bits_keys/derived_bits_length.js': {},
   'derive_bits_keys/derived_bits_length_testcases.js': {
     comment:
@@ -49,16 +46,11 @@ export default {
   'derive_bits_keys/ecdh_bits.js': {},
   'derive_bits_keys/ecdh_keys.https.any.js': {},
   'derive_bits_keys/ecdh_keys.js': {},
-  'derive_bits_keys/hkdf.https.any.js': {
-    comment: 'Fixed in PR #4040',
-    expectedFailures: [/0 length/],
-  },
+  'derive_bits_keys/hkdf.https.any.js': {},
   'derive_bits_keys/hkdf.js': {},
   'derive_bits_keys/hkdf_vectors.js': {},
   'derive_bits_keys/pbkdf2.https.any.js': {
-    comment:
-      'Expected failures: Fixed in PR #4040, Skipped tests: keeps timing out',
-    expectedFailures: [/0 length/],
+    comment: 'Cannot cope with this many iterations, keeps timing out',
     skippedTests: [/with 100000 iterations/],
   },
   'derive_bits_keys/pbkdf2.js': {},

--- a/src/wpt/WebCryptoAPI-test.ts
+++ b/src/wpt/WebCryptoAPI-test.ts
@@ -46,7 +46,10 @@ export default {
   'derive_bits_keys/ecdh_bits.js': {},
   'derive_bits_keys/ecdh_keys.https.any.js': {},
   'derive_bits_keys/ecdh_keys.js': {},
-  'derive_bits_keys/hkdf.https.any.js': {},
+  'derive_bits_keys/hkdf.https.any.js': {
+    comment: 'Cannot cope with this many iterations, keeps timing out',
+    skippedTests: [/with 100000 iterations/],
+  },
   'derive_bits_keys/hkdf.js': {},
   'derive_bits_keys/hkdf_vectors.js': {},
   'derive_bits_keys/pbkdf2.https.any.js': {


### PR DESCRIPTION
- [HKDF, PBKDF2: Allow outputLen = 0 to conform to spec](https://github.com/cloudflare/workerd/commit/b8d006da6c97e4df44d60f9513c9e0ecd4c229dd)
- [EllipticKey, EdDsaKey: Fix memory corruption for outputLen = 0](https://github.com/cloudflare/workerd/commit/ce42e23e125b07222bda922b5caf27bca42108e9)