### PR TITLE
Add name to container StartParams

### DIFF
--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -14,7 +14,8 @@ namespace workerd::api {
 
 Container::Container(rpc::Container::Client rpcClient, bool running)
     : rpcClient(IoContext::current().addObject(kj::heap(kj::mv(rpcClient)))),
-      running(running) {}
+      running(running),
+      name() {}
 
 void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions) {
   JSG_REQUIRE(!running, Error, "start() cannot be called on a container that is already running.");
@@ -45,6 +46,11 @@ void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions)
 
       list.set(i, str(field->name, "=", field->value));
     }
+  }
+
+  KJ_IF_SOME(name_, options.name) {
+    req.setName(name_);
+    name = kj::mv(name_);
   }
 
   IoContext::current().addTask(req.sendIgnoringResult());

--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -27,14 +27,19 @@ class Container: public jsg::Object {
     jsg::Optional<kj::Array<kj::String>> entrypoint;
     bool enableInternet = false;
     jsg::Optional<jsg::Dict<kj::String>> env;
+    jsg::Optional<kj::String> name;
 
     // TODO(containers): Allow intercepting stdin/stdout/stderr by specifying streams here.
 
-    JSG_STRUCT(entrypoint, enableInternet, env);
+    JSG_STRUCT(entrypoint, enableInternet, env, name);
   };
 
   bool getRunning() {
     return running;
+  }
+
+  jsg::Optional<kj::StringPtr> getName() {
+    return name;
   }
 
   // Methods correspond closely to the RPC interface in `container.capnp`.
@@ -48,6 +53,7 @@ class Container: public jsg::Object {
 
   JSG_RESOURCE_TYPE(Container) {
     JSG_READONLY_PROTOTYPE_PROPERTY(running, getRunning);
+    JSG_READONLY_PROTOTYPE_PROPERTY(name, getName);
     JSG_METHOD(start);
     JSG_METHOD(monitor);
     JSG_METHOD(destroy);
@@ -62,6 +68,7 @@ class Container: public jsg::Object {
  private:
   IoOwn<rpc::Container::Client> rpcClient;
   bool running;
+  kj::Maybe<kj::String> name;
 
   kj::Maybe<jsg::Value> destroyReason;
 

--- a/src/workerd/io/container.capnp
+++ b/src/workerd/io/container.capnp
@@ -34,6 +34,9 @@ interface Container @0x9aaceefc06523bca {
     # If null, the container will start with the environment variables defined in its image.
     # The format is defined as a list of `NAME=VALUE`.
     # The container runtime should validate the environment variables input.
+
+    name @3 :Text;
+    # The user-specified name of the container.
   }
 
   monitor @2 () -> (exitCode: Int32);

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -14,8 +14,11 @@ export class DurableObjectExample extends DurableObject {
 
     // Start container with valid configuration
     await container.start({
+      name: 'test-container-exit-code',
       entrypoint: ['node', 'nonexistant.js'],
     });
+
+    assert.strictEqual(container.name, 'test-container-exit-code');
 
     let exitCode = undefined;
     await container.monitor().catch((err) => {
@@ -37,10 +40,13 @@ export class DurableObjectExample extends DurableObject {
 
     // Start container with valid configuration
     await container.start({
+      name: 'test-container-basic',
       entrypoint: ['node', 'app.js'],
       env: { A: 'B', C: 'D', L: 'F' },
       enableInternet: true,
     });
+
+    assert.strictEqual(container.name, 'test-container-basic');
 
     const monitor = container.monitor().catch((_err) => {});
 


### PR DESCRIPTION
Also add it as a readonly property to the container object.

The name is passed into the containers runtime and made available via the API so that users can view container names in the Dash (rather than only DO actor IDs).