### PR TITLE
Refactor how RPCs are delivered

### DIFF
--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -221,6 +221,10 @@ export class MyService extends WorkerEntrypoint {
     throw new Error('METHOD THREW');
   }
 
+  async neverReturn() {
+    await new Promise((resolve) => {});
+  }
+
   async tryUseGlobalRpcPromise() {
     return await globalRpcPromise;
   }
@@ -768,6 +772,12 @@ export let namedServiceBinding = {
       message:
         'Could not serialize object of type "Object". This type does not support ' +
         'serialization.',
+    });
+
+    // A stateless entryponit method that never returns should fail due to PendingEvent tracking.
+    await assert.rejects(() => env.MyService.neverReturn(), {
+      name: 'Error',
+      message: 'The script will never generate a response.',
     });
 
     {

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -505,6 +505,11 @@ class IoContext::PendingEvent: public kj::Refcounted {
 };
 
 IoContext::~IoContext() noexcept(false) {
+  if (!canceler.isEmpty()) {
+    canceler.cancel(JSG_KJ_EXCEPTION(
+        FAILED, Error, "The execution context responding to this call was canceled."));
+  }
+
   // Detach the PendingEvent if it still exists.
   KJ_IF_SOME(pe, pendingEvent) {
     pe.maybeContext = kj::none;

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -433,7 +433,7 @@ void IoContext::addWaitUntil(kj::Promise<void> promise) {
   }
 
   if (incomingRequests.empty()) {
-    KJ_LOG(WARNING, "Adding task to IoContext with no current IncomingRequest",
+    DEBUG_FATAL_RELEASE_LOG(WARNING, "Adding task to IoContext with no current IncomingRequest",
         lastDeliveredLocation, kj::getStackTrace());
   }
 

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -513,6 +513,54 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   template <typename T>
   kj::_::ReducePromises<RemoveIoOwn<T>> awaitJs(jsg::Lock& js, jsg::Promise<T> promise);
 
+  // Make a kj::Function which, when called, re-enters this IoContext to run some code.
+  //
+  // `func` is a function with a signature similar to:
+  //
+  //     template <typename... Params, typename Result>
+  //     jsg::Promise<Result> func(jsg::Lock& js, Params&&... params);
+  //
+  // (Optionally, the `jsg::Promise<Result>` can just be `Result` instead.)
+  //
+  // The returned lambda will a signature like:
+  //
+  //     kj::Promise<Result> func(Params&&...);
+  //
+  // This function can be invoked without holding the isolate lock.
+  //
+  // You might think that all this does is set up a lambda that captures the IoContext and calls
+  // ctx.run(). But, it turns out getting this right is a lot more complicated.
+  // - What if the IoContext has been canceled / destroyed, or is destroyed during the callback?
+  // - What if it still exists, but it's an actor and there's no longer an IncomingRequest?
+  // - How do you prevent "the script will never generate a response" if the callback is the
+  //   only thing being waited for?
+  // - What if the call was made within blockConcurrencyWhile()? The callback will be blocked until
+  //   the critical section ends, which could lead to deadlock if the critical section code is
+  //   waiting on it?
+  //
+  // This solves all that:
+  // - If the IoContext is destroyed, the callback throws an exception.
+  // - However, as long as the callback itself exists, it is treated as if a task were added using
+  //   addTask(). In actors, this blocks hibernation and keeps the IncomingRequest live.
+  // - Additionally, the calback counts as a PendingEvent.
+  // - The callback is allowed to run within the critical section (blockConcurrencyWhile()) from
+  //   which it was called.
+  //
+  // In short, you should almost never use ctx.run() to re-enter an existing context. You almost
+  // always want either awaitIo() (to re-enter the context after some KJ promise completes) or
+  // makeReentryCallback() (to re-enter the context on a callback).
+  //
+  // The returned function can be called multiple times.
+  //
+  // Note that when invoking the returned function, the function object itself must outlive the
+  // Promise it returns -- just like a coroutine lambda that has a capture. This should, of course,
+  // be assumed of all functions that return promises, but classically kj::Promise's own `.then()`
+  // does not keep its input continuation functions live in this way. If you want to pass the
+  // callback to `.then()`, you can wrap it in `kj::coCapture()`, but note that this means it can
+  // only be called once.
+  template <typename Func>
+  auto makeReentryCallback(Func func);
+
   // Returns the number of times addTask() has been called (even if the tasks have completed).
   uint taskCount() {
     return addTaskCounter;
@@ -916,6 +964,11 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   // IoContext (e.g. in the ActorContext) MUST be canceled when the IoContext is
   // destructed.
   kj::Own<TimeoutManager> timeoutManager;
+
+  // This canceler will be canceled when the IoContext is destroyed. Use it to wrap promises that
+  // need to be held externally but which should error if the IoContext is canceled. This is used
+  // for `makeReentryCallback()` in particular.
+  kj::Canceler canceler;
 
   kj::Own<WorkerInterface> getSubrequestChannelImpl(uint channel,
       bool isInHouse,
@@ -1387,6 +1440,44 @@ kj::_::ReducePromises<RemoveIoOwn<T>> IoContext::awaitJs(jsg::Lock& js, jsg::Pro
   }
 
   return kj::mv(paf.promise);
+}
+
+template <typename Func>
+auto IoContext::makeReentryCallback(Func func) {
+  // We need to:
+  // - Use addTask() to make sure that, if we're in an actor, the IncomingEvent stays alive while
+  //   the callback exists (and hibernation is blocked).
+  // - Call registerPendingEvent() to make sure that, if we're NOT in an actor, we don't conclude
+  //   that there's nothing left to wait for while the callback exists.
+  // TODO(perf): Probably both of these things could be done in simpler ways involving less
+  //   allocation, but it would require some refactoring.
+  auto [promise, fulfiller] = kj::newPromiseAndFulfiller<void>();
+  addTask(kj::mv(promise));
+  auto releaseNotifier =
+      kj::defer([fulfiller = kj::mv(fulfiller), pe = registerPendingEvent()]() mutable {
+    fulfiller->fulfill();
+  });
+
+  return [self = getWeakRef(), cs = getCriticalSection(), releaseNotifier = kj::mv(releaseNotifier),
+             func = kj::fwd<Func>(func)](auto&&... params) mutable {
+    auto& ctx = JSG_REQUIRE_NONNULL(self->tryGet(), Error,
+        "The execution context which hosts this callback is no longer running.");
+
+    return ctx.canceler.wrap(ctx.run(
+        [&ctx, &func, ... params = kj::fwd<decltype(params)>(params)](Worker::Lock& lock) mutable {
+      using ResultType = kj::Decay<decltype(func(lock, kj::fwd<decltype(params)>(params)...))>;
+
+      if constexpr (kj::isSameType<ResultType, void>()) {
+        (void)ctx;
+        func(lock, kj::fwd<decltype(params)>(params)...);
+      } else if constexpr (jsg::isPromise<ResultType>()) {
+        return ctx.awaitJs(lock, func(lock, kj::fwd<decltype(params)>(params)...));
+      } else {
+        (void)ctx;
+        return func(lock, kj::fwd<decltype(params)>(params)...);
+      }
+    }, kj::mv(cs)));
+  };
 }
 
 template <typename T>

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -1451,6 +1451,10 @@ kj::_::ReducePromises<RemoveIoOwn<T>> IoContext::awaitJs(jsg::Lock& js, jsg::Pro
 
 template <IoContext::TopUpFlag topUp, typename Func>
 auto IoContext::makeReentryCallback(Func func) {
+  // A reentry callback is meant for *re-*entry, so should only be created while already inside
+  // the IoContext. Initial entry into the IoContext should just use run().
+  requireCurrent();
+
   // We need to:
   // - Use addTask() to make sure that, if we're in an actor, the IncomingEvent stays alive while
   //   the callback exists (and hibernation is blocked).


### PR DESCRIPTION
This introduces `IoContext::makeReentryCallback()`, which takes a function intended to run under the isolate lock, and returns a function which can be invoked _outside_ the lock, and which will do all the necessary things to enter the isolate. This has proven more complicated than it looks. See the doc comment for details.

I created this for a different use case, but in this PR I went ahead and used it to clean up how JsRpcTarget works, as I was fairly unhappy with the existing code.

This fixes at least one bug with RPC: If you made an RPC call during blockConcurrentlyWhile, and passed it a callback, calls to the callback would be blocked until the end of blockConcurrencyWhile. This goes against the usual semantics of blockConcurrencyWhile, which says that interactions initiated from _inside_ the block are allowed to complete inside the block.

This PR also fixes the warning `Adding task to IoContext with no current IncomingRequest`, but sort of by accident, and there are deeper underlying problems there which aren't actually fixed. I might work on that in a separate PR.