### PR TITLE
Implement vfs path limits

### DIFF
--- a/src/workerd/api/filesystem.c++
+++ b/src/workerd/api/filesystem.c++
@@ -59,6 +59,22 @@ struct NormalizedFilePath {
   void validate() {
     JSG_REQUIRE(url.getProtocol() == "file:"_kj, TypeError, "File path must be a file: URL");
     JSG_REQUIRE(url.getHost().size() == 0, Error, "File path must not have a host");
+
+    // Let's count the number of path segments in the URL. We want to make sure that
+    // it does not have more than 48 segments. Why 48? Great question! It's a completely
+    // arbitrary limit that we set to prevent excessively long paths that could lead to
+    // performance issues.
+    // We also limit the maximum total length of the path to 4096 characters.
+    auto pathname = url.getPathname();
+    JSG_REQUIRE(pathname.size() <= 4096, Error, "File path is too long"_kj);
+
+    uint32_t segmentCount = 0;
+    for (auto i: kj::indices(pathname)) {
+      if (pathname[i] == '/') {
+        segmentCount++;
+      }
+    }
+    JSG_REQUIRE(segmentCount <= 48, Error, "File path has too many segments"_kj);
   }
 
   operator const jsg::Url&() const {

--- a/src/workerd/api/node/tests/fs-misc-test.js
+++ b/src/workerd/api/node/tests/fs-misc-test.js
@@ -144,3 +144,19 @@ export const statFsTest = {
     });
   },
 };
+
+export const pathLimitTest = {
+  test() {
+    // Trying to open a path longer than 4096 characters should throw an error.
+    const longPath = '/tmp/a'.repeat(4097);
+    throws(() => openSync(longPath, 'r'), {
+      message: /File path is too long/,
+    });
+
+    // Trying to open a path with more than 48 segments should throw an error.
+    const tooManySegments = '/a'.repeat(49);
+    throws(() => openSync(tooManySegments, 'r'), {
+      message: /File path has too many segments/,
+    });
+  },
+};

--- a/src/workerd/io/worker-fs.h
+++ b/src/workerd/io/worker-fs.h
@@ -131,8 +131,6 @@ namespace workerd {
 // TODO(node-fs): Currently, all files and directories use a fixed last
 // modified time set to the Unix epoch. This is temporary.
 
-// TODO(node-fs): Enforce overall path length limits.
-
 enum class FsType {
   FILE,
   DIRECTORY,


### PR DESCRIPTION
* Limit paths to a total of 4096 characters total. Note that this includes percent-encoded characters, so a path like `/a/b/c/d/e/%ZZ` counts as 14 characters... the path limit is checked after percent-encoding normalization (percent encodings that aren't actually necessary are decoded)
* Limits path to a total of 48 path segments. For example, a path like '/a/b/c' counts as 3 segments, while a path like `/a/b/c/' counts as 4.

The limits here are completely arbitrary. We can set them to whatever we'd like. They are intended specifically just to place a reasonable limit so that paths themselves don't eat up too many resources on their own.