### PR TITLE
Improve handling of httpServerHandler `handler` argument

### DIFF
--- a/src/cloudflare/node.ts
+++ b/src/cloudflare/node.ts
@@ -12,12 +12,65 @@ interface NodeStyleServer {
   address(): { port?: number | null | undefined };
 }
 
+function getInstance<T extends object = object>(
+  constructorOrObject?: (new () => T) | T
+): {
+  returnValue: T;
+  instance: T;
+} {
+  // If the constructorOrObject is a function, we assume it is a class
+  // constructor. Return the prototype of that class.
+  if (typeof constructorOrObject === 'function') {
+    return {
+      returnValue: constructorOrObject as T,
+      instance: constructorOrObject.prototype as T,
+    };
+  }
+  // If it is an object (and not null), we assume it is already an
+  // instance, return it as is.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (constructorOrObject !== null && typeof constructorOrObject === 'object') {
+    return {
+      returnValue: constructorOrObject,
+      instance: constructorOrObject,
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (constructorOrObject !== undefined) {
+    throw new TypeError(
+      'Expected a constructor function or an object, but received: ' +
+        typeof constructorOrObject
+    );
+  }
+  // Otherwise, return a new basic object.
+  const instance = {} as T;
+  return {
+    returnValue: instance,
+    instance: instance,
+  };
+}
+
+type Fetcher = {
+  fetch(request: Request): Promise<Response>;
+};
+
+export function httpServerHandler(
+  desc: ServerDescriptor | NodeStyleServer
+): Fetcher;
 export function httpServerHandler(
   desc: ServerDescriptor | NodeStyleServer,
-  handlers?: Record<string, unknown> | null
-): {
-  fetch(request: Request): Promise<Response>;
-} {
+  constructor: new (...args: unknown[]) => object
+): Fetcher;
+export function httpServerHandler(
+  desc: ServerDescriptor | NodeStyleServer,
+  object: object
+): Fetcher;
+
+export function httpServerHandler<T extends object = object>(
+  desc: ServerDescriptor | NodeStyleServer,
+  constructorOrObject?: (new (...args: unknown[]) => T) | T
+): Fetcher {
   // While the TypeScript type system prevents `desc` from being null or undefined,
   // JavaScript does not, so we need to check for it at runtime.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -64,30 +117,30 @@ export function httpServerHandler(
     throw new Error('Failed to determine port for server');
   }
 
-  if (handlers !== undefined && typeof handlers !== 'object') {
-    throw new Error(
-      'Handlers parameter passed to httpServerHandler method must be an object'
-    );
-  }
+  // We intentionally omitted ctx and env variables. Users should use
+  // importable equivalents to access those values. For example, using
+  // import { env, waitUntil } from 'cloudflare:workers
+  // `disallow_importable_env` compat flag should not be set if you are using this
+  // and need access to the env since that will prevent access.
+  const fetch = async function (request: Request): Promise<Response> {
+    const instance = portMapper.get(port);
+    // TODO: Investigate supporting automatically assigned ports as being bound without a port configuration.
+    if (!instance) {
+      const error = new Error(
+        `Http server with port ${port} not found. This is likely a bug with your code. You should check if server.listen() was called with the same port (${port})`
+      );
+      // @ts-expect-error TS2339 We're imitating Node.js errors.
+      error.code = 'ERR_INVALID_ARG_VALUE';
+      throw error;
+    }
+    return instance.fetch(request);
+  };
 
-  return Object.assign(handlers ?? {}, {
-    // We intentionally omitted ctx and env variables. Users should use
-    // importable equivalents to access those values. For example, using
-    // import { env, waitUntil } from 'cloudflare:workers
-    // `disallow_importable_env` compat flag should not be set if you are using this
-    // and need access to the env since that will prevent access.
-    async fetch(request: Request): Promise<Response> {
-      const instance = portMapper.get(port);
-      // TODO: Investigate supporting automatically assigned ports as being bound without a port configuration.
-      if (!instance) {
-        const error = new Error(
-          `Http server with port ${port} not found. This is likely a bug with your code. You should check if server.listen() was called with the same port (${port})`
-        );
-        // @ts-expect-error TS2339 We're imitating Node.js errors.
-        error.code = 'ERR_INVALID_ARG_VALUE';
-        throw error;
-      }
-      return instance.fetch(request);
-    },
+  const { returnValue, instance } = getInstance<T>(constructorOrObject);
+  Object.defineProperty(instance, 'fetch', {
+    value: fetch,
+    configurable: true,
+    writable: true,
   });
+  return returnValue as Fetcher;
 }


### PR DESCRIPTION
Modifies the second argument to `httpServerHandler(...)` to improve the ergonomics a bit
Previously, passing a handler object to the function would copy methods off of it onto a new object, e.g.

```js
const myHandlers = {
  scheduled(...) {}
};

const handler = httpServerHandler(..., myHandlers);
strictEqual(handler, myHandlers);  // false! 
```

And extending classes that extend WorkerEntrypoint was awkward and could not use the `handlers` argument at all.

This change fixes both, and improves testing.

After this change:

```js
const myHandlers = {
  scheduled(...) {}
};

const handler = httpServerHandler(..., myHandlers);
strictEqual(handler, myHandlers);  // true! 

// ...

class MyHandler extends WorkerEntrypoint {}
const handler = httpServerHandler(..., MyHandler);
strictEqual(handler, MyHandler);  // true!
```

Builds-on: https://github.com/cloudflare/workerd/pull/4735
Closes: https://github.com/cloudflare/workerd/issues/4734