### PR TITLE
Begin consolidating duplicated legacy module registry init code

### DIFF
--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -320,11 +320,7 @@ class WorkerdApi final: public Worker::Api {
   // Part of the original module registry API.
   static kj::Maybe<jsg::ModuleRegistry::ModuleInfo> tryCompileModule(jsg::Lock& js,
       config::Worker::Module::Reader conf,
-      jsg::CompilationObserver& observer,
-      CompatibilityFlags::Reader featureFlags);
-  static kj::Maybe<jsg::ModuleRegistry::ModuleInfo> tryCompileModule(jsg::Lock& js,
-      const Worker::Script::Module& module,
-      jsg::CompilationObserver& observer,
+      const jsg::CompilationObserver& observer,
       CompatibilityFlags::Reader featureFlags);
 
   // Convert a module definition from workerd config to a Worker::Script::Module (which may contain


### PR DESCRIPTION
There is a fair amount of duplicated code for module initialization between workerd and the internal repo. This starts the process of consolidating by moving a handful of utility methods over to worker-modules.h. A follow-up next step will be to update the internal code to use these from the shared location.

this builds on #5070 which must land first.