### PR TITLE
Adds wait for event and workflows module

### DIFF
--- a/src/pyodide/internal/workers.py
+++ b/src/pyodide/internal/workers.py
@@ -12,7 +12,6 @@ from _workers import (
     FormDataValue,
     Headers,
     JSBody,
-    NonRetryableError,
     Request,
     RequestInitCfProperties,
     Response,

--- a/src/pyodide/internal/workflows.py
+++ b/src/pyodide/internal/workflows.py
@@ -1,0 +1,12 @@
+"""
+Workflow-specific classes and exceptions for the workers module.
+"""
+
+
+class NonRetryableError(Exception):
+    """
+    A marker exception used to signal that a workflow step should not be retried.
+    This is a special exception used by workflows.
+    """
+
+    pass

--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -118,7 +118,11 @@ async function setupPatches(pyodide: Pyodide): Promise<void> {
     }
     // The SDK was moved from `cloudflare.workers` to just `workers`.
     await injectSitePackagesModule(pyodide, '_workers', '_workers');
-    await injectSitePackagesModule(pyodide, 'workers', 'workers');
+
+    // Create workers package structure with workflows submodule
+    pyodide.FS.mkdir(`${sitePackages}/workers`);
+    await injectSitePackagesModule(pyodide, 'workers', 'workers/__init__');
+    await injectSitePackagesModule(pyodide, 'workflows', 'workers/workflows');
 
     // Install patches as needed
     if (TRANSITIVE_REQUIREMENTS.has('aiohttp')) {

--- a/src/workerd/server/tests/python/workflow-entrypoint/workflow.py
+++ b/src/workerd/server/tests/python/workflow-entrypoint/workflow.py
@@ -3,6 +3,7 @@
 #     https://opensource.org/licenses/Apache-2.0
 
 from workers import WorkflowEntrypoint
+from workers.workflows import NonRetryableError
 
 
 class WorkflowEntrypointExample(WorkflowEntrypoint):
@@ -10,13 +11,13 @@ class WorkflowEntrypointExample(WorkflowEntrypoint):
         async def await_step(fn):
             try:
                 return await fn()
-            except TypeError as e:
+            except NonRetryableError as e:
                 print(f"Successfully caught {type(e).__name__}: {e}")
 
         @step.do("my_failing")
         async def my_failing():
             print("Executing my_failing")
-            raise TypeError("Intentional error in my_failing")
+            raise NonRetryableError("Intentional error in my_failing")
 
         @step.do("normal_step")
         async def normal_step():


### PR DESCRIPTION
- updates the entrypoint helper to include a module dedicated to workflows (similarly to `cloudflare:workflows`)
- adds `wait_for_event` in the workflow step wrapper