### PR TITLE
Allow workers-devprod to bypass CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,5 +24,5 @@ jobs:
           path-to-document: 'https://www.cloudflare.com/cla/'
           # branch should not be protected
           branch: 'cla-signatures'
-          allowlist: dependabot[bot]
+          allowlist: dependabot[bot],workers-devprod
           lock-pullrequest-aftermerge: false


### PR DESCRIPTION
If we can't trust our own bot, who can we trust?