### PR TITLE
EW-9285 Drop inaccurate stream cancellation error message

### DIFF
--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -651,7 +651,7 @@ class TailStreamTarget final: public rpc::TailStreamTarget::Server {
   KJ_DISALLOW_COPY_AND_MOVE(TailStreamTarget);
   ~TailStreamTarget() {
     if (doneFulfiller->isWaiting()) {
-      doneFulfiller->reject(KJ_EXCEPTION(DISCONNECTED, "Tail stream session canceled."));
+      doneFulfiller->reject(KJ_EXCEPTION(DISCONNECTED, "Streaming tail session canceled."));
     }
   }
 
@@ -942,11 +942,14 @@ class TailStreamTarget final: public rpc::TailStreamTarget::Server {
     }
 
     KJ_IF_SOME(p, promise) {
+      // When doFulfill applies the last promise refers to the outcome event. In that case the chain
+      // of promises provides all remaining events to the user tail handler, so we should fulfill
+      // the doneFulfiller afterwards, indicating that TailStreamTarget has received all events over
+      // the stream and has done all its work, that the stream self-evidently did not get canceled
+      // prematurely. This applies even if promises were rejected.
       if (doFulfill) {
         p = p.then(js, [&](jsg::Lock& js) { doneFulfiller->fulfill(); },
-            [&](jsg::Lock& js, jsg::Value&& value) {
-          doneFulfiller->reject(KJ_EXCEPTION(DISCONNECTED, "Streaming tail session canceled"));
-        });
+            [&](jsg::Lock& js, jsg::Value&& value) { doneFulfiller->fulfill(); });
       }
       return ioContext.awaitJs(js, kj::mv(p));
     }


### PR DESCRIPTION
The given "Streaming tail session canceled" error we observed happens if we receive the outcome event in the tail stream handler and the promise for the js call where we provide the outcome event to user code gets canceled. This promise can be canceled for a number of reasons that the user is responsible for, such as an exception thrown in the outcome event handler or hitting the CPU limit, as was shown in testing. Additional testing showed that if there is a JS exception thrown in handlers other than the outcome handler, we do not get the given error. It does not indicate the runtime behaving unexpectedly?

**Why do we have this error?**
Looking at git history, it turns out that I originally added the error when fixing an issue where the tail stream handler failed to get the outcome event. In the PR (https://github.com/cloudflare/workerd/pull/3646), I commented "Also added an error handler to reject the fulfiller if needed." This refers to me adding the doneFulfiller->reject() call and the error, which wasn't present in an earlier version of the PR, so that if the promise chain is rejected, we do not leave the fulfiller in a waiting state.
Unfortunately, the reject() call was cargo-culted from the TailStreamTarget destructor, including the eror that's present there. In that case, we emit a cancellation error, which makes sense since TailStreamTarget being destructed without doneFulfiller being fulfilled does indicate that it may have been cancelled without providing all required events to the JS-level handler. But, in the case of the promise rejection this is not the case, since instead of the whole stream being canceled we have only seen a JS call cause an exception. In that case, the error is happening on the user side, and the user will receive telemetry data about exceeded limits or JS-level exceptions accordingly. There is nothing more we can do in this case – we have delivered all events to the user tail handler, and there is nothing for us to warn about.

Also see the downstream PR.