### PR TITLE
[nfc] More clang-tidy and include cleanup

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -127,7 +127,7 @@ jsg::JsRef<jsg::JsValue> listResultsToMap(
     auto map = js.map();
     size_t cachedReadBytes = 0;
     size_t uncachedReadBytes = 0;
-    for (auto entry: value) {
+    for (const auto& entry: value) {
       auto& bytesRef =
           entry.status == ActorCacheOps::CacheStatus::CACHED ? cachedReadBytes : uncachedReadBytes;
       bytesRef += entry.key.size() + entry.value.size();
@@ -164,7 +164,7 @@ getMultipleResultsToMap(size_t numInputKeys) {
       auto map = js.map();
       uint32_t cachedUnits = 0;
       uint32_t uncachedUnits = 0;
-      for (auto entry: value) {
+      for (const auto& entry: value) {
         auto& unitsRef =
             entry.status == ActorCacheOps::CacheStatus::CACHED ? cachedUnits : uncachedUnits;
         unitsRef += billingUnits(entry.key.size() + entry.value.size());

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -10,12 +10,8 @@
 // abstractly related.
 
 #include <workerd/api/http.h>
-#include <workerd/api/worker-rpc.h>
 #include <workerd/io/actor-id.h>
 #include <workerd/jsg/jsg.h>
-
-#include <capnp/compat/byte-stream.h>
-#include <capnp/compat/http-over-capnp.h>
 
 namespace workerd {
 template <typename T>

--- a/src/workerd/api/analytics-engine.c++
+++ b/src/workerd/api/analytics-engine.c++
@@ -4,6 +4,7 @@
 
 #include "analytics-engine.h"
 
+#include <workerd/api/analytics-engine-impl.h>
 #include <workerd/api/analytics-engine.capnp.h>
 #include <workerd/io/io-context.h>
 

--- a/src/workerd/api/analytics-engine.h
+++ b/src/workerd/api/analytics-engine.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <workerd/api/analytics-engine-impl.h>
-#include <workerd/api/util.h>
 #include <workerd/io/io-util.h>
 #include <workerd/jsg/jsg.h>
 

--- a/src/workerd/api/crypto/dh.c++
+++ b/src/workerd/api/crypto/dh.c++
@@ -1,5 +1,7 @@
 #include "dh.h"
 
+#include "impl.h"
+
 #include <workerd/io/io-context.h>
 
 #include <ncrypto.h>

--- a/src/workerd/api/crypto/dh.h
+++ b/src/workerd/api/crypto/dh.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include "impl.h"
-
 #include <workerd/jsg/jsg.h>
 
-#include <openssl/dh.h>
+#include <openssl/base.h>
 
 #include <kj/common.h>
 

--- a/src/workerd/api/crypto/digest.c++
+++ b/src/workerd/api/crypto/digest.c++
@@ -240,7 +240,7 @@ kj::OneOf<jsg::Ref<CryptoKey>, CryptoKeyPair> CryptoKey::Impl::generateHmac(jsg:
       "HMAC key length must be a non-zero unsigned long integer (requested ", length, ").");
 
   auto keyDataArray = kj::heapArray<kj::byte>(
-      integerCeilDivision<std::make_unsigned<decltype(length)>::type>(length, 8u));
+      integerCeilDivision<std::make_unsigned_t<decltype(length)>>(length, 8u));
   IoContext::current().getEntropySource().generate(keyDataArray);
   zeroOutTrailingKeyBits(keyDataArray, length);
 

--- a/src/workerd/api/crypto/ec.c++
+++ b/src/workerd/api/crypto/ec.c++
@@ -232,7 +232,7 @@ class EllipticKey final: public AsymmetricKeyCryptoKeyImpl {
 
     kj::Vector<kj::byte> sharedSecret;
     sharedSecret.resize(
-        integerCeilDivision<std::make_unsigned<decltype(fieldSize)>::type>(fieldSize, 8u));
+        integerCeilDivision<std::make_unsigned_t<decltype(fieldSize)>>(fieldSize, 8u));
     auto written = ECDH_compute_key(sharedSecret.begin(), sharedSecret.capacity(),
         publicEcKey.getPublicKey(), privateEcKey.getKey(), nullptr);
     JSG_REQUIRE(written > 0, DOMOperationError, "Failed to generate shared ECDH secret",

--- a/src/workerd/api/crypto/jwk.h
+++ b/src/workerd/api/crypto/jwk.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "impl.h"
 #include "keys.h"
 
 namespace workerd::api {

--- a/src/workerd/api/hibernatable-web-socket.h
+++ b/src/workerd/api/hibernatable-web-socket.h
@@ -12,7 +12,6 @@
 #include <workerd/io/worker.h>
 
 #include <kj/debug.h>
-#include <kj/time.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/hibernation-event-params.h
+++ b/src/workerd/api/hibernation-event-params.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <kj/common.h>
-#include <kj/debug.h>
+#include <kj/exception.h>
 #include <kj/one-of.h>
 #include <kj/string.h>
 

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -190,7 +190,7 @@ bool Headers::hasLowerCase(kj::StringPtr name) {
     KJ_DREQUIRE(!('A' <= c && c <= 'Z'));
   }
 #endif
-  return headers.find(name) != headers.end();
+  return headers.contains(name);
 }
 
 kj::Array<Headers::DisplayedHeader> Headers::getDisplayedHeaders(jsg::Lock& js) {
@@ -306,7 +306,7 @@ kj::ArrayPtr<jsg::ByteString> Headers::getAll(jsg::ByteString name) {
 
 bool Headers::has(jsg::ByteString name) {
   requireValidHeaderName(name);
-  return headers.find(toLower(kj::mv(name))) != headers.end();
+  return headers.contains(toLower(kj::mv(name)));
 }
 
 void Headers::set(jsg::Lock& js, jsg::ByteString name, jsg::ByteString value) {

--- a/src/workerd/api/kv.h
+++ b/src/workerd/api/kv.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <workerd/api/http.h>
 #include <workerd/api/streams/readable.h>
 #include <workerd/api/worker-rpc.h>
 #include <workerd/io/limit-enforcer.h>

--- a/src/workerd/api/memory-cache.c++
+++ b/src/workerd/api/memory-cache.c++
@@ -54,7 +54,7 @@ SharedMemoryCache::~SharedMemoryCache() noexcept(false) {
 
 void SharedMemoryCache::suggest(const Limits& limits) const {
   auto data = this->data.lockExclusive();
-  bool isKnownLimit = data->suggestedLimits.find(limits) != data->suggestedLimits.end();
+  bool isKnownLimit = data->suggestedLimits.contains(limits);
   data->suggestedLimits.insert(limits);
   if (!isKnownLimit) {
     resize(*data);

--- a/src/workerd/api/memory-cache.h
+++ b/src/workerd/api/memory-cache.h
@@ -2,13 +2,12 @@
 
 #include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/jsg/jsg.h>
-#include <workerd/util/uuid.h>
 
 #include <kj/hash.h>
 #include <kj/map.h>
 #include <kj/mutex.h>
 #include <kj/table.h>
-#include <kj/timer.h>
+#include <kj/time.h>
 
 #include <list>
 #include <set>

--- a/src/workerd/api/node/async-hooks.h
+++ b/src/workerd/api/node/async-hooks.h
@@ -3,7 +3,6 @@
 //     https://opensource.org/licenses/Apache-2.0
 #pragma once
 
-#include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/jsg/async-context.h>
 #include <workerd/jsg/jsg.h>
 

--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -20,8 +20,6 @@
 
 #include <capnp/dynamic.h>
 
-#include <unordered_set>
-
 namespace workerd::api::node {
 
 // To be exposed only as an internal module for use by other built-ins.

--- a/src/workerd/api/node/timers.h
+++ b/src/workerd/api/node/timers.h
@@ -5,7 +5,7 @@
 
 #include <workerd/jsg/jsg.h>
 
-#include <kj/string.h>
+#include <kj/common.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/pyodide/pyodide-test.c++
+++ b/src/workerd/api/pyodide/pyodide-test.c++
@@ -242,7 +242,6 @@ w["h
   KJ_REQUIRE(result.size() == 0);
 }
 
-using pyodide::ArtifactBundler;
 using pyodide::PythonModuleInfo;
 
 template <typename... Params>

--- a/src/workerd/api/pyodide/requirements.c++
+++ b/src/workerd/api/pyodide/requirements.c++
@@ -5,6 +5,7 @@
 
 #include <capnp/compat/json.h>
 #include <capnp/message.h>
+#include <kj/debug.h>
 
 #include <cctype>
 

--- a/src/workerd/api/unsafe.c++
+++ b/src/workerd/api/unsafe.c++
@@ -1,5 +1,6 @@
 #include "unsafe.h"
 
+#include <workerd/io/io-context.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/script.h>
 

--- a/src/workerd/api/unsafe.h
+++ b/src/workerd/api/unsafe.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <workerd/io/io-context.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/modules-new.h>
 #include <workerd/jsg/url.h>

--- a/src/workerd/api/url-standard.h
+++ b/src/workerd/api/url-standard.h
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <kj/hash.h>
-#include "form-data.h"
+#include <kj/one-of.h>
 #include <workerd/api/blob.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/url.h>

--- a/src/workerd/io/hibernation-manager.h
+++ b/src/workerd/io/hibernation-manager.h
@@ -9,7 +9,7 @@
 #include <workerd/api/web-socket.h>
 #include <workerd/jsg/jsg.h>
 
-#include <kj/debug.h>
+#include <kj/exception.h>
 
 #include <list>
 

--- a/src/workerd/io/io-own.h
+++ b/src/workerd/io/io-own.h
@@ -2,11 +2,11 @@
 
 #include <workerd/util/weak-refs.h>
 
-#include <kj/async-io.h>
+#include <kj/async.h>
 #include <kj/common.h>
+#include <kj/function.h>
 #include <kj/mutex.h>
 #include <kj/refcount.h>
-#include <kj/string.h>
 #include <kj/vector.h>
 
 #include <typeinfo>

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -10,7 +10,6 @@
 #include <workerd/jsg/memory.h>
 #include <workerd/util/own-util.h>
 
-#include <kj/async.h>
 #include <kj/map.h>
 #include <kj/one-of.h>
 #include <kj/refcount.h>

--- a/src/workerd/io/worker-fs.c++
+++ b/src/workerd/io/worker-fs.c++
@@ -1073,7 +1073,7 @@ bool TmpDirStoreScope::hasCurrent() {
 
 TmpDirStoreScope& TmpDirStoreScope::current() {
   KJ_ASSERT(hasCurrent(), "no current TmpDirStoreScope");
-  return *static_cast<TmpDirStoreScope*>(tmpDirStorageScope);
+  return *tmpDirStorageScope;
 }
 
 TmpDirStoreScope::TmpDirStoreScope(kj::Maybe<kj::Badge<TmpDirStoreScope>> guard)

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -9,6 +9,7 @@
 
 #include <capnp/compat/http-over-capnp.h>
 #include <kj/compat/http.h>
+#include <kj/debug.h>
 
 namespace workerd {
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -12,20 +12,15 @@
 #include <workerd/io/frankenvalue.h>
 #include <workerd/io/io-channels.h>
 #include <workerd/io/limit-enforcer.h>
-#include <workerd/io/outcome.capnp.h>
 #include <workerd/io/request-tracker.h>
 #include <workerd/io/worker-fs.h>
-#include <workerd/io/worker-interface.capnp.h>
 #include <workerd/io/worker-interface.h>
 #include <workerd/io/worker-source.h>
 #include <workerd/jsg/async-context.h>
 #include <workerd/jsg/jsg.h>
-#include <workerd/util/thread-scopes.h>
 #include <workerd/util/uncaught-exception-source.h>
 #include <workerd/util/weak-refs.h>
-#include <workerd/util/xthreadnotifier.h>
 
-#include <capnp/schema.capnp.h>
 #include <kj/compat/http.h>
 #include <kj/mutex.h>
 

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -8,6 +8,7 @@
 #include "util.h"
 #include "wrappable.h"
 
+#include <v8-function.h>
 #include <v8-promise.h>
 
 #include <kj/async.h>

--- a/src/workerd/server/actor-id-impl-test.c++
+++ b/src/workerd/server/actor-id-impl-test.c++
@@ -11,8 +11,8 @@
 #include <kj/encoding.h>
 #include <kj/test.h>
 
-constexpr kj::byte zero32[SHA256_DIGEST_LENGTH] = {
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+constexpr kj::byte zero32[SHA256_DIGEST_LENGTH] = {0};
+
 KJ_TEST("ActorIdImpl equals test") {
   using ActorIdImpl = workerd::server::ActorIdFactoryImpl::ActorIdImpl;
   struct ActorEqualsTest {
@@ -25,7 +25,7 @@ KJ_TEST("ActorIdImpl equals test") {
         const char* rightString,
         bool expectedResult)
         : expectedResult(expectedResult) {
-      kj::byte idParamCopier[SHA256_DIGEST_LENGTH];
+      kj::byte idParamCopier[SHA256_DIGEST_LENGTH] = {0};
       memset(idParamCopier, leftFill, SHA256_DIGEST_LENGTH);
       if (leftString == nullptr) {
         actorLeft = ActorIdImpl(idParamCopier, kj::none);
@@ -59,10 +59,10 @@ kj::String computeProperTestMac(const char* strId, const char* strKey) {
   auto id = kj::decodeHex(kj::heapString(strId));
   KJ_ASSERT(!id.hadErrors);
   KJ_ASSERT(id.size() == SHA256_DIGEST_LENGTH);
-  kj::byte key[SHA256_DIGEST_LENGTH];
+  kj::byte key[SHA256_DIGEST_LENGTH] = {0};
   auto stringPtrKey = kj::StringPtr(strKey);
   SHA256(stringPtrKey.asBytes().begin(), stringPtrKey.size(), key);
-  kj::byte hmacOut[SHA256_DIGEST_LENGTH];
+  kj::byte hmacOut[SHA256_DIGEST_LENGTH] = {0};
   unsigned int len = SHA256_DIGEST_LENGTH;
   HMAC(EVP_sha256(), key, sizeof(key), id.begin(), BASE_LENGTH, hmacOut, &len);
   KJ_ASSERT(len == SHA256_DIGEST_LENGTH);

--- a/src/workerd/server/alarm-scheduler.h
+++ b/src/workerd/server/alarm-scheduler.h
@@ -9,7 +9,6 @@
 
 #include <kj/async.h>
 #include <kj/common.h>
-#include <kj/debug.h>
 #include <kj/map.h>
 #include <kj/time.h>
 #include <kj/timer.h>

--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -8,12 +8,10 @@
 
 #include <capnp/compat/byte-stream.h>
 #include <capnp/list.h>
-#include <capnp/message.h>
 #include <kj/async.h>
 #include <kj/compat/http.h>
 #include <kj/map.h>
 #include <kj/string.h>
-#include <kj/tuple.h>
 
 namespace workerd::server {
 

--- a/src/workerd/server/facet-tree-index-test.c++
+++ b/src/workerd/server/facet-tree-index-test.c++
@@ -156,7 +156,7 @@ KJ_TEST("FacetTreeIndex corruption handling") {
     // Write valid entry: parent=0, name="valid"
     uint16_t parent = 0;
     uint16_t nameLen = 5;
-    byte entry[4 + 5];
+    byte entry[4 + 5] = {0};
     memcpy(entry, &parent, 2);
     memcpy(entry + 2, &nameLen, 2);
     memcpy(entry + 4, "valid", 5);
@@ -165,7 +165,7 @@ KJ_TEST("FacetTreeIndex corruption handling") {
     // Write corrupted entry: parent=999 (invalid), name="corrupt"
     uint16_t badParent = 999;
     uint16_t badNameLen = 7;
-    byte badEntry[4 + 7];
+    byte badEntry[4 + 7] = {0};
     memcpy(badEntry, &badParent, 2);
     memcpy(badEntry + 2, &badNameLen, 2);
     memcpy(badEntry + 4, "corrupt", 7);
@@ -175,7 +175,7 @@ KJ_TEST("FacetTreeIndex corruption handling") {
     // Write valid entry after corruption that should be ignored
     uint16_t ignoredParent = 0;
     uint16_t ignoredNameLen = 7;
-    byte ignoredEntry[4 + 7];
+    byte ignoredEntry[4 + 7] = {0};
     memcpy(ignoredEntry, &ignoredParent, 2);
     memcpy(ignoredEntry + 2, &ignoredNameLen, 2);
     memcpy(ignoredEntry + 4, "ignored", 7);

--- a/src/workerd/server/facet-tree-index.c++
+++ b/src/workerd/server/facet-tree-index.c++
@@ -22,7 +22,7 @@ FacetTreeIndex::FacetTreeIndex(kj::Own<const kj::File> fileParam)
   // nothing was ever written to the index, so we just rewrite it and start over.
   if (fileBytes.size() <= sizeof(MAGIC_NUMBER)) {
     // New file, initialize with magic number.
-    file->write(0, kj::arrayPtr(MAGIC_NUMBER).asBytes());
+    file->write(0, kj::asBytes(MAGIC_NUMBER));
     file->datasync();
     offset = sizeof(MAGIC_NUMBER);
     return;

--- a/src/workerd/server/fallback-service.c++
+++ b/src/workerd/server/fallback-service.c++
@@ -5,6 +5,7 @@
 #include <kj/async-io.h>
 #include <kj/compat/http.h>
 #include <kj/compat/url.h>
+#include <kj/debug.h>
 #include <kj/one-of.h>
 #include <kj/string.h>
 #include <kj/thread.h>

--- a/src/workerd/util/mimetype.h
+++ b/src/workerd/util/mimetype.h
@@ -6,7 +6,6 @@
 #include <workerd/jsg/memory.h>
 
 #include <kj/common.h>
-#include <kj/exception.h>
 #include <kj/map.h>
 #include <kj/string.h>
 

--- a/src/workerd/util/uuid.c++
+++ b/src/workerd/util/uuid.c++
@@ -7,6 +7,7 @@
 #include <openssl/rand.h>
 
 #include <kj/compat/http.h>
+#include <kj/debug.h>
 
 #include <cstdlib>
 


### PR DESCRIPTION
Aided by misc-include-cleaner, the include cleanup here should reduce compile times slightly as the affected headers are used in a bunch of files, so total include size will decrease in a bunch of spots. No attempt is done to clean up includes in c++ files for now (which would be many more changes).
I expect that this will require downstream changes, I'll cover those in another PR.