### PR TITLE
Add support for readable streams in AI binding

### DIFF
--- a/src/cloudflare/internal/ai-api.ts
+++ b/src/cloudflare/internal/ai-api.ts
@@ -108,6 +108,7 @@ async function blobToBase64(blob: Blob): Promise<string> {
   return btoa(binary);
 }
 
+// TODO: merge this function with the one with images-api.ts
 function isReadableStream(obj: unknown): obj is ReadableStream {
   return !!(
     obj &&
@@ -131,7 +132,7 @@ function findReadableStreamKeys(
       value &&
       typeof value === 'object' &&
       'body' in value &&
-      isReadableStream(value?.body);
+      isReadableStream(value.body);
 
     if (hasReadableStreamBody || isReadableStream(value)) {
       readableStreamKeys.push(key);
@@ -262,7 +263,7 @@ export class Ai {
         userInputs: JSON.stringify({ ...userInputs }),
       };
       const aiEndpoint = new URL('https://workers-binding.ai/run');
-      for(const [key, value] of Object.entries(query)) {
+      for (const [key, value] of Object.entries(query)) {
         aiEndpoint.searchParams.set(key, value);
       }
 

--- a/src/cloudflare/internal/ai-api.ts
+++ b/src/cloudflare/internal/ai-api.ts
@@ -121,7 +121,7 @@ export function isReadableStream(value: any): boolean {
 function findReadableStreamKeys(inputs: Record<string, object>): Array<string> {
   const readableStreamKeys = [];
   for (const [key, value] of Object.entries(inputs)) {
-    if (isReadableStream((value as AiInputReadableStream)?.body) || isReadableStream(value instanceof ReadableStream)) {
+    if (isReadableStream((value as AiInputReadableStream)?.body) || isReadableStream(value)) {
       readableStreamKeys.push(key);
     }
   }
@@ -229,9 +229,8 @@ export class Ai {
 
       // Construct query params
       // Append inputs with ai.run options that are passed to the inference request
-      const query: any = Object.assign({}, {...cleanedOptions}, {userInputs: JSON.stringify({...inputs})});
+      const query: any = { ...cleanedOptions, userInputs: JSON.stringify({...inputs}) };
       const queryParams = new URLSearchParams(query).toString();
-      console.log(queryParams);
 
       let endpointUrl = `https://workers-binding.ai/run?version=3&${queryParams}`;
       if (options.gateway?.id) {

--- a/src/cloudflare/internal/test/ai/ai-api-test.js
+++ b/src/cloudflare/internal/test/ai/ai-api-test.js
@@ -219,7 +219,8 @@ export const tests = {
           },
           {
             name: 'AiInternalError',
-            message: 'Muliple ReadableStreams [audio,image] are not supported',
+            message:
+              'Multiple ReadableStreams are not supported. Found streams in keys: [audio, image]',
           }
         );
         // Test request internal status code is present

--- a/src/cloudflare/internal/test/ai/ai-api-test.js
+++ b/src/cloudflare/internal/test/ai/ai-api-test.js
@@ -158,7 +158,7 @@ export const tests = {
     {
       // Test errors from one readable stream input without content-type
       await assert.rejects(
-        async() => {
+        async () => {
           const arr = [1, 2, 3];
           const encoder = new TextEncoder();
           const resp = await env.ai.run('readableStreamIputs', {
@@ -208,7 +208,8 @@ export const tests = {
         },
         {
           name: 'AiInternalError',
-          message: 'Multiple ReadableStreams are not supported. Found streams in keys: [audio, image]',
+          message:
+            'Multiple ReadableStreams are not supported. Found streams in keys: [audio, image]',
         }
       );
     }

--- a/src/cloudflare/internal/test/ai/ai-api-test.js
+++ b/src/cloudflare/internal/test/ai/ai-api-test.js
@@ -224,7 +224,6 @@ export const tests = {
           }
         );
         // Test request internal status code is present
-        assert.deepEqual;
         assert.deepStrictEqual(env.ai.lastRequestInternalStatusCode, 1001);
       }
     }

--- a/src/cloudflare/internal/test/ai/ai-api-test.js
+++ b/src/cloudflare/internal/test/ai/ai-api-test.js
@@ -100,7 +100,7 @@ export const tests = {
 
     {
       // Test one readable stream input
-      const arr = [1,2,3];
+      const arr = [1, 2, 3];
       const resp = await env.ai.run('readableStreamIputs', {
         audio: {
           body: new ReadableStream({
@@ -112,20 +112,21 @@ export const tests = {
               controller.close();
             },
           }),
-          contentType: "audio/wav"
-        }
+          contentType: 'audio/wav',
+        },
       });
 
       assert.deepStrictEqual(resp, {
         inputs: {},
         options: { userInputs: '{}', version: '3' },
-        requestUrl: 'https://workers-binding.ai/run?version=3&userInputs=%7B%7D',
+        requestUrl:
+          'https://workers-binding.ai/run?version=3&userInputs=%7B%7D',
       });
     }
 
     {
       // Test one readable stream input with additional parameters
-      const arr = [1,2,3];
+      const arr = [1, 2, 3];
       const resp = await env.ai.run('readableStreamIputs', {
         audio: {
           body: new ReadableStream({
@@ -137,23 +138,27 @@ export const tests = {
               controller.close();
             },
           }),
-          contentType: "audio/wav"
+          contentType: 'audio/wav',
         },
         detect_language: true,
-        prompt: "test prompt"
+        prompt: 'test prompt',
       });
 
       assert.deepStrictEqual(resp, {
         inputs: {},
-        options: { userInputs: '{"detect_language":true,"prompt":"test prompt"}', version: '3' },
-        requestUrl: 'https://workers-binding.ai/run?version=3&userInputs=%7B%22detect_language%22%3Atrue%2C%22prompt%22%3A%22test+prompt%22%7D',
+        options: {
+          userInputs: '{"detect_language":true,"prompt":"test prompt"}',
+          version: '3',
+        },
+        requestUrl:
+          'https://workers-binding.ai/run?version=3&userInputs=%7B%22detect_language%22%3Atrue%2C%22prompt%22%3A%22test+prompt%22%7D',
       });
     }
 
     {
       // Test errors from one readable stream input without content-type
       try {
-        const arr = [1,2,3];
+        const arr = [1, 2, 3];
         const resp = await env.ai.run('readableStreamIputs', {
           audio: {
             body: new ReadableStream({
@@ -165,7 +170,7 @@ export const tests = {
                 controller.close();
               },
             }),
-          }
+          },
         });
       } catch (e) {
         assert.deepEqual(
@@ -186,24 +191,24 @@ export const tests = {
     {
       // Test errors from two readable stream inputs
       try {
-        const arr = [1,2,3];
+        const arr = [1, 2, 3];
         const stream = new ReadableStream({
-              start(controller) {
-                const encoder = new TextEncoder();
-                for (const ele of arr) {
-                  controller.enqueue(encoder.encode(ele));
-                }
-                controller.close();
-              },
-            });
+          start(controller) {
+            const encoder = new TextEncoder();
+            for (const ele of arr) {
+              controller.enqueue(encoder.encode(ele));
+            }
+            controller.close();
+          },
+        });
         const resp = await env.ai.run('readableStreamIputs', {
           audio: {
             body: stream,
-            contentType: "audio/wav"
+            contentType: 'audio/wav',
           },
           image: {
             body: stream,
-            contentType: "image/png"
+            contentType: 'image/png',
           },
         });
       } catch (e) {

--- a/src/cloudflare/internal/test/ai/ai-mock.js
+++ b/src/cloudflare/internal/test/ai/ai-mock.js
@@ -88,10 +88,10 @@ export default {
       });
     }
 
-    const reqContentType = request.headers.get("content-type");
+    const reqContentType = request.headers.get('content-type');
 
     let data = {};
-    if (reqContentType === "application/json") {
+    if (reqContentType === 'application/json') {
       data = await request.json();
     } else {
       data = {
@@ -131,7 +131,7 @@ export default {
       return Response.json(
         {
           inputs: {},
-          options: {...data.options},
+          options: { ...data.options },
           requestUrl: request.url,
         },
         {

--- a/src/cloudflare/internal/test/ai/ai-mock.js
+++ b/src/cloudflare/internal/test/ai/ai-mock.js
@@ -12,14 +12,6 @@ function base64ToBlob(base64, mimeType) {
   return new Blob([bytes], { type: mimeType });
 }
 
-export function extractQueryParams(params) {
-  const query = {};
-  for (const [key, value] of params) {
-    query[key] = value;
-  }
-  return query;
-}
-
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
@@ -96,7 +88,7 @@ export default {
     } else {
       data = {
         inputs: request.body,
-        options: extractQueryParams(url.searchParams),
+        options: Object.fromEntries(url.searchParams),
       };
     }
 


### PR DESCRIPTION
Workers AI is extending its binding to allow for passing ReadableStreams as inputs,
this will only be supported for a few models and will be fully backwards compatible.

For newer models, users will be able to send bigger media files as raw JS ReadableStream
objects. This will result in faster inference responses.