### PR TITLE
[o11y] Fold up WorkerTracer weak reference

### DIFF
--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -590,7 +590,7 @@ jsg::JsValue ToJs(jsg::Lock& js, const tracing::TailEvent& event, StringCache& c
     KJ_CASE_ONEOF(link, tracing::Link) {
       obj.set(js, EVENT_STR, ToJs(js, link, cache));
     }
-    KJ_CASE_ONEOF(attrs, kj::Array<tracing::Attribute>) {
+    KJ_CASE_ONEOF(attrs, CustomInfo) {
       obj.set(js, EVENT_STR, ToJs(js, attrs, cache));
     }
   }


### PR DESCRIPTION
This is no longer needed now that the top-level span is owned by WorkerTracer.

Also see the corresponding downstream PR.