### PR TITLE
Implements vendor package tests for Python

### DIFF
--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -100,6 +100,18 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
         "numpy_snapshot_hash": "5055deb53f404afacba73642fd10e766b123e661847e8fdf4f1ec92d8ca624dc",
         "fastapi_snapshot": "ew-py-package-snapshot_fastapi-v2.bin",
         "fastapi_snapshot_hash": "d204956a074cd74f7fe72e029e9a82686fcb8a138b509f765e664a03bfdd50fb",
+        "vendored_packages_for_tests": [
+            {
+                # Downloaded from https://pub-25a5b2f2f1b84655b185a505c7a3ad23.r2.dev/beautifulsoup4-vendored-for-ew-testing.zip
+                "name": "beautifulsoup4",
+                "sha256": "5aa09c5f549443969dda260a70e58e3ac8537bd3d29155b307a3d98b36eb70fd",
+            },
+            {
+                # Downloaded from https://pub-25a5b2f2f1b84655b185a505c7a3ad23.r2.dev/fastapi-vendored-for-ew-testing.zip
+                "name": "fastapi",
+                "sha256": "5e6e21dbeda7c1eaadb99e6e52aa2ce45325b51e9a417198701e68e0cfd12a4c",
+            },
+        ],
     },
     {
         "name": "0.27.7",
@@ -117,6 +129,18 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
         "numpy_snapshot_hash": "429b1174f9c0d73f9c845007c60595c0a80141b440c080c862568f9d2351dcbb",
         "fastapi_snapshot": "package_snapshot_fastapi-23337a32b.bin",
         "fastapi_snapshot_hash": "23337a032bb78f8c2d1abb9439a9c16f56c50130b67aff6bf82b78c896d9a1cc",
+        "vendored_packages_for_tests": [
+            {
+                # Downloaded from https://pub-25a5b2f2f1b84655b185a505c7a3ad23.r2.dev/beautifulsoup4-vendored-for-ew-testing.zip
+                "name": "beautifulsoup4",
+                "sha256": "5aa09c5f549443969dda260a70e58e3ac8537bd3d29155b307a3d98b36eb70fd",
+            },
+            {
+                # Downloaded from https://pub-25a5b2f2f1b84655b185a505c7a3ad23.r2.dev/fastapi-vendored-for-ew-testing.zip
+                "name": "fastapi",
+                "sha256": "5e6e21dbeda7c1eaadb99e6e52aa2ce45325b51e9a417198701e68e0cfd12a4c",
+            },
+        ],
     },
     {
         "real_pyodide_version": "0.26.0a2",

--- a/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
@@ -1,0 +1,15 @@
+load(":vendor_test.bzl", "vendored_py_wd_test")
+
+vendored_py_wd_test(
+    name = "fastapi_vendor_test",
+    main_py_file = "fastapi.py",
+    test_template = "fastapi_vendor.wd-test",
+    vendored_srcs_target_prefix = "@fastapi_src",
+)
+
+vendored_py_wd_test(
+    name = "beautifulsoup4_vendor_test",
+    main_py_file = "beautifulsoup4.py",
+    test_template = "beautifulsoup4_vendor.wd-test",
+    vendored_srcs_target_prefix = "@beautifulsoup4_src",
+)

--- a/src/workerd/server/tests/python/vendor_pkg_tests/beautifulsoup4.py
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/beautifulsoup4.py
@@ -1,0 +1,9 @@
+import bs4
+
+
+async def test():
+    assert bs4.__version__
+    # Use beautifulsoup4 to parse HTML
+    soup = bs4.BeautifulSoup("<html></html>", "html.parser")
+    print(soup.prettify())
+    print("BeautifulSoup4 ran successfully!")

--- a/src/workerd/server/tests/python/vendor_pkg_tests/beautifulsoup4_vendor.wd-test
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/beautifulsoup4_vendor.wd-test
@@ -1,0 +1,16 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "beautifulsoup4-vendor-test",
+      worker = (
+        modules = [
+          (name = "main.py", pythonModule = embed "beautifulsoup4.py"),
+          %PYTHON_VENDORED_MODULES%
+        ],
+        compatibilityDate = "2024-01-15",
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+      )
+    ),
+  ],
+);

--- a/src/workerd/server/tests/python/vendor_pkg_tests/fastapi.py
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/fastapi.py
@@ -1,0 +1,6 @@
+import fastapi
+
+
+async def test():
+    assert fastapi.__version__
+    print("FastAPI imported successfully!")

--- a/src/workerd/server/tests/python/vendor_pkg_tests/fastapi_vendor.wd-test
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/fastapi_vendor.wd-test
@@ -1,0 +1,16 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "fastapi-vendor-test",
+      worker = (
+        modules = [
+          (name = "main.py", pythonModule = embed "fastapi.py"),
+          %PYTHON_VENDORED_MODULES%
+        ],
+        compatibilityDate = "2024-01-15",
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+      )
+    ),
+  ],
+);

