### PR TITLE
Move python module metadata state creation to worker-modules.c++.

### DIFF
--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -7,6 +7,7 @@
 #include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/modules-new.h>
+#include <workerd/util/strong-bool.h>
 
 #include <pyodide/generated/pyodide_extra.capnp.h>
 #include <pyodide/pyodide_static.capnp.h>
@@ -22,6 +23,12 @@
 #include <kj/timer.h>
 
 namespace workerd::api::pyodide {
+
+WD_STRONG_BOOL(CreateBaselineSnapshot);
+WD_STRONG_BOOL(IsTracing);
+WD_STRONG_BOOL(IsValidating);
+WD_STRONG_BOOL(IsWorkerd);
+WD_STRONG_BOOL(SnapshotToDisk);
 
 const auto PYTHON_PACKAGES_URL =
     "https://storage.googleapis.com/cloudflare-edgeworker-python-packages/";
@@ -139,10 +146,10 @@ class PyodideMetadataReader: public jsg::Object {
         kj::String pyodideVersion,
         kj::String packagesVersion,
         kj::String packagesLock,
-        bool isWorkerd,
-        bool isTracing,
-        bool snapshotToDisk,
-        bool createBaselineSnapshot,
+        IsWorkerd isWorkerd,
+        IsTracing isTracing,
+        SnapshotToDisk snapshotToDisk,
+        CreateBaselineSnapshot createBaselineSnapshot,
         kj::Maybe<kj::Array<kj::byte>> memorySnapshot)
         : mainModule(kj::mv(mainModule)),
           moduleInfo(kj::mv(names), kj::mv(contents)),

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -135,6 +135,7 @@ wd_cc_library(
 
 wd_cc_library(
     name = "worker-modules",
+    srcs = ["worker-modules.c++"],
     hdrs = ["worker-modules.h"],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/workerd/io/worker-modules.c++
+++ b/src/workerd/io/worker-modules.c++
@@ -1,0 +1,108 @@
+#include "worker-modules.h"
+
+namespace workerd::modules::python {
+kj::Own<api::pyodide::PyodideMetadataReader::State> createPyodideMetadataState(
+    const Worker::Script::ModulesSource& source,
+    api::pyodide::IsWorkerd isWorkerd,
+    api::pyodide::IsTracing isTracing,
+    api::pyodide::SnapshotToDisk snapshotToDisk,
+    api::pyodide::CreateBaselineSnapshot createBaselineSnapshot,
+    PythonSnapshotRelease::Reader pythonRelease,
+    kj::Maybe<kj::Array<kj::byte>> maybeSnapshot,
+    CompatibilityFlags::Reader featureFlags) {
+  auto mainModule = kj::str(source.mainModule);
+  auto modules = source.modules.asPtr();
+  int numFiles = 0;
+  int numRequirements = 0;
+  for (auto& module: modules) {
+    KJ_SWITCH_ONEOF(module.content) {
+      KJ_CASE_ONEOF(content, Worker::Script::TextModule) {
+        numFiles++;
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::DataModule) {
+        numFiles++;
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::WasmModule) {
+        // Not exposed to Python.
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::JsonModule) {
+        numFiles++;
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::EsModule) {
+        // Not exposed to Python.
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::CommonJsModule) {
+        // Not exposed to Python.
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::PythonModule) {
+        numFiles++;
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::PythonRequirement) {
+        numRequirements++;
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::CapnpModule) {
+        // Not exposed to Python.
+      }
+    }
+  }
+
+  auto names = kj::heapArrayBuilder<kj::String>(numFiles);
+  auto contents = kj::heapArrayBuilder<kj::Array<kj::byte>>(numFiles);
+  auto requirements = kj::heapArrayBuilder<kj::String>(numRequirements);
+  for (auto& module: modules) {
+    KJ_SWITCH_ONEOF(module.content) {
+      KJ_CASE_ONEOF(content, Worker::Script::TextModule) {
+        names.add(kj::str(module.name));
+        contents.add(kj::heapArray(content.body.asBytes()));
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::DataModule) {
+        names.add(kj::str(module.name));
+        contents.add(kj::heapArray(content.body));
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::WasmModule) {
+        // Not exposed to Python.
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::JsonModule) {
+        names.add(kj::str(module.name));
+        contents.add(kj::heapArray(content.body.asBytes()));
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::EsModule) {
+        // Not exposed to Python.
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::CommonJsModule) {
+        // Not exposed to Python.
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::PythonModule) {
+        KJ_REQUIRE(module.name.endsWith(".py"));
+        names.add(kj::str(module.name));
+        contents.add(kj::heapArray(content.body.asBytes()));
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::PythonRequirement) {
+        requirements.add(kj::str(module.name));
+      }
+      KJ_CASE_ONEOF(content, Worker::Script::CapnpModule) {
+        // Not exposeud to Python.
+      }
+    }
+  }
+
+  auto lock = KJ_ASSERT_NONNULL(workerd::api::pyodide::getPyodideLock(pythonRelease),
+      kj::str("No lock file defined for Python packages release ", pythonRelease.getPackages()));
+
+  // clang-format off
+  return kj::heap<workerd::api::pyodide::PyodideMetadataReader::State>(
+      kj::mv(mainModule),
+      names.finish(),
+      contents.finish(),
+      requirements.finish(),
+      kj::str(pythonRelease.getPyodide()),
+      kj::str(pythonRelease.getPackages()),
+      kj::mv(lock),
+      isWorkerd,
+      isTracing,
+      snapshotToDisk,
+      createBaselineSnapshot,
+      kj::mv(maybeSnapshot));
+  // clang-format on
+}
+}  // namespace workerd::modules::python

--- a/src/workerd/io/worker-modules.h
+++ b/src/workerd/io/worker-modules.h
@@ -75,6 +75,21 @@ jsg::ModuleRegistry::ModuleInfo addCapnpModule(
 }
 }  // namespace modules::capnp
 
+// ===========================================================================================
+// Python module support
+
+namespace modules::python {
+kj::Own<api::pyodide::PyodideMetadataReader::State> createPyodideMetadataState(
+    const Worker::Script::ModulesSource& source,
+    api::pyodide::IsWorkerd isWorkerd,
+    api::pyodide::IsTracing isTracing,
+    api::pyodide::SnapshotToDisk snapshotToDisk,
+    api::pyodide::CreateBaselineSnapshot createBaselineSnapshot,
+    PythonSnapshotRelease::Reader pythonRelease,
+    kj::Maybe<kj::Array<kj::byte>> maybeSnapshot,
+    CompatibilityFlags::Reader featureFlags);
+}  // namespace modules::python
+
 // Creates an instance of the (new) ModuleRegistry. This method provides the
 // initialization logic that is agnostic to the Worker::Api implementation,
 // but accepts a callback parameter to handle the Worker::Api-specific details.


### PR DESCRIPTION
Allows reuse of the same state creation code in both workerd-api.c++ and the internal repo equivalent.

I'm working on consolidating all of the code that is used to initialize the module registry so that we can share as much as possible between workerd and the internal project to simplify maintenance and help make enabling the new module registry in the production environment easier.

This will be the first of a few PRS that will be moving the python-specific initialization code out to shared locations as much as possible.