### PR TITLE
Buffer tail worker events before onset event.

### DIFF
--- a/src/workerd/api/tail-worker-test-receiver.js
+++ b/src/workerd/api/tail-worker-test-receiver.js
@@ -32,7 +32,7 @@ export const test = {
 
     // The shared tail worker we configured only produces onset and outcome events, so every trace is identical here.
     // Number of traces based on how often main tail worker is invoked from previous tests
-    let numTraces = 26;
+    let numTraces = 27;
     let basicTrace =
       '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"trace","traces":[]}}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}';
     assert.deepStrictEqual(

--- a/src/workerd/api/tail-worker-test.js
+++ b/src/workerd/api/tail-worker-test.js
@@ -121,8 +121,9 @@ export const test = {
 
       // tail-worker-test-jsrpc: Regression test for EW-9282 (missing onset event with
       // JsRpcSessionCustomEventImpl). This is derived from tests/js-rpc-test.js.
-      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"custom"}}{"type":"spanOpen","name":"jsRpcSession","spanId":"0000000000000001"}{"type":"spanClose","outcome":"ok"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"custom"}}{"type":"spanOpen","name":"durable_object_subrequest","spanId":"0000000000000002"}{"type":"spanClose","outcome":"ok"}{"type":"spanOpen","name":"jsRpcSession","spanId":"0000000000000001"}{"type":"spanClose","outcome":"ok"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
       '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc","methodName":"nonFunctionProperty"}}{"type":"log","level":"log","message":["bar"]}{"type":"log","level":"log","message":["foo"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"durableObject","spanId":"0000000000000000","entrypoint":"MyActor","scriptTags":[],"info":{"type":"jsrpc","methodName":"functionProperty"}}{"type":"log","level":"log","message":["baz"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
     ];
 
     assert.deepStrictEqual(response, expected);

--- a/src/workerd/api/tail-worker-test.wd-test
+++ b/src/workerd/api/tail-worker-test.wd-test
@@ -106,7 +106,12 @@ const jsRpcWorker :Workerd.Worker = (
 
   bindings = [
     (name = "MyService", service = (name = "js-rpc-test", entrypoint = "MyService")),
+    (name = "MyActor", durableObjectNamespace = "MyActor"),
   ],
+  durableObjectNamespaces = [
+    (className = "MyActor", uniqueKey = "foo"),
+  ],
+  durableObjectStorage = (inMemory = void),
 
   streamingTails = ["log"],
 );

--- a/src/workerd/io/tracer.h
+++ b/src/workerd/io/tracer.h
@@ -33,9 +33,18 @@ class TailStreamWriter final: public kj::Refcounted {
     uint32_t sequence = 0;
     State(Reporter reporter): reporter(kj::mv(reporter)) {}
   };
+
+  TailEvent createTailEvent(const InvocationSpanContext& context,
+      TailEvent::Event&& event,
+      kj::Date timestamp,
+      uint32_t& sequence);
+
   kj::Maybe<State> state;
   bool onsetSeen = false;
   bool outcomeSeen = false;
+  // Events received before onset are buffered here and flushed when onset arrives.
+  // This ensures onset is always the first event sent to streaming tail workers.
+  kj::Vector<TailEvent> bufferedEvents;
 };
 }  // namespace tracing
 


### PR DESCRIPTION
Streaming tail workers require onset event to be reported first. This change buffers events received before onset and flushes them when onset arrives.