### PR TITLE
add perf_hooks module and global Performance classes

### DIFF
--- a/src/node/internal/internal_dns_promises.ts
+++ b/src/node/internal/internal_dns_promises.ts
@@ -40,7 +40,7 @@ import type {
   SOA,
   SRV,
   TTLResponse,
-} from 'node:internal/internal_dns_client';
+} from 'node-internal:internal_dns_client';
 
 export * from 'node-internal:internal_dns_constants';
 export {

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -937,3 +937,18 @@ export class ERR_SERVER_ALREADY_LISTEN extends NodeError {
     );
   }
 }
+
+export class ERR_ILLEGAL_CONSTRUCTOR extends NodeTypeError {
+  constructor() {
+    super('ERR_ILLEGAL_CONSTRUCTOR', 'Illegal constructor');
+  }
+}
+
+export class ERR_PERFORMANCE_INVALID_TIMESTAMP extends NodeTypeError {
+  constructor(value: unknown) {
+    super(
+      'ERR_PERFORMANCE_INVALID_TIMESTAMP',
+      `${value} is not a valid timestamp`
+    );
+  }
+}

--- a/src/node/perf_hooks.ts
+++ b/src/node/perf_hooks.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+// Copyright Joyent and Node contributors. All rights reserved. MIT license.
+
+import { ERR_METHOD_NOT_IMPLEMENTED } from 'node-internal:internal_errors';
+
+export const constants = Object.freeze({
+  NODE_PERFORMANCE_GC_MAJOR: 4,
+  NODE_PERFORMANCE_GC_MINOR: 1,
+  NODE_PERFORMANCE_GC_INCREMENTAL: 8,
+  NODE_PERFORMANCE_GC_WEAKCB: 16,
+  NODE_PERFORMANCE_GC_FLAGS_NO: 0,
+  NODE_PERFORMANCE_GC_FLAGS_CONSTRUCT_RETAINED: 2,
+  NODE_PERFORMANCE_GC_FLAGS_FORCED: 4,
+  NODE_PERFORMANCE_GC_FLAGS_SYNCHRONOUS_PHANTOM_PROCESSING: 8,
+  NODE_PERFORMANCE_GC_FLAGS_ALL_AVAILABLE_GARBAGE: 16,
+  NODE_PERFORMANCE_GC_FLAGS_ALL_EXTERNAL_MEMORY: 32,
+  NODE_PERFORMANCE_GC_FLAGS_SCHEDULE_IDLE: 64,
+});
+
+export const performance = globalThis.performance;
+export const Performance = globalThis.Performance;
+
+export function createHistogram(): void {
+  throw new ERR_METHOD_NOT_IMPLEMENTED('createHistogram');
+}
+
+export function monitorEventLoopDelay(): void {
+  throw new ERR_METHOD_NOT_IMPLEMENTED('monitorEventLoopDelay');
+}
+
+export const PerformanceEntry = globalThis.PerformanceEntry;
+export const PerformanceMeasure = globalThis.PerformanceMeasure;
+export const PerformanceMark = globalThis.PerformanceMark;
+export const PerformanceObserver = globalThis.PerformanceObserver;
+export const PerformanceObserverEntryList =
+  globalThis.PerformanceObserverEntryList;
+export const PerformanceResourceTiming = globalThis.PerformanceResourceTiming;
+
+// We intentionally not actually implement support for perf_hooks feedback into the worker.
+// Even though, classes like PerformanceEntry and PerformanceObserver are here, they are
+// not actually expected to be used for anything, at least not for the foreseeable future.
+export default {
+  Performance,
+  PerformanceEntry,
+  PerformanceMark,
+  PerformanceMeasure,
+  PerformanceObserver,
+  PerformanceObserverEntryList,
+  PerformanceResourceTiming,
+  monitorEventLoopDelay,
+  createHistogram,
+  performance,
+  constants,
+};

--- a/src/node/timers.ts
+++ b/src/node/timers.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+// Copyright Joyent and Node contributors. All rights reserved. MIT license.
+
 import * as _promises from 'node-internal:internal_timers_promises';
 import {
   setTimeout,

--- a/src/node/zlib.ts
+++ b/src/node/zlib.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+// Copyright Joyent and Node contributors. All rights reserved. MIT license.
+
 import * as zlib from 'node-internal:internal_zlib';
 import { crc32 } from 'node-internal:internal_zlib';
 import { constants, codes } from 'node-internal:internal_zlib_constants';

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -950,12 +950,6 @@ jsg::JsValue ServiceWorkerGlobalScope::getProcess(jsg::Lock& js) {
   }
 }
 
-double Performance::now() {
-  // We define performance.now() for compatibility purposes, but due to Spectre concerns it
-  // returns exactly what Date.now() returns.
-  return dateNow();
-}
-
 jsg::Ref<StorageManager> Navigator::getStorage(jsg::Lock& js) {
   return js.alloc<StorageManager>();
 }

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -9,6 +9,7 @@
 #include "hibernation-event-params.h"
 #include "http.h"
 #include "messagechannel.h"
+#include "performance.h"
 
 #include <workerd/io/io-timers.h>
 #include <workerd/jsg/jsg.h>
@@ -111,32 +112,6 @@ class Navigator: public jsg::Object {
     if (reader.getWebFileSystem()) {
       JSG_LAZY_READONLY_INSTANCE_PROPERTY(storage, getStorage);
     }
-  }
-};
-
-class Performance: public jsg::Object {
- public:
-  // We always return a time origin of 0, making performance.now() equivalent to Date.now(). There
-  // is no other appropriate time origin to use given that the Worker platform is intended to be
-  // treated like one big computer rather than many individual instances. In particular, if and
-  // when we start snapshotting applications after startup and then starting instances from that
-  // snapshot, what would the right time origin be? The time when the snapshot was created? This
-  // seems to leak implementation details in a weird way.
-  //
-  // Note that the purpose of `timeOrigin` is normally to allow `now()` to return a more-precise
-  // measurement. Measuring against a recent time allows the values returned by `now()` to be
-  // smaller in magnitude, which allows them to be more precise due to the nature of floating
-  // point numbers. In our case, though, we don't return precise measurements from this interface
-  // anyway, for Spectre reasons -- it returns the same as Date.now().
-  double getTimeOrigin() {
-    return 0.0;
-  }
-
-  double now();
-
-  JSG_RESOURCE_TYPE(Performance) {
-    JSG_READONLY_INSTANCE_PROPERTY(timeOrigin, getTimeOrigin);
-    JSG_METHOD(now);
   }
 };
 
@@ -771,6 +746,18 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
     JSG_NESTED_TYPE(IdentityTransformStream);
     JSG_NESTED_TYPE(HTMLRewriter);
 
+    // Performance API
+    JSG_NESTED_TYPE(Performance);
+
+    if (flags.getEnableGlobalPerformanceClasses() || flags.getEnableNodeJsPerfHooksModule()) {
+      JSG_NESTED_TYPE(PerformanceEntry);
+      JSG_NESTED_TYPE(PerformanceMark);
+      JSG_NESTED_TYPE(PerformanceMeasure);
+      JSG_NESTED_TYPE(PerformanceResourceTiming);
+      JSG_NESTED_TYPE(PerformanceObserver);
+      JSG_NESTED_TYPE(PerformanceObserverEntryList);
+    }
+
     JSG_TS_ROOT();
     JSG_TS_DEFINE(
       interface Console {
@@ -923,6 +910,6 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
   api::WorkerGlobalScope, api::ServiceWorkerGlobalScope, api::TestController,                      \
       api::ExecutionContext, api::ExportedHandler,                                                 \
       api::ServiceWorkerGlobalScope::StructuredCloneOptions, api::PromiseRejectionEvent,           \
-      api::Navigator, api::Performance, api::AlarmInvocationInfo, api::Immediate, api::Cloudflare
+      api::Navigator, api::AlarmInvocationInfo, api::Immediate, api::Cloudflare
 // The list of global-scope.h types that are added to worker.c++'s JSG_DECLARE_ISOLATE_TYPE
 }  // namespace workerd::api

--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -125,6 +125,10 @@ void registerNodeJsCompatModules(Registry& registry, auto featureFlags) {
       return featureFlags.getEnableNodeJsVmModule();
     }
 
+    if (module.getName() == "node:perf_hooks"_kj) {
+      return featureFlags.getEnableNodeJsPerfHooksModule();
+    }
+
     return true;
   });
 

