### PR TITLE
Fix the list of proxied special methods for DO/RPC in Python.

### DIFF
--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -232,17 +232,30 @@ async function initPyInstance(
   return res as PyModule;
 }
 
+// https://developers.cloudflare.com/workers/runtime-apis/rpc/reserved-methods/
+const SPECIAL_HANDLER_NAMES = ['fetch', 'connect'];
+const SPECIAL_DO_HANDLER_NAMES = [
+  'alarm',
+  'webSocketMessage',
+  'webSocketClose',
+  'webSocketError',
+];
+
 function makeEntrypointProxyHandler(
-  pyInstancePromise: Promise<PyModule>
+  pyInstancePromise: Promise<PyModule>,
+  isDurableObject: boolean
 ): ProxyHandler<any> {
   return {
     get(target, prop, receiver): any {
       if (typeof prop !== 'string') {
         return Reflect.get(target, prop, receiver);
       }
+
       // Proxy calls to `fetch` to methods named `on_fetch` (and the same for other handlers.)
-      const isKnownHandler = SUPPORTED_HANDLER_NAMES.includes(prop);
-      if (isKnownHandler) {
+      const isKnownHandler = SPECIAL_HANDLER_NAMES.includes(prop);
+      const isKnownDoHandler =
+        isDurableObject && SPECIAL_DO_HANDLER_NAMES.includes(prop);
+      if (isKnownHandler || isKnownDoHandler) {
         prop = 'on_' + prop;
       }
 
@@ -264,6 +277,7 @@ function makeEntrypointClass(
   classKind: AnyClass,
   methods: string[]
 ): any {
+  const isDurableObject = classKind.name === 'DurableObject';
   const result = class EntrypointWrapper extends classKind {
     public constructor(...args: any[]) {
       super(...args);
@@ -271,7 +285,10 @@ function makeEntrypointClass(
       const pyInstancePromise = initPyInstance(className, args);
       // We do not know the methods that are defined on the RPC class, so we need a proxy to
       // support any possible method name.
-      return new Proxy(this, makeEntrypointProxyHandler(pyInstancePromise));
+      return new Proxy(
+        this,
+        makeEntrypointProxyHandler(pyInstancePromise, isDurableObject)
+      );
     }
   };
 


### PR DESCRIPTION
Methods like `scheduled` aren't special in DO/RPC, so we do not proxy them to `on_scheduled`. But there are also other methods that we haven't been proxying.

This is just a quick PR to fix this.