### PR TITLE
Fix double write of entry_size

### DIFF
--- a/src/workerd/api/memory-cache.c++
+++ b/src/workerd/api/memory-cache.c++
@@ -504,8 +504,6 @@ jsg::Promise<jsg::JsRef<jsg::JsValue>> MemoryCache::read(jsg::Lock& js,
     KJ_SWITCH_ONEOF(cacheUse.getWithFallback(key.value, readSpan)) {
       KJ_CASE_ONEOF(result, kj::Own<CacheValue>) {
         // Optimization: Don't even release the isolate lock if the value is already in cache.
-        readSpan.setTag("entry_size"_kjc, static_cast<double>(result->bytes.size()));
-
         jsg::Deserializer deserializer(js, result->bytes.asPtr());
         auto value = jsg::JsRef(js, deserializer.readValue(js));
 


### PR DESCRIPTION
For the cache_hit path entry_size is already set by getWithFallback