### PR TITLE
Make improvements to node:fs error handling

### DIFF
--- a/src/workerd/api/filesystem.c++
+++ b/src/workerd/api/filesystem.c++
@@ -91,6 +91,33 @@ struct NormalizedFilePath {
     case workerd::FsError::READ_ONLY: {
       throwUVException(js, UV_EPERM, syscall);
     }
+    case workerd::FsError::TOO_MANY_OPEN_FILES: {
+      throwUVException(js, UV_EMFILE, syscall);
+    }
+    case workerd::FsError::ALREADY_EXISTS: {
+      throwUVException(js, UV_EEXIST, syscall);
+    }
+    case workerd::FsError::NOT_SUPPORTED: {
+      throwUVException(js, UV_ENOSYS, syscall);
+    }
+    case workerd::FsError::NOT_PERMITTED: {
+      throwUVException(js, UV_EPERM, syscall);
+    }
+    case workerd::FsError::NOT_PERMITTED_ON_DIRECTORY: {
+      throwUVException(js, UV_EISDIR, syscall);
+    }
+    case workerd::FsError::FAILED: {
+      throwUVException(js, UV_EIO, syscall);
+    }
+    case workerd::FsError::INVALID_PATH: {
+      throwUVException(js, UV_EINVAL, syscall, "invalid path"_kj);
+    }
+    case workerd::FsError::FILE_SIZE_LIMIT_EXCEEDED: {
+      throwUVException(js, UV_EPERM, syscall, "file size limit exceeded"_kj);
+    }
+    case workerd::FsError::SYMLINK_DEPTH_EXCEEDED: {
+      throwUVException(js, UV_ELOOP, syscall, "symlink depth exceeded"_kj);
+    }
     default: {
       throwUVException(js, UV_EPERM, syscall);
     }
@@ -129,13 +156,17 @@ kj::Maybe<Stat> FileSystemModule::stat(
             // must have been set to false.
             return Stat(link->stat(js));
           }
+          KJ_CASE_ONEOF(err, workerd::FsError) {
+            // If we got here, then the path was not found.
+            throwFsError(js, err, "stat"_kj);
+          }
         }
         KJ_UNREACHABLE;
       }
     }
     KJ_CASE_ONEOF(fd, int) {
       KJ_IF_SOME(opened, vfs.tryGetFd(js, fd)) {
-        KJ_SWITCH_ONEOF(opened.node) {
+        KJ_SWITCH_ONEOF(opened->node) {
           KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
             return Stat(file->stat(js));
           }
@@ -167,7 +198,10 @@ void FileSystemModule::setLastModified(
               js, normalizedPath, {.followLinks = options.followSymlinks.orDefault(true)})) {
         KJ_SWITCH_ONEOF(node) {
           KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
-            file->setLastModified(js, lastModified);
+            KJ_IF_SOME(err, file->setLastModified(js, lastModified)) {
+              // If we got here, then the file is read-only.
+              throwFsError(js, err, "futimes"_kj);
+            }
             return;
           }
           KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
@@ -180,14 +214,20 @@ void FileSystemModule::setLastModified(
             // we do nothing.
             return;
           }
+          KJ_CASE_ONEOF(err, workerd::FsError) {
+            // If we got here, then the path was not found.
+            throwFsError(js, err, "futimes"_kj);
+          }
         }
       }
     }
     KJ_CASE_ONEOF(fd, int) {
       KJ_IF_SOME(opened, vfs.tryGetFd(js, fd)) {
-        KJ_SWITCH_ONEOF(opened.node) {
+        KJ_SWITCH_ONEOF(opened->node) {
           KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
-            file->setLastModified(js, lastModified);
+            KJ_IF_SOME(err, file->setLastModified(js, lastModified)) {
+              throwFsError(js, err, "futimes"_kj);
+            }
             return;
           }
           KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
@@ -217,34 +257,42 @@ void FileSystemModule::truncate(jsg::Lock& js, kj::OneOf<int, FilePath> pathOrFd
       KJ_IF_SOME(node, vfs.resolve(js, normalizedPath)) {
         KJ_SWITCH_ONEOF(node) {
           KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
-            file->resize(js, size);
+            KJ_IF_SOME(err, file->resize(js, size)) {
+              throwFsError(js, err, "ftruncate"_kj);
+            }
             return;
           }
           KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
-            JSG_FAIL_REQUIRE(Error, "Invalid operation on a directory");
+            throwUVException(js, UV_EISDIR, "ftruncate"_kj);
             return;
           }
           KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
             // If we got here, then followSymLinks was set to false. We cannot
             // truncate a symbolic link.
-            JSG_FAIL_REQUIRE(Error, "Invalid operation on a symlink");
+            throwUVException(js, UV_EINVAL, "ftruncate"_kj);
+          }
+          KJ_CASE_ONEOF(err, workerd::FsError) {
+            // If we got here, then the path was not found.
+            throwFsError(js, err, "ftruncate"_kj);
           }
         }
       }
     }
     KJ_CASE_ONEOF(fd, int) {
       KJ_IF_SOME(opened, vfs.tryGetFd(js, fd)) {
-        KJ_SWITCH_ONEOF(opened.node) {
+        KJ_SWITCH_ONEOF(opened->node) {
           KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
-            file->resize(js, size);
+            KJ_IF_SOME(err, file->resize(js, size)) {
+              throwFsError(js, err, "ftruncate"_kj);
+            }
             return;
           }
           KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
-            JSG_FAIL_REQUIRE(Error, "Invalid operation on a directory");
+            throwUVException(js, UV_EISDIR, "ftruncate"_kj);
             return;
           }
           KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
-            JSG_FAIL_REQUIRE(Error, "Invalid operation on a symlink");
+            throwUVException(js, UV_EINVAL, "ftruncate"_kj);
           }
         }
         KJ_UNREACHABLE;
@@ -260,28 +308,34 @@ kj::String FileSystemModule::readLink(jsg::Lock& js, FilePath path, ReadLinkOpti
   auto& vfs = JSG_REQUIRE_NONNULL(
       workerd::VirtualFileSystem::tryGetCurrent(js), Error, "No current virtual file system"_kj);
   NormalizedFilePath normalizedPath(kj::mv(path));
-  auto node = JSG_REQUIRE_NONNULL(
-      vfs.resolve(js, normalizedPath, {.followLinks = false}), Error, "file not found");
-  KJ_SWITCH_ONEOF(node) {
-    KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
-      if (options.failIfNotSymlink) {
-        throwUVException(js, UV_EINVAL, "readlink"_kj);
+  KJ_IF_SOME(node, vfs.resolve(js, normalizedPath, {.followLinks = false})) {
+    KJ_SWITCH_ONEOF(node) {
+      KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
+        if (options.failIfNotSymlink) {
+          throwUVException(js, UV_EINVAL, "readlink"_kj);
+        }
+        kj::Path path = normalizedPath;
+        return path.toString(true);
       }
-      kj::Path path = normalizedPath;
-      return path.toString(true);
-    }
-    KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
-      if (options.failIfNotSymlink) {
-        throwUVException(js, UV_EINVAL, "readlink"_kj);
+      KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
+        if (options.failIfNotSymlink) {
+          throwUVException(js, UV_EINVAL, "readlink"_kj);
+        }
+        kj::Path path = normalizedPath;
+        return path.toString(true);
       }
-      kj::Path path = normalizedPath;
-      return path.toString(true);
+      KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
+        return link->getTargetPath().toString(true);
+      }
+      KJ_CASE_ONEOF(err, workerd::FsError) {
+        // If we got here, then the path was not found.
+        throwFsError(js, err, "readlink"_kj);
+      }
     }
-    KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
-      return link->getTargetPath().toString(true);
-    }
+    KJ_UNREACHABLE;
+  } else {
+    throwUVException(js, UV_ENOENT, "readlink"_kj);
   }
