### PR TITLE
[nfc] Add WD_STRONG_BOOL() macro

### DIFF
--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -115,6 +115,7 @@ wd_cc_library(
         "//src/workerd/util:completion-membrane",
         "//src/workerd/util:exception",
         "//src/workerd/util:sqlite",
+        "//src/workerd/util:strong-bool",
         "//src/workerd/util:thread-scopes",
         "//src/workerd/util:uuid",
         "@capnp-cpp//src/capnp:capnp-rpc",

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -661,9 +661,9 @@ struct Worker::Isolate::Impl {
 
     ConsoleMode consoleMode;
 
-    // When structuredLogging is true AND consoleMode is STDOUT js logs will be emitted to STDOUT
+    // When structuredLogging is YES AND consoleMode is STDOUT js logs will be emitted to STDOUT
     // as newline separated json objects.
-    bool structuredLogging;
+    StructuredLogging structuredLogging;
 
    public:
     kj::Own<jsg::Lock> lock;
@@ -1007,7 +1007,7 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
     kj::Own<IsolateLimitEnforcer> limitEnforcerParam,
     InspectorPolicy inspectorPolicy,
     ConsoleMode consoleMode,
-    bool structuredLogging)
+    StructuredLogging structuredLogging)
     : metrics(kj::mv(metricsParam)),
       id(kj::str(id)),
       limitEnforcer(kj::mv(limitEnforcerParam)),
