### PR TITLE
[nfc] Assorted JSG simplifications

### DIFF
--- a/src/workerd/api/form-data-memory-test.c++
+++ b/src/workerd/api/form-data-memory-test.c++
@@ -2,19 +2,10 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-#include "actor-state.h"
-#include "actor.h"
-#include "basics.h"
 #include "blob.h"
 #include "form-data.h"
-#include "http.h"
-#include "queue.h"
-#include "sockets.h"
-#include "sql.h"
 #include "streams.h"
-#include "web-socket.h"
 
-#include <workerd/io/promise-wrapper.h>
 #include <workerd/jsg/jsg-test.h>
 #include <workerd/jsg/jsg.h>
 
@@ -93,20 +84,11 @@ JSG_DECLARE_ISOLATE_TYPE(HeadersIsolate,
     // It's unfortunate but we have to pull in all of these sets of
     // types just for the test to build, even tho they aren't actually
     // used by or relevant to the test.
-    EW_ACTOR_ISOLATE_TYPES,
-    EW_ACTOR_STATE_ISOLATE_TYPES,
-    EW_BASICS_ISOLATE_TYPES,
-    EW_BLOB_ISOLATE_TYPES,
     EW_FORMDATA_ISOLATE_TYPES,
-    EW_QUEUE_ISOLATE_TYPES,
-    EW_URL_ISOLATE_TYPES,
-    EW_URL_STANDARD_ISOLATE_TYPES,
-    EW_SOCKETS_ISOLATE_TYPES,
-    EW_SQL_ISOLATE_TYPES,
-    EW_STREAMS_ISOLATE_TYPES,
-    EW_WEBSOCKET_ISOLATE_TYPES,
-    EW_HTTP_ISOLATE_TYPES,
-    jsg::TypeWrapperExtension<PromiseWrapper>);
+    workerd::api::Blob,
+    workerd::api::Blob::Options,
+    workerd::api::File,
+    workerd::api::File::Options);
 
 KJ_TEST("FormData memory is accounted for") {
   jsg::test::Evaluator<HeadersContext, HeadersIsolate, CompatibilityFlags::Reader> e(v8System);

--- a/src/workerd/api/headers-test.c++
+++ b/src/workerd/api/headers-test.c++
@@ -2,17 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-#include "actor-state.h"
-#include "actor.h"
-#include "basics.h"
-#include "blob.h"
-#include "form-data.h"
 #include "http.h"
-#include "queue.h"
-#include "sockets.h"
-#include "sql.h"
-#include "streams.h"
-#include "web-socket.h"
 
 #include <workerd/io/promise-wrapper.h>
 #include <workerd/jsg/jsg-test.h>
@@ -102,22 +92,7 @@ struct HeadersContext: public jsg::Object, public jsg::ContextGlobal {
 
 JSG_DECLARE_ISOLATE_TYPE(HeadersIsolate,
     HeadersContext,
-    // It's unfortunate but we have to pull in all of these sets of
-    // types just for the test to build, even tho they aren't actually
-    // used by or relevant to the test.
-    EW_ACTOR_ISOLATE_TYPES,
-    EW_ACTOR_STATE_ISOLATE_TYPES,
-    EW_BASICS_ISOLATE_TYPES,
-    EW_BLOB_ISOLATE_TYPES,
-    EW_FORMDATA_ISOLATE_TYPES,
-    EW_QUEUE_ISOLATE_TYPES,
-    EW_URL_ISOLATE_TYPES,
-    EW_URL_STANDARD_ISOLATE_TYPES,
-    EW_SOCKETS_ISOLATE_TYPES,
-    EW_SQL_ISOLATE_TYPES,
-    EW_STREAMS_ISOLATE_TYPES,
-    EW_WEBSOCKET_ISOLATE_TYPES,
-    EW_HTTP_ISOLATE_TYPES,
+    workerd::api::Headers,
     jsg::TypeWrapperExtension<PromiseWrapper>);
 
 KJ_TEST("Header memory is accounted for") {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -734,8 +734,8 @@ consteval size_t prefixLengthToStrip(const char (&s)[N]) {
       ::workerd::jsg::prefixLengthToStrip(#name)>
 // (Internal implementation details for JSG_STRUCT.)
 #define JSG_STRUCT_REGISTER_MEMBER(_, name)                                                        \
-  registry.template registerStructProperty<name##_JSG_NAME_DO_NOT_USE_DIRECTLY,                    \
-      decltype(::kj::instance<Self>().name), &Self::name>()
+  registry.template registerStructProperty<decltype(::kj::instance<Self>().name), &Self::name>(    \
+      name##_JSG_NAME_DO_NOT_USE_DIRECTLY)
 
 // Indexes for adding API data to V8's Isolate object.
 enum SetDataIndex {

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -1186,7 +1186,7 @@ struct JsSetup {
     ModuleRegistryImpl<TypeWrapper>::from(js)->addBuiltinBundle(bundle);
   }
 
-  template <const char* propertyName, const char* moduleName>
+  template <const char* moduleName>
   struct LazyJsInstancePropertyCallback {
     static void callback(
         v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Value>& info) {
@@ -1210,7 +1210,7 @@ struct JsSetup {
 
   template <const char* propertyName, const char* moduleName, bool readonly>
   inline void registerLazyJsInstanceProperty() {
-    using Callback = LazyJsInstancePropertyCallback<propertyName, moduleName>;
+    using Callback = LazyJsInstancePropertyCallback<moduleName>;
     check(context->Global()->SetLazyDataProperty(context, v8StrIntern(js.v8Isolate, propertyName),
         Callback::callback, v8::Local<v8::Value>(),
         readonly ? v8::PropertyAttribute::ReadOnly : v8::PropertyAttribute::None));
@@ -1504,7 +1504,63 @@ class ResourceWrapper {
   v8::Local<v8::FunctionTemplate> getTemplate(v8::Isolate* isolate, T*) {
     v8::Global<v8::FunctionTemplate>& slot = isContext ? contextConstructor : memoizedConstructor;
     if (slot.IsEmpty()) {
-      auto result = makeConstructor<isContext>(isolate);
+      // Construct lazily.
+      v8::EscapableHandleScope scope(isolate);
+
+      v8::Local<v8::FunctionTemplate> constructor;
+      if constexpr (!isContext && hasConstructorMethod((T*)nullptr)) {
+        constructor =
+            v8::FunctionTemplate::New(isolate, &ConstructorCallback<TypeWrapper, T>::callback);
+      } else {
+        constructor = v8::FunctionTemplate::New(isolate, &throwIllegalConstructor);
+      }
+
+      auto prototype = constructor->PrototypeTemplate();
+
+      // Signatures protect our methods from being invoked with the wrong `this`.
+      auto signature = v8::Signature::New(isolate, constructor);
+
+      auto instance = constructor->InstanceTemplate();
+
+      instance->SetInternalFieldCount(Wrappable::INTERNAL_FIELD_COUNT);
+
+      auto classname = v8StrIntern(isolate, typeName(typeid(T)));
+
+      if (getShouldSetToStringTag(isolate)) {
+        prototype->Set(
+            v8::Symbol::GetToStringTag(isolate), classname, v8::PropertyAttribute::DontEnum);
+      }
+
+      // Previously, miniflare would use the lack of a Symbol.toStringTag on a class to
+      // detect a type that came from the runtime. That's obviously a bit problematic because
+      // Symbol.toStringTag is required for full compliance on standard web platform APIs.
+      // To help use cases where it is necessary to detect if a class is a runtime class, we
+      // will add a special symbol to the prototype of the class to indicate. Note that
+      // because this uses the global symbol registry user code could still mark their own
+      // classes with this symbol but that's unlikely to be a problem in any practical case.
+      auto internalMarker =
+          v8::Symbol::For(isolate, v8StrIntern(isolate, "cloudflare:internal-class"));
+      prototype->Set(internalMarker, internalMarker,
+          static_cast<v8::PropertyAttribute>(v8::PropertyAttribute::DontEnum |
+              v8::PropertyAttribute::DontDelete | v8::PropertyAttribute::ReadOnly));
+
+      constructor->SetClassName(classname);
+
+      static_assert(kj::isSameType<typename T::jsgThis, T>(),
+          "Name passed to JSG_RESOURCE_TYPE() must be the class's own name.");
+
+      auto& typeWrapper = static_cast<TypeWrapper&>(*this);
+
+      ResourceTypeBuilder<TypeWrapper, T, isContext> builder(
+          typeWrapper, isolate, constructor, instance, prototype, signature);
+
+      if constexpr (isDetected<GetConfiguration, T>()) {
+        T::template registerMembers<decltype(builder), T>(builder, configuration);
+      } else {
+        T::template registerMembers<decltype(builder), T>(builder);
+      }
+
+      auto result = scope.Escape(constructor);
       slot.Reset(isolate, result);
       return result;
     } else {
@@ -1516,67 +1572,6 @@ class ResourceWrapper {
   Configuration configuration;
   v8::Global<v8::FunctionTemplate> memoizedConstructor;
   v8::Global<v8::FunctionTemplate> contextConstructor;
-
-  template <bool isContext>
-  v8::Local<v8::FunctionTemplate> makeConstructor(v8::Isolate* isolate) {
-    // Construct lazily.
-    v8::EscapableHandleScope scope(isolate);
-
-    v8::Local<v8::FunctionTemplate> constructor;
-    if constexpr (!isContext && hasConstructorMethod((T*)nullptr)) {
-      constructor =
-          v8::FunctionTemplate::New(isolate, &ConstructorCallback<TypeWrapper, T>::callback);
-    } else {
-      constructor = v8::FunctionTemplate::New(isolate, &throwIllegalConstructor);
-    }
-
-    auto prototype = constructor->PrototypeTemplate();
-
-    // Signatures protect our methods from being invoked with the wrong `this`.
-    auto signature = v8::Signature::New(isolate, constructor);
-
-    auto instance = constructor->InstanceTemplate();
-
-    instance->SetInternalFieldCount(Wrappable::INTERNAL_FIELD_COUNT);
-
-    auto classname = v8StrIntern(isolate, typeName(typeid(T)));
-
-    if (getShouldSetToStringTag(isolate)) {
-      prototype->Set(
-          v8::Symbol::GetToStringTag(isolate), classname, v8::PropertyAttribute::DontEnum);
-    }
-
-    // Previously, miniflare would use the lack of a Symbol.toStringTag on a class to
-    // detect a type that came from the runtime. That's obviously a bit problematic because
-    // Symbol.toStringTag is required for full compliance on standard web platform APIs.
-    // To help use cases where it is necessary to detect if a class is a runtime class, we
-    // will add a special symbol to the prototype of the class to indicate. Note that
-    // because this uses the global symbol registry user code could still mark their own
-    // classes with this symbol but that's unlikely to be a problem in any practical case.
-    auto internalMarker =
-        v8::Symbol::For(isolate, v8StrIntern(isolate, "cloudflare:internal-class"));
-    prototype->Set(internalMarker, internalMarker,
-        static_cast<v8::PropertyAttribute>(v8::PropertyAttribute::DontEnum |
-            v8::PropertyAttribute::DontDelete | v8::PropertyAttribute::ReadOnly));
-
-    constructor->SetClassName(classname);
-
-    static_assert(kj::isSameType<typename T::jsgThis, T>(),
-        "Name passed to JSG_RESOURCE_TYPE() must be the class's own name.");
-
-    auto& typeWrapper = static_cast<TypeWrapper&>(*this);
-
-    ResourceTypeBuilder<TypeWrapper, T, isContext> builder(
-        typeWrapper, isolate, constructor, instance, prototype, signature);
-
-    if constexpr (isDetected<GetConfiguration, T>()) {
-      T::template registerMembers<decltype(builder), T>(builder, configuration);
-    } else {
-      T::template registerMembers<decltype(builder), T>(builder);
-    }
-
-    return scope.Escape(constructor);
-  }
 
   void setupJavascript(jsg::Lock& js) {
     JsSetup<TypeWrapper, T> setup(js, js.v8Context());

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -609,8 +609,8 @@ struct MemberCounter {
     ++members;
   }
 
-  template <const char* name, typename Property, auto property>
-  inline void registerStructProperty() {
+  template <typename Property, auto property>
+  inline void registerStructProperty(const char* name) {
     ++members;
   }
 
@@ -789,8 +789,8 @@ struct MembersBuilder {
     // BuildRtti<Configuration, T>::build(constant.initType());
   }
 
-  template <const char* name, typename Property, Property Self::*property>
-  void registerStructProperty() {
+  template <typename Property, Property Self::*property>
+  void registerStructProperty(const char* name) {
     auto prop = members[memberIndex++].initProperty();
     prop.setName(name);
     BuildRtti<Configuration, Property>::build(prop.initType(), rtti);


### PR DESCRIPTION
[nfc] minor JSG simplifications to improve compile times
Cleaning up this and similar structures will help reduce code size since lots
of downstream code inherits from it.

[nfc] JSG memory tests: Only include required types
This makes the test binaries much smaller.

============

Cleaning up some old branch/stashes. Review this using `git diff -w` for clarity.