### PR TITLE
Restrict JSG_STRUCT from having v8 local members

### DIFF
--- a/src/workerd/api/node/util.c++
+++ b/src/workerd/api/node/util.c++
@@ -132,29 +132,44 @@ jsg::JsArray UtilModule::getOwnNonIndexProperties(jsg::Lock& js, jsg::JsObject v
       js, jsg::KeyCollectionFilter::OWN_ONLY, propertyFilter, jsg::IndexFilter::SKIP_INDICES);
 }
 
-jsg::Optional<UtilModule::PromiseDetails> UtilModule::getPromiseDetails(jsg::JsValue value) {
+jsg::Optional<UtilModule::PromiseDetails> UtilModule::getPromiseDetails(
+    jsg::Lock& js, jsg::JsValue value) {
   auto promise = KJ_UNWRAP_OR_RETURN(value.tryCast<jsg::JsPromise>(), kj::none);
   auto state = promise.state();
   if (state != jsg::PromiseState::PENDING) {
     auto result = promise.result();
-    return PromiseDetails{.state = state, .result = result};
+    return PromiseDetails{
+      .state = state,
+      .result = jsg::JsRef(js, result),
+    };
   } else {
-    return PromiseDetails{.state = state, .result = kj::none};
+    return PromiseDetails{
+      .state = state,
+      .result = kj::none,
+    };
   }
 }
 
-jsg::Optional<UtilModule::ProxyDetails> UtilModule::getProxyDetails(jsg::JsValue value) {
+jsg::Optional<UtilModule::ProxyDetails> UtilModule::getProxyDetails(
+    jsg::Lock& js, jsg::JsValue value) {
   auto proxy = KJ_UNWRAP_OR_RETURN(value.tryCast<jsg::JsProxy>(), kj::none);
   auto target = proxy.target();
   auto handler = proxy.handler();
-  return ProxyDetails{.target = target, .handler = handler};
+  return ProxyDetails{
+    .target = jsg::JsRef(js, target),
+    .handler = jsg::JsRef(js, handler),
+  };
 }
 
-jsg::Optional<UtilModule::PreviewedEntries> UtilModule::previewEntries(jsg::JsValue value) {
+jsg::Optional<UtilModule::PreviewedEntries> UtilModule::previewEntries(
+    jsg::Lock& js, jsg::JsValue value) {
   auto object = KJ_UNWRAP_OR_RETURN(value.tryCast<jsg::JsObject>(), kj::none);
   bool isKeyValue;
   auto entries = object.previewEntries(&isKeyValue);
-  return PreviewedEntries{.entries = entries, .isKeyValue = isKeyValue};
+  return PreviewedEntries{
+    .entries = jsg::JsRef(js, entries),
+    .isKeyValue = isKeyValue,
+  };
 }
 
 jsg::JsString UtilModule::getConstructorName(jsg::Lock& js, jsg::JsObject value) {

--- a/src/workerd/api/node/util.h
+++ b/src/workerd/api/node/util.h
@@ -175,27 +175,27 @@ class UtilModule final: public jsg::Object {
 
   struct PromiseDetails {
     int state;  // TODO: can we make this a `jsg::PromiseState`
-    jsg::Optional<jsg::JsValue> result;
+    jsg::Optional<jsg::JsRef<jsg::JsValue>> result;
 
     JSG_STRUCT(state, result);
   };
-  jsg::Optional<PromiseDetails> getPromiseDetails(jsg::JsValue value);
+  jsg::Optional<PromiseDetails> getPromiseDetails(jsg::Lock& js, jsg::JsValue value);
 
   struct ProxyDetails {
-    jsg::JsValue target;
-    jsg::JsValue handler;
+    jsg::JsRef<jsg::JsValue> target;
+    jsg::JsRef<jsg::JsValue> handler;
 
     JSG_STRUCT(target, handler);
   };
-  jsg::Optional<ProxyDetails> getProxyDetails(jsg::JsValue value);
+  jsg::Optional<ProxyDetails> getProxyDetails(jsg::Lock& js, jsg::JsValue value);
 
   struct PreviewedEntries {
-    jsg::JsArray entries;
+    jsg::JsRef<jsg::JsArray> entries;
     bool isKeyValue;
 
     JSG_STRUCT(entries, isKeyValue);
   };
-  jsg::Optional<PreviewedEntries> previewEntries(jsg::JsValue value);
+  jsg::Optional<PreviewedEntries> previewEntries(jsg::Lock& js, jsg::JsValue value);
 
   jsg::JsString getConstructorName(jsg::Lock& js, jsg::JsObject value);
 

--- a/src/workerd/api/urlpattern-standard.h
+++ b/src/workerd/api/urlpattern-standard.h
@@ -71,8 +71,8 @@ class URLPattern final: public jsg::Object {
   // URLPatternComponentResult API is defined as part of the URLPattern
   // specification.
   struct URLPatternComponentResult final {
-    jsg::JsString input;
-    jsg::JsObject groups;
+    jsg::JsRef<jsg::JsString> input;
+    jsg::JsRef<jsg::JsObject> groups;
 
     JSG_STRUCT(input, groups);
     JSG_STRUCT_TS_OVERRIDE(URLPatternComponentResult {
@@ -85,7 +85,7 @@ class URLPattern final: public jsg::Object {
   // components of a URL. The URLPatternResult API is defined as
   // part of the URLPattern specification.
   struct URLPatternResult final {
-    kj::Array<kj::OneOf<jsg::JsString, URLPatternInit>> inputs;
+    kj::Array<kj::OneOf<jsg::JsRef<jsg::JsString>, URLPatternInit>> inputs;
 #define V(_, name) URLPatternComponentResult name;
     URL_PATTERN_COMPONENTS(V)
 #undef V

--- a/src/workerd/api/worker-loader.c++
+++ b/src/workerd/api/worker-loader.c++
@@ -38,7 +38,7 @@ jsg::Ref<Fetcher> WorkerStub::getEntrypoint(jsg::Lock& js,
 
   KJ_IF_SOME(o, options) {
     KJ_IF_SOME(p, o.props) {
-      props = Frankenvalue::fromJs(js, p);
+      props = Frankenvalue::fromJs(js, p.getHandle(js));
     }
   }
 
@@ -65,7 +65,7 @@ jsg::Ref<DurableObjectClass> WorkerStub::getDurableObjectClass(jsg::Lock& js,
 
   KJ_IF_SOME(o, options) {
     KJ_IF_SOME(p, o.props) {
-      props = Frankenvalue::fromJs(js, p);
+      props = Frankenvalue::fromJs(js, p.getHandle(js));
     }
   }
 

--- a/src/workerd/api/worker-loader.h
+++ b/src/workerd/api/worker-loader.h
@@ -20,7 +20,7 @@ class WorkerStub: public jsg::Object {
   WorkerStub(IoOwn<WorkerStubChannel> channel): channel(kj::mv(channel)) {}
 
   struct EntrypointOptions {
-    jsg::Optional<jsg::JsObject> props;
+    jsg::Optional<jsg::JsRef<jsg::JsObject>> props;
 
     JSG_STRUCT(props);
   };


### PR DESCRIPTION
Make it a compile time error for a JSG_STRUCT to have members that are v8 locals (including JsValues).

It's not entirely safe for a JSG_STRUCT to use v8 locals because the struct may outlive the v8 HandleScope in which the locals were created. Let's enforce it at compile time.

Refs: https://github.com/cloudflare/workerd/pull/4834#discussion_r2298231231