### PR TITLE
Update node to 20.19.1 (version used by wrangler).

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,7 +181,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           # Match workers-sdk node version
-          node-version: 18.20.5
+          node-version: 20.19.1
           cache: 'pnpm'
       - name: Install workers-sdk dependencies
         run: pnpm install


### PR DESCRIPTION
This unbreaks CI on the main branch.