### PR TITLE
Fixes WorkerEntrypoint methods not being reported in validator.

### DIFF
--- a/src/pyodide/internal/introspection.py
+++ b/src/pyodide/internal/introspection.py
@@ -6,21 +6,42 @@ from workers import DurableObject, WorkerEntrypoint, WorkflowEntrypoint
 from pyodide.ffi import to_js
 
 
-def collect_classes(user_mod, cls):
+def collect_methods(class_val):
+    """
+    Iterates through the methods in `class_val` and returns only public non-static/non-class methods
+    defined on that class.
+    """
+    return [
+        name
+        for name, value in class_val.__dict__.items()
+        if not isinstance(value, (classmethod, staticmethod))
+        and not name.startswith("_")
+    ]
+
+
+def collect_classes(user_mod, base_cls):
     """
     Iterates through the defined symbols in the input module. Returns any classes which extend
-    DurableObject.
+    `base_cls` (where `base_cls` is one of DurableObject, WorkerEntrypoint or WorkflowEntrypoint).
+
+    This method returns a list of JS objects like [{"className": "MyClass", "methodNames": ["foo"]}].]
     """
     if hasattr(user_mod, "__all__"):
         keys = user_mod.__all__
     else:
         keys = (key for key in dir(user_mod) if not key.startswith("_"))
 
-    def filter(key):
-        val = getattr(user_mod, key)
-        return isclass(val) and issubclass(val, cls) and val is not cls
+    exported_attrs = [getattr(user_mod, key) for key in keys]
 
-    return to_js([key for key in keys if filter(key)])
+    def filter(val):
+        return isclass(val) and issubclass(val, base_cls) and val is not base_cls
+
+    class_attrs = [attr for attr in exported_attrs if filter(attr)]
+    result = [
+        {"className": attr.__name__, "methodNames": collect_methods(attr)}
+        for attr in class_attrs
+    ]
+    return to_js(result, dict_converter=js.Object.fromEntries)
 
 
 def collect_entrypoint_classes(user_mod):

--- a/src/pyodide/internal/workers.py
+++ b/src/pyodide/internal/workers.py
@@ -895,7 +895,9 @@ def handler(func):
 
 
 def _wrap_attr(attr):
-    if not callable(attr):
+    # `isinstance(attr, classmethod)` implies `not callable(attr)`, but we keep the latter for
+    # readability.
+    if not callable(attr) or isinstance(attr, (classmethod, staticmethod)):
         return attr
 
     @functools.wraps(attr)

--- a/src/pyodide/python-entrypoint.js
+++ b/src/pyodide/python-entrypoint.js
@@ -32,10 +32,10 @@ async function doAnImport(name) {
 // Pass the import function to the helper
 setDoAnImport(doAnImport, cloudflareWorkersModule, cloudflareSocketsModule);
 
-function makeEntrypointClassFromNames(names, cls) {
-  return names.map((className) => [
+function makeEntrypointClassFromNames(classes, baseClass) {
+  return classes.map(({ className, methodNames }) => [
     className,
-    makeEntrypointClass(className, cls),
+    makeEntrypointClass(className, baseClass, methodNames),
   ]);
 }
 
@@ -46,9 +46,10 @@ const entrypoints = {
 };
 
 const pythonEntrypoints = Object.fromEntries(
-  Object.entries(entrypoints).flatMap(([key, cls]) =>
-    makeEntrypointClassFromNames(pythonEntrypointClasses[key], cls)
-  )
+  Object.entries(entrypoints).flatMap(([key, baseClass]) => {
+    const classes = pythonEntrypointClasses[key];
+    return makeEntrypointClassFromNames(classes, baseClass);
+  })
 );
 
 export { pythonEntrypoints };


### PR DESCRIPTION
Turns out WorkerEntrypoint support for Python is broken due to the validator needing to know at least one method that it exports. This should fix it.