### PR TITLE
remove unnecessary eslint rules and enable on more files

### DIFF
--- a/src/cloudflare/internal/ai-api.ts
+++ b/src/cloudflare/internal/ai-api.ts
@@ -70,14 +70,14 @@ export type AiModelsSearchObject = {
 };
 
 export class InferenceUpstreamError extends Error {
-  public constructor(message: string, name = 'InferenceUpstreamError') {
+  constructor(message: string, name = 'InferenceUpstreamError') {
     super(message);
     this.name = name;
   }
 }
 
 export class AiInternalError extends Error {
-  public constructor(message: string, name = 'AiInternalError') {
+  constructor(message: string, name = 'AiInternalError') {
     super(message);
     this.name = name;
   }
@@ -112,23 +112,20 @@ export class Ai {
   // @ts-expect-error this option is deprecated, do not use this
   private logs: Array<string> = [];
   private options: AiOptions = {};
-  public lastRequestId: string | null = null;
-  public aiGatewayLogId: string | null = null;
-  public lastRequestHttpStatusCode: number | null = null;
-  public lastRequestInternalStatusCode: number | null = null;
+  lastRequestId: string | null = null;
+  aiGatewayLogId: string | null = null;
+  lastRequestHttpStatusCode: number | null = null;
+  lastRequestInternalStatusCode: number | null = null;
 
-  public constructor(fetcher: Fetcher) {
+  constructor(fetcher: Fetcher) {
     this.fetcher = fetcher;
   }
 
-  public async fetch(
-    input: RequestInfo | URL,
-    init?: RequestInit
-  ): Promise<Response> {
+  async fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     return this.fetcher.fetch(input, init);
   }
 
-  public async run(
+  async run(
     model: string,
     inputs: Record<string, object>,
     options: AiOptions = {}
@@ -191,7 +188,7 @@ export class Ai {
   /*
    * @deprecated this method is deprecated, do not use this
    */
-  public getLogs(): string[] {
+  getLogs(): string[] {
     return [];
   }
 
@@ -222,7 +219,7 @@ export class Ai {
     }
   }
 
-  public async models(
+  async models(
     params: AiModelsSearchParams = {}
   ): Promise<AiModelsSearchObject[]> {
     const url = new URL('https://workers-binding.ai/ai-api/models/search');
@@ -246,18 +243,18 @@ export class Ai {
     }
   }
 
-  public async toMarkdown(
+  async toMarkdown(
     files: { name: string; blob: Blob }[],
     options?: { gateway?: GatewayOptions; extraHeaders?: object }
   ): Promise<ConversionResponse[]>;
-  public async toMarkdown(
+  async toMarkdown(
     files: {
       name: string;
       blob: Blob;
     },
     options?: { gateway?: GatewayOptions; extraHeaders?: object }
   ): Promise<ConversionResponse>;
-  public async toMarkdown(
+  async toMarkdown(
     files: { name: string; blob: Blob } | { name: string; blob: Blob }[],
     options?: { gateway?: GatewayOptions; extraHeaders?: object }
   ): Promise<ConversionResponse | ConversionResponse[]> {
@@ -329,11 +326,11 @@ export class Ai {
     return obj;
   }
 
-  public gateway(gatewayId: string): AiGateway {
+  gateway(gatewayId: string): AiGateway {
     return new AiGateway(this.fetcher, gatewayId);
   }
 
-  public autorag(autoragId?: string): AutoRAG {
+  autorag(autoragId?: string): AutoRAG {
     return new AutoRAG(this.fetcher, autoragId);
   }
 }

--- a/src/cloudflare/internal/aig-api.ts
+++ b/src/cloudflare/internal/aig-api.ts
@@ -110,14 +110,14 @@ export type AIGatewayUniversalRequest = {
 };
 
 export class AiGatewayInternalError extends Error {
-  public constructor(message: string) {
+  constructor(message: string) {
     super(message);
     this.name = 'AiGatewayInternalError';
   }
 }
 
 export class AiGatewayLogNotFound extends Error {
-  public constructor(message: string) {
+  constructor(message: string) {
     super(message);
     this.name = 'AiGatewayLogNotFound';
   }
@@ -145,13 +145,13 @@ export class AiGateway {
   readonly #fetcher: Fetcher;
   readonly #gatewayId: string;
 
-  public constructor(fetcher: Fetcher, gatewayId: string) {
+  constructor(fetcher: Fetcher, gatewayId: string) {
     this.#fetcher = fetcher;
     this.#gatewayId = gatewayId;
   }
 
   // eslint-disable-next-line
-  public async getUrl(provider?: AIGatewayProviders | string): Promise<string> {
+  async getUrl(provider?: AIGatewayProviders | string): Promise<string> {
     const res = await this.#fetcher.fetch(
       `https://workers-binding.ai/ai-gateway/gateways/${this.#gatewayId}/url/${provider ?? 'universal'}`,
       { method: 'GET' }
@@ -166,7 +166,7 @@ export class AiGateway {
     return data.result.url;
   }
 
-  public async getLog(logId: string): Promise<AiGatewayLog> {
+  async getLog(logId: string): Promise<AiGatewayLog> {
     const res = await this.#fetcher.fetch(
       `https://workers-binding.ai/ai-gateway/gateways/${this.#gatewayId}/logs/${logId}`,
       {
@@ -192,7 +192,7 @@ export class AiGateway {
     }
   }
 
-  public async patchLog(logId: string, data: AiGatewayPatchLog): Promise<void> {
+  async patchLog(logId: string, data: AiGatewayPatchLog): Promise<void> {
     const res = await this.#fetcher.fetch(
       `https://workers-binding.ai/ai-gateway/gateways/${this.#gatewayId}/logs/${logId}`,
       {
@@ -217,7 +217,7 @@ export class AiGateway {
     }
   }
 
-  public run(
+  run(
     data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
     options?: { gateway?: GatewayOptions; extraHeaders?: object }
   ): Promise<Response> {

--- a/src/cloudflare/internal/autorag-api.ts
+++ b/src/cloudflare/internal/autorag-api.ts
@@ -7,28 +7,28 @@ interface Fetcher {
 }
 
 export class AutoRAGInternalError extends Error {
-  public constructor(message: string, name = 'AutoRAGInternalError') {
+  constructor(message: string, name = 'AutoRAGInternalError') {
     super(message);
     this.name = name;
   }
 }
 
 export class AutoRAGNotFoundError extends Error {
-  public constructor(message: string, name = 'AutoRAGNotFoundError') {
+  constructor(message: string, name = 'AutoRAGNotFoundError') {
     super(message);
     this.name = name;
   }
 }
 
 export class AutoRAGUnauthorizedError extends Error {
-  public constructor(message: string, name = 'AutoRAGUnauthorizedError') {
+  constructor(message: string, name = 'AutoRAGUnauthorizedError') {
     super(message);
     this.name = name;
   }
 }
 
 export class AutoRAGNameNotSetError extends Error {
-  public constructor(message: string, name = 'AutoRAGNameNotSetError') {
+  constructor(message: string, name = 'AutoRAGNameNotSetError') {
     super(message);
     this.name = name;
   }
@@ -119,12 +119,12 @@ export class AutoRAG {
   readonly #fetcher: Fetcher;
   readonly #autoragId: string | null;
 
-  public constructor(fetcher: Fetcher, autoragId?: string) {
+  constructor(fetcher: Fetcher, autoragId?: string) {
     this.#fetcher = fetcher;
     this.#autoragId = autoragId || null;
   }
 
-  public async list(): Promise<AutoRagListResponse> {
+  async list(): Promise<AutoRagListResponse> {
     const res = await this.#fetcher.fetch(
       `https://workers-binding.ai/autorag/rags`,
       {
@@ -144,9 +144,7 @@ export class AutoRAG {
     return data.result;
   }
 
-  public async search(
-    params: AutoRagSearchRequest
-  ): Promise<AutoRagSearchResponse> {
+  async search(params: AutoRagSearchRequest): Promise<AutoRagSearchResponse> {
     if (!this.#autoragId) {
       throw new AutoRAGNameNotSetError('AutoRAG name not defined');
     }
@@ -180,13 +178,11 @@ export class AutoRAG {
     return data.result;
   }
 
-  public async aiSearch(
-    params: AutoRagAiSearchRequestStreaming
-  ): Promise<Response>;
-  public async aiSearch(
+  async aiSearch(params: AutoRagAiSearchRequestStreaming): Promise<Response>;
+  async aiSearch(
     params: AutoRagAiSearchRequest
   ): Promise<AutoRagAiSearchResponse>;
-  public async aiSearch(
+  async aiSearch(
     params: AutoRagAiSearchRequest
   ): Promise<AutoRagAiSearchResponse | Response> {
     if (!this.#autoragId) {

--- a/src/cloudflare/internal/br-api.ts
+++ b/src/cloudflare/internal/br-api.ts
@@ -9,14 +9,11 @@ interface Fetcher {
 export class BrowserRendering {
   private readonly fetcher: Fetcher;
 
-  public constructor(fetcher: Fetcher) {
+  constructor(fetcher: Fetcher) {
     this.fetcher = fetcher;
   }
 
-  public async fetch(
-    input: RequestInfo | URL,
-    init?: RequestInit
-  ): Promise<Response> {
+  async fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     return this.fetcher.fetch(input, init);
   }
 }

--- a/src/cloudflare/internal/d1-api.ts
+++ b/src/cloudflare/internal/d1-api.ts
@@ -73,28 +73,28 @@ class D1Database {
   private readonly alwaysPrimarySession: D1DatabaseSessionAlwaysPrimary;
   protected readonly fetcher: Fetcher;
 
-  public constructor(fetcher: Fetcher) {
+  constructor(fetcher: Fetcher) {
     this.fetcher = fetcher;
     this.alwaysPrimarySession = new D1DatabaseSessionAlwaysPrimary(
       this.fetcher
     );
   }
 
-  public prepare(query: string): D1PreparedStatement {
+  prepare(query: string): D1PreparedStatement {
     return new D1PreparedStatement(this.alwaysPrimarySession, query);
   }
 
-  public async batch<T = unknown>(
+  async batch<T = unknown>(
     statements: D1PreparedStatement[]
   ): Promise<D1Result<T>[]> {
     return this.alwaysPrimarySession.batch(statements);
   }
 
-  public async exec(query: string): Promise<D1ExecResult> {
+  async exec(query: string): Promise<D1ExecResult> {
     return this.alwaysPrimarySession.exec(query);
   }
 
-  public withSession(
+  withSession(
     constraintOrBookmark?: D1SessionBookmarkOrConstraint
   ): D1DatabaseSession {
     constraintOrBookmark = constraintOrBookmark?.trim();
@@ -107,7 +107,7 @@ class D1Database {
   /**
    * @deprecated
    */
-  public async dump(): Promise<ArrayBuffer> {
+  async dump(): Promise<ArrayBuffer> {
     return this.alwaysPrimarySession.dump();
   }
 }
@@ -116,7 +116,7 @@ class D1DatabaseSession {
   protected fetcher: Fetcher;
   protected bookmarkOrConstraint: D1SessionBookmarkOrConstraint;
 
-  public constructor(
+  constructor(
     fetcher: Fetcher,
     bookmarkOrConstraint: D1SessionBookmarkOrConstraint
   ) {
@@ -152,11 +152,11 @@ class D1DatabaseSession {
     return this.getBookmark();
   }
 
-  public prepare(sql: string): D1PreparedStatement {
+  prepare(sql: string): D1PreparedStatement {
     return new D1PreparedStatement(this, sql);
   }
 
-  public async batch<T = unknown>(
+  async batch<T = unknown>(
     statements: D1PreparedStatement[]
   ): Promise<D1Result<T>[]> {
     const exec = (await this._sendOrThrow(
@@ -170,7 +170,7 @@ class D1DatabaseSession {
 
   // Returns the latest bookmark we received from all responses processed so far.
   // It does not return constraints that might have be passed during the session creation.
-  public getBookmark(): D1SessionBookmark | null {
+  getBookmark(): D1SessionBookmark | null {
     switch (this.bookmarkOrConstraint) {
       // First to any replica, and then anywhere that satisfies the bookmark.
       case D1_SESSION_CONSTRAINT_FIRST_UNCONSTRAINED:
@@ -212,7 +212,7 @@ class D1DatabaseSession {
     });
   }
 
-  public async _sendOrThrow<T = unknown>(
+  async _sendOrThrow<T = unknown>(
     endpoint: string,
     query: string | string[],
     params: unknown[],
@@ -229,7 +229,7 @@ class D1DatabaseSession {
     }
   }
 
-  public async _send<T = unknown>(
+  async _send<T = unknown>(
     endpoint: string,
     query: string | string[],
     params: unknown[],
@@ -281,14 +281,14 @@ class D1DatabaseSession {
 }
 
 class D1DatabaseSessionAlwaysPrimary extends D1DatabaseSession {
-  public constructor(fetcher: Fetcher) {
+  constructor(fetcher: Fetcher) {
     // Will always go to primary, since we won't be ever updating this constraint.
     super(fetcher, D1_SESSION_CONSTRAINT_FIRST_PRIMARY);
   }
 
   // We ignore bookmarks for this special type of session,
   // since all queries are sent to the primary.
-  public override _updateBookmark(
+  override _updateBookmark(
     _newBookmark: D1SessionBookmark
   ): D1SessionBookmark | null {
     return null;
@@ -296,7 +296,7 @@ class D1DatabaseSessionAlwaysPrimary extends D1DatabaseSession {
 
   // There is no bookmark returned ever by this special type of session,
   // since all queries are sent to the primary.
-  public override getBookmark(): D1SessionBookmark | null {
+  override getBookmark(): D1SessionBookmark | null {
     return null;
   }
 
@@ -305,7 +305,7 @@ class D1DatabaseSessionAlwaysPrimary extends D1DatabaseSession {
   // For backwards compatibility they always go to the primary database.
   //
 
-  public async exec(query: string): Promise<D1ExecResult> {
+  async exec(query: string): Promise<D1ExecResult> {
     const lines = query.trim().split('\n');
     const _exec = await this._send('/execute', lines, [], 'NONE');
     const exec = Array.isArray(_exec) ? _exec : [_exec];
@@ -339,7 +339,7 @@ class D1DatabaseSessionAlwaysPrimary extends D1DatabaseSession {
    * DEPRECATED, TO BE REMOVED WITH NEXT BREAKING CHANGE
    * Only applies to the deprecated v1 alpha databases.
    */
-  public async dump(): Promise<ArrayBuffer> {
+  async dump(): Promise<ArrayBuffer> {
     const response = await this._wrappedFetch('http://d1/dump', {
       method: 'POST',
       headers: {
@@ -364,10 +364,10 @@ class D1DatabaseSessionAlwaysPrimary extends D1DatabaseSession {
 
 class D1PreparedStatement {
   private readonly dbSession: D1DatabaseSession;
-  public readonly statement: string;
-  public readonly params: unknown[];
+  readonly statement: string;
+  readonly params: unknown[];
 
-  public constructor(
+  constructor(
     dbSession: D1DatabaseSession,
     statement: string,
     values?: unknown[]
@@ -377,7 +377,7 @@ class D1PreparedStatement {
     this.params = values || [];
   }
 
-  public bind(...values: unknown[]): D1PreparedStatement {
+  bind(...values: unknown[]): D1PreparedStatement {
     // Validate value types
     const transformedValues = values.map((r: unknown): unknown => {
       const rType = typeof r;
@@ -421,9 +421,9 @@ class D1PreparedStatement {
     );
   }
 
-  public async first<T = unknown>(colName: string): Promise<T | null>;
-  public async first<T = Record<string, unknown>>(): Promise<T | null>;
-  public async first<T = unknown>(
+  async first<T = unknown>(colName: string): Promise<T | null>;
+  async first<T = Record<string, unknown>>(): Promise<T | null>;
+  async first<T = unknown>(
     colName?: string
   ): Promise<Record<string, T> | T | null> {
     const info = firstIfArray(
@@ -453,7 +453,7 @@ class D1PreparedStatement {
   }
 
   /* eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters */
-  public async run<T = Record<string, unknown>>(): Promise<D1Response> {
+  async run<T = Record<string, unknown>>(): Promise<D1Response> {
     return firstIfArray(
       await this.dbSession._sendOrThrow<T>(
         '/execute',
@@ -464,7 +464,7 @@ class D1PreparedStatement {
     );
   }
 
-  public async all<T = Record<string, unknown>>(): Promise<D1Result<T[]>> {
+  async all<T = Record<string, unknown>>(): Promise<D1Result<T[]>> {
     return toArrayOfObjects(
       firstIfArray(
         await this.dbSession._sendOrThrow<T[]>(
@@ -477,7 +477,7 @@ class D1PreparedStatement {
     );
   }
 
-  public async raw<T = unknown[]>(options?: D1RawOptions): Promise<T[]> {
+  async raw<T = unknown[]>(options?: D1RawOptions): Promise<T[]> {
     const s = firstIfArray(
       await this.dbSession._sendOrThrow<Record<string, unknown>>(
         '/query',

--- a/src/cloudflare/internal/email.d.ts
+++ b/src/cloudflare/internal/email.d.ts
@@ -5,7 +5,7 @@
 // Type definitions for c++ implementation.
 
 export class EmailMessage {
-  public constructor(from: string, to: string, raw: ReadableStream | string);
-  public readonly from: string;
-  public readonly to: string;
+  constructor(from: string, to: string, raw: ReadableStream | string);
+  readonly from: string;
+  readonly to: string;
 }

--- a/src/cloudflare/internal/images-api.ts
+++ b/src/cloudflare/internal/images-api.ts
@@ -26,9 +26,9 @@ type RawInfoResponse =
     };
 
 class TransformationResultImpl implements ImageTransformationResult {
-  public constructor(private readonly bindingsResponse: Response) {}
+  constructor(private readonly bindingsResponse: Response) {}
 
-  public contentType(): string {
+  contentType(): string {
     const contentType = this.bindingsResponse.headers.get('content-type');
     if (!contentType) {
       throw new ImagesErrorImpl(
@@ -40,11 +40,11 @@ class TransformationResultImpl implements ImageTransformationResult {
     return contentType;
   }
 
-  public image(): ReadableStream<Uint8Array> {
+  image(): ReadableStream<Uint8Array> {
     return this.bindingsResponse.body || new ReadableStream();
   }
 
-  public response(): Response {
+  response(): Response {
     return new Response(this.image(), {
       headers: {
         'content-type': this.contentType(),
@@ -54,9 +54,9 @@ class TransformationResultImpl implements ImageTransformationResult {
 }
 
 class DrawTransformer {
-  public constructor(
-    public readonly child: ImageTransformerImpl,
-    public readonly options: ImageDrawOptions
+  constructor(
+    readonly child: ImageTransformerImpl,
+    readonly options: ImageDrawOptions
   ) {}
 }
 
@@ -64,7 +64,7 @@ class ImageTransformerImpl implements ImageTransformer {
   private transforms: (ImageTransform | DrawTransformer)[];
   private consumed: boolean;
 
-  public constructor(
+  constructor(
     private readonly fetcher: Fetcher,
     private readonly stream: ReadableStream<Uint8Array>
   ) {
@@ -72,12 +72,12 @@ class ImageTransformerImpl implements ImageTransformer {
     this.consumed = false;
   }
 
-  public transform(transform: ImageTransform): this {
+  transform(transform: ImageTransform): this {
     this.transforms.push(transform);
     return this;
   }
 
-  public draw(
+  draw(
     image: ReadableStream<Uint8Array> | ImageTransformer,
     options: ImageDrawOptions = {}
   ): this {
@@ -99,7 +99,7 @@ class ImageTransformerImpl implements ImageTransformer {
     return this;
   }
 
-  public async output(
+  async output(
     options: ImageOutputOptions
   ): Promise<ImageTransformationResult> {
     const formData = new StreamableFormData();
@@ -200,11 +200,9 @@ function isDrawTransformer(input: unknown): input is DrawTransformer {
 }
 
 class ImagesBindingImpl implements ImagesBinding {
-  public constructor(private readonly fetcher: Fetcher) {}
+  constructor(private readonly fetcher: Fetcher) {}
 
-  public async info(
-    stream: ReadableStream<Uint8Array>
-  ): Promise<ImageInfoResponse> {
+  async info(stream: ReadableStream<Uint8Array>): Promise<ImageInfoResponse> {
     const body = new StreamableFormData();
     body.append('image', stream, { type: 'file' });
 
@@ -235,15 +233,15 @@ class ImagesBindingImpl implements ImagesBinding {
     return r;
   }
 
-  public input(stream: ReadableStream<Uint8Array>): ImageTransformer {
+  input(stream: ReadableStream<Uint8Array>): ImageTransformer {
     return new ImageTransformerImpl(this.fetcher, stream);
   }
 }
 
 class ImagesErrorImpl extends Error implements ImagesError {
-  public constructor(
+  constructor(
     message: string,
-    public readonly code: number
+    readonly code: number
   ) {
     super(message);
   }
@@ -323,7 +321,7 @@ class StreamableFormData {
   }[];
   private boundary: string;
 
-  public constructor() {
+  constructor() {
     this.entries = [];
 
     this.boundary = '--------------------------';
@@ -332,7 +330,7 @@ class StreamableFormData {
     }
   }
 
-  public append(
+  append(
     field: string,
     value: ReadableStream | string,
     options?: EntryOptions
@@ -382,11 +380,11 @@ class StreamableFormData {
     return new Blob(['--', this.boundary, '--', CRLF]).stream();
   }
 
-  public contentType(): string {
+  contentType(): string {
     return `multipart/form-data; boundary=${this.boundary}`;
   }
 
-  public stream(): ReadableStream {
+  stream(): ReadableStream {
     const streams: ReadableStream[] = [this.multipartBoundary()];
 
     const valueStreams = [];

--- a/src/cloudflare/internal/pipeline-transform.ts
+++ b/src/cloudflare/internal/pipeline-transform.ts
@@ -91,10 +91,7 @@ export class PipelineTransformImpl<
 
   // stub overridden on the subclass
   // eslint-disable-next-line @typescript-eslint/require-await
-  public async run(
-    _records: I[],
-    _metadata: PipelineBatchMetadata
-  ): Promise<O[]> {
+  async run(_records: I[], _metadata: PipelineBatchMetadata): Promise<O[]> {
     throw new Error('should be implemented by parent');
   }
 

--- a/src/cloudflare/internal/sockets.d.ts
+++ b/src/cloudflare/internal/sockets.d.ts
@@ -5,11 +5,11 @@
 // Type definitions for c++ implementation.
 
 export class Socket {
-  public readonly readable: unknown;
-  public readonly writable: unknown;
-  public readonly closed: Promise<void>;
-  public close(): Promise<void>;
-  public startTls(options: TlsOptions): Socket;
+  readonly readable: unknown;
+  readonly writable: unknown;
+  readonly closed: Promise<void>;
+  close(): Promise<void>;
+  startTls(options: TlsOptions): Socket;
 }
 
 export type TlsOptions = {

--- a/src/cloudflare/internal/vectorize-api.ts
+++ b/src/cloudflare/internal/vectorize-api.ts
@@ -32,14 +32,14 @@ function toNdJson(arr: object[]): string {
  * and not visible to end users.
  */
 class VectorizeIndexImpl implements Vectorize {
-  public constructor(
+  constructor(
     private readonly fetcher: Fetcher,
     private readonly indexId: string,
     private readonly indexVersion: VectorizeVersion,
     private readonly useNdJson: boolean
   ) {}
 
-  public async describe(): Promise<VectorizeIndexInfo> {
+  async describe(): Promise<VectorizeIndexInfo> {
     const endpoint =
       this.indexVersion === 'v2' ? `info` : `binding/indexes/${this.indexId}`;
     const res = await this._send(Operation.INDEX_GET, endpoint, {
@@ -49,7 +49,7 @@ class VectorizeIndexImpl implements Vectorize {
     return await toJson<VectorizeIndexInfo>(res);
   }
 
-  public async query(
+  async query(
     vector: VectorFloatArray | number[],
     options?: VectorizeQueryOptions
   ): Promise<VectorizeMatches> {
@@ -93,7 +93,7 @@ class VectorizeIndexImpl implements Vectorize {
     }
   }
 
-  public async queryById(
+  async queryById(
     vectorId: string,
     options?: VectorizeQueryOptions
   ): Promise<VectorizeMatches> {
@@ -104,9 +104,7 @@ class VectorizeIndexImpl implements Vectorize {
     }
   }
 
-  public async insert(
-    vectors: VectorizeVector[]
-  ): Promise<VectorizeAsyncMutation> {
+  async insert(vectors: VectorizeVector[]): Promise<VectorizeAsyncMutation> {
     const endpoint =
       this.indexVersion === 'v2'
         ? `insert`
@@ -141,9 +139,7 @@ class VectorizeIndexImpl implements Vectorize {
     return await toJson<VectorizeAsyncMutation>(res);
   }
 
-  public async upsert(
-    vectors: VectorizeVector[]
-  ): Promise<VectorizeAsyncMutation> {
+  async upsert(vectors: VectorizeVector[]): Promise<VectorizeAsyncMutation> {
     const endpoint =
       this.indexVersion === 'v2'
         ? `upsert`
@@ -178,7 +174,7 @@ class VectorizeIndexImpl implements Vectorize {
     return await toJson<VectorizeAsyncMutation>(res);
   }
 
-  public async getByIds(ids: string[]): Promise<VectorizeVector[]> {
+  async getByIds(ids: string[]): Promise<VectorizeVector[]> {
     const endpoint =
       this.indexVersion === 'v2'
         ? `getByIds`
@@ -195,7 +191,7 @@ class VectorizeIndexImpl implements Vectorize {
     return await toJson<VectorizeVector[]>(res);
   }
 
-  public async deleteByIds(ids: string[]): Promise<VectorizeAsyncMutation> {
+  async deleteByIds(ids: string[]): Promise<VectorizeAsyncMutation> {
     const endpoint =
       this.indexVersion === 'v2'
         ? `deleteByIds`

--- a/src/cloudflare/internal/vectorize.d.ts
+++ b/src/cloudflare/internal/vectorize.d.ts
@@ -198,14 +198,14 @@ declare abstract class VectorizeIndex {
    * Get information about the currently bound index.
    * @returns A promise that resolves with information about the current index.
    */
-  public describe(): Promise<VectorizeIndexDetails>;
+  describe(): Promise<VectorizeIndexDetails>;
   /**
    * Use the provided vector to perform a similarity search across the index.
    * @param vector Input vector that will be used to drive the similarity search.
    * @param options Configuration options to massage the returned data.
    * @returns A promise that resolves with matched and scored vectors.
    */
-  public query(
+  query(
     vector: VectorFloatArray | number[],
     options?: VectorizeQueryOptions
   ): Promise<VectorizeMatches>;
@@ -214,25 +214,25 @@ declare abstract class VectorizeIndex {
    * @param vectors List of vectors that will be inserted.
    * @returns A promise that resolves with the ids & count of records that were successfully processed.
    */
-  public insert(vectors: VectorizeVector[]): Promise<VectorizeVectorMutation>;
+  insert(vectors: VectorizeVector[]): Promise<VectorizeVectorMutation>;
   /**
    * Upsert a list of vectors into the index dataset. If a provided id exists, it will be replaced with the new values.
    * @param vectors List of vectors that will be upserted.
    * @returns A promise that resolves with the ids & count of records that were successfully processed.
    */
-  public upsert(vectors: VectorizeVector[]): Promise<VectorizeVectorMutation>;
+  upsert(vectors: VectorizeVector[]): Promise<VectorizeVectorMutation>;
   /**
    * Delete a list of vectors with a matching id.
    * @param ids List of vector ids that should be deleted.
    * @returns A promise that resolves with the ids & count of records that were successfully processed (and thus deleted).
    */
-  public deleteByIds(ids: string[]): Promise<VectorizeVectorMutation>;
+  deleteByIds(ids: string[]): Promise<VectorizeVectorMutation>;
   /**
    * Get a list of vectors with a matching id.
    * @param ids List of vector ids that should be returned.
    * @returns A promise that resolves with the raw unscored vectors matching the id set.
    */
-  public getByIds(ids: string[]): Promise<VectorizeVector[]>;
+  getByIds(ids: string[]): Promise<VectorizeVector[]>;
 }
 
 /**
@@ -245,14 +245,14 @@ declare abstract class Vectorize {
    * Get information about the currently bound index.
    * @returns A promise that resolves with information about the current index.
    */
-  public describe(): Promise<VectorizeIndexInfo>;
+  describe(): Promise<VectorizeIndexInfo>;
   /**
    * Use the provided vector to perform a similarity search across the index.
    * @param vector Input vector that will be used to drive the similarity search.
    * @param options Configuration options to massage the returned data.
    * @returns A promise that resolves with matched and scored vectors.
    */
-  public query(
+  query(
     vector: VectorFloatArray | number[],
     options?: VectorizeQueryOptions
   ): Promise<VectorizeMatches>;
@@ -262,7 +262,7 @@ declare abstract class Vectorize {
    * @param options Configuration options to massage the returned data.
    * @returns A promise that resolves with matched and scored vectors.
    */
-  public queryById(
+  queryById(
     vectorId: string,
     options?: VectorizeQueryOptions
   ): Promise<VectorizeMatches>;
@@ -271,23 +271,23 @@ declare abstract class Vectorize {
    * @param vectors List of vectors that will be inserted.
    * @returns A promise that resolves with a unique identifier of a mutation containing the insert changeset.
    */
-  public insert(vectors: VectorizeVector[]): Promise<VectorizeAsyncMutation>;
+  insert(vectors: VectorizeVector[]): Promise<VectorizeAsyncMutation>;
   /**
    * Upsert a list of vectors into the index dataset. If a provided id exists, it will be replaced with the new values.
    * @param vectors List of vectors that will be upserted.
    * @returns A promise that resolves with a unique identifier of a mutation containing the upsert changeset.
    */
-  public upsert(vectors: VectorizeVector[]): Promise<VectorizeAsyncMutation>;
+  upsert(vectors: VectorizeVector[]): Promise<VectorizeAsyncMutation>;
   /**
    * Delete a list of vectors with a matching id.
    * @param ids List of vector ids that should be deleted.
    * @returns A promise that resolves with a unique identifier of a mutation containing the delete changeset.
    */
-  public deleteByIds(ids: string[]): Promise<VectorizeAsyncMutation>;
+  deleteByIds(ids: string[]): Promise<VectorizeAsyncMutation>;
   /**
    * Get a list of vectors with a matching id.
    * @param ids List of vector ids that should be returned.
    * @returns A promise that resolves with the raw unscored vectors matching the id set.
    */
-  public getByIds(ids: string[]): Promise<VectorizeVector[]>;
+  getByIds(ids: string[]): Promise<VectorizeVector[]>;
 }

--- a/src/cloudflare/internal/workers.d.ts
+++ b/src/cloudflare/internal/workers.d.ts
@@ -1,26 +1,26 @@
 export class DurableObject {
-  public constructor(ctx: unknown, env: unknown);
+  constructor(ctx: unknown, env: unknown);
 
-  public ctx: unknown;
-  public env: unknown;
+  ctx: unknown;
+  env: unknown;
 }
 
 export class WorkerEntrypoint {
-  public constructor(ctx: unknown, env: unknown);
+  constructor(ctx: unknown, env: unknown);
 
-  public ctx: unknown;
-  public env: unknown;
+  ctx: unknown;
+  env: unknown;
 }
 
 export class WorkflowEntrypoint {
-  public constructor(ctx: unknown, env: unknown);
+  constructor(ctx: unknown, env: unknown);
 
-  public ctx: unknown;
-  public env: unknown;
+  ctx: unknown;
+  env: unknown;
 }
 
 export class RpcStub {
-  public constructor(server: object);
+  constructor(server: object);
 }
 
 export class RpcTarget {}

--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -3,7 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 export class NonRetryableError extends Error {
-  public constructor(message: string, name = 'NonRetryableError') {
+  constructor(message: string, name = 'NonRetryableError') {
     super(message);
     this.name = name;
   }
@@ -41,44 +41,44 @@ async function callFetcher<T>(
 
 class InstanceImpl implements WorkflowInstance {
   private readonly fetcher: Fetcher;
-  public readonly id: string;
+  readonly id: string;
 
-  public constructor(id: string, fetcher: Fetcher) {
+  constructor(id: string, fetcher: Fetcher) {
     this.id = id;
     this.fetcher = fetcher;
   }
 
-  public async pause(): Promise<void> {
+  async pause(): Promise<void> {
     await callFetcher(this.fetcher, '/pause', {
       id: this.id,
     });
   }
-  public async resume(): Promise<void> {
+  async resume(): Promise<void> {
     await callFetcher(this.fetcher, '/resume', {
       id: this.id,
     });
   }
 
-  public async terminate(): Promise<void> {
+  async terminate(): Promise<void> {
     await callFetcher(this.fetcher, '/terminate', {
       id: this.id,
     });
   }
 
-  public async restart(): Promise<void> {
+  async restart(): Promise<void> {
     await callFetcher(this.fetcher, '/restart', {
       id: this.id,
     });
   }
 
-  public async status(): Promise<InstanceStatus> {
+  async status(): Promise<InstanceStatus> {
     const result = await callFetcher<InstanceStatus>(this.fetcher, '/status', {
       id: this.id,
     });
     return result;
   }
 
-  public async sendEvent({
+  async sendEvent({
     type,
     payload,
   }: {
@@ -96,11 +96,11 @@ class InstanceImpl implements WorkflowInstance {
 class WorkflowImpl {
   private readonly fetcher: Fetcher;
 
-  public constructor(fetcher: Fetcher) {
+  constructor(fetcher: Fetcher) {
     this.fetcher = fetcher;
   }
 
-  public async get(id: string): Promise<WorkflowInstance> {
+  async get(id: string): Promise<WorkflowInstance> {
     const result = await callFetcher<{
       id: string;
     }>(this.fetcher, '/get', { id });
@@ -108,7 +108,7 @@ class WorkflowImpl {
     return new InstanceImpl(result.id, this.fetcher);
   }
 
-  public async create(
+  async create(
     options?: WorkflowInstanceCreateOptions
   ): Promise<WorkflowInstance> {
     const result = await callFetcher<{
@@ -118,7 +118,7 @@ class WorkflowImpl {
     return new InstanceImpl(result.id, this.fetcher);
   }
 
-  public async createBatch(
+  async createBatch(
     options: WorkflowInstanceCreateOptions[]
   ): Promise<WorkflowInstance[]> {
     const results = await callFetcher<

--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -19,7 +19,7 @@ declare abstract class NonRetryableError extends Error {
    * `__brand` is used to differentiate between `NonRetryableError` and `Error`
    * and is omitted from the constructor because users should not set it
    */
-  public constructor(message: string, name?: string);
+  constructor(message: string, name?: string);
 }
 
 declare abstract class Workflow<PARAMS = unknown> {
@@ -28,14 +28,14 @@ declare abstract class Workflow<PARAMS = unknown> {
    * @param id Id for the instance of this Workflow
    * @returns A promise that resolves with a handle for the Instance
    */
-  public get(id: string): Promise<WorkflowInstance>;
+  get(id: string): Promise<WorkflowInstance>;
 
   /**
    * Create a new instance and return a handle to it. If a provided id exists, an error will be thrown.
    * @param options Options when creating an instance including name and params
    * @returns A promise that resolves with a handle for the Instance
    */
-  public create(
+  create(
     options?: WorkflowInstanceCreateOptions<PARAMS>
   ): Promise<WorkflowInstance>;
 
@@ -45,7 +45,7 @@ declare abstract class Workflow<PARAMS = unknown> {
    * @param batch List of Options when creating an instance including name and params
    * @returns A promise that resolves with a list of handles for the created instances.
    */
-  public createBatch(
+  createBatch(
     batch: WorkflowInstanceCreateOptions<PARAMS>[]
   ): Promise<WorkflowInstance[]>;
 }
@@ -106,37 +106,37 @@ interface WorkflowError {
 }
 
 declare abstract class WorkflowInstance {
-  public id: string;
+  id: string;
 
   /**
    * Pause the instance.
    */
-  public pause(): Promise<void>;
+  pause(): Promise<void>;
 
   /**
    * Resume the instance. If it is already running, an error will be thrown.
    */
-  public resume(): Promise<void>;
+  resume(): Promise<void>;
 
   /**
    * Terminate the instance. If it is errored, terminated or complete, an error will be thrown.
    */
-  public terminate(): Promise<void>;
+  terminate(): Promise<void>;
 
   /**
    * Restart the instance.
    */
-  public restart(): Promise<void>;
+  restart(): Promise<void>;
 
   /**
    * Returns the current status of the instance.
    */
-  public status(): Promise<InstanceStatus>;
+  status(): Promise<InstanceStatus>;
 
   /**
    * Send an event to this instance.
    */
-  public sendEvent({
+  sendEvent({
     type,
     payload,
   }: {

--- a/src/node/_stream_duplex.js
+++ b/src/node/_stream_duplex.js
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 //
-/* eslint-disable */
 
 // prettier-ignore
 import {

--- a/src/node/_stream_passthrough.js
+++ b/src/node/_stream_passthrough.js
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 //
-/* eslint-disable */
 import { PassThrough } from 'node-internal:streams_transform';
 export { PassThrough };
 export default PassThrough;

--- a/src/node/_stream_readable.js
+++ b/src/node/_stream_readable.js
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 //
-/* eslint-disable */
 
 // prettier-ignore
 import {

--- a/src/node/_stream_transform.js
+++ b/src/node/_stream_transform.js
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 //
-/* eslint-disable */
 import { Transform } from 'node-internal:streams_transform';
 export { Transform };
 export default Transform;

--- a/src/node/async_hooks.ts
+++ b/src/node/async_hooks.ts
@@ -6,11 +6,11 @@
 import { default as async_hooks } from 'node-internal:async_hooks';
 
 class AsyncHook {
-  public enable(): this {
+  enable(): this {
     return this;
   }
 
-  public disable(): this {
+  disable(): this {
     return this;
   }
 }

--- a/src/node/diagnostics_channel.ts
+++ b/src/node/diagnostics_channel.ts
@@ -87,29 +87,29 @@ export class TracingChannel {
   private [kAsyncEnd]?: ChannelType;
   private [kError]?: ChannelType;
 
-  public constructor() {
+  constructor() {
     throw new Error(
       'Use diagnostic_channel.tracingChannels() to create TracingChannel'
     );
   }
 
-  public get start(): ChannelType | undefined {
+  get start(): ChannelType | undefined {
     return this[kStart];
   }
-  public get end(): ChannelType | undefined {
+  get end(): ChannelType | undefined {
     return this[kEnd];
   }
-  public get asyncStart(): ChannelType | undefined {
+  get asyncStart(): ChannelType | undefined {
     return this[kAsyncStart];
   }
-  public get asyncEnd(): ChannelType | undefined {
+  get asyncEnd(): ChannelType | undefined {
     return this[kAsyncEnd];
   }
-  public get error(): ChannelType | undefined {
+  get error(): ChannelType | undefined {
     return this[kError];
   }
 
-  public subscribe(subscriptions: TracingChannelSubscriptions): void {
+  subscribe(subscriptions: TracingChannelSubscriptions): void {
     if (subscriptions.start !== undefined)
       this[kStart]?.subscribe(subscriptions.start);
     if (subscriptions.end !== undefined)
@@ -122,7 +122,7 @@ export class TracingChannel {
       this[kError]?.subscribe(subscriptions.error);
   }
 
-  public unsubscribe(subscriptions: TracingChannelSubscriptions): void {
+  unsubscribe(subscriptions: TracingChannelSubscriptions): void {
     if (subscriptions.start !== undefined)
       this[kStart]?.unsubscribe(subscriptions.start);
     if (subscriptions.end !== undefined)
@@ -135,7 +135,7 @@ export class TracingChannel {
       this[kError]?.unsubscribe(subscriptions.error);
   }
 
-  public traceSync(
+  traceSync(
     fn: (...args: unknown[]) => unknown,
     context: Record<string, unknown> = {},
     thisArg: unknown = globalThis,
@@ -162,7 +162,7 @@ export class TracingChannel {
     );
   }
 
-  public tracePromise(
+  tracePromise(
     fn: (...args: unknown[]) => unknown,
     context: Record<string, unknown> = {},
     thisArg: unknown = globalThis,
@@ -207,7 +207,7 @@ export class TracingChannel {
     );
   }
 
-  public traceCallback(
+  traceCallback(
     fn: (...args: unknown[]) => unknown,
     position = -1,
     context: Record<string, unknown> = {},

--- a/src/node/dns.ts
+++ b/src/node/dns.ts
@@ -33,77 +33,77 @@ export const resolve = callbackify(dns.resolve.bind(this));
 export const resolveAny = callbackify(dns.resolveAny.bind(this));
 
 export class Resolver {
-  public cancel(): void {
+  cancel(): void {
     // TODO(soon): Implement this.
     throw new Error('Not implemented');
   }
 
-  public setLocalAddress(): void {
+  setLocalAddress(): void {
     // Does not apply to workerd implementation
     throw new Error('Not implemented');
   }
 
-  public getServers(...args: Parameters<typeof getServers>): void {
+  getServers(...args: Parameters<typeof getServers>): void {
     getServers(...args);
   }
 
-  public resolve(...args: Parameters<typeof resolve>): void {
+  resolve(...args: Parameters<typeof resolve>): void {
     resolve(...args);
   }
 
-  public resolve4(...args: Parameters<typeof resolve4>): void {
+  resolve4(...args: Parameters<typeof resolve4>): void {
     resolve4(...args);
   }
 
-  public resolve6(...args: Parameters<typeof resolve6>): void {
+  resolve6(...args: Parameters<typeof resolve6>): void {
     resolve6(...args);
   }
 
-  public resolveAny(...args: Parameters<typeof resolveAny>): void {
+  resolveAny(...args: Parameters<typeof resolveAny>): void {
     resolveAny(...args);
   }
 
-  public resolveCaa(...args: Parameters<typeof resolveCaa>): void {
+  resolveCaa(...args: Parameters<typeof resolveCaa>): void {
     resolveCaa(...args);
   }
 
-  public resolveCname(...args: Parameters<typeof resolveCname>): void {
+  resolveCname(...args: Parameters<typeof resolveCname>): void {
     resolveCname(...args);
   }
 
-  public resolveMx(...args: Parameters<typeof resolveMx>): void {
+  resolveMx(...args: Parameters<typeof resolveMx>): void {
     resolveMx(...args);
   }
 
-  public resolveNaptr(...args: Parameters<typeof resolveNaptr>): void {
+  resolveNaptr(...args: Parameters<typeof resolveNaptr>): void {
     resolveNaptr(...args);
   }
 
-  public resolveNs(...args: Parameters<typeof resolveNs>): void {
+  resolveNs(...args: Parameters<typeof resolveNs>): void {
     resolveNs(...args);
   }
 
-  public resolvePtr(...args: Parameters<typeof resolvePtr>): void {
+  resolvePtr(...args: Parameters<typeof resolvePtr>): void {
     resolvePtr(...args);
   }
 
-  public resolveSoa(...args: Parameters<typeof resolveSoa>): void {
+  resolveSoa(...args: Parameters<typeof resolveSoa>): void {
     resolveSoa(...args);
   }
 
-  public resolveSrv(...args: Parameters<typeof resolveSrv>): void {
+  resolveSrv(...args: Parameters<typeof resolveSrv>): void {
     resolveSrv(...args);
   }
 
-  public resolveTxt(...args: Parameters<typeof resolveTxt>): void {
+  resolveTxt(...args: Parameters<typeof resolveTxt>): void {
     resolveTxt(...args);
   }
 
-  public reverse(...args: Parameters<typeof reverse>): void {
+  reverse(...args: Parameters<typeof reverse>): void {
     reverse(...args);
   }
 
-  public setServers(...args: Parameters<typeof setServers>): void {
+  setServers(...args: Parameters<typeof setServers>): void {
     setServers(...args);
   }
 }

--- a/src/node/internal/async_hooks.d.ts
+++ b/src/node/internal/async_hooks.d.ts
@@ -5,17 +5,14 @@ export interface AsyncResourceOptions {
 }
 
 export class AsyncResource {
-  public constructor(type: string, options?: AsyncResourceOptions);
-  public runInAsyncScope<R>(
-    fn: (...args: unknown[]) => R,
-    ...args: unknown[]
-  ): R;
+  constructor(type: string, options?: AsyncResourceOptions);
+  runInAsyncScope<R>(fn: (...args: unknown[]) => R, ...args: unknown[]): R;
 
-  public bind<Func extends (...args: unknown[]) => unknown>(
+  bind<Func extends (...args: unknown[]) => unknown>(
     fn: Func
   ): Func & { asyncResource: AsyncResource };
 
-  public static bind<
+  static bind<
     Func extends (this: ThisArg, ...args: unknown[]) => unknown,
     ThisArg,
   >(
@@ -26,7 +23,7 @@ export class AsyncResource {
 }
 
 export class AsyncLocalStorage<T> {
-  public run<R>(store: T, fn: (...args: unknown[]) => R, ...args: unknown[]): R;
-  public exit<R>(fn: (...args: unknown[]) => R, ...args: unknown[]): R;
-  public getStore(): T;
+  run<R>(store: T, fn: (...args: unknown[]) => R, ...args: unknown[]): R;
+  exit<R>(fn: (...args: unknown[]) => R, ...args: unknown[]): R;
+  getStore(): T;
 }

--- a/src/node/internal/crypto.d.ts
+++ b/src/node/internal/crypto.d.ts
@@ -31,44 +31,44 @@ export interface CheckOptions {
 }
 
 export class X509Certificate {
-  public static parse(data: ArrayBuffer | ArrayBufferView): X509Certificate;
-  public get subject(): string | undefined;
-  public get subjectAltName(): string | undefined;
-  public get infoAccess(): string | undefined;
-  public get issuer(): string | undefined;
-  public get issuerCert(): X509Certificate | undefined;
-  public get validFrom(): string | undefined;
-  public get validTo(): string | undefined;
-  public get fingerprint(): string | undefined;
-  public get fingerprint256(): string | undefined;
-  public get fingerprint512(): string | undefined;
-  public get keyUsage(): string[] | undefined;
-  public get serialNumber(): string | undefined;
-  public get pem(): string | undefined;
-  public get raw(): ArrayBuffer | undefined;
-  public get publicKey(): CryptoKey | undefined;
-  public get isCA(): boolean;
-  public checkHost(host: string, options?: CheckOptions): string | undefined;
-  public checkEmail(email: string, options?: CheckOptions): string | undefined;
-  public checkIp(ip: string, options?: CheckOptions): string | undefined;
-  public checkIssued(cert: X509Certificate): boolean;
-  public checkPrivateKey(key: CryptoKey): boolean;
-  public verify(key: CryptoKey): boolean;
-  public toLegacyObject(): object;
+  static parse(data: ArrayBuffer | ArrayBufferView): X509Certificate;
+  get subject(): string | undefined;
+  get subjectAltName(): string | undefined;
+  get infoAccess(): string | undefined;
+  get issuer(): string | undefined;
+  get issuerCert(): X509Certificate | undefined;
+  get validFrom(): string | undefined;
+  get validTo(): string | undefined;
+  get fingerprint(): string | undefined;
+  get fingerprint256(): string | undefined;
+  get fingerprint512(): string | undefined;
+  get keyUsage(): string[] | undefined;
+  get serialNumber(): string | undefined;
+  get pem(): string | undefined;
+  get raw(): ArrayBuffer | undefined;
+  get publicKey(): CryptoKey | undefined;
+  get isCA(): boolean;
+  checkHost(host: string, options?: CheckOptions): string | undefined;
+  checkEmail(email: string, options?: CheckOptions): string | undefined;
+  checkIp(ip: string, options?: CheckOptions): string | undefined;
+  checkIssued(cert: X509Certificate): boolean;
+  checkPrivateKey(key: CryptoKey): boolean;
+  verify(key: CryptoKey): boolean;
+  toLegacyObject(): object;
 }
 
 // Hash and Hmac
 export class HashHandle {
-  public constructor(algorithm: string, xofLen: number);
-  public update(data: Buffer | ArrayBufferView): number;
-  public digest(): ArrayBuffer;
-  public copy(xofLen: number): HashHandle;
+  constructor(algorithm: string, xofLen: number);
+  update(data: Buffer | ArrayBufferView): number;
+  digest(): ArrayBuffer;
+  copy(xofLen: number): HashHandle;
 }
 
 export class SignHandle {
-  public constructor(algorithm: string);
-  public update(data: Buffer | ArrayBufferView): void;
-  public sign(
+  constructor(algorithm: string);
+  update(data: Buffer | ArrayBufferView): void;
+  sign(
     key: CryptoKey,
     rsaPadding?: number,
     pssSaltLength?: number,
@@ -77,9 +77,9 @@ export class SignHandle {
 }
 
 export class VerifyHandle {
-  public constructor(algorithm: string);
-  public update(data: Buffer | ArrayBufferView): void;
-  public verify(
+  constructor(algorithm: string);
+  update(data: Buffer | ArrayBufferView): void;
+  verify(
     key: CryptoKey,
     signature: ArrayBufferView,
     rsaPadding?: number,
@@ -107,22 +107,19 @@ export function verifyOneShot(
 ): boolean;
 
 export class CipherHandle {
-  public constructor(
+  constructor(
     mode: 'cipher' | 'decipher',
     algorithm: string,
     key: CryptoKey,
     iv: ArrayBuffer | ArrayBufferView,
     authTagLength?: number
   );
-  public update(data: ArrayBuffer | ArrayBufferView): ArrayBuffer;
-  public final(): ArrayBuffer;
-  public setAAD(
-    data: ArrayBuffer | ArrayBufferView,
-    plaintextLength?: number
-  ): void;
-  public setAutoPadding(autoPadding: boolean): void;
-  public getAuthTag(): ArrayBuffer | undefined;
-  public setAuthTag(tag: ArrayBuffer | ArrayBufferView): void;
+  update(data: ArrayBuffer | ArrayBufferView): ArrayBuffer;
+  final(): ArrayBuffer;
+  setAAD(data: ArrayBuffer | ArrayBufferView, plaintextLength?: number): void;
+  setAutoPadding(autoPadding: boolean): void;
+  getAuthTag(): ArrayBuffer | undefined;
+  setAuthTag(tag: ArrayBuffer | ArrayBufferView): void;
 }
 
 export interface PublicPrivateCipherOptions {
@@ -185,9 +182,9 @@ export function getCipherInfo(
 export type ArrayLike = ArrayBuffer | string | Buffer | ArrayBufferView;
 
 export class HmacHandle {
-  public constructor(algorithm: string, key: ArrayLike | CryptoKey);
-  public update(data: Buffer | ArrayBufferView): number;
-  public digest(): ArrayBuffer;
+  constructor(algorithm: string, key: ArrayLike | CryptoKey);
+  update(data: Buffer | ArrayBufferView): number;
+  digest(): ArrayBuffer;
 }
 
 // hkdf
@@ -459,32 +456,32 @@ export interface GenerateKeyPairOptions {
 
 // DiffieHellman
 export class DiffieHellmanHandle {
-  public constructor(
+  constructor(
     sizeOrKey: number | ArrayBuffer | ArrayBufferView,
     generator: number | ArrayBuffer | ArrayBufferView
   );
-  public setPublicKey(data: ArrayBuffer | ArrayBufferView | Buffer): void;
-  public setPrivateKey(data: ArrayBuffer | ArrayBufferView | Buffer): void;
-  public getPublicKey(): ArrayBuffer;
-  public getPrivateKey(): ArrayBuffer;
-  public getGenerator(): ArrayBuffer;
-  public getPrime(): ArrayBuffer;
+  setPublicKey(data: ArrayBuffer | ArrayBufferView | Buffer): void;
+  setPrivateKey(data: ArrayBuffer | ArrayBufferView | Buffer): void;
+  getPublicKey(): ArrayBuffer;
+  getPrivateKey(): ArrayBuffer;
+  getGenerator(): ArrayBuffer;
+  getPrime(): ArrayBuffer;
 
-  public computeSecret(key: ArrayBuffer | ArrayBufferView): ArrayBuffer;
-  public generateKeys(): ArrayBuffer;
+  computeSecret(key: ArrayBuffer | ArrayBufferView): ArrayBuffer;
+  generateKeys(): ArrayBuffer;
 
-  public getVerifyError(): number;
+  getVerifyError(): number;
 }
 
 export type ECDHFormat = 'compressed' | 'uncompressed' | 'hybrid';
 export class ECDHHandle {
-  public constructor(curveName: string);
-  public computeSecret(otherPublicKey: ArrayBufferView): ArrayBuffer;
-  public generateKeys(): ArrayBuffer;
-  public getPrivateKey(): ArrayBuffer;
-  public getPublicKey(format: ECDHFormat): ArrayBuffer;
-  public setPrivateKey(key: ArrayBufferView): void;
-  public static convertKey(
+  constructor(curveName: string);
+  computeSecret(otherPublicKey: ArrayBufferView): ArrayBuffer;
+  generateKeys(): ArrayBuffer;
+  getPrivateKey(): ArrayBuffer;
+  getPublicKey(format: ECDHFormat): ArrayBuffer;
+  setPrivateKey(key: ArrayBufferView): void;
+  static convertKey(
     key: ArrayBufferView,
     curveName: string,
     format: ECDHFormat

--- a/src/node/internal/crypto_dh.ts
+++ b/src/node/internal/crypto_dh.ts
@@ -62,20 +62,20 @@ import {
 const DH_GENERATOR = 2;
 
 declare class SharedDiffieHellman {
-  public generateKeys: typeof dhGenerateKeys;
-  public computeSecret: typeof dhComputeSecret;
-  public getPrime: typeof dhGetPrime;
-  public getGenerator: typeof dhGetGenerator;
-  public getPublicKey: typeof dhGetPublicKey;
-  public getPrivateKey: typeof dhGetPrivateKey;
-  public setPrivateKey: typeof dhSetPrivateKey;
-  public setPublicKey: typeof dhSetPublicKey;
+  generateKeys: typeof dhGenerateKeys;
+  computeSecret: typeof dhComputeSecret;
+  getPrime: typeof dhGetPrime;
+  getGenerator: typeof dhGetGenerator;
+  getPublicKey: typeof dhGetPublicKey;
+  getPrivateKey: typeof dhGetPrivateKey;
+  setPrivateKey: typeof dhSetPrivateKey;
+  setPublicKey: typeof dhSetPublicKey;
 }
 
 declare class DiffieHellman extends SharedDiffieHellman {
-  public [kHandle]: cryptoImpl.DiffieHellmanHandle;
+  [kHandle]: cryptoImpl.DiffieHellmanHandle;
 
-  public constructor(
+  constructor(
     sizeOrKey: number | ArrayLike,
     keyEncoding?: number | string,
     generator?: number | ArrayLike,
@@ -154,8 +154,8 @@ function DiffieHellman(
 }
 
 declare class DiffieHellmanGroup extends SharedDiffieHellman {
-  public [kHandle]: cryptoImpl.DiffieHellmanHandle;
-  public constructor(name: string);
+  [kHandle]: cryptoImpl.DiffieHellmanHandle;
+  constructor(name: string);
 }
 
 function DiffieHellmanGroup(this: unknown, name: string): DiffieHellmanGroup {

--- a/src/node/internal/crypto_hash.ts
+++ b/src/node/internal/crypto_hash.ts
@@ -68,20 +68,17 @@ interface _kState {
 }
 
 declare class Hash extends Transform {
-  public [kHandle]: cryptoImpl.HashHandle;
-  public [kState]: _kState;
+  [kHandle]: cryptoImpl.HashHandle;
+  [kState]: _kState;
 
-  public constructor(
-    algorithm: string | cryptoImpl.HashHandle,
-    options?: HashOptions
-  );
+  constructor(algorithm: string | cryptoImpl.HashHandle, options?: HashOptions);
 
-  public copy(options?: HashOptions): Hash;
-  public update(
+  copy(options?: HashOptions): Hash;
+  update(
     data: string | Buffer | ArrayBufferView,
     encoding?: string
   ): Hash | Hmac;
-  public digest(outputEncoding?: string): Buffer | string;
+  digest(outputEncoding?: string): Buffer | string;
 }
 
 // These helper functions are needed because the constructors can
@@ -193,19 +190,19 @@ Hash.prototype.digest = function (
 ///////////////////////////
 
 declare class Hmac extends Transform {
-  public [kHandle]: cryptoImpl.HmacHandle;
-  public [kState]: _kState;
-  public constructor(
+  [kHandle]: cryptoImpl.HmacHandle;
+  [kState]: _kState;
+  constructor(
     hmac: string,
     key: ArrayLike | KeyObject | CryptoKey,
     options?: TransformOptions
   );
-  public copy(options?: HashOptions): Hash;
-  public update(
+  copy(options?: HashOptions): Hash;
+  update(
     data: string | Buffer | ArrayBufferView,
     encoding?: string
   ): Hash | Hmac;
-  public digest(outputEncoding?: string): Buffer | string;
+  digest(outputEncoding?: string): Buffer | string;
 }
 
 export function createHmac(

--- a/src/node/internal/crypto_keys.ts
+++ b/src/node/internal/crypto_keys.ts
@@ -140,16 +140,16 @@ function validateExportOptions(
 }
 
 export abstract class KeyObject {
-  public [kHandle]: CryptoKey;
+  [kHandle]: CryptoKey;
 
-  public constructor() {
+  constructor() {
     // KeyObjects cannot be created with new ... use one of the
     // create or generate methods, or use from to get from a
     // CryptoKey.
     throw new Error('Illegal constructor');
   }
 
-  public static from(key: CryptoKey): KeyObject {
+  static from(key: CryptoKey): KeyObject {
     if (!(key instanceof CryptoKey)) {
       throw new ERR_INVALID_ARG_TYPE('key', 'CryptoKey', key);
     }
@@ -181,7 +181,7 @@ export abstract class KeyObject {
     }
   }
 
-  public export(options: ExportOptions = {}): KeyExportResult {
+  export(options: ExportOptions = {}): KeyExportResult {
     validateObject(options, 'options');
 
     validateExportOptions(options, this.type);
@@ -207,7 +207,7 @@ export abstract class KeyObject {
     return ret;
   }
 
-  public equals(otherKeyObject: KeyObject): boolean {
+  equals(otherKeyObject: KeyObject): boolean {
     if (this === otherKeyObject || this[kHandle] === otherKeyObject[kHandle])
       return true;
     if (this.type !== otherKeyObject.type) return false;
@@ -221,9 +221,9 @@ export abstract class KeyObject {
     return cryptoImpl.equals(this[kHandle], otherKeyObject[kHandle]);
   }
 
-  public abstract get type(): KeyObjectType;
+  abstract get type(): KeyObjectType;
 
-  public get [Symbol.toStringTag](): string {
+  get [Symbol.toStringTag](): string {
     return 'KeyObject';
   }
 }
@@ -237,7 +237,7 @@ export function getKeyObjectHandle(obj: KeyObject): CryptoKey {
 }
 
 abstract class AsymmetricKeyObject extends KeyObject {
-  public get asymmetricKeyDetails(): AsymmetricKeyDetails {
+  get asymmetricKeyDetails(): AsymmetricKeyDetails {
     const detail = cryptoImpl.getAsymmetricKeyDetail(this[kHandle]);
     if (isArrayBuffer(detail.publicExponent)) {
       detail.publicExponent = arrayBufferToUnsignedBigInt(
@@ -247,16 +247,16 @@ abstract class AsymmetricKeyObject extends KeyObject {
     return detail;
   }
 
-  public get asymmetricKeyType(): AsymmetricKeyType {
+  get asymmetricKeyType(): AsymmetricKeyType {
     return cryptoImpl.getAsymmetricKeyType(this[kHandle]);
   }
 
-  public toCryptoKey(): void {
+  toCryptoKey(): void {
     // TODO(soon): Implement the toCryptoKey API (added in Node.js 23.0.0)
     throw new ERR_METHOD_NOT_IMPLEMENTED('toCryptoKey');
   }
 
-  public [kInspect](
+  [kInspect](
     depth: number,
     options: {
       depth?: number;
@@ -280,39 +280,39 @@ abstract class AsymmetricKeyObject extends KeyObject {
 }
 
 export class PublicKeyObject extends AsymmetricKeyObject {
-  public override export(options?: PublicKeyExportOptions): KeyExportResult {
+  override export(options?: PublicKeyExportOptions): KeyExportResult {
     return super.export(options);
   }
 
-  public get type(): KeyObjectType {
+  get type(): KeyObjectType {
     return 'public';
   }
 }
 
 export class PrivateKeyObject extends AsymmetricKeyObject {
-  public override export(options?: PrivateKeyExportOptions): KeyExportResult {
+  override export(options?: PrivateKeyExportOptions): KeyExportResult {
     return super.export(options);
   }
 
-  public get type(): KeyObjectType {
+  get type(): KeyObjectType {
     return 'private';
   }
 }
 
 export class SecretKeyObject extends KeyObject {
-  public get symmetricKeySize(): number {
+  get symmetricKeySize(): number {
     return (this[kHandle].algorithm as unknown as string).length | 0;
   }
 
-  public override export(options?: SecretKeyExportOptions): KeyExportResult {
+  override export(options?: SecretKeyExportOptions): KeyExportResult {
     return super.export(options);
   }
 
-  public get type(): KeyObjectType {
+  get type(): KeyObjectType {
     return 'secret';
   }
 
-  public [kInspect](depth: number, options: { depth?: number }): string | this {
+  [kInspect](depth: number, options: { depth?: number }): string | this {
     if (depth < 0) return this;
 
     const opts = {

--- a/src/node/internal/crypto_spkac.ts
+++ b/src/node/internal/crypto_spkac.ts
@@ -62,13 +62,13 @@ export function exportChallenge(
 // rely on any object state.
 
 export declare class Certificate {
-  public constructor();
-  public verifySpkac: typeof verifySpkac;
-  public exportPublicKey: typeof exportPublicKey;
-  public exportChallenge: typeof exportChallenge;
-  public static verifySpkac: typeof verifySpkac;
-  public static exportPublicKey: typeof exportPublicKey;
-  public static exportChallenge: typeof exportChallenge;
+  constructor();
+  verifySpkac: typeof verifySpkac;
+  exportPublicKey: typeof exportPublicKey;
+  exportChallenge: typeof exportChallenge;
+  static verifySpkac: typeof verifySpkac;
+  static exportPublicKey: typeof exportPublicKey;
+  static exportChallenge: typeof exportChallenge;
 }
 
 // For backwards compatibility reasons, this cannot be converted into a

--- a/src/node/internal/internal_dns_promises.ts
+++ b/src/node/internal/internal_dns_promises.ts
@@ -56,84 +56,84 @@ export {
 
 export class Resolver {
   // eslint-disable-next-line @typescript-eslint/require-await
-  public async cancel(): Promise<void> {
+  async cancel(): Promise<void> {
     // TODO(soon): Implement this.
     throw new Error('Not implemented');
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
-  public async setLocalAddress(): Promise<void> {
+  async setLocalAddress(): Promise<void> {
     // Does not apply to workerd implementation
     throw new Error('Not implemented');
   }
 
-  public getServers(): Promise<string[]> {
+  getServers(): Promise<string[]> {
     return getServers();
   }
 
-  public resolve(name: string, rrtype: string): ReturnType<typeof resolve> {
+  resolve(name: string, rrtype: string): ReturnType<typeof resolve> {
     return resolve(name, rrtype);
   }
 
-  public resolve4(
+  resolve4(
     input: string,
     options?: { ttl?: boolean }
   ): Promise<(string | TTLResponse)[]> {
     return resolve4(input, options);
   }
 
-  public resolve6(
+  resolve6(
     input: string,
     options?: { ttl?: boolean }
   ): Promise<(string | TTLResponse)[]> {
     return resolve6(input, options);
   }
 
-  public resolveAny(): Promise<void> {
+  resolveAny(): Promise<void> {
     return resolveAny();
   }
 
-  public resolveCaa(name: string): Promise<CAA[]> {
+  resolveCaa(name: string): Promise<CAA[]> {
     return resolveCaa(name);
   }
 
-  public resolveCname(name: string): Promise<string[]> {
+  resolveCname(name: string): Promise<string[]> {
     return resolveCname(name);
   }
 
-  public resolveMx(name: string): Promise<MX[]> {
+  resolveMx(name: string): Promise<MX[]> {
     return resolveMx(name);
   }
 
-  public resolveNaptr(name: string): Promise<NAPTR[]> {
+  resolveNaptr(name: string): Promise<NAPTR[]> {
     return resolveNaptr(name);
   }
 
-  public resolveNs(name: string): Promise<string[]> {
+  resolveNs(name: string): Promise<string[]> {
     return resolveNs(name);
   }
 
-  public esolvePtr(name: string): Promise<string[]> {
+  esolvePtr(name: string): Promise<string[]> {
     return resolvePtr(name);
   }
 
-  public resolveSoa(name: string): Promise<SOA> {
+  resolveSoa(name: string): Promise<SOA> {
     return resolveSoa(name);
   }
 
-  public resolveSrv(name: string): Promise<SRV[]> {
+  resolveSrv(name: string): Promise<SRV[]> {
     return resolveSrv(name);
   }
 
-  public resolveTxt(name: string): Promise<string[][]> {
+  resolveTxt(name: string): Promise<string[][]> {
     return resolveTxt(name);
   }
 
-  public reverse(name: string): Promise<string[]> {
+  reverse(name: string): Promise<string[]> {
     return reverse(name);
   }
 
-  public setServers(): Promise<void> {
+  setServers(): Promise<void> {
     return setServers();
   }
 }

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -25,9 +25,6 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
-/* eslint-disable */
-
-// TODO(soon): Fill in more of the internal/errors implementation
 
 import { inspect } from 'node-internal:internal_inspect';
 import type { PeerCertificate } from 'node:tls';
@@ -55,7 +52,7 @@ export class NodeErrorAbstraction extends Error {
     this.name = name;
   }
 
-  override toString() {
+  override toString(): string {
     return `${this.name} [${this.code}]: ${this.message}`;
   }
 }
@@ -70,7 +67,7 @@ export class NodeRangeError extends NodeErrorAbstraction {
   constructor(code: string, message: string) {
     super(RangeError.prototype.name, code, message);
     Object.setPrototypeOf(this, RangeError.prototype);
-    this.toString = function () {
+    this.toString = function (): string {
       return `${this.name} [${this.code}]: ${this.message}`;
     };
   }
@@ -80,7 +77,7 @@ export class NodeTypeError extends NodeErrorAbstraction implements TypeError {
   constructor(code: string, message: string) {
     super(TypeError.prototype.name, code, message);
     Object.setPrototypeOf(this, TypeError.prototype);
-    this.toString = function () {
+    this.toString = function (): string {
       return `${this.name} [${this.code}]: ${this.message}`;
     };
   }
@@ -93,7 +90,7 @@ export class NodeSyntaxError
   constructor(code: string, message: string) {
     super(SyntaxError.prototype.name, code, message);
     Object.setPrototypeOf(this, SyntaxError.prototype);
-    this.toString = function () {
+    this.toString = function (): string {
       return `${this.name} [${this.code}]: ${this.message}`;
     };
   }
@@ -174,8 +171,7 @@ function createInvalidArgType(
     } else if (other.length === 2) {
       msg += `one of ${other[0]} or ${other[1]}`;
     } else {
-      // @ts-ignore
-      if (other[0].toLowerCase() !== other[0]) {
+      if (other[0]?.toLowerCase() !== other[0]) {
         msg += 'an ';
       }
       msg += `${other[0]}`;
@@ -185,7 +181,7 @@ function createInvalidArgType(
   return msg;
 }
 
-function invalidArgTypeHelper(input: any) {
+function invalidArgTypeHelper(input: unknown): string {
   if (input == null) {
     return ` Received ${input}`;
   }
@@ -193,7 +189,8 @@ function invalidArgTypeHelper(input: any) {
     return ` Received function ${input.name}`;
   }
   if (typeof input === 'object') {
-    if (input.constructor && input.constructor.name) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (input.constructor?.name) {
       return ` Received an instance of ${input.constructor.name}`;
     }
     return ` Received ${inspect(input, { depth: -1 })}`;
@@ -205,7 +202,7 @@ function invalidArgTypeHelper(input: any) {
   return ` Received type ${typeof input} (${inspected})`;
 }
 
-function addNumericalSeparator(val: string) {
+function addNumericalSeparator(val: string): string {
   let res = '';
   let i = val.length;
   const start = val[0] === '-' ? 1 : 0;
@@ -329,6 +326,7 @@ export class ERR_OUT_OF_RANGE extends RangeError {
     // Add the error code to the name to include it in the stack trace.
     this.name = `${name} [${this.code}]`;
     // Access the stack to generate the error message including the error code from the name.
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     this.stack;
     // Reset the name to the actual name.
     this.name = name;
@@ -392,18 +390,20 @@ export class AbortError extends Error {
   }
 }
 
-function determineSpecificType(value: any) {
+function determineSpecificType(value: unknown): string {
   if (value == null) {
+    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
     return '' + value;
   }
   if (typeof value === 'function' && value.name) {
     return `function ${value.name}`;
   }
   if (typeof value === 'object') {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (value.constructor?.name) {
       return `an instance of ${value.constructor.name}`;
     }
-    return `${inspect(value, { depth: -1 })}`;
+    return inspect(value, { depth: -1 });
   }
   let inspected = inspect(value, { colors: false });
   if (inspected.length > 28) inspected = `${inspected.slice(0, 25)}...`;
@@ -440,7 +440,7 @@ export class ERR_MISSING_ARGS extends NodeTypeError {
 
     const len = args.length;
 
-    const wrap = (a: unknown) => `"${a}"`;
+    const wrap = (a: unknown): string => `"${a}"`;
 
     args = args.map((a) =>
       Array.isArray(a) ? a.map(wrap).join(' or ') : wrap(a)
@@ -463,6 +463,7 @@ export class ERR_MISSING_ARGS extends NodeTypeError {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents,@typescript-eslint/no-duplicate-type-constituents
 export type Falsy = false | 0 | -0 | 0n | '' | null | undefined | typeof NaN;
 export class ERR_FALSY_VALUE_REJECTION extends NodeError {
   reason: Falsy;
@@ -475,7 +476,7 @@ export class ERR_FALSY_VALUE_REJECTION extends NodeError {
 export class ERR_METHOD_NOT_IMPLEMENTED extends NodeError {
   constructor(name: string | symbol) {
     if (typeof name === 'symbol') {
-      name = (name as symbol).description!;
+      name = name.description as string;
     }
     super(
       'ERR_METHOD_NOT_IMPLEMENTED',
@@ -492,7 +493,7 @@ export class ERR_STREAM_CANNOT_PIPE extends NodeError {
 export class ERR_STREAM_DESTROYED extends NodeError {
   constructor(name: string | symbol) {
     if (typeof name === 'symbol') {
-      name = (name as symbol).description!;
+      name = name.description as string;
     }
     super(
       'ERR_STREAM_DESTROYED',
@@ -503,7 +504,7 @@ export class ERR_STREAM_DESTROYED extends NodeError {
 export class ERR_STREAM_ALREADY_FINISHED extends NodeError {
   constructor(name: string | symbol) {
     if (typeof name === 'symbol') {
-      name = (name as symbol).description!;
+      name = name.description as string;
     }
     super(
       'ERR_STREAM_ALREADY_FINISHED',
@@ -623,7 +624,7 @@ export class DnsError extends NodeError {
 export class ERR_OPTION_NOT_IMPLEMENTED extends NodeError {
   constructor(name: string | symbol) {
     if (typeof name === 'symbol') {
-      name = (name as symbol).description!;
+      name = name.description as string;
     }
     super(
       'ERR_OPTION_NOT_IMPLEMENTED',
@@ -633,7 +634,7 @@ export class ERR_OPTION_NOT_IMPLEMENTED extends NodeError {
 }
 
 export class ERR_SOCKET_BAD_PORT extends NodeError {
-  constructor(name: string, port: any, allowZero: boolean) {
+  constructor(name: string, port: unknown, allowZero: boolean) {
     const operator = allowZero ? '>=' : '>';
     super(
       'ERR_SOCKET_BAD_PORT',
@@ -759,21 +760,24 @@ export class ConnResetException extends NodeError {
   }
 }
 
-export function aggregateTwoErrors(innerError: any, outerError: any) {
+export function aggregateTwoErrors(
+  innerError: unknown,
+  outerError: Error | null
+): AggregateError {
   if (innerError && outerError && innerError !== outerError) {
-    if (Array.isArray(outerError.errors)) {
+    if ('errors' in outerError && Array.isArray(outerError.errors)) {
       // If `outerError` is already an `AggregateError`.
       outerError.errors.push(innerError);
-      return outerError;
+      return outerError as AggregateError;
     }
     const err = new AggregateError(
       [outerError, innerError],
       outerError.message
     );
-    (err as any).code = outerError.code;
+    (err as unknown as NodeError).code = (outerError as NodeError).code;
     return err;
   }
-  return innerError || outerError;
+  return (innerError || outerError) as AggregateError;
 }
 
 export class ERR_INVALID_IP_ADDRESS extends NodeTypeError {

--- a/src/node/internal/internal_fs.ts
+++ b/src/node/internal/internal_fs.ts
@@ -25,45 +25,41 @@ import { Buffer } from 'node-internal:internal_buffer';
 const kType = Symbol('type');
 
 export class Dirent {
-  public name: string | Buffer;
-  public parentPath: string | Buffer;
+  name: string | Buffer;
+  parentPath: string | Buffer;
   private [kType]: number;
 
-  public constructor(
-    name: string | Buffer,
-    type: number,
-    path: string | Buffer
-  ) {
+  constructor(name: string | Buffer, type: number, path: string | Buffer) {
     this.name = name;
     this.parentPath = path;
     this[kType] = type;
   }
 
-  public isDirectory(): boolean {
+  isDirectory(): boolean {
     return this[kType] === UV_DIRENT_DIR;
   }
 
-  public isFile(): boolean {
+  isFile(): boolean {
     return this[kType] === UV_DIRENT_FILE;
   }
 
-  public isBlockDevice(): boolean {
+  isBlockDevice(): boolean {
     return this[kType] === UV_DIRENT_BLOCK;
   }
 
-  public isCharacterDevice(): boolean {
+  isCharacterDevice(): boolean {
     return this[kType] === UV_DIRENT_CHAR;
   }
 
-  public isSymbolicLink(): boolean {
+  isSymbolicLink(): boolean {
     return this[kType] === UV_DIRENT_LINK;
   }
 
-  public isFIFO(): boolean {
+  isFIFO(): boolean {
     return this[kType] === UV_DIRENT_FIFO;
   }
 
-  public isSocket(): boolean {
+  isSocket(): boolean {
     return this[kType] === UV_DIRENT_SOCKET;
   }
 }
@@ -86,7 +82,7 @@ export class Dir {
   #encoding: BufferEncoding | null | undefined | 'buffer';
   #path: FilePath;
 
-  public constructor(
+  constructor(
     handle: cffs.DirEntryHandle[] | undefined,
     path: FilePath,
     options: DirOptions
@@ -103,15 +99,13 @@ export class Dir {
     this.#encoding = encoding as BufferEncoding;
   }
 
-  public get path(): FilePath {
+  get path(): FilePath {
     return this.#path;
   }
 
-  public read(): Promise<Dirent | null>;
-  public read(callback: DirentReadCallback): void;
-  public read(
-    callback?: DirentReadCallback
-  ): Promise<Dirent | null> | undefined {
+  read(): Promise<Dirent | null>;
+  read(callback: DirentReadCallback): void;
+  read(callback?: DirentReadCallback): Promise<Dirent | null> | undefined {
     if (typeof callback === 'function') {
       validateFunction(callback, 'callback');
       try {
@@ -135,7 +129,7 @@ export class Dir {
     }
   }
 
-  public readSync(): Dirent | null {
+  readSync(): Dirent | null {
     if (this.#handle === undefined) throw new ERR_DIR_CLOSED();
     const ent = this.#handle.shift();
     if (ent == null) return null;
@@ -150,7 +144,7 @@ export class Dir {
     );
   }
 
-  public close(callback?: (err: unknown) => void): Promise<void> | undefined {
+  close(callback?: (err: unknown) => void): Promise<void> | undefined {
     this.closeSync();
     if (typeof callback === 'function') {
       validateFunction(callback, 'callback');
@@ -162,14 +156,14 @@ export class Dir {
     return Promise.resolve();
   }
 
-  public closeSync(): void {
+  closeSync(): void {
     if (this.#handle === undefined) {
       throw new ERR_DIR_CLOSED();
     }
     this.#handle = undefined;
   }
 
-  public async *entries(): AsyncGenerator<Dirent, unknown, unknown> {
+  async *entries(): AsyncGenerator<Dirent, unknown, unknown> {
     for (;;) {
       const ent = await this.read();
       if (ent == null) return;
@@ -177,15 +171,15 @@ export class Dir {
     }
   }
 
-  public [Symbol.asyncIterator](): AsyncGenerator<Dirent, unknown, unknown> {
+  [Symbol.asyncIterator](): AsyncGenerator<Dirent, unknown, unknown> {
     return this.entries();
   }
 
-  public async [Symbol.asyncDispose](): Promise<void> {
+  async [Symbol.asyncDispose](): Promise<void> {
     await this.close();
   }
 
-  public [Symbol.dispose](): void {
+  [Symbol.dispose](): void {
     this.closeSync();
   }
 }

--- a/src/node/internal/internal_fs_promises.ts
+++ b/src/node/internal/internal_fs_promises.ts
@@ -85,7 +85,7 @@ class FileHandle {
   #fd: number | undefined;
   #handle: cffs.FdHandle | undefined;
 
-  public constructor(badge: symbol, fd: number) {
+  constructor(badge: symbol, fd: number) {
     if (badge !== kBadge) {
       throw new TypeError('Illegal constructor');
     }
@@ -93,12 +93,12 @@ class FileHandle {
     this.#handle = cffs.getFdHandle(fd);
   }
 
-  public get fd(): number | undefined {
+  get fd(): number | undefined {
     // The fd property will be undefined if the handle has been closed.
     return this.#fd;
   }
 
-  public async appendFile(
+  async appendFile(
     data: string | ArrayBufferView,
     options: WriteFileOptions = {}
   ): Promise<void> {
@@ -108,35 +108,35 @@ class FileHandle {
     await appendFile(this.#fd, data, options);
   }
 
-  public async chmod(mode: string | number): Promise<void> {
+  async chmod(mode: string | number): Promise<void> {
     if (this.#fd === undefined) {
       throw new ERR_EBADF({ syscall: 'stat' });
     }
     await fchmod(this.#fd, mode);
   }
 
-  public async chown(uid: number, gid: number): Promise<void> {
+  async chown(uid: number, gid: number): Promise<void> {
     if (this.#fd === undefined) {
       throw new ERR_EBADF({ syscall: 'stat' });
     }
     await fchown(this.#fd, uid, gid);
   }
 
-  public async datasync(): Promise<void> {
+  async datasync(): Promise<void> {
     if (this.#fd === undefined) {
       throw new ERR_EBADF({ syscall: 'stat' });
     }
     await fdatasync(this.#fd);
   }
 
-  public async sync(): Promise<void> {
+  async sync(): Promise<void> {
     if (this.#fd === undefined) {
       throw new ERR_EBADF({ syscall: 'stat' });
     }
     await fsync(this.#fd);
   }
 
-  public async read<T extends NodeJS.ArrayBufferView>(
+  async read<T extends NodeJS.ArrayBufferView>(
     bufferOrOptions: T | ReadSyncOptions = {},
     offsetOrOptions: number | ReadSyncOptions = {},
     length?: number,
@@ -190,7 +190,7 @@ class FileHandle {
     };
   }
 
-  public async readv<T extends NodeJS.ArrayBufferView>(
+  async readv<T extends NodeJS.ArrayBufferView>(
     buffers: T[],
     position: Position = null
   ): Promise<{ bytesRead: number; buffers: T[] }> {
@@ -204,7 +204,7 @@ class FileHandle {
     };
   }
 
-  public async readFile(
+  async readFile(
     options: BufferEncoding | null | ReadFileSyncOptions = {}
   ): Promise<string | Buffer> {
     if (this.#fd === undefined) {
@@ -213,38 +213,35 @@ class FileHandle {
     return await readFile(this.#fd, options);
   }
 
-  public readLines(_options: any = undefined): void {
+  readLines(_options: any = undefined): void {
     if (this.#fd === undefined) {
       throw new ERR_EBADF({ syscall: 'stat' });
     }
     throw new Error('not implemented');
   }
 
-  public async stat(options: StatOptions = {}): Promise<Stats | undefined> {
+  async stat(options: StatOptions = {}): Promise<Stats | undefined> {
     if (this.#fd === undefined) {
       throw new ERR_EBADF({ syscall: 'stat' });
     }
     return await fstat(this.#fd, options);
   }
 
-  public async truncate(len: number = 0): Promise<void> {
+  async truncate(len: number = 0): Promise<void> {
     if (this.#fd === undefined) {
       throw new ERR_EBADF({ syscall: 'stat' });
     }
     await ftruncate(this.#fd, len);
   }
 
-  public async utimes(
-    atime: RawTime | Date,
-    mtime: RawTime | Date
-  ): Promise<void> {
+  async utimes(atime: RawTime | Date, mtime: RawTime | Date): Promise<void> {
     if (this.#fd === undefined) {
       throw new ERR_EBADF({ syscall: 'stat' });
     }
     await futimes(this.#fd, atime, mtime);
   }
 
-  public async write(
+  async write(
     buffer: NodeJS.ArrayBufferView | string,
     offsetPositionOrOptions: WriteSyncOptions | Position = null,
     lengthOrEncoding?: number | BufferEncoding | null,
@@ -272,7 +269,7 @@ class FileHandle {
     };
   }
 
-  public async writev(
+  async writev(
     buffers: NodeJS.ArrayBufferView[],
     position: Position = null
   ): Promise<{ bytesWritten: number; buffers: NodeJS.ArrayBufferView[] }> {
@@ -286,7 +283,7 @@ class FileHandle {
     };
   }
 
-  public async writeFile(
+  async writeFile(
     data: string | Buffer,
     options: BufferEncoding | null | WriteFileOptions = {}
   ): Promise<{ bytesWritten: number; buffer: Buffer }> {
@@ -302,31 +299,31 @@ class FileHandle {
     };
   }
 
-  public async close(): Promise<void> {
+  async close(): Promise<void> {
     if (this.#handle !== undefined) this.#handle.close();
     this.#fd = undefined;
     this.#handle = undefined;
   }
 
-  public async [Symbol.asyncDispose](): Promise<void> {
+  async [Symbol.asyncDispose](): Promise<void> {
     await this.close();
   }
 
-  public readableWebStream(_options: any = {}): void {
+  readableWebStream(_options: any = {}): void {
     if (this.#fd === undefined) {
       throw new ERR_EBADF({ syscall: 'stat' });
     }
     throw new Error('not implemented');
   }
 
-  public createReadStream(_options: any = undefined): void {
+  createReadStream(_options: any = undefined): void {
     if (this.#fd === undefined) {
       throw new ERR_EBADF({ syscall: 'stat' });
     }
     throw new Error('not implemented');
   }
 
-  public createWriteStream(_options: any = undefined): void {
+  createWriteStream(_options: any = undefined): void {
     if (this.#fd === undefined) {
       throw new ERR_EBADF({ syscall: 'stat' });
     }

--- a/src/node/internal/internal_fs_streams.ts
+++ b/src/node/internal/internal_fs_streams.ts
@@ -11,13 +11,13 @@ export type ReadStreamOptions = {
 
 // @ts-expect-error TS2323 Cannot redeclare.
 export declare class ReadStream extends Readable {
-  public fd: number | null;
-  public flags: string;
-  public path: string;
-  public mode: number;
+  fd: number | null;
+  flags: string;
+  path: string;
+  mode: number;
 
-  public constructor(path: string, options?: Record<string, unknown>);
-  public close(callback: VoidFunction): void;
+  constructor(path: string, options?: Record<string, unknown>);
+  close(callback: VoidFunction): void;
 }
 
 // @ts-expect-error TS2323 Cannot redeclare.
@@ -69,9 +69,9 @@ export type WriteStreamOptions = {
 
 // @ts-expect-error TS2323 Cannot redeclare.
 export declare class WriteStream extends Writable {
-  public constructor(path: string, options?: WriteStreamOptions);
-  public close(cb: VoidFunction): void;
-  public destroySoon(): void;
+  constructor(path: string, options?: WriteStreamOptions);
+  close(cb: VoidFunction): void;
+  destroySoon(): void;
 }
 
 // @ts-expect-error TS2323 Cannot redeclare.

--- a/src/node/internal/internal_fs_utils.ts
+++ b/src/node/internal/internal_fs_utils.ts
@@ -788,34 +788,30 @@ function validateStringAfterArrayBufferView(
 // Therefore, we intentionally use a class-style object here and make it an
 // error to try to create your own Stats object using the constructor.
 export class Stats {
-  public dev: number | bigint;
-  public ino: number | bigint;
-  public mode: number | bigint;
-  public nlink: number | bigint;
-  public uid: number | bigint;
-  public gid: number | bigint;
-  public rdev: number | bigint;
-  public size: number | bigint;
-  public blksize: number | bigint;
-  public blocks: number | bigint;
-  public atimeMs: number | bigint;
-  public mtimeMs: number | bigint;
-  public ctimeMs: number | bigint;
-  public birthtimeMs: number | bigint;
-  public atimeNs?: bigint;
-  public mtimeNs?: bigint;
-  public ctimeNs?: bigint;
-  public birthtimeNs?: bigint;
-  public atime: Date;
-  public mtime: Date;
-  public ctime: Date;
-  public birthtime: Date;
+  dev: number | bigint;
+  ino: number | bigint;
+  mode: number | bigint;
+  nlink: number | bigint;
+  uid: number | bigint;
+  gid: number | bigint;
+  rdev: number | bigint;
+  size: number | bigint;
+  blksize: number | bigint;
+  blocks: number | bigint;
+  atimeMs: number | bigint;
+  mtimeMs: number | bigint;
+  ctimeMs: number | bigint;
+  birthtimeMs: number | bigint;
+  atimeNs?: bigint;
+  mtimeNs?: bigint;
+  ctimeNs?: bigint;
+  birthtimeNs?: bigint;
+  atime: Date;
+  mtime: Date;
+  ctime: Date;
+  birthtime: Date;
 
-  public constructor(
-    badge: symbol,
-    stat: InternalStat,
-    options: { bigint: boolean }
-  ) {
+  constructor(badge: symbol, stat: InternalStat, options: { bigint: boolean }) {
     // The kBadge symbol is never exported for users. We use it as an internal
     // marker to ensure that only internal code can create a Stats object using
     // the constructor.
@@ -895,31 +891,31 @@ export class Stats {
     }
   }
 
-  public isBlockDevice(): boolean {
+  isBlockDevice(): boolean {
     return (Number(this.mode) & S_IFMT) === S_IFBLK;
   }
 
-  public isCharacterDevice(): boolean {
+  isCharacterDevice(): boolean {
     return (Number(this.mode) & S_IFMT) === S_IFCHR;
   }
 
-  public isDirectory(): boolean {
+  isDirectory(): boolean {
     return (Number(this.mode) & S_IFMT) === S_IFDIR;
   }
 
-  public isFIFO(): boolean {
+  isFIFO(): boolean {
     return (Number(this.mode) & S_IFMT) === S_IFIFO;
   }
 
-  public isFile(): boolean {
+  isFile(): boolean {
     return (Number(this.mode) & S_IFMT) === S_IFREG;
   }
 
-  public isSocket(): boolean {
+  isSocket(): boolean {
     return (Number(this.mode) & S_IFMT) === S_IFSOCK;
   }
 
-  public isSymbolicLink(): boolean {
+  isSymbolicLink(): boolean {
     return (Number(this.mode) & S_IFMT) === S_IFLNK;
   }
 }

--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -146,38 +146,38 @@ export type SocketWriteData = Array<{
 
 // @ts-expect-error TS2323 Redeclare error.
 export declare class Socket extends _Socket {
-  public timeout: number;
-  public connecting: boolean;
-  public _aborted: boolean;
-  public _hadError: boolean;
-  public _parent: null | Socket['_handle'];
-  public _parentWrap: null | Socket | JSStreamSocket;
-  public _host: null | string;
-  public _peername: null | string;
-  public _getsockname(): {
+  timeout: number;
+  connecting: boolean;
+  _aborted: boolean;
+  _hadError: boolean;
+  _parent: null | Socket['_handle'];
+  _parentWrap: null | Socket | JSStreamSocket;
+  _host: null | string;
+  _peername: null | string;
+  _getsockname(): {
     address?: string;
     port?: number;
     family?: string;
   };
-  public [kLastWriteQueueSize]: number | null | undefined;
-  public [kTimeout]: Socket | null | undefined;
-  public [kBuffer]: null | boolean | Uint8Array;
-  public [kBufferCb]:
+  [kLastWriteQueueSize]: number | null | undefined;
+  [kTimeout]: Socket | null | undefined;
+  [kBuffer]: null | boolean | Uint8Array;
+  [kBufferCb]:
     | null
     | undefined
     | ((len?: number, buf?: Buffer) => boolean | Uint8Array);
-  public [kBufferGen]: null | (() => undefined | Uint8Array);
-  public [kSocketInfo]: null | {
+  [kBufferGen]: null | (() => undefined | Uint8Array);
+  [kSocketInfo]: null | {
     address?: string;
     port?: number;
     family?: number | string;
     remoteAddress?: Record<string, unknown>;
   };
-  public [kBytesRead]: number;
-  public [kBytesWritten]: number;
-  public [kReinitializeHandle](handle: Socket['_handle']): void;
-  public _closeAfterHandlingError: boolean;
-  public _handle: null | {
+  [kBytesRead]: number;
+  [kBytesWritten]: number;
+  [kReinitializeHandle](handle: Socket['_handle']): void;
+  _closeAfterHandlingError: boolean;
+  _handle: null | {
     writeQueueSize?: number;
     lastWriteQueueSize?: number;
     reading: boolean | undefined;
@@ -192,37 +192,37 @@ export declare class Socket extends _Socket {
       addressType: number;
     };
   };
-  public _sockname?: null | AddressInfo;
-  public _onTimeout(): void;
-  public _unrefTimer(): void;
-  public _writeGeneric(
+  _sockname?: null | AddressInfo;
+  _onTimeout(): void;
+  _unrefTimer(): void;
+  _writeGeneric(
     writev: boolean,
     data: SocketWriteData,
     encoding: string,
     cb: (err?: Error) => void
   ): void;
-  public _final(cb: (err?: Error) => void): void;
-  public _read(n: number): void;
-  public _reset(): void;
-  public _getpeername(): Record<string, unknown>;
-  public _writableState: null | unknown[];
-  public _bytesDispatched: number;
-  public _pendingData: SocketWriteData | null;
-  public _pendingEncoding: string;
-  public _undestroy(): void;
+  _final(cb: (err?: Error) => void): void;
+  _read(n: number): void;
+  _reset(): void;
+  _getpeername(): Record<string, unknown>;
+  _writableState: null | unknown[];
+  _bytesDispatched: number;
+  _pendingData: SocketWriteData | null;
+  _pendingEncoding: string;
+  _undestroy(): void;
   // This should have existed in _Socket type but it's not...
-  public writableBuffer?: Writable & {
+  writableBuffer?: Writable & {
     allBuffers: boolean;
     length: number;
   };
 
   // Defined by TLSSocket
-  public encrypted?: boolean;
-  public _finishInit(): void;
+  encrypted?: boolean;
+  _finishInit(): void;
 
-  public constructor(options?: SocketOptions);
-  public prototype: Socket;
-  public resetAndClosing?: boolean;
+  constructor(options?: SocketOptions);
+  prototype: Socket;
+  resetAndClosing?: boolean;
 }
 
 // @ts-expect-error TS2323 Redeclare error.

--- a/src/node/internal/internal_timers.ts
+++ b/src/node/internal/internal_timers.ts
@@ -36,7 +36,7 @@ export class Timeout {
   #isRepeat: boolean;
   #isRefed: boolean;
 
-  public constructor(
+  constructor(
     callback: (...args: unknown[]) => unknown,
     after: number = 1,
     args: unknown[] = [],
@@ -69,38 +69,38 @@ export class Timeout {
     }
   }
 
-  public refresh(): this {
+  refresh(): this {
     this.#clearTimeout();
     this.#constructTimer();
     return this;
   }
 
-  public unref(): this {
+  unref(): this {
     // Intentionally left as no-op.
     this.#isRefed = false;
     return this;
   }
 
-  public ref(): this {
+  ref(): this {
     // Intentionally left as no-op.
     this.#isRefed = true;
     return this;
   }
 
-  public hasRef(): boolean {
+  hasRef(): boolean {
     return this.#isRefed;
   }
 
-  public close(): this {
+  close(): this {
     this.#clearTimeout();
     return this;
   }
 
-  public [Symbol.dispose](): void {
+  [Symbol.dispose](): void {
     this.#clearTimeout();
   }
 
-  public [Symbol.toPrimitive](): number {
+  [Symbol.toPrimitive](): number {
     return this.#timer;
   }
 

--- a/src/node/internal/internal_timers_promises.ts
+++ b/src/node/internal/internal_timers_promises.ts
@@ -217,16 +217,14 @@ declare global {
 // finalized. Note, also, that Scheduler is expected to be defined as a global,
 // but while the API is experimental we shouldn't expose it as such.
 class Scheduler {
-  public [kScheduler] = true;
+  [kScheduler] = true;
 
-  public yield(): Promise<void> {
+  yield(): Promise<void> {
     if (!this[kScheduler]) throw new ERR_INVALID_THIS('Scheduler');
     return setImmediate();
   }
 
-  public wait(
-    ...args: Parameters<typeof globalThis.scheduler.wait>
-  ): Promise<void> {
+  wait(...args: Parameters<typeof globalThis.scheduler.wait>): Promise<void> {
     if (!this[kScheduler]) throw new ERR_INVALID_THIS('Scheduler');
     return globalThis.scheduler.wait(...args);
   }

--- a/src/node/internal/internal_tls_common.ts
+++ b/src/node/internal/internal_tls_common.ts
@@ -28,8 +28,8 @@ import { validateInteger } from 'node-internal:validators';
 
 // @ts-expect-error TS2323 Redeclare error.
 export declare class SecureContext {
-  public context: unknown;
-  public constructor(
+  context: unknown;
+  constructor(
     _secureProtocol?: string,
     secureOptions?: number,
     minVersion?: string,

--- a/src/node/internal/internal_tls_jsstream.ts
+++ b/src/node/internal/internal_tls_jsstream.ts
@@ -53,13 +53,13 @@ const kPendingClose = Symbol('kPendingClose');
  * "real" JavaScript stream. JSStreamSocket is exactly this.
  */
 export class JSStreamSocket extends Socket {
-  public stream: Duplex;
-  public [kCurrentWriteRequest]: null | unknown;
-  public [kCurrentShutdownRequest]: null | unknown;
-  public [kPendingShutdownRequest]: null | unknown;
-  public [kPendingClose]: boolean;
+  stream: Duplex;
+  [kCurrentWriteRequest]: null | unknown;
+  [kCurrentShutdownRequest]: null | unknown;
+  [kPendingShutdownRequest]: null | unknown;
+  [kPendingClose]: boolean;
 
-  public constructor(stream: Duplex) {
+  constructor(stream: Duplex) {
     // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
     const closePromise = Promise.withResolvers<void>();
     const openPromise = Promise.withResolvers<SocketInfo>();
@@ -152,21 +152,21 @@ export class JSStreamSocket extends Socket {
     this.read(0);
   }
 
-  public isClosing(): boolean {
+  isClosing(): boolean {
     return !this.readable || !this.writable;
   }
 
-  public readStart(): number {
+  readStart(): number {
     this.stream.resume();
     return 0;
   }
 
-  public readStop(): number {
+  readStop(): number {
     this.stream.pause();
     return 0;
   }
 
-  public doShutdown(req: unknown): number {
+  doShutdown(req: unknown): number {
     // TODO(addaleax): It might be nice if we could get into a state where
     // DoShutdown() is not called on streams while a write is still pending.
     //
@@ -199,7 +199,7 @@ export class JSStreamSocket extends Socket {
     return 0;
   }
 
-  public doClose(): void {
+  doClose(): void {
     this[kPendingClose] = true;
 
     const handle = this._handle;

--- a/src/node/internal/internal_tls_wrap.ts
+++ b/src/node/internal/internal_tls_wrap.ts
@@ -66,10 +66,10 @@ const kIsVerified = Symbol('verified');
 
 // @ts-expect-error TS2323 Cannot redeclare error.
 export declare class TLSSocket extends Socket {
-  public _hadError: boolean;
-  public _handle: Socket['_handle'];
-  public _init(): void;
-  public _tlsOptions: TlsOptions &
+  _hadError: boolean;
+  _handle: Socket['_handle'];
+  _init(): void;
+  _tlsOptions: TlsOptions &
     ConnectionOptions &
     SocketOptions &
     TcpSocketConnectOpts & {
@@ -78,62 +78,56 @@ export declare class TLSSocket extends Socket {
       server?: unknown;
       onread?: OnReadOpts;
     };
-  public _secureEstablished: boolean;
-  public _securePending: boolean;
-  public _newSessionPending: boolean;
-  public _controlReleased: boolean;
-  public authorized: boolean;
-  public encrypted: boolean;
-  public handle: ReturnType<TLSSocket['_wrapHandle']>;
-  public servername: null | string;
-  public secureConnecting: boolean;
-  public ssl: TLSSocket['_handle'];
-  public [kRes]: null | Socket['_handle'];
-  public [kIsVerified]: boolean;
-  public [kPendingSession]: null | Buffer;
-  public [kErrorEmitted]: boolean;
-  public [kConnectOptions]?: NormalizedConnectionOptions;
+  _secureEstablished: boolean;
+  _securePending: boolean;
+  _newSessionPending: boolean;
+  _controlReleased: boolean;
+  authorized: boolean;
+  encrypted: boolean;
+  handle: ReturnType<TLSSocket['_wrapHandle']>;
+  servername: null | string;
+  secureConnecting: boolean;
+  ssl: TLSSocket['_handle'];
+  [kRes]: null | Socket['_handle'];
+  [kIsVerified]: boolean;
+  [kPendingSession]: null | Buffer;
+  [kErrorEmitted]: boolean;
+  [kConnectOptions]?: NormalizedConnectionOptions;
 
-  public constructor(
+  constructor(
     socket: Socket | Duplex | undefined,
     opts: TLSSocket['_tlsOptions']
   );
-  public prototype: TLSSocket;
+  prototype: TLSSocket;
 
-  public _destroySSL(): void;
-  public _emitTLSError(error: Error): void;
-  public _finishInit(): void;
-  public _handleTimeout(): void;
-  public _releaseControl(): boolean;
-  public _start(): void;
-  public _tlsError(error: Error): Error | null;
-  public _wrapHandle(
+  _destroySSL(): void;
+  _emitTLSError(error: Error): void;
+  _finishInit(): void;
+  _handleTimeout(): void;
+  _releaseControl(): boolean;
+  _start(): void;
+  _tlsError(error: Error): Error | null;
+  _wrapHandle(
     wrap: null | Socket,
     handle: Socket['_handle'] | null | undefined,
     wrapHasActiveWriteFromPrevOwner: boolean
   ): unknown;
-  public disableRenegotiation(): void;
-  public getX509Certificate(): ReturnType<TLSSocketType['getX509Certificate']>;
-  public setKeyCert(context: unknown): void;
-  public setServername(name: string): void;
-  public setSession(session: string | Buffer): void;
-  public setMaxSendFragment(size: number): boolean;
-  public getCertificate(): ReturnType<TLSSocketType['getCertificate']>;
-  public getPeerX509Certificate(): ReturnType<
-    TLSSocketType['getPeerX509Certificate']
-  >;
-  public renegotiate(
+  disableRenegotiation(): void;
+  getX509Certificate(): ReturnType<TLSSocketType['getX509Certificate']>;
+  setKeyCert(context: unknown): void;
+  setServername(name: string): void;
+  setSession(session: string | Buffer): void;
+  setMaxSendFragment(size: number): boolean;
+  getCertificate(): ReturnType<TLSSocketType['getCertificate']>;
+  getPeerX509Certificate(): ReturnType<TLSSocketType['getPeerX509Certificate']>;
+  renegotiate(
     options: {
       rejectUnauthorized?: boolean | undefined;
       requestCert?: boolean | undefined;
     },
     callback?: (error: Error | null) => void
   ): boolean;
-  public exportKeyingMaterial(
-    length: number,
-    label: string,
-    context?: Buffer
-  ): Buffer;
+  exportKeyingMaterial(length: number, label: string, context?: Buffer): Buffer;
 }
 
 function onnewsessionclient(

--- a/src/node/internal/internal_zlib.ts
+++ b/src/node/internal/internal_zlib.ts
@@ -329,25 +329,25 @@ export function brotliCompress(
   processChunkCaptureError(new BrotliCompress(options), data, callback);
 }
 export class Gzip extends Zlib {
-  public constructor(options: ZlibOptions) {
+  constructor(options: ZlibOptions) {
     super(options, CONST_GZIP);
   }
 }
 
 export class Gunzip extends Zlib {
-  public constructor(options: ZlibOptions) {
+  constructor(options: ZlibOptions) {
     super(options, CONST_GUNZIP);
   }
 }
 
 export class Deflate extends Zlib {
-  public constructor(options: ZlibOptions) {
+  constructor(options: ZlibOptions) {
     super(options, CONST_DEFLATE);
   }
 }
 
 export class DeflateRaw extends Zlib {
-  public constructor(options?: ZlibOptions) {
+  constructor(options?: ZlibOptions) {
     if (options?.windowBits === 8) {
       options.windowBits = 9;
     }
@@ -356,31 +356,31 @@ export class DeflateRaw extends Zlib {
 }
 
 export class Inflate extends Zlib {
-  public constructor(options: ZlibOptions) {
+  constructor(options: ZlibOptions) {
     super(options, CONST_INFLATE);
   }
 }
 
 export class InflateRaw extends Zlib {
-  public constructor(options: ZlibOptions) {
+  constructor(options: ZlibOptions) {
     super(options, CONST_INFLATERAW);
   }
 }
 
 export class Unzip extends Zlib {
-  public constructor(options: ZlibOptions) {
+  constructor(options: ZlibOptions) {
     super(options, CONST_UNZIP);
   }
 }
 
 export class BrotliCompress extends Brotli {
-  public constructor(options: BrotliOptions) {
+  constructor(options: BrotliOptions) {
     super(options, CONST_BROTLI_ENCODE);
   }
 }
 
 export class BrotliDecompress extends Brotli {
-  public constructor(options: BrotliOptions) {
+  constructor(options: BrotliOptions) {
     super(options, CONST_BROTLI_DECODE);
   }
 }

--- a/src/node/internal/internal_zlib_base.ts
+++ b/src/node/internal/internal_zlib_base.ts
@@ -342,22 +342,22 @@ const zlibDefaultOptions = {
 };
 
 export class ZlibBase extends Transform {
-  public bytesWritten: number = 0;
+  bytesWritten: number = 0;
 
-  public _maxOutputLength: number;
-  public _outBuffer: Buffer;
-  public _outOffset: number = 0;
-  public _chunkSize: number;
-  public _defaultFlushFlag: number;
-  public _finishFlushFlag: number;
-  public _defaultFullFlushFlag: number;
-  public _info: boolean;
-  public _handle: ZlibHandleType | null = null;
-  public _writeState = new Uint32Array(2);
+  _maxOutputLength: number;
+  _outBuffer: Buffer;
+  _outOffset: number = 0;
+  _chunkSize: number;
+  _defaultFlushFlag: number;
+  _finishFlushFlag: number;
+  _defaultFullFlushFlag: number;
+  _info: boolean;
+  _handle: ZlibHandleType | null = null;
+  _writeState = new Uint32Array(2);
 
-  public [kError]: NodeError | undefined;
+  [kError]: NodeError | undefined;
 
-  public constructor(
+  constructor(
     opts: ZlibOptions & DuplexOptions,
     mode: number,
     handle: ZlibHandleType,
@@ -437,39 +437,39 @@ export class ZlibBase extends Transform {
     this._maxOutputLength = maxOutputLength;
   }
 
-  public get _closed(): boolean {
+  get _closed(): boolean {
     return this._handle == null;
   }
 
   // @deprecated Use `bytesWritten` instead.
-  public get bytesRead(): number {
+  get bytesRead(): number {
     return this.bytesWritten;
   }
 
   // @deprecated Use `bytesWritten` instead.
-  public set bytesRead(value: number) {
+  set bytesRead(value: number) {
     this.bytesWritten = value;
   }
 
-  public reset(): void {
+  reset(): void {
     ok(this._handle, 'zlib binding closed');
     this._handle.reset();
   }
 
   // This is the _flush function called by the transform class,
   // internally, when the last chunk has been written.
-  public override _flush(callback: () => void): void {
+  override _flush(callback: () => void): void {
     this._transform(Buffer.alloc(0), 'utf8', callback);
   }
 
   // Force Transform compat behavior.
-  public override _final(callback: () => void): void {
+  override _final(callback: () => void): void {
     callback();
   }
 
-  public flush(kind: number, callback: () => void): void;
-  public flush(callback?: () => void): void;
-  public flush(
+  flush(kind: number, callback: () => void): void;
+  flush(callback?: () => void): void;
+  flush(
     kind?: number | (() => void),
     callback: (() => void) | undefined = undefined
   ): void {
@@ -491,14 +491,14 @@ export class ZlibBase extends Transform {
     }
   }
 
-  public close(callback?: () => void): void {
+  close(callback?: () => void): void {
     if (callback) {
       finished(this, callback);
     }
     this.destroy();
   }
 
-  public override _destroy<T extends Error>(
+  override _destroy<T extends Error>(
     err: T,
     callback: (err: T) => never
   ): void {
@@ -506,7 +506,7 @@ export class ZlibBase extends Transform {
     callback(err);
   }
 
-  public override _transform(
+  override _transform(
     chunk: Buffer & { [kFlushFlag]?: number },
     _encoding: BufferEncoding,
     cb: () => void
@@ -526,17 +526,9 @@ export class ZlibBase extends Transform {
   }
 
   // This function is left for backwards compatibility.
-  public _processChunk(
-    chunk: Buffer,
-    flushFlag: number,
-    cb?: undefined
-  ): Buffer;
-  public _processChunk(
-    chunk: Buffer,
-    flushFlag: number,
-    cb: () => void
-  ): undefined;
-  public _processChunk(
+  _processChunk(chunk: Buffer, flushFlag: number, cb?: undefined): Buffer;
+  _processChunk(chunk: Buffer, flushFlag: number, cb: () => void): undefined;
+  _processChunk(
     chunk: Buffer,
     flushFlag: number,
     cb?: () => void
@@ -574,10 +566,10 @@ export class ZlibBase extends Transform {
 }
 
 export class Zlib extends ZlibBase {
-  public _level = CONST_Z_DEFAULT_COMPRESSION;
-  public _strategy = CONST_Z_DEFAULT_STRATEGY;
+  _level = CONST_Z_DEFAULT_COMPRESSION;
+  _strategy = CONST_Z_DEFAULT_STRATEGY;
 
-  public constructor(options: ZlibOptions | null | undefined, mode: number) {
+  constructor(options: ZlibOptions | null | undefined, mode: number) {
     let windowBits = CONST_Z_DEFAULT_WINDOWBITS;
     let level = CONST_Z_DEFAULT_COMPRESSION;
     let memLevel = CONST_Z_DEFAULT_MEMLEVEL;
@@ -666,7 +658,7 @@ export class Zlib extends ZlibBase {
     this._writeState = writeState;
   }
 
-  public params(level: number, strategy: number, callback: () => void): void {
+  params(level: number, strategy: number, callback: () => void): void {
     checkRangesOrGetDefault(
       level,
       'level',
@@ -722,7 +714,7 @@ const brotliDefaultOptions: ZlibDefaultOptions = {
 };
 
 export class Brotli extends ZlibBase {
-  public constructor(options: BrotliOptions | undefined | null, mode: number) {
+  constructor(options: BrotliOptions | undefined | null, mode: number) {
     ok(mode === CONST_BROTLI_DECODE || mode === CONST_BROTLI_ENCODE);
     brotliInitParamsArray.fill(-1);
 

--- a/src/node/internal/streams_util.d.ts
+++ b/src/node/internal/streams_util.d.ts
@@ -185,19 +185,19 @@ export function getHighWaterMark(
 
 // BufferList class
 export class BufferList {
-  public head: BufferListNode | null;
-  public tail: BufferListNode | null;
-  public length: number;
+  head: BufferListNode | null;
+  tail: BufferListNode | null;
+  length: number;
 
-  public push(v: Buffer | string): void;
-  public unshift(v: Buffer | string): void;
-  public shift(): Buffer | string | undefined;
-  public clear(): void;
-  public join(s: string): string;
-  public concat(n: number): Buffer;
-  public consume(n: number, hasStrings?: boolean): Buffer | string;
-  public first(): Buffer | string;
-  public [Symbol.iterator](): IterableIterator<Buffer | string>;
+  push(v: Buffer | string): void;
+  unshift(v: Buffer | string): void;
+  shift(): Buffer | string | undefined;
+  clear(): void;
+  join(s: string): string;
+  concat(n: number): Buffer;
+  consume(n: number, hasStrings?: boolean): Buffer | string;
+  first(): Buffer | string;
+  [Symbol.iterator](): IterableIterator<Buffer | string>;
 }
 
 interface BufferListNode {

--- a/src/node/internal/util.d.ts
+++ b/src/node/internal/util.d.ts
@@ -5,24 +5,24 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export abstract class MIMEType {
-  public constructor(input: string);
-  public type: string;
-  public subtype: string;
-  public readonly essence: string;
-  public readonly params: MIMEParams;
-  public toString(): string;
-  public toJSON(): string;
+  constructor(input: string);
+  type: string;
+  subtype: string;
+  readonly essence: string;
+  readonly params: MIMEParams;
+  toString(): string;
+  toJSON(): string;
 }
 
 export abstract class MIMEParams {
-  public constructor();
-  public delete(name: string): void;
-  public get(name: string): string | undefined;
-  public has(name: string): boolean;
-  public set(name: string, value: string): void;
-  public entries(): Iterable<string[]>;
-  public keys(): Iterable<string>;
-  public values(): Iterable<string>;
+  constructor();
+  delete(name: string): void;
+  get(name: string): string | undefined;
+  has(name: string): boolean;
+  set(name: string, value: string): void;
+  entries(): Iterable<string[]>;
+  keys(): Iterable<string>;
+  values(): Iterable<string>;
 }
 
 export const kResourceTypeInspect: unique symbol;

--- a/src/node/internal/zlib.d.ts
+++ b/src/node/internal/zlib.d.ts
@@ -181,18 +181,18 @@ type ErrorHandler = (errno: number, code: string, message: string) => void;
 type ProcessHandler = () => void;
 
 export abstract class CompressionStream {
-  public [owner_symbol]: Zlib;
+  [owner_symbol]: Zlib;
   // Not used by C++ implementation but required to be Node.js compatible.
-  public inOff: number;
-  public buffer: NodeJS.TypedArray | null;
-  public cb: () => void;
-  public availOutBefore: number;
-  public availInBefore: number;
-  public flushFlag: number;
+  inOff: number;
+  buffer: NodeJS.TypedArray | null;
+  cb: () => void;
+  availOutBefore: number;
+  availInBefore: number;
+  flushFlag: number;
 
-  public constructor(mode: number);
-  public close(): void;
-  public write(
+  constructor(mode: number);
+  close(): void;
+  write(
     flushFlag: number,
     inputBuffer: NodeJS.TypedArray,
     inputOffset: number,
@@ -201,7 +201,7 @@ export abstract class CompressionStream {
     outputOffset: number,
     outputLength: number
   ): void;
-  public writeSync(
+  writeSync(
     flushFlag: number,
     inputBuffer: NodeJS.TypedArray,
     inputOffset: number,
@@ -210,14 +210,14 @@ export abstract class CompressionStream {
     outputOffset: number,
     outputLength: number
   ): void;
-  public reset(): void;
+  reset(): void;
 
   // Workerd specific functions
-  public setErrorHandler(cb: ErrorHandler): void;
+  setErrorHandler(cb: ErrorHandler): void;
 }
 
 export class ZlibStream extends CompressionStream {
-  public initialize(
+  initialize(
     windowBits: number,
     level: number,
     memLevel: number,
@@ -226,23 +226,23 @@ export class ZlibStream extends CompressionStream {
     processCallback: ProcessHandler,
     dictionary: ZlibOptions['dictionary']
   ): void;
-  public params(level: number, strategy: number): void;
+  params(level: number, strategy: number): void;
 }
 
 export class BrotliDecoder extends CompressionStream {
-  public initialize(
+  initialize(
     params: Uint32Array,
     writeResult: Uint32Array,
     writeCallback: () => void
   ): boolean;
-  public params(): void;
+  params(): void;
 }
 
 export class BrotliEncoder extends CompressionStream {
-  public initialize(
+  initialize(
     params: Uint32Array,
     writeResult: Uint32Array,
     writeCallback: () => void
   ): boolean;
-  public params(): void;
+  params(): void;
 }

--- a/src/pyodide/internal/loadPackage.ts
+++ b/src/pyodide/internal/loadPackage.ts
@@ -107,9 +107,9 @@ function loadBundleFromArtifactBundler(requirement: string): Promise<Reader> {
  * ArrayBufferReader wraps around an arrayBuffer in a way that tar.js is able to read from
  */
 class ArrayBufferReader {
-  public constructor(private arrayBuffer: ArrayBuffer) {}
+  constructor(private arrayBuffer: ArrayBuffer) {}
 
-  public read(offset: number, buf: Uint8Array): number {
+  read(offset: number, buf: Uint8Array): number {
     const size = this.arrayBuffer.byteLength;
     if (offset >= size || offset < 0) {
       return 0;

--- a/src/pyodide/internal/pool/builtin_wrappers.ts
+++ b/src/pyodide/internal/pool/builtin_wrappers.ts
@@ -4,8 +4,8 @@ import type { default as UnsafeEvalType } from 'internal:unsafe-eval';
 if (typeof FinalizationRegistry === 'undefined') {
   // @ts-expect-error cannot assign to globalThis
   globalThis.FinalizationRegistry = class FinalizationRegistry {
-    public register(): void {}
-    public unregister(): void {}
+    register(): void {}
+    unregister(): void {}
   };
 }
 

--- a/src/pyodide/internal/setupPackages.ts
+++ b/src/pyodide/internal/setupPackages.ts
@@ -50,7 +50,7 @@ class VirtualizedDir {
   private dynlibTarFs: TarFSInfo; // /usr/lib directory
   private soFiles: FilePath[];
   private loadedRequirements: Set<string>;
-  public constructor() {
+  constructor() {
     this.rootInfo = createTarFsInfo();
     this.dynlibTarFs = createTarFsInfo();
     this.soFiles = [];
@@ -63,7 +63,7 @@ class VirtualizedDir {
    * If a file or directory already exists, an error is thrown.
    * @param {TarInfo} overlayInfo The directory that is to be "copied" into site-packages
    */
-  public mountOverlay(overlayInfo: TarFSInfo, dir: InstallDir): void {
+  mountOverlay(overlayInfo: TarFSInfo, dir: InstallDir): void {
     const dest = dir == 'dynlib' ? this.dynlibTarFs : this.rootInfo;
     overlayInfo.children!.forEach((val, key) => {
       if (dest.children!.has(key)) {
@@ -85,7 +85,7 @@ class VirtualizedDir {
    * @param {String} requirement The canonicalized package name this small bundle corresponds to
    * @param {InstallDir} installDir The `install_dir` field from the metadata about the package taken from the lockfile
    */
-  public addSmallBundle(
+  addSmallBundle(
     tarInfo: TarFSInfo,
     soFiles: string[],
     requirement: string,
@@ -105,7 +105,7 @@ class VirtualizedDir {
    * @param {List<String>} soFiles A list of .so files contained in the big bundle
    * @param {List<String>} requirements canonicalized list of packages to pick from the big bundle
    */
-  public addBigBundle(
+  addBigBundle(
     tarInfo: TarFSInfo,
     soFiles: string[],
     requirements: Set<string>
@@ -129,23 +129,23 @@ class VirtualizedDir {
     }
   }
 
-  public getSitePackagesRoot(): TarFSInfo {
+  getSitePackagesRoot(): TarFSInfo {
     return this.rootInfo;
   }
 
-  public getDynlibRoot(): TarFSInfo {
+  getDynlibRoot(): TarFSInfo {
     return this.dynlibTarFs;
   }
 
-  public getSoFilesToLoad(): FilePath[] {
+  getSoFilesToLoad(): FilePath[] {
     return this.soFiles;
   }
 
-  public hasRequirementLoaded(req: string): boolean {
+  hasRequirementLoaded(req: string): boolean {
     return this.loadedRequirements.has(req);
   }
 
-  public mount(Module: Module, tarFS: EmscriptenFS<TarFSInfo>): void {
+  mount(Module: Module, tarFS: EmscriptenFS<TarFSInfo>): void {
     Module.FS.mkdirTree(Module.FS.sessionSitePackages);
     Module.FS.mount(
       tarFS,

--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/explicit-module-boundary-types  */
+/* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return  */
 // This file is a BUILTIN module that provides the actual implementation for the
 // python-entrypoint.js USER module.
 
@@ -293,7 +293,7 @@ function makeEntrypointClass(
 ): any {
   const isDurableObject = classKind.name === 'DurableObject';
   const result = class EntrypointWrapper extends classKind {
-    public constructor(...args: any[]) {
+    constructor(...args: any[]) {
       super(...args);
       // Initialise a Python instance of the class.
       const pyInstancePromise = initPyInstance(className, args);

--- a/src/wpt/harness/common.ts
+++ b/src/wpt/harness/common.ts
@@ -43,7 +43,7 @@ export class FilterList {
   // We keep this set so we can warn the user about this.
   private unmatchedRegexps: Set<RegExp> = new Set();
 
-  public constructor(filters: (string | RegExp)[] | true | undefined) {
+  constructor(filters: (string | RegExp)[] | true | undefined) {
     if (filters === undefined) {
       return;
     }
@@ -64,7 +64,7 @@ export class FilterList {
     this.unmatchedRegexps = new Set(this.regexps);
   }
 
-  public has(input: string): boolean {
+  has(input: string): boolean {
     if (this.matchesAll) {
       return true;
     }
@@ -76,7 +76,7 @@ export class FilterList {
     return this.regexps.some((r) => r.test(input));
   }
 
-  public delete(input: string): boolean {
+  delete(input: string): boolean {
     if (this.matchesAll) {
       return true;
     }
@@ -95,7 +95,7 @@ export class FilterList {
     return false;
   }
 
-  public getUnmatched(): Set<string | RegExp> {
+  getUnmatched(): Set<string | RegExp> {
     return this.strings.union(this.unmatchedRegexps);
   }
 }

--- a/src/wpt/harness/globals.ts
+++ b/src/wpt/harness/globals.ts
@@ -56,16 +56,13 @@ function relativizeRequest(
 }
 
 globalThis.Request = class _Request extends Request {
-  public constructor(input: RequestInfo | URL, init?: RequestInit) {
+  constructor(input: RequestInfo | URL, init?: RequestInit) {
     super(relativizeRequest(input, init));
   }
 };
 
 globalThis.Response = class _Response extends Response {
-  public static override redirect(
-    url: string | URL,
-    status?: number
-  ): Response {
+  static override redirect(url: string | URL, status?: number): Response {
     return super.redirect(relativizeUrl(url), status);
   }
 };
@@ -91,7 +88,7 @@ globalThis.fetch = async (
 };
 
 class _Location {
-  public get ancestorOrigins(): DOMStringList {
+  get ancestorOrigins(): DOMStringList {
     return {
       length: 0,
       item(_index: number): string | null {
@@ -103,53 +100,53 @@ class _Location {
     };
   }
 
-  public get hash(): string {
+  get hash(): string {
     return globalThis.state.testUrl.hash;
   }
 
-  public get host(): string {
+  get host(): string {
     return globalThis.state.testUrl.host;
   }
 
-  public get hostname(): string {
+  get hostname(): string {
     return globalThis.state.testUrl.hostname;
   }
 
-  public get href(): string {
+  get href(): string {
     return globalThis.state.testUrl.href;
   }
 
-  public get origin(): string {
+  get origin(): string {
     return globalThis.state.testUrl.origin;
   }
 
-  public get pathname(): string {
+  get pathname(): string {
     return globalThis.state.testUrl.pathname;
   }
 
-  public get port(): string {
+  get port(): string {
     return globalThis.state.testUrl.port;
   }
 
-  public get protocol(): string {
+  get protocol(): string {
     return globalThis.state.testUrl.protocol;
   }
 
-  public get search(): string {
+  get search(): string {
     return globalThis.state.testUrl.search;
   }
 
-  public assign(url: string): void {
+  assign(url: string): void {
     globalThis.state.testUrl = new URL(url);
   }
 
-  public reload(): void {}
+  reload(): void {}
 
-  public replace(url: string): void {
+  replace(url: string): void {
     globalThis.state.testUrl = new URL(url);
   }
 
-  public toString(): string {
+  toString(): string {
     return globalThis.state.testUrl.href;
   }
 }

--- a/src/wpt/harness/harness.ts
+++ b/src/wpt/harness/harness.ts
@@ -109,24 +109,24 @@ type TestCase = {
 // to the evaled  WPT test code.
 class RunnerState {
   // URL corresponding to the current test file, based on the WPT directory structure.
-  public testUrl: URL;
+  testUrl: URL;
 
   // Filename of the current test. Used in error messages.
-  public testFileName: string;
+  testFileName: string;
 
   // The worker environment. Used to allow fetching resources in the test.
-  public env: Env;
+  env: Env;
 
   // Makes test options available from assertion functions
-  public options: TestRunnerOptions;
+  options: TestRunnerOptions;
 
   // A test is pushed to this list as soon as it is discovered
-  public subtests: Test[] = [];
+  subtests: Test[] = [];
 
   // Callbacks to be run once the entire test is done.
-  public completionCallbacks: UnknownFunc[] = [];
+  completionCallbacks: UnknownFunc[] = [];
 
-  public constructor(
+  constructor(
     testUrl: URL,
     testFileName: string,
     env: Env,
@@ -138,7 +138,7 @@ class RunnerState {
     this.options = options;
   }
 
-  public async validate(): Promise<void> {
+  async validate(): Promise<void> {
     // Exception handling is set up on every promise in the test function that created it.
     await Promise.all(this.subtests.map((t) => t.promise));
 
@@ -245,15 +245,15 @@ globalThis.console.error = colorPrint(
 
 class WPTMetadata {
   // Specifies the Javascript global scopes for the test. (Not currently supported)
-  public global: string[] = [];
+  global: string[] = [];
   // Specifies additional JS scripts to execute.
-  public scripts: string[] = [];
+  scripts: string[] = [];
   // Adjusts the timeout for the tests in this file. (Not currently supported)
-  public timeout?: string;
+  timeout?: string;
   // Sets a human-readable title for the entire test file. (Not currently supported.)
-  public title?: string;
+  title?: string;
   // Specifies a variant of this test, which can be used in subsetTestByKey (Not currently supported.)
-  public variants: URLSearchParams[] = [];
+  variants: URLSearchParams[] = [];
 }
 
 function parseWptMetadata(code: string): WPTMetadata {
@@ -508,13 +508,13 @@ export default ${JSON.stringify(generatedConfig, null, 2)} satisfies TestRunnerC
 }
 
 class WPTTestResult {
-  public test: string;
-  public status: 'OK' | 'ERROR';
-  public subtests: WPTSubtestResult[] = [];
+  test: string;
+  status: 'OK' | 'ERROR';
+  subtests: WPTSubtestResult[] = [];
   // TODO(soon): Track elapsed time
-  public duration: number = 0;
+  duration: number = 0;
 
-  public constructor(result: RunnerState, options: TestRunnerOptions) {
+  constructor(result: RunnerState, options: TestRunnerOptions) {
     this.test = WPTTestResult.getTestNameFromUrl(result.testUrl);
     this.status = options.disabledTests === true ? 'ERROR' : 'OK';
     this.subtests = result.subtests.map((r) => new WPTSubtestResult(r));
@@ -528,12 +528,12 @@ class WPTTestResult {
 }
 
 class WPTSubtestResult {
-  public name: string;
-  public status: 'PASS' | 'FAIL';
-  public message?: string;
-  public isExpectedFailure?: true;
+  name: string;
+  status: 'PASS' | 'FAIL';
+  message?: string;
+  isExpectedFailure?: true;
 
-  public constructor(result: Test) {
+  constructor(result: Test) {
     this.name = sanitize_unpaired_surrogates(result.name);
     if (result.error instanceof Error) {
       this.message = result.error.message;
@@ -566,49 +566,49 @@ function generateReport(config: TestRunnerConfig): string {
 }
 
 class Stats {
-  public moduleBase: string;
-  public coverage = new CoverageStats();
-  public pass = new PassStats();
+  moduleBase: string;
+  coverage = new CoverageStats();
+  pass = new PassStats();
 
-  public constructor(moduleBase: string) {
+  constructor(moduleBase: string) {
     this.moduleBase = moduleBase;
   }
 
-  public toList(): unknown[] {
+  toList(): unknown[] {
     return [this.moduleBase, ...this.coverage.toList(), ...this.pass.toList()];
   }
 }
 class CoverageStats {
-  public ok: number = 0;
-  public disabled: number = 0;
+  ok: number = 0;
+  disabled: number = 0;
 
-  public get total(): number {
+  get total(): number {
     return this.ok + this.disabled;
   }
 
-  public get ok_percent(): number {
+  get ok_percent(): number {
     return (this.ok / this.total) * 100;
   }
 
-  public toList(): unknown[] {
+  toList(): unknown[] {
     return [this.ok, this.disabled, this.total, this.ok_percent.toFixed(0)];
   }
 }
 
 class PassStats {
-  public pass: number = 0;
-  public fail: number = 0;
-  public disabled: number = 0;
+  pass: number = 0;
+  fail: number = 0;
+  disabled: number = 0;
 
-  public get total(): number {
+  get total(): number {
     return this.pass + this.fail + this.disabled;
   }
 
-  public get pass_percent(): number {
+  get pass_percent(): number {
     return (this.pass / this.total) * 100;
   }
 
-  public toList(): unknown[] {
+  toList(): unknown[] {
     return [
       this.pass,
       this.fail,

--- a/src/wpt/harness/test.ts
+++ b/src/wpt/harness/test.ts
@@ -47,7 +47,7 @@ type TestErrorType = Error | 'OMITTED' | 'DISABLED' | undefined;
  */
 /* eslint-disable @typescript-eslint/no-this-alias -- WPT allows for overriding the this environment for a step but defaults to the Test class */
 export class Test {
-  public static Phases = {
+  static Phases = {
     INITIAL: 0,
     STARTED: 1,
     HAS_RESULT: 2,
@@ -55,17 +55,17 @@ export class Test {
     COMPLETE: 4,
   } as const;
 
-  public name: string;
-  public properties: unknown;
-  public phase: (typeof Test.Phases)[keyof typeof Test.Phases];
-  public cleanup_callbacks: UnknownFunc[] = [];
+  name: string;
+  properties: unknown;
+  phase: (typeof Test.Phases)[keyof typeof Test.Phases];
+  cleanup_callbacks: UnknownFunc[] = [];
 
-  public error: TestErrorType = undefined;
+  error: TestErrorType = undefined;
 
   // If this test is asynchronous, stores a promise that resolves on test completion
-  public promise?: Promise<void>;
+  promise?: Promise<void>;
 
-  public constructor(name: string, properties?: unknown) {
+  constructor(name: string, properties?: unknown) {
     this.name = name;
     this.properties = properties;
     this.phase = Test.Phases.INITIAL;
@@ -80,11 +80,7 @@ export class Test {
    * @param [this_obj] - The object to use as the this
    * value when calling ``func``. Defaults to the  :js:class:`Test` object.
    */
-  public step(
-    func: UnknownFunc,
-    this_obj?: object,
-    ...rest: unknown[]
-  ): unknown {
+  step(func: UnknownFunc, this_obj?: object, ...rest: unknown[]): unknown {
     if (this.phase > Test.Phases.STARTED) {
       return undefined;
     }
@@ -128,7 +124,7 @@ export class Test {
    * @param [this_obj] - The object to use as the this
    * value when calling ``func``. Defaults to the :js:class:`Test` object.
    */
-  public step_func(func: UnknownFunc, this_obj?: object): UnknownFunc {
+  step_func(func: UnknownFunc, this_obj?: object): UnknownFunc {
     if (arguments.length === 1) {
       this_obj = this;
     }
@@ -148,7 +144,7 @@ export class Test {
    * @param [this_obj] - The object to use as the this
    * value when calling `func`. Defaults to the :js:class:`Test` object.
    */
-  public step_func_done(func?: UnknownFunc, this_obj?: object): UnknownFunc {
+  step_func_done(func?: UnknownFunc, this_obj?: object): UnknownFunc {
     if (arguments.length === 1) {
       this_obj = this;
     }
@@ -170,7 +166,7 @@ export class Test {
    * in case of failure.
    *
    */
-  public unreached_func(description?: string): UnknownFunc {
+  unreached_func(description?: string): UnknownFunc {
     return this.step_func(() => {
       assert_unreached(description);
     });
@@ -189,7 +185,7 @@ export class Test {
    * test step.
    *
    */
-  public step_timeout(
+  step_timeout(
     func: UnknownFunc,
     timeout: number,
     ...rest: unknown[]
@@ -200,11 +196,11 @@ export class Test {
     );
   }
 
-  public add_cleanup(func: UnknownFunc): void {
+  add_cleanup(func: UnknownFunc): void {
     this.cleanup_callbacks.push(func);
   }
 
-  public done(): void {
+  done(): void {
     if (this.phase >= Test.Phases.CLEANING) {
       return;
     }
@@ -212,7 +208,7 @@ export class Test {
     this.cleanup();
   }
 
-  public cleanup(): void {
+  cleanup(): void {
     // TODO(soon): Cleanup functions can also return a promise instead of being synchronous, but we don't need this for any tests currently.
     for (const cleanFn of this.cleanup_callbacks) {
       cleanFn();
@@ -223,12 +219,12 @@ export class Test {
 
 /* eslint-enable @typescript-eslint/no-this-alias */
 class SkippedTest extends Test {
-  public constructor(name: string, reason: TestErrorType) {
+  constructor(name: string, reason: TestErrorType) {
     super(name);
     this.error = reason;
   }
 
-  public override step(
+  override step(
     _func: UnknownFunc,
     _this_obj?: object,
     ..._rest: unknown[]
@@ -277,7 +273,7 @@ globalThis.promise_test = (func, name, properties): void => {
 class AsyncTest extends Test {
   private resolve: () => void;
 
-  public constructor(name: string, properties: unknown) {
+  constructor(name: string, properties: unknown) {
     super(name, properties);
 
     // eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- void is being used as a valid generic in this context
@@ -286,7 +282,7 @@ class AsyncTest extends Test {
     this.resolve = resolve;
   }
 
-  public override done(): void {
+  override done(): void {
     super.done();
     this.resolve();
   }

--- a/tools/base.eslint.config.mjs
+++ b/tools/base.eslint.config.mjs
@@ -17,8 +17,8 @@ export function baseConfig() {
       },
       rules: {
         "@typescript-eslint/explicit-function-return-type": "error",
-        "@typescript-eslint/explicit-member-accessibility": "error",
-        "@typescript-eslint/explicit-module-boundary-types": "error",
+        "@typescript-eslint/explicit-member-accessibility": ["error", { "accessibility": "no-public" }],
+        "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/no-require-imports": "error",
         "@typescript-eslint/prefer-enum-initializers": "error",
         "@typescript-eslint/restrict-template-expressions": "off",


### PR DESCRIPTION
Removes unnecessary eslint rule that forces to add "public" qualifier to all methods in classes. This is unnecessary and just a typescript sugar. Doesn't make any difference to add public or not, and just bloats the code.

I also enabled eslint on couple of more files with these changes.