### PR TITLE
Python: `Response`: Handle instance json method

### DIFF
--- a/src/workerd/server/tests/python/sdk/worker.py
+++ b/src/workerd/server/tests/python/sdk/worker.py
@@ -437,6 +437,12 @@ async def response_unit_tests(env):
     response_json = Response.json([1, 2, 3])
     assert await response_json.text() == "[1, 2, 3]"
 
+    response_json = Response.from_json([1, 2, 3])
+    assert await response_json.text() == "[1, 2, 3]"
+
+    response_json = Response("[1, 2, 3]")
+    assert await response_json.json() == [1, 2, 3]
+
     response_json = Response.json("test")
     assert await response_json.text() == '"test"'
 


### PR DESCRIPTION
The JavaScript `json` method is both a static method and an instance method on `Response`. Doing this in Python is awkward and doesn't work correctly with static type checkers. To maintain compatibility, I made `json()` work at runtime as a static method or an instance method. It will only type check when used as an instance method.

I added a new `from_json()` method which is static only and will work as expected with mypy.

I also made as many places as possible return `Response` instead of `FetchResponse`.