### PR TITLE
Internal Build: Handle forks from Cloudflare org members

### DIFF
--- a/.github/workflows/internal-build-fork.yml
+++ b/.github/workflows/internal-build-fork.yml
@@ -64,13 +64,14 @@ jobs:
           CI_URL: ${{ secrets.CI_URL }}
           CI_CLIENT_ID: ${{ secrets.CI_CF_ACCESS_CLIENT_ID }}
           CI_CLIENT_SECRET: ${{ secrets.CI_CF_ACCESS_CLIENT_SECRET }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           python3 -u ./tools/cross/internal_build.py \
             ${{github.event.pull_request.number}} \
             ${{steps.get_sha.outputs.sha}} \
             ${{github.event.pull_request.head.sha}} \
             ${{github.run_attempt}} \
-            "${{github.event.pull_request.user.login}}/${{github.event.pull_request.head.ref}}" \
+            "${{github.event.pull_request.user.login}}/$HEAD_REF" \
             $CI_URL \
             $CI_CLIENT_ID \
             $CI_CLIENT_SECRET


### PR DESCRIPTION
~The internal build workflow is limited by the fact, that it needs a commit which belongs to `cloudflare/workerd` repo. Commits in forks, unfortunately, do not belong in this repo - hence we need to create an internal branch which mirrors the fork branch and then call the internal build with the mirror branch instead.~
It turns out that it works across forks - some magic involved I'm sure.