### PR TITLE
increase timeout duration of js-weak-ref-test

### DIFF
--- a/src/workerd/server/tests/weakref/BUILD.bazel
+++ b/src/workerd/server/tests/weakref/BUILD.bazel
@@ -2,6 +2,7 @@ load("@aspect_rules_js//js:defs.bzl", "js_test")
 
 js_test(
     name = "js-weak-ref-test",
+    size = "large",
     data = [
         ":config.capnp",
         ":index.mjs",


### PR DESCRIPTION
It flakes for the default timeout size 15 seconds.