### PR TITLE
Add D1 total_attempts field to query meta response

### DIFF
--- a/src/cloudflare/internal/test/d1/d1-api-test-common.js
+++ b/src/cloudflare/internal/test/d1/d1-api-test-common.js
@@ -43,7 +43,8 @@ export const itShould = async (description, ...assertions) => {
   }
 };
 
-// Make it easy to specify only a the meta properties we're interested in
+// Make it easy to specify only a the meta properties we're interested in.
+// Anything specified here as `anything` won't be checked.
 const meta = (values) => ({
   duration: anything,
   served_by: anything,
@@ -56,6 +57,7 @@ const meta = (values) => ({
   size_after: anything,
   rows_read: anything,
   rows_written: anything,
+  total_attempts: anything,
   ...values,
 });
 

--- a/types/defines/d1.d.ts
+++ b/types/defines/d1.d.ts
@@ -22,7 +22,13 @@ interface D1Meta {
      * The duration of the SQL query execution by the database instance. It doesn't include any network time.
      */
     sql_duration_ms: number;
-  }
+  };
+
+  /**
+   * Number of total attempts to execute the query, due to automatic retries.
+   * Note: All other fields in the response like `timings` only apply to the last attempt.
+   */
+  total_attempts?: number;
 }
 
 interface D1Response {
@@ -44,11 +50,11 @@ type D1SessionConstraint =
   // Indicates that the first query should go to the primary, and the rest queries
   // using the same D1DatabaseSession will go to any replica that is consistent with
   // the bookmark maintained by the session (returned by the first query).
-  | "first-primary"
+  | 'first-primary'
   // Indicates that the first query can go anywhere (primary or replica), and the rest queries
   // using the same D1DatabaseSession will go to any replica that is consistent with
   // the bookmark maintained by the session (returned by the first query).
-  | "first-unconstrained";
+  | 'first-unconstrained';
 type D1SessionBookmark = string;
 
 declare abstract class D1Database {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -7505,6 +7505,11 @@ interface D1Meta {
      */
     sql_duration_ms: number;
   };
+  /**
+   * Number of total attempts to execute the query, due to automatic retries.
+   * Note: All other fields in the response like `timings` only apply to the last attempt.
+   */
+  total_attempts?: number;
 }
 interface D1Response {
   success: true;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -7534,6 +7534,11 @@ export interface D1Meta {
      */
     sql_duration_ms: number;
   };
+  /**
+   * Number of total attempts to execute the query, due to automatic retries.
+   * Note: All other fields in the response like `timings` only apply to the last attempt.
+   */
+  total_attempts?: number;
 }
 export interface D1Response {
   success: true;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -7276,6 +7276,11 @@ interface D1Meta {
      */
     sql_duration_ms: number;
   };
+  /**
+   * Number of total attempts to execute the query, due to automatic retries.
+   * Note: All other fields in the response like `timings` only apply to the last attempt.
+   */
+  total_attempts?: number;
 }
 interface D1Response {
   success: true;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -7303,6 +7303,11 @@ export interface D1Meta {
      */
     sql_duration_ms: number;
   };
+  /**
+   * Number of total attempts to execute the query, due to automatic retries.
+   * Note: All other fields in the response like `timings` only apply to the last attempt.
+   */
+  total_attempts?: number;
 }
 export interface D1Response {
   success: true;


### PR DESCRIPTION
The D1 service will start returning `meta.total_attempts` in its query responses (see CFSQL-1136 internally).

This change updates the D1 workerd tests to not fail with that extra property, and also adds it to the D1 response types as optional.

## Test 

```sh
% bazel run //src/cloudflare/internal/test/d1:d1-api-test              
...
Executing tests from //src/cloudflare/internal/test/d1:d1-api-test
-----------------------------------------------------------------------------
workerd/server/server.c++:5530: debug: [ TEST ] d1-api-test:testWithoutSessions
workerd/server/server.c++:5544: debug: [ PASS ] d1-api-test:testWithoutSessions (350.448ms)

% bazel run //src/cloudflare/internal/test/d1:d1-api-test-with-sessions
...
Executing tests from //src/cloudflare/internal/test/d1:d1-api-test-with-sessions
-----------------------------------------------------------------------------
workerd/server/server.c++:5530: debug: [ TEST ] d1-api-test-with-sessions:test_d1_api_happy_path
workerd/server/server.c++:5544: debug: [ PASS ] d1-api-test-with-sessions:test_d1_api_happy_path (322.872ms)
workerd/server/server.c++:5530: debug: [ TEST ] d1-api-test-with-sessions:test_d1_api_happy_path_withsessions_default
workerd/server/server.c++:5544: debug: [ PASS ] d1-api-test-with-sessions:test_d1_api_happy_path_withsessions_default (232.835ms)
workerd/server/server.c++:5530: debug: [ TEST ] d1-api-test-with-sessions:test_d1_api_happy_path_withsessions_first_primary
workerd/server/server.c++:5544: debug: [ PASS ] d1-api-test-with-sessions:test_d1_api_happy_path_withsessions_first_primary (226.749ms)
workerd/server/server.c++:5530: debug: [ TEST ] d1-api-test-with-sessions:test_d1_api_happy_path_withsessions_first_unconstrained
workerd/server/server.c++:5544: debug: [ PASS ] d1-api-test-with-sessions:test_d1_api_happy_path_withsessions_first_unconstrained (214.832ms)
workerd/server/server.c++:5530: debug: [ TEST ] d1-api-test-with-sessions:test_d1_api_happy_path_withsessions_some_ranomd_token
workerd/server/server.c++:5544: debug: [ PASS ] d1-api-test-with-sessions:test_d1_api_happy_path_withsessions_some_ranomd_token (204.774ms)
workerd/server/server.c++:5530: debug: [ TEST ] d1-api-test-with-sessions:test_d1_api_withsessions_old_token_skipped
workerd/server/server.c++:5544: debug: [ PASS ] d1-api-test-with-sessions:test_d1_api_withsessions_old_token_skipped (8.787ms)
workerd/server/server.c++:5530: debug: [ TEST ] d1-api-test-with-sessions:test_d1_api_withsessions_token_handling
workerd/server/server.c++:5544: debug: [ PASS ] d1-api-test-with-sessions:test_d1_api_withsessions_token_handling (906.591ms)
```