### PR TITLE
[wpt] Update status of some fetch tests

### DIFF
--- a/src/wpt/fetch/api-test.ts
+++ b/src/wpt/fetch/api-test.ts
@@ -59,8 +59,8 @@ export default {
   },
   'basic/conditional-get.any.js': {
     comment:
-      "It seems like they expect us to use the ETag if re-requested but return 200 OK anyway. Don't quite get it.",
-    expectedFailures: ['Testing conditional GET with ETags'],
+      "This test is too browser specific. It's assuming a request was served from cache vs received by server.",
+    omittedTests: ['Testing conditional GET with ETags'],
   },
   'basic/error-after-response.any.js': {
     comment:
@@ -87,20 +87,12 @@ export default {
     disabledTests: true,
   },
   'basic/keepalive.any.js': {
-    comment: 'Hard to run - involves iframes and workers',
-    expectedFailures: [
-      "[keepalive] simple GET request on 'load' [no payload]; setting up",
-      "[keepalive] simple GET request on 'unload' [no payload]; setting up",
-      "[keepalive] simple GET request on 'pagehide' [no payload]; setting up",
-      "[keepalive] simple POST request on 'load' [no payload]; setting up",
-      "[keepalive] simple POST request on 'unload' [no payload]; setting up",
-      "[keepalive] simple POST request on 'pagehide' [no payload]; setting up",
-      'simple keepalive test for web workers;',
-    ],
+    comment: 'Keepalive is not implemented',
+    disabledTests: true,
   },
   'basic/mediasource.window.js': {
-    comment: 'MediaSource not implemented',
-    expectedFailures: ['Cannot fetch blob: URL from a MediaSource'],
+    comment: 'MediaSource not implemented. It is DOM-specific',
+    omittedTests: ['Cannot fetch blob: URL from a MediaSource'],
   },
   'basic/mode-no-cors.sub.any.js': {
     comment: 'Request.mode is not relevant to us',
@@ -112,7 +104,7 @@ export default {
   },
   'basic/referrer.any.js': {
     comment: 'Referrer is not implemented',
-    disabledTests: true,
+    omittedTests: true,
   },
   'basic/request-forbidden-headers.any.js': {
     comment: 'We do not have forbidden headers',
@@ -130,7 +122,7 @@ export default {
   'basic/request-headers.any.js': {
     comment: 'Reasons listed per test case',
     expectedFailures: [
-      // Float16Array not implemengted
+      // Float16Array not implemented
       'Fetch with POST with Float16Array body',
       // Fake HTTP method names not accepted
       'Fetch with Chicken',
@@ -146,7 +138,7 @@ export default {
       'Fetch with PUT and mode "same-origin" needs an Origin header',
       'Fetch with PUT with body',
       'Fetch with POST and mode "no-cors" needs an Origin header',
-      // WPT is epxecting us to insert some kind of User-Agent
+      // WPT is expecting us to insert some kind of User-Agent
       'Fetch with GET',
       'Fetch with POST with Blob body',
       'Fetch with POST with Float64Array body',
@@ -169,14 +161,14 @@ export default {
   },
   'basic/request-referrer.any.js': {
     comment: 'Referrer is not implemented',
-    disabledTests: true,
+    omittedTests: true,
   },
   'basic/request-upload.any.js': {
     comment: 'Appears to corrupt the state of workerd',
     disabledTests: true,
   },
   'basic/request-upload.h2.any.js': {
-    comment: 'Do we support HTTP 2?',
+    comment: 'Enable if HTTP/2 is implemented',
     disabledTests: true,
   },
   'basic/response-null-body.any.js': {
@@ -204,7 +196,7 @@ export default {
   },
   'basic/scheme-others.sub.any.js': {},
   'basic/status.h2.any.js': {
-    comment: 'Do we support HTTP 2?',
+    comment: 'Enable if HTTP/2 is implemented',
     disabledTests: true,
   },
   'basic/stream-response.any.js': {},
@@ -221,7 +213,7 @@ export default {
 
   'body/cloned-any.js': {
     comment:
-      'At a glance it seems like we are just taking references to them instead of cloning?',
+      'We need to actually clone the body instead of taking a reference to it.',
     expectedFailures: ['TypedArray is cloned', 'ArrayBuffer is cloned'],
   },
   'body/formdata.any.js': {},
@@ -320,7 +312,8 @@ export default {
     ],
   },
   'credentials/authentication-redirection.any.js': {
-    comment: 'I think this is ok because we do not care about CORS',
+    comment:
+      'Even though the actual bug was fixed (Authorization now stripped), these tests are failing due to certificate problems',
     expectedFailures: [
       'getAuthorizationHeaderValue - same origin redirection',
       'getAuthorizationHeaderValue - cross origin redirection',
@@ -417,16 +410,9 @@ export default {
   },
   'headers/headers-normalize.any.js': {},
   'headers/headers-record.any.js': {
-    comment: 'Investigate our Headers implementation',
-    expectedFailures: [
-      'Correct operation ordering with two properties',
-      'Correct operation ordering with two properties one of which has an invalid name',
-      'Correct operation ordering with two properties one of which has an invalid value',
-      'Correct operation ordering with non-enumerable properties',
-      'Correct operation ordering with undefined descriptors',
-      'Basic operation with Symbol keys',
-      'Operation with non-enumerable Symbol keys',
-    ],
+    comment:
+      'This test checks the exact order of operations in JS involved in accessing headers. Our implementation is in C++ instead.',
+    omittedTests: true,
   },
   'headers/headers-structure.any.js': {},
 
@@ -467,7 +453,7 @@ export default {
   'redirect/redirect-count.any.js': {},
   'redirect/redirect-empty-location.any.js': {
     comment:
-      '(1) CORS is not implemented, our behaviour is OK, (2) We are expected to reject fetch in this case',
+      'Fix our handling of empty Location header. Even when fixed, tests will still fail due to CORS stuff',
     expectedFailures: [
       'redirect response with empty Location, manual mode',
       'redirect response with empty Location, follow mode',
@@ -475,46 +461,17 @@ export default {
   },
   'redirect/redirect-keepalive.any.js': {
     comment: 'Keepalive is not implemented',
-    expectedFailures: [
-      '[keepalive][new window][unload] same-origin redirect; setting up',
-      '[keepalive][new window][unload] same-origin redirect + preflight; setting up',
-      '[keepalive][new window][unload] cross-origin redirect; setting up',
-      '[keepalive][new window][unload] cross-origin redirect + preflight; setting up',
-      '[keepalive][new window][unload] redirect to file URL; setting up',
-      '[keepalive][new window][unload] redirect to data URL; setting up',
-    ],
+    disabledTests: true,
   },
   'redirect/redirect-keepalive.https.any.js': {
     comment: 'Keepalive is not implemented',
-    expectedFailures: [
-      '[keepalive][iframe][load] mixed content redirect; setting up',
-    ],
+    disabledTests: true,
   },
   'redirect/redirect-location-escape.tentative.any.js': {},
   'redirect/redirect-location.any.js': {
-    comment: 'Manual mode apparently expects status to be 0 in these cases',
-    expectedFailures: [
-      'Redirect 301 in "manual" mode with invalid location',
-      'Redirect 303 in "manual" mode without location',
-      'Redirect 302 in "manual" mode with data location',
-      'Redirect 308 in "manual" mode without location',
-      'Redirect 302 in "manual" mode with valid location',
-      'Redirect 302 in "manual" mode with invalid location',
-      'Redirect 307 in "manual" mode with valid location',
-      'Redirect 303 in "manual" mode with invalid location',
-      'Redirect 307 in "manual" mode without location',
-      'Redirect 308 in "manual" mode with data location',
-      'Redirect 308 in "manual" mode with valid location',
-      'Redirect 303 in "manual" mode with valid location',
-      'Redirect 308 in "manual" mode with invalid location',
-      'Redirect 307 in "manual" mode with invalid location',
-      'Redirect 307 in "manual" mode with data location',
-      'Redirect 303 in "manual" mode with data location',
-      'Redirect 301 in "manual" mode with valid location',
-      'Redirect 302 in "manual" mode without location',
-      'Redirect 301 in "manual" mode without location',
-      'Redirect 301 in "manual" mode with data location',
-    ],
+    comment:
+      'Status is expected to be 0 in a browser to avoid leaking info. We do not implement CORS',
+    omittedTests: [/Redirect 3\d\d in "manual" mode .*/],
   },
   'redirect/redirect-method.any.js': {
     comment: 'Reasons listed per case',
@@ -539,57 +496,30 @@ export default {
     ],
   },
   'redirect/redirect-mode.any.js': {
-    comment: 'CORS is not implemented',
-    omittedTests: true,
+    comment: "This test contains stuff besides CORS. Don't omit it all.",
+    omittedTests: [
+      /(same|cross)-origin redirect 3\d\d in manual redirect and (no-cors|cors) mode/,
+      /cross-origin redirect 3\d\d in follow redirect and no-cors mode/,
+      'manual redirect with a CORS error should be rejected',
+    ],
   },
   'redirect/redirect-origin.any.js': {
     comment: 'CORS is not implemented',
-    expectedFailures: [
-      '[POST] Redirect 302 Same origin to other origin',
-      '[GET] Redirect 308 Other origin to same origin',
-      '[POST] Redirect 307 Other origin to same origin',
-      '[GET] Redirect 308 Other origin to other origin',
-      '[GET] Redirect 302 Same origin to other origin',
-      '[GET] Redirect 307 Other origin to other origin',
-      '[POST] Redirect 308 Other origin to same origin',
-      '[POST] Redirect 303 Same origin to other origin',
-      '[GET] Redirect 301 Other origin to other origin',
-      '[GET] Redirect 301 Same origin to other origin',
-      '[GET] Redirect 302 Other origin to same origin',
-      '[POST] Redirect 301 Other origin to other origin',
-      '[GET] Redirect 303 Other origin to other origin',
-      '[GET] Redirect 307 Other origin to same origin',
-      '[POST] Redirect 302 Other origin to other origin',
-      '[POST] Redirect 303 Other origin to other origin',
-      '[POST] Redirect 303 Other origin to same origin',
-      '[GET] Redirect 308 Same origin to other origin',
-      '[GET] Redirect 302 Other origin to other origin',
-      '[POST] Redirect 301 Same origin to other origin',
-      '[POST] Redirect 302 Other origin to same origin',
-      '[POST] Redirect 307 Same origin to other origin',
-      '[GET] Redirect 301 Other origin to same origin',
-      '[POST] Redirect 308 Other origin to other origin',
-      '[POST] Redirect 308 Same origin to other origin',
-      '[POST] Redirect 307 Other origin to other origin',
-      '[GET] Redirect 307 Same origin to other origin',
-      '[POST] Redirect 301 Other origin to same origin',
-      '[GET] Redirect 303 Same origin to other origin',
-      '[GET] Redirect 303 Other origin to same origin',
-    ],
+    omittedTests: true,
   },
   'redirect/redirect-referrer-override.any.js': {
     comment: 'Referer is not implemented',
-    disabledTests: true,
+    omittedTests: true,
   },
   'redirect/redirect-referrer.any.js': {
     comment: 'Referrer is not implemented',
-    disabledTests: true,
+    omittedTests: true,
   },
   'redirect/redirect-schemes.any.js': {},
   'redirect/redirect-to-dataurl.any.js': {},
   'redirect/redirect-upload.h2.any.js': {
     comment: 'Do we support HTTP 2?',
-    disabledTests: true,
+    omittedTests: true,
   },
 
   'request/forbidden-method.any.js': {
@@ -598,9 +528,7 @@ export default {
   },
   'request/multi-globals/construct-in-detached-frame.window.js': {
     comment: "We don't support detached realms",
-    expectedFailures: [
-      'creating a request from another request in a detached realm should work',
-    ],
+    omittedTests: true,
   },
   'request/request-bad-port.any.js': {},
   'request/request-cache-default-conditional.any.js': {
@@ -652,7 +580,7 @@ export default {
   },
   'request/request-error.any.js': {
     comment:
-      'These tests would require us to throw errors for some invalid situations that we just ingore',
+      'These tests would require us to throw errors for some invalid situations that we just ignore',
     expectedFailures: [
       "RequestInit's window is not null",
       'Input URL has credentials',
@@ -669,45 +597,7 @@ export default {
   'request/request-error.js': {},
   'request/request-headers.any.js': {
     comment: 'Neither CORS nor header filtering is implemented',
-    expectedFailures: [
-      'Adding invalid request header "Accept-Charset: KO"',
-      'Adding invalid request header "accept-charset: KO"',
-      'Adding invalid request header "ACCEPT-ENCODING: KO"',
-      'Adding invalid request header "Accept-Encoding: KO"',
-      'Adding invalid request header "Access-Control-Request-Headers: KO"',
-      'Adding invalid request header "Access-Control-Request-Method: KO"',
-      'Adding invalid request header "Connection: KO"',
-      'Adding invalid request header "Content-Length: KO"',
-      'Adding invalid request header "Cookie: KO"',
-      'Adding invalid request header "Cookie2: KO"',
-      'Adding invalid request header "Date: KO"',
-      'Adding invalid request header "DNT: KO"',
-      'Adding invalid request header "Expect: KO"',
-      'Adding invalid request header "Host: KO"',
-      'Adding invalid request header "Keep-Alive: KO"',
-      'Adding invalid request header "Origin: KO"',
-      'Adding invalid request header "Referer: KO"',
-      'Adding invalid request header "Set-Cookie: KO"',
-      'Adding invalid request header "TE: KO"',
-      'Adding invalid request header "Trailer: KO"',
-      'Adding invalid request header "Transfer-Encoding: KO"',
-      'Adding invalid request header "Upgrade: KO"',
-      'Adding invalid request header "Via: KO"',
-      'Adding invalid request header "Proxy-: KO"',
-      'Adding invalid request header "proxy-a: KO"',
-      'Adding invalid request header "Sec-: KO"',
-      'Adding invalid request header "sec-b: KO"',
-      'Adding invalid no-cors request header "Content-Type: KO"',
-      'Adding invalid no-cors request header "Potato: KO"',
-      'Adding invalid no-cors request header "proxy: KO"',
-      'Adding invalid no-cors request header "proxya: KO"',
-      'Adding invalid no-cors request header "sec: KO"',
-      'Adding invalid no-cors request header "secb: KO"',
-      'Adding invalid no-cors request header "Empty-Value: "',
-      'Check that request constructor is filtering headers provided as init parameter',
-      'Check that no-cors request constructor is filtering headers provided as init parameter',
-      'Check that no-cors request constructor is filtering headers provided as part of request parameter',
-    ],
+    omittedTests: true,
   },
   'request/request-init-002.any.js': {},
   'request/request-init-contenttype.any.js': {},
@@ -755,16 +645,16 @@ export default {
   },
   'response/response-arraybuffer-realm.window.js': {
     comment: 'Skipped because it involves iframes',
-    disabledTests: true,
+    omittedTests: true,
   },
   'response/response-blob-realm.any.js': {
     comment: 'Skipped because it involves iframes',
-    disabledTests: true,
+    omittedTests: true,
   },
   'response/response-cancel-stream.any.js': {},
   'response/response-clone-iframe.window.js': {
     comment: 'Skipped because it involves iframes',
-    disabledTests: true,
+    omittedTests: true,
   },
   'response/response-clone.any.js': {
     comment: 'TODO Investigate this',


### PR DESCRIPTION
This PR updates the status of some WPT tests to match our recent discussions
- Turn on redirect-mode tests because they do contain some non-cors stuff as well
- Omit any tests relating to:
    - CSP
    - CORS
    - Referrer
    - Header filtering
    - DOM stuff
    - Browser specific stuff
- Although we're probably never going to have it I left these as disabled instead of omitted. This is because we technically might be able to add it later:
  - Keepalive
  - Integrity
  - Ambient credentials
  - Please let me know anything here ought to really be nuked