### PR TITLE
Remove experimental from `python_workflows` compat flag

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -835,8 +835,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # enabled, the original module registry implementation will follow the recommended behavior.
 
   pythonWorkflows @95 :Bool
-      $compatEnableFlag("python_workflows")
-      $experimental;
+    $compatEnableFlag("python_workflows")
+    $compatDisableFlag("disable_python_workflows")
+    $impliedByAfterDate(name = "pythonWorkers", date = "2025-09-20");
   # Enables support for Python workflows.
   # This is still in development and may change in the future.
 

--- a/src/workerd/server/tests/python/workflow-entrypoint/workflow-entrypoint.wd-test
+++ b/src/workerd/server/tests/python/workflow-entrypoint/workflow-entrypoint.wd-test
@@ -10,7 +10,7 @@ const config :Workerd.Config = (
 const pyWorker :Workerd.Worker = (
   compatibilityDate = "2025-03-04",
 
-  compatibilityFlags = ["experimental", %PYTHON_FEATURE_FLAGS, "python_workflows"],
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workflows"],
 
   modules = [
     (name = "workflow.py", pythonModule = embed "workflow.py"),


### PR DESCRIPTION
Removes `experimental` from `python_workflows`, allowing the compat flag to be enabled in production.