### PR TITLE
feat: add email queuing compat flag for email sending queuing

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1016,4 +1016,13 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # v8 serialization. More error types are supported, and own properties are included.
   # Note that when enabled, deserialization of the errors will not preserve the original
   # stack by default.
+
+  emailSendingQueuing @116 :Bool
+      $compatEnableFlag("enable_email_sending_queuing")
+      $compatDisableFlag("disable_email_sending_queuing")
+      $experimental;
+  # Enables Queuing on the `.send(message: EmailMessage)` function on send_email binding if there's
+  # a temporary error on email delivery.
+  # Note that by enabling this, user-provided Message-IDs are stripped and
+  # Email Workers will generate and use its own.
 }


### PR DESCRIPTION
Related to EMAIL-1245

On an effort to not break older user workers when send_email queuing is done, we introduce a compat flag `emailSendingQueuing` - this is because email queuing will potentially need some behavior breaking changes (e.g.: managed message-ids).

Marked as experimental for now