@@ -1485,7 +1485,7 @@ void setWebAssemblyModuleHasInstance(jsg::Lock& lock, v8::Local<v8::Context> con
 void Worker::setupContext(jsg::Lock& lock,
     v8::Local<v8::Context> context,
     Worker::ConsoleMode consoleMode,
-    bool structuredLogging) {
+    StructuredLogging structuredLogging) {
   // Set WebAssembly.Module @@HasInstance
   setWebAssemblyModuleHasInstance(lock, context);
 
@@ -1835,7 +1835,7 @@ void Worker::processEntrypointClass(jsg::Lock& js,
 void Worker::handleLog(jsg::Lock& js,
     ConsoleMode consoleMode,
     LogLevel level,
-    bool structuredLogging,
+    StructuredLogging structuredLogging,
     const v8::Global<v8::Function>& original,
     const v8::FunctionCallbackInfo<v8::Value>& info) {
   // Call original V8 implementation so messages sent to connected inspector if any
@@ -1965,7 +1965,7 @@ void Worker::handleLog(jsg::Lock& js,
 
     auto levelStr = logLevelToString(level);
     args[length] = v8::Boolean::New(js.v8Isolate, colors);
-    args[length + 1] = v8::Boolean::New(js.v8Isolate, structuredLogging);
+    args[length + 1] = v8::Boolean::New(js.v8Isolate, bool(structuredLogging));
     args[length + 2] = jsg::v8StrIntern(js.v8Isolate, levelStr);
     auto formatted = js.toString(
         jsg::check(formatLog->Call(context, js.v8Undefined(), length + 3, args.data())));

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -19,6 +19,7 @@
 #include <workerd/io/worker-source.h>
 #include <workerd/jsg/async-context.h>
 #include <workerd/jsg/jsg.h>
+#include <workerd/util/strong-bool.h>
 #include <workerd/util/uncaught-exception-source.h>
 #include <workerd/util/weak-refs.h>
 
@@ -30,6 +31,8 @@ class Isolate;
 }
 
 namespace workerd {
+
+WD_STRONG_BOOL(StructuredLogging);
 
 namespace api {
 class DurableObjectState;
@@ -180,7 +183,7 @@ class Worker: public kj::AtomicRefcounted {
   static void setupContext(jsg::Lock& lock,
       v8::Local<v8::Context> context,
       Worker::ConsoleMode consoleMode,
-      bool structuredLogging);
+      StructuredLogging structuredLogging);
 
  private:
   kj::Own<const Script> script;
@@ -208,7 +211,7 @@ class Worker: public kj::AtomicRefcounted {
   static void handleLog(jsg::Lock& js,
       ConsoleMode mode,
       LogLevel level,
-      bool structuredLogging,
+      StructuredLogging structuredLogging,
       const v8::Global<v8::Function>& original,
       const v8::FunctionCallbackInfo<v8::Value>& info);
 
@@ -318,7 +321,7 @@ class Worker::Isolate: public kj::AtomicRefcounted {
       kj::Own<IsolateLimitEnforcer> limitEnforcer,
       InspectorPolicy inspectorPolicy,
       ConsoleMode consoleMode = ConsoleMode::INSPECTOR_ONLY,
-      bool structuredLogging = false);
+      StructuredLogging structuredLogging = StructuredLogging::NO);
 
   ~Isolate() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(Isolate);
@@ -460,7 +463,7 @@ class Worker::Isolate: public kj::AtomicRefcounted {
   kj::Own<IsolateLimitEnforcer> limitEnforcer;
   kj::Own<Api> api;
   ConsoleMode consoleMode;
-  bool structuredLogging;
+  StructuredLogging structuredLogging;
 
   // If non-null, a serialized JSON object with a single "flags" property, which is a list of
   // compatibility enable-flags that are relevant to FL.

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -4829,7 +4829,7 @@ kj::Promise<void> Server::run(
   TRACE_EVENT("workerd", "Server.run");
 
   // Update structured logging setting from config
-  structuredLogging = config.getStructuredLogging();
+  structuredLogging = StructuredLogging(config.getStructuredLogging());
 
   kj::HttpHeaderTable::Builder headerTableBuilder;
   globalContext = kj::heap<GlobalContext>(*this, v8System, headerTableBuilder);

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -131,7 +131,7 @@ class Server final: private kj::TaskSet::ErrorHandler {
   bool experimental = false;
 
   Worker::ConsoleMode consoleMode;
-  bool structuredLogging;
+  StructuredLogging structuredLogging{StructuredLogging::NO};
 
   kj::Own<api::MemoryCacheProvider> memoryCacheProvider;
 

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -101,6 +101,15 @@ wd_cc_library(
 )
 
 wd_cc_library(
+    name = "strong-bool",
+    hdrs = ["strong-bool.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj",
+    ],
+)
+
+wd_cc_library(
     name = "uuid",
     srcs = ["uuid.c++"],
     hdrs = ["uuid.h"],
@@ -259,6 +268,13 @@ kj_test(
     src = "string-buffer-test.c++",
     deps = [
         ":string-buffer",
+    ],
+)
+
+kj_test(
+    src = "strong-bool-test.c++",
+    deps = [
+        ":strong-bool",
     ],
 )
 

--- a/src/workerd/util/strong-bool-test.c++
+++ b/src/workerd/util/strong-bool-test.c++
@@ -1,0 +1,180 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "strong-bool.h"
+
+#include <kj/test.h>
+
+namespace workerd {
+
+WD_STRONG_BOOL(Strongbad);
+WD_STRONG_BOOL(Burninator);
+
+constexpr Strongbad giveStrongbad() {
+  return Strongbad::NO;
+}
+constexpr Burninator giveBurninator() {
+  return Burninator::YES;
+}
+constexpr void takeStrongbad(Strongbad strongbadValue) {}
+constexpr void takeBurninator(Burninator burninatorValue) {}
+
+// TODO(soon): We don't have negative compile tests that I know of :(
+KJ_TEST("WD_STRONG_BOOL compile failures") {
+  [[maybe_unused]] Strongbad strongbadValue{Strongbad::NO};
+  [[maybe_unused]] Burninator burninatorValue{Burninator::YES};
+  [[maybe_unused]] bool booleanValue = false;
+  [[maybe_unused]] int integerValue = 123;
+
+  // No uninitialized values
+  //Strongbad uninitialized;
+
+  // No implicit conversion from bool or int
+  //strongbad = false;
+  //strongbad = 123;
+  //strongbad = booleanValue;
+  //strongbad = integerValue;
+  //Strongbad s1 = false;
+  //Strongbad s2 = 123;
+
+  // No implicit conversion to bool or int
+  //booleanValue = strongbadValue;
+  //integerValue = strongbadValue;
+  //bool b = strongbadValue;
+  //int i = strongbadValue;
+  //int i = Strongbad::NO;
+  //bool b = Strongbad::YES;
+
+  // No implicit conversion between strong bools.
+  //strongbadValue = burninatorValue;
+  //if (strongbadValue == burninatorValue) {}
+
+  //takeBurninator(giveStrongbad());
+  //takeStrongbad(giveBurninator());
+}
+
+KJ_TEST("WD_STRONG_BOOL can be explicitly converted to and from `bool`") {
+  Strongbad strongbadNo{Strongbad::NO};
+  Strongbad strongbadYes{Strongbad::YES};
+
+  auto booleanValue = bool(strongbadNo);
+  static_assert(kj::isSameType<decltype(booleanValue), bool>());
+
+  auto strongbadNo2 = Strongbad(booleanValue);
+  static_assert(kj::isSameType<decltype(strongbadNo2), Strongbad>());
+
+  // Literals can be explicitly converted in both directions, too.
+  static_assert(kj::isSameType<decltype(bool(Strongbad::NO)), bool>());
+  static_assert(kj::isSameType<decltype(Strongbad(false)), Strongbad>());
+
+  // Can't use static_assert because they're not constexpr. We'll test constexpr elsewhere.
+  KJ_EXPECT(!bool(strongbadNo));
+  KJ_EXPECT(bool(strongbadYes));
+  KJ_EXPECT(Strongbad(false) == Strongbad::NO);
+  KJ_EXPECT(Strongbad(true) == Strongbad::YES);
+}
+
+KJ_TEST("WD_STRONG_BOOL can be contextually converted to `bool`") {
+  Strongbad strongbadNo{Strongbad::NO};
+  Burninator burninatorYes{Burninator::YES};
+
+  // It's a Strongbad ...
+  static_assert(kj::isSameType<decltype(strongbadNo), Strongbad>());
+  static_assert(kj::isSameType<decltype(Strongbad::NO), const Strongbad>());
+  static_assert(kj::isSameType<decltype(Strongbad::YES), const Strongbad>());
+
+  // ... until you use it in an explicitly boolean context.
+  static_assert(kj::isSameType<decltype(!strongbadNo), bool>());
+  static_assert(kj::isSameType<decltype(strongbadNo && burninatorYes), bool>());
+  static_assert(kj::isSameType<decltype(strongbadNo || burninatorYes), bool>());
+
+  // These are all contextually converted to `bool`s.
+  if (strongbadNo) {}
+  if (strongbadNo && burninatorYes) {}
+  if (strongbadNo || burninatorYes) {}
+
+  // Can't use static_assert because they're not constexpr. We'll test constexpr elsewhere.
+  KJ_EXPECT(!strongbadNo);
+  KJ_EXPECT(!Strongbad::NO);
+
+  // TODO(someday): KJ magic asserts are not a boolean context :(
+  KJ_EXPECT(!!burninatorYes);
+  KJ_EXPECT(!!Strongbad::YES);
+}
+
+KJ_TEST("WD_STRONG_BOOL is constexpr") {
+  if constexpr (constexpr auto s = giveStrongbad()) {
+    static_assert(kj::isSameType<decltype(s), const Strongbad>());
+  }
+
+  constexpr Strongbad strongbadValue{Strongbad::NO};
+  if constexpr (strongbadValue) {}
+  if constexpr (Strongbad(true)) {}
+  if constexpr (bool(Strongbad::NO)) {}
+  if constexpr (Strongbad::NO || Strongbad::YES) {}
+  if constexpr (Strongbad::NO && Strongbad::YES) {}
+  [[maybe_unused]] constexpr auto order = Strongbad::YES <=> Strongbad::NO;
+
+  static_assert(!strongbadValue);
+}
+
+KJ_TEST("WD_STRONG_BOOL comparison operators") {
+  constexpr Strongbad strongbadNo{Strongbad::NO};
+  constexpr Strongbad strongbadYes{Strongbad::YES};
+
+  if constexpr (strongbadNo == strongbadYes) {}
+  if constexpr (strongbadNo != strongbadYes) {}
+  if constexpr (strongbadNo < strongbadYes) {}
+  if constexpr (strongbadNo > strongbadYes) {}
+  if constexpr (strongbadNo <= strongbadYes) {}
+  if constexpr (strongbadNo >= strongbadYes) {}
+
+  static_assert(strongbadNo == strongbadNo);
+  static_assert(strongbadYes == strongbadYes);
+  static_assert(!(strongbadNo != strongbadNo));
+  static_assert(!(strongbadYes != strongbadYes));
+  static_assert(!(strongbadNo < strongbadNo));
+  static_assert(!(strongbadYes < strongbadYes));
+  static_assert(strongbadNo < strongbadYes);
+  static_assert(strongbadYes > strongbadNo);
+  static_assert(strongbadYes >= strongbadNo);
+  static_assert(strongbadNo <= strongbadYes);
+  static_assert(!(strongbadYes <= strongbadNo));
+  static_assert(!(strongbadNo >= strongbadYes));
+}
+
+KJ_TEST("WD_STRONG_BOOL logical operators") {
+  constexpr Strongbad strongbadNo{Strongbad::NO};
+  constexpr Strongbad strongbadYes{Strongbad::YES};
+
+  static_assert(kj::isSameType<decltype(strongbadNo && strongbadYes), Strongbad>());
+  static_assert(kj::isSameType<decltype(strongbadNo || strongbadYes), Strongbad>());
+
+  // Logical operators with contextual conversion
+  if (strongbadNo && strongbadYes) {}
+  if (strongbadNo || strongbadYes) {}
+
+  static_assert((strongbadNo && strongbadNo) == Strongbad::NO);
+  static_assert((strongbadNo && strongbadYes) == Strongbad::NO);
+  static_assert((strongbadYes && strongbadNo) == Strongbad::NO);
+  static_assert((strongbadYes && strongbadYes) == Strongbad::YES);
+  static_assert((strongbadNo || strongbadNo) == Strongbad::NO);
+  static_assert((strongbadNo || strongbadYes) == Strongbad::YES);
+  static_assert((strongbadYes || strongbadNo) == Strongbad::YES);
+  static_assert((strongbadYes || strongbadYes) == Strongbad::YES);
+}
+
+KJ_TEST("WD_STRONG_BOOL can be stringified") {
+  constexpr Strongbad strongbadNo{Strongbad::NO};
+  constexpr Strongbad strongbadYes{Strongbad::YES};
+  constexpr auto stringNo = kj::_::STR * strongbadNo;
+  constexpr auto stringYes = kj::_::STR * strongbadYes;
+  static_assert(stringNo == "Strongbad::NO"_kjc);
+  static_assert(stringYes == "Strongbad::YES"_kjc);
+
+  static_assert(kj::_::STR * Burninator::NO == "Burninator::NO"_kjc);
+  static_assert(kj::_::STR * Burninator::YES == "Burninator::YES"_kjc);
+}
+
+}  // namespace workerd

--- a/src/workerd/util/strong-bool.h
+++ b/src/workerd/util/strong-bool.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace workerd {
+
+// WD_STRONG_BOOL(StrongBool) defines a class type, `StrongBool`, which acts like a boolean flag,
+// but with greater type safety.
+//
+// `StrongBool` has the following restrictions:
+// - No default constructor: you must explicitly initialize values
+// - No possibility for uninitialized values
+// - No implicit conversion to or from boolean values
+//
+// `StrongBool` supports the following explicit and contextual boolean conversions:
+// - Explicit conversion from boolean values: `StrongBool(true)`, `StrongBool(false)`
+// - Explicit conversion to boolean values: `bool(StrongBool::YES)`, `bool(StrongBool::NO)`
+// - Contextual boolean conversion: `if (strongBool)`, `while (strongBool)`, `!strongBool`
+//
+// `StrongBool` supports the full suite of comparison and logical operators. Note that ! is
+// supported via contextual conversion (`explicit operator bool()`), rather than `operator!()`.
+//
+// Logical operators (&& and ||) preserve the type of their operands when the operands are the same
+// `StrongBool` type. Otherwise, contextual boolean conversion applies, and the operands will be
+// converted to `bool` before the operator is invoked.
+#define WD_STRONG_BOOL(Type)                                                                       \
+  class Type final {                                                                               \
+   public:                                                                                         \
+    static const Type NO;                                                                          \
+    static const Type YES;                                                                         \
+    constexpr explicit Type(bool booleanValue): value(booleanValue ? Value::YES : Value::NO) {}    \
+    constexpr explicit operator bool() const {                                                     \
+      return value == YES;                                                                         \
+    }                                                                                              \
+    constexpr auto operator<=>(const Type&) const = default;                                       \
+    constexpr Type operator&&(const Type& other) const {                                           \
+      return Type(value == YES && other.value == YES);                                             \
+    }                                                                                              \
+    constexpr Type operator||(const Type& other) const {                                           \
+      return Type(value == YES || other.value == YES);                                             \
+    }                                                                                              \
+                                                                                                   \
+   private:                                                                                        \
+    enum class Value : std::uint8_t { NO, YES };                                                   \
+    constexpr Type(Value value): value(value) {}                                                   \
+    Value value;                                                                                   \
+  };                                                                                               \
+  constexpr inline kj::LiteralStringConst KJ_STRINGIFY(Type value) {                               \
+    return value ? #Type "::YES"_kjc : #Type "::NO"_kjc;                                           \
+  }                                                                                                \
+  inline constexpr Type Type::NO{Type::Value::NO};                                                 \
+  inline constexpr Type Type::YES {                                                                \
+    Type::Value::YES                                                                               \
+  }
+
+}  // namespace workerd


### PR DESCRIPTION
This commit defines a macro which allows us to define "strong boolean" types. In particular, these types never implicitly convert to or from `bool`, or each other. This allows for greater type safety, especially in places where functions accept multiple `bool` parameters right next to each other. The call sites of such functions are notoriously difficult to maintain, as switching the order of two `bool` parameters will change the semantics of every call site, but will not introduce any compilation failures to alert you to the change.

A common way to define a strong boolean is to use an `enum class Foo: bool { NO, YES }` type. That pattern is a big improvement in terms of type safety over standard booleans. It has a couple flaws, however:

- Contextual boolean conversion is impossible
- Uninitialized values remain possible

The lack of contextual boolean conversion is a significant pain point preventing our adoption -- no one wants to write `if (foo == Foo::YES)` where they would normally just write `if (foo)`. The uninitialized value issue is not a disadvantage over regular booleans, but is unfortunate.

This commit introduces a macro, WD_STRONG_BOOL(T), which defines a more ergonomic strong bool than the `enum class` pattern can provide. The resulting types provide:

- Two nested constants, `NO` and `YES`, to be used as "literals"
- Contextual boolean conversion
- Explicit conversion to/from booleans
- Protection against uninitialized values
- Type-preserving logical operators
- Comparison operators via the spaceship operator
- KJ stringification support