### PR TITLE
increase benchmark iterations&durations

### DIFF
--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -90,7 +90,10 @@ wd_cc_benchmark(
 wd_cc_benchmark(
     name = "bench-util",
     srcs = ["bench-util.c++"],
-    deps = ["//src/workerd/jsg"],
+    deps = [
+        ":test-fixture",
+        "//src/workerd/jsg",
+    ],
 )
 
 wd_test(

--- a/src/workerd/tests/bench-api-headers.c++
+++ b/src/workerd/tests/bench-api-headers.c++
@@ -50,8 +50,13 @@ struct ApiHeaders: public benchmark::Fixture {
 // initialization performs a lot of copying, benchmark it
 BENCHMARK_F(ApiHeaders, constructor)(benchmark::State& state) {
   fixture->runInIoContext([&](const TestFixture::Environment& env) {
+    auto& js = env.js;
     for (auto _: state) {
-      auto jsHeaders = env.js.alloc<api::Headers>(env.js, *kjHeaders, api::Headers::Guard::REQUEST);
+      for (size_t i = 0; i < 10000; ++i) {
+        benchmark::DoNotOptimize(
+            js.alloc<api::Headers>(js, *kjHeaders, api::Headers::Guard::REQUEST));
+        benchmark::DoNotOptimize(i);
+      }
     }
   });
 }

--- a/src/workerd/tests/bench-global-scope.c++
+++ b/src/workerd/tests/bench-global-scope.c++
@@ -33,8 +33,11 @@ struct GlobalScopeBenchmark: public benchmark::Fixture {
 
 BENCHMARK_F(GlobalScopeBenchmark, request)(benchmark::State& state) {
   for (auto _: state) {
-    auto result = fixture->runRequest(kj::HttpMethod::POST, "http://www.example.com"_kj, "TEST"_kj);
-    KJ_EXPECT(result.statusCode == 200);
+    for (size_t i = 0; i < 10000; ++i) {
+      benchmark::DoNotOptimize(
+          fixture->runRequest(kj::HttpMethod::POST, "http://www.example.com"_kj, "TEST"_kj));
+      benchmark::DoNotOptimize(i);
+    }
   }
 }
 

--- a/src/workerd/tests/bench-json.c++
+++ b/src/workerd/tests/bench-json.c++
@@ -18,21 +18,23 @@ static void Test_JSON_ENC(benchmark::State& state) {
   // Perform setup here
 
   for (auto _: state) {
-    // This code gets timed
-    KJ_EXPECT(json.encode(capnp::VOID) == "null");
-    KJ_EXPECT(json.encode(true) == "true");
-    KJ_EXPECT(json.encode(false) == "false");
-    KJ_EXPECT(json.encode(123) == "123");
-    KJ_EXPECT(json.encode(-5.5) == "-5.5");
-    KJ_EXPECT(json.encode(capnp::Text::Reader("foo")) == "\"foo\"");
-    KJ_EXPECT(json.encode(capnp::Text::Reader("ab\"cd\\ef\x03")) == "\"ab\\\"cd\\\\ef\\u0003\"");
+    for (size_t i = 0; i < 100000; i++) {
+      // This code gets timed
+      KJ_EXPECT(json.encode(capnp::VOID) == "null");
+      KJ_EXPECT(json.encode(true) == "true");
+      KJ_EXPECT(json.encode(false) == "false");
+      KJ_EXPECT(json.encode(123) == "123");
+      KJ_EXPECT(json.encode(-5.5) == "-5.5");
+      KJ_EXPECT(json.encode(capnp::Text::Reader("foo")) == "\"foo\"");
+      KJ_EXPECT(json.encode(capnp::Text::Reader("ab\"cd\\ef\x03")) == "\"ab\\\"cd\\\\ef\\u0003\"");
 
-    json.setPrettyPrint(false);
-    kj::byte bytes[] = {12, 34, 56};
-    KJ_EXPECT(json.encode(capnp::Data::Reader(bytes, 3)) == "[12,34,56]");
+      json.setPrettyPrint(false);
+      kj::byte bytes[] = {12, 34, 56};
+      KJ_EXPECT(json.encode(capnp::Data::Reader(bytes, 3)) == "[12,34,56]");
 
-    json.setPrettyPrint(true);
-    KJ_EXPECT(json.encode(capnp::Data::Reader(bytes, 3)) == "[12, 34, 56]");
+      json.setPrettyPrint(true);
+      KJ_EXPECT(json.encode(capnp::Data::Reader(bytes, 3)) == "[12, 34, 56]");
+    }
   }
 }
 
@@ -41,12 +43,16 @@ static void Test_JSON_DEC(benchmark::State& state) {
   capnp::JsonCodec json;
   capnp::MallocMessageBuilder responseMessage;
   json.handleByAnnotation<workerd::api::public_beta::R2BindingRequest>();
-  kj::StringPtr dummy =
+  static constexpr kj::StringPtr dummy =
       "{\"version\":1,\"method\":\"completeMultipartUpload\",\"object\":\"multipart_object_name4\",\"uploadId\":\"uploadId\",\"parts\":[{\"etag\":\"1234\",\"part\":1},{\"etag\":\"56789\",\"part\":2}]}"_kj;
 
   for (auto _: state) {
-    auto responseBuilder = responseMessage.initRoot<workerd::api::public_beta::R2BindingRequest>();
-    json.decode(dummy, responseBuilder);
+    for (size_t i = 0; i < 100000; i++) {
+      auto responseBuilder =
+          responseMessage.initRoot<workerd::api::public_beta::R2BindingRequest>();
+      json.decode(dummy, responseBuilder);
+      benchmark::DoNotOptimize(responseBuilder);
+    }
   }
 }
 

--- a/src/workerd/tests/bench-kj-headers.c++
+++ b/src/workerd/tests/bench-kj-headers.c++
@@ -25,21 +25,26 @@ struct KjHeaders: public benchmark::Fixture {
 };
 
 BENCHMARK_F(KjHeaders, Parse)(benchmark::State& state) {
+  kj::String in = kj::heapString(
+      "GET /favicon.ico HTTP/1.1\r\n"
+      "Host: 0.0.0.0=5000\r\n"
+      "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9) Gecko/2008061015 Firefox/3.0\r\n"
+      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
+      "Accept-Language: en-us,en;q=0.5\r\n"
+      "Accept-Encoding: gzip,deflate\r\n"
+      "Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7\r\n"
+      "Keep-Alive: 300\r\n"
+      "Connection: keep-alive\r\n"
+      "\r\n");
+
   for (auto _: state) {
     kj::HttpHeaders headers(*table);
 
-    auto in = kj::heapString(
-        "GET /favicon.ico HTTP/1.1\r\n"
-        "Host: 0.0.0.0=5000\r\n"
-        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9) Gecko/2008061015 Firefox/3.0\r\n"
-        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
-        "Accept-Language: en-us,en;q=0.5\r\n"
-        "Accept-Encoding: gzip,deflate\r\n"
-        "Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7\r\n"
-        "Keep-Alive: 300\r\n"
-        "Connection: keep-alive\r\n"
-        "\r\n");
-    KJ_EXPECT(headers.tryParseRequest(in.asArray()).is<kj::HttpHeaders::Request>());
+    for (size_t i = 0; i < 1000; ++i) {
+      benchmark::DoNotOptimize(
+          headers.tryParseRequest(in.asArray()).is<kj::HttpHeaders::Request>());
+      benchmark::DoNotOptimize(i);
+    }
   }
 }
 

--- a/src/workerd/tests/bench-mimetype.c++
+++ b/src/workerd/tests/bench-mimetype.c++
@@ -4,23 +4,40 @@
 namespace workerd {
 namespace {
 
-WD_BENCH("Mimetype::ParseAndSerialize") {
-  MimeType::parse("text/plain;charset=UTF-8"_kj).toString();
-  MimeType::parse("multipart/byteranges; boundary=3d6b6a416f9b5"_kj).toString();
-  MimeType::parse("video/webm;codecs=\"vp09.02.10.10.01.09.16.09.01,opus\""_kj).toString();
+static void MimeType_ParseAndSerialize(benchmark::State& state) {
+  for (auto _: state) {
+    for (size_t i = 0; i < 10000; i++) {
+      benchmark::DoNotOptimize(MimeType::parse("text/plain;charset=UTF-8"_kj).toString());
+      benchmark::DoNotOptimize(
+          MimeType::parse("multipart/byteranges; boundary=3d6b6a416f9b5"_kj).toString());
+      benchmark::DoNotOptimize(
+          MimeType::parse("video/webm;codecs=\"vp09.02.10.10.01.09.16.09.01,opus\""_kj).toString());
 
-  // longest entry from https://www.iana.org/assignments/media-types/media-types.xhtml
-  MimeType::parse(
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"_kj)
-      .toString();
+      // longest entry from https://www.iana.org/assignments/media-types/media-types.xhtml
+      benchmark::DoNotOptimize(MimeType::parse(
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"_kj)
+                                   .toString());
+
+      benchmark::DoNotOptimize(i);
+    }
+  }
 }
 
-WD_BENCH("Mimetype::Serialize") {
-  MimeType::PLAINTEXT.toString();
-  MimeType::CSS.toString();
-  MimeType::HTML.toString();
-  MimeType::JSON.toString();
+static void MimeType_Serialize(benchmark::State& state) {
+  for (auto _: state) {
+    for (size_t i = 0; i < 100000; ++i) {
+      benchmark::DoNotOptimize(MimeType::PLAINTEXT.toString());
+      benchmark::DoNotOptimize(MimeType::CSS.toString());
+      benchmark::DoNotOptimize(MimeType::HTML.toString());
+      benchmark::DoNotOptimize(MimeType::JSON.toString());
+
+      benchmark::DoNotOptimize(i);
+    }
+  }
 }
+
+WD_BENCHMARK(MimeType_ParseAndSerialize)->Name("Mimetype::ParseAndSerialize");
+WD_BENCHMARK(MimeType_Serialize)->Name("Mimetype::Serialize");
 
 }  // namespace
 


### PR DESCRIPTION
Current benchmarks are too fast to be used as a baseline, and creates false results.