### PR TITLE
Implements support for Python in dynamic workers.

### DIFF
--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -72,6 +72,7 @@ def _make_bundle_version_info(versions):
         if name != "development":
             entry["id"] = _bundle_id(**entry)
         entry["feature_flags"] = [entry["flag"]]
+        entry["feature_string_flags"] = [entry["enable_flag_name"]]
         if "packages" in entry:
             entry["packages"] = entry["packages"]["info"]["tag"]
         _add_integrity(entry)
@@ -92,6 +93,7 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
         "backport": "63",
         "integrity": "sha256-xrG65VJvao9GYH07C73Uq2jA9DW7O1DP16fiZo36Xq0=",
         "flag": "pythonWorkers",
+        "enable_flag_name": "python_workers",
         "emscripten_version": "3.1.52",
         "python_version": "3.12.1",
         "baseline_snapshot": "baseline-d13ce2f4a.bin",
@@ -121,6 +123,7 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
         "backport": "2",
         "integrity": "sha256-04qtaf3jr6q7mixWrpeASgYzTW1WHb9NEILBGl8M9hk=",
         "flag": "pythonWorkers20250116",
+        "enable_flag_name": "python_workers_20250116",
         "emscripten_version": "3.1.58",
         "python_version": "3.12.7",
         "baseline_snapshot": "baseline-59fa311f4.bin",
@@ -149,5 +152,6 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
         "pyodide_date": "dev",
         "id": "dev",
         "flag": "pythonWorkersDevPyodide",
+        "enable_flag_name": "python_workers_development",
     },
 ])

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -758,6 +758,7 @@ wd_test(
 )
 
 wd_test(
+    size = "large",
     src = "worker-loader-test.wd-test",
     args = ["--experimental"],
     data = ["worker-loader-test.js"],

--- a/src/workerd/api/worker-loader.h
+++ b/src/workerd/api/worker-loader.h
@@ -59,8 +59,9 @@ class WorkerLoader: public jsg::Object {
     jsg::Optional<kj::Array<const byte>> data;  // byte blob, imports as ArrayBuffer
     jsg::Optional<jsg::Value> json;             // arbitrary JS value, will be serialized to JSON
                                                 // and then parsed again when imported
+    jsg::Optional<kj::String> py;               // Python module
 
-    JSG_STRUCT(js, cjs, text, data, json);
+    JSG_STRUCT(js, cjs, text, data, json, py);
 
     // HACK: When we serialize the JSON in extractSource() we need to place the owned kj::String
     //   somewhere since Worker::Script::Source only gets a kj::StringPtr.


### PR DESCRIPTION
### Test Plan

```
bazel run @workerd//src/workerd/api:worker-loader-test
```