### PR TITLE
Fixes wrapping of Python to Python calls.

### DIFF
--- a/src/pyodide/types/Pyodide.d.ts
+++ b/src/pyodide/types/Pyodide.d.ts
@@ -20,7 +20,10 @@ interface PyModule {
 
 interface Pyodide {
   _module: Module;
-  runPython: (code: string, opts?: { globals?: PyDict }) => any;
+  runPython: (
+    code: string,
+    opts?: { globals?: PyDict; filename?: string }
+  ) => any;
   registerJsModule: (handle: string, mod: object) => void;
   pyimport: (moduleName: string) => PyModule;
   FS: FS;


### PR DESCRIPTION
Turns out we are incorrectly wrapping calls within RPC classes. This PR fixes that.

### Test Plan

```
bazel run @workerd//src/workerd/server/tests/python:durable-object_development@
```