### PR TITLE
[o11y] Harmonize span tag types between existing tracing and user tracing/Streaming Tail Worker

### DIFF
--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -68,7 +68,7 @@ struct ScriptVersion {
 
 struct OTelSpanTag final: public jsg::Object {
   kj::String key;
-  kj::OneOf<bool, int64_t, double, kj::String> value;
+  Span::TagValue value;
   JSG_STRUCT(key, value);
 };
 

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -133,8 +133,8 @@ jsg::JsValue ToJs(jsg::Lock& js, const tracing::Attribute::Value& value) {
     KJ_CASE_ONEOF(d, double) {
       return js.num(d);
     }
-    KJ_CASE_ONEOF(i, int32_t) {
-      return js.num(i);
+    KJ_CASE_ONEOF(i, int64_t) {
+      return js.bigInt(i);
     }
   }
   KJ_UNREACHABLE;

--- a/src/workerd/io/trace-test.c++
+++ b/src/workerd/io/trace-test.c++
@@ -595,7 +595,7 @@ KJ_TEST("Read/Write TailEvent with Multiple Attributes") {
   // An attribute event can have one or more Attributes specified.
   kj::Vector<tracing::Attribute> attrs(2);
   attrs.add(tracing::Attribute(kj::str("foo"), true));
-  attrs.add(tracing::Attribute(kj::str("bar"), 123));
+  attrs.add(tracing::Attribute(kj::str("bar"), (int64_t)123));
 
   tracing::TailEvent info(context, kj::UNIX_EPOCH, 0, tracing::Mark(attrs.releaseAsArray()));
   info.copyTo(infoBuilder);

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -875,7 +875,7 @@ kj::Array<tracing::Attribute::Value> readValues(const rpc::Trace::Attribute::Rea
         return inner.getFloat();
       }
       case rpc::Trace::Attribute::Value::Inner::INT: {
-        return static_cast<int32_t>(inner.getInt());
+        return static_cast<int64_t>(inner.getInt());
       }
     }
     KJ_UNREACHABLE;
@@ -908,7 +908,7 @@ void tracing::Attribute::copyTo(rpc::Trace::Attribute::Builder builder) const {
       KJ_CASE_ONEOF(f, double) {
         builder.initInner().setFloat(f);
       }
-      KJ_CASE_ONEOF(i, int32_t) {
+      KJ_CASE_ONEOF(i, int64_t) {
         builder.initInner().setInt(i);
       }
     }
@@ -932,7 +932,7 @@ tracing::Attribute tracing::Attribute::clone() const {
       KJ_CASE_ONEOF(f, double) {
         return f;
       }
-      KJ_CASE_ONEOF(i, int32_t) {
+      KJ_CASE_ONEOF(i, int64_t) {
         return i;
       }
     }
@@ -1641,10 +1641,7 @@ Span::TagValue spanTagClone(const Span::TagValue& tag) {
       return kj::str(str);
     }
     KJ_CASE_ONEOF(val, int64_t) {
-      // TODO(o11y): We can't stringify BigInt, which causes test problems. Export this as hex
-      // instead? Then again OTel assumes that int values can be represented as JS numbers, so
-      // representing this as a double/Number might be fine despite the possible precision loss.
-      return kj::str(val);
+      return val;
     }
     KJ_CASE_ONEOF(val, double) {
       return val;

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -555,14 +555,14 @@ EventInfo cloneEventInfo(const EventInfo& info);
 
 template <typename T>
 concept AttributeValue = kj::isSameType<kj::String, T>() || kj::isSameType<bool, T>() ||
-    kj::isSameType<double, T>() || kj::isSameType<int32_t, T>();
+    kj::isSameType<double, T>() || kj::isSameType<int64_t, T>();
 
 // An Attribute mark is used to add detail to a span over its lifetime.
 // The Attribute struct can also be used to provide arbitrary additional
 // properties for some other structs.
 // Modeled after https://opentelemetry.io/docs/concepts/signals/traces/#attributes
 struct Attribute final {
-  using Value = kj::OneOf<kj::String, bool, double, int32_t>;
+  using Value = kj::OneOf<kj::String, bool, double, int64_t>;
   using Values = kj::Array<Value>;
 
   explicit Attribute(kj::String name, Value&& value);
@@ -893,7 +893,7 @@ struct Span {
   // create a `Span`, use a `SpanBuilder`.
 
  public:
-  using TagValue = kj::OneOf<bool, int64_t, double, kj::String>;
+  using TagValue = tracing::Attribute::Value;
   // TODO(someday): Support binary bytes, too.
   using TagMap = kj::HashMap<kj::ConstString, TagValue>;
   using Tag = TagMap::Entry;

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -173,7 +173,7 @@ struct Trace @0x8e8d911203762d34 {
       inner :union {
         text @0 :Text;
         bool @1 :Bool;
-        int @2 :Int32;
+        int @2 :Int64;
         float @3 :Float64;
       }
     }

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -2637,7 +2637,7 @@ interface OTelSpan {
 }
 interface OTelSpanTag {
   key: string;
-  value: boolean | (number | bigint) | number | string;
+  value: string | boolean | number | (number | bigint);
 }
 interface TraceException {
   readonly timestamp: number;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -2649,7 +2649,7 @@ export interface OTelSpan {
 }
 export interface OTelSpanTag {
   key: string;
-  value: boolean | (number | bigint) | number | string;
+  value: string | boolean | number | (number | bigint);
 }
 export interface TraceException {
   readonly timestamp: number;


### PR DESCRIPTION
The definitions differed by having int32_t or int64_t, respectively.