### PR TITLE
Fix critical error transaction handling in sqlite-backed DOs

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -676,8 +676,18 @@ jsg::JsRef<jsg::JsValue> DurableObjectStorage::transactionSync(
       sqlite.run(SqliteDatabase::TRUSTED, kj::str("RELEASE _cf_sync_savepoint_", depth));
       return kj::mv(result);
     }, [&](jsg::Value exception) -> jsg::JsRef<jsg::JsValue> {
-      sqlite.run(SqliteDatabase::TRUSTED, kj::str("ROLLBACK TO _cf_sync_savepoint_", depth));
-      sqlite.run(SqliteDatabase::TRUSTED, kj::str("RELEASE _cf_sync_savepoint_", depth));
+      if (sqlite.observedCriticalError()) {
+        // The database has observed a critical error that forced an automatic rollback.  SQLite
+        // docs recommend attempting an explicit rollback, even though it is expected to fail due
+        // to missing savepoints.
+        kj::runCatchingExceptions([&]() {
+          sqlite.run(SqliteDatabase::TRUSTED, kj::str("ROLLBACK TO _cf_sync_savepoint_", depth));
+          sqlite.run(SqliteDatabase::TRUSTED, kj::str("RELEASE _cf_sync_savepoint_", depth));
+        });
+      } else {
+        sqlite.run(SqliteDatabase::TRUSTED, kj::str("ROLLBACK TO _cf_sync_savepoint_", depth));
+        sqlite.run(SqliteDatabase::TRUSTED, kj::str("RELEASE _cf_sync_savepoint_", depth));
+      }
       js.throwException(kj::mv(exception));
     });
   } else {

--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -673,6 +673,12 @@ jsg::JsRef<jsg::JsValue> DurableObjectStorage::transactionSync(
     sqlite.run(SqliteDatabase::TRUSTED, kj::str("SAVEPOINT _cf_sync_savepoint_", depth));
     return js.tryCatch([&]() {
       auto result = callback(js);
+
+      // In the case of critical errors, we throw an exception to attempt rollback and convey
+      // failure to the caller of transactionSync(), even if the callback did not throw.
+      JSG_REQUIRE(!sqlite.observedCriticalError(), Error,
+          "Cannot commit transaction due to an earlier SQL critical error");
+
       sqlite.run(SqliteDatabase::TRUSTED, kj::str("RELEASE _cf_sync_savepoint_", depth));
       return kj::mv(result);
     }, [&](jsg::Value exception) -> jsg::JsRef<jsg::JsValue> {

--- a/src/workerd/api/sql-test.js
+++ b/src/workerd/api/sql-test.js
@@ -1708,8 +1708,9 @@ export let testCriticalErrorOnTransactionRollback = {
     let stub = env.ns.get(id);
     await stub.createStringTable();
 
-    // TODO(now): this call should rethrow the broken exception, but doesn't:
-    await stub.runActorFunc('doCriticalErrorOnTransactionRollback');
+    await assert.rejects(async () => {
+      await stub.runActorFunc('doCriticalErrorOnTransactionRollback');
+    }, /^Error: database or disk is full: SQLITE_FULL/);
 
     // Get a new stub since the old stub is broken due to critical error
     stub = env.ns.get(id);

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -181,6 +181,7 @@ kj::Maybe<kj::Promise<void>> ActorSqlite::ExplicitTxn::commit() {
 }
 
 kj::Promise<void> ActorSqlite::ExplicitTxn::rollback() {
+  actorSqlite.requireNotBroken();
   JSG_REQUIRE(!hasChild, Error,
       "Cannot roll back an outer transaction while a nested transaction is still running.");
   if (!committed) {

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -205,13 +205,14 @@ void ActorSqlite::onCriticalError(
     kj::StringPtr errorMessage, kj::Maybe<kj::Exception> maybeException) {
   // If we have already experienced a terminal exception, no need to replace it
   if (broken == kj::none) {
-    // TODO(someday): If we are setting the broken exception, do we also need to explicitly break
-    // the output gate?
     kj::Exception exception = kj::mv(maybeException).orDefault([&]() {
       return JSG_KJ_EXCEPTION(FAILED, Error, errorMessage);
     });
     exception.setDescription(kj::str("broken.outputGateBroken; ", exception.getDescription()));
-    broken.emplace(kj::mv(exception));
+    broken.emplace(kj::cp(exception));
+
+    // Also ensure output gate is explicitly broken.
+    commitTasks.add(outputGate.lockWhile(kj::Promise<void>(kj::mv(exception))));
   }
 }
 

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -206,14 +206,11 @@ void ActorSqlite::onCriticalError(
   if (broken == kj::none) {
     // TODO(someday): If we are setting the broken exception, do we also need to explicitly break
     // the output gate?
-    KJ_IF_SOME(e, maybeException) {
-      e.setDescription(kj::str("broken.outputGateBroken; ", e.getDescription()));
-      broken.emplace(kj::mv(e));
-    } else {
-      kj::Exception exception = JSG_KJ_EXCEPTION(FAILED, Error, errorMessage);
-      exception.setDescription(kj::str("broken.outputGateBroken; ", exception.getDescription()));
-      broken.emplace(kj::mv(exception));
-    }
+    kj::Exception exception = kj::mv(maybeException).orDefault([&]() {
+      return JSG_KJ_EXCEPTION(FAILED, Error, errorMessage);
+    });
+    exception.setDescription(kj::str("broken.outputGateBroken; ", exception.getDescription()));
+    broken.emplace(kj::mv(exception));
   }
 }
 

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -1588,9 +1588,11 @@ void testCriticalError(const char* expectedErrorMessage,
     }
   });
 
+  KJ_EXPECT(!db.observedCriticalError());
   KJ_EXPECT_THROW_MESSAGE(expectedErrorMessage, triggerErrorFn(db, vfs));
 
   KJ_EXPECT(criticalErrorCallbackCalled);
+  KJ_EXPECT(db.observedCriticalError());
 }
 
 KJ_TEST("SQLite critical error handling for SQLITE_IOERR") {
@@ -1626,11 +1628,13 @@ KJ_TEST("SQLite critical error handling for SQLITE_IOERR") {
   // Now arrange for an error on write().
   KJ_ASSERT_NONNULL(dir->dbFile)->error = KJ_EXCEPTION(FAILED, "test-vfs-error");
 
+  KJ_EXPECT(!db.observedCriticalError());
   KJ_EXPECT_THROW_MESSAGE("test-vfs-error", db.run(SqliteDatabase::TRUSTED, kj::str(R"(
     INSERT INTO things(value) VALUES (456);
   )")));
 
   KJ_EXPECT(criticalErrorCallbackCalled);
+  KJ_EXPECT(db.observedCriticalError());
 }
 
 // No test for SQLITE_BUSY as a critical error because we haven't been able to figure out how to

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -203,11 +203,18 @@ class SqliteDatabase {
     onWriteCallback = kj::mv(callback);
   }
 
+  // Invokes the given callback when a "critical error" causes an automatic rollback during a
+  // transaction.
+  //
+  // See: https://www.sqlite.org/lang_transaction.html#response_to_errors_within_a_transaction
   void onCriticalError(
       kj::Function<void(kj::StringPtr errorMessage, kj::Maybe<kj::Exception> maybeException)>
           callback) {
     onCriticalErrorCallback = kj::mv(callback);
   }
+
+  // Returns true if a transaction was automatically rolled due to a critical error.
+  bool observedCriticalError();
 
   // Invoke the onWrite() callback.
   //
@@ -319,6 +326,7 @@ class SqliteDatabase {
   // Set while a statement is executing.
   kj::Maybe<sqlite3_stmt&> currentStatement;
 
+  bool criticalErrorOccurred = false;
   kj::Maybe<kj::Function<void()>> onWriteCallback;
   kj::Maybe<kj::Function<void(kj::StringPtr errorMessage, kj::Maybe<kj::Exception> maybeException)>>
       onCriticalErrorCallback;


### PR DESCRIPTION
When sqlite encounters certain "critical errors" during a transaction (like when the db exceeds available storage), it may automatically roll back the transaction.  We already have code that attempts to handle rollbacks due to critical errors, but it interacts poorly with the savepoint-based explicit transactions set up by `.transaction()` and `.transactionSync()`, triggering "no such savepoint" internal errors when it attempts to commit or roll back a savepoint that had already been removed.  This PR updates the handling to suppress failures due to missing savepoints after critical errors.

It also addresses an edge case where a critical error during an explicit `.transaction()` did not propagate a broken exception to the caller.