### PR TITLE
Change ctx.facets.get() to take a callback for start info. 

### DIFF
--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -392,17 +392,21 @@ class DurableObjectFacets: public jsg::Object {
   DurableObjectFacets(kj::Maybe<IoPtr<Worker::Actor::FacetManager>> facetManager)
       : facetManager(kj::mv(facetManager)) {}
 
-  struct GetOptions {
+  struct StartupOptions {
     jsg::Ref<DurableObjectClass> $class;
     jsg::Optional<kj::OneOf<jsg::Ref<DurableObjectId>, kj::String>> id;
 
     JSG_STRUCT($class, id);
   };
 
-  // Get a facet by name, starting it if it isn't already running (or restarting it if the options
-  // change). Returns a `Fetcher` instead of a `DurableObject` becasue the returend stub does not
-  // have the `id` or `name` methods that a DO stub normally has.
-  jsg::Ref<Fetcher> get(jsg::Lock& js, kj::String name, GetOptions options);
+  // Get a facet by name, starting it if it isn't already running. `getStartupOptions` is invoked
+  // only if the facet wasn't already running, to get information needed to start the facet.
+  //
+  // Returns a `Fetcher` instead of a `DurableObject` becasue the returend stub does not have the
+  // `id` or `name` methods that a DO stub normally has.
+  jsg::Ref<Fetcher> get(jsg::Lock& js,
+      kj::String name,
+      jsg::Function<jsg::Promise<StartupOptions>()> getStartupOptions);
 
   void abort(jsg::Lock& js, kj::String name, jsg::JsValue reason);
   void delete_(jsg::Lock& js, kj::String name);
@@ -665,6 +669,6 @@ class DurableObjectState: public jsg::Object {
       api::DurableObjectStorageOperations::GetAlarmOptions,                                        \
       api::DurableObjectStorageOperations::PutOptions,                                             \
       api::DurableObjectStorageOperations::SetAlarmOptions, api::WebSocketRequestResponsePair,     \
-      api::DurableObjectFacets, api::DurableObjectFacets::GetOptions
+      api::DurableObjectFacets, api::DurableObjectFacets::StartupOptions
 
 }  // namespace workerd::api

--- a/src/workerd/api/worker-loader-test.js
+++ b/src/workerd/api/worker-loader-test.js
@@ -119,7 +119,9 @@ export class FacetTestActor extends DurableObject {
 
     let cls = worker.getDurableObjectClass('MyActor');
 
-    let facet = this.ctx.facets.get('bar', { class: cls });
+    let facet = this.ctx.facets.get('bar', () => {
+      return { class: cls };
+    });
 
     assert.strictEqual(await facet.increment(), 1);
     assert.strictEqual(await facet.increment(4), 5);

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -810,7 +810,7 @@ class Worker::Actor final: public kj::Refcounted {
 
     // These methods are C++ equivalents of the JavaScript ctx.facets API.
     virtual kj::Own<IoChannelFactory::ActorChannel> getFacet(
-        kj::StringPtr name, StartInfo startInfo) = 0;
+        kj::StringPtr name, kj::Function<kj::Promise<StartInfo>()> getStartInfo) = 0;
     virtual void abortFacet(kj::StringPtr name, kj::Exception reason) = 0;
     virtual void deleteFacet(kj::StringPtr name) = 0;
   };

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2169,22 +2169,54 @@ class Server::WorkerService final: public Service,
                                 public kj::Refcounted,
                                 public Worker::Actor::FacetManager {
      public:
+      // Information which is needed before start() can be called, but may not be available yet
+      // when the ActorContainer is constructed (especially in the case of facets).
+      struct ClassAndId {
+        kj::Own<ActorClass> actorClass;
+        Worker::Actor::Id id;
+
+        ClassAndId(kj::Own<ActorClass> actorClass, Worker::Actor::Id id)
+            : actorClass(kj::mv(actorClass)),
+              id(kj::mv(id)) {}
+      };
+
       ActorContainer(kj::String key,
-          Worker::Actor::Id id,
           ActorNamespace& ns,
           kj::Maybe<ActorContainer&> parent,
-          kj::Own<ActorClass> actorClass,
+          kj::OneOf<ClassAndId, kj::Promise<ClassAndId>> classAndIdParam,
           kj::Timer& timer)
           : key(kj::mv(key)),
-            id(kj::mv(id)),
             tracker(kj::refcounted<RequestTracker>(*this)),
             ns(ns),
             root(parent.map([](ActorContainer& p) -> ActorContainer& { return p.root; })
                      .orDefault(*this)),
             parent(parent),
-            actorClass(kj::mv(actorClass)),
             timer(timer),
-            lastAccess(timer.now()) {}
+            lastAccess(timer.now()) {
+        KJ_SWITCH_ONEOF(classAndIdParam) {
+          KJ_CASE_ONEOF(value, ClassAndId) {
+            // `classAndId` is immediately available.
+            classAndId = kj::mv(value);
+          }
+          KJ_CASE_ONEOF(promise, kj::Promise<ClassAndId>) {
+            // We are receiving a promise for a `ClassAndId` to come later. Arrange to initialize
+            // `classAndId` from the promise. Create a `ForkedPromise<void>` that resolves when
+            // initialization is complete.
+            classAndId = promise
+                             .then([this](ClassAndId value) {
+              auto& forked = KJ_ASSERT_NONNULL(classAndId.tryGet<kj::ForkedPromise<void>>());
+              if (!forked.hasBranches()) {
+                // HACK: We're about to replace the ForkedPromise but it has no one waiting on it,
+                //   so we'd end up cancelling ourselves. Add a branch and detach it so this doesn't
+                //   happen.
+                forked.addBranch().detach([](auto&&) {});
+              }
+
+              classAndId = kj::mv(value);
+            }).fork();
+          }
+        }
+      }
 
       ~ActorContainer() noexcept(false) {
         // Shutdown the tracker so we don't use active/inactive hooks anymore.
@@ -2268,11 +2300,17 @@ class Server::WorkerService final: public Service,
         requireNotBroken();
 
         if (actor == kj::none) {
+          KJ_IF_SOME(promise, classAndId.tryGet<kj::ForkedPromise<void>>()) {
+            co_await promise;
+          }
+
+          auto& [actorClass, id] = KJ_ASSERT_NONNULL(classAndId.tryGet<ClassAndId>());
+
           KJ_IF_SOME(promise, actorClass->whenReady()) {
             co_await promise;
           }
 
-          start();
+          start(actorClass, id);
         }
 
         co_return KJ_ASSERT_NONNULL(actor)->addRef();
@@ -2286,6 +2324,9 @@ class Server::WorkerService final: public Service,
           // Need to start the cleanup loop.
           ns.cleanupTask = ns.cleanupLoop();
         }
+
+        // Since `getActor()` completed, `classAndId` must be resolved.
+        auto& actorClass = KJ_ASSERT_NONNULL(classAndId.tryGet<ClassAndId>()).actorClass;
 
         co_return actorClass->startRequest(kj::mv(metadata), kj::mv(actor))
             .attach(kj::defer([self = kj::addRef(*this)]() mutable { self->updateAccessTime(); }));
@@ -2326,8 +2367,8 @@ class Server::WorkerService final: public Service,
       kj::Own<ActorContainer> getFacetContainer(
           kj::String childKey, Worker::Actor::Id childId, kj::Own<ActorClass> childActorClass) {
         auto makeContainer = [&]() {
-          return kj::refcounted<ActorContainer>(
-              kj::mv(childKey), kj::mv(childId), ns, *this, kj::mv(childActorClass), timer);
+          return kj::refcounted<ActorContainer>(kj::mv(childKey), ns, *this,
+              ClassAndId(kj::mv(childActorClass), kj::mv(childId)), timer);
         };
 
         bool isNew = false;
@@ -2339,9 +2380,13 @@ class Server::WorkerService final: public Service,
             container->getKey(), kj::mv(container)};
         });
 
+        // TODO(now): This KJ_ASSERT_NONNULL isn't really valid but this block is going away in the
+        //   next commit anyway.
+        auto& [entryClass, entryId] =
+            KJ_ASSERT_NONNULL(entry.value->classAndId.tryGet<ClassAndId>());
         if (!isNew &&
-            (entry.value->actorClass.get() != childActorClass.get() ||
-                !Worker::Actor::idsEqual(entry.value->id, childId))) {
+            (entryClass.get() != childActorClass.get() ||
+                !Worker::Actor::idsEqual(entryId, childId))) {
           // TODO(facets): Should this be a softer restart?
           entry.value->abort(JSG_KJ_EXCEPTION(FAILED, Error,
               "The facet is restarting because the parent specified different parameters to "
@@ -2391,18 +2436,20 @@ class Server::WorkerService final: public Service,
       kj::Maybe<kj::Own<Worker::Actor>> actor;
 
       kj::String key;
-      Worker::Actor::Id id;
       kj::Own<RequestTracker> tracker;
       ActorNamespace& ns;
       ActorContainer& root;
       kj::Maybe<ActorContainer&> parent;
-      kj::Own<ActorClass> actorClass;
       kj::Timer& timer;
       kj::TimePoint lastAccess;
       kj::Maybe<kj::Own<Worker::Actor::HibernationManager>> manager;
       kj::Maybe<kj::Promise<void>> shutdownTask;
       kj::Maybe<kj::Promise<void>> onBrokenTask;
       kj::Maybe<kj::Exception> brokenReason;
+
+      // If this is a `ForkedPromise<void>`, await the promise. When it has resolved, then
+      // `classAndId` will have been replaced with the resolved `ClassAndId` value.
+      kj::OneOf<ClassAndId, kj::ForkedPromise<void>> classAndId;
 
       // FacetTreeIndex for this actor. Only initialized on the root.
       kj::Maybe<kj::Own<FacetTreeIndex>> facetTreeIndex;
@@ -2573,7 +2620,7 @@ class Server::WorkerService final: public Service,
         actor = kj::none;
       }
 
-      void start() {
+      void start(kj::Own<ActorClass>& actorClass, Worker::Actor::Id& id) {
         KJ_REQUIRE(actor == nullptr);
 
         auto makeActorCache = [this](const ActorCache::SharedLru& sharedLru, OutputGate& outputGate,
@@ -2700,8 +2747,8 @@ class Server::WorkerService final: public Service,
 
       return actors
           .findOrCreate(key, [&]() mutable {
-        auto container = kj::refcounted<ActorContainer>(
-            kj::mv(key), kj::mv(id), *this, kj::none, kj::addRef(*actorClass), timer);
+        auto container = kj::refcounted<ActorContainer>(kj::mv(key), *this, kj::none,
+            ActorContainer::ClassAndId(kj::addRef(*actorClass), kj::mv(id)), timer);
 
         return kj::HashMap<kj::StringPtr, kj::Own<ActorContainer>>::Entry{
           container->getKey(), kj::mv(container)};

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -688,11 +688,16 @@ declare class WebSocketRequestResponsePair {
   get response(): string;
 }
 interface DurableObjectFacets {
-  get(name: string, options: DurableObjectFacetsGetOptions): Fetcher;
+  get(
+    name: string,
+    getStartupOptions: () =>
+      | DurableObjectFacetsStartupOptions
+      | Promise<DurableObjectFacetsStartupOptions>,
+  ): Fetcher;
   abort(name: string, reason: any): void;
   delete(name: string): void;
 }
-interface DurableObjectFacetsGetOptions {
+interface DurableObjectFacetsStartupOptions {
   $class: DurableObjectClass;
   id?: DurableObjectId | string;
 }

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -693,11 +693,16 @@ export declare class WebSocketRequestResponsePair {
   get response(): string;
 }
 export interface DurableObjectFacets {
-  get(name: string, options: DurableObjectFacetsGetOptions): Fetcher;
+  get(
+    name: string,
+    getStartupOptions: () =>
+      | DurableObjectFacetsStartupOptions
+      | Promise<DurableObjectFacetsStartupOptions>,
+  ): Fetcher;
   abort(name: string, reason: any): void;
   delete(name: string): void;
 }
-export interface DurableObjectFacetsGetOptions {
+export interface DurableObjectFacetsStartupOptions {
   $class: DurableObjectClass;
   id?: DurableObjectId | string;
 }


### PR DESCRIPTION
Previously, the caller of `facets.get()` would always provide the actor class and (optionally) `id`. If the facet was already running, these values would be compared against the running copy, and the facet would be reset if they didn't match.

This proves to be a bit problematic:

* Comparing ActorClass objects for equality proves to be more difficult than expected. With dynamic worker loading, the actor class may have dynamically-specified `props`, and comparing `props` for equality is not really possible since it's an arbitrary value. We could say that if you call `dynamicWorker.getActorClass()` multiple times, even with the same inputs, the returned classes are considered "different", but this would probably lead to facets restarting unexpectedly.

* The API is aesthetically inconsistent with dynamic worker loading. With worker loaders, you call `loader.get(name, callback)`, where the callback returns the worker code. The callback is not called if the worker is already running. For consistency, facets should work the same way.

So, this changes the facets API to now expect a callback as the second parameter to `get()`. The callback is not called if the facet is already running. If you want to change the class or ID, you'll have to abort() the existing facet first.