### PR TITLE
repro for stack leaking bug

### DIFF
--- a/samples/helloworld_esm/worker.js
+++ b/samples/helloworld_esm/worker.js
@@ -2,6 +2,8 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+throw new AggregateError([new Error('boom')], 'message', { cause: new Error('cause') });
+
 export default {
   async fetch(req, env) {
     return new Response("Hello World\n");

--- a/src/pyodide/internal/_workers.py
+++ b/src/pyodide/internal/_workers.py
@@ -215,7 +215,9 @@ def _to_python_exception(exc: JsException) -> Exception:
 def _from_js_error(exc: JsException) -> Exception:
     # convert into Python exception after a full round trip
     # Python - JS - Python
-    if not exc.message or not exc.message.startswith("PythonError"):
+    if exc.name != "PythonError" and (
+        not exc.message or not exc.message.startswith("PythonError")
+    ):
         return _to_python_exception(exc)
 
     # extract the Python exception type from the traceback

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -820,3 +820,12 @@ wd_test(
     args = ["--experimental"],
     data = ["tests/streams-circ-ref-regression-test.js"],
 )
+
+wd_test(
+    src = "tests/rpc-error-test.wd-test",
+    args = ["--experimental"],
+    data = [
+        "tests/rpc-error-test.js",
+        "tests/rpc-error-test.rpc.js",
+    ],
+)

--- a/src/workerd/api/tests/rpc-error-test.js
+++ b/src/workerd/api/tests/rpc-error-test.js
@@ -1,0 +1,44 @@
+import { notStrictEqual } from 'assert';
+
+export const test = {
+  async test(_, env) {
+    try {
+      await env.RPC.foo(null);
+      throw new Error('Expected error not thrown');
+    } catch (e) {
+      // The error returned by RPC will have a stack2 property that contains
+      // the original stack from the worker where the error was thrown.
+      notStrictEqual(e.stack2, undefined);
+      // Because we are not setting the trusted option when deserializing the
+      // error, the stack of the error reported here should be different from
+      // the original stack.
+      notStrictEqual(e.stack2, e.stack);
+    }
+
+    try {
+      await env.RPC.bar(null).baz(null);
+      throw new Error('Expected error not thrown');
+    } catch (e) {
+      // The error returned by RPC will have a stack2 property that contains
+      // the original stack from the worker where the error was thrown.
+      notStrictEqual(e.stack2, undefined);
+      // Because we are not setting the trusted option when deserializing the
+      // error, the stack of the error reported here should be different from
+      // the original stack.
+      notStrictEqual(e.stack2, e.stack);
+    }
+
+    try {
+      await env.RPC.xyz(null);
+      throw new Error('Expected error not thrown');
+    } catch (e) {
+      // The error returned by RPC will have a stack2 property that contains
+      // the original stack from the worker where the error was thrown.
+      notStrictEqual(e.stack2, undefined);
+      // Because we are not setting the trusted option when deserializing the
+      // error, the stack of the error reported here should be different from
+      // the original stack.
+      notStrictEqual(e.stack2, e.stack);
+    }
+  },
+};

--- a/src/workerd/api/tests/rpc-error-test.js
+++ b/src/workerd/api/tests/rpc-error-test.js
@@ -16,7 +16,9 @@ export const test = {
     }
 
     try {
-      await env.RPC.bar(null).baz(null);
+      const bar = await env.RPC.bar(null);
+      const baz = await bar.baz(null);
+      await baz.qux(null);
       throw new Error('Expected error not thrown');
     } catch (e) {
       // The error returned by RPC will have a stack2 property that contains
@@ -39,6 +41,17 @@ export const test = {
       // error, the stack of the error reported here should be different from
       // the original stack.
       notStrictEqual(e.stack2, e.stack);
+    }
+
+    {
+      const err = await env.RPC.abc(null).a;
+      // The error returned by RPC will have a stack2 property that contains
+      // the original stack from the worker where the error was thrown.
+      notStrictEqual(err.stack2, undefined);
+      // Because we are not setting the trusted option when deserializing the
+      // error, the stack of the error reported here should be different from
+      // the original stack.
+      notStrictEqual(err.stack2, err.stack);
     }
   },
 };

--- a/src/workerd/api/tests/rpc-error-test.js
+++ b/src/workerd/api/tests/rpc-error-test.js
@@ -1,57 +1,80 @@
 import { notStrictEqual } from 'assert';
+import { DurableObject } from 'cloudflare:workers';
+
+export class Foo extends DurableObject {
+  constructor(state, env) {
+    super(state, env)
+    this.state = state
+  }
+
+  async foo() {
+    await scheduler.wait(10);
+    let id = this.env.Bar.idFromName('bar');
+    let stub = this.env.Bar.get(id);
+
+    try {
+      await stub.bar();
+    } catch (e) {
+      console.log('err:', e)
+      throw e;
+    }
+  }
+
+  async alarm() {
+    console.log('alarm called')
+    try {
+      await this.foo()
+      this.resolve();
+    } catch (e) {
+      this.reject(e);
+    }
+  }
+
+  async fetch1() {
+    console.log('fetch called')
+    const time = Date.now() + 50;
+    await this.state.storage.setAlarm(time);
+
+    await this.waitForAlarm(time);
+  }
+
+
+  async waitForAlarm(scheduledTime) {
+    let self = this;
+    const { promise, resolve, reject } = Promise.withResolvers();
+    self.resolve = resolve;
+    self.reject = reject;
+
+    try {
+      await promise;
+      if (Date.now() < scheduledTime.valueOf()) {
+        throw new Error(
+          `Date.now() is before scheduledTime! ${Date.now()} vs ${scheduledTime.valueOf()}`
+        );
+      }
+    } catch (e) {
+      throw new Error(
+        `error waiting for alarm at ${scheduledTime.valueOf()}: ${e}`
+      );
+    }
+
+    let alarm = await this.state.storage.getAlarm();
+    if (alarm != null) {
+      throw new Error(`alarm time not cleared when handler ends. ${alarm}`);
+    }
+  }
+}
 
 export const test = {
   async test(_, env) {
     try {
-      await env.RPC.foo(null);
-      throw new Error('Expected error not thrown');
+      let id = env.Foo.idFromName('foo');
+      let stub = env.Foo.get(id);
+      await stub.fetch1();
     } catch (e) {
-      // The error returned by RPC will have a stack2 property that contains
-      // the original stack from the worker where the error was thrown.
-      notStrictEqual(e.stack2, undefined);
-      // Because we are not setting the trusted option when deserializing the
-      // error, the stack of the error reported here should be different from
-      // the original stack.
-      notStrictEqual(e.stack2, e.stack);
-    }
+      // e.stack should not contain bar.blah()
+      // if it does then we're leaking
 
-    try {
-      const bar = await env.RPC.bar(null);
-      const baz = await bar.baz(null);
-      await baz.qux(null);
-      throw new Error('Expected error not thrown');
-    } catch (e) {
-      // The error returned by RPC will have a stack2 property that contains
-      // the original stack from the worker where the error was thrown.
-      notStrictEqual(e.stack2, undefined);
-      // Because we are not setting the trusted option when deserializing the
-      // error, the stack of the error reported here should be different from
-      // the original stack.
-      notStrictEqual(e.stack2, e.stack);
-    }
-
-    try {
-      await env.RPC.xyz(null);
-      throw new Error('Expected error not thrown');
-    } catch (e) {
-      // The error returned by RPC will have a stack2 property that contains
-      // the original stack from the worker where the error was thrown.
-      notStrictEqual(e.stack2, undefined);
-      // Because we are not setting the trusted option when deserializing the
-      // error, the stack of the error reported here should be different from
-      // the original stack.
-      notStrictEqual(e.stack2, e.stack);
-    }
-
-    {
-      const err = await env.RPC.abc(null).a;
-      // The error returned by RPC will have a stack2 property that contains
-      // the original stack from the worker where the error was thrown.
-      notStrictEqual(err.stack2, undefined);
-      // Because we are not setting the trusted option when deserializing the
-      // error, the stack of the error reported here should be different from
-      // the original stack.
-      notStrictEqual(err.stack2, err.stack);
     }
   },
 };

--- a/src/workerd/api/tests/rpc-error-test.rpc.js
+++ b/src/workerd/api/tests/rpc-error-test.rpc.js
@@ -1,0 +1,25 @@
+export default {
+  foo() {
+    const err = new Error('boom');
+    err.stack2 = err.stack;
+    throw err;
+  },
+
+  async bar() {
+    await scheduler.wait(10);
+    return {
+      async baz() {
+        await scheduler.wait(10);
+        const err = new Error('bork');
+        err.stack2 = err.stack;
+        throw err;
+      },
+    };
+  },
+
+  xyz() {
+    const err = new Error('bang');
+    err.stack2 = err.stack;
+    return Promise.reject(err);
+  },
+};

--- a/src/workerd/api/tests/rpc-error-test.rpc.js
+++ b/src/workerd/api/tests/rpc-error-test.rpc.js
@@ -1,3 +1,21 @@
+import { RpcTarget } from 'cloudflare:workers';
+
+class Baz extends RpcTarget {
+  async qux() {
+    await scheduler.wait(10);
+    const err = new Error('bork');
+    err.stack2 = err.stack;
+    throw err;
+  }
+}
+
+class Bar extends RpcTarget {
+  async baz() {
+    await scheduler.wait(10);
+    return new Baz();
+  }
+}
+
 export default {
   foo() {
     const err = new Error('boom');
@@ -7,19 +25,18 @@ export default {
 
   async bar() {
     await scheduler.wait(10);
-    return {
-      async baz() {
-        await scheduler.wait(10);
-        const err = new Error('bork');
-        err.stack2 = err.stack;
-        throw err;
-      },
-    };
+    return new Bar();
   },
 
   xyz() {
     const err = new Error('bang');
     err.stack2 = err.stack;
     return Promise.reject(err);
+  },
+
+  abc() {
+    const err = new Error('boom');
+    err.stack2 = err.stack;
+    return { a: err };
   },
 };

--- a/src/workerd/api/tests/rpc-error-test.rpc.js
+++ b/src/workerd/api/tests/rpc-error-test.rpc.js
@@ -1,42 +1,48 @@
-import { RpcTarget } from 'cloudflare:workers';
+import { DurableObject } from 'cloudflare:workers';
 
-class Baz extends RpcTarget {
-  async qux() {
+// class Baz extends RpcTarget {
+//   async qux() {
+//     await scheduler.wait(10);
+//     const err = new Error('bork');
+//     err.stack2 = err.stack;
+//     throw err;
+//   }
+// }
+
+export class Bar extends DurableObject {
+  async bar() {
+    await this.blah()
+  }
+
+  async blah () {
     await scheduler.wait(10);
     const err = new Error('bork');
-    err.stack2 = err.stack;
+    err.trusted = true
     throw err;
   }
 }
 
-class Bar extends RpcTarget {
-  async baz() {
-    await scheduler.wait(10);
-    return new Baz();
-  }
-}
+// export default {
+//   foo() {
+//     const err = new Error('boom');
+//     err.stack2 = err.stack;
+//     throw err;
+//   },
 
-export default {
-  foo() {
-    const err = new Error('boom');
-    err.stack2 = err.stack;
-    throw err;
-  },
+//   async bar() {
+//     await scheduler.wait(10);
+//     return new Bar();
+//   },
 
-  async bar() {
-    await scheduler.wait(10);
-    return new Bar();
-  },
+//   xyz() {
+//     const err = new Error('bang');
+//     err.stack2 = err.stack;
+//     return Promise.reject(err);
+//   },
 
-  xyz() {
-    const err = new Error('bang');
-    err.stack2 = err.stack;
-    return Promise.reject(err);
-  },
-
-  abc() {
-    const err = new Error('boom');
-    err.stack2 = err.stack;
-    return { a: err };
-  },
-};
+//   abc() {
+//     const err = new Error('boom');
+//     err.stack2 = err.stack;
+//     return { a: err };
+//   },
+// };

--- a/src/workerd/api/tests/rpc-error-test.wd-test
+++ b/src/workerd/api/tests/rpc-error-test.wd-test
@@ -2,26 +2,39 @@ using Workerd = import "/workerd/workerd.capnp";
 
 const unitTests :Workerd.Config = (
   services = [
+    (name = "TEST_TMPDIR", disk = (writable = true)),
     ( name = "rpc-error-test",
       worker = (
         modules = [
           (name = "worker", esModule = embed "rpc-error-test.js")
         ],
-        compatibilityDate = "2025-08-01",
-        compatibilityFlags = ["nodejs_compat"],
+        compatibilityDate = "2025-08-10",
+        compatibilityFlags = ["nodejs_compat", "experimental"],
         bindings = [
-          ( name = "RPC", service = "rpc-target" ),
-        ]
-      )
+          (name = "Foo", durableObjectNamespace = "Foo"),
+          (name = "Bar", durableObjectNamespace=(serviceName="rpc-target", className="Bar")),
+        ],
+        durableObjectNamespaces = [
+          (className = "Foo", uniqueKey = "foo"),
+        ],
+
+        durableObjectStorage = (localDisk = "TEST_TMPDIR"),
+      ),
+
     ),
     ( name = "rpc-target",
       worker = (
         modules = [
           (name = "worker", esModule = embed "rpc-error-test.rpc.js")
         ],
-        compatibilityFlags = ["nodejs_compat"],
-        compatibilityDate = "2025-08-01",
-      )
+        compatibilityFlags = ["nodejs_compat", "experimental"],
+        compatibilityDate = "2025-08-10",
+        durableObjectNamespaces = [
+          (className = "Bar", uniqueKey = "bar")
+        ],
+
+        durableObjectStorage = (localDisk = "TEST_TMPDIR"),
+      ),
     ),
   ],
 );

--- a/src/workerd/api/tests/rpc-error-test.wd-test
+++ b/src/workerd/api/tests/rpc-error-test.wd-test
@@ -1,0 +1,27 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "rpc-error-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "rpc-error-test.js")
+        ],
+        compatibilityDate = "2025-08-01",
+        compatibilityFlags = ["nodejs_compat"],
+        bindings = [
+          ( name = "RPC", service = "rpc-target" ),
+        ]
+      )
+    ),
+    ( name = "rpc-target",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "rpc-error-test.rpc.js")
+        ],
+        compatibilityFlags = ["nodejs_compat"],
+        compatibilityDate = "2025-08-01",
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -167,6 +167,7 @@ void serializeJsValue(jsg::Lock& js,
         .version = 15,
         .omitHeader = false,
         .treatClassInstancesAsPlainObjects = false,
+        .treatErrorsAsHostObjects = true,
         .externalHandler = externalHandler,
       });
   serializer.write(js, value);
