### PR TITLE
Make Socket async disposable, and Sql Cursor sync disposable

### DIFF
--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -153,6 +153,7 @@ class Socket: public jsg::Object {
     JSG_READONLY_PROTOTYPE_PROPERTY(secureTransport, getSecureTransport);
     JSG_METHOD(close);
     JSG_METHOD(startTls);
+    JSG_ASYNC_DISPOSE(close);
 
     JSG_TS_OVERRIDE({
       get secureTransport(): 'on' | 'off' | 'starttls';

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -97,6 +97,17 @@ async function test(state) {
     ]);
   }
 
+  let cursorToBeDisposed;
+  {
+    // Test disposable cursor
+    using cursor = sql.exec('SELECT 123 As foo, "abc" AS bar');
+    cursorToBeDisposed = cursor; // Keep a reference to the cursor
+  }
+  // Cursor should be disposed now, so it can't be used anymore.
+  assert.throws(() => cursorToBeDisposed.one(), {
+    message: /Expected exactly one result from SQL query/,
+  });
+
   {
     // Test one row with .one()
     let cursor = sql.exec('SELECT 123 AS foo, "abc" AS bar');

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -357,6 +357,12 @@ void SqlStorage::Cursor::endQuery(State& stateRef) {
   state = kj::none;
 }
 
+void SqlStorage::Cursor::dispose() {
+  KJ_IF_SOME(stateRef, state) {
+    endQuery(*stateRef);
+  }
+}
+
 kj::Array<const SqliteDatabase::Query::ValuePtr> SqlStorage::Cursor::mapBindings(
     kj::ArrayPtr<BindingValue> values) {
   return KJ_MAP(value, values) -> SqliteDatabase::Query::ValuePtr {

--- a/src/workerd/api/sql.h
+++ b/src/workerd/api/sql.h
@@ -193,11 +193,14 @@ class SqlStorage::Cursor final: public jsg::Object {
   double getRowsRead();
   double getRowsWritten();
 
+  void dispose();
+
   jsg::JsArray getColumnNames(jsg::Lock& js);
   JSG_RESOURCE_TYPE(Cursor, CompatibilityFlags::Reader flags) {
     JSG_METHOD(next);
     JSG_METHOD(toArray);
     JSG_METHOD(one);
+    JSG_DISPOSE(dispose);
 
     JSG_ITERABLE(rows);
     JSG_METHOD(raw);


### PR DESCRIPTION
Start making some api types disposable starting with Socket and Sql Cursor. This is really just to demonstrate how we can start making some of our types supports dispose/async dispose. We don't have many types that actually have a lifecycle in which disposal is relevant but the few we do have can be adapted easily.

example:

```js
await using socket = connect('...');
// socket automatically closes when scope exits.
```