### PR TITLE
Reproduction of issue with `connect()` and `globalOutbound`

### DIFF
--- a/samples/connect-with-global-outbound/config.capnp
+++ b/samples/connect-with-global-outbound/config.capnp
@@ -1,0 +1,21 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const helloWorldExample :Workerd.Config = (
+  services = [ (name = "main", worker = .helloWorld), (name = "outbound", worker = .outbound) ],
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ]
+);
+
+const helloWorld :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js")
+  ],
+  compatibilityDate = "2023-02-28",
+  globalOutbound = "outbound"
+);
+
+const outbound :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "outbound.js")
+  ],
+  compatibilityDate = "2023-02-28",
+);

--- a/samples/connect-with-global-outbound/outbound.js
+++ b/samples/connect-with-global-outbound/outbound.js
@@ -1,0 +1,6 @@
+export default {
+  fetch(request) {
+    console.log('Outbound Worker called');
+    return fetch(request);
+  },
+};

--- a/samples/connect-with-global-outbound/worker.js
+++ b/samples/connect-with-global-outbound/worker.js
@@ -1,0 +1,14 @@
+import { connect } from 'cloudflare:sockets';
+
+export default {
+  async fetch(req, env) {
+    const url = new URL(req.url);
+    if (url.pathname == '/http') {
+      return fetch('http://example.com');
+    } else if (url.pathname == '/connect') {
+      await connect('example.com:5432');
+      return new Response('connection ok');
+    }
+    return new Response('try /http or /connect');
+  },
+};


### PR DESCRIPTION
Relating to https://github.com/cloudflare/workers-sdk/issues/9238, it seems that using `connect()` in a Worker with a `globalOutbound` configured is not supported, because the `connect()` tries to go via the global outbound, failing because Workers don't support TCP ingress. I'd expect the `connect()` API to bypass `globalOutbound` and go straight to the `internet` service, so that it's possible to use `connect()` in a Worker with `globalOutbound` configured.

To reproduce, run `pnpx workerd samples/connect-with-global-outbound/config.capnp` and `curl http://localhost:8080/connect`. `workerd` will throw an error like the following:

```
workerd/server/server.c++:3872: error: Uncaught exception: workerd/jsg/_virtual_includes/iterator/workerd/jsg/value.h:1479: failed: remote.jsg.TypeError: Incoming CONNECT on a worker not supported
```

Removing the `globalOutbound` setting allows the connection to be established as expected.