### PR TITLE
Separate Fetcher and FetchHandler interfaces

### DIFF
--- a/src/cloudflare/internal/http.ts
+++ b/src/cloudflare/internal/http.ts
@@ -1,6 +1,11 @@
 export interface Fetcher {
+  fetch: typeof fetch;
+}
+
+export interface FetchHandler {
   // We don't use typeof fetch here because that would use the client-side signature,
   // which is different from the server-side signature.
   fetch: (request: Request, env?: unknown, ctx?: unknown) => Promise<Response>;
 }
-export const portMapper = new Map<number, Fetcher>();
+
+export const portMapper = new Map<number, FetchHandler>();

--- a/src/cloudflare/node.ts
+++ b/src/cloudflare/node.ts
@@ -1,11 +1,10 @@
 // Copyright (c) 2024 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-import { portMapper } from 'cloudflare-internal:http';
-
-interface Fetcher {
-  fetch(request: Request, env?: unknown, ctx?: unknown): Promise<Response>;
-}
+import {
+  portMapper,
+  type FetchHandler as Fetcher,
+} from 'cloudflare-internal:http';
 
 interface ServerDescriptor {
   port?: number | null | undefined;


### PR DESCRIPTION
Avoid conflicts with the different signatures of the fetch method.