### PR TITLE
feat: Add deleteBulk method for JSRPC testing

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -2362,6 +2362,13 @@ kj::Maybe<jsg::Ref<JsRpcProperty>> Fetcher::getRpcMethod(jsg::Lock& js, kj::Stri
     return kj::none;
   }
 
+  return getRpcMethodInternal(js, kj::mv(name));
+}
+
+kj::Maybe<jsg::Ref<JsRpcProperty>> Fetcher::getRpcMethodInternal(jsg::Lock& js, kj::String name) {
+  // Same as getRpcMethod, but skips compatibility check to allow RPC to be used from bindings
+  // attached to workers without rpc flag.
+
   // Do not return a method for `then`, otherwise JavaScript decides this is a thenable, i.e. a
   // custom Promise, which will mean a Promise that resolves to this object will attempt to chain
   // with it, which is not what you want!

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -579,6 +579,8 @@ public:
   jsg::Promise<ScheduledResult> scheduled(jsg::Lock& js, jsg::Optional<ScheduledOptions> options);
 
   kj::Maybe<jsg::Ref<JsRpcProperty>> getRpcMethod(jsg::Lock& js, kj::String name);
+  // Internal method for use from bindings code. It skips compatibility flags checks.
+  kj::Maybe<jsg::Ref<JsRpcProperty>> getRpcMethodInternal(jsg::Lock& js, kj::String name);
   kj::Maybe<jsg::Ref<JsRpcProperty>> getRpcMethodForTestOnly(jsg::Lock& js, kj::String name) {
     return getRpcMethod(js, kj::mv(name));
   }

--- a/src/workerd/api/kv-test.js
+++ b/src/workerd/api/kv-test.js
@@ -248,7 +248,8 @@ export let getBulkTest = {
 export let deleteBulkTest = {
   async test(ctrl, env, ctx) {
     // Single key
-    await env.KV.deleteBulk('success');
+    let result = await env.KV.deleteBulk('success');
+    assert.strictEqual(result, undefined);
 
     // Failure
     await assert.rejects(env.KV.deleteBulk('error'), {
@@ -256,7 +257,8 @@ export let deleteBulkTest = {
     });
 
     // Multiple keys
-    await env.KV.deleteBulk(['key1', 'key2', 'key3']);
+    result = await env.KV.deleteBulk(['key1', 'key2', 'key3']);
+    assert.strictEqual(result, undefined);
 
     // Too many keys
     await assert.rejects(

--- a/src/workerd/api/kv-test.wd-test
+++ b/src/workerd/api/kv-test.wd-test
@@ -9,7 +9,8 @@ const unitTests :Workerd.Config = (
         ],
         bindings = [ ( name = "KV", kvNamespace = "kv-test" ), ],
         compatibilityDate = "2023-07-24",
-        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers"],
+        # "experimental" flag is needed to test deleteBulk
+        compatibilityFlags = ["experimental", "nodejs_compat", "service_binding_extra_handlers"],
       )
     ),
   ],

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -626,4 +626,12 @@ jsg::Promise<void> KvNamespace::delete_(jsg::Lock& js, kj::String name) {
   });
 }
 
+jsg::Ref<JsRpcPromise> KvNamespace::deleteBulk(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  jsg::Lock& js = jsg::Lock::from(args.GetIsolate());
+  auto fetcher = js.alloc<Fetcher>(subrequestChannel, Fetcher::RequiresHostAndProtocol::NO, true);
+  auto method = JSG_REQUIRE_NONNULL(
+      fetcher->getRpcMethodInternal(js, kj::str("delete"_kj)), Error, "missing delete method");
+  return method->call(args);
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -160,44 +160,86 @@ class KvNamespace: public jsg::Object {
     // `Metadata` before `Key` type parameter for backwards-compatibility with `workers-types@3`.
     // `Key` is also an optional type parameter, which must come after required parameters.
 
-    JSG_TS_OVERRIDE(KVNamespace<Key extends string = string> {
-      get(key: Key, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<string | null>;
-      get(key: Key, type: "text"): Promise<string | null>;
-      get<ExpectedValue = unknown>(key: Key, type: "json"): Promise<ExpectedValue | null>;
-      get(key: Key, type: "arrayBuffer"): Promise<ArrayBuffer | null>;
-      get(key: Key, type: "stream"): Promise<ReadableStream | null>;
-      get(key: Key, options?: KVNamespaceGetOptions<"text">): Promise<string | null>;
-      get<ExpectedValue = unknown>(key: Key, options?: KVNamespaceGetOptions<"json">): Promise<ExpectedValue | null>;
-      get(key: Key, options?: KVNamespaceGetOptions<"arrayBuffer">): Promise<ArrayBuffer | null>;
-      get(key: Key, options?: KVNamespaceGetOptions<"stream">): Promise<ReadableStream | null>;
+    if (flags.getWorkerdExperimental()) {
+      JSG_TS_OVERRIDE(KVNamespace<Key extends string = string> {
+        get(key: Key, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<string | null>;
+        get(key: Key, type: "text"): Promise<string | null>;
+        get<ExpectedValue = unknown>(key: Key, type: "json"): Promise<ExpectedValue | null>;
+        get(key: Key, type: "arrayBuffer"): Promise<ArrayBuffer | null>;
+        get(key: Key, type: "stream"): Promise<ReadableStream | null>;
+        get(key: Key, options?: KVNamespaceGetOptions<"text">): Promise<string | null>;
+        get<ExpectedValue = unknown>(key: Key, options?: KVNamespaceGetOptions<"json">): Promise<ExpectedValue | null>;
+        get(key: Key, options?: KVNamespaceGetOptions<"arrayBuffer">): Promise<ArrayBuffer | null>;
+        get(key: Key, options?: KVNamespaceGetOptions<"stream">): Promise<ReadableStream | null>;
 
-      get(key: Array<Key>, type: "text"): Promise<Map<string, string | null>>;
-      get<ExpectedValue = unknown>(key: Array<Key>, type: "json"): Promise<Map<string, ExpectedValue | null>>;
-      get(key: Array<Key>, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<Map<string, string | null>>;
-      get(key: Array<Key>, options?: KVNamespaceGetOptions<"text">): Promise<Map<string, string | null>>;
-      get<ExpectedValue = unknown>(key: Array<Key>, options?: KVNamespaceGetOptions<"json">): Promise<Map<string, ExpectedValue | null>>;
+        get(key: Array<Key>, type: "text"): Promise<Map<string, string | null>>;
+        get<ExpectedValue = unknown>(key: Array<Key>, type: "json"): Promise<Map<string, ExpectedValue | null>>;
+        get(key: Array<Key>, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<Map<string, string | null>>;
+        get(key: Array<Key>, options?: KVNamespaceGetOptions<"text">): Promise<Map<string, string | null>>;
+        get<ExpectedValue = unknown>(key: Array<Key>, options?: KVNamespaceGetOptions<"json">): Promise<Map<string, ExpectedValue | null>>;
 
-      list<Metadata = unknown>(options?: KVNamespaceListOptions): Promise<KVNamespaceListResult<Metadata, Key>>;
+        list<Metadata = unknown>(options?: KVNamespaceListOptions): Promise<KVNamespaceListResult<Metadata, Key>>;
 
-      put(key: Key, value: string | ArrayBuffer | ArrayBufferView | ReadableStream, options?: KVNamespacePutOptions): Promise<void>;
+        put(key: Key, value: string | ArrayBuffer | ArrayBufferView | ReadableStream, options?: KVNamespacePutOptions): Promise<void>;
 
-      getWithMetadata<Metadata = unknown>(key: Key, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
-      getWithMetadata<Metadata = unknown>(key: Key, type: "text"): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
-      getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Key, type: "json"): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
-      getWithMetadata<Metadata = unknown>(key: Key, type: "arrayBuffer"): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
-      getWithMetadata<Metadata = unknown>(key: Key, type: "stream"): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
-      getWithMetadata<Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"text">): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
-      getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"json">): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
-      getWithMetadata<Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"arrayBuffer">): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
-      getWithMetadata<Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"stream">): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Key, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Key, type: "text"): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
+        getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Key, type: "json"): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Key, type: "arrayBuffer"): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Key, type: "stream"): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"text">): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
+        getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"json">): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"arrayBuffer">): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"stream">): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
 
