### PR TITLE
macOS CI: use sandbox for building even if we can't use it for tests

### DIFF
--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -80,7 +80,7 @@ build:ci-macOS --copt=-UDEBUG
 build:ci-macOS-debug --config=debug
 
 # Unfortunately on macOS, we need to be able to invoke sudo to configure the network for sidecar tests
-build:ci-macOS --spawn_strategy=local
+test:ci-macOS --spawn_strategy=local
 
 build:ci-windows --config=windows_no_dbg
 build:ci-windows-debug --config=debug


### PR DESCRIPTION
We can't use the sandbox to execute tests because it interferes with sidecar IP randomization. But we can still use it for builds. This might work around an tsc bug (https://github.com/microsoft/TypeScript/issues/22208). However, this only fixes macOS. Problems can still happen on Windows because there is no bazel sandboxing there to begin with.