### PR TITLE
Python: Fix top level entropy with Pyodide 0.28

### DIFF
--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("//:build/python_metadata.bzl", "BUNDLE_VERSION_INFO", "PYTHON_IMPORTS_TO_TEST", "PYTHON_LOCKFILES")
-load("//src/workerd/server/tests/python:import_tests.bzl", "gen_import_tests")
+load("//src/workerd/server/tests/python:import_tests.bzl", "gen_import_tests", "gen_rust_import_tests")
 load("//src/workerd/server/tests/python:py_wd_test.bzl", "py_wd_test")
 
 # pyodide_dev.capnp.bin represents a custom pyodide version "dev" that is generated
@@ -30,22 +29,16 @@ py_wd_test("sdk")
 
 py_wd_test("seek-metadatafs")
 
-[
-    gen_import_tests(
-        PYTHON_IMPORTS_TO_TEST[info["packages"]],
-        python_version,
-        # TODO: The packages below don't currently work in the latest package/python versions. Need
-        # to fix them.
-        pkg_skip_versions = {
-            "0.28.0": [
-                "micropip",  # missing lockfile
-                "soupsieve",  # Circular dependency with beautifulsoup4
-                "langchain_openai",  # Problem with top level entropy
-            ],
-        },
-    )
-    for python_version, info in BUNDLE_VERSION_INFO.items()
-]
+gen_import_tests(
+    pkg_skip_versions = {
+        "0.28.0": [
+            "micropip",  # missing lockfile
+            "soupsieve",  # Circular dependency with beautifulsoup4
+        ],
+    },
+)
+
+gen_rust_import_tests()
 
 py_wd_test("undefined-handler")
 

--- a/src/workerd/server/tests/python/import_tests.bzl
+++ b/src/workerd/server/tests/python/import_tests.bzl
@@ -1,7 +1,8 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("//:build/python_metadata.bzl", "BUNDLE_VERSION_INFO", "PYTHON_IMPORTS_TO_TEST")
 load("//src/workerd/server/tests/python:py_wd_test.bzl", "py_wd_test")
 
-def generate_import_py_file(imports):
+def _generate_import_py_file(imports):
     res = ""
     for imp in imports:
         res += "import " + imp + "\n"
@@ -14,26 +15,44 @@ WD_FILE_TEMPLATE = """
 using Workerd = import "/workerd/workerd.capnp";
 
 const unitTests :Workerd.Config = (
-  services = [
-    ( name = "python-import-{}",
-      worker = (
-        modules = [
-          (name = "worker.py", pythonModule = embed "./worker.py"),
-          (name = "{}", pythonRequirement = ""),
-        ],
-        compatibilityDate = "2024-05-02",
-        compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
-      )
-    ),
-  ]
+    services = [
+        ( name = "python-import-{name}",
+            worker = (
+                modules = [
+                    (name = "worker.py", pythonModule = embed "./worker.py"),
+                    {requirements}
+                ],
+                compatibilityDate = "2024-05-02",
+                compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+            )
+        ),
+    ]
 );"""
 
-def generate_wd_test_file(requirement):
-    return WD_FILE_TEMPLATE.format(requirement, requirement)
+def _generate_wd_test_file(name, requirements):
+    l = []
+    for req in requirements:
+        l.append('(name = "{}", pythonRequirement = ""),\n'.format(req))
+    requirements = "".join(l)
+    return WD_FILE_TEMPLATE.format(name = name, requirements = requirements)
+
+def _test(name, directory, wd_test, py_file, python_version, **kwds):
+    pkg_tag = BUNDLE_VERSION_INFO[python_version]["packages"]
+    py_wd_test(
+        name = name,
+        directory = directory,
+        src = wd_test,
+        python_flags = [python_version],
+        make_snapshot = False,
+        args = ["--experimental", "--pyodide-package-disk-cache-dir", "../all_pyodide_wheels_%s" % pkg_tag],
+        data = [py_file, "@all_pyodide_wheels_%s//:whls" % pkg_tag],
+        **kwds
+    )
 
 # to_test is a dictionary from library name to list of imports
