### PR TITLE
Replace deprecated capnp set/add methods with setPtr/addPtr/addPtrPtr

### DIFF
--- a/build/deps/gen/dep_capnp_cpp.bzl
+++ b/build/deps/gen/dep_capnp_cpp.bzl
@@ -2,11 +2,11 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-URL = "https://github.com/capnproto/capnproto/tarball/c3d7de8246dc897eeabb89885dd9271455ff8054"
-STRIP_PREFIX = "capnproto-capnproto-c3d7de8/c++"
-SHA256 = "bc82c16f793cb007a91e9c10f51a535bcc0f34b81461c2203d7c4ec40ec907f2"
+URL = "https://github.com/capnproto/capnproto/tarball/b78bb1a8664d7e63eeaffb99314900803f0990a6"
+STRIP_PREFIX = "capnproto-capnproto-b78bb1a/c++"
+SHA256 = "8f2d59d6c174badb6381b75b74383c5f9fcaffe3542427adeda988fd3b4edf84"
 TYPE = "tgz"
-COMMIT = "c3d7de8246dc897eeabb89885dd9271455ff8054"
+COMMIT = "b78bb1a8664d7e63eeaffb99314900803f0990a6"
 
 def dep_capnp_cpp():
     http_archive(

--- a/src/workerd/api/cache.c++
+++ b/src/workerd/api/cache.c++
@@ -95,7 +95,7 @@ jsg::Promise<jsg::Optional<jsg::Ref<Response>>> Cache::match(jsg::Lock& js,
         jsRequest->getUrl(), kj::none, flags.getCacheApiCompatFlags());
     auto requestHeaders = kj::HttpHeaders(context.getHeaderTable());
     jsRequest->shallowCopyHeadersTo(requestHeaders);
-    requestHeaders.set(context.getHeaderIds().cacheControl, "only-if-cached");
+    requestHeaders.setPtr(context.getHeaderIds().cacheControl, "only-if-cached");
     auto nativeRequest = httpClient->request(
         kj::HttpMethod::GET, validateUrl(jsRequest->getUrl()), requestHeaders, uint64_t(0));
 
@@ -507,7 +507,7 @@ jsg::Promise<bool> Cache::delete_(jsg::Lock& js,
     //   your own origin isn't a security flaw. Also, a Worker sending PURGE requests to its own
     //   origin's cache is not a security flaw (that's what this very API is implementing after
     //   all) so it all lines up nicely.
-    requestHeaders.add("X-Real-IP"_kj, "127.0.0.1"_kj);
+    requestHeaders.addPtrPtr("X-Real-IP"_kj, "127.0.0.1"_kj);
     auto nativeRequest = httpClient->request(
         kj::HttpMethod::PURGE, validateUrl(jsRequest->getUrl()), requestHeaders, uint64_t(0));
 

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -137,7 +137,7 @@ class Container::TcpPortWorkerInterface final: public WorkerInterface {
     // We need to convert the URL from proxy format (full URL in request line) to host format
     // (path in request line, hostname in Host header).
     auto newHeaders = headers.cloneShallow();
-    newHeaders.set(kj::HttpHeaderId::HOST, parsedUrl.host);
+    newHeaders.setPtr(kj::HttpHeaderId::HOST, parsedUrl.host);
     auto noHostUrl = parsedUrl.toString(kj::Url::Context::HTTP_REQUEST);
 
     // Make a TCP connection...

--- a/src/workerd/api/headers-test.c++
+++ b/src/workerd/api/headers-test.c++
@@ -72,7 +72,7 @@ struct HeadersContext: public jsg::Object, public jsg::ContextGlobal {
       auto kFoo = builder.add("foo");
       auto headersTable = builder.build();
       kj::HttpHeaders kjHeaders(*headersTable);
-      kjHeaders.set(kFoo, "test");
+      kjHeaders.setPtr(kFoo, "test");
 
       auto headers =
           js.alloc<workerd::api::Headers>(js, kjHeaders, workerd::api::Headers::Guard::NONE);

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -178,7 +178,7 @@ jsg::Ref<Headers> Headers::clone(jsg::Lock& js) const {
 void Headers::shallowCopyTo(kj::HttpHeaders& out) {
   for (auto& entry: headers) {
     for (auto& value: entry.second.values) {
-      out.add(entry.second.name, value);
+      out.addPtrPtr(entry.second.name, value);
     }
   }
 }
@@ -1669,7 +1669,7 @@ kj::Promise<DeferredProxy<void>> Response::send(jsg::Lock& js,
         // requested, so we'll just use the client's requested headers.
         KJ_IF_SOME(reqHeaders, maybeReqHeaders) {
           KJ_IF_SOME(value, reqHeaders.get(kj::HttpHeaderId::SEC_WEBSOCKET_EXTENSIONS)) {
-            outHeaders.set(kj::HttpHeaderId::SEC_WEBSOCKET_EXTENSIONS, value);
+            outHeaders.setPtr(kj::HttpHeaderId::SEC_WEBSOCKET_EXTENSIONS, value);
           }
         }
       }
@@ -1907,10 +1907,10 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(jsg::Lock& js,
       KJ_FALLTHROUGH;
     case Request::CacheMode::NOCACHE:
       if (headers.get(headerIds.cacheControl) == kj::none) {
-        headers.set(headerIds.cacheControl, "no-cache");
+        headers.setPtr(headerIds.cacheControl, "no-cache");
       }
       if (headers.get(headerIds.pragma) == kj::none) {
-        headers.set(headerIds.pragma, "no-cache");
+        headers.setPtr(headerIds.pragma, "no-cache");
       }
       KJ_FALLTHROUGH;
     case Request::CacheMode::NONE:
@@ -1976,7 +1976,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(jsg::Lock& js,
         // the code in global-scope.c++ on the receiving end will decide the body should be null.
         // We'd like to avoid this weird discontinuity, so let's set Content-Length explicitly to
         // 0.
-        headers.set(kj::HttpHeaderId::CONTENT_LENGTH, "0"_kj);
+        headers.setPtr(kj::HttpHeaderId::CONTENT_LENGTH, "0"_kj);
       }
 
       nativeRequest = client->request(jsRequest->getMethodEnum(), url, headers, maybeLength);

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -82,9 +82,9 @@ kj::Own<kj::HttpClient> KvNamespace::getHttpClient(IoContext& context,
 
   auto client = context.getHttpClient(subrequestChannel, true, kj::none, traceContext);
 
-  headers.add(FLPROD_405_HEADER, urlStr);
+  headers.addPtrPtr(FLPROD_405_HEADER, urlStr);
   for (const auto& header: additionalHeaders) {
-    headers.add(header.name.asPtr(), header.value.asPtr());
+    headers.addPtrPtr(header.name.asPtr(), header.value.asPtr());
   }
 
   return client;
@@ -544,7 +544,7 @@ jsg::Promise<void> KvNamespace::put(jsg::Lock& js,
 
     KJ_SWITCH_ONEOF(supportedBody) {
       KJ_CASE_ONEOF(text, kj::String) {
-        headers.set(kj::HttpHeaderId::CONTENT_TYPE, MimeType::PLAINTEXT_STRING);
+        headers.setPtr(kj::HttpHeaderId::CONTENT_TYPE, MimeType::PLAINTEXT_STRING);
         expectedBodySize = uint64_t(text.size());
       }
       KJ_CASE_ONEOF(data, kj::Array<byte>) {

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -183,11 +183,11 @@ kj::Promise<void> WorkerQueue::send(
   KJ_IF_SOME(opts, options) {
     KJ_IF_SOME(type, opts.contentType) {
       auto validatedType = validateContentType(type);
-      headers.add(HDR_MSG_FORMAT, validatedType);
+      headers.addPtrPtr(HDR_MSG_FORMAT, validatedType);
       contentType = validatedType;
     }
     KJ_IF_SOME(secs, opts.delaySeconds) {
-      headers.add(HDR_MSG_DELAY, kj::str(secs));
+      headers.addPtr(HDR_MSG_DELAY, kj::str(secs));
     }
   }
 
@@ -195,7 +195,7 @@ kj::Promise<void> WorkerQueue::send(
   KJ_IF_SOME(type, contentType) {
     serialized = serialize(js, body, type, SerializeArrayBufferBehavior::DEEP_COPY);
   } else if (workerd::FeatureFlags::get(js).getQueuesJsonMessages()) {
-    headers.add("X-Msg-Fmt", IncomingQueueMessage::ContentType::JSON);
+    headers.addPtrPtr("X-Msg-Fmt", IncomingQueueMessage::ContentType::JSON);
     serialized = serialize(
         js, body, IncomingQueueMessage::ContentType::JSON, SerializeArrayBufferBehavior::DEEP_COPY);
   } else {
@@ -306,14 +306,14 @@ kj::Promise<void> WorkerQueue::sendBatch(jsg::Lock& js,
   // decide whether it's too large.
   // TODO(someday): Enforce the size limits here instead for very slightly better performance.
   auto headers = kj::HttpHeaders(context.getHeaderTable());
-  headers.add("CF-Queue-Batch-Count"_kj, kj::str(messageCount));
-  headers.add("CF-Queue-Batch-Bytes"_kj, kj::str(totalSize));
-  headers.add("CF-Queue-Largest-Msg"_kj, kj::str(largestMessage));
+  headers.addPtr("CF-Queue-Batch-Count"_kj, kj::str(messageCount));
+  headers.addPtr("CF-Queue-Batch-Bytes"_kj, kj::str(totalSize));
+  headers.addPtr("CF-Queue-Largest-Msg"_kj, kj::str(largestMessage));
   headers.set(kj::HttpHeaderId::CONTENT_TYPE, MimeType::JSON.toString());
 
   KJ_IF_SOME(opts, options) {
     KJ_IF_SOME(secs, opts.delaySeconds) {
-      headers.add(HDR_MSG_DELAY, kj::str(secs));
+      headers.addPtr(HDR_MSG_DELAY, kj::str(secs));
     }
   }
 

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -545,7 +545,7 @@ class StreamWorkerInterface final: public WorkerInterface {
     // We need to convert the URL from proxy format (full URL in request line) to host format
     // (path in request line, hostname in Host header).
     auto newHeaders = headers.cloneShallow();
-    newHeaders.set(kj::HttpHeaderId::HOST, parsedUrl.host);
+    newHeaders.setPtr(kj::HttpHeaderId::HOST, parsedUrl.host);
     auto noHostUrl = parsedUrl.toString(kj::Url::Context::HTTP_REQUEST);
     // Create a new HTTP client using our stream
     auto httpClient = kj::newHttpClient(headerTable, *stream);

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3211,7 +3211,7 @@ kj::Promise<void> Worker::Isolate::attachInspector(kj::Timer& timer,
   KJ_REQUIRE(impl->inspector != kj::none);
 
   kj::HttpHeaders headers(headerTable);
-  headers.set(controlHeaderId, "{\"ewLog\":{\"status\":\"ok\"}}");
+  headers.setPtr(controlHeaderId, "{\"ewLog\":{\"status\":\"ok\"}}");
   auto webSocket = response.acceptWebSocket(headers);
 
   // This `attachInspector()` overload is used by the internal Cloudflare Workers runtime, which has

--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -179,10 +179,10 @@ kj::Promise<ContainerClient::Response> ContainerClient::dockerApiRequest(kj::Net
   auto connection = co_await address->connect();
   auto httpClient = kj::newHttpClient(headerTable, *connection).attach(kj::mv(connection));
   kj::HttpHeaders headers(headerTable);
-  headers.set(kj::HttpHeaderId::HOST, "localhost");
+  headers.setPtr(kj::HttpHeaderId::HOST, "localhost");
 
   KJ_IF_SOME(requestBody, body) {
-    headers.set(kj::HttpHeaderId::CONTENT_TYPE, "application/json");
+    headers.setPtr(kj::HttpHeaderId::CONTENT_TYPE, "application/json");
     headers.set(kj::HttpHeaderId::CONTENT_LENGTH, kj::str(requestBody.size()));
 
     auto req = httpClient->request(method, endpoint, headers, requestBody.size());

--- a/src/workerd/server/fallback-service.c++
+++ b/src/workerd/server/fallback-service.c++
@@ -129,8 +129,8 @@ ModuleOrRedirect tryResolveV1(ImportType type,
         auto client = kj::newHttpClient(io.provider->getTimer(), *headerTable, *addr, {});
 
         kj::HttpHeaders headers(*headerTable);
-        headers.set(kMethod, getMethodFromType(type));
-        headers.set(kj::HttpHeaderId::HOST, "localhost"_kj);
+        headers.setPtr(kMethod, getMethodFromType(type));
+        headers.setPtr(kj::HttpHeaderId::HOST, "localhost"_kj);
 
         auto request = client->request(kj::HttpMethod::GET, spec, headers, kj::none);
 
@@ -208,7 +208,7 @@ ModuleOrRedirect tryResolveV2(ImportType type,
         auto client = kj::newHttpClient(io.provider->getTimer(), *headerTable, *addr, {});
 
         kj::HttpHeaders headers(*headerTable);
-        headers.set(kj::HttpHeaderId::HOST, "localhost");
+        headers.setPtr(kj::HttpHeaderId::HOST, "localhost");
 
         auto request = client->request(kj::HttpMethod::POST, "/", headers, payload.size());
         {

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -4649,8 +4649,8 @@ KJ_TEST("Server: Catch websocket server errors") {
   kj::HttpHeaderTable headerTable;
   NotVeryGoodEntropySource entropySource;
   kj::HttpHeaders headers(headerTable);
-  headers.set(kj::HttpHeaderId::HOST, "foo");
-  headers.set(kj::HttpHeaderId::UPGRADE, "websocket");
+  headers.setPtr(kj::HttpHeaderId::HOST, "foo");
+  headers.setPtr(kj::HttpHeaderId::UPGRADE, "websocket");
   {
     auto wsConn = test.connect("test-addr");
     auto client = kj::newHttpClient(
@@ -4673,8 +4673,8 @@ KJ_TEST("Server: Catch websocket server errors") {
   }
   {
     auto wsConn = test.connect("test-addr");
-    headers.set(kj::HttpHeaderId::HOST, "foo");
-    headers.set(kj::HttpHeaderId::UPGRADE, "websocket");
+    headers.setPtr(kj::HttpHeaderId::HOST, "foo");
+    headers.setPtr(kj::HttpHeaderId::UPGRADE, "websocket");
     auto client = kj::newHttpClient(
         headerTable, wsConn.getStream(), kj::HttpClientSettings{.entropySource = entropySource});
     auto res = client->openWebSocket("/", headers).wait(waitScope);

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -410,7 +410,7 @@ class Server::HttpRewriter {
 
     KJ_IF_SOME(h, cfBlobHeader) {
       KJ_IF_SOME(b, cfBlobJson) {
-        result.headers->set(h, b);
+        result.headers->setPtr(h, b);
       } else {
         result.headers->unset(h);
       }
@@ -494,7 +494,7 @@ class Server::HttpRewriter {
     void apply(kj::HttpHeaders& headers) {
       for (auto& header: injectedHeaders) {
         KJ_IF_SOME(v, header.value) {
-          headers.set(header.id, v);
+          headers.setPtr(header.id, v);
         } else {
           headers.unset(header.id);
         }
@@ -3050,7 +3050,7 @@ class Server::WorkerService final: public Service,
         const kj::HttpHeaders& headers, kj::Maybe<kj::StringPtr> cacheName) {
       auto headersCopy = headers.cloneShallow();
       KJ_IF_SOME(name, cacheName) {
-        headersCopy.set(cacheNamespaceHeader, name);
+        headersCopy.setPtr(cacheNamespaceHeader, name);
       }
 
       return headersCopy;


### PR DESCRIPTION
Updating uses of deprecated `kj::HttpHeaders` API