### PR TITLE
Add node:http sample

### DIFF
--- a/samples/nodejs-compat-http/README.md
+++ b/samples/nodejs-compat-http/README.md
@@ -1,0 +1,28 @@
+# Node.js 'node:http' Compat Example
+
+To run the example on http://localhost:8080
+
+```sh
+$ ./workerd serve config.capnp
+```
+
+To run using bazel
+
+```sh
+$ bazel run //src/workerd/server:workerd -- serve ~/cloudflare/workerd/samples/nodejs-compat/config.capnp
+```
+
+To create a standalone binary that can be run:
+
+```sh
+$ ./workerd compile config.capnp > nodejs-compat
+
+$ ./nodejs-compat
+```
+
+To test:
+
+```sh
+% curl http://localhost:8080
+Hello World
+```

--- a/samples/nodejs-compat-http/config.capnp
+++ b/samples/nodejs-compat-http/config.capnp
@@ -1,0 +1,35 @@
+# Imports the base schema for workerd configuration files.
+
+# Refer to the comments in /src/workerd/server/workerd.capnp for more details.
+
+using Workerd = import "/workerd/workerd.capnp";
+
+# A constant of type Workerd.Config defines the top-level configuration for an
+# instance of the workerd runtime. A single config file can contain multiple
+# Workerd.Config definitions and must have at least one.
+const helloWorldExample :Workerd.Config = (
+
+  # Every workerd instance consists of a set of named services. A worker, for instance,
+  # is a type of service. Other types of services can include external servers, the
+  # ability to talk to a network, or accessing a disk directory. Here we create a single
+  # worker service. The configuration details for the worker are defined below.
+  services = [ (name = "main", worker = .helloWorld) ],
+
+  # Every configuration defines the one or more sockets on which the server will listene.
+  # Here, we create a single socket that will listen on localhost port 8080, and will
+  # dispatch to the "main" service that we defined above.
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ]
+);
+
+# The definition of the actual helloWorld worker exposed using the "main" service.
+# In this example the worker is implemented as a single simple script (see worker.js).
+# The compatibilityDate is required. For more details on compatibility dates see:
+#   https://developers.cloudflare.com/workers/platform/compatibility-dates/
+
+const helloWorld :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js")
+  ],
+  compatibilityDate = "2025-07-01",
+  compatibilityFlags = ["nodejs_compat", "enable_nodejs_http_modules"]
+);

--- a/samples/nodejs-compat-http/worker.js
+++ b/samples/nodejs-compat-http/worker.js
@@ -1,0 +1,21 @@
+import { get } from 'node:http';
+export default {
+  async fetch(request) {
+    const { promise, resolve } = Promise.withResolvers();
+    get('http://example.com', {
+      headers: {
+        'accept': 'text/plain',
+      }
+    }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+      res.on('end', () => {
+        console.log('...', data);
+        resolve(new Response(data));
+      });
+    });
+    return promise;
+  }
+};


### PR DESCRIPTION
Adds a simple `node:http` sample.

It would be good to also have a sample that shows use of some other popular module that uses http (like got, or simple-get) but we can add that later.