### PR TITLE
Changes `run` method and fixes `sleep_until`

### DIFF
--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -264,29 +264,25 @@ function makeEntrypointProxyHandler(
         isDurableObject && SPECIAL_DO_HANDLER_NAMES.includes(prop);
       const isFetch = prop === 'fetch';
       const isWorkflowHandler = isWorkflow && prop === 'run';
-      if (
-        (isKnownHandler || isKnownDoHandler || isWorkflowHandler) &&
-        legacyGlobalHandlers
-      ) {
+      if ((isKnownHandler || isKnownDoHandler) && legacyGlobalHandlers) {
         prop = 'on_' + prop;
       }
 
       return async function (...args: any[]): Promise<any> {
         // Check if the requested method exists and if so, call it.
         const pyInstance = await pyInstancePromise;
-        const targetProp = prop;
 
-        if (typeof pyInstance[targetProp] !== 'function') {
-          throw new TypeError(`Method ${targetProp} does not exist`);
+        if (typeof pyInstance[prop] !== 'function') {
+          throw new TypeError(`Method ${prop} does not exist`);
         }
 
         if ((isKnownHandler || isKnownDoHandler) && !isFetch) {
-          return await doPyCallHelper(true, pyInstance[targetProp], args);
+          return await doPyCallHelper(true, pyInstance[prop], args);
         }
 
         if (workflowsEnabled && isWorkflowHandler) {
           // we're hiding this behind a compat flag for now
-          return await doPyCallHelper(true, pyInstance[targetProp], args);
+          return await doPyCallHelper(true, pyInstance[prop], args);
         }
 
         const introspectionMod = await getIntrospectionMod();
@@ -295,7 +291,7 @@ function makeEntrypointProxyHandler(
         return await doPyCall(introspectionMod.wrapper_func, [
           isRelaxed,
           pyInstance,
-          targetProp,
+          prop,
           ...args,
         ]);
       };

--- a/src/workerd/server/tests/python/workflow-entrypoint/workflow.py
+++ b/src/workerd/server/tests/python/workflow-entrypoint/workflow.py
@@ -3,21 +3,20 @@
 #     https://opensource.org/licenses/Apache-2.0
 
 from workers import WorkflowEntrypoint
-from workers.workflows import NonRetryableError
 
 
 class WorkflowEntrypointExample(WorkflowEntrypoint):
-    async def on_run(self, event, step):
+    async def run(self, event, step):
         async def await_step(fn):
             try:
                 return await fn()
-            except NonRetryableError as e:
+            except TypeError as e:
                 print(f"Successfully caught {type(e).__name__}: {e}")
 
         @step.do("my_failing")
         async def my_failing():
             print("Executing my_failing")
-            raise NonRetryableError("Intentional error in my_failing")
+            raise TypeError("Intentional error in my_failing")
 
         @step.do("normal_step")
         async def normal_step():


### PR DESCRIPTION
- Changes the workflow handler method to `run` instead of the `on_run`, as the platform moves away from the prefixes
- Fixes `sleep_until`: users can now provide either a string (respecting rules of `WorkflowDelayDuration`), or a `datetime.datetime` object which is then converted into a JS `Date` object