### PR TITLE
disallow kj::Promise in v8 fast api

### DIFF
--- a/src/workerd/jsg/fast-api-test.c++
+++ b/src/workerd/jsg/fast-api-test.c++
@@ -300,6 +300,7 @@ KJ_TEST("isFastApiCompatible Detection") {
   using PromiseMethod = jsg::Promise<int> (FastMethodContext::*)(int32_t);
   using MaybeVoidMethod = kj::Maybe<void> (FastMethodContext::*)();
   using StaticMethodContainerMethod = void(StaticMethodContainer);
+  using KjPromiseMethod = void (FastMethodContext::*)(kj::Promise<void>);
 
   // Static assertions for compatible method types
   // --------------------------------------------
@@ -358,11 +359,7 @@ KJ_TEST("isFastApiCompatible Detection") {
   static_assert(!isFastApiCompatible<MaybeVoidMethod>,
       "Methods returning Maybe<void> should not be fast-method compatible");
   static_assert(isFastApiCompatible<StaticMethodContainerMethod>, "This should be compatible");
-
-  // jsg::test::Evaluator<FastMethodContext, FastMethodIsolate> e(v8System);
-  // auto& wrapper = FastMethodIsolate_TypeWrapper::from(e.getIsolate().ptr);
-  // Foo foo = wrapper.unwrap<Foo>(
-  //     v8::Local<v8::Context>(), v8::Local<v8::Value>(), TypeErrorContext::arrayElement(1));
+  static_assert(!isFastApiCompatible<KjPromiseMethod>, "Promise is not compatible");
 }
 
 }  // namespace

--- a/src/workerd/jsg/fast-api.h
+++ b/src/workerd/jsg/fast-api.h
@@ -16,6 +16,7 @@
 #include <v8-local-handle.h>
 #include <v8-value.h>
 
+#include <kj/async.h>
 #include <kj/common.h>
 
 namespace workerd::jsg {
@@ -28,6 +29,12 @@ constexpr bool isFunctionCallbackInfo = false;
 template <typename T>
 constexpr bool isFunctionCallbackInfo<v8::FunctionCallbackInfo<T>> = true;
 
+template <typename T>
+constexpr bool isKjPromise = false;
+
+template <typename T>
+constexpr bool isKjPromise<kj::Promise<T>> = true;
+
 // These types are passed by fast api as is and do not require wrapping/unwrapping.
 template <typename T>
 concept FastApiPrimitive = kj::isSameType<T, void>() || kj::isSameType<T, bool>() ||
@@ -36,7 +43,8 @@ concept FastApiPrimitive = kj::isSameType<T, void>() || kj::isSameType<T, bool>(
 
 // Helper to determine if a type can be used as a parameter in V8 Fast API
 template <typename T>
-concept FastApiParam = !isFunctionCallbackInfo<kj::RemoveConst<kj::Decay<T>>>;
+concept FastApiParam = !isFunctionCallbackInfo<kj::RemoveConst<kj::Decay<T>>> &&
+    !isKjPromise<kj::RemoveConst<kj::Decay<T>>>;
 
 // Helper to determine if a type can be used as a return value in a V8 Fast API
 template <typename T>


### PR DESCRIPTION
Disallow kj::promise for now to understand if it's causing an issue with v8 fast api.