### PR TITLE
Speed up CI by reusing generated types from test-linux

### DIFF
--- a/.github/workflows/_bazel.yml
+++ b/.github/workflows/_bazel.yml
@@ -97,6 +97,8 @@ jobs:
           # Enable lld identical code folding to significantly reduce binary size.
           echo "build:macos --config=macos_lld_icf" >> .bazelrc
       - name: Configure download mirrors
+        # Temporarily disabled because it is currently causing 404s for packages
+        if: false
         shell: bash
         run: |
           if [ ! -z "${{ secrets.WORKERS_MIRROR_URL }}" ] ; then
@@ -148,6 +150,14 @@ jobs:
           path: bazel-bin/src/workerd/server/workerd${{ runner.os == 'Windows' && '.exe' || '' }}
           if-no-files-found: error
 
+      - name: Upload generated types snapshot
+        if: inputs.upload_types
+        uses: actions/upload-artifact@v4
+        id: upload-generated-snapshot
+        with:
+          name: generated-snapshot
+          path: bazel-bin/types/definitions/
+
       - name: Drop large Bazel cache files
         if: always()
         # Github has a nominal 10GB of storage for all cached builds associated with a project.
@@ -168,3 +178,5 @@ jobs:
       - name: Bazel shutdown
         # Check that there are no .bazelrc issues that prevent shutdown.
         run: bazel shutdown
+    outputs:
+      generated-snapshot-url: ${{ steps.upload-generated-snapshot.outputs.artifact-url }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,7 @@ jobs:
       extra_bazel_args: '--config=ci-test --config=ci-linux'
       upload_test_logs: true
       upload_binary: true
+      upload_types: true
     secrets:
       BAZEL_CACHE_KEY: ${{ secrets.BAZEL_CACHE_KEY }}
       WORKERS_MIRROR_URL: ${{ secrets.WORKERS_MIRROR_URL }}
@@ -106,23 +107,16 @@ jobs:
 
   check-snapshot:
     runs-on: ubuntu-22.04
+    needs: [test-linux]
     steps:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - name: Cache
-        id: cache
-        uses: actions/cache@v4
-        # Use same cache and build configuration as release build, this allows us to keep download
-        # sizes small and generate types with optimization enabled, should be slightly faster.
+      - name: Download snapshot
+        uses: actions/download-artifact@v4
         with:
-          path: ~/bazel-disk-cache
-          key: bazel-disk-cache-release-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}
-      - name: Setup Runner
-        uses: ./.github/actions/setup-runner
-      - name: build types
-        run: |
-          bazel build --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types:types
+          name: generated-snapshot
+          path: bazel-bin/types/definitions
       - name: Check snapshot diff
         run: |
           diff -r types/generated-snapshot/latest bazel-bin/types/definitions/latest > types.diff


### PR DESCRIPTION
The workflow was correct after all, but whatever service is in `secrets.WORKERS_MIRROR_URL` is returning 404s for NodeJS. I just disabled it for now until we investigate. 

No rush on merging this PR; I'll probably do it after I get back from vacation.