### PR TITLE
[rust] do not generate cxx.h header

### DIFF
--- a/build/deps/gen/dep_workerd_cxx.bzl
+++ b/build/deps/gen/dep_workerd_cxx.bzl
@@ -2,11 +2,11 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-URL = "https://github.com/cloudflare/workerd-cxx/tarball/d3ada6fc896554ed6d02fc91eea36010e36c11c7"
-STRIP_PREFIX = "cloudflare-workerd-cxx-d3ada6f"
-SHA256 = "40ea7fa6dc718f24878db48731dfb34363724e9d6ffd8d26480c8a28321b7618"
+URL = "https://github.com/cloudflare/workerd-cxx/tarball/0a978d5829a47388831e1cd936d111edf8174165"
+STRIP_PREFIX = "cloudflare-workerd-cxx-0a978d5"
+SHA256 = "2b7a16a90b1949e9aee8121cc2df1bab78bfc61e52674b36d029a42f3e388f91"
 TYPE = "tgz"
-COMMIT = "d3ada6fc896554ed6d02fc91eea36010e36c11c7"
+COMMIT = "0a978d5829a47388831e1cd936d111edf8174165"
 
 def dep_workerd_cxx():
     http_archive(

--- a/build/wd_rust_binary.bzl
+++ b/build/wd_rust_binary.bzl
@@ -38,8 +38,7 @@ def wd_rust_binary(
             # Not applying visibility here – if you import the cxxbridge header, you will likely
             # also need the rust library itself to avoid linker errors.
             deps = cxx_bridge_deps + [
-                "@workerd-cxx//:cxx",
-                "//src/rust/cxx-integration:cxx-include",
+                "@workerd-cxx//:core",
             ],
         )
 

--- a/build/wd_rust_crate.bzl
+++ b/build/wd_rust_crate.bzl
@@ -1,28 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
-def rust_cxx_include(name, visibility = [], include_prefix = None):
-    native.genrule(
-        name = "%s/generated" % name,
-        outs = ["cxx.h"],
-        cmd = "$(location @workerd-cxx//:codegen) --header > \"$@\"",
-        tools = ["@workerd-cxx//:codegen"],
-        target_compatible_with = select({
-            "@//build/config:no_build": ["@platforms//:incompatible"],
-            "//conditions:default": [],
-        }),
-    )
-
-    native.cc_library(
-        name = name,
-        hdrs = ["cxx.h"],
-        include_prefix = include_prefix,
-        visibility = visibility,
-        target_compatible_with = select({
-            "@//build/config:no_build": ["@platforms//:incompatible"],
-            "//conditions:default": [],
-        }),
-    )
-
 def rust_cxx_bridge(
         name,
         src,
@@ -107,8 +84,7 @@ def wd_rust_crate(
             # Not applying visibility here – if you import the cxxbridge header, you will likely
             # also need the rust library itself to avoid linker errors.
             deps = cxx_bridge_deps + [
-                "@workerd-cxx//:cxx",
-                "//src/rust/cxx-integration:cxx-include",
+                "@workerd-cxx//:core",
             ],
         )
 

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -37,6 +37,7 @@
 -isystembazel-bin/external/capnp-cpp/src/kj/compat/_virtual_includes/kj-gzip
 -isystembazel-bin/external/capnp-cpp/src/kj/compat/_virtual_includes/kj-http
 -isystembazel-bin/external/capnp-cpp/src/kj/compat/_virtual_includes/kj-tls
+-isystembazel-bin/external/workerd-cxx/_virtual_includes/core/
 -isystembazel-bin/external/workerd-cxx/kj-rs/_virtual_includes/kj-rs-lib/
 -isystembazel-bin/external/v8
 -isystembazel-bin/external/v8/icu

--- a/src/rust/cxx-integration/BUILD.bazel
+++ b/src/rust/cxx-integration/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//:build/wd_rust_crate.bzl", "rust_cxx_include", "wd_rust_crate")
+load("//:build/wd_rust_crate.bzl", "wd_rust_crate")
 
 wd_rust_crate(
     name = "cxx-integration",
@@ -12,10 +12,4 @@ wd_rust_crate(
         "@crates_vendor//:tracing",
         "@workerd-cxx//kj-rs",
     ],
-)
-
-rust_cxx_include(
-    name = "cxx-include",
-    include_prefix = "rust",
-    visibility = ["//visibility:public"],
 )

--- a/src/rust/python-parser/BUILD
+++ b/src/rust/python-parser/BUILD
@@ -1,5 +1,5 @@
 load("//:build/kj_test.bzl", "kj_test")
-load("//:build/wd_rust_crate.bzl", "rust_cxx_include", "wd_rust_crate")
+load("//:build/wd_rust_crate.bzl", "wd_rust_crate")
 
 wd_rust_crate(
     name = "python-parser",


### PR DESCRIPTION
but consume it directly using bazel target.

follow up to https://github.com/cloudflare/workerd-cxx/pull/48