### PR TITLE
Move vendor dir in Python search path just before site-packages.

### DIFF
--- a/src/pyodide/internal/setupPackages.ts
+++ b/src/pyodide/internal/setupPackages.ts
@@ -217,7 +217,7 @@ export function mountWorkerFiles(Module: Module): void {
 
 /**
  * Add the directories created by mountLib to sys.path.
- * Has to run after the runtime is initialized.
+ * Has to run after the runtime is initialized but before memory snapshot is collected.
  */
 export function adjustSysPath(Module: Module): void {
   const site_packages = Module.FS.sessionSitePackages;

--- a/src/workerd/server/tests/python/vendor_dir/worker.py
+++ b/src/workerd/server/tests/python/vendor_dir/worker.py
@@ -1,5 +1,42 @@
+import sys
+
 from a import A
 
 
 def test():
     assert A == 77
+    test_path_ordering()
+
+
+def test_path_ordering():
+    """Verify that the Python path is set in the correct order.
+    '/session/metadata/vendor' should be positioned after the system paths
+    but before any site-packages paths.
+    """
+    vendor_path = "/session/metadata/vendor"
+    vendor_index = sys.path.index(vendor_path)
+
+    # Check that vendor_path is in sys.path
+    assert vendor_index >= 0, f"{vendor_path} not found in sys.path"
+
+    # Verify that all site-packages paths come after the vendor path
+    for i, path in enumerate(sys.path):
+        if "site-packages" in path:
+            assert i > vendor_index, (
+                f"site-packages path {path} appears before vendor path"
+            )
+
+    # Verify system paths come before the vendor path
+    system_paths = [
+        "/lib/python312.zip",
+        "/lib/python3.12",
+        "/lib/python3.12/lib-dynload",
+    ]
+    for path in system_paths:
+        if path in sys.path:
+            assert sys.path.index(path) < vendor_index, (
+                f"System path {path} appears after vendor path"
+            )
+
+    # Print the path for debugging if needed
+    print("Python sys.path:", sys.path)


### PR DESCRIPTION
We have two functions that adjust the sys path in Python Workers. The first one (adjustSysPath) only runs when not restoring from a snapshot, so it is effectively immortalised in the memory snapshots. To avoid needing to regenerate all the memory snapshots (which for package snapshots would be a problem) we just rearrange the path at the same time as when we add the vendor path to the sys path.

### Test Plan

```
$ bazel run @workerd//src/workerd/server/tests/python:vendor_dir_development@

Python sys.path: ['/session', '/lib/python312.zip', '/lib/python3.12', '/lib/python3.12/lib-dynload', '/session/metadata', '/session/metadata/vendor', '/lib/python3.12/site-packages', '/session/lib/python3.12/site-packages']
```