### PR TITLE
test: Add failing `Request` + `expectedLength` tests to `workerd/api/tests/streams-test.js`

### DIFF
--- a/src/workerd/api/tests/streams-test.js
+++ b/src/workerd/api/tests/streams-test.js
@@ -36,6 +36,44 @@ export const ts = {
   },
 };
 
+export const rsRequest = {
+  async test(ctrl, env) {
+    const resp = await env.subrequest.fetch(
+      new Request('http://example.org', {
+        method: 'POST',
+        body: new ReadableStream({
+          expectedLength: 10,
+          start(c) {
+            c.enqueue(enc.encode('hellohello'));
+            c.close();
+          },
+        }),
+      })
+    );
+    for await (const _ of resp.body) {
+    }
+  },
+};
+
+export const tsRequest = {
+  async test(ctrl, env) {
+    const { readable, writable } = new TransformStream({
+      expectedLength: 10,
+    });
+    const writer = writable.getWriter();
+    writer.write(enc.encode('hellohello'));
+    writer.close();
+    const resp = await env.subrequest.fetch(
+      new Request('http://example.org', {
+        method: 'POST',
+        body: readable,
+      })
+    );
+    for await (const _ of resp.body) {
+    }
+  },
+};
+
 export const byobMin = {
   async test() {
     let controller;


### PR DESCRIPTION
As per the existing tests we'd expect the `Content-Length` to be adopted from the input stream even when a fetch request is made with `body` set to a fixed-length stream.

This follows from:
- https://github.com/cloudflare/workerd/commit/fd4fc7564c9a78b2925908700df5de7092c37041
- https://github.com/cloudflare/workerd/blob/a018eee88da5245a50c9340cf1bb07747cda6846/src/workerd/api/global-scope.c%2B%2B#L207-L213

However, when `new Request` is used, the original size of the stream is lost.