### PR TITLE
Experimental feature: Durable Object Facets

### DIFF
--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -25,6 +25,7 @@ class SqlStorage;
 class DurableObject;
 class DurableObjectId;
 class WebSocket;
+class DurableObjectClass;
 
 kj::Array<kj::byte> serializeV8Value(jsg::Lock& js, const jsg::JsValue& value);
 
@@ -386,6 +387,41 @@ class DurableObjectTransaction final: public jsg::Object, public DurableObjectSt
   friend DurableObjectStorage;
 };
 
+class DurableObjectFacets: public jsg::Object {
+ public:
+  DurableObjectFacets(kj::Maybe<IoPtr<Worker::Actor::FacetManager>> facetManager)
+      : facetManager(kj::mv(facetManager)) {}
+
+  struct GetOptions {
+    jsg::Ref<DurableObjectClass> $class;
+    jsg::Optional<kj::OneOf<jsg::Ref<DurableObjectId>, kj::String>> id;
+
+    JSG_STRUCT($class, id);
+  };
+
+  // Get a facet by name, starting it if it isn't already running (or restarting it if the options
+  // change). Returns a `Fetcher` instead of a `DurableObject` becasue the returend stub does not
+  // have the `id` or `name` methods that a DO stub normally has.
+  jsg::Ref<Fetcher> get(jsg::Lock& js, kj::String name, GetOptions options);
+
+  void abort(jsg::Lock& js, kj::String name, jsg::JsValue reason);
+  void delete_(jsg::Lock& js, kj::String name);
+
+  JSG_RESOURCE_TYPE(DurableObjectFacets) {
+    JSG_METHOD(get);
+    JSG_METHOD(abort);
+    JSG_METHOD_NAMED(delete, delete_);
+  }
+
+ private:
+  kj::Maybe<IoPtr<Worker::Actor::FacetManager>> facetManager;
+
+  Worker::Actor::FacetManager& getFacetManager() {
+    return *JSG_REQUIRE_NONNULL(
+        facetManager, Error, "This Durable Object does not support creating facets.");
+  }
+};
+
 // The type placed in event.actorState (pre-modules API).
 // NOTE: It hasn't been renamed under the assumption that it will only be
 // used for colo-local namespaces.
@@ -476,7 +512,8 @@ class DurableObjectState: public jsg::Object {
       jsg::JsRef<jsg::JsValue> exports,
       kj::Maybe<jsg::Ref<DurableObjectStorage>> storage,
       kj::Maybe<rpc::Container::Client> container,
-      bool containerRunning);
+      bool containerRunning,
+      kj::Maybe<Worker::Actor::FacetManager&> facetManager);
 
   void waitUntil(kj::Promise<void> promise);
 
