### PR TITLE
EW-9223 Transition abseil dependency to canonical name

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -75,11 +75,11 @@ build:v8-codegen-opt --per_file_copt=v8/src/parsing@-O2
 build:v8-codegen-opt --per_file_copt=v8/src/snapshot@-O2
 build:v8-codegen-opt --per_file_copt=v8/src/wasm@-O2
 # V8 is heavily using absl for hashing now, optimize it too.
-build:v8-codegen-opt --per_file_copt=external/com_google_absl@-O2
+build:v8-codegen-opt --per_file_copt=external/abseil-cpp@-O2
 
 # In Google projects, exceptions are not used as a rule. Disabling them is more consistent with the
 # canonical V8 build and improves code size.
-build:unix --per_file_copt=external/com_google_absl@-fno-exceptions
+build:unix --per_file_copt=external/abseil-cpp@-fno-exceptions
 build:unix --per_file_copt=external/com_google_protobuf@-fno-exceptions
 build:unix --per_file_copt=external/com_google_tcmalloc@-fno-exceptions
 build:unix --per_file_copt=external/com_googlesource_chromium_icu@-fno-exceptions
@@ -88,7 +88,7 @@ build:unix --per_file_copt=external/ssl@-fno-exceptions
 build:unix --per_file_copt=external/v8@-fno-exceptions
 build:unix --per_file_copt=external/ada-url@-fno-exceptions
 build:unix --per_file_copt=external/simdutf@-fno-exceptions
-build:windows --per_file_copt=external/com_google_absl@/GX-
+build:windows --per_file_copt=external/abseil-cpp@/GX-
 build:windows --per_file_copt=external/com_google_protobuf@/GX-
 build:windows --per_file_copt=external/com_google_tcmalloc@/GX-
 build:windows --per_file_copt=external/com_googlesource_chromium_icu@/GX-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,7 +16,7 @@ deps_gen()
 # Bazel basics
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 NODE_VERSION = "22.14.0"
 
@@ -88,7 +88,7 @@ dep_pyodide()
 # tcmalloc requires Abseil.
 #
 git_repository(
-    name = "com_google_absl",
+    name = "abseil-cpp",
     commit = "72093794ac42be8105817ae0b0569fb411a6ca9b",
     remote = "https://chromium.googlesource.com/chromium/src/third_party/abseil-cpp.git",
 )
@@ -122,6 +122,7 @@ git_repository(
 http_archive(
     name = "com_google_tcmalloc",
     integrity = "sha256-8joG3SxfLYqR2liUznBAcMkHKYMmUtsO1qGr505VBMY=",
+    repo_mapping = {"@com_google_absl": "@abseil-cpp"},
     strip_prefix = "google-tcmalloc-91765c1",
     type = "tgz",
     url = "https://github.com/google/tcmalloc/tarball/91765c11461a01579fcbdddf430a556b818818c4",

--- a/build/deps/deps.jsonc
+++ b/build/deps/deps.jsonc
@@ -47,7 +47,10 @@
       "repo": "protobuf",
       "file_regex": "protobuf-.*\\.tar\\.gz",
       // Frozen because protobuf version management is difficult. Newer versions currently break build.
-      "freeze_version": "v29.3"
+      "freeze_version": "v29.4",
+      "repo_mapping": {
+        "@com_google_absl": "@abseil-cpp"
+      }
     },
     {
       "type": "github_release",

--- a/build/deps/gen/dep_com_google_protobuf.bzl
+++ b/build/deps/gen/dep_com_google_protobuf.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "v29.3"
-URL = "https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protobuf-29.3.tar.gz"
-STRIP_PREFIX = "protobuf-29.3"
-SHA256 = "008a11cc56f9b96679b4c285fd05f46d317d685be3ab524b2a310be0fbad987e"
+TAG_NAME = "v29.4"
+URL = "https://github.com/protocolbuffers/protobuf/releases/download/v29.4/protobuf-29.4.tar.gz"
+STRIP_PREFIX = "protobuf-29.4"
+SHA256 = "6bd9dcc91b17ef25c26adf86db71c67ec02431dc92e9589eaf82e22889230496"
 TYPE = "tgz"
 
 def dep_com_google_protobuf():
@@ -15,4 +15,5 @@ def dep_com_google_protobuf():
         strip_prefix = STRIP_PREFIX,
         type = TYPE,
         sha256 = SHA256,
+        repo_mapping = {"@com_google_absl": "@abseil-cpp"},
     )

--- a/build/deps/v8.bzl
+++ b/build/deps/v8.bzl
@@ -52,7 +52,6 @@ def deps_v8():
         patches = ["//:patches/v8/" + p for p in PATCHES],
         strip_prefix = "v8-" + VERSION,
         url = "https://github.com/v8/v8/archive/refs/tags/" + VERSION + ".tar.gz",
-        repo_mapping = {"@abseil-cpp": "@com_google_absl"},
     )
 
     git_repository(

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -6,7 +6,7 @@
 -Ibazel-bin/external/perfetto/
 -Iexternal/perfetto-sdk/sdk/
 -Iexternal/ada-url/
--Iexternal/com_google_absl/
+-Iexternal/abseil-cpp/
 -Iexternal/simdutf/
 -Iexternal/nbytes/include/
 -Iexternal/com_google_benchmark/include/

--- a/src/pyodide/helpers.bzl
+++ b/src/pyodide/helpers.bzl
@@ -1,7 +1,6 @@
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@capnp-cpp//src/capnp:cc_capnp_library.bzl", "cc_capnp_library")
 load("//:build/capnp_embed.bzl", "capnp_embed")
 load("//:build/js_file.bzl", "js_file")
@@ -19,9 +18,6 @@ def _out_path(name, version):
     if version:
         res = version + "/" + res
     return res
-
-def _out(src, version):
-    return _out_path(_out_name(src), version)
 
 def _ts_bundle_out(prefix, name, version):
     return ":" + _out_path(prefix + name.removeprefix("internal/").replace("/", "_"), version)


### PR DESCRIPTION
This is the name under which abseil is available in Bazel Central Registry, working towards transitioning to bzlmod.