### PR TITLE
types(workflows)!: make InstanceStatus.error an Error-like object

### DIFF
--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -81,7 +81,7 @@ type InstanceStatus = {
     | 'waiting' // instance is hibernating and waiting for sleep or event to finish
     | 'waitingForPause' // instance is finishing the current work to pause
     | 'unknown';
-  error?: string;
+	error?: { message: string; name: 'Error' };
   output?: object;
 };
 


### PR DESCRIPTION
The workflows runtime returns an Error-like object, not a plain string. The previous declaration made error handling awkward and misleading.