### PR TITLE
Remove polyfill-breaking throwing stubs for cwd(), chdir(), umask()

### DIFF
--- a/src/node/internal/internal_process.ts
+++ b/src/node/internal/internal_process.ts
@@ -435,19 +435,22 @@ export function unref(_maybeRefable: unknown): void {
 }
 
 // TODO(soon): Support via experimental FS
-export function chdir(_dir: string): void {
-  throw new ERR_UNSUPPORTED_OPERATION();
-}
+// Non-throwing stub to ensure polyfills still engage
+export const chdir = undefined;
+// export function chdir(_dir: string): void {
+// }
 
 // TODO(soon): Support via experimental FS
-export function cwd(): string {
-  throw new ERR_UNSUPPORTED_OPERATION();
-}
+// Non-throwing stub to ensure polyfills still engage
+export const cwd = undefined;
+// export function cwd(): string {
+// }
 
 // TODO(soon): Support via experimental FS
-export function umask(_mask: string | number): void {
-  throw new ERR_UNSUPPORTED_OPERATION();
-}
+// Non-throwing stub to ensure polyfills still engage
+export const umask = undefined;
+// export function umask(_mask: string | number): void {
+// }
 
 export const hrtime: {
   (time?: [number, number]): [number, number];

--- a/src/workerd/api/node/tests/process-nodejs-test.js
+++ b/src/workerd/api/node/tests/process-nodejs-test.js
@@ -320,6 +320,43 @@ export const processUnsupported = {
   },
 };
 
+// Properties which are undefined and NOT throwing stubs to ensure polyfillability
+// via if (!process.prop) process.prop = polyfill();
+// Some of these might be implemented at future dates.
+export const processUndefined = {
+  test() {
+    // TODO(soon): Implement these!
+    assert.strictEqual(process.cwd, undefined);
+    assert.strictEqual(process.chdir, undefined);
+    assert.strictEqual(process.umask, undefined);
+    assert.strictEqual(process.stdin, undefined);
+    assert.strictEqual(process.stdout, undefined);
+    assert.strictEqual(process.stderr, undefined);
+
+    assert.strictEqual(process.exitCode, undefined);
+    assert.strictEqual(process.channel, undefined);
+    assert.strictEqual(process.connected, undefined);
+    assert.strictEqual(process.binding, undefined);
+    assert.strictEqual(process.debugPort, undefined);
+    assert.strictEqual(process.dlopen, undefined);
+    assert.strictEqual(process.finalization, undefined);
+    assert.strictEqual(process.getActiveResourcesInfo, undefined);
+    assert.strictEqual(process.setUncaughtExceptionCaptureCallback, undefined);
+    assert.strictEqual(process.hasUncaughtExceptionCaptureCallback, undefined);
+    assert.strictEqual(process.memoryUsage, undefined);
+    assert.strictEqual(process.noDeprecation, undefined);
+    assert.strictEqual(process.permission, undefined);
+    assert.strictEqual(process.release, undefined);
+    assert.strictEqual(process.report, undefined);
+    assert.strictEqual(process.resourceUsage, undefined);
+    assert.strictEqual(process.send, undefined);
+    assert.strictEqual(process.traceDeprecation, undefined);
+    assert.strictEqual(process.throwDeprecation, undefined);
+    assert.strictEqual(process.sourceMapsEnabled, undefined);
+    assert.strictEqual(process.threadCpuUsage, undefined);
+  },
+};
+
 export const processVersions = {
   test() {
     assert.strictEqual(typeof process.versions, 'object');


### PR DESCRIPTION
The `process.cwd()` throwing stub caused a break when this was being polyfilled.

This removes the throwing stub for all of `cwd`, `chdir` and `umask`, until these are correctly implemented.

In the mean time tests are added for undefined implementations as distinct from throwing stubs.

Resolves https://github.com/cloudflare/workerd/issues/4338.