### PR TITLE
Fix Apple build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -362,6 +362,10 @@ build:release_macos --linkopt="-Wl,-no_function_starts"
 build:release_macos_cross_x86_64 --config=release_macos
 build:release_macos_cross_x86_64 --config=macos-cross-x86_64
 
+# Set DEVELOPER_DIR for all builds on macOS to fix bzlmod apple_support
+build --action_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+build --host_action_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+
 # On macOS, optionally compile using LLD (19 or higher is compatible with the default flags added by
 # apple_support). Requires Homebrew's lld package to be installed and symlinked into /usr/local/bin.
 # This is less CPU intensive than the system linker, but also slightly slower in terms of wall time

--- a/.bazelrc
+++ b/.bazelrc
@@ -362,9 +362,9 @@ build:release_macos --linkopt="-Wl,-no_function_starts"
 build:release_macos_cross_x86_64 --config=release_macos
 build:release_macos_cross_x86_64 --config=macos-cross-x86_64
 
-# Set DEVELOPER_DIR for all builds on macOS to fix bzlmod apple_support
-build --action_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
-build --host_action_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+# Set DEVELOPER_DIR for macOS builds to fix bzlmod apple_support
+build:macos --action_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+build:macos --host_action_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
 
 # On macOS, optionally compile using LLD (19 or higher is compatible with the default flags added by
 # apple_support). Requires Homebrew's lld package to be installed and symlinked into /usr/local/bin.


### PR DESCRIPTION
I'm by no means a Bazel expert here, but https://github.com/cloudflare/workerd/commit/3cbfb8ffaad83095ec8247d86850585c70ca56e6 seemed to break the Apple build support afaict.

I know I can use the Docker devcontainer, but I like to be able to run the native builds as well.

I was getting these errors - 

```
ERROR: 
  /private/var/tmp/_bazel_gbedford/732b72733c1f22207815e1579510d1a0/external/apple_support+/crosstool/BUILD:25:20:
   Executing apple_genrule @@apple_support+//crosstool:exec_wrapped_clang_pp.target_config [for tool] failed: 
  (Exit 127): bash failed: error executing Genrule command (from target 
  @@apple_support+//crosstool:exec_wrapped_clang_pp.target_config) 
    (cd 
  /private/var/tmp/_bazel_gbedford/732b72733c1f22207815e1579510d1a0/sandbox/darwin-sandbox/453/execroot/_main && \
    exec env - \
      APPLE_SDK_PLATFORM=MacOSX \
      APPLE_SDK_VERSION_OVERRIDE=15.4 \
      PATH=/bin:/usr/bin:/usr/local/bin \
      XCODE_VERSION_OVERRIDE=16.3.0.16E140 \
    /bin/bash -c '
  env -i   DEVELOPER_DIR=${DEVELOPER_DIR:-}   xcrun     --sdk macosx     clang     -mmacosx-version-min=10.15     
  -std=c++17     -lc++     -arch arm64     -arch x86_64     -O3     -o 
  bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/apple_support+/crosstool/wrapped_clang_pp     
  external/apple_support+/crosstool/wrapped_clang.cc
  ')
  # Configuration: 4f4d2be3b3f458927c7fc4442744c08886bb0f9e12917fa088b23c70ebf160ad
  # Execution platform: @@platforms//host:host

  Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
  env: 16.3.app/Contents/Developer: No such file or directory
  Target //src/workerd/api/node:tests/util-nodejs-test failed to build
  INFO: Elapsed time: 0.643s, Critical Path: 0.17s
```

Where the `env: 16.3.app/Contents/Developer: No such file or directory` was previously attaching to `/Applications/Xcode 16.3.app/Contents/Developer` which was working before that commit.

This change overrides the `Developer` dir for Mac, resolving the issue as long as it's a 16.3 version. Suggestions for a better way to go about this are very much welcome too.