### PR TITLE
devcontainer update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/base:dev-bookworm
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:22
 
 # Install dependencies, including clang via through LLVM APT repository. Note that this
 # will also install lldb and clangd alongside dependencies.
@@ -11,3 +11,6 @@ ENV PATH /usr/lib/llvm-${LLVM_VERSION}/bin:$PATH
 
 # Install Bazel (via Bazelisk)
 RUN npm install -g @bazel/bazelisk
+
+# Install Just
+RUN npm install -g rust-just


### PR DESCRIPTION
This updates the devcontainer to Node.js 22 and adds `just` using the Node.js wrapper which is only supported on Node.js 22.