### PR TITLE
Put AbortSignal RPC behind a compat flag

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -7,6 +7,7 @@
 #include "actor-state.h"
 #include "global-scope.h"
 
+#include <workerd/io/features.h>
 #include <workerd/io/io-context.h>
 
 #include <capnp/message.h>
@@ -818,10 +819,11 @@ void AbortSignal::triggerAbort(
 }
 
 void AbortSignal::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
+  JSG_REQUIRE(FeatureFlags::get(js).getAbortSignalRpc(), DOMDataCloneError,
+      "AbortSignal serialization is not enabled.");
+
   auto& handler = JSG_REQUIRE_NONNULL(serializer.getExternalHandler(), DOMDataCloneError,
       "AbortSignal can only be serialized for RPC.");
-
-  LOG_PERIODICALLY(WARNING, "NOSENTRY An AbortSignal was serialized for RPC");
 
   auto externalHandler = dynamic_cast<RpcSerializerExternalHandler*>(&handler);
   JSG_REQUIRE(

--- a/src/workerd/api/tests/abortsignal-test.wd-test
+++ b/src/workerd/api/tests/abortsignal-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "abortsignal-test.js")
         ],
         compatibilityDate = "2025-01-01",
-        compatibilityFlags = ["nodejs_compat", "experimental"],
+        compatibilityFlags = ["nodejs_compat", "enable_abortsignal_rpc", "experimental"],
         bindings = [
           (name = "RpcRemoteEnd", service = (name = "abortsignal-test", entrypoint = "RpcRemoteEnd")),
         ]

--- a/src/workerd/api/tests/js-rpc-socket-test.wd-test
+++ b/src/workerd/api/tests/js-rpc-socket-test.wd-test
@@ -13,7 +13,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "js-rpc-test.js")
         ],
         compatibilityDate = "2024-01-01",
-        compatibilityFlags = ["nodejs_compat","fetcher_no_get_put_delete","experimental"],
+        compatibilityFlags = ["nodejs_compat","fetcher_no_get_put_delete","enable_abortsignal_rpc","experimental"],
         bindings = [
           (name = "self", service = "nonClass-loop"),
           (name = "MyService", service = "MyService-loop"),

--- a/src/workerd/api/tests/js-rpc-test.wd-test
+++ b/src/workerd/api/tests/js-rpc-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "js-rpc-test.js")
         ],
         compatibilityDate = "2024-01-01",
-        compatibilityFlags = ["nodejs_compat","fetcher_no_get_put_delete","experimental"],
+        compatibilityFlags = ["nodejs_compat","fetcher_no_get_put_delete","enable_abortsignal_rpc","experimental"],
         bindings = [
           (name = "self", service = (name = "js-rpc-test", entrypoint = "nonClass")),
           (name = "MyService", service = (name = "js-rpc-test", entrypoint = "MyService")),

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -755,4 +755,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $experimental;
   # Enables the experimental Web File System API.
   # WARNING: This API is still in development and may change or be removed in the future.
+
+  abortSignalRpc @88 :Bool
+      $compatEnableFlag("enable_abortsignal_rpc")
+      $experimental;
+  # Enables experimental support for passing AbortSignal over RPC.
 }


### PR DESCRIPTION
There were zero instances of the log message "An AbortSignal was serialized for RPC" over the weekend, so it seems like no one was relying on this feature.

Put it behind the compat flag `enable_abortsignal_rpc` so as to avoid users being surprised by odd behaviours.