### PR TITLE
Rename Cloudflare namespace in types to CF

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -156,7 +156,7 @@ declare namespace Rpc {
   };
 }
 
-declare namespace Cloudflare {
+declare namespace CF {
   interface Env {}
 }
 
@@ -292,5 +292,5 @@ declare module 'cloudflare:workers' {
     ): Promise<unknown>;
   }
 
-  export const env: Cloudflare.Env;
+  export const env: CF.Env;
 }

--- a/types/generated-snapshot/2021-11-03/index.d.ts
+++ b/types/generated-snapshot/2021-11-03/index.d.ts
@@ -6092,7 +6092,7 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-declare namespace Cloudflare {
+declare namespace CF {
   interface Env {}
 }
 declare module "cloudflare:workers" {
@@ -6205,7 +6205,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Cloudflare.Env;
+  export const env: CF.Env;
 }
 interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2021-11-03/index.ts
+++ b/types/generated-snapshot/2021-11-03/index.ts
@@ -6075,7 +6075,7 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-export declare namespace Cloudflare {
+export declare namespace CF {
   interface Env {}
 }
 export interface SecretsStoreSecret {

--- a/types/generated-snapshot/2022-01-31/index.d.ts
+++ b/types/generated-snapshot/2022-01-31/index.d.ts
@@ -6118,7 +6118,7 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-declare namespace Cloudflare {
+declare namespace CF {
   interface Env {}
 }
 declare module "cloudflare:workers" {
@@ -6231,7 +6231,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Cloudflare.Env;
+  export const env: CF.Env;
 }
 interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2022-01-31/index.ts
+++ b/types/generated-snapshot/2022-01-31/index.ts
@@ -6101,7 +6101,7 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-export declare namespace Cloudflare {
+export declare namespace CF {
   interface Env {}
 }
 export interface SecretsStoreSecret {

--- a/types/generated-snapshot/2022-03-21/index.d.ts
+++ b/types/generated-snapshot/2022-03-21/index.d.ts
@@ -6136,7 +6136,7 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-declare namespace Cloudflare {
+declare namespace CF {
   interface Env {}
 }
 declare module "cloudflare:workers" {
@@ -6249,7 +6249,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Cloudflare.Env;
+  export const env: CF.Env;
 }
 interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2022-03-21/index.ts
+++ b/types/generated-snapshot/2022-03-21/index.ts
@@ -6119,7 +6119,7 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-export declare namespace Cloudflare {
+export declare namespace CF {
   interface Env {}
 }
 export interface SecretsStoreSecret {

--- a/types/generated-snapshot/2022-08-04/index.d.ts
+++ b/types/generated-snapshot/2022-08-04/index.d.ts
@@ -6137,7 +6137,7 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-declare namespace Cloudflare {
+declare namespace CF {
   interface Env {}
 }
 declare module "cloudflare:workers" {
@@ -6250,7 +6250,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Cloudflare.Env;
+  export const env: CF.Env;
 }
 interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2022-08-04/index.ts
+++ b/types/generated-snapshot/2022-08-04/index.ts
@@ -6120,7 +6120,7 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-export declare namespace Cloudflare {
+export declare namespace CF {
   interface Env {}
 }
 export interface SecretsStoreSecret {

--- a/types/generated-snapshot/2022-10-31/index.d.ts
+++ b/types/generated-snapshot/2022-10-31/index.d.ts
@@ -6141,7 +6141,7 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-declare namespace Cloudflare {
+declare namespace CF {
   interface Env {}
 }
 declare module "cloudflare:workers" {
@@ -6254,7 +6254,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Cloudflare.Env;
+  export const env: CF.Env;
 }
 interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2022-10-31/index.ts
+++ b/types/generated-snapshot/2022-10-31/index.ts
@@ -6124,7 +6124,7 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-export declare namespace Cloudflare {
+export declare namespace CF {
   interface Env {}
 }
 export interface SecretsStoreSecret {

--- a/types/generated-snapshot/2022-11-30/index.d.ts
+++ b/types/generated-snapshot/2022-11-30/index.d.ts
@@ -6146,7 +6146,7 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-declare namespace Cloudflare {
+declare namespace CF {
   interface Env {}
 }
 declare module "cloudflare:workers" {
@@ -6259,7 +6259,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Cloudflare.Env;
+  export const env: CF.Env;
 }
 interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2022-11-30/index.ts
+++ b/types/generated-snapshot/2022-11-30/index.ts
@@ -6129,7 +6129,7 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-export declare namespace Cloudflare {
+export declare namespace CF {
   interface Env {}
 }
 export interface SecretsStoreSecret {

--- a/types/generated-snapshot/2023-03-01/index.d.ts
+++ b/types/generated-snapshot/2023-03-01/index.d.ts
@@ -6148,7 +6148,7 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-declare namespace Cloudflare {
+declare namespace CF {
   interface Env {}
 }
 declare module "cloudflare:workers" {
@@ -6261,7 +6261,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Cloudflare.Env;
+  export const env: CF.Env;
 }
 interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2023-03-01/index.ts
+++ b/types/generated-snapshot/2023-03-01/index.ts
@@ -6131,7 +6131,7 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-export declare namespace Cloudflare {
+export declare namespace CF {
   interface Env {}
 }
 export interface SecretsStoreSecret {

--- a/types/generated-snapshot/2023-07-01/index.d.ts
+++ b/types/generated-snapshot/2023-07-01/index.d.ts
@@ -6148,7 +6148,7 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-declare namespace Cloudflare {
+declare namespace CF {
   interface Env {}
 }
 declare module "cloudflare:workers" {
@@ -6261,7 +6261,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Cloudflare.Env;
+  export const env: CF.Env;
 }
 interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/2023-07-01/index.ts
+++ b/types/generated-snapshot/2023-07-01/index.ts
@@ -6131,7 +6131,7 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-export declare namespace Cloudflare {
+export declare namespace CF {
   interface Env {}
 }
 export interface SecretsStoreSecret {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -6234,7 +6234,7 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-declare namespace Cloudflare {
+declare namespace CF {
   interface Env {}
 }
 declare module "cloudflare:workers" {
@@ -6347,7 +6347,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Cloudflare.Env;
+  export const env: CF.Env;
 }
 interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -6217,7 +6217,7 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-export declare namespace Cloudflare {
+export declare namespace CF {
   interface Env {}
 }
 export interface SecretsStoreSecret {

--- a/types/generated-snapshot/oldest/index.d.ts
+++ b/types/generated-snapshot/oldest/index.d.ts
@@ -6092,7 +6092,7 @@ declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-declare namespace Cloudflare {
+declare namespace CF {
   interface Env {}
 }
 declare module "cloudflare:workers" {
@@ -6205,7 +6205,7 @@ declare module "cloudflare:workers" {
       step: WorkflowStep,
     ): Promise<unknown>;
   }
-  export const env: Cloudflare.Env;
+  export const env: CF.Env;
 }
 interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/oldest/index.ts
+++ b/types/generated-snapshot/oldest/index.ts
@@ -6075,7 +6075,7 @@ export declare namespace Rpc {
     >]: MethodOrProperty<T[K]>;
   };
 }
-export declare namespace Cloudflare {
+export declare namespace CF {
   interface Env {}
 }
 export interface SecretsStoreSecret {


### PR DESCRIPTION
corresponding workers-sdk PR: https://github.com/cloudflare/workers-sdk/pull/9179

the Cloudflare namespace was conflicting with the Cloudflare global when both generated types and @cloudflare/workers-types existed. This renames the namespace (not user facing) to CF to prevent this.