### PR TITLE
improve performance of recursiveFreeze

### DIFF
--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -160,7 +160,7 @@ kj::String Lock::serializeJson(v8::Local<v8::Value> value) {
 }
 
 void Lock::recursivelyFreeze(Value& value) {
-  jsg::recursivelyFreeze(v8Context(), value.getHandle(*this));
+  jsg::recursivelyFreeze(*this, value.getHandle(*this));
 }
 
 v8::Local<v8::String> Lock::wrapString(kj::StringPtr text) {

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -157,7 +157,7 @@ JsArray JsObject::previewEntries(bool* isKeyValue) {
 }
 
 void JsObject::recursivelyFreeze(Lock& js) {
-  jsg::recursivelyFreeze(js.v8Context(), inner);
+  jsg::recursivelyFreeze(js, inner);
 }
 
 void JsObject::seal(Lock& js) {

--- a/src/workerd/jsg/util-test.c++
+++ b/src/workerd/jsg/util-test.c++
@@ -14,7 +14,7 @@ class ContextGlobalObject: public Object, public ContextGlobal {};
 
 struct FreezeContext: public ContextGlobalObject {
   void recursivelyFreeze(jsg::Lock& js, v8::Local<v8::Value> value) {
-    jsg::recursivelyFreeze(js.v8Isolate->GetCurrentContext(), value);
+    jsg::recursivelyFreeze(js, value);
   }
   JSG_RESOURCE_TYPE(FreezeContext) {
     JSG_METHOD(recursivelyFreeze);

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -203,7 +203,7 @@ kj::Array<kj::byte> asBytes(v8::Local<v8::ArrayBufferView> arrayBufferView);
 //   or may contain non-simple values it won't do the right thing. It is safe to call this on the
 //   output of JSON.parse().
 // TODO(cleanup): Maybe replace this with a function that parses and freezes JSON in one step.
-void recursivelyFreeze(v8::Local<v8::Context> context, v8::Local<v8::Value> value);
+void recursivelyFreeze(jsg::Lock& js, v8::Local<v8::Value> value);
 
 // Make a deep clone of the given object.
 v8::Local<v8::Value> deepClone(v8::Local<v8::Context> context, v8::Local<v8::Value> value);

--- a/src/workerd/tests/bench-util.c++
+++ b/src/workerd/tests/bench-util.c++
@@ -34,7 +34,7 @@ static void Util_RecursivelyFreeze(benchmark::State& state) {
 
     for (auto _: state) {
       for (size_t i = 0; i < 100000; ++i) {
-        jsg::recursivelyFreeze(js.v8Context(), obj);
+        jsg::recursivelyFreeze(js, obj);
         benchmark::DoNotOptimize(i);
       }
     }


### PR DESCRIPTION
Use iteration instead of recursion with a queue to avoid stack overflow and improve cache locality.