### PR TITLE
put http and https modules behind compat flag

### DIFF
--- a/src/workerd/api/node/tests/http-agent-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/http-agent-nodejs-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "http-agent-nodejs-test.js")
         ],
         compatibilityDate = "2025-01-15",
-        compatibilityFlags = ["nodejs_compat", "experimental"],
+        compatibilityFlags = ["nodejs_compat", "experimental", "enable_nodejs_http_modules"],
         bindings = [
           (name = "PONG_SERVER_PORT", fromEnvironment = "PONG_SERVER_PORT"),
         ],

--- a/src/workerd/api/node/tests/http-client-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/http-client-nodejs-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "http-client-nodejs-test.js")
         ],
         compatibilityDate = "2025-01-15",
-        compatibilityFlags = ["nodejs_compat", "experimental"],
+        compatibilityFlags = ["nodejs_compat", "experimental", "enable_nodejs_http_modules"],
         bindings = [
           (name = "PONG_SERVER_PORT", fromEnvironment = "PONG_SERVER_PORT"),
           (name = "ASD_SERVER_PORT", fromEnvironment = "ASD_SERVER_PORT"),

--- a/src/workerd/api/node/tests/http-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/http-nodejs-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "http-nodejs-test.js")
         ],
         compatibilityDate = "2025-01-15",
-        compatibilityFlags = ["nodejs_compat", "experimental"],
+        compatibilityFlags = ["nodejs_compat", "experimental", "enable_nodejs_http_modules"],
         bindings = [
           (name = "PONG_SERVER_PORT", fromEnvironment = "PONG_SERVER_PORT"),
           (name = "ASD_SERVER_PORT", fromEnvironment = "ASD_SERVER_PORT"),

--- a/src/workerd/api/node/tests/http-outgoing-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/http-outgoing-nodejs-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "http-outgoing-nodejs-test.js")
         ],
         compatibilityDate = "2025-01-15",
-        compatibilityFlags = ["nodejs_compat", "experimental"],
+        compatibilityFlags = ["nodejs_compat", "experimental", "enable_nodejs_http_modules"],
         bindings = [
           (name = "FINISH_WRITABLE_PORT", fromEnvironment = "FINISH_WRITABLE_PORT"),
           (name = "WRITABLE_FINISHED_PORT", fromEnvironment = "WRITABLE_FINISHED_PORT"),

--- a/src/workerd/api/node/util.c++
+++ b/src/workerd/api/node/util.c++
@@ -12,12 +12,6 @@
 
 namespace workerd::api::node {
 
-bool isExperimentalNodeJsCompatModule(kj::StringPtr name) {
-  return name == "node:fs"_kj || name == "node:http"_kj || name == "node:_http_common"_kj ||
-      name == "node:_http_outgoing"_kj || name == "node:_http_client"_kj ||
-      name == "node:_http_incoming"_kj || name == "node:_http_agent"_kj;
-}
-
 MIMEParams::MIMEParams(kj::Maybe<MimeType&> mimeType): mimeType(mimeType) {}
 
 // Oddly, Node.js allows creating MIMEParams directly but it's not actually

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -870,4 +870,10 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # The original version of the headers sent to edgeworker were truncated to a single
   # value for specific header names, such as To and Cc. With this compat flag we will send
   # the full header values to the worker script.
+
+  enableNodejsHttpModules @100 :Bool
+      $compatEnableFlag("enable_nodejs_http_modules")
+      $compatDisableFlag("disable_nodejs_http_modules")
+      $impliedByAfterDate(names = ["nodeJsCompat", "nodeJsCompatV2"], date = "2025-08-01");
+  # Enables Node.js http related modules such as node:http and node:https
 }

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -874,6 +874,6 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   enableNodejsHttpModules @100 :Bool
       $compatEnableFlag("enable_nodejs_http_modules")
       $compatDisableFlag("disable_nodejs_http_modules")
-      $impliedByAfterDate(names = ["nodeJsCompat", "nodeJsCompatV2"], date = "2025-08-01");
+      $impliedByAfterDate(name = "nodeJsCompat", date = "2025-08-15");
   # Enables Node.js http related modules such as node:http and node:https
 }


### PR DESCRIPTION
This pull-request enables the following modules and functions behind a compat flag

- `node:_http_agent`
  - Agent
  - globalAgent
- `node:_http_client`
  - ClientRequest
- `node:_http_common`
  - _checkIsHttpToken
  - _checkInvalidHeaderChar
  - chunkExpression
  - continueExpression
  - methods
  - kIncomingMessage
- `node:_http_incoming`
  - IncomingMessage 
- `node:_http_outgoing`
  -  validateHeaderName
  - validateHeaderValue
  - kUniqueHeaders
  - kHighWaterMark
  - parseUniqueHeadersOption
  - OutgoingMessage
- `node:http`
  - validateHeaderName
  - validateHeaderValue
  - METHODS
  - STATUS_CODES
  - ClientRequest
  - request
  - get
  - WebSocket
  - OutgoingMessage
  - Agent
  - globalAgent
  - IncomingMessage
- `node:https`
  - get
  - request
  - Agent
  - globalAgent 

cc @vicb 