### PR TITLE
remove duplicate handleScope creation

### DIFF
--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -294,7 +294,6 @@ struct LiftKj_ {
     auto isolate = info.GetIsolate();
     try {
       try {
-        v8::HandleScope scope(isolate);
         if constexpr (isVoid<T>()) {
           func();
           if constexpr (!kj::canConvert<Info&, v8::PropertyCallbackInfo<void>&>()) {

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -341,7 +341,7 @@ struct LiftKj_<v8::Local<v8::Promise>> {
       return;
     }
 
-    v8::HandleScope scope(isolate);
+    KJ_DASSERT(v8::HandleScope::NumberOfHandles(isolate) > 0);
     v8::TryCatch tryCatch(isolate);
     try {
       try {

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -294,6 +294,7 @@ struct LiftKj_ {
     auto isolate = info.GetIsolate();
     try {
       try {
+        KJ_DASSERT(v8::HandleScope::NumberOfHandles(isolate) > 0);
         if constexpr (isVoid<T>()) {
           func();
           if constexpr (!kj::canConvert<Info&, v8::PropertyCallbackInfo<void>&>()) {

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -294,7 +294,6 @@ struct LiftKj_ {
     auto isolate = info.GetIsolate();
     try {
       try {
-        KJ_DASSERT(v8::HandleScope::NumberOfHandles(isolate) > 0);
         if constexpr (isVoid<T>()) {
           func();
           if constexpr (!kj::canConvert<Info&, v8::PropertyCallbackInfo<void>&>()) {
@@ -341,7 +340,6 @@ struct LiftKj_<v8::Local<v8::Promise>> {
       return;
     }
 
-    KJ_DASSERT(v8::HandleScope::NumberOfHandles(isolate) > 0);
     v8::TryCatch tryCatch(isolate);
     try {
       try {


### PR DESCRIPTION
on all functions (except v8 fast api), handleScope is created automatically. this pull-request avoids creating the handleScope twice.

This change improves the performance by **20-25%!!!** (on all functions in workerd)

- Before

```
SlowAPI             348050 ns       348007 ns         1976
SlowAPIWithLock     300119 ns       300090 ns         2299
```

- After

```
SlowAPI             291597 ns       291551 ns         2410
SlowAPIWithLock     239857 ns       239840 ns         2845
```