### PR TITLE
Add factory function for read-only empty directory

### DIFF
--- a/src/workerd/io/worker-fs.c++
+++ b/src/workerd/io/worker-fs.c++
@@ -1223,6 +1223,11 @@ kj::Rc<Directory> Directory::newWritable() {
   return kj::rc<WritableDirectory>();
 }
 
+kj::Rc<Directory> Directory::newEmptyReadonly() {
+  Directory::Builder builder;
+  return builder.finish();
+}
+
 kj::Rc<Directory> Directory::newWritable(jsg::Lock& js) {
   auto dir = kj::rc<WritableDirectory>();
   dir->countTowardsIsolateLimit(js);

--- a/src/workerd/io/worker-fs.h
+++ b/src/workerd/io/worker-fs.h
@@ -418,6 +418,10 @@ class Directory: public kj::Refcounted, public kj::EnableAddRefToThis<Directory>
   // when the handle is dropped.
   static kj::Rc<Directory> newWritable() KJ_WARN_UNUSED_RESULT;
 
+  // As a utility in some cases, we need the ability to create empty read-only
+  // directories.
+  static kj::Rc<Directory> newEmptyReadonly() KJ_WARN_UNUSED_RESULT;
+
   // Variation of newWritable that ensures the Directory instance itself is
   // counted towwards the isolate memory limit. This should be the typical
   // case for directories created by user code, such as when creating a


### PR DESCRIPTION
Provides a simple utility method for easily creating an empty, read-only workers-fs `Directory`. To be used by the production system in certain cases.