--- a/src/workerd/api/node/tests/BUILD.bazel
+++ b/src/workerd/api/node/tests/BUILD.bazel
@@ -149,6 +149,12 @@ wd_test(
 )
 
 wd_test(
+    src = "perf-hooks-nodejs-test.wd-test",
+    args = ["--experimental"],
+    data = ["perf-hooks-nodejs-test.js"],
+)
+
+wd_test(
     src = "path-test.wd-test",
     args = ["--experimental"],
     data = ["path-test.js"],

--- a/src/workerd/api/node/tests/perf-hooks-nodejs-test.js
+++ b/src/workerd/api/node/tests/perf-hooks-nodejs-test.js
@@ -1,0 +1,305 @@
+import {
+  performance as perfHooksPerformance,
+  Performance,
+  PerformanceEntry,
+  PerformanceMark,
+  PerformanceMeasure,
+  PerformanceObserver,
+  PerformanceObserverEntryList,
+  PerformanceResourceTiming,
+  createHistogram,
+  monitorEventLoopDelay,
+  constants,
+} from 'node:perf_hooks';
+import { deepStrictEqual, ok, throws } from 'node:assert';
+
+export const testPerformanceExports = {
+  test() {
+    // Test that all expected exports exist
+    ok(performance);
+    ok(Performance);
+    ok(PerformanceEntry);
+    ok(PerformanceMark);
+    ok(PerformanceMeasure);
+    ok(PerformanceObserver);
+    ok(PerformanceObserverEntryList);
+    ok(PerformanceResourceTiming);
+    ok(createHistogram);
+    ok(monitorEventLoopDelay);
+    ok(constants);
+
+    // Test that performance is an instance of Performance
+    ok(perfHooksPerformance instanceof Performance);
+  },
+};
+
+export const testPerformanceConstants = {
+  test() {
+    deepStrictEqual(constants, {
+      NODE_PERFORMANCE_GC_FLAGS_ALL_AVAILABLE_GARBAGE: 16,
+      NODE_PERFORMANCE_GC_FLAGS_ALL_EXTERNAL_MEMORY: 32,
+      NODE_PERFORMANCE_GC_FLAGS_CONSTRUCT_RETAINED: 2,
+      NODE_PERFORMANCE_GC_FLAGS_FORCED: 4,
+      NODE_PERFORMANCE_GC_FLAGS_NO: 0,
+      NODE_PERFORMANCE_GC_FLAGS_SCHEDULE_IDLE: 64,
+      NODE_PERFORMANCE_GC_FLAGS_SYNCHRONOUS_PHANTOM_PROCESSING: 8,
+      NODE_PERFORMANCE_GC_INCREMENTAL: 8,
+      NODE_PERFORMANCE_GC_MAJOR: 4,
+      NODE_PERFORMANCE_GC_MINOR: 1,
+      NODE_PERFORMANCE_GC_WEAKCB: 16,
+    });
+    ok(Object.isFrozen(constants));
+  },
+};
+
+export const testPerformanceBasicFunctionality = {
+  test() {
+    // Test that performance.now() works
+    const start = perfHooksPerformance.now();
+    ok(typeof start === 'number');
+    ok(start >= 0, 'start should be bigger than or equal to 0');
+
+    // Test that consecutive calls return increasing values
+    const end = perfHooksPerformance.now();
+    ok(end >= start, 'end should be bigger than or equal to start');
+
+    // Test performance.timeOrigin
+    ok(typeof perfHooksPerformance.timeOrigin === 'number');
+    ok(
+      perfHooksPerformance.timeOrigin >= 0,
+      'timeOrigin should be bigger than or equal to 0'
+    );
+  },
+};
+
+export const testUnimplementedMethods = {
+  test() {
+    throws(() => createHistogram(), { message: /is not implemented/ });
+    throws(() => monitorEventLoopDelay(), {
+      message: /is not implemented/,
+    });
+    throws(() => perfHooksPerformance.mark('type-test-mark'), {
+      message: /is not implemented/,
+    });
+    throws(
+      () => perfHooksPerformance.measure('type-test-measure', 'type-test-mark'),
+      {
+        message: /is not implemented/,
+      }
+    );
+  },
+};
+
+export const testPerformanceEntryTypes = {
+  test() {
+    const allEntries = perfHooksPerformance.getEntries();
+    ok(Array.isArray(allEntries));
+
+    // Test getting entries by type
+    const markEntries = perfHooksPerformance.getEntriesByType('mark');
+    ok(Array.isArray(markEntries));
+
+    const measureEntries = perfHooksPerformance.getEntriesByType('measure');
+    ok(Array.isArray(measureEntries));
+
+    // The following does not throw
+    perfHooksPerformance.clearMarks();
+    perfHooksPerformance.clearMeasures();
+  },
+};
+
+export const testEventCounts = {
+  test() {
+    // Test that eventCounts exists and is an object
+    const eventCounts = perfHooksPerformance.eventCounts;
+    ok(eventCounts, 'eventCounts should exist');
+    ok(typeof eventCounts === 'object', 'eventCounts should be an object');
+
+    // Test that eventCounts has the expected Map-like methods
+    ok(
+      typeof eventCounts.get === 'function',
+      'eventCounts should have get method'
+    );
+    ok(
+      typeof eventCounts.has === 'function',
+      'eventCounts should have has method'
+    );
+    ok(
+      typeof eventCounts.entries === 'function',
+      'eventCounts should have entries method'
+    );
+    ok(
+      typeof eventCounts.keys === 'function',
+      'eventCounts should have keys method'
+    );
+    ok(
+      typeof eventCounts.values === 'function',
+      'eventCounts should have values method'
+    );
+    ok(
+      typeof eventCounts.forEach === 'function',
+      'eventCounts should have forEach method'
+    );
+
+    // Test that eventCounts has a size property
+    ok('size' in eventCounts, 'eventCounts should have size property');
+    ok(typeof eventCounts.size === 'number', 'size should be a number');
+    ok(eventCounts.size >= 0, 'size should be non-negative');
+    deepStrictEqual(
+      eventCounts.size,
+      0,
+      'size should be 0 for empty EventCounts'
+    );
+
+    // Test that eventCounts does NOT have mutating methods (it's read-only)
+    ok(!('set' in eventCounts), 'eventCounts should not have set method');
+    ok(!('delete' in eventCounts), 'eventCounts should not have delete method');
+    ok(!('clear' in eventCounts), 'eventCounts should not have clear method');
+
+    // Test Map-like methods behavior with various key types
+    // Since we don't track events, these should return empty/false/undefined
+    const testKeys = [
+      'click',
+      'keydown',
+      '',
+      'special-chars!@#',
+      '123',
+      'undefined',
+      'null',
+    ];
+    for (const key of testKeys) {
+      const result = eventCounts.get(key);
+      ok(
+        result === undefined,
+        `get('${key}') should return undefined for non-existent keys`
+      );
+
+      const hasResult = eventCounts.has(key);
+      ok(
+        hasResult === false,
+        `has('${key}') should return false for non-existent keys`
+      );
+    }
+
+    // Test that eventCounts is iterable
+    ok(
+      typeof eventCounts[Symbol.iterator] === 'function',
+      'eventCounts should be iterable'
+    );
+
+    // Test that Symbol.iterator works correctly (may or may not be the same reference as entries)
+    // The spec doesn't require them to be the same reference, just functionally equivalent
+
+    // Test iteration methods return proper iterators
+    const entriesIter = eventCounts.entries();
+    ok(
+      entriesIter && typeof entriesIter.next === 'function',
+      'entries() should return an iterator'
+    );
+    ok(
+      typeof entriesIter[Symbol.iterator] === 'function',
+      'entries iterator should be iterable'
+    );
+    const entriesResult = entriesIter.next();
+    ok(
+      entriesResult.done === true,
+      'entries iterator should be done immediately (empty map)'
+    );
+    ok(
+      entriesResult.value === undefined,
+      'entries iterator value should be undefined when done'
+    );
+
+    const keysIter = eventCounts.keys();
+    ok(
+      keysIter && typeof keysIter.next === 'function',
+      'keys() should return an iterator'
+    );
+    ok(
+      typeof keysIter[Symbol.iterator] === 'function',
+      'keys iterator should be iterable'
+    );
+    const keysResult = keysIter.next();
+    ok(
+      keysResult.done === true,
+      'keys iterator should be done immediately (empty map)'
+    );
+    ok(
+      keysResult.value === undefined,
+      'keys iterator value should be undefined when done'
+    );
+
+    const valuesIter = eventCounts.values();
+    ok(
+      valuesIter && typeof valuesIter.next === 'function',
+      'values() should return an iterator'
+    );
+    ok(
+      typeof valuesIter[Symbol.iterator] === 'function',
+      'values iterator should be iterable'
+    );
+    const valuesResult = valuesIter.next();
+    ok(
+      valuesResult.done === true,
+      'values iterator should be done immediately (empty map)'
+    );
+    ok(
+      valuesResult.value === undefined,
+      'values iterator value should be undefined when done'
+    );
+
+    // Test forEach with different scenarios
+    let forEachCalled = false;
+    let forEachContext = null;
+    const customThis = { custom: true };
+
+    eventCounts.forEach(function () {
+      forEachCalled = true;
+    });
+    // Since the map is empty, forEach shouldn't call the callback
+    ok(!forEachCalled, 'forEach should not call callback when map is empty');
+
+    // Test forEach with thisArg
+    eventCounts.forEach(function () {
+      forEachContext = this;
+    }, customThis);
+    ok(
+      forEachContext === null,
+      'forEach with thisArg should not be called for empty map'
+    );
+
+    // Test that we can iterate over it with for...of
+    const entries = [];
+    for (const entry of eventCounts) {
+      entries.push(entry);
+    }
+    ok(Array.isArray(entries), 'Should be able to iterate with for...of');
+    ok(entries.length === 0, 'Should have no entries currently');
+
+    // Test spread operator
+    const spreadEntries = [...eventCounts];
+    ok(Array.isArray(spreadEntries), 'Should be able to use spread operator');
+    ok(spreadEntries.length === 0, 'Spread should produce empty array');
+
+    const spreadKeys = [...eventCounts.keys()];
+    ok(Array.isArray(spreadKeys), 'Should be able to spread keys');
+    ok(spreadKeys.length === 0, 'Keys spread should produce empty array');
+
+    const spreadValues = [...eventCounts.values()];
+    ok(Array.isArray(spreadValues), 'Should be able to spread values');
+    ok(spreadValues.length === 0, 'Values spread should produce empty array');
+
+    // Test Array.from
+    const fromEntries = Array.from(eventCounts);
+    ok(Array.isArray(fromEntries), 'Array.from should work with eventCounts');
+    ok(fromEntries.length === 0, 'Array.from should produce empty array');
+
+    // Verify eventCounts reference behavior
+    const eventCounts2 = perfHooksPerformance.eventCounts;
+    ok(
+      eventCounts2,
+      'Second call to performance.eventCounts should also return an object'
+    );
+    // Note: The implementation may return a new instance each time, which is acceptable
+  },
+};

--- a/src/workerd/api/node/tests/perf-hooks-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/perf-hooks-nodejs-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "perf-hooks-nodejs-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "perf-hooks-nodejs-test.js")
+        ],
+        compatibilityDate = "2025-09-04",
+        compatibilityFlags = ["nodejs_compat", "enable_nodejs_perf_hooks_module"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/performance.c++
+++ b/src/workerd/api/performance.c++
@@ -1,0 +1,178 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "performance.h"
+
+#include <workerd/io/io-util.h>
+
+#include <kj/encoding.h>
+
+namespace workerd::api {
+
+double Performance::now() {
+  // We define performance.now() for compatibility purposes, but due to Spectre concerns it
+  // returns exactly what Date.now() returns.
+  return dateNow();
+}
+
+jsg::JsObject PerformanceEntry::toJSON(jsg::Lock& js) {
+  JSG_FAIL_REQUIRE(Error, "PerformanceEntry.toJSON is not implemented"_kj);
+}
+
+jsg::JsObject PerformanceResourceTiming::toJSON(jsg::Lock& js) {
+  JSG_FAIL_REQUIRE(Error, "PerformanceResourceTiming.toJSON is not implemented"_kj);
+}
+
+void Performance::clearMarks(jsg::Optional<kj::String> name) { /* Intentionally left as no-op */ }
+void Performance::clearMeasures(jsg::Optional<kj::String> name) { /* Intentionally left as no-op */
+}
+void Performance::clearResourceTimings() { /* Intentionally left as no-op */ }
+
+kj::ArrayPtr<jsg::Ref<PerformanceEntry>> Performance::getEntries() {
+  return {};
+}
+
+kj::ArrayPtr<jsg::Ref<PerformanceEntry>> Performance::getEntriesByName(
+    kj::String name, kj::String type) {
+  return {};
+}
+
+kj::ArrayPtr<jsg::Ref<PerformanceEntry>> Performance::getEntriesByType(kj::String type) {
+  return {};
+}
+
+kj::ArrayPtr<jsg::Ref<PerformanceEntry>> PerformanceObserverEntryList::getEntries() {
+  return {};
+}
+
+kj::ArrayPtr<jsg::Ref<PerformanceEntry>> PerformanceObserverEntryList::getEntriesByType(
+    kj::String type) {
+  return {};
+}
+
+kj::ArrayPtr<jsg::Ref<PerformanceEntry>> PerformanceObserverEntryList::getEntriesByName(
+    kj::String name, jsg::Optional<kj::String> type) {
+  return {};
+}
+
+jsg::Ref<PerformanceMark> Performance::mark(
+    jsg::Lock& js, kj::String name, jsg::Optional<PerformanceMark::Options> options) {
+  JSG_FAIL_REQUIRE(Error, "Performance.mark is not implemented");
+}
+
+jsg::Ref<PerformanceMeasure> Performance::measure(jsg::Lock& js,
+    kj::String measureName,
+    kj::OneOf<PerformanceMeasure::Options, kj::String> measureOptionsOrStartMark,
+    jsg::Optional<kj::String> maybeEndMark) {
+  JSG_FAIL_REQUIRE(Error, "Performance.measure is not implemented");
+}
+
+void Performance::setResourceTimingBufferSize(uint32_t size) {
+  JSG_FAIL_REQUIRE(Error, "Performance.setResourceTimingBufferSize is not implemented");
+}
+
+jsg::Ref<PerformanceObserver> PerformanceObserver::constructor(jsg::Lock& js, Callback callback) {
+  return js.alloc<PerformanceObserver>(js, callback);
+}
+
+void PerformanceObserver::disconnect() {
+  JSG_FAIL_REQUIRE(Error, "PerformanceObserver.disconnect is not implemented");
+}
+
+void PerformanceObserver::observe(jsg::Optional<ObserveOptions> options) {
+  JSG_FAIL_REQUIRE(Error, "PerformanceObserver.observe is not implemented");
+}
+
+kj::Array<jsg::Ref<PerformanceEntry>> PerformanceObserver::takeRecords() {
+  return {};
+}
+kj::Array<kj::String> PerformanceObserver::getSupportedEntryTypes() {
+  // We return empty string because we don't support any of these entry types.
+  // Because we return empty string, two of the web-platform tests fail. This is intentional.
+  return kj::heapArray<kj::String>(0);
+}
+
+void Performance::eventLoopUtilization() {
+  JSG_FAIL_REQUIRE(Error, "Performance.eventLoopUtilization is not implemented");
+}
+
+void Performance::markResourceTiming() {
+  JSG_FAIL_REQUIRE(Error, "Performance.markResourceTiming is not implemented");
+}
+
+jsg::Function<void()> Performance::timerify(jsg::Lock& js, jsg::Function<void()> fn) {
+  // We currently don't support timerify, so we just return the function as is.
+  return kj::mv(fn);
+}
+
+jsg::Optional<uint32_t> EventCounts::get(kj::String eventType) {
+  KJ_IF_SOME(count, eventCounts.find(eventType)) {
+    return count;
+  }
+  return kj::none;
+}
+
+bool EventCounts::has(kj::String eventType) {
+  return eventCounts.find(eventType) != kj::none;
+}
+
+uint32_t EventCounts::getSize() {
+  return eventCounts.size();
+}
+
+jsg::Ref<EventCounts::EntryIterator> EventCounts::entries(jsg::Lock& js) {
+  return jsg::alloc<EntryIterator>(IteratorState(JSG_THIS));
+}
+
+kj::Maybe<EventCounts::EntryIteratorType> EventCounts::entryIteratorNext(
+    jsg::Lock& js, IteratorState& state) {
+  if (state.index >= state.entries.size()) {
+    return kj::none;
+  }
+  auto& entry = state.entries[state.index++];
+  // Return [key, value] as an array
+  return kj::arr(kj::str(kj::get<0>(entry)), kj::str(kj::get<1>(entry)));
+}
+
+jsg::Ref<EventCounts::KeyIterator> EventCounts::keys(jsg::Lock& js) {
+  return jsg::alloc<KeyIterator>(IteratorState(JSG_THIS));
+}
+
+kj::Maybe<EventCounts::KeyIteratorType> EventCounts::keyIteratorNext(
+    jsg::Lock& js, IteratorState& state) {
+  if (state.index >= state.entries.size()) {
+    return kj::none;
+  }
+  auto& entry = state.entries[state.index++];
+  return kj::str(kj::get<0>(entry));
+}
+
+jsg::Ref<EventCounts::ValueIterator> EventCounts::values(jsg::Lock& js) {
+  return jsg::alloc<ValueIterator>(IteratorState(JSG_THIS));
+}
+
+kj::Maybe<EventCounts::ValueIteratorType> EventCounts::valueIteratorNext(
+    jsg::Lock& js, IteratorState& state) {
+  if (state.index >= state.entries.size()) {
+    return kj::none;
+  }
+  auto& entry = state.entries[state.index++];
+  return kj::get<1>(entry);
+}
+
+void EventCounts::forEach(jsg::Lock& js,
+    jsg::Function<void(uint32_t, kj::String, jsg::Ref<EventCounts>)> callback,
+    jsg::Optional<jsg::JsValue> thisArg) {
+  // Since we don't track events, this is effectively a no-op
+  for (auto& entry: eventCounts) {
+    callback(js, entry.value, kj::str(entry.key), JSG_THIS);
+  }
+}
+
+jsg::Ref<EventCounts> Performance::getEventCounts(jsg::Lock& js) {
+  // Return a new EventCounts instance (currently empty as we don't track events)
+  return js.alloc<EventCounts>();
+}
+
+}  // namespace workerd::api

--- a/src/workerd/api/performance.h
+++ b/src/workerd/api/performance.h
@@ -1,0 +1,479 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <workerd/api/basics.h>
+#include <workerd/io/compatibility-date.capnp.h>
+#include <workerd/jsg/jsg.h>
+
+namespace workerd::api {
+
+// ======================================================================================
+// Performance API
+// ======================================================================================
+//
+// This implementation provides a subset of the Performance API for compatibility with
+// other JavaScript runtimes. We are not intending to fully implement in-worker
+// performance-timing feedback as Cloudflare Workers run in a different context than
+// traditional browser or Node.js environments.
+//
+// The APIs here are primarily provided to support code portability and to prevent
+// runtime errors when code expects these standard APIs to exist.
+//
+// Specifications:
+// - W3C Performance Timeline: https://w3c.github.io/performance-timeline/
+// - W3C User Timing: https://w3c.github.io/user-timing/
+// - MDN Documentation: https://developer.mozilla.org/en-US/docs/Web/API/Performance_API
+//
+// Current limitations:
+// - No actual performance metrics collection within workers
+// - PerformanceObserver is provided but with minimal functionality
+// - Most entry types are not supported
+// - Timing data may not reflect actual worker execution characteristics
+
+class PerformanceEntry: public jsg::Object {
+ public:
+  PerformanceEntry(kj::String name, kj::String entryType, uint32_t startTime, uint32_t duration)
+      : name(kj::mv(name)),
+        entryType(kj::mv(entryType)),
+        startTime(startTime),
+        duration(duration) {}
+
+  kj::StringPtr getName() {
+    return name;
+  };
+  kj::StringPtr getEntryType() {
+    return entryType;
+  };
+  uint32_t getStartTime() {
+    return startTime;
+  };
+  uint32_t getDuration() {
+    return duration;
+  };
+
+  jsg::JsObject toJSON(jsg::Lock& js);
+
+  JSG_RESOURCE_TYPE(PerformanceEntry) {
+    JSG_READONLY_PROTOTYPE_PROPERTY(name, getName);
+    JSG_READONLY_PROTOTYPE_PROPERTY(entryType, getEntryType);
+    JSG_READONLY_PROTOTYPE_PROPERTY(startTime, getStartTime);
+    JSG_READONLY_PROTOTYPE_PROPERTY(duration, getDuration);
+    JSG_METHOD(toJSON);
+  }
+
+ protected:
+  kj::String name;
+  kj::String entryType;
+  uint32_t startTime;
+  uint32_t duration;
+};
+
+class PerformanceMark: public PerformanceEntry {
+ public:
+  PerformanceMark(kj::String name, uint32_t startTime)
+      : PerformanceEntry(kj::mv(name), kj::str("mark"), startTime, 0) {}
+
+  struct Options {
+    jsg::Optional<jsg::JsRef<jsg::JsValue>> detail;
+    jsg::Optional<uint32_t> startTime;
+
+    JSG_STRUCT(detail, startTime);
+  };
+
+  jsg::JsValue getDetail(jsg::Lock& js) {
+    KJ_IF_SOME(value, detail) {
+      return value.getHandle(js);
+    }
+    return js.null();
+  }
+
+  JSG_RESOURCE_TYPE(PerformanceMark) {
+    JSG_INHERIT(PerformanceEntry);
+    JSG_READONLY_PROTOTYPE_PROPERTY(detail, getDetail);
+  }
+
+ private:
+  jsg::Optional<jsg::JsRef<jsg::JsValue>> detail;
+};
+
+class PerformanceMeasure: public PerformanceEntry {
+ public:
+  PerformanceMeasure(kj::String name, uint32_t startTime, uint32_t duration)
+      : PerformanceEntry(kj::mv(name), kj::str("measure"), startTime, duration) {}
+
+  struct Entry {
+    kj::String entryType;
+    kj::String name;
+    kj::OneOf<kj::Date, uint32_t> startTime;
+    uint32_t duration;
+    jsg::Optional<jsg::JsRef<jsg::JsObject>> detail;
+
+    JSG_STRUCT(entryType, name, startTime, duration, detail);
+  };
+
+  struct Options {
+    jsg::Optional<jsg::JsRef<jsg::JsObject>> detail;
+    jsg::Optional<uint32_t> start;
+    jsg::Optional<uint32_t> duration;
+    jsg::Optional<uint32_t> end;
+
+    JSG_STRUCT(detail, start, duration, end);
+  };
+
+  jsg::JsValue getDetail(jsg::Lock& js) {
+    KJ_IF_SOME(value, detail) {
+      return value.getHandle(js);
+    }
+    return js.null();
+  }
+
+  JSG_RESOURCE_TYPE(PerformanceMeasure) {
+    JSG_INHERIT(PerformanceEntry);
+    JSG_READONLY_PROTOTYPE_PROPERTY(detail, getDetail);
+  }
+
+ private:
+  jsg::Optional<jsg::JsRef<jsg::JsValue>> detail;
+};
+
+class PerformanceResourceTiming: public PerformanceEntry {
+ public:
+  PerformanceResourceTiming(kj::String name, uint32_t startTime, uint32_t duration)
+      : PerformanceEntry(kj::mv(name), kj::str("resource"), startTime, duration) {}
+
+  uint32_t getConnectEnd() {
+    return 0;
+  }
+  uint32_t getConnectStart() {
+    return 0;
+  }
+  uint32_t getDecodedBodySize() {
+    return 0;
+  }
+  uint32_t getDomainLookupEnd() {
+    return 0;
+  }
+  uint32_t getDomainLookupStart() {
+    return 0;
+  }
+  uint32_t getEncodedBodySize() {
+    return 0;
+  }
+  uint32_t getFetchStart() {
+    return 0;
+  }
+  jsg::JsString getInitiatorType(jsg::Lock& js) {
+    return js.str();
+  }
+  jsg::JsString getNextHopProtocol(jsg::Lock& js) {
+    return js.str();
+  }
+  uint32_t getRedirectEnd() {
+    return 0;
+  }
+  uint32_t getRedirectStart() {
+    return 0;
+  }
+  uint32_t getRequestStart() {
+    return 0;
+  }
+  uint32_t getResponseEnd() {
+    return 0;
+  }
+  uint32_t getResponseStart() {
+    return 0;
+  }
+  uint32_t getResponseStatus() {
+    return 0;
+  }
+  jsg::Optional<uint32_t> getSecureConnectionStart() {
+    return kj::none;
+  }
+  uint32_t getTransferSize() {
+    return 0;
+  }
+  uint32_t getWorkerStart() {
+    return 0;
+  }
+
+  jsg::JsObject toJSON(jsg::Lock& js);
+
+  JSG_RESOURCE_TYPE(PerformanceResourceTiming) {
+    JSG_INHERIT(PerformanceEntry);
+    JSG_READONLY_PROTOTYPE_PROPERTY(connectEnd, getConnectEnd);
+    JSG_READONLY_PROTOTYPE_PROPERTY(connectStart, getConnectStart);
+    JSG_READONLY_PROTOTYPE_PROPERTY(decodedBodySize, getDecodedBodySize);
+    JSG_READONLY_PROTOTYPE_PROPERTY(domainLookupEnd, getDomainLookupEnd);
+    JSG_READONLY_PROTOTYPE_PROPERTY(domainLookupStart, getDomainLookupStart);
+    JSG_READONLY_PROTOTYPE_PROPERTY(encodedBodySize, getEncodedBodySize);
+    JSG_READONLY_PROTOTYPE_PROPERTY(fetchStart, getFetchStart);
+    JSG_READONLY_PROTOTYPE_PROPERTY(initiatorType, getInitiatorType);
+    JSG_READONLY_PROTOTYPE_PROPERTY(nextHopProtocol, getNextHopProtocol);
+    JSG_READONLY_PROTOTYPE_PROPERTY(redirectEnd, getRedirectEnd);
+    JSG_READONLY_PROTOTYPE_PROPERTY(redirectStart, getRedirectStart);
+    JSG_READONLY_PROTOTYPE_PROPERTY(requestStart, getRequestStart);
+    JSG_READONLY_PROTOTYPE_PROPERTY(responseEnd, getResponseEnd);
+    JSG_READONLY_PROTOTYPE_PROPERTY(responseStart, getResponseStart);
+    JSG_READONLY_PROTOTYPE_PROPERTY(responseStatus, getResponseStatus);
+    JSG_READONLY_PROTOTYPE_PROPERTY(secureConnectionStart, getSecureConnectionStart);
+    JSG_READONLY_PROTOTYPE_PROPERTY(transferSize, getTransferSize);
+    JSG_READONLY_PROTOTYPE_PROPERTY(workerStart, getWorkerStart);
+  }
+};
+
+class PerformanceObserverEntryList: public jsg::Object {
+ public:
+  kj::ArrayPtr<jsg::Ref<PerformanceEntry>> getEntries();
+  kj::ArrayPtr<jsg::Ref<PerformanceEntry>> getEntriesByType(kj::String type);
+  kj::ArrayPtr<jsg::Ref<PerformanceEntry>> getEntriesByName(
+      kj::String name, jsg::Optional<kj::String> type);
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    // No managed objects to visit currently
+  }
+
+  JSG_RESOURCE_TYPE(PerformanceObserverEntryList) {
+    JSG_METHOD(getEntries);
+    JSG_METHOD(getEntriesByType);
+    JSG_METHOD(getEntriesByName);
+  }
+};
+
+// PerformanceObserver provides a way to observe performance timeline entries.
+// This is a minimal implementation for compatibility purposes.
+//
+// Spec: https://w3c.github.io/performance-timeline/#the-performanceobserver-interface
+// MDN: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver
+//
+// Note: In the Workers environment, this observer will not receive most performance
+// entries as we don't track detailed performance metrics within workers. The API
+// is provided mainly for compatibility with code that expects it to exist.
+class PerformanceObserver: public jsg::Object {
+ public:
+  struct CallbackOptions {
+    jsg::Optional<uint32_t> droppedEntriesCount;
+    JSG_STRUCT(droppedEntriesCount);
+  };
+
+  using Callback = jsg::JsValue;
+
+  static jsg::Ref<PerformanceObserver> constructor(jsg::Lock& js, Callback callback);
+
+  PerformanceObserver(jsg::Lock& js, Callback callback): callback(callback.addRef(js)) {}
+
+  struct ObserveOptions {
+    bool buffered;
+    uint32_t durationThreshold = 104;
+    kj::Array<kj::String> entryTypes;
+    jsg::Optional<kj::String> type;
+    jsg::Optional<kj::String> name;
+
+    JSG_STRUCT(buffered, durationThreshold, entryTypes, type, name);
+  };
+  void disconnect();
+  void observe(jsg::Optional<ObserveOptions> options);
+  kj::Array<jsg::Ref<PerformanceEntry>> takeRecords();
+  // Returns the list of supported entry types. Currently returns an empty array
+  // as we don't actively support performance entry collection in workers.
+  // Spec: https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute
+  static kj::Array<kj::String> getSupportedEntryTypes();
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(callback);
+  }
+
+  JSG_RESOURCE_TYPE(PerformanceObserver) {
+    JSG_METHOD(disconnect);
+    JSG_METHOD(observe);
+    JSG_METHOD(takeRecords);
+    JSG_STATIC_READONLY_PROPERTY_NAMED(supportedEntryTypes, getSupportedEntryTypes);
+  }
+
+ private:
+  jsg::JsRef<jsg::JsValue> callback;
+};
+
+// EventCounts provides a read-only map of event counts per event type.
+// This is a minimal implementation for compatibility with the EventCounts API.
+//
+// Spec: https://w3c.github.io/event-timing/#eventcounts
+// MDN: https://developer.mozilla.org/en-US/docs/Web/API/EventCounts
+//
+// The EventCounts interface is a read-only map-like object where:
+// - Keys are event type strings (e.g., "click", "keydown")
+// - Values are the number of events dispatched for that type
+// - It doesn't have clear(), delete(), or set() methods
+class EventCounts: public jsg::Object {
+ public:
+  EventCounts() = default;
+
+  jsg::Optional<uint32_t> get(kj::String eventType);
+  bool has(kj::String eventType);
+  uint32_t getSize();
+
+  struct IteratorState {
+    jsg::Ref<EventCounts> parent;
+    size_t index = 0;
+    kj::Vector<kj::Tuple<kj::String, uint32_t>> entries;
+
+    IteratorState(jsg::Ref<EventCounts> parent): parent(kj::mv(parent)) {
+      // Copy the entries from the map into our vector for stable iteration
+      // Check if the map has any entries before iterating
+      if (this->parent->eventCounts.size() > 0) {
+        for (auto& entry: this->parent->eventCounts) {
+          entries.add(kj::tuple(kj::str(entry.key), entry.value));
+        }
+      }
+    }
+
+    void visitForGc(jsg::GcVisitor& visitor) {
+      visitor.visit(parent);
+    }
+  };
+
+  using EntryIteratorType = kj::Array<kj::String>;
+  using KeyIteratorType = kj::String;
+  using ValueIteratorType = uint32_t;
+
+  JSG_ITERATOR(EntryIterator, entries, EntryIteratorType, IteratorState, entryIteratorNext)
+  JSG_ITERATOR(KeyIterator, keys, KeyIteratorType, IteratorState, keyIteratorNext)
+  JSG_ITERATOR(ValueIterator, values, ValueIteratorType, IteratorState, valueIteratorNext)
+
+  void forEach(jsg::Lock& js,
+      jsg::Function<void(uint32_t, kj::String, jsg::Ref<EventCounts>)>,
+      jsg::Optional<jsg::JsValue>);
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    // No managed objects to visit currently
+  }
+
+  JSG_RESOURCE_TYPE(EventCounts) {
+    JSG_READONLY_PROTOTYPE_PROPERTY(size, getSize);
+    JSG_METHOD(get);
+    JSG_METHOD(has);
+    JSG_METHOD(entries);
+    JSG_METHOD(keys);
+    JSG_METHOD(values);
+    JSG_METHOD(forEach);
+    JSG_ITERABLE(entries);
+  }
+
+ private:
+  // Static iterator next methods
+  static kj::Maybe<EntryIteratorType> entryIteratorNext(jsg::Lock& js, IteratorState& state);
+  static kj::Maybe<KeyIteratorType> keyIteratorNext(jsg::Lock& js, IteratorState& state);
+  static kj::Maybe<ValueIteratorType> valueIteratorNext(jsg::Lock& js, IteratorState& state);
+
+  // For now, we keep this empty as we don't actually track events in the worker context.
+  // This can be extended in the future to store actual event counts.
+  kj::HashMap<kj::String, uint32_t> eventCounts;
+
+  friend struct IteratorState;
+};
+
+// Performance provides timing-related functionality and performance metrics.
+// This is a minimal implementation focused on compatibility rather than providing
+// detailed performance insights within the Workers environment.
+//
+// Spec: https://w3c.github.io/hr-time/#the-performance-interface
+// MDN: https://developer.mozilla.org/en-US/docs/Web/API/Performance
+//
+// Key limitations in Workers:
+// - performance.now() returns the same precision as Date.now() for security reasons
+// - Most performance entry types are not supported
+// - Resource timing and navigation timing are not applicable in the Workers context
+// - User timing (marks and measures) have limited implementation
+class Performance: public EventTarget {
+ public:
+  static jsg::Ref<Performance> constructor() = delete;
+
+  // We always return a time origin of 0, making performance.now() equivalent to Date.now(). There
+  // is no other appropriate time origin to use given that the Worker platform is intended to be
+  // treated like one big computer rather than many individual instances. In particular, if and
+  // when we start snapshotting applications after startup and then starting instances from that
+  // snapshot, what would the right time origin be? The time when the snapshot was created? This
+  // seems to leak implementation details in a weird way.
+  //
+  // Note that the purpose of `timeOrigin` is normally to allow `now()` to return a more-precise
+  // measurement. Measuring against a recent time allows the values returned by `now()` to be
+  // smaller in magnitude, which alzlows them to be more precise due to the nature of floating
+  // point numbers. In our case, though, we don't return precise measurements from this interface
+  // anyway, for Spectre reasons -- it returns the same as Date.now().
+  double getTimeOrigin() {
+    return 0.0;
+  }
+
+  jsg::Ref<EventCounts> getEventCounts(jsg::Lock& js);
+
+  double now();
+
+  void clearMarks(jsg::Optional<kj::String> name);
+  void clearMeasures(jsg::Optional<kj::String> name);
+  void clearResourceTimings();
+  kj::ArrayPtr<jsg::Ref<PerformanceEntry>> getEntries();
+  kj::ArrayPtr<jsg::Ref<PerformanceEntry>> getEntriesByName(kj::String name, kj::String type);
+  kj::ArrayPtr<jsg::Ref<PerformanceEntry>> getEntriesByType(kj::String type);
+  jsg::Ref<PerformanceMark> mark(
+      jsg::Lock& js, kj::String name, jsg::Optional<PerformanceMark::Options> options);
+
+  // Following signatures are supported:
+  // - measure(measureName)
+  // - measure(measureName, startMark)
+  // - measure(measureName, startMark, endMark)
+  // - measure(measureName, measureOptions)
+  // - measure(measureName, measureOptions, endMark)
+  jsg::Ref<PerformanceMeasure> measure(jsg::Lock& js,
+      kj::String measureName,
+      kj::OneOf<PerformanceMeasure::Options, kj::String> measureOptionsOrStartMark,
+      jsg::Optional<kj::String> maybeEndMark);
+
+  void setResourceTimingBufferSize(uint32_t size);
+  void eventLoopUtilization();
+
+  // In the browser, this function is not public.  However, it must be used inside fetch
+  // which is a Node.js dependency, not a internal module
+  void markResourceTiming();
+  jsg::Function<void()> timerify(jsg::Lock& js, jsg::Function<void()> fn);
+
+  JSG_RESOURCE_TYPE(Performance, CompatibilityFlags::Reader flags) {
+    JSG_INHERIT(EventTarget);
+    JSG_READONLY_PROTOTYPE_PROPERTY(timeOrigin, getTimeOrigin);
+    JSG_METHOD(now);
+
+    // The following are provided as non-ops to ensure availability
+    // of the APIS but we are currently not planning to provide
+    // performance timing feedback within a worker using these
+    // apis.
+    JSG_READONLY_PROTOTYPE_PROPERTY(eventCounts, getEventCounts);
+    JSG_METHOD(clearMarks);
+    JSG_METHOD(clearMeasures);
+    JSG_METHOD(clearResourceTimings);
+    JSG_METHOD(getEntries);
+    JSG_METHOD(getEntriesByName);
+    JSG_METHOD(getEntriesByType);
+    JSG_METHOD(mark);
+    JSG_METHOD(measure);
+    JSG_METHOD(setResourceTimingBufferSize);
+
+    if (flags.getNodeJsCompatV2()) {
+      JSG_METHOD(eventLoopUtilization);
+      JSG_METHOD(markResourceTiming);
+      JSG_METHOD(timerify);
+    }
+  }
+};
+
+#define EW_PERFORMANCE_ISOLATE_TYPES                                                               \
+  api::Performance, api::PerformanceMark, api::PerformanceMeasure, api::PerformanceMark::Options,  \
+      api::PerformanceMeasure::Options, api::PerformanceMeasure::Entry,                            \
+      api::PerformanceObserverEntryList, api::PerformanceEntry, api::PerformanceResourceTiming,    \
+      api::PerformanceObserver, api::PerformanceObserver::ObserveOptions,                          \
+      api::PerformanceObserver::CallbackOptions, api::EventCounts,                                 \
+      api::EventCounts::EntryIterator, api::EventCounts::EntryIterator::Next,                      \
+      api::EventCounts::KeyIterator, api::EventCounts::KeyIterator::Next,                          \
+      api::EventCounts::ValueIterator, api::EventCounts::ValueIterator::Next
+
+}  // namespace workerd::api

