### PR TITLE
feat: Add `WorkflowRetentionDuration` to `WorkflowInstanceCreateOptions`

### DIFF
--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -50,6 +50,21 @@ declare abstract class Workflow<PARAMS = unknown> {
   ): Promise<WorkflowInstance[]>;
 }
 
+type WorkflowDurationLabel =
+  | 'second'
+  | 'minute'
+  | 'hour'
+  | 'day'
+  | 'week'
+  | 'month'
+  | 'year';
+
+type WorkflowSleepDuration =
+  | `${number} ${WorkflowDurationLabel}${'s' | ''}`
+  | number;
+
+type WorkflowRetentionDuration = WorkflowSleepDuration;
+
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**
    * An id for your Workflow instance. Must be unique within the Workflow.
@@ -60,6 +75,14 @@ interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
    * The event payload the Workflow instance is triggered with
    */
   params?: PARAMS;
+  /**
+   * The retention policy for the Workflow instance.
+   * Defaults to the maximum retention period available for the owner's account.
+   */
+  retention?: {
+    successRetention?: WorkflowRetentionDuration;
+    errorRetention?: WorkflowRetentionDuration;
+  };
 }
 
 type InstanceStatus = {

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -230,6 +230,8 @@ declare module 'cloudflare:workers' {
 
   export type WorkflowTimeoutDuration = WorkflowSleepDuration;
 
+  export type WorkflowRetentionDuration = WorkflowSleepDuration;
+
   export type WorkflowBackoff = 'constant' | 'linear' | 'exponential';
 
   export type WorkflowStepConfig = {

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -36,6 +36,21 @@ declare abstract class Workflow<PARAMS = unknown> {
   ): Promise<WorkflowInstance[]>;
 }
 
+type WorkflowDurationLabel =
+  | 'second'
+  | 'minute'
+  | 'hour'
+  | 'day'
+  | 'week'
+  | 'month'
+  | 'year';
+
+type WorkflowSleepDuration =
+  | `${number} ${WorkflowDurationLabel}${'s' | ''}`
+  | number;
+
+type WorkflowRetentionDuration = WorkflowSleepDuration;
+
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**
    * An id for your Workflow instance. Must be unique within the Workflow.
@@ -45,6 +60,14 @@ interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
    * The event payload the Workflow instance is triggered with
    */
   params?: PARAMS;
+  /**
+   * The retention policy for Workflow instance.
+   * Defaults to the maximum retention period available for the owner's account.
+   */
+  retention?: {
+    successRetention?: WorkflowRetentionDuration,
+    errorRetention?: WorkflowRetentionDuration,
+  };
 }
 
 type InstanceStatus = {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -6444,6 +6444,7 @@ declare module "cloudflare:workers" {
     | number;
   export type WorkflowDelayDuration = WorkflowSleepDuration;
   export type WorkflowTimeoutDuration = WorkflowSleepDuration;
+  export type WorkflowRetentionDuration = WorkflowSleepDuration;
   export type WorkflowBackoff = "constant" | "linear" | "exponential";
   export type WorkflowStepConfig = {
     retries?: {
@@ -7057,6 +7058,18 @@ declare abstract class Workflow<PARAMS = unknown> {
     batch: WorkflowInstanceCreateOptions<PARAMS>[],
   ): Promise<WorkflowInstance[]>;
 }
+type WorkflowDurationLabel =
+  | "second"
+  | "minute"
+  | "hour"
+  | "day"
+  | "week"
+  | "month"
+  | "year";
+type WorkflowSleepDuration =
+  | `${number} ${WorkflowDurationLabel}${"s" | ""}`
+  | number;
+type WorkflowRetentionDuration = WorkflowSleepDuration;
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**
    * An id for your Workflow instance. Must be unique within the Workflow.
@@ -7066,6 +7079,14 @@ interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
    * The event payload the Workflow instance is triggered with
    */
   params?: PARAMS;
+  /**
+   * The retention policy for Workflow instance.
+   * Defaults to the maximum retention period available for the owner's account.
+   */
+  retention?: {
+    successRetention?: WorkflowRetentionDuration;
+    errorRetention?: WorkflowRetentionDuration;
+  };
 }
 type InstanceStatus = {
   status:

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -6912,6 +6912,18 @@ export declare abstract class Workflow<PARAMS = unknown> {
     batch: WorkflowInstanceCreateOptions<PARAMS>[],
   ): Promise<WorkflowInstance[]>;
 }
+export type WorkflowDurationLabel =
+  | "second"
+  | "minute"
+  | "hour"
+  | "day"
+  | "week"
+  | "month"
+  | "year";
+export type WorkflowSleepDuration =
+  | `${number} ${WorkflowDurationLabel}${"s" | ""}`
+  | number;
+export type WorkflowRetentionDuration = WorkflowSleepDuration;
 export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**
    * An id for your Workflow instance. Must be unique within the Workflow.
@@ -6921,6 +6933,14 @@ export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
    * The event payload the Workflow instance is triggered with
    */
   params?: PARAMS;
+  /**
+   * The retention policy for Workflow instance.
+   * Defaults to the maximum retention period available for the owner's account.
+   */
+  retention?: {
+    successRetention?: WorkflowRetentionDuration;
+    errorRetention?: WorkflowRetentionDuration;
+  };
 }
 export type InstanceStatus = {
   status:

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -6216,6 +6216,7 @@ declare module "cloudflare:workers" {
     | number;
   export type WorkflowDelayDuration = WorkflowSleepDuration;
   export type WorkflowTimeoutDuration = WorkflowSleepDuration;
+  export type WorkflowRetentionDuration = WorkflowSleepDuration;
   export type WorkflowBackoff = "constant" | "linear" | "exponential";
   export type WorkflowStepConfig = {
     retries?: {
@@ -6829,6 +6830,18 @@ declare abstract class Workflow<PARAMS = unknown> {
     batch: WorkflowInstanceCreateOptions<PARAMS>[],
   ): Promise<WorkflowInstance[]>;
 }
+type WorkflowDurationLabel =
+  | "second"
+  | "minute"
+  | "hour"
+  | "day"
+  | "week"
+  | "month"
+  | "year";
+type WorkflowSleepDuration =
+  | `${number} ${WorkflowDurationLabel}${"s" | ""}`
+  | number;
+type WorkflowRetentionDuration = WorkflowSleepDuration;
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**
    * An id for your Workflow instance. Must be unique within the Workflow.
@@ -6838,6 +6851,14 @@ interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
    * The event payload the Workflow instance is triggered with
    */
   params?: PARAMS;
+  /**
+   * The retention policy for Workflow instance.
+   * Defaults to the maximum retention period available for the owner's account.
+   */
+  retention?: {
+    successRetention?: WorkflowRetentionDuration;
+    errorRetention?: WorkflowRetentionDuration;
+  };
 }
 type InstanceStatus = {
   status:

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -6684,6 +6684,18 @@ export declare abstract class Workflow<PARAMS = unknown> {
     batch: WorkflowInstanceCreateOptions<PARAMS>[],
   ): Promise<WorkflowInstance[]>;
 }
+export type WorkflowDurationLabel =
+  | "second"
+  | "minute"
+  | "hour"
+  | "day"
+  | "week"
+  | "month"
+  | "year";
+export type WorkflowSleepDuration =
+  | `${number} ${WorkflowDurationLabel}${"s" | ""}`
+  | number;
+export type WorkflowRetentionDuration = WorkflowSleepDuration;
 export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**
    * An id for your Workflow instance. Must be unique within the Workflow.
@@ -6693,6 +6705,14 @@ export interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
    * The event payload the Workflow instance is triggered with
    */
   params?: PARAMS;
+  /**
+   * The retention policy for Workflow instance.
+   * Defaults to the maximum retention period available for the owner's account.
+   */
+  retention?: {
+    successRetention?: WorkflowRetentionDuration;
+    errorRetention?: WorkflowRetentionDuration;
+  };
 }
 export type InstanceStatus = {
   status:


### PR DESCRIPTION
Related to WOR-638

We need to expose `InstanceRetention` as an additional field to `WorkflowInstanceCreateOptions`, thus allowing custom retention periods through binding-shim.