### PR TITLE
Types: Update SpanOpen event type definition

### DIFF
--- a/types/defines/trace.d.ts
+++ b/types/defines/trace.d.ts
@@ -125,7 +125,7 @@ interface Hibernate {
 interface SpanOpen {
   readonly type: "spanOpen";
   readonly name: string;
-  readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
+  readonly parentSpanId: string;
 }
 
 interface SpanClose {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -8298,7 +8298,7 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
+    readonly parentSpanId: string;
   }
   interface SpanClose {
     readonly type: "spanClose";

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -8161,7 +8161,7 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
+    readonly parentSpanId: string;
   }
   interface SpanClose {
     readonly type: "spanClose";

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -8046,7 +8046,7 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
+    readonly parentSpanId: string;
   }
   interface SpanClose {
     readonly type: "spanClose";

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -7909,7 +7909,7 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
-    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
+    readonly parentSpanId: string;
   }
   interface SpanClose {
     readonly type: "spanClose";


### PR DESCRIPTION
The `SpanOpen` events I'm receiving look like this. I think the types are lagging behind the implementation so I've updated them.


```json
{
  "traceId": "f1a80216514fd0828da5c90f9e56b981",
  "invocationId": "d997300c8a8cf18ba74e64dc9eb9c5e4",
  "spanId": "281dc4b384e8a164",
  "timestamp": "2025-07-17T00:37:37.433Z",
  "sequence": 0,
  "event": {
    "type": "spanOpen",
    "name": "worker",
    "parentSpanId": "0"
  }
}
```
