### PR TITLE
Implement dynamic tails on dynamically-loaded workers.

### DIFF
--- a/src/workerd/api/worker-loader-test.wd-test
+++ b/src/workerd/api/worker-loader-test.wd-test
@@ -17,6 +17,7 @@ const unitTests :Workerd.Config = (
         ],
         durableObjectNamespaces = [
           (className = "FacetTestActor", uniqueKey = "FacetTestActor"),
+          (className = "RendezvousActor", uniqueKey = "RendezvousActor"),
         ],
         durableObjectStorage = (inMemory = void),
         globalOutbound = (name = "worker-loader-test", entrypoint = "defaultOutbound"),

--- a/src/workerd/api/worker-loader.h
+++ b/src/workerd/api/worker-loader.h
@@ -90,10 +90,11 @@ class WorkerLoader: public jsg::Object {
     // If `null`, block the global outbound (all requests throw errors).
     jsg::Optional<kj::Maybe<jsg::Ref<Fetcher>>> globalOutbound;
 
-    // TODO(someday): cache API outbound?
+    // Specify tail workers.
+    jsg::Optional<kj::Array<jsg::Ref<Fetcher>>> tails;
+    jsg::Optional<kj::Array<jsg::Ref<Fetcher>>> streamingTails;
 
-    // TODO(someday): Support specifying a list of tail workers. These should work similarly to
-    //   globalOutbound.
+    // TODO(someday): cache API outbound?
 
     JSG_STRUCT(compatibilityDate,
         compatibilityFlags,
@@ -101,7 +102,8 @@ class WorkerLoader: public jsg::Object {
         mainModule,
         modules,
         env,
-        globalOutbound);
+        globalOutbound,
+        tails);
   };
 
   jsg::Ref<WorkerStub> get(

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -282,6 +282,10 @@ struct DynamicWorkerSource {
   // Where should global fetch() (and connect()) be sent?
   kj::Maybe<kj::Own<IoChannelFactory::SubrequestChannel>> globalOutbound;
 
+  // Tail workers that should receive tail events for invocations of the dynamic worker.
+  kj::Array<kj::Own<IoChannelFactory::SubrequestChannel>> tails;
+  kj::Array<kj::Own<IoChannelFactory::SubrequestChannel>> streamingTails;
+
   // Owns any data structures pointed into by the other members. (E.g. `source` contains a lot of
   // `StringPtr`s; `ownContent` owns the backing buffer for them.)
   kj::Own<void> ownContent;

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3949,6 +3949,19 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
         .subrequestChannels = kj::mv(subrequestChannels),
         .actorClassChannels = kj::mv(actorClassChannels),
 
+        .tails = KJ_MAP(tail, source.tails) -> FutureSubrequestChannel {
+          return {
+            .designator = kj::mv(tail),
+            .errorContext = kj::str("Worker's tail"),
+          };
+        },
+        .streamingTails = KJ_MAP(tail, source.streamingTails) -> FutureSubrequestChannel {
+          return {
+            .designator = kj::mv(tail),
+            .errorContext = kj::str("Worker's streaming tail"),
+          };
+        },
+
         .compileBindings = [env = kj::mv(source.env)](
             jsg::Lock& js, const Worker::Api& api, v8::Local<v8::Object> target) mutable {
           env.populateJsObject(js, jsg::JsObject(target));
@@ -4162,24 +4175,24 @@ kj::Promise<kj::Own<Server::Service>> Server::makeWorker(kj::StringPtr name,
     .actorClassChannels = kj::mv(actorClassChannels),
     .workerLoaderChannels = kj::mv(workerLoaderChannels),
 
+    // clang-format off
     .tails = KJ_MAP(tail, conf.getTails()) -> FutureSubrequestChannel {
-    return {
-      .designator = tail,
-      .errorContext = kj::str("Worker \"", name, "\"'s tails"),
-    };
-  },
+      return {
+        .designator = tail,
+        .errorContext = kj::str("Worker \"", name, "\"'s tails"),
+      };
+    },
 
     .streamingTails = KJ_MAP(streamingTail, conf.getStreamingTails()) -> FutureSubrequestChannel {
-    return {
-      .designator = streamingTail,
-      .errorContext = kj::str("Worker \"", name, "\"'s streaming tails"),
-    };
-  },
+      return {
+        .designator = streamingTail,
+        .errorContext = kj::str("Worker \"", name, "\"'s streaming tails"),
+      };
+    },
 
     .actorStorageConf = conf.getDurableObjectStorage(),
     .containerEngineConf = conf.getContainerEngine(),
 
-    // clang-format off
     .compileBindings = [globals = kj::mv(globals)](
         jsg::Lock& lock, const Worker::Api& api, v8::Local<v8::Object> target) {
       return WorkerdApi::from(api).compileGlobals(lock, globals, target, 1);


### PR DESCRIPTION
You can now specify an array of `tails` (and `streamingTails`, if `allowExperimental` is enabled) as part of a dynamic worker's source. This is just like setting `globalOutbound` -- you can specify any service binding (including loopback ctx.exports bindings).