### PR TITLE
Structured Logging

### DIFF
--- a/src/node/internal/internal_inspect.ts
+++ b/src/node/internal/internal_inspect.ts
@@ -2971,11 +2971,29 @@ export function stripVTControlCharacters(str: string): string {
 
 // Called from C++ on `console.log()`s to format values
 export function formatLog(
-  ...args: [...values: unknown[], colors: boolean]
+  ...args: [
+    ...values: unknown[],
+    colors: boolean,
+    structuredLogging: boolean,
+    level: string,
+  ]
 ): string {
-  const inspectOptions: InspectOptions = { colors: args.pop() as boolean };
+  const level = args.pop() as string;
+  const structuredLogging = args.pop() as boolean;
+  const colors = args.pop() as boolean;
+  const inspectOptions: InspectOptions = { colors };
+
   try {
-    return formatWithOptions(inspectOptions, ...args);
+    const message = formatWithOptions(inspectOptions, ...args);
+    if (structuredLogging) {
+      return JSON.stringify({
+        timestamp: Date.now(),
+        level,
+        message,
+      });
+    } else {
+      return message;
+    }
   } catch (err) {
     return `<Formatting threw (${isError(err) ? err.stack : String(err)})>`;
   }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -61,6 +61,23 @@ namespace workerd {
 
 namespace {
 
+constexpr kj::StringPtr logLevelToString(LogLevel level) {
+  switch (level) {
+    case LogLevel::DEBUG_:
+      return "debug";
+    case LogLevel::INFO:
+      return "info";
+    case LogLevel::LOG:
+      return "log";
+    case LogLevel::WARN:
+      return "warn";
+    case LogLevel::ERROR:
+      return "error";
+    default:
+      return "log";
+  }
+}
+
 void headersToCDP(const kj::HttpHeaders& in, capnp::JsonValue::Builder out) {
   std::map<kj::StringPtr, kj::Vector<kj::StringPtr>> inMap;
   in.forEach([&](kj::StringPtr name, kj::StringPtr value) {
@@ -559,6 +576,7 @@ struct Worker::Isolate::Impl {
           oldCurrentApi(currentApi),
           limitEnforcer(isolate.getLimitEnforcer()),
           consoleMode(isolate.consoleMode),
+          structuredLogging(isolate.structuredLogging),
           lock(isolate.api->lock(stackScope)) {
       WarnAboutIsolateLockScope::maybeWarn();
 
@@ -606,7 +624,7 @@ struct Worker::Isolate::Impl {
         i.get()->contextCreated(
             v8_inspector::V8ContextInfo(context, 1, jsg::toInspectorStringView("Worker")));
       }
-      Worker::setupContext(*lock, context, consoleMode);
+      Worker::setupContext(*lock, context, consoleMode, structuredLogging);
     }
 
     void disposeContext(jsg::JsContext<api::ServiceWorkerGlobalScope> context) {
@@ -642,6 +660,10 @@ struct Worker::Isolate::Impl {
     const IsolateLimitEnforcer& limitEnforcer;  // only so we can call getIsolateStats()
 
     ConsoleMode consoleMode;
+
+    // When structuredLogging is true AND consoleMode is STDOUT js logs will be emitted to STDOUT
+    // as newline separated json objects.
+    bool structuredLogging;
 
    public:
     kj::Own<jsg::Lock> lock;
@@ -984,12 +1006,14 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
     kj::StringPtr id,
     kj::Own<IsolateLimitEnforcer> limitEnforcerParam,
     InspectorPolicy inspectorPolicy,
-    ConsoleMode consoleMode)
+    ConsoleMode consoleMode,
+    bool structuredLogging)
     : metrics(kj::mv(metricsParam)),
       id(kj::str(id)),
       limitEnforcer(kj::mv(limitEnforcerParam)),
       api(kj::mv(apiParam)),
       consoleMode(consoleMode),
+      structuredLogging(structuredLogging),
       featureFlagsForFl(makeCompatJson(decompileCompatibilityFlagsForFl(api->getFeatureFlags()))),
       impl(kj::heap<Impl>(*api, *metrics, *limitEnforcer, inspectorPolicy)),
       weakIsolateRef(WeakIsolateRef::wrap(this)),
@@ -1454,8 +1478,10 @@ void setWebAssemblyModuleHasInstance(jsg::Lock& lock, v8::Local<v8::Context> con
       module->DefineOwnProperty(context, v8::Symbol::GetHasInstance(lock.v8Isolate), function));
 }
 
-void Worker::setupContext(
-    jsg::Lock& lock, v8::Local<v8::Context> context, Worker::ConsoleMode consoleMode) {
+void Worker::setupContext(jsg::Lock& lock,
+    v8::Local<v8::Context> context,
+    Worker::ConsoleMode consoleMode,
+    bool structuredLogging) {
   // Set WebAssembly.Module @@HasInstance
   setWebAssemblyModuleHasInstance(lock, context);
 
@@ -1471,9 +1497,9 @@ void Worker::setupContext(
         lock.v8Isolate, jsg::check(console->Get(context, methodStr)).As<v8::Function>());
 
     auto f = lock.wrapSimpleFunction(context,
-        [consoleMode, level, original = kj::mv(original)](
+        [consoleMode, level, structuredLogging, original = kj::mv(original)](
             jsg::Lock& js, const v8::FunctionCallbackInfo<v8::Value>& info) {
-      handleLog(js, consoleMode, level, original, info);
+      handleLog(js, consoleMode, level, structuredLogging, original, info);
     });
     jsg::check(console->Set(context, methodStr, f));
   };
@@ -1805,12 +1831,16 @@ void Worker::processEntrypointClass(jsg::Lock& js,
 void Worker::handleLog(jsg::Lock& js,
     ConsoleMode consoleMode,
     LogLevel level,
+    bool structuredLogging,
     const v8::Global<v8::Function>& original,
     const v8::FunctionCallbackInfo<v8::Value>& info) {
   // Call original V8 implementation so messages sent to connected inspector if any
   auto context = js.v8Context();
   int length = info.Length();
-  v8::LocalVector<v8::Value> args(js.v8Isolate, length + 1);
+  // to pass additional arguments from this function to js' `formatLog` we add arguments to the end
+  // of the arguments vector, then in formatLog we `pop` these from the vector.
+  // 3 is just the number of args we currently pass.
+  v8::LocalVector<v8::Value> args(js.v8Isolate, length + 3);
   for (auto i: kj::zeroTo(length)) args[i] = info[i];
   jsg::check(original.Get(js.v8Isolate)->Call(context, info.This(), length, args.data()));
 
@@ -1916,7 +1946,8 @@ void Worker::handleLog(jsg::Lock& js,
 #endif
 
     // Log warnings and errors to stderr
-    auto useStderr = level >= LogLevel::WARN;
+    // Always log to stdout when structuredLogging is enabled.
+    auto useStderr = level >= LogLevel::WARN && !structuredLogging;
     auto fd = useStderr ? stderr : stdout;
     auto tty = useStderr ? STDERR_TTY : STDOUT_TTY;
     auto colors =
@@ -1928,9 +1959,12 @@ void Worker::handleLog(jsg::Lock& js,
     KJ_ASSERT(formatLogVal->IsFunction());
     auto formatLog = formatLogVal.As<v8::Function>();
 
+    auto levelStr = logLevelToString(level);
     args[length] = v8::Boolean::New(js.v8Isolate, colors);
+    args[length + 1] = v8::Boolean::New(js.v8Isolate, structuredLogging);
+    args[length + 2] = jsg::v8StrIntern(js.v8Isolate, levelStr);
     auto formatted = js.toString(
-        jsg::check(formatLog->Call(context, js.v8Undefined(), length + 1, args.data())));
+        jsg::check(formatLog->Call(context, js.v8Undefined(), length + 3, args.data())));
     fprintf(fd, "%s\n", formatted.cStr());
     fflush(fd);
   }

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -176,8 +176,10 @@ class Worker: public kj::AtomicRefcounted {
   void setConnectOverride(kj::String networkAddress, ConnectFn connectFn);
   kj::Maybe<ConnectFn&> getConnectOverride(kj::StringPtr networkAddress);
 
-  static void setupContext(
-      jsg::Lock& lock, v8::Local<v8::Context> context, Worker::ConsoleMode consoleMode);
+  static void setupContext(jsg::Lock& lock,
+      v8::Local<v8::Context> context,
+      Worker::ConsoleMode consoleMode,
+      bool structuredLogging);
 
  private:
   kj::Own<const Script> script;
@@ -205,6 +207,7 @@ class Worker: public kj::AtomicRefcounted {
   static void handleLog(jsg::Lock& js,
       ConsoleMode mode,
       LogLevel level,
+      bool structuredLogging,
       const v8::Global<v8::Function>& original,
       const v8::FunctionCallbackInfo<v8::Value>& info);
 
@@ -312,7 +315,8 @@ class Worker::Isolate: public kj::AtomicRefcounted {
       kj::StringPtr id,
       kj::Own<IsolateLimitEnforcer> limitEnforcer,
       InspectorPolicy inspectorPolicy,
-      ConsoleMode consoleMode = ConsoleMode::INSPECTOR_ONLY);
+      ConsoleMode consoleMode = ConsoleMode::INSPECTOR_ONLY,
+      bool structuredLogging = false);
 
   ~Isolate() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(Isolate);
@@ -453,6 +457,7 @@ class Worker::Isolate: public kj::AtomicRefcounted {
   kj::Own<IsolateLimitEnforcer> limitEnforcer;
   kj::Own<Api> api;
   ConsoleMode consoleMode;
+  bool structuredLogging;
 
   // If non-null, a serialized JSON object with a single "flags" property, which is a list of
   // compatibility enable-flags that are relevant to FL.

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -47,6 +47,7 @@ wd_cc_binary(
     malloc = ":malloc",
     visibility = ["//visibility:public"],
     deps = [
+        ":json-logger",
         ":server",
         ":v8-platform-impl",
         ":workerd-meta_capnp",
@@ -136,6 +137,20 @@ wd_cc_library(
 )
 
 wd_capnp_library(src = "docker-api.capnp")
+
+wd_capnp_library(src = "log-schema.capnp")
+
+wd_cc_library(
+    name = "json-logger",
+    srcs = ["json-logger.c++"],
+    hdrs = ["json-logger.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":log-schema_capnp",
+        "@capnp-cpp//src/capnp/compat:json",
+        "@capnp-cpp//src/kj",
+    ],
+)
 
 wd_cc_library(
     name = "container-client",
@@ -268,5 +283,13 @@ kj_test(
     deps = [
         ":facet-tree-index",
         "@capnp-cpp//src/kj",
+    ],
+)
+
+kj_test(
+    src = "json-logger-test.c++",
+    deps = [
+        ":json-logger",
+        "@capnp-cpp//src/capnp/compat:json",
     ],
 )

--- a/src/workerd/server/json-logger-test.c++
+++ b/src/workerd/server/json-logger-test.c++
@@ -1,0 +1,91 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#if __linux__
+#include "json-logger.h"
+
+#include <workerd/server/log-schema.capnp.h>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <capnp/compat/json.h>
+#include <capnp/message.h>
+#include <kj/async-unix.h>
+#include <kj/io.h>
+
+#include <cstdio>
+#endif  // __linux__
+#include <kj/test.h>
+
+namespace workerd::server {
+namespace {
+#if __linux__
+// This test uses pipe2 and dup2 to capture stdout which is far easier on linux.
+
+struct FdPair {
+  kj::AutoCloseFd output;
+  kj::AutoCloseFd input;
+};
+
+auto makePipeFds() {
+  int pipeFds[2];
+  KJ_SYSCALL(pipe2(pipeFds, O_CLOEXEC));
+
+  return FdPair{
+    .output = kj::AutoCloseFd(pipeFds[0]),
+    .input = kj::AutoCloseFd(pipeFds[1]),
+  };
+}
+
+KJ_TEST("JsonLogger stdout validation") {
+  JsonLogger logger;
+
+  // Set up pipes to intercept stdout
+  auto interceptorPipe = makePipeFds();
+  int originalStdout = dup(STDOUT_FILENO);
+  KJ_SYSCALL(dup2(interceptorPipe.input.get(), STDOUT_FILENO));
+  interceptorPipe.input = nullptr;
+  KJ_DEFER({
+    // Restore stdout
+    KJ_SYSCALL(dup2(originalStdout, STDOUT_FILENO));
+    close(originalStdout);
+  });
+
+  // Log a test message
+  KJ_LOG(ERROR, "Test JSON message");
+
+  fflush(stdout);
+  // Read the JSON output
+  char buffer[4096];
+  ssize_t n;
+  KJ_SYSCALL(n = read(interceptorPipe.output.get(), buffer, sizeof(buffer) - 1));
+
+  // Should end with newline
+  KJ_ASSERT(buffer[--n] == '\n');
+  buffer[n] = '\0';
+
+  kj::StringPtr jsonOutput(buffer, n);
+
+  // Parse and validate the JSON using Cap'n Proto codec
+  capnp::JsonCodec codec;
+  codec.handleByAnnotation<log_schema::LogEntry>();
+
+  capnp::MallocMessageBuilder message;
+  auto logEntry = message.initRoot<log_schema::LogEntry>();
+  codec.decode(jsonOutput, logEntry);
+
+  // Validate the parsed JSON structure
+  KJ_EXPECT(logEntry.getLevel() == log_schema::LogEntry::LogLevel::ERROR);
+  KJ_EXPECT(logEntry.getMessage() == "Test JSON message");
+  KJ_EXPECT(logEntry.getTimestamp() > 0);
+  auto source = logEntry.getSource();
+  KJ_EXPECT(kj::StringPtr(source.begin(), source.size()).endsWith("json-logger-test.c++:49"));
+}
+#endif  // __linux__
+
+KJ_TEST("Blank test because KJ fails when 0 tests are enabled") {}
+
+}  // namespace
+}  // namespace workerd::server

--- a/src/workerd/server/json-logger.c++
+++ b/src/workerd/server/json-logger.c++
@@ -1,0 +1,86 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "json-logger.h"
+
+#include <workerd/server/log-schema.capnp.h>
+
+#include <capnp/compat/json.h>
+#include <capnp/message.h>
+#include <kj/debug.h>
+#include <kj/string.h>
+
+#include <cstdio>
+
+namespace workerd::server {
+
+log_schema::LogEntry::LogLevel severityToLogLevel(kj::LogSeverity severity) {
+  switch (severity) {
+    case kj::LogSeverity::INFO:
+      return log_schema::LogEntry::LogLevel::INFO;
+    case kj::LogSeverity::WARNING:
+      return log_schema::LogEntry::LogLevel::WARNING;
+    case kj::LogSeverity::ERROR:
+      return log_schema::LogEntry::LogLevel::ERROR;
+    case kj::LogSeverity::FATAL:
+      return log_schema::LogEntry::LogLevel::FATAL;
+    case kj::LogSeverity::DBG:
+      return log_schema::LogEntry::LogLevel::DEBUG;
+  }
+}
+
+kj::String buildJsonLogMessage(
+    kj::LogSeverity severity, const char* file, int line, int contextDepth, kj::StringPtr text) {
+  capnp::MallocMessageBuilder message;
+  auto logEntry = message.initRoot<log_schema::LogEntry>();
+
+  logEntry.setTimestamp(
+      (kj::systemPreciseCalendarClock().now() - kj::UNIX_EPOCH) / kj::MILLISECONDS);
+
+  logEntry.setLevel(severityToLogLevel(severity));
+
+  auto location = kj::str(file, ":", line);
+  logEntry.setSource(location);
+
+  logEntry.setMessage(text);
+
+  if (contextDepth > 0) {
+    logEntry.setContextDepth(static_cast<uint32_t>(contextDepth));
+  }
+
+  capnp::JsonCodec codec;
+  codec.handleByAnnotation<log_schema::LogEntry>();
+  codec.setPrettyPrint(false);  // Compact JSON for logs
+  return codec.encode(logEntry);
+}
+
+void JsonLogger::logMessage(
+    kj::LogSeverity severity, const char* file, int line, int contextDepth, kj::String&& text) {
+  // Prevent infinite recursion if logging code itself logs
+  if (loggingInProgress) {
+    return;
+  }
+  loggingInProgress = true;
+  KJ_DEFER(loggingInProgress = false);
+
+  auto json = buildJsonLogMessage(severity, file, line, contextDepth, text);
+
+  puts(json.cStr());
+}
+
+kj::Function<void(kj::Function<void()>)> JsonLogger::getThreadInitializer() {
+  auto nextInit = next.getThreadInitializer();
+
+  return [nextInit = kj::mv(nextInit)](kj::Function<void()> func) mutable {
+    nextInit([&]() {
+      JsonLogger logger;
+
+      // Make sure func is destroyed before the context is destroyed.
+      auto ownFunc = kj::mv(func);
+      ownFunc();
+    });
+  };
+}
+
+}  // namespace workerd::server

--- a/src/workerd/server/json-logger.h
+++ b/src/workerd/server/json-logger.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <kj/exception.h>
+#include <kj/function.h>
+#include <kj/string.h>
+
+namespace workerd::server {
+
+class JsonLogger: public kj::ExceptionCallback {
+ public:
+  void logMessage(kj::LogSeverity severity,
+      const char* file,
+      int line,
+      int contextDepth,
+      kj::String&& text) override;
+
+  kj::Function<void(kj::Function<void()>)> getThreadInitializer() override;
+
+  StackTraceMode stackTraceMode() override {
+    return StackTraceMode::ADDRESS_ONLY;
+  }
+
+ private:
+  bool loggingInProgress = false;
+};
+
+}  // namespace workerd::server

--- a/src/workerd/server/log-schema.capnp
+++ b/src/workerd/server/log-schema.capnp
@@ -1,0 +1,37 @@
+# Copyright (c) 2017-2022 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+@0x9f8a7b6c5d4e3f2a;
+using Cxx = import "/capnp/c++.capnp";
+using Json = import "/capnp/compat/json.capnp";
+
+$Cxx.namespace("workerd::server::log_schema");
+$Cxx.allowCancellation;
+
+struct LogEntry {
+  # Structured log entry for workerd JSON logging
+
+  timestamp @0 :UInt64 $Json.name("timestamp");
+  # Unix timestamp in milliseconds when the log was generated
+
+  level @1 :LogLevel $Json.name("level");
+  # Severity level of the log message
+
+  source @2 :Text $Json.name("source");
+  # Source file and line number where the log originated (e.g., "server.c++:123")
+
+  message @3 :Text $Json.name("message");
+  # The actual log message content
+
+  contextDepth @4 :UInt32 $Json.name("context_depth");
+  # Context depth for nested operations (optional, only included if > 0)
+
+  enum LogLevel {
+    debug @0 $Json.name("debug");
+    info @1 $Json.name("info");
+    warning @2 $Json.name("warning");
+    error @3 $Json.name("error");
+    fatal @4 $Json.name("fatal");
+  }
+}

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -4033,7 +4033,8 @@ kj::Own<Server::WorkerService> Server::makeWorkerImpl(kj::StringPtr name,
       def.source.variant.is<WorkerSource::ScriptSource>() &&
               !def.featureFlags.getNewModuleRegistry()
           ? Worker::ConsoleMode::INSPECTOR_ONLY
-          : consoleMode);
+          : consoleMode,
+      structuredLogging);
 
   // If we are using the inspector, we need to register the Worker::Isolate
   // with the inspector service.
@@ -4826,6 +4827,10 @@ kj::Promise<void> Server::handleDrain(kj::Promise<void> drainWhen) {
 kj::Promise<void> Server::run(
     jsg::V8System& v8System, config::Config::Reader config, kj::Promise<void> drainWhen) {
   TRACE_EVENT("workerd", "Server.run");
+
+  // Update structured logging setting from config
+  structuredLogging = config.getStructuredLogging();
+
   kj::HttpHeaderTable::Builder headerTableBuilder;
   globalContext = kj::heap<GlobalContext>(*this, v8System, headerTableBuilder);
   invalidConfigServiceSingleton = kj::refcounted<InvalidConfigService>();

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -131,6 +131,7 @@ class Server final: private kj::TaskSet::ErrorHandler {
   bool experimental = false;
 
   Worker::ConsoleMode consoleMode;
+  bool structuredLogging;
 
   kj::Own<api::MemoryCacheProvider> memoryCacheProvider;
 

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -10,6 +10,7 @@
 #include <workerd/io/supported-compatibility-date.capnp.h>
 #include <workerd/jsg/setup.h>
 #include <workerd/rust/cxx-integration/lib.rs.h>
+#include <workerd/server/json-logger.h>
 #include <workerd/server/v8-platform-impl.h>
 #include <workerd/server/workerd-meta.capnp.h>
 #include <workerd/server/workerd.capnp.h>
@@ -1344,6 +1345,13 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
 #endif
       TRACE_EVENT("workerd", "serveImpl()");
       auto config = getConfig();
+
+      // Initialize JSON logger if structured logging is enabled (similar to SyslogFriendlyLogger)
+      kj::Maybe<JsonLogger> jsonLogger;
+      if (config.getStructuredLogging()) {
+        jsonLogger.emplace();  // Stack-allocated instance for the entire serve scope
+      }
+
       auto platform = jsg::defaultPlatform(0);
       WorkerdPlatform v8Platform(*platform);
       jsg::V8System v8System(v8Platform,

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -84,6 +84,12 @@ struct Config {
   # A list of gates which are enabled.
   # These are used to gate features/changes in workerd and in our internal repo. See the equivalent
   # config definition in our internal repo for more details.
+
+  structuredLogging @5 :Bool = false;
+  # If true, logs will be emitted as JSON for structured logging.
+  # When false, logs use the traditional human-readable format.
+  # This affects the format of logs from KJ_LOG and exception reporting as well as js logs.
+  # This won't work for logs coming from service worker syntax workers with the old module registry.
 }
 
 # ========================================================================================


### PR DESCRIPTION
This commit adds structured logging support to workerd. This is disabled by default but can be enabled with the structuredLogging configuration option.

When enabled workerd will output json log messages to stdout. The two sources of logs are c++ logs/errors and js errors.