-def gen_import_tests(to_test, python_version, pkg_skip_versions = {}):
+def _gen_import_tests(to_test, python_version, pkg_skip_versions):
     for lib in to_test.keys():
+        skip_python_flags = [version for version, packages in pkg_skip_versions.items() if lib in packages]
         if lib.endswith("-tests"):
             # TODO: The pyodide-build-scripts should be updated to not emit these packages. Once
             # that's done we can remove this check.
@@ -45,23 +64,69 @@ def gen_import_tests(to_test, python_version, pkg_skip_versions = {}):
         write_file(
             name = worker_py_fname + "@rule",
             out = worker_py_fname,
-            content = [generate_import_py_file(to_test[lib])],
+            content = [_generate_import_py_file(to_test[lib])],
         )
         write_file(
             name = wd_test_fname + "@rule",
             out = wd_test_fname,
-            content = [generate_wd_test_file(lib)],
+            content = [_generate_wd_test_file(lib, [lib])],
         )
 
-        skip_python_flags = [version for version, packages in pkg_skip_versions.items() if lib in packages]
-        py_wd_test(
+        _test(
             name = prefix,
             directory = lib,
-            src = wd_test_fname,
-            python_flags = [python_version],
+            wd_test = wd_test_fname,
+            py_file = worker_py_fname,
+            python_version = python_version,
             skip_python_flags = skip_python_flags,
-            make_snapshot = False,
-            args = ["--experimental", "--pyodide-package-disk-cache-dir", "../all_pyodide_wheels_20240829.4"],
-            data = [worker_py_fname, "@all_pyodide_wheels_20240829.4//:whls"],
-            size = "enormous",
         )
+
+def gen_import_tests(*, pkg_skip_versions = {}):
+    for python_version, info in BUNDLE_VERSION_INFO.items():
+        to_test = PYTHON_IMPORTS_TO_TEST[info["packages"]]
+        _gen_import_tests(to_test, python_version, pkg_skip_versions = pkg_skip_versions)
+
+def _rotations(lst):
+    result = []
+    cur = lst
+    for i in range(len(lst)):
+        result.append(cur)
+        cur = cur[1:] + [cur[0]]
+    return result
+
+def _pkg_permutations(lst):
+    return _rotations(lst) + _rotations(reversed(lst))
+
+def _gen_rust_import_tests(python_version):
+    if python_version in ["0.26.0a2", "development"]:
+        pkgs = _rotations(["tiktoken", "pydantic"])
+    else:
+        pkgs = _pkg_permutations(["cryptography", "jiter", "tiktoken", "pydantic"])
+
+    for res in pkgs:
+        name = "-".join(res)
+        prefix = "import2/" + name
+        worker_py_fname = python_version + "/" + prefix + "/worker.py"
+        wd_test_fname = python_version + "/" + prefix + "/import.wd-test"
+        write_file(
+            name = worker_py_fname + "@rule",
+            out = worker_py_fname,
+            content = [_generate_import_py_file(res)],
+        )
+        write_file(
+            name = wd_test_fname + "@rule",
+            out = wd_test_fname,
+            content = [_generate_wd_test_file(name, res)],
+        )
+
+        _test(
+            name = prefix,
+            directory = name,
+            wd_test = wd_test_fname,
+            py_file = worker_py_fname,
+            python_version = python_version,
+        )
+
+def gen_rust_import_tests():
+    for python_version in BUNDLE_VERSION_INFO.keys():
+        _gen_rust_import_tests(python_version)


### PR DESCRIPTION
* Make `allow_bad_entropy_calls()` nest properly.

* For reasons I don't entirely understand, in Pyodide 0.28 only the first Rust package to be imported makes the get_entropy call. See gen_rust_import_tests() which tests that importing four rust packages in different permutations works correctly.

* For Python modules we want to patch `exec_module`. Generally it seems that for binary extensions we want to patch `create_module` and not `exec_module`, with the exception of "numpy.random.mtrand". When there is a second case of a binary extension that needs a patch to exec_module, we can consider switching to a less ad-hoc approach.

I also refactored `import_tests.bzl` while I was at it.