### PR TITLE
Implement node API util.styleText using Claude Code.

### DIFF
--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -241,8 +241,33 @@ export function getSystemErrorMessage(): void {
   throw new Error('node:util getSystemErrorMessage is not implemented');
 }
 
-export function styleText(): void {
-  throw new Error('node:util styleText is not implemented');
+export function styleText(
+  format: string | readonly string[],
+  text: string,
+  options?: { validateStream?: boolean }
+): string {
+  if (typeof text !== 'string') {
+    throw new ERR_INVALID_ARG_TYPE('text', 'string', text);
+  }
+
+  // In Node, options.validateStream defaults to true, in which case the function inserts ANSI
+  // color codes if `options.stream` (default: stdout) is a TTY. In workers, we don't have TTYs at
+  // all, so by default styleText() would never produce any ANSI codes. So, the vast majority of
+  // the type, the correct behavior is to just return `text` verbatim, and it's not really worth
+  // it for us to bother implementing the ANSI logic.
+  //
+  // That said, someone can technically pass `validateStream: false` to request that the ASNI codes
+  // are generated either way. We don't have the necessary tables for this so we'll throw in this
+  // case.
+  if (options && !options.validateStream) {
+    throw new Error(
+      'options.validateStream for node:util styleText() is not implemented'
+    );
+  }
+
+  // ANSI coloring is disabled so the format is irrelevant and we'll just return the text.
+  void format;
+  return text;
 }
 
 export default {

--- a/src/workerd/api/node/tests/util-nodejs-test.js
+++ b/src/workerd/api/node/tests/util-nodejs-test.js
@@ -4680,3 +4680,31 @@ export const testTypes = {
     }
   },
 };
+
+export const styleText = {
+  test() {
+    const { styleText } = util;
+
+    // Since workers has no TTY streams, styleText never colorizes anything.
+    assert.strictEqual(styleText('red', 'foo'), 'foo');
+    assert.strictEqual(styleText('bold', 'bar'), 'bar');
+    assert.strictEqual(styleText(['red', 'bold'], 'baz'), 'baz');
+    assert.strictEqual(styleText('blue', ''), '');
+
+    // Test options parameter (should be accepted but not affect output)
+    assert.strictEqual(
+      styleText('red', 'foo', { validateStream: true }),
+      'foo'
+    );
+    assert.throws(
+      () => {
+        styleText('red', 'foo', { validateStream: false });
+      },
+      {
+        name: 'Error',
+        message:
+          'options.validateStream for node:util styleText() is not implemented',
+      }
+    );
+  },
+};


### PR DESCRIPTION
This API turns out to be easy to implement if we assume that, because there are no TTY streams in Workers, color codes should never be added to output. So, just return `text` verbatim!

---------------------------------

Mainly, though, this was an experiment in using AI to fill in node compat gaps.

I gave Claude Code (using Claude 4) the following prompt:

```
We'd like to improve workerd's Node API compatibility. We need to choose a Node API that workerd has not yet implemented. Please help me choose an API to implement.

* Unsupported APIs are listed in the compatibility matrix at https://workers-nodejs-compat-matrix.pages.dev/runtime-support.csv where they are marked "unsupported".
* Please favor APIs that are simple to implement.
* We don't care about implementing APIs that are already deprecated in node. Please check the node documentation to verify the API is not deprecated.
* Please check the code in deps/workerd/src/node to verify that the API is not implemented (the matrix could be out of date).

When you've chosen an API, please describe the API and a plan for implementing it, keeping in mind the fundamental differences between Node's normal execution model vs. the Workers runtime environment. Do not actually make code changes yet.
```

On the first pass I didn't tell it to check for deprecated APIs, and it implemented assert.CallTracker. Turns out that's deprecated, so I threw it away and tried again.

It next suggested `process.{get,set}SourceMapsEnabled`, but without actually hooking up to any sourcemap system -- it would just set and get a boolean that does nothing. I decided that sounded too dumb so asked it to find something better.

Then it came up with styleText(). Great.

Initially the implementation of styleText() tried to produce ANSI codes, but I asked Claude to run its same test code against actual Node, and it failed -- the real implementation actually produced different output. To be honest, I didn't understand why; Claude's version looked more correct to me. But I then realized something: If stdout is not a TTY, Node doesn't add ANSI codes at all. Nothing in Workers is a TTY. So I had Claude simplify the implementation to never add color codes.

I did some manual clean-up of the final code as well. In particular, Claude's test was way too elaborate for such a simple function.