### PR TITLE
add node:console implementation

### DIFF
--- a/src/node/console.ts
+++ b/src/node/console.ts
@@ -1,0 +1,74 @@
+import { ERR_METHOD_NOT_IMPLEMENTED } from 'node-internal:internal_errors';
+import type {
+  Console as _Console,
+  ConsoleConstructorOptions,
+} from 'node:console';
+
+export function Console(_options: ConsoleConstructorOptions): Console {
+  throw new ERR_METHOD_NOT_IMPLEMENTED('Console');
+}
+
+export const log = console.log.bind(console);
+Console.log = log;
+export const info = console.info.bind(console);
+Console.info = info;
+export const debug = console.debug.bind(console);
+Console.debug = debug;
+export const warn = console.warn.bind(console);
+Console.warn = warn;
+export const error = console.error.bind(console);
+Console.error = error;
+export const dir = console.dir.bind(console);
+Console.dir = dir;
+export const time = console.time.bind(console);
+Console.time = time;
+export const timeEnd = console.timeEnd.bind(console);
+Console.timeEnd = timeEnd;
+export const timeLog = console.timeLog.bind(console);
+Console.timeLog = timeLog;
+export const trace = console.trace.bind(console);
+Console.trace = trace;
+export const assert = console.assert.bind(console);
+Console.assert = assert;
+export const clear = console.clear.bind(console);
+Console.clear = clear;
+export const count = console.count.bind(console);
+Console.count = count;
+export const countReset = console.countReset.bind(console);
+Console.countReset = countReset;
+export const group = console.group.bind(console);
+Console.group = group;
+export const groupEnd = console.groupEnd.bind(console);
+Console.groupEnd = groupEnd;
+export const table = console.table.bind(console);
+Console.table = table;
+
+export const dirxml = console.dirxml.bind(console);
+Console.dirxml = dirxml;
+export const groupCollapsed = console.groupCollapsed.bind(console);
+Console.groupCollapsed = groupCollapsed;
+export const profile = console.profile.bind(console);
+Console.profile = profile;
+export const profileEnd = console.profileEnd.bind(console);
+Console.profileEnd = profileEnd;
+export const timeStamp = console.timeStamp.bind(console);
+Console.timeStamp = timeStamp;
+
+export function context(): void {
+  throw new ERR_METHOD_NOT_IMPLEMENTED('Console.context');
+}
+Console.context = context;
+
+export function createTask(): void {
+  throw new ERR_METHOD_NOT_IMPLEMENTED('Console.createTask');
+}
+Console.createTask = createTask;
+
+// We want to make sure the following works:
+// ```js
+// import mod from 'node:console`;
+// new mod.Console(...)
+// ```
+Console.Console = Console;
+
+export default Console;

--- a/src/workerd/api/node/tests/BUILD.bazel
+++ b/src/workerd/api/node/tests/BUILD.bazel
@@ -16,6 +16,12 @@ wd_test(
 )
 
 wd_test(
+    src = "console-nodejs-test.wd-test",
+    args = ["--experimental"],
+    data = ["console-nodejs-test.js"],
+)
+
+wd_test(
     size = "enormous",
     src = "crypto_dh-test.wd-test",
     args = ["--experimental"],

--- a/src/workerd/api/node/tests/console-nodejs-test.js
+++ b/src/workerd/api/node/tests/console-nodejs-test.js
@@ -1,0 +1,67 @@
+import Console from 'node:console';
+import { strictEqual, doesNotThrow, throws } from 'node:assert';
+
+// These methods are retrieved using Object.keys(require('node:console'))
+// on Node.js v22.17.1
+const methods = [
+  'log',
+  'info',
+  'debug',
+  'warn',
+  'error',
+  'dir',
+  'time',
+  'timeEnd',
+  'timeLog',
+  'trace',
+  'assert',
+  'clear',
+  'count',
+  'countReset',
+  'group',
+  'groupEnd',
+  'table',
+  'dirxml',
+  'groupCollapsed',
+  'Console',
+  'profile',
+  'profileEnd',
+  'timeStamp',
+  'context',
+  'createTask',
+];
+
+const notImplementedMethods = ['context', 'createTask', 'Console'];
+
+export const testMethodNames = {
+  async test() {
+    for (const method of methods) {
+      strictEqual(
+        typeof Console[method],
+        'function',
+        `Method Console.${method} is not a function`
+      );
+    }
+  },
+};
+
+export const testNotImplemented = {
+  async test() {
+    for (const method of notImplementedMethods) {
+      throws(() => Console[method](), {
+        code: 'ERR_METHOD_NOT_IMPLEMENTED',
+      });
+    }
+  },
+};
+
+export const testMethods = {
+  async test() {
+    const implementedMethods = methods.filter(
+      (m) => !notImplementedMethods.includes(m)
+    );
+    for (const method of implementedMethods) {
+      doesNotThrow(() => Console[method](`Calling Console.${method}()`));
+    }
+  },
+};

--- a/src/workerd/api/node/tests/console-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/console-nodejs-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "console-nodejs-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "console-nodejs-test.js")
+        ],
+        compatibilityDate = "2025-09-03",
+        compatibilityFlags = ["nodejs_compat"],
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
In reality, node:console differs from globalThis.console and supports additional features. The existing polyfill implementation for node:console just uses globalThis.console methods underneath. For the sake of removing the polyfills from wrangler, here's the implementation.

Polyfill also adds several variables that is not documented (and not used generally out there) such as the following methods/attributes that I didn't add this to this pull-request. I'm not sure if we should add them. I'm leaving this discussion to the reviewers. Ref: https://github.com/unjs/unenv/blob/main/src/runtime/node/console.ts

- [ ] _ignoreErrors
- [ ] _stderr
- [ ] _stdout
- [ ] _times
- [ ] _stdoutErrorHandler
- [ ] _stderrErrorHandler