### PR TITLE
Rename LogLevel::DEBUG to avoid clashing with DEBUG macro

### DIFF
--- a/src/workerd/server/json-logger.c++
+++ b/src/workerd/server/json-logger.c++
@@ -26,7 +26,7 @@ log_schema::LogEntry::LogLevel severityToLogLevel(kj::LogSeverity severity) {
     case kj::LogSeverity::FATAL:
       return log_schema::LogEntry::LogLevel::FATAL;
     case kj::LogSeverity::DBG:
-      return log_schema::LogEntry::LogLevel::DEBUG;
+      return log_schema::LogEntry::LogLevel::DEBUG_;
   }
 }
 

--- a/src/workerd/server/log-schema.capnp
+++ b/src/workerd/server/log-schema.capnp
@@ -28,7 +28,8 @@ struct LogEntry {
   # Context depth for nested operations (optional, only included if > 0)
 
   enum LogLevel {
-    debug @0 $Json.name("debug");
+    debug @0 $Cxx.name("debug_") $Json.name("debug");
+    # in C++, the constant will be DEBUG_ to avoid clashing with the DEBUG macro
     info @1 $Json.name("info");
     warning @2 $Json.name("warning");
     error @3 $Json.name("error");


### PR DESCRIPTION
The macro `DEBUG` is often defined during debug builds. For example, it's defined for anyone developing locally on a Mac. Because macros are a mess, this means that we can't use `DEBUG` as an enum constant, as it would clash. I added an ugly `L_` prefix to avoid the clash.