### PR TITLE
Pass a jsg::Lock to wrap and unwrap so we can get the isolate from it…

### DIFF
--- a/src/workerd/io/promise-wrapper.h
+++ b/src/workerd/io/promise-wrapper.h
@@ -30,23 +30,23 @@ class PromiseWrapper {
   // For some reason, this wasn't needed for jsg::V8Ref<T>...
 
   template <typename T>
-  v8::Local<v8::Promise> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Promise> wrap(jsg::Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::Promise<T> promise) {
-    auto& js = jsg::Lock::from(context->GetIsolate());
     auto jsPromise = IoContext::current().awaitIoLegacy(js, kj::mv(promise));
-    return static_cast<Self&>(*this).wrap(context, kj::mv(creator), kj::mv(jsPromise));
+    return static_cast<Self&>(*this).wrap(js, context, kj::mv(creator), kj::mv(jsPromise));
   }
 
   template <typename T>
-  kj::Maybe<kj::Promise<T>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<kj::Promise<T>> tryUnwrap(jsg::Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       kj::Promise<T>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
     auto& wrapper = static_cast<Self&>(*this);
     auto jsPromise = KJ_UNWRAP_OR_RETURN(
-        wrapper.tryUnwrap(context, handle, (jsg::Promise<T>*)nullptr, parentObject), kj::none);
-    auto& js = jsg::Lock::from(context->GetIsolate());
+        wrapper.tryUnwrap(js, context, handle, (jsg::Promise<T>*)nullptr, parentObject), kj::none);
     return IoContext::current().awaitJs(js, kj::mv(jsPromise));
   }
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1079,8 +1079,8 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
     lock->v8Isolate->SetPromiseRejectCallback([](v8::PromiseRejectMessage message) {
       // TODO(cleanup): IoContext doesn't really need to be involved here. We are trying to call
       // a method of ServiceWorkerGlobalScope, which is the context object. So we should be able to
-      // do something like unwrap(isolate->GetCurrentContext()).emitPromiseRejection(). However, JSG
-      // doesn't currently provide an easy way to do this.
+      // do something like unwrap(lock, isolate->GetCurrentContext()).emitPromiseRejection().
+      // However, JSG doesn't currently provide an easy way to do this.
       if (IoContext::hasCurrent()) {
         try {
           IoContext::current().getCurrentLock().reportPromiseRejectEvent(message);
@@ -1102,9 +1102,8 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
     lock->v8Isolate->SetPromiseCrossContextCallback(
         [](v8::Local<v8::Context> context, v8::Local<v8::Promise> promise,
             v8::Local<v8::Object> tag) -> v8::MaybeLocal<v8::Promise> {
+      auto& js = jsg::Lock::current();
       try {
-        auto& js = jsg::Lock::from(context->GetIsolate());
-
         // Generally this condition is only going to happen when using dynamic imports.
         // It should not be common.
         JSG_REQUIRE(IoContext::hasCurrent(), Error,
@@ -1129,7 +1128,7 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
       } catch (...) {
         auto ex = kj::getCaughtExceptionAsKj();
         KJ_LOG(ERROR, "Setting promise cross context follower failed unexpectedly", ex);
-        jsg::throwInternalError(context->GetIsolate(), kj::mv(ex));
+        jsg::throwInternalError(js.v8Isolate, kj::mv(ex));
         return v8::MaybeLocal<v8::Promise>();
       }
     });

--- a/src/workerd/jsg/buffersource.h
+++ b/src/workerd/jsg/buffersource.h
@@ -468,20 +468,22 @@ class BufferSourceWrapper {
     return "BufferSource";
   }
 
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       BufferSource bufferSource) {
-    return bufferSource.getHandle(Lock::from(context->GetIsolate()));
+    return bufferSource.getHandle(js);
   }
 
-  kj::Maybe<BufferSource> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<BufferSource> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       BufferSource*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
     if (!handle->IsArrayBuffer() && !handle->IsArrayBufferView()) {
       return kj::none;
     }
-    return BufferSource(Lock::from(context->GetIsolate()), handle);
+    return BufferSource(js, handle);
   }
 };
 

--- a/src/workerd/jsg/fast-api-test.c++
+++ b/src/workerd/jsg/fast-api-test.c++
@@ -51,12 +51,12 @@ class FastMethodContext: public jsg::Object, public jsg::ContextGlobal {
 
   // When arbitrary type unwrapping is supported, keep this test as it is.
   int32_t processObject(v8::Local<v8::Object> obj) {
-    auto isolate = v8::Isolate::GetCurrent();
-    auto context = isolate->GetCurrentContext();
-    auto testKey = v8::String::NewFromUtf8(isolate, "test").ToLocalChecked();
+    auto& js = jsg::Lock::current();
+    auto context = js.v8Context();
+    auto testKey = v8::String::NewFromUtf8(js.v8Isolate, "test").ToLocalChecked();
     v8::Local<v8::Value> value;
     if (obj->Get(context, testKey).ToLocal(&value)) {
-      v8::String::Utf8Value type(isolate, value->TypeOf(isolate));
+      v8::String::Utf8Value type(js.v8Isolate, value->TypeOf(js.v8Isolate));
       KJ_ASSERT(value->IsInt32(), "Received ", *type);
       return value.As<v8::Int32>()->Value();
     }

--- a/src/workerd/jsg/iterator.h
+++ b/src/workerd/jsg/iterator.h
@@ -135,7 +135,7 @@ class GeneratorImpl {
   static kj::Maybe<Signature> tryGetFunction(
       v8::Isolate* isolate, v8::Local<v8::Object> object, kj::StringPtr name, auto& wrapper) {
     auto context = isolate->GetCurrentContext();
-    return wrapper.tryUnwrap(isolate->GetCurrentContext(),
+    return wrapper.tryUnwrap(Lock::from(isolate), isolate->GetCurrentContext(),
         check(object->Get(context, v8StrIntern(isolate, name))), (Signature*)nullptr, object);
   }
 
@@ -542,30 +542,34 @@ class GeneratorWrapper {
 
   template <typename T>
   v8::Local<v8::Object> wrap(
-      v8::Local<v8::Context>, kj::Maybe<v8::Local<v8::Object>>, Generator<T>&&) = delete;
+      Lock& js, v8::Local<v8::Context>, kj::Maybe<v8::Local<v8::Object>>, Generator<T>&&) = delete;
 
   template <typename T>
-  v8::Local<v8::Object> wrap(
-      v8::Local<v8::Context>, kj::Maybe<v8::Local<v8::Object>>, AsyncGenerator<T>&&) = delete;
+  v8::Local<v8::Object> wrap(Lock& js,
+      v8::Local<v8::Context>,
+      kj::Maybe<v8::Local<v8::Object>>,
+      AsyncGenerator<T>&&) = delete;
 
   template <typename T>
-  v8::Local<v8::Object> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Object> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>>,
       GeneratorNext<T>&& next) = delete;
   // Generator, AsyncGenerator, and GeneratorNext instances should never be
   // passed back out into JavaScript. Use Iterators for that.
 
   template <typename T>
-  kj::Maybe<GeneratorNext<T>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<GeneratorNext<T>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       GeneratorNext<T>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
     if (handle->IsObject()) {
-      auto isolate = context->GetIsolate();
+      auto isolate = js.v8Isolate;
       auto& typeWrapper = TypeWrapper::from(isolate);
       auto object = handle.template As<v8::Object>();
 
-      bool done = typeWrapper.template unwrap<bool>(context,
+      bool done = typeWrapper.template unwrap<bool>(js, context,
           check(object->Get(context, v8StrIntern(isolate, "done"_kj))), TypeErrorContext::other());
 
       auto value = check(object->Get(context, v8StrIntern(isolate, "value"_kj)));
@@ -587,19 +591,18 @@ class GeneratorWrapper {
         } else {
           return GeneratorNext<T>{
             .done = true,
-            .value = typeWrapper.tryUnwrap(context, value, (T*)nullptr, parentObject),
+            .value = typeWrapper.tryUnwrap(js, context, value, (T*)nullptr, parentObject),
           };
         }
       }
 
-      KJ_IF_SOME(v, typeWrapper.tryUnwrap(context, value, (T*)nullptr, parentObject)) {
+      KJ_IF_SOME(v, typeWrapper.tryUnwrap(js, context, value, (T*)nullptr, parentObject)) {
         return GeneratorNext<T>{
           .done = false,
           .value = kj::mv(v),
         };
       } else {
-        throwTypeError(
-            context->GetIsolate(), TypeErrorContext::other(), TypeWrapper::getName((T*)nullptr));
+        throwTypeError(js.v8Isolate, TypeErrorContext::other(), TypeWrapper::getName((T*)nullptr));
       }
     }
 
@@ -607,12 +610,13 @@ class GeneratorWrapper {
   }
 
   template <typename T>
-  kj::Maybe<Generator<T>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<Generator<T>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       Generator<T>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
     if (handle->IsObject()) {
-      auto isolate = context->GetIsolate();
+      auto isolate = js.v8Isolate;
       auto object = handle.As<v8::Object>();
       auto iter = check(object->Get(context, v8::Symbol::GetIterator(isolate)));
       if (iter->IsFunction()) {
@@ -627,12 +631,13 @@ class GeneratorWrapper {
   }
 
   template <typename T>
-  kj::Maybe<AsyncGenerator<T>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<AsyncGenerator<T>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       AsyncGenerator<T>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
     if (handle->IsObject()) {
-      auto isolate = context->GetIsolate();
+      auto isolate = js.v8Isolate;
       auto object = handle.As<v8::Object>();
       auto iter = check(object->Get(context, v8::Symbol::GetAsyncIterator(isolate)));
       // If there is no async iterator, let's try a sync iterator
@@ -674,39 +679,43 @@ class SequenceWrapper {
   }
 
   template <typename U>
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(jsg::Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       jsg::Sequence<U> sequence) {
-    v8::Isolate* isolate = context->GetIsolate();
+    v8::Isolate* isolate = js.v8Isolate;
     v8::EscapableHandleScope handleScope(isolate);
     v8::LocalVector<v8::Value> items(isolate, sequence.size());
     for (auto i: kj::indices(sequence)) {
-      items[i] = static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(sequence[i]));
+      items[i] = static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::mv(sequence[i]));
     }
     return handleScope.Escape(v8::Array::New(isolate, items.data(), items.size()));
   }
 
   template <typename U>
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(jsg::Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       jsg::Sequence<U>& sequence) {
-    v8::Isolate* isolate = context->GetIsolate();
+    v8::Isolate* isolate = js.v8Isolate;
     v8::EscapableHandleScope handleScope(isolate);
     v8::LocalVector<v8::Value> items(isolate, sequence.size());
     for (auto i: kj::indices(sequence)) {
-      items[i] = static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(sequence[i]));
+      items[i] = static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::mv(sequence[i]));
     }
     return handleScope.Escape(v8::Array::New(isolate, items.data(), items.size()));
   }
 
   template <typename U>
-  kj::Maybe<Sequence<U>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<Sequence<U>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       Sequence<U>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
-    auto isolate = context->GetIsolate();
+    auto isolate = js.v8Isolate;
     auto& typeWrapper = TypeWrapper::from(isolate);
-    KJ_IF_SOME(gen, typeWrapper.tryUnwrap(context, handle, (Generator<U>*)nullptr, parentObject)) {
+    KJ_IF_SOME(gen,
+        typeWrapper.tryUnwrap(js, context, handle, (Generator<U>*)nullptr, parentObject)) {
       kj::Vector<U> items;
       // We intentionally ignore the forEach return value.
       gen.forEach(Lock::from(isolate), [&items](Lock&, U item, auto&) { items.add(kj::mv(item)); });

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1813,7 +1813,7 @@ class JsContext {
   JsContext(v8::Local<v8::Context> handle,
       Ref<T> object,
       kj::Maybe<kj::Own<void>> maybeNewRegistryHandle = kj::none)
-      : handle(handle->GetIsolate(), handle),
+      : handle(v8::Isolate::GetCurrent(), handle),
         object(kj::mv(object)),
         maybeNewRegistryHandle(kj::mv(maybeNewRegistryHandle)) {}
 

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -699,7 +699,7 @@ void JsMessage::addJsStackTrace(Lock& js, kj::Vector<kj::String>& lines) {
     }
   } else {
     for (auto i: kj::zeroTo(trace->GetFrameCount())) {
-      auto frame = trace->GetFrame(context->GetIsolate(), i);
+      auto frame = trace->GetFrame(js.v8Isolate, i);
       kj::StringTree locationStr;
 
       auto scriptName = frame->GetScriptName();

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -604,27 +604,28 @@ struct JsValueWrapper {
   }
 
 #define V(Name)                                                                                    \
-  v8::Local<v8::Name> wrap(                                                                        \
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, Js##Name value) {  \
+  v8::Local<v8::Name> wrap(jsg::Lock& js, v8::Local<v8::Context> context,                          \
+      kj::Maybe<v8::Local<v8::Object>> creator, Js##Name value) {                                  \
     return value;                                                                                  \
   }                                                                                                \
-  v8::Local<v8::Name> wrap(v8::Local<v8::Context> context,                                         \
+  v8::Local<v8::Name> wrap(jsg::Lock& js, v8::Local<v8::Context> context,                          \
       kj::Maybe<v8::Local<v8::Object>> creator, JsRef<Js##Name> value) {                           \
-    return value.getHandle(Lock::from(context->GetIsolate()));                                     \
+    return value.getHandle(js);                                                                    \
   }
 
   TYPES_TO_WRAP(V)
 #undef V
 
   template <typename T, typename = kj::EnableIf<std::is_assignable_v<JsValue, T>>>
-  kj::Maybe<T> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<T> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       T*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
     if constexpr (kj::isSameType<T, JsString>()) {
       return T(check(handle->ToString(context)));
     } else if constexpr (kj::isSameType<T, JsBoolean>()) {
-      return T(handle->ToBoolean(context->GetIsolate()));
+      return T(handle->ToBoolean(js.v8Isolate));
     } else if constexpr (kj::isSameType<T, JsNumber>()) {
       return T(check(handle->ToNumber(context)));
     } else {
@@ -637,14 +638,14 @@ struct JsValueWrapper {
   }
 
   template <typename T, typename = kj::EnableIf<std::is_assignable_v<JsValue, T>>>
-  kj::Maybe<JsRef<T>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<JsRef<T>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       JsRef<T>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
-    auto isolate = context->GetIsolate();
-    auto& js = Lock::from(isolate);
+    auto isolate = js.v8Isolate;
     KJ_IF_SOME(result,
-        TypeWrapper::from(isolate).tryUnwrap(context, handle, (T*)nullptr, parentObject)) {
+        TypeWrapper::from(isolate).tryUnwrap(js, context, handle, (T*)nullptr, parentObject)) {
       return JsRef(js, result);
     }
     return kj::none;

--- a/src/workerd/jsg/modules-new-test.c++
+++ b/src/workerd/jsg/modules-new-test.c++
@@ -98,8 +98,10 @@ struct TestTypeWrapper {
   static TestTypeWrapper& from(v8::Isolate*) {
     KJ_UNIMPLEMENTED("not implemented");
   }
-  v8::Local<v8::Value> wrap(
-      v8::Local<v8::Context>, kj::Maybe<v8::Local<v8::Object>>, jsg::Ref<TestType>) {
+  v8::Local<v8::Value> wrap(jsg::Lock& lock,
+      v8::Local<v8::Context>,
+      kj::Maybe<v8::Local<v8::Object>>,
+      jsg::Ref<TestType>) {
     KJ_UNIMPLEMENTED("not implemented");
   }
 };
@@ -366,8 +368,10 @@ KJ_TEST("A built-in bundle with two modules") {
       static W w;
       return w;
     }
-    v8::Local<v8::Value> wrap(
-        v8::Local<v8::Context>, kj::Maybe<v8::Local<v8::Object>>, jsg::Ref<TestType>) {
+    v8::Local<v8::Value> wrap(jsg::Lock& lock,
+        v8::Local<v8::Context>,
+        kj::Maybe<v8::Local<v8::Object>>,
+        jsg::Ref<TestType>) {
       return v8::Local<v8::Value>();
     }
   };
@@ -945,7 +949,7 @@ KJ_TEST("compileEvalFunction in synthetic module works") {
       auto ext = js.alloc<TestType>(js, specifier);
       auto& wrapper = TestIsolate_TypeWrapper::from(js.v8Isolate);
       auto fn = Module::compileEvalFunction(js, "bar(123);"_kj, "foo"_kj,
-          JsObject(wrapper.wrap(js.v8Context(), kj::none, ext.addRef())), observer);
+          JsObject(wrapper.wrap(js, js.v8Context(), kj::none, ext.addRef())), observer);
       return js.tryCatch([&] {
         fn(js);
         KJ_ASSERT(ext->barCalled);
@@ -1008,7 +1012,7 @@ KJ_TEST("import.meta works as expected") {
       auto& wrapper = TestIsolate_TypeWrapper::from(js.v8Isolate);
       KJ_IF_SOME(fn,
           wrapper.tryUnwrap(
-              js.v8Context(), res, (Function<kj::String(kj::String)>*)nullptr, kj::none)) {
+              js, js.v8Context(), res, (Function<kj::String(kj::String)>*)nullptr, kj::none)) {
         KJ_ASSERT(fn(js, kj::str("foo/bar")) == "file:///foo/bar"_kj);
       } else {
       }

--- a/src/workerd/jsg/modules-new.h
+++ b/src/workerd/jsg/modules-new.h
@@ -378,7 +378,7 @@ class Module {
         auto ext = js.alloc<T>(js, specifier);
         ns.setDefault(js, ext->getExports(js));
         auto fn = Module::compileEvalFunction(js, source, name,
-            JsObject(wrapper.wrap(js.v8Context(), kj::none, ext.addRef())), observer);
+            JsObject(wrapper.wrap(js, js.v8Context(), kj::none, ext.addRef())), observer);
         fn(js);
         // If there are named exports specified for the module namespace,
         // then we want to examine the ext->getExports() to extract those.
@@ -403,7 +403,8 @@ class Module {
                const Module::ModuleNamespace& ns,
                const CompilationObserver& observer) mutable -> bool {
       Ref<T> instance = factory(js);
-      auto value = TypeWrapper::from(js.v8Isolate).wrap(js.v8Context(), kj::none, kj::mv(instance));
+      auto value =
+          TypeWrapper::from(js.v8Isolate).wrap(js, js.v8Context(), kj::none, kj::mv(instance));
       return ns.setDefault(js, JsValue(value));
     };
   }
@@ -515,7 +516,7 @@ class ModuleBundle {
             [](Lock& js, const Url& specifier, const Module::ModuleNamespace& ns,
                 const CompilationObserver&) {
           auto value = TypeWrapper::from(js.v8Isolate)
-                           .wrap(js.v8Context(), kj::none, js.alloc<T>(js, specifier));
+                           .wrap(js, js.v8Context(), kj::none, js.alloc<T>(js, specifier));
           ns.setDefault(js, JsValue(value));
           return true;
         });

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -19,7 +19,7 @@ v8::MaybeLocal<v8::Module> resolveCallback(v8::Local<v8::Context> context,
     v8::Local<v8::String> specifier,
     v8::Local<v8::FixedArray> import_attributes,
     v8::Local<v8::Module> referrer) {
-  auto& js = jsg::Lock::from(context->GetIsolate());
+  auto& js = Lock::current();
   v8::MaybeLocal<v8::Module> result;
 
   // The specification for import attributes strongly recommends that embedders
@@ -107,7 +107,7 @@ v8::MaybeLocal<v8::Module> resolveCallback(v8::Local<v8::Context> context,
 // callback; V8 will crash if you try to call `SetSyntheticModuleExport()` from anywhere else.
 v8::MaybeLocal<v8::Value> evaluateSyntheticModuleCallback(
     v8::Local<v8::Context> context, v8::Local<v8::Module> module) {
-  auto& js = Lock::from(context->GetIsolate());
+  auto& js = Lock::current();
   v8::EscapableHandleScope scope(js.v8Isolate);
   v8::MaybeLocal<v8::Value> result;
 
@@ -226,7 +226,7 @@ v8::MaybeLocal<v8::Value> evaluateSyntheticModuleCallback(
   })) {
     // V8 doc comments say in the case of an error, throw the error and return an empty Maybe.
     // I.e. NOT a rejected promise. OK...
-    context->GetIsolate()->ThrowException(makeInternalError(js.v8Isolate, kj::mv(exception)));
+    js.v8Isolate->ThrowException(makeInternalError(js.v8Isolate, kj::mv(exception)));
     result = v8::Local<v8::Promise>();
   }
 

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -103,13 +103,14 @@ struct ConstructorCallback<TypeWrapper, T, Ref<T>(Args...), kj::_::Indexes<index
       throwIfConstructorCalledAsFunction(args, typeid(T));
 
       auto context = isolate->GetCurrentContext();
+      auto& js = Lock::from(isolate);
       auto obj = args.This();
       KJ_ASSERT(obj->InternalFieldCount() == Wrappable::INTERNAL_FIELD_COUNT);
 
       auto& wrapper = TypeWrapper::from(isolate);
 
-      Ref<T> ptr = T::constructor(wrapper.template unwrap<Args>(
-          context, args, indexes, TypeErrorContext::constructorArgument(typeid(T), indexes))...);
+      Ref<T> ptr = T::constructor(wrapper.template unwrap<Args>(js, context, args, indexes,
+          TypeErrorContext::constructorArgument(typeid(T), indexes))...);
       if constexpr (T::jsgHasReflection) {
         ptr->jsgInitReflection(wrapper);
       }
@@ -128,13 +129,14 @@ struct ConstructorCallback<TypeWrapper, T, Ref<T>(Lock&, Args...), kj::_::Indexe
       throwIfConstructorCalledAsFunction(args, typeid(T));
 
       auto context = isolate->GetCurrentContext();
+      auto& js = Lock::from(isolate);
       auto obj = args.This();
       KJ_ASSERT(obj->InternalFieldCount() == Wrappable::INTERNAL_FIELD_COUNT);
 
       auto& wrapper = TypeWrapper::from(isolate);
 
       Ref<T> ptr = T::constructor(Lock::from(isolate),
-          wrapper.template unwrap<Args>(context, args, indexes,
+          wrapper.template unwrap<Args>(js, context, args, indexes,
               TypeErrorContext::constructorArgument(typeid(T), indexes))...);
       if constexpr (T::jsgHasReflection) {
         ptr->jsgInitReflection(wrapper);
@@ -158,13 +160,14 @@ struct ConstructorCallback<TypeWrapper,
       throwIfConstructorCalledAsFunction(args, typeid(T));
 
       auto context = isolate->GetCurrentContext();
+      auto& js = Lock::from(isolate);
       auto obj = args.This();
       KJ_ASSERT(obj->InternalFieldCount() == Wrappable::INTERNAL_FIELD_COUNT);
 
       auto& wrapper = TypeWrapper::from(isolate);
 
       Ref<T> ptr = T::constructor(args,
-          wrapper.template unwrap<Args>(context, args, indexes,
+          wrapper.template unwrap<Args>(js, context, args, indexes,
               TypeErrorContext::constructorArgument(typeid(T), indexes))...);
       if constexpr (T::jsgHasReflection) {
         ptr->jsgInitReflection(wrapper);
@@ -218,13 +221,14 @@ struct MethodCallback<TypeWrapper,
       auto context = isolate->GetCurrentContext();
       auto obj = args.This();
       auto& wrapper = TypeWrapper::from(isolate);
+      auto& lock = Lock::from(isolate);
       auto& self = extractInternalPointer<T, isContext>(context, obj);
       if constexpr (isVoid<Ret>()) {
-        (self.*method)(wrapper.template unwrap<Args>(context, args, indexes,
+        (self.*method)(wrapper.template unwrap<Args>(lock, context, args, indexes,
             TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
       } else {
-        return wrapper.wrap(context, obj,
-            (self.*method)(wrapper.template unwrap<Args>(context, args, indexes,
+        return wrapper.wrap(lock, context, obj,
+            (self.*method)(wrapper.template unwrap<Args>(lock, context, args, indexes,
                 TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...));
       }
     });
@@ -240,12 +244,13 @@ struct MethodCallback<TypeWrapper,
     auto isolate = options.isolate;
     v8::HandleScope handleScope(isolate);
     auto context = isolate->GetCurrentContext();
+    auto& js = Lock::from(isolate);
     auto& self = extractInternalPointer<T, isContext>(context, receiver);
     auto& wrapper = TypeWrapper::from(isolate);
 
     return liftKj<Ret>(isolate, [&]() {
-      return (self.*method)(wrapper.template unwrapFastApi<Args>(
-          context, fastArgs, TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
+      return (self.*method)(wrapper.template unwrapFastApi<Args>(js, context, fastArgs,
+          TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
     });
   }
 };
@@ -280,12 +285,12 @@ struct MethodCallback<TypeWrapper,
       auto& lock = Lock::from(isolate);
       if constexpr (isVoid<Ret>()) {
         (self.*method)(lock,
-            wrapper.template unwrap<Args>(context, args, indexes,
+            wrapper.template unwrap<Args>(lock, context, args, indexes,
                 TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
       } else {
-        return wrapper.wrap(context, obj,
+        return wrapper.wrap(lock, context, obj,
             (self.*method)(lock,
-                wrapper.template unwrap<Args>(context, args, indexes,
+                wrapper.template unwrap<Args>(lock, context, args, indexes,
                     TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...));
       }
     });
@@ -307,7 +312,7 @@ struct MethodCallback<TypeWrapper,
 
     return liftKj<Ret>(isolate, [&]() {
       return (self.*method)(lock,
-          wrapper.template unwrapFastApi<Args>(context, fastArgs,
+          wrapper.template unwrapFastApi<Args>(lock, context, fastArgs,
               TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
     });
   }
@@ -337,15 +342,16 @@ struct MethodCallback<TypeWrapper,
       auto context = isolate->GetCurrentContext();
       auto obj = args.This();
       auto& wrapper = TypeWrapper::from(isolate);
+      auto& lock = Lock::from(isolate);
       auto& self = extractInternalPointer<T, isContext>(context, obj);
       if constexpr (isVoid<Ret>()) {
         (self.*method)(args,
-            wrapper.template unwrap<Args>(context, args, indexes,
+            wrapper.template unwrap<Args>(lock, context, args, indexes,
                 TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
       } else {
-        return wrapper.wrap(context, obj,
+        return wrapper.wrap(lock, context, obj,
             (self.*method)(args,
-                wrapper.template unwrap<Args>(context, args, indexes,
+                wrapper.template unwrap<Args>(lock, context, args, indexes,
                     TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...));
       }
     });
@@ -411,12 +417,13 @@ struct StaticMethodCallback<TypeWrapper,
       auto isolate = args.GetIsolate();
       auto context = isolate->GetCurrentContext();
       auto& wrapper = TypeWrapper::from(isolate);
+      auto& lock = Lock::from(isolate);
       if constexpr (isVoid<Ret>()) {
-        (*method)(wrapper.template unwrap<Args>(context, args, indexes,
+        (*method)(wrapper.template unwrap<Args>(lock, context, args, indexes,
             TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
       } else {
-        return wrapper.wrap(context, kj::none,
-            (*method)(wrapper.template unwrap<Args>(context, args, indexes,
+        return wrapper.wrap(lock, context, kj::none,
+            (*method)(wrapper.template unwrap<Args>(lock, context, args, indexes,
                 TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...));
       }
     });
@@ -432,11 +439,12 @@ struct StaticMethodCallback<TypeWrapper,
     auto isolate = options.isolate;
     v8::HandleScope handleScope(isolate);
     auto context = isolate->GetCurrentContext();
+    auto& lock = Lock::from(isolate);
     auto& wrapper = TypeWrapper::from(isolate);
 
     return liftKj<Ret>(isolate, [&]() {
-      return (*method)(wrapper.template unwrapFastApi<Args>(
-          context, fastArgs, TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
+      return (*method)(wrapper.template unwrapFastApi<Args>(lock, context, fastArgs,
+          TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
     });
   }
 };
@@ -467,12 +475,12 @@ struct StaticMethodCallback<TypeWrapper,
       auto& lock = Lock::from(isolate);
       if constexpr (isVoid<Ret>()) {
         (*method)(lock,
-            wrapper.template unwrap<Args>(context, args, indexes,
+            wrapper.template unwrap<Args>(lock, context, args, indexes,
                 TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
       } else {
-        return wrapper.wrap(context, kj::none,
+        return wrapper.wrap(lock, context, kj::none,
             (*method)(lock,
-                wrapper.template unwrap<Args>(context, args, indexes,
+                wrapper.template unwrap<Args>(lock, context, args, indexes,
                     TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...));
       }
     });
@@ -493,7 +501,7 @@ struct StaticMethodCallback<TypeWrapper,
 
     return liftKj<Ret>(isolate, [&]() {
       return (*method)(lock,
-          wrapper.template unwrapFastApi<Args>(context, fastArgs,
+          wrapper.template unwrapFastApi<Args>(lock, context, fastArgs,
               TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
     });
   }
@@ -519,15 +527,16 @@ struct StaticMethodCallback<TypeWrapper,
     liftKj(args, [&]() {
       auto isolate = args.GetIsolate();
       auto context = isolate->GetCurrentContext();
+      auto& lock = Lock::from(isolate);
       auto& wrapper = TypeWrapper::from(isolate);
       if constexpr (isVoid<Ret>()) {
         (*method)(args,
-            wrapper.template unwrap<Args>(context, args, indexes,
+            wrapper.template unwrap<Args>(lock, context, args, indexes,
                 TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...);
       } else {
-        return wrapper.wrap(context, kj::none,
+        return wrapper.wrap(lock, context, kj::none,
             (*method)(args,
-                wrapper.template unwrap<Args>(context, args, indexes,
+                wrapper.template unwrap<Args>(lock, context, args, indexes,
                     TypeErrorContext::methodArgument(typeid(T), methodName, indexes))...));
       }
     });
@@ -574,14 +583,15 @@ struct GetterCallback;
         auto isolate = info.GetIsolate();                                                          \
         auto context = isolate->GetCurrentContext();                                               \
         auto obj = info.This();                                                                    \
+        auto& js = Lock::from(isolate);                                                            \
         auto& wrapper = TypeWrapper::from(isolate);                                                \
         /* V8 no longer supports AccessorSignature, so we must manually verify `this`'s type. */   \
         if (!isContext && !wrapper.getTemplate(isolate, (T*)nullptr)->HasInstance(obj)) {          \
           throwTypeError(isolate, kIllegalInvocation);                                             \
         }                                                                                          \
         auto& self = extractInternalPointer<T, isContext>(context, obj);                           \
-        return wrapper.wrap(                                                                       \
-            context, obj, (self.*method)(wrapper.unwrap(context, (kj::Decay<Args>*)nullptr)...));  \
+        return wrapper.wrap(js, context, obj,                                                      \
+            (self.*method)(wrapper.unwrap(js, context, (kj::Decay<Args>*)nullptr)...));            \
       });                                                                                          \
     }                                                                                              \
     template <typename ReturnType = Ret>                                                           \
@@ -593,11 +603,12 @@ struct GetterCallback;
       auto isolate = options.isolate;                                                              \
       v8::HandleScope handleScope(isolate);                                                        \
       auto context = isolate->GetCurrentContext();                                                 \
+      auto& lock = Lock::from(isolate);                                                            \
       auto& self = extractInternalPointer<T, isContext>(context, receiver);                        \
       auto& wrapper = TypeWrapper::from(isolate);                                                  \
       return liftKj<ReturnType>(isolate, [&]() {                                                   \
         return (self.*method)(                                                                     \
-            wrapper.template unwrapFastApi<Args>(context, (kj::Decay<Args>*)nullptr)...);          \
+            wrapper.template unwrapFastApi<Args>(lock, context, (kj::Decay<Args>*)nullptr)...);    \
       });                                                                                          \
     }                                                                                              \
   };                                                                                               \
@@ -615,6 +626,7 @@ struct GetterCallback;
       liftKj(info, [&]() {                                                                         \
         auto isolate = info.GetIsolate();                                                          \
         auto context = isolate->GetCurrentContext();                                               \
+        auto& js = Lock::from(isolate);                                                            \
         auto obj = info.This();                                                                    \
         auto& wrapper = TypeWrapper::from(isolate);                                                \
         /* V8 no longer supports AccessorSignature, so we must manually verify `this`'s type. */   \
@@ -622,9 +634,8 @@ struct GetterCallback;
           throwTypeError(isolate, kIllegalInvocation);                                             \
         }                                                                                          \
         auto& self = extractInternalPointer<T, isContext>(context, obj);                           \
-        return wrapper.wrap(context, obj,                                                          \
-            (self.*method)(                                                                        \
-                Lock::from(isolate), wrapper.unwrap(context, (kj::Decay<Args>*)nullptr)...));      \
+        return wrapper.wrap(js, context, obj,                                                      \
+            (self.*method)(js, wrapper.unwrap(js, context, (kj::Decay<Args>*)nullptr)...));        \
       });                                                                                          \
     }                                                                                              \
     template <typename ReturnType = Ret>                                                           \
@@ -636,11 +647,12 @@ struct GetterCallback;
       auto isolate = options.isolate;                                                              \
       v8::HandleScope handleScope(isolate);                                                        \
       auto context = isolate->GetCurrentContext();                                                 \
+      auto& js = Lock::from(isolate);                                                              \
       auto& self = extractInternalPointer<T, isContext>(context, receiver);                        \
       auto& wrapper = TypeWrapper::from(isolate);                                                  \
       return liftKj<ReturnType>(isolate, [&]() {                                                   \
-        return (self.*method)(Lock::from(isolate),                                                 \
-            wrapper.template unwrapFastApi<Args>(context, (kj::Decay<Args>*)nullptr)...);          \
+        return (self.*method)(                                                                     \
+            js, wrapper.template unwrapFastApi<Args>(js, context, (kj::Decay<Args>*)nullptr)...);  \
       });                                                                                          \
     }                                                                                              \
   };                                                                                               \
@@ -688,6 +700,7 @@ struct PropertyGetterCallback;
       liftKj(info, [&]() {                                                                         \
         auto isolate = info.GetIsolate();                                                          \
         auto context = isolate->GetCurrentContext();                                               \
+        auto& js = Lock::from(isolate);                                                            \
         auto obj = info.This();                                                                    \
         auto& wrapper = TypeWrapper::from(isolate);                                                \
         /* V8 no longer supports AccessorSignature, so we must manually verify `this`'s type. */   \
@@ -695,8 +708,8 @@ struct PropertyGetterCallback;
           throwTypeError(isolate, kIllegalInvocation);                                             \
         }                                                                                          \
         auto& self = extractInternalPointer<T, isContext>(context, obj);                           \
-        return wrapper.wrap(                                                                       \
-            context, obj, (self.*method)(wrapper.unwrap(context, (kj::Decay<Args>*)nullptr)...));  \
+        return wrapper.wrap(js, context, obj,                                                      \
+            (self.*method)(wrapper.unwrap(js, context, (kj::Decay<Args>*)nullptr)...));            \
       });                                                                                          \
     }                                                                                              \
     template <typename ReturnType = Ret>                                                           \
@@ -710,9 +723,10 @@ struct PropertyGetterCallback;
       auto context = isolate->GetCurrentContext();                                                 \
       auto& self = extractInternalPointer<T, isContext>(context, receiver);                        \
       auto& wrapper = TypeWrapper::from(isolate);                                                  \
+      auto& js = Lock::from(isolate);                                                              \
                                                                                                    \
       return liftKj<ReturnType>(isolate, [&]() -> ReturnType {                                     \
-        return (self.*method)(wrapper.unwrap(context, (kj::Decay<Args>*)nullptr)...);              \
+        return (self.*method)(wrapper.unwrap(js, context, (kj::Decay<Args>*)nullptr)...);          \
       });                                                                                          \
     }                                                                                              \
   };                                                                                               \
@@ -730,6 +744,7 @@ struct PropertyGetterCallback;
       liftKj(info, [&]() {                                                                         \
         auto isolate = info.GetIsolate();                                                          \
         auto context = isolate->GetCurrentContext();                                               \
+        auto& js = Lock::from(isolate);                                                            \
         auto obj = info.This();                                                                    \
         auto& wrapper = TypeWrapper::from(isolate);                                                \
         /* V8 no longer supports AccessorSignature, so we must manually verify `this`'s type. */   \
@@ -737,9 +752,8 @@ struct PropertyGetterCallback;
           throwTypeError(isolate, kIllegalInvocation);                                             \
         }                                                                                          \
         auto& self = extractInternalPointer<T, isContext>(context, obj);                           \
-        return wrapper.wrap(context, obj,                                                          \
-            (self.*method)(                                                                        \
-                Lock::from(isolate), wrapper.unwrap(context, (kj::Decay<Args>*)nullptr)...));      \
+        return wrapper.wrap(js, context, obj,                                                      \
+            (self.*method)(js, wrapper.unwrap(js, context, (kj::Decay<Args>*)nullptr)...));        \
       });                                                                                          \
     }                                                                                              \
     template <typename ReturnType = Ret>                                                           \
@@ -752,11 +766,11 @@ struct PropertyGetterCallback;
       v8::HandleScope handleScope(isolate);                                                        \
       auto context = isolate->GetCurrentContext();                                                 \
       auto& self = extractInternalPointer<T, isContext>(context, receiver);                        \
-      auto& lock = Lock::from(isolate);                                                            \
+      auto& js = Lock::from(isolate);                                                              \
       auto& wrapper = TypeWrapper::from(isolate);                                                  \
                                                                                                    \
       return liftKj<ReturnType>(isolate, [&]() -> ReturnType {                                     \
-        return (self.*method)(lock, wrapper.unwrap(context, (kj::Decay<Args>*)nullptr)...);        \
+        return (self.*method)(js, wrapper.unwrap(js, context, (kj::Decay<Args>*)nullptr)...);      \
       });                                                                                          \
     }                                                                                              \
   };                                                                                               \
@@ -801,6 +815,7 @@ struct SetterCallback<TypeWrapper, methodName, void (T::*)(Arg), method, isConte
     liftKj(info, [&]() {
       auto isolate = info.GetIsolate();
       auto context = isolate->GetCurrentContext();
+      auto& js = Lock::from(isolate);
       auto obj = info.This();
       auto& wrapper = TypeWrapper::from(isolate);
       // V8 no longer supports AccessorSignature, so we must manually verify `this`'s type.
@@ -809,7 +824,7 @@ struct SetterCallback<TypeWrapper, methodName, void (T::*)(Arg), method, isConte
       }
       auto& self = extractInternalPointer<T, isContext>(context, obj);
       (self.*method)(wrapper.template unwrap<Arg>(
-          context, value, TypeErrorContext::setterArgument(typeid(T), methodName)));
+          js, context, value, TypeErrorContext::setterArgument(typeid(T), methodName)));
     });
   }
 };
@@ -834,9 +849,10 @@ struct SetterCallback<TypeWrapper, methodName, void (T::*)(Lock&, Arg), method, 
         throwTypeError(isolate, kIllegalInvocation);
       }
       auto& self = extractInternalPointer<T, isContext>(context, obj);
-      (self.*method)(Lock::from(isolate),
+      auto& js = Lock::from(isolate);
+      (self.*method)(js,
           wrapper.template unwrap<Arg>(
-              context, value, TypeErrorContext::setterArgument(typeid(T), methodName)));
+              js, context, value, TypeErrorContext::setterArgument(typeid(T), methodName)));
     });
   }
 };
@@ -862,6 +878,7 @@ struct PropertySetterCallback<TypeWrapper, methodName, void (T::*)(Arg), method,
     liftKj(info, [&]() {
       auto isolate = info.GetIsolate();
       auto context = isolate->GetCurrentContext();
+      auto& js = Lock::from(isolate);
       auto obj = info.This();
       auto& wrapper = TypeWrapper::from(isolate);
       // V8 no longer supports AccessorSignature, so we must manually verify `this`'s type.
@@ -870,7 +887,7 @@ struct PropertySetterCallback<TypeWrapper, methodName, void (T::*)(Arg), method,
       }
       auto& self = extractInternalPointer<T, isContext>(context, obj);
       (self.*method)(wrapper.template unwrap<Arg>(
-          context, info[0], TypeErrorContext::setterArgument(typeid(T), methodName)));
+          js, context, info[0], TypeErrorContext::setterArgument(typeid(T), methodName)));
     });
   }
 
@@ -884,12 +901,13 @@ struct PropertySetterCallback<TypeWrapper, methodName, void (T::*)(Arg), method,
     auto isolate = options.isolate;
     v8::HandleScope handleScope(isolate);
     auto context = isolate->GetCurrentContext();
+    auto& js = Lock::from(isolate);
     auto& self = extractInternalPointer<T, isContext>(context, receiver);
     auto& wrapper = TypeWrapper::from(isolate);
 
     liftKj<void>(isolate, [&]() -> void {
       (self.*method)(wrapper.template unwrapFastApi<Arg>(
-          context, fastArgs, TypeErrorContext::setterArgument(typeid(T), methodName)));
+          js, context, fastArgs, TypeErrorContext::setterArgument(typeid(T), methodName)));
     });
   }
 };
@@ -916,9 +934,10 @@ struct PropertySetterCallback<TypeWrapper, methodName, void (T::*)(Lock&, Arg), 
         throwTypeError(isolate, kIllegalInvocation);
       }
       auto& self = extractInternalPointer<T, isContext>(context, obj);
-      (self.*method)(Lock::from(isolate),
+      auto& js = Lock::from(isolate);
+      (self.*method)(js,
           wrapper.template unwrap<Arg>(
-              context, info[0], TypeErrorContext::setterArgument(typeid(T), methodName)));
+              js, context, info[0], TypeErrorContext::setterArgument(typeid(T), methodName)));
     });
   }
 
@@ -939,7 +958,7 @@ struct PropertySetterCallback<TypeWrapper, methodName, void (T::*)(Lock&, Arg), 
     liftKj<void>(isolate, [&]() -> void {
       (self.*method)(lock,
           wrapper.template unwrapFastApi<Arg>(
-              context, fastArgs, TypeErrorContext::setterArgument(typeid(T), methodName)));
+              lock, context, fastArgs, TypeErrorContext::setterArgument(typeid(T), methodName)));
     });
   }
 };
@@ -969,7 +988,7 @@ struct DeserializeInvoker<TypeWrapper,
     Ret(Lock&, Tag, Deserializer&, const TypeHandler<Types>&...)> {
   static v8::Local<v8::Object> call(
       TypeWrapper& wrapper, Lock& js, Tag tag, Deserializer& deserializer) {
-    return wrapper.wrap(js.v8Context(), kj::none,
+    return wrapper.wrap(js, js.v8Context(), kj::none,
         T::deserialize(
             js, tag, deserializer, TypeWrapper::template TYPE_HANDLER_INSTANCE<Types>...));
   }
@@ -1122,7 +1141,7 @@ struct WildcardPropertyCallbacks<TypeWrapper,
       auto& lock = Lock::from(isolate);
       KJ_IF_SOME(value, (self.*getNamedMethod)(lock, kj::str(name.As<v8::String>()))) {
         result = v8::Intercepted::kYes;
-        return wrapper.wrap(context, obj, kj::fwd<Ret>(value));
+        return wrapper.wrap(lock, context, obj, kj::fwd<Ret>(value));
       } else {
         // Return an empty handle to indicate the member doesn't exist.
         return {};
@@ -1653,11 +1672,13 @@ class ResourceWrapper {
     return typeid(T);
   }
 
-  v8::Local<v8::Object> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, Ref<T>&& value) {
+  v8::Local<v8::Object> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      Ref<T>&& value) {
     // Wrap a value of type T.
 
-    auto isolate = context->GetIsolate();
+    auto isolate = js.v8Isolate;
 
     KJ_IF_SOME(h, value->tryGetHandle(isolate)) {
       return h;
@@ -1757,7 +1778,8 @@ class ResourceWrapper {
     });
   }
 
-  kj::Maybe<T&> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<T&> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       T*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -1766,7 +1788,7 @@ class ResourceWrapper {
     if (handle->IsObject()) {
       v8::Local<v8::Object> instance =
           v8::Local<v8::Object>::Cast(handle)->FindInstanceInPrototypeChain(
-              getTemplate(context->GetIsolate(), nullptr));
+              getTemplate(js.v8Isolate, nullptr));
       if (!instance.IsEmpty()) {
         return extractInternalPointer<T, false>(context, instance);
       }
@@ -1775,13 +1797,14 @@ class ResourceWrapper {
     return kj::none;
   }
 
-  kj::Maybe<Ref<T>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<Ref<T>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       Ref<T>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
     // Try to unwrap a value of type Ref<T>.
 
-    KJ_IF_SOME(p, tryUnwrap(context, handle, (T*)nullptr, parentObject)) {
+    KJ_IF_SOME(p, tryUnwrap(js, context, handle, (T*)nullptr, parentObject)) {
       return Ref<T>(kj::addRef(p));
     } else {
       return kj::none;
@@ -1888,10 +1911,11 @@ class ObjectWrapper {
   }
 
   // Wrap a value of type T.
-  v8::Local<v8::Object> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Object> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       Ref<Object>&& value) {
-    auto isolate = context->GetIsolate();
+    auto isolate = js.v8Isolate;
 
     KJ_IF_SOME(h, value->tryGetHandle(isolate)) {
       return h;
@@ -1914,7 +1938,8 @@ class ObjectWrapper {
   }
 
   // We do not support unwrapping Ref<Object>; use V8Ref<v8::Object> instead.
-  kj::Maybe<Ref<Object>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<Ref<Object>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       Ref<Object>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) = delete;

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -489,7 +489,7 @@ void IsolateBase::oomError(const char* location, const v8::OOMDetails& oom) {
 
 v8::ModifyCodeGenerationFromStringsResult IsolateBase::modifyCodeGenCallback(
     v8::Local<v8::Context> context, v8::Local<v8::Value> source, bool isCodeLike) {
-  v8::Isolate* isolate = context->GetIsolate();
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
   IsolateBase* self = static_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
   return {.codegen_allowed = self->evalAllowed, .modified_source = {}};
 }
@@ -497,13 +497,13 @@ v8::ModifyCodeGenerationFromStringsResult IsolateBase::modifyCodeGenCallback(
 bool IsolateBase::allowWasmCallback(v8::Local<v8::Context> context, v8::Local<v8::String> source) {
   // Don't allow WASM unless arbitrary eval() is allowed.
   IsolateBase* self =
-      static_cast<IsolateBase*>(context->GetIsolate()->GetData(SET_DATA_ISOLATE_BASE));
+      static_cast<IsolateBase*>(v8::Isolate::GetCurrent()->GetData(SET_DATA_ISOLATE_BASE));
   return self->evalAllowed;
 }
 
 bool IsolateBase::jspiEnabledCallback(v8::Local<v8::Context> context) {
   IsolateBase* self =
-      static_cast<IsolateBase*>(context->GetIsolate()->GetData(SET_DATA_ISOLATE_BASE));
+      static_cast<IsolateBase*>(v8::Isolate::GetCurrent()->GetData(SET_DATA_ISOLATE_BASE));
   return self->jspiEnabled;
 }
 

--- a/src/workerd/jsg/type-wrapper-test.c++
+++ b/src/workerd/jsg/type-wrapper-test.c++
@@ -39,15 +39,17 @@ class TestExtension {
     return "TestExtensionTypeName";
   }
 
-  v8::Local<v8::Number> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Number> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       TestExtensionType value) {
-    return v8::Number::New(context->GetIsolate(), value.value);
+    return v8::Number::New(js.v8Isolate, value.value);
   }
 
   v8::Local<v8::Context> newContext(v8::Isolate* isolate, TestExtensionType value) = delete;
 
-  kj::Maybe<TestExtensionType> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<TestExtensionType> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       TestExtensionType*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -521,7 +521,8 @@ void throwTunneledException(v8::Isolate* isolate, v8::Local<v8::Value> exception
 
 kj::Exception createTunneledException(v8::Isolate* isolate, v8::Local<v8::Value> exception) {
   auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
-  return jsgIsolate.unwrapException(isolate->GetCurrentContext(), exception);
+  auto& js = Lock::from(isolate);
+  return jsgIsolate.unwrapException(js, isolate->GetCurrentContext(), exception);
 }
 
 kj::Exception Lock::exceptionToKj(Value&& exception) {
@@ -571,7 +572,7 @@ kj::Array<kj::byte> asBytes(v8::Local<v8::ArrayBufferView> arrayBufferView) {
 void recursivelyFreeze(v8::Local<v8::Context> context, v8::Local<v8::Value> value) {
   if (value->IsArray()) {
     // Optimize array freezing (Array is a subclass of Object, but we can iterate it faster).
-    v8::HandleScope scope(context->GetIsolate());
+    v8::HandleScope scope(v8::Isolate::GetCurrent());
     auto arr = value.As<v8::Array>();
 
     for (auto i: kj::zeroTo(arr->Length())) {
@@ -580,7 +581,7 @@ void recursivelyFreeze(v8::Local<v8::Context> context, v8::Local<v8::Value> valu
 
     check(arr->SetIntegrityLevel(context, v8::IntegrityLevel::kFrozen));
   } else if (value->IsObject()) {
-    v8::HandleScope scope(context->GetIsolate());
+    v8::HandleScope scope(v8::Isolate::GetCurrent());
     auto obj = value.As<v8::Object>();
     auto names = check(obj->GetPropertyNames(context, v8::KeyCollectionMode::kOwnOnly,
         v8::ALL_PROPERTIES, v8::IndexFilter::kIncludeIndices));

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -29,11 +29,12 @@ namespace workerd::jsg {
 
 // TypeWrapper mixin for numbers and booleans.
 //
-// This wrapper has extra wrap() overloads that take an isolate instead of a context. This is used
-// to implement static constants in JavaScript: we need to be able to wrap C++ constants in V8
-// values before a context has been entered.
+// This wrapper has extra wrap() overloads that take an isolate instead of a
+// lock and a context. This is used to implement static constants in
+// JavaScript: we need to be able to wrap C++ constants in V8 values before a
+// context has been entered.
 //
-// Note that we can't generally change the wrap(context, ...) functions to wrap(isolate, ...)
+// Note that we can't generally change the wrap(js, context, ...) functions to wrap(isolate, ...)
 // because ResourceWrapper<TW, T>::wrap() needs the context to create new object instances.
 class PrimitiveWrapper {
  public:
@@ -41,9 +42,11 @@ class PrimitiveWrapper {
     return "number";
   }
 
-  v8::Local<v8::Number> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, double value) {
-    return wrap(context->GetIsolate(), creator, value);
+  v8::Local<v8::Number> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      double value) {
+    return wrap(js.v8Isolate, creator, value);
   }
 
   v8::Local<v8::Number> wrap(
@@ -51,7 +54,8 @@ class PrimitiveWrapper {
     return v8::Number::New(isolate, value);
   }
 
-  kj::Maybe<double> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<double> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       double*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -62,9 +66,11 @@ class PrimitiveWrapper {
     return "byte";
   }
 
-  v8::Local<v8::Number> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, int8_t value) {
-    return wrap(context->GetIsolate(), creator, value);
+  v8::Local<v8::Number> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      int8_t value) {
+    return wrap(js.v8Isolate, creator, value);
   }
 
   v8::Local<v8::Number> wrap(
@@ -72,7 +78,8 @@ class PrimitiveWrapper {
     return v8::Integer::New(isolate, value);
   }
 
-  kj::Maybe<int8_t> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<int8_t> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       int8_t*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -92,9 +99,11 @@ class PrimitiveWrapper {
     return "octet";
   }
 
-  v8::Local<v8::Number> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, uint8_t value) {
-    return wrap(context->GetIsolate(), creator, value);
+  v8::Local<v8::Number> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      uint8_t value) {
+    return wrap(js.v8Isolate, creator, value);
   }
 
   v8::Local<v8::Number> wrap(
@@ -102,7 +111,8 @@ class PrimitiveWrapper {
     return v8::Integer::NewFromUnsigned(isolate, value);
   }
 
-  kj::Maybe<uint8_t> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<uint8_t> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       uint8_t*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -124,9 +134,11 @@ class PrimitiveWrapper {
     return "short integer";
   }
 
-  v8::Local<v8::Number> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, int16_t value) {
-    return wrap(context->GetIsolate(), creator, value);
+  v8::Local<v8::Number> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      int16_t value) {
+    return wrap(js.v8Isolate, creator, value);
   }
 
   v8::Local<v8::Number> wrap(
@@ -134,7 +146,8 @@ class PrimitiveWrapper {
     return v8::Number::New(isolate, value);
   }
 
-  kj::Maybe<int16_t> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<int16_t> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       int16_t*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -154,9 +167,11 @@ class PrimitiveWrapper {
     return "unsigned short integer";
   }
 
-  v8::Local<v8::Number> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, uint16_t value) {
-    return wrap(context->GetIsolate(), creator, value);
+  v8::Local<v8::Number> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      uint16_t value) {
+    return wrap(js.v8Isolate, creator, value);
   }
 
   v8::Local<v8::Number> wrap(
@@ -164,7 +179,8 @@ class PrimitiveWrapper {
     return v8::Integer::NewFromUnsigned(isolate, value);
   }
 
-  kj::Maybe<uint16_t> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<uint16_t> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       uint16_t*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -186,9 +202,11 @@ class PrimitiveWrapper {
     return "integer";
   }
 
-  v8::Local<v8::Number> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, int value) {
-    return wrap(context->GetIsolate(), creator, value);
+  v8::Local<v8::Number> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      int value) {
+    return wrap(js.v8Isolate, creator, value);
   }
 
   v8::Local<v8::Number> wrap(
@@ -196,7 +214,8 @@ class PrimitiveWrapper {
     return v8::Number::New(isolate, value);
   }
 
-  kj::Maybe<int> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<int> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       int*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -222,9 +241,11 @@ class PrimitiveWrapper {
     return "unsigned integer";
   }
 
-  v8::Local<v8::Number> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, uint32_t value) {
-    return wrap(context->GetIsolate(), creator, value);
+  v8::Local<v8::Number> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      uint32_t value) {
+    return wrap(js.v8Isolate, creator, value);
   }
 
   v8::Local<v8::Number> wrap(
@@ -232,7 +253,8 @@ class PrimitiveWrapper {
     return v8::Integer::NewFromUnsigned(isolate, value);
   }
 
-  kj::Maybe<uint32_t> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<uint32_t> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       uint32_t*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -258,9 +280,11 @@ class PrimitiveWrapper {
     return "bigint";
   }
 
-  v8::Local<v8::BigInt> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, uint64_t value) {
-    return wrap(context->GetIsolate(), creator, value);
+  v8::Local<v8::BigInt> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      uint64_t value) {
+    return wrap(js.v8Isolate, creator, value);
   }
 
   v8::Local<v8::BigInt> wrap(
@@ -268,7 +292,8 @@ class PrimitiveWrapper {
     return v8::BigInt::New(isolate, value);
   }
 
-  kj::Maybe<uint64_t> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<uint64_t> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       uint64_t*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -300,9 +325,11 @@ class PrimitiveWrapper {
     return "bigint";
   }
 
-  v8::Local<v8::BigInt> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, int64_t value) {
-    return wrap(context->GetIsolate(), creator, value);
+  v8::Local<v8::BigInt> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      int64_t value) {
+    return wrap(js.v8Isolate, creator, value);
   }
 
   v8::Local<v8::BigInt> wrap(
@@ -310,7 +337,8 @@ class PrimitiveWrapper {
     return v8::BigInt::New(isolate, value);
   }
 
-  kj::Maybe<int64_t> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<int64_t> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       int64_t*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -340,10 +368,10 @@ class PrimitiveWrapper {
 
   template <typename T, typename = kj::EnableIf<kj::isSameType<T, bool>()>>
   v8::Local<v8::Boolean> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, T value) {
+      Lock& js, v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, T value) {
     // The template is needed to prevent this overload from being chosen for arbitrary types that
     // can convert to bool, such as pointers.
-    return wrap(context->GetIsolate(), creator, value);
+    return wrap(js.v8Isolate, creator, value);
   }
 
   template <typename T, typename = kj::EnableIf<kj::isSameType<T, bool>()>>
@@ -354,11 +382,12 @@ class PrimitiveWrapper {
     return v8::Boolean::New(isolate, value);
   }
 
-  kj::Maybe<bool> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<bool> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       bool*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
-    return handle->ToBoolean(context->GetIsolate())->Value();
+    return handle->ToBoolean(js.v8Isolate)->Value();
   }
 };
 
@@ -371,13 +400,14 @@ class NameWrapper {
     return "string or Symbol";
   }
 
-  v8::Local<v8::Value> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, Name value) {
-    auto isolate = context->GetIsolate();
-    KJ_SWITCH_ONEOF(value.getUnwrapped(isolate)) {
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      Name value) {
+    KJ_SWITCH_ONEOF(value.getUnwrapped(js.v8Isolate)) {
       KJ_CASE_ONEOF(string, kj::StringPtr) {
         auto& wrapper = static_cast<TypeWrapper&>(*this);
-        return wrapper.wrap(isolate, creator, kj::str(string));
+        return wrapper.wrap(js.v8Isolate, creator, kj::str(string));
       }
       KJ_CASE_ONEOF(symbol, v8::Local<v8::Symbol>) {
         return symbol;
@@ -386,18 +416,19 @@ class NameWrapper {
     KJ_UNREACHABLE;
   }
 
-  kj::Maybe<Name> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<Name> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       Name*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
     if (handle->IsSymbol()) {
-      return Name(Lock::from(context->GetIsolate()), handle.As<v8::Symbol>());
+      return Name(js, handle.As<v8::Symbol>());
     }
 
     // Since most things are coercible to a string, this ought to catch pretty much
     // any value other than symbol
     auto& wrapper = static_cast<TypeWrapper&>(*this);
-    KJ_IF_SOME(string, wrapper.tryUnwrap(context, handle, (kj::String*)nullptr, parentObject)) {
+    KJ_IF_SOME(string, wrapper.tryUnwrap(js, context, handle, (kj::String*)nullptr, parentObject)) {
       return Name(kj::mv(string));
     }
 
@@ -441,16 +472,18 @@ class StringWrapper {
     return "DOMString";
   }
 
-  v8::Local<v8::String> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::String> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::ArrayPtr<const char> value) {
-    return v8Str(context->GetIsolate(), value);
+    return v8Str(js.v8Isolate, value);
   }
 
-  v8::Local<v8::String> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::String> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::Array<const char> value) {
-    return wrap(context, creator, value.asPtr());
+    return wrap(js, context, creator, value.asPtr());
   }
 
   v8::Local<v8::String> wrap(
@@ -458,28 +491,31 @@ class StringWrapper {
     return v8Str(isolate, value);
   }
 
-  v8::Local<v8::String> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::String> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       const ByteString& value) {
     // TODO(cleanup): Move to a HeaderStringWrapper in the api directory.
-    return wrap(context, creator, value.asPtr());
+    return wrap(js, context, creator, value.asPtr());
   }
 
-  v8::Local<v8::String> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::String> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       const USVString& value) {
-    return wrap(context, creator, value.asPtr());
+    return wrap(js, context, creator, value.asPtr());
   }
 
-  v8::Local<v8::String> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::String> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       const DOMString& value) {
-    return wrap(context, creator, value.asPtr());
+    return wrap(js, context, creator, value.asPtr());
   }
 
   template <StringLike T>
-  kj::Maybe<T> tryUnwrap(v8::Local<v8::Context> context, const v8::FastOneByteString& handle, T*) {
-    auto& js = Lock::from(context->GetIsolate());
+  kj::Maybe<T> tryUnwrap(
+      Lock& js, v8::Local<v8::Context> context, const v8::FastOneByteString& handle, T*) {
     size_t utf8_length = simdutf::utf8_length_from_latin1(handle.data, handle.length);
     kj::Array<char> buf = kj::heapArray<char>(utf8_length + 1);
     buf[utf8_length] = '\0';
@@ -503,7 +539,8 @@ class StringWrapper {
     }
   }
 
-  kj::Maybe<kj::String> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<kj::String> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       kj::String*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -513,31 +550,34 @@ class StringWrapper {
     // for us to check if handle is a string here or not, ToString does
     // that for us.
     JsString str(check(handle->ToString(context)));
-    return str.toString(Lock::from(context->GetIsolate()));
+    return str.toString(js);
   }
 
-  kj::Maybe<ByteString> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<ByteString> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       ByteString*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
     JsString str(check(handle->ToString(context)));
-    return str.toByteString(Lock::from(context->GetIsolate()));
+    return str.toByteString(js);
   }
 
-  kj::Maybe<USVString> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<USVString> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       USVString*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
     JsString str(check(handle->ToString(context)));
-    return str.toUSVString(Lock::from(context->GetIsolate()));
+    return str.toUSVString(js);
   }
 
-  kj::Maybe<DOMString> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<DOMString> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       DOMString*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
     JsString str(check(handle->ToString(context)));
-    return str.toDOMString(Lock::from(context->GetIsolate()));
+    return str.toDOMString(js);
   }
 };
 
@@ -564,17 +604,20 @@ class OptionalWrapper {
   }
 
   template <typename U>
-  v8::Local<v8::Value> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, Optional<U> ptr) {
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      Optional<U> ptr) {
     KJ_IF_SOME(p, ptr) {
-      return static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::fwd<U>(p));
+      return static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::fwd<U>(p));
     } else {
-      return v8::Undefined(context->GetIsolate());
+      return v8::Undefined(js.v8Isolate);
     }
   }
 
   template <typename U>
-  kj::Maybe<Optional<U>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<Optional<U>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       Optional<U>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -582,7 +625,7 @@ class OptionalWrapper {
       return Optional<U>(kj::none);
     } else {
       return static_cast<TypeWrapper*>(this)
-          ->tryUnwrap(context, handle, (kj::Decay<U>*)nullptr, parentObject)
+          ->tryUnwrap(js, context, handle, (kj::Decay<U>*)nullptr, parentObject)
           .map([](auto&& value) -> Optional<U> { return kj::fwd<decltype(value)>(value); });
     }
   }
@@ -598,18 +641,20 @@ class LenientOptionalWrapper {
   }
 
   template <typename U>
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       LenientOptional<U> ptr) {
     KJ_IF_SOME(p, ptr) {
-      return static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::fwd<U>(p));
+      return static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::fwd<U>(p));
     } else {
-      return v8::Undefined(context->GetIsolate());
+      return v8::Undefined(js.v8Isolate);
     }
   }
 
   template <typename U>
-  kj::Maybe<LenientOptional<U>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<LenientOptional<U>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       LenientOptional<U>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -618,7 +663,7 @@ class LenientOptionalWrapper {
     } else {
       KJ_IF_SOME(unwrapped,
           static_cast<TypeWrapper*>(this)->tryUnwrap(
-              context, handle, (kj::Decay<U>*)nullptr, parentObject)) {
+              js, context, handle, (kj::Decay<U>*)nullptr, parentObject)) {
         return LenientOptional<U>(kj::mv(unwrapped));
       } else {
         return LenientOptional<U>(kj::none);
@@ -644,17 +689,20 @@ class MaybeWrapper {
   }
 
   template <typename U>
-  v8::Local<v8::Value> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, kj::Maybe<U> ptr) {
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      kj::Maybe<U> ptr) {
     KJ_IF_SOME(p, ptr) {
-      return static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::fwd<U>(p));
+      return static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::fwd<U>(p));
     } else {
-      return v8::Null(context->GetIsolate());
+      return v8::Null(js.v8Isolate);
     }
   }
 
   template <typename U>
-  kj::Maybe<kj::Maybe<U>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<kj::Maybe<U>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       kj::Maybe<U>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -665,11 +713,11 @@ class MaybeWrapper {
       // the following tryUnwrap returning a nullptr because of an incorrect type. The
       // noSubstituteNull compatibility flag is needed to fix that.
       return static_cast<TypeWrapper*>(this)
-          ->tryUnwrap(context, handle, (kj::Decay<U>*)nullptr, parentObject)
+          ->tryUnwrap(js, context, handle, (kj::Decay<U>*)nullptr, parentObject)
           .map([](auto&& value) -> kj::Maybe<U> { return kj::fwd<decltype(value)>(value); });
     } else {
       return static_cast<TypeWrapper*>(this)->tryUnwrap(
-          context, handle, (kj::Decay<U>*)nullptr, parentObject);
+          js, context, handle, (kj::Decay<U>*)nullptr, parentObject);
     }
   }
 
@@ -704,12 +752,14 @@ class OneOfWrapper {
   }
 
   template <typename U, typename... V>
-  bool wrapHelper(v8::Local<v8::Context> context,
+  bool wrapHelper(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::OneOf<V...>& in,
       v8::Local<v8::Value>& out) {
     if (in.template is<U>()) {
-      out = static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(in.template get<U>()));
+      out =
+          static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::mv(in.template get<U>()));
       return true;
     } else {
       return false;
@@ -717,30 +767,31 @@ class OneOfWrapper {
   }
 
   template <typename... U>
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::OneOf<U...> value) {
     v8::Local<v8::Value> result;
-    if (!(wrapHelper<U>(context, creator, value, result) || ...)) {
-      result = v8::Undefined(context->GetIsolate());
+    if (!(wrapHelper<U>(js, context, creator, value, result) || ...)) {
+      result = v8::Undefined(js.v8Isolate);
     }
     return result;
   }
 
   template <template <typename> class Predicate, typename U, typename... V>
   bool unwrapHelperRecursive(
-      v8::Local<v8::Context> context, v8::Local<v8::Value> in, kj::OneOf<V...>& out) {
+      Lock& js, v8::Local<v8::Context> context, v8::Local<v8::Value> in, kj::OneOf<V...>& out) {
     if constexpr (isOneOf<U>) {
       // Ugh, a nested OneOf. We can't just call tryUnwrap(), because then our string/numeric
       // coercion might trigger early.
       U val;
-      if (unwrapHelper<Predicate>(context, in, val)) {
+      if (unwrapHelper<Predicate>(js, context, in, val)) {
         out.template init<U>(kj::mv(val));
         return true;
       }
     } else if constexpr (Predicate<kj::Decay<U>>::value) {
       KJ_IF_SOME(val,
-          static_cast<TypeWrapper*>(this)->tryUnwrap(context, in, (U*)nullptr, kj::none)) {
+          static_cast<TypeWrapper*>(this)->tryUnwrap(js, context, in, (U*)nullptr, kj::none)) {
         out.template init<U>(kj::mv(val));
         return true;
       }
@@ -749,8 +800,9 @@ class OneOfWrapper {
   }
 
   template <template <typename> class Predicate, typename... U>
-  bool unwrapHelper(v8::Local<v8::Context> context, v8::Local<v8::Value> in, kj::OneOf<U...>& out) {
-    return (unwrapHelperRecursive<Predicate, U>(context, in, out) || ...);
+  bool unwrapHelper(
+      Lock& js, v8::Local<v8::Context> context, v8::Local<v8::Value> in, kj::OneOf<U...>& out) {
+    return (unwrapHelperRecursive<Predicate, U>(js, context, in, out) || ...);
   }
 
   // Predicates for helping implement nested OneOf unwrapping. These must be struct templates
@@ -779,7 +831,8 @@ class OneOfWrapper {
   };
 
   template <typename... U>
-  kj::Maybe<kj::OneOf<U...>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<kj::OneOf<U...>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       kj::OneOf<U...>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -814,14 +867,14 @@ class OneOfWrapper {
     //
     // TODO(someday): Prove that this is the same algorithm as the one defined by Web IDL.
     kj::OneOf<U...> result;
-    if (unwrapHelper<IsResourceType>(context, handle, result) ||
-        unwrapHelper<IsFallibleType>(context, handle, result) ||
-        (handle->IsBoolean() && unwrapHelper<IsBooleanType>(context, handle, result)) ||
-        (handle->IsNumber() && unwrapHelper<IsNumericType>(context, handle, result)) ||
-        (handle->IsBigInt() && unwrapHelper<IsNumericType>(context, handle, result)) ||
-        (unwrapHelper<IsStringType>(context, handle, result)) ||
-        (unwrapHelper<IsNumericType>(context, handle, result)) ||
-        (unwrapHelper<IsBooleanType>(context, handle, result))) {
+    if (unwrapHelper<IsResourceType>(js, context, handle, result) ||
+        unwrapHelper<IsFallibleType>(js, context, handle, result) ||
+        (handle->IsBoolean() && unwrapHelper<IsBooleanType>(js, context, handle, result)) ||
+        (handle->IsNumber() && unwrapHelper<IsNumericType>(js, context, handle, result)) ||
+        (handle->IsBigInt() && unwrapHelper<IsNumericType>(js, context, handle, result)) ||
+        (unwrapHelper<IsStringType>(js, context, handle, result)) ||
+        (unwrapHelper<IsNumericType>(js, context, handle, result)) ||
+        (unwrapHelper<IsBooleanType>(js, context, handle, result))) {
       return kj::mv(result);
     }
     return kj::none;
@@ -842,44 +895,48 @@ class ArrayWrapper {
   }
 
   template <typename U>
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::Array<U> array) {
-    v8::Isolate* isolate = context->GetIsolate();
+    v8::Isolate* isolate = js.v8Isolate;
     v8::EscapableHandleScope handleScope(isolate);
 
     v8::LocalVector<v8::Value> items(isolate, array.size());
     for (auto n = 0; n < items.size(); n++) {
-      items[n] = static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(array[n]));
+      items[n] = static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::mv(array[n]));
     }
     auto out = v8::Array::New(isolate, items.data(), items.size());
 
     return handleScope.Escape(out);
   }
   template <typename U>
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::ArrayPtr<U> array) {
-    v8::Isolate* isolate = context->GetIsolate();
+    v8::Isolate* isolate = js.v8Isolate;
     v8::EscapableHandleScope handleScope(isolate);
 
     v8::LocalVector<v8::Value> items(isolate, array.size());
     for (auto n = 0; n < items.size(); n++) {
-      items[n] = static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(array[n]));
+      items[n] = static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::mv(array[n]));
     }
     auto out = v8::Array::New(isolate, items.data(), items.size());
 
     return handleScope.Escape(out);
   }
   template <typename U>
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::Array<U>& array) {
-    return static_cast<TypeWrapper*>(this)->wrap(context, creator, array.asPtr());
+    return static_cast<TypeWrapper*>(this)->wrap(js, context, creator, array.asPtr());
   }
 
   template <typename U>
-  kj::Maybe<kj::Array<U>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<kj::Array<U>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       kj::Array<U>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -893,7 +950,7 @@ class ArrayWrapper {
     for (auto i: kj::zeroTo(length)) {
       v8::Local<v8::Value> element = check(array->Get(context, i));
       builder.add(static_cast<TypeWrapper*>(this)->template unwrap<U>(
-          context, element, TypeErrorContext::arrayElement(i)));
+          js, context, element, TypeErrorContext::arrayElement(i)));
     }
     return builder.finish();
   }
@@ -913,24 +970,26 @@ class SetWrapper {
   }
 
   template <typename U>
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::HashSet<U> set) {
-    v8::Isolate* isolate = context->GetIsolate();
+    v8::Isolate* isolate = js.v8Isolate;
     v8::EscapableHandleScope handleScope(isolate);
 
     auto out = v8::Set::New(isolate);
     for (auto& item: set) {
       v8::HandleScope scope(isolate);
-      check(
-          out->Add(context, static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(item))));
+      check(out->Add(
+          context, static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::mv(item))));
     }
 
     return handleScope.Escape(out);
   }
 
   template <typename U>
-  kj::Maybe<kj::HashSet<U>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<kj::HashSet<U>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       kj::HashSet<U>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -946,7 +1005,7 @@ class SetWrapper {
     for (auto i: kj::zeroTo(length)) {
       v8::Local<v8::Value> element = check(array->Get(context, i));
       auto value = static_cast<TypeWrapper*>(this)->template unwrap<U>(
-          context, element, TypeErrorContext::other());
+          js, context, element, TypeErrorContext::other());
       builder.upsert(kj::mv(value), [&](U& existing, U&& replacement) {
         JSG_FAIL_REQUIRE(TypeError, "Duplicate values in the set after unwrapping.");
       });
@@ -1013,6 +1072,13 @@ class ArrayBufferWrapper {
     return "ArrayBuffer or ArrayBufferView";
   }
 
+  v8::Local<v8::ArrayBuffer> wrap(jsg::Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      kj::Array<byte> value) {
+    return wrap(js.v8Isolate, creator, kj::mv(value));
+  }
+
   v8::Local<v8::ArrayBuffer> wrap(
       v8::Isolate* isolate, kj::Maybe<v8::Local<v8::Object>> creator, kj::Array<byte> value) {
     // We need to construct a BackingStore that owns the byte array. We use the version of
@@ -1055,13 +1121,8 @@ class ArrayBufferWrapper {
     }
   }
 
-  v8::Local<v8::ArrayBuffer> wrap(v8::Local<v8::Context> context,
-      kj::Maybe<v8::Local<v8::Object>> creator,
-      kj::Array<byte> value) {
-    return wrap(context->GetIsolate(), creator, kj::mv(value));
-  }
-
-  kj::Maybe<kj::Array<byte>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<kj::Array<byte>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       kj::Array<byte>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -1073,11 +1134,12 @@ class ArrayBufferWrapper {
     return kj::none;
   }
 
-  kj::Maybe<kj::Array<const byte>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<kj::Array<const byte>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       kj::Array<const byte>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
-    return tryUnwrap(context, handle, (kj::Array<byte>*)nullptr, parentObject);
+    return tryUnwrap(js, context, handle, (kj::Array<byte>*)nullptr, parentObject);
   }
 };
 
@@ -1094,25 +1156,28 @@ class DictWrapper {
   }
 
   template <typename K, typename V>
-  v8::Local<v8::Value> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, Dict<V, K> dict) {
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      Dict<V, K> dict) {
     static_assert(webidl::isStringType<K>, "Dicts must be keyed on a string type.");
 
-    v8::Isolate* isolate = context->GetIsolate();
+    v8::Isolate* isolate = js.v8Isolate;
     v8::EscapableHandleScope handleScope(isolate);
     auto out = v8::Object::New(isolate);
     for (auto& field: dict.fields) {
       // Set() returns Maybe<bool>. As usual, if the Maybe is null, then there was an exception,
       // but I have no idea what it means if the Maybe was filled in with the boolean value false...
       KJ_ASSERT(check(out->Set(context,
-          static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(field.name)),
-          static_cast<TypeWrapper*>(this)->wrap(context, creator, kj::mv(field.value)))));
+          static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::mv(field.name)),
+          static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::mv(field.value)))));
     }
     return handleScope.Escape(out);
   }
 
   template <typename K, typename V>
