### PR TITLE
test: Add failing `ReadableStream` input `fetch` test suite to `workerd/api/tests/streamed-fetch-test.js`

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -482,6 +482,12 @@ wd_test(
 )
 
 wd_test(
+    src = "streams/streamed-fetch-test.wd-test",
+    args = ["--experimental"],
+    data = ["streams/streamed-fetch-test.js"],
+)
+
+wd_test(
     src = "tests/abort-internal-streams-test.wd-test",
     args = ["--experimental"],
     data = ["tests/abort-internal-streams-test.js"],

--- a/src/workerd/api/tests/streamed-fetch-test.js
+++ b/src/workerd/api/tests/streamed-fetch-test.js
@@ -1,0 +1,109 @@
+import { strictEqual, ok, fail, deepStrictEqual } from 'node:assert';
+
+async function expectResolution(promise) {
+  try {
+    return await promise;
+  } catch {
+    fail('error was not expected');
+  }
+}
+
+async function expectRejection(promise, message) {
+  try {
+    await promise;
+    fail('error was expected');
+  } catch (err) {
+    strictEqual(err.message, message);
+  }
+}
+
+export const readAllTextFailedPull = {
+  async test(ctrl, env) {
+    const resp = await expectResolution(env.subrequest.fetch('http://example.org', {
+      method: 'POST',
+      body: new ReadableStream({
+        async pull(c) {
+          c.enqueue('test');
+          await scheduler.wait(10);
+          throw new Error('boom');
+        },
+      }, {
+        highWaterMark: 0,
+      }),
+    }));
+    await expectRejection(resp.text(), 'boom');
+  },
+};
+
+export const readAllTextFailedStart = {
+  async test(ctrl, env) {
+    const resp = await expectResolution(env.subrequest.fetch('http://example.org', {
+      method: 'POST',
+      body: new ReadableStream({
+        async start(c) {
+          c.enqueue('test');
+          await scheduler.wait(10);
+          throw new Error('boom');
+        },
+      }, {
+        highWaterMark: 0
+      }),
+    }));
+    await expectRejection(resp.text(), 'boom');
+  },
+};
+
+export const readAllTextFailed = {
+  async test(ctrl, env) {
+    const resp = await expectResolution(env.subrequest.fetch('http://example.org', {
+      method: 'POST',
+      body: new ReadableStream({
+        async start(c) {
+          c.enqueue('test');
+          await scheduler.wait(10);
+          c.error(new Error('boom'));
+        },
+      }, {
+        highWaterMark: 0
+      }),
+    }));
+    await expectRejection(resp.text(), 'boom');
+  },
+};
+
+export const readableStreamFromAsyncGenerator = {
+  async test(ctrl, env) {
+    async function* gen() {
+      yield 'test';
+      await scheduler.wait(10);
+      throw new Error('boom');
+    }
+    const resp = await expectResolution(env.subrequest.fetch('http://example.org', {
+      method: 'POST',
+      body: ReadableStream.from(gen()),
+    }));
+    await expectRejection(resp.text(), 'boom');
+  },
+};
+
+export const readableStreamFromThrowingAsyncGen = {
+  async test(ctrl, env) {
+    async function* gen() {
+      yield 'hello';
+      await scheduler.wait(10);
+      throw new Error('boom');
+    }
+    const resp = await expectResolution(env.subrequest.fetch('http://example.org', {
+      method: 'POST',
+      body: ReadableStream.from(gen()),
+    }));
+  },
+};
+
+export default {
+  async fetch(request, env) {
+    await request.text();
+    request.signal.throwIfAborted();
+    return new Response('OK');
+  },
+};

--- a/src/workerd/api/tests/streamed-fetch-test.wd-test
+++ b/src/workerd/api/tests/streamed-fetch-test.wd-test
@@ -1,0 +1,19 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  v8Flags = ["--expose-gc"],
+  services = [
+    ( name = "streamed-fetch-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "streamed-fetch-test.js")
+        ],
+        compatibilityDate = "2023-01-15",
+        compatibilityFlags = ["nodejs_compat", "internal_stream_byob_return_view"],
+        bindings = [
+          (name = "subrequest", service = "streamed-fetch-test")
+        ]
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
The existing tests in `streams-test.js` check that a `ReadableStream` failing into an error state propagates this error to an underlying `Response` / `BodySource`: https://github.com/cloudflare/workerd/blob/d9dce3c35c2de3edadded68bed496680bf89950d/src/workerd/api/tests/streams-test.js#L215-L272

However, given a duplex-fetch scenario, i.e. passing a failing `ReadableStream` to `fetch` there's no propagation and the rejection is instead uncaught and **the error is unobservable** by default.

This also doesn't seem to result in the `Request` closing properly. Instead, it's ended properly with `successSteps`. If I'm interpreting the Fetch standard correctly, the `processBodyError` routine isn't defined properly for this scenario: https://fetch.spec.whatwg.org/#body-fully-read

I'd expect:
- That the request is cancelled on the receiving end (this doesn't seem to be happening and can be observed by checking `request.signal` or checking the `request.body` stream not throwing an error)
- That the request rejects _somewhere_ on the sending end (I'd assume that `response.text()` rejects given that the input has failed, however, that's an assumption that might not hold with duplex fetch streams)

Regardless of the spec, this currently makes this error extremely hard to observe.
If we want to abort the original request _and_ observe the stream's error, the only straightforward option seems to me to manually:
- create an `AbortController`
- create a reader (`body.getReader()`)
- create a wrapping `ReadableStream`
- set `expectedLength` to the input stream's `expectedLength`
  - this is only possible by enumerating the internal `Symbol(length)` and parsing it manually
- passthrough `reader.read()` and call `controller.enqueue` or `controller.close`
- on error, call `controller.error` to close receiving end
  - **then:** call `abortController.abort(error)`
- return both the new `ReadableStream` and `abortController.signal`
- Pass `body: ReadableStream, signal: signal` to the `fetch` call

[See sample code for the above](https://gist.github.com/kitten/06bc7148b0424863d029ba4df6d2511e)

This has two undesired problems:
- The original error instance gets lost and is replaced by `AbortError`
- An internal `Symbol(length)` has to be accessed to preserve the `expectedLength` for which there's no public API as far as I'm aware

It's hard to tell what the spec wants to happen in this case. The same behaviour can be observed by Bun actually, and I've got a test suite replicating this here: https://github.com/kitten/workerd-fetched-stream-repro

However, it's safe to say that this should lead to a request cancellation, which maybe should then consequently propagate to the response body.