### PR TITLE
Update deps updater so it can trigger workflow runs

### DIFF
--- a/.github/workflows/deps-updater.yml
+++ b/.github/workflows/deps-updater.yml
@@ -28,6 +28,8 @@ jobs:
           ref: main
       - name: Update dependencies
         run: build/deps/update-deps.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Open pull request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/.github/workflows/deps-updater.yml
+++ b/.github/workflows/deps-updater.yml
@@ -31,6 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Open pull request
+        id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "update dependencies to latest version"
@@ -42,3 +43,7 @@ jobs:
           body: |
             This is an automated pull request for updating the dependencies of workerd.
           delete-branch: true
+      - name: Enable Pull Request Automerge
+        run: gh pr merge --rebase --auto ${{ steps.create-pr.outputs.pull-request-number }}
+        env:
+          GH_TOKEN: ${{ secrets.DEVPROD_PAT }}

--- a/.github/workflows/deps-updater.yml
+++ b/.github/workflows/deps-updater.yml
@@ -2,10 +2,10 @@ name: Dependency updater
 
 on:
   schedule:
+    # Run at 00:00 UTC every Sunday
     - cron: '0 0 * * 0'
-
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Allow manual triggering for testing
+  workflow_dispatch:
 
 concurrency:
   group: deps-updater
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
+          token: ${{ secrets.DEVPROD_PAT }}
+          ref: main
       - name: Update dependencies
         run: build/deps/update-deps.py
       - name: Open pull request
@@ -32,6 +34,9 @@ jobs:
           commit-message: "update dependencies to latest version"
           branch: "automatic-update-deps"
           title: "Update dependencies"
+          token: ${{ secrets.DEVPROD_PAT }}
+          author: "Workers DevProd <workers-devprod@cloudflare.com>"
+          committer: "Workers DevProd <workers-devprod@cloudflare.com>"
           body: |
             This is an automated pull request for updating the dependencies of workerd.
           delete-branch: true


### PR DESCRIPTION
Instead of running with the default GITHUB_TOKEN, we now run with the DEVPROD_PAT.

I also added a manual trigger, so we can create a roll deps PR any time.