### PR TITLE
remove AsyncInputStream::read overrides

### DIFF
--- a/src/workerd/util/abortable.h
+++ b/src/workerd/util/abortable.h
@@ -60,12 +60,6 @@ class AbortableInputStream final: public kj::AsyncInputStream, public kj::Refcou
   AbortableInputStream(kj::Own<kj::AsyncInputStream> inner, RefcountedCanceler& canceler)
       : impl(kj::mv(inner), canceler) {}
 
-  kj::Promise<size_t> read(void* buffer, size_t minBytes, size_t maxBytes) override {
-    kj::Promise<size_t> (kj::AsyncInputStream::*read)(void*, size_t, size_t) =
-        &kj::AsyncInputStream::read;
-    return impl.wrap<size_t>(read, buffer, minBytes, maxBytes);
-  }
-
   kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
     kj::Promise<size_t> (kj::AsyncInputStream::*tryRead)(void*, size_t, size_t) =
         &kj::AsyncInputStream::tryRead;

--- a/src/workerd/util/stream-utils.c++
+++ b/src/workerd/util/stream-utils.c++
@@ -63,9 +63,6 @@ class NeuterableInputStreamImpl final: public NeuterableInputStream {
     }
   }
 
-  kj::Promise<size_t> read(void* buffer, size_t minBytes, size_t maxBytes) override {
-    return canceler.wrap(getStream().read(buffer, minBytes, maxBytes));
-  }
   kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
     return canceler.wrap(getStream().tryRead(buffer, minBytes, maxBytes));
   }
@@ -108,9 +105,6 @@ class NeuterableIoStreamImpl final: public NeuterableIoStream {
 
   // AsyncInputStream
 
-  kj::Promise<size_t> read(void* buffer, size_t minBytes, size_t maxBytes) override {
-    return canceler.wrap(getStream().read(buffer, minBytes, maxBytes));
-  }
   kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
     return canceler.wrap(getStream().tryRead(buffer, minBytes, maxBytes));
   }


### PR DESCRIPTION
The method becomes non-virtual in https://github.com/capnproto/capnproto/pull/2319 We can remove overrides now.