### PR TITLE
Implements dedicated snapshots for Python Workers.

### DIFF
--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -44,6 +44,7 @@ export interface CompatibilityFlags {
   python_workflows?: boolean;
   python_no_global_handlers?: boolean;
   python_workers_force_new_vendor_path?: boolean;
+  python_dedicated_snapshot?: boolean;
 }
 
 export interface CloudflareGlobal {
@@ -52,10 +53,17 @@ export interface CloudflareGlobal {
   };
 }
 
-const compatibilityFlags: CompatibilityFlags =
+// WARNING: unless experimental mode is enabled this will not include experimental flags.
+// So even if you enable an experimental flag in a test, it may not show up here.
+// The code responsible for populating this is Cloudflare::getCompatibilityFlags in global-scope.c++.
+//
+// If you're looking to test experimental flags here, then enable the flag and experimental mode.
+export const compatibilityFlags: CompatibilityFlags =
   (globalThis as CloudflareGlobal)?.Cloudflare?.compatibilityFlags ?? {};
 export const workflowsEnabled: boolean = !!compatibilityFlags.python_workflows;
 export const legacyGlobalHandlers: boolean =
   !compatibilityFlags.python_no_global_handlers;
 export const legacyVendorPath: boolean =
   !compatibilityFlags.python_workers_force_new_vendor_path;
+export const IS_DEDICATED_SNAPSHOT_ENABLED =
+  compatibilityFlags.python_dedicated_snapshot;

--- a/src/pyodide/types/emscripten.d.ts
+++ b/src/pyodide/types/emscripten.d.ts
@@ -36,7 +36,7 @@ interface API {
   pyodide_base: {
     pyimport_impl: PyCallable;
   };
-  serializeHiwireState(): SnapshotConfig;
+  serializeHiwireState(serializer: (obj: any) => any): SnapshotConfig;
   pyVersionTuple: [number, number, number];
 }
 

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -306,7 +306,8 @@ struct ArtifactBundler_State {
   kj::Own<ArtifactBundler_State> clone() {
     return kj::heap<ArtifactBundler_State>(packageManager,
         existingSnapshot.map(
-            [](kj::Array<const kj::byte>& data) { return kj::heapArray<const kj::byte>(data); }));
+            [](kj::Array<const kj::byte>& data) { return kj::heapArray<const kj::byte>(data); }),
+        isValidating);
   }
 };
 

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -954,4 +954,12 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatEnableDate("2025-09-20");
   # This flag enables additional checks in the control plane to validate that workflows are
   # defined and used correctly
+
+  pythonDedicatedSnapshot @110 :Bool
+      $compatEnableFlag("python_dedicated_snapshot")
+      $impliedByAfterDate(name = "pythonWorkers20250116", date = "2000-01-01")
+      $experimental;
+  # Enables the generation of dedicated snapshots on Python Worker upload. The snapshot will be
+  # stored inside the resulting WorkerBundle of the Worker. The snapshot will be taken after the
+  # top-level execution of the Worker.
 }


### PR DESCRIPTION
This PR implements dedicated memory snapshot support in Python Workers. These dedicated snapshots are intended to be returned via the validator and then stored in the WorkerBundle.

Run down of features this PR implements:

* new compatibility flag marked `experimental` which enables code paths to generate and load dedicated snapshots.
* ~~new exceptions `PythonRuntimeError` and `PythonUserError` to help us distinguish between internal errors in our runtime code and user code errors~~ https://github.com/cloudflare/workerd/pull/4746
* dynamic libraries are now loaded from the vendored packages directory when necessary
* hiwire custom serialiser/deserialiser for global JS objects that our internal code references with a user-facing error message if their code attempts the same at the top-level of their worker
* collection of the snapshot at the very end, to ensure the full top-level execution is captured
* ~~type for pyodide_entrypoint_helper~~ https://github.com/cloudflare/workerd/pull/4746