### PR TITLE
simplify type-wrapper by removing support from certain types

### DIFF
--- a/src/workerd/io/promise-wrapper-test.c++
+++ b/src/workerd/io/promise-wrapper-test.c++
@@ -56,9 +56,9 @@ struct CaptureThrowContext: public jsg::Object, public ContextGlobal {
     JSG_FAIL_REQUIRE(TypeError, "boom");
   }
 
-  static kj::Promise<void> staticTest3(v8::Isolate* isolate) {
+  static kj::Promise<void> staticTest3(jsg::Lock& js) {
     // Tests that JsExceptionThrown is handled properly.
-    jsg::throwTypeError(isolate, "boom"_kj);
+    jsg::throwTypeError(js.v8Isolate, "boom"_kj);
   }
 
   kj::Promise<void> getTest() {

--- a/src/workerd/jsg/fast-api-test.c++
+++ b/src/workerd/jsg/fast-api-test.c++
@@ -258,27 +258,6 @@ KJ_TEST("Fast methods properly catch JSG_FAIL_REQUIRE errors") {
 }
 
 KJ_TEST("isFastMethodCompatible Detection") {
-  static_assert(
-      FastApiWrappedObject<FastMethodIsolate_TypeWrapper, kj::String>, "should be compatible");
-
-  static_assert(FastApiParam<FastMethodIsolate_TypeWrapper, WrappedInt>, "should be compatible");
-
-  static_assert(FastApiParam<FastMethodIsolate_TypeWrapper, kj::OneOf<kj::String, WrappedInt>>,
-      "should be compatible");
-
-  static_assert(!FastApiParam<FastMethodIsolate_TypeWrapper, WrappedInt&>, "should be compatible");
-
-  struct Foo {};
-
-  static_assert(!FastApiWrappedObject<FastMethodIsolate_TypeWrapper, Foo>, "foo is not a jsg type");
-
-  static_assert(!FastApiWrappedObject<FastMethodIsolate_TypeWrapper, jsg::Lock&>,
-      "lock is not a wrapped type");
-
-  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper,
-                    void (FastMethodContext::*)(bool, jsg::Lock&)>,
-      "lock is accepted only as first argument");
-
   static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper,
                     void (FastMethodContext::*)(jsg::Lock&, bool)>,
       "lock is accepted only as first argument");
@@ -321,9 +300,6 @@ KJ_TEST("isFastMethodCompatible Detection") {
   using KjArrayMethod = kj::Array<int> (FastMethodContext::*)(int32_t);
   using PromiseMethod = jsg::Promise<int> (FastMethodContext::*)(int32_t);
   using MaybeVoidMethod = kj::Maybe<void> (FastMethodContext::*)();
-  using PointerMethod = void(v8::Isolate*);
-  using ReferenceMethod = void(v8::Isolate&);
-  using StaticMethodContainerReferenceMethod = void(StaticMethodContainer&);
   using StaticMethodContainerMethod = void(StaticMethodContainer);
 
   // Static assertions for compatible method types
@@ -361,10 +337,6 @@ KJ_TEST("isFastMethodCompatible Detection") {
   static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, ConstLockFirstMethod>,
       "Const methods with Lock& as first parameter should be fast-method compatible");
 
-  // Complex methods
-  static_assert(FastApiParam<FastMethodIsolate_TypeWrapper, WrappedInt>,
-      "JSG_STRUCT as a parameter is supported");
-
   // Static assertions for incompatible method types
   // ----------------------------------------------
 
@@ -389,15 +361,8 @@ KJ_TEST("isFastMethodCompatible Detection") {
       "Methods returning Promise should not be fast-method compatible");
   static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper, MaybeVoidMethod>,
       "Methods returning Maybe<void> should not be fast-method compatible");
-  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper, PointerMethod>,
-      "Methods that have a parameter of v8::Isolate* should not be fast-method compatible");
-  static_assert(!isFastMethodCompatible<FastMethodIsolate_TypeWrapper, ReferenceMethod>,
-      "Methods that have a parameter of a reference should not be fast-method compatible");
   static_assert(isFastMethodCompatible<FastMethodIsolate_TypeWrapper, StaticMethodContainerMethod>,
       "This should be compatible");
