### PR TITLE
Fetch Python deps asynchronously in the main thread.

### DIFF
--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -221,10 +221,10 @@ class Server final: private kj::TaskSet::ErrorHandler {
   kj::Own<Service> makeDiskDirectoryService(kj::StringPtr name,
       config::DiskDirectory::Reader conf,
       kj::HttpHeaderTable::Builder& headerTableBuilder);
-  kj::Own<Service> makeWorker(kj::StringPtr name,
+  kj::Promise<kj::Own<Service>> makeWorker(kj::StringPtr name,
       config::Worker::Reader conf,
       capnp::List<config::Extension>::Reader extensions);
-  kj::Own<Service> makeService(config::Service::Reader conf,
+  kj::Promise<kj::Own<Service>> makeService(config::Service::Reader conf,
       kj::HttpHeaderTable::Builder& headerTableBuilder,
       capnp::List<config::Extension>::Reader extensions);
 
@@ -261,12 +261,12 @@ class Server final: private kj::TaskSet::ErrorHandler {
   struct ConfigErrorReporter;
   struct DynamicErrorReporter;
   struct WorkerDef;
-  kj::Own<WorkerService> makeWorkerImpl(kj::StringPtr name,
+  kj::Promise<kj::Own<WorkerService>> makeWorkerImpl(kj::StringPtr name,
       WorkerDef def,
       capnp::List<config::Extension>::Reader extensions,
       ErrorReporter& errorReporter);
 
-  void startServices(jsg::V8System& v8System,
+  kj::Promise<void> startServices(jsg::V8System& v8System,
       config::Config::Reader config,
       kj::HttpHeaderTable::Builder& headerTableBuilder,
       kj::ForkedPromise<void>& forkedDrainWhen);
@@ -280,6 +280,9 @@ class Server final: private kj::TaskSet::ErrorHandler {
       bool forTest = false);
 
   void unlinkWorkerLoaders();
+
+  kj::Promise<void> preloadPython(
+      kj::StringPtr workerName, const WorkerDef& workerDef, ErrorReporter& errorReporter);
 
   friend struct FutureSubrequestChannel;
 };

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -135,34 +135,6 @@ static const PythonConfig defaultConfig{
   .createBaselineSnapshot = false,
 };
 
-kj::Path getPyodideBundleFileName(kj::StringPtr version) {
-  return kj::Path(kj::str("pyodide_", version, ".capnp.bin"));
-}
-
-kj::Maybe<kj::Own<const kj::ReadableFile>> getPyodideBundleFile(
-    const kj::Maybe<kj::Own<const kj::Directory>>& maybeDir, kj::StringPtr version) {
-  KJ_IF_SOME(dir, maybeDir) {
-    kj::Path filename = getPyodideBundleFileName(version);
-    auto file = dir->tryOpenFile(filename);
-
-    return file;
-  }
-
-  return kj::none;
-}
-
-void writePyodideBundleFileToDisk(const kj::Maybe<kj::Own<const kj::Directory>>& maybeDir,
-    kj::StringPtr version,
-    kj::ArrayPtr<byte> bytes) {
-  KJ_IF_SOME(dir, maybeDir) {
-    kj::Path filename = getPyodideBundleFileName(version);
-    auto replacer = dir->replaceFile(filename, kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
-
-    replacer->get().writeAll(bytes);
-    replacer->commit();
-  }
-}
-
 kj::Own<api::pyodide::PyodideMetadataReader::State> makePyodideMetadataReader(
     const Worker::Script::ModulesSource& source,
     const PythonConfig& pythonConfig,
@@ -280,61 +252,10 @@ kj::Own<api::pyodide::PyodideMetadataReader::State> makePyodideMetadataReader(
 
 }  // namespace
 
-kj::Maybe<jsg::Bundle::Reader> fetchPyodideBundle(
+jsg::Bundle::Reader retrievePyodideBundle(
     const api::pyodide::PythonConfig& pyConfig, kj::StringPtr version) {
-  if (pyConfig.pyodideBundleManager.getPyodideBundle(version) != kj::none) {
-    return pyConfig.pyodideBundleManager.getPyodideBundle(version);
-  }
-
-  auto maybePyodideBundleFile = getPyodideBundleFile(pyConfig.pyodideDiskCacheRoot, version);
-  KJ_IF_SOME(pyodideBundleFile, maybePyodideBundleFile) {
-    auto body = pyodideBundleFile->readAllBytes();
-    pyConfig.pyodideBundleManager.setPyodideBundleData(kj::str(version), kj::mv(body));
-    return pyConfig.pyodideBundleManager.getPyodideBundle(version);
-  }
-
-  if (version == "dev") {
-    // the "dev" version is special and indicates we're using the tip-of-tree version built for testing
-    // so we shouldn't fetch it from the internet, only check for its existence in the disk cache
-    return kj::none;
-  }
-
-  {
-    kj::Thread([&]() {
-      kj::String url =
-          kj::str("https://pyodide-capnp-bin.edgeworker.net/pyodide_", version, ".capnp.bin");
-      KJ_LOG(INFO, "Loading Pyodide bundle from internet", url);
-      kj::AsyncIoContext io = kj::setupAsyncIo();
-      kj::HttpHeaderTable table;
-
-      kj::TlsContext::Options options;
-      options.useSystemTrustStore = true;
-
-      kj::Own<kj::TlsContext> tls = kj::heap<kj::TlsContext>(kj::mv(options));
-      auto& network = io.provider->getNetwork();
-      auto tlsNetwork = tls->wrapNetwork(network);
-      auto& timer = io.provider->getTimer();
-
-      auto client = kj::newHttpClient(timer, table, network, *tlsNetwork);
-
-      kj::HttpHeaders headers(table);
-
-      auto req = client->request(kj::HttpMethod::GET, url.asPtr(), headers);
-
-      auto res = req.response.wait(io.waitScope);
-      KJ_ASSERT(res.statusCode == 200,
-          kj::str(
-              "Request for Pyodide bundle at ", url, " failed with HTTP status ", res.statusCode));
-      auto body = res.body->readAllBytes().wait(io.waitScope);
-
-      writePyodideBundleFileToDisk(pyConfig.pyodideDiskCacheRoot, version, body);
-
-      pyConfig.pyodideBundleManager.setPyodideBundleData(kj::str(version), kj::mv(body));
-    });
-  }
-
-  KJ_LOG(INFO, "Loaded Pyodide package from internet");
-  return pyConfig.pyodideBundleManager.getPyodideBundle(version);
+  auto result = pyConfig.pyodideBundleManager.getPyodideBundle(version);
+  return KJ_ASSERT_NONNULL(result, "Failed to get Pyodide bundle");
 }
 
 /**
@@ -733,8 +654,7 @@ void WorkerdApi::compileModules(jsg::Lock& lockParam,
           "The python_workers compatibility flag is required to use Python.");
       auto pythonRelease = KJ_ASSERT_NONNULL(getPythonSnapshotRelease(featureFlags));
       auto version = getPythonBundleName(pythonRelease);
-      auto bundle = KJ_ASSERT_NONNULL(
-          fetchPyodideBundle(impl->pythonConfig, version), "Failed to get Pyodide bundle");
+      auto bundle = retrievePyodideBundle(impl->pythonConfig, version);
       // Inject SetupEmscripten module
       {
         auto emscriptenRuntime =
@@ -742,14 +662,6 @@ void WorkerdApi::compileModules(jsg::Lock& lockParam,
         modules->addBuiltinModule("internal:setup-emscripten",
             jsg::alloc<SetupEmscripten>(kj::mv(emscriptenRuntime)),
             workerd::jsg::ModuleRegistry::Type::INTERNAL);
-      }
-
-      // Get Python requirements and fetch packages
-      KJ_IF_SOME(a, artifacts) {
-        KJ_IF_SOME(pm, a->packageManager) {
-          auto pythonRequirements = getPythonRequirements(source);
-          fetchPyodidePackages(impl->pythonConfig, pm, pythonRequirements, pythonRelease);
-        }
       }
 
       // Inject Pyodide bundle
@@ -1236,16 +1148,7 @@ kj::Own<jsg::modules::ModuleRegistry> WorkerdApi::initializeBundleModuleRegistry
       // Inject metadata that the entrypoint module will read.
       auto pythonRelease = KJ_ASSERT_NONNULL(getPythonSnapshotRelease(featureFlags));
       auto version = getPythonBundleName(pythonRelease);
-      auto bundle = KJ_ASSERT_NONNULL(
-          fetchPyodideBundle(pythonConfig, version), "Failed to get Pyodide bundle");
-
-      // Get Python requirements and fetch packages
-      KJ_IF_SOME(a, artifacts) {
-        KJ_IF_SOME(pm, a->packageManager) {
-          auto pythonRequirements = getPythonRequirements(source);
-          fetchPyodidePackages(pythonConfig, pm, pythonRequirements, pythonRelease);
-        }
-      }
+      auto bundle = retrievePyodideBundle(pythonConfig, version);
 
       // We end up add modules from the bundle twice, once to get BUILTIN modules
       // and again to get the BUILTIN_ONLY modules. These end up in two different

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -308,9 +308,6 @@ class WorkerdApi final: public Worker::Api {
   kj::Own<Impl> impl;
 };
 
-kj::Maybe<jsg::Bundle::Reader> fetchPyodideBundle(
-    const api::pyodide::PythonConfig& pyConfig, kj::StringPtr version);
-
 kj::Array<kj::String> getPythonRequirements(const Worker::Script::ModulesSource& source);
 
 }  // namespace workerd::server

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -840,8 +840,6 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
       auto features = message.getRoot<CompatibilityFlags>();
       features.setPythonWorkers(true);
       auto pythonRelease = KJ_ASSERT_NONNULL(getPythonSnapshotRelease(features));
-      auto version = getPythonBundleName(pythonRelease);
-      KJ_ASSERT_NONNULL(fetchPyodideBundle(config, version), "Failed to get Pyodide bundle");
 
       auto lock = KJ_ASSERT_NONNULL(api::pyodide::getPyodideLock(pythonRelease));
 


### PR DESCRIPTION
Moves where Python deps (bundle and built-in packages) are downloaded so that the download can be accomplished asynchronously in the main workerd thread.

### Test Plan

```
$ bazel run @workerd//src/workerd/server/tests/python:durable-object_0.26.0a2@
$ bazel run @workerd//src/workerd/server/tests/python:import/urllib3_0.27.7@ --test_tag_filters=-none
$ bazel run @workerd//src/workerd/server:workerd -- pyodide-lock
```