### PR TITLE
add waitUntil method to cloudflare:workers module

### DIFF
--- a/src/cloudflare/internal/workers.d.ts
+++ b/src/cloudflare/internal/workers.d.ts
@@ -24,3 +24,5 @@ export class RpcStub {
 }
 
 export class RpcTarget {}
+
+export function waitUntil(promise: Promise<unknown>): void;

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -89,3 +89,5 @@ export const env = new Proxy(
     },
   }
 );
+
+export const waitUntil = entrypoints.waitUntil.bind(entrypoints);

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -554,6 +554,11 @@ class EntrypointsModule: public jsg::Object {
   EntrypointsModule() = default;
   EntrypointsModule(jsg::Lock&, const jsg::Url&) {}
 
+  void waitUntil(kj::Promise<void> promise) {
+    JSG_REQUIRE(IoContext::hasCurrent(), Error, "waitUntil requires an active request");
+    IoContext::current().addWaitUntil(kj::mv(promise));
+  }
+
   JSG_RESOURCE_TYPE(EntrypointsModule) {
     JSG_NESTED_TYPE(WorkerEntrypoint);
     JSG_NESTED_TYPE(WorkflowEntrypoint);
@@ -562,6 +567,8 @@ class EntrypointsModule: public jsg::Object {
     JSG_NESTED_TYPE_NAMED(JsRpcProperty, RpcProperty);
     JSG_NESTED_TYPE_NAMED(JsRpcStub, RpcStub);
     JSG_NESTED_TYPE_NAMED(JsRpcTarget, RpcTarget);
+
+    JSG_METHOD(waitUntil);
   }
 };
 


### PR DESCRIPTION
Starting from today, the following code works:

```js
import { waitUntil } from 'cloudflare:workers';

let globalWaitUntilPromise = null;

export default {
  async fetch() {
    globalWaitUntilPromise = null;
    let resolve;
    globalWaitUntilPromise = new Promise((r) => {
      resolve = r;
    });
    
    waitUntil(
      (async () => {
        await scheduler.wait(100);
        resolve();
      })()
    );

    return new Response('hello world');
  }
}
```