@@ -212,6 +213,7 @@ DeserializeResult deserializeJsValue(
       jsg::Deserializer::Options{
         .version = 15,
         .readHeader = true,
+        .preserveStackInErrors = false,
         .externalHandler = externalHandler,
       });
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2185,36 +2185,7 @@ void Worker::Lock::logUncaughtException(
 
 void Worker::Lock::logUncaughtException(UncaughtExceptionSource source, kj::Exception&& exception) {
   jsg::Lock& js = *this;
-
-  // If we have an attached serialized exception, deserialize it and log that instead, rather
-  // than try to reconstruct based on the KJ exception description.
-  //
-  // TODO(cleanup): Eventually, js.exceptionToJsValue() should do this internally, and then we
-  //   should remove the code from here.
-  KJ_IF_SOME(serializedJsError, exception.getDetail(jsg::TUNNELED_EXCEPTION_DETAIL_ID)) {
-    if (!js.v8Isolate->IsExecutionTerminating()) {
-      kj::Maybe<jsg::JsValue> deserialized;
-
-      v8::TryCatch tryCatch(js.v8Isolate);
-      try {
-        jsg::Deserializer deser(js, serializedJsError);
-        deserialized = deser.readValue(js);
-      } catch (jsg::JsExceptionThrown&) {
-        // Failed to deserialize, we'll continue with exceptionToJsValue() instead.
-        //
-        // Note that we're intentionally not checking tryCatch.CanContinue() here, because we still
-        // want to log the exception even if the isolate has been terminated.
-      }
-
-      KJ_IF_SOME(d, deserialized) {
-        logUncaughtException(source, d);
-        return;
-      }
-    }
-  }
-
-  // Couldn't deserialize an attached exception, so use `exceptionToJsValue()`.
-  auto jsError = js.exceptionToJsValue(kj::mv(exception));
+  auto jsError = js.exceptionToJsValue(kj::mv(exception), {.trusted = true});
   logUncaughtException(source, jsError.getHandle(js));
 }
 

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2502,9 +2502,10 @@ class Lock {
   // error, this reproduces the original error. If it is not a tunneled error, then it is treated
   // as an internal error: the KJ exception message is logged to stderr, and a JavaScript error
   // is returned with a generic description.
-  Value exceptionToJs(kj::Exception&& exception);
+  Value exceptionToJs(kj::Exception&& exception, MakeInternalErrorOptions options = {});
 
-  JsRef<JsValue> exceptionToJsValue(kj::Exception&& exception);
+  JsRef<JsValue> exceptionToJsValue(
+      kj::Exception&& exception, MakeInternalErrorOptions options = {});
 
   // Encodes the given JavaScript exception into a KJ exception, formatting the description in
   // such a way that hopefully exceptionToJs() can reproduce something equivalent to the original
@@ -2521,8 +2522,9 @@ class Lock {
   // via JSG understand how to handle this and propagate the exception back to JavaScript.
   [[noreturn]] void throwException(Value&& exception);
 
-  [[noreturn]] void throwException(kj::Exception&& exception) {
-    throwException(exceptionToJs(kj::mv(exception)));
+  [[noreturn]] void throwException(
+      kj::Exception&& exception, MakeInternalErrorOptions options = {}) {
+    throwException(exceptionToJs(kj::mv(exception), options));
   }
 
   [[noreturn]] void throwException(const JsValue& exception);
@@ -2609,11 +2611,11 @@ class Lock {
 
   // Construct an immediately-rejected promise throwing the given exception.
   template <typename T>
-  Promise<T> rejectedPromise(kj::Exception&& exception);
+  Promise<T> rejectedPromise(kj::Exception&& exception, MakeInternalErrorOptions options = {});
 
   // Like above, but return a pure-JS promise, not a typed Promise.
   JsPromise rejectedJsPromise(jsg::JsValue exception);
-  JsPromise rejectedJsPromise(kj::Exception&& exception);
+  JsPromise rejectedJsPromise(kj::Exception&& exception, MakeInternalErrorOptions options = {});
 
   // Like `kj::evalNow()`, but returns a jsg::Promise for the result. Synchronous exceptions are
   // caught and returned as a rejected promise.

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -624,8 +624,8 @@ JsPromise Lock::rejectedJsPromise(jsg::JsValue exception) {
   return JsPromise(handleScope.Escape(resolver->GetPromise()));
 }
 
-JsPromise Lock::rejectedJsPromise(kj::Exception&& exception) {
-  return rejectedJsPromise(exceptionToJsValue(kj::mv(exception)).getHandle(*this));
+JsPromise Lock::rejectedJsPromise(kj::Exception&& exception, MakeInternalErrorOptions options) {
+  return rejectedJsPromise(exceptionToJsValue(kj::mv(exception), options).getHandle(*this));
 }
 
 PromiseState JsPromise::state() {

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -239,7 +239,8 @@ v8::MaybeLocal<v8::Value> evaluateSyntheticModuleCallback(
   })) {
     // V8 doc comments say in the case of an error, throw the error and return an empty Maybe.
     // I.e. NOT a rejected promise. OK...
-    js.v8Isolate->ThrowException(makeInternalError(js.v8Isolate, kj::mv(exception)));
+    auto ex = js.exceptionToJsValue(kj::mv(exception));
+    js.v8Isolate->ThrowException(ex.getHandle(js));
     result = v8::Local<v8::Promise>();
   }
 

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -695,7 +695,7 @@ v8::MaybeLocal<v8::Promise> dynamicImportCallback(v8::Local<v8::Context> context
       }
       return makeRejected(tryCatch.Exception());
     } catch (kj::Exception& ex) {
-      return makeRejected(makeInternalError(js.v8Isolate, kj::mv(ex)));
+      return makeRejected(kjExceptionToJs(js.v8Isolate, kj::mv(ex)));
     }
   }
 
@@ -739,7 +739,8 @@ v8::MaybeLocal<v8::Promise> dynamicImportCallback(v8::Local<v8::Context> context
 
     return makeRejected(tryCatch.Exception());
   } catch (kj::Exception& ex) {
-    return makeRejected(makeInternalError(js.v8Isolate, kj::mv(ex)));
+    auto exc = js.exceptionToJs(kj::mv(ex));
+    return makeRejected(exc.getHandle(js));
   }
   KJ_UNREACHABLE;
 }

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -345,7 +345,8 @@ class Promise {
     }
 
     void reject(Lock& js, kj::Exception exception) {
-      reject(js, makeInternalError(js.v8Isolate, kj::mv(exception)));
+      auto exc = js.exceptionToJs(kj::mv(exception));
+      reject(js, exc.getHandle(js));
     }
 
     Resolver addRef(Lock& js) {
@@ -487,9 +488,9 @@ Promise<T> Lock::rejectedPromise(jsg::Value exception) {
 }
 
 template <typename T>
-Promise<T> Lock::rejectedPromise(kj::Exception&& exception) {
+Promise<T> Lock::rejectedPromise(kj::Exception&& exception, MakeInternalErrorOptions options) {
   return withinHandleScope(
-      [&] { return rejectedPromise<T>(makeInternalError(v8Isolate, kj::mv(exception))); });
+      [&] { return rejectedPromise<T>(kjExceptionToJs(v8Isolate, kj::mv(exception), options)); });
 }
 
 template <class Func>

--- a/src/workerd/jsg/ser-test.c++
+++ b/src/workerd/jsg/ser-test.c++
@@ -180,6 +180,40 @@ struct SerTestContext: public ContextGlobalObject {
     return val;
   }
 
+  JsValue roundTripErrorNoStack(Lock& js, JsObject errorObj) {
+    Serializer ser(js,
+        Serializer::Options{
+          .treatErrorsAsHostObjects = true,
+        });
+
+    ser.write(js, errorObj);
+    auto content = ser.release();
+    Deserializer deser(js, content,
+        Deserializer::Options{
+          .preserveStackInErrors = false,
+        });
+    auto retObj = KJ_ASSERT_NONNULL(deser.readValue(js).tryCast<JsObject>());
+
+    // Verify that converting to/from kj::Exception works as expected since
+    // that uses the same ser/deser logic.
+    {
+      auto kjEx = js.exceptionToKj(errorObj);
+      auto backToJs = js.exceptionToJsValue(kj::mv(kjEx)).getHandle(js);
+      auto retObj2 = KJ_ASSERT_NONNULL(backToJs.tryCast<JsObject>());
+      // Because the trusted option was not passed, the stack should be different.
+      KJ_ASSERT(!retObj2.get(js, "stack"_kj).strictEquals(errorObj.get(js, "stack"_kj)));
+    }
+    {
+      auto kjEx = js.exceptionToKj(errorObj);
+      auto backToJs = js.exceptionToJsValue(kj::mv(kjEx), {.trusted = true}).getHandle(js);
+      auto retObj2 = KJ_ASSERT_NONNULL(backToJs.tryCast<JsObject>());
+      // Because the trusted option is true, the stack should be the same.
+      KJ_ASSERT(retObj2.get(js, "stack"_kj).strictEquals(errorObj.get(js, "stack"_kj)));
+    }
+
+    return retObj.get(js, js.str("stack"_kj));
+  }
+
   JSG_RESOURCE_TYPE(SerTestContext) {
     JSG_NESTED_TYPE(Foo);
     JSG_NESTED_TYPE(Bar);
@@ -187,6 +221,7 @@ struct SerTestContext: public ContextGlobalObject {
     JSG_NESTED_TYPE(Qux);
     JSG_METHOD(roundTrip);
     JSG_METHOD(roundTripError);
+    JSG_METHOD(roundTripErrorNoStack);
   }
 };
 JSG_DECLARE_ISOLATE_TYPE(SerTestIsolate,
@@ -353,6 +388,9 @@ KJ_TEST("serialization of errors") {
       "boolean", "true");
   e.expectEval("roundTripError(new SuppressedError('a', 'b', 'c', {cause:'c'})) instanceof "
                "SuppressedError",
+      "boolean", "true");
+
+  e.expectEval("const e = new Error('boom'); e2 = roundTripErrorNoStack(e); e.stack !== e2.stack",
       "boolean", "true");
 }
 

--- a/src/workerd/jsg/util-test.c++
+++ b/src/workerd/jsg/util-test.c++
@@ -243,6 +243,27 @@ struct TunneledContext: public ContextGlobalObject {
   void throwTunneledGarbledDOMException() {
     KJ_FAIL_REQUIRE("jsg.DOMException(: thrown from throwTunneledGarbledDOMException");
   }
+  bool testTrustedErrorWithProps(jsg::Lock& js) {
+    jsg::JsValue stack = js.undefined();
+    try {
+      auto err = KJ_ASSERT_NONNULL(
+          jsg::JsValue(v8::Exception::SuppressedError(js.str("foo"_kj))).tryCast<jsg::JsObject>());
+      err.set(js, "foo"_kj, js.boolean(true));
+      stack = err.get(js, "stack"_kj);
+      KJ_ASSERT(stack.isString());
+      kj::throwFatalException(js.exceptionToKj(err));
+    } catch (...) {
+      auto ex = kj::getCaughtExceptionAsKj();
+      KJ_ASSERT(isTunneledException(ex.getDescription()));
+      auto decodedErr = jsg::JsValue(kjExceptionToJs(js.v8Isolate, kj::mv(ex)));
+      auto obj = KJ_ASSERT_NONNULL(decodedErr.tryCast<jsg::JsObject>());
+      KJ_ASSERT(obj.get(js, "foo"_kj).strictEquals(js.boolean(true)));
+      KJ_ASSERT(obj.get(js, "message"_kj).toString(js) == "foo"_kj);
+      KJ_ASSERT(obj.get(js, "name"_kj).toString(js) == "SuppressedError"_kj);
+      KJ_ASSERT(obj.get(js, "stack"_kj).strictEquals(stack));
+      return true;
+    }
+  }
 
   JSG_RESOURCE_TYPE(TunneledContext) {
     JSG_NESTED_TYPE(DOMException);
@@ -269,6 +290,7 @@ struct TunneledContext: public ContextGlobalObject {
     JSG_METHOD(throwTunneledDOMException);
     JSG_METHOD(throwTunneledInvalidDOMException);
     JSG_METHOD(throwTunneledGarbledDOMException);
+    JSG_METHOD(testTrustedErrorWithProps);
   }
 };
 JSG_DECLARE_ISOLATE_TYPE(TunneledIsolate, TunneledContext);
@@ -334,6 +356,8 @@ KJ_TEST("throw tunneled exception") {
     KJ_EXPECT_LOG(ERROR, " thrown from throwTunneledGarbledDOMException");
     e.expectEval("throwTunneledGarbledDOMException()", "throws",
         "Error: internal error; reference = 0123456789abcdefghijklmn");
+
+    e.expectEval("testTrustedErrorWithProps()", "boolean", "true");
   }
 }
 

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -252,7 +252,7 @@ DecodedException decodeTunneledException(
                 jsg::Deserializer::Options{
                   // By default, we do not preserve stacks in deserialized errors because
                   // of trust concerns sharing stack details over potentially untrusted
-                  // boundaries. However, if the caller has explicitly indiciate that the
+                  // boundaries. However, if the caller has explicitly indicated that the
                   // scope it trusted, we will preserve the stack in the deserialized error.
                   .preserveStackInErrors = options.trusted,
                 });

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -53,6 +53,27 @@ bool getShouldSetToStringTag(v8::Isolate* isolate);
 kj::String fullyQualifiedTypeName(const std::type_info& type);
 kj::String typeName(const std::type_info& type);
 
+struct MakeInternalErrorOptions {
+  // When trusted is true and the kj::Exception has a serialized exception detail, the
+  // stack will be included in the deserialized error if it is available. When false,
+  // the stack will be omitted.
+  bool trusted = false;
+
+  // When ignoreDetail is true, tells kjExceptionToJs() to ignore any serialized
+  // exception detail in the kj::Exception.
+  bool ignoreDetail = false;
+
+  // If the deserialized exception detail is not an object, then it will be ignored
+  // and we will fall back to constructing a new error object. The default is true
+  // to preserve existing behavior, but setting this to false may be useful in some
+  // cases. When false, the kjExceptionToJs() might return a non-object value.
+  bool allowNonObjects = false;
+
+  // When doNotLog is true and this is an actually-internal error, the error will
+  // not be logged.
+  bool doNotLog = false;
+};
+
 // Creates a JavaScript error that obfuscates the exception details, while logging the full details
 // to stderr. If the KJ exception was created using throwTunneledException(), don't log anything
 // but instead return the original reconstructed JavaScript exception.
@@ -61,13 +82,15 @@ v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::StringPtr inter
 // Creates a JavaScript error that obfuscates the exception details, while logging the full details
 // to stderr. If the KJ exception was created using throwTunneledException(), don't log anything
 // but instead return the original reconstructed JavaScript exception.
-v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::Exception&& exception);
+v8::Local<v8::Value> kjExceptionToJs(
+    v8::Isolate* isolate, kj::Exception&& exception, MakeInternalErrorOptions options = {});
 
-// calls makeInternalError() and then tells the isolate to throw it.
+// calls kjExceptionToJs() and then tells the isolate to throw it.
 void throwInternalError(v8::Isolate* isolate, kj::StringPtr internalMessage);
 
-// calls makeInternalError() and then tells the isolate to throw it.
-void throwInternalError(v8::Isolate* isolate, kj::Exception&& exception);
+// calls kjExceptionToJs() and then tells the isolate to throw it.
+void throwInternalError(
+    v8::Isolate* isolate, kj::Exception&& exception, MakeInternalErrorOptions options = {});
 
 constexpr kj::Exception::DetailTypeId TUNNELED_EXCEPTION_DETAIL_ID = 0xe8027292171b1646ull;
 
@@ -160,11 +183,11 @@ void throwIllegalConstructor(const v8::FunctionCallbackInfo<v8::Value>& args);
 kj::StringPtr extractTunneledExceptionDescription(kj::StringPtr message);
 
 // Given a JavaScript exception, returns a KJ exception that contains a tunneled exception type that
-// can be converted back to JavaScript via makeInternalError().
+// can be converted back to JavaScript via kjExceptionToJs().
 kj::Exception createTunneledException(v8::Isolate* isolate, v8::Local<v8::Value> exception);
 
 // Given a JavaScript exception, throw a KJ exception that contains a tunneled exception type that
-// can be converted back to JavaScript via makeInternalError().
+// can be converted back to JavaScript via kjExceptionToJs().
 //
 // Equivalent to throwing the exception returned by `createTunneledException(exception)`.
 [[noreturn]] void throwTunneledException(v8::Isolate* isolate, v8::Local<v8::Value> exception);
@@ -366,7 +389,7 @@ struct LiftKj_<v8::Local<v8::Promise>> {
         // the v8::Value representing the tunneled error, it itself may cause a JS exception to be
         // thrown. This is the reason for the nested try-catch blocks -- we need to be able to
         // swallow any JsExceptionThrown exceptions that this catch block generates.
-        returnRejectedPromise(info, makeInternalError(isolate, kj::mv(exception)), tryCatch);
+        returnRejectedPromise(info, kjExceptionToJs(isolate, kj::mv(exception)), tryCatch);
       }
     } catch (JsExceptionThrown&) {
       if (tryCatch.CanContinue()) {

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -1458,7 +1458,11 @@ class ExceptionWrapper {
       v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::Exception exception) {
-    return makeInternalError(js.v8Isolate, kj::mv(exception));
+    // Converts the error with default options. If the exception is a tunneled
+    // exception that has a serialized JS error, then that will be used. If
+    // that is used, the stack will be omitted by default. Pass the .trusted = true
+    // option to include the stack. See kjExceptionToJs for details.
+    return kjExceptionToJs(js.v8Isolate, kj::mv(exception));
   }
 
   kj::Maybe<kj::Exception> tryUnwrap(Lock& js,
@@ -1508,6 +1512,10 @@ class ExceptionWrapper {
           "TypeError"_kj,
           "SyntaxError"_kj,
           "ReferenceError"_kj,
+          "AggregateError"_kj,
+          "SuppressedError"_kj,
+          "URIError"_kj,
+          "EvalError"_kj,
           // WASM Error Types
           "CompileError"_kj,
           "LinkError"_kj,


### PR DESCRIPTION
After a comprehensive deep dive against the stack leaking bug, here's our findings:

We are not returning errors, always re throwing and catching
Stack trace on Sentry is combined from two services 

We've updated your test in this branch @jasnell  to try to reproduce this (but we can't). Both Foo and Bar are actors. 

test -> Foo.fetch1 -> sets alarm
alarm -> Foo.foo() -> Bar.bar() -> Bar.blah()
