### PR TITLE
Resolve several multiple-bool-args lints

### DIFF
--- a/src/workerd/api/crypto/crc-impl.c++
+++ b/src/workerd/api/crypto/crc-impl.c++
@@ -34,6 +34,7 @@ constexpr T reverse(T value) {
 }
 
 template <Uint64OrUint32 T>
+// NOLINTNEXTLINE(edgeworker-multiple-bool-args)
 constexpr std::array<T, crcTableSize> gen_crc_table(T polynomial, bool reflectIn, bool reflectOut) {
   constexpr auto numIterations = sizeof(polynomial) * 8;  // number of bits in polynomial
   auto crcTable = std::array<T, crcTableSize>{};


### PR DESCRIPTION
Soon, I intend to land a new clang-tidy plugin downstream which squawks if we have functions which accept more than one boolean parameter.

We run our clang-tidy with warnings-as-errors for as much of our codebase as we can, including some workerd directories. This PR resolves the lints which cropped up in workerd when I ran it.

In doing so, I discovered a couple minor bugs in our heap snapshot functionality.