### PR TITLE
Python: Tidy up default class handling, NFC

### DIFF
--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -41,14 +41,8 @@ import { TRANSITIVE_REQUIREMENTS } from 'pyodide-internal:metadata';
  */
 function prepareWasmLinearMemory(
   Module: Module,
-  pyodide_entrypoint_helper: PyodideEntrypointHelper | null
+  pyodide_entrypoint_helper: PyodideEntrypointHelper
 ): void {
-  if (!pyodide_entrypoint_helper) {
-    throw new PythonRuntimeError(
-      'pyodide_entrypoint_helper is required to load snapshot'
-    );
-  }
-
   enterJaegerSpan('preload_dynamic_libs', () => {
     preloadDynamicLibs(Module);
   });
@@ -149,7 +143,7 @@ export function loadPyodide(
   isWorkerd: boolean,
   lockfile: PackageLock,
   indexURL: string,
-  pyodide_entrypoint_helper: PyodideEntrypointHelper | null
+  pyodide_entrypoint_helper: PyodideEntrypointHelper
 ): Pyodide {
   try {
     const Module = enterJaegerSpan('instantiate_emscripten', () =>

--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -712,15 +712,10 @@ export function maybeCollectSnapshot(Module: Module): void {
 
 export function finalizeBootstrap(
   Module: Module,
-  pyodide_entrypoint_helper: PyodideEntrypointHelper | null
+  pyodide_entrypoint_helper: PyodideEntrypointHelper
 ): void {
   const customHiwireStateDeserializer = (obj: any): any => {
     if ('pyodide_entrypoint_helper' in obj) {
-      if (!pyodide_entrypoint_helper) {
-        throw new PythonRuntimeError(
-          'pyodide_entrypoint_helper is required for hiwire deserialisation'
-        );
-      }
       return pyodide_entrypoint_helper;
     }
     if ('abort_signal_any' in obj) {


### PR DESCRIPTION
Factored the default class handling into its own function. Use `findIndex()` to locate default class.