### PR TITLE
fix: decrease WAE blob limit to 16KB

### DIFF
--- a/src/workerd/api/analytics-engine-impl.h
+++ b/src/workerd/api/analytics-engine-impl.h
@@ -11,7 +11,7 @@ namespace workerd::api {
 constexpr uint MAX_INDEXES_LENGTH = 1;
 constexpr size_t MAX_INDEX_SIZE_IN_BYTES = 96;
 constexpr uint MAX_ARRAY_MEMBERS = 20;
-constexpr size_t MAX_CUMULATIVE_BYTES_IN_BLOBS = 1600 * MAX_ARRAY_MEMBERS;
+constexpr size_t MAX_CUMULATIVE_BYTES_IN_BLOBS = 800 * MAX_ARRAY_MEMBERS;
 
 template <typename Message>
 void setDoubles(Message msg, kj::ArrayPtr<double> arr, kj::StringPtr errorPrefix) {


### PR DESCRIPTION
When talking about increasing the WAE limit there was a miscommunication about how high we can go for the new blob limit, causing us to make it twice as big as we can safely allow.

Follow up to #4319 