### PR TITLE
Refactor: Give Worker::Script::ScriptSource same treatment as ModulesSource.

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1321,7 +1321,7 @@ Worker::Script::Script(kj::Own<const Isolate> isolateParam,
                 // This path is used for the older, service worker syntax workers.
 
                 impl->globals =
-                    script.compileGlobals(lock, isolate->getApi(), isolate->getApi().getObserver());
+                    isolate->getApi().compileServiceWorkerGlobals(lock, script, *isolate);
 
                 {
                   // It's unclear to me if CompileUnboundScript() can get trapped in any

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -74,6 +74,10 @@ class WorkerdApi final: public Worker::Api {
       const Worker::Isolate& isolate,
       kj::Maybe<kj::Own<api::pyodide::ArtifactBundler_State>> artifacts) const override;
 
+  kj::Array<Worker::Script::CompiledGlobal> compileServiceWorkerGlobals(jsg::Lock& lock,
+      const Worker::Script::ScriptSource& source,
+      const Worker::Isolate& isolate) const override;
+
   // A pipeline-level binding.
   struct Global {
     // TODO(cleanup): Get rid of this and just load from config.Worker.bindings capnp structure
@@ -275,11 +279,6 @@ class WorkerdApi final: public Worker::Api {
  private:
   struct Impl;
   kj::Own<Impl> impl;
-
-  kj::Array<Worker::Script::CompiledGlobal> compileScriptGlobals(jsg::Lock& lock,
-      config::Worker::Reader conf,
-      Worker::ValidationErrorReporter& errorReporter,
-      const jsg::CompilationObserver& observer) const;
 };
 
 kj::Maybe<jsg::Bundle::Reader> fetchPyodideBundle(


### PR DESCRIPTION
This is a continuation of #4082. I had left `ScriptSource` still containing a weird callback because I didn't think I needed to update it. Turns out I do actually need to update it to avoid some ugliness later.

Luckily this turned out to be a much smaller refactor. I would have done it in the first place had I realized.