### PR TITLE
[o11y] Support more STW features

### DIFF
--- a/src/workerd/api/tail-worker-test.js
+++ b/src/workerd/api/tail-worker-test.js
@@ -9,6 +9,15 @@ export default {
   // https://developers.cloudflare.com/workers/observability/logs/tail-workers/
   tailStream(...args) {
     // Onset event, must be singleton
+
+    // For scheduled and alarm tests, override scheduledTime to make this test deterministic.
+    if (
+      args[0].event.info.type == 'scheduled' ||
+      args[0].event.info.type == 'alarm'
+    ) {
+      args[0].event.info.scheduledTime = '1970-01-01T00:00:00.000Z';
+    }
+
     resposeMap.set(args[0].traceId, JSON.stringify(args[0].event));
     return (...args) => {
       // TODO(streaming-tail-worker): Support several queued elements

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -200,8 +200,14 @@ jsg::JsValue ToJs(jsg::Lock& js, const tracing::JsRpcEventInfo& info, StringCach
 jsg::JsValue ToJs(jsg::Lock& js, const tracing::ScheduledEventInfo& info, StringCache& cache) {
   auto obj = js.obj();
   obj.set(js, TYPE_STR, cache.get(js, SCHEDULED_STR));
-  // TODO (streaming-tail-worker): Make timestamp available again, except when running tests
-  obj.set(js, SCHEDULEDTIME_STR, js.date(kj::UNIX_EPOCH));
+  if (isPredictableModeForTest()) {
+    obj.set(js, SCHEDULEDTIME_STR, js.date(kj::UNIX_EPOCH));
+  } else {
+    // TODO(streaming-tail): Depending on if the schedule handler is invoked with a scheduledTime
+    // argument or not, the value in the trace can be either the current time or the scheduledTime
+    // parameter. Is this the correct behavior?
+    obj.set(js, SCHEDULEDTIME_STR, js.date(info.scheduledTime));
+  }
   obj.set(js, CRON_STR, js.str(info.cron));
   return obj;
 }
@@ -209,8 +215,11 @@ jsg::JsValue ToJs(jsg::Lock& js, const tracing::ScheduledEventInfo& info, String
 jsg::JsValue ToJs(jsg::Lock& js, const tracing::AlarmEventInfo& info, StringCache& cache) {
   auto obj = js.obj();
   obj.set(js, TYPE_STR, cache.get(js, ALARM_STR));
-  // TODO (streaming-tail-worker): Make timestamp available again, except when running tests
-  obj.set(js, SCHEDULEDTIME_STR, js.date(kj::UNIX_EPOCH));
+  if (isPredictableModeForTest()) {
+    obj.set(js, SCHEDULEDTIME_STR, js.date(kj::UNIX_EPOCH));
+  } else {
+    obj.set(js, SCHEDULEDTIME_STR, js.date(info.scheduledTime));
+  }
   return obj;
 }
 

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -747,10 +747,12 @@ class TailStreamTarget final: public rpc::TailStreamTarget::Server {
 
     // Invoke the tailStream handler function.
     v8::Local<v8::Function> fn = maybeFn.As<v8::Function>();
-    v8::Local<v8::Value> obj = ToJs(js, event, stringCache);
+    v8::LocalVector<v8::Value> handlerArgs(js.v8Isolate, 2);
+    handlerArgs[0] = ToJs(js, event, stringCache);
+    handlerArgs[1] = handler->env.getHandle(js);
 
     try {
-      auto result = jsg::check(fn->Call(js.v8Context(), target, 1, &obj));
+      auto result = jsg::check(fn->Call(js.v8Context(), target, 2, handlerArgs.data()));
 
       // We need to be able to access the results builder from both the
       // success and failure branches of the promise we set up below.

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -661,6 +661,11 @@ class TailStreamTarget final: public rpc::TailStreamTarget::Server {
       for (auto reader: eventReaders) {
         events.add(tracing::TailEvent(reader));
       }
+      // TODO(streaming-tail): Timestamp handling here serves as a placeholder, proper
+      // implementation will be more work, incl. addressing potential spectre concerns.
+      for (auto& event: events) {
+        event.timestamp = ioContext.now();
+      }
 
       // If we have not yet received the onset event, the first event in the
       // received collection must be an Onset event and must be handled separately.


### PR DESCRIPTION
- [o11y] Support STW event scheduledTime
- [o11y] Support env in tailStream
  The ctx argument will be suported in a follow-up.
- [o11y] Provide unique span IDs for streaming tail worker
- [o11y] Add initial timestamp support
  We might do this completely differently (possibly providing tracee time instead of tracer time), but having timestamps available aids evaluation.
