### PR TITLE
Support userland RPC

### DIFF
--- a/samples/multiworker/README.md
+++ b/samples/multiworker/README.md
@@ -1,0 +1,22 @@
+# Node.js Compat Example
+
+> Make sure you build `rpc.js` before running this sample
+
+To run using bazel
+
+```sh
+$ bazel run //src/workerd/server:workerd -- serve ~/cloudflare/workerd/samples/nodejs-compat/config.capnp
+```
+
+and in another terminal
+
+```sh
+$ bazel run //src/workerd/server:workerd -- serve ~/cloudflare/workerd/samples/nodejs-compat/config-remote.capnp
+```
+
+To test:
+
+```sh
+% curl http://localhost:8080
+{"pipelining":"qux","function":1,"functionArg":5,"rpcTarget":-4,"rpcTargetPipeline":3}
+```

--- a/samples/multiworker/config-remote.capnp
+++ b/samples/multiworker/config-remote.capnp
@@ -1,0 +1,42 @@
+# Imports the base schema for workerd configuration files.
+
+# Refer to the comments in /src/workerd/server/workerd.capnp for more details.
+
+using Workerd = import "/workerd/workerd.capnp";
+
+# A constant of type Workerd.Config defines the top-level configuration for an
+# instance of the workerd runtime. A single config file can contain multiple
+# Workerd.Config definitions and must have at least one.
+const helloWorldExample :Workerd.Config = (
+
+  # Every workerd instance consists of a set of named services. A worker, for instance,
+  # is a type of service. Other types of services can include external servers, the
+  # ability to talk to a network, or accessing a disk directory. Here we create a single
+  # worker service. The configuration details for the worker are defined below.
+  services = [
+    (name = "other", worker = .other),
+    ( name = "internet",
+        network = (
+          allow = ["public", "private"],
+        )
+      )
+  ],
+
+  # Each configuration defines the sockets on which the server will listen.
+  # Here, we create a single socket that will listen on localhost port 8080, and will
+  # dispatch to the "main" service that we defined above.
+  sockets = [
+    ( name = "http", address = "*:8081", http = (), service = "other" )
+  ],
+
+);
+
+const other :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "other.js"),
+    (name = "rpc.js", esModule = embed "rpc.js")
+  ],
+  compatibilityDate = "2025-01-01",
+  bindings = [(service = (name = "other", entrypoint = "W"), name = "SELF")]
+
+);

--- a/samples/multiworker/config.capnp
+++ b/samples/multiworker/config.capnp
@@ -1,0 +1,52 @@
+# Imports the base schema for workerd configuration files.
+
+# Refer to the comments in /src/workerd/server/workerd.capnp for more details.
+
+using Workerd = import "/workerd/workerd.capnp";
+
+# A constant of type Workerd.Config defines the top-level configuration for an
+# instance of the workerd runtime. A single config file can contain multiple
+# Workerd.Config definitions and must have at least one.
+const helloWorldExample :Workerd.Config = (
+
+  # Every workerd instance consists of a set of named services. A worker, for instance,
+  # is a type of service. Other types of services can include external servers, the
+  # ability to talk to a network, or accessing a disk directory. Here we create a single
+  # worker service. The configuration details for the worker are defined below.
+  services = [
+    (name = "main", worker = .main),
+    (name = "gateway", worker = .gateway),
+    ( name = "internet",
+        network = (
+          allow = ["public", "private"],
+        )
+      )
+  ],
+
+  # Each configuration defines the sockets on which the server will listen.
+  # Here, we create a single socket that will listen on localhost port 8080, and will
+  # dispatch to the "main" service that we defined above.
+  sockets = [
+    ( name = "http", address = "*:8080", http = (), service = "main" ),
+  ],
+
+);
+
+const main :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js"),
+  ],
+  compatibilityDate = "2025-01-01",
+  bindings = [(service = (name= "gateway", entrypoint = "Gateway"), name = "GATEWAY")]
+);
+
+
+
+const gateway :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "gateway.js"),
+    (name = "rpc.js", esModule = embed "rpc.js")
+  ],
+  compatibilityDate = "2025-01-01",
+);
+

