### PR TITLE
chore: bump Workers Analytics cumulative blob limit to 32KB

### DIFF
--- a/src/workerd/api/analytics-engine-impl.h
+++ b/src/workerd/api/analytics-engine-impl.h
@@ -11,7 +11,7 @@ namespace workerd::api {
 constexpr uint MAX_INDEXES_LENGTH = 1;
 constexpr size_t MAX_INDEX_SIZE_IN_BYTES = 96;
 constexpr uint MAX_ARRAY_MEMBERS = 20;
-constexpr size_t MAX_CUMULATIVE_BYTES_IN_BLOBS = 256 * MAX_ARRAY_MEMBERS;
+constexpr size_t MAX_CUMULATIVE_BYTES_IN_BLOBS = 1600 * MAX_ARRAY_MEMBERS;
 
 template <typename Message>
 void setDoubles(Message msg, kj::ArrayPtr<double> arr, kj::StringPtr errorPrefix) {


### PR DESCRIPTION
Increases the limit of maximum number of blob bytes you can write in a single Analytics Engine event from 5120 bytes to 32KB