### PR TITLE
Include support for virtual "stdio" file descriptors

### DIFF
--- a/src/node/internal/internal_fs_utils.ts
+++ b/src/node/internal/internal_fs_utils.ts
@@ -372,23 +372,21 @@ export function validateWriteArgs(
   if (isArrayBufferView(buffer)) {
     if (typeof offsetOrOptions === 'object' && offsetOrOptions != null) {
       ({
-        offset = 0,
-        length = buffer.byteLength - offset,
+        offset = buffer.byteOffset,
+        length = buffer.byteLength,
         position = null,
       } = (offsetOrOptions as WriteSyncOptions | null) || {});
     }
     position ??= null;
     offset ??= buffer.byteOffset;
+    length ??= buffer.byteLength;
 
     validateInteger(offset, 'offset', 0);
     validatePosition(position, 'position');
-
-    length ??= buffer.byteLength - offset;
-
     validateInteger(length, 'length', 0);
 
     // Validate that the offset + length do not exceed the buffer's byte length.
-    if (offset + length > buffer.byteLength) {
+    if (length > buffer.byteLength) {
       throw new ERR_INVALID_ARG_VALUE('offset', offset, 'out of bounds');
     }
 

--- a/src/workerd/api/node/tests/fs-access-test.js
+++ b/src/workerd/api/node/tests/fs-access-test.js
@@ -15,6 +15,11 @@ import {
   exists,
   promises,
   constants,
+  fstatSync,
+  closeSync,
+  openSync,
+  writeSync,
+  readSync,
 } from 'node:fs';
 
 const { F_OK, R_OK, W_OK, X_OK } = constants;
@@ -291,4 +296,43 @@ export const existsCallbackTest = {
   },
 };
 
+export const stdioFds = {
+  test() {
+    let stat1 = fstatSync(0);
+    let stat2 = fstatSync(1);
+    let stat3 = fstatSync(2);
+    ok(stat1.isFile());
+    ok(stat2.isFile());
+    ok(stat3.isFile());
+    closeSync(0);
+    closeSync(1);
+    closeSync(2);
+    // After closing the stdio file descriptors, they can still be used.
+    // That is, we don't actually close them.
+    stat1 = fstatSync(0);
+    stat2 = fstatSync(1);
+    stat3 = fstatSync(2);
+    ok(stat1.isFile());
+    ok(stat2.isFile());
+    ok(stat3.isFile());
+
+    // Writing to the stdio file descriptors is permitted, always in append mode.
+    // Position is ignored.
+    writeSync(0, 'Hello, stdin!\n', 1000);
+    writeSync(0, 'test', 500);
+    writeSync(1, 'Hello, stdin!\n', 1000);
+    writeSync(1, 'test', 500);
+    writeSync(2, 'Hello, stdin!\n', 1000);
+    writeSync(2, 'test', 500);
+
+    stat1 = fstatSync(0);
+    strictEqual(stat1.size, 0);
+
+    const buf = Buffer.alloc(20);
+    const bytesRead = readSync(0, buf, { position: 1000 });
+
+    const fd = openSync('/tmp/test.txt', 'w');
+    strictEqual(fd, 3);
+  },
+};
 // There is no promise version of exists in Node.js, so no test for it here.

--- a/src/workerd/api/node/tests/fs-test.js
+++ b/src/workerd/api/node/tests/fs-test.js
@@ -253,7 +253,9 @@ export const writeSyncTest = {
       kErrInvalidArgType
     );
     throws(() => writeSync(123, 'Hello World'), kErrEBadf);
-    throws(() => writeSync(fd, Buffer.alloc(2), { offset: 5 }), kErrOutOfRange);
+    throws(() => writeSync(fd, Buffer.alloc(2), { offset: 5 }), {
+      code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    });
     throws(
       () => writeSync(fd, Buffer.alloc(2), { length: 5 }),
       kErrInvalidArgValue
@@ -313,10 +315,9 @@ export const writeAsyncCallbackTest = {
       () => write(fd, 'Hello World', { position: 'hello' }, mustNotCall),
       kErrInvalidArgType
     );
-    throws(
-      () => write(fd, Buffer.alloc(2), { offset: 5 }, mustNotCall),
-      kErrOutOfRange
-    );
+    throws(() => write(fd, Buffer.alloc(2), { offset: 5 }, mustNotCall), {
+      code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    });
     throws(
       () => write(fd, Buffer.alloc(2), { length: 5 }, mustNotCall),
       kErrInvalidArgValue
@@ -429,7 +430,7 @@ export const writeSyncTest4 = {
 
     // Specifying an offset or length beyond the buffer size is not allowed.
     throws(() => writeSync(fd, Buffer.from('Hello World'), 100, 3), {
-      message: /out of bounds/,
+      message: /outside of buffer bounds/,
     });
     // Specifying an offset or length beyond the buffer size is not allowed.
     throws(() => writeSync(fd, Buffer.from('Hello World'), 0, 100), {

--- a/src/workerd/io/worker-fs.c++
+++ b/src/workerd/io/worker-fs.c++
@@ -1,6 +1,7 @@
 #include "worker-fs.h"
 
 #include <workerd/io/io-context.h>
+#include <workerd/io/tracer.h>
 #include <workerd/util/uuid.h>
 #include <workerd/util/weak-refs.h>
 
@@ -874,6 +875,8 @@ class VirtualFileSystemImpl final: public VirtualFileSystem {
         weakThis(
             kj::rc<WeakRef<VirtualFileSystemImpl>>(kj::Badge<VirtualFileSystemImpl>(), *this)) {}
 
+  kj::Rc<OpenedFile> getStdio(jsg::Lock& js, Stdio stdio) const override;
+
   ~VirtualFileSystemImpl() noexcept(false) override {
     weakThis->invalidate();
   }
@@ -989,10 +992,17 @@ class VirtualFileSystemImpl final: public VirtualFileSystem {
   }
 
   void closeFd(jsg::Lock& js, int fd) const override {
+    // We do not allow closing the stdio file descriptors.
+    static constexpr int kMaxFd = static_cast<int>(Stdio::ERR);
+    if (fd <= kMaxFd) return;
     closeFdWithoutExplicitLock(fd);
   }
 
   kj::Maybe<kj::Rc<OpenedFile>> tryGetFd(jsg::Lock& js, int fd) const override {
+    static constexpr int kMaxFd = static_cast<int>(Stdio::ERR);
+    if (fd <= kMaxFd) {
+      return getStdio(js, static_cast<Stdio>(fd));
+    }
     KJ_IF_SOME(opened, openedFiles.find(fd)) {
       return opened.addRef();
     }
@@ -1015,7 +1025,7 @@ class VirtualFileSystemImpl final: public VirtualFileSystem {
   friend class FdHandle;
 
   // The next file descriptor to be used for the next file opened.
-  mutable int nextFd = 0;
+  mutable int nextFd = static_cast<int>(Stdio::ERR) + 1;
 
   mutable kj::HashMap<int, kj::Rc<OpenedFile>> openedFiles;
 
@@ -1622,6 +1632,114 @@ class DevRandomFile final: public File, public kj::EnableAddRefToThis<DevRandomF
   mutable kj::Maybe<kj::String> maybeUniqueId;
 };
 
+// An StdioFile is a special file implementation used to represent stdin,
+// stdout, and stderr outputs. Writes are always forwarded to the underlying
+// logging mechanisms. Reads always return EOF (0-byte reads).
+class StdioFile final: public File, public kj::EnableAddRefToThis<StdioFile> {
+ public:
+  StdioFile(VirtualFileSystem::Stdio type): type(type) {}
+
+  Stat stat(jsg::Lock& js) override {
+    return Stat{
+      .type = FsType::FILE,
+      .size = 0,
+      .lastModified = kj::UNIX_EPOCH,
+      .writable = true,
+      .device = false,
+    };
+  }
+
+  kj::OneOf<FsError, kj::Rc<File>> clone(jsg::Lock&) override {
+    kj::Rc<File> ref = addRefToThis();
+    return kj::mv(ref);
+  }
+
+  kj::Maybe<FsError> replace(jsg::Lock& js, kj::Rc<File> file) override {
+    return FsError::NOT_PERMITTED;
+  }
+
+  kj::Maybe<FsError> setLastModified(jsg::Lock& js, kj::Date date = kj::UNIX_EPOCH) override {
+    return FsError::NOT_PERMITTED;
+  }
+
+  kj::Maybe<FsError> fill(jsg::Lock& js, kj::byte value, kj::Maybe<uint32_t> offset) override {
+    return FsError::NOT_PERMITTED;
+  }
+
+  kj::Maybe<FsError> resize(jsg::Lock& js, uint32_t size) override {
+    return FsError::NOT_PERMITTED;
+  }
+
+  kj::StringPtr jsgGetMemoryName() const override {
+    return "stdio"_kj;
+  }
+
+  size_t jsgGetMemorySelfSize() const override {
+    return sizeof(StdioFile);
+  }
+
+  void jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const override {}
+
+  kj::OneOf<FsError, uint32_t> write(
+      jsg::Lock&, uint32_t, kj::ArrayPtr<const kj::byte> buffer) override {
+    // Protect against unreasonably large writes.
+    if (buffer.size() > 16 * 1024) {
+      return FsError::FILE_SIZE_LIMIT_EXCEEDED;
+    }
+
+    if (buffer.size() == 0) return uint32_t(0);
+
+    // We ignore the offset here. All writes are assumed to be appends.
+    if (type != VirtualFileSystem::Stdio::IN) {
+
+      if (IoContext::hasCurrent()) {
+        auto& ioContext = IoContext::current();
+        KJ_IF_SOME(tracer, ioContext.getWorkerTracer()) {
+          // If there is a worker tracer, then we'll direct the log output to it.
+          LogLevel level =
+              (type == VirtualFileSystem::Stdio::OUT) ? LogLevel::INFO : LogLevel::ERROR;
+          auto timestamp = ioContext.now();
+          // The assumption here is that the buffer is a complete UTF-8 string.
+          // That's not always true if the caller doesn't take care to write
+          // complete UTF-8 sequences, but it's easiest for us to assume this
+          // case in order to avoid having to buffer partial sequences, which
+          // gets complicated. Worst case the log output is a bit garbled,
+          // which isn't the end of the world and is easier for the user to
+          // fix on their end.
+          tracer.addLog(
+              ioContext.getInvocationSpanContext(), timestamp, level, kj::str(buffer.asChars()));
+        }
+      }
+
+      // Now forward the bytes on to the the impl specific logging mechanism,
+      // if any. In workerd this will forward the output to stdout/stderr.
+      // In production this likely goes nowhere, similar to the way the
+      // handleLog method works in worker.c++.
+      Worker::Api::current().writeStdio(type, buffer);
+    }
+    return static_cast<uint32_t>(buffer.size());
+  }
+
+  uint32_t read(jsg::Lock&, uint32_t, kj::ArrayPtr<kj::byte>) const override {
+    return 0;  // EOF
+  }
+
+  kj::StringPtr getUniqueId(jsg::Lock&) const override {
+    KJ_IF_SOME(id, maybeUniqueId) {
+      return id;
+    }
+    // Generating a UUID requires randomness, which requires an IoContext.
+    JSG_REQUIRE(IoContext::hasCurrent(), Error, "Cannot generate a unique ID outside of a request");
+    auto& ioContext = IoContext::current();
+    maybeUniqueId = workerd::randomUUID(ioContext.getEntropySource());
+    return KJ_ASSERT_NONNULL(maybeUniqueId);
+  }
+
+ private:
+  VirtualFileSystem::Stdio type;
+  mutable kj::Maybe<kj::String> maybeUniqueId;
+};
+
 }  // namespace
 
 kj::Rc<File> getDevNull() {
@@ -1647,6 +1765,18 @@ kj::Rc<Directory> getDevDirectory() {
   builder.add("full", getDevFull());
   builder.add("random", getDevRandom());
   return builder.finish();
+}
+
+kj::Rc<VirtualFileSystem::OpenedFile> VirtualFileSystemImpl::getStdio(
+    jsg::Lock& js, Stdio stdio) const {
+  int n = static_cast<int>(stdio);
+  KJ_IF_SOME(existing, openedFiles.find(n)) {
+    return existing.addRef();
+  }
+  kj::Rc<workerd::File> file = kj::rc<StdioFile>(stdio);
+  auto opened = kj::rc<VirtualFileSystem::OpenedFile>(n, true, true, true, kj::mv(file));
+  openedFiles.insert(n, opened.addRef());
+  return kj::mv(opened);
 }
 
 }  // namespace workerd

--- a/src/workerd/io/worker-fs.h
+++ b/src/workerd/io/worker-fs.h
@@ -589,6 +589,13 @@ class VirtualFileSystem {
     uint32_t position = 0;
   };
 
+  enum class Stdio {
+    IN,
+    OUT,
+    ERR,
+  };
+  virtual kj::Rc<OpenedFile> getStdio(jsg::Lock& js, Stdio stdio) const KJ_WARN_UNUSED_RESULT = 0;
+
   // Attempts to open a file descriptor for the given file URL. It's critical
   // to understand that the file descriptor table is shared for the entire
   // worker. This means that if a file descriptor is opened, it will remain

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -603,6 +603,27 @@ class Worker::Api {
 
   // Return the virtual file system for this worker.
   virtual const VirtualFileSystem& getVirtualFileSystem() const = 0;
+
+  // Output virtual stdio to... somewhere.
+  virtual void writeStdio(VirtualFileSystem::Stdio type, kj::ArrayPtr<const kj::byte> bytes) const {
+    // By default, these go nowhere unless overridden or the verbose option is set, which
+    // it never is in production.
+    switch (type) {
+      case VirtualFileSystem::Stdio::ERR: {
+        KJ_LOG(INFO, "stderr", bytes);
+        return;
+      }
+      case VirtualFileSystem::Stdio::OUT: {
+        KJ_LOG(INFO, "stdout", bytes);
+        return;
+      }
+      case VirtualFileSystem::Stdio::IN: {
+        // stdin should never be directed to here.
+        break;
+      }
+    }
+    KJ_UNREACHABLE;
+  }
 };
 
 // A Worker may bounce between threads as it handles multiple requests, but can only actually

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -1465,4 +1465,31 @@ const VirtualFileSystem& WorkerdApi::getVirtualFileSystem() const {
   return *impl->vfs;
 }
 
+void WorkerdApi::writeStdio(
+    VirtualFileSystem::Stdio type, kj::ArrayPtr<const kj::byte> bytes) const {
+  // Currently this outputs log messages in the typical kj line
+  // format like:
+  //   workerd/server/workerd-api.c++:1476: warning: bytes.asChars() = HELLO WORLD
+  //   workerd/server/workerd-api.c++:1472: error: bytes.asChars() = HELLO WORLD ERR
+  //
+  // Which isn't the most elegant. The handleLog method in worker.c++, alternatively,
+  // outputs just the message itself by writing directly to stderr or stdout, giving
+  // prettier output. We could do that here too if we think it's better.
+  switch (type) {
+    case VirtualFileSystem::Stdio::ERR: {
+      KJ_LOG(ERROR, bytes.asChars());
+      return;
+    }
+    case VirtualFileSystem::Stdio::OUT: {
+      KJ_LOG(WARNING, bytes.asChars());
+      return;
+    }
+    case VirtualFileSystem::Stdio::IN: {
+      // stdin should never be directed to here.
+      break;
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
 }  // namespace workerd::server

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -50,6 +50,7 @@ class WorkerdApi final: public Worker::Api {
   static const WorkerdApi& from(const Worker::Api&);
 
   const VirtualFileSystem& getVirtualFileSystem() const override;
+  void writeStdio(VirtualFileSystem::Stdio type, kj::ArrayPtr<const kj::byte> bytes) const override;
 
   kj::Own<jsg::Lock> lock(jsg::V8StackScope& stackScope) const override;
   CompatibilityFlags::Reader getFeatureFlags() const override;


### PR DESCRIPTION
Reserve fd's 0, 1, and 2 for stdin, stdout, and stderr virtual files.

These are intended to serve as the underlying basis for `process.stdin`, `process.stdout`, and `process.stderr`