### PR TITLE
reduce iteration count of benchmarks

### DIFF
--- a/src/workerd/tests/bench-global-scope.c++
+++ b/src/workerd/tests/bench-global-scope.c++
@@ -33,7 +33,7 @@ struct GlobalScopeBenchmark: public benchmark::Fixture {
 
 BENCHMARK_F(GlobalScopeBenchmark, request)(benchmark::State& state) {
   for (auto _: state) {
-    for (size_t i = 0; i < 10000; ++i) {
+    for (size_t i = 0; i < 1000; ++i) {
       benchmark::DoNotOptimize(
           fixture->runRequest(kj::HttpMethod::POST, "http://www.example.com"_kj, "TEST"_kj));
       benchmark::DoNotOptimize(i);

--- a/src/workerd/tests/bench-util.c++
+++ b/src/workerd/tests/bench-util.c++
@@ -33,7 +33,7 @@ static void Util_RecursivelyFreeze(benchmark::State& state) {
     auto obj = jsg::check(v8::JSON::Parse(js.v8Context(), jsg::v8Str(js.v8Isolate, cfProperty)));
 
     for (auto _: state) {
-      for (size_t i = 0; i < 100000; ++i) {
+      for (size_t i = 0; i < 1000; ++i) {
         jsg::recursivelyFreeze(js.v8Context(), obj);
         benchmark::DoNotOptimize(i);
       }


### PR DESCRIPTION
Reduce iteration counts due to

> This benchmark contains 1702 system calls, totalling 7.1 s of execution time. Since they cannot be consistently instrumented, those calls are not included in the measure. Please switch to [the Walltime instrument to accurately measure system calls](https://codspeed.io/docs/instruments/walltime). Learn more [about measurement and system calls](https://codspeed.io/docs/instruments/cpu/overview#system-calls).