### PR TITLE
Fixup node:fs callback api arg checks

### DIFF
--- a/src/node/internal/internal_fs.ts
+++ b/src/node/internal/internal_fs.ts
@@ -7,7 +7,10 @@ import {
   UV_DIRENT_FIFO,
   UV_DIRENT_SOCKET,
 } from 'node-internal:internal_fs_constants';
-import { type FilePath } from 'node-internal:internal_fs_utils';
+import {
+  type FilePath,
+  type ValidEncoding,
+} from 'node-internal:internal_fs_utils';
 import {
   default as cffs,
   type DirEntryHandle,
@@ -65,7 +68,7 @@ export class Dirent {
 }
 
 export interface DirOptions {
-  encoding?: BufferEncoding | null | undefined | 'buffer';
+  encoding?: ValidEncoding | undefined;
 }
 
 export type DirentReadCallback = (
@@ -79,7 +82,7 @@ export class Dir {
   // of DirEntryHandle objects just like the one used in the readdir
   // API.
   #handle: DirEntryHandle[] | undefined;
-  #encoding: BufferEncoding | null | undefined | 'buffer';
+  #encoding: ValidEncoding | undefined;
   #path: FilePath;
 
   constructor(

--- a/src/node/internal/internal_fs_callback.ts
+++ b/src/node/internal/internal_fs_callback.ts
@@ -54,6 +54,7 @@ import {
   type SymlinkType,
   type ReadDirOptions,
   type WriteSyncOptions,
+  type ValidEncoding,
   getValidatedFd,
   validateBufferArray,
   stringToFlags,
@@ -534,16 +535,34 @@ export function mkdir(
 
 export function mkdtemp(
   prefix: FilePath,
-  optionsOrCallback: SingleArgCallback<string> | MkdirTempSyncOptions,
+  optionsOrCallback:
+    | SingleArgCallback<string>
+    | MkdirTempSyncOptions
+    | BufferEncoding
+    | 'buffer'
+    | null,
   callback?: SingleArgCallback<string>
 ): void {
-  let options: MkdirTempSyncOptions;
+  let options: MkdirTempSyncOptions | ValidEncoding;
   if (typeof optionsOrCallback === 'function') {
     callback = optionsOrCallback;
     options = {};
   } else {
     options = optionsOrCallback;
   }
+  if (typeof options === 'string' || options == null) {
+    options = { encoding: options };
+  }
+  validateObject(options, 'options');
+  const { encoding = null } = options;
+  if (
+    encoding !== null &&
+    encoding !== 'buffer' &&
+    !Buffer.isEncoding(encoding)
+  ) {
+    throw new ERR_INVALID_ARG_VALUE('options.encoding', encoding);
+  }
+
   callWithSingleArgCallback(
     () => fssync.mkdtempSync(prefix, options),
     callback
@@ -884,10 +903,15 @@ export function read<T extends NodeJS.ArrayBufferView>(
 
 export function readdir(
   path: FilePath,
-  optionsOrCallback: SingleArgCallback<ReadDirResult> | ReadDirOptions,
+  optionsOrCallback:
+    | SingleArgCallback<ReadDirResult>
+    | ReadDirOptions
+    | BufferEncoding
+    | 'buffer'
+    | null,
   callback?: SingleArgCallback<ReadDirResult>
 ): void {
-  let options: ReadDirOptions;
+  let options: ReadDirOptions | ValidEncoding;
   if (typeof optionsOrCallback === 'function') {
     callback = optionsOrCallback;
     options = {
@@ -922,13 +946,27 @@ export function readFile(
     | ReadFileSyncOptions,
   callback?: SingleArgCallback<string | Buffer>
 ): void {
-  let options: BufferEncoding | null | ReadFileSyncOptions;
+  let options: ValidEncoding | ReadFileSyncOptions;
   if (typeof optionsOrCallback === 'function') {
     callback = optionsOrCallback;
     options = {};
   } else {
     options = optionsOrCallback;
   }
+
+  if (typeof options === 'string' || options == null) {
+    options = { encoding: options };
+  }
+  validateObject(options, 'options');
+  const { encoding = null } = options;
+  if (
+    encoding !== null &&
+    encoding !== 'buffer' &&
+    !Buffer.isEncoding(encoding)
+  ) {
+    throw new ERR_INVALID_ARG_VALUE('options.encoding', encoding);
+  }
+
   // TODO(node-fs): Validate options more. Specifically the encoding option
   callWithSingleArgCallback(() => fssync.readFileSync(path, options), callback);
 }
@@ -942,12 +980,15 @@ export function readlink(
     | ReadLinkSyncOptions,
   callback?: SingleArgCallback<string | Buffer>
 ): void {
-  let options: BufferEncoding | 'buffer' | null | ReadLinkSyncOptions;
+  let options: ValidEncoding | ReadLinkSyncOptions;
   if (typeof optionsOrCallback === 'function') {
     callback = optionsOrCallback;
     options = {};
   } else {
     options = optionsOrCallback;
+  }
+  if (typeof options === 'string' || options == null) {
+    options = { encoding: options };
   }
   path = normalizePath(path);
   validateObject(options, 'options');
@@ -998,12 +1039,16 @@ export function realpath(
     | ReadLinkSyncOptions,
   callback?: SingleArgCallback<string | Buffer>
 ): void {
-  let options: BufferEncoding | null | ReadLinkSyncOptions;
+  let options: ValidEncoding | ReadLinkSyncOptions;
   if (typeof optionsOrCallback === 'function') {
     callback = optionsOrCallback;
     options = {};
   } else {
     options = optionsOrCallback;
+  }
+
+  if (typeof options === 'string' || options == null) {
+    options = { encoding: options };
   }
 
   validateObject(options, 'options');
@@ -1182,7 +1227,7 @@ export function write<T extends NodeJS.ArrayBufferView>(
   callback?: DoubleArgCallback<number, T>
 ): void {
   let offsetOrOptions: WriteSyncOptions | Position | undefined;
-  let lengthOrEncoding: number | BufferEncoding | null | undefined;
+  let lengthOrEncoding: number | ValidEncoding | undefined;
   let position: Position | undefined;
   if (typeof offsetOptionsPositionOrCallback === 'function') {
     callback = offsetOptionsPositionOrCallback;
@@ -1255,7 +1300,7 @@ export function writeFile(
     | WriteFileOptions,
   callback?: ErrorOnlyCallback
 ): void {
-  let options: BufferEncoding | null | WriteFileOptions;
+  let options: ValidEncoding | WriteFileOptions;
   if (typeof optionsOrCallback === 'function') {
     callback = optionsOrCallback;
     options = {

--- a/src/node/internal/internal_fs_callback.ts
+++ b/src/node/internal/internal_fs_callback.ts
@@ -538,9 +538,7 @@ export function mkdtemp(
   optionsOrCallback:
     | SingleArgCallback<string>
     | MkdirTempSyncOptions
-    | BufferEncoding
-    | 'buffer'
-    | null,
+    | ValidEncoding,
   callback?: SingleArgCallback<string>
 ): void {
   let options: MkdirTempSyncOptions | ValidEncoding;

--- a/src/node/internal/internal_fs_callback.ts
+++ b/src/node/internal/internal_fs_callback.ts
@@ -904,9 +904,7 @@ export function readdir(
   optionsOrCallback:
     | SingleArgCallback<ReadDirResult>
     | ReadDirOptions
-    | BufferEncoding
-    | 'buffer'
-    | null,
+    | ValidEncoding,
   callback?: SingleArgCallback<ReadDirResult>
 ): void {
   let options: ReadDirOptions | ValidEncoding;

--- a/src/node/internal/internal_fs_promises.ts
+++ b/src/node/internal/internal_fs_promises.ts
@@ -59,6 +59,7 @@ import {
   type FilePath,
   type ReadDirOptions,
   type WriteSyncOptions,
+  type ValidEncoding,
 } from 'node-internal:internal_fs_utils';
 import type { Dirent } from 'node-internal:internal_fs';
 import { Buffer } from 'node-internal:internal_buffer';
@@ -217,7 +218,7 @@ export class FileHandle extends EventEmitter {
   }
 
   async readFile(
-    options: BufferEncoding | null | ReadFileSyncOptions = {}
+    options: ValidEncoding | ReadFileSyncOptions = {}
   ): Promise<string | Buffer> {
     if (this.#fd === undefined) {
       throw new ERR_EBADF({ syscall: 'stat' });
@@ -256,7 +257,7 @@ export class FileHandle extends EventEmitter {
   async write(
     buffer: NodeJS.ArrayBufferView | string,
     offsetPositionOrOptions: WriteSyncOptions | Position = null,
-    lengthOrEncoding?: number | BufferEncoding | null,
+    lengthOrEncoding?: number | ValidEncoding,
     position: Position = null
   ): Promise<{ bytesWritten: number; buffer: NodeJS.ArrayBufferView }> {
     if (this.#fd === undefined) {
@@ -297,7 +298,7 @@ export class FileHandle extends EventEmitter {
 
   async writeFile(
     data: string | Buffer,
-    options: BufferEncoding | null | WriteFileOptions = {}
+    options: ValidEncoding | WriteFileOptions = {}
   ): Promise<{ bytesWritten: number; buffer: Buffer }> {
     if (this.#fd === undefined) {
       throw new ERR_EBADF({ syscall: 'stat' });
@@ -491,21 +492,21 @@ export function readdir(
 
 export function readFile(
   path: number | FilePath,
-  options: BufferEncoding | null | ReadFileSyncOptions = {}
+  options: ValidEncoding | ReadFileSyncOptions = {}
 ): Promise<string | Buffer> {
   return Promise.try(() => fssync.readFileSync(path, options));
 }
 
 export function readlink(
   path: FilePath,
-  options: BufferEncoding | null | ReadLinkSyncOptions = {}
+  options: ValidEncoding | ReadLinkSyncOptions = {}
 ): Promise<string | Buffer> {
   return Promise.try(() => fssync.readlinkSync(path, options));
 }
 
 export function realpath(
   path: FilePath,
-  options: BufferEncoding | null | ReadLinkSyncOptions = {}
+  options: ValidEncoding | ReadLinkSyncOptions = {}
 ): Promise<string | Buffer> {
   return Promise.try(() => fssync.realpathSync(path, options));
 }
@@ -568,7 +569,7 @@ export function watch(): Promise<void> {
 export function writeFile(
   path: number | FilePath,
   data: string | ArrayBufferView,
-  options: BufferEncoding | null | WriteFileOptions = {}
+  options: ValidEncoding | WriteFileOptions = {}
 ): Promise<void> {
   return Promise.try(() => {
     // While writeFileSync returns the number of bytes written,

--- a/src/node/internal/internal_fs_sync.ts
+++ b/src/node/internal/internal_fs_sync.ts
@@ -38,6 +38,7 @@ import {
   type SymlinkType,
   type ReadDirOptions,
   type WriteSyncOptions,
+  type ValidEncoding,
   validatePosition,
   validateAccessArgs,
   validateChownArgs,
@@ -134,10 +135,10 @@ export function accessSync(path: FilePath, mode: number = F_OK): void {
 export function appendFileSync(
   path: number | FilePath,
   data: string | ArrayBufferView,
-  options: BufferEncoding | null | WriteFileOptions = {}
+  options: ValidEncoding | WriteFileOptions = {}
 ): number {
   if (typeof options === 'string' || options == null) {
-    options = { encoding: options as BufferEncoding | null };
+    options = { encoding: options as BufferEncoding };
   }
   const {
     encoding = 'utf8',
@@ -441,12 +442,12 @@ export function mkdirSync(
 }
 
 export type MkdirTempSyncOptions = {
-  encoding?: BufferEncoding | null | undefined;
+  encoding?: ValidEncoding | undefined;
 };
 
 export function mkdtempSync(
   prefix: FilePath,
-  options: BufferEncoding | null | MkdirTempSyncOptions = {}
+  options: ValidEncoding | MkdirTempSyncOptions = {}
 ): string {
   if (typeof options === 'string' || options == null) {
     options = { encoding: options };
@@ -509,7 +510,7 @@ export type ReadDirResult = string[] | Buffer[] | Dirent[];
 
 export function readdirSync(
   path: FilePath,
-  options: BufferEncoding | 'buffer' | null | ReadDirOptions = {}
+  options: ValidEncoding | ReadDirOptions = {}
 ): ReadDirResult {
   if (typeof options === 'string' || options == null) {
     options = { encoding: options };
@@ -545,18 +546,18 @@ export function readdirSync(
   }
 
   return handles.map((handle) => {
-    return Buffer.from(handle.name).toString(encoding);
+    return Buffer.from(handle.name).toString(encoding as string);
   });
 }
 
 export type ReadFileSyncOptions = {
-  encoding?: BufferEncoding | 'buffer' | null | undefined;
+  encoding?: ValidEncoding | undefined;
   flag?: string | number | undefined;
 };
 
 export function readFileSync(
   pathOrFd: number | FilePath,
-  options: BufferEncoding | 'buffer' | null | ReadFileSyncOptions = {}
+  options: ValidEncoding | ReadFileSyncOptions = {}
 ): string | Buffer {
   if (typeof options === 'string' || options == null) {
     options = { encoding: options };
@@ -589,12 +590,12 @@ export function readFileSync(
 }
 
 export type ReadLinkSyncOptions = {
-  encoding?: BufferEncoding | 'buffer' | null | undefined;
+  encoding?: ValidEncoding | undefined;
 };
 
 export function readlinkSync(
   path: FilePath,
-  options: BufferEncoding | 'buffer' | null | ReadLinkSyncOptions = {}
+  options: ValidEncoding | ReadLinkSyncOptions = {}
 ): string | Buffer {
   if (typeof options === 'string' || options == null) {
     options = { encoding: options };
@@ -657,7 +658,7 @@ export function readvSync(
 
 export function realpathSync(
   p: FilePath,
-  options: BufferEncoding | null | ReadLinkSyncOptions = {}
+  options: ValidEncoding | ReadLinkSyncOptions = {}
 ): string | Buffer {
   if (typeof options === 'string' || options == null) {
     options = { encoding: options };
@@ -786,7 +787,7 @@ export function utimesSync(
 export function writeFileSync(
   path: number | FilePath,
   data: string | ArrayBufferView,
-  options: BufferEncoding | null | WriteFileOptions = {}
+  options: ValidEncoding | WriteFileOptions = {}
 ): number {
   const {
     path: validatedPath,
@@ -802,7 +803,7 @@ export function writeSync(
   fd: number,
   buffer: NodeJS.ArrayBufferView | string,
   offsetOrOptions: WriteSyncOptions | Position = null,
-  length?: number | BufferEncoding | null,
+  length?: number | ValidEncoding,
   position?: Position
 ): number {
   const {

--- a/src/node/internal/internal_fs_utils.ts
+++ b/src/node/internal/internal_fs_utils.ts
@@ -83,6 +83,8 @@ import type {
   WriteFileOptions,
 } from 'node:fs';
 
+export type ValidEncoding = BufferEncoding | 'buffer' | null;
+
 import type { Stat as InternalStat } from 'cloudflare-internal:filesystem';
 
 // A non-public symbol used to ensure that certain constructors cannot
@@ -313,20 +315,23 @@ export function validateRmDirArgs(
 // We could use the @types/node definition here but it's a bit overly
 // complex for our needs here.
 export type ReadDirOptions = {
-  encoding?: BufferEncoding | 'buffer' | null | undefined;
+  encoding?: ValidEncoding | undefined;
   withFileTypes?: boolean | undefined;
   recursive?: boolean | undefined;
 };
 
 export function validateReaddirArgs(
   path: FilePath,
-  options: ReadDirOptions
+  options: ReadDirOptions | ValidEncoding
 ): {
   path: URL;
-  encoding: BufferEncoding | 'buffer';
+  encoding: ValidEncoding;
   withFileTypes: boolean;
   recursive: boolean;
 } {
+  if (typeof options === 'string' || options == null) {
+    options = { encoding: options };
+  }
   validateObject(options, 'options');
   const {
     encoding = 'utf8',
@@ -351,7 +356,7 @@ export function validateOpendirArgs(
   options: OpenDirOptions
 ): {
   path: URL;
-  encoding: BufferEncoding | null | 'buffer';
+  encoding: ValidEncoding;
   recursive: boolean;
 } {
   validateObject(options, 'options');
@@ -381,7 +386,7 @@ export function validateWriteArgs(
   fd: number,
   buffer: NodeJS.ArrayBufferView | string,
   offsetOrOptions: WriteSyncOptions | Position | undefined,
-  length: number | BufferEncoding | null | undefined,
+  length: number | ValidEncoding | undefined,
   position: Position | undefined
 ): { fd: number; buffer: Buffer[]; position: Position } {
   fd = getValidatedFd(fd);
@@ -434,7 +439,7 @@ export function validateWriteArgs(
 export function validateWriteFileArgs(
   path: number | FilePath,
   data: string | ArrayBufferView,
-  options: BufferEncoding | null | WriteFileOptions
+  options: ValidEncoding | WriteFileOptions
 ): {
   path: number | URL;
   data: NodeJS.ArrayBufferView;

--- a/src/workerd/api/node/tests/fs-test.js
+++ b/src/workerd/api/node/tests/fs-test.js
@@ -38,11 +38,10 @@ import {
   writeFile,
   appendFile,
   read,
-  // TODO(node-fs): Uncomment when relevant tests are provided.
-  // readdir,
-  // readlink,
-  // realpath,
-  // mkdtemp,
+  readdir,
+  readlink,
+  realpath,
+  mkdtemp,
   ReadStream,
   WriteStream,
   readdirSync,
@@ -1098,12 +1097,26 @@ export const readBadEncoding = {
       throw new Error('This function must not be called');
     }
 
-    // TODO(node-fs): Enable these tests once encoding is verified correctly
-    // throws(() => readFile('/tmp/test.txt', 'bad-encoding', mustNotCall), kErrorObj);
-    // throws(() => readdir('/tmp/test.txt', 'bad-encoding', mustNotCall), kErrorObj);
-    // throws(() => readlink('/tmp/test.txt', 'bad-encoding', mustNotCall), kErrorObj);
-    // throws(() => realpath('/tmp/test.txt', 'bad-encoding', mustNotCall), kErrorObj);
-    // throws(() => mkdtemp('/tmp/test.txt', 'bad-encoding', mustNotCall), kErrorObj);
+    throws(
+      () => readFile('/tmp/test.txt', 'bad-encoding', mustNotCall),
+      kErrorObj
+    );
+    throws(
+      () => readdir('/tmp/test.txt', 'bad-encoding', mustNotCall),
+      kErrorObj
+    );
+    throws(
+      () => readlink('/tmp/test.txt', 'bad-encoding', mustNotCall),
+      kErrorObj
+    );
+    throws(
+      () => realpath('/tmp/test.txt', 'bad-encoding', mustNotCall),
+      kErrorObj
+    );
+    throws(
+      () => mkdtemp('/tmp/test.txt', 'bad-encoding', mustNotCall),
+      kErrorObj
+    );
   },
 };
 


### PR DESCRIPTION
Fixup some node:fs callback API arguments checks and simplify type defs for encodings.