-      getWithMetadata<Metadata = unknown>(key: Array<Key>, type: "text"): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>;
-      getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Array<Key>, type: "json"): Promise<Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
-      getWithMetadata<Metadata = unknown>(key: Array<Key>, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>;
-      getWithMetadata<Metadata = unknown>(key: Array<Key>, options?: KVNamespaceGetOptions<"text">): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>;
-      getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Array<Key>, options?: KVNamespaceGetOptions<"json">): Promise<Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
-      delete(key: Key): Promise<void>;
-    });
+        getWithMetadata<Metadata = unknown>(key: Array<Key>, type: "text"): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>;
+        getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Array<Key>, type: "json"): Promise<Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Array<Key>, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Array<Key>, options?: KVNamespaceGetOptions<"text">): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>;
+        getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Array<Key>, options?: KVNamespaceGetOptions<"json">): Promise<Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
+        delete(key: Key): Promise<void>;
+        deleteBulk(keys: Key | Key[]): Promise<void>;
+      });
+    } else {
+      JSG_TS_OVERRIDE(KVNamespace<Key extends string = string> {
+        get(key: Key, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<string | null>;
+        get(key: Key, type: "text"): Promise<string | null>;
+        get<ExpectedValue = unknown>(key: Key, type: "json"): Promise<ExpectedValue | null>;
+        get(key: Key, type: "arrayBuffer"): Promise<ArrayBuffer | null>;
+        get(key: Key, type: "stream"): Promise<ReadableStream | null>;
+        get(key: Key, options?: KVNamespaceGetOptions<"text">): Promise<string | null>;
+        get<ExpectedValue = unknown>(key: Key, options?: KVNamespaceGetOptions<"json">): Promise<ExpectedValue | null>;
+        get(key: Key, options?: KVNamespaceGetOptions<"arrayBuffer">): Promise<ArrayBuffer | null>;
+        get(key: Key, options?: KVNamespaceGetOptions<"stream">): Promise<ReadableStream | null>;
+
+        get(key: Array<Key>, type: "text"): Promise<Map<string, string | null>>;
+        get<ExpectedValue = unknown>(key: Array<Key>, type: "json"): Promise<Map<string, ExpectedValue | null>>;
+        get(key: Array<Key>, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<Map<string, string | null>>;
+        get(key: Array<Key>, options?: KVNamespaceGetOptions<"text">): Promise<Map<string, string | null>>;
+        get<ExpectedValue = unknown>(key: Array<Key>, options?: KVNamespaceGetOptions<"json">): Promise<Map<string, ExpectedValue | null>>;
+
+        list<Metadata = unknown>(options?: KVNamespaceListOptions): Promise<KVNamespaceListResult<Metadata, Key>>;
+
+        put(key: Key, value: string | ArrayBuffer | ArrayBufferView | ReadableStream, options?: KVNamespacePutOptions): Promise<void>;
+
+        getWithMetadata<Metadata = unknown>(key: Key, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Key, type: "text"): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
+        getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Key, type: "json"): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Key, type: "arrayBuffer"): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Key, type: "stream"): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"text">): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
+        getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"json">): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"arrayBuffer">): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"stream">): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
+
+        getWithMetadata<Metadata = unknown>(key: Array<Key>, type: "text"): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>;
+        getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Array<Key>, type: "json"): Promise<Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Array<Key>, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>;
+        getWithMetadata<Metadata = unknown>(key: Array<Key>, options?: KVNamespaceGetOptions<"text">): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>;
+        getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Array<Key>, options?: KVNamespaceGetOptions<"json">): Promise<Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
+        delete(key: Key): Promise<void>;
+      });
+    }
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {

--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <workerd/api/http.h>
 #include <workerd/api/streams/readable.h>
+#include <workerd/api/worker-rpc.h>
 #include <workerd/io/limit-enforcer.h>
 #include <workerd/jsg/jsg.h>
 
@@ -31,7 +33,7 @@ class KvNamespace: public jsg::Object {
   };
 
   // `subrequestChannel` is what to pass to IoContext::getHttpClient() to get an HttpClient
-  // representing this namespace.
+  // representing this namespace. It is also used to construct fetcher for JSRPC methods.
   // `additionalHeaders` is what gets appended to every outbound request.
   explicit KvNamespace(kj::Array<AdditionalHeader> additionalHeaders, uint subrequestChannel)
       : additionalHeaders(kj::mv(additionalHeaders)),
@@ -130,6 +132,7 @@ class KvNamespace: public jsg::Object {
       const jsg::TypeHandler<PutSupportedTypes>& putTypeHandler);
 
   jsg::Promise<void> delete_(jsg::Lock& js, kj::String name);
+  jsg::Ref<JsRpcPromise> deleteBulk(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   JSG_RESOURCE_TYPE(KvNamespace) {
     JSG_METHOD(get);
@@ -137,6 +140,8 @@ class KvNamespace: public jsg::Object {
     JSG_METHOD(put);
     JSG_METHOD(getWithMetadata);
     JSG_METHOD_NAMED(delete, delete_);
+    // Temporary method for tests
+    JSG_METHOD(deleteBulk);
 
     JSG_TS_ROOT();
 

--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -134,14 +134,16 @@ class KvNamespace: public jsg::Object {
   jsg::Promise<void> delete_(jsg::Lock& js, kj::String name);
   jsg::Ref<JsRpcPromise> deleteBulk(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  JSG_RESOURCE_TYPE(KvNamespace) {
+  JSG_RESOURCE_TYPE(KvNamespace, CompatibilityFlags::Reader flags) {
     JSG_METHOD(get);
     JSG_METHOD(list);
     JSG_METHOD(put);
     JSG_METHOD(getWithMetadata);
     JSG_METHOD_NAMED(delete, delete_);
-    // Temporary method for tests
-    JSG_METHOD(deleteBulk);
+    if (flags.getWorkerdExperimental()) {
+      // Temporary method for tests
+      JSG_METHOD(deleteBulk);
+    }
 
     JSG_TS_ROOT();
 

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -1919,7 +1919,7 @@ interface KVNamespace<Key extends string = string> {
     Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>
   >;
   delete(key: Key): Promise<void>;
-  deleteBulk(): JsRpcPromise;
+  deleteBulk(keys: Key | Key[]): Promise<void>;
 }
 interface KVNamespaceListOptions {
   limit?: number;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -1919,6 +1919,7 @@ interface KVNamespace<Key extends string = string> {
     Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>
   >;
   delete(key: Key): Promise<void>;
+  deleteBulk(): JsRpcPromise;
 }
 interface KVNamespaceListOptions {
   limit?: number;
@@ -2164,6 +2165,11 @@ type R2Objects = {
 );
 interface R2UploadPartOptions {
   ssecKey?: ArrayBuffer | string;
+}
+declare abstract class JsRpcPromise {
+  then(handler: Function, errorHandler?: Function): any;
+  catch(errorHandler: Function): any;
+  finally(onFinally: Function): any;
 }
 declare abstract class JsRpcProperty {
   then(handler: Function, errorHandler?: Function): any;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -1928,6 +1928,7 @@ export interface KVNamespace<Key extends string = string> {
     Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>
   >;
   delete(key: Key): Promise<void>;
+  deleteBulk(): JsRpcPromise;
 }
 export interface KVNamespaceListOptions {
   limit?: number;
@@ -2173,6 +2174,11 @@ export type R2Objects = {
 );
 export interface R2UploadPartOptions {
   ssecKey?: ArrayBuffer | string;
+}
+export declare abstract class JsRpcPromise {
+  then(handler: Function, errorHandler?: Function): any;
+  catch(errorHandler: Function): any;
+  finally(onFinally: Function): any;
 }
 export declare abstract class JsRpcProperty {
   then(handler: Function, errorHandler?: Function): any;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -1928,7 +1928,7 @@ export interface KVNamespace<Key extends string = string> {
     Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>
   >;
   delete(key: Key): Promise<void>;
-  deleteBulk(): JsRpcPromise;
+  deleteBulk(keys: Key | Key[]): Promise<void>;
 }
 export interface KVNamespaceListOptions {
   limit?: number;


### PR DESCRIPTION
Adding temporary `deleteBulk` method would allow us to test our JSRPC implementation before replacing `delete` method for the binding.