### PR TITLE
Revert most of the work for pyodide isolate pools.

### DIFF
--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -544,12 +544,11 @@ void DiskCache::put(jsg::Lock& js, kj::String key, kj::Array<kj::byte> data) {
 
 jsg::JsValue SetupEmscripten::getModule(jsg::Lock& js) {
   js.installJspi();
-  js.v8Context()->SetSecurityToken(emscriptenRuntime.contextToken.getHandle(js));
   return emscriptenRuntime.emscriptenRuntime.getHandle(js);
 }
 
 void SetupEmscripten::visitForGc(jsg::GcVisitor& visitor) {
-  visitor.visit(const_cast<EmscriptenRuntime&>(emscriptenRuntime).emscriptenRuntime);
+  visitor.visit(emscriptenRuntime.emscriptenRuntime);
 }
 
 }  // namespace workerd::api::pyodide

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -484,8 +484,8 @@ class SimplePythonLimiter: public jsg::Object {
 
 class SetupEmscripten: public jsg::Object {
  public:
-  SetupEmscripten(const EmscriptenRuntime& emscriptenRuntime)
-      : emscriptenRuntime(emscriptenRuntime) {};
+  SetupEmscripten(EmscriptenRuntime emscriptenRuntime)
+      : emscriptenRuntime(kj::mv(emscriptenRuntime)) {};
 
   jsg::JsValue getModule(jsg::Lock& js);
 
@@ -494,7 +494,7 @@ class SetupEmscripten: public jsg::Object {
   }
 
  private:
-  const EmscriptenRuntime& emscriptenRuntime;
+  EmscriptenRuntime emscriptenRuntime;
   void visitForGc(jsg::GcVisitor& visitor);
 };
 

--- a/src/workerd/api/pyodide/setup-emscripten.c++
+++ b/src/workerd/api/pyodide/setup-emscripten.c++
@@ -81,14 +81,11 @@ EmscriptenRuntime EmscriptenRuntime::initialize(
       pyodideAsmWasmReader = module.getData();
     }
   }
-  auto context = js.v8Context();
-  Worker::setupContext(js, context, Worker::ConsoleMode::INSPECTOR_ONLY);
   auto module = loadEmscriptenSetupModule(js, KJ_ASSERT_NONNULL(emsciptenSetupJsReader));
   instantiateEmscriptenSetupModule(js, module);
   auto instantiateEmscriptenModule = getInstantiateEmscriptenModule(js, module);
   auto emscriptenModule = callInstantiateEmscriptenModule(js, instantiateEmscriptenModule,
       isWorkerd, KJ_ASSERT_NONNULL(pythonStdlibZipReader), KJ_ASSERT_NONNULL(pyodideAsmWasmReader));
-  auto contextToken = jsg::JsValue(context->GetSecurityToken());
-  return EmscriptenRuntime{contextToken.addRef(js), emscriptenModule.addRef(js)};
+  return EmscriptenRuntime{emscriptenModule.addRef(js)};
 }
 }  // namespace workerd::api::pyodide

--- a/src/workerd/api/pyodide/setup-emscripten.h
+++ b/src/workerd/api/pyodide/setup-emscripten.h
@@ -4,7 +4,6 @@
 
 namespace workerd::api::pyodide {
 struct EmscriptenRuntime {
-  jsg::JsRef<jsg::JsValue> contextToken;
   jsg::JsRef<jsg::JsValue> emscriptenRuntime;
   static EmscriptenRuntime initialize(jsg::Lock& js, bool isWorkerd, jsg::Bundle::Reader bundle);
 };

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -591,10 +591,6 @@ class Worker::Api {
 
   // Return the virtual file system for this worker.
   virtual const VirtualFileSystem& getVirtualFileSystem() const = 0;
-
-  virtual kj::Maybe<const api::pyodide::EmscriptenRuntime&> getEmscriptenRuntime() const {
-    return kj::none;
-  }
 };
 
 // A Worker may bounce between threads as it handles multiple requests, but can only actually

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -71,9 +71,6 @@ class WorkerdApi final: public Worker::Api {
       config::Worker::Reader conf,
       Worker::ValidationErrorReporter& errorReporter);
 
-  kj::Maybe<const api::pyodide::EmscriptenRuntime&> getEmscriptenRuntime() const
-      KJ_LIFETIMEBOUND override;
-
   void compileModules(jsg::Lock& lock,
       const Worker::Script::ModulesSource& source,
       const Worker::Isolate& isolate,


### PR DESCRIPTION
While this work made sense at the time it is growing to be more of a maintenance burden than it's worth. Our runtime is not really built to support isolates with multiple contexts.

Work was never done to actually make use of this in production because we are not currently focusing on performance of python cold starts.

This commit can be reverted in the future if we want to revisit this approach, but for now, it's better to reduce the tech debt by getting rid of it.

Because of other features we are currently developing it is likely that we'll have a better solution to python cold starts that doesn't require multiple contexts and would eliminate the need for this anyway.