### PR TITLE
Update new modules registry to align with vfs

### DIFF
--- a/src/workerd/api/tests/new-module-registry-test.js
+++ b/src/workerd/api/tests/new-module-registry-test.js
@@ -13,7 +13,7 @@ import { foo as foo2, default as def2 } from 'bar';
 import { createRequire } from 'module';
 
 // Verify that import.meta.url is correct here.
-strictEqual(import.meta.url, 'file:///worker');
+strictEqual(import.meta.url, 'file:///bundle/worker');
 
 // Verify that import.meta.main is true here.
 ok(import.meta.main);
@@ -44,7 +44,8 @@ console.log(import.meta);
 // Verify that import.meta.resolve provides correct results here.
 // The input should be interpreted as a URL and normalized according
 // to the rules in the WHATWG URL specification.
-strictEqual(import.meta.resolve('./.././test/.././../foo'), 'file:///foo');
+strictEqual(import.meta.resolve('./.././test/.././.%2e/foo'), 'file:///foo');
+strictEqual(import.meta.resolve('foo'), 'file:///bundle/foo');
 
 // There are four tests at this top level... one for the import of the node:assert
 // module without the node: prefix specifier, two for the imports of the foo and
@@ -58,7 +59,7 @@ strictEqual(def2, 2);
 strictEqual(fs, 'abc');
 
 // Equivalent to the above, but using the file: URL scheme.
-import { foo as foo3, default as def3 } from 'file:///foo';
+import { foo as foo3, default as def3 } from 'file:///bundle/foo';
 strictEqual(foo, foo3);
 strictEqual(def, def3);
 
@@ -78,7 +79,7 @@ import { default as cjs2 } from 'cjs2';
 strictEqual(cjs2.foo, 1);
 strictEqual(cjs2.bar, 2);
 strictEqual(cjs2.filename, 'cjs1');
-strictEqual(cjs2.dirname, '/');
+strictEqual(cjs2.dirname, '/bundle');
 strictEqual(cjs2.assert, assert);
 
 // CommonJS modules can define named exports.
@@ -91,7 +92,7 @@ const customRequireCjs = myRequire('cjs1');
 strictEqual(customRequireCjs.foo, cjs1foo);
 strictEqual(customRequireCjs.bar, cjs1bar);
 
