### PR TITLE
Includes snapshot type in Python startup limit exceeds error.

### DIFF
--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -105,6 +105,7 @@ const CREATED_SNAPSHOT_META: DsoLoadInfo = {
   soMemoryBases: {},
   loadOrder: [],
 };
+export const LOADED_SNAPSHOT_TYPE = LOADED_SNAPSHOT_META?.settings.snapshotType;
 
 /**
  * Preload a dynamic library.

--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -21,6 +21,7 @@ import {
   PythonUserError,
   reportError,
 } from 'pyodide-internal:util';
+import { LOADED_SNAPSHOT_TYPE } from 'pyodide-internal:snapshot';
 
 type PyFuture<T> = Promise<T> & { copy(): PyFuture<T>; destroy(): void };
 
@@ -239,7 +240,7 @@ function getMainModule(): Promise<PyModule> {
           pyimportMainModule(pyodide)
         );
       } finally {
-        Limiter.finishStartup();
+        Limiter.finishStartup(LOADED_SNAPSHOT_TYPE);
       }
     })();
     return mainModulePromise;

--- a/src/pyodide/types/limiter.d.ts
+++ b/src/pyodide/types/limiter.d.ts
@@ -1,9 +1,13 @@
 // A typescript declaration file for the internal Limiter JSG class
 // see src/workerd/api/pyodide/pyodide.h (SimplePythonLimiter)
 
+import ArtifactBundler from './artifacts.js';
+
 interface Limiter {
   beginStartup: () => void;
-  finishStartup: () => void;
+  finishStartup: (
+    snapshotType: ArtifactBundler.SnapshotType | undefined
+  ) => void;
 }
 
 declare const limiter: Limiter;

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -448,7 +448,7 @@ class SimplePythonLimiter: public jsg::Object {
     }
   }
 
-  void finishStartup() {
+  void finishStartup(kj::Maybe<kj::String> snapshotType) {
     KJ_IF_SOME(cb, getTimeCb) {
       JSG_REQUIRE(startTime != kj::none, TypeError, "Need to call `beginStartup` first.");
       auto endTime = cb();
@@ -456,7 +456,7 @@ class SimplePythonLimiter: public jsg::Object {
       auto diffMs = diff / kj::MILLISECONDS;
 
       JSG_REQUIRE(diffMs <= startupLimitMs, TypeError, "Python Worker startup exceeded CPU limit ",
-          diffMs, "<=", startupLimitMs);
+          diffMs, "<=", startupLimitMs, " with snapshot ", snapshotType.orDefault(kj::str("none")));
     }
   }
 


### PR DESCRIPTION
This will help us ensure that the right snapshot was being used during startup and debug issues with startup limits.