### PR TITLE
[o11y] Return STW outcome properly

### DIFF
--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -649,12 +649,12 @@ interface EventDispatcher @0xf20697475ec1752d {
   #
   # In C++, we use `WorkerInterface::customEvent()` to dispatch this event.
 
-  tailStreamSession @10 () -> (topLevel :TailStreamTarget) $Cxx.allowCancellation;
+  tailStreamSession @10 () -> (topLevel :TailStreamTarget, result :EventOutcome) $Cxx.allowCancellation;
   # Opens a streaming tail session. The call does not return until the session is complete.
   #
   # `topLevel` is the top-level tail session target, on which exactly one method call can
   # be made. This call must be made using pipelining since `tailStreamSession()` won't return
-  # until after the call completes.
+  # until after the call completes. result is accessed after the session is complete.
 
   obsolete5 @5();
   obsolete6 @6();


### PR DESCRIPTION
Provide the right outcome for the Streaming Tail Worker event, instead of always returning OK. This includes support for propagating the result via RPC.
Overlaps with #4540, should try to stitch these together cleanly.