### PR TITLE
process.stderr to use console.debug, with DEBUG level to stderr

### DIFF
--- a/src/workerd/io/worker-fs.c++
+++ b/src/workerd/io/worker-fs.c++
@@ -1758,7 +1758,7 @@ void writeStdio(jsg::Lock& js, VirtualFileSystem::Stdio type, kj::ArrayPtr<const
   if (chars[endPos - 1] == '\n') endPos--;
 
   KJ_IF_SOME(console, js.global().get(js, "console"_kj).tryCast<jsg::JsObject>()) {
-    auto method = console.get(js, type == VirtualFileSystem::Stdio::OUT ? "log"_kj : "error"_kj);
+    auto method = console.get(js, type == VirtualFileSystem::Stdio::OUT ? "log"_kj : "debug"_kj);
     if (method.isFunction()) {
       v8::Local<v8::Value> methodVal(method);
       auto methodFunc = methodVal.As<v8::Function>();

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1949,7 +1949,7 @@ void Worker::handleLog(jsg::Lock& js,
 
     // Log warnings and errors to stderr
     // Always log to stdout when structuredLogging is enabled.
-    auto useStderr = level == LogLevel::DEBUG_ || level >= LogLevel::WARN && !structuredLogging;
+    auto useStderr = level == LogLevel::DEBUG_ || (level >= LogLevel::WARN && !structuredLogging);
     auto fd = useStderr ? stderr : stdout;
     auto tty = useStderr ? STDERR_TTY : STDOUT_TTY;
     auto colors =

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1949,7 +1949,7 @@ void Worker::handleLog(jsg::Lock& js,
 
     // Log warnings and errors to stderr
     // Always log to stdout when structuredLogging is enabled.
-    auto useStderr = level >= LogLevel::WARN && !structuredLogging;
+    auto useStderr = level == LogLevel::DEBUG_ || level >= LogLevel::WARN && !structuredLogging;
     auto fd = useStderr ? stderr : stdout;
     auto tty = useStderr ? STDERR_TTY : STDOUT_TTY;
     auto colors =

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1949,7 +1949,7 @@ void Worker::handleLog(jsg::Lock& js,
 
     // Log warnings and errors to stderr
     // Always log to stdout when structuredLogging is enabled.
-    auto useStderr = level == LogLevel::DEBUG_ || (level >= LogLevel::WARN && !structuredLogging);
+    auto useStderr = (level == LogLevel::DEBUG_ || level >= LogLevel::WARN) && !structuredLogging;
     auto fd = useStderr ? stderr : stdout;
     auto tty = useStderr ? STDERR_TTY : STDOUT_TTY;
     auto colors =

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -5180,9 +5180,9 @@ KJ_TEST("Server: structured logging with console methods") {
     KJ_ASSERT(logline.contains(R"("message":"logged")"), logline);
   });
 
-  // process.stderr should be info
+  // process.stderr should be debug
   expectLogLine(interceptorPipe.output.get(), [](kj::StringPtr logline) {
-    KJ_ASSERT(logline.contains(R"("level":"error")"), logline);
+    KJ_ASSERT(logline.contains(R"("level":"debug")"), logline);
     KJ_ASSERT(logline.contains(R"("message":"stderr")"), logline);
   });
 
@@ -5195,7 +5195,7 @@ KJ_TEST("Server: structured logging with console methods") {
   });
 
   expectLogLine(interceptorPipe.output.get(), [](kj::StringPtr logline) {
-    KJ_ASSERT(logline.contains(R"("level":"error")"), logline);
+    KJ_ASSERT(logline.contains(R"("level":"debug")"), logline);
     KJ_ASSERT(logline.contains(R"("message":"after await")"), logline);
   });
 }


### PR DESCRIPTION
Another process follow-on that we determined could be made as an incremental improvement post-unflagging.

Instead of treating `process.stderr` as a `console.error` instead treating `process.stderr` as a `console.debug` call.

In addition, this updates the STDOUT ConsoleMode to use stderr when outputting `LogLevel::DEBUG_` in workerd server.

This seems to more closely align with the semantic meaning of stderr but we would need to verify the DX here.