### PR TITLE
Support Structured Logging at startup.

### DIFF
--- a/src/workerd/server/json-logger.h
+++ b/src/workerd/server/json-logger.h
@@ -6,6 +6,7 @@
 
 #include <kj/exception.h>
 #include <kj/function.h>
+#include <kj/main.h>
 #include <kj/string.h>
 
 namespace workerd::server {
@@ -26,6 +27,38 @@ class JsonLogger: public kj::ExceptionCallback {
 
  private:
   bool loggingInProgress = false;
+};
+
+class StructuredLoggingProcessContext final: public kj::ProcessContext {
+  // A ProcessContext implementation that supports both plain text and structured JSON logging.
+  // This context wraps TopLevelProcessContext and adds the ability to emit log messages in
+  // JSON format when structured logging is enabled.
+
+ public:
+  explicit StructuredLoggingProcessContext(kj::StringPtr programName);
+
+  // Enable structured JSON logging. This can only be called once and cannot be reversed.
+  // When enabled: Log messages are formatted as JSON and sent to stdout or stderr
+  //               This also enables an ExceptionCallback to replace KJ_LOGs with structured logs.
+  //               To reduce code duplication from TopLevelProcessContext, while JsonLogger sends
+  //               all logs to stdout, StructuredLoggingProcessContext sends all to the fd that
+  //               TopLevelProcessContext would have sent to.
+  // When disabled: Log messages are sent as plain text to stdout or stderr (like
+  //                TopLevelProcessContext)
+  void enableStructuredLogging();
+
+  kj::StringPtr getProgramName() override;
+  KJ_NORETURN(void exit() override);
+  void warning(kj::StringPtr message) const override;
+  void error(kj::StringPtr message) const override;
+  KJ_NORETURN(void exitError(kj::StringPtr message) override);
+  KJ_NORETURN(void exitInfo(kj::StringPtr message) override);
+  void increaseLoggingVerbosity() override;
+
+ private:
+  kj::TopLevelProcessContext topLevelContext;
+  kj::Maybe<JsonLogger> jsonLogger;
+  bool useStructuredLogging = false;
 };
 
 }  // namespace workerd::server

--- a/src/workerd/server/tests/structured-logging/BUILD.bazel
+++ b/src/workerd/server/tests/structured-logging/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+
+js_test(
+    name = "structured-logging-test",
+    data = [
+        ":structured-logging-json.wd-test",
+        "//src/workerd/server:workerd",
+    ],
+    entry_point = "structured-logging-test.mjs",
+    env = {
+        "WORKERD_BINARY": "$(rootpath //src/workerd/server:workerd)",
+        "WD_TEST_CONFIG": "$(rootpath :structured-logging-json.wd-test)",
+    },
+)

--- a/src/workerd/server/tests/structured-logging/structured-logging-json.wd-test
+++ b/src/workerd/server/tests/structured-logging/structured-logging-json.wd-test
@@ -1,0 +1,27 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (
+      name = "main",
+      worker = (
+        modules = [
+          (
+            name = "worker.js",
+            esModule = "invalid javascript syntax {{{"
+          )
+        ],
+        compatibilityDate = "2023-05-18",
+      )
+    )
+  ],
+  sockets = [
+    (
+      name = "http",
+      address = "*:8080",
+      http = (),
+      service = "main"
+    )
+  ],
+  structuredLogging = true
+);

--- a/src/workerd/server/tests/structured-logging/structured-logging-test.mjs
+++ b/src/workerd/server/tests/structured-logging/structured-logging-test.mjs
@@ -1,0 +1,73 @@
+import { spawn } from 'node:child_process';
+import { env } from 'node:process';
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+assert(
+  env.WORKERD_BINARY !== undefined,
+  'You must set the WORKERD_BINARY environment variable.'
+);
+assert(
+  env.WD_TEST_CONFIG !== undefined,
+  'You must set the WD_TEST_CONFIG environment variable.'
+);
+
+test('structured logging produces valid JSON with required fields', async () => {
+  const result = await new Promise((resolve) => {
+    let output = '';
+    const child = spawn(env.WORKERD_BINARY, ['test', env.WD_TEST_CONFIG], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    child.stdout.on('data', (data) => (output += data));
+    child.stderr.on('data', (data) => (output += data));
+    child.on('close', () => resolve(output));
+  });
+
+  // Parse as JSON - extract the first JSON line
+  let logEntry;
+  assert.doesNotThrow(() => {
+    // Split by lines and find the first valid JSON line
+    const lines = result.split('\n');
+    const jsonLine = lines.find((line) => line.trim().startsWith('{'));
+    assert(jsonLine, 'No JSON line found in output');
+    logEntry = JSON.parse(jsonLine);
+  }, `Output is not valid JSON: ${result}`);
+
+  // Verify required structure
+  assert.strictEqual(
+    typeof logEntry,
+    'object',
+    'Log entry should be an object'
+  );
+  assert(logEntry !== null, 'Log entry should not be null');
+
+  // Verify required fields exist with correct types
+  assert(
+    typeof logEntry.level === 'string',
+    `level should be string, got: ${typeof logEntry.level}`
+  );
+  assert(
+    typeof logEntry.message === 'string',
+    `message should be string, got: ${typeof logEntry.message}`
+  );
+  assert(
+    typeof logEntry.timestamp === 'string',
+    `timestamp should be string, got: ${typeof logEntry.timestamp}`
+  );
+
+  // Verify timestamp is a valid ISO date
+  assert.doesNotThrow(() => {
+    new Date(logEntry.timestamp);
+  }, `timestamp should be valid date: ${logEntry.timestamp}`);
+
+  // Verify error content is present in the message
+  assert(
+    logEntry.message.includes('SyntaxError'),
+    `Missing SyntaxError in message: ${logEntry.message}`
+  );
+  assert(
+    logEntry.message.includes('javascript'),
+    `Missing javascript reference in message: ${logEntry.message}`
+  );
+});


### PR DESCRIPTION
Many startup and config errors are logged through ProcessContext. These logs up until now were logged in plain text even when structuredLogging was enabled.

This change adds support for structured logging at startup. This change is still limited as any logs and errors during parsing of the configuration will still be logged as plain text.

But this should minimize those to the absolute minimum.


One important thing to note, in order to not duplicate any logic from TopLevelProcessContext, error logs from StructuredLoggingProcessContext go to STDERR instead of STDOUT.