### PR TITLE
Python Workflows API improvements

### DIFF
--- a/src/workerd/server/tests/python/workflow-entrypoint/worker.js
+++ b/src/workerd/server/tests/python/workflow-entrypoint/worker.js
@@ -4,18 +4,10 @@ import * as assert from 'node:assert';
 class Context extends RpcTarget {
   async do(name, fn) {
     try {
-      return await fn();
+      const result = await fn();
+      return result;
     } catch (e) {
       console.log(`Error received: ${e.name} Message: ${e.message}`);
-      if (
-        (e instanceof Error &&
-          (e.name === 'NonRetryableError' ||
-            e.message.startsWith('NonRetryableError'))) ||
-        (e.message.startsWith('PythonError') &&
-          e.message.includes('_workers.NonRetryableError'))
-      ) {
-        // we need this statement on the engine
-      }
       // let's rethrow here since the engine does the same
       throw e;
     }
@@ -33,6 +25,6 @@ export default {
       },
       stubStep
     );
-    assert.deepStrictEqual(resp, 'bar');
+    assert.deepStrictEqual(resp, 'foobar');
   },
 };

--- a/src/workerd/server/tests/python/workflow-entrypoint/workflow.py
+++ b/src/workerd/server/tests/python/workflow-entrypoint/workflow.py
@@ -2,56 +2,65 @@
 # Licensed under the Apache 2.0 license found in the LICENSE file or at:
 #     https://opensource.org/licenses/Apache-2.0
 
-from workers import NonRetryableError, WorkflowEntrypoint
-
-
-class MyCustomException(Exception):
-    pass
+from workers import WorkflowEntrypoint
 
 
 class WorkflowEntrypointExample(WorkflowEntrypoint):
     async def on_run(self, event, step):
-        @step.do("my_first_step")
-        async def workflow_step():
-            print("Doing workflow step... About to raise an error")
-            raise TypeError("Test error")
+        async def await_step(fn):
+            try:
+                return await fn()
+            except TypeError as e:
+                print(f"Successfully caught {type(e).__name__}: {e}")
 
-        try:
-            await workflow_step()
-        except TypeError as e:
-            print(f"successfully caught {e} with decorator")
+        @step.do("my_failing")
+        async def my_failing():
+            print("Executing my_failing")
+            raise TypeError("Intentional error in my_failing")
+
+        @step.do("normal_step")
+        async def normal_step():
+            print("Executing normal step")
+            return "done"
+
+        await await_step(normal_step)
+
+        @step.do("step_1")
+        async def step_1():
+            print("Executing step 1")
+            return {"foo": "foo"}
+
+        @step.do("step_2")
+        async def step_2():
+            print("Executing step 2")
+            return {"bar": "bar"}
+
+        # DAG example with error handling
+        @step.do("step_3", depends=[my_failing, step_2], concurrent=True)
+        async def step_3(_result1, _result2):
+            # this should never run because one of the dependencies will fail
             pass
 
-        async def step_with_callback():
-            print("Doing workflow step... About to raise an error")
-            raise NonRetryableError("Test error")
+        await await_step(step_3)
 
-        try:
-            await step.do("my_second_step", step_with_callback)
-        except NonRetryableError as e:
-            print(f"successfully caught {e} with callback")
-            pass
+        # `step_1` and `step_2` run serially
+        @step.do("step_4", depends=[step_1, step_2], concurrent=False)
+        async def step_4(result1, result2):
+            print("Executing step 4 (depends on step 1 and step 2)")
+            assert result1["foo"] == "foo"
+            assert result2["bar"] == "bar"
 
-        @step.do("my_errored_step")
-        async def workflow_step():
-            print("Doing workflow step... About to raise an error")
-            raise MyCustomException("Test error")
+        await await_step(step_4)
 
-        try:
-            await workflow_step()
-        except MyCustomException as e:
-            print(f"successfully caught {e} with decorator")
-            pass
+        @step.do("step_5", depends=[step_1, step_2], concurrent=False)
+        async def step_5(result1, result2):
+            print("Executing step 5 (depends on step 1 and step 2)")
+            assert result1["foo"] == "foo"
+            assert result2["bar"] == "bar"
 
-        @step.do("my_third_step")
-        async def workflow_step_success():
-            return event["foo"]
+            return result1["foo"] + result2["bar"]
 
-        try:
-            return await workflow_step_success()
-            # should not get thrown
-        except Exception as e:
-            print(f"Error in workflow step: {e}")
+        return await await_step(step_5)
 
 
 async def test(ctrl, env, ctx):


### PR DESCRIPTION
This PR includes breaking changes on the `step` API. Workflows are still experimental and under active development
- bugfix `step.do` to await for Js promise rejection
- new error translation layer between Python exceptions and Js errors (for now custom exceptions won't be catchable)
- new DAG optional params - users are now able to define a list of dependencies (other steps they depend on) and have them be executed (in parallel or sequentially). See [this diff](https://github.com/cloudflare/workerd/compare/caio/python-workflows-2?expand=1#diff-5a01b2a830d4f6b351d55e7100a3762882d709d39e2a5cdb89f1398d80a8b34b)
- removes the option to call a step with a callable as the second param - makes the API more uniform
- adds coverage for these additions in the existing test