### PR TITLE
Implements support for jaeger tracing at top-level for Python.

### DIFF
--- a/src/pyodide/internal/jaeger.ts
+++ b/src/pyodide/internal/jaeger.ts
@@ -1,10 +1,11 @@
 import { default as internalJaeger } from 'pyodide-internal:internalJaeger';
+import { IS_TRACING } from 'pyodide-internal:metadata';
 
 /**
  * Used for tracing via Jaeger.
  */
 export function enterJaegerSpan<T>(span: string, callback: () => T): T {
-  if (!internalJaeger.traceId) {
+  if (!IS_TRACING || !internalJaeger.traceId) {
     // Jaeger tracing not enabled or traceId is not present in request.
     return callback();
   }

--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -39,8 +39,6 @@ export const TRANSITIVE_REQUIREMENTS =
 
 // Entrypoints
 export const MAIN_MODULE_NAME = MetadataReader.getMainModule();
-export const DURABLE_OBJECT_CLASSES = MetadataReader.getDurableObjectClasses();
-export const WORKER_ENTRYPOINT_CLASSES = MetadataReader.getEntrypointClasses();
 
 export interface CompatibilityFlags {
   python_workflows?: boolean;

--- a/src/pyodide/types/runtime-generated/metadata.d.ts
+++ b/src/pyodide/types/runtime-generated/metadata.d.ts
@@ -20,8 +20,6 @@ declare namespace MetadataReader {
   const getPackagesLock: () => string;
   const read: (index: number, position: number, buffer: Uint8Array) => number;
   const getTransitiveRequirements: () => Set<string>;
-  const getDurableObjectClasses: () => string[] | null;
-  const getEntrypointClasses: () => string[] | null;
   const constructor: {
     getBaselineSnapshotImports(): string[];
   };

--- a/src/workerd/api/pyodide/pyodide.c++
+++ b/src/workerd/api/pyodide/pyodide.c++
@@ -411,11 +411,7 @@ PyodideMetadataReader::State::State(const State& other)
       snapshotToDisk(other.snapshotToDisk),
       createBaselineSnapshot(other.createBaselineSnapshot),
       memorySnapshot(other.memorySnapshot.map(
-          [](auto& snapshot) { return kj::heapArray<kj::byte>(snapshot); })),
-      durableObjectClasses(other.durableObjectClasses.map(
-          [](auto& classes) { return KJ_MAP(c, classes) { return kj::str(c); }; })),
-      entrypointClasses(other.entrypointClasses.map(
-          [](auto& classes) { return KJ_MAP(c, classes) { return kj::str(c); }; })) {}
+          [](auto& snapshot) { return kj::heapArray<kj::byte>(snapshot); })) {}
 
 kj::Own<PyodideMetadataReader::State> PyodideMetadataReader::State::clone() {
   return kj::heap<PyodideMetadataReader::State>(*this);

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -128,8 +128,6 @@ class PyodideMetadataReader: public jsg::Object {
     bool snapshotToDisk;
     bool createBaselineSnapshot;
     kj::Maybe<kj::Array<kj::byte>> memorySnapshot;
-    kj::Maybe<kj::Array<kj::String>> durableObjectClasses;
-    kj::Maybe<kj::Array<kj::String>> entrypointClasses;
 
     State(kj::String mainModule,
         kj::Array<kj::String> names,
@@ -142,9 +140,7 @@ class PyodideMetadataReader: public jsg::Object {
         bool isTracing,
         bool snapshotToDisk,
         bool createBaselineSnapshot,
-        kj::Maybe<kj::Array<kj::byte>> memorySnapshot,
-        kj::Maybe<kj::Array<kj::String>> durableObjectClasses,
-        kj::Maybe<kj::Array<kj::String>> entrypointClasses)
+        kj::Maybe<kj::Array<kj::byte>> memorySnapshot)
         : mainModule(kj::mv(mainModule)),
           moduleInfo(kj::mv(names), kj::mv(contents)),
           requirements(kj::mv(requirements)),
@@ -155,9 +151,7 @@ class PyodideMetadataReader: public jsg::Object {
           isTracingFlag(isTracing),
           snapshotToDisk(snapshotToDisk),
           createBaselineSnapshot(createBaselineSnapshot),
-          memorySnapshot(kj::mv(memorySnapshot)),
-          durableObjectClasses(kj::mv(durableObjectClasses)),
-          entrypointClasses(kj::mv(entrypointClasses)) {
+          memorySnapshot(kj::mv(memorySnapshot)) {
       verifyNoMainModuleInVendor();
     }
 
@@ -232,20 +226,6 @@ class PyodideMetadataReader: public jsg::Object {
 
   kj::HashSet<kj::String> getTransitiveRequirements();
 
-  kj::Maybe<kj::ArrayPtr<kj::String>> getDurableObjectClasses() {
-    KJ_IF_SOME(cls, state->durableObjectClasses) {
-      return cls.asPtr();
-    }
-    return kj::none;
-  }
-
-  kj::Maybe<kj::ArrayPtr<kj::String>> getEntrypointClasses() {
-    KJ_IF_SOME(cls, state->entrypointClasses) {
-      return cls.asPtr();
-    }
-    return kj::none;
-  }
-
   static kj::Array<kj::StringPtr> getBaselineSnapshotImports();
 
   JSG_RESOURCE_TYPE(PyodideMetadataReader) {
@@ -267,8 +247,6 @@ class PyodideMetadataReader: public jsg::Object {
     JSG_METHOD(getPackagesLock);
     JSG_METHOD(isCreatingBaselineSnapshot);
     JSG_METHOD(getTransitiveRequirements);
-    JSG_METHOD(getDurableObjectClasses);
-    JSG_METHOD(getEntrypointClasses);
     JSG_STATIC_METHOD(getBaselineSnapshotImports);
   }
 

--- a/src/workerd/io/worker-source.h
+++ b/src/workerd/io/worker-source.h
@@ -136,14 +136,6 @@ struct WorkerSource {
 
     bool isPython;
 
-    // Only in workerd (not on the edge), only as a hack for Python, we infer the list of
-    // entrypoint classes based on the declared self-referential bindings and actor namespaces
-    // pointing at the service. This is needed becaues in workerd, the Python runtime is unable
-    // to fully execute at startup in order to discover what the Worker actually exports. This
-    // should be fixed eventually, but for now, we use this work-around.
-    kj::Array<kj::String> inferredEntrypointClassesForPython;
-    kj::Array<kj::String> inferredActorClassesForPython;
-
     // Optional Python memory snapshot. The actual capnp type is declared in the internal codebase,
     // so we use AnyStruct here. This is deprecated anyway.
     kj::Maybe<capnp::AnyStruct::Reader> pythonMemorySnapshot;

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -4095,7 +4095,7 @@ kj::Own<Server::WorkerService> Server::makeWorkerImpl(kj::StringPtr name,
       : ArtifactBundler::makeDisabledBundler();
 
   auto script = isolate->newScript(name, kj::mv(def.source), IsolateObserver::StartType::COLD,
-      false, errorReporter, kj::mv(artifactBundler));
+      SpanParent(nullptr), false, errorReporter, kj::mv(artifactBundler));
 
   using Global = WorkerdApi::Global;
   jsg::V8Ref<v8::Object> ctxExportsHandle = nullptr;

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -74,7 +74,8 @@ class WorkerdApi final: public Worker::Api {
   void compileModules(jsg::Lock& lock,
       const Worker::Script::ModulesSource& source,
       const Worker::Isolate& isolate,
-      kj::Maybe<kj::Own<api::pyodide::ArtifactBundler_State>> artifacts) const override;
+      kj::Maybe<kj::Own<api::pyodide::ArtifactBundler_State>> artifacts,
+      SpanParent parentSpan) const override;
 
   kj::Array<Worker::Script::CompiledGlobal> compileServiceWorkerGlobals(jsg::Lock& lock,
       const Worker::Script::ScriptSource& source,

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -345,7 +345,8 @@ TestFixture::TestFixture(SetupParams&& params)
           IsolateObserver::StartType::COLD,
           false,
           kj::none,
-          kj::none)),
+          kj::none,
+          SpanParent(nullptr))),
       worker(kj::atomicRefcounted<Worker>(kj::atomicAddRef(*workerScript),
           kj::atomicRefcounted<WorkerObserver>(),
           [](jsg::Lock&, const Worker::Api&, v8::Local<v8::Object>, v8::Local<v8::Object>) {


### PR DESCRIPTION
Python Workers need to be initialised at the top-level, but the IoContext is not available in that case. The Jaeger tracing grabs the current request's span via the IoContext. This PR (and the upstream PR) implements an alternative path of grabbing a span, by passing it through to InternalJaegerTrace when it is created. This enables Python to log spans at the top-level.

This enables us to remove the last special code path for Python initialisation (which had a number of limitations) and simplifies Python init significantly.

