### PR TITLE
Small improvement to the httpServerHandler ergonomics

### DIFF
--- a/src/cloudflare/node.ts
+++ b/src/cloudflare/node.ts
@@ -12,12 +12,65 @@ interface NodeStyleServer {
   address(): { port?: number | null | undefined };
 }
 
+function getInstance<T extends object = object>(
+  constructorOrObject?: (new () => T) | T
+): {
+  returnValue: T;
+  instance: T;
+} {
+  // If the constructorOrObject is a function, we assume it is a class
+  // constructor. Return the prototype of that class.
+  if (typeof constructorOrObject === 'function') {
+    return {
+      returnValue: constructorOrObject as T,
+      instance: constructorOrObject.prototype as T,
+    };
+  }
+  // If it is an object (and not null), we assume it is already an
+  // instance, return it as is.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (constructorOrObject !== null && typeof constructorOrObject === 'object') {
+    return {
+      returnValue: constructorOrObject,
+      instance: constructorOrObject,
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (constructorOrObject !== undefined) {
+    throw new TypeError(
+      'Expected a constructor function or an object, but received: ' +
+        typeof constructorOrObject
+    );
+  }
+  // Otherwise, return a new basic object.
+  const instance = {} as T;
+  return {
+    returnValue: instance,
+    instance: instance,
+  };
+}
+
+type Fetcher = {
+  fetch(request: Request): Promise<Response>;
+};
+
+export function httpServerHandler(
+  desc: ServerDescriptor | NodeStyleServer
+): Fetcher;
 export function httpServerHandler(
   desc: ServerDescriptor | NodeStyleServer,
-  handlers?: Record<string, unknown> | null
-): {
-  fetch(request: Request): Promise<Response>;
-} {
+  constructor: new (...args: unknown[]) => object
+): Fetcher;
+export function httpServerHandler(
+  desc: ServerDescriptor | NodeStyleServer,
+  object: object
+): Fetcher;
+
+export function httpServerHandler<T extends object = object>(
+  desc: ServerDescriptor | NodeStyleServer,
+  constructorOrObject?: (new (...args: unknown[]) => T) | T
+): Fetcher {
   // While the TypeScript type system prevents `desc` from being null or undefined,
   // JavaScript does not, so we need to check for it at runtime.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -64,30 +117,30 @@ export function httpServerHandler(
     throw new Error('Failed to determine port for server');
   }
 
-  if (handlers !== undefined && typeof handlers !== 'object') {
-    throw new Error(
-      'Handlers parameter passed to httpServerHandler method must be an object'
-    );
-  }
+  // We intentionally omitted ctx and env variables. Users should use
+  // importable equivalents to access those values. For example, using
+  // import { env, waitUntil } from 'cloudflare:workers
+  // `disallow_importable_env` compat flag should not be set if you are using this
+  // and need access to the env since that will prevent access.
+  const fetch = async function (request: Request): Promise<Response> {
+    const instance = portMapper.get(port);
+    // TODO: Investigate supporting automatically assigned ports as being bound without a port configuration.
+    if (!instance) {
+      const error = new Error(
+        `Http server with port ${port} not found. This is likely a bug with your code. You should check if server.listen() was called with the same port (${port})`
+      );
+      // @ts-expect-error TS2339 We're imitating Node.js errors.
+      error.code = 'ERR_INVALID_ARG_VALUE';
+      throw error;
+    }
+    return instance.fetch(request);
+  };
 
-  return Object.assign(handlers ?? {}, {
-    // We intentionally omitted ctx and env variables. Users should use
-    // importable equivalents to access those values. For example, using
-    // import { env, waitUntil } from 'cloudflare:workers
-    // `disallow_importable_env` compat flag should not be set if you are using this
-    // and need access to the env since that will prevent access.
-    async fetch(request: Request): Promise<Response> {
-      const instance = portMapper.get(port);
-      // TODO: Investigate supporting automatically assigned ports as being bound without a port configuration.
-      if (!instance) {
-        const error = new Error(
-          `Http server with port ${port} not found. This is likely a bug with your code. You should check if server.listen() was called with the same port (${port})`
-        );
-        // @ts-expect-error TS2339 We're imitating Node.js errors.
-        error.code = 'ERR_INVALID_ARG_VALUE';
-        throw error;
-      }
-      return instance.fetch(request);
-    },
+  const { returnValue, instance } = getInstance<T>(constructorOrObject);
+  Object.defineProperty(instance, 'fetch', {
+    value: fetch,
+    configurable: true,
+    writable: true,
   });
+  return returnValue as Fetcher;
 }

--- a/src/cloudflare/node.ts
+++ b/src/cloudflare/node.ts
@@ -3,23 +3,74 @@
 //     https://opensource.org/licenses/Apache-2.0
 import { portMapper } from 'cloudflare-internal:http';
 
+interface ServerDescriptor {
+  port?: number | null | undefined;
+}
+
+interface NodeStyleServer {
+  listen(...args: unknown[]): this;
+  address(): { port?: number | null | undefined };
+}
+
 export function httpServerHandler(
-  { port }: { port?: number } = {},
-  handlers: Record<string, unknown> = {}
+  desc: ServerDescriptor | NodeStyleServer,
+  handlers?: Record<string, unknown> | null
 ): {
   fetch(request: Request): Promise<Response>;
 } {
-  if (port == null) {
-    throw new Error('Port is required when calling httpServerHandler()');
-  }
+  // While the TypeScript type system prevents `desc` from being null or undefined,
+  // JavaScript does not, so we need to check for it at runtime.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (handlers == null || typeof handlers !== 'object') {
+  if (desc == null) {
+    throw new Error('Server descriptor cannot be null or undefined');
+  }
+
+  // The desc can be a ServerDescriptor or a Server (where "Server" is defined
+  // as a type that has a "listen()" method and an "address()" method).
+  let port: number | null = null;
+
+  // If there is no port defined and desc has a listen method, we will try to
+  // access it as a Server, calling listen() if necessary to determine the port.
+  if (
+    (desc as ServerDescriptor).port == null &&
+    typeof (desc as NodeStyleServer).listen === 'function'
+  ) {
+    const server = desc as NodeStyleServer;
+    // First, let's see if the server-like thing already has a port.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    let serverPort = server.address()?.port;
+    if (typeof serverPort === 'number') {
+      // Nice, we're already bound to a port.
+      port = serverPort;
+    } else {
+      // We're not yet bound to a port. Try calling listen() to start the server
+      // and determine the port.
+      server.listen();
+      // Did it work? We do expect the listen in this case to synchronously
+      // assign the port so we can check it immediately.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      serverPort = server.address()?.port;
+      if (typeof serverPort === 'number') {
+        // Nice. We've got a port now.
+        port = serverPort;
+      }
+    }
+  } else if (typeof (desc as ServerDescriptor).port === 'number') {
+    // We're a ServerDescriptor with a port defined.
+    port = (desc as ServerDescriptor).port as number;
+  }
+
+  if (port == null) {
+    throw new Error('Failed to determine port for server');
+  }
+
+  if (handlers !== undefined && typeof handlers !== 'object') {
     throw new Error(
       'Handlers parameter passed to httpServerHandler method must be an object'
     );
   }
 
-  return Object.assign(handlers, {
+  return Object.assign(handlers ?? {}, {
     // We intentionally omitted ctx and env variables. Users should use
     // importable equivalents to access those values. For example, using
     // import { env, waitUntil } from 'cloudflare:workers

--- a/src/workerd/api/node/tests/BUILD.bazel
+++ b/src/workerd/api/node/tests/BUILD.bazel
@@ -533,6 +533,12 @@ wd_test(
     data = ["os-test.js"],
 )
 
+wd_test(
+    src = "http-server-nodejs-global-test.wd-test",
+    args = ["--experimental"],
+    data = ["http-server-nodejs-global-test.js"],
+)
+
 js_binary(
     name = "sidecar-supervisor",
     entry_point = "sidecar-supervisor.mjs",

--- a/src/workerd/api/node/tests/http-server-nodejs-global-test.js
+++ b/src/workerd/api/node/tests/http-server-nodejs-global-test.js
@@ -1,0 +1,20 @@
+import http from 'node:http';
+import { strictEqual } from 'node:assert';
+import { httpServerHandler } from 'cloudflare:node';
+
+const server = http.createServer((req, res) => {
+  res.end('hello world');
+});
+
+// The server can be started by passing it to the httpServerHandler
+// which will call the server's listen method if it hasn't already
+// been called.
+export default httpServerHandler(server);
+strictEqual(typeof server.address().port, 'number');
+
+export const checkItWorks = {
+  async test(_ctrl, env) {
+    const resp = await env.SUBREQUEST.fetch('http://example.com');
+    strictEqual(await resp.text(), 'hello world');
+  },
+};

--- a/src/workerd/api/node/tests/http-server-nodejs-global-test.wd-test
+++ b/src/workerd/api/node/tests/http-server-nodejs-global-test.wd-test
@@ -1,0 +1,18 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "http-server-nodejs-global-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "http-server-nodejs-global-test.js")
+        ],
+        compatibilityDate = "2025-01-15",
+        compatibilityFlags = ["nodejs_compat", "experimental", "enable_nodejs_http_modules", "enable_nodejs_http_server_modules"],
+        bindings = [
+          ( name = "SUBREQUEST", service = "http-server-nodejs-global-test" ),
+        ],
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
Since calling `listen()` on the node:http Server is largely boilerplate, we can simplify the ergonomics by allowing the user to pass the server directly into httpServerHandler and having it call `listen()` for the user if it hasn't already been called. Code that is already written for node.js that is ported without modifications would likely still be just calling `listen` but this should make things easier overall.

```js
import http from 'node:http';
import { httpServerHandler } from 'cloudflare:node';

const server = http.createServer((req, res) => {
  res.end('hello world');
});

export default httpServerHandler(server);
```