### PR TITLE
Python: Patch context.waitUntil to prevent problems with proxy lifetimes

### DIFF
--- a/src/pyodide/eslint.config.mjs
+++ b/src/pyodide/eslint.config.mjs
@@ -7,6 +7,12 @@ export default [
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-non-null-assertion': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
+      'no-empty': [
+        'error',
+        {
+          allowEmptyCatch: true,
+        },
+      ],
     },
   },
 ];

--- a/src/pyodide/internal/_workers.py
+++ b/src/pyodide/internal/_workers.py
@@ -1066,8 +1066,11 @@ def _wrap_subclass(cls):
     original_init = cls.__init__
 
     def wrapped_init(self, *args, **kwargs):
+        if len(args) > 0:
+            _pyodide_entrypoint_helper.patchWaitUntil(args[0])
         if len(args) > 1:
-            args = (args[0], _EnvWrapper(args[1]), *args[2:])
+            args = list(args)
+            args[1] = _EnvWrapper(args[1])
 
         original_init(self, *args, **kwargs)
 

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -956,7 +956,6 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
 
   pythonDedicatedSnapshot @110 :Bool
       $compatEnableFlag("python_dedicated_snapshot")
-      $impliedByAfterDate(name = "pythonWorkers20250116", date = "2000-01-01")
       $experimental;
   # Enables the generation of dedicated snapshots on Python Worker upload. The snapshot will be
   # stored inside the resulting WorkerBundle of the Worker. The snapshot will be taken after the

--- a/src/workerd/server/tests/python/python-rpc/worker.py
+++ b/src/workerd/server/tests/python/python-rpc/worker.py
@@ -4,6 +4,7 @@
 
 import collections.abc
 import json
+from asyncio import Future, sleep
 from datetime import datetime
 from http import HTTPMethod
 from unittest import TestCase
@@ -15,6 +16,8 @@ from pyodide.ffi import JsException, JsProxy, to_js
 
 assertRaises = TestCase().assertRaises
 assertRaisesRegex = TestCase().assertRaisesRegex
+
+testFuture = Future()
 
 
 class PythonRpcTester(WorkerEntrypoint):
@@ -55,6 +58,13 @@ class PythonRpcTester(WorkerEntrypoint):
         assert abs((py_date - curr_date).microseconds) < 1e6
 
         return True
+
+    async def sleep_then_set_result(self):
+        await sleep(0.1)
+        testFuture.set_result(100)
+
+    async def test_wait_until_coroutine_lifetime(self):
+        self.ctx.waitUntil(self.sleep_then_set_result())
 
 
 class CustomType:
@@ -259,3 +269,10 @@ async def test(ctrl, env, ctx):
 
     # Verify that the `env` in the DO is correctly wrapped.
     assert await env.PythonRpc.check_env()
+
+    # Check that the coroutine returned by sleep_then_set_result() lasts long enough.
+    # sleep_then_set_result() resolves testFuture after sleeping for 100ms.
+    await env.PythonRpc.test_wait_until_coroutine_lifetime()
+    assert not testFuture.done()
+    await sleep(0.2)
+    assert testFuture.result() == 100


### PR DESCRIPTION
Without this patch, `context.waitUntil()` fails with borrowed proxy destroyed at end of function call error message.