### PR TITLE
Simplify tryResolveMainModule to use js.resolveModule

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1388,8 +1388,7 @@ Worker::Script::Script(kj::Own<const Isolate> isolateParam,
                   } else {
                     limitScope = isolate->getLimitEnforcer().enterStartupJs(js, limitErrorOrTime);
                   }
-                  auto& modules = KJ_ASSERT_NONNULL(impl->moduleContext)->getModuleRegistry();
-                  impl->configureDynamicImports(lock, modules);
+                  impl->configureDynamicImports(lock, *jsg::ModuleRegistry::from(lock));
                   isolate->getApi().compileModules(
                       lock, modulesSource, *isolate, kj::mv(artifacts), kj::mv(parentSpan));
                 }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1545,43 +1545,16 @@ kj::Maybe<jsg::JsObject> tryResolveMainModule(jsg::Lock& js,
   } else {
     limitScope = script.getIsolate().getLimitEnforcer().enterStartupJs(js, limitErrorOrTime);
   }
-  if (script.getIsolate().getApi().getFeatureFlags().getNewModuleRegistry()) {
-    KJ_DEFER({
-      if (limitErrorOrTime.is<kj::Exception>()) {
-        // If we hit the limit in PerformMicrotaskCheckpoint() we may not have actually
-        // thrown an exception.
-        throw jsg::JsExceptionThrown();
-      }
-    });
-    // This intentionally does not return the kj::Maybe directly from the
-    // call to tryResolveModuleNamespace because I intend to add some additional
-    // logging/metrics logic around this call.
-    KJ_IF_SOME(ns,
-        jsg::modules::ModuleRegistry::tryResolveModuleNamespace(js, mainModule.toString(false))) {
-      return ns;
+
+  KJ_DEFER({
+    if (limitErrorOrTime.is<kj::Exception>()) {
+      // If we hit the limit in PerformMicrotaskCheckpoint() we may not have actually
+      // thrown an exception.
+      throw jsg::JsExceptionThrown();
     }
-  } else {
-    auto& registry = jsContext->getModuleRegistry();
-    KJ_IF_SOME(entry, registry.resolve(js, mainModule, kj::none)) {
-      JSG_REQUIRE(entry.maybeSynthetic == kj::none, TypeError, "Main module must be an ES module.");
-      auto module = entry.module.getHandle(js);
-      jsg::instantiateModule(js, module);
-
-      if (limitErrorOrTime.is<kj::Exception>()) {
-        // If we hit the limit in PerformMicrotaskCheckpoint() we may not have actually
-        // thrown an exception.
-        throw jsg::JsExceptionThrown();
-      }
-
-      auto ns = module->GetModuleNamespace().As<v8::Object>();
-      // The V8 module API is weird. Only the first call to Evaluate() will evaluate the
-      // module, even if subsequent calls pass a different context. Verify that we didn't
-      // switch contexts.
-      KJ_ASSERT(jsg::check(ns->GetCreationContext(js.v8Isolate)) == js.v8Context(),
-          "module was originally instantiated in a different context");
-
-      return jsg::JsObject(ns);
-    }
+  });
+  KJ_IF_SOME(resolved, js.resolveModule(mainModule.toString(false), jsg::RequireEsm::YES)) {
+    return resolved;
   }
   return kj::none;
 }

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -323,7 +323,7 @@ kj::Maybe<JsObject> Lock::resolveInternalModule(kj::StringPtr specifier) {
   return jsg::JsObject(module.getHandle(*this).As<v8::Object>());
 }
 
-kj::Maybe<JsObject> Lock::resolveModule(kj::StringPtr specifier) {
+kj::Maybe<JsObject> Lock::resolveModule(kj::StringPtr specifier, RequireEsm requireEsm) {
   auto& isolate = IsolateBase::from(v8Isolate);
   if (isolate.isUsingNewModuleRegistry()) {
     return jsg::modules::ModuleRegistry::tryResolveModuleNamespace(
@@ -335,6 +335,9 @@ kj::Maybe<JsObject> Lock::resolveModule(kj::StringPtr specifier) {
   auto spec = kj::Path::parse(specifier);
   auto& info = JSG_REQUIRE_NONNULL(
       moduleRegistry->resolve(*this, spec), Error, kj::str("No such module: ", specifier));
+  if (!!requireEsm) {
+    JSG_REQUIRE(info.maybeSynthetic == kj::none, TypeError, "Main module must be an ES module.");
+  }
   auto module = info.module.getHandle(*this);
   jsg::instantiateModule(*this, module);
   return JsObject(module->GetModuleNamespace().As<v8::Object>());

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -335,7 +335,7 @@ kj::Maybe<JsObject> Lock::resolveModule(kj::StringPtr specifier, RequireEsm requ
   auto spec = kj::Path::parse(specifier);
   auto& info = JSG_REQUIRE_NONNULL(
       moduleRegistry->resolve(*this, spec), Error, kj::str("No such module: ", specifier));
-  if (!!requireEsm) {
+  if (requireEsm) {
     JSG_REQUIRE(info.maybeSynthetic == kj::none, TypeError, "Main module must be an ES module.");
   }
   auto module = info.module.getHandle(*this);

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -13,6 +13,7 @@
 #include <workerd/jsg/exception.h>
 #include <workerd/jsg/macro-meta.h>
 #include <workerd/jsg/memory.h>
+#include <workerd/util/strong-bool.h>
 
 #include <v8-external-memory-accounter.h>
 #include <v8-forward.h>
@@ -764,6 +765,7 @@ enum SetDataIndex {
 // These types can be used in C++ to represent various JavaScript idioms / Web IDL types.
 
 class Lock;
+WD_STRONG_BOOL(RequireEsm);
 
 // Arbitrary V8 data, wrapped for storage from C++. You can't do much with it, so instead you
 // should probably use V8Ref<T>, a version of this that's strongly typed.
@@ -2820,7 +2822,8 @@ class Lock {
 
   // Resolve a module namespace from the given specifier.
   // This variation includes modules from the worker bundle.
-  kj::Maybe<JsObject> resolveModule(kj::StringPtr specifier);
+  kj::Maybe<JsObject> resolveModule(
+      kj::StringPtr specifier, RequireEsm requireEsm = RequireEsm::NO);
 
  private:
   // Mark the jsg::Lock as being disallowed from being passed as a parameter into


### PR DESCRIPTION
This is the first of a set of PRs in preparation for the final push to enable the new module registry in the downstream project. 
I will be moving the capnp module implementation out to workerd as part of this, and to do so we need to rework how the capnp::SchemaLoader is accessed. 
Instead of it living on the `Worker::Api` object, the intent here is for it to eventually live on the module registry. 
However, it's a bit tricky because right now the capnp module TypeWrapper extension requires that the `SchemaLoader` instance is passed in as part of the TypeWrapper configuration. 
I will be changing that so that the capnp module typewrapper can pull it off the `jsg::Lock` instead, via either of the new module registry implementations, but to do so I first need to clean up a few other bits and pieces and just normalize how we're accessing the module registry and how we're storing the ownership for either of the two implementations. 
This PR lays some of the ground work, the next PR will actually add the `capnp::SchemaLoader` to the module registry implementations, then I will have an internal PR that updates the capnp module implementation to use those, followed thereafter by another PR that moves the capnp module impl out to workerd. 
I'm splitting it up over several PRs in order to hopefully keep it from not getting too convoluted.