### PR TITLE
Add compile-time serializability checks

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -1028,7 +1028,7 @@ kj::Array<kj::byte> serializeV8Value(jsg::Lock& js, const jsg::JsValue& value) {
         .version = 15,
         .omitHeader = false,
       });
-  serializer.write(js, value);
+  serializer.writeDynamic(js, value);
   auto released = serializer.release();
   return kj::mv(released.data);
 }

--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -829,12 +829,13 @@ void AbortSignal::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   JSG_REQUIRE(
       externalHandler != nullptr, DOMDataCloneError, "AbortSignal can only be serialized for RPC.");
 
-  serializer.writeRawUint32(static_cast<uint>(canceler->isCanceled()));
-  serializer.writeRawUint32(static_cast<uint>(flag));
+  serializer.write(canceler->isCanceled());
+  serializer.write(flag);
+
   KJ_IF_SOME(r, reason) {
     serializer.writeDynamic(js, r.getHandle(js));
   } else {
-    serializer.writeDynamic(js, js.undefined());
+    serializer.write(js, kj::none);
   }
 
   if (getAborted(js) || getNeverAborts()) {

--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -798,7 +798,7 @@ void AbortSignal::triggerAbort(
     IoContext& ioContext = IoContext::current();
     jsg::Serializer ser(js);
     KJ_IF_SOME(r, reason) {
-      ser.write(js, r.getHandle(js));
+      ser.writeDynamic(js, r.getHandle(js));
     }
 
     auto released = ser.release();
@@ -832,9 +832,9 @@ void AbortSignal::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   serializer.writeRawUint32(static_cast<uint>(canceler->isCanceled()));
   serializer.writeRawUint32(static_cast<uint>(flag));
   KJ_IF_SOME(r, reason) {
-    serializer.write(js, r.getHandle(js));
+    serializer.writeDynamic(js, r.getHandle(js));
   } else {
-    serializer.write(js, js.undefined());
+    serializer.writeDynamic(js, js.undefined());
   }
 
   if (getAborted(js) || getNeverAborts()) {

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -532,7 +532,7 @@ void Headers::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   // is a common header ID, or the value zero to indicate an uncommon header, which is then
   // followed by a length-delimited name.
 
-  serializer.writeRawUint32(static_cast<uint>(guard));
+  serializer.write(guard);
 
   // Write the count of headers.
   uint count = 0;
@@ -551,9 +551,9 @@ void Headers::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
         serializer.writeRawUint32(c);
       } else {
         serializer.writeRawUint32(0);
-        serializer.writeLengthDelimited(header.name);
+        serializer.write(header.name);
       }
-      serializer.writeLengthDelimited(value);
+      serializer.write(value);
     }
   }
 }
