### PR TITLE
Add a debug module for workerd testing

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -874,3 +874,11 @@ wd_test(
         "tests/rpc-error-test.rpc.js",
     ],
 )
+
+wd_test(
+    src = "tests/debug-test.wd-test",
+    args = ["--experimental"],
+    data = [
+        "tests/debug-test.js",
+    ],
+)

--- a/src/workerd/api/debug.c++
+++ b/src/workerd/api/debug.c++
@@ -1,0 +1,18 @@
+#include "debug.h"
+
+#include <workerd/util/autogate.h>
+
+namespace workerd::api {
+
+bool InternalDebugModule::autogateIsEnabled(jsg::Lock&, kj::String name) {
+  const char* prefix = "workerd-autogate-";
+
+  for (auto i: kj::zeroTo(static_cast<size_t>(util::AutogateKey::NumOfKeys))) {
+    auto key = static_cast<util::AutogateKey>(i);
+    if (util::Autogate::isEnabled(key) && name == kj::str(prefix, key)) {
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace workerd::api

--- a/src/workerd/api/debug.h
+++ b/src/workerd/api/debug.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <workerd/jsg/jsg.h>
+
+namespace workerd::api {
+
+// A special purpose module used for internal debugging and testing only.
+// **This module must not be available in production deployments**
+class InternalDebugModule: public jsg::Object {
+ public:
+  InternalDebugModule() = default;
+
+  bool autogateIsEnabled(jsg::Lock&, kj::String name);
+
+  JSG_RESOURCE_TYPE(InternalDebugModule) {
+    JSG_METHOD(autogateIsEnabled);
+  }
+};
+}  // namespace workerd::api
+#define EW_DEBUG_ISOLATE_TYPES workerd::api::InternalDebugModule

--- a/src/workerd/api/modules.h
+++ b/src/workerd/api/modules.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <workerd/api/base64.h>
+#include <workerd/api/debug.h>
 #include <workerd/api/filesystem.h>
 #include <workerd/api/node/node.h>
 #include <workerd/api/pyodide/pyodide.h>
@@ -48,6 +49,14 @@ void registerModules(Registry& registry, auto featureFlags) {
   if (featureFlags.getUnsafeModule()) {
     registerUnsafeModule(registry);
   }
+
+  // Debug module is only to be made available in non-production deployments.
+  // It is enabled with an experimental compat flag that must be explicitly set.
+  if (featureFlags.getEnableWorkerdDebugModule()) {
+    registry.template addBuiltinModule<InternalDebugModule>(
+        "workerd:debug", workerd::jsg::ModuleRegistry::Type::BUILTIN);
+  }
+
   registerSocketsModule(registry, featureFlags);
   registerBase64Module(registry, featureFlags);
   registry.addBuiltinBundle(CLOUDFLARE_BUNDLE);

--- a/src/workerd/api/tests/debug-test.js
+++ b/src/workerd/api/tests/debug-test.js
@@ -1,0 +1,9 @@
+import { default as Debug } from 'workerd:debug';
+import { strictEqual } from 'node:assert';
+
+export const autogateIsEnabledTest = {
+  // Test to ensure that async context is propagated into custom thenables.
+  async test() {
+    strictEqual(Debug.autogateIsEnabled('workerd-autogate-test-workerd'), true);
+  },
+};

--- a/src/workerd/api/tests/debug-test.wd-test
+++ b/src/workerd/api/tests/debug-test.wd-test
@@ -1,0 +1,16 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  autogates = ["workerd-autogate-test-workerd"],
+  services = [
+    ( name = "debug-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "debug-test.js")
+        ],
+        compatibilityDate = "2025-09-01",
+        compatibilityFlags = ["nodejs_compat", "enable_workerd_debug_module"]
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1163,4 +1163,11 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
     $experimental;
   # Enables the Node.js non-functional stub trace_events module. It is required to use this
   # flag with nodejs_compat (or nodejs_compat_v2).
+
+  enableWorkerdDebugModule @136 :Bool
+    $compatEnableFlag("enable_workerd_debug_module")
+    $experimental;
+  # Enables the workerd debug module.
+  # **NEVER ENABLE THIS FLAG IN PRODUCTION**
+  # **NEVER SET A DEFAULT ON DATE**
 }

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -12,6 +12,7 @@
 #include <workerd/api/commonjs.h>
 #include <workerd/api/container.h>
 #include <workerd/api/crypto/impl.h>
+#include <workerd/api/debug.h>
 #include <workerd/api/encoding.h>
 #include <workerd/api/events.h>
 #include <workerd/api/eventsource.h>
@@ -101,6 +102,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
     EW_CONTAINER_ISOLATE_TYPES,
     EW_CJS_ISOLATE_TYPES,
     EW_CRYPTO_ISOLATE_TYPES,
+    EW_DEBUG_ISOLATE_TYPES,
     EW_ENCODING_ISOLATE_TYPES,
     EW_EVENTS_ISOLATE_TYPES,
     EW_FORMDATA_ISOLATE_TYPES,


### PR DESCRIPTION
Scratching an itch to make it easier to provide debugging utilities in workerd for testing. This echoes the debug binding in the internal repo but is made available via an import so that top-level scope can use it easily.