### PR TITLE
[TD] Update api/base64 to use jsg::BufferSource

### DIFF
--- a/src/workerd/api/base64-test.c++
+++ b/src/workerd/api/base64-test.c++
@@ -8,7 +8,7 @@ namespace workerd::api {
 namespace {
 
 KJ_TEST("base64 encode") {
-  auto t = TestFixture();
+  TestFixture t;
 
   t.runInIoContext([](const workerd::TestFixture::Environment& env) {
     auto b = Base64Module();
@@ -20,7 +20,7 @@ KJ_TEST("base64 encode") {
 }
 
 KJ_TEST("base64 valid decode") {
-  auto t = TestFixture();
+  TestFixture t;
 
   t.runInIoContext([](const workerd::TestFixture::Environment& env) {
     auto b = Base64Module();
@@ -32,7 +32,7 @@ KJ_TEST("base64 valid decode") {
 }
 
 KJ_TEST("base64 invalid decode") {
-  auto t = TestFixture();
+  TestFixture t;
 
   t.runInIoContext([](const workerd::TestFixture::Environment& env) {
     auto b = Base64Module();
@@ -49,7 +49,7 @@ KJ_TEST("base64 invalid decode") {
 }
 
 KJ_TEST("base64 decode as string") {
-  auto t = TestFixture();
+  TestFixture t;
 
   t.runInIoContext([](const workerd::TestFixture::Environment& env) {
     auto b = Base64Module();

--- a/src/workerd/api/base64.c++
+++ b/src/workerd/api/base64.c++
@@ -26,7 +26,7 @@ jsg::BufferSource Base64Module::encodeArray(jsg::Lock& js, jsg::BufferSource inp
   auto out_size = simdutf::binary_to_base64(input.asArrayPtr().asChars().begin(), input.size(),
       buf.asArrayPtr().asChars().begin(), simdutf::base64_default);
   KJ_ASSERT(out_size <= size);
-  buf.trim(size - out_size);
+  buf.limit(out_size);
   return jsg::BufferSource(js, kj::mv(buf));
 }
 

--- a/src/workerd/api/base64.c++
+++ b/src/workerd/api/base64.c++
@@ -6,35 +6,38 @@
 
 namespace workerd::api {
 
-kj::Array<kj::byte> Base64Module::decodeArray(kj::Array<kj::byte> input) {
-  auto size = simdutf::maximal_binary_length_from_base64((const char*)input.begin(), input.size());
-  auto buf = kj::heapArray<kj::byte>(size);
-  auto result = simdutf::base64_to_binary(
-      input.asChars().begin(), input.size(), buf.asChars().begin(), simdutf::base64_default);
+jsg::BufferSource Base64Module::decodeArray(jsg::Lock& js, jsg::BufferSource input) {
+  auto ptr = input.asArrayPtr();
+  auto size = simdutf::maximal_binary_length_from_base64((const char*)ptr.begin(), ptr.size());
+  auto buf = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, size);
+  auto result = simdutf::base64_to_binary(ptr.asChars().begin(), input.size(),
+      buf.asArrayPtr().asChars().begin(), simdutf::base64_default);
   JSG_REQUIRE(result.error == simdutf::SUCCESS, DOMSyntaxError,
       kj::str("Invalid base64 at position ", result.count, ": ",
           simdutf::error_to_string(result.error).data()));
   KJ_ASSERT(result.count <= size);
-  return buf.slice(0, result.count).attach(kj::mv(buf));
+  buf.trim(buf.size() - result.count);
+  return jsg::BufferSource(js, kj::mv(buf));
 }
 
-kj::Array<kj::byte> Base64Module::encodeArray(kj::Array<kj::byte> input) {
+jsg::BufferSource Base64Module::encodeArray(jsg::Lock& js, jsg::BufferSource input) {
   auto size = simdutf::base64_length_from_binary(input.size());
-  auto buf = kj::heapArray<kj::byte>(size);
-  auto out_size = simdutf::binary_to_base64(
-      input.asChars().begin(), input.size(), buf.asChars().begin(), simdutf::base64_default);
+  auto buf = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, size);
+  auto out_size = simdutf::binary_to_base64(input.asArrayPtr().asChars().begin(), input.size(),
+      buf.asArrayPtr().asChars().begin(), simdutf::base64_default);
   KJ_ASSERT(out_size <= size);
-  return buf.slice(0, out_size).attach(kj::mv(buf));
+  buf.trim(size - out_size);
+  return jsg::BufferSource(js, kj::mv(buf));
 }
 
-jsg::JsString Base64Module::encodeArrayToString(jsg::Lock& js, kj::Array<kj::byte> input) {
+jsg::JsString Base64Module::encodeArrayToString(jsg::Lock& js, jsg::BufferSource input) {
+  KJ_ASSERT(input.size() < 256 * 1024 * 1024);
   auto size = simdutf::base64_length_from_binary(input.size());
-  auto buf = kj::heapArray<kj::byte>(size);
-  auto out_size = simdutf::binary_to_base64(
-      input.asChars().begin(), input.size(), buf.asChars().begin(), simdutf::base64_default);
+  auto buf = jsg::BackingStore::alloc(js, size);
+  auto out_size = simdutf::binary_to_base64(input.asArrayPtr().asChars().begin(), input.size(),
+      buf.asArrayPtr().asChars().begin(), simdutf::base64_default);
   KJ_ASSERT(out_size <= size);
-
-  return js.str(buf.first(out_size));
+  return js.str(buf.asArrayPtr().first(out_size));
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/base64.h
+++ b/src/workerd/api/base64.h
@@ -11,14 +11,19 @@ class Base64Module final: public jsg::Object {
   Base64Module() = default;
   Base64Module(jsg::Lock&, const jsg::Url&) {}
 
-  kj::Array<kj::byte> decodeArray(kj::Array<kj::byte>);
-  kj::Array<kj::byte> encodeArray(kj::Array<kj::byte>);
-  jsg::JsString encodeArrayToString(jsg::Lock&, kj::Array<kj::byte>);
+  jsg::BufferSource decodeArray(jsg::Lock& js, jsg::BufferSource source);
+  jsg::BufferSource encodeArray(jsg::Lock& js, jsg::BufferSource source);
+  jsg::JsString encodeArrayToString(jsg::Lock&, jsg::BufferSource source);
 
   JSG_RESOURCE_TYPE(Base64Module) {
     JSG_METHOD(encodeArray);
     JSG_METHOD(decodeArray);
     JSG_METHOD(encodeArrayToString);
+    JSG_TS_OVERRIDE({
+      decodeArray(source: ArrayBuffer | ArrayBufferView): ArrayBuffer;
+      encodeArray(source: ArrayBuffer | ArrayBufferView): ArrayBuffer;
+      encodeArrayToString(source: ArrayBuffer | ArrayBufferView): string;
+    });
   }
 };
 


### PR DESCRIPTION
Avoid an additional copy when returning results to JS by using a jsg::BufferSource as the output type. Since we are running in the v8 sandbox now, kj::Array<kj::byte> allocations that are not backed by a v8::BackingStore are more expensive because they require a copy to get the data into the sandbox.

(`TD` == Technical Debt)