### PR TITLE
[o11y] Assorted Streaming Tail Worker bug fixes

### DIFF
--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -761,7 +761,10 @@ class TailStreamTarget final: public rpc::TailStreamTarget::Server {
 
     // Invoke the tailStream handler function.
     v8::Local<v8::Function> fn = maybeFn.As<v8::Function>();
-    auto maybeCtx = KJ_ASSERT_NONNULL(handler->getCtx()).tryGetHandle(js);
+    kj::Maybe<v8::Local<v8::Object>> maybeCtx;
+    KJ_IF_SOME(hCtx, handler->getCtx()) {
+      maybeCtx = hCtx.tryGetHandle(js);
+    }
     v8::LocalVector<v8::Value> handlerArgs(js.v8Isolate, maybeCtx != kj::none ? 3 : 2);
     handlerArgs[0] = ToJs(js, event, stringCache);
     handlerArgs[1] = handler->env.getHandle(js);


### PR DESCRIPTION
This may address two bugs seen in testing (which have not been reproduced yet).
- Do not provide outcome event for pipelineLogLevel == PipelineLogLevel::NONE, we already don't provide the other event types there (matching the legacy tail worker).
- Do not assert that a handler context is available.