### PR TITLE
EW-9282 EW-9451 Further fix errors with Onset event being reported too late

### DIFF
--- a/src/workerd/api/tail-worker-test-jsrpc.js
+++ b/src/workerd/api/tail-worker-test-jsrpc.js
@@ -11,6 +11,14 @@ export class MyService extends WorkerEntrypoint {
     console.log('foo');
     return { foo: 123 };
   }
+
+  constructor(ctx, env) {
+    // As a regression test for EW-9282, check that logging in the constructor does not result in
+    // missing onset errors. This requires setting the onset event early on, before getting a
+    // handler to the entrypoint.
+    console.log('bar');
+    super(ctx, env);
+  }
 }
 
 export default {

--- a/src/workerd/api/tail-worker-test.js
+++ b/src/workerd/api/tail-worker-test.js
@@ -84,7 +84,7 @@ export const test = {
       // tail-worker-test-jsrpc: Regression test for EW-9282 (missing onset event with
       // JsRpcSessionCustomEventImpl). This is derived from tests/js-rpc-test.js.
       '{"type":"onset","executionModel":"stateless","scriptTags":[],"info":{"type":"custom"}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
-      '{"type":"onset","executionModel":"stateless","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc","methodName":"nonFunctionProperty"}}{"type":"log","level":"log","message":["foo"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc","methodName":"nonFunctionProperty"}}{"type":"log","level":"log","message":["bar"]}{"type":"log","level":"log","message":["foo"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
     ];
 
     assert.deepStrictEqual(response, expected);


### PR DESCRIPTION
In #4881, we fixed the missing/delayed Onset issue for some cases, but to handle logs etc. being created in constructors we need to set the event before invoking JS at all. This requires some slight code duplication so we can access the method name in time.