### PR TITLE
Fix Redirects for internalNewHttpClient

### DIFF
--- a/src/workerd/util/stream-utils.c++
+++ b/src/workerd/util/stream-utils.c++
@@ -189,6 +189,11 @@ kj::Own<kj::AsyncOutputStream> newNullOutputStream() {
   return kj::heap<NullIoStream>();
 }
 
+kj::AsyncOutputStream& getGlobalNullOutputStream() {
+  static NullIoStream globalNullStream;
+  return globalNullStream;
+}
+
 kj::Own<kj::AsyncInputStream> newMemoryInputStream(kj::ArrayPtr<const kj::byte> data) {
   return kj::heap<MemoryInputStream>(data);
 }

--- a/src/workerd/util/stream-utils.h
+++ b/src/workerd/util/stream-utils.h
@@ -8,6 +8,9 @@ kj::Own<kj::AsyncIoStream> newNullIoStream();
 kj::Own<kj::AsyncInputStream> newNullInputStream();
 kj::Own<kj::AsyncOutputStream> newNullOutputStream();
 
+// Get a shared global null output stream (singleton, thread-safe)
+kj::AsyncOutputStream& getGlobalNullOutputStream();
+
 kj::Own<kj::AsyncInputStream> newMemoryInputStream(kj::ArrayPtr<const kj::byte>);
 kj::Own<kj::AsyncInputStream> newMemoryInputStream(kj::StringPtr);
 


### PR DESCRIPTION
- Fix: Redirects for `internalNewHttpClient`
- Fix: Read all data for redirects.