### PR TITLE
Python: Make a relaxed call to Python entrypoint class handlers

### DIFF
--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -243,7 +243,11 @@ function makeEntrypointProxyHandler(
       return async function (...args: any[]): Promise<any> {
         const pyInstance = await pyInstancePromise;
         if (typeof pyInstance[prop] === 'function') {
-          const res = await doPyCall(pyInstance[prop], args);
+          const res = await doPyCallHelper(
+            isKnownHandler,
+            pyInstance[prop],
+            args
+          );
           if (isKnownHandler) {
             return res?.js_object ?? res;
           }

--- a/src/workerd/server/tests/python/durable-object/worker.py
+++ b/src/workerd/server/tests/python/durable-object/worker.py
@@ -14,7 +14,7 @@ class DurableObjectExample(DurableObject):
         self.state = state
         self.counter = 0
 
-    async def on_fetch(self, req, env, ctx):
+    async def on_fetch(self):
         self.counter += 1
         return Response(f"hello from python {self.counter}")
 


### PR DESCRIPTION
Allows us to define entrypoint class handlers that take fewer than 4 arguments.

- [x] Add a test