### PR TITLE
Add noop jurisdictions in workerd

### DIFF
--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -174,8 +174,8 @@ jsg::Ref<DurableObject> DurableObjectNamespace::getImpl(jsg::Lock& js,
 }
 
 jsg::Ref<DurableObjectNamespace> DurableObjectNamespace::jurisdiction(
-    jsg::Lock& js, kj::String jurisdiction) {
-  auto newIdFactory = idFactory->cloneWithJurisdiction(jurisdiction);
+    jsg::Lock& js, jsg::Optional<kj::String> maybeJurisdiction) {
+  auto newIdFactory = idFactory->cloneWithJurisdiction(maybeJurisdiction);
 
   KJ_SWITCH_ONEOF(channel) {
     KJ_CASE_ONEOF(channelId, uint) {

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -208,7 +208,8 @@ class DurableObjectNamespace: public jsg::Object {
       jsg::Lock& js, jsg::Ref<DurableObjectId> id, jsg::Optional<GetDurableObjectOptions> options);
 
   // Creates a subnamespace with the jurisdiction hardcoded.
-  jsg::Ref<DurableObjectNamespace> jurisdiction(jsg::Lock& js, kj::String jurisdiction);
+  jsg::Ref<DurableObjectNamespace> jurisdiction(
+      jsg::Lock& js, jsg::Optional<kj::String> maybeJurisdiction);
 
   JSG_RESOURCE_TYPE(DurableObjectNamespace, CompatibilityFlags::Reader flags) {
     JSG_METHOD(newUniqueId);

--- a/src/workerd/io/actor-id.h
+++ b/src/workerd/io/actor-id.h
@@ -50,7 +50,8 @@ class ActorIdFactory {
   virtual kj::Own<ActorId> idFromName(kj::String name) = 0;
   virtual kj::Own<ActorId> idFromString(kj::String str) = 0;
   virtual bool matchesJurisdiction(const ActorId& id) = 0;
-  virtual kj::Own<ActorIdFactory> cloneWithJurisdiction(kj::StringPtr jurisdiction) = 0;
+  virtual kj::Own<ActorIdFactory> cloneWithJurisdiction(
+      kj::Maybe<kj::StringPtr> maybeJurisdiction) = 0;
 };
 
 }  // namespace workerd

--- a/src/workerd/server/actor-id-impl.c++
+++ b/src/workerd/server/actor-id-impl.c++
@@ -36,6 +36,10 @@ ActorIdFactoryImpl::ActorIdFactoryImpl(kj::StringPtr uniqueKey) {
   KJ_ASSERT(SHA256(uniqueKey.asBytes().begin(), uniqueKey.size(), key) == key);
 }
 
+ActorIdFactoryImpl::ActorIdFactoryImpl(const kj::byte keyParam[SHA256_DIGEST_LENGTH]) {
+  memcpy(key, keyParam, sizeof(key));
+}
+
 kj::Own<ActorIdFactory::ActorId> ActorIdFactoryImpl::newUniqueId(
     kj::Maybe<kj::StringPtr> jurisdiction) {
   JSG_REQUIRE(
@@ -90,7 +94,12 @@ kj::Own<ActorIdFactory::ActorId> ActorIdFactoryImpl::idFromString(kj::String str
   return kj::heap<ActorIdImpl>(id, kj::none);
 }
 
-kj::Own<ActorIdFactory> ActorIdFactoryImpl::cloneWithJurisdiction(kj::StringPtr jurisdiction) {
+kj::Own<ActorIdFactory> ActorIdFactoryImpl::cloneWithJurisdiction(
+    kj::Maybe<kj::StringPtr> maybeJurisdiction) {
+  if (maybeJurisdiction == kj::none) {
+    return kj::heap<ActorIdFactoryImpl>(key);
+  }
+
   JSG_FAIL_REQUIRE(Error, "Jurisdiction restrictions are not implemented in workerd.");
 }
 

--- a/src/workerd/server/actor-id-impl.h
+++ b/src/workerd/server/actor-id-impl.h
@@ -8,6 +8,8 @@ namespace workerd::server {
 class ActorIdFactoryImpl final: public ActorIdFactory {
  public:
   ActorIdFactoryImpl(kj::StringPtr uniqueKey);
+  ActorIdFactoryImpl(const kj::byte keyParam[SHA256_DIGEST_LENGTH]);
+
   class ActorIdImpl final: public ActorId {
    public:
     ActorIdImpl(const kj::byte idParam[SHA256_DIGEST_LENGTH], kj::Maybe<kj::String> name);
@@ -29,7 +31,8 @@ class ActorIdFactoryImpl final: public ActorIdFactory {
   kj::Own<ActorId> newUniqueId(kj::Maybe<kj::StringPtr> jurisdiction) override;
   kj::Own<ActorId> idFromName(kj::String name) override;
   kj::Own<ActorId> idFromString(kj::String str) override;
-  kj::Own<ActorIdFactory> cloneWithJurisdiction(kj::StringPtr jurisdiction) override;
+  kj::Own<ActorIdFactory> cloneWithJurisdiction(
+      kj::Maybe<kj::StringPtr> maybeJurisdiction) override;
   bool matchesJurisdiction(const ActorId& id) override;
 
  private:


### PR DESCRIPTION
I am on the fence whether this is worthwhile. I don't like it because the jurisdictions feature makes no sense in workerd, but customers would like to have jurisdiction support in local development. This adds jurisdictions which effectively do nothing, but should have the same properties that they do in edgeworker. This changes the way that actor IDs are computed in workerd, which is technically a breaking change.