### PR TITLE
Roll Deps: V8 14.0 -> 14.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,7 +101,7 @@ git_repository(
 git_repository(
     name = "fp16",
     build_file_content = "exports_files(glob([\"**\"]))",
-    commit = "0a92994d729ff76a58f692d3028ca1b64b145d91",
+    commit = "b3720617faf1a4581ed7e6787cc51722ec7751f0",
     remote = "https://github.com/Maratyszcza/FP16.git",
 )
 

--- a/build/deps/v8.bzl
+++ b/build/deps/v8.bzl
@@ -1,9 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-VERSION = "14.0.365.4"
+VERSION = "14.1.146.1"
 
-INTEGRITY = "sha256-rw6N1X1qhhGlhYpUyvkuQ9dDRuoSPXCn0tuYq6uJSbw="
+INTEGRITY = "sha256-2HdTM2N2J1XBI6617Icx73S2qs5+Qd/h4hQUek8CUFU="
 
 PATCHES = [
     "0001-Allow-manually-setting-ValueDeserializer-format-vers.patch",

--- a/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
+++ b/patches/v8/0001-Allow-manually-setting-ValueDeserializer-format-vers.patch
@@ -37,10 +37,10 @@ index 0cb3e045bc46ec732956318b980e749d1847d06d..40ad805c7970cc9379e69f046205836d
     * Reads raw data in various common formats to the buffer.
     * Note that integer types are read in base-128 varint format, not with a
 diff --git a/src/api/api.cc b/src/api/api.cc
-index d58ef6307e1e968154a9341d207ceb1399dc17b0..a343a580f76d1b5eeba0f44f345b02e722d6db57 100644
+index e5f703bb5e7ddbf8351a2ab6d3e9d9991316c09e..42e5379a07826371a40c99b81dd1e5fbd23abdb4 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -3445,6 +3445,10 @@ uint32_t ValueDeserializer::GetWireFormatVersion() const {
+@@ -3472,6 +3472,10 @@ uint32_t ValueDeserializer::GetWireFormatVersion() const {
    return private_->deserializer.GetWireFormatVersion();
  }
  

--- a/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
+++ b/patches/v8/0002-Allow-manually-setting-ValueSerializer-format-versio.patch
@@ -23,10 +23,10 @@ index 40ad805c7970cc9379e69f046205836dbd760373..596be18adeb3a5a81794aaa44b1d347d
     * Writes out a header, which includes the format version.
     */
 diff --git a/src/api/api.cc b/src/api/api.cc
-index a343a580f76d1b5eeba0f44f345b02e722d6db57..0311748cb83e8fa098305ee33e043d9311e94370 100644
+index 42e5379a07826371a40c99b81dd1e5fbd23abdb4..5878974fb70297c2aef4a5d28740058e468b947a 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -3317,6 +3317,10 @@ ValueSerializer::ValueSerializer(Isolate* v8_isolate, Delegate* delegate)
+@@ -3344,6 +3344,10 @@ ValueSerializer::ValueSerializer(Isolate* v8_isolate, Delegate* delegate)
  
  ValueSerializer::~ValueSerializer() { delete private_; }
  

--- a/patches/v8/0003-Allow-Windows-builds-under-Bazel.patch
+++ b/patches/v8/0003-Allow-Windows-builds-under-Bazel.patch
@@ -6,10 +6,10 @@ Subject: Allow Windows builds under Bazel
 Signed-off-by: James M Snell <jsnell@cloudflare.com>
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index f7da8ea9b5773a04240898e2a097421f1f7a672f..1a5780d8b081cf299c20e3e94122fe4c4ddd1a3d 100644
+index 3bbb5fd48f8a833621141fa70f304d4f72dac43b..cd3b8de463e7dc811886bd18f509656ed2cd3807 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -3960,6 +3960,8 @@ filegroup(
+@@ -3969,6 +3969,8 @@ filegroup(
          "@v8//bazel/config:is_inline_asm_x64": ["src/heap/base/asm/x64/push_registers_asm.cc"],
          "@v8//bazel/config:is_inline_asm_arm": ["src/heap/base/asm/arm/push_registers_asm.cc"],
          "@v8//bazel/config:is_inline_asm_arm64": ["src/heap/base/asm/arm64/push_registers_asm.cc"],

--- a/patches/v8/0005-Speed-up-V8-bazel-build-by-always-using-target-cfg.patch
+++ b/patches/v8/0005-Speed-up-V8-bazel-build-by-always-using-target-cfg.patch
@@ -10,7 +10,7 @@ both target and exec configurations as generator tools depend on them.
 Signed-off-by: James M Snell <jsnell@cloudflare.com>
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 1a5780d8b081cf299c20e3e94122fe4c4ddd1a3d..7d8792401684c30b0d1d63890ad61badcac4ba69 100644
+index cd3b8de463e7dc811886bd18f509656ed2cd3807..5e2235a868d2b9f10d33ef379faeb5c44890a96a 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
 @@ -19,6 +19,7 @@ load(
@@ -21,7 +21,7 @@ index 1a5780d8b081cf299c20e3e94122fe4c4ddd1a3d..7d8792401684c30b0d1d63890ad61bad
  )
  load(":bazel/v8-non-pointer-compression.bzl", "v8_binary_non_pointer_compression")
  
-@@ -4358,22 +4359,20 @@ filegroup(
+@@ -4368,22 +4369,20 @@ filegroup(
      ],
  )
  
@@ -50,7 +50,7 @@ index 1a5780d8b081cf299c20e3e94122fe4c4ddd1a3d..7d8792401684c30b0d1d63890ad61bad
  )
  
  v8_mksnapshot(
-@@ -4594,7 +4593,6 @@ v8_binary(
+@@ -4604,7 +4603,6 @@ v8_binary(
      srcs = [
          "src/regexp/gen-regexp-special-case.cc",
          "src/regexp/special-case.h",

--- a/patches/v8/0006-Implement-Promise-Context-Tagging.patch
+++ b/patches/v8/0006-Implement-Promise-Context-Tagging.patch
@@ -5,10 +5,10 @@ Subject: Implement Promise Context Tagging
 
 
 diff --git a/include/v8-callbacks.h b/include/v8-callbacks.h
-index a9f380e38abdde83b6a3f8b5804d81e46df421bc..7a3e5c26a549f4f42e20a8f28301dd61704ce583 100644
+index 920e4e25f10cdc6add9f74453575dcf793c1f0d5..7ccb6d08f440d805c829d1efd099cf4359e756a0 100644
 --- a/include/v8-callbacks.h
 +++ b/include/v8-callbacks.h
-@@ -516,6 +516,14 @@ using FilterETWSessionByURL2Callback = FilterETWSessionByURLResult (*)(
+@@ -519,6 +519,14 @@ using FilterETWSessionByURL2Callback = FilterETWSessionByURLResult (*)(
      Local<Context> context, const std::string& etw_filter_payload);
  #endif  // V8_OS_WIN
  
@@ -24,10 +24,10 @@ index a9f380e38abdde83b6a3f8b5804d81e46df421bc..7a3e5c26a549f4f42e20a8f28301dd61
  
  #endif  // INCLUDE_V8_ISOLATE_CALLBACKS_H_
 diff --git a/include/v8-isolate.h b/include/v8-isolate.h
-index 582a485ccccdc84bce392e8a8623e1e81769a026..4bc7192b05f036de18317b7df34aa8b9eb8a97e2 100644
+index 16c61f605f9909dafba169948ce15d883fa7cfbe..abfb1ad3b0b0e9d9466cd385b5207cbf28e2e14d 100644
 --- a/include/v8-isolate.h
 +++ b/include/v8-isolate.h
-@@ -1844,6 +1844,9 @@ class V8_EXPORT Isolate {
+@@ -1853,6 +1853,9 @@ class V8_EXPORT Isolate {
     */
    uint64_t GetHashSeed();
  
@@ -37,7 +37,7 @@ index 582a485ccccdc84bce392e8a8623e1e81769a026..4bc7192b05f036de18317b7df34aa8b9
    Isolate() = delete;
    ~Isolate() = delete;
    Isolate(const Isolate&) = delete;
-@@ -1891,6 +1894,19 @@ MaybeLocal<T> Isolate::GetDataFromSnapshotOnce(size_t index) {
+@@ -1900,6 +1903,19 @@ MaybeLocal<T> Isolate::GetDataFromSnapshotOnce(size_t index) {
    return {};
  }
  
@@ -58,10 +58,10 @@ index 582a485ccccdc84bce392e8a8623e1e81769a026..4bc7192b05f036de18317b7df34aa8b9
  
  #endif  // INCLUDE_V8_ISOLATE_H_
 diff --git a/src/api/api.cc b/src/api/api.cc
-index 0311748cb83e8fa098305ee33e043d9311e94370..ac3a516d93e0b9871796486251827467e802b7a2 100644
+index 5878974fb70297c2aef4a5d28740058e468b947a..111def335e53fabb6ce6ac0b2f4d20ae3b5835ce 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -12566,6 +12566,25 @@ TryToCopyAndConvertArrayToCppBuffer<CTypeInfoBuilder<double>::Build().GetId(),
+@@ -12605,6 +12605,25 @@ TryToCopyAndConvertArrayToCppBuffer<CTypeInfoBuilder<double>::Build().GetId(),
                                                              max_length);
  }
  
@@ -187,7 +187,7 @@ index f3ece10afb659042fbb195a98cad8254cf1188c5..cd5261012bd9a2f16b2f3354b6c526ab
    return instance;
  }
 diff --git a/src/compiler/js-create-lowering.cc b/src/compiler/js-create-lowering.cc
-index 822012d74153df43bf1ddefdddde3d27ae80a954..4b275a2ab9384625bf7cc5df777ae663862c4250 100644
+index e22b54b4c8354017481367ab0999ddd11a387b9c..1fdd5a1a8cbc464f39099b3f08655fb025dace48 100644
 --- a/src/compiler/js-create-lowering.cc
 +++ b/src/compiler/js-create-lowering.cc
 @@ -1126,10 +1126,12 @@ Reduction JSCreateLowering::ReduceJSCreatePromise(Node* node) {
@@ -205,10 +205,10 @@ index 822012d74153df43bf1ddefdddde3d27ae80a954..4b275a2ab9384625bf7cc5df777ae663
         offset < JSPromise::kSizeWithEmbedderFields; offset += kTaggedSize) {
      a.Store(AccessBuilder::ForJSObjectOffset(offset),
 diff --git a/src/diagnostics/objects-printer.cc b/src/diagnostics/objects-printer.cc
-index 65e694850ecfd3afc8839d851c5dd024549b8187..4de528103be80124c75ed7806ba829526c8c9542 100644
+index 71e67115368ce1ba8762251ca19943bfa57e253a..c79a4fe2fa685df87ea6448238f903db09216ef7 100644
 --- a/src/diagnostics/objects-printer.cc
 +++ b/src/diagnostics/objects-printer.cc
-@@ -962,6 +962,7 @@ void JSPromise::JSPromisePrint(std::ostream& os) {
+@@ -970,6 +970,7 @@ void JSPromise::JSPromisePrint(std::ostream& os) {
    }
    os << "\n - has_handler: " << has_handler();
    os << "\n - is_silent: " << is_silent();
@@ -217,7 +217,7 @@ index 65e694850ecfd3afc8839d851c5dd024549b8187..4de528103be80124c75ed7806ba82952
  }
  
 diff --git a/src/execution/isolate-inl.h b/src/execution/isolate-inl.h
-index 8579c79d99cf67cdbf4109d84169ba0e0e4458c5..3e5662b29265104741c7d98d79257a81e8b0fa46 100644
+index 3e122ecf5d3c60eb4a334eaef30fedbf71102bba..0d7e90da840560c371e5ca4e9626c056bbf78a6b 100644
 --- a/src/execution/isolate-inl.h
 +++ b/src/execution/isolate-inl.h
 @@ -133,6 +133,25 @@ bool Isolate::is_execution_terminating() {
@@ -247,10 +247,10 @@ index 8579c79d99cf67cdbf4109d84169ba0e0e4458c5..3e5662b29265104741c7d98d79257a81
  Tagged<Object> Isolate::VerifyBuiltinsResult(Tagged<Object> result) {
    if (is_execution_terminating() && !v8_flags.strict_termination_checks) {
 diff --git a/src/execution/isolate.cc b/src/execution/isolate.cc
-index b5c8ab68340aaec141ecef818d148937e2fbc641..c2f47f68450ee5ca800716d585d70284079faf0a 100644
+index 377b984f26f5cbb14f9b49ed21c5e70f5692def1..99b99ed4166c566237b2fcf07b848fdb4334669b 100644
 --- a/src/execution/isolate.cc
 +++ b/src/execution/isolate.cc
-@@ -622,6 +622,8 @@ void Isolate::Iterate(RootVisitor* v, ThreadLocalTop* thread) {
+@@ -624,6 +624,8 @@ void Isolate::Iterate(RootVisitor* v, ThreadLocalTop* thread) {
                        FullObjectSlot(&thread->pending_message_));
    v->VisitRootPointer(Root::kStackRoots, nullptr,
                        FullObjectSlot(&thread->context_));
@@ -259,7 +259,7 @@ index b5c8ab68340aaec141ecef818d148937e2fbc641..c2f47f68450ee5ca800716d585d70284
  
    for (v8::TryCatch* block = thread->try_catch_handler_; block != nullptr;
         block = block->next_) {
-@@ -5854,6 +5856,7 @@ bool Isolate::Init(SnapshotData* startup_snapshot_data,
+@@ -5898,6 +5900,7 @@ bool Isolate::Init(SnapshotData* startup_snapshot_data,
      shared_heap_object_cache_.push_back(ReadOnlyRoots(this).undefined_value());
    }
  
@@ -267,7 +267,7 @@ index b5c8ab68340aaec141ecef818d148937e2fbc641..c2f47f68450ee5ca800716d585d70284
    InitializeThreadLocal();
  
    // Profiler has to be created after ThreadLocal is initialized
-@@ -7948,5 +7951,40 @@ void Isolate::PrintNumberStringCacheStats(const char* comment,
+@@ -7988,5 +7991,40 @@ void Isolate::PrintNumberStringCacheStats(const char* comment,
    PrintF("\n");
  }
  
@@ -309,10 +309,10 @@ index b5c8ab68340aaec141ecef818d148937e2fbc641..c2f47f68450ee5ca800716d585d70284
  }  // namespace internal
  }  // namespace v8
 diff --git a/src/execution/isolate.h b/src/execution/isolate.h
-index b4209daea87ac5df53182de5c0dc6a084b8dda7d..c7726eaf074dcf412b61b29061ef719970544d97 100644
+index 90c80955145a10dd696ec6f39611eb2d4e78dcca..9cfaddb0c9a29faa0b6f5645be6561ec690d1c25 100644
 --- a/src/execution/isolate.h
 +++ b/src/execution/isolate.h
-@@ -2391,6 +2391,15 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
+@@ -2400,6 +2400,15 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
                                         v8::ExceptionContext callback_kind);
    void SetExceptionPropagationCallback(ExceptionPropagationCallback callback);
  
@@ -328,7 +328,7 @@ index b4209daea87ac5df53182de5c0dc6a084b8dda7d..c7726eaf074dcf412b61b29061ef7199
  #ifdef V8_ENABLE_WASM_SIMD256_REVEC
    void set_wasm_revec_verifier_for_test(
        compiler::turboshaft::WasmRevecVerifier* verifier) {
-@@ -2933,6 +2942,12 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
+@@ -2942,6 +2951,12 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
  
    bool is_frozen_ = false;
  
@@ -341,7 +341,7 @@ index b4209daea87ac5df53182de5c0dc6a084b8dda7d..c7726eaf074dcf412b61b29061ef7199
    friend class GlobalSafepoint;
    friend class heap::HeapTester;
    friend class IsolateForPointerCompression;
-@@ -2940,6 +2955,7 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
+@@ -2949,6 +2964,7 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
    friend class IsolateGroup;
    friend class TestSerializer;
    friend class SharedHeapNoClientsTest;
@@ -350,10 +350,10 @@ index b4209daea87ac5df53182de5c0dc6a084b8dda7d..c7726eaf074dcf412b61b29061ef7199
  
  // The current entered Isolate and its thread data. Do not access these
 diff --git a/src/heap/factory.cc b/src/heap/factory.cc
-index ba83a6a8bf40687fe4c46dd25fac883221b5cd56..259a62966f8120c594877381f4029987d606be42 100644
+index 87b7dc6cbb557a59c7f455b1bf53c9c961562419..beaba2fe943e54f6aa3399ca4759db3a78073626 100644
 --- a/src/heap/factory.cc
 +++ b/src/heap/factory.cc
-@@ -4564,6 +4564,12 @@ Handle<JSPromise> Factory::NewJSPromiseWithoutHook() {
+@@ -4587,6 +4587,12 @@ Handle<JSPromise> Factory::NewJSPromiseWithoutHook() {
    DisallowGarbageCollection no_gc;
    Tagged<JSPromise> raw = *promise;
    raw->set_reactions_or_result(Smi::zero(), SKIP_WRITE_BARRIER);
@@ -394,10 +394,10 @@ index c37d9edafd5f5b460a9aa39f5aa5a275a6d49015..0e3aa9cb10bafcf0528adf43500c4267
    }
    return ThrowIfOutOfMemory();
 diff --git a/src/profiler/heap-snapshot-generator.cc b/src/profiler/heap-snapshot-generator.cc
-index 40ee39d700916be0fa2c82d64de8fcf02138abaa..c75cd7a2de525fd3186f718451f4cee2640fee20 100644
+index ff0be3558517befcc420e9df813370bb6a2c59e8..c6d5af9fe6953a3a3f07a172e4cab85fa57cc475 100644
 --- a/src/profiler/heap-snapshot-generator.cc
 +++ b/src/profiler/heap-snapshot-generator.cc
-@@ -2069,6 +2069,8 @@ void V8HeapExplorer::ExtractJSPromiseReferences(HeapEntry* entry,
+@@ -2082,6 +2082,8 @@ void V8HeapExplorer::ExtractJSPromiseReferences(HeapEntry* entry,
    SetInternalReference(entry, "reactions_or_result",
                         promise->reactions_or_result(),
                         JSPromise::kReactionsOrResultOffset);
@@ -453,10 +453,10 @@ index 262b9aa5aa6974a4628d0679ada91aff76567906..9730731cd42c0ea6ce0d96ec250a11fc
  }  // namespace internal
  }  // namespace v8
 diff --git a/src/runtime/runtime.h b/src/runtime/runtime.h
-index 0fcff20ce40c4c6e01f120e5bc9fefc96bba1a1e..ee80eeffdead1e45d70984a9fbdf9a570e85c545 100644
+index ab9f8b88686c00b18df661169455452ccb3b14ea..4485f11096a4858d11710f9a7b07f603acdee924 100644
 --- a/src/runtime/runtime.h
 +++ b/src/runtime/runtime.h
-@@ -431,20 +431,22 @@ constexpr bool CanTriggerGC(T... properties) {
+@@ -432,20 +432,22 @@ constexpr bool CanTriggerGC(T... properties) {
    F(StrictNotEqual, 2, 1)                  \
    F(ReferenceEqual, 2, 1)
  

--- a/patches/v8/0008-increase-visibility-of-virtual-method.patch
+++ b/patches/v8/0008-increase-visibility-of-virtual-method.patch
@@ -9,10 +9,10 @@ v8-platform-wrapper.h implementation.
 Signed-off-by: James M Snell <jsnell@cloudflare.com>
 
 diff --git a/include/v8-platform.h b/include/v8-platform.h
-index 234205f408312a273d6dfae25a9585d3a96efd75..77a42f6668d2eeec87bd6a912b3cd1a5cec310cb 100644
+index 6aadcab4ba987ed20d0ff3df76f54b1052713b2a..bbabb4b472095868ca1f66a7accde51aee10bca2 100644
 --- a/include/v8-platform.h
 +++ b/include/v8-platform.h
-@@ -1410,7 +1410,7 @@ class Platform {
+@@ -1407,7 +1407,7 @@ class Platform {
      return &default_observer;
    }
  

--- a/patches/v8/0009-Add-ValueSerializer-SetTreatFunctionsAsHostObjects.patch
+++ b/patches/v8/0009-Add-ValueSerializer-SetTreatFunctionsAsHostObjects.patch
@@ -30,10 +30,10 @@ index 596be18adeb3a5a81794aaa44b1d347dec6c0c7d..141f138e08de849e3e02b3b2b346e643
     * Write raw data in various common formats to the buffer.
     * Note that integer types are written in base-128 varint format, not with a
 diff --git a/src/api/api.cc b/src/api/api.cc
-index ac3a516d93e0b9871796486251827467e802b7a2..51c4cd44b2e2fdacb42dc4649743508dc9d9ca15 100644
+index 111def335e53fabb6ce6ac0b2f4d20ae3b5835ce..3909e6560b2e5836fad0630706402f1b7e349330 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -3327,6 +3327,10 @@ void ValueSerializer::SetTreatArrayBufferViewsAsHostObjects(bool mode) {
+@@ -3354,6 +3354,10 @@ void ValueSerializer::SetTreatArrayBufferViewsAsHostObjects(bool mode) {
    private_->serializer.SetTreatArrayBufferViewsAsHostObjects(mode);
  }
  

--- a/patches/v8/0010-Modify-where-to-look-for-fp16-dependency.-This-depen.patch
+++ b/patches/v8/0010-Modify-where-to-look-for-fp16-dependency.-This-depen.patch
@@ -8,10 +8,10 @@ Subject: Modify where to look for fp16 dependency. This dependency is normally
 Signed-off-by: James M Snell <jsnell@cloudflare.com>
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 7d8792401684c30b0d1d63890ad61badcac4ba69..177301d141540e81e2a8ac885f2d05432533f00d 100644
+index 5e2235a868d2b9f10d33ef379faeb5c44890a96a..2e084a0d4584bbd1cbc66808213d1c25dead70b3 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -3983,16 +3983,22 @@ v8_library(
+@@ -3992,17 +3992,23 @@ v8_library(
    ],
  )
  
@@ -21,6 +21,7 @@ index 7d8792401684c30b0d1d63890ad61badcac4ba69..177301d141540e81e2a8ac885f2d0543
 -  hdrs = [
 -    "third_party/fp16/src/include/fp16/fp16.h",
 -    "third_party/fp16/src/include/fp16/bitcasts.h",
+-    "third_party/fp16/src/include/fp16/macros.h",
 -  ],
 -  includes = [
 -    "third_party/fp16/src/include",
@@ -38,6 +39,7 @@ index 7d8792401684c30b0d1d63890ad61badcac4ba69..177301d141540e81e2a8ac885f2d0543
 +    name = "lib_fp16_includes",
 +    hdrs = [
 +        "@fp16//:include/fp16/bitcasts.h",
++        "@fp16//:include/fp16/macros.h",
 +        "@fp16//:include/fp16/fp16.h",
 +    ],
 +    strip_include_prefix = "include",

--- a/patches/v8/0011-Revert-heap-Add-masm-specific-unwinding-annotations-.patch
+++ b/patches/v8/0011-Revert-heap-Add-masm-specific-unwinding-annotations-.patch
@@ -14,10 +14,10 @@ of getting our V8 upgrade unblocked.
 Signed-off-by: James M Snell <jsnell@cloudflare.com>
 
 diff --git a/BUILD.gn b/BUILD.gn
-index 8dda88f8ad8c20256bafb94f221e4a6bde86a98b..32c3a0201c4ea29e14a08dacfdc59e5d8e2b5dc1 100644
+index 487a7466168196eb0c8ae19963394e34285c08a0..d717cfdbdb7e374683639747d891371d9d913333 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -4340,8 +4340,8 @@ v8_header_set("v8_internal_headers") {
+@@ -4364,8 +4364,8 @@ v8_header_set("v8_internal_headers") {
      "src/tasks/operations-barrier.h",
      "src/tasks/task-utils.h",
      "src/torque/runtime-macro-shims.h",
@@ -27,7 +27,7 @@ index 8dda88f8ad8c20256bafb94f221e4a6bde86a98b..32c3a0201c4ea29e14a08dacfdc59e5d
      "src/tracing/trace-id.h",
      "src/tracing/traced-value.h",
      "src/tracing/tracing-category-observer.h",
-@@ -7078,12 +7078,7 @@ v8_source_set("v8_heap_base") {
+@@ -7116,12 +7116,7 @@ v8_source_set("v8_heap_base") {
    ]
  
    if (current_cpu == "x64") {
@@ -42,7 +42,7 @@ index 8dda88f8ad8c20256bafb94f221e4a6bde86a98b..32c3a0201c4ea29e14a08dacfdc59e5d
      sources += [ "src/heap/base/asm/ia32/push_registers_asm.cc" ]
    } else if (current_cpu == "arm") {
 diff --git a/src/heap/base/asm/x64/push_registers_asm.cc b/src/heap/base/asm/x64/push_registers_asm.cc
-index 554caddfa77ff91c907c377aa95cc6b1eb907e5c..73f8c4c078e091c378868de49b5254cc89a0a688 100644
+index b0eb0d8c64176e0d31c48cb53975dfa2af61808a..2ca24727ae6d261df1f14b6ef06b21b005db787a 100644
 --- a/src/heap/base/asm/x64/push_registers_asm.cc
 +++ b/src/heap/base/asm/x64/push_registers_asm.cc
 @@ -14,16 +14,61 @@
@@ -112,10 +112,10 @@ index 554caddfa77ff91c907c377aa95cc6b1eb907e5c..73f8c4c078e091c378868de49b5254cc
  asm(
  #ifdef __APPLE__
      ".globl _PushAllRegistersAndIterateStack            \n"
-@@ -64,3 +109,5 @@ asm(
+@@ -71,3 +116,5 @@ asm(
      ".Lfunc_end0-PushAllRegistersAndIterateStack        \n"
  #endif  // !defined(__APPLE__)
-     );
+     ".cfi_endproc                                      \n");
 +
 +#endif  // !_WIN64
 diff --git a/src/heap/base/asm/x64/push_registers_masm.asm b/src/heap/base/asm/x64/push_registers_masm.asm

--- a/patches/v8/0012-Update-illegal-invocation-error-message-in-v8.patch
+++ b/patches/v8/0012-Update-illegal-invocation-error-message-in-v8.patch
@@ -23,10 +23,10 @@ index 14925978e9c123324c36897664cb57343de25952..b8e19ff8b8552e7789aa09700979bfd3
      "Immutable prototype object '%' cannot have their prototype set")          \
    T(ImportAttributesDuplicateKey, "Import attribute has duplicate key '%'")    \
 diff --git a/test/cctest/test-api.cc b/test/cctest/test-api.cc
-index 7a829f0a593c7a909af2ea76e4ac283b5071875a..21d72396cb578f85ac241fd668a9ad67a0f9cb1c 100644
+index 0c6a25de32431596f27ce7d162b08e4ae3cd495d..5a4fe8fa8684c06e5701cf10d239392e7214cbcf 100644
 --- a/test/cctest/test-api.cc
 +++ b/test/cctest/test-api.cc
-@@ -220,6 +220,17 @@ THREADED_TEST(IsolateOfContext) {
+@@ -223,6 +223,17 @@ THREADED_TEST(IsolateOfContext) {
    CHECK(isolate->IsCurrent());
  }
  
@@ -44,7 +44,7 @@ index 7a829f0a593c7a909af2ea76e4ac283b5071875a..21d72396cb578f85ac241fd668a9ad67
  static void TestSignatureLooped(const char* operation, Local<Value> receiver,
                                  v8::Isolate* isolate) {
    v8::base::ScopedVector<char> source(200);
-@@ -237,12 +248,7 @@ static void TestSignatureLooped(const char* operation, Local<Value> receiver,
+@@ -240,12 +251,7 @@ static void TestSignatureLooped(const char* operation, Local<Value> receiver,
    if (!expected_to_throw) {
      CHECK_EQ(10, signature_callback_count);
    } else {
@@ -58,7 +58,7 @@ index 7a829f0a593c7a909af2ea76e4ac283b5071875a..21d72396cb578f85ac241fd668a9ad67
    }
    signature_expected_receiver_global.Reset();
  }
-@@ -269,12 +275,7 @@ static void TestSignatureOptimized(const char* operation, Local<Value> receiver,
+@@ -272,12 +278,7 @@ static void TestSignatureOptimized(const char* operation, Local<Value> receiver,
    if (!expected_to_throw) {
      CHECK_EQ(3, signature_callback_count);
    } else {

--- a/patches/v8/0013-Implement-cross-request-context-promise-resolve-hand.patch
+++ b/patches/v8/0013-Implement-cross-request-context-promise-resolve-hand.patch
@@ -6,10 +6,10 @@ Subject: Implement cross-request context promise resolve handling
 Signed-off-by: James M Snell <jsnell@cloudflare.com>
 
 diff --git a/BUILD.gn b/BUILD.gn
-index 32c3a0201c4ea29e14a08dacfdc59e5d8e2b5dc1..94ea55f0221f1d3e99929d6f154dfe04ef05bbaf 100644
+index d717cfdbdb7e374683639747d891371d9d913333..8cab8cc3fb4b69fc8eb356fe9b1824e7c7807ae5 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -4340,8 +4340,8 @@ v8_header_set("v8_internal_headers") {
+@@ -4364,8 +4364,8 @@ v8_header_set("v8_internal_headers") {
      "src/tasks/operations-barrier.h",
      "src/tasks/task-utils.h",
      "src/torque/runtime-macro-shims.h",
@@ -20,10 +20,10 @@ index 32c3a0201c4ea29e14a08dacfdc59e5d8e2b5dc1..94ea55f0221f1d3e99929d6f154dfe04
      "src/tracing/traced-value.h",
      "src/tracing/tracing-category-observer.h",
 diff --git a/include/v8-callbacks.h b/include/v8-callbacks.h
-index 7a3e5c26a549f4f42e20a8f28301dd61704ce583..a1ca454e3641ed38eeb921398ec10f34a91c2fd9 100644
+index 7ccb6d08f440d805c829d1efd099cf4359e756a0..a8d8ce9895585ea70804f859ec3c3a0dea117d34 100644
 --- a/include/v8-callbacks.h
 +++ b/include/v8-callbacks.h
-@@ -524,6 +524,25 @@ using FilterETWSessionByURL2Callback = FilterETWSessionByURLResult (*)(
+@@ -527,6 +527,25 @@ using FilterETWSessionByURL2Callback = FilterETWSessionByURLResult (*)(
  using PromiseCrossContextCallback = MaybeLocal<Promise> (*)(
      Local<Context> context, Local<Promise> promise, Local<Object> tag);
  
@@ -50,10 +50,10 @@ index 7a3e5c26a549f4f42e20a8f28301dd61704ce583..a1ca454e3641ed38eeb921398ec10f34
  
  #endif  // INCLUDE_V8_ISOLATE_CALLBACKS_H_
 diff --git a/include/v8-isolate.h b/include/v8-isolate.h
-index 4bc7192b05f036de18317b7df34aa8b9eb8a97e2..550d8ec91a679a0b2c5213f7819798da81a399eb 100644
+index abfb1ad3b0b0e9d9466cd385b5207cbf28e2e14d..1125dd7572307681cf91ec339bd60cae2d974eed 100644
 --- a/include/v8-isolate.h
 +++ b/include/v8-isolate.h
-@@ -1846,6 +1846,8 @@ class V8_EXPORT Isolate {
+@@ -1855,6 +1855,8 @@ class V8_EXPORT Isolate {
  
    class PromiseContextScope;
    void SetPromiseCrossContextCallback(PromiseCrossContextCallback callback);
@@ -63,10 +63,10 @@ index 4bc7192b05f036de18317b7df34aa8b9eb8a97e2..550d8ec91a679a0b2c5213f7819798da
    Isolate() = delete;
    ~Isolate() = delete;
 diff --git a/src/api/api.cc b/src/api/api.cc
-index 51c4cd44b2e2fdacb42dc4649743508dc9d9ca15..3fd2eecfb969e7ad225d550885a96d642b6f86c2 100644
+index 3909e6560b2e5836fad0630706402f1b7e349330..41050f920d842b417c3336d7f81fb9bdd2204f52 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -12582,7 +12582,13 @@ Isolate::PromiseContextScope::PromiseContextScope(Isolate* isolate,
+@@ -12621,7 +12621,13 @@ Isolate::PromiseContextScope::PromiseContextScope(Isolate* isolate,
    DCHECK(!isolate_->has_promise_context_tag());
    DCHECK(!tag.IsEmpty());
    i::Handle<i::Object> handle = Utils::OpenHandle(*tag);
@@ -121,7 +121,7 @@ index 202180adbbae91a689a667c40d20b4b1b9cb6edd..c93ac5905d7b349d1c59e9fa86b48662
      deferred {
        return runtime::ResolvePromise(promise, resolution);
 diff --git a/src/execution/isolate-inl.h b/src/execution/isolate-inl.h
-index 3e5662b29265104741c7d98d79257a81e8b0fa46..da76ad354235009562499bd68e81625c72580429 100644
+index 0d7e90da840560c371e5ca4e9626c056bbf78a6b..3eda374ffb2dd440cee67989ead439801d702b64 100644
 --- a/src/execution/isolate-inl.h
 +++ b/src/execution/isolate-inl.h
 @@ -133,18 +133,20 @@ bool Isolate::is_execution_terminating() {
@@ -167,10 +167,10 @@ index 3e5662b29265104741c7d98d79257a81e8b0fa46..da76ad354235009562499bd68e81625c
  Tagged<Object> Isolate::VerifyBuiltinsResult(Tagged<Object> result) {
    if (is_execution_terminating() && !v8_flags.strict_termination_checks) {
 diff --git a/src/execution/isolate.cc b/src/execution/isolate.cc
-index c2f47f68450ee5ca800716d585d70284079faf0a..dfe75233e3bf85e57adfd8562df1ac9e1766caaa 100644
+index 99b99ed4166c566237b2fcf07b848fdb4334669b..828859990410155925139120e19997c217792647 100644
 --- a/src/execution/isolate.cc
 +++ b/src/execution/isolate.cc
-@@ -622,8 +622,6 @@ void Isolate::Iterate(RootVisitor* v, ThreadLocalTop* thread) {
+@@ -624,8 +624,6 @@ void Isolate::Iterate(RootVisitor* v, ThreadLocalTop* thread) {
                        FullObjectSlot(&thread->pending_message_));
    v->VisitRootPointer(Root::kStackRoots, nullptr,
                        FullObjectSlot(&thread->context_));
@@ -179,7 +179,7 @@ index c2f47f68450ee5ca800716d585d70284079faf0a..dfe75233e3bf85e57adfd8562df1ac9e
  
    for (v8::TryCatch* block = thread->try_catch_handler_; block != nullptr;
         block = block->next_) {
-@@ -7986,5 +7984,20 @@ MaybeHandle<JSPromise> Isolate::RunPromiseCrossContextCallback(
+@@ -8026,5 +8024,20 @@ MaybeHandle<JSPromise> Isolate::RunPromiseCrossContextCallback(
    return v8::Utils::OpenHandle(*result);
  }
  
@@ -201,7 +201,7 @@ index c2f47f68450ee5ca800716d585d70284079faf0a..dfe75233e3bf85e57adfd8562df1ac9e
  }  // namespace internal
  }  // namespace v8
 diff --git a/src/execution/isolate.h b/src/execution/isolate.h
-index c7726eaf074dcf412b61b29061ef719970544d97..b79f0ba1a1e551d90ca9cca50d8904319865f8f7 100644
+index 9cfaddb0c9a29faa0b6f5645be6561ec690d1c25..203facc7bae4f8584890554d76e3ee5f3db09cea 100644
 --- a/src/execution/isolate.h
 +++ b/src/execution/isolate.h
 @@ -44,6 +44,7 @@
@@ -212,7 +212,7 @@ index c7726eaf074dcf412b61b29061ef719970544d97..b79f0ba1a1e551d90ca9cca50d890431
  #include "src/objects/tagged.h"
  #include "src/runtime/runtime.h"
  #include "src/sandbox/code-pointer-table.h"
-@@ -2391,14 +2392,22 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
+@@ -2400,14 +2401,22 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
                                         v8::ExceptionContext callback_kind);
    void SetExceptionPropagationCallback(ExceptionPropagationCallback callback);
  
@@ -237,7 +237,7 @@ index c7726eaf074dcf412b61b29061ef719970544d97..b79f0ba1a1e551d90ca9cca50d890431
  
  #ifdef V8_ENABLE_WASM_SIMD256_REVEC
    void set_wasm_revec_verifier_for_test(
-@@ -2942,9 +2951,11 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
+@@ -2951,9 +2960,11 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
  
    bool is_frozen_ = false;
  
@@ -252,10 +252,10 @@ index c7726eaf074dcf412b61b29061ef719970544d97..b79f0ba1a1e551d90ca9cca50d890431
    class PromiseCrossContextCallbackScope;
  
 diff --git a/src/heap/factory.cc b/src/heap/factory.cc
-index 259a62966f8120c594877381f4029987d606be42..d3efa5ac3ceff5e89ca6ce33290ce56c0423ae62 100644
+index beaba2fe943e54f6aa3399ca4759db3a78073626..2d4cc7884eef25f204002d0d318ab17723054b51 100644
 --- a/src/heap/factory.cc
 +++ b/src/heap/factory.cc
-@@ -4562,18 +4562,17 @@ Handle<JSPromise> Factory::NewJSPromiseWithoutHook() {
+@@ -4585,18 +4585,17 @@ Handle<JSPromise> Factory::NewJSPromiseWithoutHook() {
    Handle<JSPromise> promise =
        Cast<JSPromise>(NewJSObject(isolate()->promise_function()));
    DisallowGarbageCollection no_gc;
@@ -296,10 +296,10 @@ index 056b539ac19ecaa703c6e0bf37937c5bd4546301..8e0ebcf758598933fc98bdb817e92f32
    // ES section #sec-triggerpromisereactions
    static Handle<Object> TriggerPromiseReactions(Isolate* isolate,
 diff --git a/src/objects/objects.cc b/src/objects/objects.cc
-index 20f70515bab0e25822076d002de56092a2e5edb0..ee87e46b2c4645faa3aa979873d02ff99ee1fd01 100644
+index 1156a433e3b7f3ae1d9d22ad75f2d786361294e1..0f0caef6424c60098a09ad8b1c00a029dde0ffd0 100644
 --- a/src/objects/objects.cc
 +++ b/src/objects/objects.cc
-@@ -4511,6 +4511,22 @@ Handle<Object> JSPromise::Fulfill(DirectHandle<JSPromise> promise,
+@@ -4533,6 +4533,22 @@ Handle<Object> JSPromise::Fulfill(DirectHandle<JSPromise> promise,
    // 6. Set promise.[[PromiseState]] to "fulfilled".
    promise->set_status(Promise::kFulfilled);
  
@@ -322,7 +322,7 @@ index 20f70515bab0e25822076d002de56092a2e5edb0..ee87e46b2c4645faa3aa979873d02ff9
    // 7. Return TriggerPromiseReactions(reactions, value).
    return TriggerPromiseReactions(isolate, reactions, value,
                                   PromiseReaction::kFulfill);
-@@ -4569,6 +4585,22 @@ Handle<Object> JSPromise::Reject(DirectHandle<JSPromise> promise,
+@@ -4591,6 +4607,22 @@ Handle<Object> JSPromise::Reject(DirectHandle<JSPromise> promise,
      isolate->ReportPromiseReject(promise, reason, kPromiseRejectWithNoHandler);
    }
  
@@ -345,7 +345,7 @@ index 20f70515bab0e25822076d002de56092a2e5edb0..ee87e46b2c4645faa3aa979873d02ff9
    // 8. Return TriggerPromiseReactions(reactions, reason).
    return TriggerPromiseReactions(isolate, reactions, reason,
                                   PromiseReaction::kReject);
-@@ -4672,6 +4704,14 @@ MaybeHandle<Object> JSPromise::Resolve(DirectHandle<JSPromise> promise,
+@@ -4694,6 +4726,14 @@ MaybeHandle<Object> JSPromise::Resolve(DirectHandle<JSPromise> promise,
  }
  
  // static
@@ -381,10 +381,10 @@ index aa845a25942f0916eee38ba36a294a22626a415c..b47d11d402cb7855d8682ba966f35517
    }
  
 diff --git a/src/roots/roots.h b/src/roots/roots.h
-index c14179f89c923c1521f79f0c9036ddbb5ab10b03..b375fe8dadc54351269fef9f61c0bd5884cf7fe4 100644
+index ee504a9eac354cddfffef89033170c9c2527cd71..37a49477beff85b64f774db0d7ce608c856a9db0 100644
 --- a/src/roots/roots.h
 +++ b/src/roots/roots.h
-@@ -422,7 +422,8 @@ class RootVisitor;
+@@ -423,7 +423,8 @@ class RootVisitor;
    V(FunctionTemplateInfo, error_stack_getter_fun_template,                  \
      ErrorStackGetterSharedFun)                                              \
    V(FunctionTemplateInfo, error_stack_setter_fun_template,                  \
@@ -459,10 +459,10 @@ index 9730731cd42c0ea6ce0d96ec250a11fcc434ebf8..7cb9fe57f6afb76c450f3484a1198faa
  }  // namespace internal
  }  // namespace v8
 diff --git a/src/runtime/runtime.h b/src/runtime/runtime.h
-index ee80eeffdead1e45d70984a9fbdf9a570e85c545..65c15dc537dd2aee67e6c718478d98607b2ebfbd 100644
+index 4485f11096a4858d11710f9a7b07f603acdee924..d72d6ecdcbe49a8f3417e1ab9941f182c604820b 100644
 --- a/src/runtime/runtime.h
 +++ b/src/runtime/runtime.h
-@@ -446,7 +446,8 @@ constexpr bool CanTriggerGC(T... properties) {
+@@ -447,7 +447,8 @@ constexpr bool CanTriggerGC(T... properties) {
    F(ConstructAggregateErrorHelper, 4, 1)                    \
    F(ConstructInternalAggregateErrorHelper, -1 /* <= 5*/, 1) \
    F(PromiseContextInit, 1, 1)                               \

--- a/patches/v8/0014-Add-another-slot-in-the-isolate-for-embedder.patch
+++ b/patches/v8/0014-Add-another-slot-in-the-isolate-for-embedder.patch
@@ -6,10 +6,10 @@ Subject: Add another slot in the isolate for embedder
 Signed-off-by: James M Snell <jsnell@cloudflare.com>
 
 diff --git a/include/v8-internal.h b/include/v8-internal.h
-index 1259a220e7b0d9b7e4aa15989e9389fbc44d20de..98375fbf3791c4369ca410c685a36e12de6c8b1d 100644
+index 4bfbac0a8503fe4d728d0220473505ea67f50d9a..77cd8cd74e9111843c27c765990c66986c36396f 100644
 --- a/include/v8-internal.h
 +++ b/include/v8-internal.h
-@@ -910,7 +910,7 @@ class Internals {
+@@ -919,7 +919,7 @@ class Internals {
    static const int kExternalTwoByteRepresentationTag = 0x02;
    static const int kExternalOneByteRepresentationTag = 0x0a;
  

--- a/patches/v8/0015-Add-ValueSerializer-SetTreatProxiesAsHostObjects.patch
+++ b/patches/v8/0015-Add-ValueSerializer-SetTreatProxiesAsHostObjects.patch
@@ -30,10 +30,10 @@ index 141f138e08de849e3e02b3b2b346e643b9e40c70..bdcb2831c55e21c6d511f56dfc79a507
     * Write raw data in various common formats to the buffer.
     * Note that integer types are written in base-128 varint format, not with a
 diff --git a/src/api/api.cc b/src/api/api.cc
-index 3fd2eecfb969e7ad225d550885a96d642b6f86c2..79ffb2d541329fe7e9c333c0dfaa86cc64b3f653 100644
+index 41050f920d842b417c3336d7f81fb9bdd2204f52..ef229c366bad9284f15a804c9f95a06850de09e4 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -3331,6 +3331,10 @@ void ValueSerializer::SetTreatFunctionsAsHostObjects(bool mode) {
+@@ -3358,6 +3358,10 @@ void ValueSerializer::SetTreatFunctionsAsHostObjects(bool mode) {
    private_->serializer.SetTreatFunctionsAsHostObjects(mode);
  }
  

--- a/patches/v8/0017-Enable-V8-shared-linkage.patch
+++ b/patches/v8/0017-Enable-V8-shared-linkage.patch
@@ -6,7 +6,7 @@ Subject: Enable V8 shared linkage
 Signed-off-by: James M Snell <jsnell@cloudflare.com>
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 177301d141540e81e2a8ac885f2d05432533f00d..5506a9de22c128e3d97df1187752a58c8aec176a 100644
+index 2e084a0d4584bbd1cbc66808213d1c25dead70b3..76942eb6f057cb409f0950eaf2cdc41d4da84717 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
 @@ -1438,6 +1438,7 @@ filegroup(
@@ -25,7 +25,7 @@ index 177301d141540e81e2a8ac885f2d05432533f00d..5506a9de22c128e3d97df1187752a58c
          "src/execution/isolate.h",
          "src/execution/isolate-data.h",
          "src/execution/isolate-inl.h",
-@@ -3184,7 +3184,6 @@ filegroup(
+@@ -3193,7 +3193,6 @@ filegroup(
  filegroup(
      name = "v8_compiler_files",
      srcs = [
@@ -33,7 +33,7 @@ index 177301d141540e81e2a8ac885f2d05432533f00d..5506a9de22c128e3d97df1187752a58c
          "src/compiler/access-builder.cc",
          "src/compiler/access-builder.h",
          "src/compiler/access-info.cc",
-@@ -3773,8 +3772,6 @@ filegroup(
+@@ -3782,8 +3781,6 @@ filegroup(
          "src/builtins/growable-fixed-array-gen.cc",
          "src/builtins/growable-fixed-array-gen.h",
          "src/builtins/number-builtins-reducer-inl.h",
@@ -42,7 +42,7 @@ index 177301d141540e81e2a8ac885f2d05432533f00d..5506a9de22c128e3d97df1187752a58c
          "src/builtins/setup-builtins-internal.cc",
          "src/builtins/torque-csa-header-includes.h",
          "src/codegen/turboshaft-builtins-assembler-inl.h",
-@@ -4049,6 +4046,7 @@ filegroup(
+@@ -4059,6 +4056,7 @@ filegroup(
          "src/snapshot/snapshot-empty.cc",
          "src/snapshot/static-roots-gen.cc",
          "src/snapshot/static-roots-gen.h",
@@ -50,7 +50,7 @@ index 177301d141540e81e2a8ac885f2d05432533f00d..5506a9de22c128e3d97df1187752a58c
      ],
  )
  
-@@ -4159,6 +4157,10 @@ filegroup(
+@@ -4169,6 +4167,10 @@ filegroup(
      name = "noicu/snapshot_files",
      srcs = [
          "src/init/setup-isolate-deserialize.cc",
@@ -61,7 +61,7 @@ index 177301d141540e81e2a8ac885f2d05432533f00d..5506a9de22c128e3d97df1187752a58c
      ] + select({
          "@v8//bazel/config:v8_target_arm": [
              "google3/snapshots/arm/noicu/embedded.S",
-@@ -4176,6 +4178,7 @@ filegroup(
+@@ -4186,6 +4188,7 @@ filegroup(
      name = "icu/snapshot_files",
      srcs = [
          "src/init/setup-isolate-deserialize.cc",

--- a/patches/v8/0018-Modify-where-to-look-for-fast_float-and-simdutf.patch
+++ b/patches/v8/0018-Modify-where-to-look-for-fast_float-and-simdutf.patch
@@ -8,10 +8,10 @@ Similar to fp16, these dependencies now needs to be downloaded by bazel.
 Signed-off-by: James M Snell <jsnell@cloudflare.com>
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 5506a9de22c128e3d97df1187752a58c8aec176a..d41ac90b41b04171c2a6cc3c4636000658796fca 100644
+index 76942eb6f057cb409f0950eaf2cdc41d4da84717..d49cfb18585538cb3a557ef484a16ae04305c0ca 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -4466,17 +4466,19 @@ cc_library(
+@@ -4476,17 +4476,19 @@ cc_library(
      ],
  )
  
@@ -42,7 +42,7 @@ index 5506a9de22c128e3d97df1187752a58c8aec176a..d41ac90b41b04171c2a6cc3c46360006
  
  v8_library(
      name = "v8_libshared",
-@@ -4507,15 +4509,15 @@ v8_library(
+@@ -4517,15 +4519,15 @@ v8_library(
      ],
      deps = [
          ":lib_dragonbox",
@@ -81,7 +81,7 @@ index 5637012bc8d391e31672f07c67144f66b22c4c5f..af3f3bcaab2a7b914c61701778ac4aae
  namespace v8 {
  namespace internal {
 diff --git a/src/objects/string-inl.h b/src/objects/string-inl.h
-index edca8fb23d446ab75f2ea8439f80d4d608e3957f..3f261565ecf075a6aad08b03ec4bc5dd7df7a1a2 100644
+index e04219e7a2e52ce5189d43eec929eb42a1db2e05..be4882ab478ae168e6d614935ccdc53360fef308 100644
 --- a/src/objects/string-inl.h
 +++ b/src/objects/string-inl.h
 @@ -12,6 +12,8 @@

--- a/patches/v8/0020-Add-methods-to-get-heap-and-external-memory-sizes-di.patch
+++ b/patches/v8/0020-Add-methods-to-get-heap-and-external-memory-sizes-di.patch
@@ -8,10 +8,10 @@ Subject: Add methods to get heap and external memory sizes directly.
 Signed-off-by: James M Snell <jsnell@cloudflare.com>
 
 diff --git a/include/v8-isolate.h b/include/v8-isolate.h
-index 550d8ec91a679a0b2c5213f7819798da81a399eb..24e44e66f9192e91a80e55865e20f905b3a7fe06 100644
+index 1125dd7572307681cf91ec339bd60cae2d974eed..d97abc73223264872b7944f996cb5035ee3c9b82 100644
 --- a/include/v8-isolate.h
 +++ b/include/v8-isolate.h
-@@ -1079,6 +1079,16 @@ class V8_EXPORT Isolate {
+@@ -1085,6 +1085,16 @@ class V8_EXPORT Isolate {
    V8_DEPRECATE_SOON("Use ExternalMemoryAccounter instead.")
    int64_t AdjustAmountOfExternalAllocatedMemory(int64_t change_in_bytes);
  
@@ -29,10 +29,10 @@ index 550d8ec91a679a0b2c5213f7819798da81a399eb..24e44e66f9192e91a80e55865e20f905
     * Returns heap profiler for this isolate. Will return NULL until the isolate
     * is initialized.
 diff --git a/src/api/api.cc b/src/api/api.cc
-index 79ffb2d541329fe7e9c333c0dfaa86cc64b3f653..534f2e20858a5b06003a9dbd61382b8c300d3a8d 100644
+index ef229c366bad9284f15a804c9f95a06850de09e4..384862eb65b9ddd37d0cc385f18a788b8d253226 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -10409,6 +10409,14 @@ void Isolate::GetHeapStatistics(HeapStatistics* heap_statistics) {
+@@ -10444,6 +10444,14 @@ void Isolate::GetHeapStatistics(HeapStatistics* heap_statistics) {
  #endif  // V8_ENABLE_WEBASSEMBLY
  }
  

--- a/patches/v8/0021-Remove-DCHECK-from-WriteOneByteV2-to-skip-v8-fatal.patch
+++ b/patches/v8/0021-Remove-DCHECK-from-WriteOneByteV2-to-skip-v8-fatal.patch
@@ -9,10 +9,10 @@ and throw a TypeError if the input string isn't one-byte only.
 Signed-off-by: James M Snell <jsnell@cloudflare.com>
 
 diff --git a/src/api/api.cc b/src/api/api.cc
-index 534f2e20858a5b06003a9dbd61382b8c300d3a8d..5796e0a3f1f265dac240ac0590656d8b65b069f1 100644
+index 384862eb65b9ddd37d0cc385f18a788b8d253226..accbf39c5b0caa9ad5f55d7decc3c80ae27952bd 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -5927,7 +5927,8 @@ void String::WriteV2(Isolate* v8_isolate, uint32_t offset, uint32_t length,
+@@ -5949,7 +5949,8 @@ void String::WriteV2(Isolate* v8_isolate, uint32_t offset, uint32_t length,
  
  void String::WriteOneByteV2(Isolate* v8_isolate, uint32_t offset,
                              uint32_t length, uint8_t* buffer, int flags) const {

--- a/patches/v8/0022-Port-concurrent-mksnapshot-support.patch
+++ b/patches/v8/0022-Port-concurrent-mksnapshot-support.patch
@@ -6,7 +6,7 @@ Subject: Port concurrent mksnapshot support
 Change-Id: I57c8158ff5d624e5379e6b072f27ac7a40419522
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index d41ac90b41b04171c2a6cc3c4636000658796fca..2bd33c49f99b8c9ab4aee237f6e25dcbeb13ad3a 100644
+index d49cfb18585538cb3a557ef484a16ae04305c0ca..afdc0516e43449c3d99115f174520ac77e0b7200 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
 @@ -120,6 +120,11 @@ v8_flag(name = "v8_enable_hugepage")
@@ -21,7 +21,7 @@ index d41ac90b41b04171c2a6cc3c4636000658796fca..2bd33c49f99b8c9ab4aee237f6e25dcb
  v8_flag(name = "v8_enable_future")
  
  # NOTE: Transitions are not recommended in library targets:
-@@ -4395,6 +4400,13 @@ v8_mksnapshot(
+@@ -4405,6 +4410,13 @@ v8_mksnapshot(
              "--no-turbo-verify-allocation",
          ],
          "//conditions:default": [],

--- a/patches/v8/0023-Port-V8_USE_ZLIB-support.patch
+++ b/patches/v8/0023-Port-V8_USE_ZLIB-support.patch
@@ -6,7 +6,7 @@ Subject: Port V8_USE_ZLIB support
 Change-Id: Icfedf3e90522f1ff5037517a39a5f0e3d44abace
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 2bd33c49f99b8c9ab4aee237f6e25dcbeb13ad3a..e6d32a244ed32d278b2c88cadbc40406c1a4d928 100644
+index afdc0516e43449c3d99115f174520ac77e0b7200..f177ace0454ce2b0483689eade7c22e88520c01d 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
 @@ -162,6 +162,11 @@ v8_flag(name = "v8_enable_verify_predictable")
@@ -29,7 +29,7 @@ index 2bd33c49f99b8c9ab4aee237f6e25dcbeb13ad3a..e6d32a244ed32d278b2c88cadbc40406
      },
      defines = [
          "GOOGLE3",
-@@ -4530,6 +4536,8 @@ v8_library(
+@@ -4540,6 +4546,8 @@ v8_library(
          "@highway//:hwy",
          "@fast_float",
          "@simdutf",
@@ -52,7 +52,7 @@ index 3c1ed7cf1e45ab4b87dd134430f7cda321e5e338..fa41e87973bebbe36da35e90a5136537
  
  namespace v8 {
 diff --git a/src/objects/deoptimization-data.cc b/src/objects/deoptimization-data.cc
-index 584400990a49f5c904c5a966cd8228a16d84961f..04da60dcb44455dea012df126dd53f5188d3ff55 100644
+index 28cc0ad4c7487fe8264623598744b512e4d57e41..9a6605c04606a00554184a2deb99586c0800cccf 100644
 --- a/src/objects/deoptimization-data.cc
 +++ b/src/objects/deoptimization-data.cc
 @@ -14,7 +14,7 @@

--- a/patches/v8/0024-Modify-where-to-look-for-dragonbox.patch
+++ b/patches/v8/0024-Modify-where-to-look-for-dragonbox.patch
@@ -5,10 +5,10 @@ Subject: Modify where to look for dragonbox
 
 
 diff --git a/BUILD.bazel b/BUILD.bazel
-index e6d32a244ed32d278b2c88cadbc40406c1a4d928..933969d80185900284195293408ee479fff1cf40 100644
+index f177ace0454ce2b0483689eade7c22e88520c01d..64bb6befb607f234b982fdeb280a24c4a7c365e4 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -3981,14 +3981,9 @@ filegroup(
+@@ -3990,14 +3990,9 @@ filegroup(
  )
  
  v8_library(

--- a/patches/v8/0027-Implement-additional-Exception-construction-methods.patch
+++ b/patches/v8/0027-Implement-additional-Exception-construction-methods.patch
@@ -25,10 +25,10 @@ index 5441a0ab6a403c566e7b0b6002e720c971480893..b9933027aaf9f7842740d6a6742a2c73
    /**
     * Creates an error message for the given exception.
 diff --git a/src/api/api.cc b/src/api/api.cc
-index 5796e0a3f1f265dac240ac0590656d8b65b069f1..f7a3b54a59e1c2f812d71b222fa505b190b1e361 100644
+index accbf39c5b0caa9ad5f55d7decc3c80ae27952bd..e7e3a2699e1d678d97062b3ee89cb7409c6890c5 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -11271,6 +11271,10 @@ DEFINE_ERROR(WasmCompileError, wasm_compile_error)
+@@ -11310,6 +11310,10 @@ DEFINE_ERROR(WasmCompileError, wasm_compile_error)
  DEFINE_ERROR(WasmLinkError, wasm_link_error)
  DEFINE_ERROR(WasmRuntimeError, wasm_runtime_error)
  DEFINE_ERROR(WasmSuspendError, wasm_suspend_error)

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -46,6 +46,8 @@ void HeapTracer::clearWrappers() {
   clearFreelistedShims();
 }
 
+using JSGWrappable = workerd::jsg::Wrappable;
+
 // V8's GC integrates with cppgc, aka "oilpan", a garbage collector for C++ objects. We want to
 // integrate with the GC in order to receive GC visitation callbacks, so that the GC is able to
 // trace through our C++ objects to find what is reachable through them. The only way for us to
@@ -72,9 +74,9 @@ void HeapTracer::clearWrappers() {
 // reused for a future allocation, if that allocation occurs before the next major GC. When a
 // major GC occurs, the freelist is cleared, since any unreachable CppgcShim objects are likely
 // condemned after that point and will be deleted shortly thereafter.
-class Wrappable::CppgcShim final: public cppgc::GarbageCollected<CppgcShim> {
+class Wrappable::CppgcShim final: public v8::Object::Wrappable {
  public:
-  CppgcShim(Wrappable& wrappable): state(Active{kj::addRef(wrappable)}) {
+  CppgcShim(JSGWrappable& wrappable): state(Active{kj::addRef(wrappable)}) {
     KJ_DASSERT(wrappable.cppgcShim == kj::none);
     wrappable.cppgcShim = *this;
   }
@@ -105,7 +107,7 @@ class Wrappable::CppgcShim final: public cppgc::GarbageCollected<CppgcShim> {
     }
   }
 
-  void Trace(cppgc::Visitor* visitor) const {
+  void Trace(cppgc::Visitor* visitor) const override {
     KJ_SWITCH_ONEOF(state) {
       KJ_CASE_ONEOF(active, Active) {
         active.wrappable->traceFromV8(*visitor);
@@ -119,15 +121,19 @@ class Wrappable::CppgcShim final: public cppgc::GarbageCollected<CppgcShim> {
     }
   }
 
+  const char* GetHumanReadableName() const override {
+    return "CppgcShim";
+  }
+
   struct Active {
-    kj::Own<Wrappable> wrappable;
+    kj::Own<JSGWrappable> wrappable;
   };
 
   // The JavaScript wrapper using this shim was collected in a minor GC. cppgc objects can only
   // be collected in full GC, so we freelist the shim object in the meantime.
   struct Freelisted {
-    kj::Maybe<Wrappable::CppgcShim&> next;
-    kj::Maybe<Wrappable::CppgcShim&>* prev;
+    kj::Maybe<JSGWrappable::CppgcShim&> next;
+    kj::Maybe<JSGWrappable::CppgcShim&>* prev;
     // kj::List doesn't quite work here because the list link is inside a OneOf. Also we want a
     // LIFO list anyway so we don't need a tail pointer, which makes things easier. So we do it
     // manually.
@@ -154,37 +160,37 @@ class Wrappable::CppgcShim final: public cppgc::GarbageCollected<CppgcShim> {
   // the main thread so concurrency is not a concern.
 };
 
-void HeapTracer::addToFreelist(Wrappable::CppgcShim& shim) {
-  auto& freelisted = shim.state.init<Wrappable::CppgcShim::Freelisted>();
+void HeapTracer::addToFreelist(JSGWrappable::CppgcShim& shim) {
+  auto& freelisted = shim.state.init<JSGWrappable::CppgcShim::Freelisted>();
   freelisted.next = freelistedShims;
   KJ_IF_SOME(next, freelisted.next) {
-    next.state.get<Wrappable::CppgcShim::Freelisted>().prev = &freelisted.next;
+    next.state.get<JSGWrappable::CppgcShim::Freelisted>().prev = &freelisted.next;
   }
   freelisted.prev = &freelistedShims;
   freelistedShims = shim;
 }
 
-Wrappable::CppgcShim* HeapTracer::allocateShim(Wrappable& wrappable) {
+JSGWrappable::CppgcShim* HeapTracer::allocateShim(JSGWrappable& wrappable) {
   KJ_IF_SOME(shim, freelistedShims) {
-    freelistedShims = shim.state.get<Wrappable::CppgcShim::Freelisted>().next;
+    freelistedShims = shim.state.get<JSGWrappable::CppgcShim::Freelisted>().next;
     KJ_IF_SOME(next, freelistedShims) {
-      next.state.get<Wrappable::CppgcShim::Freelisted>().prev = &freelistedShims;
+      next.state.get<JSGWrappable::CppgcShim::Freelisted>().prev = &freelistedShims;
     }
-    shim.state = Wrappable::CppgcShim::Active{kj::addRef(wrappable)};
+    shim.state = JSGWrappable::CppgcShim::Active{kj::addRef(wrappable)};
     KJ_DASSERT(wrappable.cppgcShim == kj::none);
     wrappable.cppgcShim = shim;
     return &shim;
   } else {
     auto& cppgcAllocHandle = isolate->GetCppHeap()->GetAllocationHandle();
-    return cppgc::MakeGarbageCollected<Wrappable::CppgcShim>(cppgcAllocHandle, wrappable);
+    return cppgc::MakeGarbageCollected<JSGWrappable::CppgcShim>(cppgcAllocHandle, wrappable);
   }
 }
 
 void HeapTracer::clearFreelistedShims() {
   for (;;) {
     KJ_IF_SOME(shim, freelistedShims) {
-      freelistedShims = shim.state.get<Wrappable::CppgcShim::Freelisted>().next;
-      shim.state = Wrappable::CppgcShim::Dead{};
+      freelistedShims = shim.state.get<JSGWrappable::CppgcShim::Freelisted>().next;
+      shim.state = JSGWrappable::CppgcShim::Dead{};
     } else {
       break;
     }
@@ -198,7 +204,7 @@ void HeapTracer::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
   // TODO(soon): Track the other fields here?
 }
 
-kj::Own<Wrappable> Wrappable::detachWrapper(bool shouldFreelistShim) {
+kj::Own<JSGWrappable> JSGWrappable::detachWrapper(bool shouldFreelistShim) {
   KJ_IF_SOME(shim, cppgcShim) {
 #if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
     // There's a possibility that the CppgcShim has already been found to be unreachable by a GC
@@ -221,11 +227,12 @@ kj::Own<Wrappable> Wrappable::detachWrapper(bool shouldFreelistShim) {
 #endif
 
     auto& tracer = HeapTracer::getTracer(isolate);
-    auto result = kj::mv(KJ_ASSERT_NONNULL(shim.state.tryGet<CppgcShim::Active>()).wrappable);
+    auto result =
+        kj::mv(KJ_ASSERT_NONNULL(shim.state.tryGet<JSGWrappable::CppgcShim::Active>()).wrappable);
     if (shouldFreelistShim) {
       tracer.addToFreelist(shim);
     } else {
-      shim.state = CppgcShim::Dead{};
+      shim.state = JSGWrappable::CppgcShim::Dead{};
     }
     wrapper = kj::none;
     cppgcShim = kj::none;


### PR DESCRIPTION
This v8 update introduces a new Wrappable API which required changes to our `Wrappable::CppgcShim` type. The rest is fairly straightforward.