### PR TITLE
Pass the binding name into the KvNamespace for more descriptive telemetry

### DIFF
--- a/src/workerd/api/kv-instrumentation-test.js
+++ b/src/workerd/api/kv-instrumentation-test.js
@@ -199,8 +199,9 @@ export const test = {
         closed: true,
       },
       {
-        name: 'kv.list',
+        name: 'KV.list',
         'db.system': 'cloudflare.kv',
+        'db.namespace': 'KV',
         'db.operation.name': 'list',
         'cloudflare.binding_type': 'KV',
         'cloudflare.kv.query.prefix': 'te',
@@ -210,8 +211,9 @@ export const test = {
         closed: true,
       },
       {
-        name: 'kv.list',
+        name: 'KV.list',
         'db.system': 'cloudflare.kv',
+        'db.namespace': 'KV',
         'db.operation.name': 'list',
         'cloudflare.binding_type': 'KV',
         'cloudflare.kv.query.prefix': 'te',
@@ -222,8 +224,9 @@ export const test = {
         closed: true,
       },
       {
-        name: 'kv.list',
+        name: 'KV.list',
         'db.system': 'cloudflare.kv',
+        'db.namespace': 'KV',
         'db.operation.name': 'list',
         'cloudflare.binding_type': 'KV',
         'cloudflare.kv.query.prefix': 'not-found',

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -473,11 +473,12 @@ jsg::Promise<jsg::JsRef<jsg::JsValue>> KvNamespace::list(
     jsg::Lock& js, jsg::Optional<ListOptions> options) {
   return js.evalNow([&] {
     auto& context = IoContext::current();
-    auto traceSpan = context.makeTraceSpan("kv.list"_kjc);
-    auto userSpan = context.makeUserTraceSpan("kv.list"_kjc);
+    auto traceSpan = context.makeTraceSpan(kj::ConstString(kj::str(bindingName, ".list")));
+    auto userSpan = context.makeUserTraceSpan(kj::ConstString(kj::str(bindingName, ".list")));
     TraceContext traceContext(kj::mv(traceSpan), kj::mv(userSpan));
 
     traceContext.userSpan.setTag("db.system"_kjc, kj::str("cloudflare.kv"_kjc));
+    traceContext.userSpan.setTag("db.namespace"_kjc, kj::str(bindingName));
     traceContext.userSpan.setTag("db.operation.name"_kjc, kj::str("list"_kjc));
     traceContext.userSpan.setTag("cloudflare.binding_type"_kjc, kj::str("KV"_kjc));
 

--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -35,9 +35,11 @@ class KvNamespace: public jsg::Object {
   // `subrequestChannel` is what to pass to IoContext::getHttpClient() to get an HttpClient
   // representing this namespace. It is also used to construct fetcher for JSRPC methods.
   // `additionalHeaders` is what gets appended to every outbound request.
-  explicit KvNamespace(kj::Array<AdditionalHeader> additionalHeaders, uint subrequestChannel)
+  explicit KvNamespace(
+      kj::String bindingName, kj::Array<AdditionalHeader> additionalHeaders, uint subrequestChannel)
       : additionalHeaders(kj::mv(additionalHeaders)),
-        subrequestChannel(subrequestChannel) {}
+        subrequestChannel(subrequestChannel),
+        bindingName(kj::mv(bindingName)) {}
 
   struct GetOptions {
     jsg::Optional<kj::String> type;
@@ -272,6 +274,7 @@ class KvNamespace: public jsg::Object {
  private:
   kj::Array<AdditionalHeader> additionalHeaders;
   uint subrequestChannel;
+  kj::String bindingName;
 };
 
 #define EW_KV_ISOLATE_TYPES                                                                        \

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3331,7 +3331,8 @@ static kj::Maybe<WorkerdApi::Global> createBinding(kj::StringPtr workerName,
       subrequestChannels.add(
           FutureSubrequestChannel{binding.getKvNamespace(), kj::mv(errorContext)});
 
-      return makeGlobal(Global::KvNamespace{.subrequestChannel = channel});
+      return makeGlobal(Global::KvNamespace{
+        .subrequestChannel = channel, .bindingName = kj::str(binding.getName())});
     }
 
     case config::Worker::Binding::R2_BUCKET: {

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -850,7 +850,7 @@ static v8::Local<v8::Value> createBindingValue(JsgWorkerdIsolate::Lock& lock,
 
     KJ_CASE_ONEOF(ns, Global::KvNamespace) {
       value = lock.wrap(context,
-          lock.alloc<api::KvNamespace>(
+          lock.alloc<api::KvNamespace>(kj::str(ns.bindingName),
               kj::Array<api::KvNamespace::AdditionalHeader>{}, ns.subrequestChannel));
     }
 

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -103,9 +103,11 @@ class WorkerdApi final: public Worker::Api {
     };
     struct KvNamespace {
       uint subrequestChannel;
+      kj::String bindingName;
 
       KvNamespace clone() const {
-        return *this;
+        return KvNamespace{
+          .subrequestChannel = subrequestChannel, .bindingName = kj::str(bindingName)};
       }
     };
     struct R2Bucket {


### PR DESCRIPTION
Depends on https://github.com/cloudflare/workerd/pull/4361

Brings the binding name into the KvNamespace so that instead of a name like `kv.list` you would get a span like `USER_PREFERENCES.list` and also having the binding name available as a `"db.namespace": "USER_PREFERNCES"` attribute.