### PR TITLE
add socket attribute to IncomingMessage

### DIFF
--- a/src/node/internal/internal_http_incoming.ts
+++ b/src/node/internal/internal_http_incoming.ts
@@ -86,7 +86,7 @@ export class IncomingMessage extends Readable implements _IncomingMessage {
       { headers, localPort }: { headers: Headers; localPort: number }
     ): void => {
       const connectingIp = headers.get('cf-connecting-ip');
-      const isConnectingIpIpv4 = connectingIp ? isIPv4(connectingIp) : false;
+      const isConnectingIpIpv4 = connectingIp ? isIPv4(connectingIp) : true;
       const remotePort = Math.floor(Math.random() * (65535 - 32768 + 1));
 
       incoming.#socket = {

--- a/src/node/internal/internal_http_incoming.ts
+++ b/src/node/internal/internal_http_incoming.ts
@@ -86,6 +86,7 @@ export class IncomingMessage extends Readable implements _IncomingMessage {
       { headers, localPort }: { headers: Headers; localPort: number }
     ): void => {
       const connectingIp = headers.get('cf-connecting-ip');
+      const remotePort = Math.floor(Math.random() * (65535 - 32768 + 1));
 
       incoming.#socket = {
         encrypted: headers.get('x-forwarded-proto') === 'https',
@@ -104,8 +105,9 @@ export class IncomingMessage extends Readable implements _IncomingMessage {
           return incoming.destroyed ? undefined : (connectingIp ?? '127.0.0.1');
         },
         get remotePort(): number | undefined {
-          // We return 80 by default, and undefined if the socket is destroyed.
-          return incoming.destroyed ? undefined : 80;
+          // Return a port in the ephemeral range (32768-65535) as clients would use,
+          // and undefined if the socket is destroyed.
+          return incoming.destroyed ? undefined : remotePort;
         },
         get localAddress(): string {
           // Host will have a value like "my-worker.yagiz.workers.dev",

--- a/src/node/internal/internal_http_incoming.ts
+++ b/src/node/internal/internal_http_incoming.ts
@@ -86,6 +86,7 @@ export class IncomingMessage extends Readable implements _IncomingMessage {
       { headers, localPort }: { headers: Headers; localPort: number }
     ): void => {
       const connectingIp = headers.get('cf-connecting-ip');
+      const isConnectingIpIpv4 = connectingIp ? isIPv4(connectingIp) : false;
       const remotePort = Math.floor(Math.random() * (65535 - 32768 + 1));
 
       incoming.#socket = {
@@ -94,10 +95,7 @@ export class IncomingMessage extends Readable implements _IncomingMessage {
           if (incoming.destroyed) {
             return undefined;
           }
-          if (connectingIp != null) {
-            return isIPv4(connectingIp) ? 'IPv4' : 'IPv6';
-          }
-          return 'IPv4';
+          return isConnectingIpIpv4 ? 'IPv4' : 'IPv6';
         },
         get remoteAddress(): string | undefined {
           // This is defined in production, and will fallback to localhost on local development

--- a/src/node/internal/internal_http_server.ts
+++ b/src/node/internal/internal_http_server.ts
@@ -39,7 +39,10 @@ import {
   validateNumber,
 } from 'node-internal:validators';
 import { portMapper } from 'cloudflare-internal:http';
-import { IncomingMessage } from 'node-internal:internal_http_incoming';
+import {
+  IncomingMessage,
+  setIncomingMessageSocket,
+} from 'node-internal:internal_http_incoming';
 import { STATUS_CODES } from 'node-internal:internal_http_constants';
 import {
   kServerResponse,
@@ -227,6 +230,10 @@ export class Server
     response: ServerResponse;
   } {
     const incoming = new this[kIncomingMessage]();
+    setIncomingMessageSocket(incoming, {
+      headers: request.headers,
+      localPort: this.#port as number,
+    });
     const reqUrl = new URL(request.url);
     incoming.url = reqUrl.pathname + reqUrl.search;
 

--- a/src/workerd/api/node/tests/http-server-nodejs-test.js
+++ b/src/workerd/api/node/tests/http-server-nodejs-test.js
@@ -1132,6 +1132,28 @@ export const testConfigurableHighWaterMark = {
   },
 };
 
+export const testIncomingMessageSocket = {
+  async test(_ctrl, env) {
+    await using server = http.createServer((req, res) => {
+      strictEqual(req.socket.encrypted, false);
+      strictEqual(req.socket.localPort, 8080);
+      strictEqual(req.socket.localAddress, '127.0.0.1');
+      strictEqual(req.socket.remoteAddress, '127.0.0.1');
+      strictEqual(req.socket.remotePort, 80);
+      strictEqual(req.socket.remoteFamily, 'IPv4');
+
+      res.writeHead(200);
+      res.end('Hello, World!');
+    });
+
+    server.listen(8080);
+
+    const res = await env.SERVICE.fetch('https://cloudflare.com');
+    strictEqual(res.status, 200);
+    strictEqual(await res.text(), 'Hello, World!');
+  },
+};
+
 let scheduledCallCount = 0;
 
 export default httpServerHandler(

--- a/src/workerd/api/node/tests/http-server-nodejs-test.js
+++ b/src/workerd/api/node/tests/http-server-nodejs-test.js
@@ -1139,7 +1139,7 @@ export const testIncomingMessageSocket = {
       strictEqual(req.socket.localPort, 8080);
       strictEqual(req.socket.localAddress, '127.0.0.1');
       strictEqual(req.socket.remoteAddress, '127.0.0.1');
-      strictEqual(req.socket.remotePort, 80);
+      strictEqual(typeof req.socket.remotePort, 'number');
       strictEqual(req.socket.remoteFamily, 'IPv4');
 
       res.writeHead(200);

--- a/src/workerd/api/node/tests/http-server-nodejs-test.js
+++ b/src/workerd/api/node/tests/http-server-nodejs-test.js
@@ -1140,6 +1140,8 @@ export const testIncomingMessageSocket = {
       strictEqual(req.socket.localAddress, '127.0.0.1');
       strictEqual(req.socket.remoteAddress, '127.0.0.1');
       strictEqual(typeof req.socket.remotePort, 'number');
+      ok(req.socket.remotePort >= Math.pow(2, 15));
+      ok(req.socket.remotePort <= Math.pow(2, 16));
       strictEqual(req.socket.remoteFamily, 'IPv4');
 
       res.writeHead(200);


### PR DESCRIPTION
Adds the missing socket attribute to IncomingMessage. After landing this, we can remove the experimental attribution from the compat flag.