### PR TITLE
Reproduction of request cancellation in workerd

### DIFF
--- a/.github/workflows/sample-test.yml
+++ b/.github/workflows/sample-test.yml
@@ -1,0 +1,92 @@
+name: Sample Tests
+
+on:
+  push:
+    branches: ["edmundhung/request-cancellation-sample"]
+  # workflow_dispatch:
+  #   inputs:
+  #     directory:
+  #       description: "Directory of the sample"
+  #       required: true
+  #     server-args:
+  #       description: "Arguments to pass to the serve command"
+  #       required: false
+  #     test-command:
+  #       description: "Command to run to test the server (default: curl http://localhost:8080)"
+  #       required: false
+  #       default: "curl http://localhost:$PORT"
+  #     port:
+  #       type: number
+  #       description: "Port the server will listen on (default: 8080)"
+  #       required: false
+  #       default: 8080
+
+permissions:
+  # Read repo
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          [
+            { name: linux, arch: X64, image: ubuntu-22.04 },
+            { name: linux-arm, arch: ARM64, image: ubuntu-22.04-arm },
+            { name: macOS, arch: ARM64, image: macos-15 },
+            { name: windows, arch: X64, image: windows-2025 },
+          ]
+    name: Sample tests - request-cancellation (${{ matrix.os.name }}, ${{ matrix.os.image}})
+    runs-on: ${{ matrix.os.image }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: "pnpm"
+
+      - name: Start workerd server
+        shell: bash
+        run: |
+          pnpm dlx workerd serve samples/request-cancellation/config.capnp > /tmp/workerd.log 2>&1 &
+          echo $! > /tmp/workerd.pid
+          sleep 5
+
+      - name: Run test command
+        shell: bash
+        run: |
+          # Trigger the request cancellation by timing out
+          curl --max-time 2 http://localhost:8080 || true
+          # Give the server a moment to log the abort message
+          sleep 1
+
+      - name: Check server logs
+        shell: bash
+        run: |
+          echo "=== Server logs ==="
+          cat /tmp/workerd.log
+          echo "=================="
+
+          if grep -q "The request was aborted!" /tmp/workerd.log; then
+            echo "✓ Server correctly detected request cancellation"
+          else
+            echo "✗ Server did not log request cancellation"
+            exit 1
+          fi
+
+      - name: Stop workerd server
+        if: always()
+        shell: bash
+        run: |
+          if [ -f /tmp/workerd.pid ]; then
+            kill $(cat /tmp/workerd.pid) 2>/dev/null || true
+          fi

--- a/samples/request-cancellation/README.md
+++ b/samples/request-cancellation/README.md
@@ -1,0 +1,28 @@
+# Request Cancellation Example
+
+To run the example on http://localhost:8080
+
+```sh
+$ ./workerd serve config.capnp
+```
+
+To run using bazel
+
+```sh
+$ bazel run //src/workerd/server:workerd -- serve ~/cloudflare/workerd/samples/request-cancellation/config.capnp
+```
+
+To create a standalone binary that can be run:
+
+```sh
+$ ./workerd compile config.capnp > request-cancellation
+
+$ ./request-cancellation
+```
+
+To test:
+
+```sh
+% curl --max-time 1 http://localhost:8080
+Request was aborted
+```

--- a/samples/request-cancellation/config.capnp
+++ b/samples/request-cancellation/config.capnp
@@ -1,0 +1,35 @@
+# Imports the base schema for workerd configuration files.
+
+# Refer to the comments in /src/workerd/server/workerd.capnp for more details.
+
+using Workerd = import "/workerd/workerd.capnp";
+
+# A constant of type Workerd.Config defines the top-level configuration for an
+# instance of the workerd runtime. A single config file can contain multiple
+# Workerd.Config definitions and must have at least one.
+const requestCancellationExample :Workerd.Config = (
+
+  # Every workerd instance consists of a set of named services. A worker, for instance,
+  # is a type of service. Other types of services can include external servers, the
+  # ability to talk to a network, or accessing a disk directory. Here we create a single
+  # worker service. The configuration details for the worker are defined below.
+  services = [ (name = "main", worker = .requestCancellation) ],
+
+  # Each configuration defines the sockets on which the server will listen.
+  # Here, we create a single socket that will listen on localhost port 8080, and will
+  # dispatch to the "main" service that we defined above.
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ]
+);
+
+# The definition of the actual worker exposed using the "main" service.
+# In this example the worker is implemented as a single simple script (see worker.js).
+# The compatibilityDate is required. For more details on compatibility dates see:
+#   https://developers.cloudflare.com/workers/platform/compatibility-dates/
+
+const requestCancellation :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js")
+  ],
+  compatibilityDate = "2025-05-23",
+  compatibilityFlags = ["enable_request_signal"]
+);

--- a/samples/request-cancellation/worker.js
+++ b/samples/request-cancellation/worker.js
@@ -3,7 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 export default {
-  async fetch(request) {
+  async fetch(request, env, ctx) {
     request.signal.addEventListener('abort', () => {
       console.log('Request was aborted');
     });
@@ -11,6 +11,7 @@ export default {
     console.log('Starting long-running task');
     // Simulate a long-running task so we can test aborting
     await new Promise((resolve) => setTimeout(resolve, 3000));
+    ctx.waitUntil(new Promise((resolve) => setTimeout(resolve, 4000)));
 
     return new Response("Request was not aborted");
   }

--- a/samples/request-cancellation/worker.js
+++ b/samples/request-cancellation/worker.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+export default {
+  async fetch(request) {
+    request.signal.addEventListener('abort', () => {
+      console.log('Request was aborted');
+    });
+
+    console.log('Starting long-running task');
+    // Simulate a long-running task so we can test aborting
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    return new Response("Request was not aborted");
+  }
+};


### PR DESCRIPTION
I have been testing [request cancellation support](https://developers.cloudflare.com/changelog/2025-05-22-handle-request-cancellation/) in Wrangler and noticed that Workerd does not log the `Request was aborted` message either. Is that expected?

The same worker does log the message in production.