### PR TITLE
release-python-runtime: Don't update released bundles by default

### DIFF
--- a/.github/workflows/release-python-runtime.yml
+++ b/.github/workflows/release-python-runtime.yml
@@ -1,6 +1,13 @@
 name: Build Python Runtime
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      update-released:
+        description: 'Update already released versions?'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
@@ -32,7 +39,7 @@ jobs:
           # boto3 v1.36.0 fails with:
           # NotImplemented error occurred in CreateMultipartUpload operation: Header 'x-amz-checksum-algorithm' with value 'CRC32' not implemented
           pip install 'boto3<1.36.0' requests
-          python3 src/pyodide/upload_bundles.py
+          python3 src/pyodide/upload_bundles.py ${{ inputs.update-released == true && '--update-released' || '' }}
 
       - name: Check for open PR and commit changes
         env:

--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -97,6 +97,7 @@ def _make_bundle_version_info(versions):
 BUNDLE_VERSION_INFO = _make_bundle_version_info([
     {
         "name": "0.26.0a2",
+        "released": True,
         "pyodide_version": "0.26.0a2",
         "pyodide_date": "2024-03-01",
         "packages": PACKAGES_20240829_4,


### PR DESCRIPTION
I manually tested both with the flag off and with it on and both work as expected.