### PR TITLE
R2-3382: Throw Error on Invalid ETag

### DIFF
--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -1021,9 +1021,19 @@ R2Bucket::UnwrappedConditional::UnwrappedConditional(jsg::Lock& js, Headers& h)
     : secondsGranularity(true) {
   KJ_IF_SOME(e, h.getNoChecks(js, "if-match"_kj)) {
     etagMatches = parseConditionalEtagHeader(kj::str(e));
+    KJ_IF_SOME(arr, etagMatches) {
+      if (arr.size() == 0) {
+        JSG_FAIL_REQUIRE(Error, "Invalid ETag in if-match header");
+      }
+    }
   }
   KJ_IF_SOME(e, h.getNoChecks(js, "if-none-match"_kj)) {
     etagDoesNotMatch = parseConditionalEtagHeader(kj::str(e));
+    KJ_IF_SOME(arr, etagDoesNotMatch) {
+      if (arr.size() == 0) {
+        JSG_FAIL_REQUIRE(Error, "Invalid ETag in if-none-match header");
+      }
+    }
   }
   KJ_IF_SOME(d, h.getNoChecks(js, "if-modified-since"_kj)) {
     auto date = parseDate(js, d);

--- a/src/workerd/api/r2-test.js
+++ b/src/workerd/api/r2-test.js
@@ -646,6 +646,22 @@ export default {
     }
     // Conditionals
     {
+      try {
+        await env.BUCKET.put('throwOnInvalidEtag', body, {
+          onlyIf: new Headers({
+            'if-match': 'strongEtag',
+          }),
+        });
+        throw new Error('This should have thrown');
+      } catch {}
+      try {
+        await env.BUCKET.put('throwOnInvalidEtag', body, {
+          onlyIf: new Headers({
+            'if-none-match': 'strongEtag',
+          }),
+        });
+        throw new Error('This should have thrown');
+      } catch {}
       await env.BUCKET.put('onlyIfStrongEtag', body, {
         onlyIf: {
           etagMatches: 'strongEtag',


### PR DESCRIPTION
When passing headers in to `onlyIf` actions on the R2 Binding, if an ETag is not quoted, it would be returned as an empty array, rather than erroring.