### PR TITLE
Avoid using obsolete internal compat flag apis

### DIFF
--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -16,7 +16,9 @@ import { Server, ServerResponse } from 'node-internal:internal_http_server';
 import type { IncomingMessageCallback } from 'node-internal:internal_http_util';
 import type { RequestOptions, ServerOptions, RequestListener } from 'node:http';
 import { ERR_METHOD_NOT_IMPLEMENTED } from 'node-internal:internal_errors';
-import { default as flags } from 'workerd:compatibility-flags';
+
+const enableNodejsHttpServerModules =
+  !!Cloudflare.compatibilityFlags['enable_nodejs_http_server_modules'];
 
 export function request(
   url: string | URL | RequestOptions,
@@ -40,7 +42,7 @@ export function createServer(
   options: ServerOptions,
   handler: RequestListener
 ): Server {
-  if (!flags.enableNodejsHttpServerModules) {
+  if (!enableNodejsHttpServerModules) {
     throw new ERR_METHOD_NOT_IMPLEMENTED('createServer');
   }
 

--- a/src/node/https.ts
+++ b/src/node/https.ts
@@ -6,12 +6,14 @@
 import { urlToHttpOptions, isURL } from 'node-internal:internal_url';
 import { ClientRequest } from 'node-internal:internal_http_client';
 import { Agent, globalAgent } from 'node-internal:internal_https_agent';
-import { default as flags } from 'workerd:compatibility-flags';
 import { ERR_METHOD_NOT_IMPLEMENTED } from 'node-internal:internal_errors';
 import { Server } from 'node-internal:internal_https_server';
 import type { IncomingMessageCallback } from 'node-internal:internal_http_util';
 import type { RequestOptions, RequestListener } from 'node:http';
 import type { ServerOptions } from 'node:https';
+
+const enableNodejsHttpServerModules =
+  !!Cloudflare.compatibilityFlags['enable_nodejs_http_server_modules'];
 
 export function request(
   url: string | URL | RequestOptions,
@@ -53,7 +55,7 @@ export function createServer(
   options: ServerOptions,
   handler: RequestListener
 ): Server {
-  if (!flags.enableNodejsHttpServerModules) {
+  if (!enableNodejsHttpServerModules) {
     throw new ERR_METHOD_NOT_IMPLEMENTED('createServer');
   }
 

--- a/src/node/internal/events.ts
+++ b/src/node/internal/events.ts
@@ -46,11 +46,13 @@ import {
 } from 'node-internal:validators';
 import { spliceOne } from 'node-internal:internal_utils';
 import { nextTick, emitWarning } from 'node-internal:internal_process';
-import { default as flags } from 'workerd:compatibility-flags';
 import { default as async_hooks } from 'node-internal:async_hooks';
 const { AsyncResource } = async_hooks;
 
 import { inspect } from 'node-internal:internal_inspect';
+
+const enableNodejsProcessV2 =
+  !!Cloudflare.compatibilityFlags['enable_nodejs_process_v2'];
 
 const kRejection = Symbol.for('nodejs.rejection');
 const kCapture = Symbol('kCapture');
@@ -520,7 +522,7 @@ function _addListener(
         }
       );
       // Only the newer process version compat adds process.emitWarning support.
-      if (flags.enableNodejsProcessV2) emitWarning(w);
+      if (enableNodejsProcessV2) emitWarning(w);
     }
   }
 

--- a/src/node/internal/internal_http_server.ts
+++ b/src/node/internal/internal_http_server.ts
@@ -64,7 +64,9 @@ import type {
   OutgoingHttpHeader,
 } from 'node:http';
 import type { Socket, AddressInfo } from 'node:net';
-import { default as flags } from 'workerd:compatibility-flags';
+
+const enableNodejsHttpServerModules =
+  !!Cloudflare.compatibilityFlags['enable_nodejs_http_server_modules'];
 
 export const kConnectionsCheckingInterval = Symbol(
   'http.server.connectionsCheckingInterval'
@@ -103,7 +105,7 @@ export class Server
   #port: number | null = null;
 
   constructor(options?: ServerOptions, requestListener?: RequestListener) {
-    if (!flags.enableNodejsHttpServerModules) {
+    if (!enableNodejsHttpServerModules) {
       throw new ERR_METHOD_NOT_IMPLEMENTED('Server');
     }
     super();
@@ -357,7 +359,7 @@ export class ServerResponse<Req extends IncomingMessage = IncomingMessage>
   }
 
   constructor(req: Req, options: ServerOptions = {}) {
-    if (!flags.enableNodejsHttpServerModules) {
+    if (!enableNodejsHttpServerModules) {
       throw new ERR_METHOD_NOT_IMPLEMENTED('ServerResponse');
     }
 

--- a/src/node/internal/process.d.ts
+++ b/src/node/internal/process.d.ts
@@ -6,6 +6,12 @@ export function setCwd(path: string): void;
 export const versions: Record<string, string>;
 export const platform: string;
 
+declare global {
+  const Cloudflare: {
+    readonly compatibilityFlags: Record<string, boolean>;
+  };
+}
+
 interface ErrorWithDetail extends Error {
   detail?: unknown;
 }

--- a/src/node/internal/public_process.ts
+++ b/src/node/internal/public_process.ts
@@ -21,7 +21,6 @@ import { parseEnv } from 'node-internal:internal_utils';
 import { Writable } from 'node-internal:streams_writable';
 import { writeSync } from 'node-internal:internal_fs_sync';
 import { ReadStream } from 'node-internal:internal_fs_streams';
-import { default as flags } from 'workerd:compatibility-flags';
 import type * as NodeFS from 'node:fs';
 import {
   platform,
@@ -35,6 +34,9 @@ import { validateString } from 'node-internal:validators';
 import type { Readable } from 'node-internal:streams_readable';
 
 export { platform, nextTick, emitWarning, env, features };
+
+const workerdExperimental = !!Cloudflare.compatibilityFlags['experimental'];
+const nodeJsCompat = !!Cloudflare.compatibilityFlags['nodejs_compat'];
 
 // For stdin, we emulate `node foo.js < /dev/null`
 export const stdin = new ReadStream(null, {
@@ -249,7 +251,7 @@ export function uptime(): number {
 }
 
 export function loadEnvFile(path: string | URL | Buffer = '.env'): void {
-  if (!flags.workerdExperimental || !flags.nodeJsCompat) {
+  if (!workerdExperimental || !nodeJsCompat) {
     throw new ERR_UNSUPPORTED_OPERATION();
   }
   const { readFileSync } = process.getBuiltinModule('fs') as typeof NodeFS;


### PR DESCRIPTION
PR against the dev branch...

Refs: https://github.com/cloudflare/workerd/pull/4591
Refs: https://github.com/cloudflare/workerd/pull/4630

Use the globalThis.Cloudflare API instead of the obsolete internal.