--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -23,6 +23,7 @@
 #include <workerd/api/messagechannel.h>
 #include <workerd/api/modules.h>
 #include <workerd/api/node/node.h>
+#include <workerd/api/performance.h>
 #include <workerd/api/pyodide/pyodide.h>
 #include <workerd/api/queue.h>
 #include <workerd/api/r2-admin.h>
@@ -89,7 +90,8 @@
   F("messagechannel", EW_MESSAGECHANNEL_ISOLATE_TYPES)                                             \
   F("workers-module", EW_WORKERS_MODULE_ISOLATE_TYPES)                                             \
   F("export-loopback", EW_EXPORT_LOOPBACK_ISOLATE_TYPES)                                           \
-  F("sync-kv", EW_SYNC_KV_ISOLATE_TYPES)
+  F("sync-kv", EW_SYNC_KV_ISOLATE_TYPES)                                                           \
+  F("performance", EW_PERFORMANCE_ISOLATE_TYPES)
 
 namespace workerd::api {
 

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1061,4 +1061,18 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
     $impliedByAfterDate(name = "nodeJsCompat", date = "2025-10-01");
   # Enables the Node.js non-functional stub vm module. It is required to use this flag with
   # nodejs_compat (or nodejs_compat_v2).
+
+  enableNodeJsPerfHooksModule @122 :Bool
+     $compatEnableFlag("enable_nodejs_perf_hooks_module")
+     $compatDisableFlag("disable_nodejs_perf_hooks_module")
+     $impliedByAfterDate(name = "nodeJsCompat", date = "2025-09-21");
+   # Enables the Node.js perf_hooks module. It is required to use this flag with
+   # nodejs_compat (or nodejs_compat_v2).
+
+  enableGlobalPerformanceClasses @123 :Bool
+     $compatEnableFlag("enable_global_performance_classes")
+     $compatDisableFlag("disable_global_performance_classes")
+     $compatEnableDate("2025-09-21");
+   # Enables PerformanceEntry, PerformanceMark, PerformanceMeasure, PerformanceResourceTiming,
+   # PerformanceObserver and PerformanceObserverEntryList global classes.
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -415,6 +415,34 @@ namespace workerd::jsg {
     registry.template registerInspectProperty<NAME, decltype(&Self::getter), &Self::getter>();     \
   } while (false)
 
+// Use inside a JSG_RESOURCE_TYPE to expose a static property on the JavaScript constructor.
+// The property will be read-only and will call the specified static function when accessed.
+// The function should take no parameters or take jsg::Lock& as the first parameter.
+// Example:
+//   static int getVersion() { return 42; }
+//   JSG_RESOURCE_TYPE(MyClass) {
+//     JSG_STATIC_READONLY_PROPERTY(getVersion);  // Exposes as MyClass.getVersion
+//   }
+#define JSG_STATIC_READONLY_PROPERTY(name)                                                         \
+  do {                                                                                             \
+    static const char NAME[] = #name;                                                              \
+    registry.template registerStaticProperty<NAME, decltype(Self::name), &Self::name>();           \
+  } while (false)
+
+// Use inside a JSG_RESOURCE_TYPE to expose a static property with a different name than the
+// underlying C++ function. The property will be read-only and will call the specified static
+// getter function when accessed. The getter can optionally take jsg::Lock& as the first parameter.
+// Example:
+//   static kj::Array<kj::String> getSupportedTypes() { ... }
+//   JSG_RESOURCE_TYPE(MyClass) {
+//     JSG_STATIC_READONLY_PROPERTY_NAMED(supportedTypes, getSupportedTypes);  // MyClass.supportedTypes
+//   }
+#define JSG_STATIC_READONLY_PROPERTY_NAMED(name, getter)                                           \
+  do {                                                                                             \
+    static const char NAME[] = #name;                                                              \
+    registry.template registerStaticProperty<NAME, decltype(Self::getter), &Self::getter>();       \
+  } while (false)
+
 // Use inside a JSG_RESOURCE_TYPE to create a static constant member on the constructor and
 // prototype of this object. Only primitive data types (booleans, strings, numbers) are allowed.
 // Unlike the JSG_INSTANCE_PROPERTY and JSG_READONLY_PROPERTY macros, this does not use a getter

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -561,6 +561,57 @@ struct StaticMethodCallback<TypeWrapper,
   }
 };
 
