### PR TITLE
[nfc] Avoid two instances of use-after-move

### DIFF
--- a/src/workerd/api/headers.c++
+++ b/src/workerd/api/headers.c++
@@ -550,7 +550,7 @@ Headers::Header::Header(jsg::Lock& js,
       values(kj::mv(values)),
       memoryAdjustment(js.getExternalMemoryAdjustment(0)) {
   size_t totalSize = 0;
-  KJ_IF_SOME(str, nameOrIndex.tryGet<kj::String>()) {
+  KJ_IF_SOME(str, this->nameOrIndex.tryGet<kj::String>()) {
     totalSize = str.size();
   }
   for (const auto& value: this->values) {

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -442,7 +442,10 @@ KJ_TEST("External memory adjustment") {
       adjuster.set(100);
       auto adjuster2 = kj::mv(adjuster);
       KJ_ASSERT(adjuster2.getAmount() == 100);
-      KJ_ASSERT(adjuster.getAmount() == 0);
+
+      // Checking that the amount is zero after the adjuster is moved away would be nice to have,
+      // but we should aim to avoid use-after-move entirely.
+      // KJ_ASSERT(adjuster.getAmount() == 0);
     }
     // Note that we are not testing the actual effect on the isolate itself here.
     // While we have added a getExternalMemory() API to the isolate via a patch in

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -34,13 +34,13 @@ struct OpaqueWrappable<T, false>: public Wrappable {
   T value;
   bool movedAway = false;
 
-  kj::StringPtr jsgGetMemoryName() const override {
+  kj::StringPtr jsgGetMemoryName() const override final {
     return "OpaqueWrappable"_kjc;
   }
-  size_t jsgGetMemorySelfSize() const override {
+  size_t jsgGetMemorySelfSize() const override final {
     return sizeof(OpaqueWrappable);
   }
-  void jsgGetMemoryInfo(MemoryTracker& tracker) const override {
+  void jsgGetMemoryInfo(MemoryTracker& tracker) const override final {
     Wrappable::jsgGetMemoryInfo(tracker);
   }
 };
@@ -50,16 +50,6 @@ struct OpaqueWrappable<T, true>: public OpaqueWrappable<T, false> {
   // When T is GC-visitable, make sure to implement visitation.
 
   using OpaqueWrappable<T, false>::OpaqueWrappable;
-
-  kj::StringPtr jsgGetMemoryName() const override {
-    return "OpaqueWrappable"_kjc;
-  }
-  size_t jsgGetMemorySelfSize() const override {
-    return sizeof(OpaqueWrappable);
-  }
-  void jsgGetMemoryInfo(MemoryTracker& tracker) const override {
-    Wrappable::jsgGetMemoryInfo(tracker);
-  }
 
   void jsgVisitForGc(GcVisitor& visitor) override {
     if (!this->movedAway) {
@@ -796,7 +786,6 @@ class UnhandledRejectionHandler {
 
   kj::Function<Handler> handler;
   bool scheduled = false;
-  size_t rejectionCount = 0;
 
   using UnhandledRejectionsTable =
       kj::Table<UnhandledRejection, kj::HashIndex<UnhandledRejectionCallbacks>>;


### PR DESCRIPTION
- [nfc] Avoid two instances of use-after-move
One of these only affects a test, but the other one could lead to memory not being fully accounted for.

- [nfc] drive-by: Clean up superfluous JSG promise code
rejectionCount was only partially cleaned up and caused a compiler warning, for OpaqueWrapper<T, true> we can inherit the identical methods from the superclass and don't need to define them again.
