### PR TITLE
[build] Optimize all of V8 on CI to speed up tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -52,25 +52,18 @@ build --per_file_copt=external/simdutf@-Wno-unused-const-variable
 # TODO(cleanup): Causes warnings with LLVM20, fix and enable again
 build --copt=-Wno-nontrivial-memaccess
 
-# Increasing the optimization level of some portions of V8 significantly speeds up Python tests in
-# GitHub Actions. This is an optional performance hack intended for CI, although it might also be
-# useful for local development.
-build:v8-codegen-opt --per_file_copt=v8/src/api@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/base@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/builtins@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/codegen@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/common@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/compiler@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/execution@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/heap@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/objects@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/parsing@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/roots@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/runtime@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/snapshot@-O2
-build:v8-codegen-opt --per_file_copt=v8/src/wasm@-O2
+# Increasing the optimization level of V8 significantly speeds up Python tests in GitHub Actions.
+# This is an optional performance hack intended for CI, although it might also be useful for local
+# development.
+build:v8-codegen-opt --per_file_copt=v8/src@-O2
 # V8 is heavily using absl for hashing now, optimize it too.
 build:v8-codegen-opt --per_file_copt=external/abseil-cpp@-O2
+# zlib and tcmalloc (for Linux) are also CPU-intensive, optimize them too.
+build:v8-codegen-opt --per_file_copt=external/tcmalloc@-O2
+build:v8-codegen-opt --per_file_copt=external/zlib@-O2
+build:v8-codegen-opt-windows --per_file_copt=v8/src@/O2
+build:v8-codegen-opt-windows --per_file_copt=external/abseil-cpp@/O2
+build:v8-codegen-opt-windows --per_file_copt=external/zlib@/O2
 
 # In Google projects, exceptions are not used as a rule. Disabling them is more consistent with the
 # canonical V8 build and improves code size.
@@ -399,16 +392,11 @@ build:coverage --action_env=GCOV=llvm-profdata-19
 build:coverage --action_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
 build:coverage --copt=-DNDEBUG
 build:coverage --combined_report=lcov
-build:coverage --strategy=TestRunner=remote,sandboxed,local
-build:coverage --strategy=CoverageReport=sandboxed,local
 build:coverage --experimental_use_llvm_covmap
 build:coverage --experimental_generate_llvm_lcov
 build:coverage --experimental_fetch_all_coverage_outputs
 build:coverage --collect_code_coverage
 build:coverage --instrumentation_filter="^//,-//external"
-build:coverage --remote_download_minimal
-build:coverage --define=tcmalloc=gperftools
-build:coverage --test_timeout=120,120,120,120
 build:coverage --instrument_test_targets
 
 # This config is defined internally and enabled on many machines.

--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -17,7 +17,7 @@ build:ci --noexperimental_check_external_repository_files
 # so avoid doing so where we can. https://github.com/bazelbuild/bazel/commit/03246077f948f2790a83520e7dccc2625650e6df
 build:ci --nobuild_runfile_links
 # Rate limit progress updates for smaller logs, default is 0.2 which leads to very frequent updates.
-build:ci --show_progress_rate_limit=1
+build:ci --show_progress_rate_limit=3
 # Enable color output
 build:ci --color=yes
 # Indicate support for more terminal columns, 100 is the line length recommended by KJ style.
@@ -27,10 +27,12 @@ test:ci --test_output=errors
 build:ci --disk_cache=~/bazel-disk-cache
 
 # test CI jobs don't need any top-level artifacts and just verify things
-build:ci-test --remote_download_outputs=minimal
+build:ci-test --remote_download_minimal
 # Enable v8-codegen-opt for test so that python tests run in an acceptable time frame but not for
-# release builds – this sets -O2 and release should keep -O3.
+# release builds – this sets -O2 and release should keep -O3. For Windows, we can enable /O2
+# unconditionally, release already uses that and just adds "/clang:-O3" on top of it.
 build:ci-test --config=v8-codegen-opt
+build:ci-windows --config=v8-codegen-opt-windows
 
 # limit storage usage on ci
 # Exclude large benchmarking binaries created in debug and asan configurations to avoid


### PR DESCRIPTION
- Python test times are unacceptably high (again), let's optimize all of V8 to mitigate this.
- Drop superfluous parameters in coverage job
- Reduce CI log frequency to reduce excessive log size