### PR TITLE
Add compat flag for appropriate handling of unrecognized import attributes

### DIFF
--- a/src/workerd/api/tests/new-module-registry-test.js
+++ b/src/workerd/api/tests/new-module-registry-test.js
@@ -168,7 +168,7 @@ export const queryAndFragment = {
   },
 };
 
-// We do not currently support import assertions/attributes. Per the recommendation
+// We do not currently support import attributes. Per the recommendation
 // in the spec, we throw an error when they are encountered.
 export const importAssertionsFail = {
   async test() {
@@ -230,7 +230,7 @@ export const wasmModuleTest = {
 //   * [x] Querys and fragments resolve new instances of known modules
 //   * [x] URL resolution works correctly
 //   * [x] Invalid URLs are correctly reported as errors
-// * [x] Import assertions should be rejected
+// * [x] Import attributes should be rejected
 // * [x] require(...) Works in CommonJs Modules
 // * [x] require(...) correctly handles node: modules with/without the node: prefix
 // * [x] Circular dependencies are correctly handled

--- a/src/workerd/api/tests/new-module-registry-test.wd-test
+++ b/src/workerd/api/tests/new-module-registry-test.wd-test
@@ -17,7 +17,7 @@ const unitTests :Workerd.Config = (
           # Ensure that async context is propagated into a dynamic import.
           (name = "als", esModule = "export default globalThis.als.getStore()"),
 
-          # Import assertions are not supported currently
+          # Import attributes are not supported currently
           (name = "ia", esModule = "import * as def from 'foo' with { a: 'test' }"),
 
           # Errors on ESM eval should be reported properly in both static and

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -816,10 +816,20 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatEnableFlag("bind_asynclocalstorage_snapshot_to_request")
       $compatDisableFlag("do_not_bind_asynclocalstorage_snapshot_to-request")
       $compatEnableDate("2025-06-16");
-      # The AsyncLocalStorage frame can capture values that are bound to the
-      # current IoContext. This is not always in the users control since we use
-      # the ALS storage frame to propagate internal trace spans as well as
-      # user-provided values. This flag, when set, binds the snapshot / bound
-      # functions to the current IoContext and will throw an error if the bound 
-      # functions are called outside of the IoContext in which they were created.
+  # The AsyncLocalStorage frame can capture values that are bound to the
+  # current IoContext. This is not always in the users control since we use
+  # the ALS storage frame to propagate internal trace spans as well as
+  # user-provided values. This flag, when set, binds the snapshot / bound
+  # functions to the current IoContext and will throw an error if the bound
+  # functions are called outside of the IoContext in which they were created.
+
+  throwOnUnrecognizedImportAssertion @94 :Bool
+      $compatEnableFlag("throw_on_unrecognized_import_assertion")
+      $compatDisableFlag("ignore_unrecognized_import_assertion")
+      $compatEnableDate("2025-06-16");
+  # In the original module registry implementation, import attributes that are not recognized
+  # would be ignored. This is not compliant with the spec which strongly recommends that runtimes
+  # throw an error when unknown import attributes are encountered. In the new module registry
+  # implementation the recommended behavior is what is implemented. With this compat flag
+  # enabled, the original module registry implementation will follow the recommended behavior.
 }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1012,6 +1012,9 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
     if (features.getNodeJsCompatV2()) {
       lock->setNodeJsCompatEnabled();
     }
+    if (features.getThrowOnUnrecognizedImportAssertion()) {
+      lock->setThrowOnUnrecognizedImportAssertion();
+    }
     if (features.getNoTopLevelAwaitInRequire()) {
       lock->disableTopLevelAwait();
     }

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -201,6 +201,14 @@ void Lock::setNodeJsCompatEnabled() {
   IsolateBase::from(v8Isolate).setNodeJsCompatEnabled({}, true);
 }
 
+void Lock::setThrowOnUnrecognizedImportAssertion() {
+  IsolateBase::from(v8Isolate).setThrowOnUnrecognizedImportAssertion();
+}
+
+bool Lock::getThrowOnUnrecognizedImportAssertion() const {
+  return IsolateBase::from(v8Isolate).getThrowOnUnrecognizedImportAssertion();
+}
+
 void Lock::disableTopLevelAwait() {
   IsolateBase::from(v8Isolate).disableTopLevelAwait();
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2682,6 +2682,8 @@ class Lock {
   void setCaptureThrowsAsRejections(bool capture);
 
   void setNodeJsCompatEnabled();
+  void setThrowOnUnrecognizedImportAssertion();
+  bool getThrowOnUnrecognizedImportAssertion() const;
   void setToStringTag();
   void disableTopLevelAwait();
 

--- a/src/workerd/jsg/modules-new.c++
+++ b/src/workerd/jsg/modules-new.c++
@@ -663,7 +663,7 @@ v8::MaybeLocal<v8::Promise> dynamicImport(v8::Local<v8::Context> context,
     v8::Local<v8::Data> host_defined_options,
     v8::Local<v8::Value> resource_name,
     v8::Local<v8::String> specifier,
-    v8::Local<v8::FixedArray> import_assertions) {
+    v8::Local<v8::FixedArray> import_attributes) {
   auto isolate = context->GetIsolate();
 
   // Since this method is called directly by V8, we don't want to use jsg::check
@@ -684,7 +684,7 @@ v8::MaybeLocal<v8::Promise> dynamicImport(v8::Local<v8::Context> context,
     return js.tryCatch([&]() -> v8::MaybeLocal<v8::Promise> {
       auto spec = js.toString(specifier);
 
-      // The proposed specification for import assertions strongly recommends that
+      // The proposed specification for import attributes strongly recommends that
       // embedders reject import attributes and types they do not understand/implement.
       // This is because import attributes can alter the interpretation of a module.
       // Throwing an error for things we do not understand is the safest thing to do
@@ -692,7 +692,7 @@ v8::MaybeLocal<v8::Promise> dynamicImport(v8::Local<v8::Context> context,
       //
       // For now, we do not support any import attributes, so if there are any at all
       // we will reject the import.
-      if (!import_assertions.IsEmpty() && import_assertions->Length() > 0) {
+      if (!import_attributes.IsEmpty() && import_attributes->Length() > 0) {
         return rejected(js, js.typeError("Import attributes are not supported"));
       };
 
@@ -747,7 +747,7 @@ IsolateModuleRegistry::IsolateModuleRegistry(
 // The callback v8 calls when static import is used.
 v8::MaybeLocal<v8::Module> resolveCallback(v8::Local<v8::Context> context,
     v8::Local<v8::String> specifier,
-    v8::Local<v8::FixedArray> import_assertions,
+    v8::Local<v8::FixedArray> import_attributes,
     v8::Local<v8::Module> referrer) {
   auto isolate = context->GetIsolate();
   auto& registry = IsolateModuleRegistry::from(isolate);
@@ -756,7 +756,7 @@ v8::MaybeLocal<v8::Module> resolveCallback(v8::Local<v8::Context> context,
   return js.tryCatch([&]() -> v8::MaybeLocal<v8::Module> {
     auto spec = kj::str(specifier);
 
-    // The proposed specification for import assertions strongly recommends that
+    // The proposed specification for import attributes strongly recommends that
     // embedders reject import attributes and types they do not understand/implement.
     // This is because import attributes can alter the interpretation of a module.
     // Throwing an error for things we do not understand is the safest thing to do
@@ -764,7 +764,7 @@ v8::MaybeLocal<v8::Module> resolveCallback(v8::Local<v8::Context> context,
     //
     // For now, we do not support any import attributes, so if there are any at all
     // we will reject the import.
-    if (!import_assertions.IsEmpty() && import_assertions->Length() > 0) {
+    if (!import_attributes.IsEmpty() && import_attributes->Length() > 0) {
       js.throwException(js.typeError("Import attributes are not supported"));
     }
 
@@ -794,7 +794,7 @@ v8::MaybeLocal<v8::Module> resolveCallback(v8::Local<v8::Context> context,
         .referrer = referrerUrl,
         .rawSpecifier = spec.asPtr(),
       };
-      // TODO(soon): Add import assertions to the context.
+      // TODO(soon): Add import attributes to the context.
 
       return registry.resolve(js, resolveContext);
     }
@@ -1321,7 +1321,7 @@ bool Module::isMain() const {
 
 bool Module::evaluateContext(const ResolveContext& context) const {
   if (context.specifier != specifier()) return false;
-  // TODO(soon): Check the import assertions in the context.
+  // TODO(soon): Check the import attributes in the context.
   return true;
 }
 

--- a/src/workerd/jsg/modules-new.h
+++ b/src/workerd/jsg/modules-new.h
@@ -28,7 +28,7 @@ namespace workerd::jsg::modules {
 // This new implementation of ModuleRegistry is designed to be more flexible,
 // modular, and extensible than the previous implementation. It is also designed
 // to support handling import specifiers as URLs, implement import.meta, properly
-// handle import assertions, sharing of modules across isolate replicas, and more.
+// handle import attributes, sharing of modules across isolate replicas, and more.
 //
 // Every Worker has exactly one ModuleRegistry associated with composed of
 // of or more ModuleBundles (e.g. a ModuleBundle with modules from the worker

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -17,24 +17,22 @@ namespace {
 // Implementation of `v8::Module::ResolveCallback`.
 v8::MaybeLocal<v8::Module> resolveCallback(v8::Local<v8::Context> context,
     v8::Local<v8::String> specifier,
-    v8::Local<v8::FixedArray> import_assertions,
+    v8::Local<v8::FixedArray> import_attributes,
     v8::Local<v8::Module> referrer) {
   auto& js = jsg::Lock::from(context->GetIsolate());
   v8::MaybeLocal<v8::Module> result;
 
-  // TODO(new-module-registry): The specification for import assertions strongly
-  // recommends that embedders reject import attributes and types they do not
-  // understand/implement. This is because import attributes can alter the
-  // interpretation of a module and are considered to be part of the unique
-  // key for caching a module.
+  // The specification for import attributes strongly recommends that embedders
+  // reject import attributes and types they do not understand/implement. This
+  // is because import attributes can alter the interpretation of a module and
+  // are considered to be part of the unique key for caching a module.
   // Throwing an error for things we do not understand is the safest thing to do.
-  // However, historically we have not followed this guideline in the spec and
-  // it's not clear if enforcing that constraint would be breaking so let's
-  // first try to determine if anyone is making use of import assertions.
-  // If we're lucky, we won't receive any hits on this and we can start
-  // enforcing the rule without a compat flag.
-  if (import_assertions->Length() > 0) {
-    LOG_NOSENTRY(WARNING, "Import attributes specified (and ignored) on static import");
+  // However, historically we have not followed this guideline in the spec
+  // and unfortunately there are applications deployed that will break if we
+  // started enforcing that guideline without a compat flag.
+  if (!import_attributes.IsEmpty() && import_attributes->Length() > 0) {
+    JSG_REQUIRE(!js.getThrowOnUnrecognizedImportAssertion(), Error,
+        "Unrecognized import attributes specified");
   }
 
   js.tryCatch([&] {

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -227,6 +227,14 @@ class IsolateBase {
     return usingNewModuleRegistry;
   }
 
+  void setThrowOnUnrecognizedImportAssertion() {
+    throwOnUnrecognizedImportAssertion = true;
+  }
+
+  bool getThrowOnUnrecognizedImportAssertion() const {
+    return throwOnUnrecognizedImportAssertion;
+  }
+
   bool pumpMsgLoop() {
     return v8System.pumpMsgLoop(ptr);
   }
@@ -282,6 +290,9 @@ class IsolateBase {
   bool setToStringTag = false;
   bool allowTopLevelAwait = true;
   bool usingNewModuleRegistry = false;
+
+  // Only used when the original module registry is used.
+  bool throwOnUnrecognizedImportAssertion = false;
 
   kj::Maybe<kj::Function<Logger>> maybeLogger;
   kj::Maybe<kj::Function<ErrorReporter>> maybeErrorReporter;

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -1,6 +1,7 @@
 load("//:build/kj_test.bzl", "kj_test")
 load("//:build/wd_cc_benchmark.bzl", "wd_cc_benchmark")
 load("//:build/wd_cc_library.bzl", "wd_cc_library")
+load("//:build/wd_test.bzl", "wd_test")
 
 wd_cc_library(
     name = "bench-tools",
@@ -83,4 +84,10 @@ wd_cc_benchmark(
     name = "bench-fast-api",
     srcs = ["bench-fast-api.c++"],
     deps = ["//src/workerd/jsg"],
+)
+
+wd_test(
+    src = "unknown-import-assertions-test.wd-test",
+    args = ["--experimental"],
+    data = ["unknown-import-assertions-test.js"],
 )

--- a/src/workerd/tests/unknown-import-assertions-test.js
+++ b/src/workerd/tests/unknown-import-assertions-test.js
@@ -1,0 +1,9 @@
+import { rejects } from 'node:assert';
+
+export const test = {
+  async test() {
+    await rejects(import('worker', { with: { a: 'b' } }), {
+      message: /Unrecognized import attributes/,
+    });
+  },
+};

--- a/src/workerd/tests/unknown-import-assertions-test.wd-test
+++ b/src/workerd/tests/unknown-import-assertions-test.wd-test
@@ -1,0 +1,18 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "unknown-import-assertions-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "unknown-import-assertions-test.js")
+        ],
+        compatibilityDate = "2025-05-01",
+        compatibilityFlags = [
+          "nodejs_compat",
+          "throw_on_unrecognized_import_assertion",
+        ]
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
In the original module registry implementation, unknown import attributes were ignored. The spec, however, strongly recommends that unknown attributes be treated as errors. Unfortunately doing so now would break existing workers so we need a compat flag.