### PR TITLE
[build] Add rudimentary header parsing support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -319,6 +319,13 @@ build:windows_dbg --linkopt='/OPT:LLDTAILMERGE' --linkopt='/OPT:SAFEICF'
 # a shared library.
 build:windows --copt='/Zc:dllexportInlines-'
 
+# Configuration for header parsing. Requires bazel toolchain support (available for macOS, Linux).
+build:parse_headers --features=parse_headers --process_headers_in_dependencies
+# Silence some capnproto warnings/errors that are not relevant for header parsing
+build:parse_headers --per_file_copt='.*\.h@-Wno-unused-function,-Wno-pragma-system-header-outside-header'
+build:parse_headers --per_file_copt=external/capnp-cpp/src/kj/common.h@-Wno-unreachable-code
+build:parse_headers --per_file_copt=external/capnp-cpp/src/capnp/arena.h@-DCAPNP_PRIVATE
+
 # optimized configuration
 build:opt -c opt
 build:opt --@capnp-cpp//src/kj:debug_memory=False

--- a/.github/workflows/_bazel.yml
+++ b/.github/workflows/_bazel.yml
@@ -31,6 +31,10 @@ on:
         type: string
         required: false
         default: //...
+      parse_headers:
+        type: boolean
+        required: false
+        default: false
       extra_bazel_args:
         type: string
         required: false
@@ -119,6 +123,13 @@ jobs:
         if: inputs.run_tests
         run: |
           bazel test --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci ${{ inputs.extra_bazel_args }} ${{ inputs.test_target }}
+      - name: Parse headers
+        # TODO(cleanup): Bazel does not allow for only parsing headers in non-recursive targets, so
+        # we can't widely enable header parsing for now (dependencies like V8 do not specify
+        # dependencies of header targets properly).
+        if: inputs.parse_headers
+        run: |
+          bazel build --config=parse_headers --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci ${{ inputs.extra_bazel_args }} //src/workerd/util //src/workerd/io:actor
       - name: Upload test logs
         if: inputs.upload_test_logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,5 +25,5 @@ jobs:
         run: git config core.hooksPath githooks
       - name: Lint
         run: |
-          bazel info output_base # Ensure bazel is initialized before procedding
+          bazel info output_base # Ensure bazel is initialized before proceeding
           python3 ./tools/cross/format.py --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,7 @@ jobs:
     with:
       extra_bazel_args: '--config=lint --config=ci-test --config=ci-linux'
       run_tests: false
+      parse_headers: true
     secrets:
       BAZEL_CACHE_KEY: ${{ secrets.BAZEL_CACHE_KEY }}
       WORKERS_MIRROR_URL: ${{ secrets.WORKERS_MIRROR_URL }}

--- a/build/BUILD.zlib
+++ b/build/BUILD.zlib
@@ -72,6 +72,7 @@ cc_library(
         "zlib.h",
         "zutil.h",
     ],
+    features = ["-parse_headers"],
     # For zlib to be found using <zlib.h> before system zlib, use this flag for the include to also be added using isystem.
     includes = ["."],
     local_defines = ["ZLIB_IMPLEMENTATION"],
@@ -136,6 +137,7 @@ cc_library(
         "contrib/optimizations/inflate.c",
     ],
     copts = zlib_warnings,
+    features = ["-parse_headers"],
     local_defines = [
         "INFLATE_CHUNK_READ_64LE",
         "ZLIB_IMPLEMENTATION",
@@ -225,6 +227,7 @@ cc_library(
     name = "zlib",
     srcs = [":zlib_files"],
     copts = zlib_warnings,
+    features = ["-parse_headers"],
     # Duplicate definitions here since we want to avoid non-local defines, some of them are needed
     # here. This excludes INFLATE_CHUNK_* which is only needed in zlib_inflate_chunk_simd.
     local_defines = ["ZLIB_IMPLEMENTATION"] + select({


### PR DESCRIPTION
Unfortunately, we can't enable this more widely without patching V8/perfetto, which don't attempt to define self-sufficient Bazel targets.