### PR TITLE
Correctly handle the event.currentTarget property

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -166,12 +166,15 @@ kj::StringPtr Event::getType() {
   return type;
 }
 
-jsg::Optional<jsg::Ref<EventTarget>> Event::getCurrentTarget() {
-  return target.map([&](jsg::Ref<EventTarget>& t) { return t.addRef(); });
+kj::Maybe<jsg::Ref<EventTarget>> Event::getCurrentTarget() {
+  if (isBeingDispatched) {
+    return getTarget();
+  }
+  return kj::none;
 }
 
 jsg::Optional<jsg::Ref<EventTarget>> Event::getTarget() {
-  return getCurrentTarget();
+  return target.map([&](jsg::Ref<EventTarget>& t) { return t.addRef(); });
 }
 
 kj::Array<jsg::Ref<EventTarget>> Event::composedPath() {

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -129,8 +129,8 @@ class Event: public jsg::Object {
 
   // The currentTarget is the EventTarget on which the Event is being
   // dispatched. This will be set every time dispatchEvent() is called
-  // successfully and will remain set after dispatching is completed.
-  jsg::Optional<jsg::Ref<EventTarget>> getCurrentTarget();
+  // successfully and will be null after dispatchEvent returns.
+  kj::Maybe<jsg::Ref<EventTarget>> getCurrentTarget();
 
   // Because we don't support hierarchical EventTargets, this function
   // will always return the same value as getCurrentTarget().
@@ -155,11 +155,23 @@ class Event: public jsg::Object {
       JSG_READONLY_PROTOTYPE_PROPERTY(cancelable, getCancelable);
       JSG_READONLY_PROTOTYPE_PROPERTY(defaultPrevented, getDefaultPrevented);
       JSG_READONLY_PROTOTYPE_PROPERTY(returnValue, getReturnValue);
-      JSG_READONLY_PROTOTYPE_PROPERTY(currentTarget, getCurrentTarget);
+      if (flags.getPedanticWpt()) {
+        JSG_READONLY_PROTOTYPE_PROPERTY(currentTarget, getCurrentTarget);
+      } else {
+        // The original implementation had getTarget simply deferring to
+        // getCurrentTarget, the new impl moves the original impl into
+        // getTarget here so having currentTarget point to getTarget
+        // preserves the original behavior.
+        JSG_READONLY_PROTOTYPE_PROPERTY(currentTarget, getTarget);
+      }
       JSG_READONLY_PROTOTYPE_PROPERTY(target, getTarget);
-      JSG_READONLY_PROTOTYPE_PROPERTY(srcElement, getCurrentTarget);
+      JSG_READONLY_PROTOTYPE_PROPERTY(srcElement, getTarget);
       JSG_READONLY_PROTOTYPE_PROPERTY(timeStamp, getTimestamp);
-      JSG_READONLY_PROTOTYPE_PROPERTY(isTrusted, getIsTrusted);
+      if (flags.getPedanticWpt()) {
+        JSG_READONLY_INSTANCE_PROPERTY(isTrusted, getIsTrusted);
+      } else {
+        JSG_READONLY_PROTOTYPE_PROPERTY(isTrusted, getIsTrusted);
+      }
 
       JSG_PROTOTYPE_PROPERTY(cancelBubble, getCancelBubble, setCancelBubble);
     } else {
@@ -170,7 +182,11 @@ class Event: public jsg::Object {
       JSG_READONLY_INSTANCE_PROPERTY(cancelable, getCancelable);
       JSG_READONLY_INSTANCE_PROPERTY(defaultPrevented, getDefaultPrevented);
       JSG_READONLY_INSTANCE_PROPERTY(returnValue, getReturnValue);
-      JSG_READONLY_INSTANCE_PROPERTY(currentTarget, getCurrentTarget);
+      if (flags.getPedanticWpt()) {
+        JSG_READONLY_INSTANCE_PROPERTY(currentTarget, getCurrentTarget);
+      } else {
+        JSG_READONLY_INSTANCE_PROPERTY(currentTarget, getTarget);
+      }
       JSG_READONLY_INSTANCE_PROPERTY(target, getTarget);
       JSG_READONLY_INSTANCE_PROPERTY(srcElement, getCurrentTarget);
       JSG_READONLY_INSTANCE_PROPERTY(timeStamp, getTimestamp);

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -876,4 +876,11 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatDisableFlag("disable_nodejs_http_modules")
       $impliedByAfterDate(name = "nodeJsCompat", date = "2025-08-15");
   # Enables Node.js http related modules such as node:http and node:https
+
+  pedanticWpt @101 :Bool
+      $compatEnableFlag("pedantic_wpt")
+      $compatDisableFlag("non_pedantic_wpt");
+  # Enables a "pedantic mode" for WPT compliance. Multiple changes are grouped under
+  # this flag that are known to be required to pass more web platform tests but which
+  # otherwise are likely not to be strictly necessary for most users.
 }

--- a/src/wpt/BUILD.bazel
+++ b/src/wpt/BUILD.bazel
@@ -66,6 +66,7 @@ wpt_test(
 
 wpt_test(
     name = "dom/events",
+    compat_flags = ["pedantic_wpt"],
     config = "dom/events-test.ts",
     wpt_directory = "@wpt//:dom/events@module",
 )

--- a/src/wpt/dom/events-test.ts
+++ b/src/wpt/dom/events-test.ts
@@ -45,9 +45,7 @@ export default {
   'EventTarget-addEventListener.any.js': {},
   'EventTarget-constructible.any.js': {
     comment: 'Should be null, not EventTarget',
-    expectedFailures: [
-      'A constructed EventTarget implements dispatch correctly',
-    ],
+    expectedFailures: [],
   },
   'EventTarget-removeEventListener.any.js': {
     comment: 'capture is not relevant outside of the DOM',

--- a/src/wpt/dom/events-test.ts
+++ b/src/wpt/dom/events-test.ts
@@ -32,8 +32,12 @@ export default {
   },
   'Event-isTrusted.any.js': {
     comment: 'isTrusted must be an own property, not a prototype property',
-    // There is a single test, whose name is the empty string
-    expectedFailures: [''],
+    // With the pedantic_wpt compat flag we actually set the isTrusted property
+    // to be an own property. However, it's an own property that uses a value
+    // in the descriptor rather than a getter and the test is specifically looking
+    // for a getter for some reason. That's way more pedantic than we want to
+    // deal with so just omit the test for now.
+    omittedTests: [''],
   },
   'EventListener-addEventListener.sub.window.js': {
     comment: 'Only relevant to browsers',

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -763,7 +763,7 @@ declare class Event {
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/currentTarget)
    */
-  get currentTarget(): EventTarget | undefined;
+  get currentTarget(): EventTarget | null;
   /**
    * Returns the object to which event is dispatched (its target).
    *
@@ -787,7 +787,7 @@ declare class Event {
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/isTrusted)
    */
-  get isTrusted(): boolean;
+  readonly isTrusted: boolean;
   /**
    * @deprecated
    *

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -768,7 +768,7 @@ export declare class Event {
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/currentTarget)
    */
-  get currentTarget(): EventTarget | undefined;
+  get currentTarget(): EventTarget | null;
   /**
    * Returns the object to which event is dispatched (its target).
    *
@@ -792,7 +792,7 @@ export declare class Event {
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/isTrusted)
    */
-  get isTrusted(): boolean;
+  readonly isTrusted: boolean;
   /**
    * @deprecated
    *


### PR DESCRIPTION
Per the spec, the currentTarget property of an Event should be null if the event is not being dispatched.

Fixes: https://github.com/cloudflare/workerd/issues/4558
Fixes: https://github.com/cloudflare/workerd/issues/4556

~~@danlapid @kentonv ... I'm hoping this can be something we don't need a compat flag for. Whatcha think?~~

Adds a new `pedantic_wpt` compat flag for these kinds of fixes. Additional changes will be made incrementally using `implied_by` compat flags so that'll bundle all these types of changes together.

/cc @npaun 