### PR TITLE
Initialise ctx/env fields on Python entrypoint superclass constructors.

### DIFF
--- a/src/pyodide/internal/workers.py
+++ b/src/pyodide/internal/workers.py
@@ -897,8 +897,9 @@ class DurableObject:
     Base class used to define a Durable Object.
     """
 
-    def __init__(*_args, **_kwds):
-        pass
+    def __init__(self, ctx, env):
+        self.ctx = ctx
+        self.env = env
 
 
 class WorkerEntrypoint:
@@ -906,8 +907,9 @@ class WorkerEntrypoint:
     Base class used to define a Worker Entrypoint.
     """
 
-    def __init__(*_args, **_kwds):
-        pass
+    def __init__(self, ctx, env):
+        self.ctx = ctx
+        self.env = env
 
 
 class WorkflowEntrypoint:
@@ -915,5 +917,6 @@ class WorkflowEntrypoint:
     Base class used to define a Workflow Entrypoint.
     """
 
-    def __init__(*_args, **_kwds):
-        pass
+    def __init__(self, ctx, env):
+        self.ctx = ctx
+        self.env = env

--- a/src/workerd/server/tests/python/durable-object/worker.py
+++ b/src/workerd/server/tests/python/durable-object/worker.py
@@ -18,6 +18,10 @@ class MixinTest:
 
 class DurableObjectExample(DurableObject, MixinTest):
     def __init__(self, state, env):
+        super().__init__(state, env)
+        assert self.env is not None
+        assert self.ctx is not None
+
         self.state = state
         self.counter = 0
         self.storage = state.storage

--- a/src/workerd/server/tests/python/python-rpc/worker.py
+++ b/src/workerd/server/tests/python/python-rpc/worker.py
@@ -18,6 +18,12 @@ assertRaisesRegex = TestCase().assertRaisesRegex
 
 
 class PythonRpcTester(WorkerEntrypoint):
+    def __init__(self, ctx, env):
+        super().__init__(ctx, env)
+        # Verify that the superclass constructor initialises the env/ctx fields.
+        assert self.env is not None
+        assert self.ctx is not None
+
     async def no_args(self):
         return "hello from python"
 


### PR DESCRIPTION
This is to match behaviour with JS which does initialise these.