### PR TITLE
Add support for process cwd, chdir and umask in process v2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:22
+FROM mcr.microsoft.com/vscode/devcontainers/base:dev-bookworm
 
 # Install dependencies, including clang via through LLVM APT repository. Note that this
 # will also install lldb and clangd alongside dependencies.
@@ -11,6 +11,3 @@ ENV PATH /usr/lib/llvm-${LLVM_VERSION}/bin:$PATH
 
 # Install Bazel (via Bazelisk)
 RUN npm install -g @bazel/bazelisk
-
-# Install Just
-RUN npm install -g rust-just

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/base:dev-bookworm
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:22
 
 # Install dependencies, including clang via through LLVM APT repository. Note that this
 # will also install lldb and clangd alongside dependencies.
@@ -11,3 +11,6 @@ ENV PATH /usr/lib/llvm-${LLVM_VERSION}/bin:$PATH
 
 # Install Bazel (via Bazelisk)
 RUN npm install -g @bazel/bazelisk
+
+# Install Just
+RUN npm install -g rust-just

--- a/src/node/internal/internal_buffer.ts
+++ b/src/node/internal/internal_buffer.ts
@@ -477,7 +477,7 @@ export function SlowBuffer(length: number) {
 Object.setPrototypeOf(SlowBuffer.prototype, Uint8Array.prototype);
 Object.setPrototypeOf(SlowBuffer, Uint8Array);
 
-Buffer.isBuffer = function isBuffer(b: unknown) {
+Buffer.isBuffer = function isBuffer(b: unknown): b is Buffer {
   return b != null && (b as any)[kIsBuffer] && b !== Buffer.prototype;
 };
 

--- a/src/node/internal/process.d.ts
+++ b/src/node/internal/process.d.ts
@@ -1,6 +1,8 @@
 export function getEnvObject(): Record<string, string>;
 export function getBuiltinModule(id: string): object;
 export function exitImpl(code: number): void;
+export function getCwd(): string;
+export function setCwd(path: string): void;
 export const versions: Record<string, string>;
 export const platform: string;
 

--- a/src/node/internal/public_process.ts
+++ b/src/node/internal/public_process.ts
@@ -30,6 +30,7 @@ import {
   features,
   _setEventsProcess,
 } from 'node-internal:internal_process';
+import { validateString } from './validators';
 
 export { platform, nextTick, emitWarning, env, features };
 
@@ -39,15 +40,11 @@ export const stdout = undefined;
 export const stderr = undefined;
 
 export function chdir(path: string | Buffer | URL): void {
-  if (typeof path !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('directory', 'string', path);
-  }
+  validateString(path, 'directory');
   processImpl.setCwd(path);
 }
 
-export function cwd(): string {
-  return processImpl.getCwd();
-}
+export const cwd = processImpl.getCwd.bind(processImpl);
 
 // We do not support setting the umask as we do not have a fine-grained
 // permissions on the VFS. Instead we only support validation of input

--- a/src/node/internal/public_process.ts
+++ b/src/node/internal/public_process.ts
@@ -30,7 +30,7 @@ import {
   features,
   _setEventsProcess,
 } from 'node-internal:internal_process';
-import { validateString } from './validators';
+import { validateString } from 'node-internal:validators';
 
 export { platform, nextTick, emitWarning, env, features };
 

--- a/src/workerd/api/node/process.c++
+++ b/src/workerd/api/node/process.c++
@@ -144,7 +144,7 @@ kj::String ProcessModule::getCwd(jsg::Lock& js) {
   if (cwd == nullptr) {
     return kj::str("/");
   }
-  return kj::str("/", cwd.toString());
+  return cwd.toString(true);
 }
 
 void ProcessModule::setCwd(jsg::Lock& js, kj::String path) {
@@ -158,7 +158,6 @@ void ProcessModule::setCwd(jsg::Lock& js, kj::String path) {
   }
 
   auto& vfs = VirtualFileSystem::current(js);
-  auto url = KJ_REQUIRE_NONNULL(jsg::Url::tryParse(path, "file:///"_kj));
 
   // Resolve the path against current working directory if it's relative
   kj::Path resolvedPath = [&]() {

--- a/src/workerd/api/node/process.c++
+++ b/src/workerd/api/node/process.c++
@@ -140,11 +140,10 @@ void ProcessModule::exitImpl(jsg::Lock& js, int code) {
 }
 
 kj::String ProcessModule::getCwd(jsg::Lock& js) {
-  auto cwd = getCurrentWorkingDirectory();
-  if (cwd == nullptr) {
-    return kj::str("/");
+  KJ_IF_SOME(cwd, getCurrentWorkingDirectory()) {
+    return cwd.toString(true);
   }
-  return cwd.toString(true);
+  return kj::str("/");
 }
 
 void ProcessModule::setCwd(jsg::Lock& js, kj::String path) {
@@ -166,8 +165,10 @@ void ProcessModule::setCwd(jsg::Lock& js, kj::String path) {
       return kj::Path::parse(path.slice(1));
     } else {
       // Relative path - resolve against current working directory
-      auto cwd = getCurrentWorkingDirectory();
-      return cwd.eval(path);
+      KJ_IF_SOME(cwd, getCurrentWorkingDirectory()) {
+        return cwd.eval(path);
+      }
+      return kj::Path({"/"}).eval(path);
     }
   }();
 

--- a/src/workerd/api/node/process.h
+++ b/src/workerd/api/node/process.h
@@ -5,6 +5,7 @@
 
 #include <workerd/api/node/i18n.h>
 #include <workerd/api/node/node-version.h>
+#include <workerd/io/worker-fs.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/util/mimetype.h>
 
@@ -46,10 +47,16 @@ class ProcessModule final: public jsg::Object {
 
   jsg::JsObject getVersions(jsg::Lock& js) const;
 
+  kj::String getCwd(jsg::Lock& js);
+
+  void setCwd(jsg::Lock& js, kj::String path);
+
   JSG_RESOURCE_TYPE(ProcessModule) {
     JSG_METHOD(getEnvObject);
     JSG_METHOD(getBuiltinModule);
     JSG_METHOD(exitImpl);
+    JSG_METHOD(getCwd);
+    JSG_METHOD(setCwd);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(versions, getVersions);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(platform, getPlatform);
   }

--- a/src/workerd/api/node/tests/fs-test.js
+++ b/src/workerd/api/node/tests/fs-test.js
@@ -871,7 +871,7 @@ export const copyAndRenameAsyncCallbackTest = {
 
 export const fsCwdTest = {
   test() {
-    const originalCwd = process.cwd();
+    process.chdir('/bundle');
 
     throws(
       () => {
@@ -887,7 +887,7 @@ export const fsCwdTest = {
     ok(existsSync('/tmp/test-cwd.txt'));
 
     ok(existsSync('test-cwd.txt'));
-    ok(!existsSync(`${originalCwd}/test-cwd.txt`));
+    ok(!existsSync(`/bundle/test-cwd.txt`));
 
     strictEqual(readFileSync('test-cwd.txt').toString(), 'Hello from /tmp');
     strictEqual(
@@ -895,7 +895,7 @@ export const fsCwdTest = {
       'Hello from /tmp'
     );
 
-    process.chdir(originalCwd);
+    process.chdir('/bundle');
 
     ok(!existsSync('test-cwd.txt'));
     throws(

--- a/src/workerd/api/node/tests/fs-test.js
+++ b/src/workerd/api/node/tests/fs-test.js
@@ -868,3 +868,43 @@ export const copyAndRenameAsyncCallbackTest = {
     strictEqual(readFileSync('/tmp/test3.txt').toString(), 'Hello World 2');
   },
 };
+
+export const fsCwdTest = {
+  test() {
+    const originalCwd = process.cwd();
+
+    throws(
+      () => {
+        writeFileSync('test-cwd.txt', 'Hello from original cwd');
+      },
+      { code: 'EPERM' }
+    );
+
+    process.chdir('/tmp');
+
+    writeFileSync('test-cwd.txt', 'Hello from /tmp');
+    ok(existsSync('test-cwd.txt'));
+    ok(existsSync('/tmp/test-cwd.txt'));
+
+    ok(existsSync('test-cwd.txt'));
+    ok(!existsSync(`${originalCwd}/test-cwd.txt`));
+
+    strictEqual(readFileSync('test-cwd.txt').toString(), 'Hello from /tmp');
+    strictEqual(
+      readFileSync('/tmp/test-cwd.txt').toString(),
+      'Hello from /tmp'
+    );
+
+    process.chdir(originalCwd);
+
+    ok(!existsSync('test-cwd.txt'));
+    throws(
+      () => {
+        readFileSync('test-cwd.txt');
+      },
+      { code: 'ENOENT' }
+    );
+
+    unlinkSync('/tmp/test-cwd.txt');
+  },
+};

--- a/src/workerd/api/node/tests/fs-test.wd-test
+++ b/src/workerd/api/node/tests/fs-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "fs-test.js")
         ],
         compatibilityDate = "2025-05-01",
-        compatibilityFlags = ["nodejs_compat", "experimental"]
+        compatibilityFlags = ["nodejs_compat", "enable_nodejs_process_v2", "experimental"]
       )
     ),
   ],

--- a/src/workerd/api/node/tests/process-nodejs-test.js
+++ b/src/workerd/api/node/tests/process-nodejs-test.js
@@ -711,7 +711,7 @@ export const processLoadEnvFile = {
 
     // supports not-passing a path
     {
-      // Uses `/bundle/.env` file.
+      // Uses `/tmp/.env` file.
       try {
         process.loadEnvFile();
         assert.fail();
@@ -742,16 +742,8 @@ export const processLoadEnvFile = {
     // supports cwd
     {
       const originalCwd = process.cwd();
+      writeFileSync('.env', validEnv);
       try {
-        process.chdir('/tmp');
-        assert.throws(
-          () => {
-            process.loadEnvFile();
-          },
-          { code: 'ENOENT' }
-        );
-
-        writeFileSync('.env', validEnv);
         process.loadEnvFile();
       } finally {
         process.chdir(originalCwd);
@@ -784,11 +776,14 @@ export const processRejectionListeners = {
   },
 };
 
+// TODO: figure out how to test static IO context
+// const staticCwd = process.cwd();
+
 export const processCwd = {
   test() {
-    const cwd = process.cwd();
-    assert.strictEqual(typeof cwd, 'string');
-    assert.ok(cwd.length > 0);
+    // assert.strictEqual(staticCwd, '/bundle');
+
+    assert.strictEqual(process.cwd(), '/tmp');
 
     const originalCwd = process.cwd();
 

--- a/src/workerd/api/node/tests/process-nodejs-test.js
+++ b/src/workerd/api/node/tests/process-nodejs-test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { writeFileSync } from 'node:fs';
+import { readdirSync, writeFileSync } from 'node:fs';
 import * as processMod from 'node:process';
 
 export const processPlatform = {
@@ -776,13 +776,14 @@ export const processRejectionListeners = {
   },
 };
 
-const staticCwd = process.cwd();
+// init time process.cwd checks
+assert.strictEqual(process.cwd(), '/bundle');
+process.chdir('/');
+assert.deepStrictEqual(readdirSync('.'), ['bundle', 'tmp', 'dev']);
 
 export const processCwd = {
   test() {
-    // TODO: FIXME!
-    // assert.strictEqual(staticCwd, '/bundle');
-
+    // cwd gets changed by iocontext
     assert.strictEqual(process.cwd(), '/tmp');
 
     const originalCwd = process.cwd();

--- a/src/workerd/api/node/tests/process-nodejs-test.js
+++ b/src/workerd/api/node/tests/process-nodejs-test.js
@@ -776,11 +776,11 @@ export const processRejectionListeners = {
   },
 };
 
-// TODO: figure out how to test static IO context
-// const staticCwd = process.cwd();
+const staticCwd = process.cwd();
 
 export const processCwd = {
   test() {
+    // TODO: FIXME!
     // assert.strictEqual(staticCwd, '/bundle');
 
     assert.strictEqual(process.cwd(), '/tmp');

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -681,7 +681,7 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   // Access the event loop's current time point. This will remain constant between ticks.
   kj::Date now();
 
-  const TmpDirStoreScope& getTmpDirStoreScope() {
+  TmpDirStoreScope& getTmpDirStoreScope() {
     return *tmpDirStoreScope;
   }
 

--- a/src/workerd/io/worker-fs.c++
+++ b/src/workerd/io/worker-fs.c++
@@ -13,6 +13,8 @@ namespace workerd {
 KNOWN_VFS_ROOTS(DEFINE_DEFAULTS_FOR_ROOTS)
 #undef DEFINE_DEFAULTS_FOR_ROOTS
 
+static kj::Path tmpPath = kj::Path::parse("tmp");
+
 // Helper function to get the current working directory path.
 // Returns the Cwd if available, otherwise returns an empty path (root).
 kj::PathPtr getCurrentWorkingDirectory() {
@@ -22,8 +24,9 @@ kj::PathPtr getCurrentWorkingDirectory() {
   if (TmpDirStoreScope::hasCurrent()) {
     return TmpDirStoreScope::current().getCwd();
   }
-  // Default to root if no context is available
-  return kj::PathPtr(nullptr);
+  // Default to "bundle" if no context is available
+  // this way bundle is used during init
+  return kj::PathPtr(tmpPath);
 }
 
 // Helper function to set the current working directory path.
@@ -1174,7 +1177,7 @@ TmpDirStoreScope& TmpDirStoreScope::current() {
 
 TmpDirStoreScope::TmpDirStoreScope(kj::Maybe<kj::Badge<TmpDirStoreScope>> guard)
     : dir(Directory::newWritable()),
-      cwd(kj::Path::parse("bundle")) {  // Initialize to bundle path
+      cwd(kj::Path::parse("tmp")) {  // Initialize to tmp path
   if (guard == kj::none) {
     kj::requireOnStack(this, "must be created on the stack");
     onStack = true;

--- a/src/workerd/io/worker-fs.c++
+++ b/src/workerd/io/worker-fs.c++
@@ -13,7 +13,7 @@ namespace workerd {
 KNOWN_VFS_ROOTS(DEFINE_DEFAULTS_FOR_ROOTS)
 #undef DEFINE_DEFAULTS_FOR_ROOTS
 
-static kj::Path tmpPath = kj::Path::parse("tmp");
+static const kj::Path tmpPath = kj::Path::parse("tmp");
 
 // Helper function to get the current working directory path.
 // Returns the Cwd if available, otherwise returns an empty path (root).
@@ -1177,7 +1177,7 @@ TmpDirStoreScope& TmpDirStoreScope::current() {
 
 TmpDirStoreScope::TmpDirStoreScope(kj::Maybe<kj::Badge<TmpDirStoreScope>> guard)
     : dir(Directory::newWritable()),
-      cwd(kj::Path::parse("tmp")) {  // Initialize to tmp path
+      cwd(kj::Path({"tmp"})) {  // Initialize to tmp path
   if (guard == kj::none) {
     kj::requireOnStack(this, "must be created on the stack");
     onStack = true;

--- a/src/workerd/io/worker-fs.h
+++ b/src/workerd/io/worker-fs.h
@@ -698,13 +698,13 @@ class TmpDirStoreScope final {
     return kj::PathPtr(cwd);
   }
 
-  void setCwd(kj::Path newCwd) const {
+  void setCwd(kj::Path newCwd) {
     cwd = kj::mv(newCwd);
   }
 
  private:
   mutable kj::Rc<Directory> dir;
-  mutable kj::Path cwd;
+  kj::Path cwd;
   bool onStack = false;
 };
 

--- a/src/workerd/io/worker-fs.h
+++ b/src/workerd/io/worker-fs.h
@@ -694,8 +694,17 @@ class TmpDirStoreScope final {
     return dir.addRef();
   }
 
+  kj::PathPtr getCwd() const {
+    return kj::PathPtr(cwd);
+  }
+
+  void setCwd(kj::Path newCwd) const {
+    cwd = kj::mv(newCwd);
+  }
+
  private:
   mutable kj::Rc<Directory> dir;
+  mutable kj::Path cwd;
   bool onStack = false;
 };
 
@@ -740,4 +749,9 @@ kj::Rc<File> getDevZero() KJ_WARN_UNUSED_RESULT;
 kj::Rc<File> getDevFull() KJ_WARN_UNUSED_RESULT;
 kj::Rc<File> getDevRandom() KJ_WARN_UNUSED_RESULT;
 kj::Rc<Directory> getDevDirectory() KJ_WARN_UNUSED_RESULT;
+
+// Helper functions for current working directory management
+kj::PathPtr getCurrentWorkingDirectory() KJ_WARN_UNUSED_RESULT;
+bool setCurrentWorkingDirectory(kj::Path newCwd) KJ_WARN_UNUSED_RESULT;
+
 }  // namespace workerd

--- a/src/workerd/io/worker-fs.h
+++ b/src/workerd/io/worker-fs.h
@@ -751,7 +751,7 @@ kj::Rc<File> getDevRandom() KJ_WARN_UNUSED_RESULT;
 kj::Rc<Directory> getDevDirectory() KJ_WARN_UNUSED_RESULT;
 
 // Helper functions for current working directory management
-kj::PathPtr getCurrentWorkingDirectory() KJ_WARN_UNUSED_RESULT;
+kj::Maybe<kj::PathPtr> getCurrentWorkingDirectory() KJ_WARN_UNUSED_RESULT;
 bool setCurrentWorkingDirectory(kj::Path newCwd) KJ_WARN_UNUSED_RESULT;
 
 }  // namespace workerd


### PR DESCRIPTION
Updates the process v2 implementation to support `process.cwd()`, `process.chdir()` and `process.umask`.

`cwd()` is integrated into the virtual filesystem where the default cwd is `/bundle`, and it is stored as a property of the tmpfs as that matches the same FS context (in theory turning virtual tmpdir into a virtual fs state).

`process.umask` is just supported as a non-failing stub supporting umask validations but never actually applying the umask as we don't have a vfs with fine-grained permissions, but it still makes sense not to throw on these operations for FS-based code.