### PR TITLE
feat(types): allow Service<T> to handle non-WorkerEntrypoint default export

### DIFF
--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -436,10 +436,17 @@ class Fetcher: public JsRpcClientProvider {
       });
     }
     JSG_TS_DEFINE(
-      type Service<T = undefined> = Fetcher<
-          T extends new (...args: any[]) => infer EntrypointClass
-              ? EntrypointClass extends Rpc.WorkerEntrypointBranded ? EntrypointClass : undefined
-              : T extends Rpc.WorkerEntrypointBranded ? T : undefined
+      type Service<
+        T extends
+          | (new (...args: any[]) => Rpc.WorkerEntrypointBranded)
+          | Rpc.WorkerEntrypointBranded
+          | ExportedHandler<any, any, any>
+          | undefined = undefined,
+      > = Fetcher<
+        T extends new (...args: any[]) => infer EntrypointClass ? EntrypointClass
+        : T extends Rpc.WorkerEntrypointBranded ? T
+        : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded> ? never
+        : undefined
       >;
     );
 

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -436,7 +436,11 @@ class Fetcher: public JsRpcClientProvider {
       });
     }
     JSG_TS_DEFINE(
-      type Service<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> = Fetcher<T>;
+      type Service<T = undefined> = Fetcher<
+          T extends new (...args: any[]) => infer EntrypointClass
+              ? EntrypointClass extends Rpc.WorkerEntrypointBranded ? EntrypointClass : undefined
+              : T extends Rpc.WorkerEntrypointBranded ? T : undefined
+      >;
     );
 
     if (!flags.getFetcherNoGetPutDelete()) {

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -442,12 +442,10 @@ class Fetcher: public JsRpcClientProvider {
           | Rpc.WorkerEntrypointBranded
           | ExportedHandler<any, any, any>
           | undefined = undefined,
-      > = Fetcher<
-        T extends new (...args: any[]) => infer EntrypointClass ? EntrypointClass
-        : T extends Rpc.WorkerEntrypointBranded ? T
+      > = T extends new (...args: any[]) => Rpc.WorkerEntrypointBranded ? Fetcher<InstanceType<T>>
+        : T extends Rpc.WorkerEntrypointBranded ? Fetcher<T>
         : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded> ? never
-        : undefined
-      >;
+        : Fetcher<undefined>
     );
 
     if (!flags.getFetcherNoGetPutDelete()) {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -1761,8 +1761,15 @@ interface RequestInit<Cf = CfProperties> {
   signal?: AbortSignal | null;
   encodeResponseBody?: "automatic" | "manual";
 }
-type Service<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> =
-  Fetcher<T>;
+type Service<T = undefined> = Fetcher<
+  T extends new (...args: any[]) => infer EntrypointClass
+    ? EntrypointClass extends Rpc.WorkerEntrypointBranded
+      ? EntrypointClass
+      : undefined
+    : T extends Rpc.WorkerEntrypointBranded
+      ? T
+      : undefined
+>;
 type Fetcher<
   T extends Rpc.EntrypointBranded | undefined = undefined,
   Reserved extends string = never,

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -1761,14 +1761,20 @@ interface RequestInit<Cf = CfProperties> {
   signal?: AbortSignal | null;
   encodeResponseBody?: "automatic" | "manual";
 }
-type Service<T = undefined> = Fetcher<
+type Service<
+  T extends
+    | (new (...args: any[]) => Rpc.WorkerEntrypointBranded)
+    | Rpc.WorkerEntrypointBranded
+    | ExportedHandler<any, any, any>
+    | undefined = undefined,
+> = Fetcher<
   T extends new (...args: any[]) => infer EntrypointClass
-    ? EntrypointClass extends Rpc.WorkerEntrypointBranded
-      ? EntrypointClass
-      : undefined
+    ? EntrypointClass
     : T extends Rpc.WorkerEntrypointBranded
       ? T
-      : undefined
+      : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded>
+        ? never
+        : undefined
 >;
 type Fetcher<
   T extends Rpc.EntrypointBranded | undefined = undefined,

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -1767,15 +1767,13 @@ type Service<
     | Rpc.WorkerEntrypointBranded
     | ExportedHandler<any, any, any>
     | undefined = undefined,
-> = Fetcher<
-  T extends new (...args: any[]) => infer EntrypointClass
-    ? EntrypointClass
-    : T extends Rpc.WorkerEntrypointBranded
-      ? T
-      : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded>
-        ? never
-        : undefined
->;
+> = T extends new (...args: any[]) => Rpc.WorkerEntrypointBranded
+  ? Fetcher<InstanceType<T>>
+  : T extends Rpc.WorkerEntrypointBranded
+    ? Fetcher<T>
+    : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded>
+      ? never
+      : Fetcher<undefined>;
 type Fetcher<
   T extends Rpc.EntrypointBranded | undefined = undefined,
   Reserved extends string = never,

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -1769,14 +1769,20 @@ export interface RequestInit<Cf = CfProperties> {
   signal?: AbortSignal | null;
   encodeResponseBody?: "automatic" | "manual";
 }
-export type Service<T = undefined> = Fetcher<
+export type Service<
+  T extends
+    | (new (...args: any[]) => Rpc.WorkerEntrypointBranded)
+    | Rpc.WorkerEntrypointBranded
+    | ExportedHandler<any, any, any>
+    | undefined = undefined,
+> = Fetcher<
   T extends new (...args: any[]) => infer EntrypointClass
-    ? EntrypointClass extends Rpc.WorkerEntrypointBranded
-      ? EntrypointClass
-      : undefined
+    ? EntrypointClass
     : T extends Rpc.WorkerEntrypointBranded
       ? T
-      : undefined
+      : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded>
+        ? never
+        : undefined
 >;
 export type Fetcher<
   T extends Rpc.EntrypointBranded | undefined = undefined,

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -1775,15 +1775,13 @@ export type Service<
     | Rpc.WorkerEntrypointBranded
     | ExportedHandler<any, any, any>
     | undefined = undefined,
-> = Fetcher<
-  T extends new (...args: any[]) => infer EntrypointClass
-    ? EntrypointClass
-    : T extends Rpc.WorkerEntrypointBranded
-      ? T
-      : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded>
-        ? never
-        : undefined
->;
+> = T extends new (...args: any[]) => Rpc.WorkerEntrypointBranded
+  ? Fetcher<InstanceType<T>>
+  : T extends Rpc.WorkerEntrypointBranded
+    ? Fetcher<T>
+    : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded>
+      ? never
+      : Fetcher<undefined>;
 export type Fetcher<
   T extends Rpc.EntrypointBranded | undefined = undefined,
   Reserved extends string = never,

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -1769,9 +1769,15 @@ export interface RequestInit<Cf = CfProperties> {
   signal?: AbortSignal | null;
   encodeResponseBody?: "automatic" | "manual";
 }
-export type Service<
-  T extends Rpc.WorkerEntrypointBranded | undefined = undefined,
-> = Fetcher<T>;
+export type Service<T = undefined> = Fetcher<
+  T extends new (...args: any[]) => infer EntrypointClass
+    ? EntrypointClass extends Rpc.WorkerEntrypointBranded
+      ? EntrypointClass
+      : undefined
+    : T extends Rpc.WorkerEntrypointBranded
+      ? T
+      : undefined
+>;
 export type Fetcher<
   T extends Rpc.EntrypointBranded | undefined = undefined,
   Reserved extends string = never,

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -1733,15 +1733,13 @@ type Service<
     | Rpc.WorkerEntrypointBranded
     | ExportedHandler<any, any, any>
     | undefined = undefined,
-> = Fetcher<
-  T extends new (...args: any[]) => infer EntrypointClass
-    ? EntrypointClass
-    : T extends Rpc.WorkerEntrypointBranded
-      ? T
-      : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded>
-        ? never
-        : undefined
->;
+> = T extends new (...args: any[]) => Rpc.WorkerEntrypointBranded
+  ? Fetcher<InstanceType<T>>
+  : T extends Rpc.WorkerEntrypointBranded
+    ? Fetcher<T>
+    : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded>
+      ? never
+      : Fetcher<undefined>;
 type Fetcher<
   T extends Rpc.EntrypointBranded | undefined = undefined,
   Reserved extends string = never,

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -1727,8 +1727,15 @@ interface RequestInit<Cf = CfProperties> {
   signal?: AbortSignal | null;
   encodeResponseBody?: "automatic" | "manual";
 }
-type Service<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> =
-  Fetcher<T>;
+type Service<T = undefined> = Fetcher<
+  T extends new (...args: any[]) => infer EntrypointClass
+    ? EntrypointClass extends Rpc.WorkerEntrypointBranded
+      ? EntrypointClass
+      : undefined
+    : T extends Rpc.WorkerEntrypointBranded
+      ? T
+      : undefined
+>;
 type Fetcher<
   T extends Rpc.EntrypointBranded | undefined = undefined,
   Reserved extends string = never,

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -1727,14 +1727,20 @@ interface RequestInit<Cf = CfProperties> {
   signal?: AbortSignal | null;
   encodeResponseBody?: "automatic" | "manual";
 }
-type Service<T = undefined> = Fetcher<
+type Service<
+  T extends
+    | (new (...args: any[]) => Rpc.WorkerEntrypointBranded)
+    | Rpc.WorkerEntrypointBranded
+    | ExportedHandler<any, any, any>
+    | undefined = undefined,
+> = Fetcher<
   T extends new (...args: any[]) => infer EntrypointClass
-    ? EntrypointClass extends Rpc.WorkerEntrypointBranded
-      ? EntrypointClass
-      : undefined
+    ? EntrypointClass
     : T extends Rpc.WorkerEntrypointBranded
       ? T
-      : undefined
+      : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded>
+        ? never
+        : undefined
 >;
 type Fetcher<
   T extends Rpc.EntrypointBranded | undefined = undefined,

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -1735,14 +1735,20 @@ export interface RequestInit<Cf = CfProperties> {
   signal?: AbortSignal | null;
   encodeResponseBody?: "automatic" | "manual";
 }
-export type Service<T = undefined> = Fetcher<
+export type Service<
+  T extends
+    | (new (...args: any[]) => Rpc.WorkerEntrypointBranded)
+    | Rpc.WorkerEntrypointBranded
+    | ExportedHandler<any, any, any>
+    | undefined = undefined,
+> = Fetcher<
   T extends new (...args: any[]) => infer EntrypointClass
-    ? EntrypointClass extends Rpc.WorkerEntrypointBranded
-      ? EntrypointClass
-      : undefined
+    ? EntrypointClass
     : T extends Rpc.WorkerEntrypointBranded
       ? T
-      : undefined
+      : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded>
+        ? never
+        : undefined
 >;
 export type Fetcher<
   T extends Rpc.EntrypointBranded | undefined = undefined,

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -1735,9 +1735,15 @@ export interface RequestInit<Cf = CfProperties> {
   signal?: AbortSignal | null;
   encodeResponseBody?: "automatic" | "manual";
 }
-export type Service<
-  T extends Rpc.WorkerEntrypointBranded | undefined = undefined,
-> = Fetcher<T>;
+export type Service<T = undefined> = Fetcher<
+  T extends new (...args: any[]) => infer EntrypointClass
+    ? EntrypointClass extends Rpc.WorkerEntrypointBranded
+      ? EntrypointClass
+      : undefined
+    : T extends Rpc.WorkerEntrypointBranded
+      ? T
+      : undefined
+>;
 export type Fetcher<
   T extends Rpc.EntrypointBranded | undefined = undefined,
   Reserved extends string = never,

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -1741,15 +1741,13 @@ export type Service<
     | Rpc.WorkerEntrypointBranded
     | ExportedHandler<any, any, any>
     | undefined = undefined,
-> = Fetcher<
-  T extends new (...args: any[]) => infer EntrypointClass
-    ? EntrypointClass
-    : T extends Rpc.WorkerEntrypointBranded
-      ? T
-      : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded>
-        ? never
-        : undefined
->;
+> = T extends new (...args: any[]) => Rpc.WorkerEntrypointBranded
+  ? Fetcher<InstanceType<T>>
+  : T extends Rpc.WorkerEntrypointBranded
+    ? Fetcher<T>
+    : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded>
+      ? never
+      : Fetcher<undefined>;
 export type Fetcher<
   T extends Rpc.EntrypointBranded | undefined = undefined,
   Reserved extends string = never,

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -406,11 +406,10 @@ class TestNaughtyObject extends DurableObject {
 interface Env {
   REGULAR_SERVICE: Service;
   RPC_SERVICE: Service<TestEntrypoint>;
+  TYPEOF_RPC_SERVICE: Service<typeof TestEntrypoint>;
   NAUGHTY_SERVICE: Service<TestNaughtyEntrypoint>;
   // @ts-expect-error `BoringClass` isn't an RPC capable type
   __INVALID_RPC_SERVICE_1: Service<BoringClass>;
-  // @ts-expect-error `TestEntrypoint` is a `DurableObject`, not a `WorkerEntrypoint`
-  __INVALID_RPC_SERVICE_2: Service<TestObject>;
 
   REGULAR_OBJECT: DurableObjectNamespace;
   RPC_OBJECT: DurableObjectNamespace<TestObject>;


### PR DESCRIPTION
This PR updates `Service<T>` so that:

- Returns `Fetcher<T>` when `T` is a `WorkerEntrypoint` class (Current behavior)
- Returns `Fetcher<InstanceType<T>>` when `T` is a `WorkerEntrypoint` constructor
- Returns  `never` when `T` is a `DurableObject` or `WorkflowEntrypoint`
- Returns `Fetcher` otherwise

This will enable `wrangler types` to infer the RPC methods from the default export with `Service<typeof import("./worker").default>` next.

Ref: https://github.com/cloudflare/workers-sdk/pull/9897