### PR TITLE
Add test duration to wd-tests too

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -4337,13 +4337,19 @@ kj::Promise<bool> Server::test(jsg::V8System& v8System,
     //   stderr wouldn't work.
     KJ_LOG(DBG, kj::str("[ TEST ] "_kj, name));
     auto req = service.startRequest({});
+    auto start = kj::systemPreciseMonotonicClock().now();
+
     bool result = co_await req->test();
     if (result) {
       ++passCount;
     } else {
       ++failCount;
     }
-    KJ_LOG(DBG, kj::str(result ? "[ PASS ] "_kj : "[ FAIL ] "_kj, name));
+
+    auto end = kj::systemPreciseMonotonicClock().now();
+    auto duration = end - start;
+
+    KJ_LOG(DBG, kj::str(result ? "[ PASS ] "_kj : "[ FAIL ] "_kj, name, " (", duration, ")"));
   };
 
   for (auto& service: services) {


### PR DESCRIPTION
C++ tests have a small note specifying the elapsed time of each test within the suite. Although workerd's JS test output is similar, it didn't previously include the duration. The value is automatically specified in an appropriate unit (e.g. us, ms, s)

Example output:
```
workerd/server/server.c++:4351: debug: [ PASS ] WebCryptoAPI:import_exportOkp_importkey_x448HttpsAny (634μs)
workerd/server/server.c++:4338: debug: [ TEST ] WebCryptoAPI:import_exportRsa_importkeyHttpsAny
workerd/server/server.c++:4351: debug: [ PASS ] WebCryptoAPI:import_exportRsa_importkeyHttpsAny (1.864743s)
workerd/server/server.c++:4338: debug: [ TEST ] WebCryptoAPI:import_exportSymmetric_importkeyHttpsAny
workerd/server/server.c++:4351: debug: [ PASS ] WebCryptoAPI:import_exportSymmetric_importkeyHttpsAny (432.037ms)
```