### PR TITLE
Rename makeInternalError to exceptionToJs

### DIFF
--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -405,7 +405,7 @@ kj::Promise<void> WorkerEntrypoint::request(kj::HttpMethod method,
         // We've already logged it here, the only thing that matters to the client is that we failed
         // due to an internal error. Note that this does not need to be labeled "remote." since jsg
         // will sanitize it as an internal error. Note that we use `setDescription()` to preserve
-        // the exception type for `cjfs::makeInternalError(...)` downstream.
+        // the exception type for `jsg::exceptionToJs(...)` downstream.
         exception.setDescription(
             kj::str("worker_do_not_log; Request failed due to internal error"));
         return kj::mv(exception);

--- a/src/workerd/jsg/dom-exception.h
+++ b/src/workerd/jsg/dom-exception.h
@@ -30,7 +30,7 @@ namespace workerd::jsg {
 class Serializer;
 class Deserializer;
 
-// JSG allows DOMExceptions to be tunneled through kj::Exceptions (see makeInternalError() for
+// JSG allows DOMExceptions to be tunneled through kj::Exceptions (see exceptionToJs() for
 // details). While this feature is activated conditionally at run-time, and thus does not depend
 // on any specific concrete C++ type, JSG needs to be able to unit test the tunneled exception
 // functionality, thus the existence of this implementation.

--- a/src/workerd/jsg/exception.h
+++ b/src/workerd/jsg/exception.h
@@ -113,7 +113,7 @@ namespace workerd::jsg {
 kj::StringPtr stripRemoteExceptionPrefix(kj::StringPtr internalMessage);
 
 // Given a KJ exception's description, returns whether it contains a tunneled exception that could
-// be converted back to JavaScript via makeInternalError().
+// be converted back to JavaScript via exceptionToJs().
 bool isTunneledException(kj::StringPtr internalMessage);
 
 // Given a KJ exception's description, returns whether it contains the magic constant that indicates

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -239,7 +239,7 @@ v8::MaybeLocal<v8::Value> evaluateSyntheticModuleCallback(
   })) {
     // V8 doc comments say in the case of an error, throw the error and return an empty Maybe.
     // I.e. NOT a rejected promise. OK...
-    js.v8Isolate->ThrowException(makeInternalError(js.v8Isolate, kj::mv(exception)));
+    js.v8Isolate->ThrowException(js.exceptionToJsValue(kj::mv(exception)).getHandle(js));
     result = v8::Local<v8::Promise>();
   }
 

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -695,7 +695,7 @@ v8::MaybeLocal<v8::Promise> dynamicImportCallback(v8::Local<v8::Context> context
       }
       return makeRejected(tryCatch.Exception());
     } catch (kj::Exception& ex) {
-      return makeRejected(makeInternalError(js.v8Isolate, kj::mv(ex)));
+      return makeRejected(js.exceptionToJs(kj::mv(ex)).getHandle(js));
     }
   }
 
@@ -739,7 +739,7 @@ v8::MaybeLocal<v8::Promise> dynamicImportCallback(v8::Local<v8::Context> context
 
     return makeRejected(tryCatch.Exception());
   } catch (kj::Exception& ex) {
-    return makeRejected(makeInternalError(js.v8Isolate, kj::mv(ex)));
+    return makeRejected(exceptionToJs(js.v8Isolate, kj::mv(ex)));
   }
   KJ_UNREACHABLE;
 }

--- a/src/workerd/jsg/observer.h
+++ b/src/workerd/jsg/observer.h
@@ -151,7 +151,7 @@ struct InternalExceptionObserver {
     kj::Maybe<InternalErrorId> internalErrorId;
   };
 
-  // Called when an internal exception is created (see makeInternalError).
+  // Called when an internal exception is created (see exceptionToJs).
   // Used to collect metrics on various internal error conditions.
   virtual void reportInternalException(const kj::Exception&, Detail detail) {}
 };

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -345,7 +345,7 @@ class Promise {
     }
 
     void reject(Lock& js, kj::Exception exception) {
-      reject(js, makeInternalError(js.v8Isolate, kj::mv(exception)));
+      reject(js, exceptionToJs(js.v8Isolate, kj::mv(exception)));
     }
 
     Resolver addRef(Lock& js) {
@@ -488,8 +488,7 @@ Promise<T> Lock::rejectedPromise(jsg::Value exception) {
 
 template <typename T>
 Promise<T> Lock::rejectedPromise(kj::Exception&& exception) {
-  return withinHandleScope(
-      [&] { return rejectedPromise<T>(makeInternalError(v8Isolate, kj::mv(exception))); });
+  return withinHandleScope([&] { return rejectedPromise<T>(exceptionToJs(kj::mv(exception))); });
 }
 
 template <class Func>

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -61,7 +61,7 @@ v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::StringPtr inter
 // Creates a JavaScript error that obfuscates the exception details, while logging the full details
 // to stderr. If the KJ exception was created using throwTunneledException(), don't log anything
 // but instead return the original reconstructed JavaScript exception.
-v8::Local<v8::Value> makeInternalError(v8::Isolate* isolate, kj::Exception&& exception);
+v8::Local<v8::Value> exceptionToJs(v8::Isolate* isolate, kj::Exception&& exception);
 
 // calls makeInternalError() and then tells the isolate to throw it.
 void throwInternalError(v8::Isolate* isolate, kj::StringPtr internalMessage);
@@ -366,7 +366,7 @@ struct LiftKj_<v8::Local<v8::Promise>> {
         // the v8::Value representing the tunneled error, it itself may cause a JS exception to be
         // thrown. This is the reason for the nested try-catch blocks -- we need to be able to
         // swallow any JsExceptionThrown exceptions that this catch block generates.
-        returnRejectedPromise(info, makeInternalError(isolate, kj::mv(exception)), tryCatch);
+        returnRejectedPromise(info, exceptionToJs(isolate, kj::mv(exception)), tryCatch);
       }
     } catch (JsExceptionThrown&) {
       if (tryCatch.CanContinue()) {

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -1458,7 +1458,7 @@ class ExceptionWrapper {
       v8::Local<v8::Context> context,
       kj::Maybe<v8::Local<v8::Object>> creator,
       kj::Exception exception) {
-    return makeInternalError(js.v8Isolate, kj::mv(exception));
+    return js.exceptionToJsValue(kj::mv(exception)).getHandle(js);
   }
 
   kj::Maybe<kj::Exception> tryUnwrap(Lock& js,


### PR DESCRIPTION
Rename the variation of the makeInternalError that converts a kj::Exception to a JS exception. This separates out this part of the change from the other change that enhances the error serialization so we can separate concerns a bit while the other change is still being tested/verified. No real functional changes here, just renaming the method and routing some of the calls through the `jsg::Lock` methods.