### PR TITLE
fix: Other protocols allowed before socket2fetcher

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -516,8 +516,10 @@ jsg::Ref<Socket> SocketsModule::connect(
 }
 
 kj::Own<kj::AsyncIoStream> Socket::takeConnectionStream(jsg::Lock& js) {
+  // We do not care if the socket was disturbed, we require the user to ensure the socket is not
+  // being used.
   writable->detach(js);
-  readable->detach(js);
+  readable->detach(js, true);
 
   closedResolver.resolve(js);
   return connectionStream->addWrappedRef();


### PR DESCRIPTION
- Ignore disturbed for both readable and writable
- Adds test to ensure previous protocol doesn't interrupt conversion.