### PR TITLE
Python: Make vendor tests keep track of Python version if necessary

### DIFF
--- a/build/deps/dep_pyodide.bzl
+++ b/build/deps/dep_pyodide.bzl
@@ -25,7 +25,8 @@ def _pyodide_packages(*, tag, lockfile_hash, all_wheels_hash, **_kwds):
         urls = ["https://github.com/cloudflare/pyodide-build-scripts/releases/download/%s/all_wheels.zip" % tag],
     )
 
-def _py_vendor_test_deps(version, name, sha256, **_kwds):
+def _py_vendor_test_deps(version, name, sha256, abi, **_kwds):
+    pyver = "-" + abi.replace(".", "") if abi else ""
     http_archive(
         name = name + "_src_" + version,
         build_file_content = """
@@ -36,7 +37,7 @@ filegroup(
 )
 """,
         sha256 = sha256,
-        url = "https://pub-25a5b2f2f1b84655b185a505c7a3ad23.r2.dev/" + name + "-vendored-for-ew-testing.zip",
+        url = "https://pub-25a5b2f2f1b84655b185a505c7a3ad23.r2.dev/" + name + pyver + "-vendored-for-ew-testing.zip",
     )
 
 def dep_pyodide():

--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -116,11 +116,13 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
             {
                 # Downloaded from https://pub-25a5b2f2f1b84655b185a505c7a3ad23.r2.dev/beautifulsoup4-vendored-for-ew-testing.zip
                 "name": "beautifulsoup4",
+                "abi": None,
                 "sha256": "5aa09c5f549443969dda260a70e58e3ac8537bd3d29155b307a3d98b36eb70fd",
             },
             {
-                # Downloaded from https://pub-25a5b2f2f1b84655b185a505c7a3ad23.r2.dev/fastapi-vendored-for-ew-testing.zip
+                # Downloaded from https://pub-25a5b2f2f1b84655b185a505c7a3ad23.r2.dev/fastapi-312-vendored-for-ew-testing.zip
                 "name": "fastapi",
+                "abi": "3.12",
                 "sha256": "5e6e21dbeda7c1eaadb99e6e52aa2ce45325b51e9a417198701e68e0cfd12a4c",
             },
         ],
@@ -146,11 +148,13 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
             {
                 # Downloaded from https://pub-25a5b2f2f1b84655b185a505c7a3ad23.r2.dev/beautifulsoup4-vendored-for-ew-testing.zip
                 "name": "beautifulsoup4",
+                "abi": None,
                 "sha256": "5aa09c5f549443969dda260a70e58e3ac8537bd3d29155b307a3d98b36eb70fd",
             },
             {
-                # Downloaded from https://pub-25a5b2f2f1b84655b185a505c7a3ad23.r2.dev/fastapi-vendored-for-ew-testing.zip
+                # Downloaded from https://pub-25a5b2f2f1b84655b185a505c7a3ad23.r2.dev/fastapi-312-vendored-for-ew-testing.zip
                 "name": "fastapi",
+                "abi": "3.12",
                 "sha256": "5e6e21dbeda7c1eaadb99e6e52aa2ce45325b51e9a417198701e68e0cfd12a4c",
             },
         ],

--- a/src/pyodide/create_vendor_zip.py
+++ b/src/pyodide/create_vendor_zip.py
@@ -8,12 +8,13 @@ creates a zip file of the resulting python_modules directory.
 """
 
 import argparse
+import os
 import shutil
 import sys
 import zipfile
 from pathlib import Path
 
-from tool_utils import run
+from tool_utils import b64digest, run
 
 PYPROJECT_TEMPLATE = """[project]
 name = "vendor-test"
@@ -39,9 +40,18 @@ def create_pyproject_toml(package_name: str, target_dir: Path) -> Path:
     return pyproject_path
 
 
-def run_pywrangler_sync(work_dir: Path) -> Path:
+def run_pywrangler_sync(work_dir: Path, python: str | None) -> Path:
     """Run `uv run pywrangler sync` in the specified directory."""
