### PR TITLE
[o11y] Defer STW outcome event reporting

### DIFF
--- a/src/workerd/io/tracer.h
+++ b/src/workerd/io/tracer.h
@@ -140,6 +140,7 @@ class WorkerTracer: public BaseTracer {
       PipelineLogLevel pipelineLogLevel,
       kj::Maybe<kj::Own<tracing::TailStreamWriter>> maybeTailStreamWriter);
   explicit WorkerTracer(PipelineLogLevel pipelineLogLevel, ExecutionModel executionModel);
+  virtual ~WorkerTracer() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(WorkerTracer);
 
   void addLog(const tracing::InvocationSpanContext& context,


### PR DESCRIPTION
This should address the 'reported tail stream event after stream close' warnings seen in testing.