### PR TITLE
Fix race condition when starting dynamically-loaded facets.

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2322,7 +2322,10 @@ class Server::WorkerService final: public Service,
             co_await promise;
           }
 
-          start(actorClass, id);
+          // A concurrent request could have started the actor, so check again.
+          if (actor == kj::none) {
+            start(actorClass, id);
+          }
         }
 
         co_return KJ_ASSERT_NONNULL(actor)->addRef();


### PR DESCRIPTION
If multiple requests to the facet are queued before the facet's isolate manages to start up, then `start()` might be called multiple times and later calls will throw an exception.