### PR TITLE
containers: Abort when the monitor exception is DISCONNECT

### DIFF
--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -14,7 +14,26 @@ namespace workerd::api {
 
 Container::Container(rpc::Container::Client rpcClient, bool running)
     : rpcClient(IoContext::current().addObject(kj::heap(kj::mv(rpcClient)))),
-      running(running) {}
+      running(running) {
+}
+
+void catchAndAbortOnDisconnect(jsg::Lock& js, jsg::Value err) {
+  jsg::JsValue handle = jsg::JsValue(err.getHandle(js));
+  auto kjException = js.exceptionToKj(handle);
+
+  // Check if the error is around disconnect
+  if (kjException.getType() == kj::Exception::Type::DISCONNECTED) {
+    auto e = JSG_KJ_EXCEPTION(FAILED, Error, "The client has disconnected");
+
+    // And abort the DO if it's due to a disconnect
+    IoContext::current().abort(kj::mv(e));
+  }
+
+  // Or just propagate the original error
+  js.throwException(kj::mv(err));
+}
+
+
 
 void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions) {
   JSG_REQUIRE(!running, Error, "start() cannot be called on a container that is already running.");
@@ -75,7 +94,7 @@ jsg::Promise<void> Container::monitor(jsg::Lock& js) {
     running = false;
     destroyReason = kj::none;
     js.throwException(kj::mv(error));
-  });
+  }).catch_(js, catchAndAbortOnDisconnect);
 }
 
 jsg::Promise<void> Container::destroy(jsg::Lock& js, jsg::Optional<jsg::Value> error) {


### PR DESCRIPTION
The issue that we are trying to fix is the capability throwing DISCONNECTED and us aborting the DO if that happens.

maybe not the best way to do it? How would I go about it? I just came up with catching the monitor exception and aborting in that case.