### PR TITLE
do not set running to false on container monitor fail

### DIFF
--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -65,7 +65,6 @@ jsg::Promise<void> Container::monitor(jsg::Lock& js) {
       js.throwException(kj::mv(error));
     }
   }, [this](jsg::Lock& js, jsg::Value&& error) {
-    running = false;
     destroyReason = kj::none;
     js.throwException(kj::mv(error));
   });


### PR DESCRIPTION
Currently, we set running to false even if the container API returned a failing response. This pull-request ensures that we're updating "running" correctly.