### PR TITLE
[NFC] Enable formatting workerd in ew-rosetta

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -395,3 +395,7 @@ build:windows --cxxopt='/Zc:__cplusplus' --host_cxxopt='/Zc:__cplusplus'
 # enable clang coverage: https://clang.llvm.org/docs/SourceBasedCodeCoverage.html
 build:clang-coverage --copt="-fprofile-instr-generate" --linkopt="-fprofile-instr-generate"
 build:clang-coverage --copt="-fcoverage-mapping" --linkopt="-fcoverage-mapping"
+
+# This config is defined internally and enabled on many machines.
+# Defining it as empty just so these machines can run build commands from the workerd repo
+build:rosetta-arm64 --define=rosetta_arm64_no_op=1


### PR DESCRIPTION
Before this trying to format workerd from the internal repo on an ew-rosetta machine would fail with a non-descriptive: 
`ERROR: Config value 'rosetta-arm64' is not defined in any .rc file` 
This commit makes the error message a bit more descriptive but also fixes the issue by defining a small no-op config for rosetta-arm64.