### PR TITLE
Adds compat flag which disables global Python handlers.

### DIFF
--- a/src/pyodide/internal/_workers.py
+++ b/src/pyodide/internal/_workers.py
@@ -808,6 +808,11 @@ def python_from_rpc(obj: "JsProxy"):
     if not hasattr(obj, "constructor"):
         return obj
 
+    if obj.constructor.name == "TestController":
+        # This object currently has no methods defined on it. If this changes we should
+        # implement a Python wrapper for it, but for now we'll just pass in None.
+        return None
+
     result = obj.to_py(default_converter=_python_from_rpc_default_converter)
 
     return result

--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -42,7 +42,7 @@ export const MAIN_MODULE_NAME = MetadataReader.getMainModule();
 
 export interface CompatibilityFlags {
   python_workflows?: boolean;
-  [key: string]: boolean | undefined;
+  python_no_global_handlers?: boolean;
 }
 
 export interface CloudflareGlobal {
@@ -54,3 +54,5 @@ export interface CloudflareGlobal {
 const compatibilityFlags: CompatibilityFlags =
   (globalThis as CloudflareGlobal)?.Cloudflare?.compatibilityFlags ?? {};
 export const workflowsEnabled: boolean = !!compatibilityFlags.python_workflows;
+export const legacyGlobalHandlers: boolean =
+  !compatibilityFlags.python_no_global_handlers;

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -901,4 +901,11 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # the methods exposed by the node.js http modules.
   # TODO(soon): Add a implifiedByAfter when node.js is enabled as well as
   # `enable_nodejs_http_modules`
+
+  pythonNoGlobalHandlers @104 :Bool
+      $compatEnableFlag("python_no_global_handlers")
+      $compatDisableFlag("disable_python_no_global_handlers")
+      $compatEnableDate("2025-08-14");
+  # Disables the global handlers for Python workers and enforces their use via default entrypoint
+  # classes.
 }

--- a/src/workerd/server/tests/python/sdk/sdk.wd-test
+++ b/src/workerd/server/tests/python/sdk/sdk.wd-test
@@ -8,7 +8,7 @@ const python :Workerd.Worker = (
     ( name = "SELF", service = "python-sdk" ),
   ],
   compatibilityDate = "2024-10-01",
-  compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_no_global_handlers"],
 );
 
 const server :Workerd.Worker = (
@@ -16,7 +16,7 @@ const server :Workerd.Worker = (
     (name = "server.py", pythonModule = embed "server.py")
   ],
   compatibilityDate = "2024-10-01",
-  compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_no_global_handlers"],
 );
 
 # We need this proxy so that internal requests made to fetch packages for Python Workers are sent

--- a/src/workerd/server/tests/python/sdk/server.py
+++ b/src/workerd/server/tests/python/sdk/server.py
@@ -1,29 +1,31 @@
-from workers import Blob, FormData, Response
+from workers import Blob, FormData, Response, WorkerEntrypoint
 
 
-async def on_fetch(request):
-    if request.url.endswith("/sub"):
-        return Response("Hi there!")
-    elif request.url.endswith("/sub_headers"):
-        assert request.headers.get("Custom-Req-Header") == "123"
-        return Response(
-            "Hi there!", headers={"Custom-Header-That-Should-Passthrough": True}
-        )
-    elif request.url.endswith("/redirect"):
-        return Response.redirect("https://example.com/sub", status=301)
-    elif request.url.endswith("/formdata"):
-        data = FormData({"field": "value"})
-        return Response(data)
-    elif request.url.endswith("/formdatablob"):
-        data = FormData({"field": "value"})
-        data["blob.py"] = Blob("print(42)", content_type="text/python")
-        data.append(
-            "metadata", Blob("{}", content_type="text/python"), filename="metadata.json"
-        )
-        return Response(data)
-    else:
-        raise ValueError("Unexpected path " + request.url)
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        if request.url.endswith("/sub"):
+            return Response("Hi there!")
+        elif request.url.endswith("/sub_headers"):
+            assert request.headers.get("Custom-Req-Header") == "123"
+            return Response(
+                "Hi there!", headers={"Custom-Header-That-Should-Passthrough": True}
+            )
+        elif request.url.endswith("/redirect"):
+            return Response.redirect("https://example.com/sub", status=301)
+        elif request.url.endswith("/formdata"):
+            data = FormData({"field": "value"})
+            return Response(data)
+        elif request.url.endswith("/formdatablob"):
+            data = FormData({"field": "value"})
+            data["blob.py"] = Blob("print(42)", content_type="text/python")
+            data.append(
+                "metadata",
+                Blob("{}", content_type="text/python"),
+                filename="metadata.json",
+            )
+            return Response(data)
+        else:
+            raise ValueError("Unexpected path " + request.url)
 
-
-def test():
-    pass
+    def test(self):
+        pass


### PR DESCRIPTION
As a team we decided to remove global handlers in Python Workers and instead standardise on a `Default` class which defines the handler methods. This PR implements a new compat flag which enforces the usage of this class.

This PR also renames the default WorkerEntrypoint to start with a capital letter rather than lowercase.

### Test Plan

```
bazel run @workerd//src/workerd/server/tests/python:sdk_development@
```