### PR TITLE
Reproduction of issue with tail event not serializable

### DIFF
--- a/samples/tail-event-proxy/config.capnp
+++ b/samples/tail-event-proxy/config.capnp
@@ -1,0 +1,35 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const tailWorkerExample :Workerd.Config = (
+  services = [
+    (name = "main", worker = .mainWorker),
+    (name = "proxy", worker = .proxyWorker),
+    (name = "tail", worker = .tailWorker),
+  ],
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ],
+);
+
+const mainWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js")
+  ],
+  compatibilityDate = "2025-05-01",
+  tails = ["proxy"],
+);
+
+const proxyWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "proxy.js")
+  ],
+  compatibilityDate = "2025-05-01",
+  bindings = [
+    (name = "TAIL_WORKER", service = "tail"),
+  ],
+);
+
+const tailWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "tail.js")
+  ],
+  compatibilityDate = "2025-05-01",
+);

--- a/samples/tail-event-proxy/proxy.js
+++ b/samples/tail-event-proxy/proxy.js
@@ -1,0 +1,5 @@
+export default {
+  async tail(events, env) {
+    await env.TAIL_WORKER.tail(events);
+  },
+};

--- a/samples/tail-event-proxy/tail.js
+++ b/samples/tail-event-proxy/tail.js
@@ -1,0 +1,5 @@
+export default {
+  tail(events) {
+    console.log('Tail events', events);
+  },
+};

--- a/samples/tail-event-proxy/worker.js
+++ b/samples/tail-event-proxy/worker.js
@@ -1,0 +1,6 @@
+export default {
+  async fetch(req, env) {
+    console.log('hello to the tail worker!');
+    return new Response("Hello World\n");
+  }
+};


### PR DESCRIPTION
Similar to #3706, we are using a "proxy" Worker placed in front of a user Worker to emulate static asset serving locally. However, it seems like tail events cannot be proxied over a service binding because they aren't serializable.

Would it be possible to make `TraceItem` (or tail events in general) serializable?

To reproduce, run:
```sh
pnpm dlx workerd serve --verbose samples/tail-event-proxy/config.capnp
curl http://localhost:8080
```

You will see an error like this from workerd:

```sh
workerd/io/worker.c++:2126: info: uncaught exception; source = Uncaught (in promise); stack = DataCloneError: Could not serialize object of type "TraceItem". This type does not support serialization.
    at Object.tail (worker:3:27)
workerd/io/io-context.c++:377: info: uncaught exception; exception = workerd/jsg/_virtual_includes/iterator/workerd/jsg/value.h:1526: failed: jsg.DOMException(DataCloneError): Could not serialize object of type "TraceItem". This type does not support serialization.
```