### PR TITLE
[o11y] Drop STW link type for now

### DIFF
--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -45,9 +45,7 @@ namespace {
   V(INVOCATIONID, "invocationId")                                                                  \
   V(JSRPC, "jsrpc")                                                                                \
   V(KILLSWITCH, "killSwitch")                                                                      \
-  V(LABEL, "label")                                                                                \
   V(LEVEL, "level")                                                                                \
-  V(LINK, "link")                                                                                  \
   V(LOADSHED, "loadShed")                                                                          \
   V(LOG, "log")                                                                                    \
   V(MAILFROM, "mailFrom")                                                                          \
@@ -535,18 +533,6 @@ jsg::JsValue ToJs(jsg::Lock& js, const tracing::Return& ret, StringCache& cache)
   return obj;
 }
 
-jsg::JsValue ToJs(jsg::Lock& js, const tracing::Link& link, StringCache& cache) {
-  auto obj = js.obj();
-  obj.set(js, TYPE_STR, cache.get(js, LINK_STR));
-  KJ_IF_SOME(label, link.label) {
-    obj.set(js, LABEL_STR, js.str(label));
-  }
-  obj.set(js, TRACEID_STR, js.str(link.traceId.toGoString()));
-  obj.set(js, INVOCATIONID_STR, js.str(link.invocationId.toGoString()));
-  obj.set(js, SPANID_STR, js.str(link.spanId.toGoString()));
-  return obj;
-}
-
 jsg::JsValue ToJs(jsg::Lock& js, const tracing::TailEvent& event, StringCache& cache) {
   auto obj = js.obj();
   obj.set(js, TRACEID_STR, js.str(event.traceId.toGoString()));
@@ -582,9 +568,6 @@ jsg::JsValue ToJs(jsg::Lock& js, const tracing::TailEvent& event, StringCache& c
     }
     KJ_CASE_ONEOF(ret, tracing::Return) {
       obj.set(js, EVENT_STR, ToJs(js, ret, cache));
-    }
-    KJ_CASE_ONEOF(link, tracing::Link) {
-      obj.set(js, EVENT_STR, ToJs(js, link, cache));
     }
     KJ_CASE_ONEOF(attrs, CustomInfo) {
       obj.set(js, EVENT_STR, ToJs(js, attrs, cache));
@@ -624,9 +607,6 @@ kj::Maybe<kj::StringPtr> getHandlerName(const tracing::TailEvent& event) {
     }
     KJ_CASE_ONEOF(_, tracing::Return) {
       return RETURN_STR;
-    }
-    KJ_CASE_ONEOF(_, tracing::Link) {
-      return LINK_STR;
     }
     KJ_CASE_ONEOF(_, tracing::CustomInfo) {
       return ATTRIBUTES_STR;

--- a/src/workerd/io/trace-test.c++
+++ b/src/workerd/io/trace-test.c++
@@ -527,23 +527,6 @@ KJ_TEST("Read/Write Outcome works") {
   KJ_ASSERT(info3.cpuTime == 1 * kj::MILLISECONDS);
 }
 
-KJ_TEST("Read/Write Link works") {
-  capnp::MallocMessageBuilder builder;
-  auto infoBuilder = builder.initRoot<rpc::Trace::Link>();
-
-  FakeEntropySource entropy;
-  auto context = tracing::InvocationSpanContext::newForInvocation(kj::none, entropy);
-
-  tracing::Link link(context, kj::str("foo"));
-  link.copyTo(infoBuilder);
-
-  tracing::Link link2(infoBuilder.asReader());
-  KJ_ASSERT(KJ_ASSERT_NONNULL(link2.label) == "foo"_kj);
-  KJ_ASSERT(link2.traceId == context.getTraceId());
-  KJ_ASSERT(link2.invocationId == context.getInvocationId());
-  KJ_ASSERT(link2.spanId == context.getSpanId());
-}
-
 KJ_TEST("Read/Write TailEvent works") {
   capnp::MallocMessageBuilder builder;
   auto infoBuilder = builder.initRoot<rpc::Trace::TailEvent>();

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -657,26 +657,7 @@ struct Return final {
   Return clone() const;
 };
 
-// A Link mark is used to establish a link from one span to another.
-// The optional label can be used to identify the link.
-struct Link final {
-  explicit Link(const InvocationSpanContext& other, kj::Maybe<kj::String> label = kj::none);
-  explicit Link(kj::Maybe<kj::String> label, TraceId traceId, TraceId invocationId, SpanId spanId);
-  Link(rpc::Trace::Link::Reader reader);
-  Link(Link&&) = default;
-  Link& operator=(Link&&) = default;
-  KJ_DISALLOW_COPY(Link);
-
-  kj::Maybe<kj::String> label;
-  TraceId traceId;
-  TraceId invocationId;
-  SpanId spanId;
-
-  void copyTo(rpc::Trace::Link::Builder builder) const;
-  Link clone() const;
-};
-
-// Mark events no longer have a corresponding type, but the term generally refers to DiagnosticChannelEvent, Exception, Log, Return, Link, and CustomInfo events.
+// Mark events no longer have a corresponding type, but the term generally refers to DiagnosticChannelEvent, Exception, Log, Return, and CustomInfo events.
 
 // Marks the opening of a child span within the streaming tail session.
 struct SpanOpen final {
@@ -793,6 +774,7 @@ struct Outcome final {
 // always an Outcome. Between those can be any number of SpanOpen, SpanClose,
 // and Mark events. Every SpanOpen *must* be associated with a SpanClose unless
 // the stream was abruptly terminated.
+// A future version may add support for Link events again.
 struct TailEvent final {
   using Event = kj::OneOf<Onset,
       Outcome,
@@ -803,7 +785,6 @@ struct TailEvent final {
       Exception,
       Log,
       Return,
-      Link,
       CustomInfo>;
 
   explicit TailEvent(

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -261,12 +261,6 @@ struct Trace @0x8e8d911203762d34 {
     # A hibernate event indicates that the tail session is being hibernated.
   }
 
-  struct Link {
-    # A link to another invocation span context.
-    label @0 :Text;
-    context @1 :InvocationSpanContext;
-  }
-
   struct TailEvent {
     # A streaming tail worker receives a series of Tail Events. Tail events always
     # occur within an InvocationSpanContext. The first TailEvent delivered to a
@@ -288,7 +282,6 @@ struct Trace @0x8e8d911203762d34 {
       diagnosticChannelEvent @10 :DiagnosticChannelEvent;
       exception @11 :Exception;
       log @12 :Log;
-      link @13 :Link;
     }
   }
 }

--- a/types/defines/trace.d.ts
+++ b/types/defines/trace.d.ts
@@ -157,14 +157,6 @@ interface Return {
   readonly info?: FetchResponseInfo;
 }
 
-interface Link {
-  readonly type: "link";
-  readonly label?: string;
-  readonly traceId: string;
-  readonly invocationId: string;
-  readonly spanId: string;
-}
-
 interface Attribute {
   readonly name: string;
   readonly value: string | string[] | boolean | boolean[] | number | number[] | bigint | bigint[];
@@ -185,7 +177,6 @@ type EventType =
   | Exception
   | Log
   | Return
-  | Link
   | Attributes;
 
 interface TailEvent<Event extends EventType> {
@@ -209,7 +200,6 @@ type TailEventHandlerObject = {
   exception?: TailEventHandler<Exception>;
   log?: TailEventHandler<Log>;
   return?: TailEventHandler<Return>;
-  link?: TailEventHandler<Link>;
   attributes?: TailEventHandler<Attributes>;
 };
 

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -8413,13 +8413,6 @@ declare namespace TailStream {
     readonly type: "return";
     readonly info?: FetchResponseInfo;
   }
-  interface Link {
-    readonly type: "link";
-    readonly label?: string;
-    readonly traceId: string;
-    readonly invocationId: string;
-    readonly spanId: string;
-  }
   interface Attribute {
     readonly name: string;
     readonly value:
@@ -8446,7 +8439,6 @@ declare namespace TailStream {
     | Exception
     | Log
     | Return
-    | Link
     | Attributes;
   interface TailEvent<Event extends EventType> {
     readonly invocationId: string;
@@ -8467,7 +8459,6 @@ declare namespace TailStream {
     exception?: TailEventHandler<Exception>;
     log?: TailEventHandler<Log>;
     return?: TailEventHandler<Return>;
-    link?: TailEventHandler<Link>;
     attributes?: TailEventHandler<Attributes>;
   };
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -8258,13 +8258,6 @@ export declare namespace TailStream {
     readonly type: "return";
     readonly info?: FetchResponseInfo;
   }
-  interface Link {
-    readonly type: "link";
-    readonly label?: string;
-    readonly traceId: string;
-    readonly invocationId: string;
-    readonly spanId: string;
-  }
   interface Attribute {
     readonly name: string;
     readonly value:
@@ -8291,7 +8284,6 @@ export declare namespace TailStream {
     | Exception
     | Log
     | Return
-    | Link
     | Attributes;
   interface TailEvent<Event extends EventType> {
     readonly invocationId: string;
@@ -8312,7 +8304,6 @@ export declare namespace TailStream {
     exception?: TailEventHandler<Exception>;
     log?: TailEventHandler<Log>;
     return?: TailEventHandler<Return>;
-    link?: TailEventHandler<Link>;
     attributes?: TailEventHandler<Attributes>;
   };
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -8193,13 +8193,6 @@ declare namespace TailStream {
     readonly type: "return";
     readonly info?: FetchResponseInfo;
   }
-  interface Link {
-    readonly type: "link";
-    readonly label?: string;
-    readonly traceId: string;
-    readonly invocationId: string;
-    readonly spanId: string;
-  }
   interface Attribute {
     readonly name: string;
     readonly value:
@@ -8226,7 +8219,6 @@ declare namespace TailStream {
     | Exception
     | Log
     | Return
-    | Link
     | Attributes;
   interface TailEvent<Event extends EventType> {
     readonly invocationId: string;
@@ -8247,7 +8239,6 @@ declare namespace TailStream {
     exception?: TailEventHandler<Exception>;
     log?: TailEventHandler<Log>;
     return?: TailEventHandler<Return>;
-    link?: TailEventHandler<Link>;
     attributes?: TailEventHandler<Attributes>;
   };
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -8038,13 +8038,6 @@ export declare namespace TailStream {
     readonly type: "return";
     readonly info?: FetchResponseInfo;
   }
-  interface Link {
-    readonly type: "link";
-    readonly label?: string;
-    readonly traceId: string;
-    readonly invocationId: string;
-    readonly spanId: string;
-  }
   interface Attribute {
     readonly name: string;
     readonly value:
@@ -8071,7 +8064,6 @@ export declare namespace TailStream {
     | Exception
     | Log
     | Return
-    | Link
     | Attributes;
   interface TailEvent<Event extends EventType> {
     readonly invocationId: string;
@@ -8092,7 +8084,6 @@ export declare namespace TailStream {
     exception?: TailEventHandler<Exception>;
     log?: TailEventHandler<Log>;
     return?: TailEventHandler<Return>;
-    link?: TailEventHandler<Link>;
     attributes?: TailEventHandler<Attributes>;
   };
   type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;


### PR DESCRIPTION
Link events were not being emitted anywhere, only the type and support for serializing it was implemented. It will not be available in the initial version, but may be supported in the future if there is a use case for it.