### PR TITLE
Don't run worker when creating snapshot with new entrypoint handlers.

### DIFF
--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -297,6 +297,13 @@ function makeEntrypointProxyHandler(
         prop = 'on_' + prop;
       }
 
+      if (!legacyGlobalHandlers && prop === 'test' && SHOULD_SNAPSHOT_TO_DISK) {
+        return async function () {
+          await getPyodide();
+          console.log('Stored snapshot to disk; quitting without running test');
+        };
+      }
+
       return async function (...args: any[]): Promise<any> {
         // Check if the requested method exists and if so, call it.
         const pyInstance = await pyInstancePromise;

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -25,11 +25,7 @@ py_wd_test("random")
 
 py_wd_test("subdirectory")
 
-# TODO(EW-9537): Snapshot disabled due to failure on 0.28
-py_wd_test(
-    "sdk",
-    make_snapshot = False,
-)
+py_wd_test("sdk")
 
 py_wd_test("seek-metadatafs")
 


### PR DESCRIPTION
We perform the same skipping logic for the legacy global handlers, so this just brings it in line with that logic.

That said, there seems to be some bug that this discovered, tracked by EW-9537