### PR TITLE
Always grab the owned source from a dynamic source

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3762,9 +3762,12 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
           env.populateJsObject(js, jsg::JsObject(target));
         },
 
-        .maybeOwnedSourceCode = !source.ownContentIsRpcResponse
-            ? kj::Maybe<kj::Own<void>>(kj::mv(source.ownContent))
-            : kj::Maybe<kj::Own<void>>(kj::none),
+        // Note here that we always keep the ownContent from the source, even if
+        // ownContentIsRpcResponse is true. This is safe in workerd because we
+        // are single-threaded here and we don't need to worry about the cross-thread
+        // ownership issues. For the downstream use, however, we need to be careful
+        // to not copy the ownContent if it is an RPC response.
+        .maybeOwnedSourceCode = kj::mv(source.ownContent),
         // clang-format on
       };
 


### PR DESCRIPTION
The previous code was guarding against a case that should never happen in workerd, and if it did would be a bug. Simplify to avoid confusion and possible issues later.