### PR TITLE
chore: move easy http_archive calls from WORKSPACE

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,3 +38,5 @@ git_override(
 # accepted by BoringSSL. Update with caution and only after confirming this is compatible with the
 # downstream build.
 bazel_dep(name = "boringssl", version = "0.20250818.0", repo_name = "ssl")
+
+include("//build/deps:deps.MODULE.bazel")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,28 +15,10 @@ deps_gen()
 # ========================================================================================
 # Bazel basics
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 NODE_VERSION = "22.18.0"
 
 # ========================================================================================
 # Simple dependencies
-
-http_archive(
-    name = "sqlite3",
-    build_file = "//:build/BUILD.sqlite3",
-    patch_args = ["-p1"],
-    patches = [
-        "//:patches/sqlite/0001-row-counts-plain.patch",
-        "//:patches/sqlite/0002-macOS-missing-PATH-fix.patch",
-        "//:patches/sqlite/0003-sqlite-complete-early-exit.patch",
-        "//:patches/sqlite/0004-invalid-wal-on-rollback-fix.patch",
-    ],
-    sha256 = "f59c349bedb470203586a6b6d10adb35f2afefa49f91e55a672a36a09a8fedf7",
-    strip_prefix = "sqlite-src-3470000",
-    url = "https://sqlite.org/2024/sqlite-src-3470000.zip",
-)
 
 load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
 
@@ -46,70 +28,6 @@ py_repositories()
 # based on our dependencies – just use cquery instead.
 # load("@com_google_benchmark//:bazel/benchmark_deps.bzl", "benchmark_deps")
 # benchmark_deps()
-
-http_archive(
-    name = "nbytes",
-    build_file = "//:build/BUILD.nbytes",
-    sha256 = "34be48071c86add2f8d14fd4a238c47230965fd743a51b8a1dd0b2f0210f0171",
-    strip_prefix = "nbytes-0.1.1",
-    url = "https://github.com/nodejs/nbytes/archive/refs/tags/v0.1.1.tar.gz",
-)
-
-http_archive(
-    name = "ncrypto",
-    sha256 = "b438cf71b1c24036e388f191a348cdc76aca75310eabca0fef5d81d5032a5d20",
-    strip_prefix = "ncrypto-1.0.1",
-    type = "tgz",
-    url = "https://github.com/nodejs/ncrypto/archive/refs/tags/1.0.1.tar.gz",
-)
-
-# ========================================================================================
-# tcmalloc
-http_archive(
-    name = "com_google_tcmalloc",
-    integrity = "sha256-29cSZUwbEyiW8Y7FneaAzNNYLHeBmAPqBuIciHeE/u0=",
-    repo_mapping = {"@com_google_absl": "@abseil-cpp"},
-    strip_prefix = "google-tcmalloc-cf3dc2d",
-    type = "tgz",
-    url = "https://github.com/google/tcmalloc/tarball/cf3dc2d98bd64cb43f4f98db0acaf5028a7b81eb",
-)
-
-git_repository(
-    name = "dragonbox",
-    build_file_content = """cc_library(
-            name = "dragonbox",
-            hdrs = glob(["include/dragonbox/*.h"]),
-            visibility = ["//visibility:public"],
-            include_prefix = "third_party/dragonbox/src",
-        )""",
-    commit = "6c7c925b571d54486b9ffae8d9d18a822801cbda",
-    remote = "https://github.com/jk-jeon/dragonbox.git",
-)
-
-git_repository(
-    name = "fast_float",
-    build_file_content = """cc_library(
-            name = "fast_float",
-            hdrs = glob(["include/fast_float/*.h"]),
-            visibility = ["//visibility:public"],
-            include_prefix = "third_party/fast_float/src",
-        )""",
-    commit = "cb1d42aaa1e14b09e1452cfdef373d051b8c02a4",
-    remote = "https://github.com/fastfloat/fast_float.git",
-)
-
-git_repository(
-    name = "fp16",
-    build_file_content = "exports_files(glob([\"**\"]))",
-    commit = "b3720617faf1a4581ed7e6787cc51722ec7751f0",
-    remote = "https://github.com/Maratyszcza/FP16.git",
-)
-
-git_repository(
-    name = "highway",
-    commit = "00fe003dac355b979f36157f9407c7c46448958e",
-    remote = "https://github.com/google/highway.git",
-)
 
 # ========================================================================================
 # Rust bootstrap

--- a/build/deps/deps.MODULE.bazel
+++ b/build/deps/deps.MODULE.bazel
@@ -1,0 +1,81 @@
+# This file is included from the root MODULE.bazel
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "sqlite3",
+    build_file = "//:build/BUILD.sqlite3",
+    patch_args = ["-p1"],
+    patches = [
+        "//:patches/sqlite/0001-row-counts-plain.patch",
+        "//:patches/sqlite/0002-macOS-missing-PATH-fix.patch",
+        "//:patches/sqlite/0003-sqlite-complete-early-exit.patch",
+        "//:patches/sqlite/0004-invalid-wal-on-rollback-fix.patch",
+    ],
+    sha256 = "f59c349bedb470203586a6b6d10adb35f2afefa49f91e55a672a36a09a8fedf7",
+    strip_prefix = "sqlite-src-3470000",
+    url = "https://sqlite.org/2024/sqlite-src-3470000.zip",
+)
+
+
+http_archive(
+    name = "nbytes",
+    build_file = "//:build/BUILD.nbytes",
+    sha256 = "34be48071c86add2f8d14fd4a238c47230965fd743a51b8a1dd0b2f0210f0171",
+    strip_prefix = "nbytes-0.1.1",
+    url = "https://github.com/nodejs/nbytes/archive/refs/tags/v0.1.1.tar.gz",
+)
+
+http_archive(
+    name = "ncrypto",
+    sha256 = "b438cf71b1c24036e388f191a348cdc76aca75310eabca0fef5d81d5032a5d20",
+    strip_prefix = "ncrypto-1.0.1",
+    type = "tgz",
+    url = "https://github.com/nodejs/ncrypto/archive/refs/tags/1.0.1.tar.gz",
+)
+
+# ========================================================================================
+# tcmalloc
+http_archive(
+    name = "com_google_tcmalloc",
+    integrity = "sha256-29cSZUwbEyiW8Y7FneaAzNNYLHeBmAPqBuIciHeE/u0=",
+    # repo_mapping = {"@com_google_absl": "@abseil-cpp"},
+    strip_prefix = "google-tcmalloc-cf3dc2d",
+    type = "tgz",
+    url = "https://github.com/google/tcmalloc/tarball/cf3dc2d98bd64cb43f4f98db0acaf5028a7b81eb",
+)
+
+http_archive(
+    name = "dragonbox",
+    build_file_content = """cc_library(
+            name = "dragonbox",
+            hdrs = glob(["include/dragonbox/*.h"]),
+            visibility = ["//visibility:public"],
+            include_prefix = "third_party/dragonbox/src",
+        )""",
+    integrity = "sha256-LxBEjWZTVbQfWZ6GmseIA/gvE7Bwzn71rntczrihePM=",
+    strip_prefix = "dragonbox-6c7c925b571d54486b9ffae8d9d18a822801cbda",
+    url = "https://github.com/jk-jeon/dragonbox/archive/6c7c925b571d54486b9ffae8d9d18a822801cbda.zip",
+)
+
+http_archive(
+    name = "fast_float",
+    build_file_content = """cc_library(
+            name = "fast_float",
+            hdrs = glob(["include/fast_float/*.h"]),
+            visibility = ["//visibility:public"],
+            include_prefix = "third_party/fast_float/src",
+        )""",
+    integrity = "sha256-LYRUr+pAEPbXBmAm6ejUg7CJ552QyUCtuPX/pYBxbik=",
+    strip_prefix = "fast_float-cb1d42aaa1e14b09e1452cfdef373d051b8c02a4",
+    url = "https://github.com/fastfloat/fast_float/archive/cb1d42aaa1e14b09e1452cfdef373d051b8c02a4.zip",
+)
+
+http_archive(
+    name = "fp16",
+    build_file_content = "exports_files(glob([\"**\"]))",
+    integrity = "sha256-CuGkuLXdiVJ74rDxbmOMuZ2N2okbXDatsOLfJBQAK5Y=",
+    strip_prefix = "FP16-b3720617faf1a4581ed7e6787cc51722ec7751f0",
+    url = "https://github.com/Maratyszcza/FP16/archive/b3720617faf1a4581ed7e6787cc51722ec7751f0.zip",
+)
+
+bazel_dep(name = "highway", version = "1.3.0")


### PR DESCRIPTION
Note, I also updated the git_repository rules, which cannot participate in the repository cache. Should make CI faster by improving caches.