### PR TITLE
Explicitly mark glob as unsupported

### DIFF
--- a/src/node/fs.ts
+++ b/src/node/fs.ts
@@ -27,7 +27,7 @@ import {
   fsyncSync,
   ftruncateSync,
   futimesSync,
-  //globSync
+  globSync,
   lchmodSync,
   lchownSync,
   lutimesSync,
@@ -79,7 +79,7 @@ export {
   fsyncSync,
   ftruncateSync,
   futimesSync,
-  //globSync
+  globSync,
   lchmodSync,
   lchownSync,
   lutimesSync,
@@ -134,7 +134,7 @@ export default {
   fsyncSync,
   ftruncateSync,
   futimesSync,
-  //globSync
+  globSync,
   lchmodSync,
   lchownSync,
   lutimesSync,

--- a/src/node/internal/internal_fs_callback.ts
+++ b/src/node/internal/internal_fs_callback.ts
@@ -84,6 +84,9 @@ import {
 import type {
   BigIntStatsFs,
   CopySyncOptions,
+  GlobOptions,
+  GlobOptionsWithFileTypes,
+  GlobOptionsWithoutFileTypes,
   MakeDirectoryOptions,
   OpenDirOptions,
   ReadAsyncOptions,
@@ -1245,6 +1248,21 @@ export function createReadStream(): void {
 }
 export function createWriteStream(): void {
   throw new Error('Not implemented');
+}
+
+export function glob(
+  _pattern: string | readonly string[],
+  _options:
+    | GlobOptions
+    | GlobOptionsWithFileTypes
+    | GlobOptionsWithoutFileTypes,
+  _callback: ErrorOnlyCallback
+): void {
+  // We do not yet implement the globSync function. In Node.js, this
+  // function depends heavily on the third party minimatch library
+  // which is not yet available in the workers runtime. This will be
+  // explored for implementation separately in the future.
+  throw new ERR_UNSUPPORTED_OPERATION();
 }
 
 // An API is considered stubbed if it is not implemented by the function

--- a/src/node/internal/internal_fs_promises.ts
+++ b/src/node/internal/internal_fs_promises.ts
@@ -50,14 +50,21 @@ import {
   type ReadDirOptions,
   type WriteSyncOptions,
 } from 'node-internal:internal_fs_utils';
+import type { Dirent } from 'node-internal:internal_fs';
 import { Buffer } from 'node-internal:internal_buffer';
 import { type Dir } from 'node-internal:internal_fs';
-import { ERR_EBADF } from 'node-internal:internal_errors';
+import {
+  ERR_EBADF,
+  ERR_UNSUPPORTED_OPERATION,
+} from 'node-internal:internal_errors';
 import { validateUint32 } from 'node-internal:validators';
 import * as constants from 'node-internal:internal_fs_constants';
 import type {
   BigIntStatsFs,
   CopySyncOptions,
+  GlobOptions,
+  GlobOptionsWithFileTypes,
+  GlobOptionsWithoutFileTypes,
   MakeDirectoryOptions,
   OpenDirOptions,
   ReadSyncOptions,
@@ -564,4 +571,18 @@ export function writeFile(
     // the promise version does not return anything when successful.
     fssync.writeFileSync(path, data, options);
   });
+}
+
+export function glob(
+  _pattern: string | readonly string[],
+  _options:
+    | GlobOptions
+    | GlobOptionsWithFileTypes
+    | GlobOptionsWithoutFileTypes = {}
+): NodeJS.AsyncIterator<string | Dirent> {
+  // We do not yet implement the globSync function. In Node.js, this
+  // function depends heavily on the third party minimatch library
+  // which is not yet available in the workers runtime. This will be
+  // explored for implementation separately in the future.
+  throw new ERR_UNSUPPORTED_OPERATION();
 }

--- a/src/node/internal/internal_fs_sync.ts
+++ b/src/node/internal/internal_fs_sync.ts
@@ -88,6 +88,9 @@ import { Buffer } from 'node-internal:internal_buffer';
 import type {
   BigIntStatsFs,
   CopySyncOptions,
+  GlobOptions,
+  GlobOptionsWithFileTypes,
+  GlobOptionsWithoutFileTypes,
   MakeDirectoryOptions,
   OpenDirOptions,
   ReadSyncOptions,
@@ -786,6 +789,20 @@ export function writevSync(
   }
 
   return cffs.write(fd, buffers, { position });
+}
+
+export function globSync(
+  _pattern: string | readonly string[],
+  _options:
+    | GlobOptions
+    | GlobOptionsWithFileTypes
+    | GlobOptionsWithoutFileTypes = {}
+): string[] {
+  // We do not yet implement the globSync function. In Node.js, this
+  // function depends heavily on the third party minimatch library
+  // which is not yet available in the workers runtime. This will be
+  // explored for implementation separately in the future.
+  throw new ERR_UNSUPPORTED_OPERATION();
 }
 
 // An API is considered stubbed if it is not implemented by the function

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -466,3 +466,9 @@ wd_test(
     args = ["--experimental"],
     data = ["tests/fs-filehandle-test.js"],
 )
+
+wd_test(
+    src = "tests/fs-glob-test.wd-test",
+    args = ["--experimental"],
+    data = ["tests/fs-glob-test.js"],
+)

--- a/src/workerd/api/node/tests/fs-glob-test.js
+++ b/src/workerd/api/node/tests/fs-glob-test.js
@@ -1,0 +1,25 @@
+import { throws } from 'node:assert';
+import { glob, globSync, promises } from 'node:fs';
+
+function mustNotCall() {
+  throw new Error('This function should not be called');
+}
+
+export const globTest = {
+  test() {
+    // Glob is unsupported currently in workerd.
+    // Verify that we're throwing an error as expected.
+
+    throws(() => glob('*.js', {}, mustNotCall), {
+      code: 'ERR_UNSUPPORTED_OPERATION',
+    });
+
+    throws(() => globSync('*.js', {}), {
+      code: 'ERR_UNSUPPORTED_OPERATION',
+    });
+
+    throws(() => promises.glob('*.js', {}), {
+      code: 'ERR_UNSUPPORTED_OPERATION',
+    });
+  },
+};

--- a/src/workerd/api/node/tests/fs-glob-test.wd-test
+++ b/src/workerd/api/node/tests/fs-glob-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "fs-glob-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "fs-glob-test.js")
+        ],
+        compatibilityDate = "2025-05-01",
+        compatibilityFlags = ["nodejs_compat", "experimental"]
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
The implementation of `node:fs` glob functionality will be provided in the future. For now, it is explicitly marked as unsupported.