### PR TITLE
[nfc] Add missing kj/string.h header to strong-bool.h

### DIFF
--- a/src/workerd/util/strong-bool.h
+++ b/src/workerd/util/strong-bool.h
@@ -3,6 +3,8 @@
 //     https://opensource.org/licenses/Apache-2.0
 #pragma once
 
+#include <kj/string.h>
+
 #include <compare>
 #include <cstdint>
 


### PR DESCRIPTION
Needed for the implementation of KJ_STRINGIFY.