+// Implements the V8 callback function for static property getters.
+template <typename TypeWrapper,
+    const char* propertyName,
+    typename T,
+    typename Getter,
+    Getter* getter>
+struct StaticPropertyCallback;
+
+template <typename TypeWrapper, const char* propertyName, typename T, typename Ret, Ret (*getter)()>
+struct StaticPropertyCallback<TypeWrapper, propertyName, T, Ret(), getter> {
+
+  static void callback(v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value>& args) {
+    liftKj(args, [&]() {
+      auto isolate = args.GetIsolate();
+      auto context = isolate->GetCurrentContext();
+      auto& wrapper = TypeWrapper::from(isolate);
+      auto& lock = Lock::from(isolate);
+
+      if constexpr (isVoid<Ret>()) {
+        (*getter)();
+      } else {
+        return wrapper.wrap(lock, context, kj::none, (*getter)());
+      }
+    });
+  }
+};
+
+// Specialization for static property getter that takes Lock& as first parameter
+template <typename TypeWrapper,
+    const char* propertyName,
+    typename T,
+    typename Ret,
+    Ret (*getter)(Lock&)>
+struct StaticPropertyCallback<TypeWrapper, propertyName, T, Ret(Lock&), getter> {
+
+  static void callback(v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value>& args) {
+    liftKj(args, [&]() {
+      auto isolate = args.GetIsolate();
+      auto context = isolate->GetCurrentContext();
+      auto& wrapper = TypeWrapper::from(isolate);
+      auto& lock = Lock::from(isolate);
+
+      if constexpr (isVoid<Ret>()) {
+        (*getter)(lock);
+      } else {
+        return wrapper.wrap(lock, context, kj::none, (*getter)(lock));
+      }
+    });
+  }
+};
+
 // Implements the V8 callback function for calling a property getter method of a C++ class.
 template <typename TypeWrapper,
     const char* methodName,