-    run(["uv", "run", "pywrangler", "sync"], cwd=work_dir)
+    env = os.environ.copy()
+    env["_PYODIDE_EXTRA_MOUNTS"] = str(work_dir)
+    if python:
+        env["_PYWRANGLER_PYTHON_VERSION"] = python
+    # TODO: Make pywrangler understand how to use Python 3.13 correctly and
+    # remove these extra commands
+    run(["uv", "venv"], cwd=work_dir, env=env)
+    run(["uv", "pip", "install", "pyodide-build"], cwd=work_dir, env=env)
+    run(["uv", "run", "pyodide", "xbuildenv", "install"], cwd=work_dir, env=env)
+    run(["uv", "run", "pywrangler", "sync"], cwd=work_dir, env=env)
     python_modules_dir = work_dir / "python_modules"
     if not python_modules_dir.exists():
         print(f"Error: python_modules directory not found at {python_modules_dir}")
@@ -49,22 +59,28 @@ def run_pywrangler_sync(work_dir: Path) -> Path:
     return python_modules_dir
 
 
-def create_zip_archive(source_dir: Path, package_name: str, output_dir: Path) -> Path:
-    """Create a zip archive of the python_modules directory."""
-    zip_filename = f"{package_name}-vendored-for-ew-testing.zip"
-    zip_path = output_dir / zip_filename
+def create_zip_archive(source_dir: Path, package_name: str, output_dir: Path) -> bool:
+    """Create a zip archive of the python_modules directory.
 
-    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+    Return value indicates whether the archive includes any binary modules (.so
+    files).
+    """
+    tmp_path = output_dir / "tmp.zip"
+    native = False
+
+    with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zipf:
         for file_path in source_dir.rglob("*"):
             if file_path.is_file():
                 # Store relative path from python_modules directory
                 arcname = file_path.relative_to(source_dir)
                 zipf.write(file_path, arcname)
+                if file_path.suffix == ".so":
+                    native = True
 
-    return zip_path
+    return native
 
 
-def vendor_package(package_name: str) -> Path:
+def vendor_package(package_name: str, python: str) -> tuple[Path, bool]:
     """Main function to vendor a Python package."""
     tmp_dir = Path("/tmp")
     work_dir = tmp_dir / f"vendor-{package_name}"
@@ -81,11 +97,15 @@ def vendor_package(package_name: str) -> Path:
 
         # Run pywrangler sync
         print("Running uv run pywrangler sync...")
-        python_modules_dir = run_pywrangler_sync(work_dir)
+        python_modules_dir = run_pywrangler_sync(work_dir, python)
 
         # Create zip archive
         print("Creating zip archive...")
-        zip_path = create_zip_archive(python_modules_dir, package_name, tmp_dir)
+        native = create_zip_archive(python_modules_dir, package_name, tmp_dir)
+        py = f"-{python}" if native else ""
+        name = f"{package_name}{py}-vendored-for-ew-testing.zip"
+        zip_path = tmp_dir / name
+        shutil.move(tmp_dir / "tmp.zip", zip_path)
     except Exception as e:
         print(f"Error vendoring package {package_name}: {e}")
         sys.exit(1)
@@ -95,7 +115,7 @@ def vendor_package(package_name: str) -> Path:
             "Upload this zip file to the ew-snapshot-tests R2 bucket: "
             + "https://dash.cloudflare.com/e415f1017791ced9d5f3eb0df2b31c9e/r2/default/buckets/ew-snapshot-tests"
         )
-        return zip_path
+        return zip_path, native
     finally:
         # Clean up work directory
         if work_dir.exists():
@@ -108,16 +128,28 @@ def main() -> int:
         description="Create a zip file of a vendored Python package's source files for vendored_py_wd_test."
     )
     parser.add_argument("package_name", help="Name of the Python package to vendor")
+    parser.add_argument("-p", "--python", help="Name of the Python version to use")
 
     args = parser.parse_args()
+    if args.python is None:
+        args.python = "3.12"
 
     if not args.package_name:
         print("Error: Package name is required")
         return 1
 
     try:
