### PR TITLE
Python: Clean up package loading, NFC

### DIFF
--- a/src/pyodide/internal/loadPackage.ts
+++ b/src/pyodide/internal/loadPackage.ts
@@ -12,10 +12,9 @@
 import {
   WORKERD_INDEX_URL,
   LOCKFILE,
-  LOAD_WHEELS_FROM_R2,
-  LOAD_WHEELS_FROM_ARTIFACT_BUNDLER,
   PACKAGES_VERSION,
   USING_OLDEST_PACKAGES_VERSION,
+  IS_WORKERD,
 } from 'pyodide-internal:metadata';
 import {
   VIRTUALIZED_DIR,
@@ -178,11 +177,11 @@ export async function loadPackages(
   if (USING_OLDEST_PACKAGES_VERSION) {
     pkgsToLoad = pkgsToLoad.union(new Set(STDLIB_PACKAGES));
   }
-  if (LOAD_WHEELS_FROM_R2) {
+  if (IS_WORKERD) {
     await loadPackagesImpl(Module, pkgsToLoad, (req) =>
       loadBundleFromR2WithRetry(req, 0)
     );
-  } else if (LOAD_WHEELS_FROM_ARTIFACT_BUNDLER) {
+  } else {
     await loadPackagesImpl(Module, pkgsToLoad, loadBundleFromArtifactBundler);
   }
 }

--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -6,9 +6,6 @@ export const IS_TRACING = MetadataReader.isTracing();
 export const SHOULD_SNAPSHOT_TO_DISK = MetadataReader.shouldSnapshotToDisk();
 export const IS_CREATING_BASELINE_SNAPSHOT =
   MetadataReader.isCreatingBaselineSnapshot();
-export const LOAD_WHEELS_FROM_R2: boolean = IS_WORKERD;
-export const LOAD_WHEELS_FROM_ARTIFACT_BUNDLER =
-  MetadataReader.shouldUsePackagesInArtifactBundler();
 export const PACKAGES_VERSION = MetadataReader.getPackagesVersion();
 export const USING_OLDEST_PACKAGES_VERSION = PACKAGES_VERSION === '20240829.4';
 // TODO: pyodide-packages.runtime-playground.workers.dev points at a worker which redirects requests
@@ -23,7 +20,11 @@ export const WORKERD_INDEX_URL = USING_OLDEST_PACKAGES_VERSION
 export const LOCKFILE = JSON.parse(
   MetadataReader.getPackagesLock()
 ) as PackageLock;
+
 export const REQUIREMENTS = MetadataReader.getRequirements();
+export const TRANSITIVE_REQUIREMENTS =
+  MetadataReader.getTransitiveRequirements();
+
 export const MAIN_MODULE_NAME = MetadataReader.getMainModule();
 export const MEMORY_SNAPSHOT_READER = MetadataReader.hasMemorySnapshot()
   ? MetadataReader

--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -1,9 +1,6 @@
 import { enterJaegerSpan } from 'pyodide-internal:jaeger';
 import {
-  VIRTUALIZED_DIR,
-  TRANSITIVE_REQUIREMENTS,
   adjustSysPath,
-  mountSitePackages,
   mountWorkerFiles,
 } from 'pyodide-internal:setupPackages';
 import {
@@ -34,6 +31,7 @@ import { simpleRunPython } from 'pyodide-internal:util';
 import { reportError } from 'pyodide-internal:util';
 import { loadPackages } from 'pyodide-internal:loadPackage';
 import { default as MetadataReader } from 'pyodide-internal:runtime-generated/metadata';
+import { TRANSITIVE_REQUIREMENTS } from 'pyodide-internal:metadata';
 
 /**
  * After running `instantiateEmscriptenModule` but before calling into any C
@@ -125,7 +123,6 @@ export async function loadPyodide(
     Module.setUnsafeEval(UnsafeEval);
     Module.setGetRandomValues(getRandomValues);
 
-    mountSitePackages(Module, VIRTUALIZED_DIR);
     entropyMountFiles(Module);
     await enterJaegerSpan('load_packages', () =>
       // NB. loadPackages adds the packages to the `VIRTUALIZED_DIR` global which then gets used in

--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -4,14 +4,12 @@
 
 import { loadPyodide } from 'pyodide-internal:python';
 import { enterJaegerSpan } from 'pyodide-internal:jaeger';
-import {
-  TRANSITIVE_REQUIREMENTS,
-  patchLoadPackage,
-} from 'pyodide-internal:setupPackages';
+import { patchLoadPackage } from 'pyodide-internal:setupPackages';
 import {
   IS_TRACING,
   IS_WORKERD,
   LOCKFILE,
+  TRANSITIVE_REQUIREMENTS,
   MAIN_MODULE_NAME,
   WORKERD_INDEX_URL,
   DURABLE_OBJECT_CLASSES,

--- a/src/pyodide/types/runtime-generated/metadata.d.ts
+++ b/src/pyodide/types/runtime-generated/metadata.d.ts
@@ -15,7 +15,6 @@ declare namespace MetadataReader {
   ) => void;
   const getMemorySnapshotSize: () => number;
   const disposeMemorySnapshot: () => void;
-  const shouldUsePackagesInArtifactBundler: () => boolean;
   const getPyodideVersion: () => string;
   const getPackagesVersion: () => string;
   const getPackagesLock: () => string;

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -116,7 +116,6 @@ class PyodideMetadataReader: public jsg::Object {
     bool isTracingFlag;
     bool snapshotToDisk;
     bool createBaselineSnapshot;
-    bool usePackagesInArtifactBundler;
     kj::Maybe<kj::Array<kj::byte>> memorySnapshot;
     kj::Maybe<kj::Array<kj::String>> durableObjectClasses;
     kj::Maybe<kj::Array<kj::String>> entrypointClasses;
@@ -132,7 +131,6 @@ class PyodideMetadataReader: public jsg::Object {
         bool isTracing,
         bool snapshotToDisk,
         bool createBaselineSnapshot,
-        bool usePackagesInArtifactBundler,
         kj::Maybe<kj::Array<kj::byte>> memorySnapshot,
         kj::Maybe<kj::Array<kj::String>> durableObjectClasses,
         kj::Maybe<kj::Array<kj::String>> entrypointClasses)
@@ -146,7 +144,6 @@ class PyodideMetadataReader: public jsg::Object {
           isTracingFlag(isTracing),
           snapshotToDisk(snapshotToDisk),
           createBaselineSnapshot(createBaselineSnapshot),
-          usePackagesInArtifactBundler(usePackagesInArtifactBundler),
           memorySnapshot(kj::mv(memorySnapshot)),
           durableObjectClasses(kj::mv(durableObjectClasses)),
           entrypointClasses(kj::mv(entrypointClasses)) {}
@@ -202,10 +199,6 @@ class PyodideMetadataReader: public jsg::Object {
   }
   int readMemorySnapshot(int offset, kj::Array<kj::byte> buf);
 
-  bool shouldUsePackagesInArtifactBundler() {
-    return state->usePackagesInArtifactBundler;
-  }
-
   kj::StringPtr getPyodideVersion() {
     return state->pyodideVersion;
   }
@@ -248,7 +241,6 @@ class PyodideMetadataReader: public jsg::Object {
     JSG_METHOD(readMemorySnapshot);
     JSG_METHOD(disposeMemorySnapshot);
     JSG_METHOD(shouldSnapshotToDisk);
-    JSG_METHOD(shouldUsePackagesInArtifactBundler);
     JSG_METHOD(getPyodideVersion);
     JSG_METHOD(getPackagesVersion);
     JSG_METHOD(getPackagesLock);

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -248,7 +248,6 @@ kj::Own<api::pyodide::PyodideMetadataReader::State> makePyodideMetadataReader(
     false     /* isTracing */,
     snapshotToDisk,
     pythonConfig.createBaselineSnapshot,
-    false,    /* usePackagesInArtifactBundler */
     kj::mv(memorySnapshot),
     kj::mv(durableObjectClasses),
     entrypointClasses.releaseAsArray()


### PR DESCRIPTION
LOAD_WHEELS_FROM_ARTIFACT_BUNDLER, has become equal to !IS_WORKERD and LOAD_WHEELS_FROM_R2 has become equal to !IS_WORKERD. So I removed these two variables and all code behind `!LOAD_WHEELS_FROM_R2 && !LOAD_WHEELS_FROM_ARTIFACT_BUNDLER` which is always `false`.