@@ -1264,6 +1315,7 @@ struct ResourceTypeBuilder {
     functionTemplate->RemovePrototype();
     constructor->Set(v8StrIntern(isolate, name), functionTemplate);
   }
+
   template <const char* name, typename Getter, Getter getter, typename Setter, Setter setter>
   inline void registerInstanceProperty() {
     auto v8Name = v8StrIntern(isolate, name);
@@ -1405,6 +1457,13 @@ struct ResourceTypeBuilder {
     constructor->PrototypeTemplate()->Set(v8Name, v8Value, v8::PropertyAttribute::ReadOnly);
   }
 
+  template <const char* name, typename Getter, Getter getter>
+  inline void registerStaticProperty() {
+    constructor->SetNativeDataProperty(v8StrIntern(isolate, name),
+        &StaticPropertyCallback<TypeWrapper, name, Self, Getter, getter>::callback, nullptr,
+        v8::Local<v8::Value>(), v8::PropertyAttribute::ReadOnly);
+  }
+
   template <const char* name, typename Method, Method method>
   inline void registerIterable() {
     prototype->Set(v8::Symbol::GetIterator(isolate),
@@ -1530,6 +1589,9 @@ struct JsSetup {
 
   template <const char* name, typename T>
   inline void registerStaticConstant(T value) {}
+
+  template <const char* name, typename Getter, Getter getter>
+  inline void registerStaticProperty() {}
 
   template <const char* name, typename Method, Method method>
   inline void registerIterable() {}

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -651,6 +651,11 @@ struct MemberCounter {
     ++members;
   }
 
+  template <const char* name, typename Getter, Getter getter>
+  inline void registerStaticProperty() {
+    ++members;
+  }
+
   template <const char* name, typename Method, Method method>
   inline void registerStaticMethod() {
     ++members;
@@ -775,6 +780,16 @@ struct MembersBuilder {
     constant.setName(name);
     constant.setValue(value);
     // BuildRtti<Configuration, T>::build(constant.initType());
+  }
+
+  template <const char* name, typename Getter, Getter getter>
+  inline void registerStaticProperty() {
+    auto prop = members[memberIndex++].initProperty();
+    prop.setName(name);
+    prop.setReadonly(true);
+    prop.setGetterFastApiCompatible(isFastApiCompatible<Getter>);
+    using GetterTraits = FunctionTraits<Getter>;
+    BuildRtti<Configuration, typename GetterTraits::ReturnType>::build(prop.initType(), rtti);
   }
 
   template <typename Property, Property Self::*property>

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -24,6 +24,7 @@
 #include <workerd/api/memory-cache.h>
 #include <workerd/api/modules.h>
 #include <workerd/api/node/node.h>
+#include <workerd/api/performance.h>
 #include <workerd/api/pyodide/pyodide.h>
 #include <workerd/api/pyodide/requirements.h>
 #include <workerd/api/pyodide/setup-emscripten.h>
@@ -134,6 +135,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
     EW_MESSAGECHANNEL_ISOLATE_TYPES,
     EW_WORKERS_MODULE_ISOLATE_TYPES,
     EW_EXPORT_LOOPBACK_ISOLATE_TYPES,
+    EW_PERFORMANCE_ISOLATE_TYPES,
     workerd::api::EnvModule,
 
     jsg::TypeWrapperExtension<PromiseWrapper>,

--- a/src/wpt/BUILD.bazel
+++ b/src/wpt/BUILD.bazel
@@ -119,3 +119,9 @@ wpt_test(
     config = "fs-test.ts",
     wpt_directory = "@wpt//:fs@module",
 )
+
+wpt_test(
+    name = "performance-timeline",
+    config = "performance-timeline-test.ts",
+    wpt_directory = "@wpt//:performance-timeline@module",
+)

--- a/src/wpt/performance-timeline-test.ts
+++ b/src/wpt/performance-timeline-test.ts
@@ -1,0 +1,224 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { type TestRunnerConfig } from 'harness/harness';
+
+export default {
+  'buffered-flag-after-timeout.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: [
+      'PerformanceObserver with buffered flag sees entry after timeout',
+    ],
+  },
+  'buffered-flag-observer.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: [
+      'PerformanceObserver with buffered flag should see past and future entries.',
+    ],
+  },
+  'buffered-flag-with-entryTypes-observer.tentative.any.js': {
+    comment: 'This is a tentative test',
+    omittedTests: true,
+  },
+  'case-sensitivity.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: [
+      'getEntriesByType values are case sensitive',
+      'getEntriesByName values are case sensitive',
+      'observe() and case sensitivity for types/entryTypes and buffered.',
+    ],
+  },
+  'droppedentriescount.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: [
+      'Dropped entries count is 0 when there are no dropped entries of relevant type.',
+      'Dropped entries correctly counted with multiple types.',
+      'Dropped entries counted even if observer was not registered at the time.',
+      'Dropped entries only surfaced on the first callback.',
+      'Dropped entries surfaced after an observe() call!',
+    ],
+  },
+  'idlharness.any.js': {
+    comment:
+      'Test file /resources/WebIDLParser.js not found. Update wpt_test.bzl to handle this case.',
+    omittedTests: true,
+  },
+  'multiple-buffered-flag-observers.any.js': {
+    comment: 'This is not yet implemented',
+    omittedTests: [
+      'Multiple PerformanceObservers with buffered flag see all entries',
+    ],
+  },
+  'navigation-id.helper.js': {},
+  'not-restored-reasons/abort-block-bfcache.window.js': {
+    comment: 'This is not yet implemented',
+    omittedTests: ['aborting a parser should block bfcache.'],
+  },
+  'not-restored-reasons/performance-navigation-timing-attributes.tentative.window.js':
+    {
+      comment: 'This is a tentative test',
+      omittedTests: true,
+    },
+  'not-restored-reasons/performance-navigation-timing-bfcache-reasons-stay.tentative.window.js':
+    {
+      comment: 'This is a tentative test',
+      omittedTests: true,
+    },
+  'not-restored-reasons/performance-navigation-timing-bfcache.tentative.window.js':
+    {
+      comment: 'This is a tentative test',
+      omittedTests: true,
+    },
+  'not-restored-reasons/performance-navigation-timing-cross-origin-bfcache.tentative.window.js':
+    {
+      comment: 'This is a tentative test',
+      omittedTests: true,
+    },
+  'not-restored-reasons/performance-navigation-timing-fetch.tentative.window.js':
+    {
+      comment: 'This is a tentative test',
+      omittedTests: true,
+    },
+  'not-restored-reasons/performance-navigation-timing-iframes-without-attributes.tentative.window.js':
+    {
+      comment: 'This is a tentative test',
+      omittedTests: true,
+    },
+  'not-restored-reasons/performance-navigation-timing-lock.https.tentative.window.js':
+    {
+      comment: 'This is a tentative test',
+      omittedTests: true,
+    },
+  'not-restored-reasons/performance-navigation-timing-navigation-failure.tentative.window.js':
+    {
+      comment: 'This is a tentative test',
+      omittedTests: true,
+    },
+  'not-restored-reasons/performance-navigation-timing-not-bfcached.tentative.window.js':
+    {
+      comment: 'This is a tentative test',
+      omittedTests: true,
+    },
+  'not-restored-reasons/performance-navigation-timing-redirect-on-history.tentative.window.js':
+    {
+      comment: 'This is a tentative test',
+      omittedTests: true,
+    },
+  'not-restored-reasons/performance-navigation-timing-reload.tentative.window.js':
+    {
+      comment: 'This is a tentative test',
+      omittedTests: true,
+    },
+  'not-restored-reasons/performance-navigation-timing-same-origin-bfcache.tentative.window.js':
+    {
+      comment: 'This is a tentative test',
+      omittedTests: true,
+    },
+  'not-restored-reasons/performance-navigation-timing-same-origin-replace.tentative.window.js':
+    {
+      comment: 'This is a tentative test',
+      omittedTests: true,
+    },
+  'not-restored-reasons/test-helper.js': {
+    comment:
+      'Test file /html/browsers/browsing-the-web/back-forward-cache/resources/rc-helper.js not found. Update wpt_test.bzl to handle this case.',
+    omittedTests: true,
+  },
+  'observer-buffered-false.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: [
+      'PerformanceObserver without buffered flag set to false cannot see past entries.',
+    ],
+  },
+  'performanceentry-tojson.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: ['Test toJSON() in PerformanceEntry'],
+  },
+  'performanceobservers.js': {},
+  'po-callback-mutate.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: [
+      'PerformanceObserver modifications inside callback should update filtering and not clear buffer',
+    ],
+  },
+  'po-disconnect-removes-observed-types.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: [
+      'Types observed are forgotten when disconnect() is called.',
+    ],
+  },
+  'po-disconnect.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: [
+      'disconnected callbacks must not be invoked',
+      'disconnecting an unconnected observer is a no-op',
+      'An observer disconnected after a mark must not have its callback invoked',
+    ],
+  },
+  'po-entries-sort.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: [
+      'getEntries, getEntriesByType, getEntriesByName sort order',
+    ],
+  },
+  'po-getentries.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: ['getEntries, getEntriesByType and getEntriesByName work'],
+  },
+  'po-mark-measure.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: [
+      'entries are observable',
+      'mark entries are observable',
+      'measure entries are observable',
+    ],
+  },
+  'po-observe-repeated-type.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: [
+      "Two calls of observe() with the same 'type' cause override.",
+    ],
+  },
+  'po-observe-type.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: [
+      "Calling observe() without 'type' or 'entryTypes' throws a TypeError",
+      'Calling observe() with entryTypes and then type should throw an InvalidModificationError',
+      'Calling observe() with type and then entryTypes should throw an InvalidModificationError',
+      'Calling observe() with type and entryTypes should throw a TypeError',
+      'Passing in unknown values to type does throw an exception.',
+      'observe() with different type values stacks.',
+    ],
+  },
+  'po-observe.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: [
+      'entryTypes must be a sequence or throw a TypeError',
+      'Empty sequence entryTypes does not throw an exception.',
+      'Unknown entryTypes do not throw an exception.',
+      'Filter unsupported entryType entryType names within the entryTypes sequence',
+      'Check observer callback parameter and this values',
+      'replace observer if already present',
+    ],
+  },
+  'po-takeRecords.any.js': {
+    comment: 'This is not yet implemented',
+    disabledTests: ["Test PerformanceObserver's takeRecords()"],
+  },
+  'supportedEntryTypes.any.js': {
+    comment:
+      'Test expect non-empty array that is cached. Our implementation does not cache it yet.',
+    disabledTests: [
+      'supportedEntryTypes exists and returns entries in alphabetical order',
+      'supportedEntryTypes caches result',
+    ],
+  },
+  'webtiming-resolution.any.js': {
+    comment: 'We intentionally fail on these',
+    disabledTests: [
+      'Verifies the resolution of performance.now() is at least 5 microseconds.',
+      'Verifies the resolution of entry.startTime is at least 5 microseconds.',
+    ],
+  },
+} satisfies TestRunnerConfig;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -301,6 +301,13 @@ interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
   FixedLengthStream: typeof FixedLengthStream;
   IdentityTransformStream: typeof IdentityTransformStream;
   HTMLRewriter: typeof HTMLRewriter;
