### PR TITLE
Add jsg::Lock::current() to replace v8::Isolate::GetCurrent()

### DIFF
--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -1866,7 +1866,7 @@ jsg::Promise<void> WritableStreamInternalController::Pipe::write(v8::Local<v8::V
   kj::byte* data = reinterpret_cast<kj::byte*>(store->Data()) + byteOffset;
   // TODO(cleanup): Have this method accept a jsg::Lock& from the caller instead of using
   // v8::Isolate::GetCurrent();
-  jsg::Lock& js = jsg::Lock::from(v8::Isolate::GetCurrent());
+  auto& js = jsg::Lock::current();
   return IoContext::current().awaitIo(js,
       writable->canceler.wrap(writable->sink->write(kj::arrayPtr(data, byteLength)))
           .attach(js.v8Ref(v8::ArrayBuffer::New(js.v8Isolate, store))),

--- a/src/workerd/api/urlpattern-standard.c++
+++ b/src/workerd/api/urlpattern-standard.c++
@@ -9,7 +9,7 @@
 namespace workerd::api::urlpattern {
 std::optional<URLPattern::URLPatternRegexEngine::regex_type> URLPattern::URLPatternRegexEngine::
     create_instance(std::string_view pattern, bool ignore_case) {
-  jsg::Lock& js = jsg::Lock::from(v8::Isolate::GetCurrent());
+  auto& js = jsg::Lock::current();
   jsg::Lock::RegExpFlags flags = jsg::Lock::RegExpFlags::kUNICODE_SETS;
   if (ignore_case) {
     flags = static_cast<jsg::Lock::RegExpFlags>(
@@ -23,13 +23,13 @@ std::optional<URLPattern::URLPatternRegexEngine::regex_type> URLPattern::URLPatt
 
 bool URLPattern::URLPatternRegexEngine::regex_match(
     std::string_view input, const regex_type& pattern) {
-  jsg::Lock& js = jsg::Lock::from(v8::Isolate::GetCurrent());
+  auto& js = jsg::Lock::current();
   return pattern.getHandle(js).match(js, kj::StringPtr(input.data(), input.size()));
 }
 
 std::optional<std::vector<std::optional<std::string>>> URLPattern::URLPatternRegexEngine::
     regex_search(std::string_view input, const regex_type& pattern) {
-  jsg::Lock& js = jsg::Lock::from(v8::Isolate::GetCurrent());
+  auto& js = jsg::Lock::current();
   KJ_IF_SOME(matches, pattern.getHandle(js)(js, kj::StringPtr(input.data(), input.size()))) {
     std::vector<std::optional<std::string>> results(matches.size() - 1);
     // The first value is always the input of the exec() command. Therefore

--- a/src/workerd/jsg/function.h
+++ b/src/workerd/jsg/function.h
@@ -152,9 +152,7 @@ class Function<Ret(Args...)> {
       Args...);
 
   Function(Wrapper* wrapper, V8Ref<v8::Object> receiver, V8Ref<v8::Function> function)
-      : Function(wrapper,
-            receiver.cast<v8::Value>(Lock::from(v8::Isolate::GetCurrent())),
-            kj::mv(function)) {}
+      : Function(wrapper, receiver.cast<v8::Value>(jsg::Lock::current()), kj::mv(function)) {}
 
   // Construct jsg::Function wrapping a JavaScript function.
   Function(Wrapper* wrapper, Value receiver, V8Ref<v8::Function> function)

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -15,11 +15,8 @@
 namespace workerd::jsg {
 
 kj::String stringifyHandle(v8::Local<v8::Value> value) {
-  // This is the only place in the entire codebase where we use v8::Isolate::GetCurrent(). It's
-  // hard to avoid since we want `kj::str(handle)` to work, which doesn't give us a chance to
-  // pass in a `Lock` or whatever.
   // TODO(cleanup): Perhaps we should require you to call `js.toString(handle)`?
-  auto& js = jsg::Lock::from(v8::Isolate::GetCurrent());
+  auto& js = jsg::Lock::current();
   return js.withinHandleScope([&] {
     v8::Local<v8::String> str = workerd::jsg::check(value->ToDetailString(js.v8Context()));
     v8::String::Utf8Value utf8(js.v8Isolate, str);

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2413,6 +2413,10 @@ class Lock {
     return *reinterpret_cast<Lock*>(v8Isolate->GetData(SET_DATA_LOCK));
   }
 
+  static Lock& current() {
+    return from(v8::Isolate::GetCurrent());
+  }
+
   // RAII construct that reports amount of external memory to be manually attributed to
   // the isolate. When the returned ExtrernalMemoryAdjuster is dropped, the amount will
   // be subtracted from the isolate's external memory accounting. If the adjuster is

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2413,6 +2413,8 @@ class Lock {
     return *reinterpret_cast<Lock*>(v8Isolate->GetData(SET_DATA_LOCK));
   }
 
+  // TODO(someday): A clang-tidy rule to enforce use of Lock::current over
+  // v8::Isolate::GetCurrent would be helpful.
   static Lock& current() {
     return from(v8::Isolate::GetCurrent());
   }

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -557,7 +557,7 @@ class JsRef final {
   // requires V8Ref types.
   template <typename U>
   operator V8Ref<U>() && {
-    return kj::mv(value).template cast<U>(Lock::from(v8::Isolate::GetCurrent()));
+    return kj::mv(value).template cast<U>(jsg::Lock::current());
   }
 
   JSG_MEMORY_INFO(JsRef) {
@@ -580,7 +580,7 @@ inline JsRef<Self> JsBase<T, Self>::addRef(Lock& js) {
 }
 
 inline kj::String KJ_STRINGIFY(const JsValue& value) {
-  return value.toString(Lock::from(v8::Isolate::GetCurrent()));
+  return value.toString(jsg::Lock::current());
 }
 
 template <typename TypeWrapper>

--- a/src/workerd/jsg/ser.c++
+++ b/src/workerd/jsg/ser.c++
@@ -72,11 +72,10 @@ void Serializer::throwDataCloneErrorForObject(jsg::Lock& js, v8::Local<v8::Objec
 }
 
 void Serializer::ThrowDataCloneError(v8::Local<v8::String> message) {
-  auto isolate = v8::Isolate::GetCurrent();
+  auto& js = jsg::Lock::current();
   try {
-    Lock& js = Lock::from(isolate);
     auto exception = js.domException(kj::str("DataCloneError"), kj::str(message));
-    isolate->ThrowException(KJ_ASSERT_NONNULL(exception.tryGetHandle(js)));
+    js.v8Isolate->ThrowException(KJ_ASSERT_NONNULL(exception.tryGetHandle(js)));
   } catch (JsExceptionThrown&) {
     // Apparently an exception was thrown during the construction of the DOMException. Most likely
     // we were terminated. In any case, we'll let that exception stay scheduled and propagate back
@@ -84,7 +83,7 @@ void Serializer::ThrowDataCloneError(v8::Local<v8::String> message) {
   } catch (...) {
     // A KJ exception was thrown, we'll have to convert it to JavaScript and propagate that
     // exception instead.
-    throwInternalError(isolate, kj::getCaughtExceptionAsKj());
+    throwInternalError(js.v8Isolate, kj::getCaughtExceptionAsKj());
   }
 }
 


### PR DESCRIPTION
Direct use of `v8::Isolate::GetCurrent()` is something that we've tried to avoid but does creep in every so often. Let's provide a more useful utility to avoid it a bit better.