### PR TITLE
Experimental feature: Dynamic worker loading

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -750,3 +750,9 @@ wd_test(
     args = ["--experimental"],
     data = ["tests/request-signal-passthrough.js"],
 )
+
+wd_test(
+    src = "worker-loader-test.wd-test",
+    args = ["--experimental"],
+    data = ["worker-loader-test.js"],
+)

--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -887,7 +887,7 @@ jsg::Ref<Fetcher> DurableObjectFacets::get(jsg::Lock& js, kj::String name, GetOp
     id = ioCtx.getActorOrThrow().cloneId();
   }
 
-  auto actorClass = ioCtx.getIoChannelFactory().getActorClass(options.$class->getChannel());
+  auto actorClass = options.$class->getChannel(ioCtx);
 
   kj::Own<Fetcher::OutgoingFactory> factory =
       kj::heap<FacetOutgoingFactory>(fm, kj::mv(actorClass), kj::mv(name), kj::mv(id));

--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -218,4 +218,16 @@ jsg::Ref<DurableObjectNamespace> DurableObjectNamespace::jurisdiction(
   KJ_UNREACHABLE;
 }
 
+kj::Own<IoChannelFactory::ActorClassChannel> DurableObjectClass::getChannel(IoContext& ioctx) {
+  KJ_SWITCH_ONEOF(channel) {
+    KJ_CASE_ONEOF(number, uint) {
+      return ioctx.getIoChannelFactory().getActorClass(number);
+    }
+    KJ_CASE_ONEOF(object, IoOwn<IoChannelFactory::ActorClassChannel>) {
+      return kj::addRef(*object);
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -263,17 +263,17 @@ class DurableObjectNamespace: public jsg::Object {
 class DurableObjectClass: public jsg::Object {
  public:
   DurableObjectClass(uint channel): channel(channel) {}
+  DurableObjectClass(IoOwn<IoChannelFactory::ActorClassChannel> channel)
+      : channel(kj::mv(channel)) {}
 
-  uint getChannel() const {
-    return channel;
-  }
+  kj::Own<IoChannelFactory::ActorClassChannel> getChannel(IoContext& ioctx);
 
   JSG_RESOURCE_TYPE(DurableObjectClass) {
     // No methods - this is just a handle that gets passed to ctx.facets.get()
   }
 
  private:
-  uint channel;
+  kj::OneOf<uint, IoOwn<IoChannelFactory::ActorClassChannel>> channel;
 };
 
 #define EW_ACTOR_ISOLATE_TYPES                                                                     \

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -2601,6 +2601,21 @@ kj::Own<WorkerInterface> Fetcher::getClient(
   KJ_UNREACHABLE;
 }
 
+kj::Own<IoChannelFactory::SubrequestChannel> Fetcher::getSubrequestChannel(IoContext& ioContext) {
+  KJ_SWITCH_ONEOF(channelOrClientFactory) {
+    KJ_CASE_ONEOF(channel, uint) {
+      return ioContext.getIoChannelFactory().getSubrequestChannel(channel);
+    }
+    KJ_CASE_ONEOF(outgoingFactory, IoOwn<OutgoingFactory>) {
+      return outgoingFactory->getSubrequestChannel();
+    }
+    KJ_CASE_ONEOF(outgoingFactory, kj::Own<CrossContextOutgoingFactory>) {
+      return outgoingFactory->getSubrequestChannel(ioContext);
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
 kj::Url Fetcher::parseUrl(jsg::Lock& js, kj::StringPtr url) {
   // We need to prep the request's URL for transmission over HTTP. fetch() accepts URLs that have
   // "." and ".." components as well as fragments (stuff after '#'), all of which needs to be

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -466,6 +466,13 @@ public:
   class OutgoingFactory {
   public:
     virtual kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) = 0;
+
+    // Get a `SubrequestChannel` representing this Fetcher. This is used especially when the
+    // Fetcher is being passed to another isolate.
+    virtual kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel() {
+      // TODO(soon): Update all implementations and remove this default implementation.
+      KJ_UNIMPLEMENTED("this Fetcher doesn't yet implement getSubrequestChannel()");
+    }
   };
 
   // Used by Fetchers that obtain their HttpClient in a custom way, but which aren't tied
@@ -474,6 +481,11 @@ public:
   class CrossContextOutgoingFactory {
   public:
     virtual kj::Own<WorkerInterface> newSingleUseClient(IoContext& context, kj::Maybe<kj::String> cfStr) = 0;
+
+    virtual kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel(IoContext& context) {
+      // TODO(soon): Update all implementations and remove this default implementation.
+      KJ_UNIMPLEMENTED("this Fetcher doesn't yet implement getSubrequestChannel()");
+    }
   };
 
   // `outgoingFactory` is used for Fetchers that use ad-hoc WorkerInterface instances, such as ones
@@ -500,6 +512,9 @@ public:
       IoContext& ioContext,
       kj::Maybe<kj::String> cfStr,
       kj::ConstString operationName);
+
+  // Get a SubrequestChannel representing this Fetcher.
+  kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel(IoContext& ioContext);
 
   // Wraps kj::Url::parse to take into account whether the Fetcher requires a host to be
   // specified on URLs, Fetcher-specific URL decoding options, and error handling.

--- a/src/workerd/api/worker-loader-test.js
+++ b/src/workerd/api/worker-loader-test.js
@@ -1,0 +1,59 @@
+import assert from 'node:assert';
+
+export let basics = {
+  async test(ctrl, env, ctx) {
+    let worker = env.loader.get('basics', () => {
+      return {
+        compatibilityDate: '2025-01-01',
+        mainModule: 'foo.js',
+        modules: {
+          'foo.js': `
+            export default {
+              greet(name) { return "Hello, " + name; }
+            }
+            export let alternate = {
+              greet(name) { return "Welcome, " + name; }
+            }
+          `,
+        },
+      };
+    });
+
+    {
+      let result = await worker.getEntrypoint().greet('Alice');
+      assert.strictEqual(result, 'Hello, Alice');
+    }
+
+    {
+      let result = await worker.getEntrypoint('alternate').greet('Bob');
+      assert.strictEqual(result, 'Welcome, Bob');
+    }
+  },
+};
+
+// Test supplying a basic `env` object.
+export let passEnv = {
+  async test(ctrl, env, ctx) {
+    let worker = env.loader.get('passEnv', () => {
+      return {
+        compatibilityDate: '2025-01-01',
+        mainModule: 'foo.js',
+        modules: {
+          'foo.js': `
+            export default {
+              fetch(req, env, ctx) {
+                return new Response("env.hello = " + env.hello);
+              },
+            }
+          `,
+        },
+        env: {
+          hello: 123,
+        },
+      };
+    });
+
+    let resp = await worker.getEntrypoint().fetch('https://example.com');
+    assert.strictEqual(await resp.text(), 'env.hello = 123');
+  },
+};

--- a/src/workerd/api/worker-loader-test.wd-test
+++ b/src/workerd/api/worker-loader-test.wd-test
@@ -10,7 +10,10 @@ const unitTests :Workerd.Config = (
         compatibilityDate = "2025-01-01",
         compatibilityFlags = ["nodejs_compat","experimental"],
         bindings = [
-          (name = "loader", workerLoader = (id = "my-loader")),
+          (name = "loader", workerLoader = ()),
+          (name = "sharedLoader1", workerLoader = (id = "shared")),
+          (name = "sharedLoader2", workerLoader = (id = "shared")),
+          (name = "uniqueLoader", workerLoader = (id = "nonshared")),
         ],
         durableObjectNamespaces = [
           (className = "FacetTestActor", uniqueKey = "FacetTestActor"),

--- a/src/workerd/api/worker-loader-test.wd-test
+++ b/src/workerd/api/worker-loader-test.wd-test
@@ -1,0 +1,18 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "worker-loader-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "worker-loader-test.js")
+        ],
+        compatibilityDate = "2025-01-01",
+        compatibilityFlags = ["nodejs_compat","experimental"],
+        bindings = [
+          (name = "loader", workerLoader = (id = "my-loader")),
+        ],
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/worker-loader-test.wd-test
+++ b/src/workerd/api/worker-loader-test.wd-test
@@ -12,6 +12,10 @@ const unitTests :Workerd.Config = (
         bindings = [
           (name = "loader", workerLoader = (id = "my-loader")),
         ],
+        durableObjectNamespaces = [
+          (className = "FacetTestActor", uniqueKey = "FacetTestActor"),
+        ],
+        durableObjectStorage = (inMemory = void),
       )
     ),
   ],

--- a/src/workerd/api/worker-loader.c++
+++ b/src/workerd/api/worker-loader.c++
@@ -1,0 +1,177 @@
+#include "worker-loader.h"
+
+#include <workerd/api/http.h>
+#include <workerd/io/compatibility-date.h>
+#include <workerd/io/features.h>
+#include <workerd/io/io-context.h>
+
+#include <capnp/message.h>
+
+namespace workerd::api {
+
+class WorkerStubEntrypointOutgoingFactory final: public Fetcher::OutgoingFactory {
+ public:
+  WorkerStubEntrypointOutgoingFactory(kj::Own<IoChannelFactory::SubrequestChannel> channel)
+      : channel(kj::mv(channel)) {}
+
+  kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) override {
+    auto& context = IoContext::current();
+
+    return context.getMetrics().wrapSubrequestClient(context.getSubrequest(
+        [&](TraceContext& tracing, IoChannelFactory& ioChannelFactory) {
+      return channel->startRequest({.cfBlobJson = kj::mv(cfStr), .tracing = tracing});
+    },
+        {.inHouse = true,
+          .wrapMetrics = true,
+          .operationName = kj::ConstString("dynamic_worker_subrequest"_kjc)}));
+  }
+
+ private:
+  kj::Own<IoChannelFactory::SubrequestChannel> channel;
+};
+
+jsg::Ref<Fetcher> WorkerStub::getEntrypoint(jsg::Lock& js,
+    jsg::Optional<kj::Maybe<kj::String>> name,
+    jsg::Optional<EntrypointOptions> options) {
+  Frankenvalue props;
+
+  KJ_IF_SOME(o, options) {
+    KJ_IF_SOME(p, o.props) {
+      props = Frankenvalue::fromJs(js, p);
+    }
+  }
+
+  kj::Maybe<kj::String> entrypointName;
+  KJ_IF_SOME(n, name) {
+    KJ_IF_SOME(n2, n) {
+      if (n2 != "default"_kj) {
+        entrypointName = kj::mv(n2);
+      }
+    }
+  }
+
+  kj::Own<Fetcher::OutgoingFactory> factory = kj::heap<WorkerStubEntrypointOutgoingFactory>(
+      channel->getEntrypoint(kj::mv(entrypointName), kj::mv(props)));
+
+  return js.alloc<Fetcher>(
+      IoContext::current().addObject(kj::mv(factory)), Fetcher::RequiresHostAndProtocol::YES, true);
+}
+
+jsg::Ref<DurableObjectClass> WorkerStub::getDurableObjectClass(jsg::Lock& js,
+    jsg::Optional<kj::Maybe<kj::String>> name,
+    jsg::Optional<EntrypointOptions> options) {
+  KJ_UNIMPLEMENTED("TODO(now): WorkerStub::getDurableObjectClass()");
+}
+
+jsg::Ref<WorkerStub> WorkerLoader::get(
+    jsg::Lock& js, kj::String name, jsg::Function<jsg::Promise<WorkerCode>()> getCode) {
+  auto& ioctx = IoContext::current();
+
+  auto reenterAndGetCode = ioctx.makeReentryCallback(
+      [getCode = kj::mv(getCode), compatDateValidation = compatDateValidation](
+          jsg::Lock& js) mutable {
+    return getCode(js).then(
+        js, [compatDateValidation](jsg::Lock& js, WorkerCode code) -> DynamicWorkerSource {
+      auto extractedSource = extractSource(js, code);
+      auto ownCompatFlags = extractCompatFlags(js, code, compatDateValidation);
+      CompatibilityFlags::Reader compatFlags = *ownCompatFlags;
+
+      Frankenvalue env;
+      KJ_IF_SOME(codeEnv, code.env) {
+        env = Frankenvalue::fromJs(js, codeEnv.getHandle(js));
+      }
+
+      return {.source = kj::mv(extractedSource),
+        .compatibilityFlags = compatFlags,
+        .env = kj::mv(env),
+        .ownContent = ownCompatFlags.attach(kj::mv(code.modules), kj::mv(code.mainModule))};
+    });
+  });
+
+  auto isolateChannel =
+      ioctx.getIoChannelFactory().loadIsolate(channel, kj::mv(name), kj::mv(reenterAndGetCode));
+
+  return js.alloc<WorkerStub>(ioctx.addObject(kj::mv(isolateChannel)));
+}
+
+Worker::Script::Source WorkerLoader::extractSource(jsg::Lock& js, WorkerCode& code) {
+  JSG_REQUIRE(code.modules.fields.size() > 0, TypeError,
+      "Dynamic Worker code must contain at least one module.");
+
+  auto modules = KJ_MAP(entry, code.modules.fields) -> Worker::Script::Module {
+    KJ_SWITCH_ONEOF(entry.value) {
+      KJ_CASE_ONEOF(text, kj::String) {
+        return {
+          .name = entry.name,
+          .content = Worker::Script::EsModule{.body = text},
+        };
+      }
+      KJ_CASE_ONEOF(module, Module) {
+        uint fieldCount = (module.js != kj::none) + (module.cjs != kj::none) +
+            (module.text != kj::none) + (module.data != kj::none) + (module.json != kj::none);
+        JSG_REQUIRE(fieldCount == 1, TypeError,
+            "Each module must contain exactly one of 'js', 'cjs', 'text', 'data', or 'json'. "
+            "Module '",
+            entry.name, "' contained ", fieldCount, " properties.");
+
+        return {.name = entry.name, .content = [&]() -> Worker::Script::ModuleContent {
+          KJ_IF_SOME(js, module.js) {
+            return Worker::Script::EsModule{.body = js};
+          } else KJ_IF_SOME(cjs, module.cjs) {
+            return Worker::Script::CommonJsModule{.body = cjs};
+          } else KJ_IF_SOME(text, module.text) {
+            return Worker::Script::TextModule{.body = text};
+          } else KJ_IF_SOME(data, module.data) {
+            return Worker::Script::DataModule{.body = data};
+          } else KJ_IF_SOME(json, module.json) {
+            kj::StringPtr serialized =
+                module.serializedJson.emplace(js.serializeJson(kj::mv(json)));
+            return Worker::Script::JsonModule{.body = serialized};
+          } else {
+            KJ_UNREACHABLE;
+          }
+        }()};
+      }
+    }
+    KJ_UNREACHABLE;
+  };
+
+  return Worker::Script::ModulesSource{
+    .mainModule = code.mainModule,
+    .modules = kj::mv(modules),
+
+    .isPython = false,  // TODO(someday): Support Python.
+  };
+}
+
+kj::Own<CompatibilityFlags::Reader> WorkerLoader::extractCompatFlags(
+    jsg::Lock& js, WorkerCode& code, CompatibilityDateValidation compatDateValidation) {
+  bool allowExperimental = code.allowExperimental.orDefault(false);
+  if (!FeatureFlags::get(js).getWorkerdExperimental()) {
+    JSG_REQUIRE(!allowExperimental, Error,
+        "'allowExperimental' is only allowed when the calling worker has the 'experimental' "
+        "compat flag set.");
+  }
+
+  kj::ArrayPtr<const kj::String> compatFlags;
+  KJ_IF_SOME(f, code.compatibilityFlags) {
+    compatFlags = f;
+  }
+
+  capnp::word scratch[capnp::sizeInWords<CompatibilityFlags>() + 4]{};
+  capnp::MallocMessageBuilder compatFlagsMessage(scratch);
+  auto compatFlagsBuilder = compatFlagsMessage.getRoot<CompatibilityFlags>();
+
+  SimpleWorkerErrorReporter errorReporter;
+
+  compileCompatibilityFlags(code.compatibilityDate, compatFlags, compatFlagsBuilder, errorReporter,
+      allowExperimental, compatDateValidation);
+
+  if (!errorReporter.errors.empty()) {
+    JSG_FAIL_REQUIRE(Error, errorReporter.errors.front());
+  }
+
+  return capnp::clone(compatFlagsBuilder.asReader());
+}
+
+}  // namespace workerd::api

--- a/src/workerd/api/worker-loader.h
+++ b/src/workerd/api/worker-loader.h
@@ -82,9 +82,14 @@ class WorkerLoader: public jsg::Object {
     // Any RPC-serializable value!
     jsg::Optional<jsg::JsRef<jsg::JsObject>> env;
 
-    jsg::Optional<jsg::Ref<Fetcher>> globalOutbound;
+    // `Fetcher` (e.g. service binding) representing the loaded worker's global outbound.
+    //
+    // If omitted, inherit the current worker's global outbound.
+    //
+    // If `null`, block the global outbound (all requests throw errors).
+    jsg::Optional<kj::Maybe<jsg::Ref<Fetcher>>> globalOutbound;
 
-    jsg::Optional<jsg::Ref<Fetcher>> cacheApiOutbound;
+    // TODO(someday): cache API outbound?
 
     // TODO(someday): Support specifying a list of tail workers. These should work similarly to
     //   globalOutbound.
@@ -95,8 +100,7 @@ class WorkerLoader: public jsg::Object {
         mainModule,
         modules,
         env,
-        globalOutbound,
-        cacheApiOutbound);
+        globalOutbound);
   };
 
   jsg::Ref<WorkerStub> get(

--- a/src/workerd/api/worker-loader.h
+++ b/src/workerd/api/worker-loader.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <workerd/io/compatibility-date.capnp.h>
+#include <workerd/io/compatibility-date.h>
+#include <workerd/io/io-channels.h>
+#include <workerd/io/io-own.h>
+#include <workerd/io/worker.h>
+#include <workerd/jsg/setup.h>
+
+namespace workerd::api {
+
+class Fetcher;
+class DurableObjectClass;
+
+// JS stub pointing to a remote Worker loaded using WorkerLoader. This is not a stub for a specific
+// entrypoint, but instead the entire Worker, allowing the caller to call any entrypoint (and
+// specify arbitrary props).
+class WorkerStub: public jsg::Object {
+ public:
+  WorkerStub(IoOwn<WorkerStubChannel> channel): channel(kj::mv(channel)) {}
+
+  struct EntrypointOptions {
+    jsg::Optional<jsg::JsObject> props;
+
+    JSG_STRUCT(props);
+  };
+
+  jsg::Ref<Fetcher> getEntrypoint(jsg::Lock& js,
+      jsg::Optional<kj::Maybe<kj::String>> name,
+      jsg::Optional<EntrypointOptions> options);
+  jsg::Ref<DurableObjectClass> getDurableObjectClass(jsg::Lock& js,
+      jsg::Optional<kj::Maybe<kj::String>> name,
+      jsg::Optional<EntrypointOptions> options);
+
+  JSG_RESOURCE_TYPE(WorkerStub) {
+    JSG_METHOD(getEntrypoint);
+    JSG_METHOD(getDurableObjectClass);
+  }
+
+ private:
+  IoOwn<WorkerStubChannel> channel;
+};
+
+// JS interface for worker loader binding.
+class WorkerLoader: public jsg::Object {
+ public:
+  // Create a WorkerLoader backed by the given I/O channel.
+  //
+  // `compatDateValidation` will differ between workerd vs. production.
+  explicit WorkerLoader(uint channel, CompatibilityDateValidation compatDateValidation)
+      : channel(channel),
+        compatDateValidation(compatDateValidation) {}
+
+  struct Module {
+    // Exactly one must be filled in.
+    jsg::Optional<kj::String> js;               // ES module
+    jsg::Optional<kj::String> cjs;              // Common JS module
+    jsg::Optional<kj::String> text;             // text blob, imports as a string
+    jsg::Optional<kj::Array<const byte>> data;  // byte blob, imports as ArrayBuffer
+    jsg::Optional<jsg::Value> json;             // arbitrary JS value, will be serialized to JSON
+                                                // and then parsed again when imported
+
+    JSG_STRUCT(js, cjs, text, data, json);
+
+    // HACK: When we serialize the JSON in extractSource() we need to place the owned kj::String
+    //   somewhere since Worker::Script::Source only gets a kj::StringPtr.
+    kj::Maybe<kj::String> serializedJson;
+  };
+
+  struct WorkerCode {
+    kj::String compatibilityDate;
+    jsg::Optional<kj::Array<kj::String>> compatibilityFlags;
+    jsg::Optional<bool> allowExperimental = false;
+
+    kj::String mainModule;
+
+    // Modules are specified as an object mapping names to content. If the content is just a
+    // string, an ES module is assumed. If it's an object, the type of module is determined
+    // based on which property is set.
+    jsg::Dict<kj::OneOf<Module, kj::String>> modules;
+
+    // Any RPC-serializable value!
+    jsg::Optional<jsg::JsRef<jsg::JsObject>> env;
+
+    jsg::Optional<jsg::Ref<Fetcher>> globalOutbound;
+
+    jsg::Optional<jsg::Ref<Fetcher>> cacheApiOutbound;
+
+    // TODO(someday): Support specifying a list of tail workers. These should work similarly to
+    //   globalOutbound.
+
+    JSG_STRUCT(compatibilityDate,
+        compatibilityFlags,
+        allowExperimental,
+        mainModule,
+        modules,
+        env,
+        globalOutbound,
+        cacheApiOutbound);
+  };
+
+  jsg::Ref<WorkerStub> get(
+      jsg::Lock& js, kj::String name, jsg::Function<jsg::Promise<WorkerCode>()> getCode);
+
+  JSG_RESOURCE_TYPE(WorkerLoader) {
+    JSG_METHOD(get);
+  }
+
+ private:
+  uint channel;
+  CompatibilityDateValidation compatDateValidation;
+
+  static Worker::Script::Source extractSource(jsg::Lock& js, WorkerCode& code);
+  static kj::Own<CompatibilityFlags::Reader> extractCompatFlags(
+      jsg::Lock& js, WorkerCode& code, CompatibilityDateValidation compatDateValidation);
+
+  kj::Promise<kj::Own<const Worker>> startWorker(
+      Worker::Script::Source extractedSource, CompatibilityFlags::Reader compatibilityFlags);
+};
+
+#define EW_WORKER_LOADER_ISOLATE_TYPES                                                             \
+  api::WorkerStub, api::WorkerStub::EntrypointOptions, api::WorkerLoader,                          \
+      api::WorkerLoader::Module, api::WorkerLoader::WorkerCode
+
+}  // namespace workerd::api

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -230,7 +230,8 @@ class WorkerStubChannel {
   virtual kj::Own<IoChannelFactory::SubrequestChannel> getEntrypoint(
       kj::Maybe<kj::String> name, Frankenvalue props) = 0;
 
-  // TODO(now): Expose actor class entrypoints for use with facets.
+  virtual kj::Own<IoChannelFactory::ActorClassChannel> getActorClass(
+      kj::Maybe<kj::String> name, Frankenvalue props) = 0;
 
   // TODO(someday): Allow caller to enumerate entrypoints?
 };

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -244,6 +244,9 @@ struct DynamicWorkerSource {
   // a `Frankenvalue` (which should eventually include all binding types, RPC stubs, etc.).
   Frankenvalue env;
 
+  // Where should global fetch() (and connect()) be sent?
+  kj::Own<IoChannelFactory::SubrequestChannel> globalOutbound;
+
   // Owns any data structures pointed into by the other members. (E.g. `source` contains a lot of
   // `StringPtr`s; `ownContent` owns the backing buffer for them.)
   kj::Own<void> ownContent;

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -139,7 +139,7 @@ class IoChannelFactory {
   // Object representing somehere where generic workers subrequests can be sent. Multiple requests
   // may be sent. This is an I/O type so it is only valid within the `IoContext` where it was
   // created.
-  class SubrequestChannel {
+  class SubrequestChannel: public kj::Refcounted {
    public:
     // Start a new request to this target.
     //

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -166,6 +166,20 @@ class IoChannelFactory {
   virtual kj::Own<ActorChannel> getColoLocalActor(
       uint channel, kj::StringPtr id, SpanParent parentSpan) = 0;
 
+  // ActorClassChannel is a reference to an actor class in another worker. This class acts as a
+  // token which can be passed into other interfaces that might use the actor class, particularly
+  // Worker::Actor::FacetManager.
+  class ActorClassChannel: public kj::Refcounted {
+   public:
+    // This class has no actual methods!
+  };
+
+  // Get an actor class binding corresponding to the given channel number.
+  virtual kj::Own<ActorClassChannel> getActorClass(uint channel) {
+    // TODO(cleanup): Remove this once the production runtime has implemented this.
+    KJ_UNIMPLEMENTED("This runtime doesn't support actor class channels.");
+  }
+
   // Aborts all actors except those in namespaces marked with `preventEviction`.
   virtual void abortAllActors(kj::Maybe<kj::Exception&> reason) {
     KJ_UNIMPLEMENTED("Only implemented by single-tenant workerd runtime");

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -797,8 +797,12 @@ class Worker::Actor final: public kj::Refcounted {
    public:
     // Information needed to start a facet.
     struct StartInfo {
-      // The actor class channel number, from a DurableObjectClass binding.
-      uint actorClassChannel;
+      // The actor class, from a DurableObjectClass binding.
+      //
+      // WARNING: The object passed here MUST be directly from IoChannelFactory::getActorClass(),
+      //   as the FacetManager implementation is allowed to assume it can downcast to whatever
+      //   type the IoChannelFactory produces.
+      kj::Own<IoChannelFactory::ActorClassChannel> actorClass;
 
       // ctx.id for the child object.
       Worker::Actor::Id id;

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3664,9 +3664,8 @@ class Server::WorkerLoaderNamespace {
         .moduleFallback = kj::none,
         .localActorConfigs = EMPTY_ACTOR_CONFIGS,
 
-        // TODO(now): Allow overriding globalOutbound.
         .globalOutbound{
-          .designator = config::Worker::Reader().getGlobalOutbound(),
+          .designator = kj::mv(source.globalOutbound),
           .errorContext = kj::str("Worker's globalOutbound"),
         },
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -652,7 +652,7 @@ class Server::ExternalTcpService final: public Service, private WorkerInterface 
 };
 
 // Service used when the service is configured as external HTTP service.
-class Server::ExternalHttpService final: public Service, private kj::TaskSet::ErrorHandler {
+class Server::ExternalHttpService final: public Service {
  public:
   ExternalHttpService(kj::Own<kj::NetworkAddress> addrParam,
       kj::Own<HttpRewriter> rewriter,
@@ -673,8 +673,7 @@ class Server::ExternalHttpService final: public Service, private kj::TaskSet::Er
         rewriter(kj::mv(rewriter)),
         headerTable(headerTable),
         byteStreamFactory(byteStreamFactory),
-        httpOverCapnpFactory(httpOverCapnpFactory),
-        waitUntilTasks(*this) {}
+        httpOverCapnpFactory(httpOverCapnpFactory) {}
 
   kj::Own<WorkerInterface> startRequest(IoChannelFactory::SubrequestMetadata metadata) override {
     return kj::heap<WorkerInterfaceImpl>(*this, kj::mv(metadata));
@@ -696,11 +695,6 @@ class Server::ExternalHttpService final: public Service, private kj::TaskSet::Er
   kj::HttpHeaderTable& headerTable;
   capnp::ByteStreamFactory& byteStreamFactory;
   capnp::HttpOverCapnpFactory& httpOverCapnpFactory;
-  kj::TaskSet waitUntilTasks;
-
-  void taskFailed(kj::Exception&& exception) override {
-    LOG_EXCEPTION("externalServiceWaitUntilTasks", exception);
-  }
 
   struct CapnpClient {
     kj::Own<kj::AsyncIoStream> connection;

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -164,6 +164,8 @@ class Server final: private kj::TaskSet::ErrorHandler {
 
   kj::HashMap<kj::String, kj::Own<Service>> services;
 
+  class WorkerLoaderNamespace;
+
   kj::Own<kj::PromiseFulfiller<void>> fatalFulfiller;
 
   // Initialized in startAlarmScheduler().
@@ -254,6 +256,7 @@ class Server final: private kj::TaskSet::ErrorHandler {
 
   struct ErrorReporter;
   struct ConfigErrorReporter;
+  struct DynamicErrorReporter;
   struct WorkerDef;
   kj::Own<WorkerService> makeWorkerImpl(kj::StringPtr name,
       WorkerDef def,

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -165,6 +165,7 @@ class Server final: private kj::TaskSet::ErrorHandler {
   kj::HashMap<kj::String, kj::Own<Service>> services;
 
   class WorkerLoaderNamespace;
+  kj::HashMap<kj::StringPtr, kj::Own<WorkerLoaderNamespace>> workerLoaderNamespaces;
 
   kj::Own<kj::PromiseFulfiller<void>> fatalFulfiller;
 
@@ -275,6 +276,8 @@ class Server final: private kj::TaskSet::ErrorHandler {
       kj::HttpHeaderTable::Builder& headerTableBuilder,
       kj::ForkedPromise<void>& forkedDrainWhen,
       bool forTest = false);
+
+  void unlinkWorkerLoaders();
 };
 
 // An ActorStorage implementation which will always respond to reads as if the state is empty,

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -278,6 +278,8 @@ class Server final: private kj::TaskSet::ErrorHandler {
       bool forTest = false);
 
   void unlinkWorkerLoaders();
+
+  friend struct FutureSubrequestChannel;
 };
 
 // An ActorStorage implementation which will always respond to reads as if the state is empty,

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -165,7 +165,8 @@ class Server final: private kj::TaskSet::ErrorHandler {
   kj::HashMap<kj::String, kj::Own<Service>> services;
 
   class WorkerLoaderNamespace;
-  kj::HashMap<kj::StringPtr, kj::Own<WorkerLoaderNamespace>> workerLoaderNamespaces;
+  kj::HashMap<kj::String, kj::Rc<WorkerLoaderNamespace>> workerLoaderNamespaces;
+  kj::Vector<kj::Rc<WorkerLoaderNamespace>> anonymousWorkerLoaderNamespaces;
 
   kj::Own<kj::PromiseFulfiller<void>> fatalFulfiller;
 

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -40,6 +40,7 @@
 #include <workerd/api/url-standard.h>
 #include <workerd/api/urlpattern-standard.h>
 #include <workerd/api/urlpattern.h>
+#include <workerd/api/worker-loader.h>
 #include <workerd/io/compatibility-date.h>
 #include <workerd/io/promise-wrapper.h>
 #include <workerd/jsg/jsg.h>
@@ -118,6 +119,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
     EW_RTTI_ISOLATE_TYPES,
     EW_HYPERDRIVE_ISOLATE_TYPES,
     EW_EVENTSOURCE_ISOLATE_TYPES,
+    EW_WORKER_LOADER_ISOLATE_TYPES,
     workerd::api::EnvModule,
 
     jsg::TypeWrapperExtension<PromiseWrapper>,

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -1006,6 +1006,12 @@ static v8::Local<v8::Value> createBindingValue(JsgWorkerdIsolate::Lock& lock,
     KJ_CASE_ONEOF(actorClass, Global::ActorClass) {
       value = lock.wrap(context, lock.alloc<api::DurableObjectClass>(actorClass.channel));
     }
+
+    KJ_CASE_ONEOF(workerLoader, Global::WorkerLoader) {
+      value = lock.wrap(context,
+          lock.alloc<api::WorkerLoader>(
+              workerLoader.channel, CompatibilityDateValidation::CODE_VERSION));
+    }
   }
 
   return value;
@@ -1095,6 +1101,9 @@ WorkerdApi::Global WorkerdApi::Global::clone() const {
 
     KJ_CASE_ONEOF(actorClass, Global::ActorClass) {
       result.value = actorClass.clone();
+    }
+    KJ_CASE_ONEOF(workerLoader, Global::WorkerLoader) {
+      result.value = workerLoader.clone();
     }
   }
 

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -238,6 +238,14 @@ class WorkerdApi final: public Worker::Api {
       }
     };
 
+    struct WorkerLoader {
+      uint channel;
+
+      WorkerLoader clone() const {
+        return *this;
+      }
+    };
+
     kj::String name;
     kj::OneOf<Json,
         Fetcher,
@@ -255,7 +263,8 @@ class WorkerdApi final: public Worker::Api {
         Hyperdrive,
         UnsafeEval,
         MemoryCache,
-        ActorClass>
+        ActorClass,
+        WorkerLoader>
         value;
 
     Global clone() const;

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -428,9 +428,11 @@ struct Worker {
         # Worker must have a name, and if a Worker with that name already exists, it'll be reused.
 
         id @27 :Text;
-        # The identifier associated with this Worker loader. Multiple Workers can bind to the
-        # same ID in order to access the same loader, so that if they request the same name from
-        # it, they'll end up sharing the same loaded Worker.
+        # Optional: The identifier associated with this Worker loader. Multiple Workers can bind to
+        # the same ID in order to access the same loader, so that if they request the same name
+        # from it, they'll end up sharing the same loaded Worker.
+        #
+        # (If omitted, the binding will not share a cache with any other binding.)
       }
 
       # TODO(someday): dispatch, other new features

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -419,6 +419,20 @@ struct Worker {
         limits @25 :MemoryCacheLimits;
       }
 
+      workerLoader :group {
+        # A binding representing the ability to dynamically load Workers from code presented at
+        # runtime.
+        #
+        # A Worker loader is not just a function that loads a Worker, but also serves as a
+        # cache of Workers, automatically unloading Workers that are not in use. To that end, each
+        # Worker must have a name, and if a Worker with that name already exists, it'll be reused.
+
+        id @27 :Text;
+        # The identifier associated with this Worker loader. Multiple Workers can bind to the
+        # same ID in order to access the same loader, so that if they request the same name from
+        # it, they'll end up sharing the same loaded Worker.
+      }
+
       # TODO(someday): dispatch, other new features
     }
 


### PR DESCRIPTION
This is an experimental-only feature and will probably remain so until we play around with it a bit. Similar to facets (#4123), the interface is likely to change based on testing. This is also strictly an implementation in workerd -- the production runtime would need a very different implementation.

A Worker loader binding allows you to start an isolate from code provided at runtime, and then talk to that isolate.

```js
let id = "foo";
let worker = env.LOADER.get(id, () => {
  // This callback is called if the given worker ID is not loaded yet.
  // (If a Worker with the same ID is already loaded by this loader, the
  // existing worker is returned without calling the callback.)

  // The callback returns the Worker's code. It can be async.
  return {
    compatibilityDate: "2025-06-01",

    // Specify the main module, whose exports are the entrypoints.
    mainModule: "foo.js",

    // Specify a map of all modules. This is an object mapping module
    // names to source code.
    modules: {
      // Normal ES modules are specified just as strings.
      "foo.js":
        "export default {\n" +
        "  fetch(req, env, ctx) { return new Response('Hello'); }\n" +
        "}\n",
      // Non-ES module types are supported too, by specifying an object
      // with one property that indicates the type.
      "some.wasm": { wasm: WASM_DATA },
    },

    // The `env` is specified as an arbitrary object. This gets serialized and
    // passed into the Worker.
    env: {
      SOME_ENV_VAR: 123
    },

    // You can override the global outbound. When the worker calls global
    // `fetch()` (or `connect()`), it will be directed to this service binding.
    globalOutbound: env.MY_OUTBOUND_WORKER,
  };
});

// Now you can get its entrypoint.
let defaultEntrypoint = worker.getEntrypoint();
await defaultEntrypoint.fetch(...);

// You can get non-default entrypoints as well.
let someEntrypoint = worker.getEntrypoint("SomeEntrypointClass");

// You can also get DO classes. These can be used with facets (#4123).
let someClass = worker.getDurableObjectClass("SomeDoClass");
```

[The test](https://github.com/cloudflare/workerd/pull/4383/files#diff-c49794f41387a0c828c7ccbcc621b25f6e4346b8a1346bec6a8d3ca88dd71958) has more examples.

TODO (this PR):
* Add a bunch more tests.

TODO (later PRs, probably):
* Eviction if idle workers.
* Extend `env` so you can actually provide resource bindings. Currently it can only contain simple serializable values.
* Support hooking up tails and cache API.