### PR TITLE
Changes to support sandboxing

### DIFF
--- a/build/deps/v8.bzl
+++ b/build/deps/v8.bzl
@@ -28,6 +28,7 @@ PATCHES = [
     "0020-Remove-unneded-latomic-linker-flag.patch",
     "0021-Add-methods-to-get-heap-and-external-memory-sizes-di.patch",
     "0022-Remove-DCHECK-from-WriteOneByteV2-to-skip-v8-fatal.patch",
+    "0023-Add-more-sandbox-APIs.patch",
 ]
 
 # V8 and its dependencies

--- a/patches/v8/0023-Add-more-sandbox-APIs.patch
+++ b/patches/v8/0023-Add-more-sandbox-APIs.patch
@@ -1,0 +1,179 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Erik Corry <erikcorry@chromium.org>
+Date: Thu, 22 May 2025 12:38:43 +0200
+Subject: Add more sandbox APIs.
+
+This has already been upstreamed at
+https://chromium-review.googlesource.com/c/v8/v8/+/6575561
+
+diff --git a/include/v8-array-buffer.h b/include/v8-array-buffer.h
+index 1d93457628cf0c41db510c4c06fd6a4e683a52dd..3e64ece5debda3951e7ca328762ab670937d0513 100644
+--- a/include/v8-array-buffer.h
++++ b/include/v8-array-buffer.h
+@@ -198,7 +198,7 @@ class V8_EXPORT ArrayBuffer : public Object {
+      * Convenience allocator.
+      *
+      * When the sandbox is enabled, this allocator will allocate its backing
+-     * memory inside the sandbox that belongs to passed isolate group.
++     * memory inside the sandbox that belongs to the passed isolate group.
+      * Otherwise, it will rely on malloc/free.
+      *
+      * Caller takes ownership, i.e. the returned object needs to be freed using
+diff --git a/include/v8-isolate.h b/include/v8-isolate.h
+index bc8fa4ded82d7746a05c4af495dbab93886b0f25..97c086e8c4b04e541daac6ef7f2d73dbfd56cef2 100644
+--- a/include/v8-isolate.h
++++ b/include/v8-isolate.h
+@@ -255,6 +255,17 @@ class V8_EXPORT IsolateGroup {
+     return !operator==(other);
+   }
+ 
++#ifdef V8_ENABLE_SANDBOX
++  /**
++   * Whether the sandbox of the isolate group contains a given pointer.
++   * Will always return true if the sandbox is not enabled.
++   */
++  bool SandboxContains(void* pointer) const;
++  VirtualAddressSpace* GetSandboxAddressSpace();
++#else
++  V8_INLINE bool SandboxContains(void* pointer) const { return true; }
++#endif
++
+  private:
+   friend class Isolate;
+   friend class ArrayBuffer::Allocator;
+diff --git a/src/api/api.cc b/src/api/api.cc
+index 62e5a7ee737523bc5c97a30678eb5570ce806729..15ac28f35942a3a4ffc6ac74ac4c888c24bf05bb 100644
+--- a/src/api/api.cc
++++ b/src/api/api.cc
+@@ -9198,6 +9198,19 @@ std::unique_ptr<v8::BackingStore> v8::ArrayBuffer::NewBackingStore(
+       static_cast<v8::BackingStore*>(backing_store.release()));
+ }
+ 
++#ifdef V8_ENABLE_SANDBOX
++bool v8::IsolateGroup::SandboxContains(void* pointer) const {
++  return isolate_group_->sandbox()->Contains(pointer);
++}
++
++VirtualAddressSpace* v8::IsolateGroup::GetSandboxAddressSpace() {
++  i::Sandbox* sandbox = isolate_group_->sandbox();
++  Utils::ApiCheck(sandbox->is_initialized(), "v8::V8::GetSandboxAddressSpace",
++                  "The sandbox must be initialized first");
++  return sandbox->address_space();
++}
++#endif
++
+ std::unique_ptr<v8::BackingStore> v8::ArrayBuffer::NewBackingStore(
+     void* data, size_t byte_length, v8::BackingStore::DeleterCallback deleter,
+     void* deleter_data) {
+diff --git a/test/cctest/test-api.cc b/test/cctest/test-api.cc
+index 59f5e7ffc05ac1edefdde2d541fde35c3bc48a66..56b17c28d72e6ad65db06fb311bd24b20204f80f 100644
+--- a/test/cctest/test-api.cc
++++ b/test/cctest/test-api.cc
+@@ -13825,7 +13825,106 @@ UNINITIALIZED_TEST(TwoIsolateGroups) {
+   TestAllocateAndNewForTwoIsolateGroups(create_params_1, create_params_2,
+                                         groups[0], groups[1]);
+ }
+-#endif
++#endif  // defined(V8_COMPRESS_POINTERS) && \
++        // !defined(V8_COMPRESS_POINTERS_IN_SHARED_CAGE)
++
++#ifdef V8_ENABLE_SANDBOX
++
++class CustomArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
++ public:
++  explicit CustomArrayBufferAllocator(v8::IsolateGroup& group)
++      : group_(group), address_space_(group.GetSandboxAddressSpace()) {}
++
++  void* Allocate(size_t size) {
++    uintptr_t result = address_space_->AllocatePages(
++        0, kSIZE, kALIGN, v8::PagePermissions::kReadWrite);
++    allocated_address_ = reinterpret_cast<void*>(result);
++    return allocated_address_;
++  }
++
++  void* AllocateUninitialized(size_t size) {
++    uintptr_t result = address_space_->AllocatePages(
++        0, kSIZE, kALIGN, v8::PagePermissions::kReadWrite);
++    allocated_address_ = reinterpret_cast<void*>(result);
++    return allocated_address_;
++  }
++
++  void Free(void* p, size_t size) {
++    address_space_->FreePages(reinterpret_cast<uintptr_t>(p), kSIZE);
++  }
++
++  void* allocated_address() const { return allocated_address_; }
++
++ private:
++  static constexpr int kSIZE = 64 << 10;
++  static constexpr int kALIGN = 64 << 10;
++  v8::IsolateGroup group_;
++  v8::VirtualAddressSpace* address_space_;
++  void* allocated_address_ = nullptr;
++};
++
++#else  // def V8_ENABLE_SANDBOX
++
++class CustomArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
++ public:
++  explicit CustomArrayBufferAllocator(v8::IsolateGroup& group) {}
++
++  void* Allocate(size_t size) {
++    void* result = malloc(size);
++    allocated_address_ = result;
++    return result;
++  }
++
++  void* AllocateUninitialized(size_t size) {
++    void* result = calloc(size, 1);
++    allocated_address_ = result;
++    return result;
++  }
++
++  void Free(void* p, size_t size) { free(p); }
++
++  void* allocated_address() const { return allocated_address_; }
++
++ private:
++  void* allocated_address_ = nullptr;
++};
++
++#endif  // def V8_ENABLE_SANDBOX
++
++UNINITIALIZED_TEST(SandboxContains) {
++  v8::IsolateGroup group1 = v8::IsolateGroup::GetDefault();
++  v8::IsolateGroup group2 = v8::IsolateGroup::CanCreateNewGroups()
++                                ? v8::IsolateGroup::Create()
++                                : v8::IsolateGroup::GetDefault();
++
++  CustomArrayBufferAllocator allocator1(group1);
++  CustomArrayBufferAllocator allocator2(group2);
++
++  v8::Isolate::CreateParams create_params_1;
++  create_params_1.array_buffer_allocator = &allocator1;
++  v8::Isolate::CreateParams create_params_2;
++  create_params_2.array_buffer_allocator = &allocator2;
++
++  TestAllocateAndNewForTwoIsolateGroups(create_params_1, create_params_2,
++                                        group1, group2);
++
++  constexpr int SIZE = 200;
++
++  void* p1 = allocator1.Allocate(SIZE);
++  void* p2 = allocator2.Allocate(SIZE);
++
++  CHECK_EQ(p1, allocator1.allocated_address());
++  CHECK_EQ(p2, allocator2.allocated_address());
++  CHECK(group1.SandboxContains(p1));
++  CHECK(group2.SandboxContains(p2));
++  if (v8::IsolateGroup::CanCreateNewGroups()) {
++    CHECK(!group1.SandboxContains(p2));
++    CHECK(!group2.SandboxContains(p1));
++  }
++
++  allocator1.Free(p1, SIZE);
++  allocator2.Free(p2, SIZE);
++}
+ 
+ unsigned ApiTestFuzzer::linear_congruential_generator;
+ std::vector<std::unique_ptr<ApiTestFuzzer>> ApiTestFuzzer::fuzzers_;

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2779,7 +2779,8 @@ class Lock {
   BufferSource bytes(kj::Array<kj::byte> data) KJ_WARN_UNUSED_RESULT;
 
   // Returns a jsg::BufferSource whose underlying JavaScript handle is an ArrayBuffer
-  // as opposed to the default Uint8Array.
+  // as opposed to the default Uint8Array.  May copy and move the bytes if they are
+  // not in the right sandbox.
   BufferSource arrayBuffer(kj::Array<kj::byte> data) KJ_WARN_UNUSED_RESULT;
 
   enum RegExpFlags {

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -348,8 +348,13 @@ static v8::Isolate* newIsolate(
 
     if (params.array_buffer_allocator == nullptr &&
         params.array_buffer_allocator_shared == nullptr) {
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+      params.array_buffer_allocator_shared = std::shared_ptr<v8::ArrayBuffer::Allocator>(
+          v8::ArrayBuffer::Allocator::NewDefaultAllocator(group));
+#else
       params.array_buffer_allocator_shared = std::shared_ptr<v8::ArrayBuffer::Allocator>(
           v8::ArrayBuffer::Allocator::NewDefaultAllocator());
+#endif
     }
     return v8::Isolate::New(group, params);
   });


### PR DESCRIPTION
Reallocate ArrayBuffer backings if they are not in the correct sandbox.

If sandbox is not in use, the SandboxContains call always returns true, and no action is taken.