### PR TITLE
fix: process hrtime test flake

### DIFF
--- a/src/workerd/api/node/tests/process-nodejs-test.js
+++ b/src/workerd/api/node/tests/process-nodejs-test.js
@@ -615,7 +615,7 @@ export const processHrtime = {
       // Ideally, this should be closer to 1000, or we could test
       // a smaller interval, but this is to work around the
       // test runner time accuracy.
-      assert(end - start >= 100_000_000n);
+      assert(end - start >= 10_000_000n);
     }
   },
 };


### PR DESCRIPTION
This should in theory deflake the process.hrtime test when running on fast machines.

I haven't been able to verify locally as I can't reproduce the issue though.

//cc @anonrig