### PR TITLE
[o11y] Stop using BigInt in STW API

### DIFF
--- a/src/workerd/api/kv-instrumentation-test.js
+++ b/src/workerd/api/kv-instrumentation-test.js
@@ -99,7 +99,7 @@ export const test = {
         name: 'kv_get_bulk',
         'db.system': 'cloudflare-kv',
         'cloudflare.kv.operation.name': 'get_bulk',
-        'cloudflare.kv.query.parameter.cacheTtl': 100n,
+        'cloudflare.kv.query.parameter.cacheTtl': 100,
         closed: true,
       },
       { closed: true, name: 'worker' },

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -144,7 +144,13 @@ jsg::JsValue ToJs(jsg::Lock& js, const tracing::Attribute::Value& value) {
       return js.num(d);
     }
     KJ_CASE_ONEOF(i, int64_t) {
-      return js.bigInt(i);
+      // We report integer values using the JS number type, instead of BigInt (which is not natively
+      // stringifiable). This limits precision to 53 bits.
+      // TODO: Document this limitation
+      // TODO(someday): Prohibit reporting integer tag values at tag creation time? For that we'd
+      // need to change the SpanTag definition, not sure if it's it since being unable to create a
+      // tag with an integral type is confusing.
+      return js.num((double)i);
     }
   }
   KJ_UNREACHABLE;


### PR DESCRIPTION
BigInt is not natively stringifiable – this has caused confusion several times and is bound to do so for external users too, report tag values using the Number type instead.