### PR TITLE
Fixes Python SDK test to use the new default entrypoint correctly.

### DIFF
--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -25,7 +25,11 @@ py_wd_test("random")
 
 py_wd_test("subdirectory")
 
-py_wd_test("sdk")
+# TODO(EW-9537): Snapshot disabled due to failure on 0.28
+py_wd_test(
+    "sdk",
+    make_snapshot = False,
+)
 
 py_wd_test("seek-metadatafs")
 


### PR DESCRIPTION
It turns out we weren't running these tests because the `test` method wasn't under the `Default` class. This PR fixes this.