### PR TITLE
Use new js error serialization to preserve error details

### DIFF
--- a/samples/helloworld_esm/worker.js
+++ b/samples/helloworld_esm/worker.js
@@ -2,6 +2,8 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+throw new AggregateError([new Error('boom')], 'message', { cause: new Error('cause') });
+
 export default {
   async fetch(req, env) {
     return new Response("Hello World\n");

--- a/src/pyodide/internal/_workers.py
+++ b/src/pyodide/internal/_workers.py
@@ -205,7 +205,9 @@ def _to_python_exception(exc: JsException) -> Exception:
 def _from_js_error(exc: JsException) -> Exception:
     # convert into Python exception after a full round trip
     # Python - JS - Python
-    if not exc.message or not exc.message.startswith("PythonError"):
+    if not exc.name == "PythonError" and (
+        not exc.message or not exc.message.startswith("PythonError")
+    ):
         return _to_python_exception(exc)
 
     # extract the Python exception type from the traceback

--- a/src/pyodide/internal/_workers.py
+++ b/src/pyodide/internal/_workers.py
@@ -205,7 +205,7 @@ def _to_python_exception(exc: JsException) -> Exception:
 def _from_js_error(exc: JsException) -> Exception:
     # convert into Python exception after a full round trip
     # Python - JS - Python
-    if not exc.name == "PythonError" and (
+    if exc.name != "PythonError" and (
         not exc.message or not exc.message.startswith("PythonError")
     ):
         return _to_python_exception(exc)

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2177,36 +2177,7 @@ void Worker::Lock::logUncaughtException(
 
 void Worker::Lock::logUncaughtException(UncaughtExceptionSource source, kj::Exception&& exception) {
   jsg::Lock& js = *this;
-
-  // If we have an attached serialized exception, deserialize it and log that instead, rather
-  // than try to reconstruct based on the KJ exception description.
-  //
-  // TODO(cleanup): Eventually, js.exceptionToJsValue() should do this internally, and then we
-  //   should remove the code from here.
-  KJ_IF_SOME(serializedJsError, exception.getDetail(jsg::TUNNELED_EXCEPTION_DETAIL_ID)) {
-    if (!js.v8Isolate->IsExecutionTerminating()) {
-      kj::Maybe<jsg::JsValue> deserialized;
-
-      v8::TryCatch tryCatch(js.v8Isolate);
-      try {
-        jsg::Deserializer deser(js, serializedJsError);
-        deserialized = deser.readValue(js);
-      } catch (jsg::JsExceptionThrown&) {
-        // Failed to deserialize, we'll continue with exceptionToJsValue() instead.
-        //
-        // Note that we're intentionally not checking tryCatch.CanContinue() here, because we still
-        // want to log the exception even if the isolate has been terminated.
-      }
-
-      KJ_IF_SOME(d, deserialized) {
-        logUncaughtException(source, d);
-        return;
-      }
-    }
-  }
-
-  // Couldn't deserialize an attached exception, so use `exceptionToJsValue()`.
-  auto jsError = js.exceptionToJsValue(kj::mv(exception));
+  auto jsError = js.exceptionToJsValue(kj::mv(exception), {.trusted = true});
   logUncaughtException(source, jsError.getHandle(js));
 }
 

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2502,9 +2502,10 @@ class Lock {
   // error, this reproduces the original error. If it is not a tunneled error, then it is treated
   // as an internal error: the KJ exception message is logged to stderr, and a JavaScript error
   // is returned with a generic description.
-  Value exceptionToJs(kj::Exception&& exception);
+  Value exceptionToJs(kj::Exception&& exception, MakeInternalErrorOptions options = {});
 
-  JsRef<JsValue> exceptionToJsValue(kj::Exception&& exception);
+  JsRef<JsValue> exceptionToJsValue(
+      kj::Exception&& exception, MakeInternalErrorOptions options = {});
 
   // Encodes the given JavaScript exception into a KJ exception, formatting the description in
   // such a way that hopefully exceptionToJs() can reproduce something equivalent to the original
@@ -2521,8 +2522,9 @@ class Lock {
   // via JSG understand how to handle this and propagate the exception back to JavaScript.
   [[noreturn]] void throwException(Value&& exception);
 
-  [[noreturn]] void throwException(kj::Exception&& exception) {
-    throwException(exceptionToJs(kj::mv(exception)));
+  [[noreturn]] void throwException(
+      kj::Exception&& exception, MakeInternalErrorOptions options = {}) {
+    throwException(exceptionToJs(kj::mv(exception), options));
   }
 
   [[noreturn]] void throwException(const JsValue& exception);
@@ -2609,11 +2611,11 @@ class Lock {
 
   // Construct an immediately-rejected promise throwing the given exception.
   template <typename T>
-  Promise<T> rejectedPromise(kj::Exception&& exception);
+  Promise<T> rejectedPromise(kj::Exception&& exception, MakeInternalErrorOptions options = {});
 
   // Like above, but return a pure-JS promise, not a typed Promise.
   JsPromise rejectedJsPromise(jsg::JsValue exception);
-  JsPromise rejectedJsPromise(kj::Exception&& exception);
+  JsPromise rejectedJsPromise(kj::Exception&& exception, MakeInternalErrorOptions options = {});
 
   // Like `kj::evalNow()`, but returns a jsg::Promise for the result. Synchronous exceptions are
   // caught and returned as a rejected promise.

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -624,8 +624,8 @@ JsPromise Lock::rejectedJsPromise(jsg::JsValue exception) {
   return JsPromise(handleScope.Escape(resolver->GetPromise()));
 }
 
-JsPromise Lock::rejectedJsPromise(kj::Exception&& exception) {
-  return rejectedJsPromise(exceptionToJsValue(kj::mv(exception)).getHandle(*this));
+JsPromise Lock::rejectedJsPromise(kj::Exception&& exception, MakeInternalErrorOptions options) {
+  return rejectedJsPromise(exceptionToJsValue(kj::mv(exception), options).getHandle(*this));
 }
 
 PromiseState JsPromise::state() {

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -239,7 +239,8 @@ v8::MaybeLocal<v8::Value> evaluateSyntheticModuleCallback(
   })) {
     // V8 doc comments say in the case of an error, throw the error and return an empty Maybe.
     // I.e. NOT a rejected promise. OK...
-    js.v8Isolate->ThrowException(kjExceptionToJs(js.v8Isolate, kj::mv(exception)));
+    auto ex = js.exceptionToJsValue(kj::mv(exception));
+    js.v8Isolate->ThrowException(ex.getHandle(js));
     result = v8::Local<v8::Promise>();
   }
 

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -239,7 +239,7 @@ v8::MaybeLocal<v8::Value> evaluateSyntheticModuleCallback(
   })) {
     // V8 doc comments say in the case of an error, throw the error and return an empty Maybe.
     // I.e. NOT a rejected promise. OK...
-    js.v8Isolate->ThrowException(makeInternalError(js.v8Isolate, kj::mv(exception)));
+    js.v8Isolate->ThrowException(kjExceptionToJs(js.v8Isolate, kj::mv(exception)));
     result = v8::Local<v8::Promise>();
   }
 

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -739,7 +739,8 @@ v8::MaybeLocal<v8::Promise> dynamicImportCallback(v8::Local<v8::Context> context
 
     return makeRejected(tryCatch.Exception());
   } catch (kj::Exception& ex) {
-    return makeRejected(kjExceptionToJs(js.v8Isolate, kj::mv(ex)));
+    auto exc = js.exceptionToJs(kj::mv(ex));
+    return makeRejected(exc.getHandle(js));
   }
   KJ_UNREACHABLE;
 }

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -695,7 +695,7 @@ v8::MaybeLocal<v8::Promise> dynamicImportCallback(v8::Local<v8::Context> context
       }
       return makeRejected(tryCatch.Exception());
     } catch (kj::Exception& ex) {
-      return makeRejected(makeInternalError(js.v8Isolate, kj::mv(ex)));
+      return makeRejected(kjExceptionToJs(js.v8Isolate, kj::mv(ex)));
     }
   }
 
@@ -739,7 +739,7 @@ v8::MaybeLocal<v8::Promise> dynamicImportCallback(v8::Local<v8::Context> context
 
     return makeRejected(tryCatch.Exception());
   } catch (kj::Exception& ex) {
-    return makeRejected(makeInternalError(js.v8Isolate, kj::mv(ex)));
+    return makeRejected(kjExceptionToJs(js.v8Isolate, kj::mv(ex)));
   }
   KJ_UNREACHABLE;
 }

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -345,7 +345,7 @@ class Promise {
     }
 
     void reject(Lock& js, kj::Exception exception) {
-      reject(js, makeInternalError(js.v8Isolate, kj::mv(exception)));
+      reject(js, kjExceptionToJs(js.v8Isolate, kj::mv(exception)));
     }
 
     Resolver addRef(Lock& js) {
@@ -489,7 +489,7 @@ Promise<T> Lock::rejectedPromise(jsg::Value exception) {
 template <typename T>
 Promise<T> Lock::rejectedPromise(kj::Exception&& exception, MakeInternalErrorOptions options) {
   return withinHandleScope(
-      [&] { return rejectedPromise<T>(makeInternalError(v8Isolate, kj::mv(exception), options)); });
+      [&] { return rejectedPromise<T>(kjExceptionToJs(v8Isolate, kj::mv(exception), options)); });
 }
 
 template <class Func>

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -345,7 +345,8 @@ class Promise {
     }
 
     void reject(Lock& js, kj::Exception exception) {
-      reject(js, kjExceptionToJs(js.v8Isolate, kj::mv(exception)));
+      auto exc = js.exceptionToJs(kj::mv(exception));
+      reject(js, exc.getHandle(js));
     }
 
     Resolver addRef(Lock& js) {

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -487,9 +487,9 @@ Promise<T> Lock::rejectedPromise(jsg::Value exception) {
 }
 
 template <typename T>
-Promise<T> Lock::rejectedPromise(kj::Exception&& exception) {
+Promise<T> Lock::rejectedPromise(kj::Exception&& exception, MakeInternalErrorOptions options) {
   return withinHandleScope(
-      [&] { return rejectedPromise<T>(makeInternalError(v8Isolate, kj::mv(exception))); });
+      [&] { return rejectedPromise<T>(makeInternalError(v8Isolate, kj::mv(exception), options)); });
 }
 
 template <class Func>

--- a/src/workerd/jsg/util-test.c++
+++ b/src/workerd/jsg/util-test.c++
@@ -255,7 +255,7 @@ struct TunneledContext: public ContextGlobalObject {
     } catch (...) {
       auto ex = kj::getCaughtExceptionAsKj();
       KJ_ASSERT(isTunneledException(ex.getDescription()));
-      auto decodedErr = jsg::JsValue(makeInternalError(js.v8Isolate, kj::mv(ex)));
+      auto decodedErr = jsg::JsValue(kjExceptionToJs(js.v8Isolate, kj::mv(ex)));
       auto obj = KJ_ASSERT_NONNULL(decodedErr.tryCast<jsg::JsObject>());
       KJ_ASSERT(obj.get(js, "foo"_kj).strictEquals(js.boolean(true)));
       KJ_ASSERT(obj.get(js, "message"_kj).toString(js) == "foo"_kj);

--- a/src/workerd/jsg/util-test.c++
+++ b/src/workerd/jsg/util-test.c++
@@ -243,6 +243,27 @@ struct TunneledContext: public ContextGlobalObject {
   void throwTunneledGarbledDOMException() {
     KJ_FAIL_REQUIRE("jsg.DOMException(: thrown from throwTunneledGarbledDOMException");
   }
+  bool testTrustedErrorWithProps(jsg::Lock& js) {
+    jsg::JsValue stack = js.undefined();
+    try {
+      auto err = KJ_ASSERT_NONNULL(
+          jsg::JsValue(v8::Exception::SuppressedError(js.str("foo"_kj))).tryCast<jsg::JsObject>());
+      err.set(js, "foo"_kj, js.boolean(true));
+      stack = err.get(js, "stack"_kj);
+      KJ_ASSERT(stack.isString());
+      kj::throwFatalException(js.exceptionToKj(err));
+    } catch (...) {
+      auto ex = kj::getCaughtExceptionAsKj();
+      KJ_ASSERT(isTunneledException(ex.getDescription()));
+      auto decodedErr = jsg::JsValue(makeInternalError(js.v8Isolate, kj::mv(ex)));
+      auto obj = KJ_ASSERT_NONNULL(decodedErr.tryCast<jsg::JsObject>());
+      KJ_ASSERT(obj.get(js, "foo"_kj).strictEquals(js.boolean(true)));
+      KJ_ASSERT(obj.get(js, "message"_kj).toString(js) == "foo"_kj);
+      KJ_ASSERT(obj.get(js, "name"_kj).toString(js) == "SuppressedError"_kj);
+      KJ_ASSERT(obj.get(js, "stack"_kj).strictEquals(stack));
+      return true;
+    }
+  }
 
   JSG_RESOURCE_TYPE(TunneledContext) {
     JSG_NESTED_TYPE(DOMException);
@@ -269,6 +290,7 @@ struct TunneledContext: public ContextGlobalObject {
     JSG_METHOD(throwTunneledDOMException);
     JSG_METHOD(throwTunneledInvalidDOMException);
     JSG_METHOD(throwTunneledGarbledDOMException);
+    JSG_METHOD(testTrustedErrorWithProps);
   }
 };
 JSG_DECLARE_ISOLATE_TYPE(TunneledIsolate, TunneledContext);
@@ -334,6 +356,8 @@ KJ_TEST("throw tunneled exception") {
     KJ_EXPECT_LOG(ERROR, " thrown from throwTunneledGarbledDOMException");
     e.expectEval("throwTunneledGarbledDOMException()", "throws",
         "Error: internal error; reference = 0123456789abcdefghijklmn");
+
+    e.expectEval("testTrustedErrorWithProps()", "boolean", "true");
   }
 }
 

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -260,7 +260,7 @@ DecodedException decodeTunneledException(
 
             // If the result came from a serialized JS detail, it might not be an object!
             // If that's the case, we'll ignore and fallback to the normal decoding below.
-            if (result.handle->IsObject() || !options.ignoreNonObjects) {
+            if (result.handle->IsObject() || options.allowNonObjects) {
               break;
             }
           } catch (jsg::JsExceptionThrown&) {

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -183,7 +183,7 @@ struct DecodedException {
 };
 
 DecodedException decodeTunneledException(
-    v8::Isolate* isolate, kj::StringPtr internalMessage, kj::Exception::Type excType) {
+    v8::Isolate* isolate, const kj::Exception& exception, const MakeInternalErrorOptions& options) {
   // We currently support tunneling the following error types:
   //
   // - Error:        While the Web IDL spec claims this is reserved for use by program authors, this
@@ -202,7 +202,7 @@ DecodedException decodeTunneledException(
   // https://heycam.github.io/webidl/#idl-exceptions
   //
   // TODO(someday): Support arbitrary user-defined error types, not just Error?
-  auto tunneledInfo = tunneledErrorType(internalMessage);
+  auto tunneledInfo = tunneledErrorType(exception.getDescription());
 
   DecodedException result;
   auto errorType = tunneledInfo.message;
@@ -219,6 +219,56 @@ DecodedException decodeTunneledException(
   result.isFromRemote = tunneledInfo.isFromRemote;
   result.isDurableObjectReset = tunneledInfo.isDurableObjectReset;
 
+  do {
+    // DOMExceptions require a parenthesized error name argument, like DOMException(SyntaxError).
+    // TODO(soon): Decoding a DOMException from the serialization detail would be better but
+    // causes problems with some code paths. For now, we will decode these as new instances and
+    // ignore serialized detail that may be included.
+    if (errorType.startsWith("DOMException(")) {
+      errorType = errorType.slice(strlen("DOMException("));
+      // Check for closing brace
+      KJ_IF_SOME(closeParen, errorType.findFirst(')')) {
+        auto& js = Lock::from(isolate);
+        auto errorName = kj::str(errorType.first(closeParen));
+        auto message = appMessage(errorType.slice(1 + closeParen));
+        auto exception = js.domException(kj::mv(errorName), kj::str(message));
+        result.handle = KJ_ASSERT_NONNULL(exception.tryGetHandle(js));
+        break;
+      }
+    }
+
+    if (tunneledInfo.isJsgError) {
+      // If the error was originally converted from a JS error, then we likely have
+      // serialized the original error object as a detail, if so, let's try to use
+      // that, otherwise, we'll fall back to constructing a new error object. If
+      // the ignoreDetail optiom is set, we skip trying to deserialize.
+      if (!options.ignoreDetail) {
+        KJ_IF_SOME(serializedJsError, exception.getDetail(jsg::TUNNELED_EXCEPTION_DETAIL_ID)) {
+          kj::Maybe<jsg::JsValue> deserialized;
+          v8::TryCatch tryCatch(isolate);
+          try {
+            auto& js = Lock::from(isolate);
+            jsg::Deserializer deser(js, serializedJsError, kj::none, kj::none,
+                jsg::Deserializer::Options{
+                  // By default, we do not preserve stacks in deserialized errors because
+                  // of trust concerns sharing stack details over potentially untrusted
+                  // boundaries. However, if the caller has explicitly indiciate that the
+                  // scope it trusted, we will preserve the stack in the deserialized error.
+                  .preserveStackInErrors = options.trusted,
+                });
+            result.handle = deser.readValue(js);
+
+            // If the result came from a serialized JS detail, it might not be an object!
+            // If that's the case, we'll ignore and fallback to the normal decoding below.
+            if (result.handle->IsObject() || !options.ignoreNonObjects) {
+              break;
+            }
+          } catch (jsg::JsExceptionThrown&) {
+            // Failed to deserialize, we'll continue with the original decoding below.
+          }
+        }
+      }
+
 #define HANDLE_V8_ERROR(error_name, error_type)                                                    \
   if (errorType.startsWith(error_name)) {                                                          \
     auto message = appMessage(errorType.slice(strlen(error_name)));                                \
@@ -226,8 +276,6 @@ DecodedException decodeTunneledException(
     break;                                                                                         \
   }
 
-  do {
-    if (tunneledInfo.isJsgError) {
       HANDLE_V8_ERROR("Error", Error);
       HANDLE_V8_ERROR("RangeError", RangeError);
       HANDLE_V8_ERROR("TypeError", TypeError);
@@ -236,36 +284,28 @@ DecodedException decodeTunneledException(
       HANDLE_V8_ERROR("CompileError", WasmCompileError);
       HANDLE_V8_ERROR("LinkError", WasmCompileError);
       HANDLE_V8_ERROR("RuntimeError", WasmCompileError);
+      HANDLE_V8_ERROR("AggregateError", AggregateError);
+      HANDLE_V8_ERROR("SuppressedError", SuppressedError);
+      HANDLE_V8_ERROR("URIError", URIError);
+      HANDLE_V8_ERROR("EvalError", EvalError);
 
-      // DOMExceptions require a parenthesized error name argument, like DOMException(SyntaxError).
-      if (errorType.startsWith("DOMException(")) {
-        errorType = errorType.slice(strlen("DOMException("));
-        // Check for closing brace
-        KJ_IF_SOME(closeParen, errorType.findFirst(')')) {
-          auto& js = Lock::from(isolate);
-          auto errorName = kj::str(errorType.first(closeParen));
-          auto message = appMessage(errorType.slice(1 + closeParen));
-          auto exception = js.domException(kj::mv(errorName), kj::str(message));
-          result.handle = KJ_ASSERT_NONNULL(exception.tryGetHandle(js));
-          break;
-        }
-      }
+#undef HANDLE_V8_ERROR
     }
-    // unrecognized exception type
+
+    // unrecognized exception type and no serialized JS error detail.
     result.internalErrorId = makeInternalErrorId();
     result.handle = v8::Exception::Error(
         v8Str(isolate, renderInternalError(KJ_ASSERT_NONNULL(result.internalErrorId))));
     result.isInternal = true;
   } while (false);
-#undef HANDLE_V8_ERROR
 
   if (result.isFromRemote) {
     setRemoteError(isolate, result.handle);
   }
 
-  if (excType == kj::Exception::Type::DISCONNECTED) {
+  if (exception.getType() == kj::Exception::Type::DISCONNECTED) {
     setRetryableError(isolate, result.handle);
-  } else if (excType == kj::Exception::Type::OVERLOADED) {
+  } else if (exception.getType() == kj::Exception::Type::OVERLOADED) {
     setOverloadedError(isolate, result.handle);
   }
 
@@ -288,22 +328,13 @@ kj::StringPtr extractTunneledExceptionDescription(kj::StringPtr message) {
   }
 }
 
-v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::Exception&& exception) {
-  auto desc = exception.getDescription();
-
-  // TODO(someday): Deserialize encoded V8 exception from
-  //   exception.getDetail(TUNNELED_EXCEPTION_DETAIL_ID), if present. WARNING: We must think
-  //   carefully about security in the case that the exception has passed between workers that
-  //   don't trust each other. Perhaps we should explicitly remove the stack trace in this case.
-  //   REMINDER: Worker::logUncaughtException() currently deserializes TUNNELED_EXCEPTION_DETAIL_ID
-  //   in order to extract a full stack trace. Once we do it here, we can remove the code from
-  //   there.
-
-  auto tunneledException = decodeTunneledException(isolate, desc, exception.getType());
-
+v8::Local<v8::Value> makeInternalError(
+    v8::Isolate* isolate, kj::Exception&& exception, MakeInternalErrorOptions options) {
+  auto tunneledException = decodeTunneledException(isolate, exception, options);
+  bool isDisconnected = exception.getType() == kj::Exception::Type::DISCONNECTED;
   if (tunneledException.isInternal) {
-    bool logWithInternalId = exception.getType() != kj::Exception::Type::DISCONNECTED &&
-        !isDoNotLogException(exception.getDescription());
+    bool logWithInternalId =
+        !isDisconnected && !isDoNotLogException(exception.getDescription()) && !options.doNotLog;
     auto& observer = IsolateBase::from(isolate).getObserver();
     observer.reportInternalException(exception,
         {
@@ -324,34 +355,35 @@ v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::Exception&& exc
       KJ_LOG(INFO, exception);  // Run with --verbose to see exception logs.
     }
 
-    if (exception.getType() == kj::Exception::Type::DISCONNECTED) {
-      auto exception = v8::Exception::Error(v8StrIntern(isolate, "Network connection lost."_kj));
+    if (isDisconnected) {
+      auto ex = v8::Exception::Error(v8StrIntern(isolate, "Network connection lost."_kj));
       if (tunneledException.isFromRemote) {
-        setRemoteError(isolate, exception);
+        setRemoteError(isolate, ex);
       }
 
       // DISCONNECTED exceptions are considered retryable
-      setRetryableError(isolate, exception);
+      setRetryableError(isolate, ex);
 
       if (tunneledException.isDurableObjectReset) {
-        setDurableObjectResetError(isolate, exception);
+        setDurableObjectResetError(isolate, ex);
       }
 
-      return exception;
+      return ex;
     }
   }
 
   return tunneledException.handle;
 }
 
-Value Lock::exceptionToJs(kj::Exception&& exception) {
+Value Lock::exceptionToJs(kj::Exception&& exception, MakeInternalErrorOptions options) {
   return withinHandleScope(
-      [&] { return Value(v8Isolate, makeInternalError(v8Isolate, kj::mv(exception))); });
+      [&] { return Value(v8Isolate, makeInternalError(v8Isolate, kj::mv(exception), options)); });
 }
 
-JsRef<JsValue> Lock::exceptionToJsValue(kj::Exception&& exception) {
+JsRef<JsValue> Lock::exceptionToJsValue(
+    kj::Exception&& exception, MakeInternalErrorOptions options) {
   return withinHandleScope([&] {
-    JsValue val = JsValue(makeInternalError(v8Isolate, kj::mv(exception)));
+    JsValue val = JsValue(makeInternalError(v8Isolate, kj::mv(exception), options));
     return val.addRef(*this);
   });
 }
@@ -370,9 +402,10 @@ void throwInternalError(v8::Isolate* isolate, kj::StringPtr internalMessage) {
   isolate->ThrowException(makeInternalError(isolate, internalMessage));
 }
 
-void throwInternalError(v8::Isolate* isolate, kj::Exception&& exception) {
+void throwInternalError(
+    v8::Isolate* isolate, kj::Exception&& exception, MakeInternalErrorOptions options) {
   KJ_IF_SOME(renderingError, kj::runCatchingExceptions([&]() {
-    isolate->ThrowException(makeInternalError(isolate, kj::mv(exception)));
+    isolate->ThrowException(makeInternalError(isolate, kj::mv(exception), options));
   })) {
     KJ_LOG(ERROR, "error rendering exception", renderingError);
     KJ_LOG(ERROR, exception);
@@ -388,6 +421,7 @@ void addExceptionDetail(Lock& js, kj::Exception& exception, v8::Local<v8::Value>
           // Make sure we don't break compatibility if V8 introduces a new version. This value can
           // be bumped to match the new version once all of production is updated to understand it.
           .version = 15,
+          .treatErrorsAsHostObjects = true,
         });
     ser.write(js, JsValue(handle));
     exception.setDetail(TUNNELED_EXCEPTION_DETAIL_ID, ser.release().data);

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -53,6 +53,26 @@ bool getShouldSetToStringTag(v8::Isolate* isolate);
 kj::String fullyQualifiedTypeName(const std::type_info& type);
 kj::String typeName(const std::type_info& type);
 
+struct MakeInternalErrorOptions {
+  // When trusted is true and the kj::Exception has a serialized exception detail, the
+  // stack will be included in the deserialized error if it is available. When false,
+  // the stack will be omitted.
+  bool trusted = false;
+
+  // When ignoreDetail is true, tells makeInternalError() to ignore any serialized
+  // exception detail in the kj::Exception.
+  bool ignoreDetail = false;
+
+  // If the deserialized exception detail is not an object, then it will be ignored
+  // and we will fall back to constructing a new error object. The default is true
+  // to preserve existing behavior, but setting this to false may be useful in some
+  // cases. When false, the makeInternalError() might return a non-object value.
+  bool ignoreNonObjects = true;
+
+  // When doNotLog is true, the error will not be logged.
+  bool doNotLog = false;
+};
+
 // Creates a JavaScript error that obfuscates the exception details, while logging the full details
 // to stderr. If the KJ exception was created using throwTunneledException(), don't log anything
 // but instead return the original reconstructed JavaScript exception.
@@ -61,13 +81,15 @@ v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::StringPtr inter
 // Creates a JavaScript error that obfuscates the exception details, while logging the full details
 // to stderr. If the KJ exception was created using throwTunneledException(), don't log anything
 // but instead return the original reconstructed JavaScript exception.
-v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::Exception&& exception);
+v8::Local<v8::Value> makeInternalError(
+    v8::Isolate* isolate, kj::Exception&& exception, MakeInternalErrorOptions options = {});
 
 // calls makeInternalError() and then tells the isolate to throw it.
 void throwInternalError(v8::Isolate* isolate, kj::StringPtr internalMessage);
 
 // calls makeInternalError() and then tells the isolate to throw it.
-void throwInternalError(v8::Isolate* isolate, kj::Exception&& exception);
+void throwInternalError(
+    v8::Isolate* isolate, kj::Exception&& exception, MakeInternalErrorOptions options = {});
 
 constexpr kj::Exception::DetailTypeId TUNNELED_EXCEPTION_DETAIL_ID = 0xe8027292171b1646ull;
 

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -67,9 +67,10 @@ struct MakeInternalErrorOptions {
   // and we will fall back to constructing a new error object. The default is true
   // to preserve existing behavior, but setting this to false may be useful in some
   // cases. When false, the makeInternalError() might return a non-object value.
-  bool ignoreNonObjects = true;
+  bool allowNonObjects = false;
 
-  // When doNotLog is true, the error will not be logged.
+  // When doNotLog is true and this is an actually-internal error, the error will
+  // not be logged.
   bool doNotLog = false;
 };
 

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -1458,6 +1458,10 @@ class ExceptionWrapper {
       v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::Exception exception) {
+    // Converts the error with default options. If the exception is a tunneled
+    // exception that has a serialized JS error, then that will be used. If
+    // that is used, the stack will be omitted by default. Pass the .trusted = true
+    // option to include the stack. See makeInternalError for details.
     return makeInternalError(js.v8Isolate, kj::mv(exception));
   }
 
@@ -1508,6 +1512,10 @@ class ExceptionWrapper {
           "TypeError"_kj,
           "SyntaxError"_kj,
           "ReferenceError"_kj,
+          "AggregateError"_kj,
+          "SuppressedError"_kj,
+          "URIError"_kj,
+          "EvalError"_kj,
           // WASM Error Types
           "CompileError"_kj,
           "LinkError"_kj,

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -1461,8 +1461,8 @@ class ExceptionWrapper {
     // Converts the error with default options. If the exception is a tunneled
     // exception that has a serialized JS error, then that will be used. If
     // that is used, the stack will be omitted by default. Pass the .trusted = true
-    // option to include the stack. See makeInternalError for details.
-    return makeInternalError(js.v8Isolate, kj::mv(exception));
+    // option to include the stack. See kjExceptionToJs for details.
+    return kjExceptionToJs(js.v8Isolate, kj::mv(exception));
   }
 
   kj::Maybe<kj::Exception> tryUnwrap(Lock& js,


### PR DESCRIPTION
Use the recently added JS error serialization mechanism to preserve JS error details in tunneled errors. Internal test changes are required (separate PR opened there).

The new mechanism adds an options struct used to customize how the kj::Exception is handled. 

The options include the ability to ignore the serialized data, selectively include the stack, selectively log, and decide how to handle non-object serializations. By default, the mechanism will ignore stack and ignore non-object serializations (e.g. in case someone does `throw 'foo'` and the serialized detail is not actually an error object. This matches the original behavior.

DOMExceptions are still handled specially, ignoring the serialized detail.