### PR TITLE
Revert "Only log ActorCache::deleteAll errors to sentry if they're interesting"

### DIFF
--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -3032,11 +3032,7 @@ kj::Promise<void> ActorCache::flushImplDeleteAll(uint retryCount) {
       e.setDescription(kj::str("broken.outputGateBroken; ", msg));
       return kj::mv(e);
     } else {
-      if (isInterestingException(e)) {
-        LOG_EXCEPTION("actorCacheDeleteAll", e);
-      } else {
-        LOG_NOSENTRY(ERROR, "actorCacheDeleteAll failed", e);
-      }
+      LOG_EXCEPTION("actorCacheDeleteAll", e);
       // Pass through exception type to convey appropriate retry behavior.
       return kj::Exception(e.getType(), __FILE__, __LINE__,
           kj::str(


### PR DESCRIPTION
Reverts cloudflare/workerd#4533

This change silenced reports of network disconnects _to DO storage_ which are causing DOs to reset. This is a real problem, not something which we can ignore. This can be assigned to the DO team to address, but the runtime team should not be silencing DO errors without input from the DO team.