### PR TITLE
EW-9282 EW-9451 Fix missing onset event for JSRpc edge cases, add JSRpc regression test

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -375,6 +375,7 @@ wd_test(
         "tail-worker-test-receiver.js",
         "tail-worker-test-dummy.js",
         "tail-worker-test-invalid.js",
+        "tail-worker-test-jsrpc.js",
         "tests/websocket-hibernation.js",
     ],
 )

--- a/src/workerd/api/tail-worker-test-jsrpc.js
+++ b/src/workerd/api/tail-worker-test-jsrpc.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert';
+import { WorkerEntrypoint } from 'cloudflare:workers';
+
+export class MyService extends WorkerEntrypoint {
+  // Define a property to test behavior of property accessors.
+  get nonFunctionProperty() {
+    // As a regression test for EW-9282, check that logging in a getter invoked via JSRPC is
+    // reflected in traces does not result in missing onset errors. This works through
+    // tail-worker-test, which calls into other tests to get traces from them and includes several
+    // tail worker implementations. See tail-worker-test.js for test output.
+    console.log('foo');
+    return { foo: 123 };
+  }
+}
+
+export default {
+  async test(controller, env, ctx) {
+    let getByName = (name) => {
+      return env.MyService.getRpcMethodForTestOnly(name);
+    };
+
+    // Check what happens if we access something that's actually declared as a property on the
+    // class. The difference in error message proves to us that `env` and `ctx` weren't visible at
+    // all, which is what we want.
+    await assert.rejects(() => getByName('nonFunctionProperty')(), {
+      name: 'TypeError',
+      message: '"nonFunctionProperty" is not a function.',
+    });
+  },
+};

--- a/src/workerd/api/tail-worker-test-receiver.js
+++ b/src/workerd/api/tail-worker-test-receiver.js
@@ -25,7 +25,7 @@ export const test = {
 
     // The shared tail worker we configured only produces onset and outcome events, so every trace is identical here.
     // Number of traces based on how often main tail worker is invoked from previous tests
-    let numTraces = 24;
+    let numTraces = 26;
     let basicTrace =
       '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"trace","traces":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}';
     assert.deepStrictEqual(

--- a/src/workerd/api/tail-worker-test.js
+++ b/src/workerd/api/tail-worker-test.js
@@ -75,6 +75,11 @@ export const test = {
       '{"type":"onset","executionModel":"durableObject","scriptTags":[],"info":{"type":"fetch","method":"GET","url":"http://example.com/hibernation","headers":[{"name":"upgrade","value":"websocket"}]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
       '{"type":"onset","executionModel":"durableObject","scriptTags":[],"info":{"type":"hibernatableWebSocket","info":{"type":"message"}}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
       '{"type":"onset","executionModel":"durableObject","scriptTags":[],"info":{"type":"hibernatableWebSocket","info":{"type":"close","code":1000,"wasClean":true}}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+
+      // tail-worker-test-jsrpc: Regression test for EW-9282 (missing onset event with
+      // JsRpcSessionCustomEventImpl). This is derived from tests/js-rpc-test.js.
+      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"custom"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"jsrpc","methodName":"nonFunctionProperty"}}{"type":"log","level":"log","message":["foo"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
     ];
 
     assert.deepStrictEqual(response, expected);

--- a/src/workerd/api/tail-worker-test.wd-test
+++ b/src/workerd/api/tail-worker-test.wd-test
@@ -33,6 +33,7 @@ const unitTests :Workerd.Config = (
     ),
     (name = "alarms", worker = .alarmsWorker),
     (name = "hiber", worker = .hiberWorker),
+    (name = "js-rpc-test", worker = .jsRpcWorker),
     (name = "TEST_TMPDIR", disk = (writable = true)),
     # Dummy legacy tail worker (gets traces from alarms worker and produces trace for main tracer)
     (name = "legacy", worker = .logLegacy, ),
@@ -93,6 +94,20 @@ const hiberWorker :Workerd.Worker = (
   bindings = [
     (name = "ns", durableObjectNamespace = "DurableObjectExample"),
   ],
+  streamingTails = ["log"],
+);
+
+const jsRpcWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "tail-worker-test-jsrpc.js")
+  ],
+  compatibilityDate = "2024-01-01",
+  compatibilityFlags = ["nodejs_compat", "experimental", "streaming_tail_worker"],
+
+  bindings = [
+    (name = "MyService", service = (name = "js-rpc-test", entrypoint = "MyService")),
+  ],
+
   streamingTails = ["log"],
 );
 


### PR DESCRIPTION
EW-9282 EW-9451 Fix missing onset event for JSRpc edge cases 
If we invoke a customEvent, we should generally report an onset event to the tracer right away. Under the STW model, we must do so if there's any chance for events like spans/logs being generated from JS (this wasn't the case with LTW so far).
For JSRPC, we would only create an onset event after we were able to successfully get a function or property to call, but we may invoke JS code before that (e.g. if a JS getter method produced a log). Accordingly, set the onset as soon as we know the function name to report with it to avoid getting errors based on other events being sent before the onset.
Note that this does result in traces being generated in some error cases (e.g. when a function lookup fails), but this is arguably the right approach, those JsRpcSessionCustomEventImpl invocations shouldn't just disappear.

EW-9282 EW-9451 Add missing JSRPC onset regression test 
Calling a JSRPC getter method would result in "expected onsetSeen; Tail stream onset was not reported" STW errors.
