### PR TITLE
[o11y] Support ctx attribute in tailStream(), clarify that only one event is passed at a time

### DIFF
--- a/src/workerd/api/tail-worker-test-dummy.js
+++ b/src/workerd/api/tail-worker-test-dummy.js
@@ -3,7 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 export default {
   // https://developers.cloudflare.com/workers/observability/logs/tail-workers/
-  tail(...args) {
-    return (...args) => {};
+  tail(event, env, ctx) {
+    return (event) => {};
   },
 };

--- a/src/workerd/api/tail-worker-test-invalid.js
+++ b/src/workerd/api/tail-worker-test-invalid.js
@@ -4,7 +4,7 @@
 
 export default {
   // https://developers.cloudflare.com/workers/observability/logs/tail-workers/
-  tailStream(args) {
+  tailStream(event, env, ctx) {
     // Return an invalid handler
     return 42;
   },

--- a/src/workerd/api/tail-worker-test-receiver.js
+++ b/src/workerd/api/tail-worker-test-receiver.js
@@ -7,12 +7,12 @@ let resposeMap = new Map();
 
 export default {
   // https://developers.cloudflare.com/workers/observability/logs/tail-workers/
-  tailStream(...args) {
+  tailStream(event, env, ctx) {
     // Onset event, must be singleton
-    resposeMap.set(args[0].traceId, JSON.stringify(args[0].event));
-    return (...args) => {
-      let cons = resposeMap.get(args[0].traceId);
-      resposeMap.set(args[0].traceId, cons + JSON.stringify(args[0].event));
+    resposeMap.set(event.traceId, JSON.stringify(event.event));
+    return (event) => {
+      let cons = resposeMap.get(event.traceId);
+      resposeMap.set(event.traceId, cons + JSON.stringify(event.event));
     };
   },
 };

--- a/src/workerd/api/tail-worker-test.js
+++ b/src/workerd/api/tail-worker-test.js
@@ -7,22 +7,21 @@ let resposeMap = new Map();
 
 export default {
   // https://developers.cloudflare.com/workers/observability/logs/tail-workers/
-  tailStream(...args) {
+  tailStream(event, env, ctx) {
     // Onset event, must be singleton
 
     // For scheduled and alarm tests, override scheduledTime to make this test deterministic.
     if (
-      args[0].event.info.type == 'scheduled' ||
-      args[0].event.info.type == 'alarm'
+      event.event.info.type == 'scheduled' ||
+      event.event.info.type == 'alarm'
     ) {
-      args[0].event.info.scheduledTime = '1970-01-01T00:00:00.000Z';
+      event.event.info.scheduledTime = '1970-01-01T00:00:00.000Z';
     }
 
-    resposeMap.set(args[0].traceId, JSON.stringify(args[0].event));
-    return (...args) => {
-      // TODO(streaming-tail-worker): Support several queued elements
-      let cons = resposeMap.get(args[0].traceId);
-      resposeMap.set(args[0].traceId, cons + JSON.stringify(args[0].event));
+    resposeMap.set(event.traceId, JSON.stringify(event.event));
+    return (event) => {
+      let cons = resposeMap.get(event.traceId);
+      resposeMap.set(event.traceId, cons + JSON.stringify(event.event));
     };
   },
 };

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -752,12 +752,17 @@ class TailStreamTarget final: public rpc::TailStreamTarget::Server {
 
     // Invoke the tailStream handler function.
     v8::Local<v8::Function> fn = maybeFn.As<v8::Function>();
-    v8::LocalVector<v8::Value> handlerArgs(js.v8Isolate, 2);
+    auto maybeCtx = KJ_ASSERT_NONNULL(handler->getCtx()).tryGetHandle(js);
+    v8::LocalVector<v8::Value> handlerArgs(js.v8Isolate, maybeCtx != kj::none ? 3 : 2);
     handlerArgs[0] = ToJs(js, event, stringCache);
     handlerArgs[1] = handler->env.getHandle(js);
+    KJ_IF_SOME(ctx, maybeCtx) {
+      handlerArgs[2] = ctx;
+    }
 
     try {
-      auto result = jsg::check(fn->Call(js.v8Context(), target, 2, handlerArgs.data()));
+      auto result =
+          jsg::check(fn->Call(js.v8Context(), target, handlerArgs.size(), handlerArgs.data()));
 
       // We need to be able to access the results builder from both the
       // success and failure branches of the promise we set up below.

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -58,6 +58,7 @@ namespace {
   V(ONSET, "onset")                                                                                \
   V(OP, "op")                                                                                      \
   V(OUTCOME, "outcome")                                                                            \
+  V(PARENTSPANID, "parentSpanId")                                                                  \
   V(QUEUE, "queue")                                                                                \
   V(QUEUENAME, "queueName")                                                                        \
   V(RAWSIZE, "rawSize")                                                                            \
@@ -432,6 +433,14 @@ jsg::JsValue ToJs(jsg::Lock& js, const tracing::SpanOpen& spanOpen, StringCache&
   KJ_IF_SOME(op, spanOpen.operationName) {
     obj.set(js, OP_STR, js.str(op));
   }
+
+  // TODO(streaming-tail): Finalize format for providing span ID/parent span ID
+  if (isPredictableModeForTest()) {
+    obj.set(js, PARENTSPANID_STR, js.str(kj::hex((uint64_t)0x2a2a2a2a2a2a2a2a)));
+  } else {
+    obj.set(js, PARENTSPANID_STR, js.str(kj::hex(spanOpen.parentSpanId)));
+  }
+
   KJ_IF_SOME(info, spanOpen.info) {
     KJ_SWITCH_ONEOF(info) {
       KJ_CASE_ONEOF(fetch, tracing::FetchEventInfo) {

--- a/src/workerd/io/trace-test.c++
+++ b/src/workerd/io/trace-test.c++
@@ -443,7 +443,7 @@ KJ_TEST("Read/Write SpanOpen works") {
   capnp::MallocMessageBuilder builder;
   auto infoBuilder = builder.initRoot<rpc::Trace::SpanOpen>();
 
-  tracing::SpanOpen info(kj::str("foo"), kj::none);
+  tracing::SpanOpen info(0x2a2a2a2a2a2a2a2a, kj::str("foo"), kj::none);
   info.copyTo(infoBuilder);
 
   auto reader = infoBuilder.asReader();

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -640,8 +640,9 @@ struct SpanOpen final {
   // details of that subrequest.
   using Info = kj::OneOf<FetchEventInfo, JsRpcEventInfo, CustomInfo>;
 
-  explicit SpanOpen(
-      kj::Maybe<kj::String> operationName = kj::none, kj::Maybe<Info> info = kj::none);
+  explicit SpanOpen(uint64_t parentSpanId,
+      kj::Maybe<kj::String> operationName = kj::none,
+      kj::Maybe<Info> info = kj::none);
   SpanOpen(rpc::Trace::SpanOpen::Reader reader);
   SpanOpen(SpanOpen&&) = default;
   SpanOpen& operator=(SpanOpen&&) = default;
@@ -649,6 +650,7 @@ struct SpanOpen final {
 
   kj::Maybe<kj::String> operationName = kj::none;
   kj::Maybe<Info> info = kj::none;
+  uint64_t parentSpanId;
 
   void copyTo(rpc::Trace::SpanOpen::Builder builder) const;
   SpanOpen clone() const;


### PR DESCRIPTION
- [o11y] Support ctx attribute in tailStream(), clarify that only one event is passed at a time
- [o11y] Provide parent span ID in SpanOpen event
  API design may still change here, so this is isolated in one commit to make reverting easier if needed.