### PR TITLE
Implement connect_pass_through experimental compat flag.

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -774,4 +774,25 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
     $compatDisableFlag("disable_request_signal");
   # Enables Request.signal for incoming requests.
   # This feature is still experimental and the compat flag has no default enable date.
+
+  connectPassThrough @91 :Bool
+    $compatEnableFlag("connect_pass_through")
+    $experimental;
+  # Causes the Worker to handle incoming connect events by simply passing them through to the
+  # Worker's globalOutbound (typically, the internet).
+  #
+  # As of this writing, Workers cannot yet receive raw socket connections, because no API has been
+  # defined for doing so. But a Worker can be configured to be the `globalOutbound` for another
+  # Worker, causing the first Worker to intercept all outbound network requests that the second
+  # Worker makes by calling `fetch()` or `connect()`. Since there's no way for the first Worker
+  # to actually handle the `connect()` requests, this implies the second Worker cannot make any
+  # raw TCP connections in this configuration. This is intended: often, the first Worker
+  # implements some sort of security rules governing what kinds of requests the second Worker can
+  # send to the internet, and if `connect()` requests were allowed to go directly to the internet,
+  # that could be used to bypass said security checks.
+  #
+  # However, sometimes outbound workers are used for reasons other than security, and in fact the
+  # outbound Worker does not really care to block `connect()` requests. Until such a time as we
+  # create an actual API for proxying connections, such outbound workers can set this compat flag
+  # to opt into allowing connect requests to pass through.
 }

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -498,7 +498,7 @@ kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host,
     kj::AsyncIoStream& connection,
     ConnectResponse& response,
     kj::HttpConnectSettings settings) {
-  TRACE_EVENT("workerd", "WorkerEntrypoint::runScheduled()");
+  TRACE_EVENT("workerd", "WorkerEntrypoint::connect()");
   auto incomingRequest =
       kj::mv(KJ_REQUIRE_NONNULL(this->incomingRequest, "connect() can only be called once"));
   this->incomingRequest = kj::none;

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -498,6 +498,31 @@ kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host,
     kj::AsyncIoStream& connection,
     ConnectResponse& response,
     kj::HttpConnectSettings settings) {
+  TRACE_EVENT("workerd", "WorkerEntrypoint::runScheduled()");
+  auto incomingRequest =
+      kj::mv(KJ_REQUIRE_NONNULL(this->incomingRequest, "connect() can only be called once"));
+  this->incomingRequest = kj::none;
+  incomingRequest->delivered();
+  auto& context = incomingRequest->getContext();
+
+  KJ_DEFER({
+    // Since we called incomingRequest->delivered, we are obliged to call `drain()`.
+    auto promise = incomingRequest->drain().attach(kj::mv(incomingRequest));
+    waitUntilTasks.add(maybeAddGcPassForTest(context, kj::mv(promise)));
+  });
+
+  if (context.getWorker().getIsolate().getApi().getFeatureFlags().getConnectPassThrough()) {
+    // connect_pass_through feature flag means we should just forward the connect request on to
+    // the global outbound.
+
+    auto next = context.getSubrequestChannelNoChecks(
+        IoContext::NEXT_CLIENT_CHANNEL, false, kj::mv(cfBlobJson));
+
+    // Note: Intentionally return without co_await so that the `incomingRequest` is destroyed,
+    //   because we don't have any need to keep the context around.
+    return next->connect(host, headers, connection, response, settings);
+  }
+
   JSG_FAIL_REQUIRE(TypeError, "Incoming CONNECT on a worker not supported");
 }
 


### PR DESCRIPTION
See comments in compatibility-date.capnp for explanation. Miniflare needs this.

cc @penalosa 