--- a/samples/multiworker/gateway.js
+++ b/samples/multiworker/gateway.js
@@ -1,0 +1,57 @@
+import { WorkerEntrypoint } from "cloudflare:workers"
+import { rpcOverWebSocket } from "rpc.js"
+
+async function proxyFetch(request, env) {
+	const proxiedHeaders = new Headers();
+	for (const [name, value] of request.headers) {
+		// The `Upgrade` header needs to be special-cased to prevent:
+		//   TypeError: Worker tried to return a WebSocket in a response to a request which did not contain the header "Upgrade: websocket"
+		if (name === "upgrade" || name.startsWith("MF-")) {
+			proxiedHeaders.set(name, value);
+		} else {
+			proxiedHeaders.set(`MF-Header-${name}`, value);
+		}
+	}
+	proxiedHeaders.set("MF-URL", request.url);
+	proxiedHeaders.set("MF-Binding", env.binding);
+	const req = new Request(request, {
+		headers: proxiedHeaders,
+	});
+
+	return fetch(env.remoteProxyConnectionString, req);
+}
+
+export class Gateway extends WorkerEntrypoint {
+	async fetch(request) {
+		return proxyFetch(request, this.env);
+	}
+
+	constructor(ctx, env) {
+    console.log("constructor")
+		const url = new URL("http://localhost:8081");
+		url.protocol = "ws:";
+		const session = rpcOverWebSocket(url.href);
+		const stub = session.getStub();
+
+		super(ctx, env);
+    this.ctx.waitUntil(scheduler.wait(5_000))
+
+		return new Proxy(this, {
+			get(target, prop) {
+				console.log(stub, prop);
+
+				if (Reflect.has(target, prop)) {
+					return Reflect.get(target, prop);
+				}
+
+				const value =  Reflect.get(stub, prop);
+        console.log("PROXY", value)
+        return value
+			},
+		});
+	}
+}
+
+export default {
+  fetch() {}
+}

--- a/samples/multiworker/other.js
+++ b/samples/multiworker/other.js
@@ -1,0 +1,51 @@
+import {WorkerEntrypoint, RpcTarget} from "cloudflare:workers"
+import {receiveRpcOverHttp} from "rpc.js"
+
+class Counter extends RpcTarget {
+	#value = 0;
+
+	increment(amount) {
+		this.#value += amount;
+		return this.#value;
+	}
+
+	value() {
+		return this.#value;
+	}
+}
+
+export class W extends WorkerEntrypoint {
+  sayHello(){
+    return "Hello there from other.js"
+  }
+  async newCounter() {
+    return new Counter()
+	}
+	async newFnCounter() {
+		let value = 0;
+		return (increment = 0) => {
+			value += increment;
+			return value;
+		};
+	}
+	async apply(fn, val) {
+		return fn(val)
+	}
+	async promisePipeline() {
+		return {
+			bar: {
+				baz: () => "qux",
+			},
+		};
+	}
+	async fetch() {
+		return new Response("Hello World");
+	}
+}
+
+export default {
+  fetch(request, env) {
+    console.log("Receiving", env.SELF)
+    return receiveRpcOverHttp(request, env.SELF);
+  }
+}

--- a/samples/multiworker/worker.js
+++ b/samples/multiworker/worker.js
@@ -1,0 +1,30 @@
+
+export default {
+  async fetch(request, env, ctx) {
+
+    let ret = {}
+
+    // Promise pipelining with primitives
+		ret.pipelining = await env.GATEWAY.promisePipeline().bar.baz();
+
+    // // Returning a callable function
+    using f = await env.GATEWAY.newFnCounter();
+		await f(2);
+		await f(1);
+		ret.function = await f(-2);
+
+    // // Sending a function argument
+    ret.functionArg = await env.GATEWAY.apply((x) => x + 2, 3);
+
+    // // // Returning an RpcTarget
+    const counter = await env.GATEWAY.newCounter();
+		await counter.increment(1);
+		await counter.increment(-5);
+		ret.rpcTarget = await counter.value()
+
+    // // Returning a pipelined RpcTarget
+    ret.rpcTargetPipeline = await env.GATEWAY.newCounter().increment(3);
+
+		return Response.json(ret);
+  }
+}

