### PR TITLE
add codspeed for continuous benchmarking

### DIFF
--- a/build/deps/build_deps.jsonc
+++ b/build/deps/build_deps.jsonc
@@ -165,8 +165,8 @@
     {
       "type": "github_release",
       "name": "com_google_benchmark",
-      "owner": "google",
-      "repo": "benchmark"
+      "owner": "CodSpeedHQ",
+      "repo": "codspeed-cpp"
     }
   ]
 }

--- a/build/deps/gen/dep_com_google_benchmark.bzl
+++ b/build/deps/gen/dep_com_google_benchmark.bzl
@@ -2,10 +2,10 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "v1.9.2"
-URL = "https://api.github.com/repos/google/benchmark/tarball/v1.9.2"
-STRIP_PREFIX = "google-benchmark-ce0b57f"
-SHA256 = "f5f18fd6c2a6edebf5c2b916d850448dbb92f3eae016a64e669cae8b5578b001"
+TAG_NAME = "v1.1.0"
+URL = "https://api.github.com/repos/CodSpeedHQ/codspeed-cpp/tarball/v1.1.0"
+STRIP_PREFIX = "CodSpeedHQ-codspeed-cpp-bf30684"
+SHA256 = "3ef8fdd074148da65da5b4f36b4724f45eca215ab615a984ba7a58b16ea47f89"
 TYPE = "tgz"
 
 def dep_com_google_benchmark():

--- a/build/wd_cc_benchmark.bzl
+++ b/build/wd_cc_benchmark.bzl
@@ -25,7 +25,7 @@ def wd_cc_benchmark(
         }),
         visibility = visibility,
         deps = deps + [
-            "@com_google_benchmark//:benchmark_main",
+            "@com_google_benchmark//google_benchmark:benchmark_main",
             "//src/workerd/tests:bench-tools",
         ],
         # use the same malloc we use for server

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -8,7 +8,7 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@capnp-cpp//src/kj:kj-test",
-        "@com_google_benchmark//:benchmark",
+        "@com_google_benchmark//google_benchmark:benchmark",
     ],
 )
 


### PR DESCRIPTION
Currently it is failing with the following error

```
bazel build //...
ERROR: Traceback (most recent call last):
        File "/home/yagiz/.cache/bazel/external/com_google_benchmark/core/BUILD", line 9, column 16, in <toplevel>
                srcs = glob(["src/**/*.cpp"] + ["src/**/*.h"] + ["src/**/*.hpp"]),
Error in glob: glob pattern 'src/**/*.h' didn't match anything, but allow_empty is set to False (the default value of allow_empty can be set with --incompatible_disallow_empty_glob).
ERROR: /home/yagiz/.cache/bazel/external/com_google_benchmark/core/BUILD: no such target '@@com_google_benchmark//core:codspeed': target 'codspeed' not declared in package 'core' defined by /home/yagiz/.cache/bazel/external/com_google_benchmark/core/BUILD
ERROR: /home/yagiz/.cache/bazel/external/com_google_benchmark/google_benchmark/BUILD.bazel:40:11: no such target '@@com_google_benchmark//core:codspeed': target 'codspeed' not declared in package 'core' defined by /home/yagiz/.cache/bazel/external/com_google_benchmark/core/BUILD and referenced by '@@com_google_benchmark//google_benchmark:benchmark'
ERROR: Analysis of target '//src/workerd/tests:bench-tools' failed; build aborted: Analysis failed
INFO: Elapsed time: 0.562s, Critical Path: 0.03s
INFO: 1 process: 171 action cache hit, 1 internal.
ERROR: Build did NOT complete successfully
FAILED:
    Fetching repository @@local_config_cc; starting
error: Recipe `build` failed on line 21 with exit code 1
```