### PR TITLE
Add the Wrangler e2e test that checks Node.js stuff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,8 +210,13 @@ jobs:
           EOF
           pnpm add /tmp/test-types -w
 
-      - name: Run Wrangler, Miniflare, Vitest, Vite tests
+      - name: Run Wrangler, Miniflare, Vitest, Vite unit tests
         run: pnpm test:ci --concurrency 1 --filter miniflare --filter wrangler --filter @cloudflare/vite-plugin --filter="./fixtures/vitest-pool-workers-examples"
+        env:
+          MINIFLARE_WORKERD_PATH: /tmp/workerd
+
+      - name: Run Wrangler Node.js e2e tests
+        run: pnpm test:e2e --filter wrangler -- unenv-preset
         env:
           MINIFLARE_WORKERD_PATH: /tmp/workerd
 


### PR DESCRIPTION
This test gives us some coverage over changes to the nodejs_compat parts of workerd.

Although an e2e test it doesn't take long to run and is not flakey so I think it is worth adding to the workerd PR checks.