### PR TITLE
add `WORKERD_ENABLE_ALL_AUTOGATES` env variable

### DIFF
--- a/build/fixtures/BUILD.bazel
+++ b/build/fixtures/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["kj_test.sh"])

--- a/build/fixtures/kj_test.sh
+++ b/build/fixtures/kj_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+"$@"

--- a/src/workerd/api/actor-state-test.c++
+++ b/src/workerd/api/actor-state-test.c++
@@ -29,7 +29,6 @@ struct ActorStateContext: public jsg::Object, public jsg::ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(ActorStateIsolate, ActorStateContext);
 
 KJ_TEST("v8 serialization version tag hasn't changed") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   jsg::test::Evaluator<ActorStateContext, ActorStateIsolate> e(v8System);
   e.getIsolate().runInLockScope([&](ActorStateIsolate::Lock& isolateLock) {
     JSG_WITHIN_CONTEXT_SCOPE(isolateLock,

--- a/src/workerd/api/basics-test.c++
+++ b/src/workerd/api/basics-test.c++
@@ -87,7 +87,6 @@ JSG_DECLARE_ISOLATE_TYPE(BasicsIsolate,
     jsg::TypeWrapperExtension<PromiseWrapper>);
 
 KJ_TEST("EventTarget native listeners work") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   jsg::test::Evaluator<BasicsContext, BasicsIsolate, CompatibilityFlags::Reader> e(v8System);
   e.expectEval("testNativeListenersWork()", "boolean", "true");
 }

--- a/src/workerd/api/crypto/aes-test.c++
+++ b/src/workerd/api/crypto/aes-test.c++
@@ -25,7 +25,6 @@ struct CryptoContext: public jsg::Object, public jsg::ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(CryptoIsolate, CryptoContext);
 
 KJ_TEST("AES-KW key wrap") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   // Basic test that I wrote when I was seeing heap corruption. Found it easier to iterate on with
   // ASAN/valgrind than using our conformance tests with test-runner.
   jsg::test::Evaluator<CryptoContext, CryptoIsolate> e(v8System);

--- a/src/workerd/api/form-data-memory-test.c++
+++ b/src/workerd/api/form-data-memory-test.c++
@@ -91,7 +91,6 @@ JSG_DECLARE_ISOLATE_TYPE(HeadersIsolate,
     workerd::api::File::Options);
 
 KJ_TEST("FormData memory is accounted for") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   jsg::test::Evaluator<HeadersContext, HeadersIsolate, CompatibilityFlags::Reader> e(v8System);
   e.expectEval("test()", "boolean", "true");
 }

--- a/src/workerd/api/headers-test.c++
+++ b/src/workerd/api/headers-test.c++
@@ -96,7 +96,6 @@ JSG_DECLARE_ISOLATE_TYPE(HeadersIsolate,
     jsg::TypeWrapperExtension<PromiseWrapper>);
 
 KJ_TEST("Header memory is accounted for") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   jsg::test::Evaluator<HeadersContext, HeadersIsolate, CompatibilityFlags::Reader> e(v8System);
   e.expectEval("test()", "boolean", "true");
 }

