### PR TITLE
Add can disown content flag to DynamicWorkerSource

### DIFF
--- a/src/workerd/api/worker-loader.c++
+++ b/src/workerd/api/worker-loader.c++
@@ -118,7 +118,8 @@ jsg::Ref<WorkerStub> WorkerLoader::get(
         .compatibilityFlags = compatFlags,
         .env = kj::mv(env),
         .globalOutbound = kj::mv(globalOutbound),
-        .ownContent = ownCompatFlags.attach(kj::mv(code.modules), kj::mv(code.mainModule))};
+        .ownContent = ownCompatFlags.attach(kj::mv(code.modules), kj::mv(code.mainModule)),
+        .ownContentIsRpcResponse = false};
     });
   });
 

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -251,6 +251,13 @@ struct DynamicWorkerSource {
   // Owns any data structures pointed into by the other members. (E.g. `source` contains a lot of
   // `StringPtr`s; `ownContent` owns the backing buffer for them.)
   kj::Own<void> ownContent;
+
+  // Indicates whether ownContent is holding onto a Cap'n Proto RPC response. This is important
+  // to know because such an RPC response must be destroyed on the same thread where it was
+  //  created, and generally should be destroyed "relatively soon", not kept around forever. If
+  //  this is false, then it is perfectly safe to transfer ownership of ownContent between threads
+  //  and keep it alive indefinitely long.
+  bool ownContentIsRpcResponse = true;
 };
 
 }  // namespace workerd


### PR DESCRIPTION
Required for the internal PR for selectively preserving the own content