### PR TITLE
fix formatters path for zed and vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,9 +18,9 @@
     "--query-driver=**",
     "--clang-tidy"
   ],
-  "clang-format.executable": "${workspaceRoot}/bazel-bin/build/deps/formatters/clang-format",
-  "bazel.buildifierExecutable": "${workspaceRoot}/bazel-bin/build/deps/formatters/buildifier",
-  "ruff.path": ["${workspaceRoot}/bazel-bin/build/deps/formatters/ruff"],
+  "clang-format.executable": "${workspaceRoot}/bazel-out/k8-fastbuild/bin/build/deps/formatters/clang-format",
+  "bazel.buildifierExecutable": "${workspaceRoot}/bazel-out/k8-fastbuild/bin/build/deps/formatters/buildifier",
+  "ruff.path": ["${workspaceRoot}/bazel-out/k8-fastbuild/bin/build/deps/formatters/ruff"],
   "rust-analyzer.workspace.discoverConfig": {
     "command": ["just", "_rust-analyzer"],
     "progressLabel": "generating rust analyzer config",

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -7,7 +7,7 @@
     "C++": {
       "formatter": {
         "external": {
-          "command": "bazel-bin/build/deps/formatters/clang-format",
+          "command": "bazel-out/k8-fastbuild/bin/build/deps/formatters/clang-format",
           "args": ["-i", "{buffer_path}"]
         }
       }
@@ -15,7 +15,7 @@
     "Python": {
       "formatter": {
         "external": {
-          "command": "bazel-bin/build/deps/formatters/ruff",
+          "command": "bazel-out/k8-fastbuild/bin/build/deps/formatters/ruff",
           "arguments": ["format", "--stdin-filename", "{buffer_path}"]
         }
       }
@@ -23,7 +23,7 @@
     "Starlark": {
       "formatter": {
         "external": {
-          "command": "bazel-bin/build/deps/formatters/buildifier",
+          "command": "bazel-out/k8-fastbuild/bin/build/deps/formatters/buildifier",
           "arguments": ["--lint=fix", "--path", "{buffer_path}"]
         }
       }


### PR DESCRIPTION
When running benchmarks, bazel-bin folder doesn't include formatters. This fixes this particular problem.