### PR TITLE
Revert "Use new js error serialization to preserve error details (#4698)

### DIFF
--- a/samples/helloworld_esm/worker.js
+++ b/samples/helloworld_esm/worker.js
@@ -2,8 +2,6 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-throw new AggregateError([new Error('boom')], 'message', { cause: new Error('cause') });
-
 export default {
   async fetch(req, env) {
     return new Response("Hello World\n");

--- a/src/pyodide/internal/_workers.py
+++ b/src/pyodide/internal/_workers.py
@@ -205,9 +205,7 @@ def _to_python_exception(exc: JsException) -> Exception:
 def _from_js_error(exc: JsException) -> Exception:
     # convert into Python exception after a full round trip
     # Python - JS - Python
-    if exc.name != "PythonError" and (
-        not exc.message or not exc.message.startswith("PythonError")
-    ):
+    if not exc.message or not exc.message.startswith("PythonError"):
         return _to_python_exception(exc)
 
     # extract the Python exception type from the traceback

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2177,7 +2177,36 @@ void Worker::Lock::logUncaughtException(
 
 void Worker::Lock::logUncaughtException(UncaughtExceptionSource source, kj::Exception&& exception) {
   jsg::Lock& js = *this;
-  auto jsError = js.exceptionToJsValue(kj::mv(exception), {.trusted = true});
+
+  // If we have an attached serialized exception, deserialize it and log that instead, rather
+  // than try to reconstruct based on the KJ exception description.
+  //
+  // TODO(cleanup): Eventually, js.exceptionToJsValue() should do this internally, and then we
+  //   should remove the code from here.
+  KJ_IF_SOME(serializedJsError, exception.getDetail(jsg::TUNNELED_EXCEPTION_DETAIL_ID)) {
+    if (!js.v8Isolate->IsExecutionTerminating()) {
+      kj::Maybe<jsg::JsValue> deserialized;
+
+      v8::TryCatch tryCatch(js.v8Isolate);
+      try {
+        jsg::Deserializer deser(js, serializedJsError);
+        deserialized = deser.readValue(js);
+      } catch (jsg::JsExceptionThrown&) {
+        // Failed to deserialize, we'll continue with exceptionToJsValue() instead.
+        //
+        // Note that we're intentionally not checking tryCatch.CanContinue() here, because we still
+        // want to log the exception even if the isolate has been terminated.
+      }
+
+      KJ_IF_SOME(d, deserialized) {
+        logUncaughtException(source, d);
+        return;
+      }
+    }
+  }
+
+  // Couldn't deserialize an attached exception, so use `exceptionToJsValue()`.
+  auto jsError = js.exceptionToJsValue(kj::mv(exception));
   logUncaughtException(source, jsError.getHandle(js));
 }
 

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2502,10 +2502,9 @@ class Lock {
   // error, this reproduces the original error. If it is not a tunneled error, then it is treated
   // as an internal error: the KJ exception message is logged to stderr, and a JavaScript error
   // is returned with a generic description.
-  Value exceptionToJs(kj::Exception&& exception, MakeInternalErrorOptions options = {});
+  Value exceptionToJs(kj::Exception&& exception);
 
-  JsRef<JsValue> exceptionToJsValue(
-      kj::Exception&& exception, MakeInternalErrorOptions options = {});
+  JsRef<JsValue> exceptionToJsValue(kj::Exception&& exception);
 
   // Encodes the given JavaScript exception into a KJ exception, formatting the description in
   // such a way that hopefully exceptionToJs() can reproduce something equivalent to the original
@@ -2522,9 +2521,8 @@ class Lock {
   // via JSG understand how to handle this and propagate the exception back to JavaScript.
   [[noreturn]] void throwException(Value&& exception);
 
-  [[noreturn]] void throwException(
-      kj::Exception&& exception, MakeInternalErrorOptions options = {}) {
-    throwException(exceptionToJs(kj::mv(exception), options));
+  [[noreturn]] void throwException(kj::Exception&& exception) {
+    throwException(exceptionToJs(kj::mv(exception)));
   }
 
   [[noreturn]] void throwException(const JsValue& exception);
@@ -2611,11 +2609,11 @@ class Lock {
 
   // Construct an immediately-rejected promise throwing the given exception.
   template <typename T>
-  Promise<T> rejectedPromise(kj::Exception&& exception, MakeInternalErrorOptions options = {});
+  Promise<T> rejectedPromise(kj::Exception&& exception);
 
   // Like above, but return a pure-JS promise, not a typed Promise.
   JsPromise rejectedJsPromise(jsg::JsValue exception);
-  JsPromise rejectedJsPromise(kj::Exception&& exception, MakeInternalErrorOptions options = {});
+  JsPromise rejectedJsPromise(kj::Exception&& exception);
 
   // Like `kj::evalNow()`, but returns a jsg::Promise for the result. Synchronous exceptions are
   // caught and returned as a rejected promise.

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -624,8 +624,8 @@ JsPromise Lock::rejectedJsPromise(jsg::JsValue exception) {
   return JsPromise(handleScope.Escape(resolver->GetPromise()));
 }
 
-JsPromise Lock::rejectedJsPromise(kj::Exception&& exception, MakeInternalErrorOptions options) {
-  return rejectedJsPromise(exceptionToJsValue(kj::mv(exception), options).getHandle(*this));
+JsPromise Lock::rejectedJsPromise(kj::Exception&& exception) {
+  return rejectedJsPromise(exceptionToJsValue(kj::mv(exception)).getHandle(*this));
 }
 
 PromiseState JsPromise::state() {

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -239,8 +239,7 @@ v8::MaybeLocal<v8::Value> evaluateSyntheticModuleCallback(
   })) {
     // V8 doc comments say in the case of an error, throw the error and return an empty Maybe.
     // I.e. NOT a rejected promise. OK...
-    auto ex = js.exceptionToJsValue(kj::mv(exception));
-    js.v8Isolate->ThrowException(ex.getHandle(js));
+    js.v8Isolate->ThrowException(makeInternalError(js.v8Isolate, kj::mv(exception)));
     result = v8::Local<v8::Promise>();
   }
 

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -695,7 +695,7 @@ v8::MaybeLocal<v8::Promise> dynamicImportCallback(v8::Local<v8::Context> context
       }
       return makeRejected(tryCatch.Exception());
     } catch (kj::Exception& ex) {
-      return makeRejected(kjExceptionToJs(js.v8Isolate, kj::mv(ex)));
+      return makeRejected(makeInternalError(js.v8Isolate, kj::mv(ex)));
     }
   }
 
@@ -739,8 +739,7 @@ v8::MaybeLocal<v8::Promise> dynamicImportCallback(v8::Local<v8::Context> context
 
     return makeRejected(tryCatch.Exception());
   } catch (kj::Exception& ex) {
-    auto exc = js.exceptionToJs(kj::mv(ex));
-    return makeRejected(exc.getHandle(js));
+    return makeRejected(makeInternalError(js.v8Isolate, kj::mv(ex)));
   }
   KJ_UNREACHABLE;
 }

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -345,8 +345,7 @@ class Promise {
     }
 
     void reject(Lock& js, kj::Exception exception) {
-      auto exc = js.exceptionToJs(kj::mv(exception));
-      reject(js, exc.getHandle(js));
+      reject(js, makeInternalError(js.v8Isolate, kj::mv(exception)));
     }
 
     Resolver addRef(Lock& js) {
@@ -488,9 +487,9 @@ Promise<T> Lock::rejectedPromise(jsg::Value exception) {
 }
 
 template <typename T>
-Promise<T> Lock::rejectedPromise(kj::Exception&& exception, MakeInternalErrorOptions options) {
+Promise<T> Lock::rejectedPromise(kj::Exception&& exception) {
   return withinHandleScope(
-      [&] { return rejectedPromise<T>(kjExceptionToJs(v8Isolate, kj::mv(exception), options)); });
+      [&] { return rejectedPromise<T>(makeInternalError(v8Isolate, kj::mv(exception))); });
 }
 
 template <class Func>

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -183,7 +183,7 @@ struct DecodedException {
 };
 
 DecodedException decodeTunneledException(
-    v8::Isolate* isolate, const kj::Exception& exception, const MakeInternalErrorOptions& options) {
+    v8::Isolate* isolate, kj::StringPtr internalMessage, kj::Exception::Type excType) {
   // We currently support tunneling the following error types:
   //
   // - Error:        While the Web IDL spec claims this is reserved for use by program authors, this
@@ -202,7 +202,7 @@ DecodedException decodeTunneledException(
   // https://heycam.github.io/webidl/#idl-exceptions
   //
   // TODO(someday): Support arbitrary user-defined error types, not just Error?
-  auto tunneledInfo = tunneledErrorType(exception.getDescription());
+  auto tunneledInfo = tunneledErrorType(internalMessage);
 
   DecodedException result;
   auto errorType = tunneledInfo.message;
@@ -219,56 +219,6 @@ DecodedException decodeTunneledException(
   result.isFromRemote = tunneledInfo.isFromRemote;
   result.isDurableObjectReset = tunneledInfo.isDurableObjectReset;
 
-  do {
-    // DOMExceptions require a parenthesized error name argument, like DOMException(SyntaxError).
-    // TODO(soon): Decoding a DOMException from the serialization detail would be better but
-    // causes problems with some code paths. For now, we will decode these as new instances and
-    // ignore serialized detail that may be included.
-    if (errorType.startsWith("DOMException(")) {
-      errorType = errorType.slice(strlen("DOMException("));
-      // Check for closing brace
-      KJ_IF_SOME(closeParen, errorType.findFirst(')')) {
-        auto& js = Lock::from(isolate);
-        auto errorName = kj::str(errorType.first(closeParen));
-        auto message = appMessage(errorType.slice(1 + closeParen));
-        auto exception = js.domException(kj::mv(errorName), kj::str(message));
-        result.handle = KJ_ASSERT_NONNULL(exception.tryGetHandle(js));
-        break;
-      }
-    }
-
-    if (tunneledInfo.isJsgError) {
-      // If the error was originally converted from a JS error, then we likely have
-      // serialized the original error object as a detail, if so, let's try to use
-      // that, otherwise, we'll fall back to constructing a new error object. If
-      // the ignoreDetail optiom is set, we skip trying to deserialize.
-      if (!options.ignoreDetail) {
-        KJ_IF_SOME(serializedJsError, exception.getDetail(jsg::TUNNELED_EXCEPTION_DETAIL_ID)) {
-          kj::Maybe<jsg::JsValue> deserialized;
-          v8::TryCatch tryCatch(isolate);
-          try {
-            auto& js = Lock::from(isolate);
-            jsg::Deserializer deser(js, serializedJsError, kj::none, kj::none,
-                jsg::Deserializer::Options{
-                  // By default, we do not preserve stacks in deserialized errors because
-                  // of trust concerns sharing stack details over potentially untrusted
-                  // boundaries. However, if the caller has explicitly indiciate that the
-                  // scope it trusted, we will preserve the stack in the deserialized error.
-                  .preserveStackInErrors = options.trusted,
-                });
-            result.handle = deser.readValue(js);
-
-            // If the result came from a serialized JS detail, it might not be an object!
-            // If that's the case, we'll ignore and fallback to the normal decoding below.
-            if (result.handle->IsObject() || options.allowNonObjects) {
-              break;
-            }
-          } catch (jsg::JsExceptionThrown&) {
-            // Failed to deserialize, we'll continue with the original decoding below.
-          }
-        }
-      }
-
 #define HANDLE_V8_ERROR(error_name, error_type)                                                    \
   if (errorType.startsWith(error_name)) {                                                          \
     auto message = appMessage(errorType.slice(strlen(error_name)));                                \
@@ -276,6 +226,8 @@ DecodedException decodeTunneledException(
     break;                                                                                         \
   }
 
+  do {
+    if (tunneledInfo.isJsgError) {
       HANDLE_V8_ERROR("Error", Error);
       HANDLE_V8_ERROR("RangeError", RangeError);
       HANDLE_V8_ERROR("TypeError", TypeError);
@@ -284,28 +236,36 @@ DecodedException decodeTunneledException(
       HANDLE_V8_ERROR("CompileError", WasmCompileError);
       HANDLE_V8_ERROR("LinkError", WasmCompileError);
       HANDLE_V8_ERROR("RuntimeError", WasmCompileError);
-      HANDLE_V8_ERROR("AggregateError", AggregateError);
-      HANDLE_V8_ERROR("SuppressedError", SuppressedError);
-      HANDLE_V8_ERROR("URIError", URIError);
-      HANDLE_V8_ERROR("EvalError", EvalError);
 
-#undef HANDLE_V8_ERROR
+      // DOMExceptions require a parenthesized error name argument, like DOMException(SyntaxError).
+      if (errorType.startsWith("DOMException(")) {
+        errorType = errorType.slice(strlen("DOMException("));
+        // Check for closing brace
+        KJ_IF_SOME(closeParen, errorType.findFirst(')')) {
+          auto& js = Lock::from(isolate);
+          auto errorName = kj::str(errorType.first(closeParen));
+          auto message = appMessage(errorType.slice(1 + closeParen));
+          auto exception = js.domException(kj::mv(errorName), kj::str(message));
+          result.handle = KJ_ASSERT_NONNULL(exception.tryGetHandle(js));
+          break;
+        }
+      }
     }
-
-    // unrecognized exception type and no serialized JS error detail.
+    // unrecognized exception type
     result.internalErrorId = makeInternalErrorId();
     result.handle = v8::Exception::Error(
         v8Str(isolate, renderInternalError(KJ_ASSERT_NONNULL(result.internalErrorId))));
     result.isInternal = true;
   } while (false);
+#undef HANDLE_V8_ERROR
 
   if (result.isFromRemote) {
     setRemoteError(isolate, result.handle);
   }
 
-  if (exception.getType() == kj::Exception::Type::DISCONNECTED) {
+  if (excType == kj::Exception::Type::DISCONNECTED) {
     setRetryableError(isolate, result.handle);
-  } else if (exception.getType() == kj::Exception::Type::OVERLOADED) {
+  } else if (excType == kj::Exception::Type::OVERLOADED) {
     setOverloadedError(isolate, result.handle);
   }
 
@@ -328,13 +288,22 @@ kj::StringPtr extractTunneledExceptionDescription(kj::StringPtr message) {
   }
 }
 
-v8::Local<v8::Value> kjExceptionToJs(
-    v8::Isolate* isolate, kj::Exception&& exception, MakeInternalErrorOptions options) {
-  auto tunneledException = decodeTunneledException(isolate, exception, options);
-  bool isDisconnected = exception.getType() == kj::Exception::Type::DISCONNECTED;
+v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::Exception&& exception) {
+  auto desc = exception.getDescription();
+
+  // TODO(someday): Deserialize encoded V8 exception from
+  //   exception.getDetail(TUNNELED_EXCEPTION_DETAIL_ID), if present. WARNING: We must think
+  //   carefully about security in the case that the exception has passed between workers that
+  //   don't trust each other. Perhaps we should explicitly remove the stack trace in this case.
+  //   REMINDER: Worker::logUncaughtException() currently deserializes TUNNELED_EXCEPTION_DETAIL_ID
+  //   in order to extract a full stack trace. Once we do it here, we can remove the code from
+  //   there.
+
+  auto tunneledException = decodeTunneledException(isolate, desc, exception.getType());
+
   if (tunneledException.isInternal) {
-    bool logWithInternalId =
-        !isDisconnected && !isDoNotLogException(exception.getDescription()) && !options.doNotLog;
+    bool logWithInternalId = exception.getType() != kj::Exception::Type::DISCONNECTED &&
+        !isDoNotLogException(exception.getDescription());
     auto& observer = IsolateBase::from(isolate).getObserver();
     observer.reportInternalException(exception,
         {
@@ -355,35 +324,34 @@ v8::Local<v8::Value> kjExceptionToJs(
       KJ_LOG(INFO, exception);  // Run with --verbose to see exception logs.
     }
 
-    if (isDisconnected) {
-      auto ex = v8::Exception::Error(v8StrIntern(isolate, "Network connection lost."_kj));
+    if (exception.getType() == kj::Exception::Type::DISCONNECTED) {
+      auto exception = v8::Exception::Error(v8StrIntern(isolate, "Network connection lost."_kj));
       if (tunneledException.isFromRemote) {
-        setRemoteError(isolate, ex);
+        setRemoteError(isolate, exception);
       }
 
       // DISCONNECTED exceptions are considered retryable
-      setRetryableError(isolate, ex);
+      setRetryableError(isolate, exception);
 
       if (tunneledException.isDurableObjectReset) {
-        setDurableObjectResetError(isolate, ex);
+        setDurableObjectResetError(isolate, exception);
       }
 
-      return ex;
+      return exception;
     }
   }
 
   return tunneledException.handle;
 }
 
-Value Lock::exceptionToJs(kj::Exception&& exception, MakeInternalErrorOptions options) {
+Value Lock::exceptionToJs(kj::Exception&& exception) {
   return withinHandleScope(
-      [&] { return Value(v8Isolate, kjExceptionToJs(v8Isolate, kj::mv(exception), options)); });
+      [&] { return Value(v8Isolate, makeInternalError(v8Isolate, kj::mv(exception))); });
 }
 
-JsRef<JsValue> Lock::exceptionToJsValue(
-    kj::Exception&& exception, MakeInternalErrorOptions options) {
+JsRef<JsValue> Lock::exceptionToJsValue(kj::Exception&& exception) {
   return withinHandleScope([&] {
-    JsValue val = JsValue(kjExceptionToJs(v8Isolate, kj::mv(exception), options));
+    JsValue val = JsValue(makeInternalError(v8Isolate, kj::mv(exception)));
     return val.addRef(*this);
   });
 }
@@ -402,10 +370,9 @@ void throwInternalError(v8::Isolate* isolate, kj::StringPtr internalMessage) {
   isolate->ThrowException(makeInternalError(isolate, internalMessage));
 }
 
-void throwInternalError(
-    v8::Isolate* isolate, kj::Exception&& exception, MakeInternalErrorOptions options) {
+void throwInternalError(v8::Isolate* isolate, kj::Exception&& exception) {
   KJ_IF_SOME(renderingError, kj::runCatchingExceptions([&]() {
-    isolate->ThrowException(kjExceptionToJs(isolate, kj::mv(exception), options));
+    isolate->ThrowException(makeInternalError(isolate, kj::mv(exception)));
   })) {
     KJ_LOG(ERROR, "error rendering exception", renderingError);
     KJ_LOG(ERROR, exception);
@@ -421,7 +388,6 @@ void addExceptionDetail(Lock& js, kj::Exception& exception, v8::Local<v8::Value>
           // Make sure we don't break compatibility if V8 introduces a new version. This value can
           // be bumped to match the new version once all of production is updated to understand it.
           .version = 15,
-          .treatErrorsAsHostObjects = true,
         });
     ser.write(js, JsValue(handle));
     exception.setDetail(TUNNELED_EXCEPTION_DETAIL_ID, ser.release().data);

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -1458,11 +1458,7 @@ class ExceptionWrapper {
       v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::Exception exception) {
-    // Converts the error with default options. If the exception is a tunneled
-    // exception that has a serialized JS error, then that will be used. If
-    // that is used, the stack will be omitted by default. Pass the .trusted = true
-    // option to include the stack. See kjExceptionToJs for details.
-    return kjExceptionToJs(js.v8Isolate, kj::mv(exception));
+    return makeInternalError(js.v8Isolate, kj::mv(exception));
   }
 
   kj::Maybe<kj::Exception> tryUnwrap(Lock& js,
@@ -1512,10 +1508,6 @@ class ExceptionWrapper {
           "TypeError"_kj,
           "SyntaxError"_kj,
           "ReferenceError"_kj,
-          "AggregateError"_kj,
-          "SuppressedError"_kj,
-          "URIError"_kj,
-          "EvalError"_kj,
           // WASM Error Types
           "CompileError"_kj,
           "LinkError"_kj,


### PR DESCRIPTION
This reverts commit 9e98c6f36f486f048aa831d3f4efa3fbdb85b402.

Ran into some quirks in prod during rollout, reverting first then will investigate