### PR TITLE
suppress unnecessary microsoft-unqualified-friend warning

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -383,6 +383,7 @@ build:release_windows --copt="-fstrict-aliasing"
 build:windows --cxxopt='/std:c++20' --host_cxxopt='/std:c++20'
 build:windows --copt='/D_CRT_USE_BUILTIN_OFFSETOF' --host_copt='/D_CRT_USE_BUILTIN_OFFSETOF'
 build:windows --copt='/DWIN32_LEAN_AND_MEAN' --host_copt='/DWIN32_LEAN_AND_MEAN'
+build:windows --copt='-Wno-microsoft-unqualified-friend' --host_copt='-Wno-microsoft-unqualified-friend'
 # The `/std:c++20` argument is unused during BoringSSL compilation and we don't
 # want a warning when compiling each file.
 build:windows --copt='-Wno-unused-command-line-argument' --host_copt='-Wno-unused-command-line-argument'


### PR DESCRIPTION
This suppresses the following warning on Windows

```
bazel-out/x64_windows-opt/bin/src/workerd/io/_virtual_includes/io\workerd/api\blob.h(115,16): warning: unqualified friend declaration referring to type outside of the nearest enclosing namespace is a Microsoft extension; add a nested name specifier [-Wmicrosoft-unqualified-friend]
  115 |   friend class File;
      |                ^
      |                ::workerd::
1 warning generated.
```