### PR TITLE
Ensure that the isolate always has a capnp schema loader associated with it

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1552,10 +1552,7 @@ kj::Maybe<jsg::JsObject> tryResolveMainModule(jsg::Lock& js,
       throw jsg::JsExceptionThrown();
     }
   });
-  KJ_IF_SOME(resolved, js.resolveModule(mainModule.toString(false), jsg::RequireEsm::YES)) {
-    return resolved;
-  }
-  return kj::none;
+  return js.resolveModule(mainModule.toString(false), jsg::RequireEsm::YES);
 }
 }  // anonymous namespace
 

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -534,6 +534,16 @@ KJ_TEST("Memory Allocation Error Propagation") {
   });
 }
 
+KJ_TEST("JS Lock has a capnp::SchemaLoader") {
+  IsolateUuidIsolate isolate(v8System, kj::heap<IsolateObserver>());
+  isolate.runInLockScope([&](IsolateUuidIsolate::Lock& lock) {
+    JSG_WITHIN_CONTEXT_SCOPE(
+        lock, lock.newContext<IsolateUuidContext>().getHandle(lock), [&](jsg::Lock& js) {
+      KJ_ASSERT(js.getCapnpSchemaLoader<IsolateUuidContext>().getAllLoaded().size() == 0);
+    });
+  });
+}
+
 }  // namespace
 
 }  // namespace workerd::jsg::test

--- a/src/workerd/jsg/modules-new.c++
+++ b/src/workerd/jsg/modules-new.c++
@@ -1136,7 +1136,8 @@ ModuleRegistry::Builder::Builder(
     const ResolveObserver& observer, const jsg::Url& bundleBase, Options options)
     : observer(observer),
       bundleBase(bundleBase),
-      options(options) {}
+      options(options),
+      schemaLoader(kj::heap<capnp::SchemaLoader>()) {}
 
 bool ModuleRegistry::Builder::allowsFallback() const {
   return (options & Options::ALLOW_FALLBACK) == Options::ALLOW_FALLBACK;
@@ -1168,7 +1169,8 @@ kj::Own<ModuleRegistry> ModuleRegistry::Builder::finish() {
 ModuleRegistry::ModuleRegistry(ModuleRegistry::Builder* builder)
     : observer(builder->observer),
       bundleBase(builder->bundleBase),
-      maybeParent(builder->maybeParent) {
+      maybeParent(builder->maybeParent),
+      schemaLoader(kj::mv(builder->schemaLoader)) {
   bundles_[kBundle] = builder->bundles_[kBundle].releaseAsArray();
   bundles_[kBuiltin] = builder->bundles_[kBuiltin].releaseAsArray();
   bundles_[kBuiltinOnly] = builder->bundles_[kBuiltinOnly].releaseAsArray();

--- a/src/workerd/jsg/modules-new.h
+++ b/src/workerd/jsg/modules-new.h
@@ -15,6 +15,7 @@
 
 #include <v8.h>
 
+#include <capnp/schema-loader.h>
 #include <kj/common.h>
 #include <kj/function.h>
 #include <kj/map.h>
@@ -613,6 +614,10 @@ class ModuleRegistry final: public ModuleRegistryBase {
 
     Builder& setEvalCallback(EvalCallback callback) KJ_LIFETIMEBOUND;
 
+    capnp::SchemaLoader& getSchemaLoader() {
+      return *schemaLoader;
+    }
+
    private:
     bool allowsFallback() const;
 
@@ -623,6 +628,7 @@ class ModuleRegistry final: public ModuleRegistryBase {
     const Options options;
     kj::Vector<kj::Own<ModuleBundle>> bundles_[ModuleRegistry::kBundleCount];
     kj::Maybe<EvalCallback> maybeEvalCallback = kj::none;
+    kj::Own<capnp::SchemaLoader> schemaLoader;
     friend class ModuleRegistry;
   };
 
@@ -668,6 +674,10 @@ class ModuleRegistry final: public ModuleRegistryBase {
     return bundleBase;
   }
 
+  const capnp::SchemaLoader& getSchemaLoader() const override {
+    return *schemaLoader;
+  }
+
  private:
   const ResolveObserver& observer;
   const jsg::Url& bundleBase;
@@ -675,6 +685,7 @@ class ModuleRegistry final: public ModuleRegistryBase {
   // One slot for each of ModuleBundle::Type
   kj::Array<kj::Own<ModuleBundle>> bundles_[kBundleCount];
   kj::Maybe<EvalCallback> maybeEvalCallback = kj::none;
+  kj::Own<capnp::SchemaLoader> schemaLoader;
 };
 
 constexpr ModuleRegistry::Builder::Options operator|(


### PR DESCRIPTION
If the worker is using the new module registry, then the registry will provide the schema loader, otherwise one will be created on demand. The schema loader is associated with the context object and will be kept alive as long as the context is alive.

Also addresses a few minor nits from 4848.

This is a follow up to, and builds on #4848