### PR TITLE
Implement fallback service support for new module registry impl

### DIFF
--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -109,6 +109,7 @@ wd_cc_library(
         ":actor-id-impl",
         ":alarm-scheduler",
         ":bundle-fs",
+        ":fallback-service",
         ":workerd_capnp",
         "//deps/rust:runtime",
         "//src/cloudflare",
@@ -143,6 +144,23 @@ wd_cc_library(
     deps = [
         ":workerd_capnp",
         "//src/workerd/io",
+    ],
+)
+
+wd_cc_library(
+    name = "fallback-service",
+    srcs = [
+        "fallback-service.c++",
+    ],
+    hdrs = [
+        "fallback-service.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":workerd_capnp",
+        "@capnp-cpp//src/kj",
+        "@capnp-cpp//src/kj:kj-async",
+        "@capnp-cpp//src/kj/compat:kj-http",
     ],
 )
 

--- a/src/workerd/server/fallback-service.c++
+++ b/src/workerd/server/fallback-service.c++
@@ -172,17 +172,7 @@ ModuleOrRedirect tryResolveV2(ImportType type,
   capnp::JsonCodec json;
   capnp::MallocMessageBuilder moduleMessage;
   auto request = moduleMessage.initRoot<server::config::FallbackServiceRequest>();
-  switch (type) {
-    case ImportType::IMPORT:
-      request.setType("import");
-      break;
-    case ImportType::REQUIRE:
-      request.setType("require");
-      break;
-    case ImportType::INTERNAL:
-      request.setType("internal");
-      break;
-  }
+  request.setType(getMethodFromType(type));
   request.setSpecifier(specifier);
   request.setReferrer(referrer);
 
@@ -192,7 +182,7 @@ ModuleOrRedirect tryResolveV2(ImportType type,
 
   if (attributes.size() > 0) {
     auto attrs = request.initAttributes(attributes.size());
-    int n = 0;
+    size_t n = 0;
     for (auto& attr: attributes) {
       attrs[n].setName(attr.key);
       attrs[n].setValue(attr.value);

--- a/src/workerd/server/fallback-service.c++
+++ b/src/workerd/server/fallback-service.c++
@@ -1,0 +1,270 @@
+#include "fallback-service.h"
+
+#include <capnp/compat/json.h>
+#include <capnp/message.h>
+#include <kj/async-io.h>
+#include <kj/compat/http.h>
+#include <kj/compat/url.h>
+#include <kj/one-of.h>
+#include <kj/string.h>
+#include <kj/thread.h>
+
+namespace workerd::fallback {
+namespace {
+
+constexpr kj::StringPtr getMethodFromType(ImportType type) {
+  switch (type) {
+    case ImportType::IMPORT:
+      return "import"_kjc;
+    case ImportType::REQUIRE:
+      return "require"_kjc;
+    case ImportType::INTERNAL:
+      return "internal"_kjc;
+  }
+  KJ_UNREACHABLE;
+}
+
+ModuleOrRedirect handleReturnPayload(
+    kj::Maybe<kj::String> jsonPayload, bool redirect, kj::StringPtr specifier) {
+  KJ_IF_SOME(payload, jsonPayload) {
+    // If the payload is empty then the fallback service failed to fetch the module.
+    if (payload.size() == 0) return kj::none;
+
+    // If redirect is true then the fallback service returned a 301 redirect. The
+    // payload is the specifier of the new target module.
+    if (redirect) {
+      return kj::Maybe(kj::mv(payload));
+    }
+
+    // The response from the fallback service must be a valid JSON serialization
+    // of the workerd module configuration. If it is not, or if there is any other
+    // error when processing here, we'll log the exception and return nothing.
+    try {
+      capnp::MallocMessageBuilder moduleMessage;
+      capnp::JsonCodec json;
+      json.handleByAnnotation<server::config::Worker::Module>();
+      auto moduleBuilder = moduleMessage.initRoot<server::config::Worker::Module>();
+      json.decode(payload, moduleBuilder);
+
+      // If the module fallback service returns a name in the module then it has to
+      // match the specifier we passed in. This is an optional sanity check.
+      if (moduleBuilder.hasName()) {
+        if (moduleBuilder.getName() != specifier) {
+          KJ_LOG(ERROR,
+              "Fallback service failed to fetch module: returned module "
+              "name does not match specifier",
+              moduleBuilder.getName(), specifier);
+          return kj::none;
+        }
+      } else {
+        moduleBuilder.setName(kj::str(specifier));
+      }
+
+      kj::Own<server::config::Worker::Module::Reader> ret = capnp::clone(moduleBuilder.asReader());
+      return ModuleOrRedirect(kj::mv(ret));
+    } catch (...) {
+      auto exception = kj::getCaughtExceptionAsKj();
+      KJ_LOG(ERROR, "Fallback service failed to fetch module", exception, specifier);
+      return kj::none;
+    }
+  }
+
+  // If we got here, no jsonPayload was received and we return nothing.
+  return kj::none;
+}
+
+// The original implementation of the fallback service uses a GET request to
+// submit the request to the service.
+ModuleOrRedirect tryResolveV1(ImportType type,
+    kj::StringPtr address,
+    kj::StringPtr specifier,
+    kj::StringPtr rawSpecifier,
+    kj::StringPtr referrer) {
+  kj::Maybe<kj::String> jsonPayload;
+  bool redirect = false;
+  bool prefixed = false;
+  kj::Url url;
+  kj::StringPtr actualSpecifier = nullptr;
+
+  // TODO(cleanup): This is a bit of a hack based on the current
+  // design of the module registry loader algorithms handling of
+  // prefixed modules. This will be simplified with the upcoming
+  // module registry refactor.
+  KJ_IF_SOME(pos, specifier.findLast('/')) {
+    auto segment = specifier.slice(pos + 1);
+    if (segment.startsWith("node:") || segment.startsWith("cloudflare:") ||
+        segment.startsWith("workerd:")) {
+      actualSpecifier = segment;
+      url.query.add(kj::Url::QueryParam{.name = kj::str("specifier"), .value = kj::str(segment)});
+      prefixed = true;
+    }
+  }
+  if (!prefixed) {
+    actualSpecifier = specifier;
+    if (actualSpecifier.startsWith("/")) {
+      actualSpecifier = specifier.slice(1);
+    }
+    url.query.add(kj::Url::QueryParam{kj::str("specifier"), kj::str(specifier)});
+  }
+  url.query.add(kj::Url::QueryParam{kj::str("referrer"), kj::str(referrer)});
+  url.query.add(kj::Url::QueryParam{kj::str("rawSpecifier"), kj::str(rawSpecifier)});
+
+  auto spec = url.toString(kj::Url::HTTP_REQUEST);
+
+  {
+    // Module loading in workerd is expected to be synchronous but we need to perform
+    // an async HTTP request to the fallback service. To accomplish that we wrap the
+    // actual request in a kj::Thread, perform the GET, and drop the thread immediately
+    // so that the destructor joins the current thread (blocking it). The thread will
+    // either set the jsonPayload variable or not.
+    kj::Thread loaderThread([&spec, address, &jsonPayload, &redirect, type]() mutable {
+      try {
+        kj::AsyncIoContext io = kj::setupAsyncIo();
+        kj::HttpHeaderTable::Builder builder;
+        kj::HttpHeaderId kMethod = builder.add("x-resolve-method");
+        auto headerTable = builder.build();
+
+        auto addr = io.provider->getNetwork().parseAddress(address, 80).wait(io.waitScope);
+        auto client = kj::newHttpClient(io.provider->getTimer(), *headerTable, *addr, {});
+
+        kj::HttpHeaders headers(*headerTable);
+        headers.set(kMethod, getMethodFromType(type));
+        headers.set(kj::HttpHeaderId::HOST, "localhost"_kj);
+
+        auto request = client->request(kj::HttpMethod::GET, spec, headers, kj::none);
+
+        kj::HttpClient::Response resp = request.response.wait(io.waitScope);
+
+        if (resp.statusCode == 301) {
+          // The fallback service responded with a redirect.
+          KJ_IF_SOME(loc, resp.headers->get(kj::HttpHeaderId::LOCATION)) {
+            redirect = true;
+            jsonPayload = kj::str(loc);
+          } else {
+            KJ_LOG(ERROR, "Fallback service returned a redirect with no location", spec);
+          }
+        } else if (resp.statusCode != 200) {
+          // Failed! Log the body of the response, if any, and fall through without
+          // setting jsonPayload to signal that the fallback service failed to return
+          // a module for this specifier.
+          auto payload = resp.body->readAllText().wait(io.waitScope);
+          KJ_LOG(ERROR, "Fallback service failed to fetch module", payload, spec);
+        } else {
+          jsonPayload = resp.body->readAllText().wait(io.waitScope);
+        }
+      } catch (...) {
+        auto exception = kj::getCaughtExceptionAsKj();
+        KJ_LOG(ERROR, "Fallback service failed to fetch module", exception, spec);
+      }
+    });
+  }
+
+  return handleReturnPayload(kj::mv(jsonPayload), redirect, actualSpecifier);
+}
+
+ModuleOrRedirect tryResolveV2(ImportType type,
+    kj::StringPtr address,
+    kj::StringPtr specifier,
+    kj::StringPtr rawSpecifier,
+    kj::StringPtr referrer,
+    const kj::HashMap<kj::StringPtr, kj::StringPtr>& attributes) {
+
+  capnp::JsonCodec json;
+  capnp::MallocMessageBuilder moduleMessage;
+  auto request = moduleMessage.initRoot<server::config::FallbackServiceRequest>();
+  switch (type) {
+    case ImportType::IMPORT:
+      request.setType("import");
+      break;
+    case ImportType::REQUIRE:
+      request.setType("require");
+      break;
+    case ImportType::INTERNAL:
+      request.setType("internal");
+      break;
+  }
+  request.setSpecifier(specifier);
+  request.setReferrer(referrer);
+
+  if (rawSpecifier != nullptr) {
+    request.setRawSpecifier(rawSpecifier);
+  }
+
+  if (attributes.size() > 0) {
+    auto attrs = request.initAttributes(attributes.size());
+    int n = 0;
+    for (auto& attr: attributes) {
+      attrs[n].setName(attr.key);
+      attrs[n].setValue(attr.value);
+      n++;
+    }
+  }
+
+  auto payload = json.encode(request);
+
+  kj::Maybe<kj::String> jsonPayload;
+  bool redirect = false;
+
+  {
+    kj::Thread loaderThread(
+        [&address, &jsonPayload, payload = kj::mv(payload), &redirect, &specifier]() mutable {
+      try {
+        kj::AsyncIoContext io = kj::setupAsyncIo();
+        kj::HttpHeaderTable::Builder builder;
+        auto headerTable = builder.build();
+
+        auto addr = io.provider->getNetwork().parseAddress(address, 80).wait(io.waitScope);
+        auto client = kj::newHttpClient(io.provider->getTimer(), *headerTable, *addr, {});
+
+        kj::HttpHeaders headers(*headerTable);
+        headers.set(kj::HttpHeaderId::HOST, "localhost");
+
+        auto request = client->request(kj::HttpMethod::POST, "/", headers, payload.size());
+        {
+          // Write then drop the payload.
+          kj::mv(request.body)->write(payload.asPtr().asBytes()).wait(io.waitScope);
+        }
+
+        kj::HttpClient::Response resp = request.response.wait(io.waitScope);
+
+        if (resp.statusCode == 301) {
+          // The fallback service responded with a redirect.
+          KJ_IF_SOME(loc, resp.headers->get(kj::HttpHeaderId::LOCATION)) {
+            redirect = true;
+            jsonPayload = kj::str(loc);
+          } else {
+            KJ_LOG(ERROR, "Fallback service returned a redirect with no location", specifier);
+          }
+        } else if (resp.statusCode != 200) {
+          // Failed! Log the body of the response, if any, and fall through without
+          // setting jsonPayload to signal that the fallback service failed to return
+          // a module for this specifier.
+          auto payload = resp.body->readAllText().wait(io.waitScope);
+          KJ_LOG(ERROR, "Fallback service failed to fetch module", payload, specifier);
+        } else {
+          jsonPayload = resp.body->readAllText().wait(io.waitScope);
+        }
+      } catch (...) {
+        auto exception = kj::getCaughtExceptionAsKj();
+        KJ_LOG(ERROR, "Fallback service failed to fetch module", exception);
+      }
+    });
+  }
+
+  return handleReturnPayload(kj::mv(jsonPayload), redirect, specifier);
+}
+}  // namespace
+
+ModuleOrRedirect tryResolve(Version version,
+    ImportType type,
+    kj::StringPtr address,
+    kj::StringPtr specifier,
+    kj::StringPtr rawSpecifier,
+    kj::StringPtr referrer,
+    const kj::HashMap<kj::StringPtr, kj::StringPtr>& attributes) {
+  return version == Version::V1
+      ? tryResolveV1(type, address, specifier, rawSpecifier, referrer)
+      : tryResolveV2(type, address, specifier, rawSpecifier, referrer, attributes);
+}
+
+}  // namespace workerd::fallback

--- a/src/workerd/server/fallback-service.h
+++ b/src/workerd/server/fallback-service.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <workerd/server/workerd.capnp.h>
+
+#include <kj/common.h>
+#include <kj/map.h>
+#include <kj/one-of.h>
+#include <kj/string.h>
+
+namespace workerd::fallback {
+
+// The fallback service is a mechanism used only in workerd local development.
+// It is used to use an external http service to resolve module specifiers
+// dynamically if the module is not found in the static bundles. A worker
+// must be configured to use the fallback service and workerd must be started
+// with the --experimental CLI flag.
+//
+// There are two versions of the fallback service protocol:
+//
+// V1: The request is sent to the fallback service as a GET request using
+// query strings to pass the details. The specifier and referrer are treated
+// as strings. Import attributes are not included.
+//
+// V2: The request is sent to the fallback service as a POST request using
+// JSON to pass the details. The specifier and referrer are treated as URLs.
+// Import attributes are included.
+//
+// The fallback service may return either a JSON string describing the module
+// configuration, a 301 redirect to a different module specifier, or an error.
+enum class ImportType {
+  // The import is a static or dynamic import
+  IMPORT,
+  // The import is a CommonJs-style require()
+  REQUIRE,
+  // The import originated from inside the runtime
+  INTERNAL,
+};
+
+enum class Version {
+  // With V1 of the fallback service, the request is sent to the fallback
+  // service as a GET request using query strings to pass the details.
+  // The specifier and referrer are treated as strings. Import attributes
+  // are not included.
+  V1,
+  // With V2 of the fallback service, the request is sent to the fallback
+  // service as a POST request using JSON to pass the details. The specifier
+  // and referrer are treated as URLs. Import attributes are included.
+  V2,
+};
+
+using ModuleOrRedirect =
+    kj::Maybe<kj::OneOf<kj::String, kj::Own<server::config::Worker::Module::Reader>>>;
+
+// Tries to resolve the module using the fallback service.
+// If a string is returned, the fallback service redirected us to resolve a
+// different module whose specifier is given by the returned string. Otherwise,
+// the fallback service returns a module configuration object.
+ModuleOrRedirect tryResolve(Version version,
+    ImportType type,
+    kj::StringPtr address,
+    kj::StringPtr specifier,
+    kj::StringPtr rawSpecifier,
+    kj::StringPtr referrer,
+    const kj::HashMap<kj::StringPtr, kj::StringPtr>& attributes);
+
+}  // namespace workerd::fallback

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3076,7 +3076,8 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name,
     }
 
     newModuleRegistry = WorkerdApi::initializeBundleModuleRegistry(*jsgobserver, modulesSource,
-        featureFlags.asReader(), pythonConfig, bundleBase, kj::mv(maybeFallbackService));
+        featureFlags.asReader(), pythonConfig, bundleBase, extensions,
+        kj::mv(maybeFallbackService));
   }
 
   auto isolateGroup = v8::IsolateGroup::GetDefault();

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -25,6 +25,7 @@
 #include <workerd/io/worker-interface.h>
 #include <workerd/io/worker.h>
 #include <workerd/server/actor-id-impl.h>
+#include <workerd/server/fallback-service.h>
 #include <workerd/util/http-util.h>
 #include <workerd/util/mimetype.h>
 #include <workerd/util/use-perfetto-categories.h>
@@ -3063,14 +3064,19 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name,
     const jsg::Url& bundleBase = workerFs->getBundleRoot();
 
     auto& modulesSource = KJ_ASSERT_NONNULL(source.tryGet<Worker::Script::ModulesSource>(),
-        "The new MOduleRegistry only works with ES modules syntax, not Service Workers syntax.");
+        "The new ModuleRegistry only works with ES modules syntax, not Service Workers syntax.");
 
     // In workerd the module registry is always associated with just a single
     // worker instance, so we initialize it here. In production, however, a
     // single instance may be shared across multiple replicas.
 
-    newModuleRegistry = WorkerdApi::initializeBundleModuleRegistry(
-        *jsgobserver, modulesSource, featureFlags.asReader(), pythonConfig, bundleBase);
+    kj::Maybe<kj::String> maybeFallbackService;
+    if (conf.hasModuleFallback()) {
+      maybeFallbackService = kj::str(conf.getModuleFallback());
+    }
+
+    newModuleRegistry = WorkerdApi::initializeBundleModuleRegistry(*jsgobserver, modulesSource,
+        featureFlags.asReader(), pythonConfig, bundleBase, kj::mv(maybeFallbackService));
   }
 
   auto isolateGroup = v8::IsolateGroup::GetDefault();
