### PR TITLE
Fix structured logs getting stuck in the buffer.

### DIFF
--- a/src/workerd/server/json-logger.c++
+++ b/src/workerd/server/json-logger.c++
@@ -9,10 +9,10 @@
 #include <capnp/compat/json.h>
 #include <capnp/message.h>
 #include <kj/debug.h>
+#include <kj/io.h>
 #include <kj/main.h>
+#include <kj/miniposix.h>
 #include <kj/string.h>
-
-#include <cstdio>
 
 namespace workerd::server {
 
@@ -67,7 +67,8 @@ void JsonLogger::logMessage(
 
   auto json = buildJsonLogMessage(severity, file, line, contextDepth, text);
 
-  puts(json.cStr());
+  // Write directly to stdout with no buffering.
+  kj::FdOutputStream(STDOUT_FILENO).write({json.asBytes(), "\n"_kj.asBytes()});
 }
 
 kj::Function<void(kj::Function<void()>)> JsonLogger::getThreadInitializer() {


### PR DESCRIPTION
The new structured logging functionality used `puts()` to write the logs to stdout.

`puts()` is an ancient C stdio function. It doesn't write directly to stdout, but rather a C stdio `FILE` structure representing stdout. This structure has a buffer.

Now, if stdout is an internactive terminal, then the FILE for stdout is automatically configured to line-buffer mode, meaning it will flush the buffer whenever a newline character is written to it. So when testing structured logging on the terminal, everything would appear to work great.

But if stdout is a disk file, pipe, socket, etc., then stdio will use file-buffering mode, which means it won't flush the buffer until it fills up. The buffer is probably something like 4096 or 8192 bytes.

This means that logs might be delayed -- or might not show up at all if workerd is shut down before the buffer fills.

It looks like Miniflare has recently switched to use this new structured logging mode by default, to get logs from workerd. Of course, this happens over a pipe, so buffering kicks in. This managed to bite me, as I couldn't see the internal error behind a problem in an app I am working on.

Anyway, there's really no need to use these ancient C functions. We can write directly to the file descriptor and avoid buffering entirely.