### PR TITLE
Improve tracing for MemoryCache

### DIFF
--- a/src/workerd/api/memory-cache.h
+++ b/src/workerd/api/memory-cache.h
@@ -184,13 +184,13 @@ class SharedMemoryCache: public kj::AtomicRefcounted {
     // expired). If no such value exists, nothing is returned, regardless of any
     // in-progress fallbacks trying to produce such a value.
     kj::Maybe<kj::Own<CacheValue>> getWithoutFallback(
-        const kj::String& key, SpanBuilder& span) const;
+        const kj::String& key, SpanBuilder& readSpan) const;
 
     struct FallbackResult {
       kj::Own<CacheValue> value;
       kj::Maybe<double> expiration;
     };
-    using FallbackDoneCallback = kj::Function<void(kj::Maybe<FallbackResult>)>;
+    using FallbackDoneCallback = kj::Function<void(kj::Maybe<FallbackResult>, SpanBuilder&)>;
     using GetWithFallbackOutcome = kj::OneOf<kj::Own<CacheValue>, FallbackDoneCallback>;
 
     // Returns either:
@@ -199,7 +199,7 @@ class SharedMemoryCache: public kj::AtomicRefcounted {
     //    or to a FallbackDoneCallback. In the latter case, the caller should
     //    invoke the fallback function.
     kj::OneOf<kj::Own<CacheValue>, kj::Promise<GetWithFallbackOutcome>> getWithFallback(
-        const kj::String& key, SpanBuilder& span) const;
+        const kj::String& key, SpanBuilder& readSpan) const;
 
     void delete_(const kj::String& key) const;
 

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -1487,7 +1487,12 @@ void SpanBuilder::setTag(kj::ConstString key, TagValue value) {
       // This is a programming error, but not a serious one. We could alternatively just emit
       // duplicate tags and leave the Jaeger UI in charge of warning about them.
       [[maybe_unused]] static auto logged = [keyPtr]() {
-        KJ_LOG(WARNING, "overwriting previous tag", keyPtr);
+        if (isPredictableModeForTest()) {
+          // Logging in ERROR level to have this fail loudly during testing.
+          KJ_LOG(ERROR, "overwriting previous tag", keyPtr);
+        } else {
+          KJ_LOG(WARNING, "overwriting previous tag", keyPtr);
+        }
         return true;
       }();
       existingValue = kj::mv(newValue);


### PR DESCRIPTION
- rename `span` to `readSpan` in several places where appropriate for readability.
- use proper span tree structure for spans
- remove redundant fallback_complete span and merge into fallback span
- Fix unsafe usage of IoContext in handleFallbackFailure