### PR TITLE
revert fast api FastOneByteString changes

### DIFF
--- a/src/workerd/jsg/fast-api.h
+++ b/src/workerd/jsg/fast-api.h
@@ -27,14 +27,6 @@ class DOMString;
 class Lock;
 class USVString;
 
-// Update this list whenever a new string type is added.
-// TODO(soon): Merge this with webidl::isStringType once NonCoercible is supported.
-template <typename T>
-concept StringLike =
-    kj::isSameType<kj::String, T>() || kj::isSameType<kj::ArrayPtr<const char>, T>() ||
-    kj::isSameType<kj::Array<const char>, T>() || kj::isSameType<ByteString, T>() ||
-    kj::isSameType<USVString, T>() || kj::isSameType<DOMString, T>();
-
 template <typename T>
 constexpr bool isFunctionCallbackInfo = false;
 
@@ -96,12 +88,6 @@ constexpr bool isFastApiCompatible<Ret(jsg::Lock&, Args...)> = FastApiMethod<Ret
 template <typename T>
 struct FastApiJSGToV8 {
   using value = v8::Local<v8::Value>;
-};
-
-template <typename T>
-  requires StringLike<kj::RemoveConst<kj::Decay<T>>>
-struct FastApiJSGToV8<T> {
-  using value = const v8::FastOneByteString&;
 };
 
 template <typename T>

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -513,19 +513,6 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
 
   template <typename U>
   auto unwrapFastApi(v8::Local<v8::Context> context,
-      const v8::FastOneByteString& handle,
-      TypeErrorContext errorContext) -> U {
-    auto maybe = this->tryUnwrap(context, handle, (kj::Decay<U>*)nullptr);
-    KJ_IF_SOME(result, maybe) {
-      return kj::fwd<RemoveMaybe<decltype(maybe)>>(result);
-    } else {
-      throwTypeError(
-          context->GetIsolate(), errorContext, TypeWrapper::getName((kj::Decay<U>*)nullptr));
-    }
-  }
-
-  template <typename U>
-  auto unwrapFastApi(v8::Local<v8::Context> context,
       v8::Local<v8::Value>& arg,
       TypeErrorContext errorContext) -> RemoveRvalueRef<U> {
     return unwrap<U>(context, arg, errorContext);

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -477,32 +477,6 @@ class StringWrapper {
     return wrap(context, creator, value.asPtr());
   }
 
-  template <StringLike T>
-  kj::Maybe<T> tryUnwrap(v8::Local<v8::Context> context, const v8::FastOneByteString& handle, T*) {
-    auto& js = Lock::from(context->GetIsolate());
-    size_t utf8_length = simdutf::utf8_length_from_latin1(handle.data, handle.length);
-    kj::Array<char> buf = kj::heapArray<char>(utf8_length + 1);
-    buf[utf8_length] = '\0';
-    if (utf8_length == handle.length) {
-      buf.first(handle.length).copyFrom(kj::arrayPtr(handle.data, handle.length));
-    } else {
-      size_t actual_length =
-          simdutf::convert_latin1_to_utf8_safe(handle.data, handle.length, buf.begin(), buf.size());
-      KJ_ASSERT(actual_length == utf8_length);
-    }
-    if constexpr (kj::isSameType<kj::String, T>()) {
-      return js.accountedKjString(kj::mv(buf));
-    } else if constexpr (kj::isSameType<ByteString, T>()) {
-      return js.accountedByteString(kj::mv(buf));
-    } else if constexpr (kj::isSameType<USVString, T>()) {
-      return js.accountedUSVString(kj::mv(buf));
-    } else if constexpr (kj::isSameType<DOMString, T>()) {
-      return js.accountedDOMString(kj::mv(buf));
-    } else {
-      return kj::mv(buf);
-    }
-  }
-
   kj::Maybe<kj::String> tryUnwrap(v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       kj::String*,


### PR DESCRIPTION
>Fast API is currently behind an autogate. No impact will be shown with this change on production.

I strongly believe that FastOneByteString doesn't bring a performance improvement for our case. There is an ongoing experiment which enables fast api, and doesn't show a good result, and I suspect this commit is the reason behind it.

Worst case scenario, we will revert this revert in a week, and no-harm is done. Best case, we see higher performance impact.