### PR TITLE
[o11y] Specify "trace" event type for Streaming Tail Worker

### DIFF
--- a/src/workerd/io/trace-stream.h
+++ b/src/workerd/io/trace-stream.h
@@ -37,9 +37,8 @@ class TailStreamCustomEventImpl final: public WorkerInterface::CustomEvent {
     return typeId;
   }
 
-  // TODO(streaming-tail-workers): Specify the correct type as specified in the
-  // internal capnp definition.
-  static constexpr uint16_t TYPE = 11;
+  // Specify same type as with TraceCustomEventImpl here by default.
+  static constexpr uint16_t TYPE = 2;
 
   rpc::TailStreamTarget::Client getCap() {
     auto result = kj::mv(KJ_ASSERT_NONNULL(clientCap, "can only call getCap() once"));


### PR DESCRIPTION
This matches the existing tail worker.
For the event info provided in the trace onset, use CustomEventInfo as with TraceEventInfo we'd always end up reporting an empty array.