### PR TITLE
GitHub workflows to check actor over author

### DIFF
--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -21,7 +21,7 @@ jobs:
         if: github.event.pull_request.head.repo.fork
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AUTHOR: ${{ github.event.pull_request.user.login }}
+          AUTHOR: ${{ github.actor }}
         run: |
           echo "Fork detected. Checking if $AUTHOR is a Cloudflare org member..."
 


### PR DESCRIPTION
Posting as a draft and for discussion, if it would be useful for third-party contributions to be able to have the internal build triggered by having the workflow run by a team member.

Perhaps a stronger security guarantee is needed for this check though?