### PR TITLE
ignore llvm20 warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -53,6 +53,9 @@ build --host_per_file_copt=external/com_google_protobuf@-Wno-deprecated-this-cap
 ## simdutf
 build --per_file_copt=external/simdutf@-Wno-unused-const-variable
 
+# TODO(cleanup): New LLVM 20 warning, fix and enable again
+build --copt=-Wno-nontrivial-memcall
+
 # Increasing the optimization level of some portions of V8 significantly speeds up Python tests in
 # GitHub Actions. This is an optional performance hack intended for CI, although it might also be
 # useful for local development.
@@ -283,6 +286,9 @@ build:linux --copt="-fdata-sections" --host_copt="-fdata-sections"
 
 # On Linux, use clang lld.
 build:linux --linkopt="-fuse-ld=lld"
+
+# Disable LLVM 20 warning about unused cli argument "-c".
+build:linux --copt='-Wno-unused-command-line-argument' --copt='-Wno-unknown-warning-option' --host_copt='-Wno-unused-command-line-argument' --host_copt='-Wno-unknown-warning-option'
 
 #
 # Windows


### PR DESCRIPTION
When using LLVM20, we receive certain errors. This follows the same pattern of EW changes.