-  KJ_UNREACHABLE;
 }
 
 void FileSystemModule::link(jsg::Lock& js, FilePath from, FilePath to, LinkOptions options) {
@@ -295,7 +349,11 @@ void FileSystemModule::link(jsg::Lock& js, FilePath from, FilePath to, LinkOptio
   const jsg::Url& fromUrl = normalizedFrom;
   const jsg::Url& toUrl = normalizedTo;
 
-  if (vfs.resolve(js, fromUrl) != kj::none) {
+  KJ_IF_SOME(maybeNode, vfs.resolve(js, fromUrl)) {
+    KJ_IF_SOME(err, maybeNode.tryGet<workerd::FsError>()) {
+      throwFsError(js, err, "link"_kj);
+    }
+    // If we got here, then the destination already exists.
     throwUVException(js, UV_EEXIST, "link"_kj, "File already exists"_kj);
   }
 
@@ -314,7 +372,9 @@ void FileSystemModule::link(jsg::Lock& js, FilePath from, FilePath to, LinkOptio
 
       // If we are creating a symbolic link, we do not need to check if the target exists.
       if (options.symbolic) {
-        dir->add(js, fromRelative.name, vfs.newSymbolicLink(js, toUrl));
+        KJ_IF_SOME(err, dir->add(js, fromRelative.name, vfs.newSymbolicLink(js, toUrl))) {
+          throwFsError(js, err, "link"_kj);
+        }
         return;
       }
 
@@ -322,14 +382,22 @@ void FileSystemModule::link(jsg::Lock& js, FilePath from, FilePath to, LinkOptio
       KJ_IF_SOME(target, vfs.resolve(js, toUrl, {.followLinks = false})) {
         KJ_SWITCH_ONEOF(target) {
           KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
-            dir->add(js, fromRelative.name, file.addRef());
+            KJ_IF_SOME(err, dir->add(js, fromRelative.name, file.addRef())) {
+              throwFsError(js, err, "link"_kj);
+            }
           }
           KJ_CASE_ONEOF(tdir, kj::Rc<workerd::Directory>) {
             // It is not permitted to hardlink to a directory.
             throwUVException(js, UV_EPERM, "link"_kj, "Cannot hardlink to a directory"_kj);
           }
           KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
-            dir->add(js, fromRelative.name, link.addRef());
+            KJ_IF_SOME(err, dir->add(js, fromRelative.name, link.addRef())) {
+              throwFsError(js, err, "link"_kj);
+            }
+          }
+          KJ_CASE_ONEOF(err, workerd::FsError) {
+            // If we got here, then the target path was not found.
+            throwFsError(js, err, "link"_kj);
           }
         }
       } else {
@@ -354,8 +422,15 @@ void FileSystemModule::unlink(jsg::Lock& js, FilePath path) {
     KJ_IF_SOME(dir, parent.tryGet<kj::Rc<workerd::Directory>>()) {
       kj::Path fpath(relative.name);
       KJ_IF_SOME(stat, dir->stat(js, fpath)) {
-        if (stat.type == FsType::DIRECTORY) {
-          throwUVException(js, UV_EISDIR, "unlink"_kj, "Cannot unlink a directory"_kj);
+        KJ_SWITCH_ONEOF(stat) {
+          KJ_CASE_ONEOF(stat, workerd::Stat) {
+            if (stat.type == FsType::DIRECTORY) {
+              throwUVException(js, UV_EISDIR, "unlink"_kj, "Cannot unlink a directory"_kj);
+            }
+          }
+          KJ_CASE_ONEOF(err, workerd::FsError) {
+            throwFsError(js, err, "unlink"_kj);
+          }
         }
       } else {
         throwUVException(js, UV_ENOENT, "unlink"_kj, "File not found"_kj);
@@ -381,15 +456,22 @@ int FileSystemModule::open(jsg::Lock& js, FilePath path, OpenOptions options) {
   auto& vfs = JSG_REQUIRE_NONNULL(
       workerd::VirtualFileSystem::tryGetCurrent(js), Error, "No current virtual file system"_kj);
   NormalizedFilePath normalizedPath(kj::mv(path));
-  auto& opened = vfs.openFd(js, normalizedPath,
-      workerd::VirtualFileSystem::OpenOptions{
-        .read = options.read,
-        .write = options.write,
-        .append = options.append,
-        .exclusive = options.exclusive,
-        .followLinks = options.followSymlinks,
-      });
-  return opened.fd;
+  KJ_SWITCH_ONEOF(vfs.openFd(js, normalizedPath,
+                      workerd::VirtualFileSystem::OpenOptions{
+                        .read = options.read,
+                        .write = options.write,
+                        .append = options.append,
+                        .exclusive = options.exclusive,
+                        .followLinks = options.followSymlinks,
+                      })) {
+    KJ_CASE_ONEOF(opened, kj::Rc<workerd::VirtualFileSystem::OpenedFile>) {
+      return opened->fd;
+    }
+    KJ_CASE_ONEOF(err, workerd::FsError) {
+      throwFsError(js, err, "open"_kj);
+    }
+  }
+  KJ_UNREACHABLE;
 }
 
 void FileSystemModule::close(jsg::Lock& js, int fd) {
@@ -406,40 +488,48 @@ uint32_t FileSystemModule::write(
   KJ_IF_SOME(opened, vfs.tryGetFd(js, fd)) {
     static const auto getPosition = [](jsg::Lock& js, auto& opened, auto& file,
                                         const WriteOptions& options) -> uint32_t {
-      if (opened.append) {
+      if (opened->append) {
         // If the file descriptor is opened in append mode, we ignore the position
         // option and always append to the end of the file.
         auto stat = file->stat(js);
         return stat.size;
       }
-      auto pos = options.position.orDefault(opened.position);
-      JSG_REQUIRE(pos <= kMax, Error, "Position out of range");
+      auto pos = options.position.orDefault(opened->position);
+      if (pos > kMax) {
+        throwUVException(js, UV_EINVAL, "write"_kj, "position out of range"_kj);
+      }
       return static_cast<uint32_t>(pos);
     };
 
-    KJ_SWITCH_ONEOF(opened.node) {
+    KJ_SWITCH_ONEOF(opened->node) {
       KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
         auto pos = getPosition(js, opened, file, options);
         uint32_t total = 0;
         for (auto& buffer: data) {
-          auto written = file->write(js, pos, buffer);
-          pos += written;
-          total += written;
+          KJ_SWITCH_ONEOF(file->write(js, pos, buffer)) {
+            KJ_CASE_ONEOF(written, uint32_t) {
+              pos += written;
+              total += written;
+            }
+            KJ_CASE_ONEOF(err, workerd::FsError) {
+              throwFsError(js, err, "write"_kj);
+            }
+          }
         }
         // We only update the position if the options.position is not set and
         // the file descriptor is not opened in append mode.
-        if (options.position == kj::none && !opened.append) {
-          opened.position += total;
+        if (options.position == kj::none && !opened->append) {
+          opened->position += total;
         }
         return total;
       }
       KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
-        JSG_FAIL_REQUIRE(Error, "Invalid operation on a directory");
+        throwUVException(js, UV_EISDIR, "write"_kj);
       }
       KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
         // If we get here, then followSymLinks was set to false when open was called.
         // We can't write to a symbolic link.
-        JSG_FAIL_REQUIRE(Error, "Invalid operation on a symlink");
+        throwUVException(js, UV_EINVAL, "write"_kj);
       }
     }
     KJ_UNREACHABLE;
@@ -453,12 +543,16 @@ uint32_t FileSystemModule::read(
   auto& vfs = JSG_REQUIRE_NONNULL(
       workerd::VirtualFileSystem::tryGetCurrent(js), Error, "No current virtual file system"_kj);
   KJ_IF_SOME(opened, vfs.tryGetFd(js, fd)) {
-    JSG_REQUIRE(opened.read, Error, "File descriptor not opened for reading"_kj);
+    if (!opened->read) {
+      throwUVException(js, UV_EBADF, "read"_kj);
+    }
 
-    KJ_SWITCH_ONEOF(opened.node) {
+    KJ_SWITCH_ONEOF(opened->node) {
       KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
-        auto pos = options.position.orDefault(opened.position);
-        JSG_REQUIRE(pos <= kMax, Error, "Position out of range");
+        auto pos = options.position.orDefault(opened->position);
+        if (pos > kMax) {
+          throwUVException(js, UV_EINVAL, "read"_kj, "position out of range"_kj);
+        }
         uint32_t total = 0;
         for (auto& buffer: data) {
           auto read = file->read(js, pos, buffer);
@@ -469,17 +563,17 @@ uint32_t FileSystemModule::read(
         }
         // We only update the position if the options.position is not set.
         if (options.position == kj::none) {
-          opened.position += total;
+          opened->position += total;
         }
         return total;
       }
       KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
-        JSG_FAIL_REQUIRE(Error, "Invalid operation on a directory");
+        throwUVException(js, UV_EISDIR, "read"_kj);
       }
       KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
         // If we get here, then followSymLinks was set to false when open was called.
         // We can't read from a symbolic link.
-        JSG_FAIL_REQUIRE(Error, "Invalid operation on a symlink");
+        throwUVException(js, UV_EINVAL, "read"_kj);
       }
     }
     KJ_UNREACHABLE;
@@ -497,33 +591,54 @@ jsg::BufferSource FileSystemModule::readAll(jsg::Lock& js, kj::OneOf<int, FilePa
       KJ_IF_SOME(node, vfs.resolve(js, normalized)) {
         KJ_SWITCH_ONEOF(node) {
           KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
-            return file->readAllBytes(js);
+            KJ_SWITCH_ONEOF(file->readAllBytes(js)) {
+              KJ_CASE_ONEOF(data, jsg::BufferSource) {
+                return kj::mv(data);
+              }
+              KJ_CASE_ONEOF(err, workerd::FsError) {
+                throwFsError(js, err, "readAll"_kj);
+              }
+            }
+            KJ_UNREACHABLE;
           }
           KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
-            JSG_FAIL_REQUIRE(Error, "Invalid operation on a directory");
+            throwUVException(js, UV_EISDIR, "readAll"_kj);
           }
           KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
             // We shouldn't be able to get here since we are following symlinks.
             KJ_UNREACHABLE;
+          }
+          KJ_CASE_ONEOF(err, workerd::FsError) {
+            throwFsError(js, err, "readAll"_kj);
           }
         }
       }
     }
     KJ_CASE_ONEOF(fd, int) {
       KJ_IF_SOME(opened, vfs.tryGetFd(js, fd)) {
-        JSG_REQUIRE(opened.read, Error, "File descriptor not opened for reading"_kj);
+        if (!opened->read) {
+          throwUVException(js, UV_EBADF, "fread"_kj);
+        }
 
-        // Make sure we're reading from a file.
-        auto& file = JSG_REQUIRE_NONNULL(
-            opened.node.tryGet<kj::Rc<workerd::File>>(), Error, "Invalid operation"_kj);
+        KJ_IF_SOME(file, opened->node.tryGet<kj::Rc<workerd::File>>()) {
+          // Move the opened.position to the end of the file.
+          KJ_DEFER({
+            auto stat = file->stat(js);
+            opened->position = stat.size;
+          });
 
-        // Move the opened.position to the end of the file.
-        KJ_DEFER({
-          auto stat = file->stat(js);
-          opened.position = stat.size;
-        });
-
-        return file->readAllBytes(js);
+          KJ_SWITCH_ONEOF(file->readAllBytes(js)) {
+            KJ_CASE_ONEOF(data, jsg::BufferSource) {
+              return kj::mv(data);
+            }
+            KJ_CASE_ONEOF(err, workerd::FsError) {
+              throwFsError(js, err, "freadAll"_kj);
+            }
+          }
+          KJ_UNREACHABLE;
+        } else {
+          throwUVException(js, UV_EBADF, "fread"_kj);
+        }
       } else {
         throwUVException(js, UV_EBADF, "fread"_kj);
       }
@@ -539,37 +654,62 @@ uint32_t FileSystemModule::writeAll(jsg::Lock& js,
   auto& vfs = JSG_REQUIRE_NONNULL(
       workerd::VirtualFileSystem::tryGetCurrent(js), Error, "No current virtual file system"_kj);
 
-  JSG_REQUIRE(data.size() <= kMax, Error, "Data size out of range"_kj);
+  if (data.size() > kMax) {
+    throwUVException(js, UV_EFBIG, "writeAll"_kj);
+  }
 
   KJ_SWITCH_ONEOF(pathOrFd) {
     KJ_CASE_ONEOF(path, FilePath) {
       NormalizedFilePath normalized(kj::mv(path));
       KJ_IF_SOME(node, vfs.resolve(js, normalized)) {
         // If the exclusive option is set, the file must not already exist.
-        JSG_REQUIRE(!options.exclusive, Error, "file already exists");
-        // The file already exists, we can write to it.
+        if (options.exclusive) {
+          throwUVException(js, UV_EEXIST, "writeAll"_kj, "file already exists"_kj);
+        }
+        // The file exists, we can write to it.
         KJ_SWITCH_ONEOF(node) {
           KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
             // First let's check that the file is writable.
             auto stat = file->stat(js);
-            JSG_REQUIRE(stat.writable, Error, "access is denied");
+            if (!stat.writable) {
+              throwUVException(js, UV_EPERM, "writeAll"_kj);
+            }
 
             // If the append option is set, we will write to the end of the file
             // instead of overwriting it.
             if (options.append) {
-              return file->write(js, stat.size, data);
+              KJ_SWITCH_ONEOF(file->write(js, stat.size, data)) {
+                KJ_CASE_ONEOF(written, uint32_t) {
+                  return written;
+                }
+                KJ_CASE_ONEOF(err, workerd::FsError) {
+                  throwFsError(js, err, "writeAll"_kj);
+                }
+              }
+              KJ_UNREACHABLE;
             }
 
             // Otherwise, we overwrite the entire file.
-            return file->writeAll(js, data);
+            KJ_SWITCH_ONEOF(file->writeAll(js, data)) {
+              KJ_CASE_ONEOF(written, uint32_t) {
+                return written;
+              }
+              KJ_CASE_ONEOF(err, workerd::FsError) {
+                throwFsError(js, err, "writeAll"_kj);
+              }
+            }
+            KJ_UNREACHABLE;
           }
           KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
-            JSG_FAIL_REQUIRE(Error, "Invalid operation on a directory");
+            throwUVException(js, UV_EISDIR, "writeAll"_kj);
           }
           KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
             // If we get here, then followSymLinks was set to false when open was called.
             // We can't write to a symbolic link.
-            JSG_FAIL_REQUIRE(Error, "Invalid operation on a symlink");
+            throwUVException(js, UV_EINVAL, "writeAll"_kj);
+          }
+          KJ_CASE_ONEOF(err, workerd::FsError) {
+            throwFsError(js, err, "writeAll"_kj);
           }
         }
         KJ_UNREACHABLE;
@@ -578,48 +718,88 @@ uint32_t FileSystemModule::writeAll(jsg::Lock& js,
       // Let's make sure the parent directory exists.
       const jsg::Url& url = normalized;
       jsg::Url::Relative relative = url.getRelative();
-      auto parent =
-          JSG_REQUIRE_NONNULL(vfs.resolve(js, relative.base), Error, "Directory does not exist"_kj);
-      // Let's make sure the parent is a directory.
-      auto& dir = JSG_REQUIRE_NONNULL(
-          parent.tryGet<kj::Rc<workerd::Directory>>(), Error, "Invalid argument"_kj);
-      auto stat = dir->stat(js);
-      JSG_REQUIRE(stat.writable, Error, "access is denied");
-      auto file = workerd::File::newWritable(js, static_cast<uint32_t>(data.size()));
-      auto written = file->writeAll(js, data);
-      dir->add(js, relative.name, kj::mv(file));
-      return written;
+
+      KJ_IF_SOME(parent, vfs.resolve(js, relative.base)) {
+        // Let's make sure the parent is a directory.
+        KJ_SWITCH_ONEOF(parent) {
+          KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
+            throwUVException(js, UV_ENOTDIR, "writeAll"_kj);
+          }
+          KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
+            auto stat = dir->stat(js);
+            if (!stat.writable) {
+              throwUVException(js, UV_EPERM, "writeAll"_kj);
+            }
+            auto file = workerd::File::newWritable(js, static_cast<uint32_t>(data.size()));
+            KJ_SWITCH_ONEOF(file->writeAll(js, data)) {
+              KJ_CASE_ONEOF(written, uint32_t) {
+                KJ_IF_SOME(err, dir->add(js, relative.name, kj::mv(file))) {
+                  throwFsError(js, err, "writeAll"_kj);
+                }
+                return written;
+              }
+              KJ_CASE_ONEOF(err, workerd::FsError) {
+                throwFsError(js, err, "writeAll"_kj);
+              }
+            }
+          }
+          KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
+            // If we get here, then followSymLinks was set to false when open was called.
+            // We can't write to a symbolic link.
+            throwUVException(js, UV_EINVAL, "writeAll"_kj);
+          }
+          KJ_CASE_ONEOF(err, workerd::FsError) {
+            // If we got here, then the parent path was not found.
+            throwFsError(js, err, "writeAll"_kj);
+          }
+        }
+        KJ_UNREACHABLE;
+      } else {
+        throwUVException(js, UV_ENOENT, "writeAll"_kj);
+      }
     }
     KJ_CASE_ONEOF(fd, int) {
       KJ_IF_SOME(opened, vfs.tryGetFd(js, fd)) {
         // Otherwise, we'll overwrite the file...
-        JSG_REQUIRE(opened.write, Error, "File descriptor not opened for writing"_kj);
-
-        // Make sure we're writing to a file.
-        auto& file = JSG_REQUIRE_NONNULL(
-            opened.node.tryGet<kj::Rc<workerd::File>>(), Error, "Invalid operation"_kj);
-
-        auto stat = file->stat(js);
-        // Make sure the file is writable.
-        JSG_REQUIRE(stat.writable, Error, "access is denied");
-
-        KJ_DEFER({
-          // In either case, we need to update the position of the file descriptor.
-          stat = file->stat(js);
-          opened.position = stat.size;
-        });
-
-        // If the file descriptor was opened in append mode, or if the append option
-        // is set, then we'll use write instead to append to the end of the file.
-        if (opened.append || options.append) {
-          return write(js, fd, kj::arr(kj::mv(data)),
-              {
-                .position = stat.size,
-              });
+        if (!opened->write) {
+          throwUVException(js, UV_EBADF, "fwrite"_kj);
         }
 
-        // Otherwise, we overwrite the entire file.
-        return file->writeAll(js, data);
+        KJ_IF_SOME(file, opened->node.tryGet<kj::Rc<workerd::File>>()) {
+          auto stat = file->stat(js);
+
+          if (!stat.writable) {
+            throwUVException(js, UV_EPERM, "fwrite"_kj);
+          }
+
+          KJ_DEFER({
+            // In either case, we need to update the position of the file descriptor.
+            stat = file->stat(js);
+            opened->position = stat.size;
+          });
+
+          // If the file descriptor was opened in append mode, or if the append option
+          // is set, then we'll use write instead to append to the end of the file.
+          if (opened->append || options.append) {
+            return write(js, fd, kj::arr(kj::mv(data)),
+                {
+                  .position = stat.size,
+                });
+          }
+
+          // Otherwise, we overwrite the entire file.
+          KJ_SWITCH_ONEOF(file->writeAll(js, data)) {
+            KJ_CASE_ONEOF(written, uint32_t) {
+              return written;
+            }
+            KJ_CASE_ONEOF(err, workerd::FsError) {
+              throwFsError(js, err, "fwriteAll"_kj);
+            }
+          }
+          KJ_UNREACHABLE;
+        } else {
+          throwUVException(js, UV_EBADF, "fwrite"_kj);
+        }
       } else {
         throwUVException(js, UV_EBADF, "fwrite"_kj);
       }
@@ -637,59 +817,113 @@ void FileSystemModule::renameOrCopy(
   NormalizedFilePath normalizedSrc(kj::mv(src));
   NormalizedFilePath normalizedDest(kj::mv(dest));
 
-  auto srcNode = JSG_REQUIRE_NONNULL(vfs.resolve(js, normalizedSrc), Error, "File not found"_kj);
-
   const jsg::Url& destUrl = normalizedDest;
   const jsg::Url& srcUrl = normalizedSrc;
-  JSG_REQUIRE(vfs.resolve(js, destUrl) == kj::none, Error, "File already exists"_kj);
+
+  auto opName = options.copy ? "copy"_kj : "rename"_kj;
+
+  KJ_IF_SOME(maybeDestNode, vfs.resolve(js, destUrl)) {
+    KJ_IF_SOME(err, maybeDestNode.tryGet<workerd::FsError>()) {
+      throwFsError(js, err, "rename"_kj);
+    }
+    throwUVException(js, UV_EEXIST, opName);
+  }
+
   auto relative = destUrl.getRelative();
   // The destination parent must exist.
-  auto parent =
-      JSG_REQUIRE_NONNULL(vfs.resolve(js, relative.base), Error, "Directory does not exist"_kj);
-  // Let's make sure the parent is a directory.
-  auto& dir = JSG_REQUIRE_NONNULL(
-      parent.tryGet<kj::Rc<workerd::Directory>>(), Error, "Invalid argument"_kj);
+  KJ_IF_SOME(parent, vfs.resolve(js, relative.base)) {
+    KJ_SWITCH_ONEOF(parent) {
+      KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
+        throwUVException(js, UV_ENOTDIR, opName);
+      }
+      KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
+        kj::Maybe<kj::Rc<Directory>> srcParent;
+        if (!options.copy) {
+          // If we are not copying, let's make sure that the source directory is writable
+          // before we actually try moving it.
+          auto relative = srcUrl.getRelative();
+          KJ_IF_SOME(parent, vfs.resolve(js, relative.base)) {
+            KJ_SWITCH_ONEOF(parent) {
+              KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
+                throwUVException(js, UV_ENOTDIR, opName);
+              }
+              KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
+                // We can only rename a file or directory if the parent is writable.
+                // If the parent is not writable, we throw an error.
+                auto stat = dir->stat(js);
+                if (!stat.writable) {
+                  throwUVException(js, UV_EPERM, opName);
+                }
+                srcParent = dir.addRef();
+              }
+              KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
+                throwUVException(js, UV_ENOTDIR, opName);
+              }
+              KJ_CASE_ONEOF(err, workerd::FsError) {
+                // If we got here, then the parent path was not found.
+                throwFsError(js, err, opName);
+              }
+            }
+          } else {
+            throwUVException(js, UV_ENOENT, opName);
+          }
+        }
 
-  kj::Maybe<kj::Rc<Directory>> srcParent;
-  if (!options.copy) {
-    // If we are not copying, let's make sure that the source directory is writable
-    // before we actually try moving it.
-    auto relative = srcUrl.getRelative();
-    auto parent =
-        JSG_REQUIRE_NONNULL(vfs.resolve(js, relative.base), Error, "Directory does not exist"_kj);
-    auto& srcDir = JSG_REQUIRE_NONNULL(
-        parent.tryGet<kj::Rc<workerd::Directory>>(), Error, "Invalid argument"_kj);
-    auto stat = srcDir->stat(js);
-    JSG_REQUIRE(stat.writable, Error, "access is denied");
-    srcParent = srcDir.addRef();
-  }
+        KJ_IF_SOME(srcNode, vfs.resolve(js, normalizedSrc)) {
+          // The next part is easy. We either clone or add ref the original node and add it to the
+          // destination directory.
+          KJ_SWITCH_ONEOF(srcNode) {
+            KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
+              auto newFile = options.copy ? file->clone(js) : file.addRef();
+              KJ_IF_SOME(err, dir->add(js, relative.name, kj::mv(newFile))) {
+                throwFsError(js, err, opName);
+              }
+            }
+            KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
+              if (options.copy) {
+                throwUVException(js, UV_EISDIR, opName);
+              }
+              KJ_IF_SOME(err, dir->add(js, relative.name, dir.addRef())) {
+                throwFsError(js, err, opName);
+              }
+            }
+            KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
+              KJ_IF_SOME(err, dir->add(js, relative.name, link.addRef())) {
+                throwFsError(js, err, opName);
+              }
+            }
+            KJ_CASE_ONEOF(err, workerd::FsError) {
+              throwFsError(js, err, opName);
+            }
+          }
 
-  // The next part is easy. We either clone or add ref the original node and add it to the
-  // destination directory.
-  KJ_SWITCH_ONEOF(srcNode) {
-    KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
-      auto newFile = options.copy ? file->clone(js) : file.addRef();
-      dir->add(js, relative.name, kj::mv(newFile));
-    }
-    KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
-      JSG_REQUIRE(!options.copy, Error, "Cannot copy a directory");
-      dir->add(js, relative.name, dir.addRef());
-    }
-    KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
-      dir->add(js, relative.name, link.addRef());
-    }
-  }
-
-  KJ_IF_SOME(dir, srcParent) {
-    auto relative = srcUrl.getRelative();
-    KJ_SWITCH_ONEOF(dir->remove(js, kj::Path({relative.name}), {.recursive = true})) {
-      KJ_CASE_ONEOF(res, bool) {
-        // Ignore the return.
+          KJ_IF_SOME(dir, srcParent) {
+            auto relative = srcUrl.getRelative();
+            KJ_SWITCH_ONEOF(dir->remove(js, kj::Path({relative.name}), {.recursive = true})) {
+              KJ_CASE_ONEOF(_, bool) {
+                // ignore the specific return value.
+                return;
+              }
+              KJ_CASE_ONEOF(err, workerd::FsError) {
+                throwFsError(js, err, "rename"_kj);
+              }
+            }
+            KJ_UNREACHABLE;
+          }
+        } else {
+          throwUVException(js, UV_ENOENT, opName);
+        }
+      }
+      KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
+        throwUVException(js, UV_ENOTDIR, opName);
       }
       KJ_CASE_ONEOF(err, workerd::FsError) {
-        throwFsError(js, err, "rename"_kj);
+        // If we got here, then the parent path was not found.
+        throwFsError(js, err, opName);
       }
     }
+  } else {
+    throwUVException(js, UV_ENOENT, opName);
   }
 }
 
@@ -714,7 +948,11 @@ jsg::Optional<kj::String> FileSystemModule::mkdir(
       KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
         throwUVException(js, UV_EEXIST, "mkdir"_kj);
       }
+      KJ_CASE_ONEOF(err, workerd::FsError) {
+        throwFsError(js, err, "mkdir"_kj);
+      }
     }
