### PR TITLE
adopting downstream's rustfmt rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -173,6 +173,7 @@ build --cxxopt="-fbracket-depth=512" --host_cxxopt="-fbracket-depth=512"
 # Using extra_rustc_flag for non-exec flags so they can be overwritten selectively.
 build --@rules_rust//:extra_rustc_flag=-Cdebug-assertions=n
 build --@rules_rust//:extra_exec_rustc_flags=-Cdebug-assertions=n
+build --@rules_rust//:rustfmt.toml=//src/rust:rustfmt.toml
 
 # We default to not enabling debug assertions and unwinding for Rust. For debug builds this is not
 # the right setting, but unfortunately we can't set that directly.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -142,53 +142,9 @@ git_repository(
     remote = "https://chromium.googlesource.com/chromium/src/third_party/zlib.git",
 )
 
-load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains", "rustfmt_toolchain_repository")
+load("//:build/rust_toolchains.bzl", "rust_toolchains")
 
-rules_rust_dependencies()
-
-RUST_STABLE_VERSION = "1.86.0"  # LLVM 19
-
-RUST_NIGHTLY_VERSION = "nightly/2025-02-20"
-
-RUST_TARGET_TRIPLES = [
-    # Add support for macOS cross-compilation
-    "x86_64-apple-darwin",
-    # Add support for macOS rosetta
-    "aarch64-unknown-linux-gnu",
-]
-
-rust_register_toolchains(
-    edition = "2024",
-    extra_target_triples = RUST_TARGET_TRIPLES,
-    versions = [
-        RUST_STABLE_VERSION,
-        RUST_NIGHTLY_VERSION,
-    ],
-)
-
-[
-    rustfmt_toolchain_repository(
-        name = "rustfmt_toolchain_" + t,
-        exec_triple = t,
-        version = RUST_NIGHTLY_VERSION,
-    )
-    for t in RUST_TARGET_TRIPLES
-]
-
-load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
-
-crate_universe_dependencies()
-
-# Load rust crate dependencies.
-# These could be regenerated from cargo.bzl by using
-# `just update-rust` (consult `just --list` or justfile for more details)
-load("//deps/rust/crates:crates.bzl", "crate_repositories")
-
-crate_repositories()
-
-load("@rules_rust//tools/rust_analyzer:deps.bzl", "rust_analyzer_dependencies")
-
-rust_analyzer_dependencies()
+rust_toolchains()
 
 # Protobuf
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -142,20 +142,38 @@ git_repository(
     remote = "https://chromium.googlesource.com/chromium/src/third_party/zlib.git",
 )
 
-load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
+load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains", "rustfmt_toolchain_repository")
 
 rules_rust_dependencies()
 
