### PR TITLE
[build] Enable zlib and concurrent mksnapshot support in V8

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,3 +20,16 @@ bazel_dep(name = "platforms", version = "1.0.0")
 # needs to be pulled in before rules_cc for this toolchain to actually be used.
 bazel_dep(name = "apple_support", version = "1.22.0")
 bazel_dep(name = "rules_cc", version = "0.1.1")
+
+bazel_dep(name = "zlib", version = "1.3.1.bcr.6")
+git_override(
+    module_name = "zlib",
+    build_file = "//:build/BUILD.zlib",
+    # This should match the version specified in V8 DEPS, but in practice it is generally acceptable
+    # for it to be behind – zlib is very stable and its API has not changed in a long time, most
+    # changes to the Chromium fork affect ancillary tools and not the zlib library itself.
+    commit = "1e85c01b15363d11fab81c46fe2b5c2179113f70",
+    remote = "https://chromium.googlesource.com/chromium/src/third_party/zlib.git",
+    patches = ["//:patches/zlib/0001-Add-dummy-MODULE.bazel.patch"],
+    patch_args = ["-p1"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -108,17 +108,6 @@ git_repository(
 
 # ========================================================================================
 # Rust bootstrap
-#
-
-git_repository(
-    name = "zlib",
-    build_file = "//:build/BUILD.zlib",
-    # This should match the version specified in V8 DEPS, but in practice it is generally acceptable
-    # for it to be behind – zlib is very stable and its API has not changed in a long time, most
-    # changes to the Chromium fork affect ancillary tools and not the zlib library itself.
-    commit = "1e85c01b15363d11fab81c46fe2b5c2179113f70",
-    remote = "https://chromium.googlesource.com/chromium/src/third_party/zlib.git",
-)
 
 load("//:build/rust_toolchains.bzl", "rust_toolchains")
 

--- a/build/BUILD.zlib
+++ b/build/BUILD.zlib
@@ -257,3 +257,13 @@ cc_library(
         "@platforms//cpu:aarch64": [":zlib_arm_crc32"],
     }),
 )
+
+# Chromium zlib includes some custom compression utils that are not present in mainline zlib but
+# used by V8.
+cc_library(
+    name = "compression_utils_portable",
+    srcs = ["google/compression_utils_portable.cc"],
+    hdrs = ["google/compression_utils_portable.h"],
+    visibility = ["//visibility:public"],
+    deps = [":zlib"],
+)

--- a/build/deps/v8.bzl
+++ b/build/deps/v8.bzl
@@ -29,6 +29,8 @@ PATCHES = [
     "0021-Add-methods-to-get-heap-and-external-memory-sizes-di.patch",
     "0022-Remove-DCHECK-from-WriteOneByteV2-to-skip-v8-fatal.patch",
     "0023-Add-more-sandbox-APIs.patch",
+    "0024-bazel-Port-concurrent-mksnapshot-support.patch",
+    "0025-bazel-Port-V8_USE_ZLIB-support.patch",
 ]
 
 # V8 and its dependencies

--- a/patches/v8/0023-Add-more-sandbox-APIs.patch
+++ b/patches/v8/0023-Add-more-sandbox-APIs.patch
@@ -20,10 +20,10 @@ index 1d93457628cf0c41db510c4c06fd6a4e683a52dd..3e64ece5debda3951e7ca328762ab670
       *
       * Caller takes ownership, i.e. the returned object needs to be freed using
 diff --git a/include/v8-isolate.h b/include/v8-isolate.h
-index bc8fa4ded82d7746a05c4af495dbab93886b0f25..97c086e8c4b04e541daac6ef7f2d73dbfd56cef2 100644
+index 6344e3bcb39f8c6658bd14ad5d3ef9db595a1fc6..2aea8bfc81ecda32e0774794390826341efecce7 100644
 --- a/include/v8-isolate.h
 +++ b/include/v8-isolate.h
-@@ -255,6 +255,17 @@ class V8_EXPORT IsolateGroup {
+@@ -253,6 +253,17 @@ class V8_EXPORT IsolateGroup {
      return !operator==(other);
    }
  
@@ -42,10 +42,10 @@ index bc8fa4ded82d7746a05c4af495dbab93886b0f25..97c086e8c4b04e541daac6ef7f2d73db
    friend class Isolate;
    friend class ArrayBuffer::Allocator;
 diff --git a/src/api/api.cc b/src/api/api.cc
-index 62e5a7ee737523bc5c97a30678eb5570ce806729..15ac28f35942a3a4ffc6ac74ac4c888c24bf05bb 100644
+index 7620d3765563c54883aedc345475c81b28efae46..2a2e3d59f6e1be026e46f4c43c85342e4ea3c146 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -9198,6 +9198,19 @@ std::unique_ptr<v8::BackingStore> v8::ArrayBuffer::NewBackingStore(
+@@ -9167,6 +9167,19 @@ std::unique_ptr<v8::BackingStore> v8::ArrayBuffer::NewBackingStore(
        static_cast<v8::BackingStore*>(backing_store.release()));
  }
  
@@ -66,10 +66,10 @@ index 62e5a7ee737523bc5c97a30678eb5570ce806729..15ac28f35942a3a4ffc6ac74ac4c888c
      void* data, size_t byte_length, v8::BackingStore::DeleterCallback deleter,
      void* deleter_data) {
 diff --git a/test/cctest/test-api.cc b/test/cctest/test-api.cc
-index 59f5e7ffc05ac1edefdde2d541fde35c3bc48a66..56b17c28d72e6ad65db06fb311bd24b20204f80f 100644
+index 90adbf2a0b12c79710d8c6f4ae28f8fe92c2991d..ad57bcb167426a1d2c2ba465d5006d8cb2e1c84a 100644
 --- a/test/cctest/test-api.cc
 +++ b/test/cctest/test-api.cc
-@@ -13825,7 +13825,106 @@ UNINITIALIZED_TEST(TwoIsolateGroups) {
+@@ -13556,7 +13556,106 @@ UNINITIALIZED_TEST(TwoIsolateGroups) {
    TestAllocateAndNewForTwoIsolateGroups(create_params_1, create_params_2,
                                          groups[0], groups[1]);
  }

--- a/patches/v8/0024-bazel-Port-concurrent-mksnapshot-support.patch
+++ b/patches/v8/0024-bazel-Port-concurrent-mksnapshot-support.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Felix Hanau <felix@cloudflare.com>
+Date: Sun, 8 Jun 2025 16:39:03 -0400
+Subject: [bazel] Port concurrent mksnapshot support
+
+Change-Id: I57c8158ff5d624e5379e6b072f27ac7a40419522
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 22776066b7ab77a6826adaaf86f6512c263ee657..5db375abd94fda5f5b6d0f14db17a7f7ae3b9f05 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -119,6 +119,11 @@ v8_flag(name = "v8_enable_hugepage")
+ 
+ v8_flag(name = "v8_enable_fast_mksnapshot")
+ 
++v8_flag(
++    name = "v8_enable_concurrent_mksnapshot",
++    default = True,
++)
++
+ v8_flag(name = "v8_enable_future")
+ 
+ # NOTE: Transitions are not recommended in library targets:
+@@ -4300,6 +4305,13 @@ v8_mksnapshot(
+             "--no-turbo-verify-allocation",
+         ],
+         "//conditions:default": [],
++    }) + select({
++        ":is_v8_enable_concurrent_mksnapshot": [
++            "--concurrent-builtin-generation",
++            # Use all the cores for concurrent builtin generation.
++            "--concurrent-turbofan-max-threads=0",
++        ],
++        "//conditions:default": [],
+     }) + select({
+         ":is_v8_enable_snapshot_code_comments": ["--code-comments"],
+         "//conditions:default": [],

--- a/patches/v8/0025-bazel-Port-V8_USE_ZLIB-support.patch
+++ b/patches/v8/0025-bazel-Port-V8_USE_ZLIB-support.patch
@@ -1,0 +1,79 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Felix Hanau <felix@cloudflare.com>
+Date: Sun, 8 Jun 2025 16:40:37 -0400
+Subject: [bazel] Port V8_USE_ZLIB support
+
+Change-Id: Icfedf3e90522f1ff5037517a39a5f0e3d44abace
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 5db375abd94fda5f5b6d0f14db17a7f7ae3b9f05..180b3ac88932a3fc518928c309261b283af6b6a5 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -158,6 +158,11 @@ v8_flag(name = "v8_enable_verify_predictable")
+ 
+ v8_flag(name = "v8_enable_test_features")
+ 
++v8_flag(
++    name = "v8_use_zlib",
++    default = True,
++)
++
+ v8_flag(name = "v8_wasm_random_fuzzers")
+ 
+ v8_flag(
+@@ -492,6 +497,7 @@ v8_config(
+         "v8_enable_drumbrake_tracing": "V8_ENABLE_DRUMBRAKE_TRACING",
+         "v8_jitless": "V8_JITLESS",
+         "v8_enable_vtunejit": "ENABLE_VTUNE_JIT_INTERFACE",
++        "v8_use_zlib": "V8_USE_ZLIB",
+     },
+     defines = [
+         "GOOGLE3",
+@@ -4429,6 +4435,8 @@ v8_library(
+         "@abseil-cpp//absl/container:flat_hash_map",
+         "@abseil-cpp//absl/container:flat_hash_set",
+         "@highway//:hwy",
++        "@zlib",
++        "@zlib//:compression_utils_portable",
+     ],
+ )
+ 
+diff --git a/src/deoptimizer/frame-translation-builder.cc b/src/deoptimizer/frame-translation-builder.cc
+index 3c1ed7cf1e45ab4b87dd134430f7cda321e5e338..fa41e87973bebbe36da35e90a513653779bc1915 100644
+--- a/src/deoptimizer/frame-translation-builder.cc
++++ b/src/deoptimizer/frame-translation-builder.cc
+@@ -11,7 +11,7 @@
+ #include "src/objects/fixed-array-inl.h"
+ 
+ #ifdef V8_USE_ZLIB
+-#include "third_party/zlib/google/compression_utils_portable.h"
++#include <google/compression_utils_portable.h>
+ #endif  // V8_USE_ZLIB
+ 
+ namespace v8 {
+diff --git a/src/objects/deoptimization-data.cc b/src/objects/deoptimization-data.cc
+index 584400990a49f5c904c5a966cd8228a16d84961f..04da60dcb44455dea012df126dd53f5188d3ff55 100644
+--- a/src/objects/deoptimization-data.cc
++++ b/src/objects/deoptimization-data.cc
+@@ -14,7 +14,7 @@
+ #include "src/objects/shared-function-info.h"
+ 
+ #ifdef V8_USE_ZLIB
+-#include "third_party/zlib/google/compression_utils_portable.h"
++#include <google/compression_utils_portable.h>
+ #endif  // V8_USE_ZLIB
+ 
+ namespace v8 {
+diff --git a/src/snapshot/snapshot-utils.cc b/src/snapshot/snapshot-utils.cc
+index ea04fcec0ecebd409d1ed9839dd0db3ac73160a9..e67eb478a0f49fa2a6c4f338e86a7e6a5e6d686f 100644
+--- a/src/snapshot/snapshot-utils.cc
++++ b/src/snapshot/snapshot-utils.cc
+@@ -7,7 +7,7 @@
+ #include "src/base/sanitizer/msan.h"
+ 
+ #ifdef V8_USE_ZLIB
+-#include "third_party/zlib/zlib.h"
++#include <zlib.h>
+ #endif
+ 
+ namespace v8 {

--- a/patches/zlib/0001-Add-dummy-MODULE.bazel.patch
+++ b/patches/zlib/0001-Add-dummy-MODULE.bazel.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Felix Hanau <felix@cloudflare.com>
+Date: Sun, 8 Jun 2025 15:55:56 -0400
+Subject: Add dummy MODULE.bazel
+
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000000000000000000000000000000000000..3611da399064ef179d4924a67c3bbdda5a765d15
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,10 @@
++# dummy file used to support bzlmod
++module(
++    name = "zlib",
++    version = "0.0.0",
++    compatibility_level = 1,
++)
++
++bazel_dep(name = "platforms", version = "1.0.0")
++bazel_dep(name = "rules_cc", version = "0.1.1")
++bazel_dep(name = "bazel_skylib", version = "1.7.1")


### PR DESCRIPTION
[build] Port zlib to bzlmod
The bzlmod transition may have regressed us to using stock zlib based on it
being pulled in by another dependency and the bzlmod zlib being chosen over the
WORKSPACE one.

[build] Enable zlib and concurrent mksnapshot support in V8
This will improve performance when hashing snapshots, and when building V8.

===========

I didn't look closely, but while developing this it appeared that we have regressed to using stock zlib through bzlmod, which would make compression/decompression performance worse.
I observed a noticeable speedup for wd-tests with this on macOS (where -DEBUG is enabled by default, that's another issue to address)