### PR TITLE
Fix ambiguous test log path for macOS builds

### DIFF
--- a/.github/workflows/_bazel.yml
+++ b/.github/workflows/_bazel.yml
@@ -156,7 +156,7 @@ jobs:
         if: inputs.upload_test_logs
         uses: actions/upload-artifact@v4
         with:
-          name: test-logs-${{ inputs.os_name }}-${{ runner.arch }}${{ inputs.suffix }}.zip
+          name: test-logs-${{ inputs.os_name }}-${{ inputs.arch_name }}${{ inputs.suffix }}.zip
           path: bazel-testlogs/**/test.xml
       - name: Report disk usage (in MB)
         if: always()


### PR DESCRIPTION
For macOS, we cross-compile both X64 and ARM64 builds on the same runner. This means that using the runner's architecture for the test log name is ambigious.