### PR TITLE
[o11y] Add tail worker autogates

### DIFF
--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -21,6 +21,10 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "test-workerd"_kj;
     case AutogateKey::V8_FAST_API:
       return "v8-fast-api"_kj;
+    case AutogateKey::STREAMING_TAIL_WORKER:
+      return "streaming-tail-worker"_kj;
+    case AutogateKey::TAIL_STREAM_REFACTOR:
+      return "tail-stream-refactor"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -15,6 +15,11 @@ namespace workerd::util {
 enum class AutogateKey {
   TEST_WORKERD,
   V8_FAST_API,
+  // Enables support for the streaming tail worker. Note that this is currently also guarded behind
+  // an experimental compat flag.
+  STREAMING_TAIL_WORKER,
+  // Enable refactor used to consolidate the different tail worker stream implementations.
+  TAIL_STREAM_REFACTOR,
   NumOfKeys  // Reserved for iteration.
 };
 


### PR DESCRIPTION
These are not used yet but may both be needed within workerd.

~Downstream PR to follow.~ Also see the downstream PR.