### PR TITLE
Update the eventsource test to use the fetcher option

### DIFF
--- a/src/workerd/api/tests/eventsource-test.js
+++ b/src/workerd/api/tests/eventsource-test.js
@@ -282,7 +282,7 @@ export const retryTest = {
 };
 
 export const constructorTest = {
-  test() {
+  test(ctrl, env) {
     throws(() => new EventSource('not a valid url'), {
       name: 'SyntaxError',
       message:
@@ -304,11 +304,15 @@ export const constructorTest = {
     );
 
     // Doesn't throw
-    new EventSource('http://example.org/message').close();
     new EventSource('http://example.org/message', {
+      fetcher: env.subrequest,
+    }).close();
+    new EventSource('http://example.org/message', {
+      fetcher: env.subrequest,
       withCredentials: false,
     }).close();
     new EventSource('http://example.org/message', {
+      fetcher: env.subrequest,
       withCredentials: undefined,
     }).close();
   },


### PR DESCRIPTION
None of the test bits here should actually hit the internet, routing all EventSource instances through the env.subrequest fetcher should redirect those back to the workers own default export.

Old backlogged issue that I finally managed to get around to.