### PR TITLE
add esbuild to pnpm onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "typescript-eslint": "^8.31.1"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [],
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ],
     "patchedDependencies": {
       "capnp-es": "patches/capnp-es.patch"
     }


### PR DESCRIPTION
This is required because we're using pnpm>=10