### PR TITLE
[cxx] add container service for local development

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ test-asan *args="//...":
 
 # e.g. just stream-test //src/cloudflare:cloudflare.capnp@eslint
 stream-test *args:
-  bazel test {{args}} --test_output=streamed --cache_test_results=no --config=debug
+  bazel test {{args}} --test_output=streamed --cache_test_results=no --config=debug --test_tag_filters= --test_size_filters=
 
 # e.g. just node-test zlib
 node-test test_name *args:

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -121,7 +121,7 @@ class Container::TcpPortWorkerInterface final: public WorkerInterface {
 
     // We don't support TLS.
     JSG_REQUIRE(parsedUrl.scheme != "https", Error,
-        "Connencting to a container using HTTPS is not currently supported; use HTTP instead. "
+        "Connecting to a container using HTTPS is not currently supported; use HTTP instead. "
         "TLS is unnecessary anyway, as the connection is already secure by default.");
 
     // Schemes other than http: and https: should have been rejected earlier, but let's verify.

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -109,6 +109,7 @@ wd_cc_library(
         ":actor-id-impl",
         ":alarm-scheduler",
         ":bundle-fs",
+        ":container-client",
         ":fallback-service",
         ":workerd_capnp",
         "//deps/rust:runtime",
@@ -129,6 +130,24 @@ wd_cc_library(
         "//src/workerd/util:perfetto",
         "//src/workerd/util:websocket-error-handler",
         "@capnp-cpp//src/kj/compat:kj-tls",
+    ],
+)
+
+wd_capnp_library(src = "docker-api.capnp")
+
+wd_cc_library(
+    name = "container-client",
+    srcs = ["container-client.c++"],
+    hdrs = ["container-client.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":docker-api_capnp",
+        "//src/workerd/io:container_capnp",
+        "//src/workerd/jsg",
+        "@capnp-cpp//src/capnp/compat:http-over-capnp",
+        "@capnp-cpp//src/kj",
+        "@capnp-cpp//src/kj:kj-async",
+        "@capnp-cpp//src/kj/compat:kj-http",
     ],
 )
 

--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -1,0 +1,411 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "container-client.h"
+
+#include <workerd/io/container.capnp.h>
+#include <workerd/jsg/jsg.h>
+#include <workerd/server/docker-api.capnp.h>
+
+#include <capnp/compat/json.h>
+#include <capnp/message.h>
+#include <kj/async-io.h>
+#include <kj/async.h>
+#include <kj/compat/http.h>
+#include <kj/debug.h>
+#include <kj/encoding.h>
+#include <kj/exception.h>
+#include <kj/string.h>
+
+namespace workerd::server {
+
+namespace {
+kj::StringPtr signalToString(uint32_t signal) {
+  switch (signal) {
+    case 1:
+      return "SIGHUP"_kj;  // Hangup
+    case 2:
+      return "SIGINT"_kj;  // Interrupt
+    case 3:
+      return "SIGQUIT"_kj;  // Quit
+    case 4:
+      return "SIGILL"_kj;  // Illegal instruction
+    case 5:
+      return "SIGTRAP"_kj;  // Trace trap
+    case 6:
+      return "SIGABRT"_kj;  // Abort
+    case 7:
+      return "SIGBUS"_kj;  // Bus error
+    case 8:
+      return "SIGFPE"_kj;  // Floating point exception
+    case 9:
+      return "SIGKILL"_kj;  // Kill
+    case 10:
+      return "SIGUSR1"_kj;  // User signal 1
+    case 11:
+      return "SIGSEGV"_kj;  // Segmentation violation
+    case 12:
+      return "SIGUSR2"_kj;  // User signal 2
+    case 13:
+      return "SIGPIPE"_kj;  // Broken pipe
+    case 14:
+      return "SIGALRM"_kj;  // Alarm clock
+    case 15:
+      return "SIGTERM"_kj;  // Termination
+    case 16:
+      return "SIGSTKFLT"_kj;  // Stack fault (Linux)
+    case 17:
+      return "SIGCHLD"_kj;  // Child status changed
+    case 18:
+      return "SIGCONT"_kj;  // Continue
+    case 19:
+      return "SIGSTOP"_kj;  // Stop
+    case 20:
+      return "SIGTSTP"_kj;  // Terminal stop
+    case 21:
+      return "SIGTTIN"_kj;  // Background read from tty
+    case 22:
+      return "SIGTTOU"_kj;  // Background write to tty
+    case 23:
+      return "SIGURG"_kj;  // Urgent condition on socket
+    case 24:
+      return "SIGXCPU"_kj;  // CPU limit exceeded
+    case 25:
+      return "SIGXFSZ"_kj;  // File size limit exceeded
+    case 26:
+      return "SIGVTALRM"_kj;  // Virtual alarm clock
+    case 27:
+      return "SIGPROF"_kj;  // Profiling alarm clock
+    case 28:
+      return "SIGWINCH"_kj;  // Window size change
+    case 29:
+      return "SIGIO"_kj;  // I/O now possible
+    case 30:
+      return "SIGPWR"_kj;  // Power failure restart (Linux)
+    case 31:
+      return "SIGSYS"_kj;  // Bad system call
+    default:
+      return "SIGKILL"_kj;
+  }
+}
+}  // namespace
+
+template <typename T>
+typename T::Builder decodeJsonResponse(kj::StringPtr response) {
+  capnp::JsonCodec codec;
+  codec.handleByAnnotation<T>();
+  capnp::MallocMessageBuilder message;
+  auto jsonRoot = message.initRoot<T>();
+  codec.decode(response, jsonRoot);
+  return jsonRoot;
+}
+
+ContainerClient::ContainerClient(capnp::ByteStreamFactory& byteStreamFactory,
+    kj::Timer& timer,
+    kj::Network& network,
+    kj::String dockerPath,
+    kj::String containerName,
+    kj::String imageName)
+    : byteStreamFactory(byteStreamFactory),
+      timer(timer),
+      network(network),
+      dockerPath(kj::mv(dockerPath)),
+      containerName(kj::encodeUriComponent(kj::mv(containerName))),
+      imageName(kj::mv(imageName)) {}
+
+// Docker-specific Port implementation that implements rpc::Container::Port::Server
+class ContainerClient::DockerPort final: public rpc::Container::Port::Server {
+ public:
+  DockerPort(ContainerClient& containerClient, kj::String containerHost, uint16_t containerPort)
+      : containerClient(containerClient),
+        containerHost(kj::mv(containerHost)),
+        containerPort(containerPort) {}
+
+  kj::Promise<void> connect(ConnectContext context) override {
+    kj::HttpHeaderTable headerTable;
+    kj::HttpHeaders headers(headerTable);
+
+    // Port mappings might have outdated mappings, we can't know if a connect request
+    // fails because the app hasn't finished starting up or because the mapping is outdated.
+    // To be safe we should inspect the container to get up to date mappings.
+    const auto [_running, portMappings] = co_await containerClient.inspectContainer();
+    auto maybeMappedPort = portMappings.find(containerPort);
+    if (maybeMappedPort == kj::none) {
+      throw JSG_KJ_EXCEPTION(DISCONNECTED, Error,
+          "connect(): Connection refused: container port not found. Make sure you exposed the port in your container definition.");
+    }
+    auto mappedPort = KJ_ASSERT_NONNULL(maybeMappedPort);
+
+    auto address =
+        co_await containerClient.network.parseAddress(kj::str(containerHost, ":", mappedPort));
+    auto connection = co_await address->connect();
+
+    auto upPipe = kj::newOneWayPipe();
+    auto upEnd = kj::mv(upPipe.in);
+    auto results = context.getResults();
+    results.setUp(containerClient.byteStreamFactory.kjToCapnp(kj::mv(upPipe.out)));
+    auto downEnd = containerClient.byteStreamFactory.capnpToKj(context.getParams().getDown());
+    pumpTask =
+        kj::joinPromisesFailFast(kj::arr(upEnd->pumpTo(*connection), connection->pumpTo(*downEnd)))
+            .ignoreResult()
+            .attach(kj::mv(upEnd), kj::mv(connection), kj::mv(downEnd));
+    co_return;
+  }
+
+ private:
+  // ContainerClient is owned by the Worker::Actor and keeps it alive.
+  ContainerClient& containerClient;
+  kj::String containerHost;
+  uint16_t containerPort;
+  kj::Maybe<kj::Promise<void>> pumpTask;
+};
+
+kj::Promise<ContainerClient::Response> ContainerClient::dockerApiRequest(
+    kj::HttpMethod method, kj::StringPtr endpoint, kj::Maybe<kj::StringPtr> body) {
+  kj::HttpHeaderTable headerTable;
+  auto address = co_await network.parseAddress(dockerPath);
+  auto connection = co_await address->connect();
+  auto httpClient = kj::newHttpClient(headerTable, *connection).attach(kj::mv(connection));
+  kj::HttpHeaders headers(headerTable);
+  headers.set(kj::HttpHeaderId::HOST, "localhost");
+
+  KJ_IF_SOME(requestBody, body) {
+    headers.set(kj::HttpHeaderId::CONTENT_TYPE, "application/json");
+    headers.set(kj::HttpHeaderId::CONTENT_LENGTH, kj::str(requestBody.size()));
+
+    auto req = httpClient->request(method, endpoint, headers, requestBody.size());
+    {
+      auto body = kj::mv(req.body);
+      co_await body->write(requestBody.asBytes());
+    }
+    auto response = co_await req.response;
+    auto result = co_await response.body->readAllText();
+    co_return Response{.statusCode = response.statusCode, .body = kj::mv(result)};
+  } else {
+    auto req = httpClient->request(method, endpoint, headers);
+    { auto body = kj::mv(req.body); }
+    auto response = co_await req.response;
+    auto result = co_await response.body->readAllText();
+    co_return Response{.statusCode = response.statusCode, .body = kj::mv(result)};
+  }
+}
+
+kj::Promise<ContainerClient::InspectResponse> ContainerClient::inspectContainer() {
+  // Docker API: GET /containers/{id}/json
+  auto endpoint = kj::str("/containers/", containerName, "/json");
+
+  auto response = co_await dockerApiRequest(kj::HttpMethod::GET, endpoint);
+  // We check if the container with the given name exist, and if it's not,
+  // we simply return false while avoiding an unnecessary error.
+  if (response.statusCode == 404) {
+    co_return InspectResponse{.isRunning = false, .ports = {}};
+  }
+  JSG_REQUIRE(response.statusCode == 200, Error, "Container inspect failed");
+  // Parse JSON response
+  auto jsonRoot = decodeJsonResponse<docker_api::Docker::ContainerInspectResponse>(response.body);
+  kj::HashMap<uint16_t, uint16_t> portMappings;
+  for (auto portMapping: jsonRoot.getNetworkSettings().getPorts().getObject()) {
+    auto port = portMapping.getName();
+    // We need to get "8080" from "8080/tcp"
+    auto rawPort = port.asString().slice(0, KJ_ASSERT_NONNULL(port.asString().find("/")));
+    auto portNumber = kj::str(rawPort).parseAs<uint16_t>();
+    uint16_t number;
+    {
+      // We need to retrieve "HostPort" from the following JSON structure
+      //
+      // "Ports": {
+      // 	"8080/tcp": [
+      // 		{
+      // 			"HostIp": "0.0.0.0",
+      // 			"HostPort": "55000"
+      // 		}
+      // 	]
+      // },
+      //
+      auto array = portMapping.getValue().getArray();
+      JSG_REQUIRE(array.size() > 0, Error, "Malformed ContainerInspect port mapping response");
+      auto obj = array[0].getObject();
+      JSG_REQUIRE(array.size() > 1, Error, "Malformed ContainerInspect port mapping object");
+      auto mappedPort = obj[1].getValue().getString();
+      number = mappedPort.asString().parseAs<uint16_t>();
+    }
+    portMappings.insert(portNumber, number);
+  }
+
+  // Look for Status field in the JSON object
+  JSG_REQUIRE(jsonRoot.hasState(), Error, "Malformed ContainerInspect response");
+  auto state = jsonRoot.getState();
+  JSG_REQUIRE(state.hasStatus(), Error, "Malformed ContainerInspect response");
+  auto status = state.getStatus();
+  bool running = status == "running";
+  co_return InspectResponse{.isRunning = running, .ports = kj::mv(portMappings)};
+}
+
+kj::Promise<void> ContainerClient::createContainer(
+    kj::Maybe<capnp::List<capnp::Text>::Reader> entrypoint,
+    kj::Maybe<capnp::List<capnp::Text>::Reader> environment) {
+  // Docker API: POST /containers/create
+  capnp::JsonCodec codec;
+  codec.handleByAnnotation<docker_api::Docker::ContainerCreateRequest>();
+  capnp::MallocMessageBuilder message;
+  auto jsonRoot = message.initRoot<docker_api::Docker::ContainerCreateRequest>();
+  jsonRoot.setImage(imageName);
+  // Add entrypoint if provided
+  KJ_IF_SOME(ep, entrypoint) {
+    auto jsonCmd = jsonRoot.initCmd(ep.size());
+    for (uint32_t i: kj::zeroTo(ep.size())) {
+      jsonCmd.set(i, ep[i]);
+    }
+  }
+
+  // Add environment variables if provided
+  KJ_IF_SOME(env, environment) {
+    auto jsonEnv = jsonRoot.initEnv(env.size());
+    for (uint32_t i: kj::zeroTo(env.size())) {
+      jsonEnv.set(i, env[i]);
+    }
+  }
+
+  auto hostConfig = jsonRoot.initHostConfig();
+  // We need to publish all ports to properly get the mapped port number locally
+  hostConfig.setPublishAllPorts(true);
+  // We need to set a restart policy to avoid having ambiguous states
+  // where the container we're managing is stuck at "exited" state.
+  hostConfig.initRestartPolicy().setName("on-failure");
+
+  // Encode to JSON string
+  kj::String jsonBody = codec.encode(jsonRoot);
+  const auto endpoint = kj::str("/containers/create?name=", containerName);
+  auto response = co_await dockerApiRequest(kj::HttpMethod::POST, endpoint, jsonBody.asPtr());
+
+  // statusCode 201 refers to "container created successfully"
+  // statusCode 409 refers to "conflict". Occurs when a container with the given name exists.
+  // Both are fine, so long as the container exists. Though we might want to call destroy and
+  // recreate on 409 in the future.
+  if (response.statusCode != 201 && response.statusCode != 409) {
+    JSG_REQUIRE(response.statusCode != 404, Error, "No such image available named ", imageName);
+    JSG_FAIL_REQUIRE(Error, "Create container failed with: ", response.body);
+  }
+}
+
+kj::Promise<void> ContainerClient::startContainer() {
+  // Docker API: POST /containers/{id}/start
+  const auto endpoint = kj::str("/containers/", containerName, "/start");
+  // We have to send an empty body since docker API will throw an error if we don't.
+  kj::StringPtr body = "";
+  auto response = co_await dockerApiRequest(kj::HttpMethod::POST, endpoint, body);
+  // statusCode 204 refers to "no error"
+  // statusCode 304 refers to "container already started"
+  // Both are fine to ignore.
+  JSG_REQUIRE(response.statusCode == 204 || response.statusCode == 304, Error,
+      "Starting container failed with: ", response.body);
+}
+
+kj::Promise<void> ContainerClient::stopContainer() {
+  // Docker API: POST /containers/{id}/stop
+  const auto endpoint = kj::str("/containers/", containerName, "/stop");
+  auto response = co_await dockerApiRequest(kj::HttpMethod::POST, endpoint);
+  // statusCode 204 refers to "no error"
+  // statusCode 304 refers to "container already stopped"
+  // Both are fine to avoid when stop container is called.
+  JSG_REQUIRE(response.statusCode == 204 || response.statusCode == 304, Error,
+      "Stopping container failed with: ", response.body);
+}
+
+kj::Promise<void> ContainerClient::killContainer(uint32_t signal) {
+  // Docker API: POST /containers/{id}/kill
+  const auto endpoint =
+      kj::str("/containers/", containerName, "/kill?signal=", signalToString(signal));
+  auto response = co_await dockerApiRequest(kj::HttpMethod::POST, endpoint);
+  // statusCode 409 refers to "container is not running"
+  // We should not throw an error when the container is already not running.
+  JSG_REQUIRE(response.statusCode == 200 || response.statusCode == 409, Error,
+      "Stopping container failed with: ", response.body);
+}
+
+kj::Promise<void> ContainerClient::status(StatusContext context) {
+  const auto [isRunning, _ports] = co_await inspectContainer();
+  context.getResults().setRunning(isRunning);
+}
+
+kj::Promise<void> ContainerClient::start(StartContext context) {
+  const auto params = context.getParams();
+
+  // Get the lists directly from Cap'n Proto
+  kj::Maybe<capnp::List<capnp::Text>::Reader> entrypoint = kj::none;
+  kj::Maybe<capnp::List<capnp::Text>::Reader> environment = kj::none;
+
+  if (params.hasEntrypoint()) {
+    entrypoint = params.getEntrypoint();
+  }
+  if (params.hasEnvironmentVariables()) {
+    environment = params.getEnvironmentVariables();
+  }
+
+  co_await createContainer(entrypoint, environment);
+  co_await startContainer();
+}
+
+kj::Promise<void> ContainerClient::monitor(MonitorContext context) {
+  // Docker API: POST /containers/{id}/wait - wait for container to exit
+  const auto endpoint = kj::str("/containers/", containerName, "/wait");
+  // Monitor is often called right after start but the api layer's start does not await the RPC's
+  // start response. That means that the createContainer call might not have even started yet.
+  // If it hasn't, we'll give it 3 tries before failing.
+  for (int i = 0; i < 3; i++) {
+    auto response = co_await dockerApiRequest(kj::HttpMethod::POST, endpoint);
+    if (response.statusCode == 404) {
+      co_await timer.afterDelay(1 * kj::SECONDS);
+      continue;
+    }
+    JSG_REQUIRE(response.statusCode == 200, Error,
+        "Monitoring container failed with: ", response.statusCode, response.body);
+    // Parse JSON response
+    auto jsonRoot = decodeJsonResponse<docker_api::Docker::ContainerMonitorResponse>(response.body);
+    auto statusCode = jsonRoot.getStatusCode();
+    JSG_REQUIRE(statusCode == 0, Error, "Container exited with unexpected exit code ", statusCode);
+    co_return;
+  }
+  JSG_FAIL_REQUIRE(Error, "Monitor failed to find container");
+}
+
+kj::Promise<void> ContainerClient::destroy(DestroyContext context) {
+  const auto [running, _ports] = co_await inspectContainer();
+  if (running) {
+    co_await stopContainer();
+    auto endpoint = kj::str("/containers/", containerName, "?force=true");
+    auto response = co_await dockerApiRequest(kj::HttpMethod::DELETE, endpoint);
+    // statusCode 204 refers to "no error"
+    // statusCode 404 refers to "no such container"
+    // Both of which are fine for us since we're tearing down the container anyway.
+    JSG_REQUIRE(response.statusCode == 204 || response.statusCode == 404, Error,
+        "Removing a container failed with: ", response.body);
+    {
+      endpoint = kj::str("/containers/", containerName, "/wait");
+      response = co_await dockerApiRequest(kj::HttpMethod::POST, endpoint);
+      JSG_REQUIRE(response.statusCode == 200 || response.statusCode == 404, Error,
+          "Waiting for container removal failed with: ", response.statusCode, response.body);
+    }
+  }
+}
+
+kj::Promise<void> ContainerClient::signal(SignalContext context) {
+  const auto params = context.getParams();
+  co_await killContainer(params.getSigno());
+}
+
+kj::Promise<void> ContainerClient::getTcpPort(GetTcpPortContext context) {
+  const auto params = context.getParams();
+  uint16_t port = params.getPort();
+  auto results = context.getResults();
+  auto dockerPort = kj::heap<DockerPort>(*this, kj::str("localhost"), port);
+  results.setPort(kj::mv(dockerPort));
+  co_return;
+}
+
+kj::Promise<void> ContainerClient::listenTcp(ListenTcpContext context) {
+  KJ_UNIMPLEMENTED("listenTcp not implemented for Docker containers - use port mapping instead");
+}
+
+}  // namespace workerd::server

--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <workerd/io/container.capnp.h>
+
+#include <capnp/compat/byte-stream.h>
+#include <capnp/list.h>
+#include <capnp/message.h>
+#include <kj/async.h>
+#include <kj/compat/http.h>
+#include <kj/map.h>
+#include <kj/string.h>
+#include <kj/tuple.h>
+
+namespace workerd::server {
+
+// Docker-based implementation that implements the rpc::Container::Server interface
+// so it can be used as a rpc::Container::Client via kj::heap<ContainerClient>().
+// This allows the Container JSG class to use Docker directly without knowing
+// it's talking to Docker instead of a real RPC service.
+class ContainerClient final: public rpc::Container::Server {
+ public:
+  ContainerClient(capnp::ByteStreamFactory& byteStreamFactory,
+      kj::Timer& timer,
+      kj::Network& network,
+      kj::String dockerPath,
+      kj::String containerName,
+      kj::String imageName);
+
+  // Implement rpc::Container::Server interface
+  kj::Promise<void> status(StatusContext context) override;
+  kj::Promise<void> start(StartContext context) override;
+  kj::Promise<void> monitor(MonitorContext context) override;
+  kj::Promise<void> destroy(DestroyContext context) override;
+  kj::Promise<void> signal(SignalContext context) override;
+  kj::Promise<void> getTcpPort(GetTcpPortContext context) override;
+  kj::Promise<void> listenTcp(ListenTcpContext context) override;
+
+ private:
+  capnp::ByteStreamFactory& byteStreamFactory;
+  kj::Timer& timer;
+  kj::Network& network;
+  kj::String dockerPath;
+  kj::String containerName;
+  kj::String imageName;
+
+  // Docker-specific Port implementation
+  class DockerPort;
+
+  struct Response {
+    kj::uint statusCode;
+    kj::String body;
+  };
+
+  struct InspectResponse {
+    bool isRunning;
+    kj::HashMap<uint16_t, uint16_t> ports;
+  };
+
+  // Docker API v1.50 helper methods
+  kj::Promise<Response> dockerApiRequest(
+      kj::HttpMethod method, kj::StringPtr endpoint, kj::Maybe<kj::StringPtr> body = kj::none);
+  kj::Promise<InspectResponse> inspectContainer();
+  kj::Promise<void> createContainer(kj::Maybe<capnp::List<capnp::Text>::Reader> entrypoint,
+      kj::Maybe<capnp::List<capnp::Text>::Reader> environment);
+  kj::Promise<void> startContainer();
+  kj::Promise<void> stopContainer();
+  kj::Promise<void> killContainer(uint32_t signal);
+};
+
+}  // namespace workerd::server

--- a/src/workerd/server/docker-api.capnp
+++ b/src/workerd/server/docker-api.capnp
@@ -1,0 +1,289 @@
+# Copyright (c) 2017-2022 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+@0xfafd0bdf57acc528;
+using Cxx = import "/capnp/c++.capnp";
+using Json = import "/capnp/compat/json.capnp";
+
+$Cxx.namespace("workerd::docker_api");
+$Cxx.allowCancellation;
+
+struct Docker {
+  # Docker API structures for container operations
+  struct PortBinding {
+    hostIp @0 :Text $Json.name("HostIp");
+    hostPort @1 :Text $Json.name("HostPort");
+  }
+
+  struct LogConfig {
+    type @0 :Text $Json.name("Type");
+    config @1 :Json.Value $Json.name("Config");
+  }
+
+  struct RestartPolicy {
+    name @0 :Text $Json.name("Name"); # "no", "always", "unless-stopped", "on-failure"
+    maximumRetryCount @1 :UInt32 $Json.name("MaximumRetryCount");
+  }
+
+  struct WeightDevice {
+    path @0 :Text;
+    weight @1 :UInt16;
+  }
+
+  struct ThrottleDevice {
+    path @0 :Text;
+    rate @1 :UInt64;
+  }
+
+  struct DeviceMapping {
+    pathOnHost @0 :Text;
+    pathInContainer @1 :Text;
+    cgroupPermissions @2 :Text;
+  }
+
+  struct DeviceRequest {
+    driver @0 :Text;
+    count @1 :Int32;
+    deviceIds @2 :List(Text);
+    capabilities @3 :List(List(Text));
+    options @4 :Json.Value;
+  }
+
+  struct Ulimit {
+    name @0 :Text;
+    soft @1 :UInt64;
+    hard @2 :UInt64;
+  }
+
+  struct IPAMConfig {
+    ipv4Address @0 :Text $Json.name("IPv4Address");
+    ipv6Address @1 :Text $Json.name("IPv6Address");
+    linkLocalIps @2 :List(Text) $Json.name("LinkLocalIPs");
+  }
+
+  struct EndpointSettings {
+    ipamConfig @0 :IPAMConfig $Json.name("IPAMConfig");
+    links @1 :List(Text) $Json.name("Links");
+    aliases @2 :List(Text) $Json.name("Aliases");
+    networkId @3 :Text $Json.name("NetworkID");
+    endpointId @4 :Text $Json.name("EndpointID");
+    gateway @5 :Text $Json.name("Gateway");
+    ipAddress @6 :Text $Json.name("IPAddress");
+    ipPrefixLen @7 :UInt32 $Json.name("IPPrefixLen");
+    ipv6Gateway @8 :Text $Json.name("IPv6Gateway");
+    globalIpv6Address @9 :Text $Json.name("GlobalIPv6Address");
+    globalIpv6PrefixLen @10 :UInt32 $Json.name("GlobalIPv6PrefixLen");
+    macAddress @11 :Text $Json.name("MacAddress");
+    driverOpts @12 :Json.Value $Json.name("DriverOpts");
+  }
+
+
+  struct ContainerCreateRequest {
+    # Request body for ContainerCreate operation - flattened structure
+    # Container configuration fields
+    hostname @0 :Text $Json.name("Hostname");
+    domainname @1 :Text $Json.name("Domainname");
+    user @2 :Text $Json.name("User");
+    attachStdin @3 :Bool = false $Json.name("AttachStdin");
+    attachStdout @4 :Bool = false $Json.name("AttachStdout");
+    attachStderr @5 :Bool = false $Json.name("AttachStderr");
+    exposedPorts @6 :Json.Value $Json.name("ExposedPorts"); # Ports mapped to empty objects
+    tty @7 :Bool $Json.name("Tty");
+    openStdin @8 :Bool $Json.name("OpenStdin");
+    stdinOnce @9 :Bool $Json.name("StdinOnce");
+    env @10 :List(Text) $Json.name("Env"); # Environment variables in "KEY=value" format
+    cmd @11 :List(Text) $Json.name("Cmd"); # Command to run
+    entrypoint @12 :Text $Json.name("Entrypoint"); # Can be string or array - simplified as Text
+    image @13 :Text $Json.name("Image"); # Image name/reference
+    labels @14 :Json.Value $Json.name("Labels"); # Labels as key-value pairs
+    volumes @15 :Json.Value $Json.name("Volumes"); # Volume mount points mapped to empty objects
+    workingDir @16 :Text $Json.name("WorkingDir");
+    networkDisabled @17 :Bool $Json.name("NetworkDisabled");
+    macAddress @18 :Text $Json.name("MacAddress");
+    stopSignal @19 :Text $Json.name("StopSignal");
+    stopTimeout @20 :UInt32 = 10 $Json.name("StopTimeout");
+
+    # Host configuration
+    hostConfig @21 :HostConfig $Json.name("HostConfig");
+
+    # Networking configuration
+    # networkingConfig @22 :NetworkingConfig $Json.name("NetworkingConfig");
+
+    struct HostConfig {
+      # Container configuration that depends on the host
+      binds @0 :List(Text) $Json.name("Binds"); # Volume bindings
+      links @1 :List(Text) $Json.name("Links");
+      memory @2 :UInt32 $Json.name("Memory");
+      memorySwap @3 :UInt32 $Json.name("MemorySwap");
+      memoryReservation @4 :UInt32 $Json.name("MemoryReservation");
+      kernelMemory @5 :UInt32 $Json.name("KernelMemory");
+      nanoCpus @6 :UInt32 $Json.name("NanoCpus");
+      cpuPercent @7 :UInt32 $Json.name("CpuPercent");
+      cpuShares @8 :UInt32 $Json.name("CpuShares");
+      cpuPeriod @9 :UInt32 $Json.name("CpuPeriod");
+      cpuRealtimePeriod @10 :UInt32 $Json.name("CpuRealtimePeriod");
+      cpuRealtimeRuntime @11 :UInt32 $Json.name("CpuRealtimeRuntime");
+      cpuQuota @12 :UInt32 $Json.name("CpuQuota");
+      cpusetCpus @13 :Text $Json.name("CpusetCpus");
+      cpusetMems @14 :Text $Json.name("CpusetMems");
+      maximumIOps @15 :UInt32 $Json.name("MaximumIOps");
+      maximumIOBps @16 :UInt32 $Json.name("MaximumIOBps");
+      blkioWeight @17 :UInt16 $Json.name("BlkioWeight");
+      blkioWeightDevice @18 :List(WeightDevice) $Json.name("BlkioWeightDevice");
+      blkioDeviceReadBps @19 :List(ThrottleDevice) $Json.name("BlkioDeviceReadBps");
+      blkioDeviceReadIOps @20 :List(ThrottleDevice) $Json.name("BlkioDeviceReadIOps");
+      blkioDeviceWriteBps @21 :List(ThrottleDevice) $Json.name("BlkioDeviceWriteBps");
+      blkioDeviceWriteIOps @22 :List(ThrottleDevice) $Json.name("BlkioDeviceWriteIOps");
+      memorySwappiness @23 :UInt32 $Json.name("MemorySwappiness");
+      oomKillDisable @24 :Bool $Json.name("OomKillDisable");
+      oomScoreAdj @25 :Int32 $Json.name("OomScoreAdj");
+      pidMode @26 :Text $Json.name("PidMode");
+      pidsLimit @27 :Int32 $Json.name("PidsLimit"); # Can be -1
+      portBindings @28 :Json.Value $Json.name("PortBindings"); # Port bindings map
+      publishAllPorts @29 :Bool $Json.name("PublishAllPorts");
+      privileged @30 :Bool $Json.name("Privileged");
+      readonlyRootfs @31 :Bool $Json.name("ReadonlyRootfs");
+      dns @32 :List(Text) $Json.name("Dns");
+      dnsOptions @33 :List(Text) $Json.name("DnsOptions");
+      dnsSearch @34 :List(Text) $Json.name("DnsSearch");
+      volumesFrom @35 :List(Text) $Json.name("VolumesFrom");
+      capAdd @36 :List(Text) $Json.name("CapAdd");
+      capDrop @37 :List(Text) $Json.name("CapDrop");
+      groupAdd @38 :List(Text) $Json.name("GroupAdd");
+      restartPolicy @39 :RestartPolicy $Json.name("RestartPolicy");
+      autoRemove @40 :Bool $Json.name("AutoRemove");
+      networkMode @41 :Text $Json.name("NetworkMode");
+      devices @42 :List(DeviceMapping) $Json.name("Devices");
+      ulimits @43 :List(Ulimit) $Json.name("Ulimits");
+      logConfig @44 :LogConfig $Json.name("LogConfig");
+      securityOpt @45 :List(Text) $Json.name("SecurityOpt");
+      storageOpt @46 :Json.Value $Json.name("StorageOpt");
+      cgroupParent @47 :Text $Json.name("CgroupParent");
+      volumeDriver @48 :Text $Json.name("VolumeDriver");
+      shmSize @49 :UInt32 $Json.name("ShmSize");
+
+    }
+  }
+
+  struct ContainerCreateResponse {
+    # Response from ContainerCreate operation
+    id @0 :Text $Json.name("Id"); # The ID of the created container
+    warnings @1 :List(Text) $Json.name("Warnings"); # Warnings encountered when creating the container
+  }
+
+  struct ContainerMonitorResponse {
+    statusCode @0 :Int32 $Json.name("StatusCode");
+  }
+
+  struct ContainerState {
+    # Container's running state
+    status @0 :Text $Json.name("Status"); # "created", "running", "paused", "restarting", "removing", "exited", "dead"
+    running @1 :Bool $Json.name("Running");
+    paused @2 :Bool $Json.name("Paused");
+    restarting @3 :Bool $Json.name("Restarting");
+    oomKilled @4 :Bool $Json.name("OOMKilled");
+    dead @5 :Bool $Json.name("Dead");
+    pid @6 :UInt32 $Json.name("Pid");
+    exitCode @7 :Int32 $Json.name("ExitCode");
+    error @8 :Text $Json.name("Error");
+    startedAt @9 :Text $Json.name("StartedAt");
+    finishedAt @10 :Text $Json.name("FinishedAt");
+  }
+
+  struct GraphDriverData {
+    # Information about the storage driver
+    name @0 :Text $Json.name("Name");
+    data @1 :Json.Value $Json.name("Data");
+  }
+
+  struct MountPoint {
+    # Mount point configuration inside the container
+    type @0 :Text $Json.name("Type"); # "bind", "volume", "tmpfs", "npipe"
+    name @1 :Text $Json.name("Name");
+    source @2 :Text $Json.name("Source");
+    destination @3 :Text $Json.name("Destination");
+    driver @4 :Text $Json.name("Driver");
+    mode @5 :Text $Json.name("Mode");
+    rw @6 :Bool $Json.name("RW");
+    propagation @7 :Text $Json.name("Propagation");
+  }
+
+  struct NetworkSettings {
+    # Network settings for the container
+    bridge @0 :Text $Json.name("Bridge");
+    sandboxId @1 :Text $Json.name("SandboxID");
+    hairpinMode @2 :Bool $Json.name("HairpinMode");
+    linkLocalIpv6Address @3 :Text $Json.name("LinkLocalIPv6Address");
+    linkLocalIpv6PrefixLen @4 :UInt32 $Json.name("LinkLocalIPv6PrefixLen");
+    sandboxKey @5 :Text $Json.name("SandboxKey");
+    endpointId @6 :Text $Json.name("EndpointID");
+    gateway @7 :Text $Json.name("Gateway");
+    globalIpv6Address @8 :Text $Json.name("GlobalIPv6Address");
+    globalIpv6PrefixLen @9 :UInt32 $Json.name("GlobalIPv6PrefixLen");
+    ipAddress @10 :Text $Json.name("IPAddress");
+    ipPrefixLen @11 :UInt32 $Json.name("IPPrefixLen");
+    ipv6Gateway @12 :Text $Json.name("IPv6Gateway");
+    macAddress @13 :Text $Json.name("MacAddress");
+    networks @14 :Json.Value $Json.name("Networks");
+    ports @15 :Json.Value $Json.name("Ports");
+  }
+
+  struct ContainerConfig {
+    # Container configuration (reusable from create)
+    hostname @0 :Text $Json.name("Hostname");
+    domainname @1 :Text $Json.name("Domainname");
+    user @2 :Text $Json.name("User");
+    attachStdin @3 :Bool $Json.name("AttachStdin");
+    attachStdout @4 :Bool $Json.name("AttachStdout");
+    attachStderr @5 :Bool $Json.name("AttachStderr");
+    exposedPorts @6 :Json.Value $Json.name("ExposedPorts");
+    tty @7 :Bool $Json.name("Tty");
+    openStdin @8 :Bool $Json.name("OpenStdin");
+    stdinOnce @9 :Bool $Json.name("StdinOnce");
+    env @10 :List(Text) $Json.name("Env");
+    cmd @11 :List(Text) $Json.name("Cmd");
+    image @12 :Text $Json.name("Image");
+    volumes @13 :Json.Value $Json.name("Volumes");
+    workingDir @14 :Text $Json.name("WorkingDir");
+    entrypoint @15 :List(Text) $Json.name("Entrypoint");
+    networkDisabled @16 :Bool $Json.name("NetworkDisabled");
+    macAddress @17 :Text $Json.name("MacAddress");
+    onBuild @18 :List(Text) $Json.name("OnBuild");
+    labels @19 :Json.Value $Json.name("Labels");
+    stopSignal @20 :Text $Json.name("StopSignal");
+    stopTimeout @21 :UInt32 $Json.name("StopTimeout");
+    shell @22 :List(Text) $Json.name("Shell");
+  }
+
+  struct ContainerInspectResponse {
+    # Response from ContainerInspect operation
+    id @0 :Text $Json.name("Id");
+    created @1 :Text $Json.name("Created");
+    path @2 :Text $Json.name("Path");
+    args @3 :List(Text) $Json.name("Args");
+    state @4 :ContainerState $Json.name("State");
+    networkSettings @5 :NetworkSettings $Json.name("NetworkSettings");
+  }
+
+  struct Command {
+    struct ContainerCreate {
+      struct Params {
+        name @0 :Text; # Optional container name
+        body @1 :ContainerCreateRequest;
+      }
+      struct Result {
+        response @0 :ContainerCreateResponse;
+      }
+    }
+
+    struct ContainerInspect {
+      struct Params {
+        id @0 :Text; # Container ID or name
+      }
+      struct Result {
+        response @0 :ContainerInspectResponse;
+      }
+    }
+  }
+}

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -9,7 +9,6 @@
 #include <workerd/io/worker.h>
 #include <workerd/server/alarm-scheduler.h>
 #include <workerd/server/workerd.capnp.h>
-#include <workerd/util/sqlite.h>
 
 #include <kj/async-io.h>
 #include <kj/compat/http.h>
@@ -102,6 +101,7 @@ class Server final: private kj::TaskSet::ErrorHandler {
     kj::String uniqueKey;
     bool isEvictable;
     bool enableSql;
+    kj::Maybe<config::Worker::DurableObjectNamespace::ContainerOptions::Reader> containerOptions;
   };
   struct Ephemeral {
     bool isEvictable;

--- a/src/workerd/server/tests/container-client/BUILD.bazel
+++ b/src/workerd/server/tests/container-client/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//:build/wd_test.bzl", "wd_test")
+
+wd_test(
+    size = "enormous",
+    src = "test.wd-test",
+    args = ["--experimental"],
+    data = ["test.js"],
+    tags = ["off-by-default"],
+)

--- a/src/workerd/server/tests/container-client/Dockerfile
+++ b/src/workerd/server/tests/container-client/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-alpine
+
+WORKDIR /usr/src/app
+RUN echo '{"name": "simple-node-app", "version": "1.0.0", "dependencies": {"ws": "^8.0.0"}}' > package.json
+RUN npm install
+
+COPY simple-node-app.js app.js
+EXPOSE 8080
+CMD [ "node", "app.js" ]

--- a/src/workerd/server/tests/container-client/README.md
+++ b/src/workerd/server/tests/container-client/README.md
@@ -1,0 +1,33 @@
+## container-client test
+
+This test is excluded from test runner. In order to run the tests, please read the following steps:
+
+- Make sure docker is installed and running correctly
+
+```shell
+docker ps
+```
+
+- Remove existing containers labeled as "cf-container-client-test"
+
+```shell
+docker rm -f $(docker ps -aq --filter name=workerd-container-client-test --all)
+```
+
+- Remove existing docker image
+
+```shell
+docker image rm cf-container-client-test
+```
+
+- Build docker image
+
+```shell
+docker build -t "cf-container-client-test" src/workerd/server/tests/container-client
+```
+
+- Run the test
+
+```shell
+just stream-test //src/workerd/server/tests/container-client:test
+```

--- a/src/workerd/server/tests/container-client/simple-node-app.js
+++ b/src/workerd/server/tests/container-client/simple-node-app.js
@@ -1,0 +1,49 @@
+const { createServer } = require('http');
+
+const webSocketEnabled = process.env.WS_ENABLED === 'true';
+
+// Create HTTP server
+const server = createServer(function (req, res) {
+  if (req.url === '/ws') {
+    // WebSocket upgrade will be handled by the WebSocket server
+    return;
+  }
+
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.write('Hello World!');
+  res.end();
+});
+
+// Check if WebSocket functionality is enabled
+if (webSocketEnabled) {
+  const WebSocket = require('ws');
+
+  // Create WebSocket server
+  const wss = new WebSocket.Server({
+    server: server,
+    path: '/ws',
+  });
+
+  wss.on('connection', function connection(ws) {
+    console.log('WebSocket connection established');
+
+    ws.on('message', function message(data) {
+      console.log('Received:', data.toString());
+      // Echo the message back with prefix
+      ws.send('Echo: ' + data.toString());
+    });
+
+    ws.on('close', function close() {
+      console.log('WebSocket connection closed');
+    });
+
+    ws.on('error', console.error);
+  });
+}
+
+server.listen(8080, function () {
+  console.log('Server listening on port 8080');
+  if (webSocketEnabled) {
+    console.log('WebSocket support enabled');
+  }
+});

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -1,0 +1,269 @@
+import { DurableObject } from 'cloudflare:workers';
+import assert from 'node:assert';
+import { scheduler } from 'node:timers/promises';
+
+const CONTAINER_NAME = 'container-example';
+
+export class DurableObjectExample extends DurableObject {
+  async testBasics() {
+    const container = this.ctx.container;
+    if (container.running) {
+      let monitor = container.monitor().catch((err) => {});
+      await container.destroy();
+      await monitor;
+    }
+    assert.strictEqual(container.running, false);
+
+    // Start container with valid configuration
+    await container.start({
+      entrypoint: ['node', 'app.js'],
+      env: { A: 'B', C: 'D', L: 'F' },
+      enableInternet: true,
+    });
+
+    const monitor = container.monitor().catch((_err) => {});
+
+    // Test HTTP requests to container
+    {
+      let resp;
+      for (let i = 0; i < 6; i++) {
+        try {
+          console.log(`Attempt ${i + 1} to connect to container ${Date.now()}`);
+          resp = await container
+            .getTcpPort(8080)
+            .fetch('http://foo/bar/baz', { method: 'POST', body: 'hello' });
+          break;
+        } catch (e) {
+          await scheduler.wait(500);
+          if (i === 5) {
+            throw e;
+          }
+        }
+      }
+
+      assert.equal(resp.status, 200);
+      assert.equal(resp.statusText, 'OK');
+      assert.strictEqual(await resp.text(), 'Hello World!');
+    }
+    await container.destroy();
+    await monitor;
+    assert.strictEqual(container.running, false);
+  }
+
+  async leaveRunning() {
+    // Start container and leave it running
+    const container = this.ctx.container;
+    if (!container.running) {
+      await container.start({
+        entrypoint: ['leave-running'],
+      });
+    }
+
+    assert.strictEqual(container.running, true);
+  }
+
+  async checkRunning() {
+    // Check container was started using leaveRunning()
+    const container = this.ctx.container;
+
+    // Let's guard in case the test assumptions are wrong.
+    if (!container.running) {
+      return;
+    }
+
+    await container.destroy();
+  }
+
+  async abort() {
+    await this.ctx.storage.put('aborted', true);
+    await this.ctx.storage.sync();
+    this.ctx.abort();
+  }
+
+  async alarm() {
+    const alarmValue = (await this.ctx.storage.get('alarm')) ?? 0;
+
+    const aborted = await this.ctx.storage.get('aborted');
+    assert.strictEqual(!!this.ctx.container, true);
+    // assert.strictEqual(this.ctx.container.running, true);
+    if (aborted) {
+      await this.ctx.storage.put('aborted-confirmed', true);
+    }
+
+    await this.ctx.storage.put('alarm', alarmValue + 1);
+  }
+
+  async getAlarmIndex() {
+    return (await this.ctx.storage.get('alarm')) ?? 0;
+  }
+
+  async startAlarm(start, ms) {
+    if (start && !this.ctx.container.running) {
+      await this.ctx.container.start();
+    } else if (start) {
+      // This is potentially bug with the ordering of your tests.
+      // This function is called assuming the container is not running,
+      // but previous test probably left the container open.
+      console.warn('WARNING: Start called but container is already running');
+    }
+    await this.ctx.storage.setAlarm(Date.now() + ms);
+  }
+
+  async checkAlarmAbortConfirmation() {
+    const abortConfirmation = await this.ctx.storage.get('aborted-confirmed');
+    if (!abortConfirmation) {
+      throw new Error(
+        `Abort confirmation did not get inserted: ${abortConfirmation}`
+      );
+    }
+  }
+
+  async testWs() {
+    await this.ctx.container.start({
+      entrypoint: ['node', 'app.js'],
+      env: { WS_ENABLED: 'true' },
+      enableInternet: true,
+    });
+
+    // Wait for container to be ready
+    await scheduler.wait(2000);
+
+    // Test WebSocket upgrade request
+    const res = await this.ctx.container
+      .getTcpPort(8080)
+      .fetch('http://foo/ws', {
+        headers: {
+          Upgrade: 'websocket',
+          Connection: 'Upgrade',
+          'Sec-WebSocket-Key': 'x3JJHMbDL1EzLkh9GBhXDw==',
+          'Sec-WebSocket-Version': '13',
+        },
+      });
+
+    // Should get WebSocket upgrade response
+    assert.strictEqual(res.status, 101);
+    assert.strictEqual(res.headers.get('upgrade'), 'websocket');
+    assert.strictEqual(!!res.webSocket, true);
+
+    // Test basic WebSocket communication
+    const ws = res.webSocket;
+    ws.accept();
+
+    // Send a test message
+    ws.send('Hello WebSocket!');
+
+    // Listen for response
+    const messagePromise = new Promise((resolve) => {
+      ws.addEventListener('message', (event) => {
+        resolve(event.data);
+      });
+    });
+
+    const response = await messagePromise;
+    assert.strictEqual(response, 'Echo: Hello WebSocket!');
+
+    ws.close();
+    await this.ctx.container.destroy();
+  }
+
+  getStatus() {
+    return this.ctx.container.running;
+  }
+}
+
+export class DurableObjectExample2 extends DurableObjectExample {}
+
+// Test basic container status
+export const testStatus = {
+  async test(_ctrl, env) {
+    for (const CONTAINER of [env.MY_CONTAINER, env.MY_DUPLICATE_CONTAINER]) {
+      const id = CONTAINER.idFromName(CONTAINER_NAME);
+      assert.strictEqual(id.name, CONTAINER_NAME);
+      const container = CONTAINER.get(id);
+      assert.strictEqual(await container.getStatus(), false);
+    }
+  },
+};
+
+// Test basic container functionality
+export const testBasics = {
+  async test(_ctrl, env) {
+    for (const CONTAINER of [env.MY_CONTAINER, env.MY_DUPLICATE_CONTAINER]) {
+      // Test creating multiple DO instances
+      for (const name of ['testBasics', 'helloWorld']) {
+        const id = CONTAINER.idFromName(name);
+        const stub = CONTAINER.get(id);
+        await stub.testBasics();
+      }
+    }
+  },
+};
+
+// Test container persistence across durable object instances
+export const testAlreadyRunning = {
+  async test(_ctrl, env) {
+    const id = env.MY_CONTAINER.idFromName('testAlreadyRunning');
+    let stub = env.MY_CONTAINER.get(id);
+
+    await stub.leaveRunning();
+
+    try {
+      await stub.abort();
+      throw new Error('Expected abort to throw');
+    } catch (err) {
+      assert.strictEqual(err.name, 'Error');
+      assert.strictEqual(
+        err.message,
+        'Application called abort() to reset Durable Object.'
+      );
+    }
+
+    // Recreate stub to get a new instance
+    stub = env.MY_CONTAINER.get(id);
+    await stub.checkRunning();
+  },
+};
+
+// Test WebSocket functionality
+export const testWebSockets = {
+  async test(_ctrl, env) {
+    const id = env.MY_CONTAINER.idFromName('testWebsockets');
+    const stub = env.MY_CONTAINER.get(id);
+    await stub.testWs();
+  },
+};
+
+// // Test alarm functionality with containers
+export const testAlarm = {
+  async test(_ctrl, env) {
+    // Test that we can recover the use_containers flag correctly in setAlarm
+    // after a DO has been evicted
+    const id = env.MY_CONTAINER.idFromName('testAlarm');
+    let stub = env.MY_CONTAINER.get(id);
+
+    // Start immediate alarm
+    await stub.startAlarm(true, 0);
+
+    // Wait for alarm to trigger
+    let retries = 0;
+    while ((await stub.getAlarmIndex()) === 0 && retries < 50) {
+      await scheduler.wait(20);
+      retries++;
+    }
+
+    // Set alarm for future and abort
+    await stub.startAlarm(false, 1000);
+
+    try {
+      await stub.abort();
+    } catch {
+      // Expected to throw
+    }
+
+    // Wait for alarm to run after abort
+    await scheduler.wait(1500);
+
+    stub = env.MY_CONTAINER.get(id);
+    await stub.checkAlarmAbortConfirmation();
+  },
+};

--- a/src/workerd/server/tests/container-client/test.wd-test
+++ b/src/workerd/server/tests/container-client/test.wd-test
@@ -1,0 +1,31 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "internet", network = ( allow = ["private"] ) ),
+    ( name = "container-client-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "test.js")
+        ],
+        compatibilityDate = "2025-01-09",
+        compatibilityFlags = ["nodejs_compat", "experimental"],
+        containerEngine = (localDocker = (socketPath = "unix:/var/run/docker.sock")),
+        durableObjectNamespaces = [
+          ( className = "DurableObjectExample",
+            uniqueKey = "container-client-test-DurableObjectExample",
+            container = (imageName = "cf-container-client-test") ),
+          ( className = "DurableObjectExample2",
+            uniqueKey = "container-client-test-DurableObjectExample2",
+            container = (imageName = "cf-container-client-test") ),
+        ],
+        durableObjectStorage = (localDisk = "TEST_TMPDIR"),
+        bindings = [
+          ( name = "MY_CONTAINER", durableObjectNamespace = "DurableObjectExample" ),
+          ( name = "MY_DUPLICATE_CONTAINER", durableObjectNamespace = "DurableObjectExample2" ),
+        ],
+      )
+    ),
+    ( name = "TEST_TMPDIR", disk = (writable = true) ),
+  ],
+);

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -601,6 +601,18 @@ struct Worker {
     # workerd uses SQLite to back all Durable Objects, but the SQL API is hidden by default to
     # emulate behavior of traditional DO namespaces on Cloudflare that aren't SQLite-backed. This
     # flag should be enabled when testing code that will run on a SQLite-backed namespace.
+
+    container @5 :ContainerOptions;
+    # If present, Durable Objects in this namespace have attached containers.
+    # workerd will talk to the configured container engine to start containers for each
+    # Durable Object based on the given image. The Durable Object can access the container via the
+    # ctx.container API. TODO(CloudChamber): add link to docs.
+
+    struct ContainerOptions {
+      imageName @0 :Text;
+      # Image name to be used to create the container using supported provider.
+      # By default, we pull the "latest" tag of this image.
+    }
   }
 
   durableObjectUniqueKeyModifier @8 :Text;
@@ -651,6 +663,20 @@ struct Worker {
   streamingTails @15 :List(ServiceDesignator);
   # List of streaming tail worker services that should receive tail events for this worker.
   # NOTE: This will be deleted in a future refactor, do not depend on this.
+
+  containerEngine :union {
+    none @16 :Void;
+    # No container engine configured. Container operations will not be available.
+
+    localDocker @17 :DockerConfiguration;
+    # Use local Docker daemon for container operations.
+    # Only used for local development and testing purposes.
+  }
+
+  struct DockerConfiguration {
+    socketPath @0 :Text;
+    # Path to the Docker socket.
+  }
 }
 
 struct ExternalServer {


### PR DESCRIPTION
Despite https://github.com/cloudflare/workerd/pull/4238, this pull-request implements the container service in C++.

In order to run the test you need to pull ubuntu image from docker using: `docker pull ubuntu`.

There are still some todos such as the following, but rest of the functionality works perfectly.

- [x] getTcpPort() implementation
- [x] signal number to signal string (example: SIGINT) conversion
- [x] Uncommenting several tests
- [x] disable the test on CI until we write a mock server that supports docker engine API.

