### PR TITLE
Ensure that VFS directories, files, and symlinks are accounted for

### DIFF
--- a/src/workerd/api/filesystem.c++
+++ b/src/workerd/api/filesystem.c++
@@ -1006,7 +1006,7 @@ jsg::Optional<kj::String> FileSystemModule::mkdir(
       if (!stat.writable) {
         node::THROW_ERR_UV_EPERM(js, "mkdir"_kj);
       }
-      auto dir = workerd::Directory::newWritable();
+      auto dir = workerd::Directory::newWritable(js);
       KJ_IF_SOME(err, current->add(js, part, dir.addRef())) {
         throwFsError(js, err, "mkdir"_kj);
       }
@@ -1017,7 +1017,7 @@ jsg::Optional<kj::String> FileSystemModule::mkdir(
     }
 
     // Now that we have the parent directory, let's try creating the new directory.
-    auto newDir = workerd::Directory::newWritable();
+    auto newDir = workerd::Directory::newWritable(js);
     KJ_IF_SOME(err, current->add(js, name.toString(false), kj::mv(newDir))) {
       throwFsError(js, err, "mkdir"_kj);
     }
@@ -1040,7 +1040,7 @@ jsg::Optional<kj::String> FileSystemModule::mkdir(
         if (!stat.writable) {
           node::THROW_ERR_UV_EPERM(js, "mkdir"_kj);
         }
-        auto newDir = workerd::Directory::newWritable();
+        auto newDir = workerd::Directory::newWritable(js);
         if (options.tmp) {
           if (tmpFileCounter >= kMax) {
             node::THROW_ERR_UV_EPERM(js, "mkdir"_kj, "Too many temporary directories created"_kj);
@@ -1536,7 +1536,7 @@ void handleCpDir(jsg::Lock& js,
         } else {
           // The destination does not exist, we'll need to create a new directory.
           // then recursively copy into it.
-          auto newDir = workerd::Directory::newWritable();
+          auto newDir = workerd::Directory::newWritable(js);
           KJ_IF_SOME(err, dest->add(js, name, newDir.addRef())) {
             // If we got here, an error was reported
             throwFsError(js, err, "cp"_kj);

--- a/src/workerd/io/worker-fs.h
+++ b/src/workerd/io/worker-fs.h
@@ -294,6 +294,12 @@ class File: public kj::Refcounted {
   // the FileSystemHandle.getUniqueId() API, which is not yet fully standardized
   // but is being implemented and has Web Platform Tests.
   virtual kj::StringPtr getUniqueId(jsg::Lock&) const = 0;
+
+  // Ensures that the symlink instance itself is counted towards the isolate
+  // memory limit.
+  virtual void countTowardsIsolateLimit(jsg::Lock& js) const {
+    // Non-op by default.
+  };
 };
 
 // A directory in the virtual file system. If the directory is read-only,
@@ -395,6 +401,14 @@ class Directory: public kj::Refcounted, public kj::EnableAddRefToThis<Directory>
   // when the handle is dropped.
   static kj::Rc<Directory> newWritable() KJ_WARN_UNUSED_RESULT;
 
+  // Variation of newWritable that ensures the Directory instance itself is
+  // counted towwards the isolate memory limit. This should be the typical
+  // case for directories created by user code, such as when creating a
+  // temporary directory under /tmp. This should not be used for directories
+  // that are created by the runtime that aren't directly under the users
+  // control, such as the /tmp directory itself.
+  static kj::Rc<Directory> newWritable(jsg::Lock& js) KJ_WARN_UNUSED_RESULT;
+
   // Used to build a new read-only directory. All files and directories added
   // may or may not be writable. The directory will not be initially included
   // in a directory. To add it to a directory, use the add method.
@@ -435,6 +449,13 @@ class Directory: public kj::Refcounted, public kj::EnableAddRefToThis<Directory>
   // the FileSystemHandle.getUniqueId() API, which is not yet fully standardized
   // but is being implemented and has Web Platform Tests.
   virtual kj::StringPtr getUniqueId(jsg::Lock&) const = 0;
+
+  // Ensures that the directory instance itself is counted towards the isolate
+  // memory limit. Not every directory needs to be counted so we don't do this
+  // by default automatically for every Directory instance.
+  virtual void countTowardsIsolateLimit(jsg::Lock& js) const {
+    // Non-op by default.
+  }
 };
 
 // The equivalent to a symbolic link. A symlink holds a reference to the
@@ -469,10 +490,15 @@ class SymbolicLink final: public kj::Refcounted {
   // but is being implemented and has Web Platform Tests.
   kj::StringPtr getUniqueId(jsg::Lock&) const;
 
+  // Ensures that the symlink instance itself is counted towards the isolate
+  // memory limit.
+  void countTowardsIsolateLimit(jsg::Lock& js) const;
+
  private:
   kj::Rc<Directory> root;
   kj::Path targetPath;
   mutable kj::Maybe<kj::String> maybeUniqueId;
+  mutable kj::Maybe<jsg::ExternalMemoryAdjustment> maybeMemoryAdjustment;
 };
 
 using FsNode = kj::OneOf<kj::Rc<File>, kj::Rc<Directory>, kj::Rc<SymbolicLink>>;


### PR DESCRIPTION
Rather than limiting the total number of VFS entries that can be created, account the overhead of directory, file, and symlink entries themselves towards the total isolate heap limit. This adds a certain amount of overhead for the accounting itself but allows greater flexibility in the number of entries that can be created overall. For instance, not counting the actual file data, a File object itself takes up about 144 bytes, so 1 million empty files would take up about 144 MB of memory, well beyond the isolate heap limit of 128 MB.