### PR TITLE
Bind AsyncLocalStorage.snapshot/wrap to the IoContext

### DIFF
--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -68,6 +68,7 @@ wd_cc_library(
         # it, move files to the main node target if needed.
         "//src/workerd/io:compatibility-date_capnp",
         "//src/workerd/jsg",
+        "//src/workerd/io",
         "//src/workerd/util:mimetype",
     ],
 )
@@ -404,4 +405,10 @@ wd_test(
     src = "tests/http-nodejs-test.wd-test",
     args = ["--experimental"],
     data = ["tests/http-nodejs-test.js"],
+)
+
+wd_test(
+    src = "tests/bound-als-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/bound-als-test.js"],
 )

--- a/src/workerd/api/node/tests/bound-als-test.js
+++ b/src/workerd/api/node/tests/bound-als-test.js
@@ -1,0 +1,75 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { strictEqual } from 'node:assert';
+
+// This test verifies that the AsyncLocalStorage snapshot and bind APIs appropriately
+// throw an error when called from outside the request context in which they were created.
+// This is a workers specific limitation and is not present in Node.js.
+
+// The test will only work if the associated compatibility flag is enabled.
+strictEqual(
+  Cloudflare.compatibilityFlags.bind_asynclocalstorage_snapshot_to_request,
+  true
+);
+
+const kErr =
+  'Cannot call this AsyncLocalStorage bound function outside of the ' +
+  'request in which it was created.';
+
+export const test = {
+  async test(_, env) {
+    const resp = await env.subrequest.fetch(
+      'http://AsyncLocalStorage/snapshot'
+    );
+    strictEqual(resp.status, 200);
+    strictEqual(await resp.text(), 'ok');
+    const resp2 = await env.subrequest.fetch(
+      'http://AsyncLocalStorage/snapshot'
+    );
+    strictEqual(resp2.status, 500);
+    strictEqual(await resp2.text(), kErr);
+
+    const resp3 = await env.subrequest.fetch('http://AsyncLocalStorage/bind');
+    strictEqual(resp3.status, 200);
+    strictEqual(await resp3.text(), 'ok');
+    const resp4 = await env.subrequest.fetch('http://AsyncLocalStorage/bind');
+    strictEqual(resp4.status, 500);
+    strictEqual(await resp4.text(), kErr);
+  },
+};
+
+let snapshot;
+let boundFn;
+
+const als = new AsyncLocalStorage();
+const noRequestSnapshot = als.run(123, () => AsyncLocalStorage.snapshot());
+
+export default {
+  async fetch(req) {
+    // A snapshot created outside of a request can still be used, and can
+    // perform i/o operation...
+    strictEqual(
+      noRequestSnapshot(() => {
+        // Works if no error is thrown. We don't care about the actual
+        // callback here.
+        setTimeout(() => {}, 0);
+        return als.getStore();
+      }),
+      123
+    );
+
+    try {
+      if (req.url.endsWith('/snapshot')) {
+        snapshot ??= AsyncLocalStorage.snapshot();
+        snapshot(() => {});
+        return new Response('ok');
+      } else if (req.url.endsWith('/bind')) {
+        boundFn ??= AsyncLocalStorage.bind(() => {});
+        boundFn();
+        return new Response('ok');
+      }
+      throw new Error('Unknown request');
+    } catch (err) {
+      return new Response(err.message, { status: 500 });
+    }
+  },
+};

--- a/src/workerd/api/node/tests/bound-als-test.wd-test
+++ b/src/workerd/api/node/tests/bound-als-test.wd-test
@@ -1,0 +1,21 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "bound-als-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "bound-als-test.js")
+        ],
+        compatibilityDate = "2025-05-01",
+        compatibilityFlags = [
+          "nodejs_compat",
+          "bind_asynclocalstorage_snapshot_to_request",
+        ],
+        bindings = [
+          (name = "subrequest", service = "bound-als-test"),
+        ]
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -811,4 +811,15 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
 
   # NOTE: `reuseCtxAcrossNonclassEvents @92` was declared earlier in the file. Next ordinal is
   #   @93.
+
+  bindAsyncLocalStorageSnapshot @93 :Bool
+      $compatEnableFlag("bind_asynclocalstorage_snapshot_to_request")
+      $compatDisableFlag("do_not_bind_asynclocalstorage_snapshot_to-request")
+      $compatEnableDate("2025-06-16");
+      # The AsyncLocalStorage frame can capture values that are bound to the
+      # current IoContext. This is not always in the users control since we use
+      # the ALS storage frame to propagate internal trace spans as well as
+      # user-provided values. This flag, when set, binds the snapshot / bound
+      # functions to the current IoContext and will throw an error if the bound 
+      # functions are called outside of the IoContext in which they were created.
 }

--- a/src/workerd/jsg/async-context.c++
+++ b/src/workerd/jsg/async-context.c++
@@ -75,15 +75,18 @@ Ref<AsyncContextFrame> AsyncContextFrame::create(Lock& js, StorageEntry storageE
   return js.alloc<AsyncContextFrame>(js, kj::mv(storageEntry));
 }
 