+  Performance: typeof Performance;
+  PerformanceEntry: typeof PerformanceEntry;
+  PerformanceMark: typeof PerformanceMark;
+  PerformanceMeasure: typeof PerformanceMeasure;
+  PerformanceResourceTiming: typeof PerformanceResourceTiming;
+  PerformanceObserver: typeof PerformanceObserver;
+  PerformanceObserverEntryList: typeof PerformanceObserverEntryList;
 }
 declare function addEventListener<Type extends keyof WorkerGlobalScopeEventMap>(
   type: Type,
@@ -477,18 +484,6 @@ declare abstract class Navigator {
   readonly language: string;
   readonly languages: string[];
   readonly storage: StorageManager;
-}
-/**
- * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
- * as well as timing of subrequests and other operations.
- *
- * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
- */
-interface Performance {
-  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancetimeorigin) */
-  readonly timeOrigin: number;
-  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancenow) */
-  now(): number;
 }
 interface AlarmInvocationInfo {
   readonly isRetry: boolean;
@@ -3362,6 +3357,169 @@ interface SyncKvListOptions {
   prefix?: string;
   reverse?: boolean;
   limit?: number;
+}
+/**
+ * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
+ * as well as timing of subrequests and other operations.
+ *
+ * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
+ */
+declare abstract class Performance extends EventTarget {
+  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancetimeorigin) */
+  get timeOrigin(): number;
+  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancenow) */
+  now(): number;
+  get eventCounts(): EventCounts;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/clearMarks) */
+  clearMarks(name?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/clearMeasures) */
+  clearMeasures(name?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/clearResourceTimings) */
+  clearResourceTimings(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/getEntries) */
+  getEntries(): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/getEntriesByName) */
+  getEntriesByName(name: string, type: string): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/getEntriesByType) */
+  getEntriesByType(type: string): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/mark) */
+  mark(name: string, options?: PerformanceMarkOptions): PerformanceMark;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/measure) */
+  measure(
+    measureName: string,
+    measureOptionsOrStartMark: PerformanceMeasureOptions | string,
+    maybeEndMark?: string,
+  ): PerformanceMeasure;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/setResourceTimingBufferSize) */
+  setResourceTimingBufferSize(size: number): void;
+}
+/**
+ * PerformanceMark is an abstract interface for PerformanceEntry objects with an entryType of "mark". Entries of this type are created by calling performance.mark() to add a named DOMHighResTimeStamp (the mark) to the browser's performance timeline.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMark)
+ */
+declare abstract class PerformanceMark extends PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMark/detail) */
+  get detail(): any;
+}
+/**
+ * PerformanceMeasure is an abstract interface for PerformanceEntry objects with an entryType of "measure". Entries of this type are created by calling performance.measure() to add a named DOMHighResTimeStamp (the measure) between two marks to the browser's performance timeline.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMeasure)
+ */
+declare abstract class PerformanceMeasure extends PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMeasure/detail) */
+  get detail(): any;
+}
+interface PerformanceMarkOptions {
+  detail?: any;
+  startTime?: number;
+}
+interface PerformanceMeasureOptions {
+  detail?: any;
+  start?: number;
+  duration?: number;
+  end?: number;
+}
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList) */
+declare abstract class PerformanceObserverEntryList {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList/getEntries) */
+  getEntries(): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList/getEntriesByType) */
+  getEntriesByType(type: string): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList/getEntriesByName) */
+  getEntriesByName(name: string, type?: string): PerformanceEntry[];
+}
+/**
+ * Encapsulates a single performance metric that is part of the performance timeline. A performance entry can be directly created by making a performance mark or measure (for example by calling the mark() method) at an explicit point in an application. Performance entries are also created in indirect ways such as loading a resource (such as an image).
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry)
+ */
+declare abstract class PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/name) */
+  get name(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/entryType) */
+  get entryType(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/startTime) */
+  get startTime(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/duration) */
+  get duration(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/toJSON) */
+  toJSON(): any;
+}
+/**
+ * Enables retrieval and analysis of detailed network timing data regarding the loading of an application's resources. An application can use the timing metrics to determine, for example, the length of time it takes to fetch a specific resource, such as an XMLHttpRequest, <SVG>, image, or script.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming)
+ */
+declare abstract class PerformanceResourceTiming extends PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/connectEnd) */
+  get connectEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/connectStart) */
+  get connectStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/decodedBodySize) */
+  get decodedBodySize(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/domainLookupEnd) */
+  get domainLookupEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/domainLookupStart) */
+  get domainLookupStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/encodedBodySize) */
+  get encodedBodySize(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/fetchStart) */
+  get fetchStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/initiatorType) */
+  get initiatorType(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/nextHopProtocol) */
+  get nextHopProtocol(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/redirectEnd) */
+  get redirectEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/redirectStart) */
+  get redirectStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/requestStart) */
+  get requestStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/responseEnd) */
+  get responseEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/responseStart) */
+  get responseStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/responseStatus) */
+  get responseStatus(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/secureConnectionStart) */
+  get secureConnectionStart(): number | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/transferSize) */
+  get transferSize(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/workerStart) */
+  get workerStart(): number;
+}
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) */
+declare class PerformanceObserver {
+  constructor(callback: any);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/disconnect) */
+  disconnect(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/observe) */
+  observe(options?: PerformanceObserverObserveOptions): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/takeRecords) */
+  takeRecords(): PerformanceEntry[];
+  readonly supportedEntryTypes: string[];
+}
+interface PerformanceObserverObserveOptions {
+  buffered: boolean;
+  durationThreshold: number;
+  entryTypes: string[];
+  type?: string;
+  name?: string;
+}
+interface EventCounts {
+  get size(): number;
+  get(eventType: string): number | undefined;
+  has(eventType: string): boolean;
+  entries(): IterableIterator<string[]>;
+  keys(): IterableIterator<string>;
+  values(): IterableIterator<number>;
+  forEach(
+    param1: (param0: number, param1: string, param2: EventCounts) => void,
+    param2?: any,
+  ): void;
+  [Symbol.iterator](): IterableIterator<string[]>;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -301,6 +301,13 @@ export interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
   FixedLengthStream: typeof FixedLengthStream;
   IdentityTransformStream: typeof IdentityTransformStream;
   HTMLRewriter: typeof HTMLRewriter;
+  Performance: typeof Performance;
+  PerformanceEntry: typeof PerformanceEntry;
+  PerformanceMark: typeof PerformanceMark;
+  PerformanceMeasure: typeof PerformanceMeasure;
+  PerformanceResourceTiming: typeof PerformanceResourceTiming;
+  PerformanceObserver: typeof PerformanceObserver;
+  PerformanceObserverEntryList: typeof PerformanceObserverEntryList;
 }
 export declare function addEventListener<
   Type extends keyof WorkerGlobalScopeEventMap,
