### PR TITLE
Track memory snapshot type in SnapshotMeta settings.

### DIFF
--- a/src/pyodide/types/artifacts.d.ts
+++ b/src/pyodide/types/artifacts.d.ts
@@ -1,7 +1,9 @@
 declare namespace ArtifactBundler {
+  type SnapshotType = 'baseline' | 'dedicated' | 'package';
   type MemorySnapshotResult = {
     snapshot: Uint8Array;
     importedModulesList: string[];
+    snapshotType: SnapshotType;
   };
 
   const hasMemorySnapshot: () => boolean;

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -273,7 +273,8 @@ class PyodideMetadataReader: public jsg::Object {
 struct MemorySnapshotResult {
   kj::Array<kj::byte> snapshot;
   kj::Array<kj::String> importedModulesList;
-  JSG_STRUCT(snapshot, importedModulesList);
+  kj::String snapshotType;
+  JSG_STRUCT(snapshot, importedModulesList, snapshotType);
 };
 
 // This used to be declared nested as ArtifactBundler::State, but then there was a need to


### PR DESCRIPTION
This enables us to perform additional checks in the validator and ensure we aren't generating a non-dedicated snapshot by mistake.