### PR TITLE
Add Durable Object ID to Onset events

### DIFF
--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -27,6 +27,7 @@ namespace {
   V(DAEMONDOWN, "daemonDown")                                                                      \
   V(DIAGNOSTICCHANNEL, "diagnosticChannel")                                                        \
   V(DISPATCHNAMESPACE, "dispatchNamespace")                                                        \
+  V(DURABLEOBJECTID, "durableObjectId")                                                            \
   V(EMAIL, "email")                                                                                \
   V(ENTRYPOINT, "entrypoint")                                                                      \
   V(ERROR, "error")                                                                                \
@@ -343,6 +344,9 @@ jsg::JsValue ToJs(jsg::Lock& js, const tracing::Onset& onset, StringCache& cache
   }
   KJ_IF_SOME(entrypoint, onset.workerInfo.entrypoint) {
     obj.set(js, ENTRYPOINT_STR, js.str(entrypoint));
+  }
+  KJ_IF_SOME(durableObjectId, onset.workerInfo.durableObjectId) {
+    obj.set(js, DURABLEOBJECTID_STR, js.str(durableObjectId));
   }
   KJ_IF_SOME(name, onset.workerInfo.scriptName) {
     obj.set(js, SCRIPTNAME_STR, js.str(name));

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -1163,6 +1163,14 @@ kj::Maybe<kj::String> getEntrypointFromReader(const rpc::Trace::Onset::Reader& r
   }
   return kj::none;
 }
+
+kj::Maybe<kj::String> getDurableObjectIdFromReader(const rpc::Trace::Onset::Reader& reader) {
+  if (reader.hasDurableObjectId()) {
+    return kj::str(reader.getDurableObjectId());
+  }
+  return kj::none;
+}
+
 kj::Maybe<tracing::Onset::TriggerContext> getTriggerContextFromReader(
     const rpc::Trace::Onset::Reader& reader) {
   if (!reader.hasTrigger()) return kj::none;
@@ -1179,6 +1187,7 @@ tracing::Onset::WorkerInfo getWorkerInfoFromReader(const rpc::Trace::Onset::Read
     .scriptId = getScriptIdFromReader(reader),
     .scriptTags = getScriptTagsFromReader(reader),
     .entrypoint = getEntrypointFromReader(reader),
+    .durableObjectId = getDurableObjectIdFromReader(reader),
   };
 }
 }  // namespace
@@ -1221,6 +1230,9 @@ void tracing::Onset::copyTo(rpc::Trace::Onset::Builder builder) const {
   KJ_IF_SOME(e, workerInfo.entrypoint) {
     builder.setEntryPoint(e);
   }
+  KJ_IF_SOME(doId, workerInfo.durableObjectId) {
+    builder.setDurableObjectId(doId);
+  }
   KJ_IF_SOME(t, trigger) {
     auto ctx = builder.initTrigger();
     t.traceId.toCapnp(ctx.initTraceId());
@@ -1246,6 +1258,7 @@ tracing::Onset::WorkerInfo tracing::Onset::WorkerInfo::clone() const {
     .scriptTags =
         scriptTags.map([](auto& tags) { return KJ_MAP(tag, tags) { return kj::str(tag); }; }),
     .entrypoint = mapCopyString(entrypoint),
+    .durableObjectId = mapCopyString(durableObjectId),
   };
 }
 

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -687,6 +687,7 @@ struct Onset final {
     kj::Maybe<kj::String> scriptId;
     kj::Maybe<kj::Array<kj::String>> scriptTags;
     kj::Maybe<kj::String> entrypoint;
+    kj::Maybe<kj::String> durableObjectId;
 
     WorkerInfo clone() const;
   };

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -386,6 +386,7 @@ void WorkerTracer::setEventInfo(
       .scriptId = mapCopyString(trace->scriptId),
       .scriptTags = KJ_MAP(tag, trace->scriptTags) { return kj::str(tag); },
       .entrypoint = mapCopyString(trace->entrypoint),
+      .durableObjectId = mapCopyString(trace->durableObjectId),
     };
 
     writer->report(context,

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -240,6 +240,7 @@ struct Trace @0x8e8d911203762d34 {
     }
     info @8: Info;
     attributes @9 :List(Attribute);
+    durableObjectId @10 :Text;
   }
 
   struct Outcome {

--- a/types/defines/trace.d.ts
+++ b/types/defines/trace.d.ts
@@ -100,6 +100,7 @@ interface Onset {
   readonly scriptName?: string;
   readonly scriptTags?: string[];
   readonly scriptVersion?: ScriptVersion;
+  readonly durableObjectId?: string;
   readonly trigger?: Trigger;
   readonly info: FetchEventInfo | JsRpcEventInfo | ScheduledEventInfo |
                  AlarmEventInfo | QueueEventInfo | EmailEventInfo |


### PR DESCRIPTION
c59f2d06b5bd added Durable Object ID to Trace events, consumed by the Legacy Tail Worker. Here we add it also to Onset events, consumed by Streaming Tail Worker.