### PR TITLE
containers: allow setting the exit code from a container runtime, and throw an error instead from jsg Container

### DIFF
--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -56,13 +56,20 @@ jsg::Promise<void> Container::monitor(jsg::Lock& js) {
   JSG_REQUIRE(running, Error, "monitor() cannot be called on a container that is not running.");
 
   return IoContext::current()
-      .awaitIo(js, rpcClient->monitorRequest(capnp::MessageSize{4, 0}).sendIgnoringResult())
-      .then(js, [this](jsg::Lock& js) {
+      .awaitIo(js, rpcClient->monitorRequest(capnp::MessageSize{4, 0}).send())
+      .then(js, [this](jsg::Lock& js, capnp::Response<rpc::Container::MonitorResults> results) {
     running = false;
+    auto exitCode = results.getExitCode();
     KJ_IF_SOME(d, destroyReason) {
       jsg::Value error = kj::mv(d);
       destroyReason = kj::none;
       js.throwException(kj::mv(error));
+    }
+
+    if (exitCode != 0) {
+      auto err = js.error(kj::str("Container exited with unexpected exit code: ", exitCode));
+      KJ_ASSERT_NONNULL(err.tryCast<jsg::JsObject>()).set(js, "exitCode", js.num(exitCode));
+      js.throwException(err);
     }
   }, [this](jsg::Lock& js, jsg::Value&& error) {
     running = false;

--- a/src/workerd/io/container.capnp
+++ b/src/workerd/io/container.capnp
@@ -36,7 +36,7 @@ interface Container @0x9aaceefc06523bca {
     # The container runtime should validate the environment variables input.
   }
 
-  monitor @2 ();
+  monitor @2 () -> (exitCode: Int32);
   # Waits for the container to shut down.
   #
   # If the container shuts down because the root process exited with a success status, or because

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -3,6 +3,29 @@ import assert from 'node:assert';
 import { scheduler } from 'node:timers/promises';
 
 export class DurableObjectExample extends DurableObject {
+  async testExitCode() {
+    const container = this.ctx.container;
+    if (container.running) {
+      let monitor = container.monitor().catch((_err) => {});
+      await container.destroy();
+      await monitor;
+    }
+    assert.strictEqual(container.running, false);
+
+    // Start container with valid configuration
+    await container.start({
+      entrypoint: ['node', 'nonexistant.js'],
+    });
+
+    let exitCode = undefined;
+    await container.monitor().catch((err) => {
+      exitCode = err.exitCode;
+    });
+
+    assert.strictEqual(typeof exitCode, 'number');
+    assert.notEqual(0, exitCode);
+  }
+
   async testBasics() {
     const container = this.ctx.container;
     if (container.running) {
@@ -194,6 +217,15 @@ export const testBasics = {
       const stub = CONTAINER.get(id);
       await stub.testBasics();
     }
+  },
+};
+
+// Test exit code monitor functionality
+export const testExitCode = {
+  async test(_ctrl, env) {
+    const id = env.CONTAINER.idFromName('testExitCode');
+    const stub = env.CONTAINER.get(id);
+    await stub.testExitCode();
   },
 };
 


### PR DESCRIPTION
Allows the user doing:
```javascript
this.ctx.container.monitor().catch(err => console.log(err.exitCode)); // exitCode will be defined if the error is due to the container exiting
```