--- a/src/cloudflare/internal/workers.d.ts
+++ b/src/cloudflare/internal/workers.d.ts
@@ -26,4 +26,6 @@ export class RpcStub {
 export class RpcTarget {}
 
 export function waitUntil(promise: Promise<unknown>): void;
-export function registerRpcTargetClass(constructor: new (...args: any[]) => any): void;
+export function registerRpcTargetClass(
+  constructor: new (...args: any[]) => any
+): void;

--- a/src/cloudflare/internal/workers.d.ts
+++ b/src/cloudflare/internal/workers.d.ts
@@ -26,3 +26,4 @@ export class RpcStub {
 export class RpcTarget {}
 
 export function waitUntil(promise: Promise<unknown>): void;
+export function registerRpcTargetClass(constructor: new (...args: any[]) => any): void;

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -91,3 +91,4 @@ export const env = new Proxy(
 );
 
 export const waitUntil = entrypoints.waitUntil.bind(entrypoints);
+export const registerRpcTargetClass = entrypoints.registerRpcTargetClass.bind(entrypoints);

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -91,4 +91,5 @@ export const env = new Proxy(
 );
 
 export const waitUntil = entrypoints.waitUntil.bind(entrypoints);
-export const registerRpcTargetClass = entrypoints.registerRpcTargetClass.bind(entrypoints);
+export const registerRpcTargetClass =
+  entrypoints.registerRpcTargetClass.bind(entrypoints);

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -20,6 +20,7 @@
 #include <workerd/jsg/modules-new.h>
 #include <workerd/jsg/ser.h>
 #include <workerd/jsg/url.h>
+
 #include <mutex>
 
 namespace workerd::api {
@@ -556,10 +557,10 @@ class EntrypointsModule: public jsg::Object {
   EntrypointsModule(jsg::Lock&, const jsg::Url&) {}
 
   void waitUntil(kj::Promise<void> promise);
-  
+
   // Register a class constructor as an RPC-capable target
   void registerRpcTargetClass(jsg::Lock& js, jsg::JsValue constructor);
-  
+
   // Helper method to check if a class is registered
   static bool isRegisteredRpcTargetClass(jsg::Lock& js, jsg::JsObject obj);
 

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -20,6 +20,7 @@
 #include <workerd/jsg/modules-new.h>
 #include <workerd/jsg/ser.h>
 #include <workerd/jsg/url.h>
+#include <mutex>
 
 namespace workerd::api {
 
@@ -555,6 +556,12 @@ class EntrypointsModule: public jsg::Object {
   EntrypointsModule(jsg::Lock&, const jsg::Url&) {}
 
   void waitUntil(kj::Promise<void> promise);
+  
+  // Register a class constructor as an RPC-capable target
+  void registerRpcTargetClass(jsg::Lock& js, jsg::JsValue constructor);
+  
+  // Helper method to check if a class is registered
+  static bool isRegisteredRpcTargetClass(jsg::Lock& js, jsg::JsObject obj);
 
   JSG_RESOURCE_TYPE(EntrypointsModule) {
     JSG_NESTED_TYPE(WorkerEntrypoint);
@@ -566,7 +573,13 @@ class EntrypointsModule: public jsg::Object {
     JSG_NESTED_TYPE_NAMED(JsRpcTarget, RpcTarget);
 
     JSG_METHOD(waitUntil);
+    JSG_METHOD(registerRpcTargetClass);
   }
+
+ private:
+  // Global registry of RPC-capable class constructor names
+  static kj::Vector<kj::String> registeredRpcClasses;
+  static std::mutex registryMutex;
 };
 
 #define EW_WORKER_RPC_ISOLATE_TYPES                                                                \


### PR DESCRIPTION
Support registering additional classes as RPC Targets. 

> Disclaimer: while I wrote and understand the test case (samples/multiworker), Claude wrote the C++, and I don't really understand it

To test, follow the instructions in `samples/multiworker/README.md`