### PR TITLE
Mark optional types on CF request data

### DIFF
--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -361,13 +361,13 @@ interface IncomingRequestCfPropertiesBase extends Record<string, unknown> {
    *
    * @example 395747
    */
-  asn: number;
+  asn?: number;
   /**
    * The organization which owns the ASN of the incoming request.
    *
    * @example "Google Cloud"
    */
-  asOrganization: string;
+  asOrganization?: string;
   /**
    * The original value of the `Accept-Encoding` header if Cloudflare modified it.
    *
@@ -496,7 +496,7 @@ interface IncomingRequestCfPropertiesCloudflareForSaaSEnterprise<HostMetadata> {
    * This field is only present if you have Cloudflare for SaaS enabled on your account
    * and you have followed the [required steps to enable it]((https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/domain-support/custom-metadata/)).
    */
-  hostMetadata: HostMetadata;
+  hostMetadata?: HostMetadata;
 }
 
 interface IncomingRequestCfPropertiesCloudflareAccessOrApiShield {


### PR DESCRIPTION
Updates optional types per current control header definitions.

The issue with `asOrganization` was orignally raised in https://github.com/cloudflare/workers-rs/pull/776, so wanted to ensure we are fixing this in the main type definitions first.