### PR TITLE
Locally disable clang-format on lambdas inside struct initializers.

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1295,59 +1295,59 @@ void Request::serialize(jsg::Lock& js,
   // Our strategy is to construct an initializer dict object and serialize that as a JS object.
   // This makes the deserialization end really simple (just call the constructor), and it also
   // gives us extensibility: we can add new fields without having to bump the serialization tag.
-  serializer.write(js,
-      jsg::JsValue(initDictHandler.wrap(js,
-          RequestInitializerDict{
-            // GET is the default, so only serialize the method if it's something else.
-            .method = method == kj::HttpMethod::GET ? jsg::Optional<kj::String>() : kj::str(method),
+  // clang-format off
+  serializer.write(js, jsg::JsValue(initDictHandler.wrap(js, RequestInitializerDict{
+    // GET is the default, so only serialize the method if it's something else.
+    .method = method == kj::HttpMethod::GET ? jsg::Optional<kj::String>() : kj::str(method),
 
-            .headers = headers.addRef(),
+    .headers = headers.addRef(),
 
-            .body = getBody().map([](jsg::Ref<ReadableStream> stream) -> Body::Initializer {
-    // jsg::Ref<ReadableStream> is one of the possible variants of Body::Initializer.
-    return kj::mv(stream);
-  }),
+    .body = getBody().map([](jsg::Ref<ReadableStream> stream) -> Body::Initializer {
+      // jsg::Ref<ReadableStream> is one of the possible variants of Body::Initializer.
+      return kj::mv(stream);
+    }),
 
-            // "manual" is the default for `redirect`, so only encode if it's not that.
-            .redirect = redirect == Redirect::MANUAL ? kj::str(getRedirect())
-                                                     : kj::Maybe<kj::String>(kj::none),
+    // "manual" is the default for `redirect`, so only encode if it's not that.
+    .redirect = redirect == Redirect::MANUAL ? kj::str(getRedirect())
+                                              : kj::Maybe<kj::String>(kj::none),
 
-            // We have to ignore .fetcher for serialization. We can't simply fail if a fetcher is present
-            // because requests received by the top-level fetch handler actually have .fetcher set to
-            // the hidden "next" binding, which historically could be different from null (although in
-            // practice these days it is always the same). We obviously want to be able to serialize
-            // requests received by the top-level fetch handler so... we have to ignore this. This
-            // property should probably go away in any case.
+    // We have to ignore .fetcher for serialization. We can't simply fail if a fetcher is present
+    // because requests received by the top-level fetch handler actually have .fetcher set to
+    // the hidden "next" binding, which historically could be different from null (although in
+    // practice these days it is always the same). We obviously want to be able to serialize
+    // requests received by the top-level fetch handler so... we have to ignore this. This
+    // property should probably go away in any case.
 
-            .cf = cf.getRef(js),
+    .cf = cf.getRef(js),
 
-            .cache = getCacheModeName(cacheMode).map(
-                [](kj::StringPtr name) -> kj::String { return kj::str(name); }),
+    .cache = getCacheModeName(cacheMode).map(
+        [](kj::StringPtr name) -> kj::String { return kj::str(name); }),
 
-            // .mode is unimplemented
-            // .credentials is unimplemented
-            // .referrer is unimplemented
-            // .referrerPolicy is unimplemented
-            // .integrity is required to be empty
+    // .mode is unimplemented
+    // .credentials is unimplemented
+    // .referrer is unimplemented
+    // .referrerPolicy is unimplemented
+    // .integrity is required to be empty
 
-            // If an AbortSignal is present, we'll try to serialize it. As of this writing, AbortSignal
-            // is not serializable, but we could add support for sending it over RPC in the future.
-            //
-            // Note we have to double-Maybe this, so that if no signal is present, the property is absent
-            // instead of `null`.
-            .signal =
-                signal.map([&js](jsg::Ref<AbortSignal>& s) -> kj::Maybe<jsg::Ref<AbortSignal>> {
-    if (s->isIgnoredForSubrequests(js)) {
-      return kj::none;
-    }
+    // If an AbortSignal is present, we'll try to serialize it. As of this writing, AbortSignal
+    // is not serializable, but we could add support for sending it over RPC in the future.
+    //
+    // Note we have to double-Maybe this, so that if no signal is present, the property is absent
+    // instead of `null`.
+    .signal =
+        signal.map([&js](jsg::Ref<AbortSignal>& s) -> kj::Maybe<jsg::Ref<AbortSignal>> {
+      if (s->isIgnoredForSubrequests(js)) {
+        return kj::none;
+      }
 
-    return s.addRef();
-  }),
+      return s.addRef();
+    }),
 
-            // Only serialize responseBodyEncoding if it's not the default AUTO
-            .encodeResponseBody = responseBodyEncoding == Response_BodyEncoding::AUTO
-                ? jsg::Optional<kj::String>()
-                : kj::str("manual")})));
+    // Only serialize responseBodyEncoding if it's not the default AUTO
+    .encodeResponseBody = responseBodyEncoding == Response_BodyEncoding::AUTO
+        ? jsg::Optional<kj::String>()
+        : kj::str("manual")
+  })));
 }
 
 jsg::Ref<Request> Request::deserialize(jsg::Lock& js,

--- a/src/workerd/api/streams/standard-test.c++
+++ b/src/workerd/api/streams/standard-test.c++
@@ -44,33 +44,32 @@ KJ_TEST("ReadableStream read all text (value readable)") {
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .pull =
-              [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
-      // Because we're using a value-based stream, two enqueue operations will
-      // require at least three reads to complete: one for the first chunk, 'hello, ',
-      // one for the second chunk, 'world!', and one to signal close.
-      KJ_SWITCH_ONEOF(controller) {
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
         // Because we're using a value-based stream, two enqueue operations will
         // require at least three reads to complete: one for the first chunk, 'hello, ',
         // one for the second chunk, 'world!', and one to signal close.
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
-          checked++;
-          c->enqueue(js, toBytes(js, kj::str("Hello, ")));
-          c->enqueue(js, toBytes(js, kj::str("world!")));
-          c->close(js);
-          return js.resolvedPromise();
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
+            checked++;
+            c->enqueue(js, toBytes(js, kj::str("Hello, ")));
+            c->enqueue(js, toBytes(js, kj::str("world!")));
+            c->close(js);
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
+        KJ_UNREACHABLE;
       }
-      KJ_UNREACHABLE;
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise =
@@ -101,33 +100,32 @@ KJ_TEST("ReadableStream read all text, rs ref held (value readable)") {
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .pull =
-              [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
-      // Because we're using a value-based stream, two enqueue operations will
-      // require at least three reads to complete: one for the first chunk, 'hello, ',
-      // one for the second chunk, 'world!', and one to signal close.
-      KJ_SWITCH_ONEOF(controller) {
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
         // Because we're using a value-based stream, two enqueue operations will
         // require at least three reads to complete: one for the first chunk, 'hello, ',
         // one for the second chunk, 'world!', and one to signal close.
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
-          checked++;
-          c->enqueue(js, toBytes(js, kj::str("Hello, ")));
-          c->enqueue(js, toBytes(js, kj::str("world!")));
-          c->close(js);
-          return js.resolvedPromise();
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
+            checked++;
+            c->enqueue(js, toBytes(js, kj::str("Hello, ")));
+            c->enqueue(js, toBytes(js, kj::str("world!")));
+            c->close(js);
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
+        KJ_UNREACHABLE;
       }
-      KJ_UNREACHABLE;
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise =
@@ -154,34 +152,33 @@ KJ_TEST("ReadableStream read all text (byte readable)") {
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .type = kj::str("bytes"),
-          .pull =
-              [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
-      // Because we're using a value-based stream, two enqueue operations will
-      // require at least three reads to complete: one for the first chunk, 'hello, ',
-      // one for the second chunk, 'world!', and one to signal close.
-      KJ_SWITCH_ONEOF(controller) {
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .type = kj::str("bytes"),
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
         // Because we're using a value-based stream, two enqueue operations will
         // require at least three reads to complete: one for the first chunk, 'hello, ',
         // one for the second chunk, 'world!', and one to signal close.
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
-          checked++;
-          c->enqueue(js, toBufferSource(js, kj::str("Hello, ")));
-          c->enqueue(js, toBufferSource(js, kj::str("world!")));
-          c->close(js);
-          return js.resolvedPromise();
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
+            checked++;
+            c->enqueue(js, toBufferSource(js, kj::str("Hello, ")));
+            c->enqueue(js, toBufferSource(js, kj::str("world!")));
+            c->close(js);
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
+        KJ_UNREACHABLE;
       }
-      KJ_UNREACHABLE;
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise =
@@ -212,33 +209,32 @@ KJ_TEST("ReadableStream read all bytes (value readable)") {
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .pull =
-              [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
-      // Because we're using a value-based stream, two enqueue operations will
-      // require at least three reads to complete: one for the first chunk, 'hello, ',
-      // one for the second chunk, 'world!', and one to signal close.
-      KJ_SWITCH_ONEOF(controller) {
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
         // Because we're using a value-based stream, two enqueue operations will
         // require at least three reads to complete: one for the first chunk, 'hello, ',
         // one for the second chunk, 'world!', and one to signal close.
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
-          checked++;
-          c->enqueue(js, toBytes(js, kj::str("Hello, ")));
-          c->enqueue(js, toBytes(js, kj::str("world!")));
-          c->close(js);
-          return js.resolvedPromise();
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
+            checked++;
+            c->enqueue(js, toBytes(js, kj::str("Hello, ")));
+            c->enqueue(js, toBytes(js, kj::str("world!")));
+            c->close(js);
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
+        KJ_UNREACHABLE;
       }
-      KJ_UNREACHABLE;
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(
@@ -269,34 +265,33 @@ KJ_TEST("ReadableStream read all bytes (byte readable)") {
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .type = kj::str("bytes"),
-          .pull =
-              [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
-      // Because we're using a value-based stream, two enqueue operations will
-      // require at least three reads to complete: one for the first chunk, 'hello, ',
-      // one for the second chunk, 'world!', and one to signal close.
-      KJ_SWITCH_ONEOF(controller) {
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .type = kj::str("bytes"),
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
         // Because we're using a value-based stream, two enqueue operations will
         // require at least three reads to complete: one for the first chunk, 'hello, ',
         // one for the second chunk, 'world!', and one to signal close.
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
-          checked++;
-          c->enqueue(js, toBufferSource(js, kj::str("Hello, ")));
-          c->enqueue(js, toBufferSource(js, kj::str("world!")));
-          c->close(js);
-          return js.resolvedPromise();
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
+            checked++;
+            c->enqueue(js, toBufferSource(js, kj::str("Hello, ")));
+            c->enqueue(js, toBufferSource(js, kj::str("world!")));
+            c->close(js);
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
+        KJ_UNREACHABLE;
       }
-      KJ_UNREACHABLE;
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(
@@ -331,35 +326,34 @@ KJ_TEST("ReadableStream read all bytes (value readable, more reads)") {
     auto chunks = kj::arr<kj::String>(kj::str("H"), kj::str("e"), kj::str("l"), kj::str("l"),
         kj::str("o"), kj::str(","), kj::str(" "), kj::str("w"), kj::str("o"), kj::str("r"),
         kj::str("l"), kj::str("d"), kj::str("!"));
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .pull =
-              [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
-      // Because we're using a value-based stream, two enqueue operations will
-      // require at least three reads to complete: one for the first chunk, 'hello, ',
-      // one for the second chunk, 'world!', and one to signal close.
-      KJ_SWITCH_ONEOF(controller) {
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
         // Because we're using a value-based stream, two enqueue operations will
         // require at least three reads to complete: one for the first chunk, 'hello, ',
         // one for the second chunk, 'world!', and one to signal close.
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
-          checked++;
-          c->enqueue(js, toBytes(js, kj::mv(chunks[counter++])));
-          if (counter == chunks.size()) {
-            c->close(js);
-          }
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
+            checked++;
+            c->enqueue(js, toBytes(js, kj::mv(chunks[counter++])));
+            if (counter == chunks.size()) {
+              c->close(js);
+            }
 
-          return js.resolvedPromise();
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
+        KJ_UNREACHABLE;
       }
-      KJ_UNREACHABLE;
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(
@@ -394,36 +388,35 @@ KJ_TEST("ReadableStream read all bytes (byte readable, more reads)") {
     auto chunks = kj::arr<kj::String>(kj::str("H"), kj::str("e"), kj::str("l"), kj::str("l"),
         kj::str("o"), kj::str(","), kj::str(" "), kj::str("w"), kj::str("o"), kj::str("r"),
         kj::str("l"), kj::str("d"), kj::str("!"));
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .type = kj::str("bytes"),
-          .pull =
-              [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
-      // Because we're using a value-based stream, two enqueue operations will
-      // require at least three reads to complete: one for the first chunk, 'hello, ',
-      // one for the second chunk, 'world!', and one to signal close.
-      KJ_SWITCH_ONEOF(controller) {
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .type = kj::str("bytes"),
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
         // Because we're using a value-based stream, two enqueue operations will
         // require at least three reads to complete: one for the first chunk, 'hello, ',
         // one for the second chunk, 'world!', and one to signal close.
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
-          checked++;
-          c->enqueue(js, toBufferSource(js, kj::mv(chunks[counter++])));
-          if (counter == chunks.size()) {
-            c->close(js);
-          }
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
+            checked++;
+            c->enqueue(js, toBufferSource(js, kj::mv(chunks[counter++])));
+            if (counter == chunks.size()) {
+              c->close(js);
+            }
 
-          return js.resolvedPromise();
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
+        KJ_UNREACHABLE;
       }
-      KJ_UNREACHABLE;
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(
@@ -461,36 +454,35 @@ KJ_TEST("ReadableStream read all bytes (byte readable, large data)") {
     chunks[0].asPtr().fill('A');
     chunks[1].asPtr().fill('B');
     chunks[2].asPtr().fill('C');
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .type = kj::str("bytes"),
-          .pull =
-              [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
-      // Because we're using a value-based stream, two enqueue operations will
-      // require at least three reads to complete: one for the first chunk, 'hello, ',
-      // one for the second chunk, 'world!', and one to signal close.
-      KJ_SWITCH_ONEOF(controller) {
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .type = kj::str("bytes"),
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
         // Because we're using a value-based stream, two enqueue operations will
         // require at least three reads to complete: one for the first chunk, 'hello, ',
         // one for the second chunk, 'world!', and one to signal close.
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
-          checked++;
-          c->enqueue(js, toBufferSource(js, kj::mv(chunks[counter++])));
-          if (counter == chunks.size()) {
-            c->close(js);
-          }
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
+            checked++;
+            c->enqueue(js, toBufferSource(js, kj::mv(chunks[counter++])));
+            if (counter == chunks.size()) {
+              c->close(js);
+            }
 
-          return js.resolvedPromise();
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
+        KJ_UNREACHABLE;
       }
-      KJ_UNREACHABLE;
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController()
@@ -530,36 +522,35 @@ KJ_TEST("ReadableStream read all bytes (value readable, wrong type)") {
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .pull =
-              [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
-      // Because we're using a value-based stream, two enqueue operations will
-      // require at least three reads to complete: one for the first chunk, 'hello, ',
-      // one for the second chunk, 'world!', and one to signal close.
-      KJ_SWITCH_ONEOF(controller) {
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
         // Because we're using a value-based stream, two enqueue operations will
         // require at least three reads to complete: one for the first chunk, 'hello, ',
         // one for the second chunk, 'world!', and one to signal close.
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
-          c->enqueue(js, js.str("wrong type"_kjc));
-          checked++;
-          return js.resolvedPromise();
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
+            c->enqueue(js, js.str("wrong type"_kjc));
+            checked++;
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
+        KJ_UNREACHABLE;
+      },
+      .cancel = [&](jsg::Lock& js, auto reason) -> jsg::Promise<void> {
+        KJ_ASSERT(kj::str(reason) == "TypeError: This ReadableStream did not return bytes.");
+        checked++;
+        return js.resolvedPromise();
       }
-      KJ_UNREACHABLE;
-    },
-          .cancel = [&](jsg::Lock& js, auto reason) -> jsg::Promise<void> {
-      KJ_ASSERT(kj::str(reason) == "TypeError: This ReadableStream did not return bytes.");
-      checked++;
-      return js.resolvedPromise();
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,
@@ -591,31 +582,30 @@ KJ_TEST("ReadableStream read all bytes (value readable, to many bytes)") {
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .pull =
-              [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
-      // Because we're using a value-based stream, two enqueue operations will
-      // require at least three reads to complete: one for the first chunk, 'hello, ',
-      // one for the second chunk, 'world!', and one to signal close.
-      KJ_SWITCH_ONEOF(controller) {
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
         // Because we're using a value-based stream, two enqueue operations will
         // require at least three reads to complete: one for the first chunk, 'hello, ',
         // one for the second chunk, 'world!', and one to signal close.
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
-          c->enqueue(js, toBytes(js, kj::str("123456789012345678901")));
-          checked++;
-          return js.resolvedPromise();
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
+            c->enqueue(js, toBytes(js, kj::str("123456789012345678901")));
+            checked++;
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
+        KJ_UNREACHABLE;
       }
-      KJ_UNREACHABLE;
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,
@@ -646,32 +636,31 @@ KJ_TEST("ReadableStream read all bytes (byte readable, to many bytes)") {
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .type = kj::str("bytes"),
-          .pull =
-              [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
-      // Because we're using a value-based stream, two enqueue operations will
-      // require at least three reads to complete: one for the first chunk, 'hello, ',
-      // one for the second chunk, 'world!', and one to signal close.
-      KJ_SWITCH_ONEOF(controller) {
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .type = kj::str("bytes"),
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
         // Because we're using a value-based stream, two enqueue operations will
         // require at least three reads to complete: one for the first chunk, 'hello, ',
         // one for the second chunk, 'world!', and one to signal close.
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
-          c->enqueue(js, toBufferSource(js, kj::str("123456789012345678901")));
-          checked++;
-          return js.resolvedPromise();
+        KJ_SWITCH_ONEOF(controller) {
+          // Because we're using a value-based stream, two enqueue operations will
+          // require at least three reads to complete: one for the first chunk, 'hello, ',
+          // one for the second chunk, 'world!', and one to signal close.
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
+            c->enqueue(js, toBufferSource(js, kj::str("123456789012345678901")));
+            checked++;
+            return js.resolvedPromise();
+          }
+          KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
         }
-        KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
+        KJ_UNREACHABLE;
       }
-      KJ_UNREACHABLE;
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,
@@ -702,19 +691,18 @@ KJ_TEST("ReadableStream read all bytes (byte readable, failed read)") {
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .type = kj::str("bytes"),
-          .pull =
-              [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
-      checked++;
-      return js.rejectedPromise<void>(js.error("boom"));
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .type = kj::str("bytes"),
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        checked++;
+        return js.rejectedPromise<void>(js.error("boom"));
+      }
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,
@@ -745,18 +733,17 @@ KJ_TEST("ReadableStream read all bytes (value readable, failed read)") {
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .pull =
-              [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
-      checked++;
-      return js.rejectedPromise<void>(js.error("boom"));
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
+        checked++;
+        return js.rejectedPromise<void>(js.error("boom"));
+      }
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,
@@ -787,19 +774,18 @@ KJ_TEST("ReadableStream read all bytes (byte readable, failed start)") {
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .type = kj::str("bytes"),
-          .start = [&](jsg::Lock& js,
-                       UnderlyingSource::Controller controller) -> jsg::Promise<void> {
-      checked++;
-      return js.rejectedPromise<void>(js.error("boom"));
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .type = kj::str("bytes"),
+      .start = [&](jsg::Lock& js, UnderlyingSource::Controller controller) -> jsg::Promise<void> {
+        checked++;
+        return js.rejectedPromise<void>(js.error("boom"));
+      }
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,
@@ -830,19 +816,18 @@ KJ_TEST("ReadableStream read all bytes (byte readable, failed start 2)") {
   preamble([](jsg::Lock& js) {
     uint checked = 0;
     auto rs = js.alloc<ReadableStream>(newReadableStreamJsController());
-    rs->getController().setup(js,
-        UnderlyingSource{
-          .type = kj::str("bytes"),
-          .start = [&](jsg::Lock& js,
-                       UnderlyingSource::Controller controller) -> jsg::Promise<void> {
-      checked++;
-      JSG_FAIL_REQUIRE(Error, "boom");
-    }
-          // Setting a highWaterMark of 0 means the pull function above will not be called
-          // immediately on creation of the stream, but only when the first read in the
-          // readall call below happens.
-        },
-        StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format off
+    rs->getController().setup(js, UnderlyingSource{
+      .type = kj::str("bytes"),
+      .start = [&](jsg::Lock& js, UnderlyingSource::Controller controller) -> jsg::Promise<void> {
+        checked++;
+        JSG_FAIL_REQUIRE(Error, "boom");
+      }
+      // Setting a highWaterMark of 0 means the pull function above will not be called
+      // immediately on creation of the stream, but only when the first read in the
+      // readall call below happens.
+    }, StreamQueuingStrategy{.highWaterMark = 0});
+    // clang-format on
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(js,

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -1760,13 +1760,17 @@ class EntrypointJsRpcTarget final: public JsRpcTargetBase {
       target = jsg::JsObject(result.As<v8::Object>());
     }
 
-    TargetInfo targetInfo{.target = target,
+    // clang-format off
+    TargetInfo targetInfo{
+      .target = target,
       .envCtx = handler->ctx.map([&](jsg::Ref<ExecutionContext>& execCtx) -> EnvCtx {
-      return {
-        .env = handler->env.getHandle(js),
-        .ctx = lock.getWorker().getIsolate().getApi().wrapExecutionContext(js, execCtx.addRef()),
-      };
-    })};
+        return {
+          .env = handler->env.getHandle(js),
+          .ctx = lock.getWorker().getIsolate().getApi().wrapExecutionContext(js, execCtx.addRef()),
+        };
+      })
+    };
+    // clang-format on
 
     // `targetInfo.envCtx` is present when we're invoking a freestanding function, and therefore
     // `env` and `ctx` need to be passed as parameters. In that case, we our method lookup

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3693,25 +3693,26 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
           .errorContext = kj::str("Worker's globalOutbound"),
         },
 
-        .compileBindings =
-            [env = kj::mv(source.env)](
-                jsg::Lock& js, const Worker::Api& api, v8::Local<v8::Object> target) {
-        if (!env.empty()) {
-          // Copy properties of the provided `env` object into `target`.
-          js.withinHandleScope([&]() {
-            auto targetObj = jsg::JsObject(target);
-            auto sourceObj = KJ_REQUIRE_NONNULL(
-                env.toJs(js).tryCast<jsg::JsObject>(), "'env' must be an object");
-            auto props = sourceObj.getPropertyNames(js, jsg::KeyCollectionFilter::OWN_ONLY,
-                jsg::PropertyFilter::ONLY_ENUMERABLE, jsg::IndexFilter::INCLUDE_INDICES);
-            auto propCount = props.size();
-            for (auto i: kj::zeroTo(propCount)) {
-              auto prop = props.get(js, i);
-              targetObj.set(js, prop, sourceObj.get(js, prop));
-            }
-          });
-        }
-      },
+        // clang-format off
+        .compileBindings = [env = kj::mv(source.env)](
+            jsg::Lock& js, const Worker::Api& api, v8::Local<v8::Object> target) {
+          if (!env.empty()) {
+            // Copy properties of the provided `env` object into `target`.
+            js.withinHandleScope([&]() {
+              auto targetObj = jsg::JsObject(target);
+              auto sourceObj = KJ_REQUIRE_NONNULL(
+                  env.toJs(js).tryCast<jsg::JsObject>(), "'env' must be an object");
+              auto props = sourceObj.getPropertyNames(js, jsg::KeyCollectionFilter::OWN_ONLY,
+                  jsg::PropertyFilter::ONLY_ENUMERABLE, jsg::IndexFilter::INCLUDE_INDICES);
+              auto propCount = props.size();
+              for (auto i: kj::zeroTo(propCount)) {
+                auto prop = props.get(js, i);
+                targetObj.set(js, prop, sourceObj.get(js, prop));
+              }
+            });
+          }
+        },
+        // clang-format on
       };
 
       DynamicErrorReporter errorReporter;
@@ -3922,11 +3923,12 @@ kj::Own<Server::Service> Server::makeWorker(kj::StringPtr name,
     .actorStorageConf = conf.getDurableObjectStorage(),
     .containerEngineConf = conf.getContainerEngine(),
 
-    .compileBindings =
-        [globals = kj::mv(globals)](
-            jsg::Lock& lock, const Worker::Api& api, v8::Local<v8::Object> target) {
-    return WorkerdApi::from(api).compileGlobals(lock, globals, target, 1);
-  },
+    // clang-format off
+    .compileBindings = [globals = kj::mv(globals)](
+        jsg::Lock& lock, const Worker::Api& api, v8::Local<v8::Object> target) {
+      return WorkerdApi::from(api).compileGlobals(lock, globals, target, 1);
+    },
+    // clang-format on
   };
 
   return makeWorkerImpl(name, kj::mv(def), extensions, errorReporter);


### PR DESCRIPTION
There doesn't seem to be appetite to fix the formatter, but these are really hard to read, so let's just disable the formatter locally in the problem areas.