### PR TITLE
Update the comment for the enable_nodejs_http_server_modules flag

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -896,7 +896,6 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatDisableFlag("disable_nodejs_http_server_modules")
       $impliedByAfterDate(name = "enableNodejsHttpModules", date = "2025-09-01");
   # Enables Node.js http server related modules such as node:_http_server
-  # This flag is experimental and may change or be removed in future versions.
   # It is required to use this flag with `enable_nodejs_http_modules` since
   # it enables the usage of http related node.js modules, and this flag enables
   # the methods exposed by the node.js http modules.


### PR DESCRIPTION
@anonrig @jasnell This PR update the comment as the flag is no more experimental (ref #4722)

One thing I note is that the [http](https://developers.cloudflare.com/workers/runtime-apis/nodejs/http/#server-side-methods) and [https](https://developers.cloudflare.com/workers/runtime-apis/nodejs/https/#server-side-methods) docs mention:

<img width="744" height="169" alt="image" src="https://github.com/user-attachments/assets/4368ef40-fec8-4cee-824b-e87ead77b066" />

That does not sound right as I think `enable_nodejs_http_modules` should also be enabled (not sure about the behavior when only the server flag is used?)

If the docs are wrong, could you please create a PR to fix that?

Thanks!