### PR TITLE
[nfc] Add no-op method to LimitEnforcer

### DIFF
--- a/src/workerd/io/limit-enforcer.h
+++ b/src/workerd/io/limit-enforcer.h
@@ -153,6 +153,9 @@ class LimitEnforcer {
 
   // Report resource usage metrics to the given request metrics object.
   virtual void reportMetrics(RequestObserver& requestMetrics) = 0;
+
+  // Only used downstream for internal metrics.
+  virtual kj::Duration consumeTimeElapsedForPeriodicLogging() = 0;
 };
 
 }  // namespace workerd

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3199,6 +3199,9 @@ class Server::WorkerService final: public Service,
   }
   void requireLimitsNotExceeded() override {}
   void reportMetrics(RequestObserver& requestMetrics) override {}
+  kj::Duration consumeTimeElapsedForPeriodicLogging() override {
+    return 0 * kj::SECONDS;
+  }
 };
 
 struct FutureSubrequestChannel {

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -168,6 +168,9 @@ struct MockLimitEnforcer final: public LimitEnforcer {
   }
   void requireLimitsNotExceeded() override {}
   void reportMetrics(RequestObserver& requestMetrics) override {}
+  kj::Duration consumeTimeElapsedForPeriodicLogging() override {
+    return 0 * kj::SECONDS;
+  }
 };
 
 struct MockIsolateLimitEnforcer final: public IsolateLimitEnforcer {


### PR DESCRIPTION
This allows us to perform some build cleanup in the downstream build (see downstream PR).