### PR TITLE
WPT harness: refactor how Test results are captured

### DIFF
--- a/src/wpt/harness/harness.ts
+++ b/src/wpt/harness/harness.ts
@@ -31,6 +31,8 @@ import {
   getHostInfo,
 } from './common';
 
+import { Test } from './test';
+
 // These imports introduce functions into the global scope, so that WPT tests can call them
 
 // Test, promise_test, async_test, test
@@ -117,11 +119,8 @@ class RunnerState {
   // Makes test options available from assertion functions
   public options: TestRunnerOptions;
 
-  // List of failed assertions occuring in the test
-  public errors: Error[] = [];
-
-  // Promises returned in the test. The test is done once all promises have resolved.
-  public promises: Promise<unknown>[] = [];
+  // A test is pushed to this list as soon as it is discovered
+  public tests: Test[] = [];
 
   // Callbacks to be run once the entire test is done.
   public completionCallbacks: UnknownFunc[] = [];
@@ -140,7 +139,8 @@ class RunnerState {
 
   public async validate(): Promise<void> {
     // Exception handling is set up on every promise in the test function that created it.
-    await Promise.all(this.promises);
+    const promises = this.tests.map((t) => t.promise).filter((p) => !!p);
+    await Promise.all(promises);
 
     for (const cleanFn of this.completionCallbacks) {
       cleanFn();
@@ -149,7 +149,13 @@ class RunnerState {
     const expectedFailures = new FilterList(this.options.expectedFailures);
     const unexpectedFailures = [];
 
-    for (const err of this.errors) {
+    for (const test of this.tests) {
+      if (!test.error) {
+        continue;
+      }
+
+      const err = test.error;
+
       if (!expectedFailures.delete(err.message)) {
         err.message = sanitize_unpaired_surrogates(err.message);
         console.warn(err);

--- a/src/wpt/harness/harness.ts
+++ b/src/wpt/harness/harness.ts
@@ -139,8 +139,7 @@ class RunnerState {
 
   public async validate(): Promise<void> {
     // Exception handling is set up on every promise in the test function that created it.
-    const promises = this.tests.map((t) => t.promise).filter((p) => !!p);
-    await Promise.all(promises);
+    await Promise.all(this.tests.map((t) => t.promise));
 
     for (const cleanFn of this.completionCallbacks) {
       cleanFn();
@@ -150,11 +149,11 @@ class RunnerState {
     const unexpectedFailures = [];
 
     for (const test of this.tests) {
-      if (!test.error) {
+      const err = test.error;
+
+      if (!err || err === 'SKIPPED') {
         continue;
       }
-
-      const err = test.error;
 
       if (!expectedFailures.delete(err.message)) {
         err.message = sanitize_unpaired_surrogates(err.message);

--- a/src/wpt/streams-test.ts
+++ b/src/wpt/streams-test.ts
@@ -273,10 +273,20 @@ export default {
       // TODO(conform): The spec allows a byob read to be fulfilled incrementally over multiple
       // respond calls, we currently do not.
       'ReadableStream with byte source: read(view) with 1 element Uint16Array, respond(1), releaseLock(), read() on second reader, enqueue()',
+      // TODO: investigate this
+      'ReadableStream with byte source: A stream must be errored if close()-d before fulfilling read(view) with Uint16Array',
+      // TODO: investigate this
+      'ReadableStream with byte source: Multiple read(view), big enqueue()',
+      // TODO: investigate this
+      'ReadableStream with byte source: Multiple read(view) and multiple enqueue()',
     ],
   },
   'readable-byte-streams/non-transferable-buffers.any.js': {},
   'readable-byte-streams/patched-global.any.js': {
+    comment: 'TODO investigate this',
+    expectedFailures: [
+      'Patched then() sees byobRequest after filling all pending pull-into descriptors',
+    ],
     runInGlobalScope: true,
   },
   'readable-byte-streams/read-min.any.js': {
@@ -670,6 +680,7 @@ export default {
       'readable.cancel() should not call cancel() again when already called from writable.abort()',
       'writable.close() should not call flush() when cancel() is already called from readable.cancel()',
       'writable.abort() should not call cancel() again when already called from readable.cancel()',
+      'readable.cancel() should not call cancel() when flush() is already called from writable.close()',
     ],
   },
   'transform-streams/errors.any.js': {


### PR DESCRIPTION
This PR is the first step in cleaning up the implementation of `test`/`async_test`/`promise_test`. 

For this one, I focused only on how the test result gets sent from the test up to our harness for reporting. This part doesn't derive from WPT code, and is our own custom implementation. 

This change captures some error messages that were previously lost. As a result, I had to add a few more failures for the streams module.

This work is also a prerequisite for WPT.fyi reports, because we previously didn't capture the names of individual subtests that were skipped or passing -- we only had tests that errored out.

In another PR, I'll try to clean up the implementations of step, done, etc. and make the promise hierarchy simpler to understand.