### PR TITLE
introduce nodejs_compat eol methods

### DIFF
--- a/src/node/os.ts
+++ b/src/node/os.ts
@@ -74,13 +74,7 @@ export function networkInterfaces(): NetworkInterfaceInfo[] {
   return {};
 }
 
-export function platform():
-  | 'linux'
-  | 'darwin'
-  | 'win32'
-  | 'freebsd'
-  | 'sunos'
-  | 'aix' {
+export function platform(): NodeJS.Platform {
   // Workers only supports POSIX platforms.
   return 'linux';
 }

--- a/src/node/tls.ts
+++ b/src/node/tls.ts
@@ -36,6 +36,16 @@ import {
 } from 'node-internal:internal_tls_common';
 import * as constants from 'node-internal:internal_tls_constants';
 import { TLSSocket, connect } from 'node-internal:internal_tls_wrap';
+import { ERR_METHOD_NOT_IMPLEMENTED } from 'node-internal:internal_errors';
+
+let createSecurePair = undefined;
+
+if (!Cloudflare.compatibilityFlags.remove_nodejs_compat_eol_methods) {
+  createSecurePair = function createSecurePair(): void {
+    throw new ERR_METHOD_NOT_IMPLEMENTED('createSecurePair');
+  };
+}
+
 export * from 'node-internal:internal_tls_constants';
 export {
   TLSSocket,
@@ -47,6 +57,7 @@ export {
   Server,
   convertALPNProtocols,
   getCiphers,
+  createSecurePair,
 };
 export default {
   SecureContext,
@@ -58,5 +69,6 @@ export default {
   checkServerIdentity,
   convertALPNProtocols,
   getCiphers,
+  createSecurePair,
   ...constants,
 };

--- a/src/node/tls.ts
+++ b/src/node/tls.ts
@@ -40,7 +40,7 @@ import { ERR_METHOD_NOT_IMPLEMENTED } from 'node-internal:internal_errors';
 
 let createSecurePair = undefined;
 
-if (!Cloudflare.compatibilityFlags.remove_nodejs_compat_eol_methods) {
+if (!Cloudflare.compatibilityFlags.remove_nodejs_compat_eol) {
   createSecurePair = function createSecurePair(): void {
     throw new ERR_METHOD_NOT_IMPLEMENTED('createSecurePair');
   };

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -8,6 +8,7 @@
 import { default as internalTypes } from 'node-internal:internal_types';
 import { default as utilImpl } from 'node-internal:util';
 import { isDeepStrictEqual as _isDeepStrictEqual } from 'node-internal:internal_comparisons';
+import { Buffer } from 'node-internal:internal_buffer';
 
 import {
   validateFunction,
@@ -38,7 +39,66 @@ import {
   isWritableStream,
   isNodeStream,
 } from 'node-internal:streams_util';
-export { inspect, format, formatWithOptions, stripVTControlCharacters };
+
+let isBoolean = undefined;
+let isBuffer = undefined;
+let isDate = undefined;
+let isError = undefined;
+let isFunction = undefined;
+let isNull = undefined;
+let isNullOrUndefined = undefined;
+let isNumber = undefined;
+let isObject = undefined;
+let isPrimitive = undefined;
+let isRegExp = undefined;
+let isString = undefined;
+let isSymbol = undefined;
+let isUndefined = undefined;
+
+if (!Cloudflare.compatibilityFlags.remove_nodejs_compat_eol_methods) {
+  isBoolean = (val: unknown): boolean => typeof val === 'boolean';
+  isBuffer = (val: unknown): boolean => Buffer.isBuffer(val);
+  isDate = (val: unknown): boolean => val instanceof Date;
+  // @ts-expect-error TS2339 Error.isError is not defined in the current typescript version.
+  isError = (val: unknown): boolean => Error.isError(val);
+  isFunction = (val: unknown): boolean => typeof val === 'function';
+  isNull = (val: unknown): boolean => val === null;
+  isNullOrUndefined = (val: unknown): boolean => val == null;
+  isNumber = (val: unknown): boolean => typeof val === 'number';
+  isObject = (val: unknown): boolean => val != null && typeof val === 'object';
+  isPrimitive = (val: unknown): boolean =>
+    val === null || (typeof val !== 'object' && typeof val !== 'function');
+  isRegExp = (val: unknown): boolean => val instanceof RegExp;
+  isString = (val: unknown): boolean => typeof val === 'string';
+  isSymbol = (val: unknown): boolean => typeof val === 'symbol';
+  isUndefined = (val: unknown): boolean => val === undefined;
+}
+
+export {
+  inspect,
+  format,
+  formatWithOptions,
+  stripVTControlCharacters,
+
+  // EOL methods
+  isBoolean,
+  isBuffer,
+  isDate,
+  isError,
+  isFunction,
+  isNull,
+  isNullOrUndefined,
+  isNumber,
+  isObject,
+  isPrimitive,
+  isRegExp,
+  isString,
+  isSymbol,
+  isUndefined,
+};
+export function isArray(val: unknown): boolean {
+  return Array.isArray(val);
+}
 export { callbackify, parseEnv } from 'node-internal:internal_utils';
 export const types = internalTypes;
 
@@ -225,10 +285,6 @@ export function isDeepStrictEqual(a: unknown, b: unknown): boolean {
   return _isDeepStrictEqual(a, b);
 }
 
-export function isArray(a: unknown): a is Array<any> {
-  return Array.isArray(a);
-}
-
 export function getSystemErrorMap(): void {
   throw new Error('node:util getSystemErrorMap is not implemented');
 }
@@ -353,5 +409,21 @@ export default {
   getCallSite,
   getCallSites,
   isDeepStrictEqual,
+
+  // EOL methods
   isArray,
+  isBoolean,
+  isBuffer,
+  isDate,
+  isError,
+  isFunction,
+  isNull,
+  isNullOrUndefined,
+  isNumber,
+  isObject,
+  isPrimitive,
+  isRegExp,
+  isString,
+  isSymbol,
+  isUndefined,
 };

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -52,7 +52,7 @@ let isString: ((val: unknown) => boolean) | undefined = undefined;
 let isSymbol: ((val: unknown) => boolean) | undefined = undefined;
 let isUndefined: ((val: unknown) => boolean) | undefined = undefined;
 
-if (!Cloudflare.compatibilityFlags.remove_nodejs_compat_eol_methods) {
+if (!Cloudflare.compatibilityFlags.remove_nodejs_compat_eol) {
   isBoolean = (val: unknown): boolean => typeof val === 'boolean';
   isBuffer = (val: unknown): boolean => Buffer.isBuffer(val);
   isDate = (val: unknown): boolean => val instanceof Date;

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -2,9 +2,6 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-/* TODO: the following is adopted code, enabling linting one day */
-/* eslint-disable */
-
 import { default as internalTypes } from 'node-internal:internal_types';
 import { default as utilImpl } from 'node-internal:util';
 import { isDeepStrictEqual as _isDeepStrictEqual } from 'node-internal:internal_comparisons';
@@ -40,26 +37,27 @@ import {
   isNodeStream,
 } from 'node-internal:streams_util';
 
-let isBoolean = undefined;
-let isBuffer = undefined;
-let isDate = undefined;
-let isError = undefined;
-let isFunction = undefined;
-let isNull = undefined;
-let isNullOrUndefined = undefined;
-let isNumber = undefined;
-let isObject = undefined;
-let isPrimitive = undefined;
-let isRegExp = undefined;
-let isString = undefined;
-let isSymbol = undefined;
-let isUndefined = undefined;
+let isBoolean: ((val: unknown) => boolean) | undefined = undefined;
+let isBuffer: ((val: unknown) => boolean) | undefined = undefined;
+let isDate: ((val: unknown) => boolean) | undefined = undefined;
+let isError: ((val: unknown) => boolean) | undefined = undefined;
+let isFunction: ((val: unknown) => boolean) | undefined = undefined;
+let isNull: ((val: unknown) => boolean) | undefined = undefined;
+let isNullOrUndefined: ((val: unknown) => boolean) | undefined = undefined;
+let isNumber: ((val: unknown) => boolean) | undefined = undefined;
+let isObject: ((val: unknown) => boolean) | undefined = undefined;
+let isPrimitive: ((val: unknown) => boolean) | undefined = undefined;
+let isRegExp: ((val: unknown) => boolean) | undefined = undefined;
+let isString: ((val: unknown) => boolean) | undefined = undefined;
+let isSymbol: ((val: unknown) => boolean) | undefined = undefined;
+let isUndefined: ((val: unknown) => boolean) | undefined = undefined;
 
 if (!Cloudflare.compatibilityFlags.remove_nodejs_compat_eol_methods) {
   isBoolean = (val: unknown): boolean => typeof val === 'boolean';
   isBuffer = (val: unknown): boolean => Buffer.isBuffer(val);
   isDate = (val: unknown): boolean => val instanceof Date;
   // @ts-expect-error TS2339 Error.isError is not defined in the current typescript version.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-call
   isError = (val: unknown): boolean => Error.isError(val);
   isFunction = (val: unknown): boolean => typeof val === 'function';
   isNull = (val: unknown): boolean => val === null;
@@ -110,6 +108,7 @@ const kCustomPromisifyArgsSymbol = Symbol.for(
 );
 
 // TODO(later): Proper type signature for promisify.
+/* eslint-disable */
 export function promisify(original: Function): Function {
   validateFunction(original, 'original');
 
@@ -169,10 +168,13 @@ export function promisify(original: Function): Function {
 }
 
 promisify.custom = kCustomPromisifiedSymbol;
+/* eslint-enable */
 
-export function inherits(ctor: Function, superCtor: Function) {
-  if (ctor === undefined || ctor === null)
-    throw new ERR_INVALID_ARG_TYPE('ctor', 'Function', ctor);
+export function inherits(
+  ctor: Function | null | undefined, // eslint-disable-line @typescript-eslint/no-unsafe-function-type
+  superCtor: Function | null | undefined // eslint-disable-line @typescript-eslint/no-unsafe-function-type
+): void {
+  if (ctor == null) throw new ERR_INVALID_ARG_TYPE('ctor', 'Function', ctor);
 
   if (superCtor === undefined || superCtor === null)
     throw new ERR_INVALID_ARG_TYPE('superCtor', 'Function', superCtor);
@@ -189,17 +191,22 @@ export function inherits(ctor: Function, superCtor: Function) {
     writable: true,
     configurable: true,
   });
-  Object.setPrototypeOf(ctor.prototype, superCtor.prototype);
+  Object.setPrototypeOf(ctor.prototype, superCtor.prototype); // eslint-disable-line @typescript-eslint/no-unsafe-argument
 }
 
-export function _extend(target: Object, source: Object) {
+export function _extend<T extends Record<string, unknown>>(
+  target: T,
+  source: unknown
+): T {
   // Don't do anything if source isn't an object
   if (source === null || typeof source !== 'object') return target;
 
   const keys = Object.keys(source);
   let i = keys.length;
   while (i--) {
-    (target as any)[keys[i]!] = (source as any)[keys[i]!];
+    (target as Record<string, unknown>)[keys[i] as keyof typeof source] = (
+      source as Record<string, unknown>
+    )[keys[i] as keyof typeof source];
   }
   return target;
 }
@@ -207,11 +214,11 @@ export function _extend(target: Object, source: Object) {
 export const TextDecoder = globalThis.TextDecoder;
 export const TextEncoder = globalThis.TextEncoder;
 
-export function toUSVString(input: any) {
+export function toUSVString(input: string): string {
   return input.toWellFormed();
 }
 
-function pad(n: any): string {
+function pad(n: unknown): string {
   return `${n}`.padStart(2, '0');
 }
 
@@ -227,24 +234,28 @@ function timestamp(): string {
   return `${d.getDate()} ${months[d.getMonth()]} ${t}`;
 }
 
-export function log(...args: any[]) {
+export function log(...args: unknown[]): void {
   console.log('%s - %s', timestamp(), format(...args));
 }
 
-export function parseArgs(..._: any[]): any {
+export function parseArgs(): unknown {
   // We currently have no plans to implement the util.parseArgs API.
   throw new Error('node:util parseArgs is not implemented');
 }
 
-export function transferableAbortController(..._: any[]): any {
+export function transferableAbortController(): void {
   throw new Error('node:util transferableAbortController is not implemented');
 }
 
-export function transferableAbortSignal(..._: any[]): any {
+export function transferableAbortSignal(): void {
   throw new Error('node:util transferableAbortSignal is not implemented');
 }
 
-export async function aborted(signal: AbortSignal, resource: object) {
+export async function aborted(
+  signal: unknown,
+  resource: unknown
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+): Promise<Event | void> {
   if (signal === undefined) {
     throw new ERR_INVALID_ARG_TYPE('signal', 'AbortSignal', signal);
   }
@@ -256,18 +267,18 @@ export async function aborted(signal: AbortSignal, resource: object) {
   validateAbortSignal(signal, 'signal');
   validateObject(resource, 'resource', kValidateObjectAllowObjects);
   if (signal.aborted) return Promise.resolve();
-  const { promise, resolve } = Promise.withResolvers();
+  const { promise, resolve } = Promise.withResolvers<Event>();
   const opts = { __proto__: null, once: true };
   signal.addEventListener('abort', resolve, opts);
   return promise;
 }
 
-export function deprecate(
-  fn: Function,
+export function deprecate<T = unknown>(
+  fn: T,
   _1?: string,
   _2?: string,
   _3?: boolean
-) {
+): T {
   // TODO(soon): Node.js's implementation wraps the given function in a new function that
   // logs a warning to the console if the function is called. Do we want to support that?
   // For now, we're just going to silently return the input method unmodified.
@@ -315,10 +326,9 @@ type TTYStream = (ReadableStream | WritableStream) & {
   getColorDepth(): number;
 };
 
-function isTTYStream(
-  stream: ReadableStream | WritableStream
-): stream is TTYStream {
+function isTTYStream(stream: unknown): stream is TTYStream {
   return (
+    stream != null &&
     typeof stream === 'object' &&
     'isTTY' in stream &&
     !!stream.isTTY &&
@@ -326,13 +336,15 @@ function isTTYStream(
   );
 }
 
-const stdoutPlaceholder = Object.create(null);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const stdoutPlaceholder: StyleTextOptions['stream'] = Object.create(null);
 export function styleText(
   format: string | string[],
-  text: string,
+  text: unknown,
   { validateStream = true, stream = stdoutPlaceholder }: StyleTextOptions = {}
 ): string {
   validateString(text, 'text');
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare
   if (validateStream !== true)
     validateBoolean(validateStream, 'options.validateStream');
 

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -422,8 +422,8 @@ export default {
   getCallSites,
   isDeepStrictEqual,
 
-  // EOL methods
   isArray,
+  // EOL methods
   isBoolean,
   isBuffer,
   isDate,

--- a/src/workerd/api/node/tests/tls-nodejs-test.js
+++ b/src/workerd/api/node/tests/tls-nodejs-test.js
@@ -1030,3 +1030,9 @@ export const testTlsStreamwrapBuffersize = {
     strictEqual(onCloseFn.mock.callCount(), 1);
   },
 };
+
+export const testEOLMethods = {
+  async test() {
+    strictEqual(typeof tls.createSecurePair, 'function');
+  },
+};

--- a/src/workerd/api/node/tests/util-nodejs-test.js
+++ b/src/workerd/api/node/tests/util-nodejs-test.js
@@ -5908,3 +5908,23 @@ export const testParseEnv = {
     );
   },
 };
+
+export const supportEOLMethods = {
+  async test() {
+    assert.strictEqual(typeof util.isArray, 'function');
+    assert.strictEqual(typeof util.isBoolean, 'function');
+    assert.strictEqual(typeof util.isBuffer, 'function');
+    assert.strictEqual(typeof util.isDate, 'function');
+    assert.strictEqual(typeof util.isError, 'function');
+    assert.strictEqual(typeof util.isFunction, 'function');
+    assert.strictEqual(typeof util.isNull, 'function');
+    assert.strictEqual(typeof util.isNullOrUndefined, 'function');
+    assert.strictEqual(typeof util.isNumber, 'function');
+    assert.strictEqual(typeof util.isObject, 'function');
+    assert.strictEqual(typeof util.isPrimitive, 'function');
+    assert.strictEqual(typeof util.isRegExp, 'function');
+    assert.strictEqual(typeof util.isString, 'function');
+    assert.strictEqual(typeof util.isSymbol, 'function');
+    assert.strictEqual(typeof util.isUndefined, 'function');
+  },
+};

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -935,4 +935,16 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatEnableDate("2025-08-11");
   # Disables adding `/session/metadata/vendor` to the Python Worker's sys.path. So Workers using
   # this flag will have to place their vendored modules in a `python_modules` directory.
+
+  removeNodejsCompatEOLMethods @108 :Bool
+    $compatEnableFlag("remove_nodejs_compat_eol_methods")
+    $compatDisableFlag("add_nodejs_compat_eol_methods")
+    $impliedByAfterDate(name = "nodeJsCompat", date = "2025-09-01");
+  # Removes the Node.js compatibility layer for EOL versions of Node.js.
+  # When the flag is enabled, APIs that have reached End-of-Life in Node.js
+  # will be removed for workers. When disabled, the APIs are present (but
+  # might still be non-functional stubs)
+  # This flag is intended to be a roll-up flag. That is, as additional APIs
+  # reach EOL, new compat flags will be added for those that will have
+  # `impliedByAfterDate(name = "removeNodeJsCompatEOL", ...` annotations.
 }

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -936,9 +936,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # Disables adding `/session/metadata/vendor` to the Python Worker's sys.path. So Workers using
   # this flag will have to place their vendored modules in a `python_modules` directory.
 
-  removeNodejsCompatEOLMethods @108 :Bool
-    $compatEnableFlag("remove_nodejs_compat_eol_methods")
-    $compatDisableFlag("add_nodejs_compat_eol_methods")
+  removeNodejsCompatEOL @108 :Bool
+    $compatEnableFlag("remove_nodejs_compat_eol")
+    $compatDisableFlag("add_nodejs_compat_eol")
     $impliedByAfterDate(name = "nodeJsCompat", date = "2025-09-01");
   # Removes the Node.js compatibility layer for EOL versions of Node.js.
   # When the flag is enabled, APIs that have reached End-of-Life in Node.js


### PR DESCRIPTION
Adds EOL methods to be removed on a future date. Let's keep this open for now and make sure we have all the methods that are EOL in a single compat flag.