### PR TITLE
Adds support for passing None to Python SDK's Response API.

### DIFF
--- a/src/pyodide/internal/_workers.py
+++ b/src/pyodide/internal/_workers.py
@@ -262,7 +262,7 @@ class Response(FetchResponse):
                 raise TypeError(
                     f"Unsupported type in Response: {body.constructor.name}"
                 )
-        elif not isinstance(body, str | FormData):
+        elif not isinstance(body, str | FormData) and body is not None:
             raise TypeError(f"Unsupported type in Response: {type(body).__name__}")
 
         # Handle constructing a Response from a JS Response.

--- a/src/workerd/server/tests/python/sdk/worker.py
+++ b/src/workerd/server/tests/python/sdk/worker.py
@@ -417,6 +417,10 @@ async def response_unit_tests(env):
     response_json = Response.json("test", headers={"Content-Type": "42"})
     assert response_json.headers.get("content-type") == "42"
 
+    response_none = Response(None, status=204)
+    assert response_none.status == 204
+    assert response_none.body is None
+
     class Test:
         def __init__(self, x):
             self.x = x


### PR DESCRIPTION
In JS it appears we can pass either `undefined` or `null` to `new Response`. So passing in `None` in Python works just fine. This PR changes the SDK to allow `None` to be passed to the `Response` constructor.

This was reported on Discord.