### PR TITLE
enable v8's explicit-resource-management and float16array

### DIFF
--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -149,6 +149,11 @@ void V8System::init(kj::Own<v8::Platform> platformParam,
   // more flags.)
   v8::V8::SetFlagsFromString("--noincremental-marking");
 
+  // These features are completed and enabled by default in Chrome, but not
+  // in V8. Follows Node.js: https://github.com/nodejs/node/pull/58154
+  v8::V8::SetFlagsFromString("--js-explicit-resource-management");
+  v8::V8::SetFlagsFromString("--js-float16array");
+
 #ifdef __APPLE__
   // On macOS arm64, we find that V8 can be collecting pages that contain compiled code when
   // handling requests in short succession. There are some specific differences for macOS arm64

--- a/src/wpt/compression-test.ts
+++ b/src/wpt/compression-test.ts
@@ -45,15 +45,7 @@ export default {
       'V8 assertion - Cannot construct ArrayBuffer with a BackingStore of SharedArrayBuffer',
     skipAllTests: true,
   },
-  'decompression-buffersource.tentative.any.js': {
-    // TODO(soon): This will be available with V8 13.8 (June 2025), enable it at that time.
-    comment: 'Enable once Float16Array is enabled',
-    expectedFailures: [
-      'chunk of type Float16Array should work for deflate',
-      'chunk of type Float16Array should work for gzip',
-      'chunk of type Float16Array should work for deflate-raw',
-    ],
-  },
+  'decompression-buffersource.tentative.any.js': {},
   'decompression-constructor-error.tentative.any.js': {
     comment: 'TODO investigate this',
     expectedFailures: [


### PR DESCRIPTION
These will be enabled by default starting from Node.js v24.