@@ -3093,10 +3099,10 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name,
     isolateRegistrar->registerIsolate(name, isolate.get());
   }
 
-  if (conf.hasModuleFallback()) {
+  if (conf.hasModuleFallback() && !featureFlags.getNewModuleRegistry()) {
     KJ_REQUIRE(experimental,
         "The module fallback service is an experimental feature. "
-        "You must run workerd with `--experimental` to use this feature.");
+        "You must run workerd with `--experimental` to use the module fallback service.");
     // If the config has the moduleFallback option, then we are going to set up the ability
     // to load certain modules from a fallback service. This is generally intended for local
     // dev/testing purposes only.
@@ -3107,150 +3113,29 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name,
             jsg::CompilationObserver& observer, jsg::ModuleRegistry::ResolveMethod method,
             kj::Maybe<kj::StringPtr> rawSpecifier) mutable
         -> kj::Maybe<kj::OneOf<kj::String, jsg::ModuleRegistry::ModuleInfo>> {
-      kj::Maybe<kj::String> jsonPayload;
-      bool redirect = false;
-      bool prefixed = false;
-      kj::Url url;
-      kj::StringPtr actualSpecifier = nullptr;
-      // TODO(cleanup): This is a bit of a hack based on the current
-      // design of the module registry loader algorithms handling of
-      // prefixed modules. This will be simplified with the upcoming
-      // module registry refactor.
-      KJ_IF_SOME(pos, specifier.findLast('/')) {
-        auto segment = specifier.slice(pos + 1);
-        if (segment.startsWith("node:") || segment.startsWith("cloudflare:") ||
-            segment.startsWith("workerd:")) {
-          actualSpecifier = segment;
-          url.query.add(
-              kj::Url::QueryParam{.name = kj::str("specifier"), .value = kj::str(segment)});
-          prefixed = true;
-        }
-      }
-      if (!prefixed) {
-        actualSpecifier = specifier;
-        if (actualSpecifier.startsWith("/")) {
-          actualSpecifier = specifier.slice(1);
-        }
-        url.query.add(kj::Url::QueryParam{kj::str("specifier"), kj::str(specifier)});
-      }
-      KJ_IF_SOME(ref, referrer) {
-        url.query.add(kj::Url::QueryParam{kj::str("referrer"), kj::mv(ref)});
-      }
-      KJ_IF_SOME(raw, rawSpecifier) {
-        url.query.add(kj::Url::QueryParam{kj::str("rawSpecifier"), kj::str(raw)});
-      }
-
-      auto spec = url.toString(kj::Url::HTTP_REQUEST);
-
-      {
-        // Module loading in workerd is expected to be synchronous but we need to perform
-        // an async HTTP request to the fallback service. To accomplish that we wrap the
-        // actual request in a kj::Thread, perform the GET, and drop the thread immediately
-        // so that the destructor joins the current thread (blocking it). The thread will
-        // either set the jsonPayload variable or not.
-        kj::Thread loaderThread([&spec, referrer = kj::mv(referrer), address = address.asPtr(),
-                                    &jsonPayload, &redirect, method]() mutable {
-          try {
-            const auto toStr = [](jsg::ModuleRegistry::ResolveMethod method) {
-              switch (method) {
-                case jsg::ModuleRegistry::ResolveMethod::IMPORT:
-                  return "import"_kjc;
-                case jsg::ModuleRegistry::ResolveMethod::REQUIRE:
-                  return "require"_kjc;
-              }
-              KJ_UNREACHABLE;
-            };
-
-            kj::AsyncIoContext io = kj::setupAsyncIo();
-
-            kj::HttpHeaderTable::Builder builder;
-            kj::HttpHeaderId kMethod = builder.add("x-resolve-method");
-            auto headerTable = builder.build();
-
-            auto addr = io.provider->getNetwork().parseAddress(address, 80).wait(io.waitScope);
-
-            auto client = kj::newHttpClient(io.provider->getTimer(), *headerTable, *addr, {});
-
-            kj::HttpHeaders headers(*headerTable);
-            headers.set(kMethod, toStr(method));
-            headers.set(kj::HttpHeaderId::HOST, "localhost"_kj);
-
-            auto request = client->request(kj::HttpMethod::GET, spec, headers, kj::none);
-
-            kj::HttpClient::Response resp = request.response.wait(io.waitScope);
-
-            if (resp.statusCode == 301) {
-              // The fallback service responded with a redirect.
-              KJ_IF_SOME(loc, resp.headers->get(kj::HttpHeaderId::LOCATION)) {
-                redirect = true;
-                jsonPayload = kj::str(loc);
-              } else {
-                KJ_LOG(ERROR, "Fallback service returned a redirect with no location", spec);
-              }
-            } else if (resp.statusCode != 200) {
-              // Failed! Log the body of the response, if any, and fall through without
-              // setting jsonPayload to signal that the fallback service failed to return
-              // a module for this specifier.
-              auto payload = resp.body->readAllText().wait(io.waitScope);
-              KJ_LOG(ERROR, "Fallback service failed to fetch module", payload, spec);
-            } else {
-              jsonPayload = resp.body->readAllText().wait(io.waitScope);
+      kj::HashMap<kj::StringPtr, kj::StringPtr> attributes;
+      KJ_IF_SOME(moduleOrRedirect,
+          workerd::fallback::tryResolve(workerd::fallback::Version::V1,
+              method == jsg::ModuleRegistry::ResolveMethod::IMPORT
+                  ? workerd::fallback::ImportType::IMPORT
+                  : workerd::fallback::ImportType::REQUIRE,
+              address, specifier, rawSpecifier.orDefault(nullptr), referrer.orDefault(kj::String()),
+              attributes)) {
+        KJ_SWITCH_ONEOF(moduleOrRedirect) {
+          KJ_CASE_ONEOF(redirect, kj::String) {
+            // If a string is returned, then the fallback service returned a 301 redirect.
+            // The value is the specifier of the new target module.
+            return kj::Maybe(kj::mv(redirect));
+          }
+          KJ_CASE_ONEOF(module, kj::Own<config::Worker::Module::Reader>) {
+            KJ_IF_SOME(module, WorkerdApi::tryCompileModule(js, *module, observer, featureFlags)) {
+              return kj::Maybe(kj::mv(module));
             }
-          } catch (...) {
-            auto exception = kj::getCaughtExceptionAsKj();
-            KJ_LOG(ERROR, "Fallback service failed to fetch module", exception, spec);
+            KJ_LOG(ERROR, "Fallback service does not support this module type", module->which());
           }
-        });
-      }
-
-      KJ_IF_SOME(payload, jsonPayload) {
-        // If the payload is empty then the fallback service failed to fetch the module.
-        if (payload.size() == 0) return kj::none;
-
-        // If redirect is true then the fallback service returned a 301 redirect. The
-        // payload is the specifier of the new target module.
-        if (redirect) {
-          return kj::Maybe(kj::mv(payload));
-        }
-
-        // The response from the fallback service must be a valid JSON serialization
-        // of the workerd module configuration. If it is not, or if there is any other
-        // error when processing here, we'll log the exception and return nothing.
-        try {
-          capnp::MallocMessageBuilder moduleMessage;
-          capnp::JsonCodec json;
-          json.handleByAnnotation<config::Worker::Module>();
-          auto moduleBuilder = moduleMessage.initRoot<config::Worker::Module>();
-          json.decode(payload, moduleBuilder);
-
-          // If the module fallback service returns a name in the module then it has to
-          // match the specifier we passed in. This is an optional sanity check.
-          if (moduleBuilder.hasName()) {
-            if (moduleBuilder.getName() != actualSpecifier) {
-              KJ_LOG(ERROR,
-                  "Fallback service failed to fetch module: returned module "
-                  "name does not match specifier",
-                  moduleBuilder.getName(), actualSpecifier);
-              return kj::none;
-            }
-          } else {
-            moduleBuilder.setName(kj::str(actualSpecifier));
-          }
-
-          auto module = WorkerdApi::tryCompileModule(js, moduleBuilder, observer, featureFlags);
-          if (module == kj::none) {
-            KJ_LOG(
-                ERROR, "Fallback service does not support this module type", moduleBuilder.which());
-          }
-          return module;
-        } catch (...) {
-          auto exception = kj::getCaughtExceptionAsKj();
-          KJ_LOG(ERROR, "Fallback service failed to fetch module", exception, spec);
-          return kj::none;
         }
       }
 
-      // If we got here, no jsonPayload was received and we return nothing.
       return kj::none;
     });
   }

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -1078,7 +1078,7 @@ static constexpr auto PYTHON_TAR_READER = "export default { }"_kj;
 
 kj::Own<jsg::modules::ModuleRegistry> WorkerdApi::initializeBundleModuleRegistry(
     const jsg::ResolveObserver& observer,
-    const Worker::Script::ModulesSource& source,
+    kj::Maybe<const Worker::Script::ModulesSource&> maybeSource,
     const CompatibilityFlags::Reader& featureFlags,
     const PythonConfig& pythonConfig,
     const jsg::Url& bundleBase,
@@ -1103,97 +1103,198 @@ kj::Own<jsg::modules::ModuleRegistry> WorkerdApi::initializeBundleModuleRegistry
   // Add the module bundles that are built into to runtime.
   api::registerBuiltinModules<JsgWorkerdIsolate_TypeWrapper>(builder, featureFlags);
 
-  // Add the module bundles that are configured by the worker.
-  jsg::modules::ModuleBundle::BundleBuilder bundleBuilder(bundleBase);
-  bool firstEsm = true;
-  bool hasPythonModules = false;
-  using namespace workerd::api::pyodide;
+  // Add the module bundles that are configured by the worker (if any)
+  // The only case where maybeSource is none is when the worker is using
+  // the old service worker script format or "inherit", in which case
+  // we will initialize a module registry with the built-ins, extensions,
+  // etc but no worker bundle modules will be added.
+  KJ_IF_SOME(source, maybeSource) {
+    jsg::modules::ModuleBundle::BundleBuilder bundleBuilder(bundleBase);
+    bool firstEsm = true;
+    bool hasPythonModules = false;
+    using namespace workerd::api::pyodide;
 
-  for (auto& def: source.modules) {
-    KJ_SWITCH_ONEOF(def.content) {
-      KJ_CASE_ONEOF(content, Worker::Script::EsModule) {
-        jsg::modules::Module::Flags flags = jsg::modules::Module::Flags::ESM;
-        // Only the first ESM module we encounter is the main module.
-        // This should also be the first module in the list but we're
-        // not enforcing that here.
-        if (firstEsm) {
-          flags = flags | jsg::modules::Module::Flags::MAIN;
+    for (auto& def: source.modules) {
+      KJ_SWITCH_ONEOF(def.content) {
+        KJ_CASE_ONEOF(content, Worker::Script::EsModule) {
+          jsg::modules::Module::Flags flags = jsg::modules::Module::Flags::ESM;
+          // Only the first ESM module we encounter is the main module.
+          // This should also be the first module in the list but we're
+          // not enforcing that here.
+          if (firstEsm) {
+            flags = flags | jsg::modules::Module::Flags::MAIN;
+            firstEsm = false;
+          }
+          // The content.body is memory-resident and is expected to outlive the
+          // module registry. We can safely pass a reference to the module handler.
+          // It will not be copied into a JS string until the module is actually
+          // evaluated.
+          bundleBuilder.addEsmModule(def.name, content.body, flags);
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::TextModule) {
+          // The content.body is memory-resident and is expected to outlive the
+          // module registry. We can safely pass a reference to the module handler.
+          // It will not be copied into a JS string until the module is actually
+          // evaluated.
+          bundleBuilder.addSyntheticModule(
+              def.name, jsg::modules::Module::newTextModuleHandler(content.body));
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::DataModule) {
+          // The content.body is memory-resident and is expected to outlive the
+          // module registry. We can safely pass a reference to the module handler.
+          // It will not be copied into a JS string until the module is actually
+          // evaluated.
+          bundleBuilder.addSyntheticModule(
+              def.name, jsg::modules::Module::newDataModuleHandler(content.body));
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::WasmModule) {
+          // The content.body is memory-resident and is expected to outlive the
+          // module registry. We can safely pass a reference to the module handler.
+          // It will not be copied into a JS string until the module is actually
+          // evaluated.
+          bundleBuilder.addSyntheticModule(
+              def.name, jsg::modules::Module::newWasmModuleHandler(content.body));
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::JsonModule) {
+          // The content.body is memory-resident and is expected to outlive the
+          // module registry. We can safely pass a reference to the module handler.
+          // It will not be copied into a JS string until the module is actually
+          // evaluated.
+          bundleBuilder.addSyntheticModule(
+              def.name, jsg::modules::Module::newJsonModuleHandler(content.body));
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::CommonJsModule) {
+          kj::ArrayPtr<const kj::StringPtr> named;
+          KJ_IF_SOME(n, content.namedExports) {
+            named = n;
+          }
+          bundleBuilder.addSyntheticModule(def.name,
+              jsg::modules::Module::newCjsStyleModuleHandler<api::CommonJsModuleContext,
+                  JsgWorkerdIsolate_TypeWrapper>(content.body, def.name),
+              KJ_MAP(name, named) { return kj::str(name); });
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::PythonModule) {
+          KJ_REQUIRE(featureFlags.getPythonWorkers(),
+              "The python_workers compatibility flag is required to use Python.");
           firstEsm = false;
+          hasPythonModules = true;
+          kj::StringPtr entry = PYTHON_ENTRYPOINT;
+          bundleBuilder.addEsmModule(def.name, entry);
+          break;
         }
-        // The content.body is memory-resident and is expected to outlive the
-        // module registry. We can safely pass a reference to the module handler.
-        // It will not be copied into a JS string until the module is actually
-        // evaluated.
-        bundleBuilder.addEsmModule(def.name, content.body, flags);
-        break;
-      }
-      KJ_CASE_ONEOF(content, Worker::Script::TextModule) {
-        // The content.body is memory-resident and is expected to outlive the
-        // module registry. We can safely pass a reference to the module handler.
-        // It will not be copied into a JS string until the module is actually
-        // evaluated.
-        bundleBuilder.addSyntheticModule(
-            def.name, jsg::modules::Module::newTextModuleHandler(content.body));
-        break;
-      }
-      KJ_CASE_ONEOF(content, Worker::Script::DataModule) {
-        // The content.body is memory-resident and is expected to outlive the
-        // module registry. We can safely pass a reference to the module handler.
-        // It will not be copied into a JS string until the module is actually
-        // evaluated.
-        bundleBuilder.addSyntheticModule(
-            def.name, jsg::modules::Module::newDataModuleHandler(content.body));
-        break;
-      }
-      KJ_CASE_ONEOF(content, Worker::Script::WasmModule) {
-        // The content.body is memory-resident and is expected to outlive the
-        // module registry. We can safely pass a reference to the module handler.
-        // It will not be copied into a JS string until the module is actually
-        // evaluated.
-        bundleBuilder.addSyntheticModule(
-            def.name, jsg::modules::Module::newWasmModuleHandler(content.body));
-        break;
-      }
-      KJ_CASE_ONEOF(content, Worker::Script::JsonModule) {
-        // The content.body is memory-resident and is expected to outlive the
-        // module registry. We can safely pass a reference to the module handler.
-        // It will not be copied into a JS string until the module is actually
-        // evaluated.
-        bundleBuilder.addSyntheticModule(
-            def.name, jsg::modules::Module::newJsonModuleHandler(content.body));
-        break;
-      }
-      KJ_CASE_ONEOF(content, Worker::Script::CommonJsModule) {
-        kj::ArrayPtr<const kj::StringPtr> named;
-        KJ_IF_SOME(n, content.namedExports) {
-          named = n;
+        KJ_CASE_ONEOF(content, Worker::Script::PythonRequirement) {
+          // Handled separately
+          break;
         }
-        bundleBuilder.addSyntheticModule(def.name,
-            jsg::modules::Module::newCjsStyleModuleHandler<api::CommonJsModuleContext,
-                JsgWorkerdIsolate_TypeWrapper>(content.body, def.name),
-            KJ_MAP(name, named) { return kj::str(name); });
-        break;
-      }
-      KJ_CASE_ONEOF(content, Worker::Script::PythonModule) {
-        KJ_REQUIRE(featureFlags.getPythonWorkers(),
-            "The python_workers compatibility flag is required to use Python.");
-        firstEsm = false;
-        hasPythonModules = true;
-        kj::StringPtr entry = PYTHON_ENTRYPOINT;
-        bundleBuilder.addEsmModule(def.name, entry);
-        break;
-      }
-      KJ_CASE_ONEOF(content, Worker::Script::PythonRequirement) {
-        // Handled separately
-        break;
-      }
-      KJ_CASE_ONEOF(content, Worker::Script::CapnpModule) {
-        KJ_FAIL_REQUIRE("capnp modules are not yet supported in workerd");
+        KJ_CASE_ONEOF(content, Worker::Script::CapnpModule) {
+          KJ_FAIL_REQUIRE("capnp modules are not yet supported in workerd");
+        }
       }
     }
-  }
 
-  builder.add(bundleBuilder.finish());
+    builder.add(bundleBuilder.finish());
+
+    // Add the built-in module bundles that support python workers/pyodide.
+    if (hasPythonModules) {
+      // TODO(new-module-registry): Move into pyodide.h/pyodide.c++
+      const auto bootrapSpecifier = "internal:setup-emscripten"_url;
+      const auto metadataSpecifier = "pyodide-internal:runtime-generated/metadata"_url;
+      const auto artifactsSpecifier = "pyodide-internal:artifacts"_url;
+      const auto internalJaegerSpecifier = "pyodide-internal:internalJaeger"_url;
+      const auto diskCacheSpecifier = "pyodide-internal:disk_cache"_url;
+      const auto limiterSpecifier = "pyodide-internal:limiter"_url;
+      const auto tarReaderSpecifier = "pyodide-internal:packages_tar_reader"_url;
+
+      // To support python workers we create two modules bundles, one BUILTIN
+      // and the other BUILTIN_ONLY. The BUILTIN bundle contains support modules
+      // that need to be importable by the python worker bootstrap module (which
+      // is added to the BUNDLE modules). The BUILTIN_ONLY bundle contains support
+      // modules that are used by the BUILTIN modules and are not intended to be
+      // accessible from the worker itself.
+
+      // Inject metadata that the entrypoint module will read.
+      auto pythonRelease = KJ_ASSERT_NONNULL(getPythonSnapshotRelease(featureFlags));
+      auto version = getPythonBundleName(pythonRelease);
+      auto bundle = KJ_ASSERT_NONNULL(
+          fetchPyodideBundle(pythonConfig, version), "Failed to get Pyodide bundle");
+
+      // We end up add modules from the bundle twice, once to get BUILTIN modules
+      // and again to get the BUILTIN_ONLY modules. These end up in two different
+      // module bundles.
+      jsg::modules::ModuleBundle::BuiltinBuilder pyodideSdkBuilder;
+
+      // There are two bundles that are relevant here, PYODIDE_BUNDLE, which is
+      // fixed and contains compiled-in modules, and the bundle that is fetched
+      // that contains the more dynamic implementation details. We have to process
+      // both.
+      jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(pyodideSdkBuilder, PYODIDE_BUNDLE);
+      jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(pyodideSdkBuilder, bundle);
+      builder.add(pyodideSdkBuilder.finish());
+
+      jsg::modules::ModuleBundle::BuiltinBuilder pyodideBundleBuilder(
+          jsg::modules::ModuleBundle::BuiltinBuilder::Type::BUILTIN_ONLY);
+
+      jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(pyodideBundleBuilder, PYODIDE_BUNDLE);
+      jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(pyodideBundleBuilder, bundle);
+
+      pyodideBundleBuilder.addSynthetic(bootrapSpecifier,
+          jsg::modules::Module::newJsgObjectModuleHandler<api::pyodide::SetupEmscripten,
+              JsgWorkerdIsolate_TypeWrapper>(
+              [](jsg::Lock& js) mutable -> jsg::Ref<api::pyodide::SetupEmscripten> {
+        auto& api = Worker::Api::current();
+        return js.alloc<api::pyodide::SetupEmscripten>(
+            KJ_ASSERT_NONNULL(api.getEmscriptenRuntime()));
+      }));
+
+      pyodideBundleBuilder.addEsm(tarReaderSpecifier, PYTHON_TAR_READER);
+
+      pyodideBundleBuilder.addSynthetic(metadataSpecifier,
+          jsg::modules::Module::newJsgObjectModuleHandler<api::pyodide::PyodideMetadataReader,
+              JsgWorkerdIsolate_TypeWrapper>(
+              [state = makePyodideMetadataReader(source, pythonConfig, pythonRelease)](
+                  jsg::Lock& js) mutable -> jsg::Ref<api::pyodide::PyodideMetadataReader> {
+        // The ModuleRegistry may be shared across multiple isolates and workers.
+        // We need to clone the PyodideMetadataReader::State for each instance
+        // that is evaluated. Typically this is only once per python worker
+        // but could be more in the future.
+        return js.alloc<PyodideMetadataReader>(state->clone());
+      }));
+      // Inject artifact bundler.
+      pyodideBundleBuilder.addSynthetic(artifactsSpecifier,
+          jsg::modules::Module::newJsgObjectModuleHandler<ArtifactBundler,
+              JsgWorkerdIsolate_TypeWrapper>(
+              [](jsg::Lock& js) mutable -> jsg::Ref<ArtifactBundler> {
+        return js.alloc<ArtifactBundler>(ArtifactBundler::makeDisabledBundler());
+      }));
+      // Inject jaeger internal tracer in a disabled state (we don't have a use for it in workerd)
+      pyodideBundleBuilder.addSynthetic(internalJaegerSpecifier,
+          jsg::modules::Module::newJsgObjectModuleHandler<DisabledInternalJaeger,
+              JsgWorkerdIsolate_TypeWrapper>(
+              [](jsg::Lock& js) mutable -> jsg::Ref<DisabledInternalJaeger> {
+        return DisabledInternalJaeger::create(js);
+      }));
+      // Inject disk cache module
+      pyodideBundleBuilder.addSynthetic(diskCacheSpecifier,
+          jsg::modules::Module::newJsgObjectModuleHandler<DiskCache, JsgWorkerdIsolate_TypeWrapper>(
+              [&packageDiskCacheRoot = pythonConfig.packageDiskCacheRoot](jsg::Lock& js) mutable
+              -> jsg::Ref<DiskCache> { return js.alloc<DiskCache>(packageDiskCacheRoot); }));
+      // Inject a (disabled) SimplePythonLimiter
+      pyodideBundleBuilder.addSynthetic(limiterSpecifier,
+          jsg::modules::Module::newJsgObjectModuleHandler<SimplePythonLimiter,
+              JsgWorkerdIsolate_TypeWrapper>(
+              [](jsg::Lock& js) mutable -> jsg::Ref<SimplePythonLimiter> {
+        return SimplePythonLimiter::makeDisabled(js);
+      }));
+
+      builder.add(pyodideBundleBuilder.finish());
+    }
+  }
 
   // Handle extensions
   jsg::modules::ModuleBundle::BuiltinBuilder publicExtensionsBuilder(
@@ -1217,99 +1318,6 @@ kj::Own<jsg::modules::ModuleRegistry> WorkerdApi::initializeBundleModuleRegistry
 
   builder.add(publicExtensionsBuilder.finish());
   builder.add(privateExtensionsBuilder.finish());
-
-  // Add the built-in module bundles that support python workers/pyodide.
-  if (hasPythonModules) {
-    // TODO(new-module-registry): Move into pyodide.h/pyodide.c++
-    const auto bootrapSpecifier = "internal:setup-emscripten"_url;
-    const auto metadataSpecifier = "pyodide-internal:runtime-generated/metadata"_url;
-    const auto artifactsSpecifier = "pyodide-internal:artifacts"_url;
-    const auto internalJaegerSpecifier = "pyodide-internal:internalJaeger"_url;
-    const auto diskCacheSpecifier = "pyodide-internal:disk_cache"_url;
-    const auto limiterSpecifier = "pyodide-internal:limiter"_url;
-    const auto tarReaderSpecifier = "pyodide-internal:packages_tar_reader"_url;
-
-    // To support python workers we create two modules bundles, one BUILTIN
-    // and the other BUILTIN_ONLY. The BUILTIN bundle contains support modules
-    // that need to be importable by the python worker bootstrap module (which
-    // is added to the BUNDLE modules). The BUILTIN_ONLY bundle contains support
-    // modules that are used by the BUILTIN modules and are not intended to be
-    // accessible from the worker itself.
-
-    // Inject metadata that the entrypoint module will read.
-    auto pythonRelease = KJ_ASSERT_NONNULL(getPythonSnapshotRelease(featureFlags));
-    auto version = getPythonBundleName(pythonRelease);
-    auto bundle = KJ_ASSERT_NONNULL(
-        fetchPyodideBundle(pythonConfig, version), "Failed to get Pyodide bundle");
-
-    // We end up add modules from the bundle twice, once to get BUILTIN modules
-    // and again to get the BUILTIN_ONLY modules. These end up in two different
-    // module bundles.
-    jsg::modules::ModuleBundle::BuiltinBuilder pyodideSdkBuilder;
-
-    // There are two bundles that are relevant here, PYODIDE_BUNDLE, which is
-    // fixed and contains compiled-in modules, and the bundle that is fetched
-    // that contains the more dynamic implementation details. We have to process
-    // both.
-    jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(pyodideSdkBuilder, PYODIDE_BUNDLE);
-    jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(pyodideSdkBuilder, bundle);
-    builder.add(pyodideSdkBuilder.finish());
-
-    jsg::modules::ModuleBundle::BuiltinBuilder pyodideBundleBuilder(
-        jsg::modules::ModuleBundle::BuiltinBuilder::Type::BUILTIN_ONLY);
-
-    jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(pyodideBundleBuilder, PYODIDE_BUNDLE);
-    jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(pyodideBundleBuilder, bundle);
-
-    pyodideBundleBuilder.addSynthetic(bootrapSpecifier,
-        jsg::modules::Module::newJsgObjectModuleHandler<api::pyodide::SetupEmscripten,
-            JsgWorkerdIsolate_TypeWrapper>(
-            [](jsg::Lock& js) mutable -> jsg::Ref<api::pyodide::SetupEmscripten> {
-      auto& api = Worker::Api::current();
-      return js.alloc<api::pyodide::SetupEmscripten>(KJ_ASSERT_NONNULL(api.getEmscriptenRuntime()));
-    }));
-
-    pyodideBundleBuilder.addEsm(tarReaderSpecifier, PYTHON_TAR_READER);
-
-    pyodideBundleBuilder.addSynthetic(metadataSpecifier,
-        jsg::modules::Module::newJsgObjectModuleHandler<api::pyodide::PyodideMetadataReader,
-            JsgWorkerdIsolate_TypeWrapper>(
-            [state = makePyodideMetadataReader(source, pythonConfig, pythonRelease)](
-                jsg::Lock& js) mutable -> jsg::Ref<api::pyodide::PyodideMetadataReader> {
-      // The ModuleRegistry may be shared across multiple isolates and workers.
-      // We need to clone the PyodideMetadataReader::State for each instance
-      // that is evaluated. Typically this is only once per python worker
-      // but could be more in the future.
-      return js.alloc<PyodideMetadataReader>(state->clone());
-    }));
-    // Inject artifact bundler.
-    pyodideBundleBuilder.addSynthetic(artifactsSpecifier,
-        jsg::modules::Module::newJsgObjectModuleHandler<ArtifactBundler,
-            JsgWorkerdIsolate_TypeWrapper>([](jsg::Lock& js) mutable -> jsg::Ref<ArtifactBundler> {
-      return js.alloc<ArtifactBundler>(ArtifactBundler::makeDisabledBundler());
-    }));
-    // Inject jaeger internal tracer in a disabled state (we don't have a use for it in workerd)
-    pyodideBundleBuilder.addSynthetic(internalJaegerSpecifier,
-        jsg::modules::Module::newJsgObjectModuleHandler<DisabledInternalJaeger,
-            JsgWorkerdIsolate_TypeWrapper>(
-            [](jsg::Lock& js) mutable -> jsg::Ref<DisabledInternalJaeger> {
-      return DisabledInternalJaeger::create(js);
-    }));
-    // Inject disk cache module
-    pyodideBundleBuilder.addSynthetic(diskCacheSpecifier,
-        jsg::modules::Module::newJsgObjectModuleHandler<DiskCache, JsgWorkerdIsolate_TypeWrapper>(
-            [&packageDiskCacheRoot = pythonConfig.packageDiskCacheRoot](jsg::Lock& js) mutable
-            -> jsg::Ref<DiskCache> { return js.alloc<DiskCache>(packageDiskCacheRoot); }));
-    // Inject a (disabled) SimplePythonLimiter
-    pyodideBundleBuilder.addSynthetic(limiterSpecifier,
-        jsg::modules::Module::newJsgObjectModuleHandler<SimplePythonLimiter,
-            JsgWorkerdIsolate_TypeWrapper>(
-            [](jsg::Lock& js) mutable -> jsg::Ref<SimplePythonLimiter> {
-      return SimplePythonLimiter::makeDisabled(js);
-    }));
-
-    builder.add(pyodideBundleBuilder.finish());
-  }
 
   // If we have a fallback service configured, add the fallback bundle.
   // The fallback bundle is used only in workerd local development mode.

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -277,7 +277,8 @@ class WorkerdApi final: public Worker::Api {
       const Worker::Script::ModulesSource& source,
       const CompatibilityFlags::Reader& featureFlags,
       const PythonConfig& pythonConfig,
-      const jsg::Url& bundleBase);
+      const jsg::Url& bundleBase,
+      kj::Maybe<kj::String> fallbackService = kj::none);
 
  private:
   struct Impl;

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -274,7 +274,7 @@ class WorkerdApi final: public Worker::Api {
   // Create the ModuleRegistry instance for the worker.
   static kj::Own<jsg::modules::ModuleRegistry> initializeBundleModuleRegistry(
       const jsg::ResolveObserver& resolveObserver,
-      const Worker::Script::ModulesSource& source,
+      kj::Maybe<const Worker::Script::ModulesSource&> source,
       const CompatibilityFlags::Reader& featureFlags,
       const PythonConfig& pythonConfig,
       const jsg::Url& bundleBase,

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -278,6 +278,7 @@ class WorkerdApi final: public Worker::Api {
       const CompatibilityFlags::Reader& featureFlags,
       const PythonConfig& pythonConfig,
       const jsg::Url& bundleBase,
+      capnp::List<config::Extension>::Reader extensions,
       kj::Maybe<kj::String> fallbackService = kj::none);
 
  private:

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -956,3 +956,20 @@ struct Extension {
     # Raw source code of ES module.
   }
 }
+
+# ========================================================================================
+# Fallback Service Request
+#  Used only to define the JSON structure of a request to the fallback service.
+
+struct FallbackServiceRequest {
+  type @0 :Text;
+  specifier @1 :Text;
+  rawSpecifier @2 :Text;
+  referrer @3 :Text;
+
+  struct Attribute {
+    name @0: Text;
+    value @1: Text;
+  }
+  attributes @4 :List(Attribute);
+}


### PR DESCRIPTION
Adds fallback service support, with a new POST based implementation for the fallback service,
Adds extension module support,
Enables registering the module registry for service worker syntax so things like the internal use of `node:util` inspect can be used for improved console output locally just like when using ESM syntax workers.
Moves the fallback service implementation out of server.c++ to a separate compilation unit.