### PR TITLE
fix(ai type): add `query` field to `Ai_Cf_Baai_Bge_Reranker_Base_Input`

### DIFF
--- a/types/defines/ai.d.ts
+++ b/types/defines/ai.d.ts
@@ -831,6 +831,7 @@ export interface Ai_Cf_Baai_Bge_Reranker_Base_Input {
   /**
    * A query you wish to perform against the provided contexts.
    */
+  query: string;
   /**
    * Number of returned results starting with the best score.
    */


### PR DESCRIPTION
Fix to issue #4151

Adds missed key `query` for the following schemas:
@cf/baai/bge-base-en-v1.5

https://developers.cloudflare.com/workers-ai/models/bge-reranker-base/