@@ -482,18 +489,6 @@ export declare abstract class Navigator {
   readonly language: string;
   readonly languages: string[];
   readonly storage: StorageManager;
-}
-/**
- * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
- * as well as timing of subrequests and other operations.
- *
- * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
- */
-export interface Performance {
-  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancetimeorigin) */
-  readonly timeOrigin: number;
-  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancenow) */
-  now(): number;
 }
 export interface AlarmInvocationInfo {
   readonly isRetry: boolean;
@@ -3375,6 +3370,169 @@ export interface SyncKvListOptions {
   prefix?: string;
   reverse?: boolean;
   limit?: number;
+}
+/**
+ * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
+ * as well as timing of subrequests and other operations.
+ *
+ * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
+ */
+export declare abstract class Performance extends EventTarget {
+  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancetimeorigin) */
+  get timeOrigin(): number;
+  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancenow) */
+  now(): number;
+  get eventCounts(): EventCounts;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/clearMarks) */
+  clearMarks(name?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/clearMeasures) */
+  clearMeasures(name?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/clearResourceTimings) */
+  clearResourceTimings(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/getEntries) */
+  getEntries(): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/getEntriesByName) */
+  getEntriesByName(name: string, type: string): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/getEntriesByType) */
+  getEntriesByType(type: string): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/mark) */
+  mark(name: string, options?: PerformanceMarkOptions): PerformanceMark;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/measure) */
+  measure(
+    measureName: string,
+    measureOptionsOrStartMark: PerformanceMeasureOptions | string,
+    maybeEndMark?: string,
+  ): PerformanceMeasure;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/setResourceTimingBufferSize) */
+  setResourceTimingBufferSize(size: number): void;
+}
+/**
+ * PerformanceMark is an abstract interface for PerformanceEntry objects with an entryType of "mark". Entries of this type are created by calling performance.mark() to add a named DOMHighResTimeStamp (the mark) to the browser's performance timeline.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMark)
+ */
+export declare abstract class PerformanceMark extends PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMark/detail) */
+  get detail(): any;
+}
+/**
+ * PerformanceMeasure is an abstract interface for PerformanceEntry objects with an entryType of "measure". Entries of this type are created by calling performance.measure() to add a named DOMHighResTimeStamp (the measure) between two marks to the browser's performance timeline.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMeasure)
+ */
+export declare abstract class PerformanceMeasure extends PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMeasure/detail) */
+  get detail(): any;
+}
+export interface PerformanceMarkOptions {
+  detail?: any;
+  startTime?: number;
+}
+export interface PerformanceMeasureOptions {
+  detail?: any;
+  start?: number;
+  duration?: number;
+  end?: number;
+}
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList) */
+export declare abstract class PerformanceObserverEntryList {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList/getEntries) */
+  getEntries(): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList/getEntriesByType) */
+  getEntriesByType(type: string): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList/getEntriesByName) */
+  getEntriesByName(name: string, type?: string): PerformanceEntry[];
+}
+/**
+ * Encapsulates a single performance metric that is part of the performance timeline. A performance entry can be directly created by making a performance mark or measure (for example by calling the mark() method) at an explicit point in an application. Performance entries are also created in indirect ways such as loading a resource (such as an image).
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry)
+ */
+export declare abstract class PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/name) */
+  get name(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/entryType) */
+  get entryType(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/startTime) */
+  get startTime(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/duration) */
+  get duration(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/toJSON) */
+  toJSON(): any;
+}
+/**
+ * Enables retrieval and analysis of detailed network timing data regarding the loading of an application's resources. An application can use the timing metrics to determine, for example, the length of time it takes to fetch a specific resource, such as an XMLHttpRequest, <SVG>, image, or script.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming)
+ */
+export declare abstract class PerformanceResourceTiming extends PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/connectEnd) */
+  get connectEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/connectStart) */
+  get connectStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/decodedBodySize) */
+  get decodedBodySize(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/domainLookupEnd) */
+  get domainLookupEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/domainLookupStart) */
+  get domainLookupStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/encodedBodySize) */
+  get encodedBodySize(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/fetchStart) */
+  get fetchStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/initiatorType) */
+  get initiatorType(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/nextHopProtocol) */
+  get nextHopProtocol(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/redirectEnd) */
+  get redirectEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/redirectStart) */
+  get redirectStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/requestStart) */
+  get requestStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/responseEnd) */
+  get responseEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/responseStart) */
+  get responseStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/responseStatus) */
+  get responseStatus(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/secureConnectionStart) */
+  get secureConnectionStart(): number | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/transferSize) */
+  get transferSize(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/workerStart) */
+  get workerStart(): number;
+}
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) */
+export declare class PerformanceObserver {
+  constructor(callback: any);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/disconnect) */
+  disconnect(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/observe) */
+  observe(options?: PerformanceObserverObserveOptions): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/takeRecords) */
+  takeRecords(): PerformanceEntry[];
+  readonly supportedEntryTypes: string[];
+}
+export interface PerformanceObserverObserveOptions {
+  buffered: boolean;
+  durationThreshold: number;
+  entryTypes: string[];
+  type?: string;
+  name?: string;
+}
+export interface EventCounts {
+  get size(): number;
+  get(eventType: string): number | undefined;
+  has(eventType: string): boolean;
+  entries(): IterableIterator<string[]>;
+  keys(): IterableIterator<string>;
+  values(): IterableIterator<number>;
+  forEach(
+    param1: (param0: number, param1: string, param2: EventCounts) => void,
+    param2?: any,
+  ): void;
+  [Symbol.iterator](): IterableIterator<string[]>;
 }
 export type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -296,6 +296,13 @@ interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
   FixedLengthStream: typeof FixedLengthStream;
   IdentityTransformStream: typeof IdentityTransformStream;
   HTMLRewriter: typeof HTMLRewriter;
