### PR TITLE
WPT fetch api disable flaky test

### DIFF
--- a/src/wpt/fetch/api-test.ts
+++ b/src/wpt/fetch/api-test.ts
@@ -14,6 +14,10 @@ export default {
   },
   'abort/general.any.js': {
     comment: 'See individual tests',
+    disabledTests: [
+      // Flaky since 2025-06-09. To be investigated.
+      'Stream errors once aborted, after reading. Underlying connection closed.',
+    ],
     expectedFailures: [
       // The fetch promise still resolves for some reason
       'Aborting rejects with AbortError',


### PR DESCRIPTION
No idea why it started flaking recently, but let's stop annoying everyone with failed builds for now