-v8::Local<v8::Function> AsyncContextFrame::wrap(
-    Lock& js, V8Ref<v8::Function>& fn, kj::Maybe<v8::Local<v8::Value>> thisArg) {
-  return wrap(js, fn.getHandle(js), thisArg);
+v8::Local<v8::Function> AsyncContextFrame::wrap(Lock& js,
+    V8Ref<v8::Function>& fn,
+    jsg::Function<void()> validate,
+    kj::Maybe<v8::Local<v8::Value>> thisArg) {
+  return wrap(js, fn.getHandle(js), kj::mv(validate), thisArg);
 }
 
-v8::Local<v8::Function> AsyncContextFrame::wrapSnapshot(Lock& js) {
+v8::Local<v8::Function> AsyncContextFrame::wrapSnapshot(Lock& js, jsg::Function<void()> validate) {
   return js.wrapReturningFunction(js.v8Context(),
-      JSG_VISITABLE_LAMBDA((frame = AsyncContextFrame::currentRef(js)), (frame),
-          (Lock& js, const v8::FunctionCallbackInfo<v8::Value>& args) {
+      JSG_VISITABLE_LAMBDA((frame = AsyncContextFrame::currentRef(js), validate = kj::mv(validate)),
+          (frame, validate), (Lock& js, const v8::FunctionCallbackInfo<v8::Value>& args) {
+            validate(js);
             auto context = js.v8Context();
             JSG_REQUIRE(args[0]->IsFunction(), TypeError, "The first argument must be a function");
             auto fn = args[0].As<v8::Function>();
@@ -97,15 +100,19 @@ v8::Local<v8::Function> AsyncContextFrame::wrapSnapshot(Lock& js) {
           }));
 }
 
-v8::Local<v8::Function> AsyncContextFrame::wrap(
-    Lock& js, v8::Local<v8::Function> fn, kj::Maybe<v8::Local<v8::Value>> thisArg) {
+v8::Local<v8::Function> AsyncContextFrame::wrap(Lock& js,
+    v8::Local<v8::Function> fn,
+    jsg::Function<void()> validate,
+    kj::Maybe<v8::Local<v8::Value>> thisArg) {
   auto context = js.v8Context();
 
   return js.wrapReturningFunction(context,
       JSG_VISITABLE_LAMBDA(
-          (frame = JSG_THIS, thisArg = js.v8Ref(thisArg.orDefault(context->Global())),
-              fn = js.v8Ref(fn)),
-          (frame, thisArg, fn), (Lock& js, const v8::FunctionCallbackInfo<v8::Value>& args) {
+          (frame = JSG_THIS, validate = kj::mv(validate),
+              thisArg = js.v8Ref(thisArg.orDefault(context->Global())), fn = js.v8Ref(fn)),
+          (frame, validate, thisArg, fn),
+          (Lock& js, const v8::FunctionCallbackInfo<v8::Value>& args) {
+            validate(js);
             auto function = fn.getHandle(js);
 
             v8::LocalVector<v8::Value> argv(js.v8Isolate, args.Length());

--- a/src/workerd/jsg/async-context.h
+++ b/src/workerd/jsg/async-context.h
@@ -144,19 +144,25 @@ class AsyncContextFrame final: public Wrappable {
   // Returns a function that captures the current frame and calls the function passed
   // in as an argument within that captured context. Equivalent to wrapping a function
   // with the signature (cb, ...args) => cb(...args).
-  static v8::Local<v8::Function> wrapSnapshot(Lock& js);
+  // The validate function is called to ensure that the current frame is still valid.
+  // If the validate function throws, the wrapper will throw.
+  static v8::Local<v8::Function> wrapSnapshot(Lock& js, jsg::Function<void()> validate);
 
   // Associates the given JavaScript function with this AsyncContextFrame, returning
   // a wrapper function that will ensure appropriate propagation of the async context
   // when the wrapper function is called.
-  v8::Local<v8::Function> wrap(
-      Lock& js, V8Ref<v8::Function>& fn, kj::Maybe<v8::Local<v8::Value>> thisArg = kj::none);
+  v8::Local<v8::Function> wrap(Lock& js,
+      V8Ref<v8::Function>& fn,
+      jsg::Function<void()> validate,
+      kj::Maybe<v8::Local<v8::Value>> thisArg = kj::none);
 
   // Associates the given JavaScript function with this AsyncContextFrame, returning
   // a wrapper function that will ensure appropriate propagation of the async context
   // when the wrapper function is called.
-  v8::Local<v8::Function> wrap(
-      Lock& js, v8::Local<v8::Function> fn, kj::Maybe<v8::Local<v8::Value>> thisArg = kj::none);
+  v8::Local<v8::Function> wrap(Lock& js,
+      v8::Local<v8::Function> fn,
+      jsg::Function<void()> validate,
+      kj::Maybe<v8::Local<v8::Value>> thisArg = kj::none);
 
   // AsyncContextFrame::Scope makes the given AsyncContextFrame the current in the
   // stack until the scope is destroyed.


### PR DESCRIPTION
The AsyncLocalStorage frame can capture values that are bound to the current IoContext. This is not always in the users control since we use the ALS storage frame to propagate internal trace spans as well as user-provided values. This changes introduces a new compat flag that, when set, binds the snapshot / bound functions to the current IoContext and will throw an error if the bound functions are called outside of the IoContext in which they were created. This is a potentially breaking change so the compat flag is required. It will be set to be enabled by default, however.

Unfortunately I believe throwing an error in this case is the only reasonable behavior. It becomes rather complicated to deal with cross-request-bound values, especially when the user may not even be aware that the context frame is capturing such values and can't do anything about it. The specific error thrown will be at least more meaningful than the crypto I/O error message that is thrown now.
 
Refs: https://github.com/cloudflare/workerd/issues/4155

/cc @vicb 