### PR TITLE
Cleans up memorySnapshot in WorkerBundle.

### DIFF
--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -101,6 +101,7 @@ BUNDLE_VERSION_INFO = make_bundle_version_info([
         "pyodide_date": "dev",
         "id": "dev",
         "flag": "pythonWorkersDevPyodide",
+        # This has a special value for baseline_from_gcs.ew-test-bin.
         "baseline_snapshot_hash": "92859211804cd350f9e14010afad86e584bdd017dc7acfd94709a87f3220afae",
     },
 ])

--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -26,10 +26,8 @@ export const TRANSITIVE_REQUIREMENTS =
   MetadataReader.getTransitiveRequirements();
 
 export const MAIN_MODULE_NAME = MetadataReader.getMainModule();
-export const MEMORY_SNAPSHOT_READER = MetadataReader.hasMemorySnapshot()
-  ? MetadataReader
-  : ArtifactBundler.hasMemorySnapshot()
-    ? ArtifactBundler
-    : undefined;
+export const MEMORY_SNAPSHOT_READER = ArtifactBundler.hasMemorySnapshot()
+  ? ArtifactBundler
+  : undefined;
 export const DURABLE_OBJECT_CLASSES = MetadataReader.getDurableObjectClasses();
 export const WORKER_ENTRYPOINT_CLASSES = MetadataReader.getEntrypointClasses();

--- a/src/pyodide/types/runtime-generated/metadata.d.ts
+++ b/src/pyodide/types/runtime-generated/metadata.d.ts
@@ -5,16 +5,10 @@ declare namespace MetadataReader {
   const isCreatingBaselineSnapshot: () => boolean;
   const getRequirements: () => string[];
   const getMainModule: () => string;
-  const hasMemorySnapshot: () => boolean;
   const getNames: () => string[];
   const getPackageSnapshotImports: (version: string) => string[];
   const getSizes: () => number[];
-  const readMemorySnapshot: (
-    offset: number,
-    buf: Uint32Array | Uint8Array
-  ) => void;
-  const getMemorySnapshotSize: () => number;
-  const disposeMemorySnapshot: () => void;
+  const shouldUsePackagesInArtifactBundler: () => boolean;
   const getPyodideVersion: () => string;
   const getPackagesVersion: () => string;
   const getPackagesLock: () => string;

--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -154,13 +154,6 @@ int PyodideMetadataReader::read(jsg::Lock& js, int index, int offset, kj::Array<
   return readToTarget(data, offset, buf);
 }
 
-int PyodideMetadataReader::readMemorySnapshot(int offset, kj::Array<kj::byte> buf) {
-  if (state->memorySnapshot == kj::none) {
-    return 0;
-  }
-  return readToTarget(KJ_REQUIRE_NONNULL(state->memorySnapshot), offset, buf);
-}
-
 kj::HashSet<kj::String> PyodideMetadataReader::getTransitiveRequirements() {
   auto packages = parseLockFile(state->packagesLock);
   auto depMap = getDepMapFromPackagesLock(*packages);

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -131,7 +131,6 @@ class PyodideMetadataReader: public jsg::Object {
         bool isTracing,
         bool snapshotToDisk,
         bool createBaselineSnapshot,
-        kj::Maybe<kj::Array<kj::byte>> memorySnapshot,
         kj::Maybe<kj::Array<kj::String>> durableObjectClasses,
         kj::Maybe<kj::Array<kj::String>> entrypointClasses)
         : mainModule(kj::mv(mainModule)),
@@ -144,7 +143,6 @@ class PyodideMetadataReader: public jsg::Object {
           isTracingFlag(isTracing),
           snapshotToDisk(snapshotToDisk),
           createBaselineSnapshot(createBaselineSnapshot),
-          memorySnapshot(kj::mv(memorySnapshot)),
           durableObjectClasses(kj::mv(durableObjectClasses)),
           entrypointClasses(kj::mv(entrypointClasses)) {}
   };
@@ -184,21 +182,6 @@ class PyodideMetadataReader: public jsg::Object {
 
   int read(jsg::Lock& js, int index, int offset, kj::Array<kj::byte> buf);
 
-  bool hasMemorySnapshot() {
-    return state->memorySnapshot != kj::none;
-  }
-  int getMemorySnapshotSize() {
-    if (state->memorySnapshot == kj::none) {
-      return 0;
-    }
-    return KJ_REQUIRE_NONNULL(state->memorySnapshot).size();
-  }
-
-  void disposeMemorySnapshot() {
-    state->memorySnapshot = kj::none;
-  }
-  int readMemorySnapshot(int offset, kj::Array<kj::byte> buf);
-
   kj::StringPtr getPyodideVersion() {
     return state->pyodideVersion;
   }
@@ -236,10 +219,6 @@ class PyodideMetadataReader: public jsg::Object {
     JSG_METHOD(getSizes);
     JSG_METHOD(getPackageSnapshotImports);
     JSG_METHOD(read);
-    JSG_METHOD(hasMemorySnapshot);
-    JSG_METHOD(getMemorySnapshotSize);
-    JSG_METHOD(readMemorySnapshot);
-    JSG_METHOD(disposeMemorySnapshot);
     JSG_METHOD(shouldSnapshotToDisk);
     JSG_METHOD(getPyodideVersion);
     JSG_METHOD(getPackagesVersion);

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -248,7 +248,6 @@ kj::Own<api::pyodide::PyodideMetadataReader::State> makePyodideMetadataReader(
     false     /* isTracing */,
     snapshotToDisk,
     pythonConfig.createBaselineSnapshot,
-    kj::mv(memorySnapshot),
     kj::mv(durableObjectClasses),
     entrypointClasses.releaseAsArray()
   );


### PR DESCRIPTION
The memory snapshot is only ever loaded via the ArtifactBundler, so this should no longer be necessary.