--- a/src/workerd/server/tests/python/vendor_pkg_tests/generate_modules.py
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/generate_modules.py
@@ -1,0 +1,38 @@
+# This script reads the list of files from a zip file and outputs a list of Cap'n Proto module
+# definitions to be used in a .wd-test for Python tests.
+import sys
+from pathlib import Path
+
+# Handle response file format (starting with @) to avoid Windows command line length limits
+file_paths = []
+for arg in sys.argv[1:]:
+    if arg.startswith("@"):
+        # Read file paths from response file (space-separated)
+        response_file = arg[1:]
+        with Path.open(response_file) as f:
+            content = f.read().strip()
+            if content:
+                file_paths.extend(content.split())
+    else:
+        file_paths.append(arg)
+
+modules = []
+for f_path in file_paths:
+    # The path from bazel is relative to the exec root, e.g.:
+    # external/fastapi_src/fastapi/__init__.py
+    # We need to strip the prefix to get the module path.
+    #
+    # On Windows, we replace windows-style path separators with standard posix path separators.
+    components = Path(f_path).parts
+    # without `external/` prefix
+    embed_path = ("../" * 7) + str(Path(*components[1:])).replace("\\", "\\\\")
+    # without `external/fastapi_src/` prefix
+    module_path = str(Path(*components[2:])).replace("\\", "/")
+
+    # Format as a Cap'n Proto module definition.
+    if f_path.endswith(".py"):
+        modules.append(f'(name = "{module_path}", pythonModule = embed "{embed_path}")')
+    elif f_path.endswith(".so"):
+        modules.append(f'(name = "{module_path}", data = embed "{embed_path}")')
+
+print(",".join(modules), end="")

--- a/src/workerd/server/tests/python/vendor_pkg_tests/vendor_test.bzl
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/vendor_test.bzl
@@ -1,0 +1,72 @@
+load("//:build/python_metadata.bzl", "BUNDLE_VERSION_INFO")
+load("//src/workerd/server/tests/python:py_wd_test.bzl", "FEATURE_FLAGS", "py_wd_test")
+
+def _vendored_py_wd_test(name, version, test_template, main_py_file, vendored_srcs_target_prefix):
+    """Creates a Python Workers test which includes vendored packages in its bundle, the
+    http_archive target containing the vendored sources should be specified in `vendored_srcs_target_prefix`.
+
+    Args:
+        name: Name of the test
+        version: The version of the package bundle
+        test_template: The .wd-test template file
+        main_py_file: The main Python file for the test
+        vendored_srcs_target_prefix: The prefix of the Bazel target containing the vendored sources
+    """
+    vendored_srcs_target = vendored_srcs_target_prefix + "_" + version + "//:all_srcs"
+
+    # Generate module list
+    module_list_name = name + "_modules_string" + "_" + version
+    native.genrule(
+        name = module_list_name,
+        srcs = [
+            vendored_srcs_target,
+            "generate_modules.py",
+        ],
+        outs = [module_list_name + ".txt"],
+        cmd = """
+        # Create a file with all the file paths to avoid Windows command line length limits
+        echo "$(locations """ + vendored_srcs_target + """)" > paths.txt
+        $(execpath @python3_13_host//:python) $(location generate_modules.py) @paths.txt > $@
+        """,
+        tools = ["@python3_13_host//:python"],
+    )
+
+    # Perform substitution to include the generated modules in template
+    substitution_name = name + "_perform_substitution" + "_" + version
+    native.genrule(
+        name = substitution_name,
+        srcs = [
+            test_template,
+            ":" + module_list_name,
+        ],
+        outs = [name + ".test.generated" + "_" + version],
+        cmd = """
+        $(execpath @python3_13_host//:python) -c "
+import sys
+with open('$(location :""" + module_list_name + """)', 'r') as f:
+    modules = f.read()
+with open('$(location """ + test_template + """)', 'r') as f:
+    template = f.read()
+result = template.replace('%PYTHON_VENDORED_MODULES%', modules)
+
+with open('$@', 'w') as f:
+    f.write(result)
+        "
+    """,
+        tools = ["@python3_13_host//:python"],
+    )
+
+    # Create the py_wd_test
+    py_wd_test(
+        name = name,
+        src = ":" + substitution_name,
+        python_flags = [version],
+        data = [
+            main_py_file,
+            vendored_srcs_target,
+        ],
+    )
+
+def vendored_py_wd_test(name, test_template, main_py_file, vendored_srcs_target_prefix):
+    for info in BUNDLE_VERSION_INFO.values():
+        _vendored_py_wd_test(name, info["name"], test_template, main_py_file, vendored_srcs_target_prefix)


### PR DESCRIPTION
This PR implements tests for a couple of popular Python packages when they are vendored. This ensures our vendoring approach to packages has some practical test coverage.

As usual, this required some painful bazel wrangling. Ideas of how to make the Bazel part of this nicer welcome.

### Test Plan

```
$ bazel run @workerd//src/workerd/server/tests/python/vendor_pkg_tests:fastapi_vendor_test_development@
$ bazel run @workerd//src/workerd/server/tests/python/vendor_pkg_tests:beautifulsoup4_vendor_test_development@
```