-        zip_path = vendor_package(args.package_name)
-        print(f"\nVendoring complete! Archive created at: {zip_path}")
+        zip_path, native = vendor_package(args.package_name, args.python)
+        print("Update python_metadata.bzl with:\n")
+        abi = args.python if native else None
+        i1 = " " * 12
+        i2 = " " * 16
+        print(i1 + "{")
+        print(i2 + f'"name": "{args.package_name}",')
+        print(i2 + f'"abi": "{abi}",')
+        print(i2 + f'"sha256": "{b64digest(zip_path)}",')
+        print(i1 + "},")
+        print()
     except KeyboardInterrupt:
         print("\nOperation cancelled by user")
         return 1

--- a/src/pyodide/make_snapshots.py
+++ b/src/pyodide/make_snapshots.py
@@ -139,6 +139,10 @@ def main() -> int:
         with timing("fastapi snapshot"):
             res += make_fastapi_snapshot(cache, cwd, compat_flags)
     print()
+    print(
+        "Upload these files to the ew-snapshot-tests R2 bucket: "
+        + "https://dash.cloudflare.com/e415f1017791ced9d5f3eb0df2b31c9e/r2/default/buckets/ew-snapshot-tests"
+    )
     print("Update python_metadata.bzl:\n")
     for key, val in res:
         print(indent(f'"{key}": "{val}"', " " * 8))

--- a/src/pyodide/tool_utils.py
+++ b/src/pyodide/tool_utils.py
@@ -1,40 +1,43 @@
-import hashlib
 import subprocess
 import sys
+from base64 import b64encode
 from contextlib import contextmanager
+from hashlib import file_digest
 from pathlib import Path
 from time import time
+from typing import Any
 
 
-def run(cmd: list[str | Path], cwd: Path | str | None = None):
+def run(
+    cmd: list[str | Path],
+    cwd: Path | str | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[Any]:
     """Execute a command and exit on failure with error output."""
     res = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=cwd,
+        cmd, capture_output=True, text=True, check=False, cwd=cwd, env=env
     )
     if res.returncode:
         print("Invocation failed:")
         print(res.stdout)
         print(res.stderr)
         sys.exit(res.returncode)
+    return res
 
 
 def bytesdigest(p: Path | str) -> bytes:
     """Calculate SHA256 digest of a file as bytes."""
-    sha256_hash = hashlib.sha256()
-    with Path(p).open("rb") as f:
-        for chunk in iter(lambda: f.read(4096), b""):
-            sha256_hash.update(chunk)
-    return sha256_hash.digest()
+    return file_digest(Path(p).open("rb"), "sha256").digest()
 
 
 def hexdigest(p: Path | str) -> str:
     """Calculate SHA256 digest of a file as hex string."""
     digest = bytesdigest(p)
     return "".join(hex(e)[2:] for e in digest)
+
+
+def b64digest(p: Path | str):
+    return "sha256-" + b64encode(bytesdigest(p)).decode()
 
 
 @contextmanager

--- a/src/pyodide/upload_bundles.py
+++ b/src/pyodide/upload_bundles.py
@@ -1,15 +1,14 @@
 import json
 import subprocess
 import sys
-from base64 import b64encode
 from copy import deepcopy
 from functools import cache
-from hashlib import file_digest
 from os import environ
 from pathlib import Path
 
 import requests
 from boto3 import client
+from tool_utils import b64digest
 
 
 def cquery(rule):
@@ -82,10 +81,7 @@ def main():
         info["backport"] = b
         key = bundle_key(**info)
         print(f"Uploading version {ver} backport {b}")
-        shasum = (
-            "sha256-"
-            + b64encode(file_digest(path.open("rb"), "sha256").digest()).decode()
-        )
+        shasum = b64digest(path)
         i = " " * 8
         print("Update python_metadata.bzl with:\n")
         print(i + f'"backport": "{b}",')


### PR DESCRIPTION
Updated make_snapshots to take an optional Python version. I also made it print the data to put into python_metadata. Vendor file entries get an abi field which is either the Python version they depend on or None if they work in all Python versions.