### PR TITLE
replacing std::copy with ArrayPtr::copyFrom

### DIFF
--- a/src/workerd/api/crypto/rsa.c++
+++ b/src/workerd/api/crypto/rsa.c++
@@ -182,8 +182,7 @@ jsg::BufferSource Rsa::cipher(jsg::Lock& js,
 
     JSG_REQUIRE(labelCopy != nullptr, DOMOperationError,
         "Failed to allocate space for RSA-OAEP label copy", tryDescribeOpensslErrors());
-    auto ptr = l.asArrayPtr();
-    std::copy(ptr.begin(), ptr.end(), labelCopy);
+    kj::arrayPtr(labelCopy, l.size()).copyFrom(l.asArrayPtr());
 
     // EVP_PKEY_CTX_set0_rsa_oaep_label below takes ownership of the buffer passed in (must have
     // been OPENSSL_malloc-allocated).

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -2769,14 +2769,10 @@ class AllReader {
   }
 
   void copyInto(kj::ArrayPtr<byte> out, PartList in) {
-    size_t pos = 0;
-    auto dest = out.begin();
     for (auto& part: in) {
-      KJ_ASSERT(part.size() <= out.size() - pos);
-      auto ptr = part.begin();
-      std::copy(ptr, ptr + part.size(), dest);
-      pos += part.size();
-      dest += part.size();
+      KJ_ASSERT(part.size() <= out.size());
+      out.first(part.size()).copyFrom(part);
+      out = out.slice(part.size());
     }
   }
 };


### PR DESCRIPTION
copyFrom throws nice exception rather than aborts the process in case of overlapping memory