### PR TITLE
Allow unprefixed handlers to be used in Python Workers.

### DIFF
--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -76,3 +76,7 @@ py_wd_test("importable-env")
 py_wd_test("python-rpc")
 
 py_wd_test("workflow-entrypoint")
+
+py_wd_test("unprefixed-handler")
+
+py_wd_test("unprefixed-do-handler")

--- a/src/workerd/server/tests/python/unprefixed-do-handler/unprefixed-do-handler.wd-test
+++ b/src/workerd/server/tests/python/unprefixed-do-handler/unprefixed-do-handler.wd-test
@@ -1,0 +1,30 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (name = "main", worker = .mainWorker),
+    (name = "TEST_TMPDIR", disk = (writable = true)),
+  ],
+);
+
+const mainWorker :Workerd.Worker = (
+  compatibilityDate = "2025-03-04",
+
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+
+  modules = [
+    (name = "worker.py", pythonModule = embed "worker.py"),
+  ],
+
+  durableObjectNamespaces = [
+    ( className = "DurableObjectExample",
+      uniqueKey = "210bd0cbd803ef7883a1ee9d86cce06e",
+      enableSql = true ),
+  ],
+
+  durableObjectStorage = (localDisk = "TEST_TMPDIR"),
+
+  bindings = [
+    (name = "ns", durableObjectNamespace = "DurableObjectExample"),
+  ],
+);

--- a/src/workerd/server/tests/python/unprefixed-do-handler/worker.py
+++ b/src/workerd/server/tests/python/unprefixed-do-handler/worker.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2023 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+from asyncio import sleep
+
+from js import Date
+from workers import DurableObject, Request, Response, handler
+
+
+class DurableObjectExample(DurableObject):
+    def __init__(self, state, env):
+        super().__init__(state, env)
+
+        self.alarm_triggered = False
+        self.storage = state.storage
+
+    async def fetch(self, request):
+        assert isinstance(request, Request)
+
+        curr = await self.storage.getAlarm()
+        if curr is None:
+            self.storage.setAlarm(Date.now() + 100)
+
+        return Response("alarm " + str(self.alarm_triggered))
+
+    async def alarm(self, alarm_info):
+        self.alarm_triggered = True
+
+
+@handler
+async def test(ctrl, env, ctx):
+    id = env.ns.idFromName("A")
+    obj = env.ns.get(id)
+
+    first_resp = await obj.fetch("http://foo.com/")
+    first_resp_data = await first_resp.text()
+    assert first_resp_data == "alarm False"
+
+    # Wait for alarm to get triggered.
+    while True:
+        await sleep(0.2)
+        resp = await obj.fetch("http://foo.com/")
+
+        alarm_triggered = await resp.text() == "alarm True"
+        if alarm_triggered:
+            break

--- a/src/workerd/server/tests/python/unprefixed-handler/unprefixed_handler.wd-test
+++ b/src/workerd/server/tests/python/unprefixed-handler/unprefixed_handler.wd-test
@@ -1,0 +1,18 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "unprefixed-handler",
+      worker = (
+        modules = [
+          (name = "worker.py", pythonModule = embed "worker.py")
+        ],
+        bindings = [
+          ( name = "SELF", service = "unprefixed-handler" ),
+        ],
+        compatibilityDate = "2025-06-15",
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+      )
+    ),
+  ],
+);

--- a/src/workerd/server/tests/python/unprefixed-handler/worker.py
+++ b/src/workerd/server/tests/python/unprefixed-handler/worker.py
@@ -1,0 +1,14 @@
+from workers import Response, handler
+
+
+@handler
+def fetch():
+    return Response("hello world")
+
+
+async def test(ctrl, env, ctx):
+    response = await env.SELF.fetch(
+        "http://example.com/",
+    )
+    text = await response.text()
+    assert text == "hello world"


### PR DESCRIPTION
Implements support for handlers without the `on_` prefix, i.e. `fetch` vs. `on_fetch`. If both are supplied then an error is thrown. Adds two tests to verify unprefixed handlers work. More tests in companion PR.

### Test Plan

```
bazel run @workerd//src/workerd/server/tests/python:unprefixed-do-handler_0.26.0a2@
bazel run @workerd//src/workerd/server/tests/python:unprefixed-handler_0.26.0a2@
```