### PR TITLE
[TD] Add jsg::JsFunction

### DIFF
--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2254,7 +2254,8 @@ class JsMessage;
   V(Map)                                                                                           \
   V(Set)                                                                                           \
   V(Promise)                                                                                       \
-  V(Proxy)
+  V(Proxy)                                                                                         \
+  V(Function)
 
 #define V(Name) class Js##Name;
 JS_TYPE_CLASSES(V)

--- a/src/workerd/jsg/jsvalue-test.c++
+++ b/src/workerd/jsg/jsvalue-test.c++
@@ -77,6 +77,10 @@ struct JsValueContext: public ContextGlobalObject {
     return js.date(0);
   }
 
+  JsValue callFunction(Lock& js, JsFunction fn) {
+    return fn.callNoReceiver(js, js.num(1));
+  }
+
   struct Foo: public Object {
     JSG_RESOURCE_TYPE(Foo) {}
   };
@@ -103,6 +107,7 @@ struct JsValueContext: public ContextGlobalObject {
     JSG_METHOD(getRef);
     JSG_METHOD(getDate);
     JSG_METHOD(checkProxyPrototype);
+    JSG_METHOD(callFunction);
     JSG_NESTED_TYPE(Foo);
   }
 };
@@ -143,6 +148,8 @@ KJ_TEST("simple") {
   e.expectEval("checkProxyPrototype(new Proxy({}, { getPrototypeOf() { return String; } } )) "
                "=== Foo",
       "boolean", "false");
+  e.expectEval("function f(val) { return this == globalThis && val === 1; }; callFunction(f);",
+      "boolean", "true");
 }
 
 }  // namespace

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -25,7 +25,6 @@ inline void requireOnStack(void* self) {
   V(ArgumentsObject)                                                                               \
   V(NativeError)                                                                                   \
   V(Name)                                                                                          \
-  V(Function)                                                                                      \
   V(AsyncFunction)                                                                                 \
   V(GeneratorFunction)                                                                             \
   V(GeneratorObject)                                                                               \
@@ -503,6 +502,46 @@ inline JsObject Lock::opaque(T&& inner) {
   KJ_ASSERT(wrapped->IsObject());
   return JsObject(wrapped.template As<v8::Object>());
 }
+
+class JsFunction final: public JsBase<v8::Function, JsFunction> {
+ public:
+  using JsBase<v8::Function, JsFunction>::JsBase;
+
+  // Calls the function with the given receiver and arguments.
+  template <IsJsValue... Args>
+  JsValue call(Lock& js, const JsValue& recv, Args... args) const {
+    v8::Local<v8::Function> fn = *this;
+    v8::Local<v8::Value> argv[] = {args...};
+    return JsValue(check(fn->Call(js.v8Context(), recv, sizeof...(Args), argv)));
+  }
+
+  // Calls the function with a null receiver and arguments.
+  template <IsJsValue... Args>
+  JsValue callNoReceiver(Lock& js, Args... args) const {
+    return call(js, js.null(), kj::fwd<Args...>(args...));
+  }
+
+  // Calls the function with the given receiver and arguments.
+  JsValue call(Lock& js, const JsValue& recv, v8::LocalVector<v8::Value>& args) const;
+
+  // Calls the function with a null receiver and arguments. When null is passed
+  // as the receiver, the global object is used instead.
+  JsValue callNoReceiver(Lock& js, v8::LocalVector<v8::Value>& args) const;
+
+  // Gets the function's length property.
+  size_t length(Lock& js) const;
+
+  // Gets the function's name property.
+  JsString name(Lock& js) const;
+
+  // Not guaranteed to be unique, but will be the same for the same function.
+  // Use the JsValue strictEquals() method for true identity comparison.
+  uint hashCode() const;
+
+  operator JsObject() const {
+    return JsObject(inner);
+  }
+};
 
 // A persistent handle for a Js* type suitable for storage and GC visitable.
 //


### PR DESCRIPTION
Scratching a long-time itch. Not to be confused with jsg::Function, which is a type-safe wrapper around a JS function that passes arguments and return values through the JSG type wrapper layer, the JsFunction is a thin wrapper around a v8::Function that aligns with jsg::JsValue and friends. This can be used to replace direct uses of v8::Function to simplify calling functions and handling the check(...) for error handling.

(TD == Technical Debt... this probably doesn't strictly qualify but it's something that's been on my backlog for many many months... there are a number of places throughout the code that can be updated to use this to simplify function call sites)