### PR TITLE
Python: Add baselineSnapshot to pyodide_extra

### DIFF
--- a/src/pyodide/helpers.bzl
+++ b/src/pyodide/helpers.bzl
@@ -47,6 +47,7 @@ def _fmt_python_snapshot_release(
         pyodide_date,
         packages,
         backport,
+        baseline_snapshot,
         baseline_snapshot_hash,
         flag,
         **_kwds):
@@ -56,6 +57,7 @@ def _fmt_python_snapshot_release(
             'pyodideRevision = "%s"' % pyodide_date,
             'packages = "%s"' % packages,
             "backport = %s" % backport,
+            'baselineSnapshot = "%s"' % baseline_snapshot,
             'baselineSnapshotHash = "%s"' % baseline_snapshot_hash,
             'flagName = "%s"' % flag,
         ],

--- a/src/pyodide/pyodide_extra.capnp
+++ b/src/pyodide/pyodide_extra.capnp
@@ -33,6 +33,8 @@ struct PythonSnapshotRelease @0x89c66fb883cb6975 {
   # For example "2024-02-18".
   backport @3 :Int64;
   # A number that is incremented each time we need to backport a fix to an existing Python release.
+  baselineSnapshot @7 :Text;
+  # Name of the baseline snapshot file for this release in r2
   baselineSnapshotHash @4 :Text;
   # A sha256 checksum hash of the baseline/universal memory snapshot to use for Python Workers using
   # this release.


### PR DESCRIPTION
So that the name of the baseline snapshot is available directly to C++.