### PR TITLE
Cleanup the AsyncDispose symbols

### DIFF
--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -281,13 +281,6 @@ Name Lock::newApiSymbol(kj::StringPtr symbol) {
   return Name(*this, v8::Symbol::ForApi(v8Isolate, v8StrIntern(v8Isolate, symbol)));
 }
 
-JsSymbol Lock::symbolDispose() {
-  return JsSymbol(v8::Symbol::GetDispose(v8Isolate));
-}
-JsSymbol Lock::symbolAsyncDispose() {
-  return IsolateBase::from(v8Isolate).getSymbolAsyncDispose();
-}
-
 kj::Maybe<JsObject> Lock::resolveInternalModule(kj::StringPtr specifier) {
   auto& isolate = IsolateBase::from(v8Isolate);
   if (isolate.isUsingNewModuleRegistry()) {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2226,7 +2226,9 @@ class JsRef;
   V(Split)                                                                                         \
   V(ToPrimitive)                                                                                   \
   V(ToStringTag)                                                                                   \
-  V(Unscopables)
+  V(Unscopables)                                                                                   \
+  V(Dispose)                                                                                       \
+  V(AsyncDispose)
 
 class JsValue;
 class JsMessage;
@@ -2800,8 +2802,6 @@ class Lock {
 #define V(Name) JsSymbol symbol##Name() KJ_WARN_UNUSED_RESULT;
   JS_V8_SYMBOLS(V)
 #undef V
-  JsSymbol symbolDispose() KJ_WARN_UNUSED_RESULT;
-  JsSymbol symbolAsyncDispose() KJ_WARN_UNUSED_RESULT;
 
   void runMicrotasks();
   void terminateExecution();

--- a/src/workerd/jsg/resource.c++
+++ b/src/workerd/jsg/resource.c++
@@ -27,9 +27,6 @@ void exposeGlobalScopeType(v8::Isolate* isolate, v8::Local<v8::Context> context)
 v8::Local<v8::Symbol> getSymbolDispose(v8::Isolate* isolate) {
   return v8::Symbol::GetDispose(isolate);
 }
-v8::Local<v8::Symbol> getSymbolAsyncDispose(v8::Isolate* isolate) {
-  return v8::Symbol::GetAsyncDispose(isolate);
-}
 
 void throwIfConstructorCalledAsFunction(
     const v8::FunctionCallbackInfo<v8::Value>& args, const std::type_info& type) {

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -1006,7 +1006,6 @@ constexpr bool hasConstructorMethod(...) {
 void exposeGlobalScopeType(v8::Isolate* isolate, v8::Local<v8::Context> context);
 
 v8::Local<v8::Symbol> getSymbolDispose(v8::Isolate* isolate);
-v8::Local<v8::Symbol> getSymbolAsyncDispose(v8::Isolate* isolate);
 
 // A configuration type that can be derived from any input type, because it contains nothing.
 class NullConfiguration {
@@ -1413,7 +1412,7 @@ struct ResourceTypeBuilder {
 
   template <const char* name, typename Method, Method method>
   inline void registerDispose() {
-    prototype->Set(getSymbolDispose(isolate),
+    prototype->Set(v8::Symbol::GetDispose(isolate),
         v8::FunctionTemplate::New(isolate,
             &MethodCallback<TypeWrapper, name, isContext, Self, Method, method,
                 ArgumentIndexes<Method>>::callback,
@@ -1423,7 +1422,7 @@ struct ResourceTypeBuilder {
 
   template <const char* name, typename Method, Method method>
   inline void registerAsyncDispose() {
-    prototype->Set(getSymbolAsyncDispose(isolate),
+    prototype->Set(v8::Symbol::GetAsyncDispose(isolate),
         v8::FunctionTemplate::New(isolate,
             &MethodCallback<TypeWrapper, name, isContext, Self, Method, method,
                 ArgumentIndexes<Method>>::callback,

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -417,12 +417,6 @@ IsolateBase::IsolateBase(
       auto opaqueTemplate = v8::FunctionTemplate::New(ptr, &throwIllegalConstructor);
       opaqueTemplate->InstanceTemplate()->SetInternalFieldCount(Wrappable::INTERNAL_FIELD_COUNT);
       this->opaqueTemplate.Reset(ptr, opaqueTemplate);
-
-      // Create Symbol.dispose and Symbol.asyncDispose.
-      symbolAsyncDispose.Reset(ptr,
-          v8::Symbol::New(ptr,
-              v8::String::NewFromUtf8(ptr, "asyncDispose", v8::NewStringType::kInternalized)
-                  .ToLocalChecked()));
     }
   });
 }
@@ -460,7 +454,6 @@ void IsolateBase::dropWrappers(kj::FunctionParam<void()> drop) {
     KJ_DEFER(heapTracer.destroy());
 
     // Make sure v8::Globals are destroyed under lock (but not until later).
-    KJ_DEFER(symbolAsyncDispose.Reset());
     KJ_DEFER(opaqueTemplate.Reset());
     KJ_DEFER(workerEnvObj.Reset());
 

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -206,10 +206,6 @@ class IsolateBase {
     return true;
   }
 
-  JsSymbol getSymbolAsyncDispose() {
-    return JsSymbol(symbolAsyncDispose.Get(ptr));
-  }
-
   // Get an object referencing this isolate that can be used to adjust external memory usage later
   kj::Own<const ExternalMemoryTarget> getExternalMemoryTarget();
 
@@ -297,9 +293,6 @@ class IsolateBase {
 
   // Object used as the underlying storage for a workers environment.
   v8::Global<v8::Object> workerEnvObj;
-
-  // Polyfilled Symbol.asyncDispose.
-  v8::Global<v8::Symbol> symbolAsyncDispose;
 
   /* *** External Memory accounting *** */
   // ExternalMemoryTarget holds a weak reference back to the isolate. ExternalMemoryAjustments


### PR DESCRIPTION
Remove obsolete stuff relating to `Symbol.asyncDispose`/`Symbol.dispose`. Once we update workerd to 13.7 we should be able to drop the additional patches that polyfill the `GetDispose()` and `GetAsyncDispose()` APIs.