@@ -1285,7 +1285,7 @@ void RequestInitializerDict::validate(jsg::Lock& js) {
 void Request::serialize(jsg::Lock& js,
     jsg::Serializer& serializer,
     const jsg::SerializeTypeHandler<RequestInitializerDict>& initDictHandler) {
-  serializer.writeLengthDelimited(url);
+  serializer.write(url);
 
   // Our strategy is to construct an initializer dict object and serialize that as a JS object.
   // This makes the deserialization end really simple (just call the constructor), and it also

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -2497,7 +2497,7 @@ jsg::Promise<Fetcher::QueueResult> Fetcher::queue(
             .version = 15,
             .omitHeader = false,
           });
-      serializer.write(js, jsg::JsValue(b.getHandle(js)));
+      serializer.writeDynamic(js, jsg::JsValue(b.getHandle(js)));
       encodedMessages.add(IncomingQueueMessage{.id = kj::mv(msg.id),
         .timestamp = msg.timestamp,
         .body = serializer.release().data,

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -744,6 +744,7 @@ struct RequestInitializerDict {
   // TODO(conform): Might support later?
 
   JSG_STRUCT(method, headers, body, redirect, fetcher, cf, cache, integrity, signal, encodeResponseBody);
+
   JSG_STRUCT_TS_OVERRIDE_DYNAMIC(CompatibilityFlags::Reader flags) {
     if(flags.getCacheOptionEnabled()) {
       if(flags.getCacheNoCache()) {

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -774,12 +774,10 @@ struct RequestInitializerDict {
       });
     }
   }
-
   // This method is called within tryUnwrap() when the type is unpacked from v8.
   // See jsg Readme for more details.
   void validate(jsg::Lock&);
 };
-
 class Request final: public Body {
 public:
   enum class Redirect {

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -667,15 +667,21 @@ struct RequestInitializerDict {
   // The script author may specify an empty body either implicitly, by allowing this property to
   // be undefined, or explicitly, by setting this property to null. To support both cases, this
   // body initializer must be Optional<Maybe<Body::Initializer>>.
-  jsg::Optional<kj::Maybe<Body::Initializer>> body;
+
+  // FakeSerializable is used because we only serialize body as a ReadableStream, but other types
+  // are accepted as input.
+  jsg::FakeSerializable<jsg::Optional<kj::Maybe<Body::Initializer>>> body;
 
   // follow, error, manual (default follow)
   jsg::Optional<kj::String> redirect;
 
-  jsg::Optional<kj::Maybe<jsg::Ref<Fetcher>>> fetcher;
+  jsg::OmitFromSerialized<kj::Maybe<jsg::Ref<Fetcher>>> fetcher;
 
   // Cloudflare-specific feature flags.
-  jsg::Optional<jsg::V8Ref<v8::Object>> cf;
+  jsg::FakeSerializable<jsg::Optional<jsg::V8Ref<v8::Object>>> cf;
+  // FakeSerializable is used because cf is an arbitrary object (but is supposed to be
+  // JSON-compatible!)
+
   // TODO(someday): We should generalize this concept to sending control information to
   //   downstream workers in the pipeline. That is, when multiple workers apply to the same
   //   request (with the first worker's subrequests being passed to the next worker), then
@@ -981,7 +987,7 @@ public:
 
   void serialize(
       jsg::Lock& js, jsg::Serializer& serializer,
-      const jsg::TypeHandler<RequestInitializerDict>& initDictHandler);
+      const jsg::SerializeTypeHandler<RequestInitializerDict>& initDictHandler);
   static jsg::Ref<Request> deserialize(
       jsg::Lock& js, rpc::SerializationTag tag, jsg::Deserializer& deserializer,
       const jsg::TypeHandler<RequestInitializerDict>& initDictHandler);
@@ -1043,9 +1049,12 @@ public:
     jsg::Optional<Headers::Initializer> headers;
 
     // Cloudflare-specific feature flags.
-    jsg::Optional<jsg::V8Ref<v8::Object>> cf;
+    jsg::FakeSerializable<jsg::Optional<jsg::V8Ref<v8::Object>>> cf;
+    // FakeSerializable is used because cf is an arbitrary object (but is supposed to be
+    // JSON-compatible!)
 
-    jsg::Optional<kj::Maybe<jsg::Ref<WebSocket>>> webSocket;
+
+    jsg::OmitFromSerialized<kj::Maybe<jsg::Ref<WebSocket>>> webSocket;
 
     jsg::Optional<kj::String> encodeBody;
 
@@ -1174,8 +1183,8 @@ public:
 
   void serialize(
       jsg::Lock& js, jsg::Serializer& serializer,
-      const jsg::TypeHandler<InitializerDict>& initDictHandler,
-      const jsg::TypeHandler<kj::Maybe<jsg::Ref<ReadableStream>>>& streamHandler);
+      const jsg::SerializeTypeHandler<InitializerDict>& initDictHandler,
+      const jsg::SerializeTypeHandler<kj::Maybe<jsg::Ref<ReadableStream>>>& streamHandler);
   static jsg::Ref<Response> deserialize(
       jsg::Lock& js, rpc::SerializationTag tag, jsg::Deserializer& deserializer,
       const jsg::TypeHandler<InitializerDict>& initDictHandler,

--- a/src/workerd/api/memory-cache.c++
+++ b/src/workerd/api/memory-cache.c++
@@ -359,7 +359,7 @@ void SharedMemoryCache::Use::delete_(const kj::String& key) const {
 static kj::Own<CacheValue> hackySerialize(jsg::Lock& js, jsg::JsRef<jsg::JsValue>& value) {
   return js.tryCatch([&]() -> kj::Own<CacheValue> {
     jsg::Serializer serializer(js);
-    serializer.write(js, value.getHandle(js));
+    serializer.writeDynamic(js, value.getHandle(js));
     return kj::atomicRefcounted<CacheValue>(serializer.release().data);
   }, [&](jsg::Value&& exception) -> kj::Own<CacheValue> {
     // We run into big problems with tunneled exceptions here. When

--- a/src/workerd/api/node/diagnostics-channel.c++
+++ b/src/workerd/api/node/diagnostics-channel.c++
@@ -32,7 +32,7 @@ void Channel::publish(jsg::Lock& js, jsg::Value message) {
         jsg::Serializer::Options{
           .omitHeader = false,
         });
-    ser.write(js, jsg::JsValue(message.getHandle(js)));
+    ser.writeDynamic(js, jsg::JsValue(message.getHandle(js)));
     auto tmp = ser.release();
     JSG_REQUIRE(tmp.sharedArrayBuffers.size() == 0 && tmp.transferredArrayBuffers.size() == 0,
         Error,

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -57,7 +57,7 @@ Serialized serializeV8(jsg::Lock& js, const jsg::JsValue& body) {
         .version = 15,
         .omitHeader = false,
       });
-  serializer.write(js, jsg::JsValue(body));
+  serializer.writeDynamic(js, jsg::JsValue(body));
   kj::Array<kj::byte> bytes = serializer.release().data;
   Serialized result;
   result.data = bytes;

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -726,7 +726,7 @@ void WebSocket::serializeAttachment(jsg::Lock& js, jsg::JsValue attachment) {
         .version = 15,
         .omitHeader = false,
       });
-  serializer.write(js, attachment);
+  serializer.writeDynamic(js, attachment);
   auto released = serializer.release();
   JSG_REQUIRE(released.data.size() <= MAX_ATTACHMENT_SIZE, Error,
       "A WebSocket 'attachment' cannot be larger than ", MAX_ATTACHMENT_SIZE,

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -1694,7 +1694,7 @@ void JsRpcTarget::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
 
 void RpcSerializerExternalHandler::serializeFunction(
     jsg::Lock& js, jsg::Serializer& serializer, v8::Local<v8::Function> func) {
-  serializer.writeRawUint32(static_cast<uint>(rpc::SerializationTag::JS_RPC_STUB));
+  serializer.write(rpc::SerializationTag::JS_RPC_STUB);
 
   rpc::JsRpcTarget::Client cap =
       kj::heap<TransientJsRpcTarget>(js, IoContext::current(), jsg::JsObject(func), true);
@@ -1753,7 +1753,7 @@ void RpcSerializerExternalHandler::serializeProxy(
     }
 
     // Great, we've concluded we can indeed point a stub at this proxy.
-    serializer.writeRawUint32(static_cast<uint>(rpc::SerializationTag::JS_RPC_STUB));
+    serializer.write(rpc::SerializationTag::JS_RPC_STUB);
 
     rpc::JsRpcTarget::Client cap =
         kj::heap<TransientJsRpcTarget>(js, IoContext::current(), handle, allowInstanceProperties);

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -168,7 +168,7 @@ void serializeJsValue(jsg::Lock& js,
         .treatClassInstancesAsPlainObjects = false,
         .externalHandler = externalHandler,
       });
-  serializer.write(js, value);
+  serializer.writeDynamic(js, value);
   kj::Array<const byte> data = serializer.release().data;
   JSG_ASSERT(data.size() <= MAX_JS_RPC_MESSAGE_SIZE, Error,
       "Serialized RPC arguments or return values are limited to 32MiB, but the size of this value "

--- a/src/workerd/io/frankenvalue.c++
+++ b/src/workerd/io/frankenvalue.c++
@@ -125,7 +125,7 @@ Frankenvalue Frankenvalue::fromJs(jsg::Lock& js, jsg::JsValue value) {
 
   js.withinHandleScope([&]() {
     jsg::Serializer ser(js, {.treatClassInstancesAsPlainObjects = false});
-    ser.write(js, value);
+    ser.writeDynamic(js, value);
     result.value = V8Serialized{ser.release().data};
   });
 

--- a/src/workerd/jsg/dom-exception.c++
+++ b/src/workerd/jsg/dom-exception.c++
@@ -63,20 +63,20 @@ int DOMException::getCode() const {
 }
 
 void DOMException::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
-  serializer.writeLengthDelimited(name);
-  serializer.writeLengthDelimited(message);
+  serializer.write(name);
+  serializer.write(message);
 
   // It's a bit unfortunate that the stack here ends up also including the name and message
   // so we end up duplicating some of the information here, but that's OK. It's better to
   // keep this implementation simple rather than to implement any kind of deduplication.
   KJ_IF_SOME(stack, this->stack.get(js, "stack")) {
-    serializer.writeLengthDelimited(stack);
+    serializer.write(stack);
   } else {
     // This branch shouldn't really be taken in the typical case. It's only here
     // to handle the case where the stack property could not be unwrapped for some
     // reason. We don't need to treat it as an error case, just set the stack to
     // the empty string and move on.
-    serializer.writeLengthDelimited(""_kj);
+    serializer.write(""_kj);
   }
 }
 

--- a/src/workerd/jsg/iterator.h
+++ b/src/workerd/jsg/iterator.h
@@ -687,6 +687,20 @@ class SequenceWrapper {
   }
 
   template <typename U>
+  v8::Local<v8::Value> wrapForSerialize(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      jsg::Sequence<U> sequence) {
+    v8::Isolate* isolate = context->GetIsolate();
+    v8::EscapableHandleScope handleScope(isolate);
+    v8::LocalVector<v8::Value> items(isolate, sequence.size());
+    for (auto i: kj::indices(sequence)) {
+      items[i] =
+          static_cast<TypeWrapper*>(this)->wrapForSerialize(context, creator, kj::mv(sequence[i]));
+    }
+    return handleScope.Escape(v8::Array::New(isolate, items.data(), items.size()));
+  }
+
+  template <typename U>
   v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       jsg::Sequence<U>& sequence) {
@@ -695,6 +709,20 @@ class SequenceWrapper {
     v8::LocalVector<v8::Value> items(isolate, sequence.size());
     for (auto i: kj::indices(sequence)) {
       items[i] = static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(sequence[i]));
+    }
+    return handleScope.Escape(v8::Array::New(isolate, items.data(), items.size()));
+  }
+
+  template <typename U>
+  v8::Local<v8::Value> wrapForSerialize(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      jsg::Sequence<U>& sequence) {
+    v8::Isolate* isolate = context->GetIsolate();
+    v8::EscapableHandleScope handleScope(isolate);
+    v8::LocalVector<v8::Value> items(isolate, sequence.size());
+    for (auto i: kj::indices(sequence)) {
+      items[i] =
+          static_cast<TypeWrapper*>(this)->wrapForSerialize(context, creator, kj::mv(sequence[i]));
     }
     return handleScope.Escape(v8::Array::New(isolate, items.data(), items.size()));
   }

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -344,6 +344,13 @@ struct BuildRtti<Configuration, jsg::NonCoercible<T>> {
   }
 };
 
+template <typename Configuration, typename T>
+struct BuildRtti<Configuration, jsg::FakeSerializable<T>> {
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) {
+    BuildRtti<Configuration, T>::build(builder, rtti);
+  }
+};
+
 // Maybe Types
 
 #define DECLARE_MAYBE_TYPE(T)                                                                      \
@@ -359,7 +366,8 @@ struct BuildRtti<Configuration, jsg::NonCoercible<T>> {
 #define FOR_EACH_MAYBE_TYPE(F)                                                                     \
   F(kj::Maybe)                                                                                     \
   F(jsg::Optional)                                                                                 \
-  F(jsg::LenientOptional)
+  F(jsg::LenientOptional)                                                                          \
+  F(jsg::OmitFromSerialized)
 
 FOR_EACH_MAYBE_TYPE(DECLARE_MAYBE_TYPE)
 

--- a/src/workerd/jsg/ser.c++
+++ b/src/workerd/jsg/ser.c++
@@ -198,7 +198,7 @@ void Serializer::transfer(Lock& js, const JsValue& value) {
   ser.TransferArrayBuffer(n, arrayBuffer);
 }
 
-void Serializer::write(Lock& js, const JsValue& value) {
+void Serializer::writeDynamic(Lock& js, const JsValue& value) {
   KJ_ASSERT(!released, "The data has already been released.");
   KJ_ASSERT(check(ser.WriteValue(js.v8Context(), value)));
 }
@@ -322,7 +322,7 @@ JsValue structuredClone(
       ser.transfer(js, item);
     }
   }
-  ser.write(js, value);
+  ser.writeDynamic(js, value);
   auto released = ser.release();
   Deserializer des(js, released, kj::none);
   return des.readValue(js);

--- a/src/workerd/jsg/ser.c++
+++ b/src/workerd/jsg/ser.c++
@@ -198,6 +198,10 @@ void Serializer::transfer(Lock& js, const JsValue& value) {
   ser.TransferArrayBuffer(n, arrayBuffer);
 }
 
+void Serializer::write(Lock& js, kj::None) {
+  writeDynamic(js, js.undefined());
+}
+
 void Serializer::writeDynamic(Lock& js, const JsValue& value) {
   KJ_ASSERT(!released, "The data has already been released.");
   KJ_ASSERT(check(ser.WriteValue(js.v8Context(), value)));

--- a/src/workerd/jsg/ser.h
+++ b/src/workerd/jsg/ser.h
@@ -151,10 +151,10 @@ class Serializer final: v8::ValueSerializer::Delegate {
 
   template <typename S, typename T>
   void write(Lock& js, const S& serializeTypeHandler, T&& val) {
-    write(js, JsValue(serializeTypeHandler.wrapForSerialize(js, kj::fwd<T>(val))));
+    writeDynamic(js, JsValue(serializeTypeHandler.wrapForSerialize(js, kj::fwd<T>(val))));
   }
 
-  void write(Lock& js, const JsValue& value);
+  void writeDynamic(Lock& js, const JsValue& value);
 
   // Implements the `transfer` option of `structuredClone()`. Pass each item in the transfer array
   // to this method before calling `write()`. This gives the Serializer permission to serialize

--- a/src/workerd/jsg/ser.h
+++ b/src/workerd/jsg/ser.h
@@ -148,6 +148,12 @@ class Serializer final: v8::ValueSerializer::Delegate {
   //
   // You can call this multiple times to write multiple values, then call `readValue()` the same
   // number of times on the deserialization side.
+
+  template <typename S, typename T>
+  void write(Lock& js, const S& serializeTypeHandler, T&& val) {
+    write(js, JsValue(serializeTypeHandler.wrapForSerialize(js, kj::fwd<T>(val))));
+  }
+
   void write(Lock& js, const JsValue& value);
 
   // Implements the `transfer` option of `structuredClone()`. Pass each item in the transfer array

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -387,7 +387,7 @@ void addExceptionDetail(Lock& js, kj::Exception& exception, v8::Local<v8::Value>
           // be bumped to match the new version once all of production is updated to understand it.
           .version = 15,
         });
-    ser.write(js, JsValue(handle));
+    ser.writeDynamic(js, JsValue(handle));
     exception.setDetail(TUNNELED_EXCEPTION_DETAIL_ID, ser.release().data);
   } catch (JsExceptionThrown&) {
     // Either:

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -45,6 +45,11 @@ class PrimitiveWrapper {
     return wrap(context->GetIsolate(), creator, value);
   }
 
+  v8::Local<v8::Number> wrapForSerialize(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, double value) {
+    return wrap(context->GetIsolate(), creator, value);
+  }
+
   v8::Local<v8::Number> wrap(
       v8::Isolate* isolate, kj::Maybe<v8::Local<v8::Object>> creator, double value) {
     return v8::Number::New(isolate, value);
@@ -62,6 +67,11 @@ class PrimitiveWrapper {
   }
 
   v8::Local<v8::Number> wrap(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, int8_t value) {
+    return wrap(context->GetIsolate(), creator, value);
+  }
+
+  v8::Local<v8::Number> wrapForSerialize(
       v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, int8_t value) {
     return wrap(context->GetIsolate(), creator, value);
   }
@@ -96,6 +106,11 @@ class PrimitiveWrapper {
     return wrap(context->GetIsolate(), creator, value);
   }
 
+  v8::Local<v8::Number> wrapForSerialize(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, uint8_t value) {
+    return wrap(context->GetIsolate(), creator, value);
+  }
+
   v8::Local<v8::Number> wrap(
       v8::Isolate* isolate, kj::Maybe<v8::Local<v8::Object>> creator, uint8_t value) {
     return v8::Integer::NewFromUnsigned(isolate, value);
@@ -124,6 +139,11 @@ class PrimitiveWrapper {
   }
 
   v8::Local<v8::Number> wrap(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, int16_t value) {
+    return wrap(context->GetIsolate(), creator, value);
+  }
+
+  v8::Local<v8::Number> wrapForSerialize(
       v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, int16_t value) {
     return wrap(context->GetIsolate(), creator, value);
   }
@@ -163,6 +183,11 @@ class PrimitiveWrapper {
     return v8::Integer::NewFromUnsigned(isolate, value);
   }
 
+  v8::Local<v8::Number> wrapForSerialize(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, uint16_t value) {
+    return wrap(context->GetIsolate(), creator, value);
+  }
+
   kj::Maybe<uint16_t> tryUnwrap(v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       uint16_t*,
@@ -186,6 +211,11 @@ class PrimitiveWrapper {
   }
 
   v8::Local<v8::Number> wrap(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, int value) {
+    return wrap(context->GetIsolate(), creator, value);
+  }
+
+  v8::Local<v8::Number> wrapForSerialize(
       v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, int value) {
     return wrap(context->GetIsolate(), creator, value);
   }
@@ -226,6 +256,11 @@ class PrimitiveWrapper {
     return wrap(context->GetIsolate(), creator, value);
   }
 
+  v8::Local<v8::Number> wrapForSerialize(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, uint32_t value) {
+    return wrap(context->GetIsolate(), creator, value);
+  }
+
   v8::Local<v8::Number> wrap(
       v8::Isolate* isolate, kj::Maybe<v8::Local<v8::Object>> creator, uint32_t value) {
     return v8::Integer::NewFromUnsigned(isolate, value);
@@ -258,6 +293,11 @@ class PrimitiveWrapper {
   }
 
   v8::Local<v8::BigInt> wrap(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, uint64_t value) {
+    return wrap(context->GetIsolate(), creator, value);
+  }
+
+  v8::Local<v8::BigInt> wrapForSerialize(
       v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, uint64_t value) {
     return wrap(context->GetIsolate(), creator, value);
   }
@@ -304,6 +344,11 @@ class PrimitiveWrapper {
     return wrap(context->GetIsolate(), creator, value);
   }
 
+  v8::Local<v8::BigInt> wrapForSerialize(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, int64_t value) {
+    return wrap(context->GetIsolate(), creator, value);
+  }
+
   v8::Local<v8::BigInt> wrap(
       v8::Isolate* isolate, kj::Maybe<v8::Local<v8::Object>> creator, int64_t value) {
     return v8::BigInt::New(isolate, value);
@@ -343,6 +388,14 @@ class PrimitiveWrapper {
     // The template is needed to prevent this overload from being chosen for arbitrary types that
     // can convert to bool, such as pointers.
     return wrap(context->GetIsolate(), creator, value);
+  }
+
+  template <typename T, typename = kj::EnableIf<kj::isSameType<T, bool>()>>
+  v8::Local<v8::Boolean> wrapForSerialize(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, T value) {
+    // The template is needed to prevent this overload from being chosen for arbitrary types that
+    // can convert to bool, such as pointers.
+    return wrapForSerialize(context->GetIsolate(), creator, value);
   }
 
   template <typename T, typename = kj::EnableIf<kj::isSameType<T, bool>()>>
@@ -477,6 +530,44 @@ class StringWrapper {
     return wrap(context, creator, value.asPtr());
   }
 
+  // ...
+
+  v8::Local<v8::String> wrapForSerialize(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      kj::ArrayPtr<const char> value) {
+    return v8Str(context->GetIsolate(), value);
+  }
+
+  v8::Local<v8::String> wrapForSerialize(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      kj::Array<const char> value) {
+    return wrap(context, creator, value.asPtr());
+  }
+
+  v8::Local<v8::String> wrapForSerialize(
+      v8::Isolate* isolate, kj::Maybe<v8::Local<v8::Object>> creator, kj::StringPtr value) {
+    return v8Str(isolate, value);
+  }
+
+  v8::Local<v8::String> wrapForSerialize(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      const ByteString& value) {
+    // TODO(cleanup): Move to a HeaderStringWrapper in the api directory.
+    return wrap(context, creator, value.asPtr());
+  }
+
+  v8::Local<v8::String> wrapForSerialize(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      const USVString& value) {
+    return wrap(context, creator, value.asPtr());
+  }
+
+  v8::Local<v8::String> wrapForSerialize(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      const DOMString& value) {
+    return wrap(context, creator, value.asPtr());
+  }
+
   kj::Maybe<kj::String> tryUnwrap(v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       kj::String*,
@@ -577,6 +668,16 @@ class OptionalWrapper {
   }
 
   template <typename U>
+  v8::Local<v8::Value> wrapForSerialize(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, Optional<U> ptr) {
+    KJ_IF_SOME(p, ptr) {
+      return static_cast<TypeWrapper*>(this)->wrapForSerialize(context, creator, kj::fwd<U>(p));
+    } else {
+      return v8::Undefined(context->GetIsolate());
+    }
+  }
+
+  template <typename U>
   kj::Maybe<Optional<U>> tryUnwrap(v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       Optional<U>*,
@@ -587,6 +688,86 @@ class OptionalWrapper {
       return static_cast<TypeWrapper*>(this)
           ->tryUnwrap(context, handle, (kj::Decay<U>*)nullptr, parentObject)
           .map([](auto&& value) -> Optional<U> { return kj::fwd<decltype(value)>(value); });
+    }
+  }
+};
+
+// =======================================================================================
+// jsg::FakeSerializable<T>
+template <typename TypeWrapper>
+class FakeSerializableWrapper {
+ public:
+  template <typename U>
+  static constexpr decltype(auto) getName(FakeSerializable<U>*) {
+    return TypeWrapper::getName((kj::Decay<U>*)nullptr);
+  }
+
+  template <typename U>
+  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      FakeSerializable<U> ptr) {
+    return static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::fwd<U>(ptr));
+  }
+
+  template <typename U>
+  v8::Local<v8::Value> wrapForSerialize(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      FakeSerializable<U> ptr) {
+    return static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::fwd<U>(ptr));
+  }
+
+  template <typename U>
+  kj::Maybe<FakeSerializable<U>> tryUnwrap(v8::Local<v8::Context> context,
+      v8::Local<v8::Value> handle,
+      FakeSerializable<U>*,
+      kj::Maybe<v8::Local<v8::Object>> parentObject) {
+    return static_cast<TypeWrapper*>(this)->tryUnwrap(
+        context, handle, (kj::Decay<U>*)nullptr, parentObject);
+  }
+};
+
+// =======================================================================================
+// jsg::OmitFromSerialized<T>
+
+template <typename TypeWrapper>
+class OmitFromSerializedWrapper {
+ public:
+  template <typename U>
+  static constexpr decltype(auto) getName(OmitFromSerialized<U>*) {
+    return TypeWrapper::getName((kj::Decay<U>*)nullptr);
+  }
+
+  template <typename U>
+  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      OmitFromSerialized<U> ptr) {
+    KJ_IF_SOME(p, ptr) {
+      return static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::fwd<U>(p));
+    } else {
+      return v8::Undefined(context->GetIsolate());
+    }
+  }
+
+  template <typename U>
+  v8::Local<v8::Value> wrapForSerialize(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      OmitFromSerialized<U> ptr) {
+    return v8::Undefined(context->GetIsolate());
+  }
+
+  template <typename U>
+  kj::Maybe<OmitFromSerialized<U>> tryUnwrap(v8::Local<v8::Context> context,
+      v8::Local<v8::Value> handle,
+      OmitFromSerialized<U>*,
+      kj::Maybe<v8::Local<v8::Object>> parentObject) {
+    if (handle->IsUndefined()) {
+      return OmitFromSerialized<U>(kj::none);
+    } else {
+      return static_cast<TypeWrapper*>(this)
+          ->tryUnwrap(context, handle, (kj::Decay<U>*)nullptr, parentObject)
+          .map([](auto&& value) -> OmitFromSerialized<U> {
+        return kj::fwd<decltype(value)>(value);
+      });
     }
   }
 };
@@ -651,6 +832,16 @@ class MaybeWrapper {
       v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, kj::Maybe<U> ptr) {
     KJ_IF_SOME(p, ptr) {
       return static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::fwd<U>(p));
+    } else {
+      return v8::Null(context->GetIsolate());
+    }
+  }
+
+  template <typename U>
+  v8::Local<v8::Value> wrapForSerialize(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, kj::Maybe<U> ptr) {
+    KJ_IF_SOME(p, ptr) {
+      return static_cast<TypeWrapper*>(this)->wrapForSerialize(context, creator, kj::fwd<U>(p));
     } else {
       return v8::Null(context->GetIsolate());
     }
@@ -725,6 +916,31 @@ class OneOfWrapper {
       kj::OneOf<U...> value) {
     v8::Local<v8::Value> result;
     if (!(wrapHelper<U>(context, creator, value, result) || ...)) {
+      result = v8::Undefined(context->GetIsolate());
+    }
+    return result;
+  }
+
+  template <typename U, typename... V>
+  bool wrapForSerializeHelper(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      kj::OneOf<V...>& in,
+      v8::Local<v8::Value>& out) {
+    if (in.template is<U>()) {
+      out = static_cast<TypeWrapper*>(this)->wrapForSerialize(
+          context, creator, kj::mv(in.template get<U>()));
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  template <typename... U>
+  v8::Local<v8::Value> wrapForSerialize(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      kj::OneOf<U...> value) {
+    v8::Local<v8::Value> result;
+    if (!(wrapForSerializeHelper<U>(context, creator, value, result) || ...)) {
       result = v8::Undefined(context->GetIsolate());
     }
     return result;
@@ -859,6 +1075,24 @@ class ArrayWrapper {
 
     return handleScope.Escape(out);
   }
+
+  template <typename U>
+  v8::Local<v8::Value> wrapForSerialize(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      kj::Array<U> array) {
+    v8::Isolate* isolate = context->GetIsolate();
+    v8::EscapableHandleScope handleScope(isolate);
+
+    v8::LocalVector<v8::Value> items(isolate, array.size());
+    for (auto n = 0; n < items.size(); n++) {
+      items[n] =
+          static_cast<TypeWrapper*>(this)->wrapForSerialize(context, creator, kj::mv(array[n]));
+    }
+    auto out = v8::Array::New(isolate, items.data(), items.size());
+
+    return handleScope.Escape(out);
+  }
+
   template <typename U>
   v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
@@ -874,11 +1108,36 @@ class ArrayWrapper {
 
     return handleScope.Escape(out);
   }
+
+  template <typename U>
+  v8::Local<v8::Value> wrapForSerialize(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      kj::ArrayPtr<U> array) {
+    v8::Isolate* isolate = context->GetIsolate();
+    v8::EscapableHandleScope handleScope(isolate);
+
+    v8::LocalVector<v8::Value> items(isolate, array.size());
+    for (auto n = 0; n < items.size(); n++) {
+      items[n] =
+          static_cast<TypeWrapper*>(this)->wrapForSerialize(context, creator, kj::mv(array[n]));
+    }
+    auto out = v8::Array::New(isolate, items.data(), items.size());
+
+    return handleScope.Escape(out);
+  }
+
   template <typename U>
   v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::Array<U>& array) {
     return static_cast<TypeWrapper*>(this)->wrap(context, creator, array.asPtr());
+  }
+
+  template <typename U>
+  v8::Local<v8::Value> wrapForSerialize(v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      kj::Array<U>& array) {
+    return static_cast<TypeWrapper*>(this)->wrapForSerialize(context, creator, array.asPtr());
   }
 
   template <typename U>
@@ -1098,6 +1357,25 @@ class DictWrapper {
       KJ_ASSERT(check(out->Set(context,
           static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(field.name)),
           static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(field.value)))));
+    }
+    return handleScope.Escape(out);
+  }
+
+  template <typename K, typename V>
+  v8::Local<v8::Value> wrapForSerialize(
+      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, Dict<V, K> dict) {
+    static_assert(webidl::isStringType<K>, "Dicts must be keyed on a string type.");
+
+    v8::Isolate* isolate = context->GetIsolate();
+    v8::EscapableHandleScope handleScope(isolate);
+    auto out = v8::Object::New(isolate);
+    for (auto& field: dict.fields) {
+      // Set() returns Maybe<bool>. As usual, if the Maybe is null, then there was an exception,
+      // but I have no idea what it means if the Maybe was filled in with the boolean value false...
+      KJ_ASSERT(check(out->Set(context,
+          static_cast<TypeWrapper*>(this)->wrapForSerialize(context, creator, kj::mv(field.name)),
+          static_cast<TypeWrapper*>(this)->wrapForSerialize(
+              context, creator, kj::mv(field.value)))));
     }
     return handleScope.Escape(out);
   }


### PR DESCRIPTION
This PR is my idea on making serialization easier and safer to use. 

The main idea is that you should call `serializer.write` for most cases, and it'll do the right thing:
- `serializer.write(x);` for bools, enums, strings will always use the standard representation we've been using so far.
- `serializer.write(js, typeHandler, x);` for structs.
- I didn't add an overload for integer types because I'm worried about places where we just do int/uint without thinking about size, so that remains as `serializer.writeRawUint32(x)` or serializer.writeRawUint64(x)`

For JSValue, the existing function `serializer.write(js, x)` is now written as  `serializer.writeDynamic(js, x);` to remind callers that we are not checking the contained type at compile time and don't know if it's serializable.

The compile-time serialization check is introduced by adding `SerializedTypeHandler<T>` and a new `writeForSerialize` method in each type wrapper. (The PR only adds it for some types; I will finish the rest once we've reviewed the concept).

There are two "escape hatches" that can be used to wrap a struct field:
- `FakeSerializable<T>` which just ignores the check for this field. Ideally we can get rid of it soon - we just need more validation about what is stored in the CF blob of a request or response.
- `OmitForSerialized<T>` is like `Optional<T>` but always encodes as `undefined` when serializing. This is useful for any struct fields that don't need to be sent.
