### PR TITLE
Python ts MAINT: Remove some type assertions

### DIFF
--- a/src/pyodide/internal/metadatafs.ts
+++ b/src/pyodide/internal/metadatafs.ts
@@ -49,7 +49,7 @@ export function createMetadataFS(Module: Module): object {
         node.tree = info as MetadataDirInfo;
       } else {
         node.index = info as number;
-        node.usedBytes = sizes[info as number] as number;
+        node.usedBytes = sizes[info as number]!;
       }
     },
     readdir(node) {

--- a/src/pyodide/internal/readOnlyFS.ts
+++ b/src/pyodide/internal/readOnlyFS.ts
@@ -50,7 +50,7 @@ export function createReadonlyFS<Info>(
       lookup(parent, name) {
         const child = FSOps.lookup(parent, name);
         if (child === undefined) {
-          throw FS.genericErrors[44] as Error; // ENOENT
+          throw FS.genericErrors[44]; // ENOENT
         }
         return ReadOnlyFS.createNode(parent, name, child);
       },

--- a/src/pyodide/internal/setupPackages.ts
+++ b/src/pyodide/internal/setupPackages.ts
@@ -121,8 +121,8 @@ class VirtualizedDir {
     // add all the .so files we will need to preload from the big bundle
     for (const soFile of soFiles) {
       // If folder is in list of requirements include .so file in list to preload.
-      const [pkg, ...rest] = soFile.split('/') as [string, ...string[]];
-      if (requirements.has(pkg)) {
+      const [pkg, ...rest] = soFile.split('/');
+      if (requirements.has(pkg!)) {
         this.soFiles.push(rest);
       }
     }

--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -425,8 +425,8 @@ function decodeSnapshot(
     );
   }
   // buf[1] is SNAPSHOT_VERSION (unused currently)
-  const snapshotOffset = header[2] as number;
-  const jsonByteLength = header[3] as number;
+  const snapshotOffset = header[2]!;
+  const jsonByteLength = header[3]!;
 
   const snapshotSize = reader.getMemorySnapshotSize() - snapshotOffset;
   const jsonBuf = new Uint8Array(jsonByteLength);

--- a/src/pyodide/internal/tar.ts
+++ b/src/pyodide/internal/tar.ts
@@ -28,7 +28,7 @@ function decodeHeader(buf: Uint8Array, reader: Reader): TarFSInfo {
   const mode = decodeNumber(buf, 100, 8);
   const size = decodeNumber(buf, 124, 12);
   const modtime = decodeNumber(buf, 136, 12);
-  const type = String.fromCharCode(buf[156] as number);
+  const type = String.fromCharCode(buf[156]!);
   return {
     path,
     name: path,
@@ -112,7 +112,7 @@ export function parseTarInfo(reader: Reader): [TarFSInfo, string[]] {
     const parts = info.path.slice(0, -1).split('/');
     for (let i = directories.length; i < parts.length - 1; i++) {
       directories.push(directory);
-      directory = directory.children!.get(parts[i] as string)!;
+      directory = directory.children!.get(parts[i]!)!;
     }
     if (info.type === '5') {
       // a directory

--- a/src/pyodide/internal/topLevelEntropy/lib.ts
+++ b/src/pyodide/internal/topLevelEntropy/lib.ts
@@ -34,7 +34,7 @@ function setupShouldAllowBadEntropy(Module: Module): void {
 function shouldAllowBadEntropy(Module: Module): boolean {
   const val = Module.HEAP8[allowed_entropy_calls_addr];
   if (val) {
-    (Module.HEAP8[allowed_entropy_calls_addr] as number)--;
+    Module.HEAP8[allowed_entropy_calls_addr]!--;
     return true;
   }
   return false;

--- a/src/pyodide/types/filesystem.d.ts
+++ b/src/pyodide/types/filesystem.d.ts
@@ -31,7 +31,7 @@ interface FS {
   ): FSNode<Info>;
   isFile: (mode: number) => boolean;
   readdir: (path: string) => string[];
-  genericErrors: Error[];
+  genericErrors: { 44: Error };
   sitePackages: string;
   sessionSitePackages: string;
   ErrnoError: { new (errno: number): Error };


### PR DESCRIPTION
If the goal is to narrow the type from `type | undefined` to `type`, it's better to do it with `!` since we still get some type checking. It's also shorter.