### PR TITLE
Types: Add traceId back to TailEvent

### DIFF
--- a/types/defines/trace.d.ts
+++ b/types/defines/trace.d.ts
@@ -189,6 +189,7 @@ type EventType =
   | Attributes;
 
 interface TailEvent<Event extends EventType> {
+  readonly traceId: string;
   readonly invocationId: string;
   readonly spanId: string;
   readonly timestamp: Date;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -8360,6 +8360,7 @@ declare namespace TailStream {
     | Link
     | Attributes;
   interface TailEvent<Event extends EventType> {
+    readonly traceId: string;
     readonly invocationId: string;
     readonly spanId: string;
     readonly timestamp: Date;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -8223,6 +8223,7 @@ export declare namespace TailStream {
     | Link
     | Attributes;
   interface TailEvent<Event extends EventType> {
+    readonly traceId: string;
     readonly invocationId: string;
     readonly spanId: string;
     readonly timestamp: Date;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -8108,6 +8108,7 @@ declare namespace TailStream {
     | Link
     | Attributes;
   interface TailEvent<Event extends EventType> {
+    readonly traceId: string;
     readonly invocationId: string;
     readonly spanId: string;
     readonly timestamp: Date;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -7971,6 +7971,7 @@ export declare namespace TailStream {
     | Link
     | Attributes;
   interface TailEvent<Event extends EventType> {
+    readonly traceId: string;
     readonly invocationId: string;
     readonly spanId: string;
     readonly timestamp: Date;


### PR DESCRIPTION
My previous change accidentally removed the `traceId` field from `TailEvent`: https://github.com/cloudflare/workerd/pull/4461/files#diff-4cf959564a421666edaa78ba067c1f16d0e5a52f912c20e00a6eaf08349458d7L179

That's silly. We need that.