### PR TITLE
Some minor fixups with new module registry

### DIFF
--- a/src/workerd/api/modules.h
+++ b/src/workerd/api/modules.h
@@ -77,14 +77,14 @@ void registerBuiltinModules(jsg::modules::ModuleRegistry::Builder& builder, auto
 
   {
     jsg::modules::ModuleBundle::BuiltinBuilder builtinsBuilder(
-        jsg::modules::ModuleBundle::BuiltinBuilder::Type::BUILTIN_ONLY);
+        jsg::modules::ModuleBundle::BuiltinBuilder::Type::BUILTIN);
     jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(builtinsBuilder, CLOUDFLARE_BUNDLE);
     builder.add(builtinsBuilder.finish());
   }
 
   {
     jsg::modules::ModuleBundle::BuiltinBuilder builtinsBuilder(
-        jsg::modules::ModuleBundle::BuiltinBuilder::Type::BUILTIN);
+        jsg::modules::ModuleBundle::BuiltinBuilder::Type::BUILTIN_ONLY);
     builtinsBuilder.addObject<EnvModule, TypeWrapper>("cloudflare-internal:env"_url);
     builtinsBuilder.addObject<FileSystemModule, TypeWrapper>("cloudflare-internal:filesystem"_url);
     jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(builtinsBuilder, CLOUDFLARE_BUNDLE);

--- a/src/workerd/api/tests/new-module-registry-test.js
+++ b/src/workerd/api/tests/new-module-registry-test.js
@@ -12,6 +12,25 @@ import { Buffer } from 'buffer'; // Intentionally omit the 'node:' prefix
 import { foo as foo2, default as def2 } from 'bar';
 import { createRequire } from 'module'; // Intentionally omit the 'node:' prefix
 
+import * as workers from 'cloudflare:workers';
+strictEqual(typeof workers, 'object');
+strictEqual(typeof workers.DurableObject, 'function');
+strictEqual(typeof workers.RpcPromise, 'function');
+strictEqual(typeof workers.RpcProperty, 'function');
+strictEqual(typeof workers.RpcStub, 'function');
+strictEqual(typeof workers.RpcTarget, 'function');
+strictEqual(typeof workers.ServiceStub, 'function');
+strictEqual(typeof workers.WorkerEntrypoint, 'function');
+strictEqual(typeof workers.WorkflowEntrypoint, 'function');
+strictEqual(typeof workers.waitUntil, 'function');
+strictEqual(typeof workers.withEnv, 'function');
+strictEqual(typeof workers.env, 'object');
+
+await rejects(import('cloudflare-internal:env'), {
+  message: /Module not found/,
+});
+await rejects(import('cloudflare-internal:filesystem'));
+
 // Verify that import.meta.url is correct here.
 strictEqual(import.meta.url, 'file:///bundle/worker');
 


### PR DESCRIPTION
* Ensure the `cloudflare-internal:*` specifiers are registered as builtin-only
* Pre-resolve the `node:process` and `node:buffer` specifiers when the new module registry is in use to avoid pumping the microtask queue prematurely during top-level scope evaluation.