### PR TITLE
Add TreatErrorsAsHostObjects to v8, customize Error serialization

### DIFF
--- a/build/deps/v8.bzl
+++ b/build/deps/v8.bzl
@@ -32,6 +32,7 @@ PATCHES = [
     "0024-Modify-where-to-look-for-dragonbox.patch",
     "0025-Disable-slow-handle-check.patch",
     "0026-Workaround-for-builtin-can-allocate-issue.patch",
+    "0027-Implement-additional-Exception-construction-methods.patch",
 ]
 
 # V8 and its dependencies

--- a/patches/v8/0027-Implement-additional-Exception-construction-methods.patch
+++ b/patches/v8/0027-Implement-additional-Exception-construction-methods.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: James M Snell <jsnell@cloudflare.com>
+Date: Tue, 1 Jul 2025 17:33:43 -0700
+Subject: Implement additional Exception construction methods
+
+Signed-off-by: James M Snell <jsnell@cloudflare.com>
+
+diff --git a/include/v8-exception.h b/include/v8-exception.h
+index 5441a0ab6a403c566e7b0b6002e720c971480893..b9933027aaf9f7842740d6a6742a2c73da65a46a 100644
+--- a/include/v8-exception.h
++++ b/include/v8-exception.h
+@@ -48,6 +48,14 @@ class V8_EXPORT Exception {
+   static Local<Value> WasmSuspendError(Local<String> message,
+                                        Local<Value> options = {});
+   static Local<Value> Error(Local<String> message, Local<Value> options = {});
++  static Local<Value> URIError(Local<String> message,
++                               Local<Value> options = {});
++  static Local<Value> EvalError(Local<String> message,
++                               Local<Value> options = {});
++  static Local<Value> AggregateError(Local<String> message,
++                                     Local<Value> options = {});
++  static Local<Value> SuppressedError(Local<String> message,
++                                      Local<Value> options = {});
+ 
+   /**
+    * Creates an error message for the given exception.
+diff --git a/src/api/api.cc b/src/api/api.cc
+index 99eb9a5dc075a0e7aa38fe31b0576a652bd12cdf..345bfb3fac0e16ad532179dd915c80b454d0cb88 100644
+--- a/src/api/api.cc
++++ b/src/api/api.cc
+@@ -11281,6 +11281,10 @@ DEFINE_ERROR(WasmCompileError, wasm_compile_error)
+ DEFINE_ERROR(WasmLinkError, wasm_link_error)
+ DEFINE_ERROR(WasmRuntimeError, wasm_runtime_error)
+ DEFINE_ERROR(WasmSuspendError, wasm_suspend_error)
++DEFINE_ERROR(EvalError, eval_error)
++DEFINE_ERROR(URIError, uri_error)
++DEFINE_ERROR(AggregateError, aggregate_error)
++DEFINE_ERROR(SuppressedError, suppressed_error)
+ DEFINE_ERROR(Error, error)
+ 
+ #undef DEFINE_ERROR
+diff --git a/src/logging/runtime-call-stats.h b/src/logging/runtime-call-stats.h
+index 9509646458bd4c7b6e4cdfa7a5109a431b8121c1..03c2063841224df6b043a4edeaea9ee1f568b563 100644
+--- a/src/logging/runtime-call-stats.h
++++ b/src/logging/runtime-call-stats.h
+@@ -218,7 +218,11 @@ namespace v8::internal {
+   V(WeakMap_Delete)                                        \
+   V(WeakMap_Get)                                           \
+   V(WeakMap_New)                                           \
+-  V(WeakMap_Set)
++  V(WeakMap_Set)                                           \
++  V(EvalError_New)                                         \
++  V(URIError_New)                                          \
++  V(AggregateError_New)                                    \
++  V(SuppressedError_New)
+ 
+ #define ADD_THREAD_SPECIFIC_COUNTER(V, Prefix, Suffix) \
+   V(Prefix##Suffix)                                    \

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -398,6 +398,11 @@ enum SerializationTag {
   # without breaking things).
 
   abortSignal @9;
+
+  nativeError @10;
+  # A JavaScript native error, such as Error, TypeError, etc. These are typically
+  # not handled as host objects in V8 but we handle them as such in workers in
+  # order to preserve additional information that we may attach to them.
 }
 
 enum StreamEncoding {

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -69,6 +69,11 @@ void JsObject::set(Lock& js, kj::StringPtr name, const JsValue& value) {
   set(js, js.strIntern(name), value);
 }
 
+void JsObject::defineProperty(Lock& js, kj::StringPtr name, const JsValue& value) {
+  v8::Local<v8::String> nameStr = js.strIntern(name);
+  check(inner->DefineOwnProperty(js.v8Context(), nameStr, value));
+}
+
 void JsObject::setReadOnly(Lock& js, kj::StringPtr name, const JsValue& value) {
   v8::Local<v8::String> nameStr = js.strIntern(name);
   check(inner->DefineOwnProperty(js.v8Context(), nameStr, value,

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -363,6 +363,13 @@ class JsObject final: public JsBase<v8::Object, JsObject> {
   void set(Lock& js, kj::StringPtr name, const JsValue& value);
   void setReadOnly(Lock& js, kj::StringPtr name, const JsValue& value);
   void setNonEnumerable(Lock& js, const JsSymbol& name, const JsValue& value);
+
+  // Like set but uses the defineProperty API instead in order to override
+  // the default property attributes. This is useful for defining properties
+  // that otherwise would not be normally settable, such as the name of an
+  // error object.
+  void defineProperty(Lock& js, kj::StringPtr name, const JsValue& value);
+
   JsValue get(Lock& js, const JsValue& name) KJ_WARN_UNUSED_RESULT;
   JsValue get(Lock& js, kj::StringPtr name) KJ_WARN_UNUSED_RESULT;
 

--- a/src/workerd/jsg/ser-test.c++
+++ b/src/workerd/jsg/ser-test.c++
@@ -150,12 +150,43 @@ struct SerTestContext: public ContextGlobalObject {
     return result;
   }
 
+  JsObject roundTripError(Lock& js, JsObject errorObj) {
+    Serializer ser(js,
+        Serializer::Options{
+          .treatErrorsAsHostObjects = true,
+        });
+    ser.write(js, errorObj);
+    auto content = ser.release();
+    Deserializer deser(js, content);
+    auto val = KJ_ASSERT_NONNULL(deser.readValue(js).tryCast<JsObject>());
+
+    auto names = errorObj.getPropertyNames(js, KeyCollectionFilter::OWN_ONLY,
+        PropertyFilter::ALL_PROPERTIES, IndexFilter::SKIP_INDICES);
+    for (size_t n = 0; n < names.size(); n++) {
+      auto before = errorObj.get(js, names.get(js, n));
+      auto after = val.get(js, names.get(js, n));
+      if (before.isArray()) {
+        auto beforeArray = KJ_ASSERT_NONNULL(before.tryCast<JsArray>());
+        auto afterArray = KJ_ASSERT_NONNULL(after.tryCast<JsArray>());
+        KJ_ASSERT(beforeArray.size() == afterArray.size());
+        for (size_t i = 0; i < beforeArray.size(); i++) {
+          KJ_ASSERT(beforeArray.get(js, i).strictEquals(afterArray.get(js, i)));
+        }
+      } else {
+        KJ_ASSERT(before.strictEquals(after));
+      }
+    }
+
+    return val;
+  }
+
   JSG_RESOURCE_TYPE(SerTestContext) {
     JSG_NESTED_TYPE(Foo);
     JSG_NESTED_TYPE(Bar);
     JSG_NESTED_TYPE(Baz);
     JSG_NESTED_TYPE(Qux);
     JSG_METHOD(roundTrip);
+    JSG_METHOD(roundTripError);
   }
 };
 JSG_DECLARE_ISOLATE_TYPE(SerTestIsolate,
@@ -282,6 +313,47 @@ KJ_TEST("serialization") {
                 "obj.bar = bar;\n"
                 "roundTrip(obj).bar.val.bar.val.bar.val.i",
       "number", "321");
+}
+
+KJ_TEST("serialization of errors") {
+  Evaluator<SerTestContext, SerTestIsolate> e(v8System);
+
+  e.expectEval(
+      "e = new Error('a', {cause:'c'}); e.foo = true; roundTripError(e).foo", "boolean", "true");
+  e.expectEval(
+      "roundTripError(new TypeError('a', {cause:'c'})) instanceof TypeError", "boolean", "true");
+  e.expectEval(
+      "roundTripError(new RangeError('a', {cause:'c'})) instanceof RangeError", "boolean", "true");
+  e.expectEval("roundTripError(new ReferenceError('a', {cause:'c'})) instanceof ReferenceError",
+      "boolean", "true");
+  e.expectEval("roundTripError(new SyntaxError('a', {cause:'c'})) instanceof SyntaxError",
+      "boolean", "true");
+  e.expectEval("e = new Error(); Object.defineProperty(e, 'name', {value: 'CustomError'}); "
+               "roundTripError(e).name",
+      "string", "CustomError");
+
+  // Throws due to serializing a cycle. Because we serialize the errors as
+  // host objects, we end up being responsible for ensuring that cycles are
+  // not present in the serialized data. For now, we're just punting on this
+  // to keep things simple, but we end up getting an error when we try to
+  // deserialize. Fortunately this case should always be rare.
+  // TODO(later): Handle cycles in errors as an edge case.
+  e.expectEval(R"(
+    const a = new Error('a');
+    a.cause = a;
+    roundTripError(a);
+  )",
+      "throws", "Error: Unable to deserialize cloned data.");
+
+  e.expectEval(
+      "roundTripError(new URIError('a', {cause:'c'})) instanceof URIError", "boolean", "true");
+  e.expectEval(
+      "roundTripError(new EvalError('a', {cause:'c'})) instanceof EvalError", "boolean", "true");
+  e.expectEval("roundTripError(new AggregateError(['a', 'b'], 'c')) instanceof AggregateError",
+      "boolean", "true");
+  e.expectEval("roundTripError(new SuppressedError('a', 'b', 'c', {cause:'c'})) instanceof "
+               "SuppressedError",
+      "boolean", "true");
 }
 
 }  // namespace

--- a/src/workerd/jsg/ser.c++
+++ b/src/workerd/jsg/ser.c++
@@ -10,6 +10,117 @@
 #include <v8-proxy.h>
 
 namespace workerd::jsg {
+namespace {
+// Keep in sync with the nativeError serialization tag defined in
+// worker-interface.capnp
+constexpr uint32_t SERIALIZATION_TAG_NATIVE_ERROR = 10;
+
+// The error tag is serialized as a uint32_t immediately following
+// the SERIALIZATION_TAG_NATIVE_ERROR tag in order to more efficiently
+// determine the type of error when deserializing so that we can
+// construct the appropriate v8::Exception type on deserialization
+// without having to expensive string comparison on the error name.
+enum class ErrorTag : uint32_t {
+  // The UNKNOWN tag is used when the error name is not recognized.
+  // When this occurs, we will serialize the name of the error, and
+  // when it is deserialized, we will create a generic Error and then
+  // set the name to the stored name.
+  UNKNOWN,
+  ERROR,
+  TYPE_ERROR,
+  RANGE_ERROR,
+  REFERENCE_ERROR,
+  SYNTAX_ERROR,
+  WASM_COMPILE_ERROR,
+  WASM_LINK_ERROR,
+  WASM_RUNTIME_ERROR,
+  WASM_SUSPEND_ERROR,
+  EVAL_ERROR,
+  URI_ERROR,
+  AGGREGATE_ERROR,
+  SUPPRESSED_ERROR,
+};
+
+constexpr ErrorTag getErrorTagFromName(jsg::Lock& js, kj::StringPtr str) {
+  if (str == "Error"_kj) {
+    return ErrorTag::ERROR;
+  } else if (str == "TypeError"_kj) {
+    return ErrorTag::TYPE_ERROR;
+  } else if (str == "RangeError"_kj) {
+    return ErrorTag::RANGE_ERROR;
+  } else if (str == "ReferenceError"_kj) {
+    return ErrorTag::REFERENCE_ERROR;
+  } else if (str == "SyntaxError"_kj) {
+    return ErrorTag::SYNTAX_ERROR;
+  } else if (str == "WasmCompileError"_kj) {
+    return ErrorTag::WASM_COMPILE_ERROR;
+  } else if (str == "WasmLinkError"_kj) {
+    return ErrorTag::WASM_LINK_ERROR;
+  } else if (str == "WasmRuntimeError"_kj) {
+    return ErrorTag::WASM_RUNTIME_ERROR;
+  } else if (str == "WasmSuspendError"_kj) {
+    return ErrorTag::WASM_SUSPEND_ERROR;
+  } else if (str == "EvalError"_kj) {
+    return ErrorTag::EVAL_ERROR;
+  } else if (str == "URIError"_kj) {
+    return ErrorTag::URI_ERROR;
+  } else if (str == "AggregateError"_kj) {
+    return ErrorTag::AGGREGATE_ERROR;
+  } else if (str == "SuppressedError"_kj) {
+    return ErrorTag::SUPPRESSED_ERROR;
+  }
+  return ErrorTag::UNKNOWN;
+}
+
+JsObject toJsError(Lock& js, ErrorTag tag, JsValue message) {
+  auto str = message.toJsString(js);
+  switch (tag) {
+    case ErrorTag::ERROR: {
+      return JsObject(v8::Exception::Error(str).As<v8::Object>());
+    }
+    case ErrorTag::TYPE_ERROR: {
+      return JsObject(v8::Exception::TypeError(str).As<v8::Object>());
+    }
+    case ErrorTag::RANGE_ERROR: {
+      return JsObject(v8::Exception::RangeError(str).As<v8::Object>());
+    }
+    case ErrorTag::REFERENCE_ERROR: {
+      return JsObject(v8::Exception::ReferenceError(str).As<v8::Object>());
+    }
+    case ErrorTag::SYNTAX_ERROR: {
+      return JsObject(v8::Exception::SyntaxError(str).As<v8::Object>());
+    }
+    case ErrorTag::WASM_COMPILE_ERROR: {
+      return JsObject(v8::Exception::WasmCompileError(str).As<v8::Object>());
+    }
+    case ErrorTag::WASM_LINK_ERROR: {
+      return JsObject(v8::Exception::WasmLinkError(str).As<v8::Object>());
+    }
+    case ErrorTag::WASM_RUNTIME_ERROR: {
+      return JsObject(v8::Exception::WasmRuntimeError(str).As<v8::Object>());
+    }
+    case ErrorTag::WASM_SUSPEND_ERROR: {
+      return JsObject(v8::Exception::WasmSuspendError(str).As<v8::Object>());
+    }
+    case ErrorTag::EVAL_ERROR: {
+      return JsObject(v8::Exception::EvalError(str).As<v8::Object>());
+    }
+    case ErrorTag::URI_ERROR: {
+      return JsObject(v8::Exception::URIError(str).As<v8::Object>());
+    }
+    case ErrorTag::AGGREGATE_ERROR: {
+      return JsObject(v8::Exception::AggregateError(str).As<v8::Object>());
+    }
+    case ErrorTag::SUPPRESSED_ERROR: {
+      return JsObject(v8::Exception::SuppressedError(str).As<v8::Object>());
+    }
+    case ErrorTag::UNKNOWN: {
+      return JsObject(v8::Exception::Error(str).As<v8::Object>());
+    }
+  }
+  return JsObject(v8::Exception::Error(str).As<v8::Object>());
+}
+}  // namespace
 
 void Serializer::ExternalHandler::serializeFunction(
     jsg::Lock& js, jsg::Serializer& serializer, v8::Local<v8::Function> func) {
@@ -24,6 +135,8 @@ void Serializer::ExternalHandler::serializeProxy(
 Serializer::Serializer(Lock& js, Options options)
     : externalHandler(options.externalHandler),
       treatClassInstancesAsPlainObjects(options.treatClassInstancesAsPlainObjects),
+      treatErrorsAsHostObjects(options.treatErrorsAsHostObjects),
+      preserveStackInErrors(options.preserveStackInErrors),
       ser(js.v8Isolate, this) {
 #ifdef KJ_DEBUG
   kj::requireOnStack(this, "jsg::Serializer must be allocated on the stack");
@@ -90,22 +203,20 @@ void Serializer::ThrowDataCloneError(v8::Local<v8::String> message) {
 bool Serializer::HasCustomHostObject(v8::Isolate* isolate) {
   // V8 will always call WriteHostObject() for objects that have internal fields. We only need
   // to override IsHostObject() if we want to treat pure-JS objects differently, which we do if
-  // treatClassInstancesAsPlainObjects is false.
-  return !treatClassInstancesAsPlainObjects;
+  // treatClassInstancesAsPlainObjects is false, or if treatErrorsAsHostObjects is true.
+  return !treatClassInstancesAsPlainObjects || treatErrorsAsHostObjects;
 }
 
 v8::Maybe<bool> Serializer::IsHostObject(v8::Isolate* isolate, v8::Local<v8::Object> object) {
   // This is only called if HasCustomHostObject() returned true.
-  KJ_ASSERT(!treatClassInstancesAsPlainObjects);
-  KJ_ASSERT(!prototypeOfObject.IsEmpty());
+  KJ_ASSERT(!treatClassInstancesAsPlainObjects || treatErrorsAsHostObjects);
 
-  // After v8 13.9, native errors needs to be handeld as a non-host objects.
-  // Meaning, we need to let default v8 serializer to handle native errors, rather than our
-  // own.
-  // Ref: https://github.com/v8/v8/commit/e3df60f3f5abe85f819ff2fad6a41d0709e30a61
   if (object->IsNativeError()) {
-    return v8::Just(false);
+    return v8::Just(treatErrorsAsHostObjects);
   }
+
+  if (treatClassInstancesAsPlainObjects) return v8::Just(false);
+  KJ_ASSERT(!prototypeOfObject.IsEmpty());
 
   // If the object's prototype is Object.prototype, then it is a plain object, which we'll allow
   // to be serialized normally. Otherwise, it is a class instance, which we should treat as a host
@@ -117,6 +228,58 @@ v8::Maybe<bool> Serializer::IsHostObject(v8::Isolate* isolate, v8::Local<v8::Obj
 v8::Maybe<bool> Serializer::WriteHostObject(v8::Isolate* isolate, v8::Local<v8::Object> object) {
   try {
     jsg::Lock& js = jsg::Lock::from(isolate);
+
+    if (object->IsNativeError()) {
+      auto nameStr = js.str("name"_kj);
+      auto messageStr = js.str("message"_kj);
+      auto stackStr = js.str("stack"_kj);
+
+      // Get the standard name, message, stack, cause, error, errors properties from
+      // the error object.
+      writeRawUint32(SERIALIZATION_TAG_NATIVE_ERROR);
+
+      // A mix of ad-hoc and regular serialization. We first serialize
+      // the error tag, which is an enum that identifies the type of error
+      // for faster/easier deserialization. Then we serialize the message which
+      // usually come from the prototype. Then we grab the own properties,
+      // serializing the number of them followed by each name and value in
+      // sequence.
+
+      jsg::JsObject errorObj(object);
+      auto name = errorObj.get(js, nameStr);
+      auto nameKjStr = name.toString(js);
+      auto tag = getErrorTagFromName(js, nameKjStr);
+      writeRawUint32(static_cast<uint32_t>(tag));
+      // We only write the name if it is not one of the known error types.
+      if (tag == ErrorTag::UNKNOWN) {
+        write(js, name);
+      }
+
+      write(js, errorObj.get(js, messageStr));
+
+      auto names = errorObj.getPropertyNames(js, KeyCollectionFilter::OWN_ONLY,
+          PropertyFilter::ALL_PROPERTIES, IndexFilter::SKIP_INDICES);
+
+      auto obj = js.obj();
+      for (size_t n = 0; n < names.size(); n++) {
+        auto name = names.get(js, n);
+        // The name typically comes from the prototype and therefore
+        // do not show up in the own properties of the error object, and the
+        // message we want to treat specially since we need it early in the
+        // deserialization.
+        // Since we already have them serialized above, we can filter them
+        // out here.
+        if (name.strictEquals(nameStr) || name.strictEquals(messageStr)) continue;
+
+        // If the preserveStackInErrors option is false, we do not include the
+        // stack property in the serialization.
+        if (!preserveStackInErrors && name.strictEquals(stackStr)) continue;
+        obj.set(js, name, errorObj.get(js, name));
+      }
+      write(js, obj);
+
+      return v8::Just(true);
+    }
 
     if (object->InternalFieldCount() != Wrappable::INTERNAL_FIELD_COUNT ||
         !Wrappable::isWorkerdApiObject(object)) {
@@ -242,6 +405,7 @@ void Deserializer::init(Lock& js,
   if (options.readHeader) {
     check(deser.ReadHeader(js.v8Context()));
   }
+  preserveStackInErrors = options.preserveStackInErrors;
   KJ_IF_SOME(version, options.version) {
     KJ_ASSERT(version >= 13, "The minimum serialization version is 13.");
     deser.SetWireFormatVersion(version);
@@ -299,6 +463,57 @@ v8::MaybeLocal<v8::SharedArrayBuffer> Deserializer::GetSharedArrayBufferFromId(
 v8::MaybeLocal<v8::Object> Deserializer::ReadHostObject(v8::Isolate* isolate) {
   try {
     uint tag = readRawUint32();
+
+    if (tag == SERIALIZATION_TAG_NATIVE_ERROR) {
+      auto& js = Lock::from(isolate);
+      auto stack = js.str("stack"_kj);
+
+      // The first uint32_t is the error tag, which identifies the type of error.
+      auto errorTag = static_cast<ErrorTag>(readRawUint32());
+      // If The error tag is UNKNOWN, we will read the name of the error next.
+      // If the error is known, we don't both serializing the name.
+      kj::Maybe<JsValue> maybeName;
+      if (errorTag == ErrorTag::UNKNOWN) {
+        maybeName = readValue(js);
+      }
+
+      // The next value is the message, which is always present.
+      // Now let's create the error object based on the tag and message.
+      auto obj = toJsError(js, errorTag, readValue(js));
+
+      // If we have a name, we set it on the error object. This is not
+      // perfect but it gets close enough. Specifically, when the error
+      // was serialized, if the user has modified the name or created
+      // their own subclass, then we end up having to create just a
+      // regular error here and change the name. It is not possible
+      // for us here to clone the exact error class that was used,
+      // so instanceof checks will not work as expected. But, that's ok.
+      KJ_IF_SOME(name, maybeName) {
+        // We use defineProperty here since the name is not typically
+        // modifiable with set() on error objects.
+        obj.defineProperty(js, "name"_kj, name);
+      }
+
+      // Now let's read the remaining properties... They were serialized as
+      // a plain object with some own properties.
+      KJ_IF_SOME(serObj, readValue(js).tryCast<JsObject>()) {
+        auto names = serObj.getPropertyNames(js, KeyCollectionFilter::OWN_ONLY,
+            PropertyFilter::ALL_PROPERTIES, IndexFilter::SKIP_INDICES);
+        for (size_t n = 0; n < names.size(); n++) {
+          auto name = names.get(js, n);
+          // If the preserveStackInErrors option is false, then we will not
+          // restore the serialized stack property if it is included in the
+          // serialized output.
+          if (!preserveStackInErrors && name.strictEquals(stack)) continue;
+          auto value = serObj.get(js, name);
+          obj.set(js, name, value);
+        }
+      }
+
+      v8::Local<v8::Object> ret = obj;
+      return ret;
+    }
+
     KJ_IF_SOME(result, IsolateBase::from(isolate).deserialize(Lock::from(isolate), tag, *this)) {
       return result;
     } else {

--- a/src/workerd/jsg/ser.h
+++ b/src/workerd/jsg/ser.h
@@ -117,6 +117,13 @@ class Serializer final: v8::ValueSerializer::Delegate {
     //   itself, but it may not be worth it to support for only that use case.
     bool treatClassInstancesAsPlainObjects = true;
 
+    bool treatErrorsAsHostObjects = false;
+
+    // When the treatErrorsAsHostObjects option is set, the preserveStackInErrors option
+    // controls whether the stack property in the error object is preserved in the
+    // serialization. If false, the stack property is not serialized.
+    bool preserveStackInErrors = true;
+
     // ExternalHandler, if any. Typically this would be allocated on the stack just before the
     // Serializer.
     kj::Maybe<ExternalHandler&> externalHandler;
@@ -203,6 +210,8 @@ class Serializer final: v8::ValueSerializer::Delegate {
   kj::Vector<std::shared_ptr<v8::BackingStore>> backingStores;
   bool released = false;
   bool treatClassInstancesAsPlainObjects;
+  bool treatErrorsAsHostObjects = false;
+  bool preserveStackInErrors = true;
 
   // Initialized to point at the prototype of `Object` if and only if
   // `treatClassInstancesAsPlainObjects` is false (in which case we will need to check against this
@@ -229,6 +238,13 @@ class Deserializer final: v8::ValueDeserializer::Delegate {
   struct Options {
     kj::Maybe<uint32_t> version;
     bool readHeader = true;
+
+    // When the serialized data used the treatErrorsAsHostObjects option is set,
+    // and we are deserializing a custom serialized error, this option controls
+    // whether to include the serialized stack property in the deserialized error.
+    // If false, the stack property is not restored and will instead be set to
+    // the captured stack at the time of deserialization.
+    bool preserveStackInErrors = true;
 
     // ExternalHandler, if any. Typically this would be allocated on the stack just before the
     // Deserializer.
@@ -287,6 +303,7 @@ class Deserializer final: v8::ValueDeserializer::Delegate {
   size_t totalInputSize;
   v8::ValueDeserializer deser;
   kj::Maybe<kj::ArrayPtr<std::shared_ptr<v8::BackingStore>>> sharedBackingStores;
+  bool preserveStackInErrors = true;
 };
 
 // Intended for use with v8::ValueSerializer data released into a kj::Array.


### PR DESCRIPTION
In v8's ValueSerializer, Errors are handled differently than ordinary objects in that arbitrary own properties are not serialized by default. This commit patches V8 to optionally treat Errors as host objects allowing us to serialize all own properties of Error objects. This also allows us to support additional Error constructors that v8's API does not support by default, such as `AggregateError` and `SuppressedError`, as well as allowing us to serialize the workers specific additional own properties that we attach to some errors.

Critically, this will also allow us to attach a faithful serialization of an error to the `details` property of a kj::Exception for tunneled exceptions.

Creating initially as a draft PR to get some initial feedback to make sure this is the right approach we want to take.

One key question is: should we just have jsg::Serializer *always* enable this (currently it's enabled with an option)

A separate internal PR will be necessary, will open that after we're sure this is the direction we want.

