### PR TITLE
Python: Repalce USING_OLDEST_PYODIDE_VERSION with pyodide.version, NFC

### DIFF
--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -10,8 +10,6 @@ export const LOAD_WHEELS_FROM_R2: boolean = IS_WORKERD;
 export const LOAD_WHEELS_FROM_ARTIFACT_BUNDLER =
   MetadataReader.shouldUsePackagesInArtifactBundler();
 export const PACKAGES_VERSION = MetadataReader.getPackagesVersion();
-export const USING_OLDEST_PYODIDE_VERSION =
-  MetadataReader.getPyodideVersion() == '0.26.0a2';
 export const USING_OLDEST_PACKAGES_VERSION = PACKAGES_VERSION === '20240829.4';
 // TODO: pyodide-packages.runtime-playground.workers.dev points at a worker which redirects requests
 // to the public R2 bucket URL at pub-45d734c4145d4285b343833ee450ef38.r2.dev. We should remove

--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -14,7 +14,6 @@ import {
   LOCKFILE,
   MAIN_MODULE_NAME,
   WORKERD_INDEX_URL,
-  USING_OLDEST_PYODIDE_VERSION,
   DURABLE_OBJECT_CLASSES,
   WORKER_ENTRYPOINT_CLASSES,
   SHOULD_SNAPSHOT_TO_DISK,
@@ -112,7 +111,7 @@ async function setupPatches(pyodide: Pyodide): Promise<void> {
     //
     // NOTE: setupPatches is called after memorySnapshotDoImports, so any modules injected here
     // shouldn't be part of the snapshot and should filtered out in filterPythonScriptImports.
-    if (USING_OLDEST_PYODIDE_VERSION) {
+    if (pyodide.version === '0.26.0a2') {
       // Inject at cloudflare.workers for backwards compatibility
       pyodide.FS.mkdir(`${sitePackages}/cloudflare`);
       await injectSitePackagesModule(pyodide, 'workers', 'cloudflare/workers');

--- a/src/pyodide/types/Pyodide.d.ts
+++ b/src/pyodide/types/Pyodide.d.ts
@@ -27,5 +27,5 @@ interface Pyodide {
   loadPackage: (names: string | string[], options: object) => Promise<any[]>;
   setStdout: (options?: any) => void;
   setStderr: (options?: any) => void;
-  version: string;
+  version: API['version'];
 }


### PR DESCRIPTION
We should also make `MetadataReader.getPyodideVersion()` return the right value so we can have conditional code before the runtime is loaded, but for now we don't need it.