### PR TITLE
Emscripten bootstrap: Propagate errors in ` _createPyodideModule` correctly

### DIFF
--- a/src/pyodide/types/emscripten.d.ts
+++ b/src/pyodide/types/emscripten.d.ts
@@ -71,6 +71,7 @@ interface EmscriptenSettings {
     config: API['config'];
   };
   readyPromise: Promise<Module>;
+  rejectReadyPromise: (e: any) => void;
 }
 
 interface Module {


### PR DESCRIPTION
This should make debugging the bootstrap much easier.