### PR TITLE
Add addBuiltinModule variant with filter function

### DIFF
--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -116,6 +116,15 @@ struct EncoderModuleRegistryImpl {
     }
   }
 
+  template <typename Func>
+  void addBuiltinBundleFiltered(jsg::Bundle::Reader bundle, Func filter) {
+    for (auto module: bundle.getModules()) {
+      if (filter(module)) {
+        addBuiltinModule(module);
+      }
+    }
+  }
+
   void addBuiltinModule(jsg::Module::Reader module) {
     TypeScriptModuleContents contents(module.getTsDeclaration());
     ModuleInfo info(module.getName(), module.getType(), kj::mv(contents));

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -316,6 +316,15 @@ class ModuleRegistryImpl final: public ModuleRegistry {
     }
   }
 
+  template <typename Func>
+  void addBuiltinBundleFiltered(Bundle::Reader bundle, Func filter) {
+    for (auto module: bundle.getModules()) {
+      if (filter(module)) {
+        addBuiltinModule(module);
+      }
+    }
+  }
+
   // Register new module accessible by a given importPath. The module is instantiated
   // after first resolve attempt within application has failed, i.e. it is possible for
   // application to override the module.


### PR DESCRIPTION
Allows us to selectively register built-in modules from a capnp bundle... for instance, to allow us to selectively register certain modules when the experimental flag is enabled.

This can be used, for instance, to allow us to land `node:fs` and `node:http` work-in-progress without that impacting production before we're ready.