### PR TITLE
enable eval() and new Function on startup

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -716,3 +716,9 @@ wd_test(
     args = ["--experimental"],
     data = ["tests/webfs-test.js"],
 )
+
+wd_test(
+    src = "tests/worker-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/worker-test.js"],
+)

--- a/src/workerd/api/tests/worker-test.js
+++ b/src/workerd/api/tests/worker-test.js
@@ -1,0 +1,27 @@
+import { throws, rejects, strictEqual } from 'node:assert';
+
+// We allow eval and new Function() during startup (global scope evaluation).
+strictEqual(eval('1+1'), 2); // should work
+const StartupFunction = new Function('return 1+1');
+strictEqual(StartupFunction(), 2); // should work
+await Promise.resolve();
+strictEqual(eval('1+1'), 2); // should still work
+const StartupFunction2 = new Function('return 2+2');
+strictEqual(StartupFunction2(), 4); // should still work
+strictEqual((await import('module-does-eval')).default, 2); // should work
+
+export const testStartupEval = {
+  async test() {
+    throws(() => eval('console.log("This should not work")'), {
+      message: /Code generation from strings disallowed for this context/,
+    });
+
+    throws(() => new Function('console.log("This should not work")'), {
+      message: /Code generation from strings disallowed for this context/,
+    });
+
+    await rejects(() => import('another-module-does-eval'), {
+      message: /Code generation from strings disallowed for this context/,
+    });
+  },
+};

--- a/src/workerd/api/tests/worker-test.wd-test
+++ b/src/workerd/api/tests/worker-test.wd-test
@@ -1,0 +1,20 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "worker-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "worker-test.js"),
+          (name = "module-does-eval", esModule = "export default eval('1+1')"),
+          (name = "another-module-does-eval", esModule = "export default eval('2+2')"),
+        ],
+        compatibilityDate = "2025-05-13",
+        compatibilityFlags = [
+          "nodejs_compat",
+          "allow_eval_during_startup",
+        ]
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -762,4 +762,10 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatEnableFlag("enable_abortsignal_rpc")
       $experimental;
   # Enables experimental support for passing AbortSignal over RPC.
+
+  allowEvalDuringStartup @89 :Bool
+      $compatEnableFlag("allow_eval_during_startup")
+      $compatEnableDate("2025-06-01")
+      $compatDisableFlag("disallow_eval_during_startup");
+  # Enables eval() and new Function() during startup.
 }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1652,6 +1652,14 @@ Worker::Worker(kj::Own<const Script> scriptParam,
             // evaluation is complete.
             TmpDirStoreScope tmpDirStoreScope;
 
+            // We allow eval and new Function() during startup, becaues startup time is entirely
+            // deterministic, so we can easily reproduce the input to eval() by just running the
+            // worker again. We do not allow eval() at runtime because we need to have a record of
+            // all code that executes in production for forensic purposes, and at runtime the input
+            // to eval() could have come from a remote source on which we don't have a record.
+            js.setAllowEval(FeatureFlags::get(js).getAllowEvalDuringStartup());
+            KJ_DEFER(js.setAllowEval(false));
+
             KJ_SWITCH_ONEOF(script->impl->unboundScriptOrMainModule) {
               KJ_CASE_ONEOF(unboundScript, jsg::NonModuleScript) {
                 auto limitScope =


### PR DESCRIPTION
Enables the usage of `eval()` and `new Function()` on startup phase of the main module. Potentially enabling libraries such as Fastify to be used within Cloudflare Workers.

Starting June 1st, 2025, the following code works:

```js
strictEqual(eval('1+1'), 2);
// or even this
strictEqual((await import('module-that-has-eval-in-it)).default, 2);

export default {
  async fetch(request, env, ctx) {
    return new Response('Hello World!');
  },
};
```