### PR TITLE
[nfc] Add StrongBool::toBool()

### DIFF
--- a/src/workerd/util/strong-bool-test.c++
+++ b/src/workerd/util/strong-bool-test.c++
@@ -108,19 +108,19 @@ KJ_TEST("WD_STRONG_BOOL can be explicitly converted to and from `bool`") {
   Strongbad strongbadNo{Strongbad::NO};
   Strongbad strongbadYes{Strongbad::YES};
 
-  auto booleanValue = bool(strongbadNo);
+  auto booleanValue = strongbadNo.toBool();
   static_assert(kj::isSameType<decltype(booleanValue), bool>());
 
   auto strongbadNo2 = Strongbad(booleanValue);
   static_assert(kj::isSameType<decltype(strongbadNo2), Strongbad>());
 
   // Literals can be explicitly converted in both directions, too.
-  static_assert(kj::isSameType<decltype(bool(Strongbad::NO)), bool>());
+  static_assert(kj::isSameType<decltype(Strongbad::NO.toBool()), bool>());
   static_assert(kj::isSameType<decltype(Strongbad(false)), Strongbad>());
 
   // Can't use static_assert because they're not constexpr. We'll test constexpr elsewhere.
-  KJ_EXPECT(!bool(strongbadNo));
-  KJ_EXPECT(bool(strongbadYes));
+  KJ_EXPECT(!strongbadNo.toBool());
+  KJ_EXPECT(strongbadYes.toBool());
   KJ_EXPECT(Strongbad(false) == Strongbad::NO);
   KJ_EXPECT(Strongbad(true) == Strongbad::YES);
 }
@@ -161,7 +161,7 @@ KJ_TEST("WD_STRONG_BOOL is constexpr") {
   constexpr Strongbad strongbadValue{Strongbad::NO};
   if constexpr (strongbadValue) {}
   if constexpr (Strongbad(true)) {}
-  if constexpr (bool(Strongbad::NO)) {}
+  if constexpr (Strongbad::NO.toBool()) {}
   if constexpr (Strongbad::NO || Strongbad::YES) {}
   if constexpr (Strongbad::NO && Strongbad::YES) {}
   [[maybe_unused]] constexpr auto order = Strongbad::YES <=> Strongbad::NO;

--- a/src/workerd/util/strong-bool.h
+++ b/src/workerd/util/strong-bool.h
@@ -20,8 +20,11 @@ namespace workerd {
 //
 // `StrongBool` supports the following explicit and contextual boolean conversions:
 // - Explicit conversion from boolean values: `StrongBool(true)`, `StrongBool(false)`
-// - Explicit conversion to boolean values: `bool(StrongBool::YES)`, `bool(StrongBool::NO)`
+// - Explicit conversion to boolean values: `bool(StrongBool::YES)`, `StrongBool::NO.toBool()`
 // - Contextual boolean conversion: `if (strongBool)`, `while (strongBool)`, `!strongBool`
+//
+// The `.toBool()` function exists to make safe, explicit conversion to `bool` more convenient,
+// avoiding the verbosity of `static_cast` and the risk of C-style/functional casts.
 //
 // `StrongBool` supports the full suite of comparison and logical operators. Note that ! is
 // supported via contextual conversion (`explicit operator bool()`), rather than `operator!()`.
@@ -36,6 +39,9 @@ namespace workerd {
     static const Type YES;                                                                         \
     constexpr explicit Type(bool booleanValue): value(booleanValue ? Value::YES : Value::NO) {}    \
     constexpr explicit operator bool() const {                                                     \
+      return toBool();                                                                             \
+    }                                                                                              \
+    constexpr bool toBool() const {                                                                \
       return value == YES;                                                                         \
     }                                                                                              \
     constexpr auto operator<=>(const Type&) const = default;                                       \


### PR DESCRIPTION
I belatedly recalled that I shouldn't be using functional-style casts, since they implicitly perform a const_cast. In this case, it's not a big risk, but in theory someone could change a strong bool type to some other type with a non-const `operator bool()`, causing a safety issue.

The type already supports static_cast, of course, but no one's going to want to use that.