### PR TITLE
[build] Comply with clang-tidy misc-throw-by-value-catch-by-reference, minor code cleanup

### DIFF
--- a/src/workerd/api/basics-test.c++
+++ b/src/workerd/api/basics-test.c++
@@ -14,7 +14,6 @@
 #include <workerd/io/promise-wrapper.h>
 #include <workerd/jsg/jsg-test.h>
 #include <workerd/jsg/jsg.h>
-#include <workerd/util/autogate.h>
 
 namespace workerd::api {
 namespace {

--- a/src/workerd/api/hibernatable-web-socket.c++
+++ b/src/workerd/api/hibernatable-web-socket.c++
@@ -132,7 +132,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result> HibernatableWebSocketCustomEve
         KJ_UNREACHABLE;
       }
     });
-  } catch (kj::Exception e) {
+  } catch (kj::Exception& e) {
     if (auto desc = e.getDescription();
         !jsg::isTunneledException(desc) && !jsg::isDoNotLogException(desc)) {
       LOG_EXCEPTION("HibernatableWebSocketCustomEventImpl"_kj, e);

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -17,7 +17,6 @@
 #include <workerd/jsg/ser.h>
 #include <workerd/jsg/url.h>
 #include <workerd/util/abortable.h>
-#include <workerd/util/autogate.h>
 #include <workerd/util/http-util.h>
 #include <workerd/util/mimetype.h>
 #include <workerd/util/stream-utils.h>

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -684,7 +684,7 @@ kj::Promise<void> sendTracesToExportedHandler(kj::Own<IoContext::IncomingRequest
       auto handler = lock.getExportedHandler(entrypointName, kj::mv(props), context.getActor());
       return lock.getGlobalScope().sendTraces(nonEmptyTraces, lock, handler);
     });
-  } catch (kj::Exception e) {
+  } catch (kj::Exception& e) {
     // TODO(someday): We only report sendTraces() as failed for metrics/logging if the initial
     //   event handler throws an exception; we do not consider waitUntil(). But all async work done
     //   in a trace handler has to be done using waitUntil(). So, this seems wrong. Should we

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -11,7 +11,6 @@
 #include <workerd/io/io-context.h>
 #include <workerd/io/tracer.h>
 #include <workerd/jsg/jsg.h>
-#include <workerd/util/autogate.h>
 #include <workerd/util/sentry.h>
 #include <workerd/util/strings.h>
 #include <workerd/util/thread-scopes.h>

--- a/src/workerd/jsg/iterator-test.c++
+++ b/src/workerd/jsg/iterator-test.c++
@@ -4,8 +4,6 @@
 
 #include "jsg-test.h"
 
-#include <workerd/util/autogate.h>
-
 namespace workerd::jsg::test {
 namespace {
 

--- a/src/workerd/jsg/promise.c++
+++ b/src/workerd/jsg/promise.c++
@@ -30,14 +30,12 @@ kj::Maybe<AsyncContextFrame&> tryGetFrame(kj::Maybe<Ref<AsyncContextFrame>>& may
 UnhandledRejectionHandler::UnhandledRejection::UnhandledRejection(jsg::Lock& js,
     jsg::V8Ref<v8::Promise> promise,
     jsg::Value value,
-    v8::Local<v8::Message> message,
-    size_t rejectionNumber)
+    v8::Local<v8::Message> message)
     : hash(kj::hashCode(promise.getHandle(js)->GetIdentityHash())),
       promise(js.v8Isolate, promise.getHandle(js)),
       value(js.v8Isolate, value.getHandle(js)),
       message(js.v8Isolate, message),
-      asyncContextFrame(getFrameRef(js)),
-      rejectionNumber(rejectionNumber) {
+      asyncContextFrame(getFrameRef(js)) {
   this->promise.SetWeak();
   this->value.SetWeak();
 }
@@ -94,7 +92,7 @@ void UnhandledRejectionHandler::rejectedWithNoHandler(
   // value and message when it does.
 
   unhandledRejections.upsert(
-      UnhandledRejection(js, kj::mv(promise), kj::mv(value), kj::mv(message), ++rejectionCount),
+      UnhandledRejection(js, kj::mv(promise), kj::mv(value), kj::mv(message)),
       [&](UnhandledRejection& existing, UnhandledRejection&& replacement) {
     // Replacing the promise here is defensive, since they have the same hash
     // it *should* be the same promise, but let's be sure. We don't need to

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -723,8 +723,7 @@ class UnhandledRejectionHandler {
     explicit UnhandledRejection(jsg::Lock& js,
         jsg::V8Ref<v8::Promise> promise,
         jsg::Value value,
-        v8::Local<v8::Message> message,
-        size_t rejectionNumber);
+        v8::Local<v8::Message> message);
 
     ~UnhandledRejection();
 
@@ -749,8 +748,6 @@ class UnhandledRejectionHandler {
     inline bool isAlive() {
       return !promise.IsEmpty() && !value.IsEmpty();
     }
-
-    size_t rejectionNumber;
 
     uint hashCode() const {
       return hash;

--- a/src/workerd/jsg/util-test.c++
+++ b/src/workerd/jsg/util-test.c++
@@ -347,63 +347,63 @@ KJ_TEST("isTunneledException") {
   try {
     context.throwTunneledTypeError();
     KJ_UNREACHABLE;
-  } catch (kj::Exception e) {
+  } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
     context.throwTunneledTypeErrorWithoutMessage();
     KJ_UNREACHABLE;
-  } catch (kj::Exception e) {
+  } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
     context.throwTunneledTypeErrorLateColon();
     KJ_UNREACHABLE;
-  } catch (kj::Exception e) {
+  } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
     context.throwTunneledTypeErrorWithExpectation();
     KJ_UNREACHABLE;
-  } catch (kj::Exception e) {
+  } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
     context.throwTunneledOperationError();
     KJ_UNREACHABLE;
-  } catch (kj::Exception e) {
+  } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
     context.throwTunneledOperationErrorLateColon();
     KJ_UNREACHABLE;
-  } catch (kj::Exception e) {
+  } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
     context.throwTunneledOperationErrorWithExpectation();
     KJ_UNREACHABLE;
-  } catch (kj::Exception e) {
+  } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
 
   try {
     context.throwBadTunneledError();
     KJ_UNREACHABLE;
-  } catch (kj::Exception e) {
+  } catch (kj::Exception& e) {
     KJ_EXPECT(!isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
     context.throwBadTunneledErrorWithExpectation();
     KJ_UNREACHABLE;
-  } catch (kj::Exception e) {
+  } catch (kj::Exception& e) {
     KJ_EXPECT(!isTunneledException(e.getDescription()), e.getDescription());
   }
 
   try {
     context.throwRemoteCpuExceededError();
     KJ_UNREACHABLE;
-  } catch (kj::Exception e) {
+  } catch (kj::Exception& e) {
     KJ_EXPECT(!isTunneledException(e.getDescription()), e.getDescription());
     KJ_EXPECT(isDoNotLogException(e.getDescription()), e.getDescription());
   }
@@ -411,7 +411,7 @@ KJ_TEST("isTunneledException") {
   try {
     JSG_FAIL_REQUIRE(InternalDOMOperationError, "foo");
     KJ_UNREACHABLE;
-  } catch (kj::Exception e) {
+  } catch (kj::Exception& e) {
     KJ_EXPECT(!isTunneledException(e.getDescription()), e.getDescription());
   }
 }

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -1904,7 +1904,7 @@ const sqlite3_io_methods SqliteDatabase::Vfs::FileImpl::FILE_METHOD_TABLE = {
   .iVersion = 3,
 #define WRAP_METHOD(errorCode, block)                                                              \
   auto& self KJ_UNUSED = *static_cast<FileImpl*>(file);                                            \
-  try block catch (kj::Exception & e) {                                                            \
+  try block catch (kj::Exception& e) {                                                             \
     reportVfsErrorCaught(kj::mv(e));                                                               \
     return errorCode;                                                                              \
   }
@@ -2121,7 +2121,7 @@ sqlite3_vfs SqliteDatabase::Vfs::makeKjVfs() {
 
 #define WRAP_METHOD(errorCode, block)                                                              \
   auto& self KJ_UNUSED = *static_cast<const SqliteDatabase::Vfs*>(vfs->pAppData);                  \
-  try block catch (kj::Exception & e) {                                                            \
+  try block catch (kj::Exception& e) {                                                             \
     KJ_LOG(ERROR, "SQLite VFS I/O error", e);                                                      \
     return errorCode;                                                                              \
   }


### PR DESCRIPTION
This allows us to expand clang-tidy coverage downstream.