### PR TITLE
[o11y] Update Streaming Tail Worker Attributes definition

### DIFF
--- a/types/defines/trace.d.ts
+++ b/types/defines/trace.d.ts
@@ -124,7 +124,7 @@ interface Hibernate {
 interface SpanOpen {
   readonly type: "spanOpen";
   readonly name: string;
-  readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+  readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
 }
 
 interface SpanClose {
@@ -153,7 +153,7 @@ interface Log {
 
 interface Return {
   readonly type: "return";
-  readonly info?: FetchResponseInfo | Attribute[];
+  readonly info?: FetchResponseInfo | Attributes;
 }
 
 interface Link {
@@ -165,9 +165,13 @@ interface Link {
 }
 
 interface Attribute {
-  readonly type: "attribute";
   readonly name: string;
   readonly value: string | string[] | boolean | boolean[] | number | number[] | bigint | bigint[];
+}
+
+interface Attributes {
+  readonly type: "attributes";
+  readonly info: Attribute[];
 }
 
 interface TailEvent {
@@ -176,12 +180,12 @@ interface TailEvent {
   readonly spanId: string;
   readonly timestamp: Date;
   readonly sequence: number;
-  readonly event: Onset | Outcome | Hibernate | SpanOpen | SpanClose | DiagnosticChannelEvent | Exception | Log | Return | Link | Attribute[];
+  readonly event: Onset | Outcome | Hibernate | SpanOpen | SpanClose | DiagnosticChannelEvent | Exception | Log | Return | Link | Attributes;
 }
 
 type TailEventHandler = (event: TailEvent) => void | Promise<void>;
 type TailEventHandlerName = "outcome" | "hibernate" | "spanOpen" | "spanClose" |
-                            "diagnosticChannel" | "exception" | "log" | "return" | "link" | "attribute";
+                            "diagnosticChannel" | "exception" | "log" | "return" | "link" | "attributes";
 type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
 type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -6344,7 +6344,7 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6368,7 +6368,7 @@ declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6378,7 +6378,6 @@ declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6389,6 +6388,10 @@ declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6407,7 +6410,7 @@ declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6420,7 +6423,7 @@ declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -6208,7 +6208,7 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6232,7 +6232,7 @@ export declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6242,7 +6242,6 @@ export declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6253,6 +6252,10 @@ export declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6271,7 +6274,7 @@ export declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6284,7 +6287,7 @@ export declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -6370,7 +6370,7 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6394,7 +6394,7 @@ declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6404,7 +6404,6 @@ declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6415,6 +6414,10 @@ declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6433,7 +6436,7 @@ declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6446,7 +6449,7 @@ declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -6234,7 +6234,7 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6258,7 +6258,7 @@ export declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6268,7 +6268,6 @@ export declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6279,6 +6278,10 @@ export declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6297,7 +6300,7 @@ export declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6310,7 +6313,7 @@ export declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -6388,7 +6388,7 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6412,7 +6412,7 @@ declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6422,7 +6422,6 @@ declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6433,6 +6432,10 @@ declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6451,7 +6454,7 @@ declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6464,7 +6467,7 @@ declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -6252,7 +6252,7 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6276,7 +6276,7 @@ export declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6286,7 +6286,6 @@ export declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6297,6 +6296,10 @@ export declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6315,7 +6318,7 @@ export declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6328,7 +6331,7 @@ export declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -6389,7 +6389,7 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6413,7 +6413,7 @@ declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6423,7 +6423,6 @@ declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6434,6 +6433,10 @@ declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6452,7 +6455,7 @@ declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6465,7 +6468,7 @@ declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -6253,7 +6253,7 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6277,7 +6277,7 @@ export declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6287,7 +6287,6 @@ export declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6298,6 +6297,10 @@ export declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6316,7 +6319,7 @@ export declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6329,7 +6332,7 @@ export declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -6393,7 +6393,7 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6417,7 +6417,7 @@ declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6427,7 +6427,6 @@ declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6438,6 +6437,10 @@ declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6456,7 +6459,7 @@ declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6469,7 +6472,7 @@ declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -6257,7 +6257,7 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6281,7 +6281,7 @@ export declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6291,7 +6291,6 @@ export declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6302,6 +6301,10 @@ export declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6320,7 +6323,7 @@ export declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6333,7 +6336,7 @@ export declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -6398,7 +6398,7 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6422,7 +6422,7 @@ declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6432,7 +6432,6 @@ declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6443,6 +6442,10 @@ declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6461,7 +6464,7 @@ declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6474,7 +6477,7 @@ declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -6262,7 +6262,7 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6286,7 +6286,7 @@ export declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6296,7 +6296,6 @@ export declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6307,6 +6306,10 @@ export declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6325,7 +6328,7 @@ export declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6338,7 +6341,7 @@ export declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -6400,7 +6400,7 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6424,7 +6424,7 @@ declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6434,7 +6434,6 @@ declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6445,6 +6444,10 @@ declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6463,7 +6466,7 @@ declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6476,7 +6479,7 @@ declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -6264,7 +6264,7 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6288,7 +6288,7 @@ export declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6298,7 +6298,6 @@ export declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6309,6 +6308,10 @@ export declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6327,7 +6330,7 @@ export declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6340,7 +6343,7 @@ export declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -6400,7 +6400,7 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6424,7 +6424,7 @@ declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6434,7 +6434,6 @@ declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6445,6 +6444,10 @@ declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6463,7 +6466,7 @@ declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6476,7 +6479,7 @@ declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -6264,7 +6264,7 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6288,7 +6288,7 @@ export declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6298,7 +6298,6 @@ export declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6309,6 +6308,10 @@ export declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6327,7 +6330,7 @@ export declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6340,7 +6343,7 @@ export declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -6486,7 +6486,7 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6510,7 +6510,7 @@ declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6520,7 +6520,6 @@ declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6531,6 +6530,10 @@ declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6549,7 +6552,7 @@ declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6562,7 +6565,7 @@ declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -6350,7 +6350,7 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6374,7 +6374,7 @@ export declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6384,7 +6384,6 @@ export declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6395,6 +6394,10 @@ export declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6413,7 +6416,7 @@ export declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6426,7 +6429,7 @@ export declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -6344,7 +6344,7 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6368,7 +6368,7 @@ declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6378,7 +6378,6 @@ declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6389,6 +6388,10 @@ declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6407,7 +6410,7 @@ declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6420,7 +6423,7 @@ declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -6208,7 +6208,7 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
     readonly type: "spanClose";
@@ -6232,7 +6232,7 @@ export declare namespace TailStream {
   }
   interface Return {
     readonly type: "return";
-    readonly info?: FetchResponseInfo | Attribute[];
+    readonly info?: FetchResponseInfo | Attributes;
   }
   interface Link {
     readonly type: "link";
@@ -6242,7 +6242,6 @@ export declare namespace TailStream {
     readonly spanId: string;
   }
   interface Attribute {
-    readonly type: "attribute";
     readonly name: string;
     readonly value:
       | string
@@ -6253,6 +6252,10 @@ export declare namespace TailStream {
       | number[]
       | bigint
       | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
   }
   interface TailEvent {
     readonly traceId: string;
@@ -6271,7 +6274,7 @@ export declare namespace TailStream {
       | Log
       | Return
       | Link
-      | Attribute[];
+      | Attributes;
   }
   type TailEventHandler = (event: TailEvent) => void | Promise<void>;
   type TailEventHandlerName =
@@ -6284,7 +6287,7 @@ export declare namespace TailStream {
     | "log"
     | "return"
     | "link"
-    | "attribute";
+    | "attributes";
   type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }


### PR DESCRIPTION
This should be easier to process in the tail worker. Note that only the JS side is updated and we still use a plain array internally, this makes this change simpler and avoids needing e.g. capnp definition changes.

Alongside this change, update the name of the handler for these events to "attributes", which is more descriptive.