-await rejects(import('file:///cjs3'), {
+await rejects(import('file:///bundle/cjs3'), {
   message: 'boom',
 });
 
@@ -109,7 +110,7 @@ await rejects(import('invalid-json'), {
 });
 
 await rejects(import('module-not-found'), {
-  message: /Module not found: file:\/\/\/module-not-found/,
+  message: /Module not found: file:\/\/\/bundle\/module-not-found/,
 });
 
 // Verify that a module is unable to perform IO operations at the top level, even if
@@ -160,10 +161,10 @@ export const queryAndFragment = {
     notStrictEqual(c, d);
 
     // The import.meta.url for each should match the specifier used to import the instance.
-    strictEqual(a.bar, 'file:///foo?query');
-    strictEqual(b.bar, 'file:///foo#fragment');
-    strictEqual(c.bar, 'file:///foo?query#fragment');
-    strictEqual(d.bar, 'file:///foo');
+    strictEqual(a.bar, 'file:///bundle/foo?query');
+    strictEqual(b.bar, 'file:///bundle/foo#fragment');
+    strictEqual(c.bar, 'file:///bundle/foo?query#fragment');
+    strictEqual(d.bar, 'file:///bundle/foo');
   },
 };
 

--- a/src/workerd/jsg/modules-new-test.c++
+++ b/src/workerd/jsg/modules-new-test.c++
@@ -24,6 +24,7 @@ using workerd::jsg::modules::ModuleRegistry;
 using workerd::jsg::modules::ResolveContext;
 
 V8System v8System;
+const jsg::Url BASE = "file:///"_url;
 
 struct ResolveObserverImpl: public ResolveObserver {
   struct Request {
@@ -123,13 +124,11 @@ JSG_DECLARE_ISOLATE_TYPE(TestIsolate, TestContext, TestType);
 // ======================================================================================
 
 KJ_TEST("An empty registry") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
-
   // We should be able to create an empty registry that returns nothing.
   // Basic resolution of this kind does not require an isolate lock.
 
   ResolveObserverImpl observer;
-  ModuleRegistry::Builder registryBuilder(observer);
+  ModuleRegistry::Builder registryBuilder(observer, BASE);
   auto registry = registryBuilder.finish();
   KJ_ASSERT(registry.get() != nullptr);
 
@@ -137,7 +136,7 @@ KJ_TEST("An empty registry") {
     .type = ResolveContext::Type::BUNDLE,
     .source = ResolveContext::Source::OTHER,
     .specifier = "file:///foo"_url,
-    .referrer = ModuleBundle::BundleBuilder::BASE,
+    .referrer = BASE,
   };
 
   KJ_ASSERT(registry->resolve(context) == kj::none);
@@ -162,7 +161,7 @@ KJ_TEST("A empty fallback bundle") {
     .type = ResolveContext::Type::BUNDLE,
     .source = ResolveContext::Source::OTHER,
     .specifier = "file:///foo"_url,
-    .referrer = ModuleBundle::BundleBuilder::BASE,
+    .referrer = BASE,
   };
 
   KJ_ASSERT(fallback->resolve(context) == kj::none);
@@ -175,14 +174,14 @@ KJ_TEST("An empty user bundle") {
   // We should be able to create an empty user bundle that returns nothing.
   // Basic resolution of this kind does not require an isolate lock.
 
-  ModuleBundle::BundleBuilder builder;
+  ModuleBundle::BundleBuilder builder(BASE);
   auto bundle = builder.finish();
 
   ResolveContext context = {
     .type = ResolveContext::Type::BUNDLE,
     .source = ResolveContext::Source::OTHER,
     .specifier = "file:///foo"_url,
-    .referrer = ModuleBundle::BundleBuilder::BASE,
+    .referrer = BASE,
   };
 
   KJ_ASSERT(bundle->resolve(context) == kj::none);
@@ -201,7 +200,7 @@ KJ_TEST("An empty built-in bundle") {
     .type = ResolveContext::Type::BUNDLE,
     .source = ResolveContext::Source::OTHER,
     .specifier = "file:///foo"_url,
-    .referrer = ModuleBundle::BundleBuilder::BASE,
+    .referrer = BASE,
   };
 
   KJ_ASSERT(bundle->resolve(context) == kj::none);
@@ -215,12 +214,12 @@ KJ_TEST("A registry with empty bundles") {
 
   ResolveObserverImpl observer;
   ModuleRegistry::Builder registryBuilder(
-      observer, ModuleRegistry::Builder::Options::ALLOW_FALLBACK);
+      observer, BASE, ModuleRegistry::Builder::Options::ALLOW_FALLBACK);
 
   registryBuilder.add(
       ModuleBundle::newFallbackBundle([](const ResolveContext& context) { return kj::none; }));
 
-  ModuleBundle::BundleBuilder bundleBuilder;
+  ModuleBundle::BundleBuilder bundleBuilder(BASE);
   registryBuilder.add(bundleBuilder.finish());
 
   ModuleBundle::BuiltinBuilder builtinBuilder;
@@ -232,7 +231,7 @@ KJ_TEST("A registry with empty bundles") {
     .type = ResolveContext::Type::BUNDLE,
     .source = ResolveContext::Source::OTHER,
     .specifier = "file:///foo"_url,
-    .referrer = ModuleBundle::BundleBuilder::BASE,
+    .referrer = BASE,
   };
 
   KJ_ASSERT(registry->resolve(context) == kj::none);
@@ -243,7 +242,7 @@ KJ_TEST("A registry with empty bundles") {
 // ======================================================================================
 
 KJ_TEST("A user bundle with a single ESM module") {
-  ModuleBundle::BundleBuilder builder;
+  ModuleBundle::BundleBuilder builder(BASE);
 
   kj::String source = kj::str("export const foo = 123;");
   builder.addEsmModule("foo", source.releaseArray(), Module::Flags::MAIN);
@@ -256,7 +255,7 @@ KJ_TEST("A user bundle with a single ESM module") {
     .type = ResolveContext::Type::BUNDLE,
     .source = ResolveContext::Source::OTHER,
     .specifier = specifier,
-    .referrer = ModuleBundle::BundleBuilder::BASE,
+    .referrer = BASE,
   };
 
   auto& module = KJ_ASSERT_NONNULL(bundle->resolve(context));
@@ -270,7 +269,7 @@ KJ_TEST("A user bundle with a single ESM module") {
 // ======================================================================================
 
 KJ_TEST("A registry with a parent") {
-  ModuleBundle::BundleBuilder builder;
+  ModuleBundle::BundleBuilder builder(BASE);
 
   kj::String source = kj::str("export const foo = 123;");
   builder.addEsmModule("foo", source.releaseArray(), Module::Flags::MAIN);
@@ -278,14 +277,14 @@ KJ_TEST("A registry with a parent") {
   const auto specifier = "file:///foo"_url;
 
   ResolveObserver observer;
-  auto parent = ModuleRegistry::Builder(observer).add(builder.finish()).finish();
-  auto registry = ModuleRegistry::Builder(observer).setParent(*parent).finish();
+  auto parent = ModuleRegistry::Builder(observer, BASE).add(builder.finish()).finish();
+  auto registry = ModuleRegistry::Builder(observer, BASE).setParent(*parent).finish();
 
   ResolveContext context = {
     .type = ResolveContext::Type::BUNDLE,
     .source = ResolveContext::Source::OTHER,
     .specifier = specifier,
-    .referrer = ModuleBundle::BundleBuilder::BASE,
+    .referrer = BASE,
   };
 
   auto& module = KJ_ASSERT_NONNULL(registry->resolve(context));
@@ -299,7 +298,7 @@ KJ_TEST("A registry with a parent") {
 // ======================================================================================
 
 KJ_TEST("A user bundle with an ESM module and a Synthetic module") {
-  ModuleBundle::BundleBuilder builder;
+  ModuleBundle::BundleBuilder builder(BASE);
 
   kj::String source = kj::str("export const foo = 123;");
   builder.addEsmModule("foo", source.releaseArray(), Module::Flags::MAIN);
@@ -318,7 +317,7 @@ KJ_TEST("A user bundle with an ESM module and a Synthetic module") {
       .type = ResolveContext::Type::BUNDLE,
       .source = ResolveContext::Source::OTHER,
       .specifier = foo,
-      .referrer = ModuleBundle::BundleBuilder::BASE,
+      .referrer = BASE,
     };
 
     auto& module = KJ_ASSERT_NONNULL(bundle->resolve(context));
@@ -334,7 +333,7 @@ KJ_TEST("A user bundle with an ESM module and a Synthetic module") {
       .type = ResolveContext::Type::BUNDLE,
       .source = ResolveContext::Source::OTHER,
       .specifier = bar,
-      .referrer = ModuleBundle::BundleBuilder::BASE,
+      .referrer = BASE,
     };
 
     auto& module = KJ_ASSERT_NONNULL(bundle->resolve(context));
@@ -350,7 +349,7 @@ KJ_TEST("A user bundle with an ESM module and a Synthetic module") {
 
 KJ_TEST("A built-in bundle with two modules") {
   ResolveObserverImpl observer;
-  ModuleRegistry::Builder registryBuilder(observer);
+  ModuleRegistry::Builder registryBuilder(observer, BASE);
 
   ModuleBundle::BuiltinBuilder builder;
 
@@ -414,7 +413,7 @@ KJ_TEST("A built-in bundle with two modules") {
 
 KJ_TEST("Built-in and Built-in only bundles") {
   ResolveObserverImpl observer;
-  ModuleRegistry::Builder registryBuilder(observer);
+  ModuleRegistry::Builder registryBuilder(observer, BASE);
 
   ModuleBundle::BuiltinBuilder builtinBuilder;
   ModuleBundle::BuiltinBuilder builtinOnlyBuilder(ModuleBundle::BuiltinBuilder::Type::BUILTIN_ONLY);
@@ -518,7 +517,7 @@ KJ_TEST("Fallback bundle that returns something") {
 
   ResolveObserverImpl observer;
   ModuleRegistry::Builder registryBuilder(
-      observer, ModuleRegistry::Builder::Options::ALLOW_FALLBACK);
+      observer, BASE, ModuleRegistry::Builder::Options::ALLOW_FALLBACK);
   auto registry = registryBuilder.add(kj::mv(fallback)).finish();
 
   const auto specifier = "file:///foo"_url;
@@ -528,7 +527,7 @@ KJ_TEST("Fallback bundle that returns something") {
       .type = ResolveContext::Type::BUNDLE,
       .source = ResolveContext::Source::OTHER,
       .specifier = specifier,
-      .referrer = ModuleBundle::BundleBuilder::BASE,
+      .referrer = BASE,
     };
 
     auto& module = KJ_ASSERT_NONNULL(registry->resolve(context));
@@ -543,7 +542,7 @@ KJ_TEST("Fallback bundle that returns something") {
       .type = ResolveContext::Type::BUILTIN,
       .source = ResolveContext::Source::OTHER,
       .specifier = specifier,
-      .referrer = ModuleBundle::BundleBuilder::BASE,
+      .referrer = BASE,
     };
 
     KJ_ASSERT(registry->resolve(context) == kj::none);
@@ -554,7 +553,7 @@ KJ_TEST("Fallback bundle that returns something") {
       .type = ResolveContext::Type::BUILTIN_ONLY,
       .source = ResolveContext::Source::OTHER,
       .specifier = specifier,
-      .referrer = ModuleBundle::BundleBuilder::BASE,
+      .referrer = BASE,
     };
 
     KJ_ASSERT(registry->resolve(context) == kj::none);
@@ -564,7 +563,7 @@ KJ_TEST("Fallback bundle that returns something") {
 // ======================================================================================
 
 KJ_TEST("Duplicate module names in a single are caught and throw properly") {
-  ModuleBundle::BundleBuilder builder;
+  ModuleBundle::BundleBuilder builder(BASE);
   builder.addSyntheticModule(
       "foo", [](Lock&, const Url&, const Module::ModuleNamespace&, const CompilationObserver&) {
     return true;
@@ -584,7 +583,7 @@ KJ_TEST("Duplicate module names in a single are caught and throw properly") {
 
 KJ_TEST("Fallback bundles are not permitted in production") {
   ResolveObserverImpl observer;
-  ModuleRegistry::Builder registryBuilder(observer);
+  ModuleRegistry::Builder registryBuilder(observer, BASE);
   try {
     registryBuilder.add(ModuleBundle::newFallbackBundle([](const ResolveContext& context) {
       return Module::newSynthetic(context.specifier.clone(), Module::Type::FALLBACK,
@@ -603,7 +602,7 @@ KJ_TEST("Fallback bundles are not permitted in production") {
 KJ_TEST("Compound Registry") {
   ResolveObserverImpl observer;
   ModuleRegistry::Builder registryBuilder(
-      observer, ModuleRegistry::Builder::Options::ALLOW_FALLBACK);
+      observer, BASE, ModuleRegistry::Builder::Options::ALLOW_FALLBACK);
 
   const auto foo = "foo:bar"_url;      // Fallback
   const auto bar = "bar:baz"_url;      // Built-in
@@ -628,7 +627,7 @@ KJ_TEST("Compound Registry") {
   builtinOnlyBuilder.addObject<TestType, TestTypeWrapper>(baz);
   registryBuilder.add(builtinOnlyBuilder.finish());
 
-  ModuleBundle::BundleBuilder bundleBuilder;
+  ModuleBundle::BundleBuilder bundleBuilder(BASE);
   kj::String quxSource = kj::str("export const foo = 123;");
   bundleBuilder.addEsmModule("qux", quxSource.releaseArray(), Module::Flags::MAIN);
   registryBuilder.add(bundleBuilder.finish());
@@ -641,7 +640,7 @@ KJ_TEST("Compound Registry") {
       .type = type,
       .source = ResolveContext::Source::OTHER,
       .specifier = specifier,
-      .referrer = ModuleBundle::BundleBuilder::BASE,
+      .referrer = BASE,
     };
     return registry.resolve(context);
   };
@@ -720,7 +719,7 @@ KJ_TEST("Compound Registry") {
 KJ_TEST("Bundle shadows built-in") {
   // A bundle module can shadow a built-in
   ResolveObserverImpl observer;
-  ModuleRegistry::Builder registryBuilder(observer);
+  ModuleRegistry::Builder registryBuilder(observer, BASE);
 
   const auto foo = "foo:bar"_url;
 
@@ -729,7 +728,7 @@ KJ_TEST("Bundle shadows built-in") {
   builtinBuilder.addEsm(foo, source.asArray());
   registryBuilder.add(builtinBuilder.finish());
 
-  ModuleBundle::BundleBuilder bundleBuilder;
+  ModuleBundle::BundleBuilder bundleBuilder(BASE);
   kj::String bundleSource = kj::str("export const foo = 456;");
   bundleBuilder.addEsmModule("foo:bar", bundleSource.releaseArray(), Module::Flags::MAIN);
   registryBuilder.add(bundleBuilder.finish());
@@ -740,7 +739,7 @@ KJ_TEST("Bundle shadows built-in") {
     .type = ResolveContext::Type::BUNDLE,
     .source = ResolveContext::Source::OTHER,
     .specifier = foo,
-    .referrer = ModuleBundle::BundleBuilder::BASE,
+    .referrer = BASE,
   };
 
   auto& module = KJ_ASSERT_NONNULL(registry->resolve(context));
@@ -753,12 +752,14 @@ KJ_TEST("Bundle shadows built-in") {
 // ======================================================================================
 
 KJ_TEST("Attaching a module registry works") {
+  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
+
   PREAMBLE(([&](Lock& js) {
     ResolveObserver resolveObserver;
     CompilationObserver compilationObserver;
-    ModuleRegistry::Builder registryBuilder(resolveObserver);
+    ModuleRegistry::Builder registryBuilder(resolveObserver, BASE);
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
     kj::String source = kj::str("export default 123; export const m = 'abc';");
     // Done this way to avoid including the nullptr at the end...
     bundleBuilder.addEsmModule("main", source.first(source.size()).attach(kj::mv(source)));
@@ -777,7 +778,7 @@ KJ_TEST("Attaching a module registry works") {
       .type = ResolveContext::Type::BUNDLE,
       .source = ResolveContext::Source::OTHER,
       .specifier = specifier,
-      .referrer = ModuleBundle::BundleBuilder::BASE,
+      .referrer = BASE,
     };
     KJ_ASSERT(registry->resolve(resolveContext) != kj::none);
 
@@ -811,9 +812,9 @@ KJ_TEST("Basic types of modules work (text, data, json, wasm)") {
   PREAMBLE(([&](Lock& js) {
     ResolveObserver resolveObserver;
     CompilationObserver compilationObserver;
-    ModuleRegistry::Builder registryBuilder(resolveObserver);
+    ModuleRegistry::Builder registryBuilder(resolveObserver, BASE);
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
     bundleBuilder.addSyntheticModule(
         "abc", Module::newTextModuleHandler(kj::str("hello").releaseArray()));
     bundleBuilder.addSyntheticModule(
@@ -887,7 +888,7 @@ KJ_TEST("Basic types of modules work (text, data, json, wasm)") {
       .type = ResolveContext::Type::BUNDLE,
       .source = ResolveContext::Source::OTHER,
       .specifier = specifier,
-      .referrer = ModuleBundle::BundleBuilder::BASE,
+      .referrer = BASE,
     };
     KJ_ASSERT_NONNULL(registry->resolve(resolveContext));
 
@@ -933,7 +934,7 @@ KJ_TEST("compileEvalFunction in synthetic module works") {
   PREAMBLE([&](Lock& js) {
     CompilationObserver compilationObserver;
     ResolveObserver resolveObserver;
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
     bundleBuilder.addSyntheticModule("abc",
         [](Lock& js, const Url& specifier, const Module::ModuleNamespace& ns,
             const CompilationObserver& observer) mutable -> bool {
@@ -958,7 +959,8 @@ KJ_TEST("compileEvalFunction in synthetic module works") {
     bundleBuilder.addEsmModule(
         "main", source.first(source.size()).attach(kj::mv(source)), Module::Flags::MAIN);
 
-    auto registry = ModuleRegistry::Builder(resolveObserver).add(bundleBuilder.finish()).finish();
+    auto registry =
+        ModuleRegistry::Builder(resolveObserver, BASE).add(bundleBuilder.finish()).finish();
 
     auto attached = registry->attachToIsolate(js, compilationObserver);
 
@@ -976,13 +978,14 @@ KJ_TEST("import.meta works as expected") {
     ResolveObserver ResolveObserver;
     CompilationObserver compilationObserver;
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
     auto foo = kj::str("export default import.meta");
     bundleBuilder.addEsmModule("foo", foo.first(foo.size()).attach(kj::mv(foo)));
     auto bar = kj::str("export default import.meta");
     bundleBuilder.addEsmModule(
         "foo/././././bar", bar.first(bar.size()).attach(kj::mv(bar)), Module::Flags::MAIN);
-    auto registry = ModuleRegistry::Builder(ResolveObserver).add(bundleBuilder.finish()).finish();
+    auto registry =
+        ModuleRegistry::Builder(ResolveObserver, BASE).add(bundleBuilder.finish()).finish();
 
     auto attached = registry->attachToIsolate(js, compilationObserver);
 
@@ -1045,11 +1048,12 @@ KJ_TEST("import specifiers with query params and hash fragments work") {
     ResolveObserver ResolveObserver;
     CompilationObserver compilationObserver;
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
     auto foo = kj::str("export default import.meta");
     bundleBuilder.addEsmModule("foo", foo.first(foo.size()).attach(kj::mv(foo)));
 
-    auto registry = ModuleRegistry::Builder(ResolveObserver).add(bundleBuilder.finish()).finish();
+    auto registry =
+        ModuleRegistry::Builder(ResolveObserver, BASE).add(bundleBuilder.finish()).finish();
 
     auto attached = registry->attachToIsolate(js, compilationObserver);
 
@@ -1093,11 +1097,11 @@ KJ_TEST("Previously resolved modules not found with incompatible resolve context
     auto source = "export default 123;"_kjc;
     builtinBuilder.addEsm(foo, source.first(source.size()).attach(kj::mv(source)));
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
     bundleBuilder.addSyntheticModule(
         "bar", Module::newDataModuleHandler(kj::heapArray<kj::byte>({1, 2, 3})));
 
-    auto registry = ModuleRegistry::Builder(observer)
+    auto registry = ModuleRegistry::Builder(observer, BASE)
                         .add(builtinBuilder.finish())
                         .add(bundleBuilder.finish())
                         .finish();
@@ -1143,14 +1147,14 @@ KJ_TEST("Awaiting top-level dynamic import in synchronous require works as expec
     ResolveObserverImpl observer;
     CompilationObserver compilationObserver;
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
     auto foo = kj::str("export default (await import('bar')).default;");
     bundleBuilder.addEsmModule("foo", foo.first(foo.size()).attach(kj::mv(foo)));
 
     auto bar = kj::str("export default 123;");
     bundleBuilder.addEsmModule("bar", bar.first(bar.size()).attach(kj::mv(bar)));
 
-    auto registry = ModuleRegistry::Builder(observer).add(bundleBuilder.finish()).finish();
+    auto registry = ModuleRegistry::Builder(observer, BASE).add(bundleBuilder.finish()).finish();
 
     auto attached = registry->attachToIsolate(js, compilationObserver);
 
@@ -1165,11 +1169,11 @@ KJ_TEST("Awaiting a never resolved promise in synchronous require fails as expec
     ResolveObserverImpl observer;
     CompilationObserver compilationObserver;
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
     auto foo = kj::str("const p = new Promise(() => {}); await p;");
     bundleBuilder.addEsmModule("foo", foo.first(foo.size()).attach(kj::mv(foo)));
 
-    auto registry = ModuleRegistry::Builder(observer).add(bundleBuilder.finish()).finish();
+    auto registry = ModuleRegistry::Builder(observer, BASE).add(bundleBuilder.finish()).finish();
 
     auto attached = registry->attachToIsolate(js, compilationObserver);
 
@@ -1194,11 +1198,11 @@ KJ_TEST("Throwing an exception inside a ESM module works as expected") {
     ResolveObserverImpl observer;
     CompilationObserver compilationObserver;
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
     auto foo = kj::str("throw new Error('foo');");
     bundleBuilder.addEsmModule("foo", foo.first(foo.size()).attach(kj::mv(foo)));
 
-    auto registry = ModuleRegistry::Builder(observer).add(bundleBuilder.finish()).finish();
+    auto registry = ModuleRegistry::Builder(observer, BASE).add(bundleBuilder.finish()).finish();
 
     auto attached = registry->attachToIsolate(js, compilationObserver);
 
@@ -1219,12 +1223,12 @@ KJ_TEST("Syntax error in ESM module is properly reported") {
     ResolveObserverImpl observer;
     CompilationObserver compilationObserver;
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
 
     auto foo = kj::str("export default 123; syntax error");
     bundleBuilder.addEsmModule("foo", foo.first(foo.size()).attach(kj::mv(foo)));
 
-    auto registry = ModuleRegistry::Builder(observer).add(bundleBuilder.finish()).finish();
+    auto registry = ModuleRegistry::Builder(observer, BASE).add(bundleBuilder.finish()).finish();
 
     auto attached = registry->attachToIsolate(js, compilationObserver);
 
@@ -1243,12 +1247,12 @@ KJ_TEST("Throwing an exception inside a CJS-style eval module works as expected"
     ResolveObserverImpl observer;
     CompilationObserver compilationObserver;
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
     bundleBuilder.addSyntheticModule("foo",
         Module::newCjsStyleModuleHandler<TestType, TestIsolate_TypeWrapper>(
             kj::str("exports.foo = 123; throw new Error('bar');"), kj::str("foo")));
 
-    auto registry = ModuleRegistry::Builder(observer).add(bundleBuilder.finish()).finish();
+    auto registry = ModuleRegistry::Builder(observer, BASE).add(bundleBuilder.finish()).finish();
 
     auto attached = registry->attachToIsolate(js, compilationObserver);
 
@@ -1269,7 +1273,7 @@ KJ_TEST("Invalid JSON syntax module throws exception as expected") {
     ResolveObserverImpl observer;
     CompilationObserver compilationObserver;
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
     auto json = kj::str("not valid json");
     bundleBuilder.addSyntheticModule(
         "foo", Module::newJsonModuleHandler(json.first(json.size()).attach(kj::mv(json))));
@@ -1278,7 +1282,7 @@ KJ_TEST("Invalid JSON syntax module throws exception as expected") {
     bundleBuilder.addEsmModule(
         "bar", esm.first(esm.size()).attach(kj::mv(esm)), Module::Flags::MAIN);
 
-    auto registry = ModuleRegistry::Builder(observer).add(bundleBuilder.finish()).finish();
+    auto registry = ModuleRegistry::Builder(observer, BASE).add(bundleBuilder.finish()).finish();
 
     auto attached = registry->attachToIsolate(js, compilationObserver);
 
@@ -1317,7 +1321,7 @@ KJ_TEST("Recursive import works or fails as expected") {
     ResolveObserverImpl observer;
     CompilationObserver compilationObserver;
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
 
     // A recursive import with an ESM works just fine...
     auto foo = kj::str("import foo from 'foo'; export default 123;");
@@ -1328,7 +1332,7 @@ KJ_TEST("Recursive import works or fails as expected") {
         Module::newCjsStyleModuleHandler<TestType, TestIsolate_TypeWrapper>(
             kj::str("require('bar')"), kj::str("bar")));
 
-    auto registry = ModuleRegistry::Builder(observer).add(bundleBuilder.finish()).finish();
+    auto registry = ModuleRegistry::Builder(observer, BASE).add(bundleBuilder.finish()).finish();
 
     auto attached = registry->attachToIsolate(js, compilationObserver);
 
@@ -1350,7 +1354,7 @@ KJ_TEST("Recursively require ESM from CJS required from ESM fails as expected (d
     ResolveObserverImpl observer;
     CompilationObserver compilationObserver;
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
 
     // In this test, we have an ESM module (bar) that imports a CJS style
     // module (foo) that synchronously tries to require the ESM module (bar).
@@ -1371,7 +1375,7 @@ KJ_TEST("Recursively require ESM from CJS required from ESM fails as expected (d
     auto bar = kj::str("export default {}; await import('foo');");
     bundleBuilder.addEsmModule("bar", bar.first(bar.size()).attach(kj::mv(bar)));
 
-    auto registry = ModuleRegistry::Builder(observer).add(bundleBuilder.finish()).finish();
+    auto registry = ModuleRegistry::Builder(observer, BASE).add(bundleBuilder.finish()).finish();
 
     auto attached = registry->attachToIsolate(js, compilationObserver);
 
@@ -1392,7 +1396,7 @@ KJ_TEST("Recursively require ESM from CJS required from ESM fails as expected (s
     ResolveObserverImpl observer;
     CompilationObserver compilationObserver;
 
-    ModuleBundle::BundleBuilder bundleBuilder;
+    ModuleBundle::BundleBuilder bundleBuilder(BASE);
 
     // In this test, we have an ESM module (bar) that imports a CJS style
     // module (foo) that synchronously tries to require the ESM module (bar).
@@ -1413,7 +1417,7 @@ KJ_TEST("Recursively require ESM from CJS required from ESM fails as expected (s
     auto bar = kj::str("export default {}; import bar from 'foo';");
     bundleBuilder.addEsmModule("bar", bar.first(bar.size()).attach(kj::mv(bar)));
 
-    auto registry = ModuleRegistry::Builder(observer).add(bundleBuilder.finish()).finish();
+    auto registry = ModuleRegistry::Builder(observer, BASE).add(bundleBuilder.finish()).finish();
 
     auto attached = registry->attachToIsolate(js, compilationObserver);
 
@@ -1431,9 +1435,9 @@ KJ_TEST("Recursively require ESM from CJS required from ESM fails as expected (s
 KJ_TEST("Resolution occurs relative to the referrer") {
   ResolveObserver observer;
   CompilationObserver compilationObserver;
-  ModuleRegistry::Builder registryBuilder(observer);
+  ModuleRegistry::Builder registryBuilder(observer, BASE);
 
-  ModuleBundle::BundleBuilder builder;
+  ModuleBundle::BundleBuilder builder(BASE);
   builder.addSyntheticModule("foo/bar", Module::newDataModuleHandler(kj::heapArray<kj::byte>(0)));
   builder.addSyntheticModule("bar", Module::newDataModuleHandler(kj::heapArray<kj::byte>(0)));
 
@@ -1546,7 +1550,7 @@ KJ_TEST("Building a bundle from a capnp description works") {
       .type = ResolveContext::Type::BUILTIN,
       .source = ResolveContext::Source::OTHER,
       .specifier = foo,
-      .referrer = ModuleBundle::BundleBuilder::BASE,
+      .referrer = BASE,
     };
     auto& module = KJ_ASSERT_NONNULL(moduleBundle->resolve(context));
     KJ_ASSERT(module.specifier() == foo);
@@ -1558,7 +1562,7 @@ KJ_TEST("Building a bundle from a capnp description works") {
       .type = ResolveContext::Type::BUILTIN,
       .source = ResolveContext::Source::OTHER,
       .specifier = bar,
-      .referrer = ModuleBundle::BundleBuilder::BASE,
+      .referrer = BASE,
     };
     auto& module = KJ_ASSERT_NONNULL(moduleBundle->resolve(context));
     KJ_ASSERT(module.specifier() == bar);
@@ -1570,7 +1574,7 @@ KJ_TEST("Building a bundle from a capnp description works") {
       .type = ResolveContext::Type::BUILTIN,
       .source = ResolveContext::Source::OTHER,
       .specifier = qux,
-      .referrer = ModuleBundle::BundleBuilder::BASE,
+      .referrer = BASE,
     };
     auto& module = KJ_ASSERT_NONNULL(moduleBundle->resolve(context));
     KJ_ASSERT(module.specifier() == qux);
@@ -1579,7 +1583,8 @@ KJ_TEST("Building a bundle from a capnp description works") {
   PREAMBLE([&](Lock& js) {
     ResolveObserver resolveObserver;
     CompilationObserver compilationObserver;
-    auto registry = ModuleRegistry::Builder(resolveObserver).add(kj::mv(moduleBundle)).finish();
+    auto registry =
+        ModuleRegistry::Builder(resolveObserver, BASE).add(kj::mv(moduleBundle)).finish();
 
     auto attached = registry->attachToIsolate(js, compilationObserver);
 
@@ -1597,11 +1602,12 @@ KJ_TEST("Using a registry from multiple threads works") {
 
   kj::AsyncIoContext io = kj::setupAsyncIo();
 
-  ModuleBundle::BundleBuilder bundleBuilder;
+  ModuleBundle::BundleBuilder bundleBuilder(BASE);
   auto foo = kj::str("export default 123; for (let n = 0; n < 1000000; n++) {}");
   bundleBuilder.addEsmModule("foo", foo.first(foo.size()).attach(kj::mv(foo)));
   ResolveObserver resolveObserver;
-  auto registry = ModuleRegistry::Builder(resolveObserver).add(bundleBuilder.finish()).finish();
+  auto registry =
+      ModuleRegistry::Builder(resolveObserver, BASE).add(bundleBuilder.finish()).finish();
 
   static constexpr auto makeThread = [](ModuleRegistry& registry) {
     auto paf = kj::newPromiseAndCrossThreadFulfiller<void>();
@@ -1634,7 +1640,7 @@ KJ_TEST("Fallback service can see original raw specifier if provided") {
   ResolveObserver resolveObserver;
   CompilationObserver compilationObserver;
   ModuleRegistry::Builder builder(
-      resolveObserver, ModuleRegistry::Builder::Options::ALLOW_FALLBACK);
+      resolveObserver, BASE, ModuleRegistry::Builder::Options::ALLOW_FALLBACK);
   auto rawSpecifier = "nothing"_kjc;
   const auto specifier = "file:///nothing"_url;
 
@@ -1643,7 +1649,7 @@ KJ_TEST("Fallback service can see original raw specifier if provided") {
   builder.add(ModuleBundle::newFallbackBundle([&](const ResolveContext& context) {
     KJ_ASSERT(context.rawSpecifier == rawSpecifier);
     KJ_ASSERT(context.specifier == specifier);
-    KJ_ASSERT(context.referrer == ModuleBundle::BundleBuilder::BASE);
+    KJ_ASSERT(context.referrer == BASE);
     called = true;
     return kj::none;
   }));
@@ -1654,7 +1660,7 @@ KJ_TEST("Fallback service can see original raw specifier if provided") {
     .type = ResolveContext::Type::BUNDLE,
     .source = ResolveContext::Source::OTHER,
     .specifier = specifier,
-    .referrer = ModuleBundle::BundleBuilder::BASE,
+    .referrer = BASE,
     .rawSpecifier = rawSpecifier,
   };
 
@@ -1669,7 +1675,7 @@ KJ_TEST("Fallback service can return a module with a different specifier") {
   ResolveObserver resolveObserver;
   CompilationObserver compilationObserver;
   ModuleRegistry::Builder builder(
-      resolveObserver, ModuleRegistry::Builder::Options::ALLOW_FALLBACK);
+      resolveObserver, BASE, ModuleRegistry::Builder::Options::ALLOW_FALLBACK);
   auto rawSpecifier = "nothing"_kjc;
   const auto specifier = "file:///nothing"_url;
   const auto url = "file:///different"_url;
@@ -1688,7 +1694,7 @@ KJ_TEST("Fallback service can return a module with a different specifier") {
     .type = ResolveContext::Type::BUNDLE,
     .source = ResolveContext::Source::OTHER,
     .specifier = specifier,
-    .referrer = ModuleBundle::BundleBuilder::BASE,
+    .referrer = BASE,
     .rawSpecifier = rawSpecifier,
   };
 
@@ -1698,7 +1704,7 @@ KJ_TEST("Fallback service can return a module with a different specifier") {
     .type = ResolveContext::Type::BUNDLE,
     .source = ResolveContext::Source::OTHER,
     .specifier = url,
-    .referrer = ModuleBundle::BundleBuilder::BASE,
+    .referrer = BASE,
     .rawSpecifier = rawSpecifier,
   };
 
@@ -1719,7 +1725,7 @@ KJ_TEST("Percent-encoding in specifiers is normalized properly") {
   ResolveObserver resolveObserver;
   CompilationObserver compilationObserver;
 
-  ModuleBundle::BundleBuilder builder;
+  ModuleBundle::BundleBuilder builder(BASE);
 
   // A specifier might have percent-encoded characters. We want those to be normalized
   // so that they are matched correctly. For instance, %66oo%2fbar should be normalized
@@ -1739,7 +1745,7 @@ KJ_TEST("Percent-encoding in specifiers is normalized properly") {
                      "export { default as jkl } from '%66oo%2fbar';");
   builder.addEsmModule("foo", foo.first(foo.size()).attach(kj::mv(foo)));
 
-  auto registry = ModuleRegistry::Builder(resolveObserver).add(builder.finish()).finish();
+  auto registry = ModuleRegistry::Builder(resolveObserver, BASE).add(builder.finish()).finish();
 
   PREAMBLE([&](Lock& js) {
     auto attached = registry->attachToIsolate(js, compilationObserver);
@@ -1762,7 +1768,7 @@ KJ_TEST("Percent-encoding in specifiers is normalized properly") {
 KJ_TEST("Aliased modules (import maps) work") {
   ResolveObserver resolveObserver;
   CompilationObserver compilationObserver;
-  ModuleBundle::BundleBuilder builder;
+  ModuleBundle::BundleBuilder builder(BASE);
 
   builder.addSyntheticModule(
       "http://example/foo", Module::newDataModuleHandler(kj::heapArray<kj::byte>(0)));
@@ -1786,20 +1792,20 @@ KJ_TEST("Aliased modules (import maps) work") {
                      "export { default as def } from 'http://example/%66oo';");
   builder.addEsmModule("qux", src.first(src.size()).attach(kj::mv(src)));
 
-  auto registry = ModuleRegistry::Builder(resolveObserver).add(builder.finish()).finish();
+  auto registry = ModuleRegistry::Builder(resolveObserver, BASE).add(builder.finish()).finish();
 
   ResolveContext contextBar{
     .type = ResolveContext::Type::BUNDLE,
     .source = ResolveContext::Source::OTHER,
     .specifier = "file:///bar"_url,
-    .referrer = ModuleBundle::BundleBuilder::BASE,
+    .referrer = BASE,
   };
 
   ResolveContext contextFoo{
     .type = ResolveContext::Type::BUNDLE,
     .source = ResolveContext::Source::OTHER,
     .specifier = "http://example/foo"_url,
-    .referrer = ModuleBundle::BundleBuilder::BASE,
+    .referrer = BASE,
   };
 
   auto& bar = KJ_ASSERT_NONNULL(registry->resolve(contextBar));
@@ -1830,12 +1836,12 @@ KJ_TEST("Aliased modules (import maps) work") {
 KJ_TEST("Import attributes are currently unsupported") {
   ResolveObserver resolveObserver;
   CompilationObserver compilationObserver;
-  ModuleBundle::BundleBuilder builder;
+  ModuleBundle::BundleBuilder builder(BASE);
 
   auto foo = kj::str("import abc from 'foo' with { type: 'json' };");
   builder.addEsmModule("foo", foo.first(foo.size()).attach(kj::mv(foo)));
 
-  auto registry = ModuleRegistry::Builder(resolveObserver).add(builder.finish()).finish();
+  auto registry = ModuleRegistry::Builder(resolveObserver, BASE).add(builder.finish()).finish();
 
   PREAMBLE([&](Lock& js) {
     auto attached = registry->attachToIsolate(js, compilationObserver);
@@ -1854,13 +1860,13 @@ KJ_TEST("Import attributes are currently unsupported") {
 KJ_TEST("Using a deferred eval callback works") {
   ResolveObserver resolveObserver;
   CompilationObserver compilationObserver;
-  ModuleBundle::BundleBuilder builder;
+  ModuleBundle::BundleBuilder builder(BASE);
 
   auto foo = kj::str("export default 1;");
   builder.addEsmModule("foo", foo.first(foo.size()).attach(kj::mv(foo)));
 
   bool called = false;
-  auto registry = ModuleRegistry::Builder(resolveObserver)
+  auto registry = ModuleRegistry::Builder(resolveObserver, BASE)
                       .add(builder.finish())
                       .setEvalCallback([&called](Lock& js, const Module& module, auto v8Module,
                                            const auto& observer) {

--- a/src/workerd/jsg/modules-new.h
+++ b/src/workerd/jsg/modules-new.h
@@ -436,9 +436,7 @@ class ModuleBundle {
   // Used to build a ModuleBundle representing modules sourced from a worker bundle.
   class BundleBuilder final: public Builder {
    public:
-    static const Url BASE;
-
-    BundleBuilder();
+    BundleBuilder(const jsg::Url& bundleBase);
     KJ_DISALLOW_COPY_AND_MOVE(BundleBuilder);
 
     using EvaluateCallback = Module::EvaluateCallback;
@@ -452,6 +450,9 @@ class ModuleBundle {
         Module::Flags flags = Module::Flags::ESM) KJ_LIFETIMEBOUND;
 
     BundleBuilder& alias(kj::StringPtr alias, kj::StringPtr specifier) KJ_LIFETIMEBOUND;
+
+   private:
+    const jsg::Url& bundleBase;
   };
 
   // Used to build a ModuleBundle representing modules sources from the runtime.
@@ -551,7 +552,9 @@ class ModuleRegistry final: public ModuleRegistryBase {
       // checked. The fallback service should only be used for local dev.
       ALLOW_FALLBACK = 1 << 0,
     };
-    Builder(const ResolveObserver& observer, Options options = Options::NONE);
+    Builder(const ResolveObserver& observer,
+        const jsg::Url& bundleBase,
+        Options options = Options::NONE);
     KJ_DISALLOW_COPY_AND_MOVE(Builder);
 
     // A ModuleRegistry may have exactly one parent registry. When set, if this
@@ -570,6 +573,7 @@ class ModuleRegistry final: public ModuleRegistryBase {
 
     // One slot for each of ModuleBundle::Type
     const ResolveObserver& observer;
+    const jsg::Url& bundleBase;
     kj::Maybe<ModuleRegistry&> maybeParent;
     const Options options;
     kj::Vector<kj::Own<ModuleBundle>> bundles_[ModuleRegistry::kBundleCount];
@@ -614,8 +618,13 @@ class ModuleRegistry final: public ModuleRegistryBase {
   ModuleRegistry(ModuleRegistry::Builder* builder);
   KJ_DISALLOW_COPY_AND_MOVE(ModuleRegistry);
 
+  const jsg::Url& getBundleBase() const {
+    return bundleBase;
+  }
+
  private:
   const ResolveObserver& observer;
+  const jsg::Url& bundleBase;
   kj::Maybe<ModuleRegistry&> maybeParent;
   // One slot for each of ModuleBundle::Type
   kj::Array<kj::Own<ModuleBundle>> bundles_[kBundleCount];

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3070,11 +3070,14 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name,
         "The new ModuleRegistry implementation is an experimental feature. "
         "You must run workerd with `--experimental` to use this feature.");
 
-    // TODO(node-fs): Get the bundle root from the vfs and pass that on to
-    // the new module registry implementation.
+    // We use the same path for modules that the virtual file system uses.
+    // For instance, if the user specifies a bundle path of "/foo/bar" and
+    // there is a module in the bundle at "/foo/bar/baz.js", then the module's
+    // import specifier url will be "file:///foo/bar/baz.js".
+    const jsg::Url& bundleBase = workerFs->getBundleRoot();
 
     newModuleRegistry = WorkerdApi::initializeBundleModuleRegistry(
-        *jsgobserver, conf, featureFlags.asReader(), pythonConfig);
+        *jsgobserver, conf, featureFlags.asReader(), pythonConfig, bundleBase);
   }
 
   auto api = kj::heap<WorkerdApi>(globalContext->v8System, featureFlags.asReader(),

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -987,9 +987,10 @@ kj::Own<jsg::modules::ModuleRegistry> WorkerdApi::initializeBundleModuleRegistry
     const jsg::ResolveObserver& observer,
     const config::Worker::Reader& conf,
     const CompatibilityFlags::Reader& featureFlags,
-    const PythonConfig& pythonConfig) {
+    const PythonConfig& pythonConfig,
+    const jsg::Url& bundleBase) {
   jsg::modules::ModuleRegistry::Builder builder(
-      observer, jsg::modules::ModuleRegistry::Builder::Options::ALLOW_FALLBACK);
+      observer, bundleBase, jsg::modules::ModuleRegistry::Builder::Options::ALLOW_FALLBACK);
 
   // This callback is used when a module is being loaded to arrange evaluating the
   // module outside of the current IoContext.
@@ -1008,7 +1009,7 @@ kj::Own<jsg::modules::ModuleRegistry> WorkerdApi::initializeBundleModuleRegistry
   api::registerBuiltinModules<JsgWorkerdIsolate_TypeWrapper>(builder, featureFlags);
 
   // Add the module bundles that are configured by the worker.
-  jsg::modules::ModuleBundle::BundleBuilder bundleBuilder;
+  jsg::modules::ModuleBundle::BundleBuilder bundleBuilder(bundleBase);
   bool firstEsm = true;
   bool hasPythonModules = false;
   using namespace workerd::api::pyodide;

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -254,7 +254,8 @@ class WorkerdApi final: public Worker::Api {
       const jsg::ResolveObserver& resolveObserver,
       const config::Worker::Reader& conf,
       const CompatibilityFlags::Reader& featureFlags,
-      const PythonConfig& pythonConfig);
+      const PythonConfig& pythonConfig,
+      const jsg::Url& bundleBase);
 
  private:
   struct Impl;


### PR DESCRIPTION
Extracted from the larger workerd PR #4029 to help split that up more... updates the new module registry to use a consistent view of the `file:///bundle` file root. 