--- a/src/workerd/api/streams/queue-test.c++
+++ b/src/workerd/api/streams/queue-test.c++
@@ -106,7 +106,6 @@ auto getEntry(jsg::Lock& js, auto size) {
 #pragma region ValueQueue Tests
 
 KJ_TEST("ValueQueue basics work") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   preamble([](jsg::Lock& js) {
     ValueQueue queue(2);
 

--- a/src/workerd/api/streams/standard-test.c++
+++ b/src/workerd/api/streams/standard-test.c++
@@ -41,7 +41,6 @@ jsg::BufferSource toBufferSource(jsg::Lock& js, kj::Array<kj::byte> bytes) {
 // Happy Cases
 
 KJ_TEST("ReadableStream read all text (value readable)") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());

--- a/src/workerd/io/frankenvalue-test.c++
+++ b/src/workerd/io/frankenvalue-test.c++
@@ -18,7 +18,6 @@ struct TestContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(TestIsolate, TestContext);
 
 KJ_TEST("Frankenvalue") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   jsg::test::Evaluator<TestContext, TestIsolate> e(v8System);
 
   e.run([&](jsg::Lock& js) {

--- a/src/workerd/io/promise-wrapper-test.c++
+++ b/src/workerd/io/promise-wrapper-test.c++
@@ -84,7 +84,6 @@ JSG_DECLARE_ISOLATE_TYPE(
     CaptureThrowIsolate, CaptureThrowContext, jsg::TypeWrapperExtension<workerd::PromiseWrapper>);
 
 KJ_TEST("Async functions capture sync errors with flag") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<CaptureThrowContext, CaptureThrowIsolate> e(v8System);
   e.setCaptureThrowsAsRejections(true);
   e.expectEval("test1()", "object", "[object Promise]");

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -280,10 +280,7 @@ wd_cc_library(
 [kj_test(
     src = f,
     local_defines = ["JSG_IMPLEMENTATION"],
-    deps = [
-        ":jsg",
-        "//src/workerd/util:autogate",
-    ],
+    deps = [":jsg"],
 ) for f in glob(
     ["*-test.c++"],
     exclude = [

--- a/src/workerd/jsg/buffersource-test.c++
+++ b/src/workerd/jsg/buffersource-test.c++
@@ -65,7 +65,6 @@ struct BufferSourceContext: public jsg::Object, public jsg::ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(BufferSourceIsolate, BufferSourceContext);
 
 KJ_TEST("BufferSource works") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<BufferSourceContext, BufferSourceIsolate> e(v8System);
 
   // By default, a BufferSource handle is created as a DataView

--- a/src/workerd/jsg/dom-exception-test.c++
+++ b/src/workerd/jsg/dom-exception-test.c++
@@ -18,7 +18,6 @@ struct DOMExceptionContext: public Object, public ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(DOMExceptionIsolate, DOMExceptionContext);
 
 KJ_TEST("DOMException's prototype is ErrorPrototype") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<DOMExceptionContext, DOMExceptionIsolate> e(v8System);
   e.expectEval(
       "Object.getPrototypeOf(DOMException.prototype) === Error.prototype", "boolean", "true");

--- a/src/workerd/jsg/function-test.c++
+++ b/src/workerd/jsg/function-test.c++
@@ -44,7 +44,6 @@ struct CallbackContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(CallbackIsolate, CallbackContext, CallbackContext::Frobber, NumberBox);
 
 KJ_TEST("callbacks") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<CallbackContext, CallbackIsolate> e(v8System);
   e.expectEval("callCallback((str, num) => {\n"
                "  return [typeof str, str, typeof num, num.toString(), 'bar'].join(', ');\n"

--- a/src/workerd/jsg/iterator-test.c++
+++ b/src/workerd/jsg/iterator-test.c++
@@ -191,7 +191,6 @@ struct GeneratorContext: public Object, public ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(GeneratorIsolate, GeneratorContext, GeneratorContext::Test);
 
 KJ_TEST("Generator works") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<GeneratorContext, GeneratorIsolate> e(v8System);
 
   e.expectEval("generatorTest([undefined,2,3])", "number", "2");

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -43,7 +43,6 @@ struct TestContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(TestIsolate, TestContext);
 
 KJ_TEST("hello world") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<TestContext, TestIsolate> e(v8System);
   e.expectEval("'Hello' + ', World!'", "string", "Hello, World!");
 }

--- a/src/workerd/jsg/jsvalue-test.c++
+++ b/src/workerd/jsg/jsvalue-test.c++
@@ -109,7 +109,6 @@ struct JsValueContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(JsValueIsolate, JsValueContext, JsValueContext::Foo);
 
 KJ_TEST("simple") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<JsValueContext, JsValueIsolate> e(v8System);
   e.expectEval("takeJsValue(false)", "boolean", "false");
   e.expectEval("takeJsString(123)", "string", "123");

--- a/src/workerd/jsg/memory-test.c++
+++ b/src/workerd/jsg/memory-test.c++
@@ -40,7 +40,6 @@ void runTest(auto callback) {
 }
 
 KJ_TEST("MemoryTracker test") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   // Verifies that workerd details are included in the heapsnapshot.
   // This is not a comprehensive test of the heapsnapshot content,
   // it is designed just to make sure that we are, in fact, publishing

--- a/src/workerd/jsg/modules-new-test.c++
+++ b/src/workerd/jsg/modules-new-test.c++
@@ -752,8 +752,6 @@ KJ_TEST("Bundle shadows built-in") {
 // ======================================================================================
 
 KJ_TEST("Attaching a module registry works") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
-
   PREAMBLE(([&](Lock& js) {
     ResolveObserver resolveObserver;
     CompilationObserver compilationObserver;

--- a/src/workerd/jsg/multiple-typewrappers-test.c++
+++ b/src/workerd/jsg/multiple-typewrappers-test.c++
@@ -137,7 +137,6 @@ void expectEval(
 }
 
 KJ_TEST("Create a context with a configuration then create a default context with another") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   capnp::MallocMessageBuilder flagsArena;
   auto flags = flagsArena.initRoot<::workerd::CompatibilityFlags>();
   auto flagsReader = flags.asReader();

--- a/src/workerd/jsg/promise-test.c++
+++ b/src/workerd/jsg/promise-test.c++
@@ -118,7 +118,6 @@ struct PromiseContext: public jsg::Object, public jsg::ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(PromiseIsolate, PromiseContext);
 
 KJ_TEST("jsg::Promise<T>") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<PromiseContext, PromiseIsolate> e(v8System);
 
   e.expectEval("setResult(promise.then(i => i + 1 /* oops, i is a string */));\n"

--- a/src/workerd/jsg/resource-test.c++
+++ b/src/workerd/jsg/resource-test.c++
@@ -21,7 +21,6 @@ struct BoxContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(BoxIsolate, BoxContext, NumberBox, BoxBox);
 
 KJ_TEST("constructors and properties") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<BoxContext, BoxIsolate> e(v8System);
   e.expectEval("new NumberBox(123).value", "number", "123");
   e.expectEval("new NumberBox(123).boxed.value", "number", "123");

--- a/src/workerd/jsg/rtti-test.c++
+++ b/src/workerd/jsg/rtti-test.c++
@@ -215,7 +215,6 @@ struct TestResource: public Base {
 };
 
 KJ_TEST("resource reference") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   KJ_EXPECT(tType<TestResource>() ==
       "(structure = (name = \"TestResource\", fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestResource\"))");
 }

--- a/src/workerd/jsg/ser-test.c++
+++ b/src/workerd/jsg/ser-test.c++
@@ -238,7 +238,6 @@ struct SerTestContextV2: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(SerTestIsolateV2, SerTestContextV2, SerTestContextV2::Bar);
 
 KJ_TEST("serialization") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<SerTestContext, SerTestIsolate> e(v8System);
 
   // Test serializing built-in values.

--- a/src/workerd/jsg/setup-test.c++
+++ b/src/workerd/jsg/setup-test.c++
@@ -15,7 +15,6 @@ struct EvalContext: public Object, public ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(EvalIsolate, EvalContext);
 
 KJ_TEST("eval() is blocked") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<EvalContext, EvalIsolate> e(v8System);
   e.expectEval("eval('123')", "throws",
       "EvalError: Code generation from strings disallowed for this context");

--- a/src/workerd/jsg/struct-test.c++
+++ b/src/workerd/jsg/struct-test.c++
@@ -42,7 +42,6 @@ struct StructContext: public Object, public ContextGlobal {
 JSG_DECLARE_ISOLATE_TYPE(StructIsolate, StructContext, NumberBox, TestStruct, SelfStruct);
 
 KJ_TEST("structs") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<StructContext, StructIsolate> e(v8System);
   e.expectEval(
       "readTestStruct({str: 'foo', num: 123, box: new NumberBox(456)})", "string", "foo, 123, 456");

--- a/src/workerd/jsg/tracing-test.c++
+++ b/src/workerd/jsg/tracing-test.c++
@@ -165,7 +165,6 @@ JSG_DECLARE_ISOLATE_TYPE(TraceTestIsolate,
     ValueBox);
 
 KJ_TEST("GC collects objects when expected") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<TraceTestContext, TraceTestIsolate> e(v8System);
 
   // Test that a full GC can collect native objects.

--- a/src/workerd/jsg/type-wrapper-test.c++
+++ b/src/workerd/jsg/type-wrapper-test.c++
@@ -61,7 +61,6 @@ class TestExtension {
 JSG_DECLARE_ISOLATE_TYPE(ExtensionIsolate, ExtensionContext, TypeWrapperExtension<TestExtension>);
 
 KJ_TEST("extensions") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<ExtensionContext, ExtensionIsolate> e(v8System);
   e.expectEval("fromExtensionType(toExtensionType(12.3))", "number", "12");
 }

--- a/src/workerd/jsg/util-test.c++
+++ b/src/workerd/jsg/util-test.c++
@@ -23,7 +23,6 @@ struct FreezeContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(FreezeIsolate, FreezeContext);
 
 KJ_TEST("recursive freezing") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<FreezeContext, FreezeIsolate> e(v8System);
   e.expectEval("let obj = { foo: [ { bar: 1 } ] };\n"
                "recursivelyFreeze(obj);\n"

--- a/src/workerd/jsg/value-test.c++
+++ b/src/workerd/jsg/value-test.c++
@@ -21,7 +21,6 @@ struct BoolContext: public ContextGlobalObject {
 JSG_DECLARE_ISOLATE_TYPE(BoolIsolate, BoolContext);
 
 KJ_TEST("bool") {
-  util::Autogate::initAutogateNamesForTest({"v8-fast-api"_kj});
   Evaluator<BoolContext, BoolIsolate> e(v8System);
   e.expectEval("takeBool(false)", "string", "false");
   e.expectEval("takeBool(true)", "string", "true");

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -25,7 +25,6 @@
 #include <workerd/io/worker-interface.h>
 #include <workerd/io/worker.h>
 #include <workerd/server/actor-id-impl.h>
-#include <workerd/util/autogate.h>
 #include <workerd/util/http-util.h>
 #include <workerd/util/mimetype.h>
 #include <workerd/util/use-perfetto-categories.h>

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -5,6 +5,8 @@
 
 #include <workerd/util/sentry.h>
 
+#include <stdlib.h>
+
 #include <capnp/message.h>
 #include <kj/common.h>
 #include <kj/debug.h>
@@ -51,9 +53,9 @@ bool Autogate::isEnabled(AutogateKey key) {
   KJ_IF_SOME(a, globalAutogate) {
     return a.gates[(unsigned long)key];
   }
-  LOG_ERROR_PERIODICALLY(
-      kj::str("Autogates not initialised, check for ", key, " will have no effect"));
-  return false;
+
+  static const bool defaultResult = getenv("WORKERD_ALL_AUTOGATES") != nullptr;
+  return defaultResult;
 }
 
 void Autogate::initAutogate(capnp::List<capnp::Text>::Reader gates) {


### PR DESCRIPTION
Ref: https://github.com/cloudflare/workerd/issues/4089

Adds an environment variable called "WORKERD_ENABLE_ALL_AUTOGATES" which enables all autogates regardless of what's set in the config. This is beneficial for testing.