### PR TITLE
EW-9365 [o11y] Implement proper Streaming Tail Worker API

### DIFF
--- a/src/workerd/api/kv-instrumentation-test.js
+++ b/src/workerd/api/kv-instrumentation-test.js
@@ -22,23 +22,26 @@ export default {
 
     // Accumulate the span info for easier testing
     return (event) => {
+      // span ids are simple counters for tests, but invocation ID allows us to differentiate them
+      let spanKey = event.invocationId + event.spanContext.spanId;
       switch (event.event.type) {
         case 'spanOpen':
-          // The span ids will change between tests, but Map preserves insertion order
-          spans.set(event.spanId, { name: event.event.name });
+          spans.set(event.invocationId + event.event.spanId, {
+            name: event.event.name,
+          });
           break;
         case 'attributes': {
-          let span = spans.get(event.spanId);
+          let span = spans.get(spanKey);
           for (let { name, value } of event.event.info) {
             span[name] = value;
           }
-          spans.set(event.spanId, span);
+          spans.set(spanKey, span);
           break;
         }
         case 'spanClose': {
-          let span = spans.get(event.spanId);
+          let span = spans.get(spanKey);
           span['closed'] = true;
-          spans.set(event.spanId, span);
+          spans.set(spanKey, span);
           break;
         }
         case 'outcome':

--- a/src/workerd/api/r2-instrumentation-test.js
+++ b/src/workerd/api/r2-instrumentation-test.js
@@ -22,23 +22,26 @@ export default {
 
     // Accumulate the span info for easier testing
     return (event) => {
+      // span ids are simple counters for tests, but invocation ID allows us to differentiate them
+      let spanKey = event.invocationId + event.spanContext.spanId;
       switch (event.event.type) {
         case 'spanOpen':
-          // The span ids will change between tests, but Map preserves insertion order
-          spans.set(event.spanId, { name: event.event.name });
+          spans.set(event.invocationId + event.event.spanId, {
+            name: event.event.name,
+          });
           break;
         case 'attributes': {
-          let span = spans.get(event.spanId);
+          let span = spans.get(spanKey);
           for (let { name, value } of event.event.info) {
             span[name] = value;
           }
-          spans.set(event.spanId, span);
+          spans.set(spanKey, span);
           break;
         }
         case 'spanClose': {
-          let span = spans.get(event.spanId);
+          let span = spans.get(spanKey);
           span['closed'] = true;
-          spans.set(event.spanId, span);
+          spans.set(spanKey, span);
           break;
         }
         case 'outcome':

--- a/src/workerd/api/tail-worker-test-receiver.js
+++ b/src/workerd/api/tail-worker-test-receiver.js
@@ -9,10 +9,17 @@ export default {
   // https://developers.cloudflare.com/workers/observability/logs/tail-workers/
   tailStream(event, env, ctx) {
     // Onset event, must be singleton
-    resposeMap.set(event.traceId, JSON.stringify(event.event));
+
+    // Set inner spanId to zero to have deterministic output.
+    event.event.spanId = '0000000000000000';
+
+    resposeMap.set(event.spanContext.traceId, JSON.stringify(event.event));
     return (event) => {
-      let cons = resposeMap.get(event.traceId);
-      resposeMap.set(event.traceId, cons + JSON.stringify(event.event));
+      let cons = resposeMap.get(event.spanContext.traceId);
+      resposeMap.set(
+        event.spanContext.traceId,
+        cons + JSON.stringify(event.event)
+      );
     };
   },
 };
@@ -27,7 +34,7 @@ export const test = {
     // Number of traces based on how often main tail worker is invoked from previous tests
     let numTraces = 26;
     let basicTrace =
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"trace","traces":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}';
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"trace","traces":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}';
     assert.deepStrictEqual(
       Array.from(resposeMap.values()),
       Array(numTraces).fill(basicTrace)

--- a/src/workerd/api/tail-worker-test.js
+++ b/src/workerd/api/tail-worker-test.js
@@ -15,6 +15,11 @@ export default {
   tailStream(event, env, ctx) {
     // Onset event, must be singleton
 
+    // The Onset spanContext does not have a spanId defined (once span context propagation is
+    // implemented, it will be defined if a trigger context is available).
+    assert.strictEqual(event.spanContext.spanId, undefined);
+    let spanIdSet = new Set();
+
     // For scheduled and alarm tests, override scheduledTime to make this test deterministic.
     if (
       event.event.info.type == 'scheduled' ||
@@ -23,10 +28,42 @@ export default {
       event.event.info.scheduledTime = '1970-01-01T00:00:00.000Z';
     }
 
-    responseMap.set(event.traceId, JSON.stringify(event.event));
+    const topLevelSpanId = event.event.spanId;
+    // Set inner spanId to zero to have deterministic output, but save it first.
+    event.event.spanId = '0000000000000000';
+
+    responseMap.set(event.spanContext.traceId, JSON.stringify(event.event));
     return (event) => {
-      let cons = responseMap.get(event.traceId);
-      responseMap.set(event.traceId, cons + JSON.stringify(event.event));
+      // The spanContext always has a non-zero spanId available for events other than Onset.
+      assert.notStrictEqual(event.spanContext.spanId, undefined);
+      assert.notStrictEqual(event.spanContext.spanId, '0000000000000000');
+
+      // For outcome events (and all other tail events except for nested spans) the reported spanId
+      // must match the span opened by the Onset event.
+      if (event.event.type == 'outcome') {
+        assert.strictEqual(event.spanContext.spanId, topLevelSpanId);
+      } else if (event.event.type == 'spanOpen') {
+        // Every SpanOpen eveny must have another span or the Onset as its parent, as described by
+        // the SpanContext spanId.
+        assert.ok(
+          event.spanContext.spanId == topLevelSpanId ||
+            spanIdSet.has(event.spanContext.spanId)
+        );
+        // Add the newly opened span to the set of spanIds.
+        spanIdSet.add(event.event.spanId);
+      } else if (
+        event.event.type == 'attributes' ||
+        event.event.type == 'spanClose'
+      ) {
+        // Every SpanClose event must point to the spanId of a previously opened span.
+        assert.ok(spanIdSet.has(event.spanContext.spanId));
+      }
+
+      let cons = responseMap.get(event.spanContext.traceId);
+      responseMap.set(
+        event.spanContext.traceId,
+        cons + JSON.stringify(event.event)
+      );
     };
   },
 };
@@ -44,47 +81,48 @@ export const test = {
     let expected = [
       // http-test.js: fetch and scheduled events get reported correctly.
       // First event is emitted by the test() event, which allows us to get some coverage for span tracing.
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"custom"}}{"type":"spanOpen","name":"fetch","parentSpanId":"0"}{"type":"attributes","info":[{"name":"network.protocol.name","value":"http"},{"name":"network.protocol.version","value":"HTTP/1.1"},{"name":"http.request.method","value":"POST"},{"name":"url.full","value":"http://placeholder/body-length"},{"name":"http.request.body.size","value":"3"},{"name":"http.response.status_code","value":"200"},{"name":"http.response.body.size","value":"22"}]}{"type":"spanClose","outcome":"ok"}{"type":"spanOpen","name":"fetch","parentSpanId":"0"}{"type":"attributes","info":[{"name":"network.protocol.name","value":"http"},{"name":"network.protocol.version","value":"HTTP/1.1"},{"name":"http.request.method","value":"POST"},{"name":"url.full","value":"http://placeholder/body-length"},{"name":"http.response.status_code","value":"200"},{"name":"http.response.body.size","value":"31"}]}{"type":"spanClose","outcome":"ok"}{"type":"spanOpen","name":"scheduled","parentSpanId":"0"}{"type":"spanClose","outcome":"ok"}{"type":"spanOpen","name":"scheduled","parentSpanId":"0"}{"type":"spanClose","outcome":"ok"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"http://placeholder/body-length","headers":[]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"http://placeholder/body-length","headers":[]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"scheduled","scheduledTime":"1970-01-01T00:00:00.000Z","cron":""}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"scheduled","scheduledTime":"1970-01-01T00:00:00.000Z","cron":"* * * * 30"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","entrypoint":"cacheMode","scriptTags":[],"info":{"type":"custom"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://placeholder/not-found","headers":[]}}{"type":"return","info":{"type":"fetch","statusCode":404}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://placeholder/web-socket","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"exception","name":"Error","message":"The Workers runtime canceled this request because it detected that your Worker\'s code had hung and would never generate a response. Refer to: https://developers.cloudflare.com/workers/observability/errors/"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"custom"}}{"type":"spanOpen","name":"fetch","spanId":"0000000000000001"}{"type":"attributes","info":[{"name":"network.protocol.name","value":"http"},{"name":"network.protocol.version","value":"HTTP/1.1"},{"name":"http.request.method","value":"POST"},{"name":"url.full","value":"http://placeholder/body-length"},{"name":"http.request.body.size","value":"3"},{"name":"http.response.status_code","value":"200"},{"name":"http.response.body.size","value":"22"}]}{"type":"spanClose","outcome":"ok"}{"type":"spanOpen","name":"fetch","spanId":"0000000000000002"}{"type":"attributes","info":[{"name":"network.protocol.name","value":"http"},{"name":"network.protocol.version","value":"HTTP/1.1"},{"name":"http.request.method","value":"POST"},{"name":"url.full","value":"http://placeholder/body-length"},{"name":"http.response.status_code","value":"200"},{"name":"http.response.body.size","value":"31"}]}{"type":"spanClose","outcome":"ok"}{"type":"spanOpen","name":"scheduled","spanId":"0000000000000003"}{"type":"spanClose","outcome":"ok"}{"type":"spanOpen","name":"scheduled","spanId":"0000000000000004"}{"type":"spanClose","outcome":"ok"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"http://placeholder/body-length","headers":[]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"http://placeholder/body-length","headers":[]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"scheduled","scheduledTime":"1970-01-01T00:00:00.000Z","cron":""}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"scheduled","scheduledTime":"1970-01-01T00:00:00.000Z","cron":"* * * * 30"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"cacheMode","scriptTags":[],"info":{"type":"custom"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://placeholder/not-found","headers":[]}}{"type":"return","info":{"type":"fetch","statusCode":404}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://placeholder/web-socket","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"exception","name":"Error","message":"The Workers runtime canceled this request because it detected that your Worker\'s code had hung and would never generate a response. Refer to: https://developers.cloudflare.com/workers/observability/errors/"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+
       // Test that when the onset event would be larger than MAX_TRACE_BYTES, we still send the event but with variable size fields counted to the size being empty.
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"","headers":[]}}{"type":"return","info":{"type":"fetch","statusCode":404}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"","headers":[]}}{"type":"return","info":{"type":"fetch","statusCode":404}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // queue-test.js: queue events
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"custom"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/message","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-delay-secs","value":"2"},{"name":"x-msg-fmt","value":"text"}]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/message","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"bytes"}]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/message","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"json"}]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/message","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"v8"}]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/batch","headers":[{"name":"cf-queue-batch-bytes","value":"31"},{"name":"cf-queue-batch-count","value":"4"},{"name":"cf-queue-largest-msg","value":"13"},{"name":"content-type","value":"application/json"},{"name":"x-msg-delay-secs","value":"2"}]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"queue","queueName":"test-queue","batchSize":5}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"custom"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/message","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-delay-secs","value":"2"},{"name":"x-msg-fmt","value":"text"}]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/message","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"bytes"}]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/message","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"json"}]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/message","headers":[{"name":"content-type","value":"application/octet-stream"},{"name":"x-msg-fmt","value":"v8"}]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"fetch","method":"POST","url":"https://fake-host/batch","headers":[{"name":"cf-queue-batch-bytes","value":"31"},{"name":"cf-queue-batch-count","value":"4"},{"name":"cf-queue-largest-msg","value":"13"},{"name":"content-type","value":"application/json"},{"name":"x-msg-delay-secs","value":"2"}]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"queue","queueName":"test-queue","batchSize":5}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // actor-alarms-test.js: alarm events
-      '{"type":"onset","executionModel":"durableObject","entrypoint":"DurableObjectExample","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://foo/test","headers":[]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"durableObject","entrypoint":"DurableObjectExample","scriptTags":[],"info":{"type":"alarm","scheduledTime":"1970-01-01T00:00:00.000Z"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"durableObject","spanId":"0000000000000000","entrypoint":"DurableObjectExample","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://foo/test","headers":[]}}{"type":"return","info":{"type":"fetch","statusCode":200}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"durableObject","spanId":"0000000000000000","entrypoint":"DurableObjectExample","scriptTags":[],"info":{"type":"alarm","scheduledTime":"1970-01-01T00:00:00.000Z"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // legacy tail worker, triggered via alarm test. It would appear that these being recorded
       // after the onsets above is not guaranteed, but since the streaming tail worker is invoked
       // when the main invocation starts whereas the legacy tail worker is only invoked when it ends
       // this should be fine in practice.
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"trace","traces":[""]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // tests/websocket-hibernation.js: hibernatableWebSocket events
-      '{"type":"onset","executionModel":"durableObject","entrypoint":"DurableObjectExample","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://example.com/","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"durableObject","entrypoint":"DurableObjectExample","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://example.com/hibernation","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"durableObject","entrypoint":"DurableObjectExample","scriptTags":[],"info":{"type":"hibernatableWebSocket","info":{"type":"message"}}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"durableObject","entrypoint":"DurableObjectExample","scriptTags":[],"info":{"type":"hibernatableWebSocket","info":{"type":"close","code":1000,"wasClean":true}}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"durableObject","spanId":"0000000000000000","entrypoint":"DurableObjectExample","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://example.com/","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"durableObject","spanId":"0000000000000000","entrypoint":"DurableObjectExample","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://example.com/hibernation","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"durableObject","spanId":"0000000000000000","entrypoint":"DurableObjectExample","scriptTags":[],"info":{"type":"hibernatableWebSocket","info":{"type":"message"}}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"durableObject","spanId":"0000000000000000","entrypoint":"DurableObjectExample","scriptTags":[],"info":{"type":"hibernatableWebSocket","info":{"type":"close","code":1000,"wasClean":true}}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
       // tail-worker-test-jsrpc: Regression test for EW-9282 (missing onset event with
       // JsRpcSessionCustomEventImpl). This is derived from tests/js-rpc-test.js.
-      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"custom"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc","methodName":"nonFunctionProperty"}}{"type":"log","level":"log","message":["bar"]}{"type":"log","level":"log","message":["foo"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"custom"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc","methodName":"nonFunctionProperty"}}{"type":"log","level":"log","message":["bar"]}{"type":"log","level":"log","message":["foo"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
     ];
 
     assert.deepStrictEqual(response, expected);

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -208,11 +208,11 @@ InvocationSpanContext InvocationSpanContext::newForInvocation(
       TraceId::fromEntropy(entropySource), SpanId::fromEntropy(entropySource), kj::mv(parent));
 }
 
