### PR TITLE
Move Worker::Api agonostic module registry init code out

### DIFF
--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -133,6 +133,21 @@ wd_cc_library(
     ],
 )
 
+wd_cc_library(
+    name = "worker-modules",
+    hdrs = ["worker-modules.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":io",
+        "//src/pyodide:pyodide_static",
+        "//src/pyodide:python-entrypoint",
+        "//src/workerd/api:pyodide",
+        "//src/workerd/api:rtti",
+        "//src/workerd/api/node",
+        "//src/workerd/jsg",
+    ],
+)
+
 # TODO(cleanup): Split this up further.
 wd_cc_library(
     name = "actor",

--- a/src/workerd/io/worker-modules.h
+++ b/src/workerd/io/worker-modules.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <workerd/api/commonjs.h>
+#include <workerd/api/modules.h>
+#include <workerd/io/io-context.h>
+#include <workerd/io/worker.h>
+#include <workerd/jsg/modules-new.h>
+#include <workerd/util/strong-bool.h>
+
+#include <pyodide/python-entrypoint.embed.h>
+
+namespace workerd {
+
+WD_STRONG_BOOL(IsPythonWorker);
+
+// Creates an instance of the (new) ModuleRegistry. This method provides the
+// initialization logic that is agnostic to the Worker::Api implementation,
+// but accepts a callback parameter to handle the Worker::Api-specific details.
+template <typename TypeWrapper>
+static kj::Arc<jsg::modules::ModuleRegistry> newWorkerModuleRegistry(
+    const jsg::ResolveObserver& resolveObserver,
+    kj::Maybe<const Worker::Script::ModulesSource&> maybeSource,
+    const CompatibilityFlags::Reader& featureFlags,
+    const jsg::Url& bundleBase,
+    auto setupForApi,
+    jsg::modules::ModuleRegistry::Builder::Options options) {
+  jsg::modules::ModuleRegistry::Builder builder(resolveObserver, bundleBase, options);
+
+  // This callback is used when a module is being loaded to arrange evaluating the
+  // module outside of the current IoContext.
+  builder.setEvalCallback([](jsg::Lock& js, const auto& module, auto v8Module,
+                              const auto& observer) -> jsg::Promise<jsg::Value> {
+    return js.tryOrReject<jsg::Value>([&] {
+      // Creating the SuppressIoContextScope here ensures that the current IoContext,
+      // if any, is moved out of the way while we are evaluating.
+      SuppressIoContextScope suppressIoContextScope;
+      KJ_DASSERT(!IoContext::hasCurrent(), "Module evaluation must not be in an IoContext");
+      return jsg::check(v8Module->Evaluate(js.v8Context()));
+    });
+  });
+
+  // Add the module bundles that are built into the runtime.
+  api::registerBuiltinModules<TypeWrapper>(builder, featureFlags);
+
+  bool hasPythonModules = false;
+
+  // Add the module bundles that are configured by the worker (if any)
+  // The only case where maybeSource is none is when the worker is using
+  // the old service worker script format or "inherit", in which case
+  // we will initialize a module registry with the built-ins, extensions,
+  // etc but no worker bundle modules will be added.
+  KJ_IF_SOME(source, maybeSource) {
+    // Register any capnp schemas contained in the source bundle
+    auto& schemaLoader = builder.getSchemaLoader();
+    for (auto schema: source.capnpSchemas) {
+      schemaLoader.load(schema);
+    }
+
+    jsg::modules::ModuleBundle::BundleBuilder bundleBuilder(bundleBase);
+    bool firstEsm = true;
+    using namespace workerd::api::pyodide;
+
+    for (auto& def: source.modules) {
+      KJ_SWITCH_ONEOF(def.content) {
+        KJ_CASE_ONEOF(content, Worker::Script::EsModule) {
+          jsg::modules::Module::Flags flags = jsg::modules::Module::Flags::ESM;
+          // Only the first ESM module we encounter is the main module.
+          // This should also be the first module in the list but we're
+          // not enforcing that here.
+          if (firstEsm) {
+            flags = flags | jsg::modules::Module::Flags::MAIN;
+            firstEsm = false;
+          }
+          // The content.body is memory-resident and is expected to outlive the
+          // module registry. We can safely pass a reference to the module handler.
+          // It will not be copied into a JS string until the module is actually
+          // evaluated.
+          bundleBuilder.addEsmModule(def.name, content.body, flags);
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::TextModule) {
+          // The content.body is memory-resident and is expected to outlive the
+          // module registry. We can safely pass a reference to the module handler.
+          // It will not be copied into a JS string until the module is actually
+          // evaluated.
+          bundleBuilder.addSyntheticModule(
+              def.name, jsg::modules::Module::newTextModuleHandler(content.body));
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::DataModule) {
+          // The content.body is memory-resident and is expected to outlive the
+          // module registry. We can safely pass a reference to the module handler.
+          // It will not be copied into a JS string until the module is actually
+          // evaluated.
+          bundleBuilder.addSyntheticModule(
+              def.name, jsg::modules::Module::newDataModuleHandler(content.body));
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::WasmModule) {
+          // The content.body is memory-resident and is expected to outlive the
+          // module registry. We can safely pass a reference to the module handler.
+          // It will not be copied into a JS string until the module is actually
+          // evaluated.
+          bundleBuilder.addSyntheticModule(
+              def.name, jsg::modules::Module::newWasmModuleHandler(content.body));
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::JsonModule) {
+          // The content.body is memory-resident and is expected to outlive the
+          // module registry. We can safely pass a reference to the module handler.
+          // It will not be copied into a JS string until the module is actually
+          // evaluated.
+          bundleBuilder.addSyntheticModule(
+              def.name, jsg::modules::Module::newJsonModuleHandler(content.body));
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::CommonJsModule) {
+          kj::ArrayPtr<const kj::StringPtr> named;
+          KJ_IF_SOME(n, content.namedExports) {
+            named = n;
+          }
+          bundleBuilder.addSyntheticModule(def.name,
+              jsg::modules::Module::newCjsStyleModuleHandler<api::CommonJsModuleContext,
+                  TypeWrapper>(content.body, def.name),
+              KJ_MAP(name, named) { return kj::str(name); });
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::PythonModule) {
+          KJ_REQUIRE(featureFlags.getPythonWorkers(),
+              "The python_workers compatibility flag is required to use Python.");
+          firstEsm = false;
+          hasPythonModules = true;
+          kj::StringPtr entry = PYTHON_ENTRYPOINT;
+          bundleBuilder.addEsmModule(def.name, entry);
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::PythonRequirement) {
+          // Handled separately
+          break;
+        }
+        KJ_CASE_ONEOF(content, Worker::Script::CapnpModule) {
+          KJ_FAIL_REQUIRE("capnp modules are not yet supported in workerd");
+        }
+      }
+    }
+
+    builder.add(bundleBuilder.finish());
+  }
+
+  // Now perform any Worker::Api-specific setup.
+  setupForApi(builder, hasPythonModules ? IsPythonWorker::YES : IsPythonWorker::NO);
+
+  // All done!
+  return builder.finish();
+}
+
+}  // namespace workerd

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -159,6 +159,7 @@ wd_cc_library(
         "//src/workerd/api:rtti",
         "//src/workerd/api/node",
         "//src/workerd/io",
+        "//src/workerd/io:worker-modules",
         "//src/workerd/jsg",
         "//src/workerd/util:perfetto",
         "@capnp-cpp//src/kj/compat:kj-gzip",

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -4265,7 +4265,7 @@ kj::Promise<kj::Own<Server::WorkerService>> Server::makeWorkerImpl(kj::StringPtr
         ? ArtifactBundler::makePackagesOnlyBundler(pythonConfig.pyodidePackageManager)
         : ArtifactBundler::makeDisabledBundler();
 
-    newModuleRegistry = WorkerdApi::initializeBundleModuleRegistry(*jsgobserver,
+    newModuleRegistry = WorkerdApi::newWorkerdModuleRegistry(*jsgobserver,
         def.source.variant.tryGet<Worker::Script::ModulesSource>(), def.featureFlags, pythonConfig,
         bundleBase, extensions, kj::mv(maybeFallbackService), kj::mv(artifactBundler));
   }

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -335,7 +335,7 @@ class WorkerdApi final: public Worker::Api {
   void setModuleFallbackCallback(kj::Function<ModuleFallbackCallback>&& callback) const override;
 
   // Create the ModuleRegistry instance for the worker.
-  static kj::Arc<jsg::modules::ModuleRegistry> initializeBundleModuleRegistry(
+  static kj::Arc<jsg::modules::ModuleRegistry> newWorkerdModuleRegistry(
       const jsg::ResolveObserver& resolveObserver,
       kj::Maybe<const Worker::Script::ModulesSource&> source,
       const CompatibilityFlags::Reader& featureFlags,


### PR DESCRIPTION
builds on #4932 which must land first ... part of the new module registry work

Separates out the bits of the new module registry initialization logic into a new `worker-modules.h` header that can be shared with the internal project too.