### PR TITLE
Some fixes for sidecar IP randomization

### DIFF
--- a/build/wd_test.bzl
+++ b/build/wd_test.bzl
@@ -151,7 +151,7 @@ def _wd_test_impl(ctx):
         runtest = runtest,
         supervisor = ctx.file.sidecar_supervisor.short_path if ctx.file.sidecar_supervisor else "",
         port_bindings = ",".join(ctx.attr.sidecar_port_bindings),
-        randomize_ip = str(ctx.attr.sidecar_randomize_ip),
+        randomize_ip = "true" if ctx.attr.sidecar_randomize_ip else "false",
     )
 
     ctx.actions.write(

--- a/build/wpt_test.bzl
+++ b/build/wpt_test.bzl
@@ -5,6 +5,19 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//:build/wd_test.bzl", "wd_test")
 
+PORT_BINDINGS = [
+    "HTTP_PORT",
+    "HTTPS_PORT",
+    # The remaining ports are not currently used by tests but need to be assigned to wptserve anyway
+    "HTTP_PORT_2",
+    "HTTPS_PORT_2",
+    "HTTP_PUBLIC_PORT",
+    "HTTPS_PUBLIC_PORT",
+    "HTTP_LOCAL_PORT",
+    "WSS_PORT",
+    "WS_PORT",
+]
+
 ### wpt_test macro
 ### (Invokes wpt_js_test_gen, wpt_wd_test_gen and wd_test to assemble a complete test suite.)
 ### -----------------------------------------------------------------------------------------
@@ -69,7 +82,7 @@ def wpt_test(name, wpt_directory, config, compat_date = "", compat_flags = [], a
         name = "{}".format(name),
         src = wd_test_gen_rule,
         args = ["--experimental"],
-        sidecar_port_bindings = ["HTTP_PORT", "HTTPS_PORT"] if start_server else [],
+        sidecar_port_bindings = PORT_BINDINGS if start_server else [],
         sidecar = "@wpt//:entrypoint" if start_server else None,
         data = data,
         **kwargs
@@ -387,8 +400,13 @@ cd $(dirname $0)
   "server_host": "$SIDECAR_HOSTNAME",
   "check_subdomains": false,
   "ports": {{
-    "http": [$HTTP_PORT, "auto"],
-    "https": [$HTTPS_PORT, "auto"]
+    "http": [$HTTP_PORT, $HTTP_PORT_2],
+    "https": [$HTTPS_PORT, $HTTPS_PORT_2],
+    "http-public": [$HTTP_PUBLIC_PORT],
+    "https-public": [$HTTPS_PUBLIC_PORT],
+    "http-local": [$HTTP_LOCAL_PORT],
+    "wss": [$WSS_PORT],
+    "ws": [$WS_PORT]
   }}
 }}
 EOF

--- a/src/workerd/api/node/tests/sidecar-supervisor.mjs
+++ b/src/workerd/api/node/tests/sidecar-supervisor.mjs
@@ -122,7 +122,7 @@ function getRandomLoopbackAddress() {
 }
 
 function canUseRandomAddress() {
-  if (process.env.RANDOMIZE_IP !== 'true') {
+  if (process.env.RANDOMIZE_IP === 'false') {
     // Test explicitly disabled randomization
     return false;
   }
@@ -156,7 +156,7 @@ function assignLoopbackAddress() {
     // On macOS, we need to explicitly assign this IP to the loopback interface
     child_process.spawnSync(
       'sudo',
-      ['/sbin/ifconfig', 'lo0', 'alias', randomHost],
+      ['/sbin/ifconfig', 'lo0', 'alias', randomAddress],
       { stdio: 'inherit' }
     );
   }

--- a/src/wpt/fetch/api-test.ts
+++ b/src/wpt/fetch/api-test.ts
@@ -17,6 +17,8 @@ export default {
     disabledTests: [
       // Flaky since 2025-06-09. To be investigated.
       'Stream errors once aborted, after reading. Underlying connection closed.',
+      // Flaky since 2025-07-25. To be investigated.
+      'Stream errors once aborted. Underlying connection closed.',
     ],
     expectedFailures: [
       // The fetch promise still resolves for some reason


### PR DESCRIPTION
* Make sure randomization is used unless it's explicitly disabled
* Make the supervisor assign _all_ of those weird ports WPT uses, even if we don't currently need them for tests.