-  kj::Maybe<Dict<V, K>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<Dict<V, K>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       Dict<V, K>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -1123,7 +1188,7 @@ class DictWrapper {
     // Currently the same as wrapper.unwrap<kj::String>(), but this allows us not to bother with the
     // TypeErrorContext, or worrying about whether the tryUnwrap(kj::String*) version will ever be
     // modified to return nullptr in the future.
-    const auto convertToUtf8 = [isolate = context->GetIsolate()](v8::Local<v8::String> v8String) {
+    const auto convertToUtf8 = [isolate = js.v8Isolate](v8::Local<v8::String> v8String) {
       auto buf = kj::heapArray<char>(v8String->Utf8LengthV2(isolate) + 1);
       v8String->WriteUtf8V2(
           isolate, buf.begin(), buf.size(), v8::String::WriteFlags::kNullTerminate);
@@ -1147,21 +1212,21 @@ class DictWrapper {
         const char* cstrName = strName.cStr();
         builder.add(typename Dict<V, K>::Field{kj::mv(strName),
           wrapper.template unwrap<V>(
-              context, value, TypeErrorContext::dictField(cstrName), object)});
+              js, context, value, TypeErrorContext::dictField(cstrName), object)});
       } else {
         // Here we have to be a bit more careful than for the kj::String case. The unwrap<K>() call
         // may throw, but we need the name in UTF-8 for the very exception that it needs to throw.
         // Thus, we do the unwrapping manually and UTF-8-convert the name only if it's needed.
-        auto unwrappedName = wrapper.tryUnwrap(context, name, (K*)nullptr, object);
+        auto unwrappedName = wrapper.tryUnwrap(js, context, name, (K*)nullptr, object);
         if (unwrappedName == kj::none) {
           auto strName = convertToUtf8(name);
-          throwTypeError(context->GetIsolate(), TypeErrorContext::dictKey(strName.cStr()),
+          throwTypeError(js.v8Isolate, TypeErrorContext::dictKey(strName.cStr()),
               TypeWrapper::getName((K*)nullptr));
         }
-        auto unwrappedValue = wrapper.tryUnwrap(context, value, (V*)nullptr, object);
+        auto unwrappedValue = wrapper.tryUnwrap(js, context, value, (V*)nullptr, object);
         if (unwrappedValue == kj::none) {
           auto strName = convertToUtf8(name);
-          throwTypeError(context->GetIsolate(), TypeErrorContext::dictField(strName.cStr()),
+          throwTypeError(js.v8Isolate, TypeErrorContext::dictField(strName.cStr()),
               TypeWrapper::getName((V*)nullptr));
         }
         builder.add(typename Dict<V, K>::Field{
@@ -1182,12 +1247,15 @@ class DateWrapper {
     return "date";
   }
 
-  v8::Local<v8::Value> wrap(
-      v8::Local<v8::Context> context, kj::Maybe<v8::Local<v8::Object>> creator, kj::Date date) {
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      kj::Date date) {
     return check(v8::Date::New(context, (date - kj::UNIX_EPOCH) / kj::MILLISECONDS));
   }
 
-  kj::Maybe<kj::Date> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<kj::Date> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       kj::Date*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -1236,12 +1304,14 @@ class NonCoercibleWrapper {
   }
 
   template <CoercibleType T>
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       NonCoercible<T>) = delete;
 
   template <CoercibleType T>
-  kj::Maybe<NonCoercible<T>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<NonCoercible<T>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       NonCoercible<T>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -1249,7 +1319,7 @@ class NonCoercibleWrapper {
     if constexpr (kj::isSameType<kj::String, T>() || kj::isSameType<jsg::USVString, T>() ||
         kj::isSameType<jsg::DOMString, T>()) {
       if (!handle->IsString()) return kj::none;
-      KJ_IF_SOME(value, wrapper.tryUnwrap(context, handle, (T*)nullptr, parentObject)) {
+      KJ_IF_SOME(value, wrapper.tryUnwrap(js, context, handle, (T*)nullptr, parentObject)) {
         return NonCoercible<T>{
           .value = kj::mv(value),
         };
@@ -1257,14 +1327,14 @@ class NonCoercibleWrapper {
       return kj::none;
     } else if constexpr (kj::isSameType<bool, T>()) {
       if (!handle->IsBoolean()) return kj::none;
-      return wrapper.tryUnwrap(context, handle, (T*)nullptr, parentObject).map([](auto& value) {
+      return wrapper.tryUnwrap(js, context, handle, (T*)nullptr, parentObject).map([](auto& value) {
         return NonCoercible<T>{
           .value = value,
         };
       });
     } else if constexpr (kj::isSameType<double, T>()) {
       if (!handle->IsNumber()) return kj::none;
-      return wrapper.tryUnwrap(context, handle, (T*)nullptr, parentObject).map([](auto& value) {
+      return wrapper.tryUnwrap(js, context, handle, (T*)nullptr, parentObject).map([](auto& value) {
         return NonCoercible<T>{
           .value = value,
         };
@@ -1301,25 +1371,27 @@ class MemoizedIdentityWrapper {
   }
 
   template <typename T>
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       MemoizedIdentity<T>& value) {
     auto& wrapper = static_cast<TypeWrapper&>(*this);
     KJ_SWITCH_ONEOF(value.value) {
       KJ_CASE_ONEOF(raw, T) {
-        auto handle = wrapper.wrap(context, creator, kj::mv(raw));
-        value.value.template init<Value>(context->GetIsolate(), handle);
+        auto handle = wrapper.wrap(js, context, creator, kj::mv(raw));
+        value.value.template init<Value>(js.v8Isolate, handle);
         return handle;
       }
       KJ_CASE_ONEOF(handle, Value) {
-        return handle.getHandle(context->GetIsolate());
+        return handle.getHandle(js.v8Isolate);
       }
     }
     __builtin_unreachable();
   }
 
   template <typename T>
-  kj::Maybe<MemoizedIdentity<T>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<MemoizedIdentity<T>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       MemoizedIdentity<T>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) = delete;
@@ -1337,12 +1409,14 @@ class IdentifiedWrapper {
   }
 
   template <typename T>
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       Identified<T>& value) = delete;
 
   template <typename T>
-  kj::Maybe<Identified<T>> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<Identified<T>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       Identified<T>*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -1351,9 +1425,9 @@ class IdentifiedWrapper {
     }
 
     auto& wrapper = static_cast<TypeWrapper&>(*this);
-    return wrapper.tryUnwrap(context, handle, (T*)nullptr, parentObject)
+    return wrapper.tryUnwrap(js, context, handle, (T*)nullptr, parentObject)
         .map([&](T&& value) -> Identified<T> {
-      auto isolate = context->GetIsolate();
+      auto isolate = js.v8Isolate;
       auto obj = handle.As<v8::Object>();
       return {.identity = {isolate, obj}, .unwrapped = kj::mv(value)};
     });
@@ -1370,16 +1444,18 @@ class SelfRefWrapper {
     return "SelfRef";
   }
 
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       const SelfRef& value) = delete;
 
-  kj::Maybe<SelfRef> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<SelfRef> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       SelfRef*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
     // I'm sticking this here because it's related and I'm lazy.
-    return SelfRef(context->GetIsolate(),
+    return SelfRef(js.v8Isolate,
         KJ_ASSERT_NONNULL(
             parentObject, "SelfRef cannot only be used as a member of a JSG_STRUCT."));
   }
@@ -1403,13 +1479,15 @@ class ExceptionWrapper {
     return "Exception";
   }
 
-  v8::Local<v8::Value> wrap(v8::Local<v8::Context> context,
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::Exception exception) {
-    return makeInternalError(context->GetIsolate(), kj::mv(exception));
+    return makeInternalError(js.v8Isolate, kj::mv(exception));
   }
 
-  kj::Maybe<kj::Exception> tryUnwrap(v8::Local<v8::Context> context,
+  kj::Maybe<kj::Exception> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
       v8::Local<v8::Value> handle,
       kj::Exception*,
       kj::Maybe<v8::Local<v8::Object>> parentObject) {
@@ -1425,7 +1503,6 @@ class ExceptionWrapper {
     // we need to drop down to the C++ interface and generate the kj::Exception
     // ourselves. If any additional JSG_RESOURCE_TYPE error-like things are
     // introduced, they'll need to be handled explicitly here also.
-    auto& js = Lock::from(context->GetIsolate());
     auto& wrapper = TypeWrapper::from(js.v8Isolate);
     kj::Exception result = [&]() {
       kj::Exception::Type excType = [&]() {
@@ -1444,7 +1521,7 @@ class ExceptionWrapper {
       }();
 
       KJ_IF_SOME(domException,
-          wrapper.tryUnwrap(context, handle, (DOMException*)nullptr, parentObject)) {
+          wrapper.tryUnwrap(js, context, handle, (DOMException*)nullptr, parentObject)) {
         return KJ_EXCEPTION(FAILED,
             kj::str("jsg.DOMException(", domException.getName(), "): ", domException.getMessage()));
       } else {

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -376,7 +376,7 @@ void Wrappable::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
 
 v8::Local<v8::Object> Wrappable::attachOpaqueWrapper(
     v8::Local<v8::Context> context, bool needsGcTracing) {
-  auto isolate = context->GetIsolate();
+  auto isolate = v8::Isolate::GetCurrent();
   auto object =
       jsg::check(IsolateBase::getOpaqueTemplate(isolate)->InstanceTemplate()->NewInstance(context));
   attachWrapper(isolate, object, needsGcTracing);


### PR DESCRIPTION
… (#4244)

* Pass a jsg::Lock to wrap and unwrap so we can get the isolate from it

In #4208 we reduced the use of context->GetCurrent since is is only a wrapper around v8::Isolate::GetCurrent.

However, discussion there raised the issue that v8::Isolate::GetCurrent is potentially slow and messy since it gets the isolate from thread-local storage. It was agreed that it would be better to pass the jsg::Lock (which has the isolate) to those functions that need it. This change implements that suggestion.