+  Performance: typeof Performance;
+  PerformanceEntry: typeof PerformanceEntry;
+  PerformanceMark: typeof PerformanceMark;
+  PerformanceMeasure: typeof PerformanceMeasure;
+  PerformanceResourceTiming: typeof PerformanceResourceTiming;
+  PerformanceObserver: typeof PerformanceObserver;
+  PerformanceObserverEntryList: typeof PerformanceObserverEntryList;
 }
 declare function addEventListener<Type extends keyof WorkerGlobalScopeEventMap>(
   type: Type,
@@ -469,18 +476,6 @@ declare abstract class Navigator {
   readonly hardwareConcurrency: number;
   readonly language: string;
   readonly languages: string[];
-}
-/**
- * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
- * as well as timing of subrequests and other operations.
- *
- * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
- */
-interface Performance {
-  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancetimeorigin) */
-  readonly timeOrigin: number;
-  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancenow) */
-  now(): number;
 }
 interface AlarmInvocationInfo {
   readonly isRetry: boolean;
@@ -3133,6 +3128,169 @@ interface SyncKvListOptions {
   prefix?: string;
   reverse?: boolean;
   limit?: number;
+}
+/**
+ * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
+ * as well as timing of subrequests and other operations.
+ *
+ * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
+ */
+declare abstract class Performance extends EventTarget {
+  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancetimeorigin) */
+  get timeOrigin(): number;
+  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancenow) */
+  now(): number;
+  get eventCounts(): EventCounts;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/clearMarks) */
+  clearMarks(name?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/clearMeasures) */
+  clearMeasures(name?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/clearResourceTimings) */
+  clearResourceTimings(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/getEntries) */
+  getEntries(): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/getEntriesByName) */
+  getEntriesByName(name: string, type: string): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/getEntriesByType) */
+  getEntriesByType(type: string): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/mark) */
+  mark(name: string, options?: PerformanceMarkOptions): PerformanceMark;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/measure) */
+  measure(
+    measureName: string,
+    measureOptionsOrStartMark: PerformanceMeasureOptions | string,
+    maybeEndMark?: string,
+  ): PerformanceMeasure;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/setResourceTimingBufferSize) */
+  setResourceTimingBufferSize(size: number): void;
+}
+/**
+ * PerformanceMark is an abstract interface for PerformanceEntry objects with an entryType of "mark". Entries of this type are created by calling performance.mark() to add a named DOMHighResTimeStamp (the mark) to the browser's performance timeline.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMark)
+ */
+declare abstract class PerformanceMark extends PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMark/detail) */
+  get detail(): any;
+}
+/**
+ * PerformanceMeasure is an abstract interface for PerformanceEntry objects with an entryType of "measure". Entries of this type are created by calling performance.measure() to add a named DOMHighResTimeStamp (the measure) between two marks to the browser's performance timeline.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMeasure)
+ */
+declare abstract class PerformanceMeasure extends PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMeasure/detail) */
+  get detail(): any;
+}
+interface PerformanceMarkOptions {
+  detail?: any;
+  startTime?: number;
+}
+interface PerformanceMeasureOptions {
+  detail?: any;
+  start?: number;
+  duration?: number;
+  end?: number;
+}
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList) */
+declare abstract class PerformanceObserverEntryList {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList/getEntries) */
+  getEntries(): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList/getEntriesByType) */
+  getEntriesByType(type: string): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList/getEntriesByName) */
+  getEntriesByName(name: string, type?: string): PerformanceEntry[];
+}
+/**
+ * Encapsulates a single performance metric that is part of the performance timeline. A performance entry can be directly created by making a performance mark or measure (for example by calling the mark() method) at an explicit point in an application. Performance entries are also created in indirect ways such as loading a resource (such as an image).
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry)
+ */
+declare abstract class PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/name) */
+  get name(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/entryType) */
+  get entryType(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/startTime) */
+  get startTime(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/duration) */
+  get duration(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/toJSON) */
+  toJSON(): any;
+}
+/**
+ * Enables retrieval and analysis of detailed network timing data regarding the loading of an application's resources. An application can use the timing metrics to determine, for example, the length of time it takes to fetch a specific resource, such as an XMLHttpRequest, <SVG>, image, or script.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming)
+ */
+declare abstract class PerformanceResourceTiming extends PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/connectEnd) */
+  get connectEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/connectStart) */
+  get connectStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/decodedBodySize) */
+  get decodedBodySize(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/domainLookupEnd) */
+  get domainLookupEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/domainLookupStart) */
+  get domainLookupStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/encodedBodySize) */
+  get encodedBodySize(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/fetchStart) */
+  get fetchStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/initiatorType) */
+  get initiatorType(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/nextHopProtocol) */
+  get nextHopProtocol(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/redirectEnd) */
+  get redirectEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/redirectStart) */
+  get redirectStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/requestStart) */
+  get requestStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/responseEnd) */
+  get responseEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/responseStart) */
+  get responseStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/responseStatus) */
+  get responseStatus(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/secureConnectionStart) */
+  get secureConnectionStart(): number | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/transferSize) */
+  get transferSize(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/workerStart) */
+  get workerStart(): number;
+}
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) */
+declare class PerformanceObserver {
+  constructor(callback: any);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/disconnect) */
+  disconnect(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/observe) */
+  observe(options?: PerformanceObserverObserveOptions): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/takeRecords) */
+  takeRecords(): PerformanceEntry[];
+  readonly supportedEntryTypes: string[];
+}
+interface PerformanceObserverObserveOptions {
+  buffered: boolean;
+  durationThreshold: number;
+  entryTypes: string[];
+  type?: string;
+  name?: string;
+}
+interface EventCounts {
+  get size(): number;
+  get(eventType: string): number | undefined;
+  has(eventType: string): boolean;
+  entries(): IterableIterator<string[]>;
+  keys(): IterableIterator<string>;
+  values(): IterableIterator<number>;
+  forEach(
+    param1: (param0: number, param1: string, param2: EventCounts) => void,
+    param2?: any,
+  ): void;
+  [Symbol.iterator](): IterableIterator<string[]>;
 }
 type AiImageClassificationInput = {
   image: number[];

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -296,6 +296,13 @@ export interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
   FixedLengthStream: typeof FixedLengthStream;
   IdentityTransformStream: typeof IdentityTransformStream;
   HTMLRewriter: typeof HTMLRewriter;
+  Performance: typeof Performance;
+  PerformanceEntry: typeof PerformanceEntry;
+  PerformanceMark: typeof PerformanceMark;
+  PerformanceMeasure: typeof PerformanceMeasure;
+  PerformanceResourceTiming: typeof PerformanceResourceTiming;
+  PerformanceObserver: typeof PerformanceObserver;
+  PerformanceObserverEntryList: typeof PerformanceObserverEntryList;
 }
 export declare function addEventListener<
   Type extends keyof WorkerGlobalScopeEventMap,
@@ -474,18 +481,6 @@ export declare abstract class Navigator {
   readonly hardwareConcurrency: number;
   readonly language: string;
   readonly languages: string[];
-}
-/**
- * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
- * as well as timing of subrequests and other operations.
- *
- * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
- */
-export interface Performance {
-  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancetimeorigin) */
-  readonly timeOrigin: number;
-  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancenow) */
-  now(): number;
 }
 export interface AlarmInvocationInfo {
   readonly isRetry: boolean;
@@ -3144,6 +3139,169 @@ export interface SyncKvListOptions {
   prefix?: string;
   reverse?: boolean;
   limit?: number;
+}
+/**
+ * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
+ * as well as timing of subrequests and other operations.
+ *
+ * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
+ */
+export declare abstract class Performance extends EventTarget {
+  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancetimeorigin) */
+  get timeOrigin(): number;
+  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancenow) */
+  now(): number;
+  get eventCounts(): EventCounts;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/clearMarks) */
+  clearMarks(name?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/clearMeasures) */
+  clearMeasures(name?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/clearResourceTimings) */
+  clearResourceTimings(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/getEntries) */
+  getEntries(): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/getEntriesByName) */
+  getEntriesByName(name: string, type: string): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/getEntriesByType) */
+  getEntriesByType(type: string): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/mark) */
+  mark(name: string, options?: PerformanceMarkOptions): PerformanceMark;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/measure) */
+  measure(
+    measureName: string,
+    measureOptionsOrStartMark: PerformanceMeasureOptions | string,
+    maybeEndMark?: string,
+  ): PerformanceMeasure;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/setResourceTimingBufferSize) */
+  setResourceTimingBufferSize(size: number): void;
+}
+/**
+ * PerformanceMark is an abstract interface for PerformanceEntry objects with an entryType of "mark". Entries of this type are created by calling performance.mark() to add a named DOMHighResTimeStamp (the mark) to the browser's performance timeline.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMark)
+ */
+export declare abstract class PerformanceMark extends PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMark/detail) */
+  get detail(): any;
+}
+/**
+ * PerformanceMeasure is an abstract interface for PerformanceEntry objects with an entryType of "measure". Entries of this type are created by calling performance.measure() to add a named DOMHighResTimeStamp (the measure) between two marks to the browser's performance timeline.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMeasure)
+ */
+export declare abstract class PerformanceMeasure extends PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceMeasure/detail) */
+  get detail(): any;
+}
+export interface PerformanceMarkOptions {
+  detail?: any;
+  startTime?: number;
+}
+export interface PerformanceMeasureOptions {
+  detail?: any;
+  start?: number;
+  duration?: number;
+  end?: number;
+}
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList) */
+export declare abstract class PerformanceObserverEntryList {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList/getEntries) */
+  getEntries(): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList/getEntriesByType) */
+  getEntriesByType(type: string): PerformanceEntry[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList/getEntriesByName) */
+  getEntriesByName(name: string, type?: string): PerformanceEntry[];
+}
+/**
+ * Encapsulates a single performance metric that is part of the performance timeline. A performance entry can be directly created by making a performance mark or measure (for example by calling the mark() method) at an explicit point in an application. Performance entries are also created in indirect ways such as loading a resource (such as an image).
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry)
+ */
+export declare abstract class PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/name) */
+  get name(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/entryType) */
+  get entryType(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/startTime) */
+  get startTime(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/duration) */
+  get duration(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceEntry/toJSON) */
+  toJSON(): any;
+}
+/**
+ * Enables retrieval and analysis of detailed network timing data regarding the loading of an application's resources. An application can use the timing metrics to determine, for example, the length of time it takes to fetch a specific resource, such as an XMLHttpRequest, <SVG>, image, or script.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming)
+ */
+export declare abstract class PerformanceResourceTiming extends PerformanceEntry {
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/connectEnd) */
+  get connectEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/connectStart) */
+  get connectStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/decodedBodySize) */
+  get decodedBodySize(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/domainLookupEnd) */
+  get domainLookupEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/domainLookupStart) */
+  get domainLookupStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/encodedBodySize) */
+  get encodedBodySize(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/fetchStart) */
+  get fetchStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/initiatorType) */
+  get initiatorType(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/nextHopProtocol) */
+  get nextHopProtocol(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/redirectEnd) */
+  get redirectEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/redirectStart) */
+  get redirectStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/requestStart) */
+  get requestStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/responseEnd) */
+  get responseEnd(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/responseStart) */
+  get responseStart(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/responseStatus) */
+  get responseStatus(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/secureConnectionStart) */
+  get secureConnectionStart(): number | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/transferSize) */
+  get transferSize(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/workerStart) */
+  get workerStart(): number;
+}
+/* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) */
+export declare class PerformanceObserver {
+  constructor(callback: any);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/disconnect) */
+  disconnect(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/observe) */
+  observe(options?: PerformanceObserverObserveOptions): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/takeRecords) */
+  takeRecords(): PerformanceEntry[];
+  readonly supportedEntryTypes: string[];
+}
+export interface PerformanceObserverObserveOptions {
+  buffered: boolean;
+  durationThreshold: number;
+  entryTypes: string[];
+  type?: string;
+  name?: string;
+}
+export interface EventCounts {
+  get size(): number;
+  get(eventType: string): number | undefined;
+  has(eventType: string): boolean;
+  entries(): IterableIterator<string[]>;
+  keys(): IterableIterator<string>;
+  values(): IterableIterator<number>;
+  forEach(
+    param1: (param0: number, param1: string, param2: EventCounts) => void,
+    param2?: any,
+  ): void;
+  [Symbol.iterator](): IterableIterator<string[]>;
 }
 export type AiImageClassificationInput = {
   image: number[];


### PR DESCRIPTION
Adds node:perf_hooks module and several global Performance prefixed classes.

### TODO

- [x] Tests
- [x] Update global performance under a different compat flag