### PR TITLE
Further refine capnp::SchemaLoader ownership

### DIFF
--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -279,6 +279,8 @@ class Worker::Script: public kj::AtomicRefcounted {
 
   void installVirtualFileSystemOnContext(v8::Local<v8::Context> context) const;
 
+  const capnp::SchemaLoader& getSchemaLoader() const;
+
   struct CompiledGlobal {
     jsg::V8Ref<v8::String> name;
     jsg::V8Ref<v8::Value> value;
@@ -593,6 +595,7 @@ class Worker::Api {
     // If the worker is using the new module registry system, this is the registry to
     // install on the newly created context. If null, the old system is assumed.
     kj::Maybe<const workerd::jsg::modules::ModuleRegistry&> newModuleRegistry;
+    kj::Maybe<const capnp::SchemaLoader&> schemaLoader;
   };
 
   // Create the context (global scope) object.

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -534,16 +534,6 @@ KJ_TEST("Memory Allocation Error Propagation") {
   });
 }
 
-KJ_TEST("JS Lock has a capnp::SchemaLoader") {
-  IsolateUuidIsolate isolate(v8System, kj::heap<IsolateObserver>());
-  isolate.runInLockScope([&](IsolateUuidIsolate::Lock& lock) {
-    JSG_WITHIN_CONTEXT_SCOPE(
-        lock, lock.newContext<IsolateUuidContext>().getHandle(lock), [&](jsg::Lock& js) {
-      KJ_ASSERT(js.getCapnpSchemaLoader<IsolateUuidContext>().getAllLoaded().size() == 0);
-    });
-  });
-}
-
 }  // namespace
 
 }  // namespace workerd::jsg::test

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -578,16 +578,11 @@ std::unique_ptr<v8::BackingStore> Lock::allocBackingStore(size_t size, AllocOpti
 }
 
 const capnp::SchemaLoader& ContextGlobal::getSchemaLoader() {
-  KJ_IF_SOME(loader, maybeSchemaLoader) {
-    return *loader;
-  }
-  auto loader = kj::heap<capnp::SchemaLoader>();
-  auto& ret = *loader;
-  setSchemaLoader(kj::mv(loader));
-  return ret;
+  return KJ_ASSERT_NONNULL(schemaLoader);
 }
 
-void ContextGlobal::setSchemaLoader(kj::Own<const capnp::SchemaLoader> schemaLoader) {
-  maybeSchemaLoader = kj::mv(schemaLoader);
+void ContextGlobal::setSchemaLoader(const capnp::SchemaLoader& schemaLoader) {
+  this->schemaLoader = schemaLoader;
 }
+
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1736,12 +1736,12 @@ class ContextGlobal {
   // object is alive. This may be the legacy or new module registry, depending which one is
   // in use. We don't care about the actual type here, just that it is kept alive.
   kj::Own<void> moduleRegistryBackingOwner;
-  kj::Maybe<kj::Own<const capnp::SchemaLoader>> maybeSchemaLoader;
+  kj::Maybe<const capnp::SchemaLoader&> schemaLoader;
 
   void setModuleRegistryBackingOwner(kj::Own<void> registry) {
     moduleRegistryBackingOwner = kj::mv(registry);
   }
-  void setSchemaLoader(kj::Own<const capnp::SchemaLoader> schemaLoader);
+  void setSchemaLoader(const capnp::SchemaLoader& schemaLoader);
 
   template <typename, typename>
   friend class ResourceWrapper;

--- a/src/workerd/jsg/modules-new-test.c++
+++ b/src/workerd/jsg/modules-new-test.c++
@@ -1894,27 +1894,5 @@ KJ_TEST("Using a deferred eval callback works") {
   });
 }
 
-KJ_TEST("New module registry has a schema loader") {
-  ResolveObserver resolveObserver;
-  CompilationObserver compilationObserver;
-  ModuleBundle::BundleBuilder builder(BASE);
-
-  auto foo = kj::str("export default 1;");
-  builder.addEsmModule("foo", foo);
-
-  bool called = false;
-  auto registry = ModuleRegistry::Builder(resolveObserver, BASE)
-                      .add(builder.finish())
-                      .setEvalCallback([&called](Lock& js, const Module& module, auto v8Module,
-                                           const auto& observer) {
-    called = true;
-    return js.resolvedPromise<Value>(js.v8Ref<v8::Value>(js.num(123)));
-  }).finish();
-
-  PREAMBLE([&](Lock& js) {
-    KJ_ASSERT(js.getCapnpSchemaLoader<TestContext>().getAllLoaded().size() == 0);
-  });
-}
-
 }  // namespace
 }  // namespace workerd::jsg::test

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -465,6 +465,7 @@ jsg::JsContext<api::ServiceWorkerGlobalScope> WorkerdApi::newContext(
     jsg::Lock& lock, Worker::Api::NewContextOptions options) const {
   jsg::NewContextOptions opts{
     .newModuleRegistry = options.newModuleRegistry,
+    .schemaLoader = options.schemaLoader,
     .enableWeakRef = getFeatureFlags().getJsWeakRef(),
   };
   return kj::downcast<JsgWorkerdIsolate::Lock>(lock).newContext<api::ServiceWorkerGlobalScope>(


### PR DESCRIPTION
In the original work here I missed that the SchemaLoader is needed during the construction of Worker::Script when using the older service worker syntax. This change moves the ownership of the SchemaLoader to the Worker::Script::Impl so that it is available during construction, with the ContextGlobal having a const reference to it.

The next step will be to move the capnp modules implementation out from the internal project into workerd.