### PR TITLE
fix Buffer.isBuffer returning true for true

### DIFF
--- a/src/node/internal/internal_buffer.ts
+++ b/src/node/internal/internal_buffer.ts
@@ -478,7 +478,7 @@ Object.setPrototypeOf(SlowBuffer.prototype, Uint8Array.prototype);
 Object.setPrototypeOf(SlowBuffer, Uint8Array);
 
 Buffer.isBuffer = function isBuffer(b: unknown): b is Buffer {
-  return b != null && (b as any)[kIsBuffer] && b !== Buffer.prototype;
+  return b instanceof Buffer;
 };
 
 export function compare(a: Buffer | Uint8Array, b: Buffer | Uint8Array) {

--- a/src/workerd/api/node/tests/util-nodejs-test.js
+++ b/src/workerd/api/node/tests/util-nodejs-test.js
@@ -5936,5 +5936,7 @@ export const testEndOfLife = {
     assert.strictEqual(typeof util.isString, 'function');
     assert.strictEqual(typeof util.isSymbol, 'function');
     assert.strictEqual(typeof util.isUndefined, 'function');
+
+    assert.strictEqual(util.isBuffer(true), false);
   },
 };


### PR DESCRIPTION
I'm not sure why we have this implementation in the first place. This new change aligns with Node.js - https://github.com/nodejs/node/blob/27e2d816176e823b79e6f3040fc06eadf70b741a/lib/buffer.js#L551