### PR TITLE
Refactor actor handling in workerd, including some bugfixes

### DIFF
--- a/src/workerd/api/node/tests/process-exit-test.js
+++ b/src/workerd/api/node/tests/process-exit-test.js
@@ -26,7 +26,7 @@ export const test2 = {
     // we check only that we received an internal error and that no other
     // lines of code ran after the process.exit call.
     {
-      const obj = env.foo.get(
+      let obj = env.foo.get(
         env.foo.idFromName('210bd0cbd803ef7883a1ee9d86cce06f')
       );
       await rejects(obj.fetch('http://example.org'), {
@@ -35,7 +35,14 @@ export const test2 = {
       await rejects(obj.fetch('http://example.org'), {
         message: /^The Node.js process.exit/,
       });
-      // The durable object should have been created twice.
+      // The durable object should have been created once, since we didn't recreate the stub.
+      strictEqual(fooCreateCount, 1);
+
+      // If we recreate the stub and try again, then the counter will increment.
+      obj = env.foo.get(env.foo.idFromName('210bd0cbd803ef7883a1ee9d86cce06f'));
+      await rejects(obj.fetch('http://example.org'), {
+        message: /^The Node.js process.exit/,
+      });
       strictEqual(fooCreateCount, 2);
     }
   },

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -1518,6 +1518,14 @@ export default {
       await doReq('sql-test-foreign-keys');
     }, /constraints were violated: FOREIGN KEY constraint failed: SQLITE_CONSTRAINT/);
 
+    // Since the DO was exploded, reusing the stub dosen't work.
+    await assert.rejects(async () => {
+      await doReq('increment');
+    }, /constraints were violated: FOREIGN KEY constraint failed: SQLITE_CONSTRAINT/);
+
+    // Get a new stub.
+    obj = env.ns.get(id);
+
     // Some increments.
     assert.equal(await doReq('increment'), 1);
     assert.equal(await doReq('increment'), 2);

--- a/src/workerd/api/unsafe.c++
+++ b/src/workerd/api/unsafe.c++
@@ -109,7 +109,11 @@ jsg::JsValue UnsafeEval::newWasmModule(jsg::Lock& js, kj::Array<kj::byte> src) {
 jsg::Promise<void> UnsafeModule::abortAllDurableObjects(jsg::Lock& js) {
   auto& context = IoContext::current();
   // Abort all actors asynchronously to avoid recursively taking isolate lock in actor destructor
-  auto promise = kj::evalLater([&]() { return context.abortAllActors(); });
+  auto promise = kj::evalLater([&]() {
+    auto exception =
+        JSG_KJ_EXCEPTION(FAILED, Error, "Application called abortAllDurableObjects().");
+    return context.abortAllActors(exception);
+  });
   return context.awaitIo(js, kj::mv(promise));
 }
 

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -460,6 +460,10 @@ class JsRpcSessionCustomEventImpl final: public WorkerInterface::CustomEvent {
     JSG_FAIL_REQUIRE(TypeError, "The receiver is not an RPC object");
   }
 
+  void failed(const kj::Exception& e) override {
+    capFulfiller->reject(kj::cp(e));
+  }
+
   // Event ID for jsRpcSession.
   //
   // Similar to WebSocket hibernation, we define this event ID in the internal codebase, but since

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -167,7 +167,7 @@ class IoChannelFactory {
       uint channel, kj::StringPtr id, SpanParent parentSpan) = 0;
 
   // Aborts all actors except those in namespaces marked with `preventEviction`.
-  virtual void abortAllActors() {
+  virtual void abortAllActors(kj::Maybe<kj::Exception&> reason) {
     KJ_UNIMPLEMENTED("Only implemented by single-tenant workerd runtime");
   }
 };

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -771,8 +771,8 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
     return getIoChannelFactory().getColoLocalActor(channel, id, kj::mv(parentSpan));
   }
 
-  void abortAllActors() {
-    return getIoChannelFactory().abortAllActors();
+  void abortAllActors(kj::Maybe<kj::Exception&> reason) {
+    return getIoChannelFactory().abortAllActors(reason);
   }
 
   // Get an HttpClient to use for Cache API subrequests.

--- a/src/workerd/io/worker-interface.c++
+++ b/src/workerd/io/worker-interface.c++
@@ -78,7 +78,16 @@ class PromisedWorkerInterface final: public WorkerInterface {
     KJ_IF_SOME(w, worker) {
       co_return co_await w->customEvent(kj::mv(event));
     } else {
-      co_await promise;
+      try {
+        co_await promise;
+      } catch (...) {
+        // Due to the exception, we're going to discard our CustomEvent. But we should tell it
+        // about why it failed first. This is important for JsRpcSessionCustomEventImpl in
+        // particular, as it needs to resolve the RPC client to the correct error.
+        auto exception = kj::getCaughtExceptionAsKj();
+        event->failed(exception);
+        kj::throwFatalException(kj::mv(exception));
+      }
       co_return co_await KJ_ASSERT_NONNULL(worker)->customEvent(kj::mv(event));
     }
   }

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -127,6 +127,10 @@ class WorkerInterface: public kj::HttpService {
     // RequestObserver. The RequestObserver implementation will define what numbers correspond to
     // what types.
     virtual uint16_t getType() = 0;
+
+    // If the CustomEvent fails before any of the other methods are called, this may be invoked
+    // to report the failure reason.
+    virtual void failed(const kj::Exception& e) {}
   };
 
   // Allows delivery of a variety of event types by implementing a callback that delivers the

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -1804,6 +1804,10 @@ KJ_TEST("Server: Durable Objects (in memory)") {
                 `  constructor(state, env) {
                 `    this.storage = state.storage;
                 `    this.id = state.id;
+                `    if (this.id.constructor.name != "DurableObjectId") {
+                `      throw new Error("durable ID should be type DurableObjectId, " +
+                `                      `got: ${this.id.constructor.name}`);
+                `    }
                 `  }
                 `  async fetch(request) {
                 `    let count = (await this.storage.get("foo")) || 0;
@@ -1984,6 +1988,10 @@ KJ_TEST("Server: Durable Objects (on disk)") {
                 `  constructor(state, env) {
                 `    this.storage = state.storage;
                 `    this.id = state.id;
+                `    if (this.id.constructor.name != "DurableObjectId") {
+                `      throw new Error("durable ID should be type DurableObjectId, " +
+                `                      `got: ${this.id.constructor.name}`);
+                `    }
                 `  }
                 `  async fetch(request) {
                 `    let count = (await this.storage.get("foo")) || 0;
@@ -2107,6 +2115,10 @@ KJ_TEST("Server: Ephemeral Objects") {
                 `  constructor(state, env) {
                 `    if (state.storage) throw new Error("storage shouldn't be present");
                 `    this.id = state.id;
+                `    if (typeof this.id != "string") {
+                `      throw new Error("ephemeral ID should be type string, " +
+                `                      `got: ${this.id.constructor.name}`);
+                `    }
                 `    this.count = 0;
                 `  }
                 `  async fetch(request) {

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2028,8 +2028,6 @@ class Server::WorkerService final: public Service,
         if (!onBrokenTriggered) {
           parent.onBrokenTasks.erase(key);
         }
-        // We need to make sure we're removed from the actors map.
-        parent.actors.erase(key);
       }
 
       void active() override {

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2173,6 +2173,10 @@ class Server::WorkerService final: public Service,
         return kj::addRef(*this);
       }
 
+      kj::Maybe<ActorContainer&> get() {
+        return container;
+      }
+
      private:
       // This is a maybe because the ActorContainer could be destroyed before ActorContainerRef
       // if the actor is broken.
@@ -2286,33 +2290,54 @@ class Server::WorkerService final: public Service,
     };
 
     kj::Promise<GetActorResult> getActorImpl(kj::String id) {
+      kj::StringPtr idPtr = id;
+
+      ActorContainer& actorContainer = *actors.findOrCreate(id, [&]() mutable {
+        auto container = kj::heap<ActorContainer>(id, *this, timer);
+
+        return kj::HashMap<kj::String, kj::Own<ActorContainer>>::Entry{
+          kj::mv(id), kj::mv(container)};
+      });
+
+      // If we don't have an ActorContainerRef, we'll create one to track the client.
+      // Note it's important that we obtain this before waiting on the lock, so that the
+      // ActorContainer can't be evicted while waiting.
+      kj::Own<ActorContainerRef> containerRef;
+      KJ_IF_SOME(ref, actorContainer.getContainerRef()) {
+        containerRef = ref.addRef();
+      } else {
+        // We have an actor, but all the clients dropped their reference to the DO so we need
+        // make a new `ActorContainerRef`. Note that `hasClients()` will return true now,
+        // preventing cleanupLoop from evicting us.
+        containerRef = kj::refcounted<ActorContainerRef>(actorContainer);
+      }
+
+      KJ_IF_SOME(a, actorContainer.actor) {
+        // This actor was used recently and hasn't been evicted, let's reuse it.
+        return GetActorResult{.actor = a->addRef(), .ref = kj::mv(containerRef)};
+      }
+
       // `getActor()` is often called with the calling isolate's lock held. We need to drop that
       // lock and take a lock on the target isolate before constructing the actor. Even if these
       // are the same isolate (as is commonly the case), we really don't want to do this stuff
       // synchronously, so this has the effect of pushing off to a later turn of the event loop.
       return service.worker->takeAsyncLockWithoutRequest(nullptr).then(
-          [this, id = kj::mv(id)](Worker::AsyncLock asyncLock) mutable -> GetActorResult {
-        kj::StringPtr idPtr = id;
-        auto& actorContainer = actors.findOrCreate(id, [&]() mutable {
-          auto container = kj::heap<ActorContainer>(idPtr, *this, timer);
-
-          return kj::HashMap<kj::String, kj::Own<ActorContainer>>::Entry{
-            kj::mv(id), kj::mv(container)};
-        });
-
-        // If we don't have an ActorContainerRef, we'll create one to track the client.
-        KJ_IF_SOME(a, actorContainer->actor) {
-          // This actor was used recently and hasn't been evicted, let's reuse it.
-          KJ_IF_SOME(ref, actorContainer->getContainerRef()) {
-            return GetActorResult{.actor = a->addRef(), .ref = ref.addRef()};
-          }
-          // We have an actor, but all the clients dropped their reference to the DO so we need
-          // make a new `ActorContainerRef`. Note that `hasClients()` will return true now,
-          // preventing cleanupLoop from evicting us.
-          return GetActorResult{
-            .actor = a->addRef(), .ref = kj::refcounted<ActorContainerRef>(*actorContainer)};
-        }
+          [this, idPtr, containerRef = kj::mv(containerRef)](
+              Worker::AsyncLock asyncLock) mutable -> GetActorResult {
         // We don't have an actor so we need to create it.
+
+        // The only way the container could be evicted while it has an active ref is if the actor
+        // became broken, but that can't happen if the actor hasn't even started up yet...
+        ActorContainer& actorContainer =
+            KJ_ASSERT_NONNULL(containerRef->get(), "ActorContainer evicted during actor startup?");
+        KJ_IF_SOME(a, actorContainer.actor) {
+          // Someone else created the actor while we were waiting for the lock.
+          // TODO(cleanup): It would be cleaner if the first request temporarily left a
+          //   ForkedPromise that other requests could wait on but that would be more complicated
+          //   to implement.
+          return GetActorResult{.actor = a->addRef(), .ref = kj::mv(containerRef)};
+        }
+
         auto& channels = KJ_ASSERT_NONNULL(service.ioChannels.tryGet<LinkedIoChannels>());
 
         auto makeActorCache = [&](const ActorCache::SharedLru& sharedLru, OutputGate& outputGate,
@@ -2377,34 +2402,23 @@ class Server::WorkerService final: public Service,
           // work for local development we need to pass an event type.
           static constexpr uint16_t hibernationEventTypeId = 8;
 
-          actorContainer->actor.emplace(
-              kj::refcounted<Worker::Actor>(*service.worker, actorContainer->getTracker(),
+          actorContainer.actor.emplace(
+              kj::refcounted<Worker::Actor>(*service.worker, actorContainer.getTracker(),
                   kj::str(idPtr), true, kj::mv(makeActorCache), className, kj::mv(makeStorage),
                   lock, kj::mv(loopback), timerChannel, kj::refcounted<ActorObserver>(),
-                  actorContainer->tryGetManagerRef(), hibernationEventTypeId));
+                  actorContainer.tryGetManagerRef(), hibernationEventTypeId));
 
           // If the actor becomes broken, remove it from the map, so a new one will be created
           // next time.
-          auto& actorRef = KJ_REQUIRE_NONNULL(actorContainer->actor);
-          auto& entry = onBrokenTasks.findOrCreateEntry(actorContainer->getKey(), [&]() {
-            return decltype(onBrokenTasks)::Entry{kj::str(actorContainer->getKey()), kj::none};
+          auto& actorRef = KJ_REQUIRE_NONNULL(actorContainer.actor);
+          auto& entry = onBrokenTasks.findOrCreateEntry(actorContainer.getKey(), [&]() {
+            return decltype(onBrokenTasks)::Entry{kj::str(actorContainer.getKey()), kj::none};
           });
-          entry.value = onActorBroken(actorRef->onBroken(), *actorContainer)
+          entry.value = onActorBroken(actorRef->onBroken(), actorContainer)
                             .eagerlyEvaluate([](kj::Exception&& e) { KJ_LOG(ERROR, e); });
 
-          KJ_IF_SOME(ref, actorContainer->getContainerRef()) {
-            // Although we didn't have a Worker::Actor, this ActorContainer _previously_ had one,
-            // and there's still at least one client with an open connection. We should continue
-            // to use our existing ActorContainerRef, otherwise we will have two or more separate
-            // refcounted ActorContainerRef's tracking the same ActorContainer. This would likely
-            // result in memory corruption because the ActorContainer's `containerRef` would
-            // lose access to one of the ActorContainerRef's.
-            return GetActorResult{.actor = actorRef->addRef(), .ref = ref.addRef()};
-          }
-
           // `hasClients()` will return true now, preventing cleanupLoop from evicting us.
-          return GetActorResult{
-            .actor = actorRef->addRef(), .ref = kj::refcounted<ActorContainerRef>(*actorContainer)};
+          return GetActorResult{.actor = actorRef->addRef(), .ref = kj::mv(containerRef)};
         });
       });
     }

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2102,7 +2102,6 @@ class Server::WorkerService final: public Service,
       kj::Maybe<kj::Own<Worker::Actor::HibernationManager>> manager;
       kj::Maybe<kj::Promise<void>> shutdownTask;
       kj::Maybe<kj::Promise<void>> onBrokenTask;
-      bool onBrokenTriggered = false;
 
       // Non-empty if at least one client has a reference to this actor.
       // If no clients are connected, we may be evicted by `cleanupLoop`.
@@ -2118,7 +2117,6 @@ class Server::WorkerService final: public Service,
           // We are intentionally ignoring any errors here. We just want to ensure
           // that the actor is removed if the onBroken promise is resolved or errors.
         }
-        onBrokenTriggered = true;
 
         // HACK: Dropping the ActorContainer will delete onBrokenTask, cancelling ourselves. This
         //   would crash. To avoid the problem, detach ourselves. This is safe because we know that

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2295,96 +2295,92 @@ class Server::WorkerService final: public Service,
 
       KJ_IF_SOME(a, containerRef->tryGetActor()) {
         // This actor was used recently and hasn't been evicted, let's reuse it.
-        return GetActorResult{.actor = a.addRef(), .ref = kj::mv(containerRef)};
+        co_return GetActorResult{.actor = a.addRef(), .ref = kj::mv(containerRef)};
       }
 
       // `getActor()` is often called with the calling isolate's lock held. We need to drop that
       // lock and take a lock on the target isolate before constructing the actor. Even if these
       // are the same isolate (as is commonly the case), we really don't want to do this stuff
       // synchronously, so this has the effect of pushing off to a later turn of the event loop.
-      return service.worker->takeAsyncLockWithoutRequest(nullptr).then(
-          [this, idPtr, containerRef = kj::mv(containerRef)](
-              Worker::AsyncLock asyncLock) mutable -> GetActorResult {
-        // We don't have an actor so we need to create it.
+      auto asyncLock = co_await service.worker->takeAsyncLockWithoutRequest(nullptr);
 
-        KJ_IF_SOME(a, containerRef->tryGetActor()) {
-          // Someone else created the actor while we were waiting for the lock.
-          // TODO(cleanup): It would be cleaner if the first request temporarily left a
-          //   ForkedPromise that other requests could wait on but that would be more complicated
-          //   to implement.
-          return GetActorResult{.actor = a.addRef(), .ref = kj::mv(containerRef)};
-        }
+      KJ_IF_SOME(a, containerRef->tryGetActor()) {
+        // Someone else created the actor while we were waiting for the lock.
+        // TODO(cleanup): It would be cleaner if the first request temporarily left a
+        //   ForkedPromise that other requests could wait on but that would be more complicated
+        //   to implement.
+        co_return GetActorResult{.actor = a.addRef(), .ref = kj::mv(containerRef)};
+      }
 
-        auto makeActorCache = [this, idStr = kj::str(idPtr)](const ActorCache::SharedLru& sharedLru,
-                                  OutputGate& outputGate, ActorCache::Hooks& hooks,
-                                  SqliteObserver& sqliteObserver) mutable {
-          return config.tryGet<Durable>().map(
-              [&](const Durable& d) -> kj::Own<ActorCacheInterface> {
-            auto& channels = KJ_ASSERT_NONNULL(service.ioChannels.tryGet<LinkedIoChannels>());
+      auto makeActorCache = [this, idStr = kj::str(idPtr)](const ActorCache::SharedLru& sharedLru,
+                                OutputGate& outputGate, ActorCache::Hooks& hooks,
+                                SqliteObserver& sqliteObserver) mutable {
+        return config.tryGet<Durable>().map(
+            [&](const Durable& d) -> kj::Own<ActorCacheInterface> {
+          auto& channels = KJ_ASSERT_NONNULL(service.ioChannels.tryGet<LinkedIoChannels>());
 
-            KJ_IF_SOME(as, channels.actorStorage) {
-              kj::Path path({d.uniqueKey, kj::str(idStr, ".sqlite")});
+          KJ_IF_SOME(as, channels.actorStorage) {
+            kj::Path path({d.uniqueKey, kj::str(idStr, ".sqlite")});
 
-              auto sqliteHooks = kj::heap<ActorSqliteHooks>(
-                  channels.alarmScheduler, ActorKey{.uniqueKey = d.uniqueKey, .actorId = idStr})
-                                     .attach(kj::mv(idStr));
+            auto sqliteHooks = kj::heap<ActorSqliteHooks>(
+                channels.alarmScheduler, ActorKey{.uniqueKey = d.uniqueKey, .actorId = idStr})
+                                    .attach(kj::mv(idStr));
 
-              auto db = kj::heap<SqliteDatabase>(*as, kj::mv(path),
-                  kj::WriteMode::CREATE | kj::WriteMode::MODIFY | kj::WriteMode::CREATE_PARENT);
+            auto db = kj::heap<SqliteDatabase>(*as, kj::mv(path),
+                kj::WriteMode::CREATE | kj::WriteMode::MODIFY | kj::WriteMode::CREATE_PARENT);
 
-              // Before we do anything, make sure the database is in WAL mode. We also need to
-              // do this after reset() is used, so register a callback for that.
-              auto setWalMode = [](SqliteDatabase& db) { db.run("PRAGMA journal_mode=WAL;"); };
-              setWalMode(*db);
-              db->afterReset(kj::mv(setWalMode));
+            // Before we do anything, make sure the database is in WAL mode. We also need to
+            // do this after reset() is used, so register a callback for that.
+            auto setWalMode = [](SqliteDatabase& db) { db.run("PRAGMA journal_mode=WAL;"); };
+            setWalMode(*db);
+            db->afterReset(kj::mv(setWalMode));
 
-              return kj::heap<ActorSqlite>(kj::mv(db), outputGate,
-                  []() -> kj::Promise<void> { return kj::READY_NOW; }, *sqliteHooks)
-                  .attach(kj::mv(sqliteHooks));
-            } else {
-              // Create an ActorCache backed by a fake, empty storage. Elsewhere, we configure
-              // ActorCache never to flush, so this effectively creates in-memory storage.
-              return kj::heap<ActorCache>(
-                  newEmptyReadOnlyActorStorage(), sharedLru, outputGate, hooks);
-            }
-          });
-        };
-
-        bool enableSql = true;
-        KJ_SWITCH_ONEOF(config) {
-          KJ_CASE_ONEOF(c, Durable) {
-            enableSql = c.enableSql;
+            return kj::heap<ActorSqlite>(kj::mv(db), outputGate,
+                []() -> kj::Promise<void> { return kj::READY_NOW; }, *sqliteHooks)
+                .attach(kj::mv(sqliteHooks));
+          } else {
+            // Create an ActorCache backed by a fake, empty storage. Elsewhere, we configure
+            // ActorCache never to flush, so this effectively creates in-memory storage.
+            return kj::heap<ActorCache>(
+                newEmptyReadOnlyActorStorage(), sharedLru, outputGate, hooks);
           }
-          KJ_CASE_ONEOF(c, Ephemeral) {
-            enableSql = c.enableSql;
-          }
-        }
-
-        auto makeStorage =
-            [enableSql = enableSql](jsg::Lock& js, const Worker::Api& api,
-                ActorCacheInterface& actorCache) -> jsg::Ref<api::DurableObjectStorage> {
-          return js.alloc<api::DurableObjectStorage>(
-              js, IoContext::current().addObject(actorCache), enableSql);
-        };
-
-        TimerChannel& timerChannel = service;
-
-        auto loopback = kj::refcounted<Loopback>(*this, kj::str(idPtr));
-
-        return service.worker->runInLockScope(asyncLock, [&](Worker::Lock& lock) {
-          // We define this event ID in the internal codebase, but to have WebSocket Hibernation
-          // work for local development we need to pass an event type.
-          static constexpr uint16_t hibernationEventTypeId = 8;
-
-          auto& actorRef = containerRef->setActor(
-              kj::refcounted<Worker::Actor>(*service.worker, containerRef->getTracker(),
-                  kj::str(idPtr), true, kj::mv(makeActorCache), className, kj::mv(makeStorage),
-                  lock, kj::mv(loopback), timerChannel, kj::refcounted<ActorObserver>(),
-                  containerRef->tryGetManagerRef(), hibernationEventTypeId));
-
-          // `hasClients()` will return true now, preventing cleanupLoop from evicting us.
-          return GetActorResult{.actor = actorRef.addRef(), .ref = kj::mv(containerRef)};
         });
+      };
+
+      bool enableSql = true;
+      KJ_SWITCH_ONEOF(config) {
+        KJ_CASE_ONEOF(c, Durable) {
+          enableSql = c.enableSql;
+        }
+        KJ_CASE_ONEOF(c, Ephemeral) {
+          enableSql = c.enableSql;
+        }
+      }
+
+      auto makeStorage =
+          [enableSql = enableSql](jsg::Lock& js, const Worker::Api& api,
+              ActorCacheInterface& actorCache) -> jsg::Ref<api::DurableObjectStorage> {
+        return js.alloc<api::DurableObjectStorage>(
+            js, IoContext::current().addObject(actorCache), enableSql);
+      };
+
+      TimerChannel& timerChannel = service;
+
+      auto loopback = kj::refcounted<Loopback>(*this, kj::str(idPtr));
+
+      co_return service.worker->runInLockScope(asyncLock, [&](Worker::Lock& lock) {
+        // We define this event ID in the internal codebase, but to have WebSocket Hibernation
+        // work for local development we need to pass an event type.
+        static constexpr uint16_t hibernationEventTypeId = 8;
+
+        auto& actorRef = containerRef->setActor(
+            kj::refcounted<Worker::Actor>(*service.worker, containerRef->getTracker(),
+                kj::str(idPtr), true, kj::mv(makeActorCache), className, kj::mv(makeStorage),
+                lock, kj::mv(loopback), timerChannel, kj::refcounted<ActorObserver>(),
+                containerRef->tryGetManagerRef(), hibernationEventTypeId));
+
+        // `hasClients()` will return true now, preventing cleanupLoop from evicting us.
+        return GetActorResult{.actor = actorRef.addRef(), .ref = kj::mv(containerRef)};
       });
     }
   };

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2143,8 +2143,8 @@ class Server::WorkerService final: public Service,
         KJ_ASSERT_NONNULL(onBrokenTask).detach([](kj::Exception&& e) {});
 
         // Hollow out the object, so that if it still has references, they won't keep these parts
-        // alive. Since any further calls to `tryGetActor()` or `setActor()` will throw, we don't
-        // have to worry about the actor being recreated.
+        // alive. Since any further calls to `getActor()` will throw, we don't have to worry about
+        // the actor being recreated.
         auto actorToDrop = kj::mv(this->actor);
         tracker->shutdown();
         auto managerToDrop = kj::mv(manager);
@@ -2153,7 +2153,8 @@ class Server::WorkerService final: public Service,
         // HibernationManager so any connected hibernatable websockets will be disconnected.
         parent.actors.erase(key);
 
-        // WARNING: `this` MAY HAVE BEEN DELETED
+        // WARNING: `this` MAY HAVE BEEN DELETED as a result of the above `erase()`. Do not access
+        //   it again here.
       }
 
       // Processes the eviction of the Durable Object and hibernates active websockets.
@@ -2197,7 +2198,7 @@ class Server::WorkerService final: public Service,
         }
         // Destroy the last strong Worker::Actor reference.
         actor = kj::none;
-        startTask = kj::none;  // so next tryGetActor() will call start() again
+        startTask = kj::none;  // so next getActor() will call start() again
       }
 
       kj::Promise<void> start() {

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -221,7 +221,7 @@ class Server final: private kj::TaskSet::ErrorHandler {
       capnp::List<config::Extension>::Reader extensions);
 
   // Aborts all actors in this server except those in namespaces marked with `preventEviction`.
-  void abortAllActors();
+  void abortAllActors(kj::Maybe<const kj::Exception&> reason);
 
   // Can only be called in the link stage.
   //

--- a/src/workerd/server/tests/unsafe-module/unsafe-module-test.js
+++ b/src/workerd/server/tests/unsafe-module/unsafe-module-test.js
@@ -42,6 +42,16 @@ export const test_abort_all_durable_objects = {
 
     await unsafe.abortAllDurableObjects();
 
+    // Since the objects were aborted, trying to use their stubs now should reject.
+    await assert.rejects(() => durableStub.fetch('http://x'), {
+      name: 'Error',
+      message: 'Application called abortAllDurableObjects().',
+    });
+    await assert.rejects(() => ephemeralStub.fetch('http://x'), {
+      name: 'Error',
+      message: 'Application called abortAllDurableObjects().',
+    });
+
     // Recreate the stubs because they are broken.
     durableStub = env.DURABLE.get(durableId);
     ephemeralStub = env.EPHEMERAL.get('thing');

--- a/src/workerd/server/tests/unsafe-module/unsafe-module-test.js
+++ b/src/workerd/server/tests/unsafe-module/unsafe-module-test.js
@@ -23,11 +23,11 @@ export const test_abort_all_durable_objects = {
     const durableId = env.DURABLE.newUniqueId();
     const durablePreventEvictionId = env.DURABLE_PREVENT_EVICTION.newUniqueId();
 
-    const durableStub = env.DURABLE.get(durableId);
+    let durableStub = env.DURABLE.get(durableId);
     const durablePreventEvictionStub = env.DURABLE_PREVENT_EVICTION.get(
       durablePreventEvictionId
     );
-    const ephemeralStub = env.EPHEMERAL.get('thing');
+    let ephemeralStub = env.EPHEMERAL.get('thing');
     const ephemeralPreventEvictionStub =
       env.EPHEMERAL_PREVENT_EVICTION.get('thing');
 
@@ -41,6 +41,10 @@ export const test_abort_all_durable_objects = {
     ).text();
 
     await unsafe.abortAllDurableObjects();
+
+    // Recreate the stubs because they are broken.
+    durableStub = env.DURABLE.get(durableId);
+    ephemeralStub = env.EPHEMERAL.get('thing');
 
     const durableRes2 = await (await durableStub.fetch('http://x')).text();
     const durablePreventEvictionRes2 = await (


### PR DESCRIPTION
This started with me refactoring the actor handling in `server.c++` to make it more amenable to changes I want to make.

Along the way, I realized there were actual bugs here, and fixed a few:
1. In production, when an actor becomes broken, all existing stubs become broken. Reusing the stubs continuously throws the same error. But in workerd, this was not the case: instead, the next call on a stub would start a new instance of the actor, "fixing itself". It's important that workerd match production so that people can properly test their code, so this fixes the bug.
2. RPC calls on broken stubs were producing "internal error", and under the hood a "PromiseFulfiller was never fulfilled" Sentry error. They should now rethrow the correct exception. (This affects production, too.)
3. The type of `ctx.id` in a Durable Object is supposed to be the special `DurableObjectId` type, but [due to a bug introduced years ago](https://github.com/cloudflare/workerd/pull/605/files#r2065153020), in workerd it was being filled in as a plain string.

There are a lot of commits here because I tried to keep each one small and easy to review. They should go fast.

Keep in mind `server.c++` only applies to workerd -- this code is not used in production.

I believe @MellowYarker is most familiar with this code so should be the main reviewer. Adding @shrima-cf because I think she recently hit these bugs while writing tests.