### PR TITLE
do not call destroy.bind()

### DIFF
--- a/src/node/internal/internal_tls_wrap.ts
+++ b/src/node/internal/internal_tls_wrap.ts
@@ -522,7 +522,10 @@ TLSSocket.prototype._start = function _start(this: TLSSocket): void {
 
     this._handle.socket.closed.then(
       onConnectionClosed.bind(this),
-      this.destroy.bind(socket)
+      (error: unknown): void => {
+        // Do not call this.destroy.bind(this) since user can override it.
+        this.destroy(error as Error);
+      }
     );
   } catch (error) {
     this.destroy(error as Error);


### PR DESCRIPTION
Partial fix to https://github.com/cloudflare/workerd/issues/4724

After this change, we have a new error, which requires a little bit more investigation:

```
workerd/server/server.c++:4781: error: Uncaught exception: workerd/io/io-context.c++:1317: failed: remote.jsg.Error: The Workers runtime canceled this request because it detected that your Worker's code had hung and would never generate a response. Refer to: https://developers.cloudflare.com/workers/observability/errors/
```