+    KJ_UNREACHABLE;
   };
 
   if (options.recursive) {
@@ -731,6 +969,7 @@ jsg::Optional<kj::String> FileSystemModule::mkdir(
     kj::Path currentPath{};
     for (const auto& part: parentPath) {
       currentPath = currentPath.append(part);
+      bool moveToNext = false;
       // Try opening the next part of the path. Note that we are not using the
       // createAs option here because we don't necessarily want to implicitly
       // create the directory if it doesn't exist. We want to create it explicitly
@@ -738,14 +977,24 @@ jsg::Optional<kj::String> FileSystemModule::mkdir(
       // and tryOpen does not us if the directory already existed or was created.
       KJ_IF_SOME(node, current->tryOpen(js, kj::Path({part}))) {
         // Let's make sure the node is a directory.
-        KJ_IF_SOME(dir, node.tryGet<kj::Rc<workerd::Directory>>()) {
-          // The node is a directory, we can continue.
-          current = kj::mv(dir);
-          continue;
-        } else {
-          throwUVException(js, UV_ENOTDIR, "mkdir"_kj);
+        KJ_SWITCH_ONEOF(node) {
+          KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
+            throwUVException(js, UV_ENOTDIR, "mkdir"_kj);
+          }
+          KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
+            throwUVException(js, UV_ENOTDIR, "mkdir"_kj);
+          }
+          KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
+            // The node is a directory, we can continue.
+            current = kj::mv(dir);
+            moveToNext = true;
+          }
+          KJ_CASE_ONEOF(err, workerd::FsError) {
+            throwFsError(js, err, "mkdir"_kj);
+          }
         }
       }
+      if (moveToNext) continue;
 
       // The node does not exist, let's create it so long as the current
       // directory is writable.
@@ -754,51 +1003,71 @@ jsg::Optional<kj::String> FileSystemModule::mkdir(
         throwUVException(js, UV_EPERM, "mkdir"_kj);
       }
       auto dir = workerd::Directory::newWritable();
-      current->add(js, part, dir.addRef());
+      KJ_IF_SOME(err, current->add(js, part, dir.addRef())) {
+        throwFsError(js, err, "mkdir"_kj);
+      }
       current = kj::mv(dir);
       if (createdPath == kj::none) {
         createdPath = currentPath.toString(true);
       }
     }
 
-    // Now that we have th parent directory, let's try creating the new directory.
+    // Now that we have the parent directory, let's try creating the new directory.
     auto newDir = workerd::Directory::newWritable();
-    current->add(js, name.toString(false), kj::mv(newDir));
+    KJ_IF_SOME(err, current->add(js, name.toString(false), kj::mv(newDir))) {
+      throwFsError(js, err, "mkdir"_kj);
+    }
+
     return kj::mv(createdPath);
   }
 
