### PR TITLE
STOR-4395 Improve span parenting for Hibernate events, add TODOs for other events

### DIFF
--- a/src/workerd/api/hibernatable-web-socket.c++
+++ b/src/workerd/api/hibernatable-web-socket.c++
@@ -107,6 +107,8 @@ kj::Promise<WorkerInterface::CustomEvent::Result> HibernatableWebSocketCustomEve
     co_await context.run(
         [entrypointName = entrypointName, &context, eventParameters = kj::mv(eventParameters),
             props = kj::mv(props)](Worker::Lock& lock) mutable {
+      jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+
       KJ_SWITCH_ONEOF(eventParameters.eventType) {
         KJ_CASE_ONEOF(text, HibernatableSocketParams::Text) {
           return lock.getGlobalScope().sendHibernatableWebSocketMessage(kj::mv(text.message),

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -936,6 +936,10 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
           // Note: No need to topUpActor() since this is the start of a top-level request, so the
           // actor will already have been topped up by IncomingRequest::delivered().
           return ctx.run([this, &ctx, callContext](Worker::Lock& lock) mutable {
+            // TODO(later): Create trace scope for STOR-4395. Is this the right place to do so, or
+            // should we try to do it earlier to capture any spans created in a constructor using
+            // Actor::ensureConstructed())?
+            jsg::AsyncContextFrame::StorageScope traceScope = ctx.makeAsyncTraceScope(lock);
             return callImpl(lock, ctx, callContext);
           });
         }) {}

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1049,8 +1049,6 @@ SpanParent IoContext::getCurrentTraceSpan() {
 }
 
 SpanParent IoContext::getCurrentUserTraceSpan() {
-  // TODO(o11y): Add support for retrieving span from storage scope lock for more accurate span
-  // context, as with Jaeger spans.
   KJ_IF_SOME(workerTracer, getWorkerTracer()) {
     return workerTracer.getUserRequestSpan();
   }

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -612,6 +612,9 @@ class TailStreamTarget final: public rpc::TailStreamTarget::Server {
         ioContext
             .run([this, &ioContext, reportContext, ownReportContext = kj::mv(ownReportContext)](
                      Worker::Lock& lock) mutable -> kj::Promise<void> {
+      // TODO(later): STOR-4395 This method is generally called several times in a single
+      // customEvent. Should an async trace scope be created each time?
+
       auto params = reportContext.getParams();
       KJ_ASSERT(params.hasEvents(), "Events are required.");
       auto eventReaders = params.getEvents();


### PR DESCRIPTION
For some customEvents, we did not create trace scopes so far. Note that this only affects the internal tracing system.