### PR TITLE
Extend existing KV test with instrumentation assertions

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -396,7 +396,10 @@ wd_test(
 wd_test(
     src = "kv-test.wd-test",
     args = ["--experimental"],
-    data = ["kv-test.js", "kv-instrumentation-test.js"],
+    data = [
+        "kv-instrumentation-test.js",
+        "kv-test.js",
+    ],
 )
 
 wd_test(

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -396,7 +396,7 @@ wd_test(
 wd_test(
     src = "kv-test.wd-test",
     args = ["--experimental"],
-    data = ["kv-test.js"],
+    data = ["kv-test.js", "kv-instrumentation-test.js"],
 )
 
 wd_test(

--- a/src/workerd/api/kv-instrumentation-test.js
+++ b/src/workerd/api/kv-instrumentation-test.js
@@ -16,7 +16,7 @@ export default {
           break;
         case 'attributes': {
           let span = spans.get(event.spanId);
-          for (let {name, value} of event.event.info) {
+          for (let { name, value } of event.event.info) {
             span[name] = value;
           }
           spans.set(event.spanId, span);
@@ -41,7 +41,9 @@ export const test = {
 
     // Recorded streaming tail worker events, in insertion order,
     // filtering spans not associated with KV
-    let received = Array.from(spans.values()).filter(span => span.name !== 'jsRpcSession');
+    let received = Array.from(spans.values()).filter(
+      (span) => span.name !== 'jsRpcSession'
+    );
 
     // spans emitted by kv-test.js in execution order
     let expected = [
@@ -49,138 +51,138 @@ export const test = {
         name: 'kv_get_bulk',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get_bulk',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get_bulk',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get_bulk',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get_bulk',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get_bulk',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get_bulk',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get_bulk',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get_bulk',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get_bulk',
         'cloudflare.kv.query.parameter.cacheTtl': 100n,
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get_bulk',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get_bulk',
-        closed: true
-      },
-      {
-        name: 'kv_get_bulk',
-        'db.system': 'cloudflare-kv',
-        'cloudflare.kv.operation.name': 'get_bulk',
-        'cloudflare.kv.query.parameter.type': 'json',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get_bulk',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get_bulk',
         'cloudflare.kv.query.parameter.type': 'json',
-        closed: true
+        closed: true,
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        'cloudflare.kv.query.parameter.type': 'json',
+        closed: true,
       },
       {
         name: 'kv_get_bulk',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get_bulk',
         'cloudflare.kv.query.parameter.type': 'arrayBuffer',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get_bulk',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get_bulk',
         'cloudflare.kv.query.parameter.type': 'banana',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_getWithMetadata',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'getWithMetadata',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get_bulk',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get_bulk',
-        closed: true
-      },
-      {
-        name: 'kv_get_bulk',
-        'db.system': 'cloudflare-kv',
-        'cloudflare.kv.operation.name': 'get_bulk',
-        'cloudflare.kv.query.parameter.type': 'json',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get_bulk',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get_bulk',
         'cloudflare.kv.query.parameter.type': 'json',
-        closed: true
+        closed: true,
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        'cloudflare.kv.query.parameter.type': 'json',
+        closed: true,
       },
       {
         name: 'kv_get',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get',
         'cloudflare.kv.query.parameter.type': 'json',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get',
         'cloudflare.kv.query.parameter.type': 'stream',
-        closed: true
+        closed: true,
       },
       {
         name: 'kv_get',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get',
         'cloudflare.kv.query.parameter.type': 'arrayBuffer',
-        closed: true
-      }
+        closed: true,
+      },
     ];
 
     assert.deepStrictEqual(received, expected);

--- a/src/workerd/api/kv-instrumentation-test.js
+++ b/src/workerd/api/kv-instrumentation-test.js
@@ -14,7 +14,11 @@ export default {
     // For each "onset" event, store a promise which we will resolve when
     // we receive the equivalent "outcome" event
     let resolveFn;
-    invocationPromises.push(new Promise((resolve, reject) => { resolveFn = resolve }));
+    invocationPromises.push(
+      new Promise((resolve, reject) => {
+        resolveFn = resolve;
+      })
+    );
 
     // Accumulate the span info for easier testing
     return (event) => {

--- a/src/workerd/api/kv-instrumentation-test.js
+++ b/src/workerd/api/kv-instrumentation-test.js
@@ -1,0 +1,188 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+import * as assert from 'node:assert';
+
+let spans = new Map();
+
+export default {
+  tailStream(event, env, ctx) {
+    // Accumulate the span info for easier testing
+    return (event) => {
+      switch (event.event.type) {
+        case 'spanOpen':
+          // The span ids will change between tests, but Map preserves insertion order
+          spans.set(event.spanId, { name: event.event.name });
+          break;
+        case 'attributes': {
+          let span = spans.get(event.spanId);
+          for (let {name, value} of event.event.info) {
+            span[name] = value;
+          }
+          spans.set(event.spanId, span);
+          break;
+        }
+        case 'spanClose': {
+          let span = spans.get(event.spanId);
+          span['closed'] = true;
+          spans.set(event.spanId, span);
+          break;
+        }
+      }
+    };
+  },
+};
+
+export const test = {
+  async test() {
+    // HACK: The prior tests terminates once the scheduled() invocation has returned a response, but
+    // propagating the outcome of the invocation may take longer. Wait briefly so this can go ahead.
+    await scheduler.wait(50);
+
+    // Recorded streaming tail worker events, in insertion order,
+    // filtering spans not associated with KV
+    let received = Array.from(spans.values()).filter(span => span.name !== 'jsRpcSession');
+
+    // spans emitted by kv-test.js in execution order
+    let expected = [
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        closed: true
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        closed: true
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        closed: true
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        closed: true
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        'cloudflare.kv.query.parameter.cacheTtl': 100n,
+        closed: true
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        closed: true
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        'cloudflare.kv.query.parameter.type': 'json',
+        closed: true
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        'cloudflare.kv.query.parameter.type': 'json',
+        closed: true
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        'cloudflare.kv.query.parameter.type': 'arrayBuffer',
+        closed: true
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        'cloudflare.kv.query.parameter.type': 'banana',
+        closed: true
+      },
+      {
+        name: 'kv_getWithMetadata',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'getWithMetadata',
+        closed: true
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        closed: true
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        'cloudflare.kv.query.parameter.type': 'json',
+        closed: true
+      },
+      {
+        name: 'kv_get_bulk',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get_bulk',
+        'cloudflare.kv.query.parameter.type': 'json',
+        closed: true
+      },
+      {
+        name: 'kv_get',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get',
+        closed: true
+      },
+      {
+        name: 'kv_get',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get',
+        closed: true
+      },
+      {
+        name: 'kv_get',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get',
+        closed: true
+      },
+      {
+        name: 'kv_get',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get',
+        closed: true
+      },
+      {
+        name: 'kv_get',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get',
+        'cloudflare.kv.query.parameter.type': 'json',
+        closed: true
+      },
+      {
+        name: 'kv_get',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get',
+        'cloudflare.kv.query.parameter.type': 'stream',
+        closed: true
+      },
+      {
+        name: 'kv_get',
+        'db.system': 'cloudflare-kv',
+        'cloudflare.kv.operation.name': 'get',
+        'cloudflare.kv.query.parameter.type': 'arrayBuffer',
+        closed: true
+      }
+    ];
+
+    assert.deepStrictEqual(received, expected);
+  },
+};

--- a/src/workerd/api/kv-test.wd-test
+++ b/src/workerd/api/kv-test.wd-test
@@ -23,5 +23,5 @@ const tailWorker :Workerd.Worker = (
     (name = "worker", esModule = embed "kv-instrumentation-test.js")
   ],
   compatibilityDate = "2024-10-14",
-  compatibilityFlags = ["experimental", "nodejs_compat", "streaming_tail_worker"],
+  compatibilityFlags = ["experimental", "nodejs_compat"],
 );

--- a/src/workerd/api/kv-test.wd-test
+++ b/src/workerd/api/kv-test.wd-test
@@ -10,8 +10,18 @@ const unitTests :Workerd.Config = (
         bindings = [ ( name = "KV", kvNamespace = "kv-test" ), ],
         compatibilityDate = "2023-07-24",
         # "experimental" flag is needed to test deleteBulk
-        compatibilityFlags = ["experimental", "nodejs_compat", "service_binding_extra_handlers"],
+        compatibilityFlags = ["experimental", "nodejs_compat", "service_binding_extra_handlers", "streaming_tail_worker", "tail_worker_user_spans"],
+        streamingTails = ["tail"],
       )
     ),
+    (name = "tail", worker = .tailWorker, ),
   ],
+);
+
+const tailWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "kv-instrumentation-test.js")
+  ],
+  compatibilityDate = "2024-10-14",
+  compatibilityFlags = ["experimental", "nodejs_compat", "streaming_tail_worker"],
 );


### PR DESCRIPTION
This sets up a streaming tail worker for the existing KV tests, and then asserts against the telemetry that they emit today. Copies the approach in the [tail worker tests](https://github.com/cloudflare/workerd/blob/main/src/workerd/api/tail-worker-test.js).

There is no KV implementation in workerd so the existing KV tests [mock each response](https://github.com/cloudflare/workerd/blob/main/src/workerd/api/kv-test.js#L9). I could duplicate this logic into a separate test file to not disturb the existing tests, but thought that keeping everything together makes sense. As we extend the instrumentation logic this will likely encourage us to improve the coverage in the existing tests.