### PR TITLE
Validator baseline fixes and addition of vendored test for fastapi.

### DIFF
--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -417,8 +417,7 @@ function decodeSnapshot(
     return undefined;
   }
   if (reader.getMemorySnapshotSize() === 0) {
-    // TODO: This code path happens in the validator. It shouldn't.
-    return undefined;
+    throw new Error(`SnapshotReader returned memory snapshot size of 0`);
   }
   const header = new Uint32Array(4);
   reader.readMemorySnapshot(0, header);


### PR DESCRIPTION
Just a simple change to throw a meaningful error if the snapshot we read has a size of 0.