### PR TITLE
Retrieve experimental compat flags in Python runtime differently.

### DIFF
--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -40,30 +40,16 @@ export const TRANSITIVE_REQUIREMENTS =
 // Entrypoints
 export const MAIN_MODULE_NAME = MetadataReader.getMainModule();
 
-export interface CompatibilityFlags {
-  python_workflows?: boolean;
-  python_no_global_handlers?: boolean;
-  python_workers_force_new_vendor_path?: boolean;
-  python_dedicated_snapshot?: boolean;
-}
-
-export interface CloudflareGlobal {
-  Cloudflare?: {
-    compatibilityFlags?: CompatibilityFlags;
-  };
-}
-
-// WARNING: unless experimental mode is enabled this will not include experimental flags.
-// So even if you enable an experimental flag in a test, it may not show up here.
-// The code responsible for populating this is Cloudflare::getCompatibilityFlags in global-scope.c++.
-//
-// If you're looking to test experimental flags here, then enable the flag and experimental mode.
-export const compatibilityFlags: CompatibilityFlags =
-  (globalThis as CloudflareGlobal)?.Cloudflare?.compatibilityFlags ?? {};
-export const workflowsEnabled: boolean = !!compatibilityFlags.python_workflows;
-export const legacyGlobalHandlers: boolean =
-  !compatibilityFlags.python_no_global_handlers;
-export const legacyVendorPath: boolean =
-  !compatibilityFlags.python_workers_force_new_vendor_path;
-export const IS_DEDICATED_SNAPSHOT_ENABLED =
-  compatibilityFlags.python_dedicated_snapshot;
+export type CompatibilityFlags = MetadataReader.CompatibilityFlags;
+export const COMPATIBILITY_FLAGS: MetadataReader.CompatibilityFlags =
+  MetadataReader.getCompatibilityFlags();
+export const WORKFLOWS_ENABLED: boolean =
+  COMPATIBILITY_FLAGS.python_workflows ?? false;
+export const LEGACY_GLOBAL_HANDLERS: boolean = !(
+  COMPATIBILITY_FLAGS.python_no_global_handlers ?? false
+);
+export const LEGACY_VENDOR_PATH: boolean = !(
+  COMPATIBILITY_FLAGS.python_workers_force_new_vendor_path ?? false
+);
+export const IS_DEDICATED_SNAPSHOT_ENABLED: boolean =
+  COMPATIBILITY_FLAGS.python_dedicated_snapshot ?? false;

--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -17,7 +17,7 @@ import {
   getRandomValues,
   entropyBeforeRequest,
 } from 'pyodide-internal:topLevelEntropy/lib';
-import { legacyVendorPath } from 'pyodide-internal:metadata';
+import { LEGACY_VENDOR_PATH } from 'pyodide-internal:metadata';
 import type { PyodideEntrypointHelper } from 'pyodide:python-entrypoint-helper';
 
 /**
@@ -71,7 +71,7 @@ function setupPythonSearchPath(pyodide: Pyodide): void {
       import sys
       from pathlib import Path
 
-      LEGACY_VENDOR_PATH = "${legacyVendorPath}" == "true"
+      LEGACY_VENDOR_PATH = "${LEGACY_VENDOR_PATH}" == "true"
       VENDOR_PATH = "/session/metadata/vendor"
       PYTHON_MODULES_PATH = "/session/metadata/python_modules"
 

--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -12,7 +12,7 @@ import {
   IS_CREATING_SNAPSHOT,
   IS_EW_VALIDATING,
   IS_DEDICATED_SNAPSHOT_ENABLED,
-  compatibilityFlags,
+  COMPATIBILITY_FLAGS,
   type CompatibilityFlags,
 } from 'pyodide-internal:metadata';
 import {
@@ -530,7 +530,7 @@ function makeLinearMemorySnapshot(
   const settings: SnapshotSettings = {
     baselineSnapshot: IS_CREATING_BASELINE_SNAPSHOT,
     snapshotType,
-    compatFlags: compatibilityFlags,
+    compatFlags: COMPATIBILITY_FLAGS,
   };
   return encodeSnapshot(Module.HEAP8, {
     version: 1,

--- a/src/pyodide/types/runtime-generated/metadata.d.ts
+++ b/src/pyodide/types/runtime-generated/metadata.d.ts
@@ -1,4 +1,11 @@
 declare namespace MetadataReader {
+  export interface CompatibilityFlags {
+    python_workflows?: boolean;
+    python_no_global_handlers?: boolean;
+    python_workers_force_new_vendor_path?: boolean;
+    python_dedicated_snapshot?: boolean;
+  }
+
   const isWorkerd: () => boolean;
   const isTracing: () => boolean;
   const shouldSnapshotToDisk: () => boolean;
@@ -20,6 +27,7 @@ declare namespace MetadataReader {
   const getPackagesLock: () => string;
   const read: (index: number, position: number, buffer: Uint8Array) => number;
   const getTransitiveRequirements: () => Set<string>;
+  const getCompatibilityFlags: () => CompatibilityFlags;
   const constructor: {
     getBaselineSnapshotImports(): string[];
   };

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -231,6 +231,13 @@ class PyodideMetadataReader: public jsg::Object {
 
   static kj::Array<kj::StringPtr> getBaselineSnapshotImports();
 
+  // Similar to Cloudflare::::getCompatibilityFlags in global-scope.c++, but the key difference is
+  // that it returns experimental flags even if `experimental` is not enabled. This avoids a gotcha
+  // where an experimental compat flag is enabled in our C++ code, but not in our JS code.
+  //
+  // This is only for use by our Python runtime.
+  jsg::JsObject getCompatibilityFlags(jsg::Lock& js);
+
   JSG_RESOURCE_TYPE(PyodideMetadataReader) {
     JSG_METHOD(isWorkerd);
     JSG_METHOD(isTracing);
@@ -250,6 +257,7 @@ class PyodideMetadataReader: public jsg::Object {
     JSG_METHOD(getPackagesLock);
     JSG_METHOD(isCreatingBaselineSnapshot);
     JSG_METHOD(getTransitiveRequirements);
+    JSG_METHOD(getCompatibilityFlags);
     JSG_STATIC_METHOD(getBaselineSnapshotImports);
   }
 


### PR DESCRIPTION
We've ran into the "experimental" gotcha by using the global compatibilityFlags field, so this introduces a custom API for the Python runtime which returns all compat flags even if they're experimental.