### PR TITLE
emit uncaughtException for global error events - DRAFT

### DIFF
--- a/src/workerd/api/node/tests/process-nodejs-test.js
+++ b/src/workerd/api/node/tests/process-nodejs-test.js
@@ -784,6 +784,15 @@ export const processRejectionListeners = {
       const { promise: promise2 } = await handledPromise;
       assert.strictEqual(promise, promise2);
     }
+
+    {
+      let uncaughtException;
+      process.on('uncaughtException', (exc) => {
+        uncaughtException = exc;
+      });
+      reportError(new Error('unhandled error'));
+      assert.strictEqual(uncaughtException.message, 'unhandled error');
+    }
   },
 };
 


### PR DESCRIPTION
This forwards global `error` events to the `process` `uncaughtException` event handler.

It's still not clear if this is the right behaviour, since it's the first time considering the interaction of `reportError` in the browser with `uncaughtException` on process and given that there are currently no other cases of global error events.