### PR TITLE
Use using instead of typedef for consistency

### DIFF
--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -125,7 +125,7 @@ class DurableObjectStorageOperations {
   jsg::Promise<void> deleteAlarm(jsg::Lock& js, jsg::Optional<SetAlarmOptions> options);
 
  protected:
-  typedef kj::StringPtr OpName;
+  using OpName = kj::StringPtr;
   static constexpr OpName OP_GET = "get()"_kj;
   static constexpr OpName OP_GET_ALARM = "getAlarm()"_kj;
   static constexpr OpName OP_LIST = "list()"_kj;

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -320,7 +320,8 @@ class EventTarget: public jsg::Object {
   using AddEventListenerOpts = kj::OneOf<AddEventListenerOptions, bool>;
   using EventListenerOpts = kj::OneOf<EventListenerOptions, bool>;
 
-  typedef jsg::Function<jsg::Optional<jsg::Value>(jsg::Ref<Event>)> HandlerFunction;
+  using HandlerFunction = jsg::Function<jsg::Optional<jsg::Value>(jsg::Ref<Event>)>;
+
   struct HandlerObject {
     HandlerFunction handleEvent;
     JSG_STRUCT(handleEvent);
@@ -330,7 +331,7 @@ class EventTarget: public jsg::Object {
       handleEvent: (event: Event) => any | undefined;
     });
   };
-  typedef kj::OneOf<HandlerFunction, HandlerObject> Handler;
+  using Handler = kj::OneOf<HandlerFunction, HandlerObject>;
 
   void addEventListener(jsg::Lock& js,
       kj::String type,

--- a/src/workerd/api/blob.h
+++ b/src/workerd/api/blob.h
@@ -29,7 +29,7 @@ class Blob: public jsg::Object {
     JSG_STRUCT(type, endings);
   };
 
-  typedef kj::Array<kj::OneOf<kj::Array<const byte>, kj::String, jsg::Ref<Blob>>> Bits;
+  using Bits = kj::Array<kj::OneOf<kj::Array<const byte>, kj::String, jsg::Ref<Blob>>>;
 
   static jsg::Ref<Blob> constructor(
       jsg::Lock& js, jsg::Optional<Bits> bits, jsg::Optional<Options> options);

--- a/src/workerd/api/crypto/impl.h
+++ b/src/workerd/api/crypto/impl.h
@@ -18,7 +18,7 @@
 
 #include <kj/encoding.h>
 
-typedef struct bignum_st BIGNUM;
+using BIGNUM = struct bignum_st;
 
 // Wrap calls to OpenSSL's EVP_* interface (and similar APIs) in this macro to
 // deal with errors.

--- a/src/workerd/api/crypto/kdf.h
+++ b/src/workerd/api/crypto/kdf.h
@@ -9,7 +9,7 @@
 
 #include <cstdint>
 
-typedef struct env_md_st EVP_MD;
+using EVP_MD = struct env_md_st;
 
 namespace workerd::api {
 

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -293,44 +293,44 @@ class AlarmInvocationInfo: public jsg::Object {
 // treat incorrect types as if the field is undefined. Without this, Durable Object class
 // constructors that set a field with one of these names would cause confusing type errors.
 struct ExportedHandler {
-  typedef jsg::Promise<jsg::Ref<api::Response>> FetchHandler(jsg::Ref<api::Request> request,
+  using FetchHandler = jsg::Promise<jsg::Ref<api::Response>>(jsg::Ref<api::Request> request,
       jsg::Value env,
       jsg::Optional<jsg::Ref<ExecutionContext>> ctx);
   jsg::LenientOptional<jsg::Function<FetchHandler>> fetch;
 
-  typedef kj::Promise<void> TailHandler(kj::Array<jsg::Ref<TraceItem>> events,
+  using TailHandler = kj::Promise<void>(kj::Array<jsg::Ref<TraceItem>> events,
       jsg::Value env,
       jsg::Optional<jsg::Ref<ExecutionContext>> ctx);
   jsg::LenientOptional<jsg::Function<TailHandler>> tail;
   jsg::LenientOptional<jsg::Function<TailHandler>> trace;
 
-  typedef kj::Promise<void> TailStreamHandler(
+  using TailStreamHandler = kj::Promise<void>(
       jsg::JsObject obj, jsg::Value env, jsg::Optional<jsg::Ref<ExecutionContext>> ctx);
   jsg::LenientOptional<jsg::Function<TailStreamHandler>> tailStream;
 
-  typedef kj::Promise<void> ScheduledHandler(jsg::Ref<ScheduledController> controller,
+  using ScheduledHandler = kj::Promise<void>(jsg::Ref<ScheduledController> controller,
       jsg::Value env,
       jsg::Optional<jsg::Ref<ExecutionContext>> ctx);
   jsg::LenientOptional<jsg::Function<ScheduledHandler>> scheduled;
 
-  typedef kj::Promise<void> AlarmHandler(jsg::Ref<AlarmInvocationInfo> alarmInfo);
+  using AlarmHandler = kj::Promise<void>(jsg::Ref<AlarmInvocationInfo> alarmInfo);
   // Alarms are only exported on DOs, which receive env bindings from the constructor
   jsg::LenientOptional<jsg::Function<AlarmHandler>> alarm;
 
-  typedef jsg::Promise<void> TestHandler(jsg::Ref<TestController> controller,
+  using TestHandler = jsg::Promise<void>(jsg::Ref<TestController> controller,
       jsg::Value env,
       jsg::Optional<jsg::Ref<ExecutionContext>> ctx);
   jsg::LenientOptional<jsg::Function<TestHandler>> test;
 
-  typedef kj::Promise<void> HibernatableWebSocketMessageHandler(
+  using HibernatableWebSocketMessageHandler = kj::Promise<void>(
       jsg::Ref<WebSocket>, kj::OneOf<kj::String, kj::Array<byte>> message);
   jsg::LenientOptional<jsg::Function<HibernatableWebSocketMessageHandler>> webSocketMessage;
 
-  typedef kj::Promise<void> HibernatableWebSocketCloseHandler(
+  using HibernatableWebSocketCloseHandler = kj::Promise<void>(
       jsg::Ref<WebSocket>, int code, kj::String reason, bool wasClean);
   jsg::LenientOptional<jsg::Function<HibernatableWebSocketCloseHandler>> webSocketClose;
 
-  typedef kj::Promise<void> HibernatableWebSocketErrorHandler(jsg::Ref<WebSocket>, jsg::Value);
+  using HibernatableWebSocketErrorHandler = kj::Promise<void>(jsg::Ref<WebSocket>, jsg::Value);
   jsg::LenientOptional<jsg::Function<HibernatableWebSocketErrorHandler>> webSocketError;
 
   // Self-ref potentially allows extracting other custom handlers from the object.

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -429,7 +429,7 @@ struct RequestInitializerDict;
 class Socket;
 struct SocketOptions;
 struct SocketAddress;
-typedef kj::OneOf<SocketAddress, kj::String> AnySocketAddress;
+using AnySocketAddress = kj::OneOf<SocketAddress, kj::String>;
 
 // Represents a client to a remote "web service".
 //
@@ -831,7 +831,7 @@ public:
   // ---------------------------------------------------------------------------
   // JS API
 
-  typedef RequestInitializerDict InitializerDict;
+  using InitializerDict = RequestInitializerDict;
 
   using Info = kj::OneOf<jsg::Ref<Request>, kj::String>;
   using Initializer = kj::OneOf<InitializerDict, jsg::Ref<Request>>;

--- a/src/workerd/api/memory-cache.h
+++ b/src/workerd/api/memory-cache.h
@@ -192,7 +192,7 @@ class SharedMemoryCache: public kj::AtomicRefcounted {
       kj::Own<CacheValue> value;
       kj::Maybe<double> expiration;
     };
-    typedef kj::Function<void(kj::Maybe<FallbackResult>)> FallbackDoneCallback;
+    using FallbackDoneCallback = kj::Function<void(kj::Maybe<FallbackResult>)>;
     using GetWithFallbackOutcome = kj::OneOf<kj::Own<CacheValue>, FallbackDoneCallback>;
 
     // Returns either:

--- a/src/workerd/api/node/buffer-string-search.h
+++ b/src/workerd/api/node/buffer-string-search.h
@@ -114,7 +114,7 @@ class StringSearchBase {
 template <typename Char>
 class StringSearch: private StringSearchBase {
  public:
-  typedef stringsearch::Vector<const Char> Vector;
+  using Vector = stringsearch::Vector<const Char>;
 
   explicit StringSearch(Vector pattern): pattern_(pattern), start_(0) {
     if (pattern.length() >= kBMMaxShift) {
@@ -163,7 +163,7 @@ class StringSearch: private StringSearchBase {
   }
 
  private:
-  typedef size_t (StringSearch::*SearchFunction)(Vector, size_t);
+  using SearchFunction = size_t (StringSearch::*)(Vector, size_t);
   size_t SingleCharSearch(Vector subject, size_t start_index);
   size_t LinearSearch(Vector subject, size_t start_index);
   size_t InitialSearch(Vector subject, size_t start_index);

--- a/src/workerd/api/pyodide/requirements.h
+++ b/src/workerd/api/pyodide/requirements.h
@@ -17,7 +17,7 @@ capnp::json::Value::Reader getField(
 kj::String canonicalizePythonPackageName(kj::StringPtr name);
 
 // map from requirement to list of dependencies
-typedef kj::HashMap<kj::String, kj::Vector<kj::String>> DepMap;
+using DepMap = kj::HashMap<kj::String, kj::Vector<kj::String>>;
 
 DepMap getDepMapFromPackagesLock(
     capnp::List<capnp::json::Value::Field, capnp::Kind::STRUCT>::Reader &packages);

--- a/src/workerd/api/queue.h
+++ b/src/workerd/api/queue.h
@@ -257,7 +257,7 @@ class QueueEvent final: public ExtendableEvent {
   struct CompletedWithError {
     kj::Exception error;
   };
-  typedef kj::OneOf<Incomplete, CompletedSuccessfully, CompletedWithError> CompletionStatus;
+  using CompletionStatus = kj::OneOf<Incomplete, CompletedSuccessfully, CompletedWithError>;
 
   void setCompletionStatus(CompletionStatus status) {
     completionStatus = status;
@@ -325,7 +325,7 @@ class QueueController final: public jsg::Object {
 
 // Extension of ExportedHandler covering queue handlers.
 struct QueueExportedHandler {
-  typedef kj::Promise<void> QueueHandler(jsg::Ref<QueueController> controller,
+  using QueueHandler = kj::Promise<void>(jsg::Ref<QueueController> controller,
       jsg::JsRef<jsg::JsValue> env,
       jsg::Optional<jsg::Ref<ExecutionContext>> ctx);
   jsg::LenientOptional<jsg::Function<QueueHandler>> queue;

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -38,7 +38,7 @@ struct SocketInfo {
   JSG_STRUCT(remoteAddress, localAddress);
 };
 
-typedef kj::OneOf<SocketAddress, kj::String> AnySocketAddress;
+using AnySocketAddress = kj::OneOf<SocketAddress, kj::String>;
 
 struct SocketOptions {
   jsg::Optional<kj::String> secureTransport;

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -11,7 +11,7 @@
 #include <workerd/jsg/jsg.h>
 
 #if _MSC_VER
-typedef long long ssize_t;
+using ssize_t = long long;
 #endif
 
 namespace workerd::api {

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -128,7 +128,7 @@ class TraceItem final: public jsg::Object {
 
   explicit TraceItem(jsg::Lock& js, const Trace& trace);
 
-  typedef kj::OneOf<jsg::Ref<FetchEventInfo>,
+  using EventInfo = kj::OneOf<jsg::Ref<FetchEventInfo>,
       jsg::Ref<JsRpcEventInfo>,
       jsg::Ref<ScheduledEventInfo>,
       jsg::Ref<AlarmEventInfo>,
@@ -136,8 +136,7 @@ class TraceItem final: public jsg::Object {
       jsg::Ref<EmailEventInfo>,
       jsg::Ref<TailEventInfo>,
       jsg::Ref<CustomEventInfo>,
-      jsg::Ref<HibernatableWebSocketEventInfo>>
-      EventInfo;
+      jsg::Ref<HibernatableWebSocketEventInfo>>;
   kj::Maybe<EventInfo> getEvent(jsg::Lock& js);
   kj::Maybe<double> getEventTimestamp();
 

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -49,16 +49,16 @@ struct ActorCacheWriteOptions {
 // Common interface between ActorCache and ActorCache::Transaction.
 class ActorCacheOps {
  public:
-  typedef kj::String Key;
-  typedef kj::StringPtr KeyPtr;
+  using Key = kj::String;
+  using KeyPtr = kj::StringPtr;
   // Keys are text for now, but we could also change this to `Array<const byte>`.
   static inline Key cloneKey(KeyPtr ptr) {
     return kj::str(ptr);
   }
 
   // Values are raw bytes.
-  typedef kj::Array<const byte> Value;
-  typedef kj::ArrayPtr<const byte> ValuePtr;
+  using Value = kj::Array<const byte>;
+  using ValuePtr = kj::ArrayPtr<const byte>;
 
   struct KeyValuePair {
     Key key;
@@ -108,7 +108,7 @@ class ActorCacheOps {
     ActorCacheWriteOptions options;
   };
 
-  typedef ActorCacheReadOptions ReadOptions;
+  using ReadOptions = ActorCacheReadOptions;
 
   // Get the values for some key, keys, or range of keys.
   //
@@ -132,7 +132,7 @@ class ActorCacheOps {
   virtual kj::OneOf<GetResultList, kj::Promise<GetResultList>> listReverse(
       Key begin, kj::Maybe<Key> end, kj::Maybe<uint> limit, ReadOptions options) = 0;
 
-  typedef ActorCacheWriteOptions WriteOptions;
+  using WriteOptions = ActorCacheWriteOptions;
 
   // Writes a key/value into cache and schedules it to be flushed to disk later.
   //
@@ -742,7 +742,7 @@ class ActorCache final: public ActorCacheInterface {
   kj::Canceler oomCanceler;
 
   // Type of a lock on `SharedLru::cleanList`. We use the same lock to protect `currentValues`.
-  typedef kj::Locked<kj::List<Entry, &Entry::link>> Lock;
+  using Lock = kj::Locked<kj::List<Entry, &Entry::link>>;
 
   // Add this entry to the clean list and set its status to CLEAN.
   // This doesn't do much, but it makes it easier to track what's going on.

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -1054,7 +1054,8 @@ kj::PromiseForResult<Func, Worker::Lock&> IoContext::run(
 
   return asyncLockPromise.then([this, inputLock = kj::mv(inputLock), func = kj::fwd<Func>(func)](
                                    Worker::AsyncLock lock) mutable {
-    typedef decltype(func(kj::instance<Worker::Lock&>())) Result;
+    using Result = decltype(func(kj::instance<Worker::Lock&>()));
+
     if constexpr (kj::isSameType<Result, void>()) {
       struct RunnableImpl: public Runnable {
         Func func;
@@ -1173,7 +1174,7 @@ jsg::PromiseForResult<Func, T, true> IoContext::awaitIoImpl(
 
   // `T` is the type produced by the input promise. `Result` is the type of the final output
   // promise. `Func` transforms from `T` to `Result`.
-  typedef jsg::ReturnType<Func, T, true> Result;
+  using Result = jsg::ReturnType<Func, T, true>;
 
   // It is necessary for us to grab a reference to the jsg::AsyncContextFrame here
   // and pass it into the then(). If the promise is rejected, and there is no rejection
@@ -1412,7 +1413,7 @@ jsg::PromiseForResult<Func, void, true> IoContext::blockConcurrencyWhile(
   auto cs = lock.startCriticalSection();
   auto cs2 = kj::addRef(*cs);
 
-  typedef jsg::RemovePromise<jsg::PromiseForResult<Func, void, true>> T;
+  using T = jsg::RemovePromise<jsg::PromiseForResult<Func, void, true>>;
   auto [result, resolver] = js.newPromiseAndResolver<T>();
 
   addTask(

--- a/src/workerd/io/io-own.h
+++ b/src/workerd/io/io-own.h
@@ -27,12 +27,12 @@ class ReverseIoOwn;
 
 template <typename T>
 struct RemoveIoOwn_ {
-  typedef T Type;
+  using Type = T;
   static constexpr bool is = false;
 };
 template <typename T>
 struct RemoveIoOwn_<IoOwn<T>> {
-  typedef T Type;
+  using Type = T;
   static constexpr bool is = true;
 };
 

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -31,8 +31,8 @@ namespace workerd {
 using kj::byte;
 using kj::uint;
 
-typedef rpc::Trace::Log::Level LogLevel;
-typedef rpc::Trace::ExecutionModel ExecutionModel;
+using LogLevel = rpc::Trace::Log::Level;
+using ExecutionModel = rpc::Trace::ExecutionModel;
 
 class Trace;
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -4264,7 +4264,7 @@ kj::Promise<void> Worker::Isolate::SubrequestClient::request(kj::HttpMethod meth
       });
     }));
   };
-  typedef decltype(signalResponse) SignalResponse;
+  using SignalResponse = decltype(signalResponse);
 
   class ResponseWrapper final: public kj::HttpService::Response {
    public:

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -51,13 +51,13 @@ class InputGate;
 class OutputGate;
 
 // Type signature of an entrypoint implementation class (Durable Object or stateless service).
-typedef kj::OneOf<jsg::Ref<api::ExecutionContext>, jsg::Ref<api::DurableObjectState>>
-    ExecutionContextOrState;
-typedef jsg::Constructor<api::ExportedHandler(ExecutionContextOrState ctx, jsg::Value env)>
-    EntrypointClass;
+using ExecutionContextOrState =
+    kj::OneOf<jsg::Ref<api::ExecutionContext>, jsg::Ref<api::DurableObjectState>>;
+using EntrypointClass =
+    jsg::Constructor<api::ExportedHandler(ExecutionContextOrState ctx, jsg::Value env)>;
 
 // The type of a top-level export -- either a simple handler or a class.
-typedef kj::OneOf<EntrypointClass, api::ExportedHandler> NamedExport;
+using NamedExport = kj::OneOf<EntrypointClass, api::ExportedHandler>;
 
 struct EntrypointClasses {
   // Class constructor for WorkerEntrypoint.
@@ -169,7 +169,7 @@ class Worker: public kj::AtomicRefcounted {
   // This is useful for allowing generic client libraries to connect to private local services using
   // just a provided address (rather than requiring them to support being passed a binding to call
   // binding.connect() on).
-  typedef kj::Function<jsg::Ref<api::Socket>(jsg::Lock&)> ConnectFn;
+  using ConnectFn = kj::Function<jsg::Ref<api::Socket>(jsg::Lock&)>;
   void setConnectOverride(kj::String networkAddress, ConnectFn connectFn);
   kj::Maybe<ConnectFn&> getConnectOverride(kj::StringPtr networkAddress);
 

--- a/src/workerd/jsg/function.h
+++ b/src/workerd/jsg/function.h
@@ -146,7 +146,7 @@ class Function<Ret(Args...)> {
 
   // When holding a JavaScript function, `Wrapper` is a C++ function that will handle converting
   // C++ arguments into JavaScript values and then call the JS function.
-  typedef Ret Wrapper(jsg::Lock& js,
+  using Wrapper = Ret(jsg::Lock& js,
       v8::Local<v8::Value> receiver,  // the `this` value in the function
       v8::Local<v8::Function> fn,
       Args...);

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -31,7 +31,7 @@ using kj::byte;
 using kj::uint;
 
 #if _MSC_VER
-typedef long long ssize_t;
+using ssize_t = long long;
 #endif
 
 namespace workerd::jsg {
@@ -1688,13 +1688,13 @@ constexpr bool isPromise() {
 // Convenience template to strip off `jsg::Promise`.
 template <typename T>
 struct RemovePromise_ {
-  typedef T Type;
+  using Type = T;
 };
 
 // Convenience template to strip off `jsg::Promise`.
 template <typename T>
 struct RemovePromise_<Promise<T>> {
-  typedef T Type;
+  using Type = T;
 };
 
 // Convenience template to strip off `jsg::Promise`.
@@ -1710,28 +1710,28 @@ struct ReturnType_;
 // `T = void` is understood to mean no parameters.
 template <typename Func, typename T>
 struct ReturnType_<Func, T, false> {
-  typedef decltype(kj::instance<Func>()(kj::instance<T>())) Type;
+  using Type = decltype(kj::instance<Func>()(kj::instance<T>()));
 };
 
 // Convenience template to calculate the return type of a function when passed parameter type T.
 // `T = void` is understood to mean no parameters.
 template <typename Func, typename T>
 struct ReturnType_<Func, T, true> {
-  typedef decltype(kj::instance<Func>()(kj::instance<Lock&>(), kj::instance<T>())) Type;
+  using Type = decltype(kj::instance<Func>()(kj::instance<Lock&>(), kj::instance<T>()));
 };
 
 // Convenience template to calculate the return type of a function when passed parameter type T.
 // `T = void` is understood to mean no parameters.
 template <typename Func>
 struct ReturnType_<Func, void, false> {
-  typedef decltype(kj::instance<Func>()()) Type;
+  using Type = decltype(kj::instance<Func>()());
 };
 
 // Convenience template to calculate the return type of a function when passed parameter type T.
 // `T = void` is understood to mean no parameters.
 template <typename Func>
 struct ReturnType_<Func, void, true> {
-  typedef decltype(kj::instance<Func>()(kj::instance<Lock&>())) Type;
+  using Type = decltype(kj::instance<Func>()(kj::instance<Lock&>()));
 };
 
 // Convenience template to calculate the return type of a function when passed parameter type T.
@@ -2035,7 +2035,7 @@ class PropertyReflection {
  private:
   kj::Maybe<Wrappable&> self;
 
-  typedef kj::Maybe<T> Unwrapper(v8::Isolate*, v8::Local<v8::Object> object, kj::StringPtr name);
+  using Unwrapper = kj::Maybe<T>(v8::Isolate*, v8::Local<v8::Object> object, kj::StringPtr name);
   Unwrapper* unwrapper = nullptr;
 
   template <typename, typename...>

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -244,11 +244,11 @@ class Promise {
   // a JavaScript exception (and jsg::JsExceptionThrown) in certain cases.
   template <typename Func, typename ErrorFunc>
   PromiseForResult<Func, T, true> then(Lock& js, Func&& func, ErrorFunc&& errorFunc) {
-    typedef ReturnType<Func, T, true> Output;
+    using Output = ReturnType<Func, T, true>;
     static_assert(kj::isSameType<Output, ReturnType<ErrorFunc, Value, true>>(),
         "functions passed to .then() must return exactly the same type");
 
-    typedef ThenCatchPair<Func, ErrorFunc> FuncPair;
+    using FuncPair = ThenCatchPair<Func, ErrorFunc>;
     return thenImpl<Output>(js, FuncPair{kj::fwd<Func>(func), kj::fwd<ErrorFunc>(errorFunc)},
         &promiseContinuation<FuncPair, false, T, Output>,
         &promiseContinuation<FuncPair, true, Value, Output>);
@@ -259,10 +259,10 @@ class Promise {
   // a JavaScript exception (and jsg::JsExceptionThrown) in certain cases.
   template <typename Func>
   PromiseForResult<Func, T, true> then(Lock& js, Func&& func) {
-    typedef ReturnType<Func, T, true> Output;
+    using Output = ReturnType<Func, T, true>;
 
     // HACK: The error function is never called, so it need not actually be a functor.
-    typedef ThenCatchPair<Func, bool> FuncPair;
+    using FuncPair = ThenCatchPair<Func, bool>;
     return thenImpl<Output>(js, FuncPair{kj::fwd<Func>(func), false},
         &promiseContinuation<FuncPair, false, T, Output>,
         &identityPromiseContinuation<FuncPair, true>);
@@ -274,7 +274,7 @@ class Promise {
         "function passed to .catch_() must return exactly the promise's type");
 
     // HACK: The non-error function is never called, so it need not actually be a functor.
-    typedef ThenCatchPair<bool, ErrorFunc> FuncPair;
+    using FuncPair = ThenCatchPair<bool, ErrorFunc>;
     return thenImpl<T>(js, FuncPair{false, kj::fwd<ErrorFunc>(errorFunc)},
         &identityPromiseContinuation<FuncPair, false>,
         &promiseContinuation<FuncPair, true, Value, T>);
@@ -503,7 +503,7 @@ Promise<T> Lock::rejectedPromise(kj::Exception&& exception) {
 
 template <class Func>
 PromiseForResult<Func, void, false> Lock::evalNow(Func&& func) {
-  typedef RemovePromise<ReturnType<Func, void>> Result;
+  using Result = RemovePromise<ReturnType<Func, void>>;
   v8::TryCatch tryCatch(v8Isolate);
   try {
     if constexpr (isPromise<ReturnType<Func, void>>()) {

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -785,7 +785,7 @@ class NullConfiguration {
 template <typename TypeWrapper>
 class DynamicResourceTypeMap {
  private:
-  typedef void ReflectionInitializer(jsg::Object& object, TypeWrapper& wrapper);
+  using ReflectionInitializer = void(jsg::Object& object, TypeWrapper& wrapper);
   struct DynamicTypeInfo {
     v8::Local<v8::FunctionTemplate> tmpl;
     kj::Maybe<ReflectionInitializer&> reflectionInitializer;
@@ -801,7 +801,7 @@ class DynamicResourceTypeMap {
     }
   }
 
-  typedef DynamicTypeInfo GetTypeInfoFunc(TypeWrapper&, v8::Isolate*);
+  using GetTypeInfoFunc = DynamicTypeInfo(TypeWrapper&, v8::Isolate*);
 
   // Maps type_info values to functions that can be used to get the associated template. Used by
   // ResourceWrapper.
@@ -826,11 +826,11 @@ class DynamicResourceTypeMap {
   // It also just provides nice symmetry with `deserializerMap`.
   //
   // The SerializeFunc() must always start by writing a tag.
-  typedef void SerializeFunc(TypeWrapper&, Lock& js, jsg::Object& instance, Serializer& serializer);
+  using SerializeFunc = void(TypeWrapper&, Lock& js, jsg::Object& instance, Serializer& serializer);
   kj::HashMap<std::type_index, SerializeFunc*> serializerMap;
 
   // Map tag numbers to deserializer functions.
-  typedef v8::Local<v8::Object> DeserializeFunc(
+  using DeserializeFunc = v8::Local<v8::Object>(
       TypeWrapper&, Lock& js, uint tag, Deserializer& deserializer);
   kj::HashMap<uint, DeserializeFunc*> deserializerMap;
 

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -65,7 +65,7 @@ class V8System {
 
   ~V8System() noexcept(false);
 
-  typedef void FatalErrorCallback(kj::StringPtr location, kj::StringPtr message);
+  using FatalErrorCallback = void(kj::StringPtr location, kj::StringPtr message);
   static void setFatalErrorCallback(FatalErrorCallback* callback);
 
  private:

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -592,8 +592,8 @@ class TypeWrapper<Self, Types...>::TypeHandlerImpl final: public TypeHandler<T> 
 // API types.
 #define JSG_DECLARE_ISOLATE_TYPE(Type, ...)                                                        \
   class Type##_TypeWrapper;                                                                        \
-  typedef ::workerd::jsg::TypeWrapper<Type##_TypeWrapper, jsg::DOMException, ##__VA_ARGS__>        \
-      Type##_TypeWrapperBase;                                                                      \
+  using Type##_TypeWrapperBase =                                                                   \
+      ::workerd::jsg::TypeWrapper<Type##_TypeWrapper, jsg::DOMException, ##__VA_ARGS__>;           \
   class Type##_TypeWrapper final: public Type##_TypeWrapperBase {                                  \
    public:                                                                                         \
     using Type##_TypeWrapperBase::TypeWrapper;                                                     \

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -25,7 +25,7 @@ namespace workerd::jsg {
 
 class Lock;
 
-typedef unsigned int uint;
+using uint = unsigned int;
 
 // When a C++ callback wishes to throw a JavaScript exception, it should first call
 // isolate->ThrowException() to set the JavaScript error value, then it should throw
@@ -269,18 +269,18 @@ template <typename T>
 struct RemoveMaybe_;
 template <typename T>
 struct RemoveMaybe_<kj::Maybe<T>> {
-  typedef T Type;
+  using Type = T;
 };
 template <typename T>
 using RemoveMaybe = typename RemoveMaybe_<T>::Type;
 
 template <typename T>
 struct RemoveRvalueRef_ {
-  typedef T Type;
+  using Type = T;
 };
 template <typename T>
 struct RemoveRvalueRef_<T&&> {
-  typedef T Type;
+  using Type = T;
 };
 template <typename T>
 using RemoveRvalueRef = typename RemoveRvalueRef_<T>::Type;

--- a/src/workerd/util/sqlite-kv.h
+++ b/src/workerd/util/sqlite-kv.h
@@ -31,8 +31,8 @@ class SqliteKv: private SqliteDatabase::ResetListener {
  public:
   explicit SqliteKv(SqliteDatabase& db);
 
-  typedef kj::StringPtr KeyPtr;
-  typedef kj::ArrayPtr<const kj::byte> ValuePtr;
+  using KeyPtr = kj::StringPtr;
+  using ValuePtr = kj::ArrayPtr<const kj::byte>;
 
   // Search for a match for the given key. Calls the callback function with the result (a ValuePtr)
   // if found. This is intended to avoid the need to copy the bytes, if the caller would just parse


### PR DESCRIPTION
While typedef works just fine, I don't think we need two different syntaxes for doing the same thing in our codebase.