### PR TITLE
Log whenever AbortSignal is used over RPC

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -821,7 +821,7 @@ void AbortSignal::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   auto& handler = JSG_REQUIRE_NONNULL(serializer.getExternalHandler(), DOMDataCloneError,
       "AbortSignal can only be serialized for RPC.");
 
-  LOG_PERIODICALLY(WARNING, "NOSENTRY ", "An AbortSignal was serialized for RPC");
+  LOG_PERIODICALLY(WARNING, "NOSENTRY An AbortSignal was serialized for RPC");
 
   auto externalHandler = dynamic_cast<RpcSerializerExternalHandler*>(&handler);
   JSG_REQUIRE(

--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -820,6 +820,9 @@ void AbortSignal::triggerAbort(
 void AbortSignal::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   auto& handler = JSG_REQUIRE_NONNULL(serializer.getExternalHandler(), DOMDataCloneError,
       "AbortSignal can only be serialized for RPC.");
+
+  LOG_PERIODICALLY(WARNING, "NOSENTRY ", "An AbortSignal was serialized for RPC");
+
   auto externalHandler = dynamic_cast<RpcSerializerExternalHandler*>(&handler);
   JSG_REQUIRE(
       externalHandler != nullptr, DOMDataCloneError, "AbortSignal can only be serialized for RPC.");


### PR DESCRIPTION
We're going to have to put AbortSignal RPC support behind a compat flag ASAP, because it spuriously causes the outcome of a request to show `exception` even though things work fine. First we need to make sure no one is using this feature.