+  KJ_DASSERT(!options.recursive);
   // If the recursive option is not set, we will create the directory only if
   // the parent directory exists. If the parent directory does not exist, we
   // will return an error.
   auto relative = url.getRelative();
   KJ_IF_SOME(parent, vfs.resolve(js, relative.base)) {
-    // Let's make sure the parent is a directory.
-    KJ_IF_SOME(dir, parent.tryGet<kj::Rc<workerd::Directory>>()) {
-      auto stat = dir->stat(js);
-      if (!stat.writable) {
-        throwUVException(js, UV_EPERM, "mkdir"_kj);
+    KJ_SWITCH_ONEOF(parent) {
+      KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
+        throwUVException(js, UV_ENOTDIR, "mkdir"_kj);
       }
-      auto newDir = workerd::Directory::newWritable();
-      if (options.tmp) {
-        if (tmpFileCounter >= kMax) {
-          throwUVException(js, UV_EPERM, "mkdir"_kj, "Too many temporary directories created"_kj);
+      KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
+        auto stat = dir->stat(js);
+        if (!stat.writable) {
+          throwUVException(js, UV_EPERM, "mkdir"_kj);
         }
-        auto name = kj::str(relative.name, tmpFileCounter++);
-        dir->add(js, name, kj::mv(newDir));
-        KJ_IF_SOME(newUrl, relative.base.resolve(name)) {
-          // If we are creating a temporary directory, we return the URL of the
-          // new directory.
-          return kj::str(newUrl.getPathname());
-        } else {
-          throwUVException(js, UV_EINVAL, "mkdir"_kj, "Invalid name for temporary directory"_kj);
+        auto newDir = workerd::Directory::newWritable();
+        if (options.tmp) {
+          if (tmpFileCounter >= kMax) {
+            throwUVException(js, UV_EPERM, "mkdir"_kj, "Too many temporary directories created"_kj);
+          }
+          auto name = kj::str(relative.name, tmpFileCounter++);
+          KJ_IF_SOME(err, dir->add(js, name, kj::mv(newDir))) {
+            throwFsError(js, err, "mkdir"_kj);
+          }
+          KJ_IF_SOME(newUrl, relative.base.resolve(name)) {
+            // If we are creating a temporary directory, we return the URL of the
+            // new directory.
+            return kj::str(newUrl.getPathname());
+          } else {
+            throwUVException(js, UV_EINVAL, "mkdir"_kj, "Invalid name for temporary directory"_kj);
+          }
         }
-      }
 
-      dir->add(js, relative.name, kj::mv(newDir));
-      return kj::none;
-    } else {
-      throwUVException(js, UV_ENOTDIR, "mkdir"_kj);
+        KJ_IF_SOME(err, dir->add(js, relative.name, kj::mv(newDir))) {
+          throwFsError(js, err, "mkdir"_kj);
+        }
+
+        return kj::none;
+      }
+      KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
+        throwUVException(js, UV_ENOTDIR, "mkdir"_kj);
+      }
+      KJ_CASE_ONEOF(err, workerd::FsError) {
+        throwFsError(js, err, "mkdir"_kj);
+      }
     }
+    KJ_UNREACHABLE;
   } else {
     throwUVException(js, UV_ENOENT, "mkdir"_kj);
   }
@@ -824,8 +1093,15 @@ void FileSystemModule::rm(jsg::Lock& js, FilePath path, RmOptions options) {
       if (options.dironly) {
         // If the dironly option is set, we will only remove the entry if it is a directory.
         KJ_IF_SOME(stat, dir->stat(js, name)) {
-          if (stat.type != workerd::FsType::DIRECTORY) {
-            throwUVException(js, UV_ENOTDIR, "rm"_kj);
+          KJ_SWITCH_ONEOF(stat) {
+            KJ_CASE_ONEOF(stat, workerd::Stat) {
+              if (stat.type != workerd::FsType::DIRECTORY) {
+                throwUVException(js, UV_ENOTDIR, "rm"_kj);
+              }
+            }
+            KJ_CASE_ONEOF(err, workerd::FsError) {
+              throwFsError(js, err, "rm"_kj);
+            }
           }
         } else {
           throwUVException(js, UV_ENOENT, "rm"_kj);
@@ -890,7 +1166,9 @@ void readdirImpl(jsg::Lock& js,
 
         if (options.recursive) {
           workerd::SymbolicLinkRecursionGuardScope guard;
-          guard.checkSeen(link.get());
+          KJ_IF_SOME(err, guard.checkSeen(link.get())) {
+            throwFsError(js, err, "readdir"_kj);
+          }
           KJ_IF_SOME(target, link->resolve(js)) {
             KJ_SWITCH_ONEOF(target) {
               KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
@@ -898,6 +1176,9 @@ void readdirImpl(jsg::Lock& js,
               }
               KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
                 readdirImpl(js, vfs, dir, path.append(entry.key), options, entries);
+              }
+              KJ_CASE_ONEOF(err, workerd::FsError) {
+                throwFsError(js, err, "readdir"_kj);
               }
             }
           }
@@ -914,14 +1195,27 @@ kj::Array<FileSystemModule::DirEntHandle> FileSystemModule::readdir(
       workerd::VirtualFileSystem::tryGetCurrent(js), Error, "No current virtual file system"_kj);
   NormalizedFilePath normalizedPath(kj::mv(path));
 
-  auto node = JSG_REQUIRE_NONNULL(
-      vfs.resolve(js, normalizedPath, {.followLinks = false}), Error, "file not found"_kj);
-  auto& dir =
-      JSG_REQUIRE_NONNULL(node.tryGet<kj::Rc<workerd::Directory>>(), Error, "not a directory"_kj);
-
-  kj::Vector<DirEntHandle> entries;
-  readdirImpl(js, vfs, dir, normalizedPath, options, entries);
-  return entries.releaseAsArray();
+  KJ_IF_SOME(node, vfs.resolve(js, normalizedPath, {.followLinks = false})) {
+    KJ_SWITCH_ONEOF(node) {
+      KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
+        kj::Vector<DirEntHandle> entries;
+        readdirImpl(js, vfs, dir, normalizedPath, options, entries);
+        return entries.releaseAsArray();
+      }
+      KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
+        throwUVException(js, UV_ENOTDIR, "readdir"_kj);
+      }
+      KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
+        throwUVException(js, UV_EINVAL, "readdir"_kj);
+      }
+      KJ_CASE_ONEOF(err, workerd::FsError) {
+        throwFsError(js, err, "readdir"_kj);
+      }
+    }
+    KJ_UNREACHABLE;
+  } else {
+    throwUVException(js, UV_ENOENT, "readdir"_kj);
+  }
 }
 
 jsg::Ref<FileFdHandle> FileFdHandle::constructor(jsg::Lock& js, int fd) {
@@ -1022,6 +1316,37 @@ jsg::Ref<jsg::DOMException> fsErrorToDomException(jsg::Lock& js, workerd::FsErro
     case workerd::FsError::READ_ONLY: {
       return js.domException(kj::str("InvalidStateError"), kj::str("Read-only file system"));
     }
+    case workerd::FsError::NOT_PERMITTED: {
+      return js.domException(kj::str("NotAllowedError"), kj::str("Operation not permitted"));
+    }
+    case workerd::FsError::NOT_PERMITTED_ON_DIRECTORY: {
+      return js.domException(
+          kj::str("NotAllowedError"), kj::str("Operation not permitted on a directory"));
+    }
+    case workerd::FsError::ALREADY_EXISTS: {
+      return js.domException(kj::str("InvalidStateError"), kj::str("File already exists"));
+    }
+    case workerd::FsError::TOO_MANY_OPEN_FILES: {
+      return js.domException(kj::str("QuotaExceededError"),
+          kj::str("Too many open files, please close some files and try again"));
+    }
+    case workerd::FsError::FAILED: {
+      return js.domException(kj::str("UnknownError"), kj::str("File system operation failed"));
+    }
+    case workerd::FsError::NOT_SUPPORTED: {
+      return js.domException(kj::str("NotSupportedError"), kj::str("Operation not supported"));
+    }
+    case workerd::FsError::INVALID_PATH: {
+      return js.domException(kj::str("TypeMismatchError"), kj::str("Invalid file path"));
+    }
+    case workerd::FsError::FILE_SIZE_LIMIT_EXCEEDED: {
+      return js.domException(kj::str("QuotaExceededError"),
+          kj::str("File size limit exceeded, please reduce the file size and try again"));
+    }
+    case workerd::FsError::SYMLINK_DEPTH_EXCEEDED: {
+      return js.domException(kj::str("InvalidStateError"),
+          kj::str("Symbolic link depth exceeded, please check the symbolic links"));
+    }
     default: {
       return js.domException(
           kj::str("UnknownError"), kj::str("Unknown file system error: ", static_cast<int>(error)));
@@ -1059,7 +1384,10 @@ jsg::Promise<jsg::Ref<FileSystemFileHandle>> FileSystemDirectoryHandle::getFileH
     jsg::USVString name,
     jsg::Optional<FileSystemGetFileOptions> options,
     const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& exception) {
-  JSG_REQUIRE(isValidFileName(name), TypeError, "Invalid file name");
+  if (!isValidFileName(name)) {
+    auto ex = js.domException(kj::str("TypeMismatchError"), kj::str("Invalid file name: ", name));
+    return js.rejectedPromise<jsg::Ref<FileSystemFileHandle>>(exception.wrap(js, kj::mv(ex)));
+  }
   kj::Maybe<FsType> createAs;
   KJ_IF_SOME(opts, options) {
     if (opts.create) createAs = FsType::FILE;
@@ -1081,6 +1409,10 @@ jsg::Promise<jsg::Ref<FileSystemFileHandle>> FileSystemDirectoryHandle::getFileH
       KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
         KJ_UNREACHABLE;
       }
+      KJ_CASE_ONEOF(err, workerd::FsError) {
+        return js.rejectedPromise<jsg::Ref<FileSystemFileHandle>>(
+            exception.wrap(js, fsErrorToDomException(js, err)));
+      }
     }
     KJ_UNREACHABLE;
   }
@@ -1094,7 +1426,11 @@ jsg::Promise<jsg::Ref<FileSystemDirectoryHandle>> FileSystemDirectoryHandle::get
     jsg::USVString name,
     jsg::Optional<FileSystemGetDirectoryOptions> options,
     const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& exception) {
-  JSG_REQUIRE(isValidFileName(name), TypeError, "Invalid file name");
+  if (!isValidFileName(name)) {
+    auto ex =
+        js.domException(kj::str("TypeMismatchError"), kj::str("Invalid directory name: ", name));
+    return js.rejectedPromise<jsg::Ref<FileSystemDirectoryHandle>>(exception.wrap(js, kj::mv(ex)));
+  }
   kj::Maybe<FsType> createAs;
   KJ_IF_SOME(opts, options) {
     if (opts.create) createAs = FsType::FILE;
@@ -1116,6 +1452,10 @@ jsg::Promise<jsg::Ref<FileSystemDirectoryHandle>> FileSystemDirectoryHandle::get
       KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
         KJ_UNREACHABLE;
       }
+      KJ_CASE_ONEOF(err, workerd::FsError) {
+        return js.rejectedPromise<jsg::Ref<FileSystemDirectoryHandle>>(
+            exception.wrap(js, fsErrorToDomException(js, err)));
+      }
     }
     KJ_UNREACHABLE;
   }
@@ -1128,7 +1468,10 @@ jsg::Promise<void> FileSystemDirectoryHandle::removeEntry(jsg::Lock& js,
     jsg::USVString name,
     jsg::Optional<FileSystemRemoveOptions> options,
     const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& exception) {
-  JSG_REQUIRE(isValidFileName(name), TypeError, "Invalid file name");
+  if (!isValidFileName(name)) {
+    auto ex = js.domException(kj::str("TypeMismatchError"), kj::str("Invalid file name: ", name));
+    return js.rejectedPromise<void>(exception.wrap(js, kj::mv(ex)));
+  }
   auto opts = options.orDefault(FileSystemRemoveOptions{});
 
   KJ_SWITCH_ONEOF(inner->remove(js, kj::Path({name}),
@@ -1171,7 +1514,10 @@ kj::Array<jsg::Ref<FileSystemHandle>> collectEntries(
       }
       KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
         SymbolicLinkRecursionGuardScope guardScope;
-        guardScope.checkSeen(link.get());
+        KJ_IF_SOME(_, guardScope.checkSeen(link.get())) {
+          // Throw a DOMException indicating that the symbolic link is recursive.
+          JSG_FAIL_REQUIRE(DOMOperationError, "Symbolic link recursion detected"_kj);
+        }
         KJ_IF_SOME(res, link->resolve(js)) {
           KJ_SWITCH_ONEOF(res) {
             KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
@@ -1181,6 +1527,9 @@ kj::Array<jsg::Ref<FileSystemHandle>> collectEntries(
             KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
               entries.add(js.alloc<FileSystemDirectoryHandle>(
                   js.accountedUSVString(entry.key), dir.addRef()));
+            }
+            KJ_CASE_ONEOF(_, workerd::FsError) {
+              JSG_FAIL_REQUIRE(DOMOperationError, "Symbolic link recursion detected"_kj);
             }
           }
         }
@@ -1235,19 +1584,31 @@ jsg::Promise<bool> FileSystemFileHandle::isSameEntry(
   return js.resolvedPromise(false);
 }
 
-jsg::Promise<jsg::Ref<File>> FileSystemFileHandle::getFile(jsg::Lock& js) {
+jsg::Promise<jsg::Ref<File>> FileSystemFileHandle::getFile(
+    jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler) {
   // TODO(node-fs): Currently this copies the file data into the new File object.
   // Alternatively, File/Blob can be modified to allow it to be backed by a
   // workerd::File such that it does not need to create a separate in-memory
   // copy of the data. We can make that optimization as a follow-up, however.
   auto stat = inner->stat(js);
-  return js.resolvedPromise(
-      js.alloc<File>(js, inner->readAllBytes(js), js.accountedUSVString(getName(js)), kj::String(),
-          (stat.lastModified - kj::UNIX_EPOCH) / kj::MILLISECONDS));
+
+  KJ_SWITCH_ONEOF(inner->readAllBytes(js)) {
+    KJ_CASE_ONEOF(bytes, jsg::BufferSource) {
+      return js.resolvedPromise(
+          js.alloc<File>(js, kj::mv(bytes), js.accountedUSVString(getName(js)), kj::String(),
+              (stat.lastModified - kj::UNIX_EPOCH) / kj::MILLISECONDS));
+    }
+    KJ_CASE_ONEOF(err, workerd::FsError) {
+      return js.rejectedPromise<jsg::Ref<File>>(deHandler.wrap(js, fsErrorToDomException(js, err)));
+    }
+  }
+  KJ_UNREACHABLE;
 }
 
 jsg::Promise<jsg::Ref<FileSystemWritableFileStream>> FileSystemFileHandle::createWritable(
-    jsg::Lock& js, jsg::Optional<FileSystemCreateWritableOptions> options) {
+    jsg::Lock& js,
+    jsg::Optional<FileSystemCreateWritableOptions> options,
+    const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler) {
 
   // Per the spec, the writable stream we create here is expected to write into
   // a temporary space until the stream is closed. When closed, the original file
@@ -1269,24 +1630,35 @@ jsg::Promise<jsg::Ref<FileSystemWritableFileStream>> FileSystemFileHandle::creat
   stream->getController().setup(js,
       UnderlyingSink{.type = kj::str("bytes"),
         .write =
-            [state = sharedState.addRef()](
+            [state = sharedState.addRef(), &deHandler](
                 jsg::Lock& js, v8::Local<v8::Value> chunk, auto c) mutable {
     // TODO(node-fs): The spec allows the write parameter to be a WriteParams struct
     // as an alternative to a BufferSource. We should implement this before shipping
     // this feature.
     return js.tryCatch([&] {
-      auto& inner = JSG_REQUIRE_NONNULL(state->temp, DOMInvalidStateError, "File handle closed");
-      // Make sure what we got can be interpreted as bytes...
-      std::shared_ptr<v8::BackingStore> backing;
-      if (chunk->IsArrayBuffer() || chunk->IsArrayBufferView()) {
-        jsg::BufferSource source(js, chunk);
-        if (source.size() == 0) return js.resolvedPromise();
-        state->position += inner->write(js, state->position, source);
-        return js.resolvedPromise();
+      KJ_IF_SOME(inner, state->temp) {
+        // Make sure what we got can be interpreted as bytes...
+        std::shared_ptr<v8::BackingStore> backing;
+        if (chunk->IsArrayBuffer() || chunk->IsArrayBufferView()) {
+          jsg::BufferSource source(js, chunk);
+          if (source.size() == 0) return js.resolvedPromise();
+          KJ_SWITCH_ONEOF(inner->write(js, state->position, source)) {
+            KJ_CASE_ONEOF(written, uint32_t) {
+              state->position += written;
+            }
+            KJ_CASE_ONEOF(err, workerd::FsError) {
+              return js.rejectedPromise<void>(deHandler.wrap(js, fsErrorToDomException(js, err)));
+            }
+          }
+          return js.resolvedPromise();
+        }
+        return js.rejectedPromise<void>(
+            js.typeError("WritableStream received a value that is not an ArrayBuffer,"
+                         "ArrayBufferView, or string type."));
+      } else {
+        auto ex = js.domException(kj::str("InvalidStateError"), kj::str("File handle closed"));
+        return js.rejectedPromise<void>(deHandler.wrap(js, kj::mv(ex)));
       }
-      return js.rejectedPromise<void>(
-          js.typeError("WritableStream received a value that is not an ArrayBuffer,"
-                       "ArrayBufferView, or string type."));
     }, [&](jsg::Value exception) { return js.rejectedPromise<void>(kj::mv(exception)); });
   },
         .abort =
@@ -1296,12 +1668,14 @@ jsg::Promise<jsg::Ref<FileSystemWritableFileStream>> FileSystemFileHandle::creat
     return js.resolvedPromise();
   },
         .close =
-            [state = sharedState.addRef()](jsg::Lock& js) mutable {
+            [state = sharedState.addRef(), &deHandler](jsg::Lock& js) mutable {
     KJ_DEFER(state->clear());
     return js.tryCatch([&] {
       KJ_IF_SOME(temp, state->temp) {
         KJ_IF_SOME(file, state->file) {
-          file->replace(js, kj::mv(temp));
+          KJ_IF_SOME(err, file->replace(js, kj::mv(temp))) {
+            return js.rejectedPromise<void>(deHandler.wrap(js, fsErrorToDomException(js, err)));
+          }
         }
       }
       return js.resolvedPromise();
@@ -1339,22 +1713,40 @@ uint32_t FileSystemSyncAccessHandle::read(
   return ret;
 }
 
-uint32_t FileSystemSyncAccessHandle::write(
-    jsg::Lock& js, jsg::BufferSource buffer, jsg::Optional<FileSystemReadWriteOptions> options) {
+uint32_t FileSystemSyncAccessHandle::write(jsg::Lock& js,
+    jsg::BufferSource buffer,
+    jsg::Optional<FileSystemReadWriteOptions> options,
+    const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler) {
   auto& inner = JSG_REQUIRE_NONNULL(this->inner, DOMInvalidStateError, "File handle closed");
   auto offset = options.orDefault({}).at.orDefault(position);
   auto stat = inner->stat(js);
   if (offset > stat.size) {
-    inner->resize(js, offset + buffer.size());
+    KJ_IF_SOME(err, inner->resize(js, offset + buffer.size())) {
+      auto ex = fsErrorToDomException(js, err);
+      js.throwException(jsg::JsValue(deHandler.wrap(js, kj::mv(ex))));
+    }
   }
-  auto ret = inner->write(js, offset, buffer);
-  position = offset + ret;
-  return ret;
+  KJ_SWITCH_ONEOF(inner->write(js, offset, buffer)) {
+    KJ_CASE_ONEOF(written, uint32_t) {
+      position = offset + written;
+      return written;
+    }
+    KJ_CASE_ONEOF(err, workerd::FsError) {
+      auto ex = fsErrorToDomException(js, err);
+      js.throwException(jsg::JsValue(deHandler.wrap(js, kj::mv(ex))));
+    }
+  }
+  KJ_UNREACHABLE;
 }
 
-void FileSystemSyncAccessHandle::truncate(jsg::Lock& js, uint32_t newSize) {
+void FileSystemSyncAccessHandle::truncate(jsg::Lock& js,
+    uint32_t newSize,
+    const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler) {
   auto& inner = JSG_REQUIRE_NONNULL(this->inner, DOMInvalidStateError, "File handle closed");
-  inner->resize(js, newSize);
+  KJ_IF_SOME(err, inner->resize(js, newSize)) {
+    auto ex = fsErrorToDomException(js, err);
+    js.throwException(jsg::JsValue(deHandler.wrap(js, kj::mv(ex))));
+  }
   auto stat = inner->stat(js);
   if (position > stat.size) {
     position = stat.size;
@@ -1380,93 +1772,162 @@ FileSystemWritableFileStream::FileSystemWritableFileStream(
     : WritableStream(kj::mv(controller)),
       sharedState(kj::mv(sharedState)) {}
 
-jsg::Promise<void> FileSystemWritableFileStream::write(
-    jsg::Lock& js, kj::OneOf<jsg::Ref<Blob>, jsg::BufferSource, kj::String, WriteParams> data) {
+jsg::Promise<void> FileSystemWritableFileStream::write(jsg::Lock& js,
+    kj::OneOf<jsg::Ref<Blob>, jsg::BufferSource, kj::String, WriteParams> data,
+    const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler) {
   JSG_REQUIRE(!getController().isLockedToWriter(), TypeError,
       "Cannot write to a stream that is locked to a reader");
-  auto& inner = JSG_REQUIRE_NONNULL(sharedState->temp, DOMInvalidStateError, "File handle closed");
-  auto writer = getWriter(js);
-  KJ_DEFER(writer->releaseLock(js));
 
-  return js.tryCatch([&] {
-    KJ_SWITCH_ONEOF(data) {
-      KJ_CASE_ONEOF(blob, jsg::Ref<Blob>) {
-        sharedState->position += inner->write(js, sharedState->position, blob->getData());
-      }
-      KJ_CASE_ONEOF(buffer, jsg::BufferSource) {
-        sharedState->position += inner->write(js, sharedState->position, buffer);
-      }
-      KJ_CASE_ONEOF(str, kj::String) {
-        sharedState->position += inner->write(js, sharedState->position, str);
-      }
-      KJ_CASE_ONEOF(params, WriteParams) {
-        uint32_t offset = sharedState->position;
-        KJ_IF_SOME(offset, params.position) {
-          auto stat = inner->stat(js);
-          if (offset > stat.size) {
-            inner->resize(js, offset);
+  KJ_IF_SOME(inner, sharedState->temp) {
+    auto writer = getWriter(js);
+    KJ_DEFER(writer->releaseLock(js));
+
+    return js.tryCatch([&] {
+      KJ_SWITCH_ONEOF(data) {
+        KJ_CASE_ONEOF(blob, jsg::Ref<Blob>) {
+          KJ_SWITCH_ONEOF(inner->write(js, sharedState->position, blob->getData())) {
+            KJ_CASE_ONEOF(written, uint32_t) {
+              sharedState->position += written;
+            }
+            KJ_CASE_ONEOF(err, workerd::FsError) {
+              return js.rejectedPromise<void>(deHandler.wrap(js, fsErrorToDomException(js, err)));
+            }
           }
         }
-
-        if (params.type == "write"_kj) {
-          KJ_IF_SOME(data, params.data) {
-            KJ_SWITCH_ONEOF(data) {
-              KJ_CASE_ONEOF(blob, jsg::Ref<Blob>) {
-                auto ret = inner->write(js, offset, blob->getData());
-                sharedState->position = offset + ret;
-              }
-              KJ_CASE_ONEOF(buffer, jsg::BufferSource) {
-                auto ret = inner->write(js, offset, buffer);
-                sharedState->position = offset + ret;
-              }
-              KJ_CASE_ONEOF(str, kj::String) {
-                auto ret = inner->write(js, offset, str);
-                sharedState->position = offset + ret;
+        KJ_CASE_ONEOF(buffer, jsg::BufferSource) {
+          KJ_SWITCH_ONEOF(inner->write(js, sharedState->position, buffer)) {
+            KJ_CASE_ONEOF(written, uint32_t) {
+              sharedState->position += written;
+            }
+            KJ_CASE_ONEOF(err, workerd::FsError) {
+              return js.rejectedPromise<void>(deHandler.wrap(js, fsErrorToDomException(js, err)));
+            }
+          }
+        }
+        KJ_CASE_ONEOF(str, kj::String) {
+          KJ_SWITCH_ONEOF(inner->write(js, sharedState->position, str)) {
+            KJ_CASE_ONEOF(written, uint32_t) {
+              sharedState->position += written;
+            }
+            KJ_CASE_ONEOF(err, workerd::FsError) {
+              return js.rejectedPromise<void>(deHandler.wrap(js, fsErrorToDomException(js, err)));
+            }
+          }
+        }
+        KJ_CASE_ONEOF(params, WriteParams) {
+          uint32_t offset = sharedState->position;
+          KJ_IF_SOME(offset, params.position) {
+            auto stat = inner->stat(js);
+            if (offset > stat.size) {
+              KJ_IF_SOME(err, inner->resize(js, offset)) {
+                return js.rejectedPromise<void>(deHandler.wrap(js, fsErrorToDomException(js, err)));
               }
             }
           }
-        } else if (params.type == "seek"_kj) {
-          uint32_t pos = params.position.orDefault(0);
-          sharedState->position += pos;
-          auto stat = inner->stat(js);
-          if (sharedState->position > stat.size) {
-            inner->resize(js, sharedState->position);
+
+          if (params.type == "write"_kj) {
+            KJ_IF_SOME(data, params.data) {
+              KJ_SWITCH_ONEOF(data) {
+                KJ_CASE_ONEOF(blob, jsg::Ref<Blob>) {
+                  KJ_SWITCH_ONEOF(inner->write(js, offset, blob->getData())) {
+                    KJ_CASE_ONEOF(written, uint32_t) {
+                      sharedState->position = offset + written;
+                    }
+                    KJ_CASE_ONEOF(err, workerd::FsError) {
+                      return js.rejectedPromise<void>(
+                          deHandler.wrap(js, fsErrorToDomException(js, err)));
+                    }
+                  }
+                }
+                KJ_CASE_ONEOF(buffer, jsg::BufferSource) {
+                  KJ_SWITCH_ONEOF(inner->write(js, offset, buffer)) {
+                    KJ_CASE_ONEOF(written, uint32_t) {
+                      sharedState->position = offset + written;
+                    }
+                    KJ_CASE_ONEOF(err, workerd::FsError) {
+                      return js.rejectedPromise<void>(
+                          deHandler.wrap(js, fsErrorToDomException(js, err)));
+                    }
+                  }
+                }
+                KJ_CASE_ONEOF(str, kj::String) {
+                  KJ_SWITCH_ONEOF(inner->write(js, offset, str)) {
+                    KJ_CASE_ONEOF(written, uint32_t) {
+                      sharedState->position = offset + written;
+                    }
+                    KJ_CASE_ONEOF(err, workerd::FsError) {
+                      return js.rejectedPromise<void>(
+                          deHandler.wrap(js, fsErrorToDomException(js, err)));
+                    }
+                  }
+                }
+              }
+            }
+          } else if (params.type == "seek"_kj) {
+            uint32_t pos = params.position.orDefault(0);
+            sharedState->position += pos;
+            auto stat = inner->stat(js);
+            if (sharedState->position > stat.size) {
+              KJ_IF_SOME(err, inner->resize(js, sharedState->position)) {
+                return js.rejectedPromise<void>(deHandler.wrap(js, fsErrorToDomException(js, err)));
+              }
+            }
+          } else if (params.type == "truncate"_kj) {
+            uint32_t size = params.size.orDefault(0);
+            KJ_IF_SOME(err, inner->resize(js, size)) {
+              return js.rejectedPromise<void>(deHandler.wrap(js, fsErrorToDomException(js, err)));
+            }
+            auto stat = inner->stat(js);
+            if (sharedState->position > stat.size) {
+              sharedState->position = stat.size;
+            }
+          } else {
+            return js.rejectedPromise<void>(
+                js.typeError(kj::str("Invalid write type: ", params.type)));
           }
-        } else if (params.type == "truncate"_kj) {
-          uint32_t size = params.size.orDefault(0);
-          inner->resize(js, size);
-          auto stat = inner->stat(js);
-          if (sharedState->position > stat.size) {
-            sharedState->position = stat.size;
-          }
-        } else {
-          return js.rejectedPromise<void>(
-              js.typeError(kj::str("Invalid write type: ", params.type)));
         }
       }
+
+      return js.resolvedPromise();
+    }, [&](jsg::Value exception) { return js.rejectedPromise<void>(kj::mv(exception)); });
+  } else {
+    auto ex = js.domException(kj::str("InvalidStateError"), kj::str("File handle closed"));
+    return js.rejectedPromise<void>(deHandler.wrap(js, kj::mv(ex)));
+  }
+}
+
+jsg::Promise<void> FileSystemWritableFileStream::seek(jsg::Lock& js,
+    uint32_t position,
+    const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler) {
+  KJ_IF_SOME(inner, sharedState->temp) {
+    auto stat = inner->stat(js);
+    if (position > stat.size) {
+      KJ_IF_SOME(err, inner->resize(js, position)) {
+        return js.rejectedPromise<void>(deHandler.wrap(js, fsErrorToDomException(js, err)));
+      }
     }
-
+    sharedState->position = position;
     return js.resolvedPromise();
-  }, [&](jsg::Value exception) { return js.rejectedPromise<void>(kj::mv(exception)); });
+  } else {
+    auto ex = js.domException(kj::str("InvalidStateError"), kj::str("File handle closed"));
+    return js.rejectedPromise<void>(deHandler.wrap(js, kj::mv(ex)));
+  }
 }
 
-jsg::Promise<void> FileSystemWritableFileStream::seek(jsg::Lock& js, uint32_t position) {
-  auto& inner = JSG_REQUIRE_NONNULL(sharedState->temp, DOMInvalidStateError, "File handle closed");
-  auto stat = inner->stat(js);
-  if (position > stat.size) {
-    inner->resize(js, position);
+jsg::Promise<void> FileSystemWritableFileStream::truncate(
+    jsg::Lock& js, uint32_t size, const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler) {
+  KJ_IF_SOME(inner, sharedState->temp) {
+    KJ_IF_SOME(err, inner->resize(js, size)) {
+      return js.rejectedPromise<void>(deHandler.wrap(js, fsErrorToDomException(js, err)));
+    }
+    auto stat = inner->stat(js);
+    if (sharedState->position > stat.size) {
+      sharedState->position = stat.size;
+    }
+    return js.resolvedPromise();
+  } else {
+    auto ex = js.domException(kj::str("InvalidStateError"), kj::str("File handle closed"));
+    return js.rejectedPromise<void>(deHandler.wrap(js, kj::mv(ex)));
   }
-  sharedState->position = position;
-  return js.resolvedPromise();
-}
-
-jsg::Promise<void> FileSystemWritableFileStream::truncate(jsg::Lock& js, uint32_t size) {
-  auto& inner = JSG_REQUIRE_NONNULL(sharedState->temp, DOMInvalidStateError, "File handle closed");
-  inner->resize(js, size);
-  auto stat = inner->stat(js);
-  if (sharedState->position > stat.size) {
-    sharedState->position = stat.size;
-  }
-  return js.resolvedPromise();
 }
 }  // namespace workerd::api

--- a/src/workerd/api/filesystem.h
+++ b/src/workerd/api/filesystem.h
@@ -237,7 +237,8 @@ jsg::JsValue createUVException(jsg::Lock& js,
   XX(ENOTDIR, "not a directory")                                                                   \
   XX(ENOTEMPTY, "directory not empty")                                                             \
   XX(EPERM, "operation not permitted")                                                             \
-  XX(EMLINK, "too many links")
+  XX(EMLINK, "too many links")                                                                     \
+  XX(EIO, "input/output error")
 
 #define XX(code, _) constexpr int UV_##code = -code;
 UV_ERRNO_MAP(XX)
@@ -300,10 +301,12 @@ class FileSystemFileHandle: public FileSystemHandle {
     JSG_STRUCT(keepExistingData);
   };
 
-  jsg::Promise<jsg::Ref<File>> getFile(jsg::Lock& js);
+  jsg::Promise<jsg::Ref<File>> getFile(
+      jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler);
 
-  jsg::Promise<jsg::Ref<FileSystemWritableFileStream>> createWritable(
-      jsg::Lock& js, jsg::Optional<FileSystemCreateWritableOptions> options);
+  jsg::Promise<jsg::Ref<FileSystemWritableFileStream>> createWritable(jsg::Lock& js,
+      jsg::Optional<FileSystemCreateWritableOptions> options,
+      const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler);
 
   jsg::Promise<jsg::Ref<FileSystemSyncAccessHandle>> createSyncAccessHandle(jsg::Lock& js);
 
@@ -526,10 +529,14 @@ class FileSystemWritableFileStream: public WritableStream {
     JSG_STRUCT(type, size, position, data);
   };
 
-  jsg::Promise<void> write(
-      jsg::Lock& js, kj::OneOf<jsg::Ref<Blob>, jsg::BufferSource, kj::String, WriteParams> data);
-  jsg::Promise<void> seek(jsg::Lock& js, uint32_t position);
-  jsg::Promise<void> truncate(jsg::Lock& js, uint32_t size);
+  jsg::Promise<void> write(jsg::Lock& js,
+      kj::OneOf<jsg::Ref<Blob>, jsg::BufferSource, kj::String, WriteParams> data,
+      const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler);
+  jsg::Promise<void> seek(jsg::Lock& js,
+      uint32_t position,
+      const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler);
+  jsg::Promise<void> truncate(
+      jsg::Lock& js, uint32_t size, const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler);
 
   JSG_RESOURCE_TYPE(FileSystemWritableFileStream) {
     JSG_INHERIT(WritableStream);
@@ -553,10 +560,14 @@ class FileSystemSyncAccessHandle final: public jsg::Object {
 
   uint32_t read(
       jsg::Lock& js, jsg::BufferSource buffer, jsg::Optional<FileSystemReadWriteOptions> options);
-  uint32_t write(
-      jsg::Lock& js, jsg::BufferSource buffer, jsg::Optional<FileSystemReadWriteOptions> options);
+  uint32_t write(jsg::Lock& js,
+      jsg::BufferSource buffer,
+      jsg::Optional<FileSystemReadWriteOptions> options,
+      const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler);
 
-  void truncate(jsg::Lock& js, uint32_t newSize);
+  void truncate(jsg::Lock& js,
+      uint32_t newSize,
+      const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler);
   uint32_t getSize(jsg::Lock& js);
   void flush(jsg::Lock& js);
   void close(jsg::Lock& js);

--- a/src/workerd/api/tests/webfs-test.js
+++ b/src/workerd/api/tests/webfs-test.js
@@ -91,7 +91,8 @@ export const deviceTest = {
     const syncFull = await devFull.createSyncAccessHandle();
     strictEqual(syncFull.getSize(), 0);
     throws(() => syncFull.write(enc.encode('hello world')), {
-      message: 'Cannot write to /dev/full',
+      message: 'Operation not permitted',
+      name: 'NotAllowedError',
     });
     strictEqual(syncFull.getSize(), 0);
     const u8Full = new Buffer.from([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
@@ -104,7 +105,8 @@ export const deviceTest = {
     const syncRandom = await devRandom.createSyncAccessHandle();
     strictEqual(syncRandom.getSize(), 0);
     throws(() => syncRandom.write(enc.encode('hello world')), {
-      message: 'Cannot write to /dev/random',
+      message: 'Operation not permitted',
+      name: 'NotAllowedError',
     });
     strictEqual(syncRandom.getSize(), 0);
     const u8Random = new Buffer.from([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);


### PR DESCRIPTION
Larger commit goes through an improves the error reporting, ensuring that most of the c++ thrown errors have proper node.js style error codes, etc.

Makes it so that the underlying worker-fs api does not throw js errors on its own but instead returns an FsError code. This allows the WebFS and Node.js fs implementations to choose the appropriate error codes for each.