### PR TITLE
Wrap `env` in Python DO/WorkerEntrypoint constructor.

### DIFF
--- a/src/pyodide/internal/workers.py
+++ b/src/pyodide/internal/workers.py
@@ -917,6 +917,17 @@ def _wrap_subclass(cls):
             continue
         setattr(cls, k, _wrap_attr(v))
 
+    # Override the class __init__ so that we can wrap the `env` in the constructor.
+    original_init = cls.__init__
+
+    def wrapped_init(self, *args, **kwargs):
+        if len(args) > 1:
+            args = (args[0], _EnvWrapper(args[1])) + args[2:]
+
+        original_init(self, *args, **kwargs)
+
+    cls.__init__ = wrapped_init
+
 
 class DurableObject:
     """

--- a/src/workerd/server/tests/python/python-rpc/worker.py
+++ b/src/workerd/server/tests/python/python-rpc/worker.py
@@ -18,6 +18,10 @@ assertRaisesRegex = TestCase().assertRaisesRegex
 
 
 class PythonRpcTester(WorkerEntrypoint):
+    def __init__(self, ctx, env):
+        assert not isinstance(env, JsProxy)
+        self.env = env
+
     async def no_args(self):
         return "hello from python"
 
@@ -36,6 +40,14 @@ class PythonRpcTester(WorkerEntrypoint):
     async def handle_request(self, req):
         assert isinstance(req, Request)
         return req
+
+    async def check_env(self):
+        # Verify that the `env` supplied to the entrypoint class is wrapped.
+        curr_date = datetime.now()
+        py_date = await self.env.PythonRpc.identity(curr_date)
+        assert isinstance(py_date, datetime)
+        assert py_date == curr_date
+        return True
 
 
 class CustomType:
@@ -236,3 +248,6 @@ async def test(ctrl, env, ctx):
         await env.PythonRpc.identity(my_func)
     with assertRaises(TypeError):
         await env.PythonRpc.identity({"test": (1, 2, 3)})
+
+    # Verify that the `env` in the DO is correctly wrapped.
+    assert await env.PythonRpc.check_env()


### PR DESCRIPTION
This `env` is passed via the constructor, this PR ensures that it is wrapped in our `EnvWrapper` which deals with nice RPC conversions.