### PR TITLE
Make it possible to put service bindings into dynamic worker env

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -947,12 +947,14 @@ kj::OneOf<jsg::Ref<DurableObjectId>, kj::StringPtr> ActorState::getId(jsg::Lock&
 DurableObjectState::DurableObjectState(jsg::Lock& js,
     Worker::Actor::Id actorId,
     jsg::JsRef<jsg::JsValue> exports,
+    jsg::JsValue props,
     kj::Maybe<jsg::Ref<DurableObjectStorage>> storage,
     kj::Maybe<rpc::Container::Client> container,
     bool containerRunning,
     kj::Maybe<Worker::Actor::FacetManager&> facetManager)
     : id(kj::mv(actorId)),
       exports(kj::mv(exports)),
+      props(js, props),
       storage(kj::mv(storage)),
       container(container.map([&](rpc::Container::Client& cap) {
         return js.alloc<Container>(kj::mv(cap), containerRunning);

--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -5,6 +5,7 @@
 #include "actor-state.h"
 
 #include "actor.h"
+#include "export-loopback.h"
 #include "sql.h"
 #include "util.h"
 
@@ -896,10 +897,23 @@ jsg::Ref<Fetcher> DurableObjectFacets::get(jsg::Lock& js,
         id = ioCtx.getActorOrThrow().cloneId();
       }
 
-      auto actorClass = options.$class->getChannel(ioCtx);
+      DurableObjectClass& actorClass = [&]() -> DurableObjectClass& {
+        KJ_SWITCH_ONEOF(options.$class) {
+          KJ_CASE_ONEOF(bare, jsg::Ref<DurableObjectClass>) {
+            return *bare.get();
+          }
+          KJ_CASE_ONEOF(loopback, jsg::Ref<LoopbackDurableObjectNamespace>) {
+            return loopback->getClass();
+          }
+          KJ_CASE_ONEOF(loopback, jsg::Ref<LoopbackColoLocalActorNamespace>) {
+            return loopback->getClass();
+          }
+        }
+        KJ_UNREACHABLE;
+      }();
 
       return Worker::Actor::FacetManager::StartInfo{
-        .actorClass = kj::mv(actorClass),
+        .actorClass = actorClass.getChannel(ioCtx),
         .id = kj::mv(id),
       };
     });

--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -960,14 +960,14 @@ kj::OneOf<jsg::Ref<DurableObjectId>, kj::StringPtr> ActorState::getId(jsg::Lock&
 
 DurableObjectState::DurableObjectState(jsg::Lock& js,
     Worker::Actor::Id actorId,
-    jsg::JsRef<jsg::JsValue> exports,
+    jsg::JsValue exports,
     jsg::JsValue props,
     kj::Maybe<jsg::Ref<DurableObjectStorage>> storage,
     kj::Maybe<rpc::Container::Client> container,
     bool containerRunning,
     kj::Maybe<Worker::Actor::FacetManager&> facetManager)
     : id(kj::mv(actorId)),
-      exports(kj::mv(exports)),
+      exports(js, exports),
       props(js, props),
       storage(kj::mv(storage)),
       container(container.map([&](rpc::Container::Client& cap) {

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -26,6 +26,8 @@ class DurableObject;
 class DurableObjectId;
 class WebSocket;
 class DurableObjectClass;
+class LoopbackDurableObjectNamespace;
+class LoopbackColoLocalActorNamespace;
 
 kj::Array<kj::byte> serializeV8Value(jsg::Lock& js, const jsg::JsValue& value);
 
@@ -393,7 +395,10 @@ class DurableObjectFacets: public jsg::Object {
       : facetManager(kj::mv(facetManager)) {}
 
   struct StartupOptions {
-    jsg::Ref<DurableObjectClass> $class;
+    kj::OneOf<jsg::Ref<DurableObjectClass>,
+        jsg::Ref<LoopbackDurableObjectNamespace>,
+        jsg::Ref<LoopbackColoLocalActorNamespace>>
+        $class;
     jsg::Optional<kj::OneOf<jsg::Ref<DurableObjectId>, kj::String>> id;
 
     JSG_STRUCT($class, id);

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -394,11 +394,20 @@ class DurableObjectFacets: public jsg::Object {
   DurableObjectFacets(kj::Maybe<IoPtr<Worker::Actor::FacetManager>> facetManager)
       : facetManager(kj::mv(facetManager)) {}
 
+  // Describes how to run a facet. The app provides this when first accessing a facet that isn't
+  // already running.
   struct StartupOptions {
+    // The actor class to use to implement the facet.
+    //
+    // Note that the $ is needed only because `class` is a keyword in C++. JSG removes the $ from
+    // the name in the JS API. C++ does not officially recognize the existence of a $ symbol but
+    // all major compilers support using it as if it were a letter.
     kj::OneOf<jsg::Ref<DurableObjectClass>,
         jsg::Ref<LoopbackDurableObjectNamespace>,
         jsg::Ref<LoopbackColoLocalActorNamespace>>
         $class;
+
+    // Value to expose as `ctx.id` in the facet.
     jsg::Optional<kj::OneOf<jsg::Ref<DurableObjectId>, kj::String>> id;
 
     JSG_STRUCT($class, id);

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -527,7 +527,7 @@ class DurableObjectState: public jsg::Object {
  public:
   DurableObjectState(jsg::Lock& js,
       Worker::Actor::Id actorId,
-      jsg::JsRef<jsg::JsValue> exports,
+      jsg::JsValue exports,
       jsg::JsValue props,
       kj::Maybe<jsg::Ref<DurableObjectStorage>> storage,
       kj::Maybe<rpc::Container::Client> container,

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -514,6 +514,7 @@ class DurableObjectState: public jsg::Object {
   DurableObjectState(jsg::Lock& js,
       Worker::Actor::Id actorId,
       jsg::JsRef<jsg::JsValue> exports,
+      jsg::JsValue props,
       kj::Maybe<jsg::Ref<DurableObjectStorage>> storage,
       kj::Maybe<rpc::Container::Client> container,
       bool containerRunning,
@@ -523,6 +524,10 @@ class DurableObjectState: public jsg::Object {
 
   jsg::JsValue getExports(jsg::Lock& js) {
     return exports.getHandle(js);
+  }
+
+  jsg::JsValue getProps(jsg::Lock& js) {
+    return props.getHandle(js);
   }
 
   kj::OneOf<jsg::Ref<DurableObjectId>, kj::StringPtr> getId(jsg::Lock& js);
@@ -606,6 +611,7 @@ class DurableObjectState: public jsg::Object {
       // this works in production.
       JSG_LAZY_INSTANCE_PROPERTY(exports, getExports);
     }
+    JSG_LAZY_INSTANCE_PROPERTY(props, getProps);
     JSG_LAZY_INSTANCE_PROPERTY(id, getId);
     JSG_LAZY_INSTANCE_PROPERTY(storage, getStorage);
     JSG_LAZY_INSTANCE_PROPERTY(container, getContainer);
@@ -651,6 +657,7 @@ class DurableObjectState: public jsg::Object {
  private:
   Worker::Actor::Id id;
   jsg::JsRef<jsg::JsValue> exports;
+  jsg::JsRef<jsg::JsValue> props;
   kj::Maybe<jsg::Ref<DurableObjectStorage>> storage;
   kj::Maybe<jsg::Ref<Container>> container;
   kj::Maybe<IoPtr<Worker::Actor::FacetManager>> facetManager;

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -11,6 +11,7 @@
 
 #include <workerd/api/http.h>
 #include <workerd/io/actor-id.h>
+#include <workerd/io/worker-interface.capnp.h>
 #include <workerd/jsg/jsg.h>
 
 namespace workerd {
@@ -333,6 +334,12 @@ class DurableObjectClass: public jsg::Object {
   JSG_RESOURCE_TYPE(DurableObjectClass) {
     // No methods - this is just a handle that gets passed to ctx.facets.get()
   }
+
+  void serialize(jsg::Lock& js, jsg::Serializer& serializer);
+  static jsg::Ref<DurableObjectClass> deserialize(
+      jsg::Lock& js, rpc::SerializationTag tag, jsg::Deserializer& deserializer);
+
+  JSG_SERIALIZABLE(rpc::SerializationTag::ACTOR_CLASS);
 
  private:
   kj::OneOf<uint, IoOwn<IoChannelFactory::ActorClassChannel>> channel;

--- a/src/workerd/api/export-loopback.c++
+++ b/src/workerd/api/export-loopback.c++
@@ -1,0 +1,22 @@
+// Copyright (c) 2017-2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "export-loopback.h"
+
+#include <workerd/io/frankenvalue.h>
+
+namespace workerd::api {
+
+jsg::Ref<Fetcher> LoopbackServiceStub::call(jsg::Lock& js, Options options) {
+  Frankenvalue props;
+  KJ_IF_SOME(p, options.props) {
+    props = Frankenvalue::fromJs(js, p.getHandle(js));
+  }
+
+  IoContext& ioctx = IoContext::current();
+  auto channelObj = ioctx.getIoChannelFactory().getSubrequestChannel(channel, kj::mv(props));
+  return js.alloc<Fetcher>(ioctx.addObject(kj::mv(channelObj)));
+}
+
+}  // namespace workerd::api

--- a/src/workerd/api/export-loopback.c++
+++ b/src/workerd/api/export-loopback.c++
@@ -19,4 +19,15 @@ jsg::Ref<Fetcher> LoopbackServiceStub::call(jsg::Lock& js, Options options) {
   return js.alloc<Fetcher>(ioctx.addObject(kj::mv(channelObj)));
 }
 
+jsg::Ref<DurableObjectClass> LoopbackDurableObjectClass::call(jsg::Lock& js, Options options) {
+  Frankenvalue props;
+  KJ_IF_SOME(p, options.props) {
+    props = Frankenvalue::fromJs(js, p.getHandle(js));
+  }
+
+  IoContext& ioctx = IoContext::current();
+  auto channelObj = ioctx.getIoChannelFactory().getActorClass(channel, kj::mv(props));
+  return js.alloc<DurableObjectClass>(ioctx.addObject(kj::mv(channelObj)));
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/export-loopback.h
+++ b/src/workerd/api/export-loopback.h
@@ -29,6 +29,10 @@ class LoopbackServiceStub: public Fetcher {
   // Create a specialized Fetcher which can be passed over RPC.
   jsg::Ref<Fetcher> call(jsg::Lock& js, Options options);
 
+  // Note that `LoopbackServiceStub` is intentionally NOT serializable, unlike its parent class
+  // Fetcher. We want people to explicitly specialize the entrypoint with props before sending
+  // it off to other services.
+
   JSG_RESOURCE_TYPE(LoopbackServiceStub) {
     JSG_INHERIT(Fetcher);
     JSG_CALLABLE(call);

--- a/src/workerd/api/export-loopback.h
+++ b/src/workerd/api/export-loopback.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2017-2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include "http.h"
+
+namespace workerd::api {
+
+// LoopbackServiceStub is the type of a property of `ctx.exports` which points back at a stateless
+// (non-actor) entrypoint of this Worker. It can be used as a regular Fetcher to make calls to that
+// entrypoint with empty props. It can also be invoked as a function in order to specialize it with
+// props and make it available for RPC.
+class LoopbackServiceStub: public Fetcher {
+ public:
+  // Loopback services are always represented by numbered subrequest channels.
+  explicit LoopbackServiceStub(uint channel)
+      : Fetcher(channel, RequiresHostAndProtocol::YES, /*isInHouse=*/true),
+        channel(channel) {}
+
+  struct Options {
+    jsg::Optional<jsg::JsRef<jsg::JsObject>> props;
+
+    JSG_STRUCT(props);
+  };
+
+  // Create a specialized Fetcher which can be passed over RPC.
+  jsg::Ref<Fetcher> call(jsg::Lock& js, Options options);
+
+  JSG_RESOURCE_TYPE(LoopbackServiceStub) {
+    JSG_INHERIT(Fetcher);
+    JSG_CALLABLE(call);
+  }
+
+ private:
+  uint channel;
+};
+
+#define EW_EXPORT_LOOPBACK_ISOLATE_TYPES api::LoopbackServiceStub, api::LoopbackServiceStub::Options
+
+}  // namespace workerd::api

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -2482,7 +2482,9 @@ void Fetcher::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   JSG_REQUIRE(externalHandler != nullptr, DOMDataCloneError,
       "ServiceStub cannot be serialized in this context.");
 
-  serializer.writeRawUint32(externalHandler->add(getSubrequestChannel(IoContext::current())));
+  auto channel = getSubrequestChannel(IoContext::current());
+  channel->requireAllowsTransfer();
+  serializer.writeRawUint32(externalHandler->add(kj::mv(channel)));
 }
 
 jsg::Ref<Fetcher> Fetcher::deserialize(jsg::Lock& js,

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -700,6 +700,12 @@ public:
     }
   }
 
+  void serialize(jsg::Lock& js, jsg::Serializer& serializer);
+  static jsg::Ref<Fetcher> deserialize(
+      jsg::Lock& js, rpc::SerializationTag tag, jsg::Deserializer& deserializer);
+
+  JSG_SERIALIZABLE(rpc::SerializationTag::SERVICE_STUB);
+
  private:
   kj::OneOf<uint,
       IoOwn<IoChannelFactory::SubrequestChannel>,

--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -13,6 +13,7 @@
 #include <workerd/api/encoding.h>
 #include <workerd/api/events.h>
 #include <workerd/api/eventsource.h>
+#include <workerd/api/export-loopback.h>
 #include <workerd/api/filesystem.h>
 #include <workerd/api/global-scope.h>
 #include <workerd/api/html-rewriter.h>
@@ -85,7 +86,8 @@
   F("container", EW_CONTAINER_ISOLATE_TYPES)                                                       \
   F("webfs", EW_WEB_FILESYSTEM_ISOLATE_TYPE)                                                       \
   F("messagechannel", EW_MESSAGECHANNEL_ISOLATE_TYPES)                                             \
-  F("workers-module", EW_WORKERS_MODULE_ISOLATE_TYPES)
+  F("workers-module", EW_WORKERS_MODULE_ISOLATE_TYPES)                                             \
+  F("export-loopback", EW_EXPORT_LOOPBACK_ISOLATE_TYPES)
 
 namespace workerd::api {
 

--- a/src/workerd/api/worker-loader-test.js
+++ b/src/workerd/api/worker-loader-test.js
@@ -213,6 +213,9 @@ export class FacetTestActor extends DurableObject {
                 this.i += j;
                 return this.i;
               }
+              myProps() {
+                return this.ctx.props;
+              }
             }
           `,
         },
@@ -222,7 +225,9 @@ export class FacetTestActor extends DurableObject {
       };
     });
 
-    let cls = worker.getDurableObjectClass('MyActor');
+    let cls = worker.getDurableObjectClass('MyActor', {
+      props: { foo: 123, bar: 456 },
+    });
 
     let facet = this.ctx.facets.get('bar', () => {
       return { class: cls };
@@ -230,6 +235,8 @@ export class FacetTestActor extends DurableObject {
 
     assert.strictEqual(await facet.increment(), 1);
     assert.strictEqual(await facet.increment(4), 5);
+
+    assert.deepEqual(await facet.myProps(), { foo: 123, bar: 456 });
   }
 }
 

--- a/src/workerd/api/worker-loader-test.js
+++ b/src/workerd/api/worker-loader-test.js
@@ -13,7 +13,7 @@ export let basics = {
               greet(name) { return "Hello, " + name; }
             }
             export let alternate = {
-              greet(name) { return "Welcome, " + name; }
+              greet(name, env, ctx) { return \`\${ctx.props.greeting}, \${name}\`; }
             }
           `,
         },
@@ -26,8 +26,17 @@ export let basics = {
     }
 
     {
-      let result = await worker.getEntrypoint('alternate').greet('Bob');
+      let result = await worker
+        .getEntrypoint('alternate', { props: { greeting: 'Welcome' } })
+        .greet('Bob');
       assert.strictEqual(result, 'Welcome, Bob');
+    }
+
+    {
+      let result = await worker
+        .getEntrypoint('alternate', { props: { greeting: 'Howdy' } })
+        .greet('Carol');
+      assert.strictEqual(result, 'Howdy, Carol');
     }
   },
 };

--- a/src/workerd/api/worker-loader-test.js
+++ b/src/workerd/api/worker-loader-test.js
@@ -68,6 +68,22 @@ export let basics = {
       assert.strictEqual(result, "G'day, Dave!\nSup, Eve!");
     }
 
+    // Note that we CANNOT transfer a dynamic worker entrypoint.
+    assert.rejects(
+      () =>
+        worker.getEntrypoint('FancyPropsEntrypoint', {
+          props: { greeter, greeter2 },
+        }),
+      {
+        name: 'DataCloneError',
+        message:
+          'Entrypoints to dynamically-loaded workers cannot be transferred to other Workers, ' +
+          'because the system does not know how to reload this Worker from scratch. Instead, ' +
+          'have the parent Worker expose an entrypoint which constructs the dynamic worker ' +
+          'and forwards to it.',
+      }
+    );
+
     // Let's quickly verify that if we use ctx.exports.GreeterLoopback *without* invoking it, then
     // we get an error that it isn't serializable. (This isn't really testing worker-loader, it's
     // more testing LoopbackServiceStub and that serializability is not inherited.)

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -50,6 +50,7 @@ wd_cc_library(
         "compatibility-date.c++",
         "features.c++",
         "hibernation-manager.c++",
+        "io-channels.c++",
         "io-context.c++",
         "io-own.c++",
         "io-util.c++",

--- a/src/workerd/io/frankenvalue-test.c++
+++ b/src/workerd/io/frankenvalue-test.c++
@@ -12,15 +12,73 @@ namespace {
 jsg::V8System v8System;
 class ContextGlobalObject: public jsg::Object, public jsg::ContextGlobal {};
 
+enum class TestSerializationTag { TEST_SERIALIZABLE };
+
+struct TestCapEntry final: public Frankenvalue::CapTableEntry {
+  int value;
+
+  TestCapEntry(int value): value(value) {}
+  kj::Own<CapTableEntry> clone() override {
+    return kj::heap<TestCapEntry>(value);
+  }
+};
+
+class TestSerializableCap: public jsg::Object {
+ public:
+  TestSerializableCap(int value): value(value) {}
+
+  int toJSON() {
+    return value;
+  }
+
+  JSG_RESOURCE_TYPE(TestSerializableCap) {
+    JSG_METHOD(toJSON);
+  }
+
+  void serialize(jsg::Lock& js, jsg::Serializer& serializer) {
+    auto& handler = KJ_ASSERT_NONNULL(serializer.getExternalHandler());
+    auto externalHandler = dynamic_cast<Frankenvalue::CapTableBuilder*>(&handler);
+    KJ_ASSERT(externalHandler != nullptr);
+    serializer.writeRawUint32(externalHandler->add(kj::heap<TestCapEntry>(value)));
+  }
+
+  static jsg::Ref<TestSerializableCap> deserialize(
+      jsg::Lock& js, TestSerializationTag tag, jsg::Deserializer& deserializer) {
+    auto& handler = KJ_REQUIRE_NONNULL(deserializer.getExternalHandler());
+    auto externalHandler = dynamic_cast<Frankenvalue::CapTableReader*>(&handler);
+    KJ_REQUIRE(externalHandler != nullptr);
+
+    auto& cap = KJ_REQUIRE_NONNULL(externalHandler->get(deserializer.readRawUint32()));
+    auto typedCap = dynamic_cast<TestCapEntry*>(&cap);
+    KJ_REQUIRE(typedCap != nullptr);
+
+    return js.alloc<TestSerializableCap>(typedCap->value);
+  }
+
+  JSG_SERIALIZABLE(TestSerializationTag::TEST_SERIALIZABLE);
+
+ private:
+  int value;
+};
+
 struct TestContext: public ContextGlobalObject {
   JSG_RESOURCE_TYPE(TestContext) {}
 };
-JSG_DECLARE_ISOLATE_TYPE(TestIsolate, TestContext);
+JSG_DECLARE_ISOLATE_TYPE(TestIsolate, TestContext, TestSerializableCap);
 
 KJ_TEST("Frankenvalue") {
   jsg::test::Evaluator<TestContext, TestIsolate> e(v8System);
 
-  e.run([&](jsg::Lock& js) {
+  // Silence compiler warning.
+  (void)TestSerializableCap::jsgSerializeOneway;
+  (void)TestSerializableCap::jsgSerializeOldTags;
+
+  e.run([&](auto& lock) {
+    jsg::Lock& js = lock;
+    auto makeSerializableCap = [&](int i) {
+      return jsg::JsValue(lock.wrap(js.v8Context(), js.alloc<TestSerializableCap>(i)));
+    };
+
     // Create a value based on JSON.
     Frankenvalue value = Frankenvalue::fromJson(kj::str(R"({"baz": 321, "qux": "xyz"})"_kj));
 
@@ -28,19 +86,51 @@ KJ_TEST("Frankenvalue") {
     value.setProperty(kj::str("prop1"), {});
 
     // prop2 is a V8-serialized value.
-    value.setProperty(kj::str("prop2"), ({
+    value.setProperty(kj::str("prop2"), [&]() {
       auto obj = js.obj();
       obj.set(js, "foo", js.num(123));
       obj.set(js, "bar", js.str("abc"_kj));
-      Frankenvalue::fromJs(js, obj);
-    }));
+      obj.set(js, "baz", makeSerializableCap(234));
+      obj.set(js, "qux", makeSerializableCap(345));
+
+      auto result = Frankenvalue::fromJs(js, obj);
+
+      result.setProperty(kj::str("nested"), [&]() {
+        auto nested = js.obj();
+        nested.set(js, "corge", js.num(222));
+        nested.set(js, "grault",
+            jsg::JsValue(lock.wrap(js.v8Context(), js.alloc<TestSerializableCap>(333))));
+        return Frankenvalue::fromJs(js, nested);
+      }());
+      result.setProperty(kj::str("nested2"), [&]() {
+        auto nested = js.obj();
+        nested.set(js, "garply", js.num(444));
+        nested.set(js, "waldo",
+            jsg::JsValue(lock.wrap(js.v8Context(), js.alloc<TestSerializableCap>(555))));
+        return Frankenvalue::fromJs(js, nested);
+      }());
+
+      return result;
+    }());
+
+    KJ_ASSERT(value.getCapTable().size() == 4);
+    KJ_EXPECT(kj::downcast<TestCapEntry>(*value.getCapTable()[0]).value == 234);
+    KJ_EXPECT(kj::downcast<TestCapEntry>(*value.getCapTable()[1]).value == 345);
+    KJ_EXPECT(kj::downcast<TestCapEntry>(*value.getCapTable()[2]).value == 333);
+    KJ_EXPECT(kj::downcast<TestCapEntry>(*value.getCapTable()[3]).value == 555);
 
     // Round trip through capnp.
     {
       capnp::MallocMessageBuilder message;
       auto builder = message.initRoot<rpc::Frankenvalue>();
       value.toCapnp(builder);
-      value = Frankenvalue::fromCapnp(builder.asReader());
+
+      kj::Vector<kj::Own<Frankenvalue::CapTableEntry>> newCapTable;
+      for (auto& entry: value.getCapTable()) {
+        newCapTable.add(entry->clone());
+      }
+
+      value = Frankenvalue::fromCapnp(builder.asReader(), kj::mv(newCapTable));
     }
 
     // Use clone().
@@ -48,7 +138,8 @@ KJ_TEST("Frankenvalue") {
 
     // Back to JS, then JSON, then check that nothing was lost.
     KJ_EXPECT(js.serializeJson(value.toJs(js)) ==
-        R"({"baz":321,"qux":"xyz","prop1":{},"prop2":{"foo":123,"bar":"abc"}})"_kj);
+        R"({"baz":321,"qux":"xyz","prop1":{},"prop2":{"foo":123,"bar":"abc","baz":234,"qux":345)"_kj
+        R"(,"nested":{"corge":222,"grault":333},"nested2":{"garply":444,"waldo":555}}})"_kj);
   });
 }
 

--- a/src/workerd/io/frankenvalue.c++
+++ b/src/workerd/io/frankenvalue.c++
@@ -4,7 +4,7 @@
 
 namespace workerd {
 
-Frankenvalue Frankenvalue::clone() const {
+Frankenvalue Frankenvalue::clone() {
   Frankenvalue result;
 
   KJ_SWITCH_ONEOF(value) {
@@ -33,7 +33,7 @@ Frankenvalue Frankenvalue::clone() const {
   return result;
 }
 
-void Frankenvalue::toCapnp(rpc::Frankenvalue::Builder builder) const {
+void Frankenvalue::toCapnp(rpc::Frankenvalue::Builder builder) {
   KJ_SWITCH_ONEOF(value) {
     KJ_CASE_ONEOF(_, EmptyObject) {
       builder.setEmptyObject();
@@ -87,7 +87,7 @@ Frankenvalue Frankenvalue::fromCapnp(rpc::Frankenvalue::Reader reader) {
   return result;
 }
 
-jsg::JsValue Frankenvalue::toJs(jsg::Lock& js) const {
+jsg::JsValue Frankenvalue::toJs(jsg::Lock& js) {
   return js.withinHandleScope([&]() -> jsg::JsValue {
     jsg::JsValue result = [&]() -> jsg::JsValue {
       KJ_SWITCH_ONEOF(value) {
@@ -121,7 +121,7 @@ jsg::JsValue Frankenvalue::toJs(jsg::Lock& js) const {
   });
 }
 
-void Frankenvalue::populateJsObject(jsg::Lock& js, jsg::JsObject target) const {
+void Frankenvalue::populateJsObject(jsg::Lock& js, jsg::JsObject target) {
   if (!empty()) {
     js.withinHandleScope([&]() {
       auto sourceObj = KJ_REQUIRE_NONNULL(toJs(js).tryCast<jsg::JsObject>(),

--- a/src/workerd/io/frankenvalue.c++
+++ b/src/workerd/io/frankenvalue.c++
@@ -177,7 +177,7 @@ jsg::JsValue Frankenvalue::toJsImpl(jsg::Lock& js, kj::ArrayPtr<kj::Own<CapTable
 
     if (properties.size() > 0) {
       jsg::JsObject obj = KJ_REQUIRE_NONNULL(
-          result.tryCast<jsg::JsObject>(), "non-object Frakenvalue can't have properties");
+          result.tryCast<jsg::JsObject>(), "non-object Frankenvalue can't have properties");
 
       for (auto& property: properties) {
         obj.set(js, property.name,

--- a/src/workerd/io/frankenvalue.capnp
+++ b/src/workerd/io/frankenvalue.capnp
@@ -34,4 +34,10 @@ struct Frankenvalue {
   # Property name. Used only when this `Frankenvalue` represents a property, that is, it is an
   # element within the `properties` list of some other `Frankenvalue`. If this is the root value,
   # then `name` must be null.
+
+  capTableSize @5 :UInt32 = 0;
+  # How large is this value's cap table, not counting `properties`.
+  #
+  # The final cap table contains this many base caps (referenced by the union above), followed by
+  # the caps for each property, in order.
 }

--- a/src/workerd/io/frankenvalue.capnp
+++ b/src/workerd/io/frankenvalue.capnp
@@ -40,4 +40,12 @@ struct Frankenvalue {
   #
   # The final cap table contains this many base caps (referenced by the union above), followed by
   # the caps for each property, in order.
+
+  capTable @6 :AnyPointer;
+  # Some sort of representation of the cap table. The exact format is different for different
+  # contexts. Frakenvalue::toCapnp() and fromCapnp() don't handle this at all -- the caller is
+  # expected to deal with it.
+  #
+  # TODO(cleanup): Consider making `Frakenvalue` a generic over the capTable type? Maybe even make
+  #   the C++ class a template over the CapTableEntry type?
 }

--- a/src/workerd/io/frankenvalue.capnp
+++ b/src/workerd/io/frankenvalue.capnp
@@ -43,9 +43,9 @@ struct Frankenvalue {
 
   capTable @6 :AnyPointer;
   # Some sort of representation of the cap table. The exact format is different for different
-  # contexts. Frakenvalue::toCapnp() and fromCapnp() don't handle this at all -- the caller is
+  # contexts. Frankenvalue::toCapnp() and fromCapnp() don't handle this at all -- the caller is
   # expected to deal with it.
   #
-  # TODO(cleanup): Consider making `Frakenvalue` a generic over the capTable type? Maybe even make
+  # TODO(cleanup): Consider making `Frankenvalue` a generic over the capTable type? Maybe even make
   #   the C++ class a template over the CapTableEntry type?
 }

--- a/src/workerd/io/frankenvalue.h
+++ b/src/workerd/io/frankenvalue.h
@@ -26,9 +26,15 @@ class Frankenvalue {
 
   Frankenvalue clone();
 
+  class CapTableEntry;
+
   // Convert to/from capnp format.
+  //
+  // The CapTable, if any, is expected to be handled separately, as different use cases call for
+  // very different handling of the cap table.
   void toCapnp(rpc::Frankenvalue::Builder builder);
-  static Frankenvalue fromCapnp(rpc::Frankenvalue::Reader reader);
+  static Frankenvalue fromCapnp(
+      rpc::Frankenvalue::Reader reader, kj::Vector<kj::Own<CapTableEntry>> capTable = {});
 
   // Convert to/from JavaScript values. Note that round trips here don't produce the exact same
   // Frankenvalue representation: toJs() puts all the contents together into a single value, and
@@ -54,6 +60,74 @@ class Frankenvalue {
   // Frankenvalue is finally converted to JS.
   void setProperty(kj::String name, Frankenvalue value);
 
+  // ---------------------------------------------------------------------------
+  // Capability handling
+  //
+  // A Frankenvalue can contain capabilities (typically ServiceStubs). When serializing from
+  // JavaScript, these will be encoded as integer indexes into a separate table -- the CapTable.
+
+  // The Frakenvalue itself doesn't know how these "capabilities" are implemneted, so leaves this
+  // up to a higher layer. It simply manitains a table of `CapTableEntry` objects. `CapTableEntry`
+  // serves as a generic base class for multiple representations which serializers and
+  // deserializers for specific types will need to support through downcasting.
+  //
+  // In particular:
+  // - Typically, the type is `IoChannelFactory::SubrequestChannel`.
+  // - When a Frankenvalue is being used to initialize the `env` of a dynamically-loaded isolate,
+  //   each CapTableEntry may simply contain an I/O channel number.
+  // - In some environments, a CapTableEntry might some sort of description of how to load a Worker
+  //   that implements the capability.
+  class CapTableEntry {
+   public:
+    // Clone the entry, used when `Frakenvalue::clone()` is called. Many implementations may
+    // implement this using addRef().
+    virtual kj::Own<CapTableEntry> clone() = 0;
+  };
+
+  kj::ArrayPtr<kj::Own<CapTableEntry>> getCapTable() {
+    return capTable;
+  }
+
+  // Rewrite all the caps in the table by calling the `rewrite()` callback on each one.
+  template <typename Func>
+  void rewriteCaps(Func&& rewrite) {
+    for (auto& slot: capTable) {
+      slot = rewrite(kj::mv(slot));
+    }
+  }
+
+  // When deserializing a JS value, the jsg::Deserializer's ExternalHandler will have this type.
+  class CapTableReader final: public jsg::Deserializer::ExternalHandler {
+   public:
+    kj::Maybe<CapTableEntry&> get(uint index) {
+      if (index < table.size()) {
+        return *table[index];
+      } else {
+        return kj::none;
+      }
+    }
+
+   private:
+    kj::ArrayPtr<kj::Own<CapTableEntry>> table;
+    CapTableReader(kj::ArrayPtr<kj::Own<CapTableEntry>> table): table(table) {}
+    friend class Frankenvalue;
+  };
+
+  // When serializing a JS value, the jsg::Serializer's ExternalHandler will have this type.
+  class CapTableBuilder final: public jsg::Serializer::ExternalHandler {
+   public:
+    uint add(kj::Own<CapTableEntry> entry) {
+      uint result = target.capTable.size();
+      target.capTable.add(kj::mv(entry));
+      return result;
+    }
+
+   private:
+    Frankenvalue& target;
+    CapTableBuilder(Frankenvalue& target): target(target) {}
+    friend class Frankenvalue;
+  };
+
  private:
   struct EmptyObject {};
   struct Json {
@@ -66,12 +140,23 @@ class Frankenvalue {
 
   struct Property;
   kj::Vector<Property> properties;
+
+  kj::Vector<kj::Own<CapTableEntry>> capTable;
+
+  void fromCapnpImpl(rpc::Frankenvalue::Reader reader, uint& capTablePos);
+  void toCapnpImpl(rpc::Frankenvalue::Builder builder, uint capTableSize);
+  jsg::JsValue toJsImpl(jsg::Lock& js, kj::ArrayPtr<kj::Own<CapTableEntry>> capTable);
 };
 
 // Can't be defined inline since `Frankenvalue` is still incomplete there.
 struct Frankenvalue::Property {
   kj::String name;
   Frankenvalue value;
+
+  // `value.capTable` is always empty. Instead, these two values specify the slice of the parent's
+  // capTable which this Frankenvalue refers into.
+  uint capTableOffset = 0;
+  uint capTableSize = 0;
 };
 
 }  // namespace workerd

--- a/src/workerd/io/frankenvalue.h
+++ b/src/workerd/io/frankenvalue.h
@@ -24,21 +24,21 @@ class Frankenvalue {
     return value.is<EmptyObject>() && properties.empty();
   }
 
-  Frankenvalue clone() const;
+  Frankenvalue clone();
 
   // Convert to/from capnp format.
-  void toCapnp(rpc::Frankenvalue::Builder builder) const;
+  void toCapnp(rpc::Frankenvalue::Builder builder);
   static Frankenvalue fromCapnp(rpc::Frankenvalue::Reader reader);
 
   // Convert to/from JavaScript values. Note that round trips here don't produce the exact same
   // Frankenvalue representation: toJs() puts all the contents together into a single value, and
   // fromJs() always returns a Frakenvalue containing a single V8-serialized value.
-  jsg::JsValue toJs(jsg::Lock& js) const;
+  jsg::JsValue toJs(jsg::Lock& js);
   static Frankenvalue fromJs(jsg::Lock& js, jsg::JsValue value);
 
   // Like toJs() but add the properties to an existing object. Throws if the `Frankenvalue` does
   // not represent an object. This is used to populate `env` in particular.
-  void populateJsObject(jsg::Lock& js, jsg::JsObject target) const;
+  void populateJsObject(jsg::Lock& js, jsg::JsObject target);
 
   // Construct a Frakenvalue from JSON.
   //

--- a/src/workerd/io/frankenvalue.h
+++ b/src/workerd/io/frankenvalue.h
@@ -26,6 +26,10 @@ class Frankenvalue {
 
   Frankenvalue clone();
 
+  // This method only works if the `CapTableEntry`s in this `Frankenvalue` all implement
+  // `threadSafeClone()`.
+  Frankenvalue threadSafeClone() const;
+
   class CapTableEntry;
 
   // Convert to/from capnp format.
@@ -82,6 +86,10 @@ class Frankenvalue {
     // Clone the entry, used when `Frakenvalue::clone()` is called. Many implementations may
     // implement this using addRef().
     virtual kj::Own<CapTableEntry> clone() = 0;
+
+    // Like `clone()` but works on const values. Used only when `Frakenvalue::threadSafeClone()`
+    // is called. The default implementation throws an exception.
+    virtual kj::Own<CapTableEntry> threadSafeClone() const;
   };
 
   kj::ArrayPtr<kj::Own<CapTableEntry>> getCapTable() {
@@ -143,6 +151,7 @@ class Frankenvalue {
 
   kj::Vector<kj::Own<CapTableEntry>> capTable;
 
+  Frankenvalue cloneImpl() const;
   void fromCapnpImpl(rpc::Frankenvalue::Reader reader, uint& capTablePos);
   void toCapnpImpl(rpc::Frankenvalue::Builder builder, uint capTableSize);
   jsg::JsValue toJsImpl(jsg::Lock& js, kj::ArrayPtr<kj::Own<CapTableEntry>> capTable);

--- a/src/workerd/io/frankenvalue.h
+++ b/src/workerd/io/frankenvalue.h
@@ -42,7 +42,7 @@ class Frankenvalue {
 
   // Convert to/from JavaScript values. Note that round trips here don't produce the exact same
   // Frankenvalue representation: toJs() puts all the contents together into a single value, and
-  // fromJs() always returns a Frakenvalue containing a single V8-serialized value.
+  // fromJs() always returns a Frankenvalue containing a single V8-serialized value.
   jsg::JsValue toJs(jsg::Lock& js);
   static Frankenvalue fromJs(jsg::Lock& js, jsg::JsValue value);
 
@@ -50,9 +50,9 @@ class Frankenvalue {
   // not represent an object. This is used to populate `env` in particular.
   void populateJsObject(jsg::Lock& js, jsg::JsObject target);
 
-  // Construct a Frakenvalue from JSON.
+  // Construct a Frankenvalue from JSON.
   //
-  // (It's not possible to convert a Frakenvalue back to JSON, except by evaluating it in JS and
+  // (It's not possible to convert a Frankenvalue back to JSON, except by evaluating it in JS and
   // then JSON-stringifying from there.)
   static Frankenvalue fromJson(kj::String json);
 
@@ -70,8 +70,8 @@ class Frankenvalue {
   // A Frankenvalue can contain capabilities (typically ServiceStubs). When serializing from
   // JavaScript, these will be encoded as integer indexes into a separate table -- the CapTable.
 
-  // The Frakenvalue itself doesn't know how these "capabilities" are implemneted, so leaves this
-  // up to a higher layer. It simply manitains a table of `CapTableEntry` objects. `CapTableEntry`
+  // The Frankenvalue itself doesn't know how these "capabilities" are implemneted, so leaves this
+  // up to a higher layer. It simply maintains a table of `CapTableEntry` objects. `CapTableEntry`
   // serves as a generic base class for multiple representations which serializers and
   // deserializers for specific types will need to support through downcasting.
   //
@@ -79,15 +79,15 @@ class Frankenvalue {
   // - Typically, the type is `IoChannelFactory::SubrequestChannel`.
   // - When a Frankenvalue is being used to initialize the `env` of a dynamically-loaded isolate,
   //   each CapTableEntry may simply contain an I/O channel number.
-  // - In some environments, a CapTableEntry might some sort of description of how to load a Worker
-  //   that implements the capability.
+  // - In some environments, a CapTableEntry might be some sort of description of how to load a
+  //   Worker that implements the capability.
   class CapTableEntry {
    public:
-    // Clone the entry, used when `Frakenvalue::clone()` is called. Many implementations may
+    // Clone the entry, used when `Frankenvalue::clone()` is called. Many implementations may
     // implement this using addRef().
     virtual kj::Own<CapTableEntry> clone() = 0;
 
-    // Like `clone()` but works on const values. Used only when `Frakenvalue::threadSafeClone()`
+    // Like `clone()` but works on const values. Used only when `Frankenvalue::threadSafeClone()`
     // is called. The default implementation throws an exception.
     virtual kj::Own<CapTableEntry> threadSafeClone() const;
   };

--- a/src/workerd/io/io-channels.c++
+++ b/src/workerd/io/io-channels.c++
@@ -8,4 +8,17 @@ void IoChannelFactory::ActorChannel::requireAllowsTransfer() {
       "a future version.");
 }
 
+uint IoChannelCapTableEntry::getChannelNumber(Type expectedType) {
+  // A type mismatch shouldn't be possible as long as attackers cannot tamper with the
+  // serialization, but we do the check to catch bugs.
+  KJ_REQUIRE(type == expectedType,
+      "IoChannelCapTableEntry type didn't match serialized JavaScript API type.");
+
+  return channel;
+}
+
+kj::Own<Frankenvalue::CapTableEntry> IoChannelCapTableEntry::clone() {
+  return kj::heap<IoChannelCapTableEntry>(type, channel);
+}
+
 }  // namespace workerd

--- a/src/workerd/io/io-channels.c++
+++ b/src/workerd/io/io-channels.c++
@@ -21,4 +21,8 @@ kj::Own<Frankenvalue::CapTableEntry> IoChannelCapTableEntry::clone() {
   return kj::heap<IoChannelCapTableEntry>(type, channel);
 }
 
+kj::Own<Frankenvalue::CapTableEntry> IoChannelCapTableEntry::threadSafeClone() const {
+  return kj::heap<IoChannelCapTableEntry>(type, channel);
+}
+
 }  // namespace workerd

--- a/src/workerd/io/io-channels.c++
+++ b/src/workerd/io/io-channels.c++
@@ -1,0 +1,11 @@
+#include "io-channels.h"
+
+namespace workerd {
+
+void IoChannelFactory::ActorChannel::requireAllowsTransfer() {
+  JSG_FAIL_REQUIRE(DOMDataCloneError,
+      "Durable Object stubs cannot (yet) be transferred between Workers. This will change in "
+      "a future version.");
+}
+
+}  // namespace workerd

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -312,6 +312,7 @@ class IoChannelCapTableEntry final: public Frankenvalue::CapTableEntry {
   uint getChannelNumber(Type expectedType);
 
   kj::Own<CapTableEntry> clone() override;
+  kj::Own<CapTableEntry> threadSafeClone() const override;
 
  private:
   Type type;

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -286,4 +286,28 @@ struct DynamicWorkerSource {
   bool ownContentIsRpcResponse = true;
 };
 
+// A Frakenvalue::CapTableEntry which directly references a numbered I/O channel. This is ONLY
+// valid to use when the `Frankenvalue` is being deserialized as the `env` object of an isolate.
+// The caller should use frankenvalue.rewriteCaps() to rewrite the cap table entries into
+// IoChannelCapTableEntry, building the I/O channel table as it goes.
+class IoChannelCapTableEntry final: public Frankenvalue::CapTableEntry {
+ public:
+  enum Type {
+    SUBREQUEST,
+    // TODO(now): ACTOR_CLASS_CHANNEL
+    // TODO(someday): Other channel types, maybe.
+  };
+
+  IoChannelCapTableEntry(Type type, uint channel): type(type), channel(channel) {}
+
+  // Throws if type doesn't match.
+  uint getChannelNumber(Type expectedType);
+
+  kj::Own<CapTableEntry> clone() override;
+
+ private:
+  Type type;
+  uint channel;
+};
+
 }  // namespace workerd

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -145,7 +145,7 @@ class IoChannelFactory {
   // Object representing somehere where generic workers subrequests can be sent. Multiple requests
   // may be sent. This is an I/O type so it is only valid within the `IoContext` where it was
   // created.
-  class SubrequestChannel: public kj::Refcounted {
+  class SubrequestChannel: public kj::Refcounted, public Frankenvalue::CapTableEntry {
    public:
     // Start a new request to this target.
     //
@@ -156,6 +156,10 @@ class IoChannelFactory {
     // Note that the caller is expected to keep the SubrequestChannel alive until it is done with
     // the returned WorkerInterface.
     virtual kj::Own<WorkerInterface> startRequest(SubrequestMetadata metadata) = 0;
+
+    kj::Own<CapTableEntry> clone() override final {
+      return kj::addRef(*this);
+    }
   };
 
   // Obtain an object representing a particular subrequest channel.

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -217,9 +217,17 @@ class IoChannelFactory {
   // ActorClassChannel is a reference to an actor class in another worker. This class acts as a
   // token which can be passed into other interfaces that might use the actor class, particularly
   // Worker::Actor::FacetManager.
-  class ActorClassChannel: public kj::Refcounted {
+  class ActorClassChannel: public kj::Refcounted, public Frankenvalue::CapTableEntry {
    public:
-    // This class has no actual methods!
+    kj::Own<CapTableEntry> clone() override final {
+      return kj::addRef(*this);
+    }
+
+    // Same as SubrequestChannel::requireAllowsTransfer().
+    virtual void requireAllowsTransfer() = 0;
+
+    // This class has no functional methods, since it serves as a token to be passed to other
+    // interfaces (namely the facets API).
   };
 
   // Get an actor class binding corresponding to the given channel number.
@@ -294,7 +302,7 @@ class IoChannelCapTableEntry final: public Frankenvalue::CapTableEntry {
  public:
   enum Type {
     SUBREQUEST,
-    // TODO(now): ACTOR_CLASS_CHANNEL
+    ACTOR_CLASS,
     // TODO(someday): Other channel types, maybe.
   };
 

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -152,6 +152,9 @@ class IoChannelFactory {
     // Note that not all `metadata` properties make sense here, but it didn't seem worth defining
     // a new struct type. `cfBlobJson` and `parentSpan` make sense, but `featureFlagsForFl` and
     // `dynamicDispatchTarget` do not.
+    //
+    // Note that the caller is expected to keep the SubrequestChannel alive until it is done with
+    // the returned WorkerInterface.
     virtual kj::Own<WorkerInterface> startRequest(SubrequestMetadata metadata) = 0;
   };
 
@@ -161,11 +164,12 @@ class IoChannelFactory {
   // The reason to use this instead is when the channel is not necessarily going to be used to
   // start a subrequest immediately, but instead is going to be passed around as a capability.
   //
+  // `props` can only be specified if this is a loopback channel (i.e. from ctx.exports). For any
+  // other channel, it will throw.
+  //
   // TODO(cleanup): Consider getting rid of `startSubrequest()` in favor of this.
-  virtual kj::Own<SubrequestChannel> getSubrequestChannel(uint channel) {
-    // TODO(cleanup): Remove this once the production runtime has implemented this.
-    KJ_UNIMPLEMENTED("This runtime doesn't support getSubrequestChannel().");
-  }
+  virtual kj::Own<SubrequestChannel> getSubrequestChannel(
+      uint channel, kj::Maybe<Frankenvalue> props = kj::none) = 0;
 
   // Stub for a remote actor. Allows sending requests to the actor.
   class ActorChannel: public SubrequestChannel {

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -205,7 +205,11 @@ class IoChannelFactory {
   };
 
   // Get an actor class binding corresponding to the given channel number.
-  virtual kj::Own<ActorClassChannel> getActorClass(uint channel) {
+  //
+  // `props` can only be specified if this is a loopback channel (i.e. from ctx.exports). For any
+  // other channel, it will throw.
+  virtual kj::Own<ActorClassChannel> getActorClass(
+      uint channel, kj::Maybe<Frankenvalue> props = kj::none) {
     // TODO(cleanup): Remove this once the production runtime has implemented this.
     KJ_UNIMPLEMENTED("This runtime doesn't support actor class channels.");
   }

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -294,7 +294,7 @@ struct DynamicWorkerSource {
   bool ownContentIsRpcResponse = true;
 };
 
-// A Frakenvalue::CapTableEntry which directly references a numbered I/O channel. This is ONLY
+// A Frankenvalue::CapTableEntry which directly references a numbered I/O channel. This is ONLY
 // valid to use when the `Frankenvalue` is being deserialized as the `env` object of an isolate.
 // The caller should use frankenvalue.rewriteCaps() to rewrite the cap table entries into
 // IoChannelCapTableEntry, building the I/O channel table as it goes.

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -377,6 +377,17 @@ enum SerializationTag {
   # A JavaScript native error, such as Error, TypeError, etc. These are typically
   # not handled as host objects in V8 but we handle them as such in workers in
   # order to preserve additional information that we may attach to them.
+
+  serviceStub @11;
+  # A ServiceStub aka Fetcher aka Service Binding.
+  #
+  # Such stubs are different from jsRpcStub in that they don't point to a single live object, but
+  # instead represent a service that can be instantiated anywhere. This means that they can be
+  # passed around the world and instantiated in a different location, as well as persisted in
+  # long-term storage.
+  #
+  # Also because of all this, service stubs can be embedded in the `env` and `ctx.props` of other
+  # Workers. Regular RPC stubs cannot.
 }
 
 enum StreamEncoding {

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -388,6 +388,12 @@ enum SerializationTag {
   #
   # Also because of all this, service stubs can be embedded in the `env` and `ctx.props` of other
   # Workers. Regular RPC stubs cannot.
+
+  actorClass @12;
+  # An actor class reference, aka DurableObjectClass. Can be used to instantiate a facet.
+  #
+  # Similar to serviceStub, this refers to the entrypoint of a Worker that can be instantiated
+  # anywhere and any time, and thus can be persisted and used in `env` and `ctx.props`, etc.
 }
 
 enum StreamEncoding {

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3607,8 +3607,7 @@ kj::Promise<void> Worker::Actor::ensureConstructedImpl(IoContext& context, Actor
       }
 
       auto ctx = js.alloc<api::DurableObjectState>(js, cloneId(),
-          jsg::JsRef<jsg::JsValue>(
-              js, KJ_ASSERT_NONNULL(lock.getWorker().impl->ctxExports).addRef(js)),
+          jsg::JsValue(KJ_ASSERT_NONNULL(lock.getWorker().impl->ctxExports).getHandle(js)),
           impl->props.toJs(js), kj::mv(storage), kj::mv(impl->container), containerRunning,
           impl->facetManager);
 

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3307,6 +3307,7 @@ void Worker::Isolate::logMessage(jsg::Lock& js, uint16_t type, kj::StringPtr des
 
 struct Worker::Actor::Impl {
   Actor::Id actorId;
+  Frankenvalue props;
   MakeStorageFunc makeStorage;
 
   kj::Own<ActorObserver> metrics;
@@ -3474,6 +3475,7 @@ struct Worker::Actor::Impl {
       Actor::Id actorId,
       bool hasTransient,
       MakeActorCacheFunc makeActorCache,
+      Frankenvalue props,
       MakeStorageFunc makeStorage,
       kj::Own<Loopback> loopback,
       TimerChannel& timerChannel,
@@ -3484,6 +3486,7 @@ struct Worker::Actor::Impl {
       kj::Maybe<FacetManager&> facetManager,
       kj::PromiseFulfillerPair<void> paf = kj::newPromiseAndFulfiller<void>())
       : actorId(kj::mv(actorId)),
+        props(kj::mv(props)),
         makeStorage(kj::mv(makeStorage)),
         metrics(kj::mv(metricsParam)),
         transient(hasTransient),
@@ -3533,6 +3536,7 @@ Worker::Actor::Actor(const Worker& worker,
     bool hasTransient,
     MakeActorCacheFunc makeActorCache,
     kj::Maybe<kj::StringPtr> className,
+    Frankenvalue props,
     MakeStorageFunc makeStorage,
     kj::Own<Loopback> loopback,
     TimerChannel& timerChannel,
@@ -3543,7 +3547,7 @@ Worker::Actor::Actor(const Worker& worker,
     kj::Maybe<FacetManager&> facetManager)
     : worker(kj::atomicAddRef(worker)),
       tracker(tracker.map([](RequestTracker& tracker) { return tracker.addRef(); })) {
-  impl = kj::heap<Impl>(*this, kj::mv(actorId), hasTransient, kj::mv(makeActorCache),
+  impl = kj::heap<Impl>(*this, kj::mv(actorId), hasTransient, kj::mv(makeActorCache), kj::mv(props),
       kj::mv(makeStorage), kj::mv(loopback), timerChannel, kj::mv(metrics), kj::mv(manager),
       hibernationEventType, kj::mv(container), facetManager);
 
@@ -3605,7 +3609,8 @@ kj::Promise<void> Worker::Actor::ensureConstructedImpl(IoContext& context, Actor
       auto ctx = js.alloc<api::DurableObjectState>(js, cloneId(),
           jsg::JsRef<jsg::JsValue>(
               js, KJ_ASSERT_NONNULL(lock.getWorker().impl->ctxExports).addRef(js)),
-          kj::mv(storage), kj::mv(impl->container), containerRunning, impl->facetManager);
+          impl->props.toJs(js), kj::mv(storage), kj::mv(impl->container), containerRunning,
+          impl->facetManager);
 
       auto handler =
           info.cls(lock, ctx.addRef(), KJ_ASSERT_NONNULL(lock.getWorker().impl->env).addRef(js));

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -840,6 +840,7 @@ class Worker::Actor final: public kj::Refcounted {
       bool hasTransient,
       MakeActorCacheFunc makeActorCache,
       kj::Maybe<kj::StringPtr> className,
+      Frankenvalue props,
       MakeStorageFunc makeStorage,
       kj::Own<Loopback> loopback,
       TimerChannel& timerChannel,

--- a/src/workerd/jsg/jsg-test.h
+++ b/src/workerd/jsg/jsg-test.h
@@ -147,7 +147,7 @@ class Evaluator {
         v8::TryCatch tryCatch(js.v8Isolate);
 
         try {
-          func(js);
+          func(lock);
         } catch (JsExceptionThrown&) {
           if (tryCatch.HasTerminated()) {
             KJ_FAIL_ASSERT("TerminateExecution() was called");

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -4384,6 +4384,8 @@ KJ_TEST("Server: ctx.exports self-referential bindings") {
                 `      await ctx.exports.default.corge(555),
                 `      await actor.grault(456),
                 `      ctx.exports.UnconfiguredActor.constructor.name,
+                `      await ctx.exports.MyEntrypoint.myProps(),
+                `      await ctx.exports.MyEntrypoint({props: {foo: 123, bar: "abc"}}).myProps(),
                 `    ].join(", "));
                 `  },
                 `  corge(i) { return `corge: ${i}` }
@@ -4391,6 +4393,7 @@ KJ_TEST("Server: ctx.exports self-referential bindings") {
                 `export class MyEntrypoint extends WorkerEntrypoint {
                 `  foo(i) { return `foo: ${i}` }
                 `  grault(i) { return `grault: ${i}` }
+                `  myProps() { return JSON.stringify(this.ctx.props) }
                 `}
                 `export class AnotherEntrypoint extends WorkerEntrypoint {
                 `  bar(i) { return `bar: ${i}` }
@@ -4431,7 +4434,9 @@ KJ_TEST("Server: ctx.exports self-referential bindings") {
   test.start();
 
   auto conn = test.connect("test-addr");
-  conn.httpGet200("/", "foo: 123, bar: 321, baz: 234, corge: 555, grault: 456, DurableObjectClass");
+  conn.httpGet200("/",
+      "foo: 123, bar: 321, baz: 234, corge: 555, grault: 456, DurableObjectClass, "
+      "{}, {\"foo\":123,\"bar\":\"abc\"}");
 }
 
 // =======================================================================================

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -4383,7 +4383,7 @@ KJ_TEST("Server: ctx.exports self-referential bindings") {
                 `      await actor.baz(),
                 `      await ctx.exports.default.corge(555),
                 `      await actor.grault(456),
-                `      "UnconfiguredActor" in ctx.exports,  // should be false
+                `      ctx.exports.UnconfiguredActor.constructor.name,
                 `    ].join(", "));
                 `  },
                 `  corge(i) { return `corge: ${i}` }
@@ -4431,7 +4431,7 @@ KJ_TEST("Server: ctx.exports self-referential bindings") {
   test.start();
 
   auto conn = test.connect("test-addr");
-  conn.httpGet200("/", "foo: 123, bar: 321, baz: 234, corge: 555, grault: 456, false");
+  conn.httpGet200("/", "foo: 123, bar: 321, baz: 234, corge: 555, grault: 456, DurableObjectClass");
 }
 
 // =======================================================================================
@@ -4715,7 +4715,7 @@ KJ_TEST("Server: Durable Object facets") {
                 `
                 `    if (request.url.endsWith("/part1")) {
                 `      let foo = this.ctx.facets.get("foo",
-                `          () => ({class: this.env.COUNTER, id: "abc"}));
+                `          () => ({class: this.ctx.exports.CounterFacet, id: "abc"}));
                 `      results.push(await foo.increment(true));  // increments foo
                 `      results.push(await foo.increment());  // increments foo
                 `      results.push(await foo.increment());  // increments foo

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -4435,7 +4435,7 @@ KJ_TEST("Server: ctx.exports self-referential bindings") {
 
   auto conn = test.connect("test-addr");
   conn.httpGet200("/",
-      "foo: 123, bar: 321, baz: 234, corge: 555, grault: 456, DurableObjectClass, "
+      "foo: 123, bar: 321, baz: 234, corge: 555, grault: 456, LoopbackDurableObjectClass, "
       "{}, {\"foo\":123,\"bar\":\"abc\"}");
 }
 
@@ -4789,6 +4789,11 @@ KJ_TEST("Server: Durable Object facets") {
                 `      let prop2 = this.ctx.facets.get("prop2",
                 `          () => ({class: this.ctx.exports.CounterFacet, id: "abc"}));
                 `      results.push(await prop2.myProps());
+                `
+                `      let prop3 = this.ctx.facets.get("prop3",
+                `          () => ({class: this.ctx.exports.CounterFacet({props: {bProp: 321}}),
+                `                  id: "abc"}));
+                `      results.push(await prop3.myProps());
                 `    } else {
                 `      throw new Error(`bad url: ${request.url}`);
                 `    }
@@ -4949,7 +4954,7 @@ KJ_TEST("Server: Durable Object facets") {
     test.server.allowExperimental();
     test.start();
     auto conn = test.connect("test-addr");
-    conn.httpGet200("/props", "{} {\"aProp\":123} {}");
+    conn.httpGet200("/props", "{} {\"aProp\":123} {} {\"bProp\":321}");
   }
 }
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2937,8 +2937,8 @@ class Server::WorkerService final: public Service,
       static constexpr uint16_t hibernationEventTypeId = 8;
 
       return kj::refcounted<Worker::Actor>(*service->worker, tracker, kj::mv(actorId), true,
-          kj::mv(makeActorCache), className, kj::mv(makeStorage), kj::mv(loopback), timerChannel,
-          kj::refcounted<ActorObserver>(), kj::mv(manager), hibernationEventTypeId,
+          kj::mv(makeActorCache), className, props.clone(), kj::mv(makeStorage), kj::mv(loopback),
+          timerChannel, kj::refcounted<ActorObserver>(), kj::mv(manager), hibernationEventTypeId,
           kj::mv(container), facetManager);
     }
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -4266,16 +4266,18 @@ kj::Promise<kj::Own<Server::WorkerService>> Server::makeWorkerImpl(kj::StringPtr
       decltype(Global::value) value;
       KJ_IF_SOME(ns, def.localActorConfigs.find(className)) {
         // This class has storage attached. We'll create a loopback actor namespace binding.
-        // TODO(now): Currently we don't use actorClassChannel in this branch even though we have
-        //   allocated one. That will change later in this PR.
         KJ_SWITCH_ONEOF(ns) {
           KJ_CASE_ONEOF(durable, Durable) {
-            value = Global::DurableActorNamespace{
-              .actorChannel = nextActorChannel++, .uniqueKey = durable.uniqueKey};
+            value = Global::LoopbackDurableActorNamespace{
+              .actorChannel = nextActorChannel++,
+              .uniqueKey = durable.uniqueKey,
+              .classChannel = actorClassChannel,
+            };
           }
           KJ_CASE_ONEOF(ephemeral, Ephemeral) {
-            value = Global::EphemeralActorNamespace{
+            value = Global::LoopbackEphemeralActorNamespace{
               .actorChannel = nextActorChannel++,
+              .classChannel = actorClassChannel,
             };
           }
         }

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3855,7 +3855,7 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
         },
 
         .compileBindings = [env = kj::mv(source.env)](
-            jsg::Lock& js, const Worker::Api& api, v8::Local<v8::Object> target) {
+            jsg::Lock& js, const Worker::Api& api, v8::Local<v8::Object> target) mutable {
           env.populateJsObject(js, jsg::JsObject(target));
         },
 

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -285,6 +285,7 @@ class Server final: private kj::TaskSet::ErrorHandler {
       kj::StringPtr workerName, const WorkerDef& workerDef, ErrorReporter& errorReporter);
 
   friend struct FutureSubrequestChannel;
+  friend struct FutureActorClassChannel;
 };
 
 // An ActorStorage implementation which will always respond to reads as if the state is empty,

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -985,6 +985,10 @@ static v8::Local<v8::Value> createBindingValue(JsgWorkerdIsolate::Lock& lock,
       value = lock.wrap(context, lock.alloc<api::DurableObjectClass>(actorClass.channel));
     }
 
+    KJ_CASE_ONEOF(actorClass, Global::LoopbackActorClass) {
+      value = lock.wrap(context, lock.alloc<api::LoopbackDurableObjectClass>(actorClass.channel));
+    }
+
     KJ_CASE_ONEOF(workerLoader, Global::WorkerLoader) {
       value = lock.wrap(context,
           lock.alloc<api::WorkerLoader>(
@@ -1081,6 +1085,9 @@ WorkerdApi::Global WorkerdApi::Global::clone() const {
     }
 
     KJ_CASE_ONEOF(actorClass, Global::ActorClass) {
+      result.value = actorClass.clone();
+    }
+    KJ_CASE_ONEOF(actorClass, Global::LoopbackActorClass) {
       result.value = actorClass.clone();
     }
     KJ_CASE_ONEOF(workerLoader, Global::WorkerLoader) {

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -15,6 +15,7 @@
 #include <workerd/api/encoding.h>
 #include <workerd/api/events.h>
 #include <workerd/api/eventsource.h>
+#include <workerd/api/export-loopback.h>
 #include <workerd/api/filesystem.h>
 #include <workerd/api/global-scope.h>
 #include <workerd/api/html-rewriter.h>
@@ -129,6 +130,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
     EW_WORKER_LOADER_ISOLATE_TYPES,
     EW_MESSAGECHANNEL_ISOLATE_TYPES,
     EW_WORKERS_MODULE_ISOLATE_TYPES,
+    EW_EXPORT_LOOPBACK_ISOLATE_TYPES,
     workerd::api::EnvModule,
 
     jsg::TypeWrapperExtension<PromiseWrapper>,
@@ -853,6 +855,10 @@ static v8::Local<v8::Value> createBindingValue(JsgWorkerdIsolate::Lock& lock,
               pipeline.isInHouse));
     }
 
+    KJ_CASE_ONEOF(loopback, Global::LoopbackServiceStub) {
+      value = lock.wrap(context, lock.alloc<api::LoopbackServiceStub>(loopback.channel));
+    }
+
     KJ_CASE_ONEOF(ns, Global::KvNamespace) {
       value = lock.wrap(context,
           lock.alloc<api::KvNamespace>(
@@ -1027,6 +1033,9 @@ WorkerdApi::Global WorkerdApi::Global::clone() const {
     }
     KJ_CASE_ONEOF(fetcher, Global::Fetcher) {
       result.value = fetcher.clone();
+    }
+    KJ_CASE_ONEOF(loopback, Global::LoopbackServiceStub) {
+      result.value = loopback.clone();
     }
     KJ_CASE_ONEOF(kvNamespace, Global::KvNamespace) {
       result.value = kvNamespace.clone();

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -918,11 +918,22 @@ static v8::Local<v8::Value> createBindingValue(JsgWorkerdIsolate::Lock& lock,
     KJ_CASE_ONEOF(ns, Global::EphemeralActorNamespace) {
       value = lock.wrap(context, lock.alloc<api::ColoLocalActorNamespace>(ns.actorChannel));
     }
+    KJ_CASE_ONEOF(ns, Global::LoopbackEphemeralActorNamespace) {
+      value = lock.wrap(context,
+          lock.alloc<api::LoopbackColoLocalActorNamespace>(
+              ns.actorChannel, lock.alloc<api::LoopbackDurableObjectClass>(ns.classChannel)));
+    }
 
     KJ_CASE_ONEOF(ns, Global::DurableActorNamespace) {
       value = lock.wrap(context,
           lock.alloc<api::DurableObjectNamespace>(
               ns.actorChannel, kj::heap<ActorIdFactoryImpl>(ns.uniqueKey)));
+    }
+    KJ_CASE_ONEOF(ns, Global::LoopbackDurableActorNamespace) {
+      value = lock.wrap(context,
+          lock.alloc<api::LoopbackDurableObjectNamespace>(ns.actorChannel,
+              kj::heap<ActorIdFactoryImpl>(ns.uniqueKey),
+              lock.alloc<api::LoopbackDurableObjectClass>(ns.classChannel)));
     }
 
     KJ_CASE_ONEOF(ae, Global::AnalyticsEngine) {
@@ -1062,7 +1073,13 @@ WorkerdApi::Global WorkerdApi::Global::clone() const {
     KJ_CASE_ONEOF(ns, Global::EphemeralActorNamespace) {
       result.value = ns.clone();
     }
+    KJ_CASE_ONEOF(ns, Global::LoopbackEphemeralActorNamespace) {
+      result.value = ns.clone();
+    }
     KJ_CASE_ONEOF(ns, Global::DurableActorNamespace) {
+      result.value = ns.clone();
+    }
+    KJ_CASE_ONEOF(ns, Global::LoopbackDurableActorNamespace) {
       result.value = ns.clone();
     }
     KJ_CASE_ONEOF(ae, Global::AnalyticsEngine) {

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -185,11 +185,28 @@ class WorkerdApi final: public Worker::Api {
         return *this;
       }
     };
+    struct LoopbackEphemeralActorNamespace {
+      uint actorChannel;
+      uint classChannel;
+
+      LoopbackEphemeralActorNamespace clone() const {
+        return *this;
+      }
+    };
     struct DurableActorNamespace {
       uint actorChannel;
       kj::StringPtr uniqueKey;
 
       DurableActorNamespace clone() const {
+        return *this;
+      }
+    };
+    struct LoopbackDurableActorNamespace {
+      uint actorChannel;
+      kj::StringPtr uniqueKey;
+      uint classChannel;
+
+      LoopbackDurableActorNamespace clone() const {
         return *this;
       }
     };
@@ -266,7 +283,9 @@ class WorkerdApi final: public Worker::Api {
         R2Admin,
         CryptoKey,
         EphemeralActorNamespace,
+        LoopbackEphemeralActorNamespace,
         DurableActorNamespace,
+        LoopbackDurableActorNamespace,
         QueueBinding,
         kj::String,
         kj::Array<byte>,

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -241,6 +241,14 @@ class WorkerdApi final: public Worker::Api {
       }
     };
 
+    struct LoopbackActorClass {
+      uint channel;
+
+      LoopbackActorClass clone() const {
+        return *this;
+      }
+    };
+
     struct WorkerLoader {
       uint channel;
 
@@ -268,6 +276,7 @@ class WorkerdApi final: public Worker::Api {
         UnsafeEval,
         MemoryCache,
         ActorClass,
+        LoopbackActorClass,
         WorkerLoader>
         value;
 

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -100,6 +100,13 @@ class WorkerdApi final: public Worker::Api {
         return *this;
       }
     };
+    struct LoopbackServiceStub {
+      uint channel;
+
+      LoopbackServiceStub clone() const {
+        return *this;
+      }
+    };
     struct KvNamespace {
       uint subrequestChannel;
 
@@ -245,6 +252,7 @@ class WorkerdApi final: public Worker::Api {
     kj::String name;
     kj::OneOf<Json,
         Fetcher,
+        LoopbackServiceStub,
         KvNamespace,
         R2Bucket,
         R2Admin,

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -77,6 +77,11 @@ struct DummyIoChannelFactory final: public IoChannelFactory {
     KJ_FAIL_ASSERT("no subrequests");
   }
 
+  kj::Own<SubrequestChannel> getSubrequestChannel(
+      uint channel, kj::Maybe<Frankenvalue> props) override {
+    KJ_FAIL_ASSERT("no subrequests");
+  }
+
   capnp::Capability::Client getCapability(uint channel) override {
     KJ_FAIL_ASSERT("no capabilities");
   }

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -377,8 +377,9 @@ TestFixture::TestFixture(SetupParams&& params)
     };
     actor = kj::refcounted<Worker::Actor>(*worker, /*tracker=*/kj::none, kj::mv(id),
         /*hasTransient=*/false, makeActorCache,
-        /*classname=*/kj::none, makeStorage, kj::refcounted<MockActorLoopback>(), *timerChannel,
-        kj::refcounted<ActorObserver>(), kj::none, kj::none);
+        /*classname=*/kj::none, /*props=*/Frankenvalue(), makeStorage,
+        kj::refcounted<MockActorLoopback>(), *timerChannel, kj::refcounted<ActorObserver>(),
+        kj::none, kj::none);
   }
 }
 

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -497,6 +497,9 @@ interface AlarmInvocationInfo {
 interface Cloudflare {
   readonly compatibilityFlags: Record<string, boolean>;
 }
+declare abstract class ColoLocalActorNamespace {
+  get(actorId: string): Fetcher;
+}
 interface DurableObject {
   fetch(request: Request): Response | Promise<Response>;
   alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
@@ -527,7 +530,7 @@ interface DurableObjectId {
   readonly name?: string;
   readonly jurisdiction?: string;
 }
-interface DurableObjectNamespace<
+declare abstract class DurableObjectNamespace<
   T extends Rpc.DurableObjectBranded | undefined = undefined,
 > {
   newUniqueId(
@@ -568,10 +571,11 @@ type DurableObjectLocationHint =
 interface DurableObjectNamespaceGetDurableObjectOptions {
   locationHint?: DurableObjectLocationHint;
 }
-interface DurableObjectClass {}
+declare abstract class DurableObjectClass {}
 interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   exports: any;
+  props: any;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
   container?: Container;
@@ -704,7 +708,10 @@ interface DurableObjectFacets {
   delete(name: string): void;
 }
 interface DurableObjectFacetsStartupOptions {
-  $class: DurableObjectClass;
+  $class:
+    | DurableObjectClass
+    | LoopbackDurableObjectNamespace
+    | LoopbackColoLocalActorNamespace;
   id?: DurableObjectId | string;
 }
 interface AnalyticsEngineDataset {
@@ -3339,6 +3346,8 @@ declare class MessageChannel {
 interface MessagePortPostMessageOptions {
   transfer?: any[];
 }
+interface LoopbackDurableObjectNamespace extends DurableObjectNamespace {}
+interface LoopbackColoLocalActorNamespace extends ColoLocalActorNamespace {}
 type AiImageClassificationInput = {
   image: number[];
 };

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -502,6 +502,9 @@ export interface AlarmInvocationInfo {
 export interface Cloudflare {
   readonly compatibilityFlags: Record<string, boolean>;
 }
+export declare abstract class ColoLocalActorNamespace {
+  get(actorId: string): Fetcher;
+}
 export interface DurableObject {
   fetch(request: Request): Response | Promise<Response>;
   alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
@@ -532,7 +535,7 @@ export interface DurableObjectId {
   readonly name?: string;
   readonly jurisdiction?: string;
 }
-export interface DurableObjectNamespace<
+export declare abstract class DurableObjectNamespace<
   T extends Rpc.DurableObjectBranded | undefined = undefined,
 > {
   newUniqueId(
@@ -573,10 +576,11 @@ export type DurableObjectLocationHint =
 export interface DurableObjectNamespaceGetDurableObjectOptions {
   locationHint?: DurableObjectLocationHint;
 }
-export interface DurableObjectClass {}
+export declare abstract class DurableObjectClass {}
 export interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
   exports: any;
+  props: any;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
   container?: Container;
@@ -709,7 +713,10 @@ export interface DurableObjectFacets {
   delete(name: string): void;
 }
 export interface DurableObjectFacetsStartupOptions {
-  $class: DurableObjectClass;
+  $class:
+    | DurableObjectClass
+    | LoopbackDurableObjectNamespace
+    | LoopbackColoLocalActorNamespace;
   id?: DurableObjectId | string;
 }
 export interface AnalyticsEngineDataset {
@@ -3350,6 +3357,10 @@ export declare class MessageChannel {
 export interface MessagePortPostMessageOptions {
   transfer?: any[];
 }
+export interface LoopbackDurableObjectNamespace
+  extends DurableObjectNamespace {}
+export interface LoopbackColoLocalActorNamespace
+  extends ColoLocalActorNamespace {}
 export type AiImageClassificationInput = {
   image: number[];
 };

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -518,7 +518,7 @@ interface DurableObjectId {
   equals(other: DurableObjectId): boolean;
   readonly name?: string;
 }
-interface DurableObjectNamespace<
+declare abstract class DurableObjectNamespace<
   T extends Rpc.DurableObjectBranded | undefined = undefined,
 > {
   newUniqueId(
@@ -557,6 +557,7 @@ interface DurableObjectNamespaceGetDurableObjectOptions {
 }
 interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
+  props: any;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
   container?: Container;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -523,7 +523,7 @@ export interface DurableObjectId {
   equals(other: DurableObjectId): boolean;
   readonly name?: string;
 }
-export interface DurableObjectNamespace<
+export declare abstract class DurableObjectNamespace<
   T extends Rpc.DurableObjectBranded | undefined = undefined,
 > {
   newUniqueId(
@@ -562,6 +562,7 @@ export interface DurableObjectNamespaceGetDurableObjectOptions {
 }
 export interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
+  props: any;
   readonly id: DurableObjectId;
   readonly storage: DurableObjectStorage;
   container?: Container;


### PR DESCRIPTION
This implements a few things:

First, `ctx.exports` self-referential bindings now allow you to customize the props, by invoking the binding:

```js
let stub = ctx.exports.MyEntrypoint({props: {foo: 123}})
```

This gives you back a `ServiceStub` (aka `Fetcher`) which will invoke the entrypoint with the given props delivered as `ctx.props`.

This becomes interesting due to:

Second, you can now take a service binding and _put it into the env_ for a dynamically-loaded worker. You just plop it right in there:

```js
env.LOADER.get("foo", () => {
  return {
    compatibilityDate: "2025-06-01",
    mainModule: "foo.js",
    modules: {...},
    env: {
      MY_SERVICE_BINDING: this.ctx.exports.MyEntrypoint({props: {...}})
    },
  };
});
```

And that'll just work. Now the dynamic worker has a binding that points back to an entrypoint in the parent, with the props you specified.

Also, as a bonus, you can embed service bindings into props bundled into other service bindings.

NOTE: I'm still working on the internal implementation, so the internal build will fail for the moment. It's not too complicated though.