### PR TITLE
Cleanly disable WPT compression tests that require sidecar

### DIFF
--- a/src/wpt/compression-test.ts
+++ b/src/wpt/compression-test.ts
@@ -20,24 +20,23 @@ export default {
   'compression-large-flush-output.any.js': {},
   'compression-multiple-chunks.tentative.any.js': {},
   'compression-output-length.tentative.any.js': {
-    comment: 'Check if this needs backend server',
-    expectedFailures: [
+    comment:
+      'These tests require the sidecar which is not enabled for compression-test',
+    skippedTests: [
       'the length of deflated (with -raw) data should be shorter than that of the original data',
       'the length of deflated data should be shorter than that of the original data',
       'the length of gzipped data should be shorter than that of the original data',
     ],
   },
   'compression-stream.tentative.any.js': {
-    comment: 'Check if this needs backend server',
-    expectedFailures:
-      process.platform === 'win32'
-        ? []
-        : [
-            'deflated small amount data should be reinflated back to its origin',
-            'deflated large amount data should be reinflated back to its origin',
-            'gzipped small amount data should be reinflated back to its origin',
-            'gzipped large amount data should be reinflated back to its origin',
-          ],
+    comment:
+      'These tests require the sidecar which is not enabled for compression-test',
+    skippedTests: [
+      'deflated small amount data should be reinflated back to its origin',
+      'deflated large amount data should be reinflated back to its origin',
+      'gzipped small amount data should be reinflated back to its origin',
+      'gzipped large amount data should be reinflated back to its origin',
+    ],
   },
   'compression-with-detach.tentative.window.js': {},
   'decompression-bad-chunks.tentative.any.js': {


### PR DESCRIPTION
A small handful of the WPT compression tests fetch files from the wptserve backend. However, starting the sidecar is relatively slow and it's only worth doing it if we have a bunch of tests like the fetch/api tests. 

This PR properly skips the tests, because some of them spuriously pass on Windows. Today, @erikcorry also had spurious passes on Unix.