### PR TITLE
WPT test harness improvements

### DIFF
--- a/build/wpt_test.bzl
+++ b/build/wpt_test.bzl
@@ -294,6 +294,7 @@ const unitTests :Workerd.Config = (
       disk = ".",
     )
   ],
+  v8Flags = ["--expose-gc"],
   {autogates}
 );"""
 

--- a/src/wpt/BUILD.bazel
+++ b/src/wpt/BUILD.bazel
@@ -96,6 +96,10 @@ wpt_test(
     name = "WebCryptoAPI",
     size = "large",
     config = "WebCryptoAPI-test.ts",
+    target_compatible_with = select({
+        # Too slow on Windows
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     wpt_directory = "@wpt//:WebCryptoAPI@module",
-    # If you are here because this test is timing out on Windows, just disable it for Windows.
 )

--- a/src/wpt/WebCryptoAPI-test.ts
+++ b/src/wpt/WebCryptoAPI-test.ts
@@ -49,10 +49,16 @@ export default {
   'derive_bits_keys/ecdh_bits.js': {},
   'derive_bits_keys/ecdh_keys.https.any.js': {},
   'derive_bits_keys/ecdh_keys.js': {},
-  'derive_bits_keys/hkdf.https.any.js': {},
+  'derive_bits_keys/hkdf.https.any.js': {
+    comment: 'Fixed in PR #4040',
+    expectedFailures: [/0 length/],
+  },
   'derive_bits_keys/hkdf.js': {},
   'derive_bits_keys/hkdf_vectors.js': {},
-  'derive_bits_keys/pbkdf2.https.any.js': {},
+  'derive_bits_keys/pbkdf2.https.any.js': {
+    comment: 'Fixed in PR #4040',
+    expectedFailures: [/0 length/],
+  },
   'derive_bits_keys/pbkdf2.js': {},
   'derive_bits_keys/pbkdf2_vectors.js': {},
 
@@ -82,39 +88,32 @@ export default {
 
   'generateKey/failures.js': {},
   'generateKey/failures_AES-CBC.https.any.js': {
-    comment:
-      'Wrong type of error returned; too many failures to list individually.',
-    skipAllTests: true,
+    comment: 'Wrong type of error returned',
+    expectedFailures: [/^(Empty|Bad) algorithm:/],
   },
   'generateKey/failures_AES-CTR.https.any.js': {
-    comment:
-      'Wrong type of error returned; too many failures to list individually.',
-    skipAllTests: true,
+    comment: 'Wrong type of error returned',
+    expectedFailures: [/^(Empty|Bad) algorithm:/],
   },
   'generateKey/failures_AES-GCM.https.any.js': {
-    comment:
-      'Wrong type of error returned; too many failures to list individually.',
-    skipAllTests: true,
+    comment: 'Wrong type of error returned',
+    expectedFailures: [/^(Empty|Bad) algorithm:/],
   },
   'generateKey/failures_AES-KW.https.any.js': {
-    comment:
-      'Wrong type of error returned; too many failures to list individually.',
-    skipAllTests: true,
+    comment: 'Wrong type of error returned',
+    expectedFailures: [/^(Empty|Bad) algorithm:/],
   },
   'generateKey/failures_ECDH.https.any.js': {
-    comment:
-      'Wrong type of error returned; too many failures to list individually.',
-    skipAllTests: true,
+    comment: 'Wrong type of error returned',
+    expectedFailures: [/^(Empty|Bad) algorithm:/],
   },
   'generateKey/failures_ECDSA.https.any.js': {
-    comment:
-      'Wrong type of error returned; too many failures to list individually.',
-    skipAllTests: true,
+    comment: 'Wrong type of error returned',
+    expectedFailures: [/^(Empty|Bad) algorithm:/],
   },
   'generateKey/failures_Ed25519.https.any.js': {
-    comment:
-      'Wrong type of error returned; too many failures to list individually.',
-    skipAllTests: true,
+    comment: 'Wrong type of error returned',
+    expectedFailures: [/^(Empty|Bad) algorithm:/],
   },
   'generateKey/failures_Ed448.https.any.js': {
     comment:
@@ -122,29 +121,24 @@ export default {
     skipAllTests: true,
   },
   'generateKey/failures_HMAC.https.any.js': {
-    comment:
-      'Wrong type of error returned; too many failures to list individually.',
-    skipAllTests: true,
+    comment: 'Wrong type of error returned',
+    expectedFailures: [/^(Empty|Bad) algorithm:/],
   },
   'generateKey/failures_RSA-OAEP.https.any.js': {
-    comment:
-      'Wrong type of error returned; too many failures to list individually.',
-    skipAllTests: true,
+    comment: 'Wrong type of error returned',
+    expectedFailures: [/^(Empty|Bad) algorithm:/],
   },
   'generateKey/failures_RSA-PSS.https.any.js': {
-    comment:
-      'Wrong type of error returned; too many failures to list individually.',
-    skipAllTests: true,
+    comment: 'Wrong type of error returned',
+    expectedFailures: [/^(Empty|Bad) algorithm:/],
   },
   'generateKey/failures_RSASSA-PKCS1-v1_5.https.any.js': {
-    comment:
-      'Wrong type of error returned; too many failures to list individually.',
-    skipAllTests: true,
+    comment: 'Wrong type of error returned',
+    expectedFailures: [/^(Empty|Bad) algorithm:/],
   },
   'generateKey/failures_X25519.https.any.js': {
-    comment:
-      'Wrong type of error returned; too many failures to list individually.',
-    skipAllTests: true,
+    comment: 'Wrong type of error returned',
+    expectedFailures: [/^(Empty|Bad) algorithm:/],
   },
   'generateKey/failures_X448.https.any.js': {
     comment:
@@ -152,23 +146,59 @@ export default {
     skipAllTests: true,
   },
   'generateKey/successes.js': {},
-  'generateKey/successes_AES-CBC.https.any.js': {},
-  'generateKey/successes_AES-CTR.https.any.js': {},
-  'generateKey/successes_AES-GCM.https.any.js': {},
-  'generateKey/successes_AES-KW.https.any.js': {},
-  'generateKey/successes_ECDH.https.any.js': {},
-  'generateKey/successes_ECDSA.https.any.js': {},
-  'generateKey/successes_Ed25519.https.any.js': {},
+  'generateKey/successes_AES-CBC.https.any.js': {
+    comment: 'TODO investigate this',
+    expectedFailures: [/^undefined: /],
+  },
+  'generateKey/successes_AES-CTR.https.any.js': {
+    comment: 'TODO investigate this',
+    expectedFailures: [/^undefined: /],
+  },
+  'generateKey/successes_AES-GCM.https.any.js': {
+    comment: 'TODO investigate this',
+    expectedFailures: [/^undefined: /],
+  },
+  'generateKey/successes_AES-KW.https.any.js': {
+    comment: 'TODO investigate this',
+    expectedFailures: [/^undefined: /],
+  },
+  'generateKey/successes_ECDH.https.any.js': {
+    comment: 'TODO investigate this',
+    expectedFailures: [/^undefined: /],
+  },
+  'generateKey/successes_ECDSA.https.any.js': {
+    comment: 'TODO investigate this',
+    expectedFailures: [/^undefined: /],
+  },
+  'generateKey/successes_Ed25519.https.any.js': {
+    comment: 'TODO investigate this',
+    expectedFailures: [/^undefined: /],
+  },
   'generateKey/successes_Ed448.https.any.js': {
     comment:
       'Ed448 is not supported by BoringSSL and is intentionally disabled.',
     skipAllTests: true,
   },
-  'generateKey/successes_HMAC.https.any.js': {},
-  'generateKey/successes_RSA-OAEP.https.any.js': {},
-  'generateKey/successes_RSA-PSS.https.any.js': {},
-  'generateKey/successes_RSASSA-PKCS1-v1_5.https.any.js': {},
-  'generateKey/successes_X25519.https.any.js': {},
+  'generateKey/successes_HMAC.https.any.js': {
+    comment: 'TODO investigate this',
+    expectedFailures: [/^undefined: /],
+  },
+  'generateKey/successes_RSA-OAEP.https.any.js': {
+    comment: 'TODO investigate this',
+    expectedFailures: [/^undefined: /],
+  },
+  'generateKey/successes_RSA-PSS.https.any.js': {
+    comment: 'TODO investigate this',
+    expectedFailures: [/^undefined: /],
+  },
+  'generateKey/successes_RSASSA-PKCS1-v1_5.https.any.js': {
+    comment: 'TODO investigate this',
+    expectedFailures: [/^undefined: /],
+  },
+  'generateKey/successes_X25519.https.any.js': {
+    comment: 'TODO investigate this',
+    expectedFailures: [/^undefined: /],
+  },
   'generateKey/successes_X448.https.any.js': {
     comment:
       'X448 is not supported by BoringSSL and is intentionally disabled.',
@@ -195,12 +225,14 @@ export default {
   'import_export/crashtests/importKey-unsettled-promise.https.any.js': {},
   'import_export/ec_importKey.https.any.js': {},
   'import_export/ec_importKey_failures_ECDH.https.any.js': {
-    comment: 'Too many failures to list individually',
-    skipAllTests: true,
+    comment:
+      'OpenSSL call failed: EC_POINT_set_affine_coordinates_GFp(group, point, bigX, bigY, nullptr);',
+    expectedFailures: [/^Bad key length:/, /^Missing JWK 'crv' parameter:/],
   },
   'import_export/ec_importKey_failures_ECDSA.https.any.js': {
-    comment: 'Too many failures to list individually',
-    skipAllTests: true,
+    comment:
+      'OpenSSL call failed: EC_POINT_set_affine_coordinates_GFp(group, point, bigX, bigY, nullptr);',
+    expectedFailures: [/^Bad key length:/, /^Missing JWK 'crv' parameter:/],
   },
   'import_export/ec_importKey_failures_fixtures.js': {},
   'import_export/importKey_failures.js': {},

--- a/src/wpt/WebCryptoAPI-test.ts
+++ b/src/wpt/WebCryptoAPI-test.ts
@@ -234,10 +234,7 @@ export default {
     skipAllTests: true,
   },
 
-  'import_export/crashtests/importKey-unsettled-promise.https.any.js': {
-    comment: 'Test file /common/gc.js not found',
-    skipAllTests: true,
-  },
+  'import_export/crashtests/importKey-unsettled-promise.https.any.js': {},
   'import_export/ec_importKey.https.any.js': {},
   'import_export/ec_importKey_failures_ECDH.https.any.js': {
     comment: 'Too many failures to list individually',

--- a/src/wpt/WebCryptoAPI-test.ts
+++ b/src/wpt/WebCryptoAPI-test.ts
@@ -56,8 +56,10 @@ export default {
   'derive_bits_keys/hkdf.js': {},
   'derive_bits_keys/hkdf_vectors.js': {},
   'derive_bits_keys/pbkdf2.https.any.js': {
-    comment: 'Fixed in PR #4040',
+    comment:
+      'Expected failures: Fixed in PR #4040, Skipped tests: keeps timing out',
     expectedFailures: [/0 length/],
+    skippedTests: [/with 100000 iterations/],
   },
   'derive_bits_keys/pbkdf2.js': {},
   'derive_bits_keys/pbkdf2_vectors.js': {},

--- a/src/wpt/WebCryptoAPI-test.ts
+++ b/src/wpt/WebCryptoAPI-test.ts
@@ -49,16 +49,10 @@ export default {
   'derive_bits_keys/ecdh_bits.js': {},
   'derive_bits_keys/ecdh_keys.https.any.js': {},
   'derive_bits_keys/ecdh_keys.js': {},
-  'derive_bits_keys/hkdf.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found.',
-    skipAllTests: true,
-  },
+  'derive_bits_keys/hkdf.https.any.js': {},
   'derive_bits_keys/hkdf.js': {},
   'derive_bits_keys/hkdf_vectors.js': {},
-  'derive_bits_keys/pbkdf2.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found.',
-    skipAllTests: true,
-  },
+  'derive_bits_keys/pbkdf2.https.any.js': {},
   'derive_bits_keys/pbkdf2.js': {},
   'derive_bits_keys/pbkdf2_vectors.js': {},
 
@@ -158,59 +152,23 @@ export default {
     skipAllTests: true,
   },
   'generateKey/successes.js': {},
-  'generateKey/successes_AES-CBC.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found',
-    skipAllTests: true,
-  },
-  'generateKey/successes_AES-CTR.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found',
-    skipAllTests: true,
-  },
-  'generateKey/successes_AES-GCM.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found',
-    skipAllTests: true,
-  },
-  'generateKey/successes_AES-KW.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found',
-    skipAllTests: true,
-  },
-  'generateKey/successes_ECDH.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found',
-    skipAllTests: true,
-  },
-  'generateKey/successes_ECDSA.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found',
-    skipAllTests: true,
-  },
-  'generateKey/successes_Ed25519.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found',
-    skipAllTests: true,
-  },
+  'generateKey/successes_AES-CBC.https.any.js': {},
+  'generateKey/successes_AES-CTR.https.any.js': {},
+  'generateKey/successes_AES-GCM.https.any.js': {},
+  'generateKey/successes_AES-KW.https.any.js': {},
+  'generateKey/successes_ECDH.https.any.js': {},
+  'generateKey/successes_ECDSA.https.any.js': {},
+  'generateKey/successes_Ed25519.https.any.js': {},
   'generateKey/successes_Ed448.https.any.js': {
     comment:
       'Ed448 is not supported by BoringSSL and is intentionally disabled.',
     skipAllTests: true,
   },
-  'generateKey/successes_HMAC.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found',
-    skipAllTests: true,
-  },
-  'generateKey/successes_RSA-OAEP.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found',
-    skipAllTests: true,
-  },
-  'generateKey/successes_RSA-PSS.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found',
-    skipAllTests: true,
-  },
-  'generateKey/successes_RSASSA-PKCS1-v1_5.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found',
-    skipAllTests: true,
-  },
-  'generateKey/successes_X25519.https.any.js': {
-    comment: 'Test file /common/subset-tests.js not found',
-    skipAllTests: true,
-  },
+  'generateKey/successes_HMAC.https.any.js': {},
+  'generateKey/successes_RSA-OAEP.https.any.js': {},
+  'generateKey/successes_RSA-PSS.https.any.js': {},
+  'generateKey/successes_RSASSA-PKCS1-v1_5.https.any.js': {},
+  'generateKey/successes_X25519.https.any.js': {},
   'generateKey/successes_X448.https.any.js': {
     comment:
       'X448 is not supported by BoringSSL and is intentionally disabled.',

--- a/src/wpt/encoding-test.ts
+++ b/src/wpt/encoding-test.ts
@@ -6,10 +6,7 @@ import { type TestRunnerConfig } from 'harness/harness';
 
 export default {
   'api-basics.any.js': {},
-  'api-invalid-label.any.js': {
-    comment: 'Error: Test file /common/subset-tests.js not found',
-    skipAllTests: true,
-  },
+  'api-invalid-label.any.js': {},
   'api-replacement-encodings.any.js': {},
   'api-surrogates-utf8.any.js': {},
   'encodeInto.any.js': {
@@ -190,10 +187,7 @@ export default {
     skipAllTests: true,
   },
   'textdecoder-eof.any.js': {},
-  'textdecoder-fatal-single-byte.any.js': {
-    comment: '/common/subset-tests.js',
-    skipAllTests: true,
-  },
+  'textdecoder-fatal-single-byte.any.js': {},
   'textdecoder-fatal-streaming.any.js': {},
   'textdecoder-fatal.any.js': {},
   'textdecoder-ignorebom.any.js': {},

--- a/src/wpt/encoding-test.ts
+++ b/src/wpt/encoding-test.ts
@@ -10,8 +10,14 @@ export default {
   'api-replacement-encodings.any.js': {},
   'api-surrogates-utf8.any.js': {},
   'encodeInto.any.js': {
-    comment: 'Test file /common/sab.js not found',
-    skipAllTests: true,
+    comment: 'See comments on each failure',
+    expectedFailures: [
+      // Enable once Float16Array is available
+      'Invalid encodeInto() destination: Float16Array, backed by: ArrayBuffer',
+      'Invalid encodeInto() destination: Float16Array, backed by: SharedArrayBuffer',
+      // Enable once MessageChannel is implemented
+      'encodeInto() and a detached output buffer',
+    ],
   },
   'idlharness.any.js': {
     comment: 'Test file /resources/WebIDLParser.js not found',
@@ -135,8 +141,23 @@ export default {
     ],
   },
   'streams/decode-utf8.any.js': {
-    comment: 'Test file /common/sab.js not found',
-    skipAllTests: true,
+    comment: 'See comments on each failure',
+    expectedFailures: [
+      // Enable once MessageChannel is implemented
+      'decoding a transferred Uint8Array chunk should give no output',
+      'decoding a transferred ArrayBuffer chunk should give no output',
+      // TODO investigate these
+      'decoding one UTF-8 chunk should give one output string - ArrayBuffer',
+      'decoding an empty chunk should give no output chunks - ArrayBuffer',
+      'UTF-8 EOF handling - ArrayBuffer',
+      'decoding one UTF-8 chunk should give one output string - SharedArrayBuffer',
+      'decoding an empty chunk should give no output chunks - SharedArrayBuffer',
+      'UTF-8 EOF handling - SharedArrayBuffer',
+      'an initial empty chunk should be ignored - ArrayBuffer',
+      'a trailing empty chunk should be ignored - ArrayBuffer',
+      'an initial empty chunk should be ignored - SharedArrayBuffer',
+      'a trailing empty chunk should be ignored - SharedArrayBuffer',
+    ],
   },
   'streams/encode-bad-chunks.any.js': {
     comment: 'TODO investigate this',
@@ -183,8 +204,9 @@ export default {
   'textdecoder-arguments.any.js': {},
   'textdecoder-byte-order-marks.any.js': {},
   'textdecoder-copy.any.js': {
-    comment: 'Test file /common/sab.js not found',
-    skipAllTests: true,
+    comment:
+      "Failed to execute 'decode' on 'TextDecoder': parameter 1 is not of type 'Array'.",
+    expectedFailures: ['Modify buffer after passing it in (SharedArrayBuffer)'],
   },
   'textdecoder-eof.any.js': {},
   'textdecoder-fatal-single-byte.any.js': {},
@@ -209,10 +231,7 @@ export default {
       'x-user-defined => x-user-defined',
     ],
   },
-  'textdecoder-streaming.any.js': {
-    comment: 'Test file /common/sab.js not found',
-    skipAllTests: true,
-  },
+  'textdecoder-streaming.any.js': {},
   'textdecoder-utf16-surrogates.any.js': {
     comment: 'Investigate why we are not blocking invalid surrogates',
     expectedFailures: [

--- a/src/wpt/fetch/api-test.ts
+++ b/src/wpt/fetch/api-test.ts
@@ -61,10 +61,7 @@ export default {
       'Stream disconnected prematurely and a dropped promise when faced with intentionally bad chunked encoding from WPT',
     skipAllTests: true,
   },
-  'basic/gc.any.js': {
-    comment: 'Run WPT tests with --expose-gc if we want to run this test',
-    skipAllTests: true,
-  },
+  'basic/gc.any.js': {},
   'basic/header-value-combining.any.js': {
     comment:
       "Stream disconnected prematurely and a dropped promise. Not yet sure what is triggering about WPT's output",

--- a/src/wpt/harness/harness.ts
+++ b/src/wpt/harness/harness.ts
@@ -506,6 +506,7 @@ declare global {
   function setup(func: UnknownFunc | Record<string, unknown>): void;
   function add_completion_callback(func: UnknownFunc): void;
   function garbageCollect(): void;
+  function format_value(val: unknown): string;
   function createBuffer(
     type: 'ArrayBuffer' | 'SharedArrayBuffer',
     length: number,
@@ -1143,6 +1144,10 @@ globalThis.garbageCollect = (): void => {
   if (typeof gc === 'function') {
     gc();
   }
+};
+
+globalThis.format_value = (val): string => {
+  return JSON.stringify(val, null, 2);
 };
 
 globalThis.createBuffer = (

--- a/src/wpt/harness/harness.ts
+++ b/src/wpt/harness/harness.ts
@@ -500,6 +500,7 @@ declare global {
   function token(): string;
   function setup(func: UnknownFunc | Record<string, unknown>): void;
   function add_completion_callback(func: UnknownFunc): void;
+  function garbageCollect(): void;
 }
 
 // eslint-disable-next-line  @typescript-eslint/no-unsafe-assignment -- eslint doesn't like "old-style" classes. Code is copied from WPT
@@ -1119,6 +1120,12 @@ globalThis.add_completion_callback = (func: UnknownFunc): void => {
   globalThis.state.completionCallbacks.push(func);
 };
 
+globalThis.garbageCollect = (): void => {
+  if (typeof gc === 'function') {
+    gc();
+  }
+};
+
 class Location {
   public get ancestorOrigins(): DOMStringList {
     return {
@@ -1261,6 +1268,7 @@ const EXCLUDED_PATHS = new Set([
   '/resources/utils.js',
   '/common/utils.js',
   '/common/get-host-info.sub.js',
+  '/common/gc.js',
 ]);
 
 function replaceInterpolation(code: string): string {

--- a/src/wpt/harness/harness.ts
+++ b/src/wpt/harness/harness.ts
@@ -506,6 +506,11 @@ declare global {
   function setup(func: UnknownFunc | Record<string, unknown>): void;
   function add_completion_callback(func: UnknownFunc): void;
   function garbageCollect(): void;
+  function createBuffer(
+    type: 'ArrayBuffer' | 'SharedArrayBuffer',
+    length: number,
+    opts: { maxByteLength?: number } | undefined
+  ): ArrayBuffer | SharedArrayBuffer;
 }
 
 // eslint-disable-next-line  @typescript-eslint/no-unsafe-assignment -- eslint doesn't like "old-style" classes. Code is copied from WPT
@@ -1140,6 +1145,19 @@ globalThis.garbageCollect = (): void => {
   }
 };
 
+globalThis.createBuffer = (
+  type,
+  length,
+  _opts
+): ArrayBuffer | SharedArrayBuffer => {
+  switch (type) {
+    case 'ArrayBuffer':
+      return new ArrayBuffer(length);
+    case 'SharedArrayBuffer':
+      return new SharedArrayBuffer(length);
+  }
+};
+
 class Location {
   public get ancestorOrigins(): DOMStringList {
     return {
@@ -1284,6 +1302,7 @@ const EXCLUDED_PATHS = new Set([
   '/common/utils.js',
   '/common/get-host-info.sub.js',
   '/common/gc.js',
+  '/common/sab.js',
 ]);
 
 function replaceInterpolation(code: string): string {

--- a/src/wpt/harness/harness.ts
+++ b/src/wpt/harness/harness.ts
@@ -415,6 +415,11 @@ declare global {
     testCallback: TestFn | PromiseTestFn,
     testMessage: string
   ): void;
+  function subsetTest(
+    testType: TestRunnerFn,
+    testCallback: TestFn | PromiseTestFn,
+    testMessage: string
+  ): void;
   function promise_test(
     func: PromiseTestFn,
     name: string,
@@ -621,6 +626,15 @@ globalThis.subsetTestByKey = (
   testCallback,
   testMessage
 ): void => {
+  // This function is designed to allow selecting only certain tests when
+  // running in a browser, by changing the query string. We'll always run
+  // all the tests.
+
+  // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- We are emulating WPT's existing interface which always passes through the returned value
+  return testType(testCallback, testMessage);
+};
+
+globalThis.subsetTest = (testType, testCallback, testMessage): void => {
   // This function is designed to allow selecting only certain tests when
   // running in a browser, by changing the query string. We'll always run
   // all the tests.
@@ -1265,6 +1279,7 @@ function getBindingPath(base: string, rawPath: string): string {
 const EXCLUDED_PATHS = new Set([
   // Implemented in harness.ts
   '/common/subset-tests-by-key.js',
+  '/common/subset-tests.js',
   '/resources/utils.js',
   '/common/utils.js',
   '/common/get-host-info.sub.js',


### PR DESCRIPTION
* Support functions from several `/common/` files:
  - gc.js
  - sab.js (SharedArrayBuffer)
  - subset_tests.js
* Stub implementation of `format_value`
* `expectedFailures` and `skippedTests` can now contain regexes if WPT generates a pile of similar error messages.

Now that we're running everything in WebCryptoAPI, there are two effects:
1. We can remove the ad-hoc WPT-derived tests from the internal repo, as these will be easier to keep maintained.
2. The tests are now pretty slow, and take more than 60 s to run so they might time out in CI. I'm not sure what the best solution would be...