### PR TITLE
Replace jsg::alloc uses with js.alloc

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -215,7 +215,7 @@ kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::request(kj::HttpMetho
   }
 
   auto jsRequest = js.alloc<Request>(js, method, url, Request::Redirect::MANUAL, kj::mv(jsHeaders),
-      jsg::alloc<Fetcher>(IoContext::NEXT_CLIENT_CHANNEL, Fetcher::RequiresHostAndProtocol::YES),
+      js.alloc<Fetcher>(IoContext::NEXT_CLIENT_CHANNEL, Fetcher::RequiresHostAndProtocol::YES),
       /* signal */ kj::mv(abortSignal), kj::mv(cf), kj::mv(body),
       /* thisSignal */ kj::none, Request::CacheMode::NONE);
 

--- a/src/workerd/api/messagechannel.c++
+++ b/src/workerd/api/messagechannel.c++
@@ -43,12 +43,12 @@ MessagePort::MessagePort()
 
 void MessagePort::dispatchMessage(jsg::Lock& js, const jsg::JsValue& value) {
   js.tryCatch([&] {
-    auto message = jsg::alloc<MessageEvent>(js, kj::str("message"), value, kj::String(), JSG_THIS);
+    auto message = js.alloc<MessageEvent>(js, kj::str("message"), value, kj::String(), JSG_THIS);
     dispatchEventImpl(js, kj::mv(message));
   }, [&](jsg::Value exception) {
     // There was an error dispatching the message event.
     // We will dispatch a messageerror event instead.
-    auto message = jsg::alloc<MessageEvent>(
+    auto message = js.alloc<MessageEvent>(
         js, kj::str("message"), jsg::JsValue(exception.getHandle(js)), kj::String(), JSG_THIS);
     dispatchEventImpl(js, kj::mv(message));
     // Now, if this dispatchEventImpl throws, we just blow up. Don't try to catch it.
@@ -190,11 +190,11 @@ void MessagePort::setOnMessage(jsg::Lock& js, jsg::JsValue value) {
   }
 }
 
-jsg::Ref<MessageChannel> MessageChannel::constructor() {
-  auto port1 = jsg::alloc<MessagePort>();
-  auto port2 = jsg::alloc<MessagePort>();
+jsg::Ref<MessageChannel> MessageChannel::constructor(jsg::Lock& js) {
+  auto port1 = js.alloc<MessagePort>();
+  auto port2 = js.alloc<MessagePort>();
   MessagePort::entangle(*port1, *port2);
-  return jsg::alloc<MessageChannel>(kj::mv(port1), kj::mv(port2));
+  return js.alloc<MessageChannel>(kj::mv(port1), kj::mv(port2));
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/messagechannel.h
+++ b/src/workerd/api/messagechannel.h
@@ -150,7 +150,7 @@ class MessageChannel final: public jsg::Object {
       : port1(kj::mv(port1)),
         port2(kj::mv(port2)) {}
 
-  static jsg::Ref<MessageChannel> constructor();
+  static jsg::Ref<MessageChannel> constructor(jsg::Lock& js);
 
   jsg::Ref<MessagePort> getPort1() {
     return port1.addRef();

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -3447,7 +3447,7 @@ void WritableStreamJsController::setup(jsg::Lock& js,
   // because their lifetimes are identical and memory accounting itself has a memory overhead.
   state = js.allocAccounted<WritableStreamDefaultController>(
       sizeof(WritableStreamDefaultController) + sizeof(AbortSignal), js, KJ_ASSERT_NONNULL(owner),
-      jsg::alloc<AbortSignal>());
+      js.alloc<AbortSignal>());
   state.get<Controller>()->setup(js, kj::mv(underlyingSink), kj::mv(queuingStrategy));
 }
 

--- a/src/workerd/jsg/fast-api-test.c++
+++ b/src/workerd/jsg/fast-api-test.c++
@@ -128,8 +128,8 @@ class FastMethodContext: public jsg::Object, public jsg::ContextGlobal {
     }
   }
 
-  jsg::Ref<StaticMethodContainer> newContainer() {
-    return jsg::alloc<StaticMethodContainer>();
+  jsg::Ref<StaticMethodContainer> newContainer(jsg::Lock& js) {
+    return js.alloc<StaticMethodContainer>();
   }
 
   JSG_RESOURCE_TYPE(FastMethodContext) {

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -750,7 +750,7 @@ void WorkerdApi::compileModules(jsg::Lock& lockParam,
         auto emscriptenRuntime =
             api::pyodide::EmscriptenRuntime::initialize(lockParam, true, bundle);
         modules->addBuiltinModule("internal:setup-emscripten",
-            jsg::alloc<SetupEmscripten>(kj::mv(emscriptenRuntime)),
+            lockParam.alloc<SetupEmscripten>(kj::mv(emscriptenRuntime)),
             workerd::jsg::ModuleRegistry::Type::INTERNAL);
       }
 


### PR DESCRIPTION
Doesn't quite get us to where we can delete `jsg::alloc` but closer at least