### PR TITLE
Fixes regression with SDK imports in Python search path.

### DIFF
--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -66,12 +66,9 @@ function setupPythonSearchPath(pyodide: Pyodide): void {
       from pathlib import Path
 
       VENDOR_PATH = "/session/metadata/vendor"
-      SESSION_PATH = "/session/metadata"
 
       # adjustSysPath adds the session path, but it is immortalised by the memory snapshot. This
       # code runs irrespective of the memory snapshot.
-      if SESSION_PATH in sys.path:
-        sys.path.remove(SESSION_PATH)
       if VENDOR_PATH in sys.path:
         sys.path.remove(VENDOR_PATH)
 
@@ -84,7 +81,7 @@ function setupPythonSearchPath(pyodide: Pyodide): void {
       # that reproduces this (vendor_dir).
       for i, path in enumerate(sys.path):
         if 'site-packages' in path:
-          sys.path[i:i] = [SESSION_PATH, VENDOR_PATH]
+          sys.path.insert(i, VENDOR_PATH)
           break
       else:
         # If no site-packages found, fail

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -157,9 +157,13 @@ class PyodideMetadataReader: public jsg::Object {
           createBaselineSnapshot(createBaselineSnapshot),
           memorySnapshot(kj::mv(memorySnapshot)),
           durableObjectClasses(kj::mv(durableObjectClasses)),
-          entrypointClasses(kj::mv(entrypointClasses)) {}
+          entrypointClasses(kj::mv(entrypointClasses)) {
+      verifyNoMainModuleInVendor();
+    }
 
     State(const State& other);
+
+    void verifyNoMainModuleInVendor();
 
     kj::Own<State> clone();
   };

--- a/src/workerd/server/tests/python/vendor_dir/vendor_dir.wd-test
+++ b/src/workerd/server/tests/python/vendor_dir/vendor_dir.wd-test
@@ -6,10 +6,14 @@ const unitTests :Workerd.Config = (
       worker = (
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py"),
+          (name = "duplicate.py", pythonModule = embed "vendor/a.py"),
           (name = "vendor/a.py", pythonModule = embed "vendor/a.py"),
           # This module below is only here to verify that we don't crash because of
           # duplicate module names.
-          (name = "vendor/worker.py", pythonModule = embed "vendor/a.py"),
+          (name = "vendor/duplicate.py", pythonModule = embed "vendor/a.py"),
+          # This module below exercises a bug which caused our internal introspection.py
+          # module to import it instead of the SDK module. See EW-9317 for more info.
+          (name = "workers.py", pythonModule = embed "vendor/a.py"),
           (name = "numpy", pythonRequirement = "")
         ],
         compatibilityDate = "2024-01-15",


### PR DESCRIPTION
The recent change to our search path caused an existing worker which had a `workers.py` file in their bundle to fail. This happened because our own code imports `workers.py` (which is also what our SDK entrypoint is), so it attempts to import the user's module instead of our SDK module.

I have changed our code to not move the path where the user's code is before the site-packages path (where the SDK is). This change also now means that if a worker places a module that shares the name with their main module in the vendor directory, it will attempt to import the file in the vendor directory. I think that what we want to do is just fail validation in that case and that's what I implemented here too.

I have implemented a validation test in the parent repo for this too.

### Test Plan

```
$ bazel run @workerd//src/workerd/server/tests/python:vendor_dir_development@
Python sys.path: ['/session', '/lib/python312.zip', '/lib/python3.12', '/lib/python3.12/lib-dynload', '/session/metadata/vendor', '/lib/python3.12/site-packages', '/session/metadata', '/session/lib/python3.12/site-packages']
```