### PR TITLE
[o11y] Fix disabling tracing for test() event

### DIFF
--- a/src/workerd/api/tail-worker-test-receiver.js
+++ b/src/workerd/api/tail-worker-test-receiver.js
@@ -25,7 +25,7 @@ export const test = {
 
     // The shared tail worker we configured only produces onset and outcome events, so every trace is identical here.
     // Number of traces based on how often main tail worker is invoked from previous tests
-    let numTraces = 21;
+    let numTraces = 20;
     let basicTrace =
       '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"trace","traces":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}';
     assert.deepStrictEqual(

--- a/src/workerd/api/tail-worker-test.js
+++ b/src/workerd/api/tail-worker-test.js
@@ -63,7 +63,6 @@ export const test = {
       // this should be fine in practice.
       '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
       '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // tests/websocket-hibernation.js: hibernatableWebSocket events
       '{"type":"onset","executionModel":"durableObject","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://example.com/","cfJson":"","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',


### PR DESCRIPTION
So far, we only disabled this for tests with entrypoints named "test", which is not the case for all tests.

This will help us support span tracing in production. Two traces that were produced indirectly using a test event (test() -> tail() and test() -> tail() -> tailStream()) have been dropped, for the regular streaming tail worker we were already not producing traces from tests since test() does not produce an onset event.