### PR TITLE
chore(bazel): ensure pnpm run outside Bazel has similar behavior

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,8 @@
 # When enabled, pnpm will automatically download and run the version of pnpm
 # specified in the packageManager field of package.json.
 manage-package-manager-versions = true
+
+# Disabling pnpm [hoisting](https://pnpm.io/npmrc#hoist) by setting `hoist=false` is recommended on
+# projects using rules_js so that pnpm outside of Bazel lays out a node_modules tree similar to what
+# rules_js lays out under Bazel (without a hidden node_modules/.pnpm/node_modules)
+hoist=false


### PR DESCRIPTION
rules_js always lays out packages without 'hoisting' so we want any native usage of pnpm to match