+RUST_STABLE_VERSION = "1.86.0"  # LLVM 19
+
+RUST_NIGHTLY_VERSION = "nightly/2025-02-20"
+
+RUST_TARGET_TRIPLES = [
+    # Add support for macOS cross-compilation
+    "x86_64-apple-darwin",
+    # Add support for macOS rosetta
+    "aarch64-unknown-linux-gnu",
+]
+
 rust_register_toolchains(
     edition = "2024",
-    extra_target_triples = [
-        # Add support for macOS cross-compilation
-        "x86_64-apple-darwin",
-        # Add support for macOS rosetta
-        "aarch64-unknown-linux-gnu",
+    extra_target_triples = RUST_TARGET_TRIPLES,
+    versions = [
+        RUST_STABLE_VERSION,
+        RUST_NIGHTLY_VERSION,
     ],
-    versions = ["1.86.0"],  # LLVM 19
 )
+
+[
+    rustfmt_toolchain_repository(
+        name = "rustfmt_toolchain_" + t,
+        exec_triple = t,
+        version = RUST_NIGHTLY_VERSION,
+    )
+    for t in RUST_TARGET_TRIPLES
+]
 
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
 

--- a/build/rust_toolchains.bzl
+++ b/build/rust_toolchains.bzl
@@ -7,6 +7,7 @@ RUST_STABLE_VERSION = "1.86.0"  # LLVM 19
 
 RUST_NIGHTLY_VERSION = "nightly/2025-02-20"
 
+# List of additional triples to be configured on top of the local platform triple
 RUST_TARGET_TRIPLES = [
     # Add support for macOS cross-compilation
     "x86_64-apple-darwin",
@@ -17,7 +18,7 @@ RUST_TARGET_TRIPLES = [
 def rust_toolchains():
     rules_rust_dependencies()
     rust_register_toolchains(
-        edition = "2021",
+        edition = "2024",
         extra_target_triples = RUST_TARGET_TRIPLES,
         versions = [
             RUST_STABLE_VERSION,

--- a/build/rust_toolchains.bzl
+++ b/build/rust_toolchains.bzl
@@ -1,0 +1,41 @@
+load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
+load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains", "rustfmt_toolchain_repository")
+load("@rules_rust//tools/rust_analyzer:deps.bzl", "rust_analyzer_dependencies")
+load("//deps/rust/crates:crates.bzl", "crate_repositories")
+
+RUST_STABLE_VERSION = "1.86.0"  # LLVM 19
+
+RUST_NIGHTLY_VERSION = "nightly/2025-02-20"
+
+RUST_TARGET_TRIPLES = [
+    # Add support for macOS cross-compilation
+    "x86_64-apple-darwin",
+    # Add support for macOS rosetta
+    "aarch64-unknown-linux-gnu",
+]
+
+def rust_toolchains():
+    rules_rust_dependencies()
+    rust_register_toolchains(
+        edition = "2021",
+        extra_target_triples = RUST_TARGET_TRIPLES,
+        versions = [
+            RUST_STABLE_VERSION,
+            RUST_NIGHTLY_VERSION,
+        ],
+    )
+
+    for t in RUST_TARGET_TRIPLES:
+        rustfmt_toolchain_repository(
+            name = "rustfmt_toolchain_" + t,
+            exec_triple = t,
+            version = RUST_NIGHTLY_VERSION,
+        )
+
+    crate_universe_dependencies()
+
+    # Load rust crate dependencies.
+    # These could be regenerated from cargo.bzl by using
+    # `just update-rust` (consult `just --list` or justfile for more details)
+    crate_repositories()
+    rust_analyzer_dependencies()

--- a/src/rust/BUILD.bazel
+++ b/src/rust/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["rustfmt.toml"])

--- a/src/rust/cxx-integration-test/lib.rs
+++ b/src/rust/cxx-integration-test/lib.rs
@@ -1,12 +1,15 @@
 //! Non-production crate to help test various aspects of rust/c++ integration.
 
-use std::{
-    io::{Error, ErrorKind},
-    pin::Pin,
-    time::Duration,
-};
+use std::io::Error;
+use std::io::ErrorKind;
+use std::pin::Pin;
+use std::time::Duration;
 
-use tracing::{debug, error, info, trace, warn};
+use tracing::debug;
+use tracing::error;
+use tracing::info;
+use tracing::trace;
+use tracing::warn;
 
 type Result<T> = std::io::Result<T>;
 

--- a/src/rust/cxx-integration/tokio.rs
+++ b/src/rust/cxx-integration/tokio.rs
@@ -2,7 +2,8 @@ use std::future::Future;
 use std::sync::OnceLock;
 
 use tokio::task::JoinHandle;
-use tracing::{Instrument, info};
+use tracing::Instrument;
+use tracing::info;
 
 static TOKIO_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 

--- a/src/rust/gen-compile-cache/main.rs
+++ b/src/rust/gen-compile-cache/main.rs
@@ -1,6 +1,8 @@
-use clap::Parser;
+use std::fs;
 use std::path::Path;
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
+
+use clap::Parser;
 
 /// Generate V8 compile caches
 #[derive(Parser, Debug)]

--- a/src/rust/python-parser/lib.rs
+++ b/src/rust/python-parser/lib.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
-use ruff_python_ast::{Stmt, StmtImportFrom};
+use ruff_python_ast::Stmt;
+use ruff_python_ast::StmtImportFrom;
 use ruff_python_parser::parse_module;
 
 #[cxx::bridge(namespace = "edgeworker::rust::python_parser")]

--- a/src/rust/rustfmt.toml
+++ b/src/rust/rustfmt.toml
@@ -1,0 +1,3 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Item"
+

--- a/src/workerd/tools/param-extractor.rs
+++ b/src/workerd/tools/param-extractor.rs
@@ -1,13 +1,14 @@
-use std::{
-    ffi::OsStr,
-    fs::File,
-    io::{BufReader, BufWriter, Write},
-    path::Path,
-};
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::BufReader;
+use std::io::BufWriter;
+use std::io::Write;
+use std::path::Path;
 
 use anyhow::Result;
 use flate2::read::GzDecoder;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
 /// Contains the declarations we care about
 #[derive(Deserialize, PartialEq, Debug)]


### PR DESCRIPTION
will keep everything consistent.

Also extracted rust_toolchains.bzl while I'm at it (separate commit)