### PR TITLE
[build] 08-28-25 build fixups

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,8 +43,8 @@ build --per_file_copt='external@-Wno-error'
 build --per_file_copt='external/v8@-Wno-unused-function'
 build --per_file_copt='external/zlib@-Wno-unknown-warning-option,-Wno-deprecated-non-prototype'
 build --host_per_file_copt='external/zlib@-Wno-unknown-warning-option,-Wnodeprecated-non-prototype'
-build --per_file_copt=external/protobuf@-Wno-deprecated-this-capture
-build --host_per_file_copt=external/protobuf@-Wno-deprecated-this-capture
+build --per_file_copt=external/protobuf@-Wno-deprecated-declarations
+build --host_per_file_copt=external/protobuf@-Wno-deprecated-declarations
 
 ## simdutf
 build --per_file_copt=external/simdutf@-Wno-unused-const-variable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,7 +310,7 @@ jobs:
         uses: ./.github/actions/setup-runner
       - name: build types
         run: |
-            bazel build --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types:types
+            bazel build --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types
       - name: Build package
         run: node npm/scripts/build-types-package.mjs
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
         uses: ./.github/actions/setup-runner
       - name: build types
         run: |
-          bazel build --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types:types
+          bazel build --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types
       - name: Check snapshot diff
         run: |
           diff -r types/generated-snapshot/latest bazel-bin/types/definitions/latest > types.diff

--- a/build/rust_toolchains.bzl
+++ b/build/rust_toolchains.bzl
@@ -21,10 +21,11 @@ def rust_toolchains():
         edition = "2024",
         extra_target_triples = RUST_TARGET_TRIPLES,
         extra_rustc_flags = {
-            # Enable ISA extensions matching the ones used for C++
-            "x86_64-unknown-linux-gnu": ["-Ctarget-feature=+sse4.2,+clmul"],
-            "x86_64-apple-darwin": ["-Ctarget-feature=+sse4.2,+clmul"],
-            "x86_64-pc-windows-msvc": ["-Ctarget-feature=+sse4.2,+clmul"],
+            # Enable ISA extensions matching the ones used for C++. The clmul feature is included as
+            # it is still "unstable" as of 1.86.0.
+            "x86_64-unknown-linux-gnu": ["-Ctarget-feature=+sse4.2"],
+            "x86_64-apple-darwin": ["-Ctarget-feature=+sse4.2"],
+            "x86_64-pc-windows-msvc": ["-Ctarget-feature=+sse4.2"],
             "aarch64-unknown-linux-gnu": ["-Ctarget-feature=+crc"],
             # No options needed for aarch64-apple-darwin: CRC feature is enabled by default.
         },

--- a/build/wd_ts_type_test.bzl
+++ b/build/wd_ts_type_test.bzl
@@ -13,7 +13,7 @@ def wd_ts_type_test(src, **kwargs):
             "../../definitions/experimental",
         ],
         data = [
-            "//types:types",
+            "//types",
             "//types:test/types/tsconfig.json",
             "//:node_modules/expect-type",
             src,

--- a/justfile
+++ b/justfile
@@ -100,7 +100,7 @@ clippy package="...":
   bazel build //src/rust/{{package}} --config=lint
 
 generate-types:
-  bazel build //types:types
+  bazel build //types
   cp -r bazel-bin/types/definitions/latest types/generated-snapshot/
   cp -r bazel-bin/types/definitions/experimental types/generated-snapshot/
 

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -65,7 +65,7 @@ wd_cc_library(
     srcs = glob(["r2*.c++"]),
     hdrs = glob(["r2*.h"]),
     implementation_deps = [
-        "//src/workerd/api:r2-api_capnp",
+        ":r2-api_capnp",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -348,7 +348,7 @@ kj_test(
 kj_test(
     src = "multiple-typewrappers-test.c++",
     deps = [
+        ":jsg",
         "//src/workerd/io:compatibility-date_capnp",
-        "//src/workerd/jsg",
     ],
 )


### PR DESCRIPTION
- Silence warnings with updated protobuf
- rustc hasn't stabilized the clmul feature with the version we use in workerd yet – drop it for now to avoid warnings
- Simplify bazel target directives

==========

Mostly just getting rid of compiler warnings that started appearing recently.