### PR TITLE
Preserve Rpc properties from throwing after failed type conversion

### DIFF
--- a/src/pyodide/internal/_workers.py
+++ b/src/pyodide/internal/_workers.py
@@ -934,6 +934,9 @@ class _FetcherWrapper:
         if not callable(attr):
             return attr
 
+        if hasattr(attr, "__workflow_entrypoint"):
+            return attr
+
         # Not using `@functools.wraps(attr)` here because `attr` is a JS proxy.
         async def wrapper(*args, **kwargs):
             js_args = [python_to_rpc(arg) for arg in args]

--- a/src/workerd/server/tests/python/workflow-entrypoint/worker.js
+++ b/src/workerd/server/tests/python/workflow-entrypoint/worker.js
@@ -1,4 +1,4 @@
-import { RpcTarget } from 'cloudflare:workers';
+import { RpcTarget, WorkflowEntrypoint } from 'cloudflare:workers';
 import * as assert from 'node:assert';
 
 class Context extends RpcTarget {
@@ -11,6 +11,16 @@ class Context extends RpcTarget {
       // let's rethrow here since the engine does the same
       throw e;
     }
+  }
+}
+
+export class WorkflowEntrypointTester extends WorkflowEntrypoint {
+  __workflow_entrypoint = true;
+  async run() {
+    const step = new Context();
+    return await step.do('foo', async () => {
+      return 'bar';
+    });
   }
 }
 

--- a/src/workerd/server/tests/python/workflow-entrypoint/workflow-entrypoint.wd-test
+++ b/src/workerd/server/tests/python/workflow-entrypoint/workflow-entrypoint.wd-test
@@ -18,6 +18,7 @@ const pyWorker :Workerd.Worker = (
 
   bindings = [
     (name = "PythonWorkflow", service = (name = "py", entrypoint = "WorkflowEntrypointExample")),
+    (name = "MY_WORKFLOW", service = (name = "js", entrypoint = "WorkflowEntrypointTester")),
   ],
 );
 

--- a/src/workerd/server/tests/python/workflow-entrypoint/workflow.py
+++ b/src/workerd/server/tests/python/workflow-entrypoint/workflow.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache 2.0 license found in the LICENSE file or at:
 #     https://opensource.org/licenses/Apache-2.0
 
-from workers import WorkflowEntrypoint
+from workers import WorkflowEntrypoint, WorkerEntrypoint
 
 
 class WorkflowEntrypointExample(WorkflowEntrypoint):
@@ -63,5 +63,6 @@ class WorkflowEntrypointExample(WorkflowEntrypoint):
         return await await_step(step_5)
 
 
-async def test(ctrl, env, ctx):
-    pass
+class Default(WorkerEntrypoint):
+    async def test(self, ctrl, env, ctx):
+        await self.env.MY_WORKFLOW.run()


### PR DESCRIPTION
Since some bindings return nested rpc properties, we ignore type translation on return values that contain rpc stubs. Not doing so would result in errors being thrown when returning from some rpc calls (e.g.: within a workflow binding).

This workaround skips type conversions on the workflow local binding. We inject a dummy field on Miniflare's binding and consume it on the env wrapper. 

As such, this PR depends on https://github.com/cloudflare/workers-sdk/pull/10545
