### PR TITLE
[o11y] Log stack trace for tail event after close error

### DIFF
--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -711,6 +711,8 @@ auto TraceCustomEventImpl::run(kj::Own<IoContext::IncomingRequest> incomingReque
   waitUntilTasks.add(sendTracesToExportedHandler(
       kj::mv(incomingRequest), entrypointNamePtr, kj::mv(props), traces));
 
+  // Reporting a proper return code here would be nice, but for that we'd need to await running the
+  // tail handler...
   return Result{
     .outcome = EventOutcome::OK,
   };

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -35,7 +35,7 @@ void TailStreamWriter::report(const InvocationSpanContext& context, TailEvent::E
   // been closed.
   // This could be an assert, but just log an error in case this is prevalent in some edge case.
   if (outcomeSeen) {
-    KJ_LOG(ERROR, "reported tail stream event after stream close ", event);
+    KJ_LOG(ERROR, "reported tail stream event after stream close ", event, kj::getStackTrace());
   }
   auto& s = KJ_UNWRAP_OR_RETURN(state);
 


### PR DESCRIPTION
This bug is proving quite stubborn, gather more information