### PR TITLE
disallow jsg::Promise in v8 fast api

### DIFF
--- a/src/workerd/jsg/fast-api-test.c++
+++ b/src/workerd/jsg/fast-api-test.c++
@@ -301,6 +301,7 @@ KJ_TEST("isFastApiCompatible Detection") {
   using MaybeVoidMethod = kj::Maybe<void> (FastMethodContext::*)();
   using StaticMethodContainerMethod = void(StaticMethodContainer);
   using KjPromiseMethod = void (FastMethodContext::*)(kj::Promise<void>);
+  using JsgPromiseMethod = void (FastMethodContext::*)(jsg::Promise<void>);
 
   // Static assertions for compatible method types
   // --------------------------------------------
@@ -359,7 +360,8 @@ KJ_TEST("isFastApiCompatible Detection") {
   static_assert(!isFastApiCompatible<MaybeVoidMethod>,
       "Methods returning Maybe<void> should not be fast-method compatible");
   static_assert(isFastApiCompatible<StaticMethodContainerMethod>, "This should be compatible");
-  static_assert(!isFastApiCompatible<KjPromiseMethod>, "Promise is not compatible");
+  static_assert(!isFastApiCompatible<KjPromiseMethod>, "kj::Promise is not compatible");
+  static_assert(!isFastApiCompatible<JsgPromiseMethod>, "jsg::Promise is not compatible");
 }
 
 }  // namespace

--- a/src/workerd/jsg/fast-api.h
+++ b/src/workerd/jsg/fast-api.h
@@ -26,6 +26,8 @@ class ByteString;
 class DOMString;
 class Lock;
 class USVString;
+template <typename T>
+class Promise;
 
 // Update this list whenever a new string type is added.
 // TODO(soon): Merge this with webidl::isStringType once NonCoercible is supported.
@@ -47,6 +49,12 @@ constexpr bool isKjPromise = false;
 template <typename T>
 constexpr bool isKjPromise<kj::Promise<T>> = true;
 
+template <typename T>
+constexpr bool isJsgPromise = false;
+
+template <typename T>
+constexpr bool isJsgPromise<jsg::Promise<T>> = true;
+
 // These types are passed by fast api as is and do not require wrapping/unwrapping.
 template <typename T>
 concept FastApiPrimitive = kj::isSameType<T, void>() || kj::isSameType<T, bool>() ||
@@ -56,7 +64,7 @@ concept FastApiPrimitive = kj::isSameType<T, void>() || kj::isSameType<T, bool>(
 // Helper to determine if a type can be used as a parameter in V8 Fast API
 template <typename T>
 concept FastApiParam = !isFunctionCallbackInfo<kj::RemoveConst<kj::Decay<T>>> &&
-    !isKjPromise<kj::RemoveConst<kj::Decay<T>>>;
+    !isKjPromise<kj::RemoveConst<kj::Decay<T>>> && !isJsgPromise<kj::RemoveConst<kj::Decay<T>>>;
 
 // Helper to determine if a type can be used as a return value in a V8 Fast API
 template <typename T>


### PR DESCRIPTION
We disallow kj::Promise but not jsg::Promise. Let's disallow it.