### PR TITLE
Python: Add back in reportError

### DIFF
--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -31,6 +31,7 @@ import { default as SetupEmscripten } from 'internal:setup-emscripten';
 
 import { default as UnsafeEval } from 'internal:unsafe-eval';
 import { simpleRunPython } from 'pyodide-internal:util';
+import { reportError } from 'pyodide-internal:util';
 import { loadPackages } from 'pyodide-internal:loadPackage';
 import { default as MetadataReader } from 'pyodide-internal:runtime-generated/metadata';
 
@@ -112,56 +113,62 @@ export async function loadPyodide(
   lockfile: PackageLock,
   indexURL: string
 ): Promise<Pyodide> {
-  const Module = enterJaegerSpan('instantiate_emscripten', () =>
-    SetupEmscripten.getModule()
-  );
-  Module.API.config.jsglobals = globalThis;
-  if (isWorkerd) {
-    Module.API.config.indexURL = indexURL;
-    Module.API.config.resolveLockFilePromise!(lockfile);
-  }
-  Module.setUnsafeEval(UnsafeEval);
-  Module.setGetRandomValues(getRandomValues);
-
-  mountSitePackages(Module, VIRTUALIZED_DIR);
-  entropyMountFiles(Module);
-  await enterJaegerSpan('load_packages', () =>
-    // NB. loadPackages adds the packages to the `VIRTUALIZED_DIR` global which then gets used in
-    // preloadDynamicLibs.
-    loadPackages(Module, TRANSITIVE_REQUIREMENTS)
-  );
-
-  enterJaegerSpan('prepare_wasm_linear_memory', () => {
-    prepareWasmLinearMemory(Module);
-  });
-
-  maybeCollectSnapshot(Module);
-  // Mount worker files after doing snapshot upload so we ensure that data from the files is never
-  // present in snapshot memory.
-  mountWorkerFiles(Module);
-
-  if (Module.API.version === '0.26.0a2') {
-    // Finish setting up Pyodide's ffi so we can use the nice Python interface
-    // In newer versions we already did this in prepareWasmLinearMemory.
-    enterJaegerSpan('finalize_bootstrap', Module.API.finalizeBootstrap);
-  }
-  const pyodide = Module.API.public_api;
-
-  finishSnapshotSetup(pyodide);
-
-  validatePyodideVersion(pyodide);
-
-  // Need to set these here so that the logs go to the right context. If we don't they will go
-  // to SetupEmscripten's context and end up being KJ_LOG'd, which we do not want.
-  Module.API.initializeStreams(
-    null,
-    (msg) => {
-      console.log(msg);
-    },
-    (msg) => {
-      console.error(msg);
+  try {
+    const Module = enterJaegerSpan('instantiate_emscripten', () =>
+      SetupEmscripten.getModule()
+    );
+    Module.API.config.jsglobals = globalThis;
+    if (isWorkerd) {
+      Module.API.config.indexURL = indexURL;
+      Module.API.config.resolveLockFilePromise!(lockfile);
     }
-  );
-  maybeAddVendorDirectoryToPath(pyodide);
-  return pyodide;
+    Module.setUnsafeEval(UnsafeEval);
+    Module.setGetRandomValues(getRandomValues);
+
+    mountSitePackages(Module, VIRTUALIZED_DIR);
+    entropyMountFiles(Module);
+    await enterJaegerSpan('load_packages', () =>
+      // NB. loadPackages adds the packages to the `VIRTUALIZED_DIR` global which then gets used in
+      // preloadDynamicLibs.
+      loadPackages(Module, TRANSITIVE_REQUIREMENTS)
+    );
+
+    enterJaegerSpan('prepare_wasm_linear_memory', () => {
+      prepareWasmLinearMemory(Module);
+    });
+
+    maybeCollectSnapshot(Module);
+    // Mount worker files after doing snapshot upload so we ensure that data from the files is never
+    // present in snapshot memory.
+    mountWorkerFiles(Module);
+
+    if (Module.API.version === '0.26.0a2') {
+      // Finish setting up Pyodide's ffi so we can use the nice Python interface
+      // In newer versions we already did this in prepareWasmLinearMemory.
+      enterJaegerSpan('finalize_bootstrap', Module.API.finalizeBootstrap);
+    }
+    const pyodide = Module.API.public_api;
+
+    finishSnapshotSetup(pyodide);
+
+    validatePyodideVersion(pyodide);
+
+    // Need to set these here so that the logs go to the right context. If we don't they will go
+    // to SetupEmscripten's context and end up being KJ_LOG'd, which we do not want.
+    Module.API.initializeStreams(
+      null,
+      (msg) => {
+        console.log(msg);
+      },
+      (msg) => {
+        console.error(msg);
+      }
+    );
+    maybeAddVendorDirectoryToPath(pyodide);
+    return pyodide;
+  } catch (e) {
+    // In edgeworker test suite, without this we get the file name and line number of the exception
+    // but no traceback. This gives us a full traceback.
+    reportError(e as Error);
+  }
 }

--- a/src/pyodide/internal/util.ts
+++ b/src/pyodide/internal/util.ts
@@ -1,3 +1,13 @@
+// Split the stack into lines and print them individually.
+// We do this because edgeworker's test runner will put a multiline log all on one line. This is
+// very hard to read.
+export function reportError(e: Error): never {
+  e.stack?.split('\n').forEach((s: string) => {
+    console.warn(s);
+  });
+  throw e;
+}
+
 /**
  *  Simple as possible runPython function which works with no foreign function
  *  interface. We need to use this rather than the normal easier to use


### PR DESCRIPTION
This is a partial revert of #4001. Without this help, edgeworker tests show:
```
2.267743795s	1m10	2025.4.1200-4-gdecc02ecd-dev error   workerd/io/worker.c++:287
script startup threw exception; id = 79b9b0009762ad21278ebf245600582fefcdd203d9aeb3efaa2105eb948f6b2f;
description = jsg.TypeError: Cannot read properties of undefined (reading 'snapshotSize');
trace =   at pyodide-internal:snapshot:140:43; ownerId = 1212; zoneId = test-zone;
scriptId = m.python; cordon = paid; process = shared
```
AKA not a traceback, and not even the name of the function the error occurred in. With this help, we get a nice traceback in the edgeworker logs.

cc @anonrig