### PR TITLE
Expand float16 support

### DIFF
--- a/src/node/internal/internal_comparisons.ts
+++ b/src/node/internal/internal_comparisons.ts
@@ -66,7 +66,7 @@ function areSimilarRegExps(a: RegExp, b: RegExp) {
   );
 }
 
-type FloatArray = Float32Array | Float64Array;
+type FloatArray = Float16Array | Float32Array | Float64Array;
 type AnyArrayBuffer = ArrayBuffer | SharedArrayBuffer;
 
 type Memos = {

--- a/src/node/internal/util.d.ts
+++ b/src/node/internal/util.d.ts
@@ -82,7 +82,7 @@ export function isBooleanObject(value: unknown): value is boolean;
 export function isDataView(value: unknown): value is DataView;
 export function isDate(value: unknown): value is Date;
 export function isExternal(value: unknown): boolean;
-export function isFloat16Array(value: unknown): boolean; // TODO: change to value is Float16Array
+export function isFloat16Array(value: unknown): value is Float16Array;
 export function isFloat32Array(value: unknown): value is Float32Array;
 export function isFloat64Array(value: unknown): value is Float64Array;
 export function isGeneratorFunction(value: unknown): value is GeneratorFunction;

--- a/src/workerd/api/node/tests/buffer-nodejs-test.js
+++ b/src/workerd/api/node/tests/buffer-nodejs-test.js
@@ -1700,6 +1700,8 @@ export const byteLength = {
     strictEqual(Buffer.byteLength(int32), 32);
     const uint32 = new Uint32Array(8);
     strictEqual(Buffer.byteLength(uint32), 32);
+    const float16 = new Float16Array(8);
+    strictEqual(Buffer.byteLength(float16), 16);
     const float32 = new Float32Array(8);
     strictEqual(Buffer.byteLength(float32), 32);
     const float64 = new Float64Array(8);

--- a/src/workerd/api/node/tests/crypto_pbkdf2-test.js
+++ b/src/workerd/api/node/tests/crypto_pbkdf2-test.js
@@ -284,6 +284,7 @@ export const TypedArray_tests = {
       Uint8Array,
       Uint16Array,
       Uint32Array,
+      Float16Array,
       Float32Array,
       Float64Array,
       ArrayBuffer,

--- a/src/workerd/api/node/tests/string-decoder-test.js
+++ b/src/workerd/api/node/tests/string-decoder-test.js
@@ -48,6 +48,7 @@ function getArrayBufferViews(buf) {
     Uint16Array,
     Int32Array,
     Uint32Array,
+    Float16Array,
     Float32Array,
     Float64Array,
     BigInt64Array,

--- a/src/workerd/api/node/tests/util-nodejs-test.js
+++ b/src/workerd/api/node/tests/util-nodejs-test.js
@@ -286,6 +286,7 @@ export const utilInspect = {
     }
 
     [
+      Float16Array,
       Float32Array,
       Float64Array,
       Int16Array,
@@ -2416,6 +2417,7 @@ export const utilInspect = {
       [new Int8Array(2), '[Int8Array(2): null prototype] [ 0, 0 ]'],
       [new Int16Array(2), '[Int16Array(2): null prototype] [ 0, 0 ]'],
       [new Int32Array(2), '[Int32Array(2): null prototype] [ 0, 0 ]'],
+      [new Float16Array(2), '[Float16Array(2): null prototype] [ 0, 0 ]'],
       [new Float32Array(2), '[Float32Array(2): null prototype] [ 0, 0 ]'],
       [new Float64Array(2), '[Float64Array(2): null prototype] [ 0, 0 ]'],
       [new BigInt64Array(2), '[BigInt64Array(2): null prototype] [ 0n, 0n ]'],
@@ -4615,6 +4617,11 @@ export const testTypes = {
     }
 
     {
+      assert.ok(isFloat16Array(new Float16Array(0)));
+      assert.ok(!isFloat16Array(1));
+    }
+
+    {
       assert.ok(isFloat32Array(new Float32Array(0)));
       assert.ok(!isFloat32Array(1));
     }
@@ -4670,15 +4677,6 @@ export const testTypes = {
       // We don't really expose any externals in any existing APIS
       // where this would be useful, but hey, let's test it anyway.
       assert.ok(!isExternal({}));
-    }
-
-    // TODO(soon): Remove this when Float16Array is available unflagged.
-    // The proposal is stage 4 and the v8 C++ APIs are available, but the
-    // flag is still currently required to use it in JavaScript. We aren't
-    // setting that flag but we can still prepare for it to be available.
-    if (globalThis.Float16Array !== undefined) {
-      assert.ok(isFloat16Array(new Float16Array(0)));
-      assert.ok(!isFloat16Array(1));
     }
   },
 };

--- a/src/workerd/api/tests/encoding-test.js
+++ b/src/workerd/api/tests/encoding-test.js
@@ -348,6 +348,7 @@ export const encodeWptTest = {
         Uint16Array,
         Uint32Array,
         Uint8ClampedArray,
+        Float16Array,
         Float32Array,
         Float64Array,
       ].forEach((view) => {

--- a/src/workerd/jsg/buffersource-test.c++
+++ b/src/workerd/jsg/buffersource-test.c++
@@ -87,6 +87,8 @@ KJ_TEST("BufferSource works") {
 
   e.expectEval("const ab = new BigInt64Array(1); takeBufferSource(ab) === ab", "boolean", "true");
 
+  e.expectEval("const ab = new Float16Array(4); takeBufferSource(ab) === ab", "boolean", "true");
+
   e.expectEval("const ab = new Float32Array(2); takeBufferSource(ab) === ab", "boolean", "true");
 
   e.expectEval("const ab = new Float64Array(1); takeBufferSource(ab) === ab", "boolean", "true");

--- a/src/workerd/jsg/buffersource.h
+++ b/src/workerd/jsg/buffersource.h
@@ -18,6 +18,7 @@ namespace workerd::jsg {
   V(Int8Array, 1, true)                                                                            \
   V(Int16Array, 2, true)                                                                           \
   V(Int32Array, 4, true)                                                                           \
+  V(Float16Array, 2, false)                                                                        \
   V(Float32Array, 4, false)                                                                        \
   V(Float64Array, 8, false)                                                                        \
   V(BigInt64Array, 8, true)                                                                        \

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -61,8 +61,8 @@ class V8HandleWrapper {
 #define JSG_FOR_EACH_V8_VALUE_SUBCLASS(f)                                                          \
   f(ArrayBuffer) f(ArrayBufferView) f(TypedArray) f(DataView) f(Int8Array) f(Uint8Array)           \
       f(Uint8ClampedArray) f(Int16Array) f(Uint16Array) f(Int32Array) f(Uint32Array)               \
-          f(Float32Array) f(Float64Array) f(Object) f(String) f(Function) f(WasmMemoryObject)      \
-              f(BigInt)
+          f(Float16Array) f(Float32Array) f(Float64Array) f(Object) f(String) f(Function)          \
+              f(WasmMemoryObject) f(BigInt)
 
   // Define a tryUnwrap() overload for each interesting subclass of v8::Value.
 #define JSG_DEFINE_TRY_UNWRAP(type)                                                                \

--- a/src/wpt/WebCryptoAPI-test.ts
+++ b/src/wpt/WebCryptoAPI-test.ts
@@ -202,10 +202,7 @@ export default {
     skipAllTests: true,
   },
 
-  'getRandomValues.any.js': {
-    comment: 'Enable once Float16Array is exposed',
-    expectedFailures: ['Float16 arrays'],
-  },
+  'getRandomValues.any.js': {},
   'historical.any.js': {
     comment: 'To investigate but appears irrelevant to workerd',
     expectedFailures: [

--- a/src/wpt/encoding-test.ts
+++ b/src/wpt/encoding-test.ts
@@ -12,9 +12,6 @@ export default {
   'encodeInto.any.js': {
     comment: 'See comments on each failure',
     expectedFailures: [
-      // Enable once Float16Array is available
-      'Invalid encodeInto() destination: Float16Array, backed by: ArrayBuffer',
-      'Invalid encodeInto() destination: Float16Array, backed by: SharedArrayBuffer',
       // Enable once MessageChannel is implemented
       'encodeInto() and a detached output buffer',
     ],


### PR DESCRIPTION
Now that we have float16 support enabled, we can get most tests using float16 to work. Note that this is still incomplete since Node's types do not include float16 in the TypedArray definition yet.