### PR TITLE
[R2 instrumentation] Update R2 span names

### DIFF
--- a/src/workerd/api/r2-admin.c++
+++ b/src/workerd/api/r2-admin.c++
@@ -27,8 +27,8 @@ jsg::Promise<jsg::Ref<R2Bucket>> R2Admin::create(
     jsg::Lock& js, kj::String name, const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
   auto& context = IoContext::current();
 
-  auto traceSpan = context.makeTraceSpan("r2_create"_kjc);
-  auto userSpan = context.makeUserTraceSpan("r2_create"_kjc);
+  auto traceSpan = context.makeTraceSpan("r2_create_bucket"_kjc);
+  auto userSpan = context.makeUserTraceSpan("r2_create_bucket"_kjc);
   TraceContext traceContext(kj::mv(traceSpan), kj::mv(userSpan));
   auto client = context.getHttpClient(subrequestChannel, true, kj::none, traceContext);
 
@@ -68,13 +68,13 @@ jsg::Promise<R2Admin::ListResult> R2Admin::list(jsg::Lock& js,
     CompatibilityFlags::Reader flags) {
   auto& context = IoContext::current();
 
-  auto traceSpan = context.makeTraceSpan("r2_list"_kjc);
-  auto userSpan = context.makeUserTraceSpan("r2_list"_kjc);
+  auto traceSpan = context.makeTraceSpan("r2_list_buckets"_kjc);
+  auto userSpan = context.makeUserTraceSpan("r2_list_buckets"_kjc);
   TraceContext traceContext(kj::mv(traceSpan), kj::mv(userSpan));
   auto client = context.getHttpClient(subrequestChannel, true, kj::none, traceContext);
 
   traceContext.userSpan.setTag("rpc.service"_kjc, kj::str("r2"_kjc));
-  traceContext.userSpan.setTag("rpc.method"_kjc, kj::str("ListObjects"_kjc));
+  traceContext.userSpan.setTag("rpc.method"_kjc, kj::str("ListBuckets"_kjc));
 
   capnp::JsonCodec json;
   json.handleByAnnotation<R2BindingRequest>();
@@ -132,8 +132,8 @@ jsg::Promise<void> R2Admin::delete_(
     jsg::Lock& js, kj::String name, const jsg::TypeHandler<jsg::Ref<R2Error>>& errorType) {
   auto& context = IoContext::current();
 
-  auto traceSpan = context.makeTraceSpan("r2_delete"_kjc);
-  auto userSpan = context.makeUserTraceSpan("r2_delete"_kjc);
+  auto traceSpan = context.makeTraceSpan("r2_delete_bucket"_kjc);
+  auto userSpan = context.makeUserTraceSpan("r2_delete_bucket"_kjc);
   TraceContext traceContext(kj::mv(traceSpan), kj::mv(userSpan));
   auto client = context.getHttpClient(subrequestChannel, true, kj::none, traceContext);
 

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -342,8 +342,8 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::head(jsg::Lock
   return js.evalNow([&] {
     auto& context = IoContext::current();
 
-    auto traceSpan = context.makeTraceSpan("r2_get"_kjc);
-    auto userSpan = context.makeUserTraceSpan("r2_get"_kjc);
+    auto traceSpan = context.makeTraceSpan("r2_head"_kjc);
+    auto userSpan = context.makeUserTraceSpan("r2_head"_kjc);
     TraceContext traceContext(kj::mv(traceSpan), kj::mv(userSpan));
     auto client = context.getHttpClient(clientIndex, true, kj::none, traceContext);
 

--- a/src/workerd/api/r2-instrumentation-test.js
+++ b/src/workerd/api/r2-instrumentation-test.js
@@ -90,7 +90,7 @@ export const test = {
         closed: true,
       },
       {
-        name: 'r2_get',
+        name: 'r2_head',
         'cloudflare.binding.type': 'r2',
         'cloudflare.binding.name': 'BUCKET',
         'cloudflare.r2.operation': 'HeadObject',
@@ -242,7 +242,7 @@ export const test = {
         closed: true,
       },
       {
-        name: 'r2_get',
+        name: 'r2_head',
         'cloudflare.binding.type': 'r2',
         'cloudflare.binding.name': 'BUCKET',
         'cloudflare.r2.operation': 'HeadObject',
@@ -295,7 +295,7 @@ export const test = {
         closed: true,
       },
       {
-        name: 'r2_get',
+        name: 'r2_head',
         'cloudflare.binding.type': 'r2',
         'cloudflare.binding.name': 'BUCKET',
         'cloudflare.r2.operation': 'HeadObject',
@@ -348,7 +348,7 @@ export const test = {
         closed: true,
       },
       {
-        name: 'r2_get',
+        name: 'r2_head',
         'cloudflare.binding.type': 'r2',
         'cloudflare.binding.name': 'BUCKET',
         'cloudflare.r2.operation': 'HeadObject',
@@ -401,7 +401,7 @@ export const test = {
         closed: true,
       },
       {
-        name: 'r2_get',
+        name: 'r2_head',
         'cloudflare.binding.type': 'r2',
         'cloudflare.binding.name': 'BUCKET',
         'cloudflare.r2.operation': 'HeadObject',
@@ -446,7 +446,7 @@ export const test = {
         closed: true,
       },
       {
-        name: 'r2_get',
+        name: 'r2_head',
         'cloudflare.binding.type': 'r2',
         'cloudflare.binding.name': 'BUCKET',
         'cloudflare.r2.operation': 'HeadObject',
@@ -491,7 +491,7 @@ export const test = {
         closed: true,
       },
       {
-        name: 'r2_get',
+        name: 'r2_head',
         'cloudflare.binding.type': 'r2',
         'cloudflare.binding.name': 'BUCKET',
         'cloudflare.r2.operation': 'HeadObject',
@@ -545,7 +545,7 @@ export const test = {
         closed: true,
       },
       {
-        name: 'r2_get',
+        name: 'r2_head',
         'cloudflare.binding.type': 'r2',
         'cloudflare.binding.name': 'BUCKET',
         'cloudflare.r2.operation': 'HeadObject',
@@ -599,7 +599,7 @@ export const test = {
         closed: true,
       },
       {
-        name: 'r2_get',
+        name: 'r2_head',
         'cloudflare.binding.type': 'r2',
         'cloudflare.binding.name': 'BUCKET',
         'cloudflare.r2.operation': 'HeadObject',


### PR DESCRIPTION
`R2::head()` deserves it's own span name, and the bucket admin methods do too.

Depends on https://gitlab.cfdata.org/cloudflare/ew/edgeworker/-/merge_requests/11390 to update the allowlist