@@ -492,6 +529,10 @@ class DurableObjectState: public jsg::Object {
 
   jsg::Optional<jsg::Ref<Container>> getContainer() {
     return container.map([](jsg::Ref<Container>& c) { return c.addRef(); });
+  }
+
+  jsg::Ref<DurableObjectFacets> getFacets(jsg::Lock& js) {
+    return js.alloc<DurableObjectFacets>(facetManager);
   }
 
   jsg::Promise<jsg::JsRef<jsg::JsValue>> blockConcurrencyWhile(
@@ -564,6 +605,10 @@ class DurableObjectState: public jsg::Object {
     JSG_LAZY_INSTANCE_PROPERTY(id, getId);
     JSG_LAZY_INSTANCE_PROPERTY(storage, getStorage);
     JSG_LAZY_INSTANCE_PROPERTY(container, getContainer);
+    if (flags.getWorkerdExperimental()) {
+      // Experimental new API, details may change!
+      JSG_LAZY_INSTANCE_PROPERTY(facets, getFacets);
+    }
     JSG_METHOD(blockConcurrencyWhile);
     JSG_METHOD(acceptWebSocket);
     JSG_METHOD(getWebSockets);
@@ -604,6 +649,7 @@ class DurableObjectState: public jsg::Object {
   jsg::JsRef<jsg::JsValue> exports;
   kj::Maybe<jsg::Ref<DurableObjectStorage>> storage;
   kj::Maybe<jsg::Ref<Container>> container;
+  kj::Maybe<IoPtr<Worker::Actor::FacetManager>> facetManager;
 
   // Limits for Hibernatable WebSocket tags.
 
@@ -618,6 +664,7 @@ class DurableObjectState: public jsg::Object {
       api::DurableObjectStorageOperations::GetOptions,                                             \
       api::DurableObjectStorageOperations::GetAlarmOptions,                                        \
       api::DurableObjectStorageOperations::PutOptions,                                             \
-      api::DurableObjectStorageOperations::SetAlarmOptions, api::WebSocketRequestResponsePair
+      api::DurableObjectStorageOperations::SetAlarmOptions, api::WebSocketRequestResponsePair,     \
+      api::DurableObjectFacets, api::DurableObjectFacets::GetOptions
 
 }  // namespace workerd::api

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -262,9 +262,27 @@ class DurableObjectNamespace: public jsg::Object {
       jsg::Optional<GetDurableObjectOptions> options);
 };
 
+// DurableObjectClass represents a binding to a Durable Object class that can be used
+// as a facet. The only use of this type is to pass to `ctx.facets.get()`.
+class DurableObjectClass: public jsg::Object {
+ public:
+  DurableObjectClass(uint channel): channel(channel) {}
+
+  uint getChannel() const {
+    return channel;
+  }
+
+  JSG_RESOURCE_TYPE(DurableObjectClass) {
+    // No methods - this is just a handle that gets passed to ctx.facets.get()
+  }
+
+ private:
+  uint channel;
+};
+
 #define EW_ACTOR_ISOLATE_TYPES                                                                     \
   api::ColoLocalActorNamespace, api::DurableObject, api::DurableObjectId,                          \
       api::DurableObjectNamespace, api::DurableObjectNamespace::NewUniqueIdOptions,                \
-      api::DurableObjectNamespace::GetDurableObjectOptions
+      api::DurableObjectNamespace::GetDurableObjectOptions, api::DurableObjectClass
 
 }  // namespace workerd::api

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -29,6 +29,11 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
     virtual kj::Promise<void> scheduleRun(kj::Maybe<kj::Date> newAlarmTime);
 
     static const Hooks DEFAULT;
+
+    static constexpr inline Hooks& getDefaultHooks() {
+      // Hooks has no member variables, so const_cast is acceptable.
+      return const_cast<Hooks&>(Hooks::DEFAULT);
+    }
   };
 
   // Constructs ActorSqlite, arranging to honor the output gate, that is, any writes to the
@@ -43,8 +48,7 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
   explicit ActorSqlite(kj::Own<SqliteDatabase> dbParam,
       OutputGate& outputGate,
       kj::Function<kj::Promise<void>()> commitCallback,
-      // Hooks has no member variables, so const_cast is acceptable.
-      Hooks& hooks = const_cast<Hooks&>(Hooks::DEFAULT));
+      Hooks& hooks = Hooks::getDefaultHooks());
 
   bool isCommitScheduled() {
     return !currentTxn.is<NoTxn>() || deleteAllCommitScheduled;

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3640,6 +3640,20 @@ const Worker::Actor::Id& Worker::Actor::getId() {
   return impl->actorId;
 }
 
+bool Worker::Actor::idsEqual(const Id& a, const Id& b) {
+  if (a.which() != b.which()) return false;
+
+  KJ_SWITCH_ONEOF(a) {
+    KJ_CASE_ONEOF(actorId, kj::Own<ActorIdFactory::ActorId>) {
+      return actorId->equals(*b.get<kj::Own<ActorIdFactory::ActorId>>());
+    }
+    KJ_CASE_ONEOF(str, kj::String) {
+      return str == b.get<kj::String>();
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
 Worker::Actor::Id Worker::Actor::cloneId(Worker::Actor::Id& id) {
   KJ_SWITCH_ONEOF(id) {
     KJ_CASE_ONEOF(coloLocalId, kj::String) {

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3260,6 +3260,7 @@ struct Worker::Actor::Impl {
   kj::Maybe<jsg::JsRef<jsg::JsObject>> ctxObject;
 
   kj::Maybe<rpc::Container::Client> container;
+  kj::Maybe<FacetManager&> facetManager;
 
   struct NoClass {};
   struct Initializing {};
@@ -3420,12 +3421,14 @@ struct Worker::Actor::Impl {
       kj::Maybe<kj::Own<HibernationManager>> manager,
       kj::Maybe<uint16_t>& hibernationEventType,
       kj::Maybe<rpc::Container::Client> container,
+      kj::Maybe<FacetManager&> facetManager,
       kj::PromiseFulfillerPair<void> paf = kj::newPromiseAndFulfiller<void>())
       : actorId(kj::mv(actorId)),
         makeStorage(kj::mv(makeStorage)),
         metrics(kj::mv(metricsParam)),
         transient(hasTransient),
         container(kj::mv(container)),
+        facetManager(facetManager),
         hooks(loopback->addRef(), timerChannel, *metrics),
         inputGate(hooks),
         outputGate(hooks),
@@ -3476,12 +3479,13 @@ Worker::Actor::Actor(const Worker& worker,
     kj::Own<ActorObserver> metrics,
     kj::Maybe<kj::Own<HibernationManager>> manager,
     kj::Maybe<uint16_t> hibernationEventType,
-    kj::Maybe<rpc::Container::Client> container)
+    kj::Maybe<rpc::Container::Client> container,
+    kj::Maybe<FacetManager&> facetManager)
     : worker(kj::atomicAddRef(worker)),
       tracker(tracker.map([](RequestTracker& tracker) { return tracker.addRef(); })) {
   impl = kj::heap<Impl>(*this, kj::mv(actorId), hasTransient, kj::mv(makeActorCache),
       kj::mv(makeStorage), kj::mv(loopback), timerChannel, kj::mv(metrics), kj::mv(manager),
-      hibernationEventType, kj::mv(container));
+      hibernationEventType, kj::mv(container), facetManager);
 
   KJ_IF_SOME(c, className) {
     KJ_IF_SOME(cls, worker.impl->actorClasses.find(c)) {
@@ -3541,7 +3545,7 @@ kj::Promise<void> Worker::Actor::ensureConstructedImpl(IoContext& context, Actor
       auto ctx = js.alloc<api::DurableObjectState>(js, cloneId(),
           jsg::JsRef<jsg::JsValue>(
               js, KJ_ASSERT_NONNULL(lock.getWorker().impl->ctxExports).addRef(js)),
-          kj::mv(storage), kj::mv(impl->container), containerRunning);
+          kj::mv(storage), kj::mv(impl->container), containerRunning, impl->facetManager);
 
       auto handler =
           info.cls(lock, ctx.addRef(), KJ_ASSERT_NONNULL(lock.getWorker().impl->env).addRef(js));

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -905,6 +905,24 @@ class Worker::Actor final: public kj::Refcounted {
     virtual kj::Maybe<uint32_t> getEventTimeout() = 0;
   };
 
+  class FacetManager {
+   public:
+    // Information needed to start a facet.
+    struct StartInfo {
+      // The actor class channel number, from a DurableObjectClass binding.
+      uint actorClassChannel;
+
+      // ctx.id for the child object.
+      Worker::Actor::Id id;
+    };
+
+    // These methods are C++ equivalents of the JavaScript ctx.facets API.
+    virtual kj::Own<IoChannelFactory::ActorChannel> getFacet(
+        kj::StringPtr name, StartInfo startInfo) = 0;
+    virtual void abortFacet(kj::StringPtr name, kj::Exception reason) = 0;
+    virtual void deleteFacet(kj::StringPtr name) = 0;
+  };
+
   // Create a new Actor hosted by this Worker. Note that this Actor object may only be manipulated
   // from the thread that created it.
   Actor(const Worker& worker,
@@ -919,7 +937,8 @@ class Worker::Actor final: public kj::Refcounted {
       kj::Own<ActorObserver> metrics,
       kj::Maybe<kj::Own<HibernationManager>> manager,
       kj::Maybe<uint16_t> hibernationEventType,
-      kj::Maybe<rpc::Container::Client> container = kj::none);
+      kj::Maybe<rpc::Container::Client> container = kj::none,
+      kj::Maybe<FacetManager&> facetManager = kj::none);
 
   ~Actor() noexcept(false);
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -873,6 +873,7 @@ class Worker::Actor final: public kj::Refcounted {
   //   to customize the JS API but only the underlying ActorCacheInterface?
 
   using Id = kj::OneOf<kj::Own<ActorIdFactory::ActorId>, kj::String>;
+  static bool idsEqual(const Id& a, const Id& b);
 
   // Class that allows sending requests to this actor, recreating it as needed. It is safe to hold
   // onto this for longer than a Worker::Actor is alive.

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -110,6 +110,7 @@ wd_cc_library(
         ":alarm-scheduler",
         ":bundle-fs",
         ":container-client",
+        ":facet-tree-index",
         ":fallback-service",
         ":workerd_capnp",
         "//deps/rust:runtime",

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -197,6 +197,20 @@ wd_cc_library(
     ],
 )
 
+wd_cc_library(
+    name = "facet-tree-index",
+    srcs = [
+        "facet-tree-index.c++",
+    ],
+    hdrs = [
+        "facet-tree-index.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj",
+    ],
+)
+
 wd_capnp_library(
     src = "workerd.capnp",
     # Limit visibility to avoid accidental usage – there should be no need to use this outside of
@@ -245,4 +259,12 @@ copy_file(
     name = "pyodide.capnp.bin@rule",
     src = "//src/pyodide:pyodide.capnp.bin_cross",
     out = "pyodide.capnp.bin",
+)
+
+kj_test(
+    src = "facet-tree-index-test.c++",
+    deps = [
+        ":facet-tree-index",
+        "@capnp-cpp//src/kj",
+    ],
 )

--- a/src/workerd/server/facet-tree-index-test.c++
+++ b/src/workerd/server/facet-tree-index-test.c++
@@ -1,0 +1,260 @@
+#include "facet-tree-index.h"
+
+#include <kj/io.h>
+#include <kj/memory.h>
+#include <kj/test.h>
+#include <kj/time.h>
+
+namespace workerd::server {
+namespace {
+
+using kj::byte;
+using kj::uint;
+
+KJ_TEST("FacetTreeIndex basic functionality") {
+  auto file = kj::newInMemoryFile(kj::nullClock());
+
+  {
+    // Test with new empty file
+    FacetTreeIndex index(file->clone());
+
+    // Get IDs for facets
+    uint id1 = index.getId(0, "facet1");
+    uint id2 = index.getId(0, "facet2");
+    uint id3 = index.getId(id1, "child1");
+    uint id4 = index.getId(id1, "child2");
+    uint id5 = index.getId(id2, "child1");
+
+    // Check that IDs are assigned correctly
+    KJ_EXPECT(id1 == 1);
+    KJ_EXPECT(id2 == 2);
+    KJ_EXPECT(id3 == 3);
+    KJ_EXPECT(id4 == 4);
+    KJ_EXPECT(id5 == 5);
+
+    // Check that IDs are stable
+    KJ_EXPECT(index.getId(0, "facet1") == id1);
+    KJ_EXPECT(index.getId(0, "facet2") == id2);
+    KJ_EXPECT(index.getId(id1, "child1") == id3);
+    KJ_EXPECT(index.getId(id1, "child2") == id4);
+    KJ_EXPECT(index.getId(id2, "child1") == id5);
+  }
+
+  {
+    // Test with existing file (persistence)
+    FacetTreeIndex index(file->clone());
+
+    // Check that IDs are the same as before
+    KJ_EXPECT(index.getId(0, "facet1") == 1);
+    KJ_EXPECT(index.getId(0, "facet2") == 2);
+    KJ_EXPECT(index.getId(1, "child1") == 3);
+    KJ_EXPECT(index.getId(1, "child2") == 4);
+    KJ_EXPECT(index.getId(2, "child1") == 5);
+
+    // Add some new facets
+    uint id6 = index.getId(3, "grandchild1");
+    uint id7 = index.getId(3, "grandchild2");
+
+    KJ_EXPECT(id6 == 6);
+    KJ_EXPECT(id7 == 7);
+  }
+
+  {
+    // Test again with existing file
+    FacetTreeIndex index(file->clone());
+
+    // Check all IDs were preserved
+    KJ_EXPECT(index.getId(0, "facet1") == 1);
+    KJ_EXPECT(index.getId(0, "facet2") == 2);
+    KJ_EXPECT(index.getId(1, "child1") == 3);
+    KJ_EXPECT(index.getId(1, "child2") == 4);
+    KJ_EXPECT(index.getId(2, "child1") == 5);
+    KJ_EXPECT(index.getId(3, "grandchild1") == 6);
+    KJ_EXPECT(index.getId(3, "grandchild2") == 7);
+  }
+}
+
+KJ_TEST("FacetTreeIndex error handling") {
+  auto file = kj::newInMemoryFile(kj::nullClock());
+  FacetTreeIndex index(file->clone());
+
+  // Add some initial facets
+  index.getId(0, "facet1");
+  index.getId(0, "facet2");
+
+  // Test error cases
+
+  // Empty name
+  KJ_EXPECT_THROW_MESSAGE("Facet name cannot be empty", index.getId(0, ""));
+
+  // Invalid parent
+  KJ_EXPECT_THROW_MESSAGE("Invalid parent ID", index.getId(999, "child"));
+
+  // Same name but different parents should get different IDs
+  uint id1 = index.getId(1, "sameName");
+  uint id2 = index.getId(2, "sameName");
+  KJ_EXPECT(id1 != id2);
+
+  // Test name uniqueness per parent
+  uint id3 = index.getId(1, "sameName");
+  KJ_EXPECT(id3 == id1);
+}
+
+KJ_TEST("FacetTreeIndex corruption handling") {
+  auto file = kj::newInMemoryFile(kj::nullClock());
+
+  // Create a file with corrupted data
+  {
+    // Write valid header and some valid entries
+    constexpr uint64_t MAGIC_NUMBER = 0xc4cdce5bc5b0ef57;
+    file->write(0, kj::ArrayPtr<const byte>((const byte*)&MAGIC_NUMBER, sizeof(MAGIC_NUMBER)));
+
+    // Write valid entry: parent=0, name="valid"
+    uint16_t parent = 0;
+    uint16_t nameLen = 5;
+    byte entry[4 + 5];
+    memcpy(entry, &parent, 2);
+    memcpy(entry + 2, &nameLen, 2);
+    memcpy(entry + 4, "valid", 5);
+    file->write(sizeof(MAGIC_NUMBER), kj::ArrayPtr<const byte>(entry, sizeof(entry)));
+
+    // Write corrupted entry: parent=999 (invalid), name="corrupt"
+    uint16_t badParent = 999;
+    uint16_t badNameLen = 7;
+    byte badEntry[4 + 7];
+    memcpy(badEntry, &badParent, 2);
+    memcpy(badEntry + 2, &badNameLen, 2);
+    memcpy(badEntry + 4, "corrupt", 7);
+    file->write(
+        sizeof(MAGIC_NUMBER) + sizeof(entry), kj::ArrayPtr<const byte>(badEntry, sizeof(badEntry)));
+
+    // Write valid entry after corruption that should be ignored
+    uint16_t ignoredParent = 0;
+    uint16_t ignoredNameLen = 7;
+    byte ignoredEntry[4 + 7];
+    memcpy(ignoredEntry, &ignoredParent, 2);
+    memcpy(ignoredEntry + 2, &ignoredNameLen, 2);
+    memcpy(ignoredEntry + 4, "ignored", 7);
+    file->write(sizeof(MAGIC_NUMBER) + sizeof(entry) + sizeof(badEntry),
+        kj::ArrayPtr<const byte>(ignoredEntry, sizeof(ignoredEntry)));
+  }
+
+  // Open corrupted file
+  {
+    FacetTreeIndex index(file->clone());
+
+    // Check that only valid entries were read
+    KJ_EXPECT(index.getId(0, "valid") == 1);
+
+    // The corrupted entry and everything after it should have been ignored
+    // So this should create a new entry
+    uint id = index.getId(0, "corrupt");
+    KJ_EXPECT(id == 2);
+
+    // Similarly, "ignored" should be new
+    uint id2 = index.getId(0, "ignored");
+    KJ_EXPECT(id2 == 3);
+  }
+
+  // Open yet again, make sure that the newly-added entries were written successfully.
+  {
+    FacetTreeIndex index(file->clone());
+    KJ_EXPECT(index.getId(0, "valid") == 1);
+    KJ_EXPECT(index.getId(0, "corrupt") == 2);
+    KJ_EXPECT(index.getId(0, "ignored") == 3);
+  }
+}
+
+KJ_TEST("FacetTreeIndex tree structure") {
+  auto file = kj::newInMemoryFile(kj::nullClock());
+
+  FacetTreeIndex index(file->clone());
+
+  // Build a tree with multiple levels
+  uint id1 = index.getId(0, "root1");
+  uint id2 = index.getId(0, "root2");
+
+  uint id3 = index.getId(id1, "level1_1");
+  uint id4 = index.getId(id1, "level1_2");
+  uint id5 = index.getId(id2, "level1_3");
+
+  uint id6 = index.getId(id3, "level2_1");
+  uint id7 = index.getId(id3, "level2_2");
+  uint id8 = index.getId(id4, "level2_3");
+
+  uint id9 = index.getId(id6, "level3_1");
+
+  // Verify IDs
+  KJ_EXPECT(id1 == 1);
+  KJ_EXPECT(id2 == 2);
+  KJ_EXPECT(id3 == 3);
+  KJ_EXPECT(id4 == 4);
+  KJ_EXPECT(id5 == 5);
+  KJ_EXPECT(id6 == 6);
+  KJ_EXPECT(id7 == 7);
+  KJ_EXPECT(id8 == 8);
+  KJ_EXPECT(id9 == 9);
+
+  // Verify stable lookup
+  KJ_EXPECT(index.getId(id1, "level1_1") == id3);
+  KJ_EXPECT(index.getId(id3, "level2_1") == id6);
+  KJ_EXPECT(index.getId(id6, "level3_1") == id9);
+}
+
+KJ_TEST("FacetTreeIndex handles truncated files correctly") {
+  auto file = kj::newInMemoryFile(kj::nullClock());
+
+  // Step 1: Create a file with a few entries
+  {
+    FacetTreeIndex index(file->clone());
+    uint id1 = index.getId(0, "entry1");
+    uint id2 = index.getId(0, "entry2");
+    uint id3 = index.getId(0, "entry3");
+
+    KJ_EXPECT(id1 == 1);
+    KJ_EXPECT(id2 == 2);
+    KJ_EXPECT(id3 == 3);
+  }
+
+  // Step 2: Corrupt the last entry by overwriting its nameLength field with an invalid large value
+  auto fileSize = file->stat().size;
+  uint offset =
+      fileSize - 8;  // Go to the nameLength field of the last entry (2 bytes before "entry3")
+
+  // Write an impossibly large nameLength value
+  uint16_t hugeNameLength = 65000;  // Much larger than any valid name in our test file
+  file->write(
+      offset, kj::ArrayPtr<const byte>((const byte*)&hugeNameLength, sizeof(hugeNameLength)));
+
+  // Step 3: Re-read the index and add a new entry
+  {
+    FacetTreeIndex index(file->clone());
+
+    // First two entries should still be valid
+    KJ_EXPECT(index.getId(0, "entry1") == 1);
+    KJ_EXPECT(index.getId(0, "entry2") == 2);
+
+    // The corrupted entry (entry3) should not be found, so this new entry
+    // should get the ID 3 (reusing the ID that was intended for entry3)
+    uint id = index.getId(0, "replacement");
+    KJ_EXPECT(id == 3);
+  }
+
+  // Step 4: Re-read the file again and add yet another new entry
+  {
+    FacetTreeIndex index(file->clone());
+
+    // Immediately get a new entry, without checking existing ones first
+    // This should get ID 4, not reuse ID 3 again
+    uint id = index.getId(0, "another");
+
+    // Now check that all previous entries are remembered
+    KJ_EXPECT(id == 4);
+    KJ_EXPECT(index.getId(0, "entry1") == 1);
+    KJ_EXPECT(index.getId(0, "entry2") == 2);
+    KJ_EXPECT(index.getId(0, "replacement") == 3);
+  }
+}
+
+}  // namespace
+}  // namespace workerd::server

--- a/src/workerd/server/facet-tree-index.c++
+++ b/src/workerd/server/facet-tree-index.c++
@@ -1,0 +1,130 @@
+#include "facet-tree-index.h"
+
+#include <kj/debug.h>
+#include <kj/io.h>
+
+namespace workerd::server {
+
+using kj::byte;
+using kj::uint;
+
+FacetTreeIndex::FacetTreeIndex(kj::Own<const kj::File> fileParam)
+    : file(kj::mv(fileParam)),
+      offset(0) {
+  // Read the file to populate the initial index
+
+  auto fileBytes = file->readAllBytes();
+
+  // Check if the magic number is present.
+  //
+  // If the file size is less than or equal to the magic number size itself, it's possible that a
+  // previous session suffered a failure while writing the magic number. In that case we can assume
+  // nothing was ever written to the index, so we just rewrite it and start over.
+  if (fileBytes.size() <= sizeof(MAGIC_NUMBER)) {
+    // New file, initialize with magic number.
+    file->write(0, kj::arrayPtr(MAGIC_NUMBER).asBytes());
+    file->datasync();
+    offset = sizeof(MAGIC_NUMBER);
+    return;
+  }
+
+  // On the other hand, because we datasync() immediately after writing the magic number, we can
+  // assume that if _more_ bytes are written than just the magic number, then a failure did _not_
+  // occurr during the writing of the magic number, and therefore, if it contains the wrong bytes,
+  // the file must be in a format we don't recognize.
+  uint64_t magic = 0;
+  memcpy(&magic, fileBytes.begin(), sizeof(magic));
+  KJ_REQUIRE(magic == MAGIC_NUMBER, "unknown magic number on facet tree index");
+  offset = sizeof(magic);
+
+  // Read entries
+  while (offset + sizeof(EntryHeader) <= fileBytes.size()) {
+    KJ_REQUIRE(nextId() <= MAX_ID, "Maximum number of facets exceeded");
+
+    EntryHeader header;
+    memcpy(&header, fileBytes.begin() + offset, sizeof(header));
+
+    // Validation checks
+    if (header.nameLength == 0) {
+      // Empty name is invalid.
+      break;
+    }
+
+    if (offset + sizeof(EntryHeader) + header.nameLength > fileBytes.size()) {
+      // Name extends beyond file bounds, invalid.
+      break;
+    }
+
+    if (header.parentId >= nextId()) {
+      // Invalid parent ID (parent must already exist).
+      break;
+    }
+
+    // Extract the name
+    kj::String name = kj::heapString(
+        reinterpret_cast<const char*>(fileBytes.begin() + offset + sizeof(EntryHeader)),
+        header.nameLength);
+
+    bool duplicate = false;
+    entries.upsert(
+        Entry{header.parentId, kj::mv(name)}, [&](Entry&, Entry&&) { duplicate = true; });
+
+    if (duplicate) {
+      // Duplicate entry is invalid.
+      break;
+    }
+
+    // Entry was valid and processed successfully, now we can update the offset
+    offset += sizeof(EntryHeader) + header.nameLength;
+  }
+
+  if (offset < fileBytes.size()) {
+    // It appears we stopped at a corrupted entry. We assume such corruption can only be the result
+    // of a power failure in the middle of writing an entry during a past session. Any entry which
+    // was written but not synced can be presumed to have never been used, so we can simply
+    // truncate it from the file.
+    file->truncate(offset);
+  }
+}
+
+uint FacetTreeIndex::getId(uint parent, kj::StringPtr name) {
+  KJ_REQUIRE(name.size() > 0, "Facet name cannot be empty");
+  KJ_REQUIRE(name.size() <= (uint16_t)kj::maxValue, "Facet name too long");
+  KJ_REQUIRE(parent <= entries.size(), "Invalid parent ID");
+
+  // Use findOrCreate to either find an existing entry or create a new one
+  auto& entry = entries.findOrCreate(EntryPtr{parent, name}, [&]() -> Entry {
+    // New entry, need to assign a new ID and append to file
+    KJ_REQUIRE(nextId() <= MAX_ID, "Maximum number of facets exceeded");
+
+    // Prepare entry data
+    EntryHeader header{
+      .parentId = static_cast<uint16_t>(parent),
+      .nameLength = static_cast<uint16_t>(name.size()),
+    };
+
+// Don't whine about VLA being non-standard.
+#pragma clang diagnostic ignored "-Wvla-cxx-extension"
+
+    size_t entrySize = sizeof(EntryHeader) + header.nameLength;
+    byte entryData[entrySize];
+    memcpy(entryData, &header, sizeof(header));
+    memcpy(entryData + sizeof(EntryHeader), name.begin(), header.nameLength);
+
+    file->write(offset, kj::arrayPtr(entryData, entrySize));
+
+    // We don't want to return an entry that might disappear after a power failure, so sync it
+    // now.
+    file->datasync();
+
+    offset += entrySize;
+
+    return Entry{parent, kj::heapString(name)};
+  });
+
+  // Calculate the ID based on the entry's position in the set
+  // Root facet (ID 0) isn't in the entries set, so add 1 to the index
+  return 1 + (&entry - entries.begin());
+}
+
+}  // namespace workerd::server

--- a/src/workerd/server/facet-tree-index.h
+++ b/src/workerd/server/facet-tree-index.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <kj/filesystem.h>
+#include <kj/map.h>
+
+namespace workerd::server {
+
+using kj::uint;
+
+// Implements an index, stored on disk, which maps leaves of a tree to small integers in a stable
+// way.
+//
+// Specifically, this is used to assign numeric IDs to facets of Durable Objects. Each Durable
+// Object is potentially composed of a tree of "facets". One facet -- with ID zero -- serves as
+// the root facet. All other facets have a parent facet and a name. Names are unique among facets
+// with the same parent, but not globally. Each facet is assigned a numeric ID the first time it is
+// seen. These IDs are assigned sequentially.
+//
+// We assume that the total number of facets created for a single Durable Object over its entire
+// lifetime will never be very large. Therefore, it is reasonable to store the entire tree index
+// in memory, loaded in its entirely at startup. Because of this, entries can simply be stored in
+// order by ID (starting with ID 1, since no entry is needed for the root). We also assume that
+// it's never necessary to delete an entry -- while a facet itself can be deleted, if a new facet
+// is created with the same name, it should use the same ID. Therefore, the index file can be
+// append-only, modified only when a never-before-seen facet is created.
+//
+// The facet index file therefore uses a very simple format. The index is simply a sequence of
+// entries, where each entry is composed of:
+// * A 2-byte integer specifying the parent ID.
+// * A 2-byte integer specifying the length of the name. Note this cannot be zero.
+// * The bytes of the name itself (not including any NUL terminator).
+//
+// Note that the format implicitly limits a Durable Object to have no more than 65536 facets in
+// its entire lifetime. An attempt to exceed this limit will throw an exception. If this ever comes
+// up in practice, we probably need to rethink the format -- not just the size of the integers, but
+// the entire design, as it is not designed for so many facets.
+//
+// Notice that the index file's design is such that updating the file strictly at append operation.
+// This avoids the need for a write-ahead log on updates. It is still possible, in the event of
+// a power failure during an update, that the tail of the index will be corrupted. This is OK,
+// becaues that tail could not have been relied upon yet. When reading the file, if a nonsensical
+// entry is seen (parent ID out-of-range, name overrunning the end of the file, empty name, or
+// duplicate entry), the remainder of the file from that point can simply be ignored. In the
+// unlikely event that corrupted entries by coincidence appear to be valid, no harm is done -- this
+// only has the effect of assigning IDs to names that will never actually be used.
+//
+// The index file is prefixed with the 8-byte magic number 0xc4cdce5bc5b0ef57. All integers
+// (including the magic number) are in host byte order (which is little-endian on all supported
+// platforms).
+class FacetTreeIndex {
+ public:
+  // Construct the index, reading the given file to populate the initial index, and then arranging
+  // to append new entries to the file as needed.
+  FacetTreeIndex(kj::Own<const kj::File> file);
+
+  // Gets the ID for the given facet, assigning it if needed.
+  uint getId(uint parent, kj::StringPtr name);
+
+ private:
+  kj::Own<const kj::File> file;
+
+  // Offset at which to write the next entry. Typically points to the end of the file (except when
+  // a corrupted tail was detected).
+  uint offset;
+
+  struct Entry {
+    uint parent;
+    kj::String name;
+
+    bool operator==(const Entry& other) const = default;
+    auto hashCode() const {
+      return kj::hashCode(parent, name);
+    }
+  };
+
+  struct EntryPtr {
+    uint parent;
+    kj::StringPtr name;
+
+    bool operator==(const Entry& other) const {
+      return parent == other.parent && name == other.name;
+    }
+    auto hashCode() const {
+      return kj::hashCode(parent, name);
+    }
+  };
+
+  // All entries. Note that there's no need to store the ID of each entry since they are strictly
+  // ordered with no erasures. kj::HashSet is based on kj::Table which maintains the original
+  // insertion order (as long as no erasures occur), so the index of any entry can be computed
+  // by subtracting `entries.begin()` from its pointer. (Add 1 to the index to get the ID, since
+  // the root is ID zero.)
+  kj::HashSet<Entry> entries;
+
+  // Next ID that will be assigned. Off-by-one due to root not being in the set.
+  inline uint nextId() {
+    return entries.size() + 1;
+  }
+
+  static constexpr uint64_t MAGIC_NUMBER = 0xc4cdce5bc5b0ef57;
+  static constexpr uint MAX_ID = (uint16_t)kj::maxValue;
+
+  struct EntryHeader {
+    uint16_t parentId;
+    uint16_t nameLength;
+  };
+};
+
+}  // namespace workerd::server

--- a/src/workerd/server/facet-tree-index.h
+++ b/src/workerd/server/facet-tree-index.h
@@ -56,6 +56,16 @@ class FacetTreeIndex {
   // Gets the ID for the given facet, assigning it if needed.
   uint getId(uint parent, kj::StringPtr name);
 
+  // For each child of the given parent ID, call the callback.
+  template <typename Func>
+  void forEachChild(uint parentId, Func&& callback) {
+    for (auto& child: entries.range(EntryPtr{parentId, nullptr}, EntryPtr{parentId + 1, nullptr})) {
+      KJ_IASSERT(child.parent == parentId);
+      uint childId = 1 + (&child - entries.begin());
+      callback(childId, child.name);
+    }
+  }
+
  private:
   kj::Own<const kj::File> file;
 
@@ -63,13 +73,22 @@ class FacetTreeIndex {
   // a corrupted tail was detected).
   uint offset;
 
+  struct EntryPtr;
+
   struct Entry {
     uint parent;
     kj::String name;
 
     bool operator==(const Entry& other) const = default;
-    auto hashCode() const {
-      return kj::hashCode(parent, name);
+    bool operator<(const Entry& other) const {
+      if (parent < other.parent) return true;
+      if (parent > other.parent) return false;
+      return name < other.name;
+    }
+    bool operator<(const EntryPtr& other) const {
+      if (parent < other.parent) return true;
+      if (parent > other.parent) return false;
+      return name < other.name;
     }
   };
 
@@ -80,17 +99,14 @@ class FacetTreeIndex {
     bool operator==(const Entry& other) const {
       return parent == other.parent && name == other.name;
     }
-    auto hashCode() const {
-      return kj::hashCode(parent, name);
-    }
   };
 
   // All entries. Note that there's no need to store the ID of each entry since they are strictly
-  // ordered with no erasures. kj::HashSet is based on kj::Table which maintains the original
+  // ordered with no erasures. kj::TreeSet is based on kj::Table which maintains the original
   // insertion order (as long as no erasures occur), so the index of any entry can be computed
   // by subtracting `entries.begin()` from its pointer. (Add 1 to the index to get the ID, since
   // the root is ID zero.)
-  kj::HashSet<Entry> entries;
+  kj::TreeSet<Entry> entries;
 
   // Next ID that will be assigned. Off-by-one due to root not being in the set.
   inline uint nextId() {

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -4686,7 +4686,7 @@ KJ_TEST("Server: Catch websocket server errors") {
 }
 
 KJ_TEST("Server: Durable Object facets") {
-  TestServer test(R"((
+  kj::StringPtr config = R"((
     services = [
       ( name = "hello",
         worker = (
@@ -4698,7 +4698,7 @@ KJ_TEST("Server: Durable Object facets") {
                 `import { DurableObject } from "cloudflare:workers";
                 `export default {
                 `  async fetch(request, env, ctx) {
-                `    let id = env.NS.idFromName(request.url);
+                `    let id = env.NS.idFromName("name");
                 `    let actor = env.NS.get(id);
                 `    return await actor.fetch(request);
                 `  }
@@ -4706,37 +4706,74 @@ KJ_TEST("Server: Durable Object facets") {
                 `export class MyActorClass extends DurableObject {
                 `  async fetch(request) {
                 `    let results = [];
-                `    let facet = this.ctx.facets.get("foo", {class: this.env.COUNTER});
-                `    results.push(await facet.increment());
-                `    results.push(await facet.increment());
-                `    results.push(await facet.increment());
                 `
-                `    let facet2 = this.ctx.facets.get("bar", {class: this.env.COUNTER});
-                `    results.push(await facet2.increment());
+                `    if (request.url.endsWith("/part1")) {
+                `      let foo = this.ctx.facets.get("foo", {class: this.env.COUNTER});
+                `      results.push(await foo.increment(true));  // increments foo
+                `      results.push(await foo.increment());  // increments foo
+                `      results.push(await foo.increment());  // increments foo
                 `
-                `    let facet3 = this.ctx.facets.get("foo", {class: this.env.COUNTER});
-                `    results.push(await facet3.increment());
+                `      let bar = this.ctx.facets.get("bar", {class: this.env.NESTED});
+                `      results.push(await bar.increment("foo", true));  // increments bar.foo
+                `      results.push(await bar.increment("bar", true));  // increments bar.bar
+                `      results.push(await bar.increment("foo"));        // increments bar.foo
+                `
+                `      // Get foo again to make sure we get the same object.
+                `      let foo2 = this.ctx.facets.get("foo", {class: this.env.COUNTER});
+                `      results.push(await foo2.increment());  // increments foo
+                `      results.push(await foo.increment());   // increments foo
+                `    } else if (request.url.endsWith("/part2")) {
+                `      // Get in a different order from before to make sure ID assignment is
+                `      // consistent.
+                `      let bar = this.ctx.facets.get("bar", {class: this.env.NESTED});
+                `      results.push(await bar.increment("bar", true));  // increments bar.bar
+                `      results.push(await bar.increment("foo", true));  // increments bar.foo
+                `      let foo = this.ctx.facets.get("foo", {class: this.env.COUNTER});
+                `      results.push(await foo.increment(true));  // increments foo
+                `    } else {
+                `      throw new Error(`bad url: ${request.url}`);
+                `    }
+                `
                 `    return new Response(results.join(" "));
                 `  }
                 `}
                 `export class CounterFacet extends DurableObject {
-                `  i = 0;
-                `  increment() {
+                `  async increment(first) {
+                `    let storedI = (await this.ctx.storage.get("value")) || 0;
+                `    if (first) {
+                `      this.i = storedI;
+                `    } else if (this.i != storedI) {
+                `      throw new Error("inconsistent stored value ${storedI} != ${this.i}");
+                `    }
+                `    this.ctx.storage.put("value", this.i + 1);
                 `    return this.i++;
+                `  }
+                `}
+                `export class NestedFacet extends DurableObject {
+                `  increment(name, first) {
+                `    let facet = this.ctx.facets.get(name, {class: this.env.COUNTER});
+                `    return facet.increment(first);
                 `  }
                 `}
             )
           ],
           bindings = [
             (name = "NS", durableObjectNamespace = "MyActorClass"),
-            (name = "COUNTER", durableObjectClass = (name = "hello", entrypoint = "CounterFacet"))
+            (name = "COUNTER", durableObjectClass = (name = "hello", entrypoint = "CounterFacet")),
+            (name = "NESTED", durableObjectClass = (name = "hello", entrypoint = "NestedFacet"))
           ],
           durableObjectNamespaces = [
             ( className = "MyActorClass",
               uniqueKey = "mykey",
             )
           ],
-          durableObjectStorage = (inMemory = void)
+          durableObjectStorage = (localDisk = "my-disk")
+        )
+      ),
+      ( name = "my-disk",
+        disk = (
+          path = "../../do-storage",
+          writable = true,
         )
       ),
     ],
@@ -4746,12 +4783,64 @@ KJ_TEST("Server: Durable Object facets") {
         service = "hello"
       )
     ]
-  ))"_kj);
+  ))"_kj;
 
-  test.server.allowExperimental();
-  test.start();
-  auto conn = test.connect("test-addr");
-  conn.httpGet200("/", "0 1 2 0 3");
+  // Create a directory outside of the test scope which we can use across multiple TestServers.
+  auto dir = kj::newInMemoryDirectory(kj::nullClock());
+
+  {
+    TestServer test(config);
+
+    // Link our directory into the test filesystem.
+    test.root->transfer(
+        kj::Path({"do-storage"_kj}), kj::WriteMode::CREATE, *dir, nullptr, kj::TransferMode::LINK);
+
+    test.server.allowExperimental();
+    test.start();
+    auto conn = test.connect("test-addr");
+    conn.httpGet200("/part1", "0 1 2 0 0 1 3 4");
+  }
+
+  // Verify the expected files exist.
+  auto nsDir = dir->openSubdir(kj::Path({"mykey"}));
+  KJ_EXPECT(nsDir->exists(
+      kj::Path({"3652ef6221834806dc8df802d1d216e27b7d07e0a6b7adf6cfdaeec90f06459a.sqlite"})));
+  KJ_EXPECT(nsDir->exists(
+      kj::Path({"3652ef6221834806dc8df802d1d216e27b7d07e0a6b7adf6cfdaeec90f06459a.1.sqlite"})));
+  KJ_EXPECT(nsDir->exists(
+      kj::Path({"3652ef6221834806dc8df802d1d216e27b7d07e0a6b7adf6cfdaeec90f06459a.2.sqlite"})));
+  KJ_EXPECT(nsDir->exists(
+      kj::Path({"3652ef6221834806dc8df802d1d216e27b7d07e0a6b7adf6cfdaeec90f06459a.3.sqlite"})));
+  KJ_EXPECT(nsDir->exists(
+      kj::Path({"3652ef6221834806dc8df802d1d216e27b7d07e0a6b7adf6cfdaeec90f06459a.4.sqlite"})));
+  KJ_EXPECT(nsDir->exists(
+      kj::Path({"3652ef6221834806dc8df802d1d216e27b7d07e0a6b7adf6cfdaeec90f06459a.facets"})));
+
+  // We should only have created four child facets (foo, bar, bar.foo, bar.bar). No ID 5 should
+  // exist.
+  KJ_EXPECT(!nsDir->exists(
+      kj::Path({"3652ef6221834806dc8df802d1d216e27b7d07e0a6b7adf6cfdaeec90f06459a.5.sqlite"})));
+
+  // We didn't create any other durable objects in the namespace. All files in the namespace should
+  // be prefixed with our one DO ID.
+  for (auto& name: nsDir->listNames()) {
+    KJ_EXPECT(name.startsWith("3652ef6221834806dc8df802d1d216e27b7d07e0a6b7adf6cfdaeec90f06459a."),
+        "unexpected file found in namespace storage", name);
+  }
+
+  // Start a new server, make sure it's able to load the files again.
+  {
+    TestServer test(config);
+
+    // Link our directory into the test filesystem.
+    test.root->transfer(
+        kj::Path({"do-storage"_kj}), kj::WriteMode::CREATE, *dir, nullptr, kj::TransferMode::LINK);
+
+    test.server.allowExperimental();
+    test.start();
+    auto conn = test.connect("test-addr");
+    conn.httpGet200("/part2", "1 2 5");
+  }
 }
 
 }  // namespace

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -4731,6 +4731,20 @@ KJ_TEST("Server: Durable Object facets") {
                 `      let foo = this.ctx.facets.get("foo", {class: this.env.COUNTER});
                 `      results.push(await foo.increment(true));  // increments foo
                 `
+                `      let foo2 = this.ctx.facets.get("foo", {class: this.env.EXFILTRATOR});
+                `      results.push(await foo2.exfiltrate());
+                `
+                `      try {
+                `        await foo.increment();
+                `        throw new Error("broken stub didn't throw?");
+                `      } catch (err) {
+                `        if (err.message != "The facet is restarting because the parent " +
+                `            "specified different parameters to facets.get(). You may need to " +
+                `            "recreate the stub to talk to the new version.") {
+                `          throw err;
+                `        }
+                `      }
+                `
                 `      // Delete bar, which recursively deletes its children.
                 `      this.ctx.facets.delete("bar");
                 `    } else {
@@ -4758,12 +4772,19 @@ KJ_TEST("Server: Durable Object facets") {
                 `    return facet.increment(first);
                 `  }
                 `}
+                `export class ExfiltrationFacet extends DurableObject {
+                `  exfiltrate() {
+                `    return this.ctx.storage.get("value");
+                `  }
+                `}
             )
           ],
           bindings = [
             (name = "NS", durableObjectNamespace = "MyActorClass"),
             (name = "COUNTER", durableObjectClass = (name = "hello", entrypoint = "CounterFacet")),
-            (name = "NESTED", durableObjectClass = (name = "hello", entrypoint = "NestedFacet"))
+            (name = "NESTED", durableObjectClass = (name = "hello", entrypoint = "NestedFacet")),
+            ( name = "EXFILTRATOR",
+              durableObjectClass = (name = "hello", entrypoint = "ExfiltrationFacet") )
           ],
           durableObjectNamespaces = [
             ( className = "MyActorClass",
@@ -4842,7 +4863,7 @@ KJ_TEST("Server: Durable Object facets") {
     test.server.allowExperimental();
     test.start();
     auto conn = test.connect("test-addr");
-    conn.httpGet200("/part2", "1 2 5");
+    conn.httpGet200("/part2", "1 2 5 6");
   }
 
   // Root and foo still exist, bar does not.

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -4730,6 +4730,9 @@ KJ_TEST("Server: Durable Object facets") {
                 `      results.push(await bar.increment("foo", true));  // increments bar.foo
                 `      let foo = this.ctx.facets.get("foo", {class: this.env.COUNTER});
                 `      results.push(await foo.increment(true));  // increments foo
+                `
+                `      // Delete bar, which recursively deletes its children.
+                `      this.ctx.facets.delete("bar");
                 `    } else {
                 `      throw new Error(`bad url: ${request.url}`);
                 `    }
@@ -4841,6 +4844,18 @@ KJ_TEST("Server: Durable Object facets") {
     auto conn = test.connect("test-addr");
     conn.httpGet200("/part2", "1 2 5");
   }
+
+  // Root and foo still exist, bar does not.
+  KJ_EXPECT(nsDir->exists(
+      kj::Path({"3652ef6221834806dc8df802d1d216e27b7d07e0a6b7adf6cfdaeec90f06459a.sqlite"})));
+  KJ_EXPECT(nsDir->exists(
+      kj::Path({"3652ef6221834806dc8df802d1d216e27b7d07e0a6b7adf6cfdaeec90f06459a.1.sqlite"})));
+  KJ_EXPECT(!nsDir->exists(
+      kj::Path({"3652ef6221834806dc8df802d1d216e27b7d07e0a6b7adf6cfdaeec90f06459a.2.sqlite"})));
+  KJ_EXPECT(!nsDir->exists(
+      kj::Path({"3652ef6221834806dc8df802d1d216e27b7d07e0a6b7adf6cfdaeec90f06459a.3.sqlite"})));
+  KJ_EXPECT(!nsDir->exists(
+      kj::Path({"3652ef6221834806dc8df802d1d216e27b7d07e0a6b7adf6cfdaeec90f06459a.4.sqlite"})));
 }
 
 }  // namespace

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -4685,5 +4685,74 @@ KJ_TEST("Server: Catch websocket server errors") {
   }
 }
 
+KJ_TEST("Server: Durable Object facets") {
+  TestServer test(R"((
+    services = [
+      ( name = "hello",
+        worker = (
+          compatibilityDate = "2025-04-01",
+          compatibilityFlags = ["experimental"],
+          modules = [
+            ( name = "main.js",
+              esModule =
+                `import { DurableObject } from "cloudflare:workers";
+                `export default {
+                `  async fetch(request, env, ctx) {
+                `    let id = env.NS.idFromName(request.url);
+                `    let actor = env.NS.get(id);
+                `    return await actor.fetch(request);
+                `  }
+                `}
+                `export class MyActorClass extends DurableObject {
+                `  async fetch(request) {
+                `    let results = [];
+                `    let facet = this.ctx.facets.get("foo", {class: this.env.COUNTER});
+                `    results.push(await facet.increment());
+                `    results.push(await facet.increment());
+                `    results.push(await facet.increment());
+                `
+                `    let facet2 = this.ctx.facets.get("bar", {class: this.env.COUNTER});
+                `    results.push(await facet2.increment());
+                `
+                `    let facet3 = this.ctx.facets.get("foo", {class: this.env.COUNTER});
+                `    results.push(await facet3.increment());
+                `    return new Response(results.join(" "));
+                `  }
+                `}
+                `export class CounterFacet extends DurableObject {
+                `  i = 0;
+                `  increment() {
+                `    return this.i++;
+                `  }
+                `}
+            )
+          ],
+          bindings = [
+            (name = "NS", durableObjectNamespace = "MyActorClass"),
+            (name = "COUNTER", durableObjectClass = (name = "hello", entrypoint = "CounterFacet"))
+          ],
+          durableObjectNamespaces = [
+            ( className = "MyActorClass",
+              uniqueKey = "mykey",
+            )
+          ],
+          durableObjectStorage = (inMemory = void)
+        )
+      ),
+    ],
+    sockets = [
+      ( name = "main",
+        address = "test-addr",
+        service = "hello"
+      )
+    ]
+  ))"_kj);
+
+  test.server.allowExperimental();
+  test.start();
+  auto conn = test.connect("test-addr");
+  conn.httpGet200("/", "0 1 2 0 3");
+}
+
 }  // namespace
 }  // namespace workerd::server

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1849,9 +1849,9 @@ class Server::WorkerService final: public Service,
       }
 
       auto actorClass = kj::refcounted<ActorClassImpl>(*this, entry.key, kj::none);
-      auto ns = kj::heap<ActorNamespace>(kj::mv(actorClass), entry.value,
-          threadContext.getUnsafeTimer(), threadContext.getByteStreamFactory(),
-          network, dockerPath);
+      auto ns =
+          kj::heap<ActorNamespace>(kj::mv(actorClass), entry.value, threadContext.getUnsafeTimer(),
+              threadContext.getByteStreamFactory(), network, dockerPath);
       actorNamespaces.insert(entry.key, kj::mv(ns));
     }
   }
@@ -2280,9 +2280,8 @@ class Server::WorkerService final: public Service,
       kj::Own<ActorContainer> getFacetContainer(
           kj::String childKey, Worker::Actor::Id childId, kj::Own<ActorClass> childActorClass) {
         auto makeContainer = [&]() {
-          return kj::refcounted<ActorContainer>(
-              kj::mv(childKey), kj::mv(childId), ns, *this, kj::mv(childActorClass), timer,
-              byteStreamFactory);
+          return kj::refcounted<ActorContainer>(kj::mv(childKey), kj::mv(childId), ns, *this,
+              kj::mv(childActorClass), timer, byteStreamFactory);
         };
 
         bool isNew = false;
@@ -2626,8 +2625,7 @@ class Server::WorkerService final: public Service,
               containerId = kj::str(existingId);
             }
           }
-          containerClient = kj::heap<ContainerClient>(byteStreamFactory, timer,
-              ns.dockerNetwork,
+          containerClient = kj::heap<ContainerClient>(byteStreamFactory, timer, ns.dockerNetwork,
               kj::str(dockerPathRef),
               kj::str("workerd-", KJ_ASSERT_NONNULL(uniqueKey), "-", containerId),
               kj::str(imageName), service.waitUntilTasks);
@@ -2657,9 +2655,8 @@ class Server::WorkerService final: public Service,
 
       return actors
           .findOrCreate(key, [&]() mutable {
-        auto container = kj::refcounted<ActorContainer>(
-            kj::mv(key), kj::mv(id), *this, kj::none, kj::addRef(*actorClass), timer,
-            byteStreamFactory);
+        auto container = kj::refcounted<ActorContainer>(kj::mv(key), kj::mv(id), *this, kj::none,
+            kj::addRef(*actorClass), timer, byteStreamFactory);
 
         return kj::HashMap<kj::StringPtr, kj::Own<ActorContainer>>::Entry{
           container->getKey(), kj::mv(container)};

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -155,6 +155,7 @@ class Server final: private kj::TaskSet::ErrorHandler {
   kj::Own<Service> invalidConfigServiceSingleton;
 
   class ActorClass;
+  kj::Own<ActorClass> invalidConfigActorClassSingleton;
 
   // Information about all known actor namespaces. Maps serviceName -> className -> config.
   // This needs to be populated in advance of constructing any services, in order to be able to
@@ -231,12 +232,18 @@ class Server final: private kj::TaskSet::ErrorHandler {
   kj::Own<Service> lookupService(
       config::ServiceDesignator::Reader designator, kj::String errorContext);
 
+  // Like lookupService() but looks up an actor class (especially for use as a facet class).
+  // Returns none on a config error.
+  kj::Own<ActorClass> lookupActorClass(
+      config::ServiceDesignator::Reader designator, kj::String errorContext);
+
   kj::Promise<void> listenHttp(kj::Own<kj::ConnectionReceiver> listener,
       kj::Own<Service> service,
       kj::StringPtr physicalProtocol,
       kj::Own<HttpRewriter> rewriter);
 
   class InvalidConfigService;
+  class InvalidConfigActorClass;
   class ExternalHttpService;
   class ExternalTcpService;
   class NetworkService;

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -154,6 +154,8 @@ class Server final: private kj::TaskSet::ErrorHandler {
   class Service;
   kj::Own<Service> invalidConfigServiceSingleton;
 
+  class ActorClass;
+
   // Information about all known actor namespaces. Maps serviceName -> className -> config.
   // This needs to be populated in advance of constructing any services, in order to be able to
   // correctly construct dependent services.

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -969,6 +969,10 @@ static v8::Local<v8::Value> createBindingValue(JsgWorkerdIsolate::Lock& lock,
     KJ_CASE_ONEOF(unsafe, Global::UnsafeEval) {
       value = lock.wrap(context, lock.alloc<api::UnsafeEval>());
     }
+
+    KJ_CASE_ONEOF(actorClass, Global::ActorClass) {
+      value = lock.wrap(context, lock.alloc<api::DurableObjectClass>(actorClass.channel));
+    }
   }
 
   return value;
@@ -1054,6 +1058,10 @@ WorkerdApi::Global WorkerdApi::Global::clone() const {
     }
     KJ_CASE_ONEOF(unsafe, Global::UnsafeEval) {
       result.value = Global::UnsafeEval{};
+    }
+
+    KJ_CASE_ONEOF(actorClass, Global::ActorClass) {
+      result.value = actorClass.clone();
     }
   }
 

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -226,6 +226,15 @@ class WorkerdApi final: public Worker::Api {
       }
     };
     struct UnsafeEval {};
+
+    struct ActorClass {
+      uint channel;
+
+      ActorClass clone() const {
+        return *this;
+      }
+    };
+
     kj::String name;
     kj::OneOf<Json,
         Fetcher,
@@ -242,7 +251,8 @@ class WorkerdApi final: public Worker::Api {
         AnalyticsEngine,
         Hyperdrive,
         UnsafeEval,
-        MemoryCache>
+        MemoryCache,
+        ActorClass>
         value;
 
     Global clone() const;

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -354,6 +354,10 @@ struct Worker {
       service @9 :ServiceDesignator;
       # Binding to a named service (possibly, a worker).
 
+      durableObjectClass @26 :ServiceDesignator;
+      # A Durable Object class binding, without an actual storage namespace. This can be used to
+      # implement a facet.
+
       durableObjectNamespace @10 :DurableObjectNamespaceDesignator;
       # Binding to the durable object namespace implemented by the given class.
       #
@@ -438,6 +442,7 @@ struct Worker {
         queue @11 :Void;
         analyticsEngine @12 : Void;
         hyperdrive @13: Void;
+        durableObjectClass @14: Void;
       }
     }
 

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -562,12 +562,14 @@ type DurableObjectLocationHint =
 interface DurableObjectNamespaceGetDurableObjectOptions {
   locationHint?: DurableObjectLocationHint;
 }
+interface DurableObjectClass {}
 interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   exports: any;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
   container?: Container;
+  facets: DurableObjectFacets;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -684,6 +686,15 @@ declare class WebSocketRequestResponsePair {
   constructor(request: string, response: string);
   get request(): string;
   get response(): string;
+}
+interface DurableObjectFacets {
+  get(name: string, options: DurableObjectFacetsGetOptions): Fetcher;
+  abort(name: string, reason: any): void;
+  delete(name: string): void;
+}
+interface DurableObjectFacetsGetOptions {
+  $class: DurableObjectClass;
+  id?: DurableObjectId | string;
 }
 interface AnalyticsEngineDataset {
   writeDataPoint(event?: AnalyticsEngineDataPoint): void;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -567,12 +567,14 @@ export type DurableObjectLocationHint =
 export interface DurableObjectNamespaceGetDurableObjectOptions {
   locationHint?: DurableObjectLocationHint;
 }
+export interface DurableObjectClass {}
 export interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   exports: any;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
   container?: Container;
+  facets: DurableObjectFacets;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -689,6 +691,15 @@ export declare class WebSocketRequestResponsePair {
   constructor(request: string, response: string);
   get request(): string;
   get response(): string;
+}
+export interface DurableObjectFacets {
+  get(name: string, options: DurableObjectFacetsGetOptions): Fetcher;
+  abort(name: string, reason: any): void;
+  delete(name: string): void;
+}
+export interface DurableObjectFacetsGetOptions {
+  $class: DurableObjectClass;
+  id?: DurableObjectId | string;
 }
 export interface AnalyticsEngineDataset {
   writeDataPoint(event?: AnalyticsEngineDataPoint): void;


### PR DESCRIPTION
This is a new experimental Durable Objects feature. It requires the `--experimental` CLI flag and `experimental` compat flag to use. I fully expect that we may end up changing the design once we've played with it, and that's fine. This isn't intended to become generally available any time soon.

## Feature Specification

Multifaceted Durable Objects are Durable Objects (DOs) which are composed of multiple "facets" implemented by different isolates. Each facet is written like a regular DO class, but all the facets run together on the same machine to implement the DO. Each facet has its own storage in the form of a SQLite database, but these databases are all stored together as one logical object.

A multifaceted DO has a "main" facet which implements its public interface. This works exactly like a regular Durable Object. The main facet's implementation can call out to other "facets" as needed, using `ctx.facets`:

```js
// The main interface to manage facets is on `ctx`.
let facets = this.ctx.facets;

// Each facet has a name, which identifies its respective slice of storage. Names are hierarchical:
// if the main facet creates a facet called "foo", and that facet in turn creates a facet called
// "bar", the latter facet's true name is "foo/bar". A facet cannot directly access its siblings,
// unless the common parent facet chooses to pass references explicitly.
//
// Names are limited to 128 characters and cannot contain control characters nor `/`.
let name = "foo";

// To use a facet, pass the name to `this.ctx.facets.get()`.
//
// The second parameter specifies information needed to start up the facet. If the facet is already
// running, and matches the given parameters, the already-running instance is returned. If the
// parameters have changed, then the existing instance will shut down and will reload using the
// new parameters.
//
// Like with regular Durable Objects, there is no explicit "create" operation for a facet. It is
// implicitly created when first used, and is implicitly deleted if it shuts down with nothing left
// in storage.
let facet = this.ctx.facets.get(name, {
  // The class to use. This is a facet binding, which points to a class that may be defined
  // in a different Worker. As usual, ctx.exports can be used to refer to other classes
  // exported by the current worker. Dynamic Dispatch can also look up facets using
  // `getFacetClass`.
  class: this.env.FOO_FACET_CLASS,

  // The value that the facet sees in `ctx.id`. This can be a real Durable Object ID or a plain
  // string. In this example, the parent uses the facet name as the ID, but this may or may not
  // make sense depending on the use case. If not specified, defaults to inheriting the parent's
  // ID.
  id: name
});

// `facet` acts like a DO stub, except all calls are local.
await facet.someRpcMethod();

// `facets.abort()` forcefully aborts the facet immediately. No further code will execute in the
// facet until it is started again. The next call to `facets.get()` is guaranteed to call the
// callback and start a new instance. `reason` is thrown by any outstanding or future RPC calls
// on existing stubs pointing into the facet.
//
// This also transitively aborts all children of the facet.
this.ctx.facets.abort(name, reason);

// Deleting a facet aborts the facet if it is running and then deletes its underlying storage. This
// applies transitively to all children as well.
this.ctx.facets.delete(name);

// Note that `storage.deleteAll()` deletes all facets in addition to regular storage.
this.ctx.storage.deleteAll();
```

Notes:
* When any running facet becomes "broken", the entire actor breaks and will restart. There is currently no mechanism to catch errors in the parent, though one might be added in the future. As a special exception, if a facet becomes broken because a parent used `facets.abort()` or `facets.delete()` on it, this does not break the entire actor, only the specific facet.

## Storage Details

In workerd, a DO's main database has always been stored in a file called `<actor-id>.sqlite`. Each non-root facet is stored in a separate file `<actor-id>.<facet-id>.sqlite`, where `<facet-id>` is a small integer assigned to each facet. An index of facet IDs is maintained in a separate file, `<actor-id>.facets`. This file contains a simple capnp-encoded representation of the facet tree, covering at least all facets for which files exist on disk. This index enables us to avoid encoding facet names into file names, and makes it possible to list and delete facets without performing a full directory listing (which may contain files for unrelated actors).

In production (not yet implemented), facets will only be supported when using SRS to store actor data (not the old storage backend). Each facet is stored as a separate SRS "lane". Lane names are prefixed by their facet path, which is the list of facet names leading from the root to the specific facet, separated by `/` characters.