-TraceId TraceId::fromCapnp(rpc::InvocationSpanContext::TraceId::Reader reader) {
+TraceId TraceId::fromCapnp(rpc::TraceId::Reader reader) {
   return TraceId(reader.getLow(), reader.getHigh());
 }
 
-void TraceId::toCapnp(rpc::InvocationSpanContext::TraceId::Builder writer) const {
+void TraceId::toCapnp(rpc::TraceId::Builder writer) const {
   writer.setLow(low);
   writer.setHigh(high);
 }
@@ -287,6 +287,32 @@ kj::String KJ_STRINGIFY(const tracing::TailEvent::Event& event) {
 kj::String KJ_STRINGIFY(const CustomInfo& customInfo) {
   return kj::str(
       "CustomInfo: ", kj::strArray(KJ_MAP(attr, customInfo) { return kj::str(attr); }, ", "));
+}
+
+SpanContext SpanContext::fromCapnp(rpc::SpanContext::Reader reader) {
+  auto info = reader.getInfo();
+  kj::Maybe<SpanId> spanId;
+  if (info.isSpanId()) {
+    spanId = info.getSpanId();
+  }
+
+  return SpanContext(TraceId::fromCapnp(reader.getTraceId()), spanId);
+}
+
+void SpanContext::toCapnp(rpc::SpanContext::Builder writer) const {
+  traceId.toCapnp(writer.initTraceId());
+  auto info = writer.initInfo();
+  KJ_IF_SOME(s, spanId) {
+    info.setSpanId(s);
+  }
+}
+
+SpanContext SpanContext::clone() const {
+  return SpanContext(traceId, spanId);
+}
+
+kj::String KJ_STRINGIFY(const SpanContext& context) {
+  return kj::str(context.getTraceId(), "-", context.getSpanId());
 }
 
 }  // namespace tracing
@@ -941,10 +967,10 @@ tracing::Return tracing::Return::clone() const {
   return Return();
 }
 
-tracing::SpanOpen::SpanOpen(uint64_t parentSpanId, kj::String operationName, kj::Maybe<Info> info)
+tracing::SpanOpen::SpanOpen(SpanId spanId, kj::String operationName, kj::Maybe<Info> info)
     : operationName(kj::mv(operationName)),
       info(kj::mv(info)),
-      parentSpanId(parentSpanId) {}
+      spanId(spanId) {}
 
 namespace {
 kj::Maybe<tracing::SpanOpen::Info> readSpanOpenInfo(rpc::Trace::SpanOpen::Reader& reader) {
@@ -970,11 +996,11 @@ kj::Maybe<tracing::SpanOpen::Info> readSpanOpenInfo(rpc::Trace::SpanOpen::Reader
 tracing::SpanOpen::SpanOpen(rpc::Trace::SpanOpen::Reader reader)
     : operationName(kj::str(reader.getOperationName())),
       info(readSpanOpenInfo(reader)),
-      parentSpanId(reader.getParentSpanId()) {}
+      spanId(reader.getSpanId()) {}
 
 void tracing::SpanOpen::copyTo(rpc::Trace::SpanOpen::Builder builder) const {
   builder.setOperationName(operationName.asPtr());
-  builder.setParentSpanId(parentSpanId);
+  builder.setSpanId(spanId);
   KJ_IF_SOME(i, info) {
     auto infoBuilder = builder.initInfo();
     KJ_SWITCH_ONEOF(i) {
@@ -1011,7 +1037,7 @@ tracing::SpanOpen tracing::SpanOpen::clone() const {
       KJ_UNREACHABLE;
     });
   };
-  return SpanOpen(parentSpanId, kj::str(operationName), cloneInfo(info));
+  return SpanOpen(spanId, kj::str(operationName), cloneInfo(info));
 }
 
 kj::String KJ_STRINGIFY(const tracing::SpanOpen::Info& info) {
@@ -1163,13 +1189,6 @@ kj::Maybe<kj::String> getEntrypointFromReader(const rpc::Trace::Onset::Reader& r
   }
   return kj::none;
 }
-kj::Maybe<tracing::Onset::TriggerContext> getTriggerContextFromReader(
-    const rpc::Trace::Onset::Reader& reader) {
-  if (!reader.hasTrigger()) return kj::none;
-  auto trigger = reader.getTrigger();
-  return tracing::Onset::TriggerContext(tracing::TraceId::fromCapnp(trigger.getTraceId()),
-      tracing::TraceId::fromCapnp(trigger.getInvocationId()), tracing::SpanId(trigger.getSpanId()));
-}
 tracing::Onset::WorkerInfo getWorkerInfoFromReader(const rpc::Trace::Onset::Reader& reader) {
   return tracing::Onset::WorkerInfo{
     .executionModel = reader.getExecutionModel(),
@@ -1183,23 +1202,24 @@ tracing::Onset::WorkerInfo getWorkerInfoFromReader(const rpc::Trace::Onset::Read
 }
 }  // namespace
 
-tracing::Onset::Onset(tracing::Onset::Info&& info,
+tracing::Onset::Onset(tracing::SpanId spanId,
+    tracing::Onset::Info&& info,
     tracing::Onset::WorkerInfo&& workerInfo,
-    CustomInfo attributes,
-    kj::Maybe<TriggerContext> maybeTrigger)
-    : info(kj::mv(info)),
+    CustomInfo attributes)
+    : spanId(spanId),
+      info(kj::mv(info)),
       workerInfo(kj::mv(workerInfo)),
-      attributes(kj::mv(attributes)),
-      trigger(kj::mv(maybeTrigger)) {}
+      attributes(kj::mv(attributes)) {}
 
 tracing::Onset::Onset(rpc::Trace::Onset::Reader reader)
-    : info(readOnsetInfo(reader.getInfo())),
+    : spanId(reader.getSpanId()),
+      info(readOnsetInfo(reader.getInfo())),
       workerInfo(getWorkerInfoFromReader(reader)),
-      attributes(KJ_MAP(attr, reader.getAttributes()) { return tracing::Attribute(attr); }),
-      trigger(getTriggerContextFromReader(reader)) {}
+      attributes(KJ_MAP(attr, reader.getAttributes()) { return tracing::Attribute(attr); }) {}
 
 void tracing::Onset::copyTo(rpc::Trace::Onset::Builder builder) const {
   builder.setExecutionModel(workerInfo.executionModel);
+  builder.setSpanId(spanId);
   KJ_IF_SOME(name, workerInfo.scriptName) {
     builder.setScriptName(name);
   }
@@ -1220,12 +1240,6 @@ void tracing::Onset::copyTo(rpc::Trace::Onset::Builder builder) const {
   }
   KJ_IF_SOME(e, workerInfo.entrypoint) {
     builder.setEntryPoint(e);
-  }
-  KJ_IF_SOME(t, trigger) {
-    auto ctx = builder.initTrigger();
-    t.traceId.toCapnp(ctx.initTraceId());
-    t.invocationId.toCapnp(ctx.getInvocationId());
-    ctx.setSpanId(t.spanId.getId());
   }
   auto infoBuilder = builder.initInfo();
   writeOnsetInfo(info, infoBuilder);
@@ -1283,10 +1297,8 @@ tracing::EventInfo tracing::cloneEventInfo(const tracing::EventInfo& info) {
 }
 
 tracing::Onset tracing::Onset::clone() const {
-  return Onset(cloneEventInfo(info), workerInfo.clone(),
-      KJ_MAP(attr, attributes) { return attr.clone(); }, trigger.map([](const TriggerContext& ctx) {
-    return TriggerContext(ctx.traceId, ctx.invocationId, ctx.spanId);
-  }));
+  return Onset(spanId, cloneEventInfo(info), workerInfo.clone(),
+      KJ_MAP(attr, attributes) { return attr.clone(); });
 }
 
 tracing::Outcome::Outcome(EventOutcome outcome, kj::Duration cpuTime, kj::Duration wallTime)
@@ -1309,26 +1321,25 @@ tracing::Outcome tracing::Outcome::clone() const {
   return Outcome(outcome, cpuTime, wallTime);
 }
 
-tracing::TailEvent::TailEvent(const tracing::InvocationSpanContext& context,
+tracing::TailEvent::TailEvent(tracing::SpanContext context,
+    TraceId invocationId,
     kj::Date timestamp,
     kj::uint sequence,
     Event&& event)
-    : traceId(context.getTraceId()),
-      invocationId(context.getInvocationId()),
-      spanId(context.getSpanId()),
+    : spanContext(kj::mv(context)),
+      invocationId(invocationId),
       timestamp(timestamp),
       sequence(sequence),
       event(kj::mv(event)) {}
 
 tracing::TailEvent::TailEvent(TraceId traceId,
     TraceId invocationId,
-    SpanId spanId,
+    kj::Maybe<SpanId> spanId,
     kj::Date timestamp,
     kj::uint sequence,
     Event&& event)
-    : traceId(kj::mv(traceId)),
+    : spanContext(kj::mv(traceId), kj::mv(spanId)),
       invocationId(kj::mv(invocationId)),
-      spanId(kj::mv(spanId)),
       timestamp(timestamp),
       sequence(sequence),
       event(kj::mv(event)) {}
@@ -1375,18 +1386,15 @@ tracing::TailEvent::Event readEventFromTailEvent(const rpc::Trace::TailEvent::Re
 }  // namespace
 
 tracing::TailEvent::TailEvent(rpc::Trace::TailEvent::Reader reader)
-    : traceId(TraceId::fromCapnp(reader.getContext().getTraceId())),
-      invocationId(TraceId::fromCapnp(reader.getContext().getInvocationId())),
-      spanId(SpanId(reader.getContext().getSpanId())),
+    : spanContext(SpanContext::fromCapnp(reader.getSpanContext())),
+      invocationId(TraceId::fromCapnp(reader.getInvocationId())),
       timestamp(kj::UNIX_EPOCH + reader.getTimestampNs() * kj::NANOSECONDS),
       sequence(reader.getSequence()),
       event(readEventFromTailEvent(reader)) {}
 
 void tracing::TailEvent::copyTo(rpc::Trace::TailEvent::Builder builder) const {
-  auto context = builder.initContext();
-  traceId.toCapnp(context.initTraceId());
-  invocationId.toCapnp(context.initInvocationId());
-  context.setSpanId(spanId.getId());
+  spanContext.toCapnp(builder.initSpanContext());
+  invocationId.toCapnp(builder.initInvocationId());
   builder.setTimestampNs((timestamp - kj::UNIX_EPOCH) / kj::NANOSECONDS);
   builder.setSequence(sequence);
   auto eventBuilder = builder.initEvent();
@@ -1458,7 +1466,8 @@ tracing::TailEvent tracing::TailEvent::clone() const {
     }
     KJ_UNREACHABLE;
   };
-  return TailEvent(traceId, invocationId, spanId, timestamp, sequence, cloneEvent(event));
+  return TailEvent(spanContext.getTraceId(), invocationId, spanContext.getSpanId(), timestamp,
+      sequence, cloneEvent(event));
 }
 
 // ======================================================================================

--- a/types/defines/trace.d.ts
+++ b/types/defines/trace.d.ts
@@ -85,22 +85,17 @@ interface ScriptVersion {
   readonly message?: string;
 }
 
-interface Trigger {
-  readonly traceId: string;
-  readonly invocationId: string;
-  readonly spanId: string;
-}
-
 interface Onset {
   readonly type: "onset";
   readonly attributes: Attribute[];
+  // id for the span being opened by this Onset event.
+  readonly spanId: string;
   readonly dispatchNamespace?: string;
   readonly entrypoint?: string;
   readonly executionModel: string;
   readonly scriptName?: string;
   readonly scriptTags?: string[];
   readonly scriptVersion?: ScriptVersion;
-  readonly trigger?: Trigger;
   readonly info: FetchEventInfo | JsRpcEventInfo | ScheduledEventInfo |
                  AlarmEventInfo | QueueEventInfo | EmailEventInfo |
                  TraceEventInfo | HibernatableWebSocketEventInfo |
@@ -117,6 +112,8 @@ interface Outcome {
 interface SpanOpen {
   readonly type: "spanOpen";
   readonly name: string;
+  // id for the span being opened by this SpanOpen event.
+  readonly spanId: string;
   readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
 }
 
@@ -144,6 +141,10 @@ interface Log {
   readonly message: object;
 }
 
+// This marks the worker handler return information.
+// This is separate from Outcome because the worker invocation can live for a long time after
+// returning. For example - Websockets that return an http upgrade response but then continue
+// streaming information or SSE http connections.
 interface Return {
   readonly type: "return";
   readonly info?: FetchResponseInfo;
@@ -170,9 +171,29 @@ type EventType =
   | Return
   | Attributes;
 
+// Context in which this trace event lives.
+interface SpanContext {
+  // Single id for the entire top-level invocation
+  // This should be a new traceId for the first worker stage invoked in the eyeball request and then
+  // same-account service-bindings should reuse the same traceId but cross-account service-bindings
+  // should use a new traceId.
+  readonly traceId: string;
+  // spanId in which this event is handled
+  // for Onset and SpanOpen events this would be the parent span id
+  // for Outcome and SpanClose these this would be the span id of the opening Onset and SpanOpen events
+  // For Hibernate and Mark this would be the span under which they were emitted.
+  // spanId is not set ONLY if:
+  //  1. This is an Onset event
+  //  2. We are not inherting any SpanContext. (e.g. this is a cross-account service binding or a new top-level invocation)
+  readonly spanId?: string;
+}
+
 interface TailEvent<Event extends EventType> {
+  // invocation id of the currently invoked worker stage.
+  // invocation id will always be unique to every Onset event and will be the same until the Outcome event.
   readonly invocationId: string;
-  readonly spanId: string;
+  // Inherited spanContext for this event.
+  readonly spanContext: SpanContext;
   readonly timestamp: Date;
   readonly sequence: number;
   readonly event: Event;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -8495,21 +8495,17 @@ declare namespace TailStream {
     readonly tag?: string;
     readonly message?: string;
   }
-  interface Trigger {
-    readonly traceId: string;
-    readonly invocationId: string;
-    readonly spanId: string;
-  }
   interface Onset {
     readonly type: "onset";
     readonly attributes: Attribute[];
+    // id for the span being opened by this Onset event.
+    readonly spanId: string;
     readonly dispatchNamespace?: string;
     readonly entrypoint?: string;
     readonly executionModel: string;
     readonly scriptName?: string;
     readonly scriptTags?: string[];
     readonly scriptVersion?: ScriptVersion;
-    readonly trigger?: Trigger;
     readonly info:
       | FetchEventInfo
       | JsRpcEventInfo
@@ -8530,6 +8526,8 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
+    // id for the span being opened by this SpanOpen event.
+    readonly spanId: string;
     readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
@@ -8552,6 +8550,10 @@ declare namespace TailStream {
     readonly level: "debug" | "error" | "info" | "log" | "warn";
     readonly message: object;
   }
+  // This marks the worker handler return information.
+  // This is separate from Outcome because the worker invocation can live for a long time after
+  // returning. For example - Websockets that return an http upgrade response but then continue
+  // streaming information or SSE http connections.
   interface Return {
     readonly type: "return";
     readonly info?: FetchResponseInfo;
@@ -8582,9 +8584,28 @@ declare namespace TailStream {
     | Log
     | Return
     | Attributes;
+  // Context in which this trace event lives.
+  interface SpanContext {
+    // Single id for the entire top-level invocation
+    // This should be a new traceId for the first worker stage invoked in the eyeball request and then
+    // same-account service-bindings should reuse the same traceId but cross-account service-bindings
+    // should use a new traceId.
+    readonly traceId: string;
+    // spanId in which this event is handled
+    // for Onset and SpanOpen events this would be the parent span id
+    // for Outcome and SpanClose these this would be the span id of the opening Onset and SpanOpen events
+    // For Hibernate and Mark this would be the span under which they were emitted.
+    // spanId is not set ONLY if:
+    //  1. This is an Onset event
+    //  2. We are not inherting any SpanContext. (e.g. this is a cross-account service binding or a new top-level invocation)
+    readonly spanId?: string;
+  }
   interface TailEvent<Event extends EventType> {
+    // invocation id of the currently invoked worker stage.
+    // invocation id will always be unique to every Onset event and will be the same until the Outcome event.
     readonly invocationId: string;
-    readonly spanId: string;
+    // Inherited spanContext for this event.
+    readonly spanContext: SpanContext;
     readonly timestamp: Date;
     readonly sequence: number;
     readonly event: Event;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -8342,21 +8342,17 @@ export declare namespace TailStream {
     readonly tag?: string;
     readonly message?: string;
   }
-  interface Trigger {
-    readonly traceId: string;
-    readonly invocationId: string;
-    readonly spanId: string;
-  }
   interface Onset {
     readonly type: "onset";
     readonly attributes: Attribute[];
+    // id for the span being opened by this Onset event.
+    readonly spanId: string;
     readonly dispatchNamespace?: string;
     readonly entrypoint?: string;
     readonly executionModel: string;
     readonly scriptName?: string;
     readonly scriptTags?: string[];
     readonly scriptVersion?: ScriptVersion;
-    readonly trigger?: Trigger;
     readonly info:
       | FetchEventInfo
       | JsRpcEventInfo
@@ -8377,6 +8373,8 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
+    // id for the span being opened by this SpanOpen event.
+    readonly spanId: string;
     readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
@@ -8399,6 +8397,10 @@ export declare namespace TailStream {
     readonly level: "debug" | "error" | "info" | "log" | "warn";
     readonly message: object;
   }
+  // This marks the worker handler return information.
+  // This is separate from Outcome because the worker invocation can live for a long time after
+  // returning. For example - Websockets that return an http upgrade response but then continue
+  // streaming information or SSE http connections.
   interface Return {
     readonly type: "return";
     readonly info?: FetchResponseInfo;
@@ -8429,9 +8431,28 @@ export declare namespace TailStream {
     | Log
     | Return
     | Attributes;
+  // Context in which this trace event lives.
+  interface SpanContext {
+    // Single id for the entire top-level invocation
+    // This should be a new traceId for the first worker stage invoked in the eyeball request and then
+    // same-account service-bindings should reuse the same traceId but cross-account service-bindings
+    // should use a new traceId.
+    readonly traceId: string;
+    // spanId in which this event is handled
+    // for Onset and SpanOpen events this would be the parent span id
+    // for Outcome and SpanClose these this would be the span id of the opening Onset and SpanOpen events
+    // For Hibernate and Mark this would be the span under which they were emitted.
+    // spanId is not set ONLY if:
+    //  1. This is an Onset event
+    //  2. We are not inherting any SpanContext. (e.g. this is a cross-account service binding or a new top-level invocation)
+    readonly spanId?: string;
+  }
   interface TailEvent<Event extends EventType> {
+    // invocation id of the currently invoked worker stage.
+    // invocation id will always be unique to every Onset event and will be the same until the Outcome event.
     readonly invocationId: string;
-    readonly spanId: string;
+    // Inherited spanContext for this event.
+    readonly spanContext: SpanContext;
     readonly timestamp: Date;
     readonly sequence: number;
     readonly event: Event;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -8266,21 +8266,17 @@ declare namespace TailStream {
     readonly tag?: string;
     readonly message?: string;
   }
-  interface Trigger {
-    readonly traceId: string;
-    readonly invocationId: string;
-    readonly spanId: string;
-  }
   interface Onset {
     readonly type: "onset";
     readonly attributes: Attribute[];
+    // id for the span being opened by this Onset event.
+    readonly spanId: string;
     readonly dispatchNamespace?: string;
     readonly entrypoint?: string;
     readonly executionModel: string;
     readonly scriptName?: string;
     readonly scriptTags?: string[];
     readonly scriptVersion?: ScriptVersion;
-    readonly trigger?: Trigger;
     readonly info:
       | FetchEventInfo
       | JsRpcEventInfo
@@ -8301,6 +8297,8 @@ declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
+    // id for the span being opened by this SpanOpen event.
+    readonly spanId: string;
     readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
@@ -8323,6 +8321,10 @@ declare namespace TailStream {
     readonly level: "debug" | "error" | "info" | "log" | "warn";
     readonly message: object;
   }
+  // This marks the worker handler return information.
+  // This is separate from Outcome because the worker invocation can live for a long time after
+  // returning. For example - Websockets that return an http upgrade response but then continue
+  // streaming information or SSE http connections.
   interface Return {
     readonly type: "return";
     readonly info?: FetchResponseInfo;
@@ -8353,9 +8355,28 @@ declare namespace TailStream {
     | Log
     | Return
     | Attributes;
+  // Context in which this trace event lives.
+  interface SpanContext {
+    // Single id for the entire top-level invocation
+    // This should be a new traceId for the first worker stage invoked in the eyeball request and then
+    // same-account service-bindings should reuse the same traceId but cross-account service-bindings
+    // should use a new traceId.
+    readonly traceId: string;
+    // spanId in which this event is handled
+    // for Onset and SpanOpen events this would be the parent span id
+    // for Outcome and SpanClose these this would be the span id of the opening Onset and SpanOpen events
+    // For Hibernate and Mark this would be the span under which they were emitted.
+    // spanId is not set ONLY if:
+    //  1. This is an Onset event
+    //  2. We are not inherting any SpanContext. (e.g. this is a cross-account service binding or a new top-level invocation)
+    readonly spanId?: string;
+  }
   interface TailEvent<Event extends EventType> {
+    // invocation id of the currently invoked worker stage.
+    // invocation id will always be unique to every Onset event and will be the same until the Outcome event.
     readonly invocationId: string;
-    readonly spanId: string;
+    // Inherited spanContext for this event.
+    readonly spanContext: SpanContext;
     readonly timestamp: Date;
     readonly sequence: number;
     readonly event: Event;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -8111,21 +8111,17 @@ export declare namespace TailStream {
     readonly tag?: string;
     readonly message?: string;
   }
-  interface Trigger {
-    readonly traceId: string;
-    readonly invocationId: string;
-    readonly spanId: string;
-  }
   interface Onset {
     readonly type: "onset";
     readonly attributes: Attribute[];
+    // id for the span being opened by this Onset event.
+    readonly spanId: string;
     readonly dispatchNamespace?: string;
     readonly entrypoint?: string;
     readonly executionModel: string;
     readonly scriptName?: string;
     readonly scriptTags?: string[];
     readonly scriptVersion?: ScriptVersion;
-    readonly trigger?: Trigger;
     readonly info:
       | FetchEventInfo
       | JsRpcEventInfo
@@ -8146,6 +8142,8 @@ export declare namespace TailStream {
   interface SpanOpen {
     readonly type: "spanOpen";
     readonly name: string;
+    // id for the span being opened by this SpanOpen event.
+    readonly spanId: string;
     readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
   }
   interface SpanClose {
@@ -8168,6 +8166,10 @@ export declare namespace TailStream {
     readonly level: "debug" | "error" | "info" | "log" | "warn";
     readonly message: object;
   }
+  // This marks the worker handler return information.
+  // This is separate from Outcome because the worker invocation can live for a long time after
+  // returning. For example - Websockets that return an http upgrade response but then continue
+  // streaming information or SSE http connections.
   interface Return {
     readonly type: "return";
     readonly info?: FetchResponseInfo;
@@ -8198,9 +8200,28 @@ export declare namespace TailStream {
     | Log
     | Return
     | Attributes;
+  // Context in which this trace event lives.
+  interface SpanContext {
+    // Single id for the entire top-level invocation
+    // This should be a new traceId for the first worker stage invoked in the eyeball request and then
+    // same-account service-bindings should reuse the same traceId but cross-account service-bindings
+    // should use a new traceId.
+    readonly traceId: string;
+    // spanId in which this event is handled
+    // for Onset and SpanOpen events this would be the parent span id
+    // for Outcome and SpanClose these this would be the span id of the opening Onset and SpanOpen events
+    // For Hibernate and Mark this would be the span under which they were emitted.
+    // spanId is not set ONLY if:
+    //  1. This is an Onset event
+    //  2. We are not inherting any SpanContext. (e.g. this is a cross-account service binding or a new top-level invocation)
+    readonly spanId?: string;
+  }
   interface TailEvent<Event extends EventType> {
+    // invocation id of the currently invoked worker stage.
+    // invocation id will always be unique to every Onset event and will be the same until the Outcome event.
     readonly invocationId: string;
-    readonly spanId: string;
+    // Inherited spanContext for this event.
+    readonly spanContext: SpanContext;
     readonly timestamp: Date;
     readonly sequence: number;
     readonly event: Event;


### PR DESCRIPTION
This implements the Streaming Tail Worker API as discussed previously, should be a lot more elegant and less error-prone.
What isn't cleaned up yet:
- Commit history, splitting this into more digestible commits (possible to some extent)
- Many TODOs are cleared up, one is added about the Onset spanId.
- We have good tests for the spanId field defined for SpanOpen, its meaning has changed and it's now actually called spanId. We'd still want more coverage for the outer spanId defined in TailEvent, which is not included in tests as we only look at the inner event so that tests are deterministic (TailEvent includes timestamp) @mar-cf if you want to develop tests that should be helpful still, or I can add them here

Downstream PR to follow.