### PR TITLE
ActorSqlite: treat moved-later alarm rescheduling exceptions as not breaking output gate

### DIFF
--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -215,6 +215,13 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
 
   kj::TaskSet commitTasks;
 
+  class AlarmLaterErrorHandler: public kj::TaskSet::ErrorHandler {
+   public:
+    void taskFailed(kj::Exception&& exception) override;
+  };
+  AlarmLaterErrorHandler alarmLaterErrorHandler;
+  kj::TaskSet alarmLaterTasks;
+
   void onWrite();
 
   void onCriticalError(kj::StringPtr errorMessage, kj::Maybe<kj::Exception> maybeException);


### PR DESCRIPTION
ActorSqlite captures the first exception thrown by an output gate promise, so that it can continue to throw the exception on subsequent storage operations. The capture is done via a TaskSet error handler, with the assumption that all its tasks came via the output gate.

However, the TaskSet had an additional source of tasks that did not come from the output gate: When we reschedule an alarm later, we intentionally do not take an output gate lock, since we don't need to hold the gate open for it to complete.  If an alarm rescheduling task failed, the error handler would set ActorSqlite's "broken" exception.  This would cause subsequent storage operations throw exceptions -- but the actor's output gate would not be broken, so subsequent requests would not automatically go to a new instance of the actor, allowing it to remain in the degraded state until the instance was reset for other reasons (inactivity, runtime resets, etc.).

This change moves the alarm rescheduling tasks to a separate TaskSet, such that they will not affect the tracking of the "broken" exception.