### PR TITLE
Change StreamWorkerInterface::request to coroutine

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -552,8 +552,7 @@ class StreamWorkerInterface final: public WorkerInterface {
     auto service = kj::newHttpService(*httpClient);
 
     // Forward the request to the service
-    return service->request(method, noHostUrl, newHeaders, requestBody, response)
-        .attach(kj::mv(service), kj::mv(httpClient));
+    co_await service->request(method, noHostUrl, newHeaders, requestBody, response);
   }
 
   kj::Promise<void> connect(kj::StringPtr host,


### PR DESCRIPTION
Needed to satisfy the kj::HttpService contract which requires that the `kj::HttpHeaders` passed in remains valid until the request promise is complete. While not likely to be causing any actual problems, it's important to correctly satisfy the API contract.