-  static_assert(
-      !isFastMethodCompatible<FastMethodIsolate_TypeWrapper, StaticMethodContainerReferenceMethod>,
-      "Methods that have a parameter of a reference should not be fast-method compatible");
 
   // jsg::test::Evaluator<FastMethodContext, FastMethodIsolate> e(v8System);
   // auto& wrapper = FastMethodIsolate_TypeWrapper::from(e.getIsolate().ptr);

--- a/src/workerd/jsg/jsg-test.h
+++ b/src/workerd/jsg/jsg-test.h
@@ -211,8 +211,7 @@ struct NumberBox: public Object {
   }
 
   v8::Local<v8::Value> getBoxedFromTypeHandler(
-      jsg::Lock& js, v8::Isolate*, const TypeHandler<Ref<NumberBox>>& numberBoxTypeHandler) {
-    // This function takes an Isolate just to prove it can take multiple value-less parameters.
+      jsg::Lock& js, const TypeHandler<Ref<NumberBox>>& numberBoxTypeHandler) {
     return numberBoxTypeHandler.wrap(js, js.alloc<NumberBox>(value));
   }
 

--- a/src/workerd/jsg/resource-test.c++
+++ b/src/workerd/jsg/resource-test.c++
@@ -486,11 +486,11 @@ struct ReflectionContext: public ContextGlobalObject {
       return result;
     }
 
-    kj::Maybe<int> getIntReflection(kj::String name, v8::Isolate* isolate) {
-      return intReflector.get(isolate, name);
+    kj::Maybe<int> getIntReflection(jsg::Lock& js, kj::String name) {
+      return intReflector.get(js.v8Isolate, name);
     }
-    kj::Maybe<kj::String> getStringReflection(kj::String name, v8::Isolate* isolate) {
-      return stringReflector.get(isolate, name);
+    kj::Maybe<kj::String> getStringReflection(jsg::Lock& js, kj::String name) {
+      return stringReflector.get(js.v8Isolate, name);
     }
 
     PropertyReflection<int> intReflector;
@@ -539,9 +539,8 @@ struct InjectLockContext: public ContextGlobalObject {
     int val;
     v8::Isolate* v8Isolate;
 
-    static Ref<Thingy> constructor(Lock& js, int val, v8::Isolate* v8Isolate) {
-      KJ_ASSERT(js.v8Isolate == v8Isolate);
-      return js.alloc<Thingy>(val, v8Isolate);
+    static Ref<Thingy> constructor(Lock& js, int val) {
+      return js.alloc<Thingy>(val, js.v8Isolate);
     }
 
     int frob(Lock& js, int val2) {
@@ -559,8 +558,7 @@ struct InjectLockContext: public ContextGlobalObject {
       this->val = val;
     }
 
-    static int borf(Lock& js, int val, v8::Isolate* v8Isolate) {
-      KJ_ASSERT(js.v8Isolate == v8Isolate);
+    static int borf(Lock& js, int val) {
       return val * 2;
     }
 

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -245,14 +245,9 @@ struct MethodCallback<TypeWrapper,
     auto& self = extractInternalPointer<T, isContext>(context, receiver);
     auto& wrapper = TypeWrapper::from(isolate);
 
-    return liftKj<Ret>(isolate, [&]() -> Ret {
-      if constexpr (kj::isSameType<Ret, void>()) {
-        (self.*method)(wrapper.template unwrapFastApi<Args>(context, fastArgs,
-            TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
-      } else {
-        return (self.*method)(wrapper.template unwrapFastApi<Args>(context, fastArgs,
-            TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
-      }
+    return liftKj<Ret>(isolate, [&]() {
+      return (self.*method)(wrapper.template unwrapFastApi<Args>(
+          context, fastArgs, TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
     });
   }
 };
@@ -312,17 +307,10 @@ struct MethodCallback<TypeWrapper,
     auto& lock = Lock::from(isolate);
     auto& wrapper = TypeWrapper::from(isolate);
 
-    return liftKj<Ret>(isolate, [&]() -> Ret {
-      if constexpr (kj::isSameType<Ret, void>()) {
-        (self.*method)(lock,
-            wrapper.template unwrapFastApi<Args>(context, fastArgs,
-                TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
-        return;
-      } else {
-        return (self.*method)(lock,
-            wrapper.template unwrapFastApi<Args>(context, fastArgs,
-                TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
-      }
+    return liftKj<Ret>(isolate, [&]() {
+      return (self.*method)(lock,
+          wrapper.template unwrapFastApi<Args>(context, fastArgs,
+              TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
     });
   }
 };
@@ -448,14 +436,9 @@ struct StaticMethodCallback<TypeWrapper,
     auto context = isolate->GetCurrentContext();
     auto& wrapper = TypeWrapper::from(isolate);
 
-    return liftKj<Ret>(isolate, [&]() -> Ret {
-      if constexpr (kj::isSameType<Ret, void>()) {
-        (*method)(wrapper.template unwrapFastApi<Args>(context, fastArgs,
-            TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
-      } else {
-        return (*method)(wrapper.template unwrapFastApi<Args>(context, fastArgs,
-            TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
-      }
+    return liftKj<Ret>(isolate, [&]() {
+      return (*method)(wrapper.template unwrapFastApi<Args>(
+          context, fastArgs, TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
     });
   }
 };
@@ -510,17 +493,10 @@ struct StaticMethodCallback<TypeWrapper,
     auto& lock = Lock::from(isolate);
     auto& wrapper = TypeWrapper::from(isolate);
 
-    return liftKj<Ret>(isolate, [&]() -> Ret {
-      if constexpr (kj::isSameType<Ret, void>()) {
-        (*method)(lock,
-            wrapper.template unwrapFastApi<Args>(context, fastArgs,
-                TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
-        return;
-      } else {
-        return (*method)(lock,
-            wrapper.template unwrapFastApi<Args>(context, fastArgs,
-                TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
-      }
+    return liftKj<Ret>(isolate, [&]() {
+      return (*method)(lock,
+          wrapper.template unwrapFastApi<Args>(context, fastArgs,
+              TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
     });
   }
 };
@@ -621,14 +597,9 @@ struct GetterCallback;
       auto context = isolate->GetCurrentContext();                                                 \
       auto& self = extractInternalPointer<T, isContext>(context, receiver);                        \
       auto& wrapper = TypeWrapper::from(isolate);                                                  \
-      return liftKj<ReturnType>(isolate, [&]() -> ReturnType {                                     \
-        if constexpr (workerd::jsg::isVoid<ReturnType>()) {                                        \
-          (self.*method)(                                                                          \
-              wrapper.template unwrapFastApi<Args>(context, (kj::Decay<Args>*)nullptr)...);        \
-        } else {                                                                                   \
-          return (self.*method)(                                                                   \
-              wrapper.template unwrapFastApi<Args>(context, (kj::Decay<Args>*)nullptr)...);        \
-        }                                                                                          \
+      return liftKj<ReturnType>(isolate, [&]() {                                                   \
+        return (self.*method)(                                                                     \
+            wrapper.template unwrapFastApi<Args>(context, (kj::Decay<Args>*)nullptr)...);          \
       });                                                                                          \
     }                                                                                              \
   };                                                                                               \
@@ -669,14 +640,9 @@ struct GetterCallback;
       auto context = isolate->GetCurrentContext();                                                 \
       auto& self = extractInternalPointer<T, isContext>(context, receiver);                        \
       auto& wrapper = TypeWrapper::from(isolate);                                                  \
-      return liftKj<ReturnType>(isolate, [&]() -> ReturnType {                                     \
-        if constexpr (workerd::jsg::isVoid<ReturnType>()) {                                        \
-          (self.*method)(Lock::from(isolate),                                                      \
-              wrapper.template unwrapFastApi<Args>(context, (kj::Decay<Args>*)nullptr)...);        \
-        } else {                                                                                   \
-          return (self.*method)(Lock::from(isolate),                                               \
-              wrapper.template unwrapFastApi<Args>(context, (kj::Decay<Args>*)nullptr)...);        \
-        }                                                                                          \
+      return liftKj<ReturnType>(isolate, [&]() {                                                   \
+        return (self.*method)(Lock::from(isolate),                                                 \
+            wrapper.template unwrapFastApi<Args>(context, (kj::Decay<Args>*)nullptr)...);          \
       });                                                                                          \
     }                                                                                              \
   };                                                                                               \

--- a/src/workerd/jsg/util-test.c++
+++ b/src/workerd/jsg/util-test.c++
@@ -13,8 +13,8 @@ V8System v8System;
 class ContextGlobalObject: public Object, public ContextGlobal {};
 
 struct FreezeContext: public ContextGlobalObject {
-  void recursivelyFreeze(v8::Local<v8::Value> value, v8::Isolate* isolate) {
-    jsg::recursivelyFreeze(isolate->GetCurrentContext(), value);
+  void recursivelyFreeze(jsg::Lock& js, v8::Local<v8::Value> value) {
+    jsg::recursivelyFreeze(js.v8Isolate->GetCurrentContext(), value);
   }
   JSG_RESOURCE_TYPE(FreezeContext) {
     JSG_METHOD(recursivelyFreeze);
@@ -39,8 +39,8 @@ KJ_TEST("recursive freezing") {
 // ========================================================================================
 
 struct CloneContext: public ContextGlobalObject {
-  v8::Local<v8::Value> deepClone(v8::Local<v8::Value> value, v8::Isolate* isolate) {
-    return jsg::deepClone(isolate->GetCurrentContext(), value);
+  v8::Local<v8::Value> deepClone(jsg::Lock& js, v8::Local<v8::Value> value) {
+    return jsg::deepClone(js.v8Isolate->GetCurrentContext(), value);
   }
   JSG_RESOURCE_TYPE(CloneContext) {
     JSG_METHOD(deepClone);
@@ -198,14 +198,14 @@ struct TunneledContext: public ContextGlobalObject {
     auto s = kj::str("Hello, world!");
     KJ_REQUIRE(s.startsWith(";"), " jsg.TypeError");
   }
-  void throwRetunneledTypeError(v8::Isolate* isolate) {
+  void throwRetunneledTypeError(jsg::Lock& js) {
     // Not sure what to call this ...
-    v8::TryCatch tryCatch(isolate);
+    v8::TryCatch tryCatch(js.v8Isolate);
     try {
-      jsg::throwTypeError(isolate, "Dummy error message.");
+      jsg::throwTypeError(js.v8Isolate, "Dummy error message.");
       KJ_UNREACHABLE;
     } catch (JsExceptionThrown&) {
-      throwTunneledException(isolate, tryCatch.Exception());
+      throwTunneledException(js.v8Isolate, tryCatch.Exception());
     }
   }
   void throwTunneledMacroTypeError() {

--- a/src/workerd/jsg/value-test.c++
+++ b/src/workerd/jsg/value-test.c++
@@ -1197,17 +1197,17 @@ KJ_TEST("MemoizedIdentity Values") {
 // ========================================================================================
 
 struct IdentifiedContext: public ContextGlobalObject {
-  kj::String compare(Identified<kj::Date> a, Identified<kj::Date> b, v8::Isolate* isolate) {
+  kj::String compare(jsg::Lock& js, Identified<kj::Date> a, Identified<kj::Date> b) {
     bool result = a.identity == b.identity;
     KJ_EXPECT(a.identity.hashCode() != 0);
     KJ_EXPECT(b.identity.hashCode() != 0);
     if (result) {
       KJ_EXPECT(a.identity.hashCode() == b.identity.hashCode());
     }
-    KJ_EXPECT(
-        a.identity.hashCode() == kj::hashCode(a.identity.getHandle(isolate)->GetIdentityHash()));
-    KJ_EXPECT(
-        b.identity.hashCode() == kj::hashCode(b.identity.getHandle(isolate)->GetIdentityHash()));
+    KJ_EXPECT(a.identity.hashCode() ==
+        kj::hashCode(a.identity.getHandle(js.v8Isolate)->GetIdentityHash()));
+    KJ_EXPECT(b.identity.hashCode() ==
+        kj::hashCode(b.identity.getHandle(js.v8Isolate)->GetIdentityHash()));
 
     return kj::str(result, ' ', a.unwrapped - b.unwrapped);
   }


### PR DESCRIPTION
This pull-request removes support for using v8::Isolate* type as a parameter. Also starting from this pull-request, we no longer check for the parameter types in order to detect if a function is fast api compatible or not, because in reality everything is v8::Local<v8::Value>...

- v8::Isolate* - we can do the same thing via jsg::Lock&, and actually v8::Isolate* parameter is equal to js.v8Isolate parameter. so there is no need to have this