### PR TITLE
chore(ci): don't print as many lines of passed tests

### DIFF
--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -23,7 +23,7 @@ build:ci --color=yes
 # Indicate support for more terminal columns, 100 is the line length recommended by KJ style.
 build:ci --terminal_columns=100
 
-test:ci --test_output=errors
+test:ci --test_output=errors --test_summary=terse
 build:ci --disk_cache=~/bazel-disk-cache
 
 # test CI jobs don't need any top-level artifacts and just verify things


### PR DESCRIPTION
The default test_summary ("short") prints a result for every test target that was executed.        In the workerd build this amounts to hundreds of lines of additional log output when testing a broad wildcard pattern like `